### PR TITLE
fix(ios): avoid EXC_BAD_ACCESS crash during token selector navigation

### DIFF
--- a/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
+++ b/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
@@ -16,6 +16,7 @@ import {
 import type { IAllNetworkAccountInfo } from '@onekeyhq/kit-bg/src/services/ServiceAllNetwork/ServiceAllNetwork';
 import type { IVaultSettings } from '@onekeyhq/kit-bg/src/vaults/types';
 import { SEARCH_KEY_MIN_LENGTH } from '@onekeyhq/shared/src/consts/walletConsts';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IAssetSelectorParamList } from '@onekeyhq/shared/src/routes';
 import { EAssetSelectorRoutes } from '@onekeyhq/shared/src/routes';
@@ -114,6 +115,10 @@ function TokenSelector() {
         }
 
         if (aggregateTokenList.length > 1 || allAggregateTokenList.length > 1) {
+          // Delay navigation to let the current CA transaction finish rendering
+          // SVG icons, avoiding EXC_BAD_ACCESS in InstanceHandle::getTag when
+          // Reanimated intercepts layout events from unmounting SVG views.
+          await timerUtils.wait(0);
           navigation.push(
             aggregateTokenSelectorScreen ??
               EAssetSelectorRoutes.AggregateTokenSelector,


### PR DESCRIPTION
## Summary
- Add a microtask delay (`timerUtils.wait(0)`) before navigating from `TxSelectToken` to `TxSelectAggregateToken`
- This prevents a use-after-free race condition where Core Animation still renders SVG icons (`RNSVGSvgView drawRect:`) after React unmounts the component, and Reanimated's event listener accesses a freed `InstanceHandle`, causing `EXC_BAD_ACCESS` (SIGSEGV)
- Root cause is an upstream race condition between react-native-svg, react-native-reanimated, and React Native Fabric's event dispatch ([reanimated #7666](https://github.com/software-mansion/react-native-reanimated/issues/7666), [react-native #53774](https://github.com/facebook/react-native/issues/53774))

## Test plan
- [ ] Navigate to token selector, tap an aggregate token to push to AggregateTokenSelector — verify navigation still works smoothly
- [ ] Repeat rapidly on iOS device with many tokens loaded — verify no crash
- [ ] Verify no visual delay is perceptible to the user (delay is 0ms microtask)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
