### PR TITLE
feat: add network status badge component

### DIFF
--- a/packages/kit/src/components/NetworkStatusBadge/NetworkStatusBadge.tsx
+++ b/packages/kit/src/components/NetworkStatusBadge/NetworkStatusBadge.tsx
@@ -1,0 +1,83 @@
+import { useMemo } from 'react';
+import type { ComponentProps, ReactElement } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import { Badge, Stack } from '@onekeyhq/components';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+
+export type INetworkStatusBadgeProps = {
+  connected: boolean;
+  indicator?: ReactElement;
+  label?: string;
+  labelFontSize?: number;
+  badgeSize?: ComponentProps<typeof Badge>['badgeSize'];
+};
+
+export function NetworkStatusBadge({
+  connected,
+  indicator,
+  label,
+  labelFontSize = 12,
+  badgeSize = 'md',
+}: INetworkStatusBadgeProps) {
+  const intl = useIntl();
+
+  const { badgeType, indicatorElement, badgeLabel } = useMemo(() => {
+    const type = connected ? 'success' : 'critical';
+    const resolvedLabel =
+      label ||
+      (connected
+        ? intl.formatMessage({ id: ETranslations.perp_online })
+        : intl.formatMessage({ id: ETranslations.perp_offline }));
+    if (indicator) {
+      return {
+        badgeType: type,
+        indicatorElement: indicator,
+        badgeLabel: resolvedLabel,
+      };
+    }
+
+    const indicatorBg = connected ? '$success10' : '$critical10';
+    return {
+      badgeType: type,
+      badgeLabel: resolvedLabel,
+      indicatorElement: (
+        <Stack
+          position="relative"
+          w={8}
+          h={8}
+          borderRadius="$full"
+          alignItems="center"
+          justifyContent="center"
+          bg="$neutral3"
+          p="$1.5"
+        >
+          <Stack
+            position="absolute"
+            w={6}
+            h={6}
+            borderRadius="$full"
+            bg={indicatorBg}
+          />
+        </Stack>
+      ),
+    };
+  }, [connected, indicator, intl, label]);
+
+  return (
+    <Badge
+      badgeType={badgeType}
+      badgeSize={badgeSize}
+      height={badgeSize === 'lg' ? 32 : 26}
+      borderRadius="$full"
+      pl="$2"
+      px="$3"
+      gap="$1.5"
+      cursor="default"
+    >
+      {indicatorElement}
+      <Badge.Text style={{ fontSize: labelFontSize }}>{badgeLabel}</Badge.Text>
+    </Badge>
+  );
+}

--- a/packages/kit/src/components/NetworkStatusBadge/index.ts
+++ b/packages/kit/src/components/NetworkStatusBadge/index.ts
@@ -1,0 +1,1 @@
+export * from './NetworkStatusBadge';

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/NetworkStatusBadge.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/NetworkStatusBadge.tsx
@@ -1,0 +1,33 @@
+import { Stack } from '@onekeyhq/components';
+import { NetworkStatusBadge } from '@onekeyhq/kit/src/components/NetworkStatusBadge';
+
+import { Layout } from './utils/Layout';
+
+const Demo = () => {
+  return (
+    <Layout
+      componentName="NetworkStatusBadge"
+      getFilePath={() => __CURRENT_FILE_PATH__}
+      elements={[
+        {
+          title: 'Connected',
+          element: (
+            <Stack gap="$2" alignItems="center">
+              <NetworkStatusBadge connected />
+            </Stack>
+          ),
+        },
+        {
+          title: 'Disconnected',
+          element: (
+            <Stack gap="$2" alignItems="center">
+              <NetworkStatusBadge connected={false} />
+            </Stack>
+          ),
+        },
+      ]}
+    />
+  );
+};
+
+export default Demo;

--- a/packages/kit/src/views/Developer/pages/Gallery/index.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/index.tsx
@@ -447,6 +447,13 @@ const MarkdownGallery = LazyLoadPage(
     ),
 );
 
+const NetworkStatusBadgeGallery = LazyLoadPage(
+  () =>
+    import(
+      '@onekeyhq/kit/src/views/Developer/pages/Gallery/Components/stories/NetworkStatusBadge'
+    ),
+);
+
 const NotificationGallery = LazyLoadPage(
   () =>
     import(
@@ -844,6 +851,10 @@ export const galleryScreenList: {
   {
     name: EGalleryRoutes.ComponentMarkdown,
     component: MarkdownGallery,
+  },
+  {
+    name: EGalleryRoutes.ComponentNetworkStatusBadge,
+    component: NetworkStatusBadgeGallery,
   },
   {
     name: EGalleryRoutes.ComponentNotification,

--- a/packages/kit/src/views/Perp/pages/Perp.tsx
+++ b/packages/kit/src/views/Perp/pages/Perp.tsx
@@ -1,29 +1,24 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { useFocusEffect } from '@react-navigation/native';
-import { useIntl } from 'react-intl';
 
 import {
-  Badge,
-  Button,
   IconButton,
   Image,
   Page,
   Stack,
   XStack,
   YStack,
-  useIsFocusedTab,
   useMedia,
 } from '@onekeyhq/components';
-import { useFocusedTab } from '@onekeyhq/components/src/composite/Tabs/useFocusedTab';
 import { usePerpsNetworkStatusAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { FLOAT_NAV_BAR_Z_INDEX } from '@onekeyhq/shared/src/consts/zIndexConsts';
-import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes/tab';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
+import { NetworkStatusBadge } from '../../../components/NetworkStatusBadge';
 import { TabPageHeader } from '../../../components/TabPageHeader';
 import { useHyperliquidActions } from '../../../states/jotai/contexts/hyperliquid';
 import { HyperliquidTermsOverlay } from '../components/HyperliquidTerms';
@@ -48,53 +43,10 @@ function PerpLayout() {
 }
 
 function PerpNetworkStatus() {
-  const intl = useIntl();
   const [networkStatus] = usePerpsNetworkStatusAtom();
-  const isNetworkStable = networkStatus.connected;
-  const networkStyle = useMemo(() => {
-    return {
-      badgeType: isNetworkStable ? 'success' : 'critical',
-      indicatorBg: isNetworkStable ? '$success10' : '$critical10',
-      text: isNetworkStable
-        ? intl.formatMessage({ id: ETranslations.perp_online })
-        : intl.formatMessage({ id: ETranslations.perp_offline }),
-    };
-  }, [isNetworkStable, intl]);
-  return useMemo(
-    () => (
-      <Badge
-        badgeType={networkStyle.badgeType}
-        badgeSize="md"
-        height={26}
-        borderRadius="$full"
-        pl="$2"
-        px="$3"
-        gap="$1.5"
-        cursor="default"
-      >
-        <Stack
-          position="relative"
-          w={8}
-          h={8}
-          borderRadius="$full"
-          alignItems="center"
-          justifyContent="center"
-          bg="$neutral3"
-          p="$1.5"
-        >
-          <Stack
-            position="absolute"
-            w={6}
-            h={6}
-            borderRadius="$full"
-            bg={networkStyle.indicatorBg}
-          />
-        </Stack>
-        <Badge.Text style={{ fontSize: 12 }}>{networkStyle.text}</Badge.Text>
-      </Badge>
-    ),
-    [networkStyle],
-  );
+  const connected = Boolean(networkStatus?.connected);
+
+  return <NetworkStatusBadge connected={connected} />;
 }
 
 function FooterRefreshButton() {

--- a/packages/shared/src/routes/gallery.ts
+++ b/packages/shared/src/routes/gallery.ts
@@ -40,6 +40,7 @@ export enum EGalleryRoutes {
   ComponentLogger = 'component-Logger',
   ComponentLottieView = 'component-LottieView',
   ComponentMarkdown = 'component-Markdown',
+  ComponentNetworkStatusBadge = 'component-NetworkStatusBadge',
   ComponentNavigation = 'component-Navigation',
   ComponentNotification = 'component-Notification',
   ComponentNumberSizeableTextGallery = 'component-NumberSizeableText',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a NetworkStatusBadge component to display connection status with an indicator and optional label/size customization.

* **Refactor**
  * Simplified the Perp network status UI by replacing custom logic with the new NetworkStatusBadge for clearer, consistent visuals.

* **Documentation**
  * Added a developer gallery demo showcasing connected and disconnected states of NetworkStatusBadge.

* **Chores**
  * Updated gallery navigation to include the NetworkStatusBadge demo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->