### PR TITLE
fix: remove 2 articles and adjust faq layout to 2x2 grid

### DIFF
--- a/packages/kit/src/views/DeviceManagement/pages/HardwareTroubleshootingModal/index.tsx
+++ b/packages/kit/src/views/DeviceManagement/pages/HardwareTroubleshootingModal/index.tsx
@@ -101,13 +101,6 @@ function HardwareTroubleshootingModal() {
     () => [
       {
         title: intl.formatMessage({
-          id: ETranslations.global_faqs_firmware_detection,
-        }),
-        icon: 'ErrorOutline',
-        link: 'https://help.onekey.so/articles/11461120',
-      },
-      {
-        title: intl.formatMessage({
           id: ETranslations.global_faqs_forgot_pin,
         }),
         icon: 'UnlockedOutline',
@@ -126,13 +119,6 @@ function HardwareTroubleshootingModal() {
         }),
         icon: 'ConsoleOutline',
         link: 'https://help.onekey.so/articles/11461126',
-      },
-      {
-        title: intl.formatMessage({
-          id: ETranslations.global_faqs_bridge_download,
-        }),
-        icon: 'DownloadOutline',
-        link: 'https://help.onekey.so/articles/11461117',
       },
       {
         title: intl.formatMessage({
@@ -238,7 +224,7 @@ function HardwareTroubleshootingModal() {
                 key={i}
                 pl={10}
                 pt={10}
-                flexBasis={media.gtMd ? '33.333%' : '50%'}
+                flexBasis="50%"
                 height="auto"
               >
                 <YStack


### PR DESCRIPTION
Removes "firmware detection" and "hardware bridge download" articles from the hardware troubleshooting FAQ modal, keeping 4 articles displayed in a fixed 2x2 grid layout. This improves the visual consistency across different screen sizes.

## Changes
- Removed 2 FAQ items from hardwareTroubleshootingQuestions array
- Changed flexBasis from responsive (33.333%/50%) to fixed 50% for consistent 2x2 layout

## UI Update
The FAQ section now displays 4 items instead of 6 in a 2x2 grid:
- Forgot PIN
- Reset Device
- Bootloader Mode
- Bluetooth Status