### PR TITLE
fix: fix price text in perps header

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
@@ -9,6 +9,7 @@ import {
   Dialog,
   Divider,
   Page,
+  SegmentSlider,
   SizableText,
   Slider,
   Toast,
@@ -24,6 +25,7 @@ import {
 import { usePerpsActiveOpenOrdersAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   type EModalPerpRoutes,
   type IModalPerpParamList,
@@ -593,13 +595,23 @@ const SetTpslForm = memo(
                 </YStack>
 
                 <YStack flex={1} width="100%">
-                  <Slider
-                    value={formData.percentage}
-                    onChange={handlePercentageChange}
-                    max={100}
-                    min={0}
-                    step={1}
-                  />
+                  {platformEnv.isNativeIOS ? (
+                    <SegmentSlider
+                      value={formData.percentage}
+                      onChange={handlePercentageChange}
+                      max={100}
+                      min={0}
+                      segments={0}
+                    />
+                  ) : (
+                    <Slider
+                      value={formData.percentage}
+                      onChange={handlePercentageChange}
+                      max={100}
+                      min={0}
+                      step={1}
+                    />
+                  )}
                 </YStack>
               </YStack>
             ) : null}

--- a/packages/kit/src/views/Perp/components/TickerBar/MobilePerpMarketHeader.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/MobilePerpMarketHeader.tsx
@@ -157,7 +157,7 @@ function MobilePerpMarketHeader() {
                   </YStack>
                 }
               />
-              <SizableText size="$heading2xl">{`$${markPrice}`}</SizableText>
+              <SizableText size="$heading2xl">{markPrice}</SizableText>
             </>
           )}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Mobile Perp ticker now displays the mark price without a leading dollar sign; layout and loading states unchanged.

- New Features
  - Take-Profit/Stop-Loss percentage control now uses a platform-optimized segmented control on native iOS while retaining the original slider elsewhere.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->