### PR TITLE
feat: preload all tabs when startup on Desktop/Web/Ext 

### DIFF
--- a/packages/kit/src/routes/Tab/Navigator.tsx
+++ b/packages/kit/src/routes/Tab/Navigator.tsx
@@ -1,5 +1,6 @@
-import { useContext, useMemo } from 'react';
+import { useContext, useEffect, useMemo } from 'react';
 
+import { useNavigation } from '@react-navigation/native';
 import { noop } from 'lodash';
 
 import {
@@ -10,11 +11,22 @@ import {
 } from '@onekeyhq/components';
 import { TabFreezeOnBlurContext } from '@onekeyhq/kit/src/provider/Container/TabFreezeOnBlurContainer';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import type { ETabRoutes } from '@onekeyhq/shared/src/routes';
+import {
+  ERootRoutes,
+  ETabDiscoveryRoutes,
+  ETabEarnRoutes,
+  ETabHomeRoutes,
+  ETabMarketRoutes,
+  ETabRoutes,
+  ETabSwapRoutes,
+} from '@onekeyhq/shared/src/routes';
 
 import { useRouteIsFocused } from '../../hooks/useRouteIsFocused';
+import { whenAppUnlocked } from '../../utils/passwordUtils';
 
 import { tabExtraConfig, useTabRouterConfig } from './router';
+
+import type { NavigationProp } from '@react-navigation/native';
 
 // prevent pushModal from using unreleased Navigation instances during iOS modal animation by temporary exclusion,
 const useIsIOSTabNavigatorFocused =
@@ -25,12 +37,76 @@ const useIsIOSTabNavigatorFocused =
       }
     : () => true;
 
+const preloadTab = (
+  navigation: NavigationProp<any>,
+  route: string,
+  screen: string,
+  timeout: number,
+) => {
+  setTimeout(() => {
+    navigation.preload(ERootRoutes.Main, {
+      screen: route,
+      params: {
+        screen,
+      },
+    });
+  }, timeout);
+};
+
+const preloadTabs = (navigation: NavigationProp<any>) => {
+  let timeout = 100;
+  const gap = 150;
+  preloadTab(
+    navigation,
+    ETabRoutes.Market,
+    ETabMarketRoutes.TabMarket,
+    timeout,
+  );
+  preloadTab(
+    navigation,
+    ETabRoutes.Earn,
+    ETabEarnRoutes.EarnHome,
+    (timeout += gap),
+  );
+  preloadTab(
+    navigation,
+    ETabRoutes.Swap,
+    ETabSwapRoutes.TabSwap,
+    (timeout += gap),
+  );
+  preloadTab(navigation, ETabRoutes.Perp, ETabRoutes.Perp, (timeout += gap));
+  preloadTab(
+    navigation,
+    ETabRoutes.Discovery,
+    ETabDiscoveryRoutes.TabDiscovery,
+    (timeout += gap),
+  );
+  preloadTab(
+    navigation,
+    ETabRoutes.Home,
+    ETabHomeRoutes.TabHome,
+    (timeout += 2500),
+  );
+};
+
+const usePreloadTabs = platformEnv.isNative
+  ? () => {}
+  : () => {
+      const navigation = useNavigation();
+      useEffect(() => {
+        void whenAppUnlocked().then(() => {
+          preloadTabs(navigation as NavigationProp<any>);
+        });
+      }, [navigation]);
+    };
+
 export function TabNavigator() {
   const { freezeOnBlur } = useContext(TabFreezeOnBlurContext);
   const routerConfigParams = useMemo(() => ({ freezeOnBlur }), [freezeOnBlur]);
   const config = useTabRouterConfig(routerConfigParams);
   const isShowWebTabBar = platformEnv.isDesktop || platformEnv.isNativeIOS;
   const isFocused = useIsIOSTabNavigatorFocused();
+  usePreloadTabs();
   return (
     <>
       <TabStackNavigator<ETabRoutes>

--- a/packages/kit/src/routes/Tab/Navigator.tsx
+++ b/packages/kit/src/routes/Tab/Navigator.tsx
@@ -94,8 +94,13 @@ const usePreloadTabs = platformEnv.isNative
   : () => {
       const navigation = useNavigation();
       useEffect(() => {
-        void whenAppUnlocked().then(() => {
-          preloadTabs(navigation as NavigationProp<any>);
+        void Promise.race([
+          new Promise<void>((resolve) => setTimeout(resolve, 1200)),
+          whenAppUnlocked(),
+        ]).then(() => {
+          setTimeout(() => {
+            preloadTabs(navigation as NavigationProp<any>);
+          });
         });
       }, [navigation]);
     };

--- a/packages/kit/src/routes/Tab/Navigator.tsx
+++ b/packages/kit/src/routes/Tab/Navigator.tsx
@@ -94,13 +94,12 @@ const usePreloadTabs = platformEnv.isNative
   : () => {
       const navigation = useNavigation();
       useEffect(() => {
-        void Promise.race([
-          new Promise<void>((resolve) => setTimeout(resolve, 1200)),
-          whenAppUnlocked(),
-        ]).then(() => {
-          setTimeout(() => {
-            preloadTabs(navigation as NavigationProp<any>);
-          });
+        setTimeout(async () => {
+          await Promise.race([
+            new Promise<void>((resolve) => setTimeout(resolve, 1200)),
+            whenAppUnlocked(),
+          ]);
+          preloadTabs(navigation as NavigationProp<any>);
         });
       }, [navigation]);
     };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Added tab preloading to improve responsiveness when switching tabs, especially on web/desktop (non-native) platforms.
  * Preloads are staggered and delayed to reduce startup impact and make screens appear faster.

* **Behavior**
  * Preloading now waits until the app is unlocked (or a short timeout) to avoid background work before user access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->