### PR TITLE
fix: db backup and same wallet merge bugs OK-38144 OK-38140 OK-38075 OK-37994 OK-38000

### DIFF
--- a/@types/globals.d.ts
+++ b/@types/globals.d.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-var,vars-on-top */
 
+import type { ICheckCurrentDBIsMigratedToBucketResult } from '@onekeyhq/kit-bg/src/migrations/indexedToBucketsMigration/indexedToBucketsMigration';
 import type {
   ETranslations,
   ETranslationsMock,
@@ -28,6 +29,9 @@ type IOneKeyPerfTrace = {
 declare global {
   var $$appGlobals: IAppGlobals;
   var $onekeySystemDiskIsFull: boolean | undefined;
+  var $indexedDBIsMigratedToBucket:
+    | ICheckCurrentDBIsMigratedToBucketResult
+    | undefined;
 
   // eslint-disable-next-line
   // var onekey: WindowOneKey;

--- a/packages/kit-bg/src/dbs/local/indexed/LocalDbIndexedBase.ts
+++ b/packages/kit-bg/src/dbs/local/indexed/LocalDbIndexedBase.ts
@@ -33,7 +33,7 @@ import {
 import { IndexedDBAgent } from './IndexedDBAgent';
 import indexedDBUtils from './indexedDBUtils';
 
-import type { ICheckCurrentDBIsMigratedResult } from '../../../migrations/indexedToBucketsMigration/indexedToBucketsMigration';
+import type { ICheckCurrentDBIsMigratedToBucketResult } from '../../../migrations/indexedToBucketsMigration/indexedToBucketsMigration';
 import type {
   IDBWalletIdSingleton,
   IIndexedBucketsMap,
@@ -220,7 +220,7 @@ export abstract class LocalDbIndexedBase extends LocalDbBase {
     }
 
     try {
-      const checkMigratedResult: ICheckCurrentDBIsMigratedResult =
+      const checkMigratedResult: ICheckCurrentDBIsMigratedToBucketResult =
         await indexedToBucketsMigration.checkCurrentDBIsMigrated({
           buckets,
         });
@@ -247,6 +247,8 @@ export abstract class LocalDbIndexedBase extends LocalDbBase {
             checkMigratedResult,
           );
         }
+
+        globalThis.$indexedDBIsMigratedToBucket = checkMigratedResult;
       }
     } catch (error) {
       console.error('checkCurrentDBIsMigrated ERROR: ', error);

--- a/packages/kit-bg/src/dbs/local/types.ts
+++ b/packages/kit-bg/src/dbs/local/types.ts
@@ -199,6 +199,7 @@ export type IDBSetWalletNameAndAvatarParams = {
 };
 export type IDBRemoveWalletParams = {
   walletId: string;
+  skipBackupWalletRemove?: boolean;
 };
 type IDBSetAccountNameParamsBase = {
   shouldCheckDuplicate?: boolean;

--- a/packages/kit-bg/src/migrations/indexedToBucketsMigration/indexedToBucketsMigration.ts
+++ b/packages/kit-bg/src/migrations/indexedToBucketsMigration/indexedToBucketsMigration.ts
@@ -44,7 +44,7 @@ async function legacyDbExists(): Promise<boolean> {
   }
 }
 
-export type ICheckCurrentDBIsMigratedResult = {
+export type ICheckCurrentDBIsMigratedToBucketResult = {
   isMigrated: boolean;
 
   buckets: IIndexedBucketsMap;
@@ -64,7 +64,7 @@ async function checkCurrentDBIsMigrated({
   buckets,
 }: {
   buckets: IIndexedBucketsMap;
-}): Promise<ICheckCurrentDBIsMigratedResult> {
+}): Promise<ICheckCurrentDBIsMigratedToBucketResult> {
   // const cloudSyncBucket = buckets[EIndexedDBBucketNames.cloudSync];
   const accountBucket = buckets[EIndexedDBBucketNames.account];
   const backupAccountBucket = buckets[EIndexedDBBucketNames.backupAccount];
@@ -108,7 +108,7 @@ async function migrateBackupedDataToBucket({
   isMigrated,
   accountBucket,
   backupAccountBucket,
-}: ICheckCurrentDBIsMigratedResult) {
+}: ICheckCurrentDBIsMigratedToBucketResult) {
   if (isMigrated) {
     console.log(
       'migrateBackupedDataToBucket skipped:  bucketDB is migrated already',
@@ -174,7 +174,7 @@ async function migrateOneKeyV5LegacyDBToBucket({
   walletCount,
   contextCount,
   context,
-}: ICheckCurrentDBIsMigratedResult) {
+}: ICheckCurrentDBIsMigratedToBucketResult) {
   if (isMigrated) {
     console.log(
       'migrateOneKeyV5LegacyDBToBucket skipped:  bucketDB is migrated already',

--- a/packages/kit-bg/src/migrations/indexedToBucketsMigration/indexedToBucketsMigration.ts
+++ b/packages/kit-bg/src/migrations/indexedToBucketsMigration/indexedToBucketsMigration.ts
@@ -88,7 +88,9 @@ async function checkCurrentDBIsMigrated({
     walletCount > 3 ||
     credentialCount > 0 ||
     accountCount > 0 ||
-    context?.verifyString !== DEFAULT_VERIFY_STRING;
+    context?.verifyString !== DEFAULT_VERIFY_STRING ||
+    Boolean(context?.nextHD && context?.nextHD > 1) ||
+    Boolean(context?.nextWalletNo && context?.nextWalletNo > 1);
 
   return {
     isMigrated: isBucketDBMigrated,

--- a/packages/kit-bg/src/migrations/indexedToBucketsMigration/legacyIndexedDb.ts
+++ b/packages/kit-bg/src/migrations/indexedToBucketsMigration/legacyIndexedDb.ts
@@ -65,6 +65,15 @@ class LegacyIndexedDb {
     }
   }
 
+  async delete(name: ELocalDBStoreNames, id: string) {
+    try {
+      const legacyDb = await this.open();
+      await legacyDb.delete(name, id);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
   private _getObjectStoreAtVersionChange<T extends ELocalDBStoreNames>(
     tx: IDBPTransaction<
       IIndexedDBSchemaMap,

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -3505,15 +3505,19 @@ class ServiceAccount extends ServiceBase {
   async generateAllHdAndQrWalletsHashAndXfp({
     password,
     skipLocalSync,
+    skipAppStatusCheck,
   }: {
     password: string;
     skipLocalSync?: boolean;
+    skipAppStatusCheck?: boolean;
   }) {
     await this.generateAllHdAndQrWalletsHashAndXfpMutex.runExclusive(
       async () => {
-        const appStatus = await simpleDb.appStatus.getRawData();
-        if (appStatus?.allHdWalletsHashAndXfpGenerated) {
-          return;
+        if (!skipAppStatusCheck) {
+          const appStatus = await simpleDb.appStatus.getRawData();
+          if (appStatus?.allHdWalletsHashAndXfpGenerated) {
+            return;
+          }
         }
 
         const { wallets } = await this.getAllWallets({
@@ -3947,8 +3951,17 @@ class ServiceAccount extends ServiceBase {
     return false;
   }
 
-  async getLocalSameHDWallets({ password }: { password: string }) {
-    await this.generateAllHdAndQrWalletsHashAndXfp({ password });
+  async getLocalSameHDWallets({
+    password,
+    skipAppStatusCheck,
+  }: {
+    password: string;
+    skipAppStatusCheck?: boolean;
+  }) {
+    await this.generateAllHdAndQrWalletsHashAndXfp({
+      password,
+      skipAppStatusCheck,
+    });
     const { wallets: allWallets } = await this.getAllWallets({
       refillWalletInfo: true,
     });
@@ -3972,14 +3985,25 @@ class ServiceAccount extends ServiceBase {
   }
 
   @backgroundMethod()
-  async mergeDuplicateHDWallets({ password }: { password: string }) {
-    const appStatus = await simpleDb.appStatus.getRawData();
-    if (appStatus?.allHdDuplicateWalletsMerged) {
-      return;
+  async mergeDuplicateHDWallets({
+    password,
+    skipAppStatusCheck,
+  }: {
+    password: string;
+    skipAppStatusCheck?: boolean;
+  }) {
+    if (!skipAppStatusCheck) {
+      const appStatus = await simpleDb.appStatus.getRawData();
+      if (appStatus?.allHdDuplicateWalletsMerged && !skipAppStatusCheck) {
+        return;
+      }
     }
 
     try {
-      const sameWallets = await this.getLocalSameHDWallets({ password });
+      const sameWallets = await this.getLocalSameHDWallets({
+        password,
+        skipAppStatusCheck,
+      });
 
       if (sameWallets?.length) {
         const walletsToRemove: string[] = [];

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -1,5 +1,5 @@
 import { Semaphore } from 'async-mutex';
-import { debounce, isEmpty, isNil, uniqBy } from 'lodash';
+import { debounce, isEmpty, isNil, uniq, uniqBy } from 'lodash';
 
 import coreChainApi from '@onekeyhq/core/src/instance/coreChainApi';
 import type { IBip39RevealableSeedEncryptHex } from '@onekeyhq/core/src/secret';
@@ -4011,7 +4011,7 @@ class ServiceAccount extends ServiceBase {
         const { accounts: allAccounts } = await this.getAllAccounts();
 
         for (const sameWallet of sameWallets) {
-          let keepWallet: IDBWallet | undefined;
+          let walletToKeep: IDBWallet | undefined;
           const accountsToAddParams: {
             oldIndexedAccountId: string;
             deriveType: IAccountDeriveTypes;
@@ -4028,10 +4028,26 @@ class ServiceAccount extends ServiceBase {
           for (let i = 0; i < sameWallet.wallets.length; i += 1) {
             const wallet = sameWallet.wallets[i];
             if (i === 0) {
-              keepWallet = wallet;
+              walletToKeep = wallet;
             } else {
               walletsToRemove.push(wallet.id);
               walletNames.push(wallet.name);
+              try {
+                const changeHistory =
+                  await this.backgroundApi.simpleDb.changeHistory.getChangeHistory(
+                    {
+                      entityType: EChangeHistoryEntityType.Wallet,
+                      entityId: wallet.id,
+                      contentType: EChangeHistoryContentType.Name,
+                    },
+                  );
+                if (changeHistory?.length) {
+                  walletNames.push(...changeHistory.map((item) => item.value));
+                }
+              } catch (e) {
+                console.error(e);
+              }
+
               await Promise.all(
                 allAccounts
                   .filter(
@@ -4083,10 +4099,10 @@ class ServiceAccount extends ServiceBase {
                           name: indexedAccount?.name,
                         });
 
-                        if (keepWallet?.id && item.pathIndex >= 0) {
+                        if (walletToKeep?.id && item.pathIndex >= 0) {
                           const indexedAccountIdToAdd =
                             accountUtils.buildIndexedAccountId({
-                              walletId: keepWallet?.id,
+                              walletId: walletToKeep?.id,
                               index: item.pathIndex,
                             });
                           if (indexedAccountIdToAdd) {
@@ -4117,10 +4133,10 @@ class ServiceAccount extends ServiceBase {
             }
           }
 
-          if (keepWallet && keepWallet?.id && accountsToAddParams?.length) {
+          if (walletToKeep && walletToKeep?.id && accountsToAddParams?.length) {
             for (const accountToAddParam of accountsToAddParams) {
               const indexedAccountIdToAdd = accountUtils.buildIndexedAccountId({
-                walletId: keepWallet?.id,
+                walletId: walletToKeep?.id,
                 index: accountToAddParam.index,
               });
               const existingIndexedAccount = await this.getIndexedAccountSafe({
@@ -4128,7 +4144,7 @@ class ServiceAccount extends ServiceBase {
               });
               try {
                 await this.addHDOrHWAccounts({
-                  walletId: keepWallet?.id,
+                  walletId: walletToKeep?.id,
                   networkId: accountToAddParam.networkId,
                   deriveType: accountToAddParam.deriveType,
                   indexes: [accountToAddParam.index],
@@ -4171,20 +4187,20 @@ class ServiceAccount extends ServiceBase {
           } catch (e) {
             console.error(e);
           }
-          if (keepWallet) {
+          if (walletToKeep) {
             try {
               await this.backgroundApi.simpleDb.changeHistory.addChangeHistory({
                 items: [
                   {
                     entityType: EChangeHistoryEntityType.Wallet,
-                    entityId: keepWallet?.id,
+                    entityId: walletToKeep?.id,
                     contentType: EChangeHistoryContentType.Name,
                     oldValue: '',
-                    value: keepWallet?.name,
+                    value: walletToKeep?.name,
                   },
-                  ...walletNames.map((name) => ({
+                  ...uniq(walletNames).map((name) => ({
                     entityType: EChangeHistoryEntityType.Wallet,
-                    entityId: keepWallet?.id,
+                    entityId: walletToKeep?.id,
                     contentType: EChangeHistoryContentType.Name,
                     oldValue: '',
                     value: name,

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -2787,11 +2787,18 @@ class ServiceAccount extends ServiceBase {
         account,
       });
     }
+
+    if (account) {
+      void this.backgroundApi.serviceDBBackup.removeBackupImportedAccount({
+        accountId: account.id,
+      });
+    }
   }
 
   @backgroundMethod()
   async removeWallet({
     walletId,
+    skipBackupWalletRemove,
   }: Omit<IDBRemoveWalletParams, 'password' | 'isHardware'>) {
     if (!walletId) {
       throw new Error('walletId is required');
@@ -2806,6 +2813,11 @@ class ServiceAccount extends ServiceBase {
     await this.backgroundApi.serviceDApp.removeDappConnectionAfterWalletRemove({
       walletId,
     });
+    if (!skipBackupWalletRemove) {
+      void this.backgroundApi.serviceDBBackup.removeBackupHDWallet({
+        walletId,
+      });
+    }
     return result;
   }
 
@@ -4215,7 +4227,7 @@ class ServiceAccount extends ServiceBase {
 
         for (const walletId of walletsToRemove) {
           try {
-            await this.removeWallet({ walletId });
+            await this.removeWallet({ walletId, skipBackupWalletRemove: true });
           } catch (e) {
             console.error(e);
           }

--- a/packages/kit-bg/src/services/ServiceDBBackup/ServiceDBBackup.ts
+++ b/packages/kit-bg/src/services/ServiceDBBackup/ServiceDBBackup.ts
@@ -3,12 +3,14 @@ import {
   backgroundMethod,
 } from '@onekeyhq/shared/src/background/backgroundDecorators';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { type IInstanceMetaBackup } from '@onekeyhq/shared/types/desktop';
 
 import { INDEXED_DB_BUCKET_PRESET_STORE_NAMES } from '../../dbs/local/consts';
 import { ELocalDBStoreNames } from '../../dbs/local/localDBStoreNames';
 import { EIndexedDBBucketNames } from '../../dbs/local/types';
+import legacyIndexedDb from '../../migrations/indexedToBucketsMigration/legacyIndexedDb';
 import { migrateAccountBucketRecords } from '../../migrations/indexedToBucketsMigration/migrateRecordsFn';
 import { settingsPersistAtom } from '../../states/jotai/atoms';
 import ServiceBase from '../ServiceBase';
@@ -33,11 +35,133 @@ class ServiceDBBackup extends ServiceBase {
     super({ backgroundApi });
   }
 
+  canBackup() {
+    return Boolean(
+      platformEnv.isExtension || platformEnv.isDesktop || platformEnv.isWeb,
+    );
+  }
+
+  @backgroundMethod()
+  async removeBackupHDWallet({ walletId }: { walletId: string }) {
+    if (!this.canBackup()) {
+      return;
+    }
+    const isHdWallet = accountUtils.isHdWallet({ walletId });
+    if (!isHdWallet) {
+      return;
+    }
+    try {
+      const nativeDb = (await this.backgroundApi.localDb
+        .readyDb) as IndexedDBAgent;
+      const backupDB = nativeDb.getIndexedByBucketName(
+        EIndexedDBBucketNames.backupAccount,
+      );
+
+      const createBackupTx = () => {
+        return backupDB.transaction(
+          INDEXED_DB_BUCKET_PRESET_STORE_NAMES[EIndexedDBBucketNames.account],
+          'readwrite',
+        );
+      };
+
+      try {
+        const backupTx = createBackupTx();
+        await backupTx.objectStore(ELocalDBStoreNames.Wallet)?.delete(walletId);
+      } catch (error) {
+        console.error('ServiceDBBackup removeBackupHDWallet error', error);
+      }
+
+      try {
+        const backupTx = createBackupTx();
+        await backupTx
+          .objectStore(ELocalDBStoreNames.Credential)
+          ?.delete(walletId);
+      } catch (error) {
+        console.error('ServiceDBBackup removeBackupHDWallet error', error);
+      }
+    } catch (error) {
+      console.error('ServiceDBBackup removeBackupHDWallet error', error);
+    }
+
+    try {
+      await legacyIndexedDb.delete(ELocalDBStoreNames.Wallet, walletId);
+    } catch (error) {
+      console.error('ServiceDBBackup removeBackupHDWallet error', error);
+    }
+
+    try {
+      await legacyIndexedDb.delete(ELocalDBStoreNames.Credential, walletId);
+    } catch (error) {
+      console.error('ServiceDBBackup removeBackupHDWallet error', error);
+    }
+  }
+
+  @backgroundMethod()
+  async removeBackupImportedAccount({ accountId }: { accountId: string }) {
+    if (!this.canBackup()) {
+      return;
+    }
+    const isImportedAccount = accountUtils.isImportedAccount({ accountId });
+    if (!isImportedAccount) {
+      return;
+    }
+    try {
+      const nativeDb = (await this.backgroundApi.localDb
+        .readyDb) as IndexedDBAgent;
+      const backupDB = nativeDb.getIndexedByBucketName(
+        EIndexedDBBucketNames.backupAccount,
+      );
+
+      const createBackupTx = () => {
+        return backupDB.transaction(
+          INDEXED_DB_BUCKET_PRESET_STORE_NAMES[EIndexedDBBucketNames.account],
+          'readwrite',
+        );
+      };
+
+      try {
+        const backupTx = createBackupTx();
+        await backupTx
+          .objectStore(ELocalDBStoreNames.Account)
+          ?.delete(accountId);
+      } catch (error) {
+        console.error(
+          'ServiceDBBackup removeBackupImportedAccount error',
+          error,
+        );
+      }
+
+      try {
+        const backupTx = createBackupTx();
+        await backupTx
+          .objectStore(ELocalDBStoreNames.Credential)
+          ?.delete(accountId);
+      } catch (error) {
+        console.error(
+          'ServiceDBBackup removeBackupImportedAccount error',
+          error,
+        );
+      }
+    } catch (error) {
+      console.error('ServiceDBBackup removeBackupImportedAccount error', error);
+    }
+
+    try {
+      await legacyIndexedDb.delete(ELocalDBStoreNames.Account, accountId);
+    } catch (error) {
+      console.error('ServiceDBBackup removeBackupImportedAccount error', error);
+    }
+
+    try {
+      await legacyIndexedDb.delete(ELocalDBStoreNames.Credential, accountId);
+    } catch (error) {
+      console.error('ServiceDBBackup removeBackupImportedAccount error', error);
+    }
+  }
+
   @backgroundMethod()
   async backupDatabaseDaily(): Promise<void> {
-    const canBackup =
-      platformEnv.isExtension || platformEnv.isDesktop || platformEnv.isWeb;
-    if (!canBackup) {
+    if (!this.canBackup()) {
       return;
     }
 

--- a/packages/kit-bg/src/services/ServicePassword/index.ts
+++ b/packages/kit-bg/src/services/ServicePassword/index.ts
@@ -604,16 +604,28 @@ export default class ServicePassword extends ServiceBase {
           console.error(e);
         }
         try {
+          let skipAppStatusCheck = false;
+          if (
+            !this._mergeDuplicateHDWalletsExecuted &&
+            !globalThis?.$indexedDBIsMigratedToBucket?.isMigrated
+          ) {
+            skipAppStatusCheck = true;
+          }
           await this.backgroundApi.serviceAccount.mergeDuplicateHDWallets({
             password: verifyingPassword,
+            skipAppStatusCheck,
           });
         } catch (e) {
           console.error(e);
+        } finally {
+          this._mergeDuplicateHDWalletsExecuted = true;
         }
       })();
     }
     return verifyingPassword;
   }
+
+  _mergeDuplicateHDWalletsExecuted = false;
 
   // ui ------------------------------
   promptPasswordVerifyMutex = new Semaphore(1);

--- a/packages/kit/src/views/AccountManagerStacks/pages/PageResolveSameWallets/PageResolveSameWallets.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/PageResolveSameWallets/PageResolveSameWallets.tsx
@@ -143,6 +143,7 @@ export default function PageResolveSameWallets({
             onConfirm: async () => {
               try {
                 setIsRemoving(true);
+                // TODO remove this component
                 await backgroundApiProxy.serviceAccount.mergeDuplicateHDWallets(
                   { password: '' },
                 );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added ability to selectively skip backup removal when deleting wallets or accounts.
  - Introduced new controls to bypass app status checks during wallet operations.
  - Enhanced duplicate wallet merging by preserving and deduplicating wallet name change histories.
  - Added new background methods to remove HD wallet and imported account backups.
  - Added method for deleting entries from legacy databases.

- **Improvements**
  - Improved parameter handling and variable naming for clarity in wallet management features.
  - Centralized backup capability checks for more consistent backup operations.

- **Bug Fixes**
  - Ensured one-time execution of duplicate wallet merging during password verification, based on migration status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->