### PR TITLE
feat: provide callback for app unlock event in UI layer

### DIFF
--- a/packages/kit-bg/src/services/ServicePassword/index.ts
+++ b/packages/kit-bg/src/services/ServicePassword/index.ts
@@ -827,6 +827,7 @@ export default class ServicePassword extends ServiceBase {
       unLock: true,
       manualLocking: false,
     }));
+    await this.backgroundApi.serviceApp.dispatchUnlockJob();
   }
 
   @backgroundMethod()

--- a/packages/kit/src/components/UpdateReminder/hooks.tsx
+++ b/packages/kit/src/components/UpdateReminder/hooks.tsx
@@ -373,7 +373,9 @@ export const useAppUpdateInfo = (isFullModal = false, autoCheck = true) => {
               isFirstLaunch
             ) {
               await whenAppUnlocked();
-              showUpdateDialog(false, response);
+              setTimeout(() => {
+                showUpdateDialog(false, response);
+              }, 200);
             }
           }
           isFirstLaunch = false;

--- a/packages/kit/src/components/UpdateReminder/hooks.tsx
+++ b/packages/kit/src/components/UpdateReminder/hooks.tsx
@@ -362,7 +362,7 @@ export const useAppUpdateInfo = (isFullModal = false, autoCheck = true) => {
       void verifyPackage();
     } else {
       void checkForUpdates().then(
-        ({ isNeedUpdate: needUpdate, isForceUpdate, response }) => {
+        async ({ isNeedUpdate: needUpdate, isForceUpdate, response }) => {
           if (needUpdate) {
             if (isForceUpdate) {
               toUpdatePreviewPage(true, response);

--- a/packages/kit/src/components/UpdateReminder/hooks.tsx
+++ b/packages/kit/src/components/UpdateReminder/hooks.tsx
@@ -34,6 +34,7 @@ import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import backgroundApiProxy from '../../background/instance/backgroundApiProxy';
 import useAppNavigation from '../../hooks/useAppNavigation';
 import { usePromiseResult } from '../../hooks/usePromiseResult';
+import { whenAppUnlocked } from '../../utils/passwordUtils';
 
 const MIN_EXECUTION_DURATION = 3000; // 3 seconds minimum execution time
 
@@ -371,6 +372,7 @@ export const useAppUpdateInfo = (isFullModal = false, autoCheck = true) => {
               response?.isShowUpdateDialog &&
               isFirstLaunch
             ) {
+              await whenAppUnlocked();
               showUpdateDialog(false, response);
             }
           }

--- a/packages/kit/src/utils/passwordUtils.ts
+++ b/packages/kit/src/utils/passwordUtils.ts
@@ -1,3 +1,11 @@
+import uuid from 'react-native-uuid';
+
+import type { IAppEventBusPayload } from '@onekeyhq/shared/src/eventBus/appEventBus';
+import {
+  EAppEventBusNames,
+  appEventBus,
+} from '@onekeyhq/shared/src/eventBus/appEventBus';
+
 import backgroundApiProxy from '../background/instance/backgroundApiProxy';
 
 export const withPromptPasswordVerify = async <T>({
@@ -17,4 +25,27 @@ export const withPromptPasswordVerify = async <T>({
   } finally {
     await backgroundApiProxy.servicePassword.closePasswordSecuritySession();
   }
+};
+
+export const whenAppUnlocked = () => {
+  return new Promise<void>((resolve) => {
+    void backgroundApiProxy.serviceApp.isAppLocked().then(async (isLock) => {
+      if (!isLock) {
+        resolve();
+      }
+      const unlockJobId = uuid.v1().toString();
+      const callback = (
+        event: IAppEventBusPayload[EAppEventBusNames.UnlockApp],
+      ) => {
+        if (event.jobId === unlockJobId) {
+          setTimeout(() => {
+            resolve();
+          }, 100);
+          appEventBus.off(EAppEventBusNames.UnlockApp, callback);
+        }
+      };
+      appEventBus.on(EAppEventBusNames.UnlockApp, callback);
+      await backgroundApiProxy.serviceApp.addUnlockJob(unlockJobId);
+    });
+  });
 };

--- a/packages/kit/src/utils/passwordUtils.ts
+++ b/packages/kit/src/utils/passwordUtils.ts
@@ -32,6 +32,7 @@ export const whenAppUnlocked = () => {
     void backgroundApiProxy.serviceApp.isAppLocked().then(async (isLock) => {
       if (!isLock) {
         resolve();
+        return;
       }
       const unlockJobId = uuid.v1().toString();
       const callback = (

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -274,6 +274,9 @@ export interface IAppEventBusPayload {
   [EAppEventBusNames.HardwareFeaturesUpdate]: {
     deviceId: string;
   };
+  [EAppEventBusNames.UnlockApp]: {
+    jobId: string;
+  };
 }
 
 export enum EEventBusBroadcastMethodNames {

--- a/packages/shared/src/eventBus/appEventBusNames.ts
+++ b/packages/shared/src/eventBus/appEventBusNames.ts
@@ -85,6 +85,7 @@ export enum EAppEventBusNames {
   CheckWalletBackupStatus = 'CheckWalletBackupStatus',
   HomeTabsChanged = 'HomeTabsChanged',
   HardwareFeaturesUpdate = 'HardwareFeaturesUpdate',
+  UnlockApp = 'UnlockApp',
   // AccountNameChanged = 'AccountNameChanged',
   // CurrencyChanged = 'CurrencyChanged',
   // BackupRequired = 'BackupRequired',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for awaiting app unlock events, allowing certain actions (such as update reminders) to be triggered only after the app is unlocked.
  - Introduced a mechanism to queue and process unlock jobs, improving the handling of unlock-related tasks.
- **Improvements**
  - Update dialogs are now shown after the app is unlocked, enhancing user experience during app updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->