### PR TITLE
fix: limit rate decimals  ok-35854 ok-35855

### DIFF
--- a/packages/kit/src/states/jotai/contexts/swap/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/atoms.ts
@@ -2,7 +2,6 @@ import BigNumber from 'bignumber.js';
 
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { dangerAllNetworkRepresent } from '@onekeyhq/shared/src/config/presetNetworks';
-import { formatBalance } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   ESwapProviderSort,
   swapProviderRecommendApprovedWeights,
@@ -418,24 +417,25 @@ export const {
     const { fromTokenPrice, toTokenPrice } = limitPriceOrderMarketPrice;
     const fromPriceBN = new BigNumber(fromTokenPrice ?? 0);
     const toPriceBN = new BigNumber(toTokenPrice ?? 0);
-    const rate = fromPriceBN.div(toPriceBN).toFixed();
-    const reverseRate = toPriceBN.div(fromPriceBN).toFixed();
-    const rateFormat = formatBalance(rate);
-    const reverseRateFormat = formatBalance(reverseRate);
-    let rateValue = rateFormat.meta.roundValue ?? rateFormat.meta.value;
-    let reverseRateValue =
-      reverseRateFormat.meta.roundValue ?? reverseRateFormat.meta.value;
-    if (rateFormat.meta.unit) {
-      rateValue = rateFormat.meta.value;
-    }
-    if (reverseRateFormat.meta.unit) {
-      reverseRateValue = reverseRateFormat.meta.value;
-    }
+    const rate = fromPriceBN
+      .div(toPriceBN)
+      .decimalPlaces(
+        toTokenInfo?.decimals ?? LIMIT_PRICE_DEFAULT_DECIMALS,
+        BigNumber.ROUND_HALF_UP,
+      )
+      .toFixed();
+    const reverseRate = toPriceBN
+      .div(fromPriceBN)
+      .decimalPlaces(
+        fromTokenInfo?.decimals ?? LIMIT_PRICE_DEFAULT_DECIMALS,
+        BigNumber.ROUND_HALF_UP,
+      )
+      .toFixed();
     const limitPriceMarketInfo = {
       fromToken: fromTokenInfo,
       toToken: toTokenInfo,
-      rate: rateValue,
-      reverseRate: reverseRateValue,
+      rate,
+      reverseRate,
       provider,
       fromTokenMarketPrice: fromTokenPrice,
       toTokenMarketPrice: toTokenPrice,

--- a/packages/kit/src/views/Swap/components/LimitOrderCard.tsx
+++ b/packages/kit/src/views/Swap/components/LimitOrderCard.tsx
@@ -15,10 +15,10 @@ import {
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { formatDate } from '@onekeyhq/shared/src/utils/dateUtils';
-import { formatBalance } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   ESwapLimitOrderStatus,
   type IFetchLimitOrderRes,
+  LIMIT_PRICE_DEFAULT_DECIMALS,
 } from '@onekeyhq/shared/types/swap/types';
 
 import { Token } from '../../../components/Token';
@@ -132,10 +132,15 @@ const LimitOrderCard = ({
   const limitPrice = useMemo(() => {
     const fromAmountNum = decimalsAmount.fromAmount;
     const toAmountNum = decimalsAmount.toAmount;
-    const calculateLimitPrice = toAmountNum.div(fromAmountNum).toFixed();
-    const formatLimitPrice = formatBalance(calculateLimitPrice);
-    return formatLimitPrice.formattedValue;
-  }, [decimalsAmount]);
+    const calculateLimitPrice = toAmountNum
+      .div(fromAmountNum)
+      .decimalPlaces(
+        fromTokenInfo?.decimals ?? LIMIT_PRICE_DEFAULT_DECIMALS,
+        BigNumber.ROUND_HALF_UP,
+      )
+      .toFixed();
+    return calculateLimitPrice;
+  }, [decimalsAmount, fromTokenInfo?.decimals]);
   const renderLimitOrderPrice = useCallback(
     () => (
       <YStack

--- a/packages/kit/src/views/Swap/components/LimitOrderCard.tsx
+++ b/packages/kit/src/views/Swap/components/LimitOrderCard.tsx
@@ -165,14 +165,14 @@ const LimitOrderCard = ({
     let label = intl.formatMessage({
       id: ETranslations.Limit_order_status_open,
     });
-    let color = '@textCaution';
+    let color = '$textSuccess';
     if (status) {
       switch (status) {
         case ESwapLimitOrderStatus.CANCELLED:
           label = intl.formatMessage({
             id: ETranslations.Limit_order_cancel,
           });
-          color = '@textCritical';
+          color = '$textCritical';
           break;
         case ESwapLimitOrderStatus.FULFILLED:
           label = intl.formatMessage({
@@ -184,6 +184,7 @@ const LimitOrderCard = ({
           label = intl.formatMessage({
             id: ETranslations.Limit_order_status_expired,
           });
+          color = '$textCaution';
           break;
         case ESwapLimitOrderStatus.PRESIGNATURE_PENDING:
           label = intl.formatMessage({

--- a/packages/kit/src/views/Swap/pages/modal/LimitOrderDetailModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/LimitOrderDetailModal.tsx
@@ -221,31 +221,32 @@ const LimitOrderDetailModal = () => {
   const renderLimitOrderStatus = useCallback(() => {
     const { status } = orderItemState ?? {};
     let label = intl.formatMessage({
-      id: ETranslations.swap_history_detail_badge_to_pending,
+      id: ETranslations.Limit_order_status_open,
     });
-    let color = '@textCaution';
+    let color = '$textSuccess';
     if (status) {
       switch (status) {
         case ESwapLimitOrderStatus.CANCELLED:
           label = intl.formatMessage({
-            id: ETranslations.swap_history_detail_badge_expired,
+            id: ETranslations.Limit_order_cancel,
           });
-          color = '@textCritical';
+          color = '$textCritical';
           break;
         case ESwapLimitOrderStatus.FULFILLED:
           label = intl.formatMessage({
-            id: ETranslations.swap_history_detail_badge_to_success,
+            id: ETranslations.Limit_order_status_filled,
           });
           color = '$textSuccess';
           break;
         case ESwapLimitOrderStatus.EXPIRED:
           label = intl.formatMessage({
-            id: ETranslations.swap_history_detail_badge_expired,
+            id: ETranslations.Limit_order_status_expired,
           });
+          color = '$textCaution';
           break;
         case ESwapLimitOrderStatus.PRESIGNATURE_PENDING:
           label = intl.formatMessage({
-            id: ETranslations.swap_history_detail_badge_to_pending,
+            id: ETranslations.Limit_order_status_open,
           });
           break;
         default:
@@ -253,14 +254,14 @@ const LimitOrderDetailModal = () => {
       }
       return (
         <Stack
-          flexDirection={gtMd ? 'row' : 'column'}
+          flexDirection={gtMd ? 'column' : 'row'}
           gap="$2"
-          alignItems={gtMd ? 'center' : 'flex-start'}
+          alignItems={gtMd ? 'flex-start' : 'center'}
         >
           <SizableText size="$bodyMdMedium" color={color}>
             {label}
           </SizableText>
-          {status === ESwapLimitOrderStatus.OPEN ? (
+          {orderItemState?.cancelInfo ? (
             <Button
               variant="secondary"
               size="small"

--- a/packages/kit/src/views/Swap/pages/modal/LimitOrderDetailModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/LimitOrderDetailModal.tsx
@@ -29,7 +29,6 @@ import type {
   IModalSwapParamList,
 } from '@onekeyhq/shared/src/routes/swap';
 import { formatDate } from '@onekeyhq/shared/src/utils/dateUtils';
-import { formatBalance } from '@onekeyhq/shared/src/utils/numberUtils';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import type { IFetchLimitOrderRes } from '@onekeyhq/shared/types/swap/types';
@@ -92,10 +91,20 @@ const LimitOrderDetailModal = () => {
   const limitPrice = useMemo(() => {
     const fromAmountNum = decimalsAmount.fromAmount;
     const toAmountNum = decimalsAmount.toAmount;
-    const calculateLimitPrice = toAmountNum.div(fromAmountNum).toFixed();
-    const formatLimitPrice = formatBalance(calculateLimitPrice);
-    return formatLimitPrice.formattedValue;
-  }, [decimalsAmount]);
+    const calculateLimitPrice = toAmountNum
+      .div(fromAmountNum)
+      .decimalPlaces(
+        orderItemState?.toTokenInfo.decimals ?? 0,
+        BigNumber.ROUND_HALF_UP,
+      )
+      .toFixed();
+
+    return calculateLimitPrice;
+  }, [
+    decimalsAmount.fromAmount,
+    decimalsAmount.toAmount,
+    orderItemState?.toTokenInfo.decimals,
+  ]);
 
   const renderLimitOrderAssets = useCallback(() => {
     const fromAsset = {
@@ -318,8 +327,6 @@ const LimitOrderDetailModal = () => {
     const executedSellAmountBN = new BigNumber(
       executedSellAmount ?? '0',
     ).shiftedBy(-(fromTokenInfo?.decimals ?? 0));
-    const executeBuyFormat = formatBalance(executedBuyAmountBN.toFixed());
-    const executeSellFormat = formatBalance(executedSellAmountBN.toFixed());
     const sellPercentage = executedSellAmountBN
       .div(fromAmountBN)
       .multipliedBy(100)
@@ -339,9 +346,9 @@ const LimitOrderDetailModal = () => {
         </XStack>
 
         <SizableText size="$bodySm" color="$textSubdued">
-          {`${executeSellFormat.formattedValue} ${
+          {`${executedSellAmountBN.toFixed()} ${
             fromTokenInfo?.symbol ?? '-'
-          } sold for total of ${executeBuyFormat.formattedValue} ${
+          } sold for total of ${executedBuyAmountBN.toFixed()} ${
             toTokenInfo?.symbol ?? '-'
           }`}
         </SizableText>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the calculation of limit prices and rates for improved precision and clarity by directly applying token decimal settings.
  - Enhanced rate validation to be context-sensitive based on token decimals.

- **Style**
  - Updated the visual cues for limit order statuses, with open orders now shown in a success color and refined colors for cancelled and expired statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->