### PR TITLE
fix: use requestIdleCallback instead of setTimeout for native navigation(OK-49762)

### DIFF
--- a/packages/kit/src/views/Prime/pages/OneKeyId/index.tsx
+++ b/packages/kit/src/views/Prime/pages/OneKeyId/index.tsx
@@ -39,15 +39,20 @@ function OneKeyIdPage() {
   const logoutRef = useRef<() => Promise<void>>(logout);
   const isFocused = useRouteIsFocused();
 
-  const toPrimePage = useCallback(async () => {
+  const toPrimePage = useCallback(() => {
     if (isPrimeAvailable) {
       if (platformEnv.isNative) {
         navigation.popStack();
-        await timerUtils.wait(600);
+        requestIdleCallback(() => {
+          navigation.pushFullModal(EModalRoutes.PrimeModal, {
+            screen: EPrimePages.PrimeDashboard,
+          });
+        });
+      } else {
+        navigation.pushFullModal(EModalRoutes.PrimeModal, {
+          screen: EPrimePages.PrimeDashboard,
+        });
       }
-      navigation.pushFullModal(EModalRoutes.PrimeModal, {
-        screen: EPrimePages.PrimeDashboard,
-      });
     }
   }, [navigation, isPrimeAvailable]);
 

--- a/packages/kit/src/views/ScanQrCode/hooks/useParseQRCode.tsx
+++ b/packages/kit/src/views/ScanQrCode/hooks/useParseQRCode.tsx
@@ -159,7 +159,13 @@ const useParseQRCode = () => {
       const closeScanPage = async () => {
         if (popNavigation) {
           popNavigation();
-          await timerUtils.wait(platformEnv.isNative ? 1200 : 250);
+          if (platformEnv.isNative) {
+            await new Promise<void>((resolve) => {
+              requestIdleCallback(() => resolve());
+            });
+          } else {
+            await timerUtils.wait(250);
+          }
         }
       };
 
@@ -227,7 +233,13 @@ const useParseQRCode = () => {
           {
             const primeTransferData = result.data as IPrimeTransferValue;
             await closeScanPage();
-            await timerUtils.wait(600);
+            if (platformEnv.isNative) {
+              await new Promise<void>((resolve) => {
+                requestIdleCallback(() => resolve());
+              });
+            } else {
+              await timerUtils.wait(600);
+            }
             navigation.pushModal(EModalRoutes.PrimeModal, {
               screen: EPrimePages.PrimeTransfer,
               params: {


### PR DESCRIPTION
## Summary
- Replace hardcoded `timerUtils.wait` delays with `requestIdleCallback` on native to fix navigation freeze in iOS TestFlight (release) builds
- In release builds, `setTimeout` callbacks don't properly wake the iOS CFRunLoop, causing navigation UI to freeze until the next user touch
- Only native (iOS/Android) behavior is changed; web, extension, and desktop remain identical

## Changes
- **OneKeyId/index.tsx**: `toPrimePage` uses `requestIdleCallback` after `popStack()` instead of `timerUtils.wait(600)`
- **useParseQRCode.tsx**: `closeScanPage` uses `requestIdleCallback` on native instead of `timerUtils.wait(1200)`, and `PRIME_TRANSFER` case uses `requestIdleCallback` instead of `timerUtils.wait(600)`

## Test plan
- [ ] iOS TestFlight: Tap OneKey Prime button → should navigate immediately without needing extra touch
- [ ] iOS TestFlight: Scan QR code for Prime Transfer → should navigate immediately
- [ ] iOS Simulator: Same flows should still work as before
- [ ] Android: Same flows should still work as before
- [ ] Web/Extension/Desktop: No behavior change expected, verify navigation still works
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
