### PR TITLE
feat: add perps button on home page

### DIFF
--- a/packages/components/src/content/NumberSizeableText/index.tsx
+++ b/packages/components/src/content/NumberSizeableText/index.tsx
@@ -56,11 +56,10 @@ export function NumberSizeableText({
       return children;
     }
     return ['string', 'number'].includes(typeof children)
-      ? numberFormatAsRenderText(
-          String(children),
-          { formatter: actualFormatter, formatterOptions },
-          true,
-        )
+      ? numberFormatAsRenderText(String(children), {
+          formatter: actualFormatter,
+          formatterOptions,
+        })
       : '';
   }, [actualFormatter, formatterOptions, children]);
 

--- a/packages/components/src/content/NumberSizeableText/index.tsx
+++ b/packages/components/src/content/NumberSizeableText/index.tsx
@@ -4,7 +4,7 @@ import BigNumber from 'bignumber.js';
 import { isString } from 'lodash';
 
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormatAsRenderText } from '@onekeyhq/shared/src/utils/numberUtils';
 
 import { SizableText } from '../../primitives';
 import { getFontSize } from '../../utils';
@@ -56,7 +56,7 @@ export function NumberSizeableText({
       return children;
     }
     return ['string', 'number'].includes(typeof children)
-      ? numberFormat(
+      ? numberFormatAsRenderText(
           String(children),
           { formatter: actualFormatter, formatterOptions },
           true,

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -24,9 +24,10 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { getRequestHeaders } from '@onekeyhq/shared/src/request/Interceptor';
 import { memoizee } from '@onekeyhq/shared/src/utils/cacheUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
+import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   formatBalance,
-  numberFormat,
+  numberFormatAsString,
 } from '@onekeyhq/shared/src/utils/numberUtils';
 import { equalsIgnoreCase } from '@onekeyhq/shared/src/utils/stringUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
@@ -91,6 +92,9 @@ import ServiceBase from './ServiceBase';
 
 import type { IAllNetworkAccountInfo } from './ServiceAllNetwork/ServiceAllNetwork';
 
+const formatter: INumberFormatProps = {
+  formatter: 'balance',
+};
 @backgroundClass()
 export default class ServiceSwap extends ServiceBase {
   private _quoteAbortController?: AbortController;
@@ -1468,15 +1472,13 @@ export default class ServiceSwap extends ServiceBase {
                 ? ETranslations.swap_page_toast_swap_successful
                 : ETranslations.swap_page_toast_swap_failed,
           }),
-          message: `${
-            numberFormat(item.baseInfo.fromAmount, {
-              formatter: 'balance',
-            }) as string
-          } ${item.baseInfo.fromToken.symbol} → ${
-            numberFormat(item.baseInfo.toAmount, {
-              formatter: 'balance',
-            }) as string
-          } ${item.baseInfo.toToken.symbol}`,
+          message: `${numberFormatAsString(
+            item.baseInfo.fromAmount,
+            formatter,
+          )} ${item.baseInfo.fromToken.symbol} → ${numberFormatAsString(
+            item.baseInfo.toAmount,
+            formatter,
+          )} ${item.baseInfo.toToken.symbol}`,
         });
       }
     }

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -1472,13 +1472,11 @@ export default class ServiceSwap extends ServiceBase {
                 ? ETranslations.swap_page_toast_swap_successful
                 : ETranslations.swap_page_toast_swap_failed,
           }),
-          message: `${numberFormat(
-            item.baseInfo.fromAmount,
-            formatter,
-          )} ${item.baseInfo.fromToken.symbol} → ${numberFormat(
-            item.baseInfo.toAmount,
-            formatter,
-          )} ${item.baseInfo.toToken.symbol}`,
+          message: `${numberFormat(item.baseInfo.fromAmount, formatter)} ${
+            item.baseInfo.fromToken.symbol
+          } → ${numberFormat(item.baseInfo.toAmount, formatter)} ${
+            item.baseInfo.toToken.symbol
+          }`,
         });
       }
     }

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -27,7 +27,7 @@ import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   formatBalance,
-  numberFormatAsString,
+  numberFormat,
 } from '@onekeyhq/shared/src/utils/numberUtils';
 import { equalsIgnoreCase } from '@onekeyhq/shared/src/utils/stringUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
@@ -1472,10 +1472,10 @@ export default class ServiceSwap extends ServiceBase {
                 ? ETranslations.swap_page_toast_swap_successful
                 : ETranslations.swap_page_toast_swap_failed,
           }),
-          message: `${numberFormatAsString(
+          message: `${numberFormat(
             item.baseInfo.fromAmount,
             formatter,
-          )} ${item.baseInfo.fromToken.symbol} → ${numberFormatAsString(
+          )} ${item.baseInfo.fromToken.symbol} → ${numberFormat(
             item.baseInfo.toAmount,
             formatter,
           )} ${item.baseInfo.toToken.symbol}`,

--- a/packages/kit/src/views/Home/components/WalletActions/RawActions.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/RawActions.tsx
@@ -138,6 +138,17 @@ function ActionBridge(props: IActionItemsProps) {
   );
 }
 
+function ActionPerp(props: IActionItemsProps) {
+  const intl = useIntl();
+  return (
+    <ActionItem
+      label={intl.formatMessage({ id: ETranslations.global_perp })}
+      icon="ChartLineOutline"
+      {...props}
+    />
+  );
+}
+
 function ActionEarn(props: IActionItemsProps) {
   const intl = useIntl();
   return (
@@ -199,6 +210,7 @@ RawActions.Send = ActionSend;
 RawActions.Receive = ActionReceive;
 RawActions.Swap = ActionSwap;
 RawActions.Bridge = ActionBridge;
+RawActions.Perp = ActionPerp;
 RawActions.Earn = ActionEarn;
 
 export { RawActions, ActionItem };

--- a/packages/kit/src/views/Home/components/WalletActions/index.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/index.tsx
@@ -269,9 +269,11 @@ function WalletActions({ ...rest }: IXStackProps) {
     <RawActions {...rest}>
       <WalletActionSend />
       <WalletActionReceive />
-      {platformEnv.isExtensionUiPopup ? <WalletActionPerp /> : null}
-      <WalletActionSwap />
-      <WalletActionPerp />
+      {platformEnv.isExtensionUiPopup ? (
+        <WalletActionPerp />
+      ) : (
+        <WalletActionSwap />
+      )}
       <WalletActionMore />
     </RawActions>
   );

--- a/packages/kit/src/views/Home/components/WalletActions/index.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/index.tsx
@@ -15,6 +15,7 @@ import {
 } from '@onekeyhq/kit/src/states/jotai/contexts/tokenList';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type {
   IModalSendParamList,
   IModalSwapParamList,
@@ -23,7 +24,9 @@ import {
   EModalRoutes,
   EModalSignatureConfirmRoutes,
   EModalSwapRoutes,
+  ETabRoutes,
 } from '@onekeyhq/shared/src/routes';
+import type { IModalPerpParamList } from '@onekeyhq/shared/src/routes/perp';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import {
   ESwapSource,
@@ -254,12 +257,23 @@ function WalletActionSwap() {
   );
 }
 
+function WalletActionPerp() {
+  const navigation =
+    useAppNavigation<IPageNavigationProp<IModalPerpParamList>>();
+  const handlePress = useCallback(() => {
+    navigation.switchTab(ETabRoutes.Perp);
+  }, [navigation]);
+  return <RawActions.Perp onPress={handlePress} />;
+}
+
 function WalletActions({ ...rest }: IXStackProps) {
   return (
     <RawActions {...rest}>
       <WalletActionSend />
       <WalletActionReceive />
+      {platformEnv.isExtensionUiPopup ? <WalletActionPerp /> : null}
       <WalletActionSwap />
+      <WalletActionPerp />
       <WalletActionMore />
     </RawActions>
   );

--- a/packages/kit/src/views/Home/components/WalletActions/index.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/index.tsx
@@ -37,6 +37,7 @@ import type { IToken } from '@onekeyhq/shared/types/token';
 import { RawActions } from './RawActions';
 import { WalletActionMore } from './WalletActionMore';
 import { WalletActionReceive } from './WalletActionReceive';
+import { shouldOpenExpandExtPerp } from '../../../Perp/pages/ExtPerp';
 
 function WalletActionSend() {
   const navigation =
@@ -259,7 +260,9 @@ function WalletActionSwap() {
 
 function WalletActionPerp() {
   const handlePress = useCallback(() => {
-    void backgroundApiProxy.serviceWebviewPerp.openExtPerpTab();
+    if (shouldOpenExpandExtPerp()) {
+      void backgroundApiProxy.serviceWebviewPerp.openExtPerpTab();
+    }
   }, []);
   return <RawActions.Perp onPress={handlePress} />;
 }

--- a/packages/kit/src/views/Home/components/WalletActions/index.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/index.tsx
@@ -258,11 +258,9 @@ function WalletActionSwap() {
 }
 
 function WalletActionPerp() {
-  const navigation =
-    useAppNavigation<IPageNavigationProp<IModalPerpParamList>>();
   const handlePress = useCallback(() => {
-    navigation.switchTab(ETabRoutes.Perp);
-  }, [navigation]);
+    void backgroundApiProxy.serviceWebviewPerp.openExtPerpTab();
+  }, []);
   return <RawActions.Perp onPress={handlePress} />;
 }
 

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -7,7 +7,6 @@ import {
   Button,
   IconButton,
   Skeleton,
-  Stack,
   XStack,
   YStack,
   useMedia,
@@ -25,7 +24,7 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormatAsRenderText } from '@onekeyhq/shared/src/utils/numberUtils';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
 import { EHomeTab } from '@onekeyhq/shared/types';
 
@@ -33,7 +32,6 @@ import backgroundApiProxy from '../../../background/instance/backgroundApiProxy'
 import { AllNetworksManagerTrigger } from '../../../components/AccountSelector/AllNetworksManagerTrigger';
 import NumberSizeableTextWrapper from '../../../components/NumberSizeableTextWrapper';
 import { showResourceDetailsDialog } from '../../../components/Resource';
-import { usePromiseResult } from '../../../hooks/usePromiseResult';
 import {
   useAccountOverviewActions,
   useAccountOverviewStateAtom,
@@ -344,7 +342,7 @@ function HomeOverviewContainer() {
                   md
                     ? balanceSizeList.find(
                         (item) =>
-                          numberFormat(
+                          numberFormatAsRenderText(
                             String(balanceString),
                             numberFormatter,
                             true,

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -345,7 +345,6 @@ function HomeOverviewContainer() {
                           numberFormatAsRenderText(
                             String(balanceString),
                             numberFormatter,
-                            true,
                           ).length >= item.length,
                       )?.size ?? defaultBalanceSize
                     : defaultBalanceSize

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationPanel/InformationPanel.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationPanel/InformationPanel.tsx
@@ -63,7 +63,6 @@ export function InformationPanel() {
     address = '',
   } = tokenDetail;
 
-
   const formattedMarketCap = numberFormat(marketCap, currencyFormatter);
 
   const formattedLiquidity = numberFormat(liquidity, currencyFormatter);

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationPanel/InformationPanel.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationPanel/InformationPanel.tsx
@@ -7,7 +7,7 @@ import { MarketTokenPrice } from '@onekeyhq/kit/src/views/Market/components/Mark
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 
 import { useTokenDetail } from '../../hooks/useTokenDetail';
 import { TokenSecurityAlert } from '../TokenSecurityAlert';
@@ -64,9 +64,9 @@ export function InformationPanel() {
   } = tokenDetail;
 
 
-  const formattedMarketCap = numberFormatAsString(marketCap, currencyFormatter);
+  const formattedMarketCap = numberFormat(marketCap, currencyFormatter);
 
-  const formattedLiquidity = numberFormatAsString(liquidity, currencyFormatter);
+  const formattedLiquidity = numberFormat(liquidity, currencyFormatter);
 
   const priceChangeNum = parseFloat(priceChange24hPercent);
   const isPriceUp = priceChangeNum >= 0;
@@ -109,7 +109,7 @@ export function InformationPanel() {
             {intl.formatMessage({ id: ETranslations.dexmarket_holders })}
           </SizableText>
           <SizableText size="$bodySmMedium">
-            {numberFormatAsString(String(holders), marketCapFormatter)}
+            {numberFormat(String(holders), marketCapFormatter)}
           </SizableText>
         </XStack>
         {/* Audit / Security - Only show when we have security data */}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationPanel/InformationPanel.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationPanel/InformationPanel.tsx
@@ -1,10 +1,13 @@
+import { useMemo } from 'react';
+
 import { useIntl } from 'react-intl';
 
 import { SizableText, XStack, YStack } from '@onekeyhq/components';
 import { MarketTokenPrice } from '@onekeyhq/kit/src/views/Market/components/MarketTokenPrice';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
 
 import { useTokenDetail } from '../../hooks/useTokenDetail';
 import { TokenSecurityAlert } from '../TokenSecurityAlert';
@@ -22,6 +25,10 @@ function getPriceSizeByValue(price: string) {
   return '$heading3xl';
 }
 
+const marketCapFormatter: INumberFormatProps = {
+  formatter: 'marketCap',
+};
+
 export function InformationPanel() {
   const intl = useIntl();
   const [settings] = useSettingsPersistAtom();
@@ -32,6 +39,16 @@ export function InformationPanel() {
     tokenAddress,
     networkId,
   });
+
+  const currencyFormatter: INumberFormatProps = useMemo(() => {
+    const currencySymbol = settings.currencyInfo.symbol;
+    return {
+      formatter: 'marketCap',
+      formatterOptions: {
+        currency: currencySymbol,
+      },
+    };
+  }, [settings.currencyInfo.symbol]);
 
   if (!tokenDetail) return <InformationPanelSkeleton />;
 
@@ -46,21 +63,10 @@ export function InformationPanel() {
     address = '',
   } = tokenDetail;
 
-  const currencySymbol = settings.currencyInfo.symbol;
 
-  const formattedMarketCap = numberFormat(marketCap, {
-    formatter: 'marketCap',
-    formatterOptions: {
-      currency: currencySymbol,
-    },
-  });
+  const formattedMarketCap = numberFormatAsString(marketCap, currencyFormatter);
 
-  const formattedLiquidity = numberFormat(liquidity, {
-    formatter: 'marketCap',
-    formatterOptions: {
-      currency: currencySymbol,
-    },
-  });
+  const formattedLiquidity = numberFormatAsString(liquidity, currencyFormatter);
 
   const priceChangeNum = parseFloat(priceChange24hPercent);
   const isPriceUp = priceChangeNum >= 0;
@@ -103,7 +109,7 @@ export function InformationPanel() {
             {intl.formatMessage({ id: ETranslations.dexmarket_holders })}
           </SizableText>
           <SizableText size="$bodySmMedium">
-            {numberFormat(String(holders), { formatter: 'marketCap' })}
+            {numberFormatAsString(String(holders), marketCapFormatter)}
           </SizableText>
         </XStack>
         {/* Audit / Security - Only show when we have security data */}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx
@@ -14,9 +14,7 @@ import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms'
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { EModalRoutes, EOnboardingPages } from '@onekeyhq/shared/src/routes';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import {
-  numberFormatAsString,
-} from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 
 import { useTokenDetail } from '../../../hooks/useTokenDetail';
 import { usePaymentTokenPrice } from '../hooks/usePaymentTokenPrice';
@@ -155,17 +153,11 @@ export function ActionButton({
 
   // Disable button if insufficient balance
   const shouldDisable = isInsufficientBalance;
-  const displayAmountFormatted = numberFormatAsString(
-    displayAmount,
-    tokenFormatter,
-  );
+  const displayAmountFormatted = numberFormat(displayAmount, tokenFormatter);
 
   let buttonText = `${actionText} ${displayAmountFormatted} `;
   if (typeof totalValue === 'number') {
-    buttonText += `(${numberFormatAsString(
-      totalValue.toFixed(2),
-      currencyFormatter,
-    )})`;
+    buttonText += `(${numberFormat(totalValue.toFixed(2), currencyFormatter)})`;
   }
 
   if (isWrapped) {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx
@@ -13,7 +13,10 @@ import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accoun
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { EModalRoutes, EOnboardingPages } from '@onekeyhq/shared/src/routes';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
+import {
+  numberFormatAsString,
+} from '@onekeyhq/shared/src/utils/numberUtils';
 
 import { useTokenDetail } from '../../../hooks/useTokenDetail';
 import { usePaymentTokenPrice } from '../hooks/usePaymentTokenPrice';
@@ -95,6 +98,24 @@ export function ActionButton({
     amountBN,
   ]);
 
+  const tokenFormatter: INumberFormatProps = useMemo(() => {
+    return {
+      formatter: 'balance',
+      formatterOptions: {
+        tokenSymbol: token?.symbol || '',
+      },
+    };
+  }, [token?.symbol]);
+
+  const currencyFormatter: INumberFormatProps = useMemo(() => {
+    return {
+      formatter: 'value',
+      formatterOptions: {
+        currency: settingsValue.currencyInfo.symbol,
+      },
+    };
+  }, [settingsValue.currencyInfo.symbol]);
+
   const shouldCreateAddress = usePromiseResult(async () => {
     let result = false;
     if (activeAccount?.canCreateAddress && !createAddressLoading) {
@@ -134,23 +155,17 @@ export function ActionButton({
 
   // Disable button if insufficient balance
   const shouldDisable = isInsufficientBalance;
-  const displayAmountFormatted = numberFormat(displayAmount, {
-    formatter: 'balance',
-    formatterOptions: {
-      tokenSymbol: token?.symbol || '',
-    },
-  });
+  const displayAmountFormatted = numberFormatAsString(
+    displayAmount,
+    tokenFormatter,
+  );
 
-  let buttonText = `${actionText} ${displayAmountFormatted as string} `;
+  let buttonText = `${actionText} ${displayAmountFormatted} `;
   if (typeof totalValue === 'number') {
-    buttonText += `(${
-      numberFormat(totalValue.toFixed(2), {
-        formatter: 'value',
-        formatterOptions: {
-          currency: settingsValue.currencyInfo.symbol,
-        },
-      }) as string
-    })`;
+    buttonText += `(${numberFormatAsString(
+      totalValue.toFixed(2),
+      currencyFormatter,
+    )})`;
   }
 
   if (isWrapped) {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/RateDisplay.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/RateDisplay.tsx
@@ -1,5 +1,8 @@
+import { useMemo } from 'react';
+
 import { SizableText, Skeleton, XStack } from '@onekeyhq/components';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
 
 export interface IRateDisplayProps {
   rate?: number;
@@ -14,14 +17,19 @@ export function RateDisplay({
   toTokenSymbol,
   loading,
 }: IRateDisplayProps) {
-  const rateFormatted = rate
-    ? numberFormat(rate.toString(), {
-        formatter: 'price',
-        formatterOptions: {
-          tokenSymbol: toTokenSymbol || '',
-        },
-      })
-    : '-';
+  const formatter: INumberFormatProps = useMemo(
+    () => ({
+      formatter: 'price',
+      formatterOptions: {
+        tokenSymbol: toTokenSymbol || '',
+      },
+    }),
+    [toTokenSymbol],
+  );
+  const rateFormatted = useMemo(
+    () => (rate ? numberFormatAsString(rate.toString(), formatter) : '-'),
+    [formatter, rate],
+  );
 
   return (
     <XStack alignItems="center" height="$4">
@@ -29,7 +37,7 @@ export function RateDisplay({
         <Skeleton width="$32" height="$4" />
       ) : (
         <SizableText size="$bodySm" userSelect="none" color="$textSubdued">
-          {`1 ${fromTokenSymbol ?? '-'} = ${rateFormatted as string}`}
+          {`1 ${fromTokenSymbol ?? '-'} = ${rateFormatted}`}
         </SizableText>
       )}
     </XStack>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/RateDisplay.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/RateDisplay.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import { SizableText, Skeleton, XStack } from '@onekeyhq/components';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 
 export interface IRateDisplayProps {
   rate?: number;
@@ -27,7 +27,7 @@ export function RateDisplay({
     [toTokenSymbol],
   );
   const rateFormatted = useMemo(
-    () => (rate ? numberFormatAsString(rate.toString(), formatter) : '-'),
+    () => (rate ? numberFormat(rate.toString(), formatter) : '-'),
     [formatter, rate],
   );
 

--- a/packages/kit/src/views/Market/MarketHomeV2/components/LiquidityFilterControl/LiquidityFilterContent.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/LiquidityFilterControl/LiquidityFilterContent.tsx
@@ -12,7 +12,7 @@ import {
   XStack,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 
 import { parseValueToNumber, validateLiquidityInput } from '../../utils';
 
@@ -96,7 +96,7 @@ function LiquidityFilterContent({
 
       let finalPreset = preset;
       if (presetNum > maximumMinValue) {
-        finalPreset = numberFormatAsString(
+        finalPreset = numberFormat(
           String(maximumMinValue),
           marketCapFormatter,
         );
@@ -124,7 +124,7 @@ function LiquidityFilterContent({
         // Enforce maximum minimum value of 1t (minimum value cannot exceed 1t)
         const finalMinNum = Math.min(minNum, 1_000_000_000_000);
         convertedMin = String(
-          numberFormatAsString(String(finalMinNum), marketCapFormatter),
+          numberFormat(String(finalMinNum), marketCapFormatter),
         );
       } catch (error) {
         // Keep original value if parsing fails
@@ -137,7 +137,7 @@ function LiquidityFilterContent({
         const maxNum = parseValueToNumber(maxValue.trim());
         // No restriction on maximum value
         convertedMax = String(
-          numberFormatAsString(String(maxNum), marketCapFormatter),
+          numberFormat(String(maxNum), marketCapFormatter),
         );
       } catch (error) {
         // Keep original value if parsing fails

--- a/packages/kit/src/views/Market/MarketHomeV2/components/LiquidityFilterControl/LiquidityFilterContent.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/LiquidityFilterControl/LiquidityFilterContent.tsx
@@ -12,7 +12,8 @@ import {
   XStack,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormatAsRenderText } from '@onekeyhq/shared/src/utils/numberUtils';
 
 import { parseValueToNumber, validateLiquidityInput } from '../../utils';
 
@@ -96,7 +97,7 @@ function LiquidityFilterContent({
 
       let finalPreset = preset;
       if (presetNum > maximumMinValue) {
-        finalPreset = numberFormat(
+        finalPreset = numberFormatAsRenderText(
           String(maximumMinValue),
           marketCapFormatter,
         );
@@ -136,9 +137,7 @@ function LiquidityFilterContent({
       try {
         const maxNum = parseValueToNumber(maxValue.trim());
         // No restriction on maximum value
-        convertedMax = String(
-          numberFormat(String(maxNum), marketCapFormatter),
-        );
+        convertedMax = String(numberFormat(String(maxNum), marketCapFormatter));
       } catch (error) {
         // Keep original value if parsing fails
         convertedMax = maxValue;

--- a/packages/kit/src/views/Market/MarketHomeV2/components/LiquidityFilterControl/LiquidityFilterContent.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/LiquidityFilterControl/LiquidityFilterContent.tsx
@@ -12,9 +12,13 @@ import {
   XStack,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
 
 import { parseValueToNumber, validateLiquidityInput } from '../../utils';
+
+const marketCapFormatter: INumberFormatProps = {
+  formatter: 'marketCap',
+};
 
 type ILiquidityFilterContentProps = {
   value?: { min?: string; max?: string };
@@ -92,8 +96,9 @@ function LiquidityFilterContent({
 
       let finalPreset = preset;
       if (presetNum > maximumMinValue) {
-        finalPreset = String(
-          numberFormat(String(maximumMinValue), { formatter: 'marketCap' }),
+        finalPreset = numberFormatAsString(
+          String(maximumMinValue),
+          marketCapFormatter,
         );
       }
 
@@ -119,7 +124,7 @@ function LiquidityFilterContent({
         // Enforce maximum minimum value of 1t (minimum value cannot exceed 1t)
         const finalMinNum = Math.min(minNum, 1_000_000_000_000);
         convertedMin = String(
-          numberFormat(String(finalMinNum), { formatter: 'marketCap' }),
+          numberFormatAsString(String(finalMinNum), marketCapFormatter),
         );
       } catch (error) {
         // Keep original value if parsing fails
@@ -132,7 +137,7 @@ function LiquidityFilterContent({
         const maxNum = parseValueToNumber(maxValue.trim());
         // No restriction on maximum value
         convertedMax = String(
-          numberFormat(String(maxNum), { formatter: 'marketCap' }),
+          numberFormatAsString(String(maxNum), marketCapFormatter),
         );
       } catch (error) {
         // Keep original value if parsing fails

--- a/packages/kit/src/views/Market/MarketHomeV2/components/LiquidityFilterControl/LiquidityFilterContent.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/LiquidityFilterControl/LiquidityFilterContent.tsx
@@ -13,7 +13,7 @@ import {
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormatAsRenderText } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 
 import { parseValueToNumber, validateLiquidityInput } from '../../utils';
 
@@ -97,10 +97,7 @@ function LiquidityFilterContent({
 
       let finalPreset = preset;
       if (presetNum > maximumMinValue) {
-        finalPreset = numberFormatAsRenderText(
-          String(maximumMinValue),
-          marketCapFormatter,
-        );
+        finalPreset = numberFormat(String(maximumMinValue), marketCapFormatter);
       }
 
       onApply?.({ min: finalPreset, max: undefined });

--- a/packages/kit/src/views/Perp/components/HyperliquidTerms.tsx
+++ b/packages/kit/src/views/Perp/components/HyperliquidTerms.tsx
@@ -4,7 +4,12 @@ import { useFocusEffect } from '@react-navigation/native';
 import { useIntl } from 'react-intl';
 import { useWindowDimensions } from 'react-native';
 
-import type { ICarouselInstance, IYStackProps } from '@onekeyhq/components';
+import type {
+  IButtonProps,
+  ICarouselInstance,
+  IKeyOfIcons,
+  IYStackProps,
+} from '@onekeyhq/components';
 import {
   AnimatePresence,
   Button,
@@ -46,6 +51,47 @@ const useHeightRatio = () => {
   const { height } = useWindowDimensions();
   return height / 800;
 };
+
+function IndicatorButton({
+  top,
+  left,
+  right,
+  onPress,
+  visible,
+  iconName,
+  variant,
+}: {
+  top: number;
+  left?: number;
+  right?: number;
+  iconName: IKeyOfIcons;
+  variant: IButtonProps['variant'];
+  onPress: () => void;
+  visible: boolean;
+}) {
+  return (
+    <Stack position="absolute" left={left} top={top} right={right} zIndex={1}>
+      <AnimatePresence>
+        {visible ? (
+          <IconButton
+            size="small"
+            variant={variant}
+            icon={iconName}
+            iconColor="$green9"
+            borderWidth="$0.5"
+            onPress={onPress}
+            pressStyle={{
+              scale: 0.95,
+            }}
+            hoverStyle={{
+              scale: 1,
+            }}
+          />
+        ) : null}
+      </AnimatePresence>
+    </Stack>
+  );
+}
 
 export function HyperliquidTermsContent({
   overlayHeight,
@@ -349,6 +395,14 @@ export function HyperliquidTermsContent({
     [onPageIndexChange],
   );
 
+  const handlePrev = useCallback(() => {
+    carouselRef.current?.prev();
+    const prevIndex = currentIndex - 1;
+    setTimeout(() => {
+      handlePageChanged(prevIndex);
+    }, 100);
+  }, [currentIndex, handlePageChanged]);
+
   const handleNext = useCallback(() => {
     if (isConfirmationSlide) {
       if (canConfirm) {
@@ -359,15 +413,14 @@ export function HyperliquidTermsContent({
     carouselRef.current?.next();
     const nextIndex = currentIndex + 1;
     setTimeout(() => {
-      setCurrentIndex(nextIndex);
-      onPageIndexChange?.(nextIndex);
+      handlePageChanged(nextIndex);
     }, 100);
   }, [
     isConfirmationSlide,
     currentIndex,
-    onPageIndexChange,
     canConfirm,
     onConfirm,
+    handlePageChanged,
   ]);
 
   return (
@@ -397,31 +450,22 @@ export function HyperliquidTermsContent({
                 scrollEnabled: false,
               }}
             />
-            <Stack
-              position="absolute"
-              right={28}
+            <IndicatorButton
               top={overlayHeight / 2}
-              zIndex={1}
-            >
-              <AnimatePresence>
-                {currentIndex !== slidesData.length - 1 ? (
-                  <IconButton
-                    size="small"
-                    variant="primary"
-                    icon="ChevronRightOutline"
-                    iconColor="$green9"
-                    borderWidth="$0.5"
-                    onPress={handleNext}
-                    pressStyle={{
-                      scale: 0.95,
-                    }}
-                    hoverStyle={{
-                      scale: 1,
-                    }}
-                  />
-                ) : null}
-              </AnimatePresence>
-            </Stack>
+              left={28}
+              iconName="ChevronLeftOutline"
+              variant="secondary"
+              onPress={handlePrev}
+              visible={currentIndex !== 0}
+            />
+            <IndicatorButton
+              top={overlayHeight / 2}
+              right={28}
+              iconName="ChevronRightOutline"
+              variant="primary"
+              onPress={handleNext}
+              visible={currentIndex !== slidesData.length - 1}
+            />
           </Stack>
         </DelayedRender>
       </Stack>

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/AdjustPositionMarginModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/AdjustPositionMarginModal.tsx
@@ -20,7 +20,8 @@ import {
 import { usePerpsActiveAccountSummaryAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
 import { validateSizeInput } from '@onekeyhq/shared/src/utils/perpsUtils';
 
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
@@ -34,6 +35,13 @@ export interface IAdjustPositionMarginParams {
 interface IAdjustPositionMarginFormProps extends IAdjustPositionMarginParams {
   onClose: () => void;
 }
+
+const valueFormatter: INumberFormatProps = {
+  formatter: 'value',
+  formatterOptions: {
+    currency: '$',
+  },
+};
 
 type IMarginAction = 'add' | 'remove';
 
@@ -235,7 +243,7 @@ const AdjustPositionMarginForm = memo(
                 })}
               </SizableText>
               <SizableText size="$bodyMdMedium">
-                {numberFormat(
+                {numberFormatAsString(
                   currentMarginUsed
                     .decimalPlaces(2, BigNumber.ROUND_DOWN)
                     .toFixed(2),
@@ -284,7 +292,7 @@ const AdjustPositionMarginForm = memo(
               </SizableText>
               <XStack gap="$1" alignItems="center">
                 <SizableText size="$bodyMdMedium">
-                  {numberFormat(
+                  {numberFormatAsString(
                     (action === 'add' ? maxAdd : maxRemove)
                       .decimalPlaces(2, BigNumber.ROUND_DOWN)
                       .toFixed(2),

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/AdjustPositionMarginModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/AdjustPositionMarginModal.tsx
@@ -21,7 +21,7 @@ import { usePerpsActiveAccountSummaryAtom } from '@onekeyhq/kit-bg/src/states/jo
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import { validateSizeInput } from '@onekeyhq/shared/src/utils/perpsUtils';
 
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
@@ -243,7 +243,7 @@ const AdjustPositionMarginForm = memo(
                 })}
               </SizableText>
               <SizableText size="$bodyMdMedium">
-                {numberFormatAsString(
+                {numberFormat(
                   currentMarginUsed
                     .decimalPlaces(2, BigNumber.ROUND_DOWN)
                     .toFixed(2),
@@ -292,7 +292,7 @@ const AdjustPositionMarginForm = memo(
               </SizableText>
               <XStack gap="$1" alignItems="center">
                 <SizableText size="$bodyMdMedium">
-                  {numberFormatAsString(
+                  {numberFormat(
                     (action === 'add' ? maxAdd : maxRemove)
                       .decimalPlaces(2, BigNumber.ROUND_DOWN)
                       .toFixed(2),

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
@@ -9,7 +9,7 @@ import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/h
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { formatTime } from '@onekeyhq/shared/src/utils/dateUtils';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import { getValidPriceDecimals } from '@onekeyhq/shared/src/utils/perpsUtils';
 
 import { calcCellAlign, getColumnStyle } from '../utils';
@@ -89,7 +89,7 @@ const OpenOrdersRow = memo(
       const decimals = getValidPriceDecimals(price);
       const triggerCondition = order.triggerCondition;
       const origSizeBN = new BigNumber(origSize);
-      const origSizeFormatted = numberFormatAsString(
+      const origSizeFormatted = numberFormat(
         origSize,
         balanceFormatter,
       );
@@ -100,9 +100,9 @@ const OpenOrdersRow = memo(
         executePriceLimit,
       ).toFixed(decimals);
       const priceFormatted = new BigNumber(price).toFixed(decimals);
-      const sizeFormatted = numberFormatAsString(size, balanceFormatter);
+      const sizeFormatted = numberFormat(size, balanceFormatter);
       const value = priceBN.times(origSizeBN).toFixed();
-      const valueFormatted = numberFormatAsString(
+      const valueFormatted = numberFormat(
         value,
         balanceCurrencyFormatter,
       );
@@ -131,12 +131,12 @@ const OpenOrdersRow = memo(
         const tpslOrders = tpslChildren.filter((child) => child.isPositionTpsl);
         tpslOrders.forEach((child) => {
           if (child.orderType.startsWith('Take')) {
-            tpPrice = `${numberFormatAsString(
+            tpPrice = `${numberFormat(
               child.triggerPx,
               priceFormatter,
             )}`;
           } else if (child.orderType.startsWith('Stop')) {
-            slPrice = `${numberFormatAsString(
+            slPrice = `${numberFormat(
               child.triggerPx,
               priceFormatter,
             )}`;

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
@@ -8,13 +8,32 @@ import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { formatTime } from '@onekeyhq/shared/src/utils/dateUtils';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
 import { getValidPriceDecimals } from '@onekeyhq/shared/src/utils/perpsUtils';
 
 import { calcCellAlign, getColumnStyle } from '../utils';
 
 import type { IColumnConfig } from '../List/CommonTableListView';
 import type { FrontendOrder } from '@nktkas/hyperliquid';
+
+const balanceFormatter: INumberFormatProps = {
+  formatter: 'balance',
+};
+
+const balanceCurrencyFormatter: INumberFormatProps = {
+  formatter: 'balance',
+  formatterOptions: {
+    currency: '$',
+  },
+};
+
+const priceFormatter: INumberFormatProps = {
+  formatter: 'price',
+  formatterOptions: {
+    currency: '$',
+  },
+};
 
 interface IOpenOrdersRowProps {
   order: FrontendOrder;
@@ -70,9 +89,10 @@ const OpenOrdersRow = memo(
       const decimals = getValidPriceDecimals(price);
       const triggerCondition = order.triggerCondition;
       const origSizeBN = new BigNumber(origSize);
-      const origSizeFormatted = numberFormat(origSize, {
-        formatter: 'balance',
-      });
+      const origSizeFormatted = numberFormatAsString(
+        origSize,
+        balanceFormatter,
+      );
       const executePriceFormatted = new BigNumber(executePrice).toFixed(
         decimals,
       );
@@ -80,16 +100,12 @@ const OpenOrdersRow = memo(
         executePriceLimit,
       ).toFixed(decimals);
       const priceFormatted = new BigNumber(price).toFixed(decimals);
-      const sizeFormatted = numberFormat(size, {
-        formatter: 'balance',
-      });
+      const sizeFormatted = numberFormatAsString(size, balanceFormatter);
       const value = priceBN.times(origSizeBN).toFixed();
-      const valueFormatted = numberFormat(value, {
-        formatter: 'balance',
-        formatterOptions: {
-          currency: '$',
-        },
-      });
+      const valueFormatted = numberFormatAsString(
+        value,
+        balanceCurrencyFormatter,
+      );
       return {
         triggerCondition,
         origSizeFormatted,
@@ -115,23 +131,15 @@ const OpenOrdersRow = memo(
         const tpslOrders = tpslChildren.filter((child) => child.isPositionTpsl);
         tpslOrders.forEach((child) => {
           if (child.orderType.startsWith('Take')) {
-            tpPrice = `${
-              numberFormat(child.triggerPx, {
-                formatter: 'price',
-                formatterOptions: {
-                  currency: '$',
-                },
-              }) as string
-            }`;
+            tpPrice = `${numberFormatAsString(
+              child.triggerPx,
+              priceFormatter,
+            )}`;
           } else if (child.orderType.startsWith('Stop')) {
-            slPrice = `${
-              numberFormat(child.triggerPx, {
-                formatter: 'price',
-                formatterOptions: {
-                  currency: '$',
-                },
-              }) as string
-            }`;
+            slPrice = `${numberFormatAsString(
+              child.triggerPx,
+              priceFormatter,
+            )}`;
           }
         });
       }
@@ -210,9 +218,7 @@ const OpenOrdersRow = memo(
               })}
             </SizableText>
             <SizableText size="$bodySm">
-              {`${orderBaseInfo.sizeFormatted as string} / ${
-                orderBaseInfo.origSizeFormatted as string
-              }`}
+              {`${orderBaseInfo.sizeFormatted} / ${orderBaseInfo.origSizeFormatted}`}
             </SizableText>
           </XStack>
           <XStack
@@ -346,7 +352,7 @@ const OpenOrdersRow = memo(
             numberOfLines={1}
             ellipsizeMode="tail"
             size="$bodySm"
-          >{`${orderBaseInfo.sizeFormatted as string}`}</SizableText>
+          >{`${orderBaseInfo.sizeFormatted}`}</SizableText>
         </XStack>
 
         {/* Original size */}
@@ -359,7 +365,7 @@ const OpenOrdersRow = memo(
             numberOfLines={1}
             ellipsizeMode="tail"
             size="$bodySm"
-          >{`${orderBaseInfo.origSizeFormatted as string}`}</SizableText>
+          >{`${orderBaseInfo.origSizeFormatted}`}</SizableText>
         </XStack>
 
         {/* value */}
@@ -372,7 +378,7 @@ const OpenOrdersRow = memo(
             numberOfLines={1}
             ellipsizeMode="tail"
             size="$bodySm"
-          >{`${orderBaseInfo.valueFormatted as string}`}</SizableText>
+          >{`${orderBaseInfo.valueFormatted}`}</SizableText>
         </XStack>
 
         {/* Execute price */}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
@@ -89,10 +89,7 @@ const OpenOrdersRow = memo(
       const decimals = getValidPriceDecimals(price);
       const triggerCondition = order.triggerCondition;
       const origSizeBN = new BigNumber(origSize);
-      const origSizeFormatted = numberFormat(
-        origSize,
-        balanceFormatter,
-      );
+      const origSizeFormatted = numberFormat(origSize, balanceFormatter);
       const executePriceFormatted = new BigNumber(executePrice).toFixed(
         decimals,
       );
@@ -102,10 +99,7 @@ const OpenOrdersRow = memo(
       const priceFormatted = new BigNumber(price).toFixed(decimals);
       const sizeFormatted = numberFormat(size, balanceFormatter);
       const value = priceBN.times(origSizeBN).toFixed();
-      const valueFormatted = numberFormat(
-        value,
-        balanceCurrencyFormatter,
-      );
+      const valueFormatted = numberFormat(value, balanceCurrencyFormatter);
       return {
         triggerCondition,
         origSizeFormatted,
@@ -131,15 +125,9 @@ const OpenOrdersRow = memo(
         const tpslOrders = tpslChildren.filter((child) => child.isPositionTpsl);
         tpslOrders.forEach((child) => {
           if (child.orderType.startsWith('Take')) {
-            tpPrice = `${numberFormat(
-              child.triggerPx,
-              priceFormatter,
-            )}`;
+            tpPrice = `${numberFormat(child.triggerPx, priceFormatter)}`;
           } else if (child.orderType.startsWith('Stop')) {
-            slPrice = `${numberFormat(
-              child.triggerPx,
-              priceFormatter,
-            )}`;
+            slPrice = `${numberFormat(child.triggerPx, priceFormatter)}`;
           }
         });
       }

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
@@ -17,7 +17,8 @@ import {
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
 import { getValidPriceDecimals } from '@onekeyhq/shared/src/utils/perpsUtils';
 
 import { usePerpsMidPrice } from '../../../hooks/usePerpsMidPrice';
@@ -39,6 +40,24 @@ interface IPositionRowProps {
   isMobile?: boolean;
   index: number;
 }
+
+const priceFormatter: INumberFormatProps = {
+  formatter: 'price',
+  formatterOptions: {
+    currency: '$',
+  },
+};
+
+const valueFormatter: INumberFormatProps = {
+  formatter: 'value',
+  formatterOptions: {
+    currency: '$',
+  },
+};
+
+const balanceFormatter: INumberFormatProps = {
+  formatter: 'balance',
+};
 
 function MarkPrice({ coin, decimals }: { coin: string; decimals: number }) {
   const { midFormattedByDecimals } = usePerpsMidPrice({
@@ -92,6 +111,15 @@ const PositionRow = memo(
       [pos.entryPx],
     );
 
+    const sizeValueFormatter: INumberFormatProps = useMemo(() => {
+      return {
+        formatter: 'balance',
+        formatterOptions: {
+          currency: isMobile ? '' : '$',
+        },
+      };
+    }, [isMobile]);
+
     const priceInfo = useMemo(() => {
       const entryPrice = new BigNumber(pos.entryPx || '0').toFixed(decimals);
       const liquidationPrice = new BigNumber(pos.liquidationPx || '0');
@@ -108,31 +136,22 @@ const PositionRow = memo(
     const sizeInfo = useMemo(() => {
       const sizeBN = new BigNumber(pos.szi || '0');
       const sizeAbs = sizeBN.abs().toFixed();
-      const sizeAbsFormatted = numberFormat(sizeAbs, {
-        formatter: 'balance',
-      });
+      const sizeAbsFormatted = numberFormatAsString(sizeAbs, balanceFormatter);
       const sizeValue = new BigNumber(pos.positionValue || '0').toFixed();
-      const sizeValueFormatted = numberFormat(sizeValue, {
-        formatter: 'balance',
-        formatterOptions: {
-          currency: isMobile ? '' : '$',
-        },
-      });
+      const sizeValueFormatted = numberFormatAsString(
+        sizeValue,
+        sizeValueFormatter,
+      );
       return {
         sizeAbsFormatted,
         sizeValue: sizeValueFormatted,
       };
-    }, [pos.szi, pos.positionValue, isMobile]);
+    }, [pos.szi, pos.positionValue, sizeValueFormatter]);
 
     const otherInfo = useMemo(() => {
       const pnlBn = new BigNumber(pos.unrealizedPnl || '0');
       const pnlAbs = pnlBn.abs().toFixed();
-      const pnlFormatted = numberFormat(pnlAbs, {
-        formatter: 'value',
-        formatterOptions: {
-          currency: '$',
-        },
-      });
+      const pnlFormatted = numberFormatAsString(pnlAbs, valueFormatter);
       let pnlColor = '$green11';
       let pnlPlusOrMinus = '+';
       if (pnlBn.lt(0)) {
@@ -140,12 +159,10 @@ const PositionRow = memo(
         pnlPlusOrMinus = '-';
       }
       const marginUsedBN = new BigNumber(pos.marginUsed || '0');
-      const marginUsedFormatted = numberFormat(marginUsedBN.toFixed(), {
-        formatter: 'value',
-        formatterOptions: {
-          currency: '$',
-        },
-      });
+      const marginUsedFormatted = numberFormatAsString(
+        marginUsedBN.toFixed(),
+        valueFormatter,
+      );
 
       const fundingAllTimeBN = new BigNumber(pos.cumFunding.allTime);
       const fundingSinceOpenBN = new BigNumber(pos.cumFunding.sinceOpen);
@@ -197,26 +214,18 @@ const PositionRow = memo(
         if (!showOrder) {
           tpslOrders.forEach((order) => {
             if (order.orderType.startsWith('Take') && order.isPositionTpsl) {
-              tpPrice = `${
-                numberFormat(order.triggerPx, {
-                  formatter: 'price',
-                  formatterOptions: {
-                    currency: '$',
-                  },
-                }) as string
-              }`;
+              tpPrice = `${numberFormatAsString(
+                order.triggerPx,
+                priceFormatter,
+              )}`;
             } else if (
               order.orderType.startsWith('Stop') &&
               order.isPositionTpsl
             ) {
-              slPrice = `${
-                numberFormat(order.triggerPx, {
-                  formatter: 'price',
-                  formatterOptions: {
-                    currency: '$',
-                  },
-                }) as string
-              }`;
+              slPrice = `${numberFormatAsString(
+                order.triggerPx,
+                priceFormatter,
+              )}`;
             }
           });
         }
@@ -298,9 +307,7 @@ const PositionRow = memo(
                 })}
               </SizableText>
               <SizableText size="$bodyMdMedium" color={otherInfo.pnlColor}>
-                {`${otherInfo.pnlPlusOrMinus}${
-                  otherInfo.unrealizedPnl as string
-                }`}
+                {`${otherInfo.pnlPlusOrMinus}${otherInfo.unrealizedPnl}`}
               </SizableText>
             </YStack>
             <YStack gap="$1" alignItems="flex-end">
@@ -337,8 +344,8 @@ const PositionRow = memo(
                 <SizableText size="$bodySmMedium">
                   {`${
                     isSizeViewChange
-                      ? (sizeInfo.sizeValue as string)
-                      : (sizeInfo.sizeAbsFormatted as string)
+                      ? sizeInfo.sizeValue
+                      : sizeInfo.sizeAbsFormatted
                   }`}
                 </SizableText>
               </XStack>
@@ -351,7 +358,7 @@ const PositionRow = memo(
               </SizableText>
               <XStack alignItems="center" gap="$1">
                 <SizableText size="$bodySmMedium">
-                  {`${otherInfo.marginUsedFormatted as string}`}
+                  {`${otherInfo.marginUsedFormatted}`}
                 </SizableText>
                 {isIsolatedMode ? (
                   <IconButton
@@ -595,7 +602,7 @@ const PositionRow = memo(
           alignItems={calcCellAlign(columnConfigs[1].align)}
         >
           <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
-            {`${sizeInfo.sizeAbsFormatted as string}`}
+            {`${sizeInfo.sizeAbsFormatted}`}
           </SizableText>
           <SizableText
             numberOfLines={1}
@@ -603,7 +610,7 @@ const PositionRow = memo(
             size="$bodySm"
             color="$textSubdued"
           >
-            {`${sizeInfo.sizeValue as string}`}
+            {`${sizeInfo.sizeValue}`}
           </SizableText>
         </YStack>
 
@@ -652,9 +659,7 @@ const PositionRow = memo(
             numberOfLines={1}
             ellipsizeMode="tail"
           >
-            {`${otherInfo.pnlPlusOrMinus}${otherInfo.unrealizedPnl as string}(${
-              otherInfo.pnlPlusOrMinus
-            }${otherInfo.roiPercent}%)`}
+            {`${otherInfo.pnlPlusOrMinus}${otherInfo.unrealizedPnl}(${otherInfo.pnlPlusOrMinus}${otherInfo.roiPercent}%)`}
           </SizableText>
         </XStack>
 
@@ -669,7 +674,7 @@ const PositionRow = memo(
               numberOfLines={1}
               ellipsizeMode="tail"
               size="$bodySm"
-            >{`${otherInfo.marginUsedFormatted as string}`}</SizableText>
+            >{`${otherInfo.marginUsedFormatted}`}</SizableText>
             {isIsolatedMode ? (
               <IconButton
                 variant="tertiary"

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
@@ -18,7 +18,7 @@ import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import { getValidPriceDecimals } from '@onekeyhq/shared/src/utils/perpsUtils';
 
 import { usePerpsMidPrice } from '../../../hooks/usePerpsMidPrice';
@@ -136,9 +136,9 @@ const PositionRow = memo(
     const sizeInfo = useMemo(() => {
       const sizeBN = new BigNumber(pos.szi || '0');
       const sizeAbs = sizeBN.abs().toFixed();
-      const sizeAbsFormatted = numberFormatAsString(sizeAbs, balanceFormatter);
+      const sizeAbsFormatted = numberFormat(sizeAbs, balanceFormatter);
       const sizeValue = new BigNumber(pos.positionValue || '0').toFixed();
-      const sizeValueFormatted = numberFormatAsString(
+      const sizeValueFormatted = numberFormat(
         sizeValue,
         sizeValueFormatter,
       );
@@ -151,7 +151,7 @@ const PositionRow = memo(
     const otherInfo = useMemo(() => {
       const pnlBn = new BigNumber(pos.unrealizedPnl || '0');
       const pnlAbs = pnlBn.abs().toFixed();
-      const pnlFormatted = numberFormatAsString(pnlAbs, valueFormatter);
+      const pnlFormatted = numberFormat(pnlAbs, valueFormatter);
       let pnlColor = '$green11';
       let pnlPlusOrMinus = '+';
       if (pnlBn.lt(0)) {
@@ -159,7 +159,7 @@ const PositionRow = memo(
         pnlPlusOrMinus = '-';
       }
       const marginUsedBN = new BigNumber(pos.marginUsed || '0');
-      const marginUsedFormatted = numberFormatAsString(
+      const marginUsedFormatted = numberFormat(
         marginUsedBN.toFixed(),
         valueFormatter,
       );
@@ -214,7 +214,7 @@ const PositionRow = memo(
         if (!showOrder) {
           tpslOrders.forEach((order) => {
             if (order.orderType.startsWith('Take') && order.isPositionTpsl) {
-              tpPrice = `${numberFormatAsString(
+              tpPrice = `${numberFormat(
                 order.triggerPx,
                 priceFormatter,
               )}`;
@@ -222,7 +222,7 @@ const PositionRow = memo(
               order.orderType.startsWith('Stop') &&
               order.isPositionTpsl
             ) {
-              slPrice = `${numberFormatAsString(
+              slPrice = `${numberFormat(
                 order.triggerPx,
                 priceFormatter,
               )}`;

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
@@ -138,10 +138,7 @@ const PositionRow = memo(
       const sizeAbs = sizeBN.abs().toFixed();
       const sizeAbsFormatted = numberFormat(sizeAbs, balanceFormatter);
       const sizeValue = new BigNumber(pos.positionValue || '0').toFixed();
-      const sizeValueFormatted = numberFormat(
-        sizeValue,
-        sizeValueFormatter,
-      );
+      const sizeValueFormatted = numberFormat(sizeValue, sizeValueFormatter);
       return {
         sizeAbsFormatted,
         sizeValue: sizeValueFormatted,
@@ -214,18 +211,12 @@ const PositionRow = memo(
         if (!showOrder) {
           tpslOrders.forEach((order) => {
             if (order.orderType.startsWith('Take') && order.isPositionTpsl) {
-              tpPrice = `${numberFormat(
-                order.triggerPx,
-                priceFormatter,
-              )}`;
+              tpPrice = `${numberFormat(order.triggerPx, priceFormatter)}`;
             } else if (
               order.orderType.startsWith('Stop') &&
               order.isPositionTpsl
             ) {
-              slPrice = `${numberFormat(
-                order.triggerPx,
-                priceFormatter,
-              )}`;
+              slPrice = `${numberFormat(order.triggerPx, priceFormatter)}`;
             }
           });
         }

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
@@ -299,7 +299,7 @@ const TradesHistoryRow = memo(
           alignItems="center"
         >
           <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
-            {`${tradeBaseInfo.tradeValueFormatted as string}`}
+            {`${tradeBaseInfo.tradeValueFormatted}`}
           </SizableText>
         </XStack>
 
@@ -310,7 +310,7 @@ const TradesHistoryRow = memo(
           alignItems="center"
         >
           <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
-            {`${tradeBaseInfo.feeFormatted as string}`}
+            {`${tradeBaseInfo.feeFormatted}`}
           </SizableText>
         </XStack>
 

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
@@ -9,7 +9,7 @@ import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/h
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { formatTime } from '@onekeyhq/shared/src/utils/dateUtils';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import { getValidPriceDecimals } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type { IFill } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
@@ -71,10 +71,10 @@ const TradesHistoryRow = memo(
       const priceBN = new BigNumber(price);
       const sizeBN = new BigNumber(size);
       const priceFormatted = priceBN.toFixed(decimals);
-      const feeFormatted = numberFormatAsString(fee, formatter);
+      const feeFormatted = numberFormat(fee, formatter);
 
       const tradeValue = priceBN.times(sizeBN).toFixed();
-      const tradeValueFormatted = numberFormatAsString(tradeValue, formatter);
+      const tradeValueFormatted = numberFormat(tradeValue, formatter);
       return { priceFormatted, size, feeFormatted, tradeValueFormatted };
     }, [fill.fee, fill.px, fill.sz]);
 
@@ -88,7 +88,7 @@ const TradesHistoryRow = memo(
         closePnlPlusOrMinus = '-';
       }
       const closePnlStr = closePnlBN.abs().toFixed();
-      const closePnlFormatted = numberFormatAsString(closePnlStr, {
+      const closePnlFormatted = numberFormat(closePnlStr, {
         formatter: 'value',
         formatterOptions: {
           currency: '$',

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
@@ -8,7 +8,8 @@ import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { formatTime } from '@onekeyhq/shared/src/utils/dateUtils';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
 import { getValidPriceDecimals } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type { IFill } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
@@ -16,6 +17,12 @@ import { calcCellAlign, getColumnStyle } from '../utils';
 
 import type { IColumnConfig } from '../List/CommonTableListView';
 
+const formatter: INumberFormatProps = {
+  formatter: 'value',
+  formatterOptions: {
+    currency: '$',
+  },
+};
 export type ITradesHistoryRowProps = {
   fill: IFill;
   cellMinWidth: number;
@@ -64,20 +71,10 @@ const TradesHistoryRow = memo(
       const priceBN = new BigNumber(price);
       const sizeBN = new BigNumber(size);
       const priceFormatted = priceBN.toFixed(decimals);
-      const feeFormatted = numberFormat(fee, {
-        formatter: 'value',
-        formatterOptions: {
-          currency: '$',
-        },
-      });
+      const feeFormatted = numberFormatAsString(fee, formatter);
 
       const tradeValue = priceBN.times(sizeBN).toFixed();
-      const tradeValueFormatted = numberFormat(tradeValue, {
-        formatter: 'value',
-        formatterOptions: {
-          currency: '$',
-        },
-      });
+      const tradeValueFormatted = numberFormatAsString(tradeValue, formatter);
       return { priceFormatted, size, feeFormatted, tradeValueFormatted };
     }, [fill.fee, fill.px, fill.sz]);
 
@@ -91,7 +88,7 @@ const TradesHistoryRow = memo(
         closePnlPlusOrMinus = '-';
       }
       const closePnlStr = closePnlBN.abs().toFixed();
-      const closePnlFormatted = numberFormat(closePnlStr, {
+      const closePnlFormatted = numberFormatAsString(closePnlStr, {
         formatter: 'value',
         formatterOptions: {
           currency: '$',
@@ -146,9 +143,7 @@ const TradesHistoryRow = memo(
                 })}
               </SizableText>
               <SizableText size="$bodySm" color={closePnlInfo.closePnlColor}>
-                {`${closePnlInfo.closePnlPlusOrMinus}${
-                  closePnlInfo.closePnlFormatted as string
-                }`}
+                {`${closePnlInfo.closePnlPlusOrMinus}${closePnlInfo.closePnlFormatted}`}
               </SizableText>
             </YStack>
           </XStack>
@@ -188,7 +183,7 @@ const TradesHistoryRow = memo(
                 })}
               </SizableText>
               <SizableText size="$bodySm">
-                {`${tradeBaseInfo.tradeValueFormatted as string}`}
+                {`${tradeBaseInfo.tradeValueFormatted}`}
               </SizableText>
             </YStack>
             <YStack gap="$1" flex={1} alignItems="flex-end">
@@ -198,7 +193,7 @@ const TradesHistoryRow = memo(
                 })}
               </SizableText>
               <SizableText size="$bodySm">
-                {`${tradeBaseInfo.feeFormatted as string}`}
+                {`${tradeBaseInfo.feeFormatted}`}
               </SizableText>
             </YStack>
           </XStack>
@@ -331,9 +326,7 @@ const TradesHistoryRow = memo(
             size="$bodySm"
             color={closePnlInfo.closePnlColor}
           >
-            {`${closePnlInfo.closePnlPlusOrMinus}${
-              closePnlInfo.closePnlFormatted as string
-            }`}
+            {`${closePnlInfo.closePnlPlusOrMinus}${closePnlInfo.closePnlFormatted}`}
           </SizableText>
         </XStack>
       </XStack>

--- a/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingButton.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingButton.tsx
@@ -9,8 +9,8 @@ import {
   SizableText,
   Spinner,
   Toast,
-  useInTabDialog,
   YStack,
+  useInTabDialog,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { AccountSelectorCreateAddressButton } from '@onekeyhq/kit/src/components/AccountSelector/AccountSelectorCreateAddressButton';

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -234,10 +234,7 @@ function DepositWithdrawContent({
     if (selectedAction === 'withdraw') {
       return {
         balance: new BigNumber(params.withdrawable || '0').toFixed(),
-        displayBalance: numberFormat(
-          params.withdrawable || '0',
-          formatter,
-        ),
+        displayBalance: numberFormat(params.withdrawable || '0', formatter),
       };
     }
     return {

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -41,7 +41,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalRoutes, EModalSwapRoutes } from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import type { INetworkAccount } from '@onekeyhq/shared/types/account';
 import {
   HYPERLIQUID_DEPOSIT_ADDRESS,
@@ -234,7 +234,7 @@ function DepositWithdrawContent({
     if (selectedAction === 'withdraw') {
       return {
         balance: new BigNumber(params.withdrawable || '0').toFixed(),
-        displayBalance: numberFormatAsString(
+        displayBalance: numberFormat(
           params.withdrawable || '0',
           formatter,
         ),
@@ -242,7 +242,7 @@ function DepositWithdrawContent({
     }
     return {
       balance: new BigNumber(usdcBalance || '0').toFixed(),
-      displayBalance: numberFormatAsString(usdcBalance || '0', formatter),
+      displayBalance: numberFormat(usdcBalance || '0', formatter),
     };
   }, [selectedAction, params.withdrawable, usdcBalance]);
   const isValidAmount = useMemo(() => {

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -40,7 +40,8 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalRoutes, EModalSwapRoutes } from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
 import type { INetworkAccount } from '@onekeyhq/shared/types/account';
 import {
   HYPERLIQUID_DEPOSIT_ADDRESS,
@@ -59,6 +60,9 @@ import { PerpsAccountNumberValue } from '../components/PerpsAccountNumberValue';
 import { InputAccessoryDoneButton } from '../inputs/TradingFormInput';
 
 export type IPerpsDepositWithdrawActionType = 'deposit' | 'withdraw';
+const formatter: INumberFormatProps = {
+  formatter: 'balance',
+};
 
 const DEPOSIT_WITHDRAW_INPUT_ACCESSORY_VIEW_ID =
   'perp-deposit-withdraw-accessory-view';
@@ -230,16 +234,15 @@ function DepositWithdrawContent({
     if (selectedAction === 'withdraw') {
       return {
         balance: new BigNumber(params.withdrawable || '0').toFixed(),
-        displayBalance: numberFormat(params.withdrawable || '0', {
-          formatter: 'balance',
-        }),
+        displayBalance: numberFormatAsString(
+          params.withdrawable || '0',
+          formatter,
+        ),
       };
     }
     return {
       balance: new BigNumber(usdcBalance || '0').toFixed(),
-      displayBalance: numberFormat(usdcBalance || '0', {
-        formatter: 'balance',
-      }),
+      displayBalance: numberFormatAsString(usdcBalance || '0', formatter),
     };
   }, [selectedAction, params.withdrawable, usdcBalance]);
   const isValidAmount = useMemo(() => {

--- a/packages/kit/src/views/Swap/components/SwapProviderListItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProviderListItem.tsx
@@ -17,7 +17,8 @@ import {
   XStack,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
 import type {
   IFetchQuoteResult,
   ISwapToken,
@@ -28,6 +29,10 @@ import SwapRoutePaths from './SwapRoutePaths';
 
 import type { IRouteRows } from './SwapRoutePaths';
 import type { IListItemProps } from '../../../components/ListItem';
+
+const formatter: INumberFormatProps = {
+  formatter: 'balance',
+};
 
 export type ISwapProviderListItemProps = {
   providerResult: IFetchQuoteResult;
@@ -174,9 +179,7 @@ const SwapProviderListItem = ({
           return intl.formatMessage(
             { id: ETranslations.provider_min_amount_required },
             {
-              amount: numberFormat(providerResult.limit.min, {
-                formatter: 'balance',
-              }) as string,
+              amount: numberFormatAsString(providerResult.limit.min, formatter),
               token: fromToken?.symbol ?? 'unknown',
             },
           );
@@ -188,9 +191,7 @@ const SwapProviderListItem = ({
           return intl.formatMessage(
             { id: ETranslations.provider_max_amount_required },
             {
-              amount: numberFormat(providerResult.limit.max, {
-                formatter: 'balance',
-              }) as string,
+              amount: numberFormatAsString(providerResult.limit.max, formatter),
               token: fromToken?.symbol ?? 'unknown',
             },
           );
@@ -198,11 +199,9 @@ const SwapProviderListItem = ({
       }
     }
     if (providerResult.toAmount) {
-      return `${
-        numberFormat(providerResult.toAmount, {
-          formatter: 'balance',
-        }) as string
-      } ${toToken?.symbol ?? 'unknown'}`;
+      return `${numberFormatAsString(providerResult.toAmount, formatter)} ${
+        toToken?.symbol ?? 'unknown'
+      }`;
     }
     return '';
   }, [

--- a/packages/kit/src/views/Swap/components/SwapProviderListItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProviderListItem.tsx
@@ -18,7 +18,7 @@ import {
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import type {
   IFetchQuoteResult,
   ISwapToken,
@@ -179,7 +179,7 @@ const SwapProviderListItem = ({
           return intl.formatMessage(
             { id: ETranslations.provider_min_amount_required },
             {
-              amount: numberFormatAsString(providerResult.limit.min, formatter),
+              amount: numberFormat(providerResult.limit.min, formatter),
               token: fromToken?.symbol ?? 'unknown',
             },
           );
@@ -191,7 +191,7 @@ const SwapProviderListItem = ({
           return intl.formatMessage(
             { id: ETranslations.provider_max_amount_required },
             {
-              amount: numberFormatAsString(providerResult.limit.max, formatter),
+              amount: numberFormat(providerResult.limit.max, formatter),
               token: fromToken?.symbol ?? 'unknown',
             },
           );
@@ -199,7 +199,7 @@ const SwapProviderListItem = ({
       }
     }
     if (providerResult.toAmount) {
-      return `${numberFormatAsString(providerResult.toAmount, formatter)} ${
+      return `${numberFormat(providerResult.toAmount, formatter)} ${
         toToken?.symbol ?? 'unknown'
       }`;
     }

--- a/packages/kit/src/views/Swap/components/SwapRateInfoItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapRateInfoItem.tsx
@@ -3,9 +3,13 @@ import { useCallback, useMemo, useState } from 'react';
 import BigNumber from 'bignumber.js';
 
 import { SizableText, XStack } from '@onekeyhq/components';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 
+const formatter: INumberFormatProps = {
+  formatter: 'balance',
+};
 interface ISwapRateInfoItemProps {
   rate: string;
   fromToken?: ISwapToken;
@@ -24,20 +28,18 @@ const SwapRateInfoItem = ({
   const rateContent = useMemo(() => {
     const rateBN = new BigNumber(rate ?? 0);
     const exchangeRate = new BigNumber(1).div(rateBN);
-    const formatRate = numberFormat(
+    const formatRate = numberFormatAsString(
       rateSwitch ? exchangeRate.toFixed() : rateBN.toFixed(),
-      {
-        formatter: 'balance',
-      },
+      formatter,
     );
     if (rateSwitch) {
-      return `1 ${toToken?.symbol?.toUpperCase() ?? ''} = ${
-        formatRate as string
-      } ${fromToken?.symbol?.toUpperCase() ?? ''}`;
+      return `1 ${toToken?.symbol?.toUpperCase() ?? ''} = ${formatRate} ${
+        fromToken?.symbol?.toUpperCase() ?? ''
+      }`;
     }
-    return `1 ${fromToken?.symbol?.toUpperCase() ?? ''} = ${
-      formatRate as string
-    } ${toToken?.symbol?.toUpperCase() ?? ''}`;
+    return `1 ${fromToken?.symbol?.toUpperCase() ?? ''} = ${formatRate} ${
+      toToken?.symbol?.toUpperCase() ?? ''
+    }`;
   }, [fromToken, rate, rateSwitch, toToken]);
 
   return (

--- a/packages/kit/src/views/Swap/components/SwapRateInfoItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapRateInfoItem.tsx
@@ -4,7 +4,7 @@ import BigNumber from 'bignumber.js';
 
 import { SizableText, XStack } from '@onekeyhq/components';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 
 const formatter: INumberFormatProps = {
@@ -28,7 +28,7 @@ const SwapRateInfoItem = ({
   const rateContent = useMemo(() => {
     const rateBN = new BigNumber(rate ?? 0);
     const exchangeRate = new BigNumber(1).div(rateBN);
-    const formatRate = numberFormatAsString(
+    const formatRate = numberFormat(
       rateSwitch ? exchangeRate.toFixed() : rateBN.toFixed(),
       formatter,
     );

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -35,8 +35,9 @@ import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { ESwapEventAPIStatus } from '@onekeyhq/shared/src/logger/scopes/swap/scenes/swapEstimateFee';
 import { EScanQrCodeModalPages } from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
-  numberFormat,
+  numberFormatAsString,
   toBigIntHex,
 } from '@onekeyhq/shared/src/utils/numberUtils';
 import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
@@ -109,6 +110,10 @@ import {
   useSwapSlippagePercentageModeInfo,
 } from './useSwapState';
 import { useSwapTxHistoryActions } from './useSwapTxHistory';
+
+const formatter: INumberFormatProps = {
+  formatter: 'balance',
+};
 
 /**
  * React hook that manages the full lifecycle of building, approving, signing, and sending swap transactions in a multi-step workflow.
@@ -345,9 +350,10 @@ export function useSwapBuildTx() {
                     },
                     {
                       token: item.token.symbol,
-                      number: numberFormat(tokenAmountBN.toFixed(), {
-                        formatter: 'balance',
-                      }) as string,
+                      number: numberFormatAsString(
+                        tokenAmountBN.toFixed(),
+                        formatter,
+                      ),
                     },
                   ),
                 });

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -37,7 +37,7 @@ import { EScanQrCodeModalPages } from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
-  numberFormatAsString,
+  numberFormat,
   toBigIntHex,
 } from '@onekeyhq/shared/src/utils/numberUtils';
 import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
@@ -350,7 +350,7 @@ export function useSwapBuildTx() {
                     },
                     {
                       token: item.token.symbol,
-                      number: numberFormatAsString(
+                      number: numberFormat(
                         tokenAmountBN.toFixed(),
                         formatter,
                       ),

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -350,10 +350,7 @@ export function useSwapBuildTx() {
                     },
                     {
                       token: item.token.symbol,
-                      number: numberFormat(
-                        tokenAmountBN.toFixed(),
-                        formatter,
-                      ),
+                      number: numberFormat(tokenAmountBN.toFixed(), formatter),
                     },
                   ),
                 });

--- a/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
@@ -37,7 +37,8 @@ import {
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
 import { checkWrappedTokenPair } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 import {
@@ -330,6 +331,14 @@ const SwapInputContainer = ({
     }
     return false;
   }, [direction, swapTypeSwitch, fromToken, toToken]);
+  const reserveGasFormatter: INumberFormatProps = useMemo(() => {
+    return {
+      formatter: 'balance',
+      formatterOptions: {
+        tokenSymbol: fromToken?.symbol,
+      },
+    };
+  }, [fromToken?.symbol]);
   const balancePopoverContent = useMemo(() => {
     const reserveGas = swapNativeTokenReserveGas.find(
       (item) => item.networkId === fromToken?.networkId,
@@ -337,12 +346,10 @@ const SwapInputContainer = ({
     if (fromToken?.isNative) {
       let reserveGasFormatted: string | undefined | number = reserveGas;
       if (reserveGas) {
-        reserveGasFormatted = numberFormat(reserveGas.toString(), {
-          formatter: 'balance',
-          formatterOptions: {
-            tokenSymbol: fromToken?.symbol,
-          },
-        }) as string;
+        reserveGasFormatted = numberFormatAsString(
+          reserveGas.toString(),
+          reserveGasFormatter,
+        );
       }
       return (
         <XStack alignItems="center" p="$4">
@@ -366,8 +373,8 @@ const SwapInputContainer = ({
     swapNativeTokenReserveGas,
     fromToken?.isNative,
     fromToken?.networkId,
-    fromToken?.symbol,
     intl,
+    reserveGasFormatter,
   ]);
   return (
     <YStack borderRadius="$3" backgroundColor="$bgSubdued" borderWidth="$0">

--- a/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
@@ -38,7 +38,7 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import { checkWrappedTokenPair } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 import {
@@ -346,7 +346,7 @@ const SwapInputContainer = ({
     if (fromToken?.isNative) {
       let reserveGasFormatted: string | undefined | number = reserveGas;
       if (reserveGas) {
-        reserveGasFormatted = numberFormatAsString(
+        reserveGasFormatted = numberFormat(
           reserveGas.toString(),
           reserveGasFormatter,
         );

--- a/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
@@ -33,7 +33,7 @@ import {
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   EProtocolOfExchange,
   ESwapLimitOrderExpiryStep,
@@ -287,7 +287,7 @@ const SwapQuoteResult = ({
       quoteResult?.fee?.estimatedFeeFiatValue ?? '0',
     );
     const allFeeFiatValue = estimatedFeeFiatValue.plus(oneKeyFeeFiatValue);
-    const allFeeFiatValueFormat = numberFormatAsString(
+    const allFeeFiatValueFormat = numberFormat(
       allFeeFiatValue.toFixed(),
       allFeeFiatValueFormatter,
     );
@@ -302,11 +302,11 @@ const SwapQuoteResult = ({
   ]);
 
   const limitNetworkFeeMarkQuestContent = useMemo(() => {
-    const networkCostBuyAmountFormat = numberFormatAsString(
+    const networkCostBuyAmountFormat = numberFormat(
       quoteResult?.networkCostBuyAmount ?? '0',
       formatter,
     );
-    const oneKeyFeeCostFormat = numberFormatAsString(
+    const oneKeyFeeCostFormat = numberFormat(
       quoteResult?.oneKeyFeeExtraInfo?.oneKeyFeeAmount ?? '0',
       formatter,
     );

--- a/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
@@ -32,7 +32,8 @@ import {
   useSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormatAsString } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   EProtocolOfExchange,
   ESwapLimitOrderExpiryStep,
@@ -67,6 +68,8 @@ interface ISwapQuoteResultProps {
 }
 
 const SWAP_ACCORDION_VALUE = 'swap_accordion_value';
+
+const formatter: INumberFormatProps = { formatter: 'balance' };
 
 const SwapQuoteResult = ({
   onOpenProviderList,
@@ -263,6 +266,13 @@ const SwapQuoteResult = ({
     }
   }, []);
 
+  const allFeeFiatValueFormatter: INumberFormatProps = useMemo(() => {
+    return {
+      formatter: 'value',
+      formatterOptions: { currency: settingsPersistAtom.currencyInfo.symbol },
+    };
+  }, [settingsPersistAtom.currencyInfo.symbol]);
+
   const allCostFeeFormatValue = useMemo(() => {
     const oneKeyFeeAmountBN = new BigNumber(
       quoteResult?.oneKeyFeeExtraInfo?.oneKeyFeeAmount ?? '0',
@@ -277,30 +287,28 @@ const SwapQuoteResult = ({
       quoteResult?.fee?.estimatedFeeFiatValue ?? '0',
     );
     const allFeeFiatValue = estimatedFeeFiatValue.plus(oneKeyFeeFiatValue);
-    const allFeeFiatValueFormat = numberFormat(allFeeFiatValue.toFixed(), {
-      formatter: 'value',
-      formatterOptions: { currency: settingsPersistAtom.currencyInfo.symbol },
-    });
-    return `${allFeeFiatValueFormat as string}`;
+    const allFeeFiatValueFormat = numberFormatAsString(
+      allFeeFiatValue.toFixed(),
+      allFeeFiatValueFormatter,
+    );
+    return `${allFeeFiatValueFormat}`;
   }, [
-    quoteResult?.fee?.estimatedFeeFiatValue,
-    quoteResult?.oneKeyFeeExtraInfo,
-    toToken?.price,
+    quoteResult?.oneKeyFeeExtraInfo?.oneKeyFeeAmount,
     quoteResult?.kind,
+    quoteResult?.fee?.estimatedFeeFiatValue,
+    toToken?.price,
     fromToken?.price,
-    settingsPersistAtom.currencyInfo.symbol,
+    allFeeFiatValueFormatter,
   ]);
 
   const limitNetworkFeeMarkQuestContent = useMemo(() => {
-    const networkCostBuyAmountFormat = numberFormat(
+    const networkCostBuyAmountFormat = numberFormatAsString(
       quoteResult?.networkCostBuyAmount ?? '0',
-      { formatter: 'balance' },
+      formatter,
     );
-    const oneKeyFeeCostFormat = numberFormat(
+    const oneKeyFeeCostFormat = numberFormatAsString(
       quoteResult?.oneKeyFeeExtraInfo?.oneKeyFeeAmount ?? '0',
-      {
-        formatter: 'balance',
-      },
+      formatter,
     );
 
     return (
@@ -311,9 +319,9 @@ const SwapQuoteResult = ({
               id: ETranslations.limit_order_info_network_cost,
             })}
           </SizableText>
-          <SizableText size="$bodyMdMedium">{`${
-            networkCostBuyAmountFormat as string
-          } ${quoteResult?.toTokenInfo?.symbol ?? ''}`}</SizableText>
+          <SizableText size="$bodyMdMedium">{`${networkCostBuyAmountFormat} ${
+            quoteResult?.toTokenInfo?.symbol ?? ''
+          }`}</SizableText>
         </XStack>
         <XStack justifyContent="space-between">
           <SizableText size="$bodyMdMedium" color="$textSubdued">
@@ -321,9 +329,7 @@ const SwapQuoteResult = ({
               id: ETranslations.provider_ios_popover_onekey_fee,
             })}
           </SizableText>
-          <SizableText size="$bodyMdMedium">{`${
-            oneKeyFeeCostFormat as string
-          } ${
+          <SizableText size="$bodyMdMedium">{`${oneKeyFeeCostFormat} ${
             quoteResult?.oneKeyFeeExtraInfo?.oneKeyFeeSymbol ?? ''
           }`}</SizableText>
         </XStack>

--- a/packages/shared/src/utils/numberUtils.ts
+++ b/packages/shared/src/utils/numberUtils.ts
@@ -726,7 +726,7 @@ export const numberFormat = memoizee(
   },
 );
 
-export const numberFormatAsDisplay = (
+export const numberFormatAsRenderText = (
   value: string,
   { formatter, formatterOptions }: INumberFormatProps,
   isRaw = false,

--- a/packages/shared/src/utils/numberUtils.ts
+++ b/packages/shared/src/utils/numberUtils.ts
@@ -718,7 +718,17 @@ export const numberFormat = memoizee(
     if (typeof result === 'string') {
       return result;
     }
-    return result.filter((r) => typeof r === 'string' && r !== '').join('');
+    return result
+      .map((r) => {
+        if (typeof r === 'string') {
+          return r;
+        }
+        if (r.type === 'sub') {
+          return new Array(r.value - 1).fill(0).join('');
+        }
+        return '';
+      })
+      .join('');
   },
   {
     max: 200,
@@ -729,26 +739,7 @@ export const numberFormat = memoizee(
 export const numberFormatAsRenderText = (
   value: string,
   { formatter, formatterOptions }: INumberFormatProps,
-  isRaw = false,
 ) => {
   const result = numberFormatAsRaw(value, { formatter, formatterOptions });
-  if (isRaw) {
-    return result;
-  }
-
-  if (typeof result === 'string') {
-    return result;
-  }
-
-  return result
-    .map((r) => {
-      if (typeof r === 'string') {
-        return r;
-      }
-      if (r.type === 'sub') {
-        return new Array(r.value - 1).fill(0).join('');
-      }
-      return '';
-    })
-    .join('');
+  return result;
 };

--- a/packages/shared/src/utils/numberUtils.ts
+++ b/packages/shared/src/utils/numberUtils.ts
@@ -701,14 +701,20 @@ export interface INumberFormatProps {
   formatterOptions?: IFormatterOptions;
 }
 
-export const numberFormatAsString = memoizee(
+export const numberFormatAsRaw = (
+  value: string,
+  { formatter, formatterOptions }: INumberFormatProps,
+) => {
+  return formatter && value
+    ? formatDisplayNumber(
+        NUMBER_FORMATTER[formatter](String(value), formatterOptions),
+      )
+    : '';
+};
+
+export const numberFormat = memoizee(
   (value: string, { formatter, formatterOptions }: INumberFormatProps) => {
-    const result =
-      formatter && value
-        ? formatDisplayNumber(
-            NUMBER_FORMATTER[formatter](String(value), formatterOptions),
-          )
-        : '';
+    const result = numberFormatAsRaw(value, { formatter, formatterOptions });
     if (typeof result === 'string') {
       return result;
     }
@@ -720,17 +726,12 @@ export const numberFormatAsString = memoizee(
   },
 );
 
-export const numberFormat = (
+export const numberFormatAsDisplay = (
   value: string,
   { formatter, formatterOptions }: INumberFormatProps,
   isRaw = false,
 ) => {
-  const result =
-    formatter && value
-      ? formatDisplayNumber(
-          NUMBER_FORMATTER[formatter](String(value), formatterOptions),
-        )
-      : '';
+  const result = numberFormatAsRaw(value, { formatter, formatterOptions });
   if (isRaw) {
     return result;
   }

--- a/packages/shared/src/utils/numberUtils.ts
+++ b/packages/shared/src/utils/numberUtils.ts
@@ -1,6 +1,7 @@
 import BigNumber from 'bignumber.js';
 
 import { check } from '@onekeyhq/shared/src/utils/assertUtils';
+import { memoizee } from '@onekeyhq/shared/src/utils/cacheUtils';
 
 import { appLocale, fallbackAppLocaleIntl } from '../locale/appLocale';
 import platformEnv from '../platformEnv';
@@ -699,6 +700,25 @@ export interface INumberFormatProps {
   formatter?: keyof typeof NUMBER_FORMATTER;
   formatterOptions?: IFormatterOptions;
 }
+
+export const numberFormatAsString = memoizee(
+  (value: string, { formatter, formatterOptions }: INumberFormatProps) => {
+    const result =
+      formatter && value
+        ? formatDisplayNumber(
+            NUMBER_FORMATTER[formatter](String(value), formatterOptions),
+          )
+        : '';
+    if (typeof result === 'string') {
+      return result;
+    }
+    return result.filter((r) => typeof r === 'string' && r !== '').join('');
+  },
+  {
+    max: 200,
+    maxAge: 1000 * 60 * 5, // 5 minutes
+  },
+);
 
 export const numberFormat = (
   value: string,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Perp quick action to Wallet actions (visible in extension popup and now exposed in the public actions list) to open the Perp tab.

* **Enhancements**
  * Improved Hyperliquid Terms carousel with explicit prev/next controls and smoother navigation.
  * Standardized and optimized number/currency formatting across markets, swaps, Perp panels, orders, and trade history for more consistent, performant displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->