### PR TITLE
fix:firebase crash on adhoc

### DIFF
--- a/packages/app/ios/OneKeyWallet/AppDelegate.m
+++ b/packages/app/ios/OneKeyWallet/AppDelegate.m
@@ -34,7 +34,10 @@
  
 #ifdef DEBUG
 #else
-  [FIRApp configure];
+  NSString *version = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
+  if (![version isEqualToString:@"1"]) {
+    [FIRApp configure];
+  }
 #endif
   
   [super application:application didFinishLaunchingWithOptions:launchOptions];


### PR DESCRIPTION
Build number 为 1 的时候不初始化firebase