### PR TITLE
fix: force market execution for TP/SL orders and sync leverage state （OK-44117 OK-44253)

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
@@ -620,7 +620,7 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
           r: true,
           t: {
             trigger: {
-              isMarket,
+              isMarket: true,
               triggerPx: originalTpPrice,
               tpsl: 'tp',
             },
@@ -646,7 +646,7 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
           r: true,
           t: {
             trigger: {
-              isMarket,
+              isMarket: true,
               triggerPx: originalSlPrice,
               tpsl: 'sl',
             },

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
@@ -1312,20 +1312,14 @@ const PositionRow = memo(
       currentAssetOpenOrders.forEach((order) => {
         if (order.orderType.startsWith('Take')) {
           if (order.isPositionTpsl) {
-            tpPrice = `${numberFormat(
-              order.triggerPx,
-              formatters.priceFormatter,
-            )}`;
+            tpPrice = order.triggerPx;
           } else {
             hasNonPositionTpslOrder = true;
           }
         }
         if (order.orderType.startsWith('Stop')) {
           if (order.isPositionTpsl) {
-            slPrice = `${numberFormat(
-              order.triggerPx,
-              formatters.priceFormatter,
-            )}`;
+            slPrice = order.triggerPx;
           } else {
             hasNonPositionTpslOrder = true;
           }
@@ -1343,7 +1337,7 @@ const PositionRow = memo(
       // <PositionRowMobileTPSL />
       // <PositionRowDesktopTPSL />
       return { tpsl: `${tpPrice}/${slPrice}`, showOrder };
-    }, [formatters.priceFormatter, currentAssetOpenOrders]);
+    }, [currentAssetOpenOrders]);
 
     const [isSizeViewChange, setIsSizeViewChange] = useState(false);
     const handleSizeViewChange = useCallback(() => {

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -156,6 +156,11 @@ function PerpTradingForm({
       }
       return nextEnv;
     });
+    if (formData.leverage !== nextEnv.leverageValue) {
+      updateForm({
+        leverage: nextEnv.leverageValue,
+      });
+    }
   }, [
     activeAssetCtx?.ctx?.markPrice,
     activeAssetData?.availableToTrade,
@@ -163,6 +168,8 @@ function PerpTradingForm({
     activeAsset?.universe?.maxLeverage,
     activeAsset?.universe?.szDecimals,
     setTradingFormEnv,
+    formData.leverage,
+    updateForm,
   ]);
 
   // Token Switch Effect: Handle price updates when user switches tokens


### PR DESCRIPTION
- Force isMarket to true for TP/SL trigger orders
- Sync leverage value from env to formData when changed
- Remove redundant number formatting in TP/SL display

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Improvements
  - TP/SL trigger orders now execute as market orders upon trigger for more consistent execution.
  - TPSL prices in Positions display the exact trigger price entered, improving clarity.

- Bug Fixes
  - Perp trading form leverage now auto-syncs with the live environment to prevent stale values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->