### PR TITLE
fix: swap native 100% stage brn popover tips

### DIFF
--- a/packages/kit/src/views/Swap/components/SwapPercentageStageBadge.tsx
+++ b/packages/kit/src/views/Swap/components/SwapPercentageStageBadge.tsx
@@ -1,41 +1,56 @@
 import type { IStackProps } from '@onekeyhq/components';
-import { Badge } from '@onekeyhq/components';
+import { Badge, Popover } from '@onekeyhq/components';
 
 const SwapPercentageStageBadge = ({
   stage,
   onSelectStage,
   badgeSize,
   key,
+  popoverContent,
   ...props
 }: {
   stage: number;
   badgeSize?: 'sm' | 'lg';
   onSelectStage?: (stage: number) => void;
+  popoverContent?: React.ReactNode;
   key: string;
-} & IStackProps) => (
-  <Badge
-    key={key}
-    role="button"
-    badgeSize={badgeSize ?? 'sm'}
-    onPress={() => {
-      onSelectStage?.(stage);
-    }}
-    px="$1.5"
-    bg="$bgSubdued"
-    borderRadius="$2"
-    userSelect="none"
-    hoverStyle={{
-      bg: '$bgStrongHover',
-    }}
-    pressStyle={{
-      bg: '$bgStrongActive',
-    }}
-    {...props}
-  >
-    <Badge.Text size="$bodySmMedium" color="$textSubdued">
-      {stage}%
-    </Badge.Text>
-  </Badge>
-);
+} & IStackProps) => {
+  const component = (
+    <Badge
+      key={key}
+      role="button"
+      badgeSize={badgeSize ?? 'sm'}
+      onPress={() => {
+        onSelectStage?.(stage);
+      }}
+      px="$1.5"
+      bg="$bgSubdued"
+      borderRadius="$2"
+      userSelect="none"
+      hoverStyle={{
+        bg: '$bgStrongHover',
+      }}
+      pressStyle={{
+        bg: '$bgStrongActive',
+      }}
+      {...props}
+    >
+      <Badge.Text size="$bodySmMedium" color="$textSubdued">
+        {stage}%
+      </Badge.Text>
+    </Badge>
+  );
+  if (popoverContent) {
+    return (
+      <Popover
+        renderTrigger={component}
+        renderContent={() => popoverContent}
+        title=""
+        showHeader={false}
+      />
+    );
+  }
+  return component;
+};
 
 export default SwapPercentageStageBadge;

--- a/packages/kit/src/views/Swap/pages/components/SwapInputActions.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapInputActions.tsx
@@ -22,11 +22,13 @@ const SwapInputActions = ({
   showPercentageInput,
   showActionBuy,
   onSelectStage,
+  stagePopoverContent,
   fromToken,
   accountInfo,
 }: {
   showPercentageInput: boolean;
   showActionBuy: boolean;
+  stagePopoverContent?: React.ReactNode;
   onSelectStage?: (stage: number) => void;
   fromToken?: ISwapToken;
   accountInfo?: IAccountSelectorActiveAccountInfo;
@@ -103,6 +105,9 @@ const SwapInputActions = ({
                   key={`swap-percentage-input-stage-${stage}`}
                   stage={stage}
                   onSelectStage={onSelectStage}
+                  popoverContent={
+                    stage === 100 ? stagePopoverContent : undefined
+                  }
                 />
               ))}
             </>

--- a/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
@@ -265,8 +265,8 @@ const SwapInputContainer = ({
   const balancePopoverContent = useMemo(() => {
     if (fromToken?.isNative) {
       return (
-        <XStack alignItems="center" p="$2">
-          <SizableText>
+        <XStack alignItems="center" p="$4">
+          <SizableText size="$bodyMd">
             {intl.formatMessage({
               id: ETranslations.swap_native_token_max_tip,
             })}
@@ -284,6 +284,7 @@ const SwapInputContainer = ({
           onClickNetwork={onSelectToken}
         />
         <SwapInputActions
+          stagePopoverContent={balancePopoverContent}
           fromToken={fromToken}
           accountInfo={accountInfo}
           showPercentageInput={showPercentageInputDebounce}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying additional information in a popover when the swap stage reaches 100%.
* **Style**
  * Increased padding and adjusted text size for the native token max tip message to improve readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->