### PR TITLE
fix: close popover on navigation and add delay for import dialog(OK-48370)(OK-48822)

### DIFF
--- a/packages/kit/src/components/MoreActionButton/index.tsx
+++ b/packages/kit/src/components/MoreActionButton/index.tsx
@@ -1356,12 +1356,33 @@ export function MoreActionContentPage() {
   );
 }
 
+const NAVIGATION_ACTION_TYPES = new Set([
+  'GO_BACK',
+  'PUSH',
+  'NAVIGATE',
+  'POP_TO_TOP',
+  'POP_TO',
+  'POP',
+  'NAVIGATE_DEPRECATED',
+  'RESET',
+  'REPLACE',
+  'JUMP_TO',
+]);
 function MoreActionContent({
   containerStyle,
 }: {
   containerStyle?: IYStackProps;
 }) {
   const isDesktopMode = useIsDesktopModeUIInTabPages();
+  const { closePopover } = usePopoverContext();
+
+  useEffect(() => {
+    rootNavigationRef.current?.addListener('__unsafe_action__', ({ data }) => {
+      if (NAVIGATION_ACTION_TYPES.has(data.action.type)) {
+        void closePopover?.();
+      }
+    });
+  }, [closePopover]);
   return (
     <MoreActionProvider>
       <YStack minHeight={600} {...containerStyle}>

--- a/packages/kit/src/views/Market/components/Chart/value-chart/Chart.tsx
+++ b/packages/kit/src/views/Market/components/Chart/value-chart/Chart.tsx
@@ -32,11 +32,7 @@ export default function ChartWrapper({
   const throttledOnHover = throttle(onHover, 25);
 
   useAnimatedReaction<[boolean, string, string]>(
-    () => [
-      (isActive).value,
-      (originalX).value,
-      (originalY).value,
-    ],
+    () => [isActive.value, originalX.value, originalY.value],
     ([hasValue, x, y]) => {
       runOnJS(throttledOnHover)(
         hasValue

--- a/packages/kit/src/views/Onboardingv2/hooks/useCloudBackup.ts
+++ b/packages/kit/src/views/Onboardingv2/hooks/useCloudBackup.ts
@@ -450,6 +450,10 @@ export function useCloudBackup() {
               },
             );
             await verifyPasswordDialog?.close?.();
+            // Delay to ensure the dialog is closed before proceeding
+            if (platformEnv.isNative) {
+              await timerUtils.wait(350);
+            }
             importProcessingDialog = showPrimeTransferImportProcessingDialog({
               navigation,
             });

--- a/packages/kit/src/views/Prime/pages/PagePrimeTransfer/PagePrimeTransferPreview.tsx
+++ b/packages/kit/src/views/Prime/pages/PagePrimeTransfer/PagePrimeTransferPreview.tsx
@@ -48,6 +48,7 @@ import type {
 import { usePrimeTransferExit } from './components/hooks/usePrimeTransferExit';
 import { PrimeTransferExitPrevent } from './components/PrimeTransferExitPrevent';
 import { showPrimeTransferImportProcessingDialog } from './components/PrimeTransferImportProcessingDialog';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
 function PreviewHeader({
   title,
@@ -547,6 +548,11 @@ export default function PagePrimeTransferPreview() {
 
           // exitTransferFlow();
           // await timerUtils.wait(1000);
+
+          // Delay to ensure the dialog is closed before proceeding
+          if (platformEnv.isNative) {
+            await timerUtils.wait(350);
+          }
 
           await backgroundApiProxy.servicePrimeTransfer.initImportProgress({
             selectedTransferData,


### PR DESCRIPTION
## Summary
- Close popover automatically when navigation actions occur
- Add delay before showing import processing dialog on native platforms to ensure previous dialog is closed

## Changes
1. **MoreActionButton**: Added navigation action listener to close popover when navigation events (GO_BACK, PUSH, NAVIGATE, etc.) occur
2. **useCloudBackup & PagePrimeTransferPreview**: Added 350ms delay on native platforms before showing import processing dialog

## Test plan
- [ ] Verify popover closes when navigating away
- [ ] Verify import processing dialog displays correctly on native after password verification