### PR TITLE
fix: emit ready event before setting isAppReady in dom-ready handler

### DIFF
--- a/apps/desktop/app/app.ts
+++ b/apps/desktop/app/app.ts
@@ -605,8 +605,11 @@ async function createMainWindow() {
 
   // dom-ready is fired after ipcMain:app/ready
   browserWindow.webContents.on('dom-ready', () => {
-    isAppReady = true;
     logger.info('set isAppReady on browserWindow dom-ready', isAppReady);
+    // Emit ready event first, so pending deep link handlers can execute
+    // before isAppReady is set to true (which affects the cache logic)
+    emitter.emit('ready');
+    isAppReady = true;
   });
 
   browserWindow.webContents.setWindowOpenHandler(({ url }) => {


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed app initialization timing to ensure proper event sequencing during startup, addressing potential issues with deep link handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes desktop deep link cold startup not working.

**Root Cause:**
- `emitter.emit('ready')` was only in the `APP_READY` IPC handler
- But `desktopApi.ready()` was commented out, so `APP_READY` was never sent
- This meant `sendEventData()` was never called during cold startup

**Fix:**
- Add `emitter.emit('ready')` to the `dom-ready` event handler
- Ensure it executes **before** `isAppReady = true`
- This ordering is critical because `sendEventData()` checks `if (!isAppReady)` to decide whether to cache the deep link

## Changes

- Modified `apps/desktop/app/app.ts` to emit ready event in dom-ready handler

## Test Plan

- [ ] Build desktop app
- [ ] Close app completely
- [ ] Click a deep link (e.g., `onekey-wallet://invite_share?code=xxx`)
- [ ] Verify app opens and navigates to the correct page