### PR TITLE
fix: update error message for device communication failure in ConnectYourDevice component

### DIFF
--- a/packages/kit/src/views/Onboarding/pages/ConnectHardwareWallet/ConnectYourDevice.tsx
+++ b/packages/kit/src/views/Onboarding/pages/ConnectHardwareWallet/ConnectYourDevice.tsx
@@ -276,7 +276,7 @@ function BridgeNotInstalledDialogContent(props: { error: NeedOneKeyBridge }) {
         translationId={
           platformEnv.isSupportWebUSB
             ? ETranslations.device_communication_failed
-            : ETranslations.device_communication_failed_with_no_web_usb_supported
+            : ETranslations.onboarding_install_onekey_bridge_help_text
         }
       />
     </Stack>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the help text shown when OneKey Bridge is not installed and WebUSB is not supported, providing improved guidance to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->