### PR TITLE
feat: enhance OnChainReward component to support perpetual rewards

### DIFF
--- a/packages/kit/src/views/ReferFriends/pages/InviteReward/components/OnChainReward/hooks/usePerpReward.ts
+++ b/packages/kit/src/views/ReferFriends/pages/InviteReward/components/OnChainReward/hooks/usePerpReward.ts
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+
+import BigNumber from 'bignumber.js';
+
+import type { IUsePerpRewardParams, IUsePerpRewardReturn } from '../types';
+
+export function usePerpReward(
+  params: IUsePerpRewardParams,
+): IUsePerpRewardReturn {
+  const { onChain } = params;
+
+  const hasPerpRewards = useMemo(
+    () => (onChain.perp?.length || 0) > 0,
+    [onChain.perp],
+  );
+
+  const perpSummary = useMemo(() => {
+    if (!hasPerpRewards) return undefined;
+    return onChain.perp
+      ?.reduce((acc, curr) => acc.plus(BigNumber(curr.usdValue)), BigNumber(0))
+      .toFixed(2);
+  }, [hasPerpRewards, onChain.perp]);
+
+  const perpSummaryFiat = useMemo(() => {
+    if (!hasPerpRewards) return undefined;
+    return onChain.perp
+      ?.reduce((acc, curr) => acc.plus(BigNumber(curr.fiatValue)), BigNumber(0))
+      .toFixed(2);
+  }, [hasPerpRewards, onChain.perp]);
+
+  const perpToken = useMemo(() => {
+    return onChain.perp?.[0]?.token;
+  }, [onChain.perp]);
+
+  return {
+    perpToken,
+    perpSummary,
+    perpSummaryFiat,
+    hasPerpRewards,
+  };
+}

--- a/packages/kit/src/views/ReferFriends/pages/InviteReward/components/OnChainReward/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/InviteReward/components/OnChainReward/index.tsx
@@ -1,12 +1,16 @@
+import { useCallback } from 'react';
+
 import { useIntl } from 'react-intl';
 
-import { SizableText, XStack } from '@onekeyhq/components';
+import { SizableText, XStack, YStack } from '@onekeyhq/components';
+import { useNavigateToEarnReward } from '@onekeyhq/kit/src/views/ReferFriends/pages/EarnReward/hooks/useNavigateToEarnReward';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { Card } from '../RewardCard';
 import { NoRewardYet } from '../shared/NoRewardYet';
 
 import { useOnChainReward } from './hooks/useOnChainReward';
+import { usePerpReward } from './hooks/usePerpReward';
 import { RewardDetailTooltip } from './RewardDetailTooltip';
 
 import type { IOnChainRewardProps } from './types';
@@ -15,9 +19,16 @@ const DEFAULT_EARN_IMAGE_URL =
   'https://uni.onekey-asset.com/server-service-indexer/evm--42161/tokens/address-0xaf88d065e77c8cc2239327c5edb3a432268e5831-1720669320510.png';
 
 export function OnChainReward({ onChain }: IOnChainRewardProps) {
-  const { earnToken, onChainSummary, showRewards, toEarnRewardPage } =
-    useOnChainReward({ onChain });
+  const { earnToken, onChainSummary, hasEarnRewards } = useOnChainReward({
+    onChain,
+  });
+  const { perpToken, perpSummary, hasPerpRewards } = usePerpReward({ onChain });
+  const navigateToEarnReward = useNavigateToEarnReward();
   const intl = useIntl();
+  const showRewards = hasEarnRewards || hasPerpRewards;
+  const toEarnRewardPage = useCallback(() => {
+    navigateToEarnReward(onChain.title || '');
+  }, [navigateToEarnReward, onChain.title]);
 
   return (
     <Card.Container flex={1}>
@@ -31,19 +42,41 @@ export function OnChainReward({ onChain }: IOnChainRewardProps) {
         onPress={toEarnRewardPage}
       />
       {showRewards ? (
-        <XStack gap="$2" ai="center" jc="space-between">
-          <XStack gap="$2" ai="center">
-            <SizableText size="$bodyMd" color="$textSubdued">
-              DeFi
-            </SizableText>
-            <RewardDetailTooltip rewards={onChain.available} iconSize="$5" />
-          </XStack>
-          <Card.TokenValue
-            tokenImageUri={earnToken?.logoURI || DEFAULT_EARN_IMAGE_URL}
-            amount={onChainSummary || 0}
-            symbol="USDC"
-          />
-        </XStack>
+        <YStack gap="$3">
+          {hasEarnRewards ? (
+            <XStack gap="$2" ai="center" jc="space-between">
+              <XStack gap="$2" ai="center">
+                <SizableText size="$bodyMd" color="$textSubdued">
+                  DeFi
+                </SizableText>
+                <RewardDetailTooltip
+                  rewards={onChain.available}
+                  iconSize="$5"
+                />
+              </XStack>
+              <Card.TokenValue
+                tokenImageUri={earnToken?.logoURI || DEFAULT_EARN_IMAGE_URL}
+                amount={onChainSummary || 0}
+                symbol={earnToken?.symbol || 'USDC'}
+              />
+            </XStack>
+          ) : null}
+
+          {hasPerpRewards ? (
+            <XStack gap="$2" ai="center" jc="space-between">
+              <XStack gap="$2" ai="center">
+                <SizableText size="$bodyMd" color="$textSubdued">
+                  {intl.formatMessage({ id: ETranslations.global_perp })}
+                </SizableText>
+              </XStack>
+              <Card.TokenValue
+                tokenImageUri={perpToken?.logoURI || DEFAULT_EARN_IMAGE_URL}
+                amount={perpSummary || 0}
+                symbol={perpToken?.symbol || 'USDC'}
+              />
+            </XStack>
+          ) : null}
+        </YStack>
       ) : (
         <NoRewardYet />
       )}

--- a/packages/kit/src/views/ReferFriends/pages/InviteReward/components/OnChainReward/types.ts
+++ b/packages/kit/src/views/ReferFriends/pages/InviteReward/components/OnChainReward/types.ts
@@ -8,17 +8,26 @@ export interface IUseOnChainRewardParams {
   onChain: IInviteSummary['Onchain'];
 }
 
+export interface IRewardTokenMeta {
+  logoURI?: string;
+  symbol?: string;
+  name?: string;
+}
+
 export interface IUseOnChainRewardReturn {
-  earnToken:
-    | {
-        logoURI?: string;
-        symbol?: string;
-        name?: string;
-      }
-    | null
-    | undefined;
+  earnToken: IRewardTokenMeta | null | undefined;
   onChainSummary: string | undefined;
   onChainSummaryFiat: string | undefined;
-  showRewards: boolean;
-  toEarnRewardPage: () => void;
+  hasEarnRewards: boolean;
+}
+
+export interface IUsePerpRewardParams {
+  onChain: IInviteSummary['Onchain'];
+}
+
+export interface IUsePerpRewardReturn {
+  perpToken: IRewardTokenMeta | null | undefined;
+  perpSummary: string | undefined;
+  perpSummaryFiat: string | undefined;
+  hasPerpRewards: boolean;
 }

--- a/packages/shared/src/referralCode/type.ts
+++ b/packages/shared/src/referralCode/type.ts
@@ -1,31 +1,26 @@
+interface IRewardToken {
+  networkId: string;
+  address: string;
+  logoURI: string;
+  name: string;
+  symbol: string;
+}
+
+interface IRewardBalance {
+  token: IRewardToken;
+  amount: string;
+  fiatValue: string;
+  usdValue: string;
+}
+
 interface IReward {
   title: string;
   description: string;
-  monthlySalesFiatValue: string;
-  available?: {
-    token: {
-      networkId: string;
-      address: string;
-      logoURI: string;
-      name: string;
-      symbol: string;
-    };
-    amount: string;
-    usdValue: string;
-    fiatValue: string;
-  }[];
-  pending?: {
-    token: {
-      networkId: string;
-      address: string;
-      logoURI: string;
-      name: string;
-      symbol: string;
-    };
-    amount: string;
-    fiatValue: string;
-    usdValue: string;
-  }[];
+  monthlySales?: string;
+  monthlySalesFiatValue?: string;
+  available?: IRewardBalance[];
+  pending?: IRewardBalance[];
+  perp?: IRewardBalance[];
 }
 
 export interface IInviteSummary {
@@ -42,42 +37,43 @@ export interface IInviteSummary {
   enabledNetworks: string[];
   totalRewards: string;
   levelPercent: string;
-  nextRebateLevel: string;
+  nextRebateLevel?: string;
   Onchain: IReward;
   rebateConfig: {
     level: number;
+    emoji: string;
+    icon: string;
     rebate: number;
     discount: number;
     threshold: number;
-    emoji: string;
+    thresholdFiatValue: string;
     labelKey: string;
     label: string;
+    configs?: Record<string, IInviteLevelCommissionRate>;
   };
   rebateLevels: {
     level: number;
     rebate: number;
     discount: number;
+    threshold: number;
     thresholdFiatValue: string;
     emoji: string;
+    icon: string;
     labelKey: string;
     label: string;
+    configs?: Record<string, IInviteLevelCommissionRate>;
   }[];
   HardwareSales: IReward & {
-    nextStage: { isEnd: boolean; amount: string; label: string };
-  };
-  banners: any[];
-  cumulativeRewards: {
-    distributed: string;
-    undistributed: string;
-    nextDistribution: string;
-    token: {
-      networkId: string;
-      address: string;
-      logoURI: string;
-      name: string;
-      symbol: string;
+    nextStage: {
+      isEnd: boolean;
+      percent: string;
+      amount: string;
+      label: string;
     };
   };
+  Earn?: Record<string, any>;
+  banners: any[];
+  cumulativeRewards: IHardwareCumulativeRewards;
 }
 
 export interface IEarnWalletHistoryItem {


### PR DESCRIPTION
- Introduced usePerpReward hook to manage perpetual rewards.
- Updated OnChainReward component to display both on-chain and perpetual rewards.
- Refactored reward summary calculations for improved clarity and efficiency.
- Modified types to accommodate new reward structures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Separated reward display into distinct "DeFi" (Earn) and "Perp" sections for improved clarity.
  * Enhanced reward data structure to better organize multiple reward types.
  * Improved reward information visibility and presentation on the Invite Reward page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->