### PR TITLE
fix(swap): add safe area bottom padding to history list (OK-49792)

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapMarketHistoryList.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMarketHistoryList.tsx
@@ -11,6 +11,7 @@ import {
   Stack,
   XStack,
   YStack,
+  useSafeAreaInsets,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
@@ -52,6 +53,7 @@ const SwapMarketHistoryList = ({
   isPushModal,
 }: ISwapMarketHistoryListProps) => {
   const intl = useIntl();
+  const { bottom } = useSafeAreaInsets();
   const [{ swapHistoryPendingList }] = useInAppNotificationAtom();
   const [{ swapHistoryAlertDismissed }] = useNotificationsAtom();
   const navigation =
@@ -230,6 +232,7 @@ const SwapMarketHistoryList = ({
           })}
         />
       }
+      ListFooterComponent={<Stack h={bottom || '$2'} />}
     />
   );
 };


### PR DESCRIPTION
The last item in the swap history list was being cut off on mobile devices because the SectionList did not account for the bottom safe area inset.

Added ListFooterComponent with safe area bottom padding to ensure all items are visible and scrollable.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/9965">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
