### PR TITLE
fix: upgrade electron to 39.5.1 to fix macOS rendering glitches

### DIFF
--- a/.claude/skills/1k-platform-requirements/SKILL.md
+++ b/.claude/skills/1k-platform-requirements/SKILL.md
@@ -110,7 +110,7 @@ Firefox manifest extends Chrome manifest but may have different requirements. Cu
 grep '"electron":' apps/desktop/package.json
 ```
 
-**Current version**: Electron 39.3.0
+**Current version**: Electron 39.5.1
 
 **Electron 39 OS Requirements**:
 - macOS: 10.15+ (Catalina)

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -67,7 +67,7 @@
     "@types/node-fetch": "^2.6.1",
     "concurrently": "9.2.1",
     "cross-env": "7.0.3",
-    "electron": "39.3.0",
+    "electron": "39.5.1",
     "electron-builder": "26.4.0",
     "esbuild": "0.27.2",
     "folderslint": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -350,7 +350,7 @@
     "@metamask/eth-sig-util": "5.1.0",
     "@polkadot/api": "14.3.1",
     "@polkadot/util": "13.2.3",
-    "electron": "39.3.0",
+    "electron": "39.5.1",
     "@walletconnect/core": "2.21.7",
     "@walletconnect/utils": "2.21.7",
     "@walletconnect/types": "2.21.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8805,7 +8805,7 @@ __metadata:
     adm-zip: "npm:^0.5.10"
     concurrently: "npm:9.2.1"
     cross-env: "npm:7.0.3"
-    electron: "npm:39.3.0"
+    electron: "npm:39.5.1"
     electron-builder: "npm:26.4.0"
     electron-check-biometric-auth-changed: "npm:1.0.0"
     electron-context-menu: "npm:^3.5.0"
@@ -24623,16 +24623,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:39.3.0":
-  version: 39.3.0
-  resolution: "electron@npm:39.3.0"
+"electron@npm:39.5.1":
+  version: 39.5.1
+  resolution: "electron@npm:39.5.1"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^22.7.7"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/dce02b92ce238999b25b1a0c5c16b1c556c668053fa4f53b31fec8783013677c33b4c604cf321df84648ebf2699e9fcfed3513f587e39dea6e2e47bd8df6b47d
+  checksum: 10/bdc7addd81321f06d03f0ad636d4c6ffd3a90d2a5243851b0be500432d6b8ed195b83ed353763d22d31c2d812070b16f4039972654e3cbbf1e25ec0c969fb5ed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Upgrade Electron from 39.3.0 to 39.5.1
- Fixes Skia Graphite out-of-order recording errors that cause rendering glitches on macOS (electron/electron#49615)
- Updated platform requirements skill doc to reflect the new version

## Test plan
- [ ] Verify desktop app builds successfully with Electron 39.5.1
- [ ] Test on macOS to confirm rendering glitches are resolved
- [ ] Verify no regressions on Windows and Linux
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
