### PR TITLE
fix: liquidation price calculation and add orderbook collapse feature OK-43388 OK-43553

### DIFF
--- a/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
+++ b/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
@@ -365,7 +365,7 @@ export function PerpOrderBook({
           horizontal={false}
           bids={l2Book.bids}
           asks={l2Book.asks}
-          maxLevelsPerSide={14}
+          maxLevelsPerSide={11}
           selectedTickOption={selectedTickOption}
           onTickOptionChange={handleTickOptionChange}
           tickOptions={tickOptions}

--- a/packages/kit/src/views/Perp/hooks/useOrderConfirm.ts
+++ b/packages/kit/src/views/Perp/hooks/useOrderConfirm.ts
@@ -43,16 +43,24 @@ export function useOrderConfirm(
         return;
       }
 
+      const formDataSnapshot = overrideSide
+        ? { ...formData, side: overrideSide }
+        : { ...formData };
+
       // Reset form before placing order
       hyperliquidActions.current.resetTradingForm();
 
-      let effectiveFormData = overrideSide
-        ? { ...formData, side: overrideSide }
-        : formData;
+      let effectiveFormData = formDataSnapshot;
 
-      const { tpValue, slValue, tpType, slType, leverage = 1 } = formData;
+      const {
+        tpValue,
+        slValue,
+        tpType,
+        slType,
+        leverage = 1,
+      } = formDataSnapshot;
       const leverageBN = new BigNumber(leverage);
-      if (formData.hasTpsl && (tpValue || slValue)) {
+      if (formDataSnapshot.hasTpsl && (tpValue || slValue)) {
         const entryPrice =
           effectiveFormData.type === 'market'
             ? new BigNumber(activeAssetCtx?.ctx?.markPrice || '0')

--- a/packages/kit/src/views/Perp/layouts/PerpDesktopLayout.tsx
+++ b/packages/kit/src/views/Perp/layouts/PerpDesktopLayout.tsx
@@ -1,4 +1,13 @@
-import { ScrollView, XStack, YStack, useMedia } from '@onekeyhq/components';
+import { useState } from 'react';
+
+import {
+  IconButton,
+  ScrollView,
+  Stack,
+  XStack,
+  YStack,
+  useMedia,
+} from '@onekeyhq/components';
 
 import { PerpOrderInfoPanel } from '../components/OrderInfoPanel/PerpOrderInfoPanel';
 import { PerpCandles } from '../components/PerpCandles';
@@ -13,6 +22,7 @@ import { PerpTradingPanel } from '../components/TradingPanel/PerpTradingPanel';
 
 function PerpDesktopLayout() {
   const { gtXl } = useMedia();
+  const [isOrderBookVisible, setIsOrderBookVisible] = useState(true);
   return (
     <ScrollView flex={1}>
       <YStack bg="$bgApp">
@@ -31,15 +41,50 @@ function PerpDesktopLayout() {
               borderBottomWidth="$px"
               borderBottomColor="$borderSubdued"
             >
-              <YStack flex={1} minHeight={600}>
-                <PerpCandles />
+              <YStack flex={1} minHeight={600} position="relative">
+                <YStack flex={1} pr={6}>
+                  <PerpCandles />
+                </YStack>
+                {gtXl ? (
+                  <Stack
+                    position="absolute"
+                    top="50%"
+                    right={-6}
+                    zIndex={2}
+                    marginTop={-2}
+                  >
+                    <IconButton
+                      icon={
+                        isOrderBookVisible
+                          ? 'ChevronRightSmallSolid'
+                          : 'ChevronLeftSmallSolid'
+                      }
+                      size="small"
+                      variant="tertiary"
+                      bg="$bg"
+                      borderWidth="$px"
+                      borderColor="$borderSubdued"
+                      borderRadius="$2"
+                      p="$0"
+                      h={40}
+                      hoverStyle={{
+                        bg: '$bgHover',
+                      }}
+                      pressStyle={{
+                        bg: '$bgActive',
+                      }}
+                      onPress={() => setIsOrderBookVisible((prev) => !prev)}
+                    />
+                  </Stack>
+                ) : null}
               </YStack>
 
-              {gtXl ? (
+              {gtXl && isOrderBookVisible ? (
                 <YStack
                   borderLeftWidth="$px"
                   borderLeftColor="$borderSubdued"
                   w={270}
+                  paddingLeft="$2"
                 >
                   <PerpOrderBook />
                 </YStack>


### PR DESCRIPTION
- Fix liquidation price calculation
- Add orderbook collapse/expand toggle button on desktop layout
- Create formData snapshot before reset to prevent size becoming 0 in edge cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a desktop toggle to show/hide the Order Book next to the chart.

- Bug Fixes
  - More accurate liquidation price estimates, especially for limit orders that execute at market.
  - More consistent TP/SL and leverage handling in order confirmations when overriding side.

- Style
  - Adjusted Order Book depth on web to show 11 levels per side (was 14).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->