### PR TITLE
fix: update mobile market token list title from market cap to turnover

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsMobile.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsMobile.tsx
@@ -23,7 +23,7 @@ export const useColumnsMobile = (): ITableColumn<IMarketToken>[] => {
       title: `${intl.formatMessage({
         id: ETranslations.global_name,
       })} / ${intl.formatMessage({
-        id: ETranslations.dexmarket_mobiletitle_mcap,
+        id: ETranslations.dexmarket_turnover,
       })}`,
       titleProps: { paddingBottom: '$2', paddingLeft: '$3' },
       dataIndex: 'tokenInfo',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the market token column title label displayed in mobile view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->