### PR TITLE
fix: split desktop shortcuts into global and discovery-scoped hooks(OK-50226)

### DIFF
--- a/packages/kit/src/hooks/useGlobalShortcuts.desktop.ts
+++ b/packages/kit/src/hooks/useGlobalShortcuts.desktop.ts
@@ -1,0 +1,41 @@
+import { useCallback } from 'react';
+
+import { useShortcuts } from '@onekeyhq/components';
+import { EModalRoutes } from '@onekeyhq/shared/src/routes';
+import { EUniversalSearchPages } from '@onekeyhq/shared/src/routes/universalSearch';
+import { EShortcutEvents } from '@onekeyhq/shared/src/shortcuts/shortcuts.enum';
+
+import useAppNavigation from './useAppNavigation';
+import { useShortcutsRouteStatus } from './useListenTabFocusState';
+
+export const useGlobalShortcuts = () => {
+  const navigation = useAppNavigation();
+  const { isAtBrowserTab, shouldReloadAppByCmdR } = useShortcutsRouteStatus();
+
+  const handleShortcuts = useCallback(
+    (data: EShortcutEvents) => {
+      switch (data) {
+        case EShortcutEvents.UniversalSearch:
+          navigation.pushModal(EModalRoutes.UniversalSearchModal, {
+            screen: EUniversalSearchPages.UniversalSearch,
+          });
+          break;
+        case EShortcutEvents.Refresh:
+          if (!isAtBrowserTab.current && shouldReloadAppByCmdR.current) {
+            void globalThis.desktopApiProxy?.system?.reload?.();
+          }
+          break;
+        case EShortcutEvents.CloseTab:
+          if (!isAtBrowserTab.current) {
+            void globalThis.desktopApiProxy?.system?.quitApp?.();
+          }
+          break;
+        default:
+          break;
+      }
+    },
+    [isAtBrowserTab, navigation, shouldReloadAppByCmdR],
+  );
+
+  useShortcuts(undefined, handleShortcuts);
+};

--- a/packages/kit/src/hooks/useGlobalShortcuts.ts
+++ b/packages/kit/src/hooks/useGlobalShortcuts.ts
@@ -1,0 +1,1 @@
+export const useGlobalShortcuts = () => {};

--- a/packages/kit/src/routes/Tab/Navigator.tsx
+++ b/packages/kit/src/routes/Tab/Navigator.tsx
@@ -17,6 +17,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { ETabRoutes } from '@onekeyhq/shared/src/routes';
 
 import { Footer } from '../../components/Footer';
+import { useGlobalShortcuts } from '../../hooks/useGlobalShortcuts';
 import { useRouteIsFocused } from '../../hooks/useRouteIsFocused';
 import { BottomMenu } from '../../provider/Container/PortalBodyContainer/BottomMenu';
 import { WebPageTabBar } from '../../provider/Container/PortalBodyContainer/WebPageTabBar';
@@ -80,6 +81,7 @@ export function TabNavigator() {
   const { gtMd } = useMedia();
   const isTabletDetailView = useSplitSubView();
 
+  useGlobalShortcuts();
   useCheckTabsChangedInDev(config);
 
   return (

--- a/packages/kit/src/views/Discovery/hooks/useShortcuts.desktop.ts
+++ b/packages/kit/src/views/Discovery/hooks/useShortcuts.desktop.ts
@@ -58,46 +58,59 @@ export const useDiscoveryShortcuts = () => {
 
   const handleShortcuts = useCallback(
     (data: EShortcutEvents) => {
-      if (!isAtBrowserTab.current) {
-        return;
-      }
-      const webview = getActiveWebview(activeTabId);
-      try {
-        switch (data) {
-          case EShortcutEvents.CopyAddressOrUrl: {
-            const url = webview?.getURL();
-            if (url) {
-              copyText(url);
-            }
-            break;
+      switch (data) {
+        // webview-specific shortcuts — only when a browser tab is focused
+        case EShortcutEvents.CopyAddressOrUrl:
+        case EShortcutEvents.GoForwardHistory:
+        case EShortcutEvents.GoBackHistory:
+        case EShortcutEvents.Refresh:
+        case EShortcutEvents.CloseTab: {
+          if (!isAtBrowserTab.current) {
+            return;
           }
-          case EShortcutEvents.GoForwardHistory:
-            webview?.goForward();
-            break;
-          case EShortcutEvents.GoBackHistory:
-            webview?.goBack();
-            break;
-          case EShortcutEvents.Refresh:
-            webview?.reload();
-            break;
-          case EShortcutEvents.CloseTab:
-            handleCloseWebTab();
-            break;
-          case EShortcutEvents.ViewHistory:
-            navigation.pushModal(EModalRoutes.DiscoveryModal, {
-              screen: EDiscoveryModalRoutes.HistoryListModal,
-            });
-            break;
-          case EShortcutEvents.ViewBookmark:
-            navigation.pushModal(EModalRoutes.DiscoveryModal, {
-              screen: EDiscoveryModalRoutes.BookmarkListModal,
-            });
-            break;
-          default:
-            break;
+          const webview = getActiveWebview(activeTabId);
+          try {
+            switch (data) {
+              case EShortcutEvents.CopyAddressOrUrl: {
+                const url = webview?.getURL();
+                if (url) {
+                  copyText(url);
+                }
+                break;
+              }
+              case EShortcutEvents.GoForwardHistory:
+                webview?.goForward();
+                break;
+              case EShortcutEvents.GoBackHistory:
+                webview?.goBack();
+                break;
+              case EShortcutEvents.Refresh:
+                webview?.reload();
+                break;
+              case EShortcutEvents.CloseTab:
+                handleCloseWebTab();
+                break;
+              default:
+                break;
+            }
+          } catch {
+            // webview methods may throw if webContents is destroyed
+          }
+          break;
         }
-      } catch {
-        // webview methods may throw if webContents is destroyed
+        // navigation shortcuts — available whenever Discovery is mounted
+        case EShortcutEvents.ViewHistory:
+          navigation.pushModal(EModalRoutes.DiscoveryModal, {
+            screen: EDiscoveryModalRoutes.HistoryListModal,
+          });
+          break;
+        case EShortcutEvents.ViewBookmark:
+          navigation.pushModal(EModalRoutes.DiscoveryModal, {
+            screen: EDiscoveryModalRoutes.BookmarkListModal,
+          });
+          break;
+        default:
+          break;
       }
     },
     [activeTabId, copyText, handleCloseWebTab, isAtBrowserTab, navigation],

--- a/packages/kit/src/views/Discovery/hooks/useShortcuts.desktop.ts
+++ b/packages/kit/src/views/Discovery/hooks/useShortcuts.desktop.ts
@@ -1,17 +1,14 @@
 import { useCallback } from 'react';
 
-import type { IPageNavigationProp } from '@onekeyhq/components';
 import { useClipboard, useShortcuts } from '@onekeyhq/components';
 import type { IElectronWebView } from '@onekeyhq/kit/src/components/WebView/types';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useBrowserTabActions } from '@onekeyhq/kit/src/states/jotai/contexts/discovery';
-import type { IDiscoveryModalParamList } from '@onekeyhq/shared/src/routes';
 import {
   EDiscoveryModalRoutes,
   EModalRoutes,
   ETabRoutes,
 } from '@onekeyhq/shared/src/routes';
-import { EUniversalSearchPages } from '@onekeyhq/shared/src/routes/universalSearch';
 import { EShortcutEvents } from '@onekeyhq/shared/src/shortcuts/shortcuts.enum';
 
 import { useShortcutsRouteStatus } from '../../../hooks/useListenTabFocusState';
@@ -19,12 +16,22 @@ import { webviewRefs } from '../utils/explorerUtils';
 
 import { useActiveTabId, useWebTabs } from './useWebTabs';
 
+function getActiveWebview(
+  tabId: string | null | undefined,
+): IElectronWebView | undefined {
+  if (!tabId) return undefined;
+  try {
+    return webviewRefs[tabId]?.innerRef as IElectronWebView | undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export const useDiscoveryShortcuts = () => {
   const { copyText } = useClipboard();
-  const navigation =
-    useAppNavigation<IPageNavigationProp<IDiscoveryModalParamList>>();
+  const navigation = useAppNavigation();
 
-  const { isAtBrowserTab, shouldReloadAppByCmdR } = useShortcutsRouteStatus();
+  const { isAtBrowserTab } = useShortcutsRouteStatus();
 
   const { activeTabId } = useActiveTabId();
   const { closeWebTab } = useBrowserTabActions().current;
@@ -51,64 +58,30 @@ export const useDiscoveryShortcuts = () => {
 
   const handleShortcuts = useCallback(
     (data: EShortcutEvents) => {
-      // only handle shortcuts when at browser tab
+      if (!isAtBrowserTab.current) {
+        return;
+      }
+      const webview = getActiveWebview(activeTabId);
       switch (data) {
-        case EShortcutEvents.CopyAddressOrUrl:
-          if (isAtBrowserTab.current) {
-            try {
-              const url = (
-                webviewRefs[activeTabId ?? '']?.innerRef as IElectronWebView
-              )?.getURL();
-              if (url) {
-                copyText(url);
-              }
-            } catch {
-              // empty
-            }
+        case EShortcutEvents.CopyAddressOrUrl: {
+          const url = webview?.getURL();
+          if (url) {
+            copyText(url);
           }
           break;
+        }
         case EShortcutEvents.GoForwardHistory:
-          if (isAtBrowserTab.current) {
-            try {
-              (
-                webviewRefs[activeTabId ?? '']?.innerRef as IElectronWebView
-              )?.goForward();
-            } catch {
-              // empty
-            }
-          }
+          webview?.goForward();
           break;
         case EShortcutEvents.GoBackHistory:
-          if (isAtBrowserTab.current) {
-            try {
-              (
-                webviewRefs[activeTabId ?? '']?.innerRef as IElectronWebView
-              )?.goBack();
-            } catch {
-              // empty
-            }
-          }
+          webview?.goBack();
           break;
         case EShortcutEvents.Refresh:
-          if (isAtBrowserTab.current) {
-            try {
-              (
-                webviewRefs[activeTabId ?? '']?.innerRef as IElectronWebView
-              )?.reload();
-            } catch {
-              // empty
-            }
-          } else if (shouldReloadAppByCmdR.current) {
-            void globalThis.desktopApiProxy?.system?.reload?.();
-          }
+          webview?.reload();
           break;
         case EShortcutEvents.CloseTab:
-          if (isAtBrowserTab.current) {
-            handleCloseWebTab();
-          } else {
-            void globalThis.desktopApiProxy?.system?.quitApp?.();
-          }
-          return;
+          handleCloseWebTab();
+          break;
         case EShortcutEvents.ViewHistory:
           navigation.pushModal(EModalRoutes.DiscoveryModal, {
             screen: EDiscoveryModalRoutes.HistoryListModal,
@@ -119,23 +92,11 @@ export const useDiscoveryShortcuts = () => {
             screen: EDiscoveryModalRoutes.BookmarkListModal,
           });
           break;
-        case EShortcutEvents.UniversalSearch:
-          navigation.pushModal(EModalRoutes.UniversalSearchModal, {
-            screen: EUniversalSearchPages.UniversalSearch,
-          });
-          break;
         default:
           break;
       }
     },
-    [
-      activeTabId,
-      copyText,
-      handleCloseWebTab,
-      isAtBrowserTab,
-      navigation,
-      shouldReloadAppByCmdR,
-    ],
+    [activeTabId, copyText, handleCloseWebTab, isAtBrowserTab, navigation],
   );
 
   useShortcuts(undefined, handleShortcuts);

--- a/packages/kit/src/views/Discovery/hooks/useShortcuts.desktop.ts
+++ b/packages/kit/src/views/Discovery/hooks/useShortcuts.desktop.ts
@@ -62,38 +62,42 @@ export const useDiscoveryShortcuts = () => {
         return;
       }
       const webview = getActiveWebview(activeTabId);
-      switch (data) {
-        case EShortcutEvents.CopyAddressOrUrl: {
-          const url = webview?.getURL();
-          if (url) {
-            copyText(url);
+      try {
+        switch (data) {
+          case EShortcutEvents.CopyAddressOrUrl: {
+            const url = webview?.getURL();
+            if (url) {
+              copyText(url);
+            }
+            break;
           }
-          break;
+          case EShortcutEvents.GoForwardHistory:
+            webview?.goForward();
+            break;
+          case EShortcutEvents.GoBackHistory:
+            webview?.goBack();
+            break;
+          case EShortcutEvents.Refresh:
+            webview?.reload();
+            break;
+          case EShortcutEvents.CloseTab:
+            handleCloseWebTab();
+            break;
+          case EShortcutEvents.ViewHistory:
+            navigation.pushModal(EModalRoutes.DiscoveryModal, {
+              screen: EDiscoveryModalRoutes.HistoryListModal,
+            });
+            break;
+          case EShortcutEvents.ViewBookmark:
+            navigation.pushModal(EModalRoutes.DiscoveryModal, {
+              screen: EDiscoveryModalRoutes.BookmarkListModal,
+            });
+            break;
+          default:
+            break;
         }
-        case EShortcutEvents.GoForwardHistory:
-          webview?.goForward();
-          break;
-        case EShortcutEvents.GoBackHistory:
-          webview?.goBack();
-          break;
-        case EShortcutEvents.Refresh:
-          webview?.reload();
-          break;
-        case EShortcutEvents.CloseTab:
-          handleCloseWebTab();
-          break;
-        case EShortcutEvents.ViewHistory:
-          navigation.pushModal(EModalRoutes.DiscoveryModal, {
-            screen: EDiscoveryModalRoutes.HistoryListModal,
-          });
-          break;
-        case EShortcutEvents.ViewBookmark:
-          navigation.pushModal(EModalRoutes.DiscoveryModal, {
-            screen: EDiscoveryModalRoutes.BookmarkListModal,
-          });
-          break;
-        default:
-          break;
+      } catch {
+        // webview methods may throw if webContents is destroyed
       }
     },
     [activeTabId, copyText, handleCloseWebTab, isAtBrowserTab, navigation],


### PR DESCRIPTION
## Summary

- **Problem**: After browser tabs were moved into a secondary sidebar menu (BrowserSubmenuColumn), `useDiscoveryShortcuts` only mounts when Discovery/MultiTabBrowser route is active. This broke Cmd+K, Cmd+R, and Cmd+W on all other tabs.
- **Solution**: Split shortcuts into two hooks:
  - `useGlobalShortcuts` — mounted in `TabNavigator` (always alive), handles Cmd+K (universal search), Cmd+R (reload app), Cmd+W (quit app)
  - `useDiscoveryShortcuts` — mounted with Discovery component, handles browser-only shortcuts (refresh webview, close tab, forward/back, copy URL, history, bookmarks)
- Cmd+R and Cmd+W retain contextual behavior: in browser tab they operate on the webview/tab, elsewhere they reload/quit the app

## Test plan

- [ ] On Desktop, navigate to **Home** tab → press Cmd+K → universal search should open
- [ ] On Desktop, navigate to **Home** tab → press Cmd+R → app should reload
- [ ] On Desktop, navigate to **Home** tab → press Cmd+W → app should quit
- [ ] On Desktop, navigate to **Discovery** → open a browser tab → press Cmd+R → webview should refresh (not app reload)
- [ ] On Desktop, navigate to **Discovery** → open a browser tab → press Cmd+W → browser tab should close (not app quit)
- [ ] On Desktop, navigate to **Discovery** → browser shortcuts (forward/back/copy URL/history/bookmarks) should work
- [ ] On Desktop, navigate to **Swap/Market** → browser-only shortcuts should have no effect
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
