### PR TITLE
Fix/perp mobial list issue OK-43632 OK-43654 OK-43660 OK-43662 OK-43662 OK-43689 OK-43712 OK-43739 OK-43782 OK-43797 

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
@@ -126,14 +126,14 @@ const PositionRow = memo(
       const fundingAllTimeBN = new BigNumber(pos.cumFunding.allTime);
       const fundingSinceOpenBN = new BigNumber(pos.cumFunding.sinceOpen);
       const fundingSinceChangeBN = new BigNumber(pos.cumFunding.sinceChange);
-      const fundingAllPlusOrMinus = fundingAllTimeBN.gt(0) ? '-' : '';
-      const fundingSinceOpenPlusOrMinus = fundingSinceOpenBN.gt(0) ? '-' : '';
+      const fundingAllPlusOrMinus = fundingAllTimeBN.gt(0) ? '-' : '+';
+      const fundingSinceOpenPlusOrMinus = fundingSinceOpenBN.gt(0) ? '-' : '+';
       const fundingSinceOpenColor = fundingSinceOpenBN.gt(0)
         ? '$textCritical'
         : '$textSuccess';
       const fundingSinceChangePlusOrMinus = fundingSinceChangeBN.gt(0)
         ? '-'
-        : '';
+        : '+';
       const fundingAllTimeFormatted = fundingAllTimeBN.abs().toFixed(2);
       const fundingSinceOpenFormatted = fundingSinceOpenBN.abs().toFixed(2);
       const fundingSinceChangeFormatted = fundingSinceChangeBN.abs().toFixed(2);
@@ -200,7 +200,12 @@ const PositionRow = memo(
           flexDirection="column"
           alignItems="flex-start"
         >
-          <XStack gap="$2" alignItems="center">
+          <XStack
+            gap="$2"
+            alignItems="center"
+            cursor="pointer"
+            onPress={() => selectToken(assetInfo.assetSymbol)}
+          >
             <XStack
               w="$4"
               h="$4"
@@ -208,8 +213,6 @@ const PositionRow = memo(
               alignItems="center"
               borderRadius="$1"
               backgroundColor={assetInfo.assetColor}
-              cursor="pointer"
-              onPress={() => selectToken(assetInfo.assetSymbol)}
             >
               <SizableText size="$bodySmMedium" color="$textOnColor">
                 {side === 'long' ? 'B' : 'S'}
@@ -294,7 +297,7 @@ const PositionRow = memo(
                     size="$bodySmMedium"
                     color={otherInfo.fundingSinceOpenColor}
                   >
-                    {`${otherInfo.fundingSinceOpenPlusOrMinus}${otherInfo.fundingSinceOpenFormatted}`}
+                    {`${otherInfo.fundingSinceOpenPlusOrMinus}$${otherInfo.fundingSinceOpenFormatted}`}
                   </SizableText>
                 }
                 renderContent={
@@ -303,12 +306,12 @@ const PositionRow = memo(
                       id: ETranslations.perp_position_funding_all_time,
                     })}
                     {': '}
-                    {`${otherInfo.fundingAllPlusOrMinus}${otherInfo.fundingAllTimeFormatted}`}
+                    {`${otherInfo.fundingAllPlusOrMinus}$${otherInfo.fundingAllTimeFormatted}`}
                     {intl.formatMessage({
                       id: ETranslations.perp_position_funding_since_change,
                     })}
                     {': '}
-                    {`${otherInfo.fundingSinceChangePlusOrMinus}${otherInfo.fundingSinceChangeFormatted}`}
+                    {`${otherInfo.fundingSinceChangePlusOrMinus}$${otherInfo.fundingSinceChangeFormatted}`}
                   </SizableText>
                 }
               />
@@ -517,7 +520,7 @@ const PositionRow = memo(
                 ellipsizeMode="tail"
                 size="$bodySm"
                 color={otherInfo.fundingSinceOpenColor}
-              >{`${otherInfo.fundingSinceOpenPlusOrMinus}${otherInfo.fundingSinceOpenFormatted}`}</SizableText>
+              >{`${otherInfo.fundingSinceOpenPlusOrMinus}$${otherInfo.fundingSinceOpenFormatted}`}</SizableText>
             }
             renderContent={
               <SizableText size="$bodySm">
@@ -525,12 +528,12 @@ const PositionRow = memo(
                   id: ETranslations.perp_position_funding_all_time,
                 })}
                 {': '}
-                {`${otherInfo.fundingAllPlusOrMinus}${otherInfo.fundingAllTimeFormatted}`}{' '}
+                {`${otherInfo.fundingAllPlusOrMinus}$${otherInfo.fundingAllTimeFormatted}`}{' '}
                 {intl.formatMessage({
                   id: ETranslations.perp_position_funding_since_change,
                 })}
                 {': '}
-                {`${otherInfo.fundingSinceChangePlusOrMinus}${otherInfo.fundingSinceChangeFormatted}`}
+                {`${otherInfo.fundingSinceChangePlusOrMinus}$${otherInfo.fundingSinceChangeFormatted}`}
               </SizableText>
             }
           />

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
@@ -119,12 +119,7 @@ const TradesHistoryRow = memo(
             width="100%"
           >
             <YStack gap="$1">
-              <XStack
-                gap="$2"
-                cursor="pointer"
-                alignItems="center"
-                onPress={() => selectToken(assetSymbol)}
-              >
+              <XStack gap="$2" alignItems="center">
                 <SizableText size="$bodyMdMedium">{assetSymbol}</SizableText>
                 <SizableText
                   size="$bodySm"

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
@@ -1,20 +1,86 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { ReactElement } from 'react';
 
+import { useIntl } from 'react-intl';
+import { InputAccessoryView, Keyboard } from 'react-native';
+
 import {
+  Button,
   IconButton,
   Input,
   ListView,
   ScrollView,
   SizableText,
+  Skeleton,
+  Stack,
   Tabs,
   Tooltip,
   XStack,
   YStack,
+  useIsKeyboardShown,
 } from '@onekeyhq/components';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { calcCellAlign, getColumnStyle } from '../utils';
 
+const TradesHistoryLoadingView = () => {
+  return (
+    <Stack
+      flex={1}
+      alignItems="flex-start"
+      justifyContent="center"
+      p="$6"
+      gap="$2"
+    >
+      <Skeleton h="$8" w="$40" />
+      <Skeleton h="$6" w="$24" />
+      <Skeleton h="$4" w="$16" />
+    </Stack>
+  );
+};
+
+const PaginationInputAccessoryViewID = 'pagination-input-accessory-view';
+
+const PaginationPercentageStageOnKeyboard = ({
+  inputAmount,
+  totalAmount,
+  onDone,
+}: {
+  inputAmount: string;
+  totalAmount: string;
+  onDone: () => void;
+}) => {
+  const intl = useIntl();
+  const isShow = useIsKeyboardShown();
+  let viewShow = platformEnv.isNativeIOS;
+  if (!platformEnv.isNativeIOS) {
+    viewShow = isShow;
+  }
+  return viewShow ? (
+    <XStack
+      p="$2.5"
+      px="$3.5"
+      justifyContent="space-between"
+      bg="$bgSubdued"
+      borderTopWidth="$px"
+      borderTopColor="$borderSubduedLight"
+    >
+      <SizableText size="$bodyLg" color="$textSubdued">
+        {inputAmount} / {totalAmount}
+      </SizableText>
+      <Button
+        variant="tertiary"
+        onPress={() => {
+          Keyboard.dismiss();
+          onDone();
+        }}
+      >
+        {intl.formatMessage({ id: ETranslations.global_done })}
+      </Button>
+    </XStack>
+  ) : null;
+};
 const PaginationFooter = ({
   currentPage,
   totalPages,
@@ -54,7 +120,7 @@ const PaginationFooter = ({
   };
 
   const handleInputBlur = () => {
-    setInputValue(currentPage.toString());
+    handleInputSubmit();
   };
 
   if (totalPages <= 1) return null;
@@ -82,6 +148,7 @@ const PaginationFooter = ({
         <XStack w={isMobile ? 40 : undefined}>
           <Input
             value={inputValue}
+            inputAccessoryViewID={PaginationInputAccessoryViewID}
             onChangeText={handleInputChange}
             onSubmitEditing={handleInputSubmit}
             onBlur={handleInputBlur}
@@ -112,6 +179,15 @@ const PaginationFooter = ({
         onPress={onNextPage}
         icon="ChevronRightOutline"
       />
+      {platformEnv.isNativeIOS ? (
+        <InputAccessoryView nativeID={PaginationInputAccessoryViewID}>
+          <PaginationPercentageStageOnKeyboard
+            inputAmount={inputValue}
+            totalAmount={totalPages.toString()}
+            onDone={handleInputSubmit}
+          />
+        </InputAccessoryView>
+      ) : null}
     </XStack>
   );
 };
@@ -145,6 +221,8 @@ export interface ICommonTableListViewProps {
   currentListPage?: number;
   setCurrentListPage?: (page: number) => void;
   useTabsList?: boolean;
+  listLoading?: boolean;
+  paginationToBottom?: boolean;
 }
 
 export function CommonTableListView({
@@ -153,7 +231,9 @@ export function CommonTableListView({
   useTabsList,
   renderRow,
   currentListPage,
+  listLoading,
   setCurrentListPage,
+  paginationToBottom,
   isMobile,
   emptyMessage = 'No data',
   emptySubMessage = 'Data will appear here',
@@ -199,13 +279,15 @@ export function CommonTableListView({
     }
   };
   const ListComponent = useTabsList ? Tabs.FlatList : ListView;
-  // console.log('paginatedData--', paginatedData.length);
   if (isMobile) {
-    return (
+    const ListContent = (
       <ListComponent
         data={paginatedData}
         ListFooterComponent={
-          enablePagination && currentListPage && totalPages > 1 ? (
+          enablePagination &&
+          currentListPage &&
+          totalPages > 1 &&
+          !paginationToBottom ? (
             <PaginationFooter
               isMobile={isMobile}
               currentPage={currentListPage}
@@ -222,26 +304,52 @@ export function CommonTableListView({
           return renderRow(item, index);
         }}
         ListEmptyComponent={
-          <YStack flex={1} alignItems="center" p="$6">
-            <SizableText size="$bodyMd" color="$textSubdued" textAlign="center">
-              {emptyMessage}
-            </SizableText>
-            <SizableText
-              size="$bodySm"
-              color="$textSubdued"
-              textAlign="center"
-              mt="$2"
-            >
-              {emptySubMessage}
-            </SizableText>
-          </YStack>
+          listLoading ? (
+            <TradesHistoryLoadingView />
+          ) : (
+            <YStack flex={1} alignItems="center" p="$6">
+              <SizableText
+                size="$bodyMd"
+                color="$textSubdued"
+                textAlign="center"
+              >
+                {emptyMessage}
+              </SizableText>
+              <SizableText
+                size="$bodySm"
+                color="$textSubdued"
+                textAlign="center"
+                mt="$2"
+              >
+                {emptySubMessage}
+              </SizableText>
+            </YStack>
+          )
         }
         contentContainerStyle={{
           paddingBottom: enablePagination && totalPages > 1 ? 0 : 16,
-          minHeight: 0,
+          minHeight: 200,
         }}
       />
     );
+    if (paginationToBottom && currentListPage && totalPages > 1) {
+      return (
+        <YStack flex={1}>
+          {ListContent}
+          <PaginationFooter
+            isMobile={isMobile}
+            currentPage={currentListPage}
+            totalPages={totalPages}
+            onPreviousPage={handlePreviousPage}
+            onNextPage={handleNextPage}
+            onPageChange={handlePageChange}
+            headerBgColor={headerBgColor}
+            headerTextColor={headerTextColor}
+          />
+        </YStack>
+      );
+    }
+    return ListContent;
   }
 
   return (
@@ -343,24 +451,66 @@ export function CommonTableListView({
                 return renderRow(item, index);
               }}
               ListEmptyComponent={
-                <YStack
-                  flex={1}
-                  justifyContent="flex-start"
-                  alignItems="flex-start"
-                  p="$5"
-                >
-                  <SizableText size="$bodyMd" color="$text" textAlign="center">
-                    {emptyMessage}
-                  </SizableText>
-                  <SizableText
-                    size="$bodySm"
-                    color="$textSubdued"
-                    textAlign="center"
-                    mt="$2"
+                listLoading ? (
+                  <YStack
+                    flex={1}
+                    justifyContent="flex-start"
+                    alignItems="flex-start"
+                    p="$5"
+                    gap="$3"
                   >
-                    {emptySubMessage}
-                  </SizableText>
-                </YStack>
+                    {[...Array(5)].map((_, index) => (
+                      <XStack
+                        key={index}
+                        flex={1}
+                        py="$1.5"
+                        px="$3"
+                        alignItems="center"
+                        minWidth={minTableWidth}
+                        {...(index % 2 === 1 && {
+                          backgroundColor: '$bgSubdued',
+                        })}
+                      >
+                        {columns.map((column, colIndex) => (
+                          <XStack
+                            key={column.key}
+                            {...getColumnStyle(column)}
+                            justifyContent={calcCellAlign(column.align) as any}
+                            alignItems="center"
+                            {...(colIndex === 0 && {
+                              pl: '$2',
+                            })}
+                          >
+                            <Skeleton h="$3" w="$16" />
+                          </XStack>
+                        ))}
+                      </XStack>
+                    ))}
+                  </YStack>
+                ) : (
+                  <YStack
+                    flex={1}
+                    justifyContent="flex-start"
+                    alignItems="flex-start"
+                    p="$5"
+                  >
+                    <SizableText
+                      size="$bodyMd"
+                      color="$text"
+                      textAlign="center"
+                    >
+                      {emptyMessage}
+                    </SizableText>
+                    <SizableText
+                      size="$bodySm"
+                      color="$textSubdued"
+                      textAlign="center"
+                      mt="$2"
+                    >
+                      {emptySubMessage}
+                    </SizableText>
+                  </YStack>
+                )
               }
               contentContainerStyle={{
                 paddingBottom: enablePagination && totalPages > 1 ? 0 : 16,

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
@@ -328,7 +328,6 @@ export function CommonTableListView({
         }
         contentContainerStyle={{
           paddingBottom: enablePagination && totalPages > 1 ? 0 : 16,
-          minHeight: 200,
         }}
       />
     );

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpOpenOrdersList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpOpenOrdersList.tsx
@@ -185,7 +185,7 @@ function PerpOpenOrdersList({ isMobile }: IPerpOpenOrdersListProps) {
   return (
     <CommonTableListView
       useTabsList
-      enablePagination
+      enablePagination={!isMobile}
       currentListPage={currentListPage}
       setCurrentListPage={setCurrentListPage}
       columns={columnsConfig}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpPositionsList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpPositionsList.tsx
@@ -245,7 +245,7 @@ function PerpPositionsList({
       useTabsList
       currentListPage={currentListPage}
       setCurrentListPage={setCurrentListPage}
-      enablePagination
+      enablePagination={!isMobile}
       columns={columnsConfig}
       minTableWidth={totalMinWidth}
       data={positionSort}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTradesHistoryList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTradesHistoryList.tsx
@@ -20,7 +20,7 @@ function PerpTradesHistoryList({
   useTabsList,
 }: IPerpTradesHistoryListProps) {
   const intl = useIntl();
-  const { trades, currentListPage, setCurrentListPage } =
+  const { trades, currentListPage, setCurrentListPage, isLoading } =
     usePerpTradesHistory();
   const columnsConfig: IColumnConfig[] = useMemo(
     () => [
@@ -132,6 +132,8 @@ function PerpTradesHistoryList({
         id: ETranslations.perp_trade_history_empty_desc,
       })}
       enablePagination
+      paginationToBottom={isMobile}
+      listLoading={isLoading}
     />
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added loading skeleton and iOS keyboard input accessory for pagination.
  - Enabled bottom pagination on mobile in Trades History.
  - Funding displays now include explicit +/− signs and a $ prefix.
  - Made token rows in Positions clickable to select assets (desktop and mobile).

- Refactor
  - Disabled pagination on mobile for Open Orders and Positions.
  - Trades History: moved pagination to bottom on mobile.
  - Removed tap-to-select on the asset symbol row in mobile Trades History.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->