### PR TITLE
fix(firmware): allow update workflow to continue after component unmounts

### DIFF
--- a/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateCheckList.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateCheckList.tsx
@@ -133,7 +133,8 @@ export function FirmwareUpdateCheckList({
                   // This prevents RetryableMountingLayerException during rapid navigation
                   await timerUtils.wait(150);
 
-                  if (!isMountedRef.current) return;
+                  // Allow workflow to continue even if component unmounts
+                  // The workflow runs in background service and doesn't depend on component lifecycle
 
                   setStepInfo({
                     step: EFirmwareUpdateSteps.updateStart,


### PR DESCRIPTION
## Summary
- Remove `isMountedRef` checks in firmware update workflow that were blocking the process from completing when the component unmounts
- The workflow runs in background service and doesn't depend on component lifecycle, so these checks were causing unnecessary interruptions
- Keep the check in `finally` block for `setWorkflowIsRunning` state management

## Test plan
- [ ] Start firmware update process
- [ ] Navigate away from the update screen during the process
- [ ] Verify the update continues and completes successfully
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
