### PR TITLE
fix: remove unused identity permission and OAuth2 configuration from Chrome manifest files

### DIFF
--- a/apps/ext/src/manifest/chrome.js
+++ b/apps/ext/src/manifest/chrome.js
@@ -63,7 +63,6 @@ module.exports = {
     '*://*.onekeycn.com/*',
     '*://*.onekeytest.com/*',
     // '*://*.eth/',
-    'identity',
     'storage',
     'unlimitedStorage',
     'webRequest',
@@ -74,18 +73,6 @@ module.exports = {
     // 'webRequest',
     'idle',
   ],
-  // OAuth2 configuration for chrome.identity.getAuthToken
-  // Required for CHROME_GET_AUTH_TOKEN method
-  'oauth2': {
-    'client_id':
-      process.env.GOOGLE_CHROME_EXTENSION_CLIENT_ID ||
-      '244450898872-foi2b6mtfqus1ed46hu5j03abne6b04s.apps.googleusercontent.com',
-    'scopes': [
-      'openid',
-      'https://www.googleapis.com/auth/userinfo.email',
-      'https://www.googleapis.com/auth/userinfo.profile',
-    ],
-  },
 };
 /*
 action:{

--- a/apps/ext/src/manifest/chrome_v3.js
+++ b/apps/ext/src/manifest/chrome_v3.js
@@ -105,7 +105,6 @@ module.exports = {
   },
   'permissions': [
     'offscreen',
-    'identity',
     // 'https://dapp-server.onekey.so/*', // allow CORS requests in firefox
     // 'http://localhost:8545/',
     // 'https://*.infura.io/',
@@ -124,17 +123,4 @@ module.exports = {
     'sidePanel',
     'contextMenus',
   ],
-  // OAuth2 configuration for chrome.identity.getAuthToken
-  // Required for CHROME_GET_AUTH_TOKEN method
-  // The client_id should be a Chrome Extension type OAuth client from Google Cloud Console
-  'oauth2': {
-    'client_id':
-      process.env.GOOGLE_CHROME_EXTENSION_CLIENT_ID ||
-      '244450898872-foi2b6mtfqus1ed46hu5j03abne6b04s.apps.googleusercontent.com',
-    'scopes': [
-      'openid',
-      'https://www.googleapis.com/auth/userinfo.email',
-      'https://www.googleapis.com/auth/userinfo.profile',
-    ],
-  },
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed OAuth2 authentication configuration from the extension manifest.
  * Removed identity permission requirements from the extension.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->