### PR TITLE
fix: hide wallets tab in universal search for web dapp mode(OK-49185)

### DIFF
--- a/packages/kit/src/views/UniversalSearch/pages/UniversalSearch.tsx
+++ b/packages/kit/src/views/UniversalSearch/pages/UniversalSearch.tsx
@@ -164,7 +164,7 @@ export function UniversalSearch({
       intl.formatMessage({
         id: ETranslations.global_all,
       }),
-      intl.formatMessage({
+      !platformEnv.isWebDappMode && intl.formatMessage({
         id: ETranslations.global_universal_search_tabs_wallets,
       }),
       intl.formatMessage({


### PR DESCRIPTION
## Summary
Hide the wallets tab in universal search when running in web dapp mode, as wallet functionality is not applicable in this context.

## Changes
- Added conditional rendering check `!platformEnv.isWebDappMode` for the wallets tab in UniversalSearch component
- The wallets tab will now only display when NOT in web dapp mode

## Test Plan
- [ ] Verify wallets tab is visible in normal mode
- [ ] Verify wallets tab is hidden in web dapp mode
- [ ] Verify other tabs continue to work correctly