### PR TITLE
chore: remove git hooks (husky)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,0 @@
-yarn lint

--- a/package.json
+++ b/package.json
@@ -68,8 +68,7 @@
     "app:desktop:op": "yarn op yarn app:desktop",
     "app:ios:op": "yarn op yarn app:ios",
     "app:android:op": "yarn op yarn app:android",
-    "app:native-bundle:op": "yarn op yarn app:native-bundle",
-    "prepare": "husky"
+    "app:native-bundle:op": "yarn op yarn app:native-bundle"
   },
   "dependencies": {
     "@aivenio/tsc-output-parser": "^2.1.1",
@@ -269,7 +268,6 @@
     "fake-indexeddb": "^5.0.0",
     "html-webpack-plugin": "^5.5.3",
     "http-proxy-middleware": "^2.0.3",
-    "husky": "^9.1.7",
     "ip": "^1.1.9",
     "jest": "^29.7.0",
     "jest-expo": "~53.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8578,7 +8578,6 @@ __metadata:
     fast-base64-decode: "npm:2.0.0"
     html-webpack-plugin: "npm:^5.5.3"
     http-proxy-middleware: "npm:^2.0.3"
-    husky: "npm:^9.1.7"
     ip: "npm:^1.1.9"
     isomorphic-ws: "npm:^4.0.1"
     jest: "npm:^29.7.0"
@@ -28933,15 +28932,6 @@ __metadata:
   dependencies:
     ms: "npm:^2.0.0"
   checksum: 10/9c7a74a2827f9294c009266c82031030eae811ca87b0da3dceb8d6071b9bde22c9f3daef0469c3c533cc67a97d8a167cd9fc0389350e5f415f61a79b171ded16
-  languageName: node
-  linkType: hard
-
-"husky@npm:^9.1.7":
-  version: 9.1.7
-  resolution: "husky@npm:9.1.7"
-  bin:
-    husky: bin.js
-  checksum: 10/c2412753f15695db369634ba70f50f5c0b7e5cb13b673d0826c411ec1bd9ddef08c1dad89ea154f57da2521d2605bd64308af748749b27d08c5f563bcd89975f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Remove husky pre-push hook configuration
- Remove husky package from devDependencies
- Remove prepare script from package.json

This change removes the git hooks enforcement to allow for a more flexible development workflow. Developers can still run linting manually when needed.

## Test plan
- [ ] Verify that commits can be created without running pre-push hooks
- [ ] Verify that `yarn lint` can still be run manually
- [ ] Confirm package.json no longer contains husky references

🤖 Generated with [Claude Code](https://claude.com/claude-code)