### PR TITLE
fix: enable swipe-back gesture for onboarding screens on iOS

### DIFF
--- a/packages/components/src/layouts/Navigation/GlobalScreenOptions.native.ts
+++ b/packages/components/src/layouts/Navigation/GlobalScreenOptions.native.ts
@@ -173,7 +173,7 @@ export function makeOnboardingScreenOptions(): IStackNavigationOptions {
   const options: IStackNavigationOptions = {
     headerShown: false,
     presentation: 'card',
-    gestureEnabled: false,
+    gestureEnabled: platformEnv.isNativeIOS,
     gestureDirection: 'horizontal',
     animation: 'slide_from_right',
   };


### PR DESCRIPTION
## Summary
- Enable iOS native swipe-back gesture on onboarding screens by setting `gestureEnabled` to `platformEnv.isNativeIOS` instead of `false`
- Android behavior remains unchanged (gesture stays disabled, animation set to `none`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/9979">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
