### PR TITLE
refactor: adjust sidebar device and referral order with shortcut keys

### DIFF
--- a/packages/kit/src/routes/Tab/router.ts
+++ b/packages/kit/src/routes/Tab/router.ts
@@ -215,7 +215,6 @@ export const useTabRouterConfig = (params?: IGetTabRouterParams) => {
         trackId: 'global-earn',
         hideOnTabBar: platformEnv.isNative,
       },
-      !platformEnv.isNative ? referFriendsTabConfig : undefined,
       platformEnv.isNative
         ? undefined
         : {
@@ -228,6 +227,7 @@ export const useTabRouterConfig = (params?: IGetTabRouterParams) => {
             trackId: 'global-my-onekey',
             hideOnTabBar: isModalStack,
           },
+      !platformEnv.isNative ? referFriendsTabConfig : undefined,
       isShowMDDiscover ? getDiscoverRouterConfig(params) : undefined,
       isShowDesktopDiscover ? getDiscoverRouterConfig(params) : undefined,
       platformEnv.isDev

--- a/packages/shared/src/shortcuts/shortcuts.enum.ts
+++ b/packages/shared/src/shortcuts/shortcuts.enum.ts
@@ -105,13 +105,13 @@ export const shortcutsMap: Record<
     keys: [shortcutsKeys.CmdOrCtrl, '5'],
     desc: 'Earn Tab',
   },
-  [EShortcutEvents.TabReferAFriend]: {
-    keys: [shortcutsKeys.CmdOrCtrl, '6'],
-    desc: 'Refer a Friend Tab',
-  },
   [EShortcutEvents.TabMyOneKey]: {
-    keys: [shortcutsKeys.CmdOrCtrl, '7'],
+    keys: [shortcutsKeys.CmdOrCtrl, '6'],
     desc: 'My OneKey Tab',
+  },
+  [EShortcutEvents.TabReferAFriend]: {
+    keys: [shortcutsKeys.CmdOrCtrl, '7'],
+    desc: 'Refer a Friend Tab',
   },
   [EShortcutEvents.TabBrowser]: {
     keys: [shortcutsKeys.CmdOrCtrl, '8'],


### PR DESCRIPTION
Reorder sidebar items to place Device tab before Referral tab. Swap corresponding keyboard shortcuts (Device: Cmd+6, Referral: Cmd+7) to match the new tab order.