### PR TITLE
fix: hide transactions tab for BTC network in market detail v2(OK-49540)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/Portfolio.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/Portfolio.tsx
@@ -45,13 +45,13 @@ function PortfolioBase({
       [gtLg],
     );
 
-  // If no account address, show a message
+  // If no account address, show no data message
   if (!accountAddress) {
     return (
       <Stack flex={1} alignItems="center" justifyContent="center" p="$8">
         <SizableText size="$bodyLg" color="$textSubdued">
           {intl.formatMessage({
-            id: ETranslations.no_account,
+            id: ETranslations.dexmarket_details_nodata,
           })}
         </SizableText>
       </Stack>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/layout/DesktopInformationTabs.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/layout/DesktopInformationTabs.tsx
@@ -74,58 +74,35 @@ export function DesktopInformationTabs({
   const tabs = useMemo(() => {
     // Check if current network supports holders tab (not available for native tokens)
     const shouldShowHoldersTab = !isNative && isHoldersTabSupported(networkId);
-    // Check if there's an account address available
-    const shouldShowPortfolioTab = !!accountAddress;
-    // Check if there's portfolio data
-    const hasPortfolioData = portfolioData.length > 0;
-
-    // For BTC network, only show portfolio tab if has portfolio data
-    if (isBTCNetwork) {
-      if (shouldShowPortfolioTab && hasPortfolioData) {
-        return [
-          <Tabs.Tab
-            key="portfolio"
-            name={intl.formatMessage({
-              id: ETranslations.dexmarket_details_myposition,
-            })}
-          >
-            <Portfolio
-              portfolioData={portfolioData}
-              isRefreshing={isRefreshing}
-              accountAddress={accountAddress}
-            />
-          </Tabs.Tab>,
-        ];
-      }
-      return [];
-    }
+    // BTC network doesn't show transactions tab
+    const shouldShowTransactionsTab = !isBTCNetwork;
 
     const items = [
-      <Tabs.Tab
-        key="transactions"
-        name={intl.formatMessage({
-          id: ETranslations.dexmarket_details_transactions,
-        })}
-      >
-        <TransactionsHistory
-          tokenAddress={tokenAddress}
-          networkId={networkId}
-        />
-      </Tabs.Tab>,
-      shouldShowPortfolioTab && (
+      shouldShowTransactionsTab && (
         <Tabs.Tab
-          key="portfolio"
+          key="transactions"
           name={intl.formatMessage({
-            id: ETranslations.dexmarket_details_myposition,
+            id: ETranslations.dexmarket_details_transactions,
           })}
         >
-          <Portfolio
-            portfolioData={portfolioData}
-            isRefreshing={isRefreshing}
-            accountAddress={accountAddress}
+          <TransactionsHistory
+            tokenAddress={tokenAddress}
+            networkId={networkId}
           />
         </Tabs.Tab>
       ),
+      <Tabs.Tab
+        key="portfolio"
+        name={intl.formatMessage({
+          id: ETranslations.dexmarket_details_myposition,
+        })}
+      >
+        <Portfolio
+          portfolioData={portfolioData}
+          isRefreshing={isRefreshing}
+          accountAddress={accountAddress}
+        />
+      </Tabs.Tab>,
       shouldShowHoldersTab && (
         <Tabs.Tab key="holders" name={holdersTabName}>
           <Holders tokenAddress={tokenAddress} networkId={networkId} />

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/layout/MobileInformationTabs.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/layout/MobileInformationTabs.tsx
@@ -74,59 +74,36 @@ export function MobileInformationTabs({
   const tabs = useMemo(() => {
     // Check if current network supports holders tab (not available for native tokens)
     const shouldShowHoldersTab = !isNative && isHoldersTabSupported(networkId);
-    // Check if there's an account address available
-    const shouldShowPortfolioTab = !!accountAddress;
-    // Check if there's portfolio data
-    const hasPortfolioData = portfolioData.length > 0;
-
-    // For BTC network, only show portfolio tab if has portfolio data
-    if (isBTCNetwork) {
-      if (shouldShowPortfolioTab && hasPortfolioData) {
-        return [
-          <Tabs.Tab
-            key="portfolio"
-            name={intl.formatMessage({
-              id: ETranslations.dexmarket_details_myposition,
-            })}
-          >
-            <Portfolio
-              portfolioData={portfolioData}
-              isRefreshing={!!isRefreshing}
-              accountAddress={accountAddress}
-            />
-          </Tabs.Tab>,
-        ];
-      }
-      return [];
-    }
+    // BTC network doesn't show transactions tab
+    const shouldShowTransactionsTab = !isBTCNetwork;
 
     const items = [
-      <Tabs.Tab
-        key="transactions"
-        name={intl.formatMessage({
-          id: ETranslations.dexmarket_details_transactions,
-        })}
-      >
-        <TransactionsHistory
-          tokenAddress={tokenAddress}
-          networkId={networkId}
-          onScrollEnd={onScrollEnd}
-        />
-      </Tabs.Tab>,
-      shouldShowPortfolioTab && (
+      shouldShowTransactionsTab && (
         <Tabs.Tab
-          key="portfolio"
+          key="transactions"
           name={intl.formatMessage({
-            id: ETranslations.dexmarket_details_myposition,
+            id: ETranslations.dexmarket_details_transactions,
           })}
         >
-          <Portfolio
-            portfolioData={portfolioData}
-            isRefreshing={!!isRefreshing}
-            accountAddress={accountAddress}
+          <TransactionsHistory
+            tokenAddress={tokenAddress}
+            networkId={networkId}
+            onScrollEnd={onScrollEnd}
           />
         </Tabs.Tab>
       ),
+      <Tabs.Tab
+        key="portfolio"
+        name={intl.formatMessage({
+          id: ETranslations.dexmarket_details_myposition,
+        })}
+      >
+        <Portfolio
+          portfolioData={portfolioData}
+          isRefreshing={!!isRefreshing}
+          accountAddress={accountAddress}
+        />
+      </Tabs.Tab>,
       shouldShowHoldersTab && (
         <Tabs.Tab key="holders" name={holdersTabName}>
           <Holders tokenAddress={tokenAddress} networkId={networkId} />

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/DesktopLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/DesktopLayout.tsx
@@ -31,10 +31,7 @@ export function DesktopLayout() {
     accountAddress,
   });
 
-  // For BTC network, show tabs only if has portfolio data
   const isBTCNetwork = networkUtils.isBTCNetwork(networkId);
-  const hasPortfolioData = portfolioData.length > 0;
-  const shouldShowTabs = !isBTCNetwork || hasPortfolioData;
 
   return (
     <XStack flex={1}>
@@ -56,16 +53,14 @@ export function DesktopLayout() {
           ) : null}
         </Stack>
 
-        {/* Info tabs - for BTC network, show only if has portfolio data */}
-        {shouldShowTabs ? (
-          <Stack h="30vh">
-            <DesktopInformationTabs
-              portfolioData={portfolioData}
-              isRefreshing={isRefreshing}
-              isBTCNetwork={isBTCNetwork}
-            />
-          </Stack>
-        ) : null}
+        {/* Info tabs */}
+        <Stack h="30vh">
+          <DesktopInformationTabs
+            portfolioData={portfolioData}
+            isRefreshing={isRefreshing}
+            isBTCNetwork={isBTCNetwork}
+          />
+        </Stack>
       </YStack>
 
       {/* Right column */}

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -25,7 +25,6 @@ import {
 import { dismissKeyboardWithDelay } from '@onekeyhq/shared/src/keyboard';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 
@@ -99,24 +98,12 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
     [focusedTab, tabNames, width],
   );
 
-  // For BTC network, hide tabs only if no portfolio data
-  const isBTCNetwork = networkUtils.isBTCNetwork(networkId);
-  const hasPortfolioData = portfolioData.length > 0;
-  const shouldHideTabs = isBTCNetwork && !hasPortfolioData;
-
   const tradingViewHeight = useMemo(() => {
-    // When tabs are completely hidden (BTC network with no portfolio), use more height for the chart
-    if (shouldHideTabs) {
-      if (platformEnv.isNative) {
-        return Number(height) - 120;
-      }
-      return height;
-    }
     if (platformEnv.isNative) {
       return Number(height) * 0.58;
     }
-    return height;
-  }, [height, shouldHideTabs]);
+    return 'calc(100vh - 96px - 74px - 250px)';
+  }, [height]);
 
   const informationHeader = useMemo(() => {
     return (


### PR DESCRIPTION
## Summary
- BTC network no longer shows the Transactions tab in market detail v2
- Portfolio tab now always displays regardless of portfolio data availability
- Show "No Data" message instead of "No Account" when no account address
- Simplified layout logic by removing unnecessary BTC-specific handling

## Changes
- `DesktopInformationTabs.tsx` / `MobileInformationTabs.tsx`: Hide Transactions tab for BTC network, always show Portfolio tab
- `Portfolio.tsx`: Display "No Data" instead of "No Account" when accountAddress is missing
- `DesktopLayout.tsx` / `MobileLayout.tsx`: Simplified BTC-specific logic

## Test Plan
- [ ] Verify BTC market detail page does not show Transactions tab
- [ ] Verify Portfolio tab shows "暂无数据" when no data
- [ ] Verify non-BTC networks still show all tabs normally