### PR TITLE
chore: upgrade electron to 31.7.7

### DIFF
--- a/apps/desktop/app/app.ts
+++ b/apps/desktop/app/app.ts
@@ -958,12 +958,11 @@ function initChildProcess() {
 const singleInstance = app.requestSingleInstanceLock();
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function quitOrMinimizeApp(event?: Event) {
+function quitOrMinimizeApp() {
   // On OS X it is common for applications and their menu bar
   // to stay active until the user quits explicitly with Cmd + Q
   if (isMac) {
     // **** renderer app will reload after minimize, and keytar not working.
-    event?.preventDefault();
     const safelyMainWindow = getSafelyMainWindow();
     safelyMainWindow?.hide();
     // ****
@@ -1029,8 +1028,8 @@ app.on('before-quit', () => {
 });
 
 // Quit when all windows are closed.
-app.on('window-all-closed', (event: Event) => {
-  quitOrMinimizeApp(event);
+app.on('window-all-closed', () => {
+  quitOrMinimizeApp();
 });
 
 // Closing the cause context: https://onekeyhq.atlassian.net/browse/OK-8096

--- a/package.json
+++ b/package.json
@@ -260,7 +260,7 @@
     "@metamask/eth-sig-util": "5.1.0",
     "@polkadot/util": "12.6.2",
     "@polkadot/util-crypto": "12.6.2",
-    "electron": "30.5.1",
+    "electron": "31.7.7",
     "@walletconnect/universal-provider": "2.11.2",
     "@walletconnect/core": "2.11.2",
     "fs": "npm:@favware/skip-dependency@1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22361,16 +22361,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:30.5.1":
-  version: 30.5.1
-  resolution: "electron@npm:30.5.1"
+"electron@npm:31.7.7":
+  version: 31.7.7
+  resolution: "electron@npm:31.7.7"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^20.9.0"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/2dd971883bcaae63e63ae2549aa029922f4935816d71b8a52b5d3ee2f2f242cf0236d7284778902d8a0cebdd8b75cf9ece1523e687b1ade81aeb000126ebaa19
+  checksum: 10/18305f258de6611867853b399c0d78b09651cc3452150b0a14b33863323a36fdbb29df70b440a7f75ff7db8ebd2132043cbe64804f6f5a191f830af10375d646
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Upgraded the underlying framework to a newer version for improved performance, security, and stability.
- **Bug Fixes**
	- Simplified the `quitOrMinimizeApp` function by removing unnecessary parameters, enhancing application behavior when all windows are closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->