### PR TITLE
chore: fix unused platform code removal

### DIFF
--- a/patches/babel-preset-expo+9.5.2.patch
+++ b/patches/babel-preset-expo+9.5.2.patch
@@ -1,8 +1,29 @@
 diff --git a/node_modules/babel-preset-expo/index.js b/node_modules/babel-preset-expo/index.js
-index 2099ee3..423182c 100644
+index 2099ee3..9054f46 100644
 --- a/node_modules/babel-preset-expo/index.js
 +++ b/node_modules/babel-preset-expo/index.js
-@@ -39,6 +39,24 @@ module.exports = function (api, options = {}) {
+@@ -2,12 +2,20 @@ const lazyImportsBlacklist = require('./lazy-imports-blacklist');
+ 
+ let hasWarnedJsxRename = false;
+ 
++function getIsDev(caller) {
++  if (caller?.isDev != null) return caller.isDev;
++
++  // https://babeljs.io/docs/options#envname
++  return process.env.BABEL_ENV === 'development' || process.env.NODE_ENV === 'development';
++}
++
+ module.exports = function (api, options = {}) {
+   const { web = {}, native = {} } = options;
+ 
+   const bundler = api.caller(getBundler);
+   const isWebpack = bundler === 'webpack';
+   let platform = api.caller(getPlatform);
++  const isDev = api.caller(getIsDev);
+ 
+   // If the `platform` prop is not defined then this must be a custom config that isn't
+   // defining a platform in the babel-loader. Currently this may happen with Next.js + Expo web.
+@@ -39,6 +47,24 @@ module.exports = function (api, options = {}) {
      );
    }
  
@@ -17,7 +38,7 @@ index 2099ee3..423182c 100644
 +    extraPlugins.push([
 +        require('metro-transform-plugins/src/inline-plugin.js'),
 +        {
-+            dev: false,
++            dev: isDev,
 +            inlinePlatform: true,
 +            platform,
 +        },
@@ -27,7 +48,7 @@ index 2099ee3..423182c 100644
    // Set true to disable `@babel/plugin-transform-react-jsx`
    // we override this logic outside of the metro preset so we can add support for
    // React 17 automatic JSX transformations.
-@@ -105,7 +123,8 @@ module.exports = function (api, options = {}) {
+@@ -105,7 +131,8 @@ module.exports = function (api, options = {}) {
        ],
      ],
      plugins: [

--- a/patches/babel-preset-expo+9.5.2.patch
+++ b/patches/babel-preset-expo+9.5.2.patch
@@ -1,16 +1,33 @@
 diff --git a/node_modules/babel-preset-expo/index.js b/node_modules/babel-preset-expo/index.js
-index 2099ee3..2f2b75b 100644
+index 2099ee3..423182c 100644
 --- a/node_modules/babel-preset-expo/index.js
 +++ b/node_modules/babel-preset-expo/index.js
-@@ -4,7 +4,6 @@ let hasWarnedJsxRename = false;
+@@ -39,6 +39,24 @@ module.exports = function (api, options = {}) {
+     );
+   }
  
- module.exports = function (api, options = {}) {
-   const { web = {}, native = {} } = options;
--
-   const bundler = api.caller(getBundler);
-   const isWebpack = bundler === 'webpack';
-   let platform = api.caller(getPlatform);
-@@ -105,7 +104,8 @@ module.exports = function (api, options = {}) {
++   // TODO: remove this on Expo 50.x
++  // fix(babel): fix unused platform code removal #25171
++  // https://github.com/expo/expo/pull/25171
++  if (require('@babel/plugin-transform-parameters')) {
++    // Metro applies this plugin too but it does it after the imports have been transformed which breaks
++    // the plugin. Here, we'll apply it before the commonjs transform, in production, to ensure `Platform.OS`
++    // is replaced with a string literal and `__DEV__` is converted to a boolean.
++    // Applying early also means that web can be transformed before the `react-native-web` transform mutates the import.
++    extraPlugins.push([
++        require('metro-transform-plugins/src/inline-plugin.js'),
++        {
++            dev: false,
++            inlinePlatform: true,
++            platform,
++        },
++    ]);
++  }
++
+   // Set true to disable `@babel/plugin-transform-react-jsx`
+   // we override this logic outside of the metro preset so we can add support for
+   // React 17 automatic JSX transformations.
+@@ -105,7 +123,8 @@ module.exports = function (api, options = {}) {
        ],
      ],
      plugins: [


### PR DESCRIPTION
reduce almost 100kb bundle size.

<img width="569" alt="image" src="https://github.com/OneKeyHQ/app-monorepo/assets/5743863/85fa1601-30ba-46a3-8ff1-d86478d322c5">

on iOS:
<img width="346" alt="image" src="https://github.com/OneKeyHQ/app-monorepo/assets/5743863/c46b4851-ca3d-478a-b2dd-61c76788faa3">
on Android:
<img width="506" alt="image" src="https://github.com/OneKeyHQ/app-monorepo/assets/5743863/22aeb932-c819-47cb-be86-18cfff2c46d8">
on Web
<img width="407" alt="image" src="https://github.com/OneKeyHQ/app-monorepo/assets/5743863/9336c7a8-11a6-4afd-a4dd-aeca5b16c703">
