### PR TITLE
refactor: simplify web tab navigation logic OK-40603

### DIFF
--- a/packages/kit/src/states/jotai/contexts/discovery/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/discovery/actions.ts
@@ -848,8 +848,6 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
       set,
       {
         url,
-        isNewWindow,
-        isInPlace,
         title,
         favicon,
         canGoBack,
@@ -859,12 +857,10 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
         handlePhishingUrl,
       }: IOnWebviewNavigationFnParams,
     ) => {
-      const now = Date.now();
       const tab = this.getWebTabById.call(set, id ?? '');
       if (!tab) {
         return;
       }
-      const isValidNewUrl = typeof url === 'string' && url !== tab.url;
 
       if (url) {
         const cache = get(phishingLruCacheAtom());
@@ -881,29 +877,6 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
           handleDeepLinkUrl({ url });
           return;
         }
-      }
-
-      if (isValidNewUrl) {
-        if (tab.timestamp && now - tab.timestamp < 500) {
-          // ignore url change if it's too fast to avoid back & forth loop
-          return;
-        }
-        if (
-          homeResettingFlags[tab.id] &&
-          url !== homeTab.url &&
-          now - homeResettingFlags[tab.id] < 1000
-        ) {
-          return;
-        }
-
-        void this.gotoSite.call(set, {
-          url,
-          title,
-          favicon,
-          isNewWindow,
-          isInPlace,
-          id: tab.id,
-        });
       }
 
       this.setWebTabData.call(set, {

--- a/packages/kit/src/states/jotai/contexts/discovery/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/discovery/actions.ts
@@ -848,6 +848,8 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
       set,
       {
         url,
+        isNewWindow,
+        isInPlace,
         title,
         favicon,
         canGoBack,
@@ -857,10 +859,12 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
         handlePhishingUrl,
       }: IOnWebviewNavigationFnParams,
     ) => {
+      const now = Date.now();
       const tab = this.getWebTabById.call(set, id ?? '');
       if (!tab) {
         return;
       }
+      const isValidNewUrl = typeof url === 'string' && url !== tab.url;
 
       if (url) {
         const cache = get(phishingLruCacheAtom());
@@ -877,6 +881,29 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
           handleDeepLinkUrl({ url });
           return;
         }
+      }
+
+      if (isValidNewUrl) {
+        if (tab.timestamp && now - tab.timestamp < 500) {
+          // ignore url change if it's too fast to avoid back & forth loop
+          return;
+        }
+        if (
+          homeResettingFlags[tab.id] &&
+          url !== homeTab.url &&
+          now - homeResettingFlags[tab.id] < 1000
+        ) {
+          return;
+        }
+
+        void this.gotoSite.call(set, {
+          url,
+          title,
+          favicon,
+          isNewWindow,
+          isInPlace,
+          id: tab.id,
+        });
       }
 
       this.setWebTabData.call(set, {

--- a/packages/kit/src/views/Discovery/components/WebContent/WebContent.desktop.tsx
+++ b/packages/kit/src/views/Discovery/components/WebContent/WebContent.desktop.tsx
@@ -59,17 +59,13 @@ function WebContent({ id, url }: IWebContentProps) {
     onNavigation({ id, loading: true });
   }, [id, onNavigation]);
   const onDidStartNavigation = useCallback(
-    ({
-      url: willNavigationUrl,
-      isInPlace,
-      isMainFrame,
-    }: DidStartNavigationEvent) => {
+    ({ url: willNavigationUrl, isMainFrame }: DidStartNavigationEvent) => {
       if (isMainFrame) {
         onNavigation({
           id,
           url: willNavigationUrl,
           loading: true,
-          isInPlace,
+          isInPlace: true,
           ...getNavStatusInfo(),
           handlePhishingUrl: (illegalUrl) => {
             console.log('=====>>>>: handlePhishingUrl', illegalUrl);


### PR DESCRIPTION
主动导航（gotoSite）→ WebView 加载 → 触发 onNavigation → 再次调用 gotoSite → 无限循环

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal navigation handling for web content to streamline navigation state updates. No visible changes to user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->