### PR TITLE
fix: exit fullscreen before hiding window on macOS close(OK-50397)

### DIFF
--- a/apps/desktop/app/app.ts
+++ b/apps/desktop/app/app.ts
@@ -981,9 +981,17 @@ async function createMainWindow() {
       event.preventDefault();
       const safelyBrowserWindow = getSafelyBrowserWindow();
       if (safelyBrowserWindow) {
-        safelyBrowserWindow.blur();
-        safelyBrowserWindow.hide(); // hide window only
-        // browserWindow.minimize(); // hide window and minimize to Docker
+        if (safelyBrowserWindow.isFullScreen()) {
+          // Exit fullscreen first, then hide after the animation completes
+          safelyBrowserWindow.once('leave-full-screen', () => {
+            safelyBrowserWindow.blur();
+            safelyBrowserWindow.hide();
+          });
+          safelyBrowserWindow.setFullScreen(false);
+        } else {
+          safelyBrowserWindow.blur();
+          safelyBrowserWindow.hide();
+        }
       }
     }
   });


### PR DESCRIPTION
## Summary
- Fix black screen issue when closing the desktop app window while in fullscreen mode on macOS
- The `close` event handler now checks `isFullScreen()` and exits fullscreen first via `setFullScreen(false)`, deferring `hide()` until the `leave-full-screen` event fires
- Non-fullscreen close behavior remains unchanged

## Test plan
- [ ] Launch desktop app on macOS
- [ ] Enter fullscreen mode (green traffic light or Ctrl+Cmd+F)
- [ ] Click close button (red traffic light) — should exit fullscreen smoothly then hide, no black screen
- [ ] Click Dock icon to reopen — app shows normally in windowed mode
- [ ] Cmd+Q from both fullscreen and windowed modes still quits cleanly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
