### PR TITLE
fix: ada async method OK-34817

### DIFF
--- a/packages/core/src/chains/ada/sdkAda/bip32.ts
+++ b/packages/core/src/chains/ada/sdkAda/bip32.ts
@@ -30,7 +30,7 @@ export async function getRootKey(
   password: string,
   hdCredential: ICoreHdCredentialEncryptHex,
 ): Promise<Buffer> {
-  const mnemonic = mnemonicFromEntropy(hdCredential, password);
+  const mnemonic: string = await mnemonicFromEntropy(hdCredential, password);
   const rootKey = await mnemonicToRootKeypair(mnemonic, DERIVATION_SCHEME);
   return rootKey;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced type safety for the `mnemonic` variable in the `getRootKey` function
	- Explicitly declared `mnemonic` as a string type

<!-- end of auto-generated comment: release notes by coderabbit.ai -->