### PR TITLE
feat: implement auto-signing of bound referral code messages using Hd wallet

### DIFF
--- a/packages/kit-bg/src/services/ServiceReferralCode.ts
+++ b/packages/kit-bg/src/services/ServiceReferralCode.ts
@@ -1,3 +1,4 @@
+import type { IUnsignedMessage } from '@onekeyhq/core/src/types';
 import {
   backgroundClass,
   backgroundMethod,
@@ -329,6 +330,33 @@ class ServiceReferralCode extends ServiceBase {
       walletId,
       referralCodeInfo,
     });
+  }
+
+  @backgroundMethod()
+  async autoSignBoundReferralCodeMessageByHDWallet({
+    unsignedMessage,
+    networkId,
+    accountId,
+  }: {
+    unsignedMessage: IUnsignedMessage;
+    networkId: string;
+    accountId: string;
+  }) {
+    if (!accountUtils.isHdAccount({ accountId })) {
+      return null;
+    }
+    const cachedPassword =
+      await this.backgroundApi.servicePassword.getCachedPassword();
+    if (!cachedPassword) {
+      return null;
+    }
+
+    const result = await this.backgroundApi.serviceSend.signMessage({
+      unsignedMessage,
+      networkId,
+      accountId,
+    });
+    return result;
   }
 }
 

--- a/packages/kit/src/views/ReferFriends/hooks/useWalletBoundReferralCode.tsx
+++ b/packages/kit/src/views/ReferFriends/hooks/useWalletBoundReferralCode.tsx
@@ -17,6 +17,7 @@ import {
 } from '@onekeyhq/components';
 import { autoFixPersonalSignMessage } from '@onekeyhq/core/src/chains/evm/sdkEvm/signMessage';
 import { EMnemonicType } from '@onekeyhq/core/src/secret';
+import type { IUnsignedMessage } from '@onekeyhq/core/src/types';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import type { IDBWallet } from '@onekeyhq/kit-bg/src/dbs/local/types';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
@@ -193,29 +194,48 @@ function InviteCode({
           walletInfo.isBtcOnlyWallet &&
           networkUtils.isBTCNetwork(walletInfo.networkId);
 
-        const signedMessage = await navigationToMessageConfirmAsync({
-          accountId: walletInfo.accountId,
-          networkId: walletInfo.networkId,
-          unsignedMessage: isBtcOnlyWallet
-            ? {
-                type: EMessageTypesBtc.ECDSA,
-                message: unsignedMessage,
-                sigOptions: {
-                  noScriptType: true,
-                },
-                payload: {
-                  isFromDApp: false,
-                },
-              }
-            : {
-                type: EMessageTypesEth.PERSONAL_SIGN,
-                message: unsignedMessage,
-                payload: [unsignedMessage, walletInfo.address],
+        const finalUnsignedMessage: IUnsignedMessage = isBtcOnlyWallet
+          ? {
+              type: EMessageTypesBtc.ECDSA,
+              message: unsignedMessage,
+              sigOptions: {
+                noScriptType: true,
               },
-          walletInternalSign: true,
-          sameModal: false,
-          skipBackupCheck: true,
-        });
+              payload: {
+                isFromDApp: false,
+              },
+            }
+          : {
+              type: EMessageTypesEth.PERSONAL_SIGN,
+              message: unsignedMessage,
+              payload: [unsignedMessage, walletInfo.address],
+            };
+
+        let signedMessage: string | null;
+
+        signedMessage =
+          await backgroundApiProxy.serviceReferralCode.autoSignBoundReferralCodeMessageByHDWallet(
+            {
+              unsignedMessage: finalUnsignedMessage,
+              networkId: walletInfo.networkId,
+              accountId: walletInfo.accountId,
+            },
+          );
+
+        if (!signedMessage) {
+          signedMessage = await navigationToMessageConfirmAsync({
+            accountId: walletInfo.accountId,
+            networkId: walletInfo.networkId,
+            unsignedMessage: finalUnsignedMessage,
+            walletInternalSign: true,
+            sameModal: false,
+            skipBackupCheck: true,
+          });
+        }
+
+        if (!signedMessage) {
+          throw new OneKeyLocalError('Failed to sign message');
+        }
 
         const bindResult =
           await backgroundApiProxy.serviceReferralCode.boundReferralCodeWithSignedMessage(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-signing for referral code binding when using HD wallets, reducing prompts and speeding up the flow.
  * Smart fallback to manual confirmation if auto-sign isn’t available.
  * Supports both BTC and ETH signing paths with correct signature formats.
  * Clearer error feedback if signing fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->