### PR TITLE
fix: market network list and banner not refreshing after network reconnect OK-48134

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerList.tsx
@@ -51,6 +51,7 @@ export function MarketBannerList() {
     [],
     {
       watchLoading: true,
+      revalidateOnReconnect: true,
     },
   );
 

--- a/packages/kit/src/views/Market/hooks/useMarketBasicConfig/index.ts
+++ b/packages/kit/src/views/Market/hooks/useMarketBasicConfig/index.ts
@@ -47,6 +47,7 @@ export function useMarketBasicConfig() {
     [],
     {
       watchLoading: true,
+      revalidateOnReconnect: true,
     },
   );
 

--- a/packages/kit/src/views/Market/hooks/useMarketNetworks.ts
+++ b/packages/kit/src/views/Market/hooks/useMarketNetworks.ts
@@ -35,6 +35,7 @@ export function useMarketNetworks() {
       {
         initResult: [] as IServerNetwork[],
         watchLoading: true,
+        revalidateOnReconnect: true,
       },
     );
 


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Market data now automatically refreshes when your network connection is restored, ensuring you always see the latest information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Add `revalidateOnReconnect: true` to market banner list hook
- Add `revalidateOnReconnect: true` to market basic config hook  
- Add `revalidateOnReconnect: true` to market networks hook

## Problem
When user disconnects from network and then reconnects while on the Market page, the network list and banner do not refresh automatically. Other data (like token list) refreshes correctly because it has `revalidateOnReconnect: true` configured.

## Solution
Added `revalidateOnReconnect: true` option to the `usePromiseResult` calls in:
- `MarketBannerList.tsx`
- `useMarketBasicConfig/index.ts`
- `useMarketNetworks.ts`

This ensures these components will automatically re-fetch data when network connectivity is restored, matching the behavior of the token list.

## Test plan
- [ ] Disconnect network while on Market page
- [ ] Reconnect network
- [ ] Verify network list and banner refresh automatically without app restart