### PR TITLE
Fix/recipient modal badge

### DIFF
--- a/packages/kit/src/views/Swap/components/SwapCommonInfoItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapCommonInfoItem.tsx
@@ -99,7 +99,7 @@ const SwapCommonInfoItem = ({
         {isLoading ? (
           <Stack py="$1">
             <Skeleton h="$3" w="$24" />
-          </Stack>  
+          </Stack>
         ) : (
           rightTrigger
         )}

--- a/packages/kit/src/views/Swap/components/SwapCommonInfoItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapCommonInfoItem.tsx
@@ -99,7 +99,7 @@ const SwapCommonInfoItem = ({
         {isLoading ? (
           <Stack py="$1">
             <Skeleton h="$3" w="$24" />
-          </Stack>
+          </Stack>  
         ) : (
           rightTrigger
         )}

--- a/packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx
@@ -42,10 +42,14 @@ const SwapSettingsCommonItem = ({
   onChange: (v: boolean) => void;
 }) => (
   <XStack justifyContent="space-between" alignItems="center">
-    <YStack flex={1} gap='$0.5'>
+    <YStack flex={1} gap="$0.5">
       <XStack alignItems="center" gap="$1.5">
         <SizableText size="$bodyLgMedium">{title}</SizableText>
-        {badgeContent ? <Badge badgeSize="sm" badgeType='success'>{badgeContent}</Badge> : null}
+        {badgeContent ? (
+          <Badge badgeSize="sm" badgeType="success">
+            {badgeContent}
+          </Badge>
+        ) : null}
       </XStack>
       <SizableText size="$bodyMd" color="$textSubdued" width="95%">
         {content}

--- a/packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx
@@ -33,15 +33,20 @@ const SwapSettingsCommonItem = ({
   onChange,
   title,
   content,
+  badgeContent,
 }: {
   title: string;
   content: string;
+  badgeContent?: string;
   value: boolean;
   onChange: (v: boolean) => void;
 }) => (
   <XStack justifyContent="space-between" alignItems="center">
-    <YStack flex={1}>
-      <SizableText size="$bodyLgMedium">{title}</SizableText>
+    <YStack flex={1} gap='$0.5'>
+      <XStack alignItems="center" gap="$1.5">
+        <SizableText size="$bodyLgMedium">{title}</SizableText>
+        {badgeContent ? <Badge badgeSize="sm" badgeType='success'>{badgeContent}</Badge> : null}
+      </XStack>
       <SizableText size="$bodyMd" color="$textSubdued" width="95%">
         {content}
       </SizableText>
@@ -64,6 +69,7 @@ const SwapSettingsDialogContent = () => {
         content={intl.formatMessage({
           id: ETranslations.swap_page_settings_simple_mode_content,
         })}
+        badgeContent="Beta"
         value={swapBatchApproveAndSwap}
         onChange={(v) => {
           setSettings((s) => ({


### PR DESCRIPTION
<img width="1283" alt="image" src="https://github.com/user-attachments/assets/86f6df94-af6c-4b1d-918c-a43d733c05e2">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在 `SwapSettingsCommonItem` 组件中添加了可选属性 `badgeContent`，允许在标题旁边显示徽章。
  - 在 `SwapSettingsDialogContent` 组件中首次使用 `badgeContent`，并设置为字符串 "Beta"。
  
- **界面调整**
  - 调整了 `SwapSettingsCommonItem` 的布局，增加了标题与徽章之间的间距。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->