### PR TITLE
fix: limit displayed lines for raw message in SignForm component

### DIFF
--- a/packages/kit/src/views/SignAndVerifyMessage/components/SignForm.tsx
+++ b/packages/kit/src/views/SignAndVerifyMessage/components/SignForm.tsx
@@ -670,6 +670,7 @@ export const SignForm = ({
                   color="$textSubdued"
                   wordWrap="break-word"
                   style={{ overflowWrap: 'break-word' }}
+                  numberOfLines={2}
                 >
                   {rawMessage}
                 </SizableText>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Message display in the signing form is now limited to two lines for improved visual layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->