### PR TITLE
fix: clear navigation stack when redirecting to refer-friends after logout(OK-49238)

### DIFF
--- a/packages/kit/src/hooks/useReferFriends.tsx
+++ b/packages/kit/src/hooks/useReferFriends.tsx
@@ -97,7 +97,12 @@ export function useReplaceToReferFriends() {
         const screen = isLogin
           ? ETabReferFriendsRoutes.TabInviteReward
           : ETabReferFriendsRoutes.TabReferAFriend;
-        navigation.replace(screen, navParams);
+        // Use reset instead of replace to clear the navigation stack
+        // This prevents the back button from appearing on the root screen
+        navigation.reset({
+          index: 0,
+          routes: [{ name: screen, params: navParams }],
+        });
       }
     },
     [navigation],


### PR DESCRIPTION
## Summary
- Use `reset` instead of `replace` when redirecting to refer-friends page after logout
- This clears the navigation stack completely, preventing the back button from appearing on desktop

## Problem
When user logs out from the `invite-reward` page, they are redirected to `/refer-friends`. However, on desktop, a back button was incorrectly appearing in the header because `navigation.replace()` only replaces the current route without clearing the navigation stack index.

## Solution
Changed `navigation.replace(screen, navParams)` to `navigation.reset({ index: 0, routes: [...] })` to completely reset the navigation stack, ensuring the target page is at index 0 and no back button is shown.

## Test plan
- [ ] Log in and navigate to refer-friends/invite-reward page on desktop
- [ ] Log out
- [ ] Verify that after redirect to /refer-friends, no back button appears in the header