### PR TITLE
fix: improve Hyperliquid SDK compatibility and perps i18n message handling OK-47453 OK-47475 OK-47653

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
@@ -400,11 +400,15 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
 
     const { value, signatureHex, signerAddress } = signedData;
 
+    // These fields are NOT part of the signed EIP-712 message in SDK > 0.24.x,
+    // so reading them from `value` is unreliable. Use stable constants instead.
+    const actionType = 'approveAgent';
+    const signatureChainId = PERPS_EVM_CHAIN_ID_HEX;
     // Only extract approveAgent signatures
     return {
       action: {
-        type: value.type as string,
-        signatureChainId: value.signatureChainId as string,
+        type: actionType,
+        signatureChainId,
         hyperliquidChain: value.hyperliquidChain as string,
         agentAddress: value.agentAddress as string,
         agentName: value.agentName as string,

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/utils/config.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/utils/config.ts
@@ -5,57 +5,39 @@ import { EActionType, EErrorType } from './types';
 
 import type { IToastConfig } from './types';
 
+const t = (id: ETranslations) => () => appLocale.intl.formatMessage({ id });
+
 export const ERROR_PATTERNS: Record<EErrorType, string[]> = {
   [EErrorType.INVALID_AGENT]: ['User or API Wallet', 'does not exist'],
 };
 
-export const ERROR_MESSAGES: Record<EErrorType, string> = {
-  [EErrorType.INVALID_AGENT]: appLocale.intl.formatMessage({
-    id: ETranslations.perp_error_enable,
-  }),
+export const ERROR_MESSAGES: Record<EErrorType, () => string> = {
+  [EErrorType.INVALID_AGENT]: t(ETranslations.perp_error_enable),
 };
 
 export const TOAST_CONFIGS: Record<EActionType, IToastConfig> = {
   [EActionType.PLACE_ORDER]: {
-    loading: appLocale.intl.formatMessage({
-      id: ETranslations.perp_toast_opening_order,
-    }),
-    successTitle: appLocale.intl.formatMessage({
-      id: ETranslations.perp_toast_order_submitted,
-    }),
+    loading: t(ETranslations.perp_toast_opening_order),
+    successTitle: t(ETranslations.perp_toast_order_submitted),
   },
 
   [EActionType.ORDER_OPEN]: {
-    loading: appLocale.intl.formatMessage({
-      id: ETranslations.perp_toast_placing_order,
-    }),
-    successTitle: appLocale.intl.formatMessage({
-      id: ETranslations.perp_toast_order_submitted,
-    }),
+    loading: t(ETranslations.perp_toast_placing_order),
+    successTitle: t(ETranslations.perp_toast_order_submitted),
   },
 
   [EActionType.ORDERS_CLOSE]: {
-    loading: appLocale.intl.formatMessage({
-      id: ETranslations.perp_toast_closing_position,
-    }),
-    successTitle: appLocale.intl.formatMessage({
-      id: ETranslations.perp_toast_order_submitted,
-    }),
+    loading: t(ETranslations.perp_toast_closing_position),
+    successTitle: t(ETranslations.perp_toast_order_submitted),
   },
 
   [EActionType.LIMIT_ORDER_CLOSE]: {
-    loading: appLocale.intl.formatMessage({
-      id: ETranslations.perp_toast_placing_limit_close,
-    }),
-    successTitle: appLocale.intl.formatMessage({
-      id: ETranslations.perp_toast_placing_limit_close_submit,
-    }),
+    loading: t(ETranslations.perp_toast_placing_limit_close),
+    successTitle: t(ETranslations.perp_toast_placing_limit_close_submit),
   },
 
   [EActionType.UPDATE_LEVERAGE]: {
-    loading: appLocale.intl.formatMessage({
-      id: ETranslations.perp_toast_upadating_leverage,
-    }),
+    loading: t(ETranslations.perp_toast_upadating_leverage),
     successTitle: (mode: string) =>
       appLocale.intl.formatMessage(
         {
@@ -92,21 +74,13 @@ export const TOAST_CONFIGS: Record<EActionType, IToastConfig> = {
   },
 
   [EActionType.UPDATE_ISOLATED_MARGIN]: {
-    loading: appLocale.intl.formatMessage({
-      id: ETranslations.perp_trading_adjust_margin_update,
-    }),
-    successTitle: appLocale.intl.formatMessage({
-      id: ETranslations.perp_trading_adjust_margin_updated,
-    }),
+    loading: t(ETranslations.perp_trading_adjust_margin_update),
+    successTitle: t(ETranslations.perp_trading_adjust_margin_updated),
   },
 
   [EActionType.SET_POSITION_TPSL]: {
-    loading: appLocale.intl.formatMessage({
-      id: ETranslations.perp_toast_setting_tp_sl,
-    }),
-    successTitle: appLocale.intl.formatMessage({
-      id: ETranslations.perp_toast_setting_tp_sl_sucess,
-    }),
+    loading: t(ETranslations.perp_toast_setting_tp_sl),
+    successTitle: t(ETranslations.perp_toast_setting_tp_sl_sucess),
   },
 
   [EActionType.CANCEL_ORDER]: {
@@ -117,18 +91,12 @@ export const TOAST_CONFIGS: Record<EActionType, IToastConfig> = {
         },
         { count },
       ),
-    successTitle: appLocale.intl.formatMessage({
-      id: ETranslations.perp_toast_canceling_order_sucess,
-    }),
+    successTitle: t(ETranslations.perp_toast_canceling_order_sucess),
   },
 
   [EActionType.WITHDRAW]: {
-    loading: appLocale.intl.formatMessage({
-      id: ETranslations.perp_toast_withdraw_loading,
-    }),
-    successTitle: appLocale.intl.formatMessage({
-      id: ETranslations.perp_toast_withdraw_success,
-    }),
+    loading: t(ETranslations.perp_toast_withdraw_loading),
+    successTitle: t(ETranslations.perp_toast_withdraw_success),
     successMessage: (amount: string) =>
       appLocale.intl.formatMessage(
         {

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/utils/withToast.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/utils/withToast.ts
@@ -45,7 +45,9 @@ async function handleError(error: unknown): Promise<void> {
     }
   }
 
-  const friendlyMessage = errorType ? ERROR_MESSAGES[errorType] : errorMessage;
+  const friendlyMessage = errorType
+    ? ERROR_MESSAGES[errorType]()
+    : errorMessage;
   Toast.error({ title: friendlyMessage });
 }
 

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
@@ -52,9 +52,12 @@ const TradesHistoryRow = memo(
   }: ITradesHistoryRowProps) => {
     const canShare = useMemo(() => {
       return (
-        fill.closedPnl && !new BigNumber(fill.closedPnl).isZero() && onShare
+        fill.closedPnl &&
+        !new BigNumber(fill.closedPnl).isZero() &&
+        !fill.liquidation &&
+        onShare
       );
-    }, [fill.closedPnl, onShare]);
+    }, [fill.closedPnl, fill.liquidation, onShare]);
     const actions = useHyperliquidActions();
     const intl = useIntl();
     const assetSymbol = useMemo(() => {

--- a/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
+++ b/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
@@ -23,7 +23,10 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
-import { getHyperliquidTokenImageUrl } from '@onekeyhq/shared/src/utils/perpsUtils';
+import {
+  getHyperliquidTokenImageUrl,
+  parseDexCoin,
+} from '@onekeyhq/shared/src/utils/perpsUtils';
 
 import { Token } from '../../../components/Token';
 import useAppNavigation from '../../../hooks/useAppNavigation';
@@ -57,7 +60,9 @@ function MobilePerpMarket() {
   }, [navigation]);
 
   const renderHeaderTitle = useCallback(() => {
-    const pairLabel = coin ? `${coin}USD` : '--';
+    const parsedCoin = coin ? parseDexCoin(coin) : null;
+    const displayCoin = parsedCoin?.displayName || coin || '';
+    const pairLabel = displayCoin ? `${displayCoin}USD` : '--';
     return (
       <XStack alignItems="center" gap="$2">
         <NavBackButton
@@ -77,7 +82,9 @@ function MobilePerpMarket() {
             size="sm"
             borderRadius="$full"
             bg={themeVariant === 'light' ? undefined : '$bgInverse'}
-            tokenImageUri={coin ? getHyperliquidTokenImageUrl(coin) : undefined}
+            tokenImageUri={
+              displayCoin ? getHyperliquidTokenImageUrl(displayCoin) : undefined
+            }
             fallbackIcon="CryptoCoinOutline"
           />
           <SizableText size="$headingLg">{pairLabel}</SizableText>


### PR DESCRIPTION
- Fix approveAgent signature extraction to use constants instead of reading from signed value (SDK > 0.24.x compatibility)
- Refactor i18n messages to use lazy evaluation functions to avoid early execution
- Fix share button visibility for liquidated trades
- Improve token display using parseDexCoin for proper coin name parsing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted share functionality for liquidated positions to prevent unintended sharing.
  * Improved token name display on mobile perpetual market interface for better clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->