### PR TITLE
fix: focused wallet error when select accout

### DIFF
--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/AccountSelectorWalletListSideBar.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/AccountSelectorWalletListSideBar.tsx
@@ -104,7 +104,13 @@ export function AccountSelectorWalletListSideBar({
       if (hideNonBackedUpWallet && !focusWalletChanged.current) {
         const backedUpWallets = r.wallets;
 
-        if (!backedUpWallets.find((w) => w.id === selectedAccount.walletId)) {
+        if (
+          !backedUpWallets.find(
+            (w) =>
+              w.id === selectedAccount.walletId ||
+              w.id === selectedAccount.focusedWallet,
+          )
+        ) {
           void actions.current.updateSelectedAccountFocusedWallet({
             num,
             focusedWallet: backedUpWallets[0]?.id,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved wallet selection validation to ensure both wallet ID and focused wallet ID are checked before updating the focused wallet, providing a more accurate selection experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->