### PR TITLE
fix: fix flicker in svg loading on React 19 &&  fix recovery phrase splitting on native

### DIFF
--- a/packages/components/src/actions/Alert/index.tsx
+++ b/packages/components/src/actions/Alert/index.tsx
@@ -7,6 +7,7 @@ import { createStyledContext, styled, useThemeName } from 'tamagui';
 
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
+import { useSettingConfig } from '../../hocs/Provider/hooks/useProviderValue';
 import {
   Button,
   Icon,
@@ -166,9 +167,11 @@ export const Alert: ComponentType<IAlertProps> = AlertFrame.styleable<
   const themeName = useThemeName() as 'light' | 'dark';
   const dangerTextColor =
     themeName === 'light' ? '$textOnBrightColor' : '$textOnColor';
+  const { HyperlinkText } = useSettingConfig();
 
   if (!show) return null;
 
+  const Text = HyperlinkText || SizableText;
   return (
     <AlertFrame
       ref={ref}
@@ -185,7 +188,7 @@ export const Alert: ComponentType<IAlertProps> = AlertFrame.styleable<
       ) : null}
       <YStack flex={1} gap="$1">
         {title ? (
-          <SizableText
+          <Text
             size="$bodyMdMedium"
             color={isDanger ? dangerTextColor : undefined}
             {...(titleNumberOfLines
@@ -193,7 +196,7 @@ export const Alert: ComponentType<IAlertProps> = AlertFrame.styleable<
               : {})}
           >
             {title}
-          </SizableText>
+          </Text>
         ) : null}
         {renderTitle
           ? renderTitle({
@@ -205,12 +208,12 @@ export const Alert: ComponentType<IAlertProps> = AlertFrame.styleable<
             })
           : null}
         {description ? (
-          <SizableText
+          <Text
             size="$bodyMd"
             color={isDanger ? dangerTextColor : '$textSubdued'}
           >
             {description}
-          </SizableText>
+          </Text>
         ) : null}
         {descriptionComponent || null}
 

--- a/packages/components/src/actions/Alert/index.tsx
+++ b/packages/components/src/actions/Alert/index.tsx
@@ -7,7 +7,6 @@ import { createStyledContext, styled, useThemeName } from 'tamagui';
 
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
-import { useSettingConfig } from '../../hocs/Provider/hooks/useProviderValue';
 import {
   Button,
   Icon,
@@ -167,11 +166,9 @@ export const Alert: ComponentType<IAlertProps> = AlertFrame.styleable<
   const themeName = useThemeName() as 'light' | 'dark';
   const dangerTextColor =
     themeName === 'light' ? '$textOnBrightColor' : '$textOnColor';
-  const { HyperlinkText } = useSettingConfig();
 
   if (!show) return null;
 
-  const Text = HyperlinkText || SizableText;
   return (
     <AlertFrame
       ref={ref}
@@ -188,7 +185,7 @@ export const Alert: ComponentType<IAlertProps> = AlertFrame.styleable<
       ) : null}
       <YStack flex={1} gap="$1">
         {title ? (
-          <Text
+          <SizableText
             size="$bodyMdMedium"
             color={isDanger ? dangerTextColor : undefined}
             {...(titleNumberOfLines
@@ -196,7 +193,7 @@ export const Alert: ComponentType<IAlertProps> = AlertFrame.styleable<
               : {})}
           >
             {title}
-          </Text>
+          </SizableText>
         ) : null}
         {renderTitle
           ? renderTitle({
@@ -208,12 +205,12 @@ export const Alert: ComponentType<IAlertProps> = AlertFrame.styleable<
             })
           : null}
         {description ? (
-          <Text
+          <SizableText
             size="$bodyMd"
             color={isDanger ? dangerTextColor : '$textSubdued'}
           >
             {description}
-          </Text>
+          </SizableText>
         ) : null}
         {descriptionComponent || null}
 

--- a/packages/components/src/primitives/Icon/index.tsx
+++ b/packages/components/src/primitives/Icon/index.tsx
@@ -24,7 +24,7 @@ const ComponentMaps: Record<string, typeof Svg> = {};
 const DEFAULT_SIZE = 24;
 
 // Global promise cache to ensure only one loading promise per icon
-const loadingPromises: Record<string, Promise<typeof Svg>> = {};
+const isLoadingIcon: Record<string, boolean> = {};
 // Callback queues for each icon
 const callbackQueues: Record<
   string,
@@ -39,31 +39,24 @@ const loadIconModule = (name: IKeyOfIcons): Promise<typeof Svg> => {
       callbackQueues[name] = [resolveCallback];
     }
 
-    // If already loading, return the existing promise
-    if (loadingPromises[name] !== undefined) {
-      return loadingPromises[name];
+    if (isLoadingIcon[name]) {
+      return;
     }
 
-    // Create new loading promise
-    loadingPromises[name] = new Promise<typeof Svg>((resolve) => {
-      void ICON_CONFIG[name]?.().then((module: any) => {
+    isLoadingIcon[name] = true;
+    void ICON_CONFIG[name]?.().then((module: any) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      if (module?.default) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        if (module?.default) {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          const component = module.default as typeof Svg;
-          ComponentMaps[name] = component;
-          delete loadingPromises[name];
+        const component = module.default as typeof Svg;
+        ComponentMaps[name] = component;
+        delete isLoadingIcon[name];
 
-          // Execute all callbacks for this icon
-          const callbacks = callbackQueues[name] || [];
-          callbacks.forEach((callback) => callback(component));
+        const callbacks = callbackQueues[name] || [];
+        callbacks.forEach((callback) => callback(component));
 
-          // Clean up
-          delete callbackQueues[name];
-
-          resolve(component);
-        }
-      });
+        delete callbackQueues[name];
+      }
     });
   });
 };

--- a/packages/components/src/primitives/Icon/index.tsx
+++ b/packages/components/src/primitives/Icon/index.tsx
@@ -1,4 +1,4 @@
-import { Suspense, forwardRef } from 'react';
+import { Suspense, forwardRef, useEffect, useState } from 'react';
 
 import { styled, withStaticProperties } from 'tamagui';
 
@@ -23,29 +23,61 @@ const ComponentMaps: Record<string, typeof Svg> = {};
 
 const DEFAULT_SIZE = 24;
 
-const loadIcon = (name: IKeyOfIcons) =>
-  new Promise<typeof Svg>((resolve) => {
-    void ICON_CONFIG[name]?.().then((module: any) => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      if (module?.default) {
+// Global promise cache to ensure only one loading promise per icon
+const loadingPromises: Record<string, Promise<typeof Svg>> = {};
+// Callback queues for each icon
+const callbackQueues: Record<
+  string,
+  Array<(component: typeof Svg) => void>
+> = {};
+
+const loadIconModule = (name: IKeyOfIcons): Promise<typeof Svg> => {
+  return new Promise((resolveCallback) => {
+    if (callbackQueues[name]) {
+      callbackQueues[name].push(resolveCallback);
+    } else {
+      callbackQueues[name] = [resolveCallback];
+    }
+
+    // If already loading, return the existing promise
+    if (loadingPromises[name] !== undefined) {
+      return loadingPromises[name];
+    }
+
+    // Create new loading promise
+    loadingPromises[name] = new Promise<typeof Svg>((resolve) => {
+      void ICON_CONFIG[name]?.().then((module: any) => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        ComponentMaps[name] = module.default as typeof Svg;
-        resolve(ComponentMaps[name]);
-      }
+        if (module?.default) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          const component = module.default as typeof Svg;
+          ComponentMaps[name] = component;
+          delete loadingPromises[name];
+
+          // Execute all callbacks for this icon
+          const callbacks = callbackQueues[name] || [];
+          callbacks.forEach((callback) => callback(component));
+
+          // Clean up
+          delete callbackQueues[name];
+
+          resolve(component);
+        }
+      });
     });
   });
+};
 
-// eslint-disable-next-line @typescript-eslint/unbound-method
-const { useSuspender } = createSuspender(
-  (name: IKeyOfIcons) =>
-    new Promise<typeof Svg>((resolve) => {
-      if (ComponentMaps[name]) {
-        resolve(ComponentMaps[name]);
-      } else {
-        void loadIcon(name).then(resolve);
-      }
-    }),
-);
+const loadIcon = (name: IKeyOfIcons) =>
+  new Promise<typeof Svg>((resolve) => {
+    // If component is already loaded, resolve immediately
+    if (ComponentMaps[name]) {
+      resolve(ComponentMaps[name]);
+      return;
+    }
+
+    void loadIconModule(name).then(resolve);
+  });
 
 function IconLoader({
   name,
@@ -57,8 +89,28 @@ function IconLoader({
   color: string;
   style?: TextStyle;
 }) {
-  const SVGComponent = useSuspender(name);
-  return <SVGComponent {...props} />;
+  const [, setCount] = useState(0);
+
+  useEffect(() => {
+    if (ComponentMaps[name]) {
+      return;
+    }
+    void loadIcon(name).then(() => {
+      setCount((prev) => prev + 1);
+    });
+  }, [name]);
+
+  const Svg = ComponentMaps[name];
+  return Svg ? (
+    <Svg {...props} />
+  ) : (
+    <OptimizationView
+      style={{
+        width: props.width,
+        height: props.height,
+      }}
+    />
+  );
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -82,24 +134,13 @@ function BasicIconContainer({ name, style }: IIconContainerProps, _: any) {
       color={componentColor}
     />
   ) : (
-    <Suspense
-      fallback={
-        <OptimizationView
-          style={{
-            width: componentWidth,
-            height: componentHeight,
-          }}
-        />
-      }
-    >
-      <IconLoader
-        width={componentWidth}
-        height={componentHeight}
-        style={style}
-        color={componentColor}
-        name={name}
-      />
-    </Suspense>
+    <IconLoader
+      width={componentWidth}
+      height={componentHeight}
+      style={style}
+      color={componentColor}
+      name={name}
+    />
   );
 }
 const IconContainer = forwardRef(BasicIconContainer);

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -216,6 +216,7 @@ class ServiceAccount extends ServiceBase {
   }
 
   @backgroundMethod()
+  @toastIfError()
   async validateMnemonic(mnemonic: string): Promise<{
     mnemonic: string;
     mnemonicType: EMnemonicType;

--- a/packages/kit/src/views/Onboarding/components/PhaseInputArea.tsx
+++ b/packages/kit/src/views/Onboarding/components/PhaseInputArea.tsx
@@ -266,8 +266,7 @@ function BasicPhaseInput(
       const trimmedValue = v ? parseSecretRecoveryPhrase(v) : '';
       if (
         trimmedValue &&
-        trimmedValue.split(' ').filter(Boolean).length === phraseLength &&
-        validateMnemonic(trimmedValue)
+        trimmedValue.split(' ').filter(Boolean).length === phraseLength
       ) {
         if (onPasteMnemonic(trimmedValue, 0)) {
           onInputChange('');

--- a/packages/kit/src/views/Staking/components/UniversalStake/index.tsx
+++ b/packages/kit/src/views/Staking/components/UniversalStake/index.tsx
@@ -1138,10 +1138,9 @@ export function UniversalStake({
 
             return (
               <XStack key={reward.title.text} gap="$1" ai="center" mt="$1.5">
-                <XStack gap="$1">
+                <XStack gap="$1" ai="center">
                   <EarnText
                     text={reward.title}
-                    alignSelf="center"
                     color={reward.title.color}
                     size={reward.title.size}
                   />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during mnemonic validation by displaying a toast notification if validation fails.
  * Adjusted mnemonic input handling to allow pasting phrases based solely on word count, without immediate validation.
  * Updated reward list alignment in the staking view for a more consistent visual presentation.

* **Refactor**
  * Reworked icon loading to remove React Suspense, improving performance and reliability when displaying icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->