### PR TITLE
fix: limit last step status OK-42160

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -491,6 +491,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     setSwapSteps({
       steps: [...steps],
       preSwapData: {
+        swapType: swapTypeSwitch,
         fromToken: fromSelectToken,
         toToken: toSelectToken,
         shouldFallback: SwapBuildShouldFallBackNetworkIds.includes(
@@ -523,6 +524,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
       quoteResult: { ...(currentQuoteRes as IFetchQuoteResult) },
     });
   }, [
+    swapTypeSwitch,
     currentQuoteRes,
     swapBatchTransferType,
     setSwapSteps,

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -464,6 +464,7 @@ export interface ISwapPreSwapData {
   providerInfo?: IFetchQuoteInfo;
   isHWAndExBatchTransfer?: boolean;
   slippage?: number;
+  swapType?: ESwapTabSwitchType;
   unSupportSlippage?: boolean;
   swapBuildResultData?: {
     swapInfo?: ISwapTxInfo;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LIMIT order support in the swap flow with clear status updates (e.g., fulfilled, partially filled, cancelled, expired).
  * Enhanced pre-swap UI to reflect real-time status for both market and LIMIT orders.
  * Switching between swap modes now refreshes steps and pre-swap data automatically.
  * Added swap type context to pre-swap details for more accurate progress tracking.
  * Maintains existing behavior for non-LIMIT swaps while improving transparency for LIMIT orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->