### PR TITLE
chore: remove .env file loading, use 1Password for secrets

### DIFF
--- a/development/env.js
+++ b/development/env.js
@@ -8,7 +8,6 @@ const results = [
       // priority: high -> low
       path.resolve(__dirname, '../.env.version'),
       path.resolve(__dirname, '../.env.expo'),
-      path.resolve(__dirname, '../.env'),
     ],
   }),
 ];


### PR DESCRIPTION
## Summary
- Remove `.env` file loading from `development/env.js`
- Sensitive environment variables now must be provided via 1Password (`yarn op`)
- `.env.version` and `.env.expo` continue to load normally

## Background
The project has migrated to 1Password for managing sensitive environment variables via `op-run.sh`. This change disables the local `.env` file loading to enforce the use of 1Password.

## Changes
- `development/env.js`: Removed `path.resolve(__dirname, '../.env')` from dotenv config

## Test plan
- [x] Syntax check passed
- [ ] `yarn op yarn app:web` works with 1Password
- [ ] `yarn op yarn fetch:locale` works with 1Password