### PR TITLE
fix: extension hardware address creation loading

### DIFF
--- a/apps/ext/src/background/extUI.ts
+++ b/apps/ext/src/background/extUI.ts
@@ -1,6 +1,8 @@
 import { EXT_UI_TO_BG_PORT_NAME } from '@onekeyhq/shared/types';
 
-const setupExtUIEventBase = (onDisconnect: () => void) => {
+const setupExtUIEventBase = (
+  onDisconnect: (port: chrome.runtime.Port) => void,
+) => {
   chrome.runtime.onConnect.addListener((port) => {
     if (port.name === EXT_UI_TO_BG_PORT_NAME) {
       port.onDisconnect.addListener(onDisconnect);
@@ -9,13 +11,15 @@ const setupExtUIEventBase = (onDisconnect: () => void) => {
 };
 
 export const setupExtUIEvent = () =>
-  setupExtUIEventBase(() => {
+  setupExtUIEventBase((port: chrome.runtime.Port) => {
+    const p = port;
     const backgroundApiProxy =
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       require('@onekeyhq/kit/src/background/instance/backgroundApiProxy')
         .default as typeof import('@onekeyhq/kit/src/background/instance/backgroundApiProxy').default;
     void backgroundApiProxy.servicePassword.resetPasswordStatus();
+    void backgroundApiProxy.serviceAccount.resetIndexedAccountAddressCreationState();
   });
 
 export const setupExtUIEventOnPassKeyPage = () =>
-  setupExtUIEventBase(() => window.close());
+  setupExtUIEventBase((port: chrome.runtime.Port) => window.close());

--- a/development/spellCheckerSkipWords.js
+++ b/development/spellCheckerSkipWords.js
@@ -21,6 +21,7 @@ module.exports = [
   'Abi',
   'Abis',
   'acc',
+  'beforeunload',
   'nobleRipemd160',
   'bitwarden',
   'Accum',

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -127,6 +127,7 @@ import simpleDb from '../../dbs/simple/simpleDb';
 import {
   devSettingsPersistAtom,
   hardwareWalletXfpStatusAtom,
+  indexedAccountAddressCreationStateAtom,
 } from '../../states/jotai/atoms';
 import { vaultFactory } from '../../vaults/factory';
 import { getVaultSettings } from '../../vaults/settings';
@@ -201,6 +202,11 @@ class ServiceAccount extends ServiceBase {
   clearAccountCache() {
     this.getIndexedAccountWithMemo.clear();
     localDb.clearStoreCachedData();
+  }
+
+  @backgroundMethod()
+  async resetIndexedAccountAddressCreationState() {
+    await indexedAccountAddressCreationStateAtom.set(undefined);
   }
 
   @backgroundMethod()


### PR DESCRIPTION
…tate method

- Added resetIndexedAccountAddressCreationState method to ServiceAccount for managing indexed account address creation state.
- Updated extUI to utilize the new method during the setup of UI events.
- Introduced beforeunload event listener in useAddAccount to handle state reset on window unload.
- Added 'beforeunload' to spell checker skip words for improved handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of account address creation state, ensuring it is reset when appropriate, including on window unload events.
* **Chores**
  * Added 'beforeunload' to the list of spell checker skip words.
* **Bug Fixes**
  * Enhanced reliability of account creation by ensuring state cleanup occurs consistently during the add account process and upon disconnection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->