### PR TITLE
OK-49175: hide connection status for deprecated and hidden wallets

### DIFF
--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/AccountSelectorWalletListSideBar.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/AccountSelectorWalletListSideBar.tsx
@@ -331,6 +331,17 @@ export function AccountSelectorWalletListSideBar({
   const walletConnectionMap = useMemo(() => {
     const map = new Map<string, boolean>();
     wallets.forEach((wallet) => {
+      // Deprecated wallets should not show connection status
+      if (wallet.deprecated) {
+        map.set(wallet.id, false);
+        return;
+      }
+      // Hidden wallets (passphrase wallets) should never show connection status
+      if (accountUtils.isHwHiddenWallet({ wallet })) {
+        map.set(wallet.id, false);
+        return;
+      }
+
       const isHwWallet = accountUtils.isHwWallet({ walletId: wallet.id });
       const deviceId = wallet.associatedDeviceInfo?.deviceId;
       const isConnected =

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/WalletListItem.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/WalletListItem.tsx
@@ -290,7 +290,8 @@ export function WalletListItem({
             focusedWallet={focusedWallet}
             onWalletPress={onWalletPress}
             onWalletLongPress={onWalletLongPress}
-            isConnected={isConnected}
+            // Hidden wallets should never show connection status
+            isConnected={false}
             {...(media.md && {
               badge: Number(index) + 1,
             })}


### PR DESCRIPTION
- Deprecated wallets no longer show USB connection indicator
- Hidden wallets (passphrase wallets) never show connection status
- Nested hidden wallets in WalletListItem always receive isConnected=false