### PR TITLE
feat: add Cancel All Orders and token filter for mobile open orders

### DIFF
--- a/packages/kit/src/states/jotai/contexts/hyperliquid/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/atoms.ts
@@ -160,6 +160,11 @@ export const {
   use: usePositionFilterByCurrentTokenAtom,
 } = contextAtom<boolean>(false);
 
+export const {
+  atom: orderFilterByCurrentTokenAtom,
+  use: useOrderFilterByCurrentTokenAtom,
+} = contextAtom<boolean>(false);
+
 export type IPerpsActiveOpenOrdersAtom = {
   accountAddress: string | undefined;
   openOrders: HL.IPerpsFrontendOrder[];

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/CancelAllOrdersModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/CancelAllOrdersModal.tsx
@@ -17,13 +17,25 @@ import { TradingGuardWrapper } from '../TradingGuardWrapper';
 
 interface ICancelAllOrdersContentProps {
   onClose?: () => void;
+  filterByCoin?: string;
 }
 
-function CancelAllOrdersContent({ onClose }: ICancelAllOrdersContentProps) {
+function CancelAllOrdersContent({
+  onClose,
+  filterByCoin,
+}: ICancelAllOrdersContentProps) {
   const actions = useHyperliquidActions();
   const intl = useIntl();
   const [{ openOrders }] = usePerpsActiveOpenOrdersAtom();
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const ordersToProcess = useMemo(
+    () =>
+      filterByCoin
+        ? openOrders.filter((o) => o.coin === filterByCoin)
+        : openOrders,
+    [openOrders, filterByCoin],
+  );
 
   const handleConfirm = useCallback(async () => {
     if (isSubmitting) return;
@@ -33,9 +45,9 @@ function CancelAllOrdersContent({ onClose }: ICancelAllOrdersContentProps) {
       await actions.current.ensureTradingEnabled();
       const symbolsMetaMap =
         await backgroundApiProxy.serviceHyperliquid.getSymbolsMetaMap({
-          coins: openOrders.map((o) => o.coin),
+          coins: ordersToProcess.map((o) => o.coin),
         });
-      const ordersToCancel = openOrders
+      const ordersToCancel = ordersToProcess
         .map((order) => {
           const tokenInfo = symbolsMetaMap[order.coin];
           if (!tokenInfo || isNil(tokenInfo?.assetId)) {
@@ -62,7 +74,7 @@ function CancelAllOrdersContent({ onClose }: ICancelAllOrdersContentProps) {
     } finally {
       setIsSubmitting(false);
     }
-  }, [actions, isSubmitting, onClose, openOrders]);
+  }, [actions, isSubmitting, onClose, ordersToProcess]);
 
   const buttonText = useMemo(() => {
     if (isSubmitting) {
@@ -99,7 +111,7 @@ function CancelAllOrdersContent({ onClose }: ICancelAllOrdersContentProps) {
   );
 }
 
-export function showCancelAllOrdersDialog() {
+export function showCancelAllOrdersDialog(filterByCoin?: string) {
   const dialogInstance = Dialog.show({
     title: appLocale.intl.formatMessage({
       id: ETranslations.perp_cacenl_all_order_title,
@@ -110,6 +122,7 @@ export function showCancelAllOrdersDialog() {
           onClose={() => {
             void dialogInstance.close();
           }}
+          filterByCoin={filterByCoin}
         />
       </PerpsProviderMirror>
     ),

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/MobileOpenOrdersListHeader.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/MobileOpenOrdersListHeader.tsx
@@ -3,28 +3,28 @@ import { useCallback } from 'react';
 import { useIntl } from 'react-intl';
 
 import { Button, Checkbox, SizableText, XStack } from '@onekeyhq/components';
-import { usePositionFilterByCurrentTokenAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
+import { useOrderFilterByCurrentTokenAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
 import { usePerpsActiveAssetAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
-import { showCloseAllPositionsDialog } from '../CloseAllPositionsModal';
+import { showCancelAllOrdersDialog } from '../CancelAllOrdersModal';
 
-interface IMobilePositionsListHeaderProps {
-  totalPositionCount: number;
-  filteredPositionCount: number;
+interface IMobileOpenOrdersListHeaderProps {
+  totalOrderCount: number;
+  filteredOrderCount: number;
 }
 
-export function MobilePositionsListHeader({
-  totalPositionCount,
-  filteredPositionCount,
-}: IMobilePositionsListHeaderProps) {
+export function MobileOpenOrdersListHeader({
+  totalOrderCount,
+  filteredOrderCount,
+}: IMobileOpenOrdersListHeaderProps) {
   const intl = useIntl();
   const [filterByCurrentToken, setFilterByCurrentToken] =
-    usePositionFilterByCurrentTokenAtom();
+    useOrderFilterByCurrentTokenAtom();
   const [activeAsset] = usePerpsActiveAssetAtom();
 
-  const handleCloseAll = useCallback(() => {
-    void showCloseAllPositionsDialog(
+  const handleCancelAll = useCallback(() => {
+    void showCancelAllOrdersDialog(
       filterByCurrentToken ? activeAsset?.coin : undefined,
     );
   }, [filterByCurrentToken, activeAsset?.coin]);
@@ -36,8 +36,8 @@ export function MobilePositionsListHeader({
     [setFilterByCurrentToken],
   );
 
-  // Early return when no positions exist
-  if (totalPositionCount === 0) {
+  // Early return when no orders exist
+  if (totalOrderCount === 0) {
     return null;
   }
 
@@ -62,15 +62,17 @@ export function MobilePositionsListHeader({
         onChange={handleFilterChange}
       />
 
-      {/* Right: Close all button - disabled only when no positions to close */}
+      {/* Right: Cancel all button - disabled only when no orders to cancel */}
       <Button
         size="small"
         variant="secondary"
-        disabled={filteredPositionCount === 0}
-        onPress={handleCloseAll}
+        disabled={filteredOrderCount === 0}
+        onPress={handleCancelAll}
       >
         <SizableText size="$bodyXs">
-          {intl.formatMessage({ id: ETranslations.perp_position_close })}
+          {intl.formatMessage({
+            id: ETranslations.perp_open_orders_cancel_all,
+          })}
         </SizableText>
       </Button>
     </XStack>

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpOpenOrdersList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpOpenOrdersList.tsx
@@ -6,12 +6,19 @@ import { useIntl } from 'react-intl';
 import type { IDebugRenderTrackerProps } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
-import { usePerpsActiveOpenOrdersAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
-import { usePerpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  useOrderFilterByCurrentTokenAtom,
+  usePerpsActiveOpenOrdersAtom,
+} from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
+import {
+  usePerpsActiveAccountAtom,
+  usePerpsActiveAssetAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IPerpsFrontendOrder } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
 import { showCancelAllOrdersDialog } from '../CancelAllOrdersModal';
+import { MobileOpenOrdersListHeader } from '../Components/MobileOpenOrdersListHeader';
 import { OpenOrdersRow } from '../Components/OpenOrdersRow';
 
 import { CommonTableListView, type IColumnConfig } from './CommonTableListView';
@@ -30,12 +37,24 @@ function PerpOpenOrdersList({
   const intl = useIntl();
   const [{ openOrders }] = usePerpsActiveOpenOrdersAtom();
   const [currentUser] = usePerpsActiveAccountAtom();
+  const [filterByCurrentToken] = useOrderFilterByCurrentTokenAtom();
+  const [activeAsset] = usePerpsActiveAssetAtom();
   const actions = useHyperliquidActions();
   const [currentListPage, setCurrentListPage] = useState(1);
   useEffect(() => {
     noop(currentUser?.accountAddress);
     setCurrentListPage(1);
   }, [currentUser?.accountAddress]);
+  useEffect(() => {
+    setCurrentListPage(1);
+  }, [filterByCurrentToken, activeAsset?.coin]);
+
+  const filteredOrders = useMemo(() => {
+    if (!isMobile || !filterByCurrentToken || !activeAsset?.coin) {
+      return openOrders;
+    }
+    return openOrders.filter((order) => order.coin === activeAsset.coin);
+  }, [openOrders, isMobile, filterByCurrentToken, activeAsset?.coin]);
 
   const columnsConfig: IColumnConfig[] = useMemo(
     () => [
@@ -200,7 +219,7 @@ function PerpOpenOrdersList({
       setCurrentListPage={setCurrentListPage}
       columns={columnsConfig}
       minTableWidth={totalMinWidth}
-      data={openOrders}
+      data={filteredOrders}
       isMobile={isMobile}
       renderRow={renderOrderRow}
       emptyMessage={intl.formatMessage({
@@ -209,6 +228,14 @@ function PerpOpenOrdersList({
       emptySubMessage={intl.formatMessage({
         id: ETranslations.perp_open_order_empty_desc,
       })}
+      ListHeaderComponent={
+        isMobile ? (
+          <MobileOpenOrdersListHeader
+            totalOrderCount={openOrders.length}
+            filteredOrderCount={filteredOrders.length}
+          />
+        ) : null
+      }
     />
   );
 }


### PR DESCRIPTION
## Summary
- Add **Cancel All** button to mobile open orders list (parity with desktop)
- Add **token filter checkbox** ("Hide other symbols") to mobile open orders, consistent with the positions list
- Support `filterByCoin` in `CancelAllOrdersModal` so Cancel All only cancels visible orders when filter is active
- Remove redundant `isAgentReady` disabled check from `MobilePositionsListHeader` (already guarded by `TradingGuardWrapper` inside the dialog)
- Reset pagination to page 1 when filter state changes

## Files changed
| File | Change |
|------|--------|
| `atoms.ts` | New `orderFilterByCurrentTokenAtom` context atom |
| `MobileOpenOrdersListHeader.tsx` | **New** — filter checkbox + Cancel All button |
| `MobilePositionsListHeader.tsx` | Remove unused `isAgentReady` import/logic |
| `CancelAllOrdersModal.tsx` | Add `filterByCoin` param to scope cancellation |
| `PerpOpenOrdersList.tsx` | Integrate filter, header, and pagination reset |

## Test plan
- [ ] Mobile, has open orders → header shows checkbox + "Cancel All" button
- [ ] Mobile, check "Hide other symbols" → only current token orders shown, Cancel All only cancels those
- [ ] Mobile, uncheck filter → all orders shown, Cancel All cancels all
- [ ] Mobile, no open orders → header hidden
- [ ] Mobile, trading not enabled → tap Cancel All → dialog shows "Enable Trading" via TradingGuardWrapper
- [ ] Mobile, filter on + switch pages → page resets to 1 when filter toggles
- [ ] Desktop → no behavior change (header only renders on mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
