### PR TITLE
fix: simplify wallet remove dialog and disable PRF secure storage temporarily

### DIFF
--- a/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletRemoveDialog.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletRemoveDialog.tsx
@@ -166,33 +166,6 @@ export function showWalletRemoveDialog({
   showCheckBox: boolean;
   isRemoveToMocked?: boolean; // hw standard wallet mocked remove only
 }) {
-  // When no checkbox needed, use simpler dialog without renderContent to avoid extra space
-  if (!showCheckBox) {
-    return Dialog.show({
-      icon: 'ErrorOutline',
-      tone: 'destructive',
-      title,
-      description,
-      onConfirmText: appLocale.intl.formatMessage({
-        id: ETranslations.global_remove,
-      }),
-      confirmButtonProps: {
-        variant: 'destructive',
-      },
-      onConfirm: async () => {
-        await backgroundApiProxy.serviceAccount.removeWallet({
-          walletId: wallet?.id || '',
-        });
-        defaultLogger.account.wallet.deleteWallet();
-        Toast.success({
-          title: appLocale.intl.formatMessage({
-            id: ETranslations.feedback_change_saved,
-          }),
-        });
-      },
-    });
-  }
-
   return Dialog.show({
     icon: 'ErrorOutline',
     tone: 'destructive',

--- a/packages/kit/src/views/Onboardingv2/pages/ConnectYourDevice.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ConnectYourDevice.tsx
@@ -468,20 +468,6 @@ function connectionIndicatorFooter({
         opacity: 0,
       }}
     >
-      {platformEnv.isWeb ? (
-        <Image
-          source={require('@onekeyhq/kit/assets/onboarding/radial-gradient.png')}
-          position="absolute"
-          left="50%"
-          bottom="0"
-          style={{
-            transform: [{ translateX: '-50%' }, { translateY: '50%' }],
-          }}
-          width={520}
-          height={226}
-          zIndex={0}
-        />
-      ) : null}
       {children}
     </YStack>
   );

--- a/packages/shared/src/storage/secureStorage/index.ts
+++ b/packages/shared/src/storage/secureStorage/index.ts
@@ -265,10 +265,15 @@ const storage: ISecureStorage = {
     await webStorage.removeItem(getSecureKey(key), undefined);
   },
 
-  supportSecureStorage(): Promise<boolean> {
+  async supportSecureStorage(): Promise<boolean> {
     // Synchronous check - basic browser support
     // For full PRF support check, use isPrfSupported() async function
-    return isPrfSupported();
+    // return isPrfSupported();
+
+    // TODO: remove this after test
+    // Note: On extension and web platforms, creating a mnemonic wallet will always require biometric verification by design,
+    // regardless of whether the user chooses to enable biometrics. This is because the password UI component does not synchronize this state.
+    return false;
   },
 
   async setSecureItemWithBiometrics(


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined wallet removal flow for improved consistency across the application.

* **Style**
  * Removed decorative gradient element from the device connection screen on web.

* **Features**
  * Adjusted secure storage capability detection settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

This PR includes the following changes:

### Changes

1. **WalletRemoveDialog.tsx** - Simplified the wallet remove dialog by removing the conditional simple dialog logic. Now uses a unified dialog flow for all cases.

2. **ConnectYourDevice.tsx** - Removed the radial gradient image component on web platform.

3. **secureStorage/index.ts** - Temporarily disabled PRF secure storage support for testing purposes.
   - `supportSecureStorage()` now returns `false` instead of checking PRF support
   - **TODO**: Restore after testing is complete
   - Note: On extension and web platforms, creating a mnemonic wallet will always require biometric verification by design, regardless of whether the user chooses to enable biometrics.

### Testing

- [ ] Tested wallet removal flow
- [ ] Verified onboarding flow on web platform
- [ ] Confirmed secure storage behavior on extension/web platforms