### PR TITLE
feat: perps manual refresh

### DIFF
--- a/development/spellCheckerSkipWords.js
+++ b/development/spellCheckerSkipWords.js
@@ -15,6 +15,7 @@ module.exports = [
   'reown',
   '0xxxxxxx',
   'nktkas',
+  'bbo',
   '100vw',
   '10xxxxxx',
   'hardcode',

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -54,7 +54,6 @@ import {
   perpsActiveAssetCtxAtom,
   perpsActiveAssetDataAtom,
   perpsCommonConfigPersistAtom,
-  perpsCurrentMidAtom,
   perpsCustomSettingsAtom,
 } from '../../states/jotai/atoms';
 import ServiceBase from '../ServiceBase';
@@ -222,11 +221,6 @@ export default class ServiceHyperliquid extends ServiceBase {
   }
 
   @backgroundMethod()
-  async getHyperLiquidCache() {
-    return { allMids: hyperLiquidCache.allMids };
-  }
-
-  @backgroundMethod()
   async updatePerpsConfigByServerWithCache() {
     return this._updatePerpsConfigByServerWithCache();
   }
@@ -242,7 +236,7 @@ export default class ServiceHyperliquid extends ServiceBase {
     },
   );
 
-    _getUserFillsByTimeMemo = cacheUtils.memoizee(
+  _getUserFillsByTimeMemo = cacheUtils.memoizee(
     async (params: IUserFillsByTimeParameters) => {
       const { infoClient } = hyperLiquidApiClients;
       return infoClient.userFillsByTime({ ...params, reversed: true } as any);
@@ -333,33 +327,6 @@ export default class ServiceHyperliquid extends ServiceBase {
     const map = await this.getSymbolsMetaMap({ coins: [coin] });
     const meta = map[coin];
     return meta;
-  }
-
-  @backgroundMethod()
-  async getSymbolMidValue({ coin }: { coin: string }) {
-    const { allMids } = await this.getHyperLiquidCache();
-    const mid = allMids?.mids?.[coin];
-    const midBN = new BigNumber(mid);
-    if (midBN.isNaN() || midBN.isLessThanOrEqualTo(0)) {
-      return undefined;
-    }
-    return mid;
-  }
-
-  async refreshCurrentMid() {
-    const selectedSymbol = await perpsActiveAssetAtom.get();
-    const currentMid = await perpsCurrentMidAtom.get();
-    const midValue = await this.getSymbolMidValue({
-      coin: selectedSymbol.coin,
-    });
-    const newMid = {
-      coin: selectedSymbol.coin,
-      mid: midValue,
-    };
-    if (isEqual(currentMid, newMid)) {
-      return;
-    }
-    await perpsCurrentMidAtom.set(newMid);
   }
 
   async updateActiveAssetCtx(data: IWsActiveAssetCtx | undefined) {
@@ -539,7 +506,6 @@ export default class ServiceHyperliquid extends ServiceBase {
     if (oldCoin !== newCoin) {
       await perpsActiveAssetCtxAtom.set(undefined);
     }
-    await this.refreshCurrentMid();
     return {
       universeItems,
       selectedUniverse,

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -242,7 +242,7 @@ export default class ServiceHyperliquid extends ServiceBase {
     },
   );
 
-  private _getUserFillsByTimeMemo = cacheUtils.memoizee(
+    _getUserFillsByTimeMemo = cacheUtils.memoizee(
     async (params: IUserFillsByTimeParameters) => {
       const { infoClient } = hyperLiquidApiClients;
       return infoClient.userFillsByTime({ ...params, reversed: true } as any);

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
@@ -221,6 +221,7 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
   //   return new ExchangeClient({
   //     transport,
   //     wallet,
+  //     signatureChainId: PERPS_EVM_CHAIN_ID_HEX,
   //   });
   // }
 

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -31,6 +31,7 @@ import {
   perpsActiveAccountAtom,
   perpsActiveAssetAtom,
   perpsActiveOrderBookOptionsAtom,
+  perpsCandlesWebviewReloadHookAtom,
   perpsNetworkStatusAtom,
   perpsWebSocketReadyStateAtom,
 } from '../../states/jotai/atoms/perps';
@@ -229,12 +230,23 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   async resumeSubscriptions(): Promise<void> {
     await this.enableSubscriptionsHandler();
     await this.updateSubscriptions();
+    const hookInfo = await perpsCandlesWebviewReloadHookAtom.get();
+    if (hookInfo.reloadHook <= -1) {
+      await perpsCandlesWebviewReloadHookAtom.set({
+        reloadHook: Date.now(),
+      });
+    }
   }
 
   @backgroundMethod()
   async pauseSubscriptions(): Promise<void> {
     await this.disableSubscriptionsHandler();
     await this._cleanupAllSubscriptions();
+
+    // after reloading the webview, the socket connection of tradingview will not be automatically unloaded, so temporarily commented out
+    // await perpsCandlesWebviewReloadHookAtom.set({
+    //   reloadHook: -100,
+    // });
   }
 
   subscriptionsHandlerDisabled = false;
@@ -771,53 +783,6 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         connected: false,
       }),
     );
-  }
-
-  private _parseKeyToParams(key: string, type: ESubscriptionType): any {
-    const parts = key.split(':');
-
-    switch (type) {
-      case ESubscriptionType.ALL_MIDS:
-        return {};
-      case ESubscriptionType.ACTIVE_ASSET_CTX:
-      case ESubscriptionType.TRADES:
-      case ESubscriptionType.BBO:
-        return { coin: parts[2] };
-      case ESubscriptionType.L2_BOOK: {
-        const params: any = { coin: parts[2] };
-        // Parse additional L2Book parameters from key
-        for (let i = 3; i < parts.length; i += 1) {
-          const part = parts[i];
-          if (part.startsWith('nSigFigs-')) {
-            const valueStr = part.substring(9);
-            if (valueStr === 'null') {
-              params.nSigFigs = null;
-            } else {
-              const value = parseInt(valueStr, 10);
-              params.nSigFigs = Number.isNaN(value) ? null : value;
-            }
-          } else if (part.startsWith('mantissa-')) {
-            const valueStr = part.substring(9);
-            if (valueStr === 'null') {
-              params.mantissa = null;
-            } else {
-              const value = parseInt(valueStr, 10);
-              params.mantissa = Number.isNaN(value) ? null : value;
-            }
-          }
-        }
-        return params;
-      }
-      case ESubscriptionType.WEB_DATA2:
-      case ESubscriptionType.USER_FILLS:
-      case ESubscriptionType.USER_EVENTS:
-      case ESubscriptionType.USER_NOTIFICATIONS:
-        return { user: parts[2] };
-      case ESubscriptionType.ACTIVE_ASSET_DATA:
-        return { user: parts[2], coin: parts[3] };
-      default:
-        return {};
-    }
   }
 
   private _emitConnectionStatus(): void {

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -461,12 +461,12 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         );
       };
       const allTypes = [
-        ESubscriptionType.ACTIVE_ASSET_CTX,
-        ESubscriptionType.ACTIVE_ASSET_DATA,
         ESubscriptionType.ALL_MIDS,
         ESubscriptionType.L2_BOOK,
-        ESubscriptionType.USER_FILLS,
+        ESubscriptionType.ACTIVE_ASSET_CTX,
+        ESubscriptionType.ACTIVE_ASSET_DATA,
         ESubscriptionType.WEB_DATA2,
+        ESubscriptionType.USER_FILLS,
       ];
       const removeAllSubscriptionHandlers = () => {
         allTypes.forEach((type) => {

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -27,6 +27,7 @@ import type {
 import type { IL2BookOptions } from '@onekeyhq/shared/types/hyperliquid/types';
 import { ESubscriptionType } from '@onekeyhq/shared/types/hyperliquid/types';
 
+import { devSettingsPersistAtom } from '../../states/jotai/atoms';
 import {
   perpsActiveAccountAtom,
   perpsActiveAssetAtom,
@@ -34,6 +35,7 @@ import {
   perpsCandlesWebviewReloadHookAtom,
   perpsNetworkStatusAtom,
   perpsTradesHistoryRefreshHookAtom,
+  perpsWebSocketDataUpdateTimesAtom,
   perpsWebSocketReadyStateAtom,
 } from '../../states/jotai/atoms/perps';
 import ServiceBase from '../ServiceBase';
@@ -447,7 +449,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       const registerSubscriptionHandler = (type: ESubscriptionType) => {
         if (!this.subscriptionHandlerByType[type]) {
           const handleData = (data: unknown) => {
-            this._handleSubscriptionData(type, data as CustomEvent);
+            void this._handleSubscriptionData(type, data as CustomEvent);
           };
           this.subscriptionHandlerByType[type] = handleData;
         }
@@ -689,13 +691,20 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     Record<ESubscriptionType, (data: unknown) => void>
   > = {};
 
-  private _handleSubscriptionData(
+  private async _handleSubscriptionData(
     subscriptionType: ESubscriptionType,
     event: CustomEvent,
-  ): void {
+  ): Promise<void> {
     try {
       if (this.subscriptionsHandlerDisabled) {
         return;
+      }
+
+      const devSettings = await devSettingsPersistAtom.get();
+      if (devSettings.enabled) {
+        void perpsWebSocketDataUpdateTimesAtom.set((prev) => ({
+          wsUpdateTimes: prev.wsUpdateTimes + 1,
+        }));
       }
 
       const data = event?.detail as unknown;

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -243,10 +243,9 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     await this.disableSubscriptionsHandler();
     await this._cleanupAllSubscriptions();
 
-    // after reloading the webview, the socket connection of tradingview will not be automatically unloaded, so temporarily commented out
-    // await perpsCandlesWebviewReloadHookAtom.set({
-    //   reloadHook: -100,
-    // });
+    await perpsCandlesWebviewReloadHookAtom.set({
+      reloadHook: -100,
+    });
   }
 
   subscriptionsHandlerDisabled = false;
@@ -394,11 +393,11 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       const transportOptions: IWebSocketTransportOptions = {
         url: 'wss://api.hyperliquid.xyz/ws',
         reconnect: {
-          maxRetries: 9_999_999,
-          connectionTimeout: 10_000,
+          maxRetries: 999_999_999,
+          connectionTimeout: 5000,
           connectionDelay: (attempt) =>
             // eslint-disable-next-line no-bitwise
-            Math.min(~~(1 << attempt) * 150, 5000),
+            Math.min(~~(1 << attempt) * 150, 8000),
           shouldReconnect: () => true,
         },
       };

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -696,14 +696,23 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     event: CustomEvent,
   ): Promise<void> {
     try {
+      const devSettings = await devSettingsPersistAtom.get();
+
+      if (devSettings.enabled) {
+        void perpsWebSocketDataUpdateTimesAtom.set((prev) => ({
+          ...prev,
+          wsDataReceiveTimes: prev.wsDataReceiveTimes + 1,
+        }));
+      }
+
       if (this.subscriptionsHandlerDisabled) {
         return;
       }
 
-      const devSettings = await devSettingsPersistAtom.get();
       if (devSettings.enabled) {
         void perpsWebSocketDataUpdateTimesAtom.set((prev) => ({
-          wsUpdateTimes: prev.wsUpdateTimes + 1,
+          ...prev,
+          wsDataUpdateTimes: prev.wsDataUpdateTimes + 1,
         }));
       }
 

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -391,6 +391,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         },
       };
       const transport = new WebSocketTransport(transportOptions);
+      // transport.socket.readyState
       transport.socket.removeEventListener('close', this.socketCloseHandler);
       transport.socket.addEventListener('close', this.socketCloseHandler);
 

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -697,8 +697,10 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   ): Promise<void> {
     try {
       const devSettings = await devSettingsPersistAtom.get();
+      const shouldUpdateWsDataUpdateTimes =
+        devSettings.enabled && devSettings.settings?.showPerpsRenderStats;
 
-      if (devSettings.enabled) {
+      if (shouldUpdateWsDataUpdateTimes) {
         void perpsWebSocketDataUpdateTimesAtom.set((prev) => ({
           ...prev,
           wsDataReceiveTimes: prev.wsDataReceiveTimes + 1,
@@ -709,7 +711,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         return;
       }
 
-      if (devSettings.enabled) {
+      if (shouldUpdateWsDataUpdateTimes) {
         void perpsWebSocketDataUpdateTimesAtom.set((prev) => ({
           ...prev,
           wsDataUpdateTimes: prev.wsDataUpdateTimes + 1,

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -708,9 +708,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       }
 
       if (subscriptionType === ESubscriptionType.ALL_MIDS) {
-        // TODO remove
-        hyperLiquidCache.allMids = data as IWsAllMids;
-        void this.backgroundApi.serviceHyperliquid.refreshCurrentMid();
+        // do nothing
       }
       if (subscriptionType === ESubscriptionType.WEB_DATA2) {
         void this.backgroundApi.serviceHyperliquid.updateActiveAccountSummary(

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -262,7 +262,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     await this._cleanupAllSubscriptions();
 
     await perpsCandlesWebviewReloadHookAtom.set({
-      reloadHook: -100,
+      reloadHook: -1 * Date.now(),
     });
   }
 

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -33,6 +33,7 @@ import {
   perpsActiveOrderBookOptionsAtom,
   perpsCandlesWebviewReloadHookAtom,
   perpsNetworkStatusAtom,
+  perpsTradesHistoryRefreshHookAtom,
   perpsWebSocketReadyStateAtom,
 } from '../../states/jotai/atoms/perps';
 import ServiceBase from '../ServiceBase';
@@ -195,6 +196,21 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   @backgroundMethod()
   async updateSubscriptions(): Promise<void> {
     await this._updateSubscriptionsDebounced();
+  }
+
+  @backgroundMethod()
+  async refreshAllPerpsData(): Promise<void> {
+    await this.getWebSocketClient();
+    await this._cleanupAllSubscriptions();
+    await this.updateSubscriptions();
+    this.backgroundApi.serviceHyperliquid._getUserFillsByTimeMemo.clear();
+    await perpsTradesHistoryRefreshHookAtom.set({
+      refreshHook: Date.now(),
+    });
+    await perpsCandlesWebviewReloadHookAtom.set({
+      reloadHook: Date.now(),
+    });
+    await timerUtils.wait(3000);
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -392,19 +392,25 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       };
       const transport = new WebSocketTransport(transportOptions);
       // transport.socket.readyState
-      transport.socket.removeEventListener('close', this.socketCloseHandler);
+      const removeAllSocketEventListeners = () => {
+        transport?.socket?.removeEventListener(
+          'close',
+          this.socketCloseHandler,
+        );
+        transport?.socket?.removeEventListener(
+          'error',
+          this.socketErrorHandler,
+        );
+        transport?.socket?.removeEventListener('open', this.socketOpenHandler);
+        transport?.socket?.removeEventListener(
+          'message',
+          this.socketMessageHandler,
+        );
+      };
+      removeAllSocketEventListeners();
       transport.socket.addEventListener('close', this.socketCloseHandler);
-
-      transport.socket.removeEventListener('error', this.socketErrorHandler);
       transport.socket.addEventListener('error', this.socketErrorHandler);
-
-      transport.socket.removeEventListener('open', this.socketOpenHandler);
       transport.socket.addEventListener('open', this.socketOpenHandler);
-
-      transport.socket.removeEventListener(
-        'message',
-        this.socketMessageHandler,
-      );
       // transport.socket.addEventListener('message', this.socketMessageHandler);
 
       const innerClient = new SubscriptionClient({ transport });
@@ -427,12 +433,28 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
           this.subscriptionHandlerByType[type],
         );
       };
-      registerSubscriptionHandler(ESubscriptionType.ACTIVE_ASSET_CTX);
-      registerSubscriptionHandler(ESubscriptionType.ACTIVE_ASSET_DATA);
-      registerSubscriptionHandler(ESubscriptionType.ALL_MIDS);
-      registerSubscriptionHandler(ESubscriptionType.L2_BOOK);
-      registerSubscriptionHandler(ESubscriptionType.USER_FILLS);
-      registerSubscriptionHandler(ESubscriptionType.WEB_DATA2);
+      const allTypes = [
+        ESubscriptionType.ACTIVE_ASSET_CTX,
+        ESubscriptionType.ACTIVE_ASSET_DATA,
+        ESubscriptionType.ALL_MIDS,
+        ESubscriptionType.L2_BOOK,
+        ESubscriptionType.USER_FILLS,
+        ESubscriptionType.WEB_DATA2,
+      ];
+      const removeAllSubscriptionHandlers = () => {
+        allTypes.forEach((type) => {
+          if (this.subscriptionHandlerByType[type]) {
+            hlEventTarget.removeEventListener(
+              type,
+              this.subscriptionHandlerByType[type],
+            );
+          }
+        });
+      };
+      removeAllSubscriptionHandlers();
+      allTypes.forEach((type) => {
+        registerSubscriptionHandler(type);
+      });
 
       // @ts-ignore
       const wsRequester = innerClient.transport._wsRequester as {
@@ -470,7 +492,23 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         wsRequester,
         subscribe,
         unsubscribe,
-        async dispose() {
+        dispose: async () => {
+          try {
+            removeAllSocketEventListeners();
+          } catch (error) {
+            console.error(
+              'dispose__removeAllSocketEventListeners__error',
+              error,
+            );
+          }
+          try {
+            removeAllSubscriptionHandlers();
+          } catch (error) {
+            console.error(
+              'dispose__removeAllSubscriptionHandlers__error',
+              error,
+            );
+          }
           await innerClient[Symbol.asyncDispose]();
         },
       };

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
@@ -38,26 +38,26 @@ export const SUBSCRIPTION_TYPE_INFO: {
     eventType: 'market',
     priority: 3,
   },
-  [ESubscriptionType.TRADES]: {
-    eventType: 'market',
-    priority: 4,
-  },
-  [ESubscriptionType.BBO]: {
-    eventType: 'market',
-    priority: 3,
-  },
   [ESubscriptionType.ACTIVE_ASSET_DATA]: {
     eventType: 'account',
     priority: 3,
   },
-  [ESubscriptionType.USER_EVENTS]: {
-    eventType: 'account',
-    priority: 2,
-  },
-  [ESubscriptionType.USER_NOTIFICATIONS]: {
-    eventType: 'account',
-    priority: 3,
-  },
+  // [ESubscriptionType.TRADES]: {
+  //   eventType: 'market',
+  //   priority: 4,
+  // },
+  // [ESubscriptionType.BBO]: {
+  //   eventType: 'market',
+  //   priority: 3,
+  // },
+  // [ESubscriptionType.USER_EVENTS]: {
+  //   eventType: 'account',
+  //   priority: 2,
+  // },
+  // [ESubscriptionType.USER_NOTIFICATIONS]: {
+  //   eventType: 'account',
+  //   priority: 3,
+  // },
 };
 
 export interface ISubscriptionSpec<T extends ESubscriptionType> {

--- a/packages/kit-bg/src/states/jotai/atomNames.ts
+++ b/packages/kit-bg/src/states/jotai/atomNames.ts
@@ -73,6 +73,7 @@ export enum EAtomNames {
   perpsNetworkStatusAtom = 'perpsNetworkStatusAtom',
   perpsWebSocketReadyStateAtom = 'perpsWebSocketReadyStateAtom',
   perpsTradesHistoryRefreshHookAtom = 'perpsTradesHistoryRefreshHookAtom',
+  perpsCandlesWebviewReloadHookAtom = 'perpsCandlesWebviewReloadHookAtom',
 }
 export type IAtomNameKeys = keyof typeof EAtomNames;
 export const atomsConfig: Partial<

--- a/packages/kit-bg/src/states/jotai/atomNames.ts
+++ b/packages/kit-bg/src/states/jotai/atomNames.ts
@@ -73,6 +73,7 @@ export enum EAtomNames {
   perpsWebSocketReadyStateAtom = 'perpsWebSocketReadyStateAtom',
   perpsTradesHistoryRefreshHookAtom = 'perpsTradesHistoryRefreshHookAtom',
   perpsCandlesWebviewReloadHookAtom = 'perpsCandlesWebviewReloadHookAtom',
+  perpsWebSocketDataUpdateTimesAtom = 'perpsWebSocketDataUpdateTimesAtom',
 }
 export type IAtomNameKeys = keyof typeof EAtomNames;
 export const atomsConfig: Partial<

--- a/packages/kit-bg/src/states/jotai/atomNames.ts
+++ b/packages/kit-bg/src/states/jotai/atomNames.ts
@@ -73,6 +73,7 @@ export enum EAtomNames {
   perpsWebSocketReadyStateAtom = 'perpsWebSocketReadyStateAtom',
   perpsTradesHistoryRefreshHookAtom = 'perpsTradesHistoryRefreshHookAtom',
   perpsCandlesWebviewReloadHookAtom = 'perpsCandlesWebviewReloadHookAtom',
+  perpsCandlesWebviewMountedAtom = 'perpsCandlesWebviewMountedAtom',
   perpsWebSocketDataUpdateTimesAtom = 'perpsWebSocketDataUpdateTimesAtom',
 }
 export type IAtomNameKeys = keyof typeof EAtomNames;

--- a/packages/kit-bg/src/states/jotai/atomNames.ts
+++ b/packages/kit-bg/src/states/jotai/atomNames.ts
@@ -66,7 +66,6 @@ export enum EAtomNames {
   perpsActiveAssetCtxAtom = 'perpsActiveAssetCtxAtom',
   perpsActiveAssetDataAtom = 'perpsActiveAssetDataAtom',
   perpsActiveOrderBookOptionsAtom = 'perpsActiveOrderBookOptionsAtom',
-  perpsCurrentMidAtom = 'perpsCurrentMidAtom', // TODO remove
   perpsCustomSettingsAtom = 'perpsCustomSettingsAtom',
   perpsCommonConfigPersistAtom = 'perpsCommonConfigPersistAtom',
   perpsUserConfigPersistAtom = 'perpsUserConfigPersistAtom',

--- a/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
@@ -52,6 +52,7 @@ export interface IDevSettings {
   showPerformanceMonitor?: boolean;
   // use local trading view URL for development
   useLocalTradingViewUrl?: boolean;
+  showPerpsRenderStats?: boolean;
 }
 
 export type IDevSettingsKeys = keyof IDevSettings;

--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -345,6 +345,14 @@ export const {
 });
 
 export const {
+  target: perpsCandlesWebviewMountedAtom,
+  use: usePerpsCandlesWebviewMountedAtom,
+} = globalAtom<{ mounted: boolean }>({
+  name: EAtomNames.perpsCandlesWebviewMountedAtom,
+  initialValue: { mounted: false },
+});
+
+export const {
   target: perpsWebSocketDataUpdateTimesAtom,
   use: usePerpsWebSocketDataUpdateTimesAtom,
 } = globalAtom<{

--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -294,17 +294,6 @@ export const {
 
 // #endregion
 
-// TODO remove
-export type IPerpsCurrentMid = {
-  coin: string;
-  mid: string | undefined;
-};
-export const { target: perpsCurrentMidAtom, use: usePerpsCurrentMidAtom } =
-  globalAtom<IPerpsCurrentMid | undefined>({
-    name: EAtomNames.perpsCurrentMidAtom,
-    initialValue: undefined,
-  });
-
 export interface IPerpsNetworkStatus {
   connected: boolean | undefined;
   lastMessageAt: number | null;

--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -347,7 +347,10 @@ export const {
 export const {
   target: perpsWebSocketDataUpdateTimesAtom,
   use: usePerpsWebSocketDataUpdateTimesAtom,
-} = globalAtom<{ wsUpdateTimes: number }>({
+} = globalAtom<{
+  wsDataReceiveTimes: number;
+  wsDataUpdateTimes: number;
+}>({
   name: EAtomNames.perpsWebSocketDataUpdateTimesAtom,
-  initialValue: { wsUpdateTimes: 0 },
+  initialValue: { wsDataReceiveTimes: 0, wsDataUpdateTimes: 0 },
 });

--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -343,3 +343,11 @@ export const {
   name: EAtomNames.perpsCandlesWebviewReloadHookAtom,
   initialValue: { reloadHook: 100 },
 });
+
+export const {
+  target: perpsWebSocketDataUpdateTimesAtom,
+  use: usePerpsWebSocketDataUpdateTimesAtom,
+} = globalAtom<{ wsUpdateTimes: number }>({
+  name: EAtomNames.perpsWebSocketDataUpdateTimesAtom,
+  initialValue: { wsUpdateTimes: 0 },
+});

--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -346,3 +346,11 @@ export const {
   name: EAtomNames.perpsTradesHistoryRefreshHookAtom,
   initialValue: { refreshHook: 0 },
 });
+
+export const {
+  target: perpsCandlesWebviewReloadHookAtom,
+  use: usePerpsCandlesWebviewReloadHookAtom,
+} = globalAtom<{ reloadHook: number }>({
+  name: EAtomNames.perpsCandlesWebviewReloadHookAtom,
+  initialValue: { reloadHook: 100 },
+});

--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useRef } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { Stack, useOrientation } from '@onekeyhq/components';
 import type { IStackStyle } from '@onekeyhq/components';
@@ -20,6 +20,7 @@ import type { WebViewNavigation } from 'react-native-webview/lib/WebViewTypes';
 interface IBaseTradingViewPerpsV2Props {
   symbol: string;
   userAddress: IHex | undefined | null;
+  webviewKey?: string;
   onLoadEnd?: () => void;
   onTradeUpdate?: (trade: ITradeEvent) => void;
 }
@@ -95,12 +96,15 @@ WebViewMemoized.displayName = 'WebViewMemoized';
 export function TradingViewPerpsV2(
   props: ITradingViewPerpsV2Props & WebViewProps,
 ) {
-  const { symbol, userAddress, onLoadEnd, onTradeUpdate } = props;
+  const { symbol, userAddress, onLoadEnd, onTradeUpdate, webviewKey } = props;
 
   const isLandscape = useOrientation();
   const isIPadPortrait = platformEnv.isNativeIOSPad && !isLandscape;
   const webRef = useRef<IWebViewRef | null>(null);
   const theme = useThemeVariant();
+  const _webviewKey = useMemo(() => {
+    return `${theme}-${webviewKey || ''}`;
+  }, [theme, webviewKey]);
 
   // Freeze initial symbol to prevent URL regeneration on symbol changes
   const initialSymbolRef = useRef(symbol);
@@ -145,7 +149,7 @@ export function TradingViewPerpsV2(
   return (
     <Stack position="relative" flex={1}>
       <WebViewMemoized
-        key={theme}
+        key={_webviewKey}
         src={staticTradingViewUrl}
         customReceiveHandler={customReceiveHandler}
         onWebViewRef={onWebViewRef}

--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { Stack, useOrientation } from '@onekeyhq/components';
 import type { IStackStyle } from '@onekeyhq/components';
+import { usePerpsCandlesWebviewMountedAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IHex } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
@@ -97,7 +98,7 @@ export function TradingViewPerpsV2(
   props: ITradingViewPerpsV2Props & WebViewProps,
 ) {
   const { symbol, userAddress, onLoadEnd, onTradeUpdate, webviewKey } = props;
-
+  const [, setMounted] = usePerpsCandlesWebviewMountedAtom();
   const isLandscape = useOrientation();
   const isIPadPortrait = platformEnv.isNativeIOSPad && !isLandscape;
   const webRef = useRef<IWebViewRef | null>(null);
@@ -105,6 +106,13 @@ export function TradingViewPerpsV2(
   const _webviewKey = useMemo(() => {
     return `${theme}-${webviewKey || ''}`;
   }, [theme, webviewKey]);
+
+  useEffect(() => {
+    setMounted({ mounted: true });
+    return () => {
+      setMounted({ mounted: false });
+    };
+  }, [setMounted]);
 
   // Freeze initial symbol to prevent URL regeneration on symbol changes
   const initialSymbolRef = useRef(symbol);

--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/messageHandlers/index.ts
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/messageHandlers/index.ts
@@ -4,8 +4,10 @@ import {
   IInjectedProviderNames,
   type IJsBridgeMessagePayload,
 } from '@onekeyfe/cross-inpage-provider-types';
+import { noop } from 'lodash';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { usePerpsTradesHistoryRefreshHookAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/perps';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -39,6 +41,7 @@ export function usePerpsMessageHandler({
   webRef: React.RefObject<IWebViewRef | null>;
 }) {
   const previousUserAddressRef = useRef<IHex | null | undefined>(userAddress);
+  const [{ refreshHook }] = usePerpsTradesHistoryRefreshHookAtom();
 
   // Use refs to maintain stable references for callbacks
   const symbolRef = useRef(symbol);
@@ -86,6 +89,7 @@ export function usePerpsMessageHandler({
       targetSymbol: string,
       targetUserAddress: IHex,
     ): Promise<ITradingMark[]> => {
+      noop(refreshHook);
       const now = new Date();
       const startDate = new Date(now);
       startDate.setHours(0, 0, 0, 0);
@@ -115,7 +119,7 @@ export function usePerpsMessageHandler({
 
       return marks;
     },
-    [convertFillToMark],
+    [convertFillToMark, refreshHook],
   );
 
   // Function to send marks update to iframe

--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/messageHandlers/index.ts
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/messageHandlers/index.ts
@@ -7,6 +7,7 @@ import {
 import { noop } from 'lodash';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import { usePerpsTradesHistoryRefreshHookAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/perps';
 import {
   EAppEventBusNames,
@@ -182,15 +183,19 @@ export function usePerpsMessageHandler({
     [webRef, fetchAndFormatMarks],
   );
 
+  const actions = useHyperliquidActions();
+
   // Handle HyperLiquid price scale requests
   const handleGetHyperliquidPriceScale = useCallback(
     async (request: { symbol: string; requestId: string }) => {
       const { symbol: requestSymbol, requestId } = request;
 
       const getValidMidValue = async () => {
-        return backgroundApiProxy.serviceHyperliquid.getSymbolMidValue({
-          coin: requestSymbol,
-        });
+        return (
+          await actions.current.getMidPrice({
+            coin: requestSymbol,
+          })
+        ).mid;
       };
 
       const WAIT_TIMEOUT_MS = timerUtils.getTimeDurationMs({ seconds: 3 });
@@ -265,7 +270,7 @@ export function usePerpsMessageHandler({
         payload: response,
       });
     },
-    [webRef],
+    [actions, webRef],
   );
 
   const customReceiveHandler = useCallback(

--- a/packages/kit/src/provider/Container/AppStateLockContainer/components/AppStateLock.tsx
+++ b/packages/kit/src/provider/Container/AppStateLockContainer/components/AppStateLock.tsx
@@ -29,6 +29,8 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { APP_STATE_LOCK_Z_INDEX } from '@onekeyhq/shared/src/utils/overlayUtils';
 
+import { DevPerpsWebSocketUpdateView } from '../../FullWindowOverlayContainer/DevOverlayWindow';
+
 import { AppStateContainer } from './AppStateContainer';
 
 import type { View as IView, KeyboardEvent } from 'react-native';
@@ -122,6 +124,7 @@ const AppStateLock = ({
               {passwordVerifyContainer}
             </Stack>
           </Stack>
+          <DevPerpsWebSocketUpdateView />
           <Stack py="$8" mb={bottom ?? 'unset'} alignItems="center">
             {v4migrationData?.isMigrationModalOpen ||
             v4migrationData?.isProcessing ? null : (

--- a/packages/kit/src/provider/Container/FullWindowOverlayContainer/DevOverlayWindow.tsx
+++ b/packages/kit/src/provider/Container/FullWindowOverlayContainer/DevOverlayWindow.tsx
@@ -20,6 +20,7 @@ import {
 import {
   useDevSettingsPersistAtom,
   usePasswordPersistAtom,
+  usePerpsWebSocketDataUpdateTimesAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { ITabMeParamList } from '@onekeyhq/shared/src/routes';
 import {
@@ -31,6 +32,16 @@ import dbPerfMonitor from '@onekeyhq/shared/src/utils/debug/dbPerfMonitor';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import useAppNavigation from '../../../hooks/useAppNavigation';
+
+function PerpsWebSocketUpdate() {
+  const [{ wsUpdateTimes }] = usePerpsWebSocketDataUpdateTimesAtom();
+  return (
+    <XStack gap="$2" alignItems="center">
+      <SizableText>Perps WSS Update:</SizableText>
+      <SizableText>{wsUpdateTimes}</SizableText>
+    </XStack>
+  );
+}
 
 function DevOverlayWindow() {
   const [devSettings, setDevSettings] = useDevSettingsPersistAtom();
@@ -269,6 +280,8 @@ function DevOverlayWindow() {
               />
             </XStack>
           </YStack>
+
+          <PerpsWebSocketUpdate />
         </YStack>
       ),
     });

--- a/packages/kit/src/provider/Container/FullWindowOverlayContainer/DevOverlayWindow.tsx
+++ b/packages/kit/src/provider/Container/FullWindowOverlayContainer/DevOverlayWindow.tsx
@@ -34,11 +34,14 @@ import backgroundApiProxy from '../../../background/instance/backgroundApiProxy'
 import useAppNavigation from '../../../hooks/useAppNavigation';
 
 function PerpsWebSocketUpdate() {
-  const [{ wsUpdateTimes }] = usePerpsWebSocketDataUpdateTimesAtom();
+  const [{ wsDataReceiveTimes, wsDataUpdateTimes }] =
+    usePerpsWebSocketDataUpdateTimesAtom();
   return (
     <XStack gap="$2" alignItems="center">
-      <SizableText>Perps WSS Update:</SizableText>
-      <SizableText>{wsUpdateTimes}</SizableText>
+      <SizableText>PerpWS 接收:</SizableText>
+      <SizableText>{wsDataReceiveTimes}</SizableText>
+      <SizableText>PerpWS 刷新:</SizableText>
+      <SizableText>{wsDataUpdateTimes}</SizableText>
     </XStack>
   );
 }

--- a/packages/kit/src/provider/Container/FullWindowOverlayContainer/DevOverlayWindow.tsx
+++ b/packages/kit/src/provider/Container/FullWindowOverlayContainer/DevOverlayWindow.tsx
@@ -20,8 +20,10 @@ import {
 import {
   useDevSettingsPersistAtom,
   usePasswordPersistAtom,
+  usePerpsCandlesWebviewMountedAtom,
   usePerpsWebSocketDataUpdateTimesAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { DEV_OVERLAY_FLOAT_BUTTON_Z_INDEX } from '@onekeyhq/shared/src/consts/zIndexConsts';
 import type { ITabMeParamList } from '@onekeyhq/shared/src/routes';
 import {
   EModalRoutes,
@@ -33,16 +35,43 @@ import dbPerfMonitor from '@onekeyhq/shared/src/utils/debug/dbPerfMonitor';
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import useAppNavigation from '../../../hooks/useAppNavigation';
 
-function PerpsWebSocketUpdate() {
-  const [{ wsDataReceiveTimes, wsDataUpdateTimes }] =
+export function DevPerpsWebSocketUpdateView() {
+  const [{ wsDataReceiveTimes, wsDataUpdateTimes }, setWsDataUpdateTimes] =
     usePerpsWebSocketDataUpdateTimesAtom();
+  const [{ mounted }] = usePerpsCandlesWebviewMountedAtom();
+  const [devSettings] = useDevSettingsPersistAtom();
+  if (!devSettings.enabled || !devSettings.settings?.showPerpsRenderStats) {
+    return null;
+  }
+
   return (
-    <XStack gap="$2" alignItems="center">
-      <SizableText>PerpWS 接收:</SizableText>
-      <SizableText>{wsDataReceiveTimes}</SizableText>
-      <SizableText>PerpWS 刷新:</SizableText>
-      <SizableText>{wsDataUpdateTimes}</SizableText>
-    </XStack>
+    <YStack maxWidth="$80">
+      <XStack gap="$2" alignItems="center" justifyContent="space-between">
+        <XStack>
+          <SizableText>PerpWS 接收: </SizableText>
+          <SizableText>{wsDataReceiveTimes}</SizableText>
+        </XStack>
+        <XStack>
+          <SizableText>PerpWS 刷新: </SizableText>
+          <SizableText>{wsDataUpdateTimes}</SizableText>
+        </XStack>
+        <XStack>
+          <SizableText>K 线挂载: </SizableText>
+          <SizableText>{mounted ? '是' : '--'}</SizableText>
+        </XStack>
+      </XStack>
+      <Button
+        onPress={() => {
+          setWsDataUpdateTimes((v) => ({
+            ...v,
+            wsDataReceiveTimes: 0,
+            wsDataUpdateTimes: 0,
+          }));
+        }}
+      >
+        重置计数
+      </Button>
+    </YStack>
   );
 }
 
@@ -284,7 +313,7 @@ function DevOverlayWindow() {
             </XStack>
           </YStack>
 
-          <PerpsWebSocketUpdate />
+          <DevPerpsWebSocketUpdateView />
         </YStack>
       ),
     });
@@ -306,6 +335,7 @@ function DevOverlayWindow() {
       left={positionInfo.align === 'left' ? 0 : undefined}
       right={positionInfo.align === 'right' ? 0 : undefined}
       top={`${positionInfo.top > 95 ? 95 : positionInfo.top}%`}
+      zIndex={DEV_OVERLAY_FLOAT_BUTTON_Z_INDEX}
     >
       <IconButton
         size="small"

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -166,8 +166,16 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     }
   });
 
-  updateL2Book = contextAtomMethod((_, set, data: HL.IBook) => {
-    set(l2BookAtom(), data);
+  updateL2Book = contextAtomMethod(async (get, set, data: HL.IBook) => {
+    const activeAsset = await perpsActiveAssetAtom.get();
+    if (activeAsset?.coin === data.coin) {
+      set(l2BookAtom(), data);
+    } else {
+      const currentBook = get(l2BookAtom());
+      if (currentBook?.coin && currentBook?.coin !== activeAsset?.coin) {
+        set(l2BookAtom(), null);
+      }
+    }
   });
 
   ensureOrderBookTickOptionsLoaded = contextAtomMethod(async (_get, set) => {

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -1,7 +1,9 @@
 import { useRef } from 'react';
 
 import { BigNumber } from 'bignumber.js';
+import { isNil } from 'lodash';
 
+import { Toast } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import type { IAppNavigation } from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { ContextJotaiActionsBase } from '@onekeyhq/kit/src/states/jotai/utils/ContextJotaiActionsBase';
@@ -17,6 +19,8 @@ import {
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { IAccountDeriveTypes } from '@onekeyhq/kit-bg/src/vaults/types';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
 import { memoFn } from '@onekeyhq/shared/src/utils/cacheUtils';
@@ -24,7 +28,12 @@ import {
   formatPriceToSignificantDigits,
   resolveTradingSize,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
-import type { IPerpsAssetPosition } from '@onekeyhq/shared/types/hyperliquid';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
+import type {
+  IMarginTable,
+  IPerpsAssetPosition,
+  IPerpsUniverse,
+} from '@onekeyhq/shared/types/hyperliquid';
 import type * as HL from '@onekeyhq/shared/types/hyperliquid/sdk';
 import {
   EPerpsSizeInputMode,
@@ -49,10 +58,6 @@ import {
 import { EActionType, withToast } from './utils';
 
 import type { ITradingFormData } from './atoms';
-import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
-import { Toast } from '@onekeyhq/components';
-import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
-import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
   private orderBookTickOptionsLoaded = false;
@@ -753,6 +758,57 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     }
   });
 
+  tokenSzDecimalsCache: {
+    [coin: string]: number | null;
+  } = {};
+
+  getTokenSzDecimals = contextAtomMethod(
+    async (get, _set, params: { coin: string }) => {
+      const { coin } = params;
+      let szDecimals: number | null = null;
+      if (this.tokenSzDecimalsCache[coin] !== null) {
+        szDecimals = this.tokenSzDecimalsCache[coin];
+      } else {
+        const tokenInfo =
+          await backgroundApiProxy.serviceHyperliquid.getSymbolMeta({
+            coin,
+          });
+        szDecimals = tokenInfo?.universe?.szDecimals ?? null;
+        this.tokenSzDecimalsCache[coin] = szDecimals;
+      }
+      return szDecimals;
+    },
+  );
+
+  getMidPrice = contextAtomMethod(
+    async (get, set, params: { coin: string }) => {
+      const { coin } = params;
+      const allMids = get(perpsAllMidsAtom());
+      const szDecimals = await this.getTokenSzDecimals.call(set, { coin });
+      const mid = allMids?.mids?.[coin];
+      const midValue = new BigNumber(mid || '');
+
+      let midFormattedByDecimals = mid;
+      if (isNil(szDecimals) || Number.isNaN(szDecimals)) {
+        midFormattedByDecimals = mid;
+      } else {
+        midFormattedByDecimals = formatPriceToSignificantDigits(
+          mid,
+          szDecimals,
+        );
+      }
+
+      if (midValue.isNaN() || midValue.isLessThanOrEqualTo(0)) {
+        return { mid: undefined, midFormattedByDecimals: undefined };
+      }
+
+      return {
+        mid,
+        midFormattedByDecimals,
+      };
+    },
+  );
+
   closeAllPositions = contextAtomMethod(
     async (get, set, type: 'market' | 'limit' = 'market') => {
       return withToast({
@@ -775,13 +831,10 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
           const midPrices = await Promise.all(
             positions.map(async (p) => {
               try {
-                const midPrice =
-                  await backgroundApiProxy.serviceHyperliquid.getSymbolMidValue(
-                    {
-                      coin: p.position.coin,
-                    },
-                  );
-                return { coin: p.position.coin, midPrice };
+                const midPriceInfo = await this.getMidPrice.call(set, {
+                  coin: p.position.coin,
+                });
+                return { coin: p.position.coin, midPrice: midPriceInfo.mid };
               } catch (error) {
                 console.warn(
                   `Failed to get mid price for ${p.position.coin}:`,
@@ -956,6 +1009,8 @@ export function useHyperliquidActions() {
   const updateAllAssetsFiltered = actions.updateAllAssetsFiltered.use();
   const ensureTradingEnabled = actions.ensureTradingEnabled.use();
   const refreshAllPerpsData = actions.refreshAllPerpsData.use();
+  const getTokenSzDecimals = actions.getTokenSzDecimals.use();
+  const getMidPrice = actions.getMidPrice.use();
 
   return useRef({
     updateAllAssetsFiltered,
@@ -993,5 +1048,7 @@ export function useHyperliquidActions() {
     ensureOrderBookTickOptionsLoaded,
     setOrderBookTickOption,
     refreshAllPerpsData,
+    getTokenSzDecimals,
+    getMidPrice,
   });
 }

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -49,6 +49,10 @@ import {
 import { EActionType, withToast } from './utils';
 
 import type { ITradingFormData } from './atoms';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
+import { Toast } from '@onekeyhq/components';
+import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
   private orderBookTickOptionsLoaded = false;
@@ -888,9 +892,23 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     },
   );
 
-  // refreshAllPerpsData
-  refreshAllPerpsData = contextAtomMethod(async (get, set) => {
-    // TODO
+  lastRefreshAllPerpsDataTime = 0;
+
+  refreshAllPerpsData = contextAtomMethod(async (_get, _set) => {
+    const now = Date.now();
+    if (
+      now - this.lastRefreshAllPerpsDataTime <
+      timerUtils.getTimeDurationMs({ seconds: 15 })
+    ) {
+      Toast.message({
+        title: appLocale.intl.formatMessage({
+          id: ETranslations.global_request_limit,
+        }),
+      });
+      return;
+    }
+    this.lastRefreshAllPerpsDataTime = now;
+    await backgroundApiProxy.serviceHyperliquidSubscription.refreshAllPerpsData();
   });
 }
 

--- a/packages/kit/src/views/Perp/components/PerpCandles.tsx
+++ b/packages/kit/src/views/Perp/components/PerpCandles.tsx
@@ -3,18 +3,23 @@ import { TradingViewPerpsV2 } from '@onekeyhq/kit/src/components/TradingView/Tra
 import {
   usePerpsActiveAccountAtom,
   usePerpsActiveAssetAtom,
+  usePerpsCandlesWebviewReloadHookAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 
 export function PerpCandles() {
   const [currentToken] = usePerpsActiveAssetAtom();
   const [currentAccount] = usePerpsActiveAccountAtom();
+  const [{ reloadHook }] = usePerpsCandlesWebviewReloadHookAtom();
 
   const content = (
     <Stack w="100%" h="100%">
-      <TradingViewPerpsV2
-        userAddress={currentAccount?.accountAddress}
-        symbol={currentToken.coin}
-      />
+      {reloadHook > 0 ? (
+        <TradingViewPerpsV2
+          webviewKey={reloadHook.toString()}
+          userAddress={currentAccount?.accountAddress}
+          symbol={currentToken.coin}
+        />
+      ) : null}
     </Stack>
   );
   return (

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -121,8 +121,8 @@ function useHyperliquidEventBusListener() {
             void actions.current.updateL2Book(data as IBook);
             break;
 
-          case ESubscriptionType.BBO:
-            break;
+          // case ESubscriptionType.BBO:
+          //   break;
 
           default:
         }

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -101,6 +101,10 @@ function useHyperliquidEventBusListener() {
             break;
           }
 
+          case ESubscriptionType.L2_BOOK:
+            void actions.current.updateL2Book(data as IBook);
+            break;
+
           case ESubscriptionType.ACTIVE_ASSET_CTX:
             // move to global jotai, updateActiveAssetCtx() in background
             // void actions.current.updateActiveAssetCtx(
@@ -115,10 +119,6 @@ function useHyperliquidEventBusListener() {
             //   data as IActiveAssetData,
             //   eventPayload.metadata.coin,
             // );
-            break;
-
-          case ESubscriptionType.L2_BOOK:
-            void actions.current.updateL2Book(data as IBook);
             break;
 
           // case ESubscriptionType.BBO:

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -15,6 +15,7 @@ import type { IPerpsActiveOrderBookOptionsAtom } from '@onekeyhq/kit-bg/src/stat
 import {
   perpsActiveAssetAtom,
   perpsActiveOrderBookOptionsAtom,
+  perpsCandlesWebviewReloadHookAtom,
   usePerpsAccountLoadingInfoAtom,
   usePerpsActiveAccountAtom,
   usePerpsActiveAssetAtom,

--- a/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
@@ -28,7 +28,6 @@ import {
   usePerpsActiveAssetCtxAtom,
   usePerpsActiveAssetDataAtom,
   usePerpsActiveOrderBookOptionsAtom,
-  usePerpsCurrentMidAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -41,7 +40,6 @@ import { showDepositWithdrawModal } from '../modals/DepositWithdrawModal';
 import { PerpsAccountNumberValue } from './PerpsAccountNumberValue';
 
 function DebugButton() {
-  const [currentMid] = usePerpsCurrentMidAtom(); // TODO remove
   const [allMids] = usePerpsAllMidsAtom();
   const [allAssetCtxs] = usePerpsAllAssetCtxsAtom();
   const { assetCtx: btcAssetCtx } = usePerpsAssetCtx({ assetId: 0 });
@@ -68,12 +66,8 @@ function DebugButton() {
         onPress={async () => {
           const simpleDbPerpData =
             await backgroundApiProxy.simpleDb.perp.getPerpData();
-          const bgHyperLiquidCache =
-            await backgroundApiProxy.serviceHyperliquid.getHyperLiquidCache();
           console.log('PerpsHeaderRight__DebugButton', {
             simpleDbPerpData,
-            bgHyperLiquidCache,
-            currentMid,
             allMids,
             allAssetCtxs,
             btcAssetCtx,

--- a/packages/kit/src/views/Perp/hooks/usePerpOrderInfoPanel.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpOrderInfoPanel.ts
@@ -139,6 +139,8 @@ export function usePerpTradesHistory() {
     return filteredTrades?.sort((a, b) => b.time - a.time);
   }, [currentAccount?.accountAddress, newTradesHistory, result]);
 
+  console.log('usePerpTradesHistory__render', newTradesHistory, refreshHook);
+
   return {
     trades: mergeTradesHistory,
     currentListPage,

--- a/packages/kit/src/views/Perp/hooks/usePerpsMidPrice.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpsMidPrice.ts
@@ -1,36 +1,24 @@
-import { useMemo } from 'react';
+import { noop } from 'lodash';
 
-import BigNumber from 'bignumber.js';
-import { isNil } from 'lodash';
-
-import { formatPriceToSignificantDigits } from '@onekeyhq/shared/src/utils/perpsUtils';
-
-import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import { usePromiseResult } from '../../../hooks/usePromiseResult';
-import { usePerpsAllMidsAtom } from '../../../states/jotai/contexts/hyperliquid';
+import {
+  useHyperliquidActions,
+  usePerpsAllMidsAtom,
+} from '../../../states/jotai/contexts/hyperliquid';
 
 export function usePerpsMidPrice({ coin }: { coin: string }): {
   mid: string | undefined;
   midFormattedByDecimals: string | undefined;
 } {
   const [allMids] = usePerpsAllMidsAtom();
-  const mid = allMids?.mids?.[coin];
-  const midValue = new BigNumber(mid || '');
-  const { result: tokenInfo } = usePromiseResult(async () => {
-    return backgroundApiProxy.serviceHyperliquid.getSymbolMeta({
-      coin,
-    });
-  }, [coin]);
-  const szDecimals = tokenInfo?.universe?.szDecimals ?? null;
-  const midFormattedByDecimals = useMemo(() => {
-    if (isNil(szDecimals) || Number.isNaN(szDecimals)) {
-      return mid;
-    }
-    const result = formatPriceToSignificantDigits(mid, szDecimals);
-    return result;
-  }, [mid, szDecimals]);
-  if (midValue.isNaN() || midValue.isLessThanOrEqualTo(0)) {
+  const actions = useHyperliquidActions();
+  const { result } = usePromiseResult(async () => {
+    noop(allMids);
+    return actions.current.getMidPrice({ coin });
+  }, [allMids, coin, actions]);
+
+  if (!result) {
     return { mid: undefined, midFormattedByDecimals: undefined };
   }
-  return { mid, midFormattedByDecimals };
+  return result;
 }

--- a/packages/kit/src/views/Perp/pages/Perp.tsx
+++ b/packages/kit/src/views/Perp/pages/Perp.tsx
@@ -5,6 +5,8 @@ import { useIntl } from 'react-intl';
 
 import {
   Badge,
+  Button,
+  IconButton,
   Image,
   Page,
   Stack,
@@ -23,6 +25,7 @@ import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import { TabPageHeader } from '../../../components/TabPageHeader';
+import { useHyperliquidActions } from '../../../states/jotai/contexts/hyperliquid';
 import { HyperliquidTermsOverlay } from '../components/HyperliquidTerms';
 import { PerpsGlobalEffects } from '../components/PerpsGlobalEffects';
 import { PerpsHeaderRight } from '../components/TradingPanel/components/PerpsHeaderRight';
@@ -94,6 +97,32 @@ function PerpNetworkStatus() {
   );
 }
 
+function FooterRefreshButton() {
+  const actions = useHyperliquidActions();
+  const [networkStatus] = usePerpsNetworkStatusAtom();
+  const [loading, setLoading] = useState(false);
+  return (
+    <IconButton
+      loading={loading}
+      disabled={!networkStatus.connected}
+      ml="$2"
+      icon="RefreshCwOutline"
+      variant="tertiary"
+      size="small"
+      onPress={async () => {
+        try {
+          setLoading(true);
+          await actions.current.refreshAllPerpsData();
+        } catch (error) {
+          console.error(error);
+        } finally {
+          setLoading(false);
+        }
+      }}
+    />
+  );
+}
+
 function PerpContentFooter() {
   const { gtSm } = useMedia();
   const { poweredByHyperliquidLogo } = usePerpsLogo();
@@ -109,6 +138,8 @@ function PerpContentFooter() {
         justifyContent="space-between"
       >
         <PerpNetworkStatus />
+        <FooterRefreshButton />
+        <Stack flex={1} />
         <Image
           source={poweredByHyperliquidLogo}
           size={170}

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
@@ -956,6 +956,15 @@ const BaseDevSettingsSection = () => {
           navigation.push(EModalSettingRoutes.SettingDevPerpGalleryModal);
         }}
       />
+      <SectionFieldItem
+        icon="CreditCardOutline"
+        name="showPerpsRenderStats"
+        title="显示 Perps 渲染统计"
+        subtitle="显示 Perps 渲染统计"
+      >
+        <Switch size={ESwitchSize.small} />
+      </SectionFieldItem>
+
       <SectionPressItem
         icon="LockOutline"
         title="CryptoGallery"

--- a/packages/shared/src/consts/zIndexConsts.ts
+++ b/packages/shared/src/consts/zIndexConsts.ts
@@ -2,6 +2,8 @@ export const APP_STATE_LOCK_Z_INDEX = 100_000_000;
 
 export const RESET_OVERLAY_Z_INDEX = APP_STATE_LOCK_Z_INDEX + 2;
 
+export const DEV_OVERLAY_FLOAT_BUTTON_Z_INDEX = APP_STATE_LOCK_Z_INDEX + 5;
+
 // in Tamagui:
 //  the z-index of the Sheet is 1e5 - 1.
 export const SHEET_AND_DIALOG_Z_INDEX = 100_000 - 1;

--- a/packages/shared/types/hyperliquid/sdk.ts
+++ b/packages/shared/types/hyperliquid/sdk.ts
@@ -106,14 +106,15 @@ export type ISignature = HL.Signature;
 export type IPerpsSubscriptionParams = {
   [ESubscriptionType.L2_BOOK]: IEventL2BookParameters;
   [ESubscriptionType.USER_FILLS]: IEventUserFillsParameters;
-  [ESubscriptionType.USER_EVENTS]: IEventUserEventsParameters;
-  [ESubscriptionType.USER_NOTIFICATIONS]: IEventNotificationParameters;
+
   [ESubscriptionType.ACTIVE_ASSET_DATA]: IEventActiveAssetDataParameters;
   [ESubscriptionType.WEB_DATA2]: IEventWebData2Parameters;
   [ESubscriptionType.ALL_MIDS]: IWsAllMidsParameters;
   [ESubscriptionType.ACTIVE_ASSET_CTX]: IEventActiveAssetCtxParameters;
-  [ESubscriptionType.TRADES]: IEventTradesParameters;
-  [ESubscriptionType.BBO]: IEventBboParameters;
+  // [ESubscriptionType.USER_EVENTS]: IEventUserEventsParameters;
+  // [ESubscriptionType.USER_NOTIFICATIONS]: IEventNotificationParameters;
+  // [ESubscriptionType.TRADES]: IEventTradesParameters;
+  // [ESubscriptionType.BBO]: IEventBboParameters;
 };
 
 export type IWebSocketTransportOptions = HL.WebSocketTransportOptions;

--- a/packages/shared/types/hyperliquid/types.ts
+++ b/packages/shared/types/hyperliquid/types.ts
@@ -5,15 +5,15 @@ import type { EHyperLiquidAgentName } from '../../src/consts/perp';
 
 export enum ESubscriptionType {
   ALL_MIDS = 'allMids',
+  L2_BOOK = 'l2Book',
   ACTIVE_ASSET_CTX = 'activeAssetCtx',
+  ACTIVE_ASSET_DATA = 'activeAssetData',
   WEB_DATA2 = 'webData2',
   USER_FILLS = 'userFills',
-  L2_BOOK = 'l2Book',
-  TRADES = 'trades',
-  BBO = 'bbo',
-  ACTIVE_ASSET_DATA = 'activeAssetData',
-  USER_EVENTS = 'userEvents',
-  USER_NOTIFICATIONS = 'userNotifications',
+  // TRADES = 'trades',
+  // BBO = 'bbo',
+  // USER_EVENTS = 'userEvents',
+  // USER_NOTIFICATIONS = 'userNotifications',
 }
 
 export interface IConnectionState {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Refresh button to Perp footer to reload market data (with rate limiting and user feedback).
  - TradingView Perps webview now supports controlled reloads and more stable mounting.
- Improvements
  - Enhanced WebSocket reconnection, cleanup, and subscription management for more reliable live data.
  - More accurate mid-price handling and L2 order book updates only for the active asset.
- Developer Tools
  - New Dev toggle to show Perps render/WebSocket stats, with an overlay view and reset.
- Chores
  - Updated internal spelling skip list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->