### PR TITLE
test: add unit tests for hash functions in secret/hash.ts

### DIFF
--- a/packages/core/src/secret/__tests__/__snapshots__/secret-hash.test.ts.snap.web
+++ b/packages/core/src/secret/__tests__/__snapshots__/secret-hash.test.ts.snap.web
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Hash Functions hash160 should match snapshot 1`] = `"a54bc3b936756940bc8c80713f3ebb0efa870eed"`;
+
+exports[`Hash Functions hash160 should match snapshot with empty data 1`] = `"b472a266d0bd89c13706a4132ccfb16f7c3b9fcb"`;
+
+exports[`Hash Functions hmacSHA256 should match snapshot 1`] = `"21a286fd6fd9f52676007c66d0f883db46d06158c266d33fb537c23bc618e567"`;
+
+exports[`Hash Functions hmacSHA256 should match snapshot with empty data 1`] = `"2711cc23e9ab1b8a9bc0fe991238da92671624a9ebdaf1c1abec06e7e9a14f9b"`;
+
+exports[`Hash Functions hmacSHA256 should match snapshot with empty key 1`] = `"51931855b3cc798605f46274a97c2b8a4879b871bb814a0696031c8ba307f6a0"`;
+
+exports[`Hash Functions hmacSHA512 should match snapshot 1`] = `"080e166f475f1c5d61f26b94d45a0cd822729a525e3a3865b87cdf58a36f039ea1948735aab3ad5027d553ad06487fb57d3a9034d2861300297d6cebf838f5bf"`;
+
+exports[`Hash Functions hmacSHA512 should match snapshot with empty data 1`] = `"d79bf88724d52a1cccf5a0a3ca1b6c803c96dba1c0229b4aa1d7c449eae348fced07751c55d2dbb535b354e7f12dbeb060a4febc6c28c92fadc8f11fb4ee25e0"`;
+
+exports[`Hash Functions hmacSHA512 should match snapshot with empty key 1`] = `"3886f0e449dda34f64d9cd3020edfa24fbb7e4e29962c072fe8018229465c4a1d196fce4ac5a378a42f2b63bab1f9208033dddd7d3acd8ce7907548caad93836"`;
+
+exports[`Hash Functions sha256 should match snapshot 1`] = `"a186000422feab857329c684e9fe91412b1a5db084100b37a98cfc95b62aa867"`;
+
+exports[`Hash Functions sha256 should match snapshot with empty data 1`] = `"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"`;

--- a/packages/core/src/secret/__tests__/secret-hash.test.ts
+++ b/packages/core/src/secret/__tests__/secret-hash.test.ts
@@ -1,0 +1,77 @@
+import { hmacSHA256, hmacSHA512, sha256, hash160 } from '../hash';
+
+describe('Hash Functions', () => {
+  describe('hmacSHA256', () => {
+    it('should match snapshot', () => {
+      const key = Buffer.from('test-key');
+      const data = Buffer.from('test-data');
+      const result = hmacSHA256(key, data);
+      expect(result.toString('hex')).toMatchSnapshot();
+    });
+
+    it('should match snapshot with empty data', () => {
+      const key = Buffer.from('test-key');
+      const data = Buffer.from('');
+      const result = hmacSHA256(key, data);
+      expect(result.toString('hex')).toMatchSnapshot();
+    });
+
+    it('should match snapshot with empty key', () => {
+      const key = Buffer.from('');
+      const data = Buffer.from('test-data');
+      const result = hmacSHA256(key, data);
+      expect(result.toString('hex')).toMatchSnapshot();
+    });
+  });
+
+  describe('hmacSHA512', () => {
+    it('should match snapshot', () => {
+      const key = Buffer.from('test-key');
+      const data = Buffer.from('test-data');
+      const result = hmacSHA512(key, data);
+      expect(result.toString('hex')).toMatchSnapshot();
+    });
+
+    it('should match snapshot with empty data', () => {
+      const key = Buffer.from('test-key');
+      const data = Buffer.from('');
+      const result = hmacSHA512(key, data);
+      expect(result.toString('hex')).toMatchSnapshot();
+    });
+
+    it('should match snapshot with empty key', () => {
+      const key = Buffer.from('');
+      const data = Buffer.from('test-data');
+      const result = hmacSHA512(key, data);
+      expect(result.toString('hex')).toMatchSnapshot();
+    });
+  });
+
+  describe('sha256', () => {
+    it('should match snapshot', () => {
+      const data = Buffer.from('test-data');
+      const result = sha256(data);
+      expect(result.toString('hex')).toMatchSnapshot();
+    });
+
+    it('should match snapshot with empty data', () => {
+      const data = Buffer.from('');
+      const result = sha256(data);
+      expect(result.toString('hex')).toMatchSnapshot();
+    });
+  });
+
+  describe('hash160', () => {
+    it('should match snapshot', () => {
+      const data = Buffer.from('test-data');
+      const result = hash160(data);
+      expect(result.toString('hex')).toMatchSnapshot();
+    });
+
+    it('should match snapshot with empty data', () => {
+      const data = Buffer.from('');
+      const result = hash160(data);
+      expect(result.toString('hex')).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
Co-Authored-By: dev-fe@onekey.so <dev-fe@onekey.so>
(cherry picked from commit 82239c4c903a4eca6ed085e87f72ae3d746bcb0a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Added comprehensive unit tests for hash functions including `hmacSHA256`, `hmacSHA512`, `sha256`, and `hash160`
	- Introduced snapshot testing to verify consistent behavior of hash functions across different input scenarios
	- Covered edge cases such as empty data and empty keys for multiple hash functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->