### PR TITLE
fix: create invoice input pad type OK-43837

### DIFF
--- a/packages/kit/src/views/Receive/pages/CreateInvoice.tsx
+++ b/packages/kit/src/views/Receive/pages/CreateInvoice.tsx
@@ -234,7 +234,7 @@ function CreateInvoice() {
               $gtMd={{
                 size: 'medium',
               }}
-              keyboardType="number-pad"
+              keyboardType="decimal-pad"
               addOns={[
                 {
                   label: lnUnit === ELightningUnit.BTC ? 'BTC' : 'sats',

--- a/packages/shared/src/utils/chainValueUtils.ts
+++ b/packages/shared/src/utils/chainValueUtils.ts
@@ -151,14 +151,16 @@ function convertBtcToSats(btc: string | number): string {
   if (btc === '' || btc === undefined) {
     return '';
   }
-  return new BigNumber(btc).times(SATS_PER_BTC).toFixed();
+  const result = new BigNumber(btc).times(SATS_PER_BTC);
+  return result.isNaN() ? '0' : result.toFixed();
 }
 
 function convertSatsToBtc(sats: string | number): string {
   if (sats === '' || sats === undefined) {
     return '';
   }
-  return new BigNumber(sats).dividedBy(SATS_PER_BTC).toFixed();
+  const result = new BigNumber(sats).dividedBy(SATS_PER_BTC);
+  return result.isNaN() ? '0' : result.toFixed();
 }
 
 function getLightningAmountDecimals({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invoice amount field now supports decimal input, making it easier to enter precise values when creating invoices.

* **Bug Fixes**
  * Improved Bitcoin amount conversions to handle invalid or missing inputs more safely, defaulting to 0 instead of producing invalid values.
  * Increased reliability of amount display and calculations to prevent unexpected results from malformed inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->