### PR TITLE
fix: resolve firmware update dialog continue button not responding

### DIFF
--- a/packages/kit/src/views/FirmwareUpdate/components/FirmwareChangeLogView.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/components/FirmwareChangeLogView.tsx
@@ -71,10 +71,10 @@ function ChangeLogSection({
   title: string;
   accordionValue: string;
   updateInfo:
-    | IFirmwareUpdateInfo
-    | IBleFirmwareUpdateInfo
-    | IBootloaderUpdateInfo
-    | undefined;
+  | IFirmwareUpdateInfo
+  | IBleFirmwareUpdateInfo
+  | IBootloaderUpdateInfo
+  | undefined;
 }) {
   return (
     <Accordion.Item value={accordionValue}>
@@ -289,11 +289,7 @@ export function FirmwareChangeLogView({
   const [, setStepInfo] = useFirmwareUpdateStepInfoAtom();
   const { showCheckList } = useFirmwareUpdateActions();
 
-  const handleConfirmClick = useCallback(
-    async (
-      _close?: (extra?: { flag?: string }) => void,
-      _closePageStack?: (extra?: { flag?: string }) => void,
-    ) => {
+  const handleConfirmClick = useCallback(async () => {
       const isUSBDeviceAvailable =
         await backgroundApiProxy.serviceHardware.detectUSBDeviceAvailability();
       if (!isUSBDeviceAvailable) {

--- a/packages/kit/src/views/FirmwareUpdate/components/FirmwareChangeLogView.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/components/FirmwareChangeLogView.tsx
@@ -289,32 +289,38 @@ export function FirmwareChangeLogView({
   const [, setStepInfo] = useFirmwareUpdateStepInfoAtom();
   const { showCheckList } = useFirmwareUpdateActions();
 
-  const handleConfirmClick = useCallback(async () => {
-    const isUSBDeviceAvailable =
-      await backgroundApiProxy.serviceHardware.detectUSBDeviceAvailability();
-    if (!isUSBDeviceAvailable) {
-      Dialog.show({
-        icon: 'TypeCoutline',
-        title: intl.formatMessage({
-          id: ETranslations.upgrade_use_usb,
-        }),
-        description: intl.formatMessage({
-          id: ETranslations.upgrade_recommend_usb,
-        }),
-        onConfirmText: intl.formatMessage({
-          id: ETranslations.global_got_it,
-        }),
-        showCancelButton: false,
+  const handleConfirmClick = useCallback(
+    async (
+      _close?: (extra?: { flag?: string }) => void,
+      _closePageStack?: (extra?: { flag?: string }) => void,
+    ) => {
+      const isUSBDeviceAvailable =
+        await backgroundApiProxy.serviceHardware.detectUSBDeviceAvailability();
+      if (!isUSBDeviceAvailable) {
+        Dialog.show({
+          icon: 'TypeCoutline',
+          title: intl.formatMessage({
+            id: ETranslations.upgrade_use_usb,
+          }),
+          description: intl.formatMessage({
+            id: ETranslations.upgrade_recommend_usb,
+          }),
+          onConfirmText: intl.formatMessage({
+            id: ETranslations.global_got_it,
+          }),
+          showCancelButton: false,
+        });
+        return;
+      }
+      setStepInfo({
+        step: EFirmwareUpdateSteps.showCheckList,
+        payload: undefined,
       });
-      return;
-    }
-    setStepInfo({
-      step: EFirmwareUpdateSteps.showCheckList,
-      payload: undefined,
-    });
-    showCheckList({ result });
-    onConfirmClick?.();
-  }, [result, showCheckList, onConfirmClick, setStepInfo, intl]);
+      showCheckList({ result });
+      onConfirmClick?.();
+    },
+    [result, showCheckList, onConfirmClick, setStepInfo, intl],
+  );
 
   const updateFirmwareInfo = result?.updateInfos?.firmware;
 

--- a/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateCheckList.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateCheckList.tsx
@@ -141,20 +141,27 @@ export function FirmwareUpdateCheckList({
                     firmwareVersions: parseFirmwareVersions(result),
                   });
 
+                  // Prepare update workflow based on firmware version
                   if (useV2FirmwareUpdateFlow) {
                     await backgroundApiProxy.serviceFirmwareUpdate.clearHardwareUiStateBeforeStartUpdateWorkflow();
                     navigation.push(EModalFirmwareUpdateRoutes.InstallV2, {
                       result,
                     });
-                    await dialog.close();
+                  } else {
+                    navigation.push(EModalFirmwareUpdateRoutes.Install, {
+                      result,
+                    });
+                  }
 
-                    // Wait for React Native Fabric to complete view cleanup
-                    // This prevents RetryableMountingLayerException during rapid navigation
-                    await timerUtils.wait(150);
+                  // Close dialog and wait for cleanup
+                  await dialog.close();
+                  await timerUtils.wait(150);
 
-                    if (!isMountedRef.current) return;
+                  if (!isMountedRef.current) return;
 
-                    setWorkflowIsRunning(true);
+                  // Start update workflow
+                  setWorkflowIsRunning(true);
+                  if (useV2FirmwareUpdateFlow) {
                     await backgroundApiProxy.serviceFirmwareUpdate.startUpdateWorkflowV2(
                       {
                         backuped: true,
@@ -163,18 +170,6 @@ export function FirmwareUpdateCheckList({
                       },
                     );
                   } else {
-                    navigation.push(EModalFirmwareUpdateRoutes.Install, {
-                      result,
-                    });
-                    await dialog.close();
-
-                    // Wait for React Native Fabric to complete view cleanup
-                    // This prevents RetryableMountingLayerException during rapid navigation
-                    await timerUtils.wait(150);
-
-                    if (!isMountedRef.current) return;
-
-                    setWorkflowIsRunning(true);
                     await backgroundApiProxy.serviceFirmwareUpdate.startUpdateWorkflow(
                       {
                         backuped: true,

--- a/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateCheckList.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateCheckList.tsx
@@ -127,14 +127,6 @@ export function FirmwareUpdateCheckList({
 
                 const updateFirmwareInfo = result?.updateInfos?.firmware;
                 try {
-                  await dialog.close();
-
-                  // Wait for React Native Fabric to complete view cleanup
-                  // This prevents RetryableMountingLayerException during rapid navigation
-                  await timerUtils.wait(150);
-
-                  if (!isMountedRef.current) return;
-
                   setStepInfo({
                     step: EFirmwareUpdateSteps.updateStart,
                     payload: {
@@ -154,6 +146,14 @@ export function FirmwareUpdateCheckList({
                     navigation.push(EModalFirmwareUpdateRoutes.InstallV2, {
                       result,
                     });
+                    await dialog.close();
+
+                    // Wait for React Native Fabric to complete view cleanup
+                    // This prevents RetryableMountingLayerException during rapid navigation
+                    await timerUtils.wait(150);
+
+                    if (!isMountedRef.current) return;
+
                     setWorkflowIsRunning(true);
                     await backgroundApiProxy.serviceFirmwareUpdate.startUpdateWorkflowV2(
                       {
@@ -166,6 +166,14 @@ export function FirmwareUpdateCheckList({
                     navigation.push(EModalFirmwareUpdateRoutes.Install, {
                       result,
                     });
+                    await dialog.close();
+
+                    // Wait for React Native Fabric to complete view cleanup
+                    // This prevents RetryableMountingLayerException during rapid navigation
+                    await timerUtils.wait(150);
+
+                    if (!isMountedRef.current) return;
+
                     setWorkflowIsRunning(true);
                     await backgroundApiProxy.serviceFirmwareUpdate.startUpdateWorkflow(
                       {

--- a/packages/kit/src/views/FirmwareUpdate/hooks/useFirmwareUpdateActions.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/hooks/useFirmwareUpdateActions.tsx
@@ -279,13 +279,13 @@ export function useFirmwareUpdateActions() {
         });
       }
 
-      Dialog.confirm({
+      Dialog.show({
         title,
         icon: 'ChecklistOutline',
         renderContent: <FirmwareUpdateCheckList result={result} />,
-        onConfirmText: intl.formatMessage({
-          id: ETranslations.global_continue,
-        }),
+        dismissOnOverlayPress: false,
+        showExitButton: false,
+        showFooter: false,
       });
     },
     [intl],


### PR DESCRIPTION
## Summary

Fixed an issue where clicking the "Continue" button in the firmware update checklist dialog had no response when switching firmware types (e.g., Bitcoin-Only → Universal).

## Root Cause

1. **Dual footer conflict**: `Dialog.confirm()` auto-generated an external footer that conflicted with `FirmwareUpdateCheckList`'s internal `Dialog.Footer`
2. **Component unmounting too early**: `dialog.close()` was called before navigation, causing the component to unmount and preventing subsequent code execution

## Solution

1. Changed `Dialog.confirm()` to `Dialog.show()` with `showFooter: false` to use only the internal footer from `FirmwareUpdateCheckList`
2. Adjusted execution order: navigation first, then dialog close, to ensure the update workflow continues even after component unmounts
3. Added `dismissOnOverlayPress: false` to prevent accidental dialog dismissal
4. Fixed function signature in `FirmwareChangeLogView` for type safety

## Files Changed

- `packages/kit/src/views/FirmwareUpdate/hooks/useFirmwareUpdateActions.tsx` - Changed Dialog.confirm to Dialog.show with internal footer control
- `packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateCheckList.tsx` - Adjusted execution order: navigation before dialog close
- `packages/kit/src/views/FirmwareUpdate/components/FirmwareChangeLogView.tsx` - Added function parameters for type compatibility

## Testing

✅ Firmware type switching flow:
1. Click "Update now" → Shows checklist dialog
2. Check all items → "Continue" button becomes enabled
3. Click "Continue" → Successfully navigates to firmware update page
4. Update workflow executes correctly

## Architecture Improvement

The change improves code clarity by making footer responsibility explicit:
- **Before**: Footer behavior controlled by mixed props (external + internal via Context)
- **After**: Footer completely controlled by internal component, clearer ownership
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
