### PR TITLE
chore: show critical alert for signature

### DIFF
--- a/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
@@ -27,6 +27,8 @@ export interface IDevSettings {
   showPrimeTest?: boolean;
   showOneKeyId?: boolean;
   usePrimeSandboxPayment?: boolean;
+  // strict signature alert display
+  strictSignatureAlert?: boolean;
   autoNavigation?: {
     enabled: boolean;
     selectedTab: ETabRoutes | null;
@@ -56,6 +58,7 @@ export const {
       showPrimeTest: false,
       showOneKeyId: false,
       usePrimeSandboxPayment: false,
+      strictSignatureAlert: false,
       autoNavigation: {
         enabled: false,
         selectedTab: ETabRoutes.Discovery,

--- a/packages/kit/src/views/Setting/pages/List/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/List/DevSettingsSection/index.tsx
@@ -319,6 +319,13 @@ export const DevSettingsSection = () => {
       >
         <Switch size={ESwitchSize.small} />
       </SectionFieldItem>
+      <SectionFieldItem
+        name="strictSignatureAlert"
+        title="严格的签名 Alert 展示"
+        subtitle="signTypedData 签名，红色 Alert"
+      >
+        <Switch size={ESwitchSize.small} />
+      </SectionFieldItem>
 
       <ListItem
         title="Bg Api 可序列化检测"

--- a/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmAlert/MessageConfirmAlert.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmAlert/MessageConfirmAlert.tsx
@@ -6,6 +6,7 @@ import { useIntl } from 'react-intl';
 import type { IAlertProps } from '@onekeyhq/components';
 import { Alert, YStack } from '@onekeyhq/components';
 import type { IUnsignedMessage } from '@onekeyhq/core/src/types';
+import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
   isPrimaryTypeOrderSign,
@@ -23,6 +24,8 @@ interface IProps {
 function MessageConfirmAlert(props: IProps) {
   const { messageDisplay, unsignedMessage, isRiskSignMethod } = props;
   const intl = useIntl();
+  const [devSettings] = useDevSettingsPersistAtom();
+  const isStrictSignatureAlert = devSettings.settings?.strictSignatureAlert;
 
   const isSignTypedDataV3orV4Method =
     unsignedMessage.type === EMessageTypesEth.TYPED_DATA_V3 ||
@@ -33,11 +36,13 @@ function MessageConfirmAlert(props: IProps) {
 
   const renderLocalParsedMessageAlert = useCallback(() => {
     if (isSignTypedDataV3orV4Method) {
-      let type: IAlertProps['type'] = 'default';
+      let type: IAlertProps['type'] = isStrictSignatureAlert
+        ? 'critical'
+        : 'default';
       let messageType = 'signTypedData';
 
       if (isPermitSignMethod || isOrderSignMethod) {
-        type = 'warning';
+        type = isStrictSignatureAlert ? 'critical' : 'warning';
         messageType = isPermitSignMethod ? 'permit' : 'order';
       }
 
@@ -74,6 +79,7 @@ function MessageConfirmAlert(props: IProps) {
     isPermitSignMethod,
     isOrderSignMethod,
     intl,
+    isStrictSignatureAlert,
   ]);
 
   const renderMessageAlerts = useCallback(() => {
@@ -88,13 +94,17 @@ function MessageConfirmAlert(props: IProps) {
           <Alert
             key={alert}
             description={alert}
-            type="warning"
+            type={isStrictSignatureAlert ? 'critical' : 'warning'}
             icon="InfoSquareOutline"
           />
         ))}
       </YStack>
     );
-  }, [messageDisplay?.alerts, renderLocalParsedMessageAlert]);
+  }, [
+    messageDisplay?.alerts,
+    renderLocalParsedMessageAlert,
+    isStrictSignatureAlert,
+  ]);
 
   return renderMessageAlerts();
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a developer setting to control the behavior of signature alerts with an intuitive switch in the settings panel.
  - Updated alert displays in the signature confirmation view to use a more critical style when the setting is enabled, ensuring clearer feedback during signature processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->