### PR TITLE
fix: Android tabs issue on v5.2.1

### DIFF
--- a/packages/components/src/layouts/TabView/StickyTabComponent/index.native.tsx
+++ b/packages/components/src/layouts/TabView/StickyTabComponent/index.native.tsx
@@ -26,7 +26,7 @@ export const TabComponent = (
     tabContentContainerStyle,
     style,
     onRefresh: onRefreshCallBack,
-    initialHeaderHeight = 220,
+    initialHeaderHeight = 0,
   }: ITabProps,
   // fix missing forwardRef warnings.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -177,17 +177,18 @@ export const TabComponent = (
       if (nativeEvent.layout.height === headerHeight) {
         return;
       }
+      if (platformEnv.isNativeAndroid && initialHeaderHeight > 0) {
+        return;
+      }
       setHeaderHeight(nativeEvent.layout.height);
     },
-    [headerHeight],
+    [headerHeight, initialHeaderHeight],
   );
   return (
     // @ts-expect-error
     <NestedTabView
       key={key}
-      headerHeight={
-        platformEnv.isNativeAndroid ? initialHeaderHeight : headerHeight
-      }
+      headerHeight={headerHeight}
       defaultIndex={initialScrollIndex}
       style={nestedTabViewStyle}
       stickyTabBar

--- a/packages/components/src/layouts/TabView/StickyTabComponent/index.native.tsx
+++ b/packages/components/src/layouts/TabView/StickyTabComponent/index.native.tsx
@@ -26,7 +26,7 @@ export const TabComponent = (
     tabContentContainerStyle,
     style,
     onRefresh: onRefreshCallBack,
-    initialHeaderHeight = 250,
+    initialHeaderHeight = 220,
   }: ITabProps,
   // fix missing forwardRef warnings.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -172,14 +172,22 @@ export const TabComponent = (
   );
 
   const onIndexChange = useCallback(() => {}, []);
-  const onLayout = useCallback(({ nativeEvent }: LayoutChangeEvent) => {
-    setHeaderHeight(nativeEvent.layout.height);
-  }, []);
+  const onLayout = useCallback(
+    ({ nativeEvent }: LayoutChangeEvent) => {
+      if (nativeEvent.layout.height === headerHeight) {
+        return;
+      }
+      setHeaderHeight(nativeEvent.layout.height);
+    },
+    [headerHeight],
+  );
   return (
     // @ts-expect-error
     <NestedTabView
       key={key}
-      headerHeight={headerHeight}
+      headerHeight={
+        platformEnv.isNativeAndroid ? initialHeaderHeight : headerHeight
+      }
       defaultIndex={initialScrollIndex}
       style={nestedTabViewStyle}
       stickyTabBar

--- a/packages/kit/src/components/TokenListView/index.tsx
+++ b/packages/kit/src/components/TokenListView/index.tsx
@@ -137,8 +137,7 @@ function TokenListView(props: IProps) {
   if (
     (isTokenSelector && tokenSelectorSearchTokenState.isSearching) ||
     (!isTokenSelector && searchTokenState.isSearching) ||
-    (!tokenListState.initialized && tokenListState.isRefreshing) ||
-    (platformEnv.isNativeAndroid && isInRequest)
+    (!tokenListState.initialized && tokenListState.isRefreshing)
   ) {
     return (
       <NestedScrollView style={{ flex: 1 }}>

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -140,6 +140,7 @@ export function HomePageView({
         data={tabs}
         ListHeaderComponent={<HomeHeaderContainer />}
         initialScrollIndex={0}
+        initialHeaderHeight={220}
         contentItemWidth={CONTENT_ITEM_WIDTH}
         contentWidth={screenWidth}
         showsVerticalScrollIndicator={false}

--- a/packages/kit/src/views/Market/MarketHome.tsx
+++ b/packages/kit/src/views/Market/MarketHome.tsx
@@ -153,7 +153,6 @@ function MarketHome() {
       return (
         <Tab
           disableRefresh
-          initialHeaderHeight={0}
           data={tabConfig}
           onSelectedPageIndex={handleSelectedPageIndex}
         />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在 `HomePageView` 组件中新增 `initialHeaderHeight` 属性，初始值为 220。
- **改进**
	- 更新 `TabComponent` 的 `initialHeaderHeight` 默认值，从 250 改为 0。
	- 简化 `TokenListView` 中的条件逻辑，优化渲染行为。
	- 移除 `MarketHome` 中 `Tab` 组件的 `initialHeaderHeight` 属性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->