### PR TITLE
fix: format cumulative rewards with 2 decimal places OK-46891

### DIFF
--- a/packages/kit/src/views/ReferFriends/pages/InviteReward/components/InvitationDetailsSection/components/InviteCodeListTable/hooks/useTableColumns.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/InviteReward/components/InvitationDetailsSection/components/InviteCodeListTable/hooks/useTableColumns.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
+import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
 import { SizableText, useMedia } from '@onekeyhq/components';
@@ -119,11 +120,16 @@ export function useTableColumns(
               ),
             }),
         align: 'left',
-        render: (value: string) => (
-          <SizableText size="$bodyMdMedium" color="$text">
-            {currencySymbol ? `${currencySymbol}${value}` : value}
-          </SizableText>
-        ),
+        render: (value: string) => {
+          const formattedValue = new BigNumber(value).toFixed(2);
+          return (
+            <SizableText size="$bodyMdMedium" color="$text">
+              {currencySymbol
+                ? `${currencySymbol}${formattedValue}`
+                : formattedValue}
+            </SizableText>
+          );
+        },
       },
       {
         title: intl.formatMessage({ id: ETranslations.referral_code_list_at }),


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display formatting of cumulative rewards in the invitation details, now showing values with two decimal places and currency symbols for enhanced clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Format cumulative rewards value to display with 2 decimal places in InviteCodeListTable
- Use BigNumber for precise decimal formatting

## Changes
- Added `BigNumber` import from `bignumber.js`
- Updated the cumulative rewards column render function to use `new BigNumber(value).toFixed(2)`

## Test plan
- [ ] Verify cumulative rewards displays with 2 decimal places (e.g., `$10.00` instead of `$10`)
- [ ] Verify formatting works correctly with and without currency symbol