### PR TITLE
fix: swap deriveType logic opt ok-34372

### DIFF
--- a/packages/kit/src/components/AccountSelector/DeriveTypeSelectorTrigger.tsx
+++ b/packages/kit/src/components/AccountSelector/DeriveTypeSelectorTrigger.tsx
@@ -293,7 +293,7 @@ export function DeriveTypeSelectorTriggerForSwap({ num }: { num: number }) {
       renderTrigger={({ label, onPress }) => (
         <DeriveTypeSelectorTriggerIconRenderer
           label={label}
-          autoShowLabel
+          autoShowLabel={false}
           onPress={onPress}
           iconProps={{
             size: '$4',

--- a/packages/kit/src/views/Swap/pages/components/SwapAccountAddressContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapAccountAddressContainer.tsx
@@ -98,7 +98,7 @@ const SwapAccountAddressContainer = ({
         })}
       </SizableText>
       {networkComponent}
-      {type === ESwapDirectionType.FROM ? (
+      {type === ESwapDirectionType.FROM && !!fromToken ? (
         <DeriveTypeSelectorTriggerForSwap num={0} />
       ) : null}
     </XStack>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了交换功能中的 `DeriveTypeSelectorTriggerForSwap` 组件的标签显示逻辑，标签将不再自动显示。
	- 修改了 `SwapAccountAddressContainer` 组件的条件渲染逻辑，确保在 `fromToken` 存在时才渲染 `DeriveTypeSelectorTriggerForSwap` 组件。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->