### PR TITLE
fix(perp): improve HyperLiquid account selection and error handling

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -513,6 +513,7 @@ export default class ServiceHyperliquid extends ServiceBase {
   }
 
   @backgroundMethod()
+  @toastIfError()
   async enableTrading() {
     await this.checkPerpsAccountStatus({
       isEnableTradingTrigger: true,
@@ -932,16 +933,17 @@ export default class ServiceHyperliquid extends ServiceBase {
   @backgroundMethod()
   async disposeExchangeClients() {
     await this.exchangeService.dispose();
-    await perpsActiveAccountStatusInfoAtom.set({
-      accountAddress: null,
-      canTrade: false,
-      details: {
-        activatedOk: false,
-        agentOk: false,
-        builderFeeOk: false,
-        referralCodeOk: false,
-      },
-    });
+    await perpsActiveAccountStatusInfoAtom.set(
+      (_prev): IPerpsActiveAccountStatusInfoAtom => ({
+        accountAddress: null,
+        details: {
+          activatedOk: false,
+          agentOk: false,
+          builderFeeOk: false,
+          referralCodeOk: false,
+        },
+      }),
+    );
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -466,14 +466,18 @@ export default class ServiceHyperliquid extends ServiceBase {
       console.log('selectPerpsAccount______111', indexedAccountId, accountId);
       if (indexedAccountId || accountId) {
         const ethNetworkId = PERPS_NETWORK_ID;
+        const getNetworkAccountParams = {
+          indexedAccountId: indexedAccountId ?? undefined,
+          accountId: indexedAccountId ? undefined : accountId ?? undefined,
+          networkId: ethNetworkId,
+          deriveType: deriveType || 'default',
+        };
+        console.log('selectPerpsAccount______222', getNetworkAccountParams);
         const account =
-          await this.backgroundApi.serviceAccount.getNetworkAccount({
-            indexedAccountId: indexedAccountId ?? undefined,
-            accountId: indexedAccountId ? undefined : accountId ?? undefined,
-            networkId: ethNetworkId,
-            deriveType: deriveType || 'default',
-          });
-        console.log('selectPerpsAccount______222', account);
+          await this.backgroundApi.serviceAccount.getNetworkAccount(
+            getNetworkAccountParams,
+          );
+        console.log('selectPerpsAccount______333', account);
         perpsAccount.accountAddress =
           (account.address?.toLowerCase() as IHex) || null;
         if (perpsAccount.accountAddress) {
@@ -485,6 +489,7 @@ export default class ServiceHyperliquid extends ServiceBase {
         });
       }
     } catch (error) {
+      console.log('selectPerpsAccount______444_error', error);
       console.error(error);
     } finally {
       clearTimeout(this.hideSelectAccountLoadingTimer);
@@ -495,7 +500,7 @@ export default class ServiceHyperliquid extends ServiceBase {
             selectAccountLoading: false,
           }),
         );
-      }, 0);
+      }, 300);
     }
 
     await perpsActiveAccountAtom.set(perpsAccount);

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -428,10 +428,6 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       }
 
       if (subscriptionType === ESubscriptionType.ALL_MIDS) {
-        console.log(
-          '[ServiceHyperliquidSubscription.handleSubscriptionData] User fills data:',
-          data,
-        );
         // TODO remove
         hyperLiquidCache.allMids = data as IWsAllMids;
         void this.backgroundApi.serviceHyperliquid.refreshCurrentMid();

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/utils/withToast.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/utils/withToast.ts
@@ -1,5 +1,5 @@
 import { Toast } from '@onekeyhq/components';
-import { perpsActiveAccountStatusInfoAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 
 import { ERROR_MESSAGES, ERROR_PATTERNS, TOAST_CONFIGS } from './config';
 import { EErrorType } from './types';
@@ -37,15 +37,7 @@ async function handleError(error: unknown): Promise<void> {
   if (errorType) {
     switch (errorType) {
       case EErrorType.INVALID_AGENT: {
-        const accountStatus = await perpsActiveAccountStatusInfoAtom.get();
-        void perpsActiveAccountStatusInfoAtom.set({
-          ...accountStatus,
-          canTrade: false,
-          details: {
-            ...accountStatus.details,
-            agentOk: false,
-          },
-        });
+        void backgroundApiProxy.serviceHyperliquid.checkPerpsAccountStatus();
         break;
       }
       default:

--- a/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
@@ -6,6 +6,7 @@ import {
   DebugRenderTracker,
   Divider,
   Icon,
+  IconButton,
   SizableText,
   XStack,
   useMedia,
@@ -53,7 +54,10 @@ function DebugButton() {
 
   return (
     <DebugRenderTracker name="PerpsHeaderRight__DebugButton">
-      <Button
+      <IconButton
+        icon="BugSolid"
+        size="small"
+        variant="tertiary"
         onPress={async () => {
           const simpleDbPerpData =
             await backgroundApiProxy.simpleDb.perp.getPerpData();
@@ -77,9 +81,7 @@ function DebugButton() {
             activePositions,
           });
         }}
-      >
-        Debug
-      </Button>
+      />
     </DebugRenderTracker>
   );
 }
@@ -89,51 +91,54 @@ export function PerpsHeaderRight() {
   const { gtSm } = useMedia();
   const accountValue = accountSummary?.accountValue;
   const intl = useIntl();
+  const [activeAccount] = usePerpsActiveAccountAtom();
   return (
     <XStack alignItems="center" gap="$5">
       {process.env.NODE_ENV !== 'production' ? <DebugButton /> : null}
-      <Badge
-        borderRadius="$full"
-        size="medium"
-        variant="secondary"
-        onPress={() =>
-          showDepositWithdrawModal({
-            actionType: 'deposit',
-            withdrawable: accountSummary?.withdrawable || '0',
-          })
-        }
-        alignItems="center"
-        justifyContent="center"
-        flexDirection="row"
-        gap="$2"
-        px="$3"
-        h={32}
-        hoverStyle={{
-          bg: '$bgStrongHover',
-        }}
-        pressStyle={{
-          bg: '$bgStrongActive',
-        }}
-        cursor="pointer"
-      >
-        <Icon name="WalletOutline" size="$4" />
+      {activeAccount.accountAddress ? (
+        <Badge
+          borderRadius="$full"
+          size="medium"
+          variant="secondary"
+          onPress={() =>
+            showDepositWithdrawModal({
+              actionType: 'deposit',
+              withdrawable: accountSummary?.withdrawable || '0',
+            })
+          }
+          alignItems="center"
+          justifyContent="center"
+          flexDirection="row"
+          gap="$2"
+          px="$3"
+          h={32}
+          hoverStyle={{
+            bg: '$bgStrongHover',
+          }}
+          pressStyle={{
+            bg: '$bgStrongActive',
+          }}
+          cursor="pointer"
+        >
+          <Icon name="WalletOutline" size="$4" />
 
-        {gtSm ? (
-          <PerpsAccountNumberValue
-            value={accountValue ?? ''}
-            skeletonWidth={60}
-            textSize="$bodySmMedium"
+          {gtSm ? (
+            <PerpsAccountNumberValue
+              value={accountValue ?? ''}
+              skeletonWidth={60}
+              textSize="$bodySmMedium"
+            />
+          ) : null}
+          <Divider
+            borderWidth={0.33}
+            borderBottomWidth={12}
+            borderColor="$borderSubdued"
           />
-        ) : null}
-        <Divider
-          borderWidth={0.33}
-          borderBottomWidth={12}
-          borderColor="$borderSubdued"
-        />
-        <SizableText size="$bodySmMedium" color="$text">
-          {intl.formatMessage({ id: ETranslations.perp_trade_deposit })}
-        </SizableText>
-      </Badge>
+          <SizableText size="$bodySmMedium" color="$text">
+            {intl.formatMessage({ id: ETranslations.perp_trade_deposit })}
+          </SizableText>
+        </Badge>
+      ) : null}
       {platformEnv.isNative ? null : (
         <PerpSettingsButton testID="perp-header-settings-button" />
       )}

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -354,12 +354,7 @@ function DepositWithdrawContent({
       }
     } catch (error) {
       console.error(`[DepositWithdrawModal.${selectedAction}] Failed:`, error);
-      Toast.error({
-        title: `${
-          selectedAction === 'deposit' ? 'Deposit' : 'Withdraw'
-        } Failed`,
-        message: error instanceof Error ? error.message : 'Transaction failed',
-      });
+      throw error;
     } finally {
       setIsSubmitting(false);
     }


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatically selects a Perps account after a new ETH account is added, improving onboarding.
  - Centralized error toasts when enabling trading for clearer feedback.

- Bug Fixes
  - Ensured account status resets correctly when disconnecting or switching, reducing stale UI states.

- Chores
  - Reduced debug logging noise in subscriptions.
  - Minor UI tweaks: show the Deposit badge only when a Perps account is active; replaced a debug button with an icon button.
  - Smoother account selection with a brief delay to avoid flicker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- Improve account selection flow with better debug logging and error handling
- Auto-select perps account when ETH accounts are added to wallet  
- Hide deposit button when no perps account is selected for better UX
- Enhance error handling with @toastIfError decorators and proper error propagation
- Clean up UI with icon-based debug button and remove duplicate error toasts

## Changes

### Account Selection Improvements
- Add comprehensive debug logging in `selectPerpsAccount` method
- Increase loading timeout from 0ms to 300ms for better user experience
- Auto-trigger perps account selection when ETH accounts are added via event bus
- Add proper error handling and logging for account selection failures

### UI/UX Enhancements  
- Conditionally show deposit button only when perps account is selected
- Replace text-based debug button with cleaner icon button
- Remove redundant error toasts to prevent duplicate error messages

### Error Handling & Code Quality
- Add `@toastIfError` decorator to `enableTrading` method for consistent error handling
- Fix atom setter type consistency in `disposeExchangeClients`
- Refactor invalid agent error handling to use service method instead of direct atom manipulation
- Remove unnecessary console logs in subscription service

## Test Plan

- [ ] Test account selection flow when switching between accounts
- [ ] Verify auto-selection works when adding new ETH accounts
- [ ] Test deposit button visibility based on account selection state
- [ ] Verify error handling shows appropriate toast messages
- [ ] Test debug functionality in development environment

🤖 Generated with [Claude Code](https://claude.ai/code)