### PR TITLE
fix: ensure decimals is number type for BigNumber.decimalPlaces()

### DIFF
--- a/packages/kit/src/hooks/useWebDapp/useOneKeyWalletDetection.ts
+++ b/packages/kit/src/hooks/useWebDapp/useOneKeyWalletDetection.ts
@@ -25,8 +25,10 @@ export function useOneKeyWalletDetection() {
 
     // find OneKey provider
     const oneKeyProvider = providers.find((provider) => {
-      const rdns = provider.info.rdns.toLowerCase();
-      const name = provider.info.name.toLowerCase();
+      if (!provider?.info) return false;
+
+      const rdns = provider.info.rdns?.toLowerCase() ?? '';
+      const name = provider.info.name?.toLowerCase() ?? '';
 
       const rdnsMatch = oneKeyRdnsPatterns.some((pattern) =>
         rdns.includes(pattern.toLowerCase()),

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.tsx
@@ -126,7 +126,10 @@ export function SwapPanelContent(props: ISwapPanelContentProps) {
       const maxAmount = BigNumber.max(
         0,
         balance.minus(new BigNumber(reserveGas)),
-      ).decimalPlaces(balanceToken?.decimals ?? 6, BigNumber.ROUND_DOWN);
+      ).decimalPlaces(
+        Number(balanceToken?.decimals ?? 6),
+        BigNumber.ROUND_DOWN,
+      );
 
       if (tradeType === ESwapDirection.BUY) {
         setPaymentAmount(maxAmount);
@@ -172,7 +175,10 @@ export function SwapPanelContent(props: ISwapPanelContentProps) {
         tradeType === ESwapDirection.BUY
           ? paymentAmountRef.current?.toFixed()
           : sellAmountRef.current?.toFixed(),
-      ).decimalPlaces(balanceToken?.decimals ?? 0, BigNumber.ROUND_DOWN);
+      ).decimalPlaces(
+        Number(balanceToken?.decimals ?? 0),
+        BigNumber.ROUND_DOWN,
+      );
       if (tradeType === ESwapDirection.BUY) {
         setPaymentAmount(changeAmount);
         tokenBuyInputRef.current?.setValue(changeAmount.toFixed());

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketWatchlistTokenList.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketWatchlistTokenList.ts
@@ -97,42 +97,44 @@ export function useMarketWatchlistTokenList({
       };
     });
 
-    const transformed: IMarketToken[] = apiResult.list.map((item) => {
-      // Get isNative from watchlist data since API doesn't return it
-      let address = item.address;
-      const networkId = item.networkId || '';
-      const key = `${networkId}:${address.toLowerCase()}`;
+    const transformed: IMarketToken[] = apiResult.list
+      .filter((item) => item && item.address != null)
+      .map((item) => {
+        // Get isNative from watchlist data since API doesn't return it
+        let address = item.address;
+        const networkId = item.networkId || '';
+        const key = `${networkId}:${address.toLowerCase()}`;
 
-      const tokenInfo = tokenMap[key];
-      const chainId = tokenInfo?.chainId || networkId;
-      const networkLogoUri = getNetworkLogoUri(chainId);
-      const sortIndex = tokenInfo?.sortIndex;
-      let isNative = tokenInfo?.isNative ?? false; // Get isNative from watchlist
+        const tokenInfo = tokenMap[key];
+        const chainId = tokenInfo?.chainId || networkId;
+        const networkLogoUri = getNetworkLogoUri(chainId);
+        const sortIndex = tokenInfo?.sortIndex;
+        let isNative = tokenInfo?.isNative ?? false; // Get isNative from watchlist
 
-      // TODO: Remove this after we have a better way to handle native tokens
-      // Special handling for native tokens (short addresses)
-      if (address.length < 30) {
-        if (item.symbol === 'SUI' && networkId === 'sui--mainnet') {
-          address = '0x2::sui::SUI';
-        } else {
-          address = '';
+        // TODO: Remove this after we have a better way to handle native tokens
+        // Special handling for native tokens (short addresses)
+        if (address.length < 30) {
+          if (item.symbol === 'SUI' && networkId === 'sui--mainnet') {
+            address = '0x2::sui::SUI';
+          } else {
+            address = '';
+          }
+          isNative = true;
         }
-        isNative = true;
-      }
 
-      // Add isNative to the API item
-      const itemWithNative = {
-        ...item,
-        address,
-        isNative,
-      } as IMarketTokenListItem & { isNative: boolean };
+        // Add isNative to the API item
+        const itemWithNative = {
+          ...item,
+          address,
+          isNative,
+        } as IMarketTokenListItem & { isNative: boolean };
 
-      return transformApiItemToToken(itemWithNative, {
-        chainId,
-        networkLogoUri,
-        sortIndex,
+        return transformApiItemToToken(itemWithNative, {
+          chainId,
+          networkLogoUri,
+          sortIndex,
+        });
       });
-    });
 
     // Build result array in watchlist order to maintain correct sorting
     const filteredTransformed = watchlist

--- a/packages/kit/src/views/Swap/hooks/useSwapLimitRate.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapLimitRate.ts
@@ -109,13 +109,13 @@ export const useSwapLimitRate = () => {
             : new BigNumber(1).div(inputBN);
           const newReverseRateValue = newReverseRate
             .decimalPlaces(
-              limitPriceMarketPrice.fromToken?.decimals ?? 0,
+              Number(limitPriceMarketPrice.fromToken?.decimals ?? 0),
               BigNumber.ROUND_HALF_UP,
             )
             .toFixed();
           const newRateValue = newRate
             .decimalPlaces(
-              limitPriceMarketPrice.toToken?.decimals ?? 0,
+              Number(limitPriceMarketPrice.toToken?.decimals ?? 0),
               BigNumber.ROUND_HALF_UP,
             )
             .toFixed();
@@ -175,7 +175,7 @@ export const useSwapLimitRate = () => {
       const useRateBN = new BigNumber(limitPriceUseRate.rate ?? '0');
       const rateBN = priceMarketBN.multipliedBy(percentageBN);
       const formatRate = rateBN.decimalPlaces(
-        limitPriceMarketPrice.toToken?.decimals ?? 0,
+        Number(limitPriceMarketPrice.toToken?.decimals ?? 0),
         BigNumber.ROUND_HALF_UP,
       );
       const limitPriceEqualMarket = useRateBN.eq(formatRate);
@@ -204,11 +204,11 @@ export const useSwapLimitRate = () => {
         ? new BigNumber(0)
         : new BigNumber(1).div(rateBN);
       const formatRate = rateBN.decimalPlaces(
-        limitPriceMarketPrice.toToken?.decimals ?? 0,
+        Number(limitPriceMarketPrice.toToken?.decimals ?? 0),
         BigNumber.ROUND_HALF_UP,
       );
       const formatReverseRate = reverseRateBN.decimalPlaces(
-        limitPriceMarketPrice.fromToken?.decimals ?? 0,
+        Number(limitPriceMarketPrice.fromToken?.decimals ?? 0),
         BigNumber.ROUND_HALF_UP,
       );
       setLimitPriceUseRate((v) => ({

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -409,7 +409,10 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
         maxAmount = BigNumber.max(
           0,
           maxAmount.minus(new BigNumber(reserveGas)),
-        ).decimalPlaces(fromSelectToken?.decimals ?? 6, BigNumber.ROUND_DOWN);
+        ).decimalPlaces(
+          Number(fromSelectToken?.decimals ?? 6),
+          BigNumber.ROUND_DOWN,
+        );
       }
       let reserveGasFormatted: string | undefined | number = reserveGas;
       if (reserveGas) {
@@ -466,7 +469,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
       const fromTokenBalanceBN = new BigNumber(fromTokenBalance ?? 0);
       const amountBN = fromTokenBalanceBN.multipliedBy(stage / 100);
       const amountAfterDecimal = amountBN.decimalPlaces(
-        fromSelectToken?.decimals ?? 6,
+        Number(fromSelectToken?.decimals ?? 6),
         BigNumber.ROUND_DOWN,
       );
       if (

--- a/packages/kit/src/views/Swap/pages/components/SwapProInputContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProInputContainer.tsx
@@ -143,7 +143,10 @@ const SwapProInputContainer = ({
           const balanceBN = new BigNumber(inputToken.balanceParsed);
           const inputNewAmount = balanceBN
             .multipliedBy(percentage)
-            .decimalPlaces(inputToken?.decimals ?? 0, BigNumber.ROUND_DOWN)
+            .decimalPlaces(
+              Number(inputToken?.decimals ?? 0),
+              BigNumber.ROUND_DOWN,
+            )
             .toFixed();
           handleInputChange(inputNewAmount);
         }

--- a/packages/kit/src/views/Swap/pages/components/SwapProLimitPriceValue.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProLimitPriceValue.tsx
@@ -223,7 +223,7 @@ const SwapProLimitPriceValue = ({
           return;
         }
         const newLimitRate = fromTokenPriceBN.dividedBy(tokenPriceBN);
-        const decimals = limitPriceMarketPrice.toToken?.decimals ?? 8;
+        const decimals = Number(limitPriceMarketPrice.toToken?.decimals ?? 8);
         const formattedRate = newLimitRate
           .decimalPlaces(decimals, BigNumber.ROUND_HALF_UP)
           .toFixed();
@@ -240,7 +240,7 @@ const SwapProLimitPriceValue = ({
         return;
       }
       const newLimitRate = tokenPriceBN.dividedBy(toTokenPriceBN);
-      const decimals = limitPriceMarketPrice.toToken?.decimals ?? 8;
+      const decimals = Number(limitPriceMarketPrice.toToken?.decimals ?? 8);
       const formattedRate = newLimitRate
         .decimalPlaces(decimals, BigNumber.ROUND_HALF_UP)
         .toFixed();
@@ -294,7 +294,7 @@ const SwapProLimitPriceValue = ({
         return;
       }
       const newLimitRate = fromTokenPriceBN.dividedBy(tokenPriceBN);
-      const decimals = limitPriceMarketPrice.toToken?.decimals ?? 8;
+      const decimals = Number(limitPriceMarketPrice.toToken?.decimals ?? 8);
       const formattedRate = newLimitRate
         .decimalPlaces(decimals, BigNumber.ROUND_HALF_UP)
         .toFixed();
@@ -313,7 +313,7 @@ const SwapProLimitPriceValue = ({
       return;
     }
     const newLimitRate = tokenPriceBN.dividedBy(toTokenPriceBN);
-    const decimals = limitPriceMarketPrice.toToken?.decimals ?? 8;
+    const decimals = Number(limitPriceMarketPrice.toToken?.decimals ?? 8);
     const formattedRate = newLimitRate
       .decimalPlaces(decimals, BigNumber.ROUND_HALF_UP)
       .toFixed();
@@ -375,7 +375,7 @@ const SwapProLimitPriceValue = ({
           return;
         }
         const newLimitRate = fromTokenPriceBN.dividedBy(newTokenPrice);
-        const decimals = limitPriceMarketPrice.toToken?.decimals ?? 8;
+        const decimals = Number(limitPriceMarketPrice.toToken?.decimals ?? 8);
         const formattedRate = newLimitRate
           .decimalPlaces(decimals, BigNumber.ROUND_HALF_UP)
           .toFixed();
@@ -391,7 +391,7 @@ const SwapProLimitPriceValue = ({
         return;
       }
       const newLimitRate = newTokenPrice.dividedBy(toTokenPriceBN);
-      const decimals = limitPriceMarketPrice.toToken?.decimals ?? 8;
+      const decimals = Number(limitPriceMarketPrice.toToken?.decimals ?? 8);
       const formattedRate = newLimitRate
         .decimalPlaces(decimals, BigNumber.ROUND_HALF_UP)
         .toFixed();


### PR DESCRIPTION
## Summary
- API returns token decimals as string type, but BigNumber.decimalPlaces() requires a primitive number
- Wrap decimals with Number() to prevent "Argument not a primitive number" error

## Test plan
- [ ] Verify swap panel balance click works without BigNumber error
- [ ] Verify swap percentage selection works without BigNumber error

🤖 Generated with [Claude Code](https://claude.com/claude-code)