### PR TITLE
fix: stabilize perps share referral invite code OK-47173 OK-46790

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpAccountList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpAccountList.tsx
@@ -165,7 +165,9 @@ function PerpAccountList({
       data={mergedData}
       isMobile={isMobile}
       renderRow={renderAccountRow}
-      listLoading={!isSubscribed}
+      // If account has no Perp address (unsupported or not created),
+      // show empty state instead of skeleton loading.
+      listLoading={currentUser?.accountAddress ? !isSubscribed : false}
       emptyMessage={intl.formatMessage({
         id: ETranslations.perp_trade_history_empty,
       })}

--- a/packages/kit/src/views/Perp/components/PositionShare/ShareView.tsx
+++ b/packages/kit/src/views/Perp/components/PositionShare/ShareView.tsx
@@ -36,6 +36,11 @@ export function ShareView({
   const generationIdRef = useRef(0);
 
   useEffect(() => {
+    if (isReferralReady === false) {
+      setPreviewImage(null);
+      setIsGenerating(true);
+      return;
+    }
     generationIdRef.current += 1;
     const currentGenerationId = generationIdRef.current;
     setIsGenerating(true);

--- a/packages/kit/src/views/Perp/components/PositionShare/useReferralUrl.ts
+++ b/packages/kit/src/views/Perp/components/PositionShare/useReferralUrl.ts
@@ -2,22 +2,78 @@ import { useMemo } from 'react';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { usePrimePersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
 import {
   WEB_APP_URL,
   WEB_APP_URL_DEV,
 } from '@onekeyhq/shared/src/config/appConfig';
 
+const primaryInviteCodeCache = new Map<string, string>();
+const inFlightPrimaryInviteCode = new Map<
+  string,
+  Promise<string | undefined>
+>();
+
+async function getPrimaryInviteCode(cacheKey: string) {
+  const cached = primaryInviteCodeCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+  let inFlight = inFlightPrimaryInviteCode.get(cacheKey);
+  if (!inFlight) {
+    inFlight = backgroundApiProxy.serviceReferralCode
+      .getSummaryInfo()
+      .then((summary) => summary?.inviteCode || undefined)
+      .catch(() => undefined);
+    inFlightPrimaryInviteCode.set(cacheKey, inFlight);
+  }
+  try {
+    const inviteCode = await inFlight;
+    if (inviteCode) {
+      primaryInviteCodeCache.set(cacheKey, inviteCode);
+    }
+    return inviteCode;
+  } finally {
+    inFlightPrimaryInviteCode.delete(cacheKey);
+  }
+}
+
 export function useReferralUrl() {
   const [devSettings] = useDevSettingsPersistAtom();
+  const [primeUser] = usePrimePersistAtom();
+
+  const useTestUrl =
+    devSettings.enabled && devSettings.settings?.enableTestEndpoint;
+
+  const referralCacheKey = useMemo(() => {
+    if (!primeUser?.isLoggedInOnServer || !primeUser.onekeyUserId) {
+      return undefined;
+    }
+    const envKey = useTestUrl ? 'dev' : 'prod';
+    return `${primeUser.onekeyUserId}:${envKey}`;
+  }, [primeUser?.isLoggedInOnServer, primeUser?.onekeyUserId, useTestUrl]);
 
   const { result: summaryInfo, isLoading } = usePromiseResult(
     async () => {
-      const code =
-        await backgroundApiProxy.serviceReferralCode.getMyReferralCode();
-      if (code) {
-        return { inviteCode: code };
+      if (referralCacheKey) {
+        const primaryCode = await getPrimaryInviteCode(referralCacheKey);
+        if (primaryCode) {
+          return { inviteCode: primaryCode };
+        }
+        const localCode =
+          await backgroundApiProxy.serviceReferralCode.getMyReferralCode();
+        if (localCode) {
+          return { inviteCode: localCode };
+        }
+        return null;
       }
+      const localCode =
+        await backgroundApiProxy.serviceReferralCode.getMyReferralCode();
+      if (localCode) {
+        return { inviteCode: localCode };
+      }
+
       const isLoggedIn = await backgroundApiProxy.servicePrime.isLoggedIn();
       if (!isLoggedIn) {
         return null;
@@ -25,20 +81,22 @@ export function useReferralUrl() {
 
       return backgroundApiProxy.serviceReferralCode.getSummaryInfo();
     },
-    [],
+    [referralCacheKey],
     {
       initResult: undefined,
       watchLoading: true,
+      undefinedResultIfReRun: true,
     },
   );
 
   const webAppUrl = useMemo(() => {
-    const useTestUrl =
-      devSettings.enabled && devSettings.settings?.enableTestEndpoint;
     return useTestUrl ? WEB_APP_URL_DEV : WEB_APP_URL;
-  }, [devSettings.enabled, devSettings.settings?.enableTestEndpoint]);
+  }, [useTestUrl]);
 
-  const inviteCode = summaryInfo?.inviteCode;
+  const cachedPrimaryCode = referralCacheKey
+    ? primaryInviteCodeCache.get(referralCacheKey)
+    : undefined;
+  const inviteCode = summaryInfo?.inviteCode || cachedPrimaryCode;
   const defaultReferralUrl = `${webAppUrl}/perps`;
 
   const referralQrCodeUrl = useMemo(() => {
@@ -50,7 +108,7 @@ export function useReferralUrl() {
 
   const referralDisplayText = inviteCode || defaultReferralUrl;
 
-  const isReady = isLoading === false;
+  const isReady = Boolean(inviteCode) || isLoading === false;
   return {
     referralQrCodeUrl,
     referralDisplayText,

--- a/packages/kit/src/views/Perp/hooks/usePerpOrderInfoPanel.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpOrderInfoPanel.ts
@@ -61,12 +61,15 @@ export function usePerpTradesHistory() {
 
   const fills: IFill[] = tradesData?.fills ?? [];
   const isLoaded: boolean = tradesData?.isLoaded ?? false;
+  const hasAccountAddress = Boolean(currentAccount?.accountAddress);
 
   return {
     trades: fills,
     currentListPage,
     setCurrentListPage,
-    isLoading: !isLoaded,
+    // If current account has no Perp address (unsupported or not created yet),
+    // show empty state instead of skeleton loading.
+    isLoading: hasAccountAddress ? !isLoaded : false,
   };
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented premature share image generation when referral data isn’t ready to avoid errors.

* **Performance**
  * Added client-side caching and in-flight deduping for referral invite codes to reduce fetch latency.

* **User Experience**
  * Refined loading behavior to show empty states (rather than skeletons) when no account address is present.
  * Exposed readiness indicator for referral data to improve display logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->