### PR TITLE
fix: clean up token detail routes in tablet split view mode

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/hooks/useMarketDetailBackNavigation.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/hooks/useMarketDetailBackNavigation.ts
@@ -5,6 +5,7 @@ import {
   useRoute,
 } from '@react-navigation/native';
 
+import { useIsTabletDetailView } from '@onekeyhq/components';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { EEnterWay } from '@onekeyhq/shared/src/logger/scopes/dex';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -19,8 +20,15 @@ export function useMarketDetailBackNavigation() {
   const reactNavigation = useReactNavigation();
   const route = useRoute();
   const params = route.params as { from?: EEnterWay } | undefined;
+  const isTabletDetailView = useIsTabletDetailView();
 
   const handleBackPress = useCallback(() => {
+    // In tablet split view mode, always use pop for back navigation
+    if (isTabletDetailView) {
+      navigation.pop();
+      return;
+    }
+
     // Check if the previous route is Market home
     const state = reactNavigation.getState();
 
@@ -52,7 +60,7 @@ export function useMarketDetailBackNavigation() {
         screen: ETabMarketRoutes.TabMarket,
       },
     });
-  }, [params, reactNavigation, navigation]);
+  }, [params, reactNavigation, navigation, isTabletDetailView]);
 
   return { handleBackPress };
 }

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/useMarketBannerList.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/useMarketBannerList.ts
@@ -1,6 +1,5 @@
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
-
 import type { IMarketBannerItem } from '@onekeyhq/shared/types/marketV2';
 
 export function useMarketBannerList() {

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/useToMarketBannerDetail.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/useToMarketBannerDetail.ts
@@ -3,7 +3,6 @@ import { useCallback } from 'react';
 import type { IPageNavigationProp } from '@onekeyhq/components';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   ETabMarketRoutes,
   type ITabMarketParamList,

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useToMarketDetailPage.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useToMarketDetailPage.ts
@@ -1,10 +1,16 @@
 import { useCallback } from 'react';
 
 import type { IPageNavigationProp } from '@onekeyhq/components';
-import { rootNavigationRef } from '@onekeyhq/components';
+import {
+  rootNavigationRef,
+  useIsTabletDetailView,
+  useIsTabletMainView,
+} from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useTokenDetailActions } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
+import { appEventBus } from '@onekeyhq/shared/src/eventBus/appEventBus';
+import { EAppEventBusNames } from '@onekeyhq/shared/src/eventBus/appEventBusNames';
 import { EEnterWay } from '@onekeyhq/shared/src/logger/scopes/dex';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
@@ -37,6 +43,8 @@ export function useToDetailPage(options?: IUseToDetailPageOptions) {
   const navigation =
     useAppNavigation<IPageNavigationProp<ITabMarketParamList>>();
   const tokenDetailActions = useTokenDetailActions();
+  const isTabletMainView = useIsTabletMainView();
+  const isTabletDetailView = useIsTabletDetailView();
 
   const toMarketDetailPage = useCallback(
     async (item: IMarketToken) => {
@@ -86,10 +94,18 @@ export function useToDetailPage(options?: IUseToDetailPageOptions) {
         // Always clear token detail when navigating
         tokenDetailActions.current.clearTokenDetail();
 
+        // Clean existing token detail pages in tablet split view mode before pushing new one
+        if (isTabletMainView || isTabletDetailView) {
+          appEventBus.emit(
+            EAppEventBusNames.CleanTokenDetailInTabletDetailView,
+            {},
+          );
+        }
+
         navigation.push(ETabMarketRoutes.MarketDetailV2, params);
       }
     },
-    [navigation, tokenDetailActions, options?.useRootNavigation, options?.from],
+    [navigation, tokenDetailActions, options?.useRootNavigation, options?.from, isTabletMainView, isTabletDetailView],
   );
 
   return toMarketDetailPage;

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useToMarketDetailPage.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useToMarketDetailPage.ts
@@ -98,14 +98,21 @@ export function useToDetailPage(options?: IUseToDetailPageOptions) {
         if (isTabletMainView || isTabletDetailView) {
           appEventBus.emit(
             EAppEventBusNames.CleanTokenDetailInTabletDetailView,
-            {},
+            undefined,
           );
         }
 
         navigation.push(ETabMarketRoutes.MarketDetailV2, params);
       }
     },
-    [navigation, tokenDetailActions, options?.useRootNavigation, options?.from, isTabletMainView, isTabletDetailView],
+    [
+      navigation,
+      tokenDetailActions,
+      options?.useRootNavigation,
+      options?.from,
+      isTabletMainView,
+      isTabletDetailView,
+    ],
   );
 
   return toMarketDetailPage;

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -425,6 +425,7 @@ export interface IAppEventBusPayload {
     route: EModalRoutes;
     params: any;
   };
+  [EAppEventBusNames.CleanTokenDetailInTabletDetailView]: undefined;
   [EAppEventBusNames.MarketHomePageEnter]: {
     from: EEnterWay;
   };

--- a/packages/shared/src/eventBus/appEventBusNames.ts
+++ b/packages/shared/src/eventBus/appEventBusNames.ts
@@ -128,6 +128,7 @@ export enum EAppEventBusNames {
   SwitchTabBar = 'SwitchTabBar',
   PushPageInTabletDetailView = 'PushPageInTabletDetailView',
   PushModalPageInTabletDetailView = 'PushModalPageInTabletDetailView',
+  CleanTokenDetailInTabletDetailView = 'CleanTokenDetailInTabletDetailView',
   MarketHomePageEnter = 'MarketHomePageEnter',
   MarketWatchListV2Changed = 'MarketWatchListV2Changed',
   SwapLimitOrderBuildSuccess = 'SwapLimitOrderBuildSuccess',


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tablet split-view back navigation so switching between market detail pages no longer leaves stale detail panes and back actions behave predictably.

* **New Features**
  * Added coordinated cleanup when opening market details on tablet layouts to keep detail and main panes synchronized and prevent navigation inconsistencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Add `CleanTokenDetailInTabletDetailView` event to clean up existing token detail pages before pushing new one in tablet split view mode
- Fix back navigation in tablet split view mode to use `pop()` instead of `navigate()` to avoid creating new pages
- Only token detail pages (MarketDetailV2, MarketNativeDetail) are cleaned up, other pages like banner list are preserved

## Changes
- `appEventBusNames.ts`: Add new event `CleanTokenDetailInTabletDetailView`
- `Bootstrap.tsx`: Add event handler to filter out token detail routes while preserving other routes
- `useToMarketDetailPage.ts`: Emit clean event before pushing new token detail in tablet mode
- `useMarketDetailBackNavigation.ts`: Use `pop()` for back navigation in tablet detail view