### PR TITLE
feat(market): add xpub parameter to portfolio API(OK-48618)

### DIFF
--- a/packages/kit-bg/src/services/ServiceMarketV2.ts
+++ b/packages/kit-bg/src/services/ServiceMarketV2.ts
@@ -624,10 +624,12 @@ class ServiceMarketV2 extends ServiceBase {
     accountAddress,
     networkId,
     tokenAddress,
+    xpub,
   }: {
     accountAddress: string;
     networkId: string;
     tokenAddress: string;
+    xpub?: string;
   }) {
     try {
       const client = await this.getClient(EServiceEndpointEnum.Utility);
@@ -641,6 +643,7 @@ class ServiceMarketV2 extends ServiceBase {
           networkId,
           accountAddress,
           tokenAddress,
+          xpub,
         },
       });
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/hooks/usePortfolioData.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/hooks/usePortfolioData.ts
@@ -8,12 +8,14 @@ interface IUsePortfolioDataProps {
   tokenAddress: string;
   networkId: string;
   accountAddress?: string;
+  xpub?: string;
 }
 
 export function usePortfolioData({
   tokenAddress,
   networkId,
   accountAddress,
+  xpub,
 }: IUsePortfolioDataProps) {
   const {
     result: portfolioData,
@@ -29,9 +31,10 @@ export function usePortfolioData({
         tokenAddress,
         networkId,
         accountAddress,
+        xpub,
       });
     },
-    [tokenAddress, networkId, accountAddress],
+    [tokenAddress, networkId, accountAddress, xpub],
     {
       watchLoading: true,
       pollingInterval: timerUtils.getTimeDurationMs({ seconds: 5 }),

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/hooks/useNetworkAccount.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/hooks/useNetworkAccount.ts
@@ -1,0 +1,61 @@
+import { useMemo } from 'react';
+
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
+import { useSelectedDeriveTypeAtom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2/atoms';
+
+export function useNetworkAccount(networkId: string) {
+  const { activeAccount } = useActiveAccount({ num: 0 });
+  const [selectedDeriveType] = useSelectedDeriveTypeAtom();
+
+  // Get network's default derive type
+  const { result: networkDefaultDeriveType } = usePromiseResult(async () => {
+    if (!networkId) return undefined;
+    return backgroundApiProxy.serviceNetwork.getGlobalDeriveTypeOfNetwork({
+      networkId,
+    });
+  }, [networkId]);
+
+  // Prioritize atom derive type (user selection) over network default derive type
+  const effectiveDeriveType = useMemo(() => {
+    return (
+      selectedDeriveType ??
+      networkDefaultDeriveType ??
+      activeAccount?.deriveType ??
+      'default'
+    );
+  }, [selectedDeriveType, networkDefaultDeriveType, activeAccount?.deriveType]);
+
+  const { result: networkAccount } = usePromiseResult(async () => {
+    if (!networkId) {
+      return null;
+    }
+
+    return backgroundApiProxy.serviceAccount.getNetworkAccount({
+      accountId: activeAccount?.indexedAccount?.id
+        ? undefined
+        : activeAccount?.account?.id,
+      indexedAccountId: activeAccount?.indexedAccount?.id,
+      networkId,
+      deriveType: effectiveDeriveType,
+    });
+  }, [
+    activeAccount?.indexedAccount?.id,
+    activeAccount?.account?.id,
+    effectiveDeriveType,
+    networkId,
+  ]);
+
+  // xpub only exists on UTXO accounts (BTC, LTC, etc.)
+  const xpub =
+    networkAccount && 'xpub' in networkAccount
+      ? networkAccount.xpub
+      : undefined;
+
+  return {
+    networkAccount,
+    accountAddress: networkAccount?.address,
+    xpub,
+  };
+}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/hooks/useNetworkAccountAddress.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/hooks/useNetworkAccountAddress.ts
@@ -1,53 +1,9 @@
-import { useMemo } from 'react';
-
-import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
-import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
-import { useSelectedDeriveTypeAtom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2/atoms';
+import { useNetworkAccount } from './useNetworkAccount';
 
 export function useNetworkAccountAddress(networkId: string) {
-  const { activeAccount } = useActiveAccount({ num: 0 });
-  const [selectedDeriveType] = useSelectedDeriveTypeAtom();
-
-  // Get network's default derive type
-  const { result: networkDefaultDeriveType } = usePromiseResult(async () => {
-    if (!networkId) return undefined;
-    return backgroundApiProxy.serviceNetwork.getGlobalDeriveTypeOfNetwork({
-      networkId,
-    });
-  }, [networkId]);
-
-  // Prioritize atom derive type (user selection) over network default derive type
-  const effectiveDeriveType = useMemo(() => {
-    return (
-      selectedDeriveType ??
-      networkDefaultDeriveType ??
-      activeAccount?.deriveType ??
-      'default'
-    );
-  }, [selectedDeriveType, networkDefaultDeriveType, activeAccount?.deriveType]);
-
-  const { result: networkAccount } = usePromiseResult(async () => {
-    if (!networkId) {
-      return null;
-    }
-
-    return backgroundApiProxy.serviceAccount.getNetworkAccount({
-      accountId: activeAccount?.indexedAccount?.id
-        ? undefined
-        : activeAccount?.account?.id,
-      indexedAccountId: activeAccount?.indexedAccount?.id,
-      networkId,
-      deriveType: effectiveDeriveType,
-    });
-  }, [
-    activeAccount?.indexedAccount?.id,
-    activeAccount?.account?.id,
-    effectiveDeriveType,
-    networkId,
-  ]);
+  const { accountAddress } = useNetworkAccount(networkId);
 
   return {
-    accountAddress: networkAccount?.address,
+    accountAddress,
   };
 }

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/DesktopLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/DesktopLayout.tsx
@@ -17,7 +17,7 @@ import {
   TokenSupplementaryInfo,
 } from '../components';
 import { usePortfolioData } from '../components/InformationTabs/components/Portfolio/hooks/usePortfolioData';
-import { useNetworkAccountAddress } from '../components/InformationTabs/hooks/useNetworkAccountAddress';
+import { useNetworkAccount } from '../components/InformationTabs/hooks/useNetworkAccount';
 import { DesktopInformationTabs } from '../components/InformationTabs/layout/DesktopInformationTabs';
 import { useTokenDetail } from '../hooks/useTokenDetail';
 
@@ -25,12 +25,13 @@ export function DesktopLayout() {
   const { tokenAddress, networkId, tokenDetail, isNative, websocketConfig } =
     useTokenDetail();
 
-  const { accountAddress } = useNetworkAccountAddress(networkId);
+  const { accountAddress, xpub } = useNetworkAccount(networkId);
 
   const { portfolioData, isRefreshing } = usePortfolioData({
     tokenAddress,
     networkId,
     accountAddress,
+    xpub,
   });
 
   const isBTCNetwork = networkUtils.isBTCNetwork(networkId);

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -38,7 +38,7 @@ import {
   TokenOverview,
 } from '../components';
 import { usePortfolioData } from '../components/InformationTabs/components/Portfolio/hooks/usePortfolioData';
-import { useNetworkAccountAddress } from '../components/InformationTabs/hooks/useNetworkAccountAddress';
+import { useNetworkAccount } from '../components/InformationTabs/hooks/useNetworkAccount';
 import { MobileInformationTabs } from '../components/InformationTabs/layout/MobileInformationTabs';
 import SwapFlashBtn from '../components/SwapPanel/components/SwapFlashBtn';
 import { SwapPanelWrap } from '../components/SwapPanel/SwapPanelWrap';
@@ -49,12 +49,13 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
     useTokenDetail();
   const intl = useIntl();
 
-  const { accountAddress } = useNetworkAccountAddress(networkId);
+  const { accountAddress, xpub } = useNetworkAccount(networkId);
 
   const { portfolioData, isRefreshing } = usePortfolioData({
     tokenAddress,
     networkId,
     accountAddress,
+    xpub,
   });
   const tabNames = useMemo(
     () => [


### PR DESCRIPTION
## Summary
- Create `useNetworkAccount` hook to expose full account info including xpub
- Refactor `useNetworkAccountAddress` to use `useNetworkAccount` internally
- Pass xpub to `fetchMarketAccountPortfolio` API for UTXO chains (BTC, LTC, etc.)

## Changes
- **New file**: `useNetworkAccount.ts` - Core hook returning networkAccount, accountAddress, and xpub
- **Modified**: `useNetworkAccountAddress.ts` - Simplified to call useNetworkAccount
- **Modified**: `usePortfolioData.ts` - Accept and pass xpub parameter
- **Modified**: `ServiceMarketV2.ts` - Add xpub to API params
- **Modified**: `MobileLayout.tsx` / `DesktopLayout.tsx` - Use useNetworkAccount to get xpub

## Test plan
- [ ] Verify portfolio tab works on EVM tokens (xpub should be undefined)
- [ ] Verify portfolio tab works on BTC tokens (xpub should be passed to API)
- [ ] Check API request includes xpub parameter for UTXO chains