### PR TITLE
Fix/swap all net tips & add createFrom for swap event

### DIFF
--- a/packages/kit/src/views/Swap/components/SwapNetworkToggleGroup.tsx
+++ b/packages/kit/src/views/Swap/components/SwapNetworkToggleGroup.tsx
@@ -1,8 +1,10 @@
 import { memo, useMemo } from 'react';
 
+import { useIntl } from 'react-intl';
 import { useWindowDimensions } from 'react-native';
 
 import { XStack } from '@onekeyhq/components';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { ISwapNetwork } from '@onekeyhq/shared/types/swap/types';
 
 import { NetworksFilterItem } from '../../../components/NetworksFilterItem';
@@ -24,6 +26,7 @@ const SwapNetworkToggleGroup = ({
   onMoreNetwork,
 }: ISwapNetworkToggleGroupProps) => {
   const { width } = useWindowDimensions();
+  const intl = useIntl();
   const isWiderScreen = width > 380;
   const filteredNetworks = useMemo(
     () => (isWiderScreen ? networks : networks.slice(0, 4)),
@@ -36,7 +39,9 @@ const SwapNetworkToggleGroup = ({
           key={network.networkId}
           networkImageUri={network.logoURI}
           tooltipContent={
-            network.name ?? network.symbol ?? network.shortcode ?? 'Unknown'
+            network.isAllNetworks
+              ? intl.formatMessage({ id: ETranslations.global_all_networks })
+              : network.name
           }
           isSelected={network?.networkId === selectedNetwork?.networkId}
           onPress={() => {

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -39,6 +39,7 @@ import {
 
 import { useSwapAddressInfo } from './useSwapAccount';
 import { useSwapTxHistoryActions } from './useSwapTxHistory';
+import { EPageType, usePageType } from '@onekeyhq/components';
 
 export function useSwapBuildTx() {
   const [fromToken] = useSwapSelectFromTokenAtom();
@@ -60,7 +61,7 @@ export function useSwapBuildTx() {
     accountId: swapFromAddressInfo.accountInfo?.account?.id ?? '',
     networkId: swapFromAddressInfo.networkId ?? '',
   });
-
+  const pageType = usePageType();
   const syncRecentTokenPairs = useCallback(
     async ({
       swapFromToken,
@@ -436,6 +437,7 @@ export function useSwapBuildTx() {
             feeType: selectQuote?.fee?.percentageFee?.toString() ?? '0',
             router: JSON.stringify(selectQuote?.routesData ?? ''),
             isFirstTime: isFirstTimeSwap,
+            createFrom: pageType === EPageType.modal ? 'modal' : 'swapPage',
           });
           setSettings((prev) => ({
             ...prev,

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 
 import BigNumber from 'bignumber.js';
 
+import { EPageType, usePageType } from '@onekeyhq/components';
 import type { IEncodedTx } from '@onekeyhq/core/src/types';
 import {
   useInAppNotificationAtom,
@@ -39,7 +40,6 @@ import {
 
 import { useSwapAddressInfo } from './useSwapAccount';
 import { useSwapTxHistoryActions } from './useSwapTxHistory';
-import { EPageType, usePageType } from '@onekeyhq/components';
 
 export function useSwapBuildTx() {
   const [fromToken] = useSwapSelectFromTokenAtom();
@@ -475,6 +475,7 @@ export function useSwapBuildTx() {
     isFirstTimeSwap,
     setSettings,
     setSwapShouldRefreshQuote,
+    pageType,
   ]);
 
   return { buildTx, wrappedTx, approveTx };

--- a/packages/shared/src/logger/scopes/swap/scenes/createOrder.ts
+++ b/packages/shared/src/logger/scopes/swap/scenes/createOrder.ts
@@ -14,6 +14,7 @@ export class CreateOrderScene extends BaseScene {
     isFirstTime,
     swapProvider,
     swapProviderName,
+    createFrom,
     router,
     slippage,
   }: {
@@ -28,6 +29,7 @@ export class CreateOrderScene extends BaseScene {
     receivedTokenSymbol: string;
     feeType: string;
     isFirstTime: boolean;
+    createFrom: string;
   }) {
     return {
       isFirstTime,
@@ -41,6 +43,7 @@ export class CreateOrderScene extends BaseScene {
       feeType,
       router,
       slippage,
+      createFrom,
     };
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 在网络切换组件中添加了本地化支持，增强了用户体验。
  - 引入了 `createFrom` 属性，以便在创建订单时捕获更多上下文信息。

- **改进**
  - 交易构建过程中加入页面类型的上下文，提升了交易处理的灵活性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->