### PR TITLE
fix: Fetch server network error

### DIFF
--- a/packages/shared/src/logger/scopes/account/scenes/wallet.ts
+++ b/packages/shared/src/logger/scopes/account/scenes/wallet.ts
@@ -125,4 +125,21 @@ export class WalletScene extends BaseScene {
       chainId: network.chainId,
     }));
   }
+
+  @LogToLocal()
+  public getServerNetworksError(error: any) {
+    let errorMessage = 'Unknown error';
+
+    if (error instanceof Error) {
+      errorMessage = error.message;
+    } else if (typeof error === 'string') {
+      errorMessage = error;
+    } else if (error && typeof error === 'object') {
+      errorMessage = JSON.stringify(error);
+    }
+
+    return {
+      error: errorMessage,
+    };
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在 `WalletScene` 类中添加了 `getServerNetworksError` 方法，用于构建和返回错误消息。
  
- **错误修复**
  - 增强了 `getAllCustomNetworks`、`getServerNetworks` 和 `searchCustomNetworkByChainList` 方法的错误处理，确保在发生错误时返回空数组或 null，而不是抛出异常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->