### PR TITLE
fix: remove tradingview gesture

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -128,7 +128,7 @@ export function MobileLayout() {
                   <InformationPanel />
                   <Stack
                     h={350}
-                    ref={tradingViewContainerRef}
+                    // ref={tradingViewContainerRef}
                     position="relative"
                     pointerEvents={
                       platformEnv.isNative ? pointerEvents : undefined

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 
+import { noop } from 'lodash';
 import { useIntl } from 'react-intl';
 import { Dimensions } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
@@ -71,11 +72,11 @@ export function MobileLayout() {
     [focusedTab, tabNames, width],
   );
 
-  const [pointerEvents, setPointerEvents] =
-    useState<IStackProps['pointerEvents']>('none');
+  // const [pointerEvents, setPointerEvents] =
+  //   useState<IStackProps['pointerEvents']>('none');
 
-  const pointerEventsSharedValue = useSharedValue(pointerEvents);
-  pointerEventsSharedValue.value = pointerEvents;
+  // const pointerEventsSharedValue = useSharedValue(pointerEvents);
+  // pointerEventsSharedValue.value = pointerEvents;
 
   // const tradingViewContainerRef = useRef<View>(null);
   // const tradingViewPositionSharedValue = useSharedValue({
@@ -108,13 +109,13 @@ export function MobileLayout() {
   //   });
   // }, [pointerEventsSharedValue, tradingViewPositionSharedValue]);
 
-  const setPointerEventsToNone = useCallback(() => {
-    if (platformEnv.isNative) {
-      if (pointerEventsSharedValue.value !== 'none') {
-        setPointerEvents('none');
-      }
-    }
-  }, [pointerEventsSharedValue]);
+  // const setPointerEventsToNone = useCallback(() => {
+  //   if (platformEnv.isNative) {
+  //     if (pointerEventsSharedValue.value !== 'none') {
+  //       setPointerEvents('none');
+  //     }
+  //   }
+  // }, [pointerEventsSharedValue]);
 
   const renderItem = useCallback(
     ({ index }: { index: number }) => {
@@ -122,7 +123,8 @@ export function MobileLayout() {
         return (
           <YStack flex={1} height={height}>
             <MobileInformationTabs
-              onScrollEnd={setPointerEventsToNone}
+              // onScrollEnd={setPointerEventsToNone}
+              onScrollEnd={noop}
               renderHeader={() => (
                 <YStack bg="$bgApp" pointerEvents="box-none">
                   <InformationPanel />
@@ -130,9 +132,9 @@ export function MobileLayout() {
                     h={350}
                     // ref={tradingViewContainerRef}
                     position="relative"
-                    pointerEvents={
-                      platformEnv.isNative ? pointerEvents : undefined
-                    }
+                    // pointerEvents={
+                    //   platformEnv.isNative ? pointerEvents : undefined
+                    // }
                     // onLayout={handleTradingViewContainerLayout}
                   >
                     <MarketTradingView
@@ -160,14 +162,7 @@ export function MobileLayout() {
         </YStack>
       );
     },
-    [
-      height,
-      networkId,
-      pointerEvents,
-      setPointerEventsToNone,
-      tokenAddress,
-      tokenDetail?.symbol,
-    ],
+    [height, networkId, tokenAddress, tokenDetail?.symbol],
   );
 
   return (

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -77,36 +77,36 @@ export function MobileLayout() {
   const pointerEventsSharedValue = useSharedValue(pointerEvents);
   pointerEventsSharedValue.value = pointerEvents;
 
-  const tradingViewContainerRef = useRef<View>(null);
-  const tradingViewPositionSharedValue = useSharedValue({
-    minY: 255,
-    maxY: 605,
-  });
+  // const tradingViewContainerRef = useRef<View>(null);
+  // const tradingViewPositionSharedValue = useSharedValue({
+  //   minY: 255,
+  //   maxY: 605,
+  // });
 
-  const handleTradingViewContainerLayout = useCallback(() => {
-    tradingViewContainerRef.current?.measure(
-      (x, y, innerWidth, innerHeight, pageX, pageY) => {
-        tradingViewPositionSharedValue.value = {
-          minY: pageY,
-          maxY: pageY + innerHeight,
-        };
-      },
-    );
-  }, [tradingViewPositionSharedValue]);
+  // const handleTradingViewContainerLayout = useCallback(() => {
+  //   tradingViewContainerRef.current?.measure(
+  //     (x, y, innerWidth, innerHeight, pageX, pageY) => {
+  //       tradingViewPositionSharedValue.value = {
+  //         minY: pageY,
+  //         maxY: pageY + innerHeight,
+  //       };
+  //     },
+  //   );
+  // }, [tradingViewPositionSharedValue]);
 
-  const tagGesture = useMemo(() => {
-    return Gesture.Tap().onStart((event) => {
-      if (platformEnv.isNative) {
-        const { minY, maxY } = tradingViewPositionSharedValue.value;
-        const isInTradingView =
-          event.absoluteY >= minY && event.absoluteY <= maxY;
-        const currentPointerEvents = isInTradingView ? 'auto' : 'none';
-        if (currentPointerEvents !== pointerEventsSharedValue.value) {
-          runOnJS(setPointerEvents)(currentPointerEvents);
-        }
-      }
-    });
-  }, [pointerEventsSharedValue, tradingViewPositionSharedValue]);
+  // const tagGesture = useMemo(() => {
+  //   return Gesture.Tap().onStart((event) => {
+  //     if (platformEnv.isNative) {
+  //       const { minY, maxY } = tradingViewPositionSharedValue.value;
+  //       const isInTradingView =
+  //         event.absoluteY >= minY && event.absoluteY <= maxY;
+  //       const currentPointerEvents = isInTradingView ? 'auto' : 'none';
+  //       if (currentPointerEvents !== pointerEventsSharedValue.value) {
+  //         runOnJS(setPointerEvents)(currentPointerEvents);
+  //       }
+  //     }
+  //   });
+  // }, [pointerEventsSharedValue, tradingViewPositionSharedValue]);
 
   const setPointerEventsToNone = useCallback(() => {
     if (platformEnv.isNative) {
@@ -133,7 +133,7 @@ export function MobileLayout() {
                     pointerEvents={
                       platformEnv.isNative ? pointerEvents : undefined
                     }
-                    onLayout={handleTradingViewContainerLayout}
+                    // onLayout={handleTradingViewContainerLayout}
                   >
                     <MarketTradingView
                       tokenAddress={tokenAddress}
@@ -161,7 +161,6 @@ export function MobileLayout() {
       );
     },
     [
-      handleTradingViewContainerLayout,
       height,
       networkId,
       pointerEvents,
@@ -172,28 +171,23 @@ export function MobileLayout() {
   );
 
   return (
-    <GestureDetector gesture={tagGesture}>
-      <YStack flex={1}>
-        <Tabs.TabBar
-          divider={false}
-          onTabPress={handleTabChange}
-          tabNames={tabNames}
-          focusedTab={focusedTab}
-        />
-        <ScrollView
-          horizontal
-          ref={scrollViewRef}
-          flex={1}
-          scrollEnabled={false}
-        >
-          {tabNames.map((item, index) => (
-            <YStack key={index} h={height} w={width}>
-              {renderItem({ index })}
-            </YStack>
-          ))}
-        </ScrollView>
-        <SwapPanel networkId={networkId} tokenAddress={tokenDetail?.address} />
-      </YStack>
-    </GestureDetector>
+    // <GestureDetector gesture={tagGesture}>
+    <YStack flex={1}>
+      <Tabs.TabBar
+        divider={false}
+        onTabPress={handleTabChange}
+        tabNames={tabNames}
+        focusedTab={focusedTab}
+      />
+      <ScrollView horizontal ref={scrollViewRef} flex={1} scrollEnabled={false}>
+        {tabNames.map((item, index) => (
+          <YStack key={index} h={height} w={width}>
+            {renderItem({ index })}
+          </YStack>
+        ))}
+      </ScrollView>
+      <SwapPanel networkId={networkId} tokenAddress={tokenDetail?.address} />
+    </YStack>
+    // </GestureDetector>
   );
 }

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
@@ -445,24 +445,6 @@ export const DevSettingsSection = () => {
       </SectionFieldItem>
 
       <SectionPressItem
-        icon="RefreshCcwOutline"
-        title="重置 App 为初次更新状态"
-        testID="reset-app-to-fresh-state"
-        onPress={() => {
-          Dialog.show({
-            title: '重置 App 为初次更新状态',
-            description: '重置后 App 将恢复到初次更新状态',
-            onConfirm: async () => {
-              await appUpdatePersistAtom.set((prev) => ({
-                ...prev,
-                latestVersion: APP_VERSION,
-                status: EAppUpdateStatus.ready,
-              }));
-            },
-          });
-        }}
-      />
-      <SectionPressItem
         icon="UploadOutline"
         title="Export Accounts Data"
         onPress={() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Refactor
  - Simplified the Mobile Market Detail layout by removing native gesture handling and pointer-event toggling, using standard tabs and horizontal scrolling while retaining the trading view and navigation behavior.
- Settings
  - Removed the developer option to reset the app to an initial update state.
- Chores
  - Minor dependency cleanup and render optimization in the Mobile Market Detail layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->