### PR TITLE
OK-32890, OK-32855, OK-32860: Refresh custom network data

### DIFF
--- a/packages/kit-bg/src/vaults/impls/evm/sdkEvm/BaseApiProvider.ts
+++ b/packages/kit-bg/src/vaults/impls/evm/sdkEvm/BaseApiProvider.ts
@@ -292,7 +292,7 @@ class BaseApiProvider {
         price24h: 0,
         balance: accountToken.balance,
         balanceParsed: accountToken.balanceParsed,
-        fiatValue: '',
+        fiatValue: '0',
       };
 
       data.push({
@@ -315,7 +315,9 @@ class BaseApiProvider {
         ['asc', 'desc', 'desc'],
       ),
       keys: md5(
-        `${networkId}__${isEmpty(map) ? '' : Object.keys(map).join(',')}`,
+        `${networkId}__${
+          isEmpty(map) ? '' : Object.keys(map).join(',')
+        }__${JSON.stringify(data)}`,
       ),
       fiatValue: undefined,
     };

--- a/packages/kit/src/components/AccountSelector/AccountSelectorEffects.tsx
+++ b/packages/kit/src/components/AccountSelector/AccountSelectorEffects.tsx
@@ -199,10 +199,18 @@ function AccountSelectorEffectsCmp({ num }: { num: number }) {
     // const fn = () => null;
     appEventBus.on(EAppEventBusNames.AccountUpdate, reloadActiveAccountInfo);
     appEventBus.on(EAppEventBusNames.WalletUpdate, reloadActiveAccountInfo);
+    appEventBus.on(
+      EAppEventBusNames.AddedCustomNetwork,
+      reloadActiveAccountInfo,
+    );
     appEventBus.on(EAppEventBusNames.DAppNetworkUpdate, updateNetwork);
     return () => {
       appEventBus.off(EAppEventBusNames.AccountUpdate, reloadActiveAccountInfo);
       appEventBus.off(EAppEventBusNames.WalletUpdate, reloadActiveAccountInfo);
+      appEventBus.off(
+        EAppEventBusNames.AddedCustomNetwork,
+        reloadActiveAccountInfo,
+      );
       appEventBus.off(EAppEventBusNames.DAppNetworkUpdate, updateNetwork);
     };
   }, [reloadActiveAccountInfo, actions]);

--- a/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
+++ b/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
@@ -21,7 +21,6 @@ import {
   YStack,
   useClipboard,
 } from '@onekeyhq/components';
-import { Token } from '@onekeyhq/kit/src/components/Token';
 import {
   EHardwareUiStateAction,
   useHardwareUiStateAtom,
@@ -42,7 +41,6 @@ import { EConfirmOnDeviceType } from '@onekeyhq/shared/types/device';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import { useAccountData } from '../../../hooks/useAccountData';
-import { usePromiseResult } from '../../../hooks/usePromiseResult';
 import { EAddressState } from '../types';
 
 import type { RouteProp } from '@react-navigation/core';
@@ -317,8 +315,12 @@ function ReceiveToken() {
             <QRCode
               value={account.address}
               size={240}
-              logo={{ uri: token?.logoURI || network.logoURI }}
-              logoSize={40}
+              logo={
+                network.isCustomNetwork
+                  ? undefined
+                  : { uri: token?.logoURI || network.logoURI }
+              }
+              logoSize={network.isCustomNetwork ? undefined : 40}
             />
           </Stack>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 添加了对自定义网络的支持，增强了账户信息的刷新功能。
  
- **改进**
  - 更新了接收令牌组件的二维码和logo渲染逻辑，以适应自定义网络。
  
- **文档**
  - 增加了代码注释，以阐明处理令牌值和标准化交易标签的目的。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->