### PR TITLE
fix(components): prevent text clipping in NumberSizeableText with splitDecimal

### DIFF
--- a/packages/components/src/content/NumberSizeableText/index.tsx
+++ b/packages/components/src/content/NumberSizeableText/index.tsx
@@ -145,7 +145,7 @@ export function NumberSizeableText({
             color={props.color}
             fontWeight={parentFontWeight}
             fontSize={parentFontSize}
-            lineHeight={props.lineHeight}
+            lineHeight={props.lineHeight ?? parentFontSize}
           >
             {r}
           </SizableText>

--- a/packages/components/src/content/NumberSizeableText/index.tsx
+++ b/packages/components/src/content/NumberSizeableText/index.tsx
@@ -41,8 +41,22 @@ export function NumberSizeableText({
   hideValue,
   autoFormatter,
   autoFormatterThreshold = 1_000_000,
+  flexShrink,
+  flexGrow,
+  flex,
+  minWidth,
+  maxWidth,
+  width,
   ...props
 }: INumberSizeableTextProps) {
+  const layoutProps = {
+    flexShrink,
+    flexGrow,
+    flex,
+    minWidth,
+    maxWidth,
+    width,
+  };
   const actualFormatter = useMemo(() => {
     if (autoFormatter && ['string', 'number'].includes(typeof children)) {
       const numericValue = new BigNumber(String(children));
@@ -110,20 +124,20 @@ export function NumberSizeableText({
   if (hideValue) {
     if (formatter === 'balance' && formatterOptions?.tokenSymbol) {
       return (
-        <SizableText {...props}>
+        <SizableText {...props} {...layoutProps}>
           **** {formatterOptions.tokenSymbol}
         </SizableText>
       );
     }
-    return <SizableText {...props}>****</SizableText>;
+    return <SizableText {...props} {...layoutProps}>****</SizableText>;
   }
 
   return typeof result === 'string' ? (
-    <SizableText {...props} {...contentStyle}>
+    <SizableText {...props} {...layoutProps} {...contentStyle}>
       {result}
     </SizableText>
   ) : (
-    <SizableText {...props} {...contentStyle}>
+    <SizableText {...props} {...layoutProps} {...contentStyle}>
       {result.map((r, index) =>
         typeof r === 'string' ? (
           <SizableText
@@ -131,6 +145,7 @@ export function NumberSizeableText({
             color={props.color}
             fontWeight={parentFontWeight}
             fontSize={parentFontSize}
+            lineHeight={props.lineHeight}
           >
             {r}
           </SizableText>

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -392,6 +392,7 @@ function HomeOverviewContainer() {
             >
               <NumberSizeableTextWrapper
                 hideValue
+                splitDecimal
                 flexShrink={1}
                 minWidth={0}
                 fontSize={48}


### PR DESCRIPTION
## Summary
- Fix text clipping issue when `splitDecimal` is enabled on `NumberSizeableText` (e.g., home balance display)
- Separate layout props (`flexShrink`, `minWidth`, etc.) so they only apply to the outer container, not to nested child `SizableText` elements
- Add explicit `lineHeight` to inner string parts to prevent inheriting the small default from `$bodyMd` size token

## Root Cause
When `splitDecimal` is enabled, `NumberSizeableText` renders nested `SizableText` children. Two issues caused text clipping:
1. The decimal part child received `{...props}` which included layout props like `flexShrink={1}` and `minWidth={0}`, causing incorrect width measurement
2. The string parts (currency symbol, integer portion) only received `fontSize` but not `lineHeight`, so they fell back to the `$bodyMd` default lineHeight which is much smaller than the 48px fontSize

## Test plan
- [ ] Verify home balance text displays fully with `splitDecimal` enabled on Android
- [ ] Verify home balance text displays fully on iOS
- [ ] Verify decimal portion still renders in `$textDisabled` color
- [ ] Verify `hideValue` mode still works correctly with layout props

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
