### PR TITLE
fix: dismiss keyboard when tx confirm page opens OK-47986

### DIFF
--- a/packages/kit/src/views/SignatureConfirm/pages/TxConfirm/TxConfirm.tsx
+++ b/packages/kit/src/views/SignatureConfirm/pages/TxConfirm/TxConfirm.tsx
@@ -21,6 +21,7 @@ import {
   EAppEventBusNames,
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
+import { dismissKeyboard } from '@onekeyhq/shared/src/keyboard';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type {
   EModalSignatureConfirmRoutes,
@@ -320,6 +321,7 @@ function TxConfirm() {
   });
 
   useEffect(() => {
+    dismissKeyboard();
     updateUnsignedTxs(unsignedTxs);
 
     const refreshNativeTokenInfo = () => {


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The keyboard now automatically dismisses when the transaction confirmation page appears.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Add keyboard dismiss when TxConfirm page opens
- Prevents keyboard from staying visible when navigating to transaction confirmation page (e.g., swap confirmation)

## Changes
- Import `dismissKeyboard` from `@onekeyhq/shared/src/keyboard`
- Call `dismissKeyboard()` in the useEffect when TxConfirm component mounts

## Test Plan
- [ ] Open swap page on mobile
- [ ] Enter amount in input field (keyboard should appear)
- [ ] Tap swap button to open confirmation page
- [ ] Verify keyboard is dismissed when confirmation page opens