### PR TITLE
feat: support Perp action in extension side panel(OK-44473)

### DIFF
--- a/packages/kit/src/views/Home/components/WalletActions/index.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/index.tsx
@@ -229,7 +229,8 @@ function WalletActions({ ...rest }: IXStackProps) {
           <WalletActionReceive key="receive" customization={customization} />
         );
       case 'swap':
-        return platformEnv.isExtensionUiPopup ? (
+        return platformEnv.isExtensionUiPopup ||
+          platformEnv.isExtensionUiSidePanel ? (
           <WalletActionPerp key="perp" customization={customization} />
         ) : (
           <WalletActionSwap key="swap" customization={customization} />


### PR DESCRIPTION
Updated WalletActions to render WalletActionPerp for the swap action when in either the extension popup or side panel environments, improving UI consistency across extension views.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Perp trading action is now accessible in the side-panel extension interface, in addition to the existing popup view. This enhancement ensures broader access to trading functionality across different wallet interface configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->