### PR TITLE
fix: resolve receive page copy button overflow on native

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/MobilePositionsListHeader.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/MobilePositionsListHeader.tsx
@@ -55,7 +55,9 @@ export function MobilePositionsListHeader({
     >
       {/* Left: Filter checkbox - same style as TP/SL checkbox in trading form */}
       <Checkbox
-        label={intl.formatMessage({ id: ETranslations.perps_hide_other_symbols })}
+        label={intl.formatMessage({
+          id: ETranslations.perps_hide_other_symbols,
+        })}
         labelProps={{ fontSize: '$bodyXs' }}
         containerProps={{ p: '$0', alignItems: 'center' }}
         width="$3.5"

--- a/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
+++ b/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
@@ -620,10 +620,7 @@ function ReceiveToken() {
         }}
       >
         <YStack gap="$1.5">
-          <XStack
-            gap="$2"
-            alignItems="center"
-          >
+          <XStack gap="$2" alignItems="center">
             <SizableText size="$bodyMd">
               {token?.symbol ?? network.symbol}
             </SizableText>
@@ -662,7 +659,11 @@ function ReceiveToken() {
               </Badge>
             ) : null}
           </XStack>
-          <XStack gap="$2" alignItems="center" justifyContent={platformEnv.isNative ? undefined : 'space-between'}>
+          <XStack
+            gap="$2"
+            alignItems="center"
+            justifyContent={platformEnv.isNative ? undefined : 'space-between'}
+          >
             {renderAddress()}
             {renderCopyAddressButton()}
           </XStack>

--- a/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
+++ b/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
@@ -62,6 +62,7 @@ import { useWalletBanner } from '../../../hooks/useWalletBanner';
 import { EAddressState } from '../types';
 
 import type { RouteProp } from '@react-navigation/core';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 function ReceiveToken() {
   useDebugComponentRemountLog({
@@ -559,7 +560,8 @@ function ReceiveToken() {
 
     return (
       <XStack
-        maxWidth={304}
+        flex={platformEnv.isNative ? 1 : undefined}
+        maxWidth={platformEnv.isNative ? undefined : 304}
         flexWrap="wrap"
         {...(shouldShowAddress && {
           onPress: handleCopyAddress,
@@ -618,7 +620,7 @@ function ReceiveToken() {
         }}
       >
         <YStack gap="$1.5">
-          <XStack gap="$2" alignItems="center">
+          <XStack gap="$2" alignItems="center" justifyContent={platformEnv.isNative ? undefined : "space-between"}>
             <SizableText size="$bodyMd">
               {token?.symbol ?? network.symbol}
             </SizableText>
@@ -657,7 +659,7 @@ function ReceiveToken() {
               </Badge>
             ) : null}
           </XStack>
-          <XStack gap="$2" alignItems="center" justifyContent="space-between">
+          <XStack gap="$2" alignItems="center">
             {renderAddress()}
             {renderCopyAddressButton()}
           </XStack>

--- a/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
+++ b/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
@@ -623,7 +623,6 @@ function ReceiveToken() {
           <XStack
             gap="$2"
             alignItems="center"
-            justifyContent={platformEnv.isNative ? undefined : 'space-between'}
           >
             <SizableText size="$bodyMd">
               {token?.symbol ?? network.symbol}
@@ -663,7 +662,7 @@ function ReceiveToken() {
               </Badge>
             ) : null}
           </XStack>
-          <XStack gap="$2" alignItems="center">
+          <XStack gap="$2" alignItems="center" justifyContent={platformEnv.isNative ? undefined : 'space-between'}>
             {renderAddress()}
             {renderCopyAddressButton()}
           </XStack>

--- a/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
+++ b/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
@@ -620,7 +620,11 @@ function ReceiveToken() {
         }}
       >
         <YStack gap="$1.5">
-          <XStack gap="$2" alignItems="center" justifyContent={platformEnv.isNative ? undefined : "space-between"}>
+          <XStack
+            gap="$2"
+            alignItems="center"
+            justifyContent={platformEnv.isNative ? undefined : 'space-between'}
+          >
             <SizableText size="$bodyMd">
               {token?.symbol ?? network.symbol}
             </SizableText>


### PR DESCRIPTION
## Summary
- Fix the copy button on the Receive page being pushed to the screen edge on native platforms
- The address container's fixed `maxWidth(304)` plus the copy button exceeded available width on narrow mobile screens, causing the button to overflow beyond the footer's horizontal padding
- Use `flex={1}` on native instead of fixed `maxWidth` so the address adapts to available space, and remove `justifyContent="space-between"` on the address row so the copy button stays adjacent to the address text
- Preserve the original `maxWidth(304)` and `space-between` layout on web

## Test plan
- [ ] Open Receive page on iOS / Android and verify the copy button is within the padded area, not at the screen edge
- [ ] Verify the address text wraps correctly and the copy button sits right next to it
- [ ] Open Receive page on web and verify layout is unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
