### PR TITLE
OK-9804, Light-mode UI clean-up

### DIFF
--- a/packages/components/src/Layout/Header/index.tsx
+++ b/packages/components/src/Layout/Header/index.tsx
@@ -9,6 +9,7 @@ import {
   useIsVerticalLayout,
   useSafeAreaInsets,
   useTheme,
+  useThemeValue,
   useUserDevice,
 } from '../../Provider/hooks';
 
@@ -31,6 +32,7 @@ const Header: FC<HeaderProps> = ({ headerLeft, headerRight }) => {
 
   const headerLeftNode = headerLeft?.();
   const { themeVariant } = useTheme();
+  const temporaryBg = useThemeValue('background-default');
   const isVerticalLayout = useIsVerticalLayout();
 
   const PrimaryComponent = (
@@ -80,7 +82,7 @@ const Header: FC<HeaderProps> = ({ headerLeft, headerRight }) => {
         ) : (
           <BlurView
             intensity={0} // TODO: change the intensity from 0 to 80 while scrolling up
-            style={{ backgroundColor: '#ffffff' }} // TODO remove this line after add ScrollUp event
+            style={{ backgroundColor: temporaryBg }} // TODO remove this line after add ScrollUp event
             tint={
               // eslint-disable-next-line no-nested-ternary
               themeVariant === 'light'

--- a/packages/components/src/Pressable/PressableItem.tsx
+++ b/packages/components/src/Pressable/PressableItem.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC } from 'react';
 
 import { Pressable as NBPressable } from 'native-base';
 
@@ -11,7 +11,6 @@ const PressableItem: FC<PressableItemProps> = ({
   onPress,
   ...props
 }) => {
-  const [isFocused, setFocused] = useState(false);
   const onPressOverride = React.useCallback(
     (e) => {
       autoHideSelectFunc(e);
@@ -25,12 +24,8 @@ const PressableItem: FC<PressableItemProps> = ({
     <NBPressable
       px={{ base: '4', lg: '6' }}
       py={4}
-      shadow="depth.2"
-      onFocus={() => setFocused(true)}
-      onBlur={() => setFocused(false)}
       _hover={{
         bg: 'surface-hovered',
-        borderColor: isFocused ? '' : '',
       }}
       _focus={{
         bg: 'surface-hovered',

--- a/packages/kit/src/views/FaceID/index.tsx
+++ b/packages/kit/src/views/FaceID/index.tsx
@@ -2,7 +2,7 @@ import React, { FC, useCallback, useLayoutEffect } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { Box, Switch, Text, Typography } from '@onekeyhq/components';
+import { Box, Switch, Text, Typography, useTheme } from '@onekeyhq/components';
 
 import backgroundApiProxy from '../../background/instance/backgroundApiProxy';
 import { ValidationFields } from '../../components/Protected';
@@ -49,6 +49,7 @@ const FaceID = () => {
   const navigation = useNavigation();
   const { authenticationType } = useStatus();
   const { enableLocalAuthentication, validationState = {} } = useSettings();
+  const { themeVariant } = useTheme();
 
   useLayoutEffect(() => {
     const title =
@@ -77,7 +78,8 @@ const FaceID = () => {
         px={{ base: 4, md: 6 }}
         bg="surface-default"
         borderRadius={12}
-        shadow="depth.2"
+        borderWidth={themeVariant === 'light' ? 1 : undefined}
+        borderColor="border-subdued"
       >
         <Text
           typography={{ sm: 'Body1Strong', md: 'Body2Strong' }}
@@ -122,7 +124,13 @@ const FaceID = () => {
                 })}
               </Typography.Subheading>
             </Box>
-            <Box mt="2" borderRadius="12" bg="surface-default" shadow="depth.2">
+            <Box
+              mt="2"
+              borderRadius="12"
+              bg="surface-default"
+              borderWidth={themeVariant === 'light' ? 1 : undefined}
+              borderColor="border-subdued"
+            >
               <Options
                 title={intl.formatMessage({
                   id: 'form__app_unlock',

--- a/packages/kit/src/views/ManageTokens/Listing.tsx
+++ b/packages/kit/src/views/ManageTokens/Listing.tsx
@@ -94,7 +94,7 @@ const HeaderTokens: FC<HeaderTokensProps> = ({
               defaultMessage: 'MY TOKENS',
             })}
           </Typography.Subheading>
-          <Box mt="2" mb="6" shadow="depth.2">
+          <Box mt="2" mb="6">
             {tokens.map((item, index) => (
               <Pressable
                 onPress={() => onDetail(item)}
@@ -323,7 +323,6 @@ const ListingToken: FC<ListingTokenProps> = ({
       bg="surface-default"
       _hover={{ bgColor: 'surface-hovered' }}
       _pressed={{ bgColor: 'surface-pressed' }}
-      shadow="depth.2"
     >
       <Box display="flex" alignItems="center" flexDirection="row">
         <TokenImage size={8} src={item.logoURI} />

--- a/packages/kit/src/views/Me/AboutSection/index.tsx
+++ b/packages/kit/src/views/Me/AboutSection/index.tsx
@@ -11,6 +11,7 @@ import {
   Spinner,
   Text,
   Typography,
+  useTheme,
   useToast,
 } from '@onekeyhq/components';
 import { copyToClipboard } from '@onekeyhq/components/src/utils/ClipboardUtils';
@@ -35,6 +36,7 @@ export const AboutSection = () => {
   const toast = useToast();
   const navigation = useNavigation<NavigationProps>();
   const { dispatch } = backgroundApiProxy;
+  const { themeVariant } = useTheme();
 
   const userAgreementUrl = useHelpLink({ path: 'articles/360002014776' });
   const privacyPolicyUrl = useHelpLink({ path: 'articles/360002003315' });
@@ -119,7 +121,12 @@ export const AboutSection = () => {
           })}
         </Typography.Subheading>
       </Box>
-      <Box borderRadius="12" bg="surface-default" shadow="depth.2">
+      <Box
+        borderRadius="12"
+        bg="surface-default"
+        borderWidth={themeVariant === 'light' ? 1 : undefined}
+        borderColor="border-subdued"
+      >
         <Pressable
           display="flex"
           flexDirection="row"

--- a/packages/kit/src/views/Me/DefaultSection/index.tsx
+++ b/packages/kit/src/views/Me/DefaultSection/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useNavigation } from '@react-navigation/core';
 import { useIntl } from 'react-intl';
 
-import { Box, Icon, Pressable } from '@onekeyhq/components';
+import { Box, Icon, Pressable, useTheme } from '@onekeyhq/components';
 import { Text } from '@onekeyhq/components/src/Typography';
 import { HomeRoutes, HomeRoutesParams } from '@onekeyhq/kit/src/routes/types';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -18,10 +18,16 @@ type NavigationProps = NativeStackNavigationProp<
 export const DefaultSection = () => {
   const intl = useIntl();
   const navigation = useNavigation<NavigationProps>();
+  const { themeVariant } = useTheme();
 
   return (
     <Box w="full" mb="6">
-      <Box borderRadius="12" bg="surface-default" shadow="depth.2">
+      <Box
+        borderRadius="12"
+        bg="surface-default"
+        borderWidth={themeVariant === 'light' ? 1 : undefined}
+        borderColor="border-subdued"
+      >
         {platformEnv.isNative && (
           <Pressable
             display="flex"

--- a/packages/kit/src/views/Me/GenaralSection/index.tsx
+++ b/packages/kit/src/views/Me/GenaralSection/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { Box, Select, Typography } from '@onekeyhq/components';
+import { Box, Select, Typography, useTheme } from '@onekeyhq/components';
 import { LOCALES_OPTION } from '@onekeyhq/components/src/locale';
 import { ThemeVariant } from '@onekeyhq/components/src/Provider/theme';
 import { useAppSelector, useSettings } from '@onekeyhq/kit/src/hooks/redux';
@@ -19,6 +19,7 @@ export const GenaralSection = () => {
   const intl = useIntl();
   const { dispatch } = backgroundApiProxy;
   const { theme, locale, selectedFiatMoneySymbol } = useSettings();
+  const { themeVariant } = useTheme();
 
   const fiatMoneySymbolList = useAppSelector((s) => s.fiatMoney.symbolList);
 
@@ -32,7 +33,12 @@ export const GenaralSection = () => {
           })}
         </Typography.Subheading>
       </Box>
-      <Box borderRadius="12" bg="surface-default" shadow="depth.2">
+      <Box
+        borderRadius="12"
+        bg="surface-default"
+        borderWidth={themeVariant === 'light' ? 1 : undefined}
+        borderColor="border-subdued"
+      >
         <Box>
           <Box w="full">
             <Select<ThemeVariant | 'system'>

--- a/packages/kit/src/views/Me/SecuritySection/index.tsx
+++ b/packages/kit/src/views/Me/SecuritySection/index.tsx
@@ -10,6 +10,7 @@ import {
   Select,
   Switch,
   Typography,
+  useTheme,
 } from '@onekeyhq/components';
 import { Text } from '@onekeyhq/components/src/Typography';
 import { useData, useSettings, useStatus } from '@onekeyhq/kit/src/hooks/redux';
@@ -48,6 +49,7 @@ export const SecuritySection = () => {
   const { authenticationType } = useStatus();
   const { isOk } = useLocalAuthentication();
   const navigation = useNavigation<NavigationProps>();
+  const { themeVariant } = useTheme();
   const lockTimerOptions = useMemo(
     () => [
       {
@@ -105,7 +107,12 @@ export const SecuritySection = () => {
             })}
           </Typography.Subheading>
         </Box>
-        <Box borderRadius="12" bg="surface-default" shadow="depth.2">
+        <Box
+          borderRadius="12"
+          bg="surface-default"
+          borderWidth={themeVariant === 'light' ? 1 : undefined}
+          borderColor="border-subdued"
+        >
           <Pressable
             display="flex"
             flexDirection="row"

--- a/packages/kit/src/views/Me/UtilSection/index.tsx
+++ b/packages/kit/src/views/Me/UtilSection/index.tsx
@@ -8,6 +8,7 @@ import {
   Pressable,
   Text,
   useIsVerticalLayout,
+  useTheme,
 } from '@onekeyhq/components';
 
 import { gotoScanQrcode } from '../../../utils/gotoScanQrcode';
@@ -15,13 +16,15 @@ import { gotoScanQrcode } from '../../../utils/gotoScanQrcode';
 export const UtilSection = () => {
   const intl = useIntl();
   const small = useIsVerticalLayout();
+  const { themeVariant } = useTheme();
   return (
     <Box
       w="full"
       mb="6"
       borderRadius="12"
       bg="surface-default"
-      shadow="depth.2"
+      borderWidth={themeVariant === 'light' ? 1 : undefined}
+      borderColor="border-subdued"
     >
       <Pressable
         display="flex"

--- a/packages/kit/src/views/Swap/SwapContent.tsx
+++ b/packages/kit/src/views/Swap/SwapContent.tsx
@@ -8,6 +8,7 @@ import {
   Divider,
   IconButton,
   Typography,
+  useTheme,
 } from '@onekeyhq/components';
 import { ModalRoutes, RootRoutes } from '@onekeyhq/kit/src/routes/types';
 
@@ -43,6 +44,7 @@ const SwapContent = () => {
   const onSwapQuoteCallback = useSwapQuoteCallback({ silent: false });
   const { onUserInput, onSwitchTokens } = useSwapActionHandlers();
   const { account, wallet } = useActiveWalletAccount();
+  const { themeVariant } = useTheme();
 
   const isDisabled = !isSwapEnabled || !wallet || !account;
 
@@ -95,11 +97,12 @@ const SwapContent = () => {
     <Center px="4">
       <Box
         bg="surface-default"
-        shadow="depth.2"
         maxW="420"
         w="full"
         borderRadius="3xl"
         p={4}
+        borderWidth={themeVariant === 'light' ? 1 : undefined}
+        borderColor="border-subdued"
       >
         <Box
           borderWidth={{ base: '0.5', md: '1' }}

--- a/packages/kit/src/views/Swap/SwapItems.tsx
+++ b/packages/kit/src/views/Swap/SwapItems.tsx
@@ -2,7 +2,14 @@ import React, { useCallback } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { Box, Center, Icon, Pressable, Text } from '@onekeyhq/components';
+import {
+  Box,
+  Center,
+  Icon,
+  Pressable,
+  Text,
+  useTheme,
+} from '@onekeyhq/components';
 
 import { useNavigation } from '../../hooks';
 import { setHaptics } from '../../hooks/setHaptics';
@@ -11,6 +18,7 @@ import { HomeRoutes, RootRoutes } from '../../routes/types';
 const SwapItems = () => {
   const intl = useIntl();
   const navigation = useNavigation();
+  const { themeVariant } = useTheme();
   const onPress = useCallback(() => {
     setHaptics();
     navigation.navigate(RootRoutes.Root, {
@@ -22,11 +30,12 @@ const SwapItems = () => {
     <Center px={4} pb="4">
       <Box
         bg="surface-default"
-        shadow="depth.2"
         mt="6"
         maxW="420"
         w="full"
         borderRadius={12}
+        borderWidth={themeVariant === 'light' ? 1 : undefined}
+        borderColor="border-subdued"
       >
         <Pressable
           h="56px"

--- a/packages/kit/src/views/Wallet/AssetsList/index.tsx
+++ b/packages/kit/src/views/Wallet/AssetsList/index.tsx
@@ -18,6 +18,7 @@ import {
   Token,
   Typography,
   useIsVerticalLayout,
+  useTheme,
   useUserDevice,
 } from '@onekeyhq/components';
 import { Tabs } from '@onekeyhq/components/src/CollapsibleTabView';
@@ -107,6 +108,7 @@ function AssetsList({
   const { account, network } = useActiveWalletAccount();
   const navigation = useNavigation<NavigationProps>();
   const { tokenEnabled } = network?.settings ?? { tokenEnabled: false };
+  const { themeVariant } = useTheme();
 
   const { size } = useUserDevice();
   const responsivePadding = () => {
@@ -141,6 +143,12 @@ function AssetsList({
         shadow={undefined}
         borderTopRadius={index === 0 ? '12px' : '0px'}
         borderRadius={index === accountTokens?.length - 1 ? '12px' : '0px'}
+        borderWidth={1}
+        borderColor={
+          themeVariant === 'light' ? 'border-subdued' : 'transparent'
+        }
+        borderTopWidth={index === 0 ? 1 : 0}
+        borderBottomWidth={index === accountTokens?.length - 1 ? 1 : 0}
         onPress={() => {
           if (onTokenPress) {
             onTokenPress({ token: item });

--- a/packages/kit/src/views/Wallet/HistoricalRecords/index.tsx
+++ b/packages/kit/src/views/Wallet/HistoricalRecords/index.tsx
@@ -16,6 +16,7 @@ import {
   SectionList,
   Spinner,
   Typography,
+  useTheme,
   useUserDevice,
 } from '@onekeyhq/components';
 import { Tabs } from '@onekeyhq/components/src/CollapsibleTabView';
@@ -92,6 +93,8 @@ const HistoricalRecords: FC<HistoricalRecordProps> = ({
     return 16;
   };
 
+  const { themeVariant } = useTheme();
+
   useEffect(() => {
     async function loadAccount() {
       if (!accountId) return;
@@ -133,6 +136,10 @@ const HistoricalRecords: FC<HistoricalRecordProps> = ({
       key={`${item.txHash}-${index}`}
       borderTopRadius={index === 0 ? '12px' : '0px'}
       borderRadius={index === section.data.length - 1 ? '12px' : '0px'}
+      borderWidth={1}
+      borderColor={themeVariant === 'light' ? 'border-subdued' : 'transparent'}
+      borderTopWidth={index === 0 ? 1 : 0}
+      borderBottomWidth={index === section.data.length - 1 ? 1 : 0}
       mb={index === section.data.length - 1 ? 6 : undefined}
       onPress={() => {
         navigation.navigate(RootRoutes.Modal, {


### PR DESCRIPTION
- Remove the shadow of Cards.
- Add a subdued border to the cards on light mode.

<img src="https://user-images.githubusercontent.com/23469879/173182933-64850bef-958b-4e6f-aa13-a9f5a0accd4d.PNG" width="240">

<img src="https://user-images.githubusercontent.com/23469879/173182944-1b05d444-43ea-4aa8-8638-d839f4e2cdcb.PNG" width="240">

<img src="https://user-images.githubusercontent.com/23469879/173182949-df1867bd-bc26-4076-ba8a-b2bda6cb5b52.PNG" width="240">




