### PR TITLE
fix: send btc nft error OK-24706

### DIFF
--- a/packages/engine/src/vaults/utils/btcForkChain/utils/coinSelectUtils.ts
+++ b/packages/engine/src/vaults/utils/btcForkChain/utils/coinSelectUtils.ts
@@ -284,7 +284,7 @@ export function coinSelectForOrdinal(
   let ordUtxoCount = 0;
   let isPrevUtxoOrd = true;
 
-  result.inputs?.forEach((item, index, array) => {
+  result.inputs?.forEach((item, index) => {
     const isOrd = Boolean(item.forceSelect);
     if (isOrd) {
       if (!isPrevUtxoOrd) {
@@ -302,12 +302,6 @@ export function coinSelectForOrdinal(
       ordUtxoCount += 1;
       isPrevUtxoOrd = true;
     } else {
-      if (index !== array.length - 1) {
-        throw new Error(
-          'coinSelectForOrdinal ERROR: Change utxo should be last',
-        );
-      }
-
       isPrevUtxoOrd = false;
     }
   });


### PR DESCRIPTION
The check for non-ord utxo order in inputs here is unnecessary, and a check error will occur when there are multiple non-ord utxos in the inputs.