### PR TITLE
fix: market swap create order event & native token max OK-41441 OK-41461

### DIFF
--- a/packages/kit/src/states/jotai/contexts/swap/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/atoms.ts
@@ -19,6 +19,7 @@ import type {
   ISwapAlertState,
   ISwapAutoSlippageSuggestedValue,
   ISwapLimitPriceInfo,
+  ISwapNativeTokenReserveGas,
   ISwapNetwork,
   ISwapPreSwapData,
   ISwapStep,
@@ -653,9 +654,4 @@ export const { atom: swapTipsAtom, use: useSwapTipsAtom } = contextAtom<
 export const {
   atom: swapNativeTokenReserveGasAtom,
   use: useSwapNativeTokenReserveGasAtom,
-} = contextAtom<
-  {
-    networkId: string;
-    reserveGas: number;
-  }[]
->([]);
+} = contextAtom<ISwapNativeTokenReserveGas[]>([]);

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
@@ -77,6 +77,7 @@ export function SwapPanelWrap() {
     balanceToken,
     fetchBalanceLoading,
     priceRate,
+    swapNativeTokenReserveGas,
   } = speedSwapActions;
 
   const filterDefaultTokens = useMemo(() => {
@@ -116,6 +117,7 @@ export function SwapPanelWrap() {
     <SwapPanelContent
       priceRate={priceRate}
       swapMevNetConfig={swapMevNetConfig}
+      swapNativeTokenReserveGas={swapNativeTokenReserveGas}
       swapPanel={swapPanel}
       balance={balance ?? new BigNumber(0)}
       balanceToken={balanceToken as IToken}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/TokenInputSection/TokenInputSection.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/TokenInputSection/TokenInputSection.tsx
@@ -24,6 +24,7 @@ import {
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
+import type { ISwapNativeTokenReserveGas } from '@onekeyhq/shared/types/swap/types';
 
 import { ESwapDirection, type ITradeType } from '../../hooks/useTradeType';
 
@@ -45,6 +46,7 @@ export interface ITokenInputSectionProps {
   onPressTokenSelector?: () => void;
   tradeType: ITradeType;
   balance?: BigNumber;
+  swapNativeTokenReserveGas: ISwapNativeTokenReserveGas[];
 }
 
 function TokenInputSectionComponent(
@@ -55,6 +57,7 @@ function TokenInputSectionComponent(
     onTokenChange,
     tradeType,
     balance,
+    swapNativeTokenReserveGas,
   }: ITokenInputSectionProps,
   ref: Ref<ITokenInputSectionRef>,
 ) {
@@ -200,9 +203,12 @@ function TokenInputSectionComponent(
           })) ?? []
         }
         selectedTokenDecimals={selectedToken?.decimals}
+        selectedTokenNetworkId={selectedToken?.networkId}
+        selectedTokenIsNative={selectedToken?.isNative}
         onSelect={handleInternalChange}
         tradeType={tradeType}
         balance={balance}
+        swapNativeTokenReserveGas={swapNativeTokenReserveGas}
       />
     </YStack>
   );

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -342,7 +342,10 @@ export function useSpeedSwapActions(props: {
       });
 
       defaultLogger.swap.createSwapOrder.swapCreateOrder({
-        quoteToAmount: buildRes.result?.toAmount ?? '',
+        fromTokenAmount,
+        fromAddress: userAddress,
+        toAddress: userAddress,
+        toTokenAmount: buildRes.result?.toAmount ?? '',
         status: ESwapEventAPIStatus.SUCCESS,
         swapProvider: buildRes.result?.info.provider ?? '',
         swapProviderName: buildRes.result?.info.providerName ?? '',
@@ -362,7 +365,10 @@ export function useSpeedSwapActions(props: {
     } catch (e) {
       setSpeedSwapBuildTxLoading(false);
       defaultLogger.swap.createSwapOrder.swapCreateOrder({
-        quoteToAmount: buildRes.result?.toAmount ?? '',
+        fromTokenAmount,
+        fromAddress: userAddress,
+        toAddress: userAddress,
+        toTokenAmount: buildRes.result?.toAmount ?? '',
         status: ESwapEventAPIStatus.FAIL,
         swapProvider: buildRes.result?.info.provider ?? '',
         swapProviderName: buildRes.result?.info.providerName ?? '',

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -24,10 +24,13 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import { ESwapEventAPIStatus } from '@onekeyhq/shared/src/logger/scopes/swap/scenes/swapEstimateFee';
 import { toBigIntHex } from '@onekeyhq/shared/src/utils/numberUtils';
 import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type {
   ISwapApproveTransaction,
+  ISwapNativeTokenReserveGas,
   ISwapTokenBase,
   ISwapTxHistory,
   ISwapTxInfo,
@@ -79,6 +82,10 @@ export function useSpeedSwapActions(props: {
     useState(false);
   const [baseToken, setBaseToken] = useState<ISwapTokenBase | undefined>();
   const [fetchBalanceLoading, setFetchBalanceLoading] = useState(false);
+  const [swapNativeTokenReserveGas, setSwapNativeTokenReserveGas] = useState<
+    ISwapNativeTokenReserveGas[]
+  >([]);
+  const [{ isFirstTimeSwap }] = useSettingsPersistAtom();
   const [priceRate, setPriceRate] = useState<
     | {
         rate?: number;
@@ -333,9 +340,43 @@ export function useSpeedSwapActions(props: {
         onCancel: cancelSpeedSwapBuildTx,
         disableMev: !antiMEV,
       });
+
+      defaultLogger.swap.createSwapOrder.swapCreateOrder({
+        quoteToAmount: buildRes.result?.toAmount ?? '',
+        status: ESwapEventAPIStatus.SUCCESS,
+        swapProvider: buildRes.result?.info.provider ?? '',
+        swapProviderName: buildRes.result?.info.providerName ?? '',
+        swapType: ESwapTabSwitchType.SWAP,
+        slippage: slippage.toString(),
+        sourceChain: fromToken.networkId ?? '',
+        receivedChain: toToken.networkId ?? '',
+        sourceTokenSymbol: fromToken.symbol ?? '',
+        receivedTokenSymbol: toToken.symbol ?? '',
+        feeType: buildRes.result?.fee?.percentageFee?.toString() ?? '0',
+        router: JSON.stringify(buildRes.result?.routesData ?? ''),
+        isFirstTime: isFirstTimeSwap,
+        createFrom: 'marketDex',
+      });
+
       return buildRes;
     } catch (e) {
       setSpeedSwapBuildTxLoading(false);
+      defaultLogger.swap.createSwapOrder.swapCreateOrder({
+        quoteToAmount: buildRes.result?.toAmount ?? '',
+        status: ESwapEventAPIStatus.FAIL,
+        swapProvider: buildRes.result?.info.provider ?? '',
+        swapProviderName: buildRes.result?.info.providerName ?? '',
+        swapType: ESwapTabSwitchType.SWAP,
+        slippage: slippage.toString(),
+        sourceChain: fromToken.networkId ?? '',
+        receivedChain: toToken.networkId ?? '',
+        sourceTokenSymbol: fromToken.symbol ?? '',
+        receivedTokenSymbol: toToken.symbol ?? '',
+        feeType: buildRes.result?.fee?.percentageFee?.toString() ?? '0',
+        router: JSON.stringify(buildRes.result?.routesData ?? ''),
+        isFirstTime: isFirstTimeSwap,
+        createFrom: 'marketDex',
+      });
     }
   }, [
     netAccountRes.result?.address,
@@ -350,6 +391,7 @@ export function useSpeedSwapActions(props: {
     handleSpeedSwapBuildTxSuccess,
     cancelSpeedSwapBuildTx,
     antiMEV,
+    isFirstTimeSwap,
   ]);
 
   // --- approve
@@ -713,6 +755,32 @@ export function useSpeedSwapActions(props: {
   }, [fetchTokenPrice, fromToken.networkId, toToken.networkId]);
 
   useEffect(() => {
+    if (fromToken?.networkId && fromToken?.isNative) {
+      void (async () => {
+        const nativeTokenConfig =
+          await backgroundApiProxy.serviceSwap.fetchSwapNativeTokenConfig({
+            networkId: fromToken.networkId,
+          });
+        setSwapNativeTokenReserveGas((pre) => {
+          const find = pre.find(
+            (item) => item.networkId === fromToken.networkId,
+          );
+          if (find) {
+            return [
+              ...pre.filter((item) => item.networkId !== fromToken.networkId),
+              {
+                networkId: fromToken.networkId,
+                reserveGas: nativeTokenConfig.reserveGas,
+              },
+            ];
+          }
+          return [...pre, nativeTokenConfig];
+        });
+      })();
+    }
+  }, [fromToken?.networkId, fromToken?.isNative, setSwapNativeTokenReserveGas]);
+
+  useEffect(() => {
     appEventBus.off(
       EAppEventBusNames.SwapSpeedBalanceUpdate,
       syncTokensBalance,
@@ -825,6 +893,7 @@ export function useSpeedSwapActions(props: {
     balance,
     balanceToken,
     fetchBalanceLoading,
+    swapNativeTokenReserveGas,
     priceRate,
   };
 }

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSwapPanel.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSwapPanel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import BigNumber from 'bignumber.js';
 

--- a/packages/shared/src/logger/scopes/swap/scenes/createOrder.ts
+++ b/packages/shared/src/logger/scopes/swap/scenes/createOrder.ts
@@ -55,6 +55,7 @@ export class CreateOrderScene extends BaseScene {
       router,
       slippage,
       createFrom,
+      source,
     };
   }
 }

--- a/packages/shared/src/logger/scopes/swap/scenes/createOrder.ts
+++ b/packages/shared/src/logger/scopes/swap/scenes/createOrder.ts
@@ -55,7 +55,6 @@ export class CreateOrderScene extends BaseScene {
       router,
       slippage,
       createFrom,
-      source,
     };
   }
 }

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -970,6 +970,11 @@ export enum ESwapSlippageCustomStatus {
   WRONG = 'wrong',
 }
 
+export interface ISwapNativeTokenReserveGas {
+  networkId: string;
+  reserveGas: number;
+}
+
 export const SwapPercentageInputStage = [25, 50, 100];
 export const SwapPercentageInputStageForNative = [25, 50, 75, 100];
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The swap interface now automatically reserves a portion of native tokens for gas fees when selecting maximum amounts, preventing users from accidentally using all their native tokens and being unable to pay transaction fees.

* **Enhancements**
  * Improved calculation of spendable amounts for native tokens in swap panels and quick amount selectors.
  * Added more robust logging for swap order creation to aid in tracking and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->