### PR TITLE
fix(OK-48282): adjust market desktop layout padding

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/MarketHomeV2.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/MarketHomeV2.tsx
@@ -1,4 +1,3 @@
-import type { PropsWithChildren } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Page, useMedia } from '@onekeyhq/components';

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/DesktopLayout.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/DesktopLayout.tsx
@@ -72,8 +72,13 @@ export function DesktopLayout({
       ? undefined
       : `calc(100vh - ${167 - bannerHeight}px)`;
     const style: Record<string, any> = { height: computedHeight };
-    if (platformEnv.isWebDappMode || platformEnv.isDesktop) {
+    
+    if (platformEnv.isWebDappMode) {
       style.paddingBottom = 100;
+    }
+
+    if (platformEnv.isDesktop) {
+      style.paddingBottom = 50;
     }
     return { height: computedHeight, containerStyle: style };
   }, [hasBanner]);


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted bottom padding on the Market Home page for desktop layouts to optimize visual spacing and layout consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Remove unused `PropsWithChildren` import from MarketHomeV2
- Differentiate bottom padding for web dapp mode vs desktop platform in market layout

## Changes
- Web dapp mode: 100px bottom padding
- Desktop app: 50px bottom padding

## Test plan
- [ ] Verify market list scrolls correctly on desktop app
- [ ] Verify market list scrolls correctly on web dapp mode