### PR TITLE
fix(bulk-send): desktop entry navigation broken after #9993

### DIFF
--- a/packages/kit/src/views/BulkSend/hooks/useNavigateToBulkSend.ts
+++ b/packages/kit/src/views/BulkSend/hooks/useNavigateToBulkSend.ts
@@ -6,10 +6,10 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   EModalBulkSendRoutes,
   EModalRoutes,
+  ERootRoutes,
   ETabHomeRoutes,
   ETabRoutes,
 } from '@onekeyhq/shared/src/routes';
-import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import type { IToken } from '@onekeyhq/shared/types/token';
 import { rootNavigationRef, useMedia } from '@onekeyhq/components';
 
@@ -45,14 +45,24 @@ export function useNavigateToBulkSend() {
           },
         });
       } else if (media.gtMd) {
-        navigation.switchTab(ETabRoutes.Home);
-        await timerUtils.wait(150);
-        rootNavigationRef.current?.navigate(ETabHomeRoutes.TabHomeBulkSendAddressesInput, {
-          networkId,
-          accountId,
-          indexedAccountId,
-          tokenInfo,
-        });
+        rootNavigationRef.current?.navigate(
+          ERootRoutes.Main,
+          {
+            screen: ETabRoutes.Home,
+            params: {
+              screen: ETabHomeRoutes.TabHomeBulkSendAddressesInput,
+              params: {
+                networkId,
+                accountId,
+                indexedAccountId,
+                tokenInfo,
+              },
+            },
+          },
+          {
+            pop: true,
+          },
+        );
       } else {
         navigation.pushModal(EModalRoutes.BulkSendModal, {
           screen: EModalBulkSendRoutes.BulkSendAddressesInput,


### PR DESCRIPTION
## Summary
- Fix Bulk Send entry click doing nothing on desktop (only switches to Home tab without opening BulkSendAddressesInput)
- Root cause: PR #9993 replaced `switchTab(Home, { screen })` with `switchTab + wait + navigation.push()`, but `navigation.push()` uses the Popover's local navigation context which cannot resolve tab-nested routes
- Fix: use `rootNavigationRef` with full route path (`Main > Home > TabHomeBulkSendAddressesInput`) to navigate reliably, matching `switchTab`'s internal pattern

## Test plan
- [ ] Desktop: click Bulk Send in MoreAction popover → should open BulkSendAddressesInput page
- [ ] Mobile: click Bulk Send → should open modal as before (unchanged path)
- [ ] Extension: click Bulk Send → should open expand tab (unchanged path)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
