### PR TITLE
OK-43447: update orderbook subscribe logic

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -45,7 +45,7 @@ interface ISubscriptionUpdateParams {
   currentUser?: IHex | null;
   currentSymbol?: string;
   isConnected?: boolean;
-  l2BookOptions?: IL2BookOptions;
+  l2BookOptions?: IL2BookOptions | null;
 }
 
 @backgroundClass()

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
@@ -158,7 +158,7 @@ export interface ISubscriptionState {
   currentUser: IHex | null;
   currentSymbol: string;
   isConnected: boolean;
-  l2BookOptions?: IL2BookOptions;
+  l2BookOptions?: IL2BookOptions | null;
 }
 
 export interface ISubscriptionDiff {

--- a/packages/kit/src/views/Perp/components/OrderBook/index.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/index.tsx
@@ -713,7 +713,7 @@ export function OrderBook({
             {showTickSelector ? (
               <Select
                 floatingPanelProps={{
-                  width: 140,
+                  width: 150,
                 }}
                 title={intl.formatMessage({
                   id: ETranslations.perp_orderbook_spread,
@@ -725,7 +725,7 @@ export function OrderBook({
                   <TouchableOpacity
                     style={{
                       minWidth: 56,
-                      maxWidth: 140,
+                      maxWidth: 150,
                       height: 24,
                       borderRadius: 4,
                       flexDirection: 'row',

--- a/packages/kit/src/views/Perp/components/OrderBook/tickSizeUtils.ts
+++ b/packages/kit/src/views/Perp/components/OrderBook/tickSizeUtils.ts
@@ -198,11 +198,11 @@ export function buildTickOptions(
  * Get the default tick option (usually the first exact match or smallest multiplier)
  */
 export function getDefaultTickOption(options: ITickParam[]): ITickParam {
-  // Prefer exact matches with smaller multipliers
-  const exactMatch = options.find((opt) => opt.exact);
-  if (exactMatch) return exactMatch;
+  if (!options.length) {
+    throw new OneKeyError('tick options must not be empty');
+  }
 
-  // Fallback to first option
+  // UI defaults to the first generated option to match display ordering
   return options[0];
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when switching tokens by handling missing order book settings more gracefully.
  * Updated tick size selection to default reliably and surface a clear error if no options are available, reducing edge-case failures.

* **Style**
  * Widened the Order Book spread selector and its trigger for better readability (140 → 150 px).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->