### PR TITLE
OK-7756 PasswordInput's IconButton is no longer focusable

### DIFF
--- a/packages/components/src/Form/FormPasswordInput.tsx
+++ b/packages/components/src/Form/FormPasswordInput.tsx
@@ -29,6 +29,7 @@ export const FormPasswordInput: FC<
           name={rightIconName}
           size="xl"
           type="plain"
+          focusable={false}
         />
       }
       {...props}


### PR DESCRIPTION
Press the Tab key to focus on the following Input or Button instead of the nested IconButton.