### PR TITLE
fix: dapp info zindex on wallet home

### DIFF
--- a/packages/kit/src/views/DAppConnection/components/DAppConnectExtensionFloatingTrigger/index.ext.tsx
+++ b/packages/kit/src/views/DAppConnection/components/DAppConnectExtensionFloatingTrigger/index.ext.tsx
@@ -221,6 +221,7 @@ function DAppConnectExtensionFloatingTrigger() {
       bg="$bgApp"
       borderTopWidth="$px"
       borderColor="$borderSubdued"
+      zIndex={999}
     >
       {renderSyncDappAccountToHomeProvider}
       <HeightTransition>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a display issue where the DApp connection trigger was appearing behind other interface elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->