### PR TITLE
xodex support

### DIFF
--- a/packages/shared/src/config/networkIds.ts
+++ b/packages/shared/src/config/networkIds.ts
@@ -11,6 +11,7 @@ export type INetworkShortCode =
   | 'onekeyall'
   | 'eth'
   | 'goerli'
+  | 'xodex'
   | 'arbitrum'
   | 'optimism'
   | 'avalanche'

--- a/packages/shared/src/config/presetNetworks.ts
+++ b/packages/shared/src/config/presetNetworks.ts
@@ -144,6 +144,47 @@ const sepolia: IServerNetwork = {
   'updatedAt': '2023-05-31T00:29:24.951Z',
 };
 
+const xodex: IServerNetwork = {
+  'balance2FeeDecimals': 9,
+  'chainId': '2415',
+  'code': 'xodex',
+  'decimals': 18,
+  'extensions': {
+    'providerOptions': {
+      'EIP1559Enabled': true,
+      'preferMetamask': true,
+    },
+  },
+  'id': 'evm--2415',
+  'impl': 'evm',
+  'isTestnet': true,
+  'logoURI':
+    'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQjoVCQUqDp2FfBoQm4e0dLqP4u1wMCTgyVdw&s',
+  'name': 'Xodex',
+  'shortcode': 'xodex',
+  'shortname': 'Xodex',
+  'symbol': 'TETH',
+  'feeMeta': {
+    'code': 'sepolia',
+    'decimals': 9,
+    'symbol': 'Gwei',
+  },
+  'defaultEnabled': false,
+  'priceConfigs': [],
+  'explorers': [
+    {
+      'address': 'https://explorer.xo-dex.com//address/{address}',
+      'block': 'https://explorer.xo-dex.com//block/{block}',
+      'name': 'https://explorer.xo-dex.com//',
+      'transaction': 'https://explorer.xo-dex.com//tx/{transaction}',
+    },
+  ],
+  'status': ENetworkStatus.LISTED,
+  'createdAt': '2023-05-31T00:29:24.951Z',
+  'updatedAt': '2023-05-31T00:29:24.951Z',
+};
+
+
 const btc: IServerNetwork = {
   'balance2FeeDecimals': 0,
   'chainId': '0',
@@ -2995,6 +3036,7 @@ export const presetNetworksMap = {
   sepolia,
   op,
   xdai,
+  xodex,
   ethw,
   cfxespace,
   aurora,

--- a/packages/shared/src/config/presetNetworks.ts
+++ b/packages/shared/src/config/presetNetworks.ts
@@ -144,6 +144,46 @@ const sepolia: IServerNetwork = {
   'updatedAt': '2023-05-31T00:29:24.951Z',
 };
 
+const xodexTestnet: IServerNetwork = {
+  'balance2FeeDecimals': 9,
+  'chainId': '2416',
+  'code': 'xodex',
+  'decimals': 18,
+  'extensions': {
+    'providerOptions': {
+      'EIP1559Enabled': true,
+      'preferMetamask': true,
+    },
+  },
+  'id': 'evm--2416',
+  'impl': 'evm',
+  'isTestnet': true,
+  'logoURI':
+    'https://i.postimg.cc/XqDnc4g2/XODEX-Avatar-02-2-copy.png',
+  'name': 'Xodex Testnet',
+  'shortcode': 'xodex',
+  'shortname': 'Xodex',
+  'symbol': 'XODEX',
+  'feeMeta': {
+    'code': 'xodex',
+    'decimals': 9,
+    'symbol': 'Gwei',
+  },
+  'defaultEnabled': false,
+  'priceConfigs': [],
+  'explorers': [
+    {
+      'address': 'https://explorer.xo-dex.com/address/{address}',
+      'block': 'https://explorer.xo-dex.com/block/{block}',
+      'name': 'https://explorer.xo-dex.com/',
+      'transaction': 'https://explorer.xo-dex.com/tx/{transaction}',
+    },
+  ],
+  'status': ENetworkStatus.LISTED,
+  'createdAt': '2023-05-31T00:29:24.951Z',
+  'updatedAt': '2023-05-31T00:29:24.951Z',
+};
+
 const xodex: IServerNetwork = {
   'balance2FeeDecimals': 9,
   'chainId': '2415',
@@ -157,15 +197,15 @@ const xodex: IServerNetwork = {
   },
   'id': 'evm--2415',
   'impl': 'evm',
-  'isTestnet': true,
+  'isTestnet': false,
   'logoURI':
-    'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQjoVCQUqDp2FfBoQm4e0dLqP4u1wMCTgyVdw&s',
+    'https://i.postimg.cc/XqDnc4g2/XODEX-Avatar-02-2-copy.png',
   'name': 'Xodex',
   'shortcode': 'xodex',
   'shortname': 'Xodex',
-  'symbol': 'TETH',
+  'symbol': 'XODEX',
   'feeMeta': {
-    'code': 'sepolia',
+    'code': 'xodex',
     'decimals': 9,
     'symbol': 'Gwei',
   },
@@ -173,17 +213,16 @@ const xodex: IServerNetwork = {
   'priceConfigs': [],
   'explorers': [
     {
-      'address': 'https://explorer.xo-dex.com//address/{address}',
-      'block': 'https://explorer.xo-dex.com//block/{block}',
-      'name': 'https://explorer.xo-dex.com//',
-      'transaction': 'https://explorer.xo-dex.com//tx/{transaction}',
+      'address': 'https://explorer.xo-dex.com/address/{address}',
+      'block': 'https://explorer.xo-dex.com/block/{block}',
+      'name': 'https://explorer.xo-dex.com/',
+      'transaction': 'https://explorer.xo-dex.com/tx/{transaction}',
     },
   ],
   'status': ENetworkStatus.LISTED,
   'createdAt': '2023-05-31T00:29:24.951Z',
   'updatedAt': '2023-05-31T00:29:24.951Z',
 };
-
 
 const btc: IServerNetwork = {
   'balance2FeeDecimals': 0,
@@ -3034,9 +3073,10 @@ export const presetNetworksMap = {
   // evm
   eth,
   sepolia,
+  xodex,
+  xodexTestnet,
   op,
   xdai,
-  xodex,
   ethw,
   cfxespace,
   aurora,
@@ -3111,6 +3151,8 @@ export const getPresetNetworks = memoFn((): IServerNetwork[] => [
   // evm
   eth,
   sepolia,
+  xodex,
+  xodexTestnet,
   op,
   xdai,
   ethw,

--- a/packages/shared/types/swap/SwapProvider.constants.ts
+++ b/packages/shared/types/swap/SwapProvider.constants.ts
@@ -268,6 +268,29 @@ export const swapDefaultSetTokens: Record<
       'isNative': false,
     },
   },
+  'evm--2415': {
+    fromToken: {
+      'networkId': 'evm--2415',
+      'contractAddress': '',
+      'name': 'Xodex',
+      'symbol': 'xodex',
+      'decimals': 18,
+      'logoURI':
+        'https://i.postimg.cc/XqDnc4g2/XODEX-Avatar-02-2-copy.png',
+
+      'isNative': true,
+    },
+    toToken: {
+      'networkId': 'evm--2415',
+      'contractAddress': '0x04068da6c83afcfa0e13ba15a6696662335d5b75',
+      'name': 'USD Coin',
+      'symbol': 'USDC',
+      'decimals': 6,
+      'logoURI':
+        'https://uni-test.onekey-asset.com/server-service-onchain/evm--250/tokens/0x04068da6c83afcfa0e13ba15a6696662335d5b75.png',
+      'isNative': false,
+    },
+  },
   'evm--324': {
     fromToken: {
       'networkId': 'evm--324',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 新增网络短代码 `'xodex'`，支持更多网络标识符。
	- 新增网络配置 `xodexTestnet` 和 `xodex`，支持主网和测试网的功能。
	- 支持在 `evm--2415` 网络上进行 Xodex 和 USD Coin 的代币互换。

- **文档**
	- 更新了网络和代币配置的相关文档以反映新功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->