### PR TITLE
style: add SectionSeparatorComponent to investment details list

### DIFF
--- a/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletBoundReferralCodeButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletBoundReferralCodeButton.tsx
@@ -74,7 +74,7 @@ function WalletBoundReferralCodeButtonView({
     refreshDisplayReferralCodeButton,
   ]);
 
-  if (displayReferralCodeButton === undefined && isLoading) {
+  if (displayReferralCodeButton === undefined) {
     return <ActionList.SkeletonItem />;
   }
 

--- a/packages/kit/src/views/Staking/pages/InvestmentDetails/index.tsx
+++ b/packages/kit/src/views/Staking/pages/InvestmentDetails/index.tsx
@@ -434,6 +434,11 @@ function BasicInvestmentDetails() {
               </Heading>
             </XStack>
           )}
+          SectionSeparatorComponent={
+            <XStack h="$6" px="$5" ai="center">
+              <Divider />
+            </XStack>
+          }
           estimatedItemSize={60}
         />
       </Page.Body>


### PR DESCRIPTION
Introduced a SectionSeparatorComponent prop to the investment details list, providing a visual divider between sections for improved readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a visual separator between sections in the investment details view for improved readability.
* **Bug Fixes**
  * Improved loading indicator behavior for the referral code button to display more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->