### PR TITLE
fix: show loading only in list area when switching PerpsReward tabs

### DIFF
--- a/packages/kit/src/views/ReferFriends/pages/PerpsReward/components/PerpsDetailsSection/PerpsDetailsSectionDesktop.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/PerpsReward/components/PerpsDetailsSection/PerpsDetailsSectionDesktop.tsx
@@ -1,7 +1,7 @@
 import { useIntl } from 'react-intl';
 import { StyleSheet } from 'react-native';
 
-import { SizableText, Switch, XStack, YStack } from '@onekeyhq/components';
+import { SizableText, Spinner, Switch, XStack, YStack } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { PerpsEmptyData } from '../PerpsEmptyData';
@@ -23,6 +23,7 @@ export function PerpsDetailsSectionDesktop({
   sortOrder,
   onSort,
   isLoadingMore,
+  isTabLoading,
 }: IPerpsDetailsSectionProps) {
   const intl = useIntl();
 
@@ -92,7 +93,11 @@ export function PerpsDetailsSectionDesktop({
 
         {/* Table Content */}
         <YStack bg="$bgApp">
-          {hasData ? (
+          {isTabLoading ? (
+            <YStack ai="center" py="$8">
+              <Spinner size="small" />
+            </YStack>
+          ) : hasData ? (
             <PerpsRecordTable
               records={records}
               sortBy={sortBy}

--- a/packages/kit/src/views/ReferFriends/pages/PerpsReward/components/PerpsDetailsSection/PerpsDetailsSectionMobile.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/PerpsReward/components/PerpsDetailsSection/PerpsDetailsSectionMobile.tsx
@@ -25,6 +25,7 @@ export function PerpsDetailsSectionMobile({
   hideZeroVolume,
   onHideZeroVolumeChange,
   isLoadingMore,
+  isTabLoading,
 }: IPerpsDetailsSectionProps) {
   const intl = useIntl();
 
@@ -85,7 +86,11 @@ export function PerpsDetailsSectionMobile({
       ) : null}
 
       {/* Card List */}
-      {hasData ? (
+      {isTabLoading ? (
+        <YStack ai="center" py="$8">
+          <Spinner size="small" />
+        </YStack>
+      ) : hasData ? (
         <YStack gap="$4">
           {records.map((record) => (
             <PerpsRecordCard key={record._id} item={record} />

--- a/packages/kit/src/views/ReferFriends/pages/PerpsReward/components/PerpsDetailsSection/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/PerpsReward/components/PerpsDetailsSection/index.tsx
@@ -22,6 +22,7 @@ export interface IPerpsDetailsSectionProps {
   sortOrder: IPerpsInvitesSortOrder;
   onSort: (field: IPerpsInvitesSortBy) => void;
   isLoadingMore?: boolean;
+  isTabLoading?: boolean;
 }
 
 export function PerpsDetailsSection(props: IPerpsDetailsSectionProps) {

--- a/packages/kit/src/views/ReferFriends/pages/PerpsReward/hooks/useNavigateToPerpsReward.ts
+++ b/packages/kit/src/views/ReferFriends/pages/PerpsReward/hooks/useNavigateToPerpsReward.ts
@@ -1,18 +1,23 @@
 import { useCallback } from 'react';
 
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
+  EModalReferFriendsRoutes,
+  EModalRoutes,
   ETabReferFriendsRoutes,
-  ETabRoutes,
 } from '@onekeyhq/shared/src/routes';
-import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
 export function useNavigateToPerpsReward() {
   const navigation = useAppNavigation();
 
-  return useCallback(async () => {
-    navigation.switchTab(ETabRoutes.ReferFriends);
-    await timerUtils.wait(50);
-    navigation.push(ETabReferFriendsRoutes.TabPerpsReward);
+  return useCallback(() => {
+    if (platformEnv.isNative) {
+      navigation.pushModal(EModalRoutes.ReferFriendsModal, {
+        screen: EModalReferFriendsRoutes.PerpsReward,
+      });
+    } else {
+      navigation.push(ETabReferFriendsRoutes.TabPerpsReward);
+    }
   }, [navigation]);
 }

--- a/packages/kit/src/views/ReferFriends/pages/PerpsReward/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/PerpsReward/index.tsx
@@ -50,6 +50,7 @@ function PerpsRewardPageWrapper() {
   const { md } = useMedia();
 
   const [isLoading, setIsLoading] = useState(false);
+  const [isTabLoading, setIsTabLoading] = useState(false);
   const [cumulativeRewards, setCumulativeRewards] = useState<
     IPerpsCumulativeRewardsResponse | undefined
   >();
@@ -314,10 +315,10 @@ function PerpsRewardPageWrapper() {
 
   // Fetch data when tab changes
   useEffect(() => {
-    setIsLoading(true);
+    setIsTabLoading(true);
     fetchCurrentTab()
       .catch((error) => console.error('Failed to fetch tab data:', error))
-      .finally(() => setIsLoading(false));
+      .finally(() => setIsTabLoading(false));
   }, [fetchCurrentTab]);
 
   // Max date for DatePicker (today)
@@ -422,6 +423,7 @@ function PerpsRewardPageWrapper() {
                 sortOrder={sortOrder}
                 onSort={handleSort}
                 isLoadingMore={isLoadingMore}
+                isTabLoading={isTabLoading}
               />
             </ScrollView>
           )}

--- a/packages/kit/src/views/ReferFriends/router/index.ts
+++ b/packages/kit/src/views/ReferFriends/router/index.ts
@@ -25,6 +25,7 @@ const ReferralLevel = LazyLoadPage(() => import('../pages/ReferralLevel'));
 const RedemptionHistory = LazyLoadPage(
   () => import('../../Redemption/pages/RedemptionHistory'),
 );
+const PerpsReward = LazyLoadPage(() => import('../pages/PerpsReward'));
 
 export const ReferFriendsRouter: IModalFlowNavigatorConfig<
   EModalReferFriendsRoutes,
@@ -77,5 +78,9 @@ export const ReferFriendsRouter: IModalFlowNavigatorConfig<
   {
     name: EModalReferFriendsRoutes.RedemptionHistory,
     component: RedemptionHistory,
+  },
+  {
+    name: EModalReferFriendsRoutes.PerpsReward,
+    component: PerpsReward,
   },
 ];

--- a/packages/shared/src/routes/referFriends.ts
+++ b/packages/shared/src/routes/referFriends.ts
@@ -17,6 +17,7 @@ export enum EModalReferFriendsRoutes {
   RewardDistributionHistory = 'RewardDistributionHistory',
   ReferralLevel = 'ReferralLevel',
   RedemptionHistory = 'RedemptionHistory',
+  PerpsReward = 'PerpsReward',
 }
 
 export type IModalReferFriendsParamList = {
@@ -67,4 +68,5 @@ export type IModalReferFriendsParamList = {
   [EModalReferFriendsRoutes.RewardDistributionHistory]: undefined;
   [EModalReferFriendsRoutes.ReferralLevel]: undefined;
   [EModalReferFriendsRoutes.RedemptionHistory]: undefined;
+  [EModalReferFriendsRoutes.PerpsReward]: undefined;
 };


### PR DESCRIPTION
## Summary
- Add `isTabLoading` state separate from `isLoading` so tab switching only shows a Spinner in the list/table area, not the entire page (RefreshControl + header refresh button)
- Mobile: show centered Spinner in card list area during tab switch
- Desktop: show centered Spinner in table content area during tab switch
- Fix native navigation to use modal route (`pushModal`) for PerpsReward page instead of `switchTab` + `push`

## Test plan
- [ ] Mobile: tap Tab switch → list area shows small Spinner, header stats and date picker stay unchanged
- [ ] Desktop: click Tab switch → table area shows Spinner, header unaffected
- [ ] Pull-to-refresh still works normally (full page loading)
- [ ] Native: navigate to PerpsReward via modal route correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
