### PR TITLE
fix: receive banner styles

### DIFF
--- a/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
+++ b/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
@@ -711,28 +711,31 @@ function ReceiveToken() {
             bg={networkLogoColor ? `${networkLogoColor}0D` : '$bgSubdued'}
             borderRadius="$2"
             borderCurve="continuous"
-            {...{
-              userSelect: 'none',
-              focusable: true,
-              focusVisibleStyle: {
-                outlineColor: '$focusRing',
-                outlineWidth: 2,
-                outlineStyle: 'solid',
-                outlineOffset: 0,
-              },
-              hoverStyle: {
-                bg: networkLogoColor ? `${networkLogoColor}1A` : '$bgHover',
-              },
-              pressStyle: {
-                bg: networkLogoColor ? `${networkLogoColor}2A` : '$bgActive',
-              },
-              onPress: banner?.href
-                ? () => handleBannerOnPress(banner)
-                : undefined,
-            }}
+            {...(banner?.href
+              ? {
+                  userSelect: 'none',
+                  focusable: true,
+                  focusVisibleStyle: {
+                    outlineColor: '$focusRing',
+                    outlineWidth: 2,
+                    outlineStyle: 'solid',
+                    outlineOffset: 0,
+                  },
+                  hoverStyle: {
+                    bg: networkLogoColor ? `${networkLogoColor}1A` : '$bgHover',
+                  },
+                  pressStyle: {
+                    bg: networkLogoColor
+                      ? `${networkLogoColor}2A`
+                      : '$bgActive',
+                  },
+                  onPress: () => handleBannerOnPress(banner),
+                }
+              : null)}
           >
             <Image
               size="$5"
+              source={{ uri: banner.src }}
               fallback={<NetworkAvatar size="$5" networkId={networkId} />}
             />
             <SizableText size="$bodyMd">{banner.title}</SizableText>

--- a/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
+++ b/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
@@ -711,9 +711,9 @@ function ReceiveToken() {
             bg={networkLogoColor ? `${networkLogoColor}0D` : '$bgSubdued'}
             borderRadius="$2"
             borderCurve="continuous"
+            userSelect="none"
             {...(banner?.href
               ? {
-                  userSelect: 'none',
                   focusable: true,
                   focusVisibleStyle: {
                     outlineColor: '$focusRing',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Receive Token banner now behaves as a link only when a destination is available, preventing accidental taps/clicks on non-interactive banners.
  * Ensures the banner image displays consistently.

* **Refactor**
  * Streamlined banner interaction logic for clearer, more predictable behavior.
  * Improved focus, hover, and press feedback when the banner is clickable.
  * Disabled text selection on the banner to avoid accidental highlighting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->