### PR TITLE
fix: fix height of chart on Market Modal page

### DIFF
--- a/packages/kit/src/views/Market/components/TokenPriceChart.tsx
+++ b/packages/kit/src/views/Market/components/TokenPriceChart.tsx
@@ -172,7 +172,7 @@ const useHeight = () => {
   const tabHeight = useTabBarHeight();
   const fixedHeight = useMemo(() => {
     if (platformEnv.isNativeIOS) {
-      return 268;
+      return 268 + (pageType === EPageType.modal ? 68 : 0);
     }
 
     if (platformEnv.isNativeAndroid) {
@@ -180,7 +180,7 @@ const useHeight = () => {
     }
 
     return 300;
-  }, []);
+  }, [pageType]);
   return useMemo(
     () => (gtMd ? 450 : height - top - tabHeight - fixedHeight),
     [fixedHeight, gtMd, height, tabHeight, top],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved height calculation for the token price chart on iOS native platforms, ensuring better layout when displayed in a modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->