### PR TITLE
fix: lock transport type during firmware update to prevent auto-switching

### DIFF
--- a/packages/kit-bg/src/services/ServiceFirmwareUpdate/ServiceFirmwareUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceFirmwareUpdate/ServiceFirmwareUpdate.ts
@@ -1231,6 +1231,7 @@ class ServiceFirmwareUpdate extends ServiceBase {
           },
         },
       });
+
       const currentTransportType =
         await this.backgroundApi.serviceSetting.getHardwareTransportType();
 
@@ -1428,116 +1429,137 @@ class ServiceFirmwareUpdate extends ServiceBase {
         // await other hardware task stop processing
         await timerUtils.wait(3000);
 
-        // TODO verify current device is matched with params.connectId\params.updateFirmware\params.updateBle
-        // pre checking
-        await this.validateMnemonicBackuped(params);
-        await this.validateUSBConnection(params);
-        // must before validateMinVersionAllowed, go to https://help.onekey.so/
-        await this.validateShouldUpdateFullResource(params);
-        // go to https://firmware.onekey.so/
-        await this.validateMinVersionAllowed(params);
-        await this.validateDeviceBattery(params);
-        await this.validateShouldUpdateBridge(params);
+        // Lock transport type during firmware update to prevent auto-switching
+        // This prevents the system from switching to BLE when USB device is temporarily
+        // unavailable during device reboot
+        const currentTransportType =
+          await this.backgroundApi.serviceSetting.getHardwareTransportType();
+        await this.backgroundApi.serviceHardware.setForceTransportType({
+          forceTransportType: currentTransportType,
+        });
+        serviceHardwareUtils.hardwareLog(
+          'startUpdateWorkflow: locked transport type',
+          currentTransportType,
+        );
 
-        // ** clear all retry tasks
-        await this.updateTasksClear('startUpdateWorkflow');
+        try {
+          // TODO verify current device is matched with params.connectId\params.updateFirmware\params.updateBle
+          // pre checking
+          await this.validateMnemonicBackuped(params);
+          await this.validateUSBConnection(params);
+          // must before validateMinVersionAllowed, go to https://help.onekey.so/
+          await this.validateShouldUpdateFullResource(params);
+          // go to https://firmware.onekey.so/
+          await this.validateMinVersionAllowed(params);
+          await this.validateDeviceBattery(params);
+          await this.validateShouldUpdateBridge(params);
 
-        let shouldRebootAfterUpdate = false;
+          // ** clear all retry tasks
+          await this.updateTasksClear('startUpdateWorkflow');
 
-        const waitRebootDelayForNextPhase = async () => {
-          if (shouldRebootAfterUpdate) {
+          let shouldRebootAfterUpdate = false;
+
+          const waitRebootDelayForNextPhase = async () => {
+            if (shouldRebootAfterUpdate) {
+              await this.waitDeviceRestart({
+                actionType: 'nextPhase',
+                releaseResult: params.releaseResult,
+              });
+              shouldRebootAfterUpdate = false;
+            }
+          };
+
+          // ** bootloader update
+          await this.cancelUpdateWorkflowIfExit();
+          if (params?.releaseResult?.updateInfos?.bootloader?.hasUpgrade) {
+            await waitRebootDelayForNextPhase();
+            await this.startUpdateBootloaderTask(params);
+
+            shouldRebootAfterUpdate = true;
+
+            // await hardware boot install and reboot
+            // move sdk
             await this.waitDeviceRestart({
-              actionType: 'nextPhase',
+              actionType: 'boot-done',
               releaseResult: params.releaseResult,
             });
-            shouldRebootAfterUpdate = false;
           }
-        };
 
-        // ** bootloader update
-        await this.cancelUpdateWorkflowIfExit();
-        if (params?.releaseResult?.updateInfos?.bootloader?.hasUpgrade) {
-          await waitRebootDelayForNextPhase();
-          await this.startUpdateBootloaderTask(params);
+          // TODO cancel workflow if modal closed or back
 
-          shouldRebootAfterUpdate = true;
+          // ** firmware update (including res update)
+          if (params?.releaseResult?.updateInfos?.firmware?.hasUpgrade) {
+            await waitRebootDelayForNextPhase();
 
-          // await hardware boot install and reboot
-          // move sdk
-          await this.waitDeviceRestart({
-            actionType: 'boot-done',
-            releaseResult: params.releaseResult,
-          });
-        }
+            const deviceType = params?.releaseResult?.deviceType;
+            // TODO recheck release if match with current connect device
+            // TODO check update version gt current version
+            // TODO check features matched
+            await this.cancelUpdateWorkflowIfExit();
+            await this.startUpdateFirmwareTaskBase(
+              {
+                connectId: params?.releaseResult?.updatingConnectId,
+                version: params?.releaseResult?.updateInfos?.firmware?.toVersion,
+                firmwareType: 'firmware',
+                deviceType,
+              },
+              params?.releaseResult?.updateInfos?.firmware,
+              params,
+            );
 
-        // TODO cancel workflow if modal closed or back
+            shouldRebootAfterUpdate = true;
+          }
 
-        // ** firmware update (including res update)
-        if (params?.releaseResult?.updateInfos?.firmware?.hasUpgrade) {
-          await waitRebootDelayForNextPhase();
+          //  ble update
+          if (params?.releaseResult?.updateInfos?.ble?.hasUpgrade) {
+            await waitRebootDelayForNextPhase();
 
-          const deviceType = params?.releaseResult?.deviceType;
-          // TODO recheck release if match with current connect device
-          // TODO check update version gt current version
-          // TODO check features matched
-          await this.cancelUpdateWorkflowIfExit();
-          await this.startUpdateFirmwareTaskBase(
-            {
-              connectId: params?.releaseResult?.updatingConnectId,
-              version: params?.releaseResult?.updateInfos?.firmware?.toVersion,
-              firmwareType: 'firmware',
-              deviceType,
-            },
-            params?.releaseResult?.updateInfos?.firmware,
-            params,
+            const deviceType = params?.releaseResult?.deviceType;
+
+            // TODO recheck release if match with current connect device
+            await this.cancelUpdateWorkflowIfExit();
+            await this.startUpdateFirmwareTaskBase(
+              {
+                connectId: params?.releaseResult?.updatingConnectId,
+                version: params?.releaseResult?.updateInfos?.ble?.toVersion,
+                firmwareType: 'ble',
+                deviceType,
+              },
+              params?.releaseResult?.updateInfos?.ble,
+              params,
+            );
+
+            shouldRebootAfterUpdate = true;
+
+            await this.waitDeviceRestart({
+              actionType: 'ble-done',
+              releaseResult: params.releaseResult,
+            });
+          }
+
+          serviceHardwareUtils.hardwareLog('startUpdateWorkflow DONE', params);
+
+          await firmwareUpdateRetryAtom.set(undefined);
+          if (params.releaseResult.originalConnectId) {
+            await this.waitDeviceRestart({
+              actionType: 'done',
+              releaseResult: params.releaseResult,
+            });
+            await this.detectMap.deleteUpdateInfo({
+              connectId: params.releaseResult.originalConnectId,
+            });
+            await this.backgroundApi.serviceHardware.updateDeviceVersionAfterFirmwareUpdate(
+              params,
+            );
+            await this.clearOnceUpdateDevSettings();
+            appEventBus.emit(EAppEventBusNames.FinishFirmwareUpdate, undefined);
+          }
+        } finally {
+          // Always clear transport type lock when firmware update completes (success or failure)
+          await this.backgroundApi.serviceHardware.clearForceTransportType();
+          serviceHardwareUtils.hardwareLog(
+            'startUpdateWorkflow: cleared transport type lock',
           );
-
-          shouldRebootAfterUpdate = true;
-        }
-
-        //  ble update
-        if (params?.releaseResult?.updateInfos?.ble?.hasUpgrade) {
-          await waitRebootDelayForNextPhase();
-
-          const deviceType = params?.releaseResult?.deviceType;
-
-          // TODO recheck release if match with current connect device
-          await this.cancelUpdateWorkflowIfExit();
-          await this.startUpdateFirmwareTaskBase(
-            {
-              connectId: params?.releaseResult?.updatingConnectId,
-              version: params?.releaseResult?.updateInfos?.ble?.toVersion,
-              firmwareType: 'ble',
-              deviceType,
-            },
-            params?.releaseResult?.updateInfos?.ble,
-            params,
-          );
-
-          shouldRebootAfterUpdate = true;
-
-          await this.waitDeviceRestart({
-            actionType: 'ble-done',
-            releaseResult: params.releaseResult,
-          });
-        }
-
-        serviceHardwareUtils.hardwareLog('startUpdateWorkflow DONE', params);
-
-        await firmwareUpdateRetryAtom.set(undefined);
-        if (params.releaseResult.originalConnectId) {
-          await this.waitDeviceRestart({
-            actionType: 'done',
-            releaseResult: params.releaseResult,
-          });
-          await this.detectMap.deleteUpdateInfo({
-            connectId: params.releaseResult.originalConnectId,
-          });
-          await this.backgroundApi.serviceHardware.updateDeviceVersionAfterFirmwareUpdate(
-            params,
-          );
-          await this.clearOnceUpdateDevSettings();
-          appEventBus.emit(EAppEventBusNames.FinishFirmwareUpdate, undefined);
         }
       },
       {
@@ -1570,54 +1592,73 @@ class ServiceFirmwareUpdate extends ServiceBase {
         // await other hardware task stop processing
         await timerUtils.wait(3000);
 
-        // pre checking
-        await this.validateMnemonicBackuped(params);
-        await this.validateUSBConnection(params);
-        // must before validateMinVersionAllowed, go to https://help.onekey.so/
-        await this.validateShouldUpdateFullResource(params);
-        // go to https://firmware.onekey.so/
-        await this.validateMinVersionAllowed(params);
-        await this.validateDeviceBattery(params);
-        await this.validateShouldUpdateBridge(params);
-
-        // ** clear all retry tasks
-        await this.updateTasksClear('startUpdateWorkflow');
-
-        await this.cancelUpdateWorkflowIfExit();
-
-        const deviceType = params?.releaseResult?.deviceType;
-        if (deviceType !== EDeviceType.Pro) {
-          throw new OneKeyLocalError(
-            'Do not support update firmware for this device',
-          );
-        }
-
-        const updateResult =
-          await this.startUpdateFirmwareTaskForNewBootVersion(params);
-        console.log(
-          'startUpdateFirmwareTaskForNewBootVersion result: ===> ',
-          updateResult,
+        // Lock transport type during firmware update to prevent auto-switching
+        const currentTransportType =
+          await this.backgroundApi.serviceSetting.getHardwareTransportType();
+        await this.backgroundApi.serviceHardware.setForceTransportType({
+          forceTransportType: currentTransportType,
+        });
+        serviceHardwareUtils.hardwareLog(
+          'startUpdateWorkflowV2: locked transport type',
+          currentTransportType,
         );
 
-        serviceHardwareUtils.hardwareLog('startUpdateWorkflow DONE', params);
+        try {
+          // pre checking
+          await this.validateMnemonicBackuped(params);
+          await this.validateUSBConnection(params);
+          // must before validateMinVersionAllowed, go to https://help.onekey.so/
+          await this.validateShouldUpdateFullResource(params);
+          // go to https://firmware.onekey.so/
+          await this.validateMinVersionAllowed(params);
+          await this.validateDeviceBattery(params);
+          await this.validateShouldUpdateBridge(params);
 
-        await firmwareUpdateRetryAtom.set(undefined);
-        if (params.releaseResult.originalConnectId) {
-          await this.waitDeviceRestart({
-            actionType: 'done',
-            releaseResult: params.releaseResult,
-          });
-          await this.detectMap.deleteUpdateInfo({
-            connectId: params.releaseResult.originalConnectId,
-          });
-          await this.backgroundApi.serviceHardware.updateDeviceVersionAfterFirmwareUpdate(
-            params,
+          // ** clear all retry tasks
+          await this.updateTasksClear('startUpdateWorkflow');
+
+          await this.cancelUpdateWorkflowIfExit();
+
+          const deviceType = params?.releaseResult?.deviceType;
+          if (deviceType !== EDeviceType.Pro) {
+            throw new OneKeyLocalError(
+              'Do not support update firmware for this device',
+            );
+          }
+
+          const updateResult =
+            await this.startUpdateFirmwareTaskForNewBootVersion(params);
+          console.log(
+            'startUpdateFirmwareTaskForNewBootVersion result: ===> ',
+            updateResult,
           );
-          await this.clearOnceUpdateDevSettings();
-          appEventBus.emit(EAppEventBusNames.FinishFirmwareUpdate, undefined);
+
+          serviceHardwareUtils.hardwareLog('startUpdateWorkflow DONE', params);
+
+          await firmwareUpdateRetryAtom.set(undefined);
+          if (params.releaseResult.originalConnectId) {
+            await this.waitDeviceRestart({
+              actionType: 'done',
+              releaseResult: params.releaseResult,
+            });
+            await this.detectMap.deleteUpdateInfo({
+              connectId: params.releaseResult.originalConnectId,
+            });
+            await this.backgroundApi.serviceHardware.updateDeviceVersionAfterFirmwareUpdate(
+              params,
+            );
+            await this.clearOnceUpdateDevSettings();
+            appEventBus.emit(EAppEventBusNames.FinishFirmwareUpdate, undefined);
+          }
+          // wait verify
+          await timerUtils.wait(2000);
+        } finally {
+          // Always clear transport type lock when firmware update completes
+          await this.backgroundApi.serviceHardware.clearForceTransportType();
+          serviceHardwareUtils.hardwareLog(
+            'startUpdateWorkflowV2: cleared transport type lock',
+          );
         }
-        // wait verify
-        await timerUtils.wait(2000);
       },
       {
         deviceParams: {

--- a/packages/shared/src/utils/deviceUtils.ts
+++ b/packages/shared/src/utils/deviceUtils.ts
@@ -246,6 +246,20 @@ function isConfirmOnDeviceAction(state: IHardwareUiState | undefined) {
   );
 }
 
+/**
+ * Get the connectId based on current transport type.
+ *
+ * Logic:
+ * - Native (Mobile): Always use BLE (connectId)
+ * - Desktop with BLE support:
+ *   - If currentTransportType is DesktopWebBle → use BLE (connectId)
+ *   - Otherwise → use USB (undefined)
+ * - Other platforms: use USB (undefined)
+ *
+ * @param connectId
+ * @param currentTransportType - Current active transport type
+ * @returns undefined for USB, connectId for BLE
+ */
 function getUpdatingConnectId({
   connectId,
   currentTransportType,
@@ -262,6 +276,18 @@ function getUpdatingConnectId({
   return platformEnv.isNative ? connectId : undefined;
 }
 
+/**
+ * Fix the updatingConnectId based on current transport type.
+ * Used for scenarios where fallback to BLE is needed when USB is not available.
+ *
+ * NOTE: This function is NOT used in firmware update flow, because firmware
+ * updates on desktop should always use USB for stability.
+ *
+ * @param updatingConnectId - The connectId from getUpdatingConnectId
+ * @param currentTransportType - Current active transport type
+ * @param device - Device info from database
+ * @returns Fixed connectId based on current transport
+ */
 function getFixedUpdatingConnectId({
   updatingConnectId,
   currentTransportType,


### PR DESCRIPTION
## Summary

- Lock transport type during firmware update workflow to prevent auto-switching
- This prevents the system from switching to BLE when USB device is temporarily unavailable during device reboot
- Ensures firmware update stability on desktop platforms

## Changes

### ServiceFirmwareUpdate.ts
- Add transport type locking at the start of `startUpdateWorkflow` and `startUpdateWorkflowV2`
- Wrap firmware update flow in try-finally to ensure lock is always released (success or failure)
- Add logging for transport type lock/unlock operations

### deviceUtils.ts
- Add JSDoc comments to `getUpdatingConnectId` function explaining the logic
- Add JSDoc comments to `getFixedUpdatingConnectId` function with usage notes
- Add inline comments for better code clarity

## Test Plan

- [ ] Test firmware update via USB connection on desktop
- [ ] Verify transport type lock is released after successful update
- [ ] Verify transport type lock is released after failed update
- [ ] Test that BLE auto-switch does not occur during device reboot