### PR TITLE
fix: enable polling mode for native token transactions in market detail

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/TransactionsHistory.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/TransactionsHistory.tsx
@@ -57,13 +57,16 @@ export function TransactionsHistory({
   networkId,
   onScrollEnd,
 }: ITransactionsHistoryProps) {
-  const { websocketConfig } = useTokenDetail();
+  const { websocketConfig, isNative } = useTokenDetail();
   const isVisible = useRouteIsFocused();
   const { gtXl } = useMedia();
   const currencyInfo = useCurrency();
 
+  // Enable polling mode for native tokens (which don't have WebSocket support)
+  // or for web non-xl screens without WebSocket txs enabled
   const normalMode =
-    !platformEnv.isNative && !gtXl && !(websocketConfig?.txs ?? false);
+    isNative ||
+    (!platformEnv.isNative && !gtXl && !(websocketConfig?.txs ?? false));
 
   const intl = useIntl();
   const {


### PR DESCRIPTION
## Summary
- Enable polling mode for native token transactions in market detail view
- Native tokens don't support WebSocket transaction updates, so use 5-second polling instead
- Adds `isNative` check to `normalMode` calculation in TransactionsHistory component

## Test plan
- [ ] Open market detail for a native token (e.g., ETH, BTC)
- [ ] Verify transactions tab updates every 5 seconds via polling
- [ ] Verify non-native tokens still use WebSocket when available

🤖 Generated with [Claude Code](https://claude.ai/code)