### PR TITLE
fix: hide scroll indicators on tab screens

### DIFF
--- a/packages/kit/src/components/ApprovalListView/index.tsx
+++ b/packages/kit/src/components/ApprovalListView/index.tsx
@@ -186,6 +186,7 @@ function ApprovalListViewCmp(props: IProps) {
     <ListComponent
       // @ts-ignore
       estimatedItemSize={tableLayout ? undefined : 60}
+      showsVerticalScrollIndicator={false}
       ref={ListComponentRef as any}
       nestedScrollEnabled={platformEnv.isNativeAndroid ? inTabList : false}
       refreshControl={

--- a/packages/kit/src/components/TokenListView/index.tsx
+++ b/packages/kit/src/components/TokenListView/index.tsx
@@ -628,6 +628,7 @@ function TokenListViewCmp(props: IProps) {
     <ListComponent
       // @ts-ignore
       estimatedItemSize={tableLayout ? undefined : 60}
+      showsVerticalScrollIndicator={false}
       refreshControl={
         onRefresh ? <PullToRefresh onRefresh={onRefresh} /> : undefined
       }

--- a/packages/kit/src/views/Borrow/pages/ReserveDetails/components/ReserveDetailsTabs.tsx
+++ b/packages/kit/src/views/Borrow/pages/ReserveDetails/components/ReserveDetailsTabs.tsx
@@ -110,7 +110,7 @@ const ReserveDetailsTabsComponent = ({
     >
       {/* Supply Info Tab */}
       <Tabs.Tab name={tabNames.supply}>
-        <Tabs.ScrollView>
+        <Tabs.ScrollView showsVerticalScrollIndicator={false}>
           <YStack px="$5" pt="$6" pb="$6" gap="$6">
             {supplyBadge ? <XStack>{supplyBadge}</XStack> : null}
 
@@ -148,7 +148,7 @@ const ReserveDetailsTabsComponent = ({
 
       {/* Borrow Info Tab */}
       <Tabs.Tab name={tabNames.borrow}>
-        <Tabs.ScrollView>
+        <Tabs.ScrollView showsVerticalScrollIndicator={false}>
           <YStack px="$5" pt="$6" pb="$6" gap="$6">
             {borrowBadge ? <XStack>{borrowBadge}</XStack> : null}
 
@@ -177,7 +177,7 @@ const ReserveDetailsTabsComponent = ({
 
       {/* More Tab */}
       <Tabs.Tab name={tabNames.more}>
-        <Tabs.ScrollView>
+        <Tabs.ScrollView showsVerticalScrollIndicator={false}>
           <YStack px="$5" pt="$6" pb="$6" gap="$8">
             <InterestRateModelSection
               networkId={networkId}

--- a/packages/kit/src/views/Earn/components/EarnMainTabs.tsx
+++ b/packages/kit/src/views/Earn/components/EarnMainTabs.tsx
@@ -60,7 +60,7 @@ const TabContentContainer = ({
 }) => {
   const tabBarHeight = useScrollContentTabBarOffset();
   return (
-    <Tabs.ScrollView>
+    <Tabs.ScrollView showsVerticalScrollIndicator={false}>
       <YStack
         pt="$6"
         pb="$6"

--- a/packages/kit/src/views/Home/components/NFTListView/index.tsx
+++ b/packages/kit/src/views/Home/components/NFTListView/index.tsx
@@ -200,6 +200,7 @@ function NFTListView(props: IProps) {
 
   return (
     <Tabs.FlatList
+      showsVerticalScrollIndicator={false}
       // @ts-ignore
       horizontalPadding={20}
       windowSize={platformEnv.isNativeAndroid ? 3 : undefined}

--- a/packages/kit/src/views/Home/pages/PortfolioContainer.tsx
+++ b/packages/kit/src/views/Home/pages/PortfolioContainer.tsx
@@ -86,6 +86,7 @@ function PortfolioContainerWithProvider() {
         <ProviderJotaiContextHistoryList>
           <ProviderJotaiContextEarn>
             <Tabs.ScrollView
+              showsVerticalScrollIndicator={false}
               contentContainerStyle={{ paddingBottom: tabBarHeight }}
               nestedScrollEnabled={platformEnv.isNativeAndroid}
               refreshControl={

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Holders/Holders.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Holders/Holders.tsx
@@ -54,6 +54,7 @@ function HoldersBase({ tokenAddress, networkId }: IHoldersProps) {
 
   return (
     <Tabs.FlatList<IMarketTokenHolder>
+      showsVerticalScrollIndicator={false}
       data={holders}
       contentContainerStyle={{
         paddingBottom: platformEnv.isNativeAndroid ? 84 : 16,
@@ -63,7 +64,6 @@ function HoldersBase({ tokenAddress, networkId }: IHoldersProps) {
         item.accountAddress + item.fiatValue + item.amount
       }
       windowSize={platformEnv.isNativeAndroid ? 3 : undefined}
-      showsVerticalScrollIndicator
       ListFooterComponent={ListFooterComponent}
       ListEmptyComponent={
         isRefreshing ? (

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/Portfolio.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/Portfolio.tsx
@@ -60,6 +60,7 @@ function PortfolioBase({
 
   return (
     <Tabs.FlatList<IMarketAccountPortfolioItem>
+      showsVerticalScrollIndicator={false}
       data={portfolioData}
       windowSize={platformEnv.isNativeAndroid ? 3 : undefined}
       contentContainerStyle={{
@@ -69,7 +70,6 @@ function PortfolioBase({
       keyExtractor={(item: IMarketAccountPortfolioItem) =>
         `${item.accountAddress}-${item.tokenAddress}`
       }
-      showsVerticalScrollIndicator
       ListEmptyComponent={
         isRefreshing ? (
           <PortfolioSkeleton />

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/TransactionsHistory.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/TransactionsHistory.tsx
@@ -123,6 +123,7 @@ export function TransactionsHistory({
 
   return (
     <Tabs.FlatList<IMarketTokenTransaction>
+      showsVerticalScrollIndicator={false}
       key={listKey}
       onEndReached={handleEndReached}
       onEndReachedThreshold={0.2}
@@ -130,7 +131,6 @@ export function TransactionsHistory({
       data={transactions}
       renderItem={renderItem}
       keyExtractor={keyExtractor}
-      showsVerticalScrollIndicator
       ListEmptyComponent={
         isRefreshing ? (
           <TransactionsSkeleton />

--- a/packages/kit/src/views/Market/MarketHomeV1/MarketHome.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV1/MarketHome.tsx
@@ -123,6 +123,7 @@ function MarketHome() {
               tab.page
             ) : (
               <Tabs.ScrollView
+                showsVerticalScrollIndicator={false}
                 scrollEnabled={false}
                 contentContainerStyle={{ overflow: 'hidden' }}
               >

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MobileMarketTokenFlatList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MobileMarketTokenFlatList.tsx
@@ -146,6 +146,7 @@ function MobileMarketTokenFlatListBase({
   const tabBarHeight = useScrollContentTabBarOffset();
   return (
     <Tabs.FlatList<IMarketToken>
+      showsVerticalScrollIndicator={false}
       data={loading ? EMPTY_DATA : data}
       renderItem={renderItem}
       keyExtractor={keyExtractor}
@@ -161,7 +162,6 @@ function MobileMarketTokenFlatListBase({
       ListHeaderComponent={ListHeaderComponent}
       ListFooterComponent={ListFooterComponent}
       ListEmptyComponent={ListEmptyComponent}
-      showsVerticalScrollIndicator
       contentContainerStyle={{
         paddingTop: 8 + (platformEnv.isNative ? 170 : 0),
         paddingBottom: platformEnv.isNativeAndroid

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
@@ -92,7 +92,7 @@ function MobileLayoutComponent({
       {...containerProps}
     >
       <Tabs.Tab name={watchlistTabName}>
-        <Tabs.ScrollView>
+        <Tabs.ScrollView showsVerticalScrollIndicator={false}>
           <YStack pt="$2" {...listContainerProps}>
             <MarketWatchlistTokenList />
           </YStack>

--- a/packages/kit/src/views/Market/components/TokenDetailTabs.tsx
+++ b/packages/kit/src/views/Market/components/TokenDetailTabs.tsx
@@ -141,7 +141,9 @@ function BasicTokenDetailTabs({
     >
       {tabConfigs.map((tab) => (
         <Tabs.Tab key={tab.title} name={tab.title}>
-          <Tabs.ScrollView showsVerticalScrollIndicator={false}>{tab.page}</Tabs.ScrollView>
+          <Tabs.ScrollView showsVerticalScrollIndicator={false}>
+            {tab.page}
+          </Tabs.ScrollView>
         </Tabs.Tab>
       ))}
     </Tabs.Container>

--- a/packages/kit/src/views/Market/components/TokenDetailTabs.tsx
+++ b/packages/kit/src/views/Market/components/TokenDetailTabs.tsx
@@ -141,7 +141,7 @@ function BasicTokenDetailTabs({
     >
       {tabConfigs.map((tab) => (
         <Tabs.Tab key={tab.title} name={tab.title}>
-          <Tabs.ScrollView>{tab.page}</Tabs.ScrollView>
+          <Tabs.ScrollView showsVerticalScrollIndicator={false}>{tab.page}</Tabs.ScrollView>
         </Tabs.Tab>
       ))}
     </Tabs.Container>

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
@@ -430,6 +430,7 @@ export function CommonTableListView<T>({
     const ListContent = (
       <DebugRenderTracker {...listViewDebugRenderTrackerProps}>
         <ListComponent
+          showsVerticalScrollIndicator={false}
           refreshControl={
             shouldUseTabsList && onPullToRefresh ? (
               <PullToRefresh onRefresh={onPullToRefresh} />
@@ -571,6 +572,7 @@ export function CommonTableListView<T>({
   return (
     <YStack flex={1}>
       <Tabs.ScrollView
+        showsVerticalScrollIndicator={false}
         style={{
           flex: 1,
         }}

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -449,7 +449,7 @@ function BasePerpTokenSelectorContent({
         isFavoritesTab && data.length === 0 && !searchQuery;
 
       return (
-        <Tabs.ScrollView>
+        <Tabs.ScrollView showsVerticalScrollIndicator={false}>
           <YStack>
             {!isFavoritesTab || data.length > 0 ? <TokenListHeader /> : null}
             <YStack height={350}>

--- a/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
+++ b/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
@@ -198,7 +198,7 @@ function MobilePerpMarket() {
               renderTabBar={() => null}
             >
               <Tabs.Tab name="orderbook">
-                <Tabs.ScrollView>{orderBookContent}</Tabs.ScrollView>
+                <Tabs.ScrollView showsVerticalScrollIndicator={false}>{orderBookContent}</Tabs.ScrollView>
               </Tabs.Tab>
             </Tabs.Container>
           </YStack>

--- a/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
+++ b/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
@@ -198,7 +198,9 @@ function MobilePerpMarket() {
               renderTabBar={() => null}
             >
               <Tabs.Tab name="orderbook">
-                <Tabs.ScrollView showsVerticalScrollIndicator={false}>{orderBookContent}</Tabs.ScrollView>
+                <Tabs.ScrollView showsVerticalScrollIndicator={false}>
+                  {orderBookContent}
+                </Tabs.ScrollView>
               </Tabs.Tab>
             </Tabs.Container>
           </YStack>

--- a/packages/kit/src/views/ReferFriends/pages/YourReferred/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/YourReferred/index.tsx
@@ -219,7 +219,7 @@ function YourReferredPageWrapper() {
                 id: ETranslations.global_wallet,
               })}
             >
-              <Tabs.ScrollView contentContainerStyle={{ paddingBottom: 40 }}>
+              <Tabs.ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={{ paddingBottom: 40 }}>
                 <WalletList />
               </Tabs.ScrollView>
             </Tabs.Tab>
@@ -228,7 +228,7 @@ function YourReferredPageWrapper() {
                 id: ETranslations.referral_referred_type_3,
               })}
             >
-              <Tabs.ScrollView contentContainerStyle={{ paddingBottom: 40 }}>
+              <Tabs.ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={{ paddingBottom: 40 }}>
                 <HardwareSales />
               </Tabs.ScrollView>
             </Tabs.Tab>

--- a/packages/kit/src/views/ReferFriends/pages/YourReferred/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/YourReferred/index.tsx
@@ -219,7 +219,10 @@ function YourReferredPageWrapper() {
                 id: ETranslations.global_wallet,
               })}
             >
-              <Tabs.ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={{ paddingBottom: 40 }}>
+              <Tabs.ScrollView
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={{ paddingBottom: 40 }}
+              >
                 <WalletList />
               </Tabs.ScrollView>
             </Tabs.Tab>
@@ -228,7 +231,10 @@ function YourReferredPageWrapper() {
                 id: ETranslations.referral_referred_type_3,
               })}
             >
-              <Tabs.ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={{ paddingBottom: 40 }}>
+              <Tabs.ScrollView
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={{ paddingBottom: 40 }}
+              >
                 <HardwareSales />
               </Tabs.ScrollView>
             </Tabs.Tab>


### PR DESCRIPTION
## Summary
- Add `showsVerticalScrollIndicator={false}` to all `Tabs.FlatList` and `Tabs.ScrollView` usages across tab screens
- Covers Home, Market, Earn, Perp, Borrow, ReferFriends, and shared list components (TokenListView, ApprovalListView)

## Test plan
- [ ] Verify scroll indicators are hidden on Home tab (Portfolio, NFT list)
- [ ] Verify scroll indicators are hidden on Market tab (token list, watchlist, detail tabs)
- [ ] Verify scroll indicators are hidden on Earn, Perp, Borrow tab screens
- [ ] Verify scrolling behavior is not affected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/9982">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
