### PR TITLE
fix: clear token detail state before opening swap pro market detail

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -95,6 +95,9 @@ import {
 } from '@onekeyhq/shared/types/swap/types';
 
 import TransactionLossNetworkFeeExceedDialog from '../../components/TransactionLossNetworkFeeExceedDialog';
+import { useTokenDetailActions } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
+import { MarketWatchListProviderMirrorV2 } from '@onekeyhq/kit/src/views/Market/MarketWatchListProviderMirrorV2';
+
 import { useSwapAddressInfo } from '../../hooks/useSwapAccount';
 import { useSwapBuildTx } from '../../hooks/useSwapBuiltTx';
 import { useSwapInit } from '../../hooks/useSwapGlobal';
@@ -176,6 +179,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     useSwapProInputAmountAtom();
   const [swapProTradeType] = useSwapProTradeTypeAtom();
   const swapProAccount = useSwapProAccount();
+  const tokenDetailActions = useTokenDetailActions();
 
   const swapFromTokenRef = useRef<ISwapToken | undefined>(undefined);
   if (swapFromTokenRef.current !== fromSelectTokenAtom) {
@@ -287,6 +291,8 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
 
   const onProMarketDetail = useCallback(() => {
     dismissKeyboard();
+    // Clear token detail before navigation to avoid stale data
+    tokenDetailActions.current.clearTokenDetail();
     navigation.pushModal(EModalRoutes.SwapModal, {
       screen: EModalSwapRoutes.SwapProMarketDetail,
       params: {
@@ -299,6 +305,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     });
   }, [
     navigation,
+    tokenDetailActions,
     swapProSelectToken?.contractAddress,
     swapProSelectToken?.networkId,
     swapProSelectToken?.isNative,
@@ -1273,9 +1280,13 @@ const SwapMainLandWithPageType = (props: ISwapMainLoadProps) => {
           : EJotaiContextStoreNames.swap
       }
     >
-      <LazyPageContainer>
-        <SwapMainLoad {...props} pageType={props?.pageType} />
-      </LazyPageContainer>
+      <MarketWatchListProviderMirrorV2
+        storeName={EJotaiContextStoreNames.marketWatchListV2}
+      >
+        <LazyPageContainer>
+          <SwapMainLoad {...props} pageType={props?.pageType} />
+        </LazyPageContainer>
+      </MarketWatchListProviderMirrorV2>
     </SwapProviderMirror>
   );
 };


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved stale token detail state when navigating to market detail screens.

* **Chores**
  * Refactored market watch list provider implementation for improved system architecture and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Add `MarketWatchListProviderMirrorV2` wrapper to `SwapMainLandWithPageType` to provide market context
- Call `clearTokenDetail` action before navigating to market detail page from swap pro
- This prevents showing stale token data when opening a new token detail page

## Test plan
- [ ] Open swap pro, select a token, click the market detail button
- [ ] Verify the token detail page shows fresh data without old token information