### PR TITLE
fix: add storageNamespace param to TradingView components

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
@@ -143,7 +143,7 @@ export function TradingViewPerpsV2(
     () => ({
       symbol: initialSymbolRef.current, // Use frozen initial symbol
       type: 'perps' as const,
-      storageNamespace: 'perps',
+      storageNamespace: 'perps' as const,
     }),
     // Empty deps: only regenerate when component mounts or webviewKey changes (via external reloadHook)
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
@@ -26,6 +26,7 @@ import {
   useTradingViewMessageHandler,
 } from './messageHandlers';
 
+import type { IMarksTimeRange } from './messageHandlers';
 import type { ICustomReceiveHandlerData } from './types';
 import type { IWebViewRef } from '../../WebView/types';
 import type { WebViewProps } from 'react-native-webview';
@@ -42,8 +43,6 @@ interface IBaseTradingViewV2Props {
 }
 
 export type ITradingViewV2Props = IBaseTradingViewV2Props & IStackStyle;
-
-import type { IMarksTimeRange } from './messageHandlers';
 
 export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
   const webRef = useRef<IWebViewRef | null>(null);
@@ -83,7 +82,7 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
       networkId,
       address: tokenAddress,
       symbol: useHyperLiquid ? hyperLiquidSymbol : symbol,
-      ...(useHyperLiquid && { type: 'perps' }),
+      type: useHyperLiquid ? 'perps' : 'market',
       storageNamespace: 'market',
     };
   }, [


### PR DESCRIPTION
## Summary
- Add `storageNamespace` parameter to TradingView components for proper storage isolation
- TradingViewV2 (market page): always pass `storageNamespace='market'`, `type` varies based on data source (perps or market)
- TradingViewPerpsV2 (perps page): pass both `type='perps'` and `storageNamespace='perps'`

## Changes
| Page | Scenario | type | storageNamespace |
|------|----------|------|------------------|
| Market | Normal tokens | `market` | `market` |
| Market | BTC with perps data source | `perps` | `market` |
| Perps | Perpetual contracts | `perps` | `perps` |

This ensures chart configurations (indicators, drawings, etc.) are stored in the correct namespace and don't mix between market and perps pages.

## Test plan
- [ ] Verify market page TradingView URL contains `type=market&storageNamespace=market` for normal tokens
- [ ] Verify market page TradingView URL contains `type=perps&storageNamespace=market` for BTC with HyperLiquid data source
- [ ] Verify perps page TradingView URL contains `type=perps&storageNamespace=perps`