### PR TITLE
chore: update electron to v16.2.8 to avoid the "AutoUpdater module fa…

### DIFF
--- a/packages/desktop/electron-builder.config.js
+++ b/packages/desktop/electron-builder.config.js
@@ -10,7 +10,7 @@ module.exports = {
   'productName': 'OneKey',
   'copyright': 'Copyright © ${author}',
   'asar': true,
-  'electronVersion': '15.3.1',
+  'electronVersion': '16.2.8',
   'buildVersion': process.env.BUILD_NUMBER,
   'directories': {
     'output': 'build-electron',

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -42,7 +42,7 @@
     "@types/electron-localshortcut": "^3.1.0",
     "@types/node-fetch": "^2.6.1",
     "cross-env": "^7.0.3",
-    "electron": "^15.5.5",
+    "electron": "16.2.8",
     "electron-builder": "^23.0.3",
     "electron-notarize": "^1.1.1",
     "esbuild": "^0.13.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10097,19 +10097,10 @@ electron-to-chromium@^1.4.147:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.154.tgz#d69c60499fc467a6c59591d29183e520afbc78a1"
   integrity sha512-GbV9djOkrnj6xmW+YYVVEI3VCQnJ0pnSTu7TW2JyjKd5cakoiSaG5R4RbEtfaD92GsY10DzbU3GYRe+IOA9kqA==
 
-electron@*:
-  version "16.0.3"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-16.0.3.tgz#458208572ca5226a833bcf4f7738d59447fc7606"
-  integrity sha512-MzCYuEqrvyEtPSUWQwr88xWBrsbhmyOKp4wqP9WfAJTEDeUfBcrQYswHuYe17Gi00gRirQb9htoC/anYfaw20w==
-  dependencies:
-    "@electron/get" "^1.13.0"
-    "@types/node" "^14.6.2"
-    extract-zip "^1.0.3"
-
-electron@^15.5.5:
-  version "15.5.5"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-15.5.5.tgz#796b7822bfb2b045b504e40657674f2869361681"
-  integrity sha512-cGS1ueek14WLvLJlJbId3fmqJLvkr7VuBI0hHt6gpKaj8m2iv/NMteRg0deLgwlxjEF6ZGGNerUJW6a96rNq/Q==
+electron@*, electron@16.2.8:
+  version "16.2.8"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-16.2.8.tgz#b7f2bd1184701e54a1bc902839d5a3ec95bb8982"
+  integrity sha512-KSOytY6SPLsh3iCziztqa/WgJyfDOKzCvNqku9gGIqSdT8CqtV66dTU1SOrKZQjRFLxHaF8LbyxUL1vwe4taqw==
   dependencies:
     "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
…ils to validate certain nested components of the bundle"