### PR TITLE
OK-43119: fix perps ticker decimal issues

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/messageHandlers/index.ts
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/messageHandlers/index.ts
@@ -11,7 +11,7 @@ import {
   EAppEventBusNames,
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
-import { calculatePriceScale } from '@onekeyhq/shared/src/utils/perpsUtils';
+import { calculateDisplayPriceScale } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type {
   IFill,
   IHex,
@@ -169,7 +169,7 @@ export function usePerpsMessageHandler({
 
       if (midValue && Number(midValue) > 0) {
         // Use HyperLiquid precision rules to calculate price scale
-        calculatedPriceScale = calculatePriceScale(midValue);
+        calculatedPriceScale = calculateDisplayPriceScale(midValue);
       }
 
       const response = {

--- a/packages/kit/src/views/Perp/components/OrderBook/tickSizeUtils.test.ts
+++ b/packages/kit/src/views/Perp/components/OrderBook/tickSizeUtils.test.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 
-import { getPriceScaleDecimals } from '@onekeyhq/shared/src/utils/perpsUtils';
+import { getDisplayPriceScaleDecimals } from '@onekeyhq/shared/src/utils/perpsUtils';
 
 import { buildTickOptions } from './tickSizeUtils';
 
@@ -66,12 +66,29 @@ const fixtures = {
       { targetTick: 0.1, nSigFigs: 2, mantissa: null },
     ],
   },
+  MEME: {
+    price: 0.002_699,
+    decimals: 6,
+    options: [
+      { targetTick: 0.000_001, nSigFigs: 4, mantissa: null },
+      { targetTick: 0.000_01, nSigFigs: 3, mantissa: null },
+      { targetTick: 0.0001, nSigFigs: 2, mantissa: null },
+    ],
+  },
+  HMSTR: {
+    price: 0.000_749,
+    decimals: 6,
+    options: [
+      { targetTick: 0.000_001, nSigFigs: 3, mantissa: null },
+      { targetTick: 0.000_01, nSigFigs: 2, mantissa: null },
+    ],
+  },
 };
 
 describe('fixtures map', () => {
   Object.entries(fixtures).forEach(([symbol, cfg]) => {
     it(`${symbol} options should match fixtures`, () => {
-      const priceDecimals = getPriceScaleDecimals(cfg.price);
+      const priceDecimals = getDisplayPriceScaleDecimals(cfg.price);
       expect(cfg.decimals).toBe(priceDecimals);
       const decimalsArg =
         priceDecimals === 0

--- a/packages/kit/src/views/Perp/components/OrderBook/useTickOptions.ts
+++ b/packages/kit/src/views/Perp/components/OrderBook/useTickOptions.ts
@@ -4,7 +4,7 @@ import BigNumber from 'bignumber.js';
 
 import {
   analyzeOrderBookPrecision,
-  getPriceScaleDecimals,
+  getDisplayPriceScaleDecimals,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type { IBookLevel } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
@@ -52,7 +52,7 @@ export function useTickOptions({
     const marketPrice = topBidPrice || topAskPrice || '0';
     if (marketPrice === '0') return null;
 
-    const priceDecimals = getPriceScaleDecimals(marketPrice);
+    const priceDecimals = getDisplayPriceScaleDecimals(marketPrice);
 
     // Handle edge case: when priceDecimals = 0, use 1 as base decimal
     const decimalsArg =

--- a/packages/shared/src/utils/perpsUtils.test.ts
+++ b/packages/shared/src/utils/perpsUtils.test.ts
@@ -10,6 +10,7 @@ import {
   calculatePriceScale,
   countDecimalPlaces,
   formatWithPrecision,
+  getDisplayPriceScaleDecimals,
   getMostFrequentDecimalPlaces,
   getValidPriceDecimals,
 } from './perpsUtils';
@@ -62,6 +63,19 @@ describe('countDecimalPlaces', () => {
     expect(countDecimalPlaces('123.45')).toBe(2);
     expect(countDecimalPlaces('0.123456')).toBe(6);
     expect(countDecimalPlaces('0')).toBe(0);
+  });
+});
+
+describe('getDisplayPriceScaleDecimals', () => {
+  test('returns correct display price scale decimals', () => {
+    expect(getDisplayPriceScaleDecimals('123')).toBe(2);
+    expect(getDisplayPriceScaleDecimals('123.4')).toBe(2);
+    expect(getDisplayPriceScaleDecimals('123.45')).toBe(2);
+    expect(getDisplayPriceScaleDecimals('0.123456')).toBe(6);
+    expect(getDisplayPriceScaleDecimals('0.0123456')).toBe(6);
+    expect(getDisplayPriceScaleDecimals('0.0012345')).toBe(6);
+    expect(getDisplayPriceScaleDecimals('0.0001230')).toBe(6);
+    expect(getDisplayPriceScaleDecimals('0.000123456')).toBe(6);
   });
 });
 

--- a/packages/shared/src/utils/perpsUtils.ts
+++ b/packages/shared/src/utils/perpsUtils.ts
@@ -194,7 +194,7 @@ function getDisplayPriceScaleDecimals(marketPrice: string | number): number {
 }
 
 function calculateDisplayPriceScale(marketPrice: string | number): number {
-  const validDecimals = getPriceScaleDecimals(marketPrice);
+  const validDecimals = getDisplayPriceScaleDecimals(marketPrice);
   return new BigNumber(10).pow(validDecimals).toNumber();
 }
 

--- a/packages/shared/src/utils/perpsUtils.ts
+++ b/packages/shared/src/utils/perpsUtils.ts
@@ -163,6 +163,42 @@ function getPriceScaleDecimals(marketPrice: string | number): number {
 }
 
 /**
+ * Determine decimal precision for UI display.
+ *
+ * Keeps the strict HyperLiquid baseline but, when prices are below 1, preserves
+ * the natural decimal length (capped by MAX_DECIMALS_PERP) so that tiny price
+ * increments are visible in the UI even if they exceed the trading constraint.
+ */
+function getDisplayPriceScaleDecimals(marketPrice: string | number): number {
+  const baseline = getPriceScaleDecimals(marketPrice);
+  const price = new BigNumber(marketPrice);
+
+  if (!price.isFinite() || price.isLessThanOrEqualTo(0)) {
+    return baseline;
+  }
+
+  if (price.isGreaterThanOrEqualTo(1)) {
+    return baseline;
+  }
+
+  const priceStr = price.toFixed();
+  const decimalIndex = priceStr.indexOf('.');
+  if (decimalIndex === -1) {
+    return baseline;
+  }
+
+  const actualDecimals = priceStr.length - decimalIndex - 1;
+  const clampedActual = Math.min(actualDecimals, MAX_DECIMALS_PERP);
+
+  return Math.max(baseline, clampedActual);
+}
+
+function calculateDisplayPriceScale(marketPrice: string | number): number {
+  const validDecimals = getPriceScaleDecimals(marketPrice);
+  return new BigNumber(10).pow(validDecimals).toNumber();
+}
+
+/**
  * Calculate price scale (10^decimals) for TradingView based on valid decimals
  *
  * @param marketPrice - The market price to analyze
@@ -685,7 +721,9 @@ export {
   MAX_DECIMALS_PERP,
   getValidPriceDecimals,
   getPriceScaleDecimals,
+  getDisplayPriceScaleDecimals,
   calculatePriceScale,
+  calculateDisplayPriceScale,
   formatPriceToValid,
   analyzeOrderBookPrecision,
   formatWithPrecision,
@@ -706,7 +744,9 @@ export default {
   MAX_DECIMALS_PERP,
   getValidPriceDecimals,
   getPriceScaleDecimals,
+  getDisplayPriceScaleDecimals,
   calculatePriceScale,
+  calculateDisplayPriceScale,
   formatPriceToValid,
   analyzeOrderBookPrecision,
   formatWithPrecision,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More accurate price decimal display for Perps, especially for prices below 1, improving readability.
  - Enhanced tick size selection with finer granularity (adds 0.1 multiplier), deduplicated options, and filtering of impractically small ticks.
  - Labels and values now consistently reflect the actual applied tick, reducing confusion.
  - Improved numerical stability and precision in price/tick calculations, leading to cleaner Order Book options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->