### PR TITLE
OK-17743, OK-17746: fix Android crash when updating firmware & show confirm popup

### DIFF
--- a/packages/components/src/Select/Container/Desktop.tsx
+++ b/packages/components/src/Select/Container/Desktop.tsx
@@ -8,7 +8,7 @@ import PresenceTransition from '../../PresenceTransition';
 import ScrollView from '../../ScrollView';
 import Typography from '../../Typography';
 
-import { renderOptions } from './Option';
+import { RenderOptions } from './Option';
 
 import type { ChildProps } from '..';
 
@@ -106,13 +106,13 @@ function Desktop<T>({
           </Box>
         ) : null}
         <ScrollView p="1" flex="1">
-          {renderOptions<T>({
-            options,
-            activeOption,
-            renderItem,
-            onChange,
-            activatable,
-          })}
+          <RenderOptions
+            options={options}
+            activeOption={activeOption}
+            renderItem={renderItem}
+            onChange={onChange}
+            activatable={activatable}
+          />
         </ScrollView>
         {isValidElement(footer) || footer === null ? (
           footer

--- a/packages/components/src/Select/Container/Mobile.tsx
+++ b/packages/components/src/Select/Container/Mobile.tsx
@@ -10,7 +10,7 @@ import IconButton from '../../IconButton';
 import ScrollView from '../../ScrollView';
 import Typography from '../../Typography';
 
-import { renderOptions } from './Option';
+import { RenderOptions } from './Option';
 
 import type { ChildProps } from '..';
 
@@ -84,13 +84,13 @@ function Mobile<T>({
           />
         </Box>
         <ScrollView _contentContainerStyle={{ padding: 2, paddingBottom: '4' }}>
-          {renderOptions<T>({
-            options,
-            activeOption,
-            renderItem,
-            onChange,
-            activatable,
-          })}
+          <RenderOptions
+            options={options}
+            activeOption={activeOption}
+            renderItem={renderItem}
+            onChange={onChange}
+            activatable={activatable}
+          />
         </ScrollView>
         {isValidElement(footer) || footer === null ? (
           footer

--- a/packages/components/src/Select/Container/MobileModalize.tsx
+++ b/packages/components/src/Select/Container/MobileModalize.tsx
@@ -12,7 +12,7 @@ import IconButton from '../../IconButton';
 import ScrollView from '../../ScrollView';
 import Typography from '../../Typography';
 
-import { renderOptions } from './Option';
+import { RenderOptions } from './Option';
 
 import type { ChildProps } from '..';
 
@@ -151,13 +151,13 @@ function Mobile<T>({
         {...dropdownProps}
       >
         <ScrollView _contentContainerStyle={{ padding: 2, paddingBottom: '4' }}>
-          {renderOptions<T>({
-            options,
-            activeOption,
-            renderItem,
-            onChange,
-            activatable,
-          })}
+          <RenderOptions
+            options={options}
+            activeOption={activeOption}
+            renderItem={renderItem}
+            onChange={onChange}
+            activatable={activatable}
+          />
         </ScrollView>
       </Box>
     </Modalize>

--- a/packages/components/src/Select/Container/Option.tsx
+++ b/packages/components/src/Select/Container/Option.tsx
@@ -1,3 +1,4 @@
+import type { FC } from 'react';
 import { Fragment } from 'react';
 
 import { useIsVerticalLayout } from '@onekeyhq/components';
@@ -127,59 +128,64 @@ function RenderSingleOption<T>({
     )
   );
 }
+type IRenderOptions<T = any> = Pick<
+  ChildProps<T>,
+  'activeOption' | 'onChange' | 'renderItem' | 'options' | 'activatable'
+>;
 
-export function renderOptions<T>({
+type IRenderOptionsFC<T = any> = FC<IRenderOptions<T>>;
+
+export const RenderOptions: IRenderOptionsFC = <T,>({
   options,
   activeOption,
   renderItem,
   onChange,
   activatable,
-}: Pick<
-  ChildProps<T>,
-  'activeOption' | 'onChange' | 'renderItem' | 'options' | 'activatable'
->) {
-  return options.map((option, index) => {
-    if (isGroup<T>(option)) {
-      const isLast = index === options.length - 1;
-      return (
-        <Fragment key={`${option.title}${index}`}>
-          {option.title.length > 0 ? (
-            // add Pressabel fix https://onekeyhq.atlassian.net/browse/OK-16171  Sliding events do not trigger problems
-            <Pressable>
-              <Typography.Subheading
-                px={{ base: '4', md: '2' }}
-                pt={2}
-                color="text-subdued"
-              >
-                {option.title}
-              </Typography.Subheading>
-            </Pressable>
-          ) : null}
-          {option.options.map((subOption) =>
-            RenderSingleOption<T>({
-              activeOption,
-              renderItem,
-              onChange,
-              option: subOption,
-              activatable,
-            }),
-          )}
-          {!isLast && (
-            <Box px={{ base: '4', md: '2' }} py={1}>
-              <Divider />
-            </Box>
-          )}
-        </Fragment>
-      );
-    }
+}: IRenderOptions<T>) => (
+  <>
+    {options.map((option, index) => {
+      if (isGroup<T>(option)) {
+        const isLast = index === options.length - 1;
+        return (
+          <Fragment key={`${option.title}${index}`}>
+            {option.title.length > 0 ? (
+              // add Pressabel fix https://onekeyhq.atlassian.net/browse/OK-16171  Sliding events do not trigger problems
+              <Pressable>
+                <Typography.Subheading
+                  px={{ base: '4', md: '2' }}
+                  pt={2}
+                  color="text-subdued"
+                >
+                  {option.title}
+                </Typography.Subheading>
+              </Pressable>
+            ) : null}
+            {option.options.map((subOption) =>
+              RenderSingleOption<T>({
+                activeOption,
+                renderItem,
+                onChange,
+                option: subOption,
+                activatable,
+              }),
+            )}
+            {!isLast && (
+              <Box px={{ base: '4', md: '2' }} py={1}>
+                <Divider />
+              </Box>
+            )}
+          </Fragment>
+        );
+      }
 
-    const singleOption = option;
-    return RenderSingleOption<T>({
-      activeOption,
-      renderItem,
-      onChange,
-      option: singleOption,
-      activatable,
-    });
-  });
-}
+      const singleOption = option;
+      return RenderSingleOption<T>({
+        activeOption,
+        renderItem,
+        onChange,
+        option: singleOption,
+        activatable,
+      });
+    })}
+  </>
+);

--- a/packages/kit/src/views/Hardware/UpdateFirmware/Updating/index.tsx
+++ b/packages/kit/src/views/Hardware/UpdateFirmware/Updating/index.tsx
@@ -218,16 +218,18 @@ const UpdatingModal: FC = () => {
         break;
       case 'ConfirmOnDevice':
         setMaxProgress(35);
-        dispatch(
-          setHardwarePopup({
-            uiRequest: UI_REQUEST.REQUEST_BUTTON,
-            payload: {
-              deviceType,
-              deviceId: '',
-              deviceConnectId: connectId,
-            },
-          }),
-        );
+        setTimeout(() => {
+          dispatch(
+            setHardwarePopup({
+              uiRequest: UI_REQUEST.REQUEST_BUTTON,
+              payload: {
+                deviceType,
+                deviceId: '',
+                deviceConnectId: connectId,
+              },
+            }),
+          );
+        }, 300);
         break;
       case 'FirmwareEraseSuccess':
         setMaxProgress(90);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16911056/221764169-2c81b63a-f309-41e4-b56e-42d382a9c871.png)

```
react-dom.development.js:15050 Uncaught Error: Rendered fewer hooks than expected. This may be caused by an accidental early return statement.
    at renderWithHooks (react-dom.development.js:15050:1)
    at updateFunctionComponent (react-dom.development.js:17356:1)
    at beginWork (react-dom.development.js:19063:1)
    at HTMLUnknownElement.callCallback (react-dom.development.js:3945:1)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:3994:1)
    at invokeGuardedCallback (react-dom.development.js:4056:1)
    at beginWork$1 (react-dom.development.js:23964:1)
    at performUnitOfWork (react-dom.development.js:22776:1)
    at workLoopSync (react-dom.development.js:22707:1)
    at renderRootSync (react-dom.development.js:22670:1)
    at performSyncWorkOnRoot (react-dom.development.js:22293:1)
    at react-dom.development.js:11327:1
    at unstable_runWithPriority (scheduler.development.js:468:1)
    at runWithPriority$1 (react-dom.development.js:11276:1)
    at flushSyncCallbackQueueImpl (react-dom.development.js:11322:1)
    at flushSyncCallbackQueue (react-dom.development.js:11309:1)
    at scheduleUpdateOnFiber (react-dom.development.js:21893:1)
    at dispatchAction (react-dom.development.js:16139:1)
    at useDeviceStatusOfHardwareWallet.ts:52:1
    at Generator.next (<anonymous>)
    at asyncGeneratorStep (asyncToGenerator.js:3:1)
    at _next (asyncToGenerator.js:22:1)
```

```
The above error occurred in the <Mobile> component:

    at Mobile (http://localhost:3000/static/js/app.a7ac6820.chunk.js:44598:28)
    at div
    at http://localhost:3000/static/js/28.chunk.js:83833:25
    at http://localhost:3000/static/js/29.chunk.js:44387:22
    at Box (http://localhost:3000/static/js/29.chunk.js:19921:23)
    at Select (http://localhost:3000/static/js/app.a7ac6820.chunk.js:45030:23)
    at WalletItemSelectDropdown (http://localhost:3000/static/js/10.chunk.js:12674:21)
    at RightContent (http://localhost:3000/static/js/10.chunk.js:11718:21)
    at div
    at http://localhost:3000/static/js/28.chunk.js:83833:25
    at Pressable (http://localhost:3000/static/js/28.chunk.js:79849:24)
    at http://localhost:3000/static/js/29.chunk.js:44387:22
    at Pressable (http://localhost:3000/static/js/29.chunk.js:23086:23)
    at http://localhost:3000/static/js/app.a7ac6820.chunk.js:42261:22
    at div
    at http://localhost:3000/static/js/28.chunk.js:83833:25
    at http://localhost:3000/static/js/29.chunk.js:44387:22
    at Box (http://localhost:3000/static/js/29.chunk.js:19921:23)
    at ListItemBase (http://localhost:3000/static/js/10.chunk.js:11734:24)
    at ListItem (http://localhost:3000/static/js/10.chunk.js:11764:22)
    at ListItemWithEmptyWallet (http://localhost:3000/static/js/10.chunk.js:11826:22)
    at ListItemWithHidden (http://localhost:3000/static/js/10.chunk.js:11924:27)
    at ItemWithSeparator (http://localhost:3000/static/js/28.chunk.js:95260:41)
    at div
    at http://localhost:3000/static/js/28.chunk.js:83833:25
    at VirtualizedListCellContextProvider (http://localhost:3000/static/js/28.chunk.js:93631:23)
    at CellRenderer (http://localhost:3000/static/js/28.chunk.js:94782:22)
    at div
    at http://localhost:3000/static/js/28.chunk.js:83833:25
    at div
    at http://localhost:3000/static/js/28.chunk.js:83833:25
    at http://localhost:3000/static/js/28.chunk.js:80209:24
    at <anonymous> (http://localhost:3000/static/js/25.chunk.js:27940:37)
    at ScrollView
    at VirtualizedListContextProvider (http://localhost:3000/static/js/28.chunk.js:93607:24)
    at VirtualizedList (http://localhost:3000/static/js/28.chunk.js:93887:21)
    at VirtualizedSectionList (http://localhost:3000/static/js/28.chunk.js:95003:20)
    at SectionList (http://localhost:3000/static/js/28.chunk.js:93094:20)
    at http://localhost:3000/static/js/29.chunk.js:44387:22
    at SectionListComponent (http://localhost:3000/static/js/29.chunk.js:10120:94)
    at Body (http://localhost:3000/static/js/10.chunk.js:12183:126)
    at div
    at http://localhost:3000/static/js/28.chunk.js:83833:25
    at http://localhost:3000/static/js/29.chunk.js:44387:22
    at Box (http://localhost:3000/static/js/29.chunk.js:19921:23)
    at WalletSelectorChildren (http://localhost:3000/static/js/10.chunk.js:13015:72)
    at div
    at http://localhost:3000/static/js/28.chunk.js:83833:25
    at http://localhost:3000/static/js/29.chunk.js:44387:22
    at Box (http://localhost:3000/static/js/29.chunk.js:19921:23)
    at div
    at http://localhost:3000/static/js/28.chunk.js:83833:25
    at AnimatedComponent (http://localhost:3000/static/js/28.chunk.js:90148:23)
    at AnimatedComponentWrapper
    at http://localhost:3000/static/js/29.chunk.js:18955:23
    at PresenceTransition (http://localhost:3000/static/js/29.chunk.js:18430:27)
    at http://localhost:3000/static/js/30.chunk.js:4758:22
    at div
    at http://localhost:3000/static/js/28.chunk.js:83833:25
    at http://localhost:3000/static/js/29.chunk.js:44387:22
    at Box (http://localhost:3000/static/js/29.chunk.js:19921:23)
    at WalletSelectorTrigger (http://localhost:3000/static/js/30.chunk.js:4907:28)
    at div
    at http://localhost:3000/static/js/28.chunk.js:83833:25
    at http://localhost:3000/static/js/29.chunk.js:44387:22
    at Box (http://localhost:3000/static/js/29.chunk.js:19921:23)
    at div
    at http://localhost:3000/static/js/28.chunk.js:83833:25
    at http://localhost:3000/static/js/29.chunk.js:44387:22
    at Box (http://localhost:3000/static/js/29.chunk.js:19921:23)
    at Sidebar (http://localhost:3000/static/js/30.chunk.js:3194:25)
    at NavigationBar (http://localhost:3000/static/js/30.chunk.js:3565:130)
    at div
    at http://localhost:3000/static/js/28.chunk.js:83833:25
    at SafeAreaProviderCompat (http://localhost:3000/static/js/27.chunk.js:97920:23)
    at BottomTabView (http://localhost:3000/static/js/30.chunk.js:2604:133)
    at BottomTabNavigator (http://localhost:3000/static/js/30.chunk.js:2296:31)
    at LazyDisplayView (http://localhost:3000/static/js/10.chunk.js:7188:25)
    at TabNavigator (http://localhost:3000/static/js/30.chunk.js:5987:72)
    at StaticContainer (http://localhost:3000/static/js/27.chunk.js:93216:16)
    at EnsureSingleNavigator (http://localhost:3000/static/js/27.chunk.js:92913:23)
    at SceneView (http://localhost:3000/static/js/27.chunk.js:93109:21)
    at div
    at http://localhost:3000/
```