### PR TITLE
fix: Morpho rewards unit

### DIFF
--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -46,6 +46,7 @@ import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import type {
   IEarnAccount,
   IEarnAccountToken,
+  IEarnRewardUnit,
 } from '@onekeyhq/shared/types/staking';
 
 import backgroundApiProxy from '../../background/instance/backgroundApiProxy';
@@ -65,7 +66,7 @@ interface ITokenAccount extends IEarnAccountToken {
   account: IEarnAccount;
 }
 
-const buildAprText = (apr: string) => (apr.endsWith('%') ? `${apr} APR` : apr);
+const buildAprText = (apr: string, unit: IEarnRewardUnit) => `${apr} ${unit}`;
 const getNumberColor = (
   value: string | number,
   defaultColor: ISizableTextProps['color'] = '$textSuccess',
@@ -211,7 +212,7 @@ function RecommendedItem({
         </SizableText>
       </XStack>
       <SizableText size="$headingXl" pt="$4" pb="$1">
-        {buildAprText(token.apr)}
+        {buildAprText(token.apr, token.rewardUnit)}
       </SizableText>
       <SizableText size="$bodyMd" color="$textSubdued">
         {`${intl.formatMessage({ id: ETranslations.global_available })}: `}
@@ -535,7 +536,10 @@ function AvailableAssets() {
           }}
         >
           {assets.map(
-            ({ name, logoURI, apr, networkId, symbol, tags = [] }, index) => (
+            (
+              { name, logoURI, apr, networkId, symbol, rewardUnit, tags = [] },
+              index,
+            ) => (
               <ListItem
                 userSelect="none"
                 key={name}
@@ -599,7 +603,7 @@ function AvailableAssets() {
                     flexGrow: 1,
                     flexBasis: 0,
                   }}
-                  primary={buildAprText(apr)}
+                  primary={buildAprText(apr, rewardUnit)}
                 />
               </ListItem>
             ),

--- a/packages/kit/src/views/Staking/components/ApproveBaseStake/index.tsx
+++ b/packages/kit/src/views/Staking/components/ApproveBaseStake/index.tsx
@@ -389,7 +389,7 @@ export const ApproveBaseStake = ({
         {apr && Number(apr) > 0 ? (
           <CalculationListItem>
             <CalculationListItem.Label>
-              {intl.formatMessage({ id: ETranslations.global_apr })}
+              {details.provider.rewardUnit}
             </CalculationListItem.Label>
             <CalculationListItem.Value color="$textSuccess">{`${apr}%`}</CalculationListItem.Value>
           </CalculationListItem>

--- a/packages/kit/src/views/Staking/components/ProtocolDetails/ProfitSection.tsx
+++ b/packages/kit/src/views/Staking/components/ProtocolDetails/ProfitSection.tsx
@@ -12,6 +12,7 @@ import {
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type {
+  IEarnRewardUnit,
   IRewardApys,
   IStakeProtocolDetails,
 } from '@onekeyhq/shared/types/staking';
@@ -25,6 +26,7 @@ import { MorphoApy } from './MorphoApy';
 type IProfitInfoProps = {
   apr?: string;
   apys?: IRewardApys;
+  rewardUnit: IEarnRewardUnit;
   rewardAssets?: Record<string, IToken>;
   earningsIn24h?: string;
   rewardToken?: string;
@@ -47,6 +49,7 @@ function ProfitInfo({
   unstakingPeriod,
   stakingTime,
   earnPoints,
+  rewardUnit,
 }: IProfitInfoProps) {
   const intl = useIntl();
 
@@ -77,9 +80,7 @@ function ProfitInfo({
             >
               <XStack gap="$1" alignItems="center">
                 <SizableText size="$bodyLgMedium" color="$textSuccess">
-                  {`${apr}% ${intl.formatMessage({
-                    id: ETranslations.global_apr,
-                  })}`}
+                  {`${apr}% ${rewardUnit}`}
                 </SizableText>
                 {apys ? (
                   <Popover
@@ -196,6 +197,7 @@ export const ProfitSection = ({
     unstakingPeriod: details.unstakingPeriod,
     stakingTime: details.provider.stakingTime,
     nextLaunchLeft: details.provider.nextLaunchLeft,
+    rewardUnit: details.provider.rewardUnit,
   };
   return <ProfitInfo {...props} />;
 };

--- a/packages/kit/src/views/Staking/components/UniversalStake/index.tsx
+++ b/packages/kit/src/views/Staking/components/UniversalStake/index.tsx
@@ -425,7 +425,7 @@ export const UniversalStake = ({
         {apr && Number(apr) > 0 ? (
           <CalculationListItem>
             <CalculationListItem.Label>
-              {intl.formatMessage({ id: ETranslations.global_apr })}
+              {details.provider.rewardUnit}
             </CalculationListItem.Label>
             <CalculationListItem.Value color="$textSuccess">
               {`${apr}%`}

--- a/packages/kit/src/views/Staking/pages/AssetProtocolList/index.tsx
+++ b/packages/kit/src/views/Staking/pages/AssetProtocolList/index.tsx
@@ -220,7 +220,9 @@ function AssetProtocolListContent({
             align="right"
             primary={
               Number(item.provider.apr) > 0
-                ? `${BigNumber(item.provider.apr ?? 0).toFixed(2)}% APR`
+                ? `${BigNumber(item.provider.apr ?? 0).toFixed(2)}% ${
+                    item.provider.rewardUnit
+                  }`
                 : null
             }
             secondary={

--- a/packages/shared/types/staking.ts
+++ b/packages/shared/types/staking.ts
@@ -67,6 +67,7 @@ export type IStakeProviderInfo = {
 
   apys?: IRewardApys;
   vault?: string;
+  rewardUnit: IEarnRewardUnit;
 };
 
 export type IStakeBaseParams = {
@@ -308,6 +309,7 @@ export interface IEarnAccountToken {
   balanceParsed: string;
   address: string;
   price: string;
+  rewardUnit: IEarnRewardUnit;
 }
 
 export type IEarnAccountResponse = {
@@ -330,6 +332,7 @@ export type IEarnAccountTokenResponse = {
   accounts: IEarnAccount[];
 };
 
+export type IEarnRewardUnit = 'APY' | 'APR';
 export type IAvailableAsset = {
   name: string;
   symbol: string;
@@ -337,6 +340,7 @@ export type IAvailableAsset = {
   apr: string;
   tags: string[];
   networkId: string;
+  rewardUnit: IEarnRewardUnit;
 };
 
 export interface IEarnAtomData {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced APR (Annual Percentage Rate) display with reward unit information
  - Added support for specifying reward units as 'APY' or 'APR'

- **Improvements**
  - Updated staking and earn-related components to show more detailed reward information
  - Improved transparency in displaying annual percentage rates across various screens

- **Technical Updates**
  - Introduced new type `IEarnRewardUnit` to support flexible reward unit representation
  - Updated data models to include reward unit properties in staking-related types

The changes provide users with more precise and contextual information about potential earnings in staking and earn features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->