### PR TITLE
refactor: update network initialization logic and remove default values

### DIFF
--- a/packages/kit-bg/src/services/ServiceMarketV2.ts
+++ b/packages/kit-bg/src/services/ServiceMarketV2.ts
@@ -75,6 +75,11 @@ class ServiceMarketV2 extends ServiceBase {
       const client = await this.getClient(EServiceEndpointEnum.Utility);
       const response = await client.get<IMarketBasicConfigResponse>(
         '/utility/v2/market/basic-config',
+        {
+          params: {
+            configVersion: 2,
+          },
+        },
       );
       return response.data;
     },

--- a/packages/kit/src/states/jotai/contexts/marketV2/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/marketV2/atoms.ts
@@ -56,8 +56,9 @@ export const { atom: isNativeAtom, use: useIsNativeAtom } =
 export const { atom: showWatchlistOnlyAtom, use: useShowWatchlistOnlyAtom } =
   contextAtom<boolean>(false);
 
+// Empty string means not initialized yet, will be set by MarketHomeV2
 export const { atom: selectedNetworkIdAtom, use: useSelectedNetworkIdAtom } =
-  contextAtom<string>('sol--101');
+  contextAtom<string>('');
 
 export const { atom: selectedMarketTabAtom, use: useSelectedMarketTabAtom } =
   contextAtom<string>('trending');

--- a/packages/kit/src/views/Market/MarketHomeV2/MarketHomeV2.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/MarketHomeV2.tsx
@@ -32,9 +32,10 @@ function MarketHome() {
   const { handleTabChange } = useTabAnalytics();
   const { handleNetworkChange } = useNetworkAnalytics(selectedNetworkId);
 
-  // Update selectedNetworkId when config loads and it's still the default
+  // Initialize with the default network from API config (only when not yet initialized)
   useEffect(() => {
-    if (defaultNetworkId && selectedNetworkId === 'sol--101') {
+    // Only initialize if selectedNetworkId is empty (not yet set)
+    if (defaultNetworkId && !selectedNetworkId) {
       setSelectedNetworkId(defaultNetworkId);
     }
   }, [defaultNetworkId, selectedNetworkId, setSelectedNetworkId]);

--- a/packages/kit/src/views/Market/MarketHomeV2/hooks/useNetworkAnalytics.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/hooks/useNetworkAnalytics.ts
@@ -29,8 +29,6 @@ export function useNetworkAnalytics(selectedNetworkId: string) {
       // Update the selected network state
       setSelectedNetworkId(networkId);
 
-      console.log('handleNetworkChange', networkId);
-
       // Track network selection
       defaultLogger.dex.list.dexNetwork({
         network: networkId,

--- a/packages/kit/src/views/Market/hooks/useMarketBasicConfig/index.ts
+++ b/packages/kit/src/views/Market/hooks/useMarketBasicConfig/index.ts
@@ -56,7 +56,7 @@ export function useMarketBasicConfig() {
 
     // Provide default values when data is not loaded yet
     basicConfig: result?.basicConfig,
-    defaultNetworkId: result?.defaultNetworkId || 'sol--101',
+    defaultNetworkId: result?.defaultNetworkId,
     recommendedTokens: result?.recommendedTokens || [],
     minLiquidity: result?.minLiquidity || 5000,
     refreshInterval: result?.refreshInterval || 5,

--- a/packages/kit/src/views/Market/hooks/useMarketBasicConfig/utils.ts
+++ b/packages/kit/src/views/Market/hooks/useMarketBasicConfig/utils.ts
@@ -10,7 +10,7 @@ import type {
 export function getDefaultNetworkId(
   basicConfig?: IMarketBasicConfigData,
 ): string {
-  return basicConfig?.networkList?.[0]?.networkId || 'sol--101';
+  return basicConfig?.networkList?.[0]?.networkId;
 }
 
 /**

--- a/packages/kit/src/views/Market/hooks/useMarketBasicConfig/utils.ts
+++ b/packages/kit/src/views/Market/hooks/useMarketBasicConfig/utils.ts
@@ -1,15 +1,11 @@
-import type {
-  IMarketBasicConfigData,
-  IMarketBasicConfigToken,
-  IMarketTokenListItem,
-} from '@onekeyhq/shared/types/marketV2';
+import type { IMarketBasicConfigData } from '@onekeyhq/shared/types/marketV2';
 
 /**
  * Extract default network ID from basic config
  */
 export function getDefaultNetworkId(
   basicConfig?: IMarketBasicConfigData,
-): string {
+): string | undefined {
   return basicConfig?.networkList?.[0]?.networkId;
 }
 

--- a/packages/shared/types/marketV2.ts
+++ b/packages/shared/types/marketV2.ts
@@ -282,12 +282,30 @@ export interface IMarketBasicConfigToken {
   logo?: string;
 }
 
+export interface IMarketBasicConfigNetworkFeature {
+  actionBar?: boolean;
+  [key: string]: unknown;
+}
+
+export interface IMarketBasicConfigFeature {
+  marketWebsocket?: {
+    transactions?: boolean;
+    price?: boolean;
+  };
+  [key: string]: unknown;
+}
+
 export interface IMarketBasicConfigData {
+  tradingViewUrl: string;
   networkList: IMarketBasicConfigNetwork[];
   recommendTokens: IMarketBasicConfigToken[];
   searchRecommendTokens: IMarketBasicConfigToken[];
   refreshInterval: number;
   minLiquidity: number;
+  networkFeature?: {
+    [networkId: string]: IMarketBasicConfigNetworkFeature;
+  };
+  feature?: IMarketBasicConfigFeature;
 }
 
 export interface IMarketBasicConfigResponse {


### PR DESCRIPTION
- Changed the initialization of selectedNetworkIdAtom to an empty string to indicate uninitialized state.
- Updated MarketHomeV2 to initialize selectedNetworkId only if it is empty.
- Removed hardcoded default network ID 'sol--101' from various locations, allowing for more dynamic configuration.
- Added new interfaces for network features and basic config data structure to support future enhancements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Market configuration now includes TradingView integration and per-network feature flags.

* **Chores**
  * Network selection initialization now respects the API-provided default instead of a hard-coded preset.
  * Market config fetches use an updated config version query to retrieve the latest settings.
  * Removed debug logging related to network changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->