### PR TITLE
Fix/hide transfer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __generated__
 .vscode/
 .chat/
 .claude/PRPs
+.claude/settings.local.json
 
 dist
 build-electron

--- a/packages/kit/src/provider/Bootstrap.tsx
+++ b/packages/kit/src/provider/Bootstrap.tsx
@@ -534,9 +534,9 @@ export function Bootstrap() {
     ) {
       const timer = setTimeout(() => {
         navigation.switchTab(autoNavigation.selectedTab as ETabRoutes);
-        navigation.pushModal(EModalRoutes.PrimeModal, {
-          screen: EPrimePages.PrimeTransfer,
-        });
+        // navigation.pushModal(EModalRoutes.PrimeModal, {
+        //   screen: EPrimePages.PrimeTransfer,
+        // });
       }, 1000);
 
       return () => clearTimeout(timer);

--- a/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSync.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSync.tsx
@@ -23,11 +23,14 @@ import { usePasswordPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms'
 import { usePrimeCloudSyncPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/prime';
 import { ELockDuration } from '@onekeyhq/shared/src/consts/appAutoLockConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { EPrimePages } from '@onekeyhq/shared/src/routes/prime';
+import type { IPrimeParamList } from '@onekeyhq/shared/src/routes/prime';
+import { EPrimeFeatures, EPrimePages } from '@onekeyhq/shared/src/routes/prime';
 import { formatDistanceToNow } from '@onekeyhq/shared/src/utils/dateUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
+import { useAppRoute } from '../../../../hooks/useAppRoute';
 import { AppAutoLockSettingsView } from '../../../Setting/pages/AppAutoLock';
+import { usePrimeAuthV2 } from '../../hooks/usePrimeAuthV2';
 import { usePrimeRequirements } from '../../hooks/usePrimeRequirements';
 
 function isAutoLockValueNotAllowed(value: number) {
@@ -88,6 +91,9 @@ function AutoLockUpdateDialogContent({
 
 function EnableOneKeyCloudSwitchListItem() {
   const [config] = usePrimeCloudSyncPersistAtom();
+  const { isPrimeSubscriptionActive } = usePrimeAuthV2();
+  const navigation = useAppNavigation();
+  const route = useAppRoute<IPrimeParamList, EPrimePages.PrimeCloudSync>();
 
   const isSubmittingRef = useRef(false);
 
@@ -123,6 +129,15 @@ function EnableOneKeyCloudSwitchListItem() {
         disabled={false}
         size={ESwitchSize.small}
         onChange={async (value) => {
+          if (value && !isPrimeSubscriptionActive) {
+            navigation.navigate(EPrimePages.PrimeFeatures, {
+              showAllFeatures: true,
+              selectedFeature: EPrimeFeatures.OneKeyCloud,
+              selectedSubscriptionPeriod:
+                route?.params?.selectedSubscriptionPeriod,
+            });
+            return;
+          }
           if (value) {
             await ensurePrimeSubscriptionActive();
           }
@@ -284,6 +299,7 @@ function AppDataSection() {
 function WalletSection() {
   const intl = useIntl();
   const navigation = useAppNavigation();
+  const [transferEnabled, setTransferEnabled] = useState(false);
   return (
     <Section title={intl.formatMessage({ id: ETranslations.prime_wallet })}>
       <ListItem
@@ -294,19 +310,33 @@ function WalletSection() {
         subtitle={intl.formatMessage({
           id: ETranslations.prime_transfer_description,
         })}
-        // drillIn
-        // onPress={() => {
-        //   navigation.navigate(EPrimePages.PrimeCloudSyncDebug);
-        // }}
+        drillIn={transferEnabled}
+        onPress={
+          transferEnabled
+            ? () => {
+                navigation.navigate(EPrimePages.PrimeTransfer);
+              }
+            : undefined
+        }
       >
-        <Badge badgeSize="sm">
-          <Badge.Text>
-            {intl.formatMessage({
-              id: ETranslations.id_prime_soon,
-            })}
-          </Badge.Text>
-        </Badge>
+        {transferEnabled ? null : (
+          <Badge badgeSize="sm">
+            <Badge.Text>
+              {intl.formatMessage({
+                id: ETranslations.id_prime_soon,
+              })}
+            </Badge.Text>
+          </Badge>
+        )}
       </ListItem>
+      <MultipleClickStack
+        showDevBgColor
+        onPress={() => {
+          setTransferEnabled(true);
+        }}
+      >
+        <Stack h="$20" />
+      </MultipleClickStack>
     </Section>
   );
 }

--- a/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSync.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSync.tsx
@@ -19,6 +19,7 @@ import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { MultipleClickStack } from '@onekeyhq/kit/src/components/MultipleClickStack';
 import { Section } from '@onekeyhq/kit/src/components/Section';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { useAppRoute } from '@onekeyhq/kit/src/hooks/useAppRoute';
 import { usePasswordPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { usePrimeCloudSyncPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/prime';
 import { ELockDuration } from '@onekeyhq/shared/src/consts/appAutoLockConsts';
@@ -28,7 +29,6 @@ import { EPrimeFeatures, EPrimePages } from '@onekeyhq/shared/src/routes/prime';
 import { formatDistanceToNow } from '@onekeyhq/shared/src/utils/dateUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
-import { useAppRoute } from '../../../../hooks/useAppRoute';
 import { AppAutoLockSettingsView } from '../../../Setting/pages/AppAutoLock';
 import { usePrimeAuthV2 } from '../../hooks/usePrimeAuthV2';
 import { usePrimeRequirements } from '../../hooks/usePrimeRequirements';

--- a/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeBenefitsList.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeBenefitsList.tsx
@@ -77,6 +77,7 @@ export function PrimeBenefitsList({
 }) {
   const navigation = useAppNavigation();
   const intl = useIntl();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { ensureOneKeyIDLoggedIn } = usePrimeRequirements();
   const { isPrimeSubscriptionActive } = usePrimeAuthV2();
 
@@ -91,15 +92,9 @@ export function PrimeBenefitsList({
           id: ETranslations.prime_onekey_cloud_desc,
         })}
         onPress={() => {
-          if (isPrimeSubscriptionActive) {
-            navigation.navigate(EPrimePages.PrimeCloudSync);
-          } else {
-            navigation.navigate(EPrimePages.PrimeFeatures, {
-              showAllFeatures: true,
-              selectedFeature: EPrimeFeatures.OneKeyCloud,
-              selectedSubscriptionPeriod,
-            });
-          }
+          navigation.navigate(EPrimePages.PrimeCloudSync, {
+            selectedSubscriptionPeriod,
+          });
         }}
       />
       {/* <PrimeBenefitsItem
@@ -125,27 +120,6 @@ export function PrimeBenefitsList({
           }
         }}
       /> */}
-      <PrimeBenefitsItem
-        icon="ArrowRightOutline"
-        title={intl.formatMessage({
-          id: ETranslations.global_transfer,
-        })}
-        subtitle={intl.formatMessage({
-          id: ETranslations.prime_transfer_description,
-        })}
-        onPress={() => {
-          if (isPrimeSubscriptionActive) {
-            navigation.navigate(EPrimePages.PrimeTransfer);
-          } else {
-            navigation.navigate(EPrimePages.PrimeTransfer);
-            // navigation.navigate(EPrimePages.PrimeFeatures, {
-            //   showAllFeatures: true,
-            //   selectedFeature: EPrimeFeatures.CloudTransfer,
-            //   selectedSubscriptionPeriod,
-            // });
-          }
-        }}
-      />
       <PrimeBenefitsItem
         icon="Copy3Outline"
         title={intl.formatMessage({

--- a/packages/shared/src/routes/prime.ts
+++ b/packages/shared/src/routes/prime.ts
@@ -33,7 +33,9 @@ export type IPrimeParamList = {
   [EPrimePages.PrimeDeviceLimit]: {
     isExceedDeviceLimit?: boolean;
   };
-  [EPrimePages.PrimeCloudSync]: undefined;
+  [EPrimePages.PrimeCloudSync]: {
+    selectedSubscriptionPeriod?: ISubscriptionPeriod;
+  };
   [EPrimePages.PrimeCloudSyncDebug]: undefined;
   [EPrimePages.PrimeCloudSyncInfo]: undefined;
   [EPrimePages.PrimeFeatures]: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added logic to check for active Prime subscription before enabling cloud sync; users without a subscription are redirected to the Prime features page.
  * Introduced a mechanism to unlock the transfer feature within the wallet section via a special interaction.
* **Improvements**
  * Updated navigation for the "OneKey Cloud" benefit to always direct users to the cloud sync page.
* **Removals**
  * Removed the "Transfer" benefit item from the Prime benefits list.
* **Other Changes**
  * Adjusted route parameters for the PrimeCloudSync page to support passing subscription period information.
  * Updated ignored files to exclude local settings from version control.
  * Disabled automatic modal navigation to the transfer screen during development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->