### PR TITLE
fix: enable pull-to-refresh from tab header on native OK-50223

### DIFF
--- a/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.native.tsx
+++ b/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.native.tsx
@@ -4,6 +4,7 @@ import { useContext, useMemo } from 'react';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   cancelAnimation,
+  runOnJS,
   scrollTo,
   useAnimatedReaction,
   useSharedValue,
@@ -12,7 +13,14 @@ import Animated, {
 
 import { CollapsibleTabContext } from './CollapsibleTabContext';
 
-export function HeaderScrollGestureWrapper({ children }: PropsWithChildren) {
+import type { IHeaderScrollGestureWrapperProps } from './HeaderScrollGestureWrapper';
+
+const REFRESH_THRESHOLD = 80;
+
+export function HeaderScrollGestureWrapper({
+  children,
+  onRefresh,
+}: PropsWithChildren<IHeaderScrollGestureWrapperProps>) {
   const tabsContext = useContext(CollapsibleTabContext);
   const refMap = tabsContext?.refMap;
   const focusedTab = tabsContext?.focusedTab;
@@ -50,11 +58,17 @@ export function HeaderScrollGestureWrapper({ children }: PropsWithChildren) {
         })
         .onEnd((e) => {
           'worklet';
-          targetScrollY.value = withDecay({
-            velocity: -e.velocityY,
-          });
+          const wasAtTop = startScrollY.value <= contentInset;
+          const pulledDown = e.translationY > REFRESH_THRESHOLD;
+          if (wasAtTop && pulledDown && onRefresh) {
+            runOnJS(onRefresh)();
+          } else {
+            targetScrollY.value = withDecay({
+              velocity: -e.velocityY,
+            });
+          }
         }),
-    [startScrollY, scrollYCurrent, targetScrollY],
+    [startScrollY, scrollYCurrent, targetScrollY, contentInset, onRefresh],
   );
 
   return (

--- a/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.tsx
+++ b/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.tsx
@@ -1,5 +1,11 @@
 import type { PropsWithChildren } from 'react';
 
-export function HeaderScrollGestureWrapper({ children }: PropsWithChildren) {
+export interface IHeaderScrollGestureWrapperProps {
+  onRefresh?: () => void;
+}
+
+export function HeaderScrollGestureWrapper({
+  children,
+}: PropsWithChildren<IHeaderScrollGestureWrapperProps>) {
   return children;
 }

--- a/packages/kit/src/views/Home/pages/HomeHeaderContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeHeaderContainer.tsx
@@ -12,6 +12,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { useActiveAccount } from '../../../states/jotai/contexts/accountSelector';
 import { HomeTokenListProviderMirror } from '../components/HomeTokenListProvider/HomeTokenListProviderMirror';
 import ReferralCodeBlock from '../components/NotBakcedUp/ReferralCodeBlock';
+import { onHomePageRefresh } from '../components/PullToRefresh';
 import { ReceiveInfo } from '../components/ReceiveInfo';
 import { WalletActions } from '../components/WalletActions';
 import WalletBanner from '../components/WalletBanner';
@@ -55,10 +56,10 @@ function BaseHomeHeaderContainer() {
           bg="$bgApp"
           pointerEvents="box-none"
         >
-          <HeaderScrollGestureWrapper>
+          <HeaderScrollGestureWrapper onRefresh={onHomePageRefresh}>
             <ReceiveInfo setShowReceiveInfo={setShowReceiveInfo} />
           </HeaderScrollGestureWrapper>
-          <HeaderScrollGestureWrapper>
+          <HeaderScrollGestureWrapper onRefresh={onHomePageRefresh}>
             <ReferralCodeBlock
               setShowReferralCodeBlock={setShowReferralCodeBlock}
             />
@@ -122,13 +123,13 @@ function BaseHomeHeaderContainer() {
           bg="$bgApp"
           pointerEvents="box-none"
         >
-          <HeaderScrollGestureWrapper>
+          <HeaderScrollGestureWrapper onRefresh={onHomePageRefresh}>
             <Stack gap="$2.5">
               <HomeOverviewContainer />
             </Stack>
           </HeaderScrollGestureWrapper>
           {isWalletNotBackedUp ? null : (
-            <HeaderScrollGestureWrapper>
+            <HeaderScrollGestureWrapper onRefresh={onHomePageRefresh}>
               <WalletActions />
             </HeaderScrollGestureWrapper>
           )}


### PR DESCRIPTION
## Summary
- On mobile, only the token list (tab content) at the bottom supported pull-to-refresh. The header area (balance overview, wallet actions, banners) did not trigger refresh when pulled down
- On small screen devices (e.g. iPhone 7/SE), the header takes up ~70% of the screen, making it nearly impossible to refresh
- Added `onRefresh` prop to `HeaderScrollGestureWrapper` so that pulling down on the header while already at the top triggers a page refresh
- Only affects native platforms — web version remains unchanged

## Test plan
- [ ] On iOS (small screen device or simulator), pull down on the header area — verify it triggers a page refresh
- [ ] On Android, verify pull-to-refresh still works from both header and content areas
- [ ] Verify normal header scroll behavior (scrolling up to collapse header) is not affected
- [ ] Verify web/desktop is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
