### PR TITLE
fix: prevent Reanimated error in PaginationButton

### DIFF
--- a/packages/components/src/composite/Banner/PaginationButton.tsx
+++ b/packages/components/src/composite/Banner/PaginationButton.tsx
@@ -76,7 +76,7 @@ export function PaginationButton({
         variant={variant}
         icon={icon}
         onPress={onPress}
-        iconProps={hoverOpacity}
+        iconProps={{ opacity: hoverOpacity.opacity }}
         theme={theme}
         onMouseEnter={onMouseEnter}
       />


### PR DESCRIPTION
## Summary
Fixed Reanimated v4 error when clicking the question icon on OneKey Prime page. The issue was caused by passing the `animation` property to the Icon component through iconProps, but Icon is not an animated component.

## Changes
Only pass the `opacity` value from `useHoverOpacity` to iconProps instead of the entire object. The outer Animated.View already handles the fade-in/fade-out animation, so the animation property is not needed.

## Testing
This fix only affects the PaginationButton component used in the Prime Features page. The hover opacity effect will still work correctly on desktop as the opacity is still being applied.