### PR TITLE
fix: exclude keyless wallets in wallet operations [OK-47578, OK-47636]

### DIFF
--- a/packages/kit-bg/src/services/ServicePrimeCloudSync/ServicePrimeCloudSync.tsx
+++ b/packages/kit-bg/src/services/ServicePrimeCloudSync/ServicePrimeCloudSync.tsx
@@ -1444,6 +1444,7 @@ class ServicePrimeCloudSync extends ServiceBase {
     const { wallets: allWallets, allDevices } =
       await this.backgroundApi.serviceAccount.getAllWallets({
         refillWalletInfo: true,
+        excludeKeylessWallet: true,
       });
     // TODO only get watching or imported accounts for better performance
     const { accounts: allAccounts } =

--- a/packages/kit-bg/src/services/ServicePrimeTransfer/ServicePrimeTransfer.ts
+++ b/packages/kit-bg/src/services/ServicePrimeTransfer/ServicePrimeTransfer.ts
@@ -879,7 +879,15 @@ class ServicePrimeTransfer extends ServiceBase {
 
     const { wallets } = await serviceAccount.getWallets();
 
-    const walletAccountMap = wallets.reduce((summary, current) => {
+    // Filter out keyless wallets
+    const filteredWallets = wallets.filter(
+      (wallet) =>
+        !accountUtils.isKeylessWallet({
+          walletId: wallet.id,
+        }),
+    );
+
+    const walletAccountMap = filteredWallets.reduce((summary, current) => {
       summary[current.id] = current;
       return summary;
     }, {} as Record<string, IDBWallet>);
@@ -990,6 +998,15 @@ class ServicePrimeTransfer extends ServiceBase {
         accountId: account.id,
       }).walletId;
       if (!walletId) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      // Skip accounts belonging to keyless wallets
+      if (
+        accountUtils.isKeylessWallet({
+          walletId,
+        })
+      ) {
         // eslint-disable-next-line no-continue
         continue;
       }

--- a/packages/kit-bg/src/services/ServiceSetting.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.ts
@@ -624,7 +624,9 @@ class ServiceSetting extends ServiceBase {
       return;
     }
 
-    const { wallets } = await this.backgroundApi.serviceAccount.getAllWallets();
+    const { wallets } = await this.backgroundApi.serviceAccount.getAllWallets({
+      excludeKeylessWallet: true,
+    });
 
     const hasHdOrHwWallet =
       wallets?.some((wallet) => {

--- a/packages/kit/src/components/KeylessWallet/useKeylessWallet.tsx
+++ b/packages/kit/src/components/KeylessWallet/useKeylessWallet.tsx
@@ -164,9 +164,6 @@ export function useKeylessWalletMethods() {
     }, []);
 
   const getAuthPackFromServer = useCallback(async (): Promise<IAuthKeyPack> => {
-    Toast.success({
-      title: 'getAuthPackFromServer',
-    });
     await loginOneKeyId();
     const user = await primePersistAtom.get();
     const packSetId = user?.keylessWalletId;


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced wallet filtering to exclude keyless wallets from list operations across synchronization, transfer processing, and account settings management for improved data accuracy.

* **Bug Fixes**
  * Removed unnecessary success notification during keyless wallet authentication to streamline the login experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
This PR fixes issues related to keyless wallets appearing in wallet operations where they should be excluded.

## Changes
- Added `excludeKeylessWallet` parameter to `getAllWallets` method in ServiceAccount
- Updated wallet listing operations to exclude keyless wallets by default where appropriate
- Removed debug toast message from useKeylessWallet hook
- Updated ServiceSetting to exclude keyless wallets when checking for HD/HW wallets

## Commits
- `feat: filter out keyless wallets in ServicePrimeTransfer`
- `fix: exclude keyless wallets in wallet operations`

## Testing
- Verify wallet operations exclude keyless wallets appropriately
- Ensure HD/HW wallet checks work correctly