### PR TITLE
Fix/perp UI

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
@@ -87,7 +87,6 @@ const PaginationFooter = ({
           w="$8"
           h="$7"
           textAlign="center"
-          size="small"
           borderColor="$borderStrong"
           borderRadius="$2"
           maxLength={totalPages.toString().length}
@@ -298,7 +297,7 @@ export function CommonTableListView({
             </XStack>
             <ListView
               style={{
-                height: 400,
+                maxHeight: 400,
               }}
               data={paginatedData}
               renderItem={({ item, index }) => {

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
@@ -62,40 +62,47 @@ const PaginationFooter = ({
     <XStack
       py="$3"
       px="$4"
-      gap="$3"
+      gap="$4"
       justifyContent={isMobile ? 'center' : 'flex-end'}
       alignItems="center"
       bg={headerBgColor}
     >
       <IconButton
+        borderRadius="$full"
+        borderWidth="$px"
+        borderColor="$border"
         variant="tertiary"
         size="small"
         disabled={currentPage === 1}
         onPress={onPreviousPage}
         icon="ChevronLeftOutline"
       />
-
-      <Input
-        value={inputValue}
-        onChangeText={handleInputChange}
-        onSubmitEditing={handleInputSubmit}
-        onBlur={handleInputBlur}
-        keyboardType="numeric"
-        w="$12"
-        h="$7.5"
-        textAlign="center"
-        size="small"
-        borderColor="$borderStrong"
-        borderRadius="$2"
-        maxLength={totalPages.toString().length}
-      />
-      <SizableText size="$bodyLg" color={headerTextColor}>
-        /
-      </SizableText>
-      <SizableText size="$bodyLg" color={headerTextColor}>
-        {totalPages}
-      </SizableText>
+      <XStack gap="$2" alignItems="center">
+        <Input
+          value={inputValue}
+          onChangeText={handleInputChange}
+          onSubmitEditing={handleInputSubmit}
+          onBlur={handleInputBlur}
+          keyboardType="numeric"
+          w="$8"
+          h="$7"
+          textAlign="center"
+          size="small"
+          borderColor="$borderStrong"
+          borderRadius="$2"
+          maxLength={totalPages.toString().length}
+        />
+        <SizableText size="$bodyMd" color={headerTextColor}>
+          /
+        </SizableText>
+        <SizableText size="$bodyMd" color={headerTextColor}>
+          {totalPages}
+        </SizableText>
+      </XStack>
       <IconButton
+        borderRadius="$full"
+        borderWidth="$px"
+        borderColor="$border"
         variant="tertiary"
         size="small"
         disabled={currentPage === totalPages}
@@ -291,7 +298,7 @@ export function CommonTableListView({
             </XStack>
             <ListView
               style={{
-                maxHeight: 254,
+                height: 400,
               }}
               data={paginatedData}
               renderItem={({ item, index }) => {

--- a/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
+++ b/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
@@ -69,7 +69,7 @@ export function PerpOrderBook() {
         horizontal={false}
         bids={l2Book.bids}
         asks={l2Book.asks}
-        maxLevelsPerSide={16}
+        maxLevelsPerSide={12}
         selectedTickOption={selectedTickOption}
         onTickOptionChange={handleTickOptionChange}
         tickOptions={tickOptionsData.tickOptions}

--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBar.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBar.tsx
@@ -5,6 +5,7 @@ import {
   ScrollView,
   SizableText,
   Skeleton,
+  Tooltip,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -124,11 +125,20 @@ function PerpTickerBar() {
         }}
       >
         <YStack>
-          <SizableText size="$bodySm" color="$textSubdued">
-            Oracle Price
-          </SizableText>
+          <Tooltip
+            renderTrigger={
+              <SizableText size="$bodySm" color="$textSubdued">
+                Oracle Price
+              </SizableText>
+            }
+            renderContent={
+              <SizableText size="$bodySm">Oracle Price</SizableText>
+            }
+            placement="top"
+          />
+
           {showSkeleton ? (
-            <Skeleton width={100} height={20} />
+            <Skeleton width={80} height={16} />
           ) : (
             <SizableText size="$headingXs">{formattedOraclePrice}</SizableText>
           )}
@@ -139,7 +149,7 @@ function PerpTickerBar() {
             24h Volume
           </SizableText>
           {showSkeleton ? (
-            <Skeleton width={100} height={20} />
+            <Skeleton width={80} height={16} />
           ) : (
             <SizableText size="$headingXs">
               $
@@ -151,11 +161,19 @@ function PerpTickerBar() {
         </YStack>
 
         <YStack>
-          <SizableText size="$bodySm" color="$textSubdued">
-            Open Interest
-          </SizableText>
+          <Tooltip
+            renderTrigger={
+              <SizableText size="$bodySm" color="$textSubdued">
+                Open Interest
+              </SizableText>
+            }
+            renderContent={
+              <SizableText size="$bodySm">Open Interest</SizableText>
+            }
+            placement="top"
+          />
           {showSkeleton ? (
-            <Skeleton width={100} height={20} />
+            <Skeleton width={80} height={16} />
           ) : (
             <SizableText size="$headingXs">
               $
@@ -169,14 +187,19 @@ function PerpTickerBar() {
         </YStack>
 
         <YStack>
-          <SizableText size="$bodySm" color="$textSubdued">
-            Funding / Countdown
-          </SizableText>
+          <Tooltip
+            renderTrigger={
+              <SizableText size="$bodySm" color="$textSubdued">
+                Funding / Countdown
+              </SizableText>
+            }
+            renderContent={
+              <SizableText size="$bodySm">Funding / Countdown</SizableText>
+            }
+            placement="top"
+          />
           {showSkeleton ? (
-            <XStack alignItems="center" gap="$2">
-              <Skeleton width={80} height={20} />
-              <Skeleton width={40} height={20} />
-            </XStack>
+            <Skeleton width={120} height={16} />
           ) : (
             <XStack alignItems="center" gap="$2">
               <SizableText

--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBar.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBar.tsx
@@ -67,6 +67,7 @@ function PerpTickerBar() {
     openInterest,
     volume24h,
     change24hPercent,
+    coin,
   } = priceData;
 
   const formattedMarkPrice = markPrice;
@@ -157,7 +158,12 @@ function PerpTickerBar() {
             <Skeleton width={100} height={20} />
           ) : (
             <SizableText size="$headingXs">
-              ${formatDisplayNumber(NUMBER_FORMATTER.marketCap(openInterest))}
+              $
+              {formatDisplayNumber(
+                NUMBER_FORMATTER.marketCap(
+                  (Number(openInterest) * Number(markPrice)).toString(),
+                ),
+              )}
             </SizableText>
           )}
         </YStack>

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -13,6 +13,7 @@ import {
   usePopoverContext,
 } from '@onekeyhq/components';
 import { Token } from '@onekeyhq/kit/src/components/Token';
+import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
 import { useCurrentTokenAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 
 import { usePerpTokenSelector } from '../../hooks';
@@ -76,7 +77,7 @@ function BasePerpTokenSelectorContent({
               Last Price
             </SizableText>
           </XStack>
-          <XStack width={140} justifyContent="flex-start">
+          <XStack width={120} justifyContent="flex-start">
             <SizableText size="$bodySm" color="$textSubdued">
               24h Change
             </SizableText>
@@ -138,6 +139,7 @@ function PerpTokenSelectorContent({
 const PerpTokenSelectorContentMemo = memo(PerpTokenSelectorContent);
 
 function BasePerpTokenSelector() {
+  const themeVariant = useThemeVariant();
   const [isOpen, setIsOpen] = useState(false);
   const [currentToken] = useCurrentTokenAtom();
   const [isLoading, setIsLoading] = useState(false);
@@ -146,7 +148,7 @@ function BasePerpTokenSelector() {
       <Popover
         title="Select Token"
         floatingPanelProps={{
-          width: 700,
+          width: 680,
         }}
         open={isOpen}
         onOpenChange={setIsOpen}
@@ -170,7 +172,7 @@ function BasePerpTokenSelector() {
             <Token
               size="md"
               borderRadius="$full"
-              bg="$bgInverse"
+              bg={themeVariant === 'light' ? null : '$bgInverse'}
               tokenImageUri={`https://app.hyperliquid.xyz/coins/${currentToken}.svg`}
               fallbackIcon="CryptoCoinOutline"
             />
@@ -189,7 +191,7 @@ function BasePerpTokenSelector() {
         )}
       />
     ),
-    [isOpen, currentToken, isLoading],
+    [isOpen, currentToken, isLoading, themeVariant],
   );
 }
 

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -48,17 +48,56 @@ function BasePerpTokenSelectorContent({
 
   return (
     <YStack>
-      <XStack px="$5" pt="$5">
-        <SearchBar
-          containerProps={{
-            borderRadius: '$2',
-          }}
-          autoFocus
-          placeholder="Search"
-          value={searchQuery}
-          onChangeText={setSearchQuery}
-        />
-      </XStack>
+      <YStack gap="$2">
+        <XStack px="$5" pt="$5">
+          <SearchBar
+            containerProps={{
+              borderRadius: '$2',
+            }}
+            autoFocus
+            placeholder="Search"
+            value={searchQuery}
+            onChangeText={setSearchQuery}
+          />
+        </XStack>
+        <XStack
+          px="$5"
+          py="$3"
+          borderBottomWidth="$px"
+          borderBottomColor="$borderSubdued"
+        >
+          <XStack width={140} justifyContent="flex-start">
+            <SizableText size="$bodySm" color="$textSubdued">
+              Asset
+            </SizableText>
+          </XStack>
+          <XStack width={80} justifyContent="flex-start">
+            <SizableText size="$bodySm" color="$textSubdued">
+              Last Price
+            </SizableText>
+          </XStack>
+          <XStack width={140} justifyContent="flex-start">
+            <SizableText size="$bodySm" color="$textSubdued">
+              24h Change
+            </SizableText>
+          </XStack>
+          <XStack width={100} justifyContent="flex-start">
+            <SizableText size="$bodySm" color="$textSubdued">
+              8h Funding
+            </SizableText>
+          </XStack>
+          <XStack width={100} justifyContent="flex-start">
+            <SizableText size="$bodySm" color="$textSubdued">
+              24h Volume
+            </SizableText>
+          </XStack>
+          <XStack flex={1} justifyContent="flex-end">
+            <SizableText size="$bodySm" color="$textSubdued">
+              Open Interest
+            </SizableText>
+          </XStack>
+        </XStack>
+      </YStack>
 
       {/* Token List */}
       <YStack flex={1} maxHeight={300}>
@@ -71,45 +110,6 @@ function BasePerpTokenSelectorContent({
               onPress={() => handleSelectToken(token.name)}
             />
           )}
-          ListHeaderComponent={
-            <XStack
-              px="$5"
-              py="$3"
-              borderBottomWidth="$px"
-              borderBottomColor="$borderSubdued"
-            >
-              <XStack width={140} justifyContent="flex-start">
-                <SizableText size="$bodySm" color="$textSubdued">
-                  Asset
-                </SizableText>
-              </XStack>
-              <XStack width={80} justifyContent="flex-start">
-                <SizableText size="$bodySm" color="$textSubdued">
-                  Last Price
-                </SizableText>
-              </XStack>
-              <XStack width={120} justifyContent="flex-start">
-                <SizableText size="$bodySm" color="$textSubdued">
-                  24h Change
-                </SizableText>
-              </XStack>
-              <XStack width={100} justifyContent="flex-start">
-                <SizableText size="$bodySm" color="$textSubdued">
-                  8h Funding
-                </SizableText>
-              </XStack>
-              <XStack width={100} justifyContent="flex-start">
-                <SizableText size="$bodySm" color="$textSubdued">
-                  24h Volume
-                </SizableText>
-              </XStack>
-              <XStack flex={1} justifyContent="flex-end">
-                <SizableText size="$bodySm" color="$textSubdued">
-                  Open Interest
-                </SizableText>
-              </XStack>
-            </XStack>
-          }
           ListEmptyComponent={
             <XStack p="$5" justifyContent="center">
               <SizableText size="$bodySm" color="$textSubdued">
@@ -169,6 +169,8 @@ function BasePerpTokenSelector() {
           >
             <Token
               size="md"
+              borderRadius="$full"
+              bg="$bgInverse"
               tokenImageUri={`https://app.hyperliquid.xyz/coins/${currentToken}.svg`}
               fallbackIcon="CryptoCoinOutline"
             />

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
@@ -57,7 +57,7 @@ const PerpTokenSelectorRow = memo(
             <Token
               size="xs"
               borderRadius="$full"
-              bg={themeVariant === 'light' ? null : '$bgInverse'}
+              bg={themeVariant === 'light' ? undefined : '$bgInverse'}
               tokenImageUri={`https://app.hyperliquid.xyz/coins/${token.name}.svg`}
               fallbackIcon="CryptoCoinOutline"
             />

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
@@ -7,6 +7,7 @@ import {
   XStack,
 } from '@onekeyhq/components';
 import { Token } from '@onekeyhq/kit/src/components/Token';
+import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
 import {
   NUMBER_FORMATTER,
   formatDisplayNumber,
@@ -29,6 +30,7 @@ interface IPerpTokenSelectorRowProps {
 
 const PerpTokenSelectorRow = memo(
   ({ token, onPress }: IPerpTokenSelectorRowProps) => {
+    const themeVariant = useThemeVariant();
     if (token.isDelisted) {
       return null;
     }
@@ -55,7 +57,7 @@ const PerpTokenSelectorRow = memo(
             <Token
               size="xs"
               borderRadius="$full"
-              bg="$bgInverse"
+              bg={themeVariant === 'light' ? null : '$bgInverse'}
               tokenImageUri={`https://app.hyperliquid.xyz/coins/${token.name}.svg`}
               fallbackIcon="CryptoCoinOutline"
             />
@@ -77,7 +79,7 @@ const PerpTokenSelectorRow = memo(
             </NumberSizeableText>
           </XStack>
 
-          <XStack width={140} justifyContent="flex-start">
+          <XStack width={120} justifyContent="flex-start">
             <SizableText
               size="$bodySm"
               color={token.change24hPercent > 0 ? '$green11' : '$red11'}

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
@@ -42,6 +42,7 @@ const PerpTokenSelectorRow = memo(
         px="$5"
         py="$3"
         cursor="pointer"
+        flex={1}
       >
         <XStack flex={1} alignItems="center">
           {/* Token Info */}
@@ -53,6 +54,8 @@ const PerpTokenSelectorRow = memo(
           >
             <Token
               size="xs"
+              borderRadius="$full"
+              bg="$bgInverse"
               tokenImageUri={`https://app.hyperliquid.xyz/coins/${token.name}.svg`}
               fallbackIcon="CryptoCoinOutline"
             />
@@ -74,7 +77,7 @@ const PerpTokenSelectorRow = memo(
             </NumberSizeableText>
           </XStack>
 
-          <XStack width={120} justifyContent="flex-start">
+          <XStack width={140} justifyContent="flex-start">
             <SizableText
               size="$bodySm"
               color={token.change24hPercent > 0 ? '$green11' : '$red11'}
@@ -108,7 +111,11 @@ const PerpTokenSelectorRow = memo(
             <SizableText size="$bodySm" color="$text">
               $
               {formatDisplayNumber(
-                NUMBER_FORMATTER.marketCap(token.openInterest),
+                NUMBER_FORMATTER.marketCap(
+                  (
+                    Number(token.openInterest) * Number(token.markPrice)
+                  ).toString(),
+                ),
               )}
             </SizableText>
           </XStack>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added tooltips to Oracle Price, Open Interest, and Funding/Countdown labels.

- Style
  - Refreshed pagination visuals: compact layout, borders, spacing, and smaller page input; increased desktop list height.
  - Themed, fully rounded token avatars; popover width reduced to 680.
  - Tuned skeleton placeholder sizes for better consistency.

- Refactor
  - Token selector now uses a dedicated header with clearer column labels above the list.

- Chores
  - Open Interest now shows notional value (open interest × mark price).
  - Order book depth per side reduced from 16 to 12.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->