### PR TITLE
Revert "feat: add provisioning profile and entitlements for macOS app"

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -82,13 +82,7 @@ jobs:
 
       - name: Setup Code Signing file
         run: |
-          PP_PATH=./apps/desktop/OneKey_Mac_App.provisionprofile
           echo ${{ secrets.DESKTOP_KEYS_SECRET }} | base64 -d > apps/desktop/sign.p12
-          echo -n ${{secrets.DESKTOP_ISO_PROVISION_PROFILE_BASE64}} | base64 --decode > $PP_PATH
-
-          # apply provisioning profile
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
 
       # - name: Publish and Sign Static Linux / Macos
       #   if: ${{ (github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/x') }}
@@ -112,11 +106,6 @@ jobs:
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           CSC_LINK: './sign.p12'
         run: 'cd apps/desktop && yarn build'
-
-      - name: Clean up keychain and provisioning profile
-        if: ${{ always() }}
-        run: |
-          rm ~/Library/MobileDevice/Provisioning\ Profiles/OneKey_Mac_App.provisionprofile
        
       - name: Upload Artifacts latest.yml
         uses: actions/upload-artifact@v4

--- a/apps/desktop/electron-builder.config.js
+++ b/apps/desktop/electron-builder.config.js
@@ -44,7 +44,6 @@ module.exports = {
       { target: 'dmg', arch: ['x64', 'arm64', 'universal'] },
       { target: 'zip', arch: ['x64', 'arm64', 'universal'] },
     ],
-    'provisioningProfile': 'OneKey_Mac_App.provisionprofile',
     'entitlements': getPath('entitlements.mac.plist'),
     'extendInfo': {
       'NSCameraUsageDescription': 'Please allow OneKey to use your camera',

--- a/apps/desktop/entitlements.mac.plist
+++ b/apps/desktop/entitlements.mac.plist
@@ -2,20 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <key>com.apple.security.app-sandbox</key>
-    <true/>
-    <key>com.apple.security.application-groups</key>
-    <array>
-      <string>BVJ3FU5H2K.so.onekey.wallet</string>
-    </array>
-    <key>com.apple.security.network.client</key>
-    <true/>
-    <key>com.apple.security.network.server</key>
-    <true/>
-    <key>com.apple.security.files.user-selected.read-write</key>
-    <true/>
-    <key>com.apple.security.files.user-selected.read-only</key>
-    <true/>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
@@ -27,8 +13,6 @@
     <key>com.apple.security.device.camera</key>
     <true/>
     <key>com.apple.security.device.bluetooth</key>
-    <true/>
-    <key>com.apple.security.device.usb</key>
     <true/>
   </dict>
 </plist>


### PR DESCRIPTION
… (#8861)"

This reverts commit ef0dfedf6cd899d83da13cbf0a33894213ab3341.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Simplified macOS application build and code signing configuration by removing provisioning profile handling from the build workflow and related configuration files.
  * Adjusted macOS application permissions, removing access to USB devices, file system operations, and network connectivity while retaining multimedia input and Bluetooth capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->