### PR TITLE
fix: remove keychain-access-groups from MAS entitlements

### DIFF
--- a/apps/desktop/entitlements.mas.plist
+++ b/apps/desktop/entitlements.mas.plist
@@ -22,12 +22,6 @@
     <true/>
     <key>com.apple.security.device.bluetooth</key>
     <true/>
-
-    <!-- Keychain access for biometric-protected storage -->
-    <key>com.apple.security.keychain-access-groups</key>
-    <array>
-      <string>$(AppIdentifierPrefix)so.onekey.wallet</string>
-    </array>
     
     <key>com.apple.developer.icloud-services</key>
     <array>


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated macOS app entitlements configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Remove `com.apple.security.keychain-access-groups` entitlement from Mac App Store entitlements plist.

## Changes

- Removed keychain-access-groups configuration from `apps/desktop/entitlements.mas.plist`

## Reason

The keychain-access-groups entitlement was causing issues with Mac App Store submission. This entitlement is not required for the MAS build.

## Testing

- [ ] Verify MAS build succeeds
- [ ] Verify app submission to App Store Connect works