### PR TITLE
fix: distinguish Defi and Perp in export file names

### DIFF
--- a/packages/kit/src/views/ReferFriends/pages/EarnReward/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/EarnReward/index.tsx
@@ -59,11 +59,15 @@ function EarnRewardPageWrapper() {
   );
 
   const tools = useCallback(() => {
+    const exportSubject =
+      activeRewardTab === EExportTab.Earn
+        ? EExportSubject.Defi
+        : EExportSubject.Perp;
     return (
       <XStack gap="$2">
         <FilterButton filterState={filterState} onFilterChange={updateFilter} />
         <ExportButton
-          subject={EExportSubject.Onchain}
+          subject={exportSubject}
           timeRange={filterState.timeRange}
           inviteCode={filterState.inviteCode}
           tab={activeRewardTab}

--- a/packages/shared/src/referralCode/type.ts
+++ b/packages/shared/src/referralCode/type.ts
@@ -388,7 +388,8 @@ export interface IUpdateInviteCodeNoteResponse {
 // Export functionality types
 export enum EExportSubject {
   HardwareSales = 'HardwareSales',
-  Onchain = 'Onchain',
+  Defi = 'Defi',
+  Perp = 'Perp',
 }
 
 export enum EExportTimeRange {


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Export functionality now correctly adapts based on your active reward tab, ensuring you export the appropriate data type for your current selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Split `EExportSubject.Onchain` into `EExportSubject.Defi` and `EExportSubject.Perp`
- Export file names now correctly distinguish between DeFi and Perp rewards:
  - DeFi tab exports: `invite_data_Defi_xxx.csv`
  - Perp tab exports: `invite_data_Perp_xxx.csv`

## Test plan
- [ ] Export data from DeFi rewards tab, verify filename contains "Defi"
- [ ] Export data from Perp rewards tab, verify filename contains "Perp"