### PR TITLE
chore: add checkout step to code review skill workflow

### DIFF
--- a/.claude/skills/1k-code-review-pr/SKILL.md
+++ b/.claude/skills/1k-code-review-pr/SKILL.md
@@ -1057,20 +1057,21 @@ const amounts = userInput.split(',').map(v => {
 
 ## Review Workflow
 
-1. **Scope**: Run `git diff origin/x...HEAD --stat` to understand change scope
-2. **Files**: Check for accidental commits and generated file references
-3. **Scripts**: Review shell scripts for proper error handling and placeholders
-4. **CI**: Verify CI workflows have appropriate verification steps
-5. **Hooks**: Check React hooks for dependency issues, memory leaks, infinite loops
-6. **Requests**: Verify concurrent/sequential request handling is optimized
-7. **Dependencies**: Check for deprecated packages in new dependencies
-8. **Errors**: Ensure proper error handling with user feedback
-9. **Null Safety**: Check for missing null/undefined guards
-10. **Race Conditions**: Look for Fabric race conditions, cleanup issues
-11. **Platform**: Check Android/iOS specific crash patterns
-12. **Type Safety**: Verify numeric types before BigNumber/decimal operations
-13. **Stale Data**: Check for cache clearing on context switches
-14. **Debounce**: Verify debounced async functions return proper promises
-15. **Security**: Review security aspects for bulk/batch operations
-16. **Docs**: Ensure PR description matches actual changes
-17. **Report**: Generate structured report with priorities and fix suggestions
+1. **Checkout**: Switch to the PR branch before reviewing: `gh pr checkout <PR_NUMBER>` (skip if already on the target branch)
+2. **Scope**: Run `git diff origin/x...HEAD --stat` to understand change scope
+3. **Files**: Check for accidental commits and generated file references
+4. **Scripts**: Review shell scripts for proper error handling and placeholders
+5. **CI**: Verify CI workflows have appropriate verification steps
+6. **Hooks**: Check React hooks for dependency issues, memory leaks, infinite loops
+7. **Requests**: Verify concurrent/sequential request handling is optimized
+8. **Dependencies**: Check for deprecated packages in new dependencies
+9. **Errors**: Ensure proper error handling with user feedback
+10. **Null Safety**: Check for missing null/undefined guards
+11. **Race Conditions**: Look for Fabric race conditions, cleanup issues
+12. **Platform**: Check Android/iOS specific crash patterns
+13. **Type Safety**: Verify numeric types before BigNumber/decimal operations
+14. **Stale Data**: Check for cache clearing on context switches
+15. **Debounce**: Verify debounced async functions return proper promises
+16. **Security**: Review security aspects for bulk/batch operations
+17. **Docs**: Ensure PR description matches actual changes
+18. **Report**: Generate structured report with priorities and fix suggestions


### PR DESCRIPTION
## Summary
- Add PR branch checkout (`gh pr checkout`) as the first step in the code review skill workflow
- Ensures reviews are performed against the correct branch diff rather than the current working branch

## Test plan
- [ ] Verify skill loads correctly with updated workflow steps
- [ ] Run `/1k-code-review-pr` on a PR to confirm checkout step is followed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/9980">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
