### PR TITLE
fix: remove unused error code for onekey id logout OK-39463 OK-39461 

### DIFF
--- a/packages/kit-bg/src/services/ServiceBase.ts
+++ b/packages/kit-bg/src/services/ServiceBase.ts
@@ -80,7 +80,7 @@ export default class ServiceBase {
           const errorCode: number | undefined = errorData?.data?.code;
           // TODO 90_002 sdk refresh token required
           // TODO 90_003 user login required
-          if ([90_002, 90_003, 90_008].includes(errorCode)) {
+          if ([90_002, 90_003].includes(errorCode)) {
             appEventBus.emit(
               EAppEventBusNames.PrimeLoginInvalidToken,
               undefined,

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/index.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/index.tsx
@@ -632,7 +632,12 @@ function WalletDetailsView({ num }: IWalletDetailsProps) {
   ]);
 
   return (
-    <Stack flex={1} pb={bottom} testID="account-selector-accountList">
+    <Stack
+      key={focusedWalletInfo?.wallet?.id}
+      flex={1}
+      pb={bottom}
+      testID="account-selector-accountList"
+    >
       <WalletDetailsHeader
         wallet={focusedWalletInfo?.wallet}
         device={focusedWalletInfo?.device}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted error handling so that only specific error codes will trigger a login invalid token event, reducing unnecessary login interruptions.
* **Improvements**
  * Enhanced wallet details view to refresh correctly when switching between wallets for a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->