### PR TITLE
fix: some market dex wrapped issue OK-41953 OK-41954 OK-41955

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.tsx
@@ -106,6 +106,7 @@ export function SwapPanelContent(props: ISwapPanelContentProps) {
 
   useEffect(() => {
     if (
+      new BigNumber(paymentAmountRef.current?.toFixed()).gt(0) &&
       !validateAmountInput(
         paymentAmountRef.current?.toFixed(),
         balanceToken?.decimals,
@@ -179,11 +180,13 @@ export function SwapPanelContent(props: ISwapPanelContentProps) {
       )}
 
       {/* Slippage setting */}
-      <SlippageSetting
-        autoDefaultValue={slippageAutoValue}
-        isMEV={swapMevNetConfig?.includes(swapPanel.networkId ?? '')}
-        onSlippageChange={(item) => setSlippage(item.value)}
-      />
+      {isWrapped ? null : (
+        <SlippageSetting
+          autoDefaultValue={slippageAutoValue}
+          isMEV={swapMevNetConfig?.includes(swapPanel.networkId ?? '')}
+          onSlippageChange={(item) => setSlippage(item.value)}
+        />
+      )}
     </YStack>
   );
 }

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx
@@ -150,6 +150,12 @@ export function ActionButton({
     })`;
   }
 
+  if (isWrapped) {
+    buttonText = intl.formatMessage({
+      id: ETranslations.swap_page_button_wrap,
+    });
+  }
+
   if (shouldDisable) {
     buttonText = intl.formatMessage({
       id: ETranslations.swap_page_button_insufficient_balance,
@@ -159,12 +165,6 @@ export function ActionButton({
   if (!hasAmount) {
     buttonText = intl.formatMessage({
       id: ETranslations.swap_page_button_enter_amount,
-    });
-  }
-
-  if (isWrapped) {
-    buttonText = intl.formatMessage({
-      id: ETranslations.swap_page_button_wrap,
     });
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevent unintended rounding adjustments until a positive amount is entered.
  - Hide slippage settings when performing a wrap to avoid irrelevant options.
  - Improve action button label priority: “Enter amount” when missing, “Wrap” when applicable, and “Insufficient balance” when disabled.
  - Clarifies edge-case messaging for more predictable, guided interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->