### PR TITLE
fix: restore tap responsiveness after view re-appears(OK-46330)

### DIFF
--- a/packages/kit/src/views/Discovery/components/DiscoveryItemCard.tsx
+++ b/packages/kit/src/views/Discovery/components/DiscoveryItemCard.tsx
@@ -79,6 +79,8 @@ export function DiscoveryItemCard({
     );
   }
 
+  // Use TouchableOpacity to fix iOS bug where setTimeout cannot be triggered
+  // through components other than Button or TouchableOpacity after hidden views are restored.
   return (
     <TouchableOpacity onPress={handlePress} activeOpacity={1}>
       <Stack

--- a/packages/kit/src/views/Discovery/components/DiscoveryItemCard.tsx
+++ b/packages/kit/src/views/Discovery/components/DiscoveryItemCard.tsx
@@ -1,6 +1,6 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
-import { StyleSheet } from 'react-native';
+import { StyleSheet, TouchableOpacity } from 'react-native';
 
 import {
   Icon,
@@ -49,6 +49,14 @@ export function DiscoveryItemCard({
     }
     return title;
   }, [title, maxWordLength]);
+
+  const handlePress = useCallback(() => {
+    handleOpenWebSite({
+      dApp,
+      webSite: { url, title, logo, sortIndex: undefined },
+    });
+  }, [handleOpenWebSite, dApp, url, title, logo]);
+
   if (isLoading) {
     return (
       <Stack
@@ -72,42 +80,38 @@ export function DiscoveryItemCard({
   }
 
   return (
-    <Stack
-      py="$2"
-      gap="$3"
-      justifyContent="center"
-      alignItems="center"
-      userSelect="none"
-      onPress={() =>
-        handleOpenWebSite({
-          dApp,
-          webSite: { url, title, logo, sortIndex: undefined },
-        })
-      }
-    >
-      <Image
-        size="$14"
-        position="relative"
-        borderRadius="$3"
-        borderCurve="continuous"
-        borderWidth={StyleSheet.hairlineWidth}
-        borderColor="$borderSubdued"
-        source={{ uri: logo }}
-        fallback={
-          <Image.Fallback>
-            <Icon size="$12" color="$iconSubdued" name="GlobusOutline" />
-          </Image.Fallback>
-        }
-      />
-      <SizableText
-        px="$2"
-        w="100%"
-        size="$bodySmMedium"
-        textAlign="center"
-        numberOfLines={2}
+    <TouchableOpacity onPress={handlePress} activeOpacity={1}>
+      <Stack
+        py="$2"
+        gap="$3"
+        justifyContent="center"
+        alignItems="center"
+        userSelect="none"
       >
-        {displayTitle}
-      </SizableText>
-    </Stack>
+        <Image
+          size="$14"
+          position="relative"
+          borderRadius="$3"
+          borderCurve="continuous"
+          borderWidth={StyleSheet.hairlineWidth}
+          borderColor="$borderSubdued"
+          source={{ uri: logo }}
+          fallback={
+            <Image.Fallback>
+              <Icon size="$12" color="$iconSubdued" name="GlobusOutline" />
+            </Image.Fallback>
+          }
+        />
+        <SizableText
+          px="$2"
+          w="100%"
+          size="$bodySmMedium"
+          textAlign="center"
+          numberOfLines={2}
+        >
+          {displayTitle}
+        </SizableText>
+      </Stack>
+    </TouchableOpacity>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved touch handling on Discovery item cards by wrapping the card in a dedicated touch wrapper for more consistent press behavior across platforms (including iOS).
  * Press interactions now route through a single press handler for more reliable navigation to linked content.
  * No public API changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->