### PR TITLE
fix: adjust market token list padding for web platform(OK-49541)

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MobileMarketTokenFlatList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MobileMarketTokenFlatList.tsx
@@ -161,7 +161,7 @@ function MobileMarketTokenFlatListBase({
       ListEmptyComponent={ListEmptyComponent}
       showsVerticalScrollIndicator
       contentContainerStyle={{
-        paddingTop: 8 + 170,
+        paddingTop: 8 + (platformEnv.isNative ? 170 : 0),
         paddingBottom: platformEnv.isNativeAndroid
           ? listContainerProps.paddingBottom
           : 16,


### PR DESCRIPTION
## Summary
- Fix market token list layout on web platform by conditionally applying extra padding
- Only add 170px extra padding on native platforms (iOS/Android)
- Web platform now uses minimal padding for proper layout

## Changes
- Modified `MobileMarketTokenFlatList.tsx` to check `platformEnv.isNative` before applying extra padding

## Test Plan
- [ ] Verify market token list displays correctly on web
- [ ] Verify market token list displays correctly on mobile (iOS/Android)