### PR TITLE
feat: support utm_source on Referral Guide page(OK-42436)

### DIFF
--- a/packages/kit/src/routes/config/deeplink/index.ts
+++ b/packages/kit/src/routes/config/deeplink/index.ts
@@ -100,7 +100,7 @@ async function processDeepLinkUrlAccount(
                 },
               });
             }
-            defaultLogger.referral.page.enterReferralGuide(code);
+            defaultLogger.referral.page.enterReferralGuide(code, utmSource);
           }
           break;
         default:

--- a/packages/kit/src/routes/config/deeplink/index.ts
+++ b/packages/kit/src/routes/config/deeplink/index.ts
@@ -100,7 +100,10 @@ async function processDeepLinkUrlAccount(
                 },
               });
             }
-            defaultLogger.referral.page.enterReferralGuide(code, utmSource);
+            defaultLogger.referral.page.enterReferralGuideFromDeepLink(
+              code,
+              utmSource,
+            );
           }
           break;
         default:

--- a/packages/kit/src/views/ReferFriends/pages/ReferAFriend/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/ReferAFriend/index.tsx
@@ -307,18 +307,20 @@ export default function ReferAFriend() {
 
       if (
         platformEnv.isWeb &&
-        globalThis?.location.href.includes('utm_source=web_share')
+        (globalThis?.location.href.includes('utm_source=web_share') ||
+          globalThis?.location.href.includes('app=1'))
       ) {
         const parsedURL = new URL(globalThis?.location.href);
         const code = parsedURL.searchParams.get('code');
+        const utmSource = parsedURL.searchParams.get('utm_source');
         const url = uriUtils.buildDeepLinkUrl({
           path: EOneKeyDeepLinkPath.invite_share,
           query: {
-            utm_source: 'web_share',
+            utm_source: utmSource || '',
             code: code || '',
           },
         });
-        defaultLogger.referral.page.enterReferralGuide(code);
+        defaultLogger.referral.page.enterReferralGuide(code, utmSource);
         globalThis.location.href = url;
       }
     });

--- a/packages/shared/src/logger/scopes/referral/scenes/page.ts
+++ b/packages/shared/src/logger/scopes/referral/scenes/page.ts
@@ -14,6 +14,8 @@ export class PageScene extends BaseScene {
     };
   }
 
+  @LogToServer()
+  @LogToLocal({ level: 'info' })
   public enterReferralGuideFromDeepLink(
     referralCode: string | undefined | null,
     utmSource: string | undefined | null,

--- a/packages/shared/src/logger/scopes/referral/scenes/page.ts
+++ b/packages/shared/src/logger/scopes/referral/scenes/page.ts
@@ -14,6 +14,16 @@ export class PageScene extends BaseScene {
     };
   }
 
+  public enterReferralGuideFromDeepLink(
+    referralCode: string | undefined | null,
+    utmSource: string | undefined | null,
+  ) {
+    return {
+      referralCode: referralCode ?? '',
+      utmSource: utmSource ?? '',
+    };
+  }
+
   @LogToServer()
   @LogToLocal({ level: 'info' })
   public signupOneKeyID() {

--- a/packages/shared/src/logger/scopes/referral/scenes/page.ts
+++ b/packages/shared/src/logger/scopes/referral/scenes/page.ts
@@ -4,9 +4,13 @@ import { LogToLocal, LogToServer } from '../../../base/decorators';
 export class PageScene extends BaseScene {
   @LogToServer()
   @LogToLocal({ level: 'info' })
-  public enterReferralGuide(referralCode: string | undefined | null) {
+  public enterReferralGuide(
+    referralCode: string | undefined | null,
+    utmSource: string | undefined | null,
+  ) {
     return {
       referralCode: referralCode ?? '',
+      utmSource: utmSource ?? '',
     };
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Referral deep links now preserve and pass the original source (utm_source) for improved attribution.
  * “Refer a Friend” opens correctly from web/app links when the URL includes app=1, in addition to utm_source=web_share.

* **Chores**
  * Enhanced analytics to differentiate deep-link vs in-app entry into the referral guide for more accurate reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->