### PR TITLE
fix: swap aptos popular token OK-42118

### DIFF
--- a/packages/shared/types/swap/SwapProvider.constants.ts
+++ b/packages/shared/types/swap/SwapProvider.constants.ts
@@ -1507,6 +1507,7 @@ export const swapPopularTokens: Record<string, ISwapToken[]> = {
       'name': 'Aptos Coin',
       'symbol': 'APT',
       'decimals': 8,
+      'isPopular': true,
       'logoURI':
         'https://uni-test.onekey-asset.com/server-service-onchain/aptos--1/tokens/0x1::aptos_coin::AptosCoin.png',
       'isNative': true,
@@ -1519,6 +1520,7 @@ export const swapPopularTokens: Record<string, ISwapToken[]> = {
       'name': 'Tether USD',
       'symbol': 'USDt',
       'decimals': 6,
+      'isPopular': true,
       'logoURI':
         'https://uni-test.onekey-asset.com/server-service-onchain/aptos--1/tokens/0x357b0b74bc833e95a115ad22604854d6b0fca151cecd94111770e5d6ffc9dc2b.png',
       'isNative': false,
@@ -1530,6 +1532,7 @@ export const swapPopularTokens: Record<string, ISwapToken[]> = {
         '0xbae207659db88bea0cbead6da0ed00aac12edcdda169e591cd41c94180b46f3b',
       'name': 'USDC',
       'symbol': 'USDC',
+      'isPopular': true,
       'decimals': 6,
       'logoURI':
         'https://uni-test.onekey-asset.com/server-service-onchain/aptos--1/tokens/0xbae207659db88bea0cbead6da0ed00aac12edcdda169e591cd41c94180b46f3b.png',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Popular tokens updated for Aptos swaps: AptosCoin is now highlighted when selecting the token to swap from, and USDt and USDC are highlighted when choosing the token to swap to. These tokens appear in the Popular list and are surfaced more prominently to speed up common swaps. No changes to other networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->