### PR TITLE
fix: swap approve manualSelect provider OK-37942

### DIFF
--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -1043,6 +1043,8 @@ export function useSwapBuildTx() {
                 protocol: selectQuote?.protocol ?? EProtocolOfExchange.SWAP,
                 provider: selectQuote?.info.provider,
                 providerName: selectQuote?.info.providerName,
+                unSupportReceiveAddressDifferent:
+                  selectQuote?.unSupportReceiveAddressDifferent,
                 fromToken,
                 toToken,
                 quoteId: selectQuote?.quoteId ?? '',

--- a/packages/kit/src/views/Swap/hooks/useSwapQuote.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapQuote.ts
@@ -461,14 +461,26 @@ export function useSwapQuote() {
       approvedSwapInfo: ISwapApproveTransaction;
       enableFilled?: boolean;
     }) => {
-      const updateQuoteList = swapQuoteResultList.filter(
-        (quote) =>
-          quote.info.provider === data.approvedSwapInfo.provider &&
-          quote.quoteId === data.approvedSwapInfo.quoteId,
-      );
-      if (updateQuoteList.length > 0) {
-        setSwapManualSelectQuoteProviders(updateQuoteList[0]);
-      }
+      setSwapManualSelectQuoteProviders({
+        protocol: data.approvedSwapInfo.protocol,
+        quoteId: data.approvedSwapInfo.quoteId,
+        info: {
+          provider: data.approvedSwapInfo.provider,
+          providerName: data.approvedSwapInfo.providerName,
+        },
+        fromTokenInfo: {
+          networkId: data.approvedSwapInfo.fromToken.networkId,
+          contractAddress: data.approvedSwapInfo.fromToken.contractAddress,
+          symbol: data.approvedSwapInfo.fromToken.symbol,
+          decimals: data.approvedSwapInfo.fromToken.decimals,
+        },
+        toTokenInfo: {
+          networkId: data.approvedSwapInfo.toToken.networkId,
+          contractAddress: data.approvedSwapInfo.toToken.contractAddress,
+          symbol: data.approvedSwapInfo.toToken.symbol,
+          decimals: data.approvedSwapInfo.toToken.decimals,
+        },
+      });
       const { approvedSwapInfo, enableFilled } = data;
       const {
         fromToken: fromTokenInfo,
@@ -522,7 +534,6 @@ export function useSwapQuote() {
       setToTokenAmount,
       swapTypeSwitchAction,
       syncNetworksSort,
-      swapQuoteResultList,
       setSwapManualSelectQuoteProviders,
     ],
   );

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -242,6 +242,7 @@ export interface ISwapApproveTransaction {
   toToken: ISwapToken;
   protocol: EProtocolOfExchange;
   swapType: ESwapTabSwitchType;
+  unSupportReceiveAddressDifferent?: boolean;
   provider: string;
   providerName: string;
   quoteId: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for indicating when swaps do not allow different receiving addresses.
- **Improvements**
  - Enhanced swap approval notifications with more detailed information about supported address configurations.
  - Improved handling of swap provider selection after approval for a more accurate and consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->