### PR TITLE
fix: fix the issue where NumberSizeableText does not fully display text on Android.

### DIFF
--- a/packages/components/src/content/NumberSizeableText/index.tsx
+++ b/packages/components/src/content/NumberSizeableText/index.tsx
@@ -46,7 +46,6 @@ export function NumberSizeableText({
             key={index}
             {...props}
             fontSize={scriptFontSize}
-            lineHeight={16}
             {...subTextStyle}
           >
             {r.value}


### PR DESCRIPTION
Web
<img width="447" alt="image" src="https://github.com/OneKeyHQ/app-monorepo/assets/5743863/0516f607-6810-4b69-923c-52bd60ec6de0">

Android
<img width="379" alt="image" src="https://github.com/OneKeyHQ/app-monorepo/assets/5743863/09ad6bae-a1a1-4c15-80c9-4e00cb53b3e6">

iOS
<img width="358" alt="image" src="https://github.com/OneKeyHQ/app-monorepo/assets/5743863/3c864397-ef36-4b4d-919f-96702e2e0d32">
