### PR TITLE
feat: onekey id delete account

### DIFF
--- a/packages/components/src/composite/Dialog/Header.tsx
+++ b/packages/components/src/composite/Dialog/Header.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from 'react';
 import { createContext, memo, useContext, useEffect, useMemo } from 'react';
 
 import type { IHyperlinkTextProps } from '@onekeyhq/kit/src/components/HyperlinkText';
@@ -19,11 +20,12 @@ export function DialogIcon({
   icon,
   tone,
   renderIcon,
+  ...stackProps
 }: {
   icon: IDialogHeaderProps['icon'];
   tone?: IDialogHeaderProps['tone'];
   renderIcon?: IDialogHeaderProps['renderIcon'];
-}) {
+} & ComponentProps<typeof Stack>) {
   const colors: {
     iconWrapperBg: ColorTokens;
     iconColor: ColorTokens;
@@ -63,7 +65,7 @@ export function DialogIcon({
   }, [tone]);
   if (renderIcon) {
     return (
-      <Stack alignSelf="flex-start" mb="$5">
+      <Stack alignSelf="flex-start" mb="$5" {...stackProps}>
         {renderIcon}
       </Stack>
     );
@@ -75,6 +77,7 @@ export function DialogIcon({
       mb="$5"
       borderRadius="$full"
       bg={colors.iconWrapperBg}
+      {...stackProps}
     >
       <Icon name={icon} size="$8" color={colors.iconColor} />
     </Stack>

--- a/packages/components/src/layouts/Swiper/type.ts
+++ b/packages/components/src/layouts/Swiper/type.ts
@@ -1,7 +1,4 @@
-import type {
-  PropsWithChildren,
-  ReactNode,
-} from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
 
 import type { IListViewProps } from '../ListView/list';
 import type { ListRenderItem } from 'react-native';

--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
@@ -675,7 +675,10 @@ class ServicePrime extends ServiceBase {
   }
 
   @backgroundMethod()
-  async sendEmailOTP(scene: 'UpdateReabteWithdrawAddress') {
+  async sendEmailOTP(scene: string) {
+    if (!scene) {
+      throw new OneKeyLocalError('sendEmailOTP ERROR: Invalid scene');
+    }
     const client = await this.getOneKeyIdClient(EServiceEndpointEnum.Prime);
     return client.post('/prime/v1/general/emailOTP', {
       scene,

--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
@@ -49,6 +49,25 @@ class ServicePrime extends ServiceBase {
     return this.getOneKeyIdClient(EServiceEndpointEnum.Prime);
   }
 
+  @backgroundMethod()
+  async apiDeleteAccount({
+    uuid,
+    emailOTP,
+  }: {
+    uuid: string;
+    emailOTP: string;
+  }) {
+    const client = await this.getOneKeyIdClient(EServiceEndpointEnum.Prime);
+    const result = await client.post<IApiClientResponse<{ ok: boolean }>>(
+      '/prime/v1/user/delete',
+      {
+        uuid,
+        emailOTP,
+      },
+    );
+    return result?.data?.data;
+  }
+
   loginMutex = new Semaphore(1);
 
   @backgroundMethod()
@@ -680,9 +699,15 @@ class ServicePrime extends ServiceBase {
       throw new OneKeyLocalError('sendEmailOTP ERROR: Invalid scene');
     }
     const client = await this.getOneKeyIdClient(EServiceEndpointEnum.Prime);
-    return client.post('/prime/v1/general/emailOTP', {
+    const result = await client.post<
+      IApiClientResponse<{
+        resendAt: number;
+        uuid: string;
+      }>
+    >('/prime/v1/general/emailOTP', {
       scene,
     });
+    return result?.data?.data;
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceReferralCode.ts
+++ b/packages/kit-bg/src/services/ServiceReferralCode.ts
@@ -53,6 +53,7 @@ class ServiceReferralCode extends ServiceBase {
     networkId: string;
     address: string;
     emailOTP: string;
+    uuid: string;
   }) {
     const client = await this.getOneKeyIdClient(EServiceEndpointEnum.Rebate);
     return client.post('/rebate/v1/address', params);

--- a/packages/kit-bg/src/vaults/impls/tron/Vault.ts
+++ b/packages/kit-bg/src/vaults/impls/tron/Vault.ts
@@ -43,6 +43,7 @@ import {
   EOnChainHistoryTxStatus,
   type IOnChainHistoryTx,
 } from '@onekeyhq/shared/types/history';
+import { EReasonForNeedPassword } from '@onekeyhq/shared/types/setting';
 import { ESwapTabSwitchType } from '@onekeyhq/shared/types/swap/types';
 import {
   EDecodedTxActionType,
@@ -83,7 +84,6 @@ import type {
   IValidateGeneralInputParams,
 } from '../../types';
 import type { Types } from 'tronweb';
-import { EReasonForNeedPassword } from '@onekeyhq/shared/types/setting';
 
 const INFINITE_AMOUNT_HEX =
   '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';

--- a/packages/kit/src/components/Resource/TronResource.tsx
+++ b/packages/kit/src/components/Resource/TronResource.tsx
@@ -20,8 +20,7 @@ import { openUrlInApp } from '@onekeyhq/shared/src/utils/openUrlUtils';
 import backgroundApiProxy from '../../background/instance/backgroundApiProxy';
 import { usePromiseResult } from '../../hooks/usePromiseResult';
 
-const TRON_RESOURCE_DOC_URL =
-  'https://help.onekey.so/articles/11461319';
+const TRON_RESOURCE_DOC_URL = 'https://help.onekey.so/articles/11461319';
 
 function ResourceDetails({
   name,

--- a/packages/kit/src/hooks/useLoginOneKeyId.tsx
+++ b/packages/kit/src/hooks/useLoginOneKeyId.tsx
@@ -21,6 +21,7 @@ import {
   EModalRoutes,
 } from '@onekeyhq/shared/src/routes';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
+import type { IPrimeUserInfo } from '@onekeyhq/shared/types/prime/primeTypes';
 
 import backgroundApiProxy from '../background/instance/backgroundApiProxy';
 import { usePrimeAuthV2 } from '../views/Prime/hooks/usePrimeAuthV2';
@@ -180,9 +181,11 @@ export const useLoginOneKeyId = () => {
     async ({
       onConfirm,
       scene,
+      description,
     }: {
       onConfirm: (code: string) => Promise<unknown>;
       scene: EPrimeEmailOTPScene;
+      description?: ({ userInfo }: { userInfo: IPrimeUserInfo }) => string;
     }) => {
       const userInfo = await backgroundApiProxy.servicePrime.getLocalUserInfo();
       return new Promise<void>((resolve) => {
@@ -192,12 +195,13 @@ export const useLoginOneKeyId = () => {
               title={intl.formatMessage({
                 id: ETranslations.prime_enter_verification_code,
               })}
-              description={intl.formatMessage(
-                {
-                  id: ETranslations.referral_address_update_desc,
-                },
-                { mail: userInfo.displayEmail ?? '' },
-              )}
+              description={
+                description?.({ userInfo }) ||
+                intl.formatMessage(
+                  { id: ETranslations.prime_sent_to },
+                  { email: userInfo.displayEmail ?? '' },
+                )
+              }
               onConfirm={async (code: string) => {
                 await timerUtils.wait(120);
                 await onConfirm(code);

--- a/packages/kit/src/hooks/useLoginOneKeyId.tsx
+++ b/packages/kit/src/hooks/useLoginOneKeyId.tsx
@@ -183,12 +183,19 @@ export const useLoginOneKeyId = () => {
       scene,
       description,
     }: {
-      onConfirm: (code: string) => Promise<unknown>;
+      onConfirm: ({
+        code,
+        uuid,
+      }: {
+        code: string;
+        uuid: string;
+      }) => Promise<unknown>;
       scene: EPrimeEmailOTPScene;
       description?: ({ userInfo }: { userInfo: IPrimeUserInfo }) => string;
     }) => {
       const userInfo = await backgroundApiProxy.servicePrime.getLocalUserInfo();
       return new Promise<void>((resolve) => {
+        let uuid = '';
         const dialog = Dialog.show({
           renderContent: (
             <EmailOTPDialog
@@ -204,12 +211,15 @@ export const useLoginOneKeyId = () => {
               }
               onConfirm={async (code: string) => {
                 await timerUtils.wait(120);
-                await onConfirm(code);
+                await onConfirm({ code, uuid });
                 await dialog.close();
                 resolve();
               }}
               sendCode={async () => {
-                return backgroundApiProxy.servicePrime.sendEmailOTP(scene);
+                const result =
+                  await backgroundApiProxy.servicePrime.sendEmailOTP(scene);
+                uuid = result.uuid;
+                return result;
               }}
             />
           ),

--- a/packages/kit/src/hooks/useLoginOneKeyId.tsx
+++ b/packages/kit/src/hooks/useLoginOneKeyId.tsx
@@ -14,6 +14,7 @@ import {
 } from '@onekeyhq/components';
 import { LazyLoadPage } from '@onekeyhq/kit/src/components/LazyLoadPage';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import type { EPrimeEmailOTPScene } from '@onekeyhq/shared/src/consts/primeConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
   EModalReferFriendsRoutes,
@@ -42,13 +43,14 @@ export function EmailOTPDialog(props: {
   title: string;
   description: string;
   sendCode: () => Promise<unknown>;
-  onConfirm: (code: string) => void;
+  onConfirm: (code: string) => void | Promise<void>;
 }) {
   const { sendCode, onConfirm, title, description } = props;
   const [isSubmittingVerificationCode, setIsSubmittingVerificationCode] =
     useState(false);
   const [countdown, setCountdown] = useState(COUNTDOWN_TIME);
   const [isResending, setIsResending] = useState(false);
+  const [isConfirming, setIsConfirming] = useState(false);
   const [verificationCode, setVerificationCode] = useState('');
   const [state, setState] = useState<{ status: 'initial' | 'error' | 'done' }>({
     status: 'initial',
@@ -99,12 +101,14 @@ export function EmailOTPDialog(props: {
 
   const handleConfirm = useCallback(async () => {
     try {
-      onConfirm(verificationCode);
+      setIsConfirming(true);
+      await onConfirm(verificationCode);
     } catch (error) {
       console.error('sendEmailOTP error', error);
       setState({ status: 'error' });
     } finally {
       setIsSubmittingVerificationCode(false);
+      setIsConfirming(false);
     }
   }, [onConfirm, verificationCode]);
 
@@ -151,7 +155,7 @@ export function EmailOTPDialog(props: {
       <Dialog.Footer
         showCancelButton={false}
         confirmButtonProps={{
-          loading: isSubmittingVerificationCode,
+          loading: isSubmittingVerificationCode || isConfirming,
           disabled: verificationCode.length !== 6,
         }}
         onConfirmText={intl.formatMessage({
@@ -175,8 +179,10 @@ export const useLoginOneKeyId = () => {
   const sendEmailOTP = useCallback(
     async ({
       onConfirm,
+      scene,
     }: {
       onConfirm: (code: string) => Promise<unknown>;
+      scene: EPrimeEmailOTPScene;
     }) => {
       const userInfo = await backgroundApiProxy.servicePrime.getLocalUserInfo();
       return new Promise<void>((resolve) => {
@@ -199,9 +205,7 @@ export const useLoginOneKeyId = () => {
                 resolve();
               }}
               sendCode={async () => {
-                return backgroundApiProxy.servicePrime.sendEmailOTP(
-                  'UpdateReabteWithdrawAddress',
-                );
+                return backgroundApiProxy.servicePrime.sendEmailOTP(scene);
               }}
             />
           ),

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/Markdown.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/Markdown.tsx
@@ -16,18 +16,33 @@ const content = `
 - New precision display under the Celestia network.
 
 ### 🐞 Bug Fixes
-- Fixed incorrect display of recipient addresses during transfers on Near and Tron networks.
-- Fixed overlapping transaction data display in Thorswap routing.
-- Fixed incomplete display of signing information on the Sui network.
+* Fixed incorrect display of recipient addresses during transfers on Near and Tron networks.
+* Fixed overlapping transaction data display in Thorswap routing.
+* Fixed incomplete display of signing information on the Sui network.
 
 ### 💎 Improvements
 - Optimized packet handling logic for signing data on the Sui network.
 - Increased blind signature message length to 4096 on the Polkadot network.
 
-### 💎 Ordered List
+### 📝 Markdown Ordered List
 1. Fixed incorrect display of recipient addresses during transfers on Near and Tron networks.
 1. Fixed overlapping transaction data display in Thorswap routing.
 1. Fixed incomplete display of signing information on the Sui network.
+
+### 💡 Markdown UnOrdered List 1
+- [ ] Fixed incorrect display of recipient addresses during transfers on Near and Tron networks.
+- [ ] Fixed overlapping transaction data display in Thorswap routing.
+- [ ] Fixed incomplete display of signing information on the Sui network.
+
+### 💡 Markdown UnOrdered List 2
+- Fixed incorrect display of recipient addresses during transfers on Near and Tron networks.
+- Fixed overlapping transaction data display in Thorswap routing.
+- Fixed incomplete display of signing information on the Sui network.
+
+### 💡 Markdown UnOrdered List 3
+* Fixed incorrect display of recipient addresses during transfers on Near and Tron networks.
+* Fixed overlapping transaction data display in Thorswap routing.
+* Fixed incomplete display of signing information on the Sui network.
 
 
 `;

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/Markdown.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/Markdown.tsx
@@ -4,7 +4,9 @@ import { Layout } from './utils/Layout';
 
 const content = `
 # Heading1
+
 ## Heading2
+
 ### ✨ New Features
 - *Don’t forget your passphrase!*
 - **Don’t forget your passphrase!**
@@ -21,6 +23,12 @@ const content = `
 ### 💎 Improvements
 - Optimized packet handling logic for signing data on the Sui network.
 - Increased blind signature message length to 4096 on the Polkadot network.
+
+### 💎 Ordered List
+1. Fixed incorrect display of recipient addresses during transfers on Near and Tron networks.
+1. Fixed overlapping transaction data display in Thorswap routing.
+1. Fixed incomplete display of signing information on the Sui network.
+
 
 `;
 

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/UnOrderedListGallery.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/UnOrderedListGallery.tsx
@@ -1,0 +1,124 @@
+import { UnOrderedList } from '@onekeyhq/components';
+
+import { Layout } from './utils/Layout';
+
+const UnOrderedListGallery = () => (
+  <Layout
+    filePath={__CURRENT_FILE_PATH__}
+    componentName="UnOrderedList"
+    elements={[
+      {
+        title: 'Basic UnOrderedList',
+        element: (
+          <UnOrderedList>
+            <UnOrderedList.Item>
+              First item with default bullet
+            </UnOrderedList.Item>
+            <UnOrderedList.Item>
+              Second item with default bullet
+            </UnOrderedList.Item>
+            <UnOrderedList.Item>
+              Third item with default bullet
+            </UnOrderedList.Item>
+          </UnOrderedList>
+        ),
+      },
+      {
+        title: 'UnOrderedList with Icons',
+        element: (
+          <UnOrderedList>
+            <UnOrderedList.Item icon="CheckRadioSolid">
+              Item with check icon - completed task
+            </UnOrderedList.Item>
+            <UnOrderedList.Item icon="XCircleSolid">
+              Item with X icon - failed task
+            </UnOrderedList.Item>
+            <UnOrderedList.Item icon="InboxSolid">
+              Item with warning icon - needs attention
+            </UnOrderedList.Item>
+            <UnOrderedList.Item icon="InfoCircleSolid">
+              Item with info icon - additional information
+            </UnOrderedList.Item>
+          </UnOrderedList>
+        ),
+      },
+      {
+        title: 'UnOrderedList with Custom Icon Props',
+        element: (
+          <UnOrderedList>
+            <UnOrderedList.Item
+              icon="HeartSolid"
+              iconProps={{ color: '$iconCritical', size: '$6' }}
+            >
+              Item with red heart icon
+            </UnOrderedList.Item>
+            <UnOrderedList.Item
+              icon="StarSolid"
+              iconProps={{ color: '$iconCaution', size: '$5' }}
+            >
+              Item with yellow star icon
+            </UnOrderedList.Item>
+            <UnOrderedList.Item
+              icon="KingVipCrownSolid"
+              iconProps={{ color: '$iconSuccess', size: '$4' }}
+            >
+              Item with green check icon
+            </UnOrderedList.Item>
+          </UnOrderedList>
+        ),
+      },
+      {
+        title: 'Mixed List (Icons and Bullets)',
+        element: (
+          <UnOrderedList>
+            <UnOrderedList.Item icon="MessageLikeSolid">
+              Document item with icon
+            </UnOrderedList.Item>
+            <UnOrderedList.Item>
+              Regular item with default bullet point
+            </UnOrderedList.Item>
+            <UnOrderedList.Item icon="FolderSolid">
+              Folder item with icon
+            </UnOrderedList.Item>
+            <UnOrderedList.Item>
+              Another regular item with default bullet
+            </UnOrderedList.Item>
+          </UnOrderedList>
+        ),
+      },
+      {
+        title: 'Feature List Example',
+        element: (
+          <UnOrderedList>
+            <UnOrderedList.Item
+              icon="CheckRadioSolid"
+              iconProps={{ color: '$iconSuccess' }}
+            >
+              Support for Manta, Neurai, and Nervos networks
+            </UnOrderedList.Item>
+            <UnOrderedList.Item
+              icon="CheckRadioSolid"
+              iconProps={{ color: '$iconSuccess' }}
+            >
+              Support for LNURL Auth authorization signing
+            </UnOrderedList.Item>
+            <UnOrderedList.Item
+              icon="CheckRadioSolid"
+              iconProps={{ color: '$iconSuccess' }}
+            >
+              Ability to view firmware version in device information
+            </UnOrderedList.Item>
+            <UnOrderedList.Item
+              icon="CheckRadioSolid"
+              iconProps={{ color: '$iconSuccess' }}
+            >
+              New precision display under the Celestia network
+            </UnOrderedList.Item>
+          </UnOrderedList>
+        ),
+      },
+    ]}
+  />
+);
+
+export default UnOrderedListGallery;

--- a/packages/kit/src/views/Developer/pages/Gallery/index.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/index.tsx
@@ -583,6 +583,10 @@ const CryptoGallery = LazyLoadPage(
     ),
 );
 
+const UnOrderedListGallery = LazyLoadPage(
+  () => import('./Components/stories/UnOrderedListGallery'),
+);
+
 export const galleryScreenList: {
   name: EGalleryRoutes;
   component: ComponentType;
@@ -852,5 +856,9 @@ export const galleryScreenList: {
   {
     name: EGalleryRoutes.ComponentCryptoGallery,
     component: CryptoGallery,
+  },
+  {
+    name: EGalleryRoutes.ComponentUnOrderedList,
+    component: UnOrderedListGallery,
   },
 ];

--- a/packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.ts
+++ b/packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.ts
@@ -56,7 +56,10 @@ export function usePrimePaymentMethods(): IUsePrimePayment {
       // TODO how to configure another userId when user login with another account
       // https://www.revenuecat.com/docs/customers/user-ids#logging-in-with-a-custom-app-user-id
 
-      Purchases.configure(apiKey, user?.privyUserId || '');
+      Purchases.configure(
+        apiKey,
+        user?.privyUserId || Purchases.generateRevenueCatAnonymousAppUserId(),
+      );
     },
     [isReady, user?.privyUserId],
   );

--- a/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeUserInfoMoreButton.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeUserInfoMoreButton.tsx
@@ -17,13 +17,13 @@ import { MultipleClickStack } from '@onekeyhq/kit/src/components/MultipleClickSt
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { EModalRoutes } from '@onekeyhq/shared/src/routes/modal';
 import { EPrimePages } from '@onekeyhq/shared/src/routes/prime';
 import { formatDateFns } from '@onekeyhq/shared/src/utils/dateUtils';
 import openUrlUtils from '@onekeyhq/shared/src/utils/openUrlUtils';
 
 import { usePrimeAuthV2 } from '../../hooks/usePrimeAuthV2';
 import { usePrimePayment } from '../../hooks/usePrimePayment';
-import { EModalRoutes } from '@onekeyhq/shared/src/routes/modal';
 
 function PrimeUserInfoMoreButtonDropDownMenu({
   handleActionListClose,

--- a/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeUserInfoMoreButton.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeUserInfoMoreButton.tsx
@@ -14,13 +14,16 @@ import {
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { MultipleClickStack } from '@onekeyhq/kit/src/components/MultipleClickStack';
+import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { EPrimePages } from '@onekeyhq/shared/src/routes/prime';
 import { formatDateFns } from '@onekeyhq/shared/src/utils/dateUtils';
 import openUrlUtils from '@onekeyhq/shared/src/utils/openUrlUtils';
 
 import { usePrimeAuthV2 } from '../../hooks/usePrimeAuthV2';
 import { usePrimePayment } from '../../hooks/usePrimePayment';
+import { EModalRoutes } from '@onekeyhq/shared/src/routes/modal';
 
 function PrimeUserInfoMoreButtonDropDownMenu({
   handleActionListClose,
@@ -36,6 +39,7 @@ function PrimeUserInfoMoreButtonDropDownMenu({
   const primeExpiredAt = user?.primeSubscription?.expiresAt;
   const { getCustomerInfo } = usePrimePayment();
   const [devSettings] = useDevSettingsPersistAtom();
+  const navigation = useAppNavigation();
   const intl = useIntl();
 
   const userInfoView = (
@@ -161,6 +165,38 @@ function PrimeUserInfoMoreButtonDropDownMenu({
               await onLogoutSuccess?.();
             },
           });
+        }}
+      />
+
+      <ActionList.Item
+        label={intl.formatMessage({
+          id: ETranslations.id_delete_onekey_id,
+        })}
+        icon="ErrorOutline"
+        destructive
+        onClose={handleActionListClose}
+        onPress={() => {
+          navigation.pushModal(EModalRoutes.PrimeModal, {
+            screen: EPrimePages.PrimeDeleteAccount,
+          });
+
+          // Dialog.show({
+          //   icon: 'ErrorOutline',
+          //   tone: 'destructive',
+          //   title: intl.formatMessage({
+          //     id: ETranslations.id_delete_onekey_id,
+          //   }),
+          //   description: intl.formatMessage({
+          //     id: ETranslations.id_delete_onekey_id_desc,
+          //   }),
+          //   onConfirmText: intl.formatMessage({
+          //     id: ETranslations.id_delete_onekey_id,
+          //   }),
+          //   onConfirm: async () => {
+          //     await logout();
+          //     await onLogoutSuccess?.();
+          //   },
+          // });
         }}
       />
     </>

--- a/packages/kit/src/views/Prime/pages/PrimeDeleteAccount/PrimeDeleteAccount.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeDeleteAccount/PrimeDeleteAccount.tsx
@@ -23,6 +23,7 @@ import { EPrimeEmailOTPScene } from '@onekeyhq/shared/src/consts/primeConsts';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
+import { EReasonForNeedPassword } from '@onekeyhq/shared/types/setting';
 
 import { usePrimeAuthV2 } from '../../hooks/usePrimeAuthV2';
 
@@ -64,7 +65,14 @@ export default function PrimeDeleteAccount() {
   const { sendEmailOTP } = useLoginOneKeyId();
 
   const handleDeleteAccount = useCallback(async () => {
-    // TODO passcode verify if passcode is set
+    const isPasswordSet =
+      await backgroundApiProxy.servicePassword.checkPasswordSet();
+    //   passcode verify if passcode is set
+    if (isPasswordSet) {
+      await backgroundApiProxy.servicePassword.promptPasswordVerify({
+        reason: EReasonForNeedPassword.Security,
+      });
+    }
     // TODO logout privy sdk
     // TODO logout atom states
     await sendEmailOTP({
@@ -216,15 +224,21 @@ export default function PrimeDeleteAccount() {
             variant: 'destructive',
           }}
         >
-          <Checkbox
-            value={checked}
-            onChange={(value) => {
-              changeChecked(!!value);
+          <Stack
+            $md={{
+              mb: '$2',
             }}
-            label={intl.formatMessage({
-              id: ETranslations.id_delete_double_check,
-            })}
-          />
+          >
+            <Checkbox
+              value={checked}
+              onChange={(value) => {
+                changeChecked(!!value);
+              }}
+              label={intl.formatMessage({
+                id: ETranslations.id_delete_double_check,
+              })}
+            />
+          </Stack>
         </Page.FooterActions>
       </Page.Footer>
     </Page>

--- a/packages/kit/src/views/Prime/pages/PrimeDeleteAccount/PrimeDeleteAccount.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeDeleteAccount/PrimeDeleteAccount.tsx
@@ -1,0 +1,211 @@
+import { useCallback, useState } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import {
+  Alert,
+  Button,
+  Checkbox,
+  Dialog,
+  Icon,
+  Markdown,
+  Page,
+  SizableText,
+  Stack,
+  Toast,
+  YStack,
+} from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { useLoginOneKeyId } from '@onekeyhq/kit/src/hooks/useLoginOneKeyId';
+import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { EPrimeEmailOTPScene } from '@onekeyhq/shared/src/consts/primeConsts';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
+
+import { usePrimeAuthV2 } from '../../hooks/usePrimeAuthV2';
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+
+export default function PrimeDeleteAccount() {
+  const { logout, user, getAccessToken } = usePrimeAuthV2();
+  const navigation = useAppNavigation();
+  const intl = useIntl();
+
+  const {
+    result: canDeleteAccount,
+    isLoading,
+    run: checkDeleteEligibility,
+  } = usePromiseResult(
+    async () => {
+      // Check if user has active subscription or other restrictions
+      const token = await getAccessToken();
+      if (!token) {
+        return { canDelete: false, reason: 'No access token' };
+      }
+
+      // Check if user has active Prime subscription
+      if (user?.primeSubscription?.isActive) {
+        return {
+          canDelete: false,
+          reason: intl.formatMessage({
+            id: ETranslations.Limit_expire_day,
+          }),
+        };
+      }
+
+      return { canDelete: true, reason: null };
+    },
+    [getAccessToken, user, intl],
+    {
+      watchLoading: true,
+    },
+  );
+
+  const { sendEmailOTP } = useLoginOneKeyId();
+
+  const handleDeleteAccount = useCallback(async () => {
+    await sendEmailOTP({
+      scene: EPrimeEmailOTPScene.DeleteOneKeyId,
+      onConfirm: async (emailOTP) => {
+        console.log('emailOTP>>>>>>', emailOTP);
+        await timerUtils.wait(2000);
+        throw new OneKeyLocalError('emailOTP error');
+        // return backgroundApiProxy.serviceReferralCode.bindAddress({
+        //   networkId,
+        //   address,
+        //   emailOTP,
+        // });
+      },
+    });
+
+    // try {
+    //   const token = await getAccessToken();
+    //   if (!token) {
+    //     Toast.error({
+    //       title: intl.formatMessage({
+    //         id: ETranslations.prime_onekeyid_log_out,
+    //       }),
+    //     });
+    //     return;
+    //   }
+
+    //   // Show final confirmation dialog
+    //   Dialog.show({
+    //     icon: 'ErrorOutline',
+    //     tone: 'destructive',
+    //     title: intl.formatMessage({
+    //       id: ETranslations.prime_onekeyid_log_out,
+    //     }),
+    //     description: intl.formatMessage({
+    //       id: ETranslations.prime_onekeyid_log_out_description,
+    //     }),
+    //     onConfirmText: intl.formatMessage({
+    //       id: ETranslations.id_delete_onekey_id,
+    //     }),
+    //     onConfirm: async () => {
+    //       try {
+    //         // Call the delete account API
+    //         await backgroundApiProxy.servicePrime.apiDeletePrimeAccount({
+    //           accessToken: token,
+    //         });
+
+    //         // Logout after successful deletion
+    //         await logout();
+
+    //         Toast.success({
+    //           title: intl.formatMessage({
+    //             id: ETranslations.prime_onekeyid_log_out,
+    //           }),
+    //         });
+
+    //         // Navigate back to login or dashboard
+    //         navigation.popStack();
+    //       } catch (error) {
+    //         console.error('Delete account error:', error);
+    //         Toast.error({
+    //           title: intl.formatMessage({
+    //             id: ETranslations.prime_onekeyid_log_out,
+    //           }),
+    //         });
+    //       }
+    //     },
+    //   });
+    // } catch (error) {
+    //   console.error('Delete account preparation error:', error);
+    //   Toast.error({
+    //     title: intl.formatMessage({
+    //       id: ETranslations.prime_onekeyid_log_out,
+    //     }),
+    //   });
+    // }
+  }, [sendEmailOTP]);
+
+  const [checked, changeChecked] = useState(false);
+
+  return (
+    <Page scrollEnabled>
+      <Page.Header
+        headerTitle={intl.formatMessage({
+          id: ETranslations.id_delete_onekey_id,
+        })}
+      />
+      <Page.Body>
+        <YStack p="$5" gap="$5" alignItems="center">
+          <Dialog.Icon
+            icon="ErrorOutline"
+            tone="destructive"
+            alignSelf="center"
+            mb={0}
+          />
+          <SizableText size="$headingXl" textAlign="center">
+            {intl.formatMessage({
+              id: ETranslations.id_delete_onekey_id,
+            })}
+          </SizableText>
+          <SizableText size="$bodyMd" color="$textSubdued" textAlign="center">
+            {intl.formatMessage({
+              id: ETranslations.id_delete_onekey_id_desc,
+            })}
+          </SizableText>
+
+          {/* Warning Alert */}
+          <Alert type="default">
+            <Markdown>
+              {intl.formatMessage({
+                id: ETranslations.id_delete_onekey_id_detail_markdown,
+              })}
+            </Markdown>
+          </Alert>
+        </YStack>
+      </Page.Body>
+      <Page.Footer>
+        <Page.FooterActions
+          onCancelText={intl.formatMessage({
+            id: ETranslations.global_cancel,
+          })}
+          onCancel={() => {
+            //
+          }}
+          onConfirmText={intl.formatMessage({
+            id: ETranslations.global_delete,
+          })}
+          onConfirm={handleDeleteAccount}
+          confirmButtonProps={{
+            disabled: !checked,
+            variant: 'destructive',
+          }}
+        >
+          <Checkbox
+            value={checked}
+            onChange={(value) => {
+              changeChecked(!!value);
+            }}
+            label={intl.formatMessage({
+              id: ETranslations.id_delete_double_check,
+            })}
+          />
+        </Page.FooterActions>
+      </Page.Footer>
+    </Page>
+  );
+}

--- a/packages/kit/src/views/Prime/pages/PrimeDeleteAccount/PrimeDeleteAccount.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeDeleteAccount/PrimeDeleteAccount.tsx
@@ -20,11 +20,11 @@ import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useLoginOneKeyId } from '@onekeyhq/kit/src/hooks/useLoginOneKeyId';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { EPrimeEmailOTPScene } from '@onekeyhq/shared/src/consts/primeConsts';
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
 import { usePrimeAuthV2 } from '../../hooks/usePrimeAuthV2';
-import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 
 export default function PrimeDeleteAccount() {
   const { logout, user, getAccessToken } = usePrimeAuthV2();
@@ -64,17 +64,38 @@ export default function PrimeDeleteAccount() {
   const { sendEmailOTP } = useLoginOneKeyId();
 
   const handleDeleteAccount = useCallback(async () => {
+    // TODO passcode verify if passcode is set
+    // TODO logout privy sdk
+    // TODO logout atom states
     await sendEmailOTP({
       scene: EPrimeEmailOTPScene.DeleteOneKeyId,
       onConfirm: async (emailOTP) => {
         console.log('emailOTP>>>>>>', emailOTP);
         await timerUtils.wait(2000);
-        throw new OneKeyLocalError('emailOTP error');
+        // throw new OneKeyLocalError('emailOTP error');
         // return backgroundApiProxy.serviceReferralCode.bindAddress({
         //   networkId,
         //   address,
         //   emailOTP,
         // });
+        navigation.popStack();
+        Dialog.show({
+          icon: 'CheckRadioSolid',
+          tone: 'success',
+          title: intl.formatMessage({
+            id: ETranslations.id_onekey_id_deleted_title,
+          }),
+          description: intl.formatMessage({
+            id: ETranslations.id_onekey_id_deleted_desc,
+          }),
+          showCancelButton: false,
+          onConfirmText: intl.formatMessage({
+            id: ETranslations.global_done,
+          }),
+          onConfirm: async () => {
+            console.log('onConfirm');
+          },
+        });
       },
     });
 
@@ -138,7 +159,7 @@ export default function PrimeDeleteAccount() {
     //     }),
     //   });
     // }
-  }, [sendEmailOTP]);
+  }, [intl, navigation, sendEmailOTP]);
 
   const [checked, changeChecked] = useState(false);
 

--- a/packages/kit/src/views/Prime/pages/PrimeDeleteAccount/PrimeDeleteAccount.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeDeleteAccount/PrimeDeleteAccount.tsx
@@ -73,21 +73,40 @@ export default function PrimeDeleteAccount() {
         reason: EReasonForNeedPassword.Security,
       });
     }
-    // TODO logout privy sdk
-    // TODO logout atom states
     await sendEmailOTP({
       scene: EPrimeEmailOTPScene.DeleteOneKeyId,
-      onConfirm: async (emailOTP) => {
-        console.log('emailOTP>>>>>>', emailOTP);
-        await timerUtils.wait(2000);
-        // throw new OneKeyLocalError('emailOTP error');
-        // return backgroundApiProxy.serviceReferralCode.bindAddress({
-        //   networkId,
-        //   address,
-        //   emailOTP,
-        // });
+      onConfirm: async ({ code, uuid }) => {
+        console.log('emailOTP>>>>>>', code, uuid);
+        const deleteResult =
+          await backgroundApiProxy.servicePrime.apiDeleteAccount({
+            uuid,
+            emailOTP: code,
+          });
+        console.log('deleteResult>>>>>>', deleteResult);
+
+        if (!deleteResult?.ok) {
+          Toast.error({
+            title: intl.formatMessage({
+              id: ETranslations.global_failed,
+            }),
+          });
+          return;
+        }
+
+        try {
+          // logout privy sdk
+          await logout();
+        } catch (error) {
+          console.error('logout error', error);
+        }
+
+        //  logout atom states
+        await backgroundApiProxy.servicePrime.setPrimePersistAtomNotLoggedIn();
+
         navigation.popStack();
         Dialog.show({
+          dismissOnOverlayPress: false,
+          disableDrag: true,
           icon: 'CheckRadioSolid',
           tone: 'success',
           title: intl.formatMessage({
@@ -167,7 +186,7 @@ export default function PrimeDeleteAccount() {
     //     }),
     //   });
     // }
-  }, [intl, navigation, sendEmailOTP]);
+  }, [intl, navigation, sendEmailOTP, logout]);
 
   const [checked, changeChecked] = useState(false);
 

--- a/packages/kit/src/views/Prime/pages/PrimeDeleteAccount/index.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeDeleteAccount/index.tsx
@@ -1,0 +1,3 @@
+import PrimeDeleteAccount from './PrimeDeleteAccount';
+
+export default PrimeDeleteAccount; 

--- a/packages/kit/src/views/Prime/pages/PrimeDeleteAccount/index.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeDeleteAccount/index.tsx
@@ -1,3 +1,3 @@
 import PrimeDeleteAccount from './PrimeDeleteAccount';
 
-export default PrimeDeleteAccount; 
+export default PrimeDeleteAccount;

--- a/packages/kit/src/views/Prime/router/index.ts
+++ b/packages/kit/src/views/Prime/router/index.ts
@@ -13,6 +13,9 @@ const PrimeCloudSyncDebug = LazyLoadPage(
   () => import('../pages/PrimeCloudSync/PagePrimeCloudSyncDebug'),
 );
 const PrimeFeatures = LazyLoadPage(() => import('../pages/PrimeFeatures'));
+const PrimeDeleteAccount = LazyLoadPage(
+  () => import('../pages/PrimeDeleteAccount'),
+);
 
 export const PrimeRouter: IModalFlowNavigatorConfig<
   EPrimePages,
@@ -37,5 +40,9 @@ export const PrimeRouter: IModalFlowNavigatorConfig<
   {
     name: EPrimePages.PrimeFeatures,
     component: PrimeFeatures,
+  },
+  {
+    name: EPrimePages.PrimeDeleteAccount,
+    component: PrimeDeleteAccount,
   },
 ];

--- a/packages/kit/src/views/ReferFriends/pages/EditAddress/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/EditAddress/index.tsx
@@ -32,6 +32,7 @@ import { renderAddressSecurityHeaderRightButton } from '@onekeyhq/kit/src/compon
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useLoginOneKeyId } from '@onekeyhq/kit/src/hooks/useLoginOneKeyId';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { EPrimeEmailOTPScene } from '@onekeyhq/shared/src/consts/primeConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type {
   EModalReferFriendsRoutes,
@@ -40,7 +41,6 @@ import type {
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import type { RouteProp } from '@react-navigation/native';
-import { EPrimeEmailOTPScene } from '@onekeyhq/shared/src/consts/primeConsts';
 
 type IFormValues = {
   networkId: string;
@@ -167,6 +167,13 @@ function BasicEditAddress() {
             emailOTP,
           });
         },
+        description: ({ userInfo }) =>
+          intl.formatMessage(
+            {
+              id: ETranslations.referral_address_update_desc,
+            },
+            { mail: userInfo.displayEmail ?? '' },
+          ),
       });
 
       navigation.pop();
@@ -177,7 +184,7 @@ function BasicEditAddress() {
         });
       });
     },
-    [navigation, onAddressAdded, sendEmailOTP],
+    [navigation, onAddressAdded, sendEmailOTP, intl],
   );
 
   const contextValue = useMemo(

--- a/packages/kit/src/views/ReferFriends/pages/EditAddress/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/EditAddress/index.tsx
@@ -40,6 +40,7 @@ import type {
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import type { RouteProp } from '@react-navigation/native';
+import { EPrimeEmailOTPScene } from '@onekeyhq/shared/src/consts/primeConsts';
 
 type IFormValues = {
   networkId: string;
@@ -158,6 +159,7 @@ function BasicEditAddress() {
       const address = values.to.resolved ?? '';
       const networkId = values.networkId ?? '';
       await sendEmailOTP({
+        scene: EPrimeEmailOTPScene.UpdateRebateWithdrawAddress,
         onConfirm: async (emailOTP) => {
           return backgroundApiProxy.serviceReferralCode.bindAddress({
             networkId,

--- a/packages/kit/src/views/ReferFriends/pages/EditAddress/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/EditAddress/index.tsx
@@ -160,11 +160,12 @@ function BasicEditAddress() {
       const networkId = values.networkId ?? '';
       await sendEmailOTP({
         scene: EPrimeEmailOTPScene.UpdateRebateWithdrawAddress,
-        onConfirm: async (emailOTP) => {
+        onConfirm: async ({ code, uuid }) => {
           return backgroundApiProxy.serviceReferralCode.bindAddress({
             networkId,
             address,
-            emailOTP,
+            emailOTP: code,
+            uuid,
           });
         },
         description: ({ userInfo }) =>

--- a/packages/kit/src/views/SignatureConfirm/components/TxFee/TxFeeInfo.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/TxFee/TxFeeInfo.tsx
@@ -16,6 +16,7 @@ import type { IEncodedTxAptos } from '@onekeyhq/core/src/chains/aptos/types';
 import type { IEncodedTxBtc } from '@onekeyhq/core/src/chains/btc/types';
 import type { IEncodedTxDot } from '@onekeyhq/core/src/chains/dot/types';
 import type { IEncodedTxEvm } from '@onekeyhq/core/src/chains/evm/types';
+import { tronTokenAddress } from '@onekeyhq/core/src/chains/tron/constants';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import {
@@ -71,7 +72,6 @@ import type {
 
 import { TxFeeEditor } from './TxFeeEditor';
 import { TxFeeSelectorTrigger } from './TxFeeSelectorTrigger';
-import { tronTokenAddress } from '@onekeyhq/core/src/chains/tron/constants';
 
 type IProps = {
   accountId: string;

--- a/packages/shared/src/config/appConfig.ts
+++ b/packages/shared/src/config/appConfig.ts
@@ -13,7 +13,8 @@ export const HARDWARE_BRIDGE_DOWNLOAD_URL =
   'https://onekey.so/download/?client=bridge';
 
 export const FIRMWARE_UPDATE_WEB_TOOLS_URL = 'https://firmware.onekey.so';
-export const FIRMWARE_CONTACT_US_URL = 'https://help.onekey.so/articles/11536900';
+export const FIRMWARE_CONTACT_US_URL =
+  'https://help.onekey.so/articles/11536900';
 export const FIRMWARE_MANUAL_ENTERING_BOOTLOADER_MODE_GUIDE =
   'https://help.onekey.so/articles/11461126';
 export const FIRMWARE_UPDATE_FULL_RES_GUIDE =

--- a/packages/shared/src/consts/primeConsts.ts
+++ b/packages/shared/src/consts/primeConsts.ts
@@ -28,7 +28,7 @@ export enum EPrimeCloudSyncDataType {
 
 export enum EPrimeEmailOTPScene {
   UpdateRebateWithdrawAddress = 'UpdateReabteWithdrawAddress',
-  DeleteOneKeyId = 'DeleteOneKeyId',
+  DeleteOneKeyId = 'DeleteAccount',
 }
 
 export const PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME = 144_000_000; // '1970/01/03'

--- a/packages/shared/src/consts/primeConsts.ts
+++ b/packages/shared/src/consts/primeConsts.ts
@@ -26,6 +26,11 @@ export enum EPrimeCloudSyncDataType {
   CustomRpc = 'CustomRpc',
 }
 
+export enum EPrimeEmailOTPScene {
+  UpdateRebateWithdrawAddress = 'UpdateReabteWithdrawAddress',
+  DeleteOneKeyId = 'DeleteOneKeyId',
+}
+
 export const PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME = 144_000_000; // '1970/01/03'
 export const RESET_CLOUD_SYNC_MASTER_PASSWORD_UUID =
   '180B50C8-E4EC-40E9-9CF3-7DD71F2882F7';

--- a/packages/shared/src/routes/gallery.ts
+++ b/packages/shared/src/routes/gallery.ts
@@ -89,5 +89,6 @@ export enum EGalleryRoutes {
   ComponentStepper = 'component-Stepper',
   CountDownCalendarAlert = 'component-CountDownCalendarAlert',
   ComponentRestart = 'component-Restart',
+  ComponentUnOrderedList = 'component-UnOrderedList',
   FontGallery = 'component-Font',
 }

--- a/packages/shared/src/routes/prime.ts
+++ b/packages/shared/src/routes/prime.ts
@@ -6,6 +6,7 @@ export enum EPrimePages {
   PrimeCloudSync = 'PrimeCloudSync',
   PrimeCloudSyncDebug = 'PrimeCloudSyncDebug',
   PrimeFeatures = 'PrimeFeatures',
+  PrimeDeleteAccount = 'PrimeDeleteAccount',
 }
 
 export enum EPrimeFeatures {
@@ -26,4 +27,5 @@ export type IPrimeParamList = {
     selectedSubscriptionPeriod?: ISubscriptionPeriod;
     showAllFeatures?: boolean;
   };
+  [EPrimePages.PrimeDeleteAccount]: undefined;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability for users to delete their OneKey ID account, including a dedicated UI flow with password and email OTP confirmation, and a new destructive action in the Prime user menu.
  - Added support for specifying OTP scenarios, such as account deletion and address updates, improving flexibility in authentication flows.
  - Showcased new UnOrderedList component variations in the developer gallery.

- **Improvements**
  - Enhanced OTP verification dialogs with asynchronous confirmation handling and clearer loading states.
  - Allowed customization of icon layout and styling in dialog components.
  - Improved user identification in payment methods by generating anonymous IDs when needed.

- **Bug Fixes / Maintenance**
  - Refactored and cleaned up code formatting, imports, and documentation without affecting functionality.
  - Updated types and method signatures for stricter input validation and more detailed response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->