### PR TITLE
fix: api error toast

### DIFF
--- a/packages/kit/src/provider/Container/ErrorToastContainer/ErrorToastContainer.tsx
+++ b/packages/kit/src/provider/Container/ErrorToastContainer/ErrorToastContainer.tsx
@@ -23,7 +23,7 @@ export function ErrorToastContainer() {
       let toastId = isFilterErrorCode(p.errorCode)
         ? String(p.errorCode)
         : undefined;
-      toastId = toastId || message;
+      toastId = toastId || (p.title ? p.title : message);
       const actions = isRequestIdMessage(message) ? (
         <Button
           size="small"

--- a/packages/shared/src/errors/errors/baseErrors.ts
+++ b/packages/shared/src/errors/errors/baseErrors.ts
@@ -59,6 +59,7 @@ export class OneKeyError<
     let requestId: string | undefined;
     let className: EOneKeyErrorClassNames | undefined;
     let name: string | undefined;
+    let disableFallbackMessage: boolean | undefined;
 
     if (!isString(errorProps) && errorProps && isObject(errorProps)) {
       ({
@@ -72,6 +73,7 @@ export class OneKeyError<
         payload: hardwareErrorPayload,
         className,
         name,
+        disableFallbackMessage,
       } = errorProps);
     } else {
       msg = isString(errorProps) ? errorProps : '';
@@ -83,7 +85,11 @@ export class OneKeyError<
       // * empty string not allowed in Web3RpcError, give a fakeMessage by default
       // * can not access this.key before constructor
       msg ||
-        `Unknown Onekey Internal Error. ${[key].filter(Boolean).join(':')}`,
+        (disableFallbackMessage
+          ? ''
+          : `Unknown Onekey Internal Error. ${[key]
+              .filter(Boolean)
+              .join(':')}`),
       data,
     );
 

--- a/packages/shared/src/errors/types/errorTypes.ts
+++ b/packages/shared/src/errors/types/errorTypes.ts
@@ -77,6 +77,7 @@ export interface IOneKeyError<
 
   // ---server props
   requestId?: string;
+  disableFallbackMessage?: boolean;
 }
 
 export type IOneKeyHardwareErrorPayload = {

--- a/packages/shared/src/errors/utils/errorToastUtils.ts
+++ b/packages/shared/src/errors/utils/errorToastUtils.ts
@@ -1,4 +1,3 @@
-import { HardwareErrorCode } from '@onekeyfe/hd-shared';
 import axios from 'axios';
 import { isPlainObject } from 'lodash';
 
@@ -34,10 +33,23 @@ function showToastOfError(error: IOneKeyError | unknown | undefined) {
   ) {
     return;
   }
+  let shouldMuteToast = false;
+  if (
+    err?.className === EOneKeyErrorClassNames.OneKeyServerApiError &&
+    !err?.message
+  ) {
+    shouldMuteToast = true;
+  }
   const isTriggered = err?.$$autoToastErrorTriggered;
   const isSameError = lastToastErrorInstance === err;
   // TODO log error to file if developer mode on
-  if (err && err?.autoToast && !isTriggered && !isSameError) {
+  if (
+    err &&
+    err?.autoToast &&
+    !isTriggered &&
+    !isSameError &&
+    !shouldMuteToast
+  ) {
     err.$$autoToastErrorTriggered = true;
     lastToastErrorInstance = err;
     appEventBus.emit(EAppEventBusNames.ShowToast, {

--- a/packages/shared/src/request/axiosInterceptor.ts
+++ b/packages/shared/src/request/axiosInterceptor.ts
@@ -73,6 +73,10 @@ axios.interceptors.response.use(
 
     const data = response.data as IOneKeyAPIBaseResponse;
 
+    // test code
+    // data.code = 4485;
+    // data.message = 'hhhh';
+
     if (data.code !== 0) {
       const requestIdKey = HEADER_REQUEST_ID_KEY;
       if (platformEnv.isDev) {
@@ -81,6 +85,7 @@ axios.interceptors.response.use(
 
       throw new OneKeyServerApiError({
         autoToast: true,
+        disableFallbackMessage: true,
         message: data.message,
         code: data.code,
         data,


### PR DESCRIPTION
(cherry picked from commit f209c553af792da38188d504b0acd117e0bce79f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 引入了 `disableFallbackMessage` 属性，以更灵活地处理错误消息。
	- 改进了 `ErrorToastContainer` 的逻辑，使得在未定义 `toastId` 时，优先使用 `p.title`。
	- 添加了控制变量 `shouldMuteToast`，以决定是否抑制错误通知。

- **修复**
	- 修改了错误处理逻辑，确保在特定条件下不显示错误通知。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->