### PR TITLE
fix: Adjust browser header title container max width

### DIFF
--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.desktop.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.desktop.tsx
@@ -53,6 +53,7 @@ function DesktopBrowser() {
           flexGrow: 0,
         }}
         headerTitleContainerStyle={{
+          maxWidth: '100%',
           flex: 1,
         }}
       />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced the header layout on the desktop view by allowing the header title area to extend fully across its container, providing a more dynamic and visually appealing display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->