### PR TITLE
fix: dismiss keyboard on scroll && update tab width on window resize && align networkId in invite page &&  tap-outside to hide keyboard on lock screen && add Keyboard Component

### DIFF
--- a/packages/components/src/actions/Popover/index.tsx
+++ b/packages/components/src/actions/Popover/index.tsx
@@ -20,7 +20,6 @@ import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { FIX_SHEET_PROPS } from '../../composite/Dialog';
-import { Divider } from '../../content';
 import { Portal } from '../../hocs';
 import {
   ModalNavigatorContext,
@@ -423,7 +422,6 @@ function RawPopover({
                 mb={bottom || '$5'}
                 borderCurve="continuous"
               >
-                {showHeader ? <Divider mx="$5" /> : null}
                 {content}
               </TMPopover.Sheet.ScrollView>
             </TMPopover.Sheet.Frame>

--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -311,7 +311,14 @@ export function Container({
                 <>
                   <YStack
                     position="relative"
-                    width={containerWidth || width}
+                    width={containerWidth ? undefined : width}
+                    style={
+                      containerWidth
+                        ? {
+                            width: containerWidth,
+                          }
+                        : undefined
+                    }
                     onLayout={handlerStickyHeaderLayout}
                   >
                     {renderHeader?.({

--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -224,7 +224,6 @@ export function Container({
         const index = tabNames.findIndex((name) => name === tabName);
         let scrollTop = scrollTopRef.current[tabName] || 0;
         startViewTransition(() => {
-          console.log('startViewTransition');
           updateListContainerHeight();
           const width = scrollElement?.clientWidth || 0;
           listContainerRef.current?.scrollTo({
@@ -312,8 +311,8 @@ export function Container({
                 <>
                   <YStack
                     position="relative"
-                    width="calc(100vw - 208px)"
-                    // onLayout={handlerStickyHeaderLayout}
+                    width={containerWidth || width}
+                    onLayout={handlerStickyHeaderLayout}
                   >
                     {renderHeader?.({
                       focusedTab,

--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -38,18 +38,24 @@ export function ContainerChild({
     <TabsScrollContext.Provider value={props}>
       <XStack
         ref={listContainerRef as any}
-        maxWidth={props.width}
+        width="calc(100vw - 208px)"
         overflow="hidden"
+        style={{ scrollSnapType: 'x' }}
       >
-        <XStack w={props.width * Children.count(children)}>
-          {Children.map(children, (child, index) => {
-            return (
-              <div style={{ flex: 1 }} key={index}>
-                {child}
-              </div>
-            );
-          })}
-        </XStack>
+        {Children.map(children, (child, index) => {
+          return (
+            <div
+              style={{
+                width: '100%',
+                flexShrink: 0,
+                scrollSnapAlign: 'center',
+              }}
+              key={index}
+            >
+              {child}
+            </div>
+          );
+        })}
       </XStack>
     </TabsScrollContext.Provider>
   );
@@ -186,26 +192,26 @@ export function Container({
     };
   }, [updateListContainerHeight]);
 
-  useLayoutEffect(() => {
-    const callback = debounce(() => {
-      if (listContainerRef.current) {
-        const tabIndex = tabNames.findIndex(
-          (name) => name === focusedTab.value,
-        );
-        listContainerRef.current.scrollTo({
-          left: (scrollElement?.clientWidth || 0) * tabIndex,
-          behavior: 'smooth',
-        });
-        setTimeout(() => {
-          updateListContainerHeight();
-        });
-      }
-    }, 150);
-    window.addEventListener('resize', callback);
-    return () => {
-      window.removeEventListener('resize', callback);
-    };
-  }, [focusedTab, scrollElement, tabNames, updateListContainerHeight]);
+  // useLayoutEffect(() => {
+  //   const callback = debounce(() => {
+  //     if (listContainerRef.current) {
+  //       const tabIndex = tabNames.findIndex(
+  //         (name) => name === focusedTab.value,
+  //       );
+  //       listContainerRef.current.scrollTo({
+  //         left: (scrollElement?.clientWidth || 0) * tabIndex,
+  //         behavior: 'smooth',
+  //       });
+  //       setTimeout(() => {
+  //         updateListContainerHeight();
+  //       });
+  //     }
+  //   }, 150);
+  //   window.addEventListener('resize', callback);
+  //   return () => {
+  //     window.removeEventListener('resize', callback);
+  //   };
+  // }, [focusedTab, scrollElement, tabNames, updateListContainerHeight]);
 
   useAnimatedReaction(
     () => focusedTab.value,
@@ -215,6 +221,7 @@ export function Container({
         const index = tabNames.findIndex((name) => name === tabName);
         let scrollTop = scrollTopRef.current[tabName] || 0;
         startViewTransition(() => {
+          console.log('startViewTransition');
           updateListContainerHeight();
           const width = scrollElement?.clientWidth || 0;
           listContainerRef.current?.scrollTo({
@@ -302,7 +309,8 @@ export function Container({
                 <>
                   <YStack
                     position="relative"
-                    onLayout={handlerStickyHeaderLayout}
+                    width="calc(100vw - 208px)"
+                    // onLayout={handlerStickyHeaderLayout}
                   >
                     {renderHeader?.({
                       focusedTab,

--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -30,15 +30,17 @@ import type { WindowScrollerChildProps } from 'react-virtualized';
 export function ContainerChild({
   children,
   listContainerRef,
+  containerWidth,
   ...props
 }: PropsWithChildren<WindowScrollerChildProps> & {
   listContainerRef: RefObject<Element>;
+  containerWidth: number | string | undefined;
 }) {
   return (
     <TabsScrollContext.Provider value={props}>
       <XStack
         ref={listContainerRef as any}
-        width="calc(100vw - 208px)"
+        width={containerWidth || props.width}
         overflow="hidden"
         style={{ scrollSnapType: 'x' }}
       >
@@ -78,6 +80,7 @@ export function Container({
   renderTabBar = renderDefaultTabBar,
   onIndexChange,
   onTabChange,
+  width: containerWidth,
   ref: containerRef,
   ...props
 }: PropsWithChildren<CollapsibleProps> & IRefProps) {
@@ -192,26 +195,26 @@ export function Container({
     };
   }, [updateListContainerHeight]);
 
-  // useLayoutEffect(() => {
-  //   const callback = debounce(() => {
-  //     if (listContainerRef.current) {
-  //       const tabIndex = tabNames.findIndex(
-  //         (name) => name === focusedTab.value,
-  //       );
-  //       listContainerRef.current.scrollTo({
-  //         left: (scrollElement?.clientWidth || 0) * tabIndex,
-  //         behavior: 'smooth',
-  //       });
-  //       setTimeout(() => {
-  //         updateListContainerHeight();
-  //       });
-  //     }
-  //   }, 150);
-  //   window.addEventListener('resize', callback);
-  //   return () => {
-  //     window.removeEventListener('resize', callback);
-  //   };
-  // }, [focusedTab, scrollElement, tabNames, updateListContainerHeight]);
+  useLayoutEffect(() => {
+    const callback = debounce(() => {
+      if (listContainerRef.current) {
+        const tabIndex = tabNames.findIndex(
+          (name) => name === focusedTab.value,
+        );
+        listContainerRef.current.scrollTo({
+          left: (scrollElement?.clientWidth || 0) * tabIndex,
+          behavior: 'instant',
+        });
+        setTimeout(() => {
+          updateListContainerHeight();
+        });
+      }
+    }, 350);
+    window.addEventListener('resize', callback);
+    return () => {
+      window.removeEventListener('resize', callback);
+    };
+  }, [focusedTab, scrollElement, tabNames, updateListContainerHeight]);
 
   useAnimatedReaction(
     () => focusedTab.value,
@@ -324,6 +327,7 @@ export function Container({
                     onTabPress,
                   } as any)}
                   <ContainerChild
+                    containerWidth={containerWidth}
                     height={height}
                     isScrolling={isScrolling}
                     scrollLeft={scrollLeft}

--- a/packages/components/src/composite/Tabs/List.tsx
+++ b/packages/components/src/composite/Tabs/List.tsx
@@ -411,7 +411,6 @@ export function List<Item>({
     noContentRenderer,
   ]);
 
-  console.log(contentContainerStyle);
   if (numColumns > 1) {
     return (
       <AutoSizer disableHeight>

--- a/packages/components/src/composite/Tabs/List.tsx
+++ b/packages/components/src/composite/Tabs/List.tsx
@@ -377,6 +377,33 @@ export function List<Item>({
     );
   }, [HeaderElement, ListEmptyComponent, FooterElement]);
 
+  const listProps = useMemo(() => {
+    return {
+      ref: listRef as any,
+      autoHeight: true,
+      height,
+      data: data?.length || sections?.length ? listData : [],
+      rowCount: data?.length || sections?.length ? listData.length : 0,
+      isScrolling: isVisible ? isScrolling : false,
+      onScroll: isVisible ? onChildScroll : undefined,
+      scrollTop: isVisible ? scrollTop : 0,
+      overscanRowCount: 10,
+      deferredMeasurementCache: cache,
+      noRowsRenderer,
+    };
+  }, [
+    height,
+    data?.length,
+    sections?.length,
+    listData,
+    isVisible,
+    isScrolling,
+    onChildScroll,
+    scrollTop,
+    cache,
+    noRowsRenderer,
+  ]);
+
   if (numColumns > 1) {
     return (
       <AutoSizer disableHeight>
@@ -387,21 +414,12 @@ export function List<Item>({
               style={contentContainerStyle as any}
             >
               <Collection
-                ref={listRef as any}
-                autoHeight
-                data={listData}
-                isScrolling={isVisible ? isScrolling : false}
-                scrollTop={isVisible ? scrollTop : 0}
-                onScroll={isVisible ? onChildScroll : undefined}
+                {...listProps}
                 width={autoSizerWidth}
-                height={height}
                 cellCount={listData.length}
-                deferredMeasurementCache={cache}
                 cellSizeAndPositionGetter={cellSizeAndPositionGetter}
                 cellRenderer={cellRenderer}
-                overscanRowCount={10}
                 rowCount={Math.ceil(listData.length / numColumns)}
-                noRowsRenderer={noRowsRenderer}
               />
             </div>
           );
@@ -419,20 +437,11 @@ export function List<Item>({
             style={contentContainerStyle as any}
           >
             <VirtualizedList
-              ref={listRef as any}
-              autoHeight
+              {...listProps}
               width={autoSizerWidth}
-              data={listData}
               height={autoSizerHeight || height || 400}
-              isScrolling={isVisible ? isScrolling : false}
-              onScroll={isVisible ? onChildScroll : undefined}
-              overscanRowCount={10}
-              scrollTop={isVisible ? scrollTop : 0}
-              rowCount={listData.length}
               rowHeight={cache.rowHeight}
-              deferredMeasurementCache={cache}
               rowRenderer={rowRenderer}
-              noRowsRenderer={noRowsRenderer}
             />
           </div>
         );

--- a/packages/components/src/composite/Tabs/List.tsx
+++ b/packages/components/src/composite/Tabs/List.tsx
@@ -82,19 +82,25 @@ export function List<Item>({
   extraData,
   keyExtractor,
   contentContainerStyle,
+  horizontalPadding = 0,
 }: Omit<IListProps<Item>, 'ListEmptyComponent'> &
   Omit<ISectionListProps<Item>, 'ListEmptyComponent'> & {
     ListEmptyComponent?: ReactNode | ComponentType<any>;
     contentContainerStyle?: CSSProperties;
+    horizontalPadding?: number;
   }) {
   const {
     registerChild,
     height,
-    width,
+    width: tabWidth,
     isScrolling,
     onChildScroll,
     scrollTop,
   } = useTabsScrollContext();
+
+  const width = useMemo(() => {
+    return tabWidth - horizontalPadding;
+  }, [tabWidth, horizontalPadding]);
   const currentTabName = useTabNameContext();
   const { focusedTab } = useTabsContext();
 
@@ -405,6 +411,7 @@ export function List<Item>({
     noContentRenderer,
   ]);
 
+  console.log(contentContainerStyle);
   if (numColumns > 1) {
     return (
       <AutoSizer disableHeight>
@@ -416,7 +423,7 @@ export function List<Item>({
             >
               <Collection
                 {...listProps}
-                width={autoSizerWidth}
+                width={width}
                 cellCount={listData.length}
                 cellSizeAndPositionGetter={cellSizeAndPositionGetter}
                 cellRenderer={cellRenderer}

--- a/packages/components/src/composite/Tabs/List.tsx
+++ b/packages/components/src/composite/Tabs/List.tsx
@@ -105,6 +105,9 @@ export function List<Item>({
   const scrollTabElementsRef = useTabsContext().scrollTabElementsRef;
 
   const listData: IListData<Item>[] = useMemo(() => {
+    if (!data?.length && !sections?.length) {
+      return [];
+    }
     const list: IListData<Item>[] = [];
     if (ListHeaderComponent) {
       list.push({ type: 'header' });

--- a/packages/components/src/composite/Tabs/List.tsx
+++ b/packages/components/src/composite/Tabs/List.tsx
@@ -426,7 +426,7 @@ export function List<Item>({
               height={autoSizerHeight || height || 400}
               isScrolling={isVisible ? isScrolling : false}
               onScroll={isVisible ? onChildScroll : undefined}
-              overscanRowCount={5}
+              overscanRowCount={10}
               scrollTop={isVisible ? scrollTop : 0}
               rowCount={listData.length}
               rowHeight={cache.rowHeight}

--- a/packages/components/src/composite/Tabs/List.tsx
+++ b/packages/components/src/composite/Tabs/List.tsx
@@ -370,7 +370,7 @@ export function List<Item>({
     [rowRenderer],
   );
 
-  const noRowsRenderer = useCallback(() => {
+  const noContentRenderer = useCallback(() => {
     return (
       <>
         {HeaderElement}
@@ -385,26 +385,24 @@ export function List<Item>({
       ref: listRef as any,
       autoHeight: true,
       height,
-      data: data?.length || sections?.length ? listData : [],
-      rowCount: data?.length || sections?.length ? listData.length : 0,
+      data: listData,
+      rowCount: listData.length,
       isScrolling: isVisible ? isScrolling : false,
       onScroll: isVisible ? onChildScroll : undefined,
       scrollTop: isVisible ? scrollTop : 0,
       overscanRowCount: 10,
       deferredMeasurementCache: cache,
-      noRowsRenderer,
+      noContentRenderer,
     };
   }, [
     height,
-    data?.length,
-    sections?.length,
     listData,
     isVisible,
     isScrolling,
     onChildScroll,
     scrollTop,
     cache,
-    noRowsRenderer,
+    noContentRenderer,
   ]);
 
   if (numColumns > 1) {

--- a/packages/components/src/composite/Tabs/List.tsx
+++ b/packages/components/src/composite/Tabs/List.tsx
@@ -4,7 +4,6 @@ import {
   isValidElement,
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
 } from 'react';

--- a/packages/components/src/composite/Tabs/List.tsx
+++ b/packages/components/src/composite/Tabs/List.tsx
@@ -1,12 +1,6 @@
 /* eslint-disable react/prop-types */
 import type { CSSProperties, ComponentType, ReactNode } from 'react';
-import {
-  isValidElement,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-} from 'react';
+import { isValidElement, useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { View } from 'react-native';
 import {
@@ -23,7 +17,10 @@ import { useConvertAnimatedToValue } from './useFocusedTab';
 
 import type { ISectionListProps } from '../../layouts';
 import type { FlashListProps } from '@shopify/flash-list';
-import type { CollectionCellRendererParams } from 'react-virtualized';
+import type {
+  CollectionCellRendererParams,
+  ListRowProps,
+} from 'react-virtualized';
 
 type IListProps<Item> = FlashListProps<Item>;
 
@@ -83,6 +80,7 @@ export function List<Item>({
   ListFooterComponentStyle,
   numColumns = 1,
   extraData,
+  keyExtractor,
   contentContainerStyle,
 }: Omit<IListProps<Item>, 'ListEmptyComponent'> &
   Omit<ISectionListProps<Item>, 'ListEmptyComponent'> & {
@@ -105,31 +103,6 @@ export function List<Item>({
   const ref = useRef<Element>(null);
 
   const scrollTabElementsRef = useTabsContext().scrollTabElementsRef;
-
-  // Cell measurement cache for react-virtualized list optimization
-  // Can be optimized with keyExtractor for better height caching performance
-  const cache = useMemo(
-    () =>
-      new CellMeasurerCache({
-        fixedWidth: true,
-        defaultHeight: estimatedItemSize || 60,
-      }),
-    [estimatedItemSize],
-  );
-
-  const isVisible = useMemo(() => {
-    return focusedTabValue === currentTabName;
-  }, [focusedTabValue, currentTabName]);
-
-  useEffect(() => {
-    if (focusedTabValue === currentTabName) {
-      if (scrollTabElementsRef?.current[currentTabName]) {
-        scrollTabElementsRef.current[currentTabName].element =
-          ref.current as HTMLElement;
-      }
-      registerChild(ref.current);
-    }
-  }, [focusedTabValue, currentTabName, registerChild, scrollTabElementsRef]);
 
   const listData: IListData<Item>[] = useMemo(() => {
     const list: IListData<Item>[] = [];
@@ -191,6 +164,40 @@ export function List<Item>({
     sections,
   ]);
 
+  // Cell measurement cache for react-virtualized list optimization
+  // Can be optimized with keyExtractor for better height caching performance
+  const cache = useMemo(
+    () =>
+      new CellMeasurerCache({
+        fixedWidth: true,
+        defaultHeight: estimatedItemSize || 60,
+        keyMapper: (rowIndex, columnIndex) => {
+          if (keyExtractor) {
+            const item = (listData[rowIndex] as { data: Item })?.data;
+            return item
+              ? keyExtractor(item, rowIndex)
+              : `${rowIndex}-${columnIndex}`;
+          }
+          return `${rowIndex}-${columnIndex}`;
+        },
+      }),
+    [estimatedItemSize, keyExtractor, listData],
+  );
+
+  const isVisible = useMemo(() => {
+    return focusedTabValue === currentTabName;
+  }, [focusedTabValue, currentTabName]);
+
+  useEffect(() => {
+    if (focusedTabValue === currentTabName) {
+      if (scrollTabElementsRef?.current[currentTabName]) {
+        scrollTabElementsRef.current[currentTabName].element =
+          ref.current as HTMLElement;
+      }
+      registerChild(ref.current);
+    }
+  }, [focusedTabValue, currentTabName, registerChild, scrollTabElementsRef]);
+
   const listRef = useRef<typeof VirtualizedList>(null);
 
   const HeaderElement = useMemo(() => {
@@ -217,15 +224,15 @@ export function List<Item>({
 
   const rowRenderer = useCallback(
     ({
-      index,
+      rowIndex,
       key,
+      parent,
       style,
-    }: {
-      index: number;
-      key: string;
-      style: React.CSSProperties;
+      columnIndex = 0,
+      index,
+    }: ListRowProps & {
+      rowIndex?: number;
     }) => {
-      const parent = listRef.current;
       const item = listData[index];
       let element = null;
       if (item.type === 'header') {
@@ -259,20 +266,18 @@ export function List<Item>({
         return (
           <CellMeasurer
             cache={cache}
-            columnIndex={0}
-            key={key}
-            parent={parent as any}
-            rowIndex={index}
+            columnIndex={columnIndex}
+            rowIndex={rowIndex || index}
+            key={key || index}
+            parent={parent}
           >
-            <div key={key} style={style}>
-              {element as React.ReactNode}
-            </div>
+            <div style={style}>{element as React.ReactNode}</div>
           </CellMeasurer>
         );
       }
 
       return (
-        <div key={key} style={style}>
+        <div key={key || index} style={style}>
           {element as React.ReactNode}
         </div>
       );
@@ -329,24 +334,40 @@ export function List<Item>({
   );
 
   useEffect(() => {
+    if (keyExtractor) {
+      return;
+    }
     if (data?.length || sections?.length || numColumns || width || extraData) {
       recompute({ numColumns, width });
     }
-  }, [data?.length, sections?.length, numColumns, width, extraData, recompute]);
+  }, [
+    data?.length,
+    sections?.length,
+    numColumns,
+    width,
+    extraData,
+    recompute,
+    keyExtractor,
+  ]);
 
   const cellRenderer = useCallback(
     (params: CollectionCellRendererParams) => {
-      const { index, key, style } = params;
+      const { index, key, style, isScrolling: isScrollingParam } = params;
       return rowRenderer({
         index,
         key: String(key),
+        rowIndex: index,
         style,
+        isScrolling: isScrollingParam,
+        columnIndex: 0,
+        isVisible: true,
+        parent: listRef.current as any,
       });
     },
     [rowRenderer],
   );
 
-  if (!data?.length && !sections?.length) {
+  const noRowsRenderer = useCallback(() => {
     return (
       <>
         {HeaderElement}
@@ -354,14 +375,17 @@ export function List<Item>({
         {FooterElement}
       </>
     );
-  }
+  }, [HeaderElement, ListEmptyComponent, FooterElement]);
 
   if (numColumns > 1) {
     return (
       <AutoSizer disableHeight>
         {({ width: autoSizerWidth }) => {
           return (
-            <div ref={ref as React.RefObject<HTMLDivElement>}>
+            <div
+              ref={ref as React.RefObject<HTMLDivElement>}
+              style={contentContainerStyle as any}
+            >
               <Collection
                 ref={listRef as any}
                 autoHeight
@@ -372,10 +396,12 @@ export function List<Item>({
                 width={autoSizerWidth}
                 height={height}
                 cellCount={listData.length}
+                deferredMeasurementCache={cache}
                 cellSizeAndPositionGetter={cellSizeAndPositionGetter}
-                cellRenderer={cellRenderer as any}
-                overscanRowCount={30}
+                cellRenderer={cellRenderer}
+                overscanRowCount={10}
                 rowCount={Math.ceil(listData.length / numColumns)}
+                noRowsRenderer={noRowsRenderer}
               />
             </div>
           );
@@ -400,11 +426,13 @@ export function List<Item>({
               height={autoSizerHeight || height || 400}
               isScrolling={isVisible ? isScrolling : false}
               onScroll={isVisible ? onChildScroll : undefined}
-              overscanRowCount={30}
+              overscanRowCount={5}
               scrollTop={isVisible ? scrollTop : 0}
               rowCount={listData.length}
               rowHeight={cache.rowHeight}
+              deferredMeasurementCache={cache}
               rowRenderer={rowRenderer}
+              noRowsRenderer={noRowsRenderer}
             />
           </div>
         );

--- a/packages/components/src/composite/Tabs/List.tsx
+++ b/packages/components/src/composite/Tabs/List.tsx
@@ -398,7 +398,6 @@ export function List<Item>({
       scrollTop: isVisible ? scrollTop : 0,
       overscanRowCount: 10,
       deferredMeasurementCache: cache,
-      noContentRenderer,
     };
   }, [
     height,
@@ -408,7 +407,6 @@ export function List<Item>({
     onChildScroll,
     scrollTop,
     cache,
-    noContentRenderer,
   ]);
 
   if (numColumns > 1) {
@@ -427,6 +425,7 @@ export function List<Item>({
                 cellSizeAndPositionGetter={cellSizeAndPositionGetter}
                 cellRenderer={cellRenderer}
                 rowCount={Math.ceil(listData.length / numColumns)}
+                noContentRenderer={noContentRenderer}
               />
             </div>
           );
@@ -449,6 +448,7 @@ export function List<Item>({
               height={autoSizerHeight || height || 400}
               rowHeight={cache.rowHeight}
               rowRenderer={rowRenderer}
+              noRowsRenderer={noContentRenderer}
             />
           </div>
         );

--- a/packages/components/src/content/Keyboard/index.native.tsx
+++ b/packages/components/src/content/Keyboard/index.native.tsx
@@ -1,0 +1,15 @@
+import {
+  KeyboardAvoidingView,
+  KeyboardAwareScrollView,
+  KeyboardControllerView,
+  KeyboardStickyView,
+  KeyboardToolbar,
+} from 'react-native-keyboard-controller';
+
+export const Keyboard = {
+  AvoidingView: KeyboardAvoidingView,
+  AwareScrollView: KeyboardAwareScrollView,
+  StickyView: KeyboardStickyView,
+  Toolbar: KeyboardToolbar,
+  ControllerView: KeyboardControllerView,
+};

--- a/packages/components/src/content/Keyboard/index.native.tsx
+++ b/packages/components/src/content/Keyboard/index.native.tsx
@@ -6,10 +6,17 @@ import {
   KeyboardToolbar,
 } from 'react-native-keyboard-controller';
 
+import {
+  dismissKeyboard,
+  dismissKeyboardWithDelay,
+} from '@onekeyhq/shared/src/keyboard';
+
 export const Keyboard = {
   AvoidingView: KeyboardAvoidingView,
   AwareScrollView: KeyboardAwareScrollView,
   StickyView: KeyboardStickyView,
   Toolbar: KeyboardToolbar,
   ControllerView: KeyboardControllerView,
+  dismiss: dismissKeyboard,
+  dismissWithDelay: dismissKeyboardWithDelay,
 };

--- a/packages/components/src/content/Keyboard/index.tsx
+++ b/packages/components/src/content/Keyboard/index.tsx
@@ -1,3 +1,7 @@
+import {
+  dismissKeyboard,
+  dismissKeyboardWithDelay,
+} from '@onekeyhq/shared/src/keyboard';
 
 export const Keyboard = {
   AvoidingView: (children: React.ReactNode) => children,
@@ -5,4 +9,6 @@ export const Keyboard = {
   StickyView: (children: React.ReactNode) => children,
   Toolbar: (children: React.ReactNode) => children,
   ControllerView: (children: React.ReactNode) => children,
+  dismiss: dismissKeyboard,
+  dismissWithDelay: dismissKeyboardWithDelay,
 };

--- a/packages/components/src/content/Keyboard/index.tsx
+++ b/packages/components/src/content/Keyboard/index.tsx
@@ -1,0 +1,8 @@
+
+export const Keyboard = {
+  AvoidingView: (children: React.ReactNode) => children,
+  AwareScrollView: (children: React.ReactNode) => children,
+  StickyView: (children: React.ReactNode) => children,
+  Toolbar: (children: React.ReactNode) => children,
+  ControllerView: (children: React.ReactNode) => children,
+};

--- a/packages/components/src/content/index.ts
+++ b/packages/components/src/content/index.ts
@@ -18,3 +18,4 @@ export * from './SheetGrabber';
 export * from './ConfirmHighlighter';
 export * from './DescriptionList';
 export * from './Theme';
+export * from './Keyboard';

--- a/packages/components/src/forms/Select/index.tsx
+++ b/packages/components/src/forms/Select/index.tsx
@@ -323,7 +323,8 @@ function SelectContent() {
       keepChildrenMounted
       sheetProps={{
         dismissOnSnapToBottom: true,
-        snapPointsMode: 'fit',
+        snapPointsMode: 'percent',
+        snapPoints: [60],
         ...sheetProps,
       }}
       floatingPanelProps={{

--- a/packages/components/src/layouts/ListView/list.native.tsx
+++ b/packages/components/src/layouts/ListView/list.native.tsx
@@ -98,6 +98,8 @@ function BaseListView<T>(
         renderItem={renderItem}
         estimatedItemSize={itemSize}
         disableAutoLayout={I18nManager.isRTL}
+        keyboardDismissMode="on-drag"
+        keyboardShouldPersistTaps="handled"
         {...restProps}
       />
     </OptimizationView>

--- a/packages/components/src/layouts/SortableListView/index.native.tsx
+++ b/packages/components/src/layouts/SortableListView/index.native.tsx
@@ -110,6 +110,8 @@ function BaseSortableListView<T>(
       data={data}
       keyExtractor={keyExtractor}
       renderItem={renderItem as RenderItem<T>}
+      keyboardDismissMode="on-drag"
+      keyboardShouldPersistTaps="handled"
       {...restProps}
     />
   );

--- a/packages/kit/src/components/TxHistoryListView/index.tsx
+++ b/packages/kit/src/components/TxHistoryListView/index.tsx
@@ -159,9 +159,12 @@ function BaseTxHistoryListView(props: IProps) {
     [],
   );
 
-  const resolvedContentContainerStyle = useStyle(contentContainerStyle || {}, {
-    resolveValues: 'auto',
-  });
+  const resolvedContentContainerStyle = useStyle(
+    contentContainerStyle || listViewStyleProps?.contentContainerStyle || {},
+    {
+      resolveValues: 'auto',
+    },
+  );
 
   const { ListHeaderComponentStyle, ListFooterComponentStyle } =
     listViewStyleProps || {};

--- a/packages/kit/src/provider/Container/AppStateLockContainer/components/AppStateLock.tsx
+++ b/packages/kit/src/provider/Container/AppStateLockContainer/components/AppStateLock.tsx
@@ -4,6 +4,7 @@ import { memo } from 'react';
 import { useIntl } from 'react-intl';
 import {
   Dimensions,
+  Keyboard,
   type View as IView,
   type KeyboardEvent,
 } from 'react-native';
@@ -87,6 +88,7 @@ const AppStateLock = ({
         flex={1}
         bg="$bgApp"
         pointerEvents={platformEnv.isNative ? undefined : 'auto'}
+        onPress={Keyboard.dismiss}
         {...props}
       >
         <Animated.View style={safeKeyboardAnimationStyle}>

--- a/packages/kit/src/views/Home/components/NFTListView/index.tsx
+++ b/packages/kit/src/views/Home/components/NFTListView/index.tsx
@@ -18,7 +18,7 @@ import type { IAccountNFT } from '@onekeyhq/shared/types/nft';
 
 import { NFTListItem } from './NFTListItem';
 
-import type { ListRenderItemInfo, StyleProp, ViewStyle } from 'react-native';
+import type { ListRenderItemInfo } from 'react-native';
 
 type IProps = {
   data: IAccountNFT[];
@@ -163,7 +163,8 @@ function NFTListView(props: IProps) {
 
   return (
     <Tabs.FlatList
-      key={numColumns}
+      // @ts-ignore
+      horizontalPadding={20}
       contentContainerStyle={style as any}
       ListHeaderComponentStyle={resolvedListHeaderComponentStyle as any}
       ListFooterComponentStyle={resolvedListFooterComponentStyle as any}

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -2,7 +2,16 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { Icon, Page, Stack, Tabs, YStack } from '@onekeyhq/components';
+import {
+  Icon,
+  Page,
+  Stack,
+  Tabs,
+  YStack,
+  getTokens,
+  useMedia,
+} from '@onekeyhq/components';
+import useProviderSideBarValue from '@onekeyhq/components/src/hocs/Provider/hooks/useProviderSideBarValue';
 import { getEnabledNFTNetworkIds } from '@onekeyhq/shared/src/engine/engineConsts';
 import {
   EAppEventBusNames,
@@ -32,6 +41,22 @@ import WalletContentWithAuth from './WalletContentWithAuth';
 
 import type { LayoutChangeEvent } from 'react-native';
 
+const useTabContainerWidth = platformEnv.isNative
+  ? () => undefined
+  : () => {
+      const { leftSidebarCollapsed = false } = useProviderSideBarValue() || {};
+      const { md } = useMedia();
+      const sideBarWidth = useMemo(() => {
+        if (md) {
+          return 0;
+        }
+        if (!leftSidebarCollapsed) {
+          return getTokens().size.sideBarWidth.val;
+        }
+        return 0;
+      }, [md, leftSidebarCollapsed]);
+      return `calc(100vw - ${sideBarWidth}px)`;
+    };
 export function HomePageView({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onPressHide,
@@ -126,8 +151,10 @@ export function HomePageView({
     return <HomeHeaderContainer />;
   }, []);
 
+  const tabContainerWidth: any = useTabContainerWidth();
   const tabContainerProps = useMemo(() => {
     return {
+      width: tabContainerWidth,
       headerContainerStyle: {
         shadowOpacity: 0,
         elevation: 0,
@@ -142,7 +169,7 @@ export function HomePageView({
         />
       ),
     };
-  }, [renderHeader]);
+  }, [renderHeader, tabContainerWidth]);
 
   const tabs = useMemo(() => {
     const key = `${account?.id ?? ''}-${account?.indexedAccountId ?? ''}-${

--- a/packages/kit/src/views/ReferFriends/pages/YourReferredWalletAddresses/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/YourReferredWalletAddresses/index.tsx
@@ -28,12 +28,14 @@ export default function YourReferredWalletAddresses() {
 
   const { items, networks } = params;
 
-  const [networkId, setNetworkId] = useState(networks?.[0]?.networkId);
-
   const networkIds = useMemo(
-    () => (networks ? networks.map((i) => i.networkId) : []),
-    [networks],
+    () => (items ? items.map((i) => i.networkId) : []),
+    [items],
   );
+  const [networkId, setNetworkId] = useState(
+    networkIds[0] || networks?.[0]?.networkId,
+  );
+
   const renderHeaderRight = useCallback(() => {
     return (
       <ControlledNetworkSelectorIconTrigger


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a consolidated Keyboard utility, providing unified access to keyboard-related components and functions.
  * Enhanced Tabs components with improved width handling, scroll snapping, and customizable key extraction for list items.
  * Added support for percentage-based bottom sheet snap points in Select components.

* **Improvements**
  * Optimized keyboard behavior in list and sortable list views for smoother user interactions.
  * Refined tab container width calculation for better responsiveness on web platforms.
  * Improved initial network selection logic in referred wallet addresses view.
  * Enhanced styling flexibility and cache handling in various list and history components.
  * Enabled keyboard dismissal by tapping the lock screen background.
  * Adjusted keyboard dismissal and tap handling behavior in list views.
  * Added horizontal padding support in NFT list view for improved layout.

* **Bug Fixes**
  * Removed unused imports and redundant code for cleaner components.
  * Removed unnecessary divider component from popover for cleaner UI.

* **Chores**
  * Updated exports to include new Keyboard utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->