### PR TITLE
fix: restore OneKey ID and Prime in webdapp more menu

### DIFF
--- a/packages/kit/src/components/MoreActionButton/index.tsx
+++ b/packages/kit/src/components/MoreActionButton/index.tsx
@@ -952,14 +952,12 @@ function MoreActionGeneralGrid() {
         onPress: handleScan,
         trackID: 'wallet-scan',
       },
-      !platformEnv.isWebDappMode
-        ? {
-            title: 'Prime',
-            icon: 'PrimeOutline' as const,
-            onPress: handlePrime,
-            trackID: 'wallet-prime',
-          }
-        : undefined,
+      {
+        title: 'Prime',
+        icon: 'PrimeOutline' as const,
+        onPress: handlePrime,
+        trackID: 'wallet-prime',
+      },
     ].filter(Boolean);
   }, [handlePrime, handleScan, handleSettings, intl]);
   return (
@@ -1299,7 +1297,7 @@ function BaseMoreActionContent() {
     <YStack flex={1}>
       <ScrollView overflow="scroll" flex={1}>
         {platformEnv.isWebDappMode ? null : <UpdateReminders />}
-        {platformEnv.isWebDappMode ? null : <MoreActionOneKeyId />}
+        <MoreActionOneKeyId />
         {isDesktopMode ? null : <MoreActionDevice />}
         <MoreActionDivider />
         <MoreActionGeneralGrid />
@@ -1335,7 +1333,7 @@ function MoreActionContent({
       <YStack minHeight={560} {...containerStyle}>
         <MoreActionContentHeader />
         {platformEnv.isWebDappMode ? null : <UpdateReminders />}
-        {platformEnv.isWebDappMode ? null : <MoreActionOneKeyId />}
+        <MoreActionOneKeyId />
         {isDesktopMode ? null : <MoreActionDevice />}
         <MoreActionDivider />
         <MoreActionGeneralGrid />


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Prime action now consistently displays in the general actions grid for all users and environments.
  * Update reminders and OneKey ID management features are now available across all supported platforms and configurations.
  * Enhanced consistency ensures uniform feature visibility and functionality regardless of platform type or environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Restore OneKey ID section visibility in webdapp mode
- Restore Prime menu item in webdapp mode General section

These features were previously hidden in commit 02c3b86ec2 for webdapp mode and are now restored.

## Changes
- Remove `platformEnv.isWebDappMode` condition for `MoreActionOneKeyId` component in `BaseMoreActionContent` and `MoreActionContent`
- Remove `!platformEnv.isWebDappMode` condition for Prime menu item in `MoreActionGeneralGrid`

## Test plan
- [ ] Verify OneKey ID section appears in webdapp more menu
- [ ] Verify Prime menu item appears in webdapp more menu General section
- [ ] Verify other platforms (desktop, mobile, extension) are not affected