### PR TITLE
fix: only re-render list when tab focused in tab list OK-44807

### DIFF
--- a/packages/kit/src/components/TxHistoryListView/index.tsx
+++ b/packages/kit/src/components/TxHistoryListView/index.tsx
@@ -57,6 +57,7 @@ type IProps = {
   onPressHistory?: (history: IAccountHistoryTx) => void;
   initialized?: boolean;
   inTabList?: boolean;
+  isTabFocused?: boolean;
   contentContainerStyle?: IListViewProps<IAccountHistoryTx>['contentContainerStyle'];
   hideValue?: boolean;
   onRefresh?: () => void;
@@ -194,18 +195,35 @@ const ListFooterComponent = ({
 
 function TxHistoryListViewSectionHeader(
   props: IHistoryListSectionGroup & {
+    inTabList?: boolean;
+    isTabFocused?: boolean;
     index: number;
     recomputeLayout: () => void;
   },
 ) {
-  const { title, titleKey, data, index, recomputeLayout } = props;
+  const {
+    title,
+    titleKey,
+    data,
+    index,
+    recomputeLayout,
+    inTabList,
+    isTabFocused,
+  } = props;
   const intl = useIntl();
+  const recomputeLayoutRef = useRef(false);
   const titleText = title || intl.formatMessage({ id: titleKey }) || '';
 
   if (data[0] && data[0].decodedTx.status === EDecodedTxStatus.Pending) {
-    setTimeout(() => {
-      recomputeLayout();
-    }, 350);
+    if (
+      ((inTabList && isTabFocused) || !inTabList) &&
+      !recomputeLayoutRef.current
+    ) {
+      setTimeout(() => {
+        recomputeLayoutRef.current = true;
+        recomputeLayout();
+      }, 350);
+    }
     return (
       <XStack
         px="$5"
@@ -249,6 +267,7 @@ function BaseTxHistoryListView(props: IProps) {
     initialized,
     contentContainerStyle,
     inTabList = false,
+    isTabFocused,
     hideValue,
     listViewStyleProps,
     onRefresh,
@@ -322,9 +341,11 @@ function BaseTxHistoryListView(props: IProps) {
         titleKey={titleKey}
         data={tx}
         index={index}
+        inTabList={inTabList}
+        isTabFocused={isTabFocused}
       />
     ),
-    [recomputeLayout],
+    [recomputeLayout, inTabList, isTabFocused],
   );
 
   const resolvedContentContainerStyle = useStyle(

--- a/packages/kit/src/views/Home/pages/TxHistoryContainer.tsx
+++ b/packages/kit/src/views/Home/pages/TxHistoryContainer.tsx
@@ -398,6 +398,7 @@ function TxHistoryListContainer() {
 
   return (
     <TxHistoryListView
+      isTabFocused={isFocused}
       showIcon
       inTabList
       hideValue


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction history view responsiveness when switching between tabs.
  * Optimized pending transaction display rendering to reduce performance degradation and provide a smoother tab navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->