### PR TITLE
fix: Disabled Nervos imported account

### DIFF
--- a/packages/kit-bg/src/vaults/impls/ckb/settings.ts
+++ b/packages/kit-bg/src/vaults/impls/ckb/settings.ts
@@ -24,7 +24,7 @@ const settings: IVaultSettings = {
   coinTypeDefault: COINTYPE_CKB,
   accountType: EDBAccountType.SIMPLE,
 
-  importedAccountEnabled: true,
+  importedAccountEnabled: false,
   hardwareAccountEnabled: true,
   externalAccountEnabled: false,
   watchingAccountEnabled: true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 更新了设置，禁用了导入账户功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->