### PR TITLE
added warning text for RenameAccountDialog

### DIFF
--- a/packages/kit/src/components/RenameDialog/index.tsx
+++ b/packages/kit/src/components/RenameDialog/index.tsx
@@ -117,6 +117,7 @@ export function RenameInputWithNameSelector({
     contentType: EChangeHistoryContentType.Name;
   };
 }) {
+  const intl = useIntl();
   const { result: shouldShowV4AccountNameSelector } =
     usePromiseResult(async () => {
       if (indexedAccount) {
@@ -158,6 +159,11 @@ export function RenameInputWithNameSelector({
           />
         ) : null}
       </Stack>
+      <Form.FieldDescription>
+        {intl.formatMessage({
+          id: ETranslations.account_name_form_helper_text,
+        })}
+      </Form.FieldDescription>
       {disabledMaxLengthLabel ? null : (
         <Form.FieldDescription textAlign="right">{`${value?.length || 0}/${
           maxLength ?? ''

--- a/packages/shared/src/locale/enum/translations.ts
+++ b/packages/shared/src/locale/enum/translations.ts
@@ -44,6 +44,7 @@
   Limit_order_status_unfilled = 'Limit.order_status_unfilled',
   Perps_referral_bonus_from = 'Perps.referral_bonus_from',
   account_model_watched = 'account_model.watched',
+  account_name_form_helper_text = 'account_name_form_helper_text',
   action_save = 'action_save',
   add_existing_wallet_badge_phrases_length = 'add_existing_wallet_badge_phrases_length',
   add_existing_wallet_desc = 'add_existing_wallet_desc',

--- a/packages/shared/src/locale/json/bn.json
+++ b/packages/shared/src/locale/json/bn.json
@@ -39,6 +39,7 @@
   "Limit.order_status_unfilled": "অপূর্ণ",
   "Perps.referral_bonus_from": "পার্পস-এ ট্রেডিং থেকে রেফারাল বোনাস",
   "account_model.watched": "দেখা হয়েছে",
+  "account_name_form_helper_text": "সংবেদনশীল তথ্য প্রবেশ করাবেন না।",
   "action_save": "সংরক্ষণ করুন",
   "add_existing_wallet_badge_phrases_length": "12–24 শব্দের পুনরুদ্ধার বাক্যাংশ সমর্থন করে",
   "add_existing_wallet_desc": "স্থানান্তর, পুনরুদ্ধার বা আমদানি",

--- a/packages/shared/src/locale/json/de.json
+++ b/packages/shared/src/locale/json/de.json
@@ -39,6 +39,7 @@
   "Limit.order_status_unfilled": "Ungefüllt",
   "Perps.referral_bonus_from": "Empfehlungsbonus aus dem Handel mit Perps",
   "account_model.watched": "Gesehen",
+  "account_name_form_helper_text": "Geben Sie keine sensiblen Informationen ein.",
   "action_save": "Speichern",
   "add_existing_wallet_badge_phrases_length": "Unterstützt Wiederherstellungsphrasen mit 12–24 Wörtern",
   "add_existing_wallet_desc": "Übertragen, wiederherstellen oder importieren",

--- a/packages/shared/src/locale/json/en_US.json
+++ b/packages/shared/src/locale/json/en_US.json
@@ -39,6 +39,7 @@
   "Limit.order_status_unfilled": "Unfilled",
   "Perps.referral_bonus_from": "Referral bonus from trading on Perps",
   "account_model.watched": "Watch-Only",
+  "account_name_form_helper_text": "Do not enter sensitive information.",
   "action_save": "Save",
   "add_existing_wallet_badge_phrases_length": "Supports 12–24 word recovery phrases",
   "add_existing_wallet_desc": "Transfer, restore or import",

--- a/packages/shared/src/locale/json/es.json
+++ b/packages/shared/src/locale/json/es.json
@@ -39,6 +39,7 @@
   "Limit.order_status_unfilled": "No completado",
   "Perps.referral_bonus_from": "Bono por referidos de operaciones en Perps",
   "account_model.watched": "Visto",
+  "account_name_form_helper_text": "No introduzcas información sensible.",
   "action_save": "Guardar",
   "add_existing_wallet_badge_phrases_length": "Admite frases de recuperación de 12 a 24 palabras",
   "add_existing_wallet_desc": "Transferir, restaurar o importar",

--- a/packages/shared/src/locale/json/fr_FR.json
+++ b/packages/shared/src/locale/json/fr_FR.json
@@ -39,6 +39,7 @@
   "Limit.order_status_unfilled": "Non rempli",
   "Perps.referral_bonus_from": "Bonus de parrainage provenant du trading sur Perps",
   "account_model.watched": "Regardé",
+  "account_name_form_helper_text": "Ne saisissez pas d'informations sensibles.",
   "action_save": "Enregistrer",
   "add_existing_wallet_badge_phrases_length": "Prend en charge les phrases de récupération de 12 à 24 mots",
   "add_existing_wallet_desc": "Transférer, restaurer ou importer",

--- a/packages/shared/src/locale/json/hi_IN.json
+++ b/packages/shared/src/locale/json/hi_IN.json
@@ -39,6 +39,7 @@
   "Limit.order_status_unfilled": "अपूर्ण",
   "Perps.referral_bonus_from": "Perps पर ट्रेडिंग से रेफरल बोनस",
   "account_model.watched": "देखा",
+  "account_name_form_helper_text": "संवेदनशील जानकारी दर्ज न करें।",
   "action_save": "सहेजें",
   "add_existing_wallet_badge_phrases_length": "12–24 शब्दों वाले रिकवरी फ़्रेज़ का समर्थन करता है",
   "add_existing_wallet_desc": "ट्रांसफर, पुनर्स्थापना या आयात",

--- a/packages/shared/src/locale/json/id.json
+++ b/packages/shared/src/locale/json/id.json
@@ -39,6 +39,7 @@
   "Limit.order_status_unfilled": "Tidak Terisi",
   "Perps.referral_bonus_from": "Bonus referral dari trading di Perps",
   "account_model.watched": "Ditonton",
+  "account_name_form_helper_text": "Jangan masukkan informasi sensitif.",
   "action_save": "Simpan",
   "add_existing_wallet_badge_phrases_length": "Mendukung frasa pemulihan 12–24 kata",
   "add_existing_wallet_desc": "Transfer, memulihkan, atau mengimpor",

--- a/packages/shared/src/locale/json/it_IT.json
+++ b/packages/shared/src/locale/json/it_IT.json
@@ -39,6 +39,7 @@
   "Limit.order_status_unfilled": "Non eseguito",
   "Perps.referral_bonus_from": "Bonus referral dal trading su Perps",
   "account_model.watched": "Visto",
+  "account_name_form_helper_text": "Non inserire informazioni sensibili.",
   "action_save": "Salva",
   "add_existing_wallet_badge_phrases_length": "Supporta frasi di recupero da 12 a 24 parole",
   "add_existing_wallet_desc": "Trasferisci, ripristina o importa",

--- a/packages/shared/src/locale/json/ja_JP.json
+++ b/packages/shared/src/locale/json/ja_JP.json
@@ -39,6 +39,7 @@
   "Limit.order_status_unfilled": "未約定",
   "Perps.referral_bonus_from": "Perpsでの取引による紹介ボーナス",
   "account_model.watched": "視聴済み",
+  "account_name_form_helper_text": "機密情報を入力しないでください。",
   "action_save": "保存",
   "add_existing_wallet_badge_phrases_length": "12～24語のリカバリーフレーズに対応",
   "add_existing_wallet_desc": "転送、復元、またはインポート",

--- a/packages/shared/src/locale/json/ko_KR.json
+++ b/packages/shared/src/locale/json/ko_KR.json
@@ -39,6 +39,7 @@
   "Limit.order_status_unfilled": "미체결",
   "Perps.referral_bonus_from": "퍼프스 거래 추천 보너스",
   "account_model.watched": "시청함",
+  "account_name_form_helper_text": "민감한 정보를 입력하지 마세요.",
   "action_save": "저장",
   "add_existing_wallet_badge_phrases_length": "12~24개 단어로 된 복구 구문 지원",
   "add_existing_wallet_desc": "전송, 복원 또는 가져오기",

--- a/packages/shared/src/locale/json/pt.json
+++ b/packages/shared/src/locale/json/pt.json
@@ -39,6 +39,7 @@
   "Limit.order_status_unfilled": "Não preenchido",
   "Perps.referral_bonus_from": "Bônus de indicação por negociação em Perps",
   "account_model.watched": "Assistido",
+  "account_name_form_helper_text": "Não insira informações confidenciais.",
   "action_save": "Salvar",
   "add_existing_wallet_badge_phrases_length": "Suporta frases de recuperação de 12 a 24 palavras",
   "add_existing_wallet_desc": "Transferir, restaurar ou importar",

--- a/packages/shared/src/locale/json/pt_BR.json
+++ b/packages/shared/src/locale/json/pt_BR.json
@@ -39,6 +39,7 @@
   "Limit.order_status_unfilled": "Não preenchido",
   "Perps.referral_bonus_from": "Bônus de indicação por negociação em Perps",
   "account_model.watched": "Assistido",
+  "account_name_form_helper_text": "Não insira informações confidenciais.",
   "action_save": "Salvar",
   "add_existing_wallet_badge_phrases_length": "Suporta frases de recuperação de 12 a 24 palavras",
   "add_existing_wallet_desc": "Transferir, restaurar ou importar",

--- a/packages/shared/src/locale/json/ru.json
+++ b/packages/shared/src/locale/json/ru.json
@@ -39,6 +39,7 @@
   "Limit.order_status_unfilled": "Неисполненный",
   "Perps.referral_bonus_from": "Реферальный бонус от торговли на Perps",
   "account_model.watched": "Просмотрено",
+  "account_name_form_helper_text": "Не вводите конфиденциальную информацию.",
   "action_save": "Сохранить",
   "add_existing_wallet_badge_phrases_length": "Поддерживает мнемонические фразы восстановления из 12–24 слов",
   "add_existing_wallet_desc": "Перенести, восстановить или импортировать",

--- a/packages/shared/src/locale/json/th_TH.json
+++ b/packages/shared/src/locale/json/th_TH.json
@@ -39,6 +39,7 @@
   "Limit.order_status_unfilled": "ไม่ได้รับการเติมเต็ม",
   "Perps.referral_bonus_from": "โบนัสแนะนำเพื่อนจากการเทรดบน Perps",
   "account_model.watched": "ดูแล้ว",
+  "account_name_form_helper_text": "ห้ามป้อนข้อมูลที่ละเอียดอ่อน",
   "action_save": "บันทึก",
   "add_existing_wallet_badge_phrases_length": "รองรับวลีการกู้คืน 12–24 คำ",
   "add_existing_wallet_desc": "ถ่ายโอน กู้คืน หรือ นำเข้า",

--- a/packages/shared/src/locale/json/uk_UA.json
+++ b/packages/shared/src/locale/json/uk_UA.json
@@ -39,6 +39,7 @@
   "Limit.order_status_unfilled": "Незаповнений",
   "Perps.referral_bonus_from": "Реферальний бонус від торгівлі на Perps",
   "account_model.watched": "Переглянуто",
+  "account_name_form_helper_text": "Не вводьте конфіденційну інформацію.",
   "action_save": "Зберегти",
   "add_existing_wallet_badge_phrases_length": "Підтримує фрази відновлення з 12–24 слів",
   "add_existing_wallet_desc": "Перенести, відновити або імпортувати",

--- a/packages/shared/src/locale/json/vi.json
+++ b/packages/shared/src/locale/json/vi.json
@@ -39,6 +39,7 @@
   "Limit.order_status_unfilled": "Chưa thực hiện",
   "Perps.referral_bonus_from": "Tiền thưởng giới thiệu từ giao dịch trên Perps",
   "account_model.watched": "Đã xem",
+  "account_name_form_helper_text": "Không nhập thông tin nhạy cảm.",
   "action_save": "Lưu",
   "add_existing_wallet_badge_phrases_length": "Hỗ trợ cụm từ khôi phục 12–24 từ",
   "add_existing_wallet_desc": "Chuyển, khôi phục hoặc nhập",

--- a/packages/shared/src/locale/json/zh_CN.json
+++ b/packages/shared/src/locale/json/zh_CN.json
@@ -39,6 +39,7 @@
   "Limit.order_status_unfilled": "未成交",
   "Perps.referral_bonus_from": "在 Perps 上交易的返佣奖金",
   "account_model.watched": "观察账户",
+  "account_name_form_helper_text": "请勿输入机密信息。",
   "action_save": "保存",
   "add_existing_wallet_badge_phrases_length": "支持 12-24 个单词的助记词",
   "add_existing_wallet_desc": "传输、恢复或导入",

--- a/packages/shared/src/locale/json/zh_HK.json
+++ b/packages/shared/src/locale/json/zh_HK.json
@@ -39,6 +39,7 @@
   "Limit.order_status_unfilled": "未成交",
   "Perps.referral_bonus_from": "在 Perps 上交易的推薦獎金",
   "account_model.watched": "觀察帳戶",
+  "account_name_form_helper_text": "請勿輸入敏感資料。",
   "action_save": "儲存",
   "add_existing_wallet_badge_phrases_length": "支援 12–24 個字的助記詞",
   "add_existing_wallet_desc": "轉移、還原或匯入",

--- a/packages/shared/src/locale/json/zh_TW.json
+++ b/packages/shared/src/locale/json/zh_TW.json
@@ -39,6 +39,7 @@
   "Limit.order_status_unfilled": "未成交",
   "Perps.referral_bonus_from": "在 Perps 上交易的推薦獎金",
   "account_model.watched": "觀察帳戶",
+  "account_name_form_helper_text": "請勿輸入敏感資訊。",
   "action_save": "保存",
   "add_existing_wallet_badge_phrases_length": "支援 12–24 個字的助記詞",
   "add_existing_wallet_desc": "轉移、還原或匯入",


### PR DESCRIPTION
<img width="800" alt="image" src="https://github.com/user-attachments/assets/32ec9879-a742-4cc0-96f5-0b4e4f9907d6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internationalized helper text to the Rename Dialog, providing users with guidance when renaming accounts. The helper text supports multiple languages automatically.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->