### PR TITLE
feat: cache merged home page data for instant startup display

### DIFF
--- a/packages/kit-bg/src/dbs/simple/base/SimpleDb.ts
+++ b/packages/kit-bg/src/dbs/simple/base/SimpleDb.ts
@@ -530,4 +530,13 @@ export class SimpleDb {
     Object.defineProperty(this, 'rookieGuide', { value });
     return value;
   }
+
+  get homePageData() {
+    const SimpleDbEntityHomePageData = (
+      require('../entity/SimpleDbEntityHomePageData') as unknown as typeof import('../entity/SimpleDbEntityHomePageData')
+    ).SimpleDbEntityHomePageData;
+    const value = new SimpleDbEntityHomePageData();
+    Object.defineProperty(this, 'homePageData', { value });
+    return value;
+  }
 }

--- a/packages/kit-bg/src/dbs/simple/base/SimpleDbProxy.ts
+++ b/packages/kit-bg/src/dbs/simple/base/SimpleDbProxy.ts
@@ -51,6 +51,7 @@ import type { SimpleDbEntityRecentRecipients } from '../entity/SimpleDbEntityRec
 import type { SimpleDbEntityReferralCode } from '../entity/SimpleDbEntityReferralCode';
 import type { SimpleDbEntityRiskTokenManagement } from '../entity/SimpleDbEntityRiskTokenManagement';
 import type { SimpleDbEntityRiskyTokens } from '../entity/SimpleDbEntityRiskyTokens';
+import type { SimpleDbEntityHomePageData } from '../entity/SimpleDbEntityHomePageData';
 import type { SimpleDbEntityRookieGuide } from '../entity/SimpleDbEntityRookieGuide';
 import type { SimpleDbEntityServerNetwork } from '../entity/SimpleDbEntityServerNetwork';
 import type { SimpleDbEntitySwapConfigs } from '../entity/SimpleDbEntitySwapConfigs';
@@ -291,4 +292,8 @@ export class SimpleDbProxy
   rookieGuide = this._createProxyService(
     'rookieGuide',
   ) as SimpleDbEntityRookieGuide;
+
+  homePageData = this._createProxyService(
+    'homePageData',
+  ) as SimpleDbEntityHomePageData;
 }

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityHomePageData.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityHomePageData.ts
@@ -3,31 +3,41 @@ import type { IAccountToken, ITokenFiat } from '@onekeyhq/shared/types/token';
 
 import { SimpleDbEntityBase } from '../base/SimpleDbEntityBase';
 
-export interface IHomePageCacheItem {
-  accountWorth: {
-    worth: Record<string, string>;
-    createAtNetworkWorth: string;
-    accountId: string;
-  };
-  tokenList: { tokens: IAccountToken[]; keys: string };
-  tokenListMap: Record<string, ITokenFiat>;
-  smallBalanceTokens: {
-    smallBalanceTokens: IAccountToken[];
-    keys: string;
-  };
-  smallBalanceTokenListMap: Record<string, ITokenFiat>;
-  smallBalanceTokensFiatValue: string;
-  riskyTokens: { riskyTokens: IAccountToken[]; keys: string };
-  riskyTokenListMap: Record<string, ITokenFiat>;
-  allTokenList: { tokens: IAccountToken[]; keys: string };
-  allTokenListMap: Record<string, ITokenFiat>;
+// ---- V2: Flat data shapes matching Jotai store structures ----
+
+export interface IHomeHeaderData {
+  totalBalance: string;
+  tokenWorth: string;
+  defiNetWorth: string;
+  tokenWorthMap: Record<string, string>;
+  createAtNetworkWorth: string;
+  accountId: string;
+  initialized: boolean;
+  isRefreshing: boolean;
+}
+
+export interface IHomeTokenListData {
+  tokens: IAccountToken[];
+  smallBalanceTokens: IAccountToken[];
+  riskyTokens: IAccountToken[];
+  tokenFiatMap: Record<string, ITokenFiat>;
+  smallBalanceFiatValue: string;
   aggregateTokensMap: Record<string, Record<string, ITokenFiat>>;
   aggregateTokensListMap: Record<string, { tokens: IAccountToken[] }>;
+  allTokens: IAccountToken[];
+  initialized: boolean;
+  isRefreshing: boolean;
+}
+
+export interface IHomePageCacheItemV2 {
+  version: 2;
+  header: IHomeHeaderData;
+  tokenList: IHomeTokenListData;
   updatedAt: number;
 }
 
 export interface ISimpleDBHomePageData {
-  [key: string]: IHomePageCacheItem;
+  [key: string]: IHomePageCacheItemV2;
 }
 
 export class SimpleDbEntityHomePageData extends SimpleDbEntityBase<ISimpleDBHomePageData> {
@@ -36,27 +46,33 @@ export class SimpleDbEntityHomePageData extends SimpleDbEntityBase<ISimpleDBHome
   override enableCache = true;
 
   @backgroundMethod()
-  async getCache({
+  async getCacheV2({
     accountId,
     networkId,
   }: {
     accountId: string;
     networkId: string;
-  }): Promise<IHomePageCacheItem | undefined> {
+  }): Promise<IHomePageCacheItemV2 | undefined> {
     const key = `${accountId}_${networkId}`;
     const rawData = await this.getRawData();
-    return rawData?.[key];
+    const item = rawData?.[key];
+    if (!item) return undefined;
+    // Skip legacy entries that don't have version: 2
+    if (!('version' in item) || item.version !== 2) {
+      return undefined;
+    }
+    return item;
   }
 
   @backgroundMethod()
-  async setCache({
+  async setCacheV2({
     accountId,
     networkId,
     data,
   }: {
     accountId: string;
     networkId: string;
-    data: IHomePageCacheItem;
+    data: IHomePageCacheItemV2;
   }) {
     const key = `${accountId}_${networkId}`;
     await this.setRawData((rawData) => ({

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityHomePageData.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityHomePageData.ts
@@ -1,0 +1,67 @@
+import { backgroundMethod } from '@onekeyhq/shared/src/background/backgroundDecorators';
+import type { IAccountToken, ITokenFiat } from '@onekeyhq/shared/types/token';
+
+import { SimpleDbEntityBase } from '../base/SimpleDbEntityBase';
+
+export interface IHomePageCacheItem {
+  accountWorth: {
+    worth: Record<string, string>;
+    createAtNetworkWorth: string;
+    accountId: string;
+  };
+  tokenList: { tokens: IAccountToken[]; keys: string };
+  tokenListMap: Record<string, ITokenFiat>;
+  smallBalanceTokens: {
+    smallBalanceTokens: IAccountToken[];
+    keys: string;
+  };
+  smallBalanceTokenListMap: Record<string, ITokenFiat>;
+  smallBalanceTokensFiatValue: string;
+  riskyTokens: { riskyTokens: IAccountToken[]; keys: string };
+  riskyTokenListMap: Record<string, ITokenFiat>;
+  allTokenList: { tokens: IAccountToken[]; keys: string };
+  allTokenListMap: Record<string, ITokenFiat>;
+  aggregateTokensMap: Record<string, Record<string, ITokenFiat>>;
+  aggregateTokensListMap: Record<string, { tokens: IAccountToken[] }>;
+  updatedAt: number;
+}
+
+export interface ISimpleDBHomePageData {
+  [key: string]: IHomePageCacheItem;
+}
+
+export class SimpleDbEntityHomePageData extends SimpleDbEntityBase<ISimpleDBHomePageData> {
+  entityName = 'homePageData';
+
+  override enableCache = true;
+
+  @backgroundMethod()
+  async getCache({
+    accountId,
+    networkId,
+  }: {
+    accountId: string;
+    networkId: string;
+  }): Promise<IHomePageCacheItem | undefined> {
+    const key = `${accountId}_${networkId}`;
+    const rawData = await this.getRawData();
+    return rawData?.[key];
+  }
+
+  @backgroundMethod()
+  async setCache({
+    accountId,
+    networkId,
+    data,
+  }: {
+    accountId: string;
+    networkId: string;
+    data: IHomePageCacheItem;
+  }) {
+    const key = `${accountId}_${networkId}`;
+    await this.setRawData((rawData) => ({
+      ...rawData,
+      [key]: data,
+    }));
+  }
+}

--- a/packages/kit-bg/src/services/ServiceToken.ts
+++ b/packages/kit-bg/src/services/ServiceToken.ts
@@ -38,6 +38,7 @@ import { getVaultSettings } from '../vaults/settings';
 import ServiceBase from './ServiceBase';
 
 import type { IDBAccount } from '../dbs/local/types';
+import type { IHomePageCacheItem } from '../dbs/simple/entity/SimpleDbEntityHomePageData';
 import type { ISimpleDBLocalTokens } from '../dbs/simple/entity/SimpleDbEntityLocalTokens';
 import type { IRiskTokenManagementDBStruct } from '../dbs/simple/entity/SimpleDbEntityRiskTokenManagement';
 
@@ -1096,6 +1097,58 @@ class ServiceToken extends ServiceBase {
   public async clearLastActiveTabNameData() {
     return this.backgroundApi.simpleDb.aggregateToken.clearLastActiveTabNameData();
   }
+
+  // ---- Home Page Data Cache ----
+
+  @backgroundMethod()
+  public async getHomePageCache({
+    accountId,
+    networkId,
+  }: {
+    accountId: string;
+    networkId: string;
+  }) {
+    return this.backgroundApi.simpleDb.homePageData.getCache({
+      accountId,
+      networkId,
+    });
+  }
+
+  @backgroundMethod()
+  public async saveHomePageCache({
+    accountId,
+    networkId,
+    data,
+  }: {
+    accountId: string;
+    networkId: string;
+    data: IHomePageCacheItem;
+  }) {
+    await this._saveHomePageCacheDebounced({ accountId, networkId, data });
+  }
+
+  _saveHomePageCacheDebounced = debounce(
+    async ({
+      accountId,
+      networkId,
+      data,
+    }: {
+      accountId: string;
+      networkId: string;
+      data: IHomePageCacheItem;
+    }) => {
+      await this.backgroundApi.simpleDb.homePageData.setCache({
+        accountId,
+        networkId,
+        data,
+      });
+    },
+    3000,
+    {
+      leading: false,
+      trailing: true,
+    },
+  );
 }
 
 export default ServiceToken;

--- a/packages/kit-bg/src/services/ServiceToken.ts
+++ b/packages/kit-bg/src/services/ServiceToken.ts
@@ -38,7 +38,11 @@ import { getVaultSettings } from '../vaults/settings';
 import ServiceBase from './ServiceBase';
 
 import type { IDBAccount } from '../dbs/local/types';
-import type { IHomePageCacheItem } from '../dbs/simple/entity/SimpleDbEntityHomePageData';
+import type {
+  IHomeHeaderData,
+  IHomePageCacheItemV2,
+  IHomeTokenListData,
+} from '../dbs/simple/entity/SimpleDbEntityHomePageData';
 import type { ISimpleDBLocalTokens } from '../dbs/simple/entity/SimpleDbEntityLocalTokens';
 import type { IRiskTokenManagementDBStruct } from '../dbs/simple/entity/SimpleDbEntityRiskTokenManagement';
 
@@ -1101,33 +1105,33 @@ class ServiceToken extends ServiceBase {
   // ---- Home Page Data Cache ----
 
   @backgroundMethod()
-  public async getHomePageCache({
+  public async getHomePageCacheV2({
     accountId,
     networkId,
   }: {
     accountId: string;
     networkId: string;
   }) {
-    return this.backgroundApi.simpleDb.homePageData.getCache({
+    return this.backgroundApi.simpleDb.homePageData.getCacheV2({
       accountId,
       networkId,
     });
   }
 
   @backgroundMethod()
-  public async saveHomePageCache({
+  public async saveHomePageCacheV2({
     accountId,
     networkId,
     data,
   }: {
     accountId: string;
     networkId: string;
-    data: IHomePageCacheItem;
+    data: IHomePageCacheItemV2;
   }) {
-    await this._saveHomePageCacheDebounced({ accountId, networkId, data });
+    await this._saveHomePageCacheV2Debounced({ accountId, networkId, data });
   }
 
-  _saveHomePageCacheDebounced = debounce(
+  _saveHomePageCacheV2Debounced = debounce(
     async ({
       accountId,
       networkId,
@@ -1135,9 +1139,9 @@ class ServiceToken extends ServiceBase {
     }: {
       accountId: string;
       networkId: string;
-      data: IHomePageCacheItem;
+      data: IHomePageCacheItemV2;
     }) => {
-      await this.backgroundApi.simpleDb.homePageData.setCache({
+      await this.backgroundApi.simpleDb.homePageData.setCacheV2({
         accountId,
         networkId,
         data,
@@ -1149,6 +1153,34 @@ class ServiceToken extends ServiceBase {
       trailing: true,
     },
   );
+
+  @backgroundMethod()
+  public async buildHomePageData({
+    headerData,
+    tokenListData,
+    accountId,
+    networkId,
+  }: {
+    headerData: IHomeHeaderData;
+    tokenListData: IHomeTokenListData;
+    accountId: string;
+    networkId: string;
+  }): Promise<IHomePageCacheItemV2> {
+    const cacheItem: IHomePageCacheItemV2 = {
+      version: 2,
+      header: headerData,
+      tokenList: tokenListData,
+      updatedAt: Date.now(),
+    };
+
+    void this.saveHomePageCacheV2({
+      accountId,
+      networkId,
+      data: cacheItem,
+    });
+
+    return cacheItem;
+  }
 }
 
 export default ServiceToken;

--- a/packages/kit/src/states/jotai/contexts/homeHeader/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/homeHeader/actions.ts
@@ -1,0 +1,52 @@
+import { useRef } from 'react';
+
+import { memoFn } from '@onekeyhq/shared/src/utils/cacheUtils';
+
+import type { IHomeHeaderData } from '@onekeyhq/kit-bg/src/dbs/simple/entity/SimpleDbEntityHomePageData';
+
+import { ContextJotaiActionsBase } from '../../utils/ContextJotaiActionsBase';
+
+import { contextAtomMethod, homeHeaderDataAtom } from './atoms';
+
+class ContextJotaiActionsHomeHeader extends ContextJotaiActionsBase {
+  setHomeHeaderData = contextAtomMethod(
+    (get, set, payload: IHomeHeaderData) => {
+      set(homeHeaderDataAtom(), payload);
+    },
+  );
+
+  setHomeHeaderRefreshing = contextAtomMethod(
+    (get, set, payload: { isRefreshing: boolean }) => {
+      set(homeHeaderDataAtom(), {
+        ...get(homeHeaderDataAtom()),
+        ...payload,
+      });
+    },
+  );
+
+  setHomeHeaderInitialized = contextAtomMethod(
+    (get, set, payload: { initialized: boolean }) => {
+      set(homeHeaderDataAtom(), {
+        ...get(homeHeaderDataAtom()),
+        ...payload,
+      });
+    },
+  );
+}
+
+const createActions = memoFn(() => {
+  return new ContextJotaiActionsHomeHeader();
+});
+
+export function useHomeHeaderActions() {
+  const actions = createActions();
+  const setHomeHeaderData = actions.setHomeHeaderData.use();
+  const setHomeHeaderRefreshing = actions.setHomeHeaderRefreshing.use();
+  const setHomeHeaderInitialized = actions.setHomeHeaderInitialized.use();
+
+  return useRef({
+    setHomeHeaderData,
+    setHomeHeaderRefreshing,
+    setHomeHeaderInitialized,
+  });
+}

--- a/packages/kit/src/states/jotai/contexts/homeHeader/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/homeHeader/atoms.ts
@@ -1,0 +1,28 @@
+import type { IHomeHeaderData } from '@onekeyhq/kit-bg/src/dbs/simple/entity/SimpleDbEntityHomePageData';
+
+import { createJotaiContext } from '../../utils/createJotaiContext';
+
+const {
+  Provider: ProviderJotaiContextHomeHeader,
+  withProvider: withHomeHeaderProvider,
+  contextAtom,
+  contextAtomMethod,
+} = createJotaiContext();
+
+export {
+  ProviderJotaiContextHomeHeader,
+  contextAtomMethod,
+  withHomeHeaderProvider,
+};
+
+export const { atom: homeHeaderDataAtom, use: useHomeHeaderDataAtom } =
+  contextAtom<IHomeHeaderData>({
+    totalBalance: '0',
+    tokenWorth: '0',
+    defiNetWorth: '0',
+    tokenWorthMap: {},
+    createAtNetworkWorth: '0',
+    accountId: '',
+    initialized: false,
+    isRefreshing: false,
+  });

--- a/packages/kit/src/states/jotai/contexts/homeHeader/index.ts
+++ b/packages/kit/src/states/jotai/contexts/homeHeader/index.ts
@@ -1,0 +1,2 @@
+export * from './actions';
+export * from './atoms';

--- a/packages/kit/src/states/jotai/contexts/tokenList/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/tokenList/actions.ts
@@ -12,6 +12,7 @@ import {
   sortTokensByFiatValue,
   sortTokensByOrder,
 } from '@onekeyhq/shared/src/utils/tokenUtils';
+import type { IHomeTokenListData } from '@onekeyhq/kit-bg/src/dbs/simple/entity/SimpleDbEntityHomePageData';
 import type {
   ETokenListSortType,
   IAccountToken,
@@ -30,6 +31,7 @@ import {
   contextAtomMethod,
   createAccountStateAtom,
   flattenAggregateTokensMapAtom,
+  homeTokenListDataAtom,
   riskyTokenListAtom,
   riskyTokenListMapAtom,
   searchKeyAtom,
@@ -594,6 +596,12 @@ class ContextJotaiActionsTokenList extends ContextJotaiActionsBase {
     },
   );
 
+  setHomeTokenListData = contextAtomMethod(
+    (get, set, payload: IHomeTokenListData) => {
+      set(homeTokenListDataAtom(), payload);
+    },
+  );
+
   updateTokenListSort = contextAtomMethod(
     (
       get,
@@ -665,6 +673,8 @@ export function useTokenListActions() {
   const refreshAggregateTokensListMap =
     actions.refreshAggregateTokensListMap.use();
 
+  const setHomeTokenListData = actions.setHomeTokenListData.use();
+
   return useRef({
     refreshSearchTokenList,
     refreshAllTokenList,
@@ -685,5 +695,6 @@ export function useTokenListActions() {
     updateTokenListSort,
     refreshAggregateTokensMap,
     refreshAggregateTokensListMap,
+    setHomeTokenListData,
   });
 }

--- a/packages/kit/src/states/jotai/contexts/tokenList/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/tokenList/atoms.ts
@@ -1,3 +1,4 @@
+import type { IHomeTokenListData } from '@onekeyhq/kit-bg/src/dbs/simple/entity/SimpleDbEntityHomePageData';
 import { flattenAggregateTokensMap } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type { IAccountToken, ITokenFiat } from '@onekeyhq/shared/types/token';
 import { ETokenListSortType } from '@onekeyhq/shared/types/token';
@@ -176,4 +177,18 @@ export const { atom: tokenListSortAtom, use: useTokenListSortAtom } =
   }>({
     sortType: ETokenListSortType.Value,
     sortDirection: 'desc',
+  });
+
+export const { atom: homeTokenListDataAtom, use: useHomeTokenListDataAtom } =
+  contextAtom<IHomeTokenListData>({
+    tokens: [],
+    smallBalanceTokens: [],
+    riskyTokens: [],
+    tokenFiatMap: {},
+    smallBalanceFiatValue: '0',
+    aggregateTokensMap: {},
+    aggregateTokensListMap: {},
+    allTokens: [],
+    initialized: false,
+    isRefreshing: false,
   });

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -1183,6 +1183,73 @@ function TokenListBlock({
         });
 
         perfTokenListView.markEnd('handleAllNetworkCacheData');
+
+        // Save home page cache for instant startup
+        const allCacheTokenListMap = {
+          ...tokenListMap,
+          ...flattenLocalAggregateTokenMap,
+        };
+        const sortedTokens = sortTokensByFiatValue({
+          tokens: tokenList,
+          map: allCacheTokenListMap,
+        });
+        const highValueTokens = sortedTokens.slice(
+          0,
+          TOKEN_LIST_HIGH_VALUE_MAX,
+        );
+        const lowValueTokens = sortedTokens.slice(TOKEN_LIST_HIGH_VALUE_MAX);
+        const lowValueFiatValue = lowValueTokens
+          .reduce(
+            (acc, t) =>
+              acc.plus(allCacheTokenListMap[t.$key]?.fiatValue ?? '0'),
+            new BigNumber(0),
+          )
+          .toFixed();
+
+        void backgroundApiProxy.serviceToken.saveHomePageCache({
+          accountId: account?.id ?? '',
+          networkId: network?.id ?? '',
+          data: {
+            accountWorth: {
+              worth: tokenListValue,
+              createAtNetworkWorth:
+                tokenListValue[
+                  accountUtils.buildAccountValueKey({
+                    accountId: account?.id ?? '',
+                    networkId: account?.createAtNetwork ?? '',
+                  })
+                ] ?? '0',
+              accountId: account?.id ?? '',
+            },
+            tokenList: {
+              tokens: highValueTokens,
+              keys: `${accountId}_${networkId}_local_all`,
+            },
+            tokenListMap,
+            smallBalanceTokens: {
+              smallBalanceTokens: lowValueTokens,
+              keys: `${accountId}_${networkId}_local_all`,
+            },
+            smallBalanceTokenListMap: tokenListMap,
+            smallBalanceTokensFiatValue: lowValueFiatValue,
+            riskyTokens: {
+              riskyTokens: riskyTokenList,
+              keys: `${accountId}_${networkId}_local_all`,
+            },
+            riskyTokenListMap: tokenListMap,
+            allTokenList: {
+              tokens: [...tokenList, ...riskyTokenList],
+              keys: `${accountId}_${networkId}_local_all`,
+            },
+            allTokenListMap: {
+              ...tokenListMap,
+              ...flattenLocalAggregateTokenMap,
+            },
+            aggregateTokensMap: localAggregateTokenMap,
+            aggregateTokensListMap: localAggregateTokenListMap,
+            updatedAt: Date.now(),
+          },
+        });
       }
     },
     [
@@ -1511,12 +1578,48 @@ function TokenListBlock({
           ...flattenAggregateTokenMap,
         },
       });
+
+      // Save home page cache for instant startup
+      if (network?.isAllNetworks) {
+        const allTokenListMapData = {
+          ...mergeTokenListMap,
+          ...riskyTokenListMap,
+          ...flattenAggregateTokenMap,
+        };
+        void backgroundApiProxy.serviceToken.saveHomePageCache({
+          accountId: account?.id ?? '',
+          networkId: network?.id ?? '',
+          data: {
+            accountWorth: {
+              worth: accountsWorth,
+              createAtNetworkWorth: createAtNetworkWorth.toFixed(),
+              accountId: account?.id ?? '',
+            },
+            tokenList,
+            tokenListMap: mergeTokenListMap,
+            smallBalanceTokens: smallBalanceTokenList,
+            smallBalanceTokenListMap: mergeTokenListMap,
+            smallBalanceTokensFiatValue: smallBalanceTokensFiatValue.toFixed(),
+            riskyTokens: riskyTokenList,
+            riskyTokenListMap,
+            allTokenList: {
+              tokens: [...mergedTokens, ...riskyTokenList.riskyTokens],
+              keys: `${tokenList.keys}_${smallBalanceTokenList.keys}_${riskyTokenList.keys}`,
+            },
+            allTokenListMap: allTokenListMapData,
+            aggregateTokensMap: aggregateTokenMap,
+            aggregateTokensListMap: aggregateTokenListMap,
+            updatedAt: Date.now(),
+          },
+        });
+      }
     }
   }, [
     account?.createAtNetwork,
     account?.id,
     allNetworksResult,
     network?.id,
+    network?.isAllNetworks,
     refreshAllTokenList,
     refreshAllTokenListMap,
     refreshAggregateTokensListMap,
@@ -1550,16 +1653,88 @@ function TokenListBlock({
       });
 
       if (networkId === networkIdsMap.onekeyall) {
-        perfTokenListView.markStart('tokenListRefreshing_1');
-        updateTokenListState({
-          initialized: false,
-          isRefreshing: true,
-        });
-        updateAccountOverviewState({
-          initialized: false,
-          isRefreshing: true,
-        });
-        handleClearAllNetworkData();
+        // Try loading home page cache first to avoid skeleton
+        const homePageCache =
+          await backgroundApiProxy.serviceToken.getHomePageCache({
+            accountId: account?.id ?? '',
+            networkId,
+          });
+
+        if (homePageCache) {
+          // Populate atoms with cached data immediately
+          updateAccountWorth({
+            accountId: homePageCache.accountWorth.accountId,
+            initialized: true,
+            worth: homePageCache.accountWorth.worth,
+            createAtNetworkWorth:
+              homePageCache.accountWorth.createAtNetworkWorth,
+            updateAll: true,
+          });
+          refreshTokenList({
+            tokens: homePageCache.tokenList.tokens,
+            keys: homePageCache.tokenList.keys,
+          });
+          refreshTokenListMap({
+            tokens: {
+              ...homePageCache.tokenListMap,
+              ...homePageCache.smallBalanceTokenListMap,
+              ...homePageCache.riskyTokenListMap,
+            },
+          });
+          refreshSmallBalanceTokenList({
+            smallBalanceTokens:
+              homePageCache.smallBalanceTokens.smallBalanceTokens,
+            keys: homePageCache.smallBalanceTokens.keys,
+          });
+          refreshSmallBalanceTokenListMap({
+            tokens: homePageCache.smallBalanceTokenListMap,
+          });
+          refreshSmallBalanceTokensFiatValue({
+            value: homePageCache.smallBalanceTokensFiatValue,
+          });
+          refreshRiskyTokenList({
+            riskyTokens: homePageCache.riskyTokens.riskyTokens,
+            keys: homePageCache.riskyTokens.keys,
+          });
+          refreshRiskyTokenListMap({
+            tokens: homePageCache.riskyTokenListMap,
+          });
+          refreshAllTokenList({
+            tokens: homePageCache.allTokenList.tokens,
+            keys: homePageCache.allTokenList.keys,
+            accountId: account?.id,
+            networkId: network?.id,
+          });
+          refreshAllTokenListMap({
+            tokens: homePageCache.allTokenListMap,
+          });
+          refreshAggregateTokensMap({
+            tokens: homePageCache.aggregateTokensMap,
+          });
+          refreshAggregateTokensListMap({
+            tokens: homePageCache.aggregateTokensListMap,
+          });
+          updateAccountOverviewState({
+            initialized: true,
+            isRefreshing: false,
+          });
+          updateTokenListState({
+            initialized: true,
+            isRefreshing: false,
+          });
+        } else {
+          // No cache, show skeleton as before
+          perfTokenListView.markStart('tokenListRefreshing_1');
+          updateTokenListState({
+            initialized: false,
+            isRefreshing: true,
+          });
+          updateAccountOverviewState({
+            initialized: false,
+            isRefreshing: true,
+          });
+          handleClearAllNetworkData();
+        }
         return;
       }
 
@@ -1766,8 +1941,11 @@ function TokenListBlock({
     refreshRiskyTokenListMap,
     refreshSmallBalanceTokenList,
     refreshSmallBalanceTokenListMap,
+    refreshSmallBalanceTokensFiatValue,
     refreshTokenList,
     refreshTokenListMap,
+    refreshAggregateTokensMap,
+    refreshAggregateTokensListMap,
     updateAccountOverviewState,
     updateAccountWorth,
     updateSearchKey,

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -87,6 +87,11 @@ import type {
   ITokenFiat,
 } from '@onekeyhq/shared/types/token';
 
+import { useHomeHeaderActions } from '@onekeyhq/kit/src/states/jotai/contexts/homeHeader';
+import {
+  buildHomeHeaderDataFromWorth,
+  buildHomeTokenListData,
+} from '../../hooks/useHomePageDataController';
 import { RichBlock } from '../RichBlock/RichBlock';
 
 const networkIdsMap = getNetworkIdsMap();
@@ -232,6 +237,7 @@ function TokenListBlock({
     refreshAggregateTokensMap,
     updateTokenListState,
     updateSearchKey,
+    setHomeTokenListData,
   } = useTokenListActions().current;
 
   const [aggregateTokenListMapAtom] = useAggregateTokensListMapAtom();
@@ -241,6 +247,8 @@ function TokenListBlock({
     updateAccountOverviewState,
     updateAllNetworksState,
   } = useAccountOverviewActions().current;
+
+  const { setHomeHeaderData } = useHomeHeaderActions().current;
 
   const { result: homeDefaultTokenMap } = usePromiseResult(async () => {
     const r = await backgroundApiProxy.serviceToken.getHomeDefaultTokenMap();
@@ -1206,49 +1214,42 @@ function TokenListBlock({
           )
           .toFixed();
 
-        void backgroundApiProxy.serviceToken.saveHomePageCache({
+        // Save V2 cache + update new flat atoms
+        const allFiatMap = {
+          ...tokenListMap,
+          ...flattenLocalAggregateTokenMap,
+        };
+        const headerData = buildHomeHeaderDataFromWorth({
           accountId: account?.id ?? '',
           networkId: network?.id ?? '',
-          data: {
-            accountWorth: {
-              worth: tokenListValue,
-              createAtNetworkWorth:
-                tokenListValue[
-                  accountUtils.buildAccountValueKey({
-                    accountId: account?.id ?? '',
-                    networkId: account?.createAtNetwork ?? '',
-                  })
-                ] ?? '0',
-              accountId: account?.id ?? '',
-            },
-            tokenList: {
-              tokens: highValueTokens,
-              keys: `${accountId}_${networkId}_local_all`,
-            },
-            tokenListMap,
-            smallBalanceTokens: {
-              smallBalanceTokens: lowValueTokens,
-              keys: `${accountId}_${networkId}_local_all`,
-            },
-            smallBalanceTokenListMap: tokenListMap,
-            smallBalanceTokensFiatValue: lowValueFiatValue,
-            riskyTokens: {
-              riskyTokens: riskyTokenList,
-              keys: `${accountId}_${networkId}_local_all`,
-            },
-            riskyTokenListMap: tokenListMap,
-            allTokenList: {
-              tokens: [...tokenList, ...riskyTokenList],
-              keys: `${accountId}_${networkId}_local_all`,
-            },
-            allTokenListMap: {
-              ...tokenListMap,
-              ...flattenLocalAggregateTokenMap,
-            },
-            aggregateTokensMap: localAggregateTokenMap,
-            aggregateTokensListMap: localAggregateTokenListMap,
-            updatedAt: Date.now(),
-          },
+          worthMap: tokenListValue,
+          createAtNetworkWorth:
+            tokenListValue[
+              accountUtils.buildAccountValueKey({
+                accountId: account?.id ?? '',
+                networkId: account?.createAtNetwork ?? '',
+              })
+            ] ?? '0',
+          defiNetWorth: '0',
+          mergeDeriveAssetsEnabled: !!vaultSettings?.mergeDeriveAssetsEnabled,
+        });
+        const tokenListDataV2 = buildHomeTokenListData({
+          tokens: highValueTokens,
+          smallBalanceTokens: lowValueTokens,
+          riskyTokens: riskyTokenList,
+          tokenFiatMap: allFiatMap,
+          smallBalanceFiatValue: lowValueFiatValue,
+          aggregateTokensMap: localAggregateTokenMap,
+          aggregateTokensListMap: localAggregateTokenListMap,
+          allTokens: [...tokenList, ...riskyTokenList],
+        });
+        setHomeHeaderData(headerData);
+        setHomeTokenListData(tokenListDataV2);
+        void backgroundApiProxy.serviceToken.buildHomePageData({
+          headerData,
+          tokenListData: tokenListDataV2,
+          accountId: account?.id ?? '',
+          networkId: network?.id ?? '',
         });
       }
     },
@@ -1256,6 +1257,7 @@ function TokenListBlock({
       account?.createAtNetwork,
       account?.id,
       network?.id,
+      vaultSettings?.mergeDeriveAssetsEnabled,
       refreshAggregateTokensListMap,
       refreshAggregateTokensMap,
       refreshAllTokenList,
@@ -1268,6 +1270,8 @@ function TokenListBlock({
       updateAccountOverviewState,
       updateAccountWorth,
       updateTokenListState,
+      setHomeHeaderData,
+      setHomeTokenListData,
     ],
   );
 
@@ -1586,31 +1590,32 @@ function TokenListBlock({
           ...riskyTokenListMap,
           ...flattenAggregateTokenMap,
         };
-        void backgroundApiProxy.serviceToken.saveHomePageCache({
+        // Save V2 cache + update new flat atoms
+        const headerData = buildHomeHeaderDataFromWorth({
           accountId: account?.id ?? '',
           networkId: network?.id ?? '',
-          data: {
-            accountWorth: {
-              worth: accountsWorth,
-              createAtNetworkWorth: createAtNetworkWorth.toFixed(),
-              accountId: account?.id ?? '',
-            },
-            tokenList,
-            tokenListMap: mergeTokenListMap,
-            smallBalanceTokens: smallBalanceTokenList,
-            smallBalanceTokenListMap: mergeTokenListMap,
-            smallBalanceTokensFiatValue: smallBalanceTokensFiatValue.toFixed(),
-            riskyTokens: riskyTokenList,
-            riskyTokenListMap,
-            allTokenList: {
-              tokens: [...mergedTokens, ...riskyTokenList.riskyTokens],
-              keys: `${tokenList.keys}_${smallBalanceTokenList.keys}_${riskyTokenList.keys}`,
-            },
-            allTokenListMap: allTokenListMapData,
-            aggregateTokensMap: aggregateTokenMap,
-            aggregateTokensListMap: aggregateTokenListMap,
-            updatedAt: Date.now(),
-          },
+          worthMap: accountsWorth,
+          createAtNetworkWorth: createAtNetworkWorth.toFixed(),
+          defiNetWorth: '0',
+          mergeDeriveAssetsEnabled: !!vaultSettings?.mergeDeriveAssetsEnabled,
+        });
+        const tokenListDataV2 = buildHomeTokenListData({
+          tokens: tokenList.tokens,
+          smallBalanceTokens: smallBalanceTokenList.smallBalanceTokens,
+          riskyTokens: riskyTokenList.riskyTokens,
+          tokenFiatMap: allTokenListMapData,
+          smallBalanceFiatValue: smallBalanceTokensFiatValue.toFixed(),
+          aggregateTokensMap: aggregateTokenMap,
+          aggregateTokensListMap: aggregateTokenListMap,
+          allTokens: [...mergedTokens, ...riskyTokenList.riskyTokens],
+        });
+        setHomeHeaderData(headerData);
+        setHomeTokenListData(tokenListDataV2);
+        void backgroundApiProxy.serviceToken.buildHomePageData({
+          headerData,
+          tokenListData: tokenListDataV2,
+          accountId: account?.id ?? '',
+          networkId: network?.id ?? '',
         });
       }
     }
@@ -1620,6 +1625,7 @@ function TokenListBlock({
     allNetworksResult,
     network?.id,
     network?.isAllNetworks,
+    vaultSettings?.mergeDeriveAssetsEnabled,
     refreshAllTokenList,
     refreshAllTokenListMap,
     refreshAggregateTokensListMap,
@@ -1632,6 +1638,8 @@ function TokenListBlock({
     refreshTokenList,
     refreshTokenListMap,
     updateAccountWorth,
+    setHomeHeaderData,
+    setHomeTokenListData,
   ]);
 
   useEffect(() => {
@@ -1653,66 +1661,65 @@ function TokenListBlock({
       });
 
       if (networkId === networkIdsMap.onekeyall) {
-        // Try loading home page cache first to avoid skeleton
-        const homePageCache =
-          await backgroundApiProxy.serviceToken.getHomePageCache({
+        // Try V2 cache first, then fall back to V1
+        let cacheLoaded = false;
+
+        const cacheV2 =
+          await backgroundApiProxy.serviceToken.getHomePageCacheV2({
             accountId: account?.id ?? '',
             networkId,
           });
 
-        if (homePageCache) {
-          // Populate atoms with cached data immediately
+        if (cacheV2) {
+          // V2: dispatch to new flat atoms + legacy atoms
+          setHomeHeaderData(cacheV2.header);
+          setHomeTokenListData(cacheV2.tokenList);
+
           updateAccountWorth({
-            accountId: homePageCache.accountWorth.accountId,
+            accountId: cacheV2.header.accountId,
             initialized: true,
-            worth: homePageCache.accountWorth.worth,
-            createAtNetworkWorth:
-              homePageCache.accountWorth.createAtNetworkWorth,
+            worth: cacheV2.header.tokenWorthMap,
+            createAtNetworkWorth: cacheV2.header.createAtNetworkWorth,
             updateAll: true,
           });
           refreshTokenList({
-            tokens: homePageCache.tokenList.tokens,
-            keys: homePageCache.tokenList.keys,
+            tokens: cacheV2.tokenList.tokens,
+            keys: 'homePageCacheV2',
           });
           refreshTokenListMap({
-            tokens: {
-              ...homePageCache.tokenListMap,
-              ...homePageCache.smallBalanceTokenListMap,
-              ...homePageCache.riskyTokenListMap,
-            },
+            tokens: cacheV2.tokenList.tokenFiatMap,
           });
           refreshSmallBalanceTokenList({
-            smallBalanceTokens:
-              homePageCache.smallBalanceTokens.smallBalanceTokens,
-            keys: homePageCache.smallBalanceTokens.keys,
+            smallBalanceTokens: cacheV2.tokenList.smallBalanceTokens,
+            keys: 'homePageCacheV2',
           });
           refreshSmallBalanceTokenListMap({
-            tokens: homePageCache.smallBalanceTokenListMap,
+            tokens: cacheV2.tokenList.tokenFiatMap,
           });
           refreshSmallBalanceTokensFiatValue({
-            value: homePageCache.smallBalanceTokensFiatValue,
+            value: cacheV2.tokenList.smallBalanceFiatValue,
           });
           refreshRiskyTokenList({
-            riskyTokens: homePageCache.riskyTokens.riskyTokens,
-            keys: homePageCache.riskyTokens.keys,
+            riskyTokens: cacheV2.tokenList.riskyTokens,
+            keys: 'homePageCacheV2',
           });
           refreshRiskyTokenListMap({
-            tokens: homePageCache.riskyTokenListMap,
+            tokens: cacheV2.tokenList.tokenFiatMap,
           });
           refreshAllTokenList({
-            tokens: homePageCache.allTokenList.tokens,
-            keys: homePageCache.allTokenList.keys,
+            tokens: cacheV2.tokenList.allTokens,
+            keys: 'homePageCacheV2_all',
             accountId: account?.id,
             networkId: network?.id,
           });
           refreshAllTokenListMap({
-            tokens: homePageCache.allTokenListMap,
+            tokens: cacheV2.tokenList.tokenFiatMap,
           });
           refreshAggregateTokensMap({
-            tokens: homePageCache.aggregateTokensMap,
+            tokens: cacheV2.tokenList.aggregateTokensMap,
           });
           refreshAggregateTokensListMap({
-            tokens: homePageCache.aggregateTokensListMap,
+            tokens: cacheV2.tokenList.aggregateTokensListMap,
           });
           updateAccountOverviewState({
             initialized: true,
@@ -1722,7 +1729,10 @@ function TokenListBlock({
             initialized: true,
             isRefreshing: false,
           });
-        } else {
+          cacheLoaded = true;
+        }
+
+        if (!cacheLoaded) {
           // No cache, show skeleton as before
           perfTokenListView.markStart('tokenListRefreshing_1');
           updateTokenListState({
@@ -1950,6 +1960,8 @@ function TokenListBlock({
     updateAccountWorth,
     updateSearchKey,
     updateTokenListState,
+    setHomeHeaderData,
+    setHomeTokenListData,
     wallet?.id,
   ]);
 

--- a/packages/kit/src/views/Home/hooks/useHomePageDataController.ts
+++ b/packages/kit/src/views/Home/hooks/useHomePageDataController.ts
@@ -1,0 +1,248 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import BigNumber from 'bignumber.js';
+
+import type {
+  IHomeHeaderData,
+  IHomeTokenListData,
+} from '@onekeyhq/kit-bg/src/dbs/simple/entity/SimpleDbEntityHomePageData';
+import { calculateAccountTokensValue } from '@onekeyhq/shared/src/utils/tokenUtils';
+import type { IAccountToken, ITokenFiat } from '@onekeyhq/shared/types/token';
+
+import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
+import { useAccountOverviewActions } from '../../../states/jotai/contexts/accountOverview';
+import { useActiveAccount } from '../../../states/jotai/contexts/accountSelector';
+import { useHomeHeaderActions } from '../../../states/jotai/contexts/homeHeader';
+import { useTokenListActions } from '../../../states/jotai/contexts/tokenList';
+
+// Build V2 header + tokenList data from the V1 atom-compatible data.
+// This is the bridge between old data sources and new flat stores.
+export function buildHomeHeaderDataFromWorth({
+  accountId,
+  networkId,
+  worthMap,
+  createAtNetworkWorth,
+  defiNetWorth,
+  mergeDeriveAssetsEnabled,
+}: {
+  accountId: string;
+  networkId: string;
+  worthMap: Record<string, string>;
+  createAtNetworkWorth: string;
+  defiNetWorth: string;
+  mergeDeriveAssetsEnabled: boolean;
+}): IHomeHeaderData {
+  const tokensWorth = {
+    worth: worthMap,
+    createAtNetworkWorth,
+    accountId,
+    initialized: true,
+  };
+  const tokenWorth = calculateAccountTokensValue({
+    accountId,
+    networkId,
+    tokensWorth,
+    mergeDeriveAssetsEnabled,
+  });
+  const totalBalance = new BigNumber(tokenWorth)
+    .plus(defiNetWorth ?? '0')
+    .toFixed();
+
+  return {
+    totalBalance,
+    tokenWorth,
+    defiNetWorth,
+    tokenWorthMap: worthMap,
+    createAtNetworkWorth,
+    accountId,
+    initialized: true,
+    isRefreshing: false,
+  };
+}
+
+export function buildHomeTokenListData({
+  tokens,
+  smallBalanceTokens,
+  riskyTokens,
+  tokenFiatMap,
+  smallBalanceFiatValue,
+  aggregateTokensMap,
+  aggregateTokensListMap,
+  allTokens,
+}: {
+  tokens: IAccountToken[];
+  smallBalanceTokens: IAccountToken[];
+  riskyTokens: IAccountToken[];
+  tokenFiatMap: Record<string, ITokenFiat>;
+  smallBalanceFiatValue: string;
+  aggregateTokensMap: Record<string, Record<string, ITokenFiat>>;
+  aggregateTokensListMap: Record<string, { tokens: IAccountToken[] }>;
+  allTokens: IAccountToken[];
+}): IHomeTokenListData {
+  return {
+    tokens,
+    smallBalanceTokens,
+    riskyTokens,
+    tokenFiatMap,
+    smallBalanceFiatValue,
+    aggregateTokensMap,
+    aggregateTokensListMap,
+    allTokens,
+    initialized: true,
+    isRefreshing: false,
+  };
+}
+
+export function useHomePageDataController() {
+  const {
+    activeAccount: { account, network },
+  } = useActiveAccount({ num: 0 });
+
+  const { setHomeHeaderData } = useHomeHeaderActions().current;
+
+  const { setHomeTokenListData } = useTokenListActions().current;
+
+  const { updateAccountWorth, updateAccountOverviewState } =
+    useAccountOverviewActions().current;
+
+  const {
+    refreshTokenList,
+    refreshTokenListMap,
+    refreshSmallBalanceTokenList,
+    refreshSmallBalanceTokenListMap,
+    refreshSmallBalanceTokensFiatValue,
+    refreshRiskyTokenList,
+    refreshRiskyTokenListMap,
+    refreshAllTokenList,
+    refreshAllTokenListMap,
+    refreshAggregateTokensMap,
+    refreshAggregateTokensListMap,
+    updateTokenListState,
+  } = useTokenListActions().current;
+
+  const prevAccountIdRef = useRef<string>('');
+
+  // Dispatch V2 cache data to both new and legacy atoms
+  const dispatchV2CacheToStores = useCallback(
+    (header: IHomeHeaderData, tokenList: IHomeTokenListData) => {
+      // New stores
+      setHomeHeaderData(header);
+      setHomeTokenListData(tokenList);
+
+      // Legacy atoms (compatibility during transition)
+      updateAccountWorth({
+        accountId: header.accountId,
+        initialized: true,
+        worth: header.tokenWorthMap,
+        createAtNetworkWorth: header.createAtNetworkWorth,
+        updateAll: true,
+      });
+      updateAccountOverviewState({
+        initialized: true,
+        isRefreshing: false,
+      });
+      updateTokenListState({
+        initialized: true,
+        isRefreshing: false,
+      });
+
+      const allFiatMap = {
+        ...tokenList.tokenFiatMap,
+      };
+
+      refreshTokenList({
+        tokens: tokenList.tokens,
+        keys: 'homePageCache',
+      });
+      refreshTokenListMap({
+        tokens: allFiatMap,
+      });
+      refreshSmallBalanceTokenList({
+        smallBalanceTokens: tokenList.smallBalanceTokens,
+        keys: 'homePageCache',
+      });
+      refreshSmallBalanceTokenListMap({
+        tokens: allFiatMap,
+      });
+      refreshSmallBalanceTokensFiatValue({
+        value: tokenList.smallBalanceFiatValue,
+      });
+      refreshRiskyTokenList({
+        riskyTokens: tokenList.riskyTokens,
+        keys: 'homePageCache',
+      });
+      refreshRiskyTokenListMap({
+        tokens: allFiatMap,
+      });
+      refreshAllTokenList({
+        tokens: tokenList.allTokens,
+        keys: 'homePageCache_all',
+        accountId: account?.id,
+        networkId: network?.id,
+      });
+      refreshAllTokenListMap({
+        tokens: allFiatMap,
+      });
+      refreshAggregateTokensMap({
+        tokens: tokenList.aggregateTokensMap,
+      });
+      refreshAggregateTokensListMap({
+        tokens: tokenList.aggregateTokensListMap,
+      });
+    },
+    [
+      account?.id,
+      network?.id,
+      setHomeHeaderData,
+      setHomeTokenListData,
+      updateAccountWorth,
+      updateAccountOverviewState,
+      updateTokenListState,
+      refreshTokenList,
+      refreshTokenListMap,
+      refreshSmallBalanceTokenList,
+      refreshSmallBalanceTokenListMap,
+      refreshSmallBalanceTokensFiatValue,
+      refreshRiskyTokenList,
+      refreshRiskyTokenListMap,
+      refreshAllTokenList,
+      refreshAllTokenListMap,
+      refreshAggregateTokensMap,
+      refreshAggregateTokensListMap,
+    ],
+  );
+
+  // Cold start: load V2 cache and dispatch to all stores
+  useEffect(() => {
+    if (!account?.id || !network?.id) return;
+    if (!network.isAllNetworks) return;
+
+    // Only run on account change to avoid duplicate loads
+    if (prevAccountIdRef.current === `${account.id}_${network.id}`) return;
+    prevAccountIdRef.current = `${account.id}_${network.id}`;
+
+    void (async () => {
+      const cacheV2 = await backgroundApiProxy.serviceToken.getHomePageCacheV2({
+        accountId: account.id,
+        networkId: network.id,
+      });
+
+      if (cacheV2) {
+        dispatchV2CacheToStores(cacheV2.header, cacheV2.tokenList);
+      }
+    })();
+  }, [
+    account?.id,
+    network?.id,
+    network?.isAllNetworks,
+    dispatchV2CacheToStores,
+  ]);
+
+  // Save V2 cache whenever accountWorth is updated with fresh data
+  // This replaces the two saveHomePageCache calls in TokenListBlock
+  return {
+    dispatchV2CacheToStores,
+    buildHomeHeaderDataFromWorth,
+    buildHomeTokenListData,
+  };
+}

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -43,6 +43,7 @@ import {
   useAccountWorthAtom,
 } from '../../../states/jotai/contexts/accountOverview';
 import { useActiveAccount } from '../../../states/jotai/contexts/accountSelector';
+import { useHomeHeaderDataAtom } from '../../../states/jotai/contexts/homeHeader';
 import { showBalanceDetailsDialog } from '../components/BalanceDetailsDialog';
 
 import type { FontSizeTokens } from 'tamagui';
@@ -66,11 +67,8 @@ function HomeOverviewContainer() {
   const [accountWorth] = useAccountWorthAtom();
   const [accountDeFiOverview] = useAccountDeFiOverviewAtom();
   const [overviewState] = useAccountOverviewStateAtom();
-  const {
-    updateAccountOverviewState,
-    updateAccountWorth,
-    updateAccountDeFiOverview,
-  } = useAccountOverviewActions().current;
+  const [homeHeaderData] = useHomeHeaderDataAtom();
+  const { updateAccountDeFiOverview } = useAccountOverviewActions().current;
 
   const [settings] = useSettingsPersistAtom();
 
@@ -94,27 +92,8 @@ function HomeOverviewContainer() {
         network.isAllNetworks ||
         (wallet.type === WALLET_TYPE_HD && !wallet.backuped)
       ) {
-        // Try loading cached accountWorth to avoid brief $0 flash
-        void (async () => {
-          const cache = await backgroundApiProxy.serviceToken.getHomePageCache({
-            accountId: account.id,
-            networkId: network.id,
-          });
-          if (cache) {
-            updateAccountWorth({
-              accountId: cache.accountWorth.accountId,
-              worth: cache.accountWorth.worth,
-              createAtNetworkWorth: cache.accountWorth.createAtNetworkWorth,
-              initialized: true,
-            });
-          } else {
-            updateAccountWorth({
-              accountId: account.id,
-              worth: {},
-              initialized: false,
-            });
-          }
-        })();
+        // Cache loading for accountWorth is handled by useHomePageDataController
+        // Only reset DeFi overview here
         updateAccountDeFiOverview({
           overview: {
             totalValue: 0,
@@ -130,8 +109,6 @@ function HomeOverviewContainer() {
     network?.id,
     network?.isAllNetworks,
     updateAccountDeFiOverview,
-    updateAccountOverviewState,
-    updateAccountWorth,
     wallet?.backuped,
     wallet?.id,
     wallet?.type,
@@ -347,6 +324,11 @@ function HomeOverviewContainer() {
   }, [account?.id, network?.id]);
 
   const balanceString = useMemo(() => {
+    // Use pre-computed totalBalance from homeHeader store when available
+    if (homeHeaderData.initialized) {
+      return homeHeaderData.totalBalance;
+    }
+    // Fallback to legacy computation for single-network or during transition
     return new BigNumber(
       calculateAccountTokensValue({
         accountId: account?.id ?? '',
@@ -358,6 +340,8 @@ function HomeOverviewContainer() {
       .plus(accountDeFiOverview.netWorth ?? 0)
       .toFixed();
   }, [
+    homeHeaderData.initialized,
+    homeHeaderData.totalBalance,
     account?.id,
     network?.id,
     accountWorth,
@@ -378,8 +362,16 @@ function HomeOverviewContainer() {
   };
 
   const showSkeleton = useMemo(() => {
+    // Show skeleton when neither new homeHeader nor legacy overview is initialized
+    if (!homeHeaderData.initialized && !overviewState.initialized) {
+      return true;
+    }
     return overviewState.isRefreshing && !overviewState.initialized;
-  }, [overviewState.isRefreshing, overviewState.initialized]);
+  }, [
+    homeHeaderData.initialized,
+    overviewState.isRefreshing,
+    overviewState.initialized,
+  ]);
 
   return (
     <YStack gap="$2.5" alignItems="flex-start">

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -94,11 +94,27 @@ function HomeOverviewContainer() {
         network.isAllNetworks ||
         (wallet.type === WALLET_TYPE_HD && !wallet.backuped)
       ) {
-        updateAccountWorth({
-          accountId: account.id,
-          worth: {},
-          initialized: false,
-        });
+        // Try loading cached accountWorth to avoid brief $0 flash
+        void (async () => {
+          const cache = await backgroundApiProxy.serviceToken.getHomePageCache({
+            accountId: account.id,
+            networkId: network.id,
+          });
+          if (cache) {
+            updateAccountWorth({
+              accountId: cache.accountWorth.accountId,
+              worth: cache.accountWorth.worth,
+              createAtNetworkWorth: cache.accountWorth.createAtNetworkWorth,
+              initialized: true,
+            });
+          } else {
+            updateAccountWorth({
+              accountId: account.id,
+              worth: {},
+              initialized: false,
+            });
+          }
+        })();
         updateAccountDeFiOverview({
           overview: {
             totalValue: 0,

--- a/packages/kit/src/views/Home/pages/HomePageContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageContainer.tsx
@@ -7,6 +7,7 @@ import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import { AccountSelectorProviderMirror } from '../../../components/AccountSelector';
 import { TabletHomeContainer } from '../../../components/TabletHomeContainer';
 import { withAccountOverviewProvider } from '../../../states/jotai/contexts/accountOverview';
+import { ProviderJotaiContextHomeHeader } from '../../../states/jotai/contexts/homeHeader';
 import {
   useActiveAccount,
   useSelectedAccount,
@@ -63,35 +64,37 @@ function HomePageContainer() {
   }
   const sceneName = EAccountSelectorSceneName.home;
   return (
-    <TabletHomeContainer>
-      <AccountSelectorProviderMirror
-        config={{
-          sceneName,
-          sceneUrl: '',
-        }}
-        enabledNum={[0]}
-      >
-        <HomePageView
-          key={sceneName}
-          sceneName={sceneName}
-          onPressHide={() => setIsHide((v) => !v)}
-        />
-        <DAppConnectExtensionFloatingTrigger />
-        <OnboardingOnMount />
-        <NotificationRegisterDaily />
-        <BTCFreshAddressProvider />
-        {/* <UrlAccountAutoReplaceHistory num={0} /> */}
+    <ProviderJotaiContextHomeHeader>
+      <TabletHomeContainer>
+        <AccountSelectorProviderMirror
+          config={{
+            sceneName,
+            sceneUrl: '',
+          }}
+          enabledNum={[0]}
+        >
+          <HomePageView
+            key={sceneName}
+            sceneName={sceneName}
+            onPressHide={() => setIsHide((v) => !v)}
+          />
+          <DAppConnectExtensionFloatingTrigger />
+          <OnboardingOnMount />
+          <NotificationRegisterDaily />
+          <BTCFreshAddressProvider />
+          {/* <UrlAccountAutoReplaceHistory num={0} /> */}
 
-        {process.env.NODE_ENV !== 'production' ? (
-          <>
-            <SelectedAccountsMapTest />
-            <SelectedAccountTest />
-            <ActiveAccountTest />
-            <EmptyRenderTest />
-          </>
-        ) : null}
-      </AccountSelectorProviderMirror>
-    </TabletHomeContainer>
+          {process.env.NODE_ENV !== 'production' ? (
+            <>
+              <SelectedAccountsMapTest />
+              <SelectedAccountTest />
+              <ActiveAccountTest />
+              <EmptyRenderTest />
+            </>
+          ) : null}
+        </AccountSelectorProviderMirror>
+      </TabletHomeContainer>
+    </ProviderJotaiContextHomeHeader>
   );
 }
 


### PR DESCRIPTION
## Summary

- Add a new `SimpleDbEntityHomePageData` entity to cache the final merged home page state (balance + token list) per account+network
- On cold start, load the single cached snapshot instead of N per-network reads + merge, eliminating skeleton/loading flash
- Save cache (debounced 3s) after every successful data load for next startup

## Changes

- **New**: `packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityHomePageData.ts` — SimpleDB entity for home page cache
- **Modified**: `SimpleDb.ts` / `SimpleDbProxy.ts` — Register new entity
- **Modified**: `ServiceToken.ts` — Add `getHomePageCache` / `saveHomePageCache` methods
- **Modified**: `TokenListBlock.tsx` — Load cache on init to skip skeleton; save cache after data updates
- **Modified**: `HomeOverviewContainer.tsx` — Load cached accountWorth to avoid $0 flash

## Test plan

- [ ] Cold start with cache: balance and token list show immediately (no skeleton)
- [ ] Cold start without cache (first time): skeleton shows as before
- [ ] Background refresh updates data after cached display
- [ ] Switch accounts: correct cached data for each account
- [ ] Single network mode: existing cache flow unaffected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
