### PR TITLE
fix: resolve Android Perp market footer Buy/Sell buttons not responding to taps(OK-50392)

### DIFF
--- a/packages/kit/src/views/Perp/components/PerpMarketFooter.android.tsx
+++ b/packages/kit/src/views/Perp/components/PerpMarketFooter.android.tsx
@@ -1,0 +1,115 @@
+import { useCallback, useMemo } from 'react';
+
+import { useNavigation } from '@react-navigation/core';
+import { useIntl } from 'react-intl';
+import { StyleSheet, View } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { runOnJS } from 'react-native-reanimated';
+
+import { Button, Page } from '@onekeyhq/components';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+
+import { useHyperliquidActions } from '../../../states/jotai/contexts/hyperliquid';
+import { GetTradingButtonStyleProps } from '../utils/styleUtils';
+
+// On Android, the native bottom tab navigator (react-native-bottom-tabs)
+// intercepts touches in the tab bar area, preventing RN's built-in touch
+// system from dispatching events to buttons in this region — even when the
+// tab bar is hidden (GONE). RNGH intercepts touches at the
+// GestureHandlerRootView (app root) level, bypassing the native view
+// hierarchy entirely.
+
+const styles = StyleSheet.create({
+  buttonContainer: {
+    flex: 1,
+  },
+});
+
+function PerpMarketFooter() {
+  const intl = useIntl();
+  const actionsRef = useHyperliquidActions();
+  const longButtonStyle = GetTradingButtonStyleProps('long');
+  const shortButtonStyle = GetTradingButtonStyleProps('short');
+  const navigation = useNavigation();
+
+  const handleBuy = useCallback(() => {
+    actionsRef.current.updateTradingForm({ side: 'long' });
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+    }
+  }, [actionsRef, navigation]);
+
+  const handleSell = useCallback(() => {
+    actionsRef.current.updateTradingForm({ side: 'short' });
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+    }
+  }, [actionsRef, navigation]);
+
+  const buyGesture = useMemo(
+    () =>
+      Gesture.Tap().onEnd(() => {
+        'worklet';
+        runOnJS(handleBuy)();
+      }),
+    [handleBuy],
+  );
+
+  const sellGesture = useMemo(
+    () =>
+      Gesture.Tap().onEnd(() => {
+        'worklet';
+        runOnJS(handleSell)();
+      }),
+    [handleSell],
+  );
+
+  const buyButton = useMemo(
+    () => (
+      <GestureDetector gesture={buyGesture}>
+        <View style={styles.buttonContainer}>
+          <Button
+            padding={0}
+            height={38}
+            borderRadius="$2"
+            bg={longButtonStyle.bg}
+            color={longButtonStyle.textColor}
+            justifyContent="center"
+            alignItems="center"
+            testID="page-footer-cancel"
+          >
+            {intl.formatMessage({ id: ETranslations.perp_trade_long })}
+          </Button>
+        </View>
+      </GestureDetector>
+    ),
+    [buyGesture, longButtonStyle, intl],
+  );
+
+  const sellButton = useMemo(
+    () => (
+      <GestureDetector gesture={sellGesture}>
+        <View style={styles.buttonContainer}>
+          <Button
+            variant="primary"
+            padding={0}
+            height={38}
+            borderRadius="$2"
+            bg={shortButtonStyle.bg}
+            color={shortButtonStyle.textColor}
+            justifyContent="center"
+            alignItems="center"
+            testID="page-footer-confirm"
+          >
+            {intl.formatMessage({ id: ETranslations.perp_trade_short })}
+          </Button>
+        </View>
+      </GestureDetector>
+    ),
+    [sellGesture, shortButtonStyle, intl],
+  );
+
+  return <Page.Footer cancelButton={buyButton} confirmButton={sellButton} />;
+}
+
+export default PerpMarketFooter;

--- a/packages/kit/src/views/Perp/components/PerpMarketFooter.tsx
+++ b/packages/kit/src/views/Perp/components/PerpMarketFooter.tsx
@@ -1,0 +1,71 @@
+import { useCallback } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import { Page } from '@onekeyhq/components';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+
+import { useHyperliquidActions } from '../../../states/jotai/contexts/hyperliquid';
+import { GetTradingButtonStyleProps } from '../utils/styleUtils';
+
+function PerpMarketFooter() {
+  const intl = useIntl();
+  const actionsRef = useHyperliquidActions();
+  const longButtonStyle = GetTradingButtonStyleProps('long');
+  const shortButtonStyle = GetTradingButtonStyleProps('short');
+
+  const handleCancel = useCallback(
+    (close: () => void) => {
+      actionsRef.current.updateTradingForm({ side: 'long' });
+      close();
+    },
+    [actionsRef],
+  );
+
+  const handleConfirm = useCallback(
+    (close: () => void) => {
+      actionsRef.current.updateTradingForm({ side: 'short' });
+      close();
+    },
+    [actionsRef],
+  );
+
+  return (
+    <Page.Footer
+      onCancelText={intl.formatMessage({
+        id: ETranslations.perp_trade_long,
+      })}
+      onConfirmText={intl.formatMessage({
+        id: ETranslations.perp_trade_short,
+      })}
+      cancelButtonProps={{
+        flex: 1,
+        padding: 0,
+        height: 38,
+        borderRadius: '$2',
+        bg: longButtonStyle.bg,
+        hoverStyle: longButtonStyle.hoverStyle,
+        pressStyle: longButtonStyle.pressStyle,
+        color: longButtonStyle.textColor,
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+      confirmButtonProps={{
+        flex: 1,
+        padding: 0,
+        height: 38,
+        borderRadius: '$2',
+        bg: shortButtonStyle.bg,
+        hoverStyle: shortButtonStyle.hoverStyle,
+        pressStyle: shortButtonStyle.pressStyle,
+        color: shortButtonStyle.textColor,
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+      onCancel={handleCancel}
+      onConfirm={handleConfirm}
+    />
+  );
+}
+
+export default PerpMarketFooter;

--- a/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
+++ b/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
@@ -31,23 +31,19 @@ import {
 import { Token } from '../../../components/Token';
 import useAppNavigation from '../../../hooks/useAppNavigation';
 import { useThemeVariant } from '../../../hooks/useThemeVariant';
-import { useHyperliquidActions } from '../../../states/jotai/contexts/hyperliquid';
 import { PerpCandles } from '../components/PerpCandles';
+import PerpMarketFooter from '../components/PerpMarketFooter';
 import { PerpOrderBook } from '../components/PerpOrderBook';
 import { MobilePerpMarketHeader } from '../components/TickerBar/MobilePerpMarketHeader';
 import { PerpsAccountSelectorProviderMirror } from '../PerpsAccountSelectorProviderMirror';
 import { PerpsProviderMirror } from '../PerpsProviderMirror';
-import { GetTradingButtonStyleProps } from '../utils/styleUtils';
 
 function MobilePerpMarket() {
   const intl = useIntl();
-  const actionsRef = useHyperliquidActions();
   const [currentToken] = usePerpsActiveAssetAtom();
   const { coin } = currentToken;
   const themeVariant = useThemeVariant();
   const navigation = useAppNavigation();
-  const longButtonStyle = GetTradingButtonStyleProps('long');
-  const shortButtonStyle = GetTradingButtonStyleProps('short');
 
   const onPressTokenSelector = useCallback(() => {
     navigation.pushModal(EModalRoutes.PerpModal, {
@@ -141,50 +137,7 @@ function MobilePerpMarket() {
     [],
   );
 
-  const pageFooter = useMemo(() => {
-    return (
-      <Page.Footer
-        onCancelText={intl.formatMessage({
-          id: ETranslations.perp_trade_long,
-        })}
-        onConfirmText={intl.formatMessage({
-          id: ETranslations.perp_trade_short,
-        })}
-        cancelButtonProps={{
-          flex: 1,
-          padding: 0,
-          height: 38,
-          borderRadius: '$2',
-          bg: longButtonStyle.bg,
-          hoverStyle: longButtonStyle.hoverStyle,
-          pressStyle: longButtonStyle.pressStyle,
-          color: longButtonStyle.textColor,
-          justifyContent: 'center',
-          alignItems: 'center',
-        }}
-        confirmButtonProps={{
-          flex: 1,
-          padding: 0,
-          height: 38,
-          borderRadius: '$2',
-          bg: shortButtonStyle.bg,
-          hoverStyle: shortButtonStyle.hoverStyle,
-          pressStyle: shortButtonStyle.pressStyle,
-          color: shortButtonStyle.textColor,
-          justifyContent: 'center',
-          alignItems: 'center',
-        }}
-        onCancel={(close) => {
-          actionsRef.current.updateTradingForm({ side: 'long' });
-          close();
-        }}
-        onConfirm={(close) => {
-          actionsRef.current.updateTradingForm({ side: 'short' });
-          close();
-        }}
-      />
-    );
-  }, [intl, actionsRef, longButtonStyle, shortButtonStyle]);
+  const pageFooter = useMemo(() => <PerpMarketFooter />, []);
 
   if (platformEnv.isNativeAndroid) {
     return (


### PR DESCRIPTION
## Summary
- On Android, the native bottom tab navigator (`react-native-bottom-tabs`) intercepts touches in the tab bar area even when hidden (GONE), causing the Perp market page's Buy/Sell footer buttons to be unresponsive
- Extracted footer into `PerpMarketFooter` with a platform-specific `.android.tsx` variant that uses `GestureDetector` from RNGH to bypass native view hierarchy touch interception
- Default (iOS/web) version keeps the original `Page.Footer` behavior unchanged

## Test plan
- [ ] On Android, open Perp market page (e.g. ETHUSD), verify Buy and Sell buttons respond to taps
- [ ] On iOS, verify Buy and Sell buttons still work as before
- [ ] Verify tapping Buy sets trading side to Long and navigates back
- [ ] Verify tapping Sell sets trading side to Short and navigates back
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
