### PR TITLE
fix: add conditional header to EarnHomeContent

### DIFF
--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -1191,6 +1191,12 @@ function EarnHomeContent({
 
   return (
     <Page fullPage>
+      {showHeader ? (
+        <TabPageHeader
+          sceneName={EAccountSelectorSceneName.home}
+          tabRoute={ETabRoutes.Earn}
+        />
+      ) : null}
       <Page.Body>
         <ScrollView
           contentContainerStyle={{ py: '$5' }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Earn tab header now displays consistently across layouts when enabled, improving visual organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->