### PR TITLE
optimize: all networks icon/send token selector styles & fix: several issues OK-39602 OK-39531 OK-39517 OK-39510

### DIFF
--- a/packages/kit-bg/src/services/ServiceUniversalSearch.ts
+++ b/packages/kit-bg/src/services/ServiceUniversalSearch.ts
@@ -349,11 +349,17 @@ class ServiceUniversalSearch extends ServiceBase {
   }
 
   private getUniversalValidateNetworkIds = memoizee(
-    async () => {
+    async ({ networkId }: { networkId?: string }) => {
       const { serviceNetwork } = this.backgroundApi;
       const { networks } = await serviceNetwork.getAllNetworks();
       let isEvmAddressChecked = false;
       const items: string[] = [];
+
+      if (networkId && networkUtils.isEvmNetwork({ networkId })) {
+        isEvmAddressChecked = true;
+        items.push(networkId);
+      }
+
       for (const network of networks) {
         if (networkUtils.isLightningNetworkByNetworkId(network.id)) {
           // eslint-disable-next-line no-continue
@@ -395,7 +401,9 @@ class ServiceUniversalSearch extends ServiceBase {
     });
 
     // Step 1: Get supported networks and batch validate
-    const networkIdList = await this.getUniversalValidateNetworkIds();
+    const networkIdList = await this.getUniversalValidateNetworkIds({
+      networkId,
+    });
     const batchValidateResult =
       await serviceValidator.serverBatchValidateAddress({
         networkIdList,

--- a/packages/kit/src/components/AccountSelector/AccountSelectorTrigger/AccountSelectorTriggerDApp.tsx
+++ b/packages/kit/src/components/AccountSelector/AccountSelectorTrigger/AccountSelectorTriggerDApp.tsx
@@ -436,6 +436,7 @@ export function AccountSelectorTriggerAddressSingle({
         logoURI={network?.logoURI ?? ''}
         isCustomNetwork={network?.isCustomNetwork}
         networkName={network?.name}
+        isAllNetworks={network?.isAllNetworks}
         size="$4"
       />
       <SizableText

--- a/packages/kit/src/components/NetworkAvatar/NetworkAvatar.tsx
+++ b/packages/kit/src/components/NetworkAvatar/NetworkAvatar.tsx
@@ -1,4 +1,10 @@
-import type { IImageProps, IXStackProps } from '@onekeyhq/components';
+import type { ComponentProps } from 'react';
+
+import type {
+  IImageProps,
+  IXStackProps,
+  SizeTokens,
+} from '@onekeyhq/components';
 import { Icon, Image, XStack } from '@onekeyhq/components';
 import type { IServerNetwork } from '@onekeyhq/shared/types';
 
@@ -11,14 +17,37 @@ export const NetworkAvatarBase = ({
   size,
   isCustomNetwork,
   networkName,
+  isAllNetworks,
+  allNetworksIconProps,
 }: {
   logoURI: string;
   size?: IImageProps['size'];
   isCustomNetwork?: boolean;
   networkName?: string;
+  isAllNetworks?: boolean;
+  allNetworksIconProps?: ComponentProps<typeof Icon>;
 }) => {
   if (isCustomNetwork) {
     return <LetterAvatar letter={networkName?.[0]} size={size} />;
+  }
+  if (isAllNetworks) {
+    if (size) {
+      return (
+        <Icon
+          name="GlobusOutline"
+          color="$iconSubdued"
+          size={size as SizeTokens}
+          {...allNetworksIconProps}
+        />
+      );
+    }
+    return (
+      <Icon
+        name="GlobusOutline"
+        color="$iconSubdued"
+        {...allNetworksIconProps}
+      />
+    );
   }
   return (
     <Image size={size} src={logoURI} borderRadius="$full">
@@ -40,9 +69,14 @@ type INetworkAvatarProps = {
   networkId?: string;
   size?: IImageProps['size'];
   isCustomNetwork?: boolean;
+  allNetworksIconProps?: ComponentProps<typeof Icon>;
 };
 
-export function NetworkAvatar({ networkId, size = '$6' }: INetworkAvatarProps) {
+export function NetworkAvatar({
+  networkId,
+  size = '$6',
+  allNetworksIconProps,
+}: INetworkAvatarProps) {
   const { serviceNetwork } = backgroundApiProxy;
   const res = usePromiseResult(
     () =>
@@ -58,11 +92,19 @@ export function NetworkAvatar({ networkId, size = '$6' }: INetworkAvatarProps) {
       checkIsFocused: false,
     },
   );
-  const { logoURI, isCustomNetwork, name } = res.result || {};
+  const { logoURI, isCustomNetwork, name, isAllNetworks } = res.result || {};
+
   if (isCustomNetwork) {
     return <LetterAvatar letter={name?.[0]} size={size} />;
   }
-  return logoURI ? <NetworkAvatarBase size={size} logoURI={logoURI} /> : null;
+  return logoURI ? (
+    <NetworkAvatarBase
+      size={size}
+      logoURI={logoURI}
+      isAllNetworks={isAllNetworks}
+      allNetworksIconProps={allNetworksIconProps}
+    />
+  ) : null;
 }
 
 type INetworkAvatarGroupProps = {

--- a/packages/kit/src/components/NetworksFilterItem/index.tsx
+++ b/packages/kit/src/components/NetworksFilterItem/index.tsx
@@ -1,6 +1,14 @@
+import { useCallback } from 'react';
+
 import { StyleSheet } from 'react-native';
 
-import { Image, SizableText, Tooltip, XStack } from '@onekeyhq/components';
+import {
+  Icon,
+  Image,
+  SizableText,
+  Tooltip,
+  XStack,
+} from '@onekeyhq/components';
 import type { IXStackProps } from '@onekeyhq/components';
 
 export type INetworksFilterItemProps = {
@@ -9,6 +17,7 @@ export type INetworksFilterItemProps = {
   isSelected?: boolean;
   tooltipContent?: string;
   disabled?: boolean;
+  isAllNetworks?: boolean;
 } & IXStackProps;
 
 export function NetworksFilterItem({
@@ -17,8 +26,39 @@ export function NetworksFilterItem({
   isSelected,
   tooltipContent,
   disabled,
+  isAllNetworks,
   ...rest
 }: INetworksFilterItemProps) {
+  const renderNetworkImage = useCallback(() => {
+    if (isAllNetworks) {
+      return (
+        <Icon
+          name="GlobusOutline"
+          color="$iconActive"
+          size="$6"
+          $gtMd={{ size: '$5' }}
+        />
+      );
+    }
+    return networkImageUri ? (
+      <Image
+        height="$6"
+        width="$6"
+        borderRadius="$full"
+        $gtMd={{
+          height: '$5',
+          width: '$5',
+        }}
+      >
+        <Image.Source
+          source={{
+            uri: networkImageUri,
+          }}
+        />
+      </Image>
+    ) : null;
+  }, [isAllNetworks, networkImageUri]);
+
   const BaseComponent = (
     <XStack
       justifyContent="center"
@@ -48,23 +88,7 @@ export function NetworksFilterItem({
       })}
       {...rest}
     >
-      {networkImageUri ? (
-        <Image
-          height="$6"
-          width="$6"
-          borderRadius="$full"
-          $gtMd={{
-            height: '$5',
-            width: '$5',
-          }}
-        >
-          <Image.Source
-            source={{
-              uri: networkImageUri,
-            }}
-          />
-        </Image>
-      ) : null}
+      {renderNetworkImage()}
       {networkName ? (
         <SizableText
           numberOfLines={1}

--- a/packages/kit/src/components/TokenListView/TokenListItem.tsx
+++ b/packages/kit/src/components/TokenListView/TokenListItem.tsx
@@ -67,7 +67,11 @@ function BasicTokenListItem(props: ITokenListItemProps) {
                 size="$bodyMd"
                 color="$textSubdued"
               />
-              <TokenPriceChangeView $key={token.$key ?? ''} size="$bodyMd" />
+              <TokenPriceChangeView
+                $key={token.$key ?? ''}
+                size="$bodyMd"
+                numberOfLines={1}
+              />
             </XStack>
           </YStack>
         </XStack>
@@ -114,8 +118,16 @@ function BasicTokenListItem(props: ITokenListItemProps) {
 
     return (
       <YStack alignItems="flex-end" flexGrow={1} flexBasis={0} maxWidth="$36">
-        <TokenPriceView $key={token.$key ?? ''} size="$bodyMdMedium" />
-        <TokenPriceChangeView $key={token.$key ?? ''} size="$bodyMd" />
+        <TokenPriceView
+          $key={token.$key ?? ''}
+          size="$bodyMdMedium"
+          numberOfLines={1}
+        />
+        <TokenPriceChangeView
+          $key={token.$key ?? ''}
+          size="$bodyMd"
+          numberOfLines={1}
+        />
       </YStack>
     );
   }, [isTokenSelector, tableLayout, token.$key]);
@@ -152,10 +164,12 @@ function BasicTokenListItem(props: ITokenListItemProps) {
     return (
       <YStack
         alignItems="flex-end"
-        {...(tableLayout && {
-          flexGrow: 1,
-          flexBasis: 0,
-        })}
+        {...(tableLayout
+          ? {
+              flexGrow: 1,
+              flexBasis: 0,
+            }
+          : { flex: 1 })}
       >
         <TokenValueView
           hideValue={hideValue}

--- a/packages/kit/src/components/TokenListView/TokenListItem.tsx
+++ b/packages/kit/src/components/TokenListView/TokenListItem.tsx
@@ -142,20 +142,20 @@ function BasicTokenListItem(props: ITokenListItemProps) {
             flexBasis: 0,
           })}
         >
+          <TokenValueView
+            hideValue={hideValue}
+            numberOfLines={1}
+            size="$bodyLgMedium"
+            $key={token.$key ?? ''}
+          />
           <TokenBalanceView
             hideValue={hideValue}
             numberOfLines={1}
             textAlign="right"
-            size="$bodyLgMedium"
-            $key={token.$key ?? ''}
-            symbol=""
-          />
-          <TokenValueView
-            hideValue={hideValue}
-            numberOfLines={1}
             size="$bodyMd"
             color="$textSubdued"
             $key={token.$key ?? ''}
+            symbol=""
           />
         </YStack>
       );

--- a/packages/kit/src/views/ChainSelector/components/AllNetworksManager/NetworkListItem.tsx
+++ b/packages/kit/src/views/ChainSelector/components/AllNetworksManager/NetworkListItem.tsx
@@ -44,6 +44,10 @@ function NetworkListItem({ network }: { network: IServerNetworkMatch }) {
           logoURI={network.logoURI}
           isCustomNetwork={network.isCustomNetwork}
           networkName={network.name}
+          isAllNetworks={network.isAllNetworks}
+          allNetworksIconProps={{
+            color: '$iconActive',
+          }}
           size="$8"
         />
       }

--- a/packages/kit/src/views/ChainSelector/components/EditableChainSelector/EditableListItem.tsx
+++ b/packages/kit/src/views/ChainSelector/components/EditableChainSelector/EditableListItem.tsx
@@ -112,8 +112,12 @@ export const EditableListItem = ({
         <NetworkAvatarBase
           logoURI={item.logoURI}
           isCustomNetwork={item.isCustomNetwork}
+          isAllNetworks={item.isAllNetworks}
           networkName={item.name}
           size="$8"
+          allNetworksIconProps={{
+            color: '$iconActive',
+          }}
         />
       }
       renderItemText={(textProps) => (

--- a/packages/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorListView.tsx
+++ b/packages/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorListView.tsx
@@ -58,6 +58,10 @@ const ChainSelectorListViewContent = ({
               logoURI={item.logoURI}
               isCustomNetwork={item.isCustomNetwork}
               networkName={item.name}
+              isAllNetworks={item.isAllNetworks}
+              allNetworksIconProps={{
+                color: '$iconActive',
+              }}
               size="$8"
             />
           }

--- a/packages/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorSectionList.tsx
+++ b/packages/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorSectionList.tsx
@@ -117,8 +117,12 @@ const ChainSelectorSectionListContent = ({
             <NetworkAvatarBase
               logoURI={item.logoURI}
               isCustomNetwork={item.isCustomNetwork}
+              isAllNetworks={item.isAllNetworks}
               networkName={item.name}
               size="$8"
+              allNetworksIconProps={{
+                color: '$iconActive',
+              }}
             />
           }
           title={

--- a/packages/kit/src/views/Swap/components/SwapNetworkToggleGroup.tsx
+++ b/packages/kit/src/views/Swap/components/SwapNetworkToggleGroup.tsx
@@ -42,6 +42,7 @@ const SwapNetworkToggleGroup = ({
           key={network.networkId}
           disabled={Boolean(disableNetworks?.includes(network.networkId))}
           networkImageUri={network.logoURI}
+          isAllNetworks={network.isAllNetworks}
           tooltipContent={
             network.isAllNetworks
               ? intl.formatMessage({ id: ETranslations.global_all_networks })

--- a/packages/kit/src/views/WalletAddress/pages/DeriveTypesAddress/index.tsx
+++ b/packages/kit/src/views/WalletAddress/pages/DeriveTypesAddress/index.tsx
@@ -230,6 +230,7 @@ const DeriveTypesAddressItem = ({
         <NetworkAvatarBase
           logoURI={network?.logoURI ?? ''}
           isCustomNetwork={network?.isCustomNetwork}
+          isAllNetworks={network?.isAllNetworks}
           networkName={network?.name}
           size="$8"
         />

--- a/packages/kit/src/views/WalletAddress/pages/WalletAddress/index.tsx
+++ b/packages/kit/src/views/WalletAddress/pages/WalletAddress/index.tsx
@@ -356,11 +356,17 @@ function SingleWalletAddressListItem({ network }: { network: IServerNetwork }) {
       <NetworkAvatarBase
         logoURI={network.logoURI}
         isCustomNetwork={network.isCustomNetwork}
+        isAllNetworks={network.isAllNetworks}
         networkName={network.name}
         size="$10"
       />
     ),
-    [network.isCustomNetwork, network.logoURI, network.name],
+    [
+      network.isAllNetworks,
+      network.isCustomNetwork,
+      network.logoURI,
+      network.name,
+    ],
   );
 
   return useMemo(

--- a/packages/shared/src/logger/scopes/reward/scenes/tronReward.ts
+++ b/packages/shared/src/logger/scopes/reward/scenes/tronReward.ts
@@ -25,6 +25,7 @@ export class TronRewardScene extends BaseScene {
     };
   }
 
+  @LogToServer()
   public redeemResource({
     networkId,
     address,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying a globe icon to represent "All Networks" in various network selection and filter components.
  * Enhanced avatar and filter items to visually distinguish "All Networks" from individual networks.

* **Improvements**
  * Improved text truncation and layout for token price and balance views to ensure better readability.
  * Updated network selection components for more consistent styling when "All Networks" is shown.

* **Logging**
  * Added server-side logging for Tron reward redemption actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->