### PR TITLE
refactor: unify token amount display style between DeFi and Perps tabs

### DIFF
--- a/packages/kit/src/views/ReferFriends/pages/EarnReward/components/EarnRewardsTab/components/RewardAccountList.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/EarnReward/components/EarnRewardsTab/components/RewardAccountList.tsx
@@ -7,8 +7,6 @@ import {
   XStack,
   YStack,
 } from '@onekeyhq/components';
-import { Currency } from '@onekeyhq/kit/src/components/Currency';
-import { Token } from '@onekeyhq/kit/src/components/Token';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type {
   IEarnRewardItem,
@@ -19,6 +17,7 @@ import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { EmptyData } from '../../EmptyData';
 import { ReferFriendsAccordionItem } from '../../ReferFriendsAccordionItem';
 import { ReferFriendsListHeader } from '../../ReferFriendsListHeader';
+import { TokenAmountWithFiat } from '../../TokenAmountWithFiat';
 
 export type IVaultAmount = Record<string, Record<string, string>>;
 
@@ -98,32 +97,11 @@ export function RewardAccountList({
                     ) : null}
                   </YStack>
 
-                  <XStack
-                    ai="center"
-                    gap="$2"
-                    flexDirection="row"
-                    $gtMd={{ gap: '$4' }}
-                  >
-                    <XStack ai="center">
-                      <Token
-                        size="xs"
-                        tokenImageUri={item.token.logoURI}
-                        mr="$2"
-                      />
-                      <NumberSizeableText
-                        formatter="balance"
-                        size="$bodyMd"
-                        formatterOptions={{
-                          tokenSymbol: item.token.symbol || '',
-                        }}
-                      >
-                        {item.amount}
-                      </NumberSizeableText>
-                    </XStack>
-                    <Currency formatter="value" size="$bodyMd">
-                      {item.fiatValue}
-                    </Currency>
-                  </XStack>
+                  <TokenAmountWithFiat
+                    token={item.token}
+                    amount={item.amount}
+                    fiatValue={item.fiatValue}
+                  />
                 </XStack>
               );
             })}

--- a/packages/kit/src/views/ReferFriends/pages/EarnReward/components/PerpsRecordsTab/components/TradingVolumeSummaryCard.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/EarnReward/components/PerpsRecordsTab/components/TradingVolumeSummaryCard.tsx
@@ -2,15 +2,15 @@ import { useIntl } from 'react-intl';
 
 import {
   type IXStackProps,
-  NumberSizeableText,
   SizableText,
   XStack,
   YStack,
 } from '@onekeyhq/components';
 import { Currency } from '@onekeyhq/kit/src/components/Currency';
-import { Token } from '@onekeyhq/kit/src/components/Token';
 import type { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IRewardToken } from '@onekeyhq/shared/src/referralCode/type';
+
+import { TokenAmountWithFiat } from '../../TokenAmountWithFiat';
 
 interface ITradingVolumeSummaryCardProps extends IXStackProps {
   titleId?: ETranslations;
@@ -54,32 +54,11 @@ export function TradingVolumeSummaryCard({
       </YStack>
 
       {/* Right section: Token icon, amount, and fiat value */}
-      <XStack ai="center" gap="$2" borderRadius="$2">
-        <Token size="xs" tokenImageUri={token.logoURI} />
-        <XStack ai="center" gap="$1">
-          <NumberSizeableText
-            formatter="balance"
-            size="$bodyMd"
-            color="$text"
-            formatterOptions={{
-              tokenSymbol: token.symbol || '',
-            }}
-          >
-            {tokenAmount}
-          </NumberSizeableText>
-          <XStack ai="center">
-            <SizableText size="$bodyMd" color="$textSubdued">
-              (
-            </SizableText>
-            <Currency formatter="value" size="$bodyMd" color="$textSubdued">
-              {tokenFiatValue}
-            </Currency>
-            <SizableText size="$bodyMd" color="$textSubdued">
-              )
-            </SizableText>
-          </XStack>
-        </XStack>
-      </XStack>
+      <TokenAmountWithFiat
+        token={token}
+        amount={tokenAmount}
+        fiatValue={tokenFiatValue}
+      />
     </XStack>
   );
 }

--- a/packages/kit/src/views/ReferFriends/pages/EarnReward/components/TokenAmountWithFiat.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/EarnReward/components/TokenAmountWithFiat.tsx
@@ -1,0 +1,44 @@
+import { NumberSizeableText, SizableText, XStack } from '@onekeyhq/components';
+import { Currency } from '@onekeyhq/kit/src/components/Currency';
+import { Token } from '@onekeyhq/kit/src/components/Token';
+import type { IRewardToken } from '@onekeyhq/shared/src/referralCode/type';
+
+interface ITokenAmountWithFiatProps {
+  token: IRewardToken;
+  amount: string;
+  fiatValue: string;
+}
+
+export function TokenAmountWithFiat({
+  token,
+  amount,
+  fiatValue,
+}: ITokenAmountWithFiatProps) {
+  return (
+    <XStack ai="center" gap="$2">
+      <Token size="xs" tokenImageUri={token.logoURI} />
+      <XStack ai="center" gap="$1">
+        <NumberSizeableText
+          formatter="balance"
+          size="$bodyMd"
+          formatterOptions={{
+            tokenSymbol: token.symbol || '',
+          }}
+        >
+          {amount}
+        </NumberSizeableText>
+        <XStack ai="center">
+          <SizableText size="$bodyMd" color="$textSubdued">
+            (
+          </SizableText>
+          <Currency formatter="value" size="$bodyMd" color="$textSubdued">
+            {fiatValue}
+          </Currency>
+          <SizableText size="$bodyMd" color="$textSubdued">
+            )
+          </SizableText>
+        </XStack>
+      </XStack>
+    </XStack>
+  );
+}


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Unified token amount and fiat value display across reward accounts and trading volume sections for improved visual consistency and code maintainability throughout the refer friends interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- Extract `TokenAmountWithFiat` component for consistent token display
- Update `RewardAccountList` (DeFi) to use the shared component
- Update `TradingVolumeSummaryCard` (Perps) to use the shared component

Both tabs now display tokens in the same format: `Token icon + amount + (fiat value)`

## Test plan

- [ ] Verify DeFi tab shows token amounts with parentheses around fiat value
- [ ] Verify Perps tab continues to display correctly
- [ ] Verify both tabs have consistent styling