### PR TITLE
OK-43072: enhance OrderBook component with interactive row selection

### DIFF
--- a/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
+++ b/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
@@ -9,14 +9,21 @@ import {
   YStack,
   useMedia,
 } from '@onekeyhq/components';
-import { useCurrentTokenPriceAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import {
+  useCurrentTokenPriceAtom,
+  useHyperliquidActions,
+} from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { useFundingCountdown } from '../hooks/useFundingCountdown';
 import { useL2Book } from '../hooks/usePerpMarketData';
 import { usePerpSession } from '../hooks/usePerpSession';
 
-import { OrderBook, OrderBookMobile, OrderPairBook } from './OrderBook';
+import {
+  type IOrderBookSelection,
+  OrderBook,
+  OrderBookMobile,
+} from './OrderBook';
 import { useTickOptions } from './OrderBook/useTickOptions';
 
 import type { ITickParam } from './OrderBook/tickSizeUtils';
@@ -77,6 +84,7 @@ export function PerpOrderBook({
   entry?: 'perpTab' | 'perpMobileMarket';
 }) {
   const { gtMd } = useMedia();
+  const actionsRef = useHyperliquidActions();
   const [selectedTickOption, setSelectedTickOption] = useState<ITickParam>();
   const prevSymbolRef = useRef<string | undefined>(undefined);
   const { l2Book, hasOrderBook } = useL2Book({
@@ -105,6 +113,14 @@ export function PerpOrderBook({
     setSelectedTickOption(option);
   }, []);
 
+  const handleLevelSelect = useCallback(
+    (selection: IOrderBookSelection) => {
+      console.log('OrderBook level selected: =>>>: ', selection);
+      actionsRef.current.updateTradingForm({ price: selection.price });
+    },
+    [actionsRef],
+  );
+
   const mobileOrderBook = useMemo(() => {
     if (!hasOrderBook || !l2Book) return null;
     if (gtMd) return null;
@@ -122,6 +138,7 @@ export function PerpOrderBook({
           showTickSelector
           priceDecimals={tickOptionsData.priceDecimals}
           sizeDecimals={tickOptionsData.sizeDecimals}
+          onSelectLevel={handleLevelSelect}
         />
       );
     }
@@ -139,6 +156,7 @@ export function PerpOrderBook({
           showTickSelector
           priceDecimals={tickOptionsData.priceDecimals}
           sizeDecimals={tickOptionsData.sizeDecimals}
+          onSelectLevel={handleLevelSelect}
         />
       </>
     );
@@ -147,6 +165,7 @@ export function PerpOrderBook({
     gtMd,
     handleTickOptionChange,
     l2Book,
+    handleLevelSelect,
     selectedTickOption,
     tickOptionsData,
     hasOrderBook,
@@ -177,6 +196,7 @@ export function PerpOrderBook({
           showTickSelector
           priceDecimals={tickOptionsData.priceDecimals}
           sizeDecimals={tickOptionsData.sizeDecimals}
+          onSelectLevel={handleLevelSelect}
         />
       ) : (
         mobileOrderBook

--- a/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
+++ b/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
@@ -12,7 +12,9 @@ import {
 import {
   useCurrentTokenPriceAtom,
   useHyperliquidActions,
+  useTradingFormAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import type { ITradingFormData } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { useFundingCountdown } from '../hooks/useFundingCountdown';
@@ -85,6 +87,7 @@ export function PerpOrderBook({
 }) {
   const { gtMd } = useMedia();
   const actionsRef = useHyperliquidActions();
+  const [formData] = useTradingFormAtom();
   const [selectedTickOption, setSelectedTickOption] = useState<ITickParam>();
   const prevSymbolRef = useRef<string | undefined>(undefined);
   const { l2Book, hasOrderBook } = useL2Book({
@@ -115,10 +118,17 @@ export function PerpOrderBook({
 
   const handleLevelSelect = useCallback(
     (selection: IOrderBookSelection) => {
-      console.log('OrderBook level selected: =>>>: ', selection);
-      actionsRef.current.updateTradingForm({ price: selection.price });
+      const updates: Partial<ITradingFormData> = {
+        price: selection.price,
+      };
+
+      if (formData.type !== 'limit') {
+        updates.type = 'limit';
+      }
+
+      actionsRef.current.updateTradingForm(updates);
     },
-    [actionsRef],
+    [actionsRef, formData.type],
   );
 
   const mobileOrderBook = useMemo(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Tap/click an order book level to auto-fill the trading form price and switch to limit order if needed (desktop and mobile).

- Improvements
  - Interactive order book rows with hover/press feedback and pointer cursor on web.
  - Clearer depth visualization with consistent percentage-based bars for bids and asks.
  - Unified interactivity across horizontal, vertical, and mobile order book views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->