### PR TITLE
fix: show warning when selecting already bound wallet in referral code dialog

### DIFF
--- a/packages/kit/src/views/ReferFriends/hooks/useWalletBoundReferralCode.tsx
+++ b/packages/kit/src/views/ReferFriends/hooks/useWalletBoundReferralCode.tsx
@@ -235,6 +235,15 @@ function InviteCode({
   // Check if there are no available wallets
   const hasNoWallets = !walletsWithStatus || walletsWithStatus.length === 0;
 
+  // Check if the selected wallet is already bound
+  const isSelectedWalletBound = useMemo(() => {
+    if (!walletsWithStatus || !selectedWalletId) return false;
+    const found = walletsWithStatus.find(
+      (w) => w.wallet.id === selectedWalletId,
+    );
+    return found?.isBound ?? false;
+  }, [walletsWithStatus, selectedWalletId]);
+
   const { result: walletInfo } = usePromiseResult(async () => {
     const r = await getReferralCodeWalletInfo(selectedWallet?.id);
     if (!r) {
@@ -347,6 +356,13 @@ function InviteCode({
             )}
           />
         )}
+        {isSelectedWalletBound ? (
+          <SizableText size="$bodySm" color="$textCritical" mt="$1">
+            {intl.formatMessage({
+              id: ETranslations.referral_already_bound,
+            })}
+          </SizableText>
+        ) : null}
       </YStack>
       <YStack gap="$1">
         <SizableText size="$bodyMd" color="$textSubdued">
@@ -388,7 +404,7 @@ function InviteCode({
           id: ETranslations.global_apply,
         })}
         confirmButtonProps={{
-          disabled: hasNoWallets,
+          disabled: hasNoWallets || isSelectedWalletBound,
         }}
       />
     </YStack>


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet binding validation in the Refer Friends feature by adding status checks for the selected wallet.
  * Added a notice to inform users when their selected wallet is already bound.
  * Disabled the referral action when attempting to use a wallet that has already been bound, preventing invalid submissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Add warning message below wallet selector when user selects a wallet that is already bound to another referral code
- Disable the Apply button when a bound wallet is selected
- Use existing translation key `referral_already_bound` for the warning message

## Changes
- Added `isSelectedWalletBound` memo to check if selected wallet is already bound
- Display red warning text "The wallet is already applied to another code" below the wallet selector
- Disable confirm button when selected wallet is bound