### PR TITLE
fix: free fee badge opt

### DIFF
--- a/packages/kit/src/views/Swap/components/SwapProviderInfoItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProviderInfoItem.tsx
@@ -97,7 +97,7 @@ const SwapProviderInfoItem = ({
                 </Badge>
               ) : null}
               {isFreeOneKeyFee ? (
-                <Badge badgeSize="sm" marginRight="$2" badgeType="success">
+                <Badge badgeSize="sm" marginRight="$2" badgeType="info">
                   {intl.formatMessage({
                     id: ETranslations.swap_stablecoin_0_fee,
                   })}

--- a/packages/kit/src/views/Swap/components/SwapQuoteResultRate.tsx
+++ b/packages/kit/src/views/Swap/components/SwapQuoteResultRate.tsx
@@ -140,7 +140,7 @@ const SwapQuoteResultRate = ({
             opacity={openResult ? 0 : 1}
             // gap="$2"
           >
-            {isBest ? (
+            {isBest && !isFreeOneKeyFee ? (
               <Badge badgeSize="sm" marginRight="$2" badgeType="success">
                 {intl.formatMessage({
                   id: ETranslations.global_best,
@@ -148,7 +148,7 @@ const SwapQuoteResultRate = ({
               </Badge>
             ) : null}
             {isFreeOneKeyFee ? (
-              <Badge badgeSize="sm" marginRight="$2" badgeType="success">
+              <Badge badgeSize="sm" marginRight="$2" badgeType="info">
                 {intl.formatMessage({
                   id: ETranslations.swap_stablecoin_0_fee,
                 })}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the visual style of the "free OneKey fee" badge to use a different color.
  - Adjusted badge display logic so that "best" and "free fee" badges are now mutually exclusive in swap rate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->