### PR TITLE
fix: prevent deletion of custom network rpc

### DIFF
--- a/packages/kit/src/views/Setting/pages/CustomRPC/index.tsx
+++ b/packages/kit/src/views/Setting/pages/CustomRPC/index.tsx
@@ -456,6 +456,7 @@ function CustomRPC() {
                     destructive: true,
                     icon: 'DeleteOutline',
                     onPress: async () => onDeleteCustomRpc(item),
+                    disabled: item.isCustomNetwork,
                   },
                 ]}
               />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The delete action for custom RPC items is now automatically disabled, preventing accidental removals of custom networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->