### PR TITLE
OK-44087 OK-44139 OK-44140, refactor: unify order close logic and add batch close modals

### DIFF
--- a/packages/kit/src/states/jotai/contexts/hyperliquid/utils/withToast.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/utils/withToast.ts
@@ -8,7 +8,7 @@ import type { EActionType } from './types';
 
 export interface IWithToastOptions<T = unknown> {
   asyncFn: () => Promise<T>;
-  actionType: EActionType;
+  actionType?: EActionType;
   args?: any[];
 }
 
@@ -51,6 +51,9 @@ async function handleError(error: unknown): Promise<void> {
 
 export async function withToast<T>(options: IWithToastOptions<T>): Promise<T> {
   const { asyncFn, actionType, args } = options;
+  if (!actionType) {
+    return asyncFn();
+  }
   const config = TOAST_CONFIGS[actionType];
   let loadingToast: { close: () => void } | undefined;
   let loadingTimer: ReturnType<typeof setTimeout> | undefined;

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/CancelAllOrdersModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/CancelAllOrdersModal.tsx
@@ -1,0 +1,111 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { isNil } from 'lodash';
+
+import { Button, Dialog, SizableText, YStack } from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import {
+  useHyperliquidActions,
+  usePerpsActiveOpenOrdersAtom,
+} from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+
+import { PerpsProviderMirror } from '../../PerpsProviderMirror';
+import { TradingGuardWrapper } from '../TradingGuardWrapper';
+
+interface ICancelAllOrdersContentProps {
+  onClose?: () => void;
+}
+
+function CancelAllOrdersContent({ onClose }: ICancelAllOrdersContentProps) {
+  const actions = useHyperliquidActions();
+  const [{ openOrders: orders }] = usePerpsActiveOpenOrdersAtom();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleConfirm = useCallback(async () => {
+    if (isSubmitting) return;
+
+    setIsSubmitting(true);
+    try {
+      await actions.current.ensureTradingEnabled();
+      const symbolsMetaMap =
+        await backgroundApiProxy.serviceHyperliquid.getSymbolsMetaMap({
+          coins: orders.map((o) => o.coin),
+        });
+      const ordersToCancel = orders
+        .map((order) => {
+          const tokenInfo = symbolsMetaMap[order.coin];
+          if (!tokenInfo || isNil(tokenInfo?.assetId)) {
+            console.warn(`Token info not found for coin: ${order.coin}`);
+            return null;
+          }
+          return {
+            assetId: tokenInfo.assetId,
+            oid: order.oid,
+          };
+        })
+        .filter(Boolean);
+
+      if (ordersToCancel.length === 0) {
+        console.warn('No valid orders to cancel or token info unavailable');
+        onClose?.();
+        return;
+      }
+
+      await actions.current.cancelOrder({ orders: ordersToCancel });
+      onClose?.();
+    } catch (error) {
+      console.error('Cancel all orders failed:', error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [actions, isSubmitting, onClose, orders]);
+
+  const buttonText = useMemo(() => {
+    if (isSubmitting) {
+      return 'Canceling...';
+    }
+    return 'Confirm Cancel All';
+  }, [isSubmitting]);
+
+  return (
+    <YStack gap="$4" p="$1">
+      {/* Description */}
+      <SizableText size="$bodyMd" color="$textSubdued">
+        This will cancel all your open orders.
+      </SizableText>
+
+      <TradingGuardWrapper>
+        <Button
+          variant="primary"
+          size="medium"
+          disabled={isSubmitting}
+          loading={isSubmitting}
+          onPress={handleConfirm}
+        >
+          {buttonText}
+        </Button>
+      </TradingGuardWrapper>
+    </YStack>
+  );
+}
+
+export function showCancelAllOrdersDialog() {
+  const dialogInstance = Dialog.show({
+    title: 'Confirm Cancel All',
+    renderContent: (
+      <PerpsProviderMirror>
+        <CancelAllOrdersContent
+          onClose={() => {
+            void dialogInstance.close();
+          }}
+        />
+      </PerpsProviderMirror>
+    ),
+    showFooter: false,
+    onClose: () => {
+      void dialogInstance.close();
+    },
+  });
+
+  return dialogInstance;
+}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/CloseAllPositionsModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/CloseAllPositionsModal.tsx
@@ -1,0 +1,129 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import {
+  Button,
+  Checkbox,
+  Dialog,
+  SizableText,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
+import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+
+import { PerpsProviderMirror } from '../../PerpsProviderMirror';
+import { TradingGuardWrapper } from '../TradingGuardWrapper';
+
+type ICloseType = 'market' | 'limit';
+
+interface ICloseAllPositionsContentProps {
+  onClose?: () => void;
+}
+
+function CloseAllPositionsContent({ onClose }: ICloseAllPositionsContentProps) {
+  const actions = useHyperliquidActions();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [closeType, setCloseType] = useState<ICloseType>('market');
+
+  const handleConfirm = useCallback(async () => {
+    if (isSubmitting) return;
+
+    setIsSubmitting(true);
+    try {
+      await actions.current.closeAllPositions(closeType);
+      onClose?.();
+    } catch (error) {
+      console.error('Close all positions failed:', error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [actions, closeType, isSubmitting, onClose]);
+
+  const buttonText = useMemo(() => {
+    if (isSubmitting) {
+      return 'Closing...';
+    }
+
+    if (closeType === 'market') {
+      return 'Confirm Market Close';
+    }
+    return 'Confirm Limit Close';
+  }, [closeType, isSubmitting]);
+
+  return (
+    <YStack gap="$4" p="$1">
+      {/* Description */}
+      <SizableText size="$bodyMd" color="$textSubdued">
+        This will close all your positions and cancel their associated TP/SL
+        orders.
+      </SizableText>
+
+      {/* Close Type Options */}
+      <YStack>
+        {/* Market Close */}
+        <XStack>
+          <Checkbox
+            labelProps={{
+              fontSize: '$bodyMd',
+            }}
+            label="Market Close"
+            value={closeType === 'market'}
+            onChange={(checked) => {
+              if (checked) {
+                setCloseType('market');
+              }
+            }}
+          />
+        </XStack>
+
+        {/* Limit Close at Mid Price */}
+        <XStack>
+          <Checkbox
+            labelProps={{
+              fontSize: '$bodyMd',
+            }}
+            label="Limit Close at Mid Price"
+            value={closeType === 'limit'}
+            onChange={(checked) => {
+              if (checked) {
+                setCloseType('limit');
+              }
+            }}
+          />
+        </XStack>
+      </YStack>
+
+      <TradingGuardWrapper>
+        <Button
+          variant="primary"
+          size="medium"
+          disabled={isSubmitting}
+          loading={isSubmitting}
+          onPress={handleConfirm}
+        >
+          {buttonText}
+        </Button>
+      </TradingGuardWrapper>
+    </YStack>
+  );
+}
+
+export function showCloseAllPositionsDialog() {
+  const dialogInstance = Dialog.show({
+    title: 'Confirm Close All',
+    renderContent: (
+      <PerpsProviderMirror>
+        <CloseAllPositionsContent
+          onClose={() => {
+            void dialogInstance.close();
+          }}
+        />
+      </PerpsProviderMirror>
+    ),
+    showFooter: false,
+    onClose: () => {
+      void dialogInstance.close();
+    },
+  });
+
+  return dialogInstance;
+}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
@@ -256,12 +256,14 @@ const ClosePositionForm = memo(
             return;
           }
 
-          await hyperliquidActions.current.limitOrderClose({
-            assetId,
-            isBuy: isLongPosition,
-            size: closeAmount,
-            limitPrice: formData.limitPrice,
-          });
+          await hyperliquidActions.current.ordersClose([
+            {
+              assetId,
+              isBuy: isLongPosition,
+              size: closeAmount,
+              limitPx: formData.limitPrice,
+            },
+          ]);
         }
 
         hyperliquidActions.current.resetTradingForm();

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpPositionsList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpPositionsList.tsx
@@ -4,12 +4,11 @@ import { noop } from 'lodash';
 import { useIntl } from 'react-intl';
 
 import type { IDebugRenderTrackerProps } from '@onekeyhq/components';
-import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
-import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import { usePerpsActivePositionLengthAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
 import { usePerpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
+import { showCloseAllPositionsDialog } from '../CloseAllPositionsModal';
 import { PositionRow } from '../Components/PositionsRow';
 
 import { CommonTableListView, type IColumnConfig } from './CommonTableListView';
@@ -24,10 +23,9 @@ function PerpPositionsList({
   isMobile,
 }: IPerpPositionsListProps) {
   const intl = useIntl();
-  const navigation = useAppNavigation();
   const [currentUser] = usePerpsActiveAccountAtom();
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
   const [positionsLength] = usePerpsActivePositionLengthAtom();
-  const actions = useHyperliquidActions();
   const [currentListPage, setCurrentListPage] = useState(1);
   useEffect(() => {
     noop(currentUser?.accountAddress);
@@ -130,10 +128,12 @@ function PerpPositionsList({
         minWidth: 100,
         align: 'right',
         flex: 1,
-        onPress: () => actions.current.closeAllPositions(),
+        ...(positionsLength > 0 && {
+          onPress: () => showCloseAllPositionsDialog(),
+        }),
       },
     ];
-  }, [actions, intl]);
+  }, [intl, positionsLength]);
   const totalMinWidth = useMemo(
     () =>
       columnsConfig.reduce(

--- a/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingPanel.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingPanel.tsx
@@ -123,7 +123,7 @@ function PerpTradingPanel({ isMobile = false }: { isMobile?: boolean }) {
     >
       <PerpTradingForm isSubmitting={isSubmitting} isMobile={isMobile} />
       {perpsAccountStatus.canTrade ? (
-        <TradingButtonGroup isSubmitting={isSubmitting} isMobile={isMobile} />
+        <TradingButtonGroup isMobile={isMobile} />
       ) : (
         <PerpTradingButton
           loading={universalLoading}

--- a/packages/kit/src/views/Perp/hooks/useOrderConfirm.ts
+++ b/packages/kit/src/views/Perp/hooks/useOrderConfirm.ts
@@ -43,6 +43,9 @@ export function useOrderConfirm(
         return;
       }
 
+      // Reset form before placing order
+      hyperliquidActions.current.resetTradingForm();
+
       let effectiveFormData = overrideSide
         ? { ...formData, side: overrideSide }
         : formData;
@@ -120,9 +123,6 @@ export function useOrderConfirm(
             price: effectiveFormData.price || '0',
           });
         }
-
-        // Reset form after successful order
-        hyperliquidActions.current.resetTradingForm();
 
         options?.onSuccess?.();
       } catch (error) {

--- a/packages/shared/types/hyperliquid/types.ts
+++ b/packages/shared/types/hyperliquid/types.ts
@@ -86,7 +86,8 @@ export interface IOrderCloseParams {
   assetId: number;
   isBuy: boolean;
   size: string;
-  midPx: string;
+  midPx?: string;
+  limitPx?: string;
   slippage?: number;
 }
 


### PR DESCRIPTION
- Merge limit and market close into unified ordersClose method
- Add CloseAllPositionsModal with market/limit options
- Add CancelAllOrdersModal for batch order cancellation
- Move form reset before order placement to prevent premature clearing
- Add debounce to trading buttons to prevent duplicate submissions
- Remove redundant isSubmitting state and loading indicators

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added “Cancel All Orders” dialog to quickly cancel all open perp orders.
  - Added “Close All Positions” dialog with Market or Limit (mid price) options.

- Improvements
  - Closing a single position now supports limit price.
  - Trading buttons are debounced to prevent accidental duplicate orders.
  - Action buttons (Cancel All/Close All) only appear when there are items to act on.
  - Trading form now clears before order submission for a smoother flow.

- UI
  - Open Orders and Positions lists now launch dedicated confirmation dialogs for bulk actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->