### PR TITLE
fix: correct async handling in ensureTradingEnabled and related calls

### DIFF
--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -9,7 +9,6 @@ import { showEnableTradingDialog } from '@onekeyhq/kit/src/views/Perp/components
 import {
   perpsActiveAccountAtom,
   perpsActiveAccountIsAgentReadyAtom,
-  perpsActiveAccountStatusAtom,
   perpsActiveAssetAtom,
   perpsActiveAssetCtxAtom,
   perpsActiveAssetDataAtom,
@@ -730,9 +729,9 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     },
   );
 
-  ensureTradingEnabled = contextAtomMethod((get, _set) => {
-    const { isAgentReady } = get(perpsActiveAccountIsAgentReadyAtom.atom());
-    if (isAgentReady === false) {
+  ensureTradingEnabled = contextAtomMethod(async (get, _set) => {
+    const info = await perpsActiveAccountIsAgentReadyAtom.get();
+    if (info.isAgentReady === false) {
       showEnableTradingDialog();
       throw new OneKeyLocalError('Trading not enabled');
     }
@@ -741,7 +740,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
   closeAllPositions = contextAtomMethod(async (get, set) => {
     return withToast({
       asyncFn: async () => {
-        this.ensureTradingEnabled.call(set);
+        await this.ensureTradingEnabled.call(set);
         const { activePositions: positions } = get(perpsActivePositionAtom());
 
         if (positions.length === 0) {

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpOpenOrdersList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpOpenOrdersList.tsx
@@ -31,7 +31,7 @@ function PerpOpenOrdersList({ isMobile }: IPerpOpenOrdersListProps) {
     setCurrentListPage(1);
   }, [currentUser?.accountAddress]);
   const handleCancelAll = useCallback(async () => {
-    actions.current.ensureTradingEnabled();
+    await actions.current.ensureTradingEnabled();
     const symbolsMetaMap =
       await backgroundApiProxy.serviceHyperliquid.getSymbolsMetaMap({
         coins: orders.map((o) => o.coin),
@@ -148,7 +148,7 @@ function PerpOpenOrdersList({ isMobile }: IPerpOpenOrdersListProps) {
 
   const handleCancelOrder = useCallback(
     async (order: FrontendOrder) => {
-      actions.current.ensureTradingEnabled();
+      await actions.current.ensureTradingEnabled();
       const symbolMeta =
         await backgroundApiProxy.serviceHyperliquid.getSymbolMeta({
           coin: order.coin,

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
@@ -146,7 +146,7 @@ const SetTpslForm = memo(
 
     const handleCancelOrder = useCallback(
       async (order: IPerpsFrontendOrder) => {
-        hyperliquidActions.current.ensureTradingEnabled();
+        await hyperliquidActions.current.ensureTradingEnabled();
         const symbolMeta =
           await backgroundApiProxy.serviceHyperliquid.getSymbolMeta({
             coin: order.coin,

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -92,6 +92,7 @@ function BasePerpTokenSelectorContent({
   onLoadingChange: (isLoading: boolean) => void;
 }) {
   const intl = useIntl();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { searchQuery, setSearchQuery, refreshAllAssets } =
     usePerpTokenSelector();
   const { closePopover } = usePopoverContext();
@@ -140,7 +141,7 @@ function BasePerpTokenSelectorContent({
             // value={searchQuery} // keep value undefined to make debounce works
           />
         </XStack>
-        <Button onPress={refreshAllAssets}>{filteredTokensLength}</Button>
+        {/* <Button onPress={refreshAllAssets}>{filteredTokensLength}</Button> */}
         <TokenListHeader />
       </YStack>
 

--- a/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
@@ -21,6 +21,8 @@ import {
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
   usePerpsActiveAccountAtom,
+  usePerpsActiveAccountIsAgentReadyAtom,
+  usePerpsActiveAccountStatusAtom,
   usePerpsActiveAccountSummaryAtom,
   usePerpsActiveAssetAtom,
   usePerpsActiveAssetCtxAtom,
@@ -48,6 +50,8 @@ function DebugButton() {
 
   const [activeAccount] = usePerpsActiveAccountAtom();
   const [activeAccountSummary] = usePerpsActiveAccountSummaryAtom();
+  const [activeAccountStatus] = usePerpsActiveAccountStatusAtom();
+  const [{ isAgentReady }] = usePerpsActiveAccountIsAgentReadyAtom();
   const [activeAsset] = usePerpsActiveAssetAtom();
   const [activeAssetCtx] = usePerpsActiveAssetCtxAtom();
   const [activeAssetData] = usePerpsActiveAssetDataAtom();
@@ -83,6 +87,8 @@ function DebugButton() {
             activeOpenOrders,
             activePositions,
             activeOrderBookOptions,
+            activeAccountStatus,
+            isAgentReady,
           });
         }}
       />


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Debug button now displays active account status and agent readiness.

* Bug Fixes
  * Prevents closing all positions or canceling orders until trading is enabled, reducing unexpected errors and improving reliability.

* Style
  * Temporarily hides the “Refresh all assets” button in the token selector.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Fixed async handling in `ensureTradingEnabled` method to properly await agent ready check
- Added missing `await` keywords to all `ensureTradingEnabled` calls across perps components
- Removed debug refresh button in token selector
- Added debug hooks for trading account status

## Changes
- `actions.ts`: Made `ensureTradingEnabled` async and await `isAgentReady` check
- `PerpOpenOrdersList.tsx`: Added await to `ensureTradingEnabled` calls in cancel handlers
- `SetTpslModal.tsx`: Added await to `ensureTradingEnabled` in order cancel handler  
- `PerpTokenSelector.tsx`: Commented out debug refresh button
- `PerpsHeaderRight.tsx`: Added debug hooks for account status and agent ready state

## Test plan
- [ ] Verify trading guard checks execute before order operations
- [ ] Test cancel all orders functionality
- [ ] Test cancel single order functionality
- [ ] Test TP/SL modal order cancellation
- [ ] Verify no floating promise warnings in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)