### PR TITLE
feat: add analytics tracking for keyless wallet onboarding and user count

### DIFF
--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/AccountSelectorWalletListSideBar.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/AccountSelectorWalletListSideBar.tsx
@@ -177,11 +177,15 @@ export function AccountSelectorWalletListSideBar({
       const hwWalletCount = wallets.filter(
         (wallet) => wallet.type === 'hw',
       ).length;
+      const keylessWalletCount = wallets.filter(
+        (wallet) => wallet.isKeyless,
+      ).length;
       const appWalletCount = walletCount - hwWalletCount;
       analytics.updateUserProfile({
         walletCount,
         hwWalletCount,
         appWalletCount,
+        keylessWalletCount,
       });
     }
   }, [wallets]);

--- a/packages/kit/src/views/Onboardingv2/pages/CreateOrImportWallet.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/CreateOrImportWallet.tsx
@@ -197,6 +197,9 @@ function CreateOrImportWallet() {
   };
 
   const handleKeylessWalletClick = useCallback(async () => {
+    defaultLogger.account.wallet.onboard({
+      onboardMethod: 'createKeylessWallet',
+    });
     // await enableKeylessWallet({
     //   fromScene: EKeylessWalletEnableScene.Onboarding,
     // });

--- a/packages/kit/src/views/Onboardingv2/pages/FinalizeWalletSetup.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/FinalizeWalletSetup.tsx
@@ -42,6 +42,9 @@ import { EMnemonicType } from '@onekeyhq/shared/src/utils/secret';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
+import { EOAuthSocialLoginProvider } from '@onekeyhq/shared/src/consts/authConsts';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import { AccountSelectorProviderMirror } from '../../../components/AccountSelector';
 import useAppNavigation from '../../../hooks/useAppNavigation';
@@ -310,6 +313,21 @@ function FinalizeWalletSetupPage({
               isKeylessWallet,
               keylessDetailsInfo,
             });
+            // Track keyless wallet creation success
+            if (isKeylessWallet && keylessDetailsInfo) {
+              defaultLogger.account.wallet.walletAdded({
+                status: 'success',
+                addMethod: 'CreateKeylessWallet',
+                isSoftwareWalletOnlyUser: true,
+                details: {
+                  provider:
+                    keylessDetailsInfo.keylessProvider ===
+                    EOAuthSocialLoginProvider.Google
+                      ? 'google'
+                      : 'apple',
+                },
+              });
+            }
           },
         });
         created.current = true;

--- a/packages/kit/src/views/Onboardingv2/pages/GetStarted.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/GetStarted.tsx
@@ -324,6 +324,9 @@ function GetStarted() {
   };
 
   const handleGoogleLogin = useCallback(async () => {
+    defaultLogger.account.wallet.onboard({
+      onboardMethod: 'createKeylessWallet',
+    });
     await checkKeylessWalletLocalExistence({
       signInProvider: EOAuthSocialLoginProvider.Google,
     });

--- a/packages/kit/src/views/Onboardingv2/pages/OneKeyIDLoginPage.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/OneKeyIDLoginPage.tsx
@@ -24,6 +24,8 @@ import type {
 } from '@onekeyhq/shared/src/routes';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import { AccountSelectorProviderMirror } from '../../../components/AccountSelector/AccountSelectorProvider';
 import { useKeylessWallet } from '../../../components/KeylessWallet/useKeylessWallet';
@@ -152,6 +154,19 @@ function OneKeyIDLoginPage() {
             });
             setIsResetMode(false);
           } else {
+            // Track wallet creation started after OAuth login succeeds
+            if (!isVerifyMode) {
+              defaultLogger.account.wallet.addWalletStarted({
+                addMethod: 'CreateKeylessWallet',
+                isSoftwareWalletOnlyUser: true,
+                details: {
+                  provider:
+                    provider === EOAuthSocialLoginProvider.Google
+                      ? 'google'
+                      : 'apple',
+                },
+              });
+            }
             await checkKeylessWalletCreatedOnServer({
               token: result.session.accessToken,
               refreshToken: result.session.refreshToken,
@@ -166,6 +181,7 @@ function OneKeyIDLoginPage() {
     [
       checkKeylessWalletCreatedOnServer,
       isResetMode,
+      isVerifyMode,
       mode,
       signInWithSocialLogin,
     ],

--- a/packages/shared/src/analytics/index.ts
+++ b/packages/shared/src/analytics/index.ts
@@ -181,6 +181,7 @@ export class Analytics {
     walletCount?: number;
     appWalletCount?: number;
     hwWalletCount?: number;
+    keylessWalletCount?: number;
   }) {
     if (this.instanceId && this.baseURL) {
       void this.requestUserProfile(attributes);

--- a/packages/shared/src/logger/scopes/account/scenes/wallet.ts
+++ b/packages/shared/src/logger/scopes/account/scenes/wallet.ts
@@ -58,6 +58,15 @@ export class WalletScene extends BaseScene {
           },
         };
 
+      case 'CreateKeylessWallet':
+        return {
+          addMethod: 'CreateKeylessWallet',
+          isSoftwareWalletOnlyUser: params.isSoftwareWalletOnlyUser,
+          details: {
+            provider: params.details.provider,
+          },
+        };
+
       default: {
         const _exhaustiveCheck: never = params;
         throw new OneKeyLocalError(
@@ -121,6 +130,16 @@ export class WalletScene extends BaseScene {
           },
         };
 
+      case 'CreateKeylessWallet':
+        return {
+          status: params.status,
+          addMethod: 'CreateKeylessWallet',
+          isSoftwareWalletOnlyUser: params.isSoftwareWalletOnlyUser,
+          details: {
+            provider: params.details.provider,
+          },
+        };
+
       default: {
         const _exhaustiveCheck: never = params;
         throw new OneKeyLocalError(
@@ -137,7 +156,8 @@ export class WalletScene extends BaseScene {
       | 'createWallet'
       | 'importWallet'
       | 'connectHWWallet'
-      | 'connect3rdPartyWallet';
+      | 'connect3rdPartyWallet'
+      | 'createKeylessWallet';
   }) {
     return params;
   }

--- a/packages/shared/types/analytics/onboarding.ts
+++ b/packages/shared/types/analytics/onboarding.ts
@@ -37,12 +37,17 @@ export interface IConnectExternalWalletPayload {
   walletName?: string;
 }
 
+export interface ICreateKeylessWalletPayload {
+  provider: 'google' | 'apple';
+}
+
 // Discriminated union type for the wallet events
 export type IWalletAddMethod =
   | 'CreateWallet'
   | 'ImportWallet'
   | 'ConnectHWWallet'
-  | 'Connect3rdPartyWallet';
+  | 'Connect3rdPartyWallet'
+  | 'CreateKeylessWallet';
 
 export type IWalletStartedParams =
   | {
@@ -67,6 +72,11 @@ export type IWalletStartedParams =
       addMethod: Extract<IWalletAddMethod, 'Connect3rdPartyWallet'>;
       details: IConnectExternalWalletPayload;
       isSoftwareWalletOnlyUser: boolean;
+    }
+  | {
+      addMethod: Extract<IWalletAddMethod, 'CreateKeylessWallet'>;
+      details: ICreateKeylessWalletPayload;
+      isSoftwareWalletOnlyUser: boolean;
     };
 
 export type IWalletAddedEventParams = IBaseEventPayload &
@@ -89,6 +99,11 @@ export type IWalletAddedEventParams = IBaseEventPayload &
     | {
         addMethod: Extract<IWalletAddMethod, 'Connect3rdPartyWallet'>;
         details: IConnectExternalWalletPayload;
+        isSoftwareWalletOnlyUser: boolean;
+      }
+    | {
+        addMethod: Extract<IWalletAddMethod, 'CreateKeylessWallet'>;
+        details: ICreateKeylessWalletPayload;
         isSoftwareWalletOnlyUser: boolean;
       }
   );


### PR DESCRIPTION
## Summary
- Add analytics events to track keyless wallet creation flow
- Add user profile attribute to track keyless wallet count

## Changes

### Analytics Events
| Event | Trigger | Key Fields |
|-------|---------|------------|
| `account_wallet_onboard` | Click "Continue with Google" button / Keyless wallet | `onboardMethod: 'createKeylessWallet'` |
| `account_wallet_addWalletStarted` | After OAuth login success | `addMethod: 'CreateKeylessWallet'`, `provider` |
| `account_wallet_walletAdded` | After wallet creation completes | `addMethod: 'CreateKeylessWallet', details: {provider : "google / apple"}` |

### User Profile
- Add `keylessWalletCount` to `updateUserProfile()` for tracking users with keyless wallets

## Files Changed
- `packages/shared/types/analytics/onboarding.ts` - Add `ICreateKeylessWalletPayload` type and extend discriminated unions
- `packages/shared/src/logger/scopes/account/scenes/wallet.ts` - Add `CreateKeylessWallet` cases
- `packages/shared/src/analytics/index.ts` - Add `keylessWalletCount` parameter
- `packages/kit/src/views/Onboardingv2/pages/GetStarted.tsx` - Add `onboard` event
- `packages/kit/src/views/Onboardingv2/pages/CreateOrImportWallet.tsx` - Add `onboard` event
- `packages/kit/src/views/Onboardingv2/pages/OneKeyIDLoginPage.tsx` - Add `addWalletStarted` event
- `packages/kit/src/views/Onboardingv2/pages/FinalizeWalletSetup.tsx` - Add `walletAdded` event
- `packages/kit/src/views/AccountManagerStacks/.../AccountSelectorWalletListSideBar.tsx` - Add `keylessWalletCount` reporting

## Test Plan
- [ ] Enable "Analytics Request in dev env" in Dev Settings
- [ ] Create a keyless wallet via Google/Apple
- [ ] Verify `onboard`, `addWalletStarted`, `walletAdded` events in Network tab
- [ ] Open wallet list sidebar and verify `keylessWalletCount` in `attributes` request