### PR TITLE
OK-43538: add perps settings dialog

### DIFF
--- a/packages/kit/src/components/TabPageHeader/HeaderRight.tsx
+++ b/packages/kit/src/components/TabPageHeader/HeaderRight.tsx
@@ -168,7 +168,7 @@ function DepositAction() {
           size="$bodySmMedium"
           color="$textSubdued"
         >
-          {intl.formatMessage({ id: ETranslations.earn_deposit })}
+          {intl.formatMessage({ id: ETranslations.perp_trade_deposit })}
         </SizableText>
       </XStack>
     </Button>

--- a/packages/kit/src/views/Perp/components/PerpSettingsButton.tsx
+++ b/packages/kit/src/views/Perp/components/PerpSettingsButton.tsx
@@ -1,0 +1,34 @@
+import { useCallback } from 'react';
+
+import { IconButton } from '@onekeyhq/components';
+import type { IIconButtonProps } from '@onekeyhq/components/src/actions/IconButton';
+import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { EModalRoutes } from '@onekeyhq/shared/src/routes';
+import { EModalSettingRoutes } from '@onekeyhq/shared/src/routes/setting';
+
+type IPerpSettingsButtonProps = Omit<IIconButtonProps, 'icon' | 'onPress'>;
+
+export function PerpSettingsButton({
+  size = 'small',
+  variant = 'tertiary',
+  ...rest
+}: IPerpSettingsButtonProps) {
+  const navigation = useAppNavigation();
+
+  const handlePress = useCallback(() => {
+    navigation.pushModal(EModalRoutes.SettingModal, {
+      screen: EModalSettingRoutes.SettingPerpUserConfig,
+    });
+  }, [navigation]);
+
+  return (
+    <IconButton
+      icon="SettingsOutline"
+      size={size}
+      variant={variant}
+      iconColor="$iconSubdued"
+      onPress={handlePress}
+      {...rest}
+    />
+  );
+}

--- a/packages/kit/src/views/Perp/components/PerpSettingsButton.tsx
+++ b/packages/kit/src/views/Perp/components/PerpSettingsButton.tsx
@@ -2,9 +2,8 @@ import { useCallback } from 'react';
 
 import { IconButton } from '@onekeyhq/components';
 import type { IIconButtonProps } from '@onekeyhq/components/src/actions/IconButton';
-import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
-import { EModalRoutes } from '@onekeyhq/shared/src/routes';
-import { EModalSettingRoutes } from '@onekeyhq/shared/src/routes/setting';
+
+import { showPerpSettingsDialog } from './PerpSettingsDialog';
 
 type IPerpSettingsButtonProps = Omit<IIconButtonProps, 'icon' | 'onPress'>;
 
@@ -13,13 +12,9 @@ export function PerpSettingsButton({
   variant = 'tertiary',
   ...rest
 }: IPerpSettingsButtonProps) {
-  const navigation = useAppNavigation();
-
   const handlePress = useCallback(() => {
-    navigation.pushModal(EModalRoutes.SettingModal, {
-      screen: EModalSettingRoutes.SettingPerpUserConfig,
-    });
-  }, [navigation]);
+    showPerpSettingsDialog();
+  }, []);
 
   return (
     <IconButton

--- a/packages/kit/src/views/Perp/components/PerpSettingsDialog.tsx
+++ b/packages/kit/src/views/Perp/components/PerpSettingsDialog.tsx
@@ -1,0 +1,57 @@
+import { Dialog, Switch, YStack } from '@onekeyhq/components';
+import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
+import { usePerpsCustomSettingsAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
+
+import { PerpsProviderMirror } from '../PerpsProviderMirror';
+
+interface IPerpSettingsDialogContentProps {
+  close: () => void;
+}
+
+function PerpSettingsDialogContent(_: IPerpSettingsDialogContentProps) {
+  const [perpsCustomSettings, setPerpsCustomSettings] =
+    usePerpsCustomSettingsAtom();
+
+  return (
+    <YStack gap="$5">
+      <ListItem
+        mx="$0"
+        p="$0"
+        title="Skip Order Confirmation"
+        subtitle="Submits orders directly without confirmation when enabled"
+      >
+        <Switch
+          value={perpsCustomSettings.skipOrderConfirm}
+          onChange={(value) => {
+            setPerpsCustomSettings((prev) => ({
+              ...prev,
+              skipOrderConfirm: value,
+            }));
+          }}
+        />
+      </ListItem>
+    </YStack>
+  );
+}
+
+export function showPerpSettingsDialog() {
+  const dialog = Dialog.show({
+    title: appLocale.intl.formatMessage({ id: ETranslations.global_settings }),
+    renderContent: (
+      <PerpsProviderMirror>
+        <PerpSettingsDialogContent
+          close={() => {
+            void dialog.close();
+          }}
+        />
+      </PerpsProviderMirror>
+    ),
+    showFooter: true,
+    showCancelButton: false,
+    onConfirmText: 'Confirm',
+  });
+
+  return dialog;
+}

--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBar.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBar.tsx
@@ -27,6 +27,7 @@ import {
 } from '@onekeyhq/shared/src/utils/numberUtils';
 
 import { useFundingCountdown, usePerpSession } from '../../hooks';
+import { PerpSettingsButton } from '../PerpSettingsButton';
 import { PerpTokenSelector } from '../TokenSelector/PerpTokenSelector';
 
 function PerpTickerBar() {
@@ -91,13 +92,16 @@ function PerpTickerBar() {
             </Badge>
           </XStack>
         </YStack>
-        <IconButton
-          icon="TradingViewCandlesOutline"
-          size="small"
-          iconColor="$iconSubdued"
-          variant="tertiary"
-          onPress={onPressCandleChart}
-        />
+        <XStack gap="$3" alignItems="center">
+          <IconButton
+            icon="TradingViewCandlesOutline"
+            size="small"
+            iconProps={{ color: '$iconSubdued' }}
+            variant="tertiary"
+            onPress={onPressCandleChart}
+          />
+          <PerpSettingsButton testID="perp-mobile-settings-button" />
+        </XStack>
       </XStack>
     );
   }

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
@@ -16,6 +16,7 @@ import {
   YStack,
   useMedia,
 } from '@onekeyhq/components';
+import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useAccountPanelDataAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
   usePerpsAccountLoadingInfoAtom,
@@ -23,6 +24,8 @@ import {
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import { EModalRoutes } from '@onekeyhq/shared/src/routes';
+import { EModalSettingRoutes } from '@onekeyhq/shared/src/routes/setting';
 
 import { showDepositWithdrawModal } from '../modals/DepositWithdrawModal';
 
@@ -59,6 +62,7 @@ function PerpAccountPanel({
   const userAddress = selectedAccount.accountAddress;
   const userAccountId = selectedAccount.accountId;
   const { gtSm } = useMedia();
+  const navigation = useAppNavigation();
   const accountDataInfo = useMemo(() => {
     const withdrawableBalance = accountSummary.withdrawable;
     const accountValue = accountSummary.accountValue;
@@ -120,6 +124,12 @@ function PerpAccountPanel({
     },
     [userAccountId, userAddress, accountSummary.withdrawable],
   );
+  const handleOpenPerpSettings = useCallback(() => {
+    navigation.pushModal(EModalRoutes.SettingModal, {
+      screen: EModalSettingRoutes.SettingPerpUserConfig,
+    });
+  }, [navigation]);
+
   if (isTradingPanel) {
     return (
       <IconButton
@@ -135,43 +145,55 @@ function PerpAccountPanel({
   }
   if (ifOnHeader) {
     return (
-      <Badge
-        borderRadius="$full"
-        size="medium"
-        variant="secondary"
-        onPress={() => handleDepositOrWithdraw('deposit')}
-        alignItems="center"
-        justifyContent="center"
-        flexDirection="row"
-        gap="$2"
-        px="$3"
-        h={32}
-        hoverStyle={{
-          bg: '$bgStrongHover',
-        }}
-        pressStyle={{
-          bg: '$bgStrongActive',
-        }}
-        cursor="pointer"
-      >
-        <Icon name="WalletOutline" size="$4" />
+      <XStack alignItems="center" gap="$5">
+        <Badge
+          borderRadius="$full"
+          size="medium"
+          variant="secondary"
+          onPress={() => handleDepositOrWithdraw('deposit')}
+          alignItems="center"
+          justifyContent="center"
+          flexDirection="row"
+          gap="$2"
+          px="$3"
+          h={32}
+          hoverStyle={{
+            bg: '$bgStrongHover',
+          }}
+          pressStyle={{
+            bg: '$bgStrongActive',
+          }}
+          cursor="pointer"
+        >
+          <Icon name="WalletOutline" size="$4" />
 
-        {gtSm
-          ? renderAccountValue(
-              accountDataInfo.accountValue ?? '',
-              60,
-              '$bodySmMedium',
-            )
-          : null}
-        <Divider
-          borderWidth={0.33}
-          borderBottomWidth={12}
-          borderColor="$borderSubdued"
-        />
-        <SizableText size="$bodySmMedium" color="$text">
-          {intl.formatMessage({ id: ETranslations.perp_trade_deposit })}
-        </SizableText>
-      </Badge>
+          {gtSm
+            ? renderAccountValue(
+                accountDataInfo.accountValue ?? '',
+                60,
+                '$bodySmMedium',
+              )
+            : null}
+          <Divider
+            borderWidth={0.33}
+            borderBottomWidth={12}
+            borderColor="$borderSubdued"
+          />
+          <SizableText size="$bodySmMedium" color="$text">
+            {intl.formatMessage({ id: ETranslations.perp_trade_deposit })}
+          </SizableText>
+        </Badge>
+        {platformEnv.isNative ? null : (
+          <IconButton
+            size="small"
+            variant="tertiary"
+            icon="SettingsOutline"
+            iconColor="$iconSubdued"
+            onPress={handleOpenPerpSettings}
+            testID="perp-header-settings-button"
+          />
+        )}
+      </XStack>
     );
   }
   return (

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
@@ -16,7 +16,6 @@ import {
   YStack,
   useMedia,
 } from '@onekeyhq/components';
-import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useAccountPanelDataAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
   usePerpsAccountLoadingInfoAtom,
@@ -24,9 +23,8 @@ import {
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import { EModalRoutes } from '@onekeyhq/shared/src/routes';
-import { EModalSettingRoutes } from '@onekeyhq/shared/src/routes/setting';
 
+import { PerpSettingsButton } from '../../PerpSettingsButton';
 import { showDepositWithdrawModal } from '../modals/DepositWithdrawModal';
 
 import type { FontSizeTokens } from 'tamagui';
@@ -62,7 +60,6 @@ function PerpAccountPanel({
   const userAddress = selectedAccount.accountAddress;
   const userAccountId = selectedAccount.accountId;
   const { gtSm } = useMedia();
-  const navigation = useAppNavigation();
   const accountDataInfo = useMemo(() => {
     const withdrawableBalance = accountSummary.withdrawable;
     const accountValue = accountSummary.accountValue;
@@ -124,11 +121,6 @@ function PerpAccountPanel({
     },
     [userAccountId, userAddress, accountSummary.withdrawable],
   );
-  const handleOpenPerpSettings = useCallback(() => {
-    navigation.pushModal(EModalRoutes.SettingModal, {
-      screen: EModalSettingRoutes.SettingPerpUserConfig,
-    });
-  }, [navigation]);
 
   if (isTradingPanel) {
     return (
@@ -184,14 +176,7 @@ function PerpAccountPanel({
           </SizableText>
         </Badge>
         {platformEnv.isNative ? null : (
-          <IconButton
-            size="small"
-            variant="tertiary"
-            icon="SettingsOutline"
-            iconColor="$iconSubdued"
-            onPress={handleOpenPerpSettings}
-            testID="perp-header-settings-button"
-          />
+          <PerpSettingsButton testID="perp-header-settings-button" />
         )}
       </XStack>
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Perp Settings dialog with an option to skip order confirmation.
  - Introduced a Settings button in the Perp ticker bar and account header (desktop/web) to open the dialog.
  - Added a quick Deposit button in the trading panel.

- Style
  - Updated deposit label text to new wording.
  - Tweaked mobile controls layout to include Settings alongside the chart icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->