### PR TITLE
feat(logger): add txnParseType and txnOrigin to send events

### DIFF
--- a/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmActions/TxConfirmActions.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmActions/TxConfirmActions.tsx
@@ -180,8 +180,8 @@ function TxConfirmActions(props: IProps) {
         unsignedTxs,
         nativeAmountInfo: nativeTokenTransferAmountToUpdate.isMaxSend
           ? {
-              maxSendAmount: nativeTokenTransferAmountToUpdate.amountToUpdate,
-            }
+            maxSendAmount: nativeTokenTransferAmountToUpdate.amountToUpdate,
+          }
           : undefined,
         precheckTiming: ESendPreCheckTimingEnum.Confirm,
         feeInfos: sendSelectedFeeInfo?.feeInfos,
@@ -240,8 +240,8 @@ function TxConfirmActions(props: IProps) {
           : nonceInfo,
         nativeAmountInfo: nativeTokenTransferAmountToUpdate.isMaxSend
           ? {
-              maxSendAmount: nativeTokenTransferAmountToUpdate.amountToUpdate,
-            }
+            maxSendAmount: nativeTokenTransferAmountToUpdate.amountToUpdate,
+          }
           : undefined,
         feeInfoEditable,
         tronResourceRentalInfo,
@@ -297,7 +297,7 @@ function TxConfirmActions(props: IProps) {
           replaceTxInfo = {
             replaceType:
               new BigNumber(encodedTx.value).isZero() &&
-              checkIsEmptyData(encodedTx.data)
+                checkIsEmptyData(encodedTx.data)
                 ? EReplaceTxType.Cancel
                 : EReplaceTxType.SpeedUp,
             replaceHistoryId: localPendingTxWithSameNonce.id,
@@ -339,6 +339,8 @@ function TxConfirmActions(props: IProps) {
           swapInfo,
           stakingInfo,
         }),
+        txnParseType: isUndefined(result?.[0].decodedTx.txParseType) ? undefined : result?.[0].decodedTx.txParseType,
+        txnOrigin: isUndefined(sourceInfo?.origin) ? undefined : sourceInfo.origin,
         feeToken: isUndefined(sendSelectedFeeInfo?.feeInfos?.[0]?.totalNative)
           ? undefined
           : `${sendSelectedFeeInfo?.feeInfos?.[0]?.totalNative} ${nativeTokenInfo.info?.symbol}`,

--- a/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmActions/TxConfirmActions.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmActions/TxConfirmActions.tsx
@@ -180,8 +180,8 @@ function TxConfirmActions(props: IProps) {
         unsignedTxs,
         nativeAmountInfo: nativeTokenTransferAmountToUpdate.isMaxSend
           ? {
-            maxSendAmount: nativeTokenTransferAmountToUpdate.amountToUpdate,
-          }
+              maxSendAmount: nativeTokenTransferAmountToUpdate.amountToUpdate,
+            }
           : undefined,
         precheckTiming: ESendPreCheckTimingEnum.Confirm,
         feeInfos: sendSelectedFeeInfo?.feeInfos,
@@ -240,8 +240,8 @@ function TxConfirmActions(props: IProps) {
           : nonceInfo,
         nativeAmountInfo: nativeTokenTransferAmountToUpdate.isMaxSend
           ? {
-            maxSendAmount: nativeTokenTransferAmountToUpdate.amountToUpdate,
-          }
+              maxSendAmount: nativeTokenTransferAmountToUpdate.amountToUpdate,
+            }
           : undefined,
         feeInfoEditable,
         tronResourceRentalInfo,
@@ -297,7 +297,7 @@ function TxConfirmActions(props: IProps) {
           replaceTxInfo = {
             replaceType:
               new BigNumber(encodedTx.value).isZero() &&
-                checkIsEmptyData(encodedTx.data)
+              checkIsEmptyData(encodedTx.data)
                 ? EReplaceTxType.Cancel
                 : EReplaceTxType.SpeedUp,
             replaceHistoryId: localPendingTxWithSameNonce.id,
@@ -339,8 +339,12 @@ function TxConfirmActions(props: IProps) {
           swapInfo,
           stakingInfo,
         }),
-        txnParseType: isUndefined(result?.[0].decodedTx.txParseType) ? undefined : result?.[0].decodedTx.txParseType,
-        txnOrigin: isUndefined(sourceInfo?.origin) ? undefined : sourceInfo.origin,
+        txnParseType: isUndefined(result?.[0].decodedTx.txParseType)
+          ? undefined
+          : result?.[0].decodedTx.txParseType,
+        txnOrigin: isUndefined(sourceInfo?.origin)
+          ? undefined
+          : sourceInfo.origin,
         feeToken: isUndefined(sendSelectedFeeInfo?.feeInfos?.[0]?.totalNative)
           ? undefined
           : `${sendSelectedFeeInfo?.feeInfos?.[0]?.totalNative} ${nativeTokenInfo.info?.symbol}`,

--- a/packages/shared/src/logger/scopes/transaction/scenes/send.ts
+++ b/packages/shared/src/logger/scopes/transaction/scenes/send.ts
@@ -1,7 +1,7 @@
-import type { EUtxoSelectionStrategy } from "@onekeyhq/shared/types/send";
+import type { EUtxoSelectionStrategy } from '@onekeyhq/shared/types/send';
 
-import { BaseScene } from "../../../base/baseScene";
-import { LogToLocal, LogToServer } from "../../../base/decorators";
+import { BaseScene } from '../../../base/baseScene';
+import { LogToLocal, LogToServer } from '../../../base/decorators';
 
 export class SendScene extends BaseScene {
   @LogToLocal()
@@ -88,7 +88,11 @@ export class SendScene extends BaseScene {
   }
 
   @LogToServer()
-  public addressInput({ addressInputMethod }: { addressInputMethod: string | undefined }) {
+  public addressInput({
+    addressInputMethod,
+  }: {
+    addressInputMethod: string | undefined;
+  }) {
     return {
       addressInputMethod,
     };

--- a/packages/shared/src/logger/scopes/transaction/scenes/send.ts
+++ b/packages/shared/src/logger/scopes/transaction/scenes/send.ts
@@ -1,7 +1,7 @@
-import type { EUtxoSelectionStrategy } from '@onekeyhq/shared/types/send';
+import type { EUtxoSelectionStrategy } from "@onekeyhq/shared/types/send";
 
-import { BaseScene } from '../../../base/baseScene';
-import { LogToLocal, LogToServer } from '../../../base/decorators';
+import { BaseScene } from "../../../base/baseScene";
+import { LogToLocal, LogToServer } from "../../../base/decorators";
 
 export class SendScene extends BaseScene {
   @LogToLocal()
@@ -88,11 +88,7 @@ export class SendScene extends BaseScene {
   }
 
   @LogToServer()
-  public addressInput({
-    addressInputMethod,
-  }: {
-    addressInputMethod: string | undefined;
-  }) {
+  public addressInput({ addressInputMethod }: { addressInputMethod: string | undefined }) {
     return {
       addressInputMethod,
     };
@@ -108,6 +104,8 @@ export class SendScene extends BaseScene {
     tokenAddress,
     feeToken,
     feeFiatValue,
+    txnParseType,
+    txnOrigin,
     tronIsResourceRentalNeeded,
     tronIsResourceRentalEnabled,
     tronIsSwapTrxEnabled,
@@ -118,6 +116,8 @@ export class SendScene extends BaseScene {
   }: {
     network: string | undefined;
     txnType: string | undefined;
+    txnParseType: string | undefined;
+    txnOrigin: string | undefined;
     interactContract: string | undefined;
     tokenType: string | undefined;
     tokenSymbol: string | undefined;
@@ -135,6 +135,8 @@ export class SendScene extends BaseScene {
     return {
       network,
       txnType,
+      txnParseType,
+      txnOrigin,
       interactContract,
       tokenType,
       tokenSymbol,


### PR DESCRIPTION
Add transaction parse type and origin tracking to send confirmation logging for improved analytics and debugging capabilities.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
