### PR TITLE
fix: fix the Earn reward desc

### DIFF
--- a/packages/kit/src/views/Staking/components/ProtocolDetails/EarnActionIcon.tsx
+++ b/packages/kit/src/views/Staking/components/ProtocolDetails/EarnActionIcon.tsx
@@ -31,6 +31,7 @@ import type {
   IEarnText,
   IEarnToken,
   IEarnTokenInfo,
+  IEarnTooltip,
   IProtocolInfo,
 } from '@onekeyhq/shared/types/staking';
 
@@ -44,14 +45,20 @@ function useHandleClaimAction({
   protocolInfo,
   tokenInfo,
   token,
+  rewardsTooltip,
 }: {
   protocolInfo?: IProtocolInfo;
   tokenInfo?: IEarnTokenInfo;
   token?: IEarnToken;
+  rewardsTooltip?: IEarnTooltip;
 }) {
+  const earnClaimRewardsMorphoDesc =
+    rewardsTooltip?.type === 'text' ? rewardsTooltip?.data?.text : undefined;
+
   const handleClaim = useHandleClaim({
     accountId: protocolInfo?.earnAccount?.accountId || '',
     networkId: tokenInfo?.networkId || '',
+    earnClaimRewardsMorphoDesc,
   });
 
   return useCallback(
@@ -278,17 +285,20 @@ function BasicClaimActionIcon({
   protocolInfo,
   tokenInfo,
   token,
+  rewardsTooltip,
 }: {
   actionIcon: IEarnClaimActionIcon;
   protocolInfo?: IProtocolInfo;
   tokenInfo?: IEarnTokenInfo;
   token?: IEarnToken;
+  rewardsTooltip?: IEarnTooltip;
 }) {
   const [loading, setLoading] = useState(false);
   const handleClaimAction = useHandleClaimAction({
     protocolInfo,
     tokenInfo,
     token,
+    rewardsTooltip,
   });
 
   return (
@@ -416,6 +426,7 @@ function BasicEarnActionIcon({
   protocolInfo,
   tokenInfo,
   token,
+  rewardsTooltip,
   onHistory,
 }: {
   title?: string;
@@ -423,6 +434,7 @@ function BasicEarnActionIcon({
   protocolInfo?: IProtocolInfo;
   tokenInfo?: IEarnTokenInfo;
   token?: IEarnToken;
+  rewardsTooltip?: IEarnTooltip;
   onHistory?: (params?: { filterType?: string }) => void;
 }) {
   if (!actionIcon) {
@@ -450,6 +462,7 @@ function BasicEarnActionIcon({
           tokenInfo={tokenInfo}
           token={token}
           actionIcon={actionIcon}
+          rewardsTooltip={rewardsTooltip}
         />
       );
     case 'claimWithKyc':

--- a/packages/kit/src/views/Staking/pages/ProtocolDetails/useHandleClaim.ts
+++ b/packages/kit/src/views/Staking/pages/ProtocolDetails/useHandleClaim.ts
@@ -21,10 +21,12 @@ export const useHandleClaim = ({
   accountId,
   networkId,
   updateFrequency,
+  earnClaimRewardsMorphoDesc,
 }: {
   accountId?: string;
   networkId: string;
   updateFrequency?: string;
+  earnClaimRewardsMorphoDesc?: string;
 }) => {
   const intl = useIntl();
   const appNavigation = useAppNavigation();
@@ -85,14 +87,16 @@ export const useHandleClaim = ({
           title: intl.formatMessage({
             id: ETranslations.earn_claim_rewards,
           }),
-          description: intl.formatMessage(
-            {
-              id: ETranslations.earn_claim_rewards_morpho_desc,
-            },
-            {
-              time: updateFrequency || '',
-            },
-          ),
+          description:
+            earnClaimRewardsMorphoDesc ||
+            intl.formatMessage(
+              {
+                id: ETranslations.earn_claim_rewards_morpho_desc,
+              },
+              {
+                time: updateFrequency || '',
+              },
+            ),
           onConfirm: async () => {
             await handleUniversalClaim({
               amount: claimAmount,
@@ -176,6 +180,7 @@ export const useHandleClaim = ({
       intl,
       updateFrequency,
       appNavigation,
+      earnClaimRewardsMorphoDesc,
     ],
   );
 };

--- a/packages/kit/src/views/Staking/pages/ProtocolDetailsV2/index.tsx
+++ b/packages/kit/src/views/Staking/pages/ProtocolDetailsV2/index.tsx
@@ -225,6 +225,7 @@ function ProtocolRewards({
                   protocolInfo={protocolInfo}
                   tokenInfo={tokenInfo}
                   token={token.token.info}
+                  rewardsTooltip={rewards?.tooltip}
                 />
               </XStack>
               <XStack>


### PR DESCRIPTION
[updateFrequency](https://github.com/OneKeyHQ/app-monorepo/blob/91fb9b80abfea499924bb23a117f629577cb2995/packages/kit/src/views/Staking/pages/ProtocolDetails/useHandleClaim.ts#L93) has been deprecated in [getProtocolDetailsV2](https://github.com/OneKeyHQ/app-monorepo/blob/91fb9b80abfea499924bb23a117f629577cb2995/packages/kit-bg/src/services/ServiceStaking.ts#L602), so we use the text of the tooltips instead.

<img width="1669" height="625" alt="SCR-20250730-pdko" src="https://github.com/user-attachments/assets/00edab17-325c-4b9f-8e7b-65a5a88ff2f7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying optional tooltip text on staking earn action icons and claim dialogs, providing users with additional contextual information about rewards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->