### PR TITLE
fix(market): use USD symbol for perps prices in watchlist

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsDesktop.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsDesktop.tsx
@@ -140,12 +140,13 @@ export const useColumnsDesktop = (
       title: intl.formatMessage({ id: ETranslations.global_price }),
       dataIndex: 'price',
       columnProps: { flex: 1 },
-      render: (text: string) => {
+      render: (text: string, record: IMarketToken) => {
+        const currencySymbol = record.perpsCoin ? '$' : currency;
         return (
           <NumberSizeableText
             size="$bodyMd"
             formatter={BigNumber(text).gt(1_000_000) ? 'marketCap' : 'price'}
-            formatterOptions={{ currency, capAtMaxT: true }}
+            formatterOptions={{ currency: currencySymbol, capAtMaxT: true }}
           >
             {text}
           </NumberSizeableText>
@@ -213,11 +214,11 @@ export const useColumnsDesktop = (
       title: intl.formatMessage({ id: ETranslations.dexmarket_turnover }),
       dataIndex: 'turnover',
       columnProps: { flex: 1.1 },
-      render: (text: number) => (
+      render: (text: number, record: IMarketToken) => (
         <NumberSizeableText
           size="$bodyMd"
           formatter="marketCap"
-          formatterOptions={{ currency }}
+          formatterOptions={{ currency: record.perpsCoin ? '$' : currency }}
         >
           {text === 0 ? '--' : text}
         </NumberSizeableText>

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsMobile.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsMobile.tsx
@@ -66,7 +66,7 @@ export const useColumnsMobile = (): ITableColumn<IMarketToken>[] => {
                   color="$textSubdued"
                   numberOfLines={1}
                   formatter="marketCap"
-                  formatterOptions={{ currency }}
+                  formatterOptions={{ currency: '$' }}
                 >
                   {record.turnover}
                 </NumberSizeableText>
@@ -121,7 +121,9 @@ export const useColumnsMobile = (): ITableColumn<IMarketToken>[] => {
                 numberOfLines={1}
                 size="$bodyLgMedium"
                 formatter="price"
-                formatterOptions={{ currency }}
+                formatterOptions={{
+                  currency: record.perpsCoin ? '$' : currency,
+                }}
               >
                 {record.price}
               </NumberSizeableText>


### PR DESCRIPTION
## Summary
- Perps prices in the market watchlist (自选) were showing the user's local currency symbol (e.g., £) despite the values being in USD
- Fixed price and turnover columns in both desktop (`useColumnsDesktop`) and mobile (`useColumnsMobile`) to always use `$` for perps tokens
- Matches the existing pattern already used in dedicated perps list components (`MarketPerpsTokenList`, `MarketPerpsTokenListItem`)

## Test plan
- [ ] Set app default currency to a non-USD currency (e.g., GBP, EUR)
- [ ] Add a perps token (e.g., BTC perpetual contract) to the watchlist
- [ ] Verify perps price displays with `$` symbol, not the local currency symbol
- [ ] Verify perps turnover displays with `$` symbol
- [ ] Verify spot token prices still display with the user's local currency symbol
- [ ] Test on both desktop/web and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
