### PR TITLE
fix: resolve auto-update popup duplication in Native and investment details cache issue (OK-38648 OK-38643 OK-38622)

### DIFF
--- a/packages/kit-bg/src/services/ServicePassword/index.ts
+++ b/packages/kit-bg/src/services/ServicePassword/index.ts
@@ -827,7 +827,10 @@ export default class ServicePassword extends ServiceBase {
       unLock: true,
       manualLocking: false,
     }));
-    await this.backgroundApi.serviceApp.dispatchUnlockJob();
+    // Delay execution to avoid UI jank
+    setTimeout(() => {
+      void this.backgroundApi.serviceApp.dispatchUnlockJob();
+    });
   }
 
   @backgroundMethod()

--- a/packages/kit/src/components/UpdateReminder/hooks.tsx
+++ b/packages/kit/src/components/UpdateReminder/hooks.tsx
@@ -372,13 +372,13 @@ export const useAppUpdateInfo = (isFullModal = false, autoCheck = true) => {
               response?.isShowUpdateDialog &&
               isFirstLaunch
             ) {
+              isFirstLaunch = false;
               await whenAppUnlocked();
               setTimeout(() => {
                 showUpdateDialog(false, response);
               }, 200);
             }
           }
-          isFirstLaunch = false;
         },
       );
     }

--- a/packages/kit/src/states/jotai/contexts/earn/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/earn/actions.ts
@@ -18,7 +18,7 @@ import { contextAtomMethod, earnAtom, earnPermitCacheAtom } from './atoms';
 
 export const homeResettingFlags: Record<string, number> = {};
 
-class ContextJotaiActionsMarket extends ContextJotaiActionsBase {
+class ContextJotaiActionsEarn extends ContextJotaiActionsBase {
   syncToDb = contextAtomMethod((get, set, payload: IEarnAtomData) => {
     const atom = earnAtom();
     if (!get(atom).isMounted) {
@@ -125,7 +125,7 @@ class ContextJotaiActionsMarket extends ContextJotaiActionsBase {
   );
 }
 
-const createActions = memoFn(() => new ContextJotaiActionsMarket());
+const createActions = memoFn(() => new ContextJotaiActionsEarn());
 
 export function useEarnActions() {
   const actions = createActions();

--- a/packages/kit/src/utils/passwordUtils.ts
+++ b/packages/kit/src/utils/passwordUtils.ts
@@ -42,10 +42,9 @@ export const whenAppUnlocked = () => {
           setTimeout(() => {
             resolve();
           }, 100);
-          appEventBus.off(EAppEventBusNames.UnlockApp, callback);
         }
       };
-      appEventBus.on(EAppEventBusNames.UnlockApp, callback);
+      appEventBus.once(EAppEventBusNames.UnlockApp, callback);
       await backgroundApiProxy.serviceApp.addUnlockJob(unlockJobId);
     });
   });

--- a/packages/kit/src/utils/passwordUtils.ts
+++ b/packages/kit/src/utils/passwordUtils.ts
@@ -42,9 +42,10 @@ export const whenAppUnlocked = () => {
           setTimeout(() => {
             resolve();
           }, 100);
+          appEventBus.off(EAppEventBusNames.UnlockApp, callback);
         }
       };
-      appEventBus.once(EAppEventBusNames.UnlockApp, callback);
+      appEventBus.on(EAppEventBusNames.UnlockApp, callback);
       await backgroundApiProxy.serviceApp.addUnlockJob(unlockJobId);
     });
   });

--- a/packages/kit/src/views/ReferFriends/pages/YourReferred/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/YourReferred/index.tsx
@@ -148,7 +148,7 @@ function WalletList() {
               drillIn
               py="$3"
               key={index}
-              title={`Wallet ${items.length - index}`}
+              title={`Wallet ${index + 1}`}
               onPress={() => {
                 navigation.push(
                   EModalReferFriendsRoutes.YourReferredWalletAddresses,

--- a/packages/kit/src/views/Staking/pages/InvestmentDetails/index.tsx
+++ b/packages/kit/src/views/Staking/pages/InvestmentDetails/index.tsx
@@ -82,6 +82,7 @@ function BasicInvestmentDetails() {
   const navigation = useAppNavigation();
   const intl = useIntl();
   const allNetworkId = useMemo(() => getNetworkIdsMap().onekeyall, []);
+
   const { result: earnInvestmentItems = [], isLoading } = usePromiseResult(
     async () => {
       const totalFiatMapKey = actions.current.buildEarnAccountsKey(
@@ -96,14 +97,6 @@ function BasicInvestmentDetails() {
             networkId: allNetworkId,
             indexedAccountId: accountInfo.activeAccount?.indexedAccount?.id,
           });
-        const earnAccountData = actions.current.getEarnAccount(totalFiatMapKey);
-        actions.current.updateEarnAccounts({
-          key: totalFiatMapKey,
-          earnAccount: {
-            ...earnAccountData,
-            ...earnAccountOnNetwork,
-          },
-        });
         list = earnAccountOnNetwork.accounts;
       }
 

--- a/packages/kit/src/views/Staking/pages/InvestmentDetails/index.tsx
+++ b/packages/kit/src/views/Staking/pages/InvestmentDetails/index.tsx
@@ -83,12 +83,30 @@ function BasicInvestmentDetails() {
   const intl = useIntl();
   const allNetworkId = useMemo(() => getNetworkIdsMap().onekeyall, []);
   const { result: earnInvestmentItems = [], isLoading } = usePromiseResult(
-    () => {
+    async () => {
       const totalFiatMapKey = actions.current.buildEarnAccountsKey(
         accountInfo.activeAccount?.account?.id,
         allNetworkId,
       );
-      const list = earnAccount?.[totalFiatMapKey]?.accounts || [];
+      let list = earnAccount?.[totalFiatMapKey]?.accounts || [];
+      if (list.length === 0) {
+        const earnAccountOnNetwork =
+          await backgroundApiProxy.serviceStaking.fetchAllNetworkAssets({
+            accountId: accountInfo.activeAccount?.account?.id ?? '',
+            networkId: allNetworkId,
+            indexedAccountId: accountInfo.activeAccount?.indexedAccount?.id,
+          });
+        const earnAccountData = actions.current.getEarnAccount(totalFiatMapKey);
+        actions.current.updateEarnAccounts({
+          key: totalFiatMapKey,
+          earnAccount: {
+            ...earnAccountData,
+            ...earnAccountOnNetwork,
+          },
+        });
+        list = earnAccountOnNetwork.accounts;
+      }
+
       return list.length
         ? backgroundApiProxy.serviceStaking.fetchInvestmentDetail(
             list.map(({ networkId, accountAddress, publicKey }) => ({
@@ -103,6 +121,7 @@ function BasicInvestmentDetails() {
     },
     [
       accountInfo.activeAccount?.account?.id,
+      accountInfo.activeAccount?.indexedAccount?.id,
       actions,
       allNetworkId,
       earnAccount,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved app unlocking process to reduce UI lag by making certain operations asynchronous.
  - Adjusted update reminder logic to ensure the first launch flag is only reset when the update dialog is actually shown.
  - Enhanced investment details page to provide fallback data fetching when account information is missing.
  - Corrected wallet list display order in the referral section to show wallets in ascending order.

- **Refactor**
  - Renamed an internal class related to earning actions for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->