### PR TITLE
fix: resolve market homepage scrolling issue && implement lazy loading for heavy rendering page on Native && fix NFT list placeholder display && correct staking homepage background color in dark mode && fix scroll issues in Carousel component

### DIFF
--- a/packages/components/src/composite/Carousel/index.tsx
+++ b/packages/components/src/composite/Carousel/index.tsx
@@ -54,7 +54,6 @@ export function Carousel<T>({
   const [pageIndex, setPageIndex] = useState<number>(0);
   const currentPage = useRef<number>(0);
   currentPage.current = pageIndex;
-  
 
   const debouncedSetPageIndex = useDebouncedCallback(setPageIndex, 50);
 
@@ -154,7 +153,6 @@ export function Carousel<T>({
   const handleHoverOut = useCallback(() => {
     startAutoPlay();
   }, [startAutoPlay]);
-
 
   return (
     <YStack userSelect="none">

--- a/packages/components/src/composite/Carousel/index.tsx
+++ b/packages/components/src/composite/Carousel/index.tsx
@@ -132,7 +132,7 @@ export function Carousel<T>({
     height: 0,
   });
 
-  const layoutWidth = useMemo(() => {
+  const pageWidth = useMemo(() => {
     return (
       layout.width - (platformEnv.isNative ? 0 : marginRatio * layout.width)
     );
@@ -173,6 +173,7 @@ export function Carousel<T>({
               ref={pagerRef as RefObject<NativePagerView>}
               style={{ width: layout.width, height: layout.height }}
               initialPage={0}
+              pageWidth={pageWidth}
               onPageSelected={onPageSelected}
               keyboardDismissMode="on-drag"
             >
@@ -180,7 +181,7 @@ export function Carousel<T>({
                 <Stack
                   key={index}
                   style={{
-                    width: layoutWidth,
+                    width: pageWidth,
                     height: '100%',
                   }}
                 >

--- a/packages/components/src/composite/Carousel/index.tsx
+++ b/packages/components/src/composite/Carousel/index.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -53,6 +54,7 @@ export function Carousel<T>({
   const [pageIndex, setPageIndex] = useState<number>(0);
   const currentPage = useRef<number>(0);
   currentPage.current = pageIndex;
+  
 
   const debouncedSetPageIndex = useDebouncedCallback(setPageIndex, 50);
 
@@ -130,6 +132,13 @@ export function Carousel<T>({
     width: 0,
     height: 0,
   });
+
+  const layoutWidth = useMemo(() => {
+    return (
+      layout.width - (platformEnv.isNative ? 0 : marginRatio * layout.width)
+    );
+  }, [layout.width, marginRatio]);
+
   const handleLayout = useCallback(
     (event: LayoutChangeEvent) => {
       setLayout(event.nativeEvent.layout);
@@ -145,6 +154,7 @@ export function Carousel<T>({
   const handleHoverOut = useCallback(() => {
     startAutoPlay();
   }, [startAutoPlay]);
+
 
   return (
     <YStack userSelect="none">
@@ -172,9 +182,7 @@ export function Carousel<T>({
                 <Stack
                   key={index}
                   style={{
-                    width:
-                      layout.width -
-                      (platformEnv.isNative ? 0 : marginRatio * layout.width),
+                    width: layoutWidth,
                     height: '100%',
                   }}
                 >

--- a/packages/components/src/layouts/Navigation/ScreenProps.ts
+++ b/packages/components/src/layouts/Navigation/ScreenProps.ts
@@ -104,7 +104,6 @@ export type IStackNavigationOptions = Omit<
   NativeStackNavigationOptions,
   'headerRight' | 'headerSearchBarOptions'
 > & {
-  // If this property is set, please ensure that `Page.skipLoading` is set to `platformEnv.isNativeIOS`.
   headerSearchBarOptions?: INavSearchBarProps;
   headerRight?: (
     props: any,

--- a/packages/components/src/layouts/Page/BasicPage.native.tsx
+++ b/packages/components/src/layouts/Page/BasicPage.native.tsx
@@ -116,18 +116,17 @@ function LoadingScreen({
 
 export function BasicPage({
   children,
-  skipLoading = true,
+  lazyLoad = false,
   fullPage = false,
 }: IBasicPageProps) {
   return (
     <Stack bg="$bgApp" flex={1}>
       {platformEnv.isNativeIOS ? <PageStatusBar /> : undefined}
-      {/* {skipLoading ? (
-        children
-      ) : (
+      {lazyLoad ? (
         <LoadingScreen fullPage={fullPage}>{children}</LoadingScreen>
-      )} */}
-      {children}
+      ) : (
+        children
+      )}
     </Stack>
   );
 }

--- a/packages/components/src/layouts/Page/BasicPage.native.tsx
+++ b/packages/components/src/layouts/Page/BasicPage.native.tsx
@@ -6,7 +6,7 @@ import { AnimatePresence, useThemeName } from 'tamagui';
 
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
-import { EPageType, useIsModalPage } from '../../hocs';
+import { useIsModalPage } from '../../hocs';
 import { useIsIpadLandscape } from '../../hooks/useOrientation';
 import { Spinner, Stack, View } from '../../primitives';
 

--- a/packages/components/src/layouts/Page/PageContainer.tsx
+++ b/packages/components/src/layouts/Page/PageContainer.tsx
@@ -11,14 +11,14 @@ import { BasicPageFooter } from './PageFooter';
 
 import type { IPageProps } from './type';
 
-export function PageContainer({ children, skipLoading, fullPage }: IPageProps) {
+export function PageContainer({ children, lazyLoad, fullPage }: IPageProps) {
   const { scrollEnabled, scrollProps } = useContext(PageContext);
 
   const safeKeyboardAnimationStyle = useSafeKeyboardAnimationStyle();
 
   return useMemo(
     () => (
-      <BasicPage skipLoading={skipLoading} fullPage={fullPage}>
+      <BasicPage lazyLoad={lazyLoad} fullPage={fullPage}>
         {scrollEnabled ? (
           <ScrollView {...scrollProps}>
             <Animated.View style={safeKeyboardAnimationStyle}>
@@ -32,7 +32,7 @@ export function PageContainer({ children, skipLoading, fullPage }: IPageProps) {
       </BasicPage>
     ),
     [
-      skipLoading,
+      lazyLoad,
       fullPage,
       scrollEnabled,
       scrollProps,

--- a/packages/components/src/layouts/Page/index.tsx
+++ b/packages/components/src/layouts/Page/index.tsx
@@ -29,7 +29,7 @@ function PagePortal({ pagePortalId }: { pagePortalId: string }) {
 
 function PageProvider({
   children,
-  skipLoading = false,
+  lazyLoad = false,
   scrollEnabled = false,
   scrollProps = { showsVerticalScrollIndicator: false },
   safeAreaEnabled = true,
@@ -63,7 +63,7 @@ function PageProvider({
     <>
       <PageContext.Provider value={value}>
         <>
-          <PageContainer skipLoading={skipLoading} fullPage={fullPage}>
+          <PageContainer lazyLoad={lazyLoad} fullPage={fullPage}>
             {children}
           </PageContainer>
           <PagePortal pagePortalId={pagePortalId} />

--- a/packages/components/src/layouts/Page/type.ts
+++ b/packages/components/src/layouts/Page/type.ts
@@ -22,7 +22,9 @@ export type IBasicPageProps = PropsWithChildren<
     /* enable the insets that you use to determine the safe area for this view. the default value is true  */
     safeAreaEnabled?: boolean;
     /* @platform native */
-    /* lazy load. the default value is false  */
+    /* lazy load. the default value is false. 
+    Mainly used to reduce stuttering when heavy rendering Native pages.
+    If the page doesn't have much content on initial render, this doesn't need to be enabled. */
     lazyLoad?: boolean;
     /* scrollEnabled. When false, the view cannot be scrolled via interaction.  */
     scrollEnabled?: boolean;

--- a/packages/components/src/layouts/Page/type.ts
+++ b/packages/components/src/layouts/Page/type.ts
@@ -21,8 +21,9 @@ export type IBasicPageProps = PropsWithChildren<
     fullPage?: boolean;
     /* enable the insets that you use to determine the safe area for this view. the default value is true  */
     safeAreaEnabled?: boolean;
-    /* skip loading view. the default value is false  */
-    skipLoading?: boolean;
+    /* @platform native */
+    /* lazy load. the default value is false  */
+    lazyLoad?: boolean;
     /* scrollEnabled. When false, the view cannot be scrolled via interaction.  */
     scrollEnabled?: boolean;
     scrollProps?: Omit<IScrollViewProps, 'children'>;

--- a/packages/components/src/layouts/Page/type.ts
+++ b/packages/components/src/layouts/Page/type.ts
@@ -19,14 +19,23 @@ export interface IPageLifeCycle {
 export type IBasicPageProps = PropsWithChildren<
   {
     fullPage?: boolean;
-    /* enable the insets that you use to determine the safe area for this view. the default value is true  */
+    /** @platform cross-platform
+     * @description Enable the insets that you use to determine the safe area for this view. The default value is true
+     *  @default false
+     */
     safeAreaEnabled?: boolean;
-    /* @platform native */
-    /* lazy load. the default value is false. 
-    Mainly used to reduce stuttering when heavy rendering Native pages.
-    If the page doesn't have much content on initial render, this doesn't need to be enabled. */
+    /** @platform native
+     * @description Lazy load. The default value is false.
+     * Mainly used to reduce stuttering when heavy rendering Native pages.
+     * If the page doesn't have much content on initial render, this doesn't need to be enabled.
+     * @default false
+     */
     lazyLoad?: boolean;
-    /* scrollEnabled. When false, the view cannot be scrolled via interaction.  */
+    /** @platform cross-platform
+     * @description ScrollEnabled. When false, the view cannot be scrolled via interaction.
+     * Note: If there are other scroll containers within the page, it may cause scroll conflicts on Native platforms.
+     * @default false
+     */
     scrollEnabled?: boolean;
     scrollProps?: Omit<IScrollViewProps, 'children'>;
   } & IPageLifeCycle

--- a/packages/components/src/primitives/Image/ImageV2.tsx
+++ b/packages/components/src/primitives/Image/ImageV2.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { Image as ExpoImage, resolveSource } from 'expo-image';
@@ -109,25 +110,37 @@ export function ImageV2({
     return ExpoImage;
   }, [animated]);
 
-  let content = (
-    <ImageComponent
-      source={resolvedSource}
-      style={{
-        width: '100%',
-        height: '100%',
-      }}
-      onError={handleError}
-      onLoad={handleLoad}
-      onLoadEnd={handleLoadEnd}
-      onDisplay={onDisplay}
-      onLoadStart={onLoadStart}
-      {...(imageProps as any)}
-    />
-  );
-
-  if (fallback && (hasError || isEmptyResolvedSource(resolvedSource))) {
-    content = <Stack>{fallback}</Stack>;
-  }
+  const content = useMemo(() => {
+    if (fallback && (hasError || isEmptyResolvedSource(resolvedSource))) {
+      return fallback as ReactElement;
+    }
+    return (
+      <ImageComponent
+        source={resolvedSource}
+        style={{
+          width: '100%',
+          height: '100%',
+        }}
+        onError={handleError}
+        onLoad={handleLoad}
+        onLoadEnd={handleLoadEnd}
+        onDisplay={onDisplay}
+        onLoadStart={onLoadStart}
+        {...(imageProps as any)}
+      />
+    );
+  }, [
+    ImageComponent,
+    fallback,
+    handleError,
+    handleLoad,
+    handleLoadEnd,
+    hasError,
+    imageProps,
+    onDisplay,
+    onLoadStart,
+    resolvedSource,
+  ]);
 
   return (
     <YStack

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/index.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/index.tsx
@@ -18,7 +18,7 @@ export function AccountSelectorStack({
   hideNonBackedUpWallet?: boolean;
 }) {
   return (
-    <Page safeAreaEnabled={false}>
+    <Page safeAreaEnabled={false} lazyLoad>
       <Page.Header headerShown={false} />
       <Page.Body>
         <XStack flex={1}>

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/index.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/index.tsx
@@ -18,7 +18,7 @@ export function AccountSelectorStack({
   hideNonBackedUpWallet?: boolean;
 }) {
   return (
-    <Page safeAreaEnabled={false} lazyLoad>
+    <Page lazyLoad safeAreaEnabled={false}>
       <Page.Header headerShown={false} />
       <Page.Body>
         <XStack flex={1}>

--- a/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
+++ b/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
@@ -311,6 +311,7 @@ function TokenSelector() {
 
   return (
     <Page
+      lazyLoad
       safeAreaEnabled={false}
       onClose={() => setSearchKey('')}
       onUnmounted={() => setSearchKey('')}

--- a/packages/kit/src/views/ChainSelector/components/EditableChainSelector/index.tsx
+++ b/packages/kit/src/views/ChainSelector/components/EditableChainSelector/index.tsx
@@ -73,6 +73,7 @@ export const EditableChainSelector: FC<IEditableChainSelectorProps> = ({
   );
   return (
     <Page
+      lazyLoad
       safeAreaEnabled={false}
       onClose={() => {
         if (allNetworksChanged && networkUtils.isAllNetwork({ networkId })) {

--- a/packages/kit/src/views/ChainSelector/components/PureChainSelector/index.tsx
+++ b/packages/kit/src/views/ChainSelector/components/PureChainSelector/index.tsx
@@ -31,7 +31,7 @@ export const PureChainSelector: FC<IPureChainSelectorProps> = ({
   const intl = useIntl();
 
   return (
-    <Page safeAreaEnabled={false}>
+    <Page lazyLoad safeAreaEnabled={false}>
       <Page.Header
         title={
           title || intl.formatMessage({ id: ETranslations.global_networks })

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/NavigatorRoute/Modal/DemoCreateModal.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/NavigatorRoute/Modal/DemoCreateModal.tsx
@@ -41,7 +41,6 @@ function DemoCreateViewModal({
   return (
     <Layout
       description="这是一个普通的 Modal 测试"
-      skipLoading
       suggestions={[
         'Modal 可以通过点击空白处关闭或返回上一级',
         'Modal 可以通过按 ESC 键关闭或返回上一级',
@@ -110,7 +109,6 @@ function DemoCreateSearchModal({
 
   return (
     <Layout
-      skipLoading
       contentInsetAdjustmentBehavior="automatic"
       description="这是一个带搜索框的 Modal"
       suggestions={['使用方式与 @react-navigation/native-stack 相同']}
@@ -182,7 +180,6 @@ function DemoCreateOptionsModal({
 
   return (
     <Layout
-      skipLoading
       contentInsetAdjustmentBehavior="automatic"
       description="这是一个带有搜索框和 RightButton 的 Demo"
       suggestions={['使用方式与 @react-navigation/native-stack 相同']}

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/NavigatorRoute/Tab/View/DemoRootHomeOptions.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/NavigatorRoute/Tab/View/DemoRootHomeOptions.tsx
@@ -46,7 +46,7 @@ const DemoRootHomeOptions = () => {
 
   return (
     <Layout
-      skipLoading={platformEnv.isNativeIOS}
+      lazyLoad={!platformEnv.isNativeIOS}
       contentInsetAdjustmentBehavior="automatic"
       description="这是一个路由 Header 演示自定义 headerRight 的用法"
       suggestions={[

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/NavigatorRoute/Tab/View/DemoRootHomeSearch.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/NavigatorRoute/Tab/View/DemoRootHomeSearch.tsx
@@ -45,7 +45,6 @@ const DemoRootHomeSearch = () => {
 
   return (
     <Layout
-      skipLoading={platformEnv.isNativeIOS}
       description="这是一个带搜索的路由 Header"
       suggestions={['使用方式与 @react-navigation/native-stack 相同']}
       boundaryConditions={['无']}
@@ -54,7 +53,7 @@ const DemoRootHomeSearch = () => {
           title: '使用说明',
           element: (
             <SizableText size="$bodyLg">{`这是一个简单的使用场景
-            1. 需要给 Screen 或者 Layout 设置一个 skipLoading={platformEnv.isNativeIOS} 以确保 iOS controller.headerSearch 动画正常
+            1. 需要给 Screen 或者 Layout 设置一个 lazLoad={!platformEnv.isNativeIOS} 以确保 iOS controller.headerSearch 动画正常
 
             2. useEffect(() => {
                 navigation.setOptions({

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/utils/Layout.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/utils/Layout.tsx
@@ -60,7 +60,7 @@ export function Layout({
   elements = [],
   scrollEnabled = true,
   contentInsetAdjustmentBehavior = 'never',
-  skipLoading = false,
+  lazyLoad = false,
   wideScreen: initialWideScreen = false,
   children,
   filePath,
@@ -76,7 +76,7 @@ export function Layout({
     | 'automatic'
     | 'scrollableAxes'
     | undefined;
-  skipLoading?: boolean;
+  lazyLoad?: boolean;
   wideScreen?: boolean;
   filePath?: string;
   elements?: {
@@ -97,7 +97,7 @@ export function Layout({
   };
 
   return (
-    <Page skipLoading={skipLoading}>
+    <Page lazyLoad={lazyLoad}>
       <ScrollView
         maxWidth="100%"
         scrollEnabled={scrollEnabled}

--- a/packages/kit/src/views/Discovery/pages/BookmarkListModal/index.tsx
+++ b/packages/kit/src/views/Discovery/pages/BookmarkListModal/index.tsx
@@ -210,7 +210,7 @@ function BookmarkListModal() {
   );
 
   return (
-    <Page>
+    <Page lazyLoad>
       <Page.Header
         title={intl.formatMessage({
           id: ETranslations.explore_bookmarks,

--- a/packages/kit/src/views/Discovery/pages/HistoryListModal/index.tsx
+++ b/packages/kit/src/views/Discovery/pages/HistoryListModal/index.tsx
@@ -129,7 +129,7 @@ function HistoryListModal() {
   );
 
   return (
-    <Page>
+    <Page lazyLoad>
       <Page.Header
         title={intl.formatMessage({
           id: ETranslations.browser_recently_closed,

--- a/packages/kit/src/views/Discovery/pages/MobileTabListModal/index.tsx
+++ b/packages/kit/src/views/Discovery/pages/MobileTabListModal/index.tsx
@@ -418,7 +418,7 @@ function MobileTabListModal() {
   }, [pinnedData, renderPinnedItem, pinInitialScrollIndex]);
 
   return (
-    <Page>
+    <Page lazyLoad>
       <Page.Header
         title={intl.formatMessage(
           { id: ETranslations.explore_tabs_count },

--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -983,7 +983,7 @@ function BasicEarnHome() {
               } as any
             }
             renderHeader={() => (
-              <YStack flex={1} gap="$4" pt="$5">
+              <YStack flex={1} gap="$4" pt="$5" bg="$bgApp">
                 {/* overview and banner */}
                 <YStack gap="$8">
                   <Overview

--- a/packages/kit/src/views/Earn/components/AvailableAssetsTabViewList.tsx
+++ b/packages/kit/src/views/Earn/components/AvailableAssetsTabViewList.tsx
@@ -338,11 +338,9 @@ export function AvailableAssetsTabViewListMobile({
   onTokenPress,
   assetType,
   faqList,
-  onRefresh,
 }: IAvailableAssetsTabViewListProps & {
   assetType: EAvailableAssetsTypeEnum;
   faqList?: Array<{ question: string; answer: string }>;
-  onRefresh?: () => void;
 }) {
   const {
     activeAccount: { account, indexedAccount },
@@ -505,7 +503,7 @@ export function AvailableAssetsTabViewListMobile({
           )}
         </YStack>
         {faqList?.length ? (
-          <YStack mt="$4" mx="$5">
+          <YStack py="$4" px="$5">
             <FAQPanel faqList={faqList} isLoading={false} />
           </YStack>
         ) : null}

--- a/packages/kit/src/views/Home/components/NFTListView/index.tsx
+++ b/packages/kit/src/views/Home/components/NFTListView/index.tsx
@@ -91,8 +91,6 @@ function NFTListView(props: IProps) {
 
   const [searchKey] = useSearchKeyAtom();
 
-  const filteredNfts = getFilteredNftsBySearchKey({ nfts: data, searchKey });
-
   const navigation = useAppNavigation();
   const {
     activeAccount: { account, network, wallet },
@@ -116,17 +114,31 @@ function NFTListView(props: IProps) {
   );
 
   const { flexBasis, numColumns } = useMumColumns();
+  const filteredNfts: (IAccountNFT | null)[] = useMemo(() => {
+    const list: (IAccountNFT | null)[] = getFilteredNftsBySearchKey({
+      nfts: data,
+      searchKey,
+    });
+    const placeholderCount = numColumns - (list.length % numColumns);
+    if (placeholderCount !== 0) {
+      list.push(...Array(placeholderCount).fill(null));
+    }
+    return list;
+  }, [data, searchKey, numColumns]);
 
   const handleRenderItem = useCallback(
-    ({ item }: ListRenderItemInfo<IAccountNFT>) => (
-      <NFTListItem
-        nft={item}
-        flexBasis={flexBasis}
-        key={`${item.collectionAddress}-${item.itemId}`}
-        onPress={handleOnPressNFT}
-        isAllNetworks={isAllNetworks}
-      />
-    ),
+    ({ item }: ListRenderItemInfo<IAccountNFT | null>) =>
+      item ? (
+        <NFTListItem
+          nft={item}
+          flexBasis={flexBasis}
+          key={`${item.collectionAddress}-${item.itemId}`}
+          onPress={handleOnPressNFT}
+          isAllNetworks={isAllNetworks}
+        />
+      ) : (
+        <Stack flex={1} />
+      ),
     [flexBasis, handleOnPressNFT, isAllNetworks],
   );
   const contentContainerStyle = useMemo(

--- a/packages/kit/src/views/Home/components/NFTListView/index.tsx
+++ b/packages/kit/src/views/Home/components/NFTListView/index.tsx
@@ -120,8 +120,11 @@ function NFTListView(props: IProps) {
       searchKey,
     });
     const placeholderCount = numColumns - (list.length % numColumns);
-    if (placeholderCount !== 0) {
-      list.push(...Array(placeholderCount).fill(null));
+    if (list?.length && placeholderCount) {
+      return [
+        ...list,
+        ...Array(placeholderCount).fill(null),
+      ] as (IAccountNFT | null)[];
     }
     return list;
   }, [data, searchKey, numColumns]);

--- a/packages/kit/src/views/Home/components/WalletBanner/WalletBanner.tsx
+++ b/packages/kit/src/views/Home/components/WalletBanner/WalletBanner.tsx
@@ -187,7 +187,7 @@ function WalletBanner() {
     <YStack py="$2.5" bg="$bgApp">
       <Carousel
         loop={false}
-        marginRatio={gtMd ? 0.28 : 0.08}
+        marginRatio={gtMd ? 0.28 : 0}
         data={filteredBanners}
         autoPlayInterval={3800}
         containerStyle={{

--- a/packages/kit/src/views/Market/MarketHomeV1/MarketHome.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV1/MarketHome.tsx
@@ -14,6 +14,7 @@ import {
   EAppEventBusNames,
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
@@ -39,7 +40,7 @@ function MarketHome() {
       categories?.map((category, index) => ({
         title: category.name,
         // eslint-disable-next-line react/no-unstable-nested-components
-        page: () =>
+        page:
           index === 0 ? (
             <MarketWatchList category={category} />
           ) : (
@@ -125,7 +126,11 @@ function MarketHome() {
       >
         {tabConfig.map((tab) => (
           <Tabs.Tab key={tab.title} name={tab.title}>
-            <Tabs.ScrollView>{tab.page()}</Tabs.ScrollView>
+            {platformEnv.isNative ? (
+              tab.page
+            ) : (
+              <Tabs.ScrollView>{tab.page}</Tabs.ScrollView>
+            )}
           </Tabs.Tab>
         ))}
       </Tabs.Container>

--- a/packages/kit/src/views/Market/components/MarketHomeList.tsx
+++ b/packages/kit/src/views/Market/components/MarketHomeList.tsx
@@ -1084,7 +1084,7 @@ function BasicMarketHomeList({
           keyExtractor={(item) => item.coingeckoId}
           rowProps={rowProps}
           showHeader={gtMd}
-          scrollEnabled={false}
+          scrollEnabled={platformEnv.isNative}
           columns={columns}
           onDragEnd={handleDragEnd}
           dataSource={sortedListData as unknown as IMarketToken[]}

--- a/packages/kit/src/views/Setting/pages/Notifications/NotificationsSettings.tsx
+++ b/packages/kit/src/views/Setting/pages/Notifications/NotificationsSettings.tsx
@@ -115,7 +115,7 @@ export default function NotificationsSettings() {
   }, [reloadSettings]);
 
   return (
-    <Page scrollEnabled skipLoading>
+    <Page scrollEnabled>
       <Page.Header
         title={intl.formatMessage({ id: ETranslations.global_notifications })}
       />

--- a/packages/kit/src/views/Setting/pages/SignatureRecord/ConnectedSites.tsx
+++ b/packages/kit/src/views/Setting/pages/SignatureRecord/ConnectedSites.tsx
@@ -110,6 +110,7 @@ export const ConnectedSites = () => {
 
   return (
     <Tabs.SectionList
+      stickySectionHeadersEnabled={false}
       sections={sections}
       // estimatedItemSize={154}
       ItemSeparatorComponent={null}

--- a/packages/kit/src/views/Setting/pages/SignatureRecord/SignText.tsx
+++ b/packages/kit/src/views/Setting/pages/SignatureRecord/SignText.tsx
@@ -138,6 +138,7 @@ export const SignText = () => {
 
   return (
     <Tabs.SectionList
+      stickySectionHeadersEnabled={false}
       sections={sections}
       keyExtractor={keyExtractor}
       // estimatedItemSize={191}

--- a/packages/kit/src/views/Setting/pages/SignatureRecord/Transactions.tsx
+++ b/packages/kit/src/views/Setting/pages/SignatureRecord/Transactions.tsx
@@ -361,6 +361,7 @@ export const Transactions = () => {
 
   return (
     <Tabs.SectionList
+      stickySectionHeadersEnabled={false}
       contentContainerStyle={{ paddingBottom: 40 }}
       sections={sections}
       // estimatedItemSize={158}

--- a/packages/kit/src/views/Swap/pages/modal/SwapMainLandModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapMainLandModal.tsx
@@ -65,7 +65,7 @@ const SwapMainLandModalPage = () => {
   }, [swapSource]);
 
   return (
-    <Page skipLoading={platformEnv.isNativeIOS}>
+    <Page lazyLoad={!platformEnv.isNativeIOS}>
       <Page.Header
         title={intl.formatMessage({ id: ETranslations.global_trade })}
       />

--- a/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
@@ -487,7 +487,7 @@ const SwapTokenSelectPage = () => {
     return popularTokens;
   }, [currentSelectNetwork?.networkId, swapTypeSwitch]);
   return (
-    <Page skipLoading={platformEnv.isNativeIOS} safeAreaEnabled={false}>
+    <Page lazyLoad={!platformEnv.isNativeIOS} safeAreaEnabled={false}>
       <Page.Header
         title={intl.formatMessage({ id: ETranslations.token_selector_title })}
         headerSearchBarOptions={{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `lazyLoad` prop to various Page components, enabling improved loading behavior on native platforms.
  * Section list components now allow section headers to scroll with content, enhancing navigation experience.

* **Bug Fixes**
  * NFT grid layouts now maintain consistent row lengths by padding incomplete rows.
  * Table scrolling and tab content rendering are now platform-aware for a smoother user experience.

* **Refactor**
  * Unified and renamed the loading control prop from `skipLoading` to `lazyLoad` across multiple components.
  * Centralized and memoized page width calculations in Carousel for consistency.
  * Improved documentation clarity for Page-related properties.

* **Style**
  * Updated header background color in Earn views for visual consistency.
  * Adjusted FAQ panel padding for better spacing.

* **Documentation**
  * Enhanced in-code documentation for Page component properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->