### PR TITLE
feat(desktop): flatten DeFi and Referral to top-level sidebar menu

### DIFF
--- a/packages/kit/src/routes/Tab/router.ts
+++ b/packages/kit/src/routes/Tab/router.ts
@@ -190,7 +190,6 @@ export const useTabRouterConfig = (params?: IGetTabRouterParams) => {
           focused ? 'CoinsSolid' : 'CoinsOutline',
         translationId: ETranslations.global_earn,
         freezeOnBlur: Boolean(params?.freezeOnBlur),
-        inMoreAction: true,
         rewrite: '/defi',
         exact: true,
         children: earnRouters,
@@ -200,11 +199,9 @@ export const useTabRouterConfig = (params?: IGetTabRouterParams) => {
       !platformEnv.isNative && isWebDappMode
         ? referFriendsTabConfig
         : undefined,
-      // In non-DAPP mode, show ReferFriends in more actions
       !platformEnv.isNative &&
         !isWebDappMode && {
           ...referFriendsTabConfig,
-          inMoreAction: true,
           hideOnTabBar: !isGtMdNonNative,
         },
       platformEnv.isNative


### PR DESCRIPTION
## Summary

- Move DeFi (Earn) and Referral menu items from the "More" dropdown to the top-level sidebar
- Both items now display directly in the sidebar with their icons visible even when collapsed

## Changes

- Removed `inMoreAction: true` from Earn (DeFi) tab configuration
- Removed `inMoreAction: true` from ReferFriends (Referral) tab configuration

## Test plan

- [ ] Open desktop app
- [ ] Verify DeFi and Referral icons appear in the sidebar (not in More menu)
- [ ] Verify icons are visible when sidebar is collapsed
- [ ] Verify clicking the icons navigates to correct pages