### PR TITLE
feat: Set WebUSB as default transport for Web and Extension

### DIFF
--- a/packages/kit-bg/src/services/ServiceSetting.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.ts
@@ -29,11 +29,14 @@ import systemLocaleUtils from '@onekeyhq/shared/src/locale/systemLocale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { memoizee } from '@onekeyhq/shared/src/utils/cacheUtils';
+import deviceUtils from '@onekeyhq/shared/src/utils/deviceUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import resetUtils from '@onekeyhq/shared/src/utils/resetUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
-import { EHardwareTransportType } from '@onekeyhq/shared/types';
-import type { IServerNetwork } from '@onekeyhq/shared/types';
+import type {
+  EHardwareTransportType,
+  IServerNetwork,
+} from '@onekeyhq/shared/types';
 import type { EAlignPrimaryAccountMode } from '@onekeyhq/shared/types/dappConnection';
 import { EServiceEndpointEnum } from '@onekeyhq/shared/types/endpoint';
 import { type IClearCacheOnAppState } from '@onekeyhq/shared/types/setting';
@@ -527,11 +530,7 @@ class ServiceSetting extends ServiceBase {
     if (hardwareTransportType) {
       return hardwareTransportType;
     }
-    // fix default value
-    if (platformEnv.isNative) {
-      return EHardwareTransportType.BLE;
-    }
-    return EHardwareTransportType.Bridge;
+    return deviceUtils.getDefaultHardwareTransportType();
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/states/jotai/atoms/settings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/settings.ts
@@ -1,7 +1,8 @@
 import type { ILocaleSymbol } from '@onekeyhq/shared/src/locale';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import deviceUtils from '@onekeyhq/shared/src/utils/deviceUtils';
 import { generateUUID } from '@onekeyhq/shared/src/utils/miscUtils';
-import { EHardwareTransportType, EOnekeyDomain } from '@onekeyhq/shared/types';
+import type { EHardwareTransportType } from '@onekeyhq/shared/types';
+import { EOnekeyDomain } from '@onekeyhq/shared/types';
 import { EAlignPrimaryAccountMode } from '@onekeyhq/shared/types/dappConnection';
 import { swapSlippageAutoValue } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
 import { ESwapSlippageSegmentKey } from '@onekeyhq/shared/types/swap/types';
@@ -79,9 +80,7 @@ export const settingsAtomInitialValue: ISettingsPersistAtom = {
   isFloatingIconAlwaysDisplay: false,
   isFilterScamHistoryEnabled: true,
   isFilterLowValueHistoryEnabled: false,
-  hardwareTransportType: platformEnv.isNative
-    ? EHardwareTransportType.BLE
-    : EHardwareTransportType.Bridge,
+  hardwareTransportType: deviceUtils.getDefaultHardwareTransportType(),
   hiddenWalletImmediately: true,
   showAddHiddenInWalletSidebar: true,
 };

--- a/packages/kit-bg/src/states/jotai/atoms/settings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/settings.ts
@@ -1,8 +1,7 @@
 import type { ILocaleSymbol } from '@onekeyhq/shared/src/locale';
-import deviceUtils from '@onekeyhq/shared/src/utils/deviceUtils';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { generateUUID } from '@onekeyhq/shared/src/utils/miscUtils';
-import type { EHardwareTransportType } from '@onekeyhq/shared/types';
-import { EOnekeyDomain } from '@onekeyhq/shared/types';
+import { EHardwareTransportType, EOnekeyDomain } from '@onekeyhq/shared/types';
 import { EAlignPrimaryAccountMode } from '@onekeyhq/shared/types/dappConnection';
 import { swapSlippageAutoValue } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
 import { ESwapSlippageSegmentKey } from '@onekeyhq/shared/types/swap/types';
@@ -11,6 +10,17 @@ import { EAtomNames } from '../atomNames';
 import { globalAtom } from '../utils';
 
 export type IEndpointType = 'prod' | 'test';
+
+// don't use deviceUtils.getDefaultHardwareTransportType(), it will cause resource export order conflict
+function getDefaultHardwareTransportType(): EHardwareTransportType {
+  if (platformEnv.isNative) {
+    return EHardwareTransportType.BLE;
+  }
+  if (platformEnv.isSupportWebUSB) {
+    return EHardwareTransportType.WEBUSB;
+  }
+  return EHardwareTransportType.Bridge;
+}
 
 export type ISettingsPersistAtom = {
   theme: 'light' | 'dark' | 'system';
@@ -80,7 +90,7 @@ export const settingsAtomInitialValue: ISettingsPersistAtom = {
   isFloatingIconAlwaysDisplay: false,
   isFilterScamHistoryEnabled: true,
   isFilterLowValueHistoryEnabled: false,
-  hardwareTransportType: deviceUtils.getDefaultHardwareTransportType(),
+  hardwareTransportType: getDefaultHardwareTransportType(),
   hiddenWalletImmediately: true,
   showAddHiddenInWalletSidebar: true,
 };

--- a/packages/kit/src/views/Setting/pages/Tab/CustomElement.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/CustomElement.tsx
@@ -36,7 +36,6 @@ import {
   usePasswordWebAuthInfoAtom,
   useSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
 import {
   GITHUB_URL,
   ONEKEY_URL,

--- a/packages/kit/src/views/Setting/pages/Tab/config.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/config.tsx
@@ -22,6 +22,7 @@ import {
   usePasswordBiologyAuthInfoAtom,
   usePasswordPersistAtom,
   usePasswordWebAuthInfoAtom,
+  useSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
   APP_STORE_LINK,
@@ -44,6 +45,7 @@ import {
 import { EPrimeFeatures, EPrimePages } from '@onekeyhq/shared/src/routes/prime';
 import { EModalShortcutsRoutes } from '@onekeyhq/shared/src/routes/shortcuts';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
+import { EHardwareTransportType } from '@onekeyhq/shared/types';
 import { EReasonForNeedPassword } from '@onekeyhq/shared/types/setting';
 
 import { usePrimeAuthV2 } from '../../../Prime/hooks/usePrimeAuthV2';
@@ -121,6 +123,7 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
   const helpCenterUrl = useHelpLink({ path: '' });
   const [devSettings] = useDevSettingsPersistAtom();
   const { isPrimeAvailable } = usePrimeAvailable();
+  const [settings] = useSettingsPersistAtom();
   return useMemo(
     () => [
       {
@@ -481,7 +484,8 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
                   renderElement: <HardwareTransportTypeListItem />,
                 }
               : undefined,
-            platformEnv.isExtension || platformEnv.isWeb
+            (platformEnv.isExtension || platformEnv.isWeb) &&
+            settings.hardwareTransportType !== EHardwareTransportType.WEBUSB
               ? {
                   icon: 'ApiConnectionOutline',
                   title: intl.formatMessage({
@@ -719,6 +723,7 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
       privacyPolicyUrl,
       copyText,
       devSettings.settings?.enableDesktopBluetooth,
+      settings.hardwareTransportType,
     ],
   );
 };

--- a/packages/shared/src/platformEnv.ts
+++ b/packages/shared/src/platformEnv.ts
@@ -383,8 +383,7 @@ const isRuntimeChrome = checkIsRuntimeChrome();
 const isRuntimeEdge = checkIsRuntimeEdge();
 const isRuntimeBrave = checkIsRuntimeBrave();
 const isRuntimeMacOSBrowser = isDesktopMac || checkIsRuntimeMacOSBrowser();
-const isSupportWebUSB =
-  (isWeb || isExtension) && (isRuntimeChrome || isRuntimeEdge);
+const isSupportWebUSB = isExtension || isWeb;
 
 // Ext manifest v2 background
 export const isExtensionBackgroundHtml: boolean =

--- a/packages/shared/src/utils/deviceUtils.ts
+++ b/packages/shared/src/utils/deviceUtils.ts
@@ -469,6 +469,16 @@ function getDeviceConnectId(
   }
 }
 
+function getDefaultHardwareTransportType(): EHardwareTransportType {
+  if (platformEnv.isNative) {
+    return EHardwareTransportType.BLE;
+  }
+  if (platformEnv.isSupportWebUSB) {
+    return EHardwareTransportType.WEBUSB;
+  }
+  return EHardwareTransportType.Bridge;
+}
+
 export default {
   dbDeviceToSearchDevice,
   getDeviceVersion,
@@ -494,4 +504,5 @@ export default {
   shouldUseV2FirmwareUpdateFlow,
   getRawDeviceId,
   getDeviceConnectId,
+  getDefaultHardwareTransportType,
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved detection of the default hardware transport type based on platform environment, now supporting BLE, WEBUSB, or Bridge as appropriate.
* **Refactor**
  * Streamlined logic for determining hardware transport type, reducing platform-specific checks and centralizing the decision process.
* **Bug Fixes**
  * The "hardware bridge status" setting is now correctly hidden when the hardware transport type is set to WEBUSB on web and extension platforms.
* **Chores**
  * Simplified WebUSB support detection, no longer dependent on browser type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->