### PR TITLE
fix: add WebSocket connection state check and improve subscription pause logic

### DIFF
--- a/development/spellCheckerSkipWords.js
+++ b/development/spellCheckerSkipWords.js
@@ -27,6 +27,7 @@ module.exports = [
   'perp',
   'hyperliquid',
   'Delisted',
+  'inferrable',
   'PerpTrade',
   'perpTradeRouters',
   'thirdparty',

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -32,6 +32,7 @@ import {
   perpsActiveAssetAtom,
   perpsActiveOrderBookOptionsAtom,
   perpsNetworkStatusAtom,
+  perpsWebSocketReadyStateAtom,
 } from '../../states/jotai/atoms/perps';
 import ServiceBase from '../ServiceBase';
 
@@ -303,6 +304,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     ...args
   ) => {
     const socket = event.target as WebSocket | undefined;
+    void perpsWebSocketReadyStateAtom.set({ readyState: socket?.readyState });
     console.log(
       'hyperliquidWebSocket__event__error',
       socket?.readyState,
@@ -316,6 +318,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     ...args
   ) => {
     const socket = event.target as WebSocket | undefined;
+    void perpsWebSocketReadyStateAtom.set({ readyState: socket?.readyState });
     console.log(
       'hyperliquidWebSocket__event__close',
       socket?.readyState,
@@ -336,6 +339,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     ...args
   ) => {
     const socket = event.target as WebSocket | undefined;
+    void perpsWebSocketReadyStateAtom.set({ readyState: socket?.readyState });
     console.log(
       'hyperliquidWebSocket__event__open',
       socket?.readyState,
@@ -356,6 +360,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     ...args
   ) => {
     const socket = event.target as WebSocket | undefined;
+    void perpsWebSocketReadyStateAtom.set({ readyState: socket?.readyState });
     console.log(
       'hyperliquidWebSocket__event__message',
       socket?.readyState,

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -74,6 +74,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   }
 
   private _client: {
+    transport: WebSocketTransport;
     dispose: () => Promise<void>;
     hlEventTarget: IHyperliquidEventTarget;
     wsRequester: {
@@ -108,6 +109,11 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
   _updateSubscriptionsDebounced = debounce(
     async () => {
+      const client = await this.getWebSocketClient();
+      if (client?.transport?.socket?.readyState !== WebSocket.OPEN) {
+        return;
+      }
+
       const activeAccount = await perpsActiveAccountAtom.get();
       const activeAsset = await perpsActiveAssetAtom.get();
       const activeOrderBookOptions =
@@ -445,6 +451,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         });
       };
       this._client = {
+        transport,
         hlEventTarget,
         wsRequester,
         subscribe,

--- a/packages/kit-bg/src/states/jotai/atomNames.ts
+++ b/packages/kit-bg/src/states/jotai/atomNames.ts
@@ -71,6 +71,7 @@ export enum EAtomNames {
   perpsCommonConfigPersistAtom = 'perpsCommonConfigPersistAtom',
   perpsUserConfigPersistAtom = 'perpsUserConfigPersistAtom',
   perpsNetworkStatusAtom = 'perpsNetworkStatusAtom',
+  perpsWebSocketReadyStateAtom = 'perpsWebSocketReadyStateAtom',
 }
 export type IAtomNameKeys = keyof typeof EAtomNames;
 export const atomsConfig: Partial<

--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -318,3 +318,21 @@ export const {
     lastMessageAt: null,
   },
 });
+
+export const {
+  target: perpsWebSocketReadyStateAtom,
+  use: usePerpsWebSocketReadyStateAtom,
+} = globalAtom<{ readyState: number | undefined } | undefined>({
+  name: EAtomNames.perpsWebSocketReadyStateAtom,
+  initialValue: undefined,
+});
+
+export const {
+  target: perpsWebSocketConnectedAtom,
+  use: usePerpsWebSocketConnectedAtom,
+} = globalAtomComputedR<boolean>({
+  read: (get) => {
+    const readyState = get(perpsWebSocketReadyStateAtom.atom());
+    return readyState?.readyState === WebSocket.OPEN;
+  },
+});

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -408,38 +408,42 @@ function useHyperliquidScreenLockHandler() {
 }
 
 function AutoPauseSubscriptions() {
-  const isFocusedPerpsTab = useIsFocusedTab();
-  const focusedTabName = useFocusedTab();
-  const isFocusedRoute = useRouteIsFocused();
-
-  console.log('AutoPauseSubscriptions___value', {
-    isFocusedPerpsTab,
-    focusedTabName,
-    isFocusedRoute,
-  });
-
   const pauseSubscriptionsTimerRef = useRef<
     ReturnType<typeof setTimeout> | undefined
   >(undefined);
-  useEffect(() => {
-    if (isFocusedRoute) {
-      clearTimeout(pauseSubscriptionsTimerRef.current);
-      void backgroundApiProxy.serviceHyperliquidSubscription.enableSubscriptionsHandler();
-      void backgroundApiProxy.serviceHyperliquidSubscription.resumeSubscriptions();
-    } else {
-      void backgroundApiProxy.serviceHyperliquidSubscription.disableSubscriptionsHandler();
-      clearTimeout(pauseSubscriptionsTimerRef.current);
-      pauseSubscriptionsTimerRef.current = setTimeout(
-        () => {
-          void backgroundApiProxy.serviceHyperliquidSubscription.pauseSubscriptions();
-        },
-        timerUtils.getTimeDurationMs({
-          minute: 10,
-          seconds: 30,
-        }),
-      );
-    }
-  }, [isFocusedRoute]);
+
+  // const isFocusedRoute = useRouteIsFocused();
+  // useEffect(() => {
+  //   //
+  // }, [isFocusedRoute]);
+
+  useListenTabFocusState(
+    ETabRoutes.Perp,
+    async (isFocus: boolean, _isHideByModal: boolean) => {
+      // console.log('AutoPauseSubscriptions___useListenTabFocusState', {
+      //   isFocus,
+      //   isHideByModal,
+      // });
+      if (isFocus) {
+        clearTimeout(pauseSubscriptionsTimerRef.current);
+        void backgroundApiProxy.serviceHyperliquidSubscription.enableSubscriptionsHandler();
+        void backgroundApiProxy.serviceHyperliquidSubscription.resumeSubscriptions();
+      } else {
+        void backgroundApiProxy.serviceHyperliquidSubscription.disableSubscriptionsHandler();
+        clearTimeout(pauseSubscriptionsTimerRef.current);
+        pauseSubscriptionsTimerRef.current = setTimeout(
+          () => {
+            void backgroundApiProxy.serviceHyperliquidSubscription.pauseSubscriptions();
+          },
+          timerUtils.getTimeDurationMs({
+            minute: 5,
+            seconds: 30,
+          }),
+        );
+      }
+    },
+  );
+
   return null;
 }
 

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -450,6 +450,12 @@ function AutoPauseSubscriptions() {
 
   useListenTabFocusState(ETabRoutes.Perp, onFocusHandler);
 
+  useEffect(() => {
+    return () => {
+      clearTimeout(pauseSubscriptionsTimerRef.current);
+    };
+  }, []);
+
   return null;
 }
 

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -417,8 +417,7 @@ function AutoPauseSubscriptions() {
   //   //
   // }, [isFocusedRoute]);
 
-  useListenTabFocusState(
-    ETabRoutes.Perp,
+  const onFocusHandler = useCallback(
     async (isFocus: boolean, _isHideByModal: boolean) => {
       // console.log('AutoPauseSubscriptions___useListenTabFocusState', {
       //   isFocus,
@@ -442,7 +441,10 @@ function AutoPauseSubscriptions() {
         );
       }
     },
+    [],
   );
+
+  useListenTabFocusState(ETabRoutes.Perp, onFocusHandler);
 
   return null;
 }

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -24,6 +24,7 @@ import {
   usePerpsActiveAccountAtom,
   usePerpsActiveAssetAtom,
   usePerpsActiveOrderBookOptionsAtom,
+  usePerpsWebSocketConnectedAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms/perps';
 import { PERPS_NETWORK_ID } from '@onekeyhq/shared/src/consts/perp';
 import { COINTYPE_ETH } from '@onekeyhq/shared/src/engine/engineConsts';
@@ -324,12 +325,13 @@ function useHyperliquidAccountSelect() {
   }, [isFocused, checkPerpsAccountStatus]);
 }
 
-function WeboscketSubscriptionUpdate() {
+function WebSocketSubscriptionUpdate() {
   const [loadingInfo] = usePerpsAccountLoadingInfoAtom();
   const [activePerpsAccount] = usePerpsActiveAccountAtom();
   const [activeAsset] = usePerpsActiveAssetAtom();
   const [activeOrderBookOptions] = usePerpsActiveOrderBookOptionsAtom();
   const actions = useHyperliquidActions();
+  const [isWebSocketConnected] = usePerpsWebSocketConnectedAtom();
 
   const isLoading = !!loadingInfo?.selectAccountLoading;
   const isLoadingRef = useRef(isLoading);
@@ -343,6 +345,7 @@ function WeboscketSubscriptionUpdate() {
     noop(activeOrderBookOptions?.nSigFigs);
 
     if (
+      isWebSocketConnected &&
       !isLoading &&
       activeAsset?.coin &&
       activeOrderBookOptions?.coin === activeAsset?.coin
@@ -351,6 +354,7 @@ function WeboscketSubscriptionUpdate() {
       void actions.current.updateSubscriptions();
     }
   }, [
+    isWebSocketConnected,
     isLoading,
     actions,
     activePerpsAccount?.accountAddress,
@@ -460,7 +464,7 @@ function PerpsGlobalEffectsView() {
   return (
     <>
       <DelayedRender delay={600}>
-        <WeboscketSubscriptionUpdate />
+        <WebSocketSubscriptionUpdate />
       </DelayedRender>
       <AutoPauseSubscriptions />
     </>

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -333,7 +333,8 @@ function WebSocketSubscriptionUpdate() {
   const actions = useHyperliquidActions();
   const [isWebSocketConnected] = usePerpsWebSocketConnectedAtom();
 
-  const isLoading = !!loadingInfo?.selectAccountLoading;
+  // eslint-disable-next-line @typescript-eslint/no-inferrable-types
+  const isLoading: boolean = !!loadingInfo?.selectAccountLoading;
   const isLoadingRef = useRef(isLoading);
   isLoadingRef.current = isLoading;
 
@@ -345,7 +346,7 @@ function WebSocketSubscriptionUpdate() {
     noop(activeOrderBookOptions?.nSigFigs);
 
     if (
-      isWebSocketConnected &&
+      isWebSocketConnected === true &&
       !isLoading &&
       activeAsset?.coin &&
       activeOrderBookOptions?.coin === activeAsset?.coin

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -1,18 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { useFocusEffect } from '@react-navigation/native';
 import { noop } from 'lodash';
 
-import {
-  useIsFocusedTab,
-  useTabIsRefreshingFocused,
-  useUpdateEffect,
-} from '@onekeyhq/components';
-import { useFocusedTab } from '@onekeyhq/components/src/composite/Tabs/useFocusedTab';
+import { useUpdateEffect } from '@onekeyhq/components';
 import { DelayedRender } from '@onekeyhq/components/src/hocs/DelayedRender';
 import {
   useAccountIsAutoCreatingAtom,
+  useAppIsLockedAtom,
   useIndexedAccountAddressCreationStateAtom,
   usePasswordAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -423,7 +418,7 @@ function AutoPauseSubscriptions() {
   // }, [isFocusedRoute]);
 
   const onFocusHandler = useCallback(
-    async (isFocus: boolean, _isHideByModal: boolean) => {
+    async ({ isFocus }: { isFocus: boolean }) => {
       // console.log('AutoPauseSubscriptions___useListenTabFocusState', {
       //   isFocus,
       //   isHideByModal,
@@ -449,7 +444,28 @@ function AutoPauseSubscriptions() {
     [],
   );
 
-  useListenTabFocusState(ETabRoutes.Perp, onFocusHandler);
+  const isFocusedRef = useRef(false);
+
+  useListenTabFocusState(
+    ETabRoutes.Perp,
+    useCallback(
+      (isFocus: boolean) => {
+        isFocusedRef.current = isFocus;
+        void onFocusHandler({ isFocus: isFocusedRef.current });
+      },
+      [onFocusHandler],
+    ),
+  );
+
+  const [isLocked] = useAppIsLockedAtom();
+
+  useEffect(() => {
+    if (isLocked) {
+      void onFocusHandler({ isFocus: false });
+    } else {
+      void onFocusHandler({ isFocus: isFocusedRef.current });
+    }
+  }, [isLocked, onFocusHandler]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposes WebSocket connection status for Perps so the UI can react to OPEN/closed state.
  * Subscriptions resume immediately when the Perps tab gains focus and auto-pause after 5m30s when unfocused; also pauses when the app is locked.

* **Bug Fixes**
  * Subscription updates now run only when the WebSocket is open, reducing transient errors.

* **Refactor**
  * Centralized focus/visibility handling for Perps subscription flow.

* **Chores**
  * Added 'inferrable' to spell-check skip list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Add WebSocket readyState check before updating subscriptions to prevent updates on closed connections
- Store transport reference in client object for state access  
- Replace route focus check with tab focus listener for better pause/resume control
- Reduce subscription pause timeout from 10m30s to 5m30s for more responsive cleanup

## Test plan
- [ ] Verify subscriptions don't update when WebSocket is closed
- [ ] Verify tab focus/blur triggers proper pause/resume behavior
- [ ] Verify subscription cleanup occurs after 5m30s of inactivity
- [ ] Test across desktop/web/mobile platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)