### PR TITLE
fix: fix: fix the crash when loading binding.node fails.

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -39,7 +39,7 @@
     "electron-log": "5.2.0",
     "electron-store": "^8.2.0",
     "electron-updater": "6.1.8",
-    "electron-windows-security": "git+https://github.com/OneKeyHQ/electron-windows-security.git#17818b10b84e889ebfe6aff684fd9ccc3f01b767",
+    "electron-windows-security": "0.0.3",
     "keytar": "^7.9.0",
     "node-fetch": "^2.6.7"
   },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -39,7 +39,7 @@
     "electron-log": "5.2.0",
     "electron-store": "^8.2.0",
     "electron-updater": "6.1.8",
-    "electron-windows-security": "0.0.2",
+    "electron-windows-security": "git+https://github.com/OneKeyHQ/electron-windows-security.git#17818b10b84e889ebfe6aff684fd9ccc3f01b767",
     "keytar": "^7.9.0",
     "node-fetch": "^2.6.7"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6706,7 +6706,7 @@ __metadata:
     electron-log: "npm:5.2.0"
     electron-store: "npm:^8.2.0"
     electron-updater: "npm:6.1.8"
-    electron-windows-security: "npm:0.0.2"
+    electron-windows-security: "git+https://github.com/OneKeyHQ/electron-windows-security.git#17818b10b84e889ebfe6aff684fd9ccc3f01b767"
     esbuild: "npm:0.15.18"
     folderslint: "npm:^1.2.0"
     glob: "npm:^7.2.0"
@@ -19704,12 +19704,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-windows-security@npm:0.0.2":
+"electron-windows-security@git+https://github.com/OneKeyHQ/electron-windows-security.git#17818b10b84e889ebfe6aff684fd9ccc3f01b767":
   version: 0.0.2
-  resolution: "electron-windows-security@npm:0.0.2"
+  resolution: "electron-windows-security@https://github.com/OneKeyHQ/electron-windows-security.git#commit=17818b10b84e889ebfe6aff684fd9ccc3f01b767"
   dependencies:
     nan: "npm:2.20.0"
-  checksum: 10/bfd18d054932f3ba79b007a19c3d68e80715d01b354f15e9faff1ab54960d084f00198b344bfcc9c1cffdc06cb3d6b2eab513483f1376c22b51f0f40a47937f5
+  checksum: 10/227db7bde7971da1e05e623d6360917ab468f9b16f58a6b04fed6b462fe12eca1823dbebac7116e2e6e95afe1934c2f253da71de98fe6718a445b6a3ba186bb6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6706,7 +6706,7 @@ __metadata:
     electron-log: "npm:5.2.0"
     electron-store: "npm:^8.2.0"
     electron-updater: "npm:6.1.8"
-    electron-windows-security: "git+https://github.com/OneKeyHQ/electron-windows-security.git#17818b10b84e889ebfe6aff684fd9ccc3f01b767"
+    electron-windows-security: "npm:0.0.3"
     esbuild: "npm:0.15.18"
     folderslint: "npm:^1.2.0"
     glob: "npm:^7.2.0"
@@ -19704,12 +19704,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-windows-security@git+https://github.com/OneKeyHQ/electron-windows-security.git#17818b10b84e889ebfe6aff684fd9ccc3f01b767":
-  version: 0.0.2
-  resolution: "electron-windows-security@https://github.com/OneKeyHQ/electron-windows-security.git#commit=17818b10b84e889ebfe6aff684fd9ccc3f01b767"
+"electron-windows-security@npm:0.0.3":
+  version: 0.0.3
+  resolution: "electron-windows-security@npm:0.0.3"
   dependencies:
     nan: "npm:2.20.0"
-  checksum: 10/227db7bde7971da1e05e623d6360917ab468f9b16f58a6b04fed6b462fe12eca1823dbebac7116e2e6e95afe1934c2f253da71de98fe6718a445b6a3ba186bb6
+  checksum: 10/d45348a8019f3f341f9a0dd34ef9a1cbaaa69744b931dff94288cae0626c8f57e93b7b3244105f00d8875324caa792277ce33c1dc3da3f020ab0d764cb44a2c8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **更新内容**
	- 更新了 `electron-windows-security` 依赖的版本，从 `0.0.2` 升级到 `0.0.3`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->