### PR TITLE
refactor: merge BrowserSubmenuColumn to single instance with animation

### DIFF
--- a/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/BrowserSubmenuColumn.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/BrowserSubmenuColumn.tsx
@@ -60,12 +60,12 @@ export function BrowserSubmenuColumn({
     focusedRouteName === ETabRoutes.Discovery ||
     focusedRouteName === multiTabBrowserRouteName;
 
-  type TabBarProps = { inSubmenu?: boolean; isCollapsedOverride?: boolean };
+  type ITabBarProps = { inSubmenu?: boolean; isCollapsedOverride?: boolean };
 
   // Single webPageTabBar with isCollapsedOverride following isHovered
   const webPageTabBarWithProps = useMemo(
     () =>
-      cloneElement(webPageTabBar as ReactElement<TabBarProps>, {
+      cloneElement(webPageTabBar as ReactElement<ITabBarProps>, {
         inSubmenu: true,
         isCollapsedOverride: !isHovered,
       }),

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/BrowserSubmenuColumn.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/BrowserSubmenuColumn.tsx
@@ -1,0 +1,94 @@
+import {
+  cloneElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type { ReactElement } from 'react';
+
+import { XStack } from '@onekeyhq/components/src/primitives';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import { ETabRoutes } from '@onekeyhq/shared/src/routes/tab';
+
+import { SubmenuColumn } from './SubmenuColumn';
+import { VerticalDivider } from './VerticalDivider';
+
+export interface IBrowserSubmenuColumnProps {
+  webPageTabBar: ReactElement;
+  focusedRouteName?: string;
+  multiTabBrowserRouteName?: string;
+}
+
+const HOVER_DELAY_MS = 150;
+
+// Browser submenu only shows on desktop and iOS (iPad)
+const isShowWebTabBar = platformEnv.isDesktop || platformEnv.isNativeIOS;
+
+export function BrowserSubmenuColumn({
+  webPageTabBar,
+  focusedRouteName,
+  multiTabBrowserRouteName,
+}: IBrowserSubmenuColumnProps) {
+  const [isHovered, setIsHovered] = useState(false);
+  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearHoverTimer = useCallback(() => {
+    if (hoverTimerRef.current) {
+      clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = null;
+    }
+  }, []);
+
+  const handleHoverIn = useCallback(() => {
+    clearHoverTimer();
+    hoverTimerRef.current = setTimeout(() => {
+      setIsHovered(true);
+    }, HOVER_DELAY_MS);
+  }, [clearHoverTimer]);
+
+  const handleHoverOut = useCallback(() => {
+    clearHoverTimer();
+    setIsHovered(false);
+  }, [clearHoverTimer]);
+
+  useEffect(() => clearHoverTimer, [clearHoverTimer]);
+
+  // Check if Browser or MultiTabBrowser is currently selected
+  const isBrowserSelected =
+    focusedRouteName === ETabRoutes.Discovery ||
+    focusedRouteName === multiTabBrowserRouteName;
+
+  type TabBarProps = { inSubmenu?: boolean; isCollapsedOverride?: boolean };
+
+  // Single webPageTabBar with isCollapsedOverride following isHovered
+  const webPageTabBarWithProps = useMemo(
+    () =>
+      cloneElement(webPageTabBar as ReactElement<TabBarProps>, {
+        inSubmenu: true,
+        isCollapsedOverride: !isHovered,
+      }),
+    [webPageTabBar, isHovered],
+  );
+
+  // Early return if conditions not met (after all hooks)
+  if (!isShowWebTabBar || !isBrowserSelected) {
+    return null;
+  }
+
+  return (
+    <XStack
+      position="relative"
+      flex={1}
+      onHoverIn={handleHoverIn}
+      onHoverOut={handleHoverOut}
+    >
+      <VerticalDivider />
+      <SubmenuColumn
+        webPageTabBar={webPageTabBarWithProps}
+        isExpanded={isHovered}
+      />
+    </XStack>
+  );
+}

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/SubmenuColumn.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/SubmenuColumn.tsx
@@ -3,7 +3,7 @@ import type { ReactElement } from 'react';
 import { YStack } from '@onekeyhq/components/src/primitives';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
-import { MIN_SIDEBAR_WIDTH } from '../../../../../utils/sidebar';
+import { MIN_SIDEBAR_WIDTH } from '@onekeyhq/components/src/utils/sidebar';
 
 // Height to align with primary menu header (Mac drag area or logo area)
 const HEADER_ALIGNMENT_HEIGHT = 52;

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/SubmenuColumn.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/SubmenuColumn.tsx
@@ -1,0 +1,39 @@
+import type { ReactElement } from 'react';
+
+import { YStack } from '@onekeyhq/components/src/primitives';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import { MIN_SIDEBAR_WIDTH } from '../../../../../utils/sidebar';
+
+// Height to align with primary menu header (Mac drag area or logo area)
+const HEADER_ALIGNMENT_HEIGHT = 52;
+const EXPANDED_SUBMENU_WIDTH = 200;
+
+export interface ISubmenuColumnProps {
+  webPageTabBar: ReactElement;
+  isExpanded?: boolean;
+}
+
+export function SubmenuColumn({
+  webPageTabBar,
+  isExpanded = false,
+}: ISubmenuColumnProps) {
+  // Desktop platforms have header space (Mac: drag area, Windows/Linux: logo)
+  // iPad has no header space
+  const shouldAddTopSpace = platformEnv.isDesktop;
+
+  return (
+    <YStack
+      width={isExpanded ? EXPANDED_SUBMENU_WIDTH : MIN_SIDEBAR_WIDTH - 10}
+      bg="$bgSidebar"
+      pt={12}
+      px={isExpanded ? '$6' : undefined}
+      alignItems={isExpanded ? undefined : 'center'}
+      flex={1}
+      animation="quick"
+    >
+      {shouldAddTopSpace ? <YStack height={HEADER_ALIGNMENT_HEIGHT} /> : null}
+      {webPageTabBar}
+    </YStack>
+  );
+}

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/VerticalDivider.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/VerticalDivider.tsx
@@ -1,0 +1,24 @@
+import { LinearGradient } from '@onekeyhq/components/src/content/LinearGradient';
+import { useThemeName } from '@onekeyhq/components/src/hooks/useStyle';
+
+export function VerticalDivider() {
+  const themeName = useThemeName();
+  const isDark = themeName === 'dark';
+
+  return (
+    <LinearGradient
+      width={1}
+      height={'100%'}
+      colors={[
+        'rgba(0, 0, 0, 0)',
+        'rgba(0, 0, 0, 0)',
+        isDark ? 'rgba(220, 220, 220, 0.12)' : 'rgba(0, 0, 0, 0.1)',
+        'rgba(0, 0, 0, 0)',
+        'rgba(0, 0, 0, 0)',
+      ]}
+      locations={[0, 0.04, 0.5, 0.8, 1]}
+      start={[0, 0]}
+      end={[0, 1]}
+    />
+  );
+}

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/index.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/index.tsx
@@ -1,0 +1,1 @@
+export * from './BrowserSubmenuColumn';

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
@@ -1,5 +1,5 @@
-import type { ReactElement } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ReactElement } from 'react';
 
 import { MotiView } from 'moti';
 import { useIntl } from 'react-intl';
@@ -39,6 +39,7 @@ import { ESwapSource } from '@onekeyhq/shared/types/swap/types';
 
 import { switchTab } from '../../Navigator/NavigationContainer';
 
+import { BrowserSubmenuColumn } from './BrowserSubmenuColumn';
 import { DesktopTabItem } from './DesktopTabItem';
 
 import type { ITabNavigatorExtraConfig } from '../../Navigator/types';
@@ -297,18 +298,30 @@ export function DesktopLeftSideBar({
   const [isHovering, setIsHovering] = useState(false);
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const isShowWebTabBar = platformEnv.isDesktop || platformEnv.isNativeIOS;
+  // Current focused route for browser submenu
+  const focusedRouteName = state.routes[state.index]?.name;
 
   const routesNotHidden = useMemo(() => {
+    // Browser submenu only shows on desktop and iOS (iPad)
+    const shouldShowBrowserSubmenu =
+      platformEnv.isDesktop || platformEnv.isNativeIOS;
     return routes.filter((route) => {
       const { options } = descriptors[route.key] as {
         options: {
           hiddenIcon?: boolean;
         };
       };
-      return !options.hiddenIcon;
+      // Hide the route if hiddenIcon is true
+      if (options.hiddenIcon) {
+        return false;
+      }
+      // Hide MultiTabBrowser from the primary menu (it's shown via Browser submenu)
+      if (shouldShowBrowserSubmenu && route.name === extraConfig?.name) {
+        return false;
+      }
+      return true;
     });
-  }, [routes, descriptors]);
+  }, [routes, descriptors, extraConfig?.name]);
 
   const tabs = useMemo(() => {
     const inMoreActionRoutes: NavigationRoute<ParamListBase, string>[] = [];
@@ -356,14 +369,6 @@ export function DesktopLeftSideBar({
         }
       };
 
-      if (isShowWebTabBar && route.name === extraConfig?.name) {
-        return (
-          <YStack flex={1} key={route.key}>
-            {webPageTabBar}
-          </YStack>
-        );
-      }
-
       return (
         <TabItemView
           key={route.key}
@@ -395,28 +400,27 @@ export function DesktopLeftSideBar({
     routesNotHidden,
     descriptors,
     state,
-    isShowWebTabBar,
-    extraConfig?.name,
     navigation,
-    webPageTabBar,
   ]);
 
-  const handleHoverIn = useCallback(() => {
-    if (hoverTimerRef.current) {
-      clearTimeout(hoverTimerRef.current);
-    }
-    hoverTimerRef.current = setTimeout(() => {
-      setIsHovering(true);
-    }, 200); // 200ms delay to prevent quick hover triggers
-  }, []);
-
-  const handleHoverOut = useCallback(() => {
+  const clearHoverTimer = useCallback(() => {
     if (hoverTimerRef.current) {
       clearTimeout(hoverTimerRef.current);
       hoverTimerRef.current = null;
     }
-    setIsHovering(false);
   }, []);
+
+  const handleHoverIn = useCallback(() => {
+    clearHoverTimer();
+    hoverTimerRef.current = setTimeout(() => {
+      setIsHovering(true);
+    }, 200);
+  }, [clearHoverTimer]);
+
+  const handleHoverOut = useCallback(() => {
+    clearHoverTimer();
+    setIsHovering(false);
+  }, [clearHoverTimer]);
 
   const handleToggleCollapse = useCallback(() => {
     defaultLogger.app.page.navigationToggle();
@@ -425,191 +429,195 @@ export function DesktopLeftSideBar({
       isCollapsed: !prev.isCollapsed,
     }));
     setIsHovering(false);
-  }, [setAppSideBarStatus, setIsHovering]);
+  }, [setAppSideBarStatus]);
 
   useShortcuts(EShortcutEvents.SideBar, handleToggleCollapse);
 
-  // Cleanup timer on unmount to prevent memory leak
-  useEffect(
-    () => () => {
-      if (hoverTimerRef.current) {
-        clearTimeout(hoverTimerRef.current);
-      }
-    },
-    [],
-  );
+  useEffect(() => clearHoverTimer, [clearHoverTimer]);
+
+  const primaryMenuWidth = isCollapse ? MIN_SIDEBAR_WIDTH : MAX_SIDEBAR_WIDTH;
 
   return (
-    <MotiView
+    <XStack
       testID="Desktop-AppSideBar-Container"
-      animate={{ width: isCollapse ? MIN_SIDEBAR_WIDTH : MAX_SIDEBAR_WIDTH }}
-      transition={
-        {
-          duration: 200,
-          type: 'timing',
-        } as MotiTransition
-      }
       style={{
         backgroundColor: theme.bgSidebar.val,
         paddingTop: top,
         zIndex: 2,
       }}
     >
-      {platformEnv.isDesktopMac ? (
-        // @ts-expect-error https://www.electronjs.org/docs/latest/tutorial/custom-window-interactions
-        <XStack
-          $platform-web={{
-            'app-region': 'drag',
-          }}
-          h={52}
-          ai="center"
-          jc="flex-end"
-          px="$4"
-        />
-      ) : null}
-      <YStack
-        position="relative"
-        flex={1}
-        testID="Desktop-AppSideBar-Content-Container"
+      <MotiView
+        testID="Desktop-AppSideBar-PrimaryMenu"
+        animate={{ width: primaryMenuWidth }}
+        transition={
+          {
+            duration: 200,
+            type: 'timing',
+          } as MotiTransition
+        }
       >
-        <MotiView
-          animate={{
-            width: isCollapse ? MIN_SIDEBAR_WIDTH : MAX_SIDEBAR_WIDTH,
-          }}
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            bottom: 0,
-          }}
-          transition={
-            {
-              duration: 120,
-              type: 'timing',
-            } as MotiTransition
-          }
+        {platformEnv.isDesktopMac ? (
+          // @ts-expect-error https://www.electronjs.org/docs/latest/tutorial/custom-window-interactions
+          <XStack
+            $platform-web={{
+              'app-region': 'drag',
+            }}
+            h={52}
+            ai="center"
+            jc="flex-end"
+            px="$4"
+          />
+        ) : null}
+        <YStack
+          position="relative"
+          flex={1}
+          testID="Desktop-AppSideBar-Content-Container"
         >
-          <YStack flex={1}>
-            {!platformEnv.isDesktopMac && !platformEnv.isNativeIOSPad ? (
-              <XStack
-                ai="center"
-                jc={isCollapse ? 'center' : 'flex-start'}
-                px="$4"
-                py="$3"
-              >
-                <Icon
-                  name="OnekeyLogoIllus"
-                  width={28}
-                  height={28}
-                  color="$text"
-                />
-                <MotiView
-                  animate={{
-                    opacity: isCollapse ? 0 : 1,
-                    width: isCollapse ? 0 : 62,
-                    marginLeft: isCollapse ? 0 : 12,
-                  }}
-                  transition={{
-                    opacity: {
-                      duration: isCollapse ? 0 : 200,
-                      type: 'timing',
-                      delay: isCollapse ? 0 : 100,
-                    },
-                    width: {
-                      duration: isCollapse ? 0 : 200,
-                      type: 'timing',
-                    },
-                    marginLeft: {
-                      duration: isCollapse ? 0 : 200,
-                      type: 'timing',
-                    },
-                  }}
-                  style={{
-                    overflow: 'hidden',
-                  }}
+          <MotiView
+            animate={{
+              width: isCollapse ? MIN_SIDEBAR_WIDTH : MAX_SIDEBAR_WIDTH,
+            }}
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              bottom: 0,
+            }}
+            transition={
+              {
+                duration: 120,
+                type: 'timing',
+              } as MotiTransition
+            }
+          >
+            <YStack flex={1}>
+              {!platformEnv.isDesktopMac && !platformEnv.isNativeIOSPad ? (
+                <XStack
+                  ai="center"
+                  jc={isCollapse ? 'center' : 'flex-start'}
+                  px="$4"
+                  py="$3"
                 >
                   <Icon
-                    name="OnekeyTextOnlyIllus"
-                    width={62}
+                    name="OnekeyLogoIllus"
+                    width={28}
                     height={28}
                     color="$text"
                   />
-                </MotiView>
-              </XStack>
-            ) : null}
-            <YStack
-              flex={1}
-              pt={isCollapse ? 0 : '$3'}
-              px="$3"
-              alignItems={isCollapse ? 'center' : undefined}
-            >
-              {tabs}
+                  <MotiView
+                    animate={{
+                      opacity: isCollapse ? 0 : 1,
+                      width: isCollapse ? 0 : 62,
+                      marginLeft: isCollapse ? 0 : 12,
+                    }}
+                    transition={{
+                      opacity: {
+                        duration: isCollapse ? 0 : 200,
+                        type: 'timing',
+                        delay: isCollapse ? 0 : 100,
+                      },
+                      width: {
+                        duration: isCollapse ? 0 : 200,
+                        type: 'timing',
+                      },
+                      marginLeft: {
+                        duration: isCollapse ? 0 : 200,
+                        type: 'timing',
+                      },
+                    }}
+                    style={{
+                      overflow: 'hidden',
+                    }}
+                  >
+                    <Icon
+                      name="OnekeyTextOnlyIllus"
+                      width={62}
+                      height={28}
+                      color="$text"
+                    />
+                  </MotiView>
+                </XStack>
+              ) : null}
+              <YStack
+                flex={1}
+                pt={isCollapse ? 0 : '$3'}
+                px="$3"
+                alignItems={isCollapse ? 'center' : undefined}
+              >
+                {tabs}
+              </YStack>
+              {bottomMenu}
             </YStack>
-            {bottomMenu}
-          </YStack>
-        </MotiView>
-      </YStack>
-      <YStack
-        testID="Desktop-AppSideBar-Separator"
-        position="absolute"
-        onHoverIn={handleHoverIn}
-        onHoverOut={handleHoverOut}
-        onPress={handleToggleCollapse}
-        cursor="pointer"
-        zIndex={1000}
-        right={-8}
-        top={0}
-        bottom={0}
-        width={16}
-      >
-        {isHovering ? (
-          <>
-            <YStack
-              position="absolute"
-              left={8}
-              top={64}
-              bottom={20}
-              width={1.5}
-              bg="$borderStrong"
-              pointerEvents="none"
-              animation="quick"
-              enterStyle={{
-                opacity: 0,
-              }}
-              opacity={1}
-            />
-            <YStack ai="center" jc="center" width="100%" mt="$24">
-              <Tooltip
-                open
-                placement="right"
-                renderTrigger={
-                  <IconButton
-                    aria-label="Toggle sidebar"
-                    icon={
-                      isCollapse
-                        ? 'ChevronRightSmallOutline'
-                        : 'ChevronLeftSmallOutline'
-                    }
-                    cursor="pointer"
-                    size="small"
-                    bg="$bgApp"
-                    elevation={5}
-                  />
-                }
-                renderContent={
-                  <Tooltip.Text shortcutKey={EShortcutEvents.SideBar}>
-                    {intl.formatMessage({
-                      id: isCollapse
-                        ? ETranslations.shortcut_expand_sidebar
-                        : ETranslations.shortcut_collapse_sidebar,
-                    })}
-                  </Tooltip.Text>
-                }
+          </MotiView>
+        </YStack>
+        <YStack
+          testID="Desktop-AppSideBar-Separator"
+          position="absolute"
+          onHoverIn={handleHoverIn}
+          onHoverOut={handleHoverOut}
+          onPress={handleToggleCollapse}
+          cursor="pointer"
+          zIndex={1000}
+          right={-8}
+          top={0}
+          bottom={0}
+          width={16}
+        >
+          {isHovering ? (
+            <>
+              <YStack
+                position="absolute"
+                left={8}
+                top={64}
+                bottom={20}
+                width={1.5}
+                bg="$borderStrong"
+                pointerEvents="none"
+                animation="quick"
+                enterStyle={{
+                  opacity: 0,
+                }}
+                opacity={1}
               />
-            </YStack>
-          </>
-        ) : null}
-      </YStack>
-    </MotiView>
+              <YStack ai="center" jc="center" width="100%" mt="$24">
+                <Tooltip
+                  open
+                  placement="right"
+                  renderTrigger={
+                    <IconButton
+                      aria-label="Toggle sidebar"
+                      icon={
+                        isCollapse
+                          ? 'ChevronRightSmallOutline'
+                          : 'ChevronLeftSmallOutline'
+                      }
+                      cursor="pointer"
+                      size="small"
+                      bg="$bgApp"
+                      elevation={5}
+                    />
+                  }
+                  renderContent={
+                    <Tooltip.Text shortcutKey={EShortcutEvents.SideBar}>
+                      {intl.formatMessage({
+                        id: isCollapse
+                          ? ETranslations.shortcut_expand_sidebar
+                          : ETranslations.shortcut_collapse_sidebar,
+                      })}
+                    </Tooltip.Text>
+                  }
+                />
+              </YStack>
+            </>
+          ) : null}
+        </YStack>
+      </MotiView>
+
+      <BrowserSubmenuColumn
+        webPageTabBar={webPageTabBar}
+        focusedRouteName={focusedRouteName}
+        multiTabBrowserRouteName={extraConfig?.name}
+      />
+    </XStack>
   );
 }

--- a/packages/kit/src/provider/Container/PortalBodyContainer/WebPageTabBar.desktop.tsx
+++ b/packages/kit/src/provider/Container/PortalBodyContainer/WebPageTabBar.desktop.tsx
@@ -2,12 +2,14 @@ import { useMedia } from '@onekeyhq/components';
 
 import DesktopCustomTabBar from '../../../views/Discovery/pages/DesktopCustomTabBar';
 
-const useShowWebBars = () => {
+export function WebPageTabBar({
+  isCollapsedOverride,
+}: {
+  isCollapsedOverride?: boolean;
+}) {
   const { gtMd } = useMedia();
-  return gtMd;
-};
-
-export const WebPageTabBar = () => {
-  const isShowWebBars = useShowWebBars();
-  return isShowWebBars ? <DesktopCustomTabBar /> : null;
-};
+  if (!gtMd) {
+    return null;
+  }
+  return <DesktopCustomTabBar isCollapsedOverride={isCollapsedOverride} />;
+}

--- a/packages/kit/src/routes/Tab/router.ts
+++ b/packages/kit/src/routes/Tab/router.ts
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 import { CommonActions } from '@react-navigation/native';
 
 import {
-  getTokenValue,
   rootNavigationRef,
   useMedia,
 } from '@onekeyhq/components';
@@ -233,11 +232,7 @@ export const useTabRouterConfig = (params?: IGetTabRouterParams) => {
             trackId: 'global-dev',
           }
         : undefined,
-      isShowDesktopDiscover
-        ? getDiscoverRouterConfig(params, {
-            marginTop: getTokenValue('$4', 'size'),
-          })
-        : undefined,
+      isShowDesktopDiscover ? getDiscoverRouterConfig(params) : undefined,
     ].filter((i) => !!i);
 
     if (isWebDappMode && tabs.length >= 2) {

--- a/packages/kit/src/views/Discovery/pages/DesktopCustomTabBar/index.tsx
+++ b/packages/kit/src/views/Discovery/pages/DesktopCustomTabBar/index.tsx
@@ -54,12 +54,15 @@ import { withBrowserProvider } from '../Browser/WithBrowserProvider';
 
 const TIMESTAMP_DIFF_MULTIPLIER = 2;
 
-function DesktopCustomTabBar() {
+function DesktopCustomTabBar({
+  isCollapsedOverride,
+}: {
+  isCollapsedOverride?: boolean;
+}) {
   const intl = useIntl();
-  const [{ isCollapsed }] = useAppSideBarStatusAtom();
-  // register desktop shortcuts for browser tab
+  const [{ isCollapsed: sidebarCollapsed }] = useAppSideBarStatusAtom();
+  const isCollapsed = isCollapsedOverride ?? sidebarCollapsed;
   useDiscoveryShortcuts();
-  // register desktop new window event
   useDesktopNewWindow();
 
   const navigation =
@@ -215,26 +218,41 @@ function DesktopCustomTabBar() {
 
   useShortcuts(undefined, handleShortcuts);
 
-  const ITEM_HEIGHT = useMemo(() => (isCollapsed ? 36 : 32), [isCollapsed]);
+  const ITEM_HEIGHT = 36;
+
+  // Shared styles for collapsed mode action buttons (New Tab, Home)
+  const collapsedStyles = useMemo(
+    () =>
+      isCollapsed
+        ? {
+            tabBarStyle: {
+              alignItems: 'center' as const,
+              justifyContent: 'center' as const,
+            },
+            // tabBarItemStyle: { height: 36 },
+          }
+        : { tabBarStyle: undefined, tabBarItemStyle: undefined },
+    [isCollapsed],
+  );
 
   const layoutList = useMemo(() => {
+    const DIVIDER_HEIGHT = 17;
     let offset = 0;
     const layouts: { offset: number; length: number; index: number }[] = [];
-    layouts.push({ offset, length: 0, index: layouts.length });
-    sections?.[0]?.data?.forEach(() => {
-      layouts.push({ offset, length: ITEM_HEIGHT, index: layouts.length });
-      offset += ITEM_HEIGHT;
-    });
-    layouts.push({ offset, length: 0, index: layouts.length });
-    layouts.push({ offset, length: 0, index: layouts.length });
-    layouts.push({ offset, length: 17 + ITEM_HEIGHT, index: layouts.length });
-    offset += 17 + ITEM_HEIGHT;
-    sections?.[1]?.data?.forEach(() => {
-      layouts.push({ offset, length: ITEM_HEIGHT, index: layouts.length });
-      offset += ITEM_HEIGHT;
-    });
-    layouts.push({ offset, length: 0, index: layouts.length });
-    offset += 0;
+
+    const addLayout = (length: number) => {
+      layouts.push({ offset, length, index: layouts.length });
+      offset += length;
+    };
+
+    addLayout(ITEM_HEIGHT * 2);
+    sections?.[0]?.data?.forEach(() => addLayout(ITEM_HEIGHT));
+    addLayout(0);
+    addLayout(0);
+    addLayout(DIVIDER_HEIGHT);
+    sections?.[1]?.data?.forEach(() => addLayout(ITEM_HEIGHT));
+    addLayout(0);
+
     return layouts;
   }, [ITEM_HEIGHT, sections]);
   const onDragEnd = useCallback(
@@ -312,14 +330,19 @@ function DesktopCustomTabBar() {
 
   return (
     <Stack
-      testID="sideabr-browser-section"
+      testID="sidebar-browser-section"
       flex={1}
-      width={isCollapsed ? MIN_SIDEBAR_WIDTH / 2 : undefined}
+      // Only set width when not in submenu and collapsed
+      // In submenu, let the outer container control the width
+      width={
+        isCollapsedOverride !== undefined || !isCollapsed
+          ? undefined
+          : MIN_SIDEBAR_WIDTH / 2
+      }
     >
       <HandleRebuildBrowserData />
       <SortableSectionList
         mx="$-3"
-        px="$3"
         ref={scrollViewRef}
         sections={sections}
         renderItem={({
@@ -350,94 +373,121 @@ function DesktopCustomTabBar() {
         SectionSeparatorComponent={null}
         onDragEnd={onDragEnd}
         allowCrossSection
-        getItemDragDisabled={(layoutItem) => {
-          // Disable dragging for section headers (which includes the new tab button)
-          return (
-            (layoutItem as ISectionLayoutItem).type ===
-            ESectionLayoutType.Header
-          );
-        }}
-        renderSectionHeader={({ index }) =>
-          index === 1 ? (
-            <>
-              <XStack
-                group="sidebarBrowserDivider"
-                alignItems="center"
-                p="$2"
-                px={isCollapsed ? '$0' : '$2'}
-              >
-                <Divider testID="pin-tab-divider" />
-                {tabs.filter((x) => !x.isPinned).length > 0 ? (
-                  <XStack
-                    position="absolute"
-                    px="1"
-                    group="sidebarClearButton"
-                    alignItems="center"
-                    userSelect="none"
-                    right="$0"
-                    top="50%"
-                    bg="$bgSidebar"
-                    opacity={0}
-                    $group-sidebarBrowserDivider-hover={{
-                      opacity: 1,
+        getItemDragDisabled={(layoutItem) =>
+          (layoutItem as ISectionLayoutItem).type === ESectionLayoutType.Header
+        }
+        renderSectionHeader={({ index }) => {
+          switch (index) {
+            case 0:
+              return (
+                <>
+                  <DesktopTabItem
+                    size="small"
+                    key="AddTabButton"
+                    label={
+                      isCollapsed
+                        ? ''
+                        : intl.formatMessage({
+                            id: ETranslations.explore_new_tab,
+                          })
+                    }
+                    shortcutKey={EShortcutEvents.NewTab2}
+                    icon="PlusSmallOutline"
+                    testID="browser-bar-add"
+                    tabBarStyle={collapsedStyles.tabBarStyle}
+                    tabBarItemStyle={collapsedStyles.tabBarItemStyle}
+                    onPress={(e) => {
+                      e.stopPropagation();
+                      if (platformEnv.isDesktop) {
+                        addBrowserHomeTab();
+                        navigation.switchTab(ETabRoutes.MultiTabBrowser);
+                      } else {
+                        navigation.pushModal(EModalRoutes.DiscoveryModal, {
+                          screen: EDiscoveryModalRoutes.SearchModal,
+                        });
+                      }
                     }}
-                    style={{
-                      containerType: 'normal',
-                      transform: platformEnv.isNative ? '' : 'translateY(-50%)',
+                  />
+                  <DesktopTabItem
+                    size="small"
+                    key="HomeButton"
+                    label={
+                      isCollapsed
+                        ? ''
+                        : intl.formatMessage({
+                            id: ETranslations.explore_back_to_home,
+                          })
+                    }
+                    icon="HomeOpenOutline"
+                    testID="browser-bar-home"
+                    tabBarStyle={collapsedStyles.tabBarStyle}
+                    tabBarItemStyle={collapsedStyles.tabBarItemStyle}
+                    onPress={(e) => {
+                      e.stopPropagation();
+                      navigation.switchTab(ETabRoutes.Discovery);
                     }}
-                    onPress={() => {
-                      void closeAllWebTabs({ navigation });
-                    }}
-                  >
-                    <Icon
-                      flexShrink={0}
-                      color="$iconSubdued"
-                      name="ArrowBottomOutline"
-                      size="$3"
-                    />
-                    <SizableText
-                      pl="$1"
-                      color="$textSubdued"
-                      size="$bodySmMedium"
-                      numberOfLines={1}
-                      $group-sidebarClearButton-hover={{
-                        color: '$text',
+                  />
+                </>
+              );
+            case 1:
+              return (
+                <XStack
+                  group="sidebarBrowserDivider"
+                  alignItems="center"
+                  p="$2"
+                  px={isCollapsed ? '$0' : '$2'}
+                  width="100%"
+                >
+                  <Divider testID="pin-tab-divider" width="$5" />
+                  {isCollapsed && tabs.filter((x) => !x.isPinned).length > 0 ? (
+                    <XStack
+                      position="absolute"
+                      px="1"
+                      group="sidebarClearButton"
+                      alignItems="center"
+                      userSelect="none"
+                      right="$0"
+                      top="50%"
+                      bg="$bgSidebar"
+                      opacity={0}
+                      $group-sidebarBrowserDivider-hover={{
+                        opacity: 1,
+                      }}
+                      style={{
+                        containerType: 'normal',
+                        transform: platformEnv.isNative
+                          ? ''
+                          : 'translateY(-50%)',
+                      }}
+                      onPress={() => {
+                        void closeAllWebTabs({ navigation });
                       }}
                     >
-                      {intl.formatMessage({ id: ETranslations.global_clear })}
-                    </SizableText>
-                  </XStack>
-                ) : null}
-              </XStack>
-              <DesktopTabItem
-                size="small"
-                key="AddTabButton"
-                label={
-                  isCollapsed
-                    ? ''
-                    : intl.formatMessage({
-                        id: ETranslations.explore_new_tab,
-                      })
-                }
-                shortcutKey={EShortcutEvents.NewTab2}
-                icon="PlusSmallOutline"
-                testID="browser-bar-add"
-                onPress={(e) => {
-                  e.stopPropagation();
-
-                  if (platformEnv.isDesktop) {
-                    addBrowserHomeTab();
-                    navigation.switchTab(ETabRoutes.MultiTabBrowser);
-                  } else {
-                    navigation.pushModal(EModalRoutes.DiscoveryModal, {
-                      screen: EDiscoveryModalRoutes.SearchModal,
-                    });
-                  }
-                }}
-              />
-            </>
-          ) : null
-        }
+                      <Icon
+                        flexShrink={0}
+                        color="$iconSubdued"
+                        name="ArrowBottomOutline"
+                        size="$3"
+                      />
+                      <SizableText
+                        pl="$1"
+                        color="$textSubdued"
+                        size="$bodySmMedium"
+                        numberOfLines={1}
+                        $group-sidebarClearButton-hover={{
+                          color: '$text',
+                        }}
+                      >
+                        {intl.formatMessage({ id: ETranslations.global_clear })}
+                      </SizableText>
+                    </XStack>
+                  ) : null}
+                </XStack>
+              );
+            default:
+              return null;
+          }
+        }}
       />
     </Stack>
   );


### PR DESCRIPTION
## Summary
- Simplify SubmenuColumn to single render path with `isExpanded` prop
- Remove absolute positioning and overlay logic from SubmenuColumn
- Add `animation="medium"` for smooth transitions between collapsed/expanded states
- Merge `webPageTabBarCollapsed`/`webPageTabBarExpanded` into single `webPageTabBarWithProps`
- Extract VerticalDivider as separate component

## Test plan
- [ ] Run `yarn app:desktop` and navigate to Browser tab
- [ ] Verify collapsed state shows narrow column with icons only
- [ ] Verify hover expands column with text labels
- [ ] Verify smooth animation transition between states