### PR TITLE
fix: add showTabBar call when closing blocked website tab

### DIFF
--- a/packages/kit/src/views/Discovery/components/WebContent/WebContent.native.tsx
+++ b/packages/kit/src/views/Discovery/components/WebContent/WebContent.native.tsx
@@ -12,6 +12,7 @@ import {
 import { EValidateUrlEnum } from '@onekeyhq/shared/types/dappConnection';
 
 import { webviewRefs } from '../../utils/explorerUtils';
+import { showTabBar } from '../../utils/tabBarUtils';
 import BlockAccessView from '../BlockAccessView';
 
 import type { IWebTab } from '../../types';
@@ -198,6 +199,7 @@ function WebContent({
           onCloseTab={() => {
             closeWebTab({ tabId: id, entry: 'BlockView' });
             setCurrentWebTab(null);
+            showTabBar();
           }}
           // onContinue={() => {
           //   addUrlToPhishingCache({ url: phishingUrlRef.current });


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the tab bar would not reappear after closing a web content tab in the Discovery view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Fix bottom TabBar disappearing when closing a blocked/illegal website tab
- Add `showTabBar()` call in BlockAccessView's `onCloseTab` callback to restore TabBar visibility

## Problem
When users visit a blocked website (e.g., phishing site) on mobile browser, the BlockAccessView is shown. When clicking "Close Tab" button, the bottom TabBar disappears and doesn't come back.

## Root Cause
In `WebContent.native.tsx`, the `onCloseTab` callback was missing the `showTabBar()` call that exists in other tab closing flows (e.g., `MobileBrowserBottomBar.native.tsx`).

## Solution
Added `showTabBar()` import and call in the `onCloseTab` callback to align with other tab closing behaviors.

## Test Plan
- [ ] Open mobile browser
- [ ] Visit a blocked/illegal website (triggers BlockAccessView)
- [ ] Click "Close Tab" button
- [ ] Verify bottom TabBar is visible after closing