### PR TITLE
fix: hide notification account settings

### DIFF
--- a/packages/kit/src/views/Setting/pages/Notifications/NotificationsSettings.tsx
+++ b/packages/kit/src/views/Setting/pages/Notifications/NotificationsSettings.tsx
@@ -24,7 +24,7 @@ import {
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import { EModalRoutes, EModalSettingRoutes } from '@onekeyhq/shared/src/routes';
+import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalNotificationsRoutes } from '@onekeyhq/shared/src/routes/notifications';
 import type { INotificationPushSettings } from '@onekeyhq/shared/types/notification';
 
@@ -166,7 +166,7 @@ export default function NotificationsSettings() {
                     }}
                   />
                 </ListItem>
-                {settings?.accountActivityPushEnabled ? (
+                {/* {settings?.accountActivityPushEnabled ? (
                   <ListItem
                     title="Manage"
                     subtitle="Choose the account for notifications."
@@ -177,7 +177,7 @@ export default function NotificationsSettings() {
                       );
                     }}
                   />
-                ) : null}
+                ) : null} */}
                 {/* <ListItem>
           <ListItem.Text
             flex={1}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 通知设置界面保留了管理通知的主要功能，用户仍可切换通知设置。
  
- **变更**
	- 移除了某些路由的导入，简化了代码结构。
	- 暂时禁用了与账户活动推送和价格警报相关的功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->