### PR TITLE
feat: create qr wallet on btc only OK-47055 OK-47064 OK-47071

### DIFF
--- a/packages/kit-bg/src/dbs/local/LocalDbBase.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.ts
@@ -2161,6 +2161,9 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
       return;
     }
 
+    const featuresInfo = await deviceUtils.attachAppParamsToFeatures({
+      features,
+    });
     let isUpdated = false;
     await this.withTransaction(EIndexedDBBucketNames.account, async (tx) => {
       await this.txUpdateRecords({
@@ -2168,7 +2171,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
         name: ELocalDBStoreNames.Device,
         ids: [device.id],
         updater: async (item) => {
-          const newFeatures = stringUtils.stableStringify(features);
+          const newFeatures = stringUtils.stableStringify(featuresInfo);
           if (item.features !== newFeatures) {
             item.features = newFeatures;
             isUpdated = true;
@@ -2243,6 +2246,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
       | {
           fw_vendor: string | undefined;
           capabilities: number[] | undefined;
+          $app_firmware_type?: EFirmwareType;
         }
       | undefined;
   }) {
@@ -2861,7 +2865,10 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
       hiddenDefaultWalletName = hiddenWalletNameInfo.hiddenWalletName;
     }
 
-    const featuresStr = JSON.stringify(features);
+    const featuresInfo = await deviceUtils.attachAppParamsToFeatures({
+      features,
+    });
+    const featuresStr = JSON.stringify(featuresInfo);
 
     const firstAccountIndex = 0;
 

--- a/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts
+++ b/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts
@@ -1227,6 +1227,7 @@ class ServiceHardware extends ServiceBase {
       | {
           fw_vendor: string | undefined;
           capabilities: number[] | undefined;
+          $app_firmware_type?: EFirmwareType;
         }
       | undefined;
     const capabilityBitcoinLike = 2;
@@ -1247,6 +1248,7 @@ class ServiceHardware extends ServiceBase {
         bitcoinOnlyFlag = {
           fw_vendor: bitcoinOnlyFwVendor,
           capabilities: newCapabilities,
+          $app_firmware_type: EFirmwareType.BitcoinOnly,
         };
       } else if (
         updateFirmwareInfo?.fromFirmwareType === EFirmwareType.BitcoinOnly &&
@@ -1267,6 +1269,7 @@ class ServiceHardware extends ServiceBase {
         bitcoinOnlyFlag = {
           fw_vendor: undefined,
           capabilities,
+          $app_firmware_type: EFirmwareType.Universal,
         };
       }
     } catch (error) {

--- a/packages/kit-bg/src/services/ServiceQrWallet/ServiceQrWallet.ts
+++ b/packages/kit-bg/src/services/ServiceQrWallet/ServiceQrWallet.ts
@@ -1,3 +1,4 @@
+import { EFirmwareType } from '@onekeyfe/hd-shared';
 import { uniq } from 'lodash';
 
 import type {
@@ -28,6 +29,7 @@ import {
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { checkIsDefined } from '@onekeyhq/shared/src/utils/assertUtils';
+import deviceUtils from '@onekeyhq/shared/src/utils/deviceUtils';
 import { generateUUID } from '@onekeyhq/shared/src/utils/miscUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import type { IQrWalletDevice } from '@onekeyhq/shared/types/device';
@@ -247,7 +249,11 @@ class ServiceQrWallet extends ServiceBase {
     allDefaultAddAccountNetworksIds = uniq([
       ...allDefaultAddAccountNetworksIds,
     ]);
-    if (networkUtils.isAllNetwork({ networkId })) {
+    const firmwareType = await deviceUtils.getFirmwareType({
+      features: byDevice?.featuresInfo,
+    });
+    const isBtcOnlyFirmware = firmwareType === EFirmwareType.BitcoinOnly;
+    if (networkUtils.isAllNetwork({ networkId }) || isBtcOnlyFirmware) {
       networkIds = uniq([...allDefaultAddAccountNetworksIds]);
     } else {
       // networkIds = [networkId];

--- a/packages/kit/src/components/AccountAvatar/AccountAvatar.tsx
+++ b/packages/kit/src/components/AccountAvatar/AccountAvatar.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react';
 import { isValidElement, useMemo } from 'react';
 
+import { EFirmwareType } from '@onekeyfe/hd-shared';
 import { isString } from 'lodash';
 
 import type {
@@ -23,7 +24,9 @@ import type {
   IDBIndexedAccount,
   IDBWallet,
 } from '@onekeyhq/kit-bg/src/dbs/local/types';
+import { presetNetworksMap } from '@onekeyhq/shared/src/config/presetNetworks';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import deviceUtils from '@onekeyhq/shared/src/utils/deviceUtils';
 import externalWalletLogoUtils from '@onekeyhq/shared/src/utils/externalWalletLogoUtils';
 import type { INetworkAccount } from '@onekeyhq/shared/types/account';
 
@@ -143,6 +146,15 @@ function BasicAccountAvatar({
         (account || dbAccount)?.address,
     ),
   );
+
+  const firmwareType = useMemo(() => {
+    if (!wallet?.associatedDeviceInfo) {
+      return undefined;
+    }
+    return deviceUtils.getFirmwareTypeByCachedFeatures({
+      features: wallet.associatedDeviceInfo?.featuresInfo,
+    });
+  }, [wallet?.associatedDeviceInfo]);
 
   const uriSource = useMemo(() => {
     const emptyAccountAvatar = <DefaultEmptyAccount />;
@@ -338,6 +350,21 @@ function BasicAccountAvatar({
           zIndex="$1"
         >
           <NetworkAvatar networkId={networkId} size={logoSize} />
+        </Stack>
+      ) : null}
+
+      {firmwareType === EFirmwareType.BitcoinOnly ? (
+        <Stack
+          position="absolute"
+          h="$4"
+          px="$0.5"
+          justifyContent="center"
+          top={-4}
+          left={-4}
+          borderRadius="$full"
+          zIndex="$1"
+        >
+          <NetworkAvatar networkId={presetNetworksMap.btc.id} size={14} />
         </Stack>
       ) : null}
     </Stack>

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/WalletDetailsHeader/index.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/WalletDetailsHeader/index.tsx
@@ -21,6 +21,7 @@ import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import type { IWalletDetailsProps } from '..';
+import deviceUtils from '@onekeyhq/shared/src/utils/deviceUtils';
 
 type IWalletDetailsHeaderProps = {
   editable?: boolean;
@@ -59,6 +60,12 @@ export function WalletDetailsHeader({
     [wallet, editable],
   );
 
+  const firmwareType = useMemo(() => {
+    return deviceUtils.getFirmwareTypeByCachedFeatures({
+      features: device?.featuresInfo,
+    });
+  }, [device]);
+
   return (
     <YStack
       testID="account-selector-header"
@@ -91,7 +98,11 @@ export function WalletDetailsHeader({
             })}
           >
             <Stack>
-              <WalletAvatar size="$8" wallet={wallet} />
+              <WalletAvatar
+                size="$8"
+                wallet={wallet}
+                firmwareTypeBadge={firmwareType}
+              />
               {isAvatarEditable ? (
                 <ListItem.Avatar.CornerIcon
                   name="MenuCircleHorSolid"

--- a/packages/shared/src/utils/deviceUtils.ts
+++ b/packages/shared/src/utils/deviceUtils.ts
@@ -23,6 +23,7 @@ import type {
   IFetchFirmwareVerifyHashParams,
   IFirmwareVerifyInfo,
   IOneKeyDeviceFeatures,
+  IOneKeyDeviceFeaturesWithAppParams,
   IOneKeyDeviceType,
 } from '../../types/device';
 import type {
@@ -558,6 +559,20 @@ function getDefaultHardwareTransportType(): EHardwareTransportType {
   return EHardwareTransportType.Bridge;
 }
 
+function getFirmwareTypeByCachedFeatures({
+  features,
+}: {
+  features:
+    | (IOneKeyDeviceFeatures & { $app_firmware_type?: EFirmwareType })
+    | undefined;
+}) {
+  if (!features) {
+    return EFirmwareType.Universal;
+  }
+
+  return features.$app_firmware_type;
+}
+
 async function getFirmwareType({
   features,
 }: {
@@ -658,6 +673,17 @@ async function buildDeviceUSBConnectId({
   return getDeviceUUID(features);
 }
 
+async function attachAppParamsToFeatures({
+  features,
+}: {
+  features: IOneKeyDeviceFeatures;
+}): Promise<IOneKeyDeviceFeaturesWithAppParams> {
+  const firmwareType = await getFirmwareType({
+    features,
+  });
+  return { ...features, $app_firmware_type: firmwareType };
+}
+
 export default {
   dbDeviceToSearchDevice,
   getDeviceVersion,
@@ -686,9 +712,11 @@ export default {
   getDeviceConnectId,
   getDefaultHardwareTransportType,
   isBtcOnlyFirmware,
+  getFirmwareTypeByCachedFeatures,
   getFirmwareType,
   getFirmwareTypeLabel,
   getFirmwareTypeLabelByFirmwareType,
   isTouchDevice,
   buildDeviceUSBConnectId,
+  attachAppParamsToFeatures,
 };

--- a/packages/shared/types/device.ts
+++ b/packages/shared/types/device.ts
@@ -25,6 +25,9 @@ export type IOneKeyDeviceType = IDeviceType;
 
 export type IOneKeyDeviceFeatures = FeaturesTransport;
 export type IOneKeyDeviceFeaturesCore = FeaturesCore;
+export type IOneKeyDeviceFeaturesWithAppParams = IOneKeyDeviceFeatures & {
+  $app_firmware_type?: EFirmwareType;
+};
 
 export type IFirmwareChangeLog = {
   [key in ILocaleSymbol]?: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect and display device firmware type (Bitcoin-only or Universal) across device lists and wallet UIs.
  * Show Bitcoin network badge on account avatars for Bitcoin-only firmware devices.
  * Firmware-aware network selection when creating QR wallet addresses and during wallet setup.
  * Device and wallet records now persist app-level firmware type so firmware info is retained across creation and updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->