### PR TITLE
fix: set default value of DB monitor toast to false

### DIFF
--- a/packages/shared/src/utils/debug/dbPerfMonitor.ts
+++ b/packages/shared/src/utils/debug/dbPerfMonitor.ts
@@ -21,7 +21,7 @@ const maxRecentCallsSize = 2000;
 const resetThreshold = 3000;
 
 const defaultSettings: IOneKeyDBPerfMonitorSettings = {
-  toastWarningEnabled: true,
+  toastWarningEnabled: false, // Default to false, controlled by dev settings
   toastWarningSize: 70,
   consoleLogEnabled: false,
   debuggerEnabled: false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default setting for warning notifications to be disabled by default.  
  * Added a comment clarifying that this setting is now managed through developer settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->