### PR TITLE
feat: add list end indicator to watchlist and banner detail list OK-47988

### DIFF
--- a/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
+++ b/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
@@ -196,6 +196,7 @@ function MarketBannerDetailContent({ title }: { title: string }) {
             hideTokenAge
             watchlistFrom={EWatchlistFrom.BannerList}
             copyFrom={ECopyFrom.BannerList}
+            showEndReachedIndicator
           />
         </Stack>
       </Page.Body>

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketWatchlistTokenList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketWatchlistTokenList.tsx
@@ -90,6 +90,7 @@ function MarketWatchlistTokenList({
       toolbar={toolbar}
       result={hideNativeToken ? watchListResultNoNative : watchlistResult}
       isWatchlistMode
+      showEndReachedIndicator
     />
   );
 }

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/DesktopLayout.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/DesktopLayout.tsx
@@ -65,7 +65,7 @@ export function DesktopLayout({
       ? undefined
       : 'calc(100vh - 167px)';
     const style: Record<string, any> = { height: computedHeight };
-    if (platformEnv.isWebDappMode) {
+    if (platformEnv.isWebDappMode || platformEnv.isDesktop) {
       style.paddingBottom = 100;
     }
     return { height: computedHeight, containerStyle: style };


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-reached indicator to token lists in the Market view, allowing users to see when they've scrolled to the bottom of available tokens

* **Style**
  * Adjusted layout padding behavior to apply to web dapp and desktop display modes, improving visual consistency across platforms

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Add `showEndReachedIndicator` to watchlist token list
- Add `showEndReachedIndicator` to banner detail token list  
- Add bottom padding for desktop platform in market layout

This shows the "end of list" indicator (line with center dot) at the bottom of these lists, matching the existing behavior in the normal trading list.