### PR TITLE
fix: show perp URL when enabled instead of disabled

### DIFF
--- a/packages/shared/src/utils/routeUtils.ts
+++ b/packages/shared/src/utils/routeUtils.ts
@@ -218,7 +218,7 @@ export const buildAllowList = (
           },
         }
       : {
-          ...(perpDisabled
+          ...(!perpDisabled
             ? {
                 [pagePath`${ERootRoutes.Main}${ETabRoutes.Perp}`]: {
                   showUrl: true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed an issue where Perp tab visibility was not properly respecting the disabled configuration state. The tab rules now correctly appear or disappear based on the configuration setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->