### PR TITLE
fix(perp,referral): stabilize dynamic tabs and improve referral record table

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -282,9 +282,9 @@ export default class ServiceHyperliquid extends ServiceBase {
     hyperLiquidErrorResolver.updateLocales(hyperLiquidErrorLocales);
 
     // Update token selector tabs atom
-    if (tokenSelectorTabs) {
-      await perpTokenSelectorTabsAtom.set(tokenSelectorTabs);
-    }
+    // Always set to transition from null (not loaded) to a valid state,
+    // even when server doesn't return tokenSelectorTabs (undefined → [])
+    await perpTokenSelectorTabsAtom.set(tokenSelectorTabs ?? []);
 
     if (shouldNotifyToDapp) {
       const config = await this.backgroundApi.simpleDb.perp.getPerpData();

--- a/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
@@ -18,7 +18,7 @@ import {
   usePerpsAllAssetCtxsAtom,
   usePerpsAllAssetsFilteredAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
-import type { IPerpDynamicTab } from '@onekeyhq/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp';
+
 import {
   usePerpTokenSelectorConfigPersistAtom,
   usePerpTokenSelectorTabsAtom,
@@ -297,16 +297,9 @@ function MobileTokenSelectorModal({
     selectorConfig?.field,
   ]);
 
-  // Compute visible dynamic tabs (those with matching tokens)
-  const visibleDynamicTabs = useMemo<IPerpDynamicTab[]>(() => {
-    const assetsByDexTyped: IPerpsUniverse[][] = assetsByDex || [];
-    const allAssetNames = new Set(
-      assetsByDexTyped.flatMap((assets) => assets.map((a) => a.name)),
-    );
-    return (dynamicTabsRaw ?? []).filter((tab) =>
-      tab.tokens.some((token) => allAssetNames.has(token)),
-    );
-  }, [assetsByDex, dynamicTabsRaw]);
+  // Show all server-configured dynamic tabs regardless of search results.
+  // Filtering by search-filtered assetsByDex would hide tabs during search.
+  const visibleDynamicTabs = dynamicTabs;
 
   usePerpActiveTabValidation({
     activeTab,

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -481,16 +481,10 @@ function BasePerpTokenSelectorContent({
     selectorConfig?.field,
   ]);
 
-  // Filter to visible dynamic tabs (those with matching tokens)
-  const visibleDynamicTabs = useMemo<IPerpDynamicTab[]>(() => {
-    const assetsByDexTyped: IPerpsUniverse[][] = assetsByDex || [];
-    const allAssetNames = new Set(
-      assetsByDexTyped.flatMap((assets) => assets.map((a) => a.name)),
-    );
-    return (dynamicTabsRaw ?? []).filter((tab) =>
-      tab.tokens.some((token) => allAssetNames.has(token)),
-    );
-  }, [assetsByDex, dynamicTabsRaw]);
+  // Show all server-configured dynamic tabs regardless of search results.
+  // Filtering by search-filtered assetsByDex would hide tabs during search
+  // and break tab persistence (assetsByDex resets to [] on unmount).
+  const visibleDynamicTabs = dynamicTabs;
 
   usePerpActiveTabValidation({
     activeTab,

--- a/packages/kit/src/views/ReferFriends/pages/PerpsReward/components/PerpsRecordTable.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/PerpsReward/components/PerpsRecordTable.tsx
@@ -12,7 +12,16 @@ import {
   useMedia,
 } from '@onekeyhq/components';
 import { Currency } from '@onekeyhq/kit/src/components/Currency';
+import { FixedColumnShadowOverlay } from '@onekeyhq/kit/src/components/FixedColumnShadowOverlay';
+import {
+  SHADOW_CONSTANTS,
+  getWebClipPath,
+  getWebShadowStyle,
+  useFixedColumnShadow,
+} from '@onekeyhq/kit/src/hooks/useFixedColumnShadow';
+import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type {
   IPerpsInviteItem,
   IPerpsInvitesSortBy,
@@ -33,9 +42,16 @@ interface IPerpsRecordTableProps {
   isLoadingMore?: boolean;
 }
 
-interface ITableRowProps {
+interface ICellContentProps {
   item: IPerpsInviteItem;
   columnWidths: IColumnWidths;
+}
+
+interface IHeaderContentProps {
+  columnWidths: IColumnWidths;
+  sortBy: IPerpsInvitesSortBy;
+  sortOrder: IPerpsInvitesSortOrder;
+  onSort: (field: IPerpsInvitesSortBy) => void;
 }
 
 interface ISortableHeaderProps {
@@ -48,6 +64,12 @@ interface ISortableHeaderProps {
   jc?: 'flex-start' | 'flex-end';
   tooltipContent?: string;
 }
+
+// Module-level constants to avoid re-creating on every render
+const SCROLL_CONTENT_STYLE = { flexGrow: 1 };
+const REWARD_FORMATTER_OPTIONS = { showPlusMinusSigns: true };
+const HOVER_OPACITY_STYLE = { opacity: 0.7 };
+const HOVER_BG_STYLE = { bg: '$bgHover' };
 
 function SortableHeader({
   label,
@@ -68,7 +90,7 @@ function SortableHeader({
         gap="$1"
         onPress={() => onSort(field)}
         cursor="pointer"
-        hoverStyle={{ opacity: 0.7 }}
+        hoverStyle={HOVER_OPACITY_STYLE}
       >
         <SizableText
           size="$headingXs"
@@ -90,7 +112,7 @@ function SortableHeader({
         ai="center"
         onPress={() => onSort(field)}
         cursor="pointer"
-        hoverStyle={{ opacity: 0.7 }}
+        hoverStyle={HOVER_OPACITY_STYLE}
       >
         <Icon
           name={
@@ -111,15 +133,21 @@ function formatDateTime(dateString: string | null | undefined): string {
   return formatDate(dateString, { hideSeconds: true });
 }
 
-function TableRow({ item, columnWidths }: ITableRowProps) {
-  return (
-    <XStack ai="center" px="$5" py="$2" hoverStyle={{ bg: '$bgHover' }}>
-      <XStack w={columnWidths.address} ai="center" py="$1">
-        <SizableText size="$bodyMd" color="$text">
-          {item.address}
-        </SizableText>
-      </XStack>
+/* --- Shared cell content components (no row wrapper) --- */
 
+function AddressCellContent({ item, columnWidths }: ICellContentProps) {
+  return (
+    <XStack w={columnWidths.address} ai="center" py="$1">
+      <SizableText size="$bodyMd" color="$text">
+        {item.address}
+      </SizableText>
+    </XStack>
+  );
+}
+
+function ScrollableCellsContent({ item, columnWidths }: ICellContentProps) {
+  return (
+    <>
       <XStack w={columnWidths.invitedAt} ai="center" py="$1">
         <SizableText size="$bodyMd" color="$text">
           {formatDateTime(item.invitationTime)}
@@ -155,42 +183,47 @@ function TableRow({ item, columnWidths }: ITableRowProps) {
           color="$textSuccess"
           formatter="value"
           size="$bodyMd"
-          formatterOptions={{
-            showPlusMinusSigns: true,
-          }}
+          formatterOptions={REWARD_FORMATTER_OPTIONS}
         >
           {item.rewardFiatValue}
         </Currency>
       </XStack>
-    </XStack>
+    </>
   );
 }
 
-function TableHeader({
+/* --- Shared header content components (no row wrapper) --- */
+
+function AddressHeaderContent({
   columnWidths,
-  sortBy,
-  sortOrder,
-  onSort,
 }: {
   columnWidths: IColumnWidths;
-  sortBy: IPerpsInvitesSortBy;
-  sortOrder: IPerpsInvitesSortOrder;
-  onSort: (field: IPerpsInvitesSortBy) => void;
 }) {
   const intl = useIntl();
 
   return (
-    <XStack ai="center" px="$5" py="$2">
-      <XStack w={columnWidths.address}>
-        <SizableText
-          size="$headingXs"
-          color="$textSubdued"
-          textTransform="uppercase"
-        >
-          {intl.formatMessage({ id: ETranslations.global_address })}
-        </SizableText>
-      </XStack>
+    <XStack w={columnWidths.address}>
+      <SizableText
+        size="$headingXs"
+        color="$textSubdued"
+        textTransform="uppercase"
+      >
+        {intl.formatMessage({ id: ETranslations.global_address })}
+      </SizableText>
+    </XStack>
+  );
+}
 
+function ScrollableHeaderContent({
+  columnWidths,
+  sortBy,
+  sortOrder,
+  onSort,
+}: IHeaderContentProps) {
+  const intl = useIntl();
+
+  return (
+    <>
       <SortableHeader
         label={intl.formatMessage({
           id: ETranslations.referral_perps_invited_at,
@@ -226,7 +259,9 @@ function TableHeader({
       />
 
       <SortableHeader
-        label={intl.formatMessage({ id: ETranslations.referral_perps_volume })}
+        label={intl.formatMessage({
+          id: ETranslations.referral_perps_volume,
+        })}
         field="volume"
         sortBy={sortBy}
         sortOrder={sortOrder}
@@ -257,7 +292,7 @@ function TableHeader({
         width={columnWidths.reward}
         jc="flex-end"
       />
-    </XStack>
+    </>
   );
 }
 
@@ -270,35 +305,126 @@ export function PerpsRecordTable({
 }: IPerpsRecordTableProps) {
   const media = useMedia();
   const isCompact = media.lg;
-  const { columnWidths, tableMinWidth } = usePerpsTableColumns(isCompact);
+  const { columnWidths } = usePerpsTableColumns(isCompact);
+  const themeVariant = useThemeVariant();
+  const isDark = themeVariant === 'dark';
+
+  // Fixed column shadow management
+  const {
+    showShadow: showFixedShadow,
+    scrollViewRef,
+    handleNativeScroll,
+    handleWebScroll,
+  } = useFixedColumnShadow({
+    position: 'left',
+    enabled: isCompact,
+  });
 
   if (!records || records.length === 0) {
     return null;
   }
 
-  const tableContent = (
-    <YStack minWidth={isCompact ? tableMinWidth : undefined}>
-      <TableHeader
-        columnWidths={columnWidths}
-        sortBy={sortBy}
-        sortOrder={sortOrder}
-        onSort={onSort}
-      />
-      {records.map((record) => (
-        <TableRow key={record._id} item={record} columnWidths={columnWidths} />
-      ))}
-    </YStack>
-  );
+  if (isCompact) {
+    // Fixed address column + horizontally scrollable rest columns
+    return (
+      <YStack py="$2">
+        <XStack flex={1} position="relative">
+          {/* Fixed address column */}
+          <YStack
+            bg="$bgApp"
+            zIndex={1}
+            $platform-web={{
+              boxShadow: showFixedShadow
+                ? getWebShadowStyle('left', isDark)
+                : 'none',
+              clipPath: getWebClipPath('left'),
+              transition: `box-shadow ${SHADOW_CONSTANTS.TRANSITION_DURATION} ease-in-out`,
+            }}
+          >
+            <XStack ai="center" px="$5" py="$2">
+              <AddressHeaderContent columnWidths={columnWidths} />
+            </XStack>
+            {records.map((record) => (
+              <XStack key={record._id} ai="center" px="$5" py="$2">
+                <AddressCellContent
+                  item={record}
+                  columnWidths={columnWidths}
+                />
+              </XStack>
+            ))}
+            <FixedColumnShadowOverlay
+              position="left"
+              visible={showFixedShadow}
+              isDark={isDark}
+            />
+          </YStack>
 
+          {/* Scrollable columns */}
+          <ScrollView
+            ref={scrollViewRef}
+            flex={1}
+            horizontal
+            showsHorizontalScrollIndicator
+            bounces={false}
+            onScroll={
+              platformEnv.isNative ? handleNativeScroll : handleWebScroll
+            }
+            scrollEventThrottle={16}
+            contentContainerStyle={SCROLL_CONTENT_STYLE}
+          >
+            <YStack>
+              <XStack ai="center" py="$2" pr="$5">
+                <ScrollableHeaderContent
+                  columnWidths={columnWidths}
+                  sortBy={sortBy}
+                  sortOrder={sortOrder}
+                  onSort={onSort}
+                />
+              </XStack>
+              {records.map((record) => (
+                <XStack key={record._id} ai="center" py="$2" pr="$5">
+                  <ScrollableCellsContent
+                    item={record}
+                    columnWidths={columnWidths}
+                  />
+                </XStack>
+              ))}
+            </YStack>
+          </ScrollView>
+        </XStack>
+        {isLoadingMore ? (
+          <YStack ai="center" py="$4">
+            <Spinner size="small" />
+          </YStack>
+        ) : null}
+      </YStack>
+    );
+  }
+
+  // Desktop: full-width layout, all columns in one row
   return (
     <YStack py="$2">
-      {isCompact ? (
-        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-          {tableContent}
-        </ScrollView>
-      ) : (
-        tableContent
-      )}
+      <XStack ai="center" px="$5" py="$2">
+        <AddressHeaderContent columnWidths={columnWidths} />
+        <ScrollableHeaderContent
+          columnWidths={columnWidths}
+          sortBy={sortBy}
+          sortOrder={sortOrder}
+          onSort={onSort}
+        />
+      </XStack>
+      {records.map((record) => (
+        <XStack
+          key={record._id}
+          ai="center"
+          px="$5"
+          py="$2"
+          hoverStyle={HOVER_BG_STYLE}
+        >
+          <AddressCellContent item={record} columnWidths={columnWidths} />
+          <ScrollableCellsContent item={record} columnWidths={columnWidths} />
+        </XStack>
+      ))}
       {isLoadingMore ? (
         <YStack ai="center" py="$4">
           <Spinner size="small" />

--- a/packages/kit/src/views/ReferFriends/pages/PerpsReward/components/PerpsRecordTable.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/PerpsReward/components/PerpsRecordTable.tsx
@@ -70,6 +70,9 @@ const SCROLL_CONTENT_STYLE = { flexGrow: 1 };
 const REWARD_FORMATTER_OPTIONS = { showPlusMinusSigns: true };
 const HOVER_OPACITY_STYLE = { opacity: 0.7 };
 const HOVER_BG_STYLE = { bg: '$bgHover' };
+// Consistent row height for compact mode to prevent drift between
+// the fixed address column and the scrollable columns (Badge vs SizableText).
+const COMPACT_ROW_MIN_HEIGHT = '$10';
 
 function SortableHeader({
   label,
@@ -341,11 +344,11 @@ export function PerpsRecordTable({
               transition: `box-shadow ${SHADOW_CONSTANTS.TRANSITION_DURATION} ease-in-out`,
             }}
           >
-            <XStack ai="center" px="$5" py="$2">
+            <XStack ai="center" px="$5" py="$2" minHeight={COMPACT_ROW_MIN_HEIGHT}>
               <AddressHeaderContent columnWidths={columnWidths} />
             </XStack>
             {records.map((record) => (
-              <XStack key={record._id} ai="center" px="$5" py="$2">
+              <XStack key={record._id} ai="center" px="$5" py="$2" minHeight={COMPACT_ROW_MIN_HEIGHT}>
                 <AddressCellContent
                   item={record}
                   columnWidths={columnWidths}
@@ -373,7 +376,7 @@ export function PerpsRecordTable({
             contentContainerStyle={SCROLL_CONTENT_STYLE}
           >
             <YStack>
-              <XStack ai="center" py="$2" pr="$5">
+              <XStack ai="center" py="$2" pr="$5" minHeight={COMPACT_ROW_MIN_HEIGHT}>
                 <ScrollableHeaderContent
                   columnWidths={columnWidths}
                   sortBy={sortBy}
@@ -382,7 +385,7 @@ export function PerpsRecordTable({
                 />
               </XStack>
               {records.map((record) => (
-                <XStack key={record._id} ai="center" py="$2" pr="$5">
+                <XStack key={record._id} ai="center" py="$2" pr="$5" minHeight={COMPACT_ROW_MIN_HEIGHT}>
                   <ScrollableCellsContent
                     item={record}
                     columnWidths={columnWidths}


### PR DESCRIPTION
## Summary

- **fix(referral)**: Fetch fresh primary invite code in share dialog to prevent stale code display
- **fix(perp)**: Always set `perpTokenSelectorTabsAtom` to transition from `null` to a valid state (`undefined → []`), fixing the "not loaded" vs "empty" distinction
- **fix(perp)**: Show all server-configured dynamic tabs regardless of search filter — prevents tabs from disappearing during search
- **feat(referral)**: Refactor `PerpsRecordTable` with fixed address column + horizontal scroll for compact mode, using `useFixedColumnShadow` hook and `FixedColumnShadowOverlay` component
- Extract module-level style constants for React reference stability

## Changes

| File | Change |
|---|---|
| `ServiceHyperliquid.ts` | Always set token selector tabs atom (null → []) |
| `MoblieTokenSelector.tsx` | Remove filtered dynamic tabs logic, show all server tabs |
| `PerpTokenSelector.tsx` | Same as above (desktop counterpart) |
| `PerpsRecordTable.tsx` | Fixed-column scroll layout for compact mode |
| `useReferFriends.tsx` | Fetch fresh invite code in share dialog |

## Test plan

- [ ] Open Perp token selector on mobile — verify all dynamic tabs display correctly
- [ ] Search tokens in Perp selector — verify tabs remain visible during search
- [ ] Open Perp token selector on desktop — verify tabs render correctly
- [ ] Open Referral > Perps Reward record table on compact screen — verify address column is fixed and remaining columns scroll horizontally with shadow indicator
- [ ] Open Referral > Perps Reward record table on desktop — verify full-width layout unchanged
- [ ] Open Refer Friends share dialog — verify invite code is fresh, not stale


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
