### PR TITLE
feat: move defi page into browser tab on Native (OK-44672)

### DIFF
--- a/packages/kit-bg/src/services/ServiceSetting.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.ts
@@ -22,7 +22,7 @@ import {
   IMPL_LTC,
 } from '@onekeyhq/shared/src/engine/engineConsts';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
-import type { ILocaleSymbol } from '@onekeyhq/shared/src/locale';
+import type { ETranslations, ILocaleSymbol } from '@onekeyhq/shared/src/locale';
 import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import {
   getDefaultLocale,
@@ -658,6 +658,14 @@ class ServiceSetting extends ServiceBase {
       controller.abort(),
     );
     this._fetchWalletConfigControllers = [];
+  }
+
+  @backgroundMethod()
+  public async setSelectedBrowserTab(tab: ETranslations) {
+    await settingsPersistAtom.set((prev) => ({
+      ...prev,
+      selectedBrowserTab: tab,
+    }));
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/states/jotai/atoms/settings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/settings.ts
@@ -1,4 +1,4 @@
-import type { ILocaleSymbol } from '@onekeyhq/shared/src/locale';
+import { ETranslations, ILocaleSymbol } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { generateUUID } from '@onekeyhq/shared/src/utils/miscUtils';
 import { EHardwareTransportType, EOnekeyDomain } from '@onekeyhq/shared/types';
@@ -24,6 +24,7 @@ function getDefaultHardwareTransportType(): EHardwareTransportType {
 
 export type ISettingsPersistAtom = {
   theme: 'light' | 'dark' | 'system';
+  selectedBrowserTab: ETranslations;
   lastLocale: ILocaleSymbol;
   locale: ILocaleSymbol;
   version: string;
@@ -67,6 +68,7 @@ export type ISettingsPersistAtom = {
 export const settingsAtomInitialValue: ISettingsPersistAtom = {
   theme: 'system',
   lastLocale: 'system',
+  selectedBrowserTab: ETranslations.global_browser,
   locale: 'system',
   version: process.env.VERSION ?? '1.0.0',
   buildNumber: process.env.BUILD_NUMBER ?? '2022010100',

--- a/packages/kit-bg/src/states/jotai/atoms/settings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/settings.ts
@@ -1,4 +1,5 @@
-import { ETranslations, ILocaleSymbol } from '@onekeyhq/shared/src/locale';
+import type { ILocaleSymbol } from '@onekeyhq/shared/src/locale';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { generateUUID } from '@onekeyhq/shared/src/utils/miscUtils';
 import { EHardwareTransportType, EOnekeyDomain } from '@onekeyhq/shared/types';

--- a/packages/kit/src/components/TabPageHeader/HeaderRight.tsx
+++ b/packages/kit/src/components/TabPageHeader/HeaderRight.tsx
@@ -115,11 +115,13 @@ export function SearchInput({
 }
 
 export function HeaderRight({
+  selectedHeaderTab,
   sceneName,
   tabRoute,
   customHeaderRightItems,
   renderCustomHeaderRightItems,
 }: {
+  selectedHeaderTab?: ETranslations;
   sceneName: EAccountSelectorSceneName;
   tabRoute: ETabRoutes;
   customHeaderRightItems?: ReactNode;
@@ -153,6 +155,14 @@ export function HeaderRight({
         {isHorizontal && platformEnv.isWebDappMode && gtXl ? (
           <ThemeButton />
         ) : null}
+      </>
+    );
+
+    const earnItems = (
+      <>
+        <GiftAction />
+        <WalletConnectionForWeb tabRoute={tabRoute} />
+        {fixedItems}
       </>
     );
 
@@ -216,7 +226,7 @@ export function HeaderRight({
           </>
         );
       case ETabRoutes.Discovery:
-        return (
+        return selectedHeaderTab === ETranslations.global_browser ? (
           <>
             <HistoryIconButton />
             {isHorizontal || !platformEnv.isNative ? undefined : (
@@ -225,15 +235,11 @@ export function HeaderRight({
             <WalletConnectionForWeb tabRoute={tabRoute} />
             {fixedItems}
           </>
+        ) : (
+          earnItems
         );
       case ETabRoutes.Earn:
-        return (
-          <>
-            <GiftAction />
-            <WalletConnectionForWeb tabRoute={tabRoute} />
-            {fixedItems}
-          </>
-        );
+        return earnItems;
       case ETabRoutes.Perp:
         return (
           <>
@@ -250,8 +256,9 @@ export function HeaderRight({
     customHeaderRightItems,
     isHorizontal,
     gtXl,
-    renderCustomHeaderRightItems,
     tabRoute,
+    renderCustomHeaderRightItems,
+    selectedHeaderTab,
     sceneName,
     gtMd,
   ]);

--- a/packages/kit/src/components/TabPageHeader/index.native.tsx
+++ b/packages/kit/src/components/TabPageHeader/index.native.tsx
@@ -17,6 +17,8 @@ export function TabPageHeader({
   sceneName,
   tabRoute,
   customHeaderRightItems,
+  selectedHeaderTab,
+  onSelectHeaderTab,
   renderCustomHeaderRightItems,
   customHeaderLeftItems,
   hideSearch = false,
@@ -27,6 +29,7 @@ export function TabPageHeader({
     return (
       <HomeTokenListProviderMirror>
         <HeaderRight
+          selectedHeaderTab={selectedHeaderTab}
           sceneName={sceneName}
           tabRoute={tabRoute}
           customHeaderRightItems={customHeaderRightItems}
@@ -35,6 +38,7 @@ export function TabPageHeader({
       </HomeTokenListProviderMirror>
     );
   }, [
+    selectedHeaderTab,
     sceneName,
     tabRoute,
     customHeaderRightItems,
@@ -53,6 +57,8 @@ export function TabPageHeader({
       >
         <View>
           <HeaderLeft
+            selectedHeaderTab={selectedHeaderTab}
+            onSelectHeaderTab={onSelectHeaderTab}
             sceneName={sceneName}
             tabRoute={tabRoute}
             customHeaderLeftItems={customHeaderLeftItems}

--- a/packages/kit/src/components/TabPageHeader/index.tsx
+++ b/packages/kit/src/components/TabPageHeader/index.tsx
@@ -16,6 +16,8 @@ import type { ITabPageHeaderProp } from './type';
 export function TabPageHeader({
   sceneName,
   tabRoute,
+  selectedHeaderTab,
+  onSelectHeaderTab,
   renderCustomHeaderRightItems,
   customHeaderRightItems,
   customHeaderLeftItems,
@@ -24,12 +26,20 @@ export function TabPageHeader({
   const renderHeaderLeft = useCallback(
     () => (
       <HeaderLeft
+        selectedHeaderTab={selectedHeaderTab}
+        onSelectHeaderTab={onSelectHeaderTab}
         sceneName={sceneName}
         tabRoute={tabRoute}
         customHeaderLeftItems={customHeaderLeftItems}
       />
     ),
-    [sceneName, tabRoute, customHeaderLeftItems],
+    [
+      selectedHeaderTab,
+      onSelectHeaderTab,
+      sceneName,
+      tabRoute,
+      customHeaderLeftItems,
+    ],
   );
 
   const { config } = useAccountSelectorContextData();
@@ -40,6 +50,7 @@ export function TabPageHeader({
         <HomeTokenListProviderMirror>
           <AccountSelectorProviderMirror enabledNum={[0]} config={config}>
             <HeaderRight
+              selectedHeaderTab={selectedHeaderTab}
               sceneName={sceneName}
               tabRoute={tabRoute}
               customHeaderRightItems={customHeaderRightItems}
@@ -50,6 +61,7 @@ export function TabPageHeader({
       ) : null,
     [
       config,
+      selectedHeaderTab,
       sceneName,
       tabRoute,
       customHeaderRightItems,

--- a/packages/kit/src/components/TabPageHeader/type.ts
+++ b/packages/kit/src/components/TabPageHeader/type.ts
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 
+import type { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import type { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
@@ -7,6 +8,7 @@ export interface ITabPageHeaderProp {
   children?: ReactNode;
   sceneName: EAccountSelectorSceneName;
   tabRoute: ETabRoutes;
+  selectedHeaderTab?: ETranslations;
   renderCustomHeaderRightItems?: ({
     fixedItems,
   }: {
@@ -15,6 +17,7 @@ export interface ITabPageHeaderProp {
   customHeaderRightItems?: ReactNode;
   customHeaderLeftItems?: ReactNode;
   hideSearch?: boolean;
+  onSelectHeaderTab?: (tab: ETranslations) => void;
 }
 
 export interface ITabPageHeaderContainerProps {

--- a/packages/kit/src/routes/Tab/router.ts
+++ b/packages/kit/src/routes/Tab/router.ts
@@ -199,6 +199,7 @@ export const useTabRouterConfig = (params?: IGetTabRouterParams) => {
         exact: true,
         children: earnRouters,
         trackId: 'global-earn',
+        hideOnTabBar: platformEnv.isNative,
       },
       isWebDappMode ? referFriendsTabConfig : undefined,
       // In non-DAPP mode, show ReferFriends in more actions

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -15,6 +15,7 @@ import {
   useSafeAreaInsets,
 } from '@onekeyhq/components';
 import type { IPageNavigationProp } from '@onekeyhq/components/src/layouts/Navigation';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { TabPageHeader } from '@onekeyhq/kit/src/components/TabPageHeader';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import useListenTabFocusState from '@onekeyhq/kit/src/hooks/useListenTabFocusState';
@@ -40,7 +41,6 @@ import {
 import { useDebugComponentRemountLog } from '@onekeyhq/shared/src/utils/debug/debugUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
-import backgroundApiProxy from '../../../../background/instance/backgroundApiProxy';
 import { EarnHomeWithProvider } from '../../../Earn/EarnHome';
 import CustomHeaderTitle from '../../components/CustomHeaderTitle';
 import { HandleRebuildBrowserData } from '../../components/HandleData/HandleRebuildBrowserTabData';

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -20,6 +20,7 @@ import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import useListenTabFocusState from '@onekeyhq/kit/src/hooks/useListenTabFocusState';
 import { useBrowserTabActions } from '@onekeyhq/kit/src/states/jotai/contexts/discovery';
 import { useTakeScreenshot } from '@onekeyhq/kit/src/views/Discovery/hooks/useTakeScreenshot';
+import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -39,6 +40,7 @@ import {
 import { useDebugComponentRemountLog } from '@onekeyhq/shared/src/utils/debug/debugUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
+import backgroundApiProxy from '../../../../background/instance/backgroundApiProxy';
 import { EarnHomeWithProvider } from '../../../Earn/EarnHome';
 import CustomHeaderTitle from '../../components/CustomHeaderTitle';
 import { HandleRebuildBrowserData } from '../../components/HandleData/HandleRebuildBrowserTabData';
@@ -133,21 +135,27 @@ function MobileBrowser() {
       RouteProp<ITabDiscoveryParamList, ETabDiscoveryRoutes.TabDiscovery>
     >();
   const { defaultTab } = route?.params || {};
-
+  const [settings] = useSettingsPersistAtom();
   const [selectedHeaderTab, setSelectedHeaderTab] = useState<ETranslations>(
-    defaultTab || ETranslations.global_browser,
+    defaultTab || settings.selectedBrowserTab || ETranslations.global_browser,
   );
+  const handleChangeHeaderTab = useCallback(async (tab: ETranslations) => {
+    setSelectedHeaderTab(tab);
+    setTimeout(async () => {
+      await backgroundApiProxy.serviceSetting.setSelectedBrowserTab(tab);
+    }, 150);
+  }, []);
   const previousDefaultTab = useRef<ETranslations | undefined>(defaultTab);
   useEffect(() => {
     if (previousDefaultTab.current !== defaultTab) {
       previousDefaultTab.current = defaultTab;
       if (defaultTab) {
-        setTimeout(() => {
-          setSelectedHeaderTab(defaultTab);
+        setTimeout(async () => {
+          await handleChangeHeaderTab(defaultTab);
         }, 100);
       }
     }
-  }, [defaultTab]);
+  }, [defaultTab, handleChangeHeaderTab]);
   const { tabs } = useWebTabs();
   const { activeTabId } = useActiveTabId();
   const { closeWebTab, setCurrentWebTab } = useBrowserTabActions().current;
@@ -388,7 +396,7 @@ function MobileBrowser() {
             sceneName={EAccountSelectorSceneName.home}
             tabRoute={ETabRoutes.Discovery}
             selectedHeaderTab={selectedHeaderTab}
-            onSelectHeaderTab={setSelectedHeaderTab}
+            onSelectHeaderTab={handleChangeHeaderTab}
           />
         </YStack>
       ) : null}

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -9,6 +9,7 @@ import {
   Page,
   Stack,
   XStack,
+  YStack,
   useMedia,
   useSafeAreaInsets,
 } from '@onekeyhq/components';
@@ -33,6 +34,7 @@ import {
 import { useDebugComponentRemountLog } from '@onekeyhq/shared/src/utils/debug/debugUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
+import { EarnHomeWithProvider } from '../../../Earn/EarnHome';
 import CustomHeaderTitle from '../../components/CustomHeaderTitle';
 import { HandleRebuildBrowserData } from '../../components/HandleData/HandleRebuildBrowserTabData';
 import HeaderRightToolBar from '../../components/HeaderRightToolBar';
@@ -53,6 +55,7 @@ import DashboardContent from '../Dashboard/DashboardContent';
 import MobileBrowserContent from './MobileBrowserContent';
 import { withBrowserProvider } from './WithBrowserProvider';
 
+import type { LayoutChangeEvent } from 'react-native';
 import type { WebView } from 'react-native-webview';
 
 const isNativeMobile = platformEnv.isNative && !platformEnv.isNativeIOSPad;
@@ -265,17 +268,20 @@ function MobileBrowser() {
   const [selectedHeaderTab, setSelectedHeaderTab] = useState<ETranslations>(
     ETranslations.global_browser,
   );
+  const [tabPageHeight, setTabPageHeight] = useState(
+    platformEnv.isNativeIOS ? 143 : 92,
+  );
+  const handleTabPageLayout = useCallback((e: LayoutChangeEvent) => {
+    // Use the actual measured height without arbitrary adjustments
+    const height = e.nativeEvent.layout.height - 20;
+    setTabPageHeight(height);
+  }, []);
   return (
     <Page fullPage>
       {/* custom header */}
 
       {displayHomePage ? (
-        <TabPageHeader
-          sceneName={EAccountSelectorSceneName.home}
-          tabRoute={ETabRoutes.Discovery}
-          selectedHeaderTab={selectedHeaderTab}
-          onSelectHeaderTab={setSelectedHeaderTab}
-        />
+        <Stack h={tabPageHeight} />
       ) : (
         <XStack
           pt={top}
@@ -302,36 +308,58 @@ function MobileBrowser() {
         </XStack>
       )}
       <Page.Body>
-        <Stack flex={1} zIndex={3} pb={gtMd ? bottom : 0}>
-          <HandleRebuildBrowserData />
-          <Stack flex={1}>
-            {gtMd ? null : (
-              <Stack display={displayHomePage ? 'flex' : 'none'}>
-                <DashboardContent onScroll={handleScroll} />
-              </Stack>
-            )}
-            <Freeze freeze={displayHomePage}>{content}</Freeze>
+        {selectedHeaderTab === ETranslations.global_browser ? (
+          <Stack flex={1} zIndex={3} pb={gtMd ? bottom : 0}>
+            <HandleRebuildBrowserData />
+            <Stack flex={1}>
+              {gtMd ? null : (
+                <Stack display={displayHomePage ? 'flex' : 'none'}>
+                  <DashboardContent onScroll={handleScroll} />
+                </Stack>
+              )}
+              <Freeze freeze={displayHomePage}>{content}</Freeze>
+            </Stack>
+            <Freeze freeze={!displayBottomBar}>
+              <Animated.View
+                ref={toolbarRef}
+                style={[
+                  toolbarAnimatedStyle,
+                  {
+                    bottom: 0,
+                    left: 0,
+                    right: 0,
+                  },
+                ]}
+              >
+                <MobileBrowserBottomBar
+                  id={activeTabId ?? ''}
+                  onGoBackHomePage={handleGoBackHome}
+                />
+              </Animated.View>
+            </Freeze>
           </Stack>
-          <Freeze freeze={!displayBottomBar}>
-            <Animated.View
-              ref={toolbarRef}
-              style={[
-                toolbarAnimatedStyle,
-                {
-                  bottom: 0,
-                  left: 0,
-                  right: 0,
-                },
-              ]}
-            >
-              <MobileBrowserBottomBar
-                id={activeTabId ?? ''}
-                onGoBackHomePage={handleGoBackHome}
-              />
-            </Animated.View>
-          </Freeze>
-        </Stack>
+        ) : (
+          <EarnHomeWithProvider showHeader={false} />
+        )}
       </Page.Body>
+      {displayHomePage ? (
+        <YStack
+          position="absolute"
+          top={-20}
+          left={0}
+          bg="$bgApp"
+          pt="$5"
+          width="100%"
+          onLayout={handleTabPageLayout}
+        >
+          <TabPageHeader
+            sceneName={EAccountSelectorSceneName.home}
+            tabRoute={ETabRoutes.Discovery}
+            selectedHeaderTab={selectedHeaderTab}
+            onSelectHeaderTab={setSelectedHeaderTab}
+          />
+        </YStack>
+      ) : null}
     </Page>
   );
 }

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Freeze } from 'react-freeze';
 import { BackHandler } from 'react-native';
@@ -22,6 +22,7 @@ import {
   EAppEventBusNames,
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IDiscoveryModalParamList } from '@onekeyhq/shared/src/routes';
 import {
@@ -261,6 +262,9 @@ function MobileBrowser() {
     handleGoBackHome,
   });
 
+  const [selectedHeaderTab, setSelectedHeaderTab] = useState<ETranslations>(
+    ETranslations.global_browser,
+  );
   return (
     <Page fullPage>
       {/* custom header */}
@@ -269,6 +273,8 @@ function MobileBrowser() {
         <TabPageHeader
           sceneName={EAccountSelectorSceneName.home}
           tabRoute={ETabRoutes.Discovery}
+          selectedHeaderTab={selectedHeaderTab}
+          onSelectHeaderTab={setSelectedHeaderTab}
         />
       ) : (
         <XStack

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -308,39 +308,48 @@ function MobileBrowser() {
         </XStack>
       )}
       <Page.Body>
-        {selectedHeaderTab === ETranslations.global_browser ? (
-          <Stack flex={1} zIndex={3} pb={gtMd ? bottom : 0}>
-            <HandleRebuildBrowserData />
-            <Stack flex={1}>
-              {gtMd ? null : (
-                <Stack display={displayHomePage ? 'flex' : 'none'}>
-                  <DashboardContent onScroll={handleScroll} />
-                </Stack>
-              )}
-              <Freeze freeze={displayHomePage}>{content}</Freeze>
-            </Stack>
-            <Freeze freeze={!displayBottomBar}>
-              <Animated.View
-                ref={toolbarRef}
-                style={[
-                  toolbarAnimatedStyle,
-                  {
-                    bottom: 0,
-                    left: 0,
-                    right: 0,
-                  },
-                ]}
-              >
-                <MobileBrowserBottomBar
-                  id={activeTabId ?? ''}
-                  onGoBackHomePage={handleGoBackHome}
-                />
-              </Animated.View>
-            </Freeze>
+        <Stack
+          flex={1}
+          zIndex={3}
+          pb={gtMd ? bottom : 0}
+          display={
+            selectedHeaderTab === ETranslations.global_browser
+              ? undefined
+              : 'none'
+          }
+        >
+          <HandleRebuildBrowserData />
+          <Stack flex={1}>
+            {gtMd ? null : (
+              <Stack display={displayHomePage ? 'flex' : 'none'}>
+                <DashboardContent onScroll={handleScroll} />
+              </Stack>
+            )}
+            <Freeze freeze={displayHomePage}>{content}</Freeze>
           </Stack>
-        ) : (
-          <EarnHomeWithProvider showHeader={false} />
-        )}
+          <Freeze freeze={!displayBottomBar}>
+            <Animated.View
+              ref={toolbarRef}
+              style={[
+                toolbarAnimatedStyle,
+                {
+                  bottom: 0,
+                  left: 0,
+                  right: 0,
+                },
+              ]}
+            >
+              <MobileBrowserBottomBar
+                id={activeTabId ?? ''}
+                onGoBackHomePage={handleGoBackHome}
+              />
+            </Animated.View>
+          </Freeze>
+        </Stack>
+        <EarnHomeWithProvider
+          showHeader={false}
+          showContent={selectedHeaderTab === ETranslations.global_earn}
+        />
       </Page.Body>
       {displayHomePage ? (
         <YStack

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { useRoute } from '@react-navigation/core';
 import { Freeze } from 'react-freeze';
 import { BackHandler } from 'react-native';
 import Animated from 'react-native-reanimated';
@@ -25,7 +26,11 @@ import {
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import type { IDiscoveryModalParamList } from '@onekeyhq/shared/src/routes';
+import type {
+  ETabDiscoveryRoutes,
+  IDiscoveryModalParamList,
+  ITabDiscoveryParamList,
+} from '@onekeyhq/shared/src/routes';
 import {
   EDiscoveryModalRoutes,
   EModalRoutes,
@@ -55,6 +60,7 @@ import DashboardContent from '../Dashboard/DashboardContent';
 import MobileBrowserContent from './MobileBrowserContent';
 import { withBrowserProvider } from './WithBrowserProvider';
 
+import type { RouteProp } from '@react-navigation/core';
 import type { LayoutChangeEvent } from 'react-native';
 import type { WebView } from 'react-native-webview';
 
@@ -122,6 +128,26 @@ const useAndroidHardwareBack = platformEnv.isNativeAndroid
   : () => {};
 
 function MobileBrowser() {
+  const route =
+    useRoute<
+      RouteProp<ITabDiscoveryParamList, ETabDiscoveryRoutes.TabDiscovery>
+    >();
+  const { defaultTab } = route?.params || {};
+
+  const [selectedHeaderTab, setSelectedHeaderTab] = useState<ETranslations>(
+    defaultTab || ETranslations.global_browser,
+  );
+  const previousDefaultTab = useRef<ETranslations | undefined>(defaultTab);
+  useEffect(() => {
+    if (previousDefaultTab.current !== defaultTab) {
+      previousDefaultTab.current = defaultTab;
+      if (defaultTab) {
+        setTimeout(() => {
+          setSelectedHeaderTab(defaultTab);
+        }, 100);
+      }
+    }
+  }, [defaultTab]);
   const { tabs } = useWebTabs();
   const { activeTabId } = useActiveTabId();
   const { closeWebTab, setCurrentWebTab } = useBrowserTabActions().current;
@@ -265,9 +291,6 @@ function MobileBrowser() {
     handleGoBackHome,
   });
 
-  const [selectedHeaderTab, setSelectedHeaderTab] = useState<ETranslations>(
-    ETranslations.global_browser,
-  );
   const [tabPageHeight, setTabPageHeight] = useState(
     platformEnv.isNativeIOS ? 143 : 92,
   );

--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -676,7 +676,7 @@ function EarnBlockedOverview(props: {
   );
 }
 
-function BasicEarnHome() {
+export function EarnHomeContent() {
   const { activeAccount } = useActiveAccount({ num: 0 });
   const { account, indexedAccount } = activeAccount;
   const media = useMedia();
@@ -1033,137 +1033,129 @@ function BasicEarnHome() {
 
   if (platformEnv.isNative && media.md) {
     return (
-      <Page fullPage>
-        <Page.Body>
-          <Stack h={tabPageHeight} />
-          <Tabs.Container
-            allowHeaderOverscroll
-            renderHeader={() => (
-              <YStack
-                flex={1}
-                gap="$4"
-                pt="$5"
-                bg="$bgApp"
+      <>
+        <Stack h={tabPageHeight} />
+        <Tabs.Container
+          allowHeaderOverscroll
+          renderHeader={() => (
+            <YStack
+              flex={1}
+              gap="$4"
+              pt="$5"
+              bg="$bgApp"
+              pointerEvents="box-none"
+            >
+              {/* overview and banner */}
+              <YStack gap="$8">
+                <Overview
+                  onRefresh={refreshOverViewData}
+                  isLoading={isLoading}
+                />
+                {banners ? (
+                  <YStack
+                    px="$5"
+                    minHeight="$36"
+                    $md={{
+                      minHeight: '$28',
+                    }}
+                    borderRadius="$3"
+                    width="100%"
+                    borderCurve="continuous"
+                  >
+                    {banners}
+                  </YStack>
+                ) : null}
+              </YStack>
+              {/* Recommended, available assets and introduction */}
+              <YStack px="$5" gap="$8">
+                <YStack pt="$3.5" gap="$8">
+                  <Recommended />
+                </YStack>
+                {/* FAQ Panel */}
+                {banners ? gtLgFaqPanel : null}
+              </YStack>
+              <SizableText
+                mx="$5"
+                pb="$4"
+                size="$headingLg"
                 pointerEvents="box-none"
               >
-                {/* overview and banner */}
-                <YStack gap="$8">
-                  <Overview
-                    onRefresh={refreshOverViewData}
-                    isLoading={isLoading}
-                  />
-                  {banners ? (
-                    <YStack
-                      px="$5"
-                      minHeight="$36"
-                      $md={{
-                        minHeight: '$28',
-                      }}
-                      borderRadius="$3"
-                      width="100%"
-                      borderCurve="continuous"
-                    >
-                      {banners}
-                    </YStack>
-                  ) : null}
-                </YStack>
-                {/* Recommended, available assets and introduction */}
-                <YStack px="$5" gap="$8">
-                  <YStack pt="$3.5" gap="$8">
-                    <Recommended />
-                  </YStack>
-                  {/* FAQ Panel */}
-                  {banners ? gtLgFaqPanel : null}
-                </YStack>
-                <SizableText
-                  mx="$5"
-                  pb="$4"
-                  size="$headingLg"
-                  pointerEvents="box-none"
-                >
-                  {intl.formatMessage({
-                    id: ETranslations.earn_available_assets,
-                  })}
-                </SizableText>
-              </YStack>
-            )}
-            renderTabBar={(props) => (
-              <Tabs.TabBar
-                {...props}
-                containerStyle={{
-                  px: '$5',
-                }}
-                divider={false}
-                renderItem={({ name, isFocused, onPress }) => (
-                  <XStack
-                    px="$2"
-                    py="$1.5"
-                    mr="$1"
-                    bg={isFocused ? '$bgActive' : '$bg'}
-                    borderRadius="$2"
-                    borderCurve="continuous"
-                    onPress={() => onPress(name)}
-                  >
-                    <SizableText
-                      size="$bodyMdMedium"
-                      color={isFocused ? '$text' : '$textSubdued'}
-                      letterSpacing={-0.15}
-                    >
-                      {name}
-                    </SizableText>
-                  </XStack>
-                )}
-              />
-            )}
-          >
-            {tabData.map((item) => (
-              <Tabs.Tab name={item.title} key={item.type}>
-                <Tabs.ScrollView
-                  refreshControl={
-                    <RefreshControl
-                      refreshing={isLoading}
-                      onRefresh={refreshOverViewData}
-                    />
-                  }
-                >
-                  <AvailableAssetsTabViewListMobile
-                    onTokenPress={handleTokenPress}
-                    assetType={item.type}
-                    faqList={faqList}
-                  />
-                </Tabs.ScrollView>
-              </Tabs.Tab>
-            ))}
-          </Tabs.Container>
-          {platformEnv.isNative ? (
-            <YStack
-              position="absolute"
-              top={-20}
-              left={0}
-              bg="$bgApp"
-              pt="$5"
-              width="100%"
-              onLayout={handleTabPageLayout}
-            >
-              <TabPageHeader
-                sceneName={EAccountSelectorSceneName.home}
-                tabRoute={ETabRoutes.Earn}
-              />
+                {intl.formatMessage({
+                  id: ETranslations.earn_available_assets,
+                })}
+              </SizableText>
             </YStack>
-          ) : null}
-        </Page.Body>
-      </Page>
+          )}
+          renderTabBar={(props) => (
+            <Tabs.TabBar
+              {...props}
+              containerStyle={{
+                px: '$5',
+              }}
+              divider={false}
+              renderItem={({ name, isFocused, onPress }) => (
+                <XStack
+                  px="$2"
+                  py="$1.5"
+                  mr="$1"
+                  bg={isFocused ? '$bgActive' : '$bg'}
+                  borderRadius="$2"
+                  borderCurve="continuous"
+                  onPress={() => onPress(name)}
+                >
+                  <SizableText
+                    size="$bodyMdMedium"
+                    color={isFocused ? '$text' : '$textSubdued'}
+                    letterSpacing={-0.15}
+                  >
+                    {name}
+                  </SizableText>
+                </XStack>
+              )}
+            />
+          )}
+        >
+          {tabData.map((item) => (
+            <Tabs.Tab name={item.title} key={item.type}>
+              <Tabs.ScrollView
+                refreshControl={
+                  <RefreshControl
+                    refreshing={isLoading}
+                    onRefresh={refreshOverViewData}
+                  />
+                }
+              >
+                <AvailableAssetsTabViewListMobile
+                  onTokenPress={handleTokenPress}
+                  assetType={item.type}
+                  faqList={faqList}
+                />
+              </Tabs.ScrollView>
+            </Tabs.Tab>
+          ))}
+        </Tabs.Container>
+        {platformEnv.isNative ? (
+          <YStack
+            position="absolute"
+            top={-20}
+            left={0}
+            bg="$bgApp"
+            pt="$5"
+            width="100%"
+            onLayout={handleTabPageLayout}
+          >
+            <TabPageHeader
+              sceneName={EAccountSelectorSceneName.home}
+              tabRoute={ETabRoutes.Earn}
+            />
+          </YStack>
+        ) : null}
+      </>
     );
   }
 
   return (
     <Page fullPage>
-      <TabPageHeader
-        sceneName={EAccountSelectorSceneName.home}
-        tabRoute={ETabRoutes.Earn}
-      >
-        {/* {headerRight} */}
-      </TabPageHeader>
       <Page.Body>
         <ScrollView
           contentContainerStyle={{ py: '$5' }}
@@ -1252,6 +1244,16 @@ function BasicEarnHome() {
   );
 }
 
+export function WithPageEarnHome() {
+  return (
+    <Page fullPage>
+      <Page.Body>
+        <EarnHomeContent />
+      </Page.Body>
+    </Page>
+  );
+}
+
 export default function EarnHome() {
   return (
     <AccountSelectorProviderMirror
@@ -1262,7 +1264,7 @@ export default function EarnHome() {
       enabledNum={[0]}
     >
       <EarnProviderMirror storeName={EJotaiContextStoreNames.earn}>
-        <BasicEarnHome />
+        <WithPageEarnHome />
       </EarnProviderMirror>
     </AccountSelectorProviderMirror>
   );

--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -637,6 +637,7 @@ function Overview({
 }
 
 function EarnBlockedOverview(props: {
+  showHeader?: boolean;
   icon: IKeyOfIcons;
   title: string;
   description: string;
@@ -644,14 +645,16 @@ function EarnBlockedOverview(props: {
   refreshing: boolean;
 }) {
   const intl = useIntl();
-  const { title, description, icon, refresh, refreshing } = props;
+  const { title, description, icon, refresh, refreshing, showHeader } = props;
 
   return (
     <Page fullPage>
-      <TabPageHeader
-        sceneName={EAccountSelectorSceneName.home}
-        tabRoute={ETabRoutes.Earn}
-      />
+      {showHeader ? (
+        <TabPageHeader
+          sceneName={EAccountSelectorSceneName.home}
+          tabRoute={ETabRoutes.Earn}
+        />
+      ) : null}
       <Page.Body>
         <Empty
           icon={icon}
@@ -676,7 +679,7 @@ function EarnBlockedOverview(props: {
   );
 }
 
-export function EarnHomeContent() {
+function EarnHomeContent({ showHeader }: { showHeader?: boolean }) {
   const { activeAccount } = useActiveAccount({ num: 0 });
   const { account, indexedAccount } = activeAccount;
   const media = useMedia();
@@ -1022,6 +1025,7 @@ export function EarnHomeContent() {
   if (!isFetchingBlockResult && blockResult?.blockData) {
     return (
       <EarnBlockedOverview
+        showHeader={showHeader}
         refresh={refreshBlockResult}
         refreshing={!!isFetchingBlockResult}
         icon={blockResult.blockData.icon.icon}
@@ -1034,7 +1038,7 @@ export function EarnHomeContent() {
   if (platformEnv.isNative && media.md) {
     return (
       <>
-        <Stack h={tabPageHeight} />
+        {showHeader ? <Stack h={tabPageHeight} /> : null}
         <Tabs.Container
           allowHeaderOverscroll
           renderHeader={() => (
@@ -1134,7 +1138,7 @@ export function EarnHomeContent() {
             </Tabs.Tab>
           ))}
         </Tabs.Container>
-        {platformEnv.isNative ? (
+        {showHeader && platformEnv.isNative ? (
           <YStack
             position="absolute"
             top={-20}
@@ -1244,17 +1248,11 @@ export function EarnHomeContent() {
   );
 }
 
-export function WithPageEarnHome() {
-  return (
-    <Page fullPage>
-      <Page.Body>
-        <EarnHomeContent />
-      </Page.Body>
-    </Page>
-  );
-}
-
-export default function EarnHome() {
+export function EarnHomeWithProvider({
+  showHeader = true,
+}: {
+  showHeader?: boolean;
+}) {
   return (
     <AccountSelectorProviderMirror
       config={{
@@ -1264,8 +1262,18 @@ export default function EarnHome() {
       enabledNum={[0]}
     >
       <EarnProviderMirror storeName={EJotaiContextStoreNames.earn}>
-        <WithPageEarnHome />
+        <EarnHomeContent showHeader={showHeader} />
       </EarnProviderMirror>
     </AccountSelectorProviderMirror>
+  );
+}
+
+export default function EarnHome() {
+  return (
+    <Page fullPage>
+      <Page.Body>
+        <EarnHomeWithProvider />
+      </Page.Body>
+    </Page>
   );
 }

--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -1276,7 +1276,6 @@ export function EarnHomeWithProvider({
   showHeader?: boolean;
   showContent?: boolean;
 }) {
-  console.log('showContent', showContent);
   return (
     <AccountSelectorProviderMirror
       config={{

--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -638,6 +638,7 @@ function Overview({
 
 function EarnBlockedOverview(props: {
   showHeader?: boolean;
+  showContent?: boolean;
   icon: IKeyOfIcons;
   title: string;
   description: string;
@@ -645,7 +646,15 @@ function EarnBlockedOverview(props: {
   refreshing: boolean;
 }) {
   const intl = useIntl();
-  const { title, description, icon, refresh, refreshing, showHeader } = props;
+  const {
+    title,
+    description,
+    icon,
+    refresh,
+    refreshing,
+    showHeader,
+    showContent,
+  } = props;
 
   return (
     <Page fullPage>
@@ -657,6 +666,7 @@ function EarnBlockedOverview(props: {
       ) : null}
       <Page.Body>
         <Empty
+          display={showContent ? undefined : 'none'}
           icon={icon}
           title={title}
           description={description}
@@ -679,7 +689,13 @@ function EarnBlockedOverview(props: {
   );
 }
 
-function EarnHomeContent({ showHeader }: { showHeader?: boolean }) {
+function EarnHomeContent({
+  showHeader,
+  showContent,
+}: {
+  showHeader?: boolean;
+  showContent?: boolean;
+}) {
   const { activeAccount } = useActiveAccount({ num: 0 });
   const { account, indexedAccount } = activeAccount;
   const media = useMedia();
@@ -1026,6 +1042,7 @@ function EarnHomeContent({ showHeader }: { showHeader?: boolean }) {
     return (
       <EarnBlockedOverview
         showHeader={showHeader}
+        showContent={showContent}
         refresh={refreshBlockResult}
         refreshing={!!isFetchingBlockResult}
         icon={blockResult.blockData.icon.icon}
@@ -1040,6 +1057,9 @@ function EarnHomeContent({ showHeader }: { showHeader?: boolean }) {
       <>
         {showHeader ? <Stack h={tabPageHeight} /> : null}
         <Tabs.Container
+          containerStyle={{
+            display: showContent ? undefined : 'none',
+          }}
           allowHeaderOverscroll
           renderHeader={() => (
             <YStack
@@ -1250,9 +1270,12 @@ function EarnHomeContent({ showHeader }: { showHeader?: boolean }) {
 
 export function EarnHomeWithProvider({
   showHeader = true,
+  showContent = true,
 }: {
   showHeader?: boolean;
+  showContent?: boolean;
 }) {
+  console.log('showContent', showContent);
   return (
     <AccountSelectorProviderMirror
       config={{
@@ -1262,7 +1285,7 @@ export function EarnHomeWithProvider({
       enabledNum={[0]}
     >
       <EarnProviderMirror storeName={EJotaiContextStoreNames.earn}>
-        <EarnHomeContent showHeader={showHeader} />
+        <EarnHomeContent showHeader={showHeader} showContent={showContent} />
       </EarnProviderMirror>
     </AccountSelectorProviderMirror>
   );

--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -1,5 +1,5 @@
 import type { PropsWithChildren } from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 import { StyleSheet } from 'react-native';
@@ -43,6 +43,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   EModalRoutes,
   EModalStakingRoutes,
+  ETabDiscoveryRoutes,
   ETabRoutes,
 } from '@onekeyhq/shared/src/routes';
 import {
@@ -1291,7 +1292,31 @@ export function EarnHomeWithProvider({
   );
 }
 
+const useNavigateToNativeEarnPage = platformEnv.isNative
+  ? () => {
+      const { md } = useMedia();
+      const navigation = useAppNavigation();
+      useLayoutEffect(() => {
+        if (md) {
+          navigation.navigate(
+            ETabRoutes.Discovery,
+            {
+              screen: ETabDiscoveryRoutes.TabDiscovery,
+              params: {
+                defaultTab: ETranslations.global_earn,
+              },
+            },
+            {
+              pop: true,
+            },
+          );
+        }
+      }, [navigation, md]);
+    }
+  : () => {};
+
 export default function EarnHome() {
+  useNavigateToNativeEarnPage();
   return (
     <Page fullPage>
       <Page.Body>

--- a/packages/kit/src/views/Home/pages/ApprovalListContainer.tsx
+++ b/packages/kit/src/views/Home/pages/ApprovalListContainer.tsx
@@ -164,9 +164,9 @@ function ApprovalListContainer() {
     };
   }, [isFocused, run]);
 
-  if (wallet && wallet.type === WALLET_TYPE_HD && !wallet.backuped) {
-    return null;
-  }
+  // if (wallet && wallet.type === WALLET_TYPE_HD && !wallet.backuped) {
+  //   return null;
+  // }
 
   return (
     <ApprovalListView

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -328,27 +328,30 @@ export function HomePageView({
         allowHeaderOverscroll
         width={tabContainerWidth}
         renderHeader={renderHeader}
-        renderTabBar={(props: any) =>
-          isWalletNotBackedUp ? null : (
-            <Tabs.TabBar
-              {...props}
-              renderItem={handleRenderItem}
-              renderToolbar={({ focusedTab }) => (
-                <TabHeaderSettings focusedTab={focusedTab} />
-              )}
-            />
-          )
-        }
-      >
-        {isWalletNotBackedUp ? (
-          <NotBackedUpEmpty />
-        ) : (
-          tabConfigs.map((tab) => (
-            <Tabs.Tab key={tab.name} name={tab.name}>
-              {tab.component}
-            </Tabs.Tab>
-          ))
+        renderTabBar={(props: any) => (
+          // isWalletNotBackedUp ? null : (
+          //   <Tabs.TabBar
+          //     {...props}
+          //     renderItem={handleRenderItem}
+          //     renderToolbar={({ focusedTab }) => (
+          //       <TabHeaderSettings focusedTab={focusedTab} />
+          //     )}
+          //   />
+          // )
+          <Tabs.TabBar
+            {...props}
+            renderItem={handleRenderItem}
+            renderToolbar={({ focusedTab }) => (
+              <TabHeaderSettings focusedTab={focusedTab} />
+            )}
+          />
         )}
+      >
+        {tabConfigs.map((tab) => (
+          <Tabs.Tab key={tab.name} name={tab.name}>
+            {tab.component}
+          </Tabs.Tab>
+        ))}
       </Tabs.Container>
     );
   }, [
@@ -357,7 +360,6 @@ export function HomePageView({
     handleRenderItem,
     isBulkRevokeApprovalEnabled,
     isNFTEnabled,
-    isWalletNotBackedUp,
     network?.id,
     renderHeader,
     tabConfigs,

--- a/packages/kit/src/views/Home/pages/NFTListContainer.tsx
+++ b/packages/kit/src/views/Home/pages/NFTListContainer.tsx
@@ -337,9 +337,9 @@ function NFTListContainer() {
     };
   }, [handleRefreshAllNetworkData, isFocused, network?.isAllNetworks, run]);
 
-  if (wallet && wallet.type === WALLET_TYPE_HD && !wallet.backuped) {
-    return null;
-  }
+  // if (wallet && wallet.type === WALLET_TYPE_HD && !wallet.backuped) {
+  //   return null;
+  // }
 
   return (
     <NFTListView

--- a/packages/kit/src/views/Home/pages/TokenListContainer.tsx
+++ b/packages/kit/src/views/Home/pages/TokenListContainer.tsx
@@ -1923,9 +1923,9 @@ function TokenListContainer({
     return false;
   }, [allNetworksState.visibleCount, network?.isAllNetworks]);
 
-  if (wallet && wallet.type === WALLET_TYPE_HD && !wallet.backuped) {
-    return null;
-  }
+  // if (wallet && wallet.type === WALLET_TYPE_HD && !wallet.backuped) {
+  //   return null;
+  // }
 
   return (
     <TokenListView

--- a/packages/kit/src/views/Home/pages/TxHistoryContainer.tsx
+++ b/packages/kit/src/views/Home/pages/TxHistoryContainer.tsx
@@ -397,9 +397,9 @@ function TxHistoryListContainer() {
     void initAddressesInfoDataFromStorage();
   }, [initAddressesInfoDataFromStorage]);
 
-  if (wallet && wallet.type === WALLET_TYPE_HD && !wallet.backuped) {
-    return null;
-  }
+  // if (wallet && wallet.type === WALLET_TYPE_HD && !wallet.backuped) {
+  //   return null;
+  // }
 
   return (
     <TxHistoryListView

--- a/packages/shared/src/routes/tabDiscovery.ts
+++ b/packages/shared/src/routes/tabDiscovery.ts
@@ -1,7 +1,11 @@
+import type { ETranslations } from '../locale';
+
 export enum ETabDiscoveryRoutes {
   TabDiscovery = 'TabDiscovery',
 }
 
 export type ITabDiscoveryParamList = {
-  [ETabDiscoveryRoutes.TabDiscovery]: undefined;
+  [ETabDiscoveryRoutes.TabDiscovery]: {
+    defaultTab?: ETranslations;
+  };
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile Discovery header: selectable browser/Earn tabs with persisted default and layout-aware header overlay.
  * TabPageHeader and header components now accept selectedHeaderTab and onSelectHeaderTab props for external control.
  * EarnHomeWithProvider export to toggle header/content and improved native Earn navigation.
  * Persisted selectedBrowserTab state and ServiceSetting API to update it; route supports defaultTab param.

* **Bug Fixes**
  * Home wallet pages render consistently — backup-status early-return guards removed.
  * Earn tab can be hidden from native tab bar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->