### PR TITLE
fix: improve keyless wallet data corruption error handling

### DIFF
--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -28,7 +28,10 @@ import {
   KEYLESS_SUPABASE_PROJECT_URL,
   KEYLESS_SUPABASE_PUBLIC_API_KEY,
 } from '@onekeyhq/shared/src/consts/authConsts';
-import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import {
+  KeylessDataCorruptedError,
+  OneKeyLocalError,
+} from '@onekeyhq/shared/src/errors';
 import type { IOneKeyError } from '@onekeyhq/shared/src/errors/types/errorTypes';
 import type {
   IAuthKeyPack,
@@ -46,6 +49,7 @@ import keylessWalletUtils from '@onekeyhq/shared/src/keylessWallet/keylessWallet
 import shamirUtils from '@onekeyhq/shared/src/keylessWallet/shamirUtils';
 import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import { ETranslations } from '@onekeyhq/shared/src/locale/enum/translations';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EOnboardingV2OneKeyIDLoginMode } from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
@@ -1640,9 +1644,11 @@ class ServiceKeylessWallet extends ServiceBase {
         backgroundApi: this.backgroundApi,
       });
     if (!mnemonicPassword) {
-      throw new OneKeyLocalError(
-        'Mnemonic password not found in storage. Please restore the wallet again.',
-      );
+      defaultLogger.wallet.keyless.dataCorruptedError({
+        reason:
+          'getMnemonicPasswordFromStorage: mnemonicPassword not found in secure storage',
+      });
+      throw new KeylessDataCorruptedError();
     }
 
     // 3.1. Verify mnemonicPassword can decrypt backendShareData and matches local keyless wallet

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessMnemonicPasswordStorage.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessMnemonicPasswordStorage.ts
@@ -1,4 +1,5 @@
-import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import { KeylessDataCorruptedError } from '@onekeyhq/shared/src/errors';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 
@@ -63,12 +64,12 @@ async function getMnemonicPasswordFromStorageWithPassword(params: {
       allowRawPassword: true,
     });
     return mnemonicPassword;
-  } catch (error) {
-    throw new OneKeyLocalError(
-      `Failed to decrypt mnemonicPassword: invalid password or corrupted data: ${
-        (error as Error)?.message
-      }`,
-    );
+  } catch (_error) {
+    defaultLogger.wallet.keyless.dataCorruptedError({
+      reason:
+        'getMnemonicPasswordFromStorageWithPassword: failed to decrypt mnemonicPassword by decryptionKey',
+    });
+    throw new KeylessDataCorruptedError();
   }
 }
 

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessRefreshTokenStorage.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessRefreshTokenStorage.ts
@@ -1,4 +1,5 @@
-import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import { KeylessDataCorruptedError } from '@onekeyhq/shared/src/errors';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 
@@ -68,12 +69,12 @@ async function getRefreshTokenFromStorageWithPassword(params: {
       });
 
     return decryptedRefreshToken;
-  } catch (error) {
-    throw new OneKeyLocalError(
-      `Failed to decrypt refreshToken: invalid password or corrupted data: ${
-        (error as Error)?.message
-      }`,
-    );
+  } catch (_error) {
+    defaultLogger.wallet.keyless.dataCorruptedError({
+      reason:
+        'getRefreshTokenFromStorageWithPassword: failed to decrypt refreshToken by decryptionKey',
+    });
+    throw new KeylessDataCorruptedError();
   }
 }
 
@@ -201,10 +202,12 @@ async function getAccessTokenFromStorage(params: {
     });
 
     return decryptedToken;
-  } catch (error) {
-    throw new OneKeyLocalError(
-      `Failed to decrypt token: corrupted data: ${(error as Error)?.message}`,
-    );
+  } catch (_error) {
+    defaultLogger.wallet.keyless.dataCorruptedError({
+      reason:
+        'getAccessTokenFromStorage: failed to decrypt token by decryptionKey',
+    });
+    throw new KeylessDataCorruptedError();
   }
 }
 

--- a/packages/kit/src/components/KeylessWallet/useKeylessWallet.tsx
+++ b/packages/kit/src/components/KeylessWallet/useKeylessWallet.tsx
@@ -2,6 +2,7 @@ import { useCallback, useRef, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 
+import type { IDialogInstance } from '@onekeyhq/components';
 import {
   Dialog,
   SizableText,
@@ -857,32 +858,43 @@ export function useKeylessWallet() {
       let mnemonic = '';
       let ownerId = '';
       let keylessDetailsInfo;
-      if (action === EKeylessFinalizeAction.Create) {
-        const result =
-          await backgroundApiProxy.serviceKeylessWallet.createKeylessWalletToServer(
-            {
-              token,
-              refreshToken,
-              pin,
-              customMnemonic: await getKeylessOnboardingCustomMnemonic(),
-            },
-          );
-        mnemonic = result.mnemonic;
-        ownerId = result.ownerId;
-        keylessDetailsInfo = result.keylessDetailsInfo;
-      }
-      if (action === EKeylessFinalizeAction.Restore) {
-        const result =
-          await backgroundApiProxy.serviceKeylessWallet.restoreKeylessWalletFromServer(
-            {
-              token,
-              refreshToken,
-              pin,
-            },
-          );
-        mnemonic = result.mnemonic;
-        ownerId = result.ownerId;
-        keylessDetailsInfo = result.keylessDetailsInfo;
+      let loadingDialog: IDialogInstance | undefined;
+      try {
+        loadingDialog = Dialog.loading({
+          title: intl.formatMessage({
+            id: ETranslations.global_preparing,
+          }),
+        });
+        await timerUtils.wait(600);
+        if (action === EKeylessFinalizeAction.Create) {
+          const result =
+            await backgroundApiProxy.serviceKeylessWallet.createKeylessWalletToServer(
+              {
+                token,
+                refreshToken,
+                pin,
+                customMnemonic: await getKeylessOnboardingCustomMnemonic(),
+              },
+            );
+          mnemonic = result.mnemonic;
+          ownerId = result.ownerId;
+          keylessDetailsInfo = result.keylessDetailsInfo;
+        }
+        if (action === EKeylessFinalizeAction.Restore) {
+          const result =
+            await backgroundApiProxy.serviceKeylessWallet.restoreKeylessWalletFromServer(
+              {
+                token,
+                refreshToken,
+                pin,
+              },
+            );
+          mnemonic = result.mnemonic;
+          ownerId = result.ownerId;
+          keylessDetailsInfo = result.keylessDetailsInfo;
+        }
+      } finally {
+        await loadingDialog?.close?.();
       }
       navigation.navigate(ERootRoutes.Onboarding, {
         screen: EOnboardingV2Routes.OnboardingV2,

--- a/packages/kit/src/components/OneKeyAuth/OAuthPopup/OAuthPopupBase.ts
+++ b/packages/kit/src/components/OneKeyAuth/OAuthPopup/OAuthPopupBase.ts
@@ -2,7 +2,7 @@ import {
   OAUTH_FLOW_TIMEOUT_MS,
   ONEKEY_OAUTH_STATE_KEY,
 } from '@onekeyhq/shared/src/consts/authConsts';
-import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import { OneKeyError, OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 
 import type { IOAuthPopupOptions, IOAuthPopupResult } from './types';
 import type { SupabaseClient } from '@supabase/supabase-js';
@@ -177,7 +177,8 @@ export abstract class OAuthPopupBase {
    * Wrap error with OneKeyLocalError if not already.
    */
   protected static wrapError(error: unknown, fallbackMessage: string): Error {
-    if (error instanceof OneKeyLocalError) {
+    // if (error instanceof OneKeyLocalError) {
+    if (error instanceof OneKeyLocalError || error instanceof OneKeyError) {
       return error;
     }
     return new OneKeyLocalError(

--- a/packages/shared/src/errors/errors/appErrors.ts
+++ b/packages/shared/src/errors/errors/appErrors.ts
@@ -45,6 +45,24 @@ export class IncorrectPassword extends OneKeyAppError {
   override className = EOneKeyErrorClassNames.IncorrectPassword;
 }
 
+export class KeylessDataCorruptedError extends OneKeyAppError {
+  constructor(props?: IOneKeyError | string) {
+    super(
+      normalizeErrorProps(props, {
+        defaultMessage: 'OneKeyError: KeylessDataCorruptedError',
+        // TODO @franco i18n
+        // defaultKey: ETranslations.auth_error_passcode_incorrect,
+        defaultKey:
+          '数据损坏，可能是更换了新设备，如果您记得 PIN 和社交账户，请登出钱包后重新添加' as any,
+      }),
+    );
+  }
+
+  override className = EOneKeyErrorClassNames.KeylessDataCorruptedError;
+
+  override name = EOneKeyErrorClassNames.KeylessDataCorruptedError;
+}
+
 export class IncorrectMasterPassword extends OneKeyAppError {
   constructor(props?: IOneKeyError | string) {
     super(

--- a/packages/shared/src/errors/types/errorTypes.ts
+++ b/packages/shared/src/errors/types/errorTypes.ts
@@ -50,6 +50,7 @@ export enum EOneKeyErrorClassNames {
   WebDeviceNotFoundOrNeedsPermission = 'WebDeviceNotFoundOrNeedsPermission',
   DeviceNotOpenedPassphrase = 'DeviceNotOpenedPassphrase',
   DeviceNotFound = 'DeviceNotFound',
+  KeylessDataCorruptedError = 'KeylessDataCorruptedError',
 }
 
 export type IOneKeyErrorI18nInfo = Record<string | number, string | number>;

--- a/packages/shared/src/logger/scopes/wallet/scenes/keyless.ts
+++ b/packages/shared/src/logger/scopes/wallet/scenes/keyless.ts
@@ -15,4 +15,9 @@ export class KeylessScene extends BaseScene {
       sdkError,
     };
   }
+
+  @LogToLocal({ level: 'error' })
+  public dataCorruptedError({ reason }: { reason: string }) {
+    return { reason };
+  }
 }


### PR DESCRIPTION
## Summary
- Add `KeylessDataCorruptedError` for better error messaging when keyless data is corrupted
- Replace generic `OneKeyLocalError` with specific `KeylessDataCorruptedError` in keyless storage operations
- Add logging for data corruption scenarios via `defaultLogger.wallet.keyless.dataCorruptedError`
- Add loading dialog during keyless wallet create/restore operations
- Fix error wrapping in OAuthPopupBase to also handle `OneKeyError` instances

## Test plan
- [ ] Test keyless wallet creation flow with loading dialog
- [ ] Test keyless wallet restore flow with loading dialog
- [ ] Verify data corruption errors show proper error message
- [ ] Check error logging works correctly for corruption scenarios