### PR TITLE
style: add notification dot on About settings(OK-39739)

### DIFF
--- a/packages/kit/src/views/Setting/pages/Tab/ListItem.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/ListItem.tsx
@@ -2,7 +2,7 @@ import { cloneElement, useCallback, useMemo } from 'react';
 
 import { StyleSheet } from 'react-native';
 
-import { Badge, SizableText, YStack } from '@onekeyhq/components';
+import { Badge, SizableText, Stack, YStack } from '@onekeyhq/components';
 import type {
   IBadgeProps,
   IIconProps,
@@ -34,15 +34,14 @@ export function TabSettingsSection(props: IStackProps & IStackStyle) {
 }
 
 export function TabSettingsListItem({
-  subText,
-  subTextProps,
+  showDot,
   ...props
-}: IListItemProps &
-  IStackStyle &
-  IStackProps & { subText?: string; subTextProps?: ISizableTextProps }) {
+}: IListItemProps & IStackStyle & IStackProps & { showDot?: boolean }) {
   return (
     <BaseListItem py="$3" px="$5" mx={0} borderRadius={0} {...props}>
-      {subText ? <SizableText {...subTextProps}>{subText}</SizableText> : null}
+      {showDot ? (
+        <Stack width="$2" height="$2" bg="$iconInfo" borderRadius="$full" />
+      ) : null}
     </BaseListItem>
   );
 }
@@ -97,9 +96,6 @@ export function TabSettingsListGrid({
       title={item?.title}
       drillIn
     >
-      {item?.subText ? (
-        <SizableText {...item.subTextProps}>{item.subText}</SizableText>
-      ) : null}
       {item?.badgeProps ? (
         <Badge
           badgeSize={item.badgeProps.badgeSize as IBadgeProps['badgeSize']}

--- a/packages/kit/src/views/Setting/pages/Tab/SettingList.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/SettingList.tsx
@@ -53,13 +53,12 @@ export function SettingList() {
                     <TabSettingsListItem
                       {...config.tabBarItemStyle}
                       drillIn
+                      showDot={config.showDot}
                       key={config.title}
                       icon={config.icon as IKeyOfIcons}
                       iconProps={config.tabBarIconStyle}
                       title={config.title}
                       px="$7"
-                      subText={config.subText}
-                      subTextProps={config.subTextProps}
                       titleProps={config.tabBarLabelStyle}
                       onPress={() => {
                         navigation.push(

--- a/packages/kit/src/views/Setting/pages/Tab/config.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/config.tsx
@@ -66,8 +66,6 @@ import { SubSearchSettings } from './SubSettings';
 export interface ISubSettingConfig {
   icon: string | IKeyOfIcons;
   title: string;
-  subText?: string;
-  subTextProps?: ISizableTextProps;
   badgeProps?: {
     badgeSize: 'sm' | 'md' | 'lg';
     badgeText: string;
@@ -97,8 +95,6 @@ export type ISettingsConfig = (
       tabBarItemStyle?: IStackStyle;
       tabBarIconStyle?: IIconProps;
       tabBarLabelStyle?: ISizableTextProps;
-      subText?: string;
-      subTextProps?: ISizableTextProps;
       Component?: ComponentType<{
         name: string;
         settingsConfig: ISettingsConfig;
@@ -517,15 +513,6 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
           id: ETranslations.global_about,
         }),
         showDot: !!appUpdateInfo.isNeedUpdate,
-        subText: appUpdateInfo.isNeedUpdate
-          ? intl.formatMessage({
-              id: ETranslations.settings_app_update_available,
-            })
-          : undefined,
-        subTextProps: {
-          size: '$bodyLgMedium',
-          color: '$textInfo',
-        },
         configs: [
           [
             {


### PR DESCRIPTION
Eliminated the subText and subTextProps from TabSettingsListItem and related config, replacing them with a showDot indicator for update notifications. This simplifies the UI and code by using a dot instead of descriptive subtext for update availability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional dot indicator to settings list items.

* **Refactor**
  * Replaced subtext display in settings list items with a dot indicator.
  * Updated settings configuration to remove subtext and related properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->