### PR TITLE
fix: replace Image.Fallback with Stack for contract interaction icon in signature records(OK-50378)

### DIFF
--- a/packages/kit/src/views/Setting/pages/SignatureRecord/Transactions.tsx
+++ b/packages/kit/src/views/Setting/pages/SignatureRecord/Transactions.tsx
@@ -7,7 +7,6 @@ import {
   Empty,
   Icon,
   IconButton,
-  Image,
   NumberSizeableText,
   SectionList,
   SizableText,
@@ -216,21 +215,17 @@ const ContractInteractionTransactionItem = () => {
   return (
     <XStack justifyContent="space-between" w="100%" alignItems="center">
       <XStack alignItems="center" pr="$2">
-        <Image
+        <Stack
           borderRadius="$full"
-          overflow="hidden"
           width={40}
           height={40}
           mr="$3"
+          bg="$gray5"
+          alignItems="center"
+          justifyContent="center"
         >
-          <Image.Fallback
-            alignItems="center"
-            justifyContent="center"
-            bg="$gray5"
-          >
-            <Icon size={40} name="GlobusOutline" color="$iconSubdued" />
-          </Image.Fallback>
-        </Image>
+          <Icon size="$6" name="GlobusOutline" color="$iconSubdued" />
+        </Stack>
         <SizableText size="$bodyLgMedium">
           {intl.formatMessage({
             id: ETranslations.transaction__contract_interaction,


### PR DESCRIPTION
## Summary
- Fixed missing icon for contract interaction ("合约交互") in signature records
- `Image.Fallback` was rendering an empty element instead of showing the `GlobusOutline` icon
- Replaced `Image` + `Image.Fallback` with `Stack` + `Icon` to correctly display the fallback icon
- Removed unused `Image` import

## Test plan
- [ ] Open signature records page (签名记录)
- [ ] Verify contract interaction entries show the globe icon correctly
- [ ] Check icon displays properly on all platforms (iOS, Android, Web, Desktop)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
