### PR TITLE
fix: use keyboard event hook without navigation dependency in AppStateLock

### DIFF
--- a/packages/components/src/hooks/useKeyboard.ts
+++ b/packages/components/src/hooks/useKeyboard.ts
@@ -110,6 +110,39 @@ export const useKeyboardEvent = (
   }, deps);
 };
 
+// Version without useIsFocused — for components rendered outside NavigationContainer
+export const useKeyboardEventWithoutNavigation = (
+  {
+    keyboardWillShow = noop,
+    keyboardWillHide = noop,
+  }: {
+    keyboardWillShow?: KeyboardEventListener;
+    keyboardWillHide?: KeyboardEventListener;
+  },
+  deps: DependencyList = [],
+) => {
+  useEffect(() => {
+    const showSubscription = Keyboard.addListener(
+      KEYBOARD_SHOW_EVENT_NAME,
+      (e) => {
+        keyboardWillShow(e);
+      },
+    );
+
+    const hideSubscription = Keyboard.addListener(
+      KEYBOARD_HIDE_EVENT_NAME,
+      (e) => {
+        keyboardWillHide(e);
+      },
+    );
+    return () => {
+      showSubscription.remove();
+      hideSubscription.remove();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+};
+
 export const updateHeightWhenKeyboardShown = (height: number) =>
   withTiming(height, {
     duration: platformEnv.isNativeIOS ? 200 : 30,

--- a/packages/kit/src/provider/Container/AppStateLockContainer/components/AppStateLock.tsx
+++ b/packages/kit/src/provider/Container/AppStateLockContainer/components/AppStateLock.tsx
@@ -19,7 +19,7 @@ import {
   ThemeableStack,
   updateHeightWhenKeyboardHide,
   updateHeightWhenKeyboardShown,
-  useKeyboardEvent,
+  useKeyboardEventWithoutNavigation,
   useSafeAreaInsets,
 } from '@onekeyhq/components';
 import Logo from '@onekeyhq/kit/assets/logo_round_decorated.png';
@@ -47,7 +47,7 @@ const useSafeKeyboardAnimationStyle = platformEnv.isNative
         flex: 1,
         bottom: keyboardHeightValue.value,
       }));
-      useKeyboardEvent({
+      useKeyboardEventWithoutNavigation({
         keyboardWillShow: (event: KeyboardEvent) => {
           keyboardHeightValue.value = updateHeightWhenKeyboardShown(
             event?.endCoordinates?.height


### PR DESCRIPTION
## Summary
- Added `useKeyboardEventWithoutNavigation` hook in `@onekeyhq/components` — a variant of `useKeyboardEvent` that does not depend on `useIsFocused` from React Navigation
- Updated `AppStateLock` to use the new hook, since it is rendered outside `NavigationContainer` and cannot access navigation context

## Test plan
- [ ] Verify keyboard animation works correctly on the lock screen (iOS & Android)
- [ ] Verify no regression in keyboard behavior on other screens using `useKeyboardEvent`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
