### PR TITLE
fix: hide share button for SUI token detail page(OK-49084)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 
+import { SUI_TYPE_ARG } from '@mysten/sui/utils';
 import { useWindowDimensions } from 'react-native';
 
 import {
@@ -196,7 +197,7 @@ export function TokenDetailHeaderLeft({
                         />
                       ) : null}
 
-                      {networkId ? (
+                      {networkId && address !== SUI_TYPE_ARG ? (
                         <ShareButton
                           networkId={networkId}
                           address={address}


### PR DESCRIPTION
## Summary
- Hide the share button when viewing the native SUI token detail page
- The token address `0x2::sui::SUI` is excluded from showing the share button

## Changes
- Modified `TokenDetailHeaderLeft.tsx` to add a condition that hides the share button for the SUI native token

## Test Plan
- [ ] Navigate to Market > SUI token detail page
- [ ] Verify the share button is not visible
- [ ] Navigate to other token detail pages
- [ ] Verify the share button is still visible for other tokens