### PR TITLE
fix: pin expo-cli version

### DIFF
--- a/.github/workflows/bundlediff-ios.yml
+++ b/.github/workflows/bundlediff-ios.yml
@@ -39,9 +39,9 @@ jobs:
       - name: Install Dependency
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: '--max_old_space_size=4096'
         run: |
-          npm i -g expo-cli && yarn
+          npm i -g expo-cli@6.0.8 && yarn
 
       - name: Generate stats.json
         env:
@@ -82,9 +82,9 @@ jobs:
       - name: Install Dependency
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: '--max_old_space_size=4096'
         run: |
-          npm i -g expo-cli && yarn
+          npm i -g expo-cli@6.0.8 && yarn
 
       - name: Generate stats.json
         env:

--- a/.github/workflows/bundlediff-web.yml
+++ b/.github/workflows/bundlediff-web.yml
@@ -39,9 +39,9 @@ jobs:
       - name: Install Dependency
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: '--max_old_space_size=4096'
         run: |
-          npm i -g expo-cli && yarn
+          npm i -g expo-cli@6.0.8 && yarn
 
       - name: Generate stats.json
         env:
@@ -82,9 +82,9 @@ jobs:
       - name: Install Dependency
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: '--max_old_space_size=4096'
         run: |
-          npm i -g expo-cli && yarn
+          npm i -g expo-cli@6.0.8 && yarn
 
       - name: Generate stats.json
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,5 +51,5 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_OPTIONS: '--max_old_space_size=4096'
         run: |
-          npm i -g expo-cli && yarn --mode=skip-build && yarn patch-package
+          npm i -g expo-cli@6.0.8 && yarn --mode=skip-build && yarn patch-package
           yarn lint

--- a/.github/workflows/release-desktop-mas.yml
+++ b/.github/workflows/release-desktop-mas.yml
@@ -86,9 +86,9 @@ jobs:
       - name: Install Dep
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_OPTIONS: "--max_old_space_size=8192"
+          NODE_OPTIONS: '--max_old_space_size=8192'
         run: |
-          npm i -g expo-cli && yarn
+          npm i -g expo-cli@6.0.8 && yarn
 
       - name: Install electron-builder v23
         env:

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -86,9 +86,9 @@ jobs:
       - name: Install Dep
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_OPTIONS: "--max_old_space_size=8192"
+          NODE_OPTIONS: '--max_old_space_size=8192'
         run: |
-          npm i -g expo-cli && yarn
+          npm i -g expo-cli@6.0.8 && yarn
 
       - name: Inject Environment Variables
         env:

--- a/.github/workflows/release-ext.yml
+++ b/.github/workflows/release-ext.yml
@@ -81,9 +81,9 @@ jobs:
       - name: Install Dep
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: '--max_old_space_size=4096'
         run: |
-          npm i -g expo-cli && yarn
+          npm i -g expo-cli@6.0.8 && yarn
 
       - name: Inject Environment Variables
         env:
@@ -97,7 +97,7 @@ jobs:
 
       - name: Build Ext
         env:
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: '--max_old_space_size=4096'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: 'cd packages/ext && yarn build:all'
 

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -70,9 +70,9 @@ jobs:
       - name: Install Dependency
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: '--max_old_space_size=4096'
         run: |
-          npm i -g expo-cli && yarn
+          npm i -g expo-cli@6.0.8 && yarn
 
       - name: Inject Environment Variables
         env:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -48,7 +48,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_OPTIONS: '--max_old_space_size=4096'
         run: |
-          npm i -g expo-cli && yarn --mode=skip-build && yarn setup:env && yarn patch-package
+          npm i -g expo-cli@6.0.8 && yarn --mode=skip-build && yarn setup:env && yarn patch-package
 
       - name: Run Tests
         env:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ yarn
 
 # Install the expo command line tool globally
 
-npm install -g expo-cli
+npm install -g expo-cli@6.0.8
 ```
 
 ## 🧑‍💻 Develop

--- a/packages/app/scripts/eas-build-pre-install.sh
+++ b/packages/app/scripts/eas-build-pre-install.sh
@@ -2,7 +2,7 @@
 # EAS Environment Secrets
 # Run Path: packages/app
 
-npm i -g expo-cli
+npm i -g expo-cli@6.0.8
 
 echo "@onekeyhq:registry=https://npm.pkg.github.com\n//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 


### PR DESCRIPTION
expo-cli 6.1.0 upgraded to webpack v5
until we upgrade to webpack v5 we should stay at version 6.0.8