### PR TITLE
fix: remove hermesProfilingIntegration to prevent stack overflow crash on iOS

### DIFF
--- a/packages/shared/src/modules3rdParty/sentry/index.native.ts
+++ b/packages/shared/src/modules3rdParty/sentry/index.native.ts
@@ -1,7 +1,6 @@
 import type { ComponentType } from 'react';
 
 import {
-  hermesProfilingIntegration,
   init,
   reactNativeTracingIntegration,
   nativeCrash as sentryNativeCrash,
@@ -37,9 +36,6 @@ export const initSentry = () => {
     integrations: [
       navigationIntegration,
       reactNativeTracingIntegration(),
-      hermesProfilingIntegration({
-        platformProfilers: true,
-      }),
     ],
     enableAutoPerformanceTracing: true,
   });


### PR DESCRIPTION
## Summary

- Remove `hermesProfilingIntegration` from native Sentry initialization to fix a fatal `EXC_BAD_ACCESS` (SIGSEGV) stack overflow crash on iOS
- The crash occurs in Hermes engine's recursive `ChromeStackFrameNode::dfsWalkHelper` when `[RNSentry stopProfiling]` serializes deep profiling call trees (e.g., on app backgrounding)
- Observed on iPhone XS Max / iOS 14.6 with low free memory (135MB), crashing within 9 seconds of app launch

## Test plan

- [ ] Verify Sentry error/crash reporting still works on iOS (only profiling telemetry is removed)
- [ ] Verify no regressions on Android native Sentry integration
- [ ] Confirm app no longer crashes on background transition on memory-constrained iOS devices
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
