### PR TITLE
fix: use KeyboardAwareScrollView for keyboard avoidance

### DIFF
--- a/apps/desktop/app/app.ts
+++ b/apps/desktop/app/app.ts
@@ -121,6 +121,7 @@ const sdkConnectSrc = isLocalUnpacked
 
 const isMac = process.platform === 'darwin';
 const isWin = process.platform === 'win32';
+const isLinux = process.platform === 'linux';
 
 let systemIdleInterval: ReturnType<typeof setInterval>;
 
@@ -484,7 +485,7 @@ async function createMainWindow() {
     show: false,
     title: APP_TITLE_NAME,
     titleBarStyle: 'hidden',
-    titleBarOverlay: isWin
+    titleBarOverlay: isWin || isLinux
       ? {
           height: 52,
           color: '#00000000',

--- a/apps/desktop/app/app.ts
+++ b/apps/desktop/app/app.ts
@@ -485,13 +485,14 @@ async function createMainWindow() {
     show: false,
     title: APP_TITLE_NAME,
     titleBarStyle: 'hidden',
-    titleBarOverlay: isWin || isLinux
-      ? {
-          height: 52,
-          color: '#00000000',
-          symbolColor: isDarkTheme ? '#ffffff' : '#000000',
-        }
-      : false,
+    titleBarOverlay:
+      isWin || isLinux
+        ? {
+            height: 52,
+            color: '#00000000',
+            symbolColor: isDarkTheme ? '#ffffff' : '#000000',
+          }
+        : false,
     trafficLightPosition: { x: 20, y: 20 },
     autoHideMenuBar: true,
     frame: true,

--- a/packages/components/src/content/Keyboard/index.tsx
+++ b/packages/components/src/content/Keyboard/index.tsx
@@ -2,6 +2,7 @@ import {
   dismissKeyboard,
   dismissKeyboardWithDelay,
 } from '@onekeyhq/shared/src/keyboard';
+import { ScrollView } from 'react-native';
 
 import type {
   KeyboardAvoidingView,
@@ -23,7 +24,7 @@ const PassThrough = ({
 
 export const Keyboard = {
   AvoidingView: PassThrough as typeof KeyboardAvoidingView,
-  AwareScrollView: PassThrough as typeof KeyboardAwareScrollView,
+  AwareScrollView: ScrollView as unknown as typeof KeyboardAwareScrollView,
   StickyView: PassThrough as typeof KeyboardStickyView,
   Toolbar: PassThrough as typeof KeyboardToolbar,
   ControllerView: PassThrough as typeof KeyboardControllerView,

--- a/packages/components/src/forms/Input/index.tsx
+++ b/packages/components/src/forms/Input/index.tsx
@@ -29,7 +29,6 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
 import { useClipboard, useSelectionColor } from '../../hooks';
-import { useScrollToLocation } from '../../layouts/ScrollView';
 import { Icon } from '../../primitives';
 
 import { Input as TMInput } from './Input';
@@ -422,7 +421,6 @@ function BaseInput(
   }
 
   const shownValue = useFixAndroidInputValueDisplay(value);
-  const { scrollToView } = useScrollToLocation(inputRef);
   // workaround for selectTextOnFocus={true} not working on Native App
   const handleFocus = useCallback(
     (e: NativeSyntheticEvent<TextInputFocusEventData>) => {
@@ -435,9 +433,8 @@ function BaseInput(
           });
         });
       }
-      scrollToView();
     },
-    [onFocus, scrollToView, selectTextOnFocus],
+    [onFocus, selectTextOnFocus],
   );
 
   const onNumberPadChangeText = useCallback(

--- a/packages/components/src/forms/TextArea/index.tsx
+++ b/packages/components/src/forms/TextArea/index.tsx
@@ -5,7 +5,6 @@ import { getFontSize } from '@onekeyhq/components/src/shared/tamagui';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { useSelectionColor } from '../../hooks';
-import { useScrollToLocation } from '../../layouts/ScrollView';
 import { getSharedInputStyles } from '../Input/sharedStyles';
 
 import { TextArea as TMTextArea } from './TamaguiTextArea';
@@ -48,13 +47,11 @@ function BaseTextArea(
   useImperativeHandle(forwardedRef, () => ref.current as TextInput);
 
   const selectionColor = useSelectionColor();
-  const { scrollToView } = useScrollToLocation(ref);
   const handleFocus = useCallback(
     async (e: NativeSyntheticEvent<TextInputFocusEventData>) => {
       onFocus?.(e);
-      scrollToView();
     },
-    [onFocus, scrollToView],
+    [onFocus],
   );
 
   return (

--- a/packages/components/src/hooks/useKeyboard.ts
+++ b/packages/components/src/hooks/useKeyboard.ts
@@ -143,21 +143,6 @@ export const useKeyboardEventWithoutNavigation = (
   }, deps);
 };
 
-// Module-level keyboard height tracker for use in non-hook contexts (e.g. callbacks).
-// Avoids re-renders — consumers read the value imperatively.
-let _currentKeyboardHeight = 0;
-
-if (platformEnv.isNative) {
-  Keyboard.addListener(KEYBOARD_SHOW_EVENT_NAME, (e) => {
-    _currentKeyboardHeight = e.endCoordinates.height;
-  });
-  Keyboard.addListener(KEYBOARD_HIDE_EVENT_NAME, () => {
-    _currentKeyboardHeight = 0;
-  });
-}
-
-export const getCurrentKeyboardHeight = () => _currentKeyboardHeight;
-
 export const updateHeightWhenKeyboardShown = (height: number) =>
   withTiming(height, {
     duration: platformEnv.isNativeIOS ? 200 : 30,

--- a/packages/components/src/hooks/useKeyboard.ts
+++ b/packages/components/src/hooks/useKeyboard.ts
@@ -143,6 +143,21 @@ export const useKeyboardEventWithoutNavigation = (
   }, deps);
 };
 
+// Module-level keyboard height tracker for use in non-hook contexts (e.g. callbacks).
+// Avoids re-renders — consumers read the value imperatively.
+let _currentKeyboardHeight = 0;
+
+if (platformEnv.isNative) {
+  Keyboard.addListener(KEYBOARD_SHOW_EVENT_NAME, (e) => {
+    _currentKeyboardHeight = e.endCoordinates.height;
+  });
+  Keyboard.addListener(KEYBOARD_HIDE_EVENT_NAME, () => {
+    _currentKeyboardHeight = 0;
+  });
+}
+
+export const getCurrentKeyboardHeight = () => _currentKeyboardHeight;
+
 export const updateHeightWhenKeyboardShown = (height: number) =>
   withTiming(height, {
     duration: platformEnv.isNativeIOS ? 200 : 30,

--- a/packages/components/src/layouts/DesktopDragZoneBox/index.desktop.tsx
+++ b/packages/components/src/layouts/DesktopDragZoneBox/index.desktop.tsx
@@ -46,6 +46,8 @@ function DesktopDragZoneBoxMac({
 }
 
 export const DesktopDragZoneBox =
-  platformEnv.isDesktopMac || platformEnv.isDesktopWin
+  platformEnv.isDesktopMac ||
+  platformEnv.isDesktopWin ||
+  platformEnv.isDesktopLinux
     ? DesktopDragZoneBoxMac
     : BaseDesktopDragZoneBox;

--- a/packages/components/src/layouts/Navigation/Header/HeaderView.tsx
+++ b/packages/components/src/layouts/Navigation/Header/HeaderView.tsx
@@ -41,7 +41,9 @@ function getHeaderTitle(
 }
 
 const DesktopDragZoneBoxView =
-  platformEnv.isDesktopMac || platformEnv.isDesktopWin
+  platformEnv.isDesktopMac ||
+  platformEnv.isDesktopWin ||
+  platformEnv.isDesktopLinux
     ? ({ disabled, children }: IDesktopDragZoneBoxProps) => {
         const isModalPage = useIsOverlayPage();
 
@@ -203,7 +205,7 @@ function HeaderView({
           alignSelf="stretch"
           px={isOnboardingScreen ? '$16' : '$5'}
           pr={
-            platformEnv.isDesktopWin &&
+            (platformEnv.isDesktopWin || platformEnv.isDesktopLinux) &&
             !isOnboardingScreen &&
             !isModelScreen
               ? WINDOWS_OVERLAY_BUTTONS_WIDTH

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/SubmenuColumn.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/SubmenuColumn.tsx
@@ -21,7 +21,9 @@ export function SubmenuColumn({
   return (
     <Stack width={COLLAPSED_SUBMENU_WIDTH} flex={1}>
       {/* Desktop drag area - always bgSidebar, not affected by expand */}
-      {platformEnv.isDesktopMac || platformEnv.isDesktopWin ? (
+      {platformEnv.isDesktopMac ||
+      platformEnv.isDesktopWin ||
+      platformEnv.isDesktopLinux ? (
         <XStack
           position="absolute"
           top={0}

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
@@ -493,7 +493,7 @@ export function DesktopLeftSideBar({
             jc="flex-end"
             px="$4"
           />
-        ) : platformEnv.isDesktopWin ? (
+        ) : platformEnv.isDesktopWin || platformEnv.isDesktopLinux ? (
           <DesktopWinSidebarTop />
         ) : (
           <MenuHamburger />
@@ -502,6 +502,7 @@ export function DesktopLeftSideBar({
           <YStack flex={1}>
             {!platformEnv.isDesktopMac &&
             !platformEnv.isDesktopWin &&
+            !platformEnv.isDesktopLinux &&
             !platformEnv.isNativeIOSPad ? (
               <XStack ai="center" jc="center" px="$4" py="$3">
                 <Icon

--- a/packages/components/src/layouts/Page/PageContainer.native.tsx
+++ b/packages/components/src/layouts/Page/PageContainer.native.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from 'react';
+import { useCallback, useContext, useMemo, useRef } from 'react';
 
 import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
 
@@ -7,12 +7,20 @@ import {
   useStyle,
 } from '@onekeyhq/components/src/shared/tamagui';
 
+import { ScrollViewRefProvider } from '../ScrollView';
+
 import { BasicPage } from './BasicPage';
 import { PageContext } from './PageContext';
 import { BasicPageFooter } from './PageFooter';
 
+import type { IScrollViewRef } from '../ScrollView';
 import type { IPageProps } from './type';
-import type { StyleProp, ViewStyle } from 'react-native';
+import type {
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  StyleProp,
+  ViewStyle,
+} from 'react-native';
 
 export function PageContainer({ children, lazyLoad, fullPage }: IPageProps) {
   const { scrollEnabled, scrollProps } = useContext(PageContext);
@@ -32,18 +40,37 @@ export function PageContainer({ children, lazyLoad, fullPage }: IPageProps) {
     { resolveValues: 'auto' },
   );
 
+  // Maintain ScrollView ref context so useScrollView() consumers still work
+  const scrollViewRef = useRef<IScrollViewRef>(null);
+  const pageOffsetRef = useRef({ x: 0, y: 0 });
+  const handleScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      pageOffsetRef.current = event.nativeEvent.contentOffset;
+      (nativeProps as { onScroll?: typeof handleScroll }).onScroll?.(event);
+    },
+    [nativeProps],
+  );
+  const contextValue = useMemo(
+    () => ({ scrollViewRef, pageOffsetRef }),
+    [scrollViewRef],
+  );
+
   return useMemo(
     () => (
       <BasicPage lazyLoad={lazyLoad} fullPage={fullPage}>
         {scrollEnabled ? (
           <KeyboardAwareScrollView
+            ref={scrollViewRef as any}
             scrollEventThrottle={30}
             {...(nativeProps as Record<string, unknown>)}
+            onScroll={handleScroll}
             style={[{ flex: 1 }, style] as StyleProp<ViewStyle>}
             contentContainerStyle={contentContainerStyle}
             bottomOffset={16}
           >
-            {children}
+            <ScrollViewRefProvider value={contextValue}>
+              {children}
+            </ScrollViewRefProvider>
           </KeyboardAwareScrollView>
         ) : (
           children
@@ -56,8 +83,10 @@ export function PageContainer({ children, lazyLoad, fullPage }: IPageProps) {
       fullPage,
       scrollEnabled,
       nativeProps,
+      handleScroll,
       style,
       contentContainerStyle,
+      contextValue,
       children,
     ],
   );

--- a/packages/components/src/layouts/Page/PageContainer.native.tsx
+++ b/packages/components/src/layouts/Page/PageContainer.native.tsx
@@ -1,0 +1,64 @@
+import { useContext, useMemo } from 'react';
+
+import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
+
+import {
+  usePropsAndStyle,
+  useStyle,
+} from '@onekeyhq/components/src/shared/tamagui';
+
+import { BasicPage } from './BasicPage';
+import { PageContext } from './PageContext';
+import { BasicPageFooter } from './PageFooter';
+
+import type { IPageProps } from './type';
+import type { StyleProp, ViewStyle } from 'react-native';
+
+export function PageContainer({ children, lazyLoad, fullPage }: IPageProps) {
+  const { scrollEnabled, scrollProps } = useContext(PageContext);
+
+  const {
+    contentContainerStyle: rawContentContainerStyle,
+    ...restScrollProps
+  } = scrollProps || {};
+
+  const [nativeProps, style] = usePropsAndStyle(
+    restScrollProps as Record<string, unknown>,
+    { resolveValues: 'auto' },
+  );
+
+  const contentContainerStyle = useStyle(
+    (rawContentContainerStyle || {}) as Record<string, unknown>,
+    { resolveValues: 'auto' },
+  );
+
+  return useMemo(
+    () => (
+      <BasicPage lazyLoad={lazyLoad} fullPage={fullPage}>
+        {scrollEnabled ? (
+          <KeyboardAwareScrollView
+            scrollEventThrottle={30}
+            {...(nativeProps as Record<string, unknown>)}
+            style={[{ flex: 1 }, style] as StyleProp<ViewStyle>}
+            contentContainerStyle={contentContainerStyle}
+            bottomOffset={16}
+          >
+            {children}
+          </KeyboardAwareScrollView>
+        ) : (
+          children
+        )}
+        <BasicPageFooter />
+      </BasicPage>
+    ),
+    [
+      lazyLoad,
+      fullPage,
+      scrollEnabled,
+      nativeProps,
+      style,
+      contentContainerStyle,
+      children,
+    ],
+  );
+}

--- a/packages/components/src/layouts/Page/PageContainer.native.tsx
+++ b/packages/components/src/layouts/Page/PageContainer.native.tsx
@@ -66,7 +66,7 @@ export function PageContainer({ children, lazyLoad, fullPage }: IPageProps) {
             onScroll={handleScroll}
             style={[{ flex: 1 }, style] as StyleProp<ViewStyle>}
             contentContainerStyle={contentContainerStyle}
-            bottomOffset={16}
+            bottomOffset={80}
           >
             <ScrollViewRefProvider value={contextValue}>
               {children}

--- a/packages/components/src/layouts/Page/PageContainer.tsx
+++ b/packages/components/src/layouts/Page/PageContainer.tsx
@@ -1,11 +1,8 @@
 import { useContext, useMemo } from 'react';
 
-import Animated from 'react-native-reanimated';
-
 import { ScrollView } from '../ScrollView';
 
 import { BasicPage } from './BasicPage';
-import { useSafeKeyboardAnimationStyle } from './hooks';
 import { PageContext } from './PageContext';
 import { BasicPageFooter } from './PageFooter';
 
@@ -14,30 +11,17 @@ import type { IPageProps } from './type';
 export function PageContainer({ children, lazyLoad, fullPage }: IPageProps) {
   const { scrollEnabled, scrollProps } = useContext(PageContext);
 
-  const safeKeyboardAnimationStyle = useSafeKeyboardAnimationStyle();
-
   return useMemo(
     () => (
       <BasicPage lazyLoad={lazyLoad} fullPage={fullPage}>
         {scrollEnabled ? (
-          <ScrollView {...scrollProps}>
-            <Animated.View style={[{ flex: 1 }, safeKeyboardAnimationStyle]}>
-              {children}
-            </Animated.View>
-          </ScrollView>
+          <ScrollView {...scrollProps}>{children}</ScrollView>
         ) : (
           children
         )}
         <BasicPageFooter />
       </BasicPage>
     ),
-    [
-      lazyLoad,
-      fullPage,
-      scrollEnabled,
-      scrollProps,
-      safeKeyboardAnimationStyle,
-      children,
-    ],
+    [lazyLoad, fullPage, scrollEnabled, scrollProps, children],
   );
 }

--- a/packages/components/src/layouts/ScrollView/index.tsx
+++ b/packages/components/src/layouts/ScrollView/index.tsx
@@ -12,6 +12,8 @@ import {
 
 import { Dimensions, ScrollView as ScrollViewNative } from 'react-native';
 
+import { getCurrentKeyboardHeight } from '../../hooks/useKeyboard';
+
 import {
   usePropsAndStyle,
   useStyle,
@@ -60,20 +62,30 @@ export const useScrollToLocation = (inputRef: RefObject<TextInput | null>) => {
   const actions = useScrollView();
   const scrollToView = useCallback(() => {
     if (platformEnv.isNative) {
+      // Delay to allow the keyboard to appear and layout to settle
       setTimeout(() => {
-        inputRef.current?.measureInWindow((x, y) => {
-          const { pageOffsetRef, scrollViewRef } = actions;
-          const windowHeight = Dimensions.get('window').height;
-          const minY = windowHeight / 4;
-          const scrollY = y - minY;
-          if (scrollY > 0) {
-            scrollViewRef?.current?.scrollTo?.({
-              y: pageOffsetRef.current.y + scrollY,
-              animated: true,
-            });
-          }
-        });
-      }, 250);
+        const keyboardHeight = getCurrentKeyboardHeight();
+        if (!keyboardHeight) return;
+
+        inputRef.current?.measureInWindow(
+          (_x: number, y: number, _width: number, height: number) => {
+            const { pageOffsetRef, scrollViewRef } = actions;
+            const windowHeight = Dimensions.get('window').height;
+            // Visible area = window height - keyboard height - buffer for footer
+            const visibleBottom = windowHeight - keyboardHeight - 60;
+            const inputBottom = y + height;
+            const gap = 16;
+
+            if (inputBottom > visibleBottom - gap) {
+              const scrollAmount = inputBottom - (visibleBottom - gap);
+              scrollViewRef?.current?.scrollTo?.({
+                y: pageOffsetRef.current.y + scrollAmount,
+                animated: true,
+              });
+            }
+          },
+        );
+      }, 300);
     }
   }, [actions, inputRef]);
   return useMemo(() => ({ scrollToView }), [scrollToView]);

--- a/packages/components/src/layouts/ScrollView/index.tsx
+++ b/packages/components/src/layouts/ScrollView/index.tsx
@@ -1,4 +1,4 @@
-import type { ForwardedRef, MutableRefObject, RefObject } from 'react';
+import type { ForwardedRef, MutableRefObject } from 'react';
 import {
   createContext,
   forwardRef,
@@ -10,9 +10,7 @@ import {
   useRef,
 } from 'react';
 
-import { Dimensions, ScrollView as ScrollViewNative } from 'react-native';
-
-import { getCurrentKeyboardHeight } from '../../hooks/useKeyboard';
+import { ScrollView as ScrollViewNative } from 'react-native';
 
 import {
   usePropsAndStyle,
@@ -27,7 +25,6 @@ import type {
   NativeSyntheticEvent,
   ScrollViewProps as ScrollViewNativeProps,
   StyleProp,
-  TextInput,
   ViewStyle,
 } from 'react-native';
 
@@ -55,41 +52,8 @@ const scrollViewRefContext = createContext<{
     },
   },
 });
-const ScrollViewRefProvider = memo(scrollViewRefContext.Provider);
+export const ScrollViewRefProvider = memo(scrollViewRefContext.Provider);
 export const useScrollView = () => useContext(scrollViewRefContext);
-
-export const useScrollToLocation = (inputRef: RefObject<TextInput | null>) => {
-  const actions = useScrollView();
-  const scrollToView = useCallback(() => {
-    if (platformEnv.isNative) {
-      // Delay to allow the keyboard to appear and layout to settle
-      setTimeout(() => {
-        const keyboardHeight = getCurrentKeyboardHeight();
-        if (!keyboardHeight) return;
-
-        inputRef.current?.measureInWindow(
-          (_x: number, y: number, _width: number, height: number) => {
-            const { pageOffsetRef, scrollViewRef } = actions;
-            const windowHeight = Dimensions.get('window').height;
-            // Visible area = window height - keyboard height - buffer for footer
-            const visibleBottom = windowHeight - keyboardHeight - 60;
-            const inputBottom = y + height;
-            const gap = 16;
-
-            if (inputBottom > visibleBottom - gap) {
-              const scrollAmount = inputBottom - (visibleBottom - gap);
-              scrollViewRef?.current?.scrollTo?.({
-                y: pageOffsetRef.current.y + scrollAmount,
-                animated: true,
-              });
-            }
-          },
-        );
-      }, 300);
-    }
-  }, [actions, inputRef]);
-  return useMemo(() => ({ scrollToView }), [scrollToView]);
-};
 
 function BaseScrollView(
   {

--- a/packages/kit/src/provider/Container/NotificationHandlerContainer/index.tsx
+++ b/packages/kit/src/provider/Container/NotificationHandlerContainer/index.tsx
@@ -151,7 +151,7 @@ function BaseNotificationHandlerContainer() {
         getEarnAccount: (props) =>
           backgroundApiProxy.serviceStaking.getEarnAccount(props),
       }).catch((error) => {
-        console.error(error)
+        console.error(error);
         showFallbackUpdateDialog(null);
       });
     };

--- a/packages/kit/src/views/Onboardingv2/components/OnboardingLayout.tsx
+++ b/packages/kit/src/views/Onboardingv2/components/OnboardingLayout.tsx
@@ -6,6 +6,7 @@ import type { IXStackProps, IYStackProps } from '@onekeyhq/components';
 import {
   Button,
   IconButton,
+  Keyboard,
   ScrollView,
   Select,
   SizableText,
@@ -24,13 +25,6 @@ import { useLanguageSelectorWithoutAuto } from '../../Setting/hooks/useLanguageS
 const DESKTOP_DRAGGABLE_STYLE = {
   WebkitAppRegion: 'drag',
 } as any;
-
-const SCROLL_VIEW_CONTENT_STYLE = {
-  px: '$5',
-  $gtMd: {
-    px: '$10',
-  },
-};
 
 const OnboardingLayoutBack = memo(({ exit }: { exit?: boolean }) => {
   const navigation = useAppNavigation();
@@ -201,6 +195,7 @@ const OnboardingLayoutBody = memo(
       [scrollable],
     );
 
+    const gtMd = useMedia();
     return (
       <YStack
         flex={1}
@@ -215,12 +210,15 @@ const OnboardingLayoutBody = memo(
         {...rest}
       >
         {scrollable ? (
-          <ScrollView
+          <Keyboard.AwareScrollView
             showsVerticalScrollIndicator={false}
-            contentContainerStyle={SCROLL_VIEW_CONTENT_STYLE}
+            bottomOffset={80}
+            contentContainerStyle={{
+              paddingHorizontal: gtMd ? 40 : 20,
+            }}
           >
             {content}
-          </ScrollView>
+          </Keyboard.AwareScrollView>
         ) : (
           content
         )}

--- a/packages/kit/src/views/Onboardingv2/components/OnboardingLayout.tsx
+++ b/packages/kit/src/views/Onboardingv2/components/OnboardingLayout.tsx
@@ -194,7 +194,7 @@ const OnboardingLayoutBody = memo(
       [scrollable],
     );
 
-    const gtMd = useMedia();
+    const { gtMd } = useMedia();
     return (
       <YStack
         flex={1}

--- a/packages/kit/src/views/Onboardingv2/components/OnboardingLayout.tsx
+++ b/packages/kit/src/views/Onboardingv2/components/OnboardingLayout.tsx
@@ -7,7 +7,6 @@ import {
   Button,
   IconButton,
   Keyboard,
-  ScrollView,
   Select,
   SizableText,
   XStack,

--- a/packages/shared/src/utils/notificationsUtils.ts
+++ b/packages/shared/src/utils/notificationsUtils.ts
@@ -103,17 +103,22 @@ export async function navigateToNotificationDetailByLocalParams({
         indexedAccountId: localParams.indexedAccountId || '',
       });
       if (accountInfos) {
-        localParams.accountId = accountInfos?.accountId || localParams.accountId;
+        localParams.accountId =
+          accountInfos?.accountId || localParams.accountId;
         localParams.indexedAccountId =
-          accountInfos?.account.indexedAccountId || localParams.indexedAccountId;
+          accountInfos?.account.indexedAccountId ||
+          localParams.indexedAccountId;
       }
     }
     // Replace template variables in targetParams values with localParams values
     for (const [key, value] of Object.entries(targetParams)) {
       if (typeof value === 'string' && value.includes('{')) {
-        targetParams[key] = value.replace(/\{local_(\w+)\}/g, (match, param) => {
-          return localParams[param as keyof typeof localParams] || match;
-        });
+        targetParams[key] = value.replace(
+          /\{local_(\w+)\}/g,
+          (match, param) => {
+            return localParams[param as keyof typeof localParams] || match;
+          },
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary
- Replace the brute-force `paddingBottom` animation in `PageContainer` with `KeyboardAwareScrollView` from `react-native-keyboard-controller` on native platforms
- Automatically scrolls to focused inputs using iOS `contentInset` mechanism — no visible blank space at the bottom
- Remove redundant `useScrollToLocation` and manual `scrollToView()` calls from `Input` / `TextArea` components
- Maintain `ScrollViewRefProvider` context in native `PageContainer` for existing `useScrollView()` consumers
- Web fallback uses standard `ScrollView` (no keyboard handling needed)

## Test plan
- [ ] iOS: Focus inputs on pages with footer buttons (e.g. Add Custom Network, Send) — input should scroll above keyboard+footer without excessive blank space
- [ ] Android: Same test — input visible, no large blank area when scrolled up
- [ ] Web: No behavioral change
- [ ] Verify `CreateCodeButton` in ReferFriends still scrolls to end correctly on native
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
