### PR TITLE
fix: close ScanQrCode modal and ActionCenter pages reliably on native-stack(OK-49762)

### DIFF
--- a/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
@@ -28,7 +28,7 @@ import type {
   ETabRoutes,
   ITabStackParamList,
 } from '@onekeyhq/shared/src/routes';
-import { ERootRoutes } from '@onekeyhq/shared/src/routes';
+import { EModalRoutes, ERootRoutes } from '@onekeyhq/shared/src/routes';
 import mmkvStorageInstance from '@onekeyhq/shared/src/storage/instance/mmkvStorageInstance';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
@@ -173,6 +173,44 @@ export const popToMainRoute = async (maxRetryTimes = 99) => {
   }
   await timerUtils.wait(150);
   await popToMainRoute(maxRetryTimes - 1);
+};
+
+export const popScanModalPages = async (maxRetryTimes = 99) => {
+  if (maxRetryTimes <= 0) {
+    return;
+  }
+  const rootState = rootNavigationRef.current?.getRootState();
+  const currentRoute = rootState?.routes?.[rootState.index];
+  if (currentRoute?.name !== ERootRoutes.Modal) {
+    return;
+  }
+  const screenName =
+    (currentRoute?.params as { screen?: string })?.screen ||
+    currentRoute?.state?.routes?.[currentRoute?.state?.index || 0]?.name;
+  if (screenName !== EModalRoutes.ScanQrCodeModal) {
+    return;
+  }
+  if (rootNavigationRef.current?.canGoBack?.()) {
+    rootNavigationRef.current?.goBack();
+  }
+  await timerUtils.wait(350);
+  await popScanModalPages(maxRetryTimes - 1);
+};
+
+export const popActionCenterPages = async (maxRetryTimes = 99) => {
+  if (maxRetryTimes <= 0) {
+    return;
+  }
+  const rootState = rootNavigationRef.current?.getRootState();
+  const currentRoute = rootState?.routes?.[rootState.index];
+  if (currentRoute?.name !== ERootRoutes.FullScreenPush) {
+    return;
+  }
+  if (rootNavigationRef.current?.canGoBack?.()) {
+    rootNavigationRef.current?.goBack();
+  }
+  await timerUtils.wait(350);
+  await popActionCenterPages(maxRetryTimes - 1);
 };
 
 export const popToTabRootScreen = async () => {

--- a/packages/kit-bg/src/services/ServiceScanQRCode/utils/parseQRCode/type.ts
+++ b/packages/kit-bg/src/services/ServiceScanQRCode/utils/parseQRCode/type.ts
@@ -119,7 +119,7 @@ export type IQRCodeHandlerParseOutsideOptions = {
   handlers?: EQRCodeHandlerNames[];
   defaultHandler?: (value: string) => void;
   autoHandleResult?: boolean;
-  popNavigation?: () => void;
+  popNavigation?: boolean;
   account?: INetworkAccount;
   network?: IServerNetwork;
   wallet?: IDBWallet;

--- a/packages/kit/src/views/Prime/pages/OneKeyId/index.tsx
+++ b/packages/kit/src/views/Prime/pages/OneKeyId/index.tsx
@@ -11,6 +11,7 @@ import {
   Stack,
   XStack,
   YStack,
+  popToMainRoute,
   useUpdateEffect,
 } from '@onekeyhq/components';
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
@@ -39,14 +40,13 @@ function OneKeyIdPage() {
   const logoutRef = useRef<() => Promise<void>>(logout);
   const isFocused = useRouteIsFocused();
 
-  const toPrimePage = useCallback(() => {
+  const toPrimePage = useCallback(async () => {
     if (isPrimeAvailable) {
       if (platformEnv.isNative) {
-        navigation.popStack();
-        requestIdleCallback(() => {
-          navigation.pushFullModal(EModalRoutes.PrimeModal, {
-            screen: EPrimePages.PrimeDashboard,
-          });
+        await popToMainRoute()
+        await timerUtils.wait(350)
+        navigation.pushFullModal(EModalRoutes.PrimeModal, {
+          screen: EPrimePages.PrimeDashboard,
         });
       } else {
         navigation.pushFullModal(EModalRoutes.PrimeModal, {

--- a/packages/kit/src/views/Prime/pages/OneKeyId/index.tsx
+++ b/packages/kit/src/views/Prime/pages/OneKeyId/index.tsx
@@ -43,8 +43,8 @@ function OneKeyIdPage() {
   const toPrimePage = useCallback(async () => {
     if (isPrimeAvailable) {
       if (platformEnv.isNative) {
-        await popToMainRoute()
-        await timerUtils.wait(350)
+        await popToMainRoute();
+        await timerUtils.wait(350);
         navigation.pushFullModal(EModalRoutes.PrimeModal, {
           screen: EPrimePages.PrimeDashboard,
         });

--- a/packages/kit/src/views/ScanQrCode/hooks/useParseQRCode.tsx
+++ b/packages/kit/src/views/ScanQrCode/hooks/useParseQRCode.tsx
@@ -8,6 +8,7 @@ import {
   Stack,
   Toast,
   ToastContent,
+  rootNavigationRef,
   useClipboard,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
@@ -32,6 +33,7 @@ import {
   EModalSettingRoutes,
   EModalSignatureConfirmRoutes,
   EOnboardingPages,
+  ERootRoutes,
 } from '@onekeyhq/shared/src/routes';
 import { EPrimePages } from '@onekeyhq/shared/src/routes/prime';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
@@ -156,16 +158,37 @@ const useParseQRCode = () => {
       }
       const { defaultHandler, popNavigation, ...options } = params;
 
-      const closeScanPage = async () => {
-        if (popNavigation) {
-          popNavigation();
-          if (platformEnv.isNative) {
-            await new Promise<void>((resolve) => {
-              requestIdleCallback(() => resolve());
-            });
-          } else {
-            await timerUtils.wait(250);
+      const closeScanPage = async (maxRetryTimes = 99) => {
+        if (maxRetryTimes <= 0) {
+          return;
+        }
+        const rootState = rootNavigationRef.current?.getRootState();
+        const currentRoute = rootState?.routes?.[rootState.index];
+
+        const isScanModal = (() => {
+          if (currentRoute?.name !== ERootRoutes.Modal) return false;
+          const screenName =
+            (currentRoute?.params as { screen?: string })?.screen ||
+            currentRoute?.state?.routes?.[
+              currentRoute?.state?.index || 0
+            ]?.name;
+          return screenName === EModalRoutes.ScanQrCodeModal;
+        })();
+
+        const isFullScreenPush =
+          currentRoute?.name === ERootRoutes.FullScreenPush;
+
+        // Only close ScanQrCode modal and ActionCenter (FullScreenPush), leave other routes untouched.
+        // Recursive goBack() is needed because on native-stack a single goBack() gets consumed
+        // by nested navigators without actually popping the root-level route.
+        if (isScanModal || isFullScreenPush) {
+          if (rootNavigationRef.current?.canGoBack?.()) {
+            rootNavigationRef.current?.goBack();
           }
+          await timerUtils.wait(150);
+          await closeScanPage(maxRetryTimes - 1);
+        } else {
+          await timerUtils.wait(350);
         }
       };
 

--- a/packages/kit/src/views/ScanQrCode/hooks/useParseQRCode.tsx
+++ b/packages/kit/src/views/ScanQrCode/hooks/useParseQRCode.tsx
@@ -8,7 +8,8 @@ import {
   Stack,
   Toast,
   ToastContent,
-  rootNavigationRef,
+  popActionCenterPages,
+  popScanModalPages,
   useClipboard,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
@@ -33,7 +34,6 @@ import {
   EModalSettingRoutes,
   EModalSignatureConfirmRoutes,
   EOnboardingPages,
-  ERootRoutes,
 } from '@onekeyhq/shared/src/routes';
 import { EPrimePages } from '@onekeyhq/shared/src/routes/prime';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
@@ -158,36 +158,10 @@ const useParseQRCode = () => {
       }
       const { defaultHandler, popNavigation, ...options } = params;
 
-      const closeScanPage = async (maxRetryTimes = 99) => {
-        if (maxRetryTimes <= 0) {
-          return;
-        }
-        const rootState = rootNavigationRef.current?.getRootState();
-        const currentRoute = rootState?.routes?.[rootState.index];
-
-        const isScanModal = (() => {
-          if (currentRoute?.name !== ERootRoutes.Modal) return false;
-          const screenName =
-            (currentRoute?.params as { screen?: string })?.screen ||
-            currentRoute?.state?.routes?.[
-              currentRoute?.state?.index || 0
-            ]?.name;
-          return screenName === EModalRoutes.ScanQrCodeModal;
-        })();
-
-        const isFullScreenPush =
-          currentRoute?.name === ERootRoutes.FullScreenPush;
-
-        // Only close ScanQrCode modal and ActionCenter (FullScreenPush), leave other routes untouched.
-        // Recursive goBack() is needed because on native-stack a single goBack() gets consumed
-        // by nested navigators without actually popping the root-level route.
-        if (isScanModal || isFullScreenPush) {
-          if (rootNavigationRef.current?.canGoBack?.()) {
-            rootNavigationRef.current?.goBack();
-          }
-          await timerUtils.wait(150);
-          await closeScanPage(maxRetryTimes - 1);
-        } else {
+      const closeScanPage = async () => {
+        if (popNavigation) {
+          await popScanModalPages();
+          await popActionCenterPages();
           await timerUtils.wait(350);
         }
       };

--- a/packages/kit/src/views/ScanQrCode/pages/ScanQrCodeModal.tsx
+++ b/packages/kit/src/views/ScanQrCode/pages/ScanQrCodeModal.tsx
@@ -211,13 +211,7 @@ export default function ScanQrCodeModal() {
   const navigation = useAppNavigation();
 
   const callback = useCallback(
-    async ({
-      value,
-      popNavigation,
-    }: {
-      value: string;
-      popNavigation: () => void;
-    }) => {
+    async (value: string) => {
       if (process.env.NODE_ENV !== 'production') {
         if (value) {
           appStorage.syncStorage.set(
@@ -227,14 +221,10 @@ export default function ScanQrCodeModal() {
         }
       }
 
-      return routeCallback({ value, popNavigation });
+      return routeCallback({ value, popNavigation: true });
     },
     [routeCallback],
   );
-
-  const popNavigation = useCallback(() => {
-    navigation.pop();
-  }, [navigation]);
 
   const isPickedImage = useRef(false);
 
@@ -254,7 +244,7 @@ export default function ScanQrCodeModal() {
       }
       if (data && data.length > 0) {
         isPickedImage.current = true;
-        await callback({ value: data, popNavigation });
+        await callback(data);
       } else {
         Toast.error({
           title: intl.formatMessage({
@@ -267,7 +257,7 @@ export default function ScanQrCodeModal() {
         data,
       );
     }
-  }, [callback, intl, popNavigation]);
+  }, [callback, intl]);
 
   const onCameraScanned = useCallback(
     async (value: string) => {
@@ -275,10 +265,10 @@ export default function ScanQrCodeModal() {
         return {};
       }
       defaultLogger.scanQrCode.readQrCode.readFromCamera(value);
-      const result = await callback({ value, popNavigation });
+      const result = await callback(value);
       return result;
     },
-    [callback, popNavigation],
+    [callback],
   );
 
   const headerRightCall = useCallback(
@@ -340,7 +330,7 @@ export default function ScanQrCodeModal() {
         />
       </Page.Body>
       <Page.Footer>
-        <DebugInput onText={(value) => callback({ value, popNavigation })} />
+        <DebugInput onText={(value) => callback(value)} />
       </Page.Footer>
     </Page>
   );

--- a/packages/kit/src/views/ScanQrCode/pages/ScanQrCodeModal.tsx
+++ b/packages/kit/src/views/ScanQrCode/pages/ScanQrCodeModal.tsx
@@ -31,6 +31,7 @@ import appStorage from '@onekeyhq/shared/src/storage/appStorage';
 import { EAppSyncStorageKeys } from '@onekeyhq/shared/src/storage/syncStorage';
 
 import { MultipleClickStack } from '../../../components/MultipleClickStack';
+import useAppNavigation from '../../../hooks/useAppNavigation';
 import { ScanQrCode } from '../components';
 import { scanFromURLAsync } from '../utils/scanFromURLAsync';
 

--- a/packages/kit/src/views/ScanQrCode/pages/ScanQrCodeModal.tsx
+++ b/packages/kit/src/views/ScanQrCode/pages/ScanQrCodeModal.tsx
@@ -31,7 +31,6 @@ import appStorage from '@onekeyhq/shared/src/storage/appStorage';
 import { EAppSyncStorageKeys } from '@onekeyhq/shared/src/storage/syncStorage';
 
 import { MultipleClickStack } from '../../../components/MultipleClickStack';
-import useAppNavigation from '../../../hooks/useAppNavigation';
 import { ScanQrCode } from '../components';
 import { scanFromURLAsync } from '../utils/scanFromURLAsync';
 
@@ -207,8 +206,6 @@ export default function ScanQrCodeModal() {
     qrWalletScene,
     showProTutorial,
   } = route.params;
-
-  const navigation = useAppNavigation();
 
   const callback = useCallback(
     async (value: string) => {

--- a/packages/shared/src/routes/scanQrCode.ts
+++ b/packages/shared/src/routes/scanQrCode.ts
@@ -6,7 +6,7 @@ export type IScanQrCodeModalParamList = {
   [EScanQrCodeModalPages.ScanQrCodeStack]: {
     callback: (params: {
       value: string;
-      popNavigation: () => void;
+      popNavigation: boolean;
     }) => Promise<{ progress?: number }>;
     qrWalletScene?: boolean;
     showProTutorial?: boolean;


### PR DESCRIPTION
## Summary
- Extract `popScanModalPages` and `popActionCenterPages` as reusable recursive navigation utilities in `NavigationContainer.tsx`, alongside `popToMainRoute`
- `popScanModalPages` recursively calls `goBack()` while the top route is a Modal with `ScanQrCodeModal` screen
- `popActionCenterPages` recursively calls `goBack()` while the top route is `FullScreenPush` (ActionCenter)
- Simplify `closeScanPage` in `useParseQRCode` to compose both functions sequentially
- Fix OneKeyId page navigation to Prime dashboard using `popToMainRoute` instead of `popStack`

## Background
On native-stack, a single `goBack()` gets consumed by nested navigators (RootModalNavigator / ModalFlowNavigator) without actually popping the root-level route. The recursive retry approach with delays ensures root routes are reliably dismissed.

## Test plan
- [ ] Open ScanQrCode from ActionCenter, scan a valid QR code → verify both scan modal and ActionCenter are closed before navigating to the result page
- [ ] Open ScanQrCode directly (not from ActionCenter), scan a valid QR code → verify scan modal is closed normally
- [ ] Navigate to OneKeyId page and tap to go to Prime dashboard → verify navigation works correctly on native
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
