### PR TITLE
fix: use async network logo hook for market detail token header OK-48072

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx
@@ -12,6 +12,7 @@ import {
   useOrientation,
 } from '@onekeyhq/components';
 import { Token } from '@onekeyhq/kit/src/components/Token';
+import { useNetworkLogoUri } from '@onekeyhq/kit/src/hooks/useNetworkLogoUri';
 import { EWatchlistFrom } from '@onekeyhq/shared/src/logger/scopes/dex';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
@@ -45,6 +46,12 @@ export function TokenDetailHeaderLeft({
     return isLandscape ? windowScreenWidth / 2 : windowScreenWidth;
   }, [isLandscape, windowScreenWidth]);
   const { md } = useMedia();
+
+  // Use hook to get network logo with async fallback
+  const effectiveNetworkLogoUri = useNetworkLogoUri({
+    logoUri: networkLogoUri,
+    networkId,
+  });
 
   const {
     handleCopyAddress,
@@ -105,7 +112,7 @@ export function TokenDetailHeaderLeft({
         <Token
           size="md"
           tokenImageUri={logoUrl}
-          networkImageUri={networkLogoUri}
+          networkImageUri={effectiveNetworkLogoUri}
           fallbackIcon="CryptoCoinOutline"
         />
 


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network logo resolution in the token detail view for more reliable logo display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Use `useNetworkLogoUri` hook in Market Detail page token header
- Fix network logo not displaying for some networks that are not in preset list
- Align with Market Home List implementation for consistent behavior

## Changes
- Import and use `useNetworkLogoUri` hook in `TokenDetailHeaderLeft.tsx`
- The hook provides async fallback to fetch network logo when local preset doesn't have it
- Results are cached for 24 hours to avoid repeated API calls

## Test plan
- [ ] Verify network logo displays correctly on Market Detail page for various tokens
- [ ] Confirm tokens with non-preset network IDs now show their network logos