### PR TITLE
fix: Add morphoVault parameter to estimate-fee api

### DIFF
--- a/packages/kit-bg/src/services/ServiceStaking.ts
+++ b/packages/kit-bg/src/services/ServiceStaking.ts
@@ -983,14 +983,16 @@ class ServiceStaking extends ServiceBase {
     action: IEarnEstimateAction;
     amount: string;
     txId?: string;
+    morphoVault?: string;
   }) {
-    const { symbol, ...rest } = params;
+    const { symbol, morphoVault, ...rest } = params;
     const client = await this.getClient(EServiceEndpointEnum.Earn);
     const resp = await client.get<{
       data: IEarnEstimateFeeResp;
     }>(`/earn/v1/estimate-fee`, {
       params: {
         symbol: symbol.toUpperCase(),
+        vault: morphoVault,
         ...rest,
       },
     });

--- a/packages/kit/src/views/Staking/components/ProtocolDetails/ProtocolRewards.tsx
+++ b/packages/kit/src/views/Staking/components/ProtocolDetails/ProtocolRewards.tsx
@@ -75,9 +75,12 @@ function RewardItem({
       <YStack gap="$2.5">
         <XStack alignItems="center" justifyContent="space-between">
           <XStack alignItems="center">
-            <Token size="sm" tokenImageUri={rewardToken.info?.logoURI} />
+            <Token
+              mr="$1.5"
+              size="sm"
+              tokenImageUri={rewardToken.info?.logoURI}
+            />
             <NumberSizeableText
-              ml="$1.5"
               size="$bodyLgMedium"
               formatter="balance"
               formatterOptions={{ tokenSymbol: rewardToken.info?.symbol }}

--- a/packages/kit/src/views/Staking/hooks/useUniversalHooks.ts
+++ b/packages/kit/src/views/Staking/hooks/useUniversalHooks.ts
@@ -305,6 +305,7 @@ export function useUniversalClaim({
       amount,
       provider,
       claimTokenAddress,
+      morphoVault,
       symbol,
       stakingInfo,
       onSuccess,
@@ -315,6 +316,7 @@ export function useUniversalClaim({
       symbol: string;
       provider: string;
       claimTokenAddress?: string;
+      morphoVault?: string;
       stakingInfo?: IStakingInfo;
       onSuccess?: IModalSendParamList['SendConfirm']['onSuccess'];
       onFail?: IModalSendParamList['SendConfirm']['onFail'];
@@ -374,6 +376,7 @@ export function useUniversalClaim({
             symbol,
             action: 'claim',
             amount,
+            morphoVault,
           });
         const tokenFiatValueBN = BigNumber(
           estimateFeeResp.token.price,

--- a/packages/kit/src/views/Staking/pages/ApproveBaseStake/index.tsx
+++ b/packages/kit/src/views/Staking/pages/ApproveBaseStake/index.tsx
@@ -107,9 +107,10 @@ const BasicApproveBaseStakePage = () => {
       symbol: token.info.symbol,
       action: 'stake',
       amount: '1',
+      morphoVault: provider.vault,
     });
     return resp;
-  }, [networkId, provider.name, token.info.symbol]);
+  }, [networkId, provider.name, token.info.symbol, provider.vault]);
 
   return (
     <Page>

--- a/packages/kit/src/views/Staking/pages/Claim/index.tsx
+++ b/packages/kit/src/views/Staking/pages/Claim/index.tsx
@@ -47,6 +47,7 @@ const ClaimPage = () => {
         identity,
         symbol: tokenInfo.symbol,
         provider: provider.name,
+        morphoVault: provider.vault,
         stakingInfo: {
           label: EEarnLabels.Claim,
           protocol: earnUtils.getEarnProviderName({
@@ -86,9 +87,10 @@ const ClaimPage = () => {
       symbol: tokenInfo.symbol,
       action: 'claim',
       amount: '1',
+      morphoVault: provider.vault,
     });
     return resp;
-  }, [networkId, provider.name, tokenInfo.symbol]);
+  }, [networkId, provider.name, tokenInfo.symbol, provider.vault]);
 
   return (
     <Page>

--- a/packages/kit/src/views/Staking/pages/ClaimOptions/index.tsx
+++ b/packages/kit/src/views/Staking/pages/ClaimOptions/index.tsx
@@ -57,6 +57,7 @@ const ClaimOptions = () => {
         amount: item.amount,
         symbol: details.token.info.symbol,
         provider,
+        morphoVault: details.provider.vault,
         stakingInfo: {
           label: EEarnLabels.Claim,
           protocol: earnUtils.getEarnProviderName({

--- a/packages/kit/src/views/Staking/pages/ProtocolDetails/useHandleClaim.ts
+++ b/packages/kit/src/views/Staking/pages/ProtocolDetails/useHandleClaim.ts
@@ -84,6 +84,7 @@ export const useHandleClaim = ({
               provider,
               stakingInfo,
               claimTokenAddress,
+              morphoVault: details.provider.vault,
             });
           },
         });

--- a/packages/kit/src/views/Staking/pages/Stake/index.tsx
+++ b/packages/kit/src/views/Staking/pages/Stake/index.tsx
@@ -186,9 +186,10 @@ function BasicStakePage() {
       symbol: tokenInfo.symbol,
       action: 'stake',
       amount: '1',
+      morphoVault: provider.vault,
     });
     return resp;
-  }, [networkId, provider.name, tokenInfo.symbol]);
+  }, [networkId, provider.name, tokenInfo.symbol, provider.vault]);
 
   const { result: estimateFeeUTXO } = usePromiseResult(async () => {
     if (!networkUtils.isBTCNetwork(networkId)) {

--- a/packages/kit/src/views/Staking/pages/Withdraw/index.tsx
+++ b/packages/kit/src/views/Staking/pages/Withdraw/index.tsx
@@ -133,9 +133,10 @@ const WithdrawPage = () => {
         provider.name.toLowerCase() === EEarnProviderEnum.Babylon.toLowerCase()
           ? identity
           : undefined,
+      morphoVault: provider.vault,
     });
     return resp;
-  }, [networkId, provider.name, tokenInfo.symbol, identity]);
+  }, [networkId, provider.name, tokenInfo.symbol, identity, provider.vault]);
 
   const { unstakingPeriod, showDetailWithdrawalRequested } = useMemo(() => {
     const showDetail = !!details?.provider?.unstakingTime;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for Morpho vault information in staking-related operations
	- Enhanced fee estimation process to include vault-specific parameters

- **Improvements**
	- Updated claim, stake, and withdraw workflows to incorporate vault context
	- Refined user interface components to better display staking-related information

- **Technical Updates**
	- Modified multiple components and hooks to support new vault-related functionality
	- Expanded parameter handling in staking service methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->