### PR TITLE
fix: swap pro limit ui OK-47771 OK-47770 

### DIFF
--- a/packages/kit/src/views/Perp/components/PerpsSlider.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsSlider.tsx
@@ -27,6 +27,12 @@ export interface IPerpsSliderProps {
   sliderHeight?: number;
   showBubble?: boolean;
   step?: number;
+  /**
+   * When true, the slider fills from center (0) instead of left edge.
+   * Negative values fill left from center, positive values fill right from center.
+   * Native only.
+   */
+  centerOrigin?: boolean;
 }
 
 function PerpsSliderComponent({
@@ -39,6 +45,7 @@ function PerpsSliderComponent({
   sliderHeight,
   showBubble = false,
   step = 1,
+  centerOrigin = false,
 }: IPerpsSliderProps) {
   if (platformEnv.isNative) {
     return (
@@ -51,6 +58,7 @@ function PerpsSliderComponent({
         disabled={disabled}
         sliderHeight={sliderHeight}
         showBubble={showBubble}
+        centerOrigin={centerOrigin}
       />
     );
   }

--- a/packages/kit/src/views/Swap/components/SwapProLimitPriceInput.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProLimitPriceInput.tsx
@@ -61,8 +61,10 @@ const SwapProLimitPriceInput = ({
   const reverseChangeComponent = useMemo(() => {
     return (
       <XStack alignItems="center" gap="$1" onPress={onReverseChange}>
-        <SizableText size="$bodyMd">{fromSymbolLabel}</SizableText>
-        <Icon name="SwapVerSolid" color="$iconSubdued" size="$4" />
+        <SizableText size="$bodyMd" maxWidth="$16" numberOfLines={1}>
+          {fromSymbolLabel}
+        </SizableText>
+        <Icon name="SwapHorSolid" color="$iconSubdued" size="$4" />
       </XStack>
     );
   }, [fromSymbolLabel, onReverseChange]);

--- a/packages/kit/src/views/Swap/pages/components/SwapProInputContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProInputContainer.tsx
@@ -195,7 +195,9 @@ const SwapProInputContainer = ({
                       borderRadius="$full"
                     />
                   ) : null}
-                  <SizableText size="$bodyMd">{inputToken?.symbol}</SizableText>
+                  <SizableText size="$bodyMd" maxWidth="$16" numberOfLines={1}>
+                    {inputToken?.symbol}
+                  </SizableText>
                   {isTokenSelectorVisible ? (
                     <Icon
                       name="ChevronDownSmallOutline"

--- a/packages/kit/src/views/Swap/pages/components/SwapProLimitPriceSlider.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProLimitPriceSlider.tsx
@@ -106,6 +106,7 @@ const SwapProLimitPriceSlider = ({
           onChange={handleSliderChange}
           segments={4}
           sliderHeight={2}
+          centerOrigin
         />
       </XStack>
       <Input

--- a/packages/kit/src/views/Swap/pages/components/SwapProLimitPriceSlider.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProLimitPriceSlider.tsx
@@ -52,6 +52,13 @@ const SwapProLimitPriceSlider = ({
     if (percentValue !== lastExternalPercentRef.current) {
       lastExternalPercentRef.current = percentValue;
     }
+    // If value is 0, return empty string to show placeholder
+    if (
+      new BigNumber(percentValueNumber).isZero() ||
+      new BigNumber(percentValueNumber).isNaN()
+    ) {
+      return '';
+    }
     return new BigNumber(percentValueNumber).toFixed(2);
   }, [isInputEditing, inputText, percentValue, percentValueNumber]);
 
@@ -119,6 +126,7 @@ const SwapProLimitPriceSlider = ({
         keyboardType="decimal-pad"
         textAlign="left"
         color={percentValueColor}
+        placeholder="0.00"
         onChangeText={handleInputChange}
         onFocus={handleInputFocus}
         onBlur={handleInputBlur}

--- a/packages/kit/src/views/Swap/pages/components/SwapProLimitPriceSlider.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProLimitPriceSlider.tsx
@@ -84,8 +84,8 @@ const SwapProLimitPriceSlider = ({
   // Handle input focus
   const handleInputFocus = useCallback(() => {
     setIsInputEditing(true);
-    setInputText(new BigNumber(percentValueNumber).toFixed(2));
-  }, [percentValueNumber]);
+    setInputText(displayValue);
+  }, [displayValue]);
 
   // Handle input blur - apply the value
   const handleInputBlur = useCallback(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added center-origin slider mode to SegmentSlider and PerpsSlider so fills originate from center (0) and extend outward for positive/negative values.

* **UI/UX Improvements**
  * Constrained token symbol text to a single line to prevent wrapping.
  * Swapped vertical swap icon for a horizontal icon for clarity.
  * Improved limit-price input: shows placeholder "0.00", treats 0/NaN as empty display, and preserves displayed value when focusing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->