### PR TITLE
refactor: remove unused perpsUserFillsCacheAtom from atomNames enum

### DIFF
--- a/packages/kit-bg/src/states/jotai/atomNames.ts
+++ b/packages/kit-bg/src/states/jotai/atomNames.ts
@@ -84,7 +84,6 @@ export enum EAtomNames {
   perpTokenSortConfigPersistAtom = 'perpTokenSortConfigPersistAtom',
   perpsDepositOrderAtom = 'perpsDepositOrderAtom',
   perpsLastUsedLeverageAtom = 'perpsLastUsedLeverageAtom',
-  perpsUserFillsCacheAtom = 'perpsUserFillsCacheAtom',
   // network doctor
   networkDoctorStateAtom = 'networkDoctorStateAtom',
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused internal state management configuration, streamlining the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->