### PR TITLE
fix: update More options button style on GetStarted page

### DIFF
--- a/packages/kit/src/views/Onboardingv2/pages/GetStarted.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/GetStarted.tsx
@@ -451,7 +451,7 @@ function GetStarted() {
               gap={38}
               justifyContent="center"
               alignItems="center"
-              pb="$9"
+              pb={58}
             >
               <DecorativeOneKeyLogo />
               <Stack gap="$4" minWidth="$80" zIndex={1}>

--- a/packages/kit/src/views/Onboardingv2/pages/GetStarted.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/GetStarted.tsx
@@ -447,7 +447,12 @@ function GetStarted() {
                 </GridItem>
               </YStack>
             </YStack>
-            <YStack gap={44} justifyContent="center" alignItems="center">
+            <YStack
+              gap={38}
+              justifyContent="center"
+              alignItems="center"
+              pb="$9"
+            >
               <DecorativeOneKeyLogo />
               <Stack gap="$4" minWidth="$80" zIndex={1}>
                 <Button
@@ -562,24 +567,18 @@ function GetStarted() {
                         </SizableText>
                       </XStack>
                     </Button>
-                    <Stack
-                      cursor="pointer"
+                    <Button
+                      variant="tertiary"
+                      size="large"
+                      alignSelf="stretch"
+                      mx="$0"
+                      borderRadius="$3"
                       onPress={handleCreateOrImportWallet}
-                      hoverStyle={{ opacity: 0.8 }}
-                      pressStyle={{ opacity: 0.6 }}
-                      py="$2"
                     >
-                      <SizableText
-                        size="$bodyMd"
-                        color="$textSubdued"
-                        textAlign="center"
-                        textDecorationLine="underline"
-                      >
-                        {intl.formatMessage({
-                          id: ETranslations.more_options,
-                        })}
-                      </SizableText>
-                    </Stack>
+                      {intl.formatMessage({
+                        id: ETranslations.more_options,
+                      })}
+                    </Button>
                   </>
                 ) : (
                   <Button


### PR DESCRIPTION
## Summary
- Replace custom Stack-based "More options" with `Button variant="tertiary"` for consistent styling
- Adjust GetStarted layout spacing (gap, padding) for better visual alignment

## Test plan
- [ ] Verify "More options" button hover width matches other buttons
- [ ] Check layout alignment on desktop and mobile