### PR TITLE
chore: update AndroidManifest and media library handling

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -17,8 +17,7 @@
         android:maxSdkVersion="30"
         tools:node="replace" />
 
-  <!-- Android 13+ (API 33+) media permissions for saving images to gallery -->
-  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" tools:node="remove" />
   <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" tools:node="remove" />
   <uses-permission android:name="android.permission.RECORD_AUDIO" tools:node="remove" />
 

--- a/packages/kit/src/views/Perp/components/PositionShare/useShareActions.ts
+++ b/packages/kit/src/views/Perp/components/PositionShare/useShareActions.ts
@@ -78,7 +78,7 @@ export function useShareActions(referralQrCodeUrl?: string) {
             'base64',
           );
 
-          const savedAsset = await MediaLibrary.saveToLibraryAsync(filepath);
+          await MediaLibrary.saveToLibraryAsync(filepath);
           await RNFS.unlink(filepath);
 
           const titleText = intl.formatMessage({
@@ -89,10 +89,10 @@ export function useShareActions(referralQrCodeUrl?: string) {
           });
 
           const openPhotoLibrary = () => {
-            if (platformEnv.isNativeAndroid && savedAsset?.uri) {
-              void Linking.openURL(savedAsset.uri).catch(() => {
-                void Linking.openURL('content://media/internal/images/media');
-              });
+            if (platformEnv.isNativeAndroid) {
+              void Linking.openURL(
+                'content://media/external/images/media',
+              ).catch(() => {});
             } else {
               void Linking.openURL('photos-redirect://');
             }

--- a/packages/shared/src/modules3rdParty/expo-media-library/index.ts
+++ b/packages/shared/src/modules3rdParty/expo-media-library/index.ts
@@ -3,7 +3,7 @@ import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import type * as MediaLibrary from 'expo-media-library';
 
 const mock = {
-  saveToLibraryAsync: async (_uri: string): Promise<MediaLibrary.Asset> => {
+  saveToLibraryAsync: async (_uri: string): Promise<void> => {
     throw new OneKeyLocalError(
       'Media library is only available on native platforms',
     );


### PR DESCRIPTION
- Remove unnecessary media permissions for Android 13+ in AndroidManifest.xml.
- Adjust saveToLibraryAsync return type in expo-media-library to void.
- Simplify photo library opening logic in useShareActions.ts for Android.