### PR TITLE
OK-44130: conditionally render PerpSettingsButton based on media query

### DIFF
--- a/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
@@ -153,13 +153,14 @@ function DepositButton() {
 }
 
 export function PerpsHeaderRight() {
+  const { gtMd } = useMedia();
   const content = (
     <XStack alignItems="center" gap="$5">
       {process.env.NODE_ENV !== 'production' ? <DebugButton /> : null}
       <DepositButton />
-      {platformEnv.isNative ? null : (
+      {gtMd ? (
         <PerpSettingsButton testID="perp-header-settings-button" />
-      )}
+      ) : null}
     </XStack>
   );
   return (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  - The settings button in the Perpetuals trading header now appears based on screen size (visible on medium and larger screens), ensuring consistent behavior across platforms.

* Refactor
  - Updated visibility logic to use responsive breakpoints for header actions, improving UI consistency without affecting other buttons (e.g., Deposit).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->