### PR TITLE
OK-39804: Rename matic to pol & correct ble connect id

### DIFF
--- a/packages/kit-bg/src/dbs/local/LocalDbBase.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.ts
@@ -2699,6 +2699,9 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
           compatibleConnectId = connectId;
           break;
         case EHardwareTransportType.BLE:
+          bleConnectId = connectId;
+          compatibleConnectId = connectId;
+          break;
         case EHardwareTransportType.DesktopWebBle:
           // BLE connections - set bleConnectId but don't override connectId
           bleConnectId = connectId;

--- a/packages/kit-bg/src/vaults/impls/evm/settings.ts
+++ b/packages/kit-bg/src/vaults/impls/evm/settings.ts
@@ -4,14 +4,14 @@ import {
   EMPTY_NATIVE_TOKEN_ADDRESS,
   EthereumCbBTC,
   EthereumDAI,
-  EthereumMatic,
+  EthereumPol,
   EthereumUSDC,
   EthereumUSDF,
   EthereumUSDT,
   EthereumUSDe,
   EthereumWBTC,
   EthereumWETH,
-  SepoliaMatic,
+  SepoliaPol,
 } from '@onekeyhq/shared/src/consts/addresses';
 import {
   COINTYPE_ETH,
@@ -49,23 +49,23 @@ const commonStakeConfigs = {
     displayProfit: true,
     stakingWithApprove: false,
   },
-  MATIC: {
+  POL: {
     enabled: true,
-    tokenAddress: EthereumMatic,
+    tokenAddress: EthereumPol,
     displayProfit: true,
     stakingWithApprove: true,
   },
 };
 
-const lidoConfig: { ETH: IStakingFlowConfig; MATIC: IStakingFlowConfig } = {
+const lidoConfig: { ETH: IStakingFlowConfig; POL: IStakingFlowConfig } = {
   ETH: {
     ...commonStakeConfigs.ETH,
     enabled: true,
     unstakeWithSignMessage: true,
     claimWithAmount: true,
   },
-  MATIC: {
-    ...commonStakeConfigs.MATIC,
+  POL: {
+    ...commonStakeConfigs.POL,
     enabled: true,
     claimWithTx: true,
   },
@@ -75,18 +75,18 @@ const stakingConfig: IStakingConfig = {
   [getNetworkIdsMap().eth]: {
     providers: {
       [EEarnProviderEnum.Lido]: {
-        supportedSymbols: ['ETH', 'MATIC'],
+        supportedSymbols: ['ETH', 'POL'],
         configs: lidoConfig,
       },
       [EEarnProviderEnum.Everstake]: {
-        supportedSymbols: ['ETH', 'MATIC'],
+        supportedSymbols: ['ETH', 'POL'],
         configs: {
           ETH: {
             ...commonStakeConfigs.ETH,
             claimWithAmount: true,
           },
-          MATIC: {
-            ...commonStakeConfigs.MATIC,
+          POL: {
+            ...commonStakeConfigs.POL,
             claimWithTx: true,
           },
         },
@@ -161,10 +161,10 @@ const stakingConfig: IStakingConfig = {
   [getNetworkIdsMap().sepolia]: {
     providers: {
       [EEarnProviderEnum.Lido]: {
-        supportedSymbols: ['ETH', 'MATIC'],
+        supportedSymbols: ['ETH', 'POL'],
         configs: {
           ...lidoConfig,
-          MATIC: { ...lidoConfig.MATIC, tokenAddress: SepoliaMatic },
+          POL: { ...lidoConfig.POL, tokenAddress: SepoliaPol },
         },
       },
     },
@@ -172,10 +172,10 @@ const stakingConfig: IStakingConfig = {
   [getNetworkIdsMap().holesky]: {
     providers: {
       [EEarnProviderEnum.Everstake]: {
-        supportedSymbols: ['ETH', 'MATIC'],
+        supportedSymbols: ['ETH', 'POL'],
         configs: {
           ETH: commonStakeConfigs.ETH,
-          MATIC: commonStakeConfigs.MATIC,
+          POL: commonStakeConfigs.POL,
         },
       },
       [EEarnProviderEnum.Lido]: {

--- a/packages/kit/src/views/Staking/components/ProtocolDetails/PortfolioSection.tsx
+++ b/packages/kit/src/views/Staking/components/ProtocolDetails/PortfolioSection.tsx
@@ -763,7 +763,7 @@ export const PortfolioSection = ({
   if (
     details.provider.name.toLowerCase() ===
       EEarnProviderEnum.Everstake.toLowerCase() &&
-    details.token.info.symbol.toLowerCase() === 'matic'
+    details.token.info.symbol.toLowerCase() === 'pol'
   ) {
     labelForClaimable = intl.formatMessage({
       id: ETranslations.earn_withdrawn,

--- a/packages/shared/src/consts/addresses.ts
+++ b/packages/shared/src/consts/addresses.ts
@@ -1,5 +1,5 @@
-export const EthereumMatic = '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0';
-export const SepoliaMatic = '0x3fd0a53f4bf853985a95f4eb3f9c9fde1f8e2b53';
+export const EthereumPol = '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0';
+export const SepoliaPol = '0x3fd0a53f4bf853985a95f4eb3f9c9fde1f8e2b53';
 export const EthereumUSDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
 export const EthereumUSDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7';
 export const EthereumDAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F';

--- a/packages/shared/types/earn.ts
+++ b/packages/shared/types/earn.ts
@@ -15,7 +15,7 @@ export type ISupportedSymbol =
   | 'WETH'
   | 'cbBTC'
   | 'WBTC'
-  | 'MATIC'
+  | 'POL'
   | 'SOL'
   | 'ATOM'
   | 'APT'

--- a/packages/shared/types/earn/earnProvider.constants.ts
+++ b/packages/shared/types/earn/earnProvider.constants.ts
@@ -2,7 +2,7 @@ import { getNetworkIdsMap } from '../../src/config/networkIds';
 import {
   EthereumCbBTC,
   EthereumDAI,
-  EthereumMatic,
+  EthereumPol,
   EthereumUSDC,
   EthereumUSDF,
   EthereumUSDT,
@@ -53,7 +53,7 @@ export const isSupportStaking = (symbol: string) =>
     'SOL',
     'APT',
     'ATOM',
-    'MATIC',
+    'POL',
     'USDC',
     'USDT',
     'DAI',
@@ -82,7 +82,7 @@ export function normalizeToEarnSymbol(
     'sol': 'SOL',
     'apt': 'APT',
     'atom': 'ATOM',
-    'matic': 'MATIC',
+    'pol': 'POL',
     'usdc': 'USDC',
     'usdt': 'USDT',
     'dai': 'DAI',
@@ -121,7 +121,7 @@ export function getImportFromToken({
     case networkIdsMap.sepolia: {
       if (
         [
-          EthereumMatic.toLowerCase(),
+          EthereumPol.toLowerCase(),
           EthereumUSDC.toLowerCase(),
           EthereumUSDT.toLowerCase(),
           EthereumDAI.toLowerCase(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated all references to the token symbol "MATIC" to "POL" across staking configurations, supported symbols, and related user interface elements.
  * Renamed associated constants and addresses to reflect the new "POL" token naming.
* **Bug Fixes**
  * Ensured correct display and handling of the "POL" token in staking providers, including Everstake.
* **Chores**
  * Updated type definitions and constant mappings to support the "POL" token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->