### PR TITLE
fix: update DesktopLeftSideBar hover and tooltip behavior

### DIFF
--- a/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
@@ -447,7 +447,8 @@ export function DesktopLeftSideBar({
       ...prev,
       isCollapsed: !prev.isCollapsed,
     }));
-  }, [setAppSideBarStatus]);
+    setIsHovering(false);
+  }, [setAppSideBarStatus, setIsHovering]);
 
   useShortcuts(EShortcutEvents.SideBar, handleToggleCollapse);
 
@@ -531,10 +532,10 @@ export function DesktopLeftSideBar({
           setIsHovering(false);
         }}
         zIndex={1000}
-        right={-3}
+        right={-5}
         top={0}
         bottom={0}
-        width={6}
+        width={10}
         pb="$20"
         ai="center"
         jc="center"
@@ -584,7 +585,9 @@ export function DesktopLeftSideBar({
               renderContent={
                 <Tooltip.Text shortcutKey={EShortcutEvents.SideBar}>
                   {intl.formatMessage({
-                    id: ETranslations.shortcut_expand_sidebar,
+                    id: isCollapse
+                      ? ETranslations.shortcut_expand_sidebar
+                      : ETranslations.shortcut_collapse_sidebar,
                   })}
                 </Tooltip.Text>
               }


### PR DESCRIPTION
- Adjusted hover state handling by adding setIsHovering to the dependency array.
- Modified sidebar positioning by changing right offset from -3 to -5 and width from 6 to 10.
- Updated tooltip text to reflect the current sidebar state (expand/collapse) based on isCollapse status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sidebar hover state handling to reset consistently when toggling.
  * Expanded the interactive hover area for improved accessibility on the sidebar control.
  * Updated contextual tooltips to display appropriate shortcuts based on sidebar state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->