### PR TITLE
fix: earn history detail txid display OK-33364

### DIFF
--- a/packages/kit/src/views/Staking/pages/HistoryList/index.tsx
+++ b/packages/kit/src/views/Staking/pages/HistoryList/index.tsx
@@ -210,7 +210,7 @@ const HistoryList = () => {
         const localNormalizedItems = localItems.map<IStakeHistory>((o) => {
           const action = o.stakingInfo.send ?? o.stakingInfo.receive;
           return {
-            txHash: o.id,
+            txHash: o.decodedTx.txid,
             timestamp: o.decodedTx.createdAt ?? o.decodedTx.updatedAt ?? 0,
             title: labelFn(o.stakingInfo.label),
             direction: o.stakingInfo.send ? 'send' : 'receive',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了本地质押历史项的交易哈希处理方式，以更准确地识别和显示交易。
- **修复**
	- 保持了时间戳属性的获取逻辑，确保在缺失时默认值为0。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->