### PR TITLE
fix: close popover after copying referral link(OK-50419)

### DIFF
--- a/packages/kit/src/views/ReferFriends/pages/InviteReward/components/shared/ReferralLinkPopoverContent.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/InviteReward/components/shared/ReferralLinkPopoverContent.tsx
@@ -10,6 +10,7 @@ import {
   YStack,
   useClipboard,
   useMedia,
+  usePopoverContext,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
@@ -90,6 +91,7 @@ export function ReferralLinkPopoverContent({
 }: IReferralLinkPopoverContentProps) {
   const intl = useIntl();
   const { copyUrl } = useClipboard();
+  const { closePopover } = usePopoverContext();
 
   const walletInviteUrl = useMemo(() => `${inviteUrl}/app`, [inviteUrl]);
   const shopInviteUrl = useMemo(() => `${inviteUrl}/shop`, [inviteUrl]);
@@ -97,12 +99,14 @@ export function ReferralLinkPopoverContent({
   const handleCopyWalletLink = useCallback(() => {
     copyUrl(walletInviteUrl);
     defaultLogger.referral.page.shareReferralLink('copy');
-  }, [copyUrl, walletInviteUrl]);
+    void closePopover?.();
+  }, [closePopover, copyUrl, walletInviteUrl]);
 
   const handleCopyShopLink = useCallback(() => {
     copyUrl(shopInviteUrl);
     defaultLogger.referral.page.shareReferralLink('copy');
-  }, [copyUrl, shopInviteUrl]);
+    void closePopover?.();
+  }, [closePopover, copyUrl, shopInviteUrl]);
 
   return (
     <YStack p="$1" $md={{ pb: '$3' }}>


### PR DESCRIPTION
## Summary
- Fixed the issue where the Popover did not dismiss after copying a referral link (HW or On-chain) in the ReferralLinkPopoverContent component
- Used `usePopoverContext()` to obtain `closePopover` and call it after the copy action, consistent with the pattern used elsewhere in the codebase

## Test plan
- [ ] Open the referral link popover (both from the dropdown and the split button)
- [ ] Click on either referral link item (HW or On-chain)
- [ ] Verify the link is copied to clipboard
- [ ] Verify the popover closes after copying
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
