### PR TITLE
fix: adjust discovery mobile search box position on Android OK-48279

### DIFF
--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -472,7 +472,11 @@ function MobileBrowser() {
           width="100%"
           onLayout={handleTabPageLayout}
         >
-          <Stack position="absolute" top={top} px="$5">
+          <Stack
+            position="absolute"
+            top={platformEnv.isNativeAndroid ? top + 5 : top}
+            px="$5"
+          >
             <LegacyUniversalSearchInput
               size="medium"
               initialTab={searchInitialTab}


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the vertical positioning of the search input in the Discovery section on Android devices to improve header layout alignment and visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Adjust the search box position in Discovery mobile view on Android by adding 5px offset from the top

## Changes
- Added platform check to only apply the 5px top offset on Android devices

## Test plan
- [ ] Test on Android device to verify search box position is moved down 5px
- [ ] Test on iOS device to verify search box position remains unchanged