### PR TITLE
refactor: streamline account binding checks on ServiceHyperliquid OK-46662

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -1222,7 +1222,12 @@ export default class ServiceHyperliquid extends ServiceBase {
       referenceAddress.toLowerCase() === accountAddress.toLowerCase();
 
     try {
-      // Check if current account is bound
+      // First account: skip binding check
+      if (isFirstAccount) {
+        return true;
+      }
+
+      // Non-first account: check if current account is bound
       const isCurrentAccountBound =
         await this.backgroundApi.serviceReferralCode.checkWalletIsBoundReferralCode(
           {
@@ -1235,13 +1240,7 @@ export default class ServiceHyperliquid extends ServiceBase {
         return true;
       }
 
-      // Current account is not bound
-      if (isFirstAccount) {
-        // First account: return false to trigger binding flow
-        return false;
-      }
-
-      // Non-first account: check first account's binding status
+      // Current account is not bound: check first account's binding status
       const isFirstAccountBound =
         await this.backgroundApi.serviceReferralCode.checkWalletIsBoundReferralCode(
           {


### PR DESCRIPTION
- Simplified the logic for checking if the current account is bound by adding a condition to skip the binding check for the first account.
- Updated comments for clarity on the binding status checks for both first and non-first accounts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined rebate binding validation logic to correctly handle account eligibility requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->