### PR TITLE
OK-49432: add KEYLESS_WALLET type to ERequestWalletTypeEnum

### DIFF
--- a/packages/kit-bg/src/services/ServiceAccountProfile.ts
+++ b/packages/kit-bg/src/services/ServiceAccountProfile.ts
@@ -886,6 +886,9 @@ class ServiceAccountProfile extends ServiceBase {
     accountId?: string;
   }) {
     if (walletId) {
+      if (accountUtils.isKeylessWallet({ walletId })) {
+        return ERequestWalletTypeEnum.KEYLESS_WALLET;
+      }
       if (accountUtils.isHdWallet({ walletId })) {
         return ERequestWalletTypeEnum.HD;
       }
@@ -907,6 +910,9 @@ class ServiceAccountProfile extends ServiceBase {
       }
     }
     if (accountId) {
+      if (accountUtils.isKeylessAccount({ accountId })) {
+        return ERequestWalletTypeEnum.KEYLESS_WALLET;
+      }
       if (accountUtils.isHdAccount({ accountId })) {
         return ERequestWalletTypeEnum.HD;
       }

--- a/packages/kit-bg/src/services/ServiceNotification/PushProvider/PushProviderWebSocket.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/PushProvider/PushProviderWebSocket.ts
@@ -249,8 +249,6 @@ export class PushProviderWebSocket extends PushProviderBase {
       void this.backgroundApi.serviceNotification.setBadge({
         count: payload.badge,
       });
-      // Trigger notification list refresh to sync read status in UI
-      appEventBus.emit(EAppEventBusNames.UpdateNotificationBadge, undefined);
     });
 
     // this.socket.off('notification');

--- a/packages/kit/src/views/Notifications/components/NotificationListView.tsx
+++ b/packages/kit/src/views/Notifications/components/NotificationListView.tsx
@@ -326,7 +326,7 @@ export function NotificationListView({
   const intl = useIntl();
   const { bottom } = useSafeAreaInsets();
   const navigation = useAppNavigation();
-  const [{ lastReceivedTime, firstTimeGuideOpened }, setNotificationsData] =
+  const [{ lastReceivedTime, firstTimeGuideOpened, badge }, setNotificationsData] =
     useNotificationsAtom();
 
   const isFirstTimeGuideOpened = useRef(false);
@@ -390,6 +390,17 @@ export function NotificationListView({
     [ENotificationPushTopicTypes.accountActivity]: 0,
     [ENotificationPushTopicTypes.system]: 0,
   });
+
+  // Clear tab unread badges when global badge becomes 0
+  useEffect(() => {
+    if (badge === 0) {
+      setUnreadMap({
+        [ENotificationPushTopicTypes.accountActivity]: 0,
+        [ENotificationPushTopicTypes.system]: 0,
+      });
+    }
+  }, [badge]);
+
   const [result, setResult] = useState<INotificationPushMessageListItem[]>([]);
   const cacheListRef = useRef<
     Record<ENotificationPushTopicTypes, INotificationPushMessageListItem[]>

--- a/packages/kit/src/views/Notifications/components/NotificationListView.tsx
+++ b/packages/kit/src/views/Notifications/components/NotificationListView.tsx
@@ -326,8 +326,10 @@ export function NotificationListView({
   const intl = useIntl();
   const { bottom } = useSafeAreaInsets();
   const navigation = useAppNavigation();
-  const [{ lastReceivedTime, firstTimeGuideOpened, badge }, setNotificationsData] =
-    useNotificationsAtom();
+  const [
+    { lastReceivedTime, firstTimeGuideOpened, badge },
+    setNotificationsData,
+  ] = useNotificationsAtom();
 
   const isFirstTimeGuideOpened = useRef(false);
   const listRef = useRef<ISectionListRef<unknown>>(null);

--- a/packages/shared/src/utils/accountUtils.ts
+++ b/packages/shared/src/utils/accountUtils.ts
@@ -1015,6 +1015,11 @@ function isKeylessWallet({
   );
 }
 
+function isKeylessAccount({ accountId }: { accountId: string }): boolean {
+  const walletId = getWalletIdFromAccountId({ accountId });
+  return isKeylessWallet({ walletId });
+}
+
 function getKeylessWalletPackSetId({ walletId }: { walletId: string }): string {
   const packSetId = walletId.split(`${WALLET_TYPE_HD}-keyless-`)[1];
   if (!packSetId) {
@@ -1147,6 +1152,7 @@ export default {
   buildAllNetworkIndexedAccountIdFromAccountId,
 
   isKeylessWallet,
+  isKeylessAccount,
   hashKeylessSocialUserId,
   isHdWallet,
   isQrWallet,

--- a/packages/shared/types/account.ts
+++ b/packages/shared/types/account.ts
@@ -50,6 +50,7 @@ export enum ERequestWalletTypeEnum {
   HW_QRCODE = 'hw-qrcode',
   URL = 'url',
   THIRD_PARTY = 'third-party',
+  KEYLESS_WALLET = 'keyless-wallet',
   UNKNOWN = 'unknown',
 }
 


### PR DESCRIPTION
## Summary
- Add KEYLESS_WALLET enum value for X-OneKey-Wallet-Type HTTP header
- Add isKeylessAccount utility function in accountUtils.ts
- Add keyless wallet detection logic in ServiceAccountProfile._getRequestWalletType()

## Changes
1. packages/shared/types/account.ts - Add enum value
2. packages/shared/src/utils/accountUtils.ts - Add isKeylessAccount function
3. packages/kit-bg/src/services/ServiceAccountProfile.ts - Add keyless wallet detection

## Test Plan
- [ ] Verify keyless wallet requests include correct X-OneKey-Wallet-Type: keyless-wallet header