### PR TITLE
fix: reset approve loading & change to address some net close same ad…  OK-39647 OK-39648

### DIFF
--- a/packages/kit/src/views/Swap/hooks/useSwapState.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapState.ts
@@ -188,7 +188,9 @@ export function useSwapActionState() {
   const swapApprovingMatchLoading = useMemo(() => {
     return (
       swapApprovingLoading &&
-      fromTokenAmount.value === swapApprovingTransaction?.amount &&
+      (fromTokenAmount.value === swapApprovingTransaction?.amount ||
+        fromTokenAmount.value ===
+          swapApprovingTransaction?.resetApproveValue) &&
       equalTokenNoCaseSensitive({
         token1: swapApprovingTransaction?.fromToken,
         token2: fromToken,
@@ -200,12 +202,13 @@ export function useSwapActionState() {
     );
   }, [
     swapApprovingLoading,
-    swapApprovingTransaction?.fromToken,
-    fromToken,
-    swapApprovingTransaction?.toToken,
-    toToken,
-    fromTokenAmount,
+    fromTokenAmount.value,
     swapApprovingTransaction?.amount,
+    swapApprovingTransaction?.resetApproveValue,
+    swapApprovingTransaction?.fromToken,
+    swapApprovingTransaction?.toToken,
+    fromToken,
+    toToken,
   ]);
   const isBatchTransfer = useSwapBatchTransfer(
     swapFromAddressInfo.networkId,

--- a/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
@@ -142,7 +142,7 @@ const SwapToAnotherAddressPage = () => {
             networkId={accountInfo?.network?.id}
             enableAddressBook
             enableWalletName
-            enableVerifySendFundToSelf
+            // enableVerifySendFundToSelf
             enableAddressInteractionStatus
             enableAddressContract
             enableAllowListValidation


### PR DESCRIPTION
…dress

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of loading indicators during swap approval by refining the matching logic for transaction amounts.
  * Disabled verification for sending funds to your own address in the swap-to-another-address modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->