### PR TITLE
feat: add perp tradingview component

### DIFF
--- a/packages/kit-bg/src/apis/backgroundApiPermissions.ts
+++ b/packages/kit-bg/src/apis/backgroundApiPermissions.ts
@@ -56,6 +56,9 @@ export const PROVIDER_API_PRIVATE_WHITE_LIST_METHOD = [
   'wallet_addBrowserUrlToRiskWhiteList',
   'tradingview_getKLineData',
   'tradingview_layoutUpdate',
+  'tradingview_getMarks',
+  'tradingview_chartReady',
+  'tradingview_getHyperliquidPriceScale',
   'btc_requestAccount',
   'btc_signTransaction',
 ];

--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
@@ -1,0 +1,186 @@
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
+
+import { useCalendars } from 'expo-localization';
+
+import { Stack, useOrientation } from '@onekeyhq/components';
+import type { IStackStyle } from '@onekeyhq/components';
+import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
+import { TRADING_VIEW_URL } from '@onekeyhq/shared/src/config/appConfig';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import type { IHex } from '@onekeyhq/shared/types/hyperliquid/sdk';
+
+import { useLocaleVariant } from '../../../hooks/useLocaleVariant';
+import { useThemeVariant } from '../../../hooks/useThemeVariant';
+import WebView from '../../WebView';
+import { getTradingViewTimezone } from '../utils/tradingViewTimezone';
+
+import { useTradeUpdates } from './hooks';
+import { usePerpsMessageHandler } from './messageHandlers';
+
+import type { ITradeEvent } from './types';
+import type { IWebViewRef } from '../../WebView/types';
+import type { WebViewProps } from 'react-native-webview';
+
+interface IBaseTradingViewPerpsV2Props {
+  symbol: string;
+  userAddress: IHex | undefined;
+  onLoadEnd?: () => void;
+  onTradeUpdate?: (trade: ITradeEvent) => void;
+  tradingViewUrl?: string;
+}
+
+export type ITradingViewPerpsV2Props = IBaseTradingViewPerpsV2Props &
+  IStackStyle;
+
+// Dynamic params sync hook - symbol changes sync via message instead of WebView reload
+const useSymbolSync = ({
+  webRef,
+  symbol,
+}: {
+  webRef: React.RefObject<IWebViewRef | null>;
+  symbol: string;
+}) => {
+  const prevSymbolRef = useRef<string>(symbol);
+
+  useEffect(() => {
+    const prevSymbol = prevSymbolRef.current;
+    const hasSymbolChanged = prevSymbol !== symbol;
+
+    if (hasSymbolChanged && webRef.current) {
+      console.log('🔄 Syncing symbol to WebView:', {
+        from: prevSymbol,
+        to: symbol,
+      });
+
+      // Sync symbol changes via message communication instead of WebView reload
+      webRef.current.sendMessageViaInjectedScript({
+        type: 'SYMBOL_CHANGE',
+        payload: {
+          symbol,
+          force: true,
+        },
+      });
+
+      prevSymbolRef.current = symbol;
+    }
+  }, [symbol, webRef]);
+};
+
+// WebView Memoized component to prevent unnecessary re-renders
+const WebViewMemoized = memo(
+  ({
+    src,
+    customReceiveHandler,
+    onWebViewRef,
+    ...otherProps
+  }: {
+    src: string;
+    customReceiveHandler: (data: any) => Promise<void>;
+    onWebViewRef: (ref: IWebViewRef | null) => void;
+    [key: string]: any;
+  }) => (
+    <WebView
+      src={src}
+      customReceiveHandler={customReceiveHandler}
+      onWebViewRef={onWebViewRef}
+      {...otherProps}
+    />
+  ),
+  (prevProps, nextProps) => {
+    // Only re-render if critical props change
+    return (
+      prevProps.src === nextProps.src &&
+      prevProps.customReceiveHandler === nextProps.customReceiveHandler
+    );
+  },
+);
+
+WebViewMemoized.displayName = 'WebViewMemoized';
+
+export function TradingViewPerpsV2(
+  props: ITradingViewPerpsV2Props & WebViewProps,
+) {
+  const isLandscape = useOrientation();
+  const isIPadPortrait = platformEnv.isNativeIOSPad && !isLandscape;
+  const webRef = useRef<IWebViewRef | null>(null);
+  const calendars = useCalendars();
+  const systemLocale = useLocaleVariant();
+  const theme = useThemeVariant();
+  const [devSettings] = useDevSettingsPersistAtom();
+
+  const { symbol, userAddress, onLoadEnd, onTradeUpdate, tradingViewUrl } =
+    props;
+
+  // Optimization: Static URL with only initialization params to avoid WebView reload
+  const staticTradingViewUrl = useMemo(() => {
+    const baseUrl =
+      tradingViewUrl ||
+      (devSettings.enabled && devSettings.settings?.useLocalTradingViewUrl
+        ? 'http://localhost:5173/'
+        : TRADING_VIEW_URL);
+
+    const url = new URL(baseUrl);
+    url.searchParams.set('timezone', getTradingViewTimezone(calendars));
+    url.searchParams.set('locale', systemLocale);
+    url.searchParams.set('platform', platformEnv.appPlatform ?? 'web');
+    url.searchParams.set('theme', theme);
+    url.searchParams.set('symbol', symbol);
+    url.searchParams.set('type', 'perps');
+
+    return url.toString();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tradingViewUrl, devSettings, calendars, systemLocale, theme]);
+
+  // Optimization: Dynamic symbol parameter sync mechanism
+  useSymbolSync({
+    webRef,
+    symbol,
+  });
+
+  const { customReceiveHandler } = usePerpsMessageHandler({
+    symbol,
+    userAddress,
+    webRef,
+  });
+
+  // trade update push
+  const { pushTradeUpdate: _pushTradeUpdate } = useTradeUpdates({
+    webRef,
+    onTradeUpdate,
+  });
+
+  const onWebViewRef = useCallback((ref: IWebViewRef | null) => {
+    webRef.current = ref;
+  }, []);
+
+  return (
+    <Stack position="relative" flex={1}>
+      <WebViewMemoized
+        src={staticTradingViewUrl}
+        customReceiveHandler={customReceiveHandler}
+        onWebViewRef={onWebViewRef}
+        onLoadEnd={onLoadEnd}
+        displayProgressBar={false}
+        pullToRefreshEnabled={false}
+        scrollEnabled={false}
+        bounces={false}
+        overScrollMode="never"
+        showsHorizontalScrollIndicator={false}
+        showsVerticalScrollIndicator={false}
+        decelerationRate="normal"
+      />
+
+      {platformEnv.isNativeIOS || isIPadPortrait ? (
+        <Stack
+          position="absolute"
+          left={0}
+          top={0}
+          bottom={0}
+          width={12}
+          zIndex={1}
+          pointerEvents="auto"
+        />
+      ) : null}
+    </Stack>
+  );
+}

--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/constants/messageTypes.ts
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/constants/messageTypes.ts
@@ -3,4 +3,4 @@ export const MESSAGE_TYPES = {
   MARKS_RESPONSE: 'MARKS_RESPONSE',
 } as const;
 
-export type MessageType = typeof MESSAGE_TYPES[keyof typeof MESSAGE_TYPES];
+export type IMessageType = (typeof MESSAGE_TYPES)[keyof typeof MESSAGE_TYPES];

--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/constants/messageTypes.ts
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/constants/messageTypes.ts
@@ -1,0 +1,6 @@
+export const MESSAGE_TYPES = {
+  MARKS_UPDATE: 'MARKS_UPDATE',
+  MARKS_RESPONSE: 'MARKS_RESPONSE',
+} as const;
+
+export type MessageType = typeof MESSAGE_TYPES[keyof typeof MESSAGE_TYPES];

--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/hooks/index.ts
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/hooks/index.ts
@@ -1,0 +1,42 @@
+import { useCallback } from 'react';
+
+import type { IWebViewRef } from '../../../WebView/types';
+import type { ITradeEvent } from '../types';
+
+// simple trade event push hook
+export function useTradeUpdates({
+  webRef,
+  onTradeUpdate,
+}: {
+  webRef: React.RefObject<IWebViewRef | null>;
+  onTradeUpdate?: (trade: ITradeEvent) => void;
+}) {
+  const pushTradeUpdate = useCallback(
+    (trade: ITradeEvent) => {
+      onTradeUpdate?.(trade);
+      webRef.current?.sendMessageViaInjectedScript({
+        type: 'TRADE_UPDATE',
+        payload: trade,
+      });
+    },
+    [webRef, onTradeUpdate],
+  );
+
+  return { pushTradeUpdate };
+}
+
+// mock trade event for testing
+export const simulateTradeEvent = (
+  symbol: string,
+  pushFn: (trade: ITradeEvent) => void,
+) => {
+  const mockTrade: ITradeEvent = {
+    symbol,
+    side: Math.random() > 0.5 ? 'buy' : 'sell',
+    size: (Math.random() * 0.5 + 0.1).toFixed(3),
+    price: (40_000 + Math.random() * 10_000).toFixed(2),
+    time: Date.now() / 1000,
+    txHash: `0x${Math.random().toString(16).substring(2, 10)}`,
+  };
+  pushFn(mockTrade);
+};

--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/index.ts
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/index.ts
@@ -1,0 +1,3 @@
+export { TradingViewPerpsV2 } from './TradingViewPerpsV2';
+export { simulateTradeEvent } from './hooks';
+export type { ITradingMark, ITradeEvent } from './types';

--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/messageHandlers/index.ts
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/messageHandlers/index.ts
@@ -1,0 +1,300 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import {
+  IInjectedProviderNames,
+  type IJsBridgeMessagePayload,
+} from '@onekeyfe/cross-inpage-provider-types';
+
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { useCurrentTokenPriceAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import { calculatePriceScale } from '@onekeyhq/shared/src/utils/perpsUtils';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
+import type { IFill, IHex } from '@onekeyhq/shared/types/hyperliquid/sdk';
+
+import { MESSAGE_TYPES } from '../constants/messageTypes';
+import { EMarksUpdateOperationEnum } from '../types';
+
+import type { IWebViewRef } from '../../../WebView/types';
+import type {
+  IGetMarksRequest,
+  IGetMarksResponse,
+  ITradingMark,
+} from '../types';
+
+export function usePerpsMessageHandler({
+  symbol,
+  userAddress,
+  webRef,
+}: {
+  symbol: string;
+  userAddress?: IHex | null;
+  webRef: React.RefObject<IWebViewRef | null>;
+}) {
+  const previousUserAddressRef = useRef<IHex | null | undefined>(userAddress);
+  const [priceData] = useCurrentTokenPriceAtom();
+
+  useEffect(() => {
+    if (priceData) {
+      // console.log('[MarksHandler] priceData: ', priceData);
+    }
+  }, [priceData]);
+
+  // Extract shared logic for fetching and formatting marks
+  const fetchAndFormatMarks = useCallback(
+    async (
+      targetSymbol: string,
+      targetUserAddress: IHex,
+    ): Promise<ITradingMark[]> => {
+      const historyTrades =
+        await backgroundApiProxy.serviceHyperliquidInfo.getUserFillsByTime({
+          user: targetUserAddress,
+          startTime: 1_731_024_000_000,
+          endTime: 2_114_352_000_000,
+          aggregateByTime: true,
+        });
+
+      // Filter trades by target symbol and format to TradingView marks
+      const filteredTrades = historyTrades.filter(
+        (trade: IFill) => trade.coin === targetSymbol,
+      );
+
+      // @ts-expect-error
+      const marks: ITradingMark[] = filteredTrades
+        .map((trade: IFill, index: number) => {
+          const isLong = trade.side === 'B'; // B = Buy, A = Sell (Ask)
+          const isOpenPosition = trade.dir.includes('Open');
+
+          // Determine label and color based on trade direction
+          const getTradeLabel = () => {
+            if (isOpenPosition) {
+              return isLong ? 'B' : 'S'; // Buy Long or Sell Short
+            }
+            return isLong ? 'B' : 'S'; // Close position
+          };
+
+          // Generate descriptive text
+          const getTradeText = () => {
+            return `${trade.dir} at ${trade.px}`;
+          };
+
+          return {
+            id: `trade_${trade.tid || index}`,
+            time: Math.floor(trade.time / 1000), // Convert milliseconds to seconds
+            text: getTradeText(),
+            label: getTradeLabel(),
+            raw: trade,
+          };
+        })
+        .sort((a, b) => b.time - a.time); // Sort by time ascending (earliest first)
+
+      return marks;
+    },
+    [],
+  );
+
+  // Function to send marks update to iframe
+  const sendMarksUpdate = useCallback(
+    (marks: ITradingMark[], operation: EMarksUpdateOperationEnum) => {
+      webRef.current?.sendMessageViaInjectedScript({
+        type: MESSAGE_TYPES.MARKS_UPDATE,
+        payload: {
+          marks,
+          symbol,
+          operation,
+        },
+      });
+    },
+    [webRef, symbol],
+  );
+
+  // Handle legacy MARKS_RESPONSE for backward compatibility
+  const handleGetMarks = useCallback(
+    async (request: IGetMarksRequest) => {
+      const { requestId } = request;
+
+      if (!userAddress) {
+        webRef.current?.sendMessageViaInjectedScript({
+          type: 'MARKS_RESPONSE',
+          payload: {
+            marks: [],
+            requestId,
+          },
+        });
+        return;
+      }
+
+      try {
+        const marks = await fetchAndFormatMarks(symbol, userAddress);
+        console.log('[MarksHandler] fetch marks: ', marks);
+
+        const response: IGetMarksResponse = {
+          marks,
+          requestId,
+        };
+
+        webRef.current?.sendMessageViaInjectedScript({
+          type: 'MARKS_RESPONSE',
+          payload: response,
+        });
+      } catch (error) {
+        console.error('Error fetching marks:', error);
+        webRef.current?.sendMessageViaInjectedScript({
+          type: 'MARKS_RESPONSE',
+          payload: {
+            marks: [],
+            requestId,
+          },
+        });
+      }
+    },
+    [webRef, userAddress, symbol, fetchAndFormatMarks],
+  );
+
+  // Handle HyperLiquid price scale requests
+  const handleGetHyperliquidPriceScale = useCallback(
+    async (request: { symbol: string; requestId: string }) => {
+      const { symbol: requestSymbol, requestId } = request;
+
+      console.log('[MessageHandler] handleGetHyperliquidPriceScale: ', request);
+
+      // Wait for matching symbol and valid market price with 3s timeout
+      const startTime = Date.now();
+      const timeout = 3000; // 3 seconds
+      let currentPriceData = priceData;
+
+      while (Date.now() - startTime < timeout) {
+        // Check if we have matching symbol and valid price
+        if (
+          currentPriceData?.coin === requestSymbol &&
+          currentPriceData?.markPrice &&
+          Number(currentPriceData.markPrice) > 0
+        ) {
+          break;
+        }
+
+        console.log(
+          '[MessageHandler] Waiting for matching symbol and valid price...',
+          {
+            requested: requestSymbol,
+            currentSymbol: currentPriceData?.coin,
+            currentPrice: currentPriceData?.markPrice,
+            elapsed: Date.now() - startTime,
+          },
+        );
+
+        await timerUtils.wait(100);
+        currentPriceData = priceData;
+      }
+
+      // Calculate priceScale using HyperLiquid precision rules
+      let calculatedPriceScale = 100; // default 2 decimal places
+
+      if (
+        currentPriceData?.coin === requestSymbol &&
+        currentPriceData?.markPrice &&
+        Number(currentPriceData.markPrice) > 0
+      ) {
+        // Use simplified HyperLiquid precision rules to calculate price scale
+        calculatedPriceScale = calculatePriceScale(currentPriceData.markPrice);
+      }
+
+      const response = {
+        priceScale: calculatedPriceScale,
+        minmov: 1,
+        requestId,
+      };
+
+      console.log('[MessageHandler] Price scale response:', {
+        symbol: requestSymbol,
+        matchedSymbol: currentPriceData?.coin,
+        markPrice: currentPriceData?.markPrice,
+        priceScale: calculatedPriceScale,
+        timeout: Date.now() - startTime >= timeout,
+      });
+
+      webRef.current?.sendMessageViaInjectedScript({
+        type: 'HYPERLIQUID_PRICESCALE_RESPONSE',
+        payload: response,
+      });
+    },
+    [webRef, priceData],
+  );
+
+  const customReceiveHandler = useCallback(
+    async (payload: IJsBridgeMessagePayload) => {
+      const { data } = payload;
+      if (typeof data !== 'object' || data === null) return;
+
+      const messageData = data as {
+        scope?: string;
+        method?: string;
+        data?: unknown;
+      };
+
+      if (messageData.scope !== IInjectedProviderNames.$private) return;
+
+      switch (messageData.method) {
+        case 'tradingview_getMarks':
+          await handleGetMarks(messageData.data as IGetMarksRequest);
+          break;
+        case 'tradingview_getHyperliquidPriceScale':
+          await handleGetHyperliquidPriceScale(
+            messageData.data as { symbol: string; requestId: string },
+          );
+          break;
+        default:
+          break;
+      }
+    },
+    [handleGetMarks, handleGetHyperliquidPriceScale],
+  );
+
+  // Monitor userAddress changes and push updates
+  useEffect(() => {
+    const previousUserAddress = previousUserAddressRef.current;
+    const currentUserAddress = userAddress;
+
+    // Skip on initial mount
+    if (previousUserAddress === undefined) {
+      previousUserAddressRef.current = currentUserAddress;
+      return;
+    }
+
+    // User address changed
+    if (previousUserAddress !== currentUserAddress) {
+      console.log('[MarksHandler] UserAddress changed:', {
+        from: previousUserAddress,
+        to: currentUserAddress,
+        symbol,
+      });
+
+      if (!currentUserAddress) {
+        // User logged out, clear marks
+        console.log('[MarksHandler] User logged out, clear marks');
+        sendMarksUpdate([], EMarksUpdateOperationEnum.CLEAR);
+      } else {
+        // User changed or logged in, fetch fresh data
+        void fetchAndFormatMarks(symbol, currentUserAddress)
+          .then((marks) => {
+            console.log(
+              '[MarksHandler] User logged in, fetch fresh data: ',
+              marks,
+            );
+            sendMarksUpdate(marks, EMarksUpdateOperationEnum.REPLACE);
+          })
+          .catch((error) => {
+            console.error('Error fetching marks on user change:', error);
+            sendMarksUpdate([], EMarksUpdateOperationEnum.CLEAR);
+          });
+      }
+
+      previousUserAddressRef.current = currentUserAddress;
+    }
+  }, [userAddress, symbol, fetchAndFormatMarks, sendMarksUpdate]);
+
+  return {
+    customReceiveHandler,
+    sendMarksUpdate,
+    fetchAndFormatMarks,
+  };
+}

--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/types.ts
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/types.ts
@@ -1,0 +1,44 @@
+export interface ITradingMark {
+  id: string;
+  time: number;
+  color: string;
+  text: string;
+  label: string;
+}
+
+export interface ITradeEvent {
+  symbol: string;
+  side: 'buy' | 'sell';
+  size: string;
+  price: string;
+  time: number;
+  txHash?: string;
+}
+
+export interface IGetMarksRequest {
+  symbol: string;
+  from: number;
+  to: number;
+  resolution?: string;
+  requestId?: string;
+}
+
+export interface IGetMarksResponse {
+  marks: ITradingMark[];
+  requestId?: string;
+}
+
+export enum EMarksUpdateOperationEnum {
+  INCREMENTAL = 'incremental',
+  REPLACE = 'replace',
+  CLEAR = 'clear',
+}
+
+export interface IMarksUpdateMessage {
+  type: 'MARKS_UPDATE';
+  payload: {
+    marks: ITradingMark[];
+    symbol: string;
+    operation: EMarksUpdateOperationEnum;
+  };
+}

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/TradingViewPerpsV2.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/TradingViewPerpsV2.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+
+import { Button, SizableText, Stack, XStack } from '@onekeyhq/components';
+import { TradingViewPerpsV2 } from '@onekeyhq/kit/src/components/TradingView/TradingViewPerpsV2';
+
+import { Layout } from './utils/Layout';
+
+const TradingViewPerpsV2Gallery = () => {
+  const [currentSymbol, setCurrentSymbol] = useState('BTC');
+
+  const tokens = [
+    { symbol: 'BTC', name: 'BTC' },
+    { symbol: 'ETH', name: 'ETH' },
+    { symbol: 'SOL', name: 'SOL' },
+  ];
+
+  return (
+    <Layout
+      getFilePath={() => __CURRENT_FILE_PATH__}
+      componentName="TradingViewPerpsV2"
+      elements={[
+        {
+          title: 'Perps Trading View - Symbol切换测试',
+          element: (
+            <Stack gap="$1">
+              <XStack gap="$1" justifyContent="center">
+                {tokens.map((token) => (
+                  <Button
+                    key={token.symbol}
+                    variant={
+                      currentSymbol === token.symbol ? 'primary' : 'secondary'
+                    }
+                    size="small"
+                    onPress={() => {
+                      console.log(
+                        `🔄 Switching symbol from ${currentSymbol} to ${token.symbol}`,
+                      );
+                      setCurrentSymbol(token.symbol);
+                    }}
+                  >
+                    {token.name}
+                  </Button>
+                ))}
+              </XStack>
+
+              <Stack alignItems="center">
+                <SizableText>Current Symbol: {currentSymbol}</SizableText>
+              </Stack>
+
+              <Stack w="100%" h={500}>
+                <TradingViewPerpsV2
+                  symbol={currentSymbol}
+                  userAddress={undefined}
+                />
+              </Stack>
+            </Stack>
+          ),
+        },
+      ]}
+    />
+  );
+};
+
+export default TradingViewPerpsV2Gallery;

--- a/packages/kit/src/views/Developer/pages/Gallery/index.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/index.tsx
@@ -485,6 +485,13 @@ const TradingViewGallery = LazyLoadPage(
     ),
 );
 
+const TradingViewPerpsV2Gallery = LazyLoadPage(
+  () =>
+    import(
+      '@onekeyhq/kit/src/views/Developer/pages/Gallery/Components/stories/TradingViewPerpsV2'
+    ),
+);
+
 const LetterAvatarGallery = LazyLoadPage(
   () =>
     import(
@@ -839,6 +846,10 @@ export const galleryScreenList: {
   {
     name: EGalleryRoutes.ComponentTradingViewGallery,
     component: TradingViewGallery,
+  },
+  {
+    name: EGalleryRoutes.ComponentTradingViewPerpsV2Gallery,
+    component: TradingViewPerpsV2Gallery,
   },
   {
     name: EGalleryRoutes.LetterAvatarGallery,

--- a/packages/kit/src/views/Perp/components/PerpCandles.tsx
+++ b/packages/kit/src/views/Perp/components/PerpCandles.tsx
@@ -1,3 +1,31 @@
-export const PerpCandles = () => {
-  return <div>PerpCandles</div>;
-};
+import { useEffect } from 'react';
+
+import { Stack } from '@onekeyhq/components';
+import { TradingViewPerpsV2 } from '@onekeyhq/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2';
+
+import { useCurrentTokenAtom } from '../../../states/jotai/contexts/hyperliquid';
+import { useHyperliquidAccount } from '../hooks';
+import { usePerpUseChainAccount } from '../hooks/usePerpUseChainAccount';
+
+export function PerpCandles() {
+  const [currentToken] = useCurrentTokenAtom();
+  const { userAddress } = usePerpUseChainAccount();
+
+  useEffect(() => {
+    if (currentToken) {
+      console.log('PerpCandles -> currentToken: ', currentToken);
+    }
+  }, [currentToken]);
+
+  useEffect(() => {
+    if (userAddress) {
+      console.log('PerpCandles -> currentUser: ', userAddress);
+    }
+  }, [userAddress]);
+
+  return (
+    <Stack w="100%" h="100%">
+      <TradingViewPerpsV2 userAddress={userAddress} symbol={currentToken} />
+    </Stack>
+  );
+}

--- a/packages/shared/src/routes/gallery.ts
+++ b/packages/shared/src/routes/gallery.ts
@@ -79,6 +79,7 @@ export enum EGalleryRoutes {
   ComponentToken = 'component-Token',
   ComponentTooltip = 'component-Tooltip',
   ComponentTradingViewGallery = 'component-TradingView',
+  ComponentTradingViewPerpsV2Gallery = 'component-TradingViewPerpsV2',
   ComponentTrigger = 'component-Trigger',
   ComponentTutorialsList = 'component-TutorialsList',
   ComponentOrderedList = 'component-OrderedList',

--- a/packages/shared/src/utils/perpsUtils.test.ts
+++ b/packages/shared/src/utils/perpsUtils.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for HyperLiquid perps price precision utilities
+ * Based on: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/tick-and-lot-size
+ */
+
+import { getValidPriceDecimals } from './perpsUtils';
+
+describe('getValidPriceDecimals', () => {
+  describe('Integer prices (always allowed)', () => {
+    test('should handle large integer prices', () => {
+      // 123456 is valid even though it has 6 significant figures
+      expect(getValidPriceDecimals('123456')).toBe(0);
+      expect(getValidPriceDecimals(123_456)).toBe(0);
+    });
+
+    test('should handle small integer prices', () => {
+      expect(getValidPriceDecimals('1')).toBe(0);
+      expect(getValidPriceDecimals('12')).toBe(0);
+      expect(getValidPriceDecimals('123')).toBe(0);
+      expect(getValidPriceDecimals(1000)).toBe(0);
+    });
+  });
+
+  describe('Non-integer prices with 5 significant figures constraint', () => {
+    test('should handle valid prices with exactly 5 significant figures', () => {
+      // 1234.5 is valid (4 integer + 1 decimal = 5 significant figures)
+      expect(getValidPriceDecimals('1234.5')).toBe(1);
+
+      // 123.45 is valid (3 integer + 2 decimal = 5 significant figures)
+      expect(getValidPriceDecimals('123.45')).toBe(2);
+
+      // 12.345 is valid (2 integer + 3 decimal = 5 significant figures)
+      expect(getValidPriceDecimals('12.345')).toBe(3);
+
+      // 1.2345 is valid (1 integer + 4 decimal = 5 significant figures)
+      expect(getValidPriceDecimals('1.2345')).toBe(4);
+    });
+
+    test('should limit prices with more than 5 significant figures', () => {
+      // 1234.56 has 6 significant figures, should be limited to 1 decimal place
+      expect(getValidPriceDecimals('1234.56')).toBe(1);
+
+      // 123.456 has 6 significant figures, should be limited to 2 decimal places
+      expect(getValidPriceDecimals('123.456')).toBe(2);
+
+      // 12.3456 has 6 significant figures, should be limited to 3 decimal places
+      expect(getValidPriceDecimals('12.3456')).toBe(3);
+    });
+
+    test('should handle prices with integer part >= 5 digits', () => {
+      // 12345.6 has 6 significant figures, integer part is 5 digits
+      // Should be limited to 0 decimal places
+      expect(getValidPriceDecimals('12345.6')).toBe(0);
+
+      // 123456.789 has integer part >= 5 digits
+      // Should be limited to 0 decimal places
+      expect(getValidPriceDecimals('123456.789')).toBe(0);
+    });
+  });
+
+  describe('Decimal places constraint (MAX_DECIMALS = 6 for perps)', () => {
+    test('should handle valid prices within 6 decimal places', () => {
+      // 0.001234 is valid (6 decimal places, 5 significant figures)
+      expect(getValidPriceDecimals('0.001234')).toBe(6);
+
+      // 0.123456 is valid (6 decimal places, but limited by 5 sig figs)
+      expect(getValidPriceDecimals('0.123456')).toBe(5);
+    });
+
+    test('should limit prices with more than 6 decimal places', () => {
+      // 0.0012345 has 7 decimal places, should be limited to 6
+      expect(getValidPriceDecimals('0.0012345')).toBe(6);
+
+      // 0.1234567 has 7 decimal places, should be limited to 6
+      expect(getValidPriceDecimals('0.1234567')).toBe(5); // Limited by 5 sig figs
+    });
+
+    test('should handle very small prices', () => {
+      // 0.000001 is valid (6 decimal places, 1 significant figure)
+      expect(getValidPriceDecimals('0.000001')).toBe(6);
+
+      // 0.0000123 has 7 decimal places, should be limited to 6
+      expect(getValidPriceDecimals('0.0000123')).toBe(6);
+    });
+  });
+
+  describe('Edge cases from HyperLiquid examples', () => {
+    test('should handle documented valid examples', () => {
+      // 1234.5 is valid but 1234.56 is not (too many significant figures)
+      expect(getValidPriceDecimals('1234.5')).toBe(1);
+
+      // 0.001234 is valid, but 0.0012345 is not (more than 6 decimal places)
+      expect(getValidPriceDecimals('0.001234')).toBe(6);
+    });
+
+    test('should limit documented invalid examples', () => {
+      // 1234.56 is not valid (too many significant figures)
+      // Should be limited to 1 decimal place
+      expect(getValidPriceDecimals('1234.56')).toBe(1);
+
+      // 0.0012345 is not valid (more than 6 decimal places)
+      // Should be limited to 6 decimal places
+      expect(getValidPriceDecimals('0.0012345')).toBe(6);
+    });
+  });
+
+  describe('szDecimals constraint examples (assuming szDecimals = 0)', () => {
+    test('should handle prices within MAX_DECIMALS - szDecimals limit', () => {
+      // With szDecimals = 0, max decimal places = 6 - 0 = 6
+      // But still limited by 5 significant figures rule
+
+      // 1.123456 has 7 significant figures, limited to 4 decimals (1+4=5 sig figs)
+      expect(getValidPriceDecimals('1.123456')).toBe(4);
+
+      // 12.12345 has 7 significant figures, limited to 3 decimals (2+3=5 sig figs)
+      expect(getValidPriceDecimals('12.12345')).toBe(3);
+
+      // 123.1234 has 7 significant figures, limited to 2 decimals (3+2=5 sig figs)
+      expect(getValidPriceDecimals('123.1234')).toBe(2);
+    });
+  });
+
+  describe('Input validation', () => {
+    test('should handle string inputs', () => {
+      expect(getValidPriceDecimals('1234.5')).toBe(1);
+      expect(getValidPriceDecimals('0.001234')).toBe(6);
+    });
+
+    test('should handle number inputs', () => {
+      expect(getValidPriceDecimals(1234.5)).toBe(1);
+      expect(getValidPriceDecimals(0.001_234)).toBe(6);
+    });
+
+    test('should handle invalid inputs with fallback', () => {
+      // Should return default 2 decimal places
+      expect(getValidPriceDecimals(0)).toBe(2);
+      expect(getValidPriceDecimals(-1)).toBe(2);
+      expect(getValidPriceDecimals('invalid')).toBe(2);
+      expect(getValidPriceDecimals('')).toBe(2);
+    });
+
+    test('should handle edge numeric values', () => {
+      expect(getValidPriceDecimals(0.1)).toBe(1);
+      expect(getValidPriceDecimals(0.01)).toBe(2);
+      expect(getValidPriceDecimals(0.001)).toBe(3);
+    });
+  });
+
+  describe('Real-world crypto price examples', () => {
+    test('should handle typical crypto prices', () => {
+      // Bitcoin-like prices
+      expect(getValidPriceDecimals('45123')).toBe(0); // Integer
+      expect(getValidPriceDecimals('45123.4')).toBe(0); // 5 integer digits, limited to 0 decimals
+
+      // Use 4-digit integer prices instead
+      expect(getValidPriceDecimals('4512.3')).toBe(1); // 1 decimal (4+1=5 sig figs)
+
+      // Ethereum-like prices
+      expect(getValidPriceDecimals('2534.67')).toBe(1); // Limited by 5 sig figs (4+1=5)
+
+      // Alt coin prices
+      expect(getValidPriceDecimals('1.2345')).toBe(4); // 4 decimals (1+4=5 sig figs)
+      expect(getValidPriceDecimals('0.123456')).toBe(5); // Limited by 5 sig figs
+
+      // Very small prices
+      expect(getValidPriceDecimals('0.000123')).toBe(6); // 6 decimals (5 sig figs)
+    });
+  });
+});

--- a/packages/shared/src/utils/perpsUtils.ts
+++ b/packages/shared/src/utils/perpsUtils.ts
@@ -1,0 +1,134 @@
+/**
+ * HyperLiquid perps price precision utilities
+ * Based on: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/tick-and-lot-size
+ */
+
+import BigNumber from 'bignumber.js';
+
+const MAX_DECIMALS_PERP = 6;
+const MAX_SIGNIFICANT_FIGURES = 5;
+
+/**
+ * Check if a number is effectively an integer (no meaningful decimal places)
+ */
+function isEffectivelyInteger(price: BigNumber): boolean {
+  return price.isInteger();
+}
+
+/**
+ * Count significant figures in a BigNumber
+ */
+function countSignificantFigures(price: BigNumber): number {
+  if (price.isZero()) return 1;
+
+  const priceStr = price.toFixed(); // Get fixed decimal representation
+  const scientificMatch = priceStr.match(/^(\d+(?:\.\d+)?)e([+-]?\d+)$/i);
+
+  if (scientificMatch) {
+    // Handle scientific notation
+    const [, mantissa] = scientificMatch;
+    return mantissa.replace('.', '').replace(/^0+/, '').length;
+  }
+
+  // Remove decimal point and leading zeros
+  const digits = priceStr.replace('.', '').replace(/^0+/, '');
+  return digits.length;
+}
+
+/**
+ * Calculate valid decimal places for HyperLiquid perp prices
+ *
+ * HyperLiquid rules:
+ * 1. Integer prices are always allowed (regardless of significant figures)
+ * 2. Non-integer prices: max 5 significant figures
+ * 3. Max decimal places = MAX_DECIMALS_PERP (6 for perps, assuming szDecimals=0)
+ *
+ * @param marketPrice - The market price to analyze
+ * @returns Valid decimal places for the price
+ */
+function getValidPriceDecimals(marketPrice: string | number): number {
+  const price = new BigNumber(marketPrice);
+
+  if (!price.isFinite() || price.isLessThanOrEqualTo(0)) {
+    return 2; // Default fallback
+  }
+
+  // Rule 1: Integer prices are always allowed
+  if (isEffectivelyInteger(price)) {
+    return 0;
+  }
+
+  // Rule 2: Non-integer prices - apply 5 significant figures limit
+  const priceStr = price.toFixed();
+  const decimalIndex = priceStr.indexOf('.');
+
+  if (decimalIndex === -1) {
+    return 0; // No decimal point
+  }
+
+  const actualDecimals = priceStr.length - decimalIndex - 1;
+  const significantFigures = countSignificantFigures(price);
+
+  // Calculate max allowed decimals based on significant figures constraint
+  const integerPart = price.integerValue(BigNumber.ROUND_DOWN);
+  const integerDigits = integerPart.isZero() ? 0 : integerPart.toFixed().length;
+
+  let maxAllowedDecimals = actualDecimals;
+
+  // Apply 5 significant figures limit for non-integer prices
+  if (significantFigures > MAX_SIGNIFICANT_FIGURES) {
+    if (integerDigits >= MAX_SIGNIFICANT_FIGURES) {
+      maxAllowedDecimals = 0;
+    } else {
+      const remainingSignificantFigures =
+        MAX_SIGNIFICANT_FIGURES - integerDigits;
+      maxAllowedDecimals = Math.min(
+        actualDecimals,
+        remainingSignificantFigures,
+      );
+    }
+  }
+
+  // Rule 3: Also limit by MAX_DECIMALS_PERP (assuming szDecimals=0)
+  maxAllowedDecimals = Math.min(maxAllowedDecimals, MAX_DECIMALS_PERP);
+
+  return Math.max(0, maxAllowedDecimals);
+}
+
+/**
+ * Calculate price scale (10^decimals) for TradingView based on valid decimals
+ *
+ * @param marketPrice - The market price to analyze
+ * @returns Price scale for TradingView (e.g., 100 for 2 decimals)
+ */
+function calculatePriceScale(marketPrice: string | number): number {
+  const validDecimals = getValidPriceDecimals(marketPrice);
+  return new BigNumber(10).exponentiatedBy(validDecimals).toNumber();
+}
+
+/**
+ * Format price according to HyperLiquid precision rules
+ *
+ * @param marketPrice - The market price to format
+ * @returns Formatted price string
+ */
+function formatPriceToValid(marketPrice: string | number): string {
+  const price = new BigNumber(marketPrice);
+
+  if (!price.isFinite() || price.isLessThanOrEqualTo(0)) {
+    return '0';
+  }
+
+  const validDecimals = getValidPriceDecimals(marketPrice);
+
+  // Format with valid decimals and remove trailing zeros as per HyperLiquid signing requirements
+  return price.toFixed(validDecimals).replace(/\.?0+$/, '');
+}
+
+export { getValidPriceDecimals, calculatePriceScale, formatPriceToValid };
+
+export default {
+  getValidPriceDecimals,
+  calculatePriceScale,
+  formatPriceToValid,
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Introduced Perps TradingView V2: faster symbol switching (no reload), user trade marks on charts, accurate price-scale/precision handling, and theme/locale/timezone support.
  * Added price-precision utilities used for price scaling and formatting.
  * Integrated the new chart into the Perp Candles view.

* Documentation
  * Added a gallery/demo page showcasing symbol switching for Perps TradingView V2.

* Tests
  * Added comprehensive tests for perps price-precision utilities.

* Chores
  * Updated permissions to support new TradingView marks and price-scale methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->