### PR TITLE
fix: swap toAmount slippage & perp some issue OK-43635 OK-43688 OK-43696 

### DIFF
--- a/packages/kit/src/states/jotai/contexts/swap/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/atoms.ts
@@ -248,8 +248,11 @@ export const {
     });
   }
   const receivedSorted = resetList.slice().sort((a, b) => {
-    const aVal = new BigNumber(a.toAmount || 0);
-    const bVal = new BigNumber(b.toAmount || 0);
+    // check toAmountSlippage
+    const aToAmountSlippage = new BigNumber(a.toAmountSlippage || 0).plus(1);
+    const bToAmountSlippage = new BigNumber(b.toAmountSlippage || 0).plus(1);
+    const aVal = new BigNumber(a.toAmount || 0).multipliedBy(aToAmountSlippage);
+    const bVal = new BigNumber(b.toAmount || 0).multipliedBy(bToAmountSlippage);
     // Check if limit exists for a and b
     const aHasLimit = !!a.limit;
     const bHasLimit = !!b.limit;

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
@@ -119,7 +119,12 @@ const TradesHistoryRow = memo(
             width="100%"
           >
             <YStack gap="$1">
-              <XStack gap="$2" cursor="pointer" alignItems="center">
+              <XStack
+                gap="$2"
+                cursor="pointer"
+                alignItems="center"
+                onPress={() => selectToken(assetSymbol)}
+              >
                 <SizableText size="$bodyMdMedium">{assetSymbol}</SizableText>
                 <SizableText
                   size="$bodySm"

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpTradersHistoryListModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpTradersHistoryListModal.tsx
@@ -1,5 +1,9 @@
+import { useIntl } from 'react-intl';
+
 import { Page } from '@onekeyhq/components';
 import { PageBody } from '@onekeyhq/components/src/layouts/Page/PageBody';
+import { PageHeader } from '@onekeyhq/components/src/layouts/Page/PageHeader';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { PerpsAccountSelectorProviderMirror } from '../../PerpsAccountSelectorProviderMirror';
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
@@ -7,8 +11,14 @@ import { PerpsProviderMirror } from '../../PerpsProviderMirror';
 import { PerpTradesHistoryList } from './List/PerpTradesHistoryList';
 
 export function PerpTradersHistoryListModal() {
+  const intl = useIntl();
   return (
     <Page>
+      <PageHeader
+        title={intl.formatMessage({
+          id: ETranslations.perp_trades_history_title,
+        })}
+      />
       <PageBody>
         <PerpTradesHistoryList isMobile />
       </PageBody>

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -518,6 +518,7 @@ export interface IFetchQuoteResult {
   kind?: ESwapQuoteKind;
   networkCostBuyAmount?: string;
   oneKeyFeeExtraInfo?: IOneKeyFeeInfo;
+  toAmountSlippage?: number;
   networkCostExceedInfo?: {
     tokenInfo: {
       symbol: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Swap: Quote list now sorts by expected received amount with slippage considered, giving more accurate rankings for real execution.
  - Perp: In mobile trade history, asset symbols are now tappable to quickly select the token, aligning behavior with desktop.
  - Perp: Traders History modal header is now localized, displaying a translated title based on your language settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->