### PR TITLE
fix: enhance Prime Transfer with TON support and improved account handling

### DIFF
--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -468,8 +468,14 @@ class ServiceAccount extends ServiceBase {
         }
       }
       if (accountUtils.isImportedAccount({ accountId: credential.id })) {
+        let accountId = credential.id;
+        if (accountUtils.isTonMnemonicCredentialId(credential.id)) {
+          accountId = accountUtils.getAccountIdFromTonMnemonicCredentialId({
+            credentialId: credential.id,
+          });
+        }
         const account = await this.getDBAccountSafe({
-          accountId: credential.id,
+          accountId,
         });
         if (!account) {
           isRemoved = true;
@@ -780,10 +786,14 @@ class ServiceAccount extends ServiceBase {
     walletId,
     networkId,
     account,
+    indexedAccountNames,
   }: {
     walletId: string;
     networkId: string;
     account: IBatchCreateAccount;
+    indexedAccountNames?: {
+      [index: number]: string;
+    };
   }) {
     const {
       addressDetail: _addressDetail,
@@ -800,6 +810,7 @@ class ServiceAccount extends ServiceBase {
       walletId,
       indexes: [dbAccount.pathIndex],
       skipIfExists: true,
+      names: indexedAccountNames,
     });
     await localDb.addAccountsToWallet({
       allAccountsBelongToNetworkId: networkId,

--- a/packages/kit-bg/src/services/ServiceBatchCreateAccount/ServiceBatchCreateAccount.ts
+++ b/packages/kit-bg/src/services/ServiceBatchCreateAccount/ServiceBatchCreateAccount.ts
@@ -36,12 +36,12 @@ import { getVaultSettings } from '../../vaults/settings';
 import { buildDefaultAddAccountNetworks } from '../ServiceAccount/defaultNetworkAccountsConfig';
 import ServiceBase from '../ServiceBase';
 
+import type { AllNetworkAddressParams } from '@onekeyfe/hd-core';
 import type {
   IAccountDeriveTypes,
   IHwAllNetworkPrepareAccountsResponse,
 } from '../../vaults/types';
 import type { IWithHardwareProcessingControlParams } from '../ServiceHardwareUI/ServiceHardwareUI';
-import type { AllNetworkAddressParams } from '@onekeyfe/hd-core';
 
 export type IBatchCreateAccountProgressInfo = {
   totalCount: number;
@@ -63,6 +63,9 @@ export type IBatchBuildAccountsParams = IBatchBuildAccountsBaseParams & {
   excludedIndexes?: {
     [index: number]: true;
   };
+  indexedAccountNames?: {
+    [index: number]: string;
+  };
   saveToDb?: boolean;
   saveToCache?: boolean;
   isVerifyAddressAction?: boolean;
@@ -83,6 +86,9 @@ type IAdvancedModeFlowParamsBase = {
   toIndex: number;
   excludedIndexes: {
     [index: number]: true;
+  };
+  indexedAccountNames?: {
+    [index: number]: string;
   };
   saveToDb: boolean;
   progressTotalCount?: number;
@@ -796,6 +802,7 @@ class ServiceBatchCreateAccount extends ServiceBase {
               excludedIndexes,
               saveToDb: true,
               hwAllNetworkPrepareAccountsResponse,
+              indexedAccountNames: params.indexedAccountNames,
             });
             addedAccounts.push({
               networkId: networkParams.networkId,
@@ -1031,6 +1038,7 @@ class ServiceBatchCreateAccount extends ServiceBase {
     hwAllNetworkPrepareAccountsResponse,
     isVerifyAddressAction,
     errorMessage,
+    indexedAccountNames,
   }: IBatchBuildAccountsParams): Promise<{
     accountsForCreate: IBatchCreateAccount[];
   }> {
@@ -1079,6 +1087,7 @@ class ServiceBatchCreateAccount extends ServiceBase {
             walletId,
             networkId,
             account: accountForCreate,
+            indexedAccountNames,
           });
           if (this.progressInfo) {
             this.progressInfo.createdCount += 1;

--- a/packages/kit-bg/src/services/ServicePrimeTransfer/ServicePrimeTransfer.ts
+++ b/packages/kit-bg/src/services/ServicePrimeTransfer/ServicePrimeTransfer.ts
@@ -45,7 +45,6 @@ import type { INetworkAccount } from '@onekeyhq/shared/types/account';
 import { EServiceEndpointEnum } from '@onekeyhq/shared/types/endpoint';
 import type {
   IE2EESocketUserInfo,
-  IPrimeTransferAccount,
   IPrimeTransferData,
   IPrimeTransferHDWallet,
   IPrimeTransferPrivateData,
@@ -1106,9 +1105,7 @@ class ServicePrimeTransfer extends ServiceBase {
     return { code, codeWithSeparator };
   }
 
-  private extractSelectedItems<
-    T extends IPrimeTransferAccount | IPrimeTransferHDWallet,
-  >({
+  private extractSelectedItems<T>({
     selectedItemMapInfo,
     dataSource,
     credentials,
@@ -1128,16 +1125,20 @@ class ServicePrimeTransfer extends ServiceBase {
       ) {
         const item = dataSource[itemId];
         let tonMnemonicCredential: string | undefined;
-        if (
-          item &&
-          accountUtils.isImportedAccount({ accountId: itemId }) &&
-          (item as unknown as { impl: string }).impl === IMPL_TON
-        ) {
-          const tonMnemonicCredentialId =
-            accountUtils.buildTonMnemonicCredentialId({
-              accountId: itemId,
-            });
-          tonMnemonicCredential = credentials?.[tonMnemonicCredentialId];
+        try {
+          if (
+            item &&
+            accountUtils.isImportedAccount({ accountId: itemId }) &&
+            (item as unknown as { impl: string } | undefined)?.impl === IMPL_TON
+          ) {
+            const tonMnemonicCredentialId =
+              accountUtils.buildTonMnemonicCredentialId({
+                accountId: itemId,
+              });
+            tonMnemonicCredential = credentials?.[tonMnemonicCredentialId];
+          }
+        } catch (e) {
+          console.error('tonMnemonicCredential error', e);
         }
         const credential = credentials?.[itemId];
         results.push({ item, credential, id: itemId, tonMnemonicCredential });

--- a/packages/kit-bg/src/services/ServicePrimeTransfer/ServicePrimeTransfer.ts
+++ b/packages/kit-bg/src/services/ServicePrimeTransfer/ServicePrimeTransfer.ts
@@ -8,6 +8,7 @@ import {
   decryptImportedCredential,
   decryptRevealableSeed,
   encryptAsync,
+  encryptRevealableSeed,
   mnemonicFromEntropy,
 } from '@onekeyhq/core/src/secret';
 import appCrypto from '@onekeyhq/shared/src/appCrypto';
@@ -22,6 +23,7 @@ import {
   WALLET_TYPE_IMPORTED,
   WALLET_TYPE_WATCHING,
 } from '@onekeyhq/shared/src/consts/dbConsts';
+import { IMPL_TON } from '@onekeyhq/shared/src/engine/engineConsts';
 import {
   OneKeyLocalError,
   TransferInvalidCodeError,
@@ -41,16 +43,18 @@ import stringUtils from '@onekeyhq/shared/src/utils/stringUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import type { INetworkAccount } from '@onekeyhq/shared/types/account';
 import { EServiceEndpointEnum } from '@onekeyhq/shared/types/endpoint';
-import {
-  EPrimeTransferServerType,
-  type IE2EESocketUserInfo,
-  type IPrimeTransferData,
-  type IPrimeTransferHDWallet,
-  type IPrimeTransferPrivateData,
-  type IPrimeTransferSelectedData,
-  type IPrimeTransferSelectedItemMap,
-  type IPrimeTransferSelectedItemMapInfo,
+import type {
+  IE2EESocketUserInfo,
+  IPrimeTransferAccount,
+  IPrimeTransferData,
+  IPrimeTransferHDWallet,
+  IPrimeTransferPrivateData,
+  IPrimeTransferSelectedData,
+  IPrimeTransferSelectedDataItem,
+  IPrimeTransferSelectedItemMap,
+  IPrimeTransferSelectedItemMapInfo,
 } from '@onekeyhq/shared/types/prime/primeTransferTypes';
+import { EPrimeTransferServerType } from '@onekeyhq/shared/types/prime/primeTransferTypes';
 import { EReasonForNeedPassword } from '@onekeyhq/shared/types/setting';
 
 import localDb from '../../dbs/local/localDb';
@@ -71,7 +75,6 @@ import e2eeClientToClientApi, {
 } from './e2ee/e2eeClientToClientApi';
 import { createE2EEClientToClientApiProxy } from './e2ee/e2eeClientToClientApiProxy';
 import { createE2EEServerApiProxy } from './e2ee/e2eeServerApiProxy';
-import transferErrors from './e2ee/transferErrors';
 
 import type {
   IECDHEKeyExchangeRequest,
@@ -1103,7 +1106,9 @@ class ServicePrimeTransfer extends ServiceBase {
     return { code, codeWithSeparator };
   }
 
-  private extractSelectedItems<T>({
+  private extractSelectedItems<
+    T extends IPrimeTransferAccount | IPrimeTransferHDWallet,
+  >({
     selectedItemMapInfo,
     dataSource,
     credentials,
@@ -1111,8 +1116,8 @@ class ServicePrimeTransfer extends ServiceBase {
     selectedItemMapInfo: IPrimeTransferSelectedItemMapInfo;
     dataSource: Record<string, T>;
     credentials?: Record<string, string>;
-  }): Array<{ item: T; credential?: string; id: string }> {
-    const results: Array<{ item: T; credential?: string; id: string }> = [];
+  }): Array<IPrimeTransferSelectedDataItem<T>> {
+    const results: Array<IPrimeTransferSelectedDataItem<T>> = [];
     const itemIds = Object.keys(selectedItemMapInfo);
 
     for (let i = 0; i < itemIds.length; i += 1) {
@@ -1122,8 +1127,20 @@ class ServicePrimeTransfer extends ServiceBase {
         dataSource?.[itemId]
       ) {
         const item = dataSource[itemId];
+        let tonMnemonicCredential: string | undefined;
+        if (
+          item &&
+          accountUtils.isImportedAccount({ accountId: itemId }) &&
+          (item as unknown as { impl: string }).impl === IMPL_TON
+        ) {
+          const tonMnemonicCredentialId =
+            accountUtils.buildTonMnemonicCredentialId({
+              accountId: itemId,
+            });
+          tonMnemonicCredential = credentials?.[tonMnemonicCredentialId];
+        }
         const credential = credentials?.[itemId];
-        results.push({ item, credential, id: itemId });
+        results.push({ item, credential, id: itemId, tonMnemonicCredential });
       }
     }
 
@@ -1390,11 +1407,19 @@ class ServicePrimeTransfer extends ServiceBase {
         };
       } = {};
 
+      const indexedAccountNames: {
+        [index: number]: string;
+      } = {};
       for (const hdAccount of wallet.accounts) {
         if (this.currentImportTaskUUID !== taskUUID) {
           // task cancelled
           return cancelledResult;
         }
+
+        if (!isNil(hdAccount?.pathIndex) && hdAccount.name) {
+          indexedAccountNames[hdAccount?.pathIndex] = hdAccount.name;
+        }
+
         try {
           const index = accountUtils.getHDAccountPathIndex({
             account: hdAccount,
@@ -1446,6 +1471,7 @@ class ServicePrimeTransfer extends ServiceBase {
                 walletId: newWallet.id,
                 fromIndex: index,
                 toIndex: index,
+                indexedAccountNames,
                 excludedIndexes: {},
                 saveToDb: true,
                 showUIProgress: true, // emit EAppEventBusNames.BatchCreateAccount event
@@ -1468,6 +1494,22 @@ class ServicePrimeTransfer extends ServiceBase {
             error: (e as Error)?.message || 'Unknown error',
           });
         }
+
+        try {
+          if (newWallet?.id && indexedAccountNames[index]) {
+            const indexedAccountId = accountUtils.buildIndexedAccountId({
+              walletId: newWallet.id,
+              index,
+            });
+            await this.backgroundApi.serviceAccount.setAccountName({
+              indexedAccountId,
+              name: indexedAccountNames[index],
+              skipEventEmit: true,
+            });
+          }
+        } catch (e) {
+          console.error(e);
+        }
       }
       //
     }
@@ -1475,6 +1517,7 @@ class ServicePrimeTransfer extends ServiceBase {
     for (const {
       item: importedAccount,
       credential,
+      tonMnemonicCredential,
     } of selectedTransferData.importedAccounts) {
       if (this.currentImportTaskUUID !== taskUUID) {
         // task cancelled
@@ -1499,6 +1542,7 @@ class ServicePrimeTransfer extends ServiceBase {
           password,
           networkId,
         });
+
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { addedAccounts } =
         await serviceAccount.restoreImportedAccountByInput({
@@ -1507,7 +1551,35 @@ class ServicePrimeTransfer extends ServiceBase {
           privateKey,
           networkId,
         });
-      if (addedAccounts?.length) {
+      if (addedAccounts?.length && addedAccounts?.[0]?.id) {
+        try {
+          if (tonMnemonicCredential) {
+            const tonRs = await decryptRevealableSeed({
+              rs: tonMnemonicCredential,
+              password,
+            });
+            const { password: localPassword } =
+              await this.backgroundApi.servicePassword.promptPasswordVerify({
+                reason: EReasonForNeedPassword.Default,
+              });
+            const tonRsEncrypted = await encryptRevealableSeed({
+              rs: tonRs,
+              password: localPassword,
+            });
+            await localDb.saveTonImportedAccountMnemonic({
+              accountId: addedAccounts?.[0]?.id,
+              rs: tonRsEncrypted,
+            });
+            // const tonMnemonic2 = await tonMnemonicFromEntropy(
+            //   tonMnemonicCredential,
+            //   password,
+            // );
+            // console.log('tonMnemonic2', tonMnemonic2);
+          }
+        } catch (e) {
+          console.error('tonMnemonicCredential error', e);
+        }
+
         await this.updateImportProgress();
         await timerUtils.wait(100); // wait for UI refresh
       }

--- a/packages/kit/src/views/Onboarding/pages/ImportWallet/ImportWalletOptions.tsx
+++ b/packages/kit/src/views/Onboarding/pages/ImportWallet/ImportWalletOptions.tsx
@@ -137,6 +137,18 @@ export function ImportWalletOptions() {
     });
   };
 
+  const handleImportFromCloud = async () => {
+    await backupEntryStatus.check();
+    navigation.push(EOnboardingPages.ImportCloudBackup);
+    defaultLogger.account.wallet.addWalletStarted({
+      addMethod: 'ImportWallet',
+      details: {
+        importType: 'cloud',
+      },
+      isSoftwareWalletOnlyUser,
+    });
+  };
+
   const handleImportByTransfer = async () => {
     // await backupEntryStatus.check();
     navigation?.pushModal(EModalRoutes.PrimeModal, {
@@ -241,7 +253,7 @@ export function ImportWalletOptions() {
                   ? ETranslations.global_google_drive
                   : ETranslations.global_icloud,
               }),
-              onPress: handleImportByTransfer,
+              onPress: handleImportFromCloud,
             } as IOptionItem)
           : null,
         isV4DbExist

--- a/packages/shared/src/utils/accountUtils.ts
+++ b/packages/shared/src/utils/accountUtils.ts
@@ -773,6 +773,14 @@ function isTonMnemonicCredentialId(credentialId: string): boolean {
   return credentialId.endsWith('--ton_credential');
 }
 
+function getAccountIdFromTonMnemonicCredentialId({
+  credentialId,
+}: {
+  credentialId: string;
+}) {
+  return credentialId.replace(/--ton_credential$/, '');
+}
+
 function buildHyperLiquidAgentCredentialId({
   userAddress,
   agentName,
@@ -904,6 +912,7 @@ export default {
   buildAccountLocalAssetsKey,
   buildTonMnemonicCredentialId,
   isTonMnemonicCredentialId,
+  getAccountIdFromTonMnemonicCredentialId,
   buildHyperLiquidAgentCredentialId,
   HYPERLIQUID_AGENT_CREDENTIAL_PREFIX,
   buildCustomEvmNetworkId,

--- a/packages/shared/types/prime/primeTransferTypes.ts
+++ b/packages/shared/types/prime/primeTransferTypes.ts
@@ -70,21 +70,16 @@ export type IPrimeTransferSelectedItemMap = {
   watchingAccount: IPrimeTransferSelectedItemMapInfo;
 };
 
+export type IPrimeTransferSelectedDataItem<T> = {
+  item: T;
+  credential?: string;
+  tonMnemonicCredential?: string;
+  id: string;
+};
 export type IPrimeTransferSelectedData = {
-  wallets: {
-    item: IPrimeTransferHDWallet;
-    credential?: string;
-    id: string;
-  }[];
-  importedAccounts: {
-    item: IPrimeTransferAccount;
-    credential?: string;
-    id: string;
-  }[];
-  watchingAccounts: {
-    item: IPrimeTransferAccount;
-    id: string;
-  }[];
+  wallets: IPrimeTransferSelectedDataItem<IPrimeTransferHDWallet>[];
+  importedAccounts: IPrimeTransferSelectedDataItem<IPrimeTransferAccount>[];
+  watchingAccounts: IPrimeTransferSelectedDataItem<IPrimeTransferAccount>[];
 };
 
 export interface IE2EESocketUserInfo {


### PR DESCRIPTION


- Add TON mnemonic credential handling in ServiceAccount for proper account lookup
- Support indexed account names in batch account creation workflow
- Implement TON mnemonic storage and restoration in Prime Transfer service
- Fix cloud backup import routing in onboarding flow
- Add utility functions for TON credential ID management
- Improve type safety in Prime Transfer selected data structures

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Per-index naming for HD/Hardware batch account creation.
  * Enabled “Import from Cloud” option in onboarding.

* Improvements
  * Prime Transfer now preserves and securely re-encrypts TON mnemonics for imported TON accounts.
  * Custom names from HD wallets are propagated to newly created indexed accounts during transfer.

* Bug Fixes
  * Correctly associates TON imported credential IDs with their underlying accounts, improving TON account detection and transfer reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->