### PR TITLE
chore: Create a Dockerfile for the e2ee-server

### DIFF
--- a/apps/e2ee-server/Dockerfile
+++ b/apps/e2ee-server/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+COPY package.json yarn.lock .yarnrc.yml ./
+COPY .yarn .yarn
+
+RUN yarn install --immutable
+
+COPY . .
+
+RUN yarn run build
+
+FROM node:20-alpine
+
+WORKDIR /app
+
+RUN apk add --no-cache tzdata && rm -rf /var/cache/apk/*
+
+COPY --from=build /app /app
+
+ENV TZ="Asia/Shanghai"
+
+EXPOSE 3868
+
+CMD ["yarn", "run", "start"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a Dockerfile to enable containerized deployment of the e2ee-server application with production-ready settings and timezone configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->