### PR TITLE
fix: account value error & disable auto create ltc account OK-38158

### DIFF
--- a/packages/kit-bg/src/services/ServiceAccount/defaultNetworkAccountsConfig.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/defaultNetworkAccountsConfig.ts
@@ -170,7 +170,6 @@ export async function buildDefaultAddAccountNetworks(
     evm: true,
     tron: true,
     sol: true,
-    ltc: true,
   });
   return networks;
 }

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAccountListItem.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAccountListItem.tsx
@@ -204,6 +204,7 @@ export function AccountSelectorAccountListItem({
                 })
               : '',
           accountId: currentNetworkAccounts[0].id,
+          mergeDeriveAssetsEnabled: vaultSettings.mergeDeriveAssetsEnabled,
         };
       }
     }
@@ -320,12 +321,16 @@ export function AccountSelectorAccountListItem({
           isOthersUniversal={isOthersUniversal}
           index={index}
           accountValue={accountValue}
+          indexedAccountId={indexedAccount?.id}
           linkedAccountId={
             indexedAccount?.associateAccount?.id ??
             currentNetworkAccount?.accountId ??
             item.id
           }
           linkedNetworkId={avatarNetworkId ?? network?.id}
+          mergeDeriveAssetsEnabled={
+            currentNetworkAccount?.mergeDeriveAssetsEnabled
+          }
         />
         {currentNetworkAccount?.address || subTitleInfo.address ? (
           <Stack
@@ -342,10 +347,12 @@ export function AccountSelectorAccountListItem({
     linkNetwork,
     currentNetworkAccount?.address,
     currentNetworkAccount?.accountId,
+    currentNetworkAccount?.mergeDeriveAssetsEnabled,
     subTitleInfo.address,
     isOthersUniversal,
     index,
     accountValue,
+    indexedAccount?.id,
     indexedAccount?.associateAccount?.id,
     item.id,
     avatarNetworkId,

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountValue.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountValue.tsx
@@ -28,8 +28,6 @@ function AccountValue(accountValue: {
     return accountValue;
   }, [accountValue, activeAccountValue, isActiveAccount]);
 
-  console.log('accountValue', accountValue);
-
   const accountValueString = useMemo(() => {
     if (typeof value === 'string') {
       return value;

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountValue.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountValue.tsx
@@ -14,6 +14,8 @@ function AccountValue(accountValue: {
   value: Record<string, string> | string;
   linkedAccountId?: string;
   linkedNetworkId?: string;
+  indexedAccountId?: string;
+  mergeDeriveAssetsEnabled?: boolean;
 }) {
   const [activeAccountValue] = useActiveAccountValueAtom();
   const isActiveAccount =
@@ -26,18 +28,34 @@ function AccountValue(accountValue: {
     return accountValue;
   }, [accountValue, activeAccountValue, isActiveAccount]);
 
+  console.log('accountValue', accountValue);
+
   const accountValueString = useMemo(() => {
     if (typeof value === 'string') {
       return value;
     }
 
-    const { linkedAccountId, linkedNetworkId } = accountValue;
+    const {
+      linkedAccountId,
+      linkedNetworkId,
+      indexedAccountId,
+      mergeDeriveAssetsEnabled,
+    } = accountValue;
 
     if (
       linkedAccountId &&
       linkedNetworkId &&
       !networkUtils.isAllNetwork({ networkId: linkedNetworkId })
     ) {
+      if (mergeDeriveAssetsEnabled && indexedAccountId) {
+        return value[
+          accountUtils.buildAccountValueKey({
+            accountId: indexedAccountId,
+            networkId: linkedNetworkId,
+          })
+        ];
+      }
+
       return value[
         accountUtils.buildAccountValueKey({
           accountId: linkedAccountId,
@@ -79,6 +97,8 @@ function AccountValueWithSpotlight({
   accountValue,
   linkedAccountId,
   linkedNetworkId,
+  indexedAccountId,
+  mergeDeriveAssetsEnabled,
 }: {
   accountValue:
     | {
@@ -91,6 +111,8 @@ function AccountValueWithSpotlight({
   index: number;
   linkedAccountId?: string;
   linkedNetworkId?: string;
+  indexedAccountId?: string;
+  mergeDeriveAssetsEnabled?: boolean;
 }) {
   return accountValue && accountValue.currency ? (
     <AccountValue
@@ -99,6 +121,8 @@ function AccountValueWithSpotlight({
       value={accountValue.value ?? ''}
       linkedAccountId={linkedAccountId}
       linkedNetworkId={linkedNetworkId}
+      indexedAccountId={indexedAccountId}
+      mergeDeriveAssetsEnabled={mergeDeriveAssetsEnabled}
     />
   ) : (
     <NumberSizeableTextWrapper

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -135,7 +135,8 @@ function HomeOverviewContainer() {
       account &&
       network &&
       accountWorth.initialized &&
-      account.id === accountWorth.accountId
+      (account.id === accountWorth.accountId ||
+        account.indexedAccountId === accountWorth.accountId)
     ) {
       if (accountUtils.isOthersAccount({ accountId: account.id })) {
         if (!network.isAllNetworks && account.createAtNetwork !== network.id)

--- a/packages/kit/src/views/Home/pages/TokenListContainer.tsx
+++ b/packages/kit/src/views/Home/pages/TokenListContainer.tsx
@@ -1286,11 +1286,15 @@ function TokenListContainer(_props: ITabPageProps) {
         }
       } else {
         updateAccountWorth({
-          accountId,
+          accountId: mergeDeriveAddressData
+            ? indexedAccount?.id ?? ''
+            : account?.id ?? '',
           initialized: true,
           worth: {
             [accountUtils.buildAccountValueKey({
-              accountId,
+              accountId: mergeDeriveAddressData
+                ? indexedAccount?.id ?? ''
+                : account?.id ?? '',
               networkId,
             })]: tokenListValue,
           },

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchAddressItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchAddressItem.tsx
@@ -4,6 +4,7 @@ import { SizableText, Stack, XStack } from '@onekeyhq/components';
 import { AccountAvatar } from '@onekeyhq/kit/src/components/AccountAvatar';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { NetworkAvatar } from '@onekeyhq/kit/src/components/NetworkAvatar';
+import { useAccountData } from '@onekeyhq/kit/src/hooks/useAccountData';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useAccountSelectorActions } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import { useUniversalSearchActions } from '@onekeyhq/kit/src/states/jotai/contexts/universalSearch';
@@ -27,6 +28,10 @@ export function UniversalSearchAddressItem({
   const navigation = useAppNavigation();
   const accountSelectorActions = useAccountSelectorActions();
   const universalSearchActions = useUniversalSearchActions();
+
+  const { vaultSettings } = useAccountData({
+    networkId: item.payload.network?.id,
+  });
 
   const handleAccountPress = useCallback(async () => {
     navigation.pop();
@@ -143,6 +148,8 @@ export function UniversalSearchAddressItem({
           accountValue={item.payload.accountsValue}
           linkedAccountId={item.payload.account?.id}
           linkedNetworkId={item.payload.network?.id}
+          indexedAccountId={item.payload.indexedAccount?.id}
+          mergeDeriveAssetsEnabled={vaultSettings?.mergeDeriveAssetsEnabled}
         />
         {item.payload.addressInfo?.displayAddress ? (
           <Stack
@@ -156,10 +163,12 @@ export function UniversalSearchAddressItem({
       </>
     );
   }, [
-    item.payload.accountsValue,
-    item.payload.addressInfo?.displayAddress,
     item.payload.account?.id,
+    item.payload.accountsValue,
     item.payload.network?.id,
+    item.payload.indexedAccount?.id,
+    item.payload.addressInfo?.displayAddress,
+    vaultSettings?.mergeDeriveAssetsEnabled,
   ]);
 
   if (item.payload.account || item.payload.isSearchedByAccountName) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying account values based on a new "merge derive assets" setting, enhancing how account information is shown in various views.
  - Improved account value display logic to support accounts identified by an additional indexed account ID.

- **Bug Fixes**
  - Updated logic to ensure account worth updates and token list data initialization work correctly with merged or derived accounts.

- **Other Changes**
  - Litecoin networks are no longer included by default when adding new accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->