### PR TITLE
feat: implement HyperLiquid builder fee support and optimize Perp provider usage

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
@@ -1,5 +1,6 @@
 import { ExchangeClient, HttpTransport } from '@nktkas/hyperliquid';
 import { BigNumber } from 'bignumber.js';
+import { isNumber } from 'lodash';
 
 import type { ICoreHyperLiquidAgentCredential } from '@onekeyhq/core/src/types';
 import {
@@ -60,6 +61,13 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
 
   private _exchangeClient: ExchangeClient | null = null;
 
+  private _builderFeeInfo:
+    | {
+        b: `0x${string}`;
+        f: number;
+      }
+    | undefined = undefined;
+
   public slippage = 0.08;
 
   private get exchangeClient(): ExchangeClient {
@@ -95,6 +103,18 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
     agentCredential?: ICoreHyperLiquidAgentCredential;
   }): Promise<void> {
     try {
+      const { hyperliquidBuilderAddress, hyperliquidMaxBuilderFee } =
+        await this.backgroundApi.simpleDb.perp.getPerpData();
+      if (
+        hyperliquidBuilderAddress &&
+        !Number.isNaN(hyperliquidMaxBuilderFee) &&
+        isNumber(hyperliquidMaxBuilderFee)
+      ) {
+        this._builderFeeInfo = {
+          b: hyperliquidBuilderAddress.toLowerCase() as `0x${string}`,
+          f: hyperliquidMaxBuilderFee,
+        };
+      }
       if (!params.userAddress) {
         throw new OneKeyLocalError(
           'ServiceHyperliquidExchange.setup Error: User address is required',
@@ -234,6 +254,7 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
       return await this._exchangeClient!.order({
         orders: params.action.orders,
         grouping: params.action.grouping,
+        builder: this._builderFeeInfo,
       });
     } catch (error) {
       throw new OneKeyLocalError(`Failed to place order: ${String(error)}`);
@@ -248,6 +269,7 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
   async dispose(): Promise<void> {
     this._account = null;
     this._exchangeClient = null;
+    this._builderFeeInfo = undefined;
   }
 
   async checkAccountCanTrade() {
@@ -295,6 +317,7 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
       return await this.exchangeClient.order({
         orders: [orderParams],
         grouping: 'na',
+        builder: this._builderFeeInfo,
       });
     } catch (error) {
       throw new OneKeyLocalError(`Failed to place order: ${String(error)}`);
@@ -392,6 +415,7 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
       return await this.exchangeClient.order({
         orders,
         grouping: orders.length > 1 ? 'normalTpsl' : 'na',
+        builder: this._builderFeeInfo,
       });
     } catch (error) {
       throw new OneKeyLocalError(
@@ -423,6 +447,7 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
       return await this.exchangeClient.order({
         orders: [orderParams],
         grouping: 'na',
+        builder: this._builderFeeInfo,
       });
     } catch (error) {
       throw new OneKeyLocalError(
@@ -468,6 +493,7 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
       return await this.exchangeClient.order({
         orders: orderParams,
         grouping: 'na',
+        builder: this._builderFeeInfo,
       });
     } catch (error) {
       throw new OneKeyLocalError(
@@ -551,6 +577,7 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
       return await this.exchangeClient.order({
         orders,
         grouping: 'positionTpsl',
+        builder: this._builderFeeInfo,
       });
     } catch (error) {
       throw new OneKeyLocalError(

--- a/packages/kit/src/views/Perp/PerpsProvider.tsx
+++ b/packages/kit/src/views/Perp/PerpsProvider.tsx
@@ -5,20 +5,18 @@ import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms
 
 import { ProviderJotaiContextHyperliquid } from '../../states/jotai/contexts/hyperliquid';
 
-export function usePerpsContextStoreInitData(
-  storeName: EJotaiContextStoreNames,
-) {
+export function usePerpsContextStoreInitData() {
   const data = useMemo(
     () => ({
-      storeName,
+      storeName: EJotaiContextStoreNames.perps,
     }),
-    [storeName],
+    [],
   );
   return data;
 }
 
 export const PerpsRootProvider = memo(() => {
-  const data = usePerpsContextStoreInitData(EJotaiContextStoreNames.perps);
+  const data = usePerpsContextStoreInitData();
   const store = useJotaiContextRootStore(data);
   return <ProviderJotaiContextHyperliquid store={store} />;
 });

--- a/packages/kit/src/views/Perp/PerpsProviderMirror.tsx
+++ b/packages/kit/src/views/Perp/PerpsProviderMirror.tsx
@@ -2,27 +2,24 @@ import { type PropsWithChildren, memo } from 'react';
 
 import { jotaiContextStore } from '@onekeyhq/kit/src/states/jotai/utils/jotaiContextStore';
 import { JotaiContextStoreMirrorTracker } from '@onekeyhq/kit/src/states/jotai/utils/JotaiContextStoreMirrorTracker';
-import type { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 
 import { ProviderJotaiContextHyperliquid } from '../../states/jotai/contexts/hyperliquid';
 
 import { usePerpsContextStoreInitData } from './PerpsProvider';
 
-export const PerpsProviderMirror = memo(
-  (props: PropsWithChildren & { storeName: EJotaiContextStoreNames }) => {
-    const { children, storeName } = props;
+export const PerpsProviderMirror = memo((props: PropsWithChildren) => {
+  const { children } = props;
 
-    const data = usePerpsContextStoreInitData(storeName);
-    const store = jotaiContextStore.getOrCreateStore(data);
+  const data = usePerpsContextStoreInitData();
+  const store = jotaiContextStore.getOrCreateStore(data);
 
-    return (
-      <>
-        <JotaiContextStoreMirrorTracker {...data} />
-        <ProviderJotaiContextHyperliquid store={store}>
-          {children}
-        </ProviderJotaiContextHyperliquid>
-      </>
-    );
-  },
-);
+  return (
+    <>
+      <JotaiContextStoreMirrorTracker {...data} />
+      <ProviderJotaiContextHyperliquid store={store}>
+        {children}
+      </ProviderJotaiContextHyperliquid>
+    </>
+  );
+});
 PerpsProviderMirror.displayName = 'PerpsProviderMirror';

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
@@ -438,7 +438,7 @@ export function showClosePositionDialog({
             id: ETranslations.perp_close_position_button_limit,
           }),
     renderContent: (
-      <PerpsProviderMirror storeName={EJotaiContextStoreNames.perps}>
+      <PerpsProviderMirror>
         <ClosePositionForm
           position={position}
           type={type}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpTradersHistoryListModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpTradersHistoryListModal.tsx
@@ -21,7 +21,7 @@ export function PerpTradersHistoryListModal() {
 
 const PerpTradersHistoryListModalWithProvider = () => {
   return (
-    <PerpsProviderMirror storeName={EJotaiContextStoreNames.perps}>
+    <PerpsProviderMirror>
       <PerpTradersHistoryListModal />
     </PerpsProviderMirror>
   );

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
@@ -339,7 +339,7 @@ export function showSetTpslDialog({
       id: ETranslations.perp_tp_sl_position_desc,
     }),
     renderContent: (
-      <PerpsProviderMirror storeName={EJotaiContextStoreNames.perps}>
+      <PerpsProviderMirror>
         <SetTpslForm
           position={position}
           szDecimals={szDecimals}

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -433,7 +433,7 @@ export async function showDepositWithdrawModal(params: IDepositWithdrawParams) {
 
   const dialogInstance = Dialog.show({
     renderContent: (
-      <PerpsProviderMirror storeName={EJotaiContextStoreNames.perps}>
+      <PerpsProviderMirror>
         <DepositWithdrawContent
           params={params}
           selectedAccount={selectedAccount}

--- a/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
+++ b/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
@@ -116,7 +116,7 @@ function MobilePerpMarket() {
 function MobilePerpMarketWithProvider() {
   return (
     <PerpsAccountSelectorProviderMirror>
-      <PerpsProviderMirror storeName={EJotaiContextStoreNames.perps}>
+      <PerpsProviderMirror>
         <MobilePerpMarket />
       </PerpsProviderMirror>
     </PerpsAccountSelectorProviderMirror>

--- a/packages/kit/src/views/Perp/pages/Perp.tsx
+++ b/packages/kit/src/views/Perp/pages/Perp.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { useFocusEffect } from '@react-navigation/native';
 
 import { Image, Page, XStack, useMedia } from '@onekeyhq/components';
@@ -23,13 +25,37 @@ function PerpLayout() {
   return <PerpMobileLayout />;
 }
 
-function PerpContent() {
-  useFocusEffect(() => {
-    void backgroundApiProxy.serviceWebviewPerp.updateBuilderFeeConfigByServer();
-  });
-
+function PerpContentFooter() {
   const { gtSm } = useMedia();
   const themeVariant = useThemeVariant();
+  return gtSm ? (
+    <Page.Footer>
+      <XStack
+        borderTopWidth="$px"
+        borderTopColor="$borderSubdued"
+        bg="$bgApp"
+        h={40}
+        alignItems="center"
+        p="$4"
+        justifyContent="flex-end"
+      >
+        <Image
+          source={
+            themeVariant === 'light'
+              ? require('../../../../assets/PoweredByHyperliquidLight.svg')
+              : require('../../../../assets/PoweredByHyperliquidDark.svg')
+          }
+          size={170}
+          resizeMode="contain"
+        />
+      </XStack>
+    </Page.Footer>
+  ) : null;
+}
+
+function PerpContent() {
+  console.log('PerpContent render');
+
   return (
     <Page>
       <TabPageHeader
@@ -37,7 +63,7 @@ function PerpContent() {
         tabRoute={ETabRoutes.Perp}
         customHeaderRightItems={
           <PerpsAccountSelectorProviderMirror>
-            <PerpsProviderMirror storeName={EJotaiContextStoreNames.perps}>
+            <PerpsProviderMirror>
               <PerpAccountPanel ifOnHeader />
             </PerpsProviderMirror>
           </PerpsAccountSelectorProviderMirror>
@@ -46,37 +72,18 @@ function PerpContent() {
       <Page.Body>
         <PerpLayout />
       </Page.Body>
-      {gtSm ? (
-        <Page.Footer>
-          <XStack
-            borderTopWidth="$px"
-            borderTopColor="$borderSubdued"
-            bg="$bgApp"
-            h={40}
-            alignItems="center"
-            p="$4"
-            justifyContent="flex-end"
-          >
-            <Image
-              source={
-                themeVariant === 'light'
-                  ? require('../../../../assets/PoweredByHyperliquidLight.svg')
-                  : require('../../../../assets/PoweredByHyperliquidDark.svg')
-              }
-              size={170}
-              resizeMode="contain"
-            />
-          </XStack>
-        </Page.Footer>
-      ) : null}
+      <PerpContentFooter />
     </Page>
   );
 }
 
 export default function Perp() {
+  useFocusEffect(() => {
+    void backgroundApiProxy.serviceWebviewPerp.updateBuilderFeeConfigByServer();
+  });
   return (
     <PerpsAccountSelectorProviderMirror>
-      <PerpsProviderMirror storeName={EJotaiContextStoreNames.perps}>
+      <PerpsProviderMirror>
         <PerpsGlobalEffects />
         <PerpContent />
       </PerpsProviderMirror>

--- a/patches/@nktkas+hyperliquid+0.24.2.patch
+++ b/patches/@nktkas+hyperliquid+0.24.2.patch
@@ -1,0 +1,38 @@
+diff --git a/node_modules/@nktkas/hyperliquid/esm/src/types/exchange/requests.d.ts b/node_modules/@nktkas/hyperliquid/esm/src/types/exchange/requests.d.ts
+index 8ecaf28..49c4550 100644
+--- a/node_modules/@nktkas/hyperliquid/esm/src/types/exchange/requests.d.ts
++++ b/node_modules/@nktkas/hyperliquid/esm/src/types/exchange/requests.d.ts
+@@ -573,12 +573,12 @@ export interface OrderRequest {
+          */
+         grouping: "na" | "normalTpsl" | "positionTpsl";
+         /** Builder fee. */
+-        builder?: {
++        builder: {
+             /** Builder address. */
+             b: Hex;
+             /** Builder fee in 0.1bps (1 = 0.0001%). */
+             f: number;
+-        };
++        } | undefined;
+     };
+     /** Unique request identifier (current timestamp in ms). */
+     nonce: number;
+diff --git a/node_modules/@nktkas/hyperliquid/script/src/types/exchange/requests.d.ts b/node_modules/@nktkas/hyperliquid/script/src/types/exchange/requests.d.ts
+index 8ecaf28..49c4550 100644
+--- a/node_modules/@nktkas/hyperliquid/script/src/types/exchange/requests.d.ts
++++ b/node_modules/@nktkas/hyperliquid/script/src/types/exchange/requests.d.ts
+@@ -573,12 +573,12 @@ export interface OrderRequest {
+          */
+         grouping: "na" | "normalTpsl" | "positionTpsl";
+         /** Builder fee. */
+-        builder?: {
++        builder: {
+             /** Builder address. */
+             b: Hex;
+             /** Builder fee in 0.1bps (1 = 0.0001%). */
+             f: number;
+-        };
++        } | undefined;
+     };
+     /** Unique request identifier (current timestamp in ms). */
+     nonce: number;


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Builder fee support for HyperLiquid: builder fees are now applied to relevant orders.
  - Added a "Powered by Hyperliquid" footer shown on larger screens with a theme-aware logo.

- Refactor
  - Simplified Perps provider usage across pages and modals: no store selection prop required, reducing boilerplate and unifying context initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Implement builder fee configuration in ServiceHyperliquidExchange for all order operations
- Simplify PerpsProviderMirror by removing unnecessary storeName parameter across all usages
- Add patch for @nktkas/hyperliquid library to support optional builder fee types
- Extract PerpContentFooter component and optimize code organization

## Changes
- **ServiceHyperliquidExchange**: Add builder fee info retrieval and integration into all order calls
- **PerpsProviderMirror**: Remove storeName prop and simplify component usage
- **Perp components**: Update all modal and page components to use simplified provider
- **Type patch**: Add patch to modify HyperLiquid library for proper builder fee type support

## Test plan
- [ ] Verify builder fee is properly applied to all HyperLiquid order operations
- [ ] Test all Perp modals and pages work correctly with simplified provider
- [ ] Validate patch-package correctly applies the type definition changes
- [ ] Ensure no TypeScript errors and all components render properly

🤖 Generated with [Claude Code](https://claude.ai/code)