### PR TITLE
fix(notifications): filter stale accounts from notification enabled count

### DIFF
--- a/packages/kit/src/views/Setting/pages/Notifications/ManageAccountActivity.tsx
+++ b/packages/kit/src/views/Setting/pages/Notifications/ManageAccountActivity.tsx
@@ -564,9 +564,17 @@ function WalletAccordionItemContainer({
         const newValue = value;
 
         if (newValue && newSettings?.[wallet.id]?.accounts) {
+          const existingAccountIds = new Set(
+            (wallet.dbAccounts ?? wallet.dbIndexedAccounts ?? []).map(
+              (a) => a.id,
+            ),
+          );
           let enabledAccountsCount = 0;
-          Object.values(newSettings?.[wallet.id]?.accounts || {}).forEach(
-            (item) => {
+          Object.entries(newSettings?.[wallet.id]?.accounts || {}).forEach(
+            ([accountId, item]) => {
+              if (!existingAccountIds.has(accountId)) {
+                return;
+              }
               if (item.enabled) {
                 enabledAccountsCount += 1;
                 if (
@@ -609,16 +617,22 @@ function WalletAccordionItemContainer({
     if (!isWalletEnabled) {
       return 0;
     }
-    return Object.values(
+    const existingAccountIds = new Set(
+      (wallet.dbAccounts ?? wallet.dbIndexedAccounts ?? []).map((a) => a.id),
+    );
+    return Object.entries(
       accountNotificationSettings?.[wallet.id]?.accounts ?? {},
-    ).filter((account) => account.enabled === true).length;
-    // return (
-    //   totalAccountsCount -
-    //   Object.values(
-    //     accountNotificationSettings?.[wallet.id]?.accounts ?? {},
-    //   ).filter((account) => account.enabled === false).length
-    // );
-  }, [isWalletEnabled, accountNotificationSettings, wallet.id]);
+    ).filter(
+      ([accountId, account]) =>
+        account.enabled === true && existingAccountIds.has(accountId),
+    ).length;
+  }, [
+    isWalletEnabled,
+    accountNotificationSettings,
+    wallet.id,
+    wallet.dbAccounts,
+    wallet.dbIndexedAccounts,
+  ]);
 
   return (
     <WalletAccordionItemMemo


### PR DESCRIPTION
## Summary
- Fix notification account count including removed accounts that still have settings entries
- Filter `enabledAccountsCount` by existing wallet accounts (`dbAccounts`/`dbIndexedAccounts`) instead of counting all settings entries
- Filter `toggleWalletSwitch` limit check to skip non-existent account entries

**Root cause**: When accounts are removed from the account selector, their notification settings entries remain. Two places counted these stale entries:
1. `enabledAccountsCount` — displayed wrong count (e.g. 20/18)
2. `toggleWalletSwitch` — incorrectly disabled existing accounts due to phantom count from removed accounts

## Test plan
- [ ] Create a wallet with 20 accounts, enable all for notifications
- [ ] Remove 2 accounts from account selector, verify count shows 18/18 (not 20/18)
- [ ] Verify the account limit alert no longer shows when actual enabled count is below threshold
- [ ] Re-enable the wallet toggle and verify all existing accounts are correctly toggled
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
