### PR TITLE
OK-41921: add showConnectWalletModalInDappMode prop to AccountSelector

### DIFF
--- a/packages/kit/src/components/AccountSelector/AccountSelectorTrigger/AccountSelectorTriggerBase.tsx
+++ b/packages/kit/src/components/AccountSelector/AccountSelectorTrigger/AccountSelectorTriggerBase.tsx
@@ -21,6 +21,7 @@ export function AccountSelectorTriggerBase({
   horizontalLayout,
   showWalletAvatar,
   showWalletName = true,
+  showConnectWalletModalInDappMode,
   ...others
 }: {
   num: number;
@@ -29,11 +30,16 @@ export function AccountSelectorTriggerBase({
   horizontalLayout?: boolean;
   showWalletAvatar?: boolean;
   showWalletName?: boolean;
+  showConnectWalletModalInDappMode?: boolean;
 } & IAccountSelectorRouteParamsExtraConfig) {
   const {
     activeAccount: { account, dbAccount, indexedAccount, accountName, wallet },
     showAccountSelector,
-  } = useAccountSelectorTrigger({ num, ...others });
+  } = useAccountSelectorTrigger({
+    num,
+    showConnectWalletModalInDappMode,
+    ...others,
+  });
   const intl = useIntl();
   const walletName =
     wallet?.name || intl.formatMessage({ id: ETranslations.global_no_wallet });

--- a/packages/kit/src/components/AccountSelector/AccountSelectorTrigger/AccountSelectorTriggerHome.tsx
+++ b/packages/kit/src/components/AccountSelector/AccountSelectorTrigger/AccountSelectorTriggerHome.tsx
@@ -34,6 +34,7 @@ export function AccountSelectorTriggerHome({
       keepAllOtherAccounts
       allowSelectEmptyAccount
       spotlightProps={spotlightProps}
+      showConnectWalletModalInDappMode
     />
   );
 }

--- a/packages/kit/src/components/AccountSelector/hooks/useAccountSelectorTrigger.tsx
+++ b/packages/kit/src/components/AccountSelector/hooks/useAccountSelectorTrigger.tsx
@@ -12,9 +12,11 @@ import {
 
 export function useAccountSelectorTrigger({
   num,
+  showConnectWalletModalInDappMode,
   ...others
 }: {
   num: number;
+  showConnectWalletModalInDappMode?: boolean;
 } & IAccountSelectorRouteParamsExtraConfig) {
   const navigation = useAppNavigation();
   const { activeAccount } = useActiveAccount({ num });
@@ -39,6 +41,7 @@ export function useAccountSelectorTrigger({
       navigation,
       sceneName,
       sceneUrl,
+      showConnectWalletModalInDappMode,
       ...others,
     });
   }, [
@@ -49,6 +52,7 @@ export function useAccountSelectorTrigger({
     num,
     sceneName,
     sceneUrl,
+    showConnectWalletModalInDappMode,
   ]);
 
   return {

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -532,9 +532,11 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
         num,
         sceneName,
         sceneUrl,
+        showConnectWalletModalInDappMode,
         ...others
       }: {
         navigation: ReturnType<typeof useAppNavigation>;
+        showConnectWalletModalInDappMode?: boolean;
       } & IAccountSelectorRouteParams &
         IAccountSelectorRouteParamsExtraConfig,
     ) => {
@@ -546,13 +548,18 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
 
       const activeAccountInfo = this.getActiveAccount.call(set, { num });
 
-      // In dapp mode, if no wallet exists, directly show connect wallet options
+      // In dapp mode, if no wallet exists, conditionally show connect wallet options
       const isWebDappMode = platformEnv.isWebDappMode;
       const hasWallet = activeAccountInfo?.wallet?.id;
       const hasAccount =
         activeAccountInfo?.account || activeAccountInfo?.indexedAccount;
 
-      if (isWebDappMode && !hasWallet && !hasAccount) {
+      if (
+        isWebDappMode &&
+        !hasWallet &&
+        !hasAccount &&
+        showConnectWalletModalInDappMode
+      ) {
         navigation.pushModal(EModalRoutes.OnboardingModal, {
           screen: EOnboardingPages.ConnectWalletOptions,
         });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an option to control whether the “Connect Wallet” modal appears in Dapp mode when no wallet/account is present.
  - Account selection triggers now respect this flag across relevant screens.
- Bug Fixes
  - Prevents unintended display of the “Connect Wallet” modal in Dapp mode by showing it only when explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->