### PR TITLE
chore: update tx simulation assets icon size

### DIFF
--- a/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmComponents/Assets.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmComponents/Assets.tsx
@@ -233,6 +233,13 @@ function SignatureAssetDetailItem({
     name,
   ]);
 
+  const tokenSize = useMemo(() => {
+    if (inSimulation) {
+      return 'md';
+    }
+    return isSmallSize ? 'sm' : 'lg';
+  }, [inSimulation, isSmallSize]);
+
   return (
     <SignatureConfirmItem {...rest}>
       {!hideLabel ? (
@@ -240,7 +247,7 @@ function SignatureAssetDetailItem({
       ) : null}
       <XStack gap="$3" alignItems="center">
         <Token
-          size={isSmallSize ? 'sm' : 'lg'}
+          size={tokenSize}
           showNetworkIcon={showNetwork}
           {...(type === 'nft' && {
             borderRadius: '$2',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted token icon sizing in Signature Confirmation: now uses a medium size during simulation, and small or large in regular flows depending on compact layout.
  * Improves visual consistency and readability of asset tokens across different contexts, providing a clearer experience during simulation and standard confirmations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->