### PR TITLE
fix: blast net symbol fix

### DIFF
--- a/packages/shared/src/config/presetNetworks.ts
+++ b/packages/shared/src/config/presetNetworks.ts
@@ -1346,7 +1346,7 @@ const blast: IServerNetwork = {
   'chainId': '81457',
   'id': 'evm--81457',
   'name': 'Blast',
-  'symbol': 'BLAST',
+  'symbol': 'ETH',
   'code': 'blast',
   'shortcode': 'blast',
   'shortname': 'blast',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the displayed symbol for the "blast" network from "BLAST" to "ETH".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->