### PR TITLE
fix(keyless): improve error handling and add detailed logging for keyless wallet flows

### DIFF
--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -1528,13 +1528,18 @@ class ServiceKeylessWallet extends ServiceBase {
     const { hashId } = await this.apiGetKeylessBackendShare({
       token,
     });
+    defaultLogger.wallet.keyless.verifyKeylessBackendShareRetrieved();
+
     const ownerId = await this.buildKeylessOwnerIdFromSocialToken({
       token,
       hashId,
     });
+    defaultLogger.wallet.keyless.verifyKeylessOwnerIdGenerated();
+
     if (mode === EOnboardingV2OneKeyIDLoginMode.KeylessVerifyPinOnly) {
       const keylessWallet =
         await this.backgroundApi.serviceAccount.getKeylessWallet();
+
       const walletOwnerId = keylessWallet?.keylessDetailsInfo?.keylessOwnerId;
       if (!walletOwnerId) {
         throw new OneKeyLocalError('Local keyless wallet not found.');
@@ -1544,6 +1549,7 @@ class ServiceKeylessWallet extends ServiceBase {
           'The local keyless wallet does not match the server record. Please check that you are using the correct account.',
         );
       }
+      defaultLogger.wallet.keyless.verifyKeylessWalletValidated();
     }
 
     await this.apiGetKeylessJuiceboxShare({
@@ -1551,6 +1557,7 @@ class ServiceKeylessWallet extends ServiceBase {
       token,
       pin,
     });
+    defaultLogger.wallet.keyless.verifyKeylessJuiceboxShareRetrieved();
 
     // Save tokens to secure storage (refreshToken with passcode, token without)
     if (
@@ -1566,8 +1573,10 @@ class ServiceKeylessWallet extends ServiceBase {
         password,
         backgroundApi: this.backgroundApi,
       });
+      defaultLogger.wallet.keyless.verifyKeylessTokensStored();
     }
     void this.apiUpdatePinConfirmStatus({ token });
+    defaultLogger.wallet.keyless.verifyKeylessPinConfirmStatusUpdated();
   }
 
   @backgroundMethod()
@@ -1642,12 +1651,14 @@ class ServiceKeylessWallet extends ServiceBase {
     if (!backendShareData) {
       throw new OneKeyLocalError('Backend share not found');
     }
+    defaultLogger.wallet.keyless.resetKeylessBackendShareRetrieved();
 
     // 1. Get ownerId from token
     const ownerId = await this.buildKeylessOwnerIdFromSocialToken({
       token,
       hashId,
     });
+    defaultLogger.wallet.keyless.resetKeylessOwnerIdGenerated();
 
     // 3. Get mnemonicPassword from secure storage
     const mnemonicPassword =
@@ -1663,6 +1674,7 @@ class ServiceKeylessWallet extends ServiceBase {
       });
       throw new KeylessDataCorruptedError();
     }
+    defaultLogger.wallet.keyless.resetKeylessMnemonicPasswordRetrieved();
 
     // 3.1. Verify mnemonicPassword can decrypt backendShareData and matches local keyless wallet
     const decryptedMnemonic = await this.decryptKeylessMnemonic({
@@ -1674,6 +1686,7 @@ class ServiceKeylessWallet extends ServiceBase {
         'Mnemonic password does not match backend share data. Please verify your credentials.',
       );
     }
+    defaultLogger.wallet.keyless.resetKeylessMnemonicVerified();
 
     // 3.2. Verify decrypted mnemonic matches local keyless wallet mnemonic
     const keylessWallet =
@@ -1681,7 +1694,10 @@ class ServiceKeylessWallet extends ServiceBase {
     if (!keylessWallet) {
       throw new OneKeyLocalError('Keyless wallet not found.');
     }
+
     const credential = await localDb.getCredential(keylessWallet.id);
+    defaultLogger.wallet.keyless.resetKeylessCredentialVerified();
+
     const rs = await decryptRevealableSeed({
       rs: credential.credential,
       password,
@@ -1692,6 +1708,7 @@ class ServiceKeylessWallet extends ServiceBase {
         'Decrypted mnemonic does not match local keyless wallet. Please verify your credentials.',
       );
     }
+    defaultLogger.wallet.keyless.resetKeylessMnemonicDecrypted();
 
     // 4. Get x-coordinates from stored data
     // juiceboxShareX is stored in backendShareData for recovery
@@ -1705,6 +1722,7 @@ class ServiceKeylessWallet extends ServiceBase {
       shareBase64: backendShareData.backendShare,
       missingX: backendShareData.juiceboxShareX,
     });
+    defaultLogger.wallet.keyless.resetKeylessJuiceboxShareRecovered();
 
     // 6. Upload juiceboxShare with new PIN
     await this.apiUploadKeylessJuiceboxShare({
@@ -1713,6 +1731,9 @@ class ServiceKeylessWallet extends ServiceBase {
       pin: newPin,
       backendShareX,
       ownerId,
+    });
+    defaultLogger.wallet.keyless.resetKeylessJuiceboxShareUploaded({
+      backendShareX,
     });
 
     // Save tokens to secure storage (refreshToken with passcode, token without)
@@ -1724,9 +1745,11 @@ class ServiceKeylessWallet extends ServiceBase {
         password,
         backgroundApi: this.backgroundApi,
       });
+      defaultLogger.wallet.keyless.resetKeylessTokensStored();
     }
 
     void this.apiResetPinConfirmStatus({ token });
+    defaultLogger.wallet.keyless.resetKeylessPinConfirmStatusUpdated();
 
     return { success: true };
   }
@@ -1761,12 +1784,14 @@ class ServiceKeylessWallet extends ServiceBase {
     if (!backendShareData) {
       throw new OneKeyLocalError('Backend share not found');
     }
+    defaultLogger.wallet.keyless.restoreKeylessBackendShareRetrieved();
 
     // check if keyless wallet is initialized
     const ownerId = await this.buildKeylessOwnerIdFromSocialToken({
       token,
       hashId,
     });
+    defaultLogger.wallet.keyless.restoreKeylessOwnerIdGenerated();
 
     // Get juicebox share from juicebox network
     const juiceboxShareData = await this.apiGetKeylessJuiceboxShare({
@@ -1777,6 +1802,7 @@ class ServiceKeylessWallet extends ServiceBase {
     if (!juiceboxShareData) {
       throw new OneKeyLocalError('Juicebox share not found');
     }
+    defaultLogger.wallet.keyless.restoreKeylessJuiceboxShareRetrieved();
 
     // Combine shares to recover mnemonic password
     const mnemonicPasswordShares = [
@@ -1787,12 +1813,14 @@ class ServiceKeylessWallet extends ServiceBase {
       mnemonicPasswordShares.map((s) => new Uint8Array(s)),
     );
     const mnemonicPassword = bufferUtils.bytesToBase64(mnemonicPasswordBytes);
+    defaultLogger.wallet.keyless.restoreKeylessMnemonicPasswordRecovered();
 
     // Decrypt mnemonic using recovered password
     const mnemonic = await this.decryptKeylessMnemonic({
       encryptedMnemonic: backendShareData.encryptedMnemonic,
       mnemonicPassword,
     });
+    defaultLogger.wallet.keyless.restoreKeylessMnemonicDecrypted();
 
     // Save mnemonicPassword to secure storage for Reset PIN flow
     await keylessMnemonicPasswordStorage.saveMnemonicPasswordToStorage({
@@ -1801,6 +1829,7 @@ class ServiceKeylessWallet extends ServiceBase {
       password,
       backgroundApi: this.backgroundApi,
     });
+    defaultLogger.wallet.keyless.restoreKeylessMnemonicPasswordStored();
 
     // Save tokens to secure storage (refreshToken with passcode, token without)
     if (refreshToken) {
@@ -1811,9 +1840,11 @@ class ServiceKeylessWallet extends ServiceBase {
         password,
         backgroundApi: this.backgroundApi,
       });
+      defaultLogger.wallet.keyless.restoreKeylessTokensStored();
     }
 
     void this.apiUpdatePinConfirmStatus({ token });
+    defaultLogger.wallet.keyless.restorePinConfirmStatusUpdated();
 
     const keylessProvider = this.buildKeylessProviderFromSocialToken({ token });
 
@@ -1872,18 +1903,23 @@ class ServiceKeylessWallet extends ServiceBase {
 
     // 1. Acquire distributed lock
     const { lockId, hashId } = await this.apiAcquireCreationLock({ token });
+    defaultLogger.wallet.keyless.createKeylessLockAcquired({ lockId });
 
     try {
       // 2. Double-check if already created (check inside lock for safety)
       const isCreated = await this.isKeylessWalletCreatedOnServer({ token });
+
       if (isCreated) {
         throw new OneKeyLocalError('Keyless wallet already created');
       }
+      defaultLogger.wallet.keyless.createKeylessWalletNotYetCreated();
 
       const ownerId = await this.buildKeylessOwnerIdFromSocialToken({
         token,
         hashId,
       });
+      defaultLogger.wallet.keyless.createKeylessOwnerIdGenerated();
+
       let mnemonic = '';
       const devSettings = await devSettingsPersistAtom.get();
       if (devSettings.enabled && customMnemonic && customMnemonic.trim()) {
@@ -1897,11 +1933,15 @@ class ServiceKeylessWallet extends ServiceBase {
         mnemonic,
         mnemonicPassword,
       });
+      defaultLogger.wallet.keyless.createKeylessMnemonicEncrypted();
+
       const mnemonicPasswordShares = await shamirUtils.split(
         new Uint8Array(mnemonicPasswordBytes),
         2,
         2,
       );
+      defaultLogger.wallet.keyless.createKeylessMnemonicPasswordShared();
+
       const [mnemonicPasswordShare1, mnemonicPasswordShare2] =
         mnemonicPasswordShares;
       const backendShare: string = bufferUtils.bytesToBase64(
@@ -1924,6 +1964,7 @@ class ServiceKeylessWallet extends ServiceBase {
         password,
         backgroundApi: this.backgroundApi,
       });
+      defaultLogger.wallet.keyless.createKeylessMnemonicPasswordStored();
 
       const _juiceboxShareData: IKeylessJuiceboxShare =
         await this.apiUploadKeylessJuiceboxShare({
@@ -1933,6 +1974,11 @@ class ServiceKeylessWallet extends ServiceBase {
           pin,
           backendShareX, // Store the other share's x-coordinate for recovery
         });
+      defaultLogger.wallet.keyless.createKeylessJuiceboxShareUploaded({
+        juiceboxShareX,
+      });
+
+      // throw new OneKeyLocalError('test33275923746234');
 
       // Make sure juiceboxShare is uploaded successfully before uploading backend share
       const _backendShareData: IKeylessBackendShare =
@@ -1943,6 +1989,9 @@ class ServiceKeylessWallet extends ServiceBase {
           backendShare,
           juiceboxShareX, // Store the other share's x-coordinate for recovery
         });
+      defaultLogger.wallet.keyless.createKeylessBackendShareUploaded({
+        backendShareX,
+      });
 
       // Save tokens to secure storage (refreshToken with passcode, token without)
       if (refreshToken) {
@@ -1953,6 +2002,7 @@ class ServiceKeylessWallet extends ServiceBase {
           password,
           backgroundApi: this.backgroundApi,
         });
+        defaultLogger.wallet.keyless.createKeylessTokensStored();
       }
 
       // void this.apiUpdatePinConfirmStatus({ token });

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/utils/JuiceboxClient.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/utils/JuiceboxClient.ts
@@ -196,7 +196,7 @@ export class JuiceboxClient {
     );
 
     // Clear token cache after successful registration
-    this.clearTokenCache();
+    // this.clearTokenCache();
   }
 
   /**

--- a/packages/kit/src/components/Password/container/PasswordSetupContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordSetupContainer.tsx
@@ -85,6 +85,7 @@ const PasswordSetupContainer = ({
       const finalPassword =
         mode === EPasswordMode.PASSCODE ? confirmPassCode : confirmPassword;
       setLoading(true);
+      let isPasswordSetSuccess = false;
       try {
         if (isBiologyAuthSwitchOn && isSupport) {
           const res = await setWebAuthEnable(true);
@@ -99,6 +100,7 @@ const PasswordSetupContainer = ({
             encodePassword,
             mode,
           );
+        isPasswordSetSuccess = true;
         Toast.success({
           title: intl.formatMessage({ id: ETranslations.auth_passcode_set }),
         });
@@ -155,11 +157,15 @@ const PasswordSetupContainer = ({
       } catch (e) {
         console.log('e.stack', (e as Error)?.stack);
         console.error(e);
-        Toast.error({
-          title: intl.formatMessage({
-            id: ETranslations.feedback_passcode_set_failed,
-          }),
-        });
+        if (!isPasswordSetSuccess) {
+          Toast.error({
+            title: intl.formatMessage({
+              id: ETranslations.feedback_passcode_set_failed,
+            }),
+          });
+        } else {
+          throw e;
+        }
       } finally {
         setLoading(false);
       }

--- a/packages/shared/src/logger/scopes/wallet/scenes/keyless.ts
+++ b/packages/shared/src/logger/scopes/wallet/scenes/keyless.ts
@@ -20,4 +20,181 @@ export class KeylessScene extends BaseScene {
   public dataCorruptedError({ reason }: { reason: string }) {
     return { reason };
   }
+
+  @LogToLocal({ level: 'info' })
+  public createKeylessLockAcquired({ lockId }: { lockId: string }) {
+    return { lockId };
+  }
+
+  @LogToLocal({ level: 'info' })
+  public createKeylessWalletNotYetCreated() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public createKeylessOwnerIdGenerated() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public createKeylessMnemonicEncrypted() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public createKeylessJuiceboxShareUploaded({
+    juiceboxShareX,
+  }: {
+    juiceboxShareX: number;
+  }) {
+    return { juiceboxShareX };
+  }
+
+  @LogToLocal({ level: 'info' })
+  public createKeylessBackendShareUploaded({
+    backendShareX,
+  }: {
+    backendShareX: number;
+  }) {
+    return { backendShareX };
+  }
+
+  @LogToLocal({ level: 'info' })
+  public createKeylessTokensStored() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public verifyKeylessJuiceboxShareRetrieved() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public verifyKeylessTokensStored() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public resetKeylessBackendShareRetrieved() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public resetKeylessOwnerIdGenerated() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public resetKeylessMnemonicPasswordRetrieved() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public resetKeylessMnemonicDecrypted() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public resetKeylessJuiceboxShareRecovered() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public resetKeylessJuiceboxShareUploaded({
+    backendShareX,
+  }: {
+    backendShareX: number;
+  }) {
+    return { backendShareX };
+  }
+
+  @LogToLocal({ level: 'info' })
+  public resetKeylessTokensStored() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public restoreKeylessBackendShareRetrieved() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public restoreKeylessOwnerIdGenerated() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public restoreKeylessJuiceboxShareRetrieved() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public restoreKeylessMnemonicPasswordRecovered() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public restoreKeylessMnemonicDecrypted() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public restoreKeylessMnemonicPasswordStored() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public restoreKeylessTokensStored() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public verifyKeylessOwnerIdGenerated() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public verifyKeylessWalletValidated() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public resetKeylessMnemonicVerified() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public resetKeylessCredentialVerified() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public resetKeylessPinConfirmStatusUpdated() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public restorePinConfirmStatusUpdated() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public createKeylessMnemonicPasswordShared() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public createKeylessMnemonicPasswordStored() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public verifyKeylessBackendShareRetrieved() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'info' })
+  public verifyKeylessPinConfirmStatusUpdated() {
+    return {};
+  }
 }


### PR DESCRIPTION
## Summary
- Fix password setup error handling to properly propagate errors after successful password set, preventing incorrect "passcode set failed" toast when the actual issue occurred later in the flow
- Add comprehensive logging throughout keyless wallet create/verify/reset/restore flows for better debugging and monitoring
- Disable token cache clearing in JuiceboxClient to prevent initialization issues during keyless wallet setup

## Test plan
- [ ] Test keyless wallet creation flow and verify logging appears in local logs
- [ ] Test keyless wallet verification flow
- [ ] Test keyless wallet reset PIN flow
- [ ] Test keyless wallet restore flow
- [ ] Verify error messages are correctly displayed when failures occur at different stages

🤖 Generated with [Claude Code](https://claude.com/claude-code)