### PR TITLE
refactor: clean up TradingViewV2 and MobileInformationTabs components

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
@@ -18,8 +18,6 @@ import {
   useAutoTokenDetailUpdate,
 } from './hooks';
 
-// import { useTradingViewV2WebSocket } from './hooks';
-
 import type { ICustomReceiveHandlerData } from './types';
 import type { IWebViewRef } from '../../WebView/types';
 import type { WebViewProps } from 'react-native-webview';

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/layout/MobileInformationTabs.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/layout/MobileInformationTabs.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { useIntl } from 'react-intl';
 
 import { Stack, Tabs } from '@onekeyhq/components';
+import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { useTokenDetail } from '../../../hooks/useTokenDetail';
@@ -14,7 +15,7 @@ export function MobileInformationTabs() {
   const { tokenAddress, networkId } = useTokenDetail();
 
   const shouldShowHolders = useMemo(() => {
-    return networkId === 'sol--101';
+    return networkId === getNetworkIdsMap().sol;
   }, [networkId]);
 
   if (!tokenAddress || !networkId) {

--- a/packages/shared/src/config/appConfig.ts
+++ b/packages/shared/src/config/appConfig.ts
@@ -44,7 +44,6 @@ export const ONEKEY_API_HOST = 'onekeycn.com';
 export const ONEKEY_TEST_API_HOST = 'onekeytest.com';
 
 export const WEB_APP_URL = 'https://app.onekey.so';
-export const WEB_APP_URL_SHORT = 'https://1key.so';
 export const WEB_APP_URL_DEV = 'https://app.onekeytest.com';
 
 export const EXT_RATE_URL = {
@@ -81,9 +80,7 @@ export const CHAIN_SELECTOR_LOGO =
 export const defaultColorScheme = 'dark';
 
 export const TRADING_VIEW_URL =
-  process.env.TRADING_VIEW_URL || 'http://localhost:5173'; // 'https://tradingview.onekeytest.com/';
+  process.env.TRADING_VIEW_URL || 'https://tradingview.onekeytest.com/';
 
 export const FALCON_DOCS_URL = 'https://docs.falcon.finance/';
 export const ONEKEY_HEALTH_CHECK_URL = '/wallet/v1/health';
-
-export const SUPPORT_URL = 'https://help.onekey.so/hc/requests/new';

--- a/packages/shared/src/config/appConfig.ts
+++ b/packages/shared/src/config/appConfig.ts
@@ -44,6 +44,7 @@ export const ONEKEY_API_HOST = 'onekeycn.com';
 export const ONEKEY_TEST_API_HOST = 'onekeytest.com';
 
 export const WEB_APP_URL = 'https://app.onekey.so';
+export const WEB_APP_URL_SHORT = 'https://1key.so';
 export const WEB_APP_URL_DEV = 'https://app.onekeytest.com';
 
 export const EXT_RATE_URL = {
@@ -80,7 +81,10 @@ export const CHAIN_SELECTOR_LOGO =
 export const defaultColorScheme = 'dark';
 
 export const TRADING_VIEW_URL =
-  process.env.TRADING_VIEW_URL || 'https://tradingview.onekeytest.com/';
+  // process.env.TRADING_VIEW_URL || 'http://localhost:5173';
+  'https://tradingview.onekeytest.com/';
 
 export const FALCON_DOCS_URL = 'https://docs.falcon.finance/';
 export const ONEKEY_HEALTH_CHECK_URL = '/wallet/v1/health';
+
+export const SUPPORT_URL = 'https://help.onekey.so/hc/requests/new';

--- a/packages/shared/src/config/appConfig.ts
+++ b/packages/shared/src/config/appConfig.ts
@@ -81,8 +81,7 @@ export const CHAIN_SELECTOR_LOGO =
 export const defaultColorScheme = 'dark';
 
 export const TRADING_VIEW_URL =
-  // process.env.TRADING_VIEW_URL || 'http://localhost:5173';
-  'https://tradingview.onekeytest.com/';
+  process.env.TRADING_VIEW_URL || 'https://tradingview.onekeytest.com/';
 
 export const FALCON_DOCS_URL = 'https://docs.falcon.finance/';
 export const ONEKEY_HEALTH_CHECK_URL = '/wallet/v1/health';


### PR DESCRIPTION
- Removed commented-out code in TradingViewV2 for improved clarity.
- Updated MobileInformationTabs to utilize getNetworkIdsMap for network ID comparison, enhancing maintainability.
- Cleaned up appConfig by removing the short URL constant and updating the default TradingView URL for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the "holders" tab display by dynamically determining the network ID instead of using a hardcoded value.

* **Chores**
  * Updated the default TradingView URL to use a remote test server instead of a local development server.
  * Removed unused commented-out code for improved code cleanliness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->