### PR TITLE
fix: scdo decoded address (OK-32676, OK-32580)

### DIFF
--- a/packages/kit-bg/src/vaults/impls/aptos/Vault.ts
+++ b/packages/kit-bg/src/vaults/impls/aptos/Vault.ts
@@ -513,9 +513,14 @@ export default class VaultAptos extends VaultBase {
 
     const account = await this.getAccount();
     const invalidSigBytes = new Uint8Array(64);
+    let pubkey = account.pub;
+    if (!pubkey) {
+      const accountOnChain = await this.client.getAccount(account.address);
+      pubkey = accountOnChain.authentication_key;
+    }
     const { rawTx: rawSignTx } = await buildSignedTx(
       newRawTx,
-      account.pub ?? '',
+      pubkey,
       bufferUtils.bytesToHex(invalidSigBytes),
     );
 

--- a/packages/kit-bg/src/vaults/impls/scdo/utils.ts
+++ b/packages/kit-bg/src/vaults/impls/scdo/utils.ts
@@ -93,7 +93,9 @@ export function decodeTransferPayload(payload: string):
       hexUtils.stripHexPrefix(address),
     );
     return {
-      address: (address as string).replace(/^0x/, `${addressBytes[0]}S`),
+      address: (address as string)
+        .toLowerCase()
+        .replace(/^0x/, `${addressBytes[0]}S`),
       amount: new BigNumber((amount as BigNumber).toString()).toFixed(),
     };
   } catch (error) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 引入了地址的大小写标准化，确保在处理过程中地址始终以小写格式返回。
	- 更新了公钥的获取逻辑，确保即使在账户对象中不可用时也能正确获取。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->