### PR TITLE
fix: use constant to check dust threshold in coinselect

### DIFF
--- a/patches/coinselect+3.1.12.patch
+++ b/patches/coinselect+3.1.12.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/coinselect/utils.js b/node_modules/coinselect/utils.js
+index 687fe66..b5e79b3 100644
+--- a/node_modules/coinselect/utils.js
++++ b/node_modules/coinselect/utils.js
+@@ -15,7 +15,7 @@ function outputBytes (output) {
+ 
+ function dustThreshold (output, feeRate) {
+   /* ... classify the output for input estimate  */
+-  return inputBytes({}) * feeRate
++  return inputBytes({}) * 3
+ }
+ 
+ function transactionBytes (inputs, outputs) {


### PR DESCRIPTION
Most BTC nodes use the default value of 3. To avoid dust check failure
when broadcasting a transaction, we should use this default value as
feeRate to check dust threshold.

Ref:
  https://github.com/bitcoin/bitcoin/blob/0dd34773334c7f4db7b05df30ee61b011795b46d/src/policy/policy.h#L52-L57

Fixes: OK-9397