### PR TITLE
fix(ci): resolve Git LFS authorization conflict in actions/checkout@v6

### DIFF
--- a/.github/workflows/bundlediff-ios.yml
+++ b/.github/workflows/bundlediff-ios.yml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           ref: ${{github.event.pull_request.head.ref}}
 
@@ -66,7 +66,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref }}
 

--- a/.github/workflows/bundlediff-web.yml
+++ b/.github/workflows/bundlediff-web.yml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           ref: ${{github.event.pull_request.head.ref}}
 
@@ -66,7 +66,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref }}
 

--- a/.github/workflows/cache-refresh.yml
+++ b/.github/workflows/cache-refresh.yml
@@ -65,7 +65,7 @@ jobs:
     steps:
       # Step 1: Checkout code
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           ref: x  # Explicitly checkout x branch
           lfs: true  # Enable Git LFS support

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -14,7 +14,7 @@ jobs:
 
   #   steps:
   #     - name: Clone Build History Branch
-  #       uses: actions/checkout@v6
+  #       uses: actions/checkout@v4
   #       with:
   #         ref: buildhistory
       
@@ -25,7 +25,7 @@ jobs:
   #         echo "current_id: $(sed -n 1p ./build_version)"
 
   #     - name: Clone Main Branch
-  #       uses: actions/checkout@v6
+  #       uses: actions/checkout@v4
   #       with:
   #         ref: x
   #         path: onekey
@@ -77,7 +77,7 @@ jobs:
 
 
       # - name: Clone Build History Branch
-      #   uses: actions/checkout@v6
+      #   uses: actions/checkout@v4
       #   with:
       #     ref: buildhistory
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
         node-version: [24.x]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           lfs: true
 

--- a/.github/workflows/release-android-debug.yml
+++ b/.github/workflows/release-android-debug.yml
@@ -28,7 +28,7 @@ jobs:
         run: rm -rf /opt/hostedtoolcache
 
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           lfs: true
 

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -27,7 +27,7 @@ jobs:
           echo "Executed at: $(date '+%Y-%m-%d %H:%M:%S')"
 
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           lfs: true
 

--- a/.github/workflows/release-desktop-bundle.yml
+++ b/.github/workflows/release-desktop-bundle.yml
@@ -25,7 +25,7 @@ jobs:
           echo "Executed at: $(date '+%Y-%m-%d %H:%M:%S')"
 
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           lfs: true
 

--- a/.github/workflows/release-desktop-flatpak.yml
+++ b/.github/workflows/release-desktop-flatpak.yml
@@ -29,7 +29,7 @@ jobs:
           echo "Executed at: $(date '+%Y-%m-%d %H:%M:%S')"
 
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           lfs: true
 

--- a/.github/workflows/release-desktop-mas.yml
+++ b/.github/workflows/release-desktop-mas.yml
@@ -25,7 +25,7 @@ jobs:
           echo "Executed at: $(date '+%Y-%m-%d %H:%M:%S')"
 
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           lfs: true
 

--- a/.github/workflows/release-desktop-snap.yml
+++ b/.github/workflows/release-desktop-snap.yml
@@ -26,7 +26,7 @@ jobs:
           echo "Executed at: $(date '+%Y-%m-%d %H:%M:%S')"
 
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           lfs: true
       - name: Install dependencies

--- a/.github/workflows/release-desktop-win.yml
+++ b/.github/workflows/release-desktop-win.yml
@@ -25,7 +25,7 @@ jobs:
           Write-Host "Executed at: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')"
 
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           lfs: true
 

--- a/.github/workflows/release-desktop-winms.yml
+++ b/.github/workflows/release-desktop-winms.yml
@@ -25,7 +25,7 @@ jobs:
           Write-Host "Executed at: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')"
 
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           lfs: true
 

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -26,7 +26,7 @@ jobs:
           echo "Executed at: $(date '+%Y-%m-%d %H:%M:%S')"
 
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           lfs: true
 

--- a/.github/workflows/release-ext.yml
+++ b/.github/workflows/release-ext.yml
@@ -26,7 +26,7 @@ jobs:
           echo "Executed at: $(date '+%Y-%m-%d %H:%M:%S')"
 
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           lfs: true
 

--- a/.github/workflows/release-ios-debug.yml
+++ b/.github/workflows/release-ios-debug.yml
@@ -26,7 +26,7 @@ jobs:
           echo "Executed at: $(date '+%Y-%m-%d %H:%M:%S')"
 
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           lfs: true
 

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -27,7 +27,7 @@ jobs:
           echo "Executed at: $(date '+%Y-%m-%d %H:%M:%S')"
 
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           lfs: true
 

--- a/.github/workflows/release-native-bundle.yml
+++ b/.github/workflows/release-native-bundle.yml
@@ -25,7 +25,7 @@ jobs:
           echo "Executed at: $(date '+%Y-%m-%d %H:%M:%S')"
 
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           lfs: true
 

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -24,7 +24,7 @@ jobs:
           echo "Executed at: $(date '+%Y-%m-%d %H:%M:%S')"
 
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           lfs: true
 
@@ -99,7 +99,7 @@ jobs:
     if: ${{ !github.event.workflow_run || (github.event.workflow_run && github.event.workflow_run.conclusion == 'success') }}
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           lfs: true
 
@@ -166,7 +166,7 @@ jobs:
     if: ${{ github.event.workflow_run && always() }}
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Run Shared Env Setup
         uses: ./.github/actions/shared-env

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -29,7 +29,7 @@ jobs:
         node-version: [24.x]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           lfs: true
 


### PR DESCRIPTION
## Summary

Fix "Duplicate header: Authorization" error that causes HTTP 400 failures when using `actions/checkout@v6` with `lfs: true`.

## Root Cause

When upgrading from `actions/checkout@v3` to `@v6`, the new version has a known compatibility issue with Git LFS:
- Git LFS automatically sets an Authorization header
- actions/checkout@v6's internal authentication also sets an Authorization header  
- These conflicting headers cause the error: `remote: Duplicate header: "Authorization"`

## Solution

**Revert to `actions/checkout@v4`** which has stable Git LFS support and doesn't have this authentication conflict issue.

Note: Initially tried adding explicit `token` parameter (method 1), but it didn't resolve the issue. Reverting to v4 is the most reliable solution.

## Changes

- Reverted all `actions/checkout@v6` → `actions/checkout@v4`
- 21 workflow files affected

## Affected Workflows

- lint, unittest, cache-refresh
- All release workflows (ios, android, web, desktop variants, extension)
- Bundle diff workflows
- daily-build, codacy

## Testing

This fix should resolve the CI failures in the "Run Shared Env Setup" step that were occurring across all workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)