### PR TITLE
fix: copy address network name error OK-42146

### DIFF
--- a/packages/kit/src/components/AccountSelector/AccountSelectorActiveAccount.tsx
+++ b/packages/kit/src/components/AccountSelector/AccountSelectorActiveAccount.tsx
@@ -244,14 +244,28 @@ export function AccountSelectorActiveAccountHome({
         networkName: network?.shortname,
       });
     } else {
+      let networkName = network?.shortname;
+      if (
+        network?.isAllNetworks &&
+        accountUtils.isOthersWallet({ walletId: wallet?.id ?? '' }) &&
+        account?.createAtNetwork
+      ) {
+        const createAtNetwork =
+          await backgroundApiProxy.serviceNetwork.getNetworkSafe({
+            networkId: account.createAtNetwork,
+          });
+        networkName = createAtNetwork?.shortname ?? networkName;
+      }
+
       copyAddressWithDeriveType({
         address: account.address,
-        networkName: network?.shortname,
+        networkName,
       });
     }
     logActiveAccount();
   }, [
     account?.address,
+    account?.createAtNetwork,
     account?.id,
     copyAddressWithDeriveType,
     deriveInfoItems,

--- a/packages/kit/src/views/AccountManagerStacks/components/AccountEdit/AccountEditButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/AccountEdit/AccountEditButton.tsx
@@ -212,13 +212,6 @@ function AccountEditButtonView({
             });
             return null;
           })()}
-          <AccountRenameButton
-            name={name}
-            wallet={wallet}
-            indexedAccount={indexedAccount}
-            account={account}
-            onClose={handleActionListClose}
-          />
           {showCopyButton ? (
             <AccountCopyButton
               wallet={wallet}
@@ -227,6 +220,14 @@ function AccountEditButtonView({
               onClose={handleActionListClose}
             />
           ) : null}
+          <AccountRenameButton
+            name={name}
+            wallet={wallet}
+            indexedAccount={indexedAccount}
+            account={account}
+            onClose={handleActionListClose}
+          />
+
           {exportKeysVisible?.showExportPrivateKey ? (
             <AccountExportPrivateKeyButton
               testID={`popover-export-private-key-${name}`}

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionCopy.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionCopy.tsx
@@ -93,9 +93,23 @@ export function WalletActionCopy({ onClose }: { onClose: () => void }) {
         networkName: network?.shortname,
       });
     } else {
+      let networkName = network?.shortname;
+
+      if (
+        network?.isAllNetworks &&
+        accountUtils.isOthersWallet({ walletId: wallet?.id ?? '' }) &&
+        account?.createAtNetwork
+      ) {
+        const createAtNetwork =
+          await backgroundApiProxy.serviceNetwork.getNetworkSafe({
+            networkId: account.createAtNetwork,
+          });
+        networkName = createAtNetwork?.shortname ?? networkName;
+      }
+
       copyAddressWithDeriveType({
         address: account?.address || '',
-        networkName: network?.shortname,
+        networkName,
       });
     }
     onClose();
@@ -112,6 +126,7 @@ export function WalletActionCopy({ onClose }: { onClose: () => void }) {
     handleAllNetworkCopyAddress,
     navigation,
     account?.id,
+    account?.createAtNetwork,
     account?.address,
     indexedAccount?.id,
     copyAddressWithDeriveType,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Copying an address now uses the correct network name when viewing “All Networks” for “Others” wallets, ensuring accurate context in the copied text.
  * The copy action updates correctly when the account’s originating network changes.

* **Style**
  * Reordered account action buttons: “Copy” now appears before “Rename” in the Account Edit view for a more intuitive flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->