### PR TITLE
style: Optimize PnL entry aciton on the page header of NFT

### DIFF
--- a/packages/kit/src/views/NFTMarket/Home/PageHeader/index.tsx
+++ b/packages/kit/src/views/NFTMarket/Home/PageHeader/index.tsx
@@ -114,16 +114,16 @@ const PageHeader = () => {
       </HStack>
       {/* Right */}
       <Hidden from="md">
-        <HStack space="8px">
-          <IconButton
-            name="DocumentChartBarOutline"
-            type="plain"
-            size="lg"
-            circle
+        <HStack space="8px" alignItems="center">
+          <Button
+            leftIconName="DocumentChartBarMini"
+            size="sm"
             onPress={() => {
               nplAction();
             }}
-          />
+          >
+            PnL
+          </Button>
           <IconButton
             name="MagnifyingGlassOutline"
             type="plain"


### PR DESCRIPTION
<img width="362" alt="CleanShot 2023-01-10 at 17 41 54@2x" src="https://user-images.githubusercontent.com/23469879/211518700-39244ace-8f40-43d0-9e94-8dbbe4f67915.png">
