### PR TITLE
fix: add isTestnet parameter

### DIFF
--- a/packages/kit-bg/src/services/ServiceKeylessWallet/utils/JuiceboxClient.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/utils/JuiceboxClient.ts
@@ -90,6 +90,10 @@ export class JuiceboxClient {
 
     const tokenUrl = `${JUICEBOX_AUTH_SERVER}/juicebox/v1/token/realms`;
 
+    const devSettings = await devSettingsPersistAtom.get();
+    const isTestnet =
+      !!devSettings.enabled && !!devSettings.settings?.enableTestEndpoint;
+
     const response = await axios.post<
       IApiClientResponse<{
         tokens: Record<string, string>;
@@ -97,6 +101,7 @@ export class JuiceboxClient {
       }>
     >(tokenUrl, {
       token: supabaseAccessToken,
+      isTestnet,
     });
     const resData = response?.data;
     if (resData?.code === 0 && resData?.data?.tokens) {


### PR DESCRIPTION
## Summary
- Add isTestnet parameter to Juicebox token request to support test environment
- Update KEYLESS_SUPABASE_PUBLIC_API_KEY with new JWT token

## Changes
- Add isTestnet parameter detection from dev settings in JuiceboxClient
- Pass isTestnet flag to Juicebox token request
- Update Supabase JWT token with new expiration date

## Test plan
- [ ] Test Juicebox token request in production environment
- [ ] Test Juicebox token request in test environment with dev settings enabled
- [ ] Verify Supabase authentication works with new JWT token