### PR TITLE
feat: add Manual Backup feature with wallet selection and routing OK-42621

### DIFF
--- a/packages/kit/src/routes/Modal/router.tsx
+++ b/packages/kit/src/routes/Modal/router.tsx
@@ -20,6 +20,7 @@ import { ModalFiatCryptoRouter } from '../../views/FiatCrypto/router';
 import { ModalFirmwareUpdateStack } from '../../views/FirmwareUpdate/router';
 import { KeyTagModalRouter } from '../../views/KeyTag/router';
 import { LiteCardPages } from '../../views/LiteCard/router';
+import { ManualBackupRouter } from '../../views/ManualBackup/router';
 import { ModalMarketStack } from '../../views/Market/router';
 import { ModalNotificationsRouter } from '../../views/Notifications/router';
 import { OnboardingRouter } from '../../views/Onboarding/router';
@@ -138,6 +139,10 @@ const router: IModalRootNavigatorConfig<EModalRoutes>[] = [
   {
     name: EModalRoutes.LiteCardModal,
     children: LiteCardPages,
+  },
+  {
+    name: EModalRoutes.ManualBackupModal,
+    children: ManualBackupRouter,
   },
   {
     name: EModalRoutes.CloudBackupModal,

--- a/packages/kit/src/views/ManualBackup/pages/SelectWallet/index.tsx
+++ b/packages/kit/src/views/ManualBackup/pages/SelectWallet/index.tsx
@@ -1,0 +1,79 @@
+import { useCallback } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import { Empty, Page, SizableText } from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { WalletListView } from '@onekeyhq/kit/src/components/WalletListView';
+import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import type { IDBWallet } from '@onekeyhq/kit-bg/src/dbs/local/types';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { EOnboardingPages } from '@onekeyhq/shared/src/routes';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import { EReasonForNeedPassword } from '@onekeyhq/shared/types/setting';
+
+export default function ManualBackupSelectWalletPage() {
+  const intl = useIntl();
+  const navigation = useAppNavigation();
+  const walletList = usePromiseResult(async () => {
+    const { wallets } = await backgroundApiProxy.serviceAccount.getWallets();
+    const hdWalletList = wallets.filter((wallet) =>
+      accountUtils.isHdWallet({ walletId: wallet.id }),
+    );
+    return hdWalletList;
+  }, []).result;
+
+  const onPick = useCallback(
+    async (item: IDBWallet) => {
+      const { mnemonic } =
+        await backgroundApiProxy.serviceAccount.getHDAccountMnemonic({
+          walletId: item.id,
+          reason: EReasonForNeedPassword.Security,
+        });
+      navigation.push(EOnboardingPages.BeforeShowRecoveryPhrase, {
+        mnemonic,
+        isBackup: true,
+        isWalletBackedUp: item.backuped,
+        walletId: item.id,
+      });
+    },
+    [navigation],
+  );
+
+  return (
+    <Page>
+      <Page.Header
+        title={intl.formatMessage({
+          id: ETranslations.settings_select_wallet,
+        })}
+      />
+      <Page.Body>
+        <WalletListView
+          walletList={walletList}
+          onPick={onPick}
+          ListEmptyComponent={
+            <Empty
+              icon="SearchOutline"
+              title={intl.formatMessage({
+                id: ETranslations.backup_no_data,
+              })}
+              description={intl.formatMessage({
+                id: ETranslations.backup_no_content_available_for_backup,
+              })}
+            />
+          }
+          ListFooterComponent={
+            walletList?.length ? (
+              <SizableText size="$bodySm" color="$textSubdued" px="$5" mt="$5">
+                {intl.formatMessage({
+                  id: ETranslations.settings_hardware_wallets_not_appear,
+                })}
+              </SizableText>
+            ) : null
+          }
+        />
+      </Page.Body>
+    </Page>
+  );
+}

--- a/packages/kit/src/views/ManualBackup/router/index.tsx
+++ b/packages/kit/src/views/ManualBackup/router/index.tsx
@@ -1,0 +1,31 @@
+import type { IModalFlowNavigatorConfig } from '@onekeyhq/components';
+import type { IManualBackupParamList } from '@onekeyhq/shared/src/routes/manualBackup';
+import { EManualBackupRoutes } from '@onekeyhq/shared/src/routes/manualBackup';
+import { EOnboardingPages } from '@onekeyhq/shared/src/routes/onboarding';
+
+import OnboardingBeforeShowRecoveryPhrase from '../../Onboarding/pages/CreateWalet/BeforeShowRecoveryPhrase';
+import OnboardingRecoveryPhrase from '../../Onboarding/pages/CreateWalet/RecoveryPhrase';
+import OnboardingVerifyRecoverPhrase from '../../Onboarding/pages/CreateWalet/VerifyRecoverPhrase';
+import ManualBackupSelectWalletPage from '../pages/SelectWallet';
+
+export const ManualBackupRouter: IModalFlowNavigatorConfig<
+  EManualBackupRoutes | EOnboardingPages,
+  IManualBackupParamList
+>[] = [
+  {
+    name: EManualBackupRoutes.ManualBackupSelectWallet,
+    component: ManualBackupSelectWalletPage,
+  },
+  {
+    name: EOnboardingPages.BeforeShowRecoveryPhrase,
+    component: OnboardingBeforeShowRecoveryPhrase,
+  },
+  {
+    name: EOnboardingPages.RecoveryPhrase,
+    component: OnboardingRecoveryPhrase,
+  },
+  {
+    name: EOnboardingPages.VerifyRecoverPhrase,
+    component: OnboardingVerifyRecoverPhrase,
+  },
+];

--- a/packages/kit/src/views/Setting/pages/Tab/config.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/config.tsx
@@ -42,6 +42,7 @@ import {
   EModalRoutes,
   EModalSettingRoutes,
 } from '@onekeyhq/shared/src/routes';
+import { EManualBackupRoutes } from '@onekeyhq/shared/src/routes/manualBackup';
 import { EPrimeFeatures, EPrimePages } from '@onekeyhq/shared/src/routes/prime';
 import { EModalShortcutsRoutes } from '@onekeyhq/shared/src/routes/shortcuts';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
@@ -193,6 +194,17 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
             },
           ],
           [
+            {
+              icon: 'SignatureOutline',
+              title: intl.formatMessage({
+                id: ETranslations.manual_backup,
+              }),
+              onPress: (navigation) => {
+                navigation?.pushModal(EModalRoutes.ManualBackupModal, {
+                  screen: EManualBackupRoutes.ManualBackupSelectWallet,
+                });
+              },
+            },
             platformEnv.isNative
               ? {
                   icon: 'OnekeyLiteOutline',

--- a/packages/shared/src/routes/manualBackup.ts
+++ b/packages/shared/src/routes/manualBackup.ts
@@ -1,0 +1,28 @@
+import type { EOnboardingPages } from './onboarding';
+
+export enum EManualBackupRoutes {
+  ManualBackupSelectWallet = 'ManualBackupSelectWallet',
+}
+
+export type IManualBackupParamList = {
+  [EManualBackupRoutes.ManualBackupSelectWallet]: undefined;
+  [EOnboardingPages.BeforeShowRecoveryPhrase]: {
+    mnemonic?: string;
+    isBackup?: boolean;
+    isWalletBackedUp?: boolean;
+    walletId?: string;
+  };
+  [EOnboardingPages.RecoveryPhrase]: {
+    mnemonic?: string;
+    isBackup?: boolean;
+    isWalletBackedUp?: boolean;
+    walletId?: string;
+  };
+  [EOnboardingPages.VerifyRecoverPhrase]: {
+    mnemonic: string;
+    verifyRecoveryPhrases?: string[][][];
+    isBackup?: boolean;
+    isWalletBackedUp?: boolean;
+    walletId?: string;
+  };
+};

--- a/packages/shared/src/routes/modal.ts
+++ b/packages/shared/src/routes/modal.ts
@@ -17,6 +17,7 @@ import type { IModalFiatCryptoParamList } from './fiatCrypto';
 import type { IModalFirmwareUpdateParamList } from './firmwareUpdate';
 import type { IModalKeyTagParamList } from './keyTag';
 import type { ILiteCardParamList } from './liteCard';
+import type { IManualBackupParamList } from './manualBackup';
 import type { IModalNotificationsParamList } from './notifications';
 import type { IOnboardingParamList } from './onboarding';
 import type { IPrimeParamList } from './prime';
@@ -54,6 +55,7 @@ export enum EModalRoutes {
   ReceiveModal = 'ReceiveModal',
   ScanQrCodeModal = 'ScanQrCodeModal',
   LiteCardModal = 'LiteCardModal',
+  ManualBackupModal = 'ManualBackupModal',
   CloudBackupModal = 'CloudBackupModal',
   WebViewModal = 'WebViewModal',
   AddressBookModal = 'AddressBookModal',
@@ -88,6 +90,7 @@ export type IModalParamList = {
   [EModalRoutes.FirmwareUpdateModal]: IModalFirmwareUpdateParamList;
   [EModalRoutes.KeyTagModal]: IModalKeyTagParamList;
   [EModalRoutes.LiteCardModal]: ILiteCardParamList;
+  [EModalRoutes.ManualBackupModal]: IManualBackupParamList;
   [EModalRoutes.MainModal]: IModalAssetListParamList &
     IModalAssetDetailsParamList &
     IModalRewardCenterParamList &


### PR DESCRIPTION
**Added manual backup option in settings**

- Introduced ManualBackupRouter to handle navigation for the manual backup process.
- Created ManualBackupSelectWalletPage for users to select wallets for backup.
- Updated router configuration to include ManualBackupModal and its associated routes.
- Enhanced settings configuration to add a button for accessing the manual backup feature.

This feature improves user experience by providing a straightforward method for backing up wallets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Manual Backup flow accessible via Settings > Backup.
  - New modal guides you to select an HD wallet, view your recovery phrase, and verify it.
  - “Manual Backup” option appears before the native backup option in Backup settings.
  - Includes secure confirmation before displaying the recovery phrase.
  - Wallet list shows an empty state when no eligible wallets are found and notes that hardware wallets won’t appear.
  - Integrates with existing onboarding verification screens for a consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->