### PR TITLE
fix: conditionally render settings button in MoreActionButton component

### DIFF
--- a/packages/kit/src/components/TabPageHeader/MoreActionButton.tsx
+++ b/packages/kit/src/components/TabPageHeader/MoreActionButton.tsx
@@ -228,18 +228,20 @@ function MoreActionButtonCmp() {
                 },
               ],
         },
-        {
-          items: [
-            {
-              label: intl.formatMessage({
-                id: ETranslations.settings_settings,
-              }),
-              icon: 'SettingsOutline',
-              onPress: handleSettings,
-            },
-          ],
-        },
-      ]}
+        !isShowMyOneKeyOnTabbar
+          ? {
+              items: [
+                {
+                  label: intl.formatMessage({
+                    id: ETranslations.settings_settings,
+                  }),
+                  icon: 'SettingsOutline',
+                  onPress: handleSettings,
+                },
+              ],
+            }
+          : null,
+      ].filter(Boolean)}
     />
   );
 }


### PR DESCRIPTION
### Problem
The settings button was being displayed redundantly in both the Desktop-AppSideBar-Container and the MoreActionButton component, creating UI duplication.

### Solution
Fixed the issue by implementing conditional rendering. The settings option in the MoreActionButton is now only displayed when the Setting tab is not shown in the sidebar.

![Web gtMd](https://github.com/user-attachments/assets/a1af2cfd-fcc2-46de-b893-e0f74e74cb60)

### Changes

Replaced the fixed display logic for the settings button with a conditional check !isShowMyOneKeyOnTabbar
Eliminated duplicate functionality when users can already see the settings button in the sidebar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The settings option in the action menu now appears only when enabled by configuration, ensuring users see only relevant choices.
	- The action list has been refined to automatically remove any empty entries, enhancing the overall clarity of available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->