### PR TITLE
fix:  hw onboarding on the empty account swap page

### DIFF
--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -192,26 +192,27 @@ class ServiceAccount extends ServiceBase {
     super({ backgroundApi });
 
     appEventBus.on(EAppEventBusNames.WalletUpdate, () => {
-      this.clearAccountCache();
+      void this.clearAccountCache();
     });
     appEventBus.on(EAppEventBusNames.AccountRemove, () => {
-      this.clearAccountCache();
+      void this.clearAccountCache();
     });
     appEventBus.on(EAppEventBusNames.AccountUpdate, () => {
-      this.clearAccountCache();
+      void this.clearAccountCache();
     });
     appEventBus.on(EAppEventBusNames.RenameDBAccounts, () => {
-      this.clearAccountCache();
+      void this.clearAccountCache();
     });
     appEventBus.on(EAppEventBusNames.WalletRename, () => {
-      this.clearAccountCache();
+      void this.clearAccountCache();
     });
     appEventBus.on(EAppEventBusNames.AddDBAccountsToWallet, () => {
-      this.clearAccountCache();
+      void this.clearAccountCache();
     });
   }
 
-  clearAccountCache() {
+  @backgroundMethod()
+  async clearAccountCache() {
     this.getIndexedAccountWithMemo.clear();
     localDb.clearStoreCachedData();
   }

--- a/packages/kit/src/components/AccountSelector/hooks/useAutoSelectAccount.tsx
+++ b/packages/kit/src/components/AccountSelector/hooks/useAutoSelectAccount.tsx
@@ -4,6 +4,7 @@ import {
   EAppEventBusNames,
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { EAccountSelectorAutoSelectTriggerBy } from '@onekeyhq/shared/types';
 
 import {
@@ -32,9 +33,10 @@ export function useAutoSelectAccount({ num }: { num: number }) {
 
   // **** autoSelectAccount after WalletUpdate
   useEffect(() => {
-    const fn = () => {
+    const fn = async () => {
       if (!account) {
-        void actions.current.autoSelectNextAccount({
+        await timerUtils.wait(600);
+        await actions.current.autoSelectNextAccount({
           num,
           sceneName,
           sceneUrl,

--- a/packages/kit/src/components/WebDapp/ConnectWalletModal.tsx
+++ b/packages/kit/src/components/WebDapp/ConnectWalletModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useRoute } from '@react-navigation/core';
 import { useIntl } from 'react-intl';
@@ -15,6 +15,7 @@ import {
 } from '@onekeyhq/shared/src/routes';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
+import { useAccountSelectorActions } from '../../states/jotai/contexts/accountSelector/actions';
 import { AccountSelectorProviderMirror } from '../AccountSelector';
 
 import { ExternalWalletList } from './ExternalWalletList';
@@ -22,6 +23,9 @@ import { OneKeyWalletConnectionOptions } from './OneKeyWalletConnectionOptions';
 import { WatchOnlyWalletContent } from './WatchOnlyWalletContent';
 
 import type { RouteProp } from '@react-navigation/core';
+
+const sceneName = EAccountSelectorSceneName.home;
+const num = 0;
 
 function ConnectWalletContent() {
   const intl = useIntl();
@@ -32,6 +36,14 @@ function ConnectWalletContent() {
     >();
   const { defaultTab } = route.params || {};
   const media = useMedia();
+  const actions = useAccountSelectorActions();
+
+  useEffect(() => {
+    void actions.current.autoSelectNextAccount({
+      sceneName,
+      num,
+    });
+  }, [actions]);
 
   const isMobile = media.md;
 
@@ -131,9 +143,9 @@ function ConnectWalletModal() {
   return (
     <AccountSelectorProviderMirror
       config={{
-        sceneName: EAccountSelectorSceneName.home,
+        sceneName,
       }}
-      enabledNum={[0]}
+      enabledNum={[num]}
     >
       <ConnectWalletContent />
     </AccountSelectorProviderMirror>

--- a/packages/shared/src/logger/scopes/accountSelector/index.ts
+++ b/packages/shared/src/logger/scopes/accountSelector/index.ts
@@ -1,8 +1,10 @@
 import { BaseScope } from '../../base/baseScope';
 import { EScopeName } from '../../types';
 
+import { AccountSelectorAutoSelectScene } from './scenes/autoSelect';
 import { AccountSelectorPerfScene } from './scenes/perf';
 import { AccountSelectorRenderScene } from './scenes/render';
+import { AccountSelectorStorageScene } from './scenes/storage';
 
 export class AccountSelectorScope extends BaseScope {
   protected override scopeName = EScopeName.accountSelector;
@@ -10,4 +12,8 @@ export class AccountSelectorScope extends BaseScope {
   render = this.createScene('render', AccountSelectorRenderScene);
 
   perf = this.createScene('perf', AccountSelectorPerfScene);
+
+  storage = this.createScene('storage', AccountSelectorStorageScene);
+
+  autoSelect = this.createScene('autoSelect', AccountSelectorAutoSelectScene);
 }

--- a/packages/shared/src/logger/scopes/accountSelector/scenes/autoSelect.ts
+++ b/packages/shared/src/logger/scopes/accountSelector/scenes/autoSelect.ts
@@ -1,0 +1,45 @@
+import { cloneDeep } from 'lodash';
+
+import type { IAccountSelectorSelectedAccount } from '@onekeyhq/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountSelector';
+
+import { BaseScene } from '../../../base/baseScene';
+import { LogToConsole } from '../../../base/decorators';
+
+export class AccountSelectorAutoSelectScene extends BaseScene {
+  @LogToConsole()
+  public startAutoSelect({
+    focusedWallet,
+    networkId,
+    walletId,
+    isAccountExist,
+  }: {
+    focusedWallet: string | undefined;
+    networkId: string | undefined;
+    walletId: string | undefined;
+    isAccountExist: boolean;
+  }) {
+    return cloneDeep({ focusedWallet, networkId, walletId, isAccountExist });
+  }
+
+  @LogToConsole()
+  public currentSelectedAccount({
+    selectedAccount,
+  }: {
+    selectedAccount: IAccountSelectorSelectedAccount;
+  }) {
+    return cloneDeep({ selectedAccount });
+  }
+
+  @LogToConsole()
+  public resetSelectedWalletToUndefined({
+    selectedAccount,
+  }: {
+    selectedAccount: IAccountSelectorSelectedAccount;
+  }) {
+    return cloneDeep([
+      'currentWallet does not exist or no indexed account',
+      { walletId: selectedAccount.walletId },
+      selectedAccount,
+    ]);
+  }
+}

--- a/packages/shared/src/logger/scopes/accountSelector/scenes/storage.ts
+++ b/packages/shared/src/logger/scopes/accountSelector/scenes/storage.ts
@@ -1,0 +1,31 @@
+import { cloneDeep } from 'lodash';
+
+import type { IAccountSelectorSelectedAccount } from '@onekeyhq/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountSelector';
+import type { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
+
+import { BaseScene } from '../../../base/baseScene';
+import { LogToConsole } from '../../../base/decorators';
+
+export class AccountSelectorStorageScene extends BaseScene {
+  @LogToConsole()
+  public updateSelectedAccount({
+    sceneName,
+    num,
+    sceneUrl,
+    oldSelectedAccount,
+    newSelectedAccount,
+  }: {
+    sceneName: EAccountSelectorSceneName | undefined;
+    num: number;
+    sceneUrl: string | undefined;
+    oldSelectedAccount: IAccountSelectorSelectedAccount;
+    newSelectedAccount: IAccountSelectorSelectedAccount;
+  }) {
+    return cloneDeep([
+      sceneName,
+      num,
+      sceneUrl,
+      { oldSelectedAccount, newSelectedAccount },
+    ]);
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically pre-selects an account when opening Connect Wallet.
  - Smarter auto-selection after wallet updates, including brief waits and better handling for hardware wallets and “Others” wallets.

- Bug Fixes
  - More reliable account switching with safeguards against race conditions and duplicate updates.
  - Ensures derive type stays consistent when changing networks.
  - Clears stale account cache in the background to reduce UI stalls and outdated data.

- Chores
  - Enhanced logging for auto-select and account selection storage to aid diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->