### PR TITLE
refactor: extract ListEndIndicator component from market lists

### DIFF
--- a/packages/components/src/content/ListEndIndicator/index.tsx
+++ b/packages/components/src/content/ListEndIndicator/index.tsx
@@ -1,0 +1,25 @@
+import { Stack } from '../../primitives';
+
+import type { StackProps } from '@tamagui/core';
+
+export type IListEndIndicatorProps = StackProps;
+
+export function ListEndIndicator(props: IListEndIndicatorProps) {
+  return (
+    <Stack
+      flexDirection="row"
+      alignItems="center"
+      justifyContent="center"
+      py="$4"
+      gap="$2"
+      {...props}
+    >
+      {/* Left line */}
+      <Stack flex={1} maxWidth={80} height={1} backgroundColor="$neutral5" />
+      {/* Center dot with border */}
+      <Stack width={4} height={4} borderRadius="$full" bg="$neutral5" />
+      {/* Right line */}
+      <Stack flex={1} maxWidth={80} height={1} backgroundColor="$neutral5" />
+    </Stack>
+  );
+}

--- a/packages/components/src/content/index.ts
+++ b/packages/components/src/content/index.ts
@@ -20,5 +20,6 @@ export * from './DescriptionList';
 export * from './Theme';
 export * from './Keyboard';
 export * from './DashText';
+export * from './ListEndIndicator';
 export * from './NetworkStatusBadge';
 export * from './OneKeyLogo';

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Holders/Holders.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Holders/Holders.tsx
@@ -2,7 +2,13 @@ import { memo, useCallback, useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { SizableText, Stack, Tabs, useMedia } from '@onekeyhq/components';
+import {
+  ListEndIndicator,
+  SizableText,
+  Stack,
+  Tabs,
+  useMedia,
+} from '@onekeyhq/components';
 import { useMarketHolders } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/hooks/useMarketHolders';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -41,16 +47,7 @@ function HoldersBase({ tokenAddress, networkId }: IHoldersProps) {
 
   const ListFooterComponent = useMemo(() => {
     if (!isRefreshing && holders.length > 0) {
-      return (
-        <Stack alignItems="center" justifyContent="center" py="$4">
-          <Stack
-            width={120}
-            height={4}
-            backgroundColor="$neutral5"
-            borderRadius="$full"
-          />
-        </Stack>
-      );
+      return <ListEndIndicator />;
     }
     return null;
   }, [isRefreshing, holders.length]);

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenListBase.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenListBase.tsx
@@ -1,7 +1,13 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import type { ReactNode } from 'react';
 
-import { Spinner, Stack, Table, useMedia } from '@onekeyhq/components';
+import {
+  ListEndIndicator,
+  Spinner,
+  Stack,
+  Table,
+  useMedia,
+} from '@onekeyhq/components';
 import type { ITableColumn } from '@onekeyhq/components';
 import {
   EAppEventBusNames,
@@ -178,16 +184,7 @@ function MarketTokenListBase({
 
     // Show end indicator when no more data to load
     if (showEndReachedIndicator && !canLoadMore && data.length > 0) {
-      return (
-        <Stack alignItems="center" justifyContent="center" py="$4">
-          <Stack
-            width={120}
-            height={4}
-            backgroundColor="$neutral5"
-            borderRadius="$full"
-          />
-        </Stack>
-      );
+      return <ListEndIndicator />;
     }
 
     return null;


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new end-of-list indicator component providing consistent visual feedback when reaching the end of data in market views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Create new `ListEndIndicator` component in `packages/components/src/content/`
- Replace duplicate footer indicator code in Market Token List and Holder List with the new component
- New style: two thin lines with a center dot

## Test plan
- [ ] Verify Market Token List shows the new indicator at the bottom when scrolled to end
- [ ] Verify Holder List shows the new indicator at the bottom when data is loaded