### PR TITLE
fix: show network icon for native tokens in market watchlist OK-47823

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenIdentityItem/TokenIdentityItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenIdentityItem/TokenIdentityItem.tsx
@@ -139,7 +139,7 @@ const BasicTokenIdentityItem: FC<ITokenIdentityItemProps> = ({
     <XStack alignItems="center" gap="$3" userSelect="none">
       <Token
         tokenImageUri={getTokenImageUri()}
-        networkImageUri={address ? effectiveNetworkLogoUri : undefined}
+        networkImageUri={effectiveNetworkLogoUri}
         fallbackIcon="CryptoCoinOutline"
         size="md"
       />


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed network logo display in token list items to render consistently when network information is available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Fixed native tokens (ETH, BTC, etc.) not showing network icon in market watchlist page
- Removed conditional check that was hiding network icon when token address is empty

## Changes
- Modified `TokenIdentityItem.tsx` to always display `effectiveNetworkLogoUri` instead of conditionally hiding it when address is empty

## Root Cause
Native tokens have an empty `address` field in API response. The previous logic `address ? effectiveNetworkLogoUri : undefined` caused network icons to not display for native tokens.

## Test Plan
- [ ] Verify native tokens (ETH, BTC) show network icon in market watchlist
- [ ] Verify non-native tokens still show network icon correctly