### PR TITLE
fix: fix missing method on near vault (OK-20326, OK-20307 )

### DIFF
--- a/packages/engine/src/vaults/impl/near/Vault.ts
+++ b/packages/engine/src/vaults/impl/near/Vault.ts
@@ -763,6 +763,10 @@ export default class Vault extends VaultBase {
     return Promise.reject(new InvalidAddress());
   }
 
+  override async validateTokenAddress(address: string): Promise<string> {
+    return this.validateAddress(address);
+  }
+
   override async broadcastTransaction(
     signedTx: ISignedTxPro,
     options?: any,

--- a/packages/engine/src/vaults/impl/near/Vault.ts
+++ b/packages/engine/src/vaults/impl/near/Vault.ts
@@ -749,6 +749,12 @@ export default class Vault extends VaultBase {
     return transactionStatuses;
   }
 
+  override validateWatchingCredential(input: string): Promise<boolean> {
+    return Promise.resolve(
+      this.settings.watchingAccountEnabled && verifyNearAddress(input).isValid,
+    );
+  }
+
   override async validateAddress(address: string): Promise<string> {
     const result = verifyNearAddress(address);
     if (result.isValid) {


### PR DESCRIPTION
missing "validateWatchingCredential": https://onekeyhq.atlassian.net/browse/OK-20307
missing "validateTokenAddress":  https://onekeyhq.atlassian.net/browse/OK-20326