### PR TITLE
fix: scdo send transaction type

### DIFF
--- a/packages/kit-bg/src/providers/ProviderApiScdo.ts
+++ b/packages/kit-bg/src/providers/ProviderApiScdo.ts
@@ -181,8 +181,9 @@ class ProviderApiScdo extends ProviderApiBase {
   }
 
   @providerApiMethod()
-  public scdo_sendTransaction(request: IJsBridgeMessagePayload) {
-    return this._signAndSendTransaction(request, true);
+  public async scdo_sendTransaction(request: IJsBridgeMessagePayload) {
+    const tx = await this._signAndSendTransaction(request, true);
+    return tx.Hash;
   }
 
   @providerApiMethod()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- `scdo_sendTransaction` 方法已更新为异步操作，返回交易哈希而非整个交易对象。
- **错误修复**
	- 保持了对账户验证和交易签名的错误处理机制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->