### PR TITLE
fix(ci): correct runner name typo in desktop bundle workflow

### DIFF
--- a/.github/workflows/release-desktop-bundle.yml
+++ b/.github/workflows/release-desktop-bundle.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   release-desktop-bundle:
-    runs-on: unbuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         node-version: [24.x]


### PR DESCRIPTION
## Summary
- Fix typo in runner name: `unbuntu-latest` → `ubuntu-24.04`

## Root Cause
The workflow was configured with a misspelled runner name "unbuntu-latest" which would cause the workflow to fail.

## Test plan
- [ ] Verify the desktop bundle workflow runs successfully