### PR TITLE
feat: enable querying all staking amount without addresses on supported chains

### DIFF
--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -686,11 +686,11 @@ function BasicEarnHome() {
     run: refreshOverViewData,
   } = usePromiseResult(
     async () => {
-      if (!account) {
+      if (!account && !indexedAccount) {
         return;
       }
       const totalFiatMapKey = actions.current.buildEarnAccountsKey(
-        account.id,
+        account?.id || indexedAccount?.id,
         allNetworkId,
       );
       let assets = actions.current.getAvailableAssets();
@@ -706,14 +706,14 @@ function BasicEarnHome() {
       }
 
       const fetchAndUpdateAction = async () => {
-        if (!account) {
+        if (!account && !indexedAccount) {
           return;
         }
         const earnAccount =
           await backgroundApiProxy.serviceStaking.fetchAllNetworkAssets({
             accountId: account?.id ?? '',
             networkId: allNetworkId,
-            indexedAccountId: account?.indexedAccountId,
+            indexedAccountId: account?.indexedAccountId || indexedAccount?.id,
           });
         const earnAccountData = actions.current.getEarnAccount(totalFiatMapKey);
         actions.current.updateEarnAccounts({
@@ -725,7 +725,7 @@ function BasicEarnHome() {
         });
       };
       const fetchAndUpdateOverview = async () => {
-        if (!account) {
+        if (!account && !indexedAccount) {
           return;
         }
         const overviewData =
@@ -733,7 +733,7 @@ function BasicEarnHome() {
             assets,
             accountId: account?.id ?? '',
             networkId: allNetworkId,
-            indexedAccountId: account?.indexedAccountId,
+            indexedAccountId: account?.indexedAccountId || indexedAccount?.id,
           });
         const earnAccountData = actions.current.getEarnAccount(totalFiatMapKey);
         actions.current.updateEarnAccounts({
@@ -758,7 +758,7 @@ function BasicEarnHome() {
       }
       return { loaded: true };
     },
-    [actions, account, allNetworkId],
+    [actions, account, allNetworkId, indexedAccount],
     {
       watchLoading: true,
       pollingInterval: timerUtils.getTimeDurationMs({ minute: 3 }),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data fetching in the Earn Home view to support scenarios where either an account or an indexed account is present, ensuring more reliable display of earning and staking information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->