### PR TITLE
fix: add revalidateOnFocus to referral level detail query(OK-49300)

### DIFF
--- a/packages/kit/src/views/ReferFriends/pages/InviteReward/components/CurrentLevelCard/hooks/useCurrentLevelCard.ts
+++ b/packages/kit/src/views/ReferFriends/pages/InviteReward/components/CurrentLevelCard/hooks/useCurrentLevelCard.ts
@@ -21,6 +21,8 @@ export function useCurrentLevelCard(
     {
       initResult: undefined,
       pollingInterval: timerUtils.getTimeDurationMs({ minute: 1 }), // Auto refresh every 1 minute
+      revalidateOnFocus: true,
+      revalidateOnReconnect: true,
     },
   );
 


### PR DESCRIPTION
## Summary

- Add `revalidateOnFocus: true` and `revalidateOnReconnect: true` to `getLevelDetail()` in `useCurrentLevelCard` hook
- Fixes referral level card not refreshing after redemption code activation — when returning from the level detail modal, the level data now auto-refreshes on focus
- Aligns with existing patterns in `usePerpsCumulativeRewards` and `InviteReward/index.tsx` which already use `revalidateOnFocus`

## Test plan

- [ ] Login with OneKey ID
- [ ] Go to the referral page
- [ ] Open the redemption center and enter a code
- [ ] After successful redemption, click "View Changes"
- [ ] Confirm the new level on the level detail page
- [ ] Return to the referral home page and verify the level card has refreshed to show the new level
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
