### PR TITLE
fix: update host security level to Unknown in ServiceDiscovery (#9005)

### DIFF
--- a/packages/kit-bg/src/services/ServiceDiscovery.ts
+++ b/packages/kit-bg/src/services/ServiceDiscovery.ts
@@ -181,7 +181,7 @@ class ServiceDiscovery extends ServiceBase {
     } catch (e) {
       return {
         host: url,
-        level: EHostSecurityLevel.Medium,
+        level: EHostSecurityLevel.Unknown,
         attackTypes: [],
         phishingSite: false,
         alert: appLocale.intl.formatMessage({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected host security status reporting during URL security assessment failures. The system now reports "Unknown" security level instead of "Medium" when unable to verify security status due to timeouts or exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->