### PR TITLE
fix: home tab content disappears after bottom tab switch

### DIFF
--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -358,6 +358,9 @@ export function Container({
     getCurrentIndex: () => {
       return tabNames.findIndex((name) => name === focusedTab.value);
     },
+    syncCurrentPage: () => {
+      // no-op on web, only needed for native PagerView
+    },
   }));
 
   return (

--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -95,6 +95,7 @@ export interface ITabContainerRef {
   setIndex: (index: number) => void;
   getFocusedTab: () => string;
   getCurrentIndex: () => number;
+  syncCurrentPage: () => void;
 }
 
 export interface ITabContainerProps {

--- a/packages/components/src/composite/Tabs/index.native.tsx
+++ b/packages/components/src/composite/Tabs/index.native.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { Tabs as NativeTabs } from 'react-native-collapsible-tab-view';
@@ -6,32 +7,30 @@ import { TabBar, TabBarItem } from './TabBar';
 
 import type { CollapsibleProps } from 'react-native-collapsible-tab-view';
 
-const Container = ({
-  children,
-  pagerProps,
-  headerContainerStyle,
-  ...props
-}: PropsWithChildren<CollapsibleProps>) => {
-  return (
-    <NativeTabs.Container
-      headerContainerStyle={{
-        shadowOpacity: 0,
-        elevation: 0,
-        ...(headerContainerStyle as any),
-      }}
-      pagerProps={
-        {
-          scrollSensitivity: 4,
-          ...pagerProps,
-        } as any
-      }
-      renderTabBar={(tabProps: any) => <TabBar {...tabProps} />}
-      {...props}
-    >
-      {children}
-    </NativeTabs.Container>
-  );
-};
+const Container = React.forwardRef<any, PropsWithChildren<CollapsibleProps>>(
+  ({ children, pagerProps, headerContainerStyle, ...props }, ref) => {
+    return (
+      <NativeTabs.Container
+        ref={ref}
+        headerContainerStyle={{
+          shadowOpacity: 0,
+          elevation: 0,
+          ...(headerContainerStyle as any),
+        }}
+        pagerProps={
+          {
+            scrollSensitivity: 4,
+            ...pagerProps,
+          } as any
+        }
+        renderTabBar={(tabProps: any) => <TabBar {...tabProps} />}
+        {...props}
+      >
+        {children}
+      </NativeTabs.Container>
+    );
+  },
+);
 
 export const Tabs = {
   ...NativeTabs,

--- a/packages/components/src/composite/Tabs/index.native.tsx
+++ b/packages/components/src/composite/Tabs/index.native.tsx
@@ -31,6 +31,7 @@ const Container = React.forwardRef<any, PropsWithChildren<CollapsibleProps>>(
     );
   },
 );
+Container.displayName = 'NativeTabsContainer';
 
 export const Tabs = {
   ...NativeTabs,

--- a/packages/kit-bg/src/services/ServiceSignature.ts
+++ b/packages/kit-bg/src/services/ServiceSignature.ts
@@ -465,7 +465,6 @@ class ServiceSignature extends ServiceBase {
     await localDb.removeAllSignedMessage();
     await localDb.removeAllConnectedSite();
   }
-
 }
 
 export default ServiceSignature;

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -129,16 +129,20 @@ export function HomePageView({
   const wasBlurredRef = useRef(false);
   useFocusEffect(
     useCallback(() => {
+      let rafId: number | undefined;
       if (wasBlurredRef.current && tabsRef.current) {
         // Force PagerView to display the correct page after freeze/unfreeze.
         // jumpToTab won't work here because onTabPress skips setPage when
         // the tab is already focused. We need to call setPageWithoutAnimation
         // directly to force the native PagerView to re-render its current page.
-        requestAnimationFrame(() => {
+        rafId = requestAnimationFrame(() => {
           tabsRef.current?.syncCurrentPage();
         });
       }
       return () => {
+        if (rafId !== undefined) {
+          cancelAnimationFrame(rafId);
+        }
         wasBlurredRef.current = true;
       };
     }, []),

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { useFocusEffect } from '@react-navigation/core';
 import { CanceledError } from 'axios';
 import { useIntl } from 'react-intl';
 
@@ -123,6 +124,26 @@ export function HomePageView({
   const [{ hasRiskApprovals }] = useApprovalsInfoAtom();
   const { updateApprovalsInfo } = useAccountOverviewActions().current;
   const tabsRef = useRef<ITabContainerRef | null>(null);
+
+  // Force PagerView to re-sync after bottom tab switch (freeze/unfreeze)
+  const wasBlurredRef = useRef(false);
+  useFocusEffect(
+    useCallback(() => {
+      if (wasBlurredRef.current && tabsRef.current) {
+        // Force PagerView to display the correct page after freeze/unfreeze.
+        // jumpToTab won't work here because onTabPress skips setPage when
+        // the tab is already focused. We need to call setPageWithoutAnimation
+        // directly to force the native PagerView to re-render its current page.
+        requestAnimationFrame(() => {
+          tabsRef.current?.syncCurrentPage();
+        });
+      }
+      return () => {
+        wasBlurredRef.current = true;
+      };
+    }, []),
+  );
+
   const hasRiskApprovalsRef = useRef(hasRiskApprovals);
   useEffect(() => {
     hasRiskApprovalsRef.current = hasRiskApprovals;

--- a/patches/react-native-collapsible-tab-view+8.0.1.patch
+++ b/patches/react-native-collapsible-tab-view+8.0.1.patch
@@ -40,7 +40,7 @@ index 7a739fc..10c5d9a 100644
  export type ScrollViewProps = ComponentProps<typeof Animated.ScrollView>;
  export type CollapsibleStyle = {
 diff --git a/node_modules/react-native-collapsible-tab-view/src/Container.tsx b/node_modules/react-native-collapsible-tab-view/src/Container.tsx
-index e782b90..3293fca 100644
+index e782b90..13b1cfe 100644
 --- a/node_modules/react-native-collapsible-tab-view/src/Container.tsx
 +++ b/node_modules/react-native-collapsible-tab-view/src/Container.tsx
 @@ -1,9 +1,10 @@
@@ -165,8 +165,7 @@ index e782b90..3293fca 100644
 -            },
 -          ],
 +          transform: [{ translateY: headerTranslateY.value }],
-         }
--      }, [revealHeaderOnScroll])
++        }
 +      }, [])
 +
 +      // Native animated header: uses RN's Animated driver for same-frame updates
@@ -256,12 +255,21 @@ index e782b90..3293fca 100644
 +              extrapolate: 'clamp',
 +            })
 +          }]
-+        }
+         }
+-      }, [revealHeaderOnScroll])
 +      }, [useNativeHeaderAnimation, nativeScrollY, headerScrollDist, contentInset])
  
        const onTabPress = React.useCallback(
          (name: TabName) => {
-@@ -349,50 +461,86 @@ export const Container = React.memo(
+@@ -344,55 +456,94 @@ export const Container = React.memo(
+           getCurrentIndex: () => {
+             return index.value
+           },
++          syncCurrentPage: () => {
++            containerRef.current?.setPageWithoutAnimation(index.value)
++          },
+         }),
+         // eslint-disable-next-line react-hooks/exhaustive-deps
          [onTabPress]
        )
  
@@ -385,7 +393,7 @@ index e782b90..3293fca 100644
                  style={[styles.container, styles.headerContainer]}
                  onLayout={getHeaderHeight}
                  pointerEvents="box-none"
-@@ -407,8 +555,9 @@ export const Container = React.memo(
+@@ -407,8 +558,9 @@ export const Container = React.memo(
                      onTabPress,
                      tabProps,
                    })}
@@ -396,7 +404,7 @@ index e782b90..3293fca 100644
                  style={[styles.container, styles.tabBarContainer]}
                  onLayout={getTabBarHeight}
                  pointerEvents="box-none"
-@@ -425,7 +574,7 @@ export const Container = React.memo(
+@@ -425,7 +577,7 @@ export const Container = React.memo(
                      tabProps,
                    })}
                </View>
@@ -754,7 +762,7 @@ index 2bd6b9c..ac74e88 100644
        contentOffset={memoContentOffset}
        automaticallyAdjustContentInsets={false}
 diff --git a/node_modules/react-native-collapsible-tab-view/src/hooks.tsx b/node_modules/react-native-collapsible-tab-view/src/hooks.tsx
-index ba7dffa..41e3a28 100644
+index ba7dffa..4b21c8e 100644
 --- a/node_modules/react-native-collapsible-tab-view/src/hooks.tsx
 +++ b/node_modules/react-native-collapsible-tab-view/src/hooks.tsx
 @@ -8,7 +8,7 @@ import {
@@ -779,7 +787,7 @@ index ba7dffa..41e3a28 100644
    return c
  }
  
-@@ -114,23 +118,31 @@ export function useTabsContext(): ContextType<TabName> {
+@@ -114,23 +118,36 @@ export function useTabsContext(): ContextType<TabName> {
   */
  export function useTabNameContext(): TabName {
    const c = useContext(TabNameContext)
@@ -802,6 +810,11 @@ index ba7dffa..41e3a28 100644
 -      const latestHeight = event.nativeEvent.layout.height
 -      if (latestHeight !== height) {
 +      const latestHeight = Math.round(event.nativeEvent.layout.height)
++      // Guard: once height has been measured, ignore transient 0-height events
++      // that can occur during screen freeze/unfreeze or memory pressure
++      if (latestHeight <= 0 && heightRef.current > 0) {
++        return
++      }
 +      if (latestHeight !== heightRef.current) {
 +        heightRef.current = latestHeight
 +        animatedHeight.value = latestHeight
@@ -816,7 +829,7 @@ index ba7dffa..41e3a28 100644
  }
  /**
   * Hook to access some key styles that make the whole thing work.
-@@ -265,10 +277,13 @@ export const useScrollHandlerY = (name: TabName) => {
+@@ -265,10 +282,13 @@ export const useScrollHandlerY = (name: TabName) => {
      accScrollY,
      offset,
      headerScrollDistance,
@@ -830,7 +843,7 @@ index ba7dffa..41e3a28 100644
    } = useTabsContext()
  
    const enabled = useSharedValue(false)
-@@ -296,10 +311,13 @@ export const useScrollHandlerY = (name: TabName) => {
+@@ -296,10 +316,13 @@ export const useScrollHandlerY = (name: TabName) => {
    useAnimatedReaction(
      () => scrollAnimation.value,
      (val) => {
@@ -845,7 +858,7 @@ index ba7dffa..41e3a28 100644
    )
  
    const onMomentumEnd = () => {
-@@ -403,6 +421,14 @@ export const useScrollHandlerY = (name: TabName) => {
+@@ -403,6 +426,14 @@ export const useScrollHandlerY = (name: TabName) => {
                accDiffClamp.value = Math.max(0, nextValue)
              }
            }
@@ -860,7 +873,7 @@ index ba7dffa..41e3a28 100644
          }
        },
        onBeginDrag: () => {
-@@ -465,6 +491,9 @@ export const useScrollHandlerY = (name: TabName) => {
+@@ -465,6 +496,9 @@ export const useScrollHandlerY = (name: TabName) => {
        return isChangingPane
      },
      (isSyncNeeded, wasSyncNeeded) => {
@@ -870,15 +883,14 @@ index ba7dffa..41e3a28 100644
        if (
          isSyncNeeded &&
          isSyncNeeded !== wasSyncNeeded &&
-@@ -505,10 +534,67 @@ export const useScrollHandlerY = (name: TabName) => {
+@@ -505,10 +539,67 @@ export const useScrollHandlerY = (name: TabName) => {
          }
        }
      },
 -    [revealHeaderOnScroll, refMap, snapThreshold, enabled, scrollTo]
 +    [revealHeaderOnScroll, refMap, snapThreshold, enabled, scrollTo, useNativeHeaderAnimation]
-   )
- 
--  return { scrollHandler, enable }
++  )
++
 +  // Native animated scroll handler: uses RN Animated.event with useNativeDriver
 +  // for same-frame header animation on Android
 +  const enabledRef = useRef(false)
@@ -931,8 +943,9 @@ index ba7dffa..41e3a28 100644
 +      runOnJS(setEnabledRefFn)(toggle)
 +    },
 +    [origEnable, setEnabledRefFn]
-+  )
-+
+   )
+ 
+-  return { scrollHandler, enable }
 +  return {
 +    scrollHandler: nativeScrollHandler || scrollHandler,
 +    enable: nativeScrollHandler ? enableWithRef : enable,
@@ -940,7 +953,7 @@ index ba7dffa..41e3a28 100644
  }
  
  type ForwardRefType<T> =
-@@ -579,11 +665,11 @@ export function useAfterMountEffect(
+@@ -579,11 +670,11 @@ export function useAfterMountEffect(
  export function useConvertAnimatedToValue<T>(
    animatedValue: Animated.SharedValue<T>
  ) {

--- a/patches/react-native-collapsible-tab-view+8.0.1.patch
+++ b/patches/react-native-collapsible-tab-view+8.0.1.patch
@@ -40,7 +40,7 @@ index 7a739fc..10c5d9a 100644
  export type ScrollViewProps = ComponentProps<typeof Animated.ScrollView>;
  export type CollapsibleStyle = {
 diff --git a/node_modules/react-native-collapsible-tab-view/src/Container.tsx b/node_modules/react-native-collapsible-tab-view/src/Container.tsx
-index e782b90..13b1cfe 100644
+index e782b90..86cb9b6 100644
 --- a/node_modules/react-native-collapsible-tab-view/src/Container.tsx
 +++ b/node_modules/react-native-collapsible-tab-view/src/Container.tsx
 @@ -1,9 +1,10 @@
@@ -103,7 +103,7 @@ index e782b90..13b1cfe 100644
        )
  
        // derived from scrollX
-@@ -258,37 +265,142 @@ export const Container = React.memo(
+@@ -258,37 +265,144 @@ export const Container = React.memo(
                scrollYCurrent.value =
                  scrollY.value[tabNames.value[index.value]] || 0
              }
@@ -183,7 +183,7 @@ index e782b90..13b1cfe 100644
 +        if (useNativeHeaderAnimation) {
 +          nativeScrollY.setValue(targetY)
 +
-+          // Retry scrollTo multiple times to ensure ScrollView is ready
++          // Retry scrollTo only if the ref is not yet available
 +          const scrollToPosition = (attempt: number) => {
 +            // Use refMapRef.current to get the latest refMap
 +            const ref = refMapRef.current[tabName]
@@ -192,8 +192,10 @@ index e782b90..13b1cfe 100644
 +                'worklet'
 +                scrollToImpl(ref, 0, targetY - contentInset, false)
 +              })()
++              // Stop retrying once we successfully found the ref and issued scrollTo
++              return
 +            }
-+            // Retry a few times to ensure scroll is applied
++            // Only retry if ref was not available yet
 +            if (attempt < 3) {
 +              setTimeout(() => scrollToPosition(attempt + 1), 50)
 +            }
@@ -261,7 +263,7 @@ index e782b90..13b1cfe 100644
  
        const onTabPress = React.useCallback(
          (name: TabName) => {
-@@ -344,55 +456,94 @@ export const Container = React.memo(
+@@ -344,55 +458,94 @@ export const Container = React.memo(
            getCurrentIndex: () => {
              return index.value
            },
@@ -393,7 +395,7 @@ index e782b90..13b1cfe 100644
                  style={[styles.container, styles.headerContainer]}
                  onLayout={getHeaderHeight}
                  pointerEvents="box-none"
-@@ -407,8 +558,9 @@ export const Container = React.memo(
+@@ -407,8 +560,9 @@ export const Container = React.memo(
                      onTabPress,
                      tabProps,
                    })}
@@ -404,7 +406,7 @@ index e782b90..13b1cfe 100644
                  style={[styles.container, styles.tabBarContainer]}
                  onLayout={getTabBarHeight}
                  pointerEvents="box-none"
-@@ -425,7 +577,7 @@ export const Container = React.memo(
+@@ -425,7 +579,7 @@ export const Container = React.memo(
                      tabProps,
                    })}
                </View>
@@ -414,7 +416,7 @@ index e782b90..13b1cfe 100644
              <AnimatedPagerView
                ref={containerRef}
 diff --git a/node_modules/react-native-collapsible-tab-view/src/FlashList.tsx b/node_modules/react-native-collapsible-tab-view/src/FlashList.tsx
-index 9ce60da..d9282a3 100644
+index 9ce60da..d8f162e 100644
 --- a/node_modules/react-native-collapsible-tab-view/src/FlashList.tsx
 +++ b/node_modules/react-native-collapsible-tab-view/src/FlashList.tsx
 @@ -3,6 +3,7 @@ import type {
@@ -494,12 +496,12 @@ index 9ce60da..d9282a3 100644
        bouncesZoom={false}
        onScroll={scrollHandler}
 -      scrollEventThrottle={16}
-+      scrollEventThrottle={1}
++      scrollEventThrottle={useNativeHeaderAnimation ? 1 : 16}
        contentInset={memoContentInset}
        contentOffset={memoContentOffset}
        refreshControl={memoRefreshControl}
 diff --git a/node_modules/react-native-collapsible-tab-view/src/FlatList.tsx b/node_modules/react-native-collapsible-tab-view/src/FlatList.tsx
-index e7a6981..e58a15f 100644
+index e7a6981..8e9ad9e 100644
 --- a/node_modules/react-native-collapsible-tab-view/src/FlatList.tsx
 +++ b/node_modules/react-native-collapsible-tab-view/src/FlatList.tsx
 @@ -1,5 +1,5 @@
@@ -552,12 +554,12 @@ index e7a6981..e58a15f 100644
        onScroll={scrollHandler}
        onContentSizeChange={scrollContentSizeChangeHandlers}
 -      scrollEventThrottle={16}
-+      scrollEventThrottle={1}
++      scrollEventThrottle={useNativeHeaderAnimation ? 1 : 16}
        contentInset={memoContentInset}
        contentOffset={memoContentOffset}
        automaticallyAdjustContentInsets={false}
 diff --git a/node_modules/react-native-collapsible-tab-view/src/MasonryFlashList.tsx b/node_modules/react-native-collapsible-tab-view/src/MasonryFlashList.tsx
-index 93756ae..6d0b2f5 100644
+index 93756ae..6f39353 100644
 --- a/node_modules/react-native-collapsible-tab-view/src/MasonryFlashList.tsx
 +++ b/node_modules/react-native-collapsible-tab-view/src/MasonryFlashList.tsx
 @@ -1,5 +1,6 @@
@@ -639,12 +641,12 @@ index 93756ae..6d0b2f5 100644
        bouncesZoom={false}
        onScroll={scrollHandler}
 -      scrollEventThrottle={16}
-+      scrollEventThrottle={1}
++      scrollEventThrottle={useNativeHeaderAnimation ? 1 : 16}
        contentInset={memoContentInset}
        contentOffset={memoContentOffset}
        refreshControl={memoRefreshControl}
 diff --git a/node_modules/react-native-collapsible-tab-view/src/ScrollView.tsx b/node_modules/react-native-collapsible-tab-view/src/ScrollView.tsx
-index 712a65b..fc9752b 100644
+index 712a65b..1236dfb 100644
 --- a/node_modules/react-native-collapsible-tab-view/src/ScrollView.tsx
 +++ b/node_modules/react-native-collapsible-tab-view/src/ScrollView.tsx
 @@ -1,5 +1,5 @@
@@ -697,12 +699,12 @@ index 712a65b..fc9752b 100644
          onScroll={scrollHandler}
          onContentSizeChange={scrollContentSizeChangeHandlers}
 -        scrollEventThrottle={16}
-+        scrollEventThrottle={1}
++        scrollEventThrottle={useNativeHeaderAnimation ? 1 : 16}
          contentInset={memoContentInset}
          contentOffset={memoContentOffset}
          automaticallyAdjustContentInsets={false}
 diff --git a/node_modules/react-native-collapsible-tab-view/src/SectionList.tsx b/node_modules/react-native-collapsible-tab-view/src/SectionList.tsx
-index 2bd6b9c..ac74e88 100644
+index 2bd6b9c..80c7377 100644
 --- a/node_modules/react-native-collapsible-tab-view/src/SectionList.tsx
 +++ b/node_modules/react-native-collapsible-tab-view/src/SectionList.tsx
 @@ -1,5 +1,5 @@
@@ -757,12 +759,12 @@ index 2bd6b9c..ac74e88 100644
        onScroll={scrollHandler}
        onContentSizeChange={scrollContentSizeChangeHandlers}
 -      scrollEventThrottle={16}
-+      scrollEventThrottle={1}
++      scrollEventThrottle={useNativeHeaderAnimation ? 1 : 16}
        contentInset={memoContentInset}
        contentOffset={memoContentOffset}
        automaticallyAdjustContentInsets={false}
 diff --git a/node_modules/react-native-collapsible-tab-view/src/hooks.tsx b/node_modules/react-native-collapsible-tab-view/src/hooks.tsx
-index ba7dffa..4b21c8e 100644
+index ba7dffa..7e961e9 100644
 --- a/node_modules/react-native-collapsible-tab-view/src/hooks.tsx
 +++ b/node_modules/react-native-collapsible-tab-view/src/hooks.tsx
 @@ -8,7 +8,7 @@ import {
@@ -774,26 +776,30 @@ index ba7dffa..4b21c8e 100644
  import { ContainerRef, RefComponent } from 'react-native-collapsible-tab-view'
  import { PagerViewOnPageScrollEvent } from 'react-native-pager-view'
  import Animated, {
-@@ -101,7 +101,11 @@ export function useTabProps<T extends TabName>(
+@@ -101,7 +101,13 @@ export function useTabProps<T extends TabName>(
   */
  export function useTabsContext(): ContextType<TabName> {
    const c = useContext(Context)
 -  if (!c) throw new Error('useTabsContext must be inside a Tabs.Container')
-+  // if (!c) throw new Error('useTabsContext must be inside a Tabs.Container')
 +  if (!c) {
++    if (__DEV__) {
++      throw new Error('useTabsContext must be inside a Tabs.Container')
++    }
 +    console.error('useTabsContext must be inside a Tabs.Container')
 +    return {} as ContextType<TabName>
 +  }
    return c
  }
  
-@@ -114,23 +118,36 @@ export function useTabsContext(): ContextType<TabName> {
+@@ -114,23 +120,38 @@ export function useTabsContext(): ContextType<TabName> {
   */
  export function useTabNameContext(): TabName {
    const c = useContext(TabNameContext)
 -  if (!c) throw new Error('useTabNameContext must be inside a TabNameContext')
-+  // if (!c) throw new Error('useTabNameContext must be inside a TabNameContext')
 +  if (!c) {
++    if (__DEV__) {
++      throw new Error('useTabNameContext must be inside a TabNameContext')
++    }
 +    console.error('useTabNameContext must be inside a TabNameContext')
 +    return '' as TabName
 +  }
@@ -829,7 +835,7 @@ index ba7dffa..4b21c8e 100644
  }
  /**
   * Hook to access some key styles that make the whole thing work.
-@@ -265,10 +282,13 @@ export const useScrollHandlerY = (name: TabName) => {
+@@ -265,10 +286,13 @@ export const useScrollHandlerY = (name: TabName) => {
      accScrollY,
      offset,
      headerScrollDistance,
@@ -843,7 +849,7 @@ index ba7dffa..4b21c8e 100644
    } = useTabsContext()
  
    const enabled = useSharedValue(false)
-@@ -296,10 +316,13 @@ export const useScrollHandlerY = (name: TabName) => {
+@@ -296,10 +320,13 @@ export const useScrollHandlerY = (name: TabName) => {
    useAnimatedReaction(
      () => scrollAnimation.value,
      (val) => {
@@ -858,7 +864,7 @@ index ba7dffa..4b21c8e 100644
    )
  
    const onMomentumEnd = () => {
-@@ -403,6 +426,14 @@ export const useScrollHandlerY = (name: TabName) => {
+@@ -403,6 +430,14 @@ export const useScrollHandlerY = (name: TabName) => {
                accDiffClamp.value = Math.max(0, nextValue)
              }
            }
@@ -873,7 +879,7 @@ index ba7dffa..4b21c8e 100644
          }
        },
        onBeginDrag: () => {
-@@ -465,6 +496,9 @@ export const useScrollHandlerY = (name: TabName) => {
+@@ -465,6 +500,9 @@ export const useScrollHandlerY = (name: TabName) => {
        return isChangingPane
      },
      (isSyncNeeded, wasSyncNeeded) => {
@@ -883,7 +889,7 @@ index ba7dffa..4b21c8e 100644
        if (
          isSyncNeeded &&
          isSyncNeeded !== wasSyncNeeded &&
-@@ -505,10 +539,67 @@ export const useScrollHandlerY = (name: TabName) => {
+@@ -505,10 +543,68 @@ export const useScrollHandlerY = (name: TabName) => {
          }
        }
      },
@@ -909,10 +915,11 @@ index ba7dffa..4b21c8e 100644
 +          // Directly write to shared values from JS thread (allowed)
 +          // Header animation is driven by native interpolation, so no lag
 +          scrollYCurrent.value = adjustedY
-+          // Use spread operator to trigger SharedValue synchronization
-+          // Direct property assignment (scrollY.value[name] = x) doesn't
-+          // trigger change detection between JS and UI threads
-+          scrollY.value = { ...scrollY.value, [name]: adjustedY }
++          // Direct property mutation avoids creating a new object on every
++          // scroll event (~1000/sec), reducing GC pressure. This is safe
++          // because no useAnimatedReaction watches scrollY directly — it's
++          // only read when focusedTab changes, which triggers independently.
++          scrollY.value[name] = adjustedY
 +          oldAccScrollY.value = accScrollY.value
 +          accScrollY.value = adjustedY + offset.value
 +        }
@@ -953,7 +960,7 @@ index ba7dffa..4b21c8e 100644
  }
  
  type ForwardRefType<T> =
-@@ -579,11 +670,11 @@ export function useAfterMountEffect(
+@@ -579,11 +675,11 @@ export function useAfterMountEffect(
  export function useConvertAnimatedToValue<T>(
    animatedValue: Animated.SharedValue<T>
  ) {


### PR DESCRIPTION
## Summary

- Fix: Home tab 切换底部 tab 后再切回来，collapsible tab 内容区域消失的问题（iOS/Android 100% 必现）
- Root cause: `freezeOnBlur: true` 导致 `react-native-pager-view` 在 unfreeze 后丢失当前页面显示状态
- 之前 `jumpToTab(focusedTab)` 方案无效，因为 `onTabPress` 检测到 tab 已选中时只做 scroll-to-top，不调用 PagerView 的 `setPage`

## Changes

1. **native Tabs.Container 添加 forwardRef** — 让 `tabsRef` 在 native 端能正确拿到 ref
2. **Container.tsx patch 新增 `syncCurrentPage()`** — 直接调用 `setPageWithoutAnimation(index.value)`，绕过 `onTabPress` 的 "已选中则跳过" 逻辑
3. **HomePageView 添加 `useFocusEffect`** — Home tab 重新获焦时调用 `syncCurrentPage()` 强制 PagerView 显示正确页面
4. **useLayoutHeight 0-height guard** — 防止 freeze/unfreeze 过程中 `containerHeight` 被错误设为 0

## Test plan

- [ ] iOS: Home → Trade → Home → 验证所有 sub-tab 内容可见
- [ ] Android: Home → Trade → Home → 验证所有 sub-tab 内容可见
- [ ] 快速切换多个底部 tab 后回到 Home
- [ ] 选择 DeFi tab → 切走 → 切回 → 验证 DeFi 仍选中且内容可见
- [ ] 验证 collapsible header 滚动行为正常
- [ ] 验证下拉刷新正常
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
