### PR TITLE
fix: omit Tamagui face property on web to prevent createFont crash

### DIFF
--- a/packages/components/tamagui.config.ts
+++ b/packages/components/tamagui.config.ts
@@ -153,14 +153,14 @@ const tamaguiWebFontFamily = webFontFamily;
 
 const font = createFont({
   family: isTamaguiNative ? 'Roobert-Regular' : tamaguiWebFontFamily,
-  face: isTamaguiNative
-    ? {
-        400: { normal: 'Roobert-Regular' },
-        500: { normal: 'Roobert-Medium' },
-        600: { normal: 'Roobert-SemiBold' },
-        700: { normal: 'Roobert-Bold' },
-      }
-    : undefined,
+  ...(isTamaguiNative && {
+    face: {
+      400: { normal: 'Roobert-Regular' },
+      500: { normal: 'Roobert-Medium' },
+      600: { normal: 'Roobert-SemiBold' },
+      700: { normal: 'Roobert-Bold' },
+    },
+  }),
   ...basicFontVariants,
 });
 


### PR DESCRIPTION
## Summary
- Fix crash introduced in #10108 where `createFont` throws `TypeError: Cannot convert undefined or null to object` on web
- `createFont` calls `Object.keys()` on every property passed to it — setting `face: undefined` still includes the key, causing the crash
- Use conditional spread (`...(isTamaguiNative && { face: {...} })`) to omit the `face` property entirely on web

## Test plan
- [ ] `yarn app:web` — app loads without `createFont` crash
- [ ] Verify Roobert font still renders correctly on web with proper weight selection
- [ ] Native platforms unaffected (face mapping still applied)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
