### PR TITLE
fix: Conditionally render HistoryIconButton in Dashboard header

### DIFF
--- a/packages/kit/src/views/Discovery/pages/Dashboard/DashboardContainer.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/DashboardContainer.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { Page, Stack, XStack, useSafeAreaInsets } from '@onekeyhq/components';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -12,10 +12,17 @@ import DashboardContent from './DashboardContent';
 
 function Dashboard() {
   const { top } = useSafeAreaInsets();
+  const historyButton = useMemo(
+    () =>
+      !platformEnv.isExtension && !platformEnv.isWeb
+        ? () => <HistoryIconButton />
+        : undefined,
+    [],
+  );
 
   return (
     <Page>
-      <Page.Header headerRight={HistoryIconButton} />
+      <Page.Header headerRight={historyButton} />
       {platformEnv.isNativeIOSPad ? <HandleRebuildBrowserData /> : null}
       {platformEnv.isNativeIOS ? (
         <XStack pt={top} px="$5" width="100%" justifyContent="flex-end">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Dashboard header now conditionally shows the history button depending on the platform. Users on supported platforms will see the history navigation option, while it remains hidden on others to streamline the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->