### PR TITLE
fix: ensure Google Drive login before cloud backup on Android

### DIFF
--- a/packages/kit/src/views/Onboardingv2/hooks/useCloudBackup.ts
+++ b/packages/kit/src/views/Onboardingv2/hooks/useCloudBackup.ts
@@ -177,6 +177,9 @@ export function useCloudBackup() {
     async ({ hideRestoreButton }: { hideRestoreButton?: boolean } = {}) => {
       const isAvailable = await checkIsAvailable();
       if (isAvailable) {
+        if (platformEnv.isNativeAndroid) {
+          await backgroundApiProxy.serviceCloudBackupV2.loginCloudIfNeed();
+        }
         navigation.navigate(ERootRoutes.Onboarding, {
           screen: EOnboardingV2Routes.OnboardingV2,
           params: {
@@ -501,6 +504,10 @@ export function useCloudBackup() {
       const isAvailable = await checkIsAvailable();
       let loadingDialog: IDialogInstance | null = null;
       if (isAvailable) {
+        if (platformEnv.isNativeAndroid) {
+          await backgroundApiProxy.serviceCloudBackupV2.loginCloudIfNeed();
+        }
+
         if (platformEnv.isNativeAndroid || alwaysGoToBackupDetail) {
           await goToPageBackupDetail({
             actionType: 'backup',


### PR DESCRIPTION
## Summary
- Add `loginCloudIfNeed()` call before cloud backup operations on Android platform
- Ensures user is logged into Google Drive before attempting restore or backup operations

## Changes
- Added Google Drive login check in `goToRestore` function
- Added Google Drive login check in `goToBackupOrRestore` function

## Test plan
- [ ] Test cloud restore flow on Android - should prompt for Google Drive login if not already logged in
- [ ] Test cloud backup flow on Android - should prompt for Google Drive login if not already logged in
- [ ] Verify iOS behavior is unchanged