### PR TITLE
fix: use scrollToEnd instead of scrollTo with MAX_SAFE_INTEGER(OK-49546)

### DIFF
--- a/packages/kit/src/views/ReferFriends/pages/InviteReward/components/InvitationDetailsSection/components/CreateCodeButton.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/InviteReward/components/InvitationDetailsSection/components/CreateCodeButton.tsx
@@ -33,7 +33,7 @@ export function CreateCodeButton({
       const scrollView = scrollViewRef?.current;
 
       if (typeof scrollView?.scrollTo === 'function') {
-        scrollView.scrollTo({ y: Number.MAX_SAFE_INTEGER, animated: true });
+        scrollView.scrollToEnd({ animated: true })
       }
     }, 500);
   }, [scrollViewRef]);


### PR DESCRIPTION
## Summary
- Replace `scrollTo({ y: Number.MAX_SAFE_INTEGER, animated: true })` with `scrollToEnd({ animated: true })` in CreateCodeButton component
- This uses the proper React Native ScrollView method for scrolling to the end instead of a workaround with MAX_SAFE_INTEGER

## Test plan
- [ ] Verify scroll to end functionality works correctly in the ReferFriends invite reward page after creating a code