### PR TITLE
fix: prevent auto-saving to storage before initialization completes

### DIFF
--- a/packages/kit/src/components/AccountSelector/AccountSelectorEffects.tsx
+++ b/packages/kit/src/components/AccountSelector/AccountSelectorEffects.tsx
@@ -159,6 +159,10 @@ function AccountSelectorEffectsCmp({ num }: { num: number }) {
   );
 
   const autoSaveToStorage = useCallback(async () => {
+    // do not save before initFromStorage() completes
+    if (!isReady) {
+      return;
+    }
     // do not save initial value to storage
     if (!isSelectedAccountDefaultValue) {
       // check initFromStorage() at AccountSelectorStorageInit
@@ -176,6 +180,7 @@ function AccountSelectorEffectsCmp({ num }: { num: number }) {
     }
   }, [
     actions,
+    isReady,
     isSelectedAccountDefaultValue,
     num,
     sceneName,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where account selector data could be saved to storage before initialization was complete.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->