### PR TITLE
fix: update refresh logic in EarnHome and useEarnPortfolio hooks for … OK-46887

### DIFF
--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -128,9 +128,6 @@ function BasicEarnHome({
   const handleListenTabFocusState = useCallback(
     (isFocus: boolean, isHideByModal: boolean) => {
       const actualFocus = isFocus && !isHideByModal;
-      if (actualFocus && !wasFocusedRef.current) {
-        void refreshEarnData();
-      }
       wasFocusedRef.current = actualFocus;
       setIsEarnTabFocused(actualFocus);
       if (!actualFocus) return;
@@ -155,7 +152,7 @@ function BasicEarnHome({
       void refetchBanners();
       void refetchFAQ();
     },
-    [actions, refetchBanners, refetchFAQ, refreshEarnData],
+    [actions, refetchBanners, refetchFAQ],
   );
 
   useListenTabFocusState(

--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -106,18 +106,18 @@ function BasicEarnHome({
   }, [filteredTxs]);
   const previousIsPendingRef = useRef(isPending);
 
+  useEffect(() => {
+    if (previousIsPendingRef.current && !isPending) {
+      void refreshEarnDataRaw();
+    }
+    previousIsPendingRef.current = isPending;
+  }, [isPending, refreshEarnDataRaw]);
+
   const refreshEarnData = useCallback(async () => {
     await backgroundApiProxy.serviceStaking.clearAvailableAssetsCache();
     actions.current.triggerRefresh();
     await refreshEarnDataRaw();
   }, [actions, refreshEarnDataRaw]);
-
-  useEffect(() => {
-    if (previousIsPendingRef.current && !isPending) {
-      void refreshEarnData();
-    }
-    previousIsPendingRef.current = isPending;
-  }, [isPending, refreshEarnData]);
 
   const navigation = useAppNavigation();
 

--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -106,18 +106,18 @@ function BasicEarnHome({
   }, [filteredTxs]);
   const previousIsPendingRef = useRef(isPending);
 
-  useEffect(() => {
-    if (previousIsPendingRef.current && !isPending) {
-      void refreshEarnDataRaw();
-    }
-    previousIsPendingRef.current = isPending;
-  }, [isPending, refreshEarnDataRaw]);
-
   const refreshEarnData = useCallback(async () => {
     await backgroundApiProxy.serviceStaking.clearAvailableAssetsCache();
     actions.current.triggerRefresh();
     await refreshEarnDataRaw();
   }, [actions, refreshEarnDataRaw]);
+
+  useEffect(() => {
+    if (previousIsPendingRef.current && !isPending) {
+      void refreshEarnData();
+    }
+    previousIsPendingRef.current = isPending;
+  }, [isPending, refreshEarnData]);
 
   const navigation = useAppNavigation();
 

--- a/packages/kit/src/views/Earn/components/EarnMainTabs.tsx
+++ b/packages/kit/src/views/Earn/components/EarnMainTabs.tsx
@@ -99,17 +99,6 @@ const EarnMainTabsComponent = ({
     [],
   );
 
-  const refreshControl = useMemo(() => {
-    return isMobile &&
-      refreshEarnAccounts &&
-      isAccountsLoading !== undefined ? (
-      <RefreshControl
-        refreshing={isAccountsLoading}
-        onRefresh={refreshEarnAccounts}
-      />
-    ) : undefined;
-  }, [isMobile, refreshEarnAccounts, isAccountsLoading]);
-
   const tabContainerWidth = useTabContainerWidth();
 
   return (


### PR DESCRIPTION
…better account state management

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account switching: stale data is now cleared, out-of-date responses are ignored, and UI state resets correctly when changing accounts.

* **Changes**
  * Focusing the Earn tab no longer triggers an immediate refresh.
  * Mobile pull-to-refresh behavior for the Earn tabs has been removed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->