### PR TITLE
fix: resolve race condition causing undefined entries in swapHistoryPendingList

### DIFF
--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -1435,11 +1435,14 @@ export default class ServiceSwap extends ServiceBase {
       (item) => item.txInfo.txId === oldTxId,
     );
     if (oldHistoryItemIndex !== -1) {
-      const newHistoryItem = swapHistoryPendingList[oldHistoryItemIndex];
+      const oldHistoryItem = swapHistoryPendingList[oldHistoryItemIndex];
       const updated = Date.now();
-      newHistoryItem.date = { ...newHistoryItem.date, updated };
-      newHistoryItem.txInfo.txId = newTxId;
-      newHistoryItem.status = status;
+      const newHistoryItem = {
+        ...oldHistoryItem,
+        date: { ...oldHistoryItem.date, updated },
+        txInfo: { ...oldHistoryItem.txInfo, txId: newTxId },
+        status,
+      };
       await this.backgroundApi.simpleDb.swapHistory.updateSwapHistoryItem(
         newHistoryItem,
         oldTxId,
@@ -1479,51 +1482,66 @@ export default class ServiceSwap extends ServiceBase {
     );
     if (index !== -1) {
       const updated = Date.now();
-      item.date = { ...item.date, updated };
       const oldItem = swapHistoryPendingList[index];
+      let updatedStatus = item.status;
       if (
         oldItem.status === ESwapTxHistoryStatus.CANCELING &&
         item.status === ESwapTxHistoryStatus.SUCCESS
       ) {
-        item.status = ESwapTxHistoryStatus.CANCELED;
+        updatedStatus = ESwapTxHistoryStatus.CANCELED;
       }
+      const updatedItem: ISwapTxHistory = {
+        ...item,
+        date: { ...item.date, updated },
+        status: updatedStatus,
+      };
       if (
-        item.txInfo.receiverTransactionId &&
+        updatedItem.txInfo.receiverTransactionId &&
         !this._crossChainReceiveTxBlockNotificationMap[
-          item.txInfo.receiverTransactionId
+          updatedItem.txInfo.receiverTransactionId
         ]
       ) {
         void this.backgroundApi.serviceNotification.blockNotificationForTxId({
-          networkId: item.baseInfo.toToken.networkId,
-          tx: item.txInfo.receiverTransactionId,
+          networkId: updatedItem.baseInfo.toToken.networkId,
+          tx: updatedItem.txInfo.receiverTransactionId,
         });
         this._crossChainReceiveTxBlockNotificationMap[
-          item.txInfo.receiverTransactionId
+          updatedItem.txInfo.receiverTransactionId
         ] = true;
       }
-      await this.backgroundApi.simpleDb.swapHistory.updateSwapHistoryItem(item);
+      await this.backgroundApi.simpleDb.swapHistory.updateSwapHistoryItem(
+        updatedItem,
+      );
       await inAppNotificationAtom.set((pre) => {
         const currentIndex = pre.swapHistoryPendingList.findIndex((i) =>
-          item.txInfo.useOrderId
-            ? i.txInfo.orderId === item.txInfo.orderId
-            : i.txInfo.txId === item.txInfo.txId,
+          updatedItem.txInfo.useOrderId
+            ? i.txInfo.orderId === updatedItem.txInfo.orderId
+            : i.txInfo.txId === updatedItem.txInfo.txId,
         );
         if (currentIndex === -1) return pre;
+        const currentOldItem = pre.swapHistoryPendingList[currentIndex];
+        let finalItem = updatedItem;
+        if (
+          currentOldItem.status === ESwapTxHistoryStatus.CANCELING &&
+          updatedItem.status !== ESwapTxHistoryStatus.CANCELED
+        ) {
+          finalItem = { ...updatedItem, status: ESwapTxHistoryStatus.CANCELED };
+        }
         const newPendingList = [...pre.swapHistoryPendingList];
-        newPendingList[currentIndex] = item;
+        newPendingList[currentIndex] = finalItem;
         return {
           ...pre,
           swapHistoryPendingList: newPendingList,
         };
       });
-      if (item.status !== ESwapTxHistoryStatus.PENDING) {
-        let fromAmountFinal = item.baseInfo.fromAmount;
-        if (item.swapInfo.otherFeeInfos?.length) {
-          item.swapInfo.otherFeeInfos.forEach((extraFeeInfo) => {
+      if (updatedItem.status !== ESwapTxHistoryStatus.PENDING) {
+        let fromAmountFinal = updatedItem.baseInfo.fromAmount;
+        if (updatedItem.swapInfo.otherFeeInfos?.length) {
+          updatedItem.swapInfo.otherFeeInfos.forEach((extraFeeInfo) => {
             if (
               equalTokenNoCaseSensitive({
                 token1: extraFeeInfo.token,
-                token2: item.baseInfo.fromToken,
+                token2: updatedItem.baseInfo.fromToken,
               })
             ) {
               fromAmountFinal = new BigNumber(fromAmountFinal)
@@ -1534,21 +1552,21 @@ export default class ServiceSwap extends ServiceBase {
         }
         void this.backgroundApi.serviceApp.showToast({
           method:
-            item.status === ESwapTxHistoryStatus.SUCCESS ||
-            item.status === ESwapTxHistoryStatus.PARTIALLY_FILLED
+            updatedItem.status === ESwapTxHistoryStatus.SUCCESS ||
+            updatedItem.status === ESwapTxHistoryStatus.PARTIALLY_FILLED
               ? 'success'
               : 'error',
           title: appLocale.intl.formatMessage({
             id:
-              item.status === ESwapTxHistoryStatus.SUCCESS ||
-              item.status === ESwapTxHistoryStatus.PARTIALLY_FILLED
+              updatedItem.status === ESwapTxHistoryStatus.SUCCESS ||
+              updatedItem.status === ESwapTxHistoryStatus.PARTIALLY_FILLED
                 ? ETranslations.swap_page_toast_swap_successful
                 : ETranslations.swap_page_toast_swap_failed,
           }),
-          message: `${numberFormat(item.baseInfo.fromAmount, formatter)} ${
-            item.baseInfo.fromToken.symbol
-          } → ${numberFormat(item.baseInfo.toAmount, formatter)} ${
-            item.baseInfo.toToken.symbol
+          message: `${numberFormat(updatedItem.baseInfo.fromAmount, formatter)} ${
+            updatedItem.baseInfo.fromToken.symbol
+          } → ${numberFormat(updatedItem.baseInfo.toAmount, formatter)} ${
+            updatedItem.baseInfo.toToken.symbol
           }`,
         });
       }

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -1519,16 +1519,8 @@ export default class ServiceSwap extends ServiceBase {
             : i.txInfo.txId === updatedItem.txInfo.txId,
         );
         if (currentIndex === -1) return pre;
-        const currentOldItem = pre.swapHistoryPendingList[currentIndex];
-        let finalItem = updatedItem;
-        if (
-          currentOldItem.status === ESwapTxHistoryStatus.CANCELING &&
-          updatedItem.status !== ESwapTxHistoryStatus.CANCELED
-        ) {
-          finalItem = { ...updatedItem, status: ESwapTxHistoryStatus.CANCELED };
-        }
         const newPendingList = [...pre.swapHistoryPendingList];
-        newPendingList[currentIndex] = finalItem;
+        newPendingList[currentIndex] = updatedItem;
         return {
           ...pre,
           swapHistoryPendingList: newPendingList,

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -1445,11 +1445,15 @@ export default class ServiceSwap extends ServiceBase {
         oldTxId,
       );
       await inAppNotificationAtom.set((pre) => {
+        const currentIndex = pre.swapHistoryPendingList.findIndex(
+          (item) => item.txInfo.txId === newTxId || item.txInfo.txId === oldTxId,
+        );
+        if (currentIndex === -1) return pre;
         const newPendingList = [...pre.swapHistoryPendingList];
-        newPendingList[oldHistoryItemIndex] = newHistoryItem;
+        newPendingList[currentIndex] = newHistoryItem;
         return {
           ...pre,
-          swapHistoryPendingList: [...newPendingList],
+          swapHistoryPendingList: newPendingList,
         };
       });
       return;
@@ -1499,11 +1503,17 @@ export default class ServiceSwap extends ServiceBase {
       }
       await this.backgroundApi.simpleDb.swapHistory.updateSwapHistoryItem(item);
       await inAppNotificationAtom.set((pre) => {
+        const currentIndex = pre.swapHistoryPendingList.findIndex((i) =>
+          item.txInfo.useOrderId
+            ? i.txInfo.orderId === item.txInfo.orderId
+            : i.txInfo.txId === item.txInfo.txId,
+        );
+        if (currentIndex === -1) return pre;
         const newPendingList = [...pre.swapHistoryPendingList];
-        newPendingList[index] = item;
+        newPendingList[currentIndex] = item;
         return {
           ...pre,
-          swapHistoryPendingList: [...newPendingList],
+          swapHistoryPendingList: newPendingList,
         };
       });
       if (item.status !== ESwapTxHistoryStatus.PENDING) {

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -1435,23 +1435,21 @@ export default class ServiceSwap extends ServiceBase {
       (item) => item.txInfo.txId === oldTxId,
     );
     if (oldHistoryItemIndex !== -1) {
-      const oldHistoryItem = swapHistoryPendingList[oldHistoryItemIndex];
       const updated = Date.now();
-      const newHistoryItem = {
-        ...oldHistoryItem,
-        date: { ...oldHistoryItem.date, updated },
-        txInfo: { ...oldHistoryItem.txInfo, txId: newTxId },
-        status,
-      };
-      await this.backgroundApi.simpleDb.swapHistory.updateSwapHistoryItem(
-        newHistoryItem,
-        oldTxId,
-      );
+      let newHistoryItem: ISwapTxHistory | undefined;
       await inAppNotificationAtom.set((pre) => {
         const currentIndex = pre.swapHistoryPendingList.findIndex(
-          (item) => item.txInfo.txId === newTxId || item.txInfo.txId === oldTxId,
+          (item) =>
+            item.txInfo.txId === newTxId || item.txInfo.txId === oldTxId,
         );
         if (currentIndex === -1) return pre;
+        const currentItem = pre.swapHistoryPendingList[currentIndex];
+        newHistoryItem = {
+          ...currentItem,
+          date: { ...currentItem.date, updated },
+          txInfo: { ...currentItem.txInfo, txId: newTxId },
+          status,
+        };
         const newPendingList = [...pre.swapHistoryPendingList];
         newPendingList[currentIndex] = newHistoryItem;
         return {
@@ -1459,6 +1457,12 @@ export default class ServiceSwap extends ServiceBase {
           swapHistoryPendingList: newPendingList,
         };
       });
+      if (newHistoryItem) {
+        await this.backgroundApi.simpleDb.swapHistory.updateSwapHistoryItem(
+          newHistoryItem,
+          oldTxId,
+        );
+      }
       return;
     }
     const approvingTransaction = await this.getApprovingTransaction();
@@ -1482,18 +1486,9 @@ export default class ServiceSwap extends ServiceBase {
     );
     if (index !== -1) {
       const updated = Date.now();
-      const oldItem = swapHistoryPendingList[index];
-      let updatedStatus = item.status;
-      if (
-        oldItem.status === ESwapTxHistoryStatus.CANCELING &&
-        item.status === ESwapTxHistoryStatus.SUCCESS
-      ) {
-        updatedStatus = ESwapTxHistoryStatus.CANCELED;
-      }
       const updatedItem: ISwapTxHistory = {
         ...item,
         date: { ...item.date, updated },
-        status: updatedStatus,
       };
       if (
         updatedItem.txInfo.receiverTransactionId &&
@@ -1509,9 +1504,7 @@ export default class ServiceSwap extends ServiceBase {
           updatedItem.txInfo.receiverTransactionId
         ] = true;
       }
-      await this.backgroundApi.simpleDb.swapHistory.updateSwapHistoryItem(
-        updatedItem,
-      );
+      let finalItem: ISwapTxHistory = updatedItem;
       await inAppNotificationAtom.set((pre) => {
         const currentIndex = pre.swapHistoryPendingList.findIndex((i) =>
           updatedItem.txInfo.useOrderId
@@ -1519,21 +1512,34 @@ export default class ServiceSwap extends ServiceBase {
             : i.txInfo.txId === updatedItem.txInfo.txId,
         );
         if (currentIndex === -1) return pre;
+        const currentOldItem = pre.swapHistoryPendingList[currentIndex];
+        if (
+          currentOldItem.status === ESwapTxHistoryStatus.CANCELING &&
+          updatedItem.status === ESwapTxHistoryStatus.SUCCESS
+        ) {
+          finalItem = {
+            ...updatedItem,
+            status: ESwapTxHistoryStatus.CANCELED,
+          };
+        }
         const newPendingList = [...pre.swapHistoryPendingList];
-        newPendingList[currentIndex] = updatedItem;
+        newPendingList[currentIndex] = finalItem;
         return {
           ...pre,
           swapHistoryPendingList: newPendingList,
         };
       });
-      if (updatedItem.status !== ESwapTxHistoryStatus.PENDING) {
-        let fromAmountFinal = updatedItem.baseInfo.fromAmount;
-        if (updatedItem.swapInfo.otherFeeInfos?.length) {
-          updatedItem.swapInfo.otherFeeInfos.forEach((extraFeeInfo) => {
+      await this.backgroundApi.simpleDb.swapHistory.updateSwapHistoryItem(
+        finalItem,
+      );
+      if (finalItem.status !== ESwapTxHistoryStatus.PENDING) {
+        let fromAmountFinal = finalItem.baseInfo.fromAmount;
+        if (finalItem.swapInfo.otherFeeInfos?.length) {
+          finalItem.swapInfo.otherFeeInfos.forEach((extraFeeInfo) => {
             if (
               equalTokenNoCaseSensitive({
                 token1: extraFeeInfo.token,
-                token2: updatedItem.baseInfo.fromToken,
+                token2: finalItem.baseInfo.fromToken,
               })
             ) {
               fromAmountFinal = new BigNumber(fromAmountFinal)
@@ -1544,21 +1550,21 @@ export default class ServiceSwap extends ServiceBase {
         }
         void this.backgroundApi.serviceApp.showToast({
           method:
-            updatedItem.status === ESwapTxHistoryStatus.SUCCESS ||
-            updatedItem.status === ESwapTxHistoryStatus.PARTIALLY_FILLED
+            finalItem.status === ESwapTxHistoryStatus.SUCCESS ||
+            finalItem.status === ESwapTxHistoryStatus.PARTIALLY_FILLED
               ? 'success'
               : 'error',
           title: appLocale.intl.formatMessage({
             id:
-              updatedItem.status === ESwapTxHistoryStatus.SUCCESS ||
-              updatedItem.status === ESwapTxHistoryStatus.PARTIALLY_FILLED
+              finalItem.status === ESwapTxHistoryStatus.SUCCESS ||
+              finalItem.status === ESwapTxHistoryStatus.PARTIALLY_FILLED
                 ? ETranslations.swap_page_toast_swap_successful
                 : ETranslations.swap_page_toast_swap_failed,
           }),
-          message: `${numberFormat(updatedItem.baseInfo.fromAmount, formatter)} ${
-            updatedItem.baseInfo.fromToken.symbol
-          } → ${numberFormat(updatedItem.baseInfo.toAmount, formatter)} ${
-            updatedItem.baseInfo.toToken.symbol
+          message: `${numberFormat(finalItem.baseInfo.fromAmount, formatter)} ${
+            finalItem.baseInfo.fromToken.symbol
+          } → ${numberFormat(finalItem.baseInfo.toAmount, formatter)} ${
+            finalItem.baseInfo.toToken.symbol
           }`,
         });
       }
@@ -1572,7 +1578,7 @@ export default class ServiceSwap extends ServiceBase {
     );
     const inAppNotification = await inAppNotificationAtom.get();
     const deleteHistoryIds = inAppNotification.swapHistoryPendingList
-      .filter((item) => statuses?.includes(item.status))
+      .filter((item) => item && statuses?.includes(item.status))
       .map((item) =>
         item.txInfo.useOrderId ? item.txInfo.orderId : item.txInfo.txId,
       );
@@ -1580,7 +1586,7 @@ export default class ServiceSwap extends ServiceBase {
       ...pre,
       swapHistoryPendingList: statuses
         ? pre.swapHistoryPendingList.filter(
-            (item) => !statuses?.includes(item.status),
+            (item) => item && !statuses?.includes(item.status),
           )
         : [],
     }));
@@ -1602,7 +1608,7 @@ export default class ServiceSwap extends ServiceBase {
     await inAppNotificationAtom.set((pre) => ({
       ...pre,
       swapHistoryPendingList: pre.swapHistoryPendingList.filter(
-        (item) => item.txInfo.txId !== deleteHistoryId,
+        (item) => item && item.txInfo.txId !== deleteHistoryId,
       ),
     }));
     await this.cleanHistoryStateIntervals(deleteHistoryId);
@@ -1748,8 +1754,9 @@ export default class ServiceSwap extends ServiceBase {
     const { swapHistoryPendingList } = await inAppNotificationAtom.get();
     const statusPendingList = swapHistoryPendingList.filter(
       (item) =>
-        item.status === ESwapTxHistoryStatus.PENDING ||
-        item.status === ESwapTxHistoryStatus.CANCELING,
+        item &&
+        (item.status === ESwapTxHistoryStatus.PENDING ||
+          item.status === ESwapTxHistoryStatus.CANCELING),
     );
     const newHistoryStatePendingList = statusPendingList.filter(
       (item) =>

--- a/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
+++ b/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
@@ -201,9 +201,10 @@ const PreSwapDialogContent = ({
       if (preSwapData?.swapType !== ESwapTabSwitchType.LIMIT) {
         findStepItem = inAppNotificationAtom.swapHistoryPendingList.find(
           (item) =>
-            item.txInfo.useOrderId
+            item &&
+            (item.txInfo.useOrderId
               ? item.txInfo.orderId === lastStep?.orderId
-              : item.txInfo.txId === lastStep?.txHash,
+              : item.txInfo.txId === lastStep?.txHash),
         );
       } else {
         findStepItem = inAppNotificationAtom.swapLimitOrders.find(

--- a/packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx
@@ -439,8 +439,9 @@ const SwapHeaderRightActionContainer = ({
     () =>
       swapHistoryPendingList.filter(
         (i) =>
-          i.status === ESwapTxHistoryStatus.PENDING ||
-          i.status === ESwapTxHistoryStatus.CANCELING,
+          i &&
+          (i.status === ESwapTxHistoryStatus.PENDING ||
+            i.status === ESwapTxHistoryStatus.CANCELING),
       ),
     [swapHistoryPendingList],
   );


### PR DESCRIPTION
## Summary
- Fix race condition in `ServiceSwap.updateSwapHistoryTx` and `ServiceSwap.updateSwapHistoryItem` where a stale array index (captured from a snapshot) was used inside the atom `set()` callback. When the list shrank between the snapshot and the update, this created sparse array holes (`undefined` entries).
- Move `findIndex` inside the `set()` callback so the index always reflects the current state.
- Add defensive null guard in `SwapHeaderRightActionContainer` filter to prevent crash on `undefined` entries.

## Test plan
- [ ] Verify swap history list renders without crash after navigating between swap pages
- [ ] Verify concurrent swap history updates (e.g., multiple pending txs resolving) don't corrupt the list
- [ ] Verify swap settings dialog opens without error
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
