### PR TITLE
fix: clear supabase auth cache on logout

### DIFF
--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPrime.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPrime.ts
@@ -1,5 +1,6 @@
 import { backgroundMethod } from '@onekeyhq/shared/src/background/backgroundDecorators';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import supabaseStorageInstance from '@onekeyhq/shared/src/storage/instance/supabaseStorageInstance';
 import { getSupabaseAuthSessionKey } from '@onekeyhq/shared/src/storage/SupabaseStorage/consts';
 import { getSupabaseClient } from '@onekeyhq/shared/src/utils/supabaseClientUtils';
 
@@ -31,6 +32,7 @@ export class SimpleDbEntityPrime extends SimpleDbEntityBase<ISimpleDBPrime> {
   // No need to manually save token here
   @backgroundMethod()
   async saveAuthToken(_authToken: string) {
+    supabaseStorageInstance.getItemWithCache.clear();
     // Supabase storage instance automatically saves token, no manual save needed
   }
 }


### PR DESCRIPTION
## Summary
- Clear Supabase storage cache when saving auth token to ensure fresh authentication state after OneKey ID logout
- Prevents stale cached data from being returned after logout

## Changes
- Added `supabaseStorageInstance.getItemWithCache.clear()` call in `SimpleDbEntityPrime.saveAuthToken()`

## Test plan
- [ ] Test OneKey ID logout flow
- [ ] Verify authentication state is properly cleared
- [ ] Confirm no stale cached data after logout

🤖 Generated with [Claude Code](https://claude.com/claude-code)