### PR TITLE
feat: Clear cache page and Support Quit/Zoom In/Zoom Out shortcuts on Windows & Linux (OK-33706 OK-33652)

### DIFF
--- a/apps/desktop/src-electron/app.ts
+++ b/apps/desktop/src-electron/app.ts
@@ -207,11 +207,16 @@ const initMenu = () => {
           label: i18nText(ETranslations.menu_actual_size),
           accelerator: 'CmdOrCtrl+0',
         },
-        {
-          role: 'zoomIn',
-          label: i18nText(ETranslations.menu_zoom_in),
-          accelerator: 'CmdOrCtrl+Plus',
-        },
+        isMac
+          ? {
+              role: 'zoomIn',
+              label: i18nText(ETranslations.menu_zoom_in),
+            }
+          : {
+              role: 'zoomIn',
+              label: i18nText(ETranslations.menu_zoom_in),
+              accelerator: 'CmdOrCtrl+Shift++',
+            },
         {
           role: 'zoomOut',
           label: i18nText(ETranslations.menu_zoom_out),

--- a/apps/desktop/src-electron/app.ts
+++ b/apps/desktop/src-electron/app.ts
@@ -215,12 +215,12 @@ const initMenu = () => {
           : {
               role: 'zoomIn',
               label: i18nText(ETranslations.menu_zoom_in),
-              accelerator: 'CmdOrCtrl+Shift++',
+              accelerator: 'CmdOrCtrl+Shift+]',
             },
         {
           role: 'zoomOut',
           label: i18nText(ETranslations.menu_zoom_out),
-          accelerator: 'CmdOrCtrl+-',
+          accelerator: isMac ? 'CmdOrCtrl+-' : 'CmdOrCtrl+Shift+[',
         },
         { type: 'separator' },
         {

--- a/apps/desktop/src-electron/app.ts
+++ b/apps/desktop/src-electron/app.ts
@@ -202,9 +202,21 @@ const initMenu = () => {
               { type: 'separator' },
             ]
           : []),
-        { role: 'resetZoom', label: i18nText(ETranslations.menu_actual_size) },
-        { role: 'zoomIn', label: i18nText(ETranslations.menu_zoom_in) },
-        { role: 'zoomOut', label: i18nText(ETranslations.menu_zoom_out) },
+        {
+          role: 'resetZoom',
+          label: i18nText(ETranslations.menu_actual_size),
+          accelerator: 'CmdOrCtrl+0',
+        },
+        {
+          role: 'zoomIn',
+          label: i18nText(ETranslations.menu_zoom_in),
+          accelerator: 'CmdOrCtrl+-',
+        },
+        {
+          role: 'zoomOut',
+          label: i18nText(ETranslations.menu_zoom_out),
+          accelerator: 'CmdOrCtrl++',
+        },
         { type: 'separator' },
         {
           role: 'togglefullscreen',

--- a/apps/desktop/src-electron/app.ts
+++ b/apps/desktop/src-electron/app.ts
@@ -154,7 +154,7 @@ const initMenu = () => {
           },
         },
         { type: 'separator' },
-        {
+        isMac && {
           role: 'hide',
           accelerator: 'Alt+CmdOrCtrl+H',
           label: i18nText(ETranslations.menu_hide_onekey_wallet),
@@ -166,6 +166,7 @@ const initMenu = () => {
         { type: 'separator' },
         {
           role: 'quit',
+          accelerator: 'CmdOrCtrl+Q',
           label: i18nText(ETranslations.menu_quit_onekey_wallet),
         },
       ].filter(Boolean),

--- a/apps/desktop/src-electron/app.ts
+++ b/apps/desktop/src-electron/app.ts
@@ -210,12 +210,12 @@ const initMenu = () => {
         {
           role: 'zoomIn',
           label: i18nText(ETranslations.menu_zoom_in),
-          accelerator: 'CmdOrCtrl+-',
+          accelerator: 'CmdOrCtrl+Plus',
         },
         {
           role: 'zoomOut',
           label: i18nText(ETranslations.menu_zoom_out),
-          accelerator: 'CmdOrCtrl++',
+          accelerator: 'CmdOrCtrl+-',
         },
         { type: 'separator' },
         {

--- a/packages/kit/src/views/Setting/pages/ClearAppCache/index.tsx
+++ b/packages/kit/src/views/Setting/pages/ClearAppCache/index.tsx
@@ -1,0 +1,242 @@
+import type { FC } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import type { INavSearchBarProps } from '@onekeyhq/components';
+import {
+  Checkbox,
+  Dialog,
+  Empty,
+  Form,
+  Page,
+  SectionList,
+  Stack,
+  Toast,
+  YStack,
+  useClipboard,
+  useForm,
+} from '@onekeyhq/components';
+import {} from '@onekeyhq/components/src/layouts/SectionList';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
+import {
+  useCurrencyPersistAtom,
+  useSettingsPersistAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import type { IClearCacheOnAppState } from '@onekeyhq/shared/types/setting';
+
+const keyExtractor = (_: unknown, index: number) => `${index}`;
+
+// onPress: () => {
+//   Dialog.show({
+//     title: intl.formatMessage({
+//       id: ETranslations.settings_clear_cache_on_app,
+//     }),
+//     renderContent: <ClearCacheOnAppContent />,
+//     tone: 'destructive',
+//     confirmButtonProps: {
+//       disabledOn: ({ getForm }) => {
+//         const { getValues } = getForm() || {};
+//         if (getValues) {
+//           const values = getValues();
+//           return !Object.values(values).some((o) => Boolean(o));
+//         }
+//         return true;
+//       },
+//     },
+//     onConfirm: async (dialogInstance) => {
+
+//     },
+//   });
+// },
+export default function ClearAppCache() {
+  const intl = useIntl();
+  const form = useForm({
+    defaultValues: {
+      tokenAndNFT: true,
+      transactionHistory: true,
+      swapHistory: true,
+      browserCache: true,
+      appUpdateCache: true,
+      browserHistory: false,
+      connectSites: false,
+      signatureRecord: false,
+      customToken: false,
+      customRpc: false,
+      serverNetworks: false,
+    } as IClearCacheOnAppState,
+  });
+  const { copyText } = useClipboard();
+
+  const values = form.watch();
+  const disabled = !Object.values(values).some((o) => Boolean(o));
+  return (
+    <Page scrollEnabled>
+      <Page.Header
+        title={intl.formatMessage({
+          id: ETranslations.settings_clear_cache_on_app,
+        })}
+      />
+      <Page.Body>
+        <Stack px="$6">
+          <Form form={form}>
+            <YStack>
+              <Form.Field name="tokenAndNFT">
+                <Checkbox
+                  label={intl.formatMessage({
+                    id: ETranslations.settings_token_nft_data,
+                  })}
+                />
+              </Form.Field>
+              <Form.Field name="transactionHistory">
+                <Checkbox
+                  label={intl.formatMessage({
+                    id: ETranslations.settings_transaction_history,
+                  })}
+                />
+              </Form.Field>
+              <Form.Field name="swapHistory">
+                <Checkbox
+                  label={intl.formatMessage({
+                    id: ETranslations.settings_swap_history,
+                  })}
+                />
+              </Form.Field>
+              <Form.Field name="browserCache">
+                <Checkbox
+                  label={intl.formatMessage({
+                    id: ETranslations.settings_browser_cache,
+                  })}
+                />
+              </Form.Field>
+              <Form.Field name="appUpdateCache">
+                <Checkbox
+                  label={intl.formatMessage({
+                    id: ETranslations.settings_app_update_cache,
+                  })}
+                />
+              </Form.Field>
+              <Form.Field name="browserHistory">
+                <Checkbox
+                  label={intl.formatMessage({
+                    id: ETranslations.settings_browser_history_bookmarks_pins_risk_dapp_whitelist,
+                  })}
+                  labelProps={{ flex: 1 } as any}
+                />
+              </Form.Field>
+              <Form.Field name="customToken">
+                <Checkbox
+                  label={intl.formatMessage({
+                    id: ETranslations.manage_token_custom_token_title,
+                  })}
+                />
+              </Form.Field>
+              <Form.Field name="customRpc">
+                <Checkbox
+                  label={intl.formatMessage({
+                    id: ETranslations.custom_rpc_title,
+                  })}
+                />
+              </Form.Field>
+              <Form.Field name="serverNetworks">
+                <Checkbox
+                  label={intl.formatMessage({
+                    id: ETranslations.clear_build_in_networks_data,
+                  })}
+                />
+              </Form.Field>
+              <Form.Field name="connectSites">
+                <Checkbox
+                  label={intl.formatMessage({
+                    id: ETranslations.settings_connected_sites,
+                  })}
+                />
+              </Form.Field>
+              <Form.Field name="signatureRecord">
+                <Checkbox
+                  label={intl.formatMessage({
+                    id: ETranslations.settings_signature_record,
+                  })}
+                />
+              </Form.Field>
+            </YStack>
+          </Form>
+        </Stack>
+      </Page.Body>
+      <Page.Footer
+        onCancel={(close) => close()}
+        onConfirm={async (close) => {
+          if (values) {
+            await backgroundApiProxy.serviceSetting.clearCacheOnApp(values);
+            Toast.success({
+              title: intl.formatMessage({
+                id: ETranslations.global_success,
+              }),
+            });
+            if (
+              values?.browserCache &&
+              (platformEnv.isWeb || platformEnv.isExtension)
+            ) {
+              if (platformEnv.isRuntimeChrome || platformEnv.isRuntimeEdge) {
+                let settingPath = 'chrome://settings/clearBrowserData';
+                if (platformEnv.isRuntimeEdge) {
+                  settingPath = 'edge://settings/clearBrowserData';
+                }
+                Dialog.show({
+                  title: intl.formatMessage({
+                    id: ETranslations.settings_clear_browser_cache,
+                  }),
+                  description: intl.formatMessage(
+                    {
+                      id: ETranslations.settings_clear_browser_cache_desc,
+                    },
+                    { url: settingPath },
+                  ),
+                  onConfirm: () => {
+                    copyText(settingPath);
+                    close();
+                  },
+                  showCancelButton: false,
+                  confirmButtonProps: {
+                    variant: 'primary',
+                    size: 'large',
+                    icon: 'Copy3Outline',
+                  },
+                  onConfirmText: intl.formatMessage({
+                    id: ETranslations.global_copy,
+                  }),
+                });
+              } else {
+                Dialog.show({
+                  title: intl.formatMessage({
+                    id: ETranslations.settings_clear_browser_cache,
+                  }),
+                  description: intl.formatMessage({
+                    id: ETranslations.settings_clear_browser_cache_desc2,
+                  }),
+                  showCancelButton: false,
+                  confirmButtonProps: {
+                    variant: 'primary',
+                    size: 'large',
+                    icon: 'Copy1Outline',
+                  },
+                  onConfirm: () => {
+                    close();
+                  },
+                });
+              }
+            } else {
+              close();
+            }
+          }
+        }}
+        confirmButtonProps={{
+          disabled,
+        }}
+      />
+    </Page>
+  );
+}

--- a/packages/kit/src/views/Setting/pages/List/SecuritySection/CleanDataItem/index.tsx
+++ b/packages/kit/src/views/Setting/pages/List/SecuritySection/CleanDataItem/index.tsx
@@ -1,132 +1,29 @@
+import { useCallback } from 'react';
+
 import { useIntl } from 'react-intl';
 
-import {
-  ActionList,
-  Checkbox,
-  Dialog,
-  Stack,
-  Toast,
-  useClipboard,
-} from '@onekeyhq/components';
+import type { IPageNavigationProp } from '@onekeyhq/components';
+import { ActionList, Dialog, Toast } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
+import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useResetApp } from '@onekeyhq/kit/src/views/Setting/hooks';
 import {
   EAppEventBusNames,
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import type { IClearCacheOnAppState } from '@onekeyhq/shared/types/setting';
-
-const ClearCacheOnAppContent = () => {
-  const intl = useIntl();
-  return (
-    <Dialog.Form
-      formProps={{
-        defaultValues: {
-          tokenAndNFT: true,
-          transactionHistory: true,
-          swapHistory: true,
-          browserCache: true,
-          appUpdateCache: true,
-          browserHistory: false,
-          connectSites: false,
-          signatureRecord: false,
-          customToken: false,
-          customRpc: false,
-          serverNetworks: false,
-        } as IClearCacheOnAppState,
-      }}
-    >
-      <Stack>
-        <Dialog.FormField name="tokenAndNFT">
-          <Checkbox
-            label={intl.formatMessage({
-              id: ETranslations.settings_token_nft_data,
-            })}
-          />
-        </Dialog.FormField>
-        <Dialog.FormField name="transactionHistory">
-          <Checkbox
-            label={intl.formatMessage({
-              id: ETranslations.settings_transaction_history,
-            })}
-          />
-        </Dialog.FormField>
-        <Dialog.FormField name="swapHistory">
-          <Checkbox
-            label={intl.formatMessage({
-              id: ETranslations.settings_swap_history,
-            })}
-          />
-        </Dialog.FormField>
-        <Dialog.FormField name="browserCache">
-          <Checkbox
-            label={intl.formatMessage({
-              id: ETranslations.settings_browser_cache,
-            })}
-          />
-        </Dialog.FormField>
-        <Dialog.FormField name="appUpdateCache">
-          <Checkbox
-            label={intl.formatMessage({
-              id: ETranslations.settings_app_update_cache,
-            })}
-          />
-        </Dialog.FormField>
-        <Dialog.FormField name="browserHistory">
-          <Checkbox
-            label={intl.formatMessage({
-              id: ETranslations.settings_browser_history_bookmarks_pins_risk_dapp_whitelist,
-            })}
-            labelProps={{ flex: 1 } as any}
-          />
-        </Dialog.FormField>
-        <Dialog.FormField name="customToken">
-          <Checkbox
-            label={intl.formatMessage({
-              id: ETranslations.manage_token_custom_token_title,
-            })}
-          />
-        </Dialog.FormField>
-        <Dialog.FormField name="customRpc">
-          <Checkbox
-            label={intl.formatMessage({
-              id: ETranslations.custom_rpc_title,
-            })}
-          />
-        </Dialog.FormField>
-        <Dialog.FormField name="serverNetworks">
-          <Checkbox
-            label={intl.formatMessage({
-              id: ETranslations.clear_build_in_networks_data,
-            })}
-          />
-        </Dialog.FormField>
-        <Dialog.FormField name="connectSites">
-          <Checkbox
-            label={intl.formatMessage({
-              id: ETranslations.settings_connected_sites,
-            })}
-          />
-        </Dialog.FormField>
-        <Dialog.FormField name="signatureRecord">
-          <Checkbox
-            label={intl.formatMessage({
-              id: ETranslations.settings_signature_record,
-            })}
-          />
-        </Dialog.FormField>
-      </Stack>
-    </Dialog.Form>
-  );
-};
+import { EModalSettingRoutes } from '@onekeyhq/shared/src/routes';
+import type { IModalSettingParamList } from '@onekeyhq/shared/src/routes';
 
 export const CleanDataItem = () => {
-  const { copyText } = useClipboard();
   const intl = useIntl();
   const resetApp = useResetApp();
+  const navigation =
+    useAppNavigation<IPageNavigationProp<IModalSettingParamList>>();
+  const toSettingClearAppCachePage = useCallback(() => {
+    navigation.push(EModalSettingRoutes.SettingClearAppCache);
+  }, [navigation]);
   return (
     <ActionList
       offset={{ mainAxis: -4, crossAxis: -10 }}
@@ -145,92 +42,7 @@ export const CleanDataItem = () => {
           label: intl.formatMessage({
             id: ETranslations.settings_clear_cache_on_app,
           }),
-          onPress: () => {
-            Dialog.show({
-              title: intl.formatMessage({
-                id: ETranslations.settings_clear_cache_on_app,
-              }),
-              renderContent: <ClearCacheOnAppContent />,
-              tone: 'destructive',
-              confirmButtonProps: {
-                disabledOn: ({ getForm }) => {
-                  const { getValues } = getForm() || {};
-                  if (getValues) {
-                    const values = getValues();
-                    return !Object.values(values).some((o) => Boolean(o));
-                  }
-                  return true;
-                },
-              },
-              onConfirm: async (dialogInstance) => {
-                const values = dialogInstance.getForm()?.getValues() as
-                  | IClearCacheOnAppState
-                  | undefined;
-                if (values) {
-                  await backgroundApiProxy.serviceSetting.clearCacheOnApp(
-                    values,
-                  );
-                  Toast.success({
-                    title: intl.formatMessage({
-                      id: ETranslations.global_success,
-                    }),
-                  });
-                  if (
-                    values?.browserCache &&
-                    (platformEnv.isWeb || platformEnv.isExtension)
-                  ) {
-                    if (
-                      platformEnv.isRuntimeChrome ||
-                      platformEnv.isRuntimeEdge
-                    ) {
-                      let settingPath = 'chrome://settings/clearBrowserData';
-                      if (platformEnv.isRuntimeEdge) {
-                        settingPath = 'edge://settings/clearBrowserData';
-                      }
-                      Dialog.show({
-                        title: intl.formatMessage({
-                          id: ETranslations.settings_clear_browser_cache,
-                        }),
-                        description: intl.formatMessage(
-                          {
-                            id: ETranslations.settings_clear_browser_cache_desc,
-                          },
-                          { url: settingPath },
-                        ),
-                        onConfirm: () => {
-                          copyText(settingPath);
-                        },
-                        showCancelButton: false,
-                        confirmButtonProps: {
-                          variant: 'primary',
-                          size: 'large',
-                          icon: 'Copy3Outline',
-                        },
-                        onConfirmText: intl.formatMessage({
-                          id: ETranslations.global_copy,
-                        }),
-                      });
-                    } else {
-                      Dialog.show({
-                        title: intl.formatMessage({
-                          id: ETranslations.settings_clear_browser_cache,
-                        }),
-                        description: intl.formatMessage({
-                          id: ETranslations.settings_clear_browser_cache_desc2,
-                        }),
-                        showCancelButton: false,
-                        confirmButtonProps: {
-                          variant: 'primary',
-                          size: 'large',
-                          icon: 'Copy1Outline',
-                        },
-                      });
-                    }
-                  }
-                }
-              },
-            });
-          },
+          onPress: toSettingClearAppCachePage,
         },
         {
           label: intl.formatMessage({

--- a/packages/kit/src/views/Setting/router/index.tsx
+++ b/packages/kit/src/views/Setting/router/index.tsx
@@ -20,6 +20,9 @@ const SettingAppAutoLockModal = LazyLoadPage(
 const SettingCurrencyModal = LazyLoadPage(
   () => import('@onekeyhq/kit/src/views/Setting/pages/Currency'),
 );
+const SettingClearAppCacheModal = LazyLoadPage(
+  () => import('@onekeyhq/kit/src/views/Setting/pages/ClearAppCache'),
+);
 const SettingListModal = LazyLoadPage(
   () => import('@onekeyhq/kit/src/views/Setting/pages/List'),
 );
@@ -111,6 +114,10 @@ export const ModalSettingStack: IModalFlowNavigatorConfig<
   {
     name: EModalSettingRoutes.SettingProtectModal,
     component: SettingProtectionModal,
+  },
+  {
+    name: EModalSettingRoutes.SettingClearAppCache,
+    component: SettingClearAppCacheModal,
   },
   {
     name: EModalSettingRoutes.SettingSignatureRecordModal,

--- a/packages/shared/src/routes/setting.ts
+++ b/packages/shared/src/routes/setting.ts
@@ -1,6 +1,7 @@
 export enum EModalSettingRoutes {
   SettingListModal = 'SettingListModal',
   SettingCurrencyModal = 'SettingCurrencyModal',
+  SettingClearAppCache = 'SettingClearAppCache',
   SettingAccountDerivationModal = 'SettingAccountDerivationModal',
   SettingSpendUTXOModal = 'SettingSpendUTXOModal',
   SettingCustomRPC = 'SettingCustomRPC',
@@ -20,6 +21,7 @@ export enum EModalSettingRoutes {
 export type IModalSettingParamList = {
   [EModalSettingRoutes.SettingListModal]: { flag?: string } | undefined;
   [EModalSettingRoutes.SettingCurrencyModal]: undefined;
+  [EModalSettingRoutes.SettingClearAppCache]: undefined;
   [EModalSettingRoutes.SettingAccountDerivationModal]: undefined;
   [EModalSettingRoutes.SettingSpendUTXOModal]: undefined;
   [EModalSettingRoutes.SettingCustomRPC]: undefined;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 更新了菜单结构，增强了 macOS 用户的体验，新增了“隐藏”和“取消隐藏”菜单项。
	- 增加了“退出”菜单项的快捷键，提升了用户可访问性。
	- 为缩放相关菜单项添加了快捷键，改善了可用性。
	- 新增了清除应用缓存的功能，提供用户友好的界面供选择清除不同类型的缓存。

- **改进**
	- 优化了事件处理，确保在全屏切换和应用空闲状态时的管理更为流畅。
	- 增强了深链接 URL 的处理，增加了调试日志。
	- 清理数据项的导航逻辑已简化，用户可直接跳转至清除缓存的设置页面。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->