### PR TITLE
feat: add useBlockExplorerNavigation hook and integrate into EmptyHistory and TxHistoryListView components OK-42292

### DIFF
--- a/packages/kit/src/components/Empty/EmptyHistory.tsx
+++ b/packages/kit/src/components/Empty/EmptyHistory.tsx
@@ -5,15 +5,9 @@ import { useIntl } from 'react-intl';
 import { Button, Empty } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import {
-  EModalRoutes,
-  EModalWalletAddressRoutes,
-} from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
-import { EWalletAddressActionType } from '@onekeyhq/shared/types/address';
 
 import { useAccountData } from '../../hooks/useAccountData';
-import useAppNavigation from '../../hooks/useAppNavigation';
 import { useBlockExplorerNavigation } from '../../hooks/useBlockExplorerNavigation';
 import { openExplorerAddressUrl } from '../../utils/explorerUtils';
 import AddressTypeSelector from '../AddressTypeSelector/AddressTypeSelector';
@@ -35,40 +29,26 @@ function EmptyHistory({
   isSingleAccount,
 }: IEmptyHistoryProps) {
   const intl = useIntl();
-  const appNavigation = useAppNavigation();
   const { account, network, vaultSettings } = useAccountData({
     accountId,
     networkId,
   });
-  const { isInternalNav } = useBlockExplorerNavigation(network, walletId);
+  const { requiresNetworkSelection, openExplorer } = useBlockExplorerNavigation(
+    network,
+    walletId,
+  );
 
   const handleOnPress = useCallback(async () => {
-    if (isInternalNav) {
-      appNavigation.pushModal(EModalRoutes.WalletAddress, {
-        screen: EModalWalletAddressRoutes.WalletAddress,
-        params: {
-          title: intl.formatMessage({
-            id: ETranslations.global_select_network,
-          }),
-          accountId,
-          walletId: walletId ?? '',
-          indexedAccountId: indexedAccountId ?? '',
-          actionType: EWalletAddressActionType.ViewInExplorer,
-        },
-      });
-    } else {
-      await openExplorerAddressUrl({
-        networkId: account?.createAtNetwork ?? network?.id,
-        address: account?.address,
-      });
-    }
+    await openExplorer({
+      accountId,
+      indexedAccountId,
+      networkId: account?.createAtNetwork ?? network?.id,
+      address: account?.address,
+    });
   }, [
-    isInternalNav,
-    appNavigation,
-    intl,
+    openExplorer,
     accountId,
     indexedAccountId,
-    walletId,
     account?.createAtNetwork,
     account?.address,
     network?.id,
@@ -107,7 +87,7 @@ function EmptyHistory({
         variant="secondary"
         onPress={handleOnPress}
         mt="$6"
-        iconAfter={isInternalNav ? undefined : 'OpenOutline'}
+        iconAfter={requiresNetworkSelection ? undefined : 'OpenOutline'}
       >
         {intl.formatMessage({ id: ETranslations.global_block_explorer })}
       </Button>
@@ -115,7 +95,7 @@ function EmptyHistory({
   }, [
     account?.indexedAccountId,
     handleOnPress,
-    isInternalNav,
+    requiresNetworkSelection,
     indexedAccountId,
     intl,
     isSingleAccount,

--- a/packages/kit/src/components/Empty/EmptyHistory.tsx
+++ b/packages/kit/src/components/Empty/EmptyHistory.tsx
@@ -43,10 +43,7 @@ function EmptyHistory({
   const { isInternalNav } = useBlockExplorerNavigation(network, walletId);
 
   const handleOnPress = useCallback(async () => {
-    if (
-      network?.isAllNetworks &&
-      !accountUtils.isOthersWallet({ walletId: walletId ?? '' })
-    ) {
+    if (isInternalNav) {
       appNavigation.pushModal(EModalRoutes.WalletAddress, {
         screen: EModalWalletAddressRoutes.WalletAddress,
         params: {
@@ -66,15 +63,15 @@ function EmptyHistory({
       });
     }
   }, [
-    network?.isAllNetworks,
-    network?.id,
-    walletId,
+    isInternalNav,
     appNavigation,
     intl,
     accountId,
     indexedAccountId,
+    walletId,
     account?.createAtNetwork,
     account?.address,
+    network?.id,
   ]);
 
   const renderViewInExplorerButton = useCallback(() => {

--- a/packages/kit/src/components/Empty/EmptyHistory.tsx
+++ b/packages/kit/src/components/Empty/EmptyHistory.tsx
@@ -14,6 +14,7 @@ import { EWalletAddressActionType } from '@onekeyhq/shared/types/address';
 
 import { useAccountData } from '../../hooks/useAccountData';
 import useAppNavigation from '../../hooks/useAppNavigation';
+import { useBlockExplorerNavigation } from '../../hooks/useBlockExplorerNavigation';
 import { openExplorerAddressUrl } from '../../utils/explorerUtils';
 import AddressTypeSelector from '../AddressTypeSelector/AddressTypeSelector';
 
@@ -39,6 +40,7 @@ function EmptyHistory({
     accountId,
     networkId,
   });
+  const { isInternalNav } = useBlockExplorerNavigation(network, walletId);
 
   const handleOnPress = useCallback(async () => {
     if (
@@ -88,7 +90,7 @@ function EmptyHistory({
         networkId={networkId ?? ''}
         indexedAccountId={indexedAccountId ?? account?.indexedAccountId ?? ''}
         renderSelectorTrigger={
-          <Button size="small" variant="secondary" onPress={() => {}} mt="$3">
+          <Button size="medium" variant="secondary" onPress={() => {}} mt="$6">
             {intl.formatMessage({
               id: ETranslations.global_block_explorer,
             })}
@@ -103,13 +105,20 @@ function EmptyHistory({
         doubleConfirm
       />
     ) : (
-      <Button size="small" variant="secondary" onPress={handleOnPress} mt="$3">
+      <Button
+        size="medium"
+        variant="secondary"
+        onPress={handleOnPress}
+        mt="$6"
+        iconAfter={isInternalNav ? undefined : 'OpenOutline'}
+      >
         {intl.formatMessage({ id: ETranslations.global_block_explorer })}
       </Button>
     );
   }, [
     account?.indexedAccountId,
     handleOnPress,
+    isInternalNav,
     indexedAccountId,
     intl,
     isSingleAccount,

--- a/packages/kit/src/components/TxHistoryListView/index.tsx
+++ b/packages/kit/src/components/TxHistoryListView/index.tsx
@@ -35,6 +35,7 @@ import { EDecodedTxStatus } from '@onekeyhq/shared/types/tx';
 
 import { useAccountData } from '../../hooks/useAccountData';
 import useAppNavigation from '../../hooks/useAppNavigation';
+import { useBlockExplorerNavigation } from '../../hooks/useBlockExplorerNavigation';
 import {
   useHasMoreOnChainHistoryAtom,
   useSearchKeyAtom,
@@ -106,6 +107,7 @@ const ListFooterComponent = ({
     accountId,
     networkId,
   });
+  const { isInternalNav } = useBlockExplorerNavigation(network, walletId);
 
   const handleOnPress = useCallback(async () => {
     if (
@@ -186,7 +188,12 @@ const ListFooterComponent = ({
               doubleConfirm
             />
           ) : (
-            <Button size="small" variant="secondary" onPress={handleOnPress}>
+            <Button
+              size="small"
+              variant="secondary"
+              onPress={handleOnPress}
+              iconAfter={isInternalNav ? undefined : 'OpenOutline'}
+            >
               {intl.formatMessage({ id: ETranslations.global_block_explorer })}
             </Button>
           )}

--- a/packages/kit/src/components/TxHistoryListView/index.tsx
+++ b/packages/kit/src/components/TxHistoryListView/index.tsx
@@ -110,10 +110,7 @@ const ListFooterComponent = ({
   const { isInternalNav } = useBlockExplorerNavigation(network, walletId);
 
   const handleOnPress = useCallback(async () => {
-    if (
-      network?.isAllNetworks &&
-      !accountUtils.isOthersWallet({ walletId: walletId ?? '' })
-    ) {
+    if (isInternalNav) {
       appNavigation.pushModal(EModalRoutes.WalletAddress, {
         screen: EModalWalletAddressRoutes.WalletAddress,
         params: {
@@ -133,15 +130,15 @@ const ListFooterComponent = ({
       });
     }
   }, [
-    network?.isAllNetworks,
-    network?.id,
-    walletId,
+    isInternalNav,
     appNavigation,
     intl,
     accountId,
     indexedAccountId,
+    walletId,
     account?.createAtNetwork,
     account?.address,
+    network?.id,
   ]);
 
   if (

--- a/packages/kit/src/components/TxHistoryListView/index.tsx
+++ b/packages/kit/src/components/TxHistoryListView/index.tsx
@@ -16,17 +16,12 @@ import {
 import { useStyle } from '@onekeyhq/components/src/hooks';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import {
-  EModalRoutes,
-  EModalWalletAddressRoutes,
-} from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { formatDate } from '@onekeyhq/shared/src/utils/dateUtils';
 import {
   convertToSectionGroups,
   getFilteredHistoryBySearchKey,
 } from '@onekeyhq/shared/src/utils/historyUtils';
-import { EWalletAddressActionType } from '@onekeyhq/shared/types/address';
 import type {
   IAccountHistoryTx,
   IHistoryListSectionGroup,
@@ -34,7 +29,6 @@ import type {
 import { EDecodedTxStatus } from '@onekeyhq/shared/types/tx';
 
 import { useAccountData } from '../../hooks/useAccountData';
-import useAppNavigation from '../../hooks/useAppNavigation';
 import { useBlockExplorerNavigation } from '../../hooks/useBlockExplorerNavigation';
 import {
   useHasMoreOnChainHistoryAtom,
@@ -95,7 +89,6 @@ const ListFooterComponent = ({
   hasMoreOnChainHistory?: boolean;
   isSingleAccount?: boolean;
 }) => {
-  const appNavigation = useAppNavigation();
   const { result: extensionActiveTabDAppInfo } = useActiveTabDAppInfo();
   const intl = useIntl();
   const addPaddingOnListFooter = useMemo(
@@ -107,35 +100,22 @@ const ListFooterComponent = ({
     accountId,
     networkId,
   });
-  const { isInternalNav } = useBlockExplorerNavigation(network, walletId);
+  const { requiresNetworkSelection, openExplorer } = useBlockExplorerNavigation(
+    network,
+    walletId,
+  );
 
   const handleOnPress = useCallback(async () => {
-    if (isInternalNav) {
-      appNavigation.pushModal(EModalRoutes.WalletAddress, {
-        screen: EModalWalletAddressRoutes.WalletAddress,
-        params: {
-          title: intl.formatMessage({
-            id: ETranslations.global_select_network,
-          }),
-          accountId,
-          walletId: walletId ?? '',
-          indexedAccountId: indexedAccountId ?? '',
-          actionType: EWalletAddressActionType.ViewInExplorer,
-        },
-      });
-    } else {
-      await openExplorerAddressUrl({
-        networkId: account?.createAtNetwork ?? network?.id,
-        address: account?.address,
-      });
-    }
+    await openExplorer({
+      accountId,
+      indexedAccountId,
+      networkId: account?.createAtNetwork ?? network?.id,
+      address: account?.address,
+    });
   }, [
-    isInternalNav,
-    appNavigation,
-    intl,
+    openExplorer,
     accountId,
     indexedAccountId,
-    walletId,
     account?.createAtNetwork,
     account?.address,
     network?.id,
@@ -189,7 +169,7 @@ const ListFooterComponent = ({
               size="small"
               variant="secondary"
               onPress={handleOnPress}
-              iconAfter={isInternalNav ? undefined : 'OpenOutline'}
+              iconAfter={requiresNetworkSelection ? undefined : 'OpenOutline'}
             >
               {intl.formatMessage({ id: ETranslations.global_block_explorer })}
             </Button>

--- a/packages/kit/src/hooks/useBlockExplorerNavigation.ts
+++ b/packages/kit/src/hooks/useBlockExplorerNavigation.ts
@@ -1,0 +1,18 @@
+import { useMemo } from 'react';
+
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import type { IServerNetwork } from '@onekeyhq/shared/types';
+
+export const useBlockExplorerNavigation = (
+  network: IServerNetwork | undefined,
+  walletId: string | undefined,
+) => {
+  const isInternalNav = useMemo(
+    () =>
+      network?.isAllNetworks &&
+      !accountUtils.isOthersWallet({ walletId: walletId ?? '' }),
+    [network?.isAllNetworks, walletId],
+  );
+
+  return { isInternalNav };
+};

--- a/packages/kit/src/hooks/useBlockExplorerNavigation.ts
+++ b/packages/kit/src/hooks/useBlockExplorerNavigation.ts
@@ -1,18 +1,71 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
+import { useIntl } from 'react-intl';
+
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import {
+  EModalRoutes,
+  EModalWalletAddressRoutes,
+} from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import type { IServerNetwork } from '@onekeyhq/shared/types';
+import { EWalletAddressActionType } from '@onekeyhq/shared/types/address';
+
+import { openExplorerAddressUrl } from '../utils/explorerUtils';
+
+import useAppNavigation from './useAppNavigation';
 
 export const useBlockExplorerNavigation = (
   network: IServerNetwork | undefined,
   walletId: string | undefined,
 ) => {
-  const isInternalNav = useMemo(
+  const intl = useIntl();
+  const appNavigation = useAppNavigation();
+
+  const requiresNetworkSelection = useMemo(
     () =>
       network?.isAllNetworks &&
       !accountUtils.isOthersWallet({ walletId: walletId ?? '' }),
     [network?.isAllNetworks, walletId],
   );
 
-  return { isInternalNav };
+  const openExplorer = useCallback(
+    async ({
+      accountId,
+      indexedAccountId,
+      networkId,
+      address,
+    }: {
+      accountId?: string;
+      indexedAccountId?: string;
+      networkId?: string;
+      address?: string;
+    }) => {
+      if (requiresNetworkSelection) {
+        appNavigation.pushModal(EModalRoutes.WalletAddress, {
+          screen: EModalWalletAddressRoutes.WalletAddress,
+          params: {
+            title: intl.formatMessage({
+              id: ETranslations.global_select_network,
+            }),
+            accountId,
+            walletId: walletId ?? '',
+            indexedAccountId: indexedAccountId ?? '',
+            actionType: EWalletAddressActionType.ViewInExplorer,
+          },
+        });
+      } else {
+        await openExplorerAddressUrl({
+          networkId,
+          address,
+        });
+      }
+    },
+    [requiresNetworkSelection, appNavigation, intl, walletId],
+  );
+
+  return {
+    requiresNetworkSelection,
+    openExplorer,
+  };
 };


### PR DESCRIPTION
- Implemented useBlockExplorerNavigation hook to determine internal navigation status based on network and wallet ID.
- Updated EmptyHistory component to utilize the new hook for conditional rendering of button icon.
- Modified TxHistoryListView component to incorporate the hook for consistent button behavior across transaction history views.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Unified address navigation: tapping an address opens the block explorer directly, or—if a network must be chosen first—prompts for network selection before proceeding.
- Style
  - Action buttons updated to medium size with increased spacing for improved readability.
  - Context-aware icon: external link icon shown only when directly opening the block explorer (hidden when network selection is required).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->