### PR TITLE
fix(desktop): detect secure storage availability on Linux

### DIFF
--- a/apps/desktop/app/libs/store.ts
+++ b/apps/desktop/app/libs/store.ts
@@ -116,6 +116,25 @@ export const deleteSecureItem = (key: string) => {
   store.set(EDesktopStoreKeys.EncryptedData, items);
 };
 
+export const isSecureStorageAvailable = (): boolean => {
+  const available = safeStorage.isEncryptionAvailable();
+  if (!available) {
+    return false;
+  }
+  // On Linux, check if we have a real secure backend (not basic_text)
+  // basic_text means data is encrypted with a hardcoded password, which is not secure
+  if (process.platform === 'linux') {
+    const backend = safeStorage.getSelectedStorageBackend();
+    if (backend === 'basic_text') {
+      logger.warn(
+        'safeStorage backend is basic_text, secure storage is not truly secure',
+      );
+      return false;
+    }
+  }
+  return true;
+};
+
 export const setASCFile = (ascFile: string) => {
   store.set(EDesktopStoreKeys.ASCFile, ascFile);
 };

--- a/packages/kit-bg/src/desktopApis/DesktopApiStorage.ts
+++ b/packages/kit-bg/src/desktopApis/DesktopApiStorage.ts
@@ -45,6 +45,10 @@ class DesktopApiStorage {
   async secureDelItemAsync(key: string): Promise<void> {
     store.deleteSecureItem(key);
   }
+
+  async isSecureStorageAvailable(): Promise<boolean> {
+    return store.isSecureStorageAvailable();
+  }
 }
 
 export default DesktopApiStorage;

--- a/packages/kit/src/components/KeylessWallet/useKeylessWallet.tsx
+++ b/packages/kit/src/components/KeylessWallet/useKeylessWallet.tsx
@@ -1015,25 +1015,14 @@ export function useVerifyKeylessPinChecking() {
   const [keylessPinConfirmStatus] = useKeylessPinConfirmStatusAtom();
 
   const cancelVerifyPin = useCallback(async (ownerId: string) => {
-    await backgroundApiProxy.servicePassword.promptPasswordVerify();
-    // Try to refresh session if refreshToken is valid
-    let refreshResult;
-    try {
-      refreshResult =
-        await backgroundApiProxy.serviceKeylessWallet.tryRefreshTokenFromStorage(
-          { ownerId },
-        );
-    } catch (error) {
-      // Continue to navigation if refresh fails
-    }
-
-    if (
-      refreshResult &&
-      refreshResult?.accessToken &&
-      refreshResult?.refreshToken
-    ) {
+    const accessToken =
+      await backgroundApiProxy.serviceKeylessWallet.getKeylessCachedAccessToken(
+        { ownerId },
+      );
+   
+    if (accessToken)     {
       await backgroundApiProxy.serviceKeylessWallet.apiUpdatePinConfirmStatus({
-        token: refreshResult.accessToken,
+        token: accessToken,
         isCancelAction: true,
       });
     }

--- a/packages/shared/src/storage/secureStorage/index.desktop.ts
+++ b/packages/shared/src/storage/secureStorage/index.desktop.ts
@@ -20,11 +20,12 @@ const removeSecureItem = async (key: string) =>
   globalThis?.desktopApiProxy?.storage?.secureDelItemAsync(key);
 
 const supportSecureStorage = async () => {
-  // The secure storage of the desktop in the development environment does not work, the data written only has the key, and the value is always empty
   if (platformEnv.isDesktop && platformEnv.isDev) {
     return false;
   }
-  return true;
+  const available =
+    await globalThis?.desktopApiProxy?.storage?.isSecureStorageAvailable?.();
+  return available ?? false;
 };
 
 const storage: ISecureStorage = {


### PR DESCRIPTION
## Summary

- Add `isSecureStorageAvailable()` to detect if Electron's safeStorage uses a secure backend
- On Linux, reject `basic_text` backend which encrypts with a hardcoded password (not truly secure)
- Update `supportSecureStorage()` to dynamically query availability from main process instead of returning `true`
- Simplify `cancelVerifyPin` logic to use cached accessToken directly

## Changes

| File | Change |
|------|--------|
| `apps/desktop/app/libs/store.ts` | Add `isSecureStorageAvailable()` with Linux backend check |
| `packages/kit-bg/src/desktopApis/DesktopApiStorage.ts` | Expose `isSecureStorageAvailable()` to renderer |
| `packages/shared/src/storage/secureStorage/index.desktop.ts` | Query main process for secure storage availability |
| `packages/kit/src/components/KeylessWallet/useKeylessWallet.tsx` | Simplify cancelVerifyPin to use cached token |

## Why

On Linux systems without a proper keychain (GNOME Keyring, KWallet, etc.), Electron's safeStorage falls back to `basic_text` backend which uses a hardcoded encryption key. This gives a false sense of security. This PR ensures we correctly detect and reject this insecure fallback.