### PR TITLE
fix: bulk revoke & aggregate token issues OK-42987 OK-43084 OK-43087 OK-43097 OK-43112

### DIFF
--- a/packages/kit/src/components/ApprovalListView/ApprovalListHeader.tsx
+++ b/packages/kit/src/components/ApprovalListView/ApprovalListHeader.tsx
@@ -31,8 +31,10 @@ function HeaderItem({ label }: { label: string }) {
 
 function ApprovalListHeader({
   recomputeLayout,
+  hideRiskOverview,
 }: {
   recomputeLayout: () => void;
+  hideRiskOverview?: boolean;
 }) {
   const intl = useIntl();
 
@@ -155,6 +157,10 @@ function ApprovalListHeader({
   }, [accountId, networkId, recomputeLayout]);
 
   const renderRiskOverview = useCallback(() => {
+    if (hideRiskOverview) {
+      return null;
+    }
+
     if (
       riskApprovals.length === 0 &&
       (warningApprovals.length === 0 || !showInactiveApprovalsAlert)
@@ -236,6 +242,7 @@ function ApprovalListHeader({
   }, [
     handleCloseInactiveApprovalsAlert,
     handleViewRiskApprovals,
+    hideRiskOverview,
     inactiveApprovalsAlertOpacity,
     intl,
     riskApprovals,

--- a/packages/kit/src/components/ApprovalListView/index.tsx
+++ b/packages/kit/src/components/ApprovalListView/index.tsx
@@ -45,6 +45,7 @@ type IProps = {
   selectDisabled?: boolean;
   searchDisabled?: boolean;
   filterByNetworkDisabled?: boolean;
+  hideRiskOverview?: boolean;
 };
 
 function ApprovalListViewCmp(props: IProps) {
@@ -57,6 +58,7 @@ function ApprovalListViewCmp(props: IProps) {
     withHeader,
     searchDisabled,
     filterByNetworkDisabled,
+    hideRiskOverview,
   } = props;
   const intl = useIntl();
   const [{ approvals }] = useApprovalListAtom();
@@ -193,7 +195,10 @@ function ApprovalListViewCmp(props: IProps) {
       ListEmptyComponent={EmptyComponentElement}
       ListHeaderComponent={
         withHeader && !showSkeleton ? (
-          <ApprovalListHeader recomputeLayout={recomputeLayout} />
+          <ApprovalListHeader
+            recomputeLayout={recomputeLayout}
+            hideRiskOverview={hideRiskOverview}
+          />
         ) : null
       }
       renderItem={({ item }) => (

--- a/packages/kit/src/views/ApprovalManagement/pages/ApprovalDetails.tsx
+++ b/packages/kit/src/views/ApprovalManagement/pages/ApprovalDetails.tsx
@@ -15,6 +15,7 @@ import {
   Page,
   SizableText,
   Stack,
+  Toast,
   XStack,
   YStack,
   useClipboard,
@@ -23,6 +24,7 @@ import type { IApproveInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IModalApprovalManagementParamList } from '@onekeyhq/shared/src/routes/approvalManagement';
 import { EModalApprovalManagementRoutes } from '@onekeyhq/shared/src/routes/approvalManagement';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import approvalUtils from '@onekeyhq/shared/src/utils/approvalUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import type { IToken } from '@onekeyhq/shared/types/token';
@@ -199,6 +201,19 @@ function ApprovalDetails() {
     async ({ tokenInfo }: { tokenInfo: IToken }) => {
       if (!isMountedRef.current) return;
 
+      if (
+        accountUtils.isWatchingAccount({
+          accountId: approval.accountId,
+        })
+      ) {
+        Toast.error({
+          title: intl.formatMessage({
+            id: ETranslations.wallet_approval_revocation_not_available_for_watch_only_wallets,
+          }),
+        });
+        return;
+      }
+
       setIsBuildingRevokeTxs(true);
       setSelectedTokens({
         [approvalUtils.buildSelectedTokenKey({
@@ -250,6 +265,7 @@ function ApprovalDetails() {
       approval.contractAddress,
       approval.networkId,
       approval.owner,
+      intl,
       navigation,
       setIsBuildingRevokeTxs,
       setSelectedTokens,
@@ -430,6 +446,18 @@ function ApprovalDetails() {
                 variant="tertiary"
                 size="small"
                 onPress={() => {
+                  if (
+                    accountUtils.isWatchingAccount({
+                      accountId: approval.accountId,
+                    })
+                  ) {
+                    Toast.error({
+                      title: intl.formatMessage({
+                        id: ETranslations.wallet_approval_revocation_not_available_for_watch_only_wallets,
+                      }),
+                    });
+                    return;
+                  }
                   setIsBulkRevokeMode((v) => !v);
                 }}
               >

--- a/packages/kit/src/views/AssetList/hooks/useTokenManagement.ts
+++ b/packages/kit/src/views/AssetList/hooks/useTokenManagement.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import { flatten } from 'lodash';
+import { flatten, uniqBy } from 'lodash';
 import { useIntl } from 'react-intl';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
@@ -97,6 +97,7 @@ export function useTokenManagement({
             backgroundApiProxy.serviceCustomToken.getCustomTokens({
               accountId: item.accountId,
               networkId: item.networkId,
+              accountXpubOrAddress: item.accountXpubOrAddress,
             }),
           ),
         ),
@@ -111,16 +112,8 @@ export function useTokenManagement({
           }),
         ),
       );
-      const uniqueTokens = allTokens.filter(
-        (token, index, self) =>
-          index ===
-          self.findIndex(
-            (t) =>
-              t.networkId === token.networkId &&
-              t.accountId === token.accountId &&
-              t.address === token.address,
-          ),
-      );
+      const uniqueTokens = uniqBy(allTokens, (token) => token.$key);
+
       const addedTokens = uniqueTokens
         .map((token) => {
           const aggregateTokenConfigKey =

--- a/packages/kit/src/views/AssetSelector/pages/AggregateTokenSelector.tsx
+++ b/packages/kit/src/views/AssetSelector/pages/AggregateTokenSelector.tsx
@@ -230,9 +230,11 @@ function AggregateTokenSelector() {
   const handleOnPressToken = useCallback(
     async (token: IAccountToken) => {
       void onSelect(token);
-      navigation.pop();
+      if (closeAfterSelect) {
+        navigation.pop();
+      }
     },
-    [onSelect, navigation],
+    [onSelect, navigation, closeAfterSelect],
   );
 
   const sortedAggregateTokens = useMemo(() => {

--- a/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
+++ b/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
@@ -105,7 +105,6 @@ function TokenSelector() {
               indexedAccountId,
               aggregateToken: token,
               onSelect,
-              closeAfterSelect,
               allAggregateTokenList,
             },
           );

--- a/packages/kit/src/views/Home/pages/ApprovalListContainer.tsx
+++ b/packages/kit/src/views/Home/pages/ApprovalListContainer.tsx
@@ -13,6 +13,7 @@ import {
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalApprovalManagementRoutes } from '@onekeyhq/shared/src/routes/approvalManagement';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { EHomeTab } from '@onekeyhq/shared/types';
 import type { IContractApproval } from '@onekeyhq/shared/types/approval';
 
@@ -24,7 +25,6 @@ import { useActiveAccount } from '../../../states/jotai/contexts/accountSelector
 import { useApprovalListActions } from '../../../states/jotai/contexts/approvalList';
 import { HomeApprovalListProviderMirror } from '../components/HomeApprovalListProvider/HomeApprovalListProviderMirror';
 import { onHomePageRefresh } from '../components/PullToRefresh';
-import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 
 function ApprovalListContainer() {
   const {

--- a/packages/kit/src/views/Home/pages/ApprovalListContainer.tsx
+++ b/packages/kit/src/views/Home/pages/ApprovalListContainer.tsx
@@ -24,6 +24,7 @@ import { useActiveAccount } from '../../../states/jotai/contexts/accountSelector
 import { useApprovalListActions } from '../../../states/jotai/contexts/approvalList';
 import { HomeApprovalListProviderMirror } from '../components/HomeApprovalListProvider/HomeApprovalListProviderMirror';
 import { onHomePageRefresh } from '../components/PullToRefresh';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 
 function ApprovalListContainer() {
   const {
@@ -159,6 +160,7 @@ function ApprovalListContainer() {
       searchDisabled
       selectDisabled
       filterByNetworkDisabled
+      hideRiskOverview={accountUtils.isWatchingWallet({ walletId: wallet?.id })}
       onRefresh={onHomePageRefresh}
       onPress={handleApprovalOnPress}
       listViewStyleProps={{

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -47,6 +47,7 @@ import { TabHeaderSettings } from './TabHeaderSettings';
 import { TokenListContainerWithProvider } from './TokenListContainer';
 import { TxHistoryListContainerWithProvider } from './TxHistoryContainer';
 import WalletContentWithAuth from './WalletContentWithAuth';
+import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 
 const networksSupportBulkRevokeApproval =
   getNetworksSupportBulkRevokeApproval();
@@ -170,10 +171,27 @@ export function HomePageView({
     vaultSettings?.NFTEnabled &&
     getEnabledNFTNetworkIds().includes(network?.id ?? '');
 
-  const isBulkRevokeApprovalEnabled =
-    (network?.isAllNetworks ||
-      networksSupportBulkRevokeApproval[network?.id ?? '']) ??
-    false;
+  const isBulkRevokeApprovalEnabled = useMemo(() => {
+    if (network?.isAllNetworks) {
+      if (
+        accountUtils.isOthersAccount({
+          accountId: account?.id ?? '',
+        })
+      ) {
+        return networkUtils.isEvmNetwork({
+          networkId: account?.createAtNetwork ?? '',
+        });
+      }
+      return true;
+    }
+
+    return networksSupportBulkRevokeApproval[network?.id ?? ''] ?? false;
+  }, [
+    network?.isAllNetworks,
+    network?.id,
+    account?.id,
+    account?.createAtNetwork,
+  ]);
 
   const isRequiredValidation = vaultSettings?.validationRequired;
   const softwareAccountDisabled = vaultSettings?.softwareAccountDisabled;

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -24,6 +24,7 @@ import { EModalRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalApprovalManagementRoutes } from '@onekeyhq/shared/src/routes/approvalManagement';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import approvalUtils from '@onekeyhq/shared/src/utils/approvalUtils';
+import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import type { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import { EContractApprovalAlertType } from '@onekeyhq/shared/types/approval';
@@ -47,7 +48,6 @@ import { TabHeaderSettings } from './TabHeaderSettings';
 import { TokenListContainerWithProvider } from './TokenListContainer';
 import { TxHistoryListContainerWithProvider } from './TxHistoryContainer';
 import WalletContentWithAuth from './WalletContentWithAuth';
-import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 
 const networksSupportBulkRevokeApproval =
   getNetworksSupportBulkRevokeApproval();

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -122,6 +122,7 @@ export function HomePageView({
         });
 
       if (
+        !accountUtils.isWatchingWallet({ walletId: wallet?.id }) &&
         approvalUtils.checkIsExistRiskApprovals({
           contractApprovals: resp.contractApprovals,
         })
@@ -160,6 +161,7 @@ export function HomePageView({
     navigation,
     account,
     updateApprovalsInfo,
+    wallet?.id,
   ]);
 
   const { vaultSettings, networkAccounts } = result.result ?? {};

--- a/packages/shared/src/locale/enum/translations.ts
+++ b/packages/shared/src/locale/enum/translations.ts
@@ -3302,6 +3302,8 @@
   wallet_approval_risky_detected_suggestion_description = 'wallet.approval_risky_detected_suggestion_description',
   wallet_approval_risky_suggestion_title = 'wallet.approval_risky_suggestion_title',
   wallet_approval_select_tokens = 'wallet.approval_select_tokens',
+  wallet_approval_summary_suggestion_desc_all = 'wallet.approval_summary_suggestion_desc_all',
+  wallet_approval_summary_suggestion_title = 'wallet.approval_summary_suggestion_title',
   wallet_backup_prompt = 'wallet.backup_prompt',
   wallet_buy_crypto_instruction = 'wallet.buy_crypto_instruction',
   wallet_collapsed_assets = 'wallet.collapsed_assets',

--- a/packages/shared/src/locale/json/bn.json
+++ b/packages/shared/src/locale/json/bn.json
@@ -3297,6 +3297,8 @@
   "wallet.approval_risky_detected_suggestion_description": "সম্ভাব্য সম্পদ ক্ষতি এড়াতে সেগুলি প্রত্যাহার করুন।",
   "wallet.approval_risky_suggestion_title": "{number} ঝুঁকিপূর্ণ অনুমোদন সনাক্ত করা হয়েছে",
   "wallet.approval_select_tokens": "টোকেন নির্বাচন করুন",
+  "wallet.approval_summary_suggestion_desc_all": "ঝুঁকিপূর্ণ {riskyNumber} · ৯০+ দিন ধরে নিষ্ক্রিয় {inactiveNumber} — ঝুঁকি কমাতে ও অপ্রয়োজনীয় অনুমতি পরিষ্কার করতে এটি প্রত্যাহার করার পরামর্শ দেওয়া হচ্ছে।",
+  "wallet.approval_summary_suggestion_title": "পর্যালোচনার জন্য {total}টি অনুমোদন রয়েছে",
   "wallet.backup_prompt": "আপনার ওয়ালেট ব্যাকআপ করুন",
   "wallet.buy_crypto_instruction": "আপনার ওয়ালেট তৈরি করতে ক্রিপ্টো কিনুন",
   "wallet.collapsed_assets": "লুকানো সম্পদ",

--- a/packages/shared/src/locale/json/de.json
+++ b/packages/shared/src/locale/json/de.json
@@ -3297,6 +3297,8 @@
   "wallet.approval_risky_detected_suggestion_description": "Widerrufen Sie sie, um potenzielle Vermögensverluste zu vermeiden.",
   "wallet.approval_risky_suggestion_title": "{number} riskante Genehmigungen erkannt",
   "wallet.approval_select_tokens": "Token auswählen",
+  "wallet.approval_summary_suggestion_desc_all": "Riskant {riskyNumber} · Seit über 90 Tagen inaktiv {inactiveNumber} — Wir empfehlen, die Berechtigung zu widerrufen, um Risiken zu verringern und unnötige Genehmigungen zu entfernen.",
+  "wallet.approval_summary_suggestion_title": "{total} Genehmigungen zu überprüfen",
   "wallet.backup_prompt": "Sichern Sie Ihre Wallet",
   "wallet.buy_crypto_instruction": "Kaufen Sie Krypto, um Ihre Geldbörse aufzuladen",
   "wallet.collapsed_assets": "Minimierte Assets",

--- a/packages/shared/src/locale/json/en_US.json
+++ b/packages/shared/src/locale/json/en_US.json
@@ -3297,6 +3297,8 @@
   "wallet.approval_risky_detected_suggestion_description": "Revoke them to avoid potential asset loss.",
   "wallet.approval_risky_suggestion_title": "{number} risky approvals detected",
   "wallet.approval_select_tokens": "Select tokens",
+  "wallet.approval_summary_suggestion_desc_all": "Risky approval(s) {riskyNumber} · Inactive for 90+ days {inactiveNumber} — We recommend revoking to reduce risk and clean up unnecessary permissions.",
+  "wallet.approval_summary_suggestion_title": "{total} approvals to review",
   "wallet.backup_prompt": "Backup your wallet",
   "wallet.buy_crypto_instruction": "Buy crypto to fund your wallet",
   "wallet.collapsed_assets": "Collapsed assets",

--- a/packages/shared/src/locale/json/es.json
+++ b/packages/shared/src/locale/json/es.json
@@ -3297,6 +3297,8 @@
   "wallet.approval_risky_detected_suggestion_description": "Revóquelas para evitar una posible pérdida de activos.",
   "wallet.approval_risky_suggestion_title": "Detectadas {number} aprobaciones de riesgo",
   "wallet.approval_select_tokens": "Seleccionar token",
+  "wallet.approval_summary_suggestion_desc_all": "Riesgo {riskyNumber} · Inactivo durante más de 90 días {inactiveNumber} — Recomendamos revocar para reducir el riesgo y limpiar los permisos innecesarios.",
+  "wallet.approval_summary_suggestion_title": "{total} aprobaciones para revisar",
   "wallet.backup_prompt": "Haz una copia de seguridad de tu cartera",
   "wallet.buy_crypto_instruction": "Compra cripto para financiar tu billetera",
   "wallet.collapsed_assets": "Activos ocultos",

--- a/packages/shared/src/locale/json/fr_FR.json
+++ b/packages/shared/src/locale/json/fr_FR.json
@@ -3297,6 +3297,8 @@
   "wallet.approval_risky_detected_suggestion_description": "Révoquez-les pour éviter toute perte d'actifs potentielle.",
   "wallet.approval_risky_suggestion_title": "{number} approbations à risque détectées",
   "wallet.approval_select_tokens": "Sélectionner le jeton",
+  "wallet.approval_summary_suggestion_desc_all": "Risqué {riskyNumber} · Inactif depuis plus de 90 jours {inactiveNumber} — Nous recommandons la révocation pour réduire les risques et supprimer les autorisations inutiles.",
+  "wallet.approval_summary_suggestion_title": "{total} approbations à examiner",
   "wallet.backup_prompt": "Sauvegardez votre portefeuille",
   "wallet.buy_crypto_instruction": "Achetez des crypto-monnaies pour alimenter votre portefeuille",
   "wallet.collapsed_assets": "Actifs masqués",

--- a/packages/shared/src/locale/json/hi_IN.json
+++ b/packages/shared/src/locale/json/hi_IN.json
@@ -3297,6 +3297,8 @@
   "wallet.approval_risky_detected_suggestion_description": "संभावित संपत्ति हानि से बचने के लिए उन्हें रद्द करें।",
   "wallet.approval_risky_suggestion_title": "{number} जोखिम भरे अनुमोदन का पता चला",
   "wallet.approval_select_tokens": "टोकन चुनें",
+  "wallet.approval_summary_suggestion_desc_all": "जोखिमपूर्ण {riskyNumber} · 90+ दिनों से निष्क्रिय {inactiveNumber} — हमारा सुझाव है कि आप जोखिम कम करने और अनावश्यक अनुमतियों को हटाने के लिए इसे रद्द कर दें।",
+  "wallet.approval_summary_suggestion_title": "समीक्षा के लिए {total} अनुमोदन",
   "wallet.backup_prompt": "अपने वॉलेट का बैकअप लें",
   "wallet.buy_crypto_instruction": "अपने वॉलेट को फंड करने के लिए क्रिप्टो खरीदें",
   "wallet.collapsed_assets": "छुपी संपत्तियां",

--- a/packages/shared/src/locale/json/id.json
+++ b/packages/shared/src/locale/json/id.json
@@ -3297,6 +3297,8 @@
   "wallet.approval_risky_detected_suggestion_description": "Cabut otorisasi untuk menghindari potensi kerugian aset.",
   "wallet.approval_risky_suggestion_title": "{number} persetujuan berisiko terdeteksi",
   "wallet.approval_select_tokens": "Pilih token",
+  "wallet.approval_summary_suggestion_desc_all": "Berisiko {riskyNumber} · Tidak aktif selama 90+ hari {inactiveNumber} — Sebaiknya cabut izin untuk mengurangi risiko dan membersihkan izin yang tidak perlu.",
+  "wallet.approval_summary_suggestion_title": "{total} persetujuan untuk ditinjau",
   "wallet.backup_prompt": "Cadangkan dompet Anda",
   "wallet.buy_crypto_instruction": "Beli kripto untuk mengisi dompet Anda",
   "wallet.collapsed_assets": "Aset tersembunyi",

--- a/packages/shared/src/locale/json/it_IT.json
+++ b/packages/shared/src/locale/json/it_IT.json
@@ -3297,6 +3297,8 @@
   "wallet.approval_risky_detected_suggestion_description": "Revocale per evitare potenziali perdite di asset.",
   "wallet.approval_risky_suggestion_title": "Rilevate {number} approvazioni rischiose",
   "wallet.approval_select_tokens": "Seleziona token",
+  "wallet.approval_summary_suggestion_desc_all": "Rischioso {riskyNumber} · Inattivo da oltre 90 giorni {inactiveNumber} — Si consiglia di revocarlo per ridurre i rischi e rimuovere le autorizzazioni non necessarie.",
+  "wallet.approval_summary_suggestion_title": "{total} approvazioni da rivedere",
   "wallet.backup_prompt": "Esegui il backup del tuo portafoglio",
   "wallet.buy_crypto_instruction": "Acquista criptovalute per finanziare il tuo portafoglio",
   "wallet.collapsed_assets": "Asset nascosti",

--- a/packages/shared/src/locale/json/ja_JP.json
+++ b/packages/shared/src/locale/json/ja_JP.json
@@ -3297,6 +3297,8 @@
   "wallet.approval_risky_detected_suggestion_description": "潜在的な資産損失を避けるために、これらをすぐに取り消してください。",
   "wallet.approval_risky_suggestion_title": "{number} 件の危険な承認が検出されました",
   "wallet.approval_select_tokens": "トークンを選択",
+  "wallet.approval_summary_suggestion_desc_all": "危険 {riskyNumber}・90日以上未使用 {inactiveNumber} — リスクを減らし、不要な権限を整理するために、取り消しをお勧めします。",
+  "wallet.approval_summary_suggestion_title": "{total} 件の承認を確認する",
   "wallet.backup_prompt": "ウォレットをバックアップする",
   "wallet.buy_crypto_instruction": "ウォレットに資金を供給するために暗号通貨を購入する",
   "wallet.collapsed_assets": "非表示の資産",

--- a/packages/shared/src/locale/json/ko_KR.json
+++ b/packages/shared/src/locale/json/ko_KR.json
@@ -3297,6 +3297,8 @@
   "wallet.approval_risky_detected_suggestion_description": "잠재적인 자산 손실을 방지하려면 해당 승인을 철회하세요.",
   "wallet.approval_risky_suggestion_title": "{number}개의 위험한 승인이 감지되었습니다",
   "wallet.approval_select_tokens": "토큰 선택",
+  "wallet.approval_summary_suggestion_desc_all": "위험 {riskyNumber} · 90일 이상 비활성 {inactiveNumber} — 리스크를 줄이고 불필요한 권한을 정리하기 위해 권한을 철회하는 것을 권장합니다।",
+  "wallet.approval_summary_suggestion_title": "검토할 승인 {total}건",
   "wallet.backup_prompt": "지갑을 백업하세요",
   "wallet.buy_crypto_instruction": "지갑에 자금을 충전하기 위해 암호화폐를 구매하세요",
   "wallet.collapsed_assets": "숨겨진 자산",

--- a/packages/shared/src/locale/json/pt.json
+++ b/packages/shared/src/locale/json/pt.json
@@ -3297,6 +3297,8 @@
   "wallet.approval_risky_detected_suggestion_description": "Revogue-as para evitar uma potencial perda de ativos.",
   "wallet.approval_risky_suggestion_title": "{number} aprovações de risco detetadas",
   "wallet.approval_select_tokens": "Selecionar token",
+  "wallet.approval_summary_suggestion_desc_all": "Arriscado {riskyNumber} · Inativo há mais de 90 dias {inactiveNumber} — Recomendamos revogar para reduzir o risco e limpar as permissões desnecessárias.",
+  "wallet.approval_summary_suggestion_title": "{total} aprovações a rever",
   "wallet.backup_prompt": "Faça backup da sua carteira",
   "wallet.buy_crypto_instruction": "Compre criptomoedas para financiar sua carteira",
   "wallet.collapsed_assets": "Ativos ocultos",

--- a/packages/shared/src/locale/json/pt_BR.json
+++ b/packages/shared/src/locale/json/pt_BR.json
@@ -3297,6 +3297,8 @@
   "wallet.approval_risky_detected_suggestion_description": "Revogue-as para evitar uma potencial perda de ativos.",
   "wallet.approval_risky_suggestion_title": "{number} aprovações de risco detectadas",
   "wallet.approval_select_tokens": "Selecionar token",
+  "wallet.approval_summary_suggestion_desc_all": "Risco {riskyNumber} · Inativo há mais de 90 dias {inactiveNumber} — Recomendamos revogar para reduzir o risco e limpar as permissões desnecessárias.",
+  "wallet.approval_summary_suggestion_title": "{total} aprovações a serem revisadas",
   "wallet.backup_prompt": "Faça backup da sua carteira",
   "wallet.buy_crypto_instruction": "Compre criptomoedas para financiar sua carteira",
   "wallet.collapsed_assets": "Ativos ocultos",

--- a/packages/shared/src/locale/json/ru.json
+++ b/packages/shared/src/locale/json/ru.json
@@ -3297,6 +3297,8 @@
   "wallet.approval_risky_detected_suggestion_description": "Отзовите их, чтобы избежать возможной потери активов.",
   "wallet.approval_risky_suggestion_title": "Обнаружено {number} рискованных разрешений",
   "wallet.approval_select_tokens": "Выберите токен",
+  "wallet.approval_summary_suggestion_desc_all": "Риск {riskyNumber} · Неактивно более 90 дней {inactiveNumber} — Рекомендуем отозвать, чтобы снизить риск и удалить ненужные разрешения.",
+  "wallet.approval_summary_suggestion_title": "{total} разрешений для проверки",
   "wallet.backup_prompt": "Создайте резервную копию вашего кошелька",
   "wallet.buy_crypto_instruction": "Купите криптовалюту для пополнения вашего кошелька",
   "wallet.collapsed_assets": "Скрытые активы",

--- a/packages/shared/src/locale/json/th_TH.json
+++ b/packages/shared/src/locale/json/th_TH.json
@@ -3297,6 +3297,8 @@
   "wallet.approval_risky_detected_suggestion_description": "เพิกถอนเพื่อหลีกเลี่ยงการสูญเสียทรัพย์สินที่อาจเกิดขึ้น",
   "wallet.approval_risky_suggestion_title": "ตรวจพบการอนุมัติที่มีความเสี่ยง {number} รายการ",
   "wallet.approval_select_tokens": "เลือกโทเคน",
+  "wallet.approval_summary_suggestion_desc_all": "เสี่ยง {riskyNumber} · ไม่ได้ใช้งานนานกว่า 90 วัน {inactiveNumber} — ขอแนะนำให้เพิกถอนเพื่อลดความเสี่ยงและล้างสิทธิ์ที่ไม่จำเป็นออก",
+  "wallet.approval_summary_suggestion_title": "มี {total} การอนุมัติที่ต้องตรวจสอบ",
   "wallet.backup_prompt": "สำรองข้อมูลกระเป๋าเงินของคุณ",
   "wallet.buy_crypto_instruction": "ซื้อคริปโตเพื่อเติมเงินในกระเป๋าเงินของคุณ",
   "wallet.collapsed_assets": "สินทรัพย์ที่ซ่อนไว้",

--- a/packages/shared/src/locale/json/uk_UA.json
+++ b/packages/shared/src/locale/json/uk_UA.json
@@ -3297,6 +3297,8 @@
   "wallet.approval_risky_detected_suggestion_description": "Скасуйте їх, щоб уникнути потенційної втрати активів.",
   "wallet.approval_risky_suggestion_title": "Виявлено {number} ризикованих дозволів",
   "wallet.approval_select_tokens": "Вибрати токен",
+  "wallet.approval_summary_suggestion_desc_all": "Ризик {riskyNumber} · Неактивний понад 90 днів {inactiveNumber} — Рекомендуємо відкликати, щоб зменшити ризик і видалити непотрібні дозволи.",
+  "wallet.approval_summary_suggestion_title": "{total} схвалень для перегляду",
   "wallet.backup_prompt": "Створіть резервну копію гаманця",
   "wallet.buy_crypto_instruction": "Купуйте криптовалюту, щоб поповнити свій гаманець",
   "wallet.collapsed_assets": "Приховані активи",

--- a/packages/shared/src/locale/json/vi.json
+++ b/packages/shared/src/locale/json/vi.json
@@ -3297,6 +3297,8 @@
   "wallet.approval_risky_detected_suggestion_description": "Thu hồi chúng để tránh thất thoát tài sản.",
   "wallet.approval_risky_suggestion_title": "Đã phát hiện {number} phê duyệt rủi ro",
   "wallet.approval_select_tokens": "Chọn token",
+  "wallet.approval_summary_suggestion_desc_all": "Rủi ro {riskyNumber} · Không hoạt động hơn 90 ngày {inactiveNumber} — Bạn nên thu hồi để giảm rủi ro và xóa các quyền không cần thiết.",
+  "wallet.approval_summary_suggestion_title": "Có {total} phê duyệt cần xem lại",
   "wallet.backup_prompt": "Sao lưu ví của bạn",
   "wallet.buy_crypto_instruction": "Mua tiền điện tử để nạp vào ví của bạn",
   "wallet.collapsed_assets": "Tài sản đã ẩn",

--- a/packages/shared/src/locale/json/zh_CN.json
+++ b/packages/shared/src/locale/json/zh_CN.json
@@ -3297,6 +3297,8 @@
   "wallet.approval_risky_detected_suggestion_description": "及时取消，避免造成资产损失。",
   "wallet.approval_risky_suggestion_title": "检测到 {number} 个有风险的授权",
   "wallet.approval_select_tokens": "选择代币",
+  "wallet.approval_summary_suggestion_desc_all": "高风险授权 {riskyNumber} 项 · 90 天未使用授权 {inactiveNumber} 项 — 建议撤销以降低风险并清理多余权限。",
+  "wallet.approval_summary_suggestion_title": "发现 {total} 个授权需要处理",
   "wallet.backup_prompt": "备份您的钱包",
   "wallet.buy_crypto_instruction": "购买加密货币至您的钱包",
   "wallet.collapsed_assets": "已收起资产",

--- a/packages/shared/src/locale/json/zh_HK.json
+++ b/packages/shared/src/locale/json/zh_HK.json
@@ -3297,6 +3297,8 @@
   "wallet.approval_risky_detected_suggestion_description": "及時取銷，避免造成資產損失。",
   "wallet.approval_risky_suggestion_title": "偵測到 {number} 個有風險的授權",
   "wallet.approval_select_tokens": "選擇代幣",
+  "wallet.approval_summary_suggestion_desc_all": "高風險授權 {riskyNumber} 項 · 90 天未使用授權 {inactiveNumber} 項 — 建議撤銷以降低風險並清理多餘權限。",
+  "wallet.approval_summary_suggestion_title": "發現 {total} 個授權需要處理",
   "wallet.backup_prompt": "備份你的錢包",
   "wallet.buy_crypto_instruction": "購買加密貨幣至您的錢包",
   "wallet.collapsed_assets": "已收起資產",

--- a/packages/shared/src/locale/json/zh_TW.json
+++ b/packages/shared/src/locale/json/zh_TW.json
@@ -3297,6 +3297,8 @@
   "wallet.approval_risky_detected_suggestion_description": "及時取銷，避免造成資產損失。",
   "wallet.approval_risky_suggestion_title": "偵測到 {number} 個有風險的授權",
   "wallet.approval_select_tokens": "選擇代幣",
+  "wallet.approval_summary_suggestion_desc_all": "高風險授權 {riskyNumber} 項 · 90 天未使用授權 {inactiveNumber} 項 — 建議撤銷以降低風險並清理多餘權限。",
+  "wallet.approval_summary_suggestion_title": "發現 {total} 個授權需要處理",
   "wallet.backup_prompt": "備份您的錢包",
   "wallet.buy_crypto_instruction": "購買加密貨幣以資助您的錢包",
   "wallet.collapsed_assets": "已收起資產",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Hide risk overview for watch-only wallets on Approval screens.
  * Block revoke and bulk-revoke for watch-only wallets with a clear message.
  * Bulk revoke availability adapts to account type and network context.
  * Added new translation strings for approval summary suggestions.
* Bug Fixes
  * Improved token de-duplication to prevent duplicate custom tokens.
  * Token selection screen only closes after selection when requested, not always.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->