### PR TITLE
Fix the style of ToggleButtonGroup on Explore

### DIFF
--- a/packages/kit/src/views/Discover/Home/Desktop/DAppCategories.tsx
+++ b/packages/kit/src/views/Discover/Home/Desktop/DAppCategories.tsx
@@ -43,6 +43,7 @@ export const DAppCategories = () => {
         buttons={buttons}
         selectedIndex={selectedIndex}
         onButtonPress={onButtonPress}
+        bg="background-default"
       />
     </Box>
   );


### PR DESCRIPTION
### Before
<img width="776" alt="CleanShot 2022-11-02 at 17 52 22@2x" src="https://user-images.githubusercontent.com/23469879/199460067-a9290692-d6fe-4069-ba83-67ec2d67820b.png">



### After
<img width="457" alt="CleanShot 2022-11-02 at 17 51 41@2x" src="https://user-images.githubusercontent.com/23469879/199460108-da4a0440-09a8-4827-8b81-c8241ae2038b.png">
