### PR TITLE
fix: fix comma separator in AmountInput on iOS(OK-32426)

### DIFF
--- a/packages/components/src/forms/Input/index.tsx
+++ b/packages/components/src/forms/Input/index.tsx
@@ -142,6 +142,8 @@ function BaseInput(
     value,
     displayAsMaskWhenEmptyValue,
     onPaste,
+    onChangeText,
+    keyboardType,
     ...props
   } = useProps(inputProps);
   const { paddingLeftWithIcon, height, iconLeftPosition } = SIZE_MAPPINGS[size];
@@ -165,13 +167,13 @@ function BaseInput(
           iconName: 'XCircleOutline',
           onPress: () => {
             inputRef?.current?.clear();
-            inputProps?.onChangeText?.('');
+            onChangeText?.('');
           },
         },
       ];
     }
     return addOnsInProps;
-  }, [allowClear, addOnsInProps, inputProps]);
+  }, [allowClear, inputProps?.value, addOnsInProps, onChangeText]);
 
   useEffect(() => {
     if (!platformEnv.isNative && inputRef.current && onPaste) {
@@ -229,6 +231,13 @@ function BaseInput(
     [onFocus, selectTextOnFocus, scrollToView],
   );
 
+  const onNumberPadChangeText = useCallback(
+    (text: string) => {
+      onChangeText?.(text.replace(',', '.'));
+    },
+    [onChangeText],
+  );
+
   return (
     <Group
       orientation="horizontal"
@@ -262,6 +271,7 @@ function BaseInput(
         <TMInput
           unstyled
           ref={inputRef}
+          keyboardType={keyboardType}
           flex={1}
           // @ts-expect-error
           pointerEvents={readonly ? 'none' : 'auto'}
@@ -293,6 +303,11 @@ function BaseInput(
           editable={editable}
           {...readOnlyStyle}
           {...props}
+          onChangeText={
+            platformEnv.isNativeIOS && keyboardType === 'decimal-pad'
+              ? onNumberPadChangeText
+              : onChangeText
+          }
         />
       </Group.Item>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在输入组件中新增了 `onChangeText` 和 `keyboardType` 属性，增强了文本输入的灵活性。
	- 引入了 `onNumberPadChangeText` 回调函数，以优化数字输入的格式处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->