### PR TITLE
fix: fix multiple Tamagui sheets may collapse into position:relative which causes z-index stacking issues.(OK-38624)

### DIFF
--- a/packages/components/src/composite/Dialog/index.tsx
+++ b/packages/components/src/composite/Dialog/index.tsx
@@ -227,7 +227,7 @@ function DialogFrame({
         snapPointsMode="fit"
         animation="quick"
         zIndex={zIndex}
-        modal={modal}
+        modal={!platformEnv.isNative && modal === undefined ? true : modal}
         {...sheetProps}
       >
         <Sheet.Overlay

--- a/packages/components/src/composite/Dialog/index.tsx
+++ b/packages/components/src/composite/Dialog/index.tsx
@@ -227,6 +227,9 @@ function DialogFrame({
         snapPointsMode="fit"
         animation="quick"
         zIndex={zIndex}
+        // OK-36893 OK-38624
+        // When modal is false, multiple Tamagui sheets may collapse into position:relative
+        // which causes z-index stacking issues
         modal={!platformEnv.isNative && modal === undefined ? true : modal}
         {...sheetProps}
       >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved dialog behavior on larger screens to prevent stacking and z-index issues when multiple sheets are open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->