### PR TITLE
fix: improve local state update with sorted market watch list (#8266)

### DIFF
--- a/packages/kit/src/states/jotai/contexts/marketV2/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/marketV2/actions.ts
@@ -148,9 +148,13 @@ class ContextJotaiActionsMarketV2 extends ContextJotaiActionsBase {
         return;
       }
 
-      // Immediately update local state
-      const newData = [...prev.data, ...params];
-      set(marketWatchListV2Atom(), { ...prev, data: newData });
+      // Immediately update local state with proper sorting
+      const sortedNewData = sortUtils.buildSortedList({
+        oldList: prev.data,
+        saveItems: params,
+        uniqByFn: (i) => `${i.chainId}:${i.contractAddress}`,
+      });
+      set(marketWatchListV2Atom(), { ...prev, data: sortedNewData });
 
       // Asynchronously call API without waiting for result
       void backgroundApiProxy.serviceMarketV2.addMarketWatchListV2({

--- a/packages/kit/src/views/Market/components/watchListHooksV2.ts
+++ b/packages/kit/src/views/Market/components/watchListHooksV2.ts
@@ -35,7 +35,7 @@ export const useWatchListV2Action = () => {
         (item, index) => ({
           chainId: item.chainId,
           contractAddress: item.contractAddress,
-          sortIndex: firstSortIndex - (index + 1) - Math.random(),
+          sortIndex: firstSortIndex - (index + 1),
         }),
       );
 


### PR DESCRIPTION
- Updated the local state update logic in ContextJotaiActionsMarketV2 to sort the market watch list upon adding new items, ensuring proper order.
- Adjusted the sortIndex calculation in useWatchListV2Action to remove randomness, enhancing consistency in item ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Watchlist now deduplicates entries when adding items, preventing duplicates across chain and contract combinations.
  * Added items maintain a consistent, sorted order for improved readability.
  * Ordering of newly added items is now deterministic based on input sequence (removed randomness), ensuring predictable placement.
  * Overall watchlist behavior is more stable and reliable when adding multiple items at once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->