### PR TITLE
OK-13687 Drawer Swipe Threshold & SegmentControl Background Color & ToggleButtonGroup styles

### DIFF
--- a/packages/components/src/CollapsibleTabView/index.ios.tsx
+++ b/packages/components/src/CollapsibleTabView/index.ios.tsx
@@ -74,6 +74,7 @@ const Container: FC<ContainerProps> = ({
           }, 0);
         }}
         headerHeight={headerHeight}
+        scrollEnabled
         renderHeader={renderHeader}
         tabViewStyle={{
           paddingX: 0,

--- a/packages/components/src/ScrollableButtonGroup/ScrollableButtonGroup.native.tsx
+++ b/packages/components/src/ScrollableButtonGroup/ScrollableButtonGroup.native.tsx
@@ -12,11 +12,10 @@ import {
 import { IBoxProps } from 'native-base';
 import Animated, {
   useAnimatedScrollHandler,
-  useAnimatedStyle,
   useSharedValue,
 } from 'react-native-reanimated';
 
-import { Box, Center, IconButton } from '@onekeyhq/components';
+import { Box, IconButton } from '@onekeyhq/components';
 
 import { useForwardRef } from '../utils/useForwardRef';
 
@@ -134,34 +133,6 @@ const ScrollableButtonGroup = forwardRef<
 
     return (
       <Box bg={bg} {...boxProps} onLayout={onContainerLayout}>
-        <Animated.View
-          style={[
-            { position: 'absolute' },
-            useAnimatedStyle(
-              () => ({
-                opacity: showLeftArrow.value ? 1 : 0,
-                zIndex: showLeftArrow.value ? 1 : -1,
-              }),
-              [],
-            ),
-          ]}
-        >
-          <Center bg={bg}>
-            {renderLeftArrow ? (
-              renderLeftArrow({ onPress: onLeftArrowPress })
-            ) : (
-              <IconButton
-                type="plain"
-                circle
-                name="ChevronLeftSolid"
-                size="sm"
-                onPress={onLeftArrowPress}
-                {...leftButtonProps}
-              />
-            )}
-          </Center>
-        </Animated.View>
-
         <Animated.ScrollView
           ref={scrollRef}
           style={{
@@ -201,33 +172,6 @@ const ScrollableButtonGroup = forwardRef<
             }),
           )}
         </Animated.ScrollView>
-        <Animated.View
-          style={[
-            { position: 'absolute', right: 0 },
-            useAnimatedStyle(
-              () => ({
-                opacity: showRightArrow.value ? 1 : 0,
-                zIndex: showRightArrow.value ? 1 : -1,
-              }),
-              [],
-            ),
-          ]}
-        >
-          <Center bg={bg}>
-            {renderRightArrow ? (
-              renderRightArrow({ onPress: onRightArrowPress })
-            ) : (
-              <IconButton
-                type="plain"
-                circle
-                name="ChevronRightSolid"
-                size="sm"
-                onPress={onRightArrowPress}
-                {...rightButtonProps}
-              />
-            )}
-          </Center>
-        </Animated.View>
       </Box>
     );
   },

--- a/packages/components/src/SegmentedControl/index.tsx
+++ b/packages/components/src/SegmentedControl/index.tsx
@@ -16,7 +16,7 @@ const SegmentedControl: FC<SegmentedControlProps> = ({ onChange, ...rest }) => {
   const fontColor = useThemeValue('text-subdued');
   const activeFontColor = useThemeValue('text-default');
   const activeBgColor = useThemeValue('surface-default');
-  const bgColor = useThemeValue('surface-neutral-default');
+  const bgColor = useThemeValue('surface-neutral-subdued');
   return (
     <SegmentedControlBase
       backgroundColor={bgColor}

--- a/packages/components/src/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/components/src/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -114,7 +114,6 @@ const ToggleButtonGroup: FC<ToggleButtonGroupProps> = ({
   return (
     <ScrollableButtonGroup
       bg={bg}
-      borderRadius="12"
       overflow="hidden"
       w="full"
       flexDirection="row"

--- a/packages/kit/src/routes/Drawer/index.tsx
+++ b/packages/kit/src/routes/Drawer/index.tsx
@@ -41,7 +41,7 @@ const DrawerStackNavigator = () => {
          * fix drawer every render blink issue: https://github.com/react-navigation/react-navigation/issues/7515
          */
         drawerType: 'back',
-        swipeEdgeWidth: 390,
+        swipeEdgeWidth: 16,
         drawerStyle,
       }}
       // drawerContent={(props) => <AccountSelectorMobile {...props} />}

--- a/packages/kit/src/views/Market/Components/MarketDetail/MarketDetailTab.tsx
+++ b/packages/kit/src/views/Market/Components/MarketDetail/MarketDetailTab.tsx
@@ -134,7 +134,6 @@ const MarketDetailTabs: FC<MarketDetailTabsProps> = ({
         setDetailTabName(tabName);
       }}
       width={isVerticalLayout ? screenWidth : screenWidth - 224}
-      pagerProps={{ scrollEnabled: false }}
       containerStyle={{
         maxWidth: MAX_PAGE_CONTAINER_WIDTH,
         width: '100%',

--- a/packages/kit/src/views/Market/Components/MarketList/MarketCategoryToggles.tsx
+++ b/packages/kit/src/views/Market/Components/MarketList/MarketCategoryToggles.tsx
@@ -69,6 +69,7 @@ const MarketCategoryToggles: React.FC<MarketCategoryHeadProps> = ({
             buttons={buttons}
             selectedIndex={toggleIndex}
             onButtonPress={toggleCategory}
+            bg="background-default"
           />
         ) : (
           <Box flex={1} width="full" flexDirection="row">

--- a/packages/kit/src/views/Wallet/index.tsx
+++ b/packages/kit/src/views/Wallet/index.tsx
@@ -97,7 +97,6 @@ const WalletTabs: FC = () => {
         }}
         renderHeader={() => <AccountInfo />}
         width={isVerticalLayout ? screenWidth : screenWidth - 224} // reduce the width on iPad, sidebar's width is 244
-        pagerProps={{ scrollEnabled: false }}
         headerHeight={
           isVerticalLayout
             ? FIXED_VERTICAL_HEADER_HEIGHT


### PR DESCRIPTION
### Components Gesture
- Change the swipe threshold of the `Drawer` from `390` to `16`.
- Enable the swipe of the `Tab` on the Account page.

### SegmentControl
- Change the background color of `SegmentControl` from `surface-neutral-default` to `surface-neutral-subuded`.

### ToggleButtonGroup
- Optimized the styles on the Market page.
- Remove the ScrollToLeft and ScrollToRight button while the platform is native.