### PR TITLE
feat: maintain a trustworthy state for ext

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -5,7 +5,10 @@ import {
   mnemonicFromEntropy,
   revealableSeedFromMnemonic,
 } from '@onekeyfe/blockchain-libs/dist/secret';
-import { encrypt } from '@onekeyfe/blockchain-libs/dist/secret/encryptors/aes256';
+import {
+  decrypt,
+  encrypt,
+} from '@onekeyfe/blockchain-libs/dist/secret/encryptors/aes256';
 import { IJsonRpcRequest } from '@onekeyfe/cross-inpage-provider-types';
 import BigNumber from 'bignumber.js';
 import * as bip39 from 'bip39';
@@ -1979,6 +1982,39 @@ class Engine {
     this.dbApi = new DbApi() as DBAPI;
     this.validator.dbApi = this.dbApi;
     return Promise.resolve();
+  }
+
+  @backgroundMethod()
+  async unsafeEncode(data: string): Promise<string | undefined> {
+    const context = await this.dbApi.getContext();
+    if (
+      typeof context !== 'undefined' &&
+      context.verifyString !== DEFAULT_VERIFY_STRING
+    ) {
+      return encrypt(context.verifyString, Buffer.from(data, 'hex')).toString(
+        'hex',
+      );
+    }
+    return undefined;
+  }
+
+  @backgroundMethod()
+  async unsafeDecode(encrypted: string): Promise<string | undefined> {
+    const context = await this.dbApi.getContext();
+    if (
+      typeof context !== 'undefined' &&
+      context.verifyString !== DEFAULT_VERIFY_STRING
+    ) {
+      try {
+        return decrypt(
+          context.verifyString,
+          Buffer.from(encrypted, 'hex'),
+        ).toString('hex');
+      } catch {
+        return undefined;
+      }
+    }
+    return undefined;
   }
 }
 

--- a/packages/kit/src/components/Protected/HardwareControl.tsx
+++ b/packages/kit/src/components/Protected/HardwareControl.tsx
@@ -1,0 +1,159 @@
+import React, { FC, useCallback, useEffect, useState } from 'react';
+
+import { useNavigation } from '@react-navigation/core';
+import { useIntl } from 'react-intl';
+
+import {
+  Box,
+  DialogManager,
+  Spinner,
+  ToastManager,
+  Typography,
+} from '@onekeyhq/components';
+import { OneKeyErrorClassNames } from '@onekeyhq/engine/src/errors';
+import type { Wallet } from '@onekeyhq/engine/src/types/wallet';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { getDeviceUUID } from '@onekeyhq/kit/src/utils/hardware';
+import type { IOneKeyDeviceFeatures } from '@onekeyhq/shared/types';
+
+import { CustomOneKeyHardwareError } from '../../utils/hardware/errors';
+import NeedBridgeDialog from '../NeedBridgeDialog';
+
+type HardwareControlProps = {
+  walletDetail?: Wallet;
+};
+
+export const HardwareControl: FC<HardwareControlProps> = ({
+  walletDetail,
+  children,
+}) => {
+  const intl = useIntl();
+  const navigation = useNavigation();
+  const [deviceFeatures, setDeviceFeatures] = useState<IOneKeyDeviceFeatures>();
+
+  const safeGoBack = useCallback(() => {
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+    }
+  }, [navigation]);
+
+  useEffect(() => {
+    function throwDeviceCheckError() {
+      ToastManager.show({
+        title: intl.formatMessage({ id: 'action__connection_timeout' }),
+      });
+      safeGoBack();
+    }
+
+    async function loadDevices() {
+      if (!walletDetail?.id) {
+        throwDeviceCheckError();
+        return;
+      }
+
+      const currentWalletDevice =
+        await backgroundApiProxy.engine.getHWDeviceByWalletId(walletDetail.id);
+
+      if (!currentWalletDevice) {
+        throwDeviceCheckError();
+        return;
+      }
+
+      let features: IOneKeyDeviceFeatures | null = null;
+      try {
+        features = await backgroundApiProxy.serviceHardware.ensureConnected(
+          currentWalletDevice.mac,
+        );
+      } catch (e: any) {
+        safeGoBack();
+
+        const { className, key, code } = e || {};
+
+        if (code === CustomOneKeyHardwareError.NeedOneKeyBridge) {
+          DialogManager.show({ render: <NeedBridgeDialog /> });
+          return;
+        }
+
+        if (className === OneKeyErrorClassNames.OneKeyAbortError) {
+          return;
+        }
+
+        if (className === OneKeyErrorClassNames.OneKeyHardwareError) {
+          ToastManager.show({
+            title: intl.formatMessage({ id: key }),
+          });
+        } else {
+          ToastManager.show({
+            title: intl.formatMessage({ id: 'action__connection_timeout' }),
+          });
+        }
+        return;
+      }
+
+      if (!features) {
+        ToastManager.show({
+          title: intl.formatMessage({ id: 'action__connection_timeout' }),
+        });
+        safeGoBack();
+        return;
+      }
+      const connectDeviceUUID = getDeviceUUID(features);
+      const connectDeviceID = features.device_id;
+
+      /**
+       * New version of database, deviceId and uuid must be the same
+       */
+      const diffDeviceIdAndUUID =
+        currentWalletDevice.deviceId && currentWalletDevice.uuid
+          ? connectDeviceID !== currentWalletDevice.deviceId ||
+            connectDeviceUUID !== currentWalletDevice.uuid
+          : false;
+
+      /**
+       * Older versions of the database, uuid must be the same as device.id
+       */
+      const diffDeviceUUIDWithoutDeviceId =
+        !currentWalletDevice.deviceId &&
+        connectDeviceUUID !== currentWalletDevice.id;
+
+      if (diffDeviceIdAndUUID || diffDeviceUUIDWithoutDeviceId) {
+        ToastManager.show({
+          title: intl.formatMessage({ id: 'msg__hardware_not_same' }),
+        });
+        safeGoBack();
+        return;
+      }
+      setDeviceFeatures(features);
+    }
+    loadDevices();
+  }, [walletDetail?.id, intl, safeGoBack]);
+
+  const abortConnect = useCallback(
+    () => backgroundApiProxy.serviceHardware.stopPolling(),
+    [],
+  );
+
+  useEffect(
+    () => () => {
+      abortConnect();
+    },
+    [abortConnect],
+  );
+
+  if (deviceFeatures) {
+    return (
+      <Box w="full" h="full">
+        {children}
+      </Box>
+    );
+  }
+
+  return (
+    <Box h="100%" justifyContent="center" alignItems="center">
+      <Spinner size="lg" />
+      <Typography.DisplayMedium mt={6}>
+        {intl.formatMessage({ id: 'modal__device_status_check' })}
+      </Typography.DisplayMedium>
+    </Box>
+  );
+};

--- a/packages/kit/src/components/Protected/SoftwareControl.tsx
+++ b/packages/kit/src/components/Protected/SoftwareControl.tsx
@@ -1,0 +1,67 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import React, { FC, useCallback, useState } from 'react';
+
+import { Box } from '@onekeyhq/components';
+import { useAppSelector } from '@onekeyhq/kit/src/hooks/redux';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import Setup from './Setup';
+import { ValidationFields } from './types';
+import Validation from './Validation';
+import ValidationExt from './ValidationExt';
+
+type SoftwareControlOptions = {
+  isLocalAuthentication?: boolean;
+  withEnableAuthentication?: boolean;
+};
+
+type SoftwareControlProps = {
+  skipSavePassword?: boolean;
+  field?: ValidationFields;
+  render: (
+    password: string,
+    options: SoftwareControlOptions,
+  ) => React.ReactNode;
+};
+
+export const SoftwareControl: FC<SoftwareControlProps> = ({
+  render,
+  skipSavePassword,
+  field,
+}) => {
+  const [password, setPassword] = useState('');
+  const [withEnableAuthentication, setWithEnableAuthentication] =
+    useState<boolean>();
+  const [isLocalAuthentication, setLocalAuthentication] = useState<boolean>();
+  const isPasswordSet = useAppSelector((s) => s.data.isPasswordSet);
+  const [hasPassword] = useState(isPasswordSet);
+
+  const onValidationOk = useCallback((text: string, value?: boolean) => {
+    setLocalAuthentication(value);
+    setPassword(text);
+  }, []);
+
+  const onSetupOk = useCallback((text: string, value?: boolean) => {
+    setWithEnableAuthentication(value);
+    setPassword(text);
+  }, []);
+
+  if (password) {
+    return (
+      <Box w="full" h="full">
+        {render(password, {
+          withEnableAuthentication,
+          isLocalAuthentication,
+        })}
+      </Box>
+    );
+  }
+
+  if (hasPassword) {
+    if (platformEnv.isExtension) {
+      return <ValidationExt onOk={onValidationOk} field={field} />;
+    }
+    return <Validation onOk={onValidationOk} field={field} />;
+  }
+  return <Setup onOk={onSetupOk} skipSavePassword={skipSavePassword} />;
+};

--- a/packages/kit/src/components/Protected/Validation.tsx
+++ b/packages/kit/src/components/Protected/Validation.tsx
@@ -13,7 +13,7 @@ import {
 } from '@onekeyhq/components';
 
 import backgroundApiProxy from '../../background/instance/backgroundApiProxy';
-import { useSettings } from '../../hooks/redux';
+import { useAppSelector } from '../../hooks/redux';
 import { hasHardwareSupported } from '../../utils/localAuthentication';
 import LocalAuthenticationButton from '../LocalAuthenticationButton';
 
@@ -29,7 +29,11 @@ type ValidationProps = {
 const Validation: FC<ValidationProps> = ({ onOk, field }) => {
   const intl = useIntl();
   const ref = useRef<any>();
-  const { enableLocalAuthentication, validationState = {} } = useSettings();
+  const enableLocalAuthentication = useAppSelector(
+    (s) => s.settings.enableLocalAuthentication,
+  );
+  const validationState =
+    useAppSelector((s) => s.settings.validationState) ?? {};
   const { control, handleSubmit, setError } = useForm<FieldValues>({
     defaultValues: { password: '' },
   });

--- a/packages/kit/src/components/Protected/ValidationExt.tsx
+++ b/packages/kit/src/components/Protected/ValidationExt.tsx
@@ -1,0 +1,79 @@
+import React, { FC, useCallback, useEffect, useState } from 'react';
+
+import { Center, Spinner } from '@onekeyhq/components';
+
+import backgroundApiProxy from '../../background/instance/backgroundApiProxy';
+
+import { ValidationFields } from './types';
+import Validation from './Validation';
+
+type ValidationExtProps = {
+  field?: ValidationFields;
+  onOk?: (text: string, isLocalAuthentication?: boolean) => void;
+};
+
+export class UnsafeVault {
+  static instance = new UnsafeVault();
+
+  vault?: string;
+
+  async setPassword(value: string): Promise<void> {
+    this.vault = await backgroundApiProxy.engine.unsafeEncode(value);
+  }
+
+  async getPassword(): Promise<string | undefined> {
+    if (!this.vault) return undefined;
+    const password = await backgroundApiProxy.engine.unsafeDecode(this.vault);
+    if (password) {
+      const result = await backgroundApiProxy.engine.verifyMasterPassword(
+        password,
+      );
+      return result ? password : undefined;
+    }
+    return undefined;
+  }
+
+  clean() {
+    this.vault = undefined;
+  }
+}
+
+const ValidationExt: FC<ValidationExtProps> = ({ field, onOk }) => {
+  const [loaded, setLoaded] = useState(false);
+  const [password, setPassword] = useState<string | undefined>();
+  useEffect(() => {
+    async function main() {
+      const data = await UnsafeVault.instance.getPassword();
+      if (data) {
+        onOk?.(data, false);
+      }
+      setPassword(data);
+      setLoaded(true);
+    }
+    main();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const onExtOk = useCallback(
+    async (text: string, isLocalAuthentication?: boolean) => {
+      await UnsafeVault.instance.setPassword(text);
+      onOk?.(text, isLocalAuthentication);
+    },
+    [onOk],
+  );
+
+  if (loaded) {
+    if (!password) {
+      return <Validation field={field} onOk={onExtOk} />;
+    }
+    return null;
+  }
+
+  return (
+    <Center w="full" h="full">
+      <Spinner />
+    </Center>
+  );
+};
+
+export default ValidationExt;

--- a/packages/kit/src/components/Protected/index.tsx
+++ b/packages/kit/src/components/Protected/index.tsx
@@ -1,28 +1,11 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import React, { FC, useCallback, useEffect, useState } from 'react';
+import React, { FC } from 'react';
 
-import { useNavigation } from '@react-navigation/core';
-import { useIntl } from 'react-intl';
-
-import {
-  Box,
-  DialogManager,
-  Spinner,
-  ToastManager,
-  Typography,
-} from '@onekeyhq/components';
-import { OneKeyErrorClassNames } from '@onekeyhq/engine/src/errors';
-import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { useData, useGetWalletDetail } from '@onekeyhq/kit/src/hooks/redux';
-import { getDeviceUUID } from '@onekeyhq/kit/src/utils/hardware';
+import { useWallet } from '@onekeyhq/kit/src/hooks/redux';
 import { IOneKeyDeviceFeatures } from '@onekeyhq/shared/types';
 
-import { CustomOneKeyHardwareError } from '../../utils/hardware/errors';
-import NeedBridgeDialog from '../NeedBridgeDialog';
-
-import Setup from './Setup';
+import { HardwareControl } from './HardwareControl';
+import { SoftwareControl } from './SoftwareControl';
 import { ValidationFields } from './types';
-import Validation from './Validation';
 
 type ProtectedOptions = {
   isLocalAuthentication?: boolean;
@@ -44,191 +27,22 @@ const Protected: FC<ProtectedProps> = ({
   field,
   walletId,
 }) => {
-  const navigation = useNavigation();
-  const walletDetail = useGetWalletDetail(walletId);
-  const intl = useIntl();
-  const { engine, serviceHardware } = backgroundApiProxy;
-  const [deviceFeatures, setDeviceFeatures] = useState<IOneKeyDeviceFeatures>();
-  const [password, setPassword] = useState('');
-  const [withEnableAuthentication, setWithEnableAuthentication] =
-    useState<boolean>();
-  const [isLocalAuthentication, setLocalAuthentication] = useState<boolean>();
-  const { isPasswordSet } = useData();
-  const [hasPassword] = useState(isPasswordSet);
-
-  const onValidationOk = useCallback((text: string, value?: boolean) => {
-    setLocalAuthentication(value);
-    setPassword(text);
-  }, []);
-
-  const onSetupOk = useCallback((text: string, value?: boolean) => {
-    setWithEnableAuthentication(value);
-    setPassword(text);
-  }, []);
-
-  const safeGoBack = useCallback(() => {
-    if (navigation.canGoBack()) {
-      navigation.goBack();
-    }
-  }, [navigation]);
-
-  /**
-   * Hardware Wallet dont need input password at here, hardware need to input password at device
-   *
-   * also if it is hardware device, need to connect bluetooth and check connection status
-   */
-  const isHardware = walletDetail?.type === 'hw';
-
-  useEffect(() => {
-    if (!isHardware) return;
-
-    function throwDeviceCheckError() {
-      ToastManager.show({
-        title: intl.formatMessage({ id: 'action__connection_timeout' }),
-      });
-      safeGoBack();
-    }
-
-    async function loadDevices() {
-      if (!walletDetail?.id) {
-        throwDeviceCheckError();
-        return;
-      }
-
-      const currentWalletDevice = await engine.getHWDeviceByWalletId(
-        walletDetail.id,
-      );
-
-      if (!currentWalletDevice) {
-        throwDeviceCheckError();
-        return;
-      }
-
-      let features: IOneKeyDeviceFeatures | null = null;
-      try {
-        features = await serviceHardware.ensureConnected(
-          currentWalletDevice.mac,
-        );
-      } catch (e: any) {
-        safeGoBack();
-
-        const { className, key, code } = e || {};
-
-        if (code === CustomOneKeyHardwareError.NeedOneKeyBridge) {
-          DialogManager.show({ render: <NeedBridgeDialog /> });
-          return;
-        }
-
-        if (className === OneKeyErrorClassNames.OneKeyAbortError) {
-          return;
-        }
-
-        if (className === OneKeyErrorClassNames.OneKeyHardwareError) {
-          ToastManager.show({
-            title: intl.formatMessage({ id: key }),
-          });
-        } else {
-          ToastManager.show({
-            title: intl.formatMessage({ id: 'action__connection_timeout' }),
-          });
-        }
-        return;
-      }
-
-      if (!features) {
-        ToastManager.show({
-          title: intl.formatMessage({ id: 'action__connection_timeout' }),
-        });
-        safeGoBack();
-        return;
-      }
-      const connectDeviceUUID = getDeviceUUID(features);
-      const connectDeviceID = features.device_id;
-
-      /**
-       * New version of database, deviceId and uuid must be the same
-       */
-      const diffDeviceIdAndUUID =
-        currentWalletDevice.deviceId && currentWalletDevice.uuid
-          ? connectDeviceID !== currentWalletDevice.deviceId ||
-            connectDeviceUUID !== currentWalletDevice.uuid
-          : false;
-
-      /**
-       * Older versions of the database, uuid must be the same as device.id
-       */
-      const diffDeviceUUIDWithoutDeviceId =
-        !currentWalletDevice.deviceId &&
-        connectDeviceUUID !== currentWalletDevice.id;
-
-      if (diffDeviceIdAndUUID || diffDeviceUUIDWithoutDeviceId) {
-        ToastManager.show({
-          title: intl.formatMessage({ id: 'msg__hardware_not_same' }),
-        });
-        safeGoBack();
-        return;
-      }
-
-      // device connect success
-      setDeviceFeatures(features);
-    }
-    loadDevices();
-  }, [isHardware, engine, walletDetail?.id, intl, safeGoBack, serviceHardware]);
-
-  const abortConnect = useCallback(
-    () => serviceHardware.stopPolling(),
-    [serviceHardware],
-  );
-
-  useEffect(
-    () => () => {
-      if (isHardware) {
-        abortConnect();
-      }
-    },
-    [isHardware, abortConnect],
-  );
-
-  if (password) {
-    return (
-      <Box w="full" h="full">
-        {children(password, {
-          withEnableAuthentication,
-          isLocalAuthentication,
-        })}
-      </Box>
-    );
-  }
-
+  const wallet = useWallet(walletId);
+  const isHardware = wallet?.type === 'hw';
   if (isHardware) {
-    if (deviceFeatures) {
-      return (
-        <Box w="full" h="full">
-          {children(password, {
-            withEnableAuthentication,
-            isLocalAuthentication,
-            deviceFeatures,
-          })}
-        </Box>
-      );
-    }
-
     return (
-      <>
-        <Box h="100%" justifyContent="center" alignItems="center">
-          <Spinner size="lg" />
-          <Typography.DisplayMedium mt={6}>
-            {intl.formatMessage({ id: 'modal__device_status_check' })}
-          </Typography.DisplayMedium>
-        </Box>
-      </>
+      <HardwareControl walletDetail={wallet}>
+        {children('', {})}
+      </HardwareControl>
     );
   }
-
-  if (hasPassword) {
-    return <Validation onOk={onValidationOk} field={field} />;
-  }
-  return <Setup onOk={onSetupOk} skipSavePassword={skipSavePassword} />;
+  return (
+    <SoftwareControl
+      skipSavePassword={skipSavePassword}
+      render={children}
+      field={field}
+    />
+  );
 };
 
 export default Protected;

--- a/packages/kit/src/hooks/redux.ts
+++ b/packages/kit/src/hooks/redux.ts
@@ -113,7 +113,7 @@ export const { use: useActiveWalletAccount, get: getActiveWalletAccount } =
     };
   });
 
-export const useGetWalletDetail = (walletId: string | null) => {
+export const useWallet = (walletId: string | null) => {
   const wallet =
     useAppSelector((s) =>
       s.runtime.wallets?.find?.((w) => w.id === walletId),

--- a/packages/kit/src/views/BackupWallet/BackupMnemonic.tsx
+++ b/packages/kit/src/views/BackupWallet/BackupMnemonic.tsx
@@ -9,7 +9,7 @@ import {
 import { updateWallet } from '@onekeyhq/kit/src/store/reducers/runtime';
 
 import backgroundApiProxy from '../../background/instance/backgroundApiProxy';
-import { useGetWalletDetail } from '../../hooks/redux';
+import { useWallet } from '../../hooks/redux';
 import { Mnemonic } from '../CreateWallet/AppWallet/Mnemonic';
 
 type RouteProps = RouteProp<
@@ -21,7 +21,7 @@ const BackupWalletMnemonic = () => {
   const navigation = useNavigation();
   const route = useRoute<RouteProps>();
   const { mnemonic, walletId } = route.params;
-  const walletDetail = useGetWalletDetail(walletId);
+  const walletDetail = useWallet(walletId);
   const onPress = useCallback(async () => {
     if (walletDetail && !walletDetail.backuped) {
       const wallet = await backgroundApiProxy.engine.confirmHDWalletBackuped(


### PR DESCRIPTION
实现打开**插件**，首次输入密码后(解锁屏的不算)。直到 `插件关闭/密码修改` 的这段时间内免密。

1. 支持生物识别环境情况下。还是走原来的验证逻辑。
2. 相关的数据，encode之后放在内存里。

技术上：
1. engine 实现了两个 UnsafeEncode 和 UnsafeDecode 
2. ValidationExt 来单独做 插件的密码校验

https://onekeygroup.slack.com/archives/C022268A5EW/p1657536196492129