### PR TITLE
fix: inject VERSION, BUNDLE_VERSION, BUILD_NUMBER env vars in rspack config

### DIFF
--- a/development/rspack/rspack.base.config.ts
+++ b/development/rspack/rspack.base.config.ts
@@ -137,6 +137,9 @@ const buildBasePlugins: (
     'process.env.PERF_MONITOR_ENABLED': JSON.stringify(
       process.env.PERF_MONITOR_ENABLED || '',
     ),
+    'process.env.VERSION': JSON.stringify(process.env.VERSION),
+    'process.env.BUNDLE_VERSION': JSON.stringify(process.env.BUNDLE_VERSION),
+    'process.env.BUILD_NUMBER': JSON.stringify(process.env.BUILD_NUMBER),
   }),
   new rspack.ProvidePlugin({
     Buffer: ['buffer', 'Buffer'],


### PR DESCRIPTION
## Summary
- Add DefinePlugin entries to inject VERSION, BUNDLE_VERSION, and BUILD_NUMBER environment variables in rspack config
- Fixes .env.version variables not being injected into client code when using `yarn app:web:rspack`

## Changes
- `development/rspack/rspack.base.config.ts`: Added three new DefinePlugin entries for version-related env vars

## Test plan
- [ ] Run `yarn app:web:rspack` and verify VERSION, BUNDLE_VERSION, BUILD_NUMBER are correctly injected