### PR TITLE
fix: cap send percentage decimals to max 6 instead of hardcoded 6

### DIFF
--- a/packages/kit/src/components/PercentageStageOnKeyboard/index.tsx
+++ b/packages/kit/src/components/PercentageStageOnKeyboard/index.tsx
@@ -20,12 +20,12 @@ export const calcPercentBalance = ({
     return '';
   }
   if (percent === 100) {
-    return decimals
+    return decimals != null
       ? valueNumber.decimalPlaces(decimals, BigNumber.ROUND_DOWN).toFixed()
       : balance;
   }
   const value = valueNumber.multipliedBy(percent).dividedBy(100);
-  return decimals
+  return decimals != null
     ? value.decimalPlaces(decimals, BigNumber.ROUND_DOWN).toFixed()
     : value.toFixed();
 };

--- a/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
@@ -1792,11 +1792,11 @@ function SendDataInputContainer() {
         calcPercentBalance({
           balance: isUseFiat ? maxBalanceFiat : maxBalance,
           percent,
-          decimals: 6,
+          decimals: Math.min(token?.decimals ?? 6, 6),
         }),
       );
     },
-    [form, isUseFiat, maxBalance, maxBalanceFiat],
+    [form, isUseFiat, maxBalance, maxBalanceFiat, token?.decimals],
   );
 
   const inputAddressFieldState = form.getFieldState('to');

--- a/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
@@ -1792,8 +1792,9 @@ function SendDataInputContainer() {
         calcPercentBalance({
           balance: isUseFiat ? maxBalanceFiat : maxBalance,
           percent,
-          decimals:
-            percent === 100
+          decimals: isUseFiat
+            ? 6
+            : percent === 100
               ? token?.decimals
               : Math.min(token?.decimals ?? 6, 6),
         }),

--- a/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
@@ -1792,7 +1792,10 @@ function SendDataInputContainer() {
         calcPercentBalance({
           balance: isUseFiat ? maxBalanceFiat : maxBalance,
           percent,
-          decimals: Math.min(token?.decimals ?? 6, 6),
+          decimals:
+            percent === 100
+              ? token?.decimals
+              : Math.min(token?.decimals ?? 6, 6),
         }),
       );
     },

--- a/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
@@ -1795,13 +1795,13 @@ function SendDataInputContainer() {
           decimals: isUseFiat
             ? 6
             : percent === 100
-              ? token?.decimals
-              : Math.min(token?.decimals ?? 6, 6),
+              ? tokenInfo?.decimals
+              : Math.min(tokenInfo?.decimals ?? 6, 6),
         }),
       );
       Keyboard.dismiss();
     },
-    [form, isUseFiat, maxBalance, maxBalanceFiat, token?.decimals],
+    [form, isUseFiat, maxBalance, maxBalanceFiat, tokenInfo?.decimals],
   );
 
   const inputAddressFieldState = form.getFieldState('to');

--- a/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
@@ -14,7 +14,7 @@ import BigNumber from 'bignumber.js';
 import { utils } from 'ethers';
 import { isEmpty, isNaN, isNil } from 'lodash';
 import { useIntl } from 'react-intl';
-import { InputAccessoryView } from 'react-native';
+import { InputAccessoryView, Keyboard } from 'react-native';
 
 import type {
   IFormMode,
@@ -1798,6 +1798,7 @@ function SendDataInputContainer() {
               : Math.min(token?.decimals ?? 6, 6),
         }),
       );
+      Keyboard.dismiss();
     },
     [form, isUseFiat, maxBalance, maxBalanceFiat, token?.decimals],
   );


### PR DESCRIPTION
## Summary
- Use `Math.min(token?.decimals ?? 6, 6)` instead of hardcoded `decimals: 6` in send page percentage selector
- Respects token's native precision when it's less than 6 (e.g., USDT with 2 decimals) while still capping at 6 for tokens with higher precision (e.g., ETH with 18 decimals)
- Prevents overly long decimal numbers from being filled into the amount input when user taps 25%/50%/75%/100%

## Test plan
- [ ] Send page: select a token with decimals < 6, tap percentage buttons, verify amount uses token's native decimals
- [ ] Send page: select a token with decimals > 6 (e.g., ETH), tap percentage buttons, verify amount is capped at 6 decimal places
- [ ] Send page: verify the amount is easy to read and modify after percentage selection
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
