### PR TITLE
fix(ios): patch react-native-screens crash on iOS 26 during screen transitions

### DIFF
--- a/patches/react-native-screens+4.20.0.patch
+++ b/patches/react-native-screens+4.20.0.patch
@@ -1,0 +1,24 @@
+diff --git a/node_modules/react-native-screens/ios/RNSScreenStack.mm b/node_modules/react-native-screens/ios/RNSScreenStack.mm
+index 498b81d..3cde0f9 100644
+--- a/node_modules/react-native-screens/ios/RNSScreenStack.mm
++++ b/node_modules/react-native-screens/ios/RNSScreenStack.mm
+@@ -858,13 +858,17 @@ - (void)rnscreens_disableInteractions
+ {
+   // When transitioning between screens, disable interactions on stack subview which wraps the screens
+   // and sink all gesture events. This should work for nested stacks and stack inside bottom tabs, inside stack.
+-  self.subviews[0].userInteractionEnabled = NO;
++  if (self.subviews.count > 0) {
++    self.subviews[0].userInteractionEnabled = NO;
++  }
+   [self addGestureRecognizer:_sinkEventsPanGestureRecognizer];
+ }
+ 
+ - (void)rnscreens_enableInteractions
+ {
+-  self.subviews[0].userInteractionEnabled = YES;
++  if (self.subviews.count > 0) {
++    self.subviews[0].userInteractionEnabled = YES;
++  }
+   [self removeGestureRecognizer:_sinkEventsPanGestureRecognizer];
+ }
+ 


### PR DESCRIPTION
## Summary
- Add `patches/react-native-screens+4.20.0.patch` to fix a fatal crash (`NSRangeException`) on iOS 26
- The crash occurs in `rnscreens_disableInteractions` when `self.subviews` is empty during nested screen transitions (e.g., sheet dismiss + screen push)
- Adds bounds check (`self.subviews.count > 0`) before accessing `self.subviews[0]` in both `rnscreens_disableInteractions` and `rnscreens_enableInteractions`

## Root Cause
`react-native-screens` 4.20.0 added iOS 26 interaction management in `willMoveToWindow:` that calls `rnscreens_disableInteractions` on ancestor `RNSScreenStackView`. When the stack view has no subviews yet (during complex nested transitions), accessing `self.subviews[0]` crashes with `NSRangeException: index 0 beyond bounds for empty array`.

## Test plan
- [ ] Verify app builds successfully on iOS
- [ ] Test screen transitions with modals and sheets on iOS 26
- [ ] Verify no regression on iOS 18
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
