### PR TITLE
fix: swap recent token skip check equal OK-40683 OK-40681

### DIFF
--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -272,9 +272,11 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       token: ISwapToken,
       disableCheckToToken?: boolean,
       skipCleanManualSelectQuoteProviders?: boolean,
+      skipCheckEqualToken?: boolean,
     ) => {
       const toToken = get(swapSelectToTokenAtom());
       if (
+        !skipCheckEqualToken &&
         equalTokenNoCaseSensitive({
           token1: toToken,
           token2: token,
@@ -314,12 +316,14 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       set,
       token: ISwapToken,
       skipCleanManualSelectQuoteProviders?: boolean,
+      skipCheckEqualToken?: boolean,
     ) => {
       if (!skipCleanManualSelectQuoteProviders) {
         this.cleanManualSelectQuoteProviders.call(set);
       }
       const fromToken = get(swapSelectFromTokenAtom());
       if (
+        !skipCheckEqualToken &&
         equalTokenNoCaseSensitive({
           token1: fromToken,
           token2: token,

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -48,7 +48,10 @@ import {
   type IModalSwapParamList,
 } from '@onekeyhq/shared/src/routes/swap';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
-import { checkWrappedTokenPair } from '@onekeyhq/shared/src/utils/tokenUtils';
+import {
+  checkWrappedTokenPair,
+  equalTokenNoCaseSensitive,
+} from '@onekeyhq/shared/src/utils/tokenUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import type {
   IFetchQuoteResult,
@@ -183,8 +186,12 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
       fromToken: ISwapToken;
       toToken: ISwapToken;
     }) => {
-      void selectFromToken(fromTokenPair, true);
-      void selectToToken(toTokenPair);
+      const skipCheckEqualToken = !equalTokenNoCaseSensitive({
+        token1: fromTokenPair,
+        token2: toTokenPair,
+      });
+      void selectFromToken(fromTokenPair, true, undefined, skipCheckEqualToken);
+      void selectToToken(toTokenPair, undefined, skipCheckEqualToken);
       defaultLogger.swap.selectToken.selectToken({
         selectFrom: ESwapSelectTokenSource.RECENT_SELECT,
       });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token selection in the swap interface to better handle cases where the selected tokens are the same, ensuring smoother user experience when choosing recent token pairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->