### PR TITLE
OK-43692: add token selector functionality and improve header interaction in MobilePerpMarket

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderBook/index.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/index.tsx
@@ -14,6 +14,7 @@ import {
 } from 'react-native';
 
 import {
+  Haptics,
   Icon,
   Select,
   YStack,
@@ -438,6 +439,9 @@ export function OrderBook({
     (side: 'bid' | 'ask', item: IOBLevel, index: number) => {
       if (!onSelectLevel) {
         return;
+      }
+      if (platformEnv.isNative) {
+        Haptics.selection();
       }
       onSelectLevel({
         price: item.price,
@@ -903,6 +907,9 @@ export function OrderPairBook({
       if (!onSelectLevel) {
         return;
       }
+      if (platformEnv.isNative) {
+        Haptics.selection();
+      }
       onSelectLevel({
         price: item.price,
         size: item.size,
@@ -1130,6 +1137,9 @@ export function OrderBookMobile({
     (side: 'bid' | 'ask', item: IOBLevel, index: number) => {
       if (!onSelectLevel) {
         return;
+      }
+      if (platformEnv.isNative) {
+        Haptics.selection();
       }
       onSelectLevel({
         price: item.price,

--- a/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
+++ b/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
@@ -1,13 +1,16 @@
 import { useCallback, useEffect } from 'react';
 
-import { Page, SizableText, XStack, YStack } from '@onekeyhq/components';
+import { Icon, Page, SizableText, XStack, YStack } from '@onekeyhq/components';
 import { usePerpsSelectedSymbolAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
   EAppEventBusNames,
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
+import { EModalRoutes } from '@onekeyhq/shared/src/routes';
+import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
 
 import { Token } from '../../../components/Token';
+import useAppNavigation from '../../../hooks/useAppNavigation';
 import { useThemeVariant } from '../../../hooks/useThemeVariant';
 import { useHyperliquidActions } from '../../../states/jotai/contexts/hyperliquid';
 import { PerpCandles } from '../components/PerpCandles';
@@ -22,13 +25,27 @@ function MobilePerpMarket() {
   const [currentToken] = usePerpsSelectedSymbolAtom();
   const { coin } = currentToken;
   const themeVariant = useThemeVariant();
+  const navigation = useAppNavigation();
   const longButtonStyle = getTradingButtonStyleProps('long');
   const shortButtonStyle = getTradingButtonStyleProps('short');
+
+  const onPressTokenSelector = useCallback(() => {
+    navigation.pushModal(EModalRoutes.PerpModal, {
+      screen: EModalPerpRoutes.MobileTokenSelector,
+    });
+  }, [navigation]);
 
   const renderHeaderTitle = useCallback(() => {
     const pairLabel = coin ? `${coin} - USD` : '--';
     return (
-      <XStack alignItems="center" gap="$2">
+      <XStack
+        alignItems="center"
+        gap="$2"
+        onPress={onPressTokenSelector}
+        cursor="pointer"
+        hoverStyle={{ opacity: 0.8 }}
+        pressStyle={{ opacity: 0.6 }}
+      >
         <Token
           size="sm"
           borderRadius="$full"
@@ -39,9 +56,10 @@ function MobilePerpMarket() {
           fallbackIcon="CryptoCoinOutline"
         />
         <SizableText size="$headingLg">{pairLabel}</SizableText>
+        <Icon name="ChevronDownSmallOutline" size="$4" color="$iconSubdued" />
       </XStack>
     );
-  }, [coin, themeVariant]);
+  }, [coin, themeVariant, onPressTokenSelector]);
 
   useEffect(() => {
     appEventBus.emit(EAppEventBusNames.HideTabBar, true);

--- a/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
+++ b/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
@@ -1,6 +1,13 @@
 import { useCallback, useEffect } from 'react';
 
-import { Icon, Page, SizableText, XStack, YStack } from '@onekeyhq/components';
+import {
+  Icon,
+  NavBackButton,
+  Page,
+  SizableText,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import { usePerpsSelectedSymbolAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
   EAppEventBusNames,
@@ -35,31 +42,42 @@ function MobilePerpMarket() {
     });
   }, [navigation]);
 
+  const onPageGoBack = useCallback(() => {
+    navigation.pop();
+  }, [navigation]);
+
   const renderHeaderTitle = useCallback(() => {
     const pairLabel = coin ? `${coin} - USD` : '--';
     return (
-      <XStack
-        alignItems="center"
-        gap="$2"
-        onPress={onPressTokenSelector}
-        cursor="pointer"
-        hoverStyle={{ opacity: 0.8 }}
-        pressStyle={{ opacity: 0.6 }}
-      >
-        <Token
-          size="sm"
-          borderRadius="$full"
-          bg={themeVariant === 'light' ? undefined : '$bgInverse'}
-          tokenImageUri={
-            coin ? `https://app.hyperliquid.xyz/coins/${coin}.svg` : undefined
-          }
-          fallbackIcon="CryptoCoinOutline"
+      <XStack alignItems="center" gap="$2">
+        <NavBackButton
+          hoverStyle={{ opacity: 0.8 }}
+          pressStyle={{ opacity: 0.6 }}
+          onPress={onPageGoBack}
         />
-        <SizableText size="$headingLg">{pairLabel}</SizableText>
-        <Icon name="ChevronDownSmallOutline" size="$4" color="$iconSubdued" />
+        <XStack
+          alignItems="center"
+          gap="$2"
+          onPress={onPressTokenSelector}
+          cursor="pointer"
+          hoverStyle={{ opacity: 0.8 }}
+          pressStyle={{ opacity: 0.6 }}
+        >
+          <Token
+            size="sm"
+            borderRadius="$full"
+            bg={themeVariant === 'light' ? undefined : '$bgInverse'}
+            tokenImageUri={
+              coin ? `https://app.hyperliquid.xyz/coins/${coin}.svg` : undefined
+            }
+            fallbackIcon="CryptoCoinOutline"
+          />
+          <SizableText size="$headingLg">{pairLabel}</SizableText>
+          <Icon name="ChevronDownSmallOutline" size="$4" color="$iconSubdued" />
+        </XStack>
       </XStack>
     );
-  }, [coin, themeVariant, onPressTokenSelector]);
+  }, [coin, themeVariant, onPressTokenSelector, onPageGoBack]);
 
   useEffect(() => {
     appEventBus.emit(EAppEventBusNames.HideTabBar, true);
@@ -71,7 +89,7 @@ function MobilePerpMarket() {
 
   return (
     <Page scrollEnabled>
-      <Page.Header headerTitle={renderHeaderTitle} />
+      <Page.Header headerLeft={renderHeaderTitle} />
       <Page.Body px="$0" py="$0">
         <YStack flex={1} bg="$bgApp" gap="$2.5">
           <MobilePerpMarketHeader />

--- a/packages/kit/src/views/Perp/pages/Perp.tsx
+++ b/packages/kit/src/views/Perp/pages/Perp.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { useFocusEffect } from '@react-navigation/native';
 import { useIntl } from 'react-intl';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Native haptic feedback when selecting levels in order books on mobile.
  - Mobile market header now includes a back button and a tappable token/pair area that opens a token selector modal.

- Refactor
  - Header composition moved from a title to an interactive left section; navigation flow adjusted for modal-based selection.

- Chores
  - Removed an unused import with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->