### PR TITLE
fix: add tooltip support for rewards in ActionField component

### DIFF
--- a/packages/kit/src/views/Earn/components/PortfolioTabContent.tsx
+++ b/packages/kit/src/views/Earn/components/PortfolioTabContent.tsx
@@ -388,6 +388,11 @@ const ActionField = ({
             color="$textSubdued"
             text={reward.description}
           />
+          {reward?.tooltip ? (
+            <XStack mr="$2">
+              <EarnTooltip tooltip={reward.tooltip} />
+            </XStack>
+          ) : null}
           <WrappedActionButton asset={asset} reward={reward} />
         </Stack>
       ))}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the reward interface in the earn section with optional informational tooltips. When available, these tooltips now appear next to reward descriptions to provide users with additional context and helpful details. This improvement helps users gain better insights into earning opportunities and make more informed decisions about available rewards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->