### PR TITLE
fix: allow supabase env overrides in dev

### DIFF
--- a/development/envExposedToClient.js
+++ b/development/envExposedToClient.js
@@ -31,6 +31,9 @@ function buildEnvExposedToClientDangerously({ platform }) {
     'SENTRY_DSN_WINMS',
     'SENTRY_DSN_REACT_NATIVE',
     'SENTRY_DSN_WEB',
+    // Supabase (publishable)
+    'SUPABASE_PROJECT_URL',
+    'SUPABASE_PUBLIC_API_KEY',
   ];
   // ***        also update Inject Environment Variables at release-ios.yml, release-android      ***
 

--- a/packages/kit/src/components/OneKeyAuth/supabase/SupabaseAuthProvider.tsx
+++ b/packages/kit/src/components/OneKeyAuth/supabase/SupabaseAuthProvider.tsx
@@ -53,7 +53,7 @@ export default function SupabaseAuthProvider({ children }: PropsWithChildren) {
   // Fetch the profile when the session changes
   // TODO profile fetch ERROR
   /*
-  // https://wtspqckturkzhstyjabx.supabase.co/rest/v1/profiles?select=*&id=eq.0c2b6a65-d588-4549-994a-f009745f9e32
+  // https://xxxx.supabase.co/rest/v1/profiles?select=*&id=eq.0c2b6a65-d588-4549-994a-f009745f9e32
     {
       "code": "PGRST205",
       "details": null,

--- a/packages/shared/src/consts/authConsts.ts
+++ b/packages/shared/src/consts/authConsts.ts
@@ -107,12 +107,14 @@ export const GOOGLE_CHROME_EXTENSION_CLIENT_ID =
 // Supabase (OneKeyAuth)
 // Project URL at https://supabase.com/dashboard/project/_/settings/api
 export const SUPABASE_PROJECT_URL = IS_DEV
-  ? 'https://wtspqckturkzhstyjabx.supabase.co' // local test
+  ? process.env.SUPABASE_PROJECT_URL ||
+    'https://zvxscjkvkjepbrjncvzt.supabase.co' // local test
   : 'https://zvxscjkvkjepbrjncvzt.supabase.co';
 
 // Publishable key at https://supabase.com/dashboard/project/_/settings/api-keys/new
 export const SUPABASE_PUBLIC_API_KEY = IS_DEV
-  ? 'sb_publishable_So24RIupCcXUHaKo1gM4VA_uOBbgjoN' // local test
+  ? process.env.SUPABASE_PUBLIC_API_KEY ||
+    'sb_publishable_ryfw0-h47JC2lHFRB2yrjw_iS_1KPgW' // local test
   : 'sb_publishable_ryfw0-h47JC2lHFRB2yrjw_iS_1KPgW';
 
 // Supabase OAuth Providers

--- a/packages/shared/src/storage/SupabaseStorage/consts.ts
+++ b/packages/shared/src/storage/SupabaseStorage/consts.ts
@@ -1,13 +1,8 @@
 /* eslint-disable spellcheck/spell-checker */
 // Supabase project URL
 
-import {
-  SUPABASE_PROJECT_URL,
-  SUPABASE_PUBLIC_API_KEY,
-} from '../../consts/authConsts';
+import { SUPABASE_PROJECT_URL } from '../../consts/authConsts';
 import { OneKeyLocalError } from '../../errors';
-
-export { SUPABASE_PROJECT_URL, SUPABASE_PUBLIC_API_KEY };
 
 export const SUPABASE_STORAGE_KEY_PREFIX = 'OneKeySupabaseAuth__';
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Supabase environment variables (project URL and API key) are now properly exposed to the client for authentication.
  * Development environment configuration now supports environment variable overrides with sensible fallback defaults.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->