### PR TITLE
fix: extend mobile token list height when banner is absent

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
@@ -12,7 +12,10 @@ import {
 import { useTabBarHeight } from '@onekeyhq/components/src/layouts/Page/hooks';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
-import { MarketBannerList } from '../components/MarketBanner';
+import {
+  MarketBannerList,
+  useMarketBannerList,
+} from '../components/MarketBanner';
 import { MarketFilterBarSmall } from '../components/MarketFilterBarSmall';
 import { MarketNormalTokenList } from '../components/MarketTokenList/MarketNormalTokenList';
 import { MarketWatchlistTokenList } from '../components/MarketTokenList/MarketWatchlistTokenList';
@@ -53,11 +56,17 @@ export function MobileLayout({
 
   const { top, bottom } = useSafeAreaInsets();
   const tabBarHeight = useTabBarHeight();
+
+  const { bannerList } = useMarketBannerList();
+  const hasBanner = Boolean(bannerList && bannerList.length > 0);
+
   const height = useMemo(() => {
+    // When no banner, increase height by banner height (~120px)
+    const bannerHeight = hasBanner ? 0 : 120;
     return platformEnv.isNative
-      ? Dimensions.get('window').height - top - bottom - 188
-      : 'calc(100vh - 140px)';
-  }, [bottom, top]);
+      ? Dimensions.get('window').height - top - bottom - 188 + bannerHeight
+      : `calc(100vh - ${140 - bannerHeight}px)`;
+  }, [bottom, top, hasBanner]);
 
   const onPageChanged = useCallback(
     (index: number) => {


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**Bug Fixes**
* Improved mobile market view layout height calculation to properly account for banner visibility, ensuring correct spacing in both banner and non-banner scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Add banner presence detection to MobileLayout using `useMarketBannerList` hook
- When no banner is displayed, increase token list height by 120px
- Matches desktop behavior for consistent UX across platforms

## Changes
- `MobileLayout.tsx`: Added `useMarketBannerList` hook and dynamic height calculation based on banner presence

## Test plan
- [ ] Test mobile market page with banner - list height should remain unchanged
- [ ] Test mobile market page without banner - list height should increase by ~120px
- [ ] Verify scrolling behavior works correctly in both scenarios