### PR TITLE
fix: free fee badge for limit

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
@@ -380,6 +380,10 @@ const SwapQuoteResult = ({
           <SwapProviderInfoItem
             providerIcon={quoteResult?.info.providerLogo ?? ''}
             providerName={quoteResult?.info.providerName ?? ''}
+            isFreeOneKeyFee={
+              new BigNumber(quoteResult?.fee?.percentageFee ?? '0').isZero() ||
+              new BigNumber(quoteResult?.fee?.percentageFee ?? '0').isNaN()
+            }
             // isLoading={swapQuoteLoading}
             fromToken={fromToken}
             onekeyFee={quoteResult?.fee?.percentageFee}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved swap quote display by indicating when the OneKey fee is free in both the limit order and general swap quote sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->