### PR TITLE
fix: ensure K-line price is preserved only for the same token in mark…

### DIFF
--- a/packages/kit/src/states/jotai/contexts/marketV2/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/marketV2/actions.ts
@@ -128,8 +128,21 @@ class ContextJotaiActionsMarketV2 extends ContextJotaiActionsBase {
         const websocketConfig = responseData.data.websocket;
 
         // Always preserve K-line updated price if it exists, fallback to API price
+        // BUT only if we're updating the SAME token (check address and networkId)
         const currentTokenDetail = get(tokenDetailAtom());
-        const hasKLinePrice = currentTokenDetail?.lastUpdated;
+        const isSameToken =
+          currentTokenDetail &&
+          equalTokenNoCaseSensitive({
+            token1: {
+              networkId,
+              contractAddress: tokenAddress,
+            },
+            token2: {
+              networkId,
+              contractAddress: currentTokenDetail.address || '',
+            },
+          });
+        const hasKLinePrice = isSameToken && currentTokenDetail?.lastUpdated;
 
         const finalTokenData = hasKLinePrice
           ? {


### PR DESCRIPTION
…etV2 actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved price chart data handling to ensure chart data is accurately preserved only when updating the same token, preventing data misalignment when viewing different tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->