### PR TITLE
chore: update trxres source flag

### DIFF
--- a/packages/kit-bg/src/vaults/impls/tron/Vault.ts
+++ b/packages/kit-bg/src/vaults/impls/tron/Vault.ts
@@ -984,6 +984,11 @@ export default class Vault extends VaultBase {
             orderId,
             fromHash: signedTx.txid,
             signedData: JSON.parse(signedTx.rawTx),
+            sourceFlag: (
+              await this.getNetwork()
+            ).isTestnet
+              ? TRON_SOURCE_FLAG_TESTNET
+              : TRON_SOURCE_FLAG_MAINNET,
           },
           params: {},
         },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of network type by correctly setting a flag to distinguish between testnet and mainnet during resource rental order uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->