### PR TITLE
fix: swap bitch transfer no hw qr wallet OK-37645

### DIFF
--- a/packages/kit/src/views/Swap/hooks/useSwapState.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapState.ts
@@ -146,12 +146,16 @@ export function useSwapBatchTransfer(
   const isExternalAccount = accountUtils.isExternalAccount({
     accountId: accountId ?? '',
   });
+  const isHDAccount = accountUtils.isHwOrQrAccount({
+    accountId: accountId ?? '',
+  });
   const isUnSupportBatchTransferNet =
     SwapBuildUseMultiplePopoversNetworkIds.includes(networkId ?? '');
   return (
     settingsPersistAtom.swapBatchApproveAndSwap &&
     !isUnSupportBatchTransferNet &&
     !isExternalAccount &&
+    !isHDAccount &&
     !providerDisableBatchTransfer
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Batch transfer is now disabled for hardware and QR code accounts, in addition to existing restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->