### PR TITLE
refactor: disable JSBundle entry point

### DIFF
--- a/apps/desktop/app/bundle.ts
+++ b/apps/desktop/app/bundle.ts
@@ -100,22 +100,23 @@ export const getBundleIndexHtmlPath = ({
   appVersion: string;
   bundleVersion: string;
 }) => {
-  if (!appVersion || !bundleVersion) {
-    return undefined;
-  }
-  if (semver.lt(platformEnv.version || '1.0.0', appVersion)) {
-    return undefined;
-  }
-  const extractDir = getBundleExtractDir({
-    appVersion: platformEnv.version || '1.0.0',
-    bundleVersion: bundleVersion || '1',
-  });
-  if (!fs.existsSync(extractDir)) {
-    return undefined;
-  }
-  const indexHtmlPath = path.join(extractDir, 'build', 'index.html');
-  logger.info('bundle-download-getBundleIndexHtmlPath', indexHtmlPath);
-  return fs.existsSync(indexHtmlPath) ? indexHtmlPath : undefined;
+  return undefined;
+  // if (!appVersion || !bundleVersion) {
+  //   return undefined;
+  // }
+  // if (semver.lt(platformEnv.version || '1.0.0', appVersion)) {
+  //   return undefined;
+  // }
+  // const extractDir = getBundleExtractDir({
+  //   appVersion: platformEnv.version || '1.0.0',
+  //   bundleVersion: bundleVersion || '1',
+  // });
+  // if (!fs.existsSync(extractDir)) {
+  //   return undefined;
+  // }
+  // const indexHtmlPath = path.join(extractDir, 'build', 'index.html');
+  // logger.info('bundle-download-getBundleIndexHtmlPath', indexHtmlPath);
+  // return fs.existsSync(indexHtmlPath) ? indexHtmlPath : undefined;
 };
 
 export const checkFileSha512 = (filePath: string, sha512: string) => {

--- a/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/CustomReactNativeHost.java
+++ b/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/CustomReactNativeHost.java
@@ -21,13 +21,13 @@ public abstract class CustomReactNativeHost extends DefaultReactNativeHost {
     @Override
     public String getJSBundleFile() {
         // Check for updated bundle first
-        String bundlePath = BundleUpdateModule.getCurrentBundleMainJSBundle(context);
-        if (bundlePath != null) {
-            File bundleFile = new File(bundlePath);
-            if (bundleFile.exists()) {
-                return bundlePath;
-            }
-        }
+        // String bundlePath = BundleUpdateModule.getCurrentBundleMainJSBundle(context);
+        // if (bundlePath != null) {
+        //     File bundleFile = new File(bundlePath);
+        //     if (bundleFile.exists()) {
+        //         return bundlePath;
+        //     }
+        // }
         
         // Fallback to default bundle
         return super.getJSBundleFile();

--- a/apps/mobile/ios/AppDelegate.swift
+++ b/apps/mobile/ios/AppDelegate.swift
@@ -88,11 +88,11 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
     return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
 #else
     // Check for updated bundle in Documents directory first
-    let bundlePath = BundleUpdateModule.currentBundleMainJSBundle()
+    // let bundlePath = BundleUpdateModule.currentBundleMainJSBundle()
 
-    if bundlePath != nil {
-      return URL(string: bundlePath!)
-    }
+    // if bundlePath != nil {
+    //   return URL(string: bundlePath!)
+    // }
 
     // Fallback to main bundle
     return Bundle.main.url(forResource: "main", withExtension: "jsbundle")

--- a/packages/kit/src/views/AppUpdate/pages/DownloadVerify.tsx
+++ b/packages/kit/src/views/AppUpdate/pages/DownloadVerify.tsx
@@ -167,7 +167,7 @@ function DownloadVerify({
             title={intl.formatMessage({
               id: ETranslations.update_download_package_label,
             })}
-            badgeText={Number(percent) !== 0 ? `${percent}%` : undefined}
+            badgeText={Number(percent) > 0 ? `${percent}%` : undefined}
             renderDescription={({ status }) => {
               if (status === EStepItemStatus.Failed) {
                 return renderDownloadError();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Revert
  - App now always uses the built-in JavaScript bundle on desktop, Android, and iOS. Over-the-air/dynamic bundle loading has been disabled.

- Bug Fixes
  - Update screen progress badge now displays a percentage only when greater than 0, preventing 0% or invalid values from appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->