### PR TITLE
fix: Improve the interaction when exiting hardware updates.(OK-30870)

### DIFF
--- a/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateExitPrevent.ts
+++ b/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateExitPrevent.ts
@@ -40,6 +40,7 @@ export function FirmwareUpdateExitPrevent({
   useAppExitPrevent({
     title,
     message,
+    shouldPreventExitOnAndroid: false,
   });
 
   // Prevent lockApp:       check servicePassword.lockApp()

--- a/packages/kit/src/views/FirmwareUpdate/hooks/useFirmwareUpdateHooks.ts
+++ b/packages/kit/src/views/FirmwareUpdate/hooks/useFirmwareUpdateHooks.ts
@@ -67,9 +67,11 @@ export function useModalExitPrevent({
 export function useAppExitPrevent({
   message,
   title,
+  shouldPreventExitOnAndroid = true,
 }: {
   message: string;
   title: string;
+  shouldPreventExitOnAndroid?: boolean;
 }) {
   const intl = useIntl();
   // Prevents web page refresh/exit
@@ -90,6 +92,9 @@ export function useAppExitPrevent({
   // Prevent Android exit
   // https://reactnavigation.org/docs/7.x/preventing-going-back
   useEffect(() => {
+    if (!shouldPreventExitOnAndroid) {
+      return;
+    }
     const onBackPress = () => {
       Alert.alert(
         title,
@@ -119,7 +124,7 @@ export function useAppExitPrevent({
     );
 
     return () => backHandler.remove();
-  }, [message, title, intl]);
+  }, [message, title, intl, shouldPreventExitOnAndroid]);
 
   // Prevent Desktop exit
   // TODO

--- a/packages/kit/src/views/FirmwareUpdate/hooks/useFirmwareUpdateHooks.ts
+++ b/packages/kit/src/views/FirmwareUpdate/hooks/useFirmwareUpdateHooks.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect } from 'react';
 
 import { useIntl } from 'react-intl';
-import { Alert, BackHandler } from 'react-native';
 
 import { Dialog, usePreventRemove } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -71,7 +70,6 @@ export function useAppExitPrevent({
   message: string;
   title: string;
 }) {
-  const intl = useIntl();
   // Prevents web page refresh/exit
   useEffect(() => {
     if (platformEnv.isRuntimeBrowser && !platformEnv.isExtensionUiPopup) {
@@ -86,43 +84,6 @@ export function useAppExitPrevent({
       };
     }
   }, [message]);
-
-  // Prevent Android exit
-  // https://reactnavigation.org/docs/7.x/preventing-going-back
-  useEffect(() => {
-    const onBackPress = () => {
-      Alert.alert(
-        title,
-        message,
-        [
-          {
-            text: intl.formatMessage({ id: ETranslations.global_cancel }),
-            onPress: () => {
-              // Do nothing
-            },
-            style: 'cancel',
-          },
-          {
-            text: intl.formatMessage({ id: ETranslations.global_quit }),
-            onPress: () => BackHandler.exitApp(),
-          },
-        ],
-        { cancelable: false },
-      );
-
-      return true;
-    };
-
-    const backHandler = BackHandler.addEventListener(
-      'hardwareBackPress',
-      onBackPress,
-    );
-
-    return () => backHandler.remove();
-  }, [message, title, intl]);
-
-  // Prevent Desktop exit
-  // TODO
 }
 
 export function useExtensionUpdatingFromExpandTab() {


### PR DESCRIPTION
Video on https://onekeyhq.atlassian.net/browse/OK-30870?focusedCommentId=33247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在Android设备上，应用程序退出预防功能已被显式禁用。
  - `useModalExitPrevent`钩子新增可选参数`shouldPreventRemove`，提供更灵活的导航控制。

- **增强功能**
  - `useAppExitPrevent`钩子逻辑经过修改，以支持Android设备的退出行为控制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->