### PR TITLE
fix: swap to another address opt code OK-42232 OK-42233

### DIFF
--- a/packages/kit/src/views/Swap/hooks/useSwapQuote.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapQuote.ts
@@ -43,6 +43,7 @@ import {
   useSwapSelectToTokenAtom,
   useSwapShouldRefreshQuoteAtom,
   useSwapSlippageDialogOpeningAtom,
+  useSwapToAnotherAccountAddressAtom,
   useSwapToTokenAmountAtom,
   useSwapTypeSwitchAtom,
 } from '../../../states/jotai/contexts/swap';
@@ -63,6 +64,7 @@ export function useSwapQuote() {
   const [swapQuoteActionLock] = useSwapQuoteActionLockAtom();
   const swapAddressInfo = useSwapAddressInfo(ESwapDirectionType.FROM);
   const swapToAddressInfo = useSwapAddressInfo(ESwapDirectionType.TO);
+  const [swapToAnotherAccountAddress] = useSwapToAnotherAccountAddressAtom();
   const [fromToken, setSwapSelectFromToken] = useSwapSelectFromTokenAtom();
   const { slippageItem } = useSwapSlippagePercentageModeInfo();
   const [toToken, setSwapSelectToToken] = useSwapSelectToTokenAtom();
@@ -265,6 +267,13 @@ export function useSwapQuote() {
       return;
     }
     if (
+      !isFocusRef.current &&
+      !swapToAnotherAccountAddress?.address &&
+      settingsAtomRef.current.swapToAnotherAccountSwitchOn
+    ) {
+      return;
+    }
+    if (
       fromToken?.networkId !== activeAccountRef.current?.networkId ||
       equalTokenNoCaseSensitive({
         token1: {
@@ -322,6 +331,7 @@ export function useSwapQuote() {
       swapToAddressInfoRef.current.address,
     );
   }, [
+    swapToAnotherAccountAddress,
     cleanQuoteInterval,
     quoteAction,
     swapAddressInfo.address,
@@ -369,6 +379,13 @@ export function useSwapQuote() {
       !isFocusRef.current &&
       swapToAddressInfo.address ===
         swapQuoteActionLockRef.current?.receivingAddress
+    ) {
+      return;
+    }
+    if (
+      !isFocusRef.current &&
+      !swapToAnotherAccountAddress?.address &&
+      settingsAtomRef.current.swapToAnotherAccountSwitchOn
     ) {
       return;
     }
@@ -433,6 +450,7 @@ export function useSwapQuote() {
       swapToAddressInfoRef.current.address,
     );
   }, [
+    swapToAnotherAccountAddress,
     cleanQuoteInterval,
     quoteAction,
     swapAddressInfo.address,

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -26,6 +26,7 @@ import {
   useSwapBuildTxFetchingAtom,
   useSwapFromTokenAmountAtom,
   useSwapLimitPriceUseRateAtom,
+  useSwapQuoteActionLockAtom,
   useSwapQuoteCurrentSelectAtom,
   useSwapQuoteIntervalCountAtom,
   useSwapSelectFromTokenAtom,
@@ -122,6 +123,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
   const [, setSwapQuoteIntervalCount] = useSwapQuoteIntervalCountAtom();
   const { selectFromToken, selectToToken, quoteAction, cleanQuoteInterval } =
     useSwapActions().current;
+  const [{ actionLock }] = useSwapQuoteActionLockAtom();
   const [fromTokenBalance] = useSwapSelectedFromTokenBalanceAtom();
   const [, setSwapShouldRefreshQuote] = useSwapShouldRefreshQuoteAtom();
   const [, setSwapBuildTxFetching] = useSwapBuildTxFetchingAtom();
@@ -233,6 +235,9 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
           toAddressInfo?.address,
         );
       } else {
+        if (actionLock) {
+          return;
+        }
         setSwapQuoteIntervalCount((v) => v + 1);
         void quoteAction(
           swapSlippageRef.current,
@@ -247,6 +252,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
       }
     },
     [
+      actionLock,
       quoteAction,
       swapFromAddressInfo?.address,
       swapFromAddressInfo?.accountInfo?.account?.id,

--- a/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
@@ -72,10 +72,14 @@ const SwapToAnotherAddressPage = () => {
   useEffect(() => {
     if (address && accountInfo?.account?.address === address) {
       form.setValue('address', { raw: address });
-    } else if (paramAddress) {
+    }
+  }, [accountInfo?.account?.address, address, form]);
+
+  useEffect(() => {
+    if (paramAddress) {
       form.setValue('address', { raw: paramAddress });
     }
-  }, [accountInfo?.account?.address, address, form, paramAddress]);
+  }, [paramAddress, form]);
 
   const handleOnOpenAccountSelector = useCallback(() => {
     setSettings((v) => ({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added “swap to another account” flow integration in swap quoting.
  - Introduced an action lock that pauses automatic quote refreshing (manual refresh unaffected).
- Bug Fixes
  - Route-provided address now reliably pre-fills the “swap to another address” input.
  - Prevents unnecessary quote requests when the app is unfocused or the alternate-account flow isn’t engaged, reducing noise and improving stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->