### PR TITLE
fix: improve video loading detection and header display

### DIFF
--- a/packages/kit/src/views/DeviceManagement/pages/DeviceGuideModal/DeviceGuideView.tsx
+++ b/packages/kit/src/views/DeviceManagement/pages/DeviceGuideModal/DeviceGuideView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { useIsFocused } from '@react-navigation/core';
 import { useIntl } from 'react-intl';
@@ -25,7 +25,7 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { useNavigateToPickYourDevicePage } from '@onekeyhq/kit/src/views/Onboarding/hooks/useToOnBoardingPage';
 
 import type { ImageSourcePropType } from 'react-native';
-import type { ReactVideoSource } from 'react-native-video';
+import type { OnProgressData, ReactVideoSource } from 'react-native-video';
 
 const LightPosterImage =
   require('./assets/mydevice_hero_poster_light.jpg') as ImageSourcePropType;
@@ -64,8 +64,15 @@ function VideoContainer() {
     };
   }, [gtMd]);
 
-  const handleVideoLoad = useCallback(() => {
-    setIsVideoLoaded(true);
+  const isVideoLoadedRef = useRef(isVideoLoaded)
+  isVideoLoadedRef.current = isVideoLoaded
+  const handleVideoLoad = useCallback((e: OnProgressData) => {
+    if (isVideoLoadedRef.current) {
+      return
+    }
+    if (e.currentTime > 0) {
+      setIsVideoLoaded(true)
+    }
   }, []);
 
   return (
@@ -98,15 +105,6 @@ function VideoContainer() {
           ...maskStyle,
         }}
       >
-        {!isVideoLoaded ? (
-          <Image
-            position="absolute"
-            width="100%"
-            height="100%"
-            resizeMode="cover"
-            source={posterSource}
-          />
-        ) : null}
         <Video
           muted
           autoPlay
@@ -119,8 +117,17 @@ function VideoContainer() {
           playInBackground={false}
           resizeMode={EVideoResizeMode.COVER}
           source={videoSource}
-          onLoad={handleVideoLoad}
+          onProgress={handleVideoLoad}
         />
+        {!isVideoLoaded ? (
+          <Image
+            position="absolute"
+            width="100%"
+            height="100%"
+            resizeMode="cover"
+            source={posterSource}
+          />
+        ) : null}
         <LinearGradient
           colors={[
             'transparent',

--- a/packages/kit/src/views/DeviceManagement/pages/DeviceGuideModal/DeviceGuideView.tsx
+++ b/packages/kit/src/views/DeviceManagement/pages/DeviceGuideModal/DeviceGuideView.tsx
@@ -64,14 +64,14 @@ function VideoContainer() {
     };
   }, [gtMd]);
 
-  const isVideoLoadedRef = useRef(isVideoLoaded)
-  isVideoLoadedRef.current = isVideoLoaded
+  const isVideoLoadedRef = useRef(isVideoLoaded);
+  isVideoLoadedRef.current = isVideoLoaded;
   const handleVideoLoad = useCallback((e: OnProgressData) => {
     if (isVideoLoadedRef.current) {
-      return
+      return;
     }
     if (e.currentTime > 0) {
-      setIsVideoLoaded(true)
+      setIsVideoLoaded(true);
     }
   }, []);
 

--- a/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
+++ b/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
@@ -149,7 +149,7 @@ function MarketBannerDetailContent({ title }: { title: string }) {
         />
       );
     }
-    return null;
+    return <Page.Header headerShown={false} />;
   }, [
     isWebDesktop,
     gtMd,

--- a/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmActions/TxConfirmActions.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmActions/TxConfirmActions.tsx
@@ -183,8 +183,8 @@ function TxConfirmActions(props: IProps) {
         unsignedTxs,
         nativeAmountInfo: nativeTokenTransferAmountToUpdate.isMaxSend
           ? {
-            maxSendAmount: nativeTokenTransferAmountToUpdate.amountToUpdate,
-          }
+              maxSendAmount: nativeTokenTransferAmountToUpdate.amountToUpdate,
+            }
           : undefined,
         precheckTiming: ESendPreCheckTimingEnum.Confirm,
         feeInfos: sendSelectedFeeInfo?.feeInfos,
@@ -243,8 +243,8 @@ function TxConfirmActions(props: IProps) {
           : nonceInfo,
         nativeAmountInfo: nativeTokenTransferAmountToUpdate.isMaxSend
           ? {
-            maxSendAmount: nativeTokenTransferAmountToUpdate.amountToUpdate,
-          }
+              maxSendAmount: nativeTokenTransferAmountToUpdate.amountToUpdate,
+            }
           : undefined,
         feeInfoEditable,
         tronResourceRentalInfo,
@@ -298,7 +298,7 @@ function TxConfirmActions(props: IProps) {
           replaceTxInfo = {
             replaceType:
               new BigNumber(encodedTx.value).isZero() &&
-                checkIsEmptyData(encodedTx.data)
+              checkIsEmptyData(encodedTx.data)
                 ? EReplaceTxType.Cancel
                 : EReplaceTxType.SpeedUp,
             replaceHistoryId: localPendingTxWithSameNonce.id,
@@ -340,10 +340,12 @@ function TxConfirmActions(props: IProps) {
           swapInfo,
           stakingInfo,
         }),
-        feeToken: isUndefined(sendSelectedFeeInfo?.feeInfos?.[0]?.totalNative) ?
-          undefined : `${sendSelectedFeeInfo?.feeInfos?.[0]?.totalNative} ${nativeTokenInfo.info?.symbol}`,
-        feeFiatValue: isUndefined(sendSelectedFeeInfo?.feeInfos?.[0]?.totalFiat) ?
-          undefined : `${sendSelectedFeeInfo?.feeInfos?.[0]?.totalFiat} ${settings?.currencyInfo.id}`,
+        feeToken: isUndefined(sendSelectedFeeInfo?.feeInfos?.[0]?.totalNative)
+          ? undefined
+          : `${sendSelectedFeeInfo?.feeInfos?.[0]?.totalNative} ${nativeTokenInfo.info?.symbol}`,
+        feeFiatValue: isUndefined(sendSelectedFeeInfo?.feeInfos?.[0]?.totalFiat)
+          ? undefined
+          : `${sendSelectedFeeInfo?.feeInfos?.[0]?.totalFiat} ${settings?.currencyInfo.id}`,
         tokenAddress: transferInfo?.tokenInfo?.address,
         tokenSymbol: transferInfo?.tokenInfo?.symbol,
         tokenType: transferInfo?.nftInfo ? 'NFT' : 'Token',

--- a/packages/shared/src/logger/scopes/transaction/scenes/send.ts
+++ b/packages/shared/src/logger/scopes/transaction/scenes/send.ts
@@ -1,7 +1,7 @@
-import type { EUtxoSelectionStrategy } from "@onekeyhq/shared/types/send";
+import type { EUtxoSelectionStrategy } from '@onekeyhq/shared/types/send';
 
-import { BaseScene } from "../../../base/baseScene";
-import { LogToLocal, LogToServer } from "../../../base/decorators";
+import { BaseScene } from '../../../base/baseScene';
+import { LogToLocal, LogToServer } from '../../../base/decorators';
 
 export class SendScene extends BaseScene {
   @LogToLocal()
@@ -88,7 +88,11 @@ export class SendScene extends BaseScene {
   }
 
   @LogToServer()
-  public addressInput({ addressInputMethod }: { addressInputMethod: string | undefined }) {
+  public addressInput({
+    addressInputMethod,
+  }: {
+    addressInputMethod: string | undefined;
+  }) {
     return {
       addressInputMethod,
     };


### PR DESCRIPTION
## Summary
- Improve video loading detection in DeviceGuideView by using `onProgress` event instead of `onLoad` for more reliable video load detection
- Add `useRef` to track video loaded state and check `currentTime > 0` before marking as loaded
- Move poster image after video in DOM for proper z-index layering
- Fix MarketBannerDetail to return `Page.Header` with `headerShown={false}` instead of `null`

## Test plan
- [ ] Verify video plays correctly in DeviceGuideModal with proper poster image display
- [ ] Verify poster image disappears once video starts playing
- [ ] Verify MarketBannerDetail header displays correctly