### PR TITLE
OK-48292: adjust layout properties in ToastNotificationContent

### DIFF
--- a/packages/components/src/actions/Toast/index.tsx
+++ b/packages/components/src/actions/Toast/index.tsx
@@ -301,6 +301,7 @@ function ToastNotificationContent({
       gap="$2"
       cursor="pointer"
       onPress={handlePress}
+      flex={1}
       $platform-native={{
         width: Math.min(width, 640) - 64,
       }}
@@ -315,7 +316,7 @@ function ToastNotificationContent({
       >
         {IconElement}
       </XStack>
-      <YStack flex={1} gap={2} flexShrink={1} maxWidth={220}>
+      <YStack flex={1} gap={2} flexShrink={1} minWidth={0}>
         <SizableText size="$headingSm" numberOfLines={2} flexShrink={1}>
           {title}
         </SizableText>


### PR DESCRIPTION
<img width="4586" height="2832" alt="CleanShot 2025-12-26 at 20 03 16@2x" src="https://github.com/user-attachments/assets/06bcb711-c3e0-447e-9fa7-767c79e1090c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Toast notification layout to better handle text wrapping and horizontal space utilization, ensuring notifications display correctly across different content lengths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->