### PR TITLE
fix: mas Desktop IAP test

### DIFF
--- a/apps/desktop/app/app.ts
+++ b/apps/desktop/app/app.ts
@@ -41,6 +41,7 @@ import type {
 import appDevOnlyApi from './appDevOnlyApi';
 import appNotification from './appNotification';
 import appPermission from './appPermission';
+import appIAP from './appIAP';
 import { ipcMessageKeys } from './config';
 import { ETranslations, i18nText, initLocale } from './i18n';
 import { registerShortcuts, unregisterShortcuts } from './libs/shortcuts';
@@ -605,6 +606,7 @@ function createMainWindow() {
   appNotification.init(subModuleInitParams);
   appPermission.init(subModuleInitParams);
   appDevOnlyApi.init(subModuleInitParams);
+  appIAP.init(subModuleInitParams);
 
   ipcMain.on(ipcMessageKeys.APP_TOGGLE_MAXIMIZE_WINDOW, () => {
     const safelyBrowserWindow = getSafelyBrowserWindow();

--- a/apps/desktop/app/appIAP.ts
+++ b/apps/desktop/app/appIAP.ts
@@ -1,0 +1,47 @@
+import { inAppPurchase } from 'electron';
+
+import type { IDesktopSubModuleInitParams } from '@onekeyhq/shared/types/desktop';
+
+async function testIAP() {
+  const canMakePayments = inAppPurchase.canMakePayments();
+  console.log('inAppPurchase___canMakePayments', canMakePayments);
+
+  // node_modules/electron/dist/Electron.app/Contents/Info.plist
+  // <key>CFBundleIdentifier</key>
+  // <string>so.onekey.wallet</string>
+  const productIDs: string[] = [
+    'Prime_Yearly',
+    'Prime_Monthly',
+    'so.onekey.wallet.Prime_Yearly',
+    'so.onekey.wallet.Prime_Monthly',
+  ];
+  const products = await inAppPurchase.getProducts(productIDs);
+  console.log('inAppPurchase___products', products);
+  console.log('inAppPurchase___products.length', products.length);
+}
+
+function init(_initParams: IDesktopSubModuleInitParams) {
+  setTimeout(() => {
+    void testIAP();
+  }, 5000);
+
+  // ipcMain.on(
+  //   ipcMessageKeys.APP_DEV_ONLY_API,
+  //   (event, apiParams: IDesktopMainProcessDevOnlyApiParams) => {
+  //     if (process.env.NODE_ENV !== 'production') {
+  //       const { module, method, params } = apiParams;
+  //       console.log('call APP_DEV_ONLY_API::', module, method, params);
+  //       if (module === 'shell') {
+  //         // @ts-ignore
+  //         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  //         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  //         shell[method](...params);
+  //       }
+  //     }
+  //   },
+  // );
+}
+
+export default {
+  init,
+};

--- a/apps/desktop/app/appIAP.ts
+++ b/apps/desktop/app/appIAP.ts
@@ -1,6 +1,13 @@
-import { inAppPurchase } from 'electron';
+import { inAppPurchase, ipcMain } from 'electron';
 
 import type { IDesktopSubModuleInitParams } from '@onekeyhq/shared/types/desktop';
+
+import { ipcMessageKeys } from './config';
+
+import type {
+  IDesktopIAPGetProductsParams,
+  IDesktopIAPGetProductsResult,
+} from './config';
 
 async function testIAP() {
   const canMakePayments = inAppPurchase.canMakePayments();
@@ -15,31 +22,39 @@ async function testIAP() {
     'so.onekey.wallet.Prime_Yearly',
     'so.onekey.wallet.Prime_Monthly',
   ];
-  const products = await inAppPurchase.getProducts(productIDs);
+  const products: Electron.Product[] = await inAppPurchase.getProducts(
+    productIDs,
+  );
   console.log('inAppPurchase___products', products);
   console.log('inAppPurchase___products.length', products.length);
 }
 
 function init(_initParams: IDesktopSubModuleInitParams) {
-  setTimeout(() => {
-    void testIAP();
-  }, 5000);
+  ipcMain.on(
+    ipcMessageKeys.IAP_GET_PRODUCTS,
+    async (event, apiParams: IDesktopIAPGetProductsParams) => {
+      if (process.env.NODE_ENV !== 'production') {
+        void testIAP();
+      }
+      if (process.platform === 'darwin') {
+        const canMakePayments = inAppPurchase.canMakePayments();
+        const products: Electron.Product[] = await inAppPurchase.getProducts(
+          apiParams.productIDs,
+        );
+        const result: IDesktopIAPGetProductsResult = {
+          canMakePayments,
+          products,
+        };
+        return event.reply(ipcMessageKeys.IAP_GET_PRODUCTS, result);
+      }
 
-  // ipcMain.on(
-  //   ipcMessageKeys.APP_DEV_ONLY_API,
-  //   (event, apiParams: IDesktopMainProcessDevOnlyApiParams) => {
-  //     if (process.env.NODE_ENV !== 'production') {
-  //       const { module, method, params } = apiParams;
-  //       console.log('call APP_DEV_ONLY_API::', module, method, params);
-  //       if (module === 'shell') {
-  //         // @ts-ignore
-  //         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-  //         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-  //         shell[method](...params);
-  //       }
-  //     }
-  //   },
-  // );
+      const result: IDesktopIAPGetProductsResult = {
+        canMakePayments: false,
+        products: [],
+      };
+      return event.reply(ipcMessageKeys.IAP_GET_PRODUCTS, result);
+    },
+  );
 }
 
 export default {

--- a/apps/desktop/app/appIAP.ts
+++ b/apps/desktop/app/appIAP.ts
@@ -3,6 +3,7 @@ import { inAppPurchase, ipcMain } from 'electron';
 import type { IDesktopSubModuleInitParams } from '@onekeyhq/shared/types/desktop';
 
 import { ipcMessageKeys } from './config';
+import { getMacAppId } from './libs/utils';
 
 import type {
   IDesktopIAPGetProductsParams,
@@ -41,18 +42,27 @@ function init(_initParams: IDesktopSubModuleInitParams) {
         const products: Electron.Product[] = await inAppPurchase.getProducts(
           apiParams.productIDs,
         );
+        // get app bundleId
+        const bundleId = getMacAppId();
+        console.log('App Bundle ID:', bundleId);
+
         const result: IDesktopIAPGetProductsResult = {
+          bundleId,
           canMakePayments,
           products,
+          productIDs: apiParams.productIDs,
         };
-        return event.reply(ipcMessageKeys.IAP_GET_PRODUCTS, result);
+        event.returnValue = result;
+        return;
       }
 
       const result: IDesktopIAPGetProductsResult = {
+        bundleId: '',
         canMakePayments: false,
         products: [],
+        productIDs: [],
       };
-      return event.reply(ipcMessageKeys.IAP_GET_PRODUCTS, result);
+      event.returnValue = result;
     },
   );
 }

--- a/apps/desktop/app/config.ts
+++ b/apps/desktop/app/config.ts
@@ -22,7 +22,9 @@ export type IDesktopIAPGetProductsParams = {
   productIDs: string[];
 };
 export type IDesktopIAPGetProductsResult = {
+  bundleId: string;
   canMakePayments: boolean;
+  productIDs: string[];
   products: Electron.Product[];
 };
 

--- a/apps/desktop/app/config.ts
+++ b/apps/desktop/app/config.ts
@@ -1,3 +1,4 @@
+/* eslint-disable spellcheck/spell-checker */
 import type { Contexts } from '@sentry/core';
 import type { Systeminformation } from 'systeminformation';
 
@@ -15,6 +16,14 @@ export type IDesktopSystemInfo = {
   cpu: Systeminformation.CpuData;
   os: Systeminformation.OsData;
   sentryContexts: Contexts;
+};
+
+export type IDesktopIAPGetProductsParams = {
+  productIDs: string[];
+};
+export type IDesktopIAPGetProductsResult = {
+  canMakePayments: boolean;
+  products: Electron.Product[];
 };
 
 export const ipcMessageKeys = {
@@ -123,4 +132,13 @@ export const ipcMessageKeys = {
   NOTIFICATION_GET_PERMISSION: 'notification/getPermission',
   NOTIFICATION_SET_BADGE: 'notification/setBadge',
   NOTIFICATION_SET_BADGE_WINDOWS: 'notification/setBadge/windows',
+
+  // IAP
+  IAP_GET_PRODUCTS: 'iap/getProducts',
+  // IAP_CAN_MAKE_PAYMENTS: 'iap/canMakePayments',
+  // IAP_BUY_PRODUCT: 'iap/buyProduct',
+  // IAP_GET_PROMOTION_RIGHTS: 'iap/getPromotionRights',
+  // IAP_GET_PROMOTION_RIGHTS_STATUS: 'iap/getPromotionRightsStatus',
+  // IAP_GET_PROMOTION_RIGHTS_STATUS_RES: 'iap/getPromotionRightsStatus/res',
+  // IAP_GET_PROMOTION_RIGHTS_STATUS_ERROR: 'iap/getPromotionRightsStatus/error',
 };

--- a/apps/desktop/app/preload.ts
+++ b/apps/desktop/app/preload.ts
@@ -22,7 +22,7 @@ import type {
 
 import { ipcMessageKeys } from './config';
 
-import type { IDesktopSystemInfo } from './config';
+import type { IDesktopIAPGetProductsResult, IDesktopIAPGetProductsParams, IDesktopSystemInfo } from './config';
 import type { IMacBundleInfo } from './libs/utils';
 
 export interface IVerifyUpdateParams {
@@ -134,6 +134,9 @@ export type IDesktopAPI = {
   callDevOnlyApi: (params: IDesktopMainProcessDevOnlyApiParams) => any;
   openLoggerFile: () => void;
   testCrash: () => void;
+  iapGetProducts: (
+    params: IDesktopIAPGetProductsParams,
+  ) => Promise<IDesktopIAPGetProductsResult>;
 };
 declare global {
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -463,6 +466,8 @@ const desktopApi = Object.freeze({
     ipcRenderer.sendSync(ipcMessageKeys.NOTIFICATION_GET_PERMISSION),
   callDevOnlyApi: (params: IDesktopMainProcessDevOnlyApiParams) =>
     ipcRenderer.sendSync(ipcMessageKeys.APP_DEV_ONLY_API, params),
+  iapGetProducts: (params: IDesktopIAPGetProductsParams) =>
+    ipcRenderer.sendSync(ipcMessageKeys.IAP_GET_PRODUCTS, params),
 });
 
 globalThis.desktopApi = desktopApi;

--- a/apps/desktop/app/preload.ts
+++ b/apps/desktop/app/preload.ts
@@ -22,7 +22,11 @@ import type {
 
 import { ipcMessageKeys } from './config';
 
-import type { IDesktopIAPGetProductsResult, IDesktopIAPGetProductsParams, IDesktopSystemInfo } from './config';
+import type {
+  IDesktopIAPGetProductsParams,
+  IDesktopIAPGetProductsResult,
+  IDesktopSystemInfo,
+} from './config';
 import type { IMacBundleInfo } from './libs/utils';
 
 export interface IVerifyUpdateParams {
@@ -466,7 +470,7 @@ const desktopApi = Object.freeze({
     ipcRenderer.sendSync(ipcMessageKeys.NOTIFICATION_GET_PERMISSION),
   callDevOnlyApi: (params: IDesktopMainProcessDevOnlyApiParams) =>
     ipcRenderer.sendSync(ipcMessageKeys.APP_DEV_ONLY_API, params),
-  iapGetProducts: (params: IDesktopIAPGetProductsParams) =>
+  iapGetProducts: async (params: IDesktopIAPGetProductsParams) =>
     ipcRenderer.sendSync(ipcMessageKeys.IAP_GET_PRODUCTS, params),
 });
 

--- a/packages/kit/src/provider/Bootstrap.tsx
+++ b/packages/kit/src/provider/Bootstrap.tsx
@@ -449,8 +449,9 @@ export const useLaunchEvents = (): void => {
   }, [isLocked]);
 };
 
-const getBuilderNumber = (builderNumber?: string) =>
-  builderNumber ? Number(builderNumber.split('-')[0]) : -1;
+const getBuilderNumber = (builderNumber?: string) => {
+  return builderNumber ? Number(builderNumber.split('-')[0]) : -1;
+};
 export const useCheckUpdateOnDesktop =
   platformEnv.isDesktop &&
   !platformEnv.isMas &&

--- a/packages/kit/src/views/Setting/pages/List/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/List/DevSettingsSection/index.tsx
@@ -800,6 +800,19 @@ export const DevSettingsSection = () => {
           });
         }}
       />
+
+      <SectionPressItem
+        title="In-App-Purchase(Mac)"
+        subtitle="设备信息"
+        onPress={async () => {
+          const products = await desktopApi.iapGetProducts({
+            productIDs: ['Prime_Yearly', 'Prime_Monthly'],
+          });
+          Dialog.debugMessage({
+            debugMessage: products,
+          });
+        }}
+      />
     </Section>
   );
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for fetching in-app purchase (IAP) product details on Mac desktop environments.
  - Introduced a developer tool in the settings to display IAP product information for debugging purposes.

- **Bug Fixes**
  - None.

- **Documentation**
  - None.

- **Refactor**
  - None.

- **Style**
  - None.

- **Tests**
  - None.

- **Chores**
  - None.

- **Revert**
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->