### PR TITLE
fix(android): patch expo-image SIGSEGV crash and webview bitmap allocation

### DIFF
--- a/packages/components/src/primitives/Image/useImage.ts
+++ b/packages/components/src/primitives/Image/useImage.ts
@@ -118,6 +118,24 @@ export function useImage(
     }
   }, [loadImage, resolvedSource]);
 
+  // Track the current ImageRef for proper lifecycle management.
+  // Using a ref avoids the closure capture bug where the effect cleanup
+  // would release a stale image value instead of the current one.
+  const currentImageRef = useRef<ImageRef | null>(null);
+
+  // Release the previous ImageRef when the image state changes.
+  // This ensures each ImageRef is released exactly once, only after
+  // it has been replaced by a new one (preventing use-after-free).
+  useEffect(() => {
+    currentImageRef.current = image;
+    return () => {
+      if (currentImageRef.current) {
+        currentImageRef.current.release();
+        currentImageRef.current = null;
+      }
+    };
+  }, [image]);
+
   useEffect(() => {
     isEffectValid.current = true;
     if (cachedImage) {
@@ -125,9 +143,7 @@ export function useImage(
     }
     loadImage();
     return () => {
-      // Invalidate the effect and release the shared object to free up memory.
       isEffectValid.current = false;
-      image?.release();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resolvedSource?.uri, cachedImage, loadImage, ...dependencies]);

--- a/patches/expo-image+3.0.10.patch
+++ b/patches/expo-image+3.0.10.patch
@@ -76,6 +76,46 @@ index 00e8ca9..f872d02 100644
      }
    }
  
+diff --git a/node_modules/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt b/node_modules/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+index f08807d..1123b3c 100644
+--- a/node_modules/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
++++ b/node_modules/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+@@ -41,7 +41,7 @@ import expo.modules.kotlin.modules.Module
+ import expo.modules.kotlin.modules.ModuleDefinition
+ import expo.modules.kotlin.sharedobjects.SharedRef
+ import expo.modules.kotlin.types.Either
+-import expo.modules.kotlin.types.EitherOfThree
++import expo.modules.kotlin.types.EitherOfFour
+ import expo.modules.kotlin.types.toKClass
+ import kotlinx.coroutines.Dispatchers
+ import kotlinx.coroutines.withContext
+@@ -219,7 +219,7 @@ class ExpoImageModule : Module() {
+         "onDisplay"
+       )
+ 
+-      Prop("source") { view: ExpoImageViewWrapper, sources: EitherOfThree<List<SourceMap>, SharedRef<Drawable>, SharedRef<Bitmap>>? ->
++      Prop("source") { view: ExpoImageViewWrapper, sources: EitherOfFour<List<SourceMap>, SourceMap, SharedRef<Drawable>, SharedRef<Bitmap>>? ->
+         if (sources == null) {
+           view.sources = emptyList()
+           return@Prop
+@@ -230,6 +230,17 @@ class ExpoImageModule : Module() {
+           return@Prop
+         }
+ 
++        // PATCHED: Handle single SourceMap passed as a map object instead of a list.
++        // On the new architecture (Fabric), the bridge may serialize a single-element
++        // source array as a plain map object (DynamicFromMap) instead of an array.
++        // Without this handler, the EitherOfThree type converter throws TypeCastException,
++        // which leaves the underlying folly::dynamic in an inconsistent state, leading to
++        // SIGSEGV in folly::dynamic::destroy() when the app backgrounds under memory pressure.
++        if (sources.`is`(toKClass<SourceMap>())) {
++          view.sources = listOf(sources.get(toKClass<SourceMap>()))
++          return@Prop
++        }
++
+         if (sources.`is`(toKClass<SharedRef<Drawable>>())) {
+           val drawable = sources.get(toKClass<SharedRef<Drawable>>()).ref
+           view.sources = listOf(DecodedSource(drawable))
 diff --git a/node_modules/expo-image/build/index.d.ts b/node_modules/expo-image/build/index.d.ts
 index ce18dad..4043e77 100644
 --- a/node_modules/expo-image/build/index.d.ts

--- a/patches/react-native-webview+13.15.0.patch
+++ b/patches/react-native-webview+13.15.0.patch
@@ -17,29 +17,37 @@ index 07f73fd..5a18160 100644
                  if (mAllowsProtectedMedia) {
                    grantedPermissions.add(requestedResource);
 diff --git a/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt b/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
-index 438ab6a..15a02b7 100644
+index 438ab6a..d5e794d 100644
 --- a/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
 +++ b/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
-@@ -34,6 +34,9 @@ val invalidCharRegex = "[\\\\/%\"]".toRegex()
+@@ -34,6 +34,17 @@ val invalidCharRegex = "[\\\\/%\"]".toRegex()
  class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
      companion object {
          const val NAME = "RNCWebView"
 +        private val defaultVideoPoster: Bitmap by lazy {
 +            Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888)
 +        }
++
++        fun safeDefaultVideoPoster(): Bitmap {
++            return if (defaultVideoPoster.isRecycled) {
++                Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888)
++            } else {
++                defaultVideoPoster
++            }
++        }
      }
  
      private val TAG = "RNCWebViewManagerImpl"
-@@ -148,7 +151,7 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
+@@ -148,7 +159,7 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
              val webChromeClient: RNCWebChromeClient =
                  object : RNCWebChromeClient(webView) {
                      override fun getDefaultVideoPoster(): Bitmap? {
 -                        return Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888)
-+                        return defaultVideoPoster
++                        return safeDefaultVideoPoster()
                      }
  
                      override fun onShowCustomView(view: View, callback: CustomViewCallback) {
-@@ -215,7 +218,7 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
+@@ -215,7 +226,7 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
              webChromeClient?.onHideCustomView()
              webChromeClient = object : RNCWebChromeClient(webView) {
                  override fun getDefaultVideoPoster(): Bitmap? {

--- a/patches/react-native-webview+13.15.0.patch
+++ b/patches/react-native-webview+13.15.0.patch
@@ -17,7 +17,7 @@ index 07f73fd..5a18160 100644
                  if (mAllowsProtectedMedia) {
                    grantedPermissions.add(requestedResource);
 diff --git a/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt b/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
-index 438ab6a..d5e794d 100644
+index 438ab6a..853bcc5 100644
 --- a/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
 +++ b/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
 @@ -34,6 +34,17 @@ val invalidCharRegex = "[\\\\/%\"]".toRegex()
@@ -52,7 +52,7 @@ index 438ab6a..d5e794d 100644
              webChromeClient = object : RNCWebChromeClient(webView) {
                  override fun getDefaultVideoPoster(): Bitmap? {
 -                    return Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888)
-+                    return defaultVideoPoster
++                    return safeDefaultVideoPoster()
                  }
              }
              webChromeClient.setAllowsProtectedMedia(mAllowsProtectedMedia);

--- a/patches/react-native-webview+13.15.0.patch
+++ b/patches/react-native-webview+13.15.0.patch
@@ -110,26 +110,28 @@ index a85ac85..f0ca9a9 100644
       * Executes the JavaScript string.
       */
 diff --git a/node_modules/react-native-webview/src/WebView.android.tsx b/node_modules/react-native-webview/src/WebView.android.tsx
-index edf06fa..e6b08b0 100644
+index edf06fa..a4be43e 100644
 --- a/node_modules/react-native-webview/src/WebView.android.tsx
 +++ b/node_modules/react-native-webview/src/WebView.android.tsx
-@@ -165,6 +165,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(
+@@ -165,6 +165,8 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(
          },
          stopLoading: () =>
            webViewRef.current && Commands.stopLoading(webViewRef.current),
-+        loadUrl: (url: string) => Commands.loadUrl(webViewRef.current, url),
++        loadUrl: (url: string) =>
++          webViewRef.current && Commands.loadUrl(webViewRef.current, url),
          postMessage: (data: string) =>
            webViewRef.current && Commands.postMessage(webViewRef.current, data),
          injectJavaScript: (data: string) =>
 diff --git a/node_modules/react-native-webview/src/WebView.ios.tsx b/node_modules/react-native-webview/src/WebView.ios.tsx
-index deb179b..961fe20 100644
+index deb179b..40385db 100644
 --- a/node_modules/react-native-webview/src/WebView.ios.tsx
 +++ b/node_modules/react-native-webview/src/WebView.ios.tsx
-@@ -149,6 +149,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(
+@@ -149,6 +149,8 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(
          },
          stopLoading: () =>
            webViewRef.current && Commands.stopLoading(webViewRef.current),
-+        loadUrl: (url: string) => Commands.loadUrl(webViewRef.current, url),
++        loadUrl: (url: string) =>
++          webViewRef.current && Commands.loadUrl(webViewRef.current, url),
          postMessage: (data: string) =>
            webViewRef.current && Commands.postMessage(webViewRef.current, data),
          injectJavaScript: (data: string) =>

--- a/patches/react-native-webview+13.15.0.patch
+++ b/patches/react-native-webview+13.15.0.patch
@@ -16,6 +16,38 @@ index 07f73fd..5a18160 100644
              } else if(requestedResource.equals(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)) {
                  if (mAllowsProtectedMedia) {
                    grantedPermissions.add(requestedResource);
+diff --git a/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt b/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+index 438ab6a..15a02b7 100644
+--- a/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
++++ b/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+@@ -34,6 +34,9 @@ val invalidCharRegex = "[\\\\/%\"]".toRegex()
+ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
+     companion object {
+         const val NAME = "RNCWebView"
++        private val defaultVideoPoster: Bitmap by lazy {
++            Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888)
++        }
+     }
+ 
+     private val TAG = "RNCWebViewManagerImpl"
+@@ -148,7 +151,7 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
+             val webChromeClient: RNCWebChromeClient =
+                 object : RNCWebChromeClient(webView) {
+                     override fun getDefaultVideoPoster(): Bitmap? {
+-                        return Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888)
++                        return defaultVideoPoster
+                     }
+ 
+                     override fun onShowCustomView(view: View, callback: CustomViewCallback) {
+@@ -215,7 +218,7 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
+             webChromeClient?.onHideCustomView()
+             webChromeClient = object : RNCWebChromeClient(webView) {
+                 override fun getDefaultVideoPoster(): Bitmap? {
+-                    return Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888)
++                    return defaultVideoPoster
+                 }
+             }
+             webChromeClient.setAllowsProtectedMedia(mAllowsProtectedMedia);
 diff --git a/node_modules/react-native-webview/apple/RNCWebViewImpl.m b/node_modules/react-native-webview/apple/RNCWebViewImpl.m
 index 7f5c24d..5623f4a 100644
 --- a/node_modules/react-native-webview/apple/RNCWebViewImpl.m


### PR DESCRIPTION
## Summary
- **expo-image**: Handle single `SourceMap` passed as a plain object instead of a list on Fabric (new architecture). On the new architecture, the bridge may serialize a single-element source array as a plain map object (`DynamicFromMap`). Without this handler, the `EitherOfThree` type converter throws `TypeCastException`, leaving the underlying `folly::dynamic` in an inconsistent state, leading to SIGSEGV in `folly::dynamic::destroy()` when the app backgrounds under memory pressure.
- **react-native-webview**: Use a lazy singleton `Bitmap` for `defaultVideoPoster` instead of allocating a new `Bitmap` on every `getDefaultVideoPoster()` call, reducing unnecessary memory allocations.

## Test plan
- [ ] Verify expo-image renders correctly on Android with Fabric (new architecture)
- [ ] Verify no SIGSEGV crash when backgrounding the app under memory pressure
- [ ] Verify webview video poster still displays correctly on Android
- [ ] Test on both old and new architecture builds
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
