### PR TITLE
fix: improve HyperLiquid agent replacement logic to prioritize non-OneKey agents

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -701,21 +701,28 @@ export default class ServiceHyperliquid extends ServiceBase {
       const privateKeyHex = bufferUtils.bytesToHex(privateKeyBytes);
       const agentAddress = new ethers.Wallet(privateKeyHex).address as IHex;
 
-      const availableNames = [
+      const onekeyAgentNames = [
         EHyperLiquidAgentName.OneKeyAgent1,
         EHyperLiquidAgentName.OneKeyAgent2,
         EHyperLiquidAgentName.OneKeyAgent3,
       ];
       let agentNameToApprove: EHyperLiquidAgentName | undefined;
       if (extraAgents.length === 3) {
-        const agentToRemove = extraAgents.sort(
-          (a, b) => a.validUntil - b.validUntil,
-        )?.[0];
+        const nonOneKeyAgents = extraAgents.filter(
+          (agent) =>
+            !onekeyAgentNames.includes(agent.name as EHyperLiquidAgentName),
+        );
+        const agentToRemove = (
+          nonOneKeyAgents.length ? nonOneKeyAgents : extraAgents
+        ).sort((a, b) => a.validUntil - b.validUntil)?.[0];
         const agentNameToRemove = agentToRemove?.name as
           | EHyperLiquidAgentName
           | undefined;
         if (agentToRemove) {
-          if (agentNameToRemove && availableNames.includes(agentNameToRemove)) {
+          if (
+            agentNameToRemove &&
+            onekeyAgentNames.includes(agentNameToRemove)
+          ) {
             agentNameToApprove = agentNameToRemove;
           } else {
             const approveAgentResult = await this.exchangeService.removeAgent({
@@ -760,7 +767,7 @@ export default class ServiceHyperliquid extends ServiceBase {
         }
       }
       if (!agentNameToApprove) {
-        for (const agentName of availableNames) {
+        for (const agentName of onekeyAgentNames) {
           if (!extraAgents.some((agent) => agent.name === agentName)) {
             agentNameToApprove = agentName;
             break;


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Prioritizes OneKey agents during selection and approval.
  * Introduces smarter removal logic that prefers removing non-OneKey agents first.
  * Enhances fallback approval to iterate through OneKey agents reliably.

* Bug Fixes
  * Prevents unintended removal of OneKey agents when multiple agents are present.
  * Improves agent name validation to reduce approval errors and edge-case failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Improved agent replacement logic when all 3 HyperLiquid agent slots are occupied
- System now prioritizes removing non-OneKey agents before removing OneKey's own agents
- Prevents unnecessary removal and re-creation of OneKeyAgent1/2/3

## Changes
- Added `onekeyAgentNames` array to identify OneKey-managed agents
- Modified agent removal logic to filter and prioritize non-OneKey agents
- Maintains existing validUntil-based sorting for selecting oldest agent to remove

## Test plan
- [ ] Verify agent approval works when less than 3 agents exist
- [ ] Verify non-OneKey agents are removed first when all 3 slots occupied
- [ ] Verify OneKey agents are removed only when all 3 slots have OneKey agents
- [ ] Verify existing agent re-use logic still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)