### PR TITLE
fix: use transparent color value as fallback for invalid Reanimated colors(OK-48511)

### DIFF
--- a/patches/react-native-reanimated+4.2.1.patch
+++ b/patches/react-native-reanimated+4.2.1.patch
@@ -1,22 +1,19 @@
 diff --git a/node_modules/react-native-reanimated/src/common/style/processors/colors.ts b/node_modules/react-native-reanimated/src/common/style/processors/colors.ts
-index 42d2c09..da78036 100644
+index 42d2c09..57dd400 100644
 --- a/node_modules/react-native-reanimated/src/common/style/processors/colors.ts
 +++ b/node_modules/react-native-reanimated/src/common/style/processors/colors.ts
-@@ -204,7 +204,11 @@ export function processColor(
+@@ -204,6 +204,9 @@ export function processColor(
    }
  
    if (result === null) {
--    throw new ReanimatedError(ERROR_MESSAGES.invalidColor(value));
 +    if (process.env.NODE_ENV === 'production') { 
-+      return false as unknown as number;
-+    } else {
-+      throw new ReanimatedError(ERROR_MESSAGES.invalidColor(value));
++      return 0x00000000;
 +    }
+     throw new ReanimatedError(ERROR_MESSAGES.invalidColor(value));
    }
  
-   return result;
 diff --git a/node_modules/react-native-reanimated/src/css/svg/native/processors/colors.ts b/node_modules/react-native-reanimated/src/css/svg/native/processors/colors.ts
-index 7682466..f8c1b53 100644
+index 7682466..2eef347 100644
 --- a/node_modules/react-native-reanimated/src/css/svg/native/processors/colors.ts
 +++ b/node_modules/react-native-reanimated/src/css/svg/native/processors/colors.ts
 @@ -29,5 +29,8 @@ export const processColorSVG: ValueProcessor<
@@ -24,7 +21,7 @@ index 7682466..f8c1b53 100644
    }
  
 +  if (process.env.NODE_ENV === 'production') {
-+    return false;
++    return 0x00000000;
 +  }
    throw new ReanimatedError(ERROR_MESSAGES.invalidColor(value));
  };


### PR DESCRIPTION
Return 0x00000000 (transparent) instead of false when color processing fails in production mode to prevent type errors and crashes.