### PR TITLE
fix: network selector state error OK-38098

### DIFF
--- a/packages/kit/src/components/AccountSelector/NetworkSelectorTrigger/NetworkSelectorTrigger.tsx
+++ b/packages/kit/src/components/AccountSelector/NetworkSelectorTrigger/NetworkSelectorTrigger.tsx
@@ -95,7 +95,7 @@ function NetworkSelectorTriggerHomeCmp({
   size?: 'small' | 'large';
 }) {
   const {
-    activeAccount: { network, account },
+    activeAccount: { network, accountName },
     showChainSelector,
   } = useNetworkSelectorTrigger({ num });
 
@@ -120,7 +120,7 @@ function NetworkSelectorTriggerHomeCmp({
 
   const isLarge = size === 'large';
 
-  if (hideOnNoAccount && !account) {
+  if (hideOnNoAccount && !accountName) {
     return null;
   }
 

--- a/packages/kit/src/components/TabPageHeader/HeaderLeft.tsx
+++ b/packages/kit/src/components/TabPageHeader/HeaderLeft.tsx
@@ -101,7 +101,7 @@ export function HeaderLeft({
           num={0}
           showAccountAddress={false}
           showCopyButton={tabRoute === ETabRoutes.Home}
-          showCreateAddressButton={tabRoute !== ETabRoutes.Home}
+          showCreateAddressButton={false}
           showNoAddressTip={false}
         />
       </XStack>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the logic for displaying the network selector trigger, ensuring it only appears when a valid account name is present.
	- The "Create Address" button is now always hidden in the account selector area, regardless of the current tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->