### PR TITLE
fix: history list item textAlign right ok-32781

### DIFF
--- a/packages/kit/src/views/Swap/components/SwapTxHistoryListCell.tsx
+++ b/packages/kit/src/views/Swap/components/SwapTxHistoryListCell.tsx
@@ -125,7 +125,7 @@ const SwapTxHistoryListCell = ({
         align="right"
         flexShrink={0}
         primary={
-          <SizableText color="$textSuccess">
+          <SizableText color="$textSuccess" textAlign="right">
             +
             <NumberSizeableText color="$textSuccess" formatter="balance">
               {item.baseInfo.toAmount}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 调整了交易历史列表中接收金额的文本对齐方式，确保其右对齐。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->