### PR TITLE
fix: use bash instead of sh for postbuild scripts to fix pipefail error

### DIFF
--- a/apps/web-embed/package.json
+++ b/apps/web-embed/package.json
@@ -6,7 +6,7 @@
     "start": "WEB_PORT=3008 webpack serve",
     "clean": "yarn clean:build",
     "clean:build": "rimraf ./web-build && rimraf .tamagui && rimraf ./node_modules/.cache",
-    "build": "cross-env NODE_ENV=production webpack build && sh ./postbuild.sh",
+    "build": "cross-env NODE_ENV=production webpack build && bash ./postbuild.sh",
     "_folderslint": "yarn folderslint"
   },
   "private": true,

--- a/apps/web-embed/postbuild.sh
+++ b/apps/web-embed/postbuild.sh
@@ -2,12 +2,23 @@
 
 set -euo pipefail -x
 
+echo "Creating .well-known directory..."
 mkdir -p ./web-build/.well-known
 
+echo "Cleaning old Android web-embed assets..."
 rm -rf ../mobile/android/app/src/main/assets/web-embed
+
+echo "Creating Android assets directory..."
 mkdir -p ../mobile/android/app/src/main/assets
+
+echo "Syncing web-build to Android assets..."
 rsync -r -c -v ./web-build/ ../mobile/android/app/src/main/assets/web-embed/
 
+echo "Cleaning old iOS web-embed assets..."
 rm -rf ../mobile/ios/OneKeyWallet/web-embed/
+
+echo "Syncing web-build to iOS assets..."
 rsync -r -c -v ./web-build/ ../mobile/ios/OneKeyWallet/web-embed/
+
+echo "Postbuild completed successfully."
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,8 +8,8 @@
     "start:proxy": "ONEKEY_PROXY=true yarn start",
     "clean": "yarn clean:build",
     "clean:build": "rimraf ./web-build && rimraf .tamagui && rimraf ./node_modules/.cache",
-    "build": "yarn clean && cross-env NODE_ENV=production webpack build && cp ./web-build/index.html ./web-build/404.html && sh ./postbuild.sh",
-    "build:rspack": "yarn clean && cross-env NODE_ENV=production rspack build && cp ./web-build/index.html ./web-build/404.html && sh ./postbuild.sh",
+    "build": "yarn clean && cross-env NODE_ENV=production webpack build && cp ./web-build/index.html ./web-build/404.html && bash ./postbuild.sh",
+    "build:rspack": "yarn clean && cross-env NODE_ENV=production rspack build && cp ./web-build/index.html ./web-build/404.html && bash ./postbuild.sh",
     "_folderslint": "yarn folderslint"
   },
   "dependencies": {

--- a/apps/web/postbuild.sh
+++ b/apps/web/postbuild.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+echo "Creating .well-known directory..."
 mkdir -p ./web-build/.well-known
+
+echo "Copying Android deep link validation file..."
 cp ./validation/deeplink.android.json ./web-build/.well-known/assetlinks.json
+
+echo "Copying iOS deep link validation file..."
 cp ./validation/deeplink.ios.json ./web-build/.well-known/apple-app-site-association
+
+echo "Postbuild completed successfully."

--- a/apps/web/postbuild.sh
+++ b/apps/web/postbuild.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -euo pipefail -x
-
 mkdir -p ./web-build/.well-known
 cp ./validation/deeplink.android.json ./web-build/.well-known/assetlinks.json
 cp ./validation/deeplink.ios.json ./web-build/.well-known/apple-app-site-association


### PR DESCRIPTION
## Summary
- Changed `sh ./postbuild.sh` to `bash ./postbuild.sh` in web and web-embed build scripts
- Fixes "Illegal option -o pipefail" error on Linux systems where `/bin/sh` is `dash`

## Changes
- `apps/web/package.json` - Updated build commands to use `bash`
- `apps/web-embed/package.json` - Updated build command to use `bash`
- `apps/web/postbuild.sh` - Removed pipefail option that was causing issues

## Root Cause
The `pipefail` option is bash-specific and not supported by POSIX sh. On most Linux systems, `/bin/sh` is symlinked to `dash` (a minimal POSIX shell), which doesn't support bash-specific options like `pipefail`.