### PR TITLE
OK-38941: add liquidity and volume display in UniversalSearchV2MarketTokenItem

### DIFF
--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
@@ -1,15 +1,21 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
+
+import BigNumber from 'bignumber.js';
+import { useIntl } from 'react-intl';
 
 import {
   IconButton,
+  NumberSizeableText,
   SizableText,
   XStack,
+  YStack,
   rootNavigationRef,
   useClipboard,
 } from '@onekeyhq/components';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { useMarketWatchListV2Atom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2/atoms';
 import { useUniversalSearchActions } from '@onekeyhq/kit/src/states/jotai/contexts/universalSearch';
+import { ETranslations } from '@onekeyhq/shared/src/locale/enum/translations';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EWatchlistFrom } from '@onekeyhq/shared/src/logger/scopes/market/scenes/token';
 import {
@@ -53,6 +59,57 @@ function ContractAddress({ address }: { address: string }) {
   );
 }
 
+function MarketTokenLiquidity({
+  liquidity,
+  volume24h,
+}: {
+  liquidity: string;
+  volume24h: string;
+}) {
+  const intl = useIntl();
+  const displayLiquidity = useMemo(
+    () => BigNumber(liquidity).gt(0),
+    [liquidity],
+  );
+  const displayVolume24h = useMemo(
+    () => BigNumber(volume24h).gt(0),
+    [volume24h],
+  );
+  return (
+    <XStack>
+      {displayLiquidity ? (
+        <XStack ai="center" gap="$1">
+          <SizableText color="$textSubdued">
+            {intl.formatMessage({
+              id: ETranslations.dexmarket_search_result_liq,
+            })}
+          </SizableText>
+          <NumberSizeableText color="$textSubdued" formatter="marketCap">
+            {liquidity}
+          </NumberSizeableText>
+        </XStack>
+      ) : null}
+      {displayLiquidity ? (
+        <SizableText color="$textSubdued" px="$1">
+          •
+        </SizableText>
+      ) : null}
+      {displayVolume24h ? (
+        <XStack ai="center" gap="$1">
+          <SizableText color="$textSubdued">
+            {intl.formatMessage({
+              id: ETranslations.dexmarket_search_result_vol,
+            })}
+          </SizableText>
+          <NumberSizeableText color="$textSubdued" formatter="marketCap">
+            {volume24h}
+          </NumberSizeableText>
+        </XStack>
+      ) : null}
+    </XStack>
+  );
+}
+
 interface IUniversalSearchMarketTokenItemProps {
   item: IUniversalSearchV2MarketToken;
   searchStatus: ESearchStatus;
@@ -65,7 +122,16 @@ export function UniversalSearchV2MarketTokenItem({
   // Ensure market watch list atom is initialized
   const [{ isMounted }] = useMarketWatchListV2Atom();
   const universalSearchActions = useUniversalSearchActions();
-  const { logoUrl, price, symbol, name, address, network } = item.payload;
+  const {
+    logoUrl,
+    price,
+    symbol,
+    name,
+    address,
+    network,
+    liquidity,
+    volume_24h: volume24h,
+  } = item.payload;
 
   const handlePress = useCallback(() => {
     rootNavigationRef.current?.goBack();
@@ -125,13 +191,16 @@ export function UniversalSearchV2MarketTokenItem({
         numberOfLines: 1,
       }}
     >
-      <XStack>
-        <MarketTokenPrice
-          price={String(price)}
-          size="$bodyLgMedium"
-          tokenName={name}
-          tokenSymbol={symbol}
-        />
+      <XStack alignItems="center">
+        <YStack alignItems="flex-end">
+          <MarketTokenPrice
+            price={String(price)}
+            size="$bodyLgMedium"
+            tokenName={name}
+            tokenSymbol={symbol}
+          />
+          <MarketTokenLiquidity liquidity={liquidity} volume24h={volume24h} />
+        </YStack>
         <MarketStarV2
           chainId={network}
           contractAddress={address}

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
@@ -11,6 +11,7 @@ import {
   YStack,
   rootNavigationRef,
   useClipboard,
+  useMedia,
 } from '@onekeyhq/components';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { useMarketWatchListV2Atom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2/atoms';
@@ -18,6 +19,7 @@ import { useUniversalSearchActions } from '@onekeyhq/kit/src/states/jotai/contex
 import { ETranslations } from '@onekeyhq/shared/src/locale/enum/translations';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EWatchlistFrom } from '@onekeyhq/shared/src/logger/scopes/market/scenes/token';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   ERootRoutes,
   ETabMarketRoutes,
@@ -67,13 +69,14 @@ function MarketTokenLiquidity({
   volume24h: string;
 }) {
   const intl = useIntl();
+  const { gtMd } = useMedia();
   const displayLiquidity = useMemo(
     () => BigNumber(liquidity).gt(0),
     [liquidity],
   );
   const displayVolume24h = useMemo(
-    () => BigNumber(volume24h).gt(0),
-    [volume24h],
+    () => gtMd && BigNumber(volume24h).gt(0),
+    [volume24h, gtMd],
   );
   return (
     <XStack>
@@ -84,12 +87,16 @@ function MarketTokenLiquidity({
               id: ETranslations.dexmarket_search_result_liq,
             })}
           </SizableText>
-          <NumberSizeableText color="$textSubdued" formatter="marketCap">
+          <NumberSizeableText
+            color="$textSubdued"
+            formatter="marketCap"
+            formatterOptions={{ capAtMaxT: true }}
+          >
             {liquidity}
           </NumberSizeableText>
         </XStack>
       ) : null}
-      {displayLiquidity ? (
+      {displayLiquidity && displayVolume24h ? (
         <SizableText color="$textSubdued" px="$1">
           •
         </SizableText>
@@ -101,7 +108,11 @@ function MarketTokenLiquidity({
               id: ETranslations.dexmarket_search_result_vol,
             })}
           </SizableText>
-          <NumberSizeableText color="$textSubdued" formatter="marketCap">
+          <NumberSizeableText
+            color="$textSubdued"
+            formatter="marketCap"
+            formatterOptions={{ capAtMaxT: true }}
+          >
             {volume24h}
           </NumberSizeableText>
         </XStack>

--- a/packages/shared/types/market.ts
+++ b/packages/shared/types/market.ts
@@ -258,4 +258,6 @@ export interface IMarketSearchV2Token {
   logoUrl: string;
   isNative: boolean;
   decimals: number;
+  liquidity: string;
+  volume_24h: string;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Universal Search results for market tokens now display liquidity and 24h volume with localized labels.
  - Improved number formatting and visibility logic for liquidity/volume.
  - Responsive behavior: volume appears on larger screens.

- UI
  - Reworked result item layout: price grouped with liquidity/volume and aligned for clearer scanning.
  - Dot separator shown when both liquidity and volume are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->