### PR TITLE
refactor: improve market detail navigation from search results

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/hooks/useMarketDetailBackNavigation.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/hooks/useMarketDetailBackNavigation.ts
@@ -5,7 +5,7 @@ import {
   useRoute,
 } from '@react-navigation/native';
 
-import { useIsTabletDetailView } from '@onekeyhq/components';
+import { Toast, useIsTabletDetailView } from '@onekeyhq/components';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { EEnterWay } from '@onekeyhq/shared/src/logger/scopes/dex';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -29,6 +29,15 @@ export function useMarketDetailBackNavigation() {
       return;
     }
 
+    if (
+      platformEnv.isNative &&
+      (params?.from === EEnterWay.Search)
+    ) {
+      navigation.pop();
+      navigation.switchTab(ETabRoutes.Discovery);
+      return;
+    }
+
     // Check if the previous route is Market home
     const state = reactNavigation.getState();
 
@@ -44,28 +53,7 @@ export function useMarketDetailBackNavigation() {
       }
     }
 
-    if (
-      platformEnv.isNative &&
-      (params?.from === EEnterWay.Search || params?.from === EEnterWay.HomeTab)
-    ) {
-      // On mobile, Market is under Discovery tab
-      navigation.switchTab(ETabRoutes.Discovery);
-      return;
-    }
-
-    // Otherwise, navigate directly to Market home
-    navigation.navigate(
-      ERootRoutes.Main,
-      {
-        screen: ETabRoutes.Market,
-        params: {
-          screen: ETabMarketRoutes.TabMarket,
-        },
-      },
-      {
-        pop: true,
-      },
-    );
+    navigation.pop();
   }, [params, reactNavigation, navigation, isTabletDetailView]);
 
   return { handleBackPress };

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
@@ -141,7 +141,7 @@ export function UniversalSearchV2MarketTokenItem({
   const [{ isMounted }] = useMarketWatchListV2Atom();
   const universalSearchActions = useUniversalSearchActions();
   const toMarketDetailPage = useToDetailPage({
-    useRootNavigation: true,
+    switchToMarketTabFirst: true,
     from: EEnterWay.Search,
   });
   const {


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved back navigation behavior when returning from market details to previous screens
  * Enhanced navigation flow when accessing market token details from search results
  * Optimized tab switching behavior for consistent experience across different devices

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Add `switchToMarketTabFirst` option to `useToDetailPage` hook for controlling tab switching behavior
- Remove `useTokenDetailActions` dependency from navigation hook (detail page auto-clears old data on mount)
- Fix navigation from universal search to market detail page using `rootNavigationRef`
- Properly handle navigation context when navigating from modal to tab

## Changes
- `useToMarketDetailPage.ts`: Added `switchToMarketTabFirst` option, removed context dependency
- `useMarketDetailBackNavigation.ts`: Simplified back navigation logic
- `UniversalSearchV2MarketTokenItem.tsx`: Updated to use new navigation option

## Test plan
- [ ] Test clicking market token from universal search navigates correctly to detail page
- [ ] Test back navigation from market detail returns to correct tab
- [ ] Test navigation on both mobile and desktop platforms