### PR TITLE
Feat/show tx hex data OK-33463

### DIFF
--- a/packages/kit/src/views/AssetDetails/pages/HistoryDetails/HistoryDetails.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/HistoryDetails/HistoryDetails.tsx
@@ -1020,7 +1020,20 @@ function HistoryDetails() {
                   id: ETranslations.global_hex_data,
                 })}
                 renderContent={txInfo.data}
-                compact
+                description={
+                  <Button
+                    size="small"
+                    variant="tertiary"
+                    onPress={() => {
+                      void openTransactionDetailsUrl({
+                        networkId: network?.id,
+                        txid,
+                      });
+                    }}
+                  >
+                    {intl.formatMessage({ id: ETranslations.global_view_more })}
+                  </Button>
+                }
               />
             ) : null}
             {vaultSettings?.isUtxo &&

--- a/packages/kit/src/views/AssetDetails/pages/HistoryDetails/HistoryDetails.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/HistoryDetails/HistoryDetails.tsx
@@ -289,8 +289,6 @@ function HistoryDetails() {
     [accountId, networkId],
   ).result;
 
-  console.log('txid changed', txid);
-
   const { result, isLoading } = usePromiseResult(
     async () => {
       if (!accountAddress) return;
@@ -974,6 +972,23 @@ function HistoryDetails() {
                     }
               }
             />
+            {txInfo?.data ? (
+              <InfoItem
+                label={intl.formatMessage({
+                  id: ETranslations.global_hex_data,
+                })}
+                renderContent={
+                  <SizableText
+                    size="$bodyMd"
+                    color="$textSubdued"
+                    style={{ wordBreak: 'break-all' }}
+                    flex={1}
+                  >
+                    {txInfo.data}
+                  </SizableText>
+                }
+              />
+            ) : null}
             <InfoItem
               label={intl.formatMessage({
                 id: ETranslations.swap_history_detail_network_fee,
@@ -1014,28 +1029,7 @@ function HistoryDetails() {
                 compact
               />
             ) : null}
-            {txInfo?.data ? (
-              <InfoItem
-                label={intl.formatMessage({
-                  id: ETranslations.global_hex_data,
-                })}
-                renderContent={txInfo.data}
-                description={
-                  <Button
-                    size="small"
-                    variant="tertiary"
-                    onPress={() => {
-                      void openTransactionDetailsUrl({
-                        networkId: network?.id,
-                        txid,
-                      });
-                    }}
-                  >
-                    {intl.formatMessage({ id: ETranslations.global_view_more })}
-                  </Button>
-                }
-              />
-            ) : null}
+
             {vaultSettings?.isUtxo &&
             (historyTx?.decodedTx.status !== EDecodedTxStatus.Pending ||
               !vaultSettings.hideTxUtxoListWhenPending) ? (

--- a/packages/shared/src/utils/historyUtils.ts
+++ b/packages/shared/src/utils/historyUtils.ts
@@ -144,14 +144,14 @@ export function getHistoryTxDetailInfo({
   const decodedTx = historyTx?.decodedTx;
   let swapInfo;
   let nonce = txDetails?.nonce;
-  let data = txDetails?.data;
+  let data = txDetails?.slicedData;
 
   if (isNil(nonce) && !isNil(decodedTx?.nonce)) {
     nonce = decodedTx.nonce;
   }
 
   if (isNil(data) && !isNil((decodedTx?.encodedTx as IEncodedTxEvm)?.data)) {
-    data = (decodedTx?.encodedTx as IEncodedTxEvm)?.data;
+    data = (decodedTx?.encodedTx as IEncodedTxEvm)?.data?.slice(0, 500);
   }
 
   let date = '-';

--- a/packages/shared/src/utils/historyUtils.ts
+++ b/packages/shared/src/utils/historyUtils.ts
@@ -151,7 +151,12 @@ export function getHistoryTxDetailInfo({
   }
 
   if (isNil(data) && !isNil((decodedTx?.encodedTx as IEncodedTxEvm)?.data)) {
-    data = (decodedTx?.encodedTx as IEncodedTxEvm)?.data?.slice(0, 500);
+    const dataStr = (decodedTx?.encodedTx as IEncodedTxEvm)?.data ?? '';
+    if (dataStr.length > 500) {
+      data = `${dataStr.slice(0, 500)}...`;
+    } else {
+      data = dataStr;
+    }
   }
 
   let date = '-';

--- a/packages/shared/types/history.ts
+++ b/packages/shared/types/history.ts
@@ -132,7 +132,7 @@ export type IOnChainHistoryTx = {
     netFeeCost?: number;
   };
 
-  data?: string;
+  slicedData?: string;
 };
 
 export type IAccountHistoryTx = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 在历史详情页面新增条件渲染，展示交易的十六进制数据（如果存在）。
  - 改进了交易数据的处理，确保长数据字符串在超过500个字符时被截断并添加省略号。

- **错误修复**
  - 移除了与交易ID变化相关的调试日志输出。

- **文档**
  - 更新了`IOnChainHistoryTx`类型中的属性名称，从`data`更改为`slicedData`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->