### PR TITLE
fix: replace invalid Lightning Network routes. (OK-35333)

### DIFF
--- a/packages/kit-bg/src/providers/ProviderApiWebln.ts
+++ b/packages/kit-bg/src/providers/ProviderApiWebln.ts
@@ -271,7 +271,10 @@ class ProviderApiWebln extends ProviderApiBase {
       case 'login': {
         return this.backgroundApi.serviceDApp.openModal({
           request,
-          screens: [EModalRoutes.SendModal, EModalSendRoutes.LnurlAuth],
+          screens: [
+            EModalRoutes.SignatureConfirmModal,
+            EModalSignatureConfirmRoutes.LnurlAuth,
+          ],
           params: {
             networkId,
             accountId,
@@ -282,7 +285,10 @@ class ProviderApiWebln extends ProviderApiBase {
       case 'payRequest': {
         return this.backgroundApi.serviceDApp.openModal({
           request,
-          screens: [EModalRoutes.SendModal, EModalSendRoutes.LnurlPayRequest],
+          screens: [
+            EModalRoutes.SignatureConfirmModal,
+            EModalSignatureConfirmRoutes.LnurlPayRequest,
+          ],
           params: {
             networkId,
             accountId,
@@ -300,7 +306,10 @@ class ProviderApiWebln extends ProviderApiBase {
       case 'withdrawRequest': {
         return this.backgroundApi.serviceDApp.openModal({
           request,
-          screens: [EModalRoutes.SendModal, EModalSendRoutes.LnurlWithdraw],
+          screens: [
+            EModalRoutes.SignatureConfirmModal,
+            EModalSignatureConfirmRoutes.LnurlWithdraw,
+          ],
           params: {
             networkId,
             accountId,

--- a/packages/kit/src/views/LightningNetwork/pages/Send/LnurlAuthModal.tsx
+++ b/packages/kit/src/views/LightningNetwork/pages/Send/LnurlAuthModal.tsx
@@ -13,8 +13,8 @@ import DappOpenModalPage from '@onekeyhq/kit/src/views/DAppConnection/pages/Dapp
 import { OneKeyError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type {
-  EModalSendRoutes,
-  IModalSendParamList,
+  EModalSignatureConfirmRoutes,
+  IModalSignatureConfirmParamList,
 } from '@onekeyhq/shared/src/routes';
 import { EDAppModalPageStatus } from '@onekeyhq/shared/types/dappConnection';
 
@@ -35,11 +35,18 @@ function LnurlAuthModal() {
   const intl = useIntl();
   const navigation = useAppNavigation();
   const route =
-    useRoute<RouteProp<IModalSendParamList, EModalSendRoutes.LnurlAuth>>();
+    useRoute<
+      RouteProp<
+        IModalSignatureConfirmParamList,
+        EModalSignatureConfirmRoutes.LnurlAuth
+      >
+    >();
   const routeParams = route.params;
   const { isSendFlow } = routeParams;
   const dAppQuery =
-    useDappQuery<IModalSendParamList[EModalSendRoutes.LnurlAuth]>();
+    useDappQuery<
+      IModalSignatureConfirmParamList[EModalSignatureConfirmRoutes.LnurlAuth]
+    >();
   const { $sourceInfo } = dAppQuery;
   const { accountId, networkId, lnurlDetails } = isSendFlow
     ? routeParams

--- a/packages/kit/src/views/LightningNetwork/pages/Send/LnurlPayRequestModal.tsx
+++ b/packages/kit/src/views/LightningNetwork/pages/Send/LnurlPayRequestModal.tsx
@@ -17,8 +17,8 @@ import type { ITransferInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 import { OneKeyError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type {
-  EModalSendRoutes,
-  IModalSendParamList,
+  EModalSignatureConfirmRoutes,
+  IModalSignatureConfirmParamList,
 } from '@onekeyhq/shared/src/routes';
 import { EDAppModalPageStatus } from '@onekeyhq/shared/types/dappConnection';
 import type { ILNURLPaymentInfo } from '@onekeyhq/shared/types/lightning';
@@ -41,11 +41,16 @@ function LnurlPayRequestModal() {
   const intl = useIntl();
   const route =
     useRoute<
-      RouteProp<IModalSendParamList, EModalSendRoutes.LnurlPayRequest>
+      RouteProp<
+        IModalSignatureConfirmParamList,
+        EModalSignatureConfirmRoutes.LnurlPayRequest
+      >
     >();
   const routeParams = route.params;
   const dAppQuery =
-    useDappQuery<IModalSendParamList[EModalSendRoutes.LnurlPayRequest]>();
+    useDappQuery<
+      IModalSignatureConfirmParamList[EModalSignatureConfirmRoutes.LnurlPayRequest]
+    >();
   const { $sourceInfo } = dAppQuery;
   const { accountId, networkId, lnurlDetails, transfersInfo } =
     routeParams.isSendFlow ? routeParams : dAppQuery;

--- a/packages/kit/src/views/LightningNetwork/pages/Send/LnurlWithdrawModal.tsx
+++ b/packages/kit/src/views/LightningNetwork/pages/Send/LnurlWithdrawModal.tsx
@@ -12,8 +12,8 @@ import DappOpenModalPage from '@onekeyhq/kit/src/views/DAppConnection/pages/Dapp
 import { OneKeyError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type {
-  EModalSendRoutes,
-  IModalSendParamList,
+  EModalSignatureConfirmRoutes,
+  IModalSignatureConfirmParamList,
 } from '@onekeyhq/shared/src/routes';
 import { EDAppModalPageStatus } from '@onekeyhq/shared/types/dappConnection';
 
@@ -34,12 +34,19 @@ import type { RouteProp } from '@react-navigation/core';
 function LnurlWithdrawModal() {
   const intl = useIntl();
   const route =
-    useRoute<RouteProp<IModalSendParamList, EModalSendRoutes.LnurlWithdraw>>();
+    useRoute<
+      RouteProp<
+        IModalSignatureConfirmParamList,
+        EModalSignatureConfirmRoutes.LnurlWithdraw
+      >
+    >();
 
   const routeParams = route.params;
   const { isSendFlow } = routeParams;
   const dAppQuery =
-    useDappQuery<IModalSendParamList[EModalSendRoutes.LnurlWithdraw]>();
+    useDappQuery<
+      IModalSignatureConfirmParamList[EModalSignatureConfirmRoutes.LnurlWithdraw]
+    >();
   const { $sourceInfo } = dAppQuery;
   const { accountId, networkId, lnurlDetails } = isSendFlow
     ? routeParams

--- a/packages/kit/src/views/Send/router/index.ts
+++ b/packages/kit/src/views/Send/router/index.ts
@@ -19,34 +19,6 @@ const SendReplaceTx = LazyLoadPage(
     ),
 );
 
-const LnurlPayRequestModal = LazyLoadPage(
-  () =>
-    import(
-      '@onekeyhq/kit/src/views/LightningNetwork/pages/Send/LnurlPayRequestModal'
-    ),
-);
-
-const LnurlWithdrawModal = LazyLoadPage(
-  () =>
-    import(
-      '@onekeyhq/kit/src/views/LightningNetwork/pages/Send/LnurlWithdrawModal'
-    ),
-);
-
-const LnurlAuthModal = LazyLoadPage(
-  () =>
-    import(
-      '@onekeyhq/kit/src/views/LightningNetwork/pages/Send/LnurlAuthModal'
-    ),
-);
-
-const WeblnSendPaymentModal = LazyLoadPage(
-  () =>
-    import(
-      '@onekeyhq/kit/src/views/LightningNetwork/pages/Webln/WeblnSendPaymentModal'
-    ),
-);
-
 const TokenSelector = LazyLoadPage(
   () => import('@onekeyhq/kit/src/views/AssetSelector/pages/TokenSelector'),
 );
@@ -93,18 +65,6 @@ export const ModalSendStack: IModalFlowNavigatorConfig<
   {
     name: EModalSendRoutes.SendReplaceTx,
     component: SendReplaceTx,
-  },
-  {
-    name: EModalSendRoutes.LnurlPayRequest,
-    component: LnurlPayRequestModal,
-  },
-  {
-    name: EModalSendRoutes.LnurlWithdraw,
-    component: LnurlWithdrawModal,
-  },
-  {
-    name: EModalSendRoutes.LnurlAuth,
-    component: LnurlAuthModal,
   },
   {
     name: EModalSendRoutes.SendSelectToken,

--- a/packages/kit/src/views/Send/router/index.ts
+++ b/packages/kit/src/views/Send/router/index.ts
@@ -66,6 +66,7 @@ export const ModalSendStack: IModalFlowNavigatorConfig<
     name: EModalSendRoutes.SendReplaceTx,
     component: SendReplaceTx,
   },
+  // TODO: The following two pages seem to not be referenced anywhere, consider removing them
   {
     name: EModalSendRoutes.SendSelectToken,
     component: TokenSelector,

--- a/packages/shared/src/routes/send.ts
+++ b/packages/shared/src/routes/send.ts
@@ -2,7 +2,6 @@ import type { IEncodedTx, IUnsignedTxPro } from '@onekeyhq/core/src/types';
 import type {
   IAccountDeriveInfo,
   IAccountDeriveTypes,
-  ITransferInfo,
   ITransferPayload,
 } from '@onekeyhq/kit-bg/src/vaults/types';
 import type { IDappSourceInfo } from '@onekeyhq/shared/types';
@@ -13,11 +12,6 @@ import type { ITokenSelectorParamList } from './assetSelector';
 import type { INetworkAccount } from '../../types/account';
 import type { EDeriveAddressActionType } from '../../types/address';
 import type { IAccountHistoryTx } from '../../types/history';
-import type {
-  ILNURLAuthServiceResponse,
-  ILNURLPayServiceResponse,
-  ILNURLWithdrawServiceResponse,
-} from '../../types/lightning';
 import type { EReplaceTxType, ISendTxOnSuccessData } from '../../types/tx';
 
 export enum EModalSendRoutes {
@@ -29,12 +23,6 @@ export enum EModalSendRoutes {
   SendReplaceTx = 'SendReplaceTx',
   SendSelectToken = 'SendSelectToken',
   SendSelectDeriveAddress = 'SendSelectDeriveAddress',
-
-  // Lightning Network
-  LnurlPayRequest = 'LnurlPayRequest',
-  LnurlWithdraw = 'LnurlWithdraw',
-  LnurlAuth = 'LnurlAuth',
-  WeblnSendPayment = 'WeblnSendPayment',
 }
 
 export type IModalSendParamList = {
@@ -87,32 +75,6 @@ export type IModalSendParamList = {
     replaceEncodedTx: IEncodedTx;
     historyTx: IAccountHistoryTx;
     onSuccess?: (data: ISendTxOnSuccessData[]) => void;
-  };
-
-  // Lightning Network
-  [EModalSendRoutes.LnurlPayRequest]: {
-    networkId: string;
-    accountId: string;
-    transfersInfo: ITransferInfo[];
-    lnurlDetails: ILNURLPayServiceResponse;
-    sourceInfo?: IDappSourceInfo;
-    onSuccess?: (txs: ISendTxOnSuccessData[]) => void;
-    onFail?: (error: Error) => void;
-    onCancel?: () => void;
-    isSendFlow?: boolean;
-  };
-  [EModalSendRoutes.LnurlWithdraw]: {
-    networkId: string;
-    accountId: string;
-    lnurlDetails: ILNURLWithdrawServiceResponse;
-    sourceInfo?: IDappSourceInfo;
-    isSendFlow?: boolean;
-  };
-  [EModalSendRoutes.LnurlAuth]: {
-    networkId: string;
-    accountId: string;
-    lnurlDetails: ILNURLAuthServiceResponse;
-    isSendFlow: boolean;
   };
   [EModalSendRoutes.SendSelectDeriveAddress]: {
     networkId: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Routing Changes**
	- Removed Lightning Network (LNURL) related modals from send routes
	- Updated routing types from send-related to signature confirmation
	- Removed specific LNURL routes for authentication, payment requests, and withdrawals

- **Modal Updates**
	- Transitioned LNURL modals to use signature confirmation flow
	- Simplified routing configuration for send-related interactions

- **Type Modifications**
	- Removed Lightning Network specific type definitions
	- Updated parameter lists and route enumerations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->