### PR TITLE
fix: discover tab fails to switch to web-page tab after opening a page

### DIFF
--- a/packages/kit/src/states/jotai/contexts/discovery/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/discovery/actions.ts
@@ -26,6 +26,10 @@ import {
   webviewRefs,
 } from '@onekeyhq/kit/src/views/Discovery/utils/explorerUtils';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import {
+  EAppEventBusNames,
+  appEventBus,
+} from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
@@ -864,6 +868,13 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
         navigation.switchTab(ETabRoutes.MultiTabBrowser);
       } else if (shouldPopNavigation) {
         navigation.switchTab(ETabRoutes.Discovery);
+        if (platformEnv.isNative) {
+          setTimeout(() => {
+            appEventBus.emit(EAppEventBusNames.SwitchDiscoveryTabInNative, {
+              tab: ETranslations.global_browser,
+            });
+          }, 150);
+        }
       }
     },
   );

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -210,6 +210,16 @@ function MobileBrowser() {
     return Promise.resolve();
   }, [activeTabId, closeWebTab, setCurrentWebTab]);
 
+  useEffect(() => {
+    const listener = (event: { tab: ETranslations }) => {
+      void handleChangeHeaderTab(event.tab);
+    };
+    appEventBus.on(EAppEventBusNames.SwitchDiscoveryTabInNative, listener);
+    return () => {
+      appEventBus.off(EAppEventBusNames.SwitchDiscoveryTabInNative, listener);
+    };
+  }, [handleChangeHeaderTab]);
+
   // For risk detection
   useEffect(() => {
     const listener = () => {

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -396,6 +396,9 @@ export interface IAppEventBusPayload {
     retry?: number;
     message?: string;
   };
+  [EAppEventBusNames.SwitchDiscoveryTabInNative]: {
+    tab: ETranslations.global_browser | ETranslations.global_earn;
+  };
 }
 
 export enum EEventBusBroadcastMethodNames {

--- a/packages/shared/src/eventBus/appEventBusNames.ts
+++ b/packages/shared/src/eventBus/appEventBusNames.ts
@@ -120,4 +120,5 @@ export enum EAppEventBusNames {
   BtcFreshAddressUpdated = 'BtcFreshAddressUpdated',
   BtcFreshAddressConnectDappRejected = 'BtcFreshAddressConnectDappRejected',
   ClientLogUploadProgress = 'ClientLogUploadProgress',
+  SwitchDiscoveryTabInNative = 'SwitchDiscoveryTabInNative',
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native app support for event-driven Discovery tab switching, enabling users to seamlessly navigate between Browser and Earn tabs with improved responsiveness and navigation efficiency in native environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->