### PR TITLE
fix(referral): set default date range for perps reward page

### DIFF
--- a/packages/kit/src/views/ReferFriends/hooks/useRewardFilter.ts
+++ b/packages/kit/src/views/ReferFriends/hooks/useRewardFilter.ts
@@ -17,7 +17,10 @@ export const getDatePickerValue = (filterState: IFilterState): IDateRange => {
   return { start: null, end: null };
 };
 
-export const useRewardFilter: () => {
+export const useRewardFilter: (initialDateRange?: {
+  startTime: number;
+  endTime: number;
+}) => {
   filterState: IFilterState;
   updateFilter: (updates: Partial<IFilterState>) => void;
   resetFilter: () => void;
@@ -25,12 +28,14 @@ export const useRewardFilter: () => {
   setCustomDateRange: (startTime: number, endTime: number) => void;
   clearCustomDateRange: () => void;
   datePickerValue: IDateRange;
-} = () => {
+} = (initialDateRange) => {
   const [filterState, setFilterState] = useState<IFilterState>({
-    timeRange: EExportTimeRange.All,
+    timeRange: initialDateRange
+      ? EExportTimeRange.Custom
+      : EExportTimeRange.All,
     inviteCode: undefined,
-    startTime: undefined,
-    endTime: undefined,
+    startTime: initialDateRange?.startTime,
+    endTime: initialDateRange?.endTime,
   });
 
   const updateFilter = useCallback((updates: Partial<IFilterState>) => {

--- a/packages/kit/src/views/ReferFriends/pages/PerpsReward/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/PerpsReward/index.tsx
@@ -89,7 +89,14 @@ function PerpsRewardPageWrapper() {
     setCustomDateRange,
     clearCustomDateRange,
     datePickerValue,
-  } = useRewardFilter();
+  } = useRewardFilter({
+    startTime: new Date('2024-01-01T00:00:00.000').getTime(),
+    endTime: (() => {
+      const d = new Date();
+      d.setHours(23, 59, 59, 999);
+      return d.getTime();
+    })(),
+  });
 
   // Intermediate state for date range selection (before both dates are selected)
   const [intermediateDateRange, setIntermediateDateRange] =


### PR DESCRIPTION
## Summary
- The PerpsReward date picker was empty on initial load, now defaults to 2024-01-01 ~ today
- Added optional `initialDateRange` parameter to `useRewardFilter` hook for setting initial date range
- Only affects PerpsReward page — EarnReward and HardwareSalesReward are unchanged

## Test plan
- [ ] Navigate to Perps Reward page, verify date picker defaults to 2024-01-01 ~ today
- [ ] Verify API request uses startTime/endTime params instead of timeRange=all
- [ ] Manually select a different date range, verify it works correctly
- [ ] Clear dates and re-select, verify normal behavior
- [ ] Verify EarnReward and HardwareSalesReward pages are unaffected