### PR TITLE
fix(Market): adjust banner skeleton count for different screen sizes

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerList.tsx
@@ -37,7 +37,8 @@ function MarketBannerListSkeletonComponent({
 }: {
   isSmallScreen: boolean;
 }) {
-  const skeletonItems = [0, 1, 2].map((i) => (
+  const skeletonCount = isSmallScreen ? 3 : 7;
+  const skeletonItems = Array.from({ length: skeletonCount }, (_, i) => (
     <MarketBannerItemSkeleton key={i} />
   ));
 


### PR DESCRIPTION
## Summary
- Mobile: keep 3 skeleton items
- Desktop: show 7 skeleton items for better visual fill

## Test plan
- [ ] Verify mobile screen shows 3 banner skeletons during loading
- [ ] Verify desktop screen shows 7 banner skeletons during loading
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10004">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
