### PR TITLE
fix(hardware): refresh device label shown in hardware dialogs(OK- 50132)

### DIFF
--- a/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts
+++ b/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts
@@ -1103,6 +1103,11 @@ class ServiceHardware extends ServiceBase {
           dbDeviceId,
           label: p.label,
         });
+        // After device label is updated, notify UI/hardware interaction layer to refresh cached device info,
+        // otherwise the hardware interaction dialog may keep showing the old name until app restart.
+        appEventBus.emit(EAppEventBusNames.HardwareFeaturesUpdate, {
+          deviceId: dbDeviceId,
+        });
         // update db wallet name
         appEventBus.emit(EAppEventBusNames.SyncDeviceLabelToWalletName, {
           walletId: p.walletId,

--- a/packages/kit-bg/src/services/ServiceHardwareUI/ServiceHardwareUI.ts
+++ b/packages/kit-bg/src/services/ServiceHardwareUI/ServiceHardwareUI.ts
@@ -70,10 +70,6 @@ class ServiceHardwareUI extends ServiceBase {
     super({ backgroundApi });
     // This service caches `connectId -> IDBDevice` for hardware interaction dialogs.
     // When device features (including label) change, invalidate cache to avoid showing stale names.
-    appEventBus.off(
-      EAppEventBusNames.HardwareFeaturesUpdate,
-      this.onHardwareFeaturesUpdate,
-    );
     appEventBus.on(
       EAppEventBusNames.HardwareFeaturesUpdate,
       this.onHardwareFeaturesUpdate,

--- a/packages/kit-bg/src/services/ServiceHardwareUI/ServiceHardwareUI.ts
+++ b/packages/kit-bg/src/services/ServiceHardwareUI/ServiceHardwareUI.ts
@@ -24,6 +24,7 @@ import type {
   IOneKeyDeviceFeatures,
 } from '@onekeyhq/shared/types/device';
 
+import localDb from '../../dbs/local/localDb';
 import {
   EHardwareUiStateAction,
   hardwareUiStateAtom,
@@ -67,9 +68,45 @@ class ServiceHardwareUI extends ServiceBase {
 
   constructor({ backgroundApi }: { backgroundApi: any }) {
     super({ backgroundApi });
+    // This service caches `connectId -> IDBDevice` for hardware interaction dialogs.
+    // When device features (including label) change, invalidate cache to avoid showing stale names.
+    appEventBus.off(
+      EAppEventBusNames.HardwareFeaturesUpdate,
+      this.onHardwareFeaturesUpdate,
+    );
+    appEventBus.on(
+      EAppEventBusNames.HardwareFeaturesUpdate,
+      this.onHardwareFeaturesUpdate,
+    );
   }
 
   hardwareProcessingManager = new HardwareProcessingManager();
+
+  private onHardwareFeaturesUpdate = async ({
+    deviceId,
+  }: {
+    deviceId: string;
+  }) => {
+    try {
+      // Delete from cache first to avoid a race where a new interaction immediately reads stale cache.
+      for (const [connectId, cached] of this.deviceCacheByConnectId.entries()) {
+        if (cached?.id === deviceId) {
+          this.deviceCacheByConnectId.delete(connectId);
+        }
+      }
+
+      const device = await localDb.getDevice(deviceId);
+      if (device?.connectId) {
+        this.deviceCacheByConnectId.delete(device.connectId);
+      } else {
+        // Conservative fallback: if connectId cannot be resolved, clear all cache to avoid stale UI.
+        this.deviceCacheByConnectId.clear();
+      }
+    } catch {
+      // Best-effort: this event is only for UI consistency. Clear cache on any error.
+      this.deviceCacheByConnectId.clear();
+    }
+  };
 
   @backgroundMethod()
   async sendUiResponse(response: UiResponseEvent) {


### PR DESCRIPTION
Problem:
- After renaming a hardware device label, hardware interaction dialogs may keep showing the old label until app restart.

Root cause:
- ServiceHardwareUI caches connectId -> IDBDevice (including featuresInfo.label) and the cache was not invalidated on label change.

Fix:
- Emit HardwareFeaturesUpdate after setDeviceLabel updates local DB.
- ServiceHardwareUI listens to HardwareFeaturesUpdate and invalidates the cached device entry (off+on to avoid duplicate listeners).

Test:
- yarn _tsc
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
