### PR TITLE
feat: add method to retrieve persisted L2 book options, OK-43593, OK-43597, OK-43601

### DIFF
--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -6,7 +6,10 @@ import { ContextJotaiActionsBase } from '@onekeyhq/kit/src/states/jotai/utils/Co
 import { perpsSelectedAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { memoFn } from '@onekeyhq/shared/src/utils/cacheUtils';
 import type * as HL from '@onekeyhq/shared/types/hyperliquid/sdk';
-import type { IL2BookOptions } from '@onekeyhq/shared/types/hyperliquid/types';
+import type {
+  IL2BookOptions,
+  IPerpOrderBookTickOptionPersist,
+} from '@onekeyhq/shared/types/hyperliquid/types';
 
 import {
   activeAssetCtxAtom,
@@ -16,6 +19,7 @@ import {
   contextAtomMethod,
   currentTokenAtom,
   l2BookAtom,
+  orderBookTickOptionsAtom,
   subscriptionActiveAtom,
   tradingFormAtom,
   tradingLoadingAtom,
@@ -25,6 +29,8 @@ import {
 import type { ITradingFormData } from './atoms';
 
 class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
+  private orderBookTickOptionsLoaded = false;
+
   updateAllMids = contextAtomMethod((_, set, data: HL.IWsAllMids) => {
     set(allMidsAtom(), data);
   });
@@ -56,6 +62,55 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
   updateL2Book = contextAtomMethod((_, set, data: HL.IBook) => {
     set(l2BookAtom(), data);
   });
+
+  ensureOrderBookTickOptionsLoaded = contextAtomMethod(async (_get, set) => {
+    if (this.orderBookTickOptionsLoaded) return;
+    try {
+      const stored = await backgroundApiProxy.simpleDb.perp.getOrderBookTickOptions();
+      set(orderBookTickOptionsAtom(), stored);
+    } catch (error) {
+      console.error('Failed to load order book tick options:', error);
+    } finally {
+      this.orderBookTickOptionsLoaded = true;
+    }
+  });
+
+  setOrderBookTickOption = contextAtomMethod(
+    async (
+      get,
+      set,
+      payload:
+        | null
+        | {
+            symbol: string;
+            option: IPerpOrderBookTickOptionPersist | null;
+          },
+    ) => {
+      if (!payload?.symbol) return;
+      const { symbol, option } = payload;
+      const prev = get(orderBookTickOptionsAtom());
+      const next: Record<string, IPerpOrderBookTickOptionPersist> = {
+        ...prev,
+      };
+
+      if (!option) {
+        delete next[symbol];
+      } else {
+        next[symbol] = option;
+      }
+
+      set(orderBookTickOptionsAtom(), next);
+
+      try {
+        await backgroundApiProxy.simpleDb.perp.setOrderBookTickOption({
+          symbol,
+          option,
+        });
+      } catch (error) {
+        console.error('Failed to persist order book tick option:', error);
+      }
+    },
+  );
 
   updateConnectionState = contextAtomMethod(
     (
@@ -702,6 +757,9 @@ export function useHyperliquidActions() {
   const setPositionTpsl = actions.setPositionTpsl.use();
   const withdraw = actions.withdraw.use();
 
+  const ensureOrderBookTickOptionsLoaded = actions.ensureOrderBookTickOptionsLoaded.use();
+  const setOrderBookTickOption = actions.setOrderBookTickOption.use();
+
   return useRef({
     updateAllMids,
     updateWebData2,
@@ -732,5 +790,8 @@ export function useHyperliquidActions() {
     cancelOrder,
     setPositionTpsl,
     withdraw,
+
+    ensureOrderBookTickOptionsLoaded,
+    setOrderBookTickOption,
   });
 }

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -66,7 +66,8 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
   ensureOrderBookTickOptionsLoaded = contextAtomMethod(async (_get, set) => {
     if (this.orderBookTickOptionsLoaded) return;
     try {
-      const stored = await backgroundApiProxy.simpleDb.perp.getOrderBookTickOptions();
+      const stored =
+        await backgroundApiProxy.simpleDb.perp.getOrderBookTickOptions();
       set(orderBookTickOptionsAtom(), stored);
     } catch (error) {
       console.error('Failed to load order book tick options:', error);
@@ -75,16 +76,31 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     }
   });
 
+  getPersistedL2BookOptions = contextAtomMethod(
+    async (get, set, coin: string): Promise<IL2BookOptions | null> => {
+      await this.ensureOrderBookTickOptionsLoaded.call(set);
+      const persistedOptions = get(orderBookTickOptionsAtom());
+      const persistedForSymbol = persistedOptions?.[coin];
+      if (!persistedForSymbol) {
+        return null;
+      }
+      return {
+        nSigFigs: persistedForSymbol.nSigFigs ?? null,
+        ...(persistedForSymbol.mantissa != null
+          ? { mantissa: persistedForSymbol.mantissa }
+          : {}),
+      };
+    },
+  );
+
   setOrderBookTickOption = contextAtomMethod(
     async (
       get,
       set,
-      payload:
-        | null
-        | {
-            symbol: string;
-            option: IPerpOrderBookTickOptionPersist | null;
-          },
+      payload: null | {
+        symbol: string;
+        option: IPerpOrderBookTickOptionPersist | null;
+      },
     ) => {
       if (!payload?.symbol) return;
       const { symbol, option } = payload;
@@ -131,6 +147,8 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     const currentToken = get(currentTokenAtom());
     if (currentToken === coin) return;
 
+    const l2BookOptions = await this.getPersistedL2BookOptions.call(set, coin);
+
     const currentForm = get(tradingFormAtom());
     set(tradingFormAtom(), {
       ...currentForm,
@@ -142,7 +160,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     });
 
     set(currentTokenAtom(), coin);
-    await this.updateSubscriptions.call(set, { l2BookOptions: null });
+    await this.updateSubscriptions.call(set, { l2BookOptions });
   });
 
   updateSubscriptions = contextAtomMethod(
@@ -757,7 +775,8 @@ export function useHyperliquidActions() {
   const setPositionTpsl = actions.setPositionTpsl.use();
   const withdraw = actions.withdraw.use();
 
-  const ensureOrderBookTickOptionsLoaded = actions.ensureOrderBookTickOptionsLoaded.use();
+  const ensureOrderBookTickOptionsLoaded =
+    actions.ensureOrderBookTickOptionsLoaded.use();
   const setOrderBookTickOption = actions.setOrderBookTickOption.use();
 
   return useRef({

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/atoms.ts
@@ -10,6 +10,7 @@ import { PERPS_EMPTY_ADDRESS } from '@onekeyhq/shared/src/consts/perp';
 import type * as HL from '@onekeyhq/shared/types/hyperliquid/sdk';
 import type {
   IConnectionState,
+  IPerpOrderBookTickOptionPersist,
   ITokenListItem,
 } from '@onekeyhq/shared/types/hyperliquid/types';
 
@@ -52,6 +53,11 @@ export const {
   atom: hyperliquidStorageReadyAtom,
   use: useHyperliquidStorageReadyAtom,
 } = contextAtom<boolean>(false);
+
+export const {
+  atom: orderBookTickOptionsAtom,
+  use: useOrderBookTickOptionsAtom,
+} = contextAtom<Record<string, IPerpOrderBookTickOptionPersist>>({});
 
 const CURRTOKEN_INIT = Symbol('CURRTOKEN_INIT');
 export const currentTokenAtom = memoizee(() =>

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/index.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/index.ts
@@ -7,6 +7,7 @@ export {
   useActiveAssetDataAtom,
   useL2BookAtom,
   useConnectionStateAtom,
+  useOrderBookTickOptionsAtom,
 } from './atoms';
 
 export { useSubscriptionActiveAtom } from './atoms';

--- a/packages/kit/src/views/Perp/components/OrderBook/useTickOptions.ts
+++ b/packages/kit/src/views/Perp/components/OrderBook/useTickOptions.ts
@@ -1,12 +1,17 @@
-import { useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import BigNumber from 'bignumber.js';
 
+import {
+  useHyperliquidActions,
+  useOrderBookTickOptionsAtom,
+} from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
   analyzeOrderBookPrecision,
   getDisplayPriceScaleDecimals,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type { IBookLevel } from '@onekeyhq/shared/types/hyperliquid/sdk';
+import type { IPerpOrderBookTickOptionPersist } from '@onekeyhq/shared/types/hyperliquid/types';
 
 import {
   type ITickParam,
@@ -17,6 +22,8 @@ import {
 interface ITickOptionsResult {
   tickOptions: ITickParam[];
   defaultTickOption: ITickParam;
+  selectedTickOption: ITickParam;
+  setSelectedTickOption: (option: ITickParam) => void;
   priceDecimals: number;
   sizeDecimals: number;
 }
@@ -37,6 +44,13 @@ export function useTickOptions({
     defaultTickOption: ITickParam;
     priceDecimals: number;
   } | null>(null);
+
+  const [persistedTickOptions] = useOrderBookTickOptionsAtom();
+  const actions = useHyperliquidActions();
+
+  useEffect(() => {
+    void actions.current.ensureOrderBookTickOptionsLoaded();
+  }, [actions]);
 
   const topBidPrice = bids[0]?.px;
   const topAskPrice = asks[0]?.px;
@@ -86,7 +100,7 @@ export function useTickOptions({
     return calculatedSizeDecimals;
   }, [bids, asks]);
 
-  return useMemo(() => {
+  const baseTickOptionsData = useMemo(() => {
     // Fallback when no data available
     if (!tickOptionsData) {
       const priceDecimals = 0;
@@ -98,13 +112,97 @@ export function useTickOptions({
         tickOptions,
         defaultTickOption,
         priceDecimals,
-        sizeDecimals,
       };
     }
 
+    return tickOptionsData;
+  }, [tickOptionsData]);
+
+  const selectedTickOption = useMemo(() => {
+    const { tickOptions, defaultTickOption } = baseTickOptionsData;
+
+    if (!symbol) return defaultTickOption;
+
+    const saved = persistedTickOptions[symbol];
+    if (saved) {
+      const byValue = tickOptions.find(
+        (option) => option.value === saved.value,
+      );
+      if (byValue) return byValue;
+
+      const byParams = tickOptions.find(
+        (option) =>
+          option.nSigFigs === saved.nSigFigs &&
+          (option.nSigFigs === 5 ? option.mantissa === saved.mantissa : true),
+      );
+
+      if (byParams) {
+        return byParams;
+      }
+    }
+
+    return defaultTickOption;
+  }, [baseTickOptionsData, persistedTickOptions, symbol]);
+
+  useEffect(() => {
+    if (!symbol) return;
+
+    const persisted = persistedTickOptions[symbol];
+    const currentPersist: IPerpOrderBookTickOptionPersist = {
+      value: selectedTickOption.value,
+      nSigFigs: selectedTickOption.nSigFigs ?? null,
+      mantissa: selectedTickOption.mantissa ?? null,
+    };
+
+    if (
+      !persisted ||
+      persisted.value !== currentPersist.value ||
+      persisted.nSigFigs !== currentPersist.nSigFigs ||
+      persisted.mantissa !== currentPersist.mantissa
+    ) {
+      void actions.current.setOrderBookTickOption({
+        symbol,
+        option: currentPersist,
+      });
+    }
+  }, [symbol, persistedTickOptions, selectedTickOption, actions]);
+
+  const handleSelectTickOption = useCallback(
+    (option: ITickParam) => {
+      if (!symbol) return;
+      if (
+        option.value === selectedTickOption.value &&
+        option.nSigFigs === selectedTickOption.nSigFigs &&
+        option.mantissa === selectedTickOption.mantissa
+      ) {
+        return;
+      }
+
+      void actions.current.setOrderBookTickOption({
+        symbol,
+        option: {
+          value: option.value,
+          nSigFigs: option.nSigFigs ?? null,
+          mantissa: option.mantissa ?? null,
+        },
+      });
+    },
+    [actions, selectedTickOption, symbol],
+  );
+
+  return useMemo(() => {
     return {
-      ...tickOptionsData,
+      tickOptions: baseTickOptionsData.tickOptions,
+      defaultTickOption: baseTickOptionsData.defaultTickOption,
+      selectedTickOption,
+      setSelectedTickOption: handleSelectTickOption,
+      priceDecimals: baseTickOptionsData.priceDecimals,
       sizeDecimals,
     };
-  }, [tickOptionsData, sizeDecimals]);
+  }, [
+    baseTickOptionsData,
+    selectedTickOption,
+    handleSelectTickOption,
+    sizeDecimals,
+  ]);
 }

--- a/packages/kit/src/views/Perp/components/OrderBook/useTickOptions.ts
+++ b/packages/kit/src/views/Perp/components/OrderBook/useTickOptions.ts
@@ -58,15 +58,18 @@ export function useTickOptions({
   const tickOptionsData = useMemo(() => {
     if (!symbol) return null;
 
-    // Return cached result if symbol hasn't changed and cache exists
-    if (tickOptionsCache.current?.symbol === symbol) {
-      return tickOptionsCache.current;
-    }
-
     const marketPrice = topBidPrice || topAskPrice || '0';
     if (marketPrice === '0') return null;
 
     const priceDecimals = getDisplayPriceScaleDecimals(marketPrice);
+    const cached =
+      tickOptionsCache.current?.symbol === symbol
+        ? tickOptionsCache.current
+        : null;
+
+    if (cached && priceDecimals <= cached.priceDecimals) {
+      return cached;
+    }
 
     // Handle edge case: when priceDecimals = 0, use 1 as base decimal
     const decimalsArg =

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
@@ -195,7 +195,7 @@ export function CommonTableListView({
     }
   };
   const ListComponent = useTabsList ? Tabs.FlatList : ListView;
-  console.log('paginatedData--', paginatedData.length);
+  // console.log('paginatedData--', paginatedData.length);
   if (isMobile) {
     return (
       <ListComponent

--- a/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
+++ b/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
@@ -58,7 +58,7 @@ function MobilePerpMarket() {
         <YStack flex={1} bg="$bgApp" gap="$2.5">
           <MobilePerpMarketHeader />
 
-          <YStack flex={1} minHeight={364}>
+          <YStack flex={1} minHeight={450}>
             <PerpCandles />
           </YStack>
 

--- a/packages/shared/types/hyperliquid/types.ts
+++ b/packages/shared/types/hyperliquid/types.ts
@@ -150,6 +150,12 @@ export interface IL2BookOptions {
   mantissa?: 2 | 5 | null;
 }
 
+export interface IPerpOrderBookTickOptionPersist {
+  value: string;
+  nSigFigs: IL2BookOptions['nSigFigs'];
+  mantissa: IL2BookOptions['mantissa'];
+}
+
 export interface IPerpCommonConfig {
   disablePerp?: boolean;
   usePerpWeb?: boolean;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Per-symbol order book tick option selection for Perp markets is now saved and automatically restored across sessions.
  * Order book subscriptions adapt dynamically to your saved tick option for each symbol.

* Style
  * Increased the mobile market chart area height for improved readability.

* Chores
  * Removed a debug console log from the order info list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->