### PR TITLE
fix(android): handle WebView render process death to prevent background ANR

### DIFF
--- a/packages/components/src/content/LottieView/index.tsx
+++ b/packages/components/src/content/LottieView/index.tsx
@@ -14,57 +14,67 @@ import type { AppStateStatus } from 'react-native';
 export const LottieView = forwardRef<
   typeof AnimatedLottieView,
   ILottieViewProps
->(({ source, loop = true, resizeMode, autoPlay = true, renderMode, ...props }, ref) => {
-  const animationRef = useRef<AnimatedLottieView | null>(null);
+>(
+  (
+    { source, loop = true, resizeMode, autoPlay = true, renderMode, ...props },
+    ref,
+  ) => {
+    const animationRef = useRef<AnimatedLottieView | null>(null);
 
-  const appStateRef = useRef(AppState.currentState);
-  const [restProps, style] = usePropsAndStyle(props, {
-    resolveValues: 'auto',
-  });
-  useEffect(() => {
-    // fix animation is stopped after entered background state on iOS
-    // https://github.com/lottie-react-native/lottie-react-native/issues/412
-    const handleStateChange = (nextAppState: AppStateStatus) => {
-      if (
-        appStateRef.current &&
-        /inactive|background/.exec(appStateRef.current) &&
-        nextAppState === 'active'
-      ) {
+    const appStateRef = useRef(AppState.currentState);
+    const [restProps, style] = usePropsAndStyle(props, {
+      resolveValues: 'auto',
+    });
+    useEffect(() => {
+      // fix animation is stopped after entered background state on iOS
+      // https://github.com/lottie-react-native/lottie-react-native/issues/412
+      const handleStateChange = (nextAppState: AppStateStatus) => {
+        if (
+          appStateRef.current &&
+          /inactive|background/.exec(appStateRef.current) &&
+          nextAppState === 'active'
+        ) {
+          animationRef.current?.play?.();
+        }
+        appStateRef.current = nextAppState;
+      };
+      const subscription = AppState.addEventListener(
+        'change',
+        handleStateChange,
+      );
+      return () => {
+        subscription.remove();
+      };
+    }, []);
+
+    useImperativeHandle(ref as any, () => ({
+      play: () => {
         animationRef.current?.play?.();
-      }
-      appStateRef.current = nextAppState;
-    };
-    const subscription = AppState.addEventListener('change', handleStateChange);
-    return () => {
-      subscription.remove();
-    };
-  }, []);
+      },
+      pause: () => {
+        animationRef.current?.pause?.();
+      },
+      reset: () => {
+        animationRef.current?.reset();
+      },
+    }));
 
-  useImperativeHandle(ref as any, () => ({
-    play: () => {
-      animationRef.current?.play?.();
-    },
-    pause: () => {
-      animationRef.current?.pause?.();
-    },
-    reset: () => {
-      animationRef.current?.reset();
-    },
-  }));
-
-  return (
-    <AnimatedLottieView
-      autoPlay={autoPlay}
-      resizeMode={resizeMode}
-      source={source as LottieNativeProps['source']}
-      loop={loop}
-      style={style as any}
-      {...(restProps as any)}
-      ref={animationRef as LegacyRef<AnimatedLottieView>}
-      renderMode={renderMode ?? (platformEnv.isNativeIOS ? 'SOFTWARE' : undefined)}
-    />
-  );
-});
+    return (
+      <AnimatedLottieView
+        autoPlay={autoPlay}
+        resizeMode={resizeMode}
+        source={source as LottieNativeProps['source']}
+        loop={loop}
+        style={style as any}
+        {...(restProps as any)}
+        ref={animationRef as LegacyRef<AnimatedLottieView>}
+        renderMode={
+          renderMode ?? (platformEnv.isNativeIOS ? 'SOFTWARE' : undefined)
+        }
+      />
+    );
+  },
+);
 
 LottieView.displayName = 'LottieView';
 

--- a/packages/kit/src/components/WebView/NativeWebView.tsx
+++ b/packages/kit/src/components/WebView/NativeWebView.tsx
@@ -32,8 +32,8 @@ import type { IWebViewWrapperRef } from '@onekeyfe/onekey-cross-webview';
 import type {
   WebViewMessageEvent,
   WebViewProps,
-  WebViewRenderProcessGoneEvent,
 } from 'react-native-webview';
+import type { WebViewRenderProcessGoneEvent } from 'react-native-webview/lib/WebViewTypes';
 
 export type INativeWebViewProps = WebViewProps & IInpageProviderWebViewProps;
 

--- a/packages/kit/src/components/WebView/NativeWebView.tsx
+++ b/packages/kit/src/components/WebView/NativeWebView.tsx
@@ -29,10 +29,7 @@ import { createMessageInjectedScript } from './utils';
 
 import type { IInpageProviderWebViewProps, IWebViewRef } from './types';
 import type { IWebViewWrapperRef } from '@onekeyfe/onekey-cross-webview';
-import type {
-  WebViewMessageEvent,
-  WebViewProps,
-} from 'react-native-webview';
+import type { WebViewMessageEvent, WebViewProps } from 'react-native-webview';
 import type { WebViewRenderProcessGoneEvent } from 'react-native-webview/lib/WebViewTypes';
 
 export type INativeWebViewProps = WebViewProps & IInpageProviderWebViewProps;

--- a/packages/kit/src/components/WebView/NativeWebView.tsx
+++ b/packages/kit/src/components/WebView/NativeWebView.tsx
@@ -29,7 +29,11 @@ import { createMessageInjectedScript } from './utils';
 
 import type { IInpageProviderWebViewProps, IWebViewRef } from './types';
 import type { IWebViewWrapperRef } from '@onekeyfe/onekey-cross-webview';
-import type { WebViewMessageEvent, WebViewProps } from 'react-native-webview';
+import type {
+  WebViewMessageEvent,
+  WebViewProps,
+  WebViewRenderProcessGoneEvent,
+} from 'react-native-webview';
 
 export type INativeWebViewProps = WebViewProps & IInpageProviderWebViewProps;
 
@@ -64,6 +68,7 @@ const NativeWebView = forwardRef(
     const refreshControlRef = useMemo(() => createRef<RefreshControl>(), []);
     const [isRefresh] = useState(false);
     const isUnmountingRef = useRef(false);
+    const [webViewKey, setWebViewKey] = useState(0);
 
     const onRefresh = useCallback(() => {
       if (isUnmountingRef.current) return;
@@ -241,6 +246,19 @@ const NativeWebView = forwardRef(
       [onScroll, pullToRefreshEnabled, refreshControlRef],
     );
 
+    const handleRenderProcessGone = useCallback(
+      (event: WebViewRenderProcessGoneEvent) => {
+        if (isUnmountingRef.current) return;
+        const { didCrash } = event.nativeEvent;
+        console.warn(
+          `WebView render process gone (didCrash: ${didCrash}), recreating WebView`,
+        );
+        // Bump key to force React to unmount the dead WebView and mount a fresh one
+        setWebViewKey((prev) => prev + 1);
+      },
+      [],
+    );
+
     const debuggingEnabled = useMemo(() => {
       if (__DEV__) {
         return true;
@@ -281,6 +299,7 @@ const NativeWebView = forwardRef(
       }
       return (
         <WebView
+          key={webViewKey}
           cacheEnabled={false}
           style={styles.container}
           originWhitelist={['*']}
@@ -308,11 +327,13 @@ const NativeWebView = forwardRef(
           onScroll={safeOnScroll}
           scrollEventThrottle={16}
           webviewDebuggingEnabled={debuggingEnabled}
+          onRenderProcessGone={handleRenderProcessGone}
           {...props}
         />
       );
     }, [
       debuggingEnabled,
+      handleRenderProcessGone,
       injectedJavaScriptBeforeContentLoaded,
       safeOnLoad,
       safeOnLoadEnd,
@@ -324,6 +345,7 @@ const NativeWebView = forwardRef(
       renderLoading,
       src,
       useGeckoView,
+      webViewKey,
       webViewOnLoadStart,
       webviewOnMessage,
       allowsBackForwardNavigationGestures,

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -326,7 +326,9 @@ export function HomePageView({
 
   const handleRenderItem = useCallback(
     (props: ITabBarItemProps) => {
-      const tabId = tabConfigsRef.current.find((i) => i.name === props.name)?.id;
+      const tabId = tabConfigsRef.current.find(
+        (i) => i.name === props.name,
+      )?.id;
       return (
         <XStack position="relative">
           <TabBarItem {...props} />

--- a/packages/kit/src/views/ReferFriends/components/ExportButton.tsx
+++ b/packages/kit/src/views/ReferFriends/components/ExportButton.tsx
@@ -55,7 +55,16 @@ export function ExportButton({
         }),
       });
     }
-  }, [exportInviteData, intl, inviteCode, subject, tab, timeRange, startTime, endTime]);
+  }, [
+    exportInviteData,
+    intl,
+    inviteCode,
+    subject,
+    tab,
+    timeRange,
+    startTime,
+    endTime,
+  ]);
 
   if (gtMd) {
     return (

--- a/packages/shared/src/config/appConfig.ts
+++ b/packages/shared/src/config/appConfig.ts
@@ -123,8 +123,7 @@ export const ONEKEY_HEALTH_CHECK_URL = '/wallet/v1/health';
 
 export const SUPPORT_URL = 'https://help.onekey.so/hc/requests/new';
 
-export const SWAP_FAQ_HELP_URL =
-  'https://help.onekey.so/articles/13608266';
+export const SWAP_FAQ_HELP_URL = 'https://help.onekey.so/articles/13608266';
 
 export const HYPERLIQUID_EXPLORER_URL = 'https://hypurrscan.io/address/';
 


### PR DESCRIPTION
## Summary

- Handle `onRenderProcessGone` callback in NativeWebView to gracefully recover when the Android system kills the WebView rendering process under memory pressure
- When the render process dies, bump the WebView `key` to force React to unmount the dead WebView and mount a fresh one, preventing `HardwareRenderer.nSetStopped` from blocking the main thread on a dead GPU surface

## Root Cause

On low-end Android devices under memory pressure, the system kills the WebView rendering process. During the subsequent Activity lifecycle transition (`paused → stopped → destroyed`), `HardwareRenderer.setStopped()` tries to synchronize with the RenderThread, but the RenderThread is blocked on `Fence::waitForever()` waiting for a GPU sync fence referencing the now-dead WebView surface. This causes the main thread to block indefinitely → Background ANR.

## Fix

Listen to `onRenderProcessGone` event (Android 8.0+, already supported by `react-native-webview`). When triggered, recreate the WebView by changing its React `key`, which unmounts the dead WebView and releases the invalid GPU surface before `HardwareRenderer` attempts to sync with it.

## Test plan

- [ ] Verify WebView loads normally on Android
- [ ] Verify WebView recovers (reloads) after renderer process death on low-memory Android device
- [ ] Verify no regression on iOS WebView behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
