### PR TITLE
fix: fix GeckoView cache exception

### DIFF
--- a/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/GeckoViewExtended.java
+++ b/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/GeckoViewExtended.java
@@ -150,16 +150,15 @@ public class GeckoViewExtended extends GeckoView implements WebExtension.Message
                     String url = source.getString("uri");
                     if (url.startsWith("file:///android_asset")) {
                         String outputPath = reactContext.getCacheDir().getAbsolutePath() + File.separator + "android_asset";
-                        boolean exists = new File(outputPath).exists();
+                        File file = new File(outputPath);
+                        boolean exists = file.exists();
                         if (exists) {
-                            String newPath = url.replace("file:///android_asset", outputPath);
-                            session.loadUri(newPath);
-                        } else {
-                            new File(outputPath).mkdir();
-                            doCopy("",outputPath);
-                            String newPath = url.replace("file:///android_asset", outputPath);
-                            session.loadUri(newPath);
+                            file.delete();
                         }
+                        new File(outputPath).mkdir();
+                        doCopy("",outputPath);
+                        String newPath = url.replace("file:///android_asset", outputPath);
+                        session.loadUri(newPath);
                     } else {
                         session.loadUri(url);
                     }

--- a/apps/web-embed/postbuild.sh
+++ b/apps/web-embed/postbuild.sh
@@ -4,11 +4,11 @@ set -x
 
 mkdir -p ./web-build/.well-known
 
-rm -rf ../app/android/app/src/main/assets/web-embed
+rm -rf ../mobile/android/app/src/main/assets/web-embed
 mkdir -p ../mobile/android/app/src/main/assets
 rsync -r -c -v ./web-build/ ../mobile/android/app/src/main/assets/web-embed/
 
-rm -rf ../app/ios/OneKeyWallet/web-embed/
+rm -rf ../mobile/ios/OneKeyWallet/web-embed/
 rsync -r -c -v ./web-build/ ../mobile/ios/OneKeyWallet/web-embed/
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when loading local assets on Android by always refreshing the cache directory before loading.
- **Chores**
  - Updated asset synchronization paths in build scripts to target new mobile app directories for both Android and iOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->