### PR TITLE
correct the logic for displaying footer buttons on the notification i…

### DIFF
--- a/packages/kit/src/components/TabPageHeader/HeaderRight.tsx
+++ b/packages/kit/src/components/TabPageHeader/HeaderRight.tsx
@@ -37,6 +37,7 @@ export function HeaderRight({
   const navigation = useAppNavigation();
   const scanQrCode = useScanQrCode();
   const [{ firstTimeGuideOpened, badge }] = useNotificationsAtom();
+
   const {
     activeAccount: { account },
   } = useActiveAccount({ num: 0 });
@@ -187,7 +188,7 @@ export function HeaderRight({
                   />
                 ) : (
                   <SizableText color="$textOnColor" size="$bodySm">
-                    {badge}
+                    {badge && badge > 99 ? '99+' : badge}
                   </SizableText>
                 )}
               </Stack>

--- a/packages/kit/src/views/Notifications/pages/NotificationIntroduction.tsx
+++ b/packages/kit/src/views/Notifications/pages/NotificationIntroduction.tsx
@@ -33,7 +33,9 @@ function NotificationIntroduction() {
   }, []);
 
   const shouldShowCancelButton =
-    !canAutoCloseWhenGranted || platformEnv.isNativeAndroid;
+    !canAutoCloseWhenGranted ||
+    platformEnv.isNativeAndroid ||
+    platformEnv.isExtension;
 
   const checkShouldClose = useCallback(
     (permission: INotificationPermissionDetail) =>
@@ -78,19 +80,23 @@ function NotificationIntroduction() {
       </Page.Body>
 
       <Page.Footer
-        confirmButtonProps={{
-          loading: confirmLoading,
-        }}
-        onConfirmText={intl.formatMessage({ id: ETranslations.global_enable })}
-        onConfirm={async (close) => {
-          try {
-            setConfirmLoading(true);
-            await backgroundApiProxy.serviceNotification.enableNotificationPermissions();
-          } finally {
-            setConfirmLoading(false);
-            isEnablePermissionCalled.current = true;
-          }
-        }}
+        {...(!platformEnv.isExtension && {
+          confirmButtonProps: {
+            loading: confirmLoading,
+          },
+          onConfirmText: intl.formatMessage({
+            id: ETranslations.global_enable,
+          }),
+          onConfirm: async (close) => {
+            try {
+              setConfirmLoading(true);
+              await backgroundApiProxy.serviceNotification.enableNotificationPermissions();
+            } finally {
+              setConfirmLoading(false);
+              isEnablePermissionCalled.current = true;
+            }
+          },
+        })}
         {...(shouldShowCancelButton && {
           onCancelText: intl.formatMessage({ id: ETranslations.global_done }),
           onCancel: (close) => {

--- a/packages/kit/src/views/Notifications/pages/NotificationList.tsx
+++ b/packages/kit/src/views/Notifications/pages/NotificationList.tsx
@@ -84,7 +84,7 @@ function NotificationItem({
   const [readedMap] = useNotificationsReadedAtom();
   return (
     <ListItem
-      gap="$1"
+      gap="$0.5"
       flexDirection="column"
       alignItems="stretch"
       userSelect="none"
@@ -93,23 +93,18 @@ function NotificationItem({
       }}
       {...rest}
     >
-      <XStack alignItems="baseline" gap="$3">
+      <XStack alignItems="baseline" gap="$3" pr="$1.5">
         <SizableText flex={1} size="$headingSm" numberOfLines={1}>
           {title}
         </SizableText>
         <SizableText size="$bodySm" color="$textSubdued" flexShrink={0}>
           {formatDistanceToNow(new Date(createdAt))}
         </SizableText>
-      </XStack>
-      <XStack>
-        <XStack flex={1}>
-          <SizableText size="$bodyMd" flex={1} maxWidth="$96">
-            {content}
-          </SizableText>
-        </XStack>
         {!readed && !!badge && !readedMap?.[msgId] ? (
           <Stack
-            m="$1.5"
+            position="absolute"
+            top="$1.5"
+            right="$-2"
             borderRadius="$full"
             bg="$bgCriticalStrong"
             w="$2"
@@ -117,6 +112,9 @@ function NotificationItem({
           />
         ) : null}
       </XStack>
+      <SizableText size="$bodyMd" flex={1} maxWidth="$96">
+        {content}
+      </SizableText>
     </ListItem>
   );
 }
@@ -199,7 +197,7 @@ function NotificationList() {
                 key={index}
                 item={item}
                 {...(index !== 0 && {
-                  mt: '$1.5',
+                  mt: '$2.5',
                 })}
                 onPress={() => {
                   void notificationsUtils.navigateToNotificationDetail({

--- a/packages/kit/src/views/Setting/components/NotificationsHelpCenterInstruction.tsx
+++ b/packages/kit/src/views/Setting/components/NotificationsHelpCenterInstruction.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { useIntl } from 'react-intl';
 
 import { Anchor, SizableText } from '@onekeyhq/components';
+import { NOTIFICATIONS_HELP_CENTER_URL } from '@onekeyhq/shared/src/config/appConfig';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import type { FormatXMLElementFn } from 'intl-messageformat';
@@ -15,7 +16,7 @@ function NotificationsHelpCenterInstruction() {
         cursor="default"
         size="$bodyMd"
         color="$textInteractive"
-        href="https://onekey.so/"
+        href={NOTIFICATIONS_HELP_CENTER_URL}
         target="_blank"
         hoverStyle={{
           color: '$textInteractiveHover',

--- a/packages/shared/src/config/appConfig.ts
+++ b/packages/shared/src/config/appConfig.ts
@@ -28,6 +28,8 @@ export const HELP_CENTER_URL = 'https://help.onekey.so/hc';
 export const LITE_CARD_URL =
   'https://onekey.so/products/onekey-lite-hardware-wallet/';
 export const BRIDGE_STATUS_URL = 'http://127.0.0.1:21320/status/';
+export const NOTIFICATIONS_HELP_CENTER_URL =
+  'https://help.onekey.so/hc/articles/10780082728335-What-to-do-if-the-app-doesn-t-receive-notifications';
 export const DOWNLOAD_URL = 'https://onekey.so/download';
 export const DOWNLOAD_MOBILE_APP_URL =
   'https://onekey.so/download?client=mobile';


### PR DESCRIPTION
- Correct the logic for displaying footer buttons on the notification introduction modal.
- Enhance the distinction of notification items in the notification center.
- Add a help center link for troubleshooting notifications.
- Display “99+” if the notification count exceeds 99.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 更新了通知帮助中心的链接，使用共享配置常量来管理 URL。
  - 添加了新的常量 `NOTIFICATIONS_HELP_CENTER_URL`，提供指向通知问题帮助中心文章的链接。

- **界面改进**
  - 修改了 `HeaderRight` 组件的徽章显示逻辑，当徽章值超过 99 时显示为 '99+'。
  - 优化了通知列表中通知项的布局和间距，提升视觉呈现。
  - 增强了取消按钮的显示逻辑，根据平台环境动态调整。

- **文档**
  - 更新了通知帮助中心的链接，确保用户可以轻松访问相关支持信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->