### PR TITLE
fix: refer friends page not redirecting after login OK-48131

### DIFF
--- a/packages/kit/src/hooks/useReferFriends.tsx
+++ b/packages/kit/src/hooks/useReferFriends.tsx
@@ -72,19 +72,26 @@ export function useReplaceToReferFriends() {
   const navigation = useAppNavigation();
 
   return useCallback(
-    async (params?: { utmSource?: string; code?: string }) => {
-      const isLogin = await backgroundApiProxy.servicePrime.isLoggedIn();
+    async (params?: {
+      utmSource?: string;
+      code?: string;
+      /** Skip isLoggedIn check when caller already knows login state */
+      isLoggedIn?: boolean;
+    }) => {
+      const { isLoggedIn: knownLoginState, ...navParams } = params ?? {};
+      const isLogin =
+        knownLoginState ?? (await backgroundApiProxy.servicePrime.isLoggedIn());
 
       if (platformEnv.isNative) {
         const screen = isLogin
           ? EModalReferFriendsRoutes.InviteReward
           : EModalReferFriendsRoutes.ReferAFriend;
-        navigation.replace(screen, params);
+        navigation.replace(screen, navParams);
       } else {
         const screen = isLogin
           ? ETabReferFriendsRoutes.TabInviteReward
           : ETabReferFriendsRoutes.TabReferAFriend;
-        navigation.replace(screen, params);
+        navigation.replace(screen, navParams);
       }
     },
     [navigation],

--- a/packages/kit/src/views/ReferFriends/pages/ReferAFriend/hooks/useReferAFriendData.ts
+++ b/packages/kit/src/views/ReferFriends/pages/ReferAFriend/hooks/useReferAFriendData.ts
@@ -18,7 +18,8 @@ export function useReferAFriendData() {
 
   // Monitor login status changes and auto-navigate when user logs in
   useLoginStatusChange(() => {
-    void replaceToReferFriends();
+    // Pass isLoggedIn: true to skip redundant check since hook already confirmed login
+    void replaceToReferFriends({ isLoggedIn: true });
   });
 
   useEffect(() => {


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **Performance Improvements**
  * Streamlined the refer friends feature by eliminating redundant login status checks, enabling faster navigation to the referral program.
  * Improved parameter handling during navigation to better preserve referral context while reducing unnecessary verification steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Fix refer friends page not redirecting to InviteReward page after user login
- Add optional `isLoggedIn` parameter to `useReplaceToReferFriends` to skip redundant login check when caller already knows login state
- Fix race condition where frontend Jotai atom state updates before backend service state syncs

## Changes
- `useReplaceToReferFriends`: Added optional `isLoggedIn` parameter to allow callers to skip the async `isLoggedIn()` check
- `useReferAFriendData`: Pass `isLoggedIn: true` in `useLoginStatusChange` callback since the hook already confirmed login state

## Root Cause
When `useLoginStatusChange` detects login via Jotai atom (`primeAtom.isLoggedIn && primeAtom.isLoggedInOnServer`), it calls `replaceToReferFriends()`. However, `replaceToReferFriends` was calling `backgroundApiProxy.servicePrime.isLoggedIn()` which hadn't synced yet, returning `false` and navigating to the wrong page.

## Test Plan
- [ ] Login on refer-friends page and verify redirect to invite-reward page
- [ ] Test on extension platform
- [ ] Test existing flows still work (direct navigation, useEffect redirect)