### PR TITLE
feat: add support for desktop USB transport type in onboarding firmware update process

### DIFF
--- a/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts
+++ b/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts
@@ -1494,6 +1494,14 @@ class ServiceHardware extends ServiceBase {
   }
 
   @backgroundMethod()
+  async getCurrentForceTransportType(): Promise<
+    EHardwareTransportType | undefined
+  > {
+    const state = await hardwareForceTransportAtom.get();
+    return state.forceTransportType;
+  }
+
+  @backgroundMethod()
   async getCurrentTransportType() {
     return this.connectionManager.getCurrentTransportType();
   }

--- a/packages/kit/src/views/Onboardingv2/utils.tsx
+++ b/packages/kit/src/views/Onboardingv2/utils.tsx
@@ -69,6 +69,16 @@ export async function getForceTransportType(
   }
 }
 
+export async function getDesktopForceUSBTransportType(): Promise<EHardwareTransportType | null> {
+  if (platformEnv.isDesktop) {
+    const dev = await backgroundApiProxy.serviceDevSetting.getDevSetting();
+    const usbCommunicationMode = dev?.settings?.usbCommunicationMode;
+    if (usbCommunicationMode === 'bridge') return EHardwareTransportType.Bridge;
+    return EHardwareTransportType.WEBUSB;
+  }
+  return null;
+}
+
 export const getDeviceLabel = (
   deviceTypeItems: EDeviceType[],
   separator = '/',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced desktop hardware device connection management during onboarding. The system now automatically preserves and restores USB transport settings when updating device firmware, ensuring optimal connection stability throughout the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->