### PR TITLE
fix: add android billing permission

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
   <uses-permission android:name="android.permission.NFC"/>
   <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+  <uses-permission android:name="com.android.vending.BILLING" />
 
     <queries>
     <intent>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Permissions**
	- Removed foreground service media playback and location access permissions
	- Added in-app billing permission for Google Play Store transactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->