### PR TITLE
perf(home): avoid localTokens rawData bridge payload

### DIFF
--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -37,7 +37,6 @@ import {
 import type { IDBAccount } from '@onekeyhq/kit-bg/src/dbs/local/types';
 import type { ISimpleDBAggregateToken } from '@onekeyhq/kit-bg/src/dbs/simple/entity/SimpleDbEntityAggregateToken';
 import type { ICustomTokenDBStruct } from '@onekeyhq/kit-bg/src/dbs/simple/entity/SimpleDbEntityCustomTokens';
-import type { ISimpleDBLocalTokens } from '@onekeyhq/kit-bg/src/dbs/simple/entity/SimpleDbEntityLocalTokens';
 import type { IRiskTokenManagementDBStruct } from '@onekeyhq/kit-bg/src/dbs/simple/entity/SimpleDbEntityRiskTokenManagement';
 import type { IAllNetworkAccountInfo } from '@onekeyhq/kit-bg/src/services/ServiceAllNetwork/ServiceAllNetwork';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -167,10 +166,6 @@ function TokenListBlock({ tableLayout }: { tableLayout?: boolean }) {
   });
 
   const customTokensRawData = useRef<ICustomTokenDBStruct | undefined>(
-    undefined,
-  );
-
-  const localTokensRawData = useRef<ISimpleDBLocalTokens | undefined>(
     undefined,
   );
 
@@ -898,10 +893,9 @@ function TokenListBlock({ tableLayout }: { tableLayout?: boolean }) {
     }) => {
       perfTokenListView.markStart('allNetworkRequestsStarted_getRawData');
 
-      let [c, r, l, a] = await Promise.all([
+      let [c, r, a] = await Promise.all([
         backgroundApiProxy.simpleDb.customTokens.getRawData(),
         backgroundApiProxy.simpleDb.riskTokenManagement.getRawData(),
-        backgroundApiProxy.simpleDb.localTokens.getRawData(),
         backgroundApiProxy.simpleDb.aggregateToken.getRawData(),
       ]);
 
@@ -917,7 +911,6 @@ function TokenListBlock({ tableLayout }: { tableLayout?: boolean }) {
         unblockedTokens: r?.unblockedTokens ?? {},
         blockedTokens: r?.blockedTokens ?? {},
       };
-      localTokensRawData.current = l ?? undefined;
       aggregateTokenRawData.current = a ?? undefined;
 
       appEventBus.emit(EAppEventBusNames.TabListStateUpdate, {
@@ -949,7 +942,6 @@ function TokenListBlock({ tableLayout }: { tableLayout?: boolean }) {
       perf.markStart('getAccountLocalTokens', {
         networkId,
         accountAddress,
-        rawDataExist: !!localTokensRawData.current,
       });
       const localTokens =
         await backgroundApiProxy.serviceToken.getAccountLocalTokens({
@@ -957,7 +949,6 @@ function TokenListBlock({ tableLayout }: { tableLayout?: boolean }) {
           networkId,
           accountAddress,
           xpub,
-          simpleDbLocalTokensRawData: localTokensRawData.current,
         });
       perf.markEnd('getAccountLocalTokens');
 


### PR DESCRIPTION
# PR 说明：Home 首屏性能优化（All‑Networks）— 避免 localTokens rawData 跨桥传参

> 目标：在不改变业务结果的前提下，减少 Home(All‑Networks) 首屏阶段的 UI↔BG 桥接开销，缩短首页加载金额时间。

## TL;DR（这次 PR 做了什么）

Home(All‑Networks) 首屏会并发触发很多次 `serviceToken.getAccountLocalTokens()` 来做“本地缓存预览”（tokenList/tokenListMap/value 等）。

之前的实现会：
1) UI 侧先读取一次 `simpleDb.localTokens.getRawData()`（这是一个可能很大的对象）；
2) 在后续 20+ 次 `getAccountLocalTokens` 调用里，把这份 rawData 作为 `simpleDbLocalTokensRawData` **从 UI 重复传给 BG**。

这会导致大量的 bridge 序列化/结构化拷贝/（dev 下）可序列化检查开销，拖慢首屏。

本 PR 改为：**不在 UI 侧读取 localTokens rawData，也不把 rawData 当参数跨桥传入 BG**。BG 内部按原逻辑自行读取 SimpleDB。

## 改动范围（代码）

仅改动 UI 侧 Home TokenListBlock：

- `packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx`
  - All‑Networks 启动阶段 `Promise.all` 中移除 `backgroundApiProxy.simpleDb.localTokens.getRawData()`
  - 调用 `backgroundApiProxy.serviceToken.getAccountLocalTokens(...)` 时不再传 `simpleDbLocalTokensRawData`

> 注意：本 PR **不修改** `packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityLocalTokens.ts`，`enableCache` 仍保持 `false`（避免 localTokens 数据量过大导致常驻内存上升）。

## 为什么能提升首屏性能？

本质是减少“跨桥传输大对象”的成本：

- `localTokens` 的 rawData 结构可能包含 `tokenListMap/tokenListValue` 等大字段；
- 在 All‑Networks 首屏阶段，`getAccountLocalTokens` 会被调用很多次；
- 把同一个大对象重复跨桥传参，会产生 **N 倍** 的序列化/拷贝/校验开销，容易把 UI 主线程和 bridge 打满，从而拉长 `Home:done:tokens`，并引入 `jsblock`。

移除该参数后，跨桥 payload 只剩下小参数（`accountId/networkId/accountAddress/xpub`），桥接成本显著下降。

## 为什么不会影响正确性？

这次改动不改变“数据来源”和“取数逻辑”，只改变 rawData 的传递方式：

1) `simpleDbLocalTokensRawData` 本来就是 **可选的性能参数**  
   - `packages/kit-bg/src/services/ServiceToken.ts:739`：`simpleDbLocalTokensRawData?: ISimpleDBLocalTokens`

2) BG 侧读取 rawData 有明确的 fallback（不传参也能工作）  
   - `packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityLocalTokens.ts:261`：  
     `const rawData = simpleDbLocalTokensRawData ?? (await this.getRawData());`

3) 查询 key 与字段读取逻辑不变  
   - 仍使用 `buildAccountLocalAssetsKey(...)` 得到 key
   - 仍从 `rawData.tokenList / tokenListMap / tokenListValue` 中按 key 取值

因此最终展示的 token 列表/余额/小额/风险标记等“业务结果”应保持一致；差异只可能是“时序上更接近当前 BG 数据”（不会比 UI 快照更差）。

## 风险评估 / trade‑offs

- **内存风险**：未启用 `localTokens` 全量 rawData 常驻缓存（`enableCache=false`），避免 token 数据很大时内存上涨。
- **I/O trade‑off**：不再把 rawData 作为参数传入后，BG 侧可能会更频繁调用 `getRawData()`（尤其在 burst 并发时）；但该成本发生在 BG 内部，不再触发大对象跨桥搬运，整体仍是明显净收益。
- **后续可选优化**（不在本 PR）：如果要进一步降低 burst 并发下的重复 storage read，可考虑在 BG `getRawData` 层做 **in-flight 去重（只共享 pending Promise，不保留结果）**，以保持正确性风险可控。

## QA Checklist（建议回归项）

- All‑Networks Home：token 列表是否能正常快速出现（包含 smallBalance/risky）
- 切换账号/切换网络：token 列表是否正确、无空白/闪烁异常
- 冷启动/热启动：首屏 loading 是否提前、`Home:done:tokens` 是否更稳定

