### PR TITLE
fix: add optional chaining for referrerConfig.configVersion in HyperLiquid service

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -198,7 +198,7 @@ export default class ServiceHyperliquid extends ServiceBase {
     // Check configVersion change before updating
     const prevConfig = await this.backgroundApi.simpleDb.perp.getPerpData();
     const prevConfigVersion = prevConfig.configVersion;
-    const newConfigVersion = referrerConfig.configVersion;
+    const newConfigVersion = referrerConfig?.configVersion;
     const isConfigVersionChanged =
       !isNil(newConfigVersion) && prevConfigVersion !== newConfigVersion;
 


### PR DESCRIPTION
## Summary
- Added optional chaining (`?.`) to safely access `referrerConfig.configVersion` in HyperLiquid service
- Prevents potential null/undefined access errors when `referrerConfig` is undefined

## Test plan
- [ ] Verify HyperLiquid perp functionality works correctly
- [ ] Confirm no runtime errors when referrerConfig is undefined