### PR TITLE
fix: prevent fetch native token info in all networks OK-41147

### DIFF
--- a/packages/kit/src/views/Home/components/WalletActions/index.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/index.tsx
@@ -76,12 +76,11 @@ function WalletActionSend() {
       isSoftwareWalletOnlyUser,
     });
 
-    const nativeToken = await backgroundApiProxy.serviceToken.getNativeToken({
-      networkId: network.id,
-      accountId: account?.id ?? '',
-    });
-
     if (vaultSettings?.isSingleToken) {
+      const nativeToken = await backgroundApiProxy.serviceToken.getNativeToken({
+        networkId: network.id,
+        accountId: account?.id ?? '',
+      });
       if (
         nativeToken &&
         deriveInfoItems.length > 1 &&


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved efficiency by fetching the native token only when relevant settings are enabled, reducing unnecessary network calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->