### PR TITLE
fix: remove isDesktop parameter from closeWebTab calls OK-42185

### DIFF
--- a/packages/kit/src/states/jotai/contexts/discovery/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/discovery/actions.ts
@@ -327,7 +327,7 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
         navigation?: ReturnType<typeof useAppNavigation>;
       },
     ) => {
-      const { tabId, entry, navigation, isDesktop = false } = payload;
+      const { tabId, entry, navigation } = payload;
       delete webviewRefs[tabId];
       const { tabs } = get(webTabsAtom());
       const targetIndex = tabs.findIndex((t) => t.id === tabId);
@@ -363,7 +363,7 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
           if (newActiveTab) {
             newActiveTab.isActive = true;
             this.setCurrentWebTab.call(set, newActiveTab.id);
-          } else if (isDesktop) {
+          } else if (platformEnv.isDesktop) {
             // if the new active tab is not in tabs, switch to Discovery (Desktop only)
             navigation?.switchTab(ETabRoutes.Discovery);
           }

--- a/packages/kit/src/views/Discovery/hooks/useShortcuts.desktop.ts
+++ b/packages/kit/src/views/Discovery/hooks/useShortcuts.desktop.ts
@@ -41,7 +41,6 @@ export const useDiscoveryShortcuts = () => {
       closeWebTab({
         tabId: activeTabId,
         entry: 'ShortCut',
-        isDesktop: true,
         navigation,
       });
     }

--- a/packages/kit/src/views/Discovery/pages/DesktopCustomTabBar/index.tsx
+++ b/packages/kit/src/views/Discovery/pages/DesktopCustomTabBar/index.tsx
@@ -105,7 +105,6 @@ function DesktopCustomTabBar() {
       void closeWebTab({
         tabId: id,
         entry: 'Menu',
-        isDesktop: true,
         navigation,
       });
     },


### PR DESCRIPTION

- Removed the isDesktop parameter from closeWebTab function calls in useShortcuts and DesktopCustomTabBar components.
- Updated the condition for switching tabs in ContextJotaiActionsDiscovery to use platformEnv.isDesktop instead of the removed parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified desktop tab-closing logic by using automatic environment detection instead of passing a desktop flag.
  - Unified calls to close web tabs across desktop views and hooks for more consistent behavior.
  - Reduced parameter complexity when closing tabs from the desktop custom tab bar and shortcuts.
  - No changes to public interfaces; existing navigation and tab behavior remain unchanged for users.
  - Improves maintainability and reduces potential for discrepancies between desktop and other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->