### PR TITLE
fix: fix width of SearchInput in iPad

### DIFF
--- a/packages/kit/src/views/Discovery/pages/Dashboard/Welcome/SearchInput.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/Welcome/SearchInput.tsx
@@ -148,7 +148,7 @@ export function SearchInput() {
           onPress={handleSearchBarPress}
           px="$3"
           $gtSm={{
-            w: 384,
+            w: platformEnv.isNative ? '100%' : 384,
           }}
         >
           <Icon name="SearchOutline" size="$5" color="$textSubdued" />

--- a/patches/@tamagui+web+1.108.0.patch
+++ b/patches/@tamagui+web+1.108.0.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/@tamagui/web/dist/cjs/hooks/useMedia.native.js b/node_modules/@tamagui/web/dist/cjs/hooks/useMedia.native.js
-index 47addac..4e90132 100644
+index 47addac..85f0848 100644
 --- a/node_modules/@tamagui/web/dist/cjs/hooks/useMedia.native.js
 +++ b/node_modules/@tamagui/web/dist/cjs/hooks/useMedia.native.js
-@@ -160,11 +160,83 @@ function unlisten() {
+@@ -160,11 +160,85 @@ function unlisten() {
    }), dispose.clear();
  }
  var setupVersion = -1;
@@ -24,13 +24,15 @@ index 47addac..4e90132 100644
 +
 +function checkTabletSplitView(callback) {
 +  if (isDualScreenDevice) {
-+    DualScreenInfoNative.isSpanning().then((result) => {
-+      callback(!!result);
-+    });
++    // DualScreenInfoNative.isSpanning().then((result) => {
++    //   callback(!!result);
++    // });
++    callback(true);
 +  } else if (ExpoDevice.deviceType === ExpoDevice.DeviceType.TABLET) {
-+    ScreenOrientation.getOrientationAsync().then((result) => {
-+      callback(result === ScreenOrientation.Orientation.LANDSCAPE_LEFT || result === ScreenOrientation.Orientation.LANDSCAPE_RIGHT);
-+    });
++    // ScreenOrientation.getOrientationAsync().then((result) => {
++    //   callback(result === ScreenOrientation.Orientation.LANDSCAPE_LEFT || result === ScreenOrientation.Orientation.LANDSCAPE_RIGHT);
++    // });
++    callback(true);
 +  } else {
 +    callback(false);
 +  }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Search input now adapts responsively based on platform, using full available width on native applications while maintaining fixed width on web.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->