### PR TITLE
fix: swpa native ios input fix

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -281,13 +281,13 @@ const SwapActionsState = ({
     () => (
       <>
         {actionComponent}
-        <Page.Footer>
-          {!platformEnv.isNativeIOS ? (
+        {!platformEnv.isNativeIOS ? (
+          <Page.Footer>
             <PercentageStageOnKeyboard
               onSelectPercentageStage={onSelectPercentageStage}
             />
-          ) : null}
-        </Page.Footer>
+          </Page.Footer>
+        ) : null}
       </>
     ),
     [actionComponent, onSelectPercentageStage],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue on native iOS where an empty footer appeared on the Swap screen, removing unnecessary blank space.
* **UI**
  * Footer now displays only on non-iOS platforms; iOS users won’t see a footer on the Swap screen, ensuring a cleaner layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->