### PR TITLE
chore: Merge webembed changes into hotfix/v5.8.1

### DIFF
--- a/@types/globals.d.ts
+++ b/@types/globals.d.ts
@@ -31,6 +31,7 @@ declare global {
   // eslint-disable-next-line
   // var onekey: WindowOneKey;
   var $onekey: IWindowOneKeyHub;
+  var $onekeyAppWebembedApiWebviewInitFailed: boolean | undefined;
 
   var $$onekeyDisabledSetTimeout: boolean | undefined;
   var $$onekeyDisabledSetInterval: boolean | undefined;

--- a/apps/web-embed/index.js
+++ b/apps/web-embed/index.js
@@ -3,6 +3,8 @@ import React, { lazy, Suspense } from 'react';
 import { createRoot } from 'react-dom/client';
 import { HashRouter, Route, Routes } from 'react-router-dom';
 import { EWebEmbedRoutePath } from '@onekeyhq/shared/src/consts/webEmbedConsts';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import { init } from './utils/init';
 
 const PageIndex = lazy(() => import('./pages/PageIndex'));
 const PageWebEmbedApi = lazy(() => import('./pages/PageWebEmbedApi'));
@@ -12,6 +14,10 @@ const PageWebEmbedPrimePurchase = lazy(() =>
 
 const container = document.getElementById('root');
 const root = createRoot(container);
+
+init();
+
+defaultLogger.app.webembed.renderHtmlRoot();
 
 root.render(
   <React.StrictMode>

--- a/apps/web-embed/sentry.js
+++ b/apps/web-embed/sentry.js
@@ -1,0 +1,3 @@
+import { initSentry } from '@onekeyhq/shared/src/modules3rdParty/sentry';
+
+initSentry();

--- a/apps/web-embed/utils/init.ts
+++ b/apps/web-embed/utils/init.ts
@@ -1,0 +1,60 @@
+import { checkIsOneKeyDomain } from '@onekeyhq/kit-bg/src/endpoints';
+import { analytics } from '@onekeyhq/shared/src/analytics';
+import { buildServiceEndpoint } from '@onekeyhq/shared/src/config/appConfig';
+import requestHelper from '@onekeyhq/shared/src/request/requestHelper';
+import { EServiceEndpointEnum } from '@onekeyhq/shared/types/endpoint';
+import type { IWebEmbedOnekeyAppSettings } from '@onekeyhq/web-embed/utils/webEmbedAppSettings';
+
+const getValueFromWebEmbedOneKeyAppSettings = <
+  T extends keyof IWebEmbedOnekeyAppSettings,
+>(
+  key: T,
+): IWebEmbedOnekeyAppSettings[keyof IWebEmbedOnekeyAppSettings] | string => {
+  const value = globalThis?.WEB_EMBED_ONEKEY_APP_SETTINGS?.[key];
+  return value ?? '';
+};
+
+const initRequestHelper = () => {
+  requestHelper.checkIsOneKeyDomain = checkIsOneKeyDomain;
+  requestHelper.getSettingsPersistAtom = async () =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    Promise.resolve({
+      currencyInfo: {
+        id: 'usd',
+        symbol: '$',
+      },
+      instanceId: getValueFromWebEmbedOneKeyAppSettings('instanceId'),
+      theme: getValueFromWebEmbedOneKeyAppSettings('themeVariant') as
+        | 'light'
+        | 'dark',
+      lastLocale: getValueFromWebEmbedOneKeyAppSettings('localeVariant'),
+      locale: getValueFromWebEmbedOneKeyAppSettings('localeVariant'),
+      version: getValueFromWebEmbedOneKeyAppSettings('appVersion'),
+      buildNumber: getValueFromWebEmbedOneKeyAppSettings('appBuildNumber'),
+    } as any);
+  requestHelper.getSettingsValuePersistAtom = async () =>
+    Promise.resolve({
+      hideValue: false,
+    });
+};
+
+export const initAnalytics = () => {
+  const instanceId = getValueFromWebEmbedOneKeyAppSettings(
+    'instanceId',
+  ) as string;
+  analytics.init({
+    instanceId,
+    baseURL: buildServiceEndpoint({
+      serviceName: EServiceEndpointEnum.Utility,
+      env:
+        globalThis?.WEB_EMBED_ONEKEY_APP_SETTINGS?.enableTestEndpoint ?? false
+          ? 'test'
+          : 'prod',
+    }),
+  });
+};
+
+export const init = () => {
+  initRequestHelper();
+  initAnalytics();
+};

--- a/apps/web-embed/utils/webEmbedAppSettings.ts
+++ b/apps/web-embed/utils/webEmbedAppSettings.ts
@@ -1,7 +1,13 @@
 export type IWebEmbedOnekeyAppSettings = {
+  isDev: boolean;
+  enableTestEndpoint: boolean;
   themeVariant: string;
   localeVariant: string;
   revenuecatApiKey: string;
+  instanceId: string;
+  platform: string;
+  appBuildNumber: string;
+  appVersion: string;
 };
 
 function getSettings(): IWebEmbedOnekeyAppSettings | undefined {

--- a/development/babelTools.js
+++ b/development/babelTools.js
@@ -158,6 +158,10 @@ function normalizeConfig({ platform, config }) {
       developmentConsts.platforms.web,
       developmentConsts.platforms.webEmbed,
     ].includes(platform) && ['@babel/plugin-transform-optional-chaining'],
+    [
+      developmentConsts.platforms.web,
+      developmentConsts.platforms.webEmbed,
+    ].includes(platform) && ['@babel/plugin-transform-numeric-separator'],
     isDev && !isJest && !isNative && ['react-refresh/babel'],
     // Need to adapt to the new version of the metro build system.
     isDev &&

--- a/development/webpack/webpack.base.config.js
+++ b/development/webpack/webpack.base.config.js
@@ -289,6 +289,10 @@ module.exports = ({ platform, basePath, configName }) => {
                 // /(@?tamagui*).*\.(c|m)?(ts|js)x?$/,
                 // // keystonehq
                 // /(@?keystonehq).*\.(c|m)?(ts|js)x?$/,
+
+                /* web-embed on  */
+                /react-router/,
+                /turbo-stream/,
               ],
               exclude: [/react-native-logs/, /react-native-modalize/],
               use: useBabelLoader,

--- a/development/webpack/webpack.web-embed.config.js
+++ b/development/webpack/webpack.web-embed.config.js
@@ -12,6 +12,12 @@ module.exports = ({
   basePath,
   platform = babelTools.developmentConsts.platforms.webEmbed,
 }) => {
+  const config = {
+    entry: {
+      sentry: path.join(basePath, 'sentry.js'),
+      main: path.join(basePath, 'index.js'),
+    },
+  };
   switch (NODE_ENV) {
     case 'production':
       return merge(
@@ -29,6 +35,7 @@ module.exports = ({
             uniqueName: 'web',
             filename: 'web-embed.[contenthash:10].js',
           },
+          ...config,
         },
       );
     case 'development':
@@ -40,6 +47,7 @@ module.exports = ({
           output: {
             publicPath: '',
           },
+          ...config,
         },
       );
   }

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
     "@babel/plugin-proposal-private-methods": "^7.18.6",
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+    "@babel/plugin-transform-numeric-separator": "^7.25.9",
     "@babel/plugin-transform-optional-chaining": "^7.25.9",
     "@babel/preset-env": "^7.22.9",
     "@emurgo/cardano-message-signing-nodejs": "^1.0.1",

--- a/packages/core/src/secret/hash.ts
+++ b/packages/core/src/secret/hash.ts
@@ -36,7 +36,11 @@ function sha512Sync({
 }
 
 async function sha512Async(params: ISha512Params): Promise<string> {
-  if (platformEnv.isNative && !platformEnv.isJest) {
+  if (
+    platformEnv.isNative &&
+    !platformEnv.isJest &&
+    !globalThis.$onekeyAppWebembedApiWebviewInitFailed
+  ) {
     const webembedApiProxy = (
       await import('@onekeyhq/kit-bg/src/webembeds/instance/webembedApiProxy')
     ).default;

--- a/packages/core/src/secret/index.ts
+++ b/packages/core/src/secret/index.ts
@@ -169,11 +169,14 @@ function fixV4VerifyStringToV5({ verifyString }: { verifyString: string }) {
 async function decryptVerifyString({
   password,
   verifyString,
+  useRnJsCrypto,
 }: {
   verifyString: string;
   password: string;
+  useRnJsCrypto?: boolean;
 }) {
   const decrypted = await decryptAsync({
+    useRnJsCrypto,
     password,
     data: Buffer.from(
       verifyString.replace(EncryptPrefixVerifyString, ''),
@@ -431,7 +434,11 @@ export type IBatchGetPublicKeysAsyncParams = {
 async function batchGetPublicKeysAsync(
   params: IBatchGetPublicKeysAsyncParams,
 ): Promise<ISecretPublicKeyInfo[]> {
-  if (platformEnv.isNative) {
+  if (
+    platformEnv.isNative &&
+    !platformEnv.isJest &&
+    !globalThis.$onekeyAppWebembedApiWebviewInitFailed
+  ) {
     const keys = await appGlobals.$webembedApiProxy.secret.batchGetPublicKeys(
       params,
     );
@@ -571,7 +578,11 @@ export type IMnemonicFromEntropyAsyncParams = {
 async function mnemonicFromEntropyAsync(
   params: IMnemonicFromEntropyAsyncParams,
 ): Promise<string> {
-  if (platformEnv.isNative) {
+  if (
+    platformEnv.isNative &&
+    !platformEnv.isJest &&
+    !globalThis.$onekeyAppWebembedApiWebviewInitFailed
+  ) {
     return appGlobals.$webembedApiProxy.secret.mnemonicFromEntropyAsync(params);
   }
   return Promise.resolve(
@@ -586,7 +597,11 @@ export type IMnemonicToSeedAsyncParams = {
 async function mnemonicToSeedAsync(
   params: IMnemonicToSeedAsyncParams,
 ): Promise<Buffer> {
-  if (platformEnv.isNative) {
+  if (
+    platformEnv.isNative &&
+    !platformEnv.isJest &&
+    !globalThis.$onekeyAppWebembedApiWebviewInitFailed
+  ) {
     const hex = await appGlobals.$webembedApiProxy.secret.mnemonicToSeedAsync(
       params,
     );
@@ -609,7 +624,11 @@ export type IGenerateRootFingerprintHexAsyncParams = {
 async function generateRootFingerprintHexAsync(
   params: IGenerateRootFingerprintHexAsyncParams,
 ): Promise<string> {
-  if (platformEnv.isNative) {
+  if (
+    platformEnv.isNative &&
+    !platformEnv.isJest &&
+    !globalThis.$onekeyAppWebembedApiWebviewInitFailed
+  ) {
     return appGlobals.$webembedApiProxy.secret.generateRootFingerprintHexAsync(
       params,
     );

--- a/packages/core/src/secret/ton-mnemonic.ts
+++ b/packages/core/src/secret/ton-mnemonic.ts
@@ -35,7 +35,11 @@ function tonRevealEntropyToMnemonic(
 }
 
 async function tonValidateMnemonic(mnemonicArray: string[]): Promise<boolean> {
-  if (platformEnv.isNative) {
+  if (
+    platformEnv.isNative &&
+    !platformEnv.isJest &&
+    !globalThis.$onekeyAppWebembedApiWebviewInitFailed
+  ) {
     return appGlobals.$webembedApiProxy.secret.tonValidateMnemonic(
       mnemonicArray,
     );
@@ -46,7 +50,11 @@ async function tonValidateMnemonic(mnemonicArray: string[]): Promise<boolean> {
 async function tonMnemonicToKeyPair(
   mnemonicArray: string[],
 ): Promise<ReturnType<typeof tonMnemonicToKeyPairFn>> {
-  if (platformEnv.isNative) {
+  if (
+    platformEnv.isNative &&
+    !platformEnv.isJest &&
+    !globalThis.$onekeyAppWebembedApiWebviewInitFailed
+  ) {
     return appGlobals.$webembedApiProxy.secret.tonMnemonicToKeyPair(
       mnemonicArray,
     );

--- a/packages/kit-bg/src/endpoints/index.ts
+++ b/packages/kit-bg/src/endpoints/index.ts
@@ -3,6 +3,7 @@ import { filter, forEach } from 'lodash';
 import { getEndpointsMapByDevSettings } from '@onekeyhq/shared/src/config/endpointsMap';
 import { OneKeyError } from '@onekeyhq/shared/src/errors';
 import errorUtils from '@onekeyhq/shared/src/errors/utils/errorUtils';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type {
   EServiceEndpointEnum,
   IEndpointDomainWhiteList,
@@ -12,6 +13,16 @@ import type {
 import { devSettingsPersistAtom } from '../states/jotai/atoms';
 
 export async function getEndpoints() {
+  if (platformEnv.isWebEmbed) {
+    const enableTestEndpoint =
+      globalThis?.WEB_EMBED_ONEKEY_APP_SETTINGS?.enableTestEndpoint ?? false;
+    return getEndpointsMapByDevSettings({
+      enabled: enableTestEndpoint,
+      settings: {
+        enableTestEndpoint,
+      },
+    });
+  }
   const settings = await devSettingsPersistAtom.get();
   return getEndpointsMapByDevSettings(settings);
 }

--- a/packages/kit-bg/src/providers/ProviderApiPrivate.ts
+++ b/packages/kit-bg/src/providers/ProviderApiPrivate.ts
@@ -15,6 +15,7 @@ import {
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { generateUUID } from '@onekeyhq/shared/src/utils/miscUtils';
 import { waitForDataLoaded } from '@onekeyhq/shared/src/utils/promiseUtils';
@@ -476,6 +477,7 @@ class ProviderApiPrivate extends ProviderApiBase {
 
   @providerApiMethod()
   async getSensitiveEncodeKey(): Promise<string> {
+    defaultLogger.app.webembed.getSensitiveEncodeKey();
     return getBgSensitiveTextEncodeKey();
   }
 
@@ -483,6 +485,7 @@ class ProviderApiPrivate extends ProviderApiBase {
 
   @providerApiMethod()
   async webEmbedApiReady(): Promise<void> {
+    defaultLogger.app.webembed.webembedApiReady();
     this.isWebEmbedApiReady = true;
     appEventBus.emit(EAppEventBusNames.LoadWebEmbedWebViewComplete, undefined);
     return Promise.resolve();

--- a/packages/kit-bg/src/services/ServicePassword/biologyAuthUtils.ts
+++ b/packages/kit-bg/src/services/ServicePassword/biologyAuthUtils.ts
@@ -34,7 +34,11 @@ class BiologyAuthUtils implements IBiologyAuth {
     await secureStorageInstance.setSecureItem('password', text);
   };
 
-  getPassword = async () => {
+  getPassword = async ({
+    useRnJsCrypto,
+  }: {
+    useRnJsCrypto?: boolean;
+  } = {}) => {
     if (!secureStorageInstance.supportSecureStorage()) {
       throw new Error('No password');
     }
@@ -44,8 +48,9 @@ class BiologyAuthUtils implements IBiologyAuth {
       text = await decodeSensitiveTextAsync({
         encodedText: text,
         key: `${encodeKeyPrefix}${settings.sensitiveEncodeKey}`,
+        useRnJsCrypto,
       });
-      text = await encodeSensitiveTextAsync({ text });
+      text = await encodeSensitiveTextAsync({ text, useRnJsCrypto });
       return text;
     }
     throw new Error('No password');
@@ -57,4 +62,4 @@ class BiologyAuthUtils implements IBiologyAuth {
   };
 }
 const biologyAuthUtils = new BiologyAuthUtils();
-export { biologyAuthUtils, biologyAuthNativeError };
+export { biologyAuthNativeError, biologyAuthUtils };

--- a/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
@@ -21,6 +21,7 @@ export interface IDevSettings {
   // disable Solana priority fee
   disableSolanaPriorityFee?: boolean;
   disableAllShortcuts?: boolean;
+  disableWebEmbedApi?: boolean; // Do not render webembedApi Webview
   webviewDebuggingEnabled?: boolean;
   allowAddSameHDWallet?: boolean;
   // use trading view test domain

--- a/packages/kit-bg/src/vaults/impls/evm/sdkEvm/BaseApiProvider.ts
+++ b/packages/kit-bg/src/vaults/impls/evm/sdkEvm/BaseApiProvider.ts
@@ -5,7 +5,11 @@ import { md5 } from 'js-md5';
 import { forEach, isEmpty, isNaN, keyBy, omit, orderBy, uniqBy } from 'lodash';
 
 import type { IBackgroundApi } from '@onekeyhq/kit-bg/src/apis/IBackgroundApi';
-import { NotImplemented, OneKeyError } from '@onekeyhq/shared/src/errors';
+import {
+  NotImplemented,
+  OneKeyError,
+  OneKeyPlainTextError,
+} from '@onekeyhq/shared/src/errors';
 import { JsonRPCRequest } from '@onekeyhq/shared/src/request/JsonRPCRequest';
 import type {
   IFetchAccountDetailsResp,
@@ -92,10 +96,10 @@ class BaseApiProvider {
       contractList: [this.nativeTokenAddress],
     });
     if (!token) {
-      throw new Error('getNativeToken failed');
+      throw new OneKeyPlainTextError('getNativeToken failed');
     }
     if (!token?.info?.decimals) {
-      throw new Error('getNativeToken decimals failed');
+      throw new OneKeyPlainTextError('getNativeToken decimals failed');
     }
     return {
       info: {

--- a/packages/kit-bg/src/webembeds/WebEmbedApiTest.ts
+++ b/packages/kit-bg/src/webembeds/WebEmbedApiTest.ts
@@ -1,8 +1,20 @@
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+
 class WebEmbedApiTest {
   test1(...params: string[]) {
     return Promise.resolve(
       `${params.join('---')}: ${globalThis.location.href}`,
     );
+  }
+
+  trackEvent() {
+    defaultLogger.app.page.testWebEmbed();
+  }
+
+  captureException() {
+    setTimeout(() => {
+      throw new Error('test webEmbed error');
+    }, 1000);
   }
 }
 

--- a/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
@@ -214,6 +214,7 @@ const PasswordVerifyContainer = ({
                 password: '',
                 isBiologyAuth: true,
                 passwordMode,
+                useRnJsCrypto: true,
               });
           }
           if (biologyAuthRes) {
@@ -303,11 +304,13 @@ const PasswordVerifyContainer = ({
         const encodePassword =
           await backgroundApiProxy.servicePassword.encodeSensitiveText({
             text: finalPassword,
+            useRnJsCrypto: true,
           });
         const verifiedPassword =
           await backgroundApiProxy.servicePassword.verifyPassword({
             password: encodePassword,
             passwordMode,
+            useRnJsCrypto: true,
           });
         setPasswordAtom((v) => ({
           ...v,
@@ -426,11 +429,11 @@ const PasswordVerifyContainer = ({
         console.error('failed to waitPasswordEncryptorReady with error', e);
         const errorMessage = (e as Error)?.message || '';
         if (errorMessage) {
-          setPasswordEncryptorInitError(errorMessage);
-          Toast.error({
-            title: errorMessage,
-            message: 'Please restart the app and try again later',
-          });
+          // setPasswordEncryptorInitError(errorMessage);
+          // Toast.error({
+          //   title: errorMessage,
+          //   message: 'Please restart the app and try again later',
+          // });
         }
         throw e;
       }
@@ -439,7 +442,7 @@ const PasswordVerifyContainer = ({
 
   const loadingView = useMemo(() => {
     return passwordEncryptorInitError ? (
-      <SizableText size="$bodyMd" color="$textSubdued" textAlign="center">
+      <SizableText size="$bodyMd" color="$textCritical" textAlign="center">
         {passwordEncryptorInitError}
       </SizableText>
     ) : (
@@ -449,28 +452,32 @@ const PasswordVerifyContainer = ({
 
   return (
     <Stack onLayout={onLayout}>
-      {isPasswordEncryptorReady ? (
-        <PasswordVerify
-          passwordMode={passwordMode}
-          alertText={alertText}
-          disableInput={isProtectionTime}
-          onPasswordChange={() => {
-            setPasswordAtom((v) => ({
-              ...v,
-              passwordVerifyStatus: { value: EPasswordVerifyStatus.DEFAULT },
-            }));
-          }}
-          status={passwordVerifyStatus}
-          onBiologyAuth={() =>
-            onBiologyAuthenticate(isExtLockAndNoCachePassword)
-          }
-          onInputPasswordAuth={onInputPasswordAuthenticate}
-          isEnable={isBiologyAuthEnable}
-          authType={isEnable ? authType : [AuthenticationType.FINGERPRINT]}
-        />
-      ) : (
-        loadingView
-      )}
+      <PasswordVerify
+        passwordMode={passwordMode}
+        alertText={alertText}
+        disableInput={isProtectionTime}
+        onPasswordChange={() => {
+          setPasswordAtom((v) => ({
+            ...v,
+            passwordVerifyStatus: { value: EPasswordVerifyStatus.DEFAULT },
+          }));
+        }}
+        status={passwordVerifyStatus}
+        onBiologyAuth={() => onBiologyAuthenticate(isExtLockAndNoCachePassword)}
+        onInputPasswordAuth={onInputPasswordAuthenticate}
+        isEnable={isBiologyAuthEnable}
+        authType={isEnable ? authType : [AuthenticationType.FINGERPRINT]}
+      />
+      {passwordEncryptorInitError ? (
+        <SizableText
+          size="$bodyMd"
+          color="$textCritical"
+          textAlign="center"
+          mt="$2"
+        >
+          {passwordEncryptorInitError}
+        </SizableText>
+      ) : null}
     </Stack>
   );
 };

--- a/packages/kit/src/components/WebView/InpageProviderWebView.native.tsx
+++ b/packages/kit/src/components/WebView/InpageProviderWebView.native.tsx
@@ -36,6 +36,8 @@ const injectedJavaScript = `
   updateMedate();
 `;
 
+const defaultOnMessage = (event: any) => {};
+
 const InpageProviderWebView: FC<IInpageProviderWebViewProps> = forwardRef(
   (
     {
@@ -58,6 +60,7 @@ const InpageProviderWebView: FC<IInpageProviderWebViewProps> = forwardRef(
       onProgress,
       webviewDebuggingEnabled,
       siteMode,
+      onMessage,
     }: IInpageProviderWebViewProps,
     ref: any,
   ) => {
@@ -185,7 +188,7 @@ const InpageProviderWebView: FC<IInpageProviderWebViewProps> = forwardRef(
           originWhitelist={['*']}
           userAgent={isDesktopMode ? desktopUserAgent : undefined}
           // https://github.com/react-native-webview/react-native-webview/issues/1779
-          onMessage={(event) => {}}
+          onMessage={onMessage || defaultOnMessage}
           {...nativeWebviewProps}
         />
       </Stack>

--- a/packages/kit/src/components/WebView/index.tsx
+++ b/packages/kit/src/components/WebView/index.tsx
@@ -12,6 +12,7 @@ import type { IElectronWebViewEvents, IWebViewOnScroll } from './types';
 import type { ESiteMode } from '../../views/Discovery/types';
 import type { IJsBridgeReceiveHandler } from '@onekeyfe/cross-inpage-provider-types';
 import type { IWebViewWrapperRef } from '@onekeyfe/onekey-cross-webview';
+import type { WebViewProps as RNWebViewProps } from 'react-native-webview';
 import type {
   WebViewErrorEvent,
   WebViewNavigation,
@@ -48,6 +49,16 @@ interface IWebViewProps extends IElectronWebViewEvents {
    * @description Open website in desktop mode or mobile mode
    */
   siteMode?: ESiteMode;
+  /** @platform native
+   * @description List of origin strings to allow being navigated to.
+   * The strings allow wildcards and follow the same rules as the navigator.
+   * For example, ['https://*.onekey.so', 'https://*.onekey.com'] will allow any URL from these domains.
+   */
+  originWhitelist?: string[];
+  /** @platform native
+   * @description A function that is invoked when the webview calls `window.ReactNativeWebView.postMessage`. Setting this property will inject this global into your webview.
+   */
+  onMessage?: RNWebViewProps['onMessage'];
 }
 
 const WebView: FC<IWebViewProps> = ({

--- a/packages/kit/src/components/WebView/types.ts
+++ b/packages/kit/src/components/WebView/types.ts
@@ -7,6 +7,7 @@ import type {
 } from './DesktopWebView';
 import type { ESiteMode } from '../../views/Discovery/types';
 import type { InpageProviderWebViewProps as InpageWebViewProps } from '@onekeyfe/cross-inpage-provider-types';
+import type { WebViewMessageEvent } from 'react-native-webview';
 import type {
   WebViewErrorEvent,
   WebViewNavigationEvent,
@@ -54,6 +55,10 @@ export interface IInpageProviderWebViewProps
    * @description Open website in desktop mode or mobile mode
    */
   siteMode?: ESiteMode;
+  /** @platform native
+   * @description A function that is invoked when the webview calls `window.ReactNativeWebView.postMessage`. Setting this property will inject this global into your webview.
+   */
+  onMessage?: (event: WebViewMessageEvent) => void;
 }
 
 export type IElectronWebView = {

--- a/packages/kit/src/components/WebViewWebEmbed/index.tsx
+++ b/packages/kit/src/components/WebViewWebEmbed/index.tsx
@@ -3,11 +3,16 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { SizableText, Stack, View, XStack } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src//background/instance/backgroundApiProxy';
 import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
+import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/settings';
+import { analytics } from '@onekeyhq/shared/src/analytics';
 import {
   REVENUECAT_API_KEY_WEB,
   REVENUECAT_API_KEY_WEB_SANDBOX,
 } from '@onekeyhq/shared/src/consts/primeConsts';
 import { EWebEmbedRoutePath } from '@onekeyhq/shared/src/consts/webEmbedConsts';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import { captureException } from '@onekeyhq/shared/src/modules3rdParty/sentry';
+import { EWebEmbedPostMessageType } from '@onekeyhq/shared/src/modules3rdParty/webEmebd/postMessage';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import webEmbedConfig from '@onekeyhq/shared/src/storage/webEmbedConfig';
 import uriUtils from '@onekeyhq/shared/src/utils/uriUtils';
@@ -20,6 +25,7 @@ import WebView from '../WebView';
 import type { JsBridgeBase } from '@onekeyfe/cross-inpage-provider-core';
 import type { IJsBridgeReceiveHandler } from '@onekeyfe/cross-inpage-provider-types';
 import type { IWebViewWrapperRef } from '@onekeyfe/onekey-cross-webview';
+import type { WebViewMessageEvent } from 'react-native-webview';
 
 const initTop = '15%';
 // /onboarding/auto_typing
@@ -34,6 +40,8 @@ export function WebViewWebEmbed({
   hashRoutePath?: EWebEmbedRoutePath;
   hashRouteQueryParams?: Record<string, string>;
 }) {
+  const [{ instanceId }] = useSettingsPersistAtom();
+
   const webviewRef = useRef<IWebViewWrapperRef | null>(null);
   const onWebViewRef = useCallback(($ref: IWebViewWrapperRef | null) => {
     webviewRef.current = $ref;
@@ -70,11 +78,27 @@ export function WebViewWebEmbed({
       return undefined;
     }
     return {
+      isDev: platformEnv.isDev ?? false,
+      enableTestEndpoint:
+        (devSettingsPersistAtom.enabled &&
+          devSettingsPersistAtom.settings?.enableTestEndpoint) ??
+        false,
+      instanceId,
+      platform: platformEnv.symbol ?? '',
+      appBuildNumber: platformEnv.buildNumber ?? '',
+      appVersion: platformEnv.version ?? '',
       themeVariant,
       localeVariant,
       revenuecatApiKey,
     };
-  }, [themeVariant, localeVariant, revenuecatApiKey]);
+  }, [
+    themeVariant,
+    localeVariant,
+    revenuecatApiKey,
+    devSettingsPersistAtom.enabled,
+    devSettingsPersistAtom.settings?.enableTestEndpoint,
+    instanceId,
+  ]);
 
   const remoteUrl = useMemo(() => {
     if (
@@ -107,6 +131,42 @@ export function WebViewWebEmbed({
     return undefined;
   }, [remoteUrl]);
 
+  // Handle messages from WebView - only works in native environments
+  const handleMessage = useCallback((event?: WebViewMessageEvent) => {
+    if (event?.nativeEvent.data) {
+      const data = JSON.parse(event.nativeEvent.data) as {
+        type: string;
+        data: any;
+      };
+      switch (data.type) {
+        case EWebEmbedPostMessageType.TrackEvent:
+          {
+            const { eventName, eventProps } = data.data as {
+              eventName: string;
+              eventProps: Record<string, any>;
+            };
+            analytics.trackEvent(eventName, eventProps);
+          }
+
+          break;
+        case EWebEmbedPostMessageType.CaptureException: {
+          const { error, stackTrace } = data.data as {
+            error: string;
+            stackTrace: Record<string, string>;
+          };
+          if (error) {
+            const errorObj = new Error(error);
+            errorObj.stack = JSON.stringify(stackTrace);
+            captureException(errorObj);
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    }
+  }, []);
+
   const webview = useMemo(() => {
     if (!webEmbedAppSettings) {
       return null;
@@ -116,6 +176,20 @@ export function WebViewWebEmbed({
       query: hashRouteQueryParams,
     });
     console.log('WebViewWebEmbed fullHash', hashRoutePath, fullHash);
+
+    if (
+      devSettingsPersistAtom.enabled &&
+      devSettingsPersistAtom.settings?.disableWebEmbedApi
+    ) {
+      return (
+        <SizableText>
+          WebEmbedApi is disabled, please enable it in dev settings
+        </SizableText>
+      );
+    }
+
+    defaultLogger.app.webembed.renderWebview();
+
     return (
       <WebView
         // *** use remote url
@@ -124,18 +198,30 @@ export function WebViewWebEmbed({
         nativeWebviewSource={nativeWebviewSource}
         onWebViewRef={onWebViewRef}
         customReceiveHandler={customReceiveHandler}
+        onMessage={handleMessage}
         nativeInjectedJavaScriptBeforeContentLoaded={`
             window.location.hash = "${fullHash}";
             window.WEB_EMBED_ONEKEY_APP_SETTINGS = {
+              isDev: "${String(webEmbedAppSettings.isDev)}",
+              enableTestEndpoint: "${String(
+                webEmbedAppSettings.enableTestEndpoint,
+              )}",
               themeVariant: "${webEmbedAppSettings?.themeVariant}",
               localeVariant: "${webEmbedAppSettings?.localeVariant}",
-              revenuecatApiKey: "${webEmbedAppSettings?.revenuecatApiKey}"
+              revenuecatApiKey: "${webEmbedAppSettings?.revenuecatApiKey}",
+              instanceId: "${webEmbedAppSettings?.instanceId}",
+              platform: "${webEmbedAppSettings?.platform}",
+              appBuildNumber: "${webEmbedAppSettings?.appBuildNumber}",
+              appVersion: "${webEmbedAppSettings?.appVersion}",
             };
           `}
       />
     );
   }, [
     customReceiveHandler,
+    devSettingsPersistAtom.enabled,
+    devSettingsPersistAtom.settings?.disableWebEmbedApi,
+    handleMessage,
     hashRoutePath,
     hashRouteQueryParams,
     nativeWebviewSource,
@@ -176,7 +262,7 @@ export function WebViewWebEmbed({
       if (minimized) {
         return { width: '$8', height: '$6', borderWidth: 4 };
       }
-      return { width: '90%', height: '$40', borderWidth: 4 };
+      return { width: '90%', height: '$60', borderWidth: 4 };
     }
     return { width: 0, height: 0, borderWidth: 0 };
   }, [config?.debug, minimized]);
@@ -226,6 +312,8 @@ export function WebViewWebEmbed({
 }
 
 function WebViewWebEmbedSingletonView() {
+  console.log('WebViewWebEmbedSingletonView render');
+  defaultLogger.app.webembed.renderWebviewSingleton();
   return (
     <WebViewWebEmbed
       isSingleton

--- a/packages/kit/src/provider/WebViewWebEmbedProvider.tsx
+++ b/packages/kit/src/provider/WebViewWebEmbedProvider.tsx
@@ -9,12 +9,18 @@ import { WebViewWebEmbedSingleton } from '../components/WebViewWebEmbed';
 
 function BasicWebViewWebEmbedProvider() {
   const [isShow, setIsShow] = useState(false);
+  const [ts, setTs] = useState(0);
   useEffect(() => {
-    appEventBus.on(EAppEventBusNames.LoadWebEmbedWebView, () => {
+    const fn = () => {
       setIsShow(true);
-    });
+      setTs(Date.now());
+    };
+    appEventBus.on(EAppEventBusNames.LoadWebEmbedWebView, fn);
+    return () => {
+      appEventBus.off(EAppEventBusNames.LoadWebEmbedWebView, fn);
+    };
   }, []);
-  return isShow ? <WebViewWebEmbedSingleton /> : null;
+  return isShow ? <WebViewWebEmbedSingleton key={ts} /> : null;
 }
 
 export const WebViewWebEmbedProvider = memo(BasicWebViewWebEmbedProvider);

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/WebEmbed.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/WebEmbed.tsx
@@ -72,6 +72,20 @@ export function WebEmbedDevConfig() {
       >
         Test RPC
       </Button>
+      <Button
+        onPress={() => {
+          void webembedApiProxy.test.trackEvent();
+        }}
+      >
+        Test Tracking Event
+      </Button>
+      <Button
+        onPress={() => {
+          void webembedApiProxy.test.captureException();
+        }}
+      >
+        Test Capture Exception
+      </Button>
     </YStack>
   );
 }

--- a/packages/kit/src/views/Developer/pages/Gallery/index.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/index.tsx
@@ -534,6 +534,20 @@ const StepperGallery = LazyLoadPage(
     ),
 );
 
+const ThemeColorsGallery = LazyLoadPage(
+  () =>
+    import(
+      '@onekeyhq/kit/src/views/Developer/pages/Gallery/Components/stories/ThemeColors'
+    ),
+);
+
+const CountDownCalendarAlertGallery = LazyLoadPage(
+  () =>
+    import(
+      '@onekeyhq/kit/src/views/Developer/pages/Gallery/Components/stories/CountDownCalendarAlert'
+    ),
+);
+
 export const galleryScreenList: {
   name: EGalleryRoutes;
   component: ComponentType;
@@ -777,6 +791,14 @@ export const galleryScreenList: {
   {
     name: EGalleryRoutes.ComponentStepper,
     component: StepperGallery,
+  },
+  {
+    name: EGalleryRoutes.CountDownCalendarAlert,
+    component: CountDownCalendarAlertGallery,
+  },
+  {
+    name: EGalleryRoutes.ComponentThemeColors,
+    component: ThemeColorsGallery,
   },
   { name: EGalleryRoutes.ComponentAnchor, component: AnchorGallery },
 ];

--- a/packages/kit/src/views/Setting/pages/List/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/List/DevSettingsSection/index.tsx
@@ -284,6 +284,13 @@ export const DevSettingsSection = () => {
         <Switch size={ESwitchSize.small} />
       </SectionFieldItem>
       <SectionFieldItem
+        name="disableWebEmbedApi"
+        title="禁止 WebEmbedApi"
+        subtitle="禁止 WebEmbedApi 渲染内置 Webview 网页"
+      >
+        <Switch size={ESwitchSize.small} />
+      </SectionFieldItem>
+      <SectionFieldItem
         name="showDevOverlayWindow"
         title="开发者悬浮窗"
         subtitle="始终悬浮于全局的开发调试工具栏"

--- a/packages/shared/src/analytics/index.ts
+++ b/packages/shared/src/analytics/index.ts
@@ -1,5 +1,10 @@
 import Axios from 'axios';
 
+import {
+  EWebEmbedPostMessageType,
+  postMessage,
+} from '@onekeyhq/shared/src/modules3rdParty/webEmebd/postMessage';
+
 import appGlobals from '../appGlobals';
 import platformEnv from '../platformEnv';
 import { headerPlatform } from '../request/InterceptorConsts';
@@ -63,7 +68,17 @@ export class Analytics {
       this.basicInfo.pageName = eventProps.pageName;
     }
     if (this.instanceId && this.baseURL) {
-      void this.requestEvent(eventName, eventProps);
+      if (platformEnv.isWebEmbed) {
+        postMessage({
+          type: EWebEmbedPostMessageType.TrackEvent,
+          data: {
+            eventName,
+            eventProps,
+          },
+        });
+      } else {
+        void this.requestEvent(eventName, eventProps);
+      }
     } else {
       this.cacheEvents.push([eventName, eventProps]);
     }
@@ -84,13 +99,14 @@ export class Analytics {
     eventName: string,
     eventProps?: Record<string, any>,
   ) {
-    // if (platformEnv.isDev || platformEnv.isE2E) {
-    //   return;
-    // }
+    if (platformEnv.isDev || platformEnv.isE2E) {
+      return;
+    }
+    const deviceInfo = await this.lazyDeviceInfo();
     const event = {
+      ...deviceInfo,
       ...eventProps,
       distinct_id: this.instanceId,
-      ...(await this.lazyDeviceInfo()),
     } as Record<string, string>;
     if (
       !platformEnv.isNative &&

--- a/packages/shared/src/config/endpointsMap.ts
+++ b/packages/shared/src/config/endpointsMap.ts
@@ -89,9 +89,12 @@ export const endpointsMap: Record<IEndpointEnv, IServiceEndpoint> = {
   },
 };
 
-export const getEndpointsMapByDevSettings = (
-  devSettings: IDevSettingsPersistAtom,
-) => {
+export const getEndpointsMapByDevSettings = (devSettings: {
+  enabled: boolean;
+  settings?: {
+    enableTestEndpoint?: boolean;
+  };
+}) => {
   if (devSettings.enabled && devSettings.settings?.enableTestEndpoint) {
     return endpointsMap.test;
   }

--- a/packages/shared/src/logger/base/logFn.ts
+++ b/packages/shared/src/logger/base/logFn.ts
@@ -65,7 +65,7 @@ export const logFn = ({
 
     switch (metadata.type) {
       case 'local':
-        {
+        if (!platformEnv.isWebEmbed) {
           // const extensionName = `${scopeName} -> ${sceneName}`;
           // const logger = getLoggerExtension(extensionName);
           // msg including extensionName, don't need to create a new logger extension

--- a/packages/shared/src/logger/scopes/app/index.ts
+++ b/packages/shared/src/logger/scopes/app/index.ts
@@ -10,6 +10,7 @@ import { InstallScene } from './scenes/install';
 import { NetworkScene } from './scenes/network';
 import { PageScene } from './scenes/page';
 import { AppPerfScene } from './scenes/perf';
+import { WebembedScene } from './scenes/webembed';
 
 export class AppScope extends BaseScope {
   protected override scopeName = EScopeName.app;
@@ -31,4 +32,6 @@ export class AppScope extends BaseScope {
   perf = this.createScene('perf', AppPerfScene);
 
   error = this.createScene('error', ErrorScene);
+
+  webembed = this.createScene('webembed', WebembedScene);
 }

--- a/packages/shared/src/logger/scopes/app/scenes/page.ts
+++ b/packages/shared/src/logger/scopes/app/scenes/page.ts
@@ -24,4 +24,16 @@ export class PageScene extends BaseScene {
   @LogToServer()
   @LogToLocal()
   public navigationToggle() {}
+
+  @LogToServer()
+  @LogToLocal()
+  public tabBarClick(tabName: string) {
+    return { tabName };
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  public testWebEmbed() {
+    return { test: 'test' };
+  }
 }

--- a/packages/shared/src/logger/scopes/app/scenes/webembed.ts
+++ b/packages/shared/src/logger/scopes/app/scenes/webembed.ts
@@ -1,0 +1,82 @@
+import { BaseScene } from '../../../base/baseScene';
+import { LogToLocal, LogToServer } from '../../../base/decorators';
+
+export class WebembedScene extends BaseScene {
+  @LogToServer()
+  @LogToLocal()
+  public initTimeout() {
+    return true;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  public emitRenderEvent() {
+    return true;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  public renderWebview() {
+    return true;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  public renderWebviewSingleton() {
+    return true;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  public webembedApiReady() {
+    return true;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  public loadWebEmbedWebViewComplete() {
+    return true;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  public getSensitiveEncodeKey() {
+    return true;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  public renderHtmlRoot() {
+    return true;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  public renderHtmlWebembedPage() {
+    return true;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  public callPageInit() {
+    return true;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  public callPageGetEncodeKey() {
+    return true;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  public callPageGetEncodeKeySuccess() {
+    return true;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  public callPageApiReady() {
+    return true;
+  }
+}

--- a/packages/shared/src/modules3rdParty/sentry/basicOptions.ts
+++ b/packages/shared/src/modules3rdParty/sentry/basicOptions.ts
@@ -4,6 +4,7 @@ import {
 } from '@sentry/react-native';
 import wordLists from 'bip39/src/wordlists/english.json';
 
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { memoizee } from '@onekeyhq/shared/src/utils/cacheUtils';
 
 import { EOneKeyErrorClassNames } from '../../errors/types/errorTypes';
@@ -113,6 +114,11 @@ export const buildBasicOptions = ({
               const newErrorText = textSlices.join(' ');
               // Save error message locally
               onError(newErrorText, event.exception?.values[index].stacktrace);
+
+              // In webEmbed environment, network requests cannot be sent, so abort subsequent operations
+              if (platformEnv.isWebEmbed) {
+                return;
+              }
               if (isFilterErrorAndSkipSentry(event.exception.values[index])) {
                 return null;
               }

--- a/packages/shared/src/modules3rdParty/sentry/index.ts
+++ b/packages/shared/src/modules3rdParty/sentry/index.ts
@@ -3,6 +3,11 @@ import type { ComponentType } from 'react';
 import * as Sentry from '@sentry/react';
 
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import {
+  EWebEmbedPostMessageType,
+  postMessage,
+} from '@onekeyhq/shared/src/modules3rdParty/webEmebd/postMessage';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import {
   buildBasicOptions,
@@ -25,6 +30,15 @@ export const initSentry = () => {
     ...buildBasicOptions({
       onError: (errorMessage, stacktrace) => {
         defaultLogger.app.error.log(errorMessage, stacktrace);
+        if (platformEnv.isWebEmbed) {
+          postMessage({
+            type: EWebEmbedPostMessageType.CaptureException,
+            data: {
+              error: errorMessage,
+              stacktrace,
+            },
+          });
+        }
       },
     }),
     ...buildSentryOptions(Sentry),

--- a/packages/shared/src/modules3rdParty/webEmebd/postMessage.ts
+++ b/packages/shared/src/modules3rdParty/webEmebd/postMessage.ts
@@ -1,0 +1,14 @@
+export enum EWebEmbedPostMessageType {
+  TrackEvent = 'trackEvent',
+  CaptureException = 'captureException',
+}
+
+export const postMessage = (data: any) => {
+  if (typeof globalThis !== 'undefined' && 'ReactNativeWebView' in globalThis) {
+    (
+      globalThis.ReactNativeWebView as {
+        postMessage: (message: string) => void;
+      }
+    )?.postMessage(JSON.stringify(data));
+  }
+};

--- a/packages/shared/src/request/Interceptor.ts
+++ b/packages/shared/src/request/Interceptor.ts
@@ -10,7 +10,6 @@ import { generateUUID } from '@onekeyhq/shared/src/utils/miscUtils';
 
 import { defaultColorScheme } from '../config/appConfig';
 
-import { checkIsOneKeyDomain } from './checkIsOneKeyDomain';
 import { headerPlatform } from './InterceptorConsts';
 import requestHelper from './requestHelper';
 

--- a/packages/shared/src/request/fetchInterceptor.ts
+++ b/packages/shared/src/request/fetchInterceptor.ts
@@ -2,7 +2,6 @@ import { forEach, isNil, isString } from 'lodash';
 
 import { defaultLogger } from '../logger/logger';
 import { isEnableLogNetwork } from '../logger/scopes/app/scenes/network';
-import platformEnv from '../platformEnv';
 
 import { HEADER_REQUEST_ID_KEY, getRequestHeaders } from './Interceptor';
 import requestHelper from './requestHelper';
@@ -117,7 +116,6 @@ const newFetch = async function (
 };
 console.log('fetchInterceptor.ts', fetch);
 if (
-  !platformEnv.isWebEmbed &&
   globalThis.fetch &&
   // @ts-ignore
   !globalThis.fetch.isNormalizedByOneKey

--- a/packages/shared/src/web/index.html.ejs
+++ b/packages/shared/src/web/index.html.ejs
@@ -45,6 +45,13 @@
             <%= htmlHeadPreloadCode %>
           </script>
       <% } %>
+      <% if ( platform == 'webEmbed' ) { %> 
+        <script>
+          if (typeof globalThis === 'undefined') {
+              var globalThis = window;
+          }
+        </script>
+      <% } %>
   </head>
 
   <!-- html template copy from node_modules/@expo/webpack-config/web-default/index.html -->
@@ -113,6 +120,15 @@
         webEmbed index.html 
       <% } %>
     </div>
+
+    <script>
+      (()=>{
+        const rootElement = document.getElementById('root');
+        if (rootElement) {
+          rootElement.setAttribute('data-html-render-time', Date.now().toString());
+        }
+      })();
+    </script>
 
     <% if ( platform !== 'webEmbed' ) { %>
       <img

--- a/yarn.lock
+++ b/yarn.lock
@@ -1443,6 +1443,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-numeric-separator@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-numeric-separator@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/0528ef041ed88e8c3f51624ee87b8182a7f246fe4013f0572788e0727d20795b558f2b82e3989b5dd416cbd339500f0d88857de41b6d3b6fdacb1d5344bcc5b1
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-object-assign@npm:^7.16.7":
   version: 7.23.3
   resolution: "@babel/plugin-transform-object-assign@npm:7.23.3"
@@ -6864,6 +6875,7 @@ __metadata:
     "@babel/plugin-proposal-export-namespace-from": "npm:^7.18.9"
     "@babel/plugin-proposal-private-methods": "npm:^7.18.6"
     "@babel/plugin-proposal-private-property-in-object": "npm:^7.21.11"
+    "@babel/plugin-transform-numeric-separator": "npm:^7.25.9"
     "@babel/plugin-transform-optional-chaining": "npm:^7.25.9"
     "@babel/preset-env": "npm:^7.22.9"
     "@benfen/bfc.js": "npm:0.2.7"


### PR DESCRIPTION
* feat: support  tracking event in web-embed page (#7199)

# Conflicts:
#	packages/shared/src/analytics/index.ts

* chore: track event  & error on webEmebed pages (#7210)

# Conflicts:
#	packages/kit/src/views/Developer/pages/Gallery/index.tsx #	packages/shared/src/logger/scopes/app/scenes/page.ts

* fix: webembed render OK-37753 (#7212)

* fix: webembed api timeout

* feat: add useRnJsCrypto option to password service methods

- Updated various methods in ServicePassword, BiologyAuthUtils, and LocalDbBase to support an optional useRnJsCrypto parameter for enhanced cryptographic operations.
- Adjusted related components to ensure compatibility with the new parameter.

* feat: enhance webembed API and logging

- Introduced a new variable $onekeyAppWebembedApiWebviewInitFailed to track webembed API initialization status.
- Updated ServicePassword and webembedApiProxy to utilize the new variable for improved error handling.
- Added logging capabilities for webembed-related events to enhance debugging and monitoring.
- Implemented a toggle in DevSettings to enable/disable the webembed API rendering.
- Adjusted PasswordVerifyContainer to improve error display logic.

* fix: add defaultLogger import in ProviderApiPrivate

- Added import for defaultLogger from the shared logger module to enhance logging capabilities in ProviderApiPrivate.
- Removed duplicate import statement for defaultLogger to clean up the code.

---------