### PR TITLE
fix: use switchTab for referral landing navigation and default to market(OK-48409)

### DIFF
--- a/packages/kit/src/views/Home/pages/referralLanding/ReferralLandingPage.tsx
+++ b/packages/kit/src/views/Home/pages/referralLanding/ReferralLandingPage.tsx
@@ -107,19 +107,12 @@ function ReferralLandingPage() {
         }
       }
 
-      // Determine target tab route
+      // Determine target tab route (default to Market)
       const pageLower = page?.toLowerCase() ?? '';
-      const targetTabRoute = PAGE_TO_TAB_ROUTE[pageLower] ?? ETabRoutes.Home;
+      const targetTabRoute = PAGE_TO_TAB_ROUTE[pageLower] ?? ETabRoutes.Market;
 
-      // Navigate to target page and replace current route
-      if (targetTabRoute === ETabRoutes.Home) {
-        navigation.popToTop();
-      } else {
-        navigation.popToTop();
-        setTimeout(() => {
-          navigation.switchTab(targetTabRoute);
-        }, 20);
-      }
+      // Navigate to target page
+      navigation.switchTab(targetTabRoute);
 
       // Open InvitedByFriend modal after navigation
       setTimeout(() => {


### PR DESCRIPTION
## Summary
- Fixed referral landing page navigation by using `switchTab` instead of `popToTop` which doesn't work when the landing page is the entry point
- Changed default navigation target from Home to Market

## Changes
- Simplified navigation logic in `ReferralLandingPage.tsx`
- Replaced `popToTop()` + `setTimeout` + `switchTab` with direct `switchTab(targetTabRoute)`
- Default target route changed from `ETabRoutes.Home` to `ETabRoutes.Market`

## Test Plan
- [ ] Visit `http://localhost:3000/r/{code}` and verify it navigates to Market page
- [ ] Visit `http://localhost:3000/r/{code}/app/perp` and verify it navigates to Perp page
- [ ] Verify the InvitedByFriend modal opens after navigation