### PR TITLE
fix: UI container full height for onboarding

### DIFF
--- a/packages/kit/src/views/Onboarding/Layout.tsx
+++ b/packages/kit/src/views/Onboarding/Layout.tsx
@@ -166,6 +166,7 @@ const Layout: FC<LayoutProps> = ({
             justifyContent={fullHeight ? 'space-between' : undefined}
           >
             <Box
+              flex={fullHeight && !secondaryContent ? 1 : undefined}
               flexShrink={fullHeight ? 0 : undefined}
               w={{ sm: secondaryContent ? 400 : 'full' }}
             >


### PR DESCRIPTION
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/18140164/189043570-891197e6-bd29-4806-aefa-bf128942262c.png">
<img width="576" alt="image" src="https://user-images.githubusercontent.com/18140164/189044400-01f9a2ab-7dfa-42a6-8544-189346a5a185.png">
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/18140164/189044679-8db2ff3c-f160-491d-9903-21ed827591eb.png">

