### PR TITLE
OK-34414: Update earn order status after transaction broadcast

### DIFF
--- a/packages/kit-bg/src/providers/ProviderApiBtc.ts
+++ b/packages/kit-bg/src/providers/ProviderApiBtc.ts
@@ -15,7 +15,6 @@ import type {
   IBtcInput,
   IBtcOutput,
 } from '@onekeyhq/core/src/chains/btc/types';
-import { IEncodedTxBtc } from '@onekeyhq/core/src/chains/btc/types';
 import type { IEncodedTx, ITxInputToSign } from '@onekeyhq/core/src/types';
 import {
   backgroundClass,
@@ -564,8 +563,8 @@ class ProviderApiBtc extends ProviderApiBase {
     ) {
       inputsToSign = options.toSignInputs.map((input) => ({
         index: input.index,
-        publicKey: input.publicKey ?? '',
-        address: input.address ?? '',
+        publicKey: input.publicKey || account.pub || '',
+        address: input.address || account.address || '',
         sighashTypes: input.sighashTypes,
         disableTweakSigner: input.disableTweakSigner,
         useTweakedSigner: input.useTweakedSigner,

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -228,6 +228,19 @@ class ServiceAccount extends ServiceBase {
     return localDb.getWalletDeviceSafe({ dbWallet, walletId });
   }
 
+  @backgroundMethod()
+  async getAccountDeviceSafe({ accountId }: { accountId: string }) {
+    const walletId = accountUtils.getWalletIdFromAccountId({ accountId });
+    if (!walletId) {
+      return null;
+    }
+    const device = await this.getWalletDeviceSafe({ walletId });
+    if (!device) {
+      return null;
+    }
+    return device;
+  }
+
   // TODO move to serviceHardware
   @backgroundMethod()
   async getDevice({ dbDeviceId }: { dbDeviceId: string }) {

--- a/packages/kit-bg/src/services/ServiceStaking.ts
+++ b/packages/kit-bg/src/services/ServiceStaking.ts
@@ -1042,7 +1042,25 @@ class ServiceStaking extends ServiceBase {
   @backgroundMethod()
   async addEarnOrder(order: IAddEarnOrderParams) {
     defaultLogger.staking.order.addOrder(order);
-    return simpleDb.earnOrders.addOrder(order);
+    await simpleDb.earnOrders.addOrder(order);
+    try {
+      await this.updateEarnOrderStatusToServer({
+        order: order as IEarnOrderItem,
+      });
+    } catch (e) {
+      // ignore error, continue
+      defaultLogger.staking.order.updateOrderStatusError({
+        txId: order.txId,
+        status: order.status,
+      });
+    }
+  }
+
+  @backgroundMethod()
+  async updateSingleEarnOrderStatus({ order }: { order: IEarnOrderItem }) {
+    await this.updateEarnOrderStatusToServer({
+      order,
+    });
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceStaking.ts
+++ b/packages/kit-bg/src/services/ServiceStaking.ts
@@ -158,6 +158,25 @@ class ServiceStaking extends ServiceBase {
     return resp.data.data;
   }
 
+  private async getFirmwareDeviceTypeParam({
+    accountId,
+  }: {
+    accountId: string;
+  }) {
+    if (!accountUtils.isHwAccount({ accountId })) {
+      return undefined;
+    }
+    const device = await this.backgroundApi.serviceAccount.getAccountDeviceSafe(
+      {
+        accountId,
+      },
+    );
+    if (device?.deviceType) {
+      return device?.deviceType;
+    }
+    return undefined;
+  }
+
   @backgroundMethod()
   async buildStakeTransaction(
     params: IStakeBaseParams,
@@ -184,6 +203,9 @@ class ServiceStaking extends ServiceBase {
       networkId,
       symbol,
       provider,
+      firmwareDeviceType: await this.getFirmwareDeviceTypeParam({
+        accountId,
+      }),
       ...rest,
     });
     return resp.data.data;
@@ -209,6 +231,9 @@ class ServiceStaking extends ServiceBase {
       accountAddress: account.address,
       networkId,
       publicKey: stakingConfig.usePublicKey ? account.pub : undefined,
+      firmwareDeviceType: await this.getFirmwareDeviceTypeParam({
+        accountId,
+      }),
       ...rest,
     });
     return resp.data.data;
@@ -268,6 +293,9 @@ class ServiceStaking extends ServiceBase {
       accountAddress: account.address,
       networkId,
       publicKey: stakingConfig.usePublicKey ? account.pub : undefined,
+      firmwareDeviceType: await this.getFirmwareDeviceTypeParam({
+        accountId,
+      }),
       ...rest,
     });
     return resp.data.data;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增方法 `getAccountDeviceSafe`，用于获取与给定账户ID关联的设备。
  - 新增私有方法 `getFirmwareDeviceTypeParam`，用于根据账户ID确定固件设备类型。
  - 新增方法 `updateSingleEarnOrderStatus`，用于更新单个收益订单的状态。

- **改进**
  - 更新了多个交易构建方法，以包括固件设备类型作为请求参数。
  - 改进了订单管理过程中的错误处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->