### PR TITLE
fix: Open searchDevice page by extension window

### DIFF
--- a/packages/kit/src/views/DeviceManagement/pages/DeviceManagementListModal/index.tsx
+++ b/packages/kit/src/views/DeviceManagement/pages/DeviceManagementListModal/index.tsx
@@ -21,10 +21,12 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   EModalDeviceManagementRoutes,
   EModalRoutes,
   EOnboardingPages,
+  ERootRoutes,
 } from '@onekeyhq/shared/src/routes';
 import deviceUtils from '@onekeyhq/shared/src/utils/deviceUtils';
 import type { IHwQrWalletWithDevice } from '@onekeyhq/shared/types/account';
@@ -71,9 +73,22 @@ function DeviceManagementListModal() {
   }, [refreshHwQrWalletList]);
 
   const onAddDevice = useCallback(async () => {
-    appNavigation.pushModal(EModalRoutes.OnboardingModal, {
-      screen: EOnboardingPages.ConnectYourDevice,
-    });
+    if (platformEnv.isExtensionUiPopup || platformEnv.isExtensionUiSidePanel) {
+      await backgroundApiProxy.serviceApp.openExtensionExpandTab({
+        routes: [
+          ERootRoutes.Modal,
+          EModalRoutes.OnboardingModal,
+          EOnboardingPages.ConnectYourDevice,
+        ],
+      });
+      if (platformEnv.isExtensionUiSidePanel) {
+        window.close();
+      }
+    } else {
+      appNavigation.pushModal(EModalRoutes.OnboardingModal, {
+        screen: EOnboardingPages.ConnectYourDevice,
+      });
+    }
   }, [appNavigation]);
 
   const onWalletPressed = useCallback(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the device onboarding experience by tailoring the process based on how you access the app.
	- When using an extension interface (popup or side panel), you are now smoothly redirected to an expanded onboarding view, with the side panel automatically closing for a more streamlined interaction.
	- In other scenarios, the traditional onboarding display remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->