### PR TITLE
fix: add shebang and strict error handling to postbuild scripts

### DIFF
--- a/apps/web-embed/postbuild.sh
+++ b/apps/web-embed/postbuild.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -x
+set -euo pipefail -x
 
 mkdir -p ./web-build/.well-known
 
@@ -10,5 +10,4 @@ rsync -r -c -v ./web-build/ ../mobile/android/app/src/main/assets/web-embed/
 
 rm -rf ../mobile/ios/OneKeyWallet/web-embed/
 rsync -r -c -v ./web-build/ ../mobile/ios/OneKeyWallet/web-embed/
-
 

--- a/apps/web/postbuild.sh
+++ b/apps/web/postbuild.sh
@@ -1,3 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail -x
+
 mkdir -p ./web-build/.well-known
 cp ./validation/deeplink.android.json ./web-build/.well-known/assetlinks.json
 cp ./validation/deeplink.ios.json ./web-build/.well-known/apple-app-site-association


### PR DESCRIPTION
## Summary

- `apps/web/postbuild.sh`: Add shebang `#!/usr/bin/env bash` and `set -euo pipefail -x`
- `apps/web-embed/postbuild.sh`: Change `set -x` to `set -euo pipefail -x`

Both scripts now have consistent, strict error handling.

Closes #9863

## Test plan

- [x] Scripts execute correctly with `set -euo pipefail -x`
- [x] Build process completes successfully