### PR TITLE
fix: remove Deposit button from non-Perps pages

### DIFF
--- a/packages/kit/src/components/TabPageHeader/DappHeader.tsx
+++ b/packages/kit/src/components/TabPageHeader/DappHeader.tsx
@@ -25,7 +25,6 @@ import {
 } from '@onekeyhq/shared/src/config/appConfig';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
-  EModalReceiveRoutes,
   EModalRoutes,
   EModalSettingRoutes,
   ETabRoutes,
@@ -392,42 +391,6 @@ function MoreDappAction({ size }: { size?: 'small' | 'medium' }) {
   );
 }
 
-function DepositButton() {
-  const intl = useIntl();
-  const navigation = useAppNavigation();
-  const {
-    activeAccount: { wallet, account, network, indexedAccount },
-  } = useActiveAccount({
-    num: 0,
-  });
-
-  const shouldShow = useMemo(() => {
-    return !!account && !!wallet;
-  }, [account, wallet]);
-
-  const handlePress = useCallback(() => {
-    navigation.pushModal(EModalRoutes.ReceiveModal, {
-      screen: EModalReceiveRoutes.ReceiveToken,
-      params: {
-        networkId: network?.id ?? '',
-        accountId: account?.id ?? '',
-        walletId: wallet?.id ?? '',
-        indexedAccountId: indexedAccount?.id,
-      },
-    });
-  }, [navigation, network?.id, account?.id, wallet?.id, indexedAccount?.id]);
-
-  if (!shouldShow) {
-    return null;
-  }
-
-  return (
-    <Button size="small" variant="primary" onPress={handlePress}>
-      {intl.formatMessage({ id: ETranslations.perp_trade_deposit })}
-    </Button>
-  );
-}
-
 function RightActions({
   tabRoute,
   customHeaderRightItems,
@@ -482,7 +445,6 @@ function RightActions({
           >
             <WalletConnectionForWeb tabRoute={tabRoute} />
           </XStack>
-          <DepositButton />
         </>
       )}
       {!isPerpsTab && gtLg ? <DownloadAppButton /> : null}


### PR DESCRIPTION
<img width="2636" height="134" alt="截屏2026-02-12 11 50 13" src="https://github.com/user-attachments/assets/0873de2d-2994-4e62-8582-74f69c7df815" />

## Summary
- Remove the global Deposit button from the DappHeader toolbar (visible on Home, Market, DeFi, Swap, Referral pages)
- The Perps page retains its own independent Deposit button in `PerpsHeaderRight`, which is unaffected
- Clean up the unused `DepositButton` component and `EModalReceiveRoutes` import from `DappHeader.tsx`


🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


