### PR TITLE
fix(web): use self.__WB_MANIFEST in service worker for Workbox compatibility

### DIFF
--- a/apps/web/src/service-worker.js
+++ b/apps/web/src/service-worker.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-restricted-globals */
+/* eslint-disable unicorn/prefer-global-this */
 import { precacheAndRoute } from 'workbox-precaching';
 import { NavigationRoute, registerRoute } from 'workbox-routing';
 import {

--- a/apps/web/src/service-worker.js
+++ b/apps/web/src/service-worker.js
@@ -9,7 +9,7 @@ import {
 import { ExpirationPlugin } from 'workbox-expiration';
 
 // Precache app shell (manifest injected by InjectManifest at build time)
-precacheAndRoute(globalThis.__WB_MANIFEST);
+precacheAndRoute(self.__WB_MANIFEST);
 
 // Navigation requests -> NetworkFirst (SPA routing, offline fallback to cached index.html)
 registerRoute(

--- a/packages/kit/src/views/ReferFriends/pages/PerpsReward/components/PerpsRecordTable.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/PerpsReward/components/PerpsRecordTable.tsx
@@ -344,15 +344,23 @@ export function PerpsRecordTable({
               transition: `box-shadow ${SHADOW_CONSTANTS.TRANSITION_DURATION} ease-in-out`,
             }}
           >
-            <XStack ai="center" px="$5" py="$2" minHeight={COMPACT_ROW_MIN_HEIGHT}>
+            <XStack
+              ai="center"
+              px="$5"
+              py="$2"
+              minHeight={COMPACT_ROW_MIN_HEIGHT}
+            >
               <AddressHeaderContent columnWidths={columnWidths} />
             </XStack>
             {records.map((record) => (
-              <XStack key={record._id} ai="center" px="$5" py="$2" minHeight={COMPACT_ROW_MIN_HEIGHT}>
-                <AddressCellContent
-                  item={record}
-                  columnWidths={columnWidths}
-                />
+              <XStack
+                key={record._id}
+                ai="center"
+                px="$5"
+                py="$2"
+                minHeight={COMPACT_ROW_MIN_HEIGHT}
+              >
+                <AddressCellContent item={record} columnWidths={columnWidths} />
               </XStack>
             ))}
             <FixedColumnShadowOverlay
@@ -376,7 +384,12 @@ export function PerpsRecordTable({
             contentContainerStyle={SCROLL_CONTENT_STYLE}
           >
             <YStack>
-              <XStack ai="center" py="$2" pr="$5" minHeight={COMPACT_ROW_MIN_HEIGHT}>
+              <XStack
+                ai="center"
+                py="$2"
+                pr="$5"
+                minHeight={COMPACT_ROW_MIN_HEIGHT}
+              >
                 <ScrollableHeaderContent
                   columnWidths={columnWidths}
                   sortBy={sortBy}
@@ -385,7 +398,13 @@ export function PerpsRecordTable({
                 />
               </XStack>
               {records.map((record) => (
-                <XStack key={record._id} ai="center" py="$2" pr="$5" minHeight={COMPACT_ROW_MIN_HEIGHT}>
+                <XStack
+                  key={record._id}
+                  ai="center"
+                  py="$2"
+                  pr="$5"
+                  minHeight={COMPACT_ROW_MIN_HEIGHT}
+                >
                   <ScrollableCellsContent
                     item={record}
                     columnWidths={columnWidths}


### PR DESCRIPTION
## Summary
- Fix Workbox `InjectManifest` build error: `Can't find self.__WB_MANIFEST in your SW source`
- Replace `globalThis.__WB_MANIFEST` with `self.__WB_MANIFEST` in the service worker source
- The `InjectManifest` plugin requires the literal `self.__WB_MANIFEST` token to locate the injection point for the precache manifest

## Test plan
- [ ] Verify `yarn app:web` production build completes without the `__WB_MANIFEST` error
- [ ] Verify the built `service-worker.js` contains the injected precache manifest
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
