### PR TITLE
fix: add skeleton loading state for batch create account table

### DIFF
--- a/packages/components/src/composite/Table/index.tsx
+++ b/packages/components/src/composite/Table/index.tsx
@@ -283,6 +283,8 @@ export interface ITableProps<T> {
   scrollEnabled?: boolean;
   showHeader?: boolean;
   showBackToTopButton?: boolean;
+  showSkeleton?: boolean;
+  skeletonCount?: number;
   dataSource: T[];
   columns: ITableColumn<T>[];
   contentContainerStyle?: IListViewProps<T>['contentContainerStyle'];
@@ -455,7 +457,7 @@ function TableHeaderRow<T>({
 }
 
 function BasicTable<T>({
-  dataSource,
+  dataSource: dataSourceOriginal,
   columns,
   extraData,
   TableHeaderComponent,
@@ -480,6 +482,8 @@ function BasicTable<T>({
   onEndReached,
   onEndReachedThreshold,
   scrollEnabled = true,
+  showSkeleton = false,
+  skeletonCount = 3,
 }: ITableProps<T>) {
   const { gtMd } = useMedia();
   const [isShowBackToTopButton, setIsShowBackToTopButton] = useState(false);
@@ -487,6 +491,13 @@ function BasicTable<T>({
   const isShowBackToTopButtonRef = useRef(isShowBackToTopButton);
   isShowBackToTopButtonRef.current = isShowBackToTopButton;
   const scrollAtRef = useRef(0);
+
+  const dataSource = useMemo(() => {
+    if (showSkeleton) {
+      return new Array(skeletonCount).fill({} as T) as T[];
+    }
+    return dataSourceOriginal;
+  }, [dataSourceOriginal, showSkeleton, skeletonCount]);
 
   const handleScrollOffsetChange = useCallback((offset: number) => {
     const isShow = offset > 0;
@@ -512,16 +523,17 @@ function BasicTable<T>({
   const handleRenderItem = useCallback(
     ({ item, index }: ListRenderItemInfo<T>) => (
       <TableRow
-        pressStyle
+        pressStyle={!showSkeleton}
+        showSkeleton={showSkeleton}
         scrollAtRef={scrollAtRef}
         item={item}
         index={index}
         columns={columns}
-        onRow={onRow}
+        onRow={showSkeleton ? undefined : onRow}
         rowProps={rowProps}
       />
     ),
-    [columns, onRow, rowProps],
+    [columns, onRow, rowProps, showSkeleton],
   );
 
   const enableBackToTopButton = showBackToTopButton && isShowBackToTopButton;
@@ -564,20 +576,21 @@ function BasicTable<T>({
   const renderSortableItem = useCallback(
     ({ item, drag, dragProps, index, isActive }: IRenderItemParams<T>) => (
       <TableRow
-        pressStyle
+        pressStyle={!showSkeleton}
         isActive={isActive}
         draggable={draggable}
         dataSet={dragProps}
+        showSkeleton={showSkeleton}
         drag={drag}
         scrollAtRef={scrollAtRef}
         item={item}
         index={index}
         columns={columns}
-        onRow={onRow}
+        onRow={showSkeleton ? undefined : onRow}
         rowProps={rowProps}
       />
     ),
-    [columns, draggable, onRow, rowProps],
+    [columns, draggable, onRow, rowProps, showSkeleton],
   );
   const list = useMemo(
     () =>

--- a/packages/kit/src/views/AccountManagerStacks/pages/BatchCreateAccount/BatchCreateAccountPreview.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/BatchCreateAccount/BatchCreateAccountPreview.tsx
@@ -11,6 +11,7 @@ import type {
   ISizableTextProps,
 } from '@onekeyhq/components';
 import {
+  Button,
   ButtonGroup,
   Checkbox,
   Divider,
@@ -21,6 +22,7 @@ import {
   Popover,
   Select,
   SizableText,
+  Skeleton,
   Spinner,
   Stack,
   Table,
@@ -243,6 +245,7 @@ function BatchCreateAccountPreviewPage({
     result: accounts = [],
     isLoading,
     setResult,
+    run,
   } = usePromiseResult(
     async () => {
       try {
@@ -605,6 +608,9 @@ function BatchCreateAccountPreviewPage({
             />
           );
         },
+        renderSkeleton: () => (
+          <Skeleton width={22} height={22} borderRadius="$full" />
+        ),
       },
       {
         title: intl.formatMessage({
@@ -631,6 +637,12 @@ function BatchCreateAccountPreviewPage({
               {account.path}
               {buildRelPathSuffix(account)}
             </SizableText>
+          </YStack>
+        ),
+        renderSkeleton: () => (
+          <YStack width="100%">
+            <Skeleton.BodyMd width="30%" />
+            <Skeleton.BodyMd width="50%" />
           </YStack>
         ),
       },
@@ -660,6 +672,11 @@ function BatchCreateAccountPreviewPage({
           >
             {balanceMap[buildBalanceMapKey({ account })] ?? '-'}
           </NumberSizeableText>
+        ),
+        renderSkeleton: () => (
+          <YStack width="100%">
+            <Skeleton.BodyMd width="100%" />
+          </YStack>
         ),
       },
     ],
@@ -693,6 +710,13 @@ function BatchCreateAccountPreviewPage({
     [totalCount, balanceMap],
   );
 
+  const shouldShowError = useMemo(() => {
+    if (previewError && !isLoading) {
+      return true;
+    }
+    return false;
+  }, [previewError, isLoading]);
+
   return (
     <Page scrollEnabled safeAreaEnabled>
       <Page.Header
@@ -703,36 +727,61 @@ function BatchCreateAccountPreviewPage({
         headerRight={headerRight}
       />
       <Page.Body>
-        <Table
-          onRow={onRow}
-          rowProps={{
-            gap: platformEnv.isNative ? '$8' : '$4',
-            px: '$3',
-            mx: '$2',
-            minHeight: '$12',
-          }}
-          estimatedItemSize="$12"
-          headerRowProps={{ py: '$2', minHeight: 36 }}
-          dataSource={isLoading ? [] : accounts}
-          columns={columns as any}
-          TableEmptyComponent={
-            <Stack
-              testID="batch-create-account-preview-loading-icon"
-              py="$20"
-              flexDirection="column"
-              justifyContent="center"
-              alignItems="center"
-            >
-              {previewError ? (
-                <SizableText color="$textCaution">{previewError}</SizableText>
-              ) : (
-                <Spinner size="large" />
-              )}
+        {shouldShowError ? (
+          <Stack
+            testID="batch-create-account-preview-loading-icon"
+            height={500}
+            flexDirection="column"
+            justifyContent="center"
+            alignItems="center"
+          >
+            <Stack maxWidth="$64">
+              <SizableText size="$headingXl" mb="$2" textAlign="center">
+                {intl.formatMessage({
+                  id: ETranslations.global_an_error_occurred,
+                })}
+              </SizableText>
+              <SizableText
+                textAlign="center"
+                size="$bodyLg"
+                mb="$6"
+                color="$textSubdued"
+              >
+                {previewError}
+              </SizableText>
+              <XStack justifyContent="center">
+                <Button
+                  width="auto"
+                  variant="primary"
+                  onPress={() => {
+                    void run();
+                  }}
+                >
+                  {intl.formatMessage({ id: ETranslations.global_retry })}
+                </Button>
+              </XStack>
             </Stack>
-          }
-          extraData={extraData}
-          keyExtractor={(item) => item.id}
-        />
+          </Stack>
+        ) : (
+          <Table
+            onRow={onRow}
+            rowProps={{
+              gap: platformEnv.isNative ? '$8' : '$4',
+              px: '$3',
+              mx: '$2',
+              minHeight: '$12',
+            }}
+            estimatedItemSize="$12"
+            headerRowProps={{ py: '$2', minHeight: 36 }}
+            showSkeleton={isLoading}
+            // showSkeleton
+            skeletonCount={3}
+            dataSource={accounts}
+            columns={columns as any}
+            extraData={extraData}
+            keyExtractor={(item) => item.id}
+          />
+        )}
       </Page.Body>
       <Page.Footer>
         <Page.FooterActions


### PR DESCRIPTION
- Add showSkeleton and skeletonCount props to Table component
- Implement skeleton rendering in table rows using renderSkeleton functions
- Improve error state display with retry button in BatchCreateAccountPreview
- Disable table interactions (pressStyle, onRow) during skeleton state
- Optimize user experience during account creation loading

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced skeleton loading state in tables, displaying placeholder rows while data is loading.
  * Added a user-friendly error panel with a retry button for preview errors in the account batch creation preview.

* **Bug Fixes**
  * Disabled row interactions and press styles when skeleton loading is active to prevent unintended actions.

* **Refactor**
  * Improved error and loading control flow for a smoother user experience during data fetches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->