### PR TITLE
fix(android): remove extra padding when using 3-button navigation (OK-49785 OK-40912)

### DIFF
--- a/patches/react-native-bottom-tabs+1.1.0.patch
+++ b/patches/react-native-bottom-tabs+1.1.0.patch
@@ -1,8 +1,21 @@
 diff --git a/node_modules/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt b/node_modules/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
-index 23cd875..b0d2fbf 100644
+index 23cd875..3fe0e1d 100644
 --- a/node_modules/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
 +++ b/node_modules/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
-@@ -227,6 +227,17 @@ class ReactBottomNavigationView(context: Context) : LinearLayout(context) {
+@@ -38,6 +38,12 @@ import com.google.android.material.navigation.NavigationBarView.LABEL_VISIBILITY
+ import com.google.android.material.transition.platform.MaterialFadeThrough
+ 
+ class ExtendedBottomNavigationView(context: Context) : BottomNavigationView(context) {
++  init {
++    // Disable automatic window insets handling to prevent extra padding
++    // when using 3-button navigation (navigation bar visible)
++    setOnApplyWindowInsetsListener(null)
++  }
++
+   override fun getMaxItemCount(): Int {
+     return 100
+   }
+@@ -227,6 +233,17 @@ class ReactBottomNavigationView(context: Context) : LinearLayout(context) {
      } else {
        bottomNavigation.visibility = VISIBLE
      }


### PR DESCRIPTION
## Summary
- Disable automatic window insets handling in `BottomNavigationView` by calling `setOnApplyWindowInsetsListener(null)`
- Fixes extra bottom padding when using 3-button navigation (system navigation bar visible) on Android

## Root Cause
Material `BottomNavigationView` automatically handles system navigation bar insets. When using 3-button navigation mode, the navigation bar is visible, and `BottomNavigationView` adds bottom padding to avoid content overlap. This caused unwanted extra padding in our tab bar.

## Solution
Disable automatic insets handling in `ExtendedBottomNavigationView` init block:
```kotlin
init {
  setOnApplyWindowInsetsListener(null)
}
```

## Test plan
- [ ] Test on Android device with 3-button navigation mode
- [ ] Verify tab bar no longer has extra bottom padding
- [ ] Test on Android device with gesture navigation to ensure no regression
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/9960">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
