### PR TITLE
optimize: copy address in account selector OK-41686

### DIFF
--- a/packages/kit/src/components/AccountSelector/AccountSelectorActiveAccount.tsx
+++ b/packages/kit/src/components/AccountSelector/AccountSelectorActiveAccount.tsx
@@ -13,7 +13,6 @@ import {
   SizableText,
   Tooltip,
   XStack,
-  useClipboard,
 } from '@onekeyhq/components';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useAllNetworkCopyAddressHandler } from '@onekeyhq/kit/src/views/WalletAddress/hooks/useAllNetworkCopyAddressHandler';
@@ -163,7 +162,6 @@ export function AccountSelectorActiveAccountHome({
 }) {
   const intl = useIntl();
   const { activeAccount } = useActiveAccount({ num });
-  const { copyText } = useClipboard();
   const copyAddressWithDeriveType = useCopyAddressWithDeriveType();
   const {
     account,

--- a/packages/kit/src/components/AccountSelector/AccountSelectorTrigger/AccountSelectorTriggerHome.tsx
+++ b/packages/kit/src/components/AccountSelector/AccountSelectorTrigger/AccountSelectorTriggerHome.tsx
@@ -27,9 +27,8 @@ export function AccountSelectorTriggerHome({
       showWalletAvatar
       showWalletName={false}
       num={num}
-      linkNetwork={
-        !(network?.isAllNetworks || vaultSettings?.mergeDeriveAssetsEnabled)
-      }
+      linkNetwork={!network?.isAllNetworks}
+      hideAddress={vaultSettings?.mergeDeriveAssetsEnabled}
       linkNetworkId={linkNetworkId}
       keepAllOtherAccounts
       allowSelectEmptyAccount

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountAddress.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountAddress.tsx
@@ -9,11 +9,13 @@ export function AccountAddress({
   address,
   linkedNetworkId,
   isEmptyAddress,
+  hideAddress,
 }: {
   num: number;
   address: string;
   linkedNetworkId?: string;
   isEmptyAddress: boolean;
+  hideAddress?: boolean;
 }) {
   const { activeAccount } = useActiveAccount({ num });
   const intl = useIntl();
@@ -30,6 +32,10 @@ export function AccountAddress({
   const noAddressMessage = intl.formatMessage({
     id: ETranslations.wallet_no_address,
   });
+
+  if (hideAddress) {
+    return null;
+  }
 
   return address || isEmptyAddress ? (
     <SizableText

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAccountListItem.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAccountListItem.tsx
@@ -59,6 +59,7 @@ export function AccountSelectorAccountListItem({
   accountsCount,
   focusedWalletInfo,
   mergeDeriveAssetsEnabled,
+  hideAddress,
 }: {
   num: number;
   linkedNetworkId: string | undefined;
@@ -83,6 +84,7 @@ export function AccountSelectorAccountListItem({
       }
     | undefined;
   mergeDeriveAssetsEnabled: boolean | undefined;
+  hideAddress?: boolean;
 }) {
   const actions = useAccountSelectorActions();
   const navigation = useAppNavigation();
@@ -121,6 +123,7 @@ export function AccountSelectorAccountListItem({
     linkedNetworkId: string | undefined;
     address: string;
     isEmptyAddress: boolean;
+    hideAddress?: boolean;
   } => {
     let address: string | undefined;
     let allowEmptyAddress = false;
@@ -158,12 +161,14 @@ export function AccountSelectorAccountListItem({
           })
         : '',
       isEmptyAddress: false,
+      hideAddress: isOthersUniversal ? false : hideAddress,
     };
   }, [
     account?.address,
     indexedAccount?.associateAccount,
     isOthersUniversal,
     linkedNetworkId,
+    hideAddress,
   ]);
 
   const subTitleInfo = useMemo(() => buildSubTitleInfo(), [buildSubTitleInfo]);
@@ -200,6 +205,7 @@ export function AccountSelectorAccountListItem({
               : undefined
           }
           wallet={focusedWalletInfo?.wallet}
+          networkId={linkedNetworkId ?? network?.id}
         />
       );
     }
@@ -229,8 +235,9 @@ export function AccountSelectorAccountListItem({
     section?.firstAccount,
     account,
     focusedWalletInfo?.wallet,
-    num,
     linkedNetworkId,
+    network?.id,
+    num,
     selectedAccount.deriveType,
   ]);
 
@@ -288,7 +295,7 @@ export function AccountSelectorAccountListItem({
           linkedNetworkId={avatarNetworkId ?? network?.id}
           mergeDeriveAssetsEnabled={mergeDeriveAssetsEnabled}
         />
-        {subTitleInfo.address ? (
+        {subTitleInfo.address && !subTitleInfo.hideAddress ? (
           <Stack
             mx="$1.5"
             w="$1"
@@ -302,6 +309,7 @@ export function AccountSelectorAccountListItem({
   }, [
     linkNetwork,
     subTitleInfo.address,
+    subTitleInfo.hideAddress,
     isOthersUniversal,
     index,
     accountValue,
@@ -354,6 +362,7 @@ export function AccountSelectorAccountListItem({
                     trailingLength: 4,
                   })}
                   isEmptyAddress={subTitleInfo.isEmptyAddress}
+                  hideAddress={subTitleInfo.hideAddress}
                 />
               </XStack>
             }

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/index.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/index.tsx
@@ -76,6 +76,7 @@ function WalletDetailsView({ num }: IWalletDetailsProps) {
   const isEditableRouteParams = route.params?.editable;
   const keepAllOtherAccounts = route.params?.keepAllOtherAccounts;
   const allowSelectEmptyAccount = route.params?.allowSelectEmptyAccount;
+  const hideAddress = route.params?.hideAddress;
   const linkedNetworkId = useMemo(() => {
     if (linkNetworkId) {
       return linkNetworkId;
@@ -534,6 +535,7 @@ function WalletDetailsView({ num }: IWalletDetailsProps) {
               mergeDeriveAssetsEnabled={
                 listDataResult?.mergeDeriveAssetsEnabled
               }
+              hideAddress={hideAddress}
             />
           )}
           renderSectionFooter={({
@@ -590,6 +592,7 @@ function WalletDetailsView({ num }: IWalletDetailsProps) {
     handleLayoutForContainer,
     handleLayoutForHeader,
     handleLayoutForSectionList,
+    hideAddress,
     initialScrollIndex,
     intl,
     isDeprecatedWallet,

--- a/packages/shared/src/logger/scopes/wallet/scenes/walletActions.ts
+++ b/packages/shared/src/logger/scopes/wallet/scenes/walletActions.ts
@@ -6,7 +6,13 @@ import { LogToServer } from '../../../base/decorators';
 type IWalletActionBaseParams = {
   walletType: string;
   networkId: string;
-  source: 'homePage' | 'tokenDetails' | 'homeTokenList' | 'earn' | 'swap';
+  source:
+    | 'homePage'
+    | 'tokenDetails'
+    | 'homeTokenList'
+    | 'earn'
+    | 'swap'
+    | 'accountSelector';
   isSoftwareWalletOnlyUser: boolean;
 };
 

--- a/packages/shared/src/routes/accountManagerStacks.ts
+++ b/packages/shared/src/routes/accountManagerStacks.ts
@@ -25,6 +25,7 @@ export type IAccountSelectorRouteParamsExtraConfig = {
   hideNonBackedUpWallet?: boolean;
   keepAllOtherAccounts?: boolean;
   allowSelectEmptyAccount?: boolean;
+  hideAddress?: boolean;
 };
 
 export type IExportAccountSecretKeysRouteParams = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Copy Address action in the Account Edit menu, with network-aware behavior and support for derived addresses.
  - Copy flow updated to open a Receive modal for hardware/QR wallets and handle merged-derive assets seamlessly.
  - Addresses can now be hidden in Account Selector and Wallet Details when configured, improving privacy in merged-derive scenarios.
  - Account Selector trigger now hides the address when merge-derive is enabled and updates network link behavior outside All Networks.
  - Wallet actions and account selector interactions are now consistently tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->