### PR TITLE
feat: add pull-to-refresh logging for wallet analytics

### DIFF
--- a/packages/kit/src/views/Home/components/PullToRefresh/index.tsx
+++ b/packages/kit/src/views/Home/components/PullToRefresh/index.tsx
@@ -6,6 +6,7 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 
 export const onHomePageRefresh = () => {
   appEventBus.emit(EAppEventBusNames.AccountDataUpdate, undefined);
@@ -24,6 +25,7 @@ function BasePullToRefresh({ onRefresh, ...props }: IPullToRefreshProps) {
     setTimeout(() => {
       setRefreshing(false);
     }, 1200);
+    defaultLogger.account.wallet.walletPullToRefresh();
   }, [onRefresh]);
 
   return (

--- a/packages/shared/src/logger/scopes/account/scenes/wallet.ts
+++ b/packages/shared/src/logger/scopes/account/scenes/wallet.ts
@@ -1,12 +1,12 @@
-import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
-import type { IServerNetwork } from '@onekeyhq/shared/types';
+import { OneKeyLocalError } from "@onekeyhq/shared/src/errors";
+import type { IServerNetwork } from "@onekeyhq/shared/types";
 import type {
   IWalletAddedEventParams,
   IWalletStartedParams,
-} from '@onekeyhq/shared/types/analytics/onboarding';
+} from "@onekeyhq/shared/types/analytics/onboarding";
 
-import { BaseScene } from '../../../base/baseScene';
-import { LogToLocal, LogToServer } from '../../../base/decorators';
+import { BaseScene } from "../../../base/baseScene";
+import { LogToLocal, LogToServer } from "../../../base/decorators";
 
 interface IToken {
   network: string;
@@ -19,27 +19,27 @@ export class WalletScene extends BaseScene {
   @LogToLocal()
   public addWalletStarted(params: IWalletStartedParams) {
     switch (params.addMethod) {
-      case 'CreateWallet':
+      case "CreateWallet":
         return {
-          addMethod: 'CreateWallet',
+          addMethod: "CreateWallet",
           isSoftwareWalletOnlyUser: params.isSoftwareWalletOnlyUser,
           details: {
             unbackedUp: params.details.unbackedUp,
           },
         };
 
-      case 'ImportWallet':
+      case "ImportWallet":
         return {
-          addMethod: 'ImportWallet',
+          addMethod: "ImportWallet",
           isSoftwareWalletOnlyUser: params.isSoftwareWalletOnlyUser,
           details: {
             importType: params.details.importType,
           },
         };
 
-      case 'ConnectHWWallet':
+      case "ConnectHWWallet":
         return {
-          addMethod: 'ConnectHWWallet',
+          addMethod: "ConnectHWWallet",
           isSoftwareWalletOnlyUser: params.isSoftwareWalletOnlyUser,
           details: {
             communication: params.details.communication,
@@ -47,9 +47,9 @@ export class WalletScene extends BaseScene {
           },
         };
 
-      case 'Connect3rdPartyWallet':
+      case "Connect3rdPartyWallet":
         return {
-          addMethod: 'Connect3rdPartyWallet',
+          addMethod: "Connect3rdPartyWallet",
           isSoftwareWalletOnlyUser: params.isSoftwareWalletOnlyUser,
           details: {
             protocol: params.details.protocol,
@@ -58,9 +58,9 @@ export class WalletScene extends BaseScene {
           },
         };
 
-      case 'CreateKeylessWallet':
+      case "CreateKeylessWallet":
         return {
-          addMethod: 'CreateKeylessWallet',
+          addMethod: "CreateKeylessWallet",
           isSoftwareWalletOnlyUser: params.isSoftwareWalletOnlyUser,
           details: {
             provider: params.details.provider,
@@ -69,9 +69,7 @@ export class WalletScene extends BaseScene {
 
       default: {
         const _exhaustiveCheck: never = params;
-        throw new OneKeyLocalError(
-          `Unreachable case: ${JSON.stringify(_exhaustiveCheck)}`,
-        );
+        throw new OneKeyLocalError(`Unreachable case: ${JSON.stringify(_exhaustiveCheck)}`);
       }
     }
   }
@@ -80,10 +78,10 @@ export class WalletScene extends BaseScene {
   @LogToLocal()
   public walletAdded(params: IWalletAddedEventParams) {
     switch (params.addMethod) {
-      case 'CreateWallet':
+      case "CreateWallet":
         return {
           status: params.status,
-          addMethod: 'CreateWallet',
+          addMethod: "CreateWallet",
           isSoftwareWalletOnlyUser: params.isSoftwareWalletOnlyUser,
           details: {
             isBiometricSet: params.details.isBiometricSet,
@@ -91,20 +89,20 @@ export class WalletScene extends BaseScene {
           },
         };
 
-      case 'ImportWallet':
+      case "ImportWallet":
         return {
           status: params.status,
-          addMethod: 'ImportWallet',
+          addMethod: "ImportWallet",
           isSoftwareWalletOnlyUser: params.isSoftwareWalletOnlyUser,
           details: {
             importType: params.details.importType,
           },
         };
 
-      case 'ConnectHWWallet':
+      case "ConnectHWWallet":
         return {
           status: params.status,
-          addMethod: 'ConnectHardware',
+          addMethod: "ConnectHardware",
           isSoftwareWalletOnlyUser: params.isSoftwareWalletOnlyUser,
           details: {
             communication: params.details.communication,
@@ -116,10 +114,10 @@ export class WalletScene extends BaseScene {
           },
         };
 
-      case 'Connect3rdPartyWallet':
+      case "Connect3rdPartyWallet":
         return {
           status: params.status,
-          addMethod: 'Connect3rdPartyWallet',
+          addMethod: "Connect3rdPartyWallet",
           isSoftwareWalletOnlyUser: params.isSoftwareWalletOnlyUser,
           details: {
             protocol: params.details.protocol,
@@ -130,10 +128,10 @@ export class WalletScene extends BaseScene {
           },
         };
 
-      case 'CreateKeylessWallet':
+      case "CreateKeylessWallet":
         return {
           status: params.status,
-          addMethod: 'CreateKeylessWallet',
+          addMethod: "CreateKeylessWallet",
           isSoftwareWalletOnlyUser: params.isSoftwareWalletOnlyUser,
           details: {
             provider: params.details.provider,
@@ -142,9 +140,7 @@ export class WalletScene extends BaseScene {
 
       default: {
         const _exhaustiveCheck: never = params;
-        throw new OneKeyLocalError(
-          `Unreachable case: ${JSON.stringify(_exhaustiveCheck)}`,
-        );
+        throw new OneKeyLocalError(`Unreachable case: ${JSON.stringify(_exhaustiveCheck)}`);
       }
     }
   }
@@ -153,11 +149,11 @@ export class WalletScene extends BaseScene {
   @LogToLocal()
   public onboard(params: {
     onboardMethod:
-      | 'createWallet'
-      | 'importWallet'
-      | 'connectHWWallet'
-      | 'connect3rdPartyWallet'
-      | 'createKeylessWallet';
+      | "createWallet"
+      | "importWallet"
+      | "connectHWWallet"
+      | "connect3rdPartyWallet"
+      | "createKeylessWallet";
   }) {
     return params;
   }
@@ -196,7 +192,7 @@ export class WalletScene extends BaseScene {
 
   @LogToServer()
   @LogToLocal()
-  public copyAddress(params: { walletType: 'hdWallet' | 'hwWallet' }) {
+  public copyAddress(params: { walletType: "hdWallet" | "hwWallet" }) {
     return params;
   }
 
@@ -237,13 +233,13 @@ export class WalletScene extends BaseScene {
 
   @LogToLocal()
   public getServerNetworksError(error: any) {
-    let errorMessage = 'Unknown error';
+    let errorMessage = "Unknown error";
 
     if (error instanceof Error) {
       errorMessage = error.message;
-    } else if (typeof error === 'string') {
+    } else if (typeof error === "string") {
       errorMessage = error;
-    } else if (error && typeof error === 'object') {
+    } else if (error && typeof error === "object") {
       errorMessage = JSON.stringify(error);
     }
 
@@ -259,4 +255,8 @@ export class WalletScene extends BaseScene {
       onboardingExit: true,
     };
   }
+
+  @LogToLocal()
+  @LogToServer()
+  public walletPullToRefresh() {}
 }


### PR DESCRIPTION
## Summary

Add analytics logging for pull-to-refresh actions on the home page to track user engagement with the refresh gesture.

## Changes

- Add `walletPullToRefresh()` method to `WalletScene` logger with `@LogToLocal()` and `@LogToServer()` decorators
- Call the new logger method in `PullToRefresh` component when user triggers a refresh

## Testing

- Pull down on home page to trigger refresh
- Verify analytics event is logged locally and to server