### PR TITLE
refactor: extract useNavigateToMarketTab hook for reusable market navigation(OK-48946)

### DIFF
--- a/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
@@ -41,6 +41,8 @@ import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { getTokenPriceChangeStyle } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type { IMarketTokenListItem } from '@onekeyhq/shared/types/marketV2';
 
+import { useNavigateToMarketTab } from '../../../Market/hooks';
+import { EMarketHomeTab } from '../../../Market/MarketHomeV2/types';
 import { RichBlock } from '../RichBlock/RichBlock';
 import { RichTable } from '../RichTable';
 
@@ -160,6 +162,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
   const intl = useIntl();
   const currencyInfo = useCurrency();
   const navigation = useAppNavigation();
+  const navigateToMarketTab = useNavigateToMarketTab();
   const [favoriteTokens, setFavoriteTokens] = useState<IFavoriteTokenDisplay[]>(
     [],
   );
@@ -622,13 +625,8 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
 
   // Navigate to Market favorites tab
   const handleViewMore = useCallback(() => {
-    rootNavigationRef.current?.navigate(ERootRoutes.Main, {
-      screen: marketTab,
-      params: {
-        screen: ETabMarketRoutes.TabMarket,
-      },
-    });
-  }, [marketTab]);
+    navigateToMarketTab({ tabToSelect: EMarketHomeTab.Watchlist });
+  }, [navigateToMarketTab]);
 
   // Render table/list layout for user favorites
   const renderUserFavoritesList = useCallback(() => {

--- a/packages/kit/src/views/Market/hooks/index.ts
+++ b/packages/kit/src/views/Market/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useMarketBasicConfig } from './useMarketBasicConfig';
 export { useMarketEnterAnalytics } from './useMarketEnterAnalytics';
 export { useMarketNetworks } from './useMarketNetworks';
+export { useNavigateToMarketTab } from './useNavigateToMarketTab';

--- a/packages/kit/src/views/Market/hooks/useNavigateToMarketTab.ts
+++ b/packages/kit/src/views/Market/hooks/useNavigateToMarketTab.ts
@@ -1,0 +1,61 @@
+import { useCallback } from 'react';
+
+import { rootNavigationRef } from '@onekeyhq/components';
+import {
+  type IMarketSelectedTab,
+  useMarketSelectedTabAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  EAppEventBusNames,
+  appEventBus,
+} from '@onekeyhq/shared/src/eventBus/appEventBus';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import {
+  ERootRoutes,
+  ETabMarketRoutes,
+  ETabRoutes,
+} from '@onekeyhq/shared/src/routes';
+
+interface INavigateToMarketTabOptions {
+  tabToSelect?: IMarketSelectedTab;
+}
+
+export function useNavigateToMarketTab() {
+  const [, setMarketSelectedTab] = useMarketSelectedTabAtom();
+
+  const navigateToMarketTab = useCallback(
+    (options?: INavigateToMarketTabOptions) => {
+      const { tabToSelect } = options ?? {};
+
+      // Switch to specific tab inside Market (watchlist or trending)
+      if (tabToSelect) {
+        setMarketSelectedTab({ tab: tabToSelect });
+      }
+
+      // Market tab differs by platform
+      const marketTab = platformEnv.isNative
+        ? ETabRoutes.Discovery
+        : ETabRoutes.Market;
+
+      rootNavigationRef.current?.navigate(ERootRoutes.Main, {
+        screen: marketTab,
+        params: {
+          screen: ETabMarketRoutes.TabMarket,
+        },
+      });
+
+      // On native, need to switch to Market sub-tab inside Discovery
+      if (platformEnv.isNative) {
+        setTimeout(() => {
+          appEventBus.emit(EAppEventBusNames.SwitchDiscoveryTabInNative, {
+            tab: ETranslations.global_market,
+          });
+        }, 150);
+      }
+    },
+    [setMarketSelectedTab],
+  );
+
+  return navigateToMarketTab;
+}


### PR DESCRIPTION
## Summary
- Create `useNavigateToMarketTab` hook to handle cross-platform market tab navigation
- Refactor `PopularTrading` component to use the new hook for "View more" navigation
- Export the hook from `Market/hooks` index for reuse across components

## Test plan
- [ ] Verify "View more" button in PopularTrading navigates to Market watchlist tab
- [ ] Test on both native (iOS/Android) and web platforms
- [ ] Ensure the Market tab switch works correctly on native platforms