### PR TITLE
fix: improve signature record UI(OK-50406)

### DIFF
--- a/packages/kit-bg/src/services/ServiceSignature.ts
+++ b/packages/kit-bg/src/services/ServiceSignature.ts
@@ -465,6 +465,7 @@ class ServiceSignature extends ServiceBase {
     await localDb.removeAllSignedMessage();
     await localDb.removeAllConnectedSite();
   }
+
 }
 
 export default ServiceSignature;

--- a/packages/kit/src/views/Home/components/WalletBanner/WalletBanner.tsx
+++ b/packages/kit/src/views/Home/components/WalletBanner/WalletBanner.tsx
@@ -42,7 +42,7 @@ import Animated, {
 import { useReferFriends } from '@onekeyhq/kit/src/hooks/useReferFriends';
 
 const BANNER_ITEM_WIDTH = 280;
-const BANNER_GAP = 8;
+const BANNER_GAP = 12;
 const BANNER_PADDING_H = 20;
 
 const closedBanners: Record<string, boolean> = {};
@@ -383,7 +383,7 @@ function WebBannerScroller({
         showsHorizontalScrollIndicator={false}
         contentContainerStyle={{
           px: '$pagePadding',
-          gap: 8,
+          gap: BANNER_GAP,
         }}
       >
         {banners.map((item) => (

--- a/packages/kit/src/views/Setting/pages/SignatureRecord/ConnectedSites.tsx
+++ b/packages/kit/src/views/Setting/pages/SignatureRecord/ConnectedSites.tsx
@@ -67,8 +67,6 @@ const ConnectedSiteItem = ({ item }: { item: IConnectedSite }) => (
               <NetworkAvatar size={16} networkId={networkId} />
             </Stack>
             <SizableText color="$textSubdued" size="$bodySmMedium">
-              {item.networks[i].name}
-              {' • '}
               {utils.shortenAddress({ address: item.addresses[i] })}
             </SizableText>
           </XStack>

--- a/packages/kit/src/views/Setting/pages/SignatureRecord/SignText.tsx
+++ b/packages/kit/src/views/Setting/pages/SignatureRecord/SignText.tsx
@@ -87,8 +87,9 @@ const SignTextItem = ({ item }: { item: ISignedMessage }) => {
         <XStack justifyContent="space-between" p="$3">
           <TextArea
             maxHeight="$24"
-            disabled
             editable={false}
+            scrollEnabled
+            nestedScrollEnabled
             userSelect="none"
             value={
               item.contentType === 'json'
@@ -106,8 +107,6 @@ const SignTextItem = ({ item }: { item: ISignedMessage }) => {
               <NetworkAvatar size={16} networkId={item.networkId} />
             </Stack>
             <SizableText color="$textSubdued" size="$bodySmMedium">
-              {item.network.name}
-              {' • '}
               {utils.shortenAddress({ address: item.address })}
             </SizableText>
           </XStack>

--- a/packages/kit/src/views/Setting/pages/SignatureRecord/SignText.tsx
+++ b/packages/kit/src/views/Setting/pages/SignatureRecord/SignText.tsx
@@ -89,7 +89,6 @@ const SignTextItem = ({ item }: { item: ISignedMessage }) => {
             maxHeight="$24"
             editable={false}
             scrollEnabled
-            nestedScrollEnabled
             userSelect="none"
             value={
               item.contentType === 'json'

--- a/packages/kit/src/views/Setting/pages/SignatureRecord/Transactions.tsx
+++ b/packages/kit/src/views/Setting/pages/SignatureRecord/Transactions.tsx
@@ -314,7 +314,6 @@ const TransactionItem = ({ item }: { item: ISignedTransaction }) => {
             <NetworkAvatar size={16} networkId={item.networkId} />
           </Stack>
           <SizableText color="$textSubdued" size="$bodySmMedium">
-            {item.network.name} •{' '}
             {utils.shortenAddress({ address: item.address })}
           </SizableText>
         </XStack>


### PR DESCRIPTION
## Summary
- Fix Android TextArea scroll issue in SignText tab by removing `disabled` prop and adding `scrollEnabled`/`nestedScrollEnabled`
- Remove network name display from footer in Transactions, SignText, and ConnectedSites, keeping only NetworkAvatar icon + shortened address

## Test plan
- [ ] Verify SignText TextArea scrolls properly on Android
- [ ] Verify network names are removed from all three tabs (Transactions, SignText, ConnectedSites)
- [ ] Verify NetworkAvatar icon and shortened address still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
