### PR TITLE
fix: upgrade react-native-purchases to fix crash on refresh app on the iOS simulator

### DIFF
--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -207,7 +207,7 @@ PODS:
   - hermes-engine (0.79.5):
     - hermes-engine/Pre-built (= 0.79.5)
   - hermes-engine/Pre-built (0.79.5)
-  - ImageColors (2.4.0):
+  - ImageColors (2.5.0):
     - ExpoModulesCore
   - JCore (2.0.3):
     - React
@@ -259,8 +259,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - MultiplatformBleAdapter (0.2.0)
-  - PurchasesHybridCommon (13.35.0):
-    - RevenueCat (= 5.27.1)
+  - PurchasesHybridCommon (14.2.0):
+    - RevenueCat (= 5.32.0)
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -2373,7 +2373,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RevenueCat (5.27.1)
+  - RevenueCat (5.32.0)
   - RNCAsyncStorage (1.22.0):
     - DoubleConversion
     - glog
@@ -2535,8 +2535,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNPurchases (8.11.3):
-    - PurchasesHybridCommon (= 13.35.0)
+  - RNPurchases (8.11.9):
+    - PurchasesHybridCommon (= 14.2.0)
     - React-Core
   - RNReanimated (3.18.0):
     - DoubleConversion
@@ -3333,7 +3333,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: f03b0e06d3882d71e67e45b073bb827da1a21aae
-  ImageColors: 869f48b27ca2afb347fd0bada3257a5f698ee55e
+  ImageColors: 51cd79f7a9d2524b7a681c660b0a50574085563b
   JCore: 4707d226b452782383a401bea8ee2518565017e6
   JPush: 7888dd3b0b4b2acaec7e1368eb8a9e3418e311d1
   JXCategoryView: 262d503acea0b1278c79a1c25b7332ffaef4d518
@@ -3344,7 +3344,7 @@ SPEC CHECKSUMS:
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
   lottie-react-native: 825856a41d05a933539ea4fdf384d67c10590547
   MultiplatformBleAdapter: b1fddd0d499b96b607e00f0faa8e60648343dc1d
-  PurchasesHybridCommon: 18288b8ad932cfeb5f142f592d5c65e626a35770
+  PurchasesHybridCommon: f1650b33e9a1dd04d5e8a40dfe757f39e63f935c
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 5f638f65935e273753b1f31a365db6a8d6dc53b5
   RCTRequired: 8b46a520ea9071e2bc47d474aa9ca31b4a935bd8
@@ -3430,7 +3430,7 @@ SPEC CHECKSUMS:
   ReactNativeSecureWindow: aca1652c05825f4a3c1706b942a5a12060c54742
   RealmJS: ff8a7d6d6e339c1b3410a96ceb4151b151fe56f5
   RestartNewArch: 8f05b9ac18db934e1df999f89d4781872ea1e7f4
-  RevenueCat: 87171c9f2412778354c8523f5625d1fece2560a5
+  RevenueCat: 7e1d0768fb287c9983173c9b28e39ccbeeb828a9
   RNCAsyncStorage: b582a51d35079f9f2ae1c6e63ae39704a445627e
   RNDeviceInfo: d863506092aef7e7af3a1c350c913d867d795047
   RNFileLogger: 52442d388d36b29b1e7884b5ffbfa916ecfbc06b
@@ -3439,7 +3439,7 @@ SPEC CHECKSUMS:
   RNImageCropPicker: de6a16085ad4e4c67850b0c662d1d333d367cc59
   RNNotifee: 3978eab0eb24f9c2ee6ee0440ee7c50748803559
   RNPermissions: b766b1fe9836eaa4975377897e7bb8851e18c037
-  RNPurchases: 614ae87f4071d2be2fbfcb9e7fe6064080cc676f
+  RNPurchases: 4c820359d90fab9c83ffd3ef5471d59db72e2ed1
   RNReanimated: 24c64a050426b2e5b27d3435f1dcd89651207ff3
   RNScreens: 6eccc6175d442f4d9142f9e0396f17fd8e3d26ec
   RNSentry: 857855d887a12dd8f049e7b72bf38d09f92ea7dc

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -112,7 +112,7 @@
     "react-native-network-logger": "2.0.0",
     "react-native-passkeys": "0.3.3",
     "react-native-permissions": "5.4.1",
-    "react-native-purchases": "8.11.3",
+    "react-native-purchases": "8.11.9",
     "react-native-qrcode-styled": "0.3.3",
     "react-native-reanimated": "3.18.0",
     "react-native-restart": "npm:react-native-restart-newarch@1.0.72",

--- a/packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.native.ts
+++ b/packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.native.ts
@@ -154,33 +154,39 @@ export function usePrimePaymentMethods(): IUsePrimePayment {
       } = p.product;
 
       if (platformEnv.isNativeAndroid) {
-        pricePerYear = new BigNumber(pricePerYear).div(1_000_000).toNumber();
-        pricePerMonth = new BigNumber(pricePerMonth).div(1_000_000).toNumber();
+        pricePerYear = new BigNumber(pricePerYear || 0)
+          .div(1_000_000)
+          .toNumber();
+        pricePerMonth = new BigNumber(pricePerMonth || 0)
+          .div(1_000_000)
+          .toNumber();
       }
 
       const unit =
         primePaymentUtils.extractCurrencySymbol(priceString, {
           useShortUSSymbol: true,
         }) ||
-        primePaymentUtils.extractCurrencySymbol(pricePerYearString, {
+        primePaymentUtils.extractCurrencySymbol(pricePerYearString || '', {
           useShortUSSymbol: true,
         }) ||
-        primePaymentUtils.extractCurrencySymbol(pricePerMonthString, {
+        primePaymentUtils.extractCurrencySymbol(pricePerMonthString || '', {
           useShortUSSymbol: true,
         });
 
       packages.push({
         subscriptionPeriod: subscriptionPeriod as ISubscriptionPeriod,
-        pricePerYear,
-        pricePerYearString: `${unit}${new BigNumber(pricePerYear).toFixed(2)}`,
-        pricePerMonth,
-        pricePerMonthString: `${unit}${new BigNumber(pricePerMonth).toFixed(
+        pricePerYear: pricePerYear || 0,
+        pricePerYearString: `${unit}${new BigNumber(pricePerYear || 0).toFixed(
           2,
         )}`,
+        pricePerMonth: pricePerMonth || 0,
+        pricePerMonthString: `${unit}${new BigNumber(
+          pricePerMonth || 0,
+        ).toFixed(2)}`,
         priceTotalPerYearString:
           subscriptionPeriod === 'P1M'
-            ? `${unit}${new BigNumber(pricePerMonth).times(12).toFixed(2)}`
-            : `${unit}${new BigNumber(pricePerYear).toFixed(2)}`,
+            ? `${unit}${new BigNumber(pricePerMonth || 0).times(12).toFixed(2)}`
+            : `${unit}${new BigNumber(pricePerYear || 0).toFixed(2)}`,
       });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7833,7 +7833,7 @@ __metadata:
     react-native-network-logger: "npm:2.0.0"
     react-native-passkeys: "npm:0.3.3"
     react-native-permissions: "npm:5.4.1"
-    react-native-purchases: "npm:8.11.3"
+    react-native-purchases: "npm:8.11.9"
     react-native-qrcode-styled: "npm:0.3.3"
     react-native-reanimated: "npm:3.18.0"
     react-native-restart: "npm:react-native-restart-newarch@1.0.72"
@@ -11279,10 +11279,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@revenuecat/purchases-typescript-internal@npm:13.35.0":
-  version: 13.35.0
-  resolution: "@revenuecat/purchases-typescript-internal@npm:13.35.0"
-  checksum: 10/17737d72bf467c7ab0b1aaac2501a2a063e4806940f04a9dc5bcf6ca958ff41c2a70a7fdf51a078603d2920b65a37e8eea41631abcbac73e741356fa71b3fcfb
+"@revenuecat/purchases-typescript-internal@npm:14.2.0":
+  version: 14.2.0
+  resolution: "@revenuecat/purchases-typescript-internal@npm:14.2.0"
+  checksum: 10/6ea103adf6956d0c018b242627bfca9fe64b2da94c1d5c5fbb5f8528f936d331b30f3def55499a4d9de9a274843c0fa584c9c6b5b1ad0f1e357e4cc79642759a
   languageName: node
   linkType: hard
 
@@ -35660,15 +35660,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-purchases@npm:8.11.3":
-  version: 8.11.3
-  resolution: "react-native-purchases@npm:8.11.3"
+"react-native-purchases@npm:8.11.9":
+  version: 8.11.9
+  resolution: "react-native-purchases@npm:8.11.9"
   dependencies:
-    "@revenuecat/purchases-typescript-internal": "npm:13.35.0"
+    "@revenuecat/purchases-typescript-internal": "npm:14.2.0"
   peerDependencies:
     react: ">= 16.6.3"
     react-native: "*"
-  checksum: 10/1f1364f0219e47efad7e602fc2bf6fae63bb5bc8dedf5eba9223927a70d627a8ae1e0b3fe8835a99433ac8e047c422285b0b7ffbc352328dc2be934192e9d981
+  checksum: 10/9194e08e65f730a50b852de15ef654b3da478d0bfef55137c749b96f3c1e068d7c910d4c3ee89ccabadd8361e45e9d59ecce1da8e999cb3e19a79c2478c71282
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://github.com/RevenueCat/react-native-purchases/pull/1320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the "react-native-purchases" dependency to version 8.11.9.
* **Bug Fixes**
  * Improved handling of price and currency data to prevent errors from missing or undefined values in payment methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->