### PR TITLE
fix: use ReferralLandingPage for invited_by_friend deeplink on all platforms

### DIFF
--- a/packages/kit/src/routes/config/deeplink/index.ts
+++ b/packages/kit/src/routes/config/deeplink/index.ts
@@ -16,13 +16,7 @@ import {
 } from '@onekeyhq/shared/src/consts/deeplinkConsts';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import {
-  EModalReferFriendsRoutes,
-  EModalRoutes,
-  ETabReferFriendsRoutes,
-  ETabRoutes,
-} from '@onekeyhq/shared/src/routes';
+import { ETabHomeRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { memoizee } from '@onekeyhq/shared/src/utils/cacheUtils';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
@@ -63,7 +57,7 @@ async function processDeepLinkUrlAccount(
         }, 1500);
         return;
       }
-      switch (platformEnv.isNative ? hostname : path?.slice(1)) {
+      switch (hostname ?? path?.slice(1)) {
         case EOneKeyDeepLinkPath.url_account: {
           const query =
             queryParams as IEOneKeyDeepLinkParams[EOneKeyDeepLinkPath.url_account];
@@ -114,32 +108,14 @@ async function processDeepLinkUrlAccount(
             const { code, page } =
               queryParams as IEOneKeyDeepLinkParams[EOneKeyDeepLinkPath.invited_by_friend];
             if (navigation) {
-              // Map page parameter to tab routes
-              const pageToTabRoute: Record<string, ETabRoutes> = {
-                perp: ETabRoutes.Perp,
-                perps: ETabRoutes.Perp,
-                swap: ETabRoutes.Swap,
-                market: ETabRoutes.Market,
-                earn: ETabRoutes.Earn,
-                defi: ETabRoutes.Earn,
-                discover: ETabRoutes.Discovery,
-              };
-              const pageLower = ((page as string) ?? '').toLowerCase();
-              const targetTabRoute =
-                pageToTabRoute[pageLower] ?? ETabRoutes.Home;
-
-              // Navigate to target tab first
-              navigation.switchTab(targetTabRoute);
-
-              // Then open InvitedByFriend modal
-              setTimeout(() => {
-                navigation.pushModal(EModalRoutes.ReferFriendsModal, {
-                  screen: EModalReferFriendsRoutes.InvitedByFriend,
-                  params: {
-                    code,
-                  },
-                });
-              }, 500);
+              // Navigate to ReferralLandingPage which handles the modal opening
+              navigation.switchTab(ETabRoutes.Home, {
+                screen: ETabHomeRoutes.TabHomeReferralLanding,
+                params: {
+                  code,
+                  page: page ?? '',
+                },
+              });
             }
           }
           break;

--- a/packages/kit/src/routes/config/deeplink/index.ts
+++ b/packages/kit/src/routes/config/deeplink/index.ts
@@ -16,7 +16,11 @@ import {
 } from '@onekeyhq/shared/src/consts/deeplinkConsts';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
-import { ETabHomeRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
+import {
+  ETabHomeRoutes,
+  ETabReferFriendsRoutes,
+  ETabRoutes,
+} from '@onekeyhq/shared/src/routes';
 import { memoizee } from '@onekeyhq/shared/src/utils/cacheUtils';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';

--- a/packages/kit/src/views/ReferFriends/hooks/useWalletBoundReferralCode.tsx
+++ b/packages/kit/src/views/ReferFriends/hooks/useWalletBoundReferralCode.tsx
@@ -235,6 +235,15 @@ function InviteCode({
   // Check if there are no available wallets
   const hasNoWallets = !walletsWithStatus || walletsWithStatus.length === 0;
 
+  // Check if the selected wallet is already bound
+  const isSelectedWalletBound = useMemo(() => {
+    if (!walletsWithStatus || !selectedWalletId) return false;
+    const found = walletsWithStatus.find(
+      (w) => w.wallet.id === selectedWalletId,
+    );
+    return found?.isBound ?? false;
+  }, [walletsWithStatus, selectedWalletId]);
+
   const { result: walletInfo } = usePromiseResult(async () => {
     const r = await getReferralCodeWalletInfo(selectedWallet?.id);
     if (!r) {
@@ -347,6 +356,13 @@ function InviteCode({
             )}
           />
         )}
+        {isSelectedWalletBound ? (
+          <SizableText size="$bodySm" color="$textCritical" mt="$1">
+            {intl.formatMessage({
+              id: ETranslations.referral_already_bound,
+            })}
+          </SizableText>
+        ) : null}
       </YStack>
       <YStack gap="$1">
         <SizableText size="$bodyMd" color="$textSubdued">
@@ -388,7 +404,7 @@ function InviteCode({
           id: ETranslations.global_apply,
         })}
         confirmButtonProps={{
-          disabled: hasNoWallets,
+          disabled: hasNoWallets || isSelectedWalletBound,
         }}
       />
     </YStack>


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Referral links now open the referral landing page directly within the app tab instead of via a modal, resulting in smoother onboarding.
  * Improved and simplified handling for other deep-link types (account, market details, invite share) so links navigate more reliably to the correct screens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- Fix Desktop app not opening InvitedByFriend page when handling `invited_by_friend` deeplink
- Fix hostname matching in deeplink switch statement (use `hostname ?? path` instead of platform-specific check)
- Navigate to ReferralLandingPage instead of directly opening modal, which handles the modal opening consistently across all platforms

## Changes

- Modified `packages/kit/src/routes/config/deeplink/index.ts`:
  - Changed switch condition from `platformEnv.isNative ? hostname : path?.slice(1)` to `hostname ?? path?.slice(1)` to fix Desktop hostname matching
  - Simplified `invited_by_friend` case to navigate to `ReferralLandingPage` which handles modal opening

## Test Plan

- [ ] Test deeplink `onekey-wallet://invited_by_friend?code=XXX&page=defi` on Desktop
- [ ] Verify ReferralLandingPage opens and then shows InvitedByFriend modal
- [ ] Verify iOS/Android still works correctly