### PR TITLE
OK-38188: Add closePageCalled ref to track page closure state in FinalizeWalletSetupPage

### DIFF
--- a/packages/kit/src/views/Onboarding/pages/FinalizeWalletSetup.tsx
+++ b/packages/kit/src/views/Onboarding/pages/FinalizeWalletSetup.tsx
@@ -59,6 +59,7 @@ function FinalizeWalletSetupPage({
   const [onboardingError, setOnboardingError] = useState<
     IOneKeyError | undefined
   >(undefined);
+  const closePageCalled = useRef(false);
 
   const {
     shouldBondReferralCode,
@@ -173,6 +174,7 @@ function FinalizeWalletSetupPage({
   };
 
   const closePage = useCallback(() => {
+    closePageCalled.current = true;
     navigation.navigate(ERootRoutes.Main);
   }, [navigation]);
 
@@ -214,7 +216,16 @@ function FinalizeWalletSetupPage({
   }, [shouldBondReferralCode, closePage]);
 
   return (
-    <Page>
+    <Page
+      onClose={() => {
+        if (
+          currentStep === EFinalizeWalletSetupSteps.Ready &&
+          !closePageCalled.current
+        ) {
+          closePage();
+        }
+      }}
+    >
       <Page.Header
         title={intl.formatMessage({
           id: ETranslations.onboarding_finalize_wallet_setup,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the wallet setup finalization to prevent multiple navigations when closing the page, ensuring a smoother onboarding experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->