### PR TITLE
fix: pre swap hw btn text opt 

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
+++ b/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
@@ -253,6 +253,26 @@ const PreSwapDialogContent = ({
     }
   }, [lastStep?.status, swapSteps.steps.length]);
 
+  const actionBtnTest = useMemo(() => {
+    if (preSwapData?.isHWAndExBatchTransfer) {
+      return intl.formatMessage({
+        id: quoteResult?.allowanceResult?.shouldResetApprove
+          ? ETranslations.swap_review_confirm_3_on_device
+          : ETranslations.swap_review_confirm_2_on_device,
+      });
+    }
+    return intl.formatMessage({
+      id: isHwWallet
+        ? ETranslations.global_confirm_on_device
+        : ETranslations.global_confirm,
+    });
+  }, [
+    intl,
+    isHwWallet,
+    preSwapData?.isHWAndExBatchTransfer,
+    quoteResult?.allowanceResult?.shouldResetApprove,
+  ]);
+
   return (
     <HeightTransition initialHeight={355}>
       {showResultContent && swapSteps.steps.length > 0 ? (
@@ -342,35 +362,18 @@ const PreSwapDialogContent = ({
                 }}
               />
               {/* Primary button */}
-              <YStack gap="$2">
-                {preSwapData?.isHWAndExBatchTransfer ? (
-                  <XStack gap="$1" alignItems="center">
-                    <SizableText size="$bodyMd">
-                      {intl.formatMessage({
-                        id: quoteResult?.allowanceResult?.shouldResetApprove
-                          ? ETranslations.swap_review_confirm_3_on_device
-                          : ETranslations.swap_review_confirm_2_on_device,
-                      })}
-                    </SizableText>
-                  </XStack>
-                ) : null}
-                <Button
-                  variant="primary"
-                  onPress={onConfirm}
-                  size="medium"
-                  disabled={
-                    swapSteps.preSwapData.estimateNetworkFeeLoading ||
-                    swapSteps.preSwapData.swapBuildLoading ||
-                    swapSteps.preSwapData.stepBeforeActionsLoading
-                  }
-                >
-                  {intl.formatMessage({
-                    id: isHwWallet
-                      ? ETranslations.global_confirm_on_device
-                      : ETranslations.global_confirm,
-                  })}
-                </Button>
-              </YStack>
+              <Button
+                variant="primary"
+                onPress={onConfirm}
+                size="medium"
+                disabled={
+                  swapSteps.preSwapData.estimateNetworkFeeLoading ||
+                  swapSteps.preSwapData.swapBuildLoading ||
+                  swapSteps.preSwapData.stepBeforeActionsLoading
+                }
+              >
+                {actionBtnTest}
+              </Button>
             </YStack>
           ) : (
             <PreSwapStep steps={swapSteps.steps} onRetry={onConfirm} />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the swap dialog action button to display context-aware labels based on wallet type and transaction state, enhancing clarity and consistency during the swap process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->