### PR TITLE
Fix text color for WatchlistToggleButton

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/WatchlistToggleButton.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/WatchlistToggleButton.tsx
@@ -33,7 +33,7 @@ export function WatchlistToggleButton({
         />
         <SizableText
           size="$bodyMd"
-          color={isActive ? '$textOnPrimary' : '$textSubdued'}
+          color={isActive ? '$textActive' : '$textSubdued'}
         >
           {intl.formatMessage({
             id: ETranslations.global_watchlist,


### PR DESCRIPTION
Update `WatchlistToggleButton` active text color to `$textActive` to fix poor contrast on light backgrounds.