### PR TITLE
feat: add spread percentage calculation to OrderBook components

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderBook/index.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/index.tsx
@@ -5,6 +5,7 @@ import BigNumber from 'bignumber.js';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { Icon, Select, useTheme, useThemeName } from '@onekeyhq/components';
+import { calculateSpreadPercentage } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type { IBookLevel } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
 import { DefaultLoadingNode } from './DefaultLoadingNode';
@@ -335,6 +336,18 @@ export function OrderBook({
   const textColor = useTextColor();
   const spreadColor = useSpreadColor();
 
+  // Calculate spread percentage from best bid/ask
+  const spreadPercentage = useMemo(() => {
+    const bestBid = aggregatedData.bids[0]?.price;
+    const bestAsk = aggregatedData.asks[0]?.price;
+
+    if (!bestBid || !bestAsk) {
+      return '0.000%';
+    }
+
+    return calculateSpreadPercentage(bestBid, bestAsk);
+  }, [aggregatedData.bids, aggregatedData.asks]);
+
   if (horizontal) {
     return (
       <View style={[styles.container, style]}>
@@ -609,7 +622,7 @@ export function OrderBook({
               />
             ) : null}
             <Text style={[styles.bodySm, { color: textColor.text }]}>
-              0.002%
+              {spreadPercentage}
             </Text>
           </View>
           {aggregatedData.bids.map((itemData, index) => (
@@ -701,6 +714,18 @@ export function OrderPairBook({
   );
   const textColor = useTextColor();
   const blockColors = useBlockColors();
+
+  // Calculate spread percentage from best bid/ask
+  const spreadPercentage = useMemo(() => {
+    const bestBid = aggregatedData.bids[0]?.price;
+    const bestAsk = aggregatedData.asks[0]?.price;
+
+    if (!bestBid || !bestAsk) {
+      return '0.000%';
+    }
+
+    return calculateSpreadPercentage(bestBid, bestAsk);
+  }, [aggregatedData.bids, aggregatedData.asks]);
   return (
     <View style={{ padding: 8 }}>
       <View style={styles.pairBookHeader}>
@@ -751,7 +776,7 @@ export function OrderPairBook({
               {midPrice}
             </Text>
             <Text style={[styles.bodySm, { color: textColor.textSubdued }]}>
-              0.002%
+              {spreadPercentage}
             </Text>
           </View>
           {aggregatedData.bids.map((itemData, index) => (

--- a/packages/shared/src/utils/perpsUtils.ts
+++ b/packages/shared/src/utils/perpsUtils.ts
@@ -238,6 +238,48 @@ function analyzeOrderBookPrecision(
 }
 
 /**
+ * Calculate bid-ask spread percentage
+ *
+ * Formula: ((bestAsk - bestBid) / midPrice) * 100
+ *
+ * @param bestBid - Best bid price
+ * @param bestAsk - Best ask price
+ * @returns Formatted spread percentage string (e.g., "0.025%")
+ */
+function calculateSpreadPercentage(
+  bestBid: string | number,
+  bestAsk: string | number,
+): string {
+  const bestBidBN = new BigNumber(bestBid);
+  const bestAskBN = new BigNumber(bestAsk);
+
+  if (
+    bestBidBN.isZero() ||
+    bestAskBN.isZero() ||
+    !bestBidBN.isFinite() ||
+    !bestAskBN.isFinite()
+  ) {
+    return '0.000%';
+  }
+
+  // Ensure ask >= bid to avoid negative spreads
+  if (bestAskBN.isLessThan(bestBidBN)) {
+    return '0.000%';
+  }
+
+  const spread = bestAskBN.minus(bestBidBN);
+  const midPrice = bestBidBN.plus(bestAskBN).dividedBy(2);
+
+  if (midPrice.isZero()) {
+    return '0.000%';
+  }
+
+  const spreadPercentage = spread.dividedBy(midPrice).multipliedBy(100);
+
+  return `${spreadPercentage.toFixed(3)}%`;
+}
+
+/**
  * Format value to specified decimal places using BigNumber precision
  */
 function formatWithPrecision(
@@ -258,6 +300,7 @@ export {
   formatWithPrecision,
   countDecimalPlaces,
   getMostFrequentDecimalPlaces,
+  calculateSpreadPercentage,
 };
 
 export default {
@@ -269,4 +312,5 @@ export default {
   formatWithPrecision,
   countDecimalPlaces,
   getMostFrequentDecimalPlaces,
+  calculateSpreadPercentage,
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Order Book and Pair view now display a dynamic bid-ask spread percentage calculated from current top-of-book prices.
  * Spread updates in real time, formatted to three decimals across views.
  * Graceful fallback to 0.000% when either side of the book is unavailable or invalid.
  * Replaces previously static spread value.
  * Consistent presentation in the horizontal Order Book and the Spread row within the paired view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->