### PR TITLE
fix: swap input max enable for all token

### DIFF
--- a/packages/kit/src/components/AmountInput/index.tsx
+++ b/packages/kit/src/components/AmountInput/index.tsx
@@ -311,9 +311,11 @@ export function AmountInput({
             userSelect: 'none',
             hoverStyle: {
               bg: '$bgHover',
+              borderBottomRightRadius: '$3',
             },
             pressStyle: {
               bg: '$bgActive',
+              borderBottomRightRadius: '$3',
             },
           })}
           {...(balanceHelperProps && {

--- a/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
@@ -221,7 +221,7 @@ const SwapInputContainer = ({
         balanceProps={{
           value: balance,
           onPress:
-            direction === ESwapDirectionType.FROM && !token?.isNative
+            direction === ESwapDirectionType.FROM
               ? onBalanceMaxPress
               : undefined,
         }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced visual styling of the `AmountInput` component by adding border radius on hover and press states
  - Simplified logic for maximum balance press action in swap input container

<!-- end of auto-generated comment: release notes by coderabbit.ai -->