### PR TITLE
fix: hardware batch create loading

### DIFF
--- a/packages/kit-bg/src/services/ServiceBatchCreateAccount/ServiceBatchCreateAccount.ts
+++ b/packages/kit-bg/src/services/ServiceBatchCreateAccount/ServiceBatchCreateAccount.ts
@@ -627,22 +627,33 @@ class ServiceBatchCreateAccount extends ServiceBase {
               async () => {
                 // throw new NewFirmwareForceUpdate({ payload: {} });
 
-                const sdkAllNetworkGetAddressResponse =
-                  await sdk.allNetworkGetAddress(
-                    deviceParams.dbDevice?.connectId || '',
-                    deviceParams.dbDevice?.deviceId || '',
-                    {
-                      ...deviceParams.deviceCommonParams,
-                      bundle: bundleParams,
-                    },
+                appEventBus.emit(
+                  EAppEventBusNames.SDKGetAllNetworkAddressesStart,
+                  undefined,
+                );
+                try {
+                  const sdkAllNetworkGetAddressResponse =
+                    await sdk.allNetworkGetAddress(
+                      deviceParams.dbDevice?.connectId || '',
+                      deviceParams.dbDevice?.deviceId || '',
+                      {
+                        ...deviceParams.deviceCommonParams,
+                        bundle: bundleParams,
+                      },
+                    );
+
+                  console.log('sdk.allNetworkGetAddress response', {
+                    bundle: bundleParams,
+                    response: sdkAllNetworkGetAddressResponse,
+                  });
+
+                  return sdkAllNetworkGetAddressResponse;
+                } finally {
+                  appEventBus.emit(
+                    EAppEventBusNames.SDKGetAllNetworkAddressesEnd,
+                    undefined,
                   );
-
-                console.log('sdk.allNetworkGetAddress response', {
-                  bundle: bundleParams,
-                  response: sdkAllNetworkGetAddressResponse,
-                });
-
-                return sdkAllNetworkGetAddressResponse;
+                }
               },
             )) as any; // TODO sdk type error
           }

--- a/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts
+++ b/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts
@@ -71,7 +71,10 @@ import type {
   IFirmwareAuthenticateParams,
   IShouldAuthenticateFirmwareParams,
 } from './HardwareVerifyManager';
-import type { IHardwareUiPayload } from '../../states/jotai/atoms';
+import type {
+  IHardwareUiPayload,
+  IHardwareUiState,
+} from '../../states/jotai/atoms';
 import type { IServiceBaseProps } from '../ServiceBase';
 import type { IUpdateFirmwareWorkflowParams } from '../ServiceFirmwareUpdate/ServiceFirmwareUpdate';
 import type {
@@ -402,12 +405,17 @@ class ServiceHardware extends ServiceBase {
               undefined,
             );
           } else {
+            if (newUiRequestType === ('ui-device_progress' as any)) {
+              console.log('ui-device_progress', originEvent);
+            }
             // show hardware ui dialog
-            await hardwareUiStateAtom.set({
-              action: newUiRequestType,
-              connectId,
-              payload: newPayload,
-            });
+            await hardwareUiStateAtom.set(
+              (): IHardwareUiState => ({
+                action: newUiRequestType,
+                connectId,
+                payload: newPayload,
+              }),
+            );
           }
         }
         await hardwareUiStateCompletedAtom.set({

--- a/packages/kit-bg/src/states/jotai/atoms/hardware.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/hardware.ts
@@ -31,6 +31,7 @@ export enum EHardwareUiStateAction {
   REQUEST_DEVICE_IN_BOOTLOADER_FOR_WEB_DEVICE = 'ui-request_select_device_in_bootloader_for_web_device',
 
   CLOSE_UI_WINDOW = 'ui-close_window',
+  DEVICE_PROGRESS = 'ui-device_progress',
 
   BLUETOOTH_PERMISSION = 'ui-bluetooth_permission',
   BLUETOOTH_CHARACTERISTIC_NOTIFY_CHANGE_FAILURE = 'ui-bluetooth_characteristic_notify_change_failure',

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -150,6 +150,8 @@ export interface IAppEventBusPayload {
     deriveType?: string | IAccountDeriveTypes;
     error?: IOneKeyError;
   };
+  [EAppEventBusNames.SDKGetAllNetworkAddressesStart]: undefined;
+  [EAppEventBusNames.SDKGetAllNetworkAddressesEnd]: undefined;
   [EAppEventBusNames.ExtensionContextMenuUpdate]: undefined;
   [EAppEventBusNames.ShowFirmwareUpdateFromBootloaderMode]: {
     connectId: string | undefined;

--- a/packages/shared/src/eventBus/appEventBusNames.ts
+++ b/packages/shared/src/eventBus/appEventBusNames.ts
@@ -33,6 +33,8 @@ export enum EAppEventBusNames {
   SyncDeviceLabelToWalletName = 'SyncDeviceLabelToWalletName',
   UpdateWalletAvatarByDeviceSerialNo = 'UpdateWalletAvatarByDeviceSerialNo',
   BatchCreateAccount = 'BatchCreateAccount',
+  SDKGetAllNetworkAddressesStart = 'SDKGetAllNetworkAddressesStart',
+  SDKGetAllNetworkAddressesEnd = 'SDKGetAllNetworkAddressesEnd',
   ExtensionContextMenuUpdate = 'ExtensionContextMenuUpdate',
   ShowFirmwareUpdateFromBootloaderMode = 'ShowFirmwareUpdateFromBootloaderMode',
   ShowFirmwareUpdateForce = 'ShowFirmwareUpdateForce',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new loading state and spinner to indicate device checking during batch account creation.
  - Introduced global control to enable or disable device progress dialogs for up to 10 minutes.

- **Improvements**
  - Simplified hardware UI state management for dialogs and toasts, removing complex queue and concurrency handling.
  - Enhanced progress feedback in batch account creation dialogs for clearer user experience.

- **Bug Fixes**
  - Improved reliability of UI state updates and event handling during device operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->