### PR TITLE
style: random fix

### DIFF
--- a/packages/kit/src/views/Market/Components/MarketList/MarketTokenCell.tsx
+++ b/packages/kit/src/views/Market/Components/MarketList/MarketTokenCell.tsx
@@ -164,12 +164,16 @@ const MarketTokenCell: FC<MarketTokenCellProps> = ({
                       }}
                     >
                       <Icon
-                        name="StarMini"
+                        name={
+                          marketTokenItem.favorited
+                            ? 'StarSolid'
+                            : 'StarOutline'
+                        }
                         size={20}
                         color={
                           marketTokenItem.favorited
                             ? 'icon-warning'
-                            : 'icon-default'
+                            : 'icon-subdued'
                         }
                       />
                     </Pressable>

--- a/packages/kit/src/views/Market/MarketDetail.tsx
+++ b/packages/kit/src/views/Market/MarketDetail.tsx
@@ -47,21 +47,15 @@ const FavoritButton = ({ tokenItem }: { tokenItem?: MarketTokenItem }) => {
   const isVertical = useIsVerticalLayout();
 
   const intl = useIntl();
-  const iconName = useMemo(() => {
-    if (tokenItem?.favorited) {
-      return 'StarMini';
-    }
-    return isVertical ? 'StarOutline' : 'StarMini';
-  }, [isVertical, tokenItem?.favorited]);
   return (
     <Box>
       <IconButton
         ml={4}
         mr={2}
         type={isVertical ? 'plain' : 'basic'}
-        name={iconName}
+        name={tokenItem?.favorited ? 'StarSolid' : 'StarOutline'}
         size={isVertical ? 'xl' : 'base'}
-        circle={!isVertical}
+        circle
         iconColor={tokenItem?.favorited ? 'icon-warning' : 'icon-default'}
         onPress={() => {
           if (tokenItem) {

--- a/packages/kit/src/views/Wallet/AccountInfo/index.tsx
+++ b/packages/kit/src/views/Wallet/AccountInfo/index.tsx
@@ -69,7 +69,7 @@ const AccountAmountInfo: FC = () => {
       accountAllValues.value.isNaN() ? (
         <Skeleton shape="DisplayXLarge" />
       ) : (
-        <HStack flex="1">
+        <HStack flex="1" alignItems="center">
           <Typography.Display2XLarge numberOfLines={2} isTruncated>
             <FormatCurrencyNumber decimals={2} value={accountAllValues.value} />
           </Typography.Display2XLarge>
@@ -108,7 +108,7 @@ const AccountAmountInfo: FC = () => {
 
   return (
     <Box alignItems="flex-start" flex="1">
-      <Box mx="-8px" my="-4px" flexDir="row">
+      <Box mx="-8px" my="-4px" flexDir="row" alignItems="center">
         <Tooltip
           hasArrow
           placement="top"
@@ -145,8 +145,6 @@ const AccountAmountInfo: FC = () => {
             label={intl.formatMessage({ id: 'form__blockchain_browser' })}
           >
             <Pressable
-              flexDirection="row"
-              alignItems="center"
               p={1}
               rounded="full"
               _hover={{ bg: 'surface-hovered' }}


### PR DESCRIPTION
### Change the shape of pressable "Blockchain Browser" from ellipse to circle
| Before                     | After                      |
|----------------------------|----------------------------|
| <img width="161" alt="CleanShot 2023-02-10 at 19 44 36@2x" src="https://user-images.githubusercontent.com/23469879/218084580-dab51c00-68b6-407b-86b9-921a617686d2.png"> | <img width="162" alt="CleanShot 2023-02-10 at 19 43 44@2x" src="https://user-images.githubusercontent.com/23469879/218084456-88f7001e-27c6-4d20-9053-6d34ec9e0cfb.png"> |

<br />

### Change the shape of `Pressable` next to total balance from ellipse to circle
| Before                     | After                      |
|----------------------------|----------------------------|
| <img width="162" alt="CleanShot 2023-02-10 at 19 51 33@2x" src="https://user-images.githubusercontent.com/23469879/218085937-caeab7b2-8be6-4d1f-b604-1a979fd2796e.png"> | <img width="195" alt="CleanShot 2023-02-10 at 19 51 25@2x" src="https://user-images.githubusercontent.com/23469879/218085946-554c2985-d1a3-4de7-b39f-b6eb8324715c.png"> |

<br />

### Change the Icon which stands for "unactivated" from StarMini to StarOutline
| Before                     | After                      |
|----------------------------|----------------------------|
| <img width="196" alt="CleanShot 2023-02-10 at 19 53 57@2x" src="https://user-images.githubusercontent.com/23469879/218086364-db779b58-3457-4204-bcf5-42575d63a535.png"> | <img width="188" alt="CleanShot 2023-02-10 at 19 53 35@2x" src="https://user-images.githubusercontent.com/23469879/218086377-9a90c527-d0ab-476e-bf49-d09c20b4defa.png"> |




