### PR TITLE
fix: prevent selection of disabled radio options

### DIFF
--- a/packages/components/src/forms/Radio/index.tsx
+++ b/packages/components/src/forms/Radio/index.tsx
@@ -1,4 +1,8 @@
+import { useCallback } from 'react';
+
 import { RadioGroup } from 'tamagui';
+
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { Label, SizableText, XStack, YStack } from '../../primitives';
 import { NATIVE_HIT_SLOP } from '../../utils';
@@ -33,11 +37,22 @@ export function Radio({
 }: IRadioProps) {
   const Container = orientation === 'horizontal' ? XStack : YStack;
 
+  const handleValueChange = useCallback(
+    (v: string) => {
+      const option = options.find((o) => o.value === v);
+      if (option?.disabled) {
+        return;
+      }
+      onChange?.(v);
+    },
+    [onChange, options],
+  );
+
   return (
     <RadioGroup
       value={value}
       defaultValue={defaultValue}
-      onValueChange={onChange}
+      onValueChange={handleValueChange}
       disabled={disabled}
     >
       <Container gap={gap} alignItems="flex-start" flexWrap="wrap">


### PR DESCRIPTION
Adds a value change handler to Radio that checks if the selected option is disabled before invoking onChange. This prevents users from selecting disabled radio options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Radio inputs now correctly ignore interactions with disabled options, preventing unintended value changes and accidental submissions.
  * Ensures behavior aligns with the visual disabled state for more reliable form usage across platforms.

* **Refactor**
  * Improved internal change handling for radio selections without altering public APIs, enhancing robustness while maintaining existing behavior for enabled options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->