### PR TITLE
feat(refer): add hardware sales order detail and notification navigation

### DIFF
--- a/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
@@ -188,15 +188,6 @@ export default class ServiceNotification extends ServiceBase {
     const msgId =
       messageInfo.extras?.params?.msgId || messageInfo.extras?.msgId;
 
-    console.log('=== NOTIFICATION RECEIVED ===', {
-      msgId,
-      title: messageInfo.title,
-      content: messageInfo.content,
-      pushSource: messageInfo.pushSource,
-      extras: messageInfo.extras,
-      fullMessageInfo: messageInfo,
-    });
-
     defaultLogger.notification.common.notificationReceived({
       messageInfo,
       notificationId: msgId,
@@ -261,13 +252,6 @@ export default class ServiceNotification extends ServiceBase {
       return;
     }
     this.addShowedNotificationId(notificationId);
-
-    console.log('=== NOTIFICATION CLICKED ===', {
-      notificationId,
-      eventSource,
-      params,
-      remotePushMessageInfo: params?.remotePushMessageInfo,
-    });
 
     defaultLogger.notification.common.notificationClicked({
       eventSource,
@@ -1269,10 +1253,6 @@ export default class ServiceNotification extends ServiceBase {
       IApiClientResponse<INotificationPushMessageListItem[]>
     >('/notification/v1/message/list', topicTypes ? { topicTypes } : undefined);
     const data = result?.data?.data || [];
-    console.log('=== NOTIFICATION LIST ===');
-    console.log('topicTypes:', topicTypes);
-    console.log('count:', data.length);
-    console.log('data:', JSON.stringify(data, null, 2));
     return data;
   }
 

--- a/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
@@ -187,6 +187,16 @@ export default class ServiceNotification extends ServiceBase {
       await notificationsDevSettingsPersistAtom.get();
     const msgId =
       messageInfo.extras?.params?.msgId || messageInfo.extras?.msgId;
+
+    console.log('=== NOTIFICATION RECEIVED ===', {
+      msgId,
+      title: messageInfo.title,
+      content: messageInfo.content,
+      pushSource: messageInfo.pushSource,
+      extras: messageInfo.extras,
+      fullMessageInfo: messageInfo,
+    });
+
     defaultLogger.notification.common.notificationReceived({
       messageInfo,
       notificationId: msgId,
@@ -251,6 +261,13 @@ export default class ServiceNotification extends ServiceBase {
       return;
     }
     this.addShowedNotificationId(notificationId);
+
+    console.log('=== NOTIFICATION CLICKED ===', {
+      notificationId,
+      eventSource,
+      params,
+      remotePushMessageInfo: params?.remotePushMessageInfo,
+    });
 
     defaultLogger.notification.common.notificationClicked({
       eventSource,
@@ -1251,7 +1268,12 @@ export default class ServiceNotification extends ServiceBase {
     const result = await client.post<
       IApiClientResponse<INotificationPushMessageListItem[]>
     >('/notification/v1/message/list', topicTypes ? { topicTypes } : undefined);
-    return result?.data?.data || [];
+    const data = result?.data?.data || [];
+    console.log('=== NOTIFICATION LIST ===');
+    console.log('topicTypes:', topicTypes);
+    console.log('count:', data.length);
+    console.log('data:', JSON.stringify(data, null, 2));
+    return data;
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceReferralCode.ts
+++ b/packages/kit-bg/src/services/ServiceReferralCode.ts
@@ -12,6 +12,7 @@ import type {
   IEarnWalletHistory,
   IExportInviteDataParams,
   IHardwareCumulativeRewards,
+  IHardwareRecordItem,
   IHardwareRecordsResponse,
   IHardwareSalesRecord,
   IInviteCodeItem,
@@ -581,6 +582,15 @@ class ServiceReferralCode extends ServiceBase {
     const response = await client.get<{
       data: IHardwareRecordsResponse;
     }>('/rebate/v1/invite/hardware-records', { params });
+    return response.data.data;
+  }
+
+  @backgroundMethod()
+  async getHardwareRecordDetail(id: string): Promise<IHardwareRecordItem> {
+    const client = await this.getOneKeyIdClient(EServiceEndpointEnum.Rebate);
+    const response = await client.get<{
+      data: IHardwareRecordItem;
+    }>(`/rebate/v1/invite/hardware-records/${id}`);
     return response.data.data;
   }
 

--- a/packages/kit/src/hooks/useReferFriends.tsx
+++ b/packages/kit/src/hooks/useReferFriends.tsx
@@ -116,22 +116,61 @@ export const useReferFriends = () => {
     return useTestEnv ? 'test' : 'prod';
   }, [devSettings.enabled, devSettings.settings?.enableTestEndpoint]);
 
-  const toInviteRewardPage = useCallback(async () => {
-    const isLogin = await backgroundApiProxy.servicePrime.isLoggedIn();
-    if (isLogin) {
-      if (platformEnv.isNative) {
-        navigation.pushModal(EModalRoutes.ReferFriendsModal, {
-          screen: EModalReferFriendsRoutes.InviteReward,
-        });
+  const toInviteRewardPage = useCallback(
+    async (params?: { showRewardDistributionHistory?: boolean }) => {
+      const isLogin = await backgroundApiProxy.servicePrime.isLoggedIn();
+      if (isLogin) {
+        if (platformEnv.isNative) {
+          navigation.pushModal(EModalRoutes.ReferFriendsModal, {
+            screen: EModalReferFriendsRoutes.InviteReward,
+            params,
+          });
+        } else {
+          navigation.switchTab<ETabRoutes.ReferFriends>(
+            ETabRoutes.ReferFriends,
+            {
+              screen: ETabReferFriendsRoutes.TabInviteReward,
+              params,
+            },
+          );
+        }
       } else {
-        navigation.switchTab<ETabRoutes.ReferFriends>(ETabRoutes.ReferFriends, {
-          screen: ETabReferFriendsRoutes.TabInviteReward,
-        });
+        void loginOneKeyId({ toOneKeyIdPageOnLoginSuccess: false });
       }
-    } else {
-      void loginOneKeyId({ toOneKeyIdPageOnLoginSuccess: false });
-    }
-  }, [loginOneKeyId, navigation]);
+    },
+    [loginOneKeyId, navigation],
+  );
+
+  const toHardwareSalesRewardPage = useCallback(
+    async (params?: { showOrderDetail?: boolean; orderId?: string }) => {
+      const isLogin = await backgroundApiProxy.servicePrime.isLoggedIn();
+      if (isLogin) {
+        if (platformEnv.isNative) {
+          navigation.pushModal(EModalRoutes.ReferFriendsModal, {
+            screen: EModalReferFriendsRoutes.HardwareSalesReward,
+            params,
+          });
+        } else {
+          navigation.switchTab<ETabRoutes.ReferFriends>(
+            ETabRoutes.ReferFriends,
+            {
+              screen: ETabReferFriendsRoutes.TabHardwareSalesReward,
+              params,
+            },
+          );
+        }
+      } else {
+        void loginOneKeyId({ toOneKeyIdPageOnLoginSuccess: false });
+      }
+    },
+    [loginOneKeyId, navigation],
+  );
+
+  const openHardwareSalesOrderDetail = useCallback(
+    (orderId: string) =>
+      toHardwareSalesRewardPage({ showOrderDetail: true, orderId }),
+    [toHardwareSalesRewardPage],
+  );
 
   const toReferFriendsPage = useCallback(async () => {
     const isLogin = await backgroundApiProxy.servicePrime.isLoggedIn();
@@ -354,7 +393,9 @@ export const useReferFriends = () => {
       toReferFriendsPage,
       shareReferRewards,
       toInviteRewardPage,
+      toHardwareSalesRewardPage,
+      openHardwareSalesOrderDetail,
     }),
-    [toReferFriendsPage, shareReferRewards, toInviteRewardPage],
+    [toReferFriendsPage, shareReferRewards, toInviteRewardPage, toHardwareSalesRewardPage, openHardwareSalesOrderDetail],
   );
 };

--- a/packages/kit/src/hooks/useReferFriends.tsx
+++ b/packages/kit/src/hooks/useReferFriends.tsx
@@ -396,6 +396,12 @@ export const useReferFriends = () => {
       toHardwareSalesRewardPage,
       openHardwareSalesOrderDetail,
     }),
-    [toReferFriendsPage, shareReferRewards, toInviteRewardPage, toHardwareSalesRewardPage, openHardwareSalesOrderDetail],
+    [
+      toReferFriendsPage,
+      shareReferRewards,
+      toInviteRewardPage,
+      toHardwareSalesRewardPage,
+      openHardwareSalesOrderDetail,
+    ],
   );
 };

--- a/packages/kit/src/provider/Container/NotificationHandlerContainer/commandRegistry.ts
+++ b/packages/kit/src/provider/Container/NotificationHandlerContainer/commandRegistry.ts
@@ -1,0 +1,39 @@
+import { ENotificationCommand } from '@onekeyhq/shared/types/notification';
+
+type ICommandContext = {
+  toInviteRewardPage: (params?: {
+    showRewardDistributionHistory?: boolean;
+  }) => Promise<void>;
+  openHardwareSalesOrderDetail: (orderId: string) => Promise<void>;
+};
+
+type ICommandHandler = (params: {
+  context: ICommandContext;
+  data?: Record<string, unknown>;
+}) => void | Promise<void>;
+
+const notificationCommandRegistry: Record<string, ICommandHandler> = {
+  [ENotificationCommand.openRewardDistributionHistoryModal]: ({ context }) => {
+    void context.toInviteRewardPage({ showRewardDistributionHistory: true });
+  },
+  [ENotificationCommand.openHardwareSalesOrder]: ({ context, data }) => {
+    const orderId = data?.orderId as string;
+    if (orderId) {
+      void context.openHardwareSalesOrderDetail(orderId);
+    }
+  },
+};
+
+export function executeNotificationCommand(
+  action: string,
+  context: ICommandContext,
+  data?: Record<string, unknown>,
+): boolean {
+  const handler = notificationCommandRegistry[action];
+  if (!handler) {
+    console.warn(`[Notification] Unknown action: ${action}`);
+    return false;
+  }
+  void handler({ context, data });
+  return true;
+}

--- a/packages/kit/src/provider/Container/NotificationHandlerContainer/index.tsx
+++ b/packages/kit/src/provider/Container/NotificationHandlerContainer/index.tsx
@@ -33,21 +33,25 @@ import { useInitialNotification } from './hooks';
 function BaseNotificationHandlerContainer() {
   const { showFallbackUpdateDialog } = useVersionCompatible();
   const navigation = useAppNavigation();
-  const { toInviteRewardPage, openHardwareSalesOrderDetail } = useReferFriends();
+  const { toInviteRewardPage, openHardwareSalesOrderDetail } =
+    useReferFriends();
 
   const { activeAccount } = useActiveAccount({ num: 0 });
   const activeAccountRef = useRef(activeAccount);
   activeAccountRef.current = activeAccount;
 
-  const getLocalParams = useCallback(() => ({
-    accountId: activeAccountRef.current?.account?.id,
-    indexedAccountId: activeAccountRef.current?.indexedAccount?.id,
-    networkId: activeAccountRef.current?.network?.id,
-    walletId: activeAccountRef.current?.wallet?.id,
-    accountName: activeAccountRef.current?.account?.name,
-    deriveType: activeAccountRef.current?.deriveType,
-    avatarUrl: activeAccountRef.current?.wallet?.avatar,
-  }), []);
+  const getLocalParams = useCallback(
+    () => ({
+      accountId: activeAccountRef.current?.account?.id,
+      indexedAccountId: activeAccountRef.current?.indexedAccount?.id,
+      networkId: activeAccountRef.current?.network?.id,
+      walletId: activeAccountRef.current?.wallet?.id,
+      accountName: activeAccountRef.current?.account?.name,
+      deriveType: activeAccountRef.current?.deriveType,
+      avatarUrl: activeAccountRef.current?.wallet?.avatar,
+    }),
+    [],
+  );
 
   const browserAction = useBrowserAction().current;
 
@@ -218,7 +222,14 @@ function BaseNotificationHandlerContainer() {
         handleExecuteCommand,
       );
     };
-  }, [browserAction, getLocalParams, navigation, showFallbackUpdateDialog, toInviteRewardPage, openHardwareSalesOrderDetail]);
+  }, [
+    browserAction,
+    getLocalParams,
+    navigation,
+    showFallbackUpdateDialog,
+    toInviteRewardPage,
+    openHardwareSalesOrderDetail,
+  ]);
   useInitialNotification();
   return null;
 }

--- a/packages/kit/src/provider/Container/NotificationHandlerContainer/index.tsx
+++ b/packages/kit/src/provider/Container/NotificationHandlerContainer/index.tsx
@@ -21,32 +21,33 @@ import {
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import { AccountSelectorProviderMirror } from '../../../components/AccountSelector';
 import useAppNavigation from '../../../hooks/useAppNavigation';
+import { useReferFriends } from '../../../hooks/useReferFriends';
 import { useVersionCompatible } from '../../../hooks/useVersionCompatible';
 import { useActiveAccount } from '../../../states/jotai/contexts/accountSelector';
 import { useBrowserAction } from '../../../states/jotai/contexts/discovery';
 import { DiscoveryBrowserProviderMirror } from '../../../views/Discovery/components/DiscoveryBrowserProviderMirror';
 
+import { executeNotificationCommand } from './commandRegistry';
 import { useInitialNotification } from './hooks';
 
 function BaseNotificationHandlerContainer() {
   const { showFallbackUpdateDialog } = useVersionCompatible();
   const navigation = useAppNavigation();
+  const { toInviteRewardPage, openHardwareSalesOrderDetail } = useReferFriends();
 
   const { activeAccount } = useActiveAccount({ num: 0 });
   const activeAccountRef = useRef(activeAccount);
   activeAccountRef.current = activeAccount;
 
-  const getLocalParams = useCallback(() => {
-    return {
-      accountId: activeAccountRef.current?.account?.id,
-      indexedAccountId: activeAccountRef.current?.indexedAccount?.id,
-      networkId: activeAccountRef.current?.network?.id,
-      walletId: activeAccountRef.current?.wallet?.id,
-      accountName: activeAccountRef.current?.account?.name,
-      deriveType: activeAccountRef.current?.deriveType,
-      avatarUrl: activeAccountRef.current?.wallet?.avatar,
-    };
-  }, [activeAccountRef]);
+  const getLocalParams = useCallback(() => ({
+    accountId: activeAccountRef.current?.account?.id,
+    indexedAccountId: activeAccountRef.current?.indexedAccount?.id,
+    networkId: activeAccountRef.current?.network?.id,
+    walletId: activeAccountRef.current?.wallet?.id,
+    accountName: activeAccountRef.current?.account?.name,
+    deriveType: activeAccountRef.current?.deriveType,
+    avatarUrl: activeAccountRef.current?.wallet?.avatar,
+  }), []);
 
   const browserAction = useBrowserAction().current;
 
@@ -176,6 +177,25 @@ function BaseNotificationHandlerContainer() {
       EAppEventBusNames.ShowNotificationInDappPage,
       handleShowNotificationDappNavigation,
     );
+
+    const handleExecuteCommand = ({
+      action,
+      data,
+    }: {
+      action: string;
+      data?: Record<string, unknown>;
+    }) => {
+      const context = { toInviteRewardPage, openHardwareSalesOrderDetail };
+      const success = executeNotificationCommand(action, context, data);
+      if (!success) {
+        showFallbackUpdateDialog(null);
+      }
+    };
+    appEventBus.on(
+      EAppEventBusNames.ExecuteNotificationCommand,
+      handleExecuteCommand,
+    );
+
     return () => {
       appEventBus.off(
         EAppEventBusNames.ShowFallbackUpdateDialog,
@@ -193,8 +213,12 @@ function BaseNotificationHandlerContainer() {
         EAppEventBusNames.ShowNotificationInDappPage,
         handleShowNotificationDappNavigation,
       );
+      appEventBus.off(
+        EAppEventBusNames.ExecuteNotificationCommand,
+        handleExecuteCommand,
+      );
     };
-  }, [browserAction, getLocalParams, navigation, showFallbackUpdateDialog]);
+  }, [browserAction, getLocalParams, navigation, showFallbackUpdateDialog, toInviteRewardPage, openHardwareSalesOrderDetail]);
   useInitialNotification();
   return null;
 }

--- a/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/HardwareSalesOrderDetail.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/HardwareSalesOrderDetail.tsx
@@ -21,7 +21,7 @@ import { Currency } from '@onekeyhq/kit/src/components/Currency';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IHardwareRecordItem } from '@onekeyhq/shared/src/referralCode/type';
 import type { IModalReferFriendsParamList } from '@onekeyhq/shared/src/routes';
-import { EModalReferFriendsRoutes } from '@onekeyhq/shared/src/routes';
+import type { EModalReferFriendsRoutes } from '@onekeyhq/shared/src/routes';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import { ReferFriendsPageContainer } from '../../components';

--- a/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/HardwareSalesOrderDetail.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/HardwareSalesOrderDetail.tsx
@@ -1,0 +1,197 @@
+import { useCallback, useState } from 'react';
+
+import { useRoute } from '@react-navigation/core';
+import { useIntl } from 'react-intl';
+
+import type { IColorTokens } from '@onekeyhq/components';
+import {
+  Badge,
+  Divider,
+  Page,
+  RefreshControl,
+  ScrollView,
+  SizableText,
+  Toast,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
+import { Currency } from '@onekeyhq/kit/src/components/Currency';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import type { IHardwareRecordItem } from '@onekeyhq/shared/src/referralCode/type';
+import type { IModalReferFriendsParamList } from '@onekeyhq/shared/src/routes';
+import { EModalReferFriendsRoutes } from '@onekeyhq/shared/src/routes';
+import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
+
+import { ReferFriendsPageContainer } from '../../components';
+
+import { HardwareRecordStatusBadge } from './components/HardwareRecordStatusBadge';
+import {
+  HardwareRecordTimeline,
+  formatTimestamp,
+} from './components/HardwareRecordTimeline';
+
+import type { RouteProp } from '@react-navigation/core';
+
+type IRouteProps = RouteProp<
+  IModalReferFriendsParamList,
+  EModalReferFriendsRoutes.HardwareSalesOrderDetail
+>;
+
+type IHardwareRecordStatus =
+  | 'Completed'
+  | 'Pending'
+  | 'Undistributed'
+  | 'Refunded';
+
+const statusToRewardColor: Record<IHardwareRecordStatus, IColorTokens> = {
+  Completed: '$textSuccess',
+  Undistributed: '$textInfo',
+  Refunded: '$textSubdued',
+  Pending: '$textCaution',
+};
+
+function HardwareSalesOrderDetailPageWrapper() {
+  const intl = useIntl();
+  const route = useRoute<IRouteProps>();
+  const { data: initialData } = route.params;
+
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [data, setData] = useState<IHardwareRecordItem>(initialData);
+
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    try {
+      const result =
+        await backgroundApiProxy.serviceReferralCode.getHardwareRecordDetail(
+          data.orderNumber,
+        );
+      setData(result);
+    } catch (err) {
+      console.error('Failed to refresh hardware record detail:', err);
+      Toast.error({ title: 'Failed to refresh order details' });
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [data.orderNumber]);
+
+  const rewardColor =
+    statusToRewardColor[(data.status as IHardwareRecordStatus) ?? ''] ||
+    '$textSuccess';
+
+  return (
+    <Page>
+      <Page.Header
+        title={intl.formatMessage({
+          id: ETranslations.global_details,
+        })}
+      />
+      <Page.Body>
+        <ReferFriendsPageContainer flex={1}>
+          <ScrollView
+            flex={1}
+            refreshControl={
+              <RefreshControl
+                refreshing={isRefreshing}
+                onRefresh={handleRefresh}
+              />
+            }
+          >
+            {/* Order Details - Two column grid layout */}
+            <XStack flexWrap="wrap" pt="$3" px="$5" pb="$5">
+              {/* Row 1: Time | Order ID */}
+              <YStack width="50%" gap="$1.5" pr="$2" pb="$6">
+                <SizableText size="$bodyMd" color="$textSubdued">
+                  {intl.formatMessage({ id: ETranslations.global_time })}
+                </SizableText>
+                <SizableText size="$bodyMdMedium">
+                  {formatTimestamp(data.orderPlacedAt)}
+                </SizableText>
+              </YStack>
+              <YStack width="50%" gap="$1.5" pr="$2" pb="$6">
+                <SizableText size="$bodyMd" color="$textSubdued">
+                  {intl.formatMessage({
+                    id: ETranslations.referral_order_id,
+                  })}
+                </SizableText>
+                <SizableText size="$bodyMdMedium">
+                  {data.itemUniqueId}
+                </SizableText>
+              </YStack>
+
+              {/* Row 2: Status | Rewards */}
+              <YStack width="50%" gap="$1.5" pr="$2" pb="$6" ai="flex-start">
+                <SizableText size="$bodyMd" color="$textSubdued">
+                  {intl.formatMessage({ id: ETranslations.global_status })}
+                </SizableText>
+                <YStack>
+                  <HardwareRecordStatusBadge
+                    status={data.status}
+                    statusLabel={data.statusLabel}
+                  />
+                </YStack>
+              </YStack>
+              <YStack width="50%" gap="$1.5" pr="$2" pb="$6">
+                <SizableText size="$bodyMd" color="$textSubdued">
+                  {intl.formatMessage({ id: ETranslations.referral_rewards })}
+                </SizableText>
+                <Currency
+                  color={rewardColor}
+                  formatter="value"
+                  size="$bodyMdMedium"
+                  formatterOptions={{
+                    showPlusMinusSigns: true,
+                  }}
+                >
+                  {data.rebateAmountFiatValue}
+                </Currency>
+              </YStack>
+
+              {/* Row 3: Referral code */}
+              <YStack width="50%" gap="$1.5" pr="$2">
+                <SizableText size="$bodyMd" color="$textSubdued">
+                  {intl.formatMessage({
+                    id: ETranslations.referral_referral_code,
+                  })}
+                </SizableText>
+                <XStack ai="center" gap="$2">
+                  <Badge badgeType="default" badgeSize="sm">
+                    {data.inviteCode}
+                  </Badge>
+                  {data.inviteCodeRemark ? (
+                    <SizableText size="$bodyMd" color="$textSubdued">
+                      {data.inviteCodeRemark}
+                    </SizableText>
+                  ) : null}
+                </XStack>
+              </YStack>
+            </XStack>
+
+            {/* History Timeline */}
+            {data.history && data.history.length > 0 ? (
+              <>
+                <Divider />
+                <HardwareRecordTimeline history={data.history} />
+              </>
+            ) : null}
+          </ScrollView>
+        </ReferFriendsPageContainer>
+      </Page.Body>
+    </Page>
+  );
+}
+
+export default function HardwareSalesOrderDetail() {
+  return (
+    <AccountSelectorProviderMirror
+      config={{
+        sceneName: EAccountSelectorSceneName.home,
+        sceneUrl: '',
+      }}
+      enabledNum={[0]}
+    >
+      <HardwareSalesOrderDetailPageWrapper />
+    </AccountSelectorProviderMirror>
+  );
+}

--- a/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/components/HardwareRecordTimeline.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/components/HardwareRecordTimeline.tsx
@@ -125,12 +125,7 @@ export function HardwareRecordTimeline({
   }
 
   return (
-    <YStack
-      bg="$bgSubdued"
-      borderTopWidth={1}
-      borderBottomWidth={1}
-      borderColor="$neutral2"
-    >
+    <YStack>
       <SizableText
         size="$headingSm"
         color="$textSubdued"
@@ -143,7 +138,7 @@ export function HardwareRecordTimeline({
         })}
       </SizableText>
       <YStack px="$5" pb="$4">
-        {history.map((historyItem: IHistoryItem, index: number) => (
+        {history.map((historyItem, index) => (
           <TimelineItem
             key={`${historyItem.type}-${historyItem.timestamp}-${index}`}
             historyItem={historyItem}

--- a/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/index.tsx
@@ -78,6 +78,10 @@ function HardwareSalesRewardPageWrapper() {
           }
         } catch (error) {
           // Silently fail - user is already on HardwareSalesReward page
+          console.error(
+            'Failed to fetch hardware order detail for modal:',
+            error,
+          );
         }
       })();
     }, [navigation, route.params?.showOrderDetail, route.params?.orderId]),

--- a/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { useFocusEffect, useRoute } from '@react-navigation/core';
 import { useIntl } from 'react-intl';
 
 import {
@@ -14,6 +15,7 @@ import {
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import { TabPageHeader } from '@onekeyhq/kit/src/components/TabPageHeader';
+import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useRedirectWhenNotLoggedIn } from '@onekeyhq/kit/src/views/ReferFriends/hooks/useRedirectWhenNotLoggedIn';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -21,7 +23,11 @@ import type {
   IHardwareCumulativeRewards,
   IHardwareRecordItem,
 } from '@onekeyhq/shared/src/referralCode/type';
-import { ETabRoutes } from '@onekeyhq/shared/src/routes';
+import {
+  EModalReferFriendsRoutes,
+  EModalRoutes,
+  ETabRoutes,
+} from '@onekeyhq/shared/src/routes';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import {
@@ -41,6 +47,41 @@ function HardwareSalesRewardPageWrapper() {
 
   const intl = useIntl();
   const { md } = useMedia();
+  const navigation = useAppNavigation();
+  const route = useRoute<{
+    key: string;
+    name: string;
+    params?: { showOrderDetail?: boolean; orderId?: string };
+  }>();
+
+  // Handle showOrderDetail param - fetch data first, then open modal
+  useFocusEffect(
+    useCallback(() => {
+      if (!route.params?.showOrderDetail || !route.params?.orderId) {
+        return;
+      }
+      const orderId = route.params.orderId;
+      navigation.setParams({ showOrderDetail: undefined, orderId: undefined });
+
+      // Fetch order detail and open modal if successful
+      void (async () => {
+        try {
+          const data =
+            await backgroundApiProxy.serviceReferralCode.getHardwareRecordDetail(
+              orderId,
+            );
+          if (data) {
+            navigation.pushModal(EModalRoutes.ReferFriendsModal, {
+              screen: EModalReferFriendsRoutes.HardwareSalesOrderDetail,
+              params: { data },
+            });
+          }
+        } catch (error) {
+          // Silently fail - user is already on HardwareSalesReward page
+        }
+      })();
+    }, [navigation, route.params?.showOrderDetail, route.params?.orderId]),
+  );
 
   const [isLoading, setIsLoading] = useState(false);
   const [cumulativeRewards, setCumulativeRewards] = useState<

--- a/packages/kit/src/views/ReferFriends/pages/InviteReward/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/InviteReward/index.tsx
@@ -123,7 +123,11 @@ function InviteRewardPage() {
       }
       navigation.setParams({ showRewardDistributionHistory: undefined });
       navigateToRewardHistory();
-    }, [navigation, navigateToRewardHistory, route.params?.showRewardDistributionHistory]),
+    }, [
+      navigation,
+      navigateToRewardHistory,
+      route.params?.showRewardDistributionHistory,
+    ]),
   );
 
   // Redirect to ReferAFriend page if user is not logged in

--- a/packages/kit/src/views/ReferFriends/pages/InviteReward/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/InviteReward/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 
+import { useFocusEffect, useRoute } from '@react-navigation/core';
 import { useIntl } from 'react-intl';
 
 import {
@@ -14,6 +15,7 @@ import {
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import { TabPageHeader } from '@onekeyhq/kit/src/components/TabPageHeader';
+import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useRedirectWhenNotLoggedIn } from '@onekeyhq/kit/src/views/ReferFriends/hooks/useRedirectWhenNotLoggedIn';
 import { CumulativeRewards } from '@onekeyhq/kit/src/views/ReferFriends/pages/InviteReward/components/CumulativeRewards';
@@ -30,6 +32,8 @@ import type { IInviteSummary } from '@onekeyhq/shared/src/referralCode/type';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
+
+import { useNavigateToRewardHistory } from '../RewardDistributionHistory/hooks/useNavigateToRewardHistory';
 
 import { ReferFriendsPageContainer } from '../../components';
 
@@ -103,6 +107,25 @@ function InviteRewardContent({
 function InviteRewardPage() {
   const intl = useIntl();
   const { md } = useMedia();
+  const navigation = useAppNavigation();
+  const navigateToRewardHistory = useNavigateToRewardHistory();
+  const route = useRoute<{
+    key: string;
+    name: string;
+    params?: { showRewardDistributionHistory?: boolean };
+  }>();
+
+  // Handle showRewardDistributionHistory param - open modal once when param is set
+  useFocusEffect(
+    useCallback(() => {
+      if (!route.params?.showRewardDistributionHistory) {
+        return;
+      }
+      navigation.setParams({ showRewardDistributionHistory: undefined });
+      navigateToRewardHistory();
+    }, [navigation, navigateToRewardHistory, route.params?.showRewardDistributionHistory]),
+  );
+
   // Redirect to ReferAFriend page if user is not logged in
   useRedirectWhenNotLoggedIn();
 

--- a/packages/kit/src/views/ReferFriends/router/index.ts
+++ b/packages/kit/src/views/ReferFriends/router/index.ts
@@ -9,6 +9,9 @@ const YourReferred = LazyLoadPage(() => import('../pages/YourReferred'));
 const HardwareSalesReward = LazyLoadPage(
   () => import('../pages/HardwareSalesReward'),
 );
+const HardwareSalesOrderDetail = LazyLoadPage(
+  () => import('../pages/HardwareSalesReward/HardwareSalesOrderDetail'),
+);
 const InviteReward = LazyLoadPage(() => import('../pages/InviteReward'));
 const EditAddress = LazyLoadPage(() => import('../pages/EditAddress'));
 const EarnReward = LazyLoadPage(() => import('../pages/EarnReward'));
@@ -46,6 +49,10 @@ export const ReferFriendsRouter: IModalFlowNavigatorConfig<
   {
     name: EModalReferFriendsRoutes.HardwareSalesReward,
     component: HardwareSalesReward,
+  },
+  {
+    name: EModalReferFriendsRoutes.HardwareSalesOrderDetail,
+    component: HardwareSalesOrderDetail,
   },
   {
     name: EModalReferFriendsRoutes.InviteReward,

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/NotificationPayloadTest.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/NotificationPayloadTest.tsx
@@ -10,7 +10,10 @@ import {
   YStack,
 } from '@onekeyhq/components';
 import { parseNotificationPayload } from '@onekeyhq/shared/src/utils/notificationsUtils';
-import { ENotificationPushMessageMode } from '@onekeyhq/shared/types/notification';
+import {
+  ENotificationCommand,
+  ENotificationPushMessageMode,
+} from '@onekeyhq/shared/types/notification';
 
 const modeOptions = [
   {
@@ -32,6 +35,10 @@ const modeOptions = [
   {
     label: 'Mode 5: Open in DApp',
     value: ENotificationPushMessageMode.openInDapp,
+  },
+  {
+    label: 'Mode 6: Command',
+    value: ENotificationPushMessageMode.command,
   },
 ];
 
@@ -75,6 +82,13 @@ const payloadExamples: Record<ENotificationPushMessageMode, string> = {
   [ENotificationPushMessageMode.openInBrowser]: 'https://onekey.so',
   [ENotificationPushMessageMode.openInApp]: 'https://onekey.so/support',
   [ENotificationPushMessageMode.openInDapp]: 'https://app.uniswap.org',
+  [ENotificationPushMessageMode.command]: JSON.stringify(
+    {
+      action: ENotificationCommand.openRewardDistributionHistoryModal,
+    },
+    null,
+    2,
+  ),
 };
 
 export function NotificationPayloadTest() {
@@ -156,6 +170,9 @@ export function NotificationPayloadTest() {
         </SizableText>
         <SizableText size="$bodySm" color="$textSubdued">
           Mode 5 (openInDapp): URL string for DApp browser
+        </SizableText>
+        <SizableText size="$bodySm" color="$textSubdued">
+          Mode 6 (command): JSON with action and optional data
         </SizableText>
       </YStack>
 

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -450,6 +450,10 @@ export interface IAppEventBusPayload {
     icon: string | undefined;
     remotePushMessageInfo: INotificationPushMessageInfo;
   };
+  [EAppEventBusNames.ExecuteNotificationCommand]: {
+    action: string;
+    data?: Record<string, unknown>;
+  };
 }
 
 export enum EEventBusBroadcastMethodNames {

--- a/packages/shared/src/eventBus/appEventBusNames.ts
+++ b/packages/shared/src/eventBus/appEventBusNames.ts
@@ -135,4 +135,5 @@ export enum EAppEventBusNames {
   SwapLimitOrderBuildSuccess = 'SwapLimitOrderBuildSuccess',
   RefreshNativeTokenInfo = 'RefreshNativeTokenInfo',
   ShowInAppPushNotification = 'ShowInAppPushNotification',
+  ExecuteNotificationCommand = 'ExecuteNotificationCommand',
 }

--- a/packages/shared/src/routes/referFriends.ts
+++ b/packages/shared/src/routes/referFriends.ts
@@ -1,6 +1,7 @@
 import type {
   IEarnWalletHistoryItem,
   IEarnWalletHistoryNetwork,
+  IHardwareRecordItem,
 } from '../referralCode/type';
 
 export enum EModalReferFriendsRoutes {
@@ -9,6 +10,7 @@ export enum EModalReferFriendsRoutes {
   YourReferred = 'YourReferred',
   YourReferredWalletAddresses = 'YourReferredWalletAddresses',
   HardwareSalesReward = 'HardwareSalesReward',
+  HardwareSalesOrderDetail = 'HardwareSalesOrderDetail',
   InviteReward = 'InviteReward',
   EditAddress = 'EditAddress',
   EarnReward = 'EarnReward',
@@ -31,8 +33,20 @@ export type IModalReferFriendsParamList = {
     networks: IEarnWalletHistoryNetwork[];
     items: IEarnWalletHistoryItem[];
   };
-  [EModalReferFriendsRoutes.HardwareSalesReward]: undefined;
-  [EModalReferFriendsRoutes.InviteReward]: undefined;
+  [EModalReferFriendsRoutes.HardwareSalesReward]:
+    | {
+        showOrderDetail?: boolean;
+        orderId?: string;
+      }
+    | undefined;
+  [EModalReferFriendsRoutes.HardwareSalesOrderDetail]: {
+    data: IHardwareRecordItem;
+  };
+  [EModalReferFriendsRoutes.InviteReward]:
+    | {
+        showRewardDistributionHistory?: boolean;
+      }
+    | undefined;
   [EModalReferFriendsRoutes.EditAddress]: {
     enabledNetworks: string[];
     accountId: string;

--- a/packages/shared/src/routes/tabReferFriends.ts
+++ b/packages/shared/src/routes/tabReferFriends.ts
@@ -13,9 +13,18 @@ export type ITabReferFriendsParamList = {
     utmSource?: string;
     code?: string;
   };
-  TabInviteReward: undefined;
+  TabInviteReward:
+    | {
+        showRewardDistributionHistory?: boolean;
+      }
+    | undefined;
   TabYourReferred: undefined;
-  TabHardwareSalesReward: undefined;
+  TabHardwareSalesReward:
+    | {
+        showOrderDetail?: boolean;
+        orderId?: string;
+      }
+    | undefined;
   TabEarnReward: {
     title: string;
   };

--- a/packages/shared/src/utils/notificationsUtils.ts
+++ b/packages/shared/src/utils/notificationsUtils.ts
@@ -200,6 +200,26 @@ export function parseNotificationPayload(
         payload as string,
       );
       break;
+    case ENotificationPushMessageMode.command:
+      try {
+        const { action, data } = JSON.parse(payload || '{}') as {
+          action?: string;
+          data?: Record<string, unknown>;
+        };
+        if (!action) {
+          fallbackHandler();
+          return;
+        }
+        // Merge extras.params with data, extras.params takes precedence for orderId etc.
+        const mergedData = { ...data, ...extras?.params };
+        appEventBus.emit(EAppEventBusNames.ExecuteNotificationCommand, {
+          action,
+          data: mergedData,
+        });
+      } catch (_error) {
+        fallbackHandler();
+      }
+      break;
     default:
       break;
   }

--- a/packages/shared/types/notification.ts
+++ b/packages/shared/types/notification.ts
@@ -202,6 +202,12 @@ export enum ENotificationPushMessageMode {
   openInBrowser = 3,
   openInApp = 4,
   openInDapp = 5,
+  command = 6,
+}
+
+export enum ENotificationCommand {
+  openRewardDistributionHistoryModal = 'openRewardDistributionHistoryModal',
+  openHardwareSalesOrder = 'openHardwareSalesOrder',
 }
 // /notification/v1/message/ack
 export type INotificationPushMessageAckParams = {


### PR DESCRIPTION
## Summary
- Add hardware sales order detail page with order information display
- Implement notification command registry for handling deep link navigation
- Add event bus support for opening hardware sales order details from notifications
- Support notification-triggered navigation to refer friends pages

## Test plan
- [ ] Test clicking notification navigates to hardware sales order detail
- [ ] Verify order detail page displays correct order information
- [ ] Test deep link navigation from notification payload
- [ ] Verify refer friends tab navigation works correctly