### PR TITLE
refactor: remove currency converter in Earn pages

### DIFF
--- a/packages/kit/src/components/Currency/index.tsx
+++ b/packages/kit/src/components/Currency/index.tsx
@@ -17,7 +17,7 @@ export const useCurrency = () => {
 
 export interface ICurrencyProps extends INumberSizeableTextProps {
   // btc / eth / usd / sats / hkd
-  sourceCurrency: string;
+  sourceCurrency?: string;
   targetCurrency?: string;
 }
 function BasicCurrency({
@@ -34,24 +34,25 @@ function BasicCurrency({
   const [{ currencyMap }] = useCurrencyPersistAtom();
   const [{ currencyInfo }] = useSettingsPersistAtom();
   const sourceCurrencyInfo = useMemo(
-    () => currencyMap[sourceCurrency],
-    [currencyMap, sourceCurrency],
+    () => currencyMap[sourceCurrency ?? currencyInfo.id],
+    [currencyInfo.id, currencyMap, sourceCurrency],
   );
   const targetCurrencyInfo = useMemo(
     () => currencyMap[targetCurrency ?? currencyInfo.id],
     [currencyInfo.id, currencyMap, targetCurrency],
   );
 
-  const value = useMemo(
-    () =>
-      sourceCurrencyInfo && targetCurrencyInfo
-        ? new BigNumber(String(children))
-            .div(new BigNumber(sourceCurrencyInfo.value))
-            .times(new BigNumber(targetCurrencyInfo.value))
-            .toFixed()
-        : children,
-    [children, sourceCurrencyInfo, targetCurrencyInfo],
-  );
+  const value = useMemo(() => {
+    if (sourceCurrencyInfo.id === targetCurrencyInfo.id) {
+      return BigNumber(String(children)).toFixed();
+    }
+    return sourceCurrencyInfo && targetCurrencyInfo
+      ? new BigNumber(String(children))
+          .div(new BigNumber(sourceCurrencyInfo.value))
+          .times(new BigNumber(targetCurrencyInfo.value))
+          .toFixed()
+      : children;
+  }, [children, sourceCurrencyInfo, targetCurrencyInfo]);
 
   return (
     <NumberSizeableTextWrapper

--- a/packages/kit/src/views/ReferFriends/pages/EarnReward/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/EarnReward/index.tsx
@@ -137,7 +137,6 @@ function List({
                     </SizableText>
                     <XStack ai="center" gap="$2">
                       <Currency
-                        sourceCurrency="usd"
                         color="$textSuccess"
                         formatter="value"
                         size="$bodyLgMedium"
@@ -216,11 +215,7 @@ function List({
                             <SizableText size="$bodyMd" color="$textSubdued">
                               (
                             </SizableText>
-                            <Currency
-                              sourceCurrency="usd"
-                              formatter="value"
-                              size="$bodyMd"
-                            >
+                            <Currency formatter="value" size="$bodyMd">
                               {item.token.fiatAmount}
                             </Currency>
                             <SizableText size="$bodyMd" color="$textSubdued">
@@ -470,7 +465,7 @@ export default function EarnReward() {
               id: ETranslations.referral_reward_undistributed,
             })}
           </SizableText>
-          <Currency sourceCurrency="usd" size="$heading5xl" formatter="value">
+          <Currency size="$heading5xl" formatter="value">
             {amount?.pending || 0}
           </Currency>
         </YStack>

--- a/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/index.tsx
@@ -166,7 +166,6 @@ export default function HardwareSalesReward() {
             </YStack>
             <XStack>
               <Currency
-                sourceCurrency="usd"
                 numberOfLines={1}
                 formatter="balance"
                 formatterOptions={{
@@ -245,12 +244,7 @@ export default function HardwareSalesReward() {
                   </SizableText>
                   <XStack gap="$2" ai="center">
                     {Number(amount.available) > 0 ? (
-                      <Currency
-                        sourceCurrency="usd"
-                        formatter="value"
-                        size="$heading5xl"
-                        pr="$0.5"
-                      >
+                      <Currency formatter="value" size="$heading5xl" pr="$0.5">
                         {amount.available}
                       </Currency>
                     ) : (
@@ -271,7 +265,6 @@ export default function HardwareSalesReward() {
                   {Number(amount.pending) > 0 ? (
                     <XStack gap="$1">
                       <Currency
-                        sourceCurrency="usd"
                         formatter="value"
                         formatterOptions={{
                           currency: settings.currencyInfo.symbol,

--- a/packages/kit/src/views/ReferFriends/pages/InviteReward/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/InviteReward/index.tsx
@@ -261,7 +261,6 @@ function RewardLevelMoney({
       />
       {threshold ? (
         <Currency
-          sourceCurrency="usd"
           formatter="balance"
           textAlign={isRight ? 'right' : undefined}
           size="$bodySmMedium"
@@ -409,7 +408,6 @@ function Dashboard({
               renderTrigger={
                 <Currency
                   pb={1}
-                  sourceCurrency="usd"
                   color="$textSuccess"
                   formatter="value"
                   size="$bodyLgMedium"
@@ -635,7 +633,6 @@ function Dashboard({
                         <Currency
                           formatter="value"
                           size="$bodyMd"
-                          sourceCurrency="usd"
                           color="$textSubdued"
                         >
                           {fiatValue}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated currency conversion logic to handle cases where the source and target currencies are the same, improving calculation efficiency.
  - Made the source currency property optional in the currency display component.
  - Removed explicit source currency settings from various reward-related pages for a more streamlined implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->