### PR TITLE
refactor: set default sort to volume for perps token selector OK-44735

### DIFF
--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -239,7 +239,10 @@ export const {
 } = globalAtom<IPerpTokenSortConfig | null>({
   name: EAtomNames.perpTokenSortConfigPersistAtom,
   persist: true,
-  initialValue: null,
+  initialValue: {
+    field: 'volume24h',
+    direction: 'desc',
+  },
 });
 
 export type IPerpsActiveOrderBookOptionsAtom =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default sorting behavior for perpetual tokens to display results sorted by 24-hour volume in descending order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->