### PR TITLE
fix: enhance size input with token/USD mode and improve validation

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
@@ -322,7 +322,7 @@ const PositionRow = memo(
               width={160}
               size="small"
               variant="secondary"
-              onPress={handleClosePosition('market')}
+              onPress={() => handleClosePosition('market')}
             >
               {intl.formatMessage({
                 id: ETranslations.perp_position_close,

--- a/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
@@ -49,7 +49,6 @@ export const SizeInput = memo(
 
     const currentPrice = tokenInfo?.markPx || '0';
 
-    // 缓存价格BigNumber实例，避免重复创建
     const priceBN = useMemo(() => new BigNumber(currentPrice), [currentPrice]);
     const hasValidPrice = useMemo(
       () => priceBN.isFinite() && priceBN.gt(0),
@@ -111,7 +110,6 @@ export const SizeInput = memo(
           return false;
         }
 
-        // USD模式下的额外限制：整数部分最多12位
         if (inputMode === 'usd' && text) {
           const [integerPart] = text.split('.');
           if (integerPart && integerPart.length > 12) {

--- a/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
@@ -1,9 +1,13 @@
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { validateSizeInput } from '@onekeyhq/shared/src/utils/perpsUtils';
+import {
+  formatWithPrecision,
+  validateSizeInput,
+} from '@onekeyhq/shared/src/utils/perpsUtils';
 
 import { TradingFormInput } from './TradingFormInput';
 
@@ -35,11 +39,89 @@ export const SizeInput = memo(
     const intl = useIntl();
     const szDecimals = tokenInfo?.szDecimals ?? 2;
     const isDisabled = disabled || !tokenInfo;
-    const maxSzs = tokenInfo?.maxTradeSzs || [0, 0];
-    const maxSize = maxSzs[side === 'long' ? 0 : 1];
+
+    const [inputMode, setInputMode] = useState<'token' | 'usd'>('token');
+    const [tokenAmount, setTokenAmount] = useState('');
+    const [usdAmount, setUsdAmount] = useState('');
+    const [isUserTyping, setIsUserTyping] = useState(false);
+
+    const prevValueRef = useRef(value);
+
+    const currentPrice = tokenInfo?.markPx || '0';
+
+    // 缓存价格BigNumber实例，避免重复创建
+    const priceBN = useMemo(() => new BigNumber(currentPrice), [currentPrice]);
+    const hasValidPrice = useMemo(
+      () => priceBN.isFinite() && priceBN.gt(0),
+      [priceBN],
+    );
+
+    useEffect(() => {
+      if (value !== prevValueRef.current) {
+        setTokenAmount(value);
+        prevValueRef.current = value;
+      }
+    }, [value]);
+
+    useEffect(() => {
+      if (inputMode === 'token' && hasValidPrice && tokenAmount) {
+        const tokenBN = new BigNumber(tokenAmount);
+        if (tokenBN.isFinite()) {
+          const usdValue = formatWithPrecision(
+            tokenBN.multipliedBy(priceBN),
+            2,
+            true,
+          );
+          setUsdAmount(usdValue);
+        }
+      }
+    }, [inputMode, tokenAmount, hasValidPrice, priceBN]);
+
+    useEffect(() => {
+      if (inputMode === 'usd' && hasValidPrice && usdAmount && !isUserTyping) {
+        const usdBN = new BigNumber(usdAmount);
+        if (usdBN.isFinite()) {
+          const newTokenValue = formatWithPrecision(
+            usdBN.dividedBy(priceBN),
+            szDecimals,
+            true,
+          );
+          setTokenAmount((prevTokenAmount) => {
+            if (newTokenValue !== prevTokenAmount) {
+              onChange(newTokenValue);
+              return newTokenValue;
+            }
+            return prevTokenAmount;
+          });
+        }
+      }
+    }, [
+      inputMode,
+      usdAmount,
+      hasValidPrice,
+      szDecimals,
+      onChange,
+      isUserTyping,
+      priceBN,
+    ]);
+
     const validator = useCallback(
-      (text: string) => validateSizeInput(text, szDecimals),
-      [szDecimals],
+      (text: string) => {
+        if (!validateSizeInput(text, inputMode === 'token' ? szDecimals : 2)) {
+          return false;
+        }
+
+        // USD模式下的额外限制：整数部分最多12位
+        if (inputMode === 'usd' && text) {
+          const [integerPart] = text.split('.');
+          if (integerPart && integerPart.length > 12) {
+            return false;
+          }
+        }
+
+        return true;
+      },
+      [szDecimals, inputMode],
     );
 
     const formatLabel = useMemo(() => {
@@ -53,15 +135,85 @@ export const SizeInput = memo(
           });
     }, [side, label, intl]);
 
+    useEffect(() => {
+      if (isUserTyping) {
+        const timer = setTimeout(() => {
+          setIsUserTyping(false);
+        }, 500);
+        return () => clearTimeout(timer);
+      }
+    }, [isUserTyping]);
+
+    const handleInputChange = useCallback(
+      (newValue: string) => {
+        setIsUserTyping(true);
+
+        if (inputMode === 'token') {
+          setTokenAmount(newValue);
+          onChange(newValue);
+        } else {
+          setUsdAmount(newValue);
+
+          if (hasValidPrice && newValue) {
+            const usdBN = new BigNumber(newValue);
+            if (usdBN.isFinite()) {
+              const tokenValue = formatWithPrecision(
+                usdBN.dividedBy(priceBN),
+                szDecimals,
+                true,
+              );
+              setTokenAmount(tokenValue);
+              onChange(tokenValue);
+            }
+          } else {
+            setTokenAmount('');
+            onChange('');
+          }
+        }
+      },
+      [inputMode, hasValidPrice, szDecimals, onChange, priceBN],
+    );
+
+    const actions = useMemo(() => {
+      const unitDisplay = inputMode === 'token' ? tokenInfo?.name || '' : 'USD';
+
+      return [
+        {
+          labelColor: '$textSubdued',
+          label: unitDisplay,
+          onPress: () => {
+            const newMode = inputMode === 'token' ? 'usd' : 'token';
+            setInputMode(newMode);
+            setIsUserTyping(false);
+
+            if (newMode === 'usd' && hasValidPrice && tokenAmount) {
+              const tokenBN = new BigNumber(tokenAmount);
+              if (tokenBN.isFinite()) {
+                const usdValue = formatWithPrecision(
+                  tokenBN.multipliedBy(priceBN),
+                  2,
+                  true,
+                );
+                setUsdAmount(usdValue);
+              }
+            }
+          },
+          disabled: !hasValidPrice,
+        },
+      ];
+    }, [inputMode, tokenInfo?.name, hasValidPrice, tokenAmount, priceBN]);
+
+    const displayValue = inputMode === 'token' ? tokenAmount : usdAmount;
+
     return (
       <TradingFormInput
-        value={value}
-        onChange={onChange}
+        value={displayValue}
+        onChange={handleInputChange}
         label={formatLabel}
         disabled={isDisabled}
         error={error}
         validator={validator}
-        suffix={tokenInfo?.name || ''}
+        actions={actions}
         isMobile={isMobile}
         placeholder={
           isMobile

--- a/packages/shared/src/utils/perpsUtils.ts
+++ b/packages/shared/src/utils/perpsUtils.ts
@@ -390,7 +390,8 @@ function validateSizeInput(input: string, szDecimals: number): boolean {
   if (szDecimals === 0) return /^[0-9]*$/.test(input);
   if (!/^[0-9]*\.?[0-9]*$/.test(input)) return false;
 
-  const [, dec = ''] = input.split('.');
+  const [integerPart, dec = ''] = input.split('.');
+  if (integerPart.length > 12) return false;
   return dec.length <= szDecimals;
 }
 


### PR DESCRIPTION
- Add token/USD input mode toggle in SizeInput component
- Implement real-time conversion between token and USD amounts
- Add integer length validation (max 12 digits) in perpsUtils
- Fix callback function in PositionsRow close position button
- Remove unused imports in PerpTradingForm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Size input now supports USD and token modes with a toggle, automatic conversion, formatting, and clearer unit labels.
  * Trading form shows position and available-to-trade values for the selected symbol with consistent formatting.

* Bug Fixes
  * Market close action no longer triggers during render — fires only on user press.
  * Size input validation strengthened: enforces token-specific decimals and caps integer part to 12 digits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->