### PR TITLE
 fix: qr wallet options OK-39003 OK-39004 

### DIFF
--- a/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/HiddenWalletRememberSwitch.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/HiddenWalletRememberSwitch.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import type { IIconProps, ISizableTextProps } from '@onekeyhq/components';
+import {
+  ESwitchSize,
+  Icon,
+  Spinner,
+  Stack,
+  Switch,
+} from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src//background/instance/backgroundApiProxy';
+import type { IListItemProps } from '@onekeyhq/kit/src/components/ListItem';
+import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
+import type { IDBWallet } from '@onekeyhq/kit-bg/src/dbs/local/types';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+
+function WalletOptionItem({
+  label,
+  description,
+  icon,
+  iconColor = '$iconSubdued',
+  isLoading,
+  children,
+  drillIn,
+  testID,
+  ...rest
+}: Omit<IListItemProps, 'icon'> & {
+  label: ISizableTextProps['children'];
+  description?: string;
+  labelColor?: ISizableTextProps['color'];
+  icon?: IIconProps['name'];
+  iconColor?: IIconProps['color'];
+  isLoading?: boolean;
+  drillIn?: boolean;
+  testID?: string;
+}) {
+  return (
+    <ListItem userSelect="none" testID={testID} {...rest}>
+      {icon ? (
+        <Stack px="$2">
+          <Icon name={icon} color={iconColor} />
+        </Stack>
+      ) : null}
+      <ListItem.Text primary={label} secondary={description} flex={1} />
+      {children}
+      {isLoading ? <Spinner /> : null}
+    </ListItem>
+  );
+}
+
+export function HiddenWalletRememberSwitch({
+  wallet,
+}: {
+  wallet: IDBWallet | undefined;
+}) {
+  const [val, setVal] = useState(!wallet?.isTemp);
+  const intl = useIntl();
+
+  return (
+    <WalletOptionItem
+      key={wallet?.id}
+      label={intl.formatMessage({
+        id: ETranslations.form_keep_hidden_wallet_label,
+      })}
+      description={intl.formatMessage({
+        id: ETranslations.form_keep_hidden_wallet_label_desc,
+      })}
+      drillIn={false}
+    >
+      <Switch
+        size={ESwitchSize.small}
+        value={val}
+        onChange={async () => {
+          if (!wallet?.id) {
+            return;
+          }
+          const newVal = !val;
+          try {
+            await backgroundApiProxy.serviceAccount.setWalletTempStatus({
+              walletId: wallet?.id,
+              isTemp: !newVal,
+            });
+            setVal(newVal);
+          } catch (error) {
+            setVal(val);
+            throw error;
+          }
+        }}
+      />
+    </WalletOptionItem>
+  );
+}

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAddAccountButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAddAccountButton.tsx
@@ -267,6 +267,9 @@ export function AccountSelectorAddAccountButton({
   );
 
   const canBatchCreateAccount = useMemo(() => {
+    if (accountUtils.isQrWallet({ walletId: focusedWalletInfo?.wallet?.id })) {
+      return false;
+    }
     return (
       accountUtils.isHdWallet({ walletId: focusedWalletInfo?.wallet?.id }) ||
       accountUtils.isHwOrQrWallet({ walletId: focusedWalletInfo?.wallet?.id })

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/index.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/index.tsx
@@ -44,6 +44,7 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 
+import { HiddenWalletRememberSwitch } from '../../../components/WalletEdit/HiddenWalletRememberSwitch';
 import { useAccountSelectorRoute } from '../../../router/useAccountSelectorRoute';
 
 import { AccountSelectorAccountListItem } from './AccountSelectorAccountListItem';
@@ -360,6 +361,7 @@ function WalletDetailsView({ num }: IWalletDetailsProps) {
   // useCallback cause re-render when unmount, but useMemo not
   const sectionListMemo = useMemo(() => {
     const isMockedStandardHwWallet = focusedWalletInfo?.wallet?.isMocked;
+    const isHiddenWallet = !!focusedWalletInfo?.wallet?.passphraseState;
     let sectionListView: React.ReactNode | null = null;
     const renderSectionListHeader = () => (
       <Stack>
@@ -432,6 +434,9 @@ function WalletDetailsView({ num }: IWalletDetailsProps) {
               </Button>
             ) : null}
           </XStack>
+        ) : null}
+        {isHiddenWallet && editMode ? (
+          <HiddenWalletRememberSwitch wallet={focusedWalletInfo?.wallet} />
         ) : null}
       </Stack>
     );


### PR DESCRIPTION
…t state

- Introduced HiddenWalletRememberSwitch component for toggling hidden wallet status.
- Integrated the component into WalletDetails view, displaying it conditionally based on wallet state.
- Updated AccountSelectorAddAccountButton to prevent batch account creation for QR wallets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a toggle switch in the wallet details view for hidden wallets, allowing users to mark a wallet as temporary or not when in edit mode.

- **Bug Fixes**
  - Batch account creation is now disabled for QR wallets to prevent unintended actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->