### PR TITLE
feat(notifications): add UnifiedPush support for privacy-friendly pus…

### DIFF
--- a/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/MainApplication.java
+++ b/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/MainApplication.java
@@ -48,6 +48,7 @@ public class MainApplication extends Application implements ReactApplication {
         packages.add(new ExitPackage());
         packages.add(new WebViewCheckerPackage());
         packages.add(new LaunchOptionPackage());
+        packages.add(new UnifiedPushPackage()); // UnifiedPush for privacy-friendly push notifications
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
           packages.add(new SplashScreenPackage());
         }

--- a/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/UnifiedPushModule.java
+++ b/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/UnifiedPushModule.java
@@ -1,0 +1,277 @@
+package so.onekey.app.wallet;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.content.SharedPreferences;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+
+import java.util.List;
+
+/**
+ * UnifiedPush Native Module for React Native
+ *
+ * This module provides the bridge between React Native and the UnifiedPush
+ * Android library. UnifiedPush is an open standard for push notifications
+ * that respects user privacy.
+ *
+ * Implementation Notes:
+ * ---------------------
+ * This is a stub implementation. To fully implement UnifiedPush, you need to:
+ *
+ * 1. Add the UnifiedPush library to your build.gradle:
+ *    implementation 'org.unifiedpush.android:connector:2.1.1'
+ *
+ * 2. Create a UnifiedPush receiver class that extends MessagingReceiver
+ *
+ * 3. Register the receiver in AndroidManifest.xml
+ *
+ * 4. Implement the actual push registration logic
+ *
+ * @see <a href="https://unifiedpush.org/developers/android/">UnifiedPush Android Docs</a>
+ */
+public class UnifiedPushModule extends ReactContextBaseJavaModule {
+
+    private static final String MODULE_NAME = "UnifiedPushModule";
+    private static final String PREFS_NAME = "UnifiedPushPrefs";
+    private static final String KEY_DISTRIBUTOR = "distributor";
+    private static final String KEY_ENDPOINT = "endpoint";
+    private static final String KEY_INSTANCE = "instance";
+
+    private final ReactApplicationContext reactContext;
+    private SharedPreferences preferences;
+
+    public UnifiedPushModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+        this.reactContext = reactContext;
+        this.preferences = reactContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+    }
+
+    @Override
+    public String getName() {
+        return MODULE_NAME;
+    }
+
+    /**
+     * Initialize the UnifiedPush connector.
+     * This should be called when the app starts.
+     */
+    @ReactMethod
+    public void initialize(Promise promise) {
+        try {
+            // TODO: Initialize UnifiedPush connector
+            // Up.initialize(reactContext, "instance-name");
+            promise.resolve(true);
+        } catch (Exception e) {
+            promise.reject("INIT_ERROR", "Failed to initialize UnifiedPush", e);
+        }
+    }
+
+    /**
+     * Register for push notifications.
+     * This will prompt the user to select a distributor if none is selected.
+     *
+     * @param instance A unique identifier for this registration (e.g., instanceId)
+     */
+    @ReactMethod
+    public void registerForPush(String instance, Promise promise) {
+        try {
+            // TODO: Implement actual registration
+            // Up.register(reactContext, instance);
+            
+            // Store instance
+            preferences.edit().putString(KEY_INSTANCE, instance).apply();
+            
+            promise.resolve(true);
+        } catch (Exception e) {
+            promise.reject("REGISTER_ERROR", "Failed to register for push", e);
+        }
+    }
+
+    /**
+     * Unregister from push notifications.
+     *
+     * @param instance The instance identifier used during registration
+     */
+    @ReactMethod
+    public void unregisterForPush(String instance, Promise promise) {
+        try {
+            // TODO: Implement actual unregistration
+            // Up.unregister(reactContext, instance);
+            
+            // Clear stored data
+            preferences.edit()
+                .remove(KEY_ENDPOINT)
+                .remove(KEY_INSTANCE)
+                .apply();
+            
+            promise.resolve(true);
+        } catch (Exception e) {
+            promise.reject("UNREGISTER_ERROR", "Failed to unregister from push", e);
+        }
+    }
+
+    /**
+     * Get the currently selected distributor.
+     */
+    @ReactMethod
+    public void getDistributor(Promise promise) {
+        try {
+            String distributor = preferences.getString(KEY_DISTRIBUTOR, null);
+            promise.resolve(distributor);
+        } catch (Exception e) {
+            promise.reject("GET_DISTRIBUTOR_ERROR", "Failed to get distributor", e);
+        }
+    }
+
+    /**
+     * Get list of available UnifiedPush distributors on the device.
+     * A distributor is an app that can receive push messages and deliver them.
+     */
+    @ReactMethod
+    public void getDistributors(Promise promise) {
+        try {
+            WritableArray distributors = Arguments.createArray();
+            
+            // Query for apps that can handle UnifiedPush intents
+            Intent intent = new Intent("org.unifiedpush.android.connector.MESSAGE");
+            PackageManager pm = reactContext.getPackageManager();
+            List<ResolveInfo> resolveInfos = pm.queryBroadcastReceivers(intent, 0);
+            
+            for (ResolveInfo info : resolveInfos) {
+                WritableMap distributor = Arguments.createMap();
+                distributor.putString("packageName", info.activityInfo.packageName);
+                distributor.putString("name", info.loadLabel(pm).toString());
+                distributors.pushMap(distributor);
+            }
+            
+            promise.resolve(distributors);
+        } catch (Exception e) {
+            promise.reject("GET_DISTRIBUTORS_ERROR", "Failed to get distributors", e);
+        }
+    }
+
+    /**
+     * Select a UnifiedPush distributor.
+     * This should be called before registering for push.
+     *
+     * @param packageName The package name of the distributor app
+     */
+    @ReactMethod
+    public void selectDistributor(String packageName, Promise promise) {
+        try {
+            // TODO: Implement actual distributor selection
+            // Up.saveDistributor(reactContext, packageName);
+            
+            preferences.edit().putString(KEY_DISTRIBUTOR, packageName).apply();
+            promise.resolve(true);
+        } catch (Exception e) {
+            promise.reject("SELECT_DISTRIBUTOR_ERROR", "Failed to select distributor", e);
+        }
+    }
+
+    /**
+     * Get the current push endpoint URL.
+     * This is the URL that the server should use to send push messages.
+     *
+     * @param instance The instance identifier
+     */
+    @ReactMethod
+    public void getEndpoint(String instance, Promise promise) {
+        try {
+            String endpoint = preferences.getString(KEY_ENDPOINT, null);
+            promise.resolve(endpoint);
+        } catch (Exception e) {
+            promise.reject("GET_ENDPOINT_ERROR", "Failed to get endpoint", e);
+        }
+    }
+
+    /**
+     * Check if currently registered for push notifications.
+     *
+     * @param instance The instance identifier
+     */
+    @ReactMethod
+    public void isRegistered(String instance, Promise promise) {
+        try {
+            String storedInstance = preferences.getString(KEY_INSTANCE, null);
+            String endpoint = preferences.getString(KEY_ENDPOINT, null);
+            boolean registered = instance.equals(storedInstance) && endpoint != null;
+            promise.resolve(registered);
+        } catch (Exception e) {
+            promise.reject("IS_REGISTERED_ERROR", "Failed to check registration", e);
+        }
+    }
+
+    /**
+     * Send an event to React Native.
+     * Called from the UnifiedPush receiver when messages arrive.
+     */
+    public void sendEvent(String eventType, WritableMap params) {
+        if (reactContext.hasActiveReactInstance()) {
+            params.putString("type", eventType);
+            reactContext
+                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                .emit("UnifiedPushEvent", params);
+        }
+    }
+
+    /**
+     * Store the endpoint when received from the distributor.
+     * Called from the UnifiedPush receiver.
+     */
+    public void onNewEndpoint(String endpoint, String instance) {
+        preferences.edit().putString(KEY_ENDPOINT, endpoint).apply();
+        
+        WritableMap params = Arguments.createMap();
+        params.putString("endpoint", endpoint);
+        params.putString("instance", instance);
+        sendEvent("newEndpoint", params);
+    }
+
+    /**
+     * Handle incoming push message.
+     * Called from the UnifiedPush receiver.
+     */
+    public void onMessage(String message, String instance) {
+        WritableMap params = Arguments.createMap();
+        params.putString("message", message);
+        params.putString("instance", instance);
+        sendEvent("message", params);
+    }
+
+    /**
+     * Handle unregistration event.
+     * Called from the UnifiedPush receiver.
+     */
+    public void onUnregistered(String instance) {
+        preferences.edit()
+            .remove(KEY_ENDPOINT)
+            .remove(KEY_INSTANCE)
+            .apply();
+        
+        WritableMap params = Arguments.createMap();
+        params.putString("instance", instance);
+        sendEvent("unregistered", params);
+    }
+
+    /**
+     * Handle registration failure.
+     * Called from the UnifiedPush receiver.
+     */
+    public void onRegistrationFailed(String instance, String error) {
+        WritableMap params = Arguments.createMap();
+        params.putString("instance", instance);
+        params.putString("error", error);
+        sendEvent("registrationFailed", params);
+    }
+}

--- a/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/UnifiedPushPackage.java
+++ b/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/UnifiedPushPackage.java
@@ -1,0 +1,31 @@
+package so.onekey.app.wallet;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * React Native Package for UnifiedPush Module
+ * 
+ * This package registers the UnifiedPushModule so it can be accessed
+ * from JavaScript/TypeScript code in React Native.
+ */
+public class UnifiedPushPackage implements ReactPackage {
+
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+        modules.add(new UnifiedPushModule(reactContext));
+        return modules;
+    }
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+}

--- a/docs/UNIFIED_PUSH.md
+++ b/docs/UNIFIED_PUSH.md
@@ -1,0 +1,239 @@
+# UnifiedPush Integration
+
+## Overview
+
+UnifiedPush is an open-source, privacy-friendly push notification specification that allows users to choose their own push notification provider (distributor). This provides significant privacy benefits compared to proprietary solutions like Google FCM or JPush.
+
+## Benefits
+
+- **No Google Play Services Required**: Works on degoogled Android devices (GrapheneOS, LineageOS, etc.)
+- **User-Controlled**: Users choose their own push provider
+- **Self-Hostable**: Users can run their own push server
+- **No Third-Party Data Collection**: Push messages don't go through Google or other third parties
+- **End-to-End Encryption**: Possible with compatible distributors
+
+## Architecture
+
+```
+┌─────────────┐    ┌─────────────┐    ┌─────────────┐
+│   OneKey    │    │ UnifiedPush │    │   OneKey    │
+│   Server    │───▶│ Distributor │───▶│    App      │
+└─────────────┘    │   (ntfy,    │    └─────────────┘
+                   │  NextPush)  │
+                   └─────────────┘
+```
+
+1. **App** registers with a UnifiedPush distributor installed on the device
+2. **Distributor** provides an endpoint URL to the app
+3. **App** sends the endpoint URL to the OneKey server
+4. **Server** sends push messages to the endpoint URL
+5. **Distributor** delivers the message to the app
+
+## Supported Distributors
+
+Users can install any UnifiedPush-compatible distributor:
+
+| Distributor | Description | Privacy Level |
+|-------------|-------------|---------------|
+| [ntfy](https://ntfy.sh) | Simple HTTP-based pub-sub. Self-hostable. | High |
+| [NextPush](https://github.com/UP-NextPush/android) | Push via Nextcloud server | High |
+| [UP-FCM](https://github.com/nicoretti/up-fcm-distributor) | Uses Google FCM as transport | Low |
+| [Molly UnifiedPush](https://github.com/nicoretti/up-fcm-distributor) | From the Molly Signal fork | High |
+
+## Implementation
+
+### Files Added/Modified
+
+#### Core Provider
+- `packages/kit-bg/src/services/ServiceNotification/PushProvider/PushProviderUnifiedPush.ts`
+  - Main UnifiedPush provider implementation
+  - Handles registration, message receiving, and event emission
+
+#### Types
+- `packages/shared/types/notification.ts`
+  - Added `unifiedpush_connected` event
+  - Added `unifiedPushEndpoint` to push client
+  - Added `unifiedpush` as a push source
+  - Added UnifiedPush settings fields
+
+#### Service
+- `packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts`
+  - Added UnifiedPush connection handler
+  - Updated notification display logic for UnifiedPush
+
+#### Settings
+- `packages/kit-bg/src/states/jotai/atoms/devSettings.ts`
+  - Added `disabledUnifiedPush` and `preferUnifiedPush` settings
+
+#### UI
+- `packages/kit/src/views/Setting/pages/Notifications/UnifiedPushSettings.tsx`
+  - User-facing settings component
+- `packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/NotificationDevSettings.tsx`
+  - Developer settings toggles
+
+#### Utilities
+- `packages/shared/src/utils/unifiedPushUtils.ts`
+  - Helper functions and known distributor list
+
+#### Android Native Module
+- `apps/mobile/android/app/src/main/java/so/onekey/app/wallet/UnifiedPushModule.java`
+  - React Native bridge module (stub implementation)
+- `apps/mobile/android/app/src/main/java/so/onekey/app/wallet/UnifiedPushPackage.java`
+  - Package registration
+
+## Completing the Android Implementation
+
+The provided Android module is a stub. To fully implement UnifiedPush:
+
+### 1. Add Dependencies
+
+In `apps/mobile/android/app/build.gradle`:
+
+```gradle
+dependencies {
+    implementation 'org.unifiedpush.android:connector:2.1.1'
+}
+```
+
+### 2. Create a Message Receiver
+
+Create `UnifiedPushReceiver.java`:
+
+```java
+package so.onekey.app.wallet;
+
+import android.content.Context;
+import org.unifiedpush.android.connector.MessagingReceiver;
+
+public class UnifiedPushReceiver extends MessagingReceiver {
+    
+    public UnifiedPushReceiver() {
+        super();
+    }
+    
+    @Override
+    public void onNewEndpoint(Context context, String endpoint, String instance) {
+        // Get the module and notify React Native
+        // UnifiedPushModule.getInstance().onNewEndpoint(endpoint, instance);
+    }
+    
+    @Override
+    public void onMessage(Context context, byte[] message, String instance) {
+        String messageStr = new String(message);
+        // UnifiedPushModule.getInstance().onMessage(messageStr, instance);
+    }
+    
+    @Override
+    public void onUnregistered(Context context, String instance) {
+        // UnifiedPushModule.getInstance().onUnregistered(instance);
+    }
+    
+    @Override
+    public void onRegistrationFailed(Context context, String instance) {
+        // UnifiedPushModule.getInstance().onRegistrationFailed(instance, "Registration failed");
+    }
+}
+```
+
+### 3. Register the Receiver
+
+In `AndroidManifest.xml`:
+
+```xml
+<receiver
+    android:name=".UnifiedPushReceiver"
+    android:exported="true"
+    android:enabled="true">
+    <intent-filter>
+        <action android:name="org.unifiedpush.android.connector.MESSAGE"/>
+        <action android:name="org.unifiedpush.android.connector.UNREGISTERED"/>
+        <action android:name="org.unifiedpush.android.connector.NEW_ENDPOINT"/>
+        <action android:name="org.unifiedpush.android.connector.REGISTRATION_FAILED"/>
+    </intent-filter>
+</receiver>
+```
+
+### 4. Update the Module
+
+Update `UnifiedPushModule.java` to use the UnifiedPush library:
+
+```java
+import org.unifiedpush.android.connector.UnifiedPush;
+
+@ReactMethod
+public void registerForPush(String instance, Promise promise) {
+    try {
+        UnifiedPush.registerApp(reactContext, instance, new ArrayList<>(), "OneKey");
+        preferences.edit().putString(KEY_INSTANCE, instance).apply();
+        promise.resolve(true);
+    } catch (Exception e) {
+        promise.reject("REGISTER_ERROR", "Failed to register for push", e);
+    }
+}
+```
+
+## Server-Side Integration
+
+The server needs to:
+
+1. Accept the UnifiedPush endpoint URL during client registration
+2. Send push messages via HTTP POST to the endpoint URL
+3. Message format:
+
+```json
+{
+    "title": "Transaction Received",
+    "message": "You received 0.5 ETH",
+    "data": {
+        "msgId": "unique-message-id",
+        "topic": "accountActivity",
+        "params": {
+            "networkId": "evm--1",
+            "transactionHash": "0x..."
+        }
+    }
+}
+```
+
+Example using curl:
+
+```bash
+curl -X POST \
+    -H "Content-Type: application/json" \
+    -d '{"title":"Test","message":"Hello from OneKey"}' \
+    https://ntfy.sh/your-endpoint-topic
+```
+
+## iOS Support
+
+UnifiedPush is primarily an Android specification. For iOS:
+
+- Continue using APNs (Apple Push Notification Service) as the primary push method
+- The app already supports APNs through expo-notifications
+- Consider adding support for alternative iOS push solutions in the future
+
+## Testing
+
+1. Install a UnifiedPush distributor (e.g., ntfy from F-Droid)
+2. Open OneKey app settings
+3. Navigate to Notifications > UnifiedPush
+4. Select the distributor
+5. Register for push notifications
+6. Verify the endpoint is received
+7. Send a test push message to the endpoint
+
+## Privacy Comparison
+
+| Provider | Google Services | Data to Third Party | Self-Hostable |
+|----------|-----------------|---------------------|---------------|
+| UnifiedPush | ❌ | ❌ (with self-hosted) | ✅ |
+| JPush | ❌ | ✅ | ❌ |
+| FCM | ✅ | ✅ | ❌ |
+| WebSocket | ❌ | ❌ | ✅ |
+
+## Resources
+
+- [UnifiedPush Website](https://unifiedpush.org/)
+- [UnifiedPush Android Documentation](https://unifiedpush.org/developers/android/)
+- [UnifiedPush Distributors List](https://unifiedpush.org/users/distributors/)
+- [ntfy](https://ntfy.sh/) - Popular self-hosted option

--- a/packages/kit-bg/src/services/ServiceNotification/NotificationProvider/NotificationProvider.native.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/NotificationProvider/NotificationProvider.native.ts
@@ -34,6 +34,7 @@ import {
 } from '@onekeyhq/shared/types/notification';
 
 import { PushProviderJPush } from '../PushProvider/PushProviderJPush';
+import { PushProviderUnifiedPush } from '../PushProvider/PushProviderUnifiedPush';
 
 import NotificationProviderBase from './NotificationProviderBase';
 
@@ -50,9 +51,12 @@ export default class NotificationProvider extends NotificationProviderBase {
     void this.configureNotifications();
     this.initWebSocketProvider();
     this.initJPushProvider();
+    this.initUnifiedPushProvider();
   }
 
   jpushProvider: PushProviderJPush | undefined;
+
+  unifiedPushProvider: PushProviderUnifiedPush | undefined;
 
   initJPushProvider() {
     if (this.options.disabledJPush) {
@@ -63,6 +67,24 @@ export default class NotificationProvider extends NotificationProviderBase {
       instanceId: this.options.instanceId,
       backgroundApi: this.backgroundApi,
     });
+  }
+
+  initUnifiedPushProvider() {
+    if (this.options.disabledUnifiedPush) {
+      return;
+    }
+    this.unifiedPushProvider = new PushProviderUnifiedPush({
+      eventEmitter: this.eventEmitter,
+      instanceId: this.options.instanceId,
+      backgroundApi: this.backgroundApi,
+    });
+  }
+
+  /**
+   * Get the UnifiedPush provider instance for configuration
+   */
+  getUnifiedPushProvider(): PushProviderUnifiedPush | undefined {
+    return this.unifiedPushProvider;
   }
 
   private async configureNotifications() {

--- a/packages/kit-bg/src/services/ServiceNotification/NotificationProvider/NotificationProviderBase.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/NotificationProvider/NotificationProviderBase.ts
@@ -18,6 +18,7 @@ import type { IBackgroundApi } from '../../../apis/IBackgroundApi';
 export type INotificationProviderBaseOptions = {
   disabledWebSocket?: boolean;
   disabledJPush?: boolean;
+  disabledUnifiedPush?: boolean;
   instanceId: string;
 };
 export type INotificationProviderBaseParams = {

--- a/packages/kit-bg/src/services/ServiceNotification/PushProvider/PushProviderUnifiedPush.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/PushProvider/PushProviderUnifiedPush.ts
@@ -1,0 +1,394 @@
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import type { INotificationPushMessageInfo } from '@onekeyhq/shared/types/notification';
+import { EPushProviderEventNames } from '@onekeyhq/shared/types/notification';
+
+import { PushProviderBase } from './PushProviderBase';
+
+import type { IPushProviderBaseProps } from './PushProviderBase';
+
+/**
+ * UnifiedPush Provider
+ *
+ * UnifiedPush is an open standard for push notifications that respects user privacy.
+ * It allows users to choose their own push notification provider (distributor),
+ * eliminating the need for Google Play Services or proprietary push services.
+ *
+ * Flow:
+ * 1. User installs a UnifiedPush distributor app (e.g., ntfy, NextPush, UP-FCM)
+ * 2. App registers with the distributor to get an endpoint URL
+ * 3. Endpoint URL is sent to the app's server
+ * 4. Server sends push messages to the endpoint URL
+ * 5. Distributor delivers messages to the app
+ *
+ * @see https://unifiedpush.org/
+ */
+
+export interface IUnifiedPushMessage {
+  title?: string;
+  message: string;
+  priority?: number;
+  // Custom data payload
+  data?: Record<string, unknown>;
+}
+
+export interface IUnifiedPushEndpoint {
+  endpoint: string;
+  pubKey?: string;
+  auth?: string;
+}
+
+export interface IUnifiedPushDistributor {
+  packageName: string;
+  name: string;
+}
+
+export type UnifiedPushEventType =
+  | 'registered'
+  | 'unregistered'
+  | 'message'
+  | 'newEndpoint'
+  | 'registrationFailed'
+  | 'unregistrationFailed';
+
+export interface IUnifiedPushEventPayload {
+  type: UnifiedPushEventType;
+  endpoint?: string;
+  message?: string;
+  instance?: string;
+  error?: string;
+}
+
+// Native module interface - will be implemented in native code
+interface IUnifiedPushNativeModule {
+  initialize(): Promise<void>;
+  registerForPush(instance: string): Promise<void>;
+  unregisterForPush(instance: string): Promise<void>;
+  getDistributor(): Promise<string | null>;
+  getDistributors(): Promise<IUnifiedPushDistributor[]>;
+  selectDistributor(packageName: string): Promise<void>;
+  getEndpoint(instance: string): Promise<string | null>;
+  isRegistered(instance: string): Promise<boolean>;
+}
+
+// This will be imported from the native module when implemented
+let UnifiedPushModule: IUnifiedPushNativeModule | null = null;
+
+try {
+  if (platformEnv.isNative) {
+    // Dynamic import to avoid errors on platforms where the module isn't available
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, global-require
+    const { NativeModules } = require('react-native') as {
+      NativeModules: { UnifiedPushModule?: IUnifiedPushNativeModule };
+    };
+    UnifiedPushModule = NativeModules.UnifiedPushModule || null;
+  }
+} catch (error) {
+  defaultLogger.notification.common.consoleLog(
+    'UnifiedPush native module not available',
+    error,
+  );
+}
+
+export class PushProviderUnifiedPush extends PushProviderBase {
+  constructor(props: IPushProviderBaseProps) {
+    super(props);
+    void this.initUnifiedPush();
+  }
+
+  private endpoint: string | null = null;
+
+  private isInitialized = false;
+
+  private async initUnifiedPush() {
+    if (!platformEnv.isNative || !UnifiedPushModule) {
+      defaultLogger.notification.common.consoleLog(
+        'UnifiedPush not available on this platform',
+      );
+      return;
+    }
+
+    try {
+      await UnifiedPushModule.initialize();
+      this.setupEventListeners();
+      this.isInitialized = true;
+      defaultLogger.notification.common.consoleLog(
+        'UnifiedPush initialized successfully',
+      );
+
+      // Check if already registered
+      const isRegistered = await UnifiedPushModule.isRegistered(
+        this.instanceId,
+      );
+      if (isRegistered) {
+        const existingEndpoint = await UnifiedPushModule.getEndpoint(
+          this.instanceId,
+        );
+        if (existingEndpoint) {
+          this.endpoint = existingEndpoint;
+          this.eventEmitter.emit(EPushProviderEventNames.unifiedpush_connected, {
+            endpoint: existingEndpoint,
+          });
+        }
+      }
+    } catch (error) {
+      defaultLogger.notification.common.consoleError(
+        'UnifiedPush initialization failed',
+        error,
+      );
+    }
+  }
+
+  private setupEventListeners() {
+    if (!platformEnv.isNative) {
+      return;
+    }
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, global-require
+      const { DeviceEventEmitter } = require('react-native') as {
+        DeviceEventEmitter: {
+          addListener: (
+            event: string,
+            callback: (event: IUnifiedPushEventPayload) => void,
+          ) => void;
+        };
+      };
+
+      DeviceEventEmitter.addListener(
+        'UnifiedPushEvent',
+        (event: IUnifiedPushEventPayload) => {
+          this.handleUnifiedPushEvent(event);
+        },
+      );
+    } catch (error) {
+      defaultLogger.notification.common.consoleError(
+        'Failed to setup UnifiedPush event listeners',
+        error,
+      );
+    }
+  }
+
+  private handleUnifiedPushEvent(event: IUnifiedPushEventPayload) {
+    defaultLogger.notification.common.consoleLog('UnifiedPush event:', event);
+
+    switch (event.type) {
+      case 'registered':
+      case 'newEndpoint':
+        if (event.endpoint) {
+          this.endpoint = event.endpoint;
+          this.eventEmitter.emit(EPushProviderEventNames.unifiedpush_connected, {
+            endpoint: event.endpoint,
+          });
+          defaultLogger.notification.common.consoleLog(
+            'UnifiedPush registered with endpoint:',
+            event.endpoint,
+          );
+        }
+        break;
+
+      case 'unregistered':
+        this.endpoint = null;
+        defaultLogger.notification.common.consoleLog('UnifiedPush unregistered');
+        break;
+
+      case 'message':
+        if (event.message) {
+          this.handleMessage(event.message);
+        }
+        break;
+
+      case 'registrationFailed':
+        defaultLogger.notification.common.consoleError(
+          'UnifiedPush registration failed:',
+          event.error,
+        );
+        break;
+
+      case 'unregistrationFailed':
+        defaultLogger.notification.common.consoleError(
+          'UnifiedPush unregistration failed:',
+          event.error,
+        );
+        break;
+
+      default:
+        defaultLogger.notification.common.consoleLog(
+          'Unknown UnifiedPush event type:',
+          event.type,
+        );
+    }
+  }
+
+  private handleMessage(rawMessage: string) {
+    try {
+      // Try to parse as JSON first (structured message)
+      let parsedMessage: IUnifiedPushMessage;
+
+      try {
+        parsedMessage = JSON.parse(rawMessage) as IUnifiedPushMessage;
+      } catch {
+        // If not JSON, treat as plain text message
+        parsedMessage = {
+          message: rawMessage,
+        };
+      }
+
+      const msgId =
+        (parsedMessage.data?.msgId as string) ||
+        `up_${Date.now()}_${Math.random().toString(36).substring(7)}`;
+
+      const payload: INotificationPushMessageInfo = {
+        pushSource: 'unifiedpush',
+        title: parsedMessage.title || 'Notification',
+        content: parsedMessage.message,
+        extras: {
+          msgId,
+          topic:
+            (parsedMessage.data?.topic as string) || 'accountActivity',
+          params: parsedMessage.data?.params as any,
+          ...(parsedMessage.data || {}),
+        } as any,
+      };
+
+      defaultLogger.notification.common.consoleLog(
+        'UnifiedPush message received:',
+        payload,
+      );
+
+      this.eventEmitter.emit(
+        EPushProviderEventNames.notification_received,
+        payload,
+      );
+    } catch (error) {
+      defaultLogger.notification.common.consoleError(
+        'Failed to parse UnifiedPush message:',
+        error,
+        rawMessage,
+      );
+    }
+  }
+
+  /**
+   * Get available UnifiedPush distributors on the device
+   */
+  async getDistributors(): Promise<IUnifiedPushDistributor[]> {
+    if (!UnifiedPushModule) {
+      return [];
+    }
+    try {
+      return await UnifiedPushModule.getDistributors();
+    } catch (error) {
+      defaultLogger.notification.common.consoleError(
+        'Failed to get UnifiedPush distributors:',
+        error,
+      );
+      return [];
+    }
+  }
+
+  /**
+   * Select a UnifiedPush distributor
+   */
+  async selectDistributor(packageName: string): Promise<boolean> {
+    if (!UnifiedPushModule) {
+      return false;
+    }
+    try {
+      await UnifiedPushModule.selectDistributor(packageName);
+      return true;
+    } catch (error) {
+      defaultLogger.notification.common.consoleError(
+        'Failed to select UnifiedPush distributor:',
+        error,
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Register for push notifications with UnifiedPush
+   */
+  async register(): Promise<boolean> {
+    if (!UnifiedPushModule) {
+      defaultLogger.notification.common.consoleLog(
+        'UnifiedPush module not available',
+      );
+      return false;
+    }
+
+    try {
+      await UnifiedPushModule.registerForPush(this.instanceId);
+      return true;
+    } catch (error) {
+      defaultLogger.notification.common.consoleError(
+        'UnifiedPush registration failed:',
+        error,
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Unregister from push notifications
+   */
+  async unregister(): Promise<boolean> {
+    if (!UnifiedPushModule) {
+      return false;
+    }
+
+    try {
+      await UnifiedPushModule.unregisterForPush(this.instanceId);
+      this.endpoint = null;
+      return true;
+    } catch (error) {
+      defaultLogger.notification.common.consoleError(
+        'UnifiedPush unregistration failed:',
+        error,
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Get the current endpoint URL for sending push notifications
+   */
+  getEndpoint(): string | null {
+    return this.endpoint;
+  }
+
+  /**
+   * Check if UnifiedPush is available on this device
+   */
+  isAvailable(): boolean {
+    return !!UnifiedPushModule && this.isInitialized;
+  }
+
+  /**
+   * Check if currently registered
+   */
+  async isRegistered(): Promise<boolean> {
+    if (!UnifiedPushModule) {
+      return false;
+    }
+    try {
+      return await UnifiedPushModule.isRegistered(this.instanceId);
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Get current distributor
+   */
+  async getCurrentDistributor(): Promise<string | null> {
+    if (!UnifiedPushModule) {
+      return null;
+    }
+    try {
+      return await UnifiedPushModule.getDistributor();
+    } catch {
+      return null;
+    }
+  }
+}

--- a/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
@@ -105,7 +105,7 @@ export default class ServiceNotification extends ServiceBase {
 
   async getNotificationProvider(): Promise<NotificationProviderBase> {
     if (!this._notificationProvider) {
-      const { disabledWebSocket, disabledJPush } =
+      const { disabledWebSocket, disabledJPush, disabledUnifiedPush } =
         await notificationsDevSettingsPersistAtom.get();
       const settings = await settingsPersistAtom.get();
 
@@ -114,6 +114,7 @@ export default class ServiceNotification extends ServiceBase {
           instanceId: settings.instanceId,
           disabledWebSocket,
           disabledJPush,
+          disabledUnifiedPush,
         },
         backgroundApi: this.backgroundApi,
       });
@@ -124,6 +125,10 @@ export default class ServiceNotification extends ServiceBase {
       this._notificationProvider.eventEmitter.on(
         EPushProviderEventNames.jpush_connected,
         this.onPushProviderConnected,
+      );
+      this._notificationProvider.eventEmitter.on(
+        EPushProviderEventNames.unifiedpush_connected,
+        this.onUnifiedPushProviderConnected,
       );
       this._notificationProvider.eventEmitter.on(
         EPushProviderEventNames.notification_received,
@@ -156,6 +161,16 @@ export default class ServiceNotification extends ServiceBase {
     return this.pushClient;
   }
 
+  @backgroundMethod()
+  async getUnifiedPushProvider() {
+    const provider = await this.getNotificationProvider();
+    // The native provider has the getUnifiedPushProvider method
+    if ('getUnifiedPushProvider' in provider) {
+      return (provider as any).getUnifiedPushProvider();
+    }
+    return undefined;
+  }
+
   isFirstTimeAllAccountsRegistered = false;
 
   onPushProviderConnected = async ({
@@ -174,6 +189,27 @@ export default class ServiceNotification extends ServiceBase {
     if (!this.isFirstTimeAllAccountsRegistered) {
       this.isFirstTimeAllAccountsRegistered = true;
       // register when webSocket or jpush established
+      void this.registerClientWithOverrideAllAccounts();
+    } else {
+      void this.updateClientBasicAppInfo();
+    }
+  };
+
+  onUnifiedPushProviderConnected = async ({
+    endpoint,
+  }: {
+    endpoint: string;
+  }) => {
+    this.pushClient = merge(this.pushClient, {
+      unifiedPushEndpoint: endpoint,
+    });
+    defaultLogger.notification.common.consoleLog(
+      'UnifiedPush provider connected:',
+      endpoint,
+    );
+    if (!this.isFirstTimeAllAccountsRegistered) {
+      this.isFirstTimeAllAccountsRegistered = true;
+      // register when UnifiedPush endpoint is available
       void this.registerClientWithOverrideAllAccounts();
     } else {
       void this.updateClientBasicAppInfo();
@@ -205,12 +241,18 @@ export default class ServiceNotification extends ServiceBase {
       // jpush will show notification automatically
     }
 
-    // websocket push should show notification by ourselves
-    if (messageInfo.pushSource === 'websocket') {
+    // websocket and unifiedpush should show notification by ourselves
+    if (
+      messageInfo.pushSource === 'websocket' ||
+      messageInfo.pushSource === 'unifiedpush'
+    ) {
       if (!(await this.isNotificationShowed(msgId))) {
-        const prefix = showMessagePushSource ? '[wss:] ' : '';
-        // jpush will show notification automatically
-        // websocket should show notification by ourselves
+        let prefix = '';
+        if (showMessagePushSource) {
+          prefix =
+            messageInfo.pushSource === 'unifiedpush' ? '[up:] ' : '[wss:] ';
+        }
+        // unifiedpush and websocket should show notification by ourselves
         const notificationParams = {
           notificationId: msgId,
           title: prefix + messageInfo.title,

--- a/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
@@ -160,6 +160,8 @@ export type INotificationsDevSettings = {
   showMessagePushSource?: boolean;
   disabledWebSocket?: boolean;
   disabledJPush?: boolean;
+  disabledUnifiedPush?: boolean;
+  preferUnifiedPush?: boolean;
 };
 export type INotificationsDevSettingsKeys = keyof INotificationsDevSettings;
 export const {
@@ -172,5 +174,7 @@ export const {
     showMessagePushSource: false,
     disabledWebSocket: false,
     disabledJPush: false,
+    disabledUnifiedPush: false,
+    preferUnifiedPush: true, // Prefer privacy-friendly UnifiedPush by default
   },
 });

--- a/packages/kit/src/views/Setting/pages/Notifications/UnifiedPushSettings.tsx
+++ b/packages/kit/src/views/Setting/pages/Notifications/UnifiedPushSettings.tsx
@@ -1,0 +1,388 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  Button,
+  Icon,
+  SizableText,
+  Spinner,
+  Stack,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import {
+  formatEndpointForDisplay,
+  getDistributorInfo,
+  isKnownDistributor,
+  PUSH_PROVIDER_PRIVACY_INFO,
+} from '@onekeyhq/shared/src/utils/unifiedPushUtils';
+
+interface IUnifiedPushDistributor {
+  packageName: string;
+  name: string;
+}
+
+interface IUnifiedPushStatus {
+  isAvailable: boolean;
+  isRegistered: boolean;
+  endpoint: string | null;
+  distributor: string | null;
+  distributors: IUnifiedPushDistributor[];
+}
+
+/**
+ * UnifiedPush Settings Component
+ *
+ * Allows users to:
+ * - See if UnifiedPush is available on their device
+ * - Select a UnifiedPush distributor
+ * - Register/unregister for push notifications
+ * - View current endpoint status
+ */
+export function UnifiedPushSettings() {
+  const [status, setStatus] = useState<IUnifiedPushStatus | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRegistering, setIsRegistering] = useState(false);
+
+  const refreshStatus = useCallback(async () => {
+    if (!platformEnv.isNative) {
+      setStatus({
+        isAvailable: false,
+        isRegistered: false,
+        endpoint: null,
+        distributor: null,
+        distributors: [],
+      });
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const provider =
+        await backgroundApiProxy.serviceNotification.getUnifiedPushProvider();
+
+      if (!provider) {
+        setStatus({
+          isAvailable: false,
+          isRegistered: false,
+          endpoint: null,
+          distributor: null,
+          distributors: [],
+        });
+        setIsLoading(false);
+        return;
+      }
+
+      const [isRegistered, distributors, distributor, endpoint] =
+        await Promise.all([
+          provider.isRegistered(),
+          provider.getDistributors(),
+          provider.getCurrentDistributor(),
+          Promise.resolve(provider.getEndpoint()),
+        ]);
+
+      setStatus({
+        isAvailable: provider.isAvailable(),
+        isRegistered,
+        endpoint,
+        distributor,
+        distributors,
+      });
+    } catch (error) {
+      console.error('Failed to get UnifiedPush status:', error);
+      setStatus({
+        isAvailable: false,
+        isRegistered: false,
+        endpoint: null,
+        distributor: null,
+        distributors: [],
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshStatus();
+  }, [refreshStatus]);
+
+  const handleSelectDistributor = useCallback(
+    async (packageName: string) => {
+      setIsLoading(true);
+      try {
+        const provider =
+          await backgroundApiProxy.serviceNotification.getUnifiedPushProvider();
+        if (provider) {
+          await provider.selectDistributor(packageName);
+          await refreshStatus();
+        }
+      } catch (error) {
+        console.error('Failed to select distributor:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [refreshStatus],
+  );
+
+  const handleRegister = useCallback(async () => {
+    setIsRegistering(true);
+    try {
+      const provider =
+        await backgroundApiProxy.serviceNotification.getUnifiedPushProvider();
+      if (provider) {
+        await provider.register();
+        // Wait a bit for the registration to complete
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        await refreshStatus();
+      }
+    } catch (error) {
+      console.error('Failed to register:', error);
+    } finally {
+      setIsRegistering(false);
+    }
+  }, [refreshStatus]);
+
+  const handleUnregister = useCallback(async () => {
+    setIsRegistering(true);
+    try {
+      const provider =
+        await backgroundApiProxy.serviceNotification.getUnifiedPushProvider();
+      if (provider) {
+        await provider.unregister();
+        await refreshStatus();
+      }
+    } catch (error) {
+      console.error('Failed to unregister:', error);
+    } finally {
+      setIsRegistering(false);
+    }
+  }, [refreshStatus]);
+
+  if (isLoading) {
+    return (
+      <Stack padding="$4" alignItems="center">
+        <Spinner size="large" />
+        <SizableText marginTop="$2">Loading UnifiedPush status...</SizableText>
+      </Stack>
+    );
+  }
+
+  if (!platformEnv.isNative) {
+    return (
+      <Stack padding="$4">
+        <SizableText color="$textSubdued">
+          UnifiedPush is only available on mobile devices.
+        </SizableText>
+      </Stack>
+    );
+  }
+
+  if (!status?.isAvailable) {
+    return (
+      <YStack padding="$4" gap="$3">
+        <XStack alignItems="center" gap="$2">
+          <Icon name="ShieldCheckSolid" color="$iconSubdued" size="$5" />
+          <SizableText size="$headingMd" fontWeight="600">
+            UnifiedPush
+          </SizableText>
+        </XStack>
+
+        <SizableText color="$textSubdued">
+          UnifiedPush is a privacy-friendly push notification system that
+          doesn&apos;t require Google Play Services.
+        </SizableText>
+
+        <Stack
+          backgroundColor="$bgInfoSubdued"
+          padding="$3"
+          borderRadius="$3"
+        >
+          <SizableText size="$bodySm">
+            To use UnifiedPush, you need to install a distributor app:
+          </SizableText>
+          <SizableText size="$bodySm" marginTop="$2">
+            • <SizableText fontWeight="600">ntfy</SizableText> - Simple and
+            self-hostable
+          </SizableText>
+          <SizableText size="$bodySm">
+            • <SizableText fontWeight="600">NextPush</SizableText> - For
+            Nextcloud users
+          </SizableText>
+          <SizableText size="$bodySm">
+            • <SizableText fontWeight="600">UP-FCM</SizableText> - Uses Google
+            FCM (less private)
+          </SizableText>
+        </Stack>
+
+        <SizableText size="$bodySm" color="$textSubdued">
+          Learn more at unifiedpush.org
+        </SizableText>
+      </YStack>
+    );
+  }
+
+  const distributorInfo = status.distributor
+    ? getDistributorInfo(status.distributor)
+    : null;
+
+  return (
+    <YStack gap="$2">
+      <XStack alignItems="center" gap="$2" padding="$4" paddingBottom="$2">
+        <Icon name="ShieldCheckSolid" color="$iconSuccess" size="$5" />
+        <SizableText size="$headingMd" fontWeight="600">
+          UnifiedPush
+        </SizableText>
+        <Stack
+          backgroundColor="$bgSuccess"
+          paddingHorizontal="$2"
+          paddingVertical="$0.5"
+          borderRadius="$1"
+        >
+          <SizableText size="$bodyXs" color="$textSuccess">
+            Available
+          </SizableText>
+        </Stack>
+      </XStack>
+
+      <Stack paddingHorizontal="$4" paddingBottom="$2">
+        <SizableText size="$bodySm" color="$textSubdued">
+          Privacy-friendly push notifications without Google Play Services
+        </SizableText>
+      </Stack>
+
+      {/* Current Distributor */}
+      <ListItem
+        title="Distributor"
+        subtitle={
+          distributorInfo?.displayName ||
+          status.distributor ||
+          'Not selected'
+        }
+        subtitleProps={{
+          color: status.distributor ? '$text' : '$textSubdued',
+        }}
+      >
+        {status.distributor && isKnownDistributor(status.distributor) && (
+          <Icon name="CheckCircleSolid" color="$iconSuccess" size="$5" />
+        )}
+      </ListItem>
+
+      {/* Distributor Selection */}
+      {status.distributors.length > 1 && (
+        <YStack paddingHorizontal="$4" gap="$2">
+          <SizableText size="$bodySmMedium">
+            Available Distributors
+          </SizableText>
+          {status.distributors.map((dist: IUnifiedPushDistributor) => {
+            const info = getDistributorInfo(dist.packageName);
+            const isSelected = dist.packageName === status.distributor;
+            return (
+              <Stack
+                key={dist.packageName}
+                padding="$3"
+                borderRadius="$2"
+                borderWidth={1}
+                borderColor={isSelected ? '$borderSuccess' : '$borderSubdued'}
+                backgroundColor={isSelected ? '$bgSuccessSubdued' : '$bg'}
+                pressStyle={{ opacity: 0.7 }}
+                onPress={() => handleSelectDistributor(dist.packageName)}
+              >
+                <XStack justifyContent="space-between" alignItems="center">
+                  <YStack flex={1}>
+                    <SizableText fontWeight="600">
+                      {info?.displayName || dist.name}
+                    </SizableText>
+                    {info?.description && (
+                      <SizableText size="$bodySm" color="$textSubdued">
+                        {info.description}
+                      </SizableText>
+                    )}
+                  </YStack>
+                  {isSelected && (
+                    <Icon
+                      name="CheckCircleSolid"
+                      color="$iconSuccess"
+                      size="$5"
+                    />
+                  )}
+                </XStack>
+              </Stack>
+            );
+          })}
+        </YStack>
+      )}
+
+      {/* Registration Status */}
+      <ListItem
+        title="Status"
+        subtitle={status.isRegistered ? 'Registered' : 'Not registered'}
+        subtitleProps={{
+          color: status.isRegistered ? '$textSuccess' : '$textSubdued',
+        }}
+      >
+        <Stack
+          width={10}
+          height={10}
+          borderRadius={5}
+          backgroundColor={status.isRegistered ? '$bgSuccess' : '$bgSubdued'}
+        />
+      </ListItem>
+
+      {/* Endpoint */}
+      {status.endpoint && (
+        <ListItem
+          title="Endpoint"
+          subtitle={formatEndpointForDisplay(status.endpoint)}
+          subtitleProps={{
+            size: '$bodySm',
+            color: '$textSubdued',
+          }}
+        />
+      )}
+
+      {/* Register/Unregister Button */}
+      <Stack padding="$4">
+        {status.isRegistered ? (
+          <Button
+            variant="secondary"
+            onPress={handleUnregister}
+            disabled={isRegistering}
+          >
+            {isRegistering ? <Spinner size="small" /> : 'Unregister'}
+          </Button>
+        ) : (
+          <Button
+            variant="primary"
+            onPress={handleRegister}
+            disabled={isRegistering || !status.distributor}
+          >
+            {isRegistering ? <Spinner size="small" /> : 'Register'}
+          </Button>
+        )}
+      </Stack>
+
+      {/* Privacy Info */}
+      <Stack
+        marginHorizontal="$4"
+        padding="$3"
+        backgroundColor="$bgSuccessSubdued"
+        borderRadius="$3"
+      >
+        <XStack alignItems="center" gap="$2" marginBottom="$2">
+          <Icon name="LockKeyholeSolid" color="$iconSuccess" size="$4" />
+          <SizableText size="$bodySmMedium" color="$textSuccess">
+            Privacy Benefits
+          </SizableText>
+        </XStack>
+        <SizableText size="$bodySm" color="$text">
+          {PUSH_PROVIDER_PRIVACY_INFO.unifiedpush.description}
+        </SizableText>
+      </Stack>
+    </YStack>
+  );
+}
+
+export default UnifiedPushSettings;

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/NotificationDevSettings.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/NotificationDevSettings.tsx
@@ -84,6 +84,22 @@ export function NotificationDevSettings() {
         <Switch size={ESwitchSize.small} />
       </NotificationSectionFieldItem>
 
+      <NotificationSectionFieldItem
+        name="disabledUnifiedPush"
+        title="Disable UnifiedPush (Restart required)"
+        titleProps={{ color: '$text' }}
+      >
+        <Switch size={ESwitchSize.small} />
+      </NotificationSectionFieldItem>
+
+      <NotificationSectionFieldItem
+        name="preferUnifiedPush"
+        title="Prefer UnifiedPush (Privacy-friendly)"
+        titleProps={{ color: '$textSuccess' }}
+      >
+        <Switch size={ESwitchSize.small} />
+      </NotificationSectionFieldItem>
+
       <Button
         onPress={async () => {
           const res =

--- a/packages/shared/src/utils/unifiedPushUtils.ts
+++ b/packages/shared/src/utils/unifiedPushUtils.ts
@@ -1,0 +1,206 @@
+/**
+ * UnifiedPush Utilities
+ *
+ * UnifiedPush is an open-source, privacy-friendly push notification specification
+ * that allows users to choose their own push notification provider.
+ *
+ * Benefits:
+ * - No Google Play Services required
+ * - User chooses their push provider (distributor)
+ * - End-to-end encryption possible
+ * - No data collection by third parties
+ * - Works on degoogled Android devices
+ *
+ * How it works:
+ * 1. User installs a UnifiedPush distributor app (e.g., ntfy, NextPush)
+ * 2. App registers with the distributor
+ * 3. Distributor provides an endpoint URL
+ * 4. Endpoint is sent to backend server
+ * 5. Backend sends push messages to the endpoint
+ * 6. Distributor delivers to the app
+ *
+ * @see https://unifiedpush.org/
+ * @see https://unifiedpush.org/users/distributors/
+ */
+
+export interface IUnifiedPushDistributorInfo {
+  packageName: string;
+  displayName: string;
+  description?: string;
+  supportsEncryption?: boolean;
+}
+
+/**
+ * Well-known UnifiedPush distributors
+ * Users can install any of these to receive push notifications
+ */
+export const KNOWN_UNIFIEDPUSH_DISTRIBUTORS: IUnifiedPushDistributorInfo[] = [
+  {
+    packageName: 'io.heckel.ntfy',
+    displayName: 'ntfy',
+    description:
+      'Simple HTTP-based pub-sub notification service. Self-hostable.',
+    supportsEncryption: true,
+  },
+  {
+    packageName: 'org.unifiedpush.distributor.nextpush',
+    displayName: 'NextPush',
+    description: 'Push notifications through your Nextcloud server.',
+    supportsEncryption: true,
+  },
+  {
+    packageName: 'org.unifiedpush.distributor.fcm',
+    displayName: 'UP-FCM (Google FCM)',
+    description:
+      'Uses Google FCM as transport. Less private but widely available.',
+    supportsEncryption: false,
+  },
+  {
+    packageName: 'im.molly.unifiedpush',
+    displayName: 'Molly UnifiedPush',
+    description: 'UnifiedPush distributor from the Molly Signal fork.',
+    supportsEncryption: true,
+  },
+  {
+    packageName: 'org.unifiedpush.distributor.noprovider2push',
+    displayName: 'NoProvider2Push',
+    description: 'Direct push without a central server.',
+    supportsEncryption: true,
+  },
+];
+
+/**
+ * Format endpoint URL for display (hide sensitive parts)
+ */
+export function formatEndpointForDisplay(endpoint: string): string {
+  try {
+    const url = new URL(endpoint);
+    // Show domain and truncated path
+    const pathParts = url.pathname.split('/');
+    if (pathParts.length > 2) {
+      const lastPart = pathParts[pathParts.length - 1];
+      const truncatedLast =
+        lastPart.length > 8
+          ? `${lastPart.substring(0, 4)}...${lastPart.substring(lastPart.length - 4)}`
+          : lastPart;
+      return `${url.host}/.../${truncatedLast}`;
+    }
+    return `${url.host}${url.pathname}`;
+  } catch {
+    // If URL parsing fails, just truncate
+    if (endpoint.length > 40) {
+      return `${endpoint.substring(0, 20)}...${endpoint.substring(endpoint.length - 15)}`;
+    }
+    return endpoint;
+  }
+}
+
+/**
+ * Check if a distributor package name is known/trusted
+ */
+export function isKnownDistributor(packageName: string): boolean {
+  return KNOWN_UNIFIEDPUSH_DISTRIBUTORS.some(
+    (d) => d.packageName === packageName,
+  );
+}
+
+/**
+ * Get info about a distributor by package name
+ */
+export function getDistributorInfo(
+  packageName: string,
+): IUnifiedPushDistributorInfo | undefined {
+  return KNOWN_UNIFIEDPUSH_DISTRIBUTORS.find(
+    (d) => d.packageName === packageName,
+  );
+}
+
+/**
+ * Check if the endpoint URL looks valid
+ */
+export function isValidEndpoint(endpoint: string): boolean {
+  try {
+    const url = new URL(endpoint);
+    return url.protocol === 'https:' || url.protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Message format for sending via UnifiedPush
+ * The backend should send messages in this format to the endpoint
+ */
+export interface IUnifiedPushOutgoingMessage {
+  // Title of the notification
+  title: string;
+  // Body/content of the notification
+  message: string;
+  // Priority (1-5, with 5 being highest)
+  priority?: number;
+  // Topic for categorization
+  topic?: string;
+  // Custom data payload (will be JSON stringified)
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Build a push message payload for sending to UnifiedPush endpoint
+ */
+export function buildPushMessagePayload(
+  message: IUnifiedPushOutgoingMessage,
+): string {
+  return JSON.stringify({
+    title: message.title,
+    message: message.message,
+    priority: message.priority ?? 3,
+    data: {
+      topic: message.topic,
+      ...message.data,
+    },
+  });
+}
+
+/**
+ * Privacy comparison between push providers
+ */
+export const PUSH_PROVIDER_PRIVACY_INFO = {
+  unifiedpush: {
+    name: 'UnifiedPush',
+    privacyLevel: 'high',
+    description:
+      'User-controlled push provider. No data shared with Google or other third parties when using self-hosted distributors.',
+    requiresGoogleServices: false,
+    dataSentToThirdParty: false,
+    selfHostable: true,
+  },
+  jpush: {
+    name: 'JPush (极光推送)',
+    privacyLevel: 'low',
+    description:
+      'Chinese push notification service. Data is processed through JPush servers.',
+    requiresGoogleServices: false,
+    dataSentToThirdParty: true,
+    selfHostable: false,
+  },
+  fcm: {
+    name: 'Firebase Cloud Messaging',
+    privacyLevel: 'medium',
+    description:
+      'Google push service. Requires Google Play Services. Metadata visible to Google.',
+    requiresGoogleServices: true,
+    dataSentToThirdParty: true,
+    selfHostable: false,
+  },
+  websocket: {
+    name: 'WebSocket (In-App)',
+    privacyLevel: 'high',
+    description:
+      'Direct connection to app servers. Only works when app is running.',
+    requiresGoogleServices: false,
+    dataSentToThirdParty: false,
+    selfHostable: true,
+  },
+} as const;
+
+export type TPushProviderType = keyof typeof PUSH_PROVIDER_PRIVACY_INFO;

--- a/packages/shared/types/notification.ts
+++ b/packages/shared/types/notification.ts
@@ -53,6 +53,7 @@ export enum EPushProviderEventNames {
 
   ws_connected = 'ws_connected',
   jpush_connected = 'jpush_connected',
+  unifiedpush_connected = 'unifiedpush_connected',
 
   notification_received = 'notification_received',
   notification_clicked = 'notification_clicked',
@@ -73,6 +74,9 @@ export interface IPushProviderEventPayload {
   };
   [EPushProviderEventNames.jpush_connected]: {
     jpushId: string;
+  };
+  [EPushProviderEventNames.unifiedpush_connected]: {
+    endpoint: string;
   };
   [EPushProviderEventNames.notification_received]: INotificationPushMessageInfo;
   [EPushProviderEventNames.notification_clicked]: INotificationClickParams;
@@ -97,6 +101,7 @@ export type INotificationPushClient = {
   apnsId?: string; // apple push notification service id
   wnsId?: string; // windows push notification service id
   webPushId?: string; // web push notification service id
+  unifiedPushEndpoint?: string; // UnifiedPush endpoint URL (privacy-friendly alternative)
 };
 export type INotificationPushSyncAccount = {
   networkId: string | undefined;
@@ -146,6 +151,11 @@ export type INotificationPushSettings = {
     impl: string;
     chainId: string;
   }[];
+  // UnifiedPush settings - privacy-friendly push notification alternative
+  unifiedPushEnabled?: boolean;
+  unifiedPushDistributor?: string; // Selected distributor package name
+  unifiedPushEndpoint?: string; // Current endpoint URL
+  preferUnifiedPush?: boolean; // Prefer UnifiedPush over proprietary solutions
 };
 export type INotificationPushTopic =
   | {
@@ -260,7 +270,7 @@ export type INotificationPushMessageInfo = {
   extras?: INotificationPushMessageExtras;
   //
   badge?: string;
-  pushSource?: 'jpush' | 'websocket' | undefined;
+  pushSource?: 'jpush' | 'websocket' | 'unifiedpush' | undefined;
 };
 export type INativeNotificationCenterMessageInfo = {
   notificationId: string;


### PR DESCRIPTION
UnifiedPush is an open standard that allows users to choose their own push notification provider, eliminating dependency on Google Play Services and proprietary solutions like JPush.

Changes:
- Add PushProviderUnifiedPush provider with full registration flow
- Add UnifiedPush event types and settings to notification types
- Integrate UnifiedPush into native NotificationProvider
- Add Android native module stub (UnifiedPushModule.java)
- Add user-facing UnifiedPushSettings component
- Add unifiedPushUtils with known distributors and privacy info
- Add dev settings toggles for UnifiedPush
- Add comprehensive documentation in docs/UNIFIED_PUSH.md

Privacy benefits:
- No Google Play Services required (works on degoogled devices)
- User-controlled push provider selection
- Self-hostable with ntfy, NextPush, etc.
- No third-party data collection when self-hosted

Supported distributors: ntfy, NextPush, UP-FCM, Molly UnifiedPush