### PR TITLE
fix: sign and verify issues, OK-42537, OK-42542, OK-42543, OK-42622, OK-42623

### DIFF
--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionMore.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionMore.tsx
@@ -24,7 +24,7 @@ import { WalletActionViewInExplorer } from './WalletActionViewInExplorer';
 export function WalletActionMore() {
   const [devSettings] = useDevSettingsPersistAtom();
   const { activeAccount } = useActiveAccount({ num: 0 });
-  const { account, network, indexedAccount, isOthersWallet } = activeAccount;
+  const { account, network } = activeAccount;
 
   const show = useReviewControl();
 
@@ -41,24 +41,8 @@ export function WalletActionMore() {
   }, [network?.id]).result;
 
   const displaySignAndVerify = usePromiseResult(async () => {
-    if (!vaultSettings?.enabledInternalSignAndVerify) {
-      return false;
-    }
-    const signAccounts =
-      await backgroundApiProxy.serviceInternalSignAndVerify.getSignAccounts({
-        networkId: network?.id ?? '',
-        accountId: account?.id ?? '',
-        indexedAccountId: indexedAccount?.id ?? '',
-        isOthersWallet,
-      });
-    return signAccounts.length > 0;
-  }, [
-    account?.id,
-    indexedAccount?.id,
-    isOthersWallet,
-    network?.id,
-    vaultSettings,
-  ]);
+    return vaultSettings?.enabledInternalSignAndVerify;
+  }, [vaultSettings]);
 
   const renderItemsAsync = useCallback(
     async ({

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionSignAndVerify.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionSignAndVerify.tsx
@@ -3,7 +3,9 @@ import { useCallback } from 'react';
 import { useIntl } from 'react-intl';
 
 import { ActionList } from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
@@ -27,6 +29,17 @@ export function WalletActionSignAndVerify({
     deriveType,
     isOthersWallet,
   } = activeAccount;
+
+  const displaySignAndVerify = usePromiseResult(async () => {
+    const signAccounts =
+      await backgroundApiProxy.serviceInternalSignAndVerify.getSignAccounts({
+        networkId: network?.id ?? '',
+        accountId: account?.id ?? '',
+        indexedAccountId: indexedAccount?.id ?? '',
+        isOthersWallet,
+      });
+    return signAccounts.length > 0;
+  }, [account?.id, indexedAccount?.id, isOthersWallet, network?.id]);
 
   const handleSignAndVerify = useCallback(async () => {
     if (!network?.id || !wallet?.id) {
@@ -56,6 +69,10 @@ export function WalletActionSignAndVerify({
     network,
     wallet,
   ]);
+
+  if (!displaySignAndVerify.result) {
+    return null;
+  }
 
   return (
     <ActionList.Item

--- a/packages/kit/src/views/SignAndVerifyMessage/components/SignForm.tsx
+++ b/packages/kit/src/views/SignAndVerifyMessage/components/SignForm.tsx
@@ -362,7 +362,9 @@ export const SignForm = ({
             const hexFormat = form.getValues('hexFormat');
             if (hexFormat && value) {
               if (!hexUtils.isHexString(value)) {
-                return 'Not a valid hex';
+                return intl.formatMessage({
+                  id: ETranslations.message_signing_message_invalid_hex,
+                });
               }
             }
             return true;

--- a/packages/kit/src/views/SignAndVerifyMessage/components/SignForm.tsx
+++ b/packages/kit/src/views/SignAndVerifyMessage/components/SignForm.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 
+import { EDeviceType } from '@onekeyfe/hd-shared';
 import { useIntl } from 'react-intl';
 
 import {
+  Alert,
   Button,
   Divider,
   Form,
@@ -40,22 +42,26 @@ type ISignFormData = {
 
 interface ISignFormProps {
   form: UseFormReturn<ISignFormData>;
+  walletId: string;
   networkId: string;
   accountId: string | undefined;
   indexedAccountId: string | undefined;
   isOthersWallet: boolean | undefined;
   onCurrentSignAccountChange: (account: ISignAccount | undefined) => void;
   onCopySignature: () => void;
+  onDisabledChange: (disabled: boolean) => void;
 }
 
 export const SignForm = ({
   form,
+  walletId,
   networkId,
   accountId,
   indexedAccountId,
   isOthersWallet,
   onCurrentSignAccountChange,
   onCopySignature,
+  onDisabledChange,
 }: ISignFormProps) => {
   const intl = useIntl();
   const signAccountsRef = useRef<ISignAccount[]>([]);
@@ -295,6 +301,45 @@ export const SignForm = ({
     }
   }, [currentSignAccount?.network.id, intl]);
 
+  const { result: isClassicOrMiniDevice } = usePromiseResult(
+    async () => {
+      if (!accountUtils.isHwWallet({ walletId })) {
+        return false;
+      }
+      const wallet = await backgroundApiProxy.serviceAccount.getWalletSafe({
+        walletId: walletId ?? '',
+      });
+      const deviceType = wallet?.associatedDeviceInfo?.deviceType;
+      console.log('wallet?.associatedDevice: ', wallet?.associatedDevice);
+      if (
+        deviceType &&
+        (deviceType === EDeviceType.Classic || deviceType === EDeviceType.Mini)
+      ) {
+        return true;
+      }
+      return false;
+    },
+    [walletId],
+    {
+      initResult: false,
+    },
+  );
+
+  const previousSignDisabled = usePrevious(
+    isClassicOrMiniDevice && currentFormat === 'bip322',
+  );
+  useEffect(() => {
+    const signDisabled = isClassicOrMiniDevice && currentFormat === 'bip322';
+    if (previousSignDisabled !== signDisabled) {
+      onDisabledChange(signDisabled);
+    }
+  }, [
+    isClassicOrMiniDevice,
+    onDisabledChange,
+    currentFormat,
+    previousSignDisabled,
+  ]);
+
   return (
     <Form form={form}>
       <Form.Field
@@ -473,80 +518,97 @@ export const SignForm = ({
       </Form.Field>
 
       {displayFormatForm ? (
-        <Form.Field
-          label={intl.formatMessage({
-            id: ETranslations.signature_format_title,
-          })}
-          labelAddon={
-            <Popover
-              title={intl.formatMessage({
-                id: ETranslations.signature_format_title,
-              })}
-              renderTrigger={
-                <Button
-                  iconAfter="QuestionmarkOutline"
-                  size="small"
-                  variant="tertiary"
-                >
-                  {intl.formatMessage({ id: ETranslations.global_learn_more })}
-                </Button>
-              }
-              renderContent={() => (
-                <YStack
-                  p="$5"
-                  pt="$0"
-                  $gtMd={{
-                    px: '$4',
-                    py: '$3',
-                  }}
-                  gap="$4"
-                >
-                  <SizableText>
+        <YStack gap="$2">
+          <Form.Field
+            label={intl.formatMessage({
+              id: ETranslations.signature_format_title,
+            })}
+            labelAddon={
+              <Popover
+                title={intl.formatMessage({
+                  id: ETranslations.signature_format_title,
+                })}
+                renderTrigger={
+                  <Button
+                    iconAfter="QuestionmarkOutline"
+                    size="small"
+                    variant="tertiary"
+                  >
                     {intl.formatMessage({
-                      id: ETranslations.signature_format_description,
+                      id: ETranslations.global_learn_more,
                     })}
-                  </SizableText>
+                  </Button>
+                }
+                renderContent={() => (
+                  <YStack
+                    p="$5"
+                    pt="$0"
+                    $gtMd={{
+                      px: '$4',
+                      py: '$3',
+                    }}
+                    gap="$4"
+                  >
+                    <SizableText>
+                      {intl.formatMessage({
+                        id: ETranslations.signature_format_description,
+                      })}
+                    </SizableText>
 
-                  <YStack>
-                    <XStack>
-                      <SizableText pr="$2">-</SizableText>
-                      <SizableText>
-                        {intl.formatMessage({
-                          id: ETranslations.signature_format_standard,
-                        })}
-                      </SizableText>
-                    </XStack>
-                    <XStack>
-                      <SizableText pr="$2">-</SizableText>
-                      <SizableText>
-                        {intl.formatMessage({
-                          id: ETranslations.signature_format_bip137,
-                        })}
-                      </SizableText>
-                    </XStack>
-                    <XStack>
-                      <SizableText pr="$2">-</SizableText>
-                      <SizableText>
-                        {intl.formatMessage({
-                          id: ETranslations.signature_format_322,
-                        })}
-                      </SizableText>
-                    </XStack>
+                    <YStack>
+                      <XStack>
+                        <SizableText pr="$2">-</SizableText>
+                        <SizableText>
+                          {intl.formatMessage({
+                            id: ETranslations.signature_format_standard,
+                          })}
+                        </SizableText>
+                      </XStack>
+                      <XStack>
+                        <SizableText pr="$2">-</SizableText>
+                        <SizableText>
+                          {intl.formatMessage({
+                            id: ETranslations.signature_format_bip137,
+                          })}
+                        </SizableText>
+                      </XStack>
+                      <XStack>
+                        <SizableText pr="$2">-</SizableText>
+                        <SizableText>
+                          {intl.formatMessage({
+                            id: ETranslations.signature_format_322,
+                          })}
+                        </SizableText>
+                      </XStack>
+                    </YStack>
                   </YStack>
-                </YStack>
-              )}
+                )}
+              />
+            }
+            name="format"
+          >
+            <Radio
+              orientation="horizontal"
+              gap="$5"
+              options={formatRadioOptions}
             />
-          }
-          name="format"
-        >
-          <Radio
-            orientation="horizontal"
-            gap="$5"
-            options={formatRadioOptions}
-          />
-        </Form.Field>
+          </Form.Field>
+          {isClassicOrMiniDevice && currentFormat === 'bip322' ? (
+            <Alert
+              title={intl.formatMessage(
+                {
+                  id: ETranslations.signature_type_not_supported_on_model,
+                },
+                {
+                  sigType: 'BIP322',
+                  deviceModel: 'Classic, Mini',
+                },
+              )}
+              type="warning"
+            />
+          ) : null}
+        </YStack>
       ) : null}
-
       <Divider />
 
       <Form.Field

--- a/packages/kit/src/views/SignAndVerifyMessage/components/VerifyForm.tsx
+++ b/packages/kit/src/views/SignAndVerifyMessage/components/VerifyForm.tsx
@@ -17,6 +17,7 @@ import {
   YStack,
 } from '@onekeyhq/components';
 import type { UseFormReturn } from '@onekeyhq/components';
+import { isTaprootAddress } from '@onekeyhq/core/src/chains/btc/sdkBtc';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -107,23 +108,26 @@ export const VerifyForm = ({ form, onNetworkDetected }: IVerifyFormProps) => {
       {
         label: intl.formatMessage({ id: ETranslations.standard_or_BIP137 }),
         value: 'bip137',
-        disabled: false,
+        disabled: isTaprootAddress(watchedAddress),
       },
       { label: 'BIP322', value: 'bip322', disabled: false },
     ];
-  }, [detectedNetworkId, intl]);
+  }, [detectedNetworkId, intl, watchedAddress]);
 
   // Set default format when displayFormatForm changes
   useEffect(() => {
     if (displayFormatForm) {
       const currentFormat = form.getValues('format');
       if (!currentFormat) {
-        form.setValue('format', 'bip137');
+        form.setValue(
+          'format',
+          isTaprootAddress(watchedAddress) ? 'bip322' : 'bip137',
+        );
       }
     } else {
       form.setValue('format', '');
     }
-  }, [displayFormatForm, form]);
+  }, [displayFormatForm, form, watchedAddress]);
 
   return (
     <Form form={form}>

--- a/packages/kit/src/views/SignAndVerifyMessage/components/VerifyForm.tsx
+++ b/packages/kit/src/views/SignAndVerifyMessage/components/VerifyForm.tsx
@@ -151,7 +151,9 @@ export const VerifyForm = ({ form, onNetworkDetected }: IVerifyFormProps) => {
             const hexFormat = form.getValues('hexFormat');
             if (hexFormat && value) {
               if (!hexUtils.isHexString(value)) {
-                return 'Not a valid hex';
+                return intl.formatMessage({
+                  id: ETranslations.message_signing_message_invalid_hex,
+                });
               }
             }
             return true;

--- a/packages/kit/src/views/SignAndVerifyMessage/pages/SignAndVerifyMessage/index.tsx
+++ b/packages/kit/src/views/SignAndVerifyMessage/pages/SignAndVerifyMessage/index.tsx
@@ -84,6 +84,7 @@ function SignAndVerifyMessage() {
   ]);
 
   const [isSigning, setIsSigning] = useState(false);
+  const [isDisabled, setIsDisabled] = useState(false);
   const [action, setAction] = useState(ESignAndVerifyAction.Sign);
   const [currentSignAccount, setCurrentSignAccount] = useState<
     ISignAccount | undefined
@@ -91,6 +92,12 @@ function SignAndVerifyMessage() {
   const [verifyDetectedNetworkId, setVerifyDetectedNetworkId] = useState<
     string | null
   >(null);
+
+  useEffect(() => {
+    if (action === ESignAndVerifyAction.Verify) {
+      setIsDisabled(false);
+    }
+  }, [action]);
 
   const signedMessageRef = useRef<{
     message: string;
@@ -244,12 +251,14 @@ function SignAndVerifyMessage() {
         <SignForm
           key="sign-form"
           form={signForm}
+          walletId={walletId ?? ''}
           networkId={networkId}
           accountId={accountId}
           indexedAccountId={indexedAccountId}
           isOthersWallet={isOthersWallet}
           onCurrentSignAccountChange={setCurrentSignAccount}
           onCopySignature={handleCopySignature}
+          onDisabledChange={setIsDisabled}
         />
       );
     }
@@ -264,6 +273,7 @@ function SignAndVerifyMessage() {
     action,
     signForm,
     verifyForm,
+    walletId,
     networkId,
     accountId,
     indexedAccountId,
@@ -336,6 +346,7 @@ function SignAndVerifyMessage() {
         })}
         confirmButtonProps={{
           loading: isSigning,
+          disabled: isDisabled,
         }}
         onConfirm={
           action === ESignAndVerifyAction.Sign ? handleSign : handleVerify

--- a/packages/shared/src/locale/enum/translations.ts
+++ b/packages/shared/src/locale/enum/translations.ts
@@ -1858,6 +1858,7 @@
   message_signing_address_invalid_text = 'message_signing.address_invalid_text',
   message_signing_address_placeholder = 'message_signing.address_placeholder',
   message_signing_main_title = 'message_signing.main_title',
+  message_signing_message_invalid_hex = 'message_signing.message_invalid_hex',
   message_signing_sign_action = 'message_signing.sign_action',
   message_signing_signature_desc = 'message_signing.signature_desc',
   message_signing_signature_invalid_text = 'message_signing.signature_invalid_text',

--- a/packages/shared/src/locale/json/bn.json
+++ b/packages/shared/src/locale/json/bn.json
@@ -1853,6 +1853,7 @@
   "message_signing.address_invalid_text": "অবৈধ ঠিকানা বা সমর্থিত নয় এমন নেটওয়ার্ক",
   "message_signing.address_placeholder": "এই ঠিকানার মালিকানা প্রমাণের জন্য একটি বার্তা লিখুন...",
   "message_signing.main_title": "বার্তা স্বাক্ষর করুন ও যাচাই করুন",
+  "message_signing.message_invalid_hex": "অবৈধ হেক্স স্ট্রিং",
   "message_signing.sign_action": "বার্তা স্বাক্ষর করুন",
   "message_signing.signature_desc": "স্বাক্ষরের পর তৈরি হয়েছে",
   "message_signing.signature_invalid_text": "অবৈধ স্বাক্ষর",

--- a/packages/shared/src/locale/json/de.json
+++ b/packages/shared/src/locale/json/de.json
@@ -1853,6 +1853,7 @@
   "message_signing.address_invalid_text": "Ungültige Adresse oder nicht unterstütztes Netzwerk",
   "message_signing.address_placeholder": "Geben Sie eine Nachricht ein, um den Besitz dieser Adresse zu bestätigen...",
   "message_signing.main_title": "Nachricht signieren & verifizieren",
+  "message_signing.message_invalid_hex": "Ungültige Hex-Zeichenkette",
   "message_signing.sign_action": "Nachricht signieren",
   "message_signing.signature_desc": "Nach der Unterzeichnung generiert",
   "message_signing.signature_invalid_text": "Ungültige Signatur",

--- a/packages/shared/src/locale/json/en_US.json
+++ b/packages/shared/src/locale/json/en_US.json
@@ -1853,6 +1853,7 @@
   "message_signing.address_invalid_text": "Invalid address or unsupported network",
   "message_signing.address_placeholder": "Enter a message to prove ownership of this address...",
   "message_signing.main_title": "Sign & verify message",
+  "message_signing.message_invalid_hex": "Invalid hex string",
   "message_signing.sign_action": "Sign message",
   "message_signing.signature_desc": "Generated after signing",
   "message_signing.signature_invalid_text": "Invalid signature",

--- a/packages/shared/src/locale/json/es.json
+++ b/packages/shared/src/locale/json/es.json
@@ -1853,6 +1853,7 @@
   "message_signing.address_invalid_text": "Dirección no válida o red no compatible",
   "message_signing.address_placeholder": "Introduce un mensaje para demostrar la propiedad de esta dirección...",
   "message_signing.main_title": "Firmar y verificar mensaje",
+  "message_signing.message_invalid_hex": "Cadena hexadecimal no válida",
   "message_signing.sign_action": "Firmar mensaje",
   "message_signing.signature_desc": "Generado después de firmar",
   "message_signing.signature_invalid_text": "Firma no válida",

--- a/packages/shared/src/locale/json/fr_FR.json
+++ b/packages/shared/src/locale/json/fr_FR.json
@@ -1853,6 +1853,7 @@
   "message_signing.address_invalid_text": "Adresse invalide ou réseau non pris en charge",
   "message_signing.address_placeholder": "Saisissez un message pour prouver que vous êtes propriétaire de cette adresse...",
   "message_signing.main_title": "Signer et vérifier le message",
+  "message_signing.message_invalid_hex": "Chaîne hexadécimale invalide",
   "message_signing.sign_action": "Signer le message",
   "message_signing.signature_desc": "Généré après signature",
   "message_signing.signature_invalid_text": "Signature invalide",

--- a/packages/shared/src/locale/json/hi_IN.json
+++ b/packages/shared/src/locale/json/hi_IN.json
@@ -1853,6 +1853,7 @@
   "message_signing.address_invalid_text": "अमान्य पता या असमर्थित नेटवर्क",
   "message_signing.address_placeholder": "इस पते के स्वामित्व को साबित करने के लिए एक संदेश दर्ज करें...",
   "message_signing.main_title": "संदेश पर हस्ताक्षर करें और सत्यापित करें",
+  "message_signing.message_invalid_hex": "अमान्य हेक्स स्ट्रिंग",
   "message_signing.sign_action": "संदेश पर हस्ताक्षर करें",
   "message_signing.signature_desc": "हस्ताक्षर करने के बाद उत्पन्न किया गया",
   "message_signing.signature_invalid_text": "अमान्य हस्ताक्षर",

--- a/packages/shared/src/locale/json/id.json
+++ b/packages/shared/src/locale/json/id.json
@@ -1853,6 +1853,7 @@
   "message_signing.address_invalid_text": "Alamat tidak valid atau jaringan tidak didukung",
   "message_signing.address_placeholder": "Masukkan pesan untuk membuktikan kepemilikan alamat ini...",
   "message_signing.main_title": "Tanda tangani & verifikasi pesan",
+  "message_signing.message_invalid_hex": "String heksadesimal tidak valid",
   "message_signing.sign_action": "Tandatangani pesan",
   "message_signing.signature_desc": "Dibuat setelah penandatanganan",
   "message_signing.signature_invalid_text": "Tanda tangan tidak valid",

--- a/packages/shared/src/locale/json/it_IT.json
+++ b/packages/shared/src/locale/json/it_IT.json
@@ -1853,6 +1853,7 @@
   "message_signing.address_invalid_text": "Indirizzo non valido o rete non supportata",
   "message_signing.address_placeholder": "Inserisci un messaggio per dimostrare la proprietà di questo indirizzo...",
   "message_signing.main_title": "Firma e verifica messaggio",
+  "message_signing.message_invalid_hex": "Stringa esadecimale non valida",
   "message_signing.sign_action": "Firma il messaggio",
   "message_signing.signature_desc": "Generato dopo la firma",
   "message_signing.signature_invalid_text": "Firma non valida",

--- a/packages/shared/src/locale/json/ja_JP.json
+++ b/packages/shared/src/locale/json/ja_JP.json
@@ -1853,6 +1853,7 @@
   "message_signing.address_invalid_text": "無効なアドレス、またはサポートされていないネットワークです",
   "message_signing.address_placeholder": "このアドレスの所有権を証明するためのメッセージを入力してください...",
   "message_signing.main_title": "メッセージの署名と検証",
+  "message_signing.message_invalid_hex": "無効な16進数文字列",
   "message_signing.sign_action": "メッセージに署名する",
   "message_signing.signature_desc": "署名後に生成されます",
   "message_signing.signature_invalid_text": "無効な署名",

--- a/packages/shared/src/locale/json/ko_KR.json
+++ b/packages/shared/src/locale/json/ko_KR.json
@@ -1853,6 +1853,7 @@
   "message_signing.address_invalid_text": "잘못된 주소이거나 지원되지 않는 네트워크입니다.",
   "message_signing.address_placeholder": "이 주소의 소유권을 증명하기 위해 메시지를 입력하세요...",
   "message_signing.main_title": "메시지 서명 및 검증",
+  "message_signing.message_invalid_hex": "잘못된 16진수 문자열",
   "message_signing.sign_action": "메시지 서명",
   "message_signing.signature_desc": "서명 후 생성됨",
   "message_signing.signature_invalid_text": "잘못된 서명",

--- a/packages/shared/src/locale/json/pt.json
+++ b/packages/shared/src/locale/json/pt.json
@@ -1853,6 +1853,7 @@
   "message_signing.address_invalid_text": "Endereço inválido ou rede não suportada",
   "message_signing.address_placeholder": "Digite uma mensagem para comprovar a propriedade deste endereço...",
   "message_signing.main_title": "Assinar e verificar mensagem",
+  "message_signing.message_invalid_hex": "String hexadecimal inválida",
   "message_signing.sign_action": "Assinar mensagem",
   "message_signing.signature_desc": "Gerado após a assinatura",
   "message_signing.signature_invalid_text": "Assinatura inválida",

--- a/packages/shared/src/locale/json/pt_BR.json
+++ b/packages/shared/src/locale/json/pt_BR.json
@@ -1853,6 +1853,7 @@
   "message_signing.address_invalid_text": "Endereço inválido ou rede não suportada",
   "message_signing.address_placeholder": "Digite uma mensagem para comprovar a propriedade deste endereço...",
   "message_signing.main_title": "Assinar e verificar mensagem",
+  "message_signing.message_invalid_hex": "String hexadecimal inválida",
   "message_signing.sign_action": "Assinar mensagem",
   "message_signing.signature_desc": "Gerado após a assinatura",
   "message_signing.signature_invalid_text": "Assinatura inválida",

--- a/packages/shared/src/locale/json/ru.json
+++ b/packages/shared/src/locale/json/ru.json
@@ -1853,6 +1853,7 @@
   "message_signing.address_invalid_text": "Недопустимый адрес или неподдерживаемая сеть",
   "message_signing.address_placeholder": "Введите сообщение, чтобы подтвердить владение этим адресом...",
   "message_signing.main_title": "Подписать и проверить сообщение",
+  "message_signing.message_invalid_hex": "Недопустимая шестнадцатеричная строка",
   "message_signing.sign_action": "Подписать сообщение",
   "message_signing.signature_desc": "Создано после подписания",
   "message_signing.signature_invalid_text": "Недопустимая подпись",

--- a/packages/shared/src/locale/json/th_TH.json
+++ b/packages/shared/src/locale/json/th_TH.json
@@ -1853,6 +1853,7 @@
   "message_signing.address_invalid_text": "ที่อยู่ไม่ถูกต้องหรือเครือข่ายไม่รองรับ",
   "message_signing.address_placeholder": "กรุณากรอกข้อความเพื่อยืนยันความเป็นเจ้าของที่อยู่นี้...",
   "message_signing.main_title": "เซ็นและยืนยันข้อความ",
+  "message_signing.message_invalid_hex": "สตริงเลขฐานสิบหกไม่ถูกต้อง",
   "message_signing.sign_action": "เซ็นข้อความ",
   "message_signing.signature_desc": "สร้างขึ้นหลังจากเซ็นชื่อ",
   "message_signing.signature_invalid_text": "ลายเซ็นไม่ถูกต้อง",

--- a/packages/shared/src/locale/json/uk_UA.json
+++ b/packages/shared/src/locale/json/uk_UA.json
@@ -1853,6 +1853,7 @@
   "message_signing.address_invalid_text": "Недійсна адреса або непідтримувана мережа",
   "message_signing.address_placeholder": "Введіть повідомлення, щоб підтвердити право власності на цю адресу...",
   "message_signing.main_title": "Підписати та перевірити повідомлення",
+  "message_signing.message_invalid_hex": "Недійсний шістнадцятковий рядок",
   "message_signing.sign_action": "Підписати повідомлення",
   "message_signing.signature_desc": "Згенеровано після підписання",
   "message_signing.signature_invalid_text": "Недійсний підпис",

--- a/packages/shared/src/locale/json/vi.json
+++ b/packages/shared/src/locale/json/vi.json
@@ -1853,6 +1853,7 @@
   "message_signing.address_invalid_text": "Địa chỉ không hợp lệ hoặc mạng không được hỗ trợ",
   "message_signing.address_placeholder": "Nhập một tin nhắn để chứng minh quyền sở hữu địa chỉ này...",
   "message_signing.main_title": "Ký & xác minh tin nhắn",
+  "message_signing.message_invalid_hex": "Chuỗi hex không hợp lệ",
   "message_signing.sign_action": "Ký thông điệp",
   "message_signing.signature_desc": "Được tạo ra sau khi ký",
   "message_signing.signature_invalid_text": "Chữ ký không hợp lệ",

--- a/packages/shared/src/locale/json/zh_CN.json
+++ b/packages/shared/src/locale/json/zh_CN.json
@@ -1853,6 +1853,7 @@
   "message_signing.address_invalid_text": "地址无效或网络不受支持",
   "message_signing.address_placeholder": "输入一条消息以证明您拥有此地址...",
   "message_signing.main_title": "签名与验证消息",
+  "message_signing.message_invalid_hex": "无效的十六进制字符串",
   "message_signing.sign_action": "签名消息",
   "message_signing.signature_desc": "签名后生成",
   "message_signing.signature_invalid_text": "无效签名",

--- a/packages/shared/src/locale/json/zh_HK.json
+++ b/packages/shared/src/locale/json/zh_HK.json
@@ -1853,6 +1853,7 @@
   "message_signing.address_invalid_text": "地址無效或不支援的網絡",
   "message_signing.address_placeholder": "輸入訊息以證明您擁有此地址...",
   "message_signing.main_title": "簽署及驗證訊息",
+  "message_signing.message_invalid_hex": "無效的十六進制字串",
   "message_signing.sign_action": "簽署訊息",
   "message_signing.signature_desc": "簽署後生成",
   "message_signing.signature_invalid_text": "無效簽名",

--- a/packages/shared/src/locale/json/zh_TW.json
+++ b/packages/shared/src/locale/json/zh_TW.json
@@ -1853,6 +1853,7 @@
   "message_signing.address_invalid_text": "無效地址或不支援的網路",
   "message_signing.address_placeholder": "輸入訊息以證明您擁有此地址...",
   "message_signing.main_title": "簽署與驗證訊息",
+  "message_signing.message_invalid_hex": "無效的十六進位字串",
   "message_signing.sign_action": "簽署訊息",
   "message_signing.signature_desc": "簽署後產生",
   "message_signing.signature_invalid_text": "無效的簽名",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - “Sign & Verify” action now appears only when supported for the current account/network.
  - Sign form adapts to hardware model: disables unsupported formats (e.g., BIP322 on Classic/Mini) and shows a helpful warning.
  - Verify form is Taproot-aware: auto-selects a compatible default and disables incompatible options (e.g., BIP137 on Taproot).
  - Confirm button is disabled when signing is unavailable, improving clarity.

- Localization
  - Hex input validation now uses a localized error message for consistency across languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->