### PR TITLE
fix: detect USB device availability before firmware upgrade

### DIFF
--- a/packages/kit/src/views/Onboardingv2/pages/CheckAndUpdate.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/CheckAndUpdate.tsx
@@ -170,13 +170,33 @@ function CheckAndUpdatePage({
   ]);
 
   const actions = useFirmwareUpdateActions();
-  const toFirmwareUpgradePage = useCallback(() => {
+  const toFirmwareUpgradePage = useCallback(async () => {
+    // Check if USB device is available
+    const isUSBDeviceAvailable =
+      await backgroundApiProxy.serviceHardware.detectUSBDeviceAvailability();
+    if (!isUSBDeviceAvailable) {
+      Dialog.show({
+        icon: 'TypeCoutline',
+        title: intl.formatMessage({
+          id: ETranslations.upgrade_use_usb,
+        }),
+        description: intl.formatMessage({
+          id: ETranslations.upgrade_recommend_usb,
+        }),
+        onConfirmText: intl.formatMessage({
+          id: ETranslations.global_got_it,
+        }),
+        showCancelButton: false,
+      });
+      return;
+    }
+
     if (deviceData.device?.connectId) {
       actions.openChangeLogModal({
         connectId: deviceData.device?.connectId,
       });
     }
-  }, [actions, deviceData.device?.connectId]);
+  }, [actions, deviceData.device?.connectId, intl]);
 
   const createStepTimeout = useCallback(() => {
     const timeout = setTimeout(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added USB device detection prior to firmware upgrade. Users will now receive a localized notification if no USB device is available before proceeding with the upgrade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->