### PR TITLE
feat: asynchronously load chain-related code to improve app startup speed

### DIFF
--- a/packages/kit-bg/src/providers/backgroundProviders.ts
+++ b/packages/kit-bg/src/providers/backgroundProviders.ts
@@ -1,26 +1,5 @@
 import { IInjectedProviderNames } from '@onekeyfe/cross-inpage-provider-types';
 
-import ProviderApiAlgo from './ProviderApiAlgo';
-import ProviderApiAlph from './ProviderApiAlph';
-import ProviderApiAptos from './ProviderApiAptos';
-import ProviderApiBfc from './ProviderApiBfc';
-import ProviderApiBtc from './ProviderApiBtc';
-import ProviderApiCardano from './ProviderApiCardano';
-import ProviderApiConflux from './ProviderApiConflux';
-import ProviderApiCosmos from './ProviderApiCosmos';
-import ProviderApiEthereum from './ProviderApiEthereum';
-import ProviderApiNear from './ProviderApiNear';
-import ProviderApiNeoN3 from './ProviderApiNeoN3';
-import ProviderApiNostr from './ProviderApiNostr';
-import ProviderApiPolkadot from './ProviderApiPolkadot';
-import ProviderApiPrivate from './ProviderApiPrivate';
-import ProviderApiScdo from './ProviderApiScdo';
-import ProviderApiSolana from './ProviderApiSolana';
-import ProviderApiSui from './ProviderApiSui';
-import ProviderApiTon from './ProviderApiTon';
-import ProviderApiTron from './ProviderApiTron';
-import ProviderApiWebln from './ProviderApiWebln';
-
 import type ProviderApiBase from './ProviderApiBase';
 import type {
   IBackgroundApi,
@@ -32,69 +11,249 @@ function createBackgroundProviders({
 }: {
   backgroundApi: IBackgroundApiBridge | IBackgroundApi;
 }) {
-  const backgroundProviders: Record<string, ProviderApiBase> = {
-    [IInjectedProviderNames.$private]: new ProviderApiPrivate({
-      backgroundApi,
-    }),
-    [IInjectedProviderNames.ethereum]: new ProviderApiEthereum({
-      backgroundApi,
-    }),
-    [IInjectedProviderNames.solana]: new ProviderApiSolana({
-      backgroundApi,
-    }),
-    // [IInjectedProviderNames.starcoin]: new ProviderApiStarcoin({
-    //   backgroundApi,
-    // }),
-    [IInjectedProviderNames.near]: new ProviderApiNear({
-      backgroundApi,
-    }),
-    [IInjectedProviderNames.aptos]: new ProviderApiAptos({
-      backgroundApi,
-    }),
-    [IInjectedProviderNames.conflux]: new ProviderApiConflux({
-      backgroundApi,
-    }),
-    [IInjectedProviderNames.tron]: new ProviderApiTron({
-      backgroundApi,
-    }),
-    [IInjectedProviderNames.algo]: new ProviderApiAlgo({
-      backgroundApi,
-    }),
-    [IInjectedProviderNames.sui]: new ProviderApiSui({
-      backgroundApi,
-    }),
-    [IInjectedProviderNames.bfc]: new ProviderApiBfc({
-      backgroundApi,
-    }),
-    [IInjectedProviderNames.ton]: new ProviderApiTon({
-      backgroundApi,
-    }),
-    [IInjectedProviderNames.alephium]: new ProviderApiAlph({
-      backgroundApi,
-    }),
-    [IInjectedProviderNames.scdo]: new ProviderApiScdo({
-      backgroundApi,
-    }),
-    [IInjectedProviderNames.cardano]: new ProviderApiCardano({
-      backgroundApi,
-    }),
-    [IInjectedProviderNames.cosmos]: new ProviderApiCosmos({
-      backgroundApi,
-    }),
-    [IInjectedProviderNames.polkadot]: new ProviderApiPolkadot({
-      backgroundApi,
-    }),
-    [IInjectedProviderNames.webln]: new ProviderApiWebln({ backgroundApi }),
-    [IInjectedProviderNames.nostr]: new ProviderApiNostr({ backgroundApi }),
-    [IInjectedProviderNames.btc]: new ProviderApiBtc({
-      backgroundApi,
-    }),
-    [IInjectedProviderNames.neo]: new ProviderApiNeoN3({
-      backgroundApi,
-    }),
-    // eslint-disable-next-line spellcheck/spell-checker
-    // sollet
-  };
+  const backgroundProviders: Record<string, ProviderApiBase> = {};
+
+  // Lazy load providers using getters
+  Object.defineProperty(backgroundProviders, IInjectedProviderNames.$private, {
+    get() {
+      const ProviderApiPrivate = import(
+        './ProviderApiPrivate'
+      ) as unknown as typeof import('./ProviderApiPrivate').default;
+      const value = new ProviderApiPrivate({ backgroundApi });
+      Object.defineProperty(this, IInjectedProviderNames.$private, { value });
+      return value;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(backgroundProviders, IInjectedProviderNames.ethereum, {
+    get() {
+      const ProviderApiEthereum = import(
+        './ProviderApiEthereum'
+      ) as unknown as typeof import('./ProviderApiEthereum').default;
+      const value = new ProviderApiEthereum({ backgroundApi });
+      Object.defineProperty(this, IInjectedProviderNames.ethereum, { value });
+      return value;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(backgroundProviders, IInjectedProviderNames.solana, {
+    get() {
+      const ProviderApiSolana = import(
+        './ProviderApiSolana'
+      ) as unknown as typeof import('./ProviderApiSolana').default;
+      const value = new ProviderApiSolana({ backgroundApi });
+      Object.defineProperty(this, IInjectedProviderNames.solana, { value });
+      return value;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(backgroundProviders, IInjectedProviderNames.near, {
+    get() {
+      const ProviderApiNear = import(
+        './ProviderApiNear'
+      ) as unknown as typeof import('./ProviderApiNear').default;
+      const value = new ProviderApiNear({ backgroundApi });
+      Object.defineProperty(this, IInjectedProviderNames.near, { value });
+      return value;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(backgroundProviders, IInjectedProviderNames.aptos, {
+    get() {
+      const ProviderApiAptos = import(
+        './ProviderApiAptos'
+      ) as unknown as typeof import('./ProviderApiAptos').default;
+      const value = new ProviderApiAptos({ backgroundApi });
+      Object.defineProperty(this, IInjectedProviderNames.aptos, { value });
+      return value;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(backgroundProviders, IInjectedProviderNames.conflux, {
+    get() {
+      const ProviderApiConflux = import(
+        './ProviderApiConflux'
+      ) as unknown as typeof import('./ProviderApiConflux').default;
+      const value = new ProviderApiConflux({ backgroundApi });
+      Object.defineProperty(this, IInjectedProviderNames.conflux, { value });
+      return value;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(backgroundProviders, IInjectedProviderNames.tron, {
+    get() {
+      const ProviderApiTron = import(
+        './ProviderApiTron'
+      ) as unknown as typeof import('./ProviderApiTron').default;
+      const value = new ProviderApiTron({ backgroundApi });
+      Object.defineProperty(this, IInjectedProviderNames.tron, { value });
+      return value;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(backgroundProviders, IInjectedProviderNames.algo, {
+    get() {
+      const ProviderApiAlgo = import(
+        './ProviderApiAlgo'
+      ) as unknown as typeof import('./ProviderApiAlgo').default;
+      const value = new ProviderApiAlgo({ backgroundApi });
+      Object.defineProperty(this, IInjectedProviderNames.algo, { value });
+      return value;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(backgroundProviders, IInjectedProviderNames.sui, {
+    get() {
+      const ProviderApiSui = import(
+        './ProviderApiSui'
+      ) as unknown as typeof import('./ProviderApiSui').default;
+      const value = new ProviderApiSui({ backgroundApi });
+      Object.defineProperty(this, IInjectedProviderNames.sui, { value });
+      return value;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(backgroundProviders, IInjectedProviderNames.bfc, {
+    get() {
+      const ProviderApiBfc = import(
+        './ProviderApiBfc'
+      ) as unknown as typeof import('./ProviderApiBfc').default;
+      const value = new ProviderApiBfc({ backgroundApi });
+      Object.defineProperty(this, IInjectedProviderNames.bfc, { value });
+      return value;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(backgroundProviders, IInjectedProviderNames.ton, {
+    get() {
+      const ProviderApiTon = import(
+        './ProviderApiTon'
+      ) as unknown as typeof import('./ProviderApiTon').default;
+      const value = new ProviderApiTon({ backgroundApi });
+      Object.defineProperty(this, IInjectedProviderNames.ton, { value });
+      return value;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(backgroundProviders, IInjectedProviderNames.alephium, {
+    get() {
+      const ProviderApiAlph = import(
+        './ProviderApiAlph'
+      ) as unknown as typeof import('./ProviderApiAlph').default;
+      const value = new ProviderApiAlph({ backgroundApi });
+      Object.defineProperty(this, IInjectedProviderNames.alephium, { value });
+      return value;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(backgroundProviders, IInjectedProviderNames.scdo, {
+    get() {
+      const ProviderApiScdo = import(
+        './ProviderApiScdo'
+      ) as unknown as typeof import('./ProviderApiScdo').default;
+      const value = new ProviderApiScdo({ backgroundApi });
+      Object.defineProperty(this, IInjectedProviderNames.scdo, { value });
+      return value;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(backgroundProviders, IInjectedProviderNames.cardano, {
+    get() {
+      const ProviderApiCardano = import(
+        './ProviderApiCardano'
+      ) as unknown as typeof import('./ProviderApiCardano').default;
+      const value = new ProviderApiCardano({ backgroundApi });
+      Object.defineProperty(this, IInjectedProviderNames.cardano, { value });
+      return value;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(backgroundProviders, IInjectedProviderNames.cosmos, {
+    get() {
+      const ProviderApiCosmos = import(
+        './ProviderApiCosmos'
+      ) as unknown as typeof import('./ProviderApiCosmos').default;
+      const value = new ProviderApiCosmos({ backgroundApi });
+      Object.defineProperty(this, IInjectedProviderNames.cosmos, { value });
+      return value;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(backgroundProviders, IInjectedProviderNames.polkadot, {
+    get() {
+      const ProviderApiPolkadot = import(
+        './ProviderApiPolkadot'
+      ) as unknown as typeof import('./ProviderApiPolkadot').default;
+      const value = new ProviderApiPolkadot({ backgroundApi });
+      Object.defineProperty(this, IInjectedProviderNames.polkadot, { value });
+      return value;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(backgroundProviders, IInjectedProviderNames.webln, {
+    get() {
+      const ProviderApiWebln = import(
+        './ProviderApiWebln'
+      ) as unknown as typeof import('./ProviderApiWebln').default;
+      const value = new ProviderApiWebln({ backgroundApi });
+      Object.defineProperty(this, IInjectedProviderNames.webln, { value });
+      return value;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(backgroundProviders, IInjectedProviderNames.nostr, {
+    get() {
+      const ProviderApiNostr = import(
+        './ProviderApiNostr'
+      ) as unknown as typeof import('./ProviderApiNostr').default;
+      const value = new ProviderApiNostr({ backgroundApi });
+      Object.defineProperty(this, IInjectedProviderNames.nostr, { value });
+      return value;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(backgroundProviders, IInjectedProviderNames.btc, {
+    get() {
+      const ProviderApiBtc = import(
+        './ProviderApiBtc'
+      ) as unknown as typeof import('./ProviderApiBtc').default;
+      const value = new ProviderApiBtc({ backgroundApi });
+      Object.defineProperty(this, IInjectedProviderNames.btc, { value });
+      return value;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(backgroundProviders, IInjectedProviderNames.neo, {
+    get() {
+      const ProviderApiNeoN3 = import(
+        './ProviderApiNeoN3'
+      ) as unknown as typeof import('./ProviderApiNeoN3').default;
+      const value = new ProviderApiNeoN3({ backgroundApi });
+      Object.defineProperty(this, IInjectedProviderNames.neo, { value });
+      return value;
+    },
+    configurable: true,
+  });
+
   return backgroundProviders;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Switched background providers to lazy-loading: providers are created on first use and then cached.
  - Improves startup responsiveness and reduces initial memory/CPU usage, especially when only a subset of providers is used.
  - Defers provider-related work and potential network activity until needed.
  - No expected change to user-facing behavior or APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->