### PR TITLE
fix: the tab issues on android

### DIFF
--- a/packages/components/src/layouts/TabView/StickyTabComponent/index.native.tsx
+++ b/packages/components/src/layouts/TabView/StickyTabComponent/index.native.tsx
@@ -26,7 +26,7 @@ export const TabComponent = (
     tabContentContainerStyle,
     style,
     onRefresh: onRefreshCallBack,
-    initialHeaderHeight = 220,
+    initialHeaderHeight = 0,
   }: ITabProps,
   // fix missing forwardRef warnings.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -177,17 +177,18 @@ export const TabComponent = (
       if (nativeEvent.layout.height === headerHeight) {
         return;
       }
+      if (platformEnv.isNativeAndroid && initialHeaderHeight > 0) {
+        return;
+      }
       setHeaderHeight(nativeEvent.layout.height);
     },
-    [headerHeight],
+    [headerHeight, initialHeaderHeight],
   );
   return (
     // @ts-expect-error
     <NestedTabView
       key={key}
-      headerHeight={
-        platformEnv.isNativeAndroid ? initialHeaderHeight : headerHeight
-      }
+      headerHeight={headerHeight}
       defaultIndex={initialScrollIndex}
       style={nestedTabViewStyle}
       stickyTabBar

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -140,6 +140,7 @@ export function HomePageView({
         data={tabs}
         ListHeaderComponent={<HomeHeaderContainer />}
         initialScrollIndex={0}
+        initialHeaderHeight={220}
         contentItemWidth={CONTENT_ITEM_WIDTH}
         contentWidth={screenWidth}
         showsVerticalScrollIndicator={false}

--- a/packages/kit/src/views/Market/MarketHome.tsx
+++ b/packages/kit/src/views/Market/MarketHome.tsx
@@ -153,7 +153,6 @@ function MarketHome() {
       return (
         <Tab
           disableRefresh
-          initialHeaderHeight={0}
           data={tabConfig}
           onSelectedPageIndex={handleSelectedPageIndex}
         />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在 `HomePageView` 组件中新增 `initialHeaderHeight` 属性，初始值为 `220`。
  
- **变更**
  - 在 `TabComponent` 中将 `initialHeaderHeight` 的默认值从 `220` 更改为 `0`。
  - 从 `MarketHome` 组件中移除 `initialHeaderHeight` 属性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->