### PR TITLE
fix earn issue OK-32700 OK-32690

### DIFF
--- a/packages/kit/src/views/Staking/components/ApproveBaseStake/index.tsx
+++ b/packages/kit/src/views/Staking/components/ApproveBaseStake/index.tsx
@@ -17,11 +17,17 @@ import { AmountInput } from '@onekeyhq/kit/src/components/AmountInput';
 import { useSendConfirm } from '@onekeyhq/kit/src/hooks/useSendConfirm';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import type { IEarnEstimateFeeResp } from '@onekeyhq/shared/types/staking';
 import type { IToken } from '@onekeyhq/shared/types/token';
 
 import { useTrackTokenAllowance } from '../../hooks/useUtilsHooks';
 import { capitalizeString, countDecimalPlaces } from '../../utils/utils';
 import { CalculationList, CalculationListItem } from '../CalculationList';
+import {
+  EstimateNetworkFee,
+  calcDaysSpent,
+  useShowStakeEstimateGasAlert,
+} from '../EstimateNetworkFee';
 import StakingFormWrapper from '../StakingFormWrapper';
 import { ValuePriceListItem } from '../ValuePriceListItem';
 
@@ -47,6 +53,8 @@ type IApproveBaseStakeProps = {
   estReceiveToken?: string;
   estReceiveTokenRate?: string;
 
+  estimateFeeResp?: IEarnEstimateFeeResp;
+
   providerName?: string;
   providerLogo?: string;
   onConfirm?: (amount: string) => Promise<void>;
@@ -66,12 +74,13 @@ export const ApproveBaseStake = ({
   approveTarget,
 
   providerLabel,
-
+  estimateFeeResp,
   showEstReceive,
   estReceiveToken,
   estReceiveTokenRate = '1',
 }: PropsWithChildren<IApproveBaseStakeProps>) => {
   const intl = useIntl();
+  const showEstimateGasAlert = useShowStakeEstimateGasAlert();
   const { navigationToSendConfirm } = useSendConfirm({
     accountId: approveTarget.accountId,
     networkId: approveTarget.networkId,
@@ -191,37 +200,65 @@ export const ApproveBaseStake = ({
     });
   }, [amountValue, approveTarget, navigationToSendConfirm, trackAllowance]);
 
-  const onSubmit = useCallback(async () => {
-    setLoading(true);
-    try {
-      await onConfirm?.(amountValue);
-    } finally {
-      setLoading(false);
-    }
-  }, [onConfirm, amountValue]);
-
   const onMax = useCallback(() => {
     onChangeAmountValue(balance);
   }, [onChangeAmountValue, balance]);
 
-  const estAnnualRewards = useMemo(() => {
-    if (Number(amountValue) > 0 && apr && Number(apr) > 0) {
-      const amountBN = BigNumber(amountValue).multipliedBy(apr).dividedBy(100);
-      return (
-        <ValuePriceListItem
-          tokenSymbol={token.symbol}
-          amount={amountBN.toFixed()}
-          fiatSymbol={symbol}
-          fiatValue={
-            Number(price) > 0
-              ? amountBN.multipliedBy(price).toFixed()
-              : undefined
-          }
-        />
+  const estAnnualRewardsState = useMemo(() => {
+    if (Number(amountValue) > 0 && Number(apr) > 0) {
+      const amountBN = BigNumber(amountValue)
+        .multipliedBy(apr ?? 0)
+        .dividedBy(100);
+      return {
+        amount: amountBN.toFixed(),
+        fiatValue:
+          Number(price) > 0
+            ? amountBN.multipliedBy(price).toFixed()
+            : undefined,
+      };
+    }
+  }, [amountValue, apr, price]);
+
+  const daysSpent = useMemo(() => {
+    if (estAnnualRewardsState?.fiatValue && estimateFeeResp?.feeFiatValue) {
+      return calcDaysSpent(
+        estAnnualRewardsState?.fiatValue,
+        estimateFeeResp.feeFiatValue,
       );
     }
-    return null;
-  }, [amountValue, apr, price, symbol, token.symbol]);
+  }, [estimateFeeResp?.feeFiatValue, estAnnualRewardsState?.fiatValue]);
+
+  const onSubmit = useCallback(async () => {
+    const submitFn = async () => {
+      setLoading(true);
+      try {
+        await onConfirm?.(amountValue);
+      } finally {
+        setLoading(false);
+      }
+    };
+    if (estAnnualRewardsState?.fiatValue && estimateFeeResp) {
+      const daySpent = calcDaysSpent(
+        estAnnualRewardsState.fiatValue,
+        estimateFeeResp.feeFiatValue,
+      );
+      if (daySpent && daySpent > 5) {
+        showEstimateGasAlert({
+          daysConsumed: daySpent,
+          estFiatValue: estimateFeeResp.feeFiatValue,
+          onConfirm: submitFn,
+        });
+        return;
+      }
+    }
+    await submitFn();
+  }, [
+    onConfirm,
+    amountValue,
+    estAnnualRewardsState,
+    estimateFeeResp,
+    showEstimateGasAlert,
+  ]);
 
   return (
     <StakingFormWrapper>
@@ -266,7 +303,7 @@ export const ApproveBaseStake = ({
         />
       ) : null}
       <CalculationList>
-        {estAnnualRewards ? (
+        {estAnnualRewardsState ? (
           <CalculationListItem>
             <CalculationListItem.Label>
               {intl.formatMessage({
@@ -274,7 +311,12 @@ export const ApproveBaseStake = ({
               })}
             </CalculationListItem.Label>
             <CalculationListItem.Value>
-              {estAnnualRewards}
+              <ValuePriceListItem
+                tokenSymbol={token.symbol}
+                fiatSymbol={symbol}
+                amount={estAnnualRewardsState.amount}
+                fiatValue={estAnnualRewardsState.fiatValue}
+              />
             </CalculationListItem.Value>
           </CalculationListItem>
         ) : null}
@@ -326,6 +368,18 @@ export const ApproveBaseStake = ({
               </XStack>
             </CalculationListItem.Value>
           </CalculationListItem>
+        ) : null}
+        {estimateFeeResp ? (
+          <EstimateNetworkFee
+            estimateFeeResp={estimateFeeResp}
+            isVisible={!!estAnnualRewardsState?.fiatValue}
+            onPress={() => {
+              showEstimateGasAlert({
+                daysConsumed: daysSpent,
+                estFiatValue: estimateFeeResp.feeFiatValue,
+              });
+            }}
+          />
         ) : null}
       </CalculationList>
       <Page.Footer

--- a/packages/kit/src/views/Staking/components/ProtocolDetails/PortfolioSection.tsx
+++ b/packages/kit/src/views/Staking/components/ProtocolDetails/PortfolioSection.tsx
@@ -16,6 +16,7 @@ import {
 } from '@onekeyhq/components';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { EEarnProviderEnum } from '@onekeyhq/shared/types/earn';
 import type { IStakeProtocolDetails } from '@onekeyhq/shared/types/staking';
 import type { IToken } from '@onekeyhq/shared/types/token';
 
@@ -113,6 +114,9 @@ type IPortfolioInfoProps = {
   pendingActiveTooltip?: string;
   claimable?: string;
   rewards?: string;
+
+  labelForClaimable?: string;
+
   minClaimableNum?: string;
   babylonOverflow?: string;
 
@@ -130,6 +134,9 @@ function PortfolioInfo({
   pendingActiveTooltip,
   claimable,
   rewards,
+
+  labelForClaimable,
+
   minClaimableNum,
 
   babylonOverflow,
@@ -212,9 +219,12 @@ function PortfolioInfo({
               tokenImageUri={token.logoURI}
               tokenSymbol={token.symbol}
               amount={claimable}
-              statusText={intl.formatMessage({
-                id: ETranslations.earn_claimable,
-              })}
+              statusText={
+                labelForClaimable ??
+                intl.formatMessage({
+                  id: ETranslations.earn_claimable,
+                })
+              }
               useLoading
               onPress={onClaim}
               buttonText={intl.formatMessage({
@@ -295,9 +305,11 @@ export const PortfolioSection = ({
   }
 
   let pendingActiveTooltip: string | undefined;
+  let labelForClaimable: string | undefined;
   if (
-    details.provider.name.toLowerCase() === 'everstake' &&
-    details.token.info.name.toLowerCase() === 'eth'
+    details.provider.name.toLowerCase() ===
+      EEarnProviderEnum.Everstake.toLowerCase() &&
+    details.token.info.symbol.toLowerCase() === 'eth'
   ) {
     pendingActiveTooltip = intl.formatMessage({
       id: ETranslations.earn_pending_activation_tooltip_eth,
@@ -309,6 +321,15 @@ export const PortfolioSection = ({
       },
       { number: details.pendingActivatePeriod },
     );
+  }
+  if (
+    details.provider.name.toLowerCase() ===
+      EEarnProviderEnum.Everstake.toLowerCase() &&
+    details.token.info.symbol.toLowerCase() === 'matic'
+  ) {
+    labelForClaimable = intl.formatMessage({
+      id: ETranslations.earn_withdrawn,
+    });
   }
 
   const portfolio: IPortfolioInfoProps = {
@@ -327,6 +348,7 @@ export const PortfolioSection = ({
         ? details.overflow
         : undefined,
     token: details.token.info,
+    labelForClaimable,
   };
 
   return (

--- a/packages/kit/src/views/Staking/components/ProtocolDetails/ProfitSection.tsx
+++ b/packages/kit/src/views/Staking/components/ProtocolDetails/ProfitSection.tsx
@@ -18,6 +18,7 @@ type IProfitInfoProps = {
   earningsIn24h?: string;
   rewardTokens?: string;
   updateFrequency?: string;
+  unstakingPeriod?: number;
   earnPoints?: boolean;
 };
 
@@ -26,6 +27,7 @@ function ProfitInfo({
   earningsIn24h,
   rewardTokens,
   updateFrequency,
+  unstakingPeriod,
   earnPoints,
 }: IProfitInfoProps) {
   const intl = useIntl();
@@ -99,6 +101,18 @@ function ProfitInfo({
               {updateFrequency}
             </GridItem>
           ) : null}
+          {unstakingPeriod ? (
+            <GridItem
+              title={intl.formatMessage({
+                id: ETranslations.earn_unstaking_period,
+              })}
+            >
+              {intl.formatMessage(
+                { id: ETranslations.earn_up_to_number_days },
+                { number: unstakingPeriod },
+              )}
+            </GridItem>
+          ) : null}
         </XStack>
       )}
     </YStack>
@@ -117,8 +131,9 @@ export const ProfitSection = ({
     apr: Number(details.provider?.apr) > 0 ? details.provider.apr : undefined,
     earningsIn24h: details.earnings24h,
     rewardTokens: details.rewardToken,
-    updateFrequency: details.updateFrequency,
+    // updateFrequency: details.updateFrequency,
     earnPoints: details.provider.earnPoints,
+    unstakingPeriod: details.unstakingPeriod,
   };
   return <ProfitInfo {...props} />;
 };

--- a/packages/kit/src/views/Staking/pages/ApproveBaseStake/index.tsx
+++ b/packages/kit/src/views/Staking/pages/ApproveBaseStake/index.tsx
@@ -3,8 +3,10 @@ import { useCallback, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 
 import { Page } from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useAppRoute } from '@onekeyhq/kit/src/hooks/useAppRoute';
+import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import type {
@@ -38,6 +40,7 @@ const ApproveBaseStakePage = () => {
         stakingInfo: {
           label: EEarnLabels.Unknown,
           protocol: provider.name,
+          protocolLogoURI: provider.logoURI,
           send: { token: token.info, amount },
           tags: [actionTag],
         },
@@ -62,6 +65,17 @@ const ApproveBaseStakePage = () => {
   );
 
   const providerLabel = useProviderLabel(provider.name);
+
+  const { result: estimateFeeResp } = usePromiseResult(async () => {
+    const resp = await backgroundApiProxy.serviceStaking.estimateFee({
+      networkId,
+      provider: provider.name,
+      symbol: token.info.symbol,
+      action: 'stake',
+      amount: '1',
+    });
+    return resp;
+  }, [networkId, provider.name, token.info.symbol]);
 
   return (
     <Page>
@@ -93,6 +107,7 @@ const ApproveBaseStakePage = () => {
             spenderAddress: details.approveTarget ?? '',
             token: token.info,
           }}
+          estimateFeeResp={estimateFeeResp}
         />
       </Page.Body>
     </Page>

--- a/packages/kit/src/views/Staking/pages/ClaimOptions/index.tsx
+++ b/packages/kit/src/views/Staking/pages/ClaimOptions/index.tsx
@@ -60,7 +60,7 @@ const ClaimOptions = () => {
           label: EEarnLabels.Claim,
           protocol: provider,
           protocolLogoURI: details.provider.logoURI,
-          send: { token: details.token.info, amount: item.amount },
+          receive: { token: details.token.info, amount: item.amount },
           tags: [buildLocalTxStatusSyncId(details)],
         },
         onSuccess: () => {

--- a/packages/kit/src/views/Staking/pages/ProtocolDetails/index.tsx
+++ b/packages/kit/src/views/Staking/pages/ProtocolDetails/index.tsx
@@ -129,7 +129,7 @@ const ProtocolDetailsPage = () => {
           label: EEarnLabels.Claim,
           protocol: result.provider.name,
           protocolLogoURI: result.provider.logoURI,
-          send: { token: result.token.info, amount: amount ?? '0' },
+          receive: { token: result.token.info, amount: amount ?? '0' },
           tags: [buildLocalTxStatusSyncId(result)],
         },
       });

--- a/packages/kit/src/views/Staking/pages/Withdraw/index.tsx
+++ b/packages/kit/src/views/Staking/pages/Withdraw/index.tsx
@@ -100,6 +100,13 @@ const WithdrawPage = () => {
     return resp;
   }, [networkId, provider.name, tokenInfo.symbol]);
 
+  const unstakingPeriod = useMemo(() => {
+    if (details.provider.unstakingTime) {
+      return Math.ceil(details.provider.unstakingTime / (24 * 60 * 60));
+    }
+    return details.unstakingPeriod; // day
+  }, [details]);
+
   return (
     <Page>
       <Page.Header
@@ -127,7 +134,7 @@ const WithdrawPage = () => {
               ? String(provider.minUnstakeAmount)
               : undefined
           }
-          unstakingPeriod={details.unstakingPeriod}
+          unstakingPeriod={unstakingPeriod}
           providerLabel={providerLabel}
           showPayWith={showPayWith}
           payWithToken={details.rewardToken}

--- a/packages/shared/types/staking.ts
+++ b/packages/shared/types/staking.ts
@@ -45,6 +45,8 @@ export type IStakeProviderInfo = {
   type?: 'native' | 'liquid';
   isStaking?: boolean;
 
+  unstakingTime?: number;
+
   // native token only
   minTransactionFee?: string;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在 `ApproveBaseStake` 组件中增加了年收益估算和网络费用处理逻辑，用户在确认质押金额前会收到超过五天的警报提示。
	- `PortfolioInfo` 组件支持自定义可领取金额标签，增强了灵活性。
	- `ProfitInfo` 组件新增了可选的解质押周期属性，提供解质押时间信息。
	- `ClaimOptions` 和 `ProtocolDetailsPage` 组件的交易对象结构进行了调整，从发送转为接收。

- **改进**
	- 在 `WithdrawPage` 组件中引入了更灵活的解质押周期计算逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->