### PR TITLE
fix: fix flex-shink of title of TxActionCommon.

### DIFF
--- a/packages/kit/src/components/TxAction/TxActionCommon.tsx
+++ b/packages/kit/src/components/TxAction/TxActionCommon.tsx
@@ -109,6 +109,7 @@ function TxActionCommonTitle({
     <XStack alignItems="center">
       <SizableText
         numberOfLines={1}
+        flexShrink={1}
         size="$bodyLgMedium"
         {...(tableLayout && {
           size: '$bodyMdMedium',


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a9e0328a-8723-472f-a43e-2adb63867e63)

![image](https://github.com/user-attachments/assets/5fb59e54-6c32-4dc2-bde6-4125e19fecf4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了 `TxActionCommon` 组件，增强了标题文本在灵活容器中的适应性。
	- 改进了 `TxActionCommonListView` 的布局响应能力，优化了描述和变化信息的渲染逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->