### PR TITLE
fix(home): replace market cap with 24h turnover in wallet favorites OK-50370

### DIFF
--- a/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
@@ -69,10 +69,10 @@ interface IFavoriteTokenDisplay {
   price: number;
   priceChange24h: number;
   marketCap: number;
+  volume24h: number;
   // Perps fields — present when perpsCoin is set
   perpsCoin?: string;
   maxLeverage?: number;
-  volume24h?: number;
 }
 
 function RecommendCardItem({
@@ -283,8 +283,8 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
           },
         },
         {
-          dataIndex: 'marketCap',
-          title: intl.formatMessage({ id: ETranslations.global_market_cap }),
+          dataIndex: 'volume24h',
+          title: intl.formatMessage({ id: ETranslations.market_24h_turnover }),
           render: (_: unknown, record: IFavoriteTokenDisplay) => (
             <NumberSizeableText
               size="$bodyLgMedium"
@@ -293,11 +293,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
                 currency: record.perpsCoin ? '$' : currencyInfo?.symbol,
               }}
             >
-              {record.perpsCoin
-                ? (record.volume24h ?? '-')
-                : new BigNumber(record.marketCap).isNaN()
-                  ? '-'
-                  : record.marketCap}
+              {new BigNumber(record.volume24h).isNaN() ? '-' : record.volume24h}
             </NumberSizeableText>
           ),
         },
@@ -345,11 +341,9 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
                     currency: record.perpsCoin ? '$' : currencyInfo?.symbol,
                   }}
                 >
-                  {record.perpsCoin
-                    ? (record.volume24h ?? '-')
-                    : new BigNumber(record.marketCap).isNaN()
-                      ? '-'
-                      : record.marketCap}
+                  {new BigNumber(record.volume24h).isNaN()
+                    ? '-'
+                    : record.volume24h}
                 </NumberSizeableText>
               </YStack>
             </XStack>
@@ -507,6 +501,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
               price: parseFloat(item.price ?? '0'),
               priceChange24h: parseFloat(item.priceChange24hPercent ?? '0'),
               marketCap: parseFloat(item.marketCap ?? '0'),
+              volume24h: parseFloat(item.volume24h ?? '0'),
             };
           })
           .filter((item): item is IFavoriteTokenDisplay => item !== null);
@@ -579,6 +574,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
               price: parseFloat(item.price ?? '0'),
               priceChange24h: parseFloat(item.priceChange24hPercent ?? '0'),
               marketCap: parseFloat(item.marketCap ?? '0'),
+              volume24h: parseFloat(item.volume24h ?? '0'),
             };
           })
           .filter((item): item is IFavoriteTokenDisplay => item !== null);

--- a/packages/shared/src/locale/enum/translations.ts
+++ b/packages/shared/src/locale/enum/translations.ts
@@ -2222,6 +2222,7 @@
   market_1y = 'market.1y',
   market_24h = 'market.24h',
   market_24h_price_range = 'market.24h_price_range',
+  market_24h_turnover = 'market.24h_turnover',
   market_24h_txns = 'market.24h_txns',
   market_24h_vol_usd = 'market.24h_vol_usd',
   market_30d = 'market.30d',

--- a/packages/shared/src/locale/json/bn.json
+++ b/packages/shared/src/locale/json/bn.json
@@ -2217,6 +2217,7 @@
   "market.1y": "১ বছর",
   "market.24h": "24H",
   "market.24h_price_range": "২৪ ঘণ্টার মূল্য পরিসীমা",
+  "market.24h_turnover": "24h টার্নওভার",
   "market.24h_txns": "২৪ ঘণ্টার লেনদেন",
   "market.24h_vol_usd": "২৪ ঘণ্টার ভলিউম (USD)",
   "market.30d": "৩০ দিন",

--- a/packages/shared/src/locale/json/de.json
+++ b/packages/shared/src/locale/json/de.json
@@ -2217,6 +2217,7 @@
   "market.1y": "1J",
   "market.24h": "24H",
   "market.24h_price_range": "24H Preisspanne",
+  "market.24h_turnover": "24h Umsatz",
   "market.24h_txns": "24H txns",
   "market.24h_vol_usd": "24H VOL(USD)",
   "market.30d": "30T",

--- a/packages/shared/src/locale/json/en_US.json
+++ b/packages/shared/src/locale/json/en_US.json
@@ -2217,6 +2217,7 @@
   "market.1y": "1Y",
   "market.24h": "24H",
   "market.24h_price_range": "24H price range",
+  "market.24h_turnover": "24h Turnover",
   "market.24h_txns": "24H txns",
   "market.24h_vol_usd": "24H VOL(USD)",
   "market.30d": "30D",

--- a/packages/shared/src/locale/json/es.json
+++ b/packages/shared/src/locale/json/es.json
@@ -2217,6 +2217,7 @@
   "market.1y": "1A",
   "market.24h": "24H",
   "market.24h_price_range": "Rango de Precios 24H",
+  "market.24h_turnover": "24h Rotación",
   "market.24h_txns": "Transacciones 24H",
   "market.24h_vol_usd": "VOL 24H(USD)",
   "market.30d": "30D",

--- a/packages/shared/src/locale/json/fr_FR.json
+++ b/packages/shared/src/locale/json/fr_FR.json
@@ -2217,6 +2217,7 @@
   "market.1y": "1A",
   "market.24h": "24H",
   "market.24h_price_range": "Écart de prix 24H",
+  "market.24h_turnover": "24h Chiffre d'affaires",
   "market.24h_txns": "24H txns",
   "market.24h_vol_usd": "VOL 24H(USD)",
   "market.30d": "30J",

--- a/packages/shared/src/locale/json/hi_IN.json
+++ b/packages/shared/src/locale/json/hi_IN.json
@@ -2217,6 +2217,7 @@
   "market.1y": "1 वर्ष",
   "market.24h": "24 घंटे",
   "market.24h_price_range": "24 घंटे की मूल्य सीमा",
+  "market.24h_turnover": "24h टर्नओवर",
   "market.24h_txns": "24 घंटे के लेनदेन",
   "market.24h_vol_usd": "24 घंटे का वॉल्यूम (USD)",
   "market.30d": "30 दिन",

--- a/packages/shared/src/locale/json/id.json
+++ b/packages/shared/src/locale/json/id.json
@@ -2217,6 +2217,7 @@
   "market.1y": "1thn",
   "market.24h": "24J",
   "market.24h_price_range": "Rentang Harga 24J",
+  "market.24h_turnover": "24h Perputaran",
   "market.24h_txns": "Transaksi 24 Jam",
   "market.24h_vol_usd": "Volume 24J (USD)",
   "market.30d": "30hr",

--- a/packages/shared/src/locale/json/it_IT.json
+++ b/packages/shared/src/locale/json/it_IT.json
@@ -2217,6 +2217,7 @@
   "market.1y": "1A",
   "market.24h": "24H",
   "market.24h_price_range": "Intervallo Prezzo 24H",
+  "market.24h_turnover": "24h Fatturato",
   "market.24h_txns": "Transazioni 24 Ore",
   "market.24h_vol_usd": "VOL 24H(USD)",
   "market.30d": "30G",

--- a/packages/shared/src/locale/json/ja_JP.json
+++ b/packages/shared/src/locale/json/ja_JP.json
@@ -2217,6 +2217,7 @@
   "market.1y": "1年",
   "market.24h": "24時間",
   "market.24h_price_range": "24時間の価格範囲",
+  "market.24h_turnover": "24h 取引高",
   "market.24h_txns": "24時間取引",
   "market.24h_vol_usd": "24時間ボリューム (USD)",
   "market.30d": "30日",

--- a/packages/shared/src/locale/json/ko_KR.json
+++ b/packages/shared/src/locale/json/ko_KR.json
@@ -2217,6 +2217,7 @@
   "market.1y": "1년",
   "market.24h": "24시간",
   "market.24h_price_range": "24시간 가격 범위",
+  "market.24h_turnover": "24h 거래액",
   "market.24h_txns": "24시간 거래",
   "market.24h_vol_usd": "24시간 거래량 (USD)",
   "market.30d": "30일",

--- a/packages/shared/src/locale/json/pt.json
+++ b/packages/shared/src/locale/json/pt.json
@@ -2217,6 +2217,7 @@
   "market.1y": "1A",
   "market.24h": "24H",
   "market.24h_price_range": "Faixa Preço 24H",
+  "market.24h_turnover": "24h Rotatividade",
   "market.24h_txns": "Transações 24H",
   "market.24h_vol_usd": "VOL 24H(USD)",
   "market.30d": "30D",

--- a/packages/shared/src/locale/json/pt_BR.json
+++ b/packages/shared/src/locale/json/pt_BR.json
@@ -2217,6 +2217,7 @@
   "market.1y": "1A",
   "market.24h": "24H",
   "market.24h_price_range": "Faixa Preço 24H",
+  "market.24h_turnover": "24h Rotatividade",
   "market.24h_txns": "Transações 24H",
   "market.24h_vol_usd": "VOL 24H(USD)",
   "market.30d": "30D",

--- a/packages/shared/src/locale/json/ru.json
+++ b/packages/shared/src/locale/json/ru.json
@@ -2217,6 +2217,7 @@
   "market.1y": "1г",
   "market.24h": "24ч",
   "market.24h_price_range": "Диапазон цен 24ч",
+  "market.24h_turnover": "24h Объём",
   "market.24h_txns": "24ч транзакции",
   "market.24h_vol_usd": "Объем 24ч (USD)",
   "market.30d": "30д",

--- a/packages/shared/src/locale/json/th_TH.json
+++ b/packages/shared/src/locale/json/th_TH.json
@@ -2217,6 +2217,7 @@
   "market.1y": "1 ปี",
   "market.24h": "24 ชั่วโมง",
   "market.24h_price_range": "ช่วงราคาตลอด 24 ชั่วโมง",
+  "market.24h_turnover": "ปริมาณ 24h",
   "market.24h_txns": "ธุรกรรม 24 ชั่วโมง",
   "market.24h_vol_usd": "ปริมาณการซื้อขาย 24 ชั่วโมง (USD)",
   "market.30d": "30 วัน",

--- a/packages/shared/src/locale/json/uk_UA.json
+++ b/packages/shared/src/locale/json/uk_UA.json
@@ -2217,6 +2217,7 @@
   "market.1y": "1р",
   "market.24h": "24 год",
   "market.24h_price_range": "Діапазон цін 24г",
+  "market.24h_turnover": "24h Обсяг",
   "market.24h_txns": "24г транзакції",
   "market.24h_vol_usd": "Обсяг 24г (USD)",
   "market.30d": "30д",

--- a/packages/shared/src/locale/json/vi.json
+++ b/packages/shared/src/locale/json/vi.json
@@ -2217,6 +2217,7 @@
   "market.1y": "1n",
   "market.24h": "24 giờ",
   "market.24h_price_range": "Phạm vi Giá 24 giờ",
+  "market.24h_turnover": "Khối lượng 24h",
   "market.24h_txns": "Giao dịch 24 giờ",
   "market.24h_vol_usd": "Khối Lượng 24 giờ (USD)",
   "market.30d": "30ng",

--- a/packages/shared/src/locale/json/zh_CN.json
+++ b/packages/shared/src/locale/json/zh_CN.json
@@ -2217,6 +2217,7 @@
   "market.1y": "1 年",
   "market.24h": "24 小时",
   "market.24h_price_range": "24 小时价格范围",
+  "market.24h_turnover": "24h 交易额",
   "market.24h_txns": "24 小时交易",
   "market.24h_vol_usd": "24 小时成交量 (USD)",
   "market.30d": "30 天",

--- a/packages/shared/src/locale/json/zh_HK.json
+++ b/packages/shared/src/locale/json/zh_HK.json
@@ -2217,6 +2217,7 @@
   "market.1y": "1 年",
   "market.24h": "24 小時",
   "market.24h_price_range": "24 小時價格範圍",
+  "market.24h_turnover": "24h 交易額",
   "market.24h_txns": "24 小時交易",
   "market.24h_vol_usd": "24 小時成交量 (USD)",
   "market.30d": "30 日",

--- a/packages/shared/src/locale/json/zh_TW.json
+++ b/packages/shared/src/locale/json/zh_TW.json
@@ -2217,6 +2217,7 @@
   "market.1y": "1 年",
   "market.24h": "24 小時",
   "market.24h_price_range": "24 小時價格範圍",
+  "market.24h_turnover": "24h 交易額",
   "market.24h_txns": "24 小時交易",
   "market.24h_vol_usd": "24 小時成交量 (USD)",
   "market.30d": "30 天",


### PR DESCRIPTION
## Summary
- **Bug**: Home page watchlist (自选) module showed "市值" (market cap) as column title but displayed volume data for perps tokens, causing data/label mismatch
- **Fix**: Unified both desktop and mobile layouts to display `volume24h` (24h turnover) for both spot and perps tokens
- **i18n**: Added new key `market_24h_turnover` ("24h 交易额") aligned with Market page's `dexmarket_turnover` terminology across all 19 languages

## Changes
- **Desktop layout** (tableLayout): Column title `市值` → `24h 交易额`, data field `marketCap` → `volume24h`
- **Mobile layout**: Token subtitle from `marketCap`/`volume24h` split → unified `volume24h`
- **Data model**: `volume24h` promoted from optional (perps-only) to required field, populated for both spot and perps tokens

## Note
Pre-existing TS error in `HomePageView.tsx:422` (`useNativeHeaderAnimation` prop) — unrelated to this change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
