### PR TITLE
refactor: update AddressInfo component to use optional props

### DIFF
--- a/packages/kit/src/components/AddressInfo/index.tsx
+++ b/packages/kit/src/components/AddressInfo/index.tsx
@@ -157,7 +157,7 @@ function AddressInfo(props: IProps) {
 
   const renderWalletAccountName = () => {
     if (!addressQueryResult?.walletAccountName) return null;
-    
+
     const badge = (
       <Badge badgeType="success" badgeSize="sm">
         {addressQueryResult.walletAccountName}

--- a/packages/kit/src/components/AddressInfo/index.tsx
+++ b/packages/kit/src/components/AddressInfo/index.tsx
@@ -155,70 +155,63 @@ function AddressInfo(props: IProps) {
     return null;
   }
 
-  const AccountNameContainer = allowClickAccountNameSwitch
-    ? SwitchHomeAccountContainer
-    : Stack;
+  const renderWalletAccountName = () => {
+    if (!addressQueryResult?.walletAccountName) return null;
+    
+    const badge = (
+      <Badge badgeType="success" badgeSize="sm">
+        {addressQueryResult.walletAccountName}
+      </Badge>
+    );
+
+    if (allowClickAccountNameSwitch) {
+      return (
+        <SwitchHomeAccountContainer
+          walletAccountName={addressQueryResult.walletAccountName}
+          accountId={addressQueryResult?.walletAccountId}
+        >
+          {badge}
+        </SwitchHomeAccountContainer>
+      );
+    }
+
+    return <Stack maxWidth="100%">{badge}</Stack>;
+  };
+
+  const renderAddressBookName = () => {
+    if (!addressQueryResult?.addressBookName) return null;
+    return (
+      <Badge badgeType="success" badgeSize="sm">
+        {addressQueryResult.addressBookName}
+      </Badge>
+    );
+  };
+
+  const renderAddressInfo = () => {
+    if (!addressInfo) return null;
+    return (
+      <AddressBadge
+        title={addressInfo.label}
+        badgeType={addressInfo.type}
+        icon={addressInfo.icon}
+      />
+    );
+  };
+
+  const content = (
+    <>
+      {renderWalletAccountName()}
+      {renderAddressBookName()}
+      {renderAddressInfo()}
+    </>
+  );
 
   return withWrapper ? (
     <XStack gap="$2" flex={1} flexWrap="wrap">
-      {addressQueryResult?.walletAccountName ? (
-        <AccountNameContainer
-          {...(allowClickAccountNameSwitch
-            ? {
-                walletAccountName: addressQueryResult?.walletAccountName,
-                accountId: addressQueryResult?.walletAccountId,
-              }
-            : {})}
-          maxWidth="100%"
-        >
-          <Badge badgeType="success" badgeSize="sm">
-            {addressQueryResult?.walletAccountName}
-          </Badge>
-        </AccountNameContainer>
-      ) : null}
-      {addressQueryResult?.addressBookName ? (
-        <Badge badgeType="success" badgeSize="sm">
-          {addressQueryResult?.addressBookName}
-        </Badge>
-      ) : null}
-      {addressInfo ? (
-        <AddressBadge
-          title={addressInfo.label}
-          badgeType={addressInfo.type}
-          icon={addressInfo.icon}
-        />
-      ) : null}
+      {content}
     </XStack>
   ) : (
-    <>
-      {addressQueryResult?.walletAccountName ? (
-        <AccountNameContainer
-          {...(allowClickAccountNameSwitch
-            ? {
-                walletAccountName: addressQueryResult?.walletAccountName,
-                accountId: addressQueryResult?.walletAccountId,
-              }
-            : {})}
-          maxWidth="100%"
-        >
-          <Badge badgeType="success" badgeSize="sm">
-            {addressQueryResult?.walletAccountName}
-          </Badge>
-        </AccountNameContainer>
-      ) : null}
-      {addressQueryResult?.addressBookName ? (
-        <Badge badgeType="success" badgeSize="sm">
-          {addressQueryResult?.addressBookName}
-        </Badge>
-      ) : null}
-      {addressInfo ? (
-        <AddressBadge
-          title={addressInfo.label}
-          badgeType={addressInfo.type}
-          icon={addressInfo.icon}
-        />
-      ) : null}
-    </>
+    content
   );
 }
 

--- a/packages/kit/src/components/AddressInfo/index.tsx
+++ b/packages/kit/src/components/AddressInfo/index.tsx
@@ -30,7 +30,7 @@ type IProps = {
 type ISwitchHomeAccountButtonProps = {
   accountId?: string;
   children: React.ReactNode;
-  walletAccountName?: string;
+  walletAccountName: string;
 };
 function SwitchHomeAccountButton({
   accountId,

--- a/packages/kit/src/components/AddressInfo/index.tsx
+++ b/packages/kit/src/components/AddressInfo/index.tsx
@@ -28,9 +28,9 @@ type IProps = {
 };
 
 type ISwitchHomeAccountButtonProps = {
-  accountId: string | undefined;
+  accountId?: string;
   children: React.ReactNode;
-  walletAccountName: string;
+  walletAccountName?: string;
 };
 function SwitchHomeAccountButton({
   accountId,
@@ -163,8 +163,12 @@ function AddressInfo(props: IProps) {
     <XStack gap="$2" flex={1} flexWrap="wrap">
       {addressQueryResult?.walletAccountName ? (
         <AccountNameContainer
-          walletAccountName={addressQueryResult?.walletAccountName}
-          accountId={addressQueryResult?.walletAccountId}
+          {...(allowClickAccountNameSwitch
+            ? {
+                walletAccountName: addressQueryResult?.walletAccountName,
+                accountId: addressQueryResult?.walletAccountId,
+              }
+            : {})}
           maxWidth="100%"
         >
           <Badge badgeType="success" badgeSize="sm">
@@ -189,8 +193,12 @@ function AddressInfo(props: IProps) {
     <>
       {addressQueryResult?.walletAccountName ? (
         <AccountNameContainer
-          walletAccountName={addressQueryResult?.walletAccountName}
-          accountId={addressQueryResult?.walletAccountId}
+          {...(allowClickAccountNameSwitch
+            ? {
+                walletAccountName: addressQueryResult?.walletAccountName,
+                accountId: addressQueryResult?.walletAccountId,
+              }
+            : {})}
           maxWidth="100%"
         >
           <Badge badgeType="success" badgeSize="sm">


### PR DESCRIPTION
 问题原因：
  1. AccountNameContainer 是一个动态组件，根据 allowClickAccountNameSwitch 的值决定是 SwitchHomeAccountContainer 还是 Stack
  2. 当 allowClickAccountNameSwitch 为 false 时，AccountNameContainer 就是普通的 Stack 组件
  3. 但代码把 walletAccountName 这个自定义属性传给了 Stack
  4. Stack 是基于 DOM 元素的组件，不认识 walletAccountName 这个属性，所以 React 报警告

  修改逻辑：
```
  {...(allowClickAccountNameSwitch ? {
    walletAccountName: addressQueryResult?.walletAccountName,
    accountId: addressQueryResult?.walletAccountId,
  } : {})}
```
  - 当 allowClickAccountNameSwitch 为 true 时：
    - AccountNameContainer = SwitchHomeAccountContainer
    - 传递 walletAccountName 和 accountId 属性（这个组件需要这些属性）
  - 当 allowClickAccountNameSwitch 为 false 时：
    - AccountNameContainer = Stack
    - 不传递任何自定义属性（避免 DOM 元素收到不认识的属性）

  这样就避免了把业务逻辑的属性传递给不需要它们的 DOM 组件，消除了 React 的警告。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved code structure for displaying wallet account and address book information, resulting in cleaner and more maintainable rendering logic.
- **Style**
  - No visible changes to the user interface; all updates are internal for better code organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->