### PR TITLE
fix: reload TradingView components on theme change

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
@@ -5,6 +5,7 @@ import type { IStackStyle } from '@onekeyhq/components';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IHex } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
+import { useThemeVariant } from '../../../hooks/useThemeVariant';
 import WebView from '../../WebView';
 import { useTradingViewUrl } from '../hooks';
 
@@ -97,6 +98,7 @@ export function TradingViewPerpsV2(
   const isLandscape = useOrientation();
   const isIPadPortrait = platformEnv.isNativeIOSPad && !isLandscape;
   const webRef = useRef<IWebViewRef | null>(null);
+  const theme = useThemeVariant();
 
   const { symbol, userAddress, onLoadEnd, onTradeUpdate, tradingViewUrl } =
     props;
@@ -135,6 +137,7 @@ export function TradingViewPerpsV2(
   return (
     <Stack position="relative" flex={1}>
       <WebViewMemoized
+        key={theme}
         src={staticTradingViewUrl}
         customReceiveHandler={customReceiveHandler}
         onWebViewRef={onWebViewRef}

--- a/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
@@ -4,6 +4,7 @@ import { Stack, useOrientation } from '@onekeyhq/components';
 import type { IStackStyle } from '@onekeyhq/components';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
+import { useThemeVariant } from '../../../hooks/useThemeVariant';
 import WebView from '../../WebView';
 import { useTradingViewUrl } from '../hooks';
 
@@ -41,6 +42,7 @@ export function TradingViewV2(props: ITradingViewV2Props & WebViewProps) {
   const isLandscape = useOrientation();
   const isIPadPortrait = platformEnv.isNativeIOSPad && !isLandscape;
   const webRef = useRef<IWebViewRef | null>(null);
+  const theme = useThemeVariant();
 
   const {
     mode,
@@ -93,6 +95,7 @@ export function TradingViewV2(props: ITradingViewV2Props & WebViewProps) {
   return (
     <Stack position="relative" flex={1}>
       <WebView
+        key={theme}
         customReceiveHandler={async (data) => {
           await customReceiveHandler(data as ICustomReceiveHandlerData);
         }}


### PR DESCRIPTION
Add theme variant dependency to force WebView reload when theme changes. This ensures TradingView components properly reflect the new theme.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trading charts now immediately reflect theme changes (e.g., light/dark) without requiring a manual refresh.
  * Ensures consistent theming across TradingView Perps V2 and TradingView V2 views during theme switches.
  * Resolves intermittent cases where charts displayed outdated theme styling after toggling themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->