### PR TITLE
feat: Implement lazy loading for Prime-related components

### DIFF
--- a/packages/kit/src/components/TabPageHeader/HeaderRight.tsx
+++ b/packages/kit/src/components/TabPageHeader/HeaderRight.tsx
@@ -28,7 +28,7 @@ import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import backgroundApiProxy from '../../background/instance/backgroundApiProxy';
 import useAppNavigation from '../../hooks/useAppNavigation';
 import { UrlAccountNavHeader } from '../../views/Home/pages/urlAccount/UrlAccountNavHeader';
-import { PrimeHeaderIconButton } from '../../views/Prime/components/PrimeHeaderIconButton';
+import { PrimeHeaderIconButtonLazy } from '../../views/Prime/components/PrimeHeaderIconButton';
 import useScanQrCode from '../../views/ScanQrCode/hooks/useScanQrCode';
 
 import { MoreActionButton } from './MoreActionButton';
@@ -138,11 +138,11 @@ export function HeaderRight({
         onPress={onScanButtonPressed}
       />
     ) : null;
-    // const primeButton =
-    //   devSettings?.enabled && devSettings?.settings?.showPrimeTest ? (
-    //     <PrimeHeaderIconButton key="prime" />
-    //   ) : null;
-    const primeButton = <PrimeHeaderIconButton key="prime" />;
+
+    const primeButton =
+      devSettings?.enabled && devSettings?.settings?.showPrimeTest ? (
+        <PrimeHeaderIconButtonLazy key="prime" visible />
+      ) : null;
 
     let notificationsButton: ReactNode | null = (
       <Stack key="notifications" testID="headerRightNotificationsButton">
@@ -237,13 +237,14 @@ export function HeaderRight({
       searchInput,
     ].filter(Boolean);
   }, [
-    media.gtMd,
-    intl,
-    onScanButtonPressed,
-    devSettings.enabled,
-    openNotificationsModal,
-    firstTimeGuideOpened,
     badge,
+    devSettings.enabled,
+    devSettings?.settings?.showPrimeTest,
+    firstTimeGuideOpened,
+    intl,
+    media.gtMd,
+    onScanButtonPressed,
+    openNotificationsModal,
     sceneName,
   ]);
   return (

--- a/packages/kit/src/provider/Container/index.tsx
+++ b/packages/kit/src/provider/Container/index.tsx
@@ -26,7 +26,7 @@ import { KeyboardContainer } from './KeyboardContainer';
 import { NavigationContainer } from './NavigationContainer';
 import { PortalBodyContainer } from './PortalBodyContainer';
 import { PrevCheckBeforeSendingContainer } from './PrevCheckBeforeSendingContainer';
-import { PrimeLoginContainer } from './PrimeLoginContainer';
+import { PrimeLoginContainerLazy } from './PrimeLoginContainer';
 
 const PageTrackerContainer = LazyLoad(
   () => import('./PageTrackerContainer'),
@@ -101,7 +101,7 @@ export function Container() {
           <CreateAddressContainer />
           <PrevCheckBeforeSendingContainer />
           <HardwareUiStateContainer />
-          <PrimeLoginContainer />
+          <PrimeLoginContainerLazy />
           <DialogLoadingContainer />
           <CloudBackupContainer />
           <FullWindowOverlayContainer />

--- a/packages/kit/src/provider/index.tsx
+++ b/packages/kit/src/provider/index.tsx
@@ -18,7 +18,7 @@ import { useDebugComponentRemountLog } from '@onekeyhq/shared/src/utils/debug/de
 import { GlobalJotaiReady } from '../components/GlobalJotaiReady';
 import PasswordVerifyPromptMount from '../components/Password/container/PasswordVerifyPromptMount';
 import { SystemLocaleTracker } from '../components/SystemLocaleTracker';
-import { PrivyProvider } from '../views/Prime/components/PrivyProvider';
+import { PrivyProviderLazy } from '../views/Prime/components/PrivyProviderLazy';
 
 import { ColdStartByNotification, Container } from './Container';
 import InAppNotification from './Container/InAppNotification';
@@ -60,8 +60,8 @@ export function KitProvider(props: any = {}) {
 
   const content = (
     <SafeAreaProvider>
-      <PrivyProvider>
-        <GlobalJotaiReady>
+      <GlobalJotaiReady>
+        <PrivyProviderLazy>
           <GestureHandlerRootView style={flexStyle}>
             <ThemeProvider>
               <NetworkReachabilityTracker />
@@ -77,8 +77,8 @@ export function KitProvider(props: any = {}) {
               <SyncHomeAccountToDappAccountProvider />
             </ThemeProvider>
           </GestureHandlerRootView>
-        </GlobalJotaiReady>
-      </PrivyProvider>
+        </PrivyProviderLazy>
+      </GlobalJotaiReady>
     </SafeAreaProvider>
   );
 

--- a/packages/kit/src/views/Prime/components/PrimeHeaderIconButton/PrimeHeaderIconButton.tsx
+++ b/packages/kit/src/views/Prime/components/PrimeHeaderIconButton/PrimeHeaderIconButton.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 
-import { HeaderIconButton, Toast } from '@onekeyhq/components';
+import { HeaderIconButton, Stack, Toast } from '@onekeyhq/components';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
@@ -38,16 +38,17 @@ export function PrimeHeaderIconButton() {
   }, [navigation, isReady]);
 
   return (
-    <HeaderIconButton
-      onPointerEnter={() => setIsHover(true)}
-      onPointerLeave={() => setIsHover(false)}
-      key="header-prime-button"
-      title="Prime"
-      icon={user?.id || isHover ? icon : 'PrimeOutline'}
-      tooltipProps={{
-        open: isHover,
-      }}
-      onPress={onPrimeButtonPressed}
-    />
+    <Stack testID="headerRightPrimeButton">
+      <HeaderIconButton
+        onPointerEnter={() => setIsHover(true)}
+        onPointerLeave={() => setIsHover(false)}
+        title="Prime"
+        icon={user?.id || isHover ? icon : 'PrimeOutline'}
+        tooltipProps={{
+          open: isHover,
+        }}
+        onPress={onPrimeButtonPressed}
+      />
+    </Stack>
   );
 }

--- a/packages/kit/src/views/Prime/components/PrimeHeaderIconButton/index.tsx
+++ b/packages/kit/src/views/Prime/components/PrimeHeaderIconButton/index.tsx
@@ -1,1 +1,18 @@
-export * from './PrimeHeaderIconButton';
+import { Suspense, lazy } from 'react';
+
+const PrimeHeaderIconButton = lazy(() =>
+  import('./PrimeHeaderIconButton').then((m) => ({
+    default: m.PrimeHeaderIconButton,
+  })),
+);
+
+export function PrimeHeaderIconButtonLazy({ visible }: { visible: boolean }) {
+  if (!visible) {
+    return null;
+  }
+  return (
+    <Suspense fallback={null}>
+      <PrimeHeaderIconButton />
+    </Suspense>
+  );
+}

--- a/packages/kit/src/views/Prime/components/PrivyProviderLazy.tsx
+++ b/packages/kit/src/views/Prime/components/PrivyProviderLazy.tsx
@@ -2,20 +2,18 @@ import { Suspense, lazy } from 'react';
 
 import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 
-const PrimeLoginContainer = lazy(() =>
-  import('./PrimeLoginContainer').then((m) => ({
-    default: m.PrimeLoginContainer,
-  })),
+const PrivyProvider = lazy(() =>
+  import('./PrivyProvider').then((m) => ({ default: m.PrivyProvider })),
 );
 
-export function PrimeLoginContainerLazy() {
+export function PrivyProviderLazy({ children }: { children: React.ReactNode }) {
   const [devSettings] = useDevSettingsPersistAtom();
   if (devSettings.enabled && devSettings.settings?.showPrimeTest) {
     return (
       <Suspense fallback={null}>
-        <PrimeLoginContainer />
+        <PrivyProvider>{children}</PrivyProvider>
       </Suspense>
     );
   }
-  return null;
+  return children;
 }


### PR DESCRIPTION
- Add lazy loading for PrimeHeaderIconButton, PrivyProvider, and PrimeLoginContainer
- Conditionally render Prime components based on dev settings
- Improve performance by deferring Prime-related component loading
- Add visibility prop to PrimeHeaderIconButton lazy component
- Restructure component imports and lazy loading mechanisms

(cherry picked from commit 6b98e520ef97a9e2b3e778a1d92a350ca363ef76)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced on-demand loading for key interface elements such as login sections and header buttons to improve performance.
  - UI components now render conditionally based on advanced settings, delivering a more dynamic and responsive experience.
  - Updated component structure ensures smoother transitions without changing overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->