### PR TITLE
fix(components): resolve 39 circular dependency lint errors

### DIFF
--- a/packages/components/src/actions/Toast/index.tsx
+++ b/packages/components/src/actions/Toast/index.tsx
@@ -17,7 +17,6 @@ import {
   View,
   XStack,
   YStack,
-  // oxlint-disable-next-line import/no-cycle
 } from '../../primitives';
 import { Spinner } from '../../primitives/Spinner/Spinner';
 
@@ -28,7 +27,6 @@ import type { IShowToasterInstance, IShowToasterProps } from './ShowCustom';
 import type { IToastMessageOptions } from './type';
 import type { IPortalManager } from '../../hocs';
 import type { IKeyOfIcons, ISizableTextProps } from '../../primitives';
-// oxlint-disable-next-line import/no-cycle
 import { usePageWidth } from '../../hooks/usePage';
 import { useWindowDimensions } from 'react-native';
 

--- a/packages/components/src/composite/Tabs/hooks.tsx
+++ b/packages/components/src/composite/Tabs/hooks.tsx
@@ -11,8 +11,10 @@ import { useWindowDimensions } from 'react-native';
 import { useMedia } from '@onekeyhq/components/src/hooks/useStyle';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
-import { isNativeTablet, useIsSplitView } from '../../hooks';
-import { useIPadModalPageWidth, useIsIpadModalPage } from '../../layouts';
+import { isNativeTablet } from '../../hooks/useIsTablet';
+import { useIsSplitView } from '../../hooks/useOrientation';
+import { useIPadModalPageWidth } from '../../layouts/Page/iPadModalPageContext';
+import { useIsIpadModalPage } from '../../layouts/Page/hooks';
 import {
   DESKTOP_MODE_UI_PAGE_BORDER_WIDTH,
   DESKTOP_MODE_UI_PAGE_MARGIN,

--- a/packages/components/src/hooks/index.tsx
+++ b/packages/components/src/hooks/index.tsx
@@ -1,5 +1,4 @@
 export * from './useBackHandler';
-// oxlint-disable-next-line import/no-cycle
 export * from './useClipboard';
 export * from './useColor';
 export * from './useDeepCompareEffect';

--- a/packages/components/src/hooks/useClipboard.ts
+++ b/packages/components/src/hooks/useClipboard.ts
@@ -8,7 +8,6 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ensureHttpsPrefix } from '@onekeyhq/shared/src/utils/uriUtils';
 
-// oxlint-disable-next-line import/no-cycle
 import { Toast } from '../actions/Toast';
 
 import type { IPasteEventParams } from '../forms';

--- a/packages/components/src/hooks/usePage.ts
+++ b/packages/components/src/hooks/usePage.ts
@@ -1,7 +1,6 @@
 import { useWindowDimensions } from 'react-native';
 
 import { useIsSplitView } from '@onekeyhq/components/src/hooks/useOrientation';
-// oxlint-disable-next-line import/no-cycle
 import { useTabContainerWidth } from '@onekeyhq/components/src/composite/Tabs/hooks';
 
 export const usePageWidth = () => {

--- a/packages/components/src/layouts/Navigation/Header/HeaderIconButton.tsx
+++ b/packages/components/src/layouts/Navigation/Header/HeaderIconButton.tsx
@@ -1,6 +1,6 @@
-import { IconButton } from '../../../actions';
+import { IconButton } from '../../../actions/IconButton';
 
-import type { IIconButtonProps } from '../../../actions';
+import type { IIconButtonProps } from '../../../actions/IconButton';
 
 function HeaderIconButton(props: IIconButtonProps) {
   return (

--- a/packages/components/src/layouts/Page/hooks.ts
+++ b/packages/components/src/layouts/Page/hooks.ts
@@ -12,9 +12,9 @@ import {
   updateHeightWhenKeyboardHide,
   updateHeightWhenKeyboardShown,
   useKeyboardEvent,
-  useSafeAreaInsets,
-} from '../../hooks';
-import { rootNavigationRef } from '../Navigation';
+} from '../../hooks/useKeyboard';
+import { useSafeAreaInsets } from '../../hooks/useLayout';
+import { rootNavigationRef } from '../Navigation/Navigator/NavigationContainer';
 
 import { PageContext } from './PageContext';
 

--- a/packages/components/src/utils/DebugRenderTracker.tsx
+++ b/packages/components/src/utils/DebugRenderTracker.tsx
@@ -7,7 +7,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import appStorage from '@onekeyhq/shared/src/storage/appStorage';
 import { EAppSyncStorageKeys } from '@onekeyhq/shared/src/storage/syncStorage';
 
-import { Toast } from '../actions';
+import { Toast } from '../actions/Toast';
 
 const css1 = 'debug-render-tracker-animated-bg';
 const css2 = 'debug-render-tracker-animated-bg0';


### PR DESCRIPTION
## Summary

- Replace barrel file imports (`index.ts` re-exports) with direct file imports at strategic points to break circular dependency chains in `packages/components/src`
- Remove 4 `oxlint-disable-next-line import/no-cycle` suppression comments that are no longer needed
- All 39 `no-cycle` lint errors resolved with zero logic changes — only import paths adjusted

### Files changed

| File | Change |
|---|---|
| `layouts/Navigation/Header/HeaderIconButton.tsx` | `../../actions` → `../../actions/IconButton` |
| `composite/Tabs/hooks.tsx` | `../../hooks` barrel → direct `useIsTablet`, `useOrientation`; `../../layouts` barrel → direct `Page/iPadModalPageContext`, `Page/hooks` |
| `utils/DebugRenderTracker.tsx` | `../actions` → `../actions/Toast` |
| `layouts/Page/hooks.ts` | `../../hooks` barrel → direct `useKeyboard`, `useLayout`; `../Navigation` barrel → direct `Navigator/NavigationContainer` |

## Test plan

- [x] `yarn lint` passes with 0 `no-cycle` errors (down from 39)
- [x] TypeScript check confirms no new type errors introduced
- [ ] Desktop/mobile app builds and runs normally
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
