### PR TITLE
fix: add new regex replacements to ChromeExtensionV3ViolationPlugin

### DIFF
--- a/development/webpack/webpack.ext.config.js
+++ b/development/webpack/webpack.ext.config.js
@@ -47,7 +47,7 @@ const chromeExtensionV3ViolationPlugin = new ChromeExtensionV3ViolationPlugin([
   },
   // maps.googleapis.com
   {
-    regexToFind: /https:\/\/maps.googleapis.com\/maps\/api\/js/g,
+    regexToFind: /https:\/\/maps\.googleapis\.com\/maps\/api\/js/g,
     replacement: '',
   },
   // js.stripe.com

--- a/development/webpack/webpack.ext.config.js
+++ b/development/webpack/webpack.ext.config.js
@@ -45,6 +45,16 @@ const chromeExtensionV3ViolationPlugin = new ChromeExtensionV3ViolationPlugin([
     regexToFind: /g\.src=`\${v}\/js\/telegram-login\.js`/g,
     replacement: 'g.src=``',
   },
+  // maps.googleapis.com
+  {
+    regexToFind: /https:\/\/maps.googleapis.com\/maps\/api\/js/g,
+    replacement: '',
+  },
+  // js.stripe.com
+  {
+    regexToFind: /\.p="https:\/\/js\.stripe\.com\/v3\/"/g,
+    replacement: '.p=""',
+  },
 ]);
 
 module.exports = ({


### PR DESCRIPTION
Added regex rules to remove or replace references to maps.googleapis.com and js.stripe.com in the ChromeExtensionV3ViolationPlugin. This helps ensure compliance with Chrome Extension V3 requirements by blocking external script loads from these sources.