### PR TITLE
fix: load new account assets error in all networks

### DIFF
--- a/packages/kit/src/views/Home/pages/NFTListContainer.tsx
+++ b/packages/kit/src/views/Home/pages/NFTListContainer.tsx
@@ -212,9 +212,10 @@ function NFTListContainer(props: ITabPageProps) {
     result: allNetworksResult,
     isEmptyAccount,
   } = useAllNetworkRequests<IFetchAccountNFTsResp>({
-    account,
-    network,
-    wallet,
+    accountId: account?.id,
+    networkId: network?.id,
+    walletId: wallet?.id,
+    isAllNetworks: network?.isAllNetworks,
     allNetworkRequests: handleAllNetworkRequests,
     allNetworkCacheRequests: handleAllNetworkCacheRequests,
     allNetworkCacheData: handleAllNetworkCacheData,

--- a/packages/kit/src/views/Home/pages/TokenListContainer.tsx
+++ b/packages/kit/src/views/Home/pages/TokenListContainer.tsx
@@ -787,9 +787,10 @@ function TokenListContainer(props: ITabPageProps) {
     result: allNetworksResult,
     isEmptyAccount,
   } = useAllNetworkRequests<IFetchAccountTokensResp>({
-    account,
-    network,
-    wallet,
+    accountId: account?.id,
+    networkId: network?.id,
+    walletId: wallet?.id,
+    isAllNetworks: network?.isAllNetworks,
     allNetworkRequests: handleAllNetworkRequests,
     allNetworkCacheRequests: handleAllNetworkCacheRequests,
     allNetworkCacheData: handleAllNetworkCacheData,

--- a/packages/kit/src/views/Home/pages/TokenListContainerPerfTest.tsx
+++ b/packages/kit/src/views/Home/pages/TokenListContainerPerfTest.tsx
@@ -99,9 +99,10 @@ export function TokenListContainerPerfTest(props: ITabPageProps) {
   }, [setOverview]);
 
   useAllNetworkRequests<IFetchAccountTokensResp>({
-    account,
-    network,
-    wallet,
+    accountId: account?.id,
+    networkId: network?.id,
+    walletId: wallet?.id,
+    isAllNetworks: network?.isAllNetworks,
     allNetworkRequests: empty as any,
     allNetworkCacheRequests: handleAllNetworkCacheRequests,
     allNetworkCacheData: handleAllNetworkCacheData,

--- a/packages/kit/src/views/Home/pages/TxHistoryContainer.tsx
+++ b/packages/kit/src/views/Home/pages/TxHistoryContainer.tsx
@@ -17,14 +17,11 @@ import {
   EModalAssetDetailRoutes,
   EModalRoutes,
 } from '@onekeyhq/shared/src/routes';
-// import { sortHistoryTxsByTime } from '@onekeyhq/shared/src/utils/historyUtils';
-import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { EHomeTab } from '@onekeyhq/shared/types';
 import type { IAccountHistoryTx } from '@onekeyhq/shared/types/history';
 import { EDecodedTxStatus } from '@onekeyhq/shared/types/tx';
 
 import { TxHistoryListView } from '../../../components/TxHistoryListView';
-// import { useAllNetworkRequests } from '../../../hooks/useAllNetwork';
 import useAppNavigation from '../../../hooks/useAppNavigation';
 import { usePromiseResult } from '../../../hooks/usePromiseResult';
 import { useAccountOverviewActions } from '../../../states/jotai/contexts/accountOverview';

--- a/packages/kit/src/views/WalletAddress/pages/WalletAddress/index.tsx
+++ b/packages/kit/src/views/WalletAddress/pages/WalletAddress/index.tsx
@@ -29,9 +29,6 @@ import {
   XStack,
   useSafeAreaInsets,
 } from '@onekeyhq/components';
-import type { IAllNetworksDBStruct } from '@onekeyhq/kit-bg/src/dbs/simple/entity/SimpleDbEntityAllNetworks';
-import type { IAllNetworkAccountInfo } from '@onekeyhq/kit-bg/src/services/ServiceAllNetwork/ServiceAllNetwork';
-import type { IAccountDeriveTypes } from '@onekeyhq/kit-bg/src/vaults/types';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import { useAccountSelectorCreateAddress } from '@onekeyhq/kit/src/components/AccountSelector/hooks/useAccountSelectorCreateAddress';
@@ -41,6 +38,9 @@ import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useCopyAccountAddress } from '@onekeyhq/kit/src/hooks/useCopyAccountAddress';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useFuseSearch } from '@onekeyhq/kit/src/views/ChainSelector/hooks/useFuseSearch';
+import type { IAllNetworksDBStruct } from '@onekeyhq/kit-bg/src/dbs/simple/entity/SimpleDbEntityAllNetworks';
+import type { IAllNetworkAccountInfo } from '@onekeyhq/kit-bg/src/services/ServiceAllNetwork/ServiceAllNetwork';
+import type { IAccountDeriveTypes } from '@onekeyhq/kit-bg/src/vaults/types';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import {
   EAppEventBusNames,

--- a/packages/kit/src/views/WalletAddress/pages/WalletAddress/index.tsx
+++ b/packages/kit/src/views/WalletAddress/pages/WalletAddress/index.tsx
@@ -769,9 +769,7 @@ function WalletAddress({
       ).length > 0
     ) {
       // TODO performance, always emit when Modal open
-      setTimeout(() => {
-        appEventBus.emit(EAppEventBusNames.AccountDataUpdate, undefined);
-      }, 100);
+      appEventBus.emit(EAppEventBusNames.AccountDataUpdate, undefined);
     }
   }, [
     accountsCreated,

--- a/packages/kit/src/views/WalletAddress/pages/WalletAddress/index.tsx
+++ b/packages/kit/src/views/WalletAddress/pages/WalletAddress/index.tsx
@@ -771,7 +771,7 @@ function WalletAddress({
       // TODO performance, always emit when Modal open
       setTimeout(() => {
         appEventBus.emit(EAppEventBusNames.AccountDataUpdate, undefined);
-      }, 300);
+      }, 100);
     }
   }, [
     accountsCreated,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了多个组件以使用更明确的参数标识符（如 `accountId`、`networkId`、`walletId` 和 `isAllNetworks`），增强了网络请求的清晰性和可读性。
	- 改进了 NFT 列表和代币列表的处理逻辑，确保在更新时避免重复项并优化状态管理。

- **错误修复**
	- 修复了处理空状态时的逻辑，确保在没有本地 NFT 或代币时返回 `null`。

- **文档**
	- 更新了交易历史管理的逻辑，简化了事件处理和数据刷新机制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->