### PR TITLE
fix(ci): resolve altool file path glob expansion issue in MAS release workflow

### DIFF
--- a/.github/workflows/release-desktop-mas.yml
+++ b/.github/workflows/release-desktop-mas.yml
@@ -156,7 +156,9 @@ jobs:
           APPLEID: ${{ secrets.APPLEID }}
           APPLEIDPASS: ${{ secrets.APPLEIDPASS }}
         run: |
-          xcrun altool --validate-app --f ./apps/desktop/build-electron/mas-universal/*.pkg -t macOS -u $APPLEID -p $APPLEIDPASS --show-progress
+          PKG_FILE=$(ls ./apps/desktop/build-electron/mas-universal/*.pkg)
+          echo "Found package: $PKG_FILE"
+          xcrun altool --validate-app --file "$PKG_FILE" -t macOS -u "$APPLEID" -p "$APPLEIDPASS" --show-progress
 
       - name: upload mas for Testflight
         continue-on-error: true
@@ -164,7 +166,9 @@ jobs:
           APPLEID: ${{ secrets.APPLEID }}
           APPLEIDPASS: ${{ secrets.APPLEIDPASS }}
         run: |
-          xcrun altool --upload-app --f ./apps/desktop/build-electron/mas-universal/*.pkg -t macOS -u $APPLEID -p $APPLEIDPASS --show-progress
+          PKG_FILE=$(ls ./apps/desktop/build-electron/mas-universal/*.pkg)
+          echo "Uploading package: $PKG_FILE"
+          xcrun altool --upload-app --file "$PKG_FILE" -t macOS -u "$APPLEID" -p "$APPLEIDPASS" --show-progress
 
       - name: 'Notify to Slack'
         if: ${{ github.event.workflow_run }}


### PR DESCRIPTION
## Summary
- Fix altool command failing with "Expected --file argument to have a value" error
- Use variable to capture .pkg file path before passing to altool
- Change `-f` to `--file` for explicit argument naming
- Add echo statement to confirm package file is found

## Root Cause
The glob pattern `*.pkg` was not being properly expanded when passed directly to altool, causing the command to receive an empty value.

## Test plan
- [ ] Re-run the MAS release workflow
- [ ] Verify altool validate and upload commands execute successfully