### PR TITLE
chore: replace OneKeyHQ/actions/expo-server to expo/expo-github-action

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -49,8 +49,8 @@ jobs:
           rm -rf apps/mobile/android/app/google-services.json
           echo ${{ secrets.GOOGLE_SERVICE_ANDROID }} | base64 -d > apps/mobile/android/app/google-services.json
 
-      - name: Setup Expo
-        uses: OneKeyHQ/actions/expo-server@main
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          registry-url: 'https://npm.pkg.github.com'
+          registry-url: 'https://registry.npmjs.org'
           always-auth: true
           scope: '@onekeyhq'
 

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -36,7 +36,7 @@ jobs:
           sentry_token: ${{ secrets.SENTRY_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.x
           registry-url: 'https://npm.pkg.github.com'

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -48,8 +48,8 @@ jobs:
           echo ${{ secrets.GOOGLE_SERVICE_IOS }} | base64 -d > apps/mobile/ios/OneKeyWallet/GoogleService-Info.plist
           echo ${{ secrets.ASC_API_KEY }} | base64 -d > apps/mobile/AscApiKey.p8
 
-      - name: Setup Expo
-        uses: OneKeyHQ/actions/expo-server@main
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow environment setup for Android and iOS releases to use the latest official Expo GitHub Action.
	- Improved compatibility and reliability by switching to the public npm registry and updating Node.js setup in the Android release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->