### PR TITLE
fix: reserveGasFormatted OK-42132

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
@@ -24,6 +24,7 @@ import {
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import { checkWrappedTokenPair } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 import {
@@ -269,19 +270,26 @@ const SwapInputContainer = ({
       (item) => item.networkId === fromToken?.networkId,
     )?.reserveGas;
     if (fromToken?.isNative) {
+      let reserveGasFormatted: string | undefined | number = reserveGas;
+      if (reserveGas) {
+        reserveGasFormatted = numberFormat(reserveGas.toString(), {
+          formatter: 'balance',
+          formatterOptions: {
+            tokenSymbol: fromToken?.symbol,
+          },
+        }) as string;
+      }
       return (
         <XStack alignItems="center" p="$4">
           <SizableText size="$bodyMd">
             {intl.formatMessage(
               {
-                id: reserveGas
+                id: reserveGasFormatted
                   ? ETranslations.swap_native_token_max_tip_already
                   : ETranslations.swap_native_token_max_tip,
               },
               {
-                num_token: reserveGas
-                  ? `${reserveGas} ${fromToken?.symbol}`
-                  : undefined,
+                num_token: reserveGasFormatted,
               },
             )}
           </SizableText>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrects the max tip message for native tokens by selecting the appropriate translation when a gas reserve is set.
  - Displays the reserved gas amount using readable number formatting in the balance popover.
  - Improves clarity of messaging without changing swap functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->