### PR TITLE
fix: resolve mobile tab bar height collapse on web platform

### DIFF
--- a/packages/components/src/layouts/Navigation/Tab/TabBar/MobileBottomTabBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/MobileBottomTabBar.tsx
@@ -120,13 +120,16 @@ export default function MobileBottomTabBar({
           }
         };
 
-        const renderItemContent = (renderActive: boolean) => (
+        const renderItemContent = (
+          renderActive: boolean,
+          isOverlay: boolean,
+        ) => (
           <MobileTabItem
             testID="Mobile-AppTabBar-TabItem-Icon"
             // @ts-expect-error
             icon={options?.tabBarIcon?.(renderActive) as IKeyOfIcons}
             label={options?.tabBarLabel as string}
-            style={[StyleSheet.absoluteFill]}
+            {...(isOverlay && { style: [StyleSheet.absoluteFill] })}
             selected={renderActive}
             {...(!(isActive === renderActive) && {
               opacity: 0,
@@ -141,8 +144,8 @@ export default function MobileBottomTabBar({
             key={route.name}
             onPress={onPress}
           >
-            {renderItemContent(false)}
-            {renderItemContent(true)}
+            {renderItemContent(false, false)}
+            {renderItemContent(true, true)}
           </Stack>
         );
       }),


### PR DESCRIPTION
## Summary
- Fix MobileBottomTabBar not visible on web due to zero height
- All `MobileTabItem` children used `StyleSheet.absoluteFill`, causing the parent container to collapse to 0px height on web (absolute elements don't contribute to parent layout in CSS)
- Make the first (inactive) item use relative positioning to establish container height, while keeping the second (active) item as an absolute overlay

## Test plan
- [ ] Verify tab bar is visible on web at `md` breakpoint (mobile layout)
- [ ] Verify tab bar still works correctly on native iOS/Android
- [ ] Verify active/inactive tab states display correctly with proper opacity transitions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/9998">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
