### PR TITLE
fix: multi device connection check for updates OK-46561

### DIFF
--- a/packages/kit-bg/src/services/ServiceFirmwareUpdate/ServiceFirmwareUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceFirmwareUpdate/ServiceFirmwareUpdate.ts
@@ -416,6 +416,7 @@ class ServiceFirmwareUpdate extends ServiceBase {
     const releaseInfo = await this.baseCheckAllFirmwareRelease({
       connectId: originalConnectId,
       firmwareType,
+      skipChangeTransportType: true,
     });
 
     const firmware = await this.checkFirmwareRelease({
@@ -589,23 +590,28 @@ class ServiceFirmwareUpdate extends ServiceBase {
   async baseCheckAllFirmwareRelease({
     connectId,
     firmwareType,
+    skipChangeTransportType,
   }: {
     connectId: string | undefined;
     firmwareType: EFirmwareType | undefined;
+    skipChangeTransportType?: boolean;
   }) {
     const hardwareSDK = await this.getSDKInstance({
       connectId,
     });
     const checkBridgeRelease = await this._hasUseBridge();
-    const currentTransportType =
-      await this.backgroundApi.serviceSetting.getHardwareTransportType();
-    const updatingConnectId = deviceUtils.getUpdatingConnectId({
-      connectId,
-      currentTransportType,
-    });
+    let currentConnectId = connectId;
+    if (!skipChangeTransportType) {
+      const currentTransportType =
+        await this.backgroundApi.serviceSetting.getHardwareTransportType();
+      currentConnectId = deviceUtils.getUpdatingConnectId({
+        connectId,
+        currentTransportType,
+      });
+    }
     const result = await convertDeviceResponse(() =>
       // method fail if device on boot mode
-      hardwareSDK.checkAllFirmwareRelease(updatingConnectId, {
+      hardwareSDK.checkAllFirmwareRelease(currentConnectId, {
         checkBridgeRelease,
         firmwareType,
       }),

--- a/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateErrors.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateErrors.tsx
@@ -283,6 +283,26 @@ export function useFirmwareUpdateErrors({
     if (
       isHardwareErrorByCode({
         error,
+        code: HardwareErrorCode.SelectDevice,
+      })
+    ) {
+      return {
+        content: (
+          <CommonError
+            icon="CrossedLargeOutline"
+            message={intl.formatMessage({
+              id: ETranslations.update_only_one_usb_device_supported_for_upgrade,
+            })}
+          />
+        ),
+        onRetryHandler: onRetry,
+        retryText: defaultRetryText,
+      };
+    }
+
+    if (
+      isHardwareErrorByCode({
+        error,
         code: HardwareErrorCode.FirmwareUpdateManuallyEnterBoot,
       }) ||
       isHardwareErrorByCode({

--- a/packages/kit/src/views/FirmwareUpdate/pages/PageFirmwareUpdateInstall.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/pages/PageFirmwareUpdateInstall.tsx
@@ -11,6 +11,7 @@ import type {
 } from '@onekeyhq/shared/src/routes';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
+import useAppNavigation from '../../../hooks/useAppNavigation';
 import { useAppRoute } from '../../../hooks/useAppRoute';
 import { FirmwareInstallingView } from '../components/FirmwareInstallingView';
 import { FirmwareLatestVersionInstalled } from '../components/FirmwareLatestVersionInstalled';
@@ -27,6 +28,7 @@ function PageFirmwareUpdateInstall() {
     EModalFirmwareUpdateRoutes.Install
   >();
   const { result } = route.params;
+  const navigation = useAppNavigation();
 
   const [stepInfo] = useFirmwareUpdateStepInfoAtom();
 
@@ -65,6 +67,9 @@ function PageFirmwareUpdateInstall() {
     }
 
     if (stepInfo.step === EFirmwareUpdateSteps.error) {
+      requestAnimationFrame(() => {
+        navigation.pop();
+      });
       return <FirmwareUpdateExitPrevent shouldPreventRemove={false} />;
     }
 
@@ -73,7 +78,7 @@ function PageFirmwareUpdateInstall() {
         <FirmwareLatestVersionInstalled />
       </>
     );
-  }, [stepInfo.step, result]);
+  }, [stepInfo.step, navigation, result]);
 
   return (
     <Page

--- a/packages/shared/src/errors/errors/hardwareErrors.ts
+++ b/packages/shared/src/errors/errors/hardwareErrors.ts
@@ -967,6 +967,19 @@ export class FirmwareUpdateVersionMismatchError extends OneKeyHardwareError {
   }
 }
 
+export class SelectDeviceError extends OneKeyHardwareError {
+  constructor(props?: IOneKeyErrorHardwareProps) {
+    super(
+      normalizeErrorProps(props, {
+        defaultMessage: 'SelectDeviceError',
+        defaultKey: ETranslations.update_ensure_one_usb_device_connected,
+      }),
+    );
+  }
+
+  override code = HardwareErrorCode.SelectDevice;
+}
+
 // UnknownHardware
 export class UnknownHardwareError extends OneKeyHardwareError {
   override className: EOneKeyErrorClassNames =

--- a/packages/shared/src/errors/utils/deviceErrorUtils.ts
+++ b/packages/shared/src/errors/utils/deviceErrorUtils.ts
@@ -71,6 +71,8 @@ export function convertDeviceError(
       return new HardwareErrors.FirmwareVersionTooLow({ payload });
     case HardwareErrorCode.DeviceUnexpectedMode:
       return new HardwareErrors.UnknownHardwareError({ payload });
+    case HardwareErrorCode.SelectDevice:
+      return new HardwareErrors.SelectDeviceError({ payload });
     case HardwareErrorCode.NotAllowInBootloaderMode:
       return new HardwareErrors.NotInBootLoaderMode({ payload });
     // case HardwareErrorCode.RequiredButInBootloaderMode:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firmware update error handling with a new message when multiple USB devices are detected (only one device is supported for updates).
  * Added automatic navigation back when firmware update errors occur.

* **Chores**
  * Enhanced error handling infrastructure for firmware update operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->