### PR TITLE
fix(bulkSend): bulk send improvements (OK-49939 OK-49938 OK-49910)

### DIFF
--- a/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/ReceiverAddressesInput.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/ReceiverAddressesInput.tsx
@@ -69,9 +69,24 @@ function ReceiverAddressesInput({ maxLines }: IReceiverAddressesInputProps) {
         amount,
         allowZero: false,
         customErrorMessages: {
+          emptyAmount: intl.formatMessage({
+            id: ETranslations.wallet_bulk_send_error_invalid_amount,
+          }),
+          invalidAmount: intl.formatMessage({
+            id: ETranslations.wallet_bulk_send_error_invalid_amount,
+          }),
+          negativeAmount: intl.formatMessage({
+            id: ETranslations.wallet_bulk_send_error_amount_zero,
+          }),
           zeroAmount: intl.formatMessage({
             id: ETranslations.wallet_bulk_send_error_amount_zero,
           }),
+          decimalPlaces: intl.formatMessage(
+            {
+              id: ETranslations.wallet_bulk_send_error_max_decimal_places,
+            },
+            { decimals: selectedToken.decimals },
+          ),
         },
       });
 

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/components/AmountInput.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/components/AmountInput.tsx
@@ -81,6 +81,12 @@ export function SpecifiedAmountInput() {
           zeroAmount: intl.formatMessage({
             id: ETranslations.wallet_bulk_send_error_amount_zero,
           }),
+          decimalPlaces: intl.formatMessage(
+            {
+              id: ETranslations.wallet_bulk_send_error_max_decimal_places,
+            },
+            { decimals: tokenInfo.decimals },
+          ),
         },
       });
       setAmountInputErrors({
@@ -451,6 +457,12 @@ export function AmountInputSection({ inDialog }: { inDialog?: boolean }) {
         zeroAmount: intl.formatMessage({
           id: ETranslations.wallet_bulk_send_error_amount_zero,
         }),
+        decimalPlaces: intl.formatMessage(
+          {
+            id: ETranslations.wallet_bulk_send_error_max_decimal_places,
+          },
+          { decimals: tokenInfo.decimals },
+        ),
       },
     });
     return { specifiedAmount: error };

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/components/TableLayout.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/components/TableLayout.tsx
@@ -153,6 +153,12 @@ function AmountCard() {
               zeroAmount: intl.formatMessage({
                 id: ETranslations.wallet_bulk_send_error_amount_zero,
               }),
+              decimalPlaces: intl.formatMessage(
+                {
+                  id: ETranslations.wallet_bulk_send_error_max_decimal_places,
+                },
+                { decimals: tokenInfo.decimals },
+              ),
             },
           });
           if (!isValid && error) {
@@ -196,6 +202,12 @@ function AmountCard() {
           zeroAmount: intl.formatMessage({
             id: ETranslations.wallet_bulk_send_error_amount_zero,
           }),
+          decimalPlaces: intl.formatMessage(
+            {
+              id: ETranslations.wallet_bulk_send_error_max_decimal_places,
+            },
+            { decimals: tokenInfo.decimals },
+          ),
         },
       });
       setAmountInputErrors({ ...amountInputErrors, specifiedAmount: error });

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/components/useTransferInfoActions.ts
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/components/useTransferInfoActions.ts
@@ -1,12 +1,15 @@
 import { useCallback } from 'react';
 
+import { useIntl } from 'react-intl';
+
 import type { ITransferInfo } from '@onekeyhq/kit-bg/src/vaults/types';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { validateTokenAmount } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type {
   ITransferInfoError,
   ITransferInfoErrors,
 } from '@onekeyhq/shared/types/bulkSend';
 import type { IToken } from '@onekeyhq/shared/types/token';
-import { validateTokenAmount } from '@onekeyhq/shared/src/utils/tokenUtils';
 
 type IUseTransferInfoActionsParams = {
   tokenInfo: IToken;
@@ -23,6 +26,8 @@ export function useTransferInfoActions({
   transferInfoErrors,
   setTransferInfoErrors,
 }: IUseTransferInfoActionsParams) {
+  const intl = useIntl();
+
   const handleDeleteTransfer = useCallback(
     (index: number) => {
       const newTransfersInfo = [...transfersInfo];
@@ -66,7 +71,24 @@ export function useTransferInfoActions({
         amount: value,
         allowZero: false,
         customErrorMessages: {
-          zeroAmount: 'Amount must be greater than 0',
+          emptyAmount: intl.formatMessage({
+            id: ETranslations.wallet_bulk_send_error_invalid_amount,
+          }),
+          invalidAmount: intl.formatMessage({
+            id: ETranslations.wallet_bulk_send_error_invalid_amount,
+          }),
+          negativeAmount: intl.formatMessage({
+            id: ETranslations.wallet_bulk_send_error_amount_zero,
+          }),
+          zeroAmount: intl.formatMessage({
+            id: ETranslations.wallet_bulk_send_error_amount_zero,
+          }),
+          decimalPlaces: intl.formatMessage(
+            {
+              id: ETranslations.wallet_bulk_send_error_max_decimal_places,
+            },
+            { decimals: tokenInfo.decimals },
+          ),
         },
       });
       const newErrors = { ...transferInfoErrors };
@@ -86,6 +108,7 @@ export function useTransferInfoActions({
       setTransferInfoErrors(newErrors);
     },
     [
+      intl,
       transfersInfo,
       setTransfersInfo,
       tokenInfo,

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionBulkSend.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionBulkSend.tsx
@@ -1,0 +1,85 @@
+import { useCallback } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import { ActionList, Badge } from '@onekeyhq/components';
+import { useOneKeyAuth } from '@onekeyhq/kit/src/components/OneKeyAuth/useOneKeyAuth';
+import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import { EModalRoutes } from '@onekeyhq/shared/src/routes';
+import { EPrimeFeatures, EPrimePages } from '@onekeyhq/shared/src/routes/prime';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
+
+import { useNavigateToBulkSend } from '../../../BulkSend/hooks/useNavigateToBulkSend';
+
+export function WalletActionBulkSend({ onClose }: { onClose: () => void }) {
+  const intl = useIntl();
+  const navigation = useAppNavigation();
+  const { activeAccount } = useActiveAccount({ num: 0 });
+  const { network, account, indexedAccount } = activeAccount;
+
+  const { user } = useOneKeyAuth();
+  const isPrimeUser = user?.primeSubscription?.isActive && user?.onekeyUserId;
+
+  const navigateToBulkSend = useNavigateToBulkSend();
+
+  const handleBulkSend = useCallback(async () => {
+    onClose();
+    await timerUtils.wait(150);
+
+    if (!isPrimeUser) {
+      defaultLogger.prime.subscription.primeEntryClick({
+        featureName: EPrimeFeatures.BulkSend,
+        entryPoint: 'moreActions',
+      });
+      navigation.pushModal(EModalRoutes.PrimeModal, {
+        screen: EPrimePages.PrimeFeatures,
+        params: {
+          showAllFeatures: false,
+          selectedFeature: EPrimeFeatures.BulkSend,
+          selectedSubscriptionPeriod: 'P1Y',
+        },
+      });
+      return;
+    }
+
+    void navigateToBulkSend({
+      networkId: network?.id,
+      accountId: account?.id,
+      indexedAccountId: indexedAccount?.id,
+    });
+  }, [
+    onClose,
+    isPrimeUser,
+    navigateToBulkSend,
+    navigation,
+    network?.id,
+    account?.id,
+    indexedAccount?.id,
+  ]);
+
+  return (
+    <ActionList.Item
+      trackID="wallet-action-bulk-send"
+      icon="ChevronDoubleUpOutline"
+      label={intl.formatMessage({
+        id: ETranslations.wallet_bulk_send_title,
+      })}
+      onClose={() => {}}
+      onPress={handleBulkSend}
+      extra={
+        isPrimeUser ? null : (
+          <Badge badgeSize="sm" badgeType="default">
+            <Badge.Text size="$bodySmMedium">
+              {intl.formatMessage({
+                id: ETranslations.prime_status_prime,
+              })}
+            </Badge.Text>
+          </Badge>
+        )
+      }
+    />
+  );
+}

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionMore.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionMore.tsx
@@ -16,6 +16,7 @@ import { HomeTokenListProviderMirrorWrapper } from '../HomeTokenListProvider';
 
 import { RawActions } from './RawActions';
 import { useWalletActionConfig } from './useWalletActionConfig';
+import { WalletActionBulkSend } from './WalletActionBulkSend';
 import { WalletActionBuy } from './WalletActionBuy';
 import { WalletActionCopy } from './WalletActionCopy';
 import { WalletActionExport } from './WalletActionExport';
@@ -137,6 +138,13 @@ export function WalletActionMore() {
             case 'copy':
               return (
                 <WalletActionCopy key="copy" onClose={handleActionListClose} />
+              );
+            case 'bulkSend':
+              return (
+                <WalletActionBulkSend
+                  key="bulkSend"
+                  onClose={handleActionListClose}
+                />
               );
             case 'sign':
               return (

--- a/packages/kit/src/views/Home/components/WalletActions/networkConfigs.ts
+++ b/packages/kit/src/views/Home/components/WalletActions/networkConfigs.ts
@@ -17,7 +17,7 @@ const networkIds = getNetworkIdsMap();
 
 export const defaultWalletActionsConfig: INetworkWalletActionsConfig = {
   mainActions: ['send', 'receive', 'swap'],
-  moreActions: ['buy', 'sell', 'explorer', 'copy', 'sign', 'reward', 'export'],
+  moreActions: ['buy', 'sell', 'explorer', 'copy', 'bulkSend', 'sign', 'reward', 'export'],
   moreActionGroups: [
     {
       type: 'trading',
@@ -26,7 +26,7 @@ export const defaultWalletActionsConfig: INetworkWalletActionsConfig = {
     },
     {
       type: 'tools',
-      actions: ['explorer', 'copy', 'sign', 'reward'],
+      actions: ['explorer', 'copy', 'bulkSend', 'sign', 'reward'],
       order: 2,
     },
     {
@@ -49,6 +49,7 @@ export const detailedNetworkConfigs: Record<
       'swap',
       'explorer',
       'copy',
+      'bulkSend',
       'sign',
       'vote',
       'reward',
@@ -62,7 +63,7 @@ export const detailedNetworkConfigs: Record<
       },
       {
         type: 'tools',
-        actions: ['explorer', 'copy', 'sign', 'vote', 'reward'],
+        actions: ['explorer', 'copy', 'bulkSend', 'sign', 'vote', 'reward'],
         order: 2,
       },
       {

--- a/packages/kit/src/views/Home/components/WalletActions/networkConfigs.ts
+++ b/packages/kit/src/views/Home/components/WalletActions/networkConfigs.ts
@@ -17,7 +17,16 @@ const networkIds = getNetworkIdsMap();
 
 export const defaultWalletActionsConfig: INetworkWalletActionsConfig = {
   mainActions: ['send', 'receive', 'swap'],
-  moreActions: ['buy', 'sell', 'explorer', 'copy', 'bulkSend', 'sign', 'reward', 'export'],
+  moreActions: [
+    'buy',
+    'sell',
+    'explorer',
+    'copy',
+    'bulkSend',
+    'sign',
+    'reward',
+    'export',
+  ],
   moreActionGroups: [
     {
       type: 'trading',

--- a/packages/kit/src/views/Home/components/WalletActions/types.ts
+++ b/packages/kit/src/views/Home/components/WalletActions/types.ts
@@ -10,6 +10,7 @@ export type IWalletActionType =
   | 'earn'
   | 'explorer'
   | 'copy'
+  | 'bulkSend'
   | 'sign'
   | 'reward'
   | 'export'


### PR DESCRIPTION
## Summary
- Add bulk send entry to wallet More menu with Prime badge for non-Prime users (OK-49910)
- Fix i18n for validateTokenAmount error messages across all BulkSend pages (OK-49939, OK-49938)
- Add new translation key `wallet_bulk_send_error_max_decimal_places` for decimal places validation

## Test plan
- [ ] Verify bulk send entry appears in More menu with Prime badge for non-Prime users
- [ ] Verify Prime users can navigate directly to bulk send flow
- [ ] Verify error messages for empty amount, invalid amount, zero amount, negative amount, and decimal places are properly localized
- [ ] Verify TRON network also shows the bulk send entry
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10031" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
