### PR TITLE
fix: swap token data mate use atom

### DIFF
--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -74,6 +74,7 @@ import {
   swapSlippagePercentageModeAtom,
   swapTokenFetchingAtom,
   swapTokenMapAtom,
+  swapTokenMetadataAtom,
 } from './atoms';
 
 class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
@@ -699,6 +700,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       const toToken = get(swapSelectToTokenAtom());
       const networks = get(swapNetworks());
       const quoteResult = get(swapQuoteCurrentSelectAtom());
+      const tokenMetadata = get(swapTokenMetadataAtom());
       const quoteResultList = get(swapQuoteListAtom());
       const quoteEventTotalCount = get(swapQuoteEventTotalCountAtom());
       const fromTokenAmount = get(swapFromTokenAmountAtom());
@@ -913,8 +915,8 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         ];
       }
 
-      if (quoteResult?.tokenMetadata) {
-        const { buyToken, sellToken } = quoteResult.tokenMetadata;
+      if (tokenMetadata?.swapTokenMetadata) {
+        const { buyToken, sellToken } = tokenMetadata.swapTokenMetadata;
         const buyTokenBuyTaxBN = new BigNumber(
           buyToken?.buyTaxBps ? buyToken?.buyTaxBps : 0,
         );

--- a/packages/kit/src/states/jotai/contexts/swap/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/atoms.ts
@@ -21,6 +21,7 @@ import type {
   ISwapSlippageSegmentItem,
   ISwapToken,
   ISwapTokenCatch,
+  ISwapTokenMetadata,
 } from '@onekeyhq/shared/types/swap/types';
 
 import { createJotaiContext } from '../../utils/createJotaiContext';
@@ -274,6 +275,19 @@ export const {
   }
   return undefined;
 });
+
+export const { atom: swapTokenMetadataAtom, use: useSwapTokenMetadataAtom } =
+  contextAtomComputed<{
+    swapTokenMetadata?: ISwapTokenMetadata;
+  }>((get) => {
+    const quoteList = get(swapQuoteListAtom());
+    const swapTokenMetadata = quoteList.find(
+      (item) => item.tokenMetadata,
+    )?.tokenMetadata;
+    return {
+      swapTokenMetadata,
+    };
+  });
 
 export const { atom: swapQuoteFetchingAtom, use: useSwapQuoteFetchingAtom } =
   contextAtom<boolean>(false);

--- a/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
@@ -20,6 +20,7 @@ import {
   useSwapSlippagePercentageAtom,
   useSwapSlippagePercentageCustomValueAtom,
   useSwapSlippagePercentageModeAtom,
+  useSwapTokenMetadataAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -55,6 +56,7 @@ const SwapQuoteResult = ({
   const [toToken] = useSwapSelectToTokenAtom();
   const [fromTokenAmount] = useSwapFromTokenAmountAtom();
   const [settingsPersistAtom] = useSettingsPersistAtom();
+  const [swapTokenMetadata] = useSwapTokenMetadataAtom();
   const swapQuoteLoading = useSwapQuoteLoading();
   const intl = useIntl();
   const [, setSwapSlippageDialogOpening] = useSwapSlippageDialogOpeningAtom();
@@ -269,9 +271,9 @@ const SwapQuoteResult = ({
                   }
                 />
               ) : null}
-              {quoteResult?.tokenMetadata
+              {swapTokenMetadata?.swapTokenMetadata
                 ? tokenMetadataParse(
-                    quoteResult?.tokenMetadata,
+                    swapTokenMetadata?.swapTokenMetadata,
                     fromToken,
                     toToken,
                   )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 引入了新的状态原子 `swapTokenMetadataAtom` 和钩子 `useSwapTokenMetadataAtom`，用于管理交换代币的元数据。
  - 在 `SwapQuoteResult` 组件中更新了代币元数据的访问方式，改为使用新的状态原子。

- **改进**
  - 优化了代币交易相关的数据流，提升了状态管理能力。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->