### PR TITLE
feat: add cache support for market trending list

### DIFF
--- a/packages/kit-bg/src/services/ServiceMarket.ts
+++ b/packages/kit-bg/src/services/ServiceMarket.ts
@@ -6,8 +6,10 @@ import {
 } from '@onekeyhq/shared/src/background/backgroundDecorators';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import { memoizee } from '@onekeyhq/shared/src/utils/cacheUtils';
 import { generateLocalIndexedIdFunc } from '@onekeyhq/shared/src/utils/miscUtils';
 import sortUtils from '@onekeyhq/shared/src/utils/sortUtils';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { EServiceEndpointEnum } from '@onekeyhq/shared/types/endpoint';
 import type {
   IMarketCategory,
@@ -34,13 +36,23 @@ class ServiceMarket extends ServiceBase {
     super({ backgroundApi });
   }
 
+  _fetchCategories = memoizee(
+    async () => {
+      const client = await this.getClient(EServiceEndpointEnum.Utility);
+      const response = await client.get<{
+        data: IMarketCategory[];
+      }>('/utility/v1/market/category/list');
+      return response.data.data;
+    },
+    {
+      promise: true,
+      maxAge: timerUtils.getTimeDurationMs({ minute: 5 }),
+    },
+  );
+
   @backgroundMethod()
   async fetchCategories(filters = [ONEKEY_SEARCH_TRANDING]) {
-    const client = await this.getClient(EServiceEndpointEnum.Utility);
-    const response = await client.get<{
-      data: IMarketCategory[];
-    }>('/utility/v1/market/category/list');
-    const { data } = response.data;
+    const data = await this._fetchCategories();
     return filters.length
       ? data
           .filter((i) => !filters.includes(i.categoryId))

--- a/packages/kit-bg/src/services/ServiceMarket.ts
+++ b/packages/kit-bg/src/services/ServiceMarket.ts
@@ -46,7 +46,7 @@ class ServiceMarket extends ServiceBase {
     },
     {
       promise: true,
-      maxAge: timerUtils.getTimeDurationMs({ minute: 5 }),
+      maxAge: timerUtils.getTimeDurationMs({ minute: 45 }),
     },
   );
 
@@ -60,18 +60,28 @@ class ServiceMarket extends ServiceBase {
       : data;
   }
 
+  _fetchSearchTrending = memoizee(
+    async () => {
+      const categories = await this.fetchCategories([]);
+      const searchTrendingCategory = categories.find(
+        (i) => i.categoryId === ONEKEY_SEARCH_TRANDING,
+      );
+      return searchTrendingCategory
+        ? this.fetchCategory(
+            searchTrendingCategory.categoryId,
+            searchTrendingCategory.coingeckoIds,
+          )
+        : [];
+    },
+    {
+      promise: true,
+      maxAge: timerUtils.getTimeDurationMs({ minute: 15 }),
+    },
+  );
+
   @backgroundMethod()
   async fetchSearchTrending() {
-    const categories = await this.fetchCategories([]);
-    const searchTrendingCategory = categories.find(
-      (i) => i.categoryId === ONEKEY_SEARCH_TRANDING,
-    );
-    return searchTrendingCategory
-      ? this.fetchCategory(
-          searchTrendingCategory.categoryId,
-          searchTrendingCategory.coingeckoIds,
-        )
-      : [];
+    return this._fetchSearchTrending();
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceMarket.ts
+++ b/packages/kit-bg/src/services/ServiceMarket.ts
@@ -46,7 +46,7 @@ class ServiceMarket extends ServiceBase {
     },
     {
       promise: true,
-      maxAge: timerUtils.getTimeDurationMs({ minute: 45 }),
+      maxAge: timerUtils.getTimeDurationMs({ minute: 15 }),
     },
   );
 

--- a/packages/kit-bg/src/services/ServiceMarket.ts
+++ b/packages/kit-bg/src/services/ServiceMarket.ts
@@ -75,7 +75,7 @@ class ServiceMarket extends ServiceBase {
     },
     {
       promise: true,
-      maxAge: timerUtils.getTimeDurationMs({ minute: 15 }),
+      maxAge: timerUtils.getTimeDurationMs({ minute: 5 }),
     },
   );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Added time-bound caching for market categories (15 minutes) and trending searches (5 minutes) to reduce redundant requests.
  * Improves responsiveness and stability when viewing categories and trending search results, especially on repeat visits.
  * Decreases network usage, leading to faster load times and a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->