### PR TITLE
feat: Add watch-only wallet tab to ConnectWalletModal

### DIFF
--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -288,7 +288,8 @@ export function Container({
         onTabPress(initialTabName, false);
       }, 100);
     }
-  }, [initialTabName, onTabPress]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <YStack

--- a/packages/kit/src/components/WebDapp/ConnectWalletModal.tsx
+++ b/packages/kit/src/components/WebDapp/ConnectWalletModal.tsx
@@ -1,9 +1,10 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { useRoute } from '@react-navigation/core';
 import { useIntl } from 'react-intl';
 
 import { Page, Stack, Tabs, useMedia } from '@onekeyhq/components';
+import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { TermsAndPrivacy } from '@onekeyhq/kit/src/views/Onboarding/pages/GetStarted/components/TermsAndPrivacy';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type {
@@ -16,11 +17,13 @@ import { AccountSelectorProviderMirror } from '../AccountSelector';
 
 import { ExternalWalletList } from './ExternalWalletList';
 import { OneKeyWalletConnectionOptions } from './OneKeyWalletConnectionOptions';
+import { WatchOnlyWalletContent } from './WatchOnlyWalletContent';
 
 import type { RouteProp } from '@react-navigation/core';
 
 function ConnectWalletModal() {
   const intl = useIntl();
+  const navigation = useAppNavigation();
   const route =
     useRoute<
       RouteProp<IOnboardingParamList, EOnboardingPages.ConnectWalletOptions>
@@ -36,10 +39,51 @@ function ConnectWalletModal() {
   const othersTitle = intl.formatMessage({
     id: ETranslations.global_others,
   });
+  const watchOnlyTitle = intl.formatMessage({
+    id: ETranslations.global_watch_only,
+  });
 
   const initialTabName = useMemo(() => {
     return defaultTab === 'others' ? othersTitle : onekeyTitle;
   }, [defaultTab, othersTitle, onekeyTitle]);
+
+  const [activeTabIndex, setActiveTabIndex] = useState<number>(() => {
+    return defaultTab === 'others' ? 1 : 0;
+  });
+
+  const handleWalletAdded = useCallback(() => {
+    navigation.popStack();
+  }, [navigation]);
+
+  const renderTabs = useMemo(
+    () => (
+      <Tabs.Container
+        initialTabName={initialTabName}
+        onIndexChange={(index) => {
+          setActiveTabIndex(index);
+        }}
+      >
+        <Tabs.Tab name={onekeyTitle}>
+          <Stack p="$5" gap="$4">
+            <OneKeyWalletConnectionOptions />
+          </Stack>
+        </Tabs.Tab>
+        <Tabs.Tab name={othersTitle}>
+          <ExternalWalletList impl="evm" />
+        </Tabs.Tab>
+        <Tabs.Tab name={watchOnlyTitle}>
+          <WatchOnlyWalletContent onWalletAdded={handleWalletAdded} />
+        </Tabs.Tab>
+      </Tabs.Container>
+    ),
+    [
+      onekeyTitle,
+      othersTitle,
+      watchOnlyTitle,
+      handleWalletAdded,
+      initialTabName,
+    ],
+  );
 
   return (
     <AccountSelectorProviderMirror
@@ -63,18 +107,9 @@ function ConnectWalletModal() {
               </Stack>
             ) : (
               // Desktop: show full tabs
-              <Tabs.Container initialTabName={initialTabName}>
-                <Tabs.Tab name={onekeyTitle}>
-                  <Stack p="$5" gap="$4">
-                    <OneKeyWalletConnectionOptions />
-                  </Stack>
-                </Tabs.Tab>
-                <Tabs.Tab name={othersTitle}>
-                  <ExternalWalletList impl="evm" />
-                </Tabs.Tab>
-              </Tabs.Container>
+              renderTabs
             )}
-            <TermsAndPrivacy />
+            {activeTabIndex === 2 ? null : <TermsAndPrivacy />}
           </Stack>
         </Page.Body>
       </Page>

--- a/packages/kit/src/components/WebDapp/ConnectWalletModal.tsx
+++ b/packages/kit/src/components/WebDapp/ConnectWalletModal.tsx
@@ -6,6 +6,7 @@ import { useIntl } from 'react-intl';
 import { Page, Stack, Tabs, useMedia } from '@onekeyhq/components';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { TermsAndPrivacy } from '@onekeyhq/kit/src/views/Onboarding/pages/GetStarted/components/TermsAndPrivacy';
+import { useImportAddressForm } from '@onekeyhq/kit/src/views/Onboarding/pages/ImportWallet/hooks/useImportAddressForm';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type {
   EOnboardingPages,
@@ -21,7 +22,7 @@ import { WatchOnlyWalletContent } from './WatchOnlyWalletContent';
 
 import type { RouteProp } from '@react-navigation/core';
 
-function ConnectWalletModal() {
+function ConnectWalletContent() {
   const intl = useIntl();
   const navigation = useAppNavigation();
   const route =
@@ -55,6 +56,11 @@ function ConnectWalletModal() {
     navigation.popStack();
   }, [navigation]);
 
+  // Watch-only wallet form state
+  const watchOnlyFormState = useImportAddressForm({
+    onWalletAdded: handleWalletAdded,
+  });
+
   const renderTabs = useMemo(
     () => (
       <Tabs.Container
@@ -72,7 +78,7 @@ function ConnectWalletModal() {
           <ExternalWalletList impl="evm" />
         </Tabs.Tab>
         <Tabs.Tab name={watchOnlyTitle}>
-          <WatchOnlyWalletContent onWalletAdded={handleWalletAdded} />
+          <WatchOnlyWalletContent {...watchOnlyFormState} />
         </Tabs.Tab>
       </Tabs.Container>
     ),
@@ -80,11 +86,45 @@ function ConnectWalletModal() {
       onekeyTitle,
       othersTitle,
       watchOnlyTitle,
-      handleWalletAdded,
+      watchOnlyFormState,
       initialTabName,
     ],
   );
 
+  return (
+    <Page>
+      <Page.Header
+        title={intl.formatMessage({
+          id: ETranslations.global_connect_wallet,
+        })}
+      />
+      <Page.Body>
+        <Stack flex={1}>
+          {isMobile ? (
+            // Mobile: show simplified view without tabs
+            <Stack p="$5" gap="$4" flex={1}>
+              <OneKeyWalletConnectionOptions />
+            </Stack>
+          ) : (
+            // Desktop: show full tabs
+            renderTabs
+          )}
+          {activeTabIndex === 2 ? null : <TermsAndPrivacy />}
+        </Stack>
+      </Page.Body>
+      {activeTabIndex === 2 ? (
+        <Page.Footer
+          confirmButtonProps={{
+            disabled: !watchOnlyFormState.isEnable,
+          }}
+          onConfirm={watchOnlyFormState.form.submit}
+        />
+      ) : null}
+    </Page>
+  );
+}
+
+function ConnectWalletModal() {
   return (
     <AccountSelectorProviderMirror
       config={{
@@ -92,27 +132,7 @@ function ConnectWalletModal() {
       }}
       enabledNum={[0]}
     >
-      <Page>
-        <Page.Header
-          title={intl.formatMessage({
-            id: ETranslations.global_connect_wallet,
-          })}
-        />
-        <Page.Body>
-          <Stack flex={1}>
-            {isMobile ? (
-              // Mobile: show simplified view without tabs
-              <Stack p="$5" gap="$4" flex={1}>
-                <OneKeyWalletConnectionOptions />
-              </Stack>
-            ) : (
-              // Desktop: show full tabs
-              renderTabs
-            )}
-            {activeTabIndex === 2 ? null : <TermsAndPrivacy />}
-          </Stack>
-        </Page.Body>
-      </Page>
+      <ConnectWalletContent />
     </AccountSelectorProviderMirror>
   );
 }

--- a/packages/kit/src/components/WebDapp/ConnectWalletModal.tsx
+++ b/packages/kit/src/components/WebDapp/ConnectWalletModal.tsx
@@ -41,7 +41,7 @@ function ConnectWalletContent() {
     id: ETranslations.global_others,
   });
   const watchOnlyTitle = intl.formatMessage({
-    id: ETranslations.global_watch_only,
+    id: ETranslations.global_watch_only_wallet,
   });
 
   const initialTabName = useMemo(() => {

--- a/packages/kit/src/components/WebDapp/ConnectWalletModal.tsx
+++ b/packages/kit/src/components/WebDapp/ConnectWalletModal.tsx
@@ -71,7 +71,7 @@ function ConnectWalletContent() {
       >
         <Tabs.Tab name={onekeyTitle}>
           <Stack p="$5" gap="$4">
-            <OneKeyWalletConnectionOptions />
+            <OneKeyWalletConnectionOptions showInModal={false} />
           </Stack>
         </Tabs.Tab>
         <Tabs.Tab name={othersTitle}>
@@ -103,7 +103,7 @@ function ConnectWalletContent() {
           {isMobile ? (
             // Mobile: show simplified view without tabs
             <Stack p="$5" gap="$4" flex={1}>
-              <OneKeyWalletConnectionOptions />
+              <OneKeyWalletConnectionOptions showInModal />
             </Stack>
           ) : (
             // Desktop: show full tabs

--- a/packages/kit/src/components/WebDapp/OneKeyWalletConnectionOptions.tsx
+++ b/packages/kit/src/components/WebDapp/OneKeyWalletConnectionOptions.tsx
@@ -47,7 +47,11 @@ function OneKeyHardwareWalletLogo() {
   );
 }
 
-function OneKeyWalletConnectionOptions() {
+function OneKeyWalletConnectionOptions({
+  showInModal,
+}: {
+  showInModal: boolean;
+}) {
   const intl = useIntl();
   const appNavigation = useAppNavigation();
 
@@ -75,6 +79,12 @@ function OneKeyWalletConnectionOptions() {
     });
   }, [appNavigation]);
 
+  const handleConnectWatchOnlyPress = useCallback(() => {
+    appNavigation.pushModal(EModalRoutes.OnboardingModal, {
+      screen: EOnboardingPages.ImportAddress,
+    });
+  }, [appNavigation]);
+
   // Mobile: show only hardware wallet + WalletConnect
   if (isMobile) {
     return (
@@ -98,6 +108,29 @@ function OneKeyWalletConnectionOptions() {
           mx="$0"
           bg="$bgSubdued"
         />
+        {showInModal ? (
+          <ListItem
+            py="$4"
+            px="$5"
+            mx="$0"
+            bg="$bgSubdued"
+            title="Watch-only wallet"
+            renderAvatar={
+              <Stack
+                h="$10"
+                w="$10"
+                bg="$bgStrong"
+                borderRadius="$2"
+                ai="center"
+                jc="center"
+              >
+                <Icon name="EyeOutline" size="$6" color="$icon" />
+              </Stack>
+            }
+            drillIn
+            onPress={handleConnectWatchOnlyPress}
+          />
+        ) : null}
       </>
     );
   }

--- a/packages/kit/src/components/WebDapp/OneKeyWalletConnectionOptions.tsx
+++ b/packages/kit/src/components/WebDapp/OneKeyWalletConnectionOptions.tsx
@@ -114,7 +114,9 @@ function OneKeyWalletConnectionOptions({
             px="$5"
             mx="$0"
             bg="$bgSubdued"
-            title="Watch-only wallet"
+            title={intl.formatMessage({
+              id: ETranslations.global_watch_only_wallet,
+            })}
             renderAvatar={
               <Stack
                 h="$10"

--- a/packages/kit/src/components/WebDapp/WatchOnlyWalletContent.tsx
+++ b/packages/kit/src/components/WebDapp/WatchOnlyWalletContent.tsx
@@ -1,0 +1,67 @@
+import { useIntl } from 'react-intl';
+
+import { Button, Stack } from '@onekeyhq/components';
+import { useImportAddressForm } from '@onekeyhq/kit/src/views/Onboarding/pages/ImportWallet/hooks/useImportAddressForm';
+import { ImportAddressCore } from '@onekeyhq/kit/src/views/Onboarding/pages/ImportWallet/ImportAddressCore';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
+
+import { AccountSelectorProviderMirror } from '../AccountSelector';
+
+interface IWatchOnlyWalletContentProps {
+  onWalletAdded?: () => void;
+}
+
+function WatchOnlyWallet({ onWalletAdded }: IWatchOnlyWalletContentProps) {
+  const intl = useIntl();
+  const {
+    form,
+    isEnable,
+    method,
+    setMethod,
+    networksResp,
+    isKeyExportEnabled,
+    isPublicKeyImport,
+    validateResult,
+    inputTextDebounced,
+    networkIdText,
+    deriveTypeValue,
+  } = useImportAddressForm({ onWalletAdded });
+
+  return (
+    <Stack flex={1} p="$5" gap="$4">
+      <ImportAddressCore
+        form={form}
+        method={method}
+        setMethod={setMethod}
+        networksResp={networksResp}
+        isKeyExportEnabled={isKeyExportEnabled}
+        isPublicKeyImport={isPublicKeyImport}
+        validateResult={validateResult}
+        inputTextDebounced={inputTextDebounced}
+        networkIdText={networkIdText}
+        deriveTypeValue={deriveTypeValue}
+      />
+      <Button variant="primary" disabled={!isEnable} onPress={form.submit}>
+        {intl.formatMessage({ id: ETranslations.global_import })}
+      </Button>
+    </Stack>
+  );
+}
+
+function WatchOnlyWalletContent({
+  onWalletAdded,
+}: IWatchOnlyWalletContentProps) {
+  return (
+    <AccountSelectorProviderMirror
+      config={{
+        sceneName: EAccountSelectorSceneName.home,
+      }}
+      enabledNum={[0]}
+    >
+      <WatchOnlyWallet onWalletAdded={onWalletAdded} />
+    </AccountSelectorProviderMirror>
+  );
+}
+
+export { WatchOnlyWalletContent };

--- a/packages/kit/src/components/WebDapp/WatchOnlyWalletContent.tsx
+++ b/packages/kit/src/components/WebDapp/WatchOnlyWalletContent.tsx
@@ -1,35 +1,47 @@
-import { useIntl } from 'react-intl';
-
-import { Button, Stack } from '@onekeyhq/components';
-import { useImportAddressForm } from '@onekeyhq/kit/src/views/Onboarding/pages/ImportWallet/hooks/useImportAddressForm';
+import type { UseFormReturn } from '@onekeyhq/components';
+import { Stack } from '@onekeyhq/components';
+import type {
+  EImportMethod,
+  IFormValues,
+} from '@onekeyhq/kit/src/views/Onboarding/pages/ImportWallet/hooks/useImportAddressForm';
 import { ImportAddressCore } from '@onekeyhq/kit/src/views/Onboarding/pages/ImportWallet/ImportAddressCore';
-import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
-
-import { AccountSelectorProviderMirror } from '../AccountSelector';
+import type { IAccountDeriveInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 
 interface IWatchOnlyWalletContentProps {
-  onWalletAdded?: () => void;
+  form: UseFormReturn<IFormValues>;
+  isEnable: boolean;
+  method: EImportMethod;
+  setMethod: (method: EImportMethod) => void;
+  networksResp: {
+    networkIds: string[];
+    publicKeyExportEnabled: Set<string>;
+    watchingAccountEnabled: Set<string>;
+  };
+  isKeyExportEnabled: boolean;
+  isPublicKeyImport: boolean;
+  validateResult?: {
+    isValid: boolean;
+    deriveInfoItems?: IAccountDeriveInfo[];
+  };
+  inputTextDebounced: string;
+  networkIdText?: string;
+  deriveTypeValue?: any;
 }
 
-function WatchOnlyWallet({ onWalletAdded }: IWatchOnlyWalletContentProps) {
-  const intl = useIntl();
-  const {
-    form,
-    isEnable,
-    method,
-    setMethod,
-    networksResp,
-    isKeyExportEnabled,
-    isPublicKeyImport,
-    validateResult,
-    inputTextDebounced,
-    networkIdText,
-    deriveTypeValue,
-  } = useImportAddressForm({ onWalletAdded });
-
+function WatchOnlyWalletContent({
+  form,
+  method,
+  setMethod,
+  networksResp,
+  isKeyExportEnabled,
+  isPublicKeyImport,
+  validateResult,
+  inputTextDebounced,
+  networkIdText,
+  deriveTypeValue,
+}: IWatchOnlyWalletContentProps) {
   return (
-    <Stack flex={1} p="$5" gap="$4">
+    <Stack flex={1} p="$5">
       <ImportAddressCore
         form={form}
         method={method}
@@ -42,25 +54,7 @@ function WatchOnlyWallet({ onWalletAdded }: IWatchOnlyWalletContentProps) {
         networkIdText={networkIdText}
         deriveTypeValue={deriveTypeValue}
       />
-      <Button variant="primary" disabled={!isEnable} onPress={form.submit}>
-        {intl.formatMessage({ id: ETranslations.global_import })}
-      </Button>
     </Stack>
-  );
-}
-
-function WatchOnlyWalletContent({
-  onWalletAdded,
-}: IWatchOnlyWalletContentProps) {
-  return (
-    <AccountSelectorProviderMirror
-      config={{
-        sceneName: EAccountSelectorSceneName.home,
-      }}
-      enabledNum={[0]}
-    >
-      <WatchOnlyWallet onWalletAdded={onWalletAdded} />
-    </AccountSelectorProviderMirror>
   );
 }
 

--- a/packages/kit/src/components/WebDapp/WebDappEmptyView.tsx
+++ b/packages/kit/src/components/WebDapp/WebDappEmptyView.tsx
@@ -152,7 +152,7 @@ function WebDappEmptyView() {
           </XStack>
 
           <YStack gap={isMobileLayout ? '$3' : '$4'}>
-            <OneKeyWalletConnectionOptions />
+            <OneKeyWalletConnectionOptions showInModal={false} />
           </YStack>
           <TermsAndPrivacy
             contentContainerProps={{

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/NewTabsGallery.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/NewTabsGallery.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import {
   ListView,
@@ -321,6 +321,50 @@ const TabsWithInitialTabDemo = () => {
   );
 };
 
+const TabsWithOnIndexChangeDemo = () => {
+  const [activeTabIndex, setActiveTabIndex] = useState(0);
+  return (
+    <YStack>
+      <Tabs.Container
+        initialTabName="Favorites"
+        onIndexChange={(index) => {
+          console.log('===>index: ', index);
+          setActiveTabIndex(index);
+        }}
+      >
+        <Tabs.Tab name="Recent">
+          <YStack p="$4" gap="$2">
+            <SizableText size="$bodyMdMedium" color="$textSubdued">
+              Recent items (默认不会显示，因为设置了 initialTabName="Favorites")
+            </SizableText>
+          </YStack>
+        </Tabs.Tab>
+        <Tabs.Tab name="Favorites">
+          <YStack p="$4" gap="$2">
+            <SizableText size="$bodyMdMedium" color="$textSubdued">
+              Favorites items
+            </SizableText>
+          </YStack>
+        </Tabs.Tab>
+        <Tabs.Tab name="Archive">
+          <YStack p="$4" gap="$2">
+            <SizableText size="$bodyMdMedium" color="$textSubdued">
+              Archive items
+            </SizableText>
+          </YStack>
+        </Tabs.Tab>
+      </Tabs.Container>
+      {activeTabIndex === 1 ? (
+        <YStack p="$4" gap="$2">
+          <SizableText size="$bodyMdMedium" color="$textSubdued">
+            Active tab index: {activeTabIndex}
+          </SizableText>
+        </YStack>
+      ) : null}
+    </YStack>
+  );
+};
+
 const NewTabsGallery = () => (
   <Layout
     filePath={__CURRENT_FILE_PATH__}
@@ -364,6 +408,14 @@ const NewTabsGallery = () => (
         element: (
           <Stack h={400}>
             <TabsWithInitialTabDemo />
+          </Stack>
+        ),
+      },
+      {
+        title: 'Tabs with OnIndexChange',
+        element: (
+          <Stack h={400}>
+            <TabsWithOnIndexChangeDemo />
           </Stack>
         ),
       },

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/NewTabsGallery.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/NewTabsGallery.tsx
@@ -325,6 +325,11 @@ const TabsWithOnIndexChangeDemo = () => {
   const [activeTabIndex, setActiveTabIndex] = useState(0);
   return (
     <YStack>
+      <YStack p="$4" gap="$2">
+        <SizableText size="$bodyMdMedium" color="$textSubdued">
+          Active tab index: {activeTabIndex}
+        </SizableText>
+      </YStack>
       <Tabs.Container
         initialTabName="Favorites"
         onIndexChange={(index) => {
@@ -354,13 +359,6 @@ const TabsWithOnIndexChangeDemo = () => {
           </YStack>
         </Tabs.Tab>
       </Tabs.Container>
-      {activeTabIndex === 1 ? (
-        <YStack p="$4" gap="$2">
-          <SizableText size="$bodyMdMedium" color="$textSubdued">
-            Active tab index: {activeTabIndex}
-          </SizableText>
-        </YStack>
-      ) : null}
     </YStack>
   );
 };

--- a/packages/kit/src/views/Onboarding/pages/ImportWallet/ImportAddress.tsx
+++ b/packages/kit/src/views/Onboarding/pages/ImportWallet/ImportAddress.tsx
@@ -1,365 +1,35 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-
 import { useIntl } from 'react-intl';
 
-import type {
-  IFormMode,
-  IReValidateMode,
-  UseFormReturn,
-} from '@onekeyhq/components';
-import {
-  Form,
-  Icon,
-  Input,
-  Page,
-  SegmentControl,
-  SizableText,
-  Stack,
-  Toast,
-  useClipboard,
-  useForm,
-  useFormWatch,
-  useMedia,
-} from '@onekeyhq/components';
-import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import {
-  AccountSelectorProviderMirror,
-  ControlledNetworkSelectorTrigger,
-} from '@onekeyhq/kit/src/components/AccountSelector';
-import { DeriveTypeSelectorFormInput } from '@onekeyhq/kit/src/components/AccountSelector/DeriveTypeSelectorTrigger';
-import { useAccountSelectorTrigger } from '@onekeyhq/kit/src/components/AccountSelector/hooks/useAccountSelectorTrigger';
-import type { IAddressInputValue } from '@onekeyhq/kit/src/components/AddressInput';
-import {
-  AddressInput,
-  createValidateAddressRule,
-} from '@onekeyhq/kit/src/components/AddressInput';
-import { MAX_LENGTH_ACCOUNT_NAME } from '@onekeyhq/kit/src/components/RenameDialog/renameConsts';
+import { Page } from '@onekeyhq/components';
+import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
-import { useDebounce } from '@onekeyhq/kit/src/hooks/useDebounce';
-import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
-import { useUserWalletProfile } from '@onekeyhq/kit/src/hooks/useUserWalletProfile';
-import { useAccountSelectorActions } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
-import useScanQrCode from '@onekeyhq/kit/src/views/ScanQrCode/hooks/useScanQrCode';
-import type {
-  IAccountDeriveInfo,
-  IAccountDeriveTypes,
-} from '@onekeyhq/kit-bg/src/vaults/types';
-import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
-import { WALLET_TYPE_WATCHING } from '@onekeyhq/shared/src/consts/dbConsts';
-import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
-import type { IGeneralInputValidation } from '@onekeyhq/shared/types/address';
 
-import { Tutorials } from '../../components';
-
-type IFormValues = {
-  networkId?: string;
-  deriveType?: IAccountDeriveTypes;
-  publicKeyValue: string;
-  addressValue: IAddressInputValue;
-  accountName?: string;
-};
-
-enum EImportMethod {
-  Address = 'Address',
-  PublicKey = 'PublicKey',
-}
-
-const FormDeriveTypeInput = ({
-  networkId,
-  deriveInfoItems,
-  fieldName,
-}: {
-  fieldName: string;
-  networkId: string;
-  deriveInfoItems: IAccountDeriveInfo[];
-}) => {
-  const intl = useIntl();
-  return (
-    <Stack mt="$2">
-      <Form.Field
-        label={intl.formatMessage({
-          id: ETranslations.derivation_path,
-        })}
-        name={fieldName}
-      >
-        <DeriveTypeSelectorFormInput
-          networkId={networkId}
-          enabledItems={deriveInfoItems}
-          undefinedResultIfReRun={false}
-          renderTrigger={({ label, onPress }) => (
-            <Stack
-              testID="derive-type-input"
-              userSelect="none"
-              flexDirection="row"
-              px="$3.5"
-              py="$2.5"
-              borderWidth={1}
-              borderColor="$borderStrong"
-              borderRadius="$3"
-              $gtMd={{
-                px: '$3',
-                py: '$1.5',
-                borderRadius: '$2',
-              }}
-              borderCurve="continuous"
-              hoverStyle={{
-                bg: '$bgHover',
-              }}
-              pressStyle={{
-                bg: '$bgActive',
-              }}
-              onPress={onPress}
-            >
-              <SizableText flex={1}>{label}</SizableText>
-              <Icon
-                name="ChevronDownSmallOutline"
-                color="$iconSubdued"
-                mr="$-0.5"
-              />
-            </Stack>
-          )}
-        />
-      </Form.Field>
-    </Stack>
-  );
-};
+import { useImportAddressForm } from './hooks/useImportAddressForm';
+import { ImportAddressCore } from './ImportAddressCore';
 
 function ImportAddress() {
   const intl = useIntl();
-  const media = useMedia();
   const navigation = useAppNavigation();
 
-  const { result: networksResp } = usePromiseResult(
-    async () => {
-      const resp =
-        await backgroundApiProxy.serviceNetwork.getPublicKeyExportOrWatchingAccountEnabledNetworks();
-      const networkIds = resp.map((o) => o.network.id);
-      const publicKeyExportEnabledNetworkIds = resp
-        .filter((o) => o.publicKeyExportEnabled)
-        .map((t) => t.network.id);
+  const handleWalletAdded = () => {
+    navigation.popStack();
+  };
 
-      const watchingAccountEnabledNetworkIds = resp
-        .filter((o) => o.watchingAccountEnabled)
-        .map((t) => t.network.id);
-      return {
-        networkIds,
-        publicKeyExportEnabled: new Set(publicKeyExportEnabledNetworkIds),
-        watchingAccountEnabled: new Set(watchingAccountEnabledNetworkIds),
-      };
-    },
-    [],
-    {
-      initResult: {
-        networkIds: [],
-        publicKeyExportEnabled: new Set([]),
-        watchingAccountEnabled: new Set([]),
-      },
-    },
-  );
-
-  const actions = useAccountSelectorActions();
-  const [method, setMethod] = useState<EImportMethod>(EImportMethod.Address);
   const {
-    activeAccount: { network },
-  } = useAccountSelectorTrigger({ num: 0 });
-  const { onPasteClearText } = useClipboard();
-  const onSubmitRef = useRef<
-    ((formContext: UseFormReturn<IFormValues>) => Promise<void>) | null
-  >(null);
-  const formOptions = useMemo(
-    () => ({
-      values: {
-        networkId:
-          network?.id && network.id !== getNetworkIdsMap().onekeyall
-            ? network?.id
-            : getNetworkIdsMap().btc,
-        deriveType: undefined,
-        publicKeyValue: '',
-        addressValue: { raw: '', resolved: undefined },
-        accountName: '',
-      },
-      mode: 'onChange' as IFormMode,
-      reValidateMode: 'onBlur' as IReValidateMode,
-      onSubmit: async (formContext: UseFormReturn<IFormValues>) => {
-        await onSubmitRef.current?.(formContext);
-      },
-    }),
-    [network?.id],
-  );
-  const form = useForm<IFormValues>(formOptions);
-
-  const { setValue, control } = form;
-  const [validateResult, setValidateResult] = useState<
-    IGeneralInputValidation | undefined
-  >();
-  const isValidating = useRef<boolean>(false);
-  const networkIdText = useFormWatch({ control, name: 'networkId' });
-  const inputText = useFormWatch({ control, name: 'publicKeyValue' });
-  const addressValue = useFormWatch({ control, name: 'addressValue' });
-  const accountName = useFormWatch({ control, name: 'accountName' });
-
-  const inputTextDebounced = useDebounce(inputText.trim(), 600);
-  const accountNameDebounced = useDebounce(accountName?.trim() || '', 600);
-
-  const validateFn = useCallback(async () => {
-    if (accountNameDebounced) {
-      try {
-        await backgroundApiProxy.serviceAccount.ensureAccountNameNotDuplicate({
-          name: accountNameDebounced,
-          walletId: WALLET_TYPE_WATCHING,
-        });
-        form.clearErrors('accountName');
-      } catch (error) {
-        form.setError('accountName', {
-          message: (error as Error)?.message,
-        });
-      }
-    } else {
-      form.clearErrors('accountName');
-    }
-
-    if (inputTextDebounced && networkIdText) {
-      const input =
-        await backgroundApiProxy.servicePassword.encodeSensitiveText({
-          text: inputTextDebounced,
-        });
-      try {
-        if (!networksResp.publicKeyExportEnabled.has(networkIdText)) {
-          throw new OneKeyLocalError(`Network not supported: ${networkIdText}`);
-        }
-        const result =
-          await backgroundApiProxy.serviceAccount.validateGeneralInputOfImporting(
-            {
-              input,
-              networkId: networkIdText,
-              validateXpub: true,
-            },
-          );
-        setValidateResult(result);
-        console.log('validateGeneralInputOfImporting result', result);
-      } catch (error) {
-        setValidateResult({
-          isValid: false,
-        });
-      }
-    } else {
-      setValidateResult(undefined);
-    }
-  }, [
-    accountNameDebounced,
+    form,
+    isEnable,
+    method,
+    setMethod,
+    networksResp,
+    isKeyExportEnabled,
+    isPublicKeyImport,
+    validateResult,
     inputTextDebounced,
     networkIdText,
-    form,
-    networksResp.publicKeyExportEnabled,
-  ]);
-
-  useEffect(() => {
-    void (async () => {
-      try {
-        isValidating.current = true;
-        await validateFn();
-      } finally {
-        isValidating.current = false;
-      }
-    })();
-  }, [validateFn]);
-
-  const { start } = useScanQrCode();
-
-  const deriveTypeValue = form.watch('deriveType');
-
-  const isEnable = useMemo(() => {
-    // filter out error parameters from different segments.
-
-    const errorsCount = Object.keys(form.formState.errors).reduce(
-      (count, name) => {
-        if (method === EImportMethod.PublicKey) {
-          return name !== 'addressValue' ? count + 1 : count;
-        }
-        if (method === EImportMethod.Address) {
-          return name !== 'publicKeyValue' ? count + 1 : count;
-        }
-        return count;
-      },
-      0,
-    );
-    if (errorsCount > 0) {
-      return false;
-    }
-    if (method === EImportMethod.Address) {
-      return !addressValue.pending && form.formState.isValid;
-    }
-    return validateResult?.isValid;
-  }, [method, addressValue.pending, validateResult, form.formState]);
-
-  const isKeyExportEnabled = useMemo(
-    () =>
-      networkIdText && networksResp.publicKeyExportEnabled.has(networkIdText),
-    [networkIdText, networksResp.publicKeyExportEnabled],
-  );
-
-  const { isSoftwareWalletOnlyUser } = useUserWalletProfile();
-  const isPublicKeyImport = useMemo(
-    () => method === EImportMethod.PublicKey && isKeyExportEnabled,
-    [method, isKeyExportEnabled],
-  );
-
-  onSubmitRef.current = useCallback(
-    async (formContext: UseFormReturn<IFormValues>) => {
-      const values = formContext.getValues();
-      const data: {
-        name?: string;
-        input: string;
-        networkId: string;
-        deriveType?: IAccountDeriveTypes;
-        shouldCheckDuplicateName?: boolean;
-      } = isPublicKeyImport
-        ? {
-            name: values.accountName,
-            input: values.publicKeyValue ?? '',
-            networkId: values.networkId ?? '',
-            deriveType: values.deriveType,
-            shouldCheckDuplicateName: true,
-          }
-        : {
-            name: values.accountName,
-            input: values.addressValue.resolved ?? '',
-            networkId: values.networkId ?? '',
-            shouldCheckDuplicateName: true,
-          };
-      const r = await backgroundApiProxy.serviceAccount.addWatchingAccount(
-        data,
-      );
-
-      const accountId = r?.accounts?.[0]?.id;
-      if (accountId) {
-        Toast.success({
-          title: intl.formatMessage({ id: ETranslations.global_success }),
-        });
-      }
-
-      void actions.current.updateSelectedAccountForSingletonAccount({
-        num: 0,
-        networkId: values.networkId,
-        walletId: WALLET_TYPE_WATCHING,
-        othersWalletAccountId: accountId,
-      });
-      navigation.popStack();
-
-      defaultLogger.account.wallet.walletAdded({
-        status: 'success',
-        addMethod: 'ImportWallet',
-        details: {
-          importType: 'address',
-        },
-        isSoftwareWalletOnlyUser,
-      });
-    },
-    [actions, intl, isPublicKeyImport, navigation, isSoftwareWalletOnlyUser],
-  );
+    deriveTypeValue,
+  } = useImportAddressForm({ onWalletAdded: handleWalletAdded });
 
   return (
     <Page scrollEnabled>
@@ -367,146 +37,18 @@ function ImportAddress() {
         title={intl.formatMessage({ id: ETranslations.global_import_address })}
       />
       <Page.Body px="$5">
-        <Form form={form}>
-          <Form.Field
-            label={intl.formatMessage({ id: ETranslations.global_network })}
-            name="networkId"
-          >
-            <ControlledNetworkSelectorTrigger
-              networkIds={networksResp.networkIds}
-            />
-          </Form.Field>
-
-          {isKeyExportEnabled ? (
-            <SegmentControl
-              fullWidth
-              value={method}
-              onChange={(v) => {
-                setMethod(v as EImportMethod);
-              }}
-              options={[
-                {
-                  label: intl.formatMessage({
-                    id: ETranslations.global_address,
-                  }),
-                  value: EImportMethod.Address,
-                  testID: 'import-address-address',
-                },
-                {
-                  label: intl.formatMessage({
-                    id: ETranslations.global_public_key,
-                  }),
-                  value: EImportMethod.PublicKey,
-                  testID: 'import-address-publicKey',
-                },
-              ]}
-            />
-          ) : null}
-          {isPublicKeyImport ? (
-            <>
-              <Form.Field
-                label={intl.formatMessage({
-                  id: ETranslations.global_public_key,
-                })}
-                name="publicKeyValue"
-              >
-                <Input
-                  secureTextEntry={false}
-                  placeholder={intl.formatMessage({
-                    id: ETranslations.form_public_key_placeholder,
-                  })}
-                  testID="import-address-input"
-                  size={media.gtMd ? 'medium' : 'large'}
-                  onPaste={onPasteClearText}
-                  addOns={[
-                    {
-                      iconName: 'ScanOutline',
-                      onPress: async () => {
-                        const result = await start({
-                          handlers: [],
-                          autoHandleResult: false,
-                        });
-                        form.setValue('publicKeyValue', result.raw);
-                      },
-                    },
-                  ]}
-                />
-              </Form.Field>
-              {validateResult?.deriveInfoItems ? (
-                <FormDeriveTypeInput
-                  fieldName="deriveType"
-                  networkId={form.getValues().networkId || ''}
-                  deriveInfoItems={validateResult?.deriveInfoItems || []}
-                />
-              ) : null}
-              <>
-                {validateResult &&
-                !validateResult?.isValid &&
-                inputTextDebounced ? (
-                  <SizableText size="$bodyMd" color="$textCritical">
-                    {intl.formatMessage({
-                      id: ETranslations.form_public_key_error_invalid,
-                    })}
-                  </SizableText>
-                ) : null}
-              </>
-            </>
-          ) : null}
-          {!isPublicKeyImport ? (
-            <>
-              <Form.Field
-                label={intl.formatMessage({ id: ETranslations.global_address })}
-                name="addressValue"
-                rules={{
-                  validate: createValidateAddressRule({
-                    defaultErrorMessage: intl.formatMessage({
-                      id: ETranslations.form_address_error_invalid,
-                    }),
-                  }),
-                }}
-              >
-                <AddressInput
-                  placeholder={intl.formatMessage({
-                    id: ETranslations.form_address_placeholder,
-                  })}
-                  networkId={networkIdText ?? ''}
-                  testID="import-address-input"
-                />
-              </Form.Field>
-            </>
-          ) : null}
-
-          <Form.Field
-            label={intl.formatMessage({
-              id: ETranslations.form_enter_account_name,
-            })}
-            name="accountName"
-          >
-            <Input
-              maxLength={MAX_LENGTH_ACCOUNT_NAME}
-              placeholder={intl.formatMessage({
-                id: ETranslations.form_enter_account_name_placeholder,
-              })}
-            />
-          </Form.Field>
-        </Form>
-        <Tutorials
-          list={[
-            {
-              title: intl.formatMessage({
-                id: ETranslations.faq_watched_account,
-              }),
-              description: intl.formatMessage({
-                id: ETranslations.faq_watched_account_desc,
-              }),
-            },
-          ]}
+        <ImportAddressCore
+          form={form}
+          method={method}
+          setMethod={setMethod}
+          networksResp={networksResp}
+          isKeyExportEnabled={isKeyExportEnabled}
+          isPublicKeyImport={isPublicKeyImport}
+          validateResult={validateResult}
+          inputTextDebounced={inputTextDebounced}
+          networkIdText={networkIdText}
+          deriveTypeValue={deriveTypeValue}
         />
-        {process.env.NODE_ENV !== 'production' ? (
-          <>
-            <SizableText>DEV-ONLY deriveType: {deriveTypeValue}</SizableText>
-          </>
-        ) : null}
       </Page.Body>
       <Page.Footer
         confirmButtonProps={{

--- a/packages/kit/src/views/Onboarding/pages/ImportWallet/ImportAddressCore.tsx
+++ b/packages/kit/src/views/Onboarding/pages/ImportWallet/ImportAddressCore.tsx
@@ -1,0 +1,276 @@
+import { useIntl } from 'react-intl';
+
+import type { UseFormReturn } from '@onekeyhq/components';
+import {
+  Form,
+  Icon,
+  Input,
+  SegmentControl,
+  SizableText,
+  Stack,
+  useClipboard,
+  useMedia,
+} from '@onekeyhq/components';
+import { ControlledNetworkSelectorTrigger } from '@onekeyhq/kit/src/components/AccountSelector';
+import { DeriveTypeSelectorFormInput } from '@onekeyhq/kit/src/components/AccountSelector/DeriveTypeSelectorTrigger';
+import {
+  AddressInput,
+  createValidateAddressRule,
+} from '@onekeyhq/kit/src/components/AddressInput';
+import { MAX_LENGTH_ACCOUNT_NAME } from '@onekeyhq/kit/src/components/RenameDialog/renameConsts';
+import useScanQrCode from '@onekeyhq/kit/src/views/ScanQrCode/hooks/useScanQrCode';
+import type { IAccountDeriveInfo } from '@onekeyhq/kit-bg/src/vaults/types';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+
+import { Tutorials } from '../../components';
+
+import { EImportMethod } from './hooks/useImportAddressForm';
+
+import type { IFormValues } from './hooks/useImportAddressForm';
+
+const FormDeriveTypeInput = ({
+  networkId,
+  deriveInfoItems,
+  fieldName,
+}: {
+  fieldName: string;
+  networkId: string;
+  deriveInfoItems: IAccountDeriveInfo[];
+}) => {
+  const intl = useIntl();
+  return (
+    <Stack mt="$2">
+      <Form.Field
+        label={intl.formatMessage({
+          id: ETranslations.derivation_path,
+        })}
+        name={fieldName}
+      >
+        <DeriveTypeSelectorFormInput
+          networkId={networkId}
+          enabledItems={deriveInfoItems}
+          undefinedResultIfReRun={false}
+          renderTrigger={({ label, onPress }) => (
+            <Stack
+              testID="derive-type-input"
+              userSelect="none"
+              flexDirection="row"
+              px="$3.5"
+              py="$2.5"
+              borderWidth={1}
+              borderColor="$borderStrong"
+              borderRadius="$3"
+              $gtMd={{
+                px: '$3',
+                py: '$1.5',
+                borderRadius: '$2',
+              }}
+              borderCurve="continuous"
+              hoverStyle={{
+                bg: '$bgHover',
+              }}
+              pressStyle={{
+                bg: '$bgActive',
+              }}
+              onPress={onPress}
+            >
+              <SizableText flex={1}>{label}</SizableText>
+              <Icon
+                name="ChevronDownSmallOutline"
+                color="$iconSubdued"
+                mr="$-0.5"
+              />
+            </Stack>
+          )}
+        />
+      </Form.Field>
+    </Stack>
+  );
+};
+
+interface IImportAddressCoreProps {
+  form: UseFormReturn<IFormValues>;
+  method: EImportMethod;
+  setMethod: (method: EImportMethod) => void;
+  networksResp: {
+    networkIds: string[];
+    publicKeyExportEnabled: Set<string>;
+    watchingAccountEnabled: Set<string>;
+  };
+  isKeyExportEnabled: boolean;
+  isPublicKeyImport: boolean;
+  validateResult?: {
+    isValid: boolean;
+    deriveInfoItems?: IAccountDeriveInfo[];
+  };
+  inputTextDebounced: string;
+  networkIdText?: string;
+  deriveTypeValue?: any;
+}
+
+function ImportAddressCore({
+  form,
+  method,
+  setMethod,
+  networksResp,
+  isKeyExportEnabled,
+  isPublicKeyImport,
+  validateResult,
+  inputTextDebounced,
+  networkIdText,
+  deriveTypeValue,
+}: IImportAddressCoreProps) {
+  const intl = useIntl();
+  const media = useMedia();
+  const { onPasteClearText } = useClipboard();
+  const { start } = useScanQrCode();
+
+  return (
+    <Stack flex={1} gap="$4">
+      <Form form={form}>
+        <Form.Field
+          label={intl.formatMessage({ id: ETranslations.global_network })}
+          name="networkId"
+        >
+          <ControlledNetworkSelectorTrigger
+            networkIds={networksResp.networkIds}
+          />
+        </Form.Field>
+
+        {isKeyExportEnabled ? (
+          <SegmentControl
+            fullWidth
+            value={method}
+            onChange={(v) => {
+              setMethod(v as EImportMethod);
+            }}
+            options={[
+              {
+                label: intl.formatMessage({
+                  id: ETranslations.global_address,
+                }),
+                value: EImportMethod.Address,
+                testID: 'import-address-address',
+              },
+              {
+                label: intl.formatMessage({
+                  id: ETranslations.global_public_key,
+                }),
+                value: EImportMethod.PublicKey,
+                testID: 'import-address-publicKey',
+              },
+            ]}
+          />
+        ) : null}
+        {isPublicKeyImport ? (
+          <>
+            <Form.Field
+              label={intl.formatMessage({
+                id: ETranslations.global_public_key,
+              })}
+              name="publicKeyValue"
+            >
+              <Input
+                secureTextEntry={false}
+                placeholder={intl.formatMessage({
+                  id: ETranslations.form_public_key_placeholder,
+                })}
+                testID="import-address-input"
+                size={media.gtMd ? 'medium' : 'large'}
+                onPaste={onPasteClearText}
+                addOns={[
+                  {
+                    iconName: 'ScanOutline',
+                    onPress: async () => {
+                      const result = await start({
+                        handlers: [],
+                        autoHandleResult: false,
+                      });
+                      form.setValue('publicKeyValue', result.raw);
+                    },
+                  },
+                ]}
+              />
+            </Form.Field>
+            {validateResult?.deriveInfoItems ? (
+              <FormDeriveTypeInput
+                fieldName="deriveType"
+                networkId={form.getValues().networkId || ''}
+                deriveInfoItems={validateResult?.deriveInfoItems || []}
+              />
+            ) : null}
+            <>
+              {validateResult &&
+              !validateResult?.isValid &&
+              inputTextDebounced ? (
+                <SizableText size="$bodyMd" color="$textCritical">
+                  {intl.formatMessage({
+                    id: ETranslations.form_public_key_error_invalid,
+                  })}
+                </SizableText>
+              ) : null}
+            </>
+          </>
+        ) : null}
+        {!isPublicKeyImport ? (
+          <>
+            <Form.Field
+              label={intl.formatMessage({ id: ETranslations.global_address })}
+              name="addressValue"
+              rules={{
+                validate: createValidateAddressRule({
+                  defaultErrorMessage: intl.formatMessage({
+                    id: ETranslations.form_address_error_invalid,
+                  }),
+                }),
+              }}
+            >
+              <AddressInput
+                placeholder={intl.formatMessage({
+                  id: ETranslations.form_address_placeholder,
+                })}
+                networkId={networkIdText ?? ''}
+                testID="import-address-input"
+              />
+            </Form.Field>
+          </>
+        ) : null}
+
+        <Form.Field
+          label={intl.formatMessage({
+            id: ETranslations.form_enter_account_name,
+          })}
+          name="accountName"
+        >
+          <Input
+            maxLength={MAX_LENGTH_ACCOUNT_NAME}
+            placeholder={intl.formatMessage({
+              id: ETranslations.form_enter_account_name_placeholder,
+            })}
+          />
+        </Form.Field>
+      </Form>
+      <Tutorials
+        list={[
+          {
+            title: intl.formatMessage({
+              id: ETranslations.faq_watched_account,
+            }),
+            description: intl.formatMessage({
+              id: ETranslations.faq_watched_account_desc,
+            }),
+          },
+        ]}
+      />
+
+      {process.env.NODE_ENV !== 'production' ? (
+        <>
+          <SizableText>DEV-ONLY deriveType: {deriveTypeValue}</SizableText>
+        </>
+      ) : null}
+    </Stack>
+  );
+}
+
+export { ImportAddressCore };
+export type { IImportAddressCoreProps };

--- a/packages/kit/src/views/Onboarding/pages/ImportWallet/hooks/useImportAddressForm.ts
+++ b/packages/kit/src/views/Onboarding/pages/ImportWallet/hooks/useImportAddressForm.ts
@@ -1,0 +1,287 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import type {
+  IFormMode,
+  IReValidateMode,
+  UseFormReturn,
+} from '@onekeyhq/components';
+import { Toast, useForm, useFormWatch } from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { useAccountSelectorTrigger } from '@onekeyhq/kit/src/components/AccountSelector/hooks/useAccountSelectorTrigger';
+import type { IAddressInputValue } from '@onekeyhq/kit/src/components/AddressInput';
+import { useDebounce } from '@onekeyhq/kit/src/hooks/useDebounce';
+import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { useUserWalletProfile } from '@onekeyhq/kit/src/hooks/useUserWalletProfile';
+import { useAccountSelectorActions } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
+import type { IAccountDeriveTypes } from '@onekeyhq/kit-bg/src/vaults/types';
+import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
+import { WALLET_TYPE_WATCHING } from '@onekeyhq/shared/src/consts/dbConsts';
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import type { IGeneralInputValidation } from '@onekeyhq/shared/types/address';
+
+export type IFormValues = {
+  networkId?: string;
+  deriveType?: IAccountDeriveTypes;
+  publicKeyValue: string;
+  addressValue: IAddressInputValue;
+  accountName?: string;
+};
+
+export enum EImportMethod {
+  Address = 'Address',
+  PublicKey = 'PublicKey',
+}
+
+interface IUseImportAddressFormProps {
+  onWalletAdded?: () => void;
+}
+
+export function useImportAddressForm({
+  onWalletAdded,
+}: IUseImportAddressFormProps) {
+  const intl = useIntl();
+
+  const { result: networksResp } = usePromiseResult(
+    async () => {
+      const resp =
+        await backgroundApiProxy.serviceNetwork.getPublicKeyExportOrWatchingAccountEnabledNetworks();
+      const networkIds = resp.map((o) => o.network.id);
+      const publicKeyExportEnabledNetworkIds = resp
+        .filter((o) => o.publicKeyExportEnabled)
+        .map((t) => t.network.id);
+
+      const watchingAccountEnabledNetworkIds = resp
+        .filter((o) => o.watchingAccountEnabled)
+        .map((t) => t.network.id);
+      return {
+        networkIds,
+        publicKeyExportEnabled: new Set(publicKeyExportEnabledNetworkIds),
+        watchingAccountEnabled: new Set(watchingAccountEnabledNetworkIds),
+      };
+    },
+    [],
+    {
+      initResult: {
+        networkIds: [],
+        publicKeyExportEnabled: new Set([]),
+        watchingAccountEnabled: new Set([]),
+      },
+    },
+  );
+
+  const actions = useAccountSelectorActions();
+  const [method, setMethod] = useState<EImportMethod>(EImportMethod.Address);
+  const {
+    activeAccount: { network },
+  } = useAccountSelectorTrigger({ num: 0 });
+  const onSubmitRef = useRef<
+    ((formContext: UseFormReturn<IFormValues>) => Promise<void>) | null
+  >(null);
+
+  const formOptions = useMemo(
+    () => ({
+      values: {
+        networkId:
+          network?.id && network.id !== getNetworkIdsMap().onekeyall
+            ? network?.id
+            : getNetworkIdsMap().btc,
+        deriveType: undefined,
+        publicKeyValue: '',
+        addressValue: { raw: '', resolved: undefined },
+        accountName: '',
+      },
+      mode: 'onChange' as IFormMode,
+      reValidateMode: 'onBlur' as IReValidateMode,
+      onSubmit: async (formContext: UseFormReturn<IFormValues>) => {
+        await onSubmitRef.current?.(formContext);
+      },
+    }),
+    [network?.id],
+  );
+
+  const form = useForm<IFormValues>(formOptions);
+  const { control } = form;
+
+  const [validateResult, setValidateResult] = useState<
+    IGeneralInputValidation | undefined
+  >();
+  const isValidating = useRef<boolean>(false);
+  const networkIdText = useFormWatch({ control, name: 'networkId' });
+  const inputText = useFormWatch({ control, name: 'publicKeyValue' });
+  const addressValue = useFormWatch({ control, name: 'addressValue' });
+  const accountName = useFormWatch({ control, name: 'accountName' });
+
+  const inputTextDebounced = useDebounce(inputText.trim(), 600);
+  const accountNameDebounced = useDebounce(accountName?.trim() || '', 600);
+
+  const validateFn = useCallback(async () => {
+    if (accountNameDebounced) {
+      try {
+        await backgroundApiProxy.serviceAccount.ensureAccountNameNotDuplicate({
+          name: accountNameDebounced,
+          walletId: WALLET_TYPE_WATCHING,
+        });
+        form.clearErrors('accountName');
+      } catch (error) {
+        form.setError('accountName', {
+          message: (error as Error)?.message,
+        });
+      }
+    } else {
+      form.clearErrors('accountName');
+    }
+
+    if (inputTextDebounced && networkIdText) {
+      const input =
+        await backgroundApiProxy.servicePassword.encodeSensitiveText({
+          text: inputTextDebounced,
+        });
+      try {
+        if (!networksResp.publicKeyExportEnabled.has(networkIdText)) {
+          throw new OneKeyLocalError(`Network not supported: ${networkIdText}`);
+        }
+        const result =
+          await backgroundApiProxy.serviceAccount.validateGeneralInputOfImporting(
+            {
+              input,
+              networkId: networkIdText,
+              validateXpub: true,
+            },
+          );
+        setValidateResult(result);
+      } catch (error) {
+        setValidateResult({
+          isValid: false,
+        });
+      }
+    } else {
+      setValidateResult(undefined);
+    }
+  }, [
+    accountNameDebounced,
+    inputTextDebounced,
+    networkIdText,
+    form,
+    networksResp.publicKeyExportEnabled,
+  ]);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        isValidating.current = true;
+        await validateFn();
+      } finally {
+        isValidating.current = false;
+      }
+    })();
+  }, [validateFn]);
+
+  const isEnable = useMemo(() => {
+    const errorsCount = Object.keys(form.formState.errors).reduce(
+      (count, name) => {
+        if (method === EImportMethod.PublicKey) {
+          return name !== 'addressValue' ? count + 1 : count;
+        }
+        if (method === EImportMethod.Address) {
+          return name !== 'publicKeyValue' ? count + 1 : count;
+        }
+        return count;
+      },
+      0,
+    );
+    if (errorsCount > 0) {
+      return false;
+    }
+    if (method === EImportMethod.Address) {
+      return !addressValue.pending && form.formState.isValid;
+    }
+    return validateResult?.isValid ?? false;
+  }, [method, addressValue.pending, validateResult, form.formState]);
+
+  const isKeyExportEnabled = useMemo(
+    () =>
+      Boolean(
+        networkIdText && networksResp.publicKeyExportEnabled.has(networkIdText),
+      ),
+    [networkIdText, networksResp.publicKeyExportEnabled],
+  );
+
+  const { isSoftwareWalletOnlyUser } = useUserWalletProfile();
+  const isPublicKeyImport = useMemo(
+    () => method === EImportMethod.PublicKey && isKeyExportEnabled,
+    [method, isKeyExportEnabled],
+  );
+
+  onSubmitRef.current = useCallback(
+    async (formContext: UseFormReturn<IFormValues>) => {
+      const values = formContext.getValues();
+      const data: {
+        name?: string;
+        input: string;
+        networkId: string;
+        deriveType?: IAccountDeriveTypes;
+        shouldCheckDuplicateName?: boolean;
+      } = isPublicKeyImport
+        ? {
+            name: values.accountName,
+            input: values.publicKeyValue ?? '',
+            networkId: values.networkId ?? '',
+            deriveType: values.deriveType,
+            shouldCheckDuplicateName: true,
+          }
+        : {
+            name: values.accountName,
+            input: values.addressValue.resolved ?? '',
+            networkId: values.networkId ?? '',
+            shouldCheckDuplicateName: true,
+          };
+      const r = await backgroundApiProxy.serviceAccount.addWatchingAccount(
+        data,
+      );
+
+      const accountId = r?.accounts?.[0]?.id;
+      if (accountId) {
+        Toast.success({
+          title: intl.formatMessage({ id: ETranslations.global_success }),
+        });
+      }
+
+      void actions.current.updateSelectedAccountForSingletonAccount({
+        num: 0,
+        networkId: values.networkId,
+        walletId: WALLET_TYPE_WATCHING,
+        othersWalletAccountId: accountId,
+      });
+
+      defaultLogger.account.wallet.walletAdded({
+        status: 'success',
+        addMethod: 'ImportWallet',
+        details: {
+          importType: 'address',
+        },
+        isSoftwareWalletOnlyUser,
+      });
+
+      onWalletAdded?.();
+    },
+    [actions, intl, isPublicKeyImport, isSoftwareWalletOnlyUser, onWalletAdded],
+  );
+
+  return {
+    form,
+    isEnable,
+    method,
+    setMethod,
+    networksResp,
+    isKeyExportEnabled,
+    isPublicKeyImport,
+    validateResult,
+    inputTextDebounced,
+    networkIdText,
+    deriveTypeValue: form.watch('deriveType'),
+  };
+}

--- a/packages/shared/src/locale/enum/translations.ts
+++ b/packages/shared/src/locale/enum/translations.ts
@@ -1571,6 +1571,7 @@
   global_warning = 'global.warning',
   global_watch_only = 'global.watch_only',
   global_watch_only_address = 'global.watch_only_address',
+  global_watch_only_wallet = 'global.watch_only_wallet',
   global_watched = 'global.watched',
   global_watchlist = 'global.watchlist',
   global_website = 'global.website',

--- a/packages/shared/src/locale/json/bn.json
+++ b/packages/shared/src/locale/json/bn.json
@@ -1566,6 +1566,7 @@
   "global.warning": "সতর্কতা",
   "global.watch_only": "শুধুমাত্র দেখুন",
   "global.watch_only_address": "শুধুমাত্র-দেখার ঠিকানা",
+  "global.watch_only_wallet": "শুধুমাত্র দেখার জন্য ওয়ালেট",
   "global.watched": "দেখা হয়েছে",
   "global.watchlist": "নজরতালিকা",
   "global.website": "ওয়েবসাইট",

--- a/packages/shared/src/locale/json/de.json
+++ b/packages/shared/src/locale/json/de.json
@@ -1566,6 +1566,7 @@
   "global.warning": "Warnung",
   "global.watch_only": "Nur ansehen",
   "global.watch_only_address": "Nur-Anzeige-Adresse",
+  "global.watch_only_wallet": "Watch-Only Wallet",
   "global.watched": "Gesehen",
   "global.watchlist": "Beobachtungsliste",
   "global.website": "Webseite",

--- a/packages/shared/src/locale/json/en_US.json
+++ b/packages/shared/src/locale/json/en_US.json
@@ -1566,6 +1566,7 @@
   "global.warning": "Warning",
   "global.watch_only": "Watch only",
   "global.watch_only_address": "Watch-only address",
+  "global.watch_only_wallet": "Watch-only wallet",
   "global.watched": "Watch-Only",
   "global.watchlist": "Watchlist",
   "global.website": "Website",

--- a/packages/shared/src/locale/json/es.json
+++ b/packages/shared/src/locale/json/es.json
@@ -1566,6 +1566,7 @@
   "global.warning": "Advertencia",
   "global.watch_only": "Solo reloj",
   "global.watch_only_address": "Dirección de solo visualización",
+  "global.watch_only_wallet": "Cartera de solo visualización",
   "global.watched": "Visto",
   "global.watchlist": "Lista de seguimiento",
   "global.website": "Sitio web",

--- a/packages/shared/src/locale/json/fr_FR.json
+++ b/packages/shared/src/locale/json/fr_FR.json
@@ -1566,6 +1566,7 @@
   "global.warning": "Avertissement",
   "global.watch_only": "Lecture seule",
   "global.watch_only_address": "Adresse en lecture seule",
+  "global.watch_only_wallet": "Portefeuille en lecture seule",
   "global.watched": "Regardé",
   "global.watchlist": "Liste de surveillance",
   "global.website": "Site web",

--- a/packages/shared/src/locale/json/hi_IN.json
+++ b/packages/shared/src/locale/json/hi_IN.json
@@ -1566,6 +1566,7 @@
   "global.warning": "चेतावनी",
   "global.watch_only": "केवल देखें",
   "global.watch_only_address": "केवल-दर्शन पता",
+  "global.watch_only_wallet": "केवल देखने वाला वॉलेट",
   "global.watched": "देखा",
   "global.watchlist": "वॉचलिस्ट",
   "global.website": "वेबसाइट",

--- a/packages/shared/src/locale/json/id.json
+++ b/packages/shared/src/locale/json/id.json
@@ -1566,6 +1566,7 @@
   "global.warning": "Peringatan",
   "global.watch_only": "Hanya menonton",
   "global.watch_only_address": "Alamat hanya-tonton",
+  "global.watch_only_wallet": "Dompet Pantau",
   "global.watched": "Ditonton",
   "global.watchlist": "Daftar Pantauan",
   "global.website": "Situs web",

--- a/packages/shared/src/locale/json/it_IT.json
+++ b/packages/shared/src/locale/json/it_IT.json
@@ -1566,6 +1566,7 @@
   "global.warning": "Avvertimento",
   "global.watch_only": "Solo guardare",
   "global.watch_only_address": "Indirizzo solo visualizzazione",
+  "global.watch_only_wallet": "Portafoglio di sola visualizzazione",
   "global.watched": "Visto",
   "global.watchlist": "Lista di controllo",
   "global.website": "Sito web",

--- a/packages/shared/src/locale/json/ja_JP.json
+++ b/packages/shared/src/locale/json/ja_JP.json
@@ -1566,6 +1566,7 @@
   "global.warning": "警告",
   "global.watch_only": "ウォッチのみ",
   "global.watch_only_address": "ウォッチ専用アドレス",
+  "global.watch_only_wallet": "閲覧専用ウォレット",
   "global.watched": "視聴済み",
   "global.watchlist": "ウォッチリスト",
   "global.website": "ウェブサイト",

--- a/packages/shared/src/locale/json/ko_KR.json
+++ b/packages/shared/src/locale/json/ko_KR.json
@@ -1566,6 +1566,7 @@
   "global.warning": "경고",
   "global.watch_only": "시청 전용",
   "global.watch_only_address": "조회 전용 주소",
+  "global.watch_only_wallet": "관찰 전용 지갑",
   "global.watched": "시청함",
   "global.watchlist": "관심목록",
   "global.website": "웹사이트",

--- a/packages/shared/src/locale/json/pt.json
+++ b/packages/shared/src/locale/json/pt.json
@@ -1566,6 +1566,7 @@
   "global.warning": "Aviso",
   "global.watch_only": "Apenas visualização",
   "global.watch_only_address": "Endereço apenas para visualização",
+  "global.watch_only_wallet": "Carteira somente de observação",
   "global.watched": "Assistido",
   "global.watchlist": "Lista de observação",
   "global.website": "Website",

--- a/packages/shared/src/locale/json/pt_BR.json
+++ b/packages/shared/src/locale/json/pt_BR.json
@@ -1566,6 +1566,7 @@
   "global.warning": "Aviso",
   "global.watch_only": "Somente visualização",
   "global.watch_only_address": "Endereço apenas para visualização",
+  "global.watch_only_wallet": "Carteira somente de observação",
   "global.watched": "Assistido",
   "global.watchlist": "Lista de observação",
   "global.website": "Site",

--- a/packages/shared/src/locale/json/ru.json
+++ b/packages/shared/src/locale/json/ru.json
@@ -1566,6 +1566,7 @@
   "global.warning": "Предупреждение",
   "global.watch_only": "Только смотреть",
   "global.watch_only_address": "Адрес только для просмотра",
+  "global.watch_only_wallet": "Кошелек только для просмотра",
   "global.watched": "Просмотрено",
   "global.watchlist": "Список наблюдения",
   "global.website": "Веб-сайт",

--- a/packages/shared/src/locale/json/th_TH.json
+++ b/packages/shared/src/locale/json/th_TH.json
@@ -1566,6 +1566,7 @@
   "global.warning": "คำเตือน",
   "global.watch_only": "ดูเท่านั้น",
   "global.watch_only_address": "ที่อยู่สำหรับดูเท่านั้น",
+  "global.watch_only_wallet": "กระเป๋าเงินแบบดูเท่านั้น",
   "global.watched": "ดูแล้ว",
   "global.watchlist": "รายการที่ติดตาม",
   "global.website": "เว็บไซต์",

--- a/packages/shared/src/locale/json/uk_UA.json
+++ b/packages/shared/src/locale/json/uk_UA.json
@@ -1566,6 +1566,7 @@
   "global.warning": "УВАГА",
   "global.watch_only": "Тільки перегляд",
   "global.watch_only_address": "Адреса лише для перегляду",
+  "global.watch_only_wallet": "Гаманець лише для перегляду",
   "global.watched": "Переглянуто",
   "global.watchlist": "Список спостереження",
   "global.website": "Вебсайт",

--- a/packages/shared/src/locale/json/vi.json
+++ b/packages/shared/src/locale/json/vi.json
@@ -1566,6 +1566,7 @@
   "global.warning": "Cảnh báo",
   "global.watch_only": "Chỉ xem",
   "global.watch_only_address": "Địa chỉ chỉ xem",
+  "global.watch_only_wallet": "Ví chỉ xem",
   "global.watched": "Đã xem",
   "global.watchlist": "Danh sách theo dõi",
   "global.website": "Trang web",

--- a/packages/shared/src/locale/json/zh_CN.json
+++ b/packages/shared/src/locale/json/zh_CN.json
@@ -1566,6 +1566,7 @@
   "global.warning": "警告",
   "global.watch_only": "仅观察",
   "global.watch_only_address": "观察地址",
+  "global.watch_only_wallet": "观察钱包",
   "global.watched": "观察钱包",
   "global.watchlist": "观察列表",
   "global.website": "网站",

--- a/packages/shared/src/locale/json/zh_HK.json
+++ b/packages/shared/src/locale/json/zh_HK.json
@@ -1566,6 +1566,7 @@
   "global.warning": "警告",
   "global.watch_only": "僅觀察",
   "global.watch_only_address": "觀察地址",
+  "global.watch_only_wallet": "觀察錢包",
   "global.watched": "觀察帳戶",
   "global.watchlist": "觀察清單",
   "global.website": "網站",

--- a/packages/shared/src/locale/json/zh_TW.json
+++ b/packages/shared/src/locale/json/zh_TW.json
@@ -1566,6 +1566,7 @@
   "global.warning": "警告",
   "global.watch_only": "僅觀察",
   "global.watch_only_address": "觀察地址",
+  "global.watch_only_wallet": "觀察錢包",
   "global.watched": "觀察帳戶",
   "global.watchlist": "觀察清單",
   "global.website": "網站",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Watch-only wallet support in connect/onboarding: import by address or public key (QR scan, network selection, derivation options) and added watch-only entry in mobile connection list.
  * Desktop: three-tab Connect view (OneKey, Others, Watch-Only).

* **Refactor**
  * Import/address form logic moved to a dedicated hook and core UI for simpler validation and faster wallet-add flow.
  * Connect modal reorganized to a compositional structure and updated navigation to return after wallet addition.

* **Style/Docs**
  * Added translation key for watch-only wallet and a tabs demo showcasing index-change behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->