### PR TITLE
fix: fix duplicate Portal rendering when using navigation.preload on Web

### DIFF
--- a/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.tsx
@@ -90,39 +90,43 @@ export function TabStackNavigator<RouteName extends string>({
 
   const tabBarPosition = useTabBarPosition();
 
-  const tabScreens = tabComponents.map(({ name, children, ...options }) => (
-    <Tab.Screen
-      key={name}
-      name={name}
-      options={{
-        ...options,
-        tabBarLabel: intl.formatMessage({ id: options.translationId }),
-        tabBarPosition,
-        // @ts-expect-error Custom property for tab bar handling
-        tabbarOnPress: options.tabbarOnPress,
-      }}
-    >
-      {children}
-    </Tab.Screen>
-  ));
-
-  if (extraConfig) {
-    const children = () => (
-      <TabSubStackNavigatorMemo config={extraConfig.children} />
-    );
-    tabScreens.push(
+  const tabScreens = useMemo(() => {
+    const screens = tabComponents.map(({ name, children, ...options }) => (
       <Tab.Screen
-        key={extraConfig.name}
-        name={extraConfig.name}
+        key={name}
+        name={name}
         options={{
-          freezeOnBlur: true,
+          ...options,
+          tabBarLabel: intl.formatMessage({ id: options.translationId }),
           tabBarPosition,
+          // @ts-expect-error Custom property for tab bar handling
+          tabbarOnPress: options.tabbarOnPress,
         }}
       >
         {children}
-      </Tab.Screen>,
-    );
-  }
+      </Tab.Screen>
+    ));
+
+    if (extraConfig) {
+      const children = () => (
+        <TabSubStackNavigatorMemo config={extraConfig.children} />
+      );
+      screens.push(
+        <Tab.Screen
+          key={extraConfig.name}
+          name={extraConfig.name}
+          options={{
+            freezeOnBlur: true,
+            tabBarPosition,
+          }}
+        >
+          {children}
+        </Tab.Screen>,
+      );
+    }
+    return screens;
+  }, [extraConfig, intl, tabBarPosition, tabComponents]);
+
   return (
     <Tab.Navigator
       tabBar={tabBarCallback}

--- a/packages/kit/src/routes/Tab/Navigator.tsx
+++ b/packages/kit/src/routes/Tab/Navigator.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo } from 'react';
+import { useContext, useEffect, useMemo, useRef } from 'react';
 
 import { useNavigation } from '@react-navigation/native';
 import { noop } from 'lodash';
@@ -89,21 +89,36 @@ const preloadTabs = (navigation: NavigationProp<any>) => {
   );
 };
 
-const usePreloadTabs =
-  platformEnv.isDev || platformEnv.isNative
-    ? () => {}
-    : () => {
-        const navigation = useNavigation();
-        useEffect(() => {
-          setTimeout(async () => {
-            await Promise.race([
-              new Promise<void>((resolve) => setTimeout(resolve, 1200)),
-              whenAppUnlocked(),
-            ]);
-            preloadTabs(navigation as NavigationProp<any>);
-          });
-        }, [navigation]);
-      };
+const usePreloadTabs = platformEnv.isNative
+  ? () => {}
+  : () => {
+      const navigation = useNavigation();
+      useEffect(() => {
+        setTimeout(async () => {
+          await Promise.race([
+            new Promise<void>((resolve) => setTimeout(resolve, 1200)),
+            whenAppUnlocked(),
+          ]);
+          preloadTabs(navigation as NavigationProp<any>);
+        });
+      }, [navigation]);
+    };
+
+// When using navigation.preload, the web layer will re-render the interface with sidebar,
+// which may cause duplicate Portal rendering. Use isRendered to prevent duplicate Portal rendering.
+let isRendered = false;
+function InPageTabContainer() {
+  const isRenderedRef = useRef(isRendered);
+  if (isRenderedRef.current) {
+    return null;
+  }
+  isRendered = true;
+  return (
+    <Portal.Container
+      name={EPortalContainerConstantName.IN_PAGE_TAB_CONTAINER}
+    />
+  );
+}
 
 export function TabNavigator() {
   const { freezeOnBlur } = useContext(TabFreezeOnBlurContext);
@@ -118,9 +133,7 @@ export function TabNavigator() {
         config={config}
         extraConfig={isShowWebTabBar ? tabExtraConfig : undefined}
       />
-      <Portal.Container
-        name={EPortalContainerConstantName.IN_PAGE_TAB_CONTAINER}
-      />
+      <InPageTabContainer />
       {!isFocused ? (
         <Stack
           position="absolute"

--- a/packages/kit/src/routes/Tab/Navigator.tsx
+++ b/packages/kit/src/routes/Tab/Navigator.tsx
@@ -91,20 +91,21 @@ const preloadTabs = (navigation: NavigationProp<any>) => {
   );
 };
 
-const usePreloadTabs = platformEnv.isNative
-  ? () => {}
-  : () => {
-      const navigation = useNavigation();
-      useEffect(() => {
-        setTimeout(async () => {
-          await Promise.race([
-            new Promise<void>((resolve) => setTimeout(resolve, 1200)),
-            whenAppUnlocked(),
-          ]);
-          preloadTabs(navigation as NavigationProp<any>);
-        });
-      }, [navigation]);
-    };
+const usePreloadTabs =
+  platformEnv.isDev || platformEnv.isNative
+    ? () => {}
+    : () => {
+        const navigation = useNavigation();
+        useEffect(() => {
+          setTimeout(async () => {
+            await Promise.race([
+              new Promise<void>((resolve) => setTimeout(resolve, 1200)),
+              whenAppUnlocked(),
+            ]);
+            preloadTabs(navigation as NavigationProp<any>);
+          });
+        }, [navigation]);
+      };
 
 // When using navigation.preload, the web layer will re-render the interface with sidebar,
 // which may cause duplicate Portal rendering. Use isRendered to prevent duplicate Portal rendering.

--- a/packages/kit/src/routes/Tab/Navigator.tsx
+++ b/packages/kit/src/routes/Tab/Navigator.tsx
@@ -139,8 +139,8 @@ export function TabNavigator() {
         config={config}
         extraConfig={isShowWebTabBar ? tabExtraConfig : undefined}
       />
-      <InPageTabContainer />
       {platformEnv.isWeb && gtMd ? <Footer /> : null}
+      <InPageTabContainer />
       {!isFocused ? (
         <Stack
           position="absolute"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized tab navigation rendering logic for improved performance and stability.
  * Enhanced tab container handling to prevent rendering issues during navigation transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->