### PR TITLE
fix: market dex change token pay token issue OK-42690 OK-42738

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
@@ -120,6 +120,16 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
     if (filterDefaultTokens.length > 0 && !paymentToken) {
       setPaymentToken(filterDefaultTokens[0]);
     }
+    if (
+      filterDefaultTokens.length > 0 &&
+      filterDefaultTokens.every(
+        (token) =>
+          token.networkId !== paymentToken?.networkId ||
+          token.contractAddress !== paymentToken?.contractAddress,
+      )
+    ) {
+      setPaymentToken(filterDefaultTokens[0]);
+    }
   }, [paymentToken, setPaymentToken, filterDefaultTokens]);
 
   useEffect(() => {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/InfoItemLabel/InfoItemLabel.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/InfoItemLabel/InfoItemLabel.tsx
@@ -30,7 +30,7 @@ export const InfoItemLabel = ({
           />
         }
         renderContent={
-          <Stack px="$4" pb="$4">
+          <Stack px="$2.5" py="$2">
             <SizableText size="$bodyMd" color="$text">
               {questionMarkContent}
             </SizableText>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the selected payment token automatically resets to a valid default when it no longer matches available options, preventing invalid or stale selections.

* **Style**
  * Tweaked popover spacing in info labels (reduced horizontal padding, adjusted vertical padding) for a cleaner, more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->