### PR TITLE
OK-43798: improve layout of DepositWithdrawModal for better text display

### DIFF
--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -426,11 +426,19 @@ function DepositWithdrawContent({
           }
           wallet={accountResult?.wallet}
         />
-        <SizableText size="$bodyMdMedium" color="$text" numberOfLines={1}>
-          {accountResult?.isOtherAccount
-            ? accountResult?.account?.name
-            : accountResult?.indexedAccount?.name}
-        </SizableText>
+        <XStack flex={1} minWidth={0} maxWidth="70%" overflow="hidden">
+          <SizableText
+            flex={1}
+            size="$bodyMdMedium"
+            color="$text"
+            numberOfLines={1}
+            ellipsizeMode="tail"
+          >
+            {accountResult?.isOtherAccount
+              ? accountResult?.account?.name
+              : accountResult?.indexedAccount?.name}
+          </SizableText>
+        </XStack>
       </XStack>
       <SegmentControl
         height={38}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Improved the Deposit/Withdraw modal to gracefully truncate long account names with an ellipsis, preventing overflow and preserving layout integrity.
  - Constrained the account name area to maintain consistent alignment and readability across screen sizes, without changing the displayed text or surrounding controls.
  - Ensures a cleaner, more polished appearance when viewing accounts with lengthy names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->