### PR TITLE
fix(desktop): improve macOS drag zone reliability

### DIFF
--- a/packages/components/src/layouts/Navigation/Header/HeaderView.tsx
+++ b/packages/components/src/layouts/Navigation/Header/HeaderView.tsx
@@ -3,9 +3,8 @@ import { memo, useCallback, useMemo, useState } from 'react';
 import * as React from 'react';
 
 import { Header } from '@react-navigation/elements';
-import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import { useFocusEffect } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useDebouncedCallback } from 'use-debounce';
 
 import { useMedia } from '@onekeyhq/components/src/hooks/useStyle';
 import { useTheme } from '@onekeyhq/components/src/shared/tamagui';
@@ -15,7 +14,6 @@ import { useIsOverlayPage } from '../../../hocs';
 import { useIsDesktopModeUIInTabPages } from '../../../hooks';
 import { Stack, XStack } from '../../../primitives';
 import { DesktopDragZoneBox } from '../../DesktopDragZoneBox';
-import { rootNavigationRef } from '../Navigator/NavigationContainer';
 
 import HeaderBackButton from './HeaderBackButton';
 import HeaderSearchBar from './HeaderSearchBar';
@@ -47,31 +45,12 @@ const DesktopDragZoneBoxView = platformEnv.isDesktopMac
 
       const [isFocus, setIsFocus] = useState(false);
 
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      const { getState } = useNavigation();
-
-      const currentRouteName = useMemo(() => {
-        const state = getState?.();
-        return state?.routes?.at(-1)?.name;
-      }, [getState]);
-
-      const handlePageFocus = useDebouncedCallback(() => {
-        setIsFocus(
-          currentRouteName ===
-            rootNavigationRef.current?.getCurrentRoute()?.name,
-        );
-      }, 100);
-
-      const handlePageBlur = useDebouncedCallback(() => {
-        setIsFocus(false);
-      }, 100);
-
       const handlePageEffect = useCallback(() => {
-        handlePageFocus();
+        setIsFocus(true);
         return () => {
-          handlePageBlur();
+          setIsFocus(false);
         };
-      }, [handlePageBlur, handlePageFocus]);
+      }, []);
 
       useFocusEffect(handlePageEffect);
 


### PR DESCRIPTION
## Summary
- Improve macOS desktop drag zone reliability
- Pass missing `title` prop to `MoreActionContentHeaderItem` component

## Changes
- Enhanced drag zone behavior on macOS desktop
- Fixed `MoreActionContentHeaderItem` not receiving the `title` prop in the header items mapping