### PR TITLE
fix: restore clearTokenDetail action in useToDetailPage hook

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useToMarketDetailPage.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useToMarketDetailPage.ts
@@ -8,6 +8,7 @@ import {
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { useTokenDetailActions } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
 import { appEventBus } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { EAppEventBusNames } from '@onekeyhq/shared/src/eventBus/appEventBusNames';
 import { EEnterWay } from '@onekeyhq/shared/src/logger/scopes/dex';
@@ -43,6 +44,7 @@ interface IUseToDetailPageOptions {
 export function useToDetailPage(options?: IUseToDetailPageOptions) {
   const navigation =
     useAppNavigation<IPageNavigationProp<ITabMarketParamList>>();
+  const tokenDetailActions = useTokenDetailActions();
   const isTabletMainView = useIsTabletMainView();
   const isTabletDetailView = useIsTabletDetailView();
 
@@ -81,6 +83,9 @@ export function useToDetailPage(options?: IUseToDetailPageOptions) {
           },
         });
       } else if (options?.switchToMarketTabFirst) {
+        // Clear token detail before navigation
+        tokenDetailActions.current.clearTokenDetail();
+
         // First switch to the appropriate tab to highlight it
         const targetTab = platformEnv.isNative
           ? ETabRoutes.Discovery
@@ -99,7 +104,9 @@ export function useToDetailPage(options?: IUseToDetailPageOptions) {
           });
         }, 500);
       } else {
-        // Regular navigation within current stack
+        // Clear token detail before navigation
+        tokenDetailActions.current.clearTokenDetail();
+
         // Clean existing token detail pages in tablet split view mode before pushing new one
         if (isTabletMainView || isTabletDetailView) {
           appEventBus.emit(
@@ -113,6 +120,7 @@ export function useToDetailPage(options?: IUseToDetailPageOptions) {
     },
     [
       navigation,
+      tokenDetailActions,
       options?.switchToMarketTabFirst,
       options?.from,
       isTabletMainView,


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved state management when navigating to token detail pages to prevent stale data from appearing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Restore `useTokenDetailActions` hook and `clearTokenDetail` action in `useToDetailPage`
- Clear token detail state before navigating to ensure stale data is removed

## Changes
- `useToMarketDetailPage.ts`: Added back `useTokenDetailActions` hook and `clearTokenDetail()` calls before navigation

## Test plan
- [ ] Navigate to token detail from market list - should clear previous token data
- [ ] Navigate to token detail from search results - should clear previous token data
- [ ] Verify new token data loads correctly without showing stale data