### PR TITLE
fix: skip passcode lock screen in WebDappMode

### DIFF
--- a/packages/kit-bg/src/states/jotai/atoms/password.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/password.ts
@@ -162,6 +162,10 @@ export const {
 
 export const { target: appIsLocked, use: useAppIsLockedAtom } =
   globalAtomComputed<boolean>((get) => {
+    // WebDappMode only supports connecting external wallets, no local wallet data to protect
+    if (platformEnv.isWebDappMode) {
+      return false;
+    }
     const { isMigrationModalOpen, isProcessing } = get(v4migrationAtom.atom());
     if (isMigrationModalOpen || isProcessing) {
       return false;


### PR DESCRIPTION
## Summary
- Skip the passcode lock screen when running in WebDappMode
- WebDappMode only supports connecting external wallets and tracking addresses
- No local wallet data needs protection in this mode

## Test plan
- [ ] Verify WebDappMode no longer shows the passcode lock screen
- [ ] Verify other platforms (desktop, mobile, extension) still show lock screen as expected
- [ ] Verify external wallet connection still works in WebDappMode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/9955">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
