### PR TITLE
fix: prevent double loading on mobile hardware sales pull-to-refresh

### DIFF
--- a/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/components/HardwareRecordsList.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/components/HardwareRecordsList.tsx
@@ -22,7 +22,8 @@ export function HardwareRecordsList({
 }: IHardwareRecordsListProps) {
   const intl = useIntl();
 
-  if (isLoading && records.length === 0) {
+  // Show list Spinner only on desktop (mobile uses RefreshControl for loading feedback)
+  if (isLoading && records.length === 0 && !isMobile) {
     return (
       <YStack ai="center" jc="center" py="$10" px="$5">
         <Spinner size="large" />


### PR DESCRIPTION
## Summary
- Skip list Spinner on mobile when pull-to-refresh `RefreshControl` already provides loading feedback
- Desktop retains the list Spinner since it has no pull-to-refresh mechanism
- Only 1 line changed: added `&& !isMobile` condition to the list loading check

## Test plan
- [ ] On mobile, pull to refresh hardware sales page — only RefreshControl loading should appear
- [ ] On desktop, click refresh — list Spinner should still show when records are empty
- [ ] Verify load-more Spinner at bottom of list still works on both platforms
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
