### PR TITLE
fix: prevent modal from blocking Android back button on Discovery page 

### DIFF
--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -70,9 +70,12 @@ const useAndroidHardwareBack = platformEnv.isNativeAndroid
       handleGoBackHome: () => Promise<void> | void;
     }) => {
       const isDiscoveryTabFocused = useRef(true);
-      useListenTabFocusState(ETabRoutes.Discovery, (isFocus: boolean) => {
-        isDiscoveryTabFocused.current = isFocus;
-      });
+      useListenTabFocusState(
+        ETabRoutes.Discovery,
+        (isFocus: boolean, isHideByModal: boolean) => {
+          isDiscoveryTabFocused.current = isFocus && !isHideByModal;
+        },
+      );
 
       useEffect(() => {
         // Only add back handler on Android

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -14,6 +14,7 @@ import {
 } from '@onekeyhq/components';
 import type { IPageNavigationProp } from '@onekeyhq/components/src/layouts/Navigation';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import useListenTabFocusState from '@onekeyhq/kit/src/hooks/useListenTabFocusState';
 import { useBrowserTabActions } from '@onekeyhq/kit/src/states/jotai/contexts/discovery';
 import { useTakeScreenshot } from '@onekeyhq/kit/src/views/Discovery/components/MobileBrowser/MobileBrowserBottomBar';
 import {
@@ -55,6 +56,62 @@ import { withBrowserProvider } from './WithBrowserProvider';
 import type { WebView } from 'react-native-webview';
 
 const isNativeMobile = platformEnv.isNative && !platformEnv.isNativeIOSPad;
+
+const useAndroidHardwareBack = platformEnv.isNativeAndroid
+  ? ({
+      displayHomePage,
+      activeTabData,
+      activeTabId,
+      handleGoBackHome,
+    }: {
+      displayHomePage: boolean;
+      activeTabData: { canGoBack?: boolean } | undefined;
+      activeTabId: string | undefined | null;
+      handleGoBackHome: () => Promise<void> | void;
+    }) => {
+      const isDiscoveryTabFocused = useRef(true);
+      useListenTabFocusState(ETabRoutes.Discovery, (isFocus: boolean) => {
+        isDiscoveryTabFocused.current = isFocus;
+      });
+
+      useEffect(() => {
+        // Only add back handler on Android
+        if (!platformEnv.isNativeAndroid) {
+          return;
+        }
+
+        const onBackPress = () => {
+          if (!isDiscoveryTabFocused.current) {
+            return false;
+          }
+          if (!displayHomePage && activeTabData?.canGoBack && activeTabId) {
+            const webviewRef = webviewRefs[activeTabId];
+            if (webviewRef?.innerRef) {
+              try {
+                (webviewRef.innerRef as WebView)?.goBack();
+              } catch (error) {
+                console.error('Error while navigating back:', error);
+              }
+            }
+          } else {
+            void handleGoBackHome();
+          }
+
+          // Prevent default behavior
+          return true;
+        };
+
+        BackHandler.addEventListener('hardwareBackPress', onBackPress);
+        return () =>
+          BackHandler.removeEventListener('hardwareBackPress', onBackPress);
+      }, [
+        activeTabId,
+        activeTabData?.canGoBack,
+        displayHomePage,
+        handleGoBackHome,
+      ]);
+    }
+  : () => {};
 
 function MobileBrowser() {
   const { tabs } = useWebTabs();
@@ -165,37 +222,12 @@ function MobileBrowser() {
     });
   }, [takeScreenshot, setCurrentWebTab, navigation]);
 
-  useEffect(() => {
-    // Only add back handler on Android
-    if (!platformEnv.isNativeAndroid) return;
-
-    const onBackPress = () => {
-      if (!displayHomePage && activeTabData?.canGoBack && activeTabId) {
-        const webviewRef = webviewRefs[activeTabId];
-        if (webviewRef?.innerRef) {
-          try {
-            (webviewRef.innerRef as WebView)?.goBack();
-          } catch (error) {
-            console.error('Error while navigating back:', error);
-          }
-        }
-      } else {
-        void handleGoBackHome();
-      }
-
-      // Prevent default behavior
-      return true;
-    };
-
-    BackHandler.addEventListener('hardwareBackPress', onBackPress);
-    return () =>
-      BackHandler.removeEventListener('hardwareBackPress', onBackPress);
-  }, [
-    activeTabId,
-    activeTabData?.canGoBack,
+  useAndroidHardwareBack({
     displayHomePage,
+    activeTabData,
+    activeTabId,
     handleGoBackHome,
-  ]);
+  });
 
   return (
     <Page fullPage>

--- a/packages/kit/src/views/Discovery/pages/Dashboard/Welcome/WelcomeItem.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/Welcome/WelcomeItem.tsx
@@ -259,7 +259,9 @@ export const WelcomeItem = memo(
         { scale: scale.value },
       ],
       shadowColor,
-      shadowOffset: SHADOW_OFFSET,
+      style: {
+        shadowOffset: SHADOW_OFFSET,
+      },
       shadowOpacity: shadowOpacity.value * scale.value,
       shadowRadius: BASE_SHADOW_RADIUS,
       elevation: BASE_ELEVATION * scale.value,

--- a/packages/kit/src/views/FirmwareUpdate/components/FirmwareChangeLogView.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/components/FirmwareChangeLogView.tsx
@@ -3,10 +3,10 @@ import { useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { StyleSheet } from 'react-native';
 
+import type { IStackProps } from '@onekeyhq/components';
 import {
   Accordion,
   Icon,
-  IStackProps,
   Markdown,
   SizableText,
   Stack,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tab focus handling in the Discovery section to account for modal visibility, ensuring more accurate tab state detection.

- **Style**
  - Updated import statements for improved code clarity (no impact on end-user experience).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->