### PR TITLE
fix: disable font scaling for text components on native(OK-50337)

### DIFF
--- a/packages/components/src/primitives/Heading/index.tsx
+++ b/packages/components/src/primitives/Heading/index.tsx
@@ -3,7 +3,9 @@ import { Heading as TamaguiHeading } from '@tamagui/text';
 import { type HeadingProps } from '@onekeyhq/components/src/shared/tamagui';
 
 export function Heading(props: HeadingProps) {
-  return <TamaguiHeading {...props} allowFontScaling={false} />;
+  return (
+    <TamaguiHeading {...props} allowFontScaling={false} maxFontSizeMultiplier={1} />
+  );
 }
 
 export type IHeadingProps = HeadingProps;

--- a/packages/components/src/primitives/Heading/index.tsx
+++ b/packages/components/src/primitives/Heading/index.tsx
@@ -4,7 +4,11 @@ import { type HeadingProps } from '@onekeyhq/components/src/shared/tamagui';
 
 export function Heading(props: HeadingProps) {
   return (
-    <TamaguiHeading {...props} allowFontScaling={false} maxFontSizeMultiplier={1} />
+    <TamaguiHeading
+      {...props}
+      allowFontScaling={false}
+      maxFontSizeMultiplier={1}
+    />
   );
 }
 

--- a/packages/components/src/primitives/Label/index.tsx
+++ b/packages/components/src/primitives/Label/index.tsx
@@ -14,6 +14,7 @@ export type ILabelProps = Omit<GetProps<typeof TMLabel>, 'variant'> & {
 export const Label = styled(TMLabel, {
   unstyled: true,
   color: '$text',
+  allowFontScaling: false,
   variants: {
     variant: {
       ':string': (variant, { font }) => {

--- a/packages/components/src/primitives/SizeableText/index.tsx
+++ b/packages/components/src/primitives/SizeableText/index.tsx
@@ -5,7 +5,14 @@ import { type SizableTextProps } from '@onekeyhq/components/src/shared/tamagui';
 export const StyledSizableText = TamaguiSizableText;
 
 export function SizableText({ size = '$bodyMd', ...props }: SizableTextProps) {
-  return <StyledSizableText allowFontScaling={false} size={size} {...props} />;
+  return (
+    <StyledSizableText
+      allowFontScaling={false}
+      maxFontSizeMultiplier={1}
+      size={size}
+      {...props}
+    />
+  );
 }
 
 export type ISizableTextProps = SizableTextProps;

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/LineNumberedTextArea.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/LineNumberedTextArea.tsx
@@ -412,6 +412,7 @@ function LineNumberedTextArea({
                 placeholder={platformEnv.isNative ? placeholder : undefined}
                 placeholderTextColor={placeholderColor}
                 allowFontScaling={false}
+                maxFontSizeMultiplier={1}
                 onFocus={handleFocus}
                 onChange={() => {
                   onInputTypeChange?.(EInputAddressChangeType.Manual);


### PR DESCRIPTION
## Summary
- Added `allowFontScaling: false` to `Label` component which was missing it entirely, causing form field labels (e.g. "接收地址") to scale with system font size on native
- Added `maxFontSizeMultiplier={1}` to `SizableText`, `Heading`, and `LineNumberedTextArea`'s `RNTextInput` as additional safeguard for React Native new architecture (Fabric)

## Test plan
- [ ] Set iOS system font to extra large (Settings > Display & Brightness > Text Size)
- [ ] Open Batch Transfer (批量转账) page
- [ ] Verify "接收地址" label does NOT scale with system font
- [ ] Verify address input text does NOT scale with system font
- [ ] Verify line numbers do NOT scale with system font
- [ ] Check other pages with `Label`, `SizableText`, and `Heading` components for consistent behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
