### PR TITLE
fix: lower window height threshold for market recommend list title

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketRecommendList/MarketRecommendList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketRecommendList/MarketRecommendList.tsx
@@ -36,7 +36,7 @@ export function MarketRecommendList({
     [windowHeight, maxSize],
   );
 
-  const actualShowTitle = useMemo(() => windowHeight > 800, [windowHeight]);
+  const actualShowTitle = useMemo(() => windowHeight > 700, [windowHeight]);
 
   const defaultTokens = useMemo(
     () => recommendedTokens?.slice(0, actualMaxSize) || [],


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive display of the market recommendations list by adjusting the window size threshold for the title section, ensuring better content visibility on smaller screens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Lower the window height threshold from 800px to 700px for showing the market recommend list title

## Changes
- Change `windowHeight > 800` to `windowHeight > 700` in `MarketRecommendList.tsx`

## Test plan
- [ ] Verify title visibility on screens between 700-800px height