### PR TITLE
feat: add canRetry prop to ImageV2 and improve retry handling

### DIFF
--- a/packages/components/src/primitives/Image/ImageV2.native.tsx
+++ b/packages/components/src/primitives/Image/ImageV2.native.tsx
@@ -21,6 +21,7 @@ const getRandomRetryTimes = () => {
 export function ImageV2({
   style: defaultStyle,
   animated,
+  canRetry = true,
   ...props
 }: IImageV2Props) {
   const sizeProps = useMemo(() => {
@@ -69,7 +70,7 @@ export function ImageV2({
   const { image, reFetchImage } = useImage((source as ImageSource) || src, {
     onError(error, retry) {
       console.error('Loading failed:', error.message);
-      if (retryTimes.current < retryTimesLimit.current) {
+      if (canRetry && retryTimes.current < retryTimesLimit.current) {
         retryTimes.current += 1;
         setTimeout(() => {
           retry();

--- a/packages/components/src/primitives/Image/ImageV2.tsx
+++ b/packages/components/src/primitives/Image/ImageV2.tsx
@@ -22,6 +22,7 @@ import type {
 export function ImageV2({
   style: defaultStyle,
   animated,
+  canRetry = true,
   ...props
 }: IImageV2Props) {
   const sizeProps = useMemo(() => {

--- a/packages/components/src/primitives/Image/type.ts
+++ b/packages/components/src/primitives/Image/type.ts
@@ -83,6 +83,10 @@ export type IImageV2Props = Omit<
     resizeMode?: ImageProps['resizeMode'];
     tintColor?: ImageProps['tintColor'];
     onProgress?: (event: ImageProgressEventData) => void;
+    /** Whether the image can be retried
+     * @default true
+     */
+    canRetry?: boolean;
   };
 
 export type IImageProps = IImageV2Props;

--- a/packages/kit/src/components/Token/index.tsx
+++ b/packages/kit/src/components/Token/index.tsx
@@ -86,11 +86,14 @@ export function Token({
     }
     return '$full';
   }, [isNFT]);
+  const source = useMemo(() => {
+    return tokenImageUri ? { uri: tokenImageUri } : undefined;
+  }, [tokenImageUri]);
   const tokenImage = (
     <Image
       size={tokenImageSize}
       borderRadius={borderRadius}
-      source={tokenImageUri ? { uri: tokenImageUri } : undefined}
+      source={source}
       fallback={
         <Stack
           bg="$gray5"

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/Image.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/Image.tsx
@@ -1,6 +1,14 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-import { Button, Icon, Image, XStack, YStack } from '@onekeyhq/components';
+import type { IImageProps } from '@onekeyhq/components';
+import {
+  Button,
+  Icon,
+  Image,
+  Skeleton,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 
 import { Layout } from './utils/Layout';
 
@@ -39,6 +47,56 @@ function ImageStateTest() {
         fallback={<Icon name="ImageMountainsOutline" size="$10" />}
         source={{ uri }}
       />
+    </YStack>
+  );
+}
+
+function OneTimeImage({
+  uri: uriProp,
+  ...props
+}: { uri: string } & IImageProps) {
+  const [uri, setUri] = useState<string>(uriProp);
+  useEffect(() => {
+    if (!uri) {
+      setUri(uriProp);
+    }
+  }, [uriProp, uri]);
+  console.log('uri', uri);
+  const source = useMemo(() => {
+    return { uri };
+  }, [uri]);
+  return (
+    <YStack gap="$4">
+      <Image size="$10" source={source} {...props} />
+    </YStack>
+  );
+}
+
+function RetryFailedImage() {
+  const [uri, setUri] = useState<string>(
+    'https://uni.onekey-asset.com/static/chain/btc.pn',
+  );
+  return (
+    <YStack gap="$4">
+      <Image
+        size="$10"
+        source={{ uri }}
+        fallback={<Icon name="ImageMountainsOutline" size="$8" />}
+      />
+      <OneTimeImage
+        uri={uri}
+        size="$10"
+        fallback={<Icon name="ImageMountainsOutline" size="$8" />}
+      />
+      <Button
+        onPress={() =>
+          setUri(
+            `https://uni.onekey-asset.com/static/chain/btc.pn${Math.random()}`,
+          )
+        }
+      >
+        retry failed image
+      </Button>
     </YStack>
   );
 }
@@ -176,6 +234,10 @@ const ImageGallery = () => (
             />
           </YStack>
         ),
+      },
+      {
+        title: 'retry failed image',
+        element: <RetryFailedImage />,
       },
     ]}
   />


### PR DESCRIPTION
Introduces a canRetry prop (default true) to ImageV2 components for both native and web, allowing control over automatic retry on image load failure. Updates type definitions and adds new storybook examples to demonstrate retry behavior. Refactors Token image source memoization for efficiency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Image component now supports a canRetry option (default on) to control whether failed image loads should retry. When disabled or after reaching the retry limit, it surfaces an error state promptly.

- Documentation
  - Added a gallery example “retry failed image” showcasing retry behavior and manual reload via a button.

- Refactor
  - Optimized Token image rendering by memoizing the image source to reduce unnecessary recalculations and potential re-renders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->