### PR TITLE
Browser / history modal empty state

### DIFF
--- a/packages/kit/src/views/Discovery/pages/BookmarkListModal/index.tsx
+++ b/packages/kit/src/views/Discovery/pages/BookmarkListModal/index.tsx
@@ -154,115 +154,6 @@ function BookmarkListModal() {
   );
   const { gtMd } = useMedia();
 
-  const renderContent = () => {
-    if (!dataSource.length) {
-      return (
-        <Empty
-          flex={1}
-          pb="$16"
-          icon="BookmarkOutline"
-          title={intl.formatMessage({
-            // eslint-disable-next-line spellcheck/spell-checker
-            id: ETranslations.explore_no_boomark,
-          })}
-        />
-      );
-    }
-
-    return (
-      <SortableListView
-        data={dataSource}
-        enabled={isEditing}
-        keyExtractor={(item) => `${item.url}`}
-        getItemLayout={(_, index) => ({
-          length: CELL_HEIGHT,
-          offset: index * CELL_HEIGHT,
-          index,
-        })}
-        onDragEnd={(ret) => onSortBookmarks(ret.data)}
-        renderItem={({ item, getIndex, drag, dragProps }) => (
-          <ListItem
-            h={CELL_HEIGHT}
-            testID={`search-modal-${item.url.toLowerCase()}`}
-            {...(!isEditing && {
-              onPress: () => {
-                handleOpenWebSite({
-                  navigation,
-                  switchToMultiTabBrowser: gtMd,
-                  webSite: {
-                    url: item.url,
-                    title: item.title,
-                  },
-                });
-                defaultLogger.discovery.dapp.enterDapp({
-                  dappDomain: item.url,
-                  dappName: item.title,
-                  enterMethod: EEnterMethod.bookmark,
-                });
-              },
-            })}
-          >
-            {isEditing ? (
-              <ListItem.IconButton
-                title={intl.formatMessage({
-                  id: ETranslations.global_remove,
-                })}
-                key="remove"
-                icon="MinusCircleSolid"
-                iconProps={{
-                  color: '$iconCritical',
-                }}
-                onPress={() => {
-                  void deleteCell(getIndex);
-                  Toast.success({
-                    title: intl.formatMessage({
-                      id: ETranslations.explore_removed_success,
-                    }),
-                  });
-                }}
-                testID="action-list-item-rename"
-              />
-            ) : null}
-            <ListItem.Avatar
-              avatar={<DiscoveryIcon size="$10" uri={item.logo} />}
-            />
-            <ListItem.Text
-              primary={item.title}
-              primaryTextProps={{
-                numberOfLines: 1,
-              }}
-              secondary={item.url}
-              secondaryTextProps={{
-                numberOfLines: 1,
-              }}
-              flex={1}
-            />
-            {isEditing ? (
-              <XStack gap="$6">
-                <ListItem.IconButton
-                  title={intl.formatMessage({
-                    id: ETranslations.explore_rename,
-                  })}
-                  key="rename"
-                  icon="PencilOutline"
-                  onPress={() => onRename(item)}
-                  testID="action-list-item-rename"
-                />
-                <ListItem.IconButton
-                  key="darg"
-                  cursor="move"
-                  icon="DragOutline"
-                  onPressIn={drag}
-                  dataSet={dragProps}
-                />
-              </XStack>
-            ) : null}
-          </ListItem>
-        )}
-      />
-    );
-  };
-
   return (
     <Page>
       <Page.Header
@@ -271,7 +162,109 @@ function BookmarkListModal() {
         })}
         headerRight={headerRight}
       />
-      <Page.Body>{renderContent()}</Page.Body>
+      <Page.Body>
+        <SortableListView
+          data={dataSource}
+          enabled={isEditing}
+          keyExtractor={(item) => `${item.url}`}
+          getItemLayout={(_, index) => ({
+            length: CELL_HEIGHT,
+            offset: index * CELL_HEIGHT,
+            index,
+          })}
+          onDragEnd={(ret) => onSortBookmarks(ret.data)}
+          ListEmptyComponent={
+            <Empty
+              py="$32"
+              my="$4"
+              icon="BookmarkOutline"
+              title={intl.formatMessage({
+                // eslint-disable-next-line spellcheck/spell-checker
+                id: ETranslations.explore_no_boomark,
+              })}
+            />
+          }
+          renderItem={({ item, getIndex, drag, dragProps }) => (
+            <ListItem
+              h={CELL_HEIGHT}
+              testID={`search-modal-${item.url.toLowerCase()}`}
+              {...(!isEditing && {
+                onPress: () => {
+                  handleOpenWebSite({
+                    navigation,
+                    switchToMultiTabBrowser: gtMd,
+                    webSite: {
+                      url: item.url,
+                      title: item.title,
+                    },
+                  });
+                  defaultLogger.discovery.dapp.enterDapp({
+                    dappDomain: item.url,
+                    dappName: item.title,
+                    enterMethod: EEnterMethod.bookmark,
+                  });
+                },
+              })}
+            >
+              {isEditing ? (
+                <ListItem.IconButton
+                  title={intl.formatMessage({
+                    id: ETranslations.global_remove,
+                  })}
+                  key="remove"
+                  icon="MinusCircleSolid"
+                  iconProps={{
+                    color: '$iconCritical',
+                  }}
+                  onPress={() => {
+                    void deleteCell(getIndex);
+                    Toast.success({
+                      title: intl.formatMessage({
+                        id: ETranslations.explore_removed_success,
+                      }),
+                    });
+                  }}
+                  testID="action-list-item-rename"
+                />
+              ) : null}
+              <ListItem.Avatar
+                avatar={<DiscoveryIcon size="$10" uri={item.logo} />}
+              />
+              <ListItem.Text
+                primary={item.title}
+                primaryTextProps={{
+                  numberOfLines: 1,
+                }}
+                secondary={item.url}
+                secondaryTextProps={{
+                  numberOfLines: 1,
+                }}
+                flex={1}
+              />
+              {isEditing ? (
+                <XStack gap="$6">
+                  <ListItem.IconButton
+                    title={intl.formatMessage({
+                      id: ETranslations.explore_rename,
+                    })}
+                    key="rename"
+                    icon="PencilOutline"
+                    onPress={() => onRename(item)}
+                    testID="action-list-item-rename"
+                  />
+                  <ListItem.IconButton
+                    key="darg"
+                    cursor="move"
+                    icon="DragOutline"
+                    onPressIn={drag}
+                    dataSet={dragProps}
+                  />
+                </XStack>
+              ) : null}
+            </ListItem>
+          )}
+        />
+      </Page.Body>
     </Page>
   );
 }

--- a/packages/kit/src/views/Discovery/pages/HistoryListModal/index.tsx
+++ b/packages/kit/src/views/Discovery/pages/HistoryListModal/index.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   Dialog,
   Divider,
+  Empty,
   IconButton,
   Page,
   SectionList,
@@ -149,6 +150,16 @@ function HistoryListModal() {
         <SectionList
           testID="History-SectionList"
           height="100%"
+          ListEmptyComponent={
+            <Empty
+              py="$32"
+              my="$4"
+              icon="ClockTimeHistoryOutline"
+              title={intl.formatMessage({
+                id: ETranslations.explore_no_history,
+              })}
+            />
+          }
           estimatedItemSize="$16"
           extraData={isEditing}
           sections={isNil(dataSource) ? [] : dataSource}


### PR DESCRIPTION
![CleanShot 2024-11-21 at 19 04 29@2x](https://github.com/user-attachments/assets/7675e3d5-c6d5-4947-9a72-e8d0270a287a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在书签列表模态框中集成了空状态处理，优化了无书签时的用户反馈。
	- 在历史记录模态框中添加了空状态组件，以便在没有浏览历史时提供清晰提示。

- **改进**
	- 简化了书签列表的渲染逻辑，提高了组件的可维护性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->