### PR TITLE
fix: return cached update info when no update is required(OK-43987)

### DIFF
--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -77,6 +77,7 @@ class ServiceAppUpdate extends ServiceBase {
     if (isFirstLaunchAfterUpdated(appInfo)) {
       await appUpdatePersistAtom.set((prev) => ({
         ...prev,
+        updateAt: 0,
         updateStrategy: EUpdateStrategy.manual,
         errorText: undefined,
         status: EAppUpdateStatus.done,

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -340,7 +340,7 @@ class ServiceAppUpdate extends ServiceBase {
     await this.refreshUpdateStatus();
     // downloading app or ready to update via local package
     if (!(await this.isNeedSyncAppUpdateInfo())) {
-      return;
+      return appUpdatePersistAtom.get();
     }
 
     const releaseInfo = await this.getAppLatestInfo(forceUpdate);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * More reliable app update status handling on first launch after an update.
  * Consistent return of current update information when no sync is needed, improving stability for features that read update status.

* **Bug Fixes**
  * Resolved an issue where the update timestamp might not reset correctly after updating, ensuring accurate detection of the most recent update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->