### PR TITLE
Fix: Add validation for empty input fields in multiple rename scenarios OK-37184

### DIFF
--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityChangeHistory.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityChangeHistory.ts
@@ -149,7 +149,8 @@ export class SimpleDbEntityChangeHistory extends SimpleDbEntityBase<IChangeHisto
       items.forEach((item) => {
         const { entityType, entityId, contentType, oldValue, value } = item;
 
-        if (!entityId || !value || value === oldValue) {
+        const trimmedValue = value?.trim();
+        if (!entityId || !value || !trimmedValue || value === oldValue) {
           return;
         }
         if (

--- a/packages/kit/src/components/ChangeHistoryDialog/ChangeHistoryDialog.tsx
+++ b/packages/kit/src/components/ChangeHistoryDialog/ChangeHistoryDialog.tsx
@@ -48,17 +48,22 @@ function ChangeHistoryDialogContent({
             {intl.formatMessage({ id: ETranslations.explore_no_history })}
           </SizableText>
         ) : (
-          items?.map((item) => (
-            <Button
-              key={item.value}
-              onPress={() => {
-                onChange?.(item.value);
-              }}
-              textEllipsis
-            >
-              {item.value}
-            </Button>
-          ))
+          items?.map((item) => {
+            if (!item?.value?.trim()) {
+              return null;
+            }
+            return (
+              <Button
+                key={item.value}
+                onPress={() => {
+                  onChange?.(item.value);
+                }}
+                textEllipsis
+              >
+                {item.value || '   '}
+              </Button>
+            );
+          })
         )}
       </YStack>
     </ScrollView>

--- a/packages/kit/src/components/RenameDialog/index.tsx
+++ b/packages/kit/src/components/RenameDialog/index.tsx
@@ -204,6 +204,14 @@ export const showRenameDialog = (
                 id: ETranslations.form_rename_error_empty,
               }),
             },
+            validate: (value: string) => {
+              if (!value?.trim()) {
+                return appLocale.intl.formatMessage({
+                  id: ETranslations.form_rename_error_empty,
+                });
+              }
+              return true;
+            },
           }}
         >
           <RenameInputWithNameSelector

--- a/packages/kit/src/views/AddressBook/components/CreateOrEditContent.tsx
+++ b/packages/kit/src/views/AddressBook/components/CreateOrEditContent.tsx
@@ -183,7 +183,12 @@ export const CreateOrEditContent: FC<ICreateOrEditContentProps> = ({
                   { 'num': 24 },
                 ),
               },
-              validate: async (text) => {
+              validate: async (text: string) => {
+                if (!text?.trim()) {
+                  return intl.formatMessage({
+                    id: ETranslations.address_book_add_address_name_empty_error,
+                  });
+                }
                 const searched =
                   await backgroundApiProxy.serviceAddressBook.findItem({
                     name: text,

--- a/packages/kit/src/views/Discovery/pages/BookmarkListModal/index.tsx
+++ b/packages/kit/src/views/Discovery/pages/BookmarkListModal/index.tsx
@@ -103,6 +103,14 @@ function BookmarkListModal() {
                     id: ETranslations.explore_bookmark_at_least,
                   }),
                 },
+                validate: (value: string) => {
+                  if (!value?.trim()) {
+                    return intl.formatMessage({
+                      id: ETranslations.explore_bookmark_at_least,
+                    });
+                  }
+                  return true;
+                },
               }}
             >
               <RenameInputWithNameSelector


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced input validation across dialogs to prevent submission of empty or whitespace-only values.
  - Improved user feedback in rename, address book, and bookmark dialogs to ensure more consistent error handling.
  - Refined display of change history items by filtering out unintended empty entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->