### PR TITLE
feat: add new shortcut events for Refer a Friend and My OneKey tabs

### DIFF
--- a/packages/kit/src/provider/Bootstrap.tsx
+++ b/packages/kit/src/provider/Bootstrap.tsx
@@ -137,6 +137,25 @@ const useDesktopEvents = platformEnv.isDesktop
       const openSettingsRef = useRef(openSettings);
       openSettingsRef.current = openSettings;
 
+      const ensureModalClosedAndNavigate = useCallback(
+        (navigateAction: () => void) => {
+          const routeState = rootNavigationRef.current?.getRootState();
+          if (routeState?.routes) {
+            // Check if any route in the stack is a Modal
+            const isModalOpen = routeState.routes.some(
+              (route) => route.name === ERootRoutes.Modal,
+            );
+            if (isModalOpen) {
+              // If a modal is open anywhere in the stack, do nothing.
+              return;
+            }
+          }
+          // If no modal is open, navigate.
+          navigateAction();
+        },
+        [],
+      );
+
       useEffect(() => {
         globalThis.desktopApi.on(ipcMessageKeys.CHECK_FOR_UPDATES, () => {
           void onCheckUpdateRef.current();
@@ -170,10 +189,14 @@ const useDesktopEvents = platformEnv.isDesktop
             navigation.switchTab(ETabRoutes.Market);
             break;
           case EShortcutEvents.TabReferAFriend:
-            void toReferFriendsPage();
+            ensureModalClosedAndNavigate(() => {
+              void toReferFriendsPage();
+            });
             break;
           case EShortcutEvents.TabMyOneKey:
-            void toMyOneKeyModal();
+            ensureModalClosedAndNavigate(() => {
+              void toMyOneKeyModal();
+            });
             break;
           case EShortcutEvents.TabBrowser:
             navigation.switchTab(ETabRoutes.Discovery);

--- a/packages/kit/src/provider/Bootstrap.tsx
+++ b/packages/kit/src/provider/Bootstrap.tsx
@@ -164,6 +164,12 @@ const useDesktopEvents = platformEnv.isDesktop
           case EShortcutEvents.TabMarket:
             navigation.switchTab(ETabRoutes.Market);
             break;
+          case EShortcutEvents.TabReferAFriend:
+            // open modal
+            break;
+          case EShortcutEvents.TabMyOneKey:
+            // open modal
+            break;
           case EShortcutEvents.TabBrowser:
             navigation.switchTab(ETabRoutes.Discovery);
             break;

--- a/packages/kit/src/provider/Bootstrap.tsx
+++ b/packages/kit/src/provider/Bootstrap.tsx
@@ -34,6 +34,8 @@ import { ESpotlightTour } from '@onekeyhq/shared/src/spotlight';
 import backgroundApiProxy from '../background/instance/backgroundApiProxy';
 import { useAppUpdateInfo } from '../components/UpdateReminder/hooks';
 import useAppNavigation from '../hooks/useAppNavigation';
+import { useReferFriends } from '../hooks/useReferFriends';
+import { useToMyOneKeyModal } from '../views/DeviceManagement/hooks/useToMyOneKeyModal';
 import { useOnLock } from '../views/Setting/pages/List/DefaultSection';
 
 import type { IntlShape } from 'react-intl';
@@ -53,6 +55,9 @@ const useDesktopEvents = platformEnv.isDesktop
       const onLock = useOnLockCallback();
       const useOnLockRef = useRef(onLock);
       useOnLockRef.current = onLock;
+
+      const { toReferFriendsPage } = useReferFriends();
+      const toMyOneKeyModal = useToMyOneKeyModal();
 
       const { checkForUpdates, onUpdateAction } = useAppUpdateInfoCallback(
         false,
@@ -165,10 +170,10 @@ const useDesktopEvents = platformEnv.isDesktop
             navigation.switchTab(ETabRoutes.Market);
             break;
           case EShortcutEvents.TabReferAFriend:
-            // open modal
+            void toReferFriendsPage();
             break;
           case EShortcutEvents.TabMyOneKey:
-            // open modal
+            void toMyOneKeyModal();
             break;
           case EShortcutEvents.TabBrowser:
             navigation.switchTab(ETabRoutes.Discovery);

--- a/packages/kit/src/views/Discovery/pages/DesktopCustomTabBar/index.tsx
+++ b/packages/kit/src/views/Discovery/pages/DesktopCustomTabBar/index.tsx
@@ -176,8 +176,6 @@ function DesktopCustomTabBar() {
   const handleShortcuts = useCallback(
     (eventName: EShortcutEvents) => {
       switch (eventName) {
-        case EShortcutEvents.TabPin6:
-        case EShortcutEvents.TabPin7:
         case EShortcutEvents.TabPin8:
         case EShortcutEvents.TabPin9:
           if (result?.pinnedTabs?.length) {

--- a/packages/shared/src/shortcuts/shortcuts.enum.ts
+++ b/packages/shared/src/shortcuts/shortcuts.enum.ts
@@ -18,6 +18,8 @@ export enum EShortcutEvents {
   TabEarn = 'TabEarn',
   TabSwap = 'TabSwap',
   TabMarket = 'TabMarket',
+  TabReferAFriend = 'TabReferAFriend',
+  TabMyOneKey = 'TabMyOneKey',
   TabBrowser = 'TabBrowser',
   ViewHistory = 'ViewHistory',
   ViewBookmark = 'ViewBookmark',
@@ -25,8 +27,6 @@ export enum EShortcutEvents {
   PinOrUnpinTab = 'PinOrUnpinTab',
   ChangeCurrentTabUrl = 'ChangeCurrentTabUrl',
   ReOpenLastClosedTab = 'ReOpenLastClosedTab',
-  TabPin6 = 'TabPin6',
-  TabPin7 = 'TabPin7',
   TabPin8 = 'TabPin8',
   TabPin9 = 'TabPin9',
 }
@@ -96,25 +96,25 @@ export const shortcutsMap: Record<
     keys: [shortcutsKeys.CmdOrCtrl, '4'],
     desc: 'Earn Tab',
   },
-  [EShortcutEvents.TabBrowser]: {
+  [EShortcutEvents.TabReferAFriend]: {
     keys: [shortcutsKeys.CmdOrCtrl, '5'],
-    desc: 'Browser Tab',
+    desc: 'Refer a Friend Tab',
   },
-  [EShortcutEvents.TabPin6]: {
+  [EShortcutEvents.TabMyOneKey]: {
     keys: [shortcutsKeys.CmdOrCtrl, '6'],
-    desc: 'Pin Tab 6',
+    desc: 'My OneKey Tab',
   },
-  [EShortcutEvents.TabPin7]: {
+  [EShortcutEvents.TabBrowser]: {
     keys: [shortcutsKeys.CmdOrCtrl, '7'],
-    desc: 'Pin Tab 6',
+    desc: 'Browser Tab',
   },
   [EShortcutEvents.TabPin8]: {
     keys: [shortcutsKeys.CmdOrCtrl, '8'],
-    desc: 'Pin Tab 6',
+    desc: 'Pin Tab 8',
   },
   [EShortcutEvents.TabPin9]: {
     keys: [shortcutsKeys.CmdOrCtrl, '9'],
-    desc: 'Pin Tab 6',
+    desc: 'Pin Tab 9',
   },
   [EShortcutEvents.ViewHistory]: {
     keys: [shortcutsKeys.CmdOrCtrl, 'Y'],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new keyboard shortcuts for quick navigation to the "Refer a Friend" (Cmd/Ctrl+5) and "My OneKey" (Cmd/Ctrl+6) pages.
  - Updated the "Browser Tab" shortcut to use Cmd/Ctrl+7.
  - Improved navigation behavior to prevent interference when a modal is active.
  
- **Refactor**
  - Removed outdated keyboard shortcuts previously available for certain actions to streamline the experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->