### PR TITLE
fix: reconnect WebSocket when resuming from background on iOS

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -326,7 +326,17 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   async resumeSubscriptions(): Promise<void> {
     await this.enableSubscriptionsHandler();
     console.log('updateSubscriptions__by__resumeSubscriptions');
+
+    // Reconnect if socket is CLOSED (iOS closes WebSocket when app is in background)
+    const client = await this.getWebSocketClient();
+    if (client?.transport?.socket?.readyState === WebSocket.CLOSED) {
+      console.log('resumeSubscriptions__reconnecting_closed_socket');
+      await this.disconnect();
+      await this.getWebSocketClient();
+    }
+
     await this.updateSubscriptions();
+
     const hookInfo = await perpsCandlesWebviewReloadHookAtom.get();
     if (hookInfo.reloadHook <= -1) {
       await perpsCandlesWebviewReloadHookAtom.set({

--- a/packages/kit/src/views/Perp/components/PerpMobileNetworkAlert.tsx
+++ b/packages/kit/src/views/Perp/components/PerpMobileNetworkAlert.tsx
@@ -6,7 +6,8 @@ import { Alert, SizableText } from '@onekeyhq/components';
 import { usePerpsNetworkStatusAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
-const ALERT_SHOW_DELAY_MS = 1500;
+// Delay to allow WebSocket auto-reconnection before showing alert
+const ALERT_SHOW_DELAY_MS = 5000;
 
 function PerpMobileNetworkAlertComponent() {
   const intl = useIntl();


### PR DESCRIPTION
## Summary
- Check if WebSocket is in CLOSED state when resuming subscriptions and reconnect if needed (iOS closes WebSocket when app is in background)
- Increase network alert delay from 1500ms to 5000ms to allow WebSocket auto-reconnection before showing alert

## Test plan
- [ ] Test on iOS: Put app in background, wait for WebSocket to close, then resume and verify reconnection works
- [ ] Verify network alert doesn't show unnecessarily during normal reconnection
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/9978">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
