### PR TITLE
feat: add market native token route for URL /market/token/:network

### DIFF
--- a/packages/kit/src/routes/Tab/Marktet/router.ts
+++ b/packages/kit/src/routes/Tab/Marktet/router.ts
@@ -42,6 +42,12 @@ export const marketRouters: ITabSubNavigatorConfig<any, any>[] = [
     rewrite: '/token/:network/:tokenAddress',
   },
   {
+    name: ETabMarketRoutes.MarketNativeDetail,
+    component: MarketDetailV2,
+    headerShown: !platformEnv.isNative,
+    rewrite: '/token/:network',
+  },
+  {
     name: ETabMarketRoutes.MarketBannerDetail,
     component: MarketBannerDetail,
     headerShown: !platformEnv.isNative,

--- a/packages/kit/src/views/Market/MarketDetailV2/MarketDetailV2.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/MarketDetailV2.tsx
@@ -33,8 +33,19 @@ import { MobileLayout } from './layouts/MobileLayout';
 
 function MarketDetail({
   route,
-}: IPageScreenProps<ITabMarketParamList, ETabMarketRoutes.MarketDetailV2>) {
-  const { tokenAddress, network, isNative, disableTrade } = route.params;
+}: IPageScreenProps<
+  ITabMarketParamList,
+  ETabMarketRoutes.MarketDetailV2 | ETabMarketRoutes.MarketNativeDetail
+>) {
+  const params = route.params as
+    | ITabMarketParamList[ETabMarketRoutes.MarketDetailV2]
+    | ITabMarketParamList[ETabMarketRoutes.MarketNativeDetail];
+
+  const network = params.network;
+  const isNative = params.isNative;
+  const disableTrade = params.disableTrade;
+  // For MarketNativeDetail route, tokenAddress is undefined, use empty string
+  const tokenAddress = 'tokenAddress' in params ? params.tokenAddress : '';
 
   // Convert shortcode back to full networkId if needed
   // network is a shortcode like 'bsc', convert it to 'evm--56'
@@ -72,7 +83,10 @@ function MarketDetail({
 }
 
 function MarketDetailV2(
-  props: IPageScreenProps<ITabMarketParamList, ETabMarketRoutes.MarketDetailV2>,
+  props: IPageScreenProps<
+    ITabMarketParamList,
+    ETabMarketRoutes.MarketDetailV2 | ETabMarketRoutes.MarketNativeDetail
+  >,
 ) {
   const isLandscape = useOrientation();
   const isTablet = useIsNativeTablet();

--- a/packages/shared/src/routes/tabMarket.ts
+++ b/packages/shared/src/routes/tabMarket.ts
@@ -4,6 +4,7 @@ export enum ETabMarketRoutes {
   TabMarket = 'TabMarket',
   MarketDetail = 'MarketDetail',
   MarketDetailV2 = 'MarketDetailV2',
+  MarketNativeDetail = 'MarketNativeDetail',
   MarketBannerDetail = 'MarketBannerDetail',
 }
 
@@ -14,6 +15,12 @@ export type ITabMarketParamList = {
   };
   [ETabMarketRoutes.MarketDetailV2]: {
     tokenAddress: string;
+    network: string;
+    isNative?: boolean;
+    from?: EEnterWay;
+    disableTrade?: boolean;
+  };
+  [ETabMarketRoutes.MarketNativeDetail]: {
     network: string;
     isNative?: boolean;
     from?: EEnterWay;

--- a/packages/shared/src/utils/routeUtils.ts
+++ b/packages/shared/src/utils/routeUtils.ts
@@ -154,6 +154,11 @@ export const buildAllowList = (
         showUrl: true,
         showParams: true,
       },
+    [pagePath`${ERootRoutes.Main}${ETabRoutes.Market}${ETabMarketRoutes.MarketNativeDetail}`]:
+      {
+        showUrl: true,
+        showParams: true,
+      },
     [pagePath`${ERootRoutes.Main}${ETabRoutes.ReferFriends}${TabReferAFriend}`]:
       { showUrl: true, showParams: false },
     [pagePath`${ERootRoutes.Main}${ETabRoutes.ReferFriends}${TabInviteReward}`]:


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for viewing market token details on native platforms with improved navigation and parameter handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Add new `MarketNativeDetail` route to support URL format `/market/token/:network` (without tokenAddress)
- This enables deep linking for native tokens like `/market/token/btc/?isNative=true&from=ExtensionSidePanel`
- Update `MarketDetailV2` component to handle both route types

## Changes
- `packages/shared/src/routes/tabMarket.ts`: Add `MarketNativeDetail` enum and type
- `packages/kit/src/routes/Tab/Marktet/router.ts`: Add route config with rewrite `/token/:network`
- `packages/shared/src/utils/routeUtils.ts`: Add allowList config for new route
- `packages/kit/src/views/Market/MarketDetailV2/MarketDetailV2.tsx`: Support both route types

## Test plan
- [ ] Test URL `/market/token/btc/?isNative=true` navigates correctly
- [ ] Test existing `/market/token/:network/:tokenAddress` URLs still work
- [ ] Test on extension side panel navigation