### PR TITLE
feat:  adjust the spacing and font size of banners in the Earn Module & support indicators in tradingView

### DIFF
--- a/packages/components/src/composite/Banner/index.tsx
+++ b/packages/components/src/composite/Banner/index.tsx
@@ -43,9 +43,7 @@ function BannerItem<T extends IBannerData>({
   const item = useProps(rawItem, {
     resolveValues: 'value',
   }) as T;
-  const textStyle = useStyle(item.titleTextProps || {}, {
-    resolveValues: 'auto',
-  });
+  console.log('item.titleTextProps', item.titleTextProps);
   const onItemPress = useCallback(() => {
     onPress(item);
   }, [item, onPress]);
@@ -79,7 +77,7 @@ function BannerItem<T extends IBannerData>({
               key={index}
               color={item.theme === 'dark' ? '$textDark' : '$textLight'}
               size="$headingLg"
-              {...textStyle}
+              {...item.titleTextProps}
             >
               {text}
             </SizableText>

--- a/packages/components/src/composite/Banner/index.tsx
+++ b/packages/components/src/composite/Banner/index.tsx
@@ -43,7 +43,6 @@ function BannerItem<T extends IBannerData>({
   const item = useProps(rawItem, {
     resolveValues: 'value',
   }) as T;
-  console.log('item.titleTextProps', item.titleTextProps);
   const onItemPress = useCallback(() => {
     onPress(item);
   }, [item, onPress]);

--- a/packages/kit-bg/src/services/ServiceMarket.ts
+++ b/packages/kit-bg/src/services/ServiceMarket.ts
@@ -15,6 +15,8 @@ import type {
 
 import ServiceBase from './ServiceBase';
 
+import type { AxiosResponse } from 'axios';
+
 const ONEKEY_SEARCH_TRANDING = 'onekey-search-trending';
 
 @backgroundClass()
@@ -124,10 +126,10 @@ class ServiceMarket extends ServiceBase {
           data:
             poolsData[index].status === 'fulfilled'
               ? (
-                  poolsData[index].value as {
-                    data: { data: IMarketDetailPool[] };
-                  }
-                ).data.data
+                  poolsData[index] as PromiseFulfilledResult<
+                    AxiosResponse<{ data: IMarketDetailPool[] }>
+                  >
+                ).value.data.data
               : [],
         }))
         .filter((i) => i.data.length);

--- a/packages/kit-bg/src/services/ServiceMarket.ts
+++ b/packages/kit-bg/src/services/ServiceMarket.ts
@@ -106,7 +106,7 @@ class ServiceMarket extends ServiceBase {
     const keys = Object.keys(detailPlatforms);
     const client = await this.getClient(EServiceEndpointEnum.Utility);
     try {
-      const poolsData = await Promise.all(
+      const poolsData = await Promise.allSettled(
         keys.map((key) =>
           client.get<{
             data: IMarketDetailPool[];
@@ -121,7 +121,14 @@ class ServiceMarket extends ServiceBase {
       return keys
         .map((key, index) => ({
           ...detailPlatforms[key],
-          data: poolsData[index].data.data,
+          data:
+            poolsData[index].status === 'fulfilled'
+              ? (
+                  poolsData[index].value as {
+                    data: { data: IMarketDetailPool[] };
+                  }
+                ).data.data
+              : [],
         }))
         .filter((i) => i.data.length);
     } catch {

--- a/packages/kit-bg/src/services/ServiceMarket.ts
+++ b/packages/kit-bg/src/services/ServiceMarket.ts
@@ -109,16 +109,21 @@ class ServiceMarket extends ServiceBase {
     const client = await this.getClient(EServiceEndpointEnum.Utility);
     try {
       const poolsData = await Promise.allSettled(
-        keys.map((key) =>
-          client.get<{
-            data: IMarketDetailPool[];
-          }>('/utility/v1/market/pools', {
-            params: {
-              query: detailPlatforms[key].contract_address,
-              network: detailPlatforms[key].coingeckoNetworkId,
-            },
-          }),
-        ),
+        keys.map((key) => {
+          const { contract_address: contractAddress, coingeckoNetworkId } =
+            detailPlatforms[key];
+          if (contractAddress && coingeckoNetworkId) {
+            return client.get<{
+              data: IMarketDetailPool[];
+            }>('/utility/v1/market/pools', {
+              params: {
+                query: contractAddress,
+                network: coingeckoNetworkId,
+              },
+            });
+          }
+          return Promise.resolve({ data: { data: [] } });
+        }),
       );
       return keys
         .map((key, index) => ({
@@ -133,7 +138,8 @@ class ServiceMarket extends ServiceBase {
               : [],
         }))
         .filter((i) => i.data.length);
-    } catch {
+    } catch (error) {
+      console.error('fetchPools error', error);
       return [];
     }
   }

--- a/packages/kit/src/components/TradingView/useTradingViewProps.ts
+++ b/packages/kit/src/components/TradingView/useTradingViewProps.ts
@@ -133,19 +133,9 @@ export const useTradingViewProps = ({
             div:has(>#header-toolbar-chart-styles) + div {
               display: none;
             }
-            div:has(>#header-toolbar-compare) + div {
-              display: none;
-            }
-            div:has(>#header-toolbar-indicators) {
-              display: none;
-            }
-            div:has(>#header-toolbar-indicators) + div {
-              display: none;
-            }
             html.theme-dark .chart-page {
               background: ${bgAppColor} !important;
             }
-
             #overlap-manager-root [class*="backdrop-"] {
               background-color: ${bgBackdropColor} !important;
             }

--- a/packages/kit/src/states/jotai/contexts/discovery/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/discovery/actions.ts
@@ -72,7 +72,7 @@ function buildWebTabData(tabs: IWebTab[]) {
     map[tab.id] = tab;
   });
   return {
-    data: [...tabs],
+    data: tabs,
     keys,
     map,
   };
@@ -124,9 +124,9 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
       }
       const result = buildWebTabData(newTabs);
       // Should update tabs
-      // if (!isEqual(result.keys, webTabs.keys) || options?.forceUpdate) {
-      set(webTabsAtom(), { keys: result.keys, tabs: result.data });
-      // }
+      if (!isEqual(result.keys, webTabs.keys) || options?.forceUpdate) {
+        set(webTabsAtom(), { keys: result.keys, tabs: result.data });
+      }
 
       set(webTabsMapAtom(), () => result.map);
       loggerForEmptyData(result.data, 'buildWebTabs->saveToSimpleDB');

--- a/packages/kit/src/states/jotai/contexts/discovery/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/discovery/actions.ts
@@ -72,7 +72,7 @@ function buildWebTabData(tabs: IWebTab[]) {
     map[tab.id] = tab;
   });
   return {
-    data: tabs,
+    data: [...tabs],
     keys,
     map,
   };
@@ -124,9 +124,9 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
       }
       const result = buildWebTabData(newTabs);
       // Should update tabs
-      if (!isEqual(result.keys, webTabs.keys) || options?.forceUpdate) {
-        set(webTabsAtom(), { keys: result.keys, tabs: result.data });
-      }
+      // if (!isEqual(result.keys, webTabs.keys) || options?.forceUpdate) {
+      set(webTabsAtom(), { keys: result.keys, tabs: result.data });
+      // }
 
       set(webTabsMapAtom(), () => result.map);
       loggerForEmptyData(result.data, 'buildWebTabs->saveToSimpleDB');

--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -697,6 +697,9 @@ function BasicEarnHome() {
           ...i,
           imgUrl: i.src,
           title: i.title || '',
+          titleTextProps: {
+            size: '$headingMd',
+          },
         })) || []
       );
     },
@@ -817,8 +820,8 @@ function BasicEarnHome() {
           itemTitleContainerStyle={{
             top: 0,
             bottom: 0,
-            right: '$3.5',
-            left: '$3.5',
+            right: '$4',
+            left: '$4',
             justifyContent: 'center',
           }}
         />

--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -815,13 +815,13 @@ function BasicEarnHome() {
             right: 0,
             width: '100%',
             jc: 'center',
-            bottom: '$3',
+            bottom: '$5',
           }}
           itemTitleContainerStyle={{
             top: 0,
             bottom: 0,
-            right: '$4',
-            left: '$4',
+            right: '$5',
+            left: '$5',
             justifyContent: 'center',
           }}
         />

--- a/packages/kit/src/views/Market/components/MarketHomeList.tsx
+++ b/packages/kit/src/views/Market/components/MarketHomeList.tsx
@@ -690,36 +690,6 @@ function BasicMarketHomeList({
                       {record.name}
                     </SizableText>
                   </YStack>
-                  {/* <Button
-                  size="small"
-                  onPress={async () => {
-                    console.log('----log', item);
-                    const response =
-                      await backgroundApiProxy.serviceMarket.fetchPools(
-                        item.symbol,
-                        item.symbol,
-                      );
-        
-                    navigation.pushModal(EModalRoutes.SwapModal, {
-                      screen: EModalSwapRoutes.SwapMainLand,
-                      params: {
-                        importNetworkId: networkId,
-                        importFromToken: {
-                          contractAddress: tokenInfo.address,
-                          symbol: tokenInfo.symbol,
-                          networkId,
-                          isNative: tokenInfo.isNative,
-                          decimals: tokenInfo.decimals,
-                          name: tokenInfo.name,
-                          logoURI: tokenInfo.logoURI,
-                          networkLogoURI: network?.logoURI,
-                        },
-                      },
-                    });
-                  }}
-                >
-                  Swap
-                </Button> */}
                 </XStack>
               ),
               renderSkeleton: () => (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 在 `earnBanners` 数组中新增 `titleTextProps` 属性，设置为 `{ size: '$headingMd' }`，以改善横幅组件的视觉展示。
- **样式**
	- 更新 `Banner` 组件的 `indicatorContainerStyle` 和 `itemTitleContainerStyle` 的布局和样式。
- **错误修复**
	- 改进 `fetchPools` 方法的错误处理能力，确保即使某些请求失败也能返回相关数据。
- **清理**
	- 移除 `MarketHomeList` 组件中未使用的 `<Button>` 组件，简化代码结构。
- **其他**
	- 优化 `BannerItem` 组件中的标题文本样式处理，简化渲染逻辑。
	- 移除 `useTradingViewProps` 函数中与 TradingView 图表头部工具栏相关的特定 CSS 规则。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->