### PR TITLE
fix: resolve desktop deep link navigation issue on cold startup

### DIFF
--- a/apps/desktop/app/app.ts
+++ b/apps/desktop/app/app.ts
@@ -394,19 +394,23 @@ function handleDeepLinkUrl(
   };
 
   const sendEventData = () => {
-    isAppReady = true;
-
     const safelyMainWindow = getSafelyMainWindow();
     if (safelyMainWindow) {
       showMainWindow();
-      if (process.env.NODE_ENV !== 'production') {
+
+      // Cold startup: cache the deep link for later processing
+      if (!isAppReady) {
         safelyMainWindow?.webContents.send(
           ipcMessageKeys.OPEN_DEEP_LINK_URL,
           eventData,
         );
       }
+
+      // Hot startup: send directly to registered listener
       mainWindow?.webContents.send(ipcMessageKeys.EVENT_OPEN_URL, eventData);
     }
+
+    isAppReady = true;
   };
   if (isAppReady && mainWindow) {
     sendEventData();

--- a/packages/kit/src/routes/config/deeplink/handler.desktop.ts
+++ b/packages/kit/src/routes/config/deeplink/handler.desktop.ts
@@ -7,7 +7,7 @@ export const registerHandler: IRegisterHandler = (
   handleDeepLinkUrl: (e: IDesktopOpenUrlEventData) => void,
 ) => {
   const desktopLinkingHandler = (
-    event: Event,
+    _event: Event,
     data: IDesktopOpenUrlEventData,
   ) => {
     handleDeepLinkUrl(data);
@@ -26,5 +26,13 @@ export const registerHandler: IRegisterHandler = (
     ipcMessageKeys.EVENT_OPEN_URL,
     desktopLinkingHandler,
   );
-  // window.desktopApi.ready();
+
+  // Process any cached deep links from cold startup
+  if (globalThis.ONEKEY_DESKTOP_DEEP_LINKS?.length > 0) {
+    const cachedLinks = [...globalThis.ONEKEY_DESKTOP_DEEP_LINKS];
+    globalThis.ONEKEY_DESKTOP_DEEP_LINKS = [];
+    cachedLinks.forEach((data) => {
+      handleDeepLinkUrl(data);
+    });
+  }
 };


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deep link handling to ensure proper and reliable processing when launching the app from external URLs in various startup scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes the issue where desktop app fails to navigate to the target page when launched via deep link while closed (cold startup).

## Problem

When users click an invite deep link while the desktop app is closed:
- ✅ Hot startup (app already running): Works correctly
- ❌ Cold startup (app is closed): App opens but doesn't navigate to the invite page

### Root Cause

Timing issue in the IPC communication:
1. Main process receives deep link and sends `EVENT_OPEN_URL` too early
2. React app hasn't finished initializing, so the IPC listener isn't registered yet
3. Deep link event is lost and navigation never happens

## Solution

Leverage the existing `ONEKEY_DESKTOP_DEEP_LINKS` cache mechanism in preload.ts:

1. **Main process** (`app.ts`): Only send `OPEN_DEEP_LINK_URL` during cold startup (`!isAppReady`)
2. **Preload layer** (`preload.ts`): Cache deep links in `ONEKEY_DESKTOP_DEEP_LINKS` array (already exists)
3. **Renderer process** (`handler.desktop.ts`): Process cached deep links after React initializes

### Flow

**Cold Startup:**
```
System deep link → Main process → OPEN_DEEP_LINK_URL → Preload caches
                                                           ↓
React initializes → registerHandler() → Read cache → Navigate ✅
```

**Hot Startup:**
```
System deep link → Main process → EVENT_OPEN_URL → Listener processes → Navigate ✅
(No caching, direct handling)
```

## Changes

- `apps/desktop/app/app.ts`: Send `OPEN_DEEP_LINK_URL` only during cold startup to avoid duplicate processing
- `packages/kit/src/routes/config/deeplink/handler.desktop.ts`: Process cached deep links from `ONEKEY_DESKTOP_DEEP_LINKS`

## Testing

### Manual Testing
1. **Cold startup**: Close app completely → Click invite link → Verify navigation
2. **Hot startup**: Keep app running → Click invite link → Verify still works

### Test Deep Link
```
onekey-wallet://invited_by_friend?code=TEST123
```

## Notes

- Minimal changes (~15 lines of code)
- Reuses existing cache mechanism in preload.ts
- No breaking changes to existing hot startup behavior