### PR TITLE
fix: search not empty hidden paste btn OK-41492 OK-41498

### DIFF
--- a/packages/kit/src/views/Swap/components/SwapQuoteResultRate.tsx
+++ b/packages/kit/src/views/Swap/components/SwapQuoteResultRate.tsx
@@ -94,8 +94,8 @@ const SwapQuoteResultRate = ({
         >
           {`1 ${
             isReverse
-              ? toToken.symbol.toUpperCase()
-              : fromToken.symbol.toUpperCase()
+              ? toToken?.symbol?.toUpperCase() ?? '-'
+              : fromToken?.symbol?.toUpperCase() ?? '-'
           } = `}
           <NumberSizeableText size="$bodyMd" formatter="balance">
             {isReverse

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -2305,6 +2305,8 @@ export function useSwapBuildTx() {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                 error?.name !== EOneKeyErrorClassNames.OneKeyAppError &&
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                error?.name !== EOneKeyErrorClassNames.OneKeyHardwareError &&
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                 error?.className !==
                   EOneKeyErrorClassNames.OneKeyHardwareError &&
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access

--- a/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
@@ -270,7 +270,7 @@ const SwapTokenSelectPage = () => {
   );
 
   const { md } = useMedia();
-  const { copyText, getClipboard, supportPaste } = useClipboard();
+  const { copyText, getClipboard } = useClipboard();
 
   const handlePaste = useCallback(async () => {
     const text = await getClipboard();
@@ -506,14 +506,15 @@ const SwapTokenSelectPage = () => {
             setSearchKeyword(afterTrim);
           },
           searchBarInputValue: searchKeyword,
-          addOns: supportPaste
-            ? [
-                {
-                  iconName: 'ClipboardOutline',
-                  onPress: handlePaste,
-                },
-              ]
-            : [],
+          addOns:
+            searchKeyword?.length === 0
+              ? [
+                  {
+                    iconName: 'ClipboardOutline',
+                    onPress: handlePaste,
+                  },
+                ]
+              : [],
         }}
       />
       <Page.Body>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when displaying token symbols in the swap rate by handling missing or undefined values.
  * Refined error handling during swap steps to prevent unnecessary fallback behavior for specific hardware errors.

* **New Features**
  * Updated the swap token selection modal so the paste button in the search bar now appears only when the search input is empty, enhancing usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->