### PR TITLE
fix: remove lazy loading for ProviderApiPrivate to fix native webview issues

### DIFF
--- a/development/spellCheckerSkipWords.js
+++ b/development/spellCheckerSkipWords.js
@@ -13,6 +13,7 @@ module.exports = [
   '0xf7ad23226db5c1c00ca0ca1468fd49c8f8bbc1489bc1c382de5adc557a69c229',
   '0xffffffffffffffffn',
   'reown',
+  'getters',
   '0xxxxxxx',
   'nktkas',
   'bbo',

--- a/packages/kit-bg/src/providers/backgroundProviders.ts
+++ b/packages/kit-bg/src/providers/backgroundProviders.ts
@@ -1,5 +1,7 @@
 import { IInjectedProviderNames } from '@onekeyfe/cross-inpage-provider-types';
 
+import ProviderApiPrivate from './ProviderApiPrivate';
+
 import type ProviderApiBase from './ProviderApiBase';
 import type {
   IBackgroundApi,
@@ -11,20 +13,25 @@ function createBackgroundProviders({
 }: {
   backgroundApi: IBackgroundApiBridge | IBackgroundApi;
 }) {
-  const backgroundProviders: Record<string, ProviderApiBase> = {};
+  const backgroundProviders: Record<string, ProviderApiBase> = {
+    [IInjectedProviderNames.$private]: new ProviderApiPrivate({
+      backgroundApi,
+    }),
+  };
+
+  // Object.defineProperty(backgroundProviders, IInjectedProviderNames.$private, {
+  //   get() {
+  //     const ProviderApiPrivate = (
+  //       require('./ProviderApiPrivate') as unknown as typeof import('./ProviderApiPrivate')
+  //     ).default;
+  //     const value = new ProviderApiPrivate({ backgroundApi });
+  //     Object.defineProperty(this, IInjectedProviderNames.$private, { value });
+  //     return value;
+  //   },
+  //   configurable: true,
+  // });
 
   // Lazy load providers using getters
-  Object.defineProperty(backgroundProviders, IInjectedProviderNames.$private, {
-    get() {
-      const ProviderApiPrivate = (
-        require('./ProviderApiPrivate') as unknown as typeof import('./ProviderApiPrivate')
-      ).default;
-      const value = new ProviderApiPrivate({ backgroundApi });
-      Object.defineProperty(this, IInjectedProviderNames.$private, { value });
-      return value;
-    },
-    configurable: true,
-  });
 
   Object.defineProperty(backgroundProviders, IInjectedProviderNames.ethereum, {
     get() {


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated spell checker configuration.

* **Refactor**
  * Modified background provider initialization handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Removed lazy loading pattern for `ProviderApiPrivate` in background providers
- Changed from `Object.defineProperty` getter pattern to direct import and instantiation
- Added 'getters' to spell checker skip words

This fix resolves issues where `ProviderApiPrivate` was not being properly initialized in native webview contexts due to the lazy loading pattern.

## Test plan
- [ ] Verify native webview functionality works correctly on iOS
- [ ] Verify native webview functionality works correctly on Android  
- [ ] Test that ProviderApiPrivate is properly initialized and accessible
- [ ] Run existing provider-related tests
- [ ] Verify no regression in desktop/web/extension platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)