### PR TITLE
feat: support copy mnemonic on recovery phrase page

### DIFF
--- a/packages/kit/src/views/Onboardingv2/pages/ShowRecoveryPhrase.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ShowRecoveryPhrase.tsx
@@ -5,6 +5,7 @@ import { useIntl } from 'react-intl';
 
 import {
   Button,
+  Dialog,
   Page,
   SizableText,
   XStack,
@@ -85,15 +86,47 @@ export default function ShowRecoveryPhrase() {
   useRecoveryPhraseProtected();
 
   const { copyText } = useClipboard();
+  const handleCopyMnemonic = useCallback(() => {
+    Dialog.show({
+      icon: 'ErrorOutline',
+      tone: 'destructive',
+      title: intl.formatMessage({
+        id: ETranslations.copy_recovery_phrases_warning_title,
+      }),
+      description: intl.formatMessage({
+        id: ETranslations.copy_recovery_phrases_warning_desc,
+      }),
+      footerProps: {
+        flexDirection: 'row-reverse',
+      },
+      onConfirmText: intl.formatMessage({
+        id: ETranslations.copy_anyway,
+      }),
+      onConfirm: () => {
+        copyText(mnemonic);
+      },
+      confirmButtonProps: {
+        testID: 'copy-recovery-phrase-confirm',
+        variant: 'secondary',
+      },
+      onCancelText: intl.formatMessage({
+        id: ETranslations.global_cancel_copy,
+      }),
+      cancelButtonProps: {
+        testID: 'copy-recovery-phrase-cancel',
+        variant: 'primary',
+      },
+    });
+  }, [copyText, intl, mnemonic]);
   const copyButton = useMemo(() => {
     return (
-      <Button size="large" onPress={() => copyText(mnemonic)}>
+      <Button size="large" onPress={handleCopyMnemonic}>
         {intl.formatMessage({
           id: ETranslations.global_copy,
         })}
       </Button>
     );
-  }, [copyText, intl, mnemonic]);
+  }, [handleCopyMnemonic, intl]);
 
   return (
     <Page>

--- a/packages/kit/src/views/Onboardingv2/pages/ShowRecoveryPhrase.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ShowRecoveryPhrase.tsx
@@ -9,6 +9,7 @@ import {
   SizableText,
   XStack,
   YStack,
+  useClipboard,
   useMedia,
 } from '@onekeyhq/components';
 import {
@@ -83,6 +84,17 @@ export default function ShowRecoveryPhrase() {
 
   useRecoveryPhraseProtected();
 
+  const { copyText } = useClipboard();
+  const copyButton = useMemo(() => {
+    return (
+      <Button size="large" onPress={() => copyText(mnemonic)}>
+        {intl.formatMessage({
+          id: ETranslations.global_copy,
+        })}
+      </Button>
+    );
+  }, [copyText, intl, mnemonic]);
+
   return (
     <Page>
       <OnboardingLayout>
@@ -127,26 +139,32 @@ export default function ShowRecoveryPhrase() {
             </XStack>
 
             {gtMd ? (
-              <Button size="large" variant="primary" onPress={handleContinue}>
-                {intl.formatMessage({
-                  id: ETranslations.global_saved_the_phrases,
-                })}
-              </Button>
+              <XStack flex={1} gap="$2">
+                {copyButton}
+                <Button size="large" variant="primary" onPress={handleContinue}>
+                  {intl.formatMessage({
+                    id: ETranslations.global_saved_the_phrases,
+                  })}
+                </Button>
+              </XStack>
             ) : null}
           </YStack>
         </OnboardingLayout.Body>
         {!gtMd ? (
           <OnboardingLayout.Footer>
-            <Button
-              w="100%"
-              size="large"
-              variant="primary"
-              onPress={handleContinue}
-            >
-              {intl.formatMessage({
-                id: ETranslations.global_saved_the_phrases,
-              })}
-            </Button>
+            <XStack gap="$2">
+              {copyButton}
+              <Button
+                w="100%"
+                size="large"
+                variant="primary"
+                onPress={handleContinue}
+              >
+                {intl.formatMessage({
+                  id: ETranslations.global_saved_the_phrases,
+                })}
+              </Button>
+            </XStack>
           </OnboardingLayout.Footer>
         ) : null}
       </OnboardingLayout>

--- a/packages/kit/src/views/Onboardingv2/pages/ShowRecoveryPhrase.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ShowRecoveryPhrase.tsx
@@ -6,6 +6,7 @@ import { useIntl } from 'react-intl';
 import {
   Button,
   Dialog,
+  Icon,
   Page,
   SizableText,
   XStack,
@@ -120,13 +121,11 @@ export default function ShowRecoveryPhrase() {
   }, [copyText, intl, mnemonic]);
   const copyButton = useMemo(() => {
     return (
-      <Button size="large" onPress={handleCopyMnemonic}>
-        {intl.formatMessage({
-          id: ETranslations.global_copy,
-        })}
+      <Button size="large" onPress={handleCopyMnemonic} childrenAsText={false}>
+        <Icon name="Copy3Outline" />
       </Button>
     );
-  }, [handleCopyMnemonic, intl]);
+  }, [handleCopyMnemonic]);
 
   return (
     <Page>
@@ -172,13 +171,18 @@ export default function ShowRecoveryPhrase() {
             </XStack>
 
             {gtMd ? (
-              <XStack flex={1} gap="$2">
-                {copyButton}
-                <Button size="large" variant="primary" onPress={handleContinue}>
+              <XStack gap="$2">
+                <Button
+                  flex={1}
+                  size="large"
+                  variant="primary"
+                  onPress={handleContinue}
+                >
                   {intl.formatMessage({
                     id: ETranslations.global_saved_the_phrases,
                   })}
                 </Button>
+                {copyButton}
               </XStack>
             ) : null}
           </YStack>
@@ -186,9 +190,8 @@ export default function ShowRecoveryPhrase() {
         {!gtMd ? (
           <OnboardingLayout.Footer>
             <XStack gap="$2">
-              {copyButton}
               <Button
-                w="100%"
+                flex={1}
                 size="large"
                 variant="primary"
                 onPress={handleContinue}
@@ -197,6 +200,7 @@ export default function ShowRecoveryPhrase() {
                   id: ETranslations.global_saved_the_phrases,
                 })}
               </Button>
+              {copyButton}
             </XStack>
           </OnboardingLayout.Footer>
         ) : null}

--- a/packages/kit/src/views/Setting/hooks/useLanguageSelector.ts
+++ b/packages/kit/src/views/Setting/hooks/useLanguageSelector.ts
@@ -56,11 +56,16 @@ export function useLanguageSelectorWithoutAuto() {
   }, [localeOptions]);
 
   const value = useMemo(() => {
-    if (locale === 'system') {
-      return systemLocale;
+    const localeValue = locale === 'system' ? systemLocale : locale;
+    if (localeValue === 'en-US') {
+      return 'en';
     }
-    return locale === 'en-US' ? 'en' : locale;
-  }, [locale, systemLocale]);
+    // Check if localeValue exists in options, fallback to 'en' if not found
+    const isValidLocale = options.some(
+      (option) => option.value === localeValue,
+    );
+    return isValidLocale ? localeValue : 'en';
+  }, [locale, systemLocale, options]);
 
   const onChange = useCallback(async (text: string) => {
     await changeLanguage(text);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recovery phrase copy now requires a confirmation dialog before copying and is available via a dedicated copy action in both large-screen and small-screen layouts.

* **Improvements**
  * Language selector now better detects and normalizes system locale, maps variants to primary locales, validates available options, and falls back gracefully when needed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->