### PR TITLE
fix: bottom tab bar clipped on OPPO foldable browser due to safe-area-inset-top height overflow

### DIFF
--- a/packages/shared/src/web/index.css
+++ b/packages/shared/src/web/index.css
@@ -40,7 +40,7 @@ html {
   scroll-behavior: smooth;
   /* Prevent text size change on orientation change https://gist.github.com/tfausak/2222823#file-ios-8-web-app-html-L138 */
   -webkit-text-size-adjust: 100%;
-  height: calc(100% + env(safe-area-inset-top));
+  height: 100%;
 }
 
 body {


### PR DESCRIPTION
## Summary
- Fix bottom tab bar being cut off on OPPO's built-in browser (foldable inner screen)
- Root cause: `html { height: calc(100% + env(safe-area-inset-top)) }` made the html element taller than the visible viewport, pushing the bottom tab bar off-screen
- On devices with camera cutouts (e.g. OPPO foldable), `env(safe-area-inset-top)` returns ~30-48px, causing the tab bar to be clipped by that amount
- Safe area is already handled at the component level by `SafeAreaProvider` from `react-native-safe-area-context`, so the CSS-level adjustment was redundant
- Simplified to `html { height: 100% }`