### PR TITLE
fix: add null check for targetParams in notification navigation

### DIFF
--- a/packages/kit/src/provider/Container/NotificationHandlerContainer/index.tsx
+++ b/packages/kit/src/provider/Container/NotificationHandlerContainer/index.tsx
@@ -150,7 +150,8 @@ function BaseNotificationHandlerContainer() {
         localParams,
         getEarnAccount: (props) =>
           backgroundApiProxy.serviceStaking.getEarnAccount(props),
-      }).catch(() => {
+      }).catch((error) => {
+        console.error(error)
         showFallbackUpdateDialog(null);
       });
     };

--- a/packages/shared/src/utils/notificationsUtils.ts
+++ b/packages/shared/src/utils/notificationsUtils.ts
@@ -95,24 +95,26 @@ export async function navigateToNotificationDetailByLocalParams({
     targetParams = targetParams.params;
   }
 
-  if (targetParams.networkId) {
-    const accountInfos = await getEarnAccount({
-      accountId: localParams.accountId || '',
-      networkId: targetParams.networkId,
-      indexedAccountId: localParams.indexedAccountId || '',
-    });
-    if (accountInfos) {
-      localParams.accountId = accountInfos?.accountId || localParams.accountId;
-      localParams.indexedAccountId =
-        accountInfos?.account.indexedAccountId || localParams.indexedAccountId;
-    }
-  }
-  // Replace template variables in targetParams values with localParams values
-  for (const [key, value] of Object.entries(targetParams)) {
-    if (typeof value === 'string' && value.includes('{')) {
-      targetParams[key] = value.replace(/\{local_(\w+)\}/g, (match, param) => {
-        return localParams[param as keyof typeof localParams] || match;
+  if (targetParams) {
+    if (targetParams?.networkId) {
+      const accountInfos = await getEarnAccount({
+        accountId: localParams.accountId || '',
+        networkId: targetParams.networkId,
+        indexedAccountId: localParams.indexedAccountId || '',
       });
+      if (accountInfos) {
+        localParams.accountId = accountInfos?.accountId || localParams.accountId;
+        localParams.indexedAccountId =
+          accountInfos?.account.indexedAccountId || localParams.indexedAccountId;
+      }
+    }
+    // Replace template variables in targetParams values with localParams values
+    for (const [key, value] of Object.entries(targetParams)) {
+      if (typeof value === 'string' && value.includes('{')) {
+        targetParams[key] = value.replace(/\{local_(\w+)\}/g, (match, param) => {
+          return localParams[param as keyof typeof localParams] || match;
+        });
+      }
     }
   }
   if (screen === ERootRoutes.Main) {


### PR DESCRIPTION
## Summary
- Guard against null/undefined `targetParams` in `navigateToNotificationDetailByLocalParams` to prevent crash when notification data is incomplete
- Add error logging in notification handler catch block for better debugging of navigation failures

## Test plan
- [ ] Verify notification navigation works correctly with valid targetParams
- [ ] Verify app does not crash when targetParams is null/undefined
- [ ] Verify error is logged when notification navigation fails
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
