### PR TITLE
Feat/bifrost dot

### DIFF
--- a/packages/kit-bg/src/vaults/impls/dot/settings.ts
+++ b/packages/kit-bg/src/vaults/impls/dot/settings.ts
@@ -61,13 +61,6 @@ const settings: IVaultSettings = {
       addressPrefix: '0',
       nativeTokenAddress: 'DOT',
     },
-    'dot--polkadot': {
-      curve: 'ed25519',
-      addressPrefix: '0',
-      nativeTokenAddress: 'DOT',
-      genesisHash:
-        '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3',
-    },
     'dot--astar': {
       curve: 'ed25519',
       addressPrefix: '5',

--- a/packages/kit-bg/src/vaults/impls/dot/settings.ts
+++ b/packages/kit-bg/src/vaults/impls/dot/settings.ts
@@ -110,6 +110,13 @@ const settings: IVaultSettings = {
       genesisHash:
         '0x9f28c6a68e0fc9646eff64935684f6eeeece527e37bbe1f213d22caa1d9d6bed',
     },
+    'dot--bifrost': {
+      curve: 'ed25519',
+      addressPrefix: '0',
+      nativeTokenAddress: 'BNC',
+      genesisHash:
+        '0x262e1b2ad728475fd6fe88e62d34c200abe6fd693931ddad144059b1eb884e5b',
+    },
     'dot--kusama-assethub': {
       curve: 'ed25519',
       addressPrefix: '2',

--- a/packages/shared/src/config/presetNetworks.ts
+++ b/packages/shared/src/config/presetNetworks.ts
@@ -2489,26 +2489,6 @@ const sol: IServerNetwork = {
   'status': ENetworkStatus.LISTED,
 };
 
-const polkadot: IServerNetwork = {
-  'chainId': 'polkadot',
-  'code': 'dot',
-  'decimals': 10,
-  'id': 'dot--polkadot',
-  'impl': 'dot',
-  'isTestnet': false,
-  'logoURI': 'https://uni.onekey-asset.com/static/chain/polkadot.png',
-  'name': 'Polkadot',
-  'shortcode': 'dot',
-  'shortname': 'DOT',
-  'symbol': 'DOT',
-  'feeMeta': {
-    'decimals': 10,
-    'symbol': 'DOT',
-  },
-  'defaultEnabled': true,
-  'status': ENetworkStatus.LISTED,
-};
-
 const astar: IServerNetwork = {
   'chainId': 'astar',
   'code': 'astar',
@@ -2648,7 +2628,6 @@ const bifrost: IServerNetwork = {
   'defaultEnabled': true,
   'status': ENetworkStatus.LISTED,
 };
-
 
 const bifrostDot: IServerNetwork = {
   'chainId': 'dot-bifrost',
@@ -3029,7 +3008,6 @@ export const presetNetworksMap = {
   noble,
 
   // polkadot
-  polkadot,
   astar,
   manta,
   joystream,
@@ -3229,7 +3207,6 @@ export const getPresetNetworks = memoFn((): IServerNetwork[] => {
     noble,
 
     // polkadot
-    polkadot,
     astar,
     manta,
     joystream,

--- a/packages/shared/src/config/presetNetworks.ts
+++ b/packages/shared/src/config/presetNetworks.ts
@@ -2649,6 +2649,27 @@ const bifrost: IServerNetwork = {
   'status': ENetworkStatus.LISTED,
 };
 
+
+const bifrostDot: IServerNetwork = {
+  'chainId': 'dot-bifrost',
+  'code': 'dot-bifrost',
+  'decimals': 12,
+  'id': 'dot--bifrost',
+  'impl': 'dot',
+  'isTestnet': false,
+  'logoURI': 'https://uni.onekey-asset.com/static/chain/bnc.png',
+  'name': 'Bifrost Polkadot',
+  'shortcode': 'dot-bifrost',
+  'shortname': 'BNC',
+  'symbol': 'BNC',
+  'feeMeta': {
+    'decimals': 12,
+    'symbol': 'BNC',
+  },
+  'defaultEnabled': true,
+  'status': ENetworkStatus.LISTED,
+};
+
 const kaspa: IServerNetwork = {
   'chainId': 'kaspa',
   'code': 'kaspa',
@@ -3014,6 +3035,7 @@ export const presetNetworksMap = {
   joystream,
   hydradx,
   bifrost,
+  bifrostDot,
   assethubPolkadot,
   assethubKusama,
 
@@ -3213,6 +3235,7 @@ export const getPresetNetworks = memoFn((): IServerNetwork[] => {
     joystream,
     hydradx,
     bifrost,
+    bifrostDot,
     assethubPolkadot,
     assethubKusama,
 

--- a/packages/shared/src/utils/networkDetectUtils.test.ts
+++ b/packages/shared/src/utils/networkDetectUtils.test.ts
@@ -238,10 +238,6 @@ describe('Network Detection by Private Key', () => {
         networkId: presetNetworksMap.kaspa.id,
         impl: presetNetworksMap.kaspa.impl,
       });
-      expect(result).toContainEqual({
-        networkId: presetNetworksMap.polkadot.id,
-        impl: presetNetworksMap.polkadot.impl,
-      });
     });
 
     test('detects Cosmos family (0x-prefixed)', async () => {
@@ -316,17 +312,17 @@ describe('Network Detection by Private Key', () => {
       });
     });
 
-    test('detects Polkadot (0x-prefixed)', async () => {
-      const privateKey =
-        '0xc052cb9ba86a213302c9518890420f9493f3a00fde54c74582bcb46ad30ce846';
-      const result = await networkDetectUtils.detectNetworkByPrivateKey({
-        privateKey,
-      });
-      expect(result).toContainEqual({
-        networkId: presetNetworksMap.polkadot.id,
-        impl: presetNetworksMap.polkadot.impl,
-      });
-    });
+    // test('detects Polkadot (0x-prefixed)', async () => {
+    //   const privateKey =
+    //     '0xc052cb9ba86a213302c9518890420f9493f3a00fde54c74582bcb46ad30ce846';
+    //   const result = await networkDetectUtils.detectNetworkByPrivateKey({
+    //     privateKey,
+    //   });
+    //   expect(result).toContainEqual({
+    //     networkId: presetNetworksMap.polkadot.id,
+    //     impl: presetNetworksMap.polkadot.impl,
+    //   });
+    // });
   });
 
   describe('64 hex without 0x prefix - Multi-chain Detection', () => {

--- a/packages/shared/src/utils/networkDetectUtils.ts
+++ b/packages/shared/src/utils/networkDetectUtils.ts
@@ -469,10 +469,6 @@ async function detectNetworkByPrivateKey({
         impl: presetNetworksMap.kaspa.impl,
       },
       {
-        networkId: presetNetworksMap.polkadot.id,
-        impl: presetNetworksMap.polkadot.impl,
-      },
-      {
         networkId: presetNetworksMap.cosmoshub.id,
         impl: presetNetworksMap.cosmoshub.impl,
       },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Network Updates**
  * Removed Polkadot as a supported chain.
  * Added Bifrost Polkadot (BNC) as a newly supported network with updated token and address configuration.

* **Tests & Detection**
  * Disabled Polkadot-related private-key detection tests.
  * Polkadot will no longer be auto-detected from certain 0x‑prefixed private keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->