### PR TITLE
fix: show native token logoURI as fallback in receive panel

### DIFF
--- a/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
+++ b/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
@@ -84,6 +84,13 @@ function ReceiveToken() {
       walletId,
     });
 
+  const { result: nativeToken } = usePromiseResult(async () => {
+    return backgroundApiProxy.serviceToken.getNativeToken({
+      accountId,
+      networkId,
+    });
+  }, [accountId, networkId]);
+
   const { handleBannerOnPress } = useWalletBanner({
     account,
     network,
@@ -653,7 +660,7 @@ function ReceiveToken() {
                 >
                   <Token
                     size="lg"
-                    tokenImageUri={token?.logoURI}
+                    tokenImageUri={token?.logoURI ?? nativeToken?.logoURI}
                     networkImageUri={network.logoURI}
                     networkId={networkId}
                   />
@@ -691,6 +698,7 @@ function ReceiveToken() {
     token?.logoURI,
     networkId,
     intl,
+    nativeToken?.logoURI,
   ]);
 
   return (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensures the token image in the Receive screen and QR code displays correctly by falling back to the native token icon when a token image is unavailable.

- **Improvements**
  - Token icons update more reliably when native asset details change, providing a more consistent visual experience during receive flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->