### PR TITLE
feat: add clear market watchlist button in dev settings

### DIFF
--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityMarketWatchListV2.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityMarketWatchListV2.ts
@@ -64,4 +64,13 @@ export class SimpleDbEntityMarketWatchListV2 extends SimpleDbEntityBase<IMarketW
       return newData;
     });
   }
+
+  async clearAllMarketWatchListV2() {
+    await this.setRawData(() => {
+      const newData: IMarketWatchListDataV2 = {
+        data: [],
+      };
+      return newData;
+    });
+  }
 }

--- a/packages/kit-bg/src/services/ServiceMarketV2.ts
+++ b/packages/kit-bg/src/services/ServiceMarketV2.ts
@@ -369,6 +369,24 @@ class ServiceMarketV2 extends ServiceBase {
     return this.getMarketWatchListV2();
   }
 
+  @backgroundMethod()
+  async clearAllMarketWatchListV2({
+    skipSaveLocalSyncItem,
+    skipEventEmit,
+  }: {
+    skipSaveLocalSyncItem?: boolean;
+    skipEventEmit?: boolean;
+  } = {}) {
+    return this.withMarketWatchListV2CloudSync({
+      watchList: [],
+      isDeleted: true,
+      skipSaveLocalSyncItem,
+      skipEventEmit,
+      fn: () =>
+        this.backgroundApi.simpleDb.marketWatchListV2.clearAllMarketWatchListV2(),
+    });
+  }
+
   /**
    * Fetch token security information for multiple tokens using batch API
    * @param tokenAddressList - Array of token addresses with their chain IDs

--- a/packages/kit/src/states/jotai/contexts/marketV2/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/marketV2/actions.ts
@@ -230,6 +230,19 @@ class ContextJotaiActionsMarketV2 extends ContextJotaiActionsBase {
       void this.addIntoWatchListV2.call(set, payload);
     },
   );
+
+  clearAllWatchListV2 = contextAtomMethod(async (get, set) => {
+    const prev = get(marketWatchListV2Atom());
+    if (!prev.isMounted) {
+      return;
+    }
+
+    // Immediately update local state
+    set(marketWatchListV2Atom(), { ...prev, data: [] });
+
+    // Asynchronously call API without waiting for result
+    await backgroundApiProxy.serviceMarketV2.clearAllMarketWatchListV2();
+  });
 }
 
 const createActions = memoFn(() => new ContextJotaiActionsMarketV2());
@@ -242,6 +255,7 @@ export function useWatchListV2Actions() {
   const saveWatchListV2 = actions.saveWatchListV2.use();
   const refreshWatchListV2 = actions.refreshWatchListV2.use();
   const sortWatchListV2Items = actions.sortWatchListV2Items.use();
+  const clearAllWatchListV2 = actions.clearAllWatchListV2.use();
   return useRef({
     isInWatchListV2,
     addIntoWatchListV2,
@@ -249,6 +263,7 @@ export function useWatchListV2Actions() {
     saveWatchListV2,
     refreshWatchListV2,
     sortWatchListV2Items,
+    clearAllWatchListV2,
   });
 }
 

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
@@ -250,6 +250,36 @@ export const DevSettingsSection = () => {
           titleProps={{ color: '$textCritical' }}
         />
       ) : null}
+
+      <SectionPressItem
+        icon="BookmarkOutline"
+        title="清空Market收藏数据"
+        subtitle="清空所有Market页面的收藏/WatchList数据"
+        onPress={() => {
+          Dialog.confirm({
+            title: '清空Market收藏数据',
+            description:
+              '确定要清空所有Market页面的收藏数据吗？此操作不可恢复。',
+            confirmButtonProps: { variant: 'destructive' },
+            onConfirm: async () => {
+              try {
+                await backgroundApiProxy.serviceMarketV2.clearAllMarketWatchListV2();
+                Toast.success({
+                  title: '成功清空Market收藏数据',
+                });
+                setTimeout(() => {
+                  void backgroundApiProxy.serviceApp.restartApp();
+                }, 1000);
+              } catch (error) {
+                Toast.error({
+                  title: '清空失败',
+                  message: String(error),
+                });
+              }
+            },
+          });
+        }}
+      />
       <SectionFieldItem
         icon="ChartTrendingOutline"
         name="enableAnalyticsRequest"


### PR DESCRIPTION
- Add clearAllMarketWatchListV2 method in SimpleDbEntityMarketWatchListV2
- Add clearAllMarketWatchListV2 service method in ServiceMarketV2
- Add clearAllWatchListV2 action in marketV2 jotai state management
- Add "清空Market收藏数据" button in dev settings with confirmation dialog
- Auto restart app after successful clear operation to refresh UI

This feature helps developers easily clear all market watchlist data during testing.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Clear Market Watchlist” option in Developer Settings.
  * Includes a destructive confirmation dialog to prevent accidental clearing.
  * On confirmation, removes all saved Market/Watchlist (V2) items.
  * Shows a success toast and restarts the app to apply changes; on error, displays an error toast with details.
  * No changes to existing watchlist add/remove behavior; regular usage remains unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->