### PR TITLE
fix: escape special characters in keyword regex for search result hig…

### DIFF
--- a/packages/kit/src/views/Discovery/components/SearchResultContent.tsx
+++ b/packages/kit/src/views/Discovery/components/SearchResultContent.tsx
@@ -392,7 +392,10 @@ export function SearchResultContent({
             >
               {item?.keyword
                 ? item.name.replace(
-                    new RegExp(item.keyword, 'ig'),
+                    new RegExp(
+                      item.keyword.replace(/[[\]()+?*^$.|\\{}]/g, '\\$&'),
+                      'ig',
+                    ),
                     (match) => `<a>${match}</a>`,
                   )
                 : item.name}


### PR DESCRIPTION
…hlighting

- Updated the regex used for highlighting keywords in SearchResultContent to escape special characters, ensuring proper matching and display of keywords in search results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search result highlighting to handle special characters in search keywords correctly, preventing errors and ensuring accurate matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->