### PR TITLE
fix(market): disable watchlist drag-to-reorder on mobile

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketWatchlistTokenList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketWatchlistTokenList.tsx
@@ -270,7 +270,7 @@ function MarketWatchlistTokenList({
       result={filteredResult}
       isWatchlistMode
       showEndReachedIndicator
-      draggable={isDraggable}
+      draggable={isDraggable && !platformEnv.isNative}
       onDragEnd={handleDragEnd}
       onItemLongPress={handleShowContextMenu}
       onItemContextMenu={handleShowContextMenu}

--- a/packages/kit/src/views/Market/components/MarketHomeList.tsx
+++ b/packages/kit/src/views/Market/components/MarketHomeList.tsx
@@ -1076,7 +1076,7 @@ function BasicMarketHomeList({
         </YStack>
       )}
       <Table
-        draggable={draggable}
+        draggable={draggable && !platformEnv.isNative}
         headerRowProps={HEADER_ROW_PROPS}
         showBackToTopButton
         stickyHeaderHiddenOnScroll


### PR DESCRIPTION
## Summary
- Disable the draggable sorting feature for the market watchlist on native (iOS/Android) platforms
- Desktop and web drag-to-reorder behavior remains unaffected
- Long-press context menu (move to top, remove from watchlist) on mobile is preserved

## Test plan
- [ ] Verify watchlist on iOS/Android no longer allows drag-to-reorder
- [ ] Verify long-press context menu still works on mobile
- [ ] Verify drag-to-reorder still works on desktop/web
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
