### PR TITLE
fix: Enhance LocalDbBase and ServiceAccount to track removed account

### DIFF
--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -1606,9 +1606,10 @@ class ServiceAccount extends ServiceBase {
     walletId: IDBWalletIdSingleton;
     activeNetworkId?: string;
   }) {
-    let { accounts } = await localDb.getSingletonAccountsOfWallet({
-      walletId,
-    });
+    let { accounts, removedAccountIds } =
+      await localDb.getSingletonAccountsOfWallet({
+        walletId,
+      });
     accounts = await Promise.all(
       accounts.map(async (account) => {
         const { id: accountId } = account;
@@ -1629,6 +1630,11 @@ class ServiceAccount extends ServiceBase {
         return account;
       }),
     );
+    if (removedAccountIds?.length) {
+      void localDb.removeAccountsByIds({
+        ids: removedAccountIds,
+      });
+    }
     return { accounts };
   }
 
@@ -4228,7 +4234,10 @@ class ServiceAccount extends ServiceBase {
 
         for (const walletId of walletsToRemove) {
           try {
-            await this.removeWallet({ walletId, skipBackupWalletRemove: true });
+            await this.removeWallet({
+              walletId,
+              // skipBackupWalletRemove: true
+            });
           } catch (e) {
             console.error(e);
           }


### PR DESCRIPTION
… IDs

- Added `removedAccountIds` to the return type of `getSingletonAccountsOfWallet` in LocalDbBase.
- Updated `ServiceAccount` to handle and remove accounts that are no longer associated with the wallet.
- Refactored `removeAccounts` method to call `removeAccountsByIds` for better clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved account and wallet management by identifying and cleaning up removed accounts from wallets.
- **Bug Fixes**
  - Enhanced consistency in account and wallet removal processes, ensuring better cleanup and data accuracy during batch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->