### PR TITLE
chore: upgrade upload-artifact@v4

### DIFF
--- a/.github/workflows/bundlediff-ios.yml
+++ b/.github/workflows/bundlediff-ios.yml
@@ -57,7 +57,7 @@ jobs:
         run: yarn stats:ios
 
       - name: Upload stats.json
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: head-stats
           path: ./apps/app/stats.json
@@ -108,7 +108,7 @@ jobs:
         run: yarn stats:ios
 
       - name: Upload stats.json
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: base-stats
           path: ./apps/app/stats.json

--- a/.github/workflows/bundlediff-web.yml
+++ b/.github/workflows/bundlediff-web.yml
@@ -57,7 +57,7 @@ jobs:
         run: yarn stats:web
 
       - name: Upload stats.json
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: head-stats
           path: ./apps/web/web-build/stats.json
@@ -108,7 +108,7 @@ jobs:
         run: yarn stats:web
 
       - name: Upload stats.json
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: base-stats
           path: ./apps/web/web-build/stats.json

--- a/.github/workflows/release-android-debug.yml
+++ b/.github/workflows/release-android-debug.yml
@@ -99,21 +99,21 @@ jobs:
           ./gradlew assembleDebug
       
       - name: Upload Main Debug APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-prod-debug
           path: |
             ./apps/mobile/android/app/build/outputs/apk/prod/debug
 
       - name: Upload Google Debug APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-google-debug
           path: |
             ./apps/mobile/android/app/build/outputs/apk/google/debug
       
       - name: Upload Huawei Debug APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
             name: release-huawei-debug
             path: |

--- a/.github/workflows/release-desktop-mas.yml
+++ b/.github/workflows/release-desktop-mas.yml
@@ -160,7 +160,7 @@ jobs:
           rm ~/Library/MobileDevice/Provisioning\ Profiles/OneKey_Mac_App.provisionprofile
 
       - name: Upload Artifacts mas
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: onekey-desktop-mas
           path: |

--- a/.github/workflows/release-desktop-snap.yml
+++ b/.github/workflows/release-desktop-snap.yml
@@ -113,7 +113,7 @@ jobs:
         run: 'cd apps/desktop && yarn build:snap'
 
       - name: Upload Artifacts Release
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release
           path: |

--- a/.github/workflows/release-desktop-winms.yml
+++ b/.github/workflows/release-desktop-winms.yml
@@ -126,14 +126,14 @@ jobs:
         run: 'cd apps/desktop && yarn build:winms'
 
       - name: Upload Artifacts Windows
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: onekey-desktop-windows
           path: |
             ./apps/desktop/build-electron/*.exe
 
       - name: Upload Artifacts Release
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release
           path: |

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -126,35 +126,35 @@ jobs:
         run: 'cd apps/desktop && yarn build'
        
       - name: Upload Artifacts latest.yml
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: onekey-desktop-yml
           path: |
             ./apps/desktop/build-electron/*.yml
 
       - name: Upload Artifacts Mac
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: onekey-desktop-mac
           path: |
             ./apps/desktop/build-electron/*.dmg
 
       - name: Upload Artifacts Windows
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: onekey-desktop-windows
           path: |
             ./apps/desktop/build-electron/*.exe
 
       - name: Upload Artifacts Linux
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: onekey-desktop-linux
           path: |
             ./apps/desktop/build-electron/*.AppImage
 
       - name: Upload Artifacts Release
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release
           path: |

--- a/.github/workflows/release-ext.yml
+++ b/.github/workflows/release-ext.yml
@@ -105,7 +105,7 @@ jobs:
         run: 'yarn app:ext:build:all'
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: onekey-extension-rn
           path: |

--- a/.github/workflows/release-ios-debug.yml
+++ b/.github/workflows/release-ios-debug.yml
@@ -112,7 +112,7 @@ jobs:
           zip OneKeyWallet-Debug.zip OneKeyWallet.app/* -r
 
       - name: Upload App File
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-App-debug
           path: |

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -99,7 +99,7 @@ jobs:
           destination_dir: ${{ env.HOST_PATH }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: app-monorepo-${{ github.sha }}
           path: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow files to use the latest version of `actions/upload-artifact` and `actions/download-artifact` actions across multiple workflow configurations
	- Version upgrades performed for iOS, web, Android, desktop, extension, and release workflows
	- No functional changes to the underlying workflow logic or processes were made

<!-- end of auto-generated comment: release notes by coderabbit.ai -->