### PR TITLE
chore: ugrapde minSdkVersion on Android

### DIFF
--- a/apps/mobile/android/build.gradle
+++ b/apps/mobile/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = findProperty('android.buildToolsVersion') ?: '34.0.0'
-        minSdkVersion = Integer.parseInt(findProperty('android.minSdkVersion') ?: '23')
+        minSdkVersion = Integer.parseInt(findProperty('android.minSdkVersion') ?: '24')
         compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: '34')
         targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '34')
         kotlinVersion = findProperty('android.kotlinVersion') ?: '1.9.0'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 更新了Android应用程序的最低SDK版本要求，现在需要Android API级别24才能运行，这可能影响与旧版本Android设备的兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->