### PR TITLE
fix: persist perps banner dismiss state to prevent layout jump on refresh(OK-50031)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/PerpetualTradingBanner/PerpetualTradingBanner.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/PerpetualTradingBanner/PerpetualTradingBanner.tsx
@@ -1,27 +1,37 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
 import { Icon, IconButton, SizableText, XStack } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { useBannerClosePersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 
 import { useTokenDetail } from '../../hooks/useTokenDetail';
 
+const PERPS_BANNER_ID = 'perps-trading-banner';
+
 export function PerpetualTradingBanner() {
   const intl = useIntl();
   const navigation = useAppNavigation();
   const { tokenDetail, perpsInfo } = useTokenDetail();
-  const [dismissed, setDismissed] = useState(false);
+  const [bannerClose, setBannerClose] = useBannerClosePersistAtom();
 
   const hlTicker = perpsInfo?.hlTicker;
 
+  const dismissed = useMemo(
+    () => bannerClose.ids.includes(PERPS_BANNER_ID),
+    [bannerClose.ids],
+  );
+
   const handleDismiss = useCallback(() => {
-    setDismissed(true);
-  }, []);
+    setBannerClose({
+      ids: [...new Set([...bannerClose.ids, PERPS_BANNER_ID])],
+    });
+  }, [bannerClose.ids, setBannerClose]);
 
   const handlePress = useCallback(() => {
     if (!hlTicker) return;


### PR DESCRIPTION
## Summary
- Replace `useState` with `useBannerClosePersistAtom` in `PerpetualTradingBanner` so the dismissed state is persisted across page refreshes
- Reuses the existing `bannerCloseIdsAtom` persistent storage that Discovery banners already use
- Fixes layout jump caused by banner reappearing after refresh when previously dismissed

## Test plan
- [ ] Open a Market token detail page that has perps support (e.g. ETH)
- [ ] Verify the perps banner displays correctly
- [ ] Close the banner and refresh the page — banner should NOT reappear
- [ ] Verify no layout jump occurs on refresh after banner is dismissed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
