### PR TITLE
fix: prevent pushModal from using unreleased Navigation instances during iOS modal animation by overlay on bluring

### DIFF
--- a/packages/kit/src/hooks/useAppNavigation.ts
+++ b/packages/kit/src/hooks/useAppNavigation.ts
@@ -144,9 +144,6 @@ function useAppNavigation<
         return;
       }
 
-      // TODO:
-      // prevent pushModal from using unreleased Navigation instances during iOS modal animation by temporary exclusion,
-      //  with plan to migrate to rootNavigationRef
       // eslint-disable-next-line no-extra-boolean-cast
       if (!!navigationInstance.push) {
         lastPushAbleNavigation = navigationInstance;

--- a/packages/kit/src/hooks/useAppNavigation.ts
+++ b/packages/kit/src/hooks/useAppNavigation.ts
@@ -148,7 +148,7 @@ function useAppNavigation<
       // prevent pushModal from using unreleased Navigation instances during iOS modal animation by temporary exclusion,
       //  with plan to migrate to rootNavigationRef
       // eslint-disable-next-line no-extra-boolean-cast
-      if (!platformEnv.isNativeIOS && !!navigationInstance.push) {
+      if (!!navigationInstance.push) {
         lastPushAbleNavigation = navigationInstance;
         navigationInstance.push(modalType, {
           screen: route,

--- a/packages/kit/src/routes/Tab/Navigator.tsx
+++ b/packages/kit/src/routes/Tab/Navigator.tsx
@@ -14,12 +14,21 @@ import { useRouteIsFocused } from '../../hooks/useRouteIsFocused';
 
 import { tabExtraConfig, useTabRouterConfig } from './router';
 
+// prevent pushModal from using unreleased Navigation instances during iOS modal animation by temporary exclusion,
+const useIsIOSTabNavigator =
+  platformEnv.isNativeIOS && !platformEnv.isNativeIOSPad
+    ? () => {
+        const isFocused = useRouteIsFocused();
+        return isFocused;
+      }
+    : () => false;
+
 export function TabNavigator() {
   const { freezeOnBlur } = useContext(TabFreezeOnBlurContext);
   const routerConfigParams = useMemo(() => ({ freezeOnBlur }), [freezeOnBlur]);
   const config = useTabRouterConfig(routerConfigParams);
   const isShowWebTabBar = platformEnv.isDesktop || platformEnv.isNativeIOS;
-  const isFocused = useRouteIsFocused();
+  const isFocused = useIsIOSTabNavigator();
   return (
     <>
       <TabStackNavigator<ETabRoutes>
@@ -29,8 +38,7 @@ export function TabNavigator() {
       <Portal.Container
         name={EPortalContainerConstantName.IN_PAGE_TAB_CONTAINER}
       />
-      {/*  prevent pushModal from using unreleased Navigation instances during iOS modal animation by temporary exclusion, */}
-      {platformEnv.isNativeIOS && !platformEnv.isNativeIOSPad && !isFocused ? (
+      {isFocused ? (
         <Stack position="absolute" top={0} left={0} right={0} bottom={0} />
       ) : null}
     </>

--- a/packages/kit/src/routes/Tab/Navigator.tsx
+++ b/packages/kit/src/routes/Tab/Navigator.tsx
@@ -1,5 +1,7 @@
 import { useContext, useMemo } from 'react';
 
+import { noop } from 'lodash';
+
 import {
   EPortalContainerConstantName,
   Portal,
@@ -39,7 +41,14 @@ export function TabNavigator() {
         name={EPortalContainerConstantName.IN_PAGE_TAB_CONTAINER}
       />
       {isFocused ? (
-        <Stack position="absolute" top={0} left={0} right={0} bottom={0} />
+        <Stack
+          position="absolute"
+          top={0}
+          left={0}
+          right={0}
+          bottom={0}
+          onPress={noop}
+        />
       ) : null}
     </>
   );

--- a/packages/kit/src/routes/Tab/Navigator.tsx
+++ b/packages/kit/src/routes/Tab/Navigator.tsx
@@ -15,7 +15,7 @@ import { useRouteIsFocused } from '../../hooks/useRouteIsFocused';
 import { tabExtraConfig, useTabRouterConfig } from './router';
 
 // prevent pushModal from using unreleased Navigation instances during iOS modal animation by temporary exclusion,
-const useIsIOSTabNavigator =
+const useIsIOSTabNavigatorFocused =
   platformEnv.isNativeIOS && !platformEnv.isNativeIOSPad
     ? () => {
         const isFocused = useRouteIsFocused();
@@ -28,7 +28,7 @@ export function TabNavigator() {
   const routerConfigParams = useMemo(() => ({ freezeOnBlur }), [freezeOnBlur]);
   const config = useTabRouterConfig(routerConfigParams);
   const isShowWebTabBar = platformEnv.isDesktop || platformEnv.isNativeIOS;
-  const isFocused = useIsIOSTabNavigator();
+  const isFocused = useIsIOSTabNavigatorFocused();
   return (
     <>
       <TabStackNavigator<ETabRoutes>

--- a/packages/kit/src/routes/Tab/Navigator.tsx
+++ b/packages/kit/src/routes/Tab/Navigator.tsx
@@ -40,7 +40,7 @@ export function TabNavigator() {
       <Portal.Container
         name={EPortalContainerConstantName.IN_PAGE_TAB_CONTAINER}
       />
-      {isFocused ? (
+      {!isFocused ? (
         <Stack
           position="absolute"
           top={0}

--- a/packages/kit/src/routes/Tab/Navigator.tsx
+++ b/packages/kit/src/routes/Tab/Navigator.tsx
@@ -3,11 +3,14 @@ import { useContext, useMemo } from 'react';
 import {
   EPortalContainerConstantName,
   Portal,
+  Stack,
   TabStackNavigator,
 } from '@onekeyhq/components';
 import { TabFreezeOnBlurContext } from '@onekeyhq/kit/src/provider/Container/TabFreezeOnBlurContainer';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { ETabRoutes } from '@onekeyhq/shared/src/routes';
+
+import { useRouteIsFocused } from '../../hooks/useRouteIsFocused';
 
 import { tabExtraConfig, useTabRouterConfig } from './router';
 
@@ -16,6 +19,7 @@ export function TabNavigator() {
   const routerConfigParams = useMemo(() => ({ freezeOnBlur }), [freezeOnBlur]);
   const config = useTabRouterConfig(routerConfigParams);
   const isShowWebTabBar = platformEnv.isDesktop || platformEnv.isNativeIOS;
+  const isFocused = useRouteIsFocused();
   return (
     <>
       <TabStackNavigator<ETabRoutes>
@@ -25,6 +29,10 @@ export function TabNavigator() {
       <Portal.Container
         name={EPortalContainerConstantName.IN_PAGE_TAB_CONTAINER}
       />
+      {/*  prevent pushModal from using unreleased Navigation instances during iOS modal animation by temporary exclusion, */}
+      {platformEnv.isNativeIOS && !platformEnv.isNativeIOSPad && !isFocused ? (
+        <Stack position="absolute" top={0} left={0} right={0} bottom={0} />
+      ) : null}
     </>
   );
 }

--- a/packages/kit/src/routes/Tab/Navigator.tsx
+++ b/packages/kit/src/routes/Tab/Navigator.tsx
@@ -23,7 +23,7 @@ const useIsIOSTabNavigatorFocused =
         const isFocused = useRouteIsFocused();
         return isFocused;
       }
-    : () => false;
+    : () => true;
 
 export function TabNavigator() {
   const { freezeOnBlur } = useContext(TabFreezeOnBlurContext);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus detection for tab navigation, especially on non-iOS and iPad devices.
  * Adjusted screen rendering logic to enhance navigation behavior when a tab is not focused.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->