### PR TITLE
chore: etrieve the SENTRY_DISABLE_AUTO_UPLOAD variable from system env during Android build.

### DIFF
--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -14,7 +14,7 @@ sentry {
     // for Sentry. This executes sentry-cli automatically so
     // you don't need to do it manually.
     // Default is disabled.
-    uploadNativeSymbols = true
+    uploadNativeSymbols = System.getenv("SENTRY_DISABLE_AUTO_UPLOAD") != "true"
 
     // Enables or disables the automatic upload of the app's native source code to Sentry.
     // This executes sentry-cli with the --include-sources param automatically so


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 更新了Sentry集成的配置，允许根据环境变量灵活控制本机符号的上传。

- **修复**
	- 通过环境变量替代硬编码的值，改进了上传行为的条件逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->