### PR TITLE
Fix/account selector bugs

### DIFF
--- a/apps/desktop/app/app.ts
+++ b/apps/desktop/app/app.ts
@@ -39,9 +39,9 @@ import type {
 } from '@onekeyhq/shared/types/desktop';
 
 import appDevOnlyApi from './appDevOnlyApi';
+import appIAP from './appIAP';
 import appNotification from './appNotification';
 import appPermission from './appPermission';
-import appIAP from './appIAP';
 import { ipcMessageKeys } from './config';
 import { ETranslations, i18nText, initLocale } from './i18n';
 import { registerShortcuts, unregisterShortcuts } from './libs/shortcuts';

--- a/packages/kit-bg/src/dbs/local/LocalDbBase.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.ts
@@ -1180,7 +1180,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
       (await this.getWalletSafe({
         walletId,
       }));
-    if (wallet) {
+    if (wallet && !wallet?.isMocked) {
       // TODO performance
       const allIndexedAccounts0 =
         allIndexedAccounts ||
@@ -2487,7 +2487,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
     return this.buildCreateHDAndHWWalletResult({
       walletId: dbWalletId,
       addedHdAccountIndex,
-      isOverrideWallet: Boolean(existingWallet),
+      isOverrideWallet: Boolean(existingWallet && !existingWallet?.isMocked),
       // isOverrideWallet: existingWallet && !isExistingHiddenWallet,
     });
   }
@@ -2849,7 +2849,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
     return this.buildCreateHDAndHWWalletResult({
       walletId: dbWalletId,
       addedHdAccountIndex,
-      isOverrideWallet: Boolean(existingWallet),
+      isOverrideWallet: Boolean(existingWallet && !existingWallet?.isMocked),
       // isOverrideWallet: existingWallet && !isExistingHiddenWallet,
     });
   }

--- a/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts
+++ b/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts
@@ -827,10 +827,19 @@ class ServiceHardware extends ServiceBase {
   async setPassphraseEnabled(p: ISetPassphraseEnabledParams) {
     const result = await this.deviceSettingsManager.setPassphraseEnabled(p);
     if (result.message) {
-      const wallet = await this.backgroundApi.serviceAccount.getWalletSafe({
-        walletId: p.walletId,
-      });
-      const dbDeviceId = wallet?.associatedDevice;
+      let dbDeviceId: string | undefined;
+      if (p.walletId) {
+        const wallet = await this.backgroundApi.serviceAccount.getWalletSafe({
+          walletId: p.walletId,
+        });
+        dbDeviceId = wallet?.associatedDevice;
+      } else {
+        const device = await localDb.getDeviceByQuery({
+          connectId: p.connectId,
+          featuresDeviceId: p.featuresDeviceId,
+        });
+        dbDeviceId = device?.id;
+      }
       if (dbDeviceId) {
         await localDb.updateDeviceFeaturesPassphraseProtection({
           dbDeviceId,

--- a/packages/kit/src/provider/Container/GlobalErrorHandlerContainer/GlobalErrorHandlerContainer.tsx
+++ b/packages/kit/src/provider/Container/GlobalErrorHandlerContainer/GlobalErrorHandlerContainer.tsx
@@ -1,0 +1,69 @@
+import { useEffect } from 'react';
+
+import { Anchor, Dialog, Stack } from '@onekeyhq/components';
+import { globalErrorHandler } from '@onekeyhq/shared/src/errors/globalErrorHandler';
+import {
+  EOneKeyErrorClassNames,
+  type IOneKeyError,
+} from '@onekeyhq/shared/src/errors/types/errorTypes';
+import errorUtils from '@onekeyhq/shared/src/errors/utils/errorUtils';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
+
+import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
+
+export function GlobalErrorHandlerContainer() {
+  useEffect(() => {
+    const fn = (error: IOneKeyError) => {
+      if (
+        errorUtils.isErrorByClassName({
+          error,
+          className: EOneKeyErrorClassNames.DeviceNotOpenedPassphrase,
+        })
+      ) {
+        const p = error.payload as
+          | {
+              connectId: string;
+              deviceId: string;
+            }
+          | undefined;
+        Dialog.show({
+          title: appLocale.intl.formatMessage({
+            id: ETranslations.passphrase_disabled_dialog_title,
+          }),
+          description: appLocale.intl.formatMessage({
+            id: ETranslations.passphrase_disabled_dialog_desc,
+          }),
+          onConfirmText: appLocale.intl.formatMessage({
+            id: ETranslations.global_enable,
+          }),
+          renderContent: (
+            <Anchor
+              href="https://help.onekey.so/hc/articles/9925655882383-Passphrases-and-hidden-wallets"
+              color="$textInfo"
+              size="$bodyMd"
+              textDecorationLine="underline"
+            >
+              {appLocale.intl.formatMessage({
+                id: ETranslations.global_learn_more,
+              })}
+            </Anchor>
+          ),
+          onConfirm: async () => {
+            await backgroundApiProxy.serviceHardware.setPassphraseEnabled({
+              walletId: '',
+              connectId: p?.connectId,
+              featuresDeviceId: p?.deviceId,
+              passphraseEnabled: true,
+            });
+          },
+        });
+      }
+    };
+    globalErrorHandler.addListener(fn);
+    return () => {
+      globalErrorHandler.removeListener(fn);
+    };
+  }, []);
+  return null;
+}

--- a/packages/kit/src/provider/Container/GlobalErrorHandlerContainer/index.tsx
+++ b/packages/kit/src/provider/Container/GlobalErrorHandlerContainer/index.tsx
@@ -1,0 +1,1 @@
+export * from './GlobalErrorHandlerContainer';

--- a/packages/kit/src/provider/Container/index.tsx
+++ b/packages/kit/src/provider/Container/index.tsx
@@ -23,6 +23,7 @@ import { ErrorToastContainer } from './ErrorToastContainer';
 import { FlipperPluginsContainer } from './FlipperPluginsContainer';
 import { ForceFirmwareUpdateContainer } from './ForceFirmwareUpdateContainer';
 import { FullWindowOverlayContainer } from './FullWindowOverlayContainer';
+import { GlobalErrorHandlerContainer } from './GlobalErrorHandlerContainer';
 import { GlobalWalletConnectModalContainer } from './GlobalWalletConnectModalContainer';
 import { HardwareUiStateContainer } from './HardwareUiStateContainer';
 import InAppNotification from './InAppNotification';
@@ -115,6 +116,7 @@ export function Container() {
           <PortalBodyContainer />
           <PageTrackerContainer />
           <ErrorToastContainer />
+          <GlobalErrorHandlerContainer />
           <ForceFirmwareUpdateContainer />
           {process.env.NODE_ENV !== 'production' ? (
             <>

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -1909,9 +1909,10 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
             const { wallets } = await serviceAccount.getAllHdHwQrWallets();
             for (const wallet0 of wallets) {
               if (
-                await serviceAccount.isWalletHasIndexedAccounts({
+                !wallet0?.isMocked &&
+                (await serviceAccount.isWalletHasIndexedAccounts({
                   walletId: wallet0.id,
-                })
+                }))
               ) {
                 selectedWallet = wallet0;
                 selectedWalletId = selectedWallet?.id;

--- a/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletEditButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletEditButton.tsx
@@ -71,6 +71,12 @@ function WalletEditButtonView({
     if (accountUtils.isQrWallet({ walletId: wallet?.id })) {
       return false;
     }
+    if (
+      accountUtils.isHwOrQrWallet({ walletId: wallet?.id }) &&
+      wallet?.isMocked
+    ) {
+      return false;
+    }
     return (
       accountUtils.isHdWallet({ walletId: wallet?.id }) ||
       accountUtils.isHwOrQrWallet({ walletId: wallet?.id })

--- a/packages/kit/src/views/Prime/components/PrivyProvider.native.tsx
+++ b/packages/kit/src/views/Prime/components/PrivyProvider.native.tsx
@@ -9,7 +9,6 @@ import {
 } from '@onekeyhq/shared/src/consts/primeConsts';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 
-
 export function PrivyProvider({ children }: { children: React.ReactNode }) {
   const appId = PRIVY_APP_ID;
   const clientId = PRIVY_MOBILE_CLIENT_ID;

--- a/packages/kit/src/views/Prime/components/PrivyProvider.tsx
+++ b/packages/kit/src/views/Prime/components/PrivyProvider.tsx
@@ -6,7 +6,6 @@ import {
 } from '@onekeyhq/shared/src/consts/primeConsts';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 
-
 export function PrivyProvider({ children }: { children: React.ReactNode }) {
   const appId = PRIVY_APP_ID;
   const clientId = PRIVY_MOBILE_CLIENT_ID;

--- a/packages/kit/src/views/Setting/pages/Tab/CustomElement.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/CustomElement.tsx
@@ -55,9 +55,9 @@ import openUrlUtils, {
 import { EHardwareTransportType } from '@onekeyhq/shared/types';
 
 import { useLocaleOptions, useResetApp } from '../../hooks';
+import { handleOpenDevMode } from '../../utils/devMode';
 
 import { TabSettingsListItem } from './ListItem';
-import { handleOpenDevMode } from '../../utils/devMode';
 
 export function LanguageListItem() {
   const locales = useLocaleOptions();

--- a/packages/shared/src/errors/errors/hardwareErrors.ts
+++ b/packages/shared/src/errors/errors/hardwareErrors.ts
@@ -77,6 +77,8 @@ export class DeviceNotOpenedPassphrase extends OneKeyHardwareError {
   }
 
   override code = HardwareErrorCode.DeviceNotOpenedPassphrase;
+
+  override className = EOneKeyErrorClassNames.DeviceNotOpenedPassphrase;
 }
 
 export class DeviceOpenedPassphrase extends OneKeyHardwareError {

--- a/packages/shared/src/errors/types/errorTypes.ts
+++ b/packages/shared/src/errors/types/errorTypes.ts
@@ -44,6 +44,7 @@ export enum EOneKeyErrorClassNames {
   FirmwareUpdateExit = 'FirmwareUpdateExit',
   FirmwareUpdateTasksClear = 'FirmwareUpdateTasksClear',
   WebDeviceNotFoundOrNeedsPermission = 'WebDeviceNotFoundOrNeedsPermission',
+  DeviceNotOpenedPassphrase = 'DeviceNotOpenedPassphrase',
 }
 
 export type IOneKeyErrorI18nInfo = Record<string | number, string | number>;

--- a/packages/shared/src/locale/enum/translations.ts
+++ b/packages/shared/src/locale/enum/translations.ts
@@ -1900,6 +1900,8 @@
   passphrase_allowed_characters_desc = 'passphrase_allowed_characters_desc',
   passphrase_allowed_characters_title = 'passphrase_allowed_characters_title',
   passphrase_character_limit = 'passphrase_character_limit',
+  passphrase_disabled_dialog_desc = 'passphrase_disabled_dialog_desc',
+  passphrase_disabled_dialog_title = 'passphrase_disabled_dialog_title',
   prime_about_onekey_prime = 'prime.about_onekey_prime',
   prime_agree_to_terms = 'prime.agree_to_terms',
   prime_agree_to_terms_privacy = 'prime.agree_to_terms_privacy',

--- a/packages/shared/src/locale/json/bn.json
+++ b/packages/shared/src/locale/json/bn.json
@@ -1895,6 +1895,8 @@
   "passphrase_allowed_characters_desc": "অক্ষর, সংখ্যা এবং প্রতীক (ASCII 32-126)",
   "passphrase_allowed_characters_title": "অনুমোদিত অক্ষর",
   "passphrase_character_limit": "সর্বোচ্চ ৫০ অক্ষর",
+  "passphrase_disabled_dialog_desc": "আপনার ডিভাইসে Passphrase সক্রিয় করুন গোপন ওয়ালেট তৈরি করতে।",
+  "passphrase_disabled_dialog_title": "গোপন ওয়ালেট তৈরি করা যাচ্ছে না",
   "prime.about_onekey_prime": "OneKey Prime পরিচিতি",
   "prime.agree_to_terms": "চালিয়ে যাওয়া মানে আপনি <link>OneKey Prime Terms</link> এর সাথে সম্মত হচ্ছেন।",
   "prime.agree_to_terms_privacy": "OneKey Prime-এ সাবস্ক্রাইব করার মাধ্যমে আপনি <termsTag>OneKey Prime শর্তাবলী</termsTag> এবং <privacyTag>গোপনীয়তা নীতি</privacyTag> মেনে নিচ্ছেন।",

--- a/packages/shared/src/locale/json/de.json
+++ b/packages/shared/src/locale/json/de.json
@@ -1895,6 +1895,8 @@
   "passphrase_allowed_characters_desc": "Buchstaben, Zahlen & Symbole (ASCII 32-126)",
   "passphrase_allowed_characters_title": "Erlaubte Zeichen",
   "passphrase_character_limit": "Maximal 50 Zeichen",
+  "passphrase_disabled_dialog_desc": "Aktivieren Sie Passphrase auf Ihrem Gerät, um versteckte Wallets zu erstellen.",
+  "passphrase_disabled_dialog_title": "Verstecktes Wallet kann nicht erstellt werden",
   "prime.about_onekey_prime": "OneKey Prime entdecken",
   "prime.agree_to_terms": "Wenn Sie fortfahren, stimmen Sie den <link>OneKey Prime Terms</link> zu.",
   "prime.agree_to_terms_privacy": "Mit Ihrem OneKey Prime-Abonnement akzeptieren Sie die <termsTag>OneKey Prime Nutzungsbedingungen</termsTag> und die <privacyTag>Datenschutzerklärung</privacyTag>.",

--- a/packages/shared/src/locale/json/en_US.json
+++ b/packages/shared/src/locale/json/en_US.json
@@ -1895,6 +1895,8 @@
   "passphrase_allowed_characters_desc": "Letters, numbers & symbols (ASCII 32-126)",
   "passphrase_allowed_characters_title": "Allowed characters",
   "passphrase_character_limit": "Max 50 characters",
+  "passphrase_disabled_dialog_desc": "Enable Passphrase on your device to create hidden wallets.",
+  "passphrase_disabled_dialog_title": "Can’t create hidden wallet",
   "prime.about_onekey_prime": "About OneKey Prime",
   "prime.agree_to_terms": "Continuing means you agree to <link>OneKey Prime Terms</link>.",
   "prime.agree_to_terms_privacy": "By subscribing to OneKey Prime you agree to the <termsTag>OneKey Prime Terms</termsTag> and <privacyTag>Privacy Policy</privacyTag>.",

--- a/packages/shared/src/locale/json/es.json
+++ b/packages/shared/src/locale/json/es.json
@@ -1895,6 +1895,8 @@
   "passphrase_allowed_characters_desc": "Letras, números y símbolos (ASCII 32-126)",
   "passphrase_allowed_characters_title": "Caracteres permitidos",
   "passphrase_character_limit": "Máximo 50 caracteres",
+  "passphrase_disabled_dialog_desc": "Activa Passphrase en tu dispositivo para crear billeteras ocultas.",
+  "passphrase_disabled_dialog_title": "No se puede crear la billetera oculta",
   "prime.about_onekey_prime": "Descubre OneKey Prime",
   "prime.agree_to_terms": "Continuar significa que aceptas los <link>OneKey Prime Terms</link>.",
   "prime.agree_to_terms_privacy": "Al suscribirte a OneKey Prime, aceptas los <termsTag>Términos de Servicio de OneKey Prime</termsTag> y la <privacyTag>Política de Privacidad</privacyTag>.",

--- a/packages/shared/src/locale/json/fr_FR.json
+++ b/packages/shared/src/locale/json/fr_FR.json
@@ -1895,6 +1895,8 @@
   "passphrase_allowed_characters_desc": "Lettres, chiffres et symboles (ASCII 32-126)",
   "passphrase_allowed_characters_title": "Caractères autorisés",
   "passphrase_character_limit": "Maximum 50 caractères",
+  "passphrase_disabled_dialog_desc": "Activez Passphrase sur votre appareil pour créer des portefeuilles cachés.",
+  "passphrase_disabled_dialog_title": "Impossible de créer un portefeuille caché",
   "prime.about_onekey_prime": "Découvrir OneKey Prime",
   "prime.agree_to_terms": "En continuant, vous acceptez les <link>OneKey Prime Terms</link>.",
   "prime.agree_to_terms_privacy": "En souscrivant à OneKey Prime, vous acceptez les <termsTag>Conditions d'utilisation OneKey Prime</termsTag> et la <privacyTag>Politique de confidentialité</privacyTag>.",

--- a/packages/shared/src/locale/json/hi_IN.json
+++ b/packages/shared/src/locale/json/hi_IN.json
@@ -1895,6 +1895,8 @@
   "passphrase_allowed_characters_desc": "अक्षर, संख्या और प्रतीक (ASCII 32-126)",
   "passphrase_allowed_characters_title": "अनुमत वर्ण",
   "passphrase_character_limit": "अधिकतम 50 वर्ण",
+  "passphrase_disabled_dialog_desc": "अपने डिवाइस पर Passphrase सक्षम करें ताकि छिपे हुए वॉलेट बनाए जा सकें।",
+  "passphrase_disabled_dialog_title": "छिपा हुआ वॉलेट नहीं बना सकते",
   "prime.about_onekey_prime": "OneKey Prime का परिचय",
   "prime.agree_to_terms": "जारी रखने का मतलब है कि आप <link>OneKey Prime Terms</link> से सहमत हैं।",
   "prime.agree_to_terms_privacy": "OneKey Prime की सदस्यता लेने से आप <termsTag>OneKey Prime की शर्तों</termsTag> और <privacyTag>गोपनीयता नीति</privacyTag> से सहमति देते हैं।",

--- a/packages/shared/src/locale/json/id.json
+++ b/packages/shared/src/locale/json/id.json
@@ -1895,6 +1895,8 @@
   "passphrase_allowed_characters_desc": "Huruf, angka & simbol (ASCII 32-126)",
   "passphrase_allowed_characters_title": "Karakter yang diizinkan",
   "passphrase_character_limit": "Maksimal 50 karakter",
+  "passphrase_disabled_dialog_desc": "Aktifkan Passphrase di perangkat Anda untuk membuat dompet tersembunyi.",
+  "passphrase_disabled_dialog_title": "Tidak dapat membuat dompet tersembunyi",
   "prime.about_onekey_prime": "Mengenal OneKey Prime",
   "prime.agree_to_terms": "Melanjutkan berarti Anda setuju dengan <link>OneKey Prime Terms</link>.",
   "prime.agree_to_terms_privacy": "Dengan berlangganan OneKey Prime, Anda menyetujui <termsTag>Syarat dan Ketentuan OneKey Prime</termsTag> serta <privacyTag>Kebijakan Privasi</privacyTag>.",

--- a/packages/shared/src/locale/json/it_IT.json
+++ b/packages/shared/src/locale/json/it_IT.json
@@ -1895,6 +1895,8 @@
   "passphrase_allowed_characters_desc": "Lettere, numeri e simboli (ASCII 32-126)",
   "passphrase_allowed_characters_title": "Caratteri consentiti",
   "passphrase_character_limit": "Massimo 50 caratteri",
+  "passphrase_disabled_dialog_desc": "Abilita la Passphrase sul tuo dispositivo per creare portafogli nascosti.",
+  "passphrase_disabled_dialog_title": "Impossibile creare il portafoglio nascosto",
   "prime.about_onekey_prime": "Scopri OneKey Prime",
   "prime.agree_to_terms": "Continuando, accetti i <link>OneKey Prime Terms</link>.",
   "prime.agree_to_terms_privacy": "Sottoscrivendo OneKey Prime accetti i <termsTag>Termini e Condizioni di OneKey Prime</termsTag> e l'<privacyTag>Informativa sulla privacy</privacyTag>.",

--- a/packages/shared/src/locale/json/ja_JP.json
+++ b/packages/shared/src/locale/json/ja_JP.json
@@ -1895,6 +1895,8 @@
   "passphrase_allowed_characters_desc": "文字、数字、記号（ASCII 32-126）",
   "passphrase_allowed_characters_title": "使用可能な文字",
   "passphrase_character_limit": "最大50文字",
+  "passphrase_disabled_dialog_desc": "デバイスでPassphraseを有効にして、隠しウォレットを作成しましょう。",
+  "passphrase_disabled_dialog_title": "隠しウォレットを作成できません",
   "prime.about_onekey_prime": "OneKey Primeのご紹介",
   "prime.agree_to_terms": "続行することで、<link>OneKey Prime Terms</link>に同意したことになります。",
   "prime.agree_to_terms_privacy": "OneKey Prime をご購読いただくことで、<termsTag>OneKey Prime 利用規約</termsTag> および <privacyTag>プライバシーポリシー</privacyTag> に同意したものとみなされます。",

--- a/packages/shared/src/locale/json/ko_KR.json
+++ b/packages/shared/src/locale/json/ko_KR.json
@@ -1895,6 +1895,8 @@
   "passphrase_allowed_characters_desc": "문자, 숫자 및 기호 (ASCII 32-126)",
   "passphrase_allowed_characters_title": "허용된 문자",
   "passphrase_character_limit": "최대 50자",
+  "passphrase_disabled_dialog_desc": "기기에 Passphrase를 활성화하여 숨겨진 지갑을 생성하세요.",
+  "passphrase_disabled_dialog_title": "숨겨진 지갑을 생성할 수 없습니다",
   "prime.about_onekey_prime": "OneKey Prime 알아보기",
   "prime.agree_to_terms": "계속 진행하면 <link>OneKey Prime Terms</link>에 동의하는 것으로 간주됩니다.",
   "prime.agree_to_terms_privacy": "OneKey Prime 구독 시 <termsTag>OneKey Prime 이용약관</termsTag> 및 <privacyTag>개인정보 처리방침</privacyTag> 에 동의하게 됩니다。",

--- a/packages/shared/src/locale/json/pt.json
+++ b/packages/shared/src/locale/json/pt.json
@@ -1895,6 +1895,8 @@
   "passphrase_allowed_characters_desc": "Letras, números e símbolos (ASCII 32-126)",
   "passphrase_allowed_characters_title": "Caracteres permitidos",
   "passphrase_character_limit": "Máximo 50 caracteres",
+  "passphrase_disabled_dialog_desc": "Ative a Passphrase no seu dispositivo para criar carteiras ocultas.",
+  "passphrase_disabled_dialog_title": "Não é possível criar carteira oculta",
   "prime.about_onekey_prime": "Conheça o OneKey Prime",
   "prime.agree_to_terms": "Ao continuar, você concorda com os <link>OneKey Prime Terms</link>.",
   "prime.agree_to_terms_privacy": "Ao subscrever o OneKey Prime, está a concordar com os <termsTag>Termos de Serviço do OneKey Prime</termsTag> e a <privacyTag>Política de Privacidade</privacyTag>.",

--- a/packages/shared/src/locale/json/pt_BR.json
+++ b/packages/shared/src/locale/json/pt_BR.json
@@ -1895,6 +1895,8 @@
   "passphrase_allowed_characters_desc": "Letras, números e símbolos (ASCII 32-126)",
   "passphrase_allowed_characters_title": "Caracteres permitidos",
   "passphrase_character_limit": "Máximo 50 caracteres",
+  "passphrase_disabled_dialog_desc": "Ative a Passphrase no seu dispositivo para criar carteiras ocultas.",
+  "passphrase_disabled_dialog_title": "Não é possível criar carteira oculta",
   "prime.about_onekey_prime": "Conheça o OneKey Prime",
   "prime.agree_to_terms": "Ao continuar, você concorda com os <link>OneKey Prime Terms</link>.",
   "prime.agree_to_terms_privacy": "Ao assinar o OneKey Prime, você está concordando com os <termsTag>Termos de Serviço do OneKey Prime</termsTag> e com a <privacyTag>Política de Privacidade</privacyTag>.",

--- a/packages/shared/src/locale/json/ru.json
+++ b/packages/shared/src/locale/json/ru.json
@@ -1895,6 +1895,8 @@
   "passphrase_allowed_characters_desc": "Буквы, цифры и символы (ASCII 32-126)",
   "passphrase_allowed_characters_title": "Допустимые символы",
   "passphrase_character_limit": "Максимум 50 символов",
+  "passphrase_disabled_dialog_desc": "Включите Passphrase на вашем устройстве, чтобы создать скрытые кошельки.",
+  "passphrase_disabled_dialog_title": "Не удаётся создать скрытый кошелёк",
   "prime.about_onekey_prime": "Узнайте о OneKey Prime",
   "prime.agree_to_terms": "Продолжая, вы соглашаетесь с <link>OneKey Prime Terms</link>.",
   "prime.agree_to_terms_privacy": "Оформляя подписку на OneKey Prime, вы принимаете <termsTag>Условия использования OneKey Prime</termsTag> и <privacyTag>Политику конфиденциальности</privacyTag>.",

--- a/packages/shared/src/locale/json/th_TH.json
+++ b/packages/shared/src/locale/json/th_TH.json
@@ -1895,6 +1895,8 @@
   "passphrase_allowed_characters_desc": "ตัวอักษร, ตัวเลข & สัญลักษณ์ (ASCII 32-126)",
   "passphrase_allowed_characters_title": "ตัวอักษรที่อนุญาต",
   "passphrase_character_limit": "สูงสุด 50 ตัวอักษร",
+  "passphrase_disabled_dialog_desc": "เปิดใช้งาน Passphrase บนอุปกรณ์ของคุณเพื่อสร้างกระเป๋าเงินที่ซ่อนอยู่",
+  "passphrase_disabled_dialog_title": "ไม่สามารถสร้างกระเป๋าเงินที่ซ่อนได้",
   "prime.about_onekey_prime": "ทำความรู้จัก OneKey Prime",
   "prime.agree_to_terms": "การดำเนินการต่อหมายความว่าคุณยอมรับ <link>OneKey Prime Terms</link>.",
   "prime.agree_to_terms_privacy": "การสมัครสมาชิก OneKey Prime หมายความว่าคุณยอมรับ <termsTag>ข้อกำหนดการใช้งาน OneKey Prime</termsTag> และ <privacyTag>นโยบายความเป็นส่วนตัว</privacyTag>",

--- a/packages/shared/src/locale/json/uk_UA.json
+++ b/packages/shared/src/locale/json/uk_UA.json
@@ -1895,6 +1895,8 @@
   "passphrase_allowed_characters_desc": "Літери, цифри та символи (ASCII 32-126)",
   "passphrase_allowed_characters_title": "Дозволені символи",
   "passphrase_character_limit": "Максимум 50 символів",
+  "passphrase_disabled_dialog_desc": "Увімкніть Passphrase на вашому пристрої, щоб створювати приховані гаманці.",
+  "passphrase_disabled_dialog_title": "Не вдається створити прихований гаманець",
   "prime.about_onekey_prime": "Дізнайтеся про OneKey Prime",
   "prime.agree_to_terms": "Продовжуючи, ви погоджуєтеся з <link>OneKey Prime Terms</link>.",
   "prime.agree_to_terms_privacy": "Оформлюючи підписку на OneKey Prime, ви приймаєте <termsTag>Умови використання OneKey Prime</termsTag> та <privacyTag>Політику конфіденційності</privacyTag>.",

--- a/packages/shared/src/locale/json/vi.json
+++ b/packages/shared/src/locale/json/vi.json
@@ -1895,6 +1895,8 @@
   "passphrase_allowed_characters_desc": "Chữ cái, số & ký hiệu (ASCII 32-126)",
   "passphrase_allowed_characters_title": "Các ký tự được phép",
   "passphrase_character_limit": "Tối đa 50 ký tự",
+  "passphrase_disabled_dialog_desc": "Bật Passphrase trên thiết bị của bạn để tạo ví ẩn.",
+  "passphrase_disabled_dialog_title": "Không thể tạo ví ẩn",
   "prime.about_onekey_prime": "Tìm hiểu OneKey Prime",
   "prime.agree_to_terms": "Tiếp tục có nghĩa là bạn đồng ý với <link>Điều khoản OneKey Prime</link>.",
   "prime.agree_to_terms_privacy": "Khi đăng ký OneKey Prime, bạn đồng ý với <termsTag>Điều khoản Dịch vụ OneKey Prime</termsTag> và <privacyTag>Chính sách Bảo mật</privacyTag>.",

--- a/packages/shared/src/locale/json/zh_CN.json
+++ b/packages/shared/src/locale/json/zh_CN.json
@@ -1895,6 +1895,8 @@
   "passphrase_allowed_characters_desc": "字母、数字和符号（ASCII 32-126）",
   "passphrase_allowed_characters_title": "允许的字符",
   "passphrase_character_limit": "最多 50 个字符",
+  "passphrase_disabled_dialog_desc": "在您的设备上启用 Passphrase 以创建隐藏钱包。",
+  "passphrase_disabled_dialog_title": "无法创建隐藏钱包",
   "prime.about_onekey_prime": "了解 OneKey Prime",
   "prime.agree_to_terms": "继续表示您同意 <link>OneKey Prime Terms</link>。",
   "prime.agree_to_terms_privacy": "订阅 OneKey Prime 即表示您同意 <termsTag>OneKey Prime 服务条款</termsTag> 和 <privacyTag>隐私政策</privacyTag>。",

--- a/packages/shared/src/locale/json/zh_HK.json
+++ b/packages/shared/src/locale/json/zh_HK.json
@@ -1895,6 +1895,8 @@
   "passphrase_allowed_characters_desc": "字母、數字及符號 (ASCII 32-126)",
   "passphrase_allowed_characters_title": "允許字符",
   "passphrase_character_limit": "最多 50 個字符",
+  "passphrase_disabled_dialog_desc": "在您的裝置上啟用 Passphrase 以創建隱藏錢包。",
+  "passphrase_disabled_dialog_title": "無法創建隱藏錢包",
   "prime.about_onekey_prime": "了解 OneKey Prime",
   "prime.agree_to_terms": "繼續即表示您同意 <link>OneKey Prime Terms</link>。",
   "prime.agree_to_terms_privacy": "訂閱 OneKey Prime 即表示您同意 <termsTag>OneKey Prime 服務條款</termsTag> 及 <privacyTag>私隱政策</privacyTag>。",

--- a/packages/shared/src/locale/json/zh_TW.json
+++ b/packages/shared/src/locale/json/zh_TW.json
@@ -1895,6 +1895,8 @@
   "passphrase_allowed_characters_desc": "字母、數字和符號 (ASCII 32-126)",
   "passphrase_allowed_characters_title": "允許的字符",
   "passphrase_character_limit": "最多 50 個字元",
+  "passphrase_disabled_dialog_desc": "在您的裝置上啟用 Passphrase 以創建隱藏錢包。",
+  "passphrase_disabled_dialog_title": "無法建立隱藏錢包",
   "prime.about_onekey_prime": "了解 OneKey Prime",
   "prime.agree_to_terms": "繼續即表示您同意 <link>OneKey Prime Terms</link>。",
   "prime.agree_to_terms_privacy": "訂閱 OneKey Prime 即表示您同意 <termsTag>OneKey Prime 服務條款</termsTag> 和 <privacyTag>隱私權政策</privacyTag>。",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a global error handler that detects when a hardware device requires passphrase activation and prompts the user with a dialog, including a direct link to a help article and an option to enable the passphrase.
  - Added new localized dialog titles and descriptions for passphrase-related hardware device errors.

- **Improvements**
  - Enhanced device identification and error handling for hardware devices, allowing more flexible device lookup by wallet or device identifiers.
  - Improved logic to exclude mocked wallets from certain account and wallet operations, such as account selection and batch creation.
  - Centralized and streamlined account removal logic with improved UI feedback and conditional dialog display based on account type.

- **Bug Fixes**
  - Updated error class and enum to better categorize hardware device errors related to passphrase activation.

- **Chores**
  - Minor code cleanup and import reordering for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->