### PR TITLE
fix: disable cache for getting account info for output OK-9812

### DIFF
--- a/packages/engine/src/vaults/VaultBase.ts
+++ b/packages/engine/src/vaults/VaultBase.ts
@@ -214,7 +214,7 @@ export abstract class VaultBase extends VaultBaseChainOnly {
 
   async getOutputAccount(): Promise<Account> {
     // The simplest case as default implementation.
-    const dbAccount = await this.getDbAccount();
+    const dbAccount = await this.getDbAccount({ noCache: true });
     return {
       id: dbAccount.id,
       name: dbAccount.name,

--- a/packages/engine/src/vaults/VaultContext.ts
+++ b/packages/engine/src/vaults/VaultContext.ts
@@ -58,8 +58,9 @@ export class VaultContext extends VaultContextBase {
 
   _dbAccount!: DBAccount;
 
-  async getDbAccount() {
-    if (!this._dbAccount || this._dbAccount.id !== this.accountId) {
+  async getDbAccount(params?: { noCache?: boolean }) {
+    const { noCache } = { noCache: false, ...params };
+    if (noCache || !this._dbAccount || this._dbAccount.id !== this.accountId) {
       this._dbAccount = await this.engine.dbApi.getAccount(this.accountId);
     }
     return this._dbAccount;

--- a/packages/engine/src/vaults/impl/cfx/Vault.ts
+++ b/packages/engine/src/vaults/impl/cfx/Vault.ts
@@ -143,7 +143,9 @@ export default class Vault extends VaultBase {
   }
 
   override async getOutputAccount(): Promise<Account> {
-    const dbAccount = (await this.getDbAccount()) as DBVariantAccount;
+    const dbAccount = (await this.getDbAccount({
+      noCache: true,
+    })) as DBVariantAccount;
     const ret = {
       id: dbAccount.id,
       name: dbAccount.name,


### PR DESCRIPTION
After renamed, should re-read DB to get the updated info of an account.

Fixes: OK-9812