### PR TITLE
Refactor: Remove 'Add' text label from device management header

### DIFF
--- a/packages/kit/src/views/DeviceManagement/pages/DeviceManagementListModal/SectionHeader.tsx
+++ b/packages/kit/src/views/DeviceManagement/pages/DeviceManagementListModal/SectionHeader.tsx
@@ -39,23 +39,12 @@ function SectionHeader() {
           })}
         </SizableText>
       </YStack>
-      <YStack ai="center" jc="center" gap="$0.5" onPress={onAddDevice}>
-        <IconButton
-          icon="PlusLargeOutline"
-          size="small"
-          variant="primary"
-          onPress={onAddDevice}
-        />
-        <SizableText
-          size="$bodySmMedium"
-          color="$textSubdued"
-          userSelect="none"
-        >
-          {intl.formatMessage({
-            id: ETranslations.global_add,
-          })}
-        </SizableText>
-      </YStack>
+      <IconButton
+        icon="PlusLargeOutline"
+        size="small"
+        variant="primary"
+        onPress={onAddDevice}
+      />
     </XStack>
   );
 }


### PR DESCRIPTION
## Summary
- Simplified the device section header by removing the text label below the add button
- The plus icon button is now displayed standalone for a cleaner UI
- Maintained the same functionality for adding new devices

## Changes
- Modified `SectionHeader.tsx` in device management:
  - Removed YStack wrapper containing both icon button and text label
  - Replaced with standalone IconButton component
  - Kept the same onPress handler

## Visual Changes
**Before**: Plus icon button with "Add"  text label below it
**After**: Plus icon button only

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/9951">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
