### PR TITLE
Ok-33349: Add double confirmation for Permit signing

### DIFF
--- a/packages/kit-bg/src/vaults/impls/kaspa/settings.ts
+++ b/packages/kit-bg/src/vaults/impls/kaspa/settings.ts
@@ -37,7 +37,7 @@ const settings: IVaultSettings = {
     // ECoreApiExportedSecretKeyType.publicKey,
   ],
 
-  defaultFeePresetIndex: 0,
+  defaultFeePresetIndex: 1,
 
   isUtxo: false,
   isSingleToken: true,

--- a/packages/kit/src/views/DAppConnection/hooks/useRiskDetection.ts
+++ b/packages/kit/src/views/DAppConnection/hooks/useRiskDetection.ts
@@ -40,6 +40,9 @@ function useRiskDetection({
     if (isEthSignType({ unsignedMessage })) {
       return true;
     }
+    if (!urlSecurityInfo) {
+      return false;
+    }
     if (
       (isPrimaryTypePermitSign({ unsignedMessage }) ||
         isPrimaryTypeOrderSign({ unsignedMessage })) &&
@@ -48,7 +51,7 @@ function useRiskDetection({
       return true;
     }
     return false;
-  }, [unsignedMessage, riskLevel]);
+  }, [unsignedMessage, riskLevel, urlSecurityInfo]);
 
   const showContinueOperate = useMemo(() => {
     if (isRiskSignMethod) {

--- a/packages/kit/src/views/DAppConnection/pages/SignMessageModal.tsx
+++ b/packages/kit/src/views/DAppConnection/pages/SignMessageModal.tsx
@@ -17,7 +17,6 @@ import { AccountSelectorTriggerDappConnectionCmp } from '@onekeyhq/kit/src/compo
 import type { IDBIndexedAccount } from '@onekeyhq/kit-bg/src/dbs/local/types';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
-  isEthSignType,
   isPrimaryTypeOrderSign,
   isPrimaryTypePermitSign,
 } from '@onekeyhq/shared/src/signMessage';
@@ -141,7 +140,6 @@ function SignMessageModal() {
 
   const isPermitSignMethod = isPrimaryTypePermitSign({ unsignedMessage });
   const isOrderSignMethod = isPrimaryTypeOrderSign({ unsignedMessage });
-  const isRiskSignMethod = isEthSignType({ unsignedMessage });
   const isSignTypedDataV3orV4Method =
     unsignedMessage.type === EMessageTypesEth.TYPED_DATA_V3 ||
     unsignedMessage.type === EMessageTypesEth.TYPED_DATA_V4;
@@ -181,7 +179,8 @@ function SignMessageModal() {
     setContinueOperate,
     riskLevel,
     urlSecurityInfo,
-  } = useRiskDetection({ origin: $sourceInfo?.origin ?? '', isRiskSignMethod });
+    isRiskSignMethod,
+  } = useRiskDetection({ origin: $sourceInfo?.origin ?? '', unsignedMessage });
 
   const handleSignMessage = useCallback(
     async (close?: (extra?: { flag?: string }) => void) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了默认费用预设配置，提升了费用管理的灵活性。
	- 风险检测钩子现在支持新的输入结构，增强了风险评估能力。
	- 签名消息模态组件简化了风险评估流程，直接利用未签名消息进行检测。

- **Bug 修复**
	- 修复了签名消息处理中的逻辑，确保了不同消息类型的验证逻辑保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->