### PR TITLE
feat: add Invitee Reward feature OK-46654 OK-46662

### DIFF
--- a/packages/kit-bg/src/services/ServiceReferralCode.ts
+++ b/packages/kit-bg/src/services/ServiceReferralCode.ts
@@ -321,7 +321,7 @@ class ServiceReferralCode extends ServiceBase {
   async getPerpsInviteeRewards(params: {
     walletAddress: string;
   }): Promise<IPerpsInviteeRewardsResponse> {
-    const client = await this.getClient(EServiceEndpointEnum.Rebate);
+    const client = await this.getOneKeyIdClient(EServiceEndpointEnum.Rebate);
     const response = await client.get<{ data: IPerpsInviteeRewardsResponse }>(
       '/rebate/v1/invite/perps-invitee-rewards',
       { params },

--- a/packages/kit-bg/src/services/ServiceReferralCode.ts
+++ b/packages/kit-bg/src/services/ServiceReferralCode.ts
@@ -18,6 +18,7 @@ import type {
   IInvitePaidHistory,
   IInvitePostConfig,
   IInviteSummary,
+  IPerpsInviteeRewardsResponse,
   IPerpsRecordsResponse,
   IUpdateInviteCodeNoteResponse,
 } from '@onekeyhq/shared/src/referralCode/type';
@@ -311,6 +312,18 @@ class ServiceReferralCode extends ServiceBase {
     }
     const response = await client.get<{ data: IPerpsRecordsResponse }>(
       '/rebate/v1/invite/perps-records',
+      { params },
+    );
+    return response.data.data;
+  }
+
+  @backgroundMethod()
+  async getPerpsInviteeRewards(params: {
+    walletAddress: string;
+  }): Promise<IPerpsInviteeRewardsResponse> {
+    const client = await this.getClient(EServiceEndpointEnum.Rebate);
+    const response = await client.get<{ data: IPerpsInviteeRewardsResponse }>(
+      '/rebate/v1/invite/perps-invitee-rewards',
       { params },
     );
     return response.data.data;

--- a/packages/kit/src/views/Perp/components/InviteeReward/InviteeRewardContent.tsx
+++ b/packages/kit/src/views/Perp/components/InviteeReward/InviteeRewardContent.tsx
@@ -1,0 +1,123 @@
+import type { useInTabDialog } from '@onekeyhq/components';
+import {
+  Alert,
+  Divider,
+  ScrollView,
+  SizableText,
+  Toast,
+  YStack,
+} from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { perpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+
+import { PerpsProviderMirror } from '../../PerpsProviderMirror';
+
+import { RewardHistoryList } from './components/RewardHistoryList';
+import { RewardSummaryCard } from './components/RewardSummaryCard';
+
+interface IInviteeRewardContentProps {
+  walletAddress: string;
+  isMobile?: boolean;
+}
+
+export function InviteeRewardContent({
+  walletAddress,
+  isMobile,
+}: IInviteeRewardContentProps) {
+  const { result: data, isLoading } = usePromiseResult(
+    async () => {
+      if (!walletAddress) {
+        return undefined;
+      }
+
+      return backgroundApiProxy.serviceReferralCode.getPerpsInviteeRewards({
+        walletAddress,
+      });
+    },
+    [walletAddress],
+    { watchLoading: true },
+  );
+
+  const content = (
+    <YStack gap="$5">
+      <YStack gap="$5">
+        <Alert
+          type="info"
+          renderTitle={() => (
+            <SizableText size="$bodySm" color="$textSubdued">
+              Rewards will be distributed to your Arbitrum wallet (same address
+              as Ethereum) by the 10th of next month.
+            </SizableText>
+          )}
+          closable
+        />
+        <RewardSummaryCard
+          isLoading={isLoading}
+          totalBonus={data?.totalBonus}
+          undistributed={data?.undistributed}
+          tokenSymbol={data?.token.symbol}
+        />
+      </YStack>
+      <Divider />
+      <YStack gap="$2">
+        <SizableText size="$bodySm" color="$textSubdued">
+          Reward Distribution History
+        </SizableText>
+        <RewardHistoryList
+          isLoading={isLoading}
+          history={data?.history}
+          token={data?.token}
+        />
+      </YStack>
+    </YStack>
+  );
+
+  if (isMobile) {
+    return (
+      <YStack flex={1} gap="$5" px="$5" py="$3">
+        {content}
+      </YStack>
+    );
+  }
+
+  return (
+    <ScrollView minHeight={350} maxHeight={500}>
+      {content}
+    </ScrollView>
+  );
+}
+
+export async function showInviteeRewardDialog(
+  dialogInTab: ReturnType<typeof useInTabDialog>,
+) {
+  const selectedAccount = await perpsActiveAccountAtom.get();
+
+  const walletAddress = selectedAccount.accountAddress;
+
+  if (!walletAddress) {
+    console.error('[InviteeRewardModal] Missing required parameters');
+    Toast.error({
+      title: 'Please select a valid account first',
+    });
+    return;
+  }
+
+  const dialogInTabRef = dialogInTab.show({
+    title: 'Invitee Reward',
+    floatingPanelProps: {
+      width: 480,
+    },
+    renderContent: (
+      <PerpsProviderMirror>
+        <InviteeRewardContent walletAddress={walletAddress} />
+      </PerpsProviderMirror>
+    ),
+    showFooter: false,
+    onClose: () => {
+      void dialogInTabRef.close();
+    },
+  });
+
+  return dialogInTabRef;
+}

--- a/packages/kit/src/views/Perp/components/InviteeReward/InviteeRewardModal.tsx
+++ b/packages/kit/src/views/Perp/components/InviteeReward/InviteeRewardModal.tsx
@@ -1,0 +1,37 @@
+import { Page, ScrollView, YStack } from '@onekeyhq/components';
+import { usePerpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+
+import { PerpsAccountSelectorProviderMirror } from '../../PerpsAccountSelectorProviderMirror';
+import { PerpsProviderMirror } from '../../PerpsProviderMirror';
+
+import { InviteeRewardContent } from './InviteeRewardContent';
+
+function InviteeRewardModalContent() {
+  const [selectedAccount] = usePerpsActiveAccountAtom();
+  const walletAddress = selectedAccount?.accountAddress ?? '';
+
+  return (
+    <Page>
+      <Page.Header title="Invitee Reward" />
+      <Page.Body>
+        <ScrollView flex={1}>
+          <YStack flex={1}>
+            <InviteeRewardContent walletAddress={walletAddress} isMobile />
+          </YStack>
+        </ScrollView>
+      </Page.Body>
+    </Page>
+  );
+}
+
+function InviteeRewardModalWithProvider() {
+  return (
+    <PerpsAccountSelectorProviderMirror>
+      <PerpsProviderMirror>
+        <InviteeRewardModalContent />
+      </PerpsProviderMirror>
+    </PerpsAccountSelectorProviderMirror>
+  );
+}
+
+export default InviteeRewardModalWithProvider;

--- a/packages/kit/src/views/Perp/components/InviteeReward/components/RewardHistoryList.tsx
+++ b/packages/kit/src/views/Perp/components/InviteeReward/components/RewardHistoryList.tsx
@@ -1,0 +1,171 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import {
+  Icon,
+  NumberSizeableText,
+  SizableText,
+  Skeleton,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
+import { Token } from '@onekeyhq/kit/src/components/Token';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import type {
+  IPerpsInviteeRewardHistoryItem,
+  IPerpsInviteeRewardToken,
+} from '@onekeyhq/shared/src/referralCode/type';
+import openUrlUtils from '@onekeyhq/shared/src/utils/openUrlUtils';
+
+const PAGE_SIZE = 10;
+
+interface IRewardHistoryListProps {
+  isLoading?: boolean;
+  history?: IPerpsInviteeRewardHistoryItem[];
+  token?: IPerpsInviteeRewardToken;
+}
+
+interface IRewardItemProps {
+  item: IPerpsInviteeRewardHistoryItem;
+  token: IPerpsInviteeRewardToken;
+}
+
+function RewardItemSkeleton() {
+  return (
+    <YStack gap="$2">
+      <Skeleton width={80} height={14} />
+      <XStack ai="center" jc="space-between" py="$1">
+        <XStack ai="center" gap="$3" flex={1}>
+          <Skeleton width={40} height={40} radius="round" />
+          <YStack gap="$1" flex={1}>
+            <Skeleton width={60} height={16} />
+            <Skeleton width={100} height={14} />
+          </YStack>
+        </XStack>
+        <Skeleton width={80} height={16} />
+      </XStack>
+    </YStack>
+  );
+}
+
+function RewardItem({ item, token }: IRewardItemProps) {
+  const handleTxPress = useCallback(() => {
+    if (item.tx) {
+      const explorerUrl = `https://arbiscan.io/tx/${item.tx}`;
+      openUrlUtils.openUrlExternal(explorerUrl);
+    }
+  }, [item.tx]);
+
+  return (
+    <YStack gap="$2">
+      <SizableText size="$bodySmMedium" color="$textSubdued">
+        {item.date}
+      </SizableText>
+      <XStack ai="center" jc="space-between" py="$1">
+        <XStack ai="center" gap="$3" flex={1}>
+          <Token size="md" tokenImageUri={token.logoURI} />
+          <YStack gap="$0.5" flex={1}>
+            <SizableText size="$bodyMdMedium">Reward</SizableText>
+            {item.tx ? (
+              <XStack
+                ai="center"
+                gap="$1"
+                onPress={handleTxPress}
+                cursor="pointer"
+              >
+                <SizableText size="$bodySm" color="$textSubdued">
+                  {`${item.tx.slice(0, 8)}...${item.tx.slice(-6)}`}
+                </SizableText>
+                <Icon name="OpenOutline" size="$4" color="$iconSubdued" />
+              </XStack>
+            ) : null}
+          </YStack>
+        </XStack>
+
+        <NumberSizeableText
+          color="$textSuccess"
+          formatter="value"
+          formatterOptions={{
+            tokenSymbol: token.symbol,
+            showPlusMinusSigns: true,
+          }}
+        >
+          {item.amount}
+        </NumberSizeableText>
+      </XStack>
+    </YStack>
+  );
+}
+
+export function RewardHistoryList({
+  isLoading,
+  history,
+  token,
+}: IRewardHistoryListProps) {
+  const intl = useIntl();
+  const [displayCount, setDisplayCount] = useState(PAGE_SIZE);
+
+  const displayedHistory = useMemo(() => {
+    if (!history) return [];
+    return history.slice(0, displayCount);
+  }, [history, displayCount]);
+
+  const hasMore = useMemo(() => {
+    if (!history) return false;
+    return displayCount < history.length;
+  }, [history, displayCount]);
+
+  const handleShowMore = useCallback(() => {
+    setDisplayCount((prev) => prev + PAGE_SIZE);
+  }, []);
+
+  if (isLoading) {
+    return (
+      <YStack gap="$5">
+        <RewardItemSkeleton />
+      </YStack>
+    );
+  }
+
+  if (!history || history.length === 0 || !token) {
+    return (
+      <YStack ai="center" jc="center" py="$6">
+        <SizableText size="$bodyMd" color="$textSubdued">
+          {intl.formatMessage({
+            id: ETranslations.global_no_data,
+            defaultMessage: 'No data',
+          })}
+        </SizableText>
+      </YStack>
+    );
+  }
+
+  return (
+    <YStack gap="$5" pt="$2">
+      {displayedHistory.map((item) => (
+        <RewardItem key={item.tx} item={item} token={token} />
+      ))}
+      {hasMore ? (
+        <XStack
+          ai="center"
+          jc="center"
+          gap="$1"
+          py="$2"
+          onPress={handleShowMore}
+          cursor="pointer"
+          hoverStyle={{ opacity: 0.8 }}
+          pressStyle={{ opacity: 0.6 }}
+        >
+          <SizableText size="$bodyMdMedium" color="$textSubdued">
+            {intl.formatMessage({
+              id: ETranslations.global_show_more,
+              defaultMessage: 'Show More',
+            })}
+          </SizableText>
+          <Icon name="ChevronDownSmallOutline" size="$4" color="$iconSubdued" />
+        </XStack>
+      ) : null}
+    </YStack>
+  );
+}

--- a/packages/kit/src/views/Perp/components/InviteeReward/components/RewardSummaryCard.tsx
+++ b/packages/kit/src/views/Perp/components/InviteeReward/components/RewardSummaryCard.tsx
@@ -1,0 +1,98 @@
+import BigNumber from 'bignumber.js';
+
+import {
+  Icon,
+  NumberSizeableText,
+  SizableText,
+  Skeleton,
+  Tooltip,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
+
+interface IRewardSummaryCardProps {
+  isLoading?: boolean;
+  totalBonus?: string;
+  undistributed?: string;
+  tokenSymbol?: string;
+}
+
+export function RewardSummaryCard({
+  isLoading,
+  totalBonus,
+  undistributed,
+  tokenSymbol,
+}: IRewardSummaryCardProps) {
+  const displayTotalBonus = totalBonus ?? '0';
+  const displayUndistributed = undistributed ?? '0';
+  const displayTokenSymbol = tokenSymbol ?? 'USDC';
+  const hasUndistributed = new BigNumber(displayUndistributed).gt(0);
+
+  return (
+    <YStack gap="$2">
+      <XStack ai="center" gap="$2">
+        <XStack ai="center" gap="$1.5" py="$0.5">
+          <Icon name="OnekeyBrand" />
+          <SizableText size="$bodySm">Referral bonus</SizableText>
+        </XStack>
+      </XStack>
+
+      <XStack ai="center" gap="$1.5" flexWrap="nowrap">
+        {isLoading ? (
+          <Skeleton width={120} height={28} />
+        ) : (
+          <NumberSizeableText
+            size="$bodySm"
+            formatter="value"
+            formatterOptions={{
+              tokenSymbol: displayTokenSymbol,
+            }}
+            numberOfLines={1}
+          >
+            {displayTotalBonus}
+          </NumberSizeableText>
+        )}
+
+        {hasUndistributed ? (
+          <XStack ai="center" gap="$1" flexShrink={1}>
+            <SizableText size="$bodySm" color="$textSubdued">
+              +
+            </SizableText>
+            <NumberSizeableText
+              size="$bodySm"
+              color="$textSubdued"
+              formatter="value"
+              formatterOptions={{
+                tokenSymbol: displayTokenSymbol,
+              }}
+              numberOfLines={1}
+              flexShrink={1}
+            >
+              {displayUndistributed}
+            </NumberSizeableText>
+            <SizableText
+              size="$bodySm"
+              color="$textSubdued"
+              numberOfLines={1}
+              flexShrink={0}
+            >
+              Undistributed
+            </SizableText>
+          </XStack>
+        ) : null}
+
+        <Tooltip
+          renderTrigger={
+            <Icon
+              name="InfoCircleOutline"
+              size="$5"
+              color="$iconSubdued"
+              cursor="pointer"
+            />
+          }
+          renderContent="This is your total referral bonus from trading on Perps."
+        />
+      </XStack>
+    </YStack>
+  );
+}

--- a/packages/kit/src/views/Perp/components/InviteeReward/hooks/useShowInviteeRewardModal.ts
+++ b/packages/kit/src/views/Perp/components/InviteeReward/hooks/useShowInviteeRewardModal.ts
@@ -1,0 +1,26 @@
+import { useCallback } from 'react';
+
+import { useInTabDialog, useMedia } from '@onekeyhq/components';
+import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { EModalRoutes } from '@onekeyhq/shared/src/routes';
+import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
+
+import { showInviteeRewardDialog } from '../InviteeRewardContent';
+
+export function useShowInviteeRewardModal() {
+  const navigation = useAppNavigation();
+  const { gtMd } = useMedia();
+  const dialogInTab = useInTabDialog();
+
+  const showModal = useCallback(async () => {
+    if (gtMd) {
+      await showInviteeRewardDialog(dialogInTab);
+    } else {
+      navigation.pushModal(EModalRoutes.PerpModal, {
+        screen: EModalPerpRoutes.PerpsInviteeRewardModal,
+      });
+    }
+  }, [gtMd, dialogInTab, navigation]);
+
+  return { showInviteeRewardModal: showModal };
+}

--- a/packages/kit/src/views/Perp/components/InviteeReward/index.tsx
+++ b/packages/kit/src/views/Perp/components/InviteeReward/index.tsx
@@ -1,0 +1,5 @@
+export {
+  InviteeRewardContent,
+  showInviteeRewardDialog,
+} from './InviteeRewardContent';
+export { useShowInviteeRewardModal } from './hooks/useShowInviteeRewardModal';

--- a/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
@@ -35,6 +35,7 @@ import { ETabRoutes } from '@onekeyhq/shared/src/routes/tab';
 import { usePerpsAssetCtx } from '../../../hooks/usePerpsAssetCtx';
 import { usePerpsMidPrice } from '../../../hooks/usePerpsMidPrice';
 import { useShowDepositWithdrawModal } from '../../../hooks/useShowDepositWithdrawModal';
+import { useShowInviteeRewardModal } from '../../InviteeReward/hooks/useShowInviteeRewardModal';
 import { PerpSettingsButton } from '../../PerpSettingsButton';
 
 import { PerpsAccountNumberValue } from './PerpsAccountNumberValue';
@@ -164,12 +165,29 @@ function DepositButton() {
   );
 }
 
+function InviteeRewardButton() {
+  const { showInviteeRewardModal } = useShowInviteeRewardModal();
+
+  return (
+    <DebugRenderTracker name="PerpsHeaderRight__InviteeRewardButton">
+      <IconButton
+        icon="GiftOutline"
+        size="small"
+        iconProps={{ color: '$iconSubdued' }}
+        variant="tertiary"
+        onPress={showInviteeRewardModal}
+      />
+    </DebugRenderTracker>
+  );
+}
+
 export function PerpsHeaderRight() {
   const { gtMd } = useMedia();
   const content = (
     <XStack alignItems="center" gap="$5">
       <WalletConnectionForWeb tabRoute={ETabRoutes.Perp} />
       {process.env.NODE_ENV !== 'production' ? <DebugButton /> : null}
+      <InviteeRewardButton />
       <DepositButton />
       {gtMd ? (
         <PerpSettingsButton testID="perp-header-settings-button" />

--- a/packages/kit/src/views/Perp/router/index.ts
+++ b/packages/kit/src/views/Perp/router/index.ts
@@ -29,6 +29,10 @@ const MobileDepositWithdrawModal = LazyLoadPage(
   () => import('../components/TradingPanel/modals/DepositWithdrawModal'),
 );
 
+const PerpsInviteeRewardModal = LazyLoadPage(
+  () => import('../components/InviteeReward/InviteeRewardModal'),
+);
+
 export const perpRouters: ITabSubNavigatorConfig<any, any>[] = [
   {
     rewrite: '/',
@@ -50,6 +54,10 @@ export const perpRouters: ITabSubNavigatorConfig<any, any>[] = [
   {
     name: EModalPerpRoutes.MobileDepositWithdrawModal,
     component: MobileDepositWithdrawModal,
+  },
+  {
+    name: EModalPerpRoutes.PerpsInviteeRewardModal,
+    component: PerpsInviteeRewardModal,
   },
 ];
 
@@ -77,5 +85,9 @@ export const ModalPerpStack: IModalFlowNavigatorConfig<
   {
     name: EModalPerpRoutes.MobileDepositWithdrawModal,
     component: MobileDepositWithdrawModal,
+  },
+  {
+    name: EModalPerpRoutes.PerpsInviteeRewardModal,
+    component: PerpsInviteeRewardModal,
   },
 ];

--- a/packages/shared/src/referralCode/type.ts
+++ b/packages/shared/src/referralCode/type.ts
@@ -415,3 +415,25 @@ export interface IHardwareCumulativeRewards {
     symbol: string;
   };
 }
+
+// Perps Invitee Reward Types
+export interface IPerpsInviteeRewardToken {
+  address: string;
+  logoURI: string;
+  name: string;
+  networkId: string;
+  symbol: string;
+}
+
+export interface IPerpsInviteeRewardHistoryItem {
+  amount: string;
+  date: string;
+  tx: string;
+}
+
+export interface IPerpsInviteeRewardsResponse {
+  history: IPerpsInviteeRewardHistoryItem[];
+  token: IPerpsInviteeRewardToken;
+  totalBonus: string;
+  undistributed: string;
+}

--- a/packages/shared/src/routes/perp.ts
+++ b/packages/shared/src/routes/perp.ts
@@ -6,6 +6,7 @@ export enum EModalPerpRoutes {
   MobileTokenSelector = 'MobileTokenSelector',
   MobileSetTpsl = 'MobileSetTpsl',
   MobileDepositWithdrawModal = 'MobileDepositWithdrawModal',
+  PerpsInviteeRewardModal = 'PerpsInviteeRewardModal',
 }
 
 export type IModalPerpParamList = {
@@ -14,4 +15,5 @@ export type IModalPerpParamList = {
   [EModalPerpRoutes.MobileTokenSelector]: undefined;
   [EModalPerpRoutes.MobileSetTpsl]: ISetTpslParams;
   [EModalPerpRoutes.MobileDepositWithdrawModal]: undefined;
+  [EModalPerpRoutes.PerpsInviteeRewardModal]: undefined;
 };


### PR DESCRIPTION
- Introduced InviteeRewardButton component to display invitee rewards in the trading panel.
- Added PerpsInviteeRewardModal to the routing configuration for handling invitee rewards.
- Implemented getPerpsInviteeRewards method in ServiceReferralCode to fetch invitee rewards data.
- Defined new types for invitee rewards in shared referral code types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invitee Reward UI showing total referral bonus and undistributed amount with loading states
  * Reward summary card with tooltip and token-aware formatting
  * Paginated reward history with transaction links and "Show More"
  * Gift icon in Perps header to open rewards (desktop: in-tab dialog; mobile: modal)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->