### PR TITLE
refactor: remove unused WebSocket metadata from event bus

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/messageHandlers/index.ts
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/messageHandlers/index.ts
@@ -325,18 +325,19 @@ export function usePerpsMessageHandler({
         type: 'account';
         subType: string;
         data: IWsUserFills;
-        metadata: {
-          timestamp: number;
-          source: string;
-          userId?: string;
-        };
       };
 
       // Only process USER_FILLS events
       if (eventPayload.subType !== ESubscriptionType.USER_FILLS) return;
 
       // Verify the data is for the current user
-      if (eventPayload.metadata.userId !== userAddressRef.current) return;
+      if (
+        !eventPayload?.data?.user ||
+        eventPayload?.data?.user?.toLowerCase() !==
+          userAddressRef.current?.toLowerCase()
+      ) {
+        return;
+      }
 
       const { data } = eventPayload;
 

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/atoms.ts
@@ -51,6 +51,7 @@ export const { atom: perpsAllAssetCtxsAtom, use: usePerpsAllAssetCtxsAtom } =
 export const { atom: l2BookAtom, use: useL2BookAtom } =
   contextAtom<HL.IBook | null>(null);
 
+// TODO remove
 export const { atom: connectionStateAtom, use: useConnectionStateAtom } =
   contextAtom<IConnectionState>({
     isConnected: false,

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -89,14 +89,6 @@ function useHyperliquidEventBusListener() {
         type: 'market' | 'account';
         subType: ESubscriptionType;
         data: any;
-        metadata: {
-          timestamp: number;
-          source: string;
-          key?: string;
-          coin?: string;
-          userId?: string;
-          interval?: string;
-        };
       };
       const { subType, data } = eventPayload;
 
@@ -113,23 +105,19 @@ function useHyperliquidEventBusListener() {
           }
 
           case ESubscriptionType.ACTIVE_ASSET_CTX:
-            if (eventPayload.metadata.coin) {
-              // move to global jotai, updateActiveAssetCtx() in background
-              // void actions.current.updateActiveAssetCtx(
-              //   data as IWsActiveAssetCtx,
-              //   eventPayload.metadata.coin,
-              // );
-            }
+            // move to global jotai, updateActiveAssetCtx() in background
+            // void actions.current.updateActiveAssetCtx(
+            //   data as IWsActiveAssetCtx,
+            //   eventPayload.metadata.coin,
+            // );
             break;
 
           case ESubscriptionType.ACTIVE_ASSET_DATA:
-            if (eventPayload.metadata.coin) {
-              // move to global jotai, updateActiveAssetData() in background
-              // void actions.current.updateActiveAssetData(
-              //   data as IActiveAssetData,
-              //   eventPayload.metadata.coin,
-              // );
-            }
+            // move to global jotai, updateActiveAssetData() in background
+            // void actions.current.updateActiveAssetData(
+            //   data as IActiveAssetData,
+            //   eventPayload.metadata.coin,
+            // );
             break;
 
           case ESubscriptionType.L2_BOOK:
@@ -155,10 +143,6 @@ function useHyperliquidEventBusListener() {
           lastConnected: number;
           service: string;
           activeSubscriptions: number;
-        };
-        metadata: {
-          timestamp: number;
-          source: string;
         };
       };
       const { data } = eventPayload;

--- a/packages/kit/src/views/Perp/hooks/usePerpOrderInfoPanel.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpOrderInfoPanel.ts
@@ -41,17 +41,17 @@ export function usePerpTradesHistory() {
         type: 'account';
         subType: string;
         data: IWsUserFills;
-        metadata: {
-          timestamp: number;
-          source: string;
-          userId?: string;
-        };
       };
 
       if (eventPayload.subType !== ESubscriptionType.USER_FILLS) return;
 
-      if (eventPayload.metadata.userId !== currentAccount?.accountAddress)
+      if (
+        !eventPayload?.data?.user ||
+        eventPayload?.data?.user?.toLowerCase() !==
+          currentAccount?.accountAddress?.toLowerCase()
+      ) {
         return;
+      }
 
       const { data } = eventPayload;
 

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -353,7 +353,6 @@ export interface IAppEventBusPayload {
     type: string;
     subType: ESubscriptionType;
     data: unknown;
-    metadata: Record<string, any>;
   };
   [EAppEventBusNames.HyperliquidConnectionChange]: {
     type: 'connection';


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Ensures user-specific fills and order info update only for the signed-in account, preventing cross-account or irrelevant updates.

- Refactor
  - Simplified Hyperliquid event handling by removing unused metadata and standardizing on type-based subscriptions, resulting in more consistent and reliable data updates across trading views and global effects.

- Chores
  - Minor comment update with no functional impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Removed unnecessary metadata from WebSocket subscription events
- Simplified event handling by extracting user/coin info directly from event data
- Improved performance by reducing data overhead in event bus
- Updated all event consumers to work without metadata dependency

## Changes
- **ServiceHyperliquidSubscription**: Removed metadata generation logic (timestamp, source, key, coin, userId)
- **Event handlers**: Updated to extract user address from `data.user` instead of `metadata.userId`
- **Event bus types**: Removed metadata field from `HyperliquidSubscriptionData` payload
- **Simplified method signature**: `_handleSubscriptionData` now takes only `subscriptionType` and `event`

## Test plan
- [ ] Verify WebSocket subscription events still work correctly
- [ ] Test user fills filtering by address
- [ ] Verify all subscription types (USER_FILLS, ACTIVE_ASSET_CTX, L2_BOOK, etc.)
- [ ] Check that event data is properly validated and processed
- [ ] Ensure no breaking changes to event consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)