### PR TITLE
feat(web): add periodic service worker update check

### DIFF
--- a/apps/web/index.js
+++ b/apps/web/index.js
@@ -130,9 +130,12 @@ if (
         });
 
         // Check for updates every 30 minutes
-        setInterval(() => {
-          registration.update();
-        }, timerUtils.getTimeDurationMs({ minute: 30 }));
+        setInterval(
+          () => {
+            registration.update().catch(() => {});
+          },
+          timerUtils.getTimeDurationMs({ minute: 30 }),
+        );
       })
       .catch((error) => {
         console.error('Service worker registration failed:', error);

--- a/apps/web/index.js
+++ b/apps/web/index.js
@@ -127,6 +127,11 @@ if (
             }
           });
         });
+
+        // Check for updates every 30 minutes
+        setInterval(() => {
+          registration.update();
+        }, 30 * 60 * 1000);
       })
       .catch((error) => {
         console.error('Service worker registration failed:', error);

--- a/apps/web/index.js
+++ b/apps/web/index.js
@@ -15,6 +15,7 @@ import {
 } from '@onekeyhq/shared/src/modules3rdParty/sentry';
 import { SentryErrorBoundaryFallback } from '@onekeyhq/kit/src/components/ErrorBoundary';
 import { initIntercom } from '@onekeyhq/shared/src/modules3rdParty/intercom';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import App from './App';
 
 if (process.env.NODE_ENV !== 'production') {
@@ -131,7 +132,7 @@ if (
         // Check for updates every 30 minutes
         setInterval(() => {
           registration.update();
-        }, 30 * 60 * 1000);
+        }, timerUtils.getTimeDurationMs({ minute: 30 }));
       })
       .catch((error) => {
         console.error('Service worker registration failed:', error);


### PR DESCRIPTION
## Summary
- Add a 30-minute interval `registration.update()` call so the service worker periodically checks for new versions
- Users on long-lived tabs will now see the update banner without needing to navigate or manually reload

## Test plan
- [ ] Deploy to a staging environment, verify service worker registers normally
- [ ] After deploying a new version, confirm the update banner appears within the polling interval on an already-open tab
- [ ] Verify no duplicate banners are shown if update is detected during both navigation and polling
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
