### PR TITLE
fix: show spotlight only when scroll index is zero in chain selector OK-37378

### DIFF
--- a/packages/kit/src/views/ChainSelector/components/EditableChainSelector/ChainSelectorContent.tsx
+++ b/packages/kit/src/views/ChainSelector/components/EditableChainSelector/ChainSelectorContent.tsx
@@ -64,11 +64,13 @@ const ListHeaderComponent = ({
   accountId,
   indexedAccountId,
   setAllNetworksChanged,
+  initialScrollIndex,
 }: {
   walletId?: string;
   accountId?: string;
   indexedAccountId?: string;
   setAllNetworksChanged?: (value: boolean) => void;
+  initialScrollIndex?: { sectionIndex: number; itemIndex?: number };
 }) => {
   const intl = useIntl();
   const navigation = useAppNavigation();
@@ -94,7 +96,7 @@ const ListHeaderComponent = ({
     return (
       <Spotlight
         delayMs={500}
-        isVisible
+        isVisible={initialScrollIndex?.sectionIndex === 0}
         message={intl.formatMessage({
           id: ETranslations.network_all_networks_selection_tip,
         })}
@@ -129,6 +131,7 @@ const ListHeaderComponent = ({
     enabledNetworksCompatibleWithWalletId.length,
     handleNetworksChange,
     indexedAccountId,
+    initialScrollIndex?.sectionIndex,
     intl,
     navigation,
     walletId,
@@ -568,6 +571,7 @@ export const EditableChainSelectorContent = ({
               }}
               ListHeaderComponent={
                 <ListHeaderComponent
+                  initialScrollIndex={initialScrollIndex}
                   walletId={walletId}
                   accountId={accountId}
                   indexedAccountId={indexedAccountId}

--- a/packages/kit/src/views/ChainSelector/components/EditableChainSelector/ChainSelectorContent.tsx
+++ b/packages/kit/src/views/ChainSelector/components/EditableChainSelector/ChainSelectorContent.tsx
@@ -96,7 +96,9 @@ const ListHeaderComponent = ({
     return (
       <Spotlight
         delayMs={500}
-        isVisible={initialScrollIndex?.sectionIndex === 0}
+        isVisible={
+          !initialScrollIndex || initialScrollIndex?.sectionIndex === 0
+        }
         message={intl.formatMessage({
           id: ETranslations.network_all_networks_selection_tip,
         })}
@@ -131,7 +133,7 @@ const ListHeaderComponent = ({
     enabledNetworksCompatibleWithWalletId.length,
     handleNetworksChange,
     indexedAccountId,
-    initialScrollIndex?.sectionIndex,
+    initialScrollIndex,
     intl,
     navigation,
     walletId,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The spotlight tip in the chain selector header now appears only when viewing the first section or if no initial scroll position is set, improving contextual guidance for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->