### PR TITLE
fix: fix version text style on android

### DIFF
--- a/packages/kit/src/views/Setting/pages/Tab/CustomElement.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/CustomElement.tsx
@@ -579,7 +579,13 @@ export function SocialButtonGroup() {
         userSelect="none"
         testID="setting-version"
       >
-        <SizableText color={textColor} size={textSize} onPress={handlePress}>
+        <SizableText
+          color={textColor}
+          size={textSize}
+          textAlign={platformEnv.isNativeAndroid ? 'center' : undefined}
+          numberOfLines={platformEnv.isNativeAndroid ? 1 : undefined}
+          onPress={handlePress}
+        >
           {upperFirst(versionString)}
         </SizableText>
         {!isTabNavigator &&


### PR DESCRIPTION
before:
<img width="290" height="206" alt="image" src="https://github.com/user-attachments/assets/137f8f82-dd8e-4c7e-b8a3-b8a7080992eb" />

after:
<img width="253" height="101" alt="image" src="https://github.com/user-attachments/assets/750f3c53-5b4a-4ece-ad74-4adc4690d71d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text alignment and line truncation for the version string on Android devices, ensuring it is centered and displayed on a single line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->