### PR TITLE
feat: Add Spotlight component gallery with example ok-35270

### DIFF
--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/Spotlight.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/Spotlight.tsx
@@ -1,33 +1,48 @@
-// import type { ITourStep } from '@onekeyhq/components';
-import {
-  Button,
-  SizableText,
-  // Spotlight,
-  // TourBox,
-  // TourStep,
-  // TourTrigger,
-  YStack,
-} from '@onekeyhq/components';
+import { Button, SizableText, YStack } from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { Spotlight } from '@onekeyhq/kit/src/components/Spotlight';
+import { ESpotlightTour } from '@onekeyhq/shared/src/spotlight';
 
 import { Layout } from './utils/Layout';
 
-// mock page
-function Page() {
-  return <YStack gap="$4" />;
+function DefaultPage() {
+  return (
+    <YStack gap="$4">
+      <Spotlight
+        delayMs={300}
+        containerProps={{ flexShrink: 1 }}
+        isVisible
+        message="description content"
+        tourName={ESpotlightTour.createAllNetworks}
+      >
+        <SizableText>content</SizableText>
+      </Spotlight>
+
+      <Button
+        onPress={() => {
+          void backgroundApiProxy.serviceSpotlight.reset();
+        }}
+      >
+        <SizableText>show spotlight</SizableText>
+      </Button>
+    </YStack>
+  );
 }
 
-const SliderGallery = () => (
-  <Layout
-    description=".."
-    suggestions={['...']}
-    boundaryConditions={['...']}
-    elements={[
-      {
-        title: 'Default',
-        element: <Page />,
-      },
-    ]}
-  />
-);
-
-export default SliderGallery;
+export default function SpotlightGallery() {
+  return (
+    <Layout
+      description="Spotlight 组件"
+      suggestions={[
+        '如果需要重复测试需用 backgroundApiProxy.serviceSpotlight.reset(); 重置',
+        '需要定义唯一 ESpotlightTour 值',
+      ]}
+      elements={[
+        {
+          title: 'Default',
+          element: <DefaultPage />,
+        },
+      ]}
+    />
+  );
+}

--- a/packages/kit/src/views/Developer/pages/Gallery/index.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/index.tsx
@@ -556,7 +556,7 @@ export const galleryScreenList: {
     component: SwipeableCellGallery,
   },
   {
-    name: EGalleryRoutes.ComponentSpotlightTour,
+    name: EGalleryRoutes.ComponentSpotlight,
     component: SpotlightGallery,
   },
   {

--- a/packages/shared/src/routes/gallery.ts
+++ b/packages/shared/src/routes/gallery.ts
@@ -1,7 +1,7 @@
 export enum EGalleryRoutes {
   Components = 'components',
   ComponentTypography = 'component-typography',
-  ComponentSpotlightTour = 'component-Spotlight',
+  ComponentSpotlight = 'component-spotlight',
   ComponentLottieView = 'component-lottieview',
   ComponentTooltip = 'component-tooltip',
   ComponentIcon = 'component-icon',


### PR DESCRIPTION
上一个 https://github.com/OneKeyHQ/app-monorepo/pull/6606 忘记配置 gpg了导致无法合并。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated a Spotlight feature in the gallery view that displays an interactive message along with a reset option.
- **Refactor**
  - Streamlined the page layout and component organization for a more cohesive gallery experience.
  - Updated routing names to maintain consistency in accessing spotlight-related components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->