### PR TITLE
fix: update ECopyFrom enum value from Others to Search in UniversalSe…

### DIFF
--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
@@ -19,6 +19,7 @@ import { useUniversalSearchActions } from '@onekeyhq/kit/src/states/jotai/contex
 import { ETranslations } from '@onekeyhq/shared/src/locale/enum/translations';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import {
+  ECopyFrom,
   EEnterWay,
   EWatchlistFrom,
 } from '@onekeyhq/shared/src/logger/scopes/dex';
@@ -57,7 +58,13 @@ function ContractAddress({ address }: { address: string }) {
         size="small"
         iconSize="$4"
         icon="Copy3Outline"
-        onPress={() => copyText(address)}
+        onPress={() => {
+          defaultLogger.dex.actions.dexCopyCA({
+            copyFrom: ECopyFrom.Search,
+            copiedContent: address,
+          });
+          copyText(address);
+        }}
       />
     </XStack>
   );

--- a/packages/shared/src/logger/scopes/dex/types.ts
+++ b/packages/shared/src/logger/scopes/dex/types.ts
@@ -23,6 +23,7 @@ export enum ESortWay {
 export enum ECopyFrom {
   Homepage = 'Homepage',
   Detail = 'Detail',
+  Search = 'Search',
   Others = 'Others',
 }
 


### PR DESCRIPTION
…archV2MarketTokenItem

- Changed ECopyFrom.Others to ECopyFrom.Search for better tracking accuracy
- Updated dex logger action to use appropriate copy source enum


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No visible changes to the search experience or copy action behavior.
- Chores
  - Added telemetry to track when users copy contract addresses from Universal Search results.
  - Expanded copy-source classification to include “Search” for more accurate analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->