### PR TITLE
OK-44058 OK-44099 OK-44135 OK-44198 OK-44179 OK-44192, refactor: optimize Perp modals and improve available balance display

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/AdjustPositionMarginModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/AdjustPositionMarginModal.tsx
@@ -169,7 +169,7 @@ const AdjustPositionMarginForm = memo(
     }, [amount, action, maxAdd, maxRemove]);
 
     const handleSubmit = useCallback(async () => {
-      if (!isValidAmount || !assetId || !currentPosition) return;
+      if (!isValidAmount || assetId === null || !currentPosition) return;
 
       setIsSubmitting(true);
       try {

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
@@ -85,7 +85,7 @@ const ClosePositionForm = memo(
 
     const [formData, setFormData] = useState<IClosePositionFormData>({
       type,
-      amount: formatWithPrecision(positionSize, szDecimals, true),
+      amount: positionSize.toFixed(),
       limitPrice: '',
       percentage: 100,
     });

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
@@ -249,18 +249,20 @@ const SetTpslForm = memo(
           return;
         }
 
-        const numericValue = new BigNumber(processedValue);
+        let numericValue = new BigNumber(processedValue);
         if (numericValue.isNaN()) {
           return;
         }
-
+        if (numericValue.gt(positionSize)) {
+          numericValue = positionSize;
+        }
         const percentage = positionSize.gt(0)
           ? numericValue.dividedBy(positionSize).multipliedBy(100).toNumber()
           : 0;
 
         setFormData((prev) => ({
           ...prev,
-          amount: processedValue,
+          amount: numericValue.toFixed(),
           percentage: Math.min(100, Math.max(0, percentage)),
         }));
       },

--- a/packages/kit/src/views/Perp/components/TradingGuardWrapper.tsx
+++ b/packages/kit/src/views/Perp/components/TradingGuardWrapper.tsx
@@ -53,7 +53,6 @@ function TradingGuardWrapperInternal({
       ) {
         void showDepositWithdrawModal(
           {
-            withdrawable: '0',
             actionType: 'deposit',
           },
           dialogInTab,

--- a/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingButton.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingButton.tsx
@@ -83,7 +83,6 @@ export function PerpTradingButton({
     ) {
       await showDepositWithdrawModal(
         {
-          withdrawable: '0',
           actionType: 'deposit',
         },
         dialogInTab,

--- a/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
@@ -113,7 +113,6 @@ function DepositButton() {
         showDepositWithdrawModal(
           {
             actionType: 'deposit',
-            withdrawable: accountSummary?.withdrawable || '0',
           },
           dialogInTab,
         )

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -65,7 +65,6 @@ const DEPOSIT_WITHDRAW_INPUT_ACCESSORY_VIEW_ID =
   'perp-deposit-withdraw-accessory-view';
 
 interface IDepositWithdrawParams {
-  withdrawable: string;
   actionType: IPerpsDepositWithdrawActionType;
 }
 
@@ -85,7 +84,7 @@ function DepositWithdrawContent({
   const { gtMd } = useMedia();
   const [accountSummary] = usePerpsActiveAccountSummaryAtom();
   const accountValue = accountSummary?.accountValue ?? '';
-
+  const withdrawable = accountSummary?.withdrawable ?? '';
   const accountValueInfoTrigger = useMemo(
     () => (
       <XStack
@@ -231,9 +230,7 @@ function DepositWithdrawContent({
 
   const availableBalance = useMemo(() => {
     const rawBalance =
-      selectedAction === 'withdraw'
-        ? params.withdrawable || '0'
-        : usdcBalance || '0';
+      selectedAction === 'withdraw' ? withdrawable || '0' : usdcBalance || '0';
 
     return {
       balance: rawBalance,
@@ -241,7 +238,7 @@ function DepositWithdrawContent({
         .decimalPlaces(2, BigNumber.ROUND_DOWN)
         .toFixed(2),
     };
-  }, [selectedAction, params.withdrawable, usdcBalance]);
+  }, [selectedAction, withdrawable, usdcBalance]);
 
   const amountBN = useMemo(() => new BigNumber(amount || '0'), [amount]);
 

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
@@ -267,7 +267,6 @@ function PerpAccountPanel() {
               showDepositWithdrawModal(
                 {
                   actionType: 'deposit',
-                  withdrawable: accountSummary?.withdrawable || '0',
                 },
                 dialogInTab,
               )
@@ -288,7 +287,6 @@ function PerpAccountPanel() {
               showDepositWithdrawModal(
                 {
                   actionType: 'withdraw',
-                  withdrawable: accountSummary?.withdrawable || '0',
                 },
                 dialogInTab,
               )

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -42,6 +42,7 @@ import {
   type ITradeSide,
   getTradingSideTextColor,
 } from '../../../utils/styleUtils';
+import { PerpsAccountNumberValue } from '../components/PerpsAccountNumberValue';
 import { PriceInput } from '../inputs/PriceInput';
 import { SizeInput } from '../inputs/SizeInput';
 import { TpSlFormInput } from '../inputs/TpSlFormInput';
@@ -56,7 +57,6 @@ interface IPerpTradingFormProps {
 }
 
 function MobileDepositButton() {
-  const [accountSummary] = usePerpsActiveAccountSummaryAtom();
   const dialogInTab = useInTabDialog();
   return (
     <IconButton
@@ -69,7 +69,6 @@ function MobileDepositButton() {
         showDepositWithdrawModal(
           {
             actionType: 'deposit',
-            withdrawable: accountSummary?.withdrawable || '0',
           },
           dialogInTab,
         )
@@ -85,6 +84,8 @@ function PerpTradingForm({
   isMobile = false,
 }: IPerpTradingFormProps) {
   const [perpsAccountLoading] = usePerpsAccountLoadingInfoAtom();
+  const [accountSummary] = usePerpsActiveAccountSummaryAtom();
+
   const [formData] = useTradingFormAtom();
   const [, setTradingFormEnv] = useTradingFormEnvAtom();
   const [tradingComputed] = useTradingFormComputedAtom();
@@ -388,9 +389,10 @@ function PerpTradingForm({
             })}
           </SizableText>
           <XStack alignItems="center" gap="$1">
-            <SizableText size="$bodySmMedium" color="$text">
-              ${availableToTradeDisplay}
-            </SizableText>
+            <PerpsAccountNumberValue
+              value={accountSummary?.withdrawable ?? ''}
+              skeletonWidth={60}
+            />
             <MobileDepositButton />
           </XStack>
         </XStack>
@@ -588,6 +590,20 @@ function PerpTradingForm({
           borderColor="$borderSubdued"
           borderRadius="$3"
         >
+          <XStack justifyContent="space-between">
+            <SizableText size="$bodySm" color="$textSubdued">
+              {intl.formatMessage({
+                id: ETranslations.perp_trade_account_overview_available,
+              })}
+            </SizableText>
+            <XStack alignItems="center" gap="$1">
+              <PerpsAccountNumberValue
+                value={accountSummary?.withdrawable ?? ''}
+                skeletonWidth={60}
+              />
+              <MobileDepositButton />
+            </XStack>
+          </XStack>
           <XStack justifyContent="space-between">
             <SizableText size="$bodySm" color="$textSubdued">
               {intl.formatMessage({


### PR DESCRIPTION
- Replace non-null assertion with explicit null check in AdjustPositionMarginModal
- Simplify amount formatting in ClosePositionModal using toFixed()
- Add amount cap validation in SetTpslModal to prevent exceeding position size
- Remove redundant withdrawable parameter from DepositWithdrawModal, use account<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an account overview row showing available withdrawable amount with a quick Deposit action.
- Improvements
  - Unified display of withdrawable balances using a dedicated number component across mobile and desktop.
  - Streamlined deposit modal behavior for a simpler, more consistent flow.
  - Refined default amount formatting in Close Position for clearer inputs.
- Bug Fixes
  - Prevented margin adjustment submission when asset selection is invalid.
  - Clamped TP/SL amounts to not exceed current position size, ensuring accurate values.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> directly
- Unify available balance display with PerpsAccountNumberValue component across trading forms