### PR TITLE
feat(web): refactor perps header toolbar and unify search button

### DIFF
--- a/packages/kit/src/components/TabPageHeader/DappHeader.tsx
+++ b/packages/kit/src/components/TabPageHeader/DappHeader.tsx
@@ -431,9 +431,11 @@ function DepositButton() {
 function RightActions({
   tabRoute,
   customHeaderRightItems,
+  customToolbarItems,
 }: {
   tabRoute: ETabRoutes;
   customHeaderRightItems?: ReactNode;
+  customToolbarItems?: ReactNode;
 }) {
   const { gtLg } = useMedia();
   const navigation = useAppNavigation();
@@ -483,7 +485,7 @@ function RightActions({
           <DepositButton />
         </>
       )}
-      {gtLg ? <DownloadAppButton /> : null}
+      {!isPerpsTab && gtLg ? <DownloadAppButton /> : null}
       <XStack
         ai="center"
         gap="$2.5"
@@ -492,6 +494,7 @@ function RightActions({
         borderRadius="$2"
         bg="$bgStrong"
       >
+        {customToolbarItems}
         <HeaderNotificationIconButton
           testID="header-right-notification"
           size="small"
@@ -540,6 +543,7 @@ export function DappHeader({
   tabRoute,
   hideSearch,
   customHeaderRightItems,
+  customToolbarItems,
 }: ITabPageHeaderProp) {
   const { gtMd } = useMedia();
   const { config } = useAccountSelectorContextData();
@@ -558,11 +562,12 @@ export function DappHeader({
             <RightActions
               tabRoute={tabRoute}
               customHeaderRightItems={customHeaderRightItems}
+              customToolbarItems={customToolbarItems}
             />
           </AccountSelectorProviderMirror>
         </HomeTokenListProviderMirror>
       ) : null,
-    [config, customHeaderRightItems, tabRoute],
+    [config, customHeaderRightItems, customToolbarItems, tabRoute],
   );
 
   const renderDesktopHeaderTitle = useCallback(

--- a/packages/kit/src/components/TabPageHeader/index.tsx
+++ b/packages/kit/src/components/TabPageHeader/index.tsx
@@ -143,6 +143,7 @@ export function TabPageHeader({
   renderCustomHeaderRightItems,
   customHeaderRightItems,
   customHeaderLeftItems,
+  customToolbarItems,
   hideSearch = false,
   hideHeaderLeft = false,
   headerPx,
@@ -158,6 +159,7 @@ export function TabPageHeader({
         selectedHeaderTab={selectedHeaderTab}
         customHeaderRightItems={customHeaderRightItems}
         customHeaderLeftItems={customHeaderLeftItems}
+        customToolbarItems={customToolbarItems}
         hideHeaderLeft={hideHeaderLeft}
         renderCustomHeaderRightItems={renderCustomHeaderRightItems}
       />

--- a/packages/kit/src/components/TabPageHeader/type.ts
+++ b/packages/kit/src/components/TabPageHeader/type.ts
@@ -16,6 +16,7 @@ export interface ITabPageHeaderProp {
   }) => ReactNode;
   customHeaderRightItems?: ReactNode;
   customHeaderLeftItems?: ReactNode;
+  customToolbarItems?: ReactNode;
   hideSearch?: boolean;
   hideHeaderLeft?: boolean;
   headerPx?: string;

--- a/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
@@ -11,6 +11,7 @@ import {
   XStack,
   useMedia,
 } from '@onekeyhq/components';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { GiftAction } from '@onekeyhq/kit/src/components/TabPageHeader/components';
 import { WalletConnectionForWeb } from '@onekeyhq/kit/src/components/TabPageHeader/components/WalletConnectionGroup';
@@ -172,7 +173,7 @@ export function PerpsHeaderRight() {
       <WalletConnectionForWeb tabRoute={ETabRoutes.Perp} />
       {process.env.NODE_ENV !== 'production' ? <DebugButton /> : null}
       <DepositButton />
-      {gtMd ? (
+      {gtMd && !platformEnv.isWebDappMode ? (
         <>
           <GiftAction source="Perps" copyAsUrl />
           <PerpSettingsButton testID="perp-header-settings-button" />

--- a/packages/kit/src/views/Perp/pages/Perp.tsx
+++ b/packages/kit/src/views/Perp/pages/Perp.tsx
@@ -10,16 +10,21 @@ import {
   YStack,
   useMedia,
 } from '@onekeyhq/components';
+import { HeaderIconButton } from '@onekeyhq/components/src/layouts/Navigation/Header';
 import { TabletHomeContainer } from '@onekeyhq/kit/src/components/TabletHomeContainer';
+import { DOWNLOAD_MOBILE_APP_URL } from '@onekeyhq/shared/src/config/appConfig';
 import { FLOAT_NAV_BAR_Z_INDEX } from '@onekeyhq/shared/src/consts/zIndexConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes/tab';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import { LazyPageContainer } from '../../../components/LazyPageContainer';
 import { TabPageHeader } from '../../../components/TabPageHeader';
+import { GiftAction } from '../../../components/TabPageHeader/components';
 import { useNativePerpFeatureGuard } from '../../../hooks/usePerpFeatureGuard';
+import { PerpSettingsButton } from '../components/PerpSettingsButton';
 import { PerpContentFooter } from '../components/PerpContentFooter';
 import { PerpsGlobalEffects } from '../components/PerpsGlobalEffects';
 import { PerpsHeaderRight } from '../components/TradingPanel/components/PerpsHeaderRight';
@@ -59,6 +64,9 @@ function PerpContent() {
     setTabPageHeight(height);
   }, []);
   const intl = useIntl();
+  const handleDownloadApp = useCallback(() => {
+    openUrlExternal(DOWNLOAD_MOBILE_APP_URL);
+  }, []);
 
   const header = (
     <TabPageHeader
@@ -78,6 +86,20 @@ function PerpContent() {
             <PerpsHeaderRight />
           </PerpsProviderMirror>
         </PerpsAccountSelectorProviderMirror>
+      }
+      customToolbarItems={
+        <>
+          <GiftAction source="Perps" size="small" copyAsUrl />
+          <PerpSettingsButton testID="perp-header-settings-button" />
+          <HeaderIconButton
+            icon="DownloadOutline"
+            size="small"
+            title={intl.formatMessage({
+              id: ETranslations.global_download_app,
+            })}
+            onPress={handleDownloadApp}
+          />
+        </>
       }
     />
   );

--- a/packages/shared/src/locale/enum/translations.ts
+++ b/packages/shared/src/locale/enum/translations.ts
@@ -1460,6 +1460,7 @@
   global_done = 'global.done',
   global_download = 'global.download',
   global_download_and_install = 'global.download_and_install',
+  global_download_app = 'global.download_app',
   global_download_onekey_wallet = 'global.download_onekey_wallet',
   global_earn = 'global.earn',
   global_edit = 'global.edit',

--- a/packages/shared/src/locale/json/bn.json
+++ b/packages/shared/src/locale/json/bn.json
@@ -1455,6 +1455,7 @@
   "global.done": "সম্পন্ন",
   "global.download": "ডাউনলোড",
   "global.download_and_install": "ডাউনলোড এবং ইনস্টল করুন",
+  "global.download_app": "অ্যাপ ডাউনলোড করুন",
   "global.download_onekey_wallet": "OneKey ওয়ালেট ডাউনলোড করুন",
   "global.earn": "DeFi",
   "global.edit": "সম্পাদনা করুন",

--- a/packages/shared/src/locale/json/de.json
+++ b/packages/shared/src/locale/json/de.json
@@ -1455,6 +1455,7 @@
   "global.done": "Erledigt",
   "global.download": "Herunterladen",
   "global.download_and_install": "Herunterladen und installieren",
+  "global.download_app": "App herunterladen",
   "global.download_onekey_wallet": "OneKey Wallet herunterladen",
   "global.earn": "DeFi",
   "global.edit": "Bearbeiten",

--- a/packages/shared/src/locale/json/en_US.json
+++ b/packages/shared/src/locale/json/en_US.json
@@ -1455,6 +1455,7 @@
   "global.done": "Done",
   "global.download": "Download",
   "global.download_and_install": "Download and install",
+  "global.download_app": "Download App",
   "global.download_onekey_wallet": "Download OneKey wallet",
   "global.earn": "DeFi",
   "global.edit": "Edit",

--- a/packages/shared/src/locale/json/es.json
+++ b/packages/shared/src/locale/json/es.json
@@ -1455,6 +1455,7 @@
   "global.done": "Hecho",
   "global.download": "Descargar",
   "global.download_and_install": "Descargar e instalar",
+  "global.download_app": "Descargar aplicación",
   "global.download_onekey_wallet": "Descargar billetera OneKey",
   "global.earn": "DeFi",
   "global.edit": "Editar",

--- a/packages/shared/src/locale/json/fr_FR.json
+++ b/packages/shared/src/locale/json/fr_FR.json
@@ -1455,6 +1455,7 @@
   "global.done": "Fait",
   "global.download": "Télécharger",
   "global.download_and_install": "Téléchargez et installez",
+  "global.download_app": "Télécharger l'application",
   "global.download_onekey_wallet": "Télécharger le portefeuille OneKey",
   "global.earn": "DeFi",
   "global.edit": "Modifier",

--- a/packages/shared/src/locale/json/hi_IN.json
+++ b/packages/shared/src/locale/json/hi_IN.json
@@ -1455,6 +1455,7 @@
   "global.done": "हो गया",
   "global.download": "डाउनलोड करें",
   "global.download_and_install": "डाउनलोड और इंस्टॉल करें",
+  "global.download_app": "ऐप डाउनलोड करें",
   "global.download_onekey_wallet": "OneKey वॉलेट डाउनलोड करें",
   "global.earn": "DeFi",
   "global.edit": "संपादित करें",

--- a/packages/shared/src/locale/json/id.json
+++ b/packages/shared/src/locale/json/id.json
@@ -1455,6 +1455,7 @@
   "global.done": "Selesai",
   "global.download": "Unduh",
   "global.download_and_install": "Unduh dan instal",
+  "global.download_app": "Unduh Aplikasi",
   "global.download_onekey_wallet": "Unduh dompet OneKey",
   "global.earn": "DeFi",
   "global.edit": "Sunting",

--- a/packages/shared/src/locale/json/it_IT.json
+++ b/packages/shared/src/locale/json/it_IT.json
@@ -1455,6 +1455,7 @@
   "global.done": "Fatto",
   "global.download": "Scarica",
   "global.download_and_install": "Scarica e installa",
+  "global.download_app": "Scarica l'app",
   "global.download_onekey_wallet": "Scarica il portafoglio OneKey",
   "global.earn": "DeFi",
   "global.edit": "Modifica",

--- a/packages/shared/src/locale/json/ja_JP.json
+++ b/packages/shared/src/locale/json/ja_JP.json
@@ -1455,6 +1455,7 @@
   "global.done": "完了",
   "global.download": "ダウンロード",
   "global.download_and_install": "ダウンロードしてインストールする",
+  "global.download_app": "アプリをダウンロード",
   "global.download_onekey_wallet": "OneKey ウォレットをダウンロード",
   "global.earn": "DeFi",
   "global.edit": "編集",

--- a/packages/shared/src/locale/json/ko_KR.json
+++ b/packages/shared/src/locale/json/ko_KR.json
@@ -1455,6 +1455,7 @@
   "global.done": "완료",
   "global.download": "다운로드",
   "global.download_and_install": "다운로드하고 설치하십시오",
+  "global.download_app": "앱 다운로드",
   "global.download_onekey_wallet": "OneKey 지갑 다운로드",
   "global.earn": "DeFi",
   "global.edit": "편집",

--- a/packages/shared/src/locale/json/pt.json
+++ b/packages/shared/src/locale/json/pt.json
@@ -1455,6 +1455,7 @@
   "global.done": "Feito",
   "global.download": "Baixar",
   "global.download_and_install": "Baixar e instalar",
+  "global.download_app": "Baixe o aplicativo",
   "global.download_onekey_wallet": "Baixar carteira OneKey",
   "global.earn": "DeFi",
   "global.edit": "Editar",

--- a/packages/shared/src/locale/json/pt_BR.json
+++ b/packages/shared/src/locale/json/pt_BR.json
@@ -1455,6 +1455,7 @@
   "global.done": "Feito",
   "global.download": "Baixar",
   "global.download_and_install": "Baixe e instale",
+  "global.download_app": "Baixe o aplicativo",
   "global.download_onekey_wallet": "Baixar carteira OneKey",
   "global.earn": "DeFi",
   "global.edit": "Editar",

--- a/packages/shared/src/locale/json/ru.json
+++ b/packages/shared/src/locale/json/ru.json
@@ -1455,6 +1455,7 @@
   "global.done": "Готово",
   "global.download": "Скачать",
   "global.download_and_install": "Скачать и установить",
+  "global.download_app": "Скачать приложение",
   "global.download_onekey_wallet": "Скачать кошелек OneKey",
   "global.earn": "DeFi",
   "global.edit": "Редактировать",

--- a/packages/shared/src/locale/json/th_TH.json
+++ b/packages/shared/src/locale/json/th_TH.json
@@ -1455,6 +1455,7 @@
   "global.done": "เสร็จสิ้น",
   "global.download": "ดาวน์โหลด",
   "global.download_and_install": "ดาวน์โหลดและติดตั้ง",
+  "global.download_app": "ดาวน์โหลดแอป",
   "global.download_onekey_wallet": "ดาวน์โหลดกระเป๋าเงิน OneKey",
   "global.earn": "DeFi",
   "global.edit": "แก้ไข",

--- a/packages/shared/src/locale/json/uk_UA.json
+++ b/packages/shared/src/locale/json/uk_UA.json
@@ -1455,6 +1455,7 @@
   "global.done": "Готово",
   "global.download": "Завантажити",
   "global.download_and_install": "Завантажте та встановіть",
+  "global.download_app": "Завантажити додаток",
   "global.download_onekey_wallet": "Завантажити гаманець OneKey",
   "global.earn": "DeFi",
   "global.edit": "Редагувати",

--- a/packages/shared/src/locale/json/vi.json
+++ b/packages/shared/src/locale/json/vi.json
@@ -1455,6 +1455,7 @@
   "global.done": "Đã xong",
   "global.download": "Tải xuống",
   "global.download_and_install": "Tải xuống và cài đặt",
+  "global.download_app": "Tải ứng dụng",
   "global.download_onekey_wallet": "Tải xuống ví OneKey",
   "global.earn": "DeFi",
   "global.edit": "Chỉnh sửa",

--- a/packages/shared/src/locale/json/zh_CN.json
+++ b/packages/shared/src/locale/json/zh_CN.json
@@ -1455,6 +1455,7 @@
   "global.done": "完成",
   "global.download": "下载",
   "global.download_and_install": "下载并安装",
+  "global.download_app": "下载应用",
   "global.download_onekey_wallet": "下载 OneKey 钱包",
   "global.earn": "DeFi",
   "global.edit": "编辑",

--- a/packages/shared/src/locale/json/zh_HK.json
+++ b/packages/shared/src/locale/json/zh_HK.json
@@ -1455,6 +1455,7 @@
   "global.done": "完成",
   "global.download": "下載",
   "global.download_and_install": "下載並安裝",
+  "global.download_app": "下載應用",
   "global.download_onekey_wallet": "下載 OneKey 錢包",
   "global.earn": "DeFi",
   "global.edit": "編輯",

--- a/packages/shared/src/locale/json/zh_TW.json
+++ b/packages/shared/src/locale/json/zh_TW.json
@@ -1455,6 +1455,7 @@
   "global.done": "完成",
   "global.download": "下載",
   "global.download_and_install": "下載並安裝",
+  "global.download_app": "下載應用",
   "global.download_onekey_wallet": "下載 OneKey 錢包",
   "global.earn": "DeFi",
   "global.edit": "編輯",


### PR DESCRIPTION
## Summary
- Show search button on all tabs (including Perps) with consistent positioning
- Add `customToolbarItems` prop to `TabPageHeader` for tab-specific toolbar items
- Move Perps-specific actions (Gift, Settings, Download) into the right toolbar group
- Replace green APP download button with icon-only style on Perps tab, using new `global_download_app` i18n key
- Hide duplicate Gift/Settings in `PerpsHeaderRight` for web dapp mode to avoid duplication

## Test plan
- [x] Open web dapp mode, verify search button appears on all tabs (Market, Perps, DeFi, Swap, Referral)
- [x] On Perps tab: verify Gift, Settings, Download icons appear in the right toolbar group
- [x] On Perps tab: verify green APP button is hidden
- [x] On non-Perps tabs: verify green APP button still shows normally
- [x] Hover over Download icon on Perps tab: verify tooltip shows "Download App"
- [x] Click Download icon: verify it opens the mobile app download URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
