### PR TITLE
refactor: update Prime feature navigation and parameters

### DIFF
--- a/packages/kit/src/components/TabPageHeader/MoreActionButton.tsx
+++ b/packages/kit/src/components/TabPageHeader/MoreActionButton.tsx
@@ -48,7 +48,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalRoutes, EModalSettingRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalBulkCopyAddressesRoutes } from '@onekeyhq/shared/src/routes/bulkCopyAddresses';
 import { EModalNotificationsRoutes } from '@onekeyhq/shared/src/routes/notifications';
-import { EPrimePages } from '@onekeyhq/shared/src/routes/prime';
+import { EPrimeFeatures, EPrimePages } from '@onekeyhq/shared/src/routes/prime';
 import extUtils from '@onekeyhq/shared/src/utils/extUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
@@ -442,18 +442,23 @@ function MoreActionContentGrid() {
     });
   }, [navigation]);
 
-  const checkIsPrimeUser = useCallback(() => {
-    if (user?.primeSubscription?.isActive && user?.privyUserId) {
-      return true;
-    }
-    navigation.pushFullModal(EModalRoutes.PrimeModal, {
-      screen: EPrimePages.PrimeDashboard,
-      params: {
-        networkId: network?.id,
-      },
-    });
-    return false;
-  }, [navigation, user, network?.id]);
+  const checkIsPrimeUser = useCallback(
+    (showFeature: EPrimeFeatures) => {
+      if (user?.primeSubscription?.isActive && user?.privyUserId) {
+        return true;
+      }
+      navigation.pushFullModal(EModalRoutes.PrimeModal, {
+        screen: EPrimePages.PrimeFeatures,
+        params: {
+          showAllFeatures: false,
+          selectedFeature: showFeature,
+          selectedSubscriptionPeriod: 'P1Y',
+        },
+      });
+      return false;
+    },
+    [navigation, user],
+  );
 
   const handleCustomerSupport = useCallback(() => {
     void showIntercom();
@@ -473,7 +478,7 @@ function MoreActionContentGrid() {
 
     if (!networkId) return;
 
-    if (!checkIsPrimeUser()) return;
+    if (!checkIsPrimeUser(EPrimeFeatures.BulkCopyAddresses)) return;
 
     navigation.pushModal(EModalRoutes.BulkCopyAddressesModal, {
       screen: EModalBulkCopyAddressesRoutes.BulkCopyAddressesModal,

--- a/packages/kit/src/components/TabPageHeader/MoreActionButton.tsx
+++ b/packages/kit/src/components/TabPageHeader/MoreActionButton.tsx
@@ -453,11 +453,12 @@ function MoreActionContentGrid() {
           showAllFeatures: false,
           selectedFeature: showFeature,
           selectedSubscriptionPeriod: 'P1Y',
+          networkId: network?.id,
         },
       });
       return false;
     },
-    [navigation, user],
+    [navigation, user, network?.id],
   );
 
   const handleCustomerSupport = useCallback(() => {

--- a/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/BulkCopyAddressesButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/BulkCopyAddressesButton.tsx
@@ -8,7 +8,7 @@ import type { IDBWallet } from '@onekeyhq/kit-bg/src/dbs/local/types';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalBulkCopyAddressesRoutes } from '@onekeyhq/shared/src/routes/bulkCopyAddresses';
-import { EPrimePages } from '@onekeyhq/shared/src/routes/prime';
+import { EPrimeFeatures, EPrimePages } from '@onekeyhq/shared/src/routes/prime';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 
@@ -35,10 +35,12 @@ export function BulkCopyAddressesButton({
       })}
       onPress={async () => {
         if (!isPrimeUser) {
-          navigation.pushFullModal(EModalRoutes.PrimeModal, {
-            screen: EPrimePages.PrimeDashboard,
+          navigation?.pushFullModal(EModalRoutes.PrimeModal, {
+            screen: EPrimePages.PrimeFeatures,
             params: {
-              networkId,
+              showAllFeatures: false,
+              selectedFeature: EPrimeFeatures.BulkCopyAddresses,
+              selectedSubscriptionPeriod: 'P1Y',
             },
           });
           return;

--- a/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/BulkCopyAddressesButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/BulkCopyAddressesButton.tsx
@@ -41,6 +41,7 @@ export function BulkCopyAddressesButton({
               showAllFeatures: false,
               selectedFeature: EPrimeFeatures.BulkCopyAddresses,
               selectedSubscriptionPeriod: 'P1Y',
+              networkId,
             },
           });
           return;

--- a/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSync.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSync.tsx
@@ -143,7 +143,7 @@ function EnableOneKeyCloudSwitchListItem() {
         onChange={async (value) => {
           if (value && !isPrimeSubscriptionActive) {
             navigation.navigate(EPrimePages.PrimeFeatures, {
-              showAllFeatures: true,
+              showAllFeatures: false,
               selectedFeature: EPrimeFeatures.OneKeyCloud,
               selectedSubscriptionPeriod:
                 route?.params?.selectedSubscriptionPeriod,

--- a/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSync.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSync.tsx
@@ -24,6 +24,7 @@ import { usePasswordPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms'
 import { usePrimeCloudSyncPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/prime';
 import { ELockDuration } from '@onekeyhq/shared/src/consts/appAutoLockConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import type { IPrimeParamList } from '@onekeyhq/shared/src/routes/prime';
 import { EPrimeFeatures, EPrimePages } from '@onekeyhq/shared/src/routes/prime';
 import { formatDistanceToNow } from '@onekeyhq/shared/src/utils/dateUtils';
@@ -142,11 +143,13 @@ function EnableOneKeyCloudSwitchListItem() {
         size={ESwitchSize.small}
         onChange={async (value) => {
           if (value && !isPrimeSubscriptionActive) {
-            navigation.navigate(EPrimePages.PrimeFeatures, {
-              showAllFeatures: false,
-              selectedFeature: EPrimeFeatures.OneKeyCloud,
-              selectedSubscriptionPeriod:
-                route?.params?.selectedSubscriptionPeriod,
+            navigation?.pushFullModal(EModalRoutes.PrimeModal, {
+              screen: EPrimePages.PrimeFeatures,
+              params: {
+                showAllFeatures: false,
+                selectedFeature: EPrimeFeatures.OneKeyCloud,
+                selectedSubscriptionPeriod: 'P1Y',
+              },
             });
             return;
           }

--- a/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeBenefitsList.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeBenefitsList.tsx
@@ -92,9 +92,15 @@ export function PrimeBenefitsList({
           id: ETranslations.prime_onekey_cloud_desc,
         })}
         onPress={() => {
-          navigation.navigate(EPrimePages.PrimeCloudSync, {
-            selectedSubscriptionPeriod,
-          });
+          if (isPrimeSubscriptionActive) {
+            navigation.navigate(EPrimePages.PrimeCloudSync);
+          } else {
+            navigation.navigate(EPrimePages.PrimeFeatures, {
+              showAllFeatures: true,
+              selectedFeature: EPrimeFeatures.OneKeyCloud,
+              selectedSubscriptionPeriod,
+            });
+          }
         }}
       />
       {/* <PrimeBenefitsItem

--- a/packages/kit/src/views/Setting/pages/Tab/config.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/config.tsx
@@ -111,7 +111,6 @@ export type ISettingsConfig = (
 export const useSettingsConfig: () => ISettingsConfig = () => {
   const appUpdateInfo = useAppUpdateInfo();
   const intl = useIntl();
-  const { isPrimeSubscriptionActive } = usePrimeAuthV2();
   const onPressAddressBook = useShowAddressBook({
     useNewModal: false,
   });
@@ -704,7 +703,6 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
       biometricAuthInfo.icon,
       appUpdateInfo.isNeedUpdate,
       devSettings.enabled,
-      isPrimeSubscriptionActive,
       onPressAddressBook,
       helpCenterUrl,
       userAgreementUrl,

--- a/packages/kit/src/views/Setting/pages/Tab/config.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/config.tsx
@@ -42,7 +42,7 @@ import {
   EModalRoutes,
   EModalSettingRoutes,
 } from '@onekeyhq/shared/src/routes';
-import { EPrimeFeatures, EPrimePages } from '@onekeyhq/shared/src/routes/prime';
+import { EPrimePages } from '@onekeyhq/shared/src/routes/prime';
 import { EModalShortcutsRoutes } from '@onekeyhq/shared/src/routes/shortcuts';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 import { EHardwareTransportType } from '@onekeyhq/shared/types';
@@ -157,23 +157,12 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
                     id: ETranslations.global_onekey_cloud,
                   }),
                   onPress: (navigation) => {
-                    if (isPrimeSubscriptionActive) {
-                      navigation?.pushModal(EModalRoutes.PrimeModal, {
-                        screen: EPrimePages.PrimeCloudSync,
-                      });
-                    } else {
-                      navigation?.pushModal(EModalRoutes.PrimeModal, {
-                        screen: EPrimePages.PrimeFeatures,
-                        params: {
-                          showAllFeatures: false,
-                          selectedFeature: EPrimeFeatures.OneKeyCloud,
-                          selectedSubscriptionPeriod: 'P1Y',
-                        },
-                      });
-                    }
+                    navigation?.pushModal(EModalRoutes.PrimeModal, {
+                      screen: EPrimePages.PrimeCloudSync,
+                    });
                   },
                 }
-              : null,
+              : undefined,
           ],
           [
             platformEnv.isNative


### PR DESCRIPTION
- Modified `MoreActionButton` to accept a feature parameter for Prime user checks.
- Updated `BulkCopyAddressesButton` to navigate to Prime features with specific parameters.
- Adjusted `PagePrimeCloudSync` to set `showAllFeatures` to false when navigating.
- Enhanced `PrimeBenefitsList` to conditionally navigate based on Prime subscription status.
- Cleaned up `config.tsx` by removing unnecessary conditional checks for Prime navigation.

These changes improve the handling of Prime features and streamline user navigation based on subscription status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved navigation experience for Prime features, directing users to the relevant feature details when accessing premium actions without an active subscription.
* **Bug Fixes**
  * Fixed navigation inconsistencies for OneKey Cloud and Bulk Copy Addresses, ensuring users are taken to the correct screens based on their subscription status.
* **Refactor**
  * Streamlined navigation logic for Prime-related actions, providing a more consistent and user-friendly flow.
  * Removed conditional checks for Prime subscription in settings, simplifying access to OneKey Cloud features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->