### PR TITLE
fix: abnormal EVM network hardware verification address display OK-45074

### DIFF
--- a/packages/kit-bg/src/vaults/impls/evm/KeyringHardware.ts
+++ b/packages/kit-bg/src/vaults/impls/evm/KeyringHardware.ts
@@ -284,10 +284,13 @@ export class KeyringHardware extends KeyringHardwareBase {
   override async buildHwAllNetworkPrepareAccountsParams(
     params: IBuildHwAllNetworkPrepareAccountsParams,
   ): Promise<AllNetworkAddressParams | undefined> {
+    const chainId = await this.getNetworkChainId();
+
     return {
       network: this.hwSdkNetwork,
       path: params.path,
       showOnOneKey: false,
+      chainName: chainId,
     };
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved hardware wallet account preparation by enhancing network chain identifier handling during account setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->