### PR TITLE
fix: fix layout logic for refer friends components

### DIFF
--- a/packages/kit/src/views/ReferFriends/pages/InvitedByFriend/components/InvitedByFriendImage.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/InvitedByFriend/components/InvitedByFriendImage.tsx
@@ -15,11 +15,14 @@ function InvitedByFriendImage() {
   const themeVariant = useThemeVariant();
   const { width: screenWidth } = useWindowDimensions();
 
-  const isDesktopImage = gtSm || platformEnv.isExtensionUiPopup;
+  const isDesktopImage =
+    !platformEnv.isNative && (gtSm || platformEnv.isExtensionUiPopup);
   const selectedImage = isDesktopImage ? desktopImg : mobileImg;
 
   const imageWidth = useMemo(() => {
-    if (gtSm) return 640;
+    if (!platformEnv.isNative && gtSm) {
+      return 640;
+    }
     return screenWidth;
   }, [gtSm, screenWidth]);
 

--- a/packages/kit/src/views/ReferFriends/pages/ReferAFriend/components/InviteCodeStepImage.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/ReferAFriend/components/InviteCodeStepImage.tsx
@@ -28,7 +28,8 @@ export function InviteCodeStepImage({ step }: IInviteCodeStepImageProps) {
   const { gtSm } = useMedia();
   const themeVariant = useThemeVariant();
   const { width: screenWidth } = useWindowDimensions();
-  const isDesktopImage = gtSm || platformEnv.isExtensionUiPopup;
+  const isDesktopImage =
+    !platformEnv.isNative && (gtSm || platformEnv.isExtensionUiPopup);
 
   // Image mapping for steps and responsive versions
   const imageMap = {
@@ -47,7 +48,7 @@ export function InviteCodeStepImage({ step }: IInviteCodeStepImageProps) {
 
   // Calculate image width based on platform and screen size
   const imageWidth = useMemo(() => {
-    if (gtSm) return 640; // Desktop: fixed width
+    if (!platformEnv.isNative && gtSm) return 640; // Desktop: fixed width
     return screenWidth; // Native / popup: screen width minus padding
   }, [gtSm, screenWidth]);
 


### PR DESCRIPTION
Updated image selection and sizing logic in InvitedByFriendImage and InviteCodeStepImage to properly handle native platforms. Desktop images and fixed widths are now only used when not on native platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined image rendering behavior to correctly differentiate between desktop and native platforms.
  * Updated image width calculations to ensure proper sizing across different device types in the Refer Friends feature.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->