### PR TITLE
fix: move sentry error filter checks before sanitization

### DIFF
--- a/packages/shared/src/modules3rdParty/sentry/basicOptions.ts
+++ b/packages/shared/src/modules3rdParty/sentry/basicOptions.ts
@@ -222,6 +222,7 @@ export const buildBasicOptions = ({
       if (Array.isArray(event.exception?.values)) {
         for (let index = 0; index < event.exception.values.length; index += 1) {
           const exceptionValue = event.exception.values[index];
+          const { type: originalType, value: originalValue } = exceptionValue;
           try {
             // Sanitize error message
             if (exceptionValue.value) {
@@ -230,15 +231,18 @@ export const buildBasicOptions = ({
               onError(newErrorText, exceptionValue.stacktrace);
               exceptionValue.value = newErrorText;
             }
-
-            // Sanitize stacktrace (local variables, context lines)
-            sanitizeStacktrace(exceptionValue.stacktrace);
-
             // In webEmbed environment, network requests cannot be sent, so abort subsequent operations
             if (platformEnv.isWebEmbed) {
               return;
             }
-            if (isFilterErrorAndSkipSentry(exceptionValue)) {
+            // Sanitize stacktrace (local variables, context lines)
+            sanitizeStacktrace(exceptionValue.stacktrace);
+            if (
+              isFilterErrorAndSkipSentry({
+                type: originalType,
+                value: originalValue,
+              })
+            ) {
               return null;
             }
           } catch {


### PR DESCRIPTION
## Summary
- Move sentry error filter checks before sanitization to ensure proper error filtering

## Test plan
- [ ] Verify sentry errors are properly filtered before sanitization

🤖 Generated with [Claude Code](https://claude.com/claude-code)