### PR TITLE
fix: Inject dialog instance into MarginModeModal(OK-44287)

### DIFF
--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/MarginModeModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/MarginModeModal.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useMemo, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 
+import type { useInPageDialog } from '@onekeyhq/components';
 import {
   Button,
   Checkbox,
@@ -128,12 +129,16 @@ function MarginModeContent({ onClose }: IMarginModeContentProps) {
   );
 }
 
-export function showMarginModeDialog(symbolCoin: string) {
+export function showMarginModeDialog(
+  symbolCoin: string,
+  dialog?: ReturnType<typeof useInPageDialog>,
+) {
   const title = `${symbolCoin} ${appLocale.intl.formatMessage({
     id: ETranslations.perp_trade_margin_type,
   })}`;
 
-  const dialogInstance = Dialog.show({
+  const DialogInstance = dialog || Dialog;
+  const dialogInstance = DialogInstance.show({
     title,
     floatingPanelProps: {
       width: 400,

--- a/packages/kit/src/views/Perp/components/TradingPanel/selectors/MarginModeSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/selectors/MarginModeSelector.tsx
@@ -2,7 +2,12 @@ import { useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { Icon, SizableText, XStack } from '@onekeyhq/components';
+import {
+  Icon,
+  SizableText,
+  XStack,
+  useInPageDialog,
+} from '@onekeyhq/components';
 import {
   usePerpsActiveAssetAtom,
   usePerpsActiveAssetDataAtom,
@@ -31,9 +36,11 @@ const MarginModeSelector = ({
       : intl.formatMessage({ id: ETranslations.perp_trade_isolated });
   }, [activeAssetData?.leverage?.type, intl]);
 
+  const dialog = useInPageDialog();
+
   const handlePress = () => {
     if (disabled) return;
-    showMarginModeDialog(selectedSymbol?.coin);
+    showMarginModeDialog(selectedSymbol?.coin, dialog);
   };
 
   return (


### PR DESCRIPTION
Updated showMarginModeDialog to accept an optional dialog instance, allowing for more flexible dialog management. MarginModeSelector now uses useInPageDialog and passes the dialog instance to the modal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Margin Mode now opens as an in-page dialog within the trading panel where supported, providing a smoother, more integrated experience.
  * Improved dialog handling ensures consistent open/close behavior across screens, reducing interruptions and keeping context visible during selection.
  * Fallback to the standard dialog remains available when in-page dialogs aren’t supported, maintaining compatibility without changing user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->