### PR TITLE
fix: percentage btn opt for mobile ok-34386

### DIFF
--- a/packages/components/src/hocs/PageType/index.tsx
+++ b/packages/components/src/hocs/PageType/index.tsx
@@ -40,5 +40,5 @@ export const PageTypeHOC = (
 
 export const usePageType = () => {
   const pageTypeContext = useContext(PageTypeContext);
-  return pageTypeContext.pageType;
+  return pageTypeContext.pageType as EPageType;
 };

--- a/packages/kit/src/views/Swap/components/SwapPercentageStageBadge.tsx
+++ b/packages/kit/src/views/Swap/components/SwapPercentageStageBadge.tsx
@@ -1,0 +1,36 @@
+import { Badge } from '@onekeyhq/components';
+
+const SwapPercentageStageBadge = ({
+  stage,
+  onSelectStage,
+  key,
+  badgeSize,
+}: {
+  stage: number;
+  badgeSize?: 'sm' | 'lg';
+  onSelectStage?: (stage: number) => void;
+  key: string;
+}) => (
+  <Badge
+    key={key}
+    role="button"
+    badgeSize={badgeSize ?? 'sm'}
+    onPress={() => {
+      onSelectStage?.(stage);
+    }}
+    px="$1.5"
+    bg="$bgSubdued"
+    borderRadius="$2"
+    userSelect="none"
+    hoverStyle={{
+      bg: '$bgStrongHover',
+    }}
+    pressStyle={{
+      bg: '$bgStrongActive',
+    }}
+  >
+    <Badge.Text>{stage}%</Badge.Text>
+  </Badge>
+);
+
+export default SwapPercentageStageBadge;

--- a/packages/kit/src/views/Swap/pages/components/SwapInputActions.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapInputActions.tsx
@@ -4,8 +4,6 @@ import { useIntl } from 'react-intl';
 
 import {
   AnimatePresence,
-  Badge,
-  Button,
   Icon,
   SizableText,
   XStack,
@@ -18,6 +16,7 @@ import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 import { SwapPercentageInputStage } from '@onekeyhq/shared/types/swap/types';
 
 import ActionBuy from '../../../AssetDetails/pages/TokenDetails/ActionBuy';
+import SwapPercentageStageBadge from '../../components/SwapPercentageStageBadge';
 
 const SwapInputActions = ({
   showPercentageInput,
@@ -61,6 +60,7 @@ const SwapInputActions = ({
             height="$5"
             px="$1.5"
             py="$0"
+            pt="$1"
             bg="$bgSubdued"
             size="small"
             label={
@@ -77,29 +77,14 @@ const SwapInputActions = ({
             tokenAddress={fromToken?.contractAddress ?? ''}
           />
         ) : null}
-        {showPercentageInput ? (
+        {!platformEnv.isNative && showPercentageInput ? (
           <>
             {needSwapPercentageInputStage.map((stage) => (
-              <Badge
+              <SwapPercentageStageBadge
                 key={`swap-percentage-input-stage-${stage}`}
-                role="button"
-                badgeSize="sm"
-                onPress={() => {
-                  onSelectStage?.(stage);
-                }}
-                px="$1.5"
-                bg="$bgSubdued"
-                borderRadius="$2"
-                userSelect="none"
-                hoverStyle={{
-                  bg: '$bgStrongHover',
-                }}
-                pressStyle={{
-                  bg: '$bgStrongActive',
-                }}
-              >
-                <Badge.Text>{stage}%</Badge.Text>
-              </Badge>
+                stage={stage}
+                onSelectStage={onSelectStage}
+              />
             ))}
           </>
         ) : null}

--- a/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
@@ -18,6 +18,7 @@ import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 import {
   ESwapDirectionType,
   ESwapRateDifferenceUnit,
+  SwapAmountInputAccessoryViewID,
 } from '@onekeyhq/shared/types/swap/types';
 
 import { useSwapAddressInfo } from '../../hooks/useSwapAccount';
@@ -206,6 +207,13 @@ const SwapInputContainer = ({
                   caretColor: 'transparent',
                 } as any)
               : undefined,
+          inputAccessoryViewID:
+            direction === ESwapDirectionType.FROM && platformEnv.isNativeIOS
+              ? SwapAmountInputAccessoryViewID
+              : undefined,
+          autoCorrect: false,
+          spellCheck: false,
+          autoComplete: 'off',
         }}
         tokenSelectorTriggerProps={{
           loading: selectTokenLoading,

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -578,4 +578,9 @@ export enum ESwapSlippageCustomStatus {
 }
 
 export const SwapPercentageInputStage = [25, 50, 100];
+export const SwapPercentageInputStageForNative = [25, 50, 75, 100];
+
 export const SwapBuildUseMultiplePopoversNetworkIds = ['tron--0x2b6653dc'];
+
+export const SwapAmountInputAccessoryViewID =
+  'swap-amount-input-accessory-view';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 引入了新的组件 `SwapPercentageStageBadge`，允许用户选择百分比阶段。
	- 增加了 `onSelectPercentageStage` 方法，支持根据选定代币余额的百分比设置输入金额。
	- 在 iOS 平台上添加了输入辅助视图，提升用户界面体验。
	- 扩展了可用的百分比输入阶段选项，包括 25%、50%、75% 和 100%。
  
- **Bug 修复**
	- 更新了输入处理功能，改善了 iOS 用户的输入体验。 

- **文档**
	- 更新了接口以反映新的属性和方法。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->