### PR TITLE
fix: disable ext bg sync storage

### DIFF
--- a/packages/shared/src/storage/syncStorage.ts
+++ b/packages/shared/src/storage/syncStorage.ts
@@ -1,11 +1,13 @@
 import { isPlainObject } from 'lodash';
 
+import platformEnv from '../platformEnv';
 import resetUtils from '../utils/resetUtils';
 
 import mmkvStorageInstance from './instance/mmkvStorageInstance';
 
 import type { AsyncStorageStatic } from '@react-native-async-storage/async-storage';
 
+// sync storage does not support extension background, don't use it in production, but only for development
 export enum EAppSyncStorageKeys {
   rrt = 'rrt',
   perf_switch = 'perf_switch',
@@ -14,8 +16,9 @@ export enum EAppSyncStorageKeys {
   onekey_perf_timer_log_config = 'onekey_perf_timer_log_config',
 }
 
-export const syncStorage = {
+const syncStorageWeb = {
   set(key: EAppSyncStorageKeys, value: boolean | string | number) {
+
     resetUtils.checkNotInResetting();
     mmkvStorageInstance.set(key, value);
   },
@@ -57,8 +60,51 @@ export const syncStorage = {
   },
 };
 
+const syncStorageExtBg: typeof syncStorageWeb = {
+  set(key: EAppSyncStorageKeys, value: boolean | string | number): void {
+    // do nothing
+  },
+  setObject<T extends Record<string, any>>(
+    key: EAppSyncStorageKeys,
+    value: T,
+  ): void {
+    // do nothing
+  },
+  getObject<T>(key: EAppSyncStorageKeys): T | undefined {
+    // do nothing
+    return undefined;
+  },
+  getString(key: EAppSyncStorageKeys): string | undefined {
+    // do nothing
+    return undefined;
+  },
+  getNumber(key: EAppSyncStorageKeys): number | undefined {
+    // do nothing
+    return undefined;
+  },
+  getBoolean(key: EAppSyncStorageKeys): boolean | undefined {
+    // do nothing
+    return undefined;
+  },
+  delete(key: EAppSyncStorageKeys): void {
+    // do nothing
+  },
+  clearAll(): void {
+    // do nothing
+  },
+  getAllKeys(): string[] {
+    // do nothing
+    return [];
+  },
+};
+
+// eslint-disable-next-line import/no-named-as-default-member
+export const syncStorage = platformEnv.isExtensionBackgroundServiceWorker
+  ? syncStorageExtBg
+  : syncStorageWeb;
+
 export interface IAppStorage extends AsyncStorageStatic {
-  syncStorage: typeof syncStorage;
+  syncStorage: typeof syncStorageWeb;
 }
 
 export const buildAppStorageFactory = (

--- a/packages/shared/src/utils/assertUtils.ts
+++ b/packages/shared/src/utils/assertUtils.ts
@@ -16,6 +16,7 @@ import { EAppSyncStorageKeys } from '../storage/syncStorage';
 
 import { isPromiseObject } from './promiseUtils';
 import timerUtils from './timerUtils';
+import errorUtils from '../errors/utils/errorUtils';
 
 type IErrorType = undefined | string | Error;
 
@@ -100,24 +101,29 @@ export function toggleBgApiSerializableChecking(enabled: boolean) {
   );
 }
 export function isBgApiSerializableCheckingDisabled() {
-  const data =
-    appStorage.syncStorage.getObject<ISerializableCheckingDisabledConfig>(
-      EAppSyncStorageKeys.onekey_disable_bg_api_serializable_checking,
-    );
-  if (!data) {
+  try {
+    const data =
+      appStorage.syncStorage.getObject<ISerializableCheckingDisabledConfig>(
+        EAppSyncStorageKeys.onekey_disable_bg_api_serializable_checking,
+      );
+    if (!data) {
+      return false;
+    }
+    if (
+      data.updateAt &&
+      Date.now() - data.updateAt >
+        timerUtils.getTimeDurationMs({
+          day: 1,
+        })
+    ) {
+      // 1 day
+      return false;
+    }
+    return Boolean(data.disabled);
+  } catch (error) {
+    errorUtils.autoPrintErrorIgnore(error);
     return false;
   }
-  if (
-    data.updateAt &&
-    Date.now() - data.updateAt >
-      timerUtils.getTimeDurationMs({
-        day: 1,
-      })
-  ) {
-    // 1 day
-    return false;
-  }
-  return Boolean(data.disabled);
 }
 export function ensureSerializable(
   obj: any,

--- a/packages/shared/src/utils/perfUtils.ts
+++ b/packages/shared/src/utils/perfUtils.ts
@@ -4,6 +4,7 @@ import appStorage from '../storage/appStorage';
 import { EAppSyncStorageKeys } from '../storage/syncStorage';
 
 import { formatDateFns } from './dateUtils';
+import errorUtils from '../errors/utils/errorUtils';
 
 export enum EPerformanceTimerLogNames {
   localDB__getAccount = 'localDB__getAccount',
@@ -18,11 +19,16 @@ export enum EPerformanceTimerLogNames {
 }
 
 function getPerformanceTimerLogConfigMap() {
-  return (
-    appStorage.syncStorage.getObject<Record<string, boolean>>(
-      EAppSyncStorageKeys.onekey_perf_timer_log_config,
-    ) ?? {}
-  );
+  try {
+    return (
+      appStorage.syncStorage.getObject<Record<string, boolean>>(
+        EAppSyncStorageKeys.onekey_perf_timer_log_config,
+      ) ?? {}
+    );
+  } catch (error) {
+    errorUtils.autoPrintErrorIgnore(error);
+    return {};
+  }
 }
 
 function updatePerformanceTimerLogConfig(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 引入了 `syncStorageWeb` 和 `syncStorageExtBg` 常量，以增强存储管理功能，支持不同平台的操作。
  
- **错误修复**
  - 在 `isBgApiSerializableCheckingDisabled` 和 `getPerformanceTimerLogConfigMap` 函数中添加了错误处理机制，确保在出现错误时应用能够正常运行。

- **文档**
  - 更新了 `IAppStorage` 接口，以反映新的 `syncStorageWeb` 结构。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->