### PR TITLE
fix: upgrade react-native-safe-area-context to 5.6.2 for RN 0.81 compatibility

### DIFF
--- a/.env.version
+++ b/.env.version
@@ -1,6 +1,6 @@
 # VERSION: https://semver.org/
 
-VERSION=5.19.3
+VERSION=5.19.4
 BUNDLE_VERSION=2
 
 # Will auto add BUILD_NUMBER variable at native CI job.Must give an empty line at end of this file.

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -132,7 +132,7 @@
     "react-native-qrcode-styled": "0.4.0",
     "react-native-reanimated": "3.19.4",
     "react-native-restart": "npm:react-native-restart-newarch@1.0.80",
-    "react-native-safe-area-context": "5.4.1",
+    "react-native-safe-area-context": "5.6.2",
     "react-native-screens": "4.18.0",
     "react-native-svg": "15.12.1",
     "react-native-tcp-socket": "6.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7982,7 +7982,7 @@ __metadata:
     react-native-qrcode-styled: "npm:0.4.0"
     react-native-reanimated: "npm:3.19.4"
     react-native-restart: "npm:react-native-restart-newarch@1.0.80"
-    react-native-safe-area-context: "npm:5.4.1"
+    react-native-safe-area-context: "npm:5.6.2"
     react-native-screens: "npm:4.18.0"
     react-native-svg: "npm:15.12.1"
     react-native-tcp-socket: "npm:6.3.0"
@@ -34853,13 +34853,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-safe-area-context@npm:5.4.1":
-  version: 5.4.1
-  resolution: "react-native-safe-area-context@npm:5.4.1"
+"react-native-safe-area-context@npm:5.6.2":
+  version: 5.6.2
+  resolution: "react-native-safe-area-context@npm:5.6.2"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10/1d8de402c4af8ee1bd00dec0c2fdb35b34ba64a62d7e235884c98216a2068f8d89e5bb89f27d2e9cd711ee9b173d9aafde53ebd2b39e64d0a1e83567de95305b
+  checksum: 10/880d87ee60119321b366eef2c151ecefe14f5bc0d39cf5cfbfb167684e571d3dae2600ee19b9bc8521f5726eb285abecaa7aafb1a3b213529dafbac24703d302
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Upgrade `react-native-safe-area-context` from 5.4.1 to 5.6.2
- Fixes Android crash on startup with Fabric/New Architecture
- Version 5.6.0+ adds proper React Native 0.81 support

## Problem
Android app crashes immediately on launch with the following stack trace:
```
abort → free → RNCSafeAreaViewProps::~RNCSafeAreaViewProps()
  → RawPropsParser::prepare<RNCSafeAreaViewProps>
    → ComponentDescriptorRegistry::add
      → FabricUIManagerBinding::installFabricUIManager
```

This is caused by `react-native-safe-area-context` 5.4.1 not being compatible with React Native 0.81's updated Fabric architecture.

## Solution
Upgrade to version 5.6.2 which includes RN 0.81 support (added in 5.6.0).

## Test plan
- [ ] Build and run Android app
- [ ] Verify app launches without crash
- [ ] Test SafeAreaView functionality

🤖 Generated with [Claude Code](https://claude.ai/code)