### PR TITLE
feat: hide share button in position share control panel on non-mobile platforms

### DIFF
--- a/packages/kit/src/views/Perp/components/PositionShare/ControlPanel.tsx
+++ b/packages/kit/src/views/Perp/components/PositionShare/ControlPanel.tsx
@@ -113,29 +113,31 @@ export function ControlPanel({
             })}
           </SizableText>
         </YStack>
-        <YStack gap="$1" alignItems="center">
-          <IconButton
-            title={intl.formatMessage({
-              id: ETranslations.explore_share,
-            })}
-            cursor="pointer"
-            icon="ShareOutline"
-            size="large"
-            onPress={onShareImage}
-            disabled={isLoading}
-            iconSize="$6"
-            borderRadius="$4"
-            borderWidth={1}
-            borderColor="$borderSubdued"
-            hoverStyle={{ borderColor: '$borderHover' }}
-            bg="$bgApp"
-          />
-          <SizableText size="$bodySm" color="$text">
-            {intl.formatMessage({
-              id: ETranslations.explore_share,
-            })}
-          </SizableText>
-        </YStack>
+        {isMobile ? (
+          <YStack gap="$1" alignItems="center">
+            <IconButton
+              title={intl.formatMessage({
+                id: ETranslations.explore_share,
+              })}
+              cursor="pointer"
+              icon="ShareOutline"
+              size="large"
+              onPress={onShareImage}
+              disabled={isLoading}
+              iconSize="$6"
+              borderRadius="$4"
+              borderWidth={1}
+              borderColor="$borderSubdued"
+              hoverStyle={{ borderColor: '$borderHover' }}
+              bg="$bgApp"
+            />
+            <SizableText size="$bodySm" color="$text">
+              {intl.formatMessage({
+                id: ETranslations.explore_share,
+              })}
+            </SizableText>
+          </YStack>
+        ) : null}
         <YStack gap="$1" alignItems="center">
           <IconButton
             title={intl.formatMessage({


### PR DESCRIPTION
## Summary
- Hide the share button in the position share control panel on non-mobile platforms
- Only display the share button when \`isMobile\` is true

## Changes
- Wrapped the share button YStack component with an \`isMobile\` conditional check in \`ControlPanel.tsx\`