### PR TITLE
fix: refresh Prime user info when menu opens (OK-49555)

### DIFF
--- a/packages/kit/src/components/MoreActionButton/index.tsx
+++ b/packages/kit/src/components/MoreActionButton/index.tsx
@@ -525,13 +525,16 @@ function MoreActionOneKeyId() {
     activeAccount: { network },
   } = useActiveAccount({ num: 0 });
 
-  const { closePopover } = usePopoverContext();
+  const { closePopover, open } = usePopoverContext();
 
   useEffect(() => {
-    if (isLoggedIn) {
+    // open !== false:
+    //   - Desktop: open is true when Popover opens, refresh data
+    //   - Mobile: open is undefined (no Popover context), refresh on mount
+    if (open !== false && isLoggedIn) {
       void backgroundApiProxy.servicePrime.apiFetchPrimeUserInfo();
     }
-  }, [isLoggedIn]);
+  }, [open, isLoggedIn]);
 
   const displayName = useMemo(() => {
     if (!isLoggedIn) {


### PR DESCRIPTION
## Summary
- Refresh Prime user info when the More Action menu opens on Desktop
- Maintain existing behavior on Mobile (refresh on page mount)
- Use `open` state from PopoverContext to detect menu open/close

## Test plan
- [x] Desktop: Open the More Action popover, verify Prime user info is fetched
- [x] Desktop: Close and reopen the popover, verify data refreshes each time
- [x] Mobile: Navigate to More Action page, verify Prime user info is fetched on mount