### PR TITLE
fix: batch tx fee missing symbol OK-35708

### DIFF
--- a/packages/kit/src/views/SignatureConfirm/components/TxFee/TxFeeInfo.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/TxFee/TxFeeInfo.tsx
@@ -1092,13 +1092,13 @@ function TxFeeInfo(props: IProps) {
         color="$text"
         formatter="balance"
         formatterOptions={{
-          tokenSymbol: txFee?.common.nativeSymbol,
+          tokenSymbol: txFeeCommon?.nativeSymbol,
         }}
       >
         {selectedFee?.totalNativeMinForDisplay ?? '-'}
       </NumberSizeableText>
     ),
-    [selectedFee?.totalNativeMinForDisplay, txFee?.common.nativeSymbol],
+    [selectedFee?.totalNativeMinForDisplay, txFeeCommon?.nativeSymbol],
   );
 
   const renderTotalFiat = useCallback(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Ensured the native token symbol now updates correctly during fee estimation for a more consistent and accurate display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->