### PR TITLE
fix: perps account improvements and pull-to-refresh optimization OK-49970 OK-50101

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -13,7 +13,10 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
-import { HYPERLIQUID_NETWORK_INACTIVE_TIMEOUT_MS } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+import {
+  HYPERLIQUID_NETWORK_INACTIVE_TIMEOUT_MS,
+  HYPERLIQUID_REFRESH_DATA_FLOW_THRESHOLD_MS,
+} from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import type {
   IHex,
   IHyperliquidEventTarget,
@@ -271,17 +274,33 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   lastRefreshAllPerpsDataAt: number | null = null;
 
   @backgroundMethod()
-  async refreshAllPerpsData(): Promise<void> {
+  async refreshAllPerpsData(): Promise<boolean> {
     const client = await this.getWebSocketClient();
-    if (client?.transport?.socket?.readyState === WebSocket.CLOSED) {
+    const isSocketOpen =
+      client?.transport?.socket?.readyState === WebSocket.OPEN;
+    const isDataFlowing =
+      this._lastMessageAt != null &&
+      Date.now() - this._lastMessageAt <
+        HYPERLIQUID_REFRESH_DATA_FLOW_THRESHOLD_MS;
+
+    if (isSocketOpen && isDataFlowing) {
+      // connection is healthy, no-op — just show pull-to-refresh animation
+      await timerUtils.wait(3000);
+      return false;
+    }
+
+    if (!isSocketOpen) {
+      // socket is closed or not available, full reconnect needed
       await this.disconnect();
       await this.getWebSocketClient();
     } else {
+      // socket is open but no recent data (possible half-open), rebuild subscriptions
       await this._cleanupAllSubscriptions();
       await timerUtils.wait(50);
       console.log('updateSubscriptions__by__refreshAllPerpsData');
       await this.updateSubscriptions();
     }
+
     this.backgroundApi.serviceHyperliquid._getUserFillsByTimeMemo.clear();
     await perpsTradesHistoryRefreshHookAtom.set({
       refreshHook: Date.now(),
@@ -291,6 +310,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     });
     this.lastRefreshAllPerpsDataAt = Date.now();
     await timerUtils.wait(3000);
+    return true;
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -149,7 +149,7 @@ export const {
       details?.activatedOk &&
       details?.internalRebateBoundOk;
     const isReadOnlyAccount = account?.accountId
-      ? accountUtils.isOthersAccount({ accountId: account.accountId })
+      ? accountUtils.isWatchingAccount({ accountId: account.accountId })
       : false;
     const accountNotSupport =
       (!account?.accountAddress && !account?.indexedAccountId) ||

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -1375,8 +1375,11 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       });
       return;
     }
-    this.lastRefreshAllPerpsDataTime = now;
-    await backgroundApiProxy.serviceHyperliquidSubscription.refreshAllPerpsData();
+    const didRefresh =
+      await backgroundApiProxy.serviceHyperliquidSubscription.refreshAllPerpsData();
+    if (didRefresh) {
+      this.lastRefreshAllPerpsDataTime = now;
+    }
   });
 }
 

--- a/packages/shared/types/hyperliquid/perp.constants.ts
+++ b/packages/shared/types/hyperliquid/perp.constants.ts
@@ -24,6 +24,7 @@ export const USDC_TOKEN_INFO = {
 } as const;
 
 export const HYPERLIQUID_NETWORK_INACTIVE_TIMEOUT_MS = 60_000;
+export const HYPERLIQUID_REFRESH_DATA_FLOW_THRESHOLD_MS = 10_000;
 export const MIN_WITHDRAW_AMOUNT = 2; // Minimum withdraw amount is 2 USDC
 
 export const TERMS_OF_SERVICE_URL =


### PR DESCRIPTION
## Summary
- Allow external and imported wallets to use perps trading (only watching-only accounts remain read-only)
- Skip WebSocket reconnect on pull-to-refresh when connection is healthy (socket open + data flowing within 10s), preventing UI disconnect flicker
- Rate limit cooldown (15s) is only consumed when actual refresh work is performed

## Test plan
- [ ] Mobile: Perps page with healthy WS connection → pull-to-refresh → no disconnect flicker, candle chart stays intact
- [ ] Mobile: Disconnect network then reconnect → pull-to-refresh → should reconnect normally (socket CLOSED branch)
- [ ] Mobile: Long idle (>10s no WS messages) → pull-to-refresh → should rebuild subscriptions
- [ ] Desktop: PerpRefreshButton → same behavior as above
- [ ] Verify external/imported wallets can access perps trading
- [ ] Verify watching-only wallets remain read-only for perps

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
