### PR TITLE
fix: enhance ServiceNotification to check msgId before acknowledgment

### DIFF
--- a/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
@@ -954,7 +954,7 @@ export default class ServiceNotification extends ServiceBase {
       isWebSocketAckSuccess = await webSocketProvider?.ackMessage(params);
     }
 
-    if (!isWebSocketAckSuccess) {
+    if (!isWebSocketAckSuccess && params.msgId) {
       const client = await this.getClient(EServiceEndpointEnum.Notification);
       const res = await client.post('/notification/v1/message/ack', {
         msgId: params.msgId,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification acknowledgment logic to prevent unnecessary HTTP requests when a message ID is not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->