### PR TITLE
fix: make secret decrypt to async

### DIFF
--- a/packages/core/@tests/coreTestsUtils.ts
+++ b/packages/core/@tests/coreTestsUtils.ts
@@ -2,7 +2,7 @@ import { omit, range } from 'lodash';
 
 import {
   decryptRevealableSeed,
-  decryptString,
+  decryptStringAsync,
   encryptImportedCredential,
   mnemonicToRevealableSeed,
 } from '../src/secret';
@@ -39,7 +39,7 @@ function expectAccountEqual(
   expect(a1).toEqual(b1);
 }
 
-function expectMnemonicValid({
+async function expectMnemonicValid({
   hdCredential,
 }: {
   hdCredential: ICoreTestsHdCredential;
@@ -47,7 +47,7 @@ function expectMnemonicValid({
   const { password } = hdCredential;
   const rsDecrypt2 = mnemonicToRevealableSeed(hdCredential.mnemonic);
 
-  const rsDecrypt = decryptRevealableSeed({
+  const rsDecrypt = await decryptRevealableSeed({
     rs: hdCredential.hdCredentialHex,
     password,
   });
@@ -170,7 +170,7 @@ async function expectGetPrivateKeysHdOk({
     // c1c3e59db78da160261befeef577daa7b54cd756e48601473cfe98d012b3ccfca240a8a3e1a328ee7611ba2688f3fadf1d7c61d36c379c0ced0eec0b66ff9ecd635a8dbfcae4cce36c15c64a79d5873d1d26cbf6c90a36034f96077d66cef413
     expect(encryptKey).toBeTruthy();
     // 105434ca932be16664cb5e44e5b006728577dd757440d068e6d15ef52c15a82f
-    const privateKey = decryptString({
+    const privateKey = await decryptStringAsync({
       password,
       data: encryptKey,
     });

--- a/packages/core/src/base/CoreChainApiBase.ts
+++ b/packages/core/src/base/CoreChainApiBase.ts
@@ -17,7 +17,7 @@ import type {
 import {
   batchGetPrivateKeys,
   batchGetPublicKeysAsync,
-  decrypt,
+  decryptAsync,
   decryptImportedCredential,
   ed25519,
   encryptAsync,
@@ -136,7 +136,7 @@ export abstract class CoreChainApiBase {
     if (credentials.imported) {
       // TODO handle relPaths privateKey here
       // const { relPaths } = account;
-      const { privateKey: p } = decryptImportedCredential({
+      const { privateKey: p } = await decryptImportedCredential({
         password,
         credential: credentials.imported,
       });
@@ -237,7 +237,9 @@ export abstract class CoreChainApiBase {
         let result: ICoreApiGetAddressItem | undefined;
 
         if (isPrivateKeyMode) {
-          const privateKeyRaw = bufferUtils.bytesToHex(decrypt(password, key));
+          const privateKeyRaw = bufferUtils.bytesToHex(
+            await decryptAsync({ password, data: key }),
+          );
           result = await this.getAddressFromPrivate({
             networkInfo: query.networkInfo,
             privateKeyRaw,

--- a/packages/core/src/chains/ada/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/ada/CoreChainSoftware.test.ts
@@ -124,8 +124,8 @@ const {
 // wasm module
 // yarn jest packages/core/src/chains/ada/CoreChainSoftware.test.ts
 describe('ADA Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/ada/CoreChainSoftware.ts
+++ b/packages/core/src/chains/ada/CoreChainSoftware.ts
@@ -2,7 +2,7 @@ import { checkIsDefined } from '@onekeyhq/shared/src/utils/assertUtils';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 
 import { CoreChainApiBase } from '../../base/CoreChainApiBase';
-import { decrypt, encryptAsync } from '../../secret';
+import { decryptAsync, encryptAsync } from '../../secret';
 import {
   ECoreApiExportedSecretKeyType,
   type ICoreApiGetAddressItem,
@@ -283,7 +283,10 @@ export default class CoreChainSoftware extends CoreChainApiBase {
         );
       }
       if (credentials.imported) {
-        const privateKey = decrypt(password, privateKeyRaw);
+        const privateKey = await decryptAsync({
+          password,
+          data: privateKeyRaw,
+        });
         return generateXprvFromPrivateKey(privateKey);
       }
     }

--- a/packages/core/src/chains/ada/sdkAda/bip32.ts
+++ b/packages/core/src/chains/ada/sdkAda/bip32.ts
@@ -5,7 +5,7 @@
 // @ts-expect-error
 import { bech32, mnemonicToRootKeypair, toPublic } from 'cardano-crypto.js';
 
-import { decrypt, mnemonicFromEntropy } from '@onekeyhq/core/src/secret';
+import { mnemonicFromEntropy } from '@onekeyhq/core/src/secret';
 
 import { DERIVATION_SCHEME, HARDENED_THRESHOLD } from './constants';
 

--- a/packages/core/src/chains/algo/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/algo/CoreChainSoftware.test.ts
@@ -48,8 +48,8 @@ const {
 
 // yarn jest packages/core/src/chains/algo/CoreChainSoftware.test.ts
 describe('ALGO Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/algo/CoreChainSoftware.ts
+++ b/packages/core/src/chains/algo/CoreChainSoftware.ts
@@ -1,6 +1,6 @@
 import { isArray } from 'lodash';
 
-import { decrypt, ed25519 } from '@onekeyhq/core/src/secret';
+import { decryptAsync, ed25519 } from '@onekeyhq/core/src/secret';
 import {
   NotImplemented,
   OneKeyInternalError,
@@ -82,7 +82,9 @@ export default class CoreChainSoftware extends CoreChainApiBase {
       throw new Error('privateKeyRaw is required');
     }
     if (keyType === ECoreApiExportedSecretKeyType.privateKey) {
-      return sdkAlgo.mnemonicFromSeed(decrypt(password, privateKeyRaw));
+      return sdkAlgo.mnemonicFromSeed(
+        await decryptAsync({ password, data: privateKeyRaw }),
+      );
     }
     throw new Error(`SecretKey type not support: ${keyType}`);
   }

--- a/packages/core/src/chains/aptos/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/aptos/CoreChainSoftware.test.ts
@@ -69,8 +69,8 @@ const {
 
 // yarn jest packages/core/src/chains/apt/CoreChainSoftware.test.ts
 describe('APT Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/aptos/CoreChainSoftware.ts
+++ b/packages/core/src/chains/aptos/CoreChainSoftware.ts
@@ -10,13 +10,14 @@ import {
 // eslint-disable-next-line camelcase
 import { sha3_256 } from 'js-sha3';
 
-import { decrypt, ed25519 } from '@onekeyhq/core/src/secret';
+import { decryptAsync, ed25519 } from '@onekeyhq/core/src/secret';
 import { OneKeyInternalError } from '@onekeyhq/shared/src/errors';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 import hexUtils from '@onekeyhq/shared/src/utils/hexUtils';
 
 import { CoreChainApiBase } from '../../base/CoreChainApiBase';
 import {
+  ECoreApiExportedSecretKeyType,
   type ICoreApiGetAddressItem,
   type ICoreApiGetAddressQueryImported,
   type ICoreApiGetAddressQueryPublicKey,
@@ -31,7 +32,6 @@ import {
   type ISignedTxPro,
   type IUnsignedMessageAptos,
 } from '../../types';
-import { ECoreApiExportedSecretKeyType } from '../../types';
 
 const curveName: ICurveName = 'ed25519';
 
@@ -82,7 +82,9 @@ export default class CoreChainSoftware extends CoreChainApiBase {
       throw new Error('privateKeyRaw is required');
     }
     if (keyType === ECoreApiExportedSecretKeyType.privateKey) {
-      return `0x${decrypt(password, privateKeyRaw).toString('hex')}`;
+      return `0x${(
+        await decryptAsync({ password, data: privateKeyRaw })
+      ).toString('hex')}`;
     }
     throw new Error(`SecretKey type not support: ${keyType}`);
   }

--- a/packages/core/src/chains/bch/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/bch/CoreChainSoftware.test.ts
@@ -53,8 +53,8 @@ const {
 
 // yarn jest packages/core/src/chains/bch/CoreChainSoftware.test.ts
 describe('BCH Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/bfc/CoreChainSoftware.ts
+++ b/packages/core/src/chains/bfc/CoreChainSoftware.ts
@@ -15,7 +15,7 @@ import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 import hexUtils from '@onekeyhq/shared/src/utils/hexUtils';
 
 import { CoreChainApiBase } from '../../base/CoreChainApiBase';
-import { decrypt } from '../../secret';
+import { decryptAsync } from '../../secret';
 import {
   ECoreApiExportedSecretKeyType,
   type ICoreApiGetAddressItem,
@@ -62,7 +62,9 @@ export default class CoreChainSoftware extends CoreChainApiBase {
       throw new Error('privateKeyRaw is required');
     }
     if (keyType === ECoreApiExportedSecretKeyType.privateKey) {
-      return `0x${decrypt(password, privateKeyRaw).toString('hex')}`;
+      return `0x${(
+        await decryptAsync({ password, data: privateKeyRaw })
+      ).toString('hex')}`;
     }
     throw new Error(`SecretKey type not support: ${keyType}`);
   }

--- a/packages/core/src/chains/btc/CoreChainSoftware.tbtc.test.ts
+++ b/packages/core/src/chains/btc/CoreChainSoftware.tbtc.test.ts
@@ -97,8 +97,8 @@ const {
 
 // yarn jest packages/core/src/chains/btc/CoreChainSoftware.tbtc.test.ts
 describe('TBTC Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/btc/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/btc/CoreChainSoftware.test.ts
@@ -54,8 +54,8 @@ const {
 
 // yarn jest packages/core/src/chains/btc/CoreChainSoftware.test.ts
 describe('BTC Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/btc/CoreChainSoftware.ts
+++ b/packages/core/src/chains/btc/CoreChainSoftware.ts
@@ -29,7 +29,7 @@ import { CoreChainApiBase } from '../../base/CoreChainApiBase';
 import {
   BaseBip32KeyDeriver,
   batchGetPublicKeysAsync,
-  decrypt,
+  decryptAsync,
   encryptAsync,
   mnemonicFromEntropyAsync,
   mnemonicToSeedAsync,
@@ -247,7 +247,7 @@ export default class CoreChainSoftwareBtc extends CoreChainApiBase {
             .fill(
               Buffer.concat([
                 Buffer.from([0]),
-                decrypt(password, privateKeyRaw),
+                await decryptAsync({ password, data: privateKeyRaw }),
               ]),
               45,
               78,
@@ -255,7 +255,9 @@ export default class CoreChainSoftwareBtc extends CoreChainApiBase {
         );
       }
       if (credentials.imported) {
-        return bs58check.encode(decrypt(password, privateKeyRaw));
+        return bs58check.encode(
+          await decryptAsync({ password, data: privateKeyRaw }),
+        );
       }
     }
     throw new Error(`SecretKey type not support: ${keyType}`);
@@ -449,7 +451,10 @@ export default class CoreChainSoftwareBtc extends CoreChainApiBase {
 
     // imported account return "" key as root privateKey
     const privateKey = privateKeys[''];
-    const xprv = decrypt(password, bufferUtils.toBuffer(privateKey));
+    const xprv = await decryptAsync({
+      password,
+      data: bufferUtils.toBuffer(privateKey),
+    });
     const startKey = {
       chainCode: xprv.slice(13, 45),
       key: xprv.slice(46, 78),

--- a/packages/core/src/chains/cfx/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/cfx/CoreChainSoftware.test.ts
@@ -65,8 +65,8 @@ const {
 
 // yarn jest packages/core/src/chains/cfx/CoreChainSoftware.test.ts
 describe('CFX Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/cfx/CoreChainSoftware.ts
+++ b/packages/core/src/chains/cfx/CoreChainSoftware.ts
@@ -2,7 +2,7 @@ import { keccak256 } from '@ethersproject/keccak256';
 import { getMessage } from 'cip-23';
 
 import {
-  decrypt,
+  decryptAsync,
   secp256k1,
   uncompressPublicKey,
 } from '@onekeyhq/core/src/secret';
@@ -74,7 +74,9 @@ export default class CoreChainSoftware extends CoreChainApiBase {
       throw new Error('privateKeyRaw is required');
     }
     if (keyType === ECoreApiExportedSecretKeyType.privateKey) {
-      return `0x${decrypt(password, privateKeyRaw).toString('hex')}`;
+      return `0x${(
+        await decryptAsync({ password, data: privateKeyRaw })
+      ).toString('hex')}`;
     }
     throw new Error(`SecretKey type not support: ${keyType}`);
   }

--- a/packages/core/src/chains/cosmos/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/cosmos/CoreChainSoftware.test.ts
@@ -96,8 +96,8 @@ const {
 
 // yarn jest packages/core/src/chains/cosmos/CoreChainSoftware.test.ts
 describe('COSMOS Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/cosmos/CoreChainSoftware.ts
+++ b/packages/core/src/chains/cosmos/CoreChainSoftware.ts
@@ -5,7 +5,7 @@ import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 import hexUtils from '@onekeyhq/shared/src/utils/hexUtils';
 
 import { CoreChainApiBase } from '../../base/CoreChainApiBase';
-import { decrypt } from '../../secret';
+import { decryptAsync } from '../../secret';
 import {
   ECoreApiExportedSecretKeyType,
   type ICoreApiGetAddressItem,
@@ -57,7 +57,9 @@ export default class CoreChainSoftware extends CoreChainApiBase {
       throw new Error('privateKeyRaw is required');
     }
     if (keyType === ECoreApiExportedSecretKeyType.privateKey) {
-      return `0x${decrypt(password, privateKeyRaw).toString('hex')}`;
+      return `0x${(
+        await decryptAsync({ password, data: privateKeyRaw })
+      ).toString('hex')}`;
     }
     throw new Error(`SecretKey type not support: ${keyType}`);
   }

--- a/packages/core/src/chains/doge/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/doge/CoreChainSoftware.test.ts
@@ -51,8 +51,8 @@ const {
 
 // yarn jest packages/core/src/chains/doge/CoreChainSoftware.test.ts
 describe('DOGE Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/dot/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/dot/CoreChainSoftware.test.ts
@@ -57,8 +57,8 @@ const {
 
 // yarn jest packages/core/src/chains/dot/CoreChainSoftware.test.ts
 describe('DOT Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/dot/CoreChainSoftware.ts
+++ b/packages/core/src/chains/dot/CoreChainSoftware.ts
@@ -11,7 +11,7 @@ import hexUtils from '@onekeyhq/shared/src/utils/hexUtils';
 
 import { CoreChainApiBase } from '../../base/CoreChainApiBase';
 import {
-  decrypt,
+  decryptAsync,
   decryptImportedCredential,
   encryptAsync,
   mnemonicFromEntropy,
@@ -78,7 +78,9 @@ export default class CoreChainSoftware extends CoreChainApiBase {
       throw new Error('privateKeyRaw is required');
     }
     if (keyType === ECoreApiExportedSecretKeyType.privateKey) {
-      return `0x${decrypt(password, privateKeyRaw).toString('hex')}`;
+      return `0x${(
+        await decryptAsync({ password, data: privateKeyRaw })
+      ).toString('hex')}`;
     }
     throw new Error(`SecretKey type not support: ${keyType}`);
   }
@@ -94,7 +96,7 @@ export default class CoreChainSoftware extends CoreChainApiBase {
       const pathComponents = account.path.split('/');
       const usedRelativePaths = relPaths || [pathComponents.pop() as string];
       const basePath = pathComponents.join('/');
-      const mnemonic = mnemonicFromEntropy(credentials.hd, password);
+      const mnemonic = await mnemonicFromEntropy(credentials.hd, password);
       const keysPromised = usedRelativePaths.map(async (relPath) => {
         const path = `${basePath}/${relPath}`;
 
@@ -116,7 +118,7 @@ export default class CoreChainSoftware extends CoreChainApiBase {
       );
     }
     if (credentials.imported) {
-      const { privateKey: p } = decryptImportedCredential({
+      const { privateKey: p } = await decryptImportedCredential({
         password,
         credential: credentials.imported,
       });
@@ -226,16 +228,18 @@ export default class CoreChainSoftware extends CoreChainApiBase {
     const indexFormatted = indexes.map((index) =>
       pathSuffix.replace('{index}', index.toString()),
     );
-    const mnemonic = mnemonicFromEntropy(hdCredential, password);
+    const mnemonic = await mnemonicFromEntropy(hdCredential, password);
 
-    const publicKeys = indexFormatted.map((index) => {
-      const path = `${pathPrefix}/${index}`;
-      const keyPair = derivationHdLedger(mnemonic, path);
-      return {
-        path,
-        pubkey: keyPair.publicKey,
-      };
-    });
+    const publicKeys = await Promise.all(
+      indexFormatted.map(async (index) => {
+        const path = `${pathPrefix}/${index}`;
+        const keyPair = derivationHdLedger(mnemonic, path);
+        return {
+          path,
+          pubkey: keyPair.publicKey,
+        };
+      }),
+    );
 
     if (publicKeys.length !== indexes.length) {
       throw new OneKeyInternalError('Unable to get public key.');

--- a/packages/core/src/chains/dot/CoreChainSoftware.ts
+++ b/packages/core/src/chains/dot/CoreChainSoftware.ts
@@ -230,16 +230,14 @@ export default class CoreChainSoftware extends CoreChainApiBase {
     );
     const mnemonic = await mnemonicFromEntropy(hdCredential, password);
 
-    const publicKeys = await Promise.all(
-      indexFormatted.map(async (index) => {
-        const path = `${pathPrefix}/${index}`;
-        const keyPair = derivationHdLedger(mnemonic, path);
-        return {
-          path,
-          pubkey: keyPair.publicKey,
-        };
-      }),
-    );
+    const publicKeys = indexFormatted.map((index) => {
+      const path = `${pathPrefix}/${index}`;
+      const keyPair = derivationHdLedger(mnemonic, path);
+      return {
+        path,
+        pubkey: keyPair.publicKey,
+      };
+    });
 
     if (publicKeys.length !== indexes.length) {
       throw new OneKeyInternalError('Unable to get public key.');

--- a/packages/core/src/chains/evm/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/evm/CoreChainSoftware.test.ts
@@ -106,8 +106,8 @@ const {
 
 // yarn jest packages/core/src/chains/evm/CoreChainSoftware.test.ts
 describe('EVM Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/evm/CoreChainSoftware.ts
+++ b/packages/core/src/chains/evm/CoreChainSoftware.ts
@@ -4,7 +4,7 @@ import { keccak256 } from '@ethersproject/keccak256';
 import * as ethUtil from 'ethereumjs-util';
 import { isString } from 'lodash';
 
-import { decrypt, uncompressPublicKey } from '@onekeyhq/core/src/secret';
+import { decryptAsync, uncompressPublicKey } from '@onekeyhq/core/src/secret';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 
 import { CoreChainApiBase } from '../../base/CoreChainApiBase';
@@ -57,7 +57,9 @@ export default class CoreChainSoftware extends CoreChainApiBase {
       throw new Error('privateKeyRaw is required');
     }
     if (keyType === ECoreApiExportedSecretKeyType.privateKey) {
-      return `0x${decrypt(password, privateKeyRaw).toString('hex')}`;
+      return `0x${(
+        await decryptAsync({ password, data: privateKeyRaw })
+      ).toString('hex')}`;
     }
     throw new Error(`SecretKey type not support: ${keyType}`);
   }

--- a/packages/core/src/chains/fil/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/fil/CoreChainSoftware.test.ts
@@ -58,8 +58,8 @@ const {
 // wasm module
 // yarn jest packages/core/src/chains/fil/CoreChainSoftware.test.ts
 describe('FIL Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/fil/CoreChainSoftware.ts
+++ b/packages/core/src/chains/fil/CoreChainSoftware.ts
@@ -9,7 +9,7 @@ import {
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 
 import { CoreChainApiBase } from '../../base/CoreChainApiBase';
-import { decrypt, uncompressPublicKey } from '../../secret';
+import { decryptAsync, uncompressPublicKey } from '../../secret';
 import {
   ECoreApiExportedSecretKeyType,
   type ICoreApiGetAddressItem,
@@ -146,9 +146,9 @@ export default class CoreChainSoftware extends CoreChainApiBase {
       throw new Error('privateKeyRaw is required');
     }
     if (keyType === ECoreApiExportedSecretKeyType.privateKey) {
-      const privateKeyBase64 = decrypt(password, privateKeyRaw).toString(
-        'base64',
-      );
+      const privateKeyBase64 = (
+        await decryptAsync({ password, data: privateKeyRaw })
+      ).toString('base64');
       return Buffer.from(
         JSON.stringify({
           'Type': 'secp256k1',

--- a/packages/core/src/chains/kaspa/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/kaspa/CoreChainSoftware.test.ts
@@ -77,8 +77,8 @@ const {
 
 // yarn jest packages/core/src/chains/kaspa/CoreChainSoftware.test.ts
 describe('KASPA Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/kaspa/CoreChainSoftware.ts
+++ b/packages/core/src/chains/kaspa/CoreChainSoftware.ts
@@ -3,7 +3,7 @@ import { checkIsDefined } from '@onekeyhq/shared/src/utils/assertUtils';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 
 import { CoreChainApiBase } from '../../base/CoreChainApiBase';
-import { decrypt } from '../../secret';
+import { decryptAsync } from '../../secret';
 import {
   ECoreApiExportedSecretKeyType,
   type ICoreApiGetAddressItem,
@@ -57,7 +57,7 @@ export default class CoreChainSoftware extends CoreChainApiBase {
     if (keyType === ECoreApiExportedSecretKeyType.privateKey) {
       const chainId = networkInfo.chainId;
       return privateKeyFromBuffer(
-        decrypt(password, privateKeyRaw),
+        await decryptAsync({ password, data: privateKeyRaw }),
         chainId,
       ).toWIF();
     }

--- a/packages/core/src/chains/lightning/CoreChainSoftware.ts
+++ b/packages/core/src/chains/lightning/CoreChainSoftware.ts
@@ -266,7 +266,7 @@ export default class CoreChainSoftware extends CoreChainApiBase {
     credentials: ICoreCredentialsInfo;
   }): Promise<string> {
     const { password, credentials, lnurlDetail } = params;
-    const mnemonic = mnemonicFromEntropy(
+    const mnemonic = await mnemonicFromEntropy(
       checkIsDefined(credentials.hd),
       password,
     );

--- a/packages/core/src/chains/ltc/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/ltc/CoreChainSoftware.test.ts
@@ -52,8 +52,8 @@ const {
 
 // yarn jest packages/core/src/chains/ltc/CoreChainSoftware.test.ts
 describe('LTC Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/near/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/near/CoreChainSoftware.test.ts
@@ -65,8 +65,8 @@ const {
 
 // yarn jest packages/core/src/chains/near/CoreChainSoftware.test.ts
 describe('NEAR Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/near/CoreChainSoftware.ts
+++ b/packages/core/src/chains/near/CoreChainSoftware.ts
@@ -5,12 +5,12 @@ import sha256 from 'js-sha256';
 import { isString } from 'lodash';
 import { transactions, utils } from 'near-api-js';
 
-import { decrypt, ed25519 } from '@onekeyhq/core/src/secret';
 import { NotImplemented } from '@onekeyhq/shared/src/errors';
 import { checkIsDefined } from '@onekeyhq/shared/src/utils/assertUtils';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 
 import { CoreChainApiBase } from '../../base/CoreChainApiBase';
+import { decryptAsync, ed25519 } from '../../secret';
 import {
   ECoreApiExportedSecretKeyType,
   type ICoreApiGetAddressItem,
@@ -157,7 +157,7 @@ export default class CoreChainSoftware extends CoreChainApiBase {
       throw new Error('privateKeyRaw is required');
     }
     if (keyType === ECoreApiExportedSecretKeyType.privateKey) {
-      const privateKey = decrypt(password, privateKeyRaw);
+      const privateKey = await decryptAsync({ password, data: privateKeyRaw });
       const publicKey = ed25519.publicFromPrivate(privateKey);
       return `ed25519:${baseEncode(Buffer.concat([privateKey, publicKey]))}`;
     }

--- a/packages/core/src/chains/nexa/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/nexa/CoreChainSoftware.test.ts
@@ -104,8 +104,8 @@ const {
 
 // yarn jest packages/core/src/chains/nexa/CoreChainSoftware.test.ts
 describe('NEXA Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/nexa/CoreChainSoftware.ts
+++ b/packages/core/src/chains/nexa/CoreChainSoftware.ts
@@ -2,7 +2,7 @@ import { NotImplemented } from '@onekeyhq/shared/src/errors';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 
 import { CoreChainApiBase } from '../../base/CoreChainApiBase';
-import { decrypt } from '../../secret';
+import { decryptAsync } from '../../secret';
 import {
   ECoreApiExportedSecretKeyType,
   type ICoreApiGetAddressItem,
@@ -47,7 +47,9 @@ export default class CoreChainSoftware extends CoreChainApiBase {
       throw new Error('privateKeyRaw is required');
     }
     if (keyType === ECoreApiExportedSecretKeyType.xprvt) {
-      return decrypt(password, privateKeyRaw).toString('hex');
+      return (await decryptAsync({ password, data: privateKeyRaw })).toString(
+        'hex',
+      );
     }
     throw new Error(`SecretKey type not support: ${keyType}`);
   }

--- a/packages/core/src/chains/nostr/CoreChainSoftware.ts
+++ b/packages/core/src/chains/nostr/CoreChainSoftware.ts
@@ -4,7 +4,7 @@ import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 import type { INetworkAccount } from '@onekeyhq/shared/types/account';
 
 import { CoreChainApiBase } from '../../base/CoreChainApiBase';
-import { decrypt } from '../../secret';
+import { decryptAsync } from '../../secret';
 import {
   ECoreApiExportedSecretKeyType,
   type ICoreApiGetAddressItem,
@@ -59,7 +59,7 @@ export default class CoreChainSoftware extends CoreChainApiBase {
       throw new Error('privateKeyRaw is required');
     }
     if (keyType === ECoreApiExportedSecretKeyType.privateKey) {
-      const privateKey = decrypt(password, privateKeyRaw);
+      const privateKey = await decryptAsync({ password, data: privateKeyRaw });
       const nostrPrivateKey = getPrivateEncodedByNip19(privateKey);
       return nostrPrivateKey;
     }

--- a/packages/core/src/chains/sol/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/sol/CoreChainSoftware.test.ts
@@ -52,8 +52,8 @@ const {
 
 // yarn jest packages/core/src/chains/sol/CoreChainSoftware.test.ts
 describe('SOL Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/sol/CoreChainSoftware.ts
+++ b/packages/core/src/chains/sol/CoreChainSoftware.ts
@@ -5,7 +5,7 @@ import { checkIsDefined } from '@onekeyhq/shared/src/utils/assertUtils';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 
 import { CoreChainApiBase } from '../../base/CoreChainApiBase';
-import { decrypt } from '../../secret';
+import { decryptAsync } from '../../secret';
 import {
   ECoreApiExportedSecretKeyType,
   type ICoreApiGetAddressItem,
@@ -104,7 +104,7 @@ export default class CoreChainSoftware extends CoreChainApiBase {
     if (keyType === ECoreApiExportedSecretKeyType.privateKey) {
       return bs58.encode(
         Buffer.concat([
-          decrypt(password, privateKeyRaw),
+          await decryptAsync({ password, data: privateKeyRaw }),
           bs58.decode(account.pub ?? ''),
         ]),
       );

--- a/packages/core/src/chains/stc/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/stc/CoreChainSoftware.test.ts
@@ -50,8 +50,8 @@ const {
 
 // yarn jest packages/core/src/chains/stc/CoreChainSoftware.test.ts
 describe('STC Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/sui/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/sui/CoreChainSoftware.test.ts
@@ -73,8 +73,8 @@ const {
 
 // yarn jest packages/core/src/chains/sui/CoreChainSoftware.test.ts
 describe('SUI Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/sui/CoreChainSoftware.ts
+++ b/packages/core/src/chains/sui/CoreChainSoftware.ts
@@ -6,7 +6,7 @@ import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 import hexUtils from '@onekeyhq/shared/src/utils/hexUtils';
 
 import { CoreChainApiBase } from '../../base/CoreChainApiBase';
-import { decrypt } from '../../secret';
+import { decryptAsync } from '../../secret';
 import {
   ECoreApiExportedSecretKeyType,
   type ICoreApiGetAddressItem,
@@ -53,7 +53,9 @@ export default class CoreChainSoftware extends CoreChainApiBase {
       throw new Error('privateKeyRaw is required');
     }
     if (keyType === ECoreApiExportedSecretKeyType.privateKey) {
-      return `0x${decrypt(password, privateKeyRaw).toString('hex')}`;
+      return `0x${(
+        await decryptAsync({ password, data: privateKeyRaw })
+      ).toString('hex')}`;
     }
     throw new Error(`SecretKey type not support: ${keyType}`);
   }

--- a/packages/core/src/chains/ton/CoreChainSoftware.ts
+++ b/packages/core/src/chains/ton/CoreChainSoftware.ts
@@ -6,7 +6,7 @@ import { OneKeyInternalError } from '@onekeyhq/shared/src/errors';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 
 import { CoreChainApiBase } from '../../base/CoreChainApiBase';
-import { decrypt } from '../../secret';
+import { decryptAsync } from '../../secret';
 import {
   ECoreApiExportedSecretKeyType,
   type ICoreApiGetAddressItem,
@@ -43,7 +43,9 @@ export default class CoreChainSoftware extends CoreChainApiBase {
       throw new Error('privateKeyRaw is required');
     }
     if (keyType === ECoreApiExportedSecretKeyType.privateKey) {
-      return decrypt(password, privateKeyRaw).toString('hex');
+      return (await decryptAsync({ password, data: privateKeyRaw })).toString(
+        'hex',
+      );
     }
     throw new Error(`SecretKey type not support: ${keyType}`);
   }

--- a/packages/core/src/chains/tron/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/tron/CoreChainSoftware.test.ts
@@ -86,8 +86,8 @@ const {
 
 // yarn jest packages/core/src/chains/tron/CoreChainSoftware.test.ts
 describe('TRON Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/tron/CoreChainSoftware.ts
+++ b/packages/core/src/chains/tron/CoreChainSoftware.ts
@@ -1,7 +1,7 @@
 import { keccak256 } from '@ethersproject/keccak256';
 import TronWeb from 'tronweb';
 
-import { decrypt, uncompressPublicKey } from '@onekeyhq/core/src/secret';
+import { decryptAsync, uncompressPublicKey } from '@onekeyhq/core/src/secret';
 import { NotImplemented } from '@onekeyhq/shared/src/errors';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 
@@ -84,7 +84,9 @@ export default class CoreChainSoftware extends CoreChainApiBase {
       throw new Error('privateKeyRaw is required');
     }
     if (keyType === ECoreApiExportedSecretKeyType.privateKey) {
-      return decrypt(password, privateKeyRaw).toString('hex');
+      return (await decryptAsync({ password, data: privateKeyRaw })).toString(
+        'hex',
+      );
     }
     throw new Error(`SecretKey type not support: ${keyType}`);
   }

--- a/packages/core/src/chains/xmr/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/xmr/CoreChainSoftware.test.ts
@@ -58,8 +58,8 @@ const {
 // TODO import wasmBinaryFileName from './moneroCore.wasm.bin';
 // yarn jest packages/core/src/chains/xmr/CoreChainSoftware.test.ts
 describe('XMR Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/xrp/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/xrp/CoreChainSoftware.test.ts
@@ -68,8 +68,8 @@ const {
 
 // yarn jest packages/core/src/chains/xrp/CoreChainSoftware.test.ts
 describe('XRP Core tests', () => {
-  it('mnemonic verify', () => {
-    coreTestsUtils.expectMnemonicValid({
+  it('mnemonic verify', async () => {
+    await coreTestsUtils.expectMnemonicValid({
       hdCredential,
     });
   });

--- a/packages/core/src/chains/xrp/CoreChainSoftware.ts
+++ b/packages/core/src/chains/xrp/CoreChainSoftware.ts
@@ -6,8 +6,9 @@ import { NotImplemented } from '@onekeyhq/shared/src/errors';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 
 import { CoreChainApiBase } from '../../base/CoreChainApiBase';
-import { decrypt } from '../../secret';
+import { decryptAsync } from '../../secret';
 import {
+  ECoreApiExportedSecretKeyType,
   type ICoreApiGetAddressItem,
   type ICoreApiGetAddressQueryImported,
   type ICoreApiGetAddressQueryPublicKey,
@@ -20,7 +21,6 @@ import {
   type ICurveName,
   type ISignedTxPro,
 } from '../../types';
-import { ECoreApiExportedSecretKeyType } from '../../types';
 
 import type { IEncodedTxXrp } from './types';
 import type { Transaction } from 'xrpl';
@@ -101,12 +101,12 @@ export default class CoreChainSoftware extends CoreChainApiBase {
     }
     if (keyType === ECoreApiExportedSecretKeyType.privateKey) {
       if (credentials.hd) {
-        return `00${decrypt(password, privateKeyRaw)
+        return `00${(await decryptAsync({ password, data: privateKeyRaw }))
           .toString('hex')
           .toUpperCase()}`;
       }
       if (credentials.imported) {
-        return `${decrypt(password, privateKeyRaw)
+        return `${(await decryptAsync({ password, data: privateKeyRaw }))
           .toString('hex')
           .toUpperCase()}`;
       }

--- a/packages/core/src/secret/__tests__/secret.test.ts
+++ b/packages/core/src/secret/__tests__/secret.test.ts
@@ -2095,7 +2095,7 @@ describe('Secret Module Tests', () => {
       }).toMatchSnapshot('invalid-verify');
     });
 
-    it('should throw error for invalid curve', async () => {
+    it('should throw error for invalid curve', () => {
       const signature = Buffer.from('00'.repeat(64), 'hex');
       const publicKey = Buffer.from('00'.repeat(33), 'hex');
       expect(() =>

--- a/packages/core/src/secret/__tests__/secret.test.ts
+++ b/packages/core/src/secret/__tests__/secret.test.ts
@@ -112,7 +112,7 @@ describe('Secret Module Tests', () => {
       expect(childKey.chainCode.length).toBe(32);
 
       // Verify we can generate valid public key from it
-      const publicKey = publicFromPrivate(
+      const publicKey = await publicFromPrivate(
         'secp256k1',
         childKey.key,
         testPassword,
@@ -282,7 +282,7 @@ describe('Secret Module Tests', () => {
       });
 
       // Get seed from hdCredential
-      const { seed } = decryptRevealableSeed({
+      const { seed } = await decryptRevealableSeed({
         rs: hdCredential,
         password: testPassword,
       });
@@ -1065,7 +1065,7 @@ describe('Secret Module Tests', () => {
       });
 
       // Then decrypt and verify
-      const decryptedCredential = decryptImportedCredential({
+      const decryptedCredential = await decryptImportedCredential({
         credential: encryptedCredential,
         password: testPassword,
       });
@@ -1081,7 +1081,7 @@ describe('Secret Module Tests', () => {
 
       expect(encryptedCredential.startsWith('|PK|')).toBe(true);
 
-      const decryptedCredential = decryptImportedCredential({
+      const decryptedCredential = await decryptImportedCredential({
         credential: encryptedCredential,
         password: testPassword,
       });
@@ -1095,21 +1095,21 @@ describe('Secret Module Tests', () => {
         password: testPassword,
       });
 
-      expect(() =>
+      await expect(
         decryptImportedCredential({
           credential: encryptedCredential,
           password: 'wrong-password',
         }),
-      ).toThrow();
+      ).rejects.toThrow();
     });
 
-    it('should throw error for invalid credential format', () => {
-      expect(() =>
+    it('should throw error for invalid credential format', async () => {
+      await expect(
         decryptImportedCredential({
           credential: '|PK|invalid-data',
           password: testPassword,
         }),
-      ).toThrow();
+      ).rejects.toThrow();
     });
 
     it('should match snapshot for decrypted credential', async () => {
@@ -1119,7 +1119,7 @@ describe('Secret Module Tests', () => {
       });
 
       expect(
-        decryptImportedCredential({
+        await decryptImportedCredential({
           credential: encryptedCredential,
           password: testPassword,
         }),
@@ -1142,7 +1142,7 @@ describe('Secret Module Tests', () => {
       });
 
       // Then decrypt and verify
-      const decryptedSeed = decryptRevealableSeed({
+      const decryptedSeed = await decryptRevealableSeed({
         rs: encryptedSeed,
         password: testPassword,
       });
@@ -1156,21 +1156,21 @@ describe('Secret Module Tests', () => {
         password: testPassword,
       });
 
-      expect(() =>
+      await expect(
         decryptRevealableSeed({
           rs: encryptedSeed,
           password: 'wrong-password',
         }),
-      ).toThrow();
+      ).rejects.toThrow();
     });
 
-    it('should throw error for invalid seed format', () => {
-      expect(() =>
+    it('should throw error for invalid seed format', async () => {
+      await expect(
         decryptRevealableSeed({
           rs: 'invalid-seed-data',
           password: testPassword,
         }),
-      ).toThrow();
+      ).rejects.toThrow();
     });
 
     it('should match snapshot for decrypted seed', async () => {
@@ -1180,7 +1180,7 @@ describe('Secret Module Tests', () => {
       });
 
       expect(
-        decryptRevealableSeed({
+        await decryptRevealableSeed({
           rs: encryptedSeed,
           password: testPassword,
         }),
@@ -1198,7 +1198,7 @@ describe('Secret Module Tests', () => {
       });
 
       // Then decrypt and verify
-      const decryptedString = decryptVerifyString({
+      const decryptedString = await decryptVerifyString({
         verifyString: encryptedString,
         password: testPassword,
       });
@@ -1214,7 +1214,7 @@ describe('Secret Module Tests', () => {
 
       expect(encryptedString.startsWith('|VS|')).toBe(true);
 
-      const decryptedString = decryptVerifyString({
+      const decryptedString = await decryptVerifyString({
         verifyString: encryptedString,
         password: testPassword,
       });
@@ -1227,21 +1227,21 @@ describe('Secret Module Tests', () => {
         password: testPassword,
       });
 
-      expect(() =>
+      await expect(
         decryptVerifyString({
           verifyString: encryptedString,
           password: 'wrong-password',
         }),
-      ).toThrow();
+      ).rejects.toThrow();
     });
 
-    it('should throw error for invalid string format', () => {
-      expect(() =>
+    it('should throw error for invalid string format', async () => {
+      await expect(
         decryptVerifyString({
           verifyString: '|VS|invalid-data',
           password: testPassword,
         }),
-      ).toThrow();
+      ).rejects.toThrow();
     });
 
     it('should match snapshot for decrypted string', async () => {
@@ -1250,7 +1250,7 @@ describe('Secret Module Tests', () => {
       });
 
       expect(
-        decryptVerifyString({
+        await decryptVerifyString({
           verifyString: encryptedString,
           password: testPassword,
         }),
@@ -1273,7 +1273,7 @@ describe('Secret Module Tests', () => {
       expect(encryptedCredential.startsWith('|PK|')).toBe(true);
 
       // Verify we can decrypt it back
-      const decryptedCredential = decryptImportedCredential({
+      const decryptedCredential = await decryptImportedCredential({
         credential: encryptedCredential,
         password: testPassword,
       });
@@ -1292,7 +1292,7 @@ describe('Secret Module Tests', () => {
         password: testPassword,
       });
 
-      const decryptedCredential = decryptImportedCredential({
+      const decryptedCredential = await decryptImportedCredential({
         credential: encryptedCredential,
         password: testPassword,
       });
@@ -1337,7 +1337,7 @@ describe('Secret Module Tests', () => {
       });
 
       // Verify we can decrypt it back
-      const decryptedSeed = decryptRevealableSeed({
+      const decryptedSeed = await decryptRevealableSeed({
         rs: encryptedSeed,
         password: testPassword,
       });
@@ -1357,7 +1357,7 @@ describe('Secret Module Tests', () => {
         password: testPassword,
       });
 
-      const decryptedSeed = decryptRevealableSeed({
+      const decryptedSeed = await decryptRevealableSeed({
         rs: encryptedSeed,
         password: testPassword,
       });
@@ -1397,53 +1397,59 @@ describe('Secret Module Tests', () => {
     );
     const encryptedPrivateKey = encrypt(testPassword, testPrivateKey);
 
-    it('should generate public key for secp256k1', () => {
-      const publicKey = publicFromPrivate(
+    it('should generate public key for secp256k1', async () => {
+      const publicKey = await publicFromPrivate(
         'secp256k1',
         encryptedPrivateKey,
         testPassword,
       );
       expect(publicKey).toBeInstanceOf(Buffer);
       expect(publicKey.length).toBeGreaterThan(0);
-      expect(publicKey.toString('hex')).toMatchSnapshot('secp256k1-public-key');
+      expect(bufferUtils.bytesToHex(publicKey)).toMatchSnapshot(
+        'secp256k1-public-key',
+      );
     });
 
-    it('should generate public key for nistp256', () => {
-      const publicKey = publicFromPrivate(
+    it('should generate public key for nistp256', async () => {
+      const publicKey = await publicFromPrivate(
         'nistp256',
         encryptedPrivateKey,
         testPassword,
       );
       expect(publicKey).toBeInstanceOf(Buffer);
       expect(publicKey.length).toBeGreaterThan(0);
-      expect(publicKey.toString('hex')).toMatchSnapshot('nistp256-public-key');
+      expect(bufferUtils.bytesToHex(publicKey)).toMatchSnapshot(
+        'nistp256-public-key',
+      );
     });
 
-    it('should generate public key for ed25519', () => {
-      const publicKey = publicFromPrivate(
+    it('should generate public key for ed25519', async () => {
+      const publicKey = await publicFromPrivate(
         'ed25519',
         encryptedPrivateKey,
         testPassword,
       );
       expect(publicKey).toBeInstanceOf(Buffer);
       expect(publicKey.length).toBeGreaterThan(0);
-      expect(publicKey.toString('hex')).toMatchSnapshot('ed25519-public-key');
+      expect(bufferUtils.bytesToHex(publicKey)).toMatchSnapshot(
+        'ed25519-public-key',
+      );
     });
 
-    it('should throw error for invalid curve', () => {
-      expect(() =>
+    it('should throw error for invalid curve', async () => {
+      await expect(
         publicFromPrivate(
           'invalid-curve' as ICurveName,
           encryptedPrivateKey,
           testPassword,
         ),
-      ).toThrow();
+      ).rejects.toThrow();
     });
 
-    it('should throw error for invalid password', () => {
-      expect(() =>
+    it('should throw error for invalid password', async () => {
+      await expect(
         publicFromPrivate('secp256k1', encryptedPrivateKey, 'wrong-password'),
-      ).toThrow(IncorrectPassword);
+      ).rejects.toThrow(IncorrectPassword);
     });
   });
 
@@ -1456,7 +1462,7 @@ describe('Secret Module Tests', () => {
       });
 
       // Verify we can decrypt it back
-      const decryptedString = decryptVerifyString({
+      const decryptedString = await decryptVerifyString({
         verifyString: encryptedString,
         password: testPassword,
       });
@@ -1481,14 +1487,14 @@ describe('Secret Module Tests', () => {
 
       // Both should decrypt correctly
       expect(
-        decryptVerifyString({
+        await decryptVerifyString({
           verifyString: withPrefix,
           password: testPassword,
         }),
       ).toBe('OneKey');
 
       expect(
-        decryptVerifyString({
+        await decryptVerifyString({
           verifyString: withoutPrefix,
           password: testPassword,
         }),
@@ -1693,31 +1699,31 @@ describe('Secret Module Tests', () => {
       chainCode: Buffer.from('0123456789abcdef0123456789abcdef', 'hex'),
     };
 
-    it('should derive public key from private key', () => {
-      const publicKey = N('secp256k1', testMasterKey, testPassword);
+    it('should derive public key from private key', async () => {
+      const publicKey = await N('secp256k1', testMasterKey, testPassword);
       expect(publicKey).toBeDefined();
       expect(publicKey.key).toBeInstanceOf(Buffer);
       expect(publicKey.chainCode).toEqual(testMasterKey.chainCode);
     });
 
-    it('should work with different curves', () => {
+    it('should work with different curves', async () => {
       const curves: ICurveName[] = ['secp256k1', 'nistp256', 'ed25519'];
-      curves.forEach((curve) => {
-        const publicKey = N(curve, testMasterKey, testPassword);
+      for (const curve of curves) {
+        const publicKey = await N(curve, testMasterKey, testPassword);
         expect(publicKey).toBeDefined();
         expect(publicKey.key).toBeInstanceOf(Buffer);
         expect(publicKey.chainCode).toEqual(testMasterKey.chainCode);
-      });
+      }
     });
 
-    it('should throw error for invalid curve', () => {
-      expect(() =>
+    it('should throw error for invalid curve', async () => {
+      await expect(
         N('invalid-curve' as ICurveName, testMasterKey, testPassword),
-      ).toThrow();
+      ).rejects.toThrow();
     });
 
-    it('should match snapshot', () => {
-      const publicKey = N('secp256k1', testMasterKey, testPassword);
+    it('should match snapshot', async () => {
+      const publicKey = await N('secp256k1', testMasterKey, testPassword);
       expect({
         key: publicKey.key.toString('hex'),
         chainCode: publicKey.chainCode.toString('hex'),
@@ -1734,8 +1740,8 @@ describe('Secret Module Tests', () => {
     const testDigest = Buffer.from('0123456789abcdef0123456789abcdef', 'hex');
     const encryptedPrivateKey = encrypt(testPassword, testPrivateKey);
 
-    it('should sign digest correctly with secp256k1', () => {
-      const signature = sign(
+    it('should sign digest correctly with secp256k1', async () => {
+      const signature = await sign(
         'secp256k1',
         encryptedPrivateKey,
         testDigest,
@@ -1744,7 +1750,7 @@ describe('Secret Module Tests', () => {
       expect(signature).toBeInstanceOf(Buffer);
       expect(signature.length).toBe(65); // secp256k1 signature is 64 bytes
 
-      const publicKey = publicFromPrivate(
+      const publicKey = await publicFromPrivate(
         'secp256k1',
         encryptedPrivateKey,
         testPassword,
@@ -1756,7 +1762,7 @@ describe('Secret Module Tests', () => {
         '1123456789abcdef0123456789abcdef',
         'hex',
       );
-      const wrongPublicKey = publicFromPrivate(
+      const wrongPublicKey = await publicFromPrivate(
         'secp256k1',
         encrypt(testPassword, wrongPrivateKey),
         testPassword,
@@ -1766,8 +1772,8 @@ describe('Secret Module Tests', () => {
       );
     });
 
-    it('should sign digest correctly with nistp256', () => {
-      const signature = sign(
+    it('should sign digest correctly with nistp256', async () => {
+      const signature = await sign(
         'nistp256',
         encryptedPrivateKey,
         testDigest,
@@ -1776,7 +1782,7 @@ describe('Secret Module Tests', () => {
       expect(signature).toBeInstanceOf(Buffer);
       expect(signature.length).toBe(65); // nistp256 signature is 64 bytes
 
-      const publicKey = publicFromPrivate(
+      const publicKey = await publicFromPrivate(
         'nistp256',
         encryptedPrivateKey,
         testPassword,
@@ -1785,8 +1791,8 @@ describe('Secret Module Tests', () => {
       expect(signature.toString('hex')).toMatchSnapshot('nistp256-signature');
     });
 
-    it('should sign digest correctly with ed25519', () => {
-      const signature = sign(
+    it('should sign digest correctly with ed25519', async () => {
+      const signature = await sign(
         'ed25519',
         encryptedPrivateKey,
         testDigest,
@@ -1795,7 +1801,7 @@ describe('Secret Module Tests', () => {
       expect(signature).toBeInstanceOf(Buffer);
       expect(signature.length).toBe(64); // ed25519 signature is 64 bytes
 
-      const publicKey = publicFromPrivate(
+      const publicKey = await publicFromPrivate(
         'ed25519',
         encryptedPrivateKey,
         testPassword,
@@ -1804,25 +1810,25 @@ describe('Secret Module Tests', () => {
       expect(signature.toString('hex')).toMatchSnapshot('ed25519-signature');
     });
 
-    it('should throw error for invalid curve', () => {
-      expect(() =>
+    it('should throw error for invalid curve', async () => {
+      await expect(
         sign(
           'invalid-curve' as ICurveName,
           encryptedPrivateKey,
           testDigest,
           testPassword,
         ),
-      ).toThrow();
+      ).rejects.toThrow();
     });
 
-    it('should throw error for invalid password', () => {
-      expect(() =>
+    it('should throw error for invalid password', async () => {
+      await expect(
         sign('secp256k1', encryptedPrivateKey, testDigest, 'wrong-password'),
-      ).toThrow();
+      ).rejects.toThrow();
     });
 
-    it('should match snapshot', () => {
-      const signature = sign(
+    it('should match snapshot', async () => {
+      const signature = await sign(
         'secp256k1',
         encryptedPrivateKey,
         testDigest,
@@ -1842,24 +1848,27 @@ describe('Secret Module Tests', () => {
         TEST_TON_MNEMONIC,
         testPassword,
       );
-      const mnemonic = tonMnemonicFromEntropy(encryptedSeed, testPassword);
+      const mnemonic = await tonMnemonicFromEntropy(
+        encryptedSeed,
+        testPassword,
+      );
       expect(typeof mnemonic).toBe('string');
       expect(mnemonic.split(' ').length).toBe(24); // TON uses 24 words
       expect(mnemonic).toMatchSnapshot('ton-mnemonic');
 
       // Verify the mnemonic can be converted back to a revealable seed
-      const encryptedSeedFromMnemonic = revealableSeedFromTonMnemonic(
+      const encryptedSeedFromMnemonic = await revealableSeedFromTonMnemonic(
         mnemonic,
         testPassword,
       );
       expect(encryptedSeedFromMnemonic).toBeDefined();
     });
 
-    it('should throw error for invalid entropy length', () => {
+    it('should throw error for invalid entropy length', async () => {
       const invalidEntropy = '0001'; // Too short
-      expect(() =>
+      await expect(
         tonMnemonicFromEntropy(invalidEntropy, testPassword),
-      ).toThrow();
+      ).rejects.toThrow();
     });
 
     it('should generate different mnemonics for different entropy', async () => {
@@ -1871,8 +1880,14 @@ describe('Secret Module Tests', () => {
         TEST_TON_MNEMONIC2,
         testPassword,
       );
-      const mnemonic1 = tonMnemonicFromEntropy(encryptedSeed, testPassword);
-      const mnemonic2 = tonMnemonicFromEntropy(encryptedSeed2, testPassword);
+      const mnemonic1 = await tonMnemonicFromEntropy(
+        encryptedSeed,
+        testPassword,
+      );
+      const mnemonic2 = await tonMnemonicFromEntropy(
+        encryptedSeed2,
+        testPassword,
+      );
 
       expect(mnemonic1).not.toBe(mnemonic2);
       expect(mnemonic1).toMatchSnapshot('ton-mnemonic-1');
@@ -1885,7 +1900,10 @@ describe('Secret Module Tests', () => {
         testPassword,
       );
 
-      const mnemonic = tonMnemonicFromEntropy(encryptedSeed, testPassword);
+      const mnemonic = await tonMnemonicFromEntropy(
+        encryptedSeed,
+        testPassword,
+      );
       expect(typeof mnemonic).toBe('string');
       expect(mnemonic.split(' ').length).toBe(24); // TON uses 24 words
     });
@@ -1895,9 +1913,9 @@ describe('Secret Module Tests', () => {
         TEST_TON_MNEMONIC,
         testPassword,
       );
-      expect(() =>
+      await expect(
         tonMnemonicFromEntropy(encryptedSeed, 'wrong-password'),
-      ).toThrow();
+      ).rejects.toThrow();
     });
 
     it('should match snapshot', async () => {
@@ -1905,7 +1923,10 @@ describe('Secret Module Tests', () => {
         TEST_TON_MNEMONIC,
         testPassword,
       );
-      const mnemonic = tonMnemonicFromEntropy(encryptedSeed, testPassword);
+      const mnemonic = await tonMnemonicFromEntropy(
+        encryptedSeed,
+        testPassword,
+      );
       expect(mnemonic).toMatchSnapshot();
     });
   });
@@ -1922,7 +1943,7 @@ describe('Secret Module Tests', () => {
       );
       expect(encryptedSeed).toBeDefined();
 
-      const decryptedSeed = decryptRevealableSeed({
+      const decryptedSeed = await decryptRevealableSeed({
         rs: encryptedSeed,
         password: testPassword,
       });
@@ -1936,7 +1957,7 @@ describe('Secret Module Tests', () => {
       );
     });
 
-    // TODO: revealableSeedFromTonMnemonic should validate mnemonic before return, should make it async
+    // TODO: revealableSeedFromTonMnemonic should validate mnemonic before return, should make it async first
     it.skip('should throw InvalidMnemonic for malformed input', async () => {
       await expect(
         revealableSeedFromTonMnemonic('', testPassword),
@@ -1968,80 +1989,88 @@ describe('Secret Module Tests', () => {
     const testDigest = Buffer.from('0123456789abcdef0123456789abcdef', 'hex');
     const encryptedPrivateKey = encrypt(testPassword, testPrivateKey);
 
-    it('should verify secp256k1 signatures correctly', () => {
-      const signature = sign(
+    it('should verify secp256k1 signatures correctly', async () => {
+      const signature = await sign(
         'secp256k1',
         encryptedPrivateKey,
         testDigest,
         testPassword,
       );
-      const publicKey = publicFromPrivate(
+      const publicKey = await publicFromPrivate(
         'secp256k1',
         encryptedPrivateKey,
         testPassword,
       );
 
-      expect(verify('secp256k1', publicKey, testDigest, signature)).toBe(true);
+      const verifyResult = verify(
+        'secp256k1',
+        publicKey,
+        testDigest,
+        signature,
+      );
+      expect(verifyResult).toBe(true);
       expect({
-        publicKey: publicKey.toString('hex'),
-        digest: testDigest.toString('hex'),
-        signature: signature.toString('hex'),
-        result: verify('secp256k1', publicKey, testDigest, signature),
+        publicKey: bufferUtils.bytesToHex(publicKey),
+        digest: bufferUtils.bytesToHex(testDigest),
+        signature: bufferUtils.bytesToHex(signature),
+        result: verifyResult,
       }).toMatchSnapshot('secp256k1-verify');
     });
 
-    it('should verify nistp256 signatures correctly', () => {
-      const signature = sign(
+    it('should verify nistp256 signatures correctly', async () => {
+      const signature = await sign(
         'nistp256',
         encryptedPrivateKey,
         testDigest,
         testPassword,
       );
-      const publicKey = publicFromPrivate(
+      const publicKey = await publicFromPrivate(
         'nistp256',
         encryptedPrivateKey,
         testPassword,
       );
 
-      expect(verify('nistp256', publicKey, testDigest, signature)).toBe(true);
+      const verifyResult = verify('nistp256', publicKey, testDigest, signature);
+      expect(verifyResult).toBe(true);
       expect({
-        publicKey: publicKey.toString('hex'),
-        digest: testDigest.toString('hex'),
-        signature: signature.toString('hex'),
-        result: verify('nistp256', publicKey, testDigest, signature),
+        publicKey: bufferUtils.bytesToHex(publicKey),
+        digest: bufferUtils.bytesToHex(testDigest),
+        signature: bufferUtils.bytesToHex(signature),
+        result: verifyResult,
       }).toMatchSnapshot('nistp256-verify');
     });
 
-    it('should verify ed25519 signatures correctly', () => {
-      const signature = sign(
+    it('should verify ed25519 signatures correctly', async () => {
+      const signature = await sign(
         'ed25519',
         encryptedPrivateKey,
         testDigest,
         testPassword,
       );
-      const publicKey = publicFromPrivate(
+      const publicKey = await publicFromPrivate(
         'ed25519',
         encryptedPrivateKey,
         testPassword,
       );
 
-      expect(verify('ed25519', publicKey, testDigest, signature)).toBe(true);
+      const verifyResult = verify('ed25519', publicKey, testDigest, signature);
+      expect(verifyResult).toBe(true);
       expect({
-        publicKey: publicKey.toString('hex'),
-        digest: testDigest.toString('hex'),
-        signature: signature.toString('hex'),
-        result: verify('ed25519', publicKey, testDigest, signature),
+        publicKey: bufferUtils.bytesToHex(publicKey),
+        digest: bufferUtils.bytesToHex(testDigest),
+        signature: bufferUtils.bytesToHex(signature),
+        result: verifyResult,
       }).toMatchSnapshot('ed25519-verify');
     });
 
-    it('should return false for invalid signatures', () => {
-      const signature = sign(
+    it('should return false for invalid signatures', async () => {
+      const signature = await sign(
         'secp256k1',
         encryptedPrivateKey,
         testDigest,
         testPassword,
       );
-      const publicKey = publicFromPrivate(
+      const publicKey = await publicFromPrivate(
         'secp256k1',
         encryptedPrivateKey,
         testPassword,
@@ -2051,18 +2080,22 @@ describe('Secret Module Tests', () => {
         'hex',
       );
 
-      expect(verify('secp256k1', publicKey, wrongDigest, signature)).toBe(
-        false,
+      const verifyResult = verify(
+        'secp256k1',
+        publicKey,
+        wrongDigest,
+        signature,
       );
+      expect(verifyResult).toBe(false);
       expect({
-        publicKey: publicKey.toString('hex'),
-        wrongDigest: wrongDigest.toString('hex'),
-        signature: signature.toString('hex'),
-        result: verify('secp256k1', publicKey, wrongDigest, signature),
+        publicKey: bufferUtils.bytesToHex(publicKey),
+        wrongDigest: bufferUtils.bytesToHex(wrongDigest),
+        signature: bufferUtils.bytesToHex(signature),
+        result: verifyResult,
       }).toMatchSnapshot('invalid-verify');
     });
 
-    it('should throw error for invalid curve', () => {
+    it('should throw error for invalid curve', async () => {
       const signature = Buffer.from('00'.repeat(64), 'hex');
       const publicKey = Buffer.from('00'.repeat(33), 'hex');
       expect(() =>

--- a/packages/core/src/secret/encryptors/__tests__/aes256.test.ts
+++ b/packages/core/src/secret/encryptors/__tests__/aes256.test.ts
@@ -21,7 +21,7 @@ describe('aes256', () => {
   describe('encrypt/decrypt', () => {
     it('should encrypt and decrypt data correctly using sync methods', () => {
       const encrypted = encrypt(testPassword, testBuffer, true);
-      const decrypted = decrypt(testPassword, encrypted, false, true);
+      const decrypted = decrypt(testPassword, encrypted, true, true);
       expect(decrypted.toString()).toBe(testData);
     });
 
@@ -30,7 +30,7 @@ describe('aes256', () => {
         password: testPassword,
         data: testBuffer,
       });
-      const decrypted = decrypt(testPassword, encrypted, false, true);
+      const decrypted = decrypt(testPassword, encrypted, true, true);
       expect(decrypted.toString()).toBe(testData);
     });
 

--- a/packages/core/src/secret/encryptors/__tests__/aes256.test.ts
+++ b/packages/core/src/secret/encryptors/__tests__/aes256.test.ts
@@ -30,7 +30,7 @@ describe('aes256', () => {
         password: testPassword,
         data: testBuffer,
       });
-      const decrypted = decrypt(testPassword, encrypted, true, true);
+      const decrypted = decrypt(testPassword, encrypted, false, true);
       expect(decrypted.toString()).toBe(testData);
     });
 

--- a/packages/core/src/secret/encryptors/__tests__/aes256.test.ts
+++ b/packages/core/src/secret/encryptors/__tests__/aes256.test.ts
@@ -21,7 +21,7 @@ describe('aes256', () => {
   describe('encrypt/decrypt', () => {
     it('should encrypt and decrypt data correctly using sync methods', () => {
       const encrypted = encrypt(testPassword, testBuffer, true);
-      const decrypted = decrypt(testPassword, encrypted, true, true);
+      const decrypted = decrypt(testPassword, encrypted, false, true);
       expect(decrypted.toString()).toBe(testData);
     });
 

--- a/packages/core/src/secret/encryptors/aes256.ts
+++ b/packages/core/src/secret/encryptors/aes256.ts
@@ -59,6 +59,10 @@ function isEncodedSensitiveText(text: string) {
   );
 }
 
+/**
+ * @deprecated 已弃用 - Use decodePasswordAsync instead. This synchronous decoding method will be removed in a future version.
+ * @see decodePasswordAsync
+ */
 function decodePassword({
   password,
   key,
@@ -81,6 +85,47 @@ function decodePassword({
     }
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return decodeSensitiveText({ encodedText: password, key, ignoreLogger });
+  }
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    password &&
+    !platformEnv.isJest &&
+    !allowRawPassword
+  ) {
+    console.error(
+      'Passing raw password is not allowed and not safe, please encode it at the beginning of debugger breakpoint call stack.',
+    );
+    throw new Error('Passing raw password is not allowed and not safe.');
+  }
+  return password;
+}
+
+async function decodePasswordAsync({
+  password,
+  key,
+  ignoreLogger,
+  allowRawPassword,
+}: {
+  password: string;
+  key?: string;
+  ignoreLogger?: boolean;
+  allowRawPassword?: boolean;
+}): Promise<string> {
+  // do nothing if password is encodeKey, but not a real password
+  if (password.startsWith(encodeKeyPrefix)) {
+    return password;
+  }
+  // decode password if it is encoded
+  if (isEncodedSensitiveText(password)) {
+    if (platformEnv.isExtensionUi) {
+      throw new Error('decodePassword can NOT be called from UI');
+    }
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    return decodeSensitiveTextAsync({
+      encodedText: password,
+      key,
+      ignoreLogger,
+    });
   }
   if (
     process.env.NODE_ENV !== 'production' &&
@@ -190,9 +235,6 @@ async function encryptAsync({
     throw new IncorrectPassword();
   }
 
-  const passwordDecoded = decodePassword({ password, allowRawPassword });
-  const dataBuffer = bufferUtils.toBuffer(data);
-
   if (platformEnv.isNative && !platformEnv.isJest) {
     const webembedApiProxy = (
       await import('@onekeyhq/kit-bg/src/webembeds/instance/webembedApiProxy')
@@ -206,6 +248,9 @@ async function encryptAsync({
     return bufferUtils.toBuffer(str, 'hex');
   }
 
+  const passwordDecoded = decodePassword({ password, allowRawPassword });
+  const dataBuffer = bufferUtils.toBuffer(data);
+
   const salt: Buffer = crypto.randomBytes(PBKDF2_SALT_LENGTH);
   const key: Buffer = keyFromPasswordAndSalt(passwordDecoded, salt);
   const iv: Buffer = crypto.randomBytes(AES256_IV_LENGTH);
@@ -216,6 +261,10 @@ async function encryptAsync({
   ]);
 }
 
+/**
+ * @deprecated 已弃用 - Use decryptAsync instead. This synchronous decryption method will be removed in a future version.
+ * @see decryptAsync
+ */
 function decrypt(
   password: string,
   data: Buffer | string,
@@ -223,6 +272,12 @@ function decrypt(
   ignoreLogger?: boolean,
   allowRawPassword?: boolean,
 ): Buffer {
+  if (!ignoreLogger) {
+    console.warn(
+      'decrypt() 已弃用 (deprecated). Please use decryptAsync() instead',
+    );
+    console.trace('decrypt() call stack');
+  }
   if (!password) {
     throw new IncorrectPassword();
   }
@@ -237,9 +292,6 @@ function decrypt(
     ignoreLogger: true,
     allowRawPassword,
   });
-  if (!passwordDecoded) {
-    throw new IncorrectPassword();
-  }
   if (!ignoreLogger) {
     defaultLogger.account.secretPerf.decodePasswordDone();
   }
@@ -293,15 +345,24 @@ export type IDecryptAsyncParams = {
   password: string;
   data: Buffer | string;
   allowRawPassword?: boolean;
+  ignoreLogger?: boolean;
 };
+/**
+ * The recommended asynchronous decryption method
+ * @param password - The password to decrypt with
+ * @param data - The data to decrypt
+ * @param allowRawPassword - Whether to allow raw password input
+ * @returns Promise<Buffer> - The decrypted data
+ */
 async function decryptAsync({
   password,
   data,
   allowRawPassword,
+  ignoreLogger,
 }: IDecryptAsyncParams): Promise<Buffer> {
-  // eslint-disable-next-line no-param-reassign
-  const passwordDecoded = decodePassword({ password, allowRawPassword });
-
+  if (!password) {
+    throw new IncorrectPassword();
+  }
   if (platformEnv.isNative && !platformEnv.isJest) {
     const webembedApiProxy = (
       await import('@onekeyhq/kit-bg/src/webembeds/instance/webembedApiProxy')
@@ -311,11 +372,71 @@ async function decryptAsync({
       // data,
       data: bufferUtils.bytesToHex(data),
       allowRawPassword,
+      ignoreLogger,
     });
     return bufferUtils.toBuffer(str, 'hex');
   }
 
-  return Promise.resolve(decrypt(passwordDecoded, data));
+  if (!ignoreLogger) {
+    defaultLogger.account.secretPerf.decodePassword();
+  }
+  // eslint-disable-next-line no-param-reassign
+  const passwordDecoded = await decodePasswordAsync({
+    password,
+    allowRawPassword,
+    ignoreLogger: true,
+  });
+  if (!passwordDecoded) {
+    throw new IncorrectPassword();
+  }
+  if (!ignoreLogger) {
+    defaultLogger.account.secretPerf.decodePasswordDone();
+  }
+
+  const dataBuffer = bufferUtils.toBuffer(data);
+  const salt: Buffer = dataBuffer.slice(0, PBKDF2_SALT_LENGTH);
+
+  if (!ignoreLogger) {
+    defaultLogger.account.secretPerf.keyFromPasswordAndSalt();
+  }
+  const key: Buffer = keyFromPasswordAndSalt(passwordDecoded, salt);
+  if (!ignoreLogger) {
+    defaultLogger.account.secretPerf.keyFromPasswordAndSaltDone();
+  }
+
+  const iv: Buffer = dataBuffer.slice(
+    PBKDF2_SALT_LENGTH,
+    ENCRYPTED_DATA_OFFSET,
+  );
+
+  try {
+    if (!ignoreLogger) {
+      defaultLogger.account.secretPerf.decryptAES();
+    }
+    // TODO make to async call RN_AES(@metamask/react-native-aes-crypto)
+    // const aesDecryptData = await RN_AES.decrypt(
+    //   dataBuffer.slice(ENCRYPTED_DATA_OFFSET).toString('base64'),
+    //   key.toString('base64'),
+    //   iv.toString('base64'),
+    // );
+
+    const aesDecryptData = AES_CBC.decrypt(
+      dataBuffer.slice(ENCRYPTED_DATA_OFFSET),
+      key,
+      true,
+      iv,
+    );
+    if (!ignoreLogger) {
+      defaultLogger.account.secretPerf.decryptAESDone();
+    }
+
+    return Buffer.from(aesDecryptData);
+  } catch (e) {
+    if (!platformEnv.isJest) {
+      console.error(e);
+    }
+    throw new IncorrectPassword();
+  }
 }
 
 export type IDecryptStringParams = {
@@ -325,6 +446,10 @@ export type IDecryptStringParams = {
   dataEncoding?: BufferEncoding;
   allowRawPassword?: boolean;
 };
+/**
+ * @deprecated 已弃用 - Use decryptStringAsync instead. This synchronous decryption method will be removed in a future version.
+ * @see decryptStringAsync
+ */
 function decryptString({
   password,
   data,
@@ -332,12 +457,34 @@ function decryptString({
   dataEncoding = 'hex',
   allowRawPassword,
 }: IDecryptStringParams): string {
+  console.warn(
+    'decryptString() 已弃用 (deprecated). Please use decryptStringAsync() instead',
+  );
+  console.trace('decryptString() call stack');
   const bytes = decrypt(
     password,
     bufferUtils.toBuffer(data, dataEncoding),
     undefined,
     allowRawPassword,
   );
+  if (resultEncoding === 'hex') {
+    return bufferUtils.bytesToHex(bytes);
+  }
+  return bufferUtils.bytesToText(bytes, resultEncoding);
+}
+
+async function decryptStringAsync({
+  password,
+  data,
+  resultEncoding = 'hex',
+  dataEncoding = 'hex',
+  allowRawPassword,
+}: IDecryptStringParams): Promise<string> {
+  const bytes = await decryptAsync({
+    password,
+    data: bufferUtils.toBuffer(data, dataEncoding),
+    allowRawPassword,
+  });
   if (resultEncoding === 'hex') {
     return bufferUtils.bytesToHex(bytes);
   }
@@ -373,6 +520,10 @@ function ensureSensitiveTextEncoded(text: string) {
   }
 }
 
+/**
+ * @deprecated 已弃用 - Use decodeSensitiveTextAsync instead. This synchronous decoding method will be removed in a future version.
+ * @see decodeSensitiveTextAsync
+ */
 function decodeSensitiveText({
   encodedText,
   key,
@@ -384,7 +535,11 @@ function decodeSensitiveText({
   // avoid recursive call log output order confusion
   ignoreLogger?: boolean;
   allowRawPassword?: boolean;
-}) {
+}): string {
+  console.warn(
+    'decodeSensitiveText() 已弃用 (deprecated). Please use decodeSensitiveTextAsync() instead',
+  );
+  console.trace('decodeSensitiveText() call stack');
   checkKeyPassedOnExtUi(key);
   const theKey = key || encodeKey;
   ensureEncodeKeyExists(theKey);
@@ -397,6 +552,44 @@ function decodeSensitiveText({
         allowRawPassword,
       ).toString('utf-8');
       return text;
+    }
+    if (encodedText.startsWith(ENCODE_TEXT_PREFIX.xor)) {
+      const text = xorDecrypt({
+        encryptedDataHex: encodedText.slice(ENCODE_TEXT_PREFIX.xor.length),
+        key: theKey,
+      });
+      return text;
+    }
+  }
+  throw new Error('Not correct encoded text');
+}
+
+async function decodeSensitiveTextAsync({
+  encodedText,
+  key,
+  ignoreLogger,
+  allowRawPassword,
+}: {
+  encodedText: string;
+  key?: string;
+  // avoid recursive call log output order confusion
+  ignoreLogger?: boolean;
+  allowRawPassword?: boolean;
+}): Promise<string> {
+  checkKeyPassedOnExtUi(key);
+  const theKey = key || encodeKey;
+  ensureEncodeKeyExists(theKey);
+  if (isEncodedSensitiveText(encodedText)) {
+    if (encodedText.startsWith(ENCODE_TEXT_PREFIX.aes)) {
+      const decrypted = await decryptAsync({
+        password: theKey,
+        data: Buffer.from(
+          encodedText.slice(ENCODE_TEXT_PREFIX.aes.length),
+          'hex',
+        ),
+        allowRawPassword,
+      });
+      return decrypted.toString('utf-8');
     }
     if (encodedText.startsWith(ENCODE_TEXT_PREFIX.xor)) {
       const text = xorDecrypt({
@@ -484,10 +677,13 @@ function setBgSensitiveTextEncodeKey(key: string) {
 
 export {
   decodePassword,
+  decodePasswordAsync,
   decodeSensitiveText,
+  decodeSensitiveTextAsync,
   decrypt,
   decryptAsync,
   decryptString,
+  decryptStringAsync,
   encodePassword,
   encodeSensitiveText,
   encrypt,

--- a/packages/core/src/secret/encryptors/aes256.ts
+++ b/packages/core/src/secret/encryptors/aes256.ts
@@ -249,6 +249,11 @@ async function encryptAsync({
   }
 
   const passwordDecoded = decodePassword({ password, allowRawPassword });
+
+  if (!passwordDecoded) {
+    throw new IncorrectPassword();
+  }
+
   const dataBuffer = bufferUtils.toBuffer(data);
 
   const salt: Buffer = crypto.randomBytes(PBKDF2_SALT_LENGTH);
@@ -292,6 +297,11 @@ function decrypt(
     ignoreLogger: true,
     allowRawPassword,
   });
+
+  if (!passwordDecoded) {
+    throw new IncorrectPassword();
+  }
+
   if (!ignoreLogger) {
     defaultLogger.account.secretPerf.decodePasswordDone();
   }

--- a/packages/kit-bg/src/migrations/v4ToV5Migration/V4MigrationForAccount.ts
+++ b/packages/kit-bg/src/migrations/v4ToV5Migration/V4MigrationForAccount.ts
@@ -7,7 +7,7 @@ import {
 } from '@onekeyhq/core/src/chains/btc/sdkBtc';
 import { verifyNexaAddressPrefix } from '@onekeyhq/core/src/chains/nexa/sdkNexa';
 import {
-  decrypt,
+  decryptAsync,
   encodeSensitiveText,
   encryptImportedCredential,
   fixV4VerifyStringToV5,
@@ -98,7 +98,10 @@ export class V4MigrationForAccount extends V4MigrationManagerBase {
     if (v4dbCredential.id.startsWith('imported-')) {
       const credentialImported = credential as IV4DBImportedCredentialRaw;
       const privateKey = bufferUtils.bytesToHex(
-        decrypt(encodedPassword, credentialImported.privateKey),
+        await decryptAsync({
+          password: encodedPassword,
+          data: credentialImported.privateKey,
+        }),
       );
       const v4account = await v4dbHubs.v4localDb.getRecordById({
         name: EV4LocalDBStoreNames.Account,
@@ -182,7 +185,10 @@ export class V4MigrationForAccount extends V4MigrationManagerBase {
     if (v4dbCredential.id.startsWith('hd-')) {
       const credentialHD = credential as IV4DBHdCredentialRaw;
       // TODO fallback to v4 password prompt
-      const entropy = decrypt(encodedPassword, credentialHD.entropy);
+      const entropy = await decryptAsync({
+        password: encodedPassword,
+        data: credentialHD.entropy,
+      });
       const wallet = await v4dbHubs.v4localDb.getRecordById({
         name: EV4LocalDBStoreNames.Wallet,
         id: v4dbCredential.id,

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -334,7 +334,7 @@ class ServiceAccount extends ServiceBase {
     password: string;
   }) {
     ensureSensitiveTextEncoded(password);
-    const rs = decryptRevealableSeed({
+    const rs = await decryptRevealableSeed({
       rs: credential,
       password,
     });
@@ -2125,7 +2125,8 @@ class ServiceAccount extends ServiceBase {
     } catch {
       throw new InvalidMnemonic();
     }
-    if (realMnemonic !== mnemonicFromEntropy(rs, password)) {
+    const mnemonicFromRs = await mnemonicFromEntropy(rs, password);
+    if (realMnemonic !== mnemonicFromRs) {
       throw new InvalidMnemonic();
     }
 
@@ -2158,7 +2159,8 @@ class ServiceAccount extends ServiceBase {
       throw new InvalidMnemonic();
     }
 
-    if (realMnemonic !== tonMnemonicFromEntropy(rs, password)) {
+    const tonMnemonicFromRs = await tonMnemonicFromEntropy(rs, password);
+    if (realMnemonic !== tonMnemonicFromRs) {
       throw new InvalidMnemonic();
     }
     await localDb.saveTonImportedAccountMnemonic({ accountId, rs });
@@ -2389,10 +2391,14 @@ class ServiceAccount extends ServiceBase {
         reason,
       });
     const credential = await localDb.getCredential(walletId);
-    let mnemonic = mnemonicFromEntropy(credential.credential, password);
-    mnemonic = await this.backgroundApi.servicePassword.encodeSensitiveText({
-      text: mnemonic,
-    });
+    const mnemonicRaw = await mnemonicFromEntropy(
+      credential.credential,
+      password,
+    );
+    const mnemonic =
+      await this.backgroundApi.servicePassword.encodeSensitiveText({
+        text: mnemonicRaw,
+      });
     return { mnemonic };
   }
 
@@ -2413,10 +2419,14 @@ class ServiceAccount extends ServiceBase {
         accountId,
       }),
     );
-    let mnemonic = tonMnemonicFromEntropy(credential.credential, password);
-    mnemonic = await this.backgroundApi.servicePassword.encodeSensitiveText({
-      text: mnemonic,
-    });
+    const mnemonicRaw = await tonMnemonicFromEntropy(
+      credential.credential,
+      password,
+    );
+    const mnemonic =
+      await this.backgroundApi.servicePassword.encodeSensitiveText({
+        text: mnemonicRaw,
+      });
     return { mnemonic };
   }
 

--- a/packages/kit-bg/src/services/ServiceV4Migration/ServiceV4Migration.ts
+++ b/packages/kit-bg/src/services/ServiceV4Migration/ServiceV4Migration.ts
@@ -364,7 +364,7 @@ class ServiceV4Migration extends ServiceBase {
     }
     try {
       if (v4DbContext?.verifyString) {
-        const result = decryptVerifyString({
+        const result = await decryptVerifyString({
           password: v5password,
           verifyString: v4DbContext?.verifyString,
         });

--- a/packages/kit-bg/src/vaults/base/KeyringSoftwareBase.ts
+++ b/packages/kit-bg/src/vaults/base/KeyringSoftwareBase.ts
@@ -199,7 +199,7 @@ export abstract class KeyringSoftwareBase extends KeyringBase {
     }
     const { name, importedCredential, password, networks, createAtNetwork } =
       params;
-    const { privateKey } = decryptImportedCredential({
+    const { privateKey } = await decryptImportedCredential({
       credential: importedCredential,
       password,
     });
@@ -268,7 +268,7 @@ export abstract class KeyringSoftwareBase extends KeyringBase {
     }
     const { name, importedCredential, password, createAtNetwork, deriveInfo } =
       params;
-    const { privateKey } = decryptImportedCredential({
+    const { privateKey } = await decryptImportedCredential({
       credential: importedCredential,
       password,
     });

--- a/packages/kit-bg/src/vaults/impls/ada/KeyringImported.ts
+++ b/packages/kit-bg/src/vaults/impls/ada/KeyringImported.ts
@@ -1,8 +1,5 @@
-import { generateXprvFromPrivateKey } from '@onekeyhq/core/src/chains/ada/sdkAda';
 import coreChainApi from '@onekeyhq/core/src/instance/coreChainApi';
-import { decrypt } from '@onekeyhq/core/src/secret';
 import type { ISignedMessagePro, ISignedTxPro } from '@onekeyhq/core/src/types';
-import { checkIsDefined } from '@onekeyhq/shared/src/utils/assertUtils';
 
 import { KeyringImportedBase } from '../../base/KeyringImportedBase';
 

--- a/packages/kit-bg/src/vaults/impls/algo/KeyringHd.ts
+++ b/packages/kit-bg/src/vaults/impls/algo/KeyringHd.ts
@@ -1,10 +1,7 @@
 import coreChainApi from '@onekeyhq/core/src/instance/coreChainApi';
-import { decrypt } from '@onekeyhq/core/src/secret';
 import type { ISignedTxPro } from '@onekeyhq/core/src/types';
 
 import { KeyringHdBase } from '../../base/KeyringHdBase';
-
-import sdkAlgo from './sdkAlgo';
 
 import type { IDBAccount } from '../../../dbs/local/types';
 import type {

--- a/packages/kit-bg/src/vaults/impls/algo/KeyringImported.ts
+++ b/packages/kit-bg/src/vaults/impls/algo/KeyringImported.ts
@@ -1,10 +1,7 @@
 import coreChainApi from '@onekeyhq/core/src/instance/coreChainApi';
-import { decrypt } from '@onekeyhq/core/src/secret';
 import type { ISignedMessagePro, ISignedTxPro } from '@onekeyhq/core/src/types';
 
 import { KeyringImportedBase } from '../../base/KeyringImportedBase';
-
-import sdkAlgo from './sdkAlgo';
 
 import type { IDBAccount } from '../../../dbs/local/types';
 import type {

--- a/packages/kit-bg/src/vaults/impls/fil/KeyringHd.ts
+++ b/packages/kit-bg/src/vaults/impls/fil/KeyringHd.ts
@@ -1,5 +1,4 @@
 import coreChainApi from '@onekeyhq/core/src/instance/coreChainApi';
-import { decrypt } from '@onekeyhq/core/src/secret';
 import type { ISignedTxPro } from '@onekeyhq/core/src/types';
 
 import { KeyringHdBase } from '../../base/KeyringHdBase';

--- a/packages/kit-bg/src/vaults/impls/kaspa/KeyringHd.ts
+++ b/packages/kit-bg/src/vaults/impls/kaspa/KeyringHd.ts
@@ -1,6 +1,4 @@
-import { privateKeyFromBuffer } from '@onekeyhq/core/src/chains/kaspa/sdkKaspa';
 import coreChainApi from '@onekeyhq/core/src/instance/coreChainApi';
-import { decrypt } from '@onekeyhq/core/src/secret';
 import type { ISignedTxPro } from '@onekeyhq/core/src/types';
 
 import { KeyringHdBase } from '../../base/KeyringHdBase';

--- a/packages/kit-bg/src/vaults/impls/kaspa/KeyringImported.ts
+++ b/packages/kit-bg/src/vaults/impls/kaspa/KeyringImported.ts
@@ -1,6 +1,4 @@
-import { privateKeyFromBuffer } from '@onekeyhq/core/src/chains/kaspa/sdkKaspa';
 import coreChainApi from '@onekeyhq/core/src/instance/coreChainApi';
-import { decrypt } from '@onekeyhq/core/src/secret';
 import type { ISignedMessagePro, ISignedTxPro } from '@onekeyhq/core/src/types';
 
 import { KeyringImportedBase } from '../../base/KeyringImportedBase';

--- a/packages/kit-bg/src/vaults/impls/near/KeyringHd.ts
+++ b/packages/kit-bg/src/vaults/impls/near/KeyringHd.ts
@@ -1,10 +1,7 @@
 import coreChainApi from '@onekeyhq/core/src/instance/coreChainApi';
-import { decrypt, ed25519 } from '@onekeyhq/core/src/secret';
 import type { ISignedTxPro } from '@onekeyhq/core/src/types';
 
 import { KeyringHdBase } from '../../base/KeyringHdBase';
-
-import { baseEncode } from './utils';
 
 import type { IDBAccount } from '../../../dbs/local/types';
 import type {

--- a/packages/kit-bg/src/vaults/impls/near/KeyringImported.ts
+++ b/packages/kit-bg/src/vaults/impls/near/KeyringImported.ts
@@ -1,10 +1,7 @@
 import coreChainApi from '@onekeyhq/core/src/instance/coreChainApi';
-import { decrypt, ed25519 } from '@onekeyhq/core/src/secret';
 import type { ISignedMessagePro, ISignedTxPro } from '@onekeyhq/core/src/types';
 
 import { KeyringImportedBase } from '../../base/KeyringImportedBase';
-
-import { baseEncode } from './utils';
 
 import type { IDBAccount } from '../../../dbs/local/types';
 import type {

--- a/packages/kit-bg/src/vaults/impls/nostr/KeyringHd.ts
+++ b/packages/kit-bg/src/vaults/impls/nostr/KeyringHd.ts
@@ -3,7 +3,6 @@ import {
   getPrivateEncodedByNip19,
 } from '@onekeyhq/core/src/chains/nostr/sdkNostr';
 import coreChainApi from '@onekeyhq/core/src/instance/coreChainApi';
-import { decrypt } from '@onekeyhq/core/src/secret';
 import type { ISignedTxPro } from '@onekeyhq/core/src/types';
 import type { IDeviceSharedCallParams } from '@onekeyhq/shared/types/device';
 

--- a/packages/kit-bg/src/vaults/impls/sol/KeyringHd.ts
+++ b/packages/kit-bg/src/vaults/impls/sol/KeyringHd.ts
@@ -1,7 +1,6 @@
 import bs58 from 'bs58';
 
 import coreChainApi from '@onekeyhq/core/src/instance/coreChainApi';
-import { decrypt } from '@onekeyhq/core/src/secret';
 import type { ISignedTxPro } from '@onekeyhq/core/src/types';
 
 import { KeyringHdBase } from '../../base/KeyringHdBase';

--- a/packages/kit-bg/src/vaults/impls/sol/KeyringImported.ts
+++ b/packages/kit-bg/src/vaults/impls/sol/KeyringImported.ts
@@ -1,7 +1,6 @@
 import bs58 from 'bs58';
 
 import coreChainApi from '@onekeyhq/core/src/instance/coreChainApi';
-import { decrypt } from '@onekeyhq/core/src/secret';
 import type { ISignedMessagePro, ISignedTxPro } from '@onekeyhq/core/src/types';
 
 import { KeyringImportedBase } from '../../base/KeyringImportedBase';

--- a/packages/kit-bg/src/vaults/impls/tron/KeyringHd.ts
+++ b/packages/kit-bg/src/vaults/impls/tron/KeyringHd.ts
@@ -1,5 +1,4 @@
 import coreChainApi from '@onekeyhq/core/src/instance/coreChainApi';
-import { decrypt, ed25519 } from '@onekeyhq/core/src/secret';
 import type { ISignedTxPro } from '@onekeyhq/core/src/types';
 import { NotImplemented } from '@onekeyhq/shared/src/errors';
 

--- a/packages/kit-bg/src/vaults/impls/tron/KeyringImported.ts
+++ b/packages/kit-bg/src/vaults/impls/tron/KeyringImported.ts
@@ -1,5 +1,4 @@
 import coreChainApi from '@onekeyhq/core/src/instance/coreChainApi';
-import { decrypt } from '@onekeyhq/core/src/secret';
 import type { ISignedMessagePro, ISignedTxPro } from '@onekeyhq/core/src/types';
 import { NotImplemented } from '@onekeyhq/shared/src/errors';
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Based on the comprehensive summary, here are the high-level release notes:

- **Asynchronous Improvements**
	- Transitioned multiple cryptographic and decryption operations to asynchronous methods
	- Added `decryptAsync` to replace synchronous `decrypt` functions
	- Updated test suites to support asynchronous operations

- **Cryptographic Enhancements**
	- Improved handling of private key and credential decryption
	- Enhanced security-related method signatures to return promises
	- Streamlined password verification processes

- **Test Coverage**
	- Updated test cases across multiple blockchain implementations to use async/await
	- Ensured consistent asynchronous handling in test environments

- **Deprecation Warnings**
	- Added deprecation notices for synchronous decryption methods
	- Encouraged migration to new asynchronous counterparts

The changes primarily focus on modernizing the codebase's approach to handling sensitive cryptographic operations, ensuring better performance and more robust error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->