### PR TITLE
OK-40799: prevent rendering of WalletBoundReferralCodeButton for mocked wallet

### DIFF
--- a/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletBoundReferralCodeButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletBoundReferralCodeButton.tsx
@@ -96,6 +96,10 @@ function WalletBoundReferralCodeButtonView({
     return null;
   }
 
+  if (wallet?.isMocked) {
+    return null;
+  }
+
   if (isLoadingReferralCodeButton) {
     return <ActionList.SkeletonItem />;
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The referral code button will no longer appear for mocked wallets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->