### PR TITLE
chore: Update network name from 'cryptoorgchain' to 'cronosposchain'

### DIFF
--- a/development/spellCheckerSkipWords.js
+++ b/development/spellCheckerSkipWords.js
@@ -195,7 +195,7 @@ module.exports = [
   'Cron',
   'crosshair',
   'Crosshair',
-  'cryptoorgchain',
+  'cronosposchain',
   'csp',
   'ctime',
   'Ctx',

--- a/packages/core/src/chains/cosmos/sdkCosmos/query/MintScanQuery.ts
+++ b/packages/core/src/chains/cosmos/sdkCosmos/query/MintScanQuery.ts
@@ -19,7 +19,7 @@ import type {
 import type { AxiosInstance } from 'axios';
 
 const NetworkIDMinScanMap: Record<string, string> = {
-  [getNetworkIdsMap().cryptoorgchain]: 'cryptoorg',
+  [getNetworkIdsMap().cronosposchain]: 'cryptoorg',
   [getNetworkIdsMap().cosmoshub]: 'cosmos',
   [getNetworkIdsMap().akash]: 'akash',
   [getNetworkIdsMap().fetch]: 'fetchai',

--- a/packages/shared/src/config/networkIds.ts
+++ b/packages/shared/src/config/networkIds.ts
@@ -42,7 +42,7 @@ export type INetworkShortCode =
   | 'akash'
   | 'fetch'
   | 'terra'
-  | 'cryptoorgchain'
+  | 'cronosposchain'
   | 'injective'
   | 'polygon'
   | 'tlightning'

--- a/packages/shared/src/config/presetNetworks.ts
+++ b/packages/shared/src/config/presetNetworks.ts
@@ -2095,17 +2095,17 @@ const akash: IServerNetwork = {
   'status': ENetworkStatus.LISTED,
 };
 
-const cryptoorgchain: IServerNetwork = {
+const cronosPosChain: IServerNetwork = {
   'chainId': 'crypto-org-chain-mainnet-1',
-  'code': 'cryptoorgchain',
+  'code': 'cronosposchain',
   'decimals': 8,
   'id': 'cosmos--crypto-org-chain-mainnet-1',
   'impl': 'cosmos',
   'isTestnet': false,
   'logoURI': 'https://uni.onekey-asset.com/static/chain/cryptoorg.png',
-  'name': 'Crypto.org',
-  'shortcode': 'cryptoorgchain',
-  'shortname': 'Crypto.org',
+  'name': 'Cronos POS Chain',
+  'shortcode': 'cronosposchain',
+  'shortname': 'Cronos POS Chain',
   'symbol': 'CRO',
   'feeMeta': {
     'decimals': 8,
@@ -2918,7 +2918,7 @@ export const presetNetworksMap = {
   secret,
   juno,
   fetchai,
-  cryptoorgchain,
+  cronosPosChain,
   akash,
   osmosis,
   cosmoshub,
@@ -3112,7 +3112,7 @@ export const getPresetNetworks = memoFn((): IServerNetwork[] => {
     secret,
     juno,
     fetchai,
-    cryptoorgchain,
+    cronosPosChain,
     akash,
     osmosis,
     cosmoshub,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the network name and references from "Crypto.org Chain" to "Cronos POS Chain" across the application.
* **Bug Fixes**
  * Ensured all spell checker and network configuration references use the new "cronosposchain" identifier instead of "cryptoorgchain".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->