### PR TITLE
fix: quoting false loading animation no stop OK-36648

### DIFF
--- a/packages/kit/src/views/Swap/components/SwapQuoteResultRate.tsx
+++ b/packages/kit/src/views/Swap/components/SwapQuoteResultRate.tsx
@@ -165,15 +165,17 @@ const SwapQuoteResultRate = ({
           </Stack>
         ) : (
           <XStack flex={1} justifyContent="flex-end">
-            <LottieView
-              source={require('@onekeyhq/kit/assets/animations/swap_loading.json')}
-              autoPlay
-              loop
-              style={{
-                width: 48,
-                height: 20,
-              }}
-            />
+            {quoting ? (
+              <LottieView
+                source={require('@onekeyhq/kit/assets/animations/swap_loading.json')}
+                autoPlay
+                loop
+                style={{
+                  width: 48,
+                  height: 20,
+                }}
+              />
+            ) : null}
             {onOpenResult ? (
               <Stack animation="quick" rotate={openResult ? '180deg' : '0deg'}>
                 <Icon

--- a/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
@@ -342,7 +342,6 @@ const SwapQuoteResult = ({
   ) {
     return null;
   }
-
   if (swapTypeSwitch === ESwapTabSwitchType.LIMIT) {
     if (quoting || swapQuoteLoading) {
       return (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The swap view now displays the loading animation only during active processing. This change streamlines the interface by preventing unnecessary animations, resulting in a cleaner and more responsive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->