### PR TITLE
fix: prevent auto-redirect to Market on wallet sub-pages

### DIFF
--- a/packages/kit/src/views/Home/hooks/useAutoRedirectToMarket.ts
+++ b/packages/kit/src/views/Home/hooks/useAutoRedirectToMarket.ts
@@ -2,15 +2,20 @@ import { useEffect, useRef } from 'react';
 
 import { rootNavigationRef } from '@onekeyhq/components';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import { ERootRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
+import {
+  ERootRoutes,
+  ETabHomeRoutes,
+  ETabRoutes,
+} from '@onekeyhq/shared/src/routes';
 
 import useAppNavigation from '../../../hooks/useAppNavigation';
 
 /**
- * Check if currently on Home tab
- * In webDappMode, we want to redirect from Home to Market tab on initial load
+ * Check if currently on Wallet main page (Home tab main page)
+ * In webDappMode, we want to redirect from Wallet to Market tab on initial load
+ * Should NOT redirect when on sub-pages like url-account
  */
-function isCurrentlyOnHomeTab(): boolean {
+function isCurrentlyOnWalletTab(): boolean {
   try {
     const state = rootNavigationRef.current?.getRootState();
     if (!state?.routes) {
@@ -30,19 +35,38 @@ function isCurrentlyOnHomeTab(): boolean {
     const routes = tabState.routes || [];
     const currentIndex = tabState.index ?? 0;
 
-    // Check if currently on Home tab
+    // Check if currently on Wallet tab (Home tab)
     const currentRoute = routes[currentIndex];
-    const isOnHome = currentRoute?.name === ETabRoutes.Home;
+    const isOnHomeTab = currentRoute?.name === ETabRoutes.Home;
 
-    return isOnHome;
+    if (!isOnHomeTab) {
+      return false;
+    }
+
+    // Check if on the main wallet page, not on sub-routes like url-account
+    const homeTabState = currentRoute?.state;
+    if (!homeTabState) {
+      // No sub-navigation state means we're on the main page
+      return true;
+    }
+
+    const homeRoutes = homeTabState.routes || [];
+    const homeCurrentIndex = homeTabState.index ?? 0;
+    const currentHomeRoute = homeRoutes[homeCurrentIndex];
+
+    // Only return true if on the main TabHome route, not on sub-pages
+    const isOnMainWalletPage =
+      currentHomeRoute?.name === ETabHomeRoutes.TabHome;
+
+    return isOnMainWalletPage;
   } catch (error) {
     return false;
   }
 }
 
 /**
- * Auto redirect to Market tab on web platform when home page is loaded
- * Only executes when currently on Home tab
+ * Auto redirect to Market tab on web platform when wallet page is loaded
+ * Only executes when currently on Wallet tab
  */
 export function useAutoRedirectToMarket() {
   const navigation = useAppNavigation();
@@ -50,8 +74,8 @@ export function useAutoRedirectToMarket() {
   const shouldRedirectToMarket = platformEnv.isWebDappMode;
 
   useEffect(() => {
-    // Only redirect if currently on Home tab
-    if (!isCurrentlyOnHomeTab()) {
+    // Only redirect if currently on Wallet tab
+    if (!isCurrentlyOnWalletTab()) {
       return;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-redirect logic to the Market by ensuring it activates only when on the Wallet main page, not on sub-pages. The redirect now operates more reliably and respects app mode settings for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->