### PR TITLE
fix(swap): filter empty data in swapHistoryPendingList usage sites

### DIFF
--- a/packages/components/src/content/NumberSizeableText/index.tsx
+++ b/packages/components/src/content/NumberSizeableText/index.tsx
@@ -129,7 +129,11 @@ export function NumberSizeableText({
         </SizableText>
       );
     }
-    return <SizableText {...props} {...layoutProps}>****</SizableText>;
+    return (
+      <SizableText {...props} {...layoutProps}>
+        ****
+      </SizableText>
+    );
   }
 
   return typeof result === 'string' ? (

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -1458,9 +1458,7 @@ export default class ServiceSwap extends ServiceBase {
       await inAppNotificationAtom.set((pre) => {
         const newPendingList = filterSwapHistoryPendingList(
           pre.swapHistoryPendingList,
-        ).map((item) =>
-          item.txInfo.txId === oldTxId ? newHistoryItem : item,
-        );
+        ).map((item) => (item.txInfo.txId === oldTxId ? newHistoryItem : item));
         return {
           ...pre,
           swapHistoryPendingList: newPendingList,
@@ -1598,9 +1596,9 @@ export default class ServiceSwap extends ServiceBase {
       : (txInfo.txId ?? '');
     await inAppNotificationAtom.set((pre) => ({
       ...pre,
-      swapHistoryPendingList: pre.swapHistoryPendingList.filter(
-        (item) => !!item && item.txInfo.txId !== deleteHistoryId,
-      ),
+      swapHistoryPendingList: filterSwapHistoryPendingList(
+        pre.swapHistoryPendingList,
+      ).filter((item) => item.txInfo.txId !== deleteHistoryId),
     }));
     await this.cleanHistoryStateIntervals(deleteHistoryId);
   }

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -1420,7 +1420,12 @@ export default class ServiceSwap extends ServiceBase {
           swapHistoryPendingList: [...filteredList, item],
         };
       }
-      return { ...pre, swapHistoryPendingList: filteredList };
+      // Item already exists — only update state if dirty entries were removed,
+      // otherwise return the original reference to avoid unnecessary re-renders.
+      if (filteredList.length !== pre.swapHistoryPendingList.length) {
+        return { ...pre, swapHistoryPendingList: filteredList };
+      }
+      return pre;
     });
   }
 

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -1404,8 +1404,9 @@ export default class ServiceSwap extends ServiceBase {
   async addSwapHistoryItem(item: ISwapTxHistory) {
     await this.backgroundApi.simpleDb.swapHistory.addSwapHistoryItem(item);
     await inAppNotificationAtom.set((pre) => {
+      const filteredList = pre.swapHistoryPendingList.filter((i) => !!i);
       if (
-        !pre.swapHistoryPendingList.filter((i) => !!i).find((i) =>
+        !filteredList.find((i) =>
           item.txInfo.useOrderId
             ? i.txInfo.orderId === item.txInfo.orderId
             : i.txInfo.txId === item.txInfo.txId,
@@ -1413,10 +1414,10 @@ export default class ServiceSwap extends ServiceBase {
       ) {
         return {
           ...pre,
-          swapHistoryPendingList: [...pre.swapHistoryPendingList, item],
+          swapHistoryPendingList: [...filteredList, item],
         };
       }
-      return pre;
+      return { ...pre, swapHistoryPendingList: filteredList };
     });
   }
 
@@ -1430,30 +1431,32 @@ export default class ServiceSwap extends ServiceBase {
     newTxId: string;
     status: ESwapTxHistoryStatus;
   }) {
-    const { swapHistoryPendingList: rawSwapHistoryPendingList } =
-      await inAppNotificationAtom.get();
-    const swapHistoryPendingList = rawSwapHistoryPendingList.filter(
-      (i) => !!i,
-    );
-    const oldHistoryItemIndex = swapHistoryPendingList.findIndex(
+    const { swapHistoryPendingList } = await inAppNotificationAtom.get();
+    const filteredList = swapHistoryPendingList.filter((i) => !!i);
+    const oldHistoryItem = filteredList.find(
       (item) => item.txInfo.txId === oldTxId,
     );
-    if (oldHistoryItemIndex !== -1) {
-      const newHistoryItem = swapHistoryPendingList[oldHistoryItemIndex];
+    if (oldHistoryItem) {
       const updated = Date.now();
-      newHistoryItem.date = { ...newHistoryItem.date, updated };
-      newHistoryItem.txInfo.txId = newTxId;
-      newHistoryItem.status = status;
+      const newHistoryItem = {
+        ...oldHistoryItem,
+        date: { ...oldHistoryItem.date, updated },
+        txInfo: { ...oldHistoryItem.txInfo, txId: newTxId },
+        status,
+      };
       await this.backgroundApi.simpleDb.swapHistory.updateSwapHistoryItem(
         newHistoryItem,
         oldTxId,
       );
       await inAppNotificationAtom.set((pre) => {
-        const newPendingList = [...pre.swapHistoryPendingList];
-        newPendingList[oldHistoryItemIndex] = newHistoryItem;
+        const newPendingList = pre.swapHistoryPendingList
+          .filter((i) => !!i)
+          .map((item) =>
+            item.txInfo.txId === oldTxId ? newHistoryItem : item,
+          );
         return {
           ...pre,
-          swapHistoryPendingList: [...newPendingList],
+          swapHistoryPendingList: newPendingList,
         };
       });
       return;
@@ -1471,20 +1474,16 @@ export default class ServiceSwap extends ServiceBase {
 
   @backgroundMethod()
   async updateSwapHistoryItem(item: ISwapTxHistory) {
-    const { swapHistoryPendingList: rawSwapHistoryPendingList } =
-      await inAppNotificationAtom.get();
-    const swapHistoryPendingList = rawSwapHistoryPendingList.filter(
-      (i) => !!i,
-    );
-    const index = swapHistoryPendingList.findIndex((i) =>
+    const { swapHistoryPendingList } = await inAppNotificationAtom.get();
+    const filteredList = swapHistoryPendingList.filter((i) => !!i);
+    const matchFn = (i: ISwapTxHistory) =>
       item.txInfo.useOrderId
         ? i.txInfo.orderId === item.txInfo.orderId
-        : i.txInfo.txId === item.txInfo.txId,
-    );
-    if (index !== -1) {
+        : i.txInfo.txId === item.txInfo.txId;
+    const oldItem = filteredList.find(matchFn);
+    if (oldItem) {
       const updated = Date.now();
       item.date = { ...item.date, updated };
-      const oldItem = swapHistoryPendingList[index];
       if (
         oldItem.status === ESwapTxHistoryStatus.CANCELING &&
         item.status === ESwapTxHistoryStatus.SUCCESS
@@ -1507,11 +1506,12 @@ export default class ServiceSwap extends ServiceBase {
       }
       await this.backgroundApi.simpleDb.swapHistory.updateSwapHistoryItem(item);
       await inAppNotificationAtom.set((pre) => {
-        const newPendingList = [...pre.swapHistoryPendingList];
-        newPendingList[index] = item;
+        const newPendingList = pre.swapHistoryPendingList
+          .filter((i) => !!i)
+          .map((i) => (matchFn(i) ? item : i));
         return {
           ...pre,
-          swapHistoryPendingList: [...newPendingList],
+          swapHistoryPendingList: newPendingList,
         };
       });
       if (item.status !== ESwapTxHistoryStatus.PENDING) {
@@ -1569,7 +1569,7 @@ export default class ServiceSwap extends ServiceBase {
       ...pre,
       swapHistoryPendingList: statuses
         ? pre.swapHistoryPendingList.filter(
-            (item) => !statuses?.includes(item.status),
+            (item) => !!item && !statuses?.includes(item.status),
           )
         : [],
     }));
@@ -1591,7 +1591,7 @@ export default class ServiceSwap extends ServiceBase {
     await inAppNotificationAtom.set((pre) => ({
       ...pre,
       swapHistoryPendingList: pre.swapHistoryPendingList.filter(
-        (item) => item.txInfo.txId !== deleteHistoryId,
+        (item) => !!item && item.txInfo.txId !== deleteHistoryId,
       ),
     }));
     await this.cleanHistoryStateIntervals(deleteHistoryId);

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -1598,7 +1598,12 @@ export default class ServiceSwap extends ServiceBase {
       ...pre,
       swapHistoryPendingList: filterSwapHistoryPendingList(
         pre.swapHistoryPendingList,
-      ).filter((item) => item.txInfo.txId !== deleteHistoryId),
+      ).filter(
+          (item) =>
+            (item.txInfo.useOrderId
+              ? item.txInfo.orderId
+              : item.txInfo.txId) !== deleteHistoryId,
+        ),
     }));
     await this.cleanHistoryStateIntervals(deleteHistoryId);
   }

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -1389,7 +1389,7 @@ export default class ServiceSwap extends ServiceBase {
     );
     await inAppNotificationAtom.set((pre) => ({
       ...pre,
-      swapHistoryPendingList: [...pendingHistories],
+      swapHistoryPendingList: pendingHistories.filter((i) => !!i),
     }));
   }
 
@@ -1405,7 +1405,7 @@ export default class ServiceSwap extends ServiceBase {
     await this.backgroundApi.simpleDb.swapHistory.addSwapHistoryItem(item);
     await inAppNotificationAtom.set((pre) => {
       if (
-        !pre.swapHistoryPendingList.find((i) =>
+        !pre.swapHistoryPendingList.filter((i) => !!i).find((i) =>
           item.txInfo.useOrderId
             ? i.txInfo.orderId === item.txInfo.orderId
             : i.txInfo.txId === item.txInfo.txId,
@@ -1430,7 +1430,11 @@ export default class ServiceSwap extends ServiceBase {
     newTxId: string;
     status: ESwapTxHistoryStatus;
   }) {
-    const { swapHistoryPendingList } = await inAppNotificationAtom.get();
+    const { swapHistoryPendingList: rawSwapHistoryPendingList } =
+      await inAppNotificationAtom.get();
+    const swapHistoryPendingList = rawSwapHistoryPendingList.filter(
+      (i) => !!i,
+    );
     const oldHistoryItemIndex = swapHistoryPendingList.findIndex(
       (item) => item.txInfo.txId === oldTxId,
     );
@@ -1467,7 +1471,11 @@ export default class ServiceSwap extends ServiceBase {
 
   @backgroundMethod()
   async updateSwapHistoryItem(item: ISwapTxHistory) {
-    const { swapHistoryPendingList } = await inAppNotificationAtom.get();
+    const { swapHistoryPendingList: rawSwapHistoryPendingList } =
+      await inAppNotificationAtom.get();
+    const swapHistoryPendingList = rawSwapHistoryPendingList.filter(
+      (i) => !!i,
+    );
     const index = swapHistoryPendingList.findIndex((i) =>
       item.txInfo.useOrderId
         ? i.txInfo.orderId === item.txInfo.orderId
@@ -1552,6 +1560,7 @@ export default class ServiceSwap extends ServiceBase {
     );
     const inAppNotification = await inAppNotificationAtom.get();
     const deleteHistoryIds = inAppNotification.swapHistoryPendingList
+      .filter((item) => !!item)
       .filter((item) => statuses?.includes(item.status))
       .map((item) =>
         item.txInfo.useOrderId ? item.txInfo.orderId : item.txInfo.txId,
@@ -1726,11 +1735,13 @@ export default class ServiceSwap extends ServiceBase {
   @backgroundMethod()
   async swapHistoryStatusFetchLoop() {
     const { swapHistoryPendingList } = await inAppNotificationAtom.get();
-    const statusPendingList = swapHistoryPendingList.filter(
-      (item) =>
-        item.status === ESwapTxHistoryStatus.PENDING ||
-        item.status === ESwapTxHistoryStatus.CANCELING,
-    );
+    const statusPendingList = swapHistoryPendingList
+      .filter((i) => !!i)
+      .filter(
+        (item) =>
+          item.status === ESwapTxHistoryStatus.PENDING ||
+          item.status === ESwapTxHistoryStatus.CANCELING,
+      );
     const newHistoryStatePendingList = statusPendingList.filter(
       (item) =>
         !this.historyCurrentStateIntervalIds.includes(

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -99,6 +99,7 @@ import {
 } from '@onekeyhq/shared/types/swap/types';
 
 import {
+  filterSwapHistoryPendingList,
   inAppNotificationAtom,
   perpsDepositOrderAtom,
 } from '../states/jotai/atoms';
@@ -1389,7 +1390,7 @@ export default class ServiceSwap extends ServiceBase {
     );
     await inAppNotificationAtom.set((pre) => ({
       ...pre,
-      swapHistoryPendingList: pendingHistories.filter((i) => !!i),
+      swapHistoryPendingList: filterSwapHistoryPendingList(pendingHistories),
     }));
   }
 
@@ -1404,7 +1405,9 @@ export default class ServiceSwap extends ServiceBase {
   async addSwapHistoryItem(item: ISwapTxHistory) {
     await this.backgroundApi.simpleDb.swapHistory.addSwapHistoryItem(item);
     await inAppNotificationAtom.set((pre) => {
-      const filteredList = pre.swapHistoryPendingList.filter((i) => !!i);
+      const filteredList = filterSwapHistoryPendingList(
+        pre.swapHistoryPendingList,
+      );
       if (
         !filteredList.find((i) =>
           item.txInfo.useOrderId
@@ -1432,10 +1435,9 @@ export default class ServiceSwap extends ServiceBase {
     status: ESwapTxHistoryStatus;
   }) {
     const { swapHistoryPendingList } = await inAppNotificationAtom.get();
-    const filteredList = swapHistoryPendingList.filter((i) => !!i);
-    const oldHistoryItem = filteredList.find(
-      (item) => item.txInfo.txId === oldTxId,
-    );
+    const oldHistoryItem = filterSwapHistoryPendingList(
+      swapHistoryPendingList,
+    ).find((item) => item.txInfo.txId === oldTxId);
     if (oldHistoryItem) {
       const updated = Date.now();
       const newHistoryItem = {
@@ -1449,11 +1451,11 @@ export default class ServiceSwap extends ServiceBase {
         oldTxId,
       );
       await inAppNotificationAtom.set((pre) => {
-        const newPendingList = pre.swapHistoryPendingList
-          .filter((i) => !!i)
-          .map((item) =>
-            item.txInfo.txId === oldTxId ? newHistoryItem : item,
-          );
+        const newPendingList = filterSwapHistoryPendingList(
+          pre.swapHistoryPendingList,
+        ).map((item) =>
+          item.txInfo.txId === oldTxId ? newHistoryItem : item,
+        );
         return {
           ...pre,
           swapHistoryPendingList: newPendingList,
@@ -1475,7 +1477,7 @@ export default class ServiceSwap extends ServiceBase {
   @backgroundMethod()
   async updateSwapHistoryItem(item: ISwapTxHistory) {
     const { swapHistoryPendingList } = await inAppNotificationAtom.get();
-    const filteredList = swapHistoryPendingList.filter((i) => !!i);
+    const filteredList = filterSwapHistoryPendingList(swapHistoryPendingList);
     const matchFn = (i: ISwapTxHistory) =>
       item.txInfo.useOrderId
         ? i.txInfo.orderId === item.txInfo.orderId
@@ -1506,9 +1508,9 @@ export default class ServiceSwap extends ServiceBase {
       }
       await this.backgroundApi.simpleDb.swapHistory.updateSwapHistoryItem(item);
       await inAppNotificationAtom.set((pre) => {
-        const newPendingList = pre.swapHistoryPendingList
-          .filter((i) => !!i)
-          .map((i) => (matchFn(i) ? item : i));
+        const newPendingList = filterSwapHistoryPendingList(
+          pre.swapHistoryPendingList,
+        ).map((i) => (matchFn(i) ? item : i));
         return {
           ...pre,
           swapHistoryPendingList: newPendingList,
@@ -1559,8 +1561,9 @@ export default class ServiceSwap extends ServiceBase {
       statuses,
     );
     const inAppNotification = await inAppNotificationAtom.get();
-    const deleteHistoryIds = inAppNotification.swapHistoryPendingList
-      .filter((item) => !!item)
+    const deleteHistoryIds = filterSwapHistoryPendingList(
+      inAppNotification.swapHistoryPendingList,
+    )
       .filter((item) => statuses?.includes(item.status))
       .map((item) =>
         item.txInfo.useOrderId ? item.txInfo.orderId : item.txInfo.txId,
@@ -1568,8 +1571,8 @@ export default class ServiceSwap extends ServiceBase {
     await inAppNotificationAtom.set((pre) => ({
       ...pre,
       swapHistoryPendingList: statuses
-        ? pre.swapHistoryPendingList.filter(
-            (item) => !!item && !statuses?.includes(item.status),
+        ? filterSwapHistoryPendingList(pre.swapHistoryPendingList).filter(
+            (item) => !statuses?.includes(item.status),
           )
         : [],
     }));
@@ -1735,13 +1738,13 @@ export default class ServiceSwap extends ServiceBase {
   @backgroundMethod()
   async swapHistoryStatusFetchLoop() {
     const { swapHistoryPendingList } = await inAppNotificationAtom.get();
-    const statusPendingList = swapHistoryPendingList
-      .filter((i) => !!i)
-      .filter(
-        (item) =>
-          item.status === ESwapTxHistoryStatus.PENDING ||
-          item.status === ESwapTxHistoryStatus.CANCELING,
-      );
+    const statusPendingList = filterSwapHistoryPendingList(
+      swapHistoryPendingList,
+    ).filter(
+      (item) =>
+        item.status === ESwapTxHistoryStatus.PENDING ||
+        item.status === ESwapTxHistoryStatus.CANCELING,
+    );
     const newHistoryStatePendingList = statusPendingList.filter(
       (item) =>
         !this.historyCurrentStateIntervalIds.includes(

--- a/packages/kit-bg/src/states/jotai/atoms/InAppNotification.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/InAppNotification.ts
@@ -22,6 +22,12 @@ export type IInAppNotificationAtom = {
   bridgeProviderManager: ISwapProviderManager[];
   swapApprovingLoading: boolean;
 };
+export function filterSwapHistoryPendingList(
+  list: ISwapTxHistory[],
+): ISwapTxHistory[] {
+  return list.filter((i) => !!i);
+}
+
 export const { target: inAppNotificationAtom, use: useInAppNotificationAtom } =
   globalAtom<IInAppNotificationAtom>({
     persist: false,

--- a/packages/kit-bg/src/states/jotai/atoms/InAppNotification.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/InAppNotification.ts
@@ -10,7 +10,8 @@ import { EAtomNames } from '../atomNames';
 import { globalAtom } from '../utils';
 
 export type IInAppNotificationAtom = {
-  swapHistoryPendingList: ISwapTxHistory[];
+  // May contain null/undefined entries due to data corruption or deserialization issues
+  swapHistoryPendingList: (ISwapTxHistory | null | undefined)[];
   swapLimitOrders: IFetchLimitOrderRes[];
   swapLimitOrdersLoading: boolean;
   swapApprovingTransaction: ISwapApproveTransaction | undefined;
@@ -22,10 +23,12 @@ export type IInAppNotificationAtom = {
   bridgeProviderManager: ISwapProviderManager[];
   swapApprovingLoading: boolean;
 };
+// Filters out null/undefined entries that may exist in swapHistoryPendingList.
+// Always use this before accessing item properties to prevent runtime crashes.
 export function filterSwapHistoryPendingList(
-  list: ISwapTxHistory[],
+  list: (ISwapTxHistory | null | undefined)[],
 ): ISwapTxHistory[] {
-  return list.filter((i) => !!i);
+  return list.filter((i): i is ISwapTxHistory => !!i);
 }
 
 export const { target: inAppNotificationAtom, use: useInAppNotificationAtom } =

--- a/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
+++ b/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
@@ -199,12 +199,14 @@ const PreSwapDialogContent = ({
     if (lastStep?.txHash || lastStep?.orderId) {
       let findStepItem: ISwapTxHistory | IFetchLimitOrderRes | undefined;
       if (preSwapData?.swapType !== ESwapTabSwitchType.LIMIT) {
-        findStepItem = inAppNotificationAtom.swapHistoryPendingList.find(
-          (item) =>
-            item.txInfo.useOrderId
-              ? item.txInfo.orderId === lastStep?.orderId
-              : item.txInfo.txId === lastStep?.txHash,
-        );
+        findStepItem = inAppNotificationAtom.swapHistoryPendingList
+          .filter((i) => !!i)
+          .find(
+            (item) =>
+              item.txInfo.useOrderId
+                ? item.txInfo.orderId === lastStep?.orderId
+                : item.txInfo.txId === lastStep?.txHash,
+          );
       } else {
         findStepItem = inAppNotificationAtom.swapLimitOrders.find(
           (item) => item.orderId === lastStep?.orderId,

--- a/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
+++ b/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
@@ -19,7 +19,10 @@ import {
   useSwapStepNetFeeLevelAtom,
   useSwapStepsAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
-import { useInAppNotificationAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  filterSwapHistoryPendingList,
+  useInAppNotificationAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import type {
@@ -199,14 +202,14 @@ const PreSwapDialogContent = ({
     if (lastStep?.txHash || lastStep?.orderId) {
       let findStepItem: ISwapTxHistory | IFetchLimitOrderRes | undefined;
       if (preSwapData?.swapType !== ESwapTabSwitchType.LIMIT) {
-        findStepItem = inAppNotificationAtom.swapHistoryPendingList
-          .filter((i) => !!i)
-          .find(
-            (item) =>
-              item.txInfo.useOrderId
-                ? item.txInfo.orderId === lastStep?.orderId
-                : item.txInfo.txId === lastStep?.txHash,
-          );
+        findStepItem = filterSwapHistoryPendingList(
+          inAppNotificationAtom.swapHistoryPendingList,
+        ).find(
+          (item) =>
+            item.txInfo.useOrderId
+              ? item.txInfo.orderId === lastStep?.orderId
+              : item.txInfo.txId === lastStep?.txHash,
+        );
       } else {
         findStepItem = inAppNotificationAtom.swapLimitOrders.find(
           (item) => item.orderId === lastStep?.orderId,

--- a/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
+++ b/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
@@ -204,11 +204,10 @@ const PreSwapDialogContent = ({
       if (preSwapData?.swapType !== ESwapTabSwitchType.LIMIT) {
         findStepItem = filterSwapHistoryPendingList(
           inAppNotificationAtom.swapHistoryPendingList,
-        ).find(
-          (item) =>
-            item.txInfo.useOrderId
-              ? item.txInfo.orderId === lastStep?.orderId
-              : item.txInfo.txId === lastStep?.txHash,
+        ).find((item) =>
+          item.txInfo.useOrderId
+            ? item.txInfo.orderId === lastStep?.orderId
+            : item.txInfo.txId === lastStep?.txHash,
         );
       } else {
         findStepItem = inAppNotificationAtom.swapLimitOrders.find(

--- a/packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx
@@ -437,7 +437,7 @@ const SwapHeaderRightActionContainer = ({
   const [swapProTradeType] = useSwapProTradeTypeAtom();
   const swapPendingStatusList = useMemo(
     () =>
-      swapHistoryPendingList.filter(
+      swapHistoryPendingList.filter(i => !!i).filter(
         (i) =>
           i.status === ESwapTxHistoryStatus.PENDING ||
           i.status === ESwapTxHistoryStatus.CANCELING,

--- a/packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx
@@ -32,6 +32,7 @@ import {
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
 import {
   EJotaiContextStoreNames,
+  filterSwapHistoryPendingList,
   useInAppNotificationAtom,
   useSettingsAtom,
   useSettingsPersistAtom,
@@ -437,7 +438,7 @@ const SwapHeaderRightActionContainer = ({
   const [swapProTradeType] = useSwapProTradeTypeAtom();
   const swapPendingStatusList = useMemo(
     () =>
-      swapHistoryPendingList.filter(i => !!i).filter(
+      filterSwapHistoryPendingList(swapHistoryPendingList).filter(
         (i) =>
           i.status === ESwapTxHistoryStatus.PENDING ||
           i.status === ESwapTxHistoryStatus.CANCELING,


### PR DESCRIPTION
## Summary
- Add `.filter((i) => !!i)` to all `swapHistoryPendingList` usage sites to prevent crashes from null/undefined entries
- Filter at source in `syncSwapHistoryPendingList` when setting atom data
- Filter at consumer sites in `ServiceSwap.ts` (`addSwapHistoryItem`, `speedUpOrCancelSwapHistoryItem`, `updateSwapHistoryItem`, `cleanSwapHistoryItems`, `swapHistoryStatusFetchLoop`)
- Filter in `PreSwapDialogContent.tsx` and `SwapHeaderRightActionContainer.tsx` before accessing item properties

## Test plan
- [ ] Verify swap history pending list displays correctly with no crashes
- [ ] Test swap operations (add, update, speed up, cancel, clean) work as expected
- [ ] Verify pending status badge count is accurate in swap header
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
