### PR TITLE
chore: remove READ_MEDIA_IMAGES and READ_MEDIA_VIDEO permissions on Android

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
   <uses-permission
         android:name="android.permission.ACCESS_COARSE_LOCATION"
         tools:node="remove" />
+  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" tools:node="remove" />
+  <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" tools:node="remove" />
 
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.INTERNET"/>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Permissions Update**
  - Removed `FOREGROUND_SERVICE_MEDIA_PLAYBACK` and `ACCESS_COARSE_LOCATION` permissions
  - Added new media-related permissions for image and video access
  - Permissions configured to be removed during build process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->