### PR TITLE
fix: adjust market desktop layout height and padding (OK-47988)

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/DesktopLayout.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/DesktopLayout.tsx
@@ -63,10 +63,10 @@ export function DesktopLayout({
   const { height, containerStyle } = useMemo(() => {
     const computedHeight = platformEnv.isNative
       ? undefined
-      : 'calc(100vh - 96px)';
+      : 'calc(100vh - 167px)';
     const style: Record<string, any> = { height: computedHeight };
     if (platformEnv.isWebDappMode) {
-      style.paddingBottom = 60;
+      style.paddingBottom = 100;
     }
     return { height: computedHeight, containerStyle: style };
   }, []);


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined layout spacing and height calculations in the Market desktop view for improved display consistency across different contexts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- Adjust market desktop layout height from `calc(100vh - 96px)` to `calc(100vh - 167px)`
- Increase paddingBottom in WebDappMode from 60 to 100

## Related Issue

OK-47988

## Test Plan

- [ ] Verify market page layout on desktop web
- [ ] Verify market page layout in WebDappMode