### PR TITLE
fix(perp): resolve multiple UI and data sync issues OK-45934 OK-45460 OK-48477 OK-48479 OK-48208

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -382,6 +382,13 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   }
 
   @backgroundMethod()
+  async forceReloadCandlesWebview(): Promise<void> {
+    await perpsCandlesWebviewReloadHookAtom.set({
+      reloadHook: Date.now(),
+    });
+  }
+
+  @backgroundMethod()
   async getSubscriptionsHandlerDisabledCount(): Promise<number> {
     return this.subscriptionsHandlerDisabledCount;
   }

--- a/packages/kit/src/hooks/usePerpFeatureGuard.ts
+++ b/packages/kit/src/hooks/usePerpFeatureGuard.ts
@@ -27,3 +27,10 @@ export function usePerpFeatureGuard() {
 
   return !perpDisabled;
 }
+
+export function useNativePerpFeatureGuard() {
+  const canRender = usePerpFeatureGuard();
+  const { perpTabShowWeb } = usePerpTabConfig();
+
+  return canRender && !perpTabShowWeb;
+}

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -377,9 +377,9 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
         );
 
         if (isSnapshot) {
-          const sortedUpdates = [...incomingUpdates].sort(
-            (a, b) => b.time - a.time,
-          );
+          const sortedUpdates = [...incomingUpdates]
+            .sort((a, b) => b.time - a.time)
+            .slice(0, 200);
           set(perpsLedgerUpdatesAtom(), {
             accountAddress: activeAccountAddress,
             updates: sortedUpdates,
@@ -395,7 +395,9 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
             (update) => !existingHashes.has(update.hash),
           );
           const mergedUpdates = [...newUpdates, ...existingUpdates];
-          const sortedUpdates = mergedUpdates.sort((a, b) => b.time - a.time);
+          const sortedUpdates = mergedUpdates
+            .sort((a, b) => b.time - a.time)
+            .slice(0, 200);
 
           set(perpsLedgerUpdatesAtom(), {
             accountAddress: activeAccountAddress,

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -509,6 +509,8 @@ function useHyperliquidScreenLockHandler() {
         // Screen unlocked - restore status
         if (isFocusedRef.current) {
           void checkPerpsAccountStatus();
+          // Force reload TradingView Candles WebView to fix data gap after screen unlock
+          void backgroundApiProxy.serviceHyperliquidSubscription.forceReloadCandlesWebview();
         }
       } else {
         // Screen locked - dispose clients

--- a/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
@@ -325,7 +325,7 @@ function MobileTokenSelectorModal({
         borderBottomColor="$borderSubdued"
       >
         <XStack flex={1}>
-          {(['all', 'hip3', 'favorites'] as const).map((tabKey) => (
+          {(['favorites', 'all', 'hip3'] as const).map((tabKey) => (
             <TabItem
               key={tabKey}
               name={TAB_LABELS[tabKey]}

--- a/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
@@ -19,6 +19,7 @@ import {
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
 import { usePerpTokenSelectorConfigPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type {
   IPerpTokenSelectorConfig,
   IPerpTokenSortField,
@@ -405,13 +406,20 @@ function MobileTokenSelectorModal({
       <Page.Body>
         <YStack flex={1} mt="$2">
           <ListView
+            // Force FlashList recreation on native to fix recycling pool bug
+            key={
+              platformEnv.isNative
+                ? `${activeTab}-${selectorConfig?.field ?? ''}-${
+                    selectorConfig?.direction ?? ''
+                  }`
+                : undefined
+            }
             useFlashList
             ref={listRef}
             keyExtractor={keyExtractor}
             estimatedItemSize={44}
-            windowSize={4}
-            initialNumToRender={10}
-            removeClippedSubviews
+            windowSize={5}
+            initialNumToRender={15}
             decelerationRate="normal"
             showsVerticalScrollIndicator
             contentContainerStyle={{

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -544,6 +544,11 @@ function BasePerpTokenSelectorContent({
             />
           )}
         >
+          <Tabs.Tab name={tabNames.favorites}>
+            {activeTab === 'favorites'
+              ? renderTokenList(listDataByTab.favorites, listRefFavorites)
+              : null}
+          </Tabs.Tab>
           <Tabs.Tab name={tabNames.all}>
             {activeTab === 'all'
               ? renderTokenList(listDataByTab.all, listRefAll, false)
@@ -552,11 +557,6 @@ function BasePerpTokenSelectorContent({
           <Tabs.Tab name={tabNames.hip3}>
             {activeTab === 'hip3'
               ? renderTokenList(listDataByTab.hip3, listRefHip3, false)
-              : null}
-          </Tabs.Tab>
-          <Tabs.Tab name={tabNames.favorites}>
-            {activeTab === 'favorites'
-              ? renderTokenList(listDataByTab.favorites, listRefFavorites, true)
               : null}
           </Tabs.Tab>
         </Tabs.Container>

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -993,6 +993,7 @@ function DepositWithdrawContent({
                   isArbUSDCOrder: true,
                 });
               }
+              void backgroundApiProxy.serviceHyperliquidSubscription.enableLedgerUpdatesSubscription();
               onClose?.();
             },
             transfersInfo: [
@@ -1006,6 +1007,7 @@ function DepositWithdrawContent({
           });
         } else {
           await buildPerpDepositTx();
+          void backgroundApiProxy.serviceHyperliquidSubscription.enableLedgerUpdatesSubscription();
           onClose?.();
         }
       } else {
@@ -1014,6 +1016,7 @@ function DepositWithdrawContent({
           amount,
           destination: selectedAccount.accountAddress,
         });
+        void backgroundApiProxy.serviceHyperliquidSubscription.enableLedgerUpdatesSubscription();
         onClose?.();
       }
     } catch (error) {

--- a/packages/kit/src/views/Perp/pages/Perp.tsx
+++ b/packages/kit/src/views/Perp/pages/Perp.tsx
@@ -19,7 +19,7 @@ import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import { LazyPageContainer } from '../../../components/LazyPageContainer';
 import { TabPageHeader } from '../../../components/TabPageHeader';
-import { usePerpFeatureGuard } from '../../../hooks/usePerpFeatureGuard';
+import { useNativePerpFeatureGuard } from '../../../hooks/usePerpFeatureGuard';
 import { HyperliquidTermsOverlay } from '../components/HyperliquidTerms';
 import { PerpContentFooter } from '../components/PerpContentFooter';
 import { PerpsGlobalEffects } from '../components/PerpsGlobalEffects';
@@ -130,7 +130,7 @@ function ExtPerpNull() {
 }
 
 export default function Perp() {
-  const canRenderPerp = usePerpFeatureGuard();
+  const canRenderPerp = useNativePerpFeatureGuard();
   if (!canRenderPerp) {
     return shouldOpenExpandExtPerp ? <ExtPerpNull /> : null;
   }


### PR DESCRIPTION
## Changes

### UI Fixes
- Fix FlashList recycling pool bug in MobileTokenSelector on native platforms
- Reorder tabs in MobileTokenSelector and restore favorites tab in PerpTokenSelector
- Adjust FlashList rendering parameters for better performance

### Data Sync Enhancements
- Force reload TradingView Candles WebView on screen unlock to prevent data gaps
- Enable ledger subscription after deposit/withdraw operations
- Limit ledger updates to 200 entries to improve memory usage

### Platform Support
- Add useNativePerpFeatureGuard hook for native platform feature checks