### PR TITLE
fix: wrap token decimals with Number() to prevent BigNumber crash

### DIFF
--- a/packages/kit/src/states/jotai/contexts/swap/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/atoms.ts
@@ -528,7 +528,7 @@ export const {
       const fromAmountBN = new BigNumber(toAmount).multipliedBy(reverseRate);
       const fromAmount = fromAmountBN
         .decimalPlaces(
-          fromToken?.decimals ?? LIMIT_PRICE_DEFAULT_DECIMALS,
+          Number(fromToken?.decimals ?? LIMIT_PRICE_DEFAULT_DECIMALS),
           BigNumber.ROUND_HALF_UP,
         )
         .toFixed();
@@ -556,7 +556,7 @@ export const {
       const toAmountBN = new BigNumber(fromAmount).multipliedBy(rate);
       const toAmount = toAmountBN
         .decimalPlaces(
-          toToken?.decimals ?? LIMIT_PRICE_DEFAULT_DECIMALS,
+          Number(toToken?.decimals ?? LIMIT_PRICE_DEFAULT_DECIMALS),
           BigNumber.ROUND_HALF_UP,
         )
         .toFixed();
@@ -798,14 +798,18 @@ export const {
     const rate = fromPriceBN
       .div(toPriceBN)
       .decimalPlaces(
-        toTokenPriceInfo.tokenInfo.decimals ?? LIMIT_PRICE_DEFAULT_DECIMALS,
+        Number(
+          toTokenPriceInfo.tokenInfo.decimals ?? LIMIT_PRICE_DEFAULT_DECIMALS,
+        ),
         BigNumber.ROUND_HALF_UP,
       )
       .toFixed();
     const reverseRate = toPriceBN
       .div(fromPriceBN)
       .decimalPlaces(
-        fromTokenPriceInfo.tokenInfo.decimals ?? LIMIT_PRICE_DEFAULT_DECIMALS,
+        Number(
+          fromTokenPriceInfo.tokenInfo.decimals ?? LIMIT_PRICE_DEFAULT_DECIMALS,
+        ),
         BigNumber.ROUND_HALF_UP,
       )
       .toFixed();

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -667,7 +667,7 @@ function DepositWithdrawContent({
     }
     const minFromTokenAmountFormatted = minFromTokenAmount
       .decimalPlaces(
-        currentPerpsDepositSelectedToken?.decimals ?? 0,
+        Number(currentPerpsDepositSelectedToken?.decimals ?? 0),
         BigNumber.ROUND_UP,
       )
       .toFixed();

--- a/packages/kit/src/views/Swap/components/LimitOrderCard.tsx
+++ b/packages/kit/src/views/Swap/components/LimitOrderCard.tsx
@@ -151,14 +151,14 @@ const LimitOrderCard = ({
       ? fromAmountNum
           .div(toAmountNum)
           .decimalPlaces(
-            toTokenInfo?.decimals ?? LIMIT_PRICE_DEFAULT_DECIMALS,
+            Number(toTokenInfo?.decimals ?? LIMIT_PRICE_DEFAULT_DECIMALS),
             BigNumber.ROUND_HALF_UP,
           )
           .toFixed()
       : toAmountNum
           .div(fromAmountNum)
           .decimalPlaces(
-            fromTokenInfo?.decimals ?? LIMIT_PRICE_DEFAULT_DECIMALS,
+            Number(fromTokenInfo?.decimals ?? LIMIT_PRICE_DEFAULT_DECIMALS),
             BigNumber.ROUND_HALF_UP,
           )
           .toFixed();

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -846,7 +846,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
             new BigNumber(swapLimitUseRate.rate),
           );
           toRealAmount = cToAmountBN.decimalPlaces(
-            toToken?.decimals ?? LIMIT_PRICE_DEFAULT_DECIMALS,
+            Number(toToken?.decimals ?? LIMIT_PRICE_DEFAULT_DECIMALS),
             BigNumber.ROUND_HALF_UP,
           );
         }

--- a/packages/kit/src/views/Swap/pages/modal/LimitOrderDetailModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/LimitOrderDetailModal.tsx
@@ -104,7 +104,7 @@ const LimitOrderDetailModal = () => {
     const calculateLimitPrice = toAmountNum
       .div(fromAmountNum)
       .decimalPlaces(
-        orderItemState?.toTokenInfo.decimals ?? 0,
+        Number(orderItemState?.toTokenInfo.decimals ?? 0),
         BigNumber.ROUND_HALF_UP,
       )
       .toFixed();
@@ -387,7 +387,7 @@ const LimitOrderDetailModal = () => {
     const calculateLimitPrice = toAmountNum
       .div(fromAmountNum)
       .decimalPlaces(
-        orderItemState?.toTokenInfo.decimals ?? 0,
+        Number(orderItemState?.toTokenInfo.decimals ?? 0),
         BigNumber.ROUND_HALF_UP,
       );
     if (kind === ESwapQuoteKind.SELL) {
@@ -397,7 +397,7 @@ const LimitOrderDetailModal = () => {
       estimationRunPrice = estimationToAmountBN
         .dividedBy(decimalsAmount.fromAmount)
         .decimalPlaces(
-          orderItemState?.toTokenInfo.decimals ?? 0,
+          Number(orderItemState?.toTokenInfo.decimals ?? 0),
           BigNumber.ROUND_HALF_UP,
         );
       const difValue = estimationRunPrice.minus(calculateLimitPrice);
@@ -414,7 +414,7 @@ const LimitOrderDetailModal = () => {
       estimationRunPrice = decimalsAmount.toAmount
         .dividedBy(estimationFromAmountBN)
         .decimalPlaces(
-          orderItemState?.toTokenInfo.decimals ?? 0,
+          Number(orderItemState?.toTokenInfo.decimals ?? 0),
           BigNumber.ROUND_HALF_UP,
         );
       const difValue = estimationRunPrice.minus(calculateLimitPrice);


### PR DESCRIPTION
## Summary

- Wrap `token.decimals` with `Number()` in all `BigNumber.decimalPlaces()` calls across Swap/Perp modules
- API responses may return `decimals` as a string (e.g., `"9"` instead of `9`), causing `BigNumber.decimalPlaces()` to throw `[BigNumber Error] Argument not a primitive number`
- Fixed 12 occurrences across 5 files: swap atoms, LimitOrderDetailModal, LimitOrderCard, SwapMainLand, DepositWithdrawModal

## Test plan

- [ ] Open Swap Pro limit order page, verify limit price calculation works correctly
- [ ] Switch between BUY/SELL direction, verify no BigNumber crash
- [ ] Open limit order detail modal, verify price display is correct
- [ ] Test Perp deposit/withdraw modal minimum amount display
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
