### PR TITLE
fix: swap fontom token opt ok-42889

### DIFF
--- a/packages/shared/types/swap/SwapProvider.constants.ts
+++ b/packages/shared/types/swap/SwapProvider.constants.ts
@@ -1387,19 +1387,6 @@ export const swapPopularTokens: Record<string, ISwapToken[]> = {
       'isPopular': true,
       'networkLogoURI': 'https://uni.onekey-asset.com/static/chain/fantom.png',
     },
-    {
-      'networkId': 'evm--250',
-      'contractAddress': '0x049d68029688eabf473097a2fc38ef61633a3c7a',
-      'name': 'Frapped USDT',
-      'symbol': 'fUSDT',
-      'decimals': 6,
-      'logoURI':
-        'https://uni.onekey-asset.com/server-service-onchain/evm--250/tokens/0x049d68029688eabf473097a2fc38ef61633a3c7a.png',
-
-      'isNative': false,
-      'isPopular': true,
-      'networkLogoURI': 'https://uni.onekey-asset.com/static/chain/fantom.png',
-    },
   ],
   'tron--0x2b6653dc': [
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the swap popular tokens list for the Fantom network by removing Frapped USDT (fUSDT) from the popular tokens.
  * All other Fantom tokens remain unchanged.
  * This update only affects which tokens are highlighted in the Fantom swap token picker.
  * No changes to other networks or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->