### PR TITLE
fix: restore OneKey ID header navigation bar(OK-46269)

### DIFF
--- a/packages/kit/src/views/Prime/router/index.ts
+++ b/packages/kit/src/views/Prime/router/index.ts
@@ -74,8 +74,5 @@ export const PrimeRouter: IModalFlowNavigatorConfig<
   {
     name: EPrimePages.OneKeyId,
     component: OneKeyId,
-    options: {
-      headerShown: false,
-    },
   },
 ];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated header display behavior for the authentication screen to use standard default settings, making the interface more consistent across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->