### PR TITLE
fix: swap allnet use i18n

### DIFF
--- a/packages/kit/src/states/jotai/contexts/swap/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/atoms.ts
@@ -51,6 +51,7 @@ export const {
     symbol: dangerAllNetworkRepresent.symbol,
     logoURI: dangerAllNetworkRepresent.logoURI,
     shortcode: dangerAllNetworkRepresent.shortcode,
+    isAllNetworks: true,
   };
   return [allNetwork, ...networks];
 });

--- a/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
@@ -431,10 +431,9 @@ const SwapTokenSelectPage = () => {
           </SizableText>
           <XStack>
             <SizableText size="$bodyMd">
-              {currentSelectNetwork?.name ??
-                currentSelectNetwork?.symbol ??
-                currentSelectNetwork?.shortcode ??
-                'Unknown'}
+              {currentSelectNetwork?.isAllNetworks
+                ? intl.formatMessage({ id: ETranslations.global_all_networks })
+                : currentSelectNetwork?.name}
             </SizableText>
           </XStack>
         </XStack>
@@ -460,7 +459,10 @@ const SwapTokenSelectPage = () => {
           selectedNetwork={currentSelectNetwork}
           onSelectNetwork={onSelectCurrentNetwork}
         />
-        <Divider mt="$2" />
+        {currentNetworkPopularTokens.length > 0 &&
+          !searchKeywordDebounce ? (
+            <Divider mt="$2" />
+          ) : null}
         <YStack flex={1}>
           <ListView
             ref={listViewRef}

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -58,6 +58,7 @@ export interface ISwapNetwork extends ISwapNetworkBase {
   symbol: string;
   shortcode?: string;
   logoURI?: string;
+  isAllNetworks?: boolean;
 }
 
 export interface ISwapTokenBase {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在网络选择界面中简化了网络名称的显示逻辑，支持显示“所有网络”的信息。
	- 新增属性 `isAllNetworks`，增强了网络数据的灵活性和表达能力。

- **用户界面改进**
	- 优化了分隔符的条件渲染，仅在特定条件下显示，提升用户体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->