### PR TITLE
OK-38662: add new networks (World Chain, HyperEVM, Monad Testnet) to presetNetworks

### DIFF
--- a/packages/shared/src/config/presetNetworks.ts
+++ b/packages/shared/src/config/presetNetworks.ts
@@ -1783,6 +1783,90 @@ const unichain: IServerNetwork = {
   'backendIndex': false,
 };
 
+const worldChain: IServerNetwork = {
+  'impl': 'evm',
+  'chainId': '480',
+  'id': 'evm--480',
+  'name': 'World Chain',
+  'symbol': 'ETH',
+  'code': 'worldchain',
+  'shortcode': 'worldchain',
+  'shortname': 'worldchain',
+  'decimals': 18,
+  'feeMeta': {
+    'decimals': 9,
+    'symbol': 'Gwei',
+    'isEIP1559FeeEnabled': false,
+    'isWithL1BaseFee': true,
+  },
+  'status': ENetworkStatus.LISTED,
+  'isTestnet': false,
+  'extensions': {
+    'position': 999,
+    'isTokenSupported': true,
+    'isNFTEnabled': false,
+  },
+  'logoURI': 'https://uni.onekey-asset.com/static/chain/world-chain.png',
+  'defaultEnabled': false,
+  'backendIndex': false,
+};
+
+const hyperEvm: IServerNetwork = {
+  'impl': 'evm',
+  'chainId': '999',
+  'id': 'evm--999',
+  'name': 'HyperEVM',
+  'symbol': 'HYPE',
+  'code': 'hyperevm',
+  'shortcode': 'hyperevm',
+  'shortname': 'hyperevm',
+  'decimals': 18,
+  'feeMeta': {
+    'decimals': 9,
+    'symbol': 'Gwei',
+    'isEIP1559FeeEnabled': false,
+    'isWithL1BaseFee': false,
+  },
+  'status': ENetworkStatus.LISTED,
+  'isTestnet': false,
+  'extensions': {
+    'position': 999,
+    'isTokenSupported': true,
+    'isNFTEnabled': false,
+  },
+  'logoURI': 'https://uni.onekey-asset.com/static/chain/hyper-evm.png',
+  'defaultEnabled': false,
+  'backendIndex': false,
+};
+
+const monadTestnet: IServerNetwork = {
+  'impl': 'evm',
+  'chainId': '10143',
+  'id': 'evm--10143',
+  'name': 'Monad Testnet',
+  'symbol': 'TMON',
+  'code': 'tmon',
+  'shortcode': 'tmon',
+  'shortname': 'tmon',
+  'decimals': 18,
+  'feeMeta': {
+    'decimals': 9,
+    'symbol': 'Gwei',
+    'isEIP1559FeeEnabled': false,
+    'isWithL1BaseFee': false,
+  },
+  'status': ENetworkStatus.LISTED,
+  'isTestnet': true,
+  'extensions': {
+    'position': 9999,
+    'isTokenSupported': false,
+    'isNFTEnabled': false,
+  },
+  'logoURI': 'https://uni.onekey-asset.com/static/chain/monad-testnet.png',
+  'defaultEnabled': false,
+  'backendIndex': false,
+};
+
 const btc: IServerNetwork = {
   'chainId': '0',
   'code': 'btc',
@@ -2997,6 +3081,9 @@ export const getPresetNetworks = memoFn((): IServerNetwork[] => {
     berachain,
     sei,
     unichain,
+    worldChain,
+    hyperEvm,
+    monadTestnet,
 
     // cosmos
     celestia,


### PR DESCRIPTION
…et) to presetNetworks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for three new EVM-based networks: World Chain, HyperEVM, and Monad Testnet. These networks are now available in the preset networks list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->