### PR TITLE
fix: fix cut-off text in perps dialog on Android

### DIFF
--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/LeverageAdjustModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/LeverageAdjustModal.tsx
@@ -125,7 +125,9 @@ const LeverageContent = memo(
                 InputComponentStyle={{
                   p: 0,
                 }}
-                fontSize={getFontSize('$heading5xl')}
+                fontSize={
+                  platformEnv.isNativeAndroid ? 34 : getFontSize('$heading5xl')
+                }
                 alignItems="center"
                 justifyContent="center"
                 value={value ? value.toString() : ''}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved readability on Android by standardizing the input text size in the Leverage Adjustment modal to a fixed, larger value.
  * Ensures consistent visual appearance on native Android devices while keeping typography unchanged on iOS and web.
  * No behavioral changes; this update strictly affects presentation to enhance clarity when adjusting leverage on Android.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->