### PR TITLE
fix: update nft cache error OK-33656

### DIFF
--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityLocalNFTs.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityLocalNFTs.ts
@@ -39,9 +39,10 @@ export class SimpleDbEntityLocalNFTs extends SimpleDbEntityBase<ILocalNFTs> {
     });
 
     await this.setRawData(({ rawData }) => ({
-      list: merge({}, rawData?.list, {
+      list: {
+        ...rawData?.list,
         [key]: nfts,
-      }),
+      },
     }));
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 优化了本地NFT列表的更新逻辑，采用更简洁的对象扩展语法。
- **错误修复**
	- 保持了错误处理机制，确保在缺少`accountAddress`和`xpub`时仍会抛出相应错误。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->