### PR TITLE
fix: prevent premature onEndReached in signature record list on Android(OK-50376)

### DIFF
--- a/packages/kit/src/views/Setting/pages/SignatureRecord/hooks.ts
+++ b/packages/kit/src/views/Setting/pages/SignatureRecord/hooks.ts
@@ -32,11 +32,13 @@ export const useGetSignatureSections = <T extends { createdAt: number }>(
 ) => {
   const ref = useRef<T[]>([]);
   const methodRef = useRef(method);
+  const hasLoadedFirstPageRef = useRef(false);
   const [query, setQuery] = useState<{ offset: number; limit: number }>({
     offset: 0,
     limit: 10,
   });
   const { networkId, searchContent: address } = useContext(SignatureContext);
+
   const {
     result: { sections, ending },
   } = usePromiseResult(
@@ -51,6 +53,7 @@ export const useGetSignatureSections = <T extends { createdAt: number }>(
       if (!isSearch) {
         ref.current.splice(query.offset, query.limit, ...resp);
       }
+      hasLoadedFirstPageRef.current = true;
       return {
         sections: groupBy(isSearch ? resp : ref.current),
         ending: resp.length < query.limit,
@@ -61,7 +64,7 @@ export const useGetSignatureSections = <T extends { createdAt: number }>(
   );
 
   const onEndReached = useCallback(() => {
-    if (ending) {
+    if (ending || !hasLoadedFirstPageRef.current) {
       return;
     }
     setQuery((prev) => ({ ...prev, offset: prev.offset + prev.limit }));


### PR DESCRIPTION
## Summary
- Fix signature record list showing empty under "All Network" on Android
- On Android, `react-native-collapsible-tab-view` fires `onEndReached` immediately on empty lists, causing offset to jump from 0→10 before first page loads. The nonce mechanism in `usePromiseResult` then discards the offset=0 result (real data), keeping only the offset=10 result (empty)
- Add `hasLoadedFirstPageRef` guard to block `onEndReached` until initial data has loaded

## Test plan
- [ ] Open Settings → Signature Record on Android
- [ ] Verify "All Network" shows transaction records
- [ ] Verify switching to specific networks still works
- [ ] Verify pagination (scroll to load more) still works
- [ ] Verify Sign Text and Connected Sites tabs also display correctly
- [ ] Verify desktop is unaffected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
