### PR TITLE
revert: Rrevert "fix: ada token decimals (#6592)"

### DIFF
--- a/packages/kit-bg/src/vaults/impls/ada/Vault.ts
+++ b/packages/kit-bg/src/vaults/impls/ada/Vault.ts
@@ -264,7 +264,7 @@ export default class Vault extends VaultBase {
               name: token.name,
               icon: token.logoURI ?? '',
               amount: new BigNumber(asset.quantity)
-                .shiftedBy(-token.decimals)
+                .shiftedBy(-network.decimals)
                 .toFixed(),
               amountValue: asset.quantity,
               symbol: token.symbol,


### PR DESCRIPTION
This reverts commit c73e3be8034660cc2f4dcc0cbeb5714feb3ce834.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected asset transfer amount calculation by using network decimals instead of token-specific decimals
	- Ensures more accurate representation of asset quantities during transaction decoding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->