### PR TITLE
fix: refactor EarnHome navigation params and fix ListItem children

### DIFF
--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -819,15 +819,28 @@ function BasicEarnHome() {
                 accountId: account?.id ?? '',
                 networkId,
               });
-            void EarnNavigation.pushDetailPageFromDeeplink(navigation, {
+            const navigationParams: {
+              accountId?: string;
+              networkId: string;
+              indexedAccountId?: string;
+              symbol: string;
+              provider: string;
+              vault?: string;
+            } = {
               accountId: earnAccount?.accountId || account?.id || '',
               indexedAccountId:
                 earnAccount?.account.indexedAccountId || indexedAccount?.id,
               provider,
               symbol,
               networkId,
-              vault: vault ?? '',
-            });
+            };
+            if (vault) {
+              navigationParams.vault = vault;
+            }
+            void EarnNavigation.pushDetailPageFromDeeplink(
+              navigation,
+              navigationParams,
+            );
           }
           return;
         }

--- a/packages/kit/src/views/Setting/pages/Tab/ListItem.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/ListItem.tsx
@@ -35,10 +35,12 @@ export function TabSettingsSection(props: IStackProps & IStackStyle) {
 
 export function TabSettingsListItem({
   showDot,
+  children,
   ...props
 }: IListItemProps & IStackStyle & IStackProps & { showDot?: boolean }) {
   return (
     <BaseListItem py="$3" px="$5" mx={0} borderRadius={0} {...props}>
+      {children}
       {showDot ? (
         <Stack width="$2" height="$2" bg="$iconInfo" borderRadius="$full" />
       ) : null}


### PR DESCRIPTION
Refactored EarnHome to build navigation parameters object before calling pushDetailPageFromDeeplink, ensuring 'vault' is only included if defined. Also updated TabSettingsListItem to render children prop, allowing for more flexible list item content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved navigation parameter handling for banner interactions on the Earn Home screen.
  * Enhanced the Tab Settings list item to support rendering nested content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->