### PR TITLE
feat: add pause/resume mechanism for WebSocket subscriptions

### DIFF
--- a/packages/kit/src/views/Perp/pages/Perp.tsx
+++ b/packages/kit/src/views/Perp/pages/Perp.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useFocusEffect } from '@react-navigation/native';
 import { useIntl } from 'react-intl';
@@ -10,8 +10,10 @@ import {
   Stack,
   XStack,
   YStack,
+  useIsFocusedTab,
   useMedia,
 } from '@onekeyhq/components';
+import { useFocusedTab } from '@onekeyhq/components/src/composite/Tabs/useFocusedTab';
 import { usePerpsNetworkStatusAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { FLOAT_NAV_BAR_Z_INDEX } from '@onekeyhq/shared/src/consts/zIndexConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -180,6 +182,7 @@ export default function Perp() {
   useFocusEffect(() => {
     void backgroundApiProxy.serviceHyperliquid.updatePerpsConfigByServer();
   });
+
   return (
     <PerpsAccountSelectorProviderMirror>
       <PerpsProviderMirror>


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Auto-pauses Hyperliquid data subscriptions when the Perps route/tab isn’t focused, and auto-resumes on focus.
  - Inactivity timer (10 minutes 30 seconds) pauses subscriptions when unfocused to reduce background activity.
- Improvements
  - More robust network status and reconnection handling for subscriptions, providing smoother recovery after reconnects.
  - Reduced unnecessary processing when subscriptions are disabled, improving performance and battery/data usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- Added automatic pause/resume mechanism for HyperLiquid WebSocket subscriptions when the Perp page is unfocused
- Implemented `pauseSubscriptions()` and `resumeSubscriptions()` methods in ServiceHyperliquidSubscription
- Added `AutoPauseSubscriptions` component to monitor route focus and control subscription lifecycle
- Refactored subscription cleanup logic to use spec-based destruction for better reliability
- Improved network status management and error handling
- Added 10.5 minute delayed pause to reduce unnecessary reconnection overhead

## Changes

### ServiceHyperliquidSubscription
- Added `pauseSubscriptions()` / `resumeSubscriptions()` methods for external control
- Added `subscriptionsHandlerDisabled` flag to prevent message processing when paused
- Refactored `IActiveSubscription` to store `spec` instead of SDK subscription object
- Improved `_destroySubscription()` to accept spec parameter for more reliable cleanup
- Enhanced `_cleanupAllSubscriptions()` to handle all subscription types comprehensively
- Swapped `socketErrorHandler` and `socketCloseHandler` order for better readability

### PerpsGlobalEffects
- Added `AutoPauseSubscriptions` component to automatically pause/resume based on route focus
- Implemented delayed pause (10.5 minutes) to avoid frequent reconnections
- Integrated with route focus detection to control subscription lifecycle

## Test plan

- [ ] Verify subscriptions pause when navigating away from Perp page
- [ ] Verify subscriptions resume when returning to Perp page
- [ ] Verify 10.5 minute delay works correctly before actual pause
- [ ] Test network status updates correctly reflect connection state
- [ ] Verify no memory leaks or orphaned subscriptions
- [ ] Test across desktop, mobile, web, and extension platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)