### PR TITLE
fix: adjust onboarding screen animation for Android

### DIFF
--- a/packages/components/src/layouts/Navigation/GlobalScreenOptions.native.ts
+++ b/packages/components/src/layouts/Navigation/GlobalScreenOptions.native.ts
@@ -170,11 +170,15 @@ export function makeFullScreenOptions(): IStackNavigationOptions {
 }
 
 export function makeOnboardingScreenOptions(): IStackNavigationOptions {
-  return {
+  const options: IStackNavigationOptions = {
     headerShown: false,
     presentation: 'card',
     gestureEnabled: false,
     gestureDirection: 'horizontal',
     animation: 'slide_from_left',
   };
+  if (platformEnv.isNativeAndroid) {
+    options.animation = 'none';
+  }
+  return options;
 }


### PR DESCRIPTION
Sets the onboarding screen animation to 'none' on native Android platforms to improve compatibility, while retaining 'slide_from_left' for other platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the onboarding experience on Android devices by optimizing screen transitions for improved platform-specific performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->