### PR TITLE
fix: interruput query native token when it's all network

### DIFF
--- a/packages/kit-bg/src/services/ServiceToken.ts
+++ b/packages/kit-bg/src/services/ServiceToken.ts
@@ -38,6 +38,7 @@ import ServiceBase from './ServiceBase';
 import type { IDBAccount } from '../dbs/local/types';
 import type { ISimpleDBLocalTokens } from '../dbs/simple/entity/SimpleDbEntityLocalTokens';
 import type { IRiskTokenManagementDBStruct } from '../dbs/simple/entity/SimpleDbEntityRiskTokenManagement';
+import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 
 @backgroundClass()
 class ServiceToken extends ServiceBase {
@@ -515,6 +516,11 @@ class ServiceToken extends ServiceBase {
     tokenIdOnNetwork?: string;
   }) {
     let tokenAddress = tokenIdOnNetwork;
+
+    if (networkUtils.isAllNetwork({ networkId })) {
+      return null;
+    }
+
     if (isNil(tokenAddress)) {
       tokenAddress = await this.getNativeTokenAddress({ networkId });
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents native token from loading in the “All Networks” view, avoiding incorrect token display and potential errors.
* **Stability**
  * Improves reliability when browsing assets across all networks by skipping unnecessary token lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->