### PR TITLE
OK-39504, OK-39505:  Simplify WalletEditButton by removing conditional rendering for WalletBoundReferralCodeButton

### DIFF
--- a/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletBoundReferralCodeButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletBoundReferralCodeButton.tsx
@@ -75,7 +75,7 @@ function WalletBoundReferralCodeButtonView({
   ]);
 
   if (!displayReferralCodeButton) {
-    // return null;
+    return null;
   }
 
   return (
@@ -85,13 +85,6 @@ function WalletBoundReferralCodeButtonView({
       label={intl.formatMessage({
         id: ETranslations.referral_wallet_edit_code,
       })}
-      extra={
-        displayReferralCodeButton ? undefined : (
-          <SizableText size="$bodyMd" color="$textSuccess">
-            已绑定
-          </SizableText>
-        )
-      }
       onPress={handlePress}
       isLoading={isLoading}
       onClose={onClose}

--- a/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletEditButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletEditButton.tsx
@@ -54,17 +54,6 @@ function WalletEditButtonView({
     );
   }, [wallet]);
 
-  const showBoundReferralCodeButton = useMemo(() => {
-    if (wallet?.isMocked) {
-      return false;
-    }
-    return (
-      accountUtils.isHdWallet({ walletId: wallet?.id }) ||
-      (!accountUtils.isHwHiddenWallet({ wallet }) &&
-        accountUtils.isHwWallet({ walletId: wallet?.id }))
-    );
-  }, [wallet]);
-
   const showBackupButton = useMemo(() => {
     return accountUtils.isHdWallet({ walletId: wallet?.id });
   }, [wallet]);
@@ -81,12 +70,10 @@ function WalletEditButtonView({
       return (
         // fix missing context in popover
         <AccountSelectorProviderMirror enabledNum={[0]} config={config}>
-          {showBoundReferralCodeButton ? (
-            <WalletBoundReferralCodeButton
-              wallet={wallet}
-              onClose={handleActionListClose}
-            />
-          ) : null}
+          <WalletBoundReferralCodeButton
+            wallet={wallet}
+            onClose={handleActionListClose}
+          />
 
           {showBackupButton ? (
             <HdWalletBackupButton
@@ -134,7 +121,6 @@ function WalletEditButtonView({
     },
     [
       config,
-      showBoundReferralCodeButton,
       wallet,
       showBackupButton,
       showDeviceManagementButton,

--- a/packages/kit/src/views/Staking/components/ProtocolDetails/EarnActionIcon.tsx
+++ b/packages/kit/src/views/Staking/components/ProtocolDetails/EarnActionIcon.tsx
@@ -392,6 +392,19 @@ function BasicClaimWithKycActionIcon({
 
 const ClaimWithKycActionIcon = memo(BasicClaimWithKycActionIcon);
 
+const f = [
+  {
+    'text': '7% of profit (OneKey 4.2% + Vault manager 2.8%)',
+  },
+  {
+    'text': 'Charged only on profit, not principal',
+  },
+  {
+    'text':
+      'Charged only on profit, not principal, 7% of profit (OneKey 4.2% + Vault manager 2.8%), 7% of profit (OneKey 4.2% + Vault manager 2.8%)',
+  },
+];
+
 function BasicEarnActionIcon({
   title,
   actionIcon,
@@ -456,7 +469,7 @@ function BasicEarnActionIcon({
           }
           renderContent={
             <ActionPopupContent
-              bulletList={actionIcon.data.bulletList}
+              bulletList={f}
               items={actionIcon.data.items}
               panel={actionIcon.data.panel}
             />

--- a/packages/kit/src/views/Staking/components/ProtocolDetails/EarnActionIcon.tsx
+++ b/packages/kit/src/views/Staking/components/ProtocolDetails/EarnActionIcon.tsx
@@ -392,19 +392,6 @@ function BasicClaimWithKycActionIcon({
 
 const ClaimWithKycActionIcon = memo(BasicClaimWithKycActionIcon);
 
-const f = [
-  {
-    'text': '7% of profit (OneKey 4.2% + Vault manager 2.8%)',
-  },
-  {
-    'text': 'Charged only on profit, not principal',
-  },
-  {
-    'text':
-      'Charged only on profit, not principal, 7% of profit (OneKey 4.2% + Vault manager 2.8%), 7% of profit (OneKey 4.2% + Vault manager 2.8%)',
-  },
-];
-
 function BasicEarnActionIcon({
   title,
   actionIcon,
@@ -469,7 +456,7 @@ function BasicEarnActionIcon({
           }
           renderContent={
             <ActionPopupContent
-              bulletList={f}
+              bulletList={actionIcon.data.bulletList}
               items={actionIcon.data.items}
               panel={actionIcon.data.panel}
             />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the logic for displaying the referral code button in wallet editing, removing conditional rendering and the "已绑定" label. The referral code button is now always rendered in the wallet edit interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->