### PR TITLE
fix: restore banner tap handler on ReceiveToken page

### DIFF
--- a/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
+++ b/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
@@ -813,7 +813,7 @@ function ReceiveToken() {
 
   const isPressable = useMemo(() => {
     return !!(banner?.href || banner?.mode);
-  }, [banner]);
+  }, [banner?.href, banner?.mode]);
   return (
     <Page safeAreaEnabled={false}>
       <Page.Header

--- a/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
+++ b/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
@@ -811,6 +811,9 @@ function ReceiveToken() {
     nativeToken?.logoURI,
   ]);
 
+  const isPressable = useMemo(() => {
+    return !!(banner?.href || banner?.mode);
+  }, [banner]);
   return (
     <Page safeAreaEnabled={false}>
       <Page.Header
@@ -832,7 +835,7 @@ function ReceiveToken() {
               borderRadius="$2"
               borderCurve="continuous"
               userSelect="none"
-              {...(banner?.href || banner?.mode
+              {...(isPressable
                 ? {
                     focusable: true,
                     focusVisibleStyle: {
@@ -853,7 +856,7 @@ function ReceiveToken() {
                     },
                     onPress: () => handleBannerOnPress(banner),
                   }
-                : null)}
+                : undefined)}
             >
               <Image
                 size="$5"

--- a/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
+++ b/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
@@ -47,7 +47,10 @@ import { EConfirmOnDeviceType } from '@onekeyhq/shared/types/device';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import AddressTypeSelector from '../../../components/AddressTypeSelector/AddressTypeSelector';
-import { FormatHyperlinkText, HyperlinkText } from '../../../components/HyperlinkText';
+import {
+  FormatHyperlinkText,
+  HyperlinkText,
+} from '../../../components/HyperlinkText';
 import { NetworkAvatar } from '../../../components/NetworkAvatar';
 import { Token } from '../../../components/Token';
 import { useAccountData } from '../../../hooks/useAccountData';
@@ -829,7 +832,7 @@ function ReceiveToken() {
               borderRadius="$2"
               borderCurve="continuous"
               userSelect="none"
-              {...(banner?.href
+              {...(banner?.href || banner?.mode
                 ? {
                     focusable: true,
                     focusVisibleStyle: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved banner interactivity logic to make clickable banners more reliable and consistent across the app, reducing cases where banners appeared interactive but did not respond.
  * Minor UI import cleanups with no visible changes to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->