### PR TITLE
OK-38657: Correct Earn account sceneName

### DIFF
--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -1027,12 +1027,12 @@ export default function EarnHome() {
   return (
     <AccountSelectorProviderMirror
       config={{
-        sceneName: EAccountSelectorSceneName.swap,
+        sceneName: EAccountSelectorSceneName.home,
         sceneUrl: '',
       }}
       enabledNum={[0]}
     >
-      <EarnProviderMirror storeName={EJotaiContextStoreNames.swap}>
+      <EarnProviderMirror storeName={EJotaiContextStoreNames.earn}>
         <BasicEarnHome />
       </EarnProviderMirror>
     </AccountSelectorProviderMirror>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal context configuration for the EarnHome screen to align with the "home" scene and "earn" store, improving consistency in account selection and state management. No changes to visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->