### PR TITLE
feat: add tradingview display price scale management in SimpleDb

### DIFF
--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPerp.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPerp.ts
@@ -32,6 +32,7 @@ export interface ISimpleDbPerpData {
   marginTables: IMarginTables | undefined;
   agentTTL?: number; // in milliseconds
   referralCode?: string;
+  tradingviewDisplayPriceScale?: Record<string, number>; // decimal places for price display in tradingview chart
 }
 
 export class SimpleDbEntityPerp extends SimpleDbEntityBase<ISimpleDbPerpData> {
@@ -117,5 +118,34 @@ export class SimpleDbEntityPerp extends SimpleDbEntityBase<ISimpleDbPerpData> {
         hyperliquidCurrentToken: token,
       }),
     );
+  }
+
+  @backgroundMethod()
+  async updateTradingviewDisplayPriceScale({
+    symbol,
+    priceScale,
+  }: {
+    symbol: string;
+    priceScale: number;
+  }) {
+    await this.setPerpData(
+      (prev): ISimpleDbPerpData => ({
+        ...prev,
+        tradingUniverse: prev?.tradingUniverse,
+        marginTables: prev?.marginTables,
+        tradingviewDisplayPriceScale: {
+          ...(prev?.tradingviewDisplayPriceScale || {}),
+          [symbol]: priceScale,
+        },
+      }),
+    );
+  }
+
+  @backgroundMethod()
+  async getTradingviewDisplayPriceScale(
+    symbol: string,
+  ): Promise<number | undefined> {
+    const config = await this.getPerpData();
+    return config.tradingviewDisplayPriceScale?.[symbol];
   }
 }

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -652,4 +652,38 @@ export default class ServiceHyperliquid extends ServiceBase {
       },
     });
   }
+
+  @backgroundMethod()
+  async getTradingviewDisplayPriceScale(
+    symbol: string,
+  ): Promise<number | undefined> {
+    return this.backgroundApi.simpleDb.perp.getTradingviewDisplayPriceScale(
+      symbol,
+    );
+  }
+
+  @backgroundMethod()
+  async setTradingviewDisplayPriceScale({
+    symbol,
+    priceScale,
+  }: {
+    symbol: string;
+    priceScale: number;
+  }) {
+    if (!symbol || priceScale === undefined || priceScale === null) {
+      return;
+    }
+    const priceScaleBN = new BigNumber(priceScale);
+    if (
+      priceScaleBN.isNaN() ||
+      priceScaleBN.isNegative() ||
+      !priceScaleBN.isInteger()
+    ) {
+      return;
+    }
+    await this.backgroundApi.simpleDb.perp.updateTradingviewDisplayPriceScale({
+      symbol,
+      priceScale,
+    });
+  }
 }

--- a/packages/kit/src/views/Perp/components/PerpCandles.tsx
+++ b/packages/kit/src/views/Perp/components/PerpCandles.tsx
@@ -1,18 +1,19 @@
 import { Stack } from '@onekeyhq/components';
 import { TradingViewPerpsV2 } from '@onekeyhq/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2';
-import { usePerpsSelectedAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-
-import { useCurrentTokenAtom } from '../../../states/jotai/contexts/hyperliquid';
+import {
+  usePerpsSelectedAccountAtom,
+  usePerpsSelectedSymbolAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 
 export function PerpCandles() {
-  const [currentToken] = useCurrentTokenAtom();
+  const [currentToken] = usePerpsSelectedSymbolAtom();
   const [currentAccount] = usePerpsSelectedAccountAtom();
 
   return (
     <Stack w="100%" h="100%">
       <TradingViewPerpsV2
         userAddress={currentAccount?.accountAddress}
-        symbol={currentToken}
+        symbol={currentToken.coin}
       />
     </Stack>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-symbol price display scale is now stored and reused for Hyperliquid perpetuals, improving price formatting consistency.
  * Price scale auto-computes from live data and gracefully falls back to saved values, reducing delays and flicker.
  * TradingView marks update in real time on user fills and refresh appropriately on login/logout.
  * Perpetuals chart now reads the selected symbol from the perp selector for more accurate charting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->