### PR TITLE
fix: add theme-color meta tag for mobile web status bar consistency(OK-50201)

### DIFF
--- a/apps/ext/src/assets/preload-html-head.js
+++ b/apps/ext/src/assets/preload-html-head.js
@@ -66,17 +66,24 @@
   // packages/components/tamagui.config.ts
   // darkColors.bgApp
   const darkColor = '#0f0f0f';
+  function applyThemeColor(color) {
+    document.documentElement.style.backgroundColor = color;
+    var meta = document.querySelector('meta[name="theme-color"]');
+    if (meta) {
+      meta.setAttribute('content', color);
+    }
+  }
   if (theme === 'dark') {
-    document.documentElement.style.backgroundColor = darkColor;
+    applyThemeColor(darkColor);
   } else if (theme === 'light') {
-    document.documentElement.style.backgroundColor = lightColor;
+    applyThemeColor(lightColor);
   } else if (window.matchMedia) {
-    const color = window.matchMedia('(prefers-color-scheme: dark)').matches
+    var color = window.matchMedia('(prefers-color-scheme: dark)').matches
       ? darkColor
       : lightColor;
-    document.documentElement.style.backgroundColor = color;
+    applyThemeColor(color);
   } else {
-    document.documentElement.style.backgroundColor = lightColor;
+    applyThemeColor(lightColor);
   }
   // themePreload end ----------------------------------------------
 

--- a/packages/shared/src/modules3rdParty/rootview-background/index.tsx
+++ b/packages/shared/src/modules3rdParty/rootview-background/index.tsx
@@ -10,6 +10,10 @@ export const updateRootViewBackgroundColor: IUpdateRootViewBackgroundColor = (
 ) => {
   setTimeout(() => {
     localStorage.setItem(THEME_PRELOAD_STORAGE_KEY, theme);
+    const meta = document.querySelector('meta[name="theme-color"]');
+    if (meta) {
+      meta.setAttribute('content', color);
+    }
     if (platformEnv.isExtension) {
       // Keep a copy in extension storage so background/service-worker can read it.
       void (async () => {

--- a/packages/shared/src/web/index.html.ejs
+++ b/packages/shared/src/web/index.html.ejs
@@ -17,6 +17,7 @@
       content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1.00001, viewport-fit=cover"
     />
     <title>OneKey</title>
+    <meta name="theme-color" content="#ffffff" />
       <% if ( isDev ) { %>
         <script
         <% if ( platform === 'ext'  ) { %>


### PR DESCRIPTION
## Summary
- Add `<meta name="theme-color">` tag to the HTML template so mobile browsers (especially iOS Safari) color the status bar area to match the page background
- Update the preload script to dynamically set the `theme-color` meta tag alongside `document.documentElement.style.backgroundColor` at page load
- Update the runtime theme change handler (`updateRootViewBackgroundColor`) to keep the `theme-color` meta tag in sync when the user switches themes

## Test plan
- [ ] Open the web app on iOS Safari (mobile) and verify the status bar area matches the page background color (white for light theme, dark for dark theme)
- [ ] Switch themes and verify the status bar color updates accordingly
- [ ] Verify no visual regression on desktop web and browser extension
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
