### PR TITLE
fix(discovery): hide browser history button on Market tab OK-49130

### DIFF
--- a/packages/kit/src/components/TabPageHeader/HeaderRight.tsx
+++ b/packages/kit/src/components/TabPageHeader/HeaderRight.tsx
@@ -160,6 +160,10 @@ export function HeaderRight({
             </>
           );
         }
+        if (selectedHeaderTab === ETranslations.global_market) {
+          return null;
+        }
+        // Browser tab
         return (
           <>
             <HistoryIconButton />


### PR DESCRIPTION
## Summary

- Fix incorrect display of browser history button on Market tab in Discovery page
- The history button should only appear when Browser tab is active, not Market tab
- Added condition check for `global_market` tab to return null instead of showing browser-specific buttons

## Changes

- `packages/kit/src/components/TabPageHeader/HeaderRight.tsx`: Added check for Market tab to hide history button

## Test Plan

- [ ] Open Discovery page on mobile
- [ ] Switch to Market tab - verify no history button appears
- [ ] Switch to Browser tab - verify history button appears
- [ ] Switch to Earn tab - verify gift button appears

Fixes OK-49130