### PR TITLE
fix: show original fee info in bnb free gas tx OK-41747

### DIFF
--- a/packages/kit/src/hooks/useListenTabFocusState.ts
+++ b/packages/kit/src/hooks/useListenTabFocusState.ts
@@ -52,10 +52,13 @@ export function useShortcutsRouteStatus() {
     },
   );
 
-  useListenTabFocusState(ETabRoutes.WebviewPerpTrade, (isFocus, isHideByModal) => {
-    isAtPerpTab.current = !isHideByModal && isFocus;
-    updateShouldReloadAppByCmdR();
-  });
+  useListenTabFocusState(
+    ETabRoutes.WebviewPerpTrade,
+    (isFocus, isHideByModal) => {
+      isAtPerpTab.current = !isHideByModal && isFocus;
+      updateShouldReloadAppByCmdR();
+    },
+  );
 
   useListenTabFocusState(ETabRoutes.Discovery, (isFocus) => {
     isAtDiscoveryTab.current = isFocus;

--- a/packages/kit/src/utils/gasFee.ts
+++ b/packages/kit/src/utils/gasFee.ts
@@ -225,6 +225,20 @@ export function calculateTotalFeeRange({
       .times(gasInfo.gasPrice)
       .toFixed();
 
+    if (gasInfo.originalGasPrice) {
+      const original = new BigNumber(limit)
+        .times(gasInfo.originalGasPrice)
+        .toFixed();
+
+      return {
+        min: nanToZeroString(max),
+        max: nanToZeroString(max),
+        minForDisplay: nanToZeroString(maxForDisplay),
+        maxForDisplay: nanToZeroString(maxForDisplay),
+        original: nanToZeroString(original),
+      };
+    }
+
     return {
       min: nanToZeroString(max),
       max: nanToZeroString(max),
@@ -372,6 +386,20 @@ export function calculateFeeForSend({
     .multipliedBy(nativeTokenPrice)
     .toFixed();
 
+  let originalTotalNative;
+  let originalTotalFiat;
+
+  if (feeRange.original) {
+    originalTotalNative = calculateTotalFeeNative({
+      amount: feeRange.original,
+      feeInfo,
+      withoutBaseFee: feeRange.withoutBaseFee,
+    });
+    originalTotalFiat = new BigNumber(originalTotalNative)
+      .multipliedBy(nativeTokenPrice)
+      .toFixed();
+  }
+
   return {
     total,
     totalMin,
@@ -384,6 +412,8 @@ export function calculateFeeForSend({
     totalFiatForDisplay,
     totalFiatMinForDisplay,
     feeRange,
+    originalTotalNative,
+    originalTotalFiat,
   };
 }
 

--- a/packages/kit/src/views/SignatureConfirm/components/TxFee/TxFeeInfo.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/TxFee/TxFeeInfo.tsx
@@ -944,6 +944,8 @@ function TxFeeInfo(props: IProps) {
       totalFiatForDisplay: string;
       totalNativeMinForDisplay: string;
       totalFiatMinForDisplay: string;
+      originalTotalNative?: string;
+      originalTotalFiat?: string;
     }[] = [];
 
     let baseGasLimit =
@@ -960,6 +962,8 @@ function TxFeeInfo(props: IProps) {
     let totalNativeMinForDisplay = new BigNumber(0);
     let totalFiatForDisplay = new BigNumber(0);
     let totalFiatMinForDisplay = new BigNumber(0);
+    let originalTotalNative = new BigNumber(0);
+    let originalTotalFiat = new BigNumber(0);
 
     for (let i = 0; i < unsignedTxs.length; i += 1) {
       const selectedFeeInfo = selectedFeeInfos[i];
@@ -1056,6 +1060,16 @@ function TxFeeInfo(props: IProps) {
         feeResult.totalFiatMinForDisplay,
       );
 
+      if (feeResult.originalTotalNative) {
+        originalTotalNative = originalTotalNative.plus(
+          feeResult.originalTotalNative,
+        );
+      }
+
+      if (feeResult.originalTotalFiat) {
+        originalTotalFiat = originalTotalFiat.plus(feeResult.originalTotalFiat);
+      }
+
       feeInfos.push({
         feeInfo: txFeeInfo,
         total: feeResult.total,
@@ -1068,6 +1082,8 @@ function TxFeeInfo(props: IProps) {
         totalFiatMinForDisplay: feeResult.totalFiatMinForDisplay,
         totalNativeForDisplay: feeResult.totalNativeForDisplay,
         totalFiatForDisplay: feeResult.totalFiatForDisplay,
+        originalTotalNative: feeResult.originalTotalNative,
+        originalTotalFiat: feeResult.originalTotalFiat,
       });
     }
 
@@ -1100,6 +1116,8 @@ function TxFeeInfo(props: IProps) {
         totalNativeMinForDisplay: totalNativeMinForDisplay.toFixed(),
         totalFiatForDisplay: totalFiatForDisplay.toFixed(),
         totalFiatMinForDisplay: totalFiatMinForDisplay.toFixed(),
+        originalTotalNative: originalTotalNative.toFixed(),
+        originalTotalFiat: originalTotalFiat.toFixed(),
       },
     };
   }, [
@@ -1496,6 +1514,14 @@ function TxFeeInfo(props: IProps) {
 
     const textColor = megafuelEligible.sponsorable ? '$text' : '$textSubdued';
 
+    const totalNative = megafuelEligible.sponsorable
+      ? selectedFee?.originalTotalNative
+      : selectedFee?.totalNativeMinForDisplay;
+
+    const totalFiat = megafuelEligible.sponsorable
+      ? selectedFee?.originalTotalFiat
+      : selectedFee?.totalFiatMinForDisplay;
+
     return (
       <XStack alignItems="center">
         <SizableText
@@ -1513,7 +1539,7 @@ function TxFeeInfo(props: IProps) {
               tokenSymbol: txFeeCommon?.nativeSymbol,
             }}
           >
-            {selectedFee?.totalNativeMinForDisplay ?? '-'}
+            {totalNative ?? '-'}
           </NumberSizeableText>
           (
           <NumberSizeableText
@@ -1524,7 +1550,7 @@ function TxFeeInfo(props: IProps) {
               currency: settings.currencyInfo.symbol,
             }}
           >
-            {selectedFee?.totalFiatMinForDisplay ?? '-'}
+            {totalFiat ?? '-'}
           </NumberSizeableText>
           )
         </SizableText>
@@ -1543,9 +1569,11 @@ function TxFeeInfo(props: IProps) {
     isResourceRentalNeeded,
     isResourceRentalEnabled,
     megafuelEligible.sponsorable,
-    txFeeCommon?.nativeSymbol,
+    selectedFee?.originalTotalNative,
     selectedFee?.totalNativeMinForDisplay,
+    selectedFee?.originalTotalFiat,
     selectedFee?.totalFiatMinForDisplay,
+    txFeeCommon?.nativeSymbol,
     settings.currencyInfo.symbol,
     intl,
   ]);

--- a/packages/shared/types/fee.ts
+++ b/packages/shared/types/fee.ts
@@ -61,6 +61,7 @@ export type IGasEIP1559 = {
 };
 
 export type IGasLegacy = {
+  originalGasPrice?: string;
   gasPrice: string;
   gasLimit: string;
   gasLimitForDisplay?: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Displays original network fees (native and fiat) alongside current estimates when available.
  * Fee summary now shows a struck-through original price next to the current price, including sponsorship/discount visibility; prime badge remains when eligible.
  * Aggregates original and current totals across multiple transactions for clearer, more accurate summaries.
  * Automatically chooses between original and standard totals based on sponsorship eligibility to reflect the most relevant cost to the user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->