### PR TITLE
fix: add BNB support in earn utilities and update related mappings

### DIFF
--- a/packages/kit/src/views/Earn/earnUtils.ts
+++ b/packages/kit/src/views/Earn/earnUtils.ts
@@ -18,6 +18,7 @@ const NetworkNameToIdMap: Record<string, string> = {
   aptos: getNetworkIdsMap().apt,
   cosmos: getNetworkIdsMap().cosmoshub,
   sbtc: getNetworkIdsMap().sbtc,
+  bsc: getNetworkIdsMap().bsc,
 };
 
 const NetworkIdToNameMap: Record<string, string> = Object.fromEntries(

--- a/packages/kit/src/views/Staking/components/OptionList/index.tsx
+++ b/packages/kit/src/views/Staking/components/OptionList/index.tsx
@@ -244,6 +244,7 @@ export const OptionList = ({
     <OptionListContext.Provider value={ctx}>
       <Stack>
         <ListView
+          useFlashList
           estimatedItemSize="$5"
           data={items}
           renderItem={renderItem}

--- a/packages/kit/src/views/Staking/pages/Withdraw/index.tsx
+++ b/packages/kit/src/views/Staking/pages/Withdraw/index.tsx
@@ -126,7 +126,7 @@ const WithdrawPage = () => {
       provider: providerName,
       symbol: tokenSymbol,
       action: 'unstake',
-      amount: earnUtils.isMomentumProvider({ providerName }) ? balance : '1',
+      amount: balance ?? '1',
       txId:
         providerName.toLowerCase() === EEarnProviderEnum.Babylon.toLowerCase()
           ? identity

--- a/packages/shared/types/earn/earnProvider.constants.ts
+++ b/packages/shared/types/earn/earnProvider.constants.ts
@@ -58,6 +58,16 @@ const earnTradeDefaultSetSui = {
   'networkLogoURI': 'https://uni.onekey-asset.com/static/chain/sui.png',
 };
 
+const earnTradeDefaultSetBNB = {
+  'networkId': 'evm--56',
+  'contractAddress': '',
+  'name': 'BNB',
+  'symbol': 'BNB',
+  'decimals': 18,
+  'isNative': true,
+  'networkLogoURI': 'https://uni.onekey-asset.com/static/chain/bsc.png',
+};
+
 export const isSupportStaking = (symbol: string) =>
   [
     'BTC',
@@ -83,6 +93,7 @@ export const earnMainnetNetworkIds = [
   getNetworkIdsMap().sol,
   getNetworkIdsMap().btc,
   getNetworkIdsMap().sui,
+  getNetworkIdsMap().bsc,
 ];
 
 export function normalizeToEarnSymbol(
@@ -180,6 +191,10 @@ export function getImportFromToken({
       importFromToken = earnTradeDefaultSetSui;
       swapTabSwitchType = ESwapTabSwitchType.SWAP;
       break;
+    case networkIdsMap.bsc:
+      importFromToken = earnTradeDefaultSetBNB;
+      swapTabSwitchType = ESwapTabSwitchType.SWAP;
+      break;
     default:
       break;
   }
@@ -205,7 +220,7 @@ export function getSymbolSupportedNetworks(): Record<
     'ATOM': [networkIdsMap.cosmoshub],
     'POL': [networkIdsMap.eth],
     'USDC': [networkIdsMap.eth, networkIdsMap.sui],
-    'USDT': [networkIdsMap.eth],
+    'USDT': [networkIdsMap.eth, networkIdsMap.bsc],
     'DAI': [networkIdsMap.eth],
     'WETH': [networkIdsMap.eth],
     'cbBTC': [networkIdsMap.eth],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Binance Smart Chain (BSC) network support to the Earn feature
  * USDT and BN(B) tokens are now available for trading on BSC within Earn functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->