### PR TITLE
fix: scrollToIndex out of range on ChainSelector Page

### DIFF
--- a/packages/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorSectionList.tsx
+++ b/packages/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorSectionList.tsx
@@ -291,6 +291,7 @@ export const ChainSelectorSectionList: FC<IChainSelectorSectionListProps> = ({
           onChangeText={onChangeText}
         />
       </Stack>
+      {/* Re-render the entire list after each text update */}
       {isPending ? null : renderSections}
     </Stack>
   );

--- a/packages/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorSectionList.tsx
+++ b/packages/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorSectionList.tsx
@@ -267,7 +267,7 @@ export const ChainSelectorSectionList: FC<IChainSelectorSectionListProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sections, networkId, text]);
 
-  const renderSections = useMemo(
+  const renderSections = useCallback(
     () =>
       sections.length ? (
         <ChainSelectorSectionListContent
@@ -292,7 +292,7 @@ export const ChainSelectorSectionList: FC<IChainSelectorSectionListProps> = ({
         />
       </Stack>
       {/* Re-render the entire list after each text update */}
-      {isPending ? null : renderSections}
+      {isPending ? null : renderSections()}
     </Stack>
   );
 };

--- a/packages/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorSectionList.tsx
+++ b/packages/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorSectionList.tsx
@@ -1,4 +1,4 @@
-import { type FC, useCallback, useMemo, useState } from 'react';
+import { type FC, useCallback, useMemo, useRef, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -65,7 +65,6 @@ const ChainSelectorSectionListContent = ({
 
   return (
     <SectionList
-      ListEmptyComponent={ListEmptyComponent}
       ListFooterComponent={<Stack h={bottom || '$2'} />}
       estimatedItemSize={48}
       sections={sections}
@@ -117,6 +116,27 @@ type IChainSelectorSectionListProps = {
   unavailable?: IServerNetworkMatch[];
 };
 
+const usePending = () => {
+  const [isPending, setIsPending] = useState(false);
+  const timerIdRef = useRef<ReturnType<typeof setTimeout>>();
+  const clearPendingTimer = useCallback(() => {
+    clearTimeout(timerIdRef.current);
+    timerIdRef.current = setTimeout(() => {
+      setIsPending(false);
+    }, 50);
+  }, []);
+  const changeIsPending = useCallback(
+    (pending: boolean) => {
+      setIsPending(pending);
+      if (pending) {
+        clearPendingTimer();
+      }
+    },
+    [clearPendingTimer],
+  );
+  return [isPending, changeIsPending] as ReturnType<typeof useState>;
+};
+
 export const ChainSelectorSectionList: FC<IChainSelectorSectionListProps> = ({
   networks,
   networkId,
@@ -125,9 +145,15 @@ export const ChainSelectorSectionList: FC<IChainSelectorSectionListProps> = ({
 }) => {
   const [text, setText] = useState('');
   const intl = useIntl();
-  const onChangeText = useCallback((value: string) => {
-    setText(value.trim());
-  }, []);
+  const [isPending, setIsPending] = usePending();
+
+  const onChangeText = useCallback(
+    (value: string) => {
+      setText(value.trim());
+      setIsPending(true);
+    },
+    [setIsPending],
+  );
 
   const networkFuseSearch = useFuseSearch(networks);
 
@@ -240,6 +266,21 @@ export const ChainSelectorSectionList: FC<IChainSelectorSectionListProps> = ({
     return initialScrollIndexNumber;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sections, networkId, text]);
+
+  const renderSections = useMemo(
+    () =>
+      sections.length ? (
+        <ChainSelectorSectionListContent
+          sections={sections}
+          networkId={networkId}
+          onPressItem={onPressItem}
+          initialScrollIndex={initialScrollIndex}
+        />
+      ) : (
+        <ListEmptyComponent />
+      ),
+    [initialScrollIndex, networkId, onPressItem, sections],
+  );
   return (
     <Stack flex={1}>
       <Stack px="$5" pb="$4">
@@ -250,12 +291,7 @@ export const ChainSelectorSectionList: FC<IChainSelectorSectionListProps> = ({
           onChangeText={onChangeText}
         />
       </Stack>
-      <ChainSelectorSectionListContent
-        sections={sections}
-        networkId={networkId}
-        onPressItem={onPressItem}
-        initialScrollIndex={initialScrollIndex}
-      />
+      {isPending ? null : renderSections}
     </Stack>
   );
 };

--- a/packages/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorSectionList.tsx
+++ b/packages/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorSectionList.tsx
@@ -1,4 +1,11 @@
-import { type FC, useCallback, useMemo, useRef, useState } from 'react';
+import {
+  type FC,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -133,6 +140,12 @@ const usePending = () => {
       }
     },
     [clearPendingTimer],
+  );
+  useEffect(
+    () => () => {
+      clearTimeout(timerIdRef.current);
+    },
+    [],
   );
   return [isPending, changeIsPending] as ReturnType<typeof useState>;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 引入了自定义钩子 `usePending`，用于管理用户交互中的待处理状态。
  - 在文本输入变化时，更新待处理状态以指示搜索操作正在进行。

- **用户体验改进**
  - 根据待处理状态条件渲染内容，防止在快速输入时不必要的重新渲染。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->