### PR TITLE
fix: perp deposit change account balance fix OK-45334

### DIFF
--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -1061,11 +1061,17 @@ function DepositWithdrawContent({
         currentPerpsDepositSelectedToken:
           arbUSDCToken ?? depositTokensWithPrice?.[0],
       }));
+    } else if (!checkAccountSupport) {
+      setPerpsDepositTokensAtom((prev) => ({
+        ...prev,
+        currentPerpsDepositSelectedToken: undefined,
+      }));
     }
   }, [
     depositTokensWithPrice,
     currentPerpsDepositSelectedToken,
     setPerpsDepositTokensAtom,
+    checkAccountSupport,
   ]);
 
   const depositTokenSelectComponent = useMemo(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed token selection behavior in perpetual trading deposits and withdrawals. The previously selected token is now properly cleared when account support is unavailable, preventing incompatible token selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->