### PR TITLE
fix: skip header top margin for iOS modal in market detail

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/MarketDetailHeader/TabPageHeaderContainer.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/MarketDetailHeader/TabPageHeaderContainer.tsx
@@ -1,6 +1,11 @@
 import type { ReactNode } from 'react';
 
-import { Page, XStack, useSafeAreaInsets } from '@onekeyhq/components';
+import {
+  Page,
+  XStack,
+  useIsOverlayPage,
+  useSafeAreaInsets,
+} from '@onekeyhq/components';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 interface ITabPageHeaderContainerProps {
@@ -11,6 +16,12 @@ export function TabPageHeaderContainer({
   children,
 }: ITabPageHeaderContainerProps) {
   const { top } = useSafeAreaInsets();
+  const isOverlayPage = useIsOverlayPage();
+
+  // Skip top margin for modal pages on iOS, as modal has its own safe area handling
+  const isIOSModalPage = platformEnv.isNativeIOS && isOverlayPage;
+  const shouldApplyTopMargin =
+    !isIOSModalPage && (top || platformEnv.isNativeAndroid);
 
   return (
     <>
@@ -20,7 +31,7 @@ export function TabPageHeaderContainer({
         justifyContent="space-between"
         px="$5"
         h="$12"
-        {...(top || platformEnv.isNativeAndroid ? { mt: top || '$2' } : {})}
+        {...(shouldApplyTopMargin ? { mt: top || '$2' } : {})}
       >
         {children}
       </XStack>

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -68,11 +68,16 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
 
   const { top, bottom } = useSafeAreaInsets();
 
+  // Skip top inset for iOS modal pages, as modal has its own safe area handling
+  const isIOSModalPage = platformEnv.isNativeIOS && isModalPage;
+
   const height = useMemo(() => {
-    return platformEnv.isNative
-      ? Dimensions.get('window').height - top - bottom - 158
-      : 'calc(100vh - 96px - 74px)';
-  }, [bottom, top]);
+    if (platformEnv.isNative) {
+      const topInset = isIOSModalPage ? 0 : top;
+      return Dimensions.get('window').height - topInset - bottom - 158;
+    }
+    return 'calc(100vh - 96px - 74px)';
+  }, [bottom, top, isIOSModalPage]);
 
   const width = useMemo(() => {
     return Dimensions.get('window').width;


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layout spacing and safe-area handling for iOS modal overlay pages
  * Improved margin calculations to ensure proper spacing across different page states on iOS devices

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Skip top safe area margin when market detail is displayed in a modal on iOS
- Adjust height calculation in MobileLayout to not subtract top inset for iOS modal pages
- Only affects iOS platform, Android behavior unchanged

## Changes
- `TabPageHeaderContainer.tsx`: Skip top margin for iOS modal pages
- `MobileLayout.tsx`: Adjust height calculation for iOS modal pages

## Test Plan
- [ ] Test market detail in modal on iOS - should have no extra top spacing
- [ ] Test market detail in tab on iOS - should have normal top spacing
- [ ] Test market detail on Android - should be unchanged