### PR TITLE
feat(video): add onProgress callback with requestAnimationFrame

### DIFF
--- a/packages/components/src/content/Video/index.tsx
+++ b/packages/components/src/content/Video/index.tsx
@@ -5,7 +5,7 @@ import { usePropsAndStyle } from '@onekeyhq/components/src/shared/tamagui';
 import type { IVideoProps } from './type';
 
 export function Video(rawProps: IVideoProps) {
-  const [{ source, repeat, resizeMode, rate, muted, ...props }, style] =
+  const [{ source, repeat, resizeMode, rate, muted, onProgress, ...props }, style] =
     usePropsAndStyle(rawProps);
   const videoRef = useRef<HTMLVideoElement>(null);
 
@@ -14,6 +14,30 @@ export function Video(rawProps: IVideoProps) {
       videoRef.current.playbackRate = rate;
     }
   }, [rate]);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video || !onProgress) return;
+
+    let animationFrameId: number;
+
+    const updateProgress = () => {
+      if (video.duration) {
+        onProgress({
+          currentTime: video.currentTime,
+          playableDuration: video.duration,
+          seekableDuration: video.duration,
+        });
+      }
+      animationFrameId = requestAnimationFrame(updateProgress);
+    };
+
+    animationFrameId = requestAnimationFrame(updateProgress);
+
+    return () => {
+      cancelAnimationFrame(animationFrameId);
+    };
+  }, [onProgress]);
 
   if (resizeMode) {
     (style as any)['object-fit'] = resizeMode;

--- a/packages/components/src/content/Video/index.tsx
+++ b/packages/components/src/content/Video/index.tsx
@@ -5,8 +5,10 @@ import { usePropsAndStyle } from '@onekeyhq/components/src/shared/tamagui';
 import type { IVideoProps } from './type';
 
 export function Video(rawProps: IVideoProps) {
-  const [{ source, repeat, resizeMode, rate, muted, onProgress, ...props }, style] =
-    usePropsAndStyle(rawProps);
+  const [
+    { source, repeat, resizeMode, rate, muted, onProgress, ...props },
+    style,
+  ] = usePropsAndStyle(rawProps);
   const videoRef = useRef<HTMLVideoElement>(null);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Add `onProgress` callback support to the Video component
- Use `requestAnimationFrame` for smooth progress updates (~60fps)
- Report `currentTime`, `playableDuration`, and `seekableDuration` to the callback

## Test plan
- [ ] Verify video progress callback is called during playback
- [ ] Verify callback stops when component unmounts
- [ ] Verify no performance issues with requestAnimationFrame loop