### PR TITLE
refactor: extract WebView features into dedicated component

### DIFF
--- a/packages/kit/src/components/WebView/WebViewWithFeatures.tsx
+++ b/packages/kit/src/components/WebView/WebViewWithFeatures.tsx
@@ -1,0 +1,43 @@
+import { useCallback, useRef } from 'react';
+
+import WebView from '.';
+
+import { useIsFocused } from '@react-navigation/native';
+
+import { useDAppNotifyChangesBase } from '../../views/Discovery/hooks/useDAppNotifyChanges';
+
+import type { IWebViewProps } from '.';
+import type { IWebViewRef } from './types';
+
+export function WebViewWithFeatures(
+  props: IWebViewProps & {
+    features?: { notifyChangedEventsToDappOnFocus?: boolean };
+  },
+) {
+  const webviewRef = useRef<IWebViewRef | null>(null);
+  const { onWebViewRef } = props;
+  const handleWebViewRef = useCallback(
+    (ref: IWebViewRef | null) => {
+      webviewRef.current = ref;
+      onWebViewRef?.(ref);
+    },
+    [onWebViewRef],
+  );
+
+  const notifyChangedEventsToDappOnFocus =
+    props?.features?.notifyChangedEventsToDappOnFocus;
+  const shouldSkipNotify = useCallback(() => {
+    return Boolean(!notifyChangedEventsToDappOnFocus);
+  }, [notifyChangedEventsToDappOnFocus]);
+  const getWebviewRef = useCallback(() => webviewRef.current, [webviewRef]);
+
+  const isFocused = useIsFocused();
+  useDAppNotifyChangesBase({
+    getWebviewRef,
+    isFocused,
+    url: props?.src,
+    shouldSkipNotify,
+  });
+
+  return <WebView {...props} onWebViewRef={handleWebViewRef} />;
+}

--- a/packages/kit/src/components/WebView/WebViewWithFeatures.tsx
+++ b/packages/kit/src/components/WebView/WebViewWithFeatures.tsx
@@ -15,7 +15,8 @@ export function WebViewWithFeatures(
   },
 ) {
   const webviewRef = useRef<IWebViewRef | null>(null);
-  const { onWebViewRef } = props;
+  const { features, ...webviewProps } = props;
+  const { onWebViewRef, src } = webviewProps;
   const handleWebViewRef = useCallback(
     (ref: IWebViewRef | null) => {
       webviewRef.current = ref;
@@ -25,7 +26,7 @@ export function WebViewWithFeatures(
   );
 
   const notifyChangedEventsToDappOnFocus =
-    props?.features?.notifyChangedEventsToDappOnFocus;
+    features?.notifyChangedEventsToDappOnFocus;
   const shouldSkipNotify = useCallback(() => {
     return Boolean(!notifyChangedEventsToDappOnFocus);
   }, [notifyChangedEventsToDappOnFocus]);
@@ -35,9 +36,9 @@ export function WebViewWithFeatures(
   useDAppNotifyChangesBase({
     getWebviewRef,
     isFocused,
-    url: props?.src,
+    url: src,
     shouldSkipNotify,
   });
 
-  return <WebView {...props} onWebViewRef={handleWebViewRef} />;
+  return <WebView {...webviewProps} onWebViewRef={handleWebViewRef} />;
 }

--- a/packages/kit/src/components/WebView/index.tsx
+++ b/packages/kit/src/components/WebView/index.tsx
@@ -1,14 +1,10 @@
 import type { ComponentProps, FC } from 'react';
 import { useCallback, useRef } from 'react';
 
-import { useIsFocused } from '@react-navigation/native';
-
 import { Button, Stack } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import extUtils from '@onekeyhq/shared/src/utils/extUtils';
-
-import { useDAppNotifyChangesBase } from '../../views/Discovery/hooks/useDAppNotifyChanges';
 
 import InpageProviderWebView from './InpageProviderWebView';
 
@@ -28,13 +24,12 @@ import type {
   WebViewSource,
 } from 'react-native-webview/lib/WebViewTypes';
 
-interface IWebViewProps
+export interface IWebViewProps
   extends IElectronWebViewEvents,
     Partial<RNWebViewProps> {
   id?: string;
   src?: string;
   onSrcChange?: (src: string) => void;
-  notifyChangedEventsToDappOnFocus?: boolean;
   openUrlInExt?: boolean;
   onWebViewRef?: (ref: IWebViewRef | null) => void;
   onNavigationStateChange?: (event: WebViewNavigation) => void;
@@ -90,7 +85,6 @@ const WebView: FC<IWebViewProps> = ({
   containerProps,
   webviewDebuggingEnabled,
   pullToRefreshEnabled,
-  notifyChangedEventsToDappOnFocus,
   ...rest
 }) => {
   const receiveHandler = useCallback<IJsBridgeReceiveHandler>(
@@ -112,18 +106,6 @@ const WebView: FC<IWebViewProps> = ({
     },
     [onWebViewRef],
   );
-
-  const getWebviewRef = useCallback(() => webviewRef.current, [webviewRef]);
-  const shouldSkipNotify = useCallback(() => {
-    return Boolean(!notifyChangedEventsToDappOnFocus);
-  }, [notifyChangedEventsToDappOnFocus]);
-  const isFocused = useIsFocused();
-  useDAppNotifyChangesBase({
-    getWebviewRef,
-    isFocused,
-    url: src,
-    shouldSkipNotify,
-  });
 
   if (
     platformEnv.isExtension &&

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/PerpGallery.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/PerpGallery.tsx
@@ -500,7 +500,7 @@ const PerpGallery = () => (
     componentName="PerpGallery"
     elements={[
       {
-        title: 'Hyperliquid API Test',
+        title: 'Hyperliquid API Test 2862',
         element: <PerpApiTests />,
       },
     ]}

--- a/packages/kit/src/views/PerpTrade/pages/PageWebviewPerpTrade.tsx
+++ b/packages/kit/src/views/PerpTrade/pages/PageWebviewPerpTrade.tsx
@@ -8,12 +8,10 @@ import {
   HeaderIconButton,
   IconButton,
   Page,
-  Stack,
   Tooltip,
   useShortcuts,
 } from '@onekeyhq/components';
 import { DelayedRender } from '@onekeyhq/components/src/hocs/DelayedRender';
-import WebView from '@onekeyhq/kit/src/components/WebView';
 import {
   HYPER_LIQUID_ORIGIN,
   HYPER_LIQUID_WEBVIEW_TRADE_URL,
@@ -33,6 +31,7 @@ import backgroundApiProxy from '../../../background/instance/backgroundApiProxy'
 import { AccountSelectorProviderMirror } from '../../../components/AccountSelector';
 import { MultipleClickStack } from '../../../components/MultipleClickStack';
 import { TabPageHeader } from '../../../components/TabPageHeader';
+import { WebViewWithFeatures } from '../../../components/WebView/WebViewWithFeatures';
 import { useShortcutsRouteStatus } from '../../../hooks/useListenTabFocusState';
 import { usePromiseResult } from '../../../hooks/usePromiseResult';
 import { SingleAccountAndNetworkSelectorTrigger } from '../../Discovery/components/HeaderRightToolBar';
@@ -111,7 +110,9 @@ function WebviewPerpTradeView() {
 
   const webview = useMemo(
     () => (
-      <WebView
+      <WebViewWithFeatures
+        // important: if set to false, the webview will not notify the dapp about the account changes first time
+        features={{ notifyChangedEventsToDappOnFocus: true }}
         id="perp-trade"
         src={url}
         onWebViewRef={(ref) => {
@@ -120,8 +121,6 @@ function WebviewPerpTradeView() {
           webviewRef.current = ref;
         }}
         allowpopups
-        // important: if set to false, the webview will not notify the dapp about the account changes first time
-        notifyChangedEventsToDappOnFocus
         onDidStartLoading={onDidStartLoading}
         onDidStartNavigation={onDidStartNavigation}
         onDidFinishLoad={onDidFinishLoad}


### PR DESCRIPTION
- Create WebViewWithFeatures component to encapsulate dapp notification logic
- Move notifyChangedEventsToDappOnFocus from WebView props to features config
- Update PerpTrade to use WebViewWithFeatures with notification feature enabled
- Clean up WebView component by removing notification-specific code

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced WebViewWithFeatures to optionally notify DApps of changes when the WebView gains focus, without affecting default behavior.
- Refactor
  - Simplified WebView API by removing the notify-on-focus prop and exporting its props type for reuse.
  - Migrated focus-notification logic into WebViewWithFeatures and updated PerpTrade to use features={{ notifyChangedEventsToDappOnFocus: true }}.
- Chores
  - Updated a gallery story title from “Hyperliquid API Test” to “Hyperliquid API Test 2862”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->