### PR TITLE
fix: pass title prop to MoreActionContentHeaderItem(OK-49957)

### DIFF
--- a/packages/kit/src/components/MoreActionButton/index.tsx
+++ b/packages/kit/src/components/MoreActionButton/index.tsx
@@ -279,6 +279,7 @@ function MoreActionContentHeader({
         {items.map((item) => (
           <MoreActionContentHeaderItem
             key={item.title}
+            title={item.title}
             icon={item.icon as IKeyOfIcons}
             onPress={item.onPress}
             trackID={item.trackID}


### PR DESCRIPTION
## Summary
- Pass missing `title` prop to `MoreActionContentHeaderItem` component in the header items mapping

## Changes
- Added `title={item.title}` to `MoreActionContentHeaderItem` in `MoreActionContentHeader`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
