### PR TITLE
fix(discovery): debounce refreshLocalData to prevent stack overflow on iOS

### DIFF
--- a/packages/kit/src/views/Discovery/hooks/useSearchPopover.ts
+++ b/packages/kit/src/views/Discovery/hooks/useSearchPopover.ts
@@ -105,8 +105,13 @@ export function useSearchPopover({
     }, 200);
   }, [setIsPopoverOpen]);
 
+  // Debounce refreshLocalData to prevent excessive re-renders of SearchPopover animation
+  // which can cause stack overflow on iOS Hermes engine when scale animation triggers rapidly
   useEffect(() => {
-    void refreshLocalData?.();
+    const timer = setTimeout(() => {
+      void refreshLocalData?.();
+    }, 50);
+    return () => clearTimeout(timer);
   }, [refreshLocalData, isPopoverOpen]);
 
   const handleSearchBarPress = useCallback(() => {


### PR DESCRIPTION
## Summary
- Add debounce to refreshLocalData call in useSearchPopover to prevent excessive re-renders of SearchPopover animation which can cause stack overflow on iOS Hermes engine when scale animation triggers rapidly

## Root Cause
The SearchPopover component uses `animation="quick"` with `scale` enterStyle/exitStyle. When `refreshLocalData` is called frequently (on every `isPopoverOpen` or `searchValue` change), it causes rapid re-renders of the SearchPopover animation. On iOS Hermes engine, this can lead to stack overflow due to recursive animation calculations.

## Fix
Added 50ms debounce to the `refreshLocalData` useEffect to prevent excessive re-renders.

## Test plan
- [ ] Test search functionality in Discovery tab on iOS
- [ ] Verify no stack overflow crash occurs when typing quickly in search input
- [ ] Verify search results still load correctly with the debounce