### PR TITLE
fix: resolve Android text selection highlight color too dark(OK-50316)

### DIFF
--- a/apps/mobile/android/app/src/main/res/values-night/colors.xml
+++ b/apps/mobile/android/app/src/main/res/values-night/colors.xml
@@ -5,4 +5,5 @@
     <color name="colorPrimary">#023c69</color>
     <color name="colorPrimaryDark">#000000</color>
     <color name="navigationBarColor">#0f0f0f</color>
+    <color name="textSelectionHighlight">#ffffff72</color>
 </resources>

--- a/apps/mobile/android/app/src/main/res/values-night/colors.xml
+++ b/apps/mobile/android/app/src/main/res/values-night/colors.xml
@@ -5,5 +5,5 @@
     <color name="colorPrimary">#023c69</color>
     <color name="colorPrimaryDark">#000000</color>
     <color name="navigationBarColor">#0f0f0f</color>
-    <color name="textSelectionHighlight">#ffffff72</color>
+    <color name="textSelectionHighlight">#72ffffff</color>
 </resources>

--- a/apps/mobile/android/app/src/main/res/values/colors.xml
+++ b/apps/mobile/android/app/src/main/res/values/colors.xml
@@ -5,5 +5,5 @@
   <color name="colorPrimary">#023c69</color>
   <color name="colorPrimaryDark">#ffffff</color>
   <color name="navigationBarColor">#ffffff</color>
-  <color name="textSelectionHighlight">#0000009b</color>
+  <color name="textSelectionHighlight">#9b000000</color>
 </resources>

--- a/apps/mobile/android/app/src/main/res/values/colors.xml
+++ b/apps/mobile/android/app/src/main/res/values/colors.xml
@@ -5,4 +5,5 @@
   <color name="colorPrimary">#023c69</color>
   <color name="colorPrimaryDark">#ffffff</color>
   <color name="navigationBarColor">#ffffff</color>
+  <color name="textSelectionHighlight">#0000009b</color>
 </resources>

--- a/apps/mobile/android/app/src/main/res/values/styles.xml
+++ b/apps/mobile/android/app/src/main/res/values/styles.xml
@@ -12,6 +12,7 @@
   <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
     <item name="android:navigationBarColor" tools:targetApi="21">@color/navigationBarColor</item>
     <item name="android:textColor">@android:color/black</item>
+    <item name="android:textColorHighlight">@color/textSelectionHighlight</item>
     <item name="android:editTextStyle">@style/ResetEditText</item>
     <item name="android:editTextBackground" tools:targetApi="11">@drawable/rn_edit_text_material</item>
     <item name="colorPrimary">@color/colorPrimary</item>

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/LineNumberedTextArea.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/LineNumberedTextArea.tsx
@@ -16,6 +16,7 @@ import {
   XStack,
   YStack,
   useClipboard,
+  useSelectionColor,
   useTheme,
 } from '@onekeyhq/components';
 import { webFontFamily } from '@onekeyhq/components/src/utils/webFontFamily';
@@ -106,6 +107,7 @@ function LineNumberedTextArea({
   const { getClipboard } = useClipboard();
   const theme = useTheme();
   const textColor = theme.text?.val;
+  const selectionColor = useSelectionColor();
   const placeholderColor = theme.textPlaceholder?.val;
   const [inputText, setInputText] = useState<string>(value);
   const [contentHeight, setContentHeight] = useState(0);
@@ -408,7 +410,7 @@ function LineNumberedTextArea({
                 editable={!disabled}
                 multiline
                 style={styles.textInput}
-                selectionColor={textColor}
+                selectionColor={selectionColor}
                 cursorColor={textColor}
                 spellCheck={false}
                 autoCorrect={false}


### PR DESCRIPTION
## Summary
- Fix Android text input selection highlight being too dark (opaque black) in light mode
- Add `android:textColorHighlight` to `AppTheme` in `styles.xml` as a global native-level fallback for all `EditText` components
- Fix `LineNumberedTextArea` (BulkSend page) incorrectly using `textColor` as `selectionColor` — now uses `useSelectionColor()` hook for consistency
- Align Android native theme highlight colors with JS theme tokens (`bgPrimaryActive`): light `#0000009b`, dark `#ffffff72`

## Test plan
- [ ] Verify text selection highlight in BulkSend address input on Android (light & dark mode)
- [ ] Verify text selection highlight in other TextInput/TextArea components on Android
- [ ] Confirm no visual regression on iOS
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
