### PR TITLE
feat: move layout menu into settings menus on popup & sindebar extension

### DIFF
--- a/packages/kit/src/components/TabPageHeader/HeaderRight.tsx
+++ b/packages/kit/src/components/TabPageHeader/HeaderRight.tsx
@@ -90,63 +90,6 @@ export function HeaderRight({
   }, [navigation]);
 
   const items = useMemo(() => {
-    const routeInfo = {
-      routes: '',
-    };
-    const layoutExtView = (
-      <ActionList
-        key="layoutExtView"
-        title={intl.formatMessage({
-          id: ETranslations.global_layout,
-        })}
-        items={[
-          platformEnv.isExtensionUiPopup
-            ? {
-                label: intl.formatMessage({
-                  id: ETranslations.open_as_sidebar,
-                }),
-                icon: 'LayoutRightOutline',
-                onPress: async () => {
-                  defaultLogger.account.wallet.openSidePanel();
-                  await extUtils.openPanelOnActionClick(true);
-                  await extUtils.openSidePanel(routeInfo);
-                  window.close();
-                },
-              }
-            : {
-                label: intl.formatMessage({
-                  id: ETranslations.open_as_popup,
-                }),
-                icon: 'LayoutTopOutline',
-                onPress: async () => {
-                  await extUtils.openPanelOnActionClick(false);
-                  window.close();
-                },
-              },
-          {
-            label: intl.formatMessage({
-              id: ETranslations.global_expand_view,
-            }),
-            icon: 'ExpandOutline',
-            onPress: async () => {
-              defaultLogger.account.wallet.openExpandView();
-              window.close();
-              await backgroundApiProxy.serviceApp.openExtensionExpandTab(
-                routeInfo,
-              );
-            },
-          },
-        ]}
-        renderTrigger={
-          <HeaderIconButton
-            key="layoutRightView"
-            title={intl.formatMessage({ id: ETranslations.global_layout })}
-            icon="LayoutRightOutline"
-          />
-        }
-      />
-    );
-
     const scanButton = media.gtMd ? (
       <HeaderIconButton
         key="scan"
@@ -231,12 +174,9 @@ export function HeaderRight({
     }
 
     if (platformEnv.isExtensionUiPopup || platformEnv.isExtensionUiSidePanel) {
-      return [
-        layoutExtView,
-        primeButton,
-        notificationsButton,
-        moreActionButton,
-      ].filter(Boolean);
+      return [primeButton, notificationsButton, moreActionButton].filter(
+        Boolean,
+      );
     }
 
     // notifications is not supported on web currently

--- a/packages/kit/src/components/TabPageHeader/MoreActionButton.tsx
+++ b/packages/kit/src/components/TabPageHeader/MoreActionButton.tsx
@@ -110,7 +110,7 @@ export function MoreActionButton() {
               label: intl.formatMessage({
                 id: ETranslations.open_as_sidebar,
               }),
-              icon: 'LayoutRightOutline',
+              icon: 'LayoutRightOutline' as const,
               onPress: async () => {
                 defaultLogger.account.wallet.openSidePanel();
                 await extUtils.openPanelOnActionClick(true);
@@ -122,7 +122,7 @@ export function MoreActionButton() {
               label: intl.formatMessage({
                 id: ETranslations.open_as_popup,
               }),
-              icon: 'LayoutTopOutline',
+              icon: 'LayoutTopOutline' as const,
               onPress: async () => {
                 await extUtils.openPanelOnActionClick(false);
                 window.close();
@@ -132,7 +132,7 @@ export function MoreActionButton() {
           label: intl.formatMessage({
             id: ETranslations.global_expand_view,
           }),
-          icon: 'ExpandOutline',
+          icon: 'ExpandOutline' as const,
           onPress: async () => {
             defaultLogger.account.wallet.openExpandView();
             window.close();
@@ -163,7 +163,7 @@ export function MoreActionButton() {
               label: intl.formatMessage({
                 id: ETranslations.settings_lock_now,
               }),
-              icon: 'LockOutline',
+              icon: 'LockOutline' as const,
               onPress: onLock,
               testID: 'lock-now',
             },
@@ -171,7 +171,7 @@ export function MoreActionButton() {
               label: intl.formatMessage({
                 id: ETranslations.scan_scan_qr_code,
               }),
-              icon: 'ScanOutline',
+              icon: 'ScanOutline' as const,
               onPress: handleScan,
               testID: 'scan-qr-code',
             },

--- a/packages/kit/src/components/TabPageHeader/MoreActionButton.tsx
+++ b/packages/kit/src/components/TabPageHeader/MoreActionButton.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -11,12 +11,15 @@ import {
   useAllTokenListMapAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/tokenList';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   EModalDeviceManagementRoutes,
   EModalRoutes,
   EModalSettingRoutes,
   EOnboardingPages,
 } from '@onekeyhq/shared/src/routes';
+import extUtils from '@onekeyhq/shared/src/utils/extUtils';
 
 import backgroundApiProxy from '../../background/instance/backgroundApiProxy';
 import useScanQrCode from '../../views/ScanQrCode/hooks/useScanQrCode';
@@ -96,6 +99,53 @@ export function MoreActionButton() {
     [openAddressBook],
   );
 
+  const popupMenu = useMemo(() => {
+    if (platformEnv.isExtensionUiPopup || platformEnv.isExtensionUiSidePanel) {
+      const routeInfo = {
+        routes: '',
+      };
+      return [
+        platformEnv.isExtensionUiPopup
+          ? {
+              label: intl.formatMessage({
+                id: ETranslations.open_as_sidebar,
+              }),
+              icon: 'LayoutRightOutline',
+              onPress: async () => {
+                defaultLogger.account.wallet.openSidePanel();
+                await extUtils.openPanelOnActionClick(true);
+                await extUtils.openSidePanel(routeInfo);
+                window.close();
+              },
+            }
+          : {
+              label: intl.formatMessage({
+                id: ETranslations.open_as_popup,
+              }),
+              icon: 'LayoutTopOutline',
+              onPress: async () => {
+                await extUtils.openPanelOnActionClick(false);
+                window.close();
+              },
+            },
+        {
+          label: intl.formatMessage({
+            id: ETranslations.global_expand_view,
+          }),
+          icon: 'ExpandOutline',
+          onPress: async () => {
+            defaultLogger.account.wallet.openExpandView();
+            window.close();
+            await backgroundApiProxy.serviceApp.openExtensionExpandTab(
+              routeInfo,
+            );
+          },
+        },
+      ];
+    }
+    return [];
+  }, [intl]);
+
   return (
     <ActionList
       key="more-action"
@@ -125,7 +175,8 @@ export function MoreActionButton() {
               onPress: handleScan,
               testID: 'scan-qr-code',
             },
-          ],
+            ...popupMenu,
+          ].filter(Boolean),
         },
         {
           items: [


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/8a7e5617-1158-4b70-b6e5-d1c3bd94e3c8)

![image](https://github.com/user-attachments/assets/9b82c2ac-8a77-4752-bcbb-6077f5378a32)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the header display for extension modes by removing redundant layout options.

- **New Features**
  - Enhanced the more actions menu to dynamically present contextual options tailored to different UI environments, including new actions for sidebar and popup layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->