### PR TITLE
fix: simplify size display logic in PositionsRow component

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
@@ -774,11 +774,9 @@ const PositionRowMobilePositionSize = memo(() => {
           </XStack>
           <XStack alignItems="center" gap="$1" cursor="pointer">
             <SizableText size="$bodySmMedium">
-              {`$${
-                isSizeViewChange
-                  ? sizeInfo.sizeValue
-                  : sizeInfo.sizeAbsFormatted
-              }`}
+              {isSizeViewChange
+                ? `$${sizeInfo.sizeValue}`
+                : sizeInfo.sizeAbsFormatted}
             </SizableText>
           </XStack>
         </YStack>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the mobile position size rendering in PositionsRow by removing redundant string construction and simplifying conditional logic.
  * Maintains identical displayed values and behavior; users should see no visual or functional changes.
  * Improves code maintainability and may offer minor performance benefits during rendering.
  * No new settings, interactions, or workflows introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->