### PR TITLE
fix: ada token decimals OK-35322

### DIFF
--- a/packages/kit-bg/src/vaults/impls/ada/Vault.ts
+++ b/packages/kit-bg/src/vaults/impls/ada/Vault.ts
@@ -264,7 +264,7 @@ export default class Vault extends VaultBase {
               name: token.name,
               icon: token.logoURI ?? '',
               amount: new BigNumber(asset.quantity)
-                .shiftedBy(-network.decimals)
+                .shiftedBy(-token.decimals)
                 .toFixed(),
               amountValue: asset.quantity,
               symbol: token.symbol,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Improved asset transfer amount calculation by using token-specific decimal precision instead of network-level decimals
    - Ensures more accurate representation of asset amounts during transactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->