### PR TITLE
fix: perp deposit to swap OK-44112

### DIFF
--- a/packages/kit/src/views/Perp/components/TradingGuardWrapper.tsx
+++ b/packages/kit/src/views/Perp/components/TradingGuardWrapper.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { memo, useCallback, useMemo } from 'react';
 
-import { Button, SizableText } from '@onekeyhq/components';
+import { Button, SizableText, useInTabDialog } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import {
   usePerpsAccountLoadingInfoAtom,
@@ -37,7 +37,7 @@ function TradingGuardWrapperInternal({
     }),
     [perpsAccount.accountAddress, perpsAccount.accountId],
   );
-
+  const dialogInTab = useInTabDialog();
   const enableTrading = useCallback(async () => {
     try {
       const status =
@@ -47,15 +47,18 @@ function TradingGuardWrapperInternal({
         accountInfo.accountAddress &&
         accountInfo.accountId
       ) {
-        void showDepositWithdrawModal({
-          withdrawable: '0',
-          actionType: 'deposit',
-        });
+        void showDepositWithdrawModal(
+          {
+            withdrawable: '0',
+            actionType: 'deposit',
+          },
+          dialogInTab,
+        );
       }
     } catch (error) {
       console.error('[TradingGuardWrapper] Enable trading failed:', error);
     }
-  }, [accountInfo.accountAddress, accountInfo.accountId]);
+  }, [accountInfo.accountAddress, accountInfo.accountId, dialogInTab]);
 
   const shouldShowEnableTrading = useMemo(
     () => forceShowEnableTrading || !isAgentReady,

--- a/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingButton.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingButton.tsx
@@ -4,7 +4,13 @@ import { BigNumber } from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
 import type { IButtonProps } from '@onekeyhq/components';
-import { Button, SizableText, Spinner, Toast } from '@onekeyhq/components';
+import {
+  Button,
+  SizableText,
+  Spinner,
+  Toast,
+  useInTabDialog,
+} from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { AccountSelectorCreateAddressButton } from '@onekeyhq/kit/src/components/AccountSelector/AccountSelectorCreateAddressButton';
 import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
@@ -65,7 +71,7 @@ export function PerpTradingButton({
     perpsAccountLoading.enableTradingLoading,
     perpsAccountLoading.selectAccountLoading,
   ]);
-
+  const dialogInTab = useInTabDialog();
   const enableTrading = useCallback(async () => {
     const status = await backgroundApiProxy.serviceHyperliquid.enableTrading();
     if (
@@ -73,12 +79,15 @@ export function PerpTradingButton({
       perpsAccount.accountAddress &&
       perpsAccount.accountId
     ) {
-      await showDepositWithdrawModal({
-        withdrawable: '0',
-        actionType: 'deposit',
-      });
+      await showDepositWithdrawModal(
+        {
+          withdrawable: '0',
+          actionType: 'deposit',
+        },
+        dialogInTab,
+      );
     }
-  }, [perpsAccount.accountAddress, perpsAccount.accountId]);
+  }, [perpsAccount.accountAddress, perpsAccount.accountId, dialogInTab]);
 
   const buttonDisabled = useMemo(() => {
     return (

--- a/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
@@ -9,6 +9,7 @@ import {
   IconButton,
   SizableText,
   XStack,
+  useInTabDialog,
   useMedia,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
@@ -96,17 +97,20 @@ function DepositButton() {
   const accountValue = accountSummary?.accountValue;
   const intl = useIntl();
   const [activeAccount] = usePerpsActiveAccountAtom();
-
+  const dialogInTab = useInTabDialog();
   const content = activeAccount.accountAddress ? (
     <Badge
       borderRadius="$full"
       size="medium"
       variant="secondary"
       onPress={() =>
-        showDepositWithdrawModal({
-          actionType: 'deposit',
-          withdrawable: accountSummary?.withdrawable || '0',
-        })
+        showDepositWithdrawModal(
+          {
+            actionType: 'deposit',
+            withdrawable: accountSummary?.withdrawable || '0',
+          },
+          dialogInTab,
+        )
       }
       alignItems="center"
       justifyContent="center"

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
@@ -10,6 +10,7 @@ import {
   Tooltip,
   XStack,
   YStack,
+  useInTabDialog,
 } from '@onekeyhq/components';
 import {
   usePerpsActiveAccountAtom,
@@ -91,7 +92,7 @@ function PerpAccountPanel() {
   const [accountSummary] = usePerpsActiveAccountSummaryAtom();
   const [selectedAccount] = usePerpsActiveAccountAtom();
   const userAddress = selectedAccount.accountAddress;
-
+  const dialogInTab = useInTabDialog();
   const intl = useIntl();
 
   //     if (!userWebData2) {
@@ -222,10 +223,13 @@ function PerpAccountPanel() {
             size="medium"
             variant="secondary"
             onPress={() =>
-              showDepositWithdrawModal({
-                actionType: 'deposit',
-                withdrawable: accountSummary?.withdrawable || '0',
-              })
+              showDepositWithdrawModal(
+                {
+                  actionType: 'deposit',
+                  withdrawable: accountSummary?.withdrawable || '0',
+                },
+                dialogInTab,
+              )
             }
             alignItems="center"
             justifyContent="center"
@@ -240,10 +244,13 @@ function PerpAccountPanel() {
             size="medium"
             variant="secondary"
             onPress={() =>
-              showDepositWithdrawModal({
-                actionType: 'withdraw',
-                withdrawable: accountSummary?.withdrawable || '0',
-              })
+              showDepositWithdrawModal(
+                {
+                  actionType: 'withdraw',
+                  withdrawable: accountSummary?.withdrawable || '0',
+                },
+                dialogInTab,
+              )
             }
             alignItems="center"
             justifyContent="center"

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -14,6 +14,7 @@ import {
   Tooltip,
   XStack,
   YStack,
+  useInTabDialog,
 } from '@onekeyhq/components';
 import type { ICheckedState } from '@onekeyhq/components';
 import {
@@ -58,6 +59,7 @@ interface IPerpTradingFormProps {
 
 function MobileDepositButton() {
   const [accountSummary] = usePerpsActiveAccountSummaryAtom();
+  const dialogInTab = useInTabDialog();
   return (
     <IconButton
       testID="perp-trading-form-mobile-deposit-button"
@@ -66,10 +68,13 @@ function MobileDepositButton() {
       iconSize="$3.5"
       icon="PlusCircleSolid"
       onPress={() =>
-        showDepositWithdrawModal({
-          actionType: 'deposit',
-          withdrawable: accountSummary?.withdrawable || '0',
-        })
+        showDepositWithdrawModal(
+          {
+            actionType: 'deposit',
+            withdrawable: accountSummary?.withdrawable || '0',
+          },
+          dialogInTab,
+        )
       }
       color="$iconSubdued"
       cursor="pointer"

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -79,6 +79,7 @@ export enum ESwapSource {
   MARKET = 'market',
   TAB = 'tab',
   APPROVING_SUCCESS = 'approving_success',
+  PERP = 'perp',
 }
 
 export enum ESwapSelectTokenSource {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Deposit/Withdraw now opens as an in-tab dialog across Perp trading screens for a smoother, consistent experience.
  - Start a token swap directly from the Deposit/Withdraw modal (e.g., when balance is insufficient), with seamless navigation to Swap.

- Bug Fixes
  - Improved validation and error messages for available balance and minimum deposit/withdraw amounts.
  - “Max” amount now uses the correct available balance.
  - More reliable modal close behavior within the tab dialog context.

- Chores
  - Internal updates to support Perp as a swap source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->