### PR TITLE
feat: add suspension alert with contact support button (OK-47904)

### DIFF
--- a/packages/kit/src/views/ReferFriends/pages/InviteReward/components/SuspensionAlert.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/InviteReward/components/SuspensionAlert.tsx
@@ -1,0 +1,40 @@
+import { useCallback, useMemo } from 'react';
+
+import { Alert, YStack } from '@onekeyhq/components';
+import { showIntercom } from '@onekeyhq/shared/src/modules3rdParty/intercom';
+
+type ISuspensionAlertProps = {
+  suspensionNotice?: string;
+  suspensionContactLabel?: string;
+};
+
+function SuspensionAlert({
+  suspensionNotice,
+  suspensionContactLabel,
+}: ISuspensionAlertProps) {
+  const handleContactSupport = useCallback(() => {
+    void showIntercom();
+  }, []);
+
+  const alertAction = useMemo(() => {
+    if (!suspensionContactLabel) {
+      return undefined;
+    }
+    return {
+      primary: suspensionContactLabel,
+      onPrimaryPress: handleContactSupport,
+    };
+  }, [suspensionContactLabel, handleContactSupport]);
+
+  if (!suspensionNotice) {
+    return null;
+  }
+
+  return (
+    <YStack px="$5" pt="$5">
+      <Alert type="critical" title={suspensionNotice} action={alertAction} />
+    </YStack>
+  );
+}
+
+export { SuspensionAlert };

--- a/packages/kit/src/views/ReferFriends/pages/InviteReward/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/InviteReward/index.tsx
@@ -3,7 +3,6 @@ import { useCallback, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import {
-  Alert,
   Page,
   ScrollView,
   Spinner,
@@ -24,6 +23,7 @@ import { ReferralCodeCard } from '@onekeyhq/kit/src/views/ReferFriends/pages/Inv
 import { RulesButton } from '@onekeyhq/kit/src/views/ReferFriends/pages/InviteReward/components/RulesButton';
 import { SectionHeader } from '@onekeyhq/kit/src/views/ReferFriends/pages/InviteReward/components/SectionHeader';
 import { ResponsiveTwoColumnLayout } from '@onekeyhq/kit/src/views/ReferFriends/pages/InviteReward/components/shared';
+import { SuspensionAlert } from '@onekeyhq/kit/src/views/ReferFriends/pages/InviteReward/components/SuspensionAlert';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IInviteSummary } from '@onekeyhq/shared/src/referralCode/type';
@@ -51,15 +51,15 @@ function InviteRewardContent({
     rebateConfig,
     withdrawAddresses,
     suspensionNotice,
+    suspensionContactLabel,
   } = summaryInfo;
 
   return (
     <>
-      {suspensionNotice ? (
-        <YStack px="$5" pt="$5">
-          <Alert type="critical" title={suspensionNotice} closable />
-        </YStack>
-      ) : null}
+      <SuspensionAlert
+        suspensionNotice={suspensionNotice}
+        suspensionContactLabel={suspensionContactLabel}
+      />
 
       <XStack px="$5" pt="$5" pb="$4" jc="space-between" ai="center">
         <SectionHeader translationId={ETranslations.global_overview} />

--- a/packages/shared/src/referralCode/type.ts
+++ b/packages/shared/src/referralCode/type.ts
@@ -23,6 +23,16 @@ interface IReward {
   perp?: IRewardBalance[];
 }
 
+export interface IWithdrawAddress {
+  _id: string;
+  networkId: string;
+  userId: string;
+  __v: number;
+  address: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface IInviteSummary {
   faqs: Array<{
     q: string;
@@ -30,11 +40,10 @@ export interface IInviteSummary {
   }>;
   inviteUrl: string;
   inviteCode: string;
+  isSuspended?: boolean;
   suspensionNotice?: string;
-  withdrawAddresses: {
-    networkId: string;
-    address: string;
-  }[];
+  suspensionContactLabel?: string;
+  withdrawAddresses: IWithdrawAddress[];
   enabledNetworks: string[];
   totalRewards: string;
   levelPercent: string;


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added suspension alerts to the refer friends feature that display critical notices when an account is suspended. Users can now contact support directly from the alert notification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Add `isSuspended` and `suspensionContactLabel` fields to `IInviteSummary` type
- Add `IWithdrawAddress` interface with complete fields from API response
- Create `SuspensionAlert` component as a standalone reusable component
- Replace closable alert with contact support action button that opens Intercom

## Changes
- `packages/shared/src/referralCode/type.ts`: Updated type definitions
- `packages/kit/src/views/ReferFriends/pages/InviteReward/components/SuspensionAlert.tsx`: New component
- `packages/kit/src/views/ReferFriends/pages/InviteReward/index.tsx`: Use new SuspensionAlert component

## Test plan
- [ ] Verify suspension alert displays when `suspensionNotice` is present
- [ ] Verify contact button shows `suspensionContactLabel` text
- [ ] Verify clicking contact button opens Intercom customer support