### PR TITLE
fix: add keyless wallet owner ID verification in PIN-only mode

### DIFF
--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -1532,6 +1532,19 @@ class ServiceKeylessWallet extends ServiceBase {
       token,
       hashId,
     });
+    if (mode === EOnboardingV2OneKeyIDLoginMode.KeylessVerifyPinOnly) {
+      const keylessWallet =
+        await this.backgroundApi.serviceAccount.getKeylessWallet();
+      const walletOwnerId = keylessWallet?.keylessDetailsInfo?.keylessOwnerId;
+      if (!walletOwnerId) {
+        throw new OneKeyLocalError('Local keyless wallet not found.');
+      }
+      if (walletOwnerId !== ownerId) {
+        throw new OneKeyLocalError(
+          'The local keyless wallet does not match the server record. Please check that you are using the correct account.',
+        );
+      }
+    }
 
     await this.apiGetKeylessJuiceboxShare({
       ownerId,


### PR DESCRIPTION
## 描述

添加了在 PIN 验证专用模式下对本地 keyless 钱包所有者 ID 的验证。该验证确保本地钱包所有者 ID 与服务器记录匹配，防止使用错误的账户。

## 测试计划

- [ ] 在 PIN 验证专用模式下测试登录流程
- [ ] 验证匹配的账户可以正常登录
- [ ] 验证不匹配的账户会显示错误提示

🤖 Generated with [Claude Code](https://claude.com/claude-code)