### PR TITLE
fix: notification account limit

### DIFF
--- a/packages/components/src/actions/Alert/index.tsx
+++ b/packages/components/src/actions/Alert/index.tsx
@@ -128,7 +128,7 @@ export const Alert = AlertFrame.styleable<IAlertProps>((props, ref) => {
   const onClose = useCallback(() => {
     setShow(false);
     onCloseProp?.();
-  }, []);
+  }, [onCloseProp]);
 
   if (!show) return null;
 

--- a/packages/components/src/actions/Alert/index.tsx
+++ b/packages/components/src/actions/Alert/index.tsx
@@ -46,6 +46,7 @@ export type IAlertProps = {
   title?: string;
   description?: string;
   closable?: boolean;
+  onClose?: () => void;
   icon?: IKeyOfIcons;
   action?: IAlertActionProps;
 };
@@ -119,11 +120,15 @@ export const Alert = AlertFrame.styleable<IAlertProps>((props, ref) => {
     type,
     fullBleed,
     action,
+    onClose: onCloseProp,
     ...rest
   } = props;
 
   const [show, setShow] = useState(true);
-  const onClose = useCallback(() => setShow(false), []);
+  const onClose = useCallback(() => {
+    setShow(false);
+    onCloseProp?.();
+  }, []);
 
   if (!show) return null;
 

--- a/packages/kit-bg/src/states/jotai/atoms/notifications.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/notifications.ts
@@ -8,6 +8,7 @@ export type INotificationsPersistAtomData = {
   lastReceivedTime: number | undefined;
   lastRegisterTime: number | undefined;
   maxAccountCount: number | undefined;
+  lastSettingsUpdateTime: number | undefined;
 };
 export const {
   target: notificationsPersistAtom,
@@ -20,6 +21,7 @@ export const {
     badge: undefined,
     lastReceivedTime: undefined,
     lastRegisterTime: undefined,
+    lastSettingsUpdateTime: undefined,
     maxAccountCount: undefined,
   },
 });

--- a/packages/kit/src/views/Setting/pages/Notifications/ManageAccountActivity.tsx
+++ b/packages/kit/src/views/Setting/pages/Notifications/ManageAccountActivity.tsx
@@ -134,7 +134,7 @@ function AccountNotificationSettingsProvider({
     ) => {
       setSettings((v) => {
         const s = buildSettings(v);
-        void backgroundApiProxy.simpleDb.notificationSettings.saveAccountActivityNotificationSettings(
+        void backgroundApiProxy.serviceNotification.saveAccountActivityNotificationSettings(
           s,
         );
         return s;
@@ -145,7 +145,7 @@ function AccountNotificationSettingsProvider({
 
   const commitSettings = useCallback(async () => {
     if (settings) {
-      await backgroundApiProxy.simpleDb.notificationSettings.saveAccountActivityNotificationSettings(
+      await backgroundApiProxy.serviceNotification.saveAccountActivityNotificationSettings(
         settings,
       );
     }
@@ -200,7 +200,7 @@ function AccountNotificationSettingsProvider({
       const savedSettings =
         await backgroundApiProxy.simpleDb.notificationSettings.getRawData();
       if (savedSettings) {
-        setSettings(savedSettings.accountActivityV2);
+        setSettings(savedSettings.accountActivity);
       }
     })();
   }, []);
@@ -223,9 +223,10 @@ function useContextAccountNotificationSettings() {
 }
 
 function formatSavedEnabledValue(value: boolean) {
-  return value === NOTIFICATION_ACCOUNT_ACTIVITY_DEFAULT_ENABLED
-    ? undefined
-    : value;
+  return value;
+  // return value === NOTIFICATION_ACCOUNT_ACTIVITY_DEFAULT_ENABLED
+  //   ? undefined
+  // : value;
 }
 
 function AccordionItem({

--- a/packages/kit/src/views/Setting/pages/Notifications/NotificationsSettings.tsx
+++ b/packages/kit/src/views/Setting/pages/Notifications/NotificationsSettings.tsx
@@ -51,7 +51,7 @@ export default function NotificationsSettings() {
     async (updated?: INotificationPushSettings) => {
       const result =
         updated ||
-        (await backgroundApiProxy.serviceNotification.fetchNotificationSettings());
+        (await backgroundApiProxy.serviceNotification.fetchServerNotificationSettings());
       setSettings(result);
       prevSettings.current = result;
     },
@@ -68,7 +68,7 @@ export default function NotificationsSettings() {
       let updated: INotificationPushSettings | undefined;
       try {
         updated =
-          await backgroundApiProxy.serviceNotification.updateNotificationSettings(
+          await backgroundApiProxy.serviceNotification.updateServerNotificationSettings(
             {
               ...settings,
               ...partSettings,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 在警报组件中添加了可选的`onClose`回调属性，以便在警报关闭时执行自定义逻辑。
	- 新增`MaxAccountLimitWarning`组件，当启用的账户数量达到限制时显示警告。
	- 在`ManageAccountActivity`组件中，添加了确认对话框以处理账户启用的最大限制。

- **功能增强**
	- 更新通知设置管理，使用新的方法名以反映服务器交互。
	- 添加`getEnabledAccountCount`方法，以计算启用账户的数量。
	- 简化了账户活动通知设置的保存逻辑。

- **文档**
	- 更新了相关方法的调用，确保与新的通知设置结构一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->