### PR TITLE
feat: add version and SHA to artifact names in workflows

### DIFF
--- a/.github/workflows/release-android-debug.yml
+++ b/.github/workflows/release-android-debug.yml
@@ -94,21 +94,21 @@ jobs:
       - name: Upload Main Debug APK
         uses: actions/upload-artifact@v4
         with:
-          name: release-prod-debug
+          name: release-prod-debug-${{ github.sha }}
           path: |
             ./apps/mobile/android/app/build/outputs/apk/prod/debug
 
       - name: Upload Google Debug APK
         uses: actions/upload-artifact@v4
         with:
-          name: release-google-debug
+          name: release-google-debug-${{ github.sha }}
           path: |
             ./apps/mobile/android/app/build/outputs/apk/google/debug
 
       - name: Upload Huawei Debug APK
         uses: actions/upload-artifact@v4
         with:
-          name: release-huawei-debug
+          name: release-huawei-debug-${{ github.sha }}
           path: |
             ./apps/mobile/android/app/build/outputs/apk/huawei/debug
 

--- a/.github/workflows/release-desktop-bundle.yml
+++ b/.github/workflows/release-desktop-bundle.yml
@@ -142,7 +142,7 @@ jobs:
       - name: upload bundle
         uses: actions/upload-artifact@v4
         with:
-          name: onekey-desktop-bundle
+          name: onekey-desktop-bundle-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
           path: |
             ./apps/desktop/bundle-zip/*
             !**/.DS_Store

--- a/.github/workflows/release-desktop-mas.yml
+++ b/.github/workflows/release-desktop-mas.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Upload Artifacts mas
         uses: actions/upload-artifact@v4
         with:
-          name: onekey-desktop-mas
+          name: onekey-desktop-mas-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
           path: |
             ./apps/desktop/build-electron/mas-universal/*.pkg
 

--- a/.github/workflows/release-desktop-snap.yml
+++ b/.github/workflows/release-desktop-snap.yml
@@ -95,12 +95,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           CSC_LINK: './sign.p12'
+          SNAP: true
         run: 'cd apps/desktop && yarn build:snap'
 
       - name: Upload Artifacts Release
         uses: actions/upload-artifact@v4
         with:
-          name: release
+          name: onekey-desktop-snap-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
           path: |
             ./apps/desktop/build-electron/*
             !./apps/desktop/build-electron/win-unpacked

--- a/.github/workflows/release-desktop-win.yml
+++ b/.github/workflows/release-desktop-win.yml
@@ -99,21 +99,21 @@ jobs:
       - name: Upload x64 Windows exe
         uses: actions/upload-artifact@v4
         with:
-          name: onekey-desktop-win-x64-exe
+          name: onekey-desktop-win-x64-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
           path: |
             ./apps/desktop/build-electron/*-x64.exe
 
       - name: Upload arm64 Windows exe
         uses: actions/upload-artifact@v4
         with:
-          name: onekey-desktop-win-arm64-exe
+          name: onekey-desktop-win-arm64-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
           path: |
             ./apps/desktop/build-electron/*-arm64.exe
 
       - name: Upload universal Windows exe
         uses: actions/upload-artifact@v4
         with:
-          name: onekey-desktop-win-universal-exe
+          name: onekey-desktop-win-universal-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
           path: |
             ./apps/desktop/build-electron/*.exe
             !./apps/desktop/build-electron/*-x64.exe
@@ -122,14 +122,14 @@ jobs:
       - name: Upload Artifacts latest.yml
         uses: actions/upload-artifact@v4
         with:
-          name: onekey-windows-desktop-yml
+          name: onekey-windows-desktop-yml-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
           path: |
             ./apps/desktop/build-electron/*.yml
 
       - name: Upload Artifacts Release
         uses: actions/upload-artifact@v4
         with:
-          name: release-windows
+          name: onekey-windows-desktop-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
           path: |
             ./apps/desktop/build-electron/*
             !./apps/desktop/build-electron/win-unpacked

--- a/.github/workflows/release-desktop-winms.yml
+++ b/.github/workflows/release-desktop-winms.yml
@@ -92,6 +92,7 @@ jobs:
           ASC_PROVIDER: ${{ secrets.ASC_PROVIDER }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          DESK_CHANNEL: ms-store
           CSC_LINK: './sign.p12'
         run: |
           cd apps/desktop
@@ -100,7 +101,7 @@ jobs:
       - name: Upload universal Windows Store exe
         uses: actions/upload-artifact@v4
         with:
-          name: onekey-desktop-winms-universal-exe
+          name: onekey-desktop-winms-universal-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
           path: |
             ./apps/desktop/build-electron/*.exe
             !./apps/desktop/build-electron/*-x64.exe

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -110,42 +110,42 @@ jobs:
       - name: Upload Artifacts latest.yml
         uses: actions/upload-artifact@v4
         with:
-          name: onekey-desktop-yml
+          name: onekey-desktop-mac-and-linux-yml-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
           path: |
             ./apps/desktop/build-electron/*.yml
 
       - name: Upload universal Mac DMG
         uses: actions/upload-artifact@v4
         with:
-          name: onekey-desktop-mac-universal-dmg
+          name: onekey-desktop-mac-universal-dmg-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
           path: |
             ./apps/desktop/build-electron/*-universal.dmg
 
       - name: Upload x64 Mac DMG
         uses: actions/upload-artifact@v4
         with:
-          name: onekey-desktop-mac-x64-dmg
+          name: onekey-desktop-mac-x64-dmg-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
           path: |
             ./apps/desktop/build-electron/*-x64.dmg
 
       - name: Upload arm64 Mac DMG
         uses: actions/upload-artifact@v4
         with:
-          name: onekey-desktop-mac-arm64-dmg
+          name: onekey-desktop-mac-arm64-dmg-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
           path: |
             ./apps/desktop/build-electron/*-arm64.dmg
 
-      - name: Upload Linux x86_64 AppImage
+      - name: Upload Linux AppImage
         uses: actions/upload-artifact@v4
         with:
-          name: onekey-desktop-linux-x86_64-appimage
+          name: onekey-desktop-linux-appimage-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
           path: |
-            ./apps/desktop/build-electron/*-x86_64.AppImage
+            ./apps/desktop/build-electron/*.AppImage
 
       - name: Upload Artifacts Release
         uses: actions/upload-artifact@v4
         with:
-          name: release-desktop-mac-and-linux
+          name: onekey-desktop-mac-and-linux-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
           path: |
             ./apps/desktop/build-electron/*
             !./apps/desktop/build-electron/win-unpacked

--- a/.github/workflows/release-ext.yml
+++ b/.github/workflows/release-ext.yml
@@ -88,14 +88,14 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: onekey-extension-rn
+          name: onekey-extension-rn-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
           path: |
             ./apps/ext/build/_dist/*.zip
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: onekey-extension-rn-development-build
+          name: onekey-extension-rn-development-build-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
           path: |
             ./apps/ext/build/_development_build_dist/*.zip
 

--- a/.github/workflows/release-ios-debug.yml
+++ b/.github/workflows/release-ios-debug.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Upload App File
         uses: actions/upload-artifact@v4
         with:
-          name: release-App-debug
+          name: release-ios-debug-${{ github.sha }}
           path: |
             ./apps/mobile/ios/outputs/Build/Products/Debug-iphonesimulator/OneKeyWallet-Debug.zip
           if-no-files-found: error

--- a/.github/workflows/release-native-bundle.yml
+++ b/.github/workflows/release-native-bundle.yml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
-          name: release-native-bundle-zips
+          name: release-native-bundle-zips-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
           path: |
             ./apps/mobile/out-dir-bundle-zip
             !**/.DS_Store
@@ -99,7 +99,7 @@ jobs:
         uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
-          name: release-native-bundle-sources
+          name: release-native-bundle-sources-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
           path: |
             ./apps/mobile/out-dir-bundle
             !**/.DS_Store

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -81,6 +81,6 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-report
+          name: test-report-${{ env.BUILD_NUMBER }}-${{ github.sha }}
           path: test-report.html
 


### PR DESCRIPTION
Updated GitHub Actions workflows to include build version, build number, bundle version, and commit SHA in artifact names for better traceability and uniqueness. Also added SNAP and DESK_CHANNEL environment variables where needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - All build artifacts now use dynamic names including app version, build number, bundle version, and commit SHA across Android, iOS, desktop (macOS, Windows, Linux, MAS, Snap), and browser extension builds for clearer identification.
  - Enabled Snap mode for Linux builds and added MS Store channel for Windows installer builds.
  - Unified Linux AppImage artifact naming and pattern.

- Tests
  - Test report artifacts now include build number and commit SHA in their names for easier traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->