### PR TITLE
feat: enhance OpenOrdersRow to support close order types and update t…

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
@@ -87,17 +87,29 @@ const OpenOrdersRow = memo(
             return order.orderType;
         }
       })();
-      const type =
-        order.side === 'B'
-          ? intl.formatMessage({
-              id: ETranslations.perp_long,
-            })
-          : intl.formatMessage({
-              id: ETranslations.perp_short,
-            });
+      const type = (() => {
+        if (order.side === 'B') {
+          if (order.reduceOnly) {
+            return `${intl.formatMessage({
+              id: ETranslations.perp_order_close_short, // Close Short
+            })}`;
+          }
+          return intl.formatMessage({
+            id: ETranslations.perp_long, // Long
+          });
+        }
+        if (order.reduceOnly) {
+          return `${intl.formatMessage({
+            id: ETranslations.perp_order_close_long, // Close Long
+          })}`;
+        }
+        return intl.formatMessage({
+          id: ETranslations.perp_short, // Short
+        });
+      })();
       const typeColor = order.side === 'B' ? '$green11' : '$red11';
       return { assetSymbol, type, orderType, typeColor };
-    }, [order.coin, order.side, order.orderType, intl]);
+    }, [order.coin, order.side, order.orderType, intl, order.reduceOnly]);
     const dateInfo = useMemo(() => {
       const timeDate = new Date(order.timestamp);
       const date = formatTime(timeDate, {

--- a/packages/shared/src/locale/enum/translations.ts
+++ b/packages/shared/src/locale/enum/translations.ts
@@ -2131,6 +2131,8 @@
   perp_open_orders_value = 'perp.open_orders_value',
   perp_oracle_price_tooltip = 'perp.oracle_price_tooltip',
   perp_order_book_depth = 'perp.order_book_depth',
+  perp_order_close_long = 'perp.order_close_long',
+  perp_order_close_short = 'perp.order_close_short',
   perp_order_mid_price_title = 'perp.order_mid_price_title',
   perp_order_mid_price_title_desc = 'perp.order_mid_price_title_desc',
   perp_order_size_small = 'perp.order_size_small',

--- a/packages/shared/src/locale/json/bn.json
+++ b/packages/shared/src/locale/json/bn.json
@@ -2126,6 +2126,8 @@
   "perp.open_orders_value": "মূল্য",
   "perp.oracle_price_tooltip": "বাহ্যিক প্রাইস ফিড থেকে সম্পদের রিয়েল-টাইম মূল্য।",
   "perp.order_book_depth": "অর্ডার বইয়ের গভীরতা",
+  "perp.order_close_long": "লং পজিশন বন্ধ করুন",
+  "perp.order_close_short": "শর্ট বন্ধ করুন",
   "perp.order_mid_price_title": "মধ্যম মূল্য",
   "perp.order_mid_price_title_desc": "সর্বোত্তম বিড এবং আস্ক মূল্যের গড়, যা ন্যায্য বাজারমূল্যকে প্রতিফলিত করে।",
   "perp.order_size_small": "অর্ডার অন্তত {amount} হতে হবে",

--- a/packages/shared/src/locale/json/de.json
+++ b/packages/shared/src/locale/json/de.json
@@ -2126,6 +2126,8 @@
   "perp.open_orders_value": "Wert",
   "perp.oracle_price_tooltip": "Echtzeitpreis des Assets aus externen Preisfeeds.",
   "perp.order_book_depth": "Orderbuchtiefe",
+  "perp.order_close_long": "Close Long",
+  "perp.order_close_short": "Close Short",
   "perp.order_mid_price_title": "Mittelpreis",
   "perp.order_mid_price_title_desc": "Der Durchschnitt aus bestem Geld- und Briefkurs, der den fairen Marktwert widerspiegelt.",
   "perp.order_size_small": "Die Order muss mindestens {amount} betragen",

--- a/packages/shared/src/locale/json/en_US.json
+++ b/packages/shared/src/locale/json/en_US.json
@@ -2126,6 +2126,8 @@
   "perp.open_orders_value": "Value",
   "perp.oracle_price_tooltip": "Real-time price of asset from external price feeds.",
   "perp.order_book_depth": "Order Book Depth",
+  "perp.order_close_long": "Close Long",
+  "perp.order_close_short": "Close Short",
   "perp.order_mid_price_title": "Mid Price",
   "perp.order_mid_price_title_desc": "The average of the best bid and ask prices, reflecting fair market value.",
   "perp.order_size_small": "Order must be at least {amount}",

--- a/packages/shared/src/locale/json/es.json
+++ b/packages/shared/src/locale/json/es.json
@@ -2126,6 +2126,8 @@
   "perp.open_orders_value": "Valor",
   "perp.oracle_price_tooltip": "Precio en tiempo real del activo a partir de fuentes de precios externas.",
   "perp.order_book_depth": "Profundidad del libro de órdenes",
+  "perp.order_close_long": "Cerrar largo",
+  "perp.order_close_short": "Cerrar corto",
   "perp.order_mid_price_title": "Precio intermedio",
   "perp.order_mid_price_title_desc": "El promedio entre los mejores precios de oferta y demanda, que refleja el valor justo de mercado.",
   "perp.order_size_small": "La orden debe ser al menos de {amount}",

--- a/packages/shared/src/locale/json/fr_FR.json
+++ b/packages/shared/src/locale/json/fr_FR.json
@@ -2126,6 +2126,8 @@
   "perp.open_orders_value": "Valeur",
   "perp.oracle_price_tooltip": "Prix en temps réel de l'actif provenant de flux de prix externes.",
   "perp.order_book_depth": "Profondeur du carnet de commandes",
+  "perp.order_close_long": "Fermer Long",
+  "perp.order_close_short": "Fermer Short",
   "perp.order_mid_price_title": "Prix moyen",
   "perp.order_mid_price_title_desc": "La moyenne des meilleurs prix d'achat et de vente, reflétant la juste valeur de marché.",
   "perp.order_size_small": "La commande doit être d'au moins {amount}",

--- a/packages/shared/src/locale/json/hi_IN.json
+++ b/packages/shared/src/locale/json/hi_IN.json
@@ -2126,6 +2126,8 @@
   "perp.open_orders_value": "मूल्य",
   "perp.oracle_price_tooltip": "बाहरी प्राइस फ़ीड्स से एसेट की रियल‑टाइम कीमत।",
   "perp.order_book_depth": "ऑर्डर बुक की गहराई",
+  "perp.order_close_long": "लॉन्ग बंद करें",
+  "perp.order_close_short": "शॉर्ट बंद करें",
   "perp.order_mid_price_title": "मध्य मूल्य",
   "perp.order_mid_price_title_desc": "सर्वोत्तम बोली और पूछ मूल्य का औसत, जो उचित बाजार मूल्य को दर्शाता है।",
   "perp.order_size_small": "ऑर्डर कम से कम {amount} का होना चाहिए",

--- a/packages/shared/src/locale/json/id.json
+++ b/packages/shared/src/locale/json/id.json
@@ -2126,6 +2126,8 @@
   "perp.open_orders_value": "Nilai",
   "perp.oracle_price_tooltip": "Harga aset waktu nyata dari feed harga eksternal.",
   "perp.order_book_depth": "Kedalaman Buku Pesanan",
+  "perp.order_close_long": "Tutup Long",
+  "perp.order_close_short": "Tutup Short",
   "perp.order_mid_price_title": "Harga Tengah",
   "perp.order_mid_price_title_desc": "Rata-rata dari harga bid dan ask terbaik, mencerminkan nilai pasar yang wajar.",
   "perp.order_size_small": "Pesanan harus setidaknya {amount}",

--- a/packages/shared/src/locale/json/it_IT.json
+++ b/packages/shared/src/locale/json/it_IT.json
@@ -2126,6 +2126,8 @@
   "perp.open_orders_value": "Valore",
   "perp.oracle_price_tooltip": "Prezzo in tempo reale dell’asset da feed di prezzo esterni.",
   "perp.order_book_depth": "Profondità del portafoglio ordini",
+  "perp.order_close_long": "Chiudi long",
+  "perp.order_close_short": "Chiudi short",
   "perp.order_mid_price_title": "Prezzo medio",
   "perp.order_mid_price_title_desc": "La media tra il miglior prezzo denaro e il miglior prezzo lettera, che riflette il valore equo di mercato.",
   "perp.order_size_small": "L'ordine deve essere almeno di {amount}",

--- a/packages/shared/src/locale/json/ja_JP.json
+++ b/packages/shared/src/locale/json/ja_JP.json
@@ -2126,6 +2126,8 @@
   "perp.open_orders_value": "価値",
   "perp.oracle_price_tooltip": "外部の価格フィードから取得した資産のリアルタイム価格。",
   "perp.order_book_depth": "注文板の深さ",
+  "perp.order_close_long": "ロングをクローズ",
+  "perp.order_close_short": "Close Short",
   "perp.order_mid_price_title": "ミッドプライス",
   "perp.order_mid_price_title_desc": "最良の買気配と売気配の平均で、公正な市場価値を反映するもの。",
   "perp.order_size_small": "注文は最低でも{amount}である必要があります",

--- a/packages/shared/src/locale/json/ko_KR.json
+++ b/packages/shared/src/locale/json/ko_KR.json
@@ -2126,6 +2126,8 @@
   "perp.open_orders_value": "평가금액",
   "perp.oracle_price_tooltip": "외부 가격 피드를 통한 자산의 실시간 가격입니다.",
   "perp.order_book_depth": "주문장 깊이",
+  "perp.order_close_long": "롱 청산",
+  "perp.order_close_short": "숏 포지션 청산",
   "perp.order_mid_price_title": "중간 가격",
   "perp.order_mid_price_title_desc": "최적 매수호가와 매도호가의 평균으로, 공정한 시장 가치를 반영합니다.",
   "perp.order_size_small": "주문은 최소 {amount}이어야 합니다",

--- a/packages/shared/src/locale/json/pt.json
+++ b/packages/shared/src/locale/json/pt.json
@@ -2126,6 +2126,8 @@
   "perp.open_orders_value": "Valor",
   "perp.oracle_price_tooltip": "Preço em tempo real do ativo a partir de feeds de preços externos.",
   "perp.order_book_depth": "Profundidade do livro de ordens",
+  "perp.order_close_long": "Fechar Long",
+  "perp.order_close_short": "Fechar Short",
   "perp.order_mid_price_title": "Preço Médio",
   "perp.order_mid_price_title_desc": "A média dos melhores preços de compra e venda, refletindo o valor justo de mercado.",
   "perp.order_size_small": "A ordem deve ser de pelo menos {amount}",

--- a/packages/shared/src/locale/json/pt_BR.json
+++ b/packages/shared/src/locale/json/pt_BR.json
@@ -2126,6 +2126,8 @@
   "perp.open_orders_value": "Valor",
   "perp.oracle_price_tooltip": "Preço em tempo real do ativo de feeds de preços externos.",
   "perp.order_book_depth": "Profundidade do livro de ordens",
+  "perp.order_close_long": "Fechar Long",
+  "perp.order_close_short": "Fechar Short",
   "perp.order_mid_price_title": "Preço Médio",
   "perp.order_mid_price_title_desc": "A média dos melhores preços de compra e venda, refletindo o valor justo de mercado.",
   "perp.order_size_small": "A ordem deve ser de pelo menos {amount}",

--- a/packages/shared/src/locale/json/ru.json
+++ b/packages/shared/src/locale/json/ru.json
@@ -2126,6 +2126,8 @@
   "perp.open_orders_value": "Значение",
   "perp.oracle_price_tooltip": "Цена актива в реальном времени из внешних ценовых источников.",
   "perp.order_book_depth": "Глубина книги заказов",
+  "perp.order_close_long": "Закрыть лонг",
+  "perp.order_close_short": "Close Short",
   "perp.order_mid_price_title": "Средняя цена",
   "perp.order_mid_price_title_desc": "Среднее значение лучшей цены покупки и продажи, отражающее справедливую рыночную стоимость.",
   "perp.order_size_small": "Минимальный размер ордера: не менее {amount}",

--- a/packages/shared/src/locale/json/th_TH.json
+++ b/packages/shared/src/locale/json/th_TH.json
@@ -2126,6 +2126,8 @@
   "perp.open_orders_value": "มูลค่า",
   "perp.oracle_price_tooltip": "ราคาสินทรัพย์แบบเรียลไทม์จากฟีดราคาภายนอก",
   "perp.order_book_depth": "ความลึกของหนังสือสั่งซื้อ",
+  "perp.order_close_long": "Close Long",
+  "perp.order_close_short": "ปิดชอร์ต",
   "perp.order_mid_price_title": "ราคากลาง",
   "perp.order_mid_price_title_desc": "ค่าเฉลี่ยของราคาซื้อและราคาขายที่ดีที่สุด สะท้อนมูลค่าตลาดที่ยุติธรรม",
   "perp.order_size_small": "คำสั่งต้องมีอย่างน้อย {amount}",

--- a/packages/shared/src/locale/json/uk_UA.json
+++ b/packages/shared/src/locale/json/uk_UA.json
@@ -2126,6 +2126,8 @@
   "perp.open_orders_value": "Значення",
   "perp.oracle_price_tooltip": "Ціна активу в реальному часі з зовнішніх джерел цінових даних.",
   "perp.order_book_depth": "Глибина книги замовлень",
+  "perp.order_close_long": "Закрити лонг",
+  "perp.order_close_short": "Закрити шорт",
   "perp.order_mid_price_title": "Середня ціна",
   "perp.order_mid_price_title_desc": "Середнє значення найкращих цін покупки та продажу, що відображає справедливу ринкову вартість.",
   "perp.order_size_small": "Замовлення має бути щонайменше {amount}",

--- a/packages/shared/src/locale/json/vi.json
+++ b/packages/shared/src/locale/json/vi.json
@@ -2126,6 +2126,8 @@
   "perp.open_orders_value": "Giá trị",
   "perp.oracle_price_tooltip": "Giá theo thời gian thực của tài sản từ các nguồn dữ liệu giá bên ngoài.",
   "perp.order_book_depth": "Độ sâu sổ lệnh",
+  "perp.order_close_long": "Close Long",
+  "perp.order_close_short": "Đóng lệnh Short",
   "perp.order_mid_price_title": "Giá trung bình",
   "perp.order_mid_price_title_desc": "Giá trung bình giữa giá chào mua và chào bán tốt nhất, phản ánh giá trị thị trường hợp lý.",
   "perp.order_size_small": "Lệnh phải có ít nhất {amount}",

--- a/packages/shared/src/locale/json/zh_CN.json
+++ b/packages/shared/src/locale/json/zh_CN.json
@@ -2126,6 +2126,8 @@
   "perp.open_orders_value": "价值",
   "perp.oracle_price_tooltip": "来自外部价格源的资产实时价格",
   "perp.order_book_depth": "委托单表示深度",
+  "perp.order_close_long": "平多",
+  "perp.order_close_short": "平空",
   "perp.order_mid_price_title": "中间价",
   "perp.order_mid_price_title_desc": "最佳买入价和卖出价的平均值，反映市场公允价值",
   "perp.order_size_small": "订单金额必须至少 {amount}",

--- a/packages/shared/src/locale/json/zh_HK.json
+++ b/packages/shared/src/locale/json/zh_HK.json
@@ -2126,6 +2126,8 @@
   "perp.open_orders_value": "價值",
   "perp.oracle_price_tooltip": "來自外部價格來源的資產實時價格",
   "perp.order_book_depth": "委託單表示深度",
+  "perp.order_close_long": "平多",
+  "perp.order_close_short": "平空",
   "perp.order_mid_price_title": "中位價",
   "perp.order_mid_price_title_desc": "最佳買入價和賣出價的平均值，反映公平市場價值",
   "perp.order_size_small": "訂單金額必須至少為 {amount}",

--- a/packages/shared/src/locale/json/zh_TW.json
+++ b/packages/shared/src/locale/json/zh_TW.json
@@ -2126,6 +2126,8 @@
   "perp.open_orders_value": "價值",
   "perp.oracle_price_tooltip": "來自外部價格來源的資產即時價格",
   "perp.order_book_depth": "委託單表示深度",
+  "perp.order_close_long": "平多",
+  "perp.order_close_short": "平空",
   "perp.order_mid_price_title": "中間價",
   "perp.order_mid_price_title_desc": "最佳買價和賣價的平均值，反映公平市場價值",
   "perp.order_size_small": "訂單金額至少需要 {amount}",


### PR DESCRIPTION
…ranslations

- Updated OpenOrdersRow component to differentiate between long and short close orders based on the reduceOnly flag.
- Added new translation keys for closing long and short orders in multiple languages.
- Updated localization files to include translations for the new keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Open Orders now display “Close Long” or “Close Short” when reduce-only is enabled, improving clarity for position-closing orders.
  - Order type labels update immediately when the reduce-only setting changes, ensuring the panel reflects the current state without delay.
  - Added localization support for the new labels (“Close Long” and “Close Short”) across supported languages, enhancing consistency and readability in the Order Info panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->