### PR TITLE
fix: refresh network accounts in address type selector after account or wallet update OK-42348

### DIFF
--- a/packages/kit/src/components/AddressTypeSelector/AddressTypeSelector.tsx
+++ b/packages/kit/src/components/AddressTypeSelector/AddressTypeSelector.tsx
@@ -20,6 +20,10 @@ import type {
   IAccountDeriveTypes,
 } from '@onekeyhq/kit-bg/src/vaults/types';
 import { IMPL_BTC, IMPL_TBTC } from '@onekeyhq/shared/src/engine/engineConsts';
+import {
+  EAppEventBusNames,
+  appEventBus,
+} from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
@@ -546,6 +550,18 @@ function AddressTypeSelector(props: IProps) {
       setTokenMap(tokenMapProp);
     }
   }, [tokenMapProp, networkAccounts, networkId]);
+
+  useEffect(() => {
+    const fn = () => {
+      void refreshNetworkAccounts();
+    };
+    appEventBus.on(EAppEventBusNames.AccountUpdate, fn);
+    appEventBus.on(EAppEventBusNames.WalletUpdate, fn);
+    return () => {
+      appEventBus.off(EAppEventBusNames.AccountUpdate, fn);
+      appEventBus.off(EAppEventBusNames.WalletUpdate, fn);
+    };
+  }, [refreshNetworkAccounts]);
 
   if (isSelectorDisabled) {
     return showTriggerWhenDisabled


### PR DESCRIPTION
…or wallet update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Address list in AddressTypeSelector now updates automatically when your account or wallet changes, ensuring you always see the latest network account options without manual refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->