### PR TITLE
chore: add react-native-network-logger in Dev

### DIFF
--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -1130,7 +1130,7 @@ PODS:
     - React-Core
   - react-native-slider (4.4.3):
     - React-Core
-  - react-native-tab-page-view (1.0.7):
+  - react-native-tab-page-view (1.0.8):
     - JXCategoryView (~> 1.6.1)
     - JXPagingView/Pager (~> 2.1.2)
     - React
@@ -1878,7 +1878,7 @@ SPEC CHECKSUMS:
   react-native-restart: 7595693413fe3ca15893702f2c8306c62a708162
   react-native-safe-area-context: 7aa8e6d9d0f3100a820efb1a98af68aa747f9284
   react-native-slider: 1cdd6ba29675df21f30544253bf7351d3c2d68c4
-  react-native-tab-page-view: eea7bd05591c6bb7b44c7b244fe3b6f67de4dbab
+  react-native-tab-page-view: f72f992dc2ab42f364ef63beeeb969d5037173ed
   react-native-tcp-socket: e724380c910c2e704816ec817ed28f1342246ff7
   react-native-video: dc3118548cf8864a83f57df4345cf6c692402e8f
   react-native-view-shot: 4475fde003fe8a210053d1f98fb9e06c1d834e1c
@@ -1931,9 +1931,9 @@ SPEC CHECKSUMS:
   SPAlert: 735da1f16a887e294719217572ce1f936d8c8782
   SPIndicator: 93e0a4fb23de51294ac48e874c0f081a5e293e4f
   SSZipArchive: fe6a26b2a54d5a0890f2567b5cc6de5caa600aef
-  Yoga: 07db09965bc46c4902e20d3ae6990d95e53af8a8
+  Yoga: 6d01ccde54c9f8b92492beb05d468dbfed1d9881
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 31e753bb2c9f68d523b0363a09cd2f6549a1a5c6
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.15.2

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -93,6 +93,7 @@
     "react-native-mmkv": "2.10.2",
     "react-native-modal": "^13.0.1",
     "react-native-nested-scroll-view": "https://github.com/OneKeyHQ/react-native-nested-scroll-view.git#feat/support-rn73",
+    "react-native-network-logger": "^1.16.1",
     "react-native-permissions": "^4.1.5",
     "react-native-randombytes": "^3.6.1",
     "react-native-reanimated": "3.6.1",

--- a/packages/kit/src/views/Developer/pages/NetworkLogger.tsx
+++ b/packages/kit/src/views/Developer/pages/NetworkLogger.tsx
@@ -1,0 +1,8 @@
+import NativeNetworkLogger from 'react-native-network-logger';
+
+import { useThemeVariant } from '../../../hooks/useThemeVariant';
+
+export default function NetworkLogger() {
+  const themeVariant = useThemeVariant();
+  return <NativeNetworkLogger theme={themeVariant} />;
+}

--- a/packages/kit/src/views/Developer/pages/TabDeveloper.tsx
+++ b/packages/kit/src/views/Developer/pages/TabDeveloper.tsx
@@ -200,11 +200,19 @@ const TabDeveloper = () => {
               </Button>
             </PartContainer>
 
-            <PartContainer title="Commit Hash">
-              <SizableText>{process.env.COMMITHASH}</SizableText>
-            </PartContainer>
+            {platformEnv.isNative ? (
+              <PartContainer title="NetworkLogger">
+                <Button
+                  onPress={() => {
+                    navigation.push(ETabDeveloperRoutes.NetworkLogger);
+                  }}
+                >
+                  NetworkLogger
+                </Button>
+              </PartContainer>
+            ) : null}
 
-            <PartContainer title="Commit Hash">
+            <PartContainer title="Async Import Test">
               <Button
                 onPress={async () => {
                   const { test } = await import('./asyncImportTest');

--- a/packages/kit/src/views/Developer/router.tsx
+++ b/packages/kit/src/views/Developer/router.tsx
@@ -12,6 +12,7 @@ const DevHome = LazyLoadPage(() => import('./pages/DevHome'));
 const DevHomeStack1 = LazyLoadPage(() => import('./pages/DevHomeStack1'));
 const DevHomeStack2 = LazyLoadPage(() => import('./pages/DevHomeStack2'));
 const SignatureRecord = LazyLoadPage(() => import('./pages/SignatureRecord'));
+const NetworkLogger = LazyLoadPage(() => import('./pages/NetworkLogger'));
 
 export const developerRouters: ITabSubNavigatorConfig<any, any>[] = [
   {
@@ -36,5 +37,9 @@ export const developerRouters: ITabSubNavigatorConfig<any, any>[] = [
   {
     name: ETabDeveloperRoutes.SignatureRecord,
     component: SignatureRecord,
+  },
+  {
+    name: ETabDeveloperRoutes.NetworkLogger,
+    component: NetworkLogger,
   },
 ];

--- a/packages/shared/src/routes/tabDeveloper.ts
+++ b/packages/shared/src/routes/tabDeveloper.ts
@@ -7,6 +7,7 @@ export enum ETabDeveloperRoutes {
   DevHomeStack1 = 'DevHomeStack1',
   DevHomeStack2 = 'DevHomeStack2',
   SignatureRecord = 'SignatureRecord',
+  NetworkLogger = 'NetworkLogger',
 }
 
 export type ITabDeveloperParamList = {
@@ -16,4 +17,5 @@ export type ITabDeveloperParamList = {
   [ETabDeveloperRoutes.DevHomeStack1]: { a: string; b: string };
   [ETabDeveloperRoutes.DevHomeStack2]: undefined;
   [ETabDeveloperRoutes.SignatureRecord]: undefined;
+  [ETabDeveloperRoutes.NetworkLogger]: undefined;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6182,6 +6182,7 @@ __metadata:
     react-native-mmkv: "npm:2.10.2"
     react-native-modal: "npm:^13.0.1"
     react-native-nested-scroll-view: "https://github.com/OneKeyHQ/react-native-nested-scroll-view.git#feat/support-rn73"
+    react-native-network-logger: "npm:^1.16.1"
     react-native-permissions: "npm:^4.1.5"
     react-native-randombytes: "npm:^3.6.1"
     react-native-reanimated: "npm:3.6.1"
@@ -29297,6 +29298,16 @@ __metadata:
   version: 9.0.1
   resolution: "react-native-nested-scroll-view@https://github.com/OneKeyHQ/react-native-nested-scroll-view.git#commit=a15061a0cdb8596dd414c3e770eb9a7630d5ee37"
   checksum: 10/87a79d30c5ed54d2bec789b0cb372506d506a1ea3abcc56aa4d495e6491f11a3790974b61c69f5443218d70ddc4aa64d926794e04f66e3ee8204324106f459dd
+  languageName: node
+  linkType: hard
+
+"react-native-network-logger@npm:^1.16.1":
+  version: 1.16.1
+  resolution: "react-native-network-logger@npm:1.16.1"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/43d168d57ece1b2246a6a8a03b4e116894cb70582087de6d5c9aca483c73858411846f314ace492634f06fba425cb895a042bd20dee0060cbc1738c367aff6ab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Will not be enabled in the production environment.

<img width="398" alt="image" src="https://github.com/user-attachments/assets/776030d9-e962-41f6-b7b0-067ad4536394">

<img width="398" alt="image" src="https://github.com/user-attachments/assets/0872c583-a98a-4b4e-b15c-26d1b0bd2fd4">

<img width="398" alt="image" src="https://github.com/user-attachments/assets/7ad31a1d-0a6b-48a6-9654-8ad5a5c1b1e7">
