### PR TITLE
fix: enhance account selection logic in AccountSelectorActions

### DIFF
--- a/packages/kit-bg/src/services/ServiceBatchCreateAccount/ServiceBatchCreateAccount.ts
+++ b/packages/kit-bg/src/services/ServiceBatchCreateAccount/ServiceBatchCreateAccount.ts
@@ -36,12 +36,12 @@ import { getVaultSettings } from '../../vaults/settings';
 import { buildDefaultAddAccountNetworks } from '../ServiceAccount/defaultNetworkAccountsConfig';
 import ServiceBase from '../ServiceBase';
 
-import type { AllNetworkAddressParams } from '@onekeyfe/hd-core';
 import type {
   IAccountDeriveTypes,
   IHwAllNetworkPrepareAccountsResponse,
 } from '../../vaults/types';
 import type { IWithHardwareProcessingControlParams } from '../ServiceHardwareUI/ServiceHardwareUI';
+import type { AllNetworkAddressParams } from '@onekeyfe/hd-core';
 
 export type IBatchCreateAccountProgressInfo = {
   totalCount: number;

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -360,14 +360,14 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
           oldSelectedAccount.walletId === 'hd-2' &&
           newSelectedAccount.walletId === 'hd-4'
         ) {
-          debugger;
+          // debugger;
         }
 
         if (
           oldSelectedAccount.walletId === undefined &&
           newSelectedAccount.walletId === 'hd-2'
         ) {
-          debugger;
+          // debugger;
         }
 
         if (

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -357,6 +357,20 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
         }
 
         if (
+          oldSelectedAccount.walletId === 'hd-2' &&
+          newSelectedAccount.walletId === 'hd-4'
+        ) {
+          debugger;
+        }
+
+        if (
+          oldSelectedAccount.walletId === undefined &&
+          newSelectedAccount.walletId === 'hd-2'
+        ) {
+          debugger;
+        }
+
+        if (
           sceneInfo?.sceneName === EAccountSelectorSceneName.discover &&
           newSelectedAccount?.indexedAccountId === 'hd-1--0'
         ) {
@@ -1667,6 +1681,8 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
         availableNetworks,
       }: IAccountSelectorSyncFromSceneParams,
     ) => {
+      await this.autoSelectNextAccountMutex.waitForUnlock();
+
       const sceneInfo = await this.getCurrentSceneInfo.call(set);
       const { sceneName, sceneUrl, sceneNum } = from;
 
@@ -1888,6 +1904,8 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
     },
   );
 
+  autoSelectNextAccountMutex = new Semaphore(1);
+
   autoSelectNextAccount = contextAtomMethod(
     async (
       get,
@@ -1927,250 +1945,254 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
         return;
       }
 
-      // TODO auto select account from home scene
-      const { network, wallet, indexedAccount, account, dbAccount } =
-        activeAccount;
-      const selectedAccount = this.getSelectedAccount.call(set, { num });
-      const isAccountExist = Boolean(indexedAccount || account || dbAccount);
-      const shouldAutoSelectNextAccount =
-        !selectedAccount?.focusedWallet ||
-        !network ||
-        !wallet ||
-        !isAccountExist;
+      await this.autoSelectNextAccountMutex.runExclusive(async () => {
+        // TODO auto select account from home scene
+        const { network, wallet, indexedAccount, account, dbAccount } =
+          activeAccount;
+        const selectedAccount = this.getSelectedAccount.call(set, { num });
+        const isAccountExist = Boolean(indexedAccount || account || dbAccount);
+        const shouldAutoSelectNextAccount =
+          !selectedAccount?.focusedWallet ||
+          !network ||
+          !wallet ||
+          !isAccountExist;
 
-      if (shouldAutoSelectNextAccount) {
-        defaultLogger.accountSelector.autoSelect.startAutoSelect({
-          focusedWallet: selectedAccount?.focusedWallet,
-          networkId: network?.id,
-          walletId: wallet?.id,
-          isAccountExist,
-        });
+        if (shouldAutoSelectNextAccount) {
+          defaultLogger.accountSelector.autoSelect.startAutoSelect({
+            focusedWallet: selectedAccount?.focusedWallet,
+            networkId: network?.id,
+            walletId: wallet?.id,
+            isAccountExist,
+          });
 
-        const selectedAccountNew = await this.cloneSelectedAccountNew.call(
-          set,
-          {
-            num,
-          },
-        );
+          const selectedAccountNew = await this.cloneSelectedAccountNew.call(
+            set,
+            {
+              num,
+            },
+          );
 
-        defaultLogger.accountSelector.autoSelect.currentSelectedAccount({
-          selectedAccount: selectedAccountNew,
-        });
+          defaultLogger.accountSelector.autoSelect.currentSelectedAccount({
+            selectedAccount: selectedAccountNew,
+          });
 
-        let selectedWalletId = wallet?.id;
-        let selectedWallet = wallet;
-        let selectedIndexedAccountId = indexedAccount?.id;
-        // accountUtils.isHwWallet
-        const hasIndexedAccounts =
-          selectedWalletId &&
-          (accountUtils.isHdWallet({
-            walletId: selectedWalletId,
-          }) ||
-            accountUtils.isHwOrQrWallet({
-              walletId: selectedWalletId,
-            })) &&
-          (await serviceAccount.isWalletHasIndexedAccounts({
-            walletId: selectedWalletId,
-          }));
-        const currentFocusWallet = selectedAccount?.focusedWallet;
-
-        // auto select hd hw wallet if current wallet not contains next available account
-        if (!selectedWalletId || !hasIndexedAccounts) {
-          let shouldSelectHdHwWallet = true;
-          if (
+          let selectedWalletId = wallet?.id;
+          let selectedWallet = wallet;
+          let selectedIndexedAccountId = indexedAccount?.id;
+          // accountUtils.isHwWallet
+          const hasIndexedAccounts =
             selectedWalletId &&
-            accountUtils.isOthersWallet({ walletId: selectedWalletId })
+            (accountUtils.isHdWallet({
+              walletId: selectedWalletId,
+            }) ||
+              accountUtils.isHwOrQrWallet({
+                walletId: selectedWalletId,
+              })) &&
+            (await serviceAccount.isWalletHasIndexedAccounts({
+              walletId: selectedWalletId,
+            }));
+          const currentFocusWallet = selectedAccount?.focusedWallet;
+
+          // auto select hd hw wallet if current wallet not contains next available account
+          if (!selectedWalletId || !hasIndexedAccounts) {
+            let shouldSelectHdHwWallet = true;
+            if (
+              selectedWalletId &&
+              accountUtils.isOthersWallet({ walletId: selectedWalletId })
+            ) {
+              try {
+                const { accounts } =
+                  await serviceAccount.getSingletonAccountsOfWallet({
+                    walletId: selectedWalletId as IDBWalletIdSingleton,
+                    activeNetworkId: network?.id || '',
+                  });
+                const firstAccount = accounts?.[0];
+                if (firstAccount) {
+                  // others wallet contains next available account, no need to switch to other hd hw wallet
+                  shouldSelectHdHwWallet = false;
+                }
+              } catch (e) {
+                //
+              }
+            }
+            if (shouldSelectHdHwWallet) {
+              // wait for hardware indexed account created
+              await timerUtils.wait(600);
+              await serviceAccount.clearAccountCache();
+              const { wallets } = await serviceAccount.getAllHdHwQrWallets();
+              for (const wallet0 of wallets) {
+                if (
+                  !wallet0?.isMocked &&
+                  (await serviceAccount.isWalletHasIndexedAccounts({
+                    walletId: wallet0.id,
+                  }))
+                ) {
+                  selectedWallet = wallet0;
+                  selectedWalletId = selectedWallet?.id;
+                  selectedAccountNew.walletId = selectedWalletId;
+                  break;
+                }
+              }
+              // maybe no hd hw wallet found, reset walletId and indexedAccountId
+              if (!selectedWallet) {
+                defaultLogger.accountSelector.autoSelect.resetSelectedWalletToUndefined(
+                  {
+                    selectedAccount: selectedAccountNew,
+                  },
+                );
+
+                selectedAccountNew.walletId = undefined;
+                selectedAccountNew.indexedAccountId = undefined;
+              }
+            }
+          }
+
+          const isHdWallet = accountUtils.isHdWallet({
+            walletId: selectedWalletId,
+          });
+          const isHwOrQrWallet = accountUtils.isHwOrQrWallet({
+            walletId: selectedWalletId,
+          });
+
+          // auto select hd or hw index account
+          if (selectedWalletId && (isHdWallet || isHwOrQrWallet)) {
+            if (
+              !indexedAccount ||
+              indexedAccount.walletId !== selectedWalletId
+            ) {
+              const { accounts: indexedAccounts } =
+                await serviceAccount.getIndexedAccountsOfWallet({
+                  walletId: selectedWalletId,
+                });
+              selectedIndexedAccountId = indexedAccounts?.[0]?.id;
+              selectedAccountNew.indexedAccountId = selectedIndexedAccountId;
+              selectedAccountNew.focusedWallet = selectedWalletId;
+              selectedAccountNew.othersWalletAccountId = undefined;
+            }
+          }
+
+          const isOthers =
+            Boolean(selectedWalletId) && !isHdWallet && !isHwOrQrWallet;
+
+          if (isOthers) {
+            selectedAccountNew.focusedWallet = selectedWalletId;
+            selectedAccountNew.walletId = selectedWalletId;
+            selectedAccountNew.indexedAccountId = undefined;
+            // others account may be removed
+            if (!account?.id) {
+              selectedAccountNew.othersWalletAccountId = undefined;
+            }
+          }
+
+          // auto select others singleton account
+          if (
+            !selectedAccountNew.indexedAccountId &&
+            !selectedAccountNew.othersWalletAccountId
           ) {
-            try {
+            const autoSelectAccountFromOthersWallet = async (
+              singletonWalletId: IDBWalletIdSingleton,
+            ) => {
               const { accounts } =
                 await serviceAccount.getSingletonAccountsOfWallet({
-                  walletId: selectedWalletId as IDBWalletIdSingleton,
+                  walletId: singletonWalletId,
                   activeNetworkId: network?.id || '',
                 });
               const firstAccount = accounts?.[0];
               if (firstAccount) {
-                // others wallet contains next available account, no need to switch to other hd hw wallet
-                shouldSelectHdHwWallet = false;
+                const accountNetworkId =
+                  accountUtils.getAccountCompatibleNetwork({
+                    account: firstAccount,
+                    networkId: network?.id || '',
+                  });
+                selectedAccountNew.focusedWallet = singletonWalletId;
+                selectedAccountNew.networkId = accountNetworkId || network?.id;
+                selectedAccountNew.deriveType = 'default';
+                selectedAccountNew.walletId = singletonWalletId;
+                selectedAccountNew.indexedAccountId = undefined;
+                selectedAccountNew.othersWalletAccountId = firstAccount.id;
+                return true;
               }
-            } catch (e) {
-              //
-            }
-          }
-          if (shouldSelectHdHwWallet) {
-            // wait for hardware indexed account created
-            await timerUtils.wait(600);
-            await serviceAccount.clearAccountCache();
-            const { wallets } = await serviceAccount.getAllHdHwQrWallets();
-            for (const wallet0 of wallets) {
-              if (
-                !wallet0?.isMocked &&
-                (await serviceAccount.isWalletHasIndexedAccounts({
-                  walletId: wallet0.id,
-                }))
-              ) {
-                selectedWallet = wallet0;
-                selectedWalletId = selectedWallet?.id;
-                selectedAccountNew.walletId = selectedWalletId;
+              return false;
+            };
+            const othersWallets: IDBWalletIdSingleton[] = [
+              WALLET_TYPE_IMPORTED,
+              WALLET_TYPE_WATCHING,
+              WALLET_TYPE_EXTERNAL,
+            ];
+            for (const walletType of othersWallets) {
+              const done = await autoSelectAccountFromOthersWallet(walletType);
+              if (done) {
                 break;
               }
             }
-            // maybe no hd hw wallet found, reset walletId and indexedAccountId
-            if (!selectedWallet) {
-              defaultLogger.accountSelector.autoSelect.resetSelectedWalletToUndefined(
-                {
-                  selectedAccount: selectedAccountNew,
-                },
-              );
+          }
 
+          // TODO auto select network and derive type, check network compatible for others wallet account
+
+          if (selectedAccountNew.walletId) {
+            const finalWallet = await serviceAccount.getWalletSafe({
+              walletId: selectedAccountNew.walletId,
+            });
+            if (!finalWallet) {
               selectedAccountNew.walletId = undefined;
               selectedAccountNew.indexedAccountId = undefined;
+              selectedAccountNew.othersWalletAccountId = undefined;
+              selectedAccountNew.focusedWallet = undefined;
+            } else if (
+              !selectedAccountNew.othersWalletAccountId &&
+              finalWallet.id &&
+              accountUtils.isOthersWallet({
+                walletId: finalWallet.id,
+              })
+            ) {
+              // reset focused wallet when last others wallet account removed
+              selectedAccountNew.othersWalletAccountId = undefined;
+              selectedAccountNew.focusedWallet = undefined;
+              selectedAccountNew.walletId = undefined;
             }
           }
-        }
 
-        const isHdWallet = accountUtils.isHdWallet({
-          walletId: selectedWalletId,
-        });
-        const isHwOrQrWallet = accountUtils.isHwOrQrWallet({
-          walletId: selectedWalletId,
-        });
-
-        // auto select hd or hw index account
-        if (selectedWalletId && (isHdWallet || isHwOrQrWallet)) {
-          if (!indexedAccount || indexedAccount.walletId !== selectedWalletId) {
-            const { accounts: indexedAccounts } =
-              await serviceAccount.getIndexedAccountsOfWallet({
-                walletId: selectedWalletId,
-              });
-            selectedIndexedAccountId = indexedAccounts?.[0]?.id;
-            selectedAccountNew.indexedAccountId = selectedIndexedAccountId;
-            selectedAccountNew.focusedWallet = selectedWalletId;
-            selectedAccountNew.othersWalletAccountId = undefined;
-          }
-        }
-
-        const isOthers =
-          Boolean(selectedWalletId) && !isHdWallet && !isHwOrQrWallet;
-
-        if (isOthers) {
-          selectedAccountNew.focusedWallet = selectedWalletId;
-          selectedAccountNew.walletId = selectedWalletId;
-          selectedAccountNew.indexedAccountId = undefined;
-          // others account may be removed
-          if (!account?.id) {
-            selectedAccountNew.othersWalletAccountId = undefined;
-          }
-        }
-
-        // auto select others singleton account
-        if (
-          !selectedAccountNew.indexedAccountId &&
-          !selectedAccountNew.othersWalletAccountId
-        ) {
-          const autoSelectAccountFromOthersWallet = async (
-            singletonWalletId: IDBWalletIdSingleton,
-          ) => {
-            const { accounts } =
-              await serviceAccount.getSingletonAccountsOfWallet({
-                walletId: singletonWalletId,
-                activeNetworkId: network?.id || '',
-              });
-            const firstAccount = accounts?.[0];
-            if (firstAccount) {
-              const accountNetworkId = accountUtils.getAccountCompatibleNetwork(
-                {
-                  account: firstAccount,
-                  networkId: network?.id || '',
-                },
-              );
-              selectedAccountNew.focusedWallet = singletonWalletId;
-              selectedAccountNew.networkId = accountNetworkId || network?.id;
-              selectedAccountNew.deriveType = 'default';
-              selectedAccountNew.walletId = singletonWalletId;
-              selectedAccountNew.indexedAccountId = undefined;
-              selectedAccountNew.othersWalletAccountId = firstAccount.id;
-              return true;
-            }
-            return false;
-          };
-          const othersWallets: IDBWalletIdSingleton[] = [
-            WALLET_TYPE_IMPORTED,
-            WALLET_TYPE_WATCHING,
-            WALLET_TYPE_EXTERNAL,
-          ];
-          for (const walletType of othersWallets) {
-            const done = await autoSelectAccountFromOthersWallet(walletType);
-            if (done) {
-              break;
-            }
-          }
-        }
-
-        // TODO auto select network and derive type, check network compatible for others wallet account
-
-        if (selectedAccountNew.walletId) {
-          const finalWallet = await serviceAccount.getWalletSafe({
-            walletId: selectedAccountNew.walletId,
-          });
-          if (!finalWallet) {
-            selectedAccountNew.walletId = undefined;
-            selectedAccountNew.indexedAccountId = undefined;
-            selectedAccountNew.othersWalletAccountId = undefined;
-            selectedAccountNew.focusedWallet = undefined;
-          } else if (
-            !selectedAccountNew.othersWalletAccountId &&
-            finalWallet.id &&
-            accountUtils.isOthersWallet({
-              walletId: finalWallet.id,
-            })
-          ) {
-            // reset focused wallet when last others wallet account removed
-            selectedAccountNew.othersWalletAccountId = undefined;
-            selectedAccountNew.focusedWallet = undefined;
-            selectedAccountNew.walletId = undefined;
-          }
-        }
-
-        await this.updateSelectedAccount.call(set, {
-          num,
-          builder: () => selectedAccountNew,
-        });
-
-        if (
-          selectedAccount.walletId !== selectedAccountNew.walletId &&
-          triggerBy !==
-            EAccountSelectorAutoSelectTriggerBy.removeLastOthersAccount &&
-          triggerBy !== EAccountSelectorAutoSelectTriggerBy.removeAccount
-        ) {
-          set(accountSelectorEditModeAtom(), false);
-        }
-      }
-
-      const isTriggerByRemoveWalletOrLastOthersAccount =
-        triggerBy &&
-        [
-          EAccountSelectorAutoSelectTriggerBy.removeWallet,
-          EAccountSelectorAutoSelectTriggerBy.removeLastOthersAccount,
-        ].includes(triggerBy);
-      // (else if) when auto select logic not trigger, should fix focusedWallet only
-      // focused A wallet, but remove B wallet, should focus back to A wallet
-      if (
-        !shouldAutoSelectNextAccount &&
-        isTriggerByRemoveWalletOrLastOthersAccount
-      ) {
-        const selectedAccountNew = await this.cloneSelectedAccountNew.call(
-          set,
-          {
+          await this.updateSelectedAccount.call(set, {
             num,
-          },
-        );
-        // autofix focusedWallet when remove an unfocused wallet
-        selectedAccountNew.focusedWallet = selectedAccountNew.walletId;
-        await this.updateSelectedAccount.call(set, {
-          num,
-          builder: () => selectedAccountNew,
-        });
-      }
+            builder: () => selectedAccountNew,
+          });
+
+          if (
+            selectedAccount.walletId !== selectedAccountNew.walletId &&
+            triggerBy !==
+              EAccountSelectorAutoSelectTriggerBy.removeLastOthersAccount &&
+            triggerBy !== EAccountSelectorAutoSelectTriggerBy.removeAccount
+          ) {
+            set(accountSelectorEditModeAtom(), false);
+          }
+        }
+
+        const isTriggerByRemoveWalletOrLastOthersAccount =
+          triggerBy &&
+          [
+            EAccountSelectorAutoSelectTriggerBy.removeWallet,
+            EAccountSelectorAutoSelectTriggerBy.removeLastOthersAccount,
+          ].includes(triggerBy);
+        // (else if) when auto select logic not trigger, should fix focusedWallet only
+        // focused A wallet, but remove B wallet, should focus back to A wallet
+        if (
+          !shouldAutoSelectNextAccount &&
+          isTriggerByRemoveWalletOrLastOthersAccount
+        ) {
+          const selectedAccountNew = await this.cloneSelectedAccountNew.call(
+            set,
+            {
+              num,
+            },
+          );
+          // autofix focusedWallet when remove an unfocused wallet
+          selectedAccountNew.focusedWallet = selectedAccountNew.walletId;
+          await this.updateSelectedAccount.call(set, {
+            num,
+            builder: () => selectedAccountNew,
+          });
+        }
+      });
     },
   );
 }

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -357,20 +357,6 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
         }
 
         if (
-          oldSelectedAccount.walletId === 'hd-2' &&
-          newSelectedAccount.walletId === 'hd-4'
-        ) {
-          // debugger;
-        }
-
-        if (
-          oldSelectedAccount.walletId === undefined &&
-          newSelectedAccount.walletId === 'hd-2'
-        ) {
-          // debugger;
-        }
-
-        if (
           sceneInfo?.sceneName === EAccountSelectorSceneName.discover &&
           newSelectedAccount?.indexedAccountId === 'hd-1--0'
         ) {


### PR DESCRIPTION
- Introduced a mutex for auto-selecting the next account to prevent race conditions.
- Added conditions to handle specific wallet transitions and ensure proper account focus.
- Refactored account selection logic to improve clarity and maintainability.
- Updated the handling of others wallet accounts to ensure correct selection and focus behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of automatic account selection across HD/Hardware and Other wallets.
  * Corrected cases where the wrong wallet/account could be focused after removing wallets or accounts.
  * Reduced inconsistent states caused by overlapping auto-select actions.

* **Refactor**
  * Streamlined the auto-select flow to handle more scenarios and ensure consistent focus and selection behavior.

* **Chores**
  * Minor code organization updates with no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->