### PR TITLE
style: fix togglebuttongroup style

### DIFF
--- a/packages/components/src/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/components/src/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -80,7 +80,12 @@ const ToggleButton: FC<
             bg={toggleButtonBg()}
           >
             {(!!leftIcon || !!leftImage) && (
-              <Center borderRadius="9999px" w={iconSize} h={iconSize}>
+              <Center
+                borderRadius="9999px"
+                w={iconSize}
+                h={iconSize}
+                mr={isSmall ? '4px' : '8px'}
+              >
                 {!!leftIcon && (
                   <Icon
                     name={leftIcon}
@@ -99,7 +104,6 @@ const ToggleButton: FC<
             {leftComponentRender?.()}
             {text.length > 0 ? (
               <Typography.Body2Strong
-                ml={isSmall ? '4px' : '8px'}
                 maxW={maxTextWidth}
                 isTruncated
                 color={isCurrent ? 'text-default' : 'text-subdued'}


### PR DESCRIPTION
Add a margin to the conditional render element instead of text.

### Before
<img width="184" alt="CleanShot 2022-11-10 at 23 30 02@2x" src="https://user-images.githubusercontent.com/23469879/201136850-f5302b31-8201-4388-805c-c702ffb63600.png">

### After
<img width="153" alt="CleanShot 2022-11-10 at 23 30 20@2x" src="https://user-images.githubusercontent.com/23469879/201136874-65d20bb1-f4a9-4431-8051-de111bdf55fb.png">
