### PR TITLE
fix: disallow internationalized domain names in email validation(OK-49609)

### DIFF
--- a/packages/shared/src/utils/stringUtils.test.ts
+++ b/packages/shared/src/utils/stringUtils.test.ts
@@ -1,7 +1,42 @@
-import { stableStringify } from './stringUtils';
+import stringUtils, { stableStringify } from './stringUtils';
 
 test('stableStringify', () => {
   expect(stableStringify({ a: '1', b: '2' })).toBe(
     stableStringify({ b: '2', a: '1' }),
   );
+});
+
+describe('isValidEmail', () => {
+  it('should return true for valid ASCII domain emails', () => {
+    expect(stringUtils.isValidEmail('test@example.com')).toBe(true);
+    expect(stringUtils.isValidEmail('user.name@domain.org')).toBe(true);
+    expect(stringUtils.isValidEmail('user+tag@gmail.com')).toBe(true);
+    expect(stringUtils.isValidEmail('a@b.co')).toBe(true);
+  });
+
+  it('should return false for emails with Chinese domains', () => {
+    expect(stringUtils.isValidEmail('test@中文.com')).toBe(false);
+    expect(stringUtils.isValidEmail('test@邮箱.中国')).toBe(false);
+    expect(stringUtils.isValidEmail('user@测试.org')).toBe(false);
+  });
+
+  it('should return false for emails with other non-ASCII domains', () => {
+    expect(stringUtils.isValidEmail('test@日本語.jp')).toBe(false);
+    expect(stringUtils.isValidEmail('test@한국어.kr')).toBe(false);
+    expect(stringUtils.isValidEmail('test@münchen.de')).toBe(false);
+  });
+
+  it('should return false for invalid email formats', () => {
+    expect(stringUtils.isValidEmail('')).toBe(false);
+    expect(stringUtils.isValidEmail('notanemail')).toBe(false);
+    expect(stringUtils.isValidEmail('@nodomain.com')).toBe(false);
+    expect(stringUtils.isValidEmail('noat.com')).toBe(false);
+  });
+
+  it('should return false for null or undefined', () => {
+    expect(stringUtils.isValidEmail(null as unknown as string)).toBe(false);
+    expect(stringUtils.isValidEmail(undefined as unknown as string)).toBe(
+      false,
+    );
+  });
 });

--- a/packages/shared/src/utils/stringUtils.ts
+++ b/packages/shared/src/utils/stringUtils.ts
@@ -133,7 +133,19 @@ function isValidEmail(email: string): boolean {
   if (!email || !isString(email)) {
     return false;
   }
-  return validator.isEmail(email);
+  if (!validator.isEmail(email)) {
+    return false;
+  }
+  // Disallow internationalized domain names (e.g., Chinese domains)
+  const domain = email.split('@')[1];
+  if (domain) {
+    for (let i = 0; i < domain.length; i += 1) {
+      if (domain.charCodeAt(i) > 127) {
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
 function addSeparatorToString({


### PR DESCRIPTION
## Summary
- Add check to reject non-ASCII characters in email domain part
- Prevents Chinese domains and other internationalized domain names (e.g., `test@中文.com`, `test@邮箱.中国`)
- Add unit tests for `isValidEmail` function

## Changes
- `packages/shared/src/utils/stringUtils.ts`: Enhanced `isValidEmail` to reject domains with charCode > 127
- `packages/shared/src/utils/stringUtils.test.ts`: Added comprehensive test cases

## Test plan
- [x] Run `yarn jest packages/shared/src/utils/stringUtils.test.ts` - all 6 tests pass
- [ ] Manual test email login with Chinese domain emails