### PR TITLE
fix: fix Cardano provider import to use default export

### DIFF
--- a/packages/kit-bg/src/providers/backgroundProviders.ts
+++ b/packages/kit-bg/src/providers/backgroundProviders.ts
@@ -192,8 +192,9 @@ function createBackgroundProviders({
 
   Object.defineProperty(backgroundProviders, IInjectedProviderNames.cardano, {
     get() {
-      const ProviderApiCardano =
-        require('./ProviderApiCardano') as unknown as typeof import('./ProviderApiCardano').default;
+      const ProviderApiCardano = (
+        require('./ProviderApiCardano') as unknown as typeof import('./ProviderApiCardano')
+      ).default;
       const value = new ProviderApiCardano({ backgroundApi });
       Object.defineProperty(this, IInjectedProviderNames.cardano, { value });
       return value;


### PR DESCRIPTION
Corrects the dynamic import of ProviderApiCardano to access its default export, ensuring the provider is instantiated properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the lazy-loading mechanism for the Cardano provider to improve code efficiency. No functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->