### PR TITLE
fix: MAS Bluetooth permission

### DIFF
--- a/.github/workflows/release-desktop-mas.yml
+++ b/.github/workflows/release-desktop-mas.yml
@@ -44,7 +44,6 @@ jobs:
           echo "PKG_VERSION=$pkg_version" >> $GITHUB_ENV
           artifacts_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           echo "ARTIFACTS_URL=$artifacts_url" >> $GITHUB_ENV
-          echo "BUILD_NUMBER=2025071122" >> $GITHUB_ENV
 
 
       - name: Setup Node

--- a/.github/workflows/release-desktop-mas.yml
+++ b/.github/workflows/release-desktop-mas.yml
@@ -44,6 +44,7 @@ jobs:
           echo "PKG_VERSION=$pkg_version" >> $GITHUB_ENV
           artifacts_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           echo "ARTIFACTS_URL=$artifacts_url" >> $GITHUB_ENV
+          echo "BUILD_NUMBER=2025071122" >> $GITHUB_ENV
 
 
       - name: Setup Node

--- a/apps/desktop/electron-builder-mas.config.js
+++ b/apps/desktop/electron-builder-mas.config.js
@@ -18,6 +18,10 @@ module.exports = {
     'entitlements': 'entitlements.mac.plist',
     'extendInfo': {
       'NSCameraUsageDescription': 'Use Camera to scan QR Code.',
+      'NSBluetoothAlwaysUsageDescription':
+        'OneKey wallet needs Bluetooth access to communicate with hardware wallets',
+      'NSBluetoothPeripheralUsageDescription':
+        'OneKey wallet needs Bluetooth access to discover and connect with hardware wallets',
     },
   },
   'mas': {
@@ -31,6 +35,10 @@ module.exports = {
     'extendInfo': {
       'ElectronTeamID': 'BVJ3FU5H2K',
       'ITSAppUsesNonExemptEncryption': false,
+      'NSBluetoothAlwaysUsageDescription':
+        'OneKey wallet needs Bluetooth access to communicate with hardware wallets',
+      'NSBluetoothPeripheralUsageDescription':
+        'OneKey wallet needs Bluetooth access to discover and connect with hardware wallets',
     },
   },
   'asarUnpack': ['**/*.node'],

--- a/apps/desktop/entitlements.mac.plist
+++ b/apps/desktop/entitlements.mac.plist
@@ -12,5 +12,7 @@
     <true/>
     <key>com.apple.security.device.camera</key>
     <true/>
+    <key>com.apple.security.device.bluetooth</key>
+    <true/>
   </dict>
 </plist>

--- a/apps/desktop/entitlements.mas.plist
+++ b/apps/desktop/entitlements.mas.plist
@@ -20,5 +20,7 @@
     <true/>
     <key>com.apple.security.device.usb</key>
     <true/>
+    <key>com.apple.security.device.bluetooth</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Bluetooth access permissions for the macOS desktop app, enabling communication with hardware wallets via Bluetooth.
  * Updated user-facing descriptions explaining the need for Bluetooth access when installing from the Mac App Store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->