### PR TITLE
fix: handle device-token string display on iOS 13 && add Android implementation

### DIFF
--- a/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/LaunchOptionModule.java
+++ b/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/LaunchOptionModule.java
@@ -125,6 +125,11 @@ public class LaunchOptionModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void registerDeviceToken(Promise promise) {
+        promise.resolve(true);
+    }
+
+    @ReactMethod
     public void getStartupTime(Promise promise) {
         Long startupTime = getStartupTime();
         promise.resolve(startupTime != null ? startupTime.doubleValue() : 0.0);

--- a/apps/mobile/ios/OneKeyWallet/LaunchOptionsManager.m
+++ b/apps/mobile/ios/OneKeyWallet/LaunchOptionsManager.m
@@ -76,10 +76,13 @@ static LaunchOptionsManager *sharedInstance = nil;
     if (!deviceToken) {
         return @"";
     }
-    return [[[[deviceToken description]
-                         stringByReplacingOccurrencesOfString: @"<" withString: @""] 
-                        stringByReplacingOccurrencesOfString: @">" withString: @""] 
-                       stringByReplacingOccurrencesOfString: @" " withString: @""];
+    NSUInteger len = [deviceToken length];
+    char *chars = (char *)[deviceToken bytes];
+    NSMutableString *hexString = [[NSMutableString alloc] init];
+    for (NSUInteger i = 0; i < len; i ++) {
+        [hexString appendString:[NSString stringWithFormat:@"%0.2hhx", chars[i]]];
+    }
+    return hexString;
 }
 
 // MARK: - RCTBridgeModule

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/DeviceToken/DeviceToken.native.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/DeviceToken/DeviceToken.native.tsx
@@ -10,7 +10,6 @@ export function DeviceToken() {
     void LaunchOptionsManager.getDeviceToken().then((token) => {
       if (token) {
         setDeviceToken(token);
-        void LaunchOptionsManager.registerDeviceToken();
       }
     });
   }, []);
@@ -18,6 +17,9 @@ export function DeviceToken() {
     <SectionPressItem
       icon="CodeOutline"
       copyable
+      onPress={() => {
+        void LaunchOptionsManager.registerDeviceToken();
+      }}
       title={deviceToken}
       subtitle="iOS DeviceToken"
     />

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/SectionPressItem.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/SectionPressItem.tsx
@@ -23,7 +23,10 @@ export function SectionPressItem({
   const { copyText } = useClipboard();
   const handleCopy = useCallback(() => {
     copyText(title);
-  }, [copyText, title]);
+    setTimeout(() => {
+      onPress?.();
+    });
+  }, [copyText, title, onPress]);
   return (
     <ListItem
       drillIn


### PR DESCRIPTION
Added registerDeviceToken method to Android module and improved device token formatting on iOS. Refactored DeviceToken component to trigger device token registration on press instead of on mount, and updated SectionPressItem to call onPress after copying text. Renamed DeviceToken.ios.tsx to DeviceToken.native.tsx for cross-platform support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Device token registration is now user-triggered through manual button interaction instead of occurring automatically, providing greater control over registration timing
  * Enhanced device token encoding for improved data handling and compatibility
  * Optimized copy-paste interaction with refined timing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->