### PR TITLE
feat: hide the DashboardBanner when the length of banners is empty.(OK-32500)

### DIFF
--- a/packages/kit/src/views/Discovery/pages/Dashboard/BookmarksAndHistoriesSection.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/BookmarksAndHistoriesSection.tsx
@@ -135,9 +135,9 @@ export function BookmarksAndHistoriesSection({
   historiesData,
   onPressMore,
   handleOpenWebSite,
-  isShowSectionHeaderBorder,
+  showSectionHeaderBorder,
 }: {
-  isShowSectionHeaderBorder?: boolean;
+  showSectionHeaderBorder?: boolean;
   bookmarksData: IBrowserBookmark[] | undefined;
   historiesData: IBrowserHistory[] | undefined;
   onPressMore: (isHistoriesView: boolean) => void;
@@ -158,7 +158,7 @@ export function BookmarksAndHistoriesSection({
   return (
     <Stack px="$5" minHeight="$40">
       <DashboardSectionHeader
-        isShowSectionHeaderBorder={isShowSectionHeaderBorder}
+        showSectionHeaderBorder={showSectionHeaderBorder}
       >
         <DashboardSectionHeader.Heading
           selected={!isHistoriesView}

--- a/packages/kit/src/views/Discovery/pages/Dashboard/BookmarksAndHistoriesSection.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/BookmarksAndHistoriesSection.tsx
@@ -135,7 +135,9 @@ export function BookmarksAndHistoriesSection({
   historiesData,
   onPressMore,
   handleOpenWebSite,
+  isShowSectionHeaderBorder,
 }: {
+  isShowSectionHeaderBorder?: boolean;
   bookmarksData: IBrowserBookmark[] | undefined;
   historiesData: IBrowserHistory[] | undefined;
   onPressMore: (isHistoriesView: boolean) => void;
@@ -155,7 +157,9 @@ export function BookmarksAndHistoriesSection({
 
   return (
     <Stack px="$5" minHeight="$40">
-      <DashboardSectionHeader>
+      <DashboardSectionHeader
+        isShowSectionHeaderBorder={isShowSectionHeaderBorder}
+      >
         <DashboardSectionHeader.Heading
           selected={!isHistoriesView}
           onPress={() => setIsHistoriesView(false)}

--- a/packages/kit/src/views/Discovery/pages/Dashboard/DashboardContent.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/DashboardContent.tsx
@@ -142,7 +142,7 @@ function DashboardContent({
         ) : null}
         {platformEnv.isExtension || platformEnv.isWeb ? null : (
           <BookmarksAndHistoriesSection
-            isShowSectionHeaderBorder={isShowBanner}
+            showSectionHeaderBorder={isShowBanner}
             key="BookmarksAndHistoriesSection"
             bookmarksData={bookmarksData}
             historiesData={historiesData}

--- a/packages/kit/src/views/Discovery/pages/Dashboard/DashboardContent.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/DashboardContent.tsx
@@ -112,7 +112,8 @@ function DashboardContent({
   );
 
   const content = useMemo(() => {
-    const isShowBanner = !Array.isArray(homePageData?.banners);
+    const isShowBanner =
+      Array.isArray(homePageData?.banners) && homePageData.banners.length > 0;
     return (
       <>
         {isShowBanner ? (

--- a/packages/kit/src/views/Discovery/pages/Dashboard/DashboardContent.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/DashboardContent.tsx
@@ -111,35 +111,37 @@ function DashboardContent({
     [navigation],
   );
 
-  const content = useMemo(
-    () => (
+  const content = useMemo(() => {
+    const isShowBanner = !Array.isArray(homePageData?.banners);
+    return (
       <>
-        <DashboardBanner
-          key="Banner"
-          banners={
-            Array.isArray(homePageData?.banners) ? homePageData?.banners : []
-          }
-          handleOpenWebSite={({ webSite, useSystemBrowser }) => {
-            if (useSystemBrowser && webSite?.url) {
-              openUrlExternal(webSite.url);
-            } else if (webSite?.url) {
-              handleOpenWebSite({
-                switchToMultiTabBrowser: gtMd,
-                webSite,
-                navigation,
-                shouldPopNavigation: false,
+        {isShowBanner ? (
+          <DashboardBanner
+            key="Banner"
+            banners={homePageData?.banners || []}
+            handleOpenWebSite={({ webSite, useSystemBrowser }) => {
+              if (useSystemBrowser && webSite?.url) {
+                openUrlExternal(webSite.url);
+              } else if (webSite?.url) {
+                handleOpenWebSite({
+                  switchToMultiTabBrowser: gtMd,
+                  webSite,
+                  navigation,
+                  shouldPopNavigation: false,
+                });
+              }
+              defaultLogger.discovery.dapp.enterDapp({
+                dappDomain: webSite?.url || '',
+                dappName: webSite?.title || '',
+                enterMethod: EEnterMethod.banner,
               });
-            }
-            defaultLogger.discovery.dapp.enterDapp({
-              dappDomain: webSite?.url || '',
-              dappName: webSite?.title || '',
-              enterMethod: EEnterMethod.banner,
-            });
-          }}
-          isLoading={isLoading}
-        />
+            }}
+            isLoading={isLoading}
+          />
+        ) : null}
         {platformEnv.isExtension || platformEnv.isWeb ? null : (
           <BookmarksAndHistoriesSection
+            isShowSectionHeaderBorder={isShowBanner}
             key="BookmarksAndHistoriesSection"
             bookmarksData={bookmarksData}
             historiesData={historiesData}
@@ -184,19 +186,18 @@ function DashboardContent({
           />
         </ReviewControl>
       </>
-    ),
-    [
-      homePageData?.banners,
-      homePageData?.categories,
-      isLoading,
-      bookmarksData,
-      historiesData,
-      onPressMore,
-      handleOpenWebSite,
-      gtMd,
-      navigation,
-    ],
-  );
+    );
+  }, [
+    homePageData?.banners,
+    homePageData?.categories,
+    isLoading,
+    bookmarksData,
+    historiesData,
+    onPressMore,
+    handleOpenWebSite,
+    gtMd,
+    navigation,
+  ]);
 
   if (platformEnv.isNative) {
     return (

--- a/packages/kit/src/views/Discovery/pages/Dashboard/DashboardSectionHeader.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/DashboardSectionHeader.tsx
@@ -37,7 +37,11 @@ function SectionButton({ children, ...rest }: IButtonProps) {
   );
 }
 
-export function DashboardSectionHeader({ children, ...rest }: IXStackProps) {
+export function DashboardSectionHeader({
+  children,
+  isShowSectionHeaderBorder = true,
+  ...rest
+}: IXStackProps & { isShowSectionHeaderBorder?: boolean }) {
   return (
     <XStack
       alignItems="center"
@@ -46,7 +50,7 @@ export function DashboardSectionHeader({ children, ...rest }: IXStackProps) {
       $gtMd={{
         pt: '$1',
         mt: '$1',
-        borderTopWidth: 1,
+        borderTopWidth: isShowSectionHeaderBorder ? 1 : 0,
         borderColor: '$borderSubdued',
       }}
       {...rest}

--- a/packages/kit/src/views/Discovery/pages/Dashboard/DashboardSectionHeader.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/DashboardSectionHeader.tsx
@@ -39,9 +39,9 @@ function SectionButton({ children, ...rest }: IButtonProps) {
 
 export function DashboardSectionHeader({
   children,
-  isShowSectionHeaderBorder = true,
+  showSectionHeaderBorder = true,
   ...rest
-}: IXStackProps & { isShowSectionHeaderBorder?: boolean }) {
+}: IXStackProps & { showSectionHeaderBorder?: boolean }) {
   return (
     <XStack
       alignItems="center"
@@ -50,7 +50,7 @@ export function DashboardSectionHeader({
       $gtMd={{
         pt: '$1',
         mt: '$1',
-        borderTopWidth: isShowSectionHeaderBorder ? 1 : 0,
+        borderTopWidth: showSectionHeaderBorder ? 1 : 0,
         borderColor: '$borderSubdued',
       }}
       {...rest}


### PR DESCRIPTION
<img width="1228" alt="image" src="https://github.com/user-attachments/assets/2ca230da-c04e-47ab-a4f2-7b255fcfef88">

![Simulator Screenshot - iPhone 15 Pro - 2024-10-22 at 19 03 14](https://github.com/user-attachments/assets/21af27ab-2ffd-47bf-8d2a-d766f6d3d8ec)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 在`BookmarksAndHistoriesSection`和`DashboardSectionHeader`组件中添加了可选属性`showSectionHeaderBorder`，允许条件渲染部分标题的边框。
	- `DashboardContent`组件现在根据`homePageData?.banners`的状态动态渲染`DashboardBanner`。

- **改进**
	- 增强了组件的灵活性，使调用者可以控制部分标题边框的可见性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->