### PR TITLE
fix(ci): add explicit bash shell for cross-platform compatibility in cache-refresh workflow

### DIFF
--- a/.github/workflows/cache-refresh.yml
+++ b/.github/workflows/cache-refresh.yml
@@ -88,6 +88,7 @@ jobs:
       # For logging and debugging purposes
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
+        shell: bash
         run: echo "dir=${{ github.workspace }}/.yarn" >> "$GITHUB_OUTPUT"
 
       # Step 4: Install dependencies to refresh cache
@@ -96,6 +97,7 @@ jobs:
       # - Update cache files in .yarn/cache directory
       # - GitHub Actions will auto-save updated cache at job end
       - name: Install dependencies (refresh cache)
+        shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_OPTIONS: '--max_old_space_size=4096'
@@ -107,6 +109,7 @@ jobs:
 
       # Step 5: Display cache statistics
       - name: Display cache statistics
+        shell: bash
         run: |
           echo "=== Yarn Cache Statistics ==="
           echo "Cache directory: ${{ steps.yarn-cache-dir-path.outputs.dir }}"
@@ -120,6 +123,7 @@ jobs:
 
       # Step 6: Verify dependency integrity
       - name: Verify dependency integrity
+        shell: bash
         run: |
           echo "Verifying installed dependencies..."
           yarn install --immutable --immutable-cache --check-cache


### PR DESCRIPTION
## Summary
- Add `shell: bash` directive to all steps using bash-specific syntax in the cache-refresh workflow
- Ensures cross-platform compatibility across Linux, macOS, and Windows runners

## Problem
The cache-refresh workflow runs on multiple operating systems including Windows, where PowerShell is the default shell. Steps using bash-specific syntax (like `${{ }}` expansions and `|` multi-line blocks) need an explicit `shell: bash` directive to work correctly on Windows runners.

## Changes
Added `shell: bash` to the following steps:
- Get yarn cache directory path
- Install dependencies (refresh cache)
- Display cache statistics
- Verify dependency integrity

## Test Plan
- [x] Workflow syntax is valid
- [ ] Will verify on Windows runner when workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)