### PR TITLE
OK-44178, refactor: auto-fetch decimals in usePerpsMidPrice hook

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
@@ -134,10 +134,9 @@ function PositionRowProvider({
   );
 }
 
-function MarkPrice({ coin, decimals }: { coin: string; decimals: number }) {
+function MarkPrice({ coin }: { coin: string }) {
   const { midFormattedByDecimals } = usePerpsMidPrice({
     coin,
-    szDecimals: decimals,
   });
 
   return useMemo(
@@ -286,7 +285,7 @@ const PositionRowDesktopEntryPrice = memo(() => {
 PositionRowDesktopEntryPrice.displayName = 'PositionRowDesktopEntryPrice';
 
 const PositionRowDesktopMarkPrice = memo(() => {
-  const { columnConfigs, coin, decimals } = usePositionRowContext();
+  const { columnConfigs, coin } = usePositionRowContext();
 
   const content = useMemo(
     () => (
@@ -295,10 +294,10 @@ const PositionRowDesktopMarkPrice = memo(() => {
         justifyContent={calcCellAlign(columnConfigs[3].align)}
         alignItems="center"
       >
-        <MarkPrice coin={coin} decimals={decimals} />
+        <MarkPrice coin={coin} />
       </XStack>
     ),
-    [columnConfigs, coin, decimals],
+    [columnConfigs, coin],
   );
   return content;
 });
@@ -1197,11 +1196,13 @@ const PositionRow = memo(
     );
     const priceInfo = useMemo(() => {
       const entryPrice = new BigNumber(pos.entryPx || '0').toFixed(decimals);
+
       const liquidationPrice = new BigNumber(pos.liquidationPx || '0');
       const entryPriceFormatted = entryPrice;
       const liquidationPriceFormatted = liquidationPrice.isZero()
         ? 'N/A'
         : liquidationPrice.toFixed(decimals);
+
       return {
         entryPriceFormatted,
         liquidationPriceFormatted,

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
@@ -54,8 +54,8 @@ interface ISetTpslFormProps extends ISetTpslParams {
   onClose: () => void;
 }
 
-function MarkPrice({ coin, szDecimals }: { coin: string; szDecimals: number }) {
-  const { midFormattedByDecimals } = usePerpsMidPrice({ coin, szDecimals });
+function MarkPrice({ coin }: { coin: string }) {
+  const { midFormattedByDecimals } = usePerpsMidPrice({ coin });
   return (
     <SizableText size="$bodyMdMedium">{midFormattedByDecimals}</SizableText>
   );
@@ -70,7 +70,7 @@ const SetTpslForm = memo(
     onClose = () => {},
   }: ISetTpslFormProps) => {
     const hyperliquidActions = useHyperliquidActions();
-    const { mid: midPrice } = usePerpsMidPrice({ coin, szDecimals });
+    const { mid: midPrice } = usePerpsMidPrice({ coin });
 
     const [{ activePositions }] = usePerpsActivePositionAtom();
     const [{ openOrders }] = usePerpsActiveOpenOrdersAtom();
@@ -427,7 +427,7 @@ const SetTpslForm = memo(
                   id: ETranslations.perp_position_mark_price,
                 })}
               </SizableText>
-              <MarkPrice coin={currentPosition.coin} szDecimals={szDecimals} />
+              <MarkPrice coin={currentPosition.coin} />
             </XStack>
           </YStack>
           <Divider />

--- a/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
@@ -46,7 +46,7 @@ function DebugButton() {
   const [allAssetCtxs] = usePerpsAllAssetCtxsAtom();
   const { assetCtx: btcAssetCtx } = usePerpsAssetCtx({ assetId: 0 });
   const { mid: btcMid, midFormattedByDecimals: btcMidFormattedByDecimals } =
-    usePerpsMidPrice({ coin: 'BTC', szDecimals: 2 });
+    usePerpsMidPrice({ coin: 'BTC' });
 
   const [activeAccount] = usePerpsActiveAccountAtom();
   const [activeAccountSummary] = usePerpsActiveAccountSummaryAtom();

--- a/packages/kit/src/views/Perp/hooks/usePerpsMidPrice.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpsMidPrice.ts
@@ -5,21 +5,23 @@ import { isNil } from 'lodash';
 
 import { formatPriceToSignificantDigits } from '@onekeyhq/shared/src/utils/perpsUtils';
 
+import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
+import { usePromiseResult } from '../../../hooks/usePromiseResult';
 import { usePerpsAllMidsAtom } from '../../../states/jotai/contexts/hyperliquid';
 
-export function usePerpsMidPrice({
-  coin,
-  szDecimals,
-}: {
-  coin: string;
-  szDecimals?: number;
-}): {
+export function usePerpsMidPrice({ coin }: { coin: string }): {
   mid: string | undefined;
   midFormattedByDecimals: string | undefined;
 } {
   const [allMids] = usePerpsAllMidsAtom();
   const mid = allMids?.mids?.[coin];
   const midValue = new BigNumber(mid || '');
+  const { result: tokenInfo } = usePromiseResult(async () => {
+    return backgroundApiProxy.serviceHyperliquid.getSymbolMeta({
+      coin,
+    });
+  }, [coin]);
+  const szDecimals = tokenInfo?.universe?.szDecimals ?? null;
   const midFormattedByDecimals = useMemo(() => {
     if (isNil(szDecimals) || Number.isNaN(szDecimals)) {
       return mid;


### PR DESCRIPTION
- Remove szDecimals parameter from usePerpsMidPrice hook
- Auto-fetch token metadata to get correct decimals for each coin
- Update all usages to remove manual szDecimals passing
- Simplify component props by removing decimals parameter
- Use usePromiseResult to fetch symbol metadata efficiently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Standardized mid/mark price formatting across Perps views (Positions, Trading Header, TP/SL), reducing inconsistencies.
  - Aligned entry price display precision with instrument settings for clearer, more accurate values.
- Refactor
  - Centralized mid-price formatting by automatically deriving instrument precision, simplifying usage across the app.
  - Streamlined components to require only the asset symbol for price displays.
- Style
  - Minor visual polish in price info sections for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->