### PR TITLE
feat: implement trading size management with manual and slider modes

### DIFF
--- a/packages/kit/src/states/jotai/contexts/hyperliquid/index.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/index.ts
@@ -6,6 +6,8 @@ export {
   useOrderBookTickOptionsAtom,
   usePerpsActiveOpenOrdersAtom,
   useTradingFormAtom,
+  useTradingFormEnvAtom,
+  useTradingFormComputedAtom,
   useTradingLoadingAtom,
   usePerpsActivePositionAtom,
   useSubscriptionActiveAtom,

--- a/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingButton.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingButton.tsx
@@ -36,12 +36,16 @@ export function PerpTradingButton({
   loading,
   handleShowConfirm,
   formData,
+  computedSize,
+  isMinimumOrderNotMet,
   isSubmitting,
   isNoEnoughMargin,
 }: {
   loading: boolean;
   handleShowConfirm: () => void;
   formData: ITradingFormData;
+  computedSize: BigNumber;
+  isMinimumOrderNotMet: boolean;
   isSubmitting: boolean;
   isNoEnoughMargin: boolean;
 }) {
@@ -76,22 +80,9 @@ export function PerpTradingButton({
     }
   }, [perpsAccount.accountAddress, perpsAccount.accountId]);
 
-  const isMinimumOrderNotMet = useMemo(() => {
-    const size = BigNumber(formData.size);
-    const price = BigNumber(formData.price);
-    const leverage = BigNumber(formData.leverage || 1);
-
-    if (!size || !price || size.lte(0) || price.lte(0)) {
-      return false;
-    }
-
-    const orderValue = size.multipliedBy(price).multipliedBy(leverage);
-    return orderValue.lt(10);
-  }, [formData.size, formData.price, formData.leverage]);
-
   const buttonDisabled = useMemo(() => {
     return (
-      !(Number(formData.size) > 0) ||
+      !computedSize.gt(0) ||
       !perpsAccountStatus.canTrade ||
       isSubmitting ||
       isNoEnoughMargin ||
@@ -102,7 +93,7 @@ export function PerpTradingButton({
           perpConfigCommon?.ipDisablePerp))
     );
   }, [
-    formData.size,
+    computedSize,
     perpsAccountStatus.canTrade,
     isSubmitting,
     isNoEnoughMargin,

--- a/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
@@ -14,6 +14,7 @@ import {
   formatWithPrecision,
   validateSizeInput,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
+import type { EPerpsSizeInputMode } from '@onekeyhq/shared/types/hyperliquid';
 
 import { TradingFormInput } from './TradingFormInput';
 
@@ -27,6 +28,9 @@ interface ISizeInputProps {
   activeAsset: IPerpsActiveAssetAtom;
   activeAssetCtx: IPerpsActiveAssetCtxAtom;
   referencePrice: string;
+  sizeInputMode: EPerpsSizeInputMode;
+  sliderPercent: number;
+  onRequestManualMode?: () => void;
   error?: string;
   disabled?: boolean;
   label?: string;
@@ -41,6 +45,9 @@ export const SizeInput = memo(
     activeAsset,
     activeAssetCtx,
     referencePrice,
+    sizeInputMode,
+    sliderPercent,
+    onRequestManualMode,
     error,
     disabled = false,
     side,
@@ -57,6 +64,14 @@ export const SizeInput = memo(
     const [isUserTyping, setIsUserTyping] = useState(false);
 
     const prevValueRef = useRef(value);
+
+    const isSliderMode = sizeInputMode === 'slider';
+
+    const sliderDisplay = useMemo(() => {
+      if (!isSliderMode) return '';
+      if (!Number.isFinite(sliderPercent)) return '0%';
+      return `${new BigNumber(sliderPercent || 0).toFixed()}%`;
+    }, [isSliderMode, sliderPercent]);
 
     const priceBN = useMemo(
       () => new BigNumber(referencePrice),
@@ -75,6 +90,7 @@ export const SizeInput = memo(
     }, [value]);
 
     useEffect(() => {
+      if (isSliderMode) return;
       if (inputMode === 'token' && hasValidPrice && tokenAmount) {
         const tokenBN = new BigNumber(tokenAmount);
         if (tokenBN.isFinite()) {
@@ -86,9 +102,10 @@ export const SizeInput = memo(
           setUsdAmount(usdValue);
         }
       }
-    }, [inputMode, tokenAmount, hasValidPrice, priceBN]);
+    }, [inputMode, tokenAmount, hasValidPrice, priceBN, isSliderMode]);
 
     useEffect(() => {
+      if (isSliderMode) return;
       if (inputMode === 'usd' && hasValidPrice && usdAmount && !isUserTyping) {
         const usdBN = new BigNumber(usdAmount);
         if (usdBN.isFinite()) {
@@ -114,10 +131,12 @@ export const SizeInput = memo(
       onChange,
       isUserTyping,
       priceBN,
+      isSliderMode,
     ]);
 
     const validator = useCallback(
       (text: string) => {
+        if (isSliderMode) return true;
         if (!validateSizeInput(text, inputMode === 'token' ? szDecimals : 2)) {
           return false;
         }
@@ -131,7 +150,7 @@ export const SizeInput = memo(
 
         return true;
       },
-      [szDecimals, inputMode],
+      [szDecimals, inputMode, isSliderMode],
     );
 
     const formatLabel = useMemo(() => {
@@ -158,6 +177,8 @@ export const SizeInput = memo(
       (newValue: string) => {
         setIsUserTyping(true);
 
+        onRequestManualMode?.();
+
         if (inputMode === 'token') {
           setTokenAmount(newValue);
           onChange(newValue);
@@ -181,7 +202,14 @@ export const SizeInput = memo(
           }
         }
       },
-      [inputMode, hasValidPrice, szDecimals, onChange, priceBN],
+      [
+        inputMode,
+        hasValidPrice,
+        szDecimals,
+        onChange,
+        priceBN,
+        onRequestManualMode,
+      ],
     );
 
     const selectItems = useMemo((): ISelectItem[] => {
@@ -202,6 +230,7 @@ export const SizeInput = memo(
         const mode = newMode as 'token' | 'usd';
         if (mode === inputMode) return;
 
+        onRequestManualMode?.();
         setInputMode(mode);
         setIsUserTyping(false);
 
@@ -217,7 +246,14 @@ export const SizeInput = memo(
           }
         }
       },
-      [inputMode, hasValidPrice, tokenAmount, priceBN, setUsdAmount],
+      [
+        inputMode,
+        hasValidPrice,
+        tokenAmount,
+        priceBN,
+        setUsdAmount,
+        onRequestManualMode,
+      ],
     );
 
     const customSuffix = useMemo(
@@ -249,7 +285,12 @@ export const SizeInput = memo(
       [selectItems, inputMode, handleModeChange, selectWidth, intl],
     );
 
-    const displayValue = inputMode === 'token' ? tokenAmount : usdAmount;
+    const displayValue = useMemo(() => {
+      if (isSliderMode) {
+        return sliderDisplay;
+      }
+      return inputMode === 'token' ? tokenAmount : usdAmount;
+    }, [isSliderMode, sliderDisplay, inputMode, tokenAmount, usdAmount]);
 
     return (
       <TradingFormInput
@@ -260,6 +301,7 @@ export const SizeInput = memo(
         error={error}
         validator={validator}
         customSuffix={customSuffix}
+        onFocus={onRequestManualMode}
         isMobile={isMobile}
         placeholder={
           isMobile

--- a/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
@@ -83,6 +83,15 @@ export const SizeInput = memo(
     );
 
     useEffect(() => {
+      if (isSliderMode) {
+        setTokenAmount('');
+        setUsdAmount('');
+        prevValueRef.current = '';
+        setIsUserTyping(false);
+      }
+    }, [isSliderMode]);
+
+    useEffect(() => {
       if (value !== prevValueRef.current) {
         setTokenAmount(value);
         prevValueRef.current = value;

--- a/packages/kit/src/views/Perp/components/TradingPanel/inputs/TradingFormInput.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/inputs/TradingFormInput.tsx
@@ -29,6 +29,7 @@ interface ITradingFormInputProps {
   label: string;
   placeholder?: string;
   disabled?: boolean;
+  onFocus?: () => void;
   error?: string;
   suffix?: string;
   customSuffix?: ReactNode;
@@ -48,6 +49,7 @@ export const TradingFormInput = memo(
     label,
     placeholder,
     disabled = false,
+    onFocus,
     error,
     suffix,
     customSuffix,
@@ -126,6 +128,7 @@ export const TradingFormInput = memo(
             size="medium"
             value={value}
             onChangeText={handleInputChange}
+            onFocus={onFocus}
             placeholder={placeholder}
             keyboardType={keyboardType}
             disabled={disabled}
@@ -198,8 +201,9 @@ export const TradingFormInput = memo(
             }}
             value={value}
             onChangeText={handleInputChange}
+            onFocus={onFocus}
             disabled={disabled}
-            keyboardType="decimal-pad"
+            keyboardType={keyboardType}
             size="small"
             containerProps={{
               bg: '$bgSubdued',

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
@@ -8,7 +8,10 @@ import {
   XStack,
   YStack,
 } from '@onekeyhq/components';
-import { useTradingFormAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import {
+  useTradingFormAtom,
+  useTradingFormComputedAtom,
+} from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
   usePerpsActiveAssetAtom,
   usePerpsCustomSettingsAtom,
@@ -41,16 +44,18 @@ function OrderConfirmContent({ onClose }: IOrderConfirmContentProps) {
   const [perpsCustomSettings, setPerpsCustomSettings] =
     usePerpsCustomSettingsAtom();
   const [formData] = useTradingFormAtom();
+  const [tradingComputed] = useTradingFormComputedAtom();
   const [selectedSymbol] = usePerpsActiveAssetAtom();
   const actionColor = getTradingSideTextColor(formData.side);
   const buttonStyleProps = GetTradingButtonStyleProps(formData.side, false);
   const actionText = formData.side === 'long' ? 'Long' : 'Short';
 
   const sizeDisplay = useMemo(() => {
-    if (formData.size && selectedSymbol?.coin)
-      return `${formData.size} ${selectedSymbol.coin}`;
-    return '0';
-  }, [formData.size, selectedSymbol?.coin]);
+    if (selectedSymbol?.coin) {
+      return `${tradingComputed.computedSizeString} ${selectedSymbol.coin}`;
+    }
+    return tradingComputed.computedSizeString;
+  }, [tradingComputed.computedSizeString, selectedSymbol?.coin]);
 
   const buttonText = useMemo(() => {
     if (isSubmitting) {

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -8,7 +8,6 @@ import {
   NumberSizeableText,
   SizableText,
   Skeleton,
-  Slider,
   XStack,
   YStack,
   getFontSize,
@@ -168,13 +167,12 @@ function PerpTradingForm({
     activeAsset?.universe?.szDecimals,
   ]);
 
-  const { availableToTradeDisplay, availableToTradeValue } = useMemo(() => {
+  const { availableToTradeDisplay } = useMemo(() => {
     const _availableToTrade = activeAssetData?.availableToTrade || [0, 0];
     const value = _availableToTrade[formData.side === 'long' ? 0 : 1] || 0;
     const valueBN = new BigNumber(value);
     return {
       availableToTradeDisplay: valueBN.toFixed(2, BigNumber.ROUND_DOWN),
-      availableToTradeValue: valueBN.toNumber(),
     };
   }, [formData.side, activeAssetData?.availableToTrade]);
 
@@ -201,88 +199,6 @@ function PerpTradingForm({
       .multipliedBy(referencePrice)
       .dividedBy(leverage || 1); // (Size × Price) ÷ Leverage = Required Margin
   }, [formData.size, referencePrice, leverage]);
-
-  // Slider Configuration: Calculate price, leverage, max value and current value for size slider
-  const sliderConfig = useMemo(() => {
-    // Get effective price for slider calculation (limit price or market price)
-    const getEffectivePrice = (): BigNumber | null => {
-      if (referencePrice.gt(0)) return referencePrice;
-      if (activeAssetCtx?.ctx?.markPrice) {
-        const markPx = new BigNumber(activeAssetCtx.ctx.markPrice);
-        return markPx.isFinite() && markPx.gt(0) ? markPx : null;
-      }
-      return null;
-    };
-
-    // Get safe leverage value (fallback to 1x if invalid)
-    const getSafeLeverage = (): BigNumber => {
-      if (!leverage) return new BigNumber(1);
-      const leverageBN = new BigNumber(leverage);
-      return leverageBN.isFinite() && leverageBN.gt(0)
-        ? leverageBN
-        : new BigNumber(1);
-    };
-
-    const effectivePrice = getEffectivePrice();
-    const safeLeverage = getSafeLeverage();
-    const currentValue = new BigNumber(formData.size || 0);
-
-    // Calculate maximum trade size: Available Balance × Leverage ÷ Price
-    const calculateMaxSize = (): number => {
-      if (!effectivePrice || effectivePrice.lte(0)) return 0;
-      if (!Number.isFinite(availableToTradeValue) || availableToTradeValue <= 0)
-        return 0;
-
-      const maxTokens = new BigNumber(availableToTradeValue)
-        .multipliedBy(safeLeverage)
-        .dividedBy(effectivePrice)
-        .decimalPlaces(
-          activeAsset?.universe?.szDecimals ?? 2,
-          BigNumber.ROUND_FLOOR,
-        );
-
-      return maxTokens.isFinite() && maxTokens.gt(0) ? maxTokens.toNumber() : 0;
-    };
-
-    const maxSize = calculateMaxSize();
-    const currentValueNum = currentValue.isFinite()
-      ? currentValue.toNumber()
-      : 0;
-
-    return {
-      price: effectivePrice,
-      leverage: safeLeverage,
-      maxSize,
-      currentValue: currentValueNum,
-      controlledValue: maxSize > 0 ? Math.min(currentValueNum, maxSize) : 0,
-      isValid: !!effectivePrice && effectivePrice.gt(0) && maxSize > 0,
-    };
-  }, [
-    referencePrice,
-    activeAssetCtx?.ctx?.markPrice,
-    activeAsset?.universe?.szDecimals,
-    leverage,
-    availableToTradeValue,
-    formData.size,
-  ]);
-
-  const sliderStep = useMemo(() => {
-    const decimals = Math.min(activeAsset?.universe?.szDecimals ?? 2, 6);
-    return Number((10 ** -decimals).toFixed(decimals));
-  }, [activeAsset?.universe?.szDecimals]);
-
-  const handleSizeSliderChange = useCallback(
-    (value?: number) => {
-      if (value === undefined) return;
-      if (!sliderConfig.isValid) return;
-      const decimals = activeAsset?.universe?.szDecimals ?? 2;
-      const formatted = new BigNumber(value)
-        .decimalPlaces(decimals, BigNumber.ROUND_FLOOR)
-        .toFixed();
-      updateForm({ size: formatted });
-    },
-    [sliderConfig.isValid, activeAsset?.universe?.szDecimals, updateForm],
-  );
 
   const handleTpslCheckboxChange = useCallback(
     (checked: ICheckedState) => {
@@ -388,17 +304,6 @@ function PerpTradingForm({
           value={formData.size}
           onChange={(value) => updateForm({ size: value })}
           isMobile={isMobile}
-        />
-        <Slider
-          mt="$2"
-          min={0}
-          max={sliderConfig.maxSize}
-          value={sliderConfig.controlledValue}
-          onChange={handleSizeSliderChange}
-          disabled={
-            isSubmitting || !sliderConfig.isValid || Number.isNaN(sliderStep)
-          }
-          step={sliderStep}
         />
         <YStack gap="$1">
           <Checkbox
@@ -564,18 +469,6 @@ function PerpTradingForm({
           symbol={perpsSelectedSymbol.coin}
           value={formData.size}
           onChange={(value) => updateForm({ size: value })}
-        />
-        <Slider
-          width="100%"
-          mt="$3"
-          min={0}
-          max={sliderConfig.maxSize}
-          value={sliderConfig.controlledValue}
-          onChange={handleSizeSliderChange}
-          disabled={
-            isSubmitting || !sliderConfig.isValid || Number.isNaN(sliderStep)
-          }
-          step={sliderStep}
         />
 
         <YStack p="$0">

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -8,7 +8,6 @@ import {
   NumberSizeableText,
   SizableText,
   Skeleton,
-  Slider,
   XStack,
   YStack,
   getFontSize,
@@ -168,13 +167,12 @@ function PerpTradingForm({
     activeAsset?.universe?.szDecimals,
   ]);
 
-  const { availableToTradeDisplay, availableToTradeValue } = useMemo(() => {
+  const { availableToTradeDisplay } = useMemo(() => {
     const _availableToTrade = activeAssetData?.availableToTrade || [0, 0];
     const value = _availableToTrade[formData.side === 'long' ? 0 : 1] || 0;
     const valueBN = new BigNumber(value);
     return {
       availableToTradeDisplay: valueBN.toFixed(2, BigNumber.ROUND_DOWN),
-      availableToTradeValue: valueBN.toNumber(),
     };
   }, [formData.side, activeAssetData?.availableToTrade]);
 
@@ -201,88 +199,6 @@ function PerpTradingForm({
       .multipliedBy(referencePrice)
       .dividedBy(leverage || 1); // (Size × Price) ÷ Leverage = Required Margin
   }, [formData.size, referencePrice, leverage]);
-
-  // Slider Configuration: Calculate price, leverage, max value and current value for size slider
-  const sliderConfig = useMemo(() => {
-    // Get effective price for slider calculation (limit price or market price)
-    const getEffectivePrice = (): BigNumber | null => {
-      if (referencePrice.gt(0)) return referencePrice;
-      if (activeAssetCtx?.ctx?.markPrice) {
-        const markPx = new BigNumber(activeAssetCtx.ctx.markPrice);
-        return markPx.isFinite() && markPx.gt(0) ? markPx : null;
-      }
-      return null;
-    };
-
-    // Get safe leverage value (fallback to 1x if invalid)
-    const getSafeLeverage = (): BigNumber => {
-      if (!leverage) return new BigNumber(1);
-      const leverageBN = new BigNumber(leverage);
-      return leverageBN.isFinite() && leverageBN.gt(0)
-        ? leverageBN
-        : new BigNumber(1);
-    };
-
-    const effectivePrice = getEffectivePrice();
-    const safeLeverage = getSafeLeverage();
-    const currentValue = new BigNumber(formData.size || 0);
-
-    // Calculate maximum trade size: Available Balance × Leverage ÷ Price
-    const calculateMaxSize = (): number => {
-      if (!effectivePrice || effectivePrice.lte(0)) return 0;
-      if (!Number.isFinite(availableToTradeValue) || availableToTradeValue <= 0)
-        return 0;
-
-      const maxTokens = new BigNumber(availableToTradeValue)
-        .multipliedBy(safeLeverage)
-        .dividedBy(effectivePrice)
-        .decimalPlaces(
-          activeAsset?.universe?.szDecimals ?? 2,
-          BigNumber.ROUND_FLOOR,
-        );
-
-      return maxTokens.isFinite() && maxTokens.gt(0) ? maxTokens.toNumber() : 0;
-    };
-
-    const maxSize = calculateMaxSize();
-    const currentValueNum = currentValue.isFinite()
-      ? currentValue.toNumber()
-      : 0;
-
-    return {
-      price: effectivePrice,
-      leverage: safeLeverage,
-      maxSize,
-      currentValue: currentValueNum,
-      controlledValue: maxSize > 0 ? Math.min(currentValueNum, maxSize) : 0,
-      isValid: !!effectivePrice && effectivePrice.gt(0) && maxSize > 0,
-    };
-  }, [
-    referencePrice,
-    activeAssetCtx?.ctx?.markPrice,
-    activeAsset?.universe?.szDecimals,
-    leverage,
-    availableToTradeValue,
-    formData.size,
-  ]);
-
-  const sliderStep = useMemo(() => {
-    const decimals = Math.min(activeAsset?.universe?.szDecimals ?? 2, 6);
-    return Number((10 ** -decimals).toFixed(decimals));
-  }, [activeAsset?.universe?.szDecimals]);
-
-  const handleSizeSliderChange = useCallback(
-    (value?: number) => {
-      if (value === undefined) return;
-      if (!sliderConfig.isValid) return;
-      const decimals = activeAsset?.universe?.szDecimals ?? 2;
-      const formatted = new BigNumber(value)
-        .decimalPlaces(decimals, BigNumber.ROUND_FLOOR)
-        .toFixed();
-      updateForm({ size: formatted });
-    },
-    [sliderConfig.isValid, activeAsset?.universe?.szDecimals, updateForm],
-  );
 
   const handleTpslCheckboxChange = useCallback(
     (checked: ICheckedState) => {
@@ -389,17 +305,6 @@ function PerpTradingForm({
           value={formData.size}
           onChange={(value) => updateForm({ size: value })}
           isMobile={isMobile}
-        />
-        <Slider
-          mt="$2"
-          min={0}
-          max={sliderConfig.maxSize}
-          value={sliderConfig.controlledValue}
-          onChange={handleSizeSliderChange}
-          disabled={
-            isSubmitting || !sliderConfig.isValid || Number.isNaN(sliderStep)
-          }
-          step={sliderStep}
         />
         <YStack gap="$1">
           <Checkbox
@@ -566,18 +471,6 @@ function PerpTradingForm({
           symbol={perpsSelectedSymbol.coin}
           value={formData.size}
           onChange={(value) => updateForm({ size: value })}
-        />
-        <Slider
-          width="100%"
-          mt="$3"
-          min={0}
-          max={sliderConfig.maxSize}
-          value={sliderConfig.controlledValue}
-          onChange={handleSizeSliderChange}
-          disabled={
-            isSubmitting || !sliderConfig.isValid || Number.isNaN(sliderStep)
-          }
-          step={sliderStep}
         />
 
         <YStack p="$0">

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -8,6 +8,7 @@ import {
   NumberSizeableText,
   SizableText,
   Skeleton,
+  Slider,
   XStack,
   YStack,
   getFontSize,
@@ -17,6 +18,8 @@ import {
   useHyperliquidActions,
   usePerpsActivePositionAtom,
   useTradingFormAtom,
+  useTradingFormComputedAtom,
+  useTradingFormEnvAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import type { ITradingFormData } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
@@ -27,6 +30,7 @@ import {
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { formatPriceToSignificantDigits } from '@onekeyhq/shared/src/utils/perpsUtils';
+import { EPerpsSizeInputMode } from '@onekeyhq/shared/types/hyperliquid';
 
 import {
   type ITradeSide,
@@ -56,6 +60,8 @@ function PerpTradingForm({
 }: IPerpTradingFormProps) {
   const [perpsAccountLoading] = usePerpsAccountLoadingInfoAtom();
   const [formData] = useTradingFormAtom();
+  const [, setTradingFormEnv] = useTradingFormEnvAtom();
+  const [tradingComputed] = useTradingFormComputedAtom();
   const intl = useIntl();
   const actions = useHyperliquidActions();
   const [activeAsset] = usePerpsActiveAssetAtom();
@@ -96,6 +102,38 @@ function PerpTradingForm({
     formData.price,
     activeAssetCtx?.ctx?.markPrice,
     updateForm,
+  ]);
+
+  useEffect(() => {
+    const nextEnv = {
+      markPrice: activeAssetCtx?.ctx?.markPrice,
+      availableToTrade: activeAssetData?.availableToTrade,
+      leverageValue: activeAssetData?.leverage?.value,
+      fallbackLeverage: activeAsset?.universe?.maxLeverage,
+      szDecimals: activeAsset?.universe?.szDecimals,
+    };
+    setTradingFormEnv((prev) => {
+      const prevAvailable = prev.availableToTrade ?? [];
+      const nextAvailable = nextEnv.availableToTrade ?? [];
+      if (
+        prev.markPrice === nextEnv.markPrice &&
+        prev.leverageValue === nextEnv.leverageValue &&
+        prev.fallbackLeverage === nextEnv.fallbackLeverage &&
+        prev.szDecimals === nextEnv.szDecimals &&
+        prevAvailable[0] === nextAvailable[0] &&
+        prevAvailable[1] === nextAvailable[1]
+      ) {
+        return prev;
+      }
+      return nextEnv;
+    });
+  }, [
+    activeAssetCtx?.ctx?.markPrice,
+    activeAssetData?.availableToTrade,
+    activeAssetData?.leverage?.value,
+    activeAsset?.universe?.maxLeverage,
+    activeAsset?.universe?.szDecimals,
+    setTradingFormEnv,
   ]);
 
   // Token Switch Effect: Handle price updates when user switches tokens
@@ -190,15 +228,55 @@ function PerpTradingForm({
 
   // Order calculations: Total value and required margin
   const totalValue = useMemo(() => {
-    const size = new BigNumber(formData.size || 0);
-    return size.multipliedBy(referencePrice); // Size × Price = Total Value
-  }, [formData.size, referencePrice]);
+    return tradingComputed.computedSizeBN.multipliedBy(referencePrice); // Size × Price = Total Value
+  }, [tradingComputed.computedSizeBN, referencePrice]);
 
   const marginRequired = useMemo(() => {
-    return new BigNumber(formData.size || 0)
+    return tradingComputed.computedSizeBN
       .multipliedBy(referencePrice)
       .dividedBy(leverage || 1); // (Size × Price) ÷ Leverage = Required Margin
-  }, [formData.size, referencePrice, leverage]);
+  }, [tradingComputed.computedSizeBN, referencePrice, leverage]);
+
+  const switchToManual = useCallback(() => {
+    if (tradingComputed.sizeInputMode === EPerpsSizeInputMode.SLIDER) {
+      updateForm({
+        sizeInputMode: EPerpsSizeInputMode.MANUAL,
+        sizePercent: 0,
+        size: '0',
+      });
+    }
+  }, [tradingComputed.sizeInputMode, updateForm]);
+
+  const handleManualSizeChange = useCallback(
+    (value: string) => {
+      updateForm({
+        size: value,
+        sizeInputMode: EPerpsSizeInputMode.MANUAL,
+        sizePercent: 0,
+      });
+    },
+    [updateForm],
+  );
+
+  const handleSliderPercentChange = useCallback(
+    (nextValue: number | number[]) => {
+      const raw = Array.isArray(nextValue) ? nextValue[0] : nextValue;
+      const value = typeof raw === 'number' && Number.isFinite(raw) ? raw : 0;
+      const clamped = Math.max(0, Math.min(100, value));
+      updateForm({
+        sizeInputMode: EPerpsSizeInputMode.SLIDER,
+        sizePercent: clamped,
+        size: '',
+      });
+    },
+    [updateForm],
+  );
+
+  const sliderValue =
+    tradingComputed.sizeInputMode === 'slider'
+      ? tradingComputed.sizePercent
+      : 0;
+  const sliderDisabled = isSubmitting || !tradingComputed.sliderEnabled;
 
   const handleTpslCheckboxChange = useCallback(
     (checked: ICheckedState) => {
@@ -303,8 +381,20 @@ function PerpTradingForm({
           activeAssetCtx={activeAssetCtx}
           symbol={perpsSelectedSymbol.coin}
           value={formData.size}
-          onChange={(value) => updateForm({ size: value })}
+          onChange={handleManualSizeChange}
+          sizeInputMode={tradingComputed.sizeInputMode}
+          sliderPercent={tradingComputed.sizePercent}
+          onRequestManualMode={switchToManual}
           isMobile={isMobile}
+        />
+        <Slider
+          mt="$2"
+          min={0}
+          max={100}
+          value={sliderValue}
+          onChange={handleSliderPercentChange}
+          disabled={sliderDisabled}
+          step={1}
         />
         <YStack gap="$1">
           <Checkbox
@@ -337,7 +427,7 @@ function PerpTradingForm({
               onChange={handleTpslChange}
               disabled={isSubmitting}
               isMobile={isMobile}
-              amount={formData.size}
+              amount={tradingComputed.computedSizeString}
             />
           ) : null}
         </YStack>
@@ -470,7 +560,20 @@ function PerpTradingForm({
           activeAssetCtx={activeAssetCtx}
           symbol={perpsSelectedSymbol.coin}
           value={formData.size}
-          onChange={(value) => updateForm({ size: value })}
+          onChange={handleManualSizeChange}
+          sizeInputMode={tradingComputed.sizeInputMode}
+          sliderPercent={tradingComputed.sizePercent}
+          onRequestManualMode={switchToManual}
+        />
+        <Slider
+          width="100%"
+          mt="$3"
+          min={0}
+          max={100}
+          value={sliderValue}
+          onChange={handleSliderPercentChange}
+          disabled={sliderDisabled}
+          step={1}
         />
 
         <YStack p="$0">
@@ -502,7 +605,7 @@ function PerpTradingForm({
               }}
               onChange={handleTpslChange}
               disabled={isSubmitting}
-              amount={formData.size}
+              amount={tradingComputed.computedSizeString}
             />
           ) : null}
         </YStack>

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -242,7 +242,7 @@ function PerpTradingForm({
       updateForm({
         sizeInputMode: EPerpsSizeInputMode.MANUAL,
         sizePercent: 0,
-        size: '0',
+        size: '',
       });
     }
   }, [tradingComputed.sizeInputMode, updateForm]);

--- a/packages/shared/types/hyperliquid/types.ts
+++ b/packages/shared/types/hyperliquid/types.ts
@@ -185,3 +185,8 @@ export type IPerpsFormattedAssetCtx = {
   change24h: string;
   change24hPercent: number;
 };
+
+export enum EPerpsSizeInputMode {
+  MANUAL = 'manual',
+  SLIDER = 'slider',
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Slider-based and manual size modes with preserved mode/percent; switching updates displayed amount immediately.
  - Position size now computed from price, leverage and available liquidity and shown consistently in the form, confirm modal, inputs, and trade button.
  - Inputs now support focus-driven manual-mode entry.

- Bug Fixes / Improvements
  - Improved validations for minimum order value and available margin with clearer disabled states and messaging.

- Refactor
  - Unified high-precision size/price calculations for consistent UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->