### PR TITLE
fix: firmware update ui OK-33661  

### DIFF
--- a/packages/kit/src/views/FirmwareUpdate/components/FirmwareChangeLogView.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/components/FirmwareChangeLogView.tsx
@@ -11,12 +11,12 @@ import {
   XStack,
 } from '@onekeyhq/components';
 import type { IKeyOfIcons } from '@onekeyhq/components/src/primitives';
-import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import {
   EFirmwareUpdateSteps,
   useFirmwareUpdateStepInfoAtom,
   useSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type {
   IBleFirmwareUpdateInfo,
@@ -165,8 +165,10 @@ export function FirmwareChangeLogContentView({
 
 export function FirmwareChangeLogView({
   result,
+  onConfirmClick,
 }: {
   result: ICheckAllFirmwareReleaseResult | undefined;
+  onConfirmClick?: () => void;
 }) {
   const intl = useIntl();
   const [, setStepInfo] = useFirmwareUpdateStepInfoAtom();
@@ -184,6 +186,7 @@ export function FirmwareChangeLogView({
             payload: undefined,
           });
           showCheckList({ result });
+          onConfirmClick?.();
         }}
       />
       <Stack>

--- a/packages/kit/src/views/FirmwareUpdate/components/FirmwareInstallingView.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/components/FirmwareInstallingView.tsx
@@ -97,7 +97,11 @@ export function FirmwareInstallingView({
         result={result}
         isDone={isDone}
         tipMessage={lastFirmwareTipMessage}
-        retryInfo={retryInfo}
+        retryInfo={
+          stepInfo.step === EFirmwareUpdateSteps.updateStart
+            ? undefined
+            : retryInfo
+        }
         progressBarKey={lastUpdateTimeRef.current}
       />
     </>

--- a/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateCheckList.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateCheckList.tsx
@@ -112,9 +112,17 @@ export function FirmwareUpdateCheckList({
                       startAtTime: Date.now(),
                     },
                   });
+
                   navigation.navigate(EModalFirmwareUpdateRoutes.Install, {
                     result,
                   });
+
+                  // navigation.dispatch(
+                  //   StackActions.replace(EModalFirmwareUpdateRoutes.Install, {
+                  //     result,
+                  //   }),
+                  // );
+
                   setWorkflowIsRunning(true);
                   await backgroundApiProxy.serviceFirmwareUpdate.startUpdateWorkflow(
                     {

--- a/packages/kit/src/views/FirmwareUpdate/pages/PageFirmwareUpdateChangeLog.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/pages/PageFirmwareUpdateChangeLog.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 
 import { Page } from '@onekeyhq/components';
 import {
@@ -10,6 +10,7 @@ import type {
   EModalFirmwareUpdateRoutes,
   IModalFirmwareUpdateParamList,
 } from '@onekeyhq/shared/src/routes';
+import type { ICheckAllFirmwareReleaseResult } from '@onekeyhq/shared/types/device';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import useAppNavigation from '../../../hooks/useAppNavigation';
@@ -36,6 +37,10 @@ function PageFirmwareUpdateChangeLog() {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const navigation = useAppNavigation();
   const [stepInfo, setStepInfo] = useFirmwareUpdateStepInfoAtom();
+
+  const confirmUpdateResult = useRef<
+    ICheckAllFirmwareReleaseResult | undefined
+  >();
 
   /*
      await backgroundApiProxy.serviceFirmwareUpdate.startFirmwareUpdateWorkflow(
@@ -84,6 +89,10 @@ function PageFirmwareUpdateChangeLog() {
   );
 
   const content = useMemo(() => {
+    // keep change log modal content when install modal back
+    if (confirmUpdateResult.current) {
+      return <FirmwareChangeLogView result={confirmUpdateResult.current} />;
+    }
     if (isLoading) {
       return (
         <>
@@ -109,7 +118,14 @@ function PageFirmwareUpdateChangeLog() {
       stepInfo.step === EFirmwareUpdateSteps.showChangeLog ||
       stepInfo.step === EFirmwareUpdateSteps.showCheckList
     ) {
-      return <FirmwareChangeLogView result={result} />;
+      return (
+        <FirmwareChangeLogView
+          result={result}
+          onConfirmClick={() => {
+            confirmUpdateResult.current = result;
+          }}
+        />
+      );
     }
     return <FirmwareLatestVersionInstalled />;
   }, [connectId, isLoading, result, run, stepInfo.payload, stepInfo.step]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在固件更新日志视图中添加了可选的确认点击回调功能。
  - 更新了导航逻辑，以确保在确认对话框关闭后正确导航到安装屏幕。

- **改进**
  - 增强了对当前语言环境的管理，确保在固件更新过程中更好地处理错误信息和状态。

- **错误修复**
  - 修复了固件安装过程中与重试信息相关的逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->