### PR TITLE
fix: fix missing subSettingsPage in i18n

### DIFF
--- a/packages/kit/src/views/Setting/pages/Tab/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/index.tsx
@@ -172,7 +172,7 @@ function SettingsTabNavigator() {
       return (
         <Tab.Screen
           key={title}
-          name={name}
+          name={title}
           component={(Component || SubSettings) as any}
           options={{
             ...(options as any),

--- a/packages/kit/src/views/Setting/pages/Tab/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/index.tsx
@@ -164,7 +164,7 @@ function SideBar({ state, descriptors, navigation }: BottomTabBarProps) {
 function SettingsTabNavigator() {
   const settingsConfig = useSettingsConfig();
   const tabScreens = useMemo(() => {
-    const items = settingsConfig.map((config, index) => {
+    const items = settingsConfig.map((config) => {
       if (!config) {
         return null;
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated tab naming in the Settings section to use titles instead of internal names, improving clarity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->