### PR TITLE
Fix/swap history accountinfo ok-33880 ok-33833

### DIFF
--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -272,10 +272,18 @@ export function useSwapBuildTx() {
         sender: {
           amount: selectQuote?.fromAmount,
           token: fromToken,
+          accountInfo: {
+            accountId: swapFromAddressInfo.accountInfo?.account?.id,
+            networkId: fromToken.networkId,
+          },
         },
         receiver: {
           amount: selectQuote.toAmount,
           token: toToken,
+          accountInfo: {
+            accountId: swapToAddressInfo.accountInfo?.account?.id,
+            networkId: toToken.networkId,
+          },
         },
         accountAddress: swapFromAddressInfo.address,
         receivingAddress: swapToAddressInfo.address,
@@ -298,7 +306,9 @@ export function useSwapBuildTx() {
     selectQuote,
     swapFromAddressInfo.address,
     swapFromAddressInfo.networkId,
+    swapFromAddressInfo.accountInfo?.account?.id,
     swapToAddressInfo.address,
+    swapToAddressInfo.accountInfo?.account?.id,
     setSwapBuildTxFetching,
     navigationToSendConfirm,
     handleBuildTxSuccess,
@@ -481,10 +491,18 @@ export function useSwapBuildTx() {
             sender: {
               amount: selectQuote.fromAmount,
               token: fromToken,
+              accountInfo: {
+                accountId: swapFromAddressInfo.accountInfo?.account?.id,
+                networkId: fromToken.networkId,
+              },
             },
             receiver: {
               amount: selectQuote.toAmount,
               token: toToken,
+              accountInfo: {
+                accountId: swapToAddressInfo.accountInfo?.account?.id,
+                networkId: toToken.networkId,
+              },
             },
             accountAddress: swapFromAddressInfo.address,
             receivingAddress: swapToAddressInfo.address,
@@ -506,6 +524,7 @@ export function useSwapBuildTx() {
     swapFromAddressInfo.networkId,
     swapFromAddressInfo.accountInfo?.account?.id,
     swapToAddressInfo.address,
+    swapToAddressInfo.accountInfo?.account?.id,
     checkOtherFee,
     intl,
   ]);

--- a/packages/kit/src/views/Swap/hooks/useSwapTxHistory.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapTxHistory.ts
@@ -37,6 +37,16 @@ export function useSwapTxHistoryActions() {
         const swapHistoryItem: ISwapTxHistory = {
           status: ESwapTxHistoryStatus.PENDING,
           currency: settingsAtom.currencyInfo.symbol,
+          accountInfo: {
+            sender: {
+              accountId: swapTxInfo.sender.accountInfo?.accountId,
+              networkId: swapTxInfo.sender.accountInfo.networkId,
+            },
+            receiver: {
+              accountId: swapTxInfo.receiver.accountInfo?.accountId,
+              networkId: swapTxInfo.receiver.accountInfo.networkId,
+            },
+          },
           baseInfo: {
             toAmount: swapTxInfo.receiver.amount,
             fromAmount: swapTxInfo.sender.amount,

--- a/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
@@ -109,7 +109,10 @@ const SwapInputContainer = ({
         hasError={fromInputHasError}
         balanceProps={{
           value: balance,
-          onPress: onBalanceMaxPress,
+          onPress:
+            direction === ESwapDirectionType.FROM && !token?.isNative
+              ? onBalanceMaxPress
+              : undefined,
         }}
         valueProps={{
           value: amountPrice,

--- a/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
@@ -19,6 +19,7 @@ import {
   useMedia,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { AddressInfo } from '@onekeyhq/kit/src/components/AddressInfo';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import useFormatDate from '@onekeyhq/kit/src/hooks/useFormatDate';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -294,12 +295,26 @@ const SwapHistoryDetailModal = () => {
               })}
               renderContent={txHistory.txInfo.sender}
               showCopy
+              description={
+                <AddressInfo
+                  address={txHistory.txInfo.sender}
+                  networkId={txHistory.accountInfo?.sender.networkId}
+                  accountId={txHistory.accountInfo?.sender.accountId}
+                />
+              }
             />
             <InfoItem
               label={intl.formatMessage({
                 id: ETranslations.swap_history_detail_received_address,
               })}
               renderContent={txHistory.txInfo.receiver}
+              description={
+                <AddressInfo
+                  address={txHistory.txInfo.receiver}
+                  networkId={txHistory.accountInfo?.receiver.networkId}
+                  accountId={txHistory.accountInfo?.receiver.accountId}
+                />
+              }
               showCopy
             />
             <InfoItem

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -438,6 +438,10 @@ export interface IFetchBuildTxResponse {
 export interface ISwapInfoSide {
   amount: string;
   token: ISwapToken;
+  accountInfo: {
+    accountId?: string;
+    networkId: string;
+  };
 }
 export interface ISwapTxInfo {
   sender: ISwapInfoSide;
@@ -507,6 +511,16 @@ export interface ISwapTxHistory {
   status: ESwapTxHistoryStatus;
   ctx?: any;
   currency?: string;
+  accountInfo: {
+    sender: {
+      accountId?: string;
+      networkId: string;
+    };
+    receiver: {
+      accountId?: string;
+      networkId: string;
+    };
+  };
   baseInfo: {
     fromToken: ISwapToken;
     toToken: ISwapToken;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在交易构建和历史记录中添加了账户信息，包括账户ID和网络ID，以增强用户的交易透明度。
	- 在交换历史详情模态中引入了地址信息组件，提供更详细的发送者和接收者地址展示。

- **Bug修复**
	- 更新了余额最大按键的处理逻辑，以确保在特定条件下正确响应用户操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->