### PR TITLE
fix: resolve Android keyboard issue during passcode confirm step

### DIFF
--- a/packages/components/src/content/LottieView/index.tsx
+++ b/packages/components/src/content/LottieView/index.tsx
@@ -14,57 +14,67 @@ import type { AppStateStatus } from 'react-native';
 export const LottieView = forwardRef<
   typeof AnimatedLottieView,
   ILottieViewProps
->(({ source, loop = true, resizeMode, autoPlay = true, renderMode, ...props }, ref) => {
-  const animationRef = useRef<AnimatedLottieView | null>(null);
+>(
+  (
+    { source, loop = true, resizeMode, autoPlay = true, renderMode, ...props },
+    ref,
+  ) => {
+    const animationRef = useRef<AnimatedLottieView | null>(null);
 
-  const appStateRef = useRef(AppState.currentState);
-  const [restProps, style] = usePropsAndStyle(props, {
-    resolveValues: 'auto',
-  });
-  useEffect(() => {
-    // fix animation is stopped after entered background state on iOS
-    // https://github.com/lottie-react-native/lottie-react-native/issues/412
-    const handleStateChange = (nextAppState: AppStateStatus) => {
-      if (
-        appStateRef.current &&
-        /inactive|background/.exec(appStateRef.current) &&
-        nextAppState === 'active'
-      ) {
+    const appStateRef = useRef(AppState.currentState);
+    const [restProps, style] = usePropsAndStyle(props, {
+      resolveValues: 'auto',
+    });
+    useEffect(() => {
+      // fix animation is stopped after entered background state on iOS
+      // https://github.com/lottie-react-native/lottie-react-native/issues/412
+      const handleStateChange = (nextAppState: AppStateStatus) => {
+        if (
+          appStateRef.current &&
+          /inactive|background/.exec(appStateRef.current) &&
+          nextAppState === 'active'
+        ) {
+          animationRef.current?.play?.();
+        }
+        appStateRef.current = nextAppState;
+      };
+      const subscription = AppState.addEventListener(
+        'change',
+        handleStateChange,
+      );
+      return () => {
+        subscription.remove();
+      };
+    }, []);
+
+    useImperativeHandle(ref as any, () => ({
+      play: () => {
         animationRef.current?.play?.();
-      }
-      appStateRef.current = nextAppState;
-    };
-    const subscription = AppState.addEventListener('change', handleStateChange);
-    return () => {
-      subscription.remove();
-    };
-  }, []);
+      },
+      pause: () => {
+        animationRef.current?.pause?.();
+      },
+      reset: () => {
+        animationRef.current?.reset();
+      },
+    }));
 
-  useImperativeHandle(ref as any, () => ({
-    play: () => {
-      animationRef.current?.play?.();
-    },
-    pause: () => {
-      animationRef.current?.pause?.();
-    },
-    reset: () => {
-      animationRef.current?.reset();
-    },
-  }));
-
-  return (
-    <AnimatedLottieView
-      autoPlay={autoPlay}
-      resizeMode={resizeMode}
-      source={source as LottieNativeProps['source']}
-      loop={loop}
-      style={style as any}
-      {...(restProps as any)}
-      ref={animationRef as LegacyRef<AnimatedLottieView>}
-      renderMode={renderMode ?? (platformEnv.isNativeIOS ? 'SOFTWARE' : undefined)}
-    />
-  );
-});
+    return (
+      <AnimatedLottieView
+        autoPlay={autoPlay}
+        resizeMode={resizeMode}
+        source={source as LottieNativeProps['source']}
+        loop={loop}
+        style={style as any}
+        {...(restProps as any)}
+        ref={animationRef as LegacyRef<AnimatedLottieView>}
+        renderMode={
+          renderMode ?? (platformEnv.isNativeIOS ? 'SOFTWARE' : undefined)
+        }
+      />
+    );
+  },
+);
 
 LottieView.displayName = 'LottieView';
 

--- a/packages/kit/src/components/Password/components/PasswordSetup.tsx
+++ b/packages/kit/src/components/Password/components/PasswordSetup.tsx
@@ -111,6 +111,8 @@ const PasswordSetup = ({
   }, [confirmBtnText, intl, passCodeFirstStep]);
   const onPassCodeNext = useCallback(async () => {
     setPassCodeConfirm(true);
+    // Fix Android keyboard not appearing: dismiss keyboard before switching to confirm step,
+    // then manually setFocus after a delay to ensure the keyboard pops up correctly.
     if (platformEnv.isNativeAndroid) {
       await dismissKeyboardWithDelay(150);
     }

--- a/packages/kit/src/components/Password/components/PasswordSetup.tsx
+++ b/packages/kit/src/components/Password/components/PasswordSetup.tsx
@@ -28,6 +28,7 @@ import PassCodeInput, {
   AUTO_FOCUS_DELAY_MS,
   PIN_CELL_COUNT,
 } from './PassCodeInput';
+import { dismissKeyboardWithDelay } from '@onekeyhq/shared/src/keyboard';
 
 export interface IPasswordSetupForm {
   password: string;
@@ -108,12 +109,14 @@ const PasswordSetup = ({
       intl.formatMessage({ id: ETranslations.auth_set_passcode })
     );
   }, [confirmBtnText, intl, passCodeFirstStep]);
-  const onPassCodeNext = useCallback(() => {
+  const onPassCodeNext = useCallback(async () => {
     setPassCodeConfirm(true);
+    if (platformEnv.isNativeAndroid) {
+      await dismissKeyboardWithDelay(150);
+    }
     onStepChange?.('confirm');
-    setTimeout(() => {
-      form.setFocus('confirmPassCode');
-    }, 150);
+    await timerUtils.wait(150)
+    form.setFocus('confirmPassCode');
   }, [form, onStepChange]);
 
   const clearPasscodeTimeOut = useCallback(() => {
@@ -364,7 +367,7 @@ const PasswordSetup = ({
                   form.clearErrors('confirmPassCode');
                 }}
                 editable
-                autoFocus={passCodeConfirm}
+                autoFocus={platformEnv.isNativeAndroid ? false : passCodeConfirm}
                 clearCodeAndFocus={passCodeConfirmClear}
                 onComplete={form.handleSubmit(onSetupPassword)}
                 autoFocusDelayMs={AUTO_FOCUS_DELAY_MS}

--- a/packages/kit/src/components/Password/components/PasswordSetup.tsx
+++ b/packages/kit/src/components/Password/components/PasswordSetup.tsx
@@ -117,7 +117,7 @@ const PasswordSetup = ({
       await dismissKeyboardWithDelay(150);
     }
     onStepChange?.('confirm');
-    await timerUtils.wait(150)
+    await timerUtils.wait(150);
     form.setFocus('confirmPassCode');
   }, [form, onStepChange]);
 
@@ -369,7 +369,9 @@ const PasswordSetup = ({
                   form.clearErrors('confirmPassCode');
                 }}
                 editable
-                autoFocus={platformEnv.isNativeAndroid ? false : passCodeConfirm}
+                autoFocus={
+                  platformEnv.isNativeAndroid ? false : passCodeConfirm
+                }
                 clearCodeAndFocus={passCodeConfirmClear}
                 onComplete={form.handleSubmit(onSetupPassword)}
                 autoFocusDelayMs={AUTO_FOCUS_DELAY_MS}

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -326,7 +326,9 @@ export function HomePageView({
 
   const handleRenderItem = useCallback(
     (props: ITabBarItemProps) => {
-      const tabId = tabConfigsRef.current.find((i) => i.name === props.name)?.id;
+      const tabId = tabConfigsRef.current.find(
+        (i) => i.name === props.name,
+      )?.id;
       return (
         <XStack position="relative">
           <TabBarItem {...props} />

--- a/packages/kit/src/views/ReferFriends/components/ExportButton.tsx
+++ b/packages/kit/src/views/ReferFriends/components/ExportButton.tsx
@@ -55,7 +55,16 @@ export function ExportButton({
         }),
       });
     }
-  }, [exportInviteData, intl, inviteCode, subject, tab, timeRange, startTime, endTime]);
+  }, [
+    exportInviteData,
+    intl,
+    inviteCode,
+    subject,
+    tab,
+    timeRange,
+    startTime,
+    endTime,
+  ]);
 
   if (gtMd) {
     return (

--- a/packages/shared/src/config/appConfig.ts
+++ b/packages/shared/src/config/appConfig.ts
@@ -123,8 +123,7 @@ export const ONEKEY_HEALTH_CHECK_URL = '/wallet/v1/health';
 
 export const SUPPORT_URL = 'https://help.onekey.so/hc/requests/new';
 
-export const SWAP_FAQ_HELP_URL =
-  'https://help.onekey.so/articles/13608266';
+export const SWAP_FAQ_HELP_URL = 'https://help.onekey.so/articles/13608266';
 
 export const HYPERLIQUID_EXPLORER_URL = 'https://hypurrscan.io/address/';
 


### PR DESCRIPTION
## Summary
- Dismiss keyboard with delay before transitioning to passcode confirm step on Android to prevent keyboard flicker
- Replace `autoFocus` prop with manual `setFocus` call on Android to avoid focus race conditions
- Use `await timerUtils.wait()` instead of `setTimeout` for cleaner async flow

## Test plan
- [ ] On Android, set up a new passcode — verify keyboard dismisses smoothly when transitioning to confirm step
- [ ] On Android, verify the confirm passcode input receives focus correctly after transition
- [ ] On iOS, verify existing behavior is unchanged (autoFocus still works as before)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
