### PR TITLE
fix: swap modal event off when effect return OK-38419

### DIFF
--- a/packages/kit/src/views/Swap/hooks/useSwapQuote.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapQuote.ts
@@ -609,11 +609,13 @@ export function useSwapQuote() {
       }
     }
     return () => {
-      appEventBus.off(EAppEventBusNames.SwapQuoteEvent, quoteEventHandler);
-      appEventBus.off(
-        EAppEventBusNames.SwapApprovingSuccess,
-        swapApprovingSuccessAction,
-      );
+      if (pageType === EPageType.modal) {
+        appEventBus.off(EAppEventBusNames.SwapQuoteEvent, quoteEventHandler);
+        appEventBus.off(
+          EAppEventBusNames.SwapApprovingSuccess,
+          swapApprovingSuccessAction,
+        );
+      }
     };
   }, [isFocused, pageType, quoteEventHandler, swapApprovingSuccessAction]);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event listener management for swap modal to ensure listeners are only removed when appropriate, enhancing stability during swap operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->