### PR TITLE
fix: exclude modal screens from Windows title bar padding OK-50307

### DIFF
--- a/packages/components/src/layouts/Navigation/Header/HeaderView.tsx
+++ b/packages/components/src/layouts/Navigation/Header/HeaderView.tsx
@@ -203,7 +203,9 @@ function HeaderView({
           alignSelf="stretch"
           px={isOnboardingScreen ? '$16' : '$5'}
           pr={
-            platformEnv.isDesktopWin && !isOnboardingScreen
+            platformEnv.isDesktopWin &&
+            !isOnboardingScreen &&
+            !isModelScreen
               ? WINDOWS_OVERLAY_BUTTONS_WIDTH
               : undefined
           }


### PR DESCRIPTION
## Summary
- On Windows desktop, the header applies right padding (`WINDOWS_OVERLAY_BUTTONS_WIDTH`) to avoid overlapping with the title bar control buttons (minimize/maximize/close)
- This padding was incorrectly applied to **modal** screens as well, causing the headerRight content (e.g. Edit button) to not align to the far right edge
- Added `!isModelScreen` check so the padding is only applied to non-modal pages where the header actually overlaps with window controls

## Test plan
- [ ] Open "Recently closed" modal on Windows desktop — verify "Edit" button is aligned to the far right
- [ ] Verify non-modal page headers on Windows still have correct padding for title bar controls
- [ ] Verify no regression on macOS desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
