### PR TITLE
fix: pre swap open dialog close quote

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -663,6 +663,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     slippageItem,
     setSwapBuildTxFetching,
     parseQuoteResultToSteps,
+    setSwapShouldRefreshQuote,
   ]);
 
   return (

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -606,17 +606,17 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
   const onPreSwapClose = useCallback(() => {
     void dialogRef.current?.close();
     setSwapBuildTxFetching(false);
-    setSwapShouldRefreshQuote(true);
     setTimeout(() => {
       setSwapSteps([]);
     }, 500);
-  }, [setSwapBuildTxFetching, setSwapShouldRefreshQuote, setSwapSteps]);
+  }, [setSwapBuildTxFetching, setSwapSteps]);
 
   const onPreSwap = useCallback(() => {
     if (!currentQuoteRes) {
       return;
     }
     cleanQuoteInterval();
+    setSwapShouldRefreshQuote(true);
     dialogRef.current = Dialog.show({
       onClose: onPreSwapClose,
       title: intl.formatMessage({ id: ETranslations.global_review_order }),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted the timing for refreshing swap quotes during the pre-swap dialog process to improve the user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->