### PR TITLE
feat: add useV2Flow setting in firmware update components

### DIFF
--- a/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
@@ -81,6 +81,7 @@ export type IFirmwareUpdateDevSettings = {
   forceUpdateBootloader: boolean;
   showDeviceDebugLogs: boolean;
   showAutoCheckHardwareUpdatesToast: boolean;
+  useV2Flow: boolean;
 };
 export type IFirmwareUpdateDevSettingsKeys = keyof IFirmwareUpdateDevSettings;
 export const {
@@ -102,6 +103,7 @@ export const {
     forceUpdateBootloader: false,
     showDeviceDebugLogs: false,
     showAutoCheckHardwareUpdatesToast: false,
+    useV2Flow: false,
   },
 });
 

--- a/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateCheckList.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateCheckList.tsx
@@ -109,10 +109,14 @@ export function FirmwareUpdateCheckList({
         onConfirm={
           result
             ? async (dialog) => {
+                // const useV2FirmwareUpdateFlow =
+                //   await deviceUtils.shouldUseV2FirmwareUpdateFlow({
+                //     features: result?.features,
+                //   });
                 const useV2FirmwareUpdateFlow =
-                  await deviceUtils.shouldUseV2FirmwareUpdateFlow({
-                    features: result?.features,
-                  });
+                  await backgroundApiProxy.serviceDevSetting.getFirmwareUpdateDevSettings(
+                    'useV2Flow',
+                  );
                 try {
                   await dialog.close();
                   setStepInfo({

--- a/packages/kit/src/views/Setting/pages/List/DevSettingsSection/FirmwareUpdateDevSettings.tsx
+++ b/packages/kit/src/views/Setting/pages/List/DevSettingsSection/FirmwareUpdateDevSettings.tsx
@@ -127,6 +127,9 @@ export function FirmwareUpdateDevSettings() {
       >
         <Switch size={ESwitchSize.small} />
       </FirmwareUpdateSectionFieldItem>
+      <FirmwareUpdateSectionFieldItem name="useV2Flow" title="Use V2 Flow">
+        <Switch size={ESwitchSize.small} />
+      </FirmwareUpdateSectionFieldItem>
       <SizableText>{JSON.stringify(devSetting, null, 2)}</SizableText>
       <FirmwareUpdateGalleryDemo />
     </YStack>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Use V2 Flow" toggle in the Firmware Update Developer Settings section.
  - The firmware update process now references the new "Use V2 Flow" setting to determine the update workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->