### PR TITLE
chore: refresh electorn by shortcuts on CmdOrCtrl + R

### DIFF
--- a/packages/kit/src/views/Discovery/hooks/useShortcuts.desktop.ts
+++ b/packages/kit/src/views/Discovery/hooks/useShortcuts.desktop.ts
@@ -101,7 +101,7 @@ export const useDiscoveryShortcuts = () => {
             } catch {
               // empty
             }
-          } else if (platformEnv.isDev) {
+          } else {
             globalThis.desktopApi.reload();
           }
           break;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 简化了“刷新”和“关闭标签”快捷键的处理逻辑。
	- 在非浏览器标签下，执行“刷新”操作不再依赖于开发模式。
	- 在非浏览器标签下，调用“关闭标签”快捷键将直接退出应用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->