### PR TITLE
OK-7278 & fix: Toast bottom blank space & show token balance at desktop layout

### DIFF
--- a/packages/components/src/Select/Container/Option.tsx
+++ b/packages/components/src/Select/Container/Option.tsx
@@ -23,6 +23,25 @@ function isGroup<T>(
   return false;
 }
 
+function Leading<T>({ option }: { option: SelectItem<T> }) {
+  const isSmallScreen = useIsVerticalLayout();
+  // hooks only available in React component
+  return (
+    <>
+      {!!option.tokenProps && (
+        <Token size={{ base: '8', md: '6' }} {...option.tokenProps} />
+      )}
+      {!!option.iconProps && (
+        <Icon
+          color={option.destructive ? 'icon-critical' : 'icon-default'}
+          size={isSmallScreen ? 24 : 20}
+          {...option.iconProps}
+        />
+      )}
+    </>
+  );
+}
+
 function RenderSingleOption<T>({
   option,
   activeOption,
@@ -36,24 +55,7 @@ function RenderSingleOption<T>({
   option: SelectItem<T>;
 }) {
   const isActive = option.value === activeOption.value;
-  const Leading = () => {
-    // hooks only available in React component
-    const isSmallScreen = useIsVerticalLayout();
-    return (
-      <>
-        {!!option.tokenProps && (
-          <Token size={{ base: '8', md: '6' }} {...option.tokenProps} />
-        )}
-        {!!option.iconProps && (
-          <Icon
-            color={option.destructive ? 'icon-critical' : 'icon-default'}
-            size={isSmallScreen ? 24 : 20}
-            {...option.iconProps}
-          />
-        )}
-      </>
-    );
-  };
+
   const OptionText = () => (
     <Box flex={1}>
       <HStack alignItems="center">
@@ -113,7 +115,9 @@ function RenderSingleOption<T>({
                 : ''
             }
           >
-            {(!!option.tokenProps || !!option.iconProps) && <Leading />}
+            {(!!option.tokenProps || !!option.iconProps) && (
+              <Leading option={option} />
+            )}
             <OptionText />
             {!!option.trailing && option.trailing}
             {!!isActive && !!activatable && <SelectedIndicator />}

--- a/packages/kit/src/views/TokenDetail/TokenInfo/index.tsx
+++ b/packages/kit/src/views/TokenDetail/TokenInfo/index.tsx
@@ -122,7 +122,7 @@ const TokenInfo: FC<TokenInfoProps> = ({ token, network }) => {
         >
           {intl.formatMessage({ id: 'action__receive' })}
         </Button>
-        {platformEnv.isExtensionUiPopup && (
+        {platformEnv.isExtensionUiPopup && platformEnv.isDev && (
           <IconButton
             onPress={() => {
               extUtils.openExpandTab({ routes: '' });

--- a/packages/kit/src/views/TokenDetail/index.tsx
+++ b/packages/kit/src/views/TokenDetail/index.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo } from 'react';
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/core';
 
 import { Box } from '@onekeyhq/components';
+import { MAX_PAGE_CONTAINER_WIDTH } from '@onekeyhq/kit/src/config';
 
 import { useActiveWalletAccount } from '../../hooks/redux';
 import { useManageTokens } from '../../hooks/useManageTokens';
@@ -41,12 +42,14 @@ const TokenDetail: React.FC<TokenDetailViewProps> = () => {
 
   return (
     <Box bg="background-default" flex={1}>
-      <HistoricalRecords
-        accountId={accountId}
-        networkId={networkId}
-        tokenId={tokenId}
-        headerView={headerView}
-      />
+      <Box flex={1} marginX="auto" w="100%" maxW={MAX_PAGE_CONTAINER_WIDTH}>
+        <HistoricalRecords
+          accountId={accountId}
+          networkId={networkId}
+          tokenId={tokenId}
+          headerView={headerView}
+        />
+      </Box>
     </Box>
   );
 };

--- a/packages/kit/src/views/Wallet/AssetsList/index.tsx
+++ b/packages/kit/src/views/Wallet/AssetsList/index.tsx
@@ -121,18 +121,29 @@ const AssetsList = () => {
                 </Text>
               )}
             />
-            <FormatCurrency
-              numbers={[item.balance, prices?.[mapKey]]}
-              render={(ele) => (
-                <Typography.Body2 color="text-subdued">
-                  {item.balance && prices?.[mapKey] ? ele : '-'}
-                </Typography.Body2>
-              )}
-            />
+            {isSmallScreen ? (
+              <FormatCurrency
+                numbers={[item.balance, prices?.[mapKey]]}
+                render={(ele) => (
+                  <Typography.Body2 color="text-subdued">
+                    {item.balance && prices?.[mapKey] ? ele : '-'}
+                  </Typography.Body2>
+                )}
+              />
+            ) : (
+              <FormatCurrency
+                numbers={[prices?.[mapKey]]}
+                render={(ele) => (
+                  <Typography.Body2 color="text-subdued">
+                    {prices?.[mapKey] ? ele : '-'}
+                  </Typography.Body2>
+                )}
+              />
+            )}
           </Box>
           {!isSmallScreen && (
             <Box mr={3} flexDirection="row" flex={1}>
-              <Icon size={20} name="ActivityOutline" />
+              {/* <Icon size={20} name="ActivityOutline" /> */}
               <FormatCurrency
                 numbers={[item.balance, prices?.[mapKey]]}
                 render={(ele) => (

--- a/packages/shared/src/web/index.css
+++ b/packages/shared/src/web/index.css
@@ -19,7 +19,8 @@ body,
   margin: 0px;
   padding: 0px;
   /* Allows content to fill the viewport and go beyond the bottom */
-  min-height: 100%;
+  height: 100%;
+  overflow: hidden;
 }
 
 #root {


### PR DESCRIPTION
- desktop 模式打开网络 token 图片闪动
- toast 关闭页面底部出现顶起的高度
- desktop token 列表需显示当前币种单价，隐藏折线图的 icon
- token 详情页隐藏了打开 ext 全屏的按钮，限制了最大宽度