### PR TITLE
chore: add Array.prototype.flatMap and toSorted polyfills for web

### DIFF
--- a/packages/shared/src/polyfills/polyfillsPlatform.web.js
+++ b/packages/shared/src/polyfills/polyfillsPlatform.web.js
@@ -8,3 +8,11 @@ if (process.env.NODE_ENV !== 'production') {
   global.$RefreshReg$ = global.$RefreshReg$ ?? (() => {});
   global.$RefreshSig$ = global.$RefreshSig$ ?? (() => (type) => type);
 }
+
+const { shim: shimArrayFlatMap } = require('array.prototype.flatmap');
+
+shimArrayFlatMap();
+
+const { shim: shimArrayToSorted } = require('array.prototype.tosorted');
+
+shimArrayToSorted();


### PR DESCRIPTION
## Summary
- Add `Array.prototype.flatMap` polyfill for web platform
- Add `Array.prototype.toSorted` polyfill for web platform

These polyfills ensure compatibility with older browsers that may not support these modern Array methods.

## Changes
- Modified `packages/shared/src/polyfills/polyfillsPlatform.web.js` to include the polyfills using `array.prototype.flatmap` and `array.prototype.tosorted` packages.