### PR TITLE
feat(web): promote search button as standalone entry in header

### DIFF
--- a/packages/kit/src/components/TabPageHeader/DappHeader.tsx
+++ b/packages/kit/src/components/TabPageHeader/DappHeader.tsx
@@ -30,6 +30,7 @@ import {
   EModalSettingRoutes,
   ETabRoutes,
 } from '@onekeyhq/shared/src/routes';
+import { EUniversalSearchPages } from '@onekeyhq/shared/src/routes/universalSearch';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 
 import backgroundApiProxy from '../../background/instance/backgroundApiProxy';
@@ -268,6 +269,35 @@ function DownloadAppButton() {
   );
 }
 
+function SearchButton() {
+  const intl = useIntl();
+  const navigation = useAppNavigation();
+  const handlePress = useCallback(() => {
+    navigation.pushModal(EModalRoutes.UniversalSearchModal, {
+      screen: EUniversalSearchPages.UniversalSearch,
+    });
+  }, [navigation]);
+
+  return (
+    <XStack
+      ai="center"
+      px="$1.5"
+      py="$1.5"
+      borderRadius="$2"
+      bg="$bgStrong"
+    >
+      <HeaderIconButton
+        size="small"
+        icon="SearchOutline"
+        title={intl.formatMessage({
+          id: ETranslations.global_search_everything,
+        })}
+        onPress={handlePress}
+      />
+    </XStack>
+  );
+}
+
 // function Web3GuideListItem() {
 //   const intl = useIntl();
 //   const handlePress = useCallback(() => {
@@ -412,6 +442,7 @@ function RightActions({
   customHeaderRightItems?: ReactNode;
 }) {
   const { gtLg } = useMedia();
+  const navigation = useAppNavigation();
   const {
     activeAccount: { wallet, account },
   } = useActiveAccount({
@@ -421,9 +452,21 @@ function RightActions({
   const isWalletConnected = !!wallet && !!account;
   const isPerpsTab = tabRoute === ETabRoutes.Perp;
 
+  const handleSearchPress = useCallback(() => {
+    navigation.pushModal(EModalRoutes.UniversalSearchModal, {
+      screen: EUniversalSearchPages.UniversalSearch,
+    });
+  }, [navigation]);
+
   return (
     <XStack ai="center" gap="$2">
-      {gtLg ? <DownloadAppButton /> : null}
+      {gtLg ? <SearchButton /> : (
+        <HeaderIconButton
+          size="small"
+          icon="SearchOutline"
+          onPress={handleSearchPress}
+        />
+      )}
       {isPerpsTab && customHeaderRightItems ? (
         customHeaderRightItems
       ) : (
@@ -439,6 +482,7 @@ function RightActions({
           <DepositButton />
         </>
       )}
+      {gtLg ? <DownloadAppButton /> : null}
       <XStack
         ai="center"
         gap="$2.5"
@@ -447,7 +491,6 @@ function RightActions({
         borderRadius="$2"
         bg="$bgStrong"
       >
-        <UniversalSearchInput size="small" />
         <HeaderNotificationIconButton
           testID="header-right-notification"
           size="small"

--- a/packages/kit/src/components/TabPageHeader/DappHeader.tsx
+++ b/packages/kit/src/components/TabPageHeader/DappHeader.tsx
@@ -458,12 +458,17 @@ function RightActions({
     });
   }, [navigation]);
 
+  const intl = useIntl();
+
   return (
     <XStack ai="center" gap="$2">
       {gtLg ? <SearchButton /> : (
         <HeaderIconButton
           size="small"
           icon="SearchOutline"
+          title={intl.formatMessage({
+            id: ETranslations.global_search_everything,
+          })}
           onPress={handleSearchPress}
         />
       )}


### PR DESCRIPTION
## Summary
- Extract the search icon from the gray toolbar group and place it as a standalone button with `$bgStrong` background, positioned before the Connect/APP buttons
- On large screens (`gtLg`): renders a `SearchButton` component with `HeaderIconButton` inside a `$bgStrong` container for visual prominence
- On medium screens: renders a standalone `HeaderIconButton` with search icon (outside the toolbar group)
- Removes search from the right-side toolbar group (notification, more, language, theme)
- Maintains existing search modal navigation and i18n tooltip on hover

## Test plan
- [ ] Verify search button appears as a standalone element before Connect button on wide screens
- [ ] Verify hover shows "Search anything" tooltip consistent with other header icons
- [ ] Verify clicking opens the universal search modal
- [ ] Verify medium screen shows search icon button outside toolbar group
- [ ] Verify the gray toolbar group no longer contains the search icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
