### PR TITLE
fix: remove duplicate order counts(OK-43806)

### DIFF
--- a/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/index.tsx
@@ -94,7 +94,7 @@ export default function HardwareSalesReward() {
         if (salesResult.status === 'fulfilled') {
           const data = salesResult.value;
           setSections(formatSections(data.items));
-          originalData.current.push(...data.items);
+          originalData.current = data.items;
         }
 
         if (summaryResult.status === 'fulfilled') {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Refreshing the Hardware Sales Rewards list now shows the latest sales only, eliminating duplicated or outdated entries.
  - Section counts and ordering update correctly after a refresh.

- Improvements
  - More consistent behavior between “Refresh” and “Load more,” with predictable list updates as new data arrives.
  - Clearer, cleaner presentation of sales items after refreshing, improving readability and confidence in the displayed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->