### PR TITLE
fix(android): skip onSaveInstanceState under low memory to prevent ANR

### DIFF
--- a/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/MainActivity.java
+++ b/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/MainActivity.java
@@ -1,9 +1,12 @@
 package so.onekey.app.wallet;
 
+import android.content.ComponentCallbacks2;
 import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
 
 import com.betomorrow.rnfilelogger.FileLoggerModule;
 import com.facebook.react.ReactActivity;
@@ -34,6 +37,7 @@ import so.onekey.app.wallet.splashscreen.singletons.SplashScreen;
 public class MainActivity extends ReactActivity {
     private FileLoggerModule fileLogger;
     SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss");
+    private volatile boolean isLowMemory = false;
 
     private SplashScreenImageResizeMode getResizeMode(Context context) {
     String resizeModeString = context.getString(R.string.expo_splash_screen_resize_mode).toLowerCase();
@@ -100,6 +104,23 @@ public class MainActivity extends ReactActivity {
     sharedI18nUtilInstance.allowRTL(getApplicationContext(), true);
     EventBus.getDefault().register(this);
     fileLogger = new FileLoggerModule((ReactApplicationContext) getReactHost().getCurrentReactContext());
+  }
+
+  @Override
+  public void onTrimMemory(int level) {
+    super.onTrimMemory(level);
+    isLowMemory = level >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
+  }
+
+  @Override
+  protected void onSaveInstanceState(@NonNull Bundle outState) {
+    if (isLowMemory) {
+      // Skip expensive state serialization to prevent ANR on low-memory devices.
+      // This is safe because we pass null to super.onCreate(), so saved state
+      // is never restored. React Native manages its own state via JavaScript.
+      return;
+    }
+    super.onSaveInstanceState(outState);
   }
 
     @Subscribe(threadMode = ThreadMode.ASYNC)


### PR DESCRIPTION
## Summary

- Track device memory pressure via `onTrimMemory()` callback in `MainActivity`
- Skip expensive `onSaveInstanceState` serialization only when device reports `TRIM_MEMORY_RUNNING_LOW` or higher
- Prevents ANR on low-end/low-memory Android devices during activity backgrounding

## Root Cause

Sentry event `23c8f9ac`: ANR on Xiaomi Redmi 2201117TG (device.class 1, 3.6GB RAM, Android 13) under critical memory pressure (LOW_MEMORY level 40).

The main thread blocks in `ComponentActivity.onSaveInstanceState()` performing View hierarchy + Fragment + SavedStateRegistry serialization. This work is **completely wasted** because:
1. `super.onCreate(null)` already ignores saved state on restore
2. React Native manages its own state via JavaScript
3. Expo uses SharedPreferences instead of `onSaveInstanceState`

## Changes

**`MainActivity.java`**:
- Add `isLowMemory` volatile flag
- Override `onTrimMemory()` to track memory pressure (`TRIM_MEMORY_RUNNING_LOW` = level 10+)
- Override `onSaveInstanceState()` to skip serialization only when `isLowMemory` is true

## Test plan

- [ ] Verify app backgrounds/foregrounds normally on devices with sufficient memory (state saving unchanged)
- [ ] Verify no ANR on low-memory scenarios (state saving skipped)
- [ ] Verify app restores correctly after being killed by system (React Native handles its own state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
