### PR TITLE
fix: enhance trading form and token selector functionality OK-47455 OK-47456 OK-47457 OK-47458 OK-47476

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTradesHistoryList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTradesHistoryList.tsx
@@ -118,6 +118,11 @@ function PerpTradesHistoryList({
         }
       }
       const parsed = parseDexCoin(fill.coin);
+      const exitPriceBN = new BigNumber(fill.px);
+      const exitPriceDecimals = getValidPriceDecimals(fill.px);
+      const exitPrice = exitPriceBN.isFinite()
+        ? exitPriceBN.toFixed(exitPriceDecimals)
+        : '0';
       showPositionShare({
         side: isLong ? 'long' : 'short',
         token: fill.coin,
@@ -126,7 +131,7 @@ function PerpTradesHistoryList({
         pnlPercent,
         leverage,
         entryPrice,
-        markPrice: fill.px,
+        markPrice: exitPrice,
         priceType: 'exit',
       });
     },

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
@@ -616,7 +616,7 @@ const SetTpslForm = memo(
                       (formData.percentage > 0 ? calculatedAmount : '')
                     }
                     onChange={handleAmountChange}
-                    suffix={currentPosition.coin}
+                    suffix={displayName}
                     validator={(value: string) => {
                       const processedValue = value.replace(/。/g, '.');
                       return validateSizeInput(processedValue, szDecimals);

--- a/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
@@ -101,6 +101,7 @@ function MobileTokenSelectorModal({
   const [selectorConfig, setSelectorConfig] =
     usePerpTokenSelectorConfigPersistAtom();
   const activeTab = selectorConfig?.activeTab ?? DEFAULT_PERP_TOKEN_ACTIVE_TAB;
+  const listRef = useRef<IListViewRef<ITokenSelectorListItem> | null>(null);
   const setActiveTab = useCallback(
     (tab: 'all' | 'hip3') => {
       setSelectorConfig((prev) => ({
@@ -108,10 +109,10 @@ function MobileTokenSelectorModal({
         direction: prev?.direction ?? DEFAULT_PERP_TOKEN_SORT_DIRECTION,
         activeTab: tab,
       }));
+      listRef.current?.scrollToOffset?.({ offset: 0, animated: false });
     },
     [setSelectorConfig],
   );
-  const listRef = useRef<IListViewRef<ITokenSelectorListItem> | null>(null);
 
   const computeSortValues = useCallback(
     (assetCtx: IPerpsAssetCtx | undefined) => {
@@ -239,9 +240,9 @@ function MobileTokenSelectorModal({
   const keyExtractor = useCallback(
     (item: { dexIndex: number; assetId?: number; index: number }) => {
       const assetId = item.assetId ?? item.index;
-      return `${item.dexIndex}-${assetId}`;
+      return `${activeTab}-${item.dexIndex}-${assetId}`;
     },
-    [],
+    [activeTab],
   );
 
   const handleSortPress = useCallback(

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -107,8 +107,6 @@ function PerpTradingForm({
   );
 
   const prevTypeRef = useRef<'market' | 'limit'>(formData.type);
-  const prevTokenRef = useRef<string>(currentTokenName || '');
-  const tokenSwitchingRef = useRef<string | false>(false);
 
   useEffect(() => {
     const prevType = prevTypeRef.current;
@@ -165,41 +163,6 @@ function PerpTradingForm({
     formData.leverage,
     updateForm,
   ]);
-
-  // Token Switch Effect: Handle price updates when user switches tokens
-  // This prevents stale price data from being used during token transitions
-  useEffect(() => {
-    const prevToken = prevTokenRef.current;
-    const hasTokenChanged =
-      currentTokenName && prevToken && prevToken !== currentTokenName;
-    const isDataSynced = prevToken === currentTokenName;
-    const shouldUpdatePrice =
-      tokenSwitchingRef.current === currentTokenName &&
-      formData.type === 'limit' &&
-      currentTokenName &&
-      midPrice &&
-      isDataSynced;
-
-    // Step 1: Detect token switch and mark switching state
-    if (hasTokenChanged) {
-      tokenSwitchingRef.current = currentTokenName;
-      prevTokenRef.current = currentTokenName;
-      return;
-    }
-
-    // Step 2: Update price after token data is synchronized (prevents stale price)
-    if (shouldUpdatePrice && midPrice) {
-      updateForm({
-        price: formatPriceToSignificantDigits(midPrice),
-      });
-      tokenSwitchingRef.current = false;
-    }
-
-    // Step 3: Initialize token reference on first load
-    if (!prevToken && currentTokenName) {
-      prevTokenRef.current = currentTokenName;
-    }
-  }, [currentTokenName, midPrice, formData.type, updateForm]);
 
   // Reference Price: Get the effective trading price (limit price or market price)
   const [, referencePriceString] = useMemo(() => {


### PR DESCRIPTION
- Added limit price update logic in ContextJotaiActionsHyperliquid to ensure accurate price handling based on current atom snapshot.
- Improved token size decimal caching in getTokenSzDecimals to optimize performance.
- Updated suffix display in SetTpslModal to use displayName for better clarity.
- Enhanced PerpTradesHistoryList to calculate and display exit price correctly.
- Refactored MobileTokenSelectorModal to ensure active tab state is preserved and list scrolls to top on tab change.
- Removed redundant token switching logic in PerpTradingForm to streamline price update handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features & Improvements**
  * Limit order prices now automatically update with current market price when switching trading assets
  * Token names display as readable identifiers instead of coin codes in take-profit/stop-loss forms
  * Mobile token selector resets to top when switching between tabs

* **Bug Fixes**
  * Improved exit price calculation and display in trade history

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->