### PR TITLE
optimize: reduce Android initial view count to improve performance

### DIFF
--- a/packages/kit/src/components/TabletHomeContainer/index.tsx
+++ b/packages/kit/src/components/TabletHomeContainer/index.tsx
@@ -14,14 +14,20 @@ import {
   YStack,
   useIsNativeTablet,
   useIsTabletDetailView,
+  useIsTabletMainView,
   useOrientation,
 } from '@onekeyhq/components';
 
 import type { LayoutChangeEvent } from 'react-native';
 
 export function TabletHomeContainer({ children }: PropsWithChildren) {
+  const isMainView = useIsTabletMainView();
   const isDetailView = useIsTabletDetailView();
   const isLandscape = useOrientation();
+
+  if (isMainView && !isLandscape) {
+    return null;
+  }
 
   if (isDetailView && isLandscape) {
     return (

--- a/packages/kit/src/routes/Tab/router.ts
+++ b/packages/kit/src/routes/Tab/router.ts
@@ -204,13 +204,16 @@ export const useTabRouterConfig = (params?: IGetTabRouterParams) => {
         trackId: 'global-earn',
         hideOnTabBar: platformEnv.isNative,
       },
-      isWebDappMode ? referFriendsTabConfig : undefined,
+      !platformEnv.isNative && isWebDappMode
+        ? referFriendsTabConfig
+        : undefined,
       // In non-DAPP mode, show ReferFriends in more actions
-      !isWebDappMode && {
-        ...referFriendsTabConfig,
-        inMoreAction: true,
-        hideOnTabBar: !isGtMdNonNative,
-      },
+      !platformEnv.isNative &&
+        !isWebDappMode && {
+          ...referFriendsTabConfig,
+          inMoreAction: true,
+          hideOnTabBar: !isGtMdNonNative,
+        },
       platformEnv.isNative
         ? undefined
         : {

--- a/packages/kit/src/routes/Tab/router.ts
+++ b/packages/kit/src/routes/Tab/router.ts
@@ -211,15 +211,17 @@ export const useTabRouterConfig = (params?: IGetTabRouterParams) => {
         inMoreAction: true,
         hideOnTabBar: !isGtMdNonNative,
       },
-      {
-        name: ETabRoutes.DeviceManagement,
-        tabBarIcon: () => 'OnekeyDeviceCustom',
-        translationId: ETranslations.global_device,
-        tabbarOnPress: toMyOneKeyModal,
-        children: null,
-        trackId: 'global-my-onekey',
-        hideOnTabBar: !isGtMdNonNative,
-      },
+      platformEnv.isNative
+        ? undefined
+        : {
+            name: ETabRoutes.DeviceManagement,
+            tabBarIcon: () => 'OnekeyDeviceCustom',
+            translationId: ETranslations.global_device,
+            tabbarOnPress: toMyOneKeyModal,
+            children: null,
+            trackId: 'global-my-onekey',
+            hideOnTabBar: !isGtMdNonNative,
+          },
       isShowMDDiscover ? getDiscoverRouterConfig(params) : undefined,
       platformEnv.isDev
         ? {

--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -360,40 +360,29 @@ export function EarnHomeWithProvider({
 
 const useNavigateToNativeEarnPage = platformEnv.isNative
   ? () => {
-      const { md } = useMedia();
       const navigation = useAppNavigation();
       const route = useAppRoute<ITabEarnParamList, ETabEarnRoutes.EarnHome>();
       const tabParam = route.params?.tab;
 
       useLayoutEffect(() => {
-        if (md) {
-          navigation.navigate(
-            ETabRoutes.Discovery,
-            {
-              screen: ETabDiscoveryRoutes.TabDiscovery,
-              params: {
-                defaultTab: ETranslations.global_earn,
-                earnTab: tabParam,
-              },
+        navigation.navigate(
+          ETabRoutes.Discovery,
+          {
+            screen: ETabDiscoveryRoutes.TabDiscovery,
+            params: {
+              defaultTab: ETranslations.global_earn,
+              earnTab: tabParam,
             },
-            {
-              pop: true,
-            },
-          );
-        }
-      }, [navigation, md, tabParam]);
+          },
+          {
+            pop: true,
+          },
+        );
+      }, [navigation, tabParam]);
     }
   : () => {};
 
 export default function EarnHome() {
   useNavigateToNativeEarnPage();
-  return platformEnv.isNative ? (
-    <Page fullPage>
-      <Page.Body>
-        <EarnHomeWithProvider />
-      </Page.Body>
-    </Page>
-  ) : (
-    <EarnHomeWithProvider />
-  );
+  return platformEnv.isNative ? null : <EarnHomeWithProvider />;
 }

--- a/packages/kit/src/views/Earn/components/AvailableAssetsTabViewList.tsx
+++ b/packages/kit/src/views/Earn/components/AvailableAssetsTabViewList.tsx
@@ -26,6 +26,7 @@ import {
 } from '@onekeyhq/kit/src/states/jotai/contexts/earn';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IEarnAvailableAsset } from '@onekeyhq/shared/types/earn';
 import { EAvailableAssetsTypeEnum } from '@onekeyhq/shared/types/earn';
 
@@ -322,7 +323,7 @@ export function AvailableAssetsTabViewList() {
         data={assets ?? []}
         columns={columns}
         keyExtractor={(asset) => asset.symbol}
-        withHeader={media.gtSm}
+        withHeader={platformEnv.isNative ? false : media.gtSm}
         defaultSortKey="yield"
         defaultSortDirection="desc"
         onPressRow={(asset) => void handleRowPress(asset)}

--- a/packages/kit/src/views/Earn/pages/EarnProtocols/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnProtocols/index.tsx
@@ -21,6 +21,7 @@ import { Token } from '@onekeyhq/kit/src/components/Token';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import type {
   ETabEarnRoutes,
@@ -59,6 +60,8 @@ function BasicEarnProtocols({ route }: { route: IRouteProps }) {
   }, [encodedLogoURI]);
 
   const media = useMedia();
+
+  const isDesktopLayout = !platformEnv.isNative && media.gtSm;
 
   const customHeaderLeft = useMemo(
     () => (
@@ -216,7 +219,7 @@ function BasicEarnProtocols({ route }: { route: IRouteProps }) {
       return (
         <YStack>
           {/* Table Header - Desktop only */}
-          {media.gtSm ? (
+          {isDesktopLayout ? (
             <ListItem mx="$0" px="$5">
               <XStack flex={2.5}>
                 <Skeleton h="$3" w={80} />
@@ -239,10 +242,10 @@ function BasicEarnProtocols({ route }: { route: IRouteProps }) {
               key={index}
               mx="$0"
               px="$5"
-              ai={media.gtSm ? 'center' : 'flex-start'}
+              ai={isDesktopLayout ? 'center' : 'flex-start'}
             >
               {/* Protocol column */}
-              <XStack flex={media.gtSm ? 2.5 : 1} ai="center" gap="$3">
+              <XStack flex={isDesktopLayout ? 2.5 : 1} ai="center" gap="$3">
                 <Skeleton w="$10" h="$10" borderRadius="$2" />
                 <YStack gap="$1" flex={1}>
                   <Skeleton h="$4" w="70%" />
@@ -250,7 +253,7 @@ function BasicEarnProtocols({ route }: { route: IRouteProps }) {
                 </YStack>
               </XStack>
 
-              {media.gtSm ? (
+              {isDesktopLayout ? (
                 <>
                   {/* Network column */}
                   <XStack flex={1} jc="flex-end">
@@ -308,18 +311,18 @@ function BasicEarnProtocols({ route }: { route: IRouteProps }) {
         defaultSortKey="yield"
         defaultSortDirection="desc"
         onPressRow={handleProtocolPress}
-        enableDrillIn={media.gtSm}
+        enableDrillIn={isDesktopLayout}
         isLoading={isLoading}
       />
     );
   }, [
-    media,
-    columns,
-    fetchProtocolData,
-    intl,
     isLoading,
     protocolData,
+    columns,
     handleProtocolPress,
+    isDesktopLayout,
+    intl,
+    fetchProtocolData,
   ]);
 
   return (

--- a/packages/kit/src/views/Swap/pages/SwapPageContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/SwapPageContainer.tsx
@@ -1,8 +1,4 @@
-import {
-  Page,
-  useIsTabletDetailView,
-  useOrientation,
-} from '@onekeyhq/components';
+import { Page } from '@onekeyhq/components';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { useDebugComponentRemountLog } from '@onekeyhq/shared/src/utils/debug/debugUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
@@ -14,20 +10,18 @@ import SwapMainLandWithPageType from './components/SwapMainLand';
 
 const SwapPageContainer = () => {
   useDebugComponentRemountLog({ name: 'SwapPageContainer' });
-  const isTabletDetailView = useIsTabletDetailView();
-  const isLandscape = useOrientation();
-  if (isTabletDetailView && isLandscape) {
-    return <TabletHomeContainer />;
-  }
+
   return (
     <Page fullPage>
-      <TabPageHeader
-        sceneName={EAccountSelectorSceneName.swap}
-        tabRoute={ETabRoutes.Swap}
-      />
-      <Page.Body>
-        <SwapMainLandWithPageType />
-      </Page.Body>
+      <TabletHomeContainer>
+        <TabPageHeader
+          sceneName={EAccountSelectorSceneName.swap}
+          tabRoute={ETabRoutes.Swap}
+        />
+        <Page.Body>
+          <SwapMainLandWithPageType />
+        </Page.Body>
+      </TabletHomeContainer>
     </Page>
   );
 };

--- a/patches/@tamagui+web+1.108.0.patch
+++ b/patches/@tamagui+web+1.108.0.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/@tamagui/web/dist/cjs/hooks/useMedia.native.js b/node_modules/@tamagui/web/dist/cjs/hooks/useMedia.native.js
-index 47addac..85f0848 100644
+index 47addac..808ba9d 100644
 --- a/node_modules/@tamagui/web/dist/cjs/hooks/useMedia.native.js
 +++ b/node_modules/@tamagui/web/dist/cjs/hooks/useMedia.native.js
-@@ -160,11 +160,85 @@ function unlisten() {
+@@ -160,11 +160,76 @@ function unlisten() {
    }), dispose.clear();
  }
  var setupVersion = -1;
@@ -46,15 +46,6 @@ index 47addac..85f0848 100644
 +      checkTabletSplitView((isSplitView) => {
 +        if (isSplitView) {
 +           switch (key2) {
-+            case 'sm':
-+              next = true;
-+              break;
-+            case 'gtSm':
-+              next = true;
-+              break;
-+            case 'md':
-+              next = true;
-+              break;
 +            case 'gtMd':
 +              next = false;
 +              break;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tablet home now respects orientation and main/tablet split views to avoid unintended rendering in portrait or split-screen.
  * Earn native flow consistently navigates to the Discovery tab on mount.
  * Tab bar placement and visibility for ReferFriends and Device Management adjusted for platform/mode to prevent misplaced tabs.

* **Refactor**
  * Simplified Swap and Earn layouts for more consistent rendering across devices.
  * Improved media/dual-screen handling and desktop vs mobile table/list behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->