### PR TITLE
fix(sidebar): prevent i18n text overflow in collapsed desktop sidebar OK-49874

### DIFF
--- a/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
@@ -79,6 +79,7 @@ function TabItemView({
     () =>
       options.hideOnTabBar ? null : (
         <YStack
+          w="100%"
           ai="center"
           gap="$0.5"
           pt={6}
@@ -110,6 +111,9 @@ function TabItemView({
             cursor="default"
             color="$text"
             textAlign="center"
+            numberOfLines={2}
+            wordWrap="break-word"
+            maxWidth="100%"
           >
             {options.collapseTabBarLabel ?? options.tabBarLabel ?? route.name}
           </SizableText>


### PR DESCRIPTION
## Summary
- Add `numberOfLines={2}` and `wordWrap="break-word"` to collapsed sidebar text labels to prevent long translations (e.g., Portuguese "Encaminhamento") from overflowing the 72px sidebar width
- Add `w="100%"` and `maxWidth="100%"` constraints so text wrapping has a boundary to break on

## Test plan
- [ ] Switch language to Portuguese (pt-BR) and verify sidebar labels like "Encaminhamento" and "Dispositivo" wrap correctly within the sidebar
- [ ] Verify English and other languages still display correctly
- [ ] Confirm no layout shift or visual regression in collapsed sidebar
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10011">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
