### PR TITLE
feat: add margin-based size input mode for perps trading

### DIFF
--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -392,7 +392,7 @@ export const {
 });
 
 export interface IPerpsTradingPreferences {
-  sizeInputUnit: 'token' | 'usd';
+  sizeInputUnit: 'token' | 'usd' | 'margin';
   slippage: number;
 }
 export const {

--- a/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
@@ -3,14 +3,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
-import type { ISelectItem } from '@onekeyhq/components';
-import {
-  Divider,
-  Icon,
-  Select,
-  SizableText,
-  XStack,
-} from '@onekeyhq/components';
+import { Divider, XStack } from '@onekeyhq/components';
 import type {
   IPerpsActiveAssetAtom,
   IPerpsActiveAssetCtxAtom,
@@ -22,6 +15,8 @@ import {
   validateSizeInput,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type { EPerpsSizeInputMode } from '@onekeyhq/shared/types/hyperliquid';
+
+import { SizeInputModeSelector } from '../selectors/SizeInputModeSelector';
 
 import { TradingFormInput } from './TradingFormInput';
 
@@ -42,6 +37,7 @@ interface ISizeInputProps {
   disabled?: boolean;
   label?: string;
   isMobile?: boolean;
+  leverage: number;
 }
 
 export const SizeInput = memo(
@@ -60,6 +56,7 @@ export const SizeInput = memo(
     side: _side,
     label,
     isMobile = false,
+    leverage,
   }: ISizeInputProps) => {
     const intl = useIntl();
     const szDecimals = activeAsset?.universe?.szDecimals ?? 2;
@@ -67,9 +64,9 @@ export const SizeInput = memo(
 
     const [tradingPreferences, setTradingPreferences] =
       usePerpsTradingPreferencesAtom();
-    const inputMode = tradingPreferences.sizeInputUnit;
+    const inputMode = tradingPreferences.sizeInputUnit ?? 'usd';
     const setInputMode = useCallback(
-      (mode: 'token' | 'usd') => {
+      (mode: 'token' | 'usd' | 'margin') => {
         setTradingPreferences((prev) => ({ ...prev, sizeInputUnit: mode }));
       },
       [setTradingPreferences],
@@ -77,10 +74,12 @@ export const SizeInput = memo(
 
     const [tokenAmount, setTokenAmount] = useState('');
     const [usdAmount, setUsdAmount] = useState('');
+    const [marginAmount, setMarginAmount] = useState('');
     const [isUserTyping, setIsUserTyping] = useState(false);
 
     const prevValueRef = useRef(value);
     const prevPriceRef = useRef(referencePrice);
+    const prevLeverageRef = useRef(leverage);
 
     const isSliderMode = sizeInputMode === 'slider';
 
@@ -92,6 +91,7 @@ export const SizeInput = memo(
       () => priceBN.isFinite() && priceBN.gt(0),
       [priceBN],
     );
+    const leverageBN = useMemo(() => new BigNumber(leverage || 1), [leverage]);
 
     // Helper: Calculate USD from Token
     const calcUsdFromToken = useCallback(
@@ -115,6 +115,28 @@ export const SizeInput = memo(
       [hasValidPrice, priceBN, szDecimals],
     );
 
+    const calcMarginFromToken = useCallback(
+      (tokenValue: string) => {
+        if (!hasValidPrice) return '';
+        const tokenBN = new BigNumber(tokenValue);
+        if (!tokenBN.isFinite()) return '';
+        const marginValue = tokenBN.multipliedBy(priceBN).dividedBy(leverageBN);
+        return formatWithPrecision(marginValue, 2, true);
+      },
+      [hasValidPrice, priceBN, leverageBN],
+    );
+
+    const calcTokenFromMargin = useCallback(
+      (marginValue: string) => {
+        if (!hasValidPrice) return '';
+        const marginBN = new BigNumber(marginValue);
+        if (!marginBN.isFinite()) return '';
+        const tokenValue = marginBN.multipliedBy(leverageBN).dividedBy(priceBN);
+        return formatWithPrecision(tokenValue, szDecimals, true);
+      },
+      [hasValidPrice, priceBN, leverageBN, szDecimals],
+    );
+
     const sliderDisplay = useMemo(() => {
       if (!isSliderMode) return '';
       if (!Number.isFinite(sliderPercent)) return '0%';
@@ -126,12 +148,13 @@ export const SizeInput = memo(
       if (isSliderMode) {
         setTokenAmount('');
         setUsdAmount('');
+        setMarginAmount('');
         prevValueRef.current = '';
         setIsUserTyping(false);
       }
     }, [isSliderMode]);
 
-    // Effect: Sync external value changes + Token→USD calculation
+    // Effect: Sync external value changes + Token→USD/Margin calculation
     useEffect(() => {
       const valueChanged = value !== prevValueRef.current;
       if (!valueChanged) return;
@@ -141,18 +164,61 @@ export const SizeInput = memo(
 
       if (!value) {
         setUsdAmount('');
+        setMarginAmount('');
         setIsUserTyping(false);
         return;
       }
 
-      // Only update USD in token mode when not actively typing
-      if (inputMode === 'token' && !isUserTyping) {
-        const usdValue = calcUsdFromToken(value);
-        if (usdValue) setUsdAmount(usdValue);
+      if (!isUserTyping) {
+        if (inputMode === 'token') {
+          const usdValue = calcUsdFromToken(value);
+          if (usdValue) setUsdAmount(usdValue);
+          const marginValue = calcMarginFromToken(value);
+          if (marginValue) setMarginAmount(marginValue);
+        } else if (inputMode === 'usd') {
+          const marginValue = calcMarginFromToken(value);
+          if (marginValue) setMarginAmount(marginValue);
+        } else if (inputMode === 'margin') {
+          const usdValue = calcUsdFromToken(value);
+          if (usdValue) setUsdAmount(usdValue);
+        }
       }
-    }, [value, inputMode, isUserTyping, calcUsdFromToken]);
+    }, [value, inputMode, isUserTyping, calcUsdFromToken, calcMarginFromToken]);
 
-    // Effect: Price change handling + USD→Token recalculation
+    // Effect: Leverage change handling
+    useEffect(() => {
+      const leverageChanged = prevLeverageRef.current !== leverage;
+      if (!leverageChanged) return;
+      prevLeverageRef.current = leverage;
+
+      if (inputMode === 'margin' && marginAmount && !isSliderMode) {
+        const newTokenValue = calcTokenFromMargin(marginAmount);
+        if (newTokenValue && newTokenValue !== tokenAmount) {
+          setTokenAmount(newTokenValue);
+          onChange(newTokenValue);
+          const usdValue = calcUsdFromToken(newTokenValue);
+          if (usdValue) setUsdAmount(usdValue);
+        }
+        return;
+      }
+
+      if (tokenAmount) {
+        const marginValue = calcMarginFromToken(tokenAmount);
+        if (marginValue) setMarginAmount(marginValue);
+      }
+    }, [
+      leverage,
+      inputMode,
+      marginAmount,
+      isSliderMode,
+      calcTokenFromMargin,
+      calcMarginFromToken,
+      tokenAmount,
+      calcUsdFromToken,
+      onChange,
+    ]);
+
+    // Effect: Price change handling + USD/Margin→Token recalculation
     useEffect(() => {
       if (isSliderMode) return;
 
@@ -163,21 +229,41 @@ export const SizeInput = memo(
         if (inputMode === 'token' && tokenAmount) {
           const usdValue = calcUsdFromToken(tokenAmount);
           if (usdValue) setUsdAmount(usdValue);
+          const marginValue = calcMarginFromToken(tokenAmount);
+          if (marginValue) setMarginAmount(marginValue);
         } else if (inputMode === 'usd' && usdAmount) {
           const newTokenValue = calcTokenFromUsd(usdAmount);
           if (newTokenValue) {
             setTokenAmount(newTokenValue);
             onChange(newTokenValue);
+            const marginValue = calcMarginFromToken(newTokenValue);
+            if (marginValue) setMarginAmount(marginValue);
+          }
+        } else if (inputMode === 'margin' && marginAmount) {
+          const newTokenValue = calcTokenFromMargin(marginAmount);
+          if (newTokenValue) {
+            setTokenAmount(newTokenValue);
+            onChange(newTokenValue);
+            const usdValue = calcUsdFromToken(newTokenValue);
+            if (usdValue) setUsdAmount(usdValue);
           }
         }
         return;
       }
 
-      if (inputMode === 'usd' && usdAmount && !isUserTyping) {
-        const newTokenValue = calcTokenFromUsd(usdAmount);
-        if (newTokenValue && newTokenValue !== tokenAmount) {
-          setTokenAmount(newTokenValue);
-          onChange(newTokenValue);
+      if (!isUserTyping) {
+        if (inputMode === 'usd' && usdAmount) {
+          const newTokenValue = calcTokenFromUsd(usdAmount);
+          if (newTokenValue && newTokenValue !== tokenAmount) {
+            setTokenAmount(newTokenValue);
+            onChange(newTokenValue);
+          }
+        } else if (inputMode === 'margin' && marginAmount) {
+          const newTokenValue = calcTokenFromMargin(marginAmount);
+          if (newTokenValue && newTokenValue !== tokenAmount) {
+            setTokenAmount(newTokenValue);
+            onChange(newTokenValue);
+          }
         }
       }
     }, [
@@ -186,9 +272,12 @@ export const SizeInput = memo(
       referencePrice,
       tokenAmount,
       usdAmount,
+      marginAmount,
       isUserTyping,
       calcUsdFromToken,
       calcTokenFromUsd,
+      calcMarginFromToken,
+      calcTokenFromMargin,
       onChange,
     ]);
 
@@ -213,9 +302,14 @@ export const SizeInput = memo(
         if (inputMode === 'token') {
           setTokenAmount(newValue);
           onChange(newValue);
-        } else {
+        } else if (inputMode === 'usd') {
           setUsdAmount(newValue);
           const tokenValue = calcTokenFromUsd(newValue);
+          setTokenAmount(tokenValue);
+          onChange(tokenValue);
+        } else {
+          setMarginAmount(newValue);
+          const tokenValue = calcTokenFromMargin(newValue);
           setTokenAmount(tokenValue);
           onChange(tokenValue);
         }
@@ -225,29 +319,38 @@ export const SizeInput = memo(
         inputMode,
         onChange,
         calcTokenFromUsd,
+        calcTokenFromMargin,
         onRequestManualMode,
       ],
     );
 
     const handleModeChange = useCallback(
       (newMode: string) => {
-        const mode = newMode as 'token' | 'usd';
+        const mode = newMode as 'token' | 'usd' | 'margin';
         if (mode === inputMode) return;
 
         onRequestManualMode?.();
         setInputMode(mode);
         setIsUserTyping(false);
 
-        // Switching to USD mode: calculate USD from current token
         if (mode === 'usd' && tokenAmount) {
           const usdValue = calcUsdFromToken(tokenAmount);
           if (usdValue) setUsdAmount(usdValue);
+          const marginValue = calcMarginFromToken(tokenAmount);
+          if (marginValue) setMarginAmount(marginValue);
+        } else if (mode === 'token' && tokenAmount) {
+          const marginValue = calcMarginFromToken(tokenAmount);
+          if (marginValue) setMarginAmount(marginValue);
+        } else if (mode === 'margin' && tokenAmount) {
+          const marginValue = calcMarginFromToken(tokenAmount);
+          if (marginValue) setMarginAmount(marginValue);
         }
       },
       [
         inputMode,
         tokenAmount,
         calcUsdFromToken,
+        calcMarginFromToken,
         onRequestManualMode,
         setInputMode,
       ],
@@ -260,8 +363,7 @@ export const SizeInput = memo(
           return false;
         }
 
-        // USD mode: limit integer part to 12 digits
-        if (inputMode === 'usd' && text) {
+        if ((inputMode === 'usd' || inputMode === 'margin') && text) {
           const [integerPart] = text.split('.');
           if (integerPart && integerPart.length > 12) return false;
         }
@@ -273,59 +375,38 @@ export const SizeInput = memo(
 
     const formatLabel = useMemo(() => {
       if (label) return label;
+      if (inputMode === 'margin') return 'Cost';
       return intl.formatMessage({
         id: ETranslations.dexmarket_details_history_amount,
       });
-    }, [label, intl]);
-
-    const selectItems = useMemo(
-      (): ISelectItem[] => [
-        { label: symbol || '', value: 'token' },
-        { label: 'USD', value: 'usd' },
-      ],
-      [symbol],
-    );
-
-    const selectWidth = useMemo(() => {
-      const tokenName = symbol || '';
-      return tokenName.length > 5 ? 140 : 100;
-    }, [symbol]);
+    }, [label, intl, inputMode]);
 
     const customSuffix = useMemo(
       () => (
-        <Select
-          items={selectItems}
-          value={inputMode}
-          onChange={handleModeChange}
-          title={intl.formatMessage({
-            id: ETranslations.perp_unit_preferrence,
-          })}
-          floatingPanelProps={{
-            width: selectWidth,
-          }}
-          renderTrigger={({ label: selectedLabel }) => (
-            <XStack alignItems="center" gap="$2" cursor="pointer">
-              {isMobile ? <Divider vertical h={24} /> : null}
-              <SizableText size="$bodyMdMedium" color="$textSubdued">
-                {selectedLabel}
-              </SizableText>
-              <Icon
-                ml="$-2"
-                name="ChevronTriangleDownSmallOutline"
-                size="$4"
-                color="$iconSubdued"
-              />
-            </XStack>
-          )}
-        />
+        <XStack alignItems="center" gap="$2">
+          {isMobile ? <Divider vertical h={24} /> : null}
+          <SizeInputModeSelector
+            value={inputMode}
+            onChange={handleModeChange}
+            tokenSymbol={symbol || ''}
+          />
+        </XStack>
       ),
-      [selectItems, inputMode, handleModeChange, selectWidth, intl, isMobile],
+      [inputMode, handleModeChange, symbol, isMobile],
     );
 
     const displayValue = useMemo(() => {
       if (isSliderMode) return sliderDisplay;
+      if (inputMode === 'margin') return marginAmount;
       return inputMode === 'token' ? tokenAmount : usdAmount;
-    }, [isSliderMode, sliderDisplay, inputMode, tokenAmount, usdAmount]);
+    }, [
+      isSliderMode,
+      sliderDisplay,
+      inputMode,
+      tokenAmount,
+      usdAmount,
+      marginAmount,
+    ]);
 
     return (
       <TradingFormInput

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -486,6 +486,7 @@ function PerpTradingForm({
         sliderPercent={tradingComputed.sizePercent}
         onRequestManualMode={switchToManual}
         isMobile={isMobile}
+        leverage={formData.leverage ?? 1}
       />
 
       <YStack {...(isMobile && { pt: '$2', pb: '$2' })}>

--- a/packages/kit/src/views/Perp/components/TradingPanel/selectors/SizeInputModeSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/selectors/SizeInputModeSelector.tsx
@@ -1,0 +1,146 @@
+import { useCallback, useMemo } from 'react';
+
+import {
+  Icon,
+  Popover,
+  Radio,
+  SizableText,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
+
+export interface ISizeInputModeSelectorProps {
+  value: 'token' | 'usd' | 'margin';
+  onChange: (value: 'token' | 'usd' | 'margin') => void;
+  tokenSymbol: string;
+}
+
+export function SizeInputModeSelector({
+  value,
+  onChange,
+  tokenSymbol,
+}: ISizeInputModeSelectorProps) {
+  const radioValue = value === 'margin' ? 'cost' : 'amount';
+
+  const handleRadioChange = useCallback(
+    (nextValue: string) => {
+      if (nextValue === 'amount') {
+        // Default to token when switching back from margin mode, unless it was already token/usd
+        if (value === 'margin') {
+          onChange('token');
+        }
+      } else if (nextValue === 'cost') {
+        onChange('margin');
+      }
+    },
+    [onChange, value],
+  );
+
+  const handleUnitChange = useCallback(
+    (unit: 'token' | 'usd') => {
+      if (value !== unit) {
+        onChange(unit);
+      }
+    },
+    [onChange, value],
+  );
+
+  const unitButtons = useMemo(
+    () => (
+      <XStack
+        bg="$bgSubdued"
+        p="$0.5"
+        borderRadius="$2"
+        gap="$1"
+        alignSelf="flex-start"
+      >
+        <XStack
+          px="$2"
+          py="$1"
+          borderRadius="$2"
+          bg={value === 'usd' ? '$bgActive' : 'transparent'}
+          cursor="pointer"
+          onPress={() => handleUnitChange('usd')}
+          hoverStyle={{
+            bg: value === 'usd' ? '$bgActive' : '$bgHover',
+          }}
+        >
+          <SizableText
+            size="$bodySmMedium"
+            color={value === 'usd' ? '$text' : '$textSubdued'}
+          >
+            USDC
+          </SizableText>
+        </XStack>
+        <XStack
+          px="$2"
+          py="$1"
+          borderRadius="$2"
+          bg={value === 'token' ? '$bgActive' : 'transparent'}
+          cursor="pointer"
+          onPress={() => handleUnitChange('token')}
+          hoverStyle={{
+            bg: value === 'token' ? '$bgActive' : '$bgHover',
+          }}
+        >
+          <SizableText
+            size="$bodySmMedium"
+            color={value === 'token' ? '$text' : '$textSubdued'}
+          >
+            {tokenSymbol || 'Token'}
+          </SizableText>
+        </XStack>
+      </XStack>
+    ),
+    [handleUnitChange, tokenSymbol, value],
+  );
+
+  const radioOptions = useMemo(
+    () => [
+      {
+        label: 'By amount',
+        value: 'amount',
+        description:
+          'Place an order by amount. Cost will change accordingly when you adjust the leverage.',
+        children: unitButtons,
+      },
+      {
+        label: 'By cost (USD)',
+        value: 'cost',
+        description:
+          "Place an order by cost. Cost won't change when you adjust the leverage.",
+      },
+    ],
+    [unitButtons],
+  );
+
+  const trigger = (
+    <XStack alignItems="center" gap="$1" cursor="pointer" userSelect="none">
+      <SizableText size="$bodyMdMedium" color="$textSubdued">
+        {value === 'token' ? tokenSymbol || 'Token' : 'USDC'}
+      </SizableText>
+      <Icon
+        name="ChevronTriangleDownSmallOutline"
+        size="$4"
+        color="$iconSubdued"
+      />
+    </XStack>
+  );
+
+  return (
+    <Popover
+      title="Select Input Mode"
+      placement="bottom-end"
+      renderTrigger={trigger}
+      renderContent={
+        <YStack width={320} p="$4">
+          <Radio
+            value={radioValue}
+            onChange={handleRadioChange}
+            options={radioOptions}
+          />
+        </YStack>
+      }
+    />
+  );
+}


### PR DESCRIPTION
- Add margin input mode with leverage-aware calculations
- Create SizeInputModeSelector component with radio selection
- Support three input modes: token, USD, and margin (cost)
- Handle leverage changes for margin-based position recalculation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added margin-based position sizing for perpetuals trading, allowing users to input position size by margin/cost in addition to token and USD options.
  * New input mode selector for seamless switching between amount-based (Token/USDC) and cost-based sizing.
  * Position cost label dynamically updates based on selected input mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->