### PR TITLE
fix: pre swap result content add done btn & order event add quote amount OK-41274 OK-41301

### DIFF
--- a/packages/kit/src/views/Swap/components/PreSwapConfirmResult.tsx
+++ b/packages/kit/src/views/Swap/components/PreSwapConfirmResult.tsx
@@ -4,6 +4,7 @@ import { useIntl } from 'react-intl';
 
 import {
   AnimatePresence,
+  Button,
   Image,
   SizableText,
   XStack,
@@ -23,12 +24,14 @@ interface IPreSwapConfirmResultProps {
   lastStep: ISwapStep;
   fromToken?: ISwapToken;
   supportUrl?: string;
+  onConfirm?: () => void;
 }
 
 const PreSwapConfirmResult = ({
   lastStep,
   fromToken,
   supportUrl,
+  onConfirm,
 }: IPreSwapConfirmResultProps) => {
   const [explorerUrl, setExplorerUrl] = useState<string>('');
   const intl = useIntl();
@@ -205,6 +208,14 @@ const PreSwapConfirmResult = ({
           </SizableText>
         </XStack>
       ) : null}
+      <Button variant="primary" onPress={onConfirm} size="medium">
+        {intl.formatMessage({
+          id:
+            lastStep.status === ESwapStepStatus.FAILED
+              ? ETranslations.global_retry
+              : ETranslations.global_done,
+        })}
+      </Button>
     </YStack>
   );
 };

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -1361,6 +1361,7 @@ export function useSwapBuildTx() {
         swapType = ESwapTabSwitchType.BRIDGE;
       }
       defaultLogger.swap.createSwapOrder.swapCreateOrder({
+        quoteToAmount: buildSwapRes.result?.toAmount ?? '',
         status: ESwapEventAPIStatus.SUCCESS,
         swapProvider: buildSwapRes.result?.info.provider ?? '',
         swapProviderName: buildSwapRes.result?.info.providerName ?? '',
@@ -1466,6 +1467,7 @@ export function useSwapBuildTx() {
             swapType = ESwapTabSwitchType.BRIDGE;
           }
           defaultLogger.swap.createSwapOrder.swapCreateOrder({
+            quoteToAmount: data?.toAmount ?? '',
             status: ESwapEventAPIStatus.FAIL,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             message: e?.message ?? 'unknown error',

--- a/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
+++ b/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
@@ -35,9 +35,13 @@ import { useSwapBuildTx } from '../../hooks/useSwapBuiltTx';
 
 interface IPreSwapDialogContentProps {
   onConfirm: () => void;
+  onDone: () => void;
 }
 
-const PreSwapDialogContent = ({ onConfirm }: IPreSwapDialogContentProps) => {
+const PreSwapDialogContent = ({
+  onDone,
+  onConfirm,
+}: IPreSwapDialogContentProps) => {
   const intl = useIntl();
   const [swapSteps, setSwapSteps] = useSwapStepsAtom();
   const { preSwapData, quoteResult } = useMemo(() => {
@@ -60,9 +64,6 @@ const PreSwapDialogContent = ({ onConfirm }: IPreSwapDialogContentProps) => {
       }),
     [activeAccount?.wallet?.id],
   );
-  const handleConfirm = () => {
-    onConfirm();
-  };
 
   const [inAppNotificationAtom, setInAppNotificationAtom] =
     useInAppNotificationAtom();
@@ -181,6 +182,7 @@ const PreSwapDialogContent = ({ onConfirm }: IPreSwapDialogContentProps) => {
     <HeightTransition initialHeight={355}>
       {showResultContent && swapSteps.steps.length > 0 ? (
         <PreSwapConfirmResult
+          onConfirm={onDone}
           fromToken={preSwapData?.fromToken}
           supportUrl={quoteResult?.supportUrl}
           lastStep={swapSteps.steps[swapSteps.steps.length - 1]}
@@ -250,7 +252,7 @@ const PreSwapDialogContent = ({ onConfirm }: IPreSwapDialogContentProps) => {
                     </SizableText>
                   </XStack>
                 ) : null}
-                <Button variant="primary" onPress={handleConfirm} size="medium">
+                <Button variant="primary" onPress={onConfirm} size="medium">
                   {intl.formatMessage({
                     id: isHwWallet
                       ? ETranslations.global_confirm_on_device
@@ -260,7 +262,7 @@ const PreSwapDialogContent = ({ onConfirm }: IPreSwapDialogContentProps) => {
               </YStack>
             </YStack>
           ) : (
-            <PreSwapStep steps={swapSteps.steps} onRetry={handleConfirm} />
+            <PreSwapStep steps={swapSteps.steps} onRetry={onConfirm} />
           )}
         </YStack>
       )}

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -652,8 +652,12 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     onActionHandlerBefore();
   }, [onActionHandlerBefore]);
 
-  const onPreSwapClose = useCallback(() => {
+  const dialogClose = useCallback(() => {
     void dialogRef.current?.close();
+  }, []);
+
+  const onPreSwapClose = useCallback(() => {
+    dialogClose();
     setSwapBuildTxFetching(false);
     void backgroundApiProxy.serviceGas.abortEstimateFee();
     setTimeout(() => {
@@ -662,7 +666,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
         preSwapData: {},
       });
     }, 500);
-  }, [setSwapBuildTxFetching, setSwapSteps]);
+  }, [setSwapBuildTxFetching, dialogClose, setSwapSteps]);
 
   const onPreSwap = useCallback(() => {
     if (!currentQuoteRes) {
@@ -696,7 +700,10 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
                         : EJotaiContextStoreNames.swap
                     }
                   >
-                    <PreSwapDialogContent onConfirm={handleConfirm} />
+                    <PreSwapDialogContent
+                      onConfirm={handleConfirm}
+                      onDone={dialogClose}
+                    />
                   </SwapProviderMirror>
                 </AccountSelectorProviderMirror>
               ),
@@ -724,7 +731,10 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
                         : EJotaiContextStoreNames.swap
                     }
                   >
-                    <PreSwapDialogContent onConfirm={handleConfirm} />
+                    <PreSwapDialogContent
+                      onDone={dialogClose}
+                      onConfirm={handleConfirm}
+                    />
                   </SwapProviderMirror>
                 </AccountSelectorProviderMirror>
               ),
@@ -733,6 +743,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
             });
     }, 100);
   }, [
+    dialogClose,
     InTabDialog,
     InModalDialog,
     currentQuoteRes,

--- a/packages/shared/src/logger/scopes/swap/scenes/createOrder.ts
+++ b/packages/shared/src/logger/scopes/swap/scenes/createOrder.ts
@@ -21,6 +21,7 @@ export class CreateOrderScene extends BaseScene {
     createFrom,
     router,
     slippage,
+    quoteToAmount,
   }: {
     status: ESwapEventAPIStatus;
     message?: string;
@@ -36,8 +37,10 @@ export class CreateOrderScene extends BaseScene {
     feeType: string;
     isFirstTime: boolean;
     createFrom: string;
+    quoteToAmount: string;
   }) {
     return {
+      quoteToAmount,
       status,
       message,
       isFirstTime,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a primary action button to the swap confirmation screen, allowing users to complete or retry the swap process as needed.
  * Dialogs related to swap actions now close automatically when the process is done.

* **Enhancements**
  * Improved logging for swap creation events with additional transaction amount details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->