### PR TITLE
fix: global derive type for batch create OK-34712

### DIFF
--- a/packages/kit/src/components/AccountSelector/DeriveTypeSelectorTrigger.tsx
+++ b/packages/kit/src/components/AccountSelector/DeriveTypeSelectorTrigger.tsx
@@ -464,7 +464,9 @@ export function DeriveTypeSelectorFormInput(
           fixedValue = defaultDeriveType;
         }
         shouldResetDeriveTypeWhenNetworkChanged.current = false;
-        onDeriveTypeChange?.(fixedValue || 'default');
+        if (fixedValue) {
+          onDeriveTypeChange?.(fixedValue);
+        }
       }
     })();
   }, [deriveType, networkId, onDeriveTypeChange, viewItems]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved derive type selector handling to prevent unnecessary function calls when no valid derive type is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->