### PR TITLE
fix: perps trades history refresh

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -600,10 +600,17 @@ export default class ServiceHyperliquid extends ServiceBase {
       }
 
       if (password) {
-        const userRole = await infoClient.userRole({
-          user: accountAddress,
-        });
-        if (userRole.role === 'missing') {
+        let isActivated = false;
+        if (hyperLiquidCache?.activatedUser?.[accountAddress] === true) {
+          isActivated = true;
+        }
+        if (!isActivated) {
+          const userRole = await infoClient.userRole({
+            user: accountAddress,
+          });
+          isActivated = userRole.role !== 'missing';
+        }
+        if (!isActivated) {
           statusDetails.activatedOk = false;
           // await this.checkBuilderFeeStatus({
           //   accountAddress,
@@ -611,9 +618,9 @@ export default class ServiceHyperliquid extends ServiceBase {
           //   statusDetails,
           // });
         } else {
+          hyperLiquidCache.activatedUser[accountAddress] = true;
           statusDetails.activatedOk = true;
 
-          // TODO cache
           // Builder fee approve must be executed before agent setup
           await this.checkBuilderFeeStatus({
             accountAddress,
@@ -636,12 +643,23 @@ export default class ServiceHyperliquid extends ServiceBase {
             });
 
             void (async () => {
-              const { referralCode } =
-                await this.backgroundApi.simpleDb.perp.getPerpData();
-              // referrer code can be approved by agent
-              void this.exchangeService.setReferrerCode({
-                code: referralCode || HYPERLIQUID_REFERRAL_CODE,
-              });
+              const cacheKey = [
+                agentCredential.userAddress.toLowerCase(),
+                agentCredential.agentAddress.toLowerCase(),
+                agentCredential.agentName,
+              ].join('-');
+              if (!hyperLiquidCache?.referrerCodeSetDone?.[cacheKey]) {
+                const { referralCode } =
+                  await this.backgroundApi.simpleDb.perp.getPerpData();
+                try {
+                  // referrer code can be approved by agent
+                  await this.exchangeService.setReferrerCode({
+                    code: referralCode || HYPERLIQUID_REFERRAL_CODE,
+                  });
+                } finally {
+                  hyperLiquidCache.referrerCodeSetDone[cacheKey] = true;
+                }
+              }
             })();
 
             // referral code is optional, so we set it to true by default
@@ -668,6 +686,20 @@ export default class ServiceHyperliquid extends ServiceBase {
     }
   }
 
+  fetchExtraAgentsWithCache = cacheUtils.memoizee(
+    async ({ user }: { user: IHex }) => {
+      const { infoClient } = hyperLiquidApiClients;
+      return infoClient.extraAgents({
+        user,
+      });
+    },
+    {
+      max: 20,
+      maxAge: timerUtils.getTimeDurationMs({ minute: 2 }),
+      promise: true,
+    },
+  );
+
   private async checkAgentStatus({
     accountAddress,
     isEnableTradingTrigger,
@@ -679,11 +711,8 @@ export default class ServiceHyperliquid extends ServiceBase {
     statusDetails: IPerpsActiveAccountStatusDetails;
     password: string;
   }) {
-    const { infoClient } = hyperLiquidApiClients;
-
     let agentCredential: ICoreHyperLiquidAgentCredential | undefined;
-    // TODO cache
-    const extraAgents = await infoClient.extraAgents({
+    const extraAgents = await this.fetchExtraAgentsWithCache({
       user: accountAddress,
     });
     if (extraAgents?.length) {
@@ -718,6 +747,7 @@ export default class ServiceHyperliquid extends ServiceBase {
       agentCredential = validAgents?.[0];
     }
     if (!agentCredential && isEnableTradingTrigger) {
+      this.fetchExtraAgentsWithCache.clear();
       const privateKeyBytes = crypto.getRandomValues(new Uint8Array(32));
       const privateKeyHex = bufferUtils.bytesToHex(privateKeyBytes);
       const agentAddress = new ethers.Wallet(privateKeyHex).address as IHex;
@@ -756,6 +786,7 @@ export default class ServiceHyperliquid extends ServiceBase {
             const pollStartTime = Date.now();
             const pollTimeoutMs = 10_000; // 10 seconds total polling timeout
             const requestTimeoutMs = 3000; // 3 seconds per request timeout
+            const { infoClient } = hyperLiquidApiClients;
 
             while (Date.now() - pollStartTime < pollTimeoutMs) {
               try {
@@ -896,13 +927,14 @@ export default class ServiceHyperliquid extends ServiceBase {
       await this.getBuilderFeeConfig();
 
     if (expectBuilderAddress) {
-      const maxBuilderFee = await this.getUserApprovedMaxBuilderFee({
+      const maxBuilderFee = await this.getUserApprovedMaxBuilderFeeWithCache({
         userAddress: accountAddress,
         builderAddress: expectBuilderAddress,
       });
       if (maxBuilderFee === expectMaxBuilderFee) {
         statusDetails.builderFeeOk = true;
       } else if (isEnableTradingTrigger) {
+        this.getUserApprovedMaxBuilderFeeWithCache.clear();
         const approveBuilderFeeResult =
           await this.exchangeService.approveBuilderFee({
             builder: expectBuilderAddress as IHex,
@@ -921,7 +953,6 @@ export default class ServiceHyperliquid extends ServiceBase {
     }
   }
 
-  // TODO cache
   async getUserApprovedMaxBuilderFee({
     userAddress,
     builderAddress,
@@ -935,6 +966,23 @@ export default class ServiceHyperliquid extends ServiceBase {
       builder: builderAddress.toLowerCase() as IHex,
     });
   }
+
+  getUserApprovedMaxBuilderFeeWithCache = cacheUtils.memoizee(
+    async ({
+      userAddress,
+      builderAddress,
+    }: {
+      userAddress: string;
+      builderAddress: string;
+    }) => {
+      return this.getUserApprovedMaxBuilderFee({ userAddress, builderAddress });
+    },
+    {
+      max: 20,
+      maxAge: timerUtils.getTimeDurationMs({ minute: 2 }),
+      promise: true,
+    },
+  );
 
   async getBuilderFeeConfig() {
     void this.updatePerpsConfigByServerWithCache();

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -979,7 +979,7 @@ export default class ServiceHyperliquid extends ServiceBase {
     },
     {
       max: 20,
-      maxAge: timerUtils.getTimeDurationMs({ minute: 2 }),
+      maxAge: timerUtils.getTimeDurationMs({ minute: 10 }),
       promise: true,
     },
   );

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
@@ -495,6 +495,8 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
           extra,
         },
       });
+      this.backgroundApi.serviceHyperliquid.fetchExtraAgentsWithCache.clear();
+      this.backgroundApi.serviceHyperliquid.getUserApprovedMaxBuilderFeeWithCache.clear();
       throw error;
     }
   }

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -239,14 +239,22 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
   subscriptionsHandlerDisabled = false;
 
+  subscriptionsHandlerDisabledCount = 0;
+
   @backgroundMethod()
   async disableSubscriptionsHandler(): Promise<void> {
     this.subscriptionsHandlerDisabled = true;
+    this.subscriptionsHandlerDisabledCount += 1;
   }
 
   @backgroundMethod()
   async enableSubscriptionsHandler(): Promise<void> {
     this.subscriptionsHandlerDisabled = false;
+  }
+
+  @backgroundMethod()
+  async getSubscriptionsHandlerDisabledCount(): Promise<number> {
+    return this.subscriptionsHandlerDisabledCount;
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/hyperLiquidCache.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/hyperLiquidCache.ts
@@ -15,6 +15,14 @@ class HyperLiquidCache {
   set allMids(allMids: IWsAllMids) {
     this._allMids = allMids;
   }
+
+  public activatedUser: {
+    [address: string]: boolean;
+  } = {};
+
+  public referrerCodeSetDone: {
+    [addressAndAgentName: string]: boolean;
+  } = {};
 }
 
 export default new HyperLiquidCache();

--- a/packages/kit-bg/src/states/jotai/atomNames.ts
+++ b/packages/kit-bg/src/states/jotai/atomNames.ts
@@ -72,6 +72,7 @@ export enum EAtomNames {
   perpsUserConfigPersistAtom = 'perpsUserConfigPersistAtom',
   perpsNetworkStatusAtom = 'perpsNetworkStatusAtom',
   perpsWebSocketReadyStateAtom = 'perpsWebSocketReadyStateAtom',
+  perpsTradesHistoryRefreshHookAtom = 'perpsTradesHistoryRefreshHookAtom',
 }
 export type IAtomNameKeys = keyof typeof EAtomNames;
 export const atomsConfig: Partial<

--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -338,3 +338,11 @@ export const {
     return readyState?.readyState === WebSocket.OPEN;
   },
 });
+
+export const {
+  target: perpsTradesHistoryRefreshHookAtom,
+  use: usePerpsTradesHistoryRefreshHookAtom,
+} = globalAtom<{ refreshHook: number }>({
+  name: EAtomNames.perpsTradesHistoryRefreshHookAtom,
+  initialValue: { refreshHook: 0 },
+});

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpOrderInfoPanel.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpOrderInfoPanel.tsx
@@ -29,6 +29,7 @@ import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import type { IModalPerpParamList } from '@onekeyhq/shared/src/routes/perp';
 import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
 
+import backgroundApiProxy from '../../../../background/instance/backgroundApiProxy';
 import { usePerpsActivePositionAtom } from '../../hooks';
 
 import { PerpOpenOrdersList } from './List/PerpOpenOrdersList';
@@ -113,17 +114,28 @@ function PerpOrderInfoPanel({ isMobile }: IPerpOrderInfoPanelProps) {
     });
   };
 
+  const lastSubscriptionsHandlerDisabledCount = useRef<number>(-1);
+
   return (
     <Tabs.Container
       ref={tabsRef as any}
       headerHeight={80}
       initialTabName="Positions"
-      onTabChange={(tab) => {
+      onTabChange={async (tab) => {
         console.log('PerpOrderInfoPanel_onTabChange_tabName::', tab);
         if (tab.tabName === 'Trades History') {
-          void perpsTradesHistoryRefreshHookAtom.set({
-            refreshHook: Date.now(),
-          });
+          const subscriptionsHandlerDisabledCount =
+            await backgroundApiProxy.serviceHyperliquidSubscription.getSubscriptionsHandlerDisabledCount();
+          if (
+            subscriptionsHandlerDisabledCount >
+            lastSubscriptionsHandlerDisabledCount.current
+          ) {
+            lastSubscriptionsHandlerDisabledCount.current =
+              subscriptionsHandlerDisabledCount;
+            void perpsTradesHistoryRefreshHookAtom.set({
+              refreshHook: Date.now(),
+            });
+          }
         }
       }}
       renderTabBar={(props) => (

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpOrderInfoPanel.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpOrderInfoPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useRef } from 'react';
 
+import { noop } from 'lodash';
 import { useIntl } from 'react-intl';
 
 import type {
@@ -19,6 +20,10 @@ import {
   usePerpsActiveOpenOrdersLengthAtom,
   usePerpsActivePositionLengthAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
+import {
+  perpsTradesHistoryRefreshHookAtom,
+  usePerpsTradesHistoryRefreshHookAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import type { IModalPerpParamList } from '@onekeyhq/shared/src/routes/perp';
@@ -113,6 +118,14 @@ function PerpOrderInfoPanel({ isMobile }: IPerpOrderInfoPanelProps) {
       ref={tabsRef as any}
       headerHeight={80}
       initialTabName="Positions"
+      onTabChange={(tab) => {
+        console.log('PerpOrderInfoPanel_onTabChange_tabName::', tab);
+        if (tab.tabName === 'Trades History') {
+          void perpsTradesHistoryRefreshHookAtom.set({
+            refreshHook: Date.now(),
+          });
+        }
+      }}
       renderTabBar={(props) => (
         <Tabs.TabBar
           {...props}

--- a/packages/kit/src/views/Perp/hooks/usePerpOrderInfoPanel.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpOrderInfoPanel.ts
@@ -1,6 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 
-import { usePerpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  usePerpsActiveAccountAtom,
+  usePerpsTradesHistoryRefreshHookAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { appEventBus } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { EAppEventBusNames } from '@onekeyhq/shared/src/eventBus/appEventBusNames';
 import type { IFill, IWsUserFills } from '@onekeyhq/shared/types/hyperliquid';
@@ -8,6 +11,7 @@ import { ESubscriptionType } from '@onekeyhq/shared/types/hyperliquid';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import { usePromiseResult } from '../../../hooks/usePromiseResult';
+import { noop } from 'lodash';
 
 interface INewTradesHistory {
   fill: IFill;
@@ -20,6 +24,7 @@ export function usePerpTradesHistory() {
   const [newTradesHistory, setNewTradesHistory] = useState<INewTradesHistory[]>(
     [],
   );
+  const [{ refreshHook }] = usePerpsTradesHistoryRefreshHookAtom();
   const newTradesHistoryRef = useRef<INewTradesHistory[]>([]);
   useEffect(() => {
     if (
@@ -85,6 +90,7 @@ export function usePerpTradesHistory() {
   const { result, isLoading } = usePromiseResult(
     async () => {
       if (currentAccount?.accountAddress) {
+        noop(refreshHook);
         const trades = await backgroundApiProxy.serviceHyperliquid.getUserFills(
           {
             user: currentAccount?.accountAddress,
@@ -97,7 +103,7 @@ export function usePerpTradesHistory() {
       }
       return [];
     },
-    [currentAccount?.accountAddress],
+    [currentAccount?.accountAddress, refreshHook],
     { watchLoading: true, initResult: [] },
   );
 

--- a/packages/kit/src/views/Perp/layouts/PerpMobileLayout.tsx
+++ b/packages/kit/src/views/Perp/layouts/PerpMobileLayout.tsx
@@ -124,6 +124,9 @@ export function PerpMobileLayout() {
       ref={tabsRef as any}
       renderHeader={() => tabHeader}
       initialTabName="Positions"
+      onTabChange={(tabName) => {
+        console.log('PerpMobileLayout_onTabChange_tabName::', tabName);
+      }}
       renderTabBar={(props) => (
         <Tabs.TabBar
           {...props}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Trades History in Perps now auto-refreshes when switching to the tab, ensuring up-to-date records after background interruptions.

- Performance
  - Faster, smoother interactions through smarter caching of user activation, agent data, and fee limits, reducing redundant network calls.

- Bug Fixes
  - Improved reliability when placing orders by clearing stale data after failures.
  - More consistent behavior during agent changes and activation flows to prevent repeated prompts or actions.

- UX
  - Mobile layout wired to handle tab-change events consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->