### PR TITLE
fix:swap no select token balance bug ok-35127

### DIFF
--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -1387,7 +1387,10 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         type === ESwapDirectionType.FROM
           ? get(swapSelectFromTokenAtom())
           : get(swapSelectToTokenAtom());
-      if (equalTokenNoCaseSensitive({ token1: newToken, token2: token })) {
+      if (
+        equalTokenNoCaseSensitive({ token1: newToken, token2: token }) ||
+        (!token && !newToken)
+      ) {
         if (type === ESwapDirectionType.FROM) {
           set(swapSelectedFromTokenBalanceAtom(), balanceDisplay ?? '');
         } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved token selection logic in swap functionality
  - Enhanced handling of token balance setting under various selection scenarios

The changes refine the token selection process, providing more flexible handling of token balances when selecting tokens for swapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->