### PR TITLE
OK-37070: show tab bar when no tabs are present in MobileBrowser component

### DIFF
--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -69,6 +69,12 @@ function MobileBrowser() {
   const { displayHomePage } = useDisplayHomePageFlag();
   const displayBottomBar = !displayHomePage;
 
+  useEffect(() => {
+    if (!tabs?.length) {
+      showTabBar();
+    }
+  }, [tabs]);
+
   const { setDisplayHomePage } = useBrowserTabActions().current;
   const firstRender = useRef(true);
   useEffect(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the mobile browsing experience by ensuring the tab bar is automatically displayed when no tabs are open, improving navigation control and overall usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->