### PR TITLE
fix(market): add proper padding bottom for mobile layout list containers OK-47595

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
@@ -9,6 +9,7 @@ import {
   useSafeAreaInsets,
   useTabContainerWidth,
 } from '@onekeyhq/components';
+import { useTabBarHeight } from '@onekeyhq/components/src/layouts/Page/hooks';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { MarketBannerList } from '../components/MarketBanner';
@@ -51,6 +52,7 @@ export function MobileLayout({
   const typedFocusedTab = focusedTab;
 
   const { top, bottom } = useSafeAreaInsets();
+  const tabBarHeight = useTabBarHeight();
   const height = useMemo(() => {
     return platformEnv.isNative
       ? Dimensions.get('window').height - top - bottom - 188
@@ -66,23 +68,41 @@ export function MobileLayout({
 
   const pageWidth = useTabContainerWidth();
 
+  const listContainerProps = useMemo(() => {
+    const getPaddingBottom = () => {
+      if (platformEnv.isNativeIOS) {
+        return 125;
+      }
+      if (platformEnv.isNativeAndroid) {
+        return tabBarHeight + 40;
+      }
+      return 0;
+    };
+
+    return {
+      flex: 1,
+      height: platformEnv.isNative ? undefined : height,
+      paddingBottom: getPaddingBottom(),
+    };
+  }, [height, tabBarHeight]);
+
   const renderItem = useCallback(
     ({ item }: { item: string }) => {
       if (item === watchlistTabName) {
         return (
-          <YStack flex={1} height={platformEnv.isNative ? undefined : height}>
+          <YStack {...listContainerProps}>
             <MarketWatchlistTokenList />
           </YStack>
         );
       }
       return (
-        <YStack flex={1} height={platformEnv.isNative ? undefined : height}>
+        <YStack {...listContainerProps}>
           <MarketFilterBarSmall {...filterBarProps} />
           <MarketNormalTokenList networkId={selectedNetworkId} />
         </YStack>
       );
     },
-    [filterBarProps, height, selectedNetworkId, watchlistTabName],
+    [filterBarProps, listContainerProps, selectedNetworkId, watchlistTabName],
   );
 
   return (


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized mobile layout rendering for improved responsiveness and platform-specific spacing on iOS and Android.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Add proper padding bottom calculation for market list containers on mobile platforms
- Use `useTabBarHeight` hook to get accurate tab bar height for Android
- Extract common list container props into a reusable memoized object

## Changes
- Import `useTabBarHeight` from components layout hooks
- Create `listContainerProps` memo that calculates platform-specific padding bottom:
  - iOS: 125px fixed padding
  - Android: tabBarHeight + 40px for dynamic calculation
  - Other platforms: 0px
- Refactor renderItem to use the shared `listContainerProps`

## Test Plan
- [ ] Verify list padding on iOS
- [ ] Verify list padding on Android
- [ ] Verify web layout remains unchanged