### PR TITLE
OK-50279, OK-50267: inject initialRouteName in linking config to restore back button after extension reload

### DIFF
--- a/packages/kit/src/routes/config/index.ts
+++ b/packages/kit/src/routes/config/index.ts
@@ -47,6 +47,9 @@ const resolveScreens = (routes: IScreenRouterConfig[]) =>
           : undefined;
         if (config) {
           prev[route.name].screens = resolveScreens(config);
+          if (config.length > 0) {
+            prev[route.name].initialRouteName = config[0].name;
+          }
         }
 
         return prev;

--- a/packages/kit/src/routes/config/index.ts
+++ b/packages/kit/src/routes/config/index.ts
@@ -35,6 +35,8 @@ interface IScreenRouterConfig {
   children?: IScreenRouterConfig[] | null;
 }
 
+const tabRouteNames: ReadonlySet<string> = new Set(Object.values(ETabRoutes));
+
 const resolveScreens = (routes: IScreenRouterConfig[]) =>
   routes
     ? routes.reduce((prev, route) => {
@@ -47,7 +49,7 @@ const resolveScreens = (routes: IScreenRouterConfig[]) =>
           : undefined;
         if (config) {
           prev[route.name].screens = resolveScreens(config);
-          if (config.length > 0) {
+          if (config.length > 0 && tabRouteNames.has(route.name)) {
             prev[route.name].initialRouteName = config[0].name;
           }
         }

--- a/packages/shared/src/utils/routeUtils.ts
+++ b/packages/shared/src/utils/routeUtils.ts
@@ -30,6 +30,7 @@ export type IScreenPathConfig = Record<
   {
     path: string;
     exact: boolean;
+    initialRouteName?: string;
     screens?: IScreenPathConfig;
   }
 >;


### PR DESCRIPTION
## Summary
- When reloading the browser on a sub-page in extension expanded window mode, the navigation stack was rebuilt from URL hash with only one entry, causing `canGoBack` to be false and the back button to disappear — users got stuck on sub-pages with no way to navigate back
- Set `initialRouteName` from first child route in `resolveScreens` so that `getStateFromPath` injects the tab home route at stack bottom when rebuilding state from URL
- Only 2 files changed, 4 lines added — the fix leverages existing `initialRouteName` handling already built into React Navigation's `getStateFromPath`

## Test plan
- [ ] In extension expanded window, navigate to a Market detail page (e.g. `/market/tokens/bitcoin`), press browser Reload → back button should appear and navigate back to Market home
- [ ] In extension expanded window, navigate to Earn protocol details, press browser Reload → back button should appear
- [ ] In extension expanded window, navigate to ReferFriends sub-pages, press browser Reload → back button should appear
- [ ] Verify that Tab home pages (Market, Swap, Earn, etc.) do NOT show a back button after reload
- [ ] Verify normal navigation flow (without reload) still works correctly on all platforms
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
