### PR TITLE
fix: remove extra params wrapper from phone-otp POST request

### DIFF
--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
@@ -205,10 +205,8 @@ class ServicePrime extends ServiceBase {
     const result = await client.post<
       IApiClientResponse<{ phone: string; otp: string }>
     >('/prime/v1/general/phone-otp', {
-      params: {
-        email,
-        otp,
-      },
+      email,
+      otp,
     });
 
     return result?.data?.data;


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved phone verification request handling for better API compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Removed the extra `params` wrapper from the POST request body in `apiFetchPhoneOtp` method
- The request was sending `{"params":{"email":"...","otp":"..."}}` instead of `{"email":"...","otp":"..."}`
- This caused the server to not recognize the request properly

## Test plan
- [ ] Verify privy.io email login works correctly
- [ ] Test OTP verification flow for @privy.io emails