### PR TITLE
fix: prevent OneKey ID remaining logged in after reset

### DIFF
--- a/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
@@ -394,6 +394,7 @@ const PasswordVerifyContainer = ({
       enablePasswordErrorProtection,
       intl,
       isLock,
+      logout,
       onVerifyRes,
       passwordErrorAttempts,
       passwordMode,

--- a/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
@@ -5,6 +5,7 @@ import { useIntl } from 'react-intl';
 
 import { SizableText, Spinner, Stack, Toast } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { usePrimeAuthV2 } from '@onekeyhq/kit/src/views/Prime/hooks/usePrimeAuthV2';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import {
   biologyAuthNativeError,
@@ -60,6 +61,7 @@ const PasswordVerifyContainer = ({
   const [hasCachedPassword, setHasCachedPassword] = useState(false);
   const [hasSecurePassword, setHasSecurePassword] = useState(true);
   const [passwordMode] = usePasswordModeAtom();
+  const { logout } = usePrimeAuthV2();
   const { title } = useBiometricAuthInfo();
   const biologyAuthAttempts = useMemo(
     () =>
@@ -340,6 +342,11 @@ const PasswordVerifyContainer = ({
               // disable setInterval on ext popup
               if (platformEnv.isExtensionUiPopup) {
                 resetUtils.startResetting();
+              }
+              try {
+                await logout();
+              } catch (error) {
+                console.error('failed to logout', error);
               }
               await backgroundApiProxy.serviceApp.resetApp();
             } catch (error) {

--- a/packages/kit/src/views/Setting/hooks/index.tsx
+++ b/packages/kit/src/views/Setting/hooks/index.tsx
@@ -4,6 +4,7 @@ import { useIntl } from 'react-intl';
 
 import { Dialog, Input, Portal } from '@onekeyhq/components';
 import type { IDialogProps } from '@onekeyhq/components/src/composite/Dialog/type';
+import { usePrimeAuthV2 } from '@onekeyhq/kit/src/views/Prime/hooks/usePrimeAuthV2';
 import { ETranslations, LOCALES_OPTION } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { RESET_OVERLAY_Z_INDEX } from '@onekeyhq/shared/src/utils/overlayUtils';
@@ -43,6 +44,7 @@ export const inAppStateLockStyle: {
 export function useResetApp(params?: { inAppStateLock: boolean }) {
   const { inAppStateLock = false } = params || {};
   const intl = useIntl();
+  const { logout } = usePrimeAuthV2();
   return useCallback(async () => {
     await timerUtils.wait(50);
     if (inAppStateLock) {
@@ -93,6 +95,11 @@ export function useResetApp(params?: { inAppStateLock: boolean }) {
           if (platformEnv.isExtensionUiPopup) {
             resetUtils.startResetting();
           }
+          try {
+            await logout();
+          } catch (error) {
+            console.error('failed to logout', error);
+          }
           await backgroundApiProxy.serviceApp.resetApp();
         } catch (e) {
           console.error('failed to reset app with error', e);
@@ -104,5 +111,5 @@ export function useResetApp(params?: { inAppStateLock: boolean }) {
         }
       },
     });
-  }, [inAppStateLock, intl]);
+  }, [inAppStateLock, intl, logout]);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an automatic logout step during the app reset process, ensuring users are logged out before the app resets.
- **Bug Fixes**
  - Improved error handling during logout to prevent interruptions in the app reset flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->