### PR TITLE
Recover the edit button for customized networks

### DIFF
--- a/packages/kit/src/views/ChainSelector/components/EditableChainSelector/EditableListItem.tsx
+++ b/packages/kit/src/views/ChainSelector/components/EditableChainSelector/EditableListItem.tsx
@@ -187,7 +187,7 @@ export const EditableListItem = ({
       bg={networkId === item.id ? '$bgActive' : undefined}
     >
       <XStack gap="$5">
-        {isCustomNetworkEditable && isEditMode && !isDisabled ? (
+        {isCustomNetworkEditable && !isDisabled ? (
           <ListItem.IconButton
             icon="PencilOutline"
             title={intl.formatMessage({ id: ETranslations.global_edit })}


### PR DESCRIPTION
<img width="1632" height="1570" alt="CleanShot 2025-12-27 at 11 19 38@2x" src="https://github.com/user-attachments/assets/b77ff8e2-6df0-49b6-ad6e-0b2a62187223" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The edit button for custom networks is now accessible regardless of edit mode status, provided the network is customizable and enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->