### PR TITLE
style: compact account info spacing

### DIFF
--- a/packages/kit/src/views/Wallet/AccountInfo/index.tsx
+++ b/packages/kit/src/views/Wallet/AccountInfo/index.tsx
@@ -47,7 +47,7 @@ type NavigationProps = ModalScreenProps<ReceiveTokenRoutesParams> &
   ModalScreenProps<SendRoutesParams>;
 
 export const FIXED_VERTICAL_HEADER_HEIGHT = 238;
-export const FIXED_HORIZONTAL_HEDER_HEIGHT = 216;
+export const FIXED_HORIZONTAL_HEDER_HEIGHT = 152;
 
 const AccountAmountInfo: FC = () => {
   const intl = useIntl();


### PR DESCRIPTION
### Before
<img width="1401" alt="CleanShot 2022-09-22 at 18 43 08@2x" src="https://user-images.githubusercontent.com/23469879/191727258-e295c2e7-d3fc-4cfe-b68e-7d759799967a.png">

### After
<img width="1406" alt="CleanShot 2022-09-22 at 18 42 49@2x" src="https://user-images.githubusercontent.com/23469879/191727272-d74f89c4-8644-4e19-9be8-e15b67640f8b.png">
