### PR TITLE
fix: resolve PromiseTarget class field initialization order issue for rspack/SWC

### DIFF
--- a/packages/shared/src/utils/promiseUtils.ts
+++ b/packages/shared/src/utils/promiseUtils.ts
@@ -153,20 +153,23 @@ export async function promiseAllSettledEnhanced<T>(
 }
 
 export class PromiseTarget<T> {
+  // IMPORTANT: Declare _resolveFn and _rejectFn BEFORE ready!
+  // This fixes a class field initialization order issue where rspack/SWC
+  // would initialize _resolveFn to undefined AFTER the Promise executor
+  // had already set it, causing the Promise to never resolve.
+  _resolveFn: ((value: T) => void) | undefined;
+  _rejectFn: ((error: Error | IOneKeyError) => void) | undefined;
+
   ready = new Promise<T>((resolve, reject) => {
     this._resolveFn = resolve;
     this._rejectFn = reject;
   });
-
-  _resolveFn: ((value: T) => void) | undefined;
 
   resolveTarget(value: T, delay = 0) {
     setTimeout(() => {
       this._resolveFn?.(value);
     }, delay);
   }
-
-  _rejectFn: ((error: Error | IOneKeyError) => void) | undefined;
 
   rejectTarget(error: Error | IOneKeyError) {
     setTimeout(() => {


### PR DESCRIPTION
## Summary
- Move `_resolveFn` and `_rejectFn` declarations before the `ready` field in `PromiseTarget` class
- Fixes a class field initialization order issue where rspack/SWC would initialize `_resolveFn` to `undefined` AFTER the Promise executor had already set it
- This caused hardware wallet communication to hang in rspack builds

## Root Cause
In ES2022+ class field semantics, fields are initialized in declaration order. When `ready` was declared first:
1. `ready = new Promise(...)` executes, sets `this._resolveFn = resolve`
2. `_resolveFn: ... | undefined` initializes, **overwrites to `undefined`**

This caused `Promise.resolve()` to never be called, blocking hardware wallet batch account creation.

## Test plan
- [x] Verified hardware wallet batch account creation works in rspack build
- [x] Verified webpack build still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)