### PR TITLE
fix: swap tron use multiple pop  ok-34223

### DIFF
--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -33,6 +33,7 @@ import {
   EProtocolOfExchange,
   ESwapApproveTransactionStatus,
   ESwapDirectionType,
+  SwapBuildUseMultiplePopoversNetworkIds,
 } from '@onekeyhq/shared/types/swap/types';
 import type { ISendTxOnSuccessData } from '@onekeyhq/shared/types/tx';
 
@@ -569,7 +570,10 @@ export function useSwapBuildTx() {
                 }) ||
                 accountUtils.isOthersAccount({
                   accountId: swapFromAddressInfo.accountInfo.account.id,
-                })
+                }) ||
+                SwapBuildUseMultiplePopoversNetworkIds.includes(
+                  fromToken.networkId,
+                )
               ) {
                 await navigationToSendConfirm({
                   approvesInfo: [approvesInfo[0]],
@@ -578,7 +582,13 @@ export function useSwapBuildTx() {
                     if (approvesInfo.length > 1) {
                       await navigationToSendConfirm({
                         approvesInfo: [approvesInfo[1]],
-                        feeInfo: data?.[0]?.feeInfo,
+                        // tron network does not support use pre fee info
+                        feeInfo:
+                          SwapBuildUseMultiplePopoversNetworkIds.includes(
+                            fromToken.networkId,
+                          )
+                            ? undefined
+                            : data?.[0]?.feeInfo,
                         isInternalSwap: true,
                         onSuccess: async (dataRes: ISendTxOnSuccessData[]) => {
                           await navigationToSendConfirm({
@@ -586,7 +596,12 @@ export function useSwapBuildTx() {
                               ? [createBuildTxRes.transferInfo]
                               : undefined,
                             encodedTx: createBuildTxRes.encodedTx,
-                            feeInfo: dataRes?.[0]?.feeInfo,
+                            feeInfo:
+                              SwapBuildUseMultiplePopoversNetworkIds.includes(
+                                fromToken.networkId,
+                              )
+                                ? undefined
+                                : dataRes?.[0]?.feeInfo,
                             swapInfo: createBuildTxRes.swapInfo,
                             isInternalSwap: true,
                             onSuccess: handleBuildTxSuccess,
@@ -602,7 +617,12 @@ export function useSwapBuildTx() {
                           : undefined,
                         encodedTx: createBuildTxRes.encodedTx,
                         swapInfo: createBuildTxRes.swapInfo,
-                        feeInfo: data?.[0]?.feeInfo,
+                        feeInfo:
+                          SwapBuildUseMultiplePopoversNetworkIds.includes(
+                            fromToken.networkId,
+                          )
+                            ? undefined
+                            : data?.[0]?.feeInfo,
                         isInternalSwap: true,
                         onSuccess: handleBuildTxSuccess,
                         onCancel: cancelBuildTx,

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -574,3 +574,5 @@ export enum ESwapSlippageCustomStatus {
   ERROR = 'error',
   WRONG = 'wrong',
 }
+
+export const SwapBuildUseMultiplePopoversNetworkIds = ['tron--0x2b6653dc'];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 引入新的常量 `SwapBuildUseMultiplePopoversNetworkIds`，用于处理与交易确认相关的费用信息。
  
- **改进**
  - 修改了交易批准逻辑，以根据网络 ID 条件处理费用信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->