### PR TITLE
feat: add account ledger history to perps trading OK-44845 Ok-45026

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -99,6 +99,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     currentSymbol: '',
     isConnected: false,
     l2BookOptions: undefined,
+    enableLedgerUpdates: false,
   };
 
   private _networkTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
@@ -160,6 +161,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       l2BookOptions,
       currentSymbol: activeAsset?.coin,
       currentUser: activeAccount?.accountAddress,
+      enableLedgerUpdates: this._currentState.enableLedgerUpdates,
     };
 
     const requiredSubSpecsMap = calculateRequiredSubscriptionsMap(params);
@@ -315,6 +317,15 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         refreshHook: Date.now(),
       });
     }
+  }
+
+  @backgroundMethod()
+  async enableLedgerUpdatesSubscription(): Promise<void> {
+    if (this._currentState.enableLedgerUpdates) {
+      return;
+    }
+    this._currentState.enableLedgerUpdates = true;
+    await this.updateSubscriptions();
   }
 
   @backgroundMethod()
@@ -505,6 +516,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         ESubscriptionType.ACTIVE_ASSET_DATA,
         ESubscriptionType.WEB_DATA2,
         ESubscriptionType.USER_FILLS,
+        ESubscriptionType.USER_NON_FUNDING_LEDGER_UPDATES,
       ];
       const removeAllSubscriptionHandlers = () => {
         allTypes.forEach((type) => {

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
@@ -5,6 +5,7 @@ import type {
   IEventActiveAssetDataParameters,
   IEventL2BookParameters,
   IEventUserFillsParameters,
+  IEventUserNonFundingLedgerUpdatesParameters,
   IEventWebData2Parameters,
   IHex,
   IPerpsSubscriptionParams,
@@ -35,6 +36,10 @@ export const SUBSCRIPTION_TYPE_INFO: {
     priority: 2,
   },
   [ESubscriptionType.USER_FILLS]: {
+    eventType: EPerpsSubscriptionCategory.ACCOUNT,
+    priority: 2,
+  },
+  [ESubscriptionType.USER_NON_FUNDING_LEDGER_UPDATES]: {
     eventType: EPerpsSubscriptionCategory.ACCOUNT,
     priority: 2,
   },
@@ -76,6 +81,7 @@ export interface ISubscriptionState {
   currentSymbol: string;
   isConnected: boolean;
   l2BookOptions?: IL2BookOptions | null;
+  enableLedgerUpdates?: boolean;
 }
 
 export interface ISubscriptionDiff {
@@ -178,6 +184,18 @@ export function calculateRequiredSubscriptions(
         params: userFillsParams,
       }),
     );
+
+    if (state.enableLedgerUpdates) {
+      const ledgerUpdatesParams: IEventUserNonFundingLedgerUpdatesParameters = {
+        user: state.currentUser,
+      };
+      specs.push(
+        buildSubscriptionSpec({
+          type: ESubscriptionType.USER_NON_FUNDING_LEDGER_UPDATES,
+          params: ledgerUpdatesParams,
+        }),
+      );
+    }
 
     if (state.currentSymbol) {
       const activeAssetDataParams: IEventActiveAssetDataParameters = {

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/atoms.ts
@@ -167,6 +167,18 @@ export const {
   }, {} as { [coin: string]: number[] });
 });
 
+export type IPerpsLedgerUpdatesAtom = {
+  accountAddress: string | undefined;
+  updates: HL.IUserNonFundingLedgerUpdate[];
+  isSubscribed: boolean;
+};
+export const { atom: perpsLedgerUpdatesAtom, use: usePerpsLedgerUpdatesAtom } =
+  contextAtom<IPerpsLedgerUpdatesAtom>({
+    accountAddress: undefined,
+    updates: [],
+    isSubscribed: false,
+  });
+
 export interface ITradingFormEnv {
   markPrice?: string;
   availableToTrade?: Array<number | string>;

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/index.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/index.ts
@@ -12,6 +12,7 @@ export {
   usePerpsActivePositionAtom,
   useSubscriptionActiveAtom,
   usePerpsAllAssetCtxsAtom,
+  usePerpsLedgerUpdatesAtom,
 } from './atoms';
 
 export type { ITradingFormData } from './atoms';

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/AccountRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/AccountRow.tsx
@@ -1,0 +1,390 @@
+import { memo, useMemo } from 'react';
+
+import BigNumber from 'bignumber.js';
+
+import { Icon, SizableText, XStack, YStack } from '@onekeyhq/components';
+import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
+import { usePerpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { formatTime } from '@onekeyhq/shared/src/utils/dateUtils';
+import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import type { IUserNonFundingLedgerUpdate } from '@onekeyhq/shared/types/hyperliquid/sdk';
+
+import { calcCellAlign, getColumnStyle } from '../utils';
+
+import type { IColumnConfig } from '../List/CommonTableListView';
+
+const balanceFormatter: INumberFormatProps = {
+  formatter: 'balance',
+  formatterOptions: {
+    currency: '$',
+  },
+};
+
+interface IAccountRowProps {
+  update: IUserNonFundingLedgerUpdate;
+  cellMinWidth: number;
+  columnConfigs: IColumnConfig[];
+  isMobile?: boolean;
+  index: number;
+}
+
+// Type display config map - TODO: Replace with i18n
+const TYPE_CONFIG = new Map([
+  [
+    'deposit',
+    { text: 'Deposit', icon: 'ArrowBottomOutline', isIncrease: true },
+  ],
+  [
+    'withdraw',
+    { text: 'Withdraw', icon: 'ArrowTopOutline', isIncrease: false },
+  ],
+  [
+    'internalTransferIn',
+    { text: 'Transfer In', icon: 'ArrowBottomOutline', isIncrease: true },
+  ],
+  [
+    'internalTransferOut',
+    { text: 'Transfer Out', icon: 'ArrowTopOutline', isIncrease: false },
+  ],
+  [
+    'accountClassTransfer',
+    {
+      text: 'Account Transfer',
+      icon: 'ArrowsRightLeftOutline',
+      isIncrease: null,
+    },
+  ],
+  [
+    'rewardsClaim',
+    { text: 'Rewards Claim', icon: 'GiftOutline', isIncrease: true },
+  ],
+  [
+    'subAccountTransferIn',
+    {
+      text: 'Sub-account Transfer In',
+      icon: 'FolderUserOutline',
+      isIncrease: true,
+    },
+  ],
+  [
+    'subAccountTransferOut',
+    {
+      text: 'Sub-account Transfer Out',
+      icon: 'FolderUserOutline',
+      isIncrease: false,
+    },
+  ],
+  [
+    'vaultDeposit',
+    { text: 'Vault Deposit', icon: 'BankOutline', isIncrease: false },
+  ],
+  [
+    'vaultWithdraw',
+    { text: 'Vault Withdraw', icon: 'BankOutline', isIncrease: true },
+  ],
+  [
+    'vaultCreate',
+    { text: 'Vault Create', icon: 'BankOutline', isIncrease: false },
+  ],
+  [
+    'vaultDistribution',
+    {
+      text: 'Vault Distribution',
+      icon: 'HandCoinsOutline',
+      isIncrease: true,
+    },
+  ],
+  [
+    'spotTransferIn',
+    { text: 'Spot Transfer In', icon: 'SendOutline', isIncrease: true },
+  ],
+  [
+    'spotTransferOut',
+    { text: 'Spot Transfer Out', icon: 'SendOutline', isIncrease: false },
+  ],
+  ['sendIn', { text: 'Send In', icon: 'SendOutline', isIncrease: true }],
+  ['sendOut', { text: 'Send Out', icon: 'SendOutline', isIncrease: false }],
+  [
+    'liquidation',
+    { text: 'Liquidation', icon: 'ClockAlertOutline', isIncrease: false },
+  ],
+]);
+
+const AccountRow = memo(
+  ({
+    update,
+    cellMinWidth,
+    columnConfigs,
+    isMobile,
+    index,
+  }: IAccountRowProps) => {
+    const [currentUser] = usePerpsActiveAccountAtom();
+
+    const { time, delta } = update;
+
+    // Determine display type (handle transfer direction for types with user/destination)
+    const displayType = useMemo(() => {
+      if (
+        delta.type === 'internalTransfer' ||
+        delta.type === 'subAccountTransfer' ||
+        delta.type === 'spotTransfer' ||
+        delta.type === 'send'
+      ) {
+        const isOut =
+          'user' in delta &&
+          currentUser?.accountAddress &&
+          delta.user.toLowerCase() === currentUser.accountAddress.toLowerCase();
+
+        if (delta.type === 'internalTransfer') {
+          return isOut ? 'internalTransferOut' : 'internalTransferIn';
+        }
+        if (delta.type === 'subAccountTransfer') {
+          return isOut ? 'subAccountTransferOut' : 'subAccountTransferIn';
+        }
+        if (delta.type === 'spotTransfer') {
+          return isOut ? 'spotTransferOut' : 'spotTransferIn';
+        }
+        if (delta.type === 'send') {
+          return isOut ? 'sendOut' : 'sendIn';
+        }
+      }
+      return delta.type;
+    }, [delta, currentUser?.accountAddress]);
+
+    const typeConfig = TYPE_CONFIG.get(displayType) || {
+      text: delta.type,
+      icon: 'QuestionMarkCircleOutline',
+      isIncrease: null,
+    };
+
+    const actionText = typeConfig.text;
+
+    const amount = useMemo(() => {
+      if (
+        (delta.type === 'spotTransfer' || delta.type === 'send') &&
+        'usdcValue' in delta
+      ) {
+        return delta.usdcValue;
+      }
+      if (
+        delta.type === 'vaultWithdraw' &&
+        'netWithdrawnUsd' in delta &&
+        delta.netWithdrawnUsd
+      ) {
+        return delta.netWithdrawnUsd;
+      }
+      if (
+        delta.type === 'vaultWithdraw' &&
+        'requestedUsd' in delta &&
+        delta.requestedUsd
+      ) {
+        return delta.requestedUsd;
+      }
+      if (delta.type === 'liquidation' && 'liquidatedNtlPos' in delta) {
+        return delta.liquidatedNtlPos;
+      }
+      if ('usdc' in delta) {
+        return delta.usdc;
+      }
+      if ('amount' in delta) {
+        return delta.amount;
+      }
+      return '0';
+    }, [delta]);
+
+    const fee = useMemo(() => {
+      if (delta.type === 'vaultWithdraw') {
+        const commission = 'commission' in delta ? Number(delta.commission) : 0;
+        const closingCost =
+          'closingCost' in delta ? Number(delta.closingCost) : 0;
+        const totalFee = commission + closingCost;
+        return totalFee > 0 ? String(totalFee) : null;
+      }
+      if ('fee' in delta && delta.fee) {
+        return delta.fee;
+      }
+      return null;
+    }, [delta]);
+
+    // Mobile: show total amount (including fee for withdrawals/transfers out)
+    const totalAmount = useMemo(() => {
+      if (isMobile && fee && typeConfig.isIncrease === false) {
+        return new BigNumber(amount).plus(fee).toFixed();
+      }
+      return amount;
+    }, [amount, fee, isMobile, typeConfig.isIncrease]);
+
+    const status = 'Completed';
+
+    const dateInfo = useMemo(() => {
+      const timeDate = new Date(time);
+      const date = formatTime(timeDate, {
+        formatTemplate: 'yyyy-LL-dd',
+      });
+      const timeStr = formatTime(timeDate, {
+        formatTemplate: 'HH:mm:ss',
+      });
+      return { date, time: timeStr };
+    }, [time]);
+
+    const iconColor = useMemo(() => {
+      if (typeConfig.isIncrease === true) return '$iconSuccess';
+      if (typeConfig.isIncrease === false) return '$iconCritical';
+      return '$icon';
+    }, [typeConfig.isIncrease]);
+
+    const textColor = useMemo(() => {
+      if (typeConfig.isIncrease === true) return '$textSuccess';
+      if (typeConfig.isIncrease === false) return '$textCritical';
+      return '$text';
+    }, [typeConfig.isIncrease]);
+
+    const signPrefix = useMemo(() => {
+      if (typeConfig.isIncrease === true) return '+ ';
+      if (typeConfig.isIncrease === false) return '- ';
+      return '';
+    }, [typeConfig.isIncrease]);
+
+    if (isMobile) {
+      return (
+        <ListItem
+          mx="$5"
+          my="$2"
+          p="$4"
+          backgroundColor="$bgSubdued"
+          flexDirection="row"
+          alignItems="center"
+          borderRadius="$3"
+          gap="$3"
+        >
+          <XStack
+            width="$10"
+            height="$10"
+            borderRadius="$full"
+            backgroundColor="$bgApp"
+            alignItems="center"
+            justifyContent="center"
+          >
+            <Icon name={typeConfig.icon as any} size="$6" color={iconColor} />
+          </XStack>
+          <YStack flex={1} gap="$1">
+            <XStack justifyContent="space-between" alignItems="center">
+              <SizableText size="$bodyLgMedium">{actionText}</SizableText>
+              <SizableText size="$bodyLgMedium" color={textColor}>
+                {signPrefix}
+                {numberFormat(totalAmount, balanceFormatter)}
+              </SizableText>
+            </XStack>
+            <XStack justifyContent="space-between" alignItems="center">
+              <SizableText size="$bodySm" color="$textSuccess">
+                {status}
+              </SizableText>
+              <SizableText size="$bodySm" color="$textSubdued">
+                {dateInfo.date} {dateInfo.time}
+              </SizableText>
+            </XStack>
+          </YStack>
+        </ListItem>
+      );
+    }
+
+    return (
+      <XStack
+        flex={1}
+        py="$1.5"
+        px="$3"
+        alignItems="center"
+        hoverStyle={{ bg: '$bgHover' }}
+        minWidth={cellMinWidth}
+        {...(index % 2 === 1 && {
+          backgroundColor: '$bgSubdued',
+        })}
+      >
+        {/* Time */}
+        <YStack
+          {...getColumnStyle(columnConfigs[0])}
+          justifyContent="center"
+          alignItems={calcCellAlign(columnConfigs[0].align)}
+          pl="$2"
+        >
+          <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
+            {dateInfo.date}
+          </SizableText>
+          <SizableText
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            size="$bodySm"
+            color="$textSubdued"
+          >
+            {dateInfo.time}
+          </SizableText>
+        </YStack>
+
+        {/* Status */}
+        <XStack
+          {...getColumnStyle(columnConfigs[1])}
+          justifyContent={calcCellAlign(columnConfigs[1].align)}
+          alignItems="center"
+        >
+          <SizableText
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            size="$bodySm"
+            color="$textSuccess"
+          >
+            {status}
+          </SizableText>
+        </XStack>
+
+        {/* Action */}
+        <XStack
+          {...getColumnStyle(columnConfigs[2])}
+          justifyContent={calcCellAlign(columnConfigs[2].align)}
+          alignItems="center"
+        >
+          <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
+            {actionText}
+          </SizableText>
+        </XStack>
+
+        {/* Amount */}
+        <XStack
+          {...getColumnStyle(columnConfigs[3])}
+          justifyContent={calcCellAlign(columnConfigs[3].align)}
+          alignItems="center"
+        >
+          <SizableText
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            size="$bodySm"
+            color={textColor}
+          >
+            {signPrefix}
+            {numberFormat(amount, balanceFormatter)}
+          </SizableText>
+        </XStack>
+
+        {/* Fee */}
+        <XStack
+          {...getColumnStyle(columnConfigs[4])}
+          justifyContent={calcCellAlign(columnConfigs[4].align)}
+          alignItems="center"
+        >
+          <SizableText
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            size="$bodySm"
+            color={fee ? '$textCritical' : undefined}
+          >
+            {fee ? numberFormat(fee, balanceFormatter) : '-'}
+          </SizableText>
+        </XStack>
+      </XStack>
+    );
+  },
+);
+
+AccountRow.displayName = 'AccountRow';
+
+export { AccountRow };

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpAccountList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpAccountList.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { noop } from 'lodash';
+import { useIntl } from 'react-intl';
+
+import type { IDebugRenderTrackerProps } from '@onekeyhq/components';
+import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import { usePerpsLedgerUpdatesAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
+import { usePerpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import type { IUserNonFundingLedgerUpdate } from '@onekeyhq/shared/types/hyperliquid/sdk';
+
+import { AccountRow } from '../Components/AccountRow';
+
+import { CommonTableListView, type IColumnConfig } from './CommonTableListView';
+
+interface IPerpAccountListProps {
+  isMobile?: boolean;
+  useTabsList?: boolean;
+  disableListScroll?: boolean;
+}
+
+function PerpAccountList({
+  isMobile,
+  useTabsList,
+  disableListScroll,
+}: IPerpAccountListProps) {
+  const intl = useIntl();
+  const [{ updates, isSubscribed }] = usePerpsLedgerUpdatesAtom();
+  const [currentUser] = usePerpsActiveAccountAtom();
+  const actions = useHyperliquidActions();
+  const [currentListPage, setCurrentListPage] = useState(1);
+
+  useEffect(() => {
+    noop(currentUser?.accountAddress);
+    setCurrentListPage(1);
+  }, [currentUser?.accountAddress]);
+
+  const columnsConfig: IColumnConfig[] = useMemo(
+    () => [
+      {
+        key: 'time',
+        title: intl.formatMessage({ id: ETranslations.global_time }),
+        minWidth: 140,
+        align: 'left',
+      },
+      {
+        key: 'status',
+        title: intl.formatMessage({ id: ETranslations.global_status }),
+        minWidth: 120,
+        align: 'left',
+      },
+      {
+        key: 'action',
+        title: 'Action',
+        minWidth: 120,
+        align: 'left',
+        flex: 1,
+      },
+      {
+        key: 'amount',
+        title: 'Amount',
+        minWidth: 140,
+        align: 'left',
+        flex: 1,
+      },
+      {
+        key: 'fee',
+        title: intl.formatMessage({ id: ETranslations.fee_fee }),
+        minWidth: 100,
+        align: 'right',
+        flex: 1,
+      },
+    ],
+    [intl],
+  );
+
+  const totalMinWidth = useMemo(
+    () =>
+      columnsConfig.reduce(
+        (sum, col) => sum + (col.width || col.minWidth || 0),
+        0,
+      ),
+    [columnsConfig],
+  );
+
+  const renderAccountRow = (
+    item: IUserNonFundingLedgerUpdate,
+    index: number,
+  ) => {
+    return (
+      <AccountRow
+        update={item}
+        isMobile={isMobile}
+        cellMinWidth={totalMinWidth}
+        columnConfigs={columnsConfig}
+        index={index}
+      />
+    );
+  };
+
+  return (
+    <CommonTableListView
+      onPullToRefresh={async () => {
+        await actions.current.refreshAllPerpsData();
+      }}
+      listViewDebugRenderTrackerProps={useMemo(
+        (): IDebugRenderTrackerProps => ({
+          name: 'PerpAccountList',
+          position: 'top-left',
+        }),
+        [],
+      )}
+      useTabsList={useTabsList}
+      disableListScroll={disableListScroll}
+      currentListPage={currentListPage}
+      setCurrentListPage={setCurrentListPage}
+      enablePagination
+      paginationToBottom={isMobile}
+      columns={columnsConfig}
+      minTableWidth={totalMinWidth}
+      data={updates}
+      isMobile={isMobile}
+      renderRow={renderAccountRow}
+      listLoading={!isSubscribed}
+      emptyMessage={intl.formatMessage({
+        id: ETranslations.perp_trade_history_empty,
+      })}
+      emptySubMessage={intl.formatMessage({
+        id: ETranslations.perp_trade_history_empty_desc,
+      })}
+    />
+  );
+}
+
+export { PerpAccountList };

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpOrderInfoPanel.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpOrderInfoPanel.tsx
@@ -9,20 +9,23 @@ import {
   Tabs,
   XStack,
 } from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import {
   usePerpsActiveOpenOrdersLengthAtom,
   usePerpsActivePositionLengthAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
+import { PerpAccountList } from './List/PerpAccountList';
 import { PerpOpenOrdersList } from './List/PerpOpenOrdersList';
 import { PerpPositionsList } from './List/PerpPositionsList';
 import { PerpTradesHistoryList } from './List/PerpTradesHistoryList';
 
-const tabNameToTranslationKey = {
+const tabNameToTranslationKey: Record<string, string> = {
   'Positions': ETranslations.perp_position_title,
   'Open Orders': ETranslations.perp_open_orders_title,
   'Trades History': ETranslations.perp_trades_history_title,
+  'Account': 'Account',
 };
 
 function TabBarItem({
@@ -52,6 +55,14 @@ function TabBarItem({
     return '';
   }, [positionsLength, openOrdersLength, name]);
 
+  const translationKey = tabNameToTranslationKey[name];
+  let tabTitle = translationKey;
+  if (translationKey.startsWith('perp.')) {
+    tabTitle = intl.formatMessage({
+      id: translationKey as ETranslations,
+    });
+  }
+
   return (
     <DebugRenderTracker
       position="bottom-center"
@@ -65,13 +76,7 @@ function TabBarItem({
         borderBottomColor="$borderActive"
         onPress={() => onPress(name)}
       >
-        <SizableText size="$headingXs">
-          {`${intl.formatMessage({
-            id: tabNameToTranslationKey[
-              name as keyof typeof tabNameToTranslationKey
-            ],
-          })} ${tabCount}`}
-        </SizableText>
+        <SizableText size="$headingXs">{`${tabTitle} ${tabCount}`}</SizableText>
       </XStack>
     </DebugRenderTracker>
   );
@@ -90,8 +95,8 @@ function PerpOrderInfoPanel() {
       headerHeight={80}
       initialTabName="Positions"
       onTabChange={async (tab) => {
-        if (tab.tabName === 'Trades History') {
-          // do nothing
+        if (tab.tabName === 'Account') {
+          void backgroundApiProxy.serviceHyperliquidSubscription.enableLedgerUpdatesSubscription();
         }
       }}
       renderTabBar={(props) => (
@@ -116,6 +121,9 @@ function PerpOrderInfoPanel() {
       </Tabs.Tab>
       <Tabs.Tab name="Trades History">
         <PerpTradesHistoryList useTabsList />
+      </Tabs.Tab>
+      <Tabs.Tab name="Account">
+        <PerpAccountList useTabsList />
       </Tabs.Tab>
     </Tabs.Container>
   );

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpTradersHistoryListModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpTradersHistoryListModal.tsx
@@ -1,41 +1,111 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { Button, Page } from '@onekeyhq/components';
+import {
+  Button,
+  Page,
+  SizableText,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import { PageBody } from '@onekeyhq/components/src/layouts/Page/PageBody';
 import { PageHeader } from '@onekeyhq/components/src/layouts/Page/PageHeader';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { usePerpTradesHistoryViewAllUrl } from '../../hooks/usePerpOrderInfoPanel';
 import { PerpsAccountSelectorProviderMirror } from '../../PerpsAccountSelectorProviderMirror';
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
 
+import { PerpAccountList } from './List/PerpAccountList';
 import { PerpTradesHistoryList } from './List/PerpTradesHistoryList';
+
+type ITabName = 'Trades' | 'Account';
+
+function TabHeader({
+  activeTab,
+  onTabChange,
+}: {
+  activeTab: ITabName;
+  onTabChange: (tab: ITabName) => void;
+}) {
+  const intl = useIntl();
+
+  return (
+    <XStack
+      bg="$bgApp"
+      borderBottomWidth="$0.5"
+      borderBottomColor="$borderSubdued"
+    >
+      <XStack
+        py="$3"
+        ml="$5"
+        mr="$2"
+        borderBottomWidth={activeTab === 'Trades' ? '$0.5' : '$0'}
+        borderBottomColor="$borderActive"
+        onPress={() => onTabChange('Trades')}
+      >
+        <SizableText size="$headingXs">
+          {intl.formatMessage({ id: ETranslations.perp_trades_history_title })}
+        </SizableText>
+      </XStack>
+      <XStack
+        py="$3"
+        mx="$2"
+        borderBottomWidth={activeTab === 'Account' ? '$0.5' : '$0'}
+        borderBottomColor="$borderActive"
+        onPress={() => onTabChange('Account')}
+      >
+        <SizableText size="$headingXs">Account</SizableText>
+      </XStack>
+    </XStack>
+  );
+}
 
 export function PerpTradersHistoryListModal() {
   const intl = useIntl();
   const { onViewAllUrl } = usePerpTradesHistoryViewAllUrl();
-  const headerRight = useCallback(
-    () => (
+  const [activeTab, setActiveTab] = useState<ITabName>('Trades');
+
+  useEffect(() => {
+    if (activeTab === 'Account') {
+      void backgroundApiProxy.serviceHyperliquidSubscription.enableLedgerUpdatesSubscription();
+    }
+  }, [activeTab]);
+
+  const headerRight = useCallback(() => {
+    if (activeTab !== 'Trades') {
+      return null;
+    }
+    return (
       <Button onPress={onViewAllUrl} variant="tertiary" size="small">
         {intl.formatMessage({
           id: ETranslations.global_view_more,
         })}
       </Button>
-    ),
-    [onViewAllUrl, intl],
-  );
+    );
+  }, [onViewAllUrl, intl, activeTab]);
+
   return (
     <Page>
       <PageHeader
         title={intl.formatMessage({
-          id: ETranslations.perp_trades_history_title,
+          id: ETranslations.global_history,
         })}
         headerRight={headerRight}
       />
       <PageBody>
-        <PerpTradesHistoryList isMobile useTabsList={false} />
+        <YStack flex={1}>
+          <TabHeader activeTab={activeTab} onTabChange={setActiveTab} />
+          <YStack flex={1}>
+            {activeTab === 'Trades' ? (
+              <PerpTradesHistoryList isMobile useTabsList={false} />
+            ) : (
+              <PerpAccountList isMobile useTabsList={false} />
+            )}
+          </YStack>
+        </YStack>
       </PageBody>
     </Page>
   );

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -35,6 +35,7 @@ import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import type {
   IBook,
   IWsAllMids,
+  IWsUserNonFundingLedgerUpdates,
   IWsWebData2,
 } from '@onekeyhq/shared/types/hyperliquid/sdk';
 import type { EPerpsSubscriptionCategory } from '@onekeyhq/shared/types/hyperliquid/types';
@@ -132,6 +133,12 @@ function useHyperliquidEventBusListener() {
 
           case ESubscriptionType.L2_BOOK:
             void actions.current.updateL2Book(data as IBook);
+            break;
+
+          case ESubscriptionType.USER_NON_FUNDING_LEDGER_UPDATES:
+            void actions.current.updateLedgerUpdates(
+              data as IWsUserNonFundingLedgerUpdates,
+            );
             break;
 
           case ESubscriptionType.ACTIVE_ASSET_CTX:

--- a/packages/kit/src/views/Perp/hooks/usePerpOrderInfoPanel.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpOrderInfoPanel.ts
@@ -131,8 +131,6 @@ export function usePerpTradesHistory() {
     }, 300);
   }, [refreshHook]);
 
-  console.log('usePerpTradesHistory__render', tradesHistory, refreshHook);
-
   return {
     trades: tradesHistory,
     currentListPage,

--- a/packages/shared/src/utils/perpsUtils.ts
+++ b/packages/shared/src/utils/perpsUtils.ts
@@ -818,6 +818,8 @@ function calculateLiquidationPrice(
 
   if (hasExistingPosition) {
     // Calculate existing position metrics
+    // IMPORTANT: Use current mark price for maintenance margin calculation, not entry price
+    // Maintenance margin is based on position's current market value, not entry value
     const existingPositionValue = existingPositionSize
       .abs()
       .multipliedBy(effectivePrice);

--- a/packages/shared/types/hyperliquid/sdk.ts
+++ b/packages/shared/types/hyperliquid/sdk.ts
@@ -9,12 +9,38 @@ export type IWsAllMids = HL.WsAllMids;
 export type IWsActiveAssetCtx = HL.WsActiveAssetCtx;
 export type IWsUserEvent = HL.WsUserEvent;
 export type IWsUserFills = HL.WsUserFills;
+export type IWsUserNonFundingLedgerUpdates = HL.WsUserNonFundingLedgerUpdates;
 export type IWsBbo = HL.WsBbo;
 export type IHyperliquidEventTarget = EventTarget; // HL.HyperliquidEventTarget;
 // export type IWebSocketAsyncRequest = WebSocketAsyncRequest; // HL.WebSocketAsyncRequest;
 
 export type IWsNotification = HL.WsNotification;
 export type IWsTrade = HL.WsTrade;
+
+// Custom Send type (not in SDK)
+export interface ISendUpdate {
+  type: 'send';
+  user: string;
+  amount: string;
+  destination: string;
+  destinationDex: string;
+  fee: string;
+  feeToken: string;
+  nativeTokenFee: string;
+  nonce: number;
+  sourceDex: string;
+  token: string;
+  usdcValue: string;
+}
+
+// Extend delta types to include custom send type
+type IExtendedDelta = HL.UserNonFundingLedgerUpdate['delta'] | ISendUpdate;
+
+export type IUserNonFundingLedgerUpdate = {
+  time: number;
+  hash: string;
+  delta: IExtendedDelta;
+};
 export type IApiRequestError = HL.ApiRequestError;
 export type IApiRequestResult = HL.SuccessResponse;
 export type IApiErrorResponse = HL.ErrorResponse;
@@ -94,6 +120,8 @@ export type IEventTradesParameters = HL.EventTradesParameters;
 export type IEventUserEventsParameters = HL.EventUserEventsParameters;
 export type IEventWebData2Parameters = HL.EventWebData2Parameters;
 export type IEventUserFillsParameters = HL.EventUserFillsParameters;
+export type IEventUserNonFundingLedgerUpdatesParameters =
+  HL.EventUserNonFundingLedgerUpdatesParameters;
 
 // Response types
 export type ISuccessResponse = HL.SuccessResponse;
@@ -106,6 +134,7 @@ export type ISignature = HL.Signature;
 export type IPerpsSubscriptionParams = {
   [ESubscriptionType.L2_BOOK]: IEventL2BookParameters;
   [ESubscriptionType.USER_FILLS]: IEventUserFillsParameters;
+  [ESubscriptionType.USER_NON_FUNDING_LEDGER_UPDATES]: IEventUserNonFundingLedgerUpdatesParameters;
 
   [ESubscriptionType.ACTIVE_ASSET_DATA]: IEventActiveAssetDataParameters;
   [ESubscriptionType.WEB_DATA2]: IEventWebData2Parameters;

--- a/packages/shared/types/hyperliquid/types.ts
+++ b/packages/shared/types/hyperliquid/types.ts
@@ -14,6 +14,7 @@ export enum ESubscriptionType {
   ACTIVE_ASSET_DATA = 'activeAssetData',
   WEB_DATA2 = 'webData2',
   USER_FILLS = 'userFills',
+  USER_NON_FUNDING_LEDGER_UPDATES = 'userNonFundingLedgerUpdates',
   // TRADES = 'trades',
   // BBO = 'bbo',
   // USER_EVENTS = 'userEvents',


### PR DESCRIPTION
- Add Account history tab alongside Trades in history modal
- Implement USER_NON_FUNDING_LEDGER_UPDATES subscription for real-time updates
- Create PerpAccountList and AccountRow components with 10+ activity type support
- Add snapshot and incremental update handling with deduplication
- Display deposit, withdraw, transfers, rewards, and vault operations
- Auto-cleanup on account switch and smart subscription management

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Account tab to Perps views displaying ledger updates with transaction history, including amounts, fees, and timestamps.
  * Introduced ledger updates subscription capability for real-time account activity tracking.
  * New account ledger UI with support for both desktop and mobile layouts, including pagination and pull-to-refresh functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->