### PR TITLE
fix: Enable PrivyProvider by default

### DIFF
--- a/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
@@ -52,7 +52,8 @@ export const {
       disableSolanaPriorityFee: false,
       disableAllShortcuts: false,
       webviewDebuggingEnabled: false,
-      showPrimeTest: true,
+      showPrimeTest: false,
+      usePrimeSandboxPayment: false,
       autoNavigation: {
         enabled: false,
         selectedTab: ETabRoutes.Discovery,

--- a/packages/kit/src/views/Prime/components/PrivyProviderLazy.tsx
+++ b/packages/kit/src/views/Prime/components/PrivyProviderLazy.tsx
@@ -1,19 +1,23 @@
 import { Suspense, lazy } from 'react';
 
-import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-
 const PrivyProvider = lazy(() =>
   import('./PrivyProvider').then((m) => ({ default: m.PrivyProvider })),
 );
 
 export function PrivyProviderLazy({ children }: { children: React.ReactNode }) {
-  const [devSettings] = useDevSettingsPersistAtom();
-  if (devSettings.enabled && devSettings.settings?.showPrimeTest) {
-    return (
-      <Suspense fallback={null}>
-        <PrivyProvider>{children}</PrivyProvider>
-      </Suspense>
-    );
-  }
-  return children;
+  // const [devSettings] = useDevSettingsPersistAtom();
+  // if (devSettings.enabled && devSettings.settings?.showPrimeTest) {
+  //   return (
+  //     <Suspense fallback={null}>
+  //       <PrivyProvider>{children}</PrivyProvider>
+  //     </Suspense>
+  //   );
+  // }
+  // return children;
+
+  return (
+    <Suspense fallback={null}>
+      <PrivyProvider>{children}</PrivyProvider>
+    </Suspense>
+  );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Prime test is now disabled by default.
  - A new configuration option for sandbox payment functionality has been introduced.
  
- **Refactor**
  - Streamlined the provider integration by removing legacy conditional logic, ensuring a consistent loading experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->