### PR TITLE
refactor: remove unused swapTypeSwitch state from SwapAccountAddressC…

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapAccountAddressContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapAccountAddressContainer.tsx
@@ -33,7 +33,6 @@ const SwapAccountAddressContainer = ({
 }: ISwapAccountAddressContainerProps) => {
   const intl = useIntl();
   const [fromToken] = useSwapSelectFromTokenAtom();
-  const [swapTypeSwitch] = useSwapTypeSwitchAtom();
   const [swapSupportAllNetwork] = useSwapNetworksIncludeAllNetworkAtom();
   const [toToken] = useSwapSelectToTokenAtom();
 
@@ -50,7 +49,7 @@ const SwapAccountAddressContainer = ({
 
     return (
       <AnimatePresence>
-        {swapTypeSwitch === ESwapTabSwitchType.BRIDGE && networkInfo ? (
+        {networkInfo ? (
           <XStack
             key="network-component"
             animation="quick"
@@ -79,7 +78,6 @@ const SwapAccountAddressContainer = ({
     );
   }, [
     swapSupportAllNetwork,
-    swapTypeSwitch,
     onClickNetwork,
     type,
     fromToken?.networkId,

--- a/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
@@ -366,7 +366,6 @@ const SwapInputContainer = ({
         }}
         tokenSelectorTriggerProps={{
           loading: selectTokenLoading,
-          selectedNetworkImageUri: token?.networkLogoURI,
           selectedTokenImageUri: token?.logoURI,
           selectedTokenSymbol: token?.symbol,
           onPress: () => {


### PR DESCRIPTION
…ontainer and selectedNetworkImageUri from SwapInputContainer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network section on the swap screen now displays whenever network info is available, ensuring consistent visibility across swap and bridge scenarios.
* **Style**
  * Removed the network logo from the token selector trigger, simplifying the token selection UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->