### PR TITLE
fix(ext): exclude vendor cache groups from ext production builds

### DIFF
--- a/development/rspack/rspack.prod.config.ts
+++ b/development/rspack/rspack.prod.config.ts
@@ -64,36 +64,42 @@ export function createProductionConfig({
         name: false,
         maxInitialRequests: 20,
         maxAsyncRequests: 50_000,
-        cacheGroups: {
-          reactVendor: {
-            test: /[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]/,
-            name: 'vendor-react',
-            chunks: 'all' as const,
-            priority: 40,
-            reuseExistingChunk: true,
-          },
-          lodashVendor: {
-            test: /[\\/]node_modules[\\/]lodash/,
-            name: 'vendor-lodash',
-            chunks: 'all' as const,
-            priority: 30,
-            reuseExistingChunk: true,
-          },
-          networkVendor: {
-            test: /[\\/]node_modules[\\/](axios|@supabase)[\\/]/,
-            name: 'vendor-network',
-            chunks: 'all' as const,
-            priority: 30,
-            reuseExistingChunk: true,
-          },
-          cryptoVendor: {
-            test: /[\\/]node_modules[\\/](@noble|@scure|ethers|bn\.js|elliptic|hash\.js|browserify)[\\/]/,
-            name: 'vendor-crypto',
-            chunks: 'all' as const,
-            priority: 20,
-            reuseExistingChunk: true,
-          },
-        },
+        // Vendor cache groups for long-term caching (web/desktop only).
+        // Extension uses its own code splitting via HtmlWebpackPlugin chunks,
+        // and named vendor chunks would NOT be included in ext HTML files,
+        // breaking the extension UI in production.
+        cacheGroups: isExt
+          ? {}
+          : {
+              reactVendor: {
+                test: /[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]/,
+                name: 'vendor-react',
+                chunks: 'all' as const,
+                priority: 40,
+                reuseExistingChunk: true,
+              },
+              lodashVendor: {
+                test: /[\\/]node_modules[\\/]lodash/,
+                name: 'vendor-lodash',
+                chunks: 'all' as const,
+                priority: 30,
+                reuseExistingChunk: true,
+              },
+              networkVendor: {
+                test: /[\\/]node_modules[\\/](axios|@supabase)[\\/]/,
+                name: 'vendor-network',
+                chunks: 'all' as const,
+                priority: 30,
+                reuseExistingChunk: true,
+              },
+              cryptoVendor: {
+                test: /[\\/]node_modules[\\/](@noble|@scure|ethers|bn\.js|elliptic|hash\.js|browserify)[\\/]/,
+                name: 'vendor-crypto',
+                chunks: 'all' as const,
+                priority: 20,
+                reuseExistingChunk: true,
+              },
+            },
       },
     },
   };

--- a/development/webpack/webpack.prod.config.js
+++ b/development/webpack/webpack.prod.config.js
@@ -79,36 +79,42 @@ module.exports = ({ platform, basePath }) => {
         name: false,
         maxInitialRequests: 20,
         maxAsyncRequests: 50_000,
-        cacheGroups: {
-          reactVendor: {
-            test: /[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]/,
-            name: 'vendor-react',
-            chunks: 'all',
-            priority: 40,
-            reuseExistingChunk: true,
-          },
-          lodashVendor: {
-            test: /[\\/]node_modules[\\/]lodash/,
-            name: 'vendor-lodash',
-            chunks: 'all',
-            priority: 30,
-            reuseExistingChunk: true,
-          },
-          networkVendor: {
-            test: /[\\/]node_modules[\\/](axios|@supabase)[\\/]/,
-            name: 'vendor-network',
-            chunks: 'all',
-            priority: 30,
-            reuseExistingChunk: true,
-          },
-          cryptoVendor: {
-            test: /[\\/]node_modules[\\/](@noble|@scure|ethers|bn\.js|elliptic|hash\.js|browserify)[\\/]/,
-            name: 'vendor-crypto',
-            chunks: 'all',
-            priority: 20,
-            reuseExistingChunk: true,
-          },
-        },
+        // Vendor cache groups for long-term caching (web/desktop only).
+        // Extension uses its own code splitting via HtmlWebpackPlugin chunks,
+        // and named vendor chunks would NOT be included in ext HTML files,
+        // breaking the extension UI in production.
+        cacheGroups: isExt
+          ? {}
+          : {
+              reactVendor: {
+                test: /[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]/,
+                name: 'vendor-react',
+                chunks: 'all',
+                priority: 40,
+                reuseExistingChunk: true,
+              },
+              lodashVendor: {
+                test: /[\\/]node_modules[\\/]lodash/,
+                name: 'vendor-lodash',
+                chunks: 'all',
+                priority: 30,
+                reuseExistingChunk: true,
+              },
+              networkVendor: {
+                test: /[\\/]node_modules[\\/](axios|@supabase)[\\/]/,
+                name: 'vendor-network',
+                chunks: 'all',
+                priority: 30,
+                reuseExistingChunk: true,
+              },
+              cryptoVendor: {
+                test: /[\\/]node_modules[\\/](@noble|@scure|ethers|bn\.js|elliptic|hash\.js|browserify)[\\/]/,
+                name: 'vendor-crypto',
+                chunks: 'all',
+                priority: 20,
+                reuseExistingChunk: true,
+              },
+            },
       },
     },
   };


### PR DESCRIPTION
## Summary
- Exclude vendor cache groups (`vendor-react`, `vendor-lodash`, `vendor-network`, `vendor-crypto`) from ext platform production builds
- Vendor cache groups added in #10053 create named chunks that are not included by HtmlWebpackPlugin when `chunks` is set to `['ui-popup']`, causing the ext UI to be missing React and other critical dependencies in production
- This results in the extension being stuck on the logo screen and unable to load

## Root Cause
The production config (`webpack.prod.config.js` / `rspack.prod.config.ts`) is shared across all platforms. Named vendor cache groups extract React, lodash, etc. into separate chunks (e.g. `vendor-react`). For the extension, `HtmlWebpackPlugin` is configured with `chunks: ['ui-popup']`, which only injects script tags for the `ui-popup` entry chunk — the named vendor chunks are excluded from the HTML, so the extension UI fails to boot.

## Fix
Conditionally skip vendor cache groups when building for the `ext` platform (`cacheGroups: isExt ? {} : { ... }`). Extension has its own code splitting strategy that doesn't rely on named vendor chunks.

## Test plan
- [ ] Build ext in production mode (`yarn app:ext:prod`) and verify it loads past the logo screen
- [ ] Verify web production build still has vendor cache groups working correctly
- [ ] Verify desktop production build is unaffected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
