### PR TITLE
fix: perp deposit to swap bridge OK-44270

### DIFF
--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -36,7 +36,10 @@ import {
   usePerpsActiveAccountSummaryAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { IPerpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import { PERPS_NETWORK_ID } from '@onekeyhq/shared/src/consts/perp';
+import {
+  PERPS_ETH_NETWORK_ID,
+  PERPS_NETWORK_ID,
+} from '@onekeyhq/shared/src/consts/perp';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalRoutes, EModalSwapRoutes } from '@onekeyhq/shared/src/routes';
@@ -337,10 +340,10 @@ function DepositWithdrawContent({
     navigation.pushModal(EModalRoutes.SwapModal, {
       screen: EModalSwapRoutes.SwapMainLand,
       params: {
-        importNetworkId: PERPS_NETWORK_ID,
-        importFromToken: swapDefaultSetTokens[PERPS_NETWORK_ID].fromToken,
+        importNetworkId: PERPS_ETH_NETWORK_ID,
+        importFromToken: swapDefaultSetTokens[PERPS_ETH_NETWORK_ID].fromToken,
         importToToken: swapDefaultSetTokens[PERPS_NETWORK_ID].toToken,
-        swapTabSwitchType: ESwapTabSwitchType.SWAP,
+        swapTabSwitchType: ESwapTabSwitchType.BRIDGE,
         swapSource: ESwapSource.PERP,
       },
     });

--- a/packages/shared/src/consts/perp.ts
+++ b/packages/shared/src/consts/perp.ts
@@ -40,6 +40,7 @@ export const PERPS_EMPTY_ADDRESS =
 
 // 'id': 'evm--42161',
 export const PERPS_NETWORK_ID: string = presetNetworksMap.arbitrum.id;
+export const PERPS_ETH_NETWORK_ID: string = presetNetworksMap.eth.id;
 // 'chainId': '42161',
 export const PERPS_EVM_CHAIN_ID_NUM: string =
   presetNetworksMap.arbitrum.chainId;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Deposit/Withdraw now opens a bridge flow in the swap modal for seamless transfers to the Perps environment.

- Bug Fixes
  - Swaps in Perps now correctly target the Ethereum network, ensuring accurate network detection and token origin.
  - Improved reliability when initiating swaps from the Perps trading panel by aligning the destination network and flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->