### PR TITLE
fix: swap pro input blur to left  & limit price smart into OK-48234 OK-48224 OK-48223 OK-48221 OK-48217 

### DIFF
--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -2199,6 +2199,18 @@ export default class ServiceSwap extends ServiceBase {
 
   @backgroundMethod()
   async fetchSpeedSwapConfig(params: { networkId: string }) {
+    const defaultConfig = {
+      provider: '',
+      speedConfig: {
+        slippage: 0.5,
+        spenderAddress: '',
+        defaultTokens: [],
+        defaultLimitTokens: [],
+        swapMevNetConfig: mevSwapNetworks,
+      },
+      supportSpeedSwap: false,
+      speedDefaultSelectToken: swapDefaultSetTokens['evm--1'].toToken,
+    };
     try {
       const client = await this.getClient(EServiceEndpointEnum.Swap);
       const res = await client.get<{ data: ISpeedSwapConfig }>(
@@ -2207,21 +2219,10 @@ export default class ServiceSwap extends ServiceBase {
           params: { networkId: params.networkId },
         },
       );
-      return res.data.data;
+      return res?.data?.data || defaultConfig;
     } catch (error) {
       console.error(error);
-      return {
-        provider: '',
-        speedConfig: {
-          slippage: 0.5,
-          spenderAddress: '',
-          defaultTokens: [],
-          defaultLimitTokens: [],
-          swapMevNetConfig: mevSwapNetworks,
-        },
-        supportSpeedSwap: false,
-        speedDefaultSelectToken: swapDefaultSetTokens['evm--1'].toToken,
-      };
+      return defaultConfig;
     }
   }
 

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -522,14 +522,17 @@ export default class ServiceSwap extends ServiceBase {
           checkInscriptionProtectionEnabled && inscriptionProtection;
         params.withCheckInscription = withCheckInscription;
       }
+      let fetchSignal: AbortSignal | undefined;
+      if (direction === ESwapDirectionType.FROM) {
+        fetchSignal = this._tokenDetailAbortControllerMap.from?.signal;
+      } else if (direction === ESwapDirectionType.TO) {
+        fetchSignal = this._tokenDetailAbortControllerMap.to?.signal;
+      }
       const { data } = await client.get<IFetchResponse<ISwapToken[]>>(
         '/swap/v1/token/detail',
         {
           params,
-          signal:
-            direction === ESwapDirectionType.FROM
-              ? this._tokenDetailAbortControllerMap.from?.signal
-              : this._tokenDetailAbortControllerMap.to?.signal,
+          signal: fetchSignal,
           headers:
             await this.backgroundApi.serviceAccountProfile._getWalletTypeHeader(
               {

--- a/packages/kit/src/views/Swap/components/SwapPercentageStageBadge.tsx
+++ b/packages/kit/src/views/Swap/components/SwapPercentageStageBadge.tsx
@@ -1,5 +1,8 @@
+import { useIntl } from 'react-intl';
+
 import type { IStackProps } from '@onekeyhq/components';
 import { Badge } from '@onekeyhq/components';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 const SwapPercentageStageBadge = ({
   stage,
@@ -11,6 +14,7 @@ const SwapPercentageStageBadge = ({
   badgeSize?: 'sm' | 'lg';
   onSelectStage?: (stage: number) => void;
 } & IStackProps) => {
+  const intl = useIntl();
   const component = (
     <Badge
       role="button"
@@ -31,7 +35,9 @@ const SwapPercentageStageBadge = ({
       {...props}
     >
       <Badge.Text size="$bodySmMedium" color="$textSubdued">
-        {stage}%
+        {stage === 0
+          ? intl.formatMessage({ id: ETranslations.Limit_market })
+          : `${stage}%`}
       </Badge.Text>
     </Badge>
   );

--- a/packages/kit/src/views/Swap/components/SwapProLimitPriceInput.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProLimitPriceInput.tsx
@@ -12,7 +12,11 @@ import {
   SwapLimitPriceInputStageSellForNative,
 } from '@onekeyhq/shared/types/swap/types';
 
-import { useSwapProTradeTypeAtom } from '../../../states/jotai/contexts/swap';
+import {
+  useSwapProDirectionAtom,
+  useSwapProTradeTypeAtom,
+} from '../../../states/jotai/contexts/swap';
+import { ESwapDirection } from '../../Market/MarketDetailV2/components/SwapPanel/hooks/useTradeType';
 import { PercentageStageOnKeyboard } from '../pages/components/SwapInputContainer';
 
 interface ISwapProLimitPriceInputProps {
@@ -32,13 +36,13 @@ const SwapProLimitPriceInput = ({
 }: ISwapProLimitPriceInputProps) => {
   const inputRef = useRef<IInputRef & TextInput>(null);
   const isFocusedRef = useRef(false);
-  const [swapProTradeType] = useSwapProTradeTypeAtom();
+  const [swapProDirection] = useSwapProDirectionAtom();
   const stageList = useMemo(() => {
-    if (swapProTradeType === ESwapProTradeType.MARKET) {
+    if (swapProDirection === ESwapDirection.BUY) {
       return SwapLimitPriceInputStageBuyForNative;
     }
     return SwapLimitPriceInputStageSellForNative;
-  }, [swapProTradeType]);
+  }, [swapProDirection]);
   // Reset scroll position to show text from the beginning when value changes and input is not focused
   useEffect(() => {
     if (!isFocusedRef.current) {
@@ -85,6 +89,11 @@ const SwapProLimitPriceInput = ({
         textAlign="left"
         keyboardType="decimal-pad"
         size="small"
+        inputAccessoryViewID={
+          platformEnv.isNativeIOS
+            ? SwapLimitPriceInputAccessoryViewID
+            : undefined
+        }
         containerProps={{
           borderWidth: 0,
           flex: 1,

--- a/packages/kit/src/views/Swap/components/SwapProLimitPriceInput.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProLimitPriceInput.tsx
@@ -6,16 +6,12 @@ import { Input, SizableText, XStack, YStack } from '@onekeyhq/components';
 import type { IInputRef } from '@onekeyhq/components';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
-  ESwapProTradeType,
   SwapLimitPriceInputAccessoryViewID,
   SwapLimitPriceInputStageBuyForNative,
   SwapLimitPriceInputStageSellForNative,
 } from '@onekeyhq/shared/types/swap/types';
 
-import {
-  useSwapProDirectionAtom,
-  useSwapProTradeTypeAtom,
-} from '../../../states/jotai/contexts/swap';
+import { useSwapProDirectionAtom } from '../../../states/jotai/contexts/swap';
 import { ESwapDirection } from '../../Market/MarketDetailV2/components/SwapPanel/hooks/useTradeType';
 import { PercentageStageOnKeyboard } from '../pages/components/SwapInputContainer';
 

--- a/packages/kit/src/views/Swap/components/SwapProLimitPriceInput.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProLimitPriceInput.tsx
@@ -1,15 +1,26 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 
+import { InputAccessoryView, type TextInput } from 'react-native';
+
 import { Input, SizableText, XStack, YStack } from '@onekeyhq/components';
 import type { IInputRef } from '@onekeyhq/components';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import {
+  ESwapProTradeType,
+  SwapLimitPriceInputAccessoryViewID,
+  SwapLimitPriceInputStageBuyForNative,
+  SwapLimitPriceInputStageSellForNative,
+} from '@onekeyhq/shared/types/swap/types';
 
-import type { TextInput } from 'react-native';
+import { useSwapProTradeTypeAtom } from '../../../states/jotai/contexts/swap';
+import { PercentageStageOnKeyboard } from '../pages/components/SwapInputContainer';
 
 interface ISwapProLimitPriceInputProps {
   value: string;
   currencySymbol: string;
   onChangeText: (text: string) => void;
   onBlur?: () => void;
+  onSelectPercentageStage: (stage: number) => void;
 }
 
 const SwapProLimitPriceInput = ({
@@ -17,10 +28,17 @@ const SwapProLimitPriceInput = ({
   currencySymbol,
   onChangeText,
   onBlur,
+  onSelectPercentageStage,
 }: ISwapProLimitPriceInputProps) => {
   const inputRef = useRef<IInputRef & TextInput>(null);
   const isFocusedRef = useRef(false);
-
+  const [swapProTradeType] = useSwapProTradeTypeAtom();
+  const stageList = useMemo(() => {
+    if (swapProTradeType === ESwapProTradeType.MARKET) {
+      return SwapLimitPriceInputStageBuyForNative;
+    }
+    return SwapLimitPriceInputStageSellForNative;
+  }, [swapProTradeType]);
   // Reset scroll position to show text from the beginning when value changes and input is not focused
   useEffect(() => {
     if (!isFocusedRef.current) {
@@ -73,6 +91,14 @@ const SwapProLimitPriceInput = ({
         }}
         addOns={[{ renderContent: currencySymbolAddOn }]}
       />
+      {platformEnv.isNativeIOS ? (
+        <InputAccessoryView nativeID={SwapLimitPriceInputAccessoryViewID}>
+          <PercentageStageOnKeyboard
+            onSelectPercentageStage={onSelectPercentageStage}
+            stageList={stageList}
+          />
+        </InputAccessoryView>
+      ) : null}
     </YStack>
   );
 };

--- a/packages/kit/src/views/Swap/components/SwapProPositionItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProPositionItem.tsx
@@ -2,7 +2,9 @@ import { useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
+import type { IYStackProps } from '@onekeyhq/components';
 import {
+  IStackProps,
   Icon,
   NumberSizeableText,
   SizableText,
@@ -20,12 +22,14 @@ interface ISwapProPositionItemProps {
   token: ISwapToken;
   onPress: (token: ISwapToken) => void;
   disabled?: boolean;
+  props?: IYStackProps;
 }
 
 const SwapProPositionItem = ({
   token,
   onPress,
   disabled,
+  props,
 }: ISwapProPositionItemProps) => {
   const intl = useIntl();
   const currencyInfo = useCurrency();
@@ -47,6 +51,7 @@ const SwapProPositionItem = ({
       gap="$4"
       onPress={disabled ? undefined : () => onPress(token)}
       opacity={disabled ? 0.5 : 1}
+      {...(props && { ...props })}
     >
       <XStack alignItems="center" gap="$2">
         <Token

--- a/packages/kit/src/views/Swap/hooks/useSwapPro.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapPro.ts
@@ -1050,22 +1050,13 @@ export function useSwapProSupportNetworksTokenList(
   };
 }
 
-export function useSwapProPositionsListFilter() {
+export function useSwapProPositionsListFilter(filterToken?: ISwapToken[]) {
   const [swapProSupportNetworksTokenList] =
     useSwapProSupportNetworksTokenListAtom();
-  const [swapProEnableCurrentSymbol] = useSwapProEnableCurrentSymbolAtom();
-  const [swapProTokenSelect] = useSwapProSelectTokenAtom();
-  const [swapFromToken] = useSwapSelectFromTokenAtom();
   const [swapTypeSwitch] = useSwapTypeSwitchAtom();
   const focusSwapPro = useMemo(() => {
     return platformEnv.isNative && swapTypeSwitch === ESwapTabSwitchType.LIMIT;
   }, [swapTypeSwitch]);
-  const filterToken = useMemo(() => {
-    if (focusSwapPro) {
-      return swapProTokenSelect;
-    }
-    return swapFromToken;
-  }, [focusSwapPro, swapProTokenSelect, swapFromToken]);
   const filterDefaultTokenList = useMemo(() => {
     let filterMinValueTokenList = swapProSupportNetworksTokenList.filter(
       (token) => {
@@ -1087,20 +1078,14 @@ export function useSwapProPositionsListFilter() {
 
   const finallyTokenList = useMemo(
     () =>
-      swapProEnableCurrentSymbol
+      filterToken
         ? swapProSupportNetworksTokenList.filter((token) =>
-            equalTokenNoCaseSensitive({
-              token1: token,
-              token2: filterToken,
-            }),
+            filterToken.some((t) =>
+              equalTokenNoCaseSensitive({ token1: t, token2: token }),
+            ),
           )
         : filterDefaultTokenList,
-    [
-      filterDefaultTokenList,
-      swapProEnableCurrentSymbol,
-      swapProSupportNetworksTokenList,
-      filterToken,
-    ],
+    [filterDefaultTokenList, swapProSupportNetworksTokenList, filterToken],
   );
   return {
     finallyTokenList,

--- a/packages/kit/src/views/Swap/hooks/useSwapPro.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapPro.ts
@@ -715,15 +715,13 @@ export function useSwapProTokenSearch(
         if (isCancelled) {
           return;
         }
-        const searchTokenParse = searchRes
-          ?.map((t) => {
-            const networkInfo = networkUtils.getLocalNetworkInfo(t.network);
-            return {
-              ...t,
-              networkLogoURI: networkInfo?.logoURI ?? '',
-            };
-          })
-          .filter((t) => !t.isNative);
+        const searchTokenParse = searchRes?.map((t) => {
+          const networkInfo = networkUtils.getLocalNetworkInfo(t.network);
+          return {
+            ...t,
+            networkLogoURI: networkInfo?.logoURI ?? '',
+          };
+        });
         const finalList = searchTokenParse ?? [];
         setSearchTokenList(finalList);
 

--- a/packages/kit/src/views/Swap/pages/components/LimitOrderList.tsx
+++ b/packages/kit/src/views/Swap/pages/components/LimitOrderList.tsx
@@ -34,7 +34,7 @@ import LimitOrderCancelDialog from './LimitOrderCancelDialog';
 interface ILimitOrderListProps {
   onClickCell: (item: IFetchLimitOrderRes) => void;
   isLoading?: boolean;
-  filterToken?: ISwapToken;
+  filterToken?: ISwapToken[];
   type: 'open' | 'history';
 }
 
@@ -132,14 +132,18 @@ const LimitOrderList = ({
     if (filterToken) {
       filteredData = filteredData.filter(
         (order) =>
-          equalTokenNoCaseSensitive({
-            token1: order.fromTokenInfo,
-            token2: filterToken,
-          }) ||
-          equalTokenNoCaseSensitive({
-            token1: order.toTokenInfo,
-            token2: filterToken,
-          }),
+          filterToken.some((t) =>
+            equalTokenNoCaseSensitive({
+              token1: t,
+              token2: order.fromTokenInfo,
+            }),
+          ) ||
+          filterToken.some((t) =>
+            equalTokenNoCaseSensitive({
+              token1: t,
+              token2: order.toTokenInfo,
+            }),
+          ),
       );
     }
     return (

--- a/packages/kit/src/views/Swap/pages/components/SwapBridgeMdContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapBridgeMdContainer.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { type ScrollView as ScrollViewNative } from 'react-native';
 
 import { EPageType, ScrollView, YStack } from '@onekeyhq/components';
-import type { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
 import type {
@@ -17,7 +16,6 @@ import SwapRecentTokenPairsGroup from '../../components/SwapRecentTokenPairsGrou
 
 import SwapActionsState from './SwapActionsState';
 import SwapAlertContainer from './SwapAlertContainer';
-import SwapPendingHistoryListComponent from './SwapPendingHistoryList';
 import SwapProTabListContainer from './SwapProTabListContainer';
 import SwapQuoteInput from './SwapQuoteInput';
 import SwapQuoteResult from './SwapQuoteResult';
@@ -147,7 +145,6 @@ const SwapBridgeMdContainer = ({
           tokenPairs={swapRecentTokenPairs}
           fromTokenAmount={fromTokenAmountValue}
         />
-        <SwapPendingHistoryListComponent pageType={pageType} />
         {shouldRenderHeavyComponents ? (
           <>
             {platformEnv.isNative && !fromTokenAmountValue ? (

--- a/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
@@ -56,8 +56,10 @@ import SwapInputActions from './SwapInputActions';
 
 export function PercentageStageOnKeyboard({
   onSelectPercentageStage,
+  stageList,
 }: {
   onSelectPercentageStage?: (stage: number) => void;
+  stageList?: number[];
 }) {
   const isShow = useIsKeyboardShown();
   const [{ swapPercentageInputStageShowForNative }] =
@@ -66,6 +68,14 @@ export function PercentageStageOnKeyboard({
   if (!platformEnv.isNativeIOS) {
     viewShow = isShow && swapPercentageInputStageShowForNative;
   }
+
+  const stageListToShow = useMemo(() => {
+    if (stageList && stageList.length > 0) {
+      return stageList;
+    }
+    return SwapPercentageInputStageForNative;
+  }, [stageList]);
+
   return viewShow ? (
     <XStack
       alignItems="center"
@@ -75,7 +85,7 @@ export function PercentageStageOnKeyboard({
       h="$10"
     >
       <>
-        {SwapPercentageInputStageForNative.map((stage) => (
+        {stageListToShow.map((stage) => (
           <SwapPercentageStageBadge
             badgeSize="lg"
             key={`swap-percentage-input-stage-${stage}`}

--- a/packages/kit/src/views/Swap/pages/components/SwapMarketHistoryList.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMarketHistoryList.tsx
@@ -43,7 +43,7 @@ interface ISectionData {
 interface ISwapMarketHistoryListProps {
   showType?: 'swap' | 'bridge';
   isPushModal?: boolean;
-  filterToken?: ISwapToken;
+  filterToken?: ISwapToken[];
 }
 
 const SwapMarketHistoryList = ({
@@ -84,14 +84,18 @@ const SwapMarketHistoryList = ({
     if (filterToken) {
       filterData = filterData.filter(
         (item) =>
-          equalTokenNoCaseSensitive({
-            token1: item.baseInfo?.fromToken,
-            token2: filterToken,
-          }) ||
-          equalTokenNoCaseSensitive({
-            token1: item.baseInfo?.toToken,
-            token2: filterToken,
-          }),
+          filterToken.some((t) =>
+            equalTokenNoCaseSensitive({
+              token1: t,
+              token2: item.baseInfo?.fromToken,
+            }),
+          ) ||
+          filterToken.some((t) =>
+            equalTokenNoCaseSensitive({
+              token1: t,
+              token2: item.baseInfo?.toToken,
+            }),
+          ),
       );
     }
     const pendingData =

--- a/packages/kit/src/views/Swap/pages/components/SwapProInputContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProInputContainer.tsx
@@ -202,6 +202,9 @@ const SwapProInputContainer = ({
           onBlur={onInputBlur}
           onFocus={onInputFocus}
           onChangeText={handleInputChange}
+          inputAccessoryViewID={
+            platformEnv.isNativeIOS ? SwapAmountInputAccessoryViewID : undefined
+          }
           placeholder={intl.formatMessage({
             id: ETranslations.content__amount,
           })}

--- a/packages/kit/src/views/Swap/pages/components/SwapProInputContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProInputContainer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
@@ -14,6 +14,7 @@ import {
   XStack,
   YStack,
 } from '@onekeyhq/components';
+import type { IInputRef } from '@onekeyhq/components';
 import {
   useSwapFromTokenAmountAtom,
   useSwapProDirectionAtom,
@@ -24,7 +25,6 @@ import {
   useSwapTypeSwitchAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
 import { validateAmountInput } from '@onekeyhq/kit/src/utils/validateAmountInput';
-import { useInAppNotificationAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
@@ -50,6 +50,7 @@ import {
 import { PercentageStageOnKeyboard } from './SwapInputContainer';
 
 import type { IToken } from '../../../Market/MarketDetailV2/components/SwapPanel/types';
+import type { TextInput } from 'react-native';
 
 interface ISwapProInputContainerProps {
   defaultTokens: ISwapTokenBase[];
@@ -77,6 +78,7 @@ const SwapProInputContainer = ({
   const [swapProUseSelectBuyToken, setSwapProUseSelectBuyToken] =
     useSwapProUseSelectBuyTokenAtom();
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const inputRef = useRef<IInputRef & TextInput>(null);
   const inputToken = useSwapProInputToken();
   const toToken = useSwapProToToken();
   const defaultTokensFromType = useMemo(() => {
@@ -154,20 +156,29 @@ const SwapProInputContainer = ({
       inputToken?.decimals,
     ],
   );
-  const [, setInAppNotification] = useInAppNotificationAtom();
-  const onInputFocus = useCallback(() => {
-    setInAppNotification((v) => ({
-      ...v,
-      swapPercentageInputStageShowForNative: true,
-    }));
-  }, [setInAppNotification]);
+
+  const isFocusedRef = useRef(false);
+  const inputValue = useMemo(() => {
+    return swapProTradeType === ESwapProTradeType.MARKET
+      ? swapProInputAmount
+      : fromInputAmount.value;
+  }, [swapProTradeType, swapProInputAmount, fromInputAmount.value]);
+
+  // Reset scroll position to show text from the beginning when value changes and input is not focused
+  useEffect(() => {
+    if (!isFocusedRef.current) {
+      inputRef.current?.setSelection?.(0, 0);
+    }
+  }, [inputValue]);
 
   const onInputBlur = useCallback(() => {
-    setInAppNotification((v) => ({
-      ...v,
-      swapPercentageInputStageShowForNative: false,
-    }));
-  }, [setInAppNotification]);
+    isFocusedRef.current = false;
+    inputRef.current?.setSelection?.(0, 0);
+  }, []);
+
+  const onInputFocus = useCallback(() => {
+    isFocusedRef.current = true;
+  }, []);
 
   useSwapLimitPriceCheck(inputToken, toToken);
 
@@ -175,6 +186,7 @@ const SwapProInputContainer = ({
     <YStack borderRadius="$2" bg="$bgStrong" mb="$2">
       <XStack borderTopLeftRadius="$2" borderTopRightRadius="$2">
         <Input
+          ref={inputRef}
           size="small"
           containerProps={{
             flex: 1,
@@ -187,8 +199,8 @@ const SwapProInputContainer = ({
               ? swapProInputAmount
               : fromInputAmount.value
           }
-          onFocus={onInputFocus}
           onBlur={onInputBlur}
+          onFocus={onInputFocus}
           onChangeText={handleInputChange}
           placeholder={intl.formatMessage({
             id: ETranslations.content__amount,

--- a/packages/kit/src/views/Swap/pages/components/SwapProLimitPriceValue.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProLimitPriceValue.tsx
@@ -25,7 +25,7 @@ const SwapProLimitPriceValue = ({
   const [settings] = useSettingsPersistAtom();
   const {
     onLimitRateChange,
-    // limitPriceSetReverse,
+    limitPriceSetReverse,
     fromTokenInfo,
     onSetMarketPrice,
     toTokenInfo,
@@ -336,36 +336,36 @@ const SwapProLimitPriceValue = ({
 
   // Handle percent change from slider or percent input
   // This updates the limit price based on the new percent value
-  // const onChangePercent = useCallback(
-  //   (value: number) => {
-  //     // Only need market price to calculate new limit rate
-  //     if (limitPriceMarketPrice.rate) {
-  //       const marketPriceBN = new BigNumber(limitPriceMarketPrice.rate);
-  //       if (marketPriceBN.isZero()) {
-  //         return;
-  //       }
-  //       const rateDifferenceChange = new BigNumber(value).dividedBy(100);
-  //       const newLimitRate = new BigNumber(1)
-  //         .plus(rateDifferenceChange)
-  //         .multipliedBy(marketPriceBN);
-  //       // Format the new rate with appropriate decimals
-  //       const decimals = limitPriceSetReverse
-  //         ? limitPriceMarketPrice.fromToken?.decimals ?? 8
-  //         : limitPriceMarketPrice.toToken?.decimals ?? 8;
-  //       const formattedRate = newLimitRate
-  //         .decimalPlaces(decimals, BigNumber.ROUND_HALF_UP)
-  //         .toFixed();
-  //       onLimitRateChange(formattedRate);
-  //     }
-  //   },
-  //   [
-  //     onLimitRateChange,
-  //     limitPriceMarketPrice.rate,
-  //     limitPriceSetReverse,
-  //     limitPriceMarketPrice.fromToken?.decimals,
-  //     limitPriceMarketPrice.toToken?.decimals,
-  //   ],
-  // );
+  const onChangePercent = useCallback(
+    (value: number) => {
+      // Only need market price to calculate new limit rate
+      if (limitPriceMarketPrice.rate) {
+        const marketPriceBN = new BigNumber(limitPriceMarketPrice.rate);
+        if (marketPriceBN.isZero()) {
+          return;
+        }
+        const rateDifferenceChange = new BigNumber(value).dividedBy(100);
+        const newLimitRate = new BigNumber(1)
+          .plus(rateDifferenceChange)
+          .multipliedBy(marketPriceBN);
+        // Format the new rate with appropriate decimals
+        const decimals = limitPriceSetReverse
+          ? limitPriceMarketPrice.fromToken?.decimals ?? 8
+          : limitPriceMarketPrice.toToken?.decimals ?? 8;
+        const formattedRate = newLimitRate
+          .decimalPlaces(decimals, BigNumber.ROUND_HALF_UP)
+          .toFixed();
+        onLimitRateChange(formattedRate);
+      }
+    },
+    [
+      onLimitRateChange,
+      limitPriceMarketPrice.rate,
+      limitPriceSetReverse,
+      limitPriceMarketPrice.fromToken?.decimals,
+      limitPriceMarketPrice.toToken?.decimals,
+    ],
+  );
 
   // Initialize with market price on first render
   useEffect(() => {
@@ -415,6 +415,7 @@ const SwapProLimitPriceValue = ({
         currencySymbol={currencySymbol}
         onChangeText={onTokenPriceInputChange}
         onBlur={onTokenPriceBlur}
+        onSelectPercentageStage={onChangePercent}
       />
       {/* <SwapProLimitPriceSlider
         percentValue={rateDifferenceInfo.value}

--- a/packages/kit/src/views/Swap/pages/components/SwapProPositionsList.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProPositionsList.tsx
@@ -15,14 +15,16 @@ import { useSwapProPositionsListFilter } from '../../hooks/useSwapPro';
 interface ISwapProPositionsListProps {
   onTokenPress: (token: ISwapToken) => void;
   onSearchClick?: () => void;
+  filterToken?: ISwapToken[];
 }
 
 const SwapProPositionsList = ({
   onTokenPress,
   onSearchClick,
+  filterToken,
 }: ISwapProPositionsListProps) => {
   const intl = useIntl();
-  const { finallyTokenList } = useSwapProPositionsListFilter();
+  const { finallyTokenList } = useSwapProPositionsListFilter(filterToken);
   const [swapProSupportNetworksTokenListLoading] =
     useSwapProSupportNetworksTokenListLoadingAtom();
   const [SwapProCurrentSymbolEnable] = useSwapProEnableCurrentSymbolAtom();

--- a/packages/kit/src/views/Swap/pages/components/SwapProTabListContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProTabListContainer.tsx
@@ -5,6 +5,7 @@ import {
   useSwapProEnableCurrentSymbolAtom,
   useSwapProSelectTokenAtom,
   useSwapSelectFromTokenAtom,
+  useSwapSelectToTokenAtom,
   useSwapTypeSwitchAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
 import { appEventBus } from '@onekeyhq/shared/src/eventBus/appEventBus';
@@ -42,6 +43,7 @@ const SwapProTabListContainer = memo(
     const [swapFromToken] = useSwapSelectFromTokenAtom();
     const [swapCurrentSymbolEnable] = useSwapProEnableCurrentSymbolAtom();
     const [swapTypeSwitch] = useSwapTypeSwitchAtom();
+    const [swapToToken] = useSwapSelectToTokenAtom();
     const focusSwapPro = useMemo(() => {
       return (
         platformEnv.isNative && swapTypeSwitch === ESwapTabSwitchType.LIMIT
@@ -49,10 +51,10 @@ const SwapProTabListContainer = memo(
     }, [swapTypeSwitch]);
     const filterToken = useMemo(() => {
       if (focusSwapPro) {
-        return swapProTokenSelect;
+        return swapProTokenSelect ? [swapProTokenSelect] : [];
       }
-      return swapFromToken;
-    }, [focusSwapPro, swapProTokenSelect, swapFromToken]);
+      return [swapFromToken, swapToToken].filter((t) => t !== undefined);
+    }, [focusSwapPro, swapFromToken, swapToToken, swapProTokenSelect]);
 
     const changeTabToLimitOrderList = useCallback(() => {
       setActiveTab(ETabName.SwapProOpenOrders);
@@ -106,6 +108,7 @@ const SwapProTabListContainer = memo(
             <SwapProPositionsList
               onTokenPress={onTokenPress}
               onSearchClick={onSearchClick}
+              filterToken={swapCurrentSymbolEnable ? filterToken : undefined}
             />
           </YStack>
           <YStack

--- a/packages/kit/src/views/Swap/pages/components/SwapProTradingPanel.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProTradingPanel.tsx
@@ -128,7 +128,9 @@ const SwapProTradingPanel = ({
           onBalanceMax={onBalanceMax}
         />
         <SwapProAccountSelect onSelectAccountClick={handleSelectAccountClick} />
-        <SwapProSlippageSetting isMEV={isMev} />
+        {swapProTradeType === ESwapProTradeType.MARKET ? (
+          <SwapProSlippageSetting isMEV={isMev} />
+        ) : null}
         {swapProTradeType === ESwapProTradeType.LIMIT ? (
           <>
             <LimitExpirySelect

--- a/packages/kit/src/views/Swap/pages/components/SwapSwapMbContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapSwapMbContainer.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { type ScrollView as ScrollViewNative } from 'react-native';
 
 import { EPageType, ScrollView, YStack } from '@onekeyhq/components';
-import type { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
 import type {
@@ -17,7 +16,6 @@ import SwapRecentTokenPairsGroup from '../../components/SwapRecentTokenPairsGrou
 
 import SwapActionsState from './SwapActionsState';
 import SwapAlertContainer from './SwapAlertContainer';
-import SwapPendingHistoryListComponent from './SwapPendingHistoryList';
 import SwapProTabListContainer from './SwapProTabListContainer';
 import SwapQuoteInput from './SwapQuoteInput';
 import SwapQuoteResult from './SwapQuoteResult';
@@ -147,7 +145,6 @@ const SwapSwapMbContainer = ({
           tokenPairs={swapRecentTokenPairs}
           fromTokenAmount={fromTokenAmountValue}
         />
-        <SwapPendingHistoryListComponent pageType={pageType} />
         {shouldRenderHeavyComponents ? (
           <>
             {platformEnv.isNative && !fromTokenAmountValue ? (

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -1092,6 +1092,8 @@ export interface ISwapNativeTokenReserveGas {
 
 export const SwapPercentageInputStage = [25, 50, 100];
 export const SwapPercentageInputStageForNative = [25, 50, 75, 100];
+export const SwapLimitPriceInputStageBuyForNative = [0, 20, 50, 100];
+export const SwapLimitPriceInputStageSellForNative = [0, -20, -50, -100];
 
 export const SwapBuildUseMultiplePopoversNetworkIds = ['tron--0x2b6653dc'];
 
@@ -1099,6 +1101,8 @@ export const SwapBuildShouldFallBackNetworkIds = ['tron--0x2b6653dc'];
 
 export const SwapAmountInputAccessoryViewID =
   'swap-amount-input-accessory-view';
+export const SwapLimitPriceInputAccessoryViewID =
+  'swap-limit-price-input-accessory-view';
 
 export const ChainFlipLogo =
   'https://uni.onekey-asset.com/static/logo/chainFlip_logo.png';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iOS keyboard accessory for quick percentage stage selection in limit price input
  * Percent-change handler enabled for updating limit prices
  * Added new preset limit-price stages for native swaps

* **Bug Fixes**
  * Slippage setting now shown only for market orders
  * Native tokens now appear in swap search results
  * Input amounts cleared when switching LIMIT on native to avoid stale values

* **UI Improvements**
  * Localized "0%" display in percentage stage badge
  * Removed pending history list from swap views
  * Improved input focus/selection and keyboard behavior

* **Other**
  * Multi-token filtering supported across swap lists and history (filterToken accepts multiple tokens)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->