### PR TITLE
feat(tradingview): add app version to URL parameters

### DIFF
--- a/packages/kit/src/components/TradingView/hooks/useTradingViewUrl.ts
+++ b/packages/kit/src/components/TradingView/hooks/useTradingViewUrl.ts
@@ -46,6 +46,9 @@ export function useTradingViewUrl(options: IUseTradingViewUrlOptions = {}) {
     url.searchParams.set('locale', locale);
     url.searchParams.set('platform', platformEnv.appPlatform ?? 'web');
     url.searchParams.set('theme', theme);
+    if (platformEnv.version) {
+      url.searchParams.set('appVersion', platformEnv.version);
+    }
 
     // Add any additional parameters
     if (additionalParams) {


### PR DESCRIPTION
## Summary
- Add `appVersion` parameter to TradingView URL for tracking app usage across different versions
- The version is obtained from `platformEnv.version` which is set from `process.env.VERSION`

## Test plan
- [ ] Verify TradingView URL includes `appVersion` parameter
- [ ] Test on different platforms (web, desktop, mobile, extension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)