### PR TITLE
fix: cloud sync int OK-42814

### DIFF
--- a/packages/kit-bg/src/dbs/local/LocalDbBase.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.ts
@@ -1708,8 +1708,14 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
       updateItem.dataTime &&
       updateItem.dataTime >= item.dataTime;
 
+    let newDataTime = updateItem.dataTime ?? item.dataTime;
     if (isNil(updateItem.dataTime)) {
       shouldUpdate = false;
+
+      if (!item.pwdHash && updateItem.pwdHash && updateItem.data) {
+        shouldUpdate = true;
+        newDataTime = undefined;
+      }
     }
 
     if (isNil(item.dataTime)) {
@@ -1732,7 +1738,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
       // update fields
       rawData: updateItem.rawData,
       data: updateItem.data,
-      dataTime: updateItem.dataTime ?? item.dataTime,
+      dataTime: newDataTime,
       isDeleted: updateItem.isDeleted,
       localSceneUpdated: updateItem.localSceneUpdated,
       serverUploaded: updateItem.serverUploaded,

--- a/packages/kit-bg/src/services/ServiceNotification/PushProvider/PushProviderWebSocket.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/PushProvider/PushProviderWebSocket.ts
@@ -170,6 +170,13 @@ export class PushProviderWebSocket extends PushProviderBase {
     this.socket.on(
       EAppSocketEventNames.primeConfigChanged,
       async (payload: IPrimeConfigChangedInfo) => {
+        if (!payload?.pwdHash) {
+          console.error(
+            'EAppSocketEventNames.primeConfigChanged ERROR:  payload pwdHash is missing',
+            payload,
+          );
+          return;
+        }
         defaultLogger.notification.websocket.consoleLog(
           'WebSocket 收到 primeConfigChanged 消息:',
           payload,
@@ -185,7 +192,7 @@ export class PushProviderWebSocket extends PushProviderBase {
             serverItems: payload.serverData,
             shouldSyncToScene: true,
             syncCredential,
-            serverPwdHash: syncCredential?.masterPasswordUUID || '', // TODO use serverPwdHash
+            serverPwdHash: payload?.pwdHash,
           },
         );
       },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixed an edge case where cloud-synced items might not update when the server timestamp was missing.
  - Ensures updates proceed when valid credentials and data are present, even without a timestamp.

- Chores
  - Added stricter validation for incoming push notifications; missing required fields now log an error and are ignored.
  - Aligned credential handling to use the server-provided hash for better consistency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->