### PR TITLE
fix: fix margin size of skeleton view in gtMd screen

### DIFF
--- a/packages/kit/src/views/Discovery/pages/Dashboard/SuggestAndExploreSection/ChunkedItemsSkeletonView.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/SuggestAndExploreSection/ChunkedItemsSkeletonView.tsx
@@ -14,6 +14,9 @@ export function ChunkedItemsSkeletonView({
   return (
     <ItemsContainer
       mx="$-5"
+      $gtMd={{
+        mx: '$-3',
+      }}
       horizontal={!isExploreView}
       contentContainerStyle={{
         px: '$2',


### PR DESCRIPTION
before: 
![image](https://github.com/OneKeyHQ/app-monorepo/assets/5743863/6e78f855-2c24-4013-bae5-56089d958ef6)

after:
![image](https://github.com/OneKeyHQ/app-monorepo/assets/5743863/08b5be64-19f7-4a12-af9e-a5aaafa3c2b5)

