### PR TITLE
refactor: hide Intercom launcher and update UI components OK-45587

### DIFF
--- a/packages/kit/src/components/AddressInput/plugins/selector.tsx
+++ b/packages/kit/src/components/AddressInput/plugins/selector.tsx
@@ -8,6 +8,7 @@ import { useAccountSelectorActions } from '@onekeyhq/kit/src/states/jotai/contex
 import { useAddressBookPick } from '@onekeyhq/kit/src/views/AddressBook/hooks/useAddressBook';
 import type { IAddressItem } from '@onekeyhq/kit/src/views/AddressBook/type';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { EInputAddressChangeType } from '@onekeyhq/shared/types/address';
 
@@ -209,13 +210,17 @@ const AccountSelectorAddressBookPlugin: FC<ISelectorPluginProps> = ({
           }),
           onPress: onShowAccountSelector,
         },
-        {
-          icon: 'ContactsOutline' as const,
-          label: intl.formatMessage({
-            id: ETranslations.send_to_contacts_selector_address_book,
-          }),
-          onPress: onContacts,
-        },
+        ...(platformEnv.isWebDappMode
+          ? []
+          : [
+              {
+                icon: 'ContactsOutline' as const,
+                label: intl.formatMessage({
+                  id: ETranslations.send_to_contacts_selector_address_book,
+                }),
+                onPress: onContacts,
+              },
+            ]),
       ]}
       renderTrigger={
         <IconButton

--- a/packages/kit/src/components/Footer/Footer.tsx
+++ b/packages/kit/src/components/Footer/Footer.tsx
@@ -4,6 +4,8 @@ import { useIntl } from 'react-intl';
 
 import { Image, XStack, useOnRouterChange } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { showIntercom } from '@onekeyhq/shared/src/modules3rdParty/intercom';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ERootRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
 
 import { usePerpsLogo } from '../../views/Perp/hooks/usePerpsLogo';
@@ -14,7 +16,7 @@ import { PerpRefreshButton } from '../PerpRefreshButton';
 import { FooterLink } from './components/FooterLink';
 import { FooterNavigation } from './components/FooterNavigation';
 
-const LINKS = [
+const getLinks = () => [
   {
     id: 'about',
     translationKey: ETranslations.global_about,
@@ -25,11 +27,19 @@ const LINKS = [
     translationKey: ETranslations.menu_help,
     href: 'https://help.onekey.so/collections/15988402',
   },
-  {
-    id: 'guide',
-    translationKey: ETranslations.global_view_tutorial,
-    href: 'https://help.onekey.so/articles/12568192',
-  },
+  platformEnv.isWebDappMode
+    ? {
+        id: 'contact',
+        translationKey: ETranslations.settings_contact_us,
+        onPress: () => {
+          void showIntercom();
+        },
+      }
+    : {
+        id: 'guide',
+        translationKey: ETranslations.global_view_tutorial,
+        href: 'https://help.onekey.so/articles/12568192',
+      },
   {
     id: 'terms',
     translationKey: ETranslations.settings_user_agreement,
@@ -63,11 +73,12 @@ export function Footer() {
 
   const linkItems = useMemo(
     () =>
-      LINKS.map((item) => (
+      getLinks().map((item) => (
         <FooterLink
           key={item.id}
           label={intl.formatMessage({ id: item.translationKey })}
           href={item.href}
+          onPress={item.onPress}
         />
       )),
     [intl],

--- a/packages/kit/src/components/Footer/components/FooterLink.tsx
+++ b/packages/kit/src/components/Footer/components/FooterLink.tsx
@@ -1,11 +1,36 @@
-import { Anchor } from '@onekeyhq/components';
+import { Anchor, SizableText } from '@onekeyhq/components';
 
 export interface IFooterLinkProps {
   label: string;
-  href: string;
+  href?: string;
+  onPress?: () => void;
 }
 
-export function FooterLink({ label, href }: IFooterLinkProps) {
+export function FooterLink({ label, href, onPress }: IFooterLinkProps) {
+  if (onPress) {
+    return (
+      <SizableText
+        size="$bodyMd"
+        color="$textSubdued"
+        cursor="pointer"
+        hoverStyle={{
+          bg: '$bgHover',
+        }}
+        pressStyle={{
+          bg: '$bgActive',
+        }}
+        px="$2"
+        py="$1"
+        mx="$-1"
+        my="$-1"
+        borderRadius="$2"
+        onPress={onPress}
+      >
+        {label}
+      </SizableText>
+    );
+  }
+
   return (
     <Anchor
       href={href}

--- a/packages/kit/src/components/TabPageHeader/MoreActionButton.tsx
+++ b/packages/kit/src/components/TabPageHeader/MoreActionButton.tsx
@@ -518,23 +518,27 @@ function MoreActionContentGrid() {
   const [{ firstTimeGuideOpened, badge }] = useNotificationsAtom();
   const items = useMemo(() => {
     return [
-      {
-        title: intl.formatMessage({
-          id: ETranslations.address_book_title,
-        }),
-        icon: 'ContactsOutline',
-        onPress: openAddressBook,
-        testID: 'address-book',
-        trackID: 'wallet-address-book',
-      },
-      {
-        title: intl.formatMessage({
-          id: ETranslations.global_my_onekey,
-        }),
-        icon: 'OnekeyDeviceCustom',
-        onPress: handleDeviceManagement,
-        testID: 'my-onekey',
-      },
+      platformEnv.isWebDappMode
+        ? undefined
+        : {
+            title: intl.formatMessage({
+              id: ETranslations.address_book_title,
+            }),
+            icon: 'ContactsOutline',
+            onPress: openAddressBook,
+            testID: 'address-book',
+            trackID: 'wallet-address-book',
+          },
+      platformEnv.isWebDappMode
+        ? undefined
+        : {
+            title: intl.formatMessage({
+              id: ETranslations.global_my_onekey,
+            }),
+            icon: 'OnekeyDeviceCustom',
+            onPress: handleDeviceManagement,
+            testID: 'my-onekey',
+          },
       {
         title: intl.formatMessage({
           id: ETranslations.settings_settings,
@@ -559,13 +563,15 @@ function MoreActionContentGrid() {
         testID: 'referral',
         onPress: toReferFriendsPage,
       },
-      {
-        title: intl.formatMessage({ id: ETranslations.scan_scan_qr_code }),
-        icon: 'ScanOutline' as const,
-        onPress: handleScan,
-        testID: 'scan-qr-code',
-        trackID: 'wallet-scan',
-      },
+      platformEnv.isWebDappMode
+        ? undefined
+        : {
+            title: intl.formatMessage({ id: ETranslations.scan_scan_qr_code }),
+            icon: 'ScanOutline' as const,
+            onPress: handleScan,
+            testID: 'scan-qr-code',
+            trackID: 'wallet-scan',
+          },
       gtMd
         ? undefined
         : {
@@ -579,23 +585,25 @@ function MoreActionContentGrid() {
             badges: badge,
             trackID: 'notification-in-more-action',
           },
-      {
-        title: intl.formatMessage({
-          id: ETranslations.global_bulk_copy_addresses,
-        }),
-        icon: 'Copy3Outline',
-        onPress: () => {
-          if (!isPrimeUser) {
-            defaultLogger.prime.subscription.primeEntryClick({
-              featureName: EPrimeFeatures.BulkCopyAddresses,
-              entryPoint: 'moreActions',
-            });
-          }
-          void openBulkCopyAddressesModal();
-        },
-        trackID: 'bulk-copy-addresses-in-more-action',
-        isPrimeFeature: true,
-      },
+      platformEnv.isWebDappMode
+        ? undefined
+        : {
+            title: intl.formatMessage({
+              id: ETranslations.global_bulk_copy_addresses,
+            }),
+            icon: 'Copy3Outline',
+            onPress: () => {
+              if (!isPrimeUser) {
+                defaultLogger.prime.subscription.primeEntryClick({
+                  featureName: EPrimeFeatures.BulkCopyAddresses,
+                  entryPoint: 'moreActions',
+                });
+              }
+              void openBulkCopyAddressesModal();
+            },
+            trackID: 'bulk-copy-addresses-in-more-action',
+            isPrimeFeature: true,
+          },
     ].filter(Boolean) as IMoreActionContentGridItemProps[];
   }, [
     badge,

--- a/packages/kit/src/components/WebDapp/OneKeyWalletConnectionOptions.tsx
+++ b/packages/kit/src/components/WebDapp/OneKeyWalletConnectionOptions.tsx
@@ -14,6 +14,7 @@ import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { EXT_RATE_URL } from '@onekeyhq/shared/src/config/appConfig';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalRoutes, EOnboardingPages } from '@onekeyhq/shared/src/routes';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 
@@ -109,18 +110,20 @@ function OneKeyWalletConnectionOptions({
   if (isMobile) {
     return (
       <>
-        <ListItem
-          py="$4"
-          px="$5"
-          mx="$0"
-          bg="$bgSubdued"
-          title={intl.formatMessage({
-            id: ETranslations.global_onekey_wallet_hardware_wallet,
-          })}
-          renderAvatar={<OneKeyHardwareWalletLogo />}
-          drillIn
-          onPress={handleConnectHardwarePress}
-        />
+        {platformEnv.isWebDappMode ? null : (
+          <ListItem
+            py="$4"
+            px="$5"
+            mx="$0"
+            bg="$bgSubdued"
+            title={intl.formatMessage({
+              id: ETranslations.global_onekey_wallet_hardware_wallet,
+            })}
+            renderAvatar={<OneKeyHardwareWalletLogo />}
+            drillIn
+            onPress={handleConnectHardwarePress}
+          />
+        )}
         <WalletConnectListItemComponent
           impl="evm"
           py="$4"
@@ -209,35 +212,37 @@ function OneKeyWalletConnectionOptions({
           </Button>
         )}
       </ListItem>
-      <ListItem
-        py="$4"
-        px="$5"
-        mx="$0"
-        bg="$bgSubdued"
-        cursor="pointer"
-        title={intl.formatMessage({
-          id: ETranslations.global_onekey_wallet_hardware_wallet,
-        })}
-        subtitle={
-          <>
-            <SizableText size="$bodyMd" color="$textSubdued">
-              1.{' '}
-              {intl.formatMessage({
-                id: ETranslations.wallet_hardware_wallet_connect_description_1,
-              })}
-            </SizableText>
-            <SizableText size="$bodyMd" color="$textSubdued">
-              2.{' '}
-              {intl.formatMessage({
-                id: ETranslations.wallet_hardware_wallet_connect_description_2,
-              })}
-            </SizableText>
-          </>
-        }
-        renderAvatar={<OneKeyHardwareWalletLogo />}
-        drillIn
-        onPress={handleConnectHardwarePress}
-      />
+      {platformEnv.isWebDappMode ? null : (
+        <ListItem
+          py="$4"
+          px="$5"
+          mx="$0"
+          bg="$bgSubdued"
+          cursor="pointer"
+          title={intl.formatMessage({
+            id: ETranslations.global_onekey_wallet_hardware_wallet,
+          })}
+          subtitle={
+            <>
+              <SizableText size="$bodyMd" color="$textSubdued">
+                1.{' '}
+                {intl.formatMessage({
+                  id: ETranslations.wallet_hardware_wallet_connect_description_1,
+                })}
+              </SizableText>
+              <SizableText size="$bodyMd" color="$textSubdued">
+                2.{' '}
+                {intl.formatMessage({
+                  id: ETranslations.wallet_hardware_wallet_connect_description_2,
+                })}
+              </SizableText>
+            </>
+          }
+          renderAvatar={<OneKeyHardwareWalletLogo />}
+          drillIn
+          onPress={handleConnectHardwarePress}
+        />
+      )}
     </>
   );
 }

--- a/packages/kit/src/provider/Bootstrap.tsx
+++ b/packages/kit/src/provider/Bootstrap.tsx
@@ -12,7 +12,6 @@ import {
   getFormInstances,
   rootNavigationRef,
   useIsTabletDetailView,
-  useMedia,
   useShortcuts,
 } from '@onekeyhq/components';
 import { ipcMessageKeys } from '@onekeyhq/desktop/app/config';
@@ -33,10 +32,7 @@ import {
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { electronUpdateListeners } from '@onekeyhq/shared/src/modules3rdParty/auto-update/electronUpdateListeners';
-import {
-  initIntercom,
-  update,
-} from '@onekeyhq/shared/src/modules3rdParty/intercom';
+import { initIntercom } from '@onekeyhq/shared/src/modules3rdParty/intercom';
 import performance from '@onekeyhq/shared/src/performance';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
@@ -461,21 +457,14 @@ const launchFloatingIconEvent = async (intl: IntlShape) => {
 };
 
 export const useIntercomInit = () => {
-  const { md } = useMedia();
   const isInitializedRef = useRef(false);
 
   useEffect(() => {
-    const shouldHideLauncher = md || !platformEnv.isWebDappMode;
-
     if (!isInitializedRef.current) {
-      // Initialize Intercom on first render, hide launcher on small screens
-      void initIntercom({ hide_default_launcher: shouldHideLauncher });
+      void initIntercom();
       isInitializedRef.current = true;
-    } else {
-      // Update launcher visibility when screen size changes
-      update({ hide_default_launcher: shouldHideLauncher });
     }
-  }, [md]);
+  }, []);
 };
 
 export const useLaunchEvents = (): void => {

--- a/packages/kit/src/views/Setting/pages/ClearAppCache/index.tsx
+++ b/packages/kit/src/views/Setting/pages/ClearAppCache/index.tsx
@@ -48,20 +48,24 @@ export default function ClearAppCache() {
         <Stack px="$6">
           <Form form={form}>
             <YStack>
-              <Form.Field name="tokenAndNFT">
-                <Checkbox
-                  label={intl.formatMessage({
-                    id: ETranslations.settings_token_nft_data,
-                  })}
-                />
-              </Form.Field>
-              <Form.Field name="transactionHistory">
-                <Checkbox
-                  label={intl.formatMessage({
-                    id: ETranslations.settings_transaction_history,
-                  })}
-                />
-              </Form.Field>
+              {platformEnv.isWebDappMode ? null : (
+                <Form.Field name="tokenAndNFT">
+                  <Checkbox
+                    label={intl.formatMessage({
+                      id: ETranslations.settings_token_nft_data,
+                    })}
+                  />
+                </Form.Field>
+              )}
+              {platformEnv.isWebDappMode ? null : (
+                <Form.Field name="transactionHistory">
+                  <Checkbox
+                    label={intl.formatMessage({
+                      id: ETranslations.settings_transaction_history,
+                    })}
+                  />
+                </Form.Field>
+              )}
               <Form.Field name="swapHistory">
                 <Checkbox
                   label={intl.formatMessage({
@@ -69,63 +73,79 @@ export default function ClearAppCache() {
                   })}
                 />
               </Form.Field>
-              <Form.Field name="browserCache">
-                <Checkbox
-                  label={intl.formatMessage({
-                    id: ETranslations.settings_browser_cache,
-                  })}
-                />
-              </Form.Field>
-              <Form.Field name="appUpdateCache">
-                <Checkbox
-                  label={intl.formatMessage({
-                    id: ETranslations.settings_app_update_cache,
-                  })}
-                />
-              </Form.Field>
-              <Form.Field name="browserHistory">
-                <Checkbox
-                  label={intl.formatMessage({
-                    id: ETranslations.settings_browser_history_bookmarks_pins_risk_dapp_whitelist,
-                  })}
-                  labelProps={{ flex: 1 } as any}
-                />
-              </Form.Field>
-              <Form.Field name="customToken">
-                <Checkbox
-                  label={intl.formatMessage({
-                    id: ETranslations.manage_token_custom_token_title,
-                  })}
-                />
-              </Form.Field>
-              <Form.Field name="customRpc">
-                <Checkbox
-                  label={intl.formatMessage({
-                    id: ETranslations.custom_rpc_title,
-                  })}
-                />
-              </Form.Field>
-              <Form.Field name="serverNetworks">
-                <Checkbox
-                  label={intl.formatMessage({
-                    id: ETranslations.clear_build_in_networks_data,
-                  })}
-                />
-              </Form.Field>
-              <Form.Field name="connectSites">
-                <Checkbox
-                  label={intl.formatMessage({
-                    id: ETranslations.settings_connected_sites,
-                  })}
-                />
-              </Form.Field>
-              <Form.Field name="signatureRecord">
-                <Checkbox
-                  label={intl.formatMessage({
-                    id: ETranslations.settings_signature_record,
-                  })}
-                />
-              </Form.Field>
+              {platformEnv.isWebDappMode ? null : (
+                <Form.Field name="browserCache">
+                  <Checkbox
+                    label={intl.formatMessage({
+                      id: ETranslations.settings_browser_cache,
+                    })}
+                  />
+                </Form.Field>
+              )}
+              {platformEnv.isWebDappMode ? null : (
+                <Form.Field name="appUpdateCache">
+                  <Checkbox
+                    label={intl.formatMessage({
+                      id: ETranslations.settings_app_update_cache,
+                    })}
+                  />
+                </Form.Field>
+              )}
+              {platformEnv.isWebDappMode ? null : (
+                <Form.Field name="browserHistory">
+                  <Checkbox
+                    label={intl.formatMessage({
+                      id: ETranslations.settings_browser_history_bookmarks_pins_risk_dapp_whitelist,
+                    })}
+                    labelProps={{ flex: 1 } as any}
+                  />
+                </Form.Field>
+              )}
+              {platformEnv.isWebDappMode ? null : (
+                <Form.Field name="customToken">
+                  <Checkbox
+                    label={intl.formatMessage({
+                      id: ETranslations.manage_token_custom_token_title,
+                    })}
+                  />
+                </Form.Field>
+              )}
+              {platformEnv.isWebDappMode ? null : (
+                <Form.Field name="customRpc">
+                  <Checkbox
+                    label={intl.formatMessage({
+                      id: ETranslations.custom_rpc_title,
+                    })}
+                  />
+                </Form.Field>
+              )}
+              {platformEnv.isWebDappMode ? null : (
+                <Form.Field name="serverNetworks">
+                  <Checkbox
+                    label={intl.formatMessage({
+                      id: ETranslations.clear_build_in_networks_data,
+                    })}
+                  />
+                </Form.Field>
+              )}
+              {platformEnv.isWebDappMode ? null : (
+                <Form.Field name="connectSites">
+                  <Checkbox
+                    label={intl.formatMessage({
+                      id: ETranslations.settings_connected_sites,
+                    })}
+                  />
+                </Form.Field>
+              )}
+              {platformEnv.isWebDappMode ? null : (
+                <Form.Field name="signatureRecord">
+                  <Checkbox
+                    label={intl.formatMessage({
+                      id: ETranslations.settings_signature_record,
+                    })}
+                  />
+                </Form.Field>
+              )}
             </YStack>
           </Form>
         </Stack>

--- a/packages/kit/src/views/Setting/pages/Tab/config.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/config.tsx
@@ -168,108 +168,110 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
         Component: OneKeyIdSubSettings,
         configs: [],
       },
-      {
-        name: ESettingsTabNames.Backup,
-        icon: 'CloudUploadSolid',
-        title: intl.formatMessage({ id: ETranslations.global_backup }),
-        configs: [
-          [
-            cloudBackupFeatureInfo?.supportCloudBackup
-              ? {
-                  icon: cloudBackupFeatureInfo?.icon,
-                  title: cloudBackupFeatureInfo?.title,
-                  onPress: (navigation) => {
-                    navigation?.popStack();
-                    void startBackup({ alwaysGoToBackupDetail: true });
-                    // void goToPageBackupList();
-                    // navigation?.pushModal(EModalRoutes.CloudBackupModal, {
-                    //   screen: ECloudBackupRoutes.CloudBackupHome,
-                    // });
-                  },
-                }
-              : null,
-            isPrimeAvailable
-              ? {
-                  // OneKey Cloud
-                  icon: 'CloudOutline',
-                  title: intl.formatMessage({
-                    id: ETranslations.global_onekey_cloud,
-                  }),
-                  onPress: (navigation) => {
-                    defaultLogger.prime.subscription.primeEntryClick({
-                      featureName: EPrimeFeatures.OneKeyCloud,
-                      entryPoint: 'settingsPage',
-                    });
+      platformEnv.isWebDappMode
+        ? undefined
+        : {
+            name: ESettingsTabNames.Backup,
+            icon: 'CloudUploadSolid',
+            title: intl.formatMessage({ id: ETranslations.global_backup }),
+            configs: [
+              [
+                cloudBackupFeatureInfo?.supportCloudBackup
+                  ? {
+                      icon: cloudBackupFeatureInfo?.icon,
+                      title: cloudBackupFeatureInfo?.title,
+                      onPress: (navigation) => {
+                        navigation?.popStack();
+                        void startBackup({ alwaysGoToBackupDetail: true });
+                        // void goToPageBackupList();
+                        // navigation?.pushModal(EModalRoutes.CloudBackupModal, {
+                        //   screen: ECloudBackupRoutes.CloudBackupHome,
+                        // });
+                      },
+                    }
+                  : null,
+                isPrimeAvailable
+                  ? {
+                      // OneKey Cloud
+                      icon: 'CloudOutline',
+                      title: intl.formatMessage({
+                        id: ETranslations.global_onekey_cloud,
+                      }),
+                      onPress: (navigation) => {
+                        defaultLogger.prime.subscription.primeEntryClick({
+                          featureName: EPrimeFeatures.OneKeyCloud,
+                          entryPoint: 'settingsPage',
+                        });
 
-                    navigation?.pushModal(EModalRoutes.PrimeModal, {
-                      screen: EPrimePages.PrimeCloudSync,
-                    });
-                  },
-                }
-              : undefined,
-          ],
-          [
-            !platformEnv.isWebDappMode
-              ? {
-                  // OneKey Transfer
-                  icon: 'MultipleDevicesOutline',
+                        navigation?.pushModal(EModalRoutes.PrimeModal, {
+                          screen: EPrimePages.PrimeCloudSync,
+                        });
+                      },
+                    }
+                  : undefined,
+              ],
+              [
+                !platformEnv.isWebDappMode
+                  ? {
+                      // OneKey Transfer
+                      icon: 'MultipleDevicesOutline',
+                      title: intl.formatMessage({
+                        id: ETranslations.transfer_transfer,
+                      }),
+                      subtitle: intl.formatMessage({
+                        id: ETranslations.prime_transfer_description,
+                      }),
+                      onPress: (navigation) => {
+                        navigation?.pushModal(EModalRoutes.PrimeModal, {
+                          screen: EPrimePages.PrimeTransfer,
+                        });
+                      },
+                    }
+                  : undefined,
+              ],
+              [
+                !platformEnv.isWebDappMode
+                  ? {
+                      icon: 'SignatureOutline',
+                      title: intl.formatMessage({
+                        id: ETranslations.manual_backup,
+                      }),
+                      onPress: (navigation) => {
+                        navigation?.pushModal(EModalRoutes.ManualBackupModal, {
+                          screen: EManualBackupRoutes.ManualBackupSelectWallet,
+                        });
+                      },
+                    }
+                  : undefined,
+                platformEnv.isNative
+                  ? {
+                      icon: 'OnekeyLiteOutline',
+                      title: intl.formatMessage({
+                        id: ETranslations.global_onekey_lite,
+                      }),
+                      onPress: (navigation) => {
+                        navigation?.pushModal(EModalRoutes.LiteCardModal, {
+                          screen: ELiteCardRoutes.LiteCardHome,
+                        });
+                      },
+                    }
+                  : undefined,
+                {
+                  // OneKey Keytag
+                  icon: 'OnekeyKeytagOutline',
                   title: intl.formatMessage({
-                    id: ETranslations.transfer_transfer,
-                  }),
-                  subtitle: intl.formatMessage({
-                    id: ETranslations.prime_transfer_description,
+                    id: ETranslations.global_onekey_keytag,
                   }),
                   onPress: (navigation) => {
-                    navigation?.pushModal(EModalRoutes.PrimeModal, {
-                      screen: EPrimePages.PrimeTransfer,
+                    defaultLogger.setting.page.enterKeyTag();
+                    navigation?.pushModal(EModalRoutes.KeyTagModal, {
+                      screen: EModalKeyTagRoutes.UserOptions,
                     });
                   },
-                }
-              : undefined,
-          ],
-          [
-            !platformEnv.isWebDappMode
-              ? {
-                  icon: 'SignatureOutline',
-                  title: intl.formatMessage({
-                    id: ETranslations.manual_backup,
-                  }),
-                  onPress: (navigation) => {
-                    navigation?.pushModal(EModalRoutes.ManualBackupModal, {
-                      screen: EManualBackupRoutes.ManualBackupSelectWallet,
-                    });
-                  },
-                }
-              : undefined,
-            platformEnv.isNative
-              ? {
-                  icon: 'OnekeyLiteOutline',
-                  title: intl.formatMessage({
-                    id: ETranslations.global_onekey_lite,
-                  }),
-                  onPress: (navigation) => {
-                    navigation?.pushModal(EModalRoutes.LiteCardModal, {
-                      screen: ELiteCardRoutes.LiteCardHome,
-                    });
-                  },
-                }
-              : undefined,
-            {
-              // OneKey Keytag
-              icon: 'OnekeyKeytagOutline',
-              title: intl.formatMessage({
-                id: ETranslations.global_onekey_keytag,
-              }),
-              onPress: (navigation) => {
-                defaultLogger.setting.page.enterKeyTag();
-                navigation?.pushModal(EModalRoutes.KeyTagModal, {
-                  screen: EModalKeyTagRoutes.UserOptions,
-                });
-              },
-            },
-          ],
-        ],
-      },
+                },
+              ],
+            ],
+          },
       {
         name: ESettingsTabNames.Preferences,
         icon: 'SettingsSolid',
@@ -351,15 +353,17 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
         }),
         configs: [
           [
-            {
-              icon: 'ContactsOutline',
-              title: intl.formatMessage({
-                id: ETranslations.settings_address_book,
-              }),
-              onPress: (navigation) => {
-                void onPressAddressBook(navigation);
-              },
-            },
+            platformEnv.isWebDappMode
+              ? undefined
+              : {
+                  icon: 'ContactsOutline',
+                  title: intl.formatMessage({
+                    id: ETranslations.settings_address_book,
+                  }),
+                  onPress: (navigation) => {
+                    void onPressAddressBook(navigation);
+                  },
+                },
           ],
           [
             !platformEnv.isWeb
@@ -375,29 +379,35 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
                   },
                 }
               : undefined,
-            {
-              icon: 'LabOutline',
-              title: intl.formatMessage({
-                id: ETranslations.global_customize_transaction,
-              }),
-              onPress: (navigation) => {
-                defaultLogger.setting.page.enterCustomizeTransaction();
-                navigation?.push(EModalSettingRoutes.SettingCustomTransaction);
-              },
-            },
+            platformEnv.isWebDappMode
+              ? undefined
+              : {
+                  icon: 'LabOutline',
+                  title: intl.formatMessage({
+                    id: ETranslations.global_customize_transaction,
+                  }),
+                  onPress: (navigation) => {
+                    defaultLogger.setting.page.enterCustomizeTransaction();
+                    navigation?.push(
+                      EModalSettingRoutes.SettingCustomTransaction,
+                    );
+                  },
+                },
           ],
           [
-            {
-              icon: 'BranchesOutline',
-              title: intl.formatMessage({
-                id: ETranslations.settings_account_derivation_path,
-              }),
-              onPress: (navigation) => {
-                navigation?.push(
-                  EModalSettingRoutes.SettingAccountDerivationModal,
-                );
-              },
-            },
+            platformEnv.isWebDappMode
+              ? undefined
+              : {
+                  icon: 'BranchesOutline',
+                  title: intl.formatMessage({
+                    id: ETranslations.settings_account_derivation_path,
+                  }),
+                  onPress: (navigation) => {
+                    navigation?.push(
+                      EModalSettingRoutes.SettingAccountDerivationModal,
+                    );
+                  },
+                },
           ],
           [
             !perpConfigCommon.disablePerp && !perpConfigCommon.usePerpWeb
@@ -413,16 +423,18 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
               : null,
           ],
           [
-            {
-              icon: 'FlashCardSolid',
-              title: intl.formatMessage({
-                id: ETranslations.settings_btc_multiple_addresses,
-              }),
-              subtitle: intl.formatMessage({
-                id: ETranslations.settings_btc_multiple_addresses_description,
-              }),
-              renderElement: <BTCFreshAddressListItem />,
-            },
+            platformEnv.isWebDappMode
+              ? undefined
+              : {
+                  icon: 'FlashCardSolid',
+                  title: intl.formatMessage({
+                    id: ETranslations.settings_btc_multiple_addresses,
+                  }),
+                  subtitle: intl.formatMessage({
+                    id: ETranslations.settings_btc_multiple_addresses_description,
+                  }),
+                  renderElement: <BTCFreshAddressListItem />,
+                },
           ],
         ],
       },
@@ -434,14 +446,16 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
         }),
         configs: [
           [
-            isPasswordSet && (biologyAuthIsSupport || webAuthIsSupport)
+            isPasswordSet &&
+            (biologyAuthIsSupport || webAuthIsSupport) &&
+            !platformEnv.isWebDappMode
               ? {
                   title: biometricAuthInfo.title,
                   icon: biometricAuthInfo.icon,
                   renderElement: <BiologyAuthListItem />,
                 }
               : null,
-            isPasswordSet
+            isPasswordSet && !platformEnv.isWebDappMode
               ? {
                   icon: 'ClockTimeHistoryOutline',
                   title: intl.formatMessage({
@@ -450,75 +464,83 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
                   renderElement: <AutoLockListItem />,
                 }
               : null,
-            {
-              icon: 'KeyOutline',
-              title: intl.formatMessage({
-                id: isPasswordSet
-                  ? ETranslations.global_change_passcode
-                  : ETranslations.global_set_passcode,
-              }),
-              onPress: async () => {
-                if (isPasswordSet) {
-                  const oldEncodedPassword =
-                    await backgroundApiProxy.servicePassword.promptPasswordVerify(
-                      {
-                        reason: EReasonForNeedPassword.Security,
-                      },
-                    );
-                  const dialog = Dialog.show({
-                    title: intl.formatMessage({
-                      id: ETranslations.global_change_passcode,
-                    }),
-                    renderContent: (
-                      <PasswordUpdateContainer
-                        oldEncodedPassword={oldEncodedPassword.password}
-                        onUpdateRes={async (data) => {
-                          if (data) {
-                            await dialog.close();
-                          }
-                        }}
-                      />
-                    ),
-                    showFooter: false,
-                  });
-                } else {
-                  void backgroundApiProxy.servicePassword.promptPasswordVerify();
-                }
-              },
-            },
+            platformEnv.isWebDappMode
+              ? undefined
+              : {
+                  icon: 'KeyOutline',
+                  title: intl.formatMessage({
+                    id: isPasswordSet
+                      ? ETranslations.global_change_passcode
+                      : ETranslations.global_set_passcode,
+                  }),
+                  onPress: async () => {
+                    if (isPasswordSet) {
+                      const oldEncodedPassword =
+                        await backgroundApiProxy.servicePassword.promptPasswordVerify(
+                          {
+                            reason: EReasonForNeedPassword.Security,
+                          },
+                        );
+                      const dialog = Dialog.show({
+                        title: intl.formatMessage({
+                          id: ETranslations.global_change_passcode,
+                        }),
+                        renderContent: (
+                          <PasswordUpdateContainer
+                            oldEncodedPassword={oldEncodedPassword.password}
+                            onUpdateRes={async (data) => {
+                              if (data) {
+                                await dialog.close();
+                              }
+                            }}
+                          />
+                        ),
+                        showFooter: false,
+                      });
+                    } else {
+                      void backgroundApiProxy.servicePassword.promptPasswordVerify();
+                    }
+                  },
+                },
           ],
           [
-            {
-              icon: 'ShieldCheckDoneOutline',
-              title: intl.formatMessage({
-                id: ETranslations.settings_protection,
-              }),
-              onPress: (navigation) => {
-                navigation?.push(EModalSettingRoutes.SettingProtectModal);
-              },
-            },
-            {
-              icon: 'LinkOutline',
-              title: intl.formatMessage({
-                id: ETranslations.settings_connected_sites,
-              }),
-              onPress: (navigation) => {
-                navigation?.pushModal(EModalRoutes.DAppConnectionModal, {
-                  screen: EDAppConnectionModal.ConnectionList,
-                });
-              },
-            },
-            {
-              icon: 'NoteOutline',
-              title: intl.formatMessage({
-                id: ETranslations.settings_signature_record,
-              }),
-              onPress: (navigation) => {
-                navigation?.push(
-                  EModalSettingRoutes.SettingSignatureRecordModal,
-                );
-              },
-            },
+            platformEnv.isWebDappMode
+              ? undefined
+              : {
+                  icon: 'ShieldCheckDoneOutline',
+                  title: intl.formatMessage({
+                    id: ETranslations.settings_protection,
+                  }),
+                  onPress: (navigation) => {
+                    navigation?.push(EModalSettingRoutes.SettingProtectModal);
+                  },
+                },
+            platformEnv.isWebDappMode
+              ? undefined
+              : {
+                  icon: 'LinkOutline',
+                  title: intl.formatMessage({
+                    id: ETranslations.settings_connected_sites,
+                  }),
+                  onPress: (navigation) => {
+                    navigation?.pushModal(EModalRoutes.DAppConnectionModal, {
+                      screen: EDAppConnectionModal.ConnectionList,
+                    });
+                  },
+                },
+            platformEnv.isWebDappMode
+              ? undefined
+              : {
+                  icon: 'NoteOutline',
+                  title: intl.formatMessage({
+                    id: ETranslations.settings_signature_record,
+                  }),
+                  onPress: (navigation) => {
+                    navigation?.push(
+                      EModalSettingRoutes.SettingSignatureRecordModal,
+                    );
+                  },
+                },
           ],
           [
             platformEnv.isExtension
@@ -568,71 +590,73 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
           ],
         ],
       },
-      {
-        name: ESettingsTabNames.Network,
-        icon: 'GlobusSolid',
-        title: intl.formatMessage({
-          id: ETranslations.global_network,
-        }),
-        configs: [
-          [
-            {
-              icon: 'GlobusOutline',
-              title: intl.formatMessage({
-                id: ETranslations.custom_network_add_network_action_text,
-              }),
-              onPress: (navigation) => {
-                defaultLogger.setting.page.enterCustomRPC();
-                navigation?.push(EModalSettingRoutes.SettingCustomNetwork);
-              },
-            },
-            {
-              icon: 'BezierNodesOutline',
-              title: intl.formatMessage({
-                id: ETranslations.custom_rpc_title,
-              }),
-              onPress: (navigation) => {
-                defaultLogger.setting.page.enterCustomRPC();
-                navigation?.push(EModalSettingRoutes.SettingCustomRPC);
-              },
-            },
-            platformEnv.isDev
-              ? {
-                  icon: 'UsbOutline',
+      platformEnv.isWebDappMode
+        ? undefined
+        : {
+            name: ESettingsTabNames.Network,
+            icon: 'GlobusSolid',
+            title: intl.formatMessage({
+              id: ETranslations.global_network,
+            }),
+            configs: [
+              [
+                {
+                  icon: 'GlobusOutline',
                   title: intl.formatMessage({
-                    id: ETranslations.device_hardware_communication,
+                    id: ETranslations.custom_network_add_network_action_text,
                   }),
-                  renderElement: <HardwareTransportTypeListItem />,
-                }
-              : undefined,
-            (platformEnv.isExtension || platformEnv.isWeb) &&
-            settings.hardwareTransportType !== EHardwareTransportType.WEBUSB
-              ? {
-                  icon: 'ApiConnectionOutline',
-                  title: intl.formatMessage({
-                    id: ETranslations.settings_hardware_bridge_status,
-                  }),
-                  onPress: () => {
-                    openUrlExternal(BRIDGE_STATUS_URL);
+                  onPress: (navigation) => {
+                    defaultLogger.setting.page.enterCustomRPC();
+                    navigation?.push(EModalSettingRoutes.SettingCustomNetwork);
                   },
-                }
-              : undefined,
-          ],
-          [
-            {
-              icon: 'FileDownloadOutline',
-              title: intl.formatMessage({
-                id: ETranslations.settings_export_network_config_label,
-              }),
-              onPress: (navigation) => {
-                navigation?.push(
-                  EModalSettingRoutes.SettingExportCustomNetworkConfig,
-                );
-              },
-            },
-          ],
-        ],
-      },
+                },
+                {
+                  icon: 'BezierNodesOutline',
+                  title: intl.formatMessage({
+                    id: ETranslations.custom_rpc_title,
+                  }),
+                  onPress: (navigation) => {
+                    defaultLogger.setting.page.enterCustomRPC();
+                    navigation?.push(EModalSettingRoutes.SettingCustomRPC);
+                  },
+                },
+                platformEnv.isDev
+                  ? {
+                      icon: 'UsbOutline',
+                      title: intl.formatMessage({
+                        id: ETranslations.device_hardware_communication,
+                      }),
+                      renderElement: <HardwareTransportTypeListItem />,
+                    }
+                  : undefined,
+                (platformEnv.isExtension || platformEnv.isWeb) &&
+                settings.hardwareTransportType !== EHardwareTransportType.WEBUSB
+                  ? {
+                      icon: 'ApiConnectionOutline',
+                      title: intl.formatMessage({
+                        id: ETranslations.settings_hardware_bridge_status,
+                      }),
+                      onPress: () => {
+                        openUrlExternal(BRIDGE_STATUS_URL);
+                      },
+                    }
+                  : undefined,
+              ],
+              [
+                {
+                  icon: 'FileDownloadOutline',
+                  title: intl.formatMessage({
+                    id: ETranslations.settings_export_network_config_label,
+                  }),
+                  onPress: (navigation) => {
+                    navigation?.push(
+                      EModalSettingRoutes.SettingExportCustomNetworkConfig,
+                    );
+                  },
+                },
+              ],
+            ],
+          },
       {
         name: ESettingsTabNames.About,
         icon: 'InfoCircleSolid',

--- a/packages/kit/src/views/Setting/pages/Tab/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/index.tsx
@@ -216,7 +216,11 @@ function SettingsTabNavigator() {
   return (
     <ConfigContext.Provider value={contextValue}>
       <Tab.Navigator
-        initialRouteName={ESettingsTabNames.Backup}
+        initialRouteName={
+          platformEnv.isWebDappMode
+            ? ESettingsTabNames.Preferences
+            : ESettingsTabNames.Backup
+        }
         tabBar={tabBarCallback}
         screenOptions={{
           headerShown: false,

--- a/packages/shared/src/modules3rdParty/intercom/index.ts
+++ b/packages/shared/src/modules3rdParty/intercom/index.ts
@@ -5,8 +5,6 @@ import Intercom, {
   update,
 } from '@intercom/messenger-js-sdk';
 
-import platformEnv from '../../platformEnv';
-
 import { getCustomerJWT, getInstanceId } from './utils';
 
 import type { InitType } from '@intercom/messenger-js-sdk/dist/types';
@@ -16,7 +14,7 @@ export const initIntercom = async (settings?: Partial<InitType>) => {
 
   Intercom({
     app_id: APP_ID,
-    hide_default_launcher: !platformEnv.isWebDappMode,
+    hide_default_launcher: true,
     alignment: 'right',
     horizontal_padding: 10,
     vertical_padding: 55,


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web DApp mode now displays customized UI with relevant options for that context, while hiding advanced features like address book, hardware wallet connections, and network settings.
  * Footer links now support interactive actions in Web DApp mode.

* **Changes**
  * Settings navigation in Web DApp mode now defaults to Preferences tab instead of Backup.
  * Intercom launcher visibility updated for consistent behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Always hide Intercom default launcher by setting `hide_default_launcher: true`
- Remove dynamic launcher visibility logic based on screen size and platform mode
- Clean up unused imports (`useMedia`, `update`)
- Update UI components: Footer, AddressInput, TabPageHeader, WebDapp
- Refactor Settings pages: ClearAppCache, Tab config

## Test plan
- [ ] Verify Intercom launcher is hidden on all screen sizes
- [ ] Verify Intercom can still be opened programmatically via `showIntercom()`
- [ ] Test Settings pages functionality
- [ ] Verify UI components render correctly