### PR TITLE
fix(keyless): re-encrypt wallet data when password is updated

### DIFF
--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -2154,7 +2154,9 @@ class ServiceKeylessWallet extends ServiceBase {
   }
 
   private async getAllKeylessWallets(): Promise<IDBWallet[]> {
-    const { wallets } = await this.backgroundApi.serviceAccount.getAllWallets();
+    const { wallets } = await this.backgroundApi.serviceAccount.getAllWallets({
+      refillWalletInfo: true,
+    });
     return wallets.filter((w) => w.isKeyless);
   }
 

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -1497,10 +1497,13 @@ class ServiceKeylessWallet extends ServiceBase {
       refreshToken &&
       mode === EOnboardingV2OneKeyIDLoginMode.KeylessVerifyPinOnly
     ) {
+      const { password } =
+        await this.backgroundApi.servicePassword.promptPasswordVerify();
       await keylessRefreshTokenStorage.saveTokensToStorage({
         ownerId,
         refreshToken,
         token,
+        password,
         backgroundApi: this.backgroundApi,
       });
     }
@@ -1568,6 +1571,10 @@ class ServiceKeylessWallet extends ServiceBase {
       throw new OneKeyLocalError('new PIN is required');
     }
 
+    // Get password first to avoid multiple prompts
+    const { password } =
+      await this.backgroundApi.servicePassword.promptPasswordVerify();
+
     // 2. Get backendShare from server
     const { backendShareData, hashId } = await this.apiGetKeylessBackendShare({
       token,
@@ -1586,6 +1593,7 @@ class ServiceKeylessWallet extends ServiceBase {
     const mnemonicPassword =
       await keylessMnemonicPasswordStorage.getMnemonicPasswordFromStorage({
         ownerId,
+        password,
         backgroundApi: this.backgroundApi,
       });
     if (!mnemonicPassword) {
@@ -1622,6 +1630,7 @@ class ServiceKeylessWallet extends ServiceBase {
         ownerId,
         refreshToken,
         token,
+        password,
         backgroundApi: this.backgroundApi,
       });
     }
@@ -1649,6 +1658,10 @@ class ServiceKeylessWallet extends ServiceBase {
     if (!pin) {
       throw new OneKeyLocalError('pin is required');
     }
+
+    // Get password first to avoid multiple prompts
+    const { password } =
+      await this.backgroundApi.servicePassword.promptPasswordVerify();
 
     // Get backend share from server
     const { backendShareData, hashId } = await this.apiGetKeylessBackendShare({
@@ -1700,6 +1713,7 @@ class ServiceKeylessWallet extends ServiceBase {
     await keylessMnemonicPasswordStorage.saveMnemonicPasswordToStorage({
       ownerId,
       mnemonicPassword,
+      password,
       backgroundApi: this.backgroundApi,
     });
 
@@ -1709,6 +1723,7 @@ class ServiceKeylessWallet extends ServiceBase {
         ownerId,
         refreshToken,
         token,
+        password,
         backgroundApi: this.backgroundApi,
       });
     }
@@ -1751,6 +1766,10 @@ class ServiceKeylessWallet extends ServiceBase {
     if (!pin) {
       throw new OneKeyLocalError('pin is required');
     }
+
+    // Get password first to avoid multiple prompts
+    const { password } =
+      await this.backgroundApi.servicePassword.promptPasswordVerify();
 
     // 1. Acquire distributed lock
     const { lockId, hashId } = await this.apiAcquireCreationLock({ token });
@@ -1808,6 +1827,7 @@ class ServiceKeylessWallet extends ServiceBase {
       await keylessMnemonicPasswordStorage.saveMnemonicPasswordToStorage({
         ownerId,
         mnemonicPassword,
+        password,
         backgroundApi: this.backgroundApi,
       });
 
@@ -1836,6 +1856,7 @@ class ServiceKeylessWallet extends ServiceBase {
           ownerId,
           refreshToken,
           token,
+          password,
           backgroundApi: this.backgroundApi,
         });
       }
@@ -1918,10 +1939,15 @@ class ServiceKeylessWallet extends ServiceBase {
       throw new OneKeyLocalError('ownerId is required');
     }
     try {
+      // Get password first to avoid multiple prompts
+      const { password } =
+        await this.backgroundApi.servicePassword.promptPasswordVerify();
+
       // Get refreshToken from secure storage (requires passcode)
       const storedTokens =
         await keylessRefreshTokenStorage.getTokensFromStorage({
           ownerId,
+          password,
           backgroundApi: this.backgroundApi,
         });
 
@@ -1957,6 +1983,7 @@ class ServiceKeylessWallet extends ServiceBase {
           ownerId,
           refreshToken: refreshResult.refresh_token,
           token: refreshResult.access_token,
+          password,
           backgroundApi: this.backgroundApi,
         });
         return {
@@ -2154,6 +2181,7 @@ class ServiceKeylessWallet extends ServiceBase {
 
     for (const wallet of keylessWallets) {
       const ownerId = wallet.keylessDetailsInfo?.keylessOwnerId;
+      // eslint-disable-next-line no-continue
       if (!ownerId) continue;
 
       const mnemonicPassword =

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -2125,6 +2125,111 @@ class ServiceKeylessWallet extends ServiceBase {
     const client = await this.getJuiceboxClientFromCache(token);
     return client.checkRateLimitStatus();
   }
+
+  private async getAllKeylessWallets(): Promise<IDBWallet[]> {
+    const { wallets } = await this.backgroundApi.serviceAccount.getAllWallets();
+    return wallets.filter((w) => w.isKeyless);
+  }
+
+  @backgroundMethod()
+  async updateKeylessDataPasscode(params: {
+    oldPassword: string;
+    newPassword: string;
+  }): Promise<{
+    rollback: () => Promise<void>;
+  }> {
+    const { oldPassword, newPassword } = params;
+
+    const keylessWallets = await this.getAllKeylessWallets();
+
+    if (keylessWallets.length === 0) {
+      return { rollback: async () => {} };
+    }
+
+    const backupData: Array<{
+      ownerId: string;
+      mnemonicPassword: string | null;
+      refreshToken: string | null;
+    }> = [];
+
+    for (const wallet of keylessWallets) {
+      const ownerId = wallet.keylessDetailsInfo?.keylessOwnerId;
+      if (!ownerId) continue;
+
+      const mnemonicPassword =
+        await keylessMnemonicPasswordStorage.getMnemonicPasswordFromStorageWithPassword(
+          {
+            ownerId,
+            password: oldPassword,
+            backgroundApi: this.backgroundApi,
+          },
+        );
+
+      const refreshToken =
+        await keylessRefreshTokenStorage.getRefreshTokenFromStorageWithPassword(
+          {
+            ownerId,
+            password: oldPassword,
+            backgroundApi: this.backgroundApi,
+          },
+        );
+
+      backupData.push({
+        ownerId,
+        mnemonicPassword,
+        refreshToken,
+      });
+    }
+
+    for (const backup of backupData) {
+      if (backup.mnemonicPassword) {
+        await keylessMnemonicPasswordStorage.saveMnemonicPasswordToStorageWithPassword(
+          {
+            ownerId: backup.ownerId,
+            mnemonicPassword: backup.mnemonicPassword,
+            password: newPassword,
+            backgroundApi: this.backgroundApi,
+          },
+        );
+      }
+
+      if (backup.refreshToken) {
+        await keylessRefreshTokenStorage.saveRefreshTokenToStorageWithPassword({
+          ownerId: backup.ownerId,
+          refreshToken: backup.refreshToken,
+          password: newPassword,
+          backgroundApi: this.backgroundApi,
+        });
+      }
+    }
+
+    return {
+      rollback: async () => {
+        for (const backup of backupData) {
+          if (backup.mnemonicPassword) {
+            await keylessMnemonicPasswordStorage.saveMnemonicPasswordToStorageWithPassword(
+              {
+                ownerId: backup.ownerId,
+                mnemonicPassword: backup.mnemonicPassword,
+                password: oldPassword,
+                backgroundApi: this.backgroundApi,
+              },
+            );
+          }
+          if (backup.refreshToken) {
+            await keylessRefreshTokenStorage.saveRefreshTokenToStorageWithPassword(
+              {
+                ownerId: backup.ownerId,
+                refreshToken: backup.refreshToken,
+                password: oldPassword,
+                backgroundApi: this.backgroundApi,
+              },
+            );
+          }
+        }
+      },
+    };
+  }
 }
 
 export default ServiceKeylessWallet;

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessAuthPackCache.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessAuthPackCache.ts
@@ -6,6 +6,13 @@ import { buildKeylessLocalEncryptionKey } from './keylessLocalEncryptionKey';
 
 import type { IBackgroundApi } from '../../../apis/IBackgroundApi';
 
+/**
+ * @deprecated This file will be deprecated in a future release.
+ * AuthPack is only stored in memory (not persisted to disk) and is cleared on app restart.
+ * Therefore, it does not require password update support (no need for *WithPassword variants).
+ * The updateKeylessDataPasscode flow intentionally does not handle AuthPack re-encryption.
+ */
+
 // In-memory cache for authPack, keyed by packSetId
 // Module-level cache shared across all instances
 // Note: Only stores the current user's authPack, cleared when caching new one

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessDeviceKeyStorage.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessDeviceKeyStorage.ts
@@ -10,6 +10,13 @@ import keylessStorageUtils from './keylessStorageUtils';
 import type { IBackgroundApi } from '../../../apis/IBackgroundApi';
 
 /**
+ * @deprecated This file will be deprecated in a future release.
+ * DevicePack is only stored temporarily and will be cleared after keyless wallet creation.
+ * Therefore, it does not require password update support (no need for *WithPassword variants).
+ * The updateKeylessDataPasscode flow intentionally does not handle DevicePack re-encryption.
+ */
+
+/**
  * Save device pack to local storage with passcode encryption.
  * Unified method for creating, enabling, and manual recovery flows.
  */

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessLocalEncryptionKey.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessLocalEncryptionKey.ts
@@ -37,6 +37,35 @@ export async function buildKeylessLocalEncryptionKey(params: {
 }
 
 /**
+ * Build encryption key from sensitiveEncodeKey and a provided password (no prompt).
+ * Used when updating password to re-encrypt keyless data with old/new password.
+ */
+export async function buildKeylessLocalEncryptionKeyWithPassword(params: {
+  password: string; // encoded password
+}): Promise<string> {
+  const { password } = params;
+
+  // 1. Get sensitiveEncodeKey from settings
+  const settings = await settingsPersistAtom.get();
+  const sensitiveEncodeKey = settings.sensitiveEncodeKey;
+
+  // 2. Decode and hash the provided password
+  const decodedPassword = await decodeSensitiveTextAsync({
+    encodedText: password,
+  });
+
+  const hashedPassword = await sha256(
+    Buffer.from(
+      `${decodedPassword}BB662525-CC49-4A52-93A5-AD237AC80A1D`,
+      'utf-8',
+    ),
+  );
+
+  // 3. Combine sensitiveEncodeKey and passcode to form encryption key
+  return `${sensitiveEncodeKey}--${hashedPassword.toString('hex')}`;
+}
+
+/**
  * Build encryption key from sensitiveEncodeKey only (no passcode required).
  * This is used for Token encryption which doesn't require passcode verification.
  */

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessLocalEncryptionKey.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessLocalEncryptionKey.ts
@@ -5,38 +5,6 @@ import { settingsPersistAtom } from '../../../states/jotai/atoms';
 import type { IBackgroundApi } from '../../../apis/IBackgroundApi';
 
 /**
- * Build encryption key from sensitiveEncodeKey and session passcode.
- * This requires passcode verification and is used for RefreshToken encryption.
- */
-export async function buildKeylessLocalEncryptionKey(params: {
-  backgroundApi: IBackgroundApi;
-}): Promise<string> {
-  const { backgroundApi } = params;
-
-  // 1. Get sensitiveEncodeKey from settings
-  const settings = await settingsPersistAtom.get();
-  const sensitiveEncodeKey = settings.sensitiveEncodeKey;
-
-  // 2. Get current session passcode
-  const { password } =
-    await backgroundApi.servicePassword.promptPasswordVerify();
-
-  const decodedPassword = await decodeSensitiveTextAsync({
-    encodedText: password,
-  });
-
-  const hashedPassword = await sha256(
-    Buffer.from(
-      `${decodedPassword}BB662525-CC49-4A52-93A5-AD237AC80A1D`,
-      'utf-8',
-    ),
-  );
-
-  // 3. Combine sensitiveEncodeKey and passcode to form encryption key
-  return `${sensitiveEncodeKey}--${hashedPassword.toString('hex')}`;
-}
-
-/**
  * Build encryption key from sensitiveEncodeKey and a provided password (no prompt).
  * Used when updating password to re-encrypt keyless data with old/new password.
  */
@@ -63,6 +31,23 @@ export async function buildKeylessLocalEncryptionKeyWithPassword(params: {
 
   // 3. Combine sensitiveEncodeKey and passcode to form encryption key
   return `${sensitiveEncodeKey}--${hashedPassword.toString('hex')}`;
+}
+
+/**
+ * Build encryption key from sensitiveEncodeKey and session passcode.
+ * This requires passcode verification and is used for RefreshToken encryption.
+ */
+export async function buildKeylessLocalEncryptionKey(params: {
+  backgroundApi: IBackgroundApi;
+}): Promise<string> {
+  const { backgroundApi } = params;
+
+  // Get current session passcode
+  const { password } =
+    await backgroundApi.servicePassword.promptPasswordVerify();
+
+  // Delegate to buildKeylessLocalEncryptionKeyWithPassword
+  return buildKeylessLocalEncryptionKeyWithPassword({ password });
 }
 
 /**

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessMnemonicPasswordStorage.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessMnemonicPasswordStorage.ts
@@ -2,7 +2,10 @@ import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 
-import { buildKeylessLocalEncryptionKey } from './keylessLocalEncryptionKey';
+import {
+  buildKeylessLocalEncryptionKey,
+  buildKeylessLocalEncryptionKeyWithPassword,
+} from './keylessLocalEncryptionKey';
 import keylessStorageUtils from './keylessStorageUtils';
 
 import type { IBackgroundApi } from '../../../apis/IBackgroundApi';
@@ -82,18 +85,78 @@ async function getMnemonicPasswordFromStorage(params: {
   }
 }
 
-/**
- * Remove mnemonicPassword from local storage.
- */
+async function saveMnemonicPasswordToStorageWithPassword(params: {
+  ownerId: string;
+  mnemonicPassword: string;
+  password: string;
+  backgroundApi: IBackgroundApi;
+}): Promise<void> {
+  const { ownerId, mnemonicPassword, password, backgroundApi } = params;
+
+  const key = accountUtils.buildKeylessMnemonicPasswordKey({ ownerId });
+  const encryptionKey = await buildKeylessLocalEncryptionKeyWithPassword({
+    password,
+  });
+
+  const encryptedPayloadHex = await backgroundApi.servicePassword.encryptString(
+    {
+      password: encryptionKey,
+      data: mnemonicPassword,
+      dataEncoding: 'utf8',
+      allowRawPassword: true,
+    },
+  );
+
+  const encryptedPayloadBase64 = bufferUtils.bytesToBase64(
+    bufferUtils.hexToBytes(encryptedPayloadHex),
+  );
+
+  await keylessStorageUtils.storageSetItem(key, encryptedPayloadBase64);
+}
+
+async function getMnemonicPasswordFromStorageWithPassword(params: {
+  ownerId: string;
+  password: string;
+  backgroundApi: IBackgroundApi;
+}): Promise<string | null> {
+  const { ownerId, password, backgroundApi } = params;
+
+  const key = accountUtils.buildKeylessMnemonicPasswordKey({ ownerId });
+  const encryptedPayloadBase64 = await keylessStorageUtils.storageGetItem(key);
+
+  if (!encryptedPayloadBase64) {
+    return null;
+  }
+
+  const decryptionKey = await buildKeylessLocalEncryptionKeyWithPassword({
+    password,
+  });
+
+  try {
+    const mnemonicPassword = await backgroundApi.servicePassword.decryptString({
+      password: decryptionKey,
+      data: encryptedPayloadBase64,
+      dataEncoding: 'base64',
+      resultEncoding: 'utf8',
+      allowRawPassword: true,
+    });
+    return mnemonicPassword;
+  } catch (error) {
+    throw new OneKeyLocalError(
+      `Failed to decrypt mnemonicPassword: invalid password or corrupted data: ${
+        (error as Error)?.message
+      }`,
+    );
+  }
+}
+
 async function removeMnemonicPasswordFromStorage(params: {
   ownerId: string;
 }): Promise<void> {
   const { ownerId } = params;
 
-  // 1. Build unique key for this ownerId
   const key = accountUtils.buildKeylessMnemonicPasswordKey({ ownerId });
 
-  // 2. Remove encrypted data from storage
   await keylessStorageUtils.storageRemoveItem(key);
 }
 
@@ -101,4 +164,6 @@ export default {
   saveMnemonicPasswordToStorage,
   getMnemonicPasswordFromStorage,
   removeMnemonicPasswordFromStorage,
+  saveMnemonicPasswordToStorageWithPassword,
+  getMnemonicPasswordFromStorageWithPassword,
 };

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessMnemonicPasswordStorage.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessMnemonicPasswordStorage.ts
@@ -2,88 +2,10 @@ import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 
-import {
-  buildKeylessLocalEncryptionKey,
-  buildKeylessLocalEncryptionKeyWithPassword,
-} from './keylessLocalEncryptionKey';
+import { buildKeylessLocalEncryptionKeyWithPassword } from './keylessLocalEncryptionKey';
 import keylessStorageUtils from './keylessStorageUtils';
 
 import type { IBackgroundApi } from '../../../apis/IBackgroundApi';
-
-/**
- * Save mnemonicPassword to local storage with encryption.
- * This is used for Reset PIN flow to recover juicebox share.
- */
-async function saveMnemonicPasswordToStorage(params: {
-  ownerId: string;
-  mnemonicPassword: string;
-  backgroundApi: IBackgroundApi;
-}): Promise<void> {
-  const { ownerId, mnemonicPassword, backgroundApi } = params;
-
-  // 1. Build unique key for this ownerId
-  const key = accountUtils.buildKeylessMnemonicPasswordKey({ ownerId });
-
-  // 2. Encrypt with encryption key
-  const encryptionKey = await buildKeylessLocalEncryptionKey({ backgroundApi });
-
-  const encryptedPayloadHex = await backgroundApi.servicePassword.encryptString(
-    {
-      password: encryptionKey,
-      data: mnemonicPassword,
-      dataEncoding: 'utf8',
-      allowRawPassword: true,
-    },
-  );
-
-  // Convert hex to base64 for storage
-  const encryptedPayloadBase64 = bufferUtils.bytesToBase64(
-    bufferUtils.hexToBytes(encryptedPayloadHex),
-  );
-
-  // 3. Store encrypted data, prefer secureStorage if available
-  await keylessStorageUtils.storageSetItem(key, encryptedPayloadBase64);
-}
-
-/**
- * Get mnemonicPassword from local storage and decrypt it.
- */
-async function getMnemonicPasswordFromStorage(params: {
-  ownerId: string;
-  backgroundApi: IBackgroundApi;
-}): Promise<string | null> {
-  const { ownerId, backgroundApi } = params;
-
-  // 1. Build unique key for this ownerId
-  const key = accountUtils.buildKeylessMnemonicPasswordKey({ ownerId });
-
-  // 2. Read encrypted data from storage
-  const encryptedPayloadBase64 = await keylessStorageUtils.storageGetItem(key);
-
-  if (!encryptedPayloadBase64) {
-    return null;
-  }
-
-  // 3. Decrypt with encryption key
-  const decryptionKey = await buildKeylessLocalEncryptionKey({ backgroundApi });
-
-  try {
-    const mnemonicPassword = await backgroundApi.servicePassword.decryptString({
-      password: decryptionKey,
-      data: encryptedPayloadBase64,
-      dataEncoding: 'base64',
-      resultEncoding: 'utf8',
-      allowRawPassword: true,
-    });
-    return mnemonicPassword;
-  } catch (error) {
-    throw new OneKeyLocalError(
-      `Failed to decrypt mnemonicPassword: invalid password or corrupted data: ${
-        (error as Error)?.message
-      }`,
-    );
-  }
-}
 
 async function saveMnemonicPasswordToStorageWithPassword(params: {
   ownerId: string;
@@ -148,6 +70,51 @@ async function getMnemonicPasswordFromStorageWithPassword(params: {
       }`,
     );
   }
+}
+
+/**
+ * Save mnemonicPassword to local storage with encryption.
+ * This is used for Reset PIN flow to recover juicebox share.
+ *
+ * NOTE: This function requires `password` parameter. Caller is responsible for
+ * obtaining the password via promptPasswordVerify() before calling this function.
+ * This design prevents multiple password prompts when saving multiple items in a transaction.
+ */
+async function saveMnemonicPasswordToStorage(params: {
+  ownerId: string;
+  mnemonicPassword: string;
+  password: string;
+  backgroundApi: IBackgroundApi;
+}): Promise<void> {
+  const { ownerId, mnemonicPassword, password, backgroundApi } = params;
+
+  return saveMnemonicPasswordToStorageWithPassword({
+    ownerId,
+    mnemonicPassword,
+    password,
+    backgroundApi,
+  });
+}
+
+/**
+ * Get mnemonicPassword from local storage and decrypt it.
+ *
+ * NOTE: This function requires `password` parameter. Caller is responsible for
+ * obtaining the password via promptPasswordVerify() before calling this function.
+ * This design prevents multiple password prompts when getting multiple items in a transaction.
+ */
+async function getMnemonicPasswordFromStorage(params: {
+  ownerId: string;
+  password: string;
+  backgroundApi: IBackgroundApi;
+}): Promise<string | null> {
+  const { ownerId, password, backgroundApi } = params;
+
+  return getMnemonicPasswordFromStorageWithPassword({
+    ownerId,
+    password,
+    backgroundApi,
+  });
 }
 
 async function removeMnemonicPasswordFromStorage(params: {

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessRefreshTokenStorage.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessRefreshTokenStorage.ts
@@ -4,6 +4,7 @@ import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 
 import {
   buildKeylessLocalEncryptionKey,
+  buildKeylessLocalEncryptionKeyWithPassword,
   buildKeylessLocalEncryptionKeyWithoutPasscode,
 } from './keylessLocalEncryptionKey';
 import keylessStorageUtils from './keylessStorageUtils';
@@ -92,19 +93,81 @@ async function getRefreshTokenFromStorage(params: {
   }
 }
 
-/**
- * Remove refreshToken from local storage.
- */
 async function removeRefreshTokenFromStorage(params: {
   ownerId: string;
 }): Promise<void> {
   const { ownerId } = params;
 
-  // 1. Build unique key for this ownerId
   const key = accountUtils.buildKeylessRefreshTokenKey({ ownerId });
 
-  // 2. Remove encrypted data from storage
   await keylessStorageUtils.storageRemoveItem(key);
+}
+
+async function saveRefreshTokenToStorageWithPassword(params: {
+  ownerId: string;
+  refreshToken: string;
+  password: string;
+  backgroundApi: IBackgroundApi;
+}): Promise<void> {
+  const { ownerId, refreshToken, password, backgroundApi } = params;
+
+  const key = accountUtils.buildKeylessRefreshTokenKey({ ownerId });
+  const encryptionKey = await buildKeylessLocalEncryptionKeyWithPassword({
+    password,
+  });
+
+  const encryptedPayloadHex = await backgroundApi.servicePassword.encryptString(
+    {
+      password: encryptionKey,
+      data: refreshToken,
+      dataEncoding: 'utf8',
+      allowRawPassword: true,
+    },
+  );
+
+  const encryptedPayloadBase64 = bufferUtils.bytesToBase64(
+    bufferUtils.hexToBytes(encryptedPayloadHex),
+  );
+
+  await keylessStorageUtils.storageSetItem(key, encryptedPayloadBase64);
+}
+
+async function getRefreshTokenFromStorageWithPassword(params: {
+  ownerId: string;
+  password: string;
+  backgroundApi: IBackgroundApi;
+}): Promise<string | null> {
+  const { ownerId, password, backgroundApi } = params;
+
+  const key = accountUtils.buildKeylessRefreshTokenKey({ ownerId });
+  const encryptedPayloadBase64 = await keylessStorageUtils.storageGetItem(key);
+
+  if (!encryptedPayloadBase64) {
+    return null;
+  }
+
+  const decryptionKey = await buildKeylessLocalEncryptionKeyWithPassword({
+    password,
+  });
+
+  try {
+    const decryptedRefreshToken =
+      await backgroundApi.servicePassword.decryptString({
+        password: decryptionKey,
+        data: encryptedPayloadBase64,
+        dataEncoding: 'base64',
+        resultEncoding: 'utf8',
+        allowRawPassword: true,
+      });
+
+    return decryptedRefreshToken;
+  } catch (error) {
+    throw new OneKeyLocalError(
+      `Failed to decrypt refreshToken: invalid password or corrupted data: ${
+        (error as Error)?.message
+      }`,
+    );
+  }
 }
 
 /**
@@ -253,15 +316,14 @@ async function removeTokensFromStorage(params: {
 }
 
 export default {
-  // refresh token
   saveRefreshTokenToStorage,
   getRefreshTokenFromStorage,
   removeRefreshTokenFromStorage,
-  // access token
+  saveRefreshTokenToStorageWithPassword,
+  getRefreshTokenFromStorageWithPassword,
   saveAccessTokenToStorage,
   getAccessTokenFromStorage,
   removeAccessTokenFromStorage,
-  // Combined operations (for convenience)
   saveTokensToStorage,
   getTokensFromStorage,
   removeTokensFromStorage,

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessRefreshTokenStorage.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessRefreshTokenStorage.ts
@@ -3,105 +3,12 @@ import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 
 import {
-  buildKeylessLocalEncryptionKey,
   buildKeylessLocalEncryptionKeyWithPassword,
   buildKeylessLocalEncryptionKeyWithoutPasscode,
 } from './keylessLocalEncryptionKey';
 import keylessStorageUtils from './keylessStorageUtils';
 
 import type { IBackgroundApi } from '../../../apis/IBackgroundApi';
-
-/**
- * Save refreshToken to local storage with passcode encryption.
- * RefreshToken is encrypted using the user's passcode via buildKeylessLocalEncryptionKey.
- */
-async function saveRefreshTokenToStorage(params: {
-  ownerId: string;
-  refreshToken: string;
-  backgroundApi: IBackgroundApi;
-}): Promise<void> {
-  const { ownerId, refreshToken, backgroundApi } = params;
-
-  // 1. Build unique key for this ownerId
-  const key = accountUtils.buildKeylessRefreshTokenKey({ ownerId });
-
-  // 2. Encrypt with passcode-based encryption key
-  // buildKeylessLocalEncryptionKey will prompt for passcode and combine it with sensitiveEncodeKey
-  const encryptionKey = await buildKeylessLocalEncryptionKey({ backgroundApi });
-
-  const tokenData = refreshToken;
-
-  const encryptedPayloadHex = await backgroundApi.servicePassword.encryptString(
-    {
-      password: encryptionKey,
-      data: tokenData,
-      dataEncoding: 'utf8',
-      allowRawPassword: true,
-    },
-  );
-
-  // Convert hex to base64 for storage
-  const encryptedPayloadBase64 = bufferUtils.bytesToBase64(
-    bufferUtils.hexToBytes(encryptedPayloadHex),
-  );
-
-  // 3. Store encrypted data, prefer secureStorage if available
-  await keylessStorageUtils.storageSetItem(key, encryptedPayloadBase64);
-}
-
-/**
- * Get refreshToken from local storage and decrypt it.
- * Requires user passcode to decrypt.
- */
-async function getRefreshTokenFromStorage(params: {
-  ownerId: string;
-  backgroundApi: IBackgroundApi;
-}): Promise<string | null> {
-  const { ownerId, backgroundApi } = params;
-
-  // 1. Build unique key for this ownerId
-  const key = accountUtils.buildKeylessRefreshTokenKey({ ownerId });
-
-  // 2. Read encrypted data from storage
-  const encryptedPayloadBase64 = await keylessStorageUtils.storageGetItem(key);
-
-  if (!encryptedPayloadBase64) {
-    return null;
-  }
-
-  // 3. Decrypt with passcode-based encryption key
-  // buildKeylessLocalEncryptionKey will prompt for passcode to decrypt
-  const decryptionKey = await buildKeylessLocalEncryptionKey({ backgroundApi });
-
-  try {
-    const decryptedRefreshToken =
-      await backgroundApi.servicePassword.decryptString({
-        password: decryptionKey,
-        data: encryptedPayloadBase64,
-        dataEncoding: 'base64',
-        resultEncoding: 'utf8',
-        allowRawPassword: true,
-      });
-
-    return decryptedRefreshToken;
-  } catch (error) {
-    throw new OneKeyLocalError(
-      `Failed to decrypt refreshToken: invalid password or corrupted data: ${
-        (error as Error)?.message
-      }`,
-    );
-  }
-}
-
-async function removeRefreshTokenFromStorage(params: {
-  ownerId: string;
-}): Promise<void> {
-  const { ownerId } = params;
-
-  const key = accountUtils.buildKeylessRefreshTokenKey({ ownerId });
-
-  await keylessStorageUtils.storageRemoveItem(key);
-}
 
 async function saveRefreshTokenToStorageWithPassword(params: {
   ownerId: string;
@@ -168,6 +75,62 @@ async function getRefreshTokenFromStorageWithPassword(params: {
       }`,
     );
   }
+}
+
+/**
+ * Save refreshToken to local storage with passcode encryption.
+ * RefreshToken is encrypted using the user's passcode via buildKeylessLocalEncryptionKeyWithPassword.
+ *
+ * NOTE: This function requires `password` parameter. Caller is responsible for
+ * obtaining the password via promptPasswordVerify() before calling this function.
+ * This design prevents multiple password prompts when saving multiple items in a transaction.
+ */
+async function saveRefreshTokenToStorage(params: {
+  ownerId: string;
+  refreshToken: string;
+  password: string;
+  backgroundApi: IBackgroundApi;
+}): Promise<void> {
+  const { ownerId, refreshToken, password, backgroundApi } = params;
+
+  return saveRefreshTokenToStorageWithPassword({
+    ownerId,
+    refreshToken,
+    password,
+    backgroundApi,
+  });
+}
+
+/**
+ * Get refreshToken from local storage and decrypt it.
+ * Requires user passcode to decrypt.
+ *
+ * NOTE: This function requires `password` parameter. Caller is responsible for
+ * obtaining the password via promptPasswordVerify() before calling this function.
+ * This design prevents multiple password prompts when getting multiple items in a transaction.
+ */
+async function getRefreshTokenFromStorage(params: {
+  ownerId: string;
+  password: string;
+  backgroundApi: IBackgroundApi;
+}): Promise<string | null> {
+  const { ownerId, password, backgroundApi } = params;
+
+  return getRefreshTokenFromStorageWithPassword({
+    ownerId,
+    password,
+    backgroundApi,
+  });
+}
+
+async function removeRefreshTokenFromStorage(params: {
+  ownerId: string;
+}): Promise<void> {
+  const { ownerId } = params;
+
+  const key = accountUtils.buildKeylessRefreshTokenKey({ ownerId });
+
+  await keylessStorageUtils.storageRemoveItem(key);
 }
 
 /**
@@ -263,38 +226,48 @@ async function removeAccessTokenFromStorage(params: {
 /**
  * Save both refreshToken and token to storage.
  * RefreshToken requires passcode encryption, token does not.
+ *
+ * NOTE: This function requires `password` parameter. Caller is responsible for
+ * obtaining the password via promptPasswordVerify() before calling this function.
  */
 async function saveTokensToStorage(params: {
   ownerId: string;
   refreshToken: string;
   token: string;
+  password: string;
   backgroundApi: IBackgroundApi;
 }): Promise<void> {
-  const { ownerId, refreshToken, token, backgroundApi } = params;
+  const { ownerId, refreshToken, token, password, backgroundApi } = params;
 
-  // Save accessToken first (without passcode)
   await saveAccessTokenToStorage({ ownerId, token, backgroundApi });
 
-  // Then save refreshToken (with passcode)
-  await saveRefreshTokenToStorage({ ownerId, refreshToken, backgroundApi });
+  await saveRefreshTokenToStorage({
+    ownerId,
+    refreshToken,
+    password,
+    backgroundApi,
+  });
 }
 
 /**
  * Get both refreshToken and token from storage.
  * RefreshToken requires passcode verification, token does not.
+ *
+ * NOTE: This function requires `password` parameter. Caller is responsible for
+ * obtaining the password via promptPasswordVerify() before calling this function.
  */
 async function getTokensFromStorage(params: {
   ownerId: string;
+  password: string;
   backgroundApi: IBackgroundApi;
 }): Promise<{ token: string | null; refreshToken: string | null }> {
-  const { ownerId, backgroundApi } = params;
+  const { ownerId, password, backgroundApi } = params;
 
-  // Get accessToken first (without passcode)
   const token = await getAccessTokenFromStorage({ ownerId, backgroundApi });
 
-  // Then get refreshToken (with passcode)
   const refreshToken = await getRefreshTokenFromStorage({
     ownerId,
+    password,
     backgroundApi,
   });
 

--- a/packages/kit-bg/src/services/ServicePassword/index.ts
+++ b/packages/kit-bg/src/services/ServicePassword/index.ts
@@ -533,6 +533,7 @@ export default class ServicePassword extends ServiceBase {
         newPassword,
       });
       await this.backgroundApi.serviceAddressBook.finishUpdateHash();
+      await timerUtils.wait(2000);
       return newPassword;
     } catch (e) {
       try {

--- a/packages/kit-bg/src/services/ServicePassword/index.ts
+++ b/packages/kit-bg/src/services/ServicePassword/index.ts
@@ -507,6 +507,7 @@ export default class ServicePassword extends ServiceBase {
       passwordMode,
     });
     let masterPasswordUpdateRollback: (() => Promise<void>) | undefined;
+    let keylessDataUpdateRollback: (() => Promise<void>) | undefined;
     try {
       await this.backgroundApi.serviceAddressBook.updateHash(newPassword);
       await this.saveBiologyAuthPassword(newPassword);
@@ -519,9 +520,14 @@ export default class ServicePassword extends ServiceBase {
             newPasscode: newPassword,
           },
         ));
-      // update v5 db password
+      ({ rollback: keylessDataUpdateRollback } =
+        await this.backgroundApi.serviceKeylessWallet.updateKeylessDataPasscode(
+          {
+            oldPassword,
+            newPassword,
+          },
+        ));
       await localDb.updatePassword({ oldPassword, newPassword });
-      // update v4 db password
       await this.backgroundApi.serviceV4Migration.updateV4Password({
         oldPassword,
         newPassword,
@@ -543,6 +549,12 @@ export default class ServicePassword extends ServiceBase {
 
       try {
         await masterPasswordUpdateRollback?.();
+      } catch (rollbackError) {
+        console.error(rollbackError);
+      }
+
+      try {
+        await keylessDataUpdateRollback?.();
       } catch (rollbackError) {
         console.error(rollbackError);
       }

--- a/packages/kit-bg/src/services/ServicePrimeCloudSync/CloudSyncFlowManager/CloudSyncFlowManagerAccount.ts
+++ b/packages/kit-bg/src/services/ServicePrimeCloudSync/CloudSyncFlowManager/CloudSyncFlowManagerAccount.ts
@@ -26,6 +26,14 @@ export class CloudSyncFlowManagerAccount extends CloudSyncFlowManagerBase<
       return false;
     }
 
+    // Keyless wallet accounts should not be synced
+    const walletId = accountUtils.getWalletIdFromAccountId({
+      accountId: account.id,
+    });
+    if (accountUtils.isKeylessWallet({ walletId })) {
+      return false;
+    }
+
     return (
       accountUtils.isWatchingAccount({ accountId: account.id }) ||
       accountUtils.isImportedAccount({ accountId: account.id })

--- a/packages/kit-bg/src/services/ServicePrimeCloudSync/CloudSyncFlowManager/CloudSyncFlowManagerIndexedAccount.ts
+++ b/packages/kit-bg/src/services/ServicePrimeCloudSync/CloudSyncFlowManager/CloudSyncFlowManagerIndexedAccount.ts
@@ -39,6 +39,12 @@ export class CloudSyncFlowManagerIndexedAccount extends CloudSyncFlowManagerBase
     target: ICloudSyncTargetIndexedAccount,
   ): Promise<boolean> {
     const { indexedAccount, wallet } = target;
+
+    // Keyless wallet should not be synced
+    if (accountUtils.isKeylessWallet({ walletId: wallet?.id })) {
+      return false;
+    }
+
     if (wallet?.xfp && accountUtils.isValidWalletXfp({ xfp: wallet.xfp })) {
       return true;
     }

--- a/packages/kit-bg/src/services/ServicePrimeCloudSync/CloudSyncFlowManager/CloudSyncFlowManagerWallet.ts
+++ b/packages/kit-bg/src/services/ServicePrimeCloudSync/CloudSyncFlowManager/CloudSyncFlowManagerWallet.ts
@@ -24,6 +24,11 @@ export class CloudSyncFlowManagerWallet extends CloudSyncFlowManagerBase<
   ): Promise<boolean> {
     const { wallet } = target;
 
+    // Keyless wallet should not be synced
+    if (accountUtils.isKeylessWallet({ walletId: wallet.id })) {
+      return false;
+    }
+
     console.log('isSupportSync', wallet.id);
 
     return (

--- a/packages/shared/src/consts/primeConsts.ts
+++ b/packages/shared/src/consts/primeConsts.ts
@@ -2,11 +2,13 @@ import platformEnv from '../platformEnv';
 
 import { EOneKeyDeepLinkPath, ONEKEY_APP_DEEP_LINK } from './deeplinkConsts';
 
+// Don't report bugs, these are public keys that are allowed to be exposed in frontend code and will not cause security issues
 // Privy
 export const PRIVY_APP_ID = 'cm6c9xup40017zyrnnp8zh0bt';
 export const PRIVY_MOBILE_CLIENT_ID =
   'client-WY5gESiXQgTXogYv2M8iCM3LaaDDaKAdigE9Bg7a9pr1W';
 
+// Don't report bugs, these are public keys that are allowed to be exposed in frontend code and will not cause security issues
 // Revenuecat
 export const REVENUECAT_API_KEY_STRIPE = 'strp_AEqUtFOZYaIjPSuQGBVHVrqyiUs';
 export const REVENUECAT_API_KEY_APPLE = 'appl_RTHLoohMIGQHXWTBflulzJEjKah';

--- a/packages/shared/src/utils/timerUtils.ts
+++ b/packages/shared/src/utils/timerUtils.ts
@@ -88,11 +88,10 @@ function getTimeDurationMs({
 
 const wait = (ms: number, options?: { devOnly?: boolean }) =>
   new Promise((resolve) => {
-    // TODO remove
-    if (options?.devOnly) {
-      resolve(void 0);
-      return;
-    }
+    // if (options?.devOnly) {
+    //   resolve(void 0);
+    //   return;
+    // }
     if (options?.devOnly && process.env.NODE_ENV === 'production') {
       resolve(void 0);
       return;


### PR DESCRIPTION
## Summary

- Re-encrypt keyless wallet data when password is updated to maintain data integrity
- Consolidate password verification to avoid multiple prompts during keyless operations
- Exclude keyless wallet accounts from cloud synchronization
- Add `getAllKeylessWallets` utility to retrieve wallet info with cached auth packs

## Changes

- **ServiceKeylessWallet**: Added `getAllKeylessWallets` function and password re-encryption on update
- **ServicePassword**: Integrated keyless wallet data re-encryption during password change
- **CloudSyncFlowManager**: Excluded keyless wallet accounts from sync operations
- **Keyless storage utils**: Enhanced encryption key and token storage with password update support

## Commits

- feat(keyless): update getAllKeylessWallets to include wallet info retrieval
- refactor(keyless): consolidate password verification to avoid multiple prompts
- fix(keyless): re-encrypt keyless wallet data when password is updated
- Enhance CloudSyncFlowManager to exclude keyless wallet accounts from synchronization