### PR TITLE
Reset and restart app fix

### DIFF
--- a/packages/kit/src/background/services/ServiceApp.ts
+++ b/packages/kit/src/background/services/ServiceApp.ts
@@ -10,16 +10,24 @@ import {
 } from '../../store/reducers/settings';
 import { setBoardingCompleted, unlock } from '../../store/reducers/status';
 import { updateWallet, updateWallets } from '../../store/reducers/wallet';
+import { reload } from '../../utils/helper';
 import {
   getPassword,
   hasHardwareSupported,
 } from '../../utils/localAuthentication';
 import { backgroundClass, backgroundMethod } from '../decorators';
+import { delay } from '../utils';
 
-import ServiceBase from './ServiceBase';
+import ServiceBase, { IServiceBaseProps } from './ServiceBase';
 
 @backgroundClass()
 class ServiceApp extends ServiceBase {
+  constructor(props: IServiceBaseProps) {
+    super(props);
+    // TODO recheck last reset status and resetApp here
+    console.log('TODO: recheck last reset status and resetApp here');
+  }
+
   @backgroundMethod()
   async resetApp() {
     const { engine, dispatch, persistor, serviceNetwork, serviceAccount } =
@@ -31,6 +39,11 @@ class ServiceApp extends ServiceBase {
     dispatch({ type: 'LOGOUT', payload: undefined });
     serviceNetwork.notifyChainChanged();
     serviceAccount.notifyAccountsChanged();
+
+    // await engine.resetApp() is NOT reliable of DB clean, so we need delay here.
+    await delay(1500);
+    // reload() MUST be called from background in Ext
+    reload();
   }
 
   @backgroundMethod()

--- a/packages/kit/src/background/services/ServiceBase.ts
+++ b/packages/kit/src/background/services/ServiceBase.ts
@@ -1,9 +1,13 @@
 import { backgroundClass } from '../decorators';
 import { IBackgroundApi } from '../IBackgroundApi';
 
+export type IServiceBaseProps = {
+  backgroundApi: any;
+};
+
 @backgroundClass()
 export default class ServiceBase {
-  constructor({ backgroundApi }: { backgroundApi: any }) {
+  constructor({ backgroundApi }: IServiceBaseProps) {
     this.backgroundApi = backgroundApi;
   }
 

--- a/packages/kit/src/utils/helper.ts
+++ b/packages/kit/src/utils/helper.ts
@@ -1,7 +1,4 @@
 import { getTime } from 'date-fns';
-import RNRestart from 'react-native-restart';
-
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 export const getTimeStamp = () => getTime(new Date());
 
@@ -15,19 +12,3 @@ export const timeout = <T>(p: Promise<T>, ms: number) =>
     setTimeout(() => reject(new Error('Timeout')), ms);
     p.then((value) => resolve(value)).catch((err) => reject(err));
   });
-
-export const reload = () => {
-  if (platformEnv.isNative) {
-    return RNRestart.Restart();
-  }
-  if (platformEnv.isDesktop) {
-    return window.desktopApi?.reload?.();
-  }
-  // reload() MUST be called from background in Ext, UI reload will close whole Browser
-  if (platformEnv.isExtensionBackground) {
-    return chrome.runtime.reload();
-  }
-  if (platformEnv.isBrowser) {
-    return window?.location?.reload?.();
-  }
-};

--- a/packages/kit/src/utils/helper.ts
+++ b/packages/kit/src/utils/helper.ts
@@ -23,10 +23,11 @@ export const reload = () => {
   if (platformEnv.isDesktop) {
     return window.desktopApi?.reload?.();
   }
-  if (platformEnv.isExtension) {
+  // reload() MUST be called from background in Ext, UI reload will close whole Browser
+  if (platformEnv.isExtensionBackground) {
     return chrome.runtime.reload();
   }
-  if (platformEnv.isWeb && typeof window !== 'undefined') {
+  if (platformEnv.isBrowser) {
     return window?.location?.reload?.();
   }
 };

--- a/packages/kit/src/views/Settings/SecuritySection/ResetButton.tsx
+++ b/packages/kit/src/views/Settings/SecuritySection/ResetButton.tsx
@@ -10,7 +10,6 @@ import {
   Pressable,
   Text,
 } from '@onekeyhq/components';
-import { reload } from '@onekeyhq/kit/src/utils/helper';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 
@@ -22,7 +21,6 @@ const ResetButton = () => {
   const onReset = useCallback(async () => {
     await backgroundApiProxy.serviceApp.resetApp();
     setShowResetModal(false);
-    reload();
   }, []);
 
   const onOpenResetModal = useCallback(async () => {

--- a/packages/kit/src/views/Unlock/index.tsx
+++ b/packages/kit/src/views/Unlock/index.tsx
@@ -16,7 +16,6 @@ import {
   useForm,
   useIsVerticalLayout,
 } from '@onekeyhq/components';
-import { reload } from '@onekeyhq/kit/src/utils/helper';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import backgroundApiProxy from '../../background/instance/backgroundApiProxy';
@@ -37,8 +36,6 @@ const ForgetPasswordButton = () => {
   const onReset = useCallback(async () => {
     await backgroundApiProxy.serviceApp.resetApp();
     setVisible(false);
-
-    reload();
   }, []);
   return (
     <>


### PR DESCRIPTION
- reload 改名为 restartApp，且必须在 background 里调用才能在插件下生效
- 添加延迟，因为 engine.resetApp 这个等待数据清理完成实际并不靠谱
- 后续 TODO： ServiceApp 构造函数内重置双保险判断，如果未清理干净再次尝试 resetApp，用于处理用户在重置过程中强杀应用的情况