### PR TITLE
feat: add tablet main view navigation ref for notification routing(OK-50333)

### DIFF
--- a/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
@@ -46,6 +46,10 @@ export const rootNavigationRef = createRef<NavigationContainerRef<any>>();
 appGlobals.$navigationRef = rootNavigationRef as MutableRefObject<
   NavigationContainerRef<any>
 >;
+appGlobals.$tabletMainViewNavigationRef =
+  tabletMainViewNavigationRef as MutableRefObject<
+    NavigationContainerRef<any>
+  >;
 
 export type IRouterChangeEvent = INavigationContainerProps['onStateChange'];
 const RouterEventContext = createContext<

--- a/packages/kit/src/views/Developer/pages/TabDeveloper.tsx
+++ b/packages/kit/src/views/Developer/pages/TabDeveloper.tsx
@@ -11,6 +11,7 @@ import {
   Stack,
   TextArea,
   YStack,
+  rootNavigationRef,
   useScrollContentTabBarOffset,
 } from '@onekeyhq/components';
 import type { IPageNavigationProp } from '@onekeyhq/components/src/layouts/Navigation';
@@ -21,6 +22,7 @@ import {
   EDAppConnectionModal,
   EModalRoutes,
   EModalSettingRoutes,
+  ERootRoutes,
   ETabDeveloperRoutes,
   ETabRoutes,
 } from '@onekeyhq/shared/src/routes';
@@ -204,7 +206,14 @@ const TabDeveloper = () => {
             <PartContainer title="Components">
               <Button
                 onPress={() => {
-                  navigation.push(ETabDeveloperRoutes.ComponentsGallery);
+                  rootNavigationRef.current?.navigate(ERootRoutes.Main, {
+                    screen: ETabRoutes.Developer,
+                    params: {
+                      screen: ETabDeveloperRoutes.ComponentsGallery
+                    }
+                  }, {
+                    pop: true,
+                  })
                 }}
               >
                 Gallery

--- a/packages/shared/src/appGlobals.ts
+++ b/packages/shared/src/appGlobals.ts
@@ -28,6 +28,7 @@ export type IAppGlobals = {
   $offscreenApiProxy: IOffscreenApi;
   $webembedApiProxy: IWebembedApi;
   $navigationRef: React.RefObject<NavigationContainerRef<any>>;
+  $tabletMainViewNavigationRef: React.RefObject<NavigationContainerRef<any>>;
   $defaultLogger?: DefaultLogger;
   $Toast?: IToast;
   $appStorage?: IAppStorage;
@@ -67,6 +68,7 @@ const appGlobals: IAppGlobals = {
   $offscreenApiProxy: undefined!,
   $webembedApiProxy: undefined!,
   $navigationRef: undefined!,
+  $tabletMainViewNavigationRef: undefined!,
   extJsBridgeUiToBg: undefined!,
   extJsBridgeOffscreenToBg: undefined!,
 };

--- a/packages/shared/src/utils/notificationsUtils.ts
+++ b/packages/shared/src/utils/notificationsUtils.ts
@@ -123,11 +123,34 @@ export async function navigateToNotificationDetailByLocalParams({
     }
   }
   if (screen === ERootRoutes.Main) {
-    await popToMainRoute();
-    await timerUtils.wait(350);
-    appGlobals.$navigationRef.current?.navigate(screen, navigationParams, {
-      pop: true,
-    });
+     if (
+      appGlobals.$tabletMainViewNavigationRef?.current &&
+      navigationParams?.screen &&
+      !navigationParams?.params?.screen
+    ) {
+      appGlobals.$tabletMainViewNavigationRef.current.navigate(
+        screen,
+        navigationParams, 
+        {
+          pop: true,
+        }
+      );
+      requestIdleCallback(() => {
+        appGlobals.$navigationRef.current?.navigate(
+        screen,
+        navigationParams, 
+        {
+          pop: true,
+        }
+      );
+      });
+    } else {
+      await popToMainRoute();
+      await timerUtils.wait(350);
+      appGlobals.$navigationRef.current?.navigate(screen, navigationParams, {
+        pop: true,
+      });
+    }
   } else if (screen === ERootRoutes.Modal) {
     let rootNavigator = appGlobals.$navigationRef.current;
     const rootState = appGlobals.$navigationRef.current?.getRootState();


### PR DESCRIPTION
## Summary
- Add `$tabletMainViewNavigationRef` to `appGlobals` for tablet-specific navigation
- Assign the tablet navigation ref in `NavigationContainer`
- Optimize notification navigation routing for tablet: use tablet main view ref when available to avoid unnecessary pop-to-main
- Update Developer tab ComponentsGallery navigation to use `rootNavigationRef`

## Test plan
- [ ] Verify notification deep link navigation works correctly on tablet
- [ ] Verify notification deep link navigation still works on phone
- [ ] Verify Developer > ComponentsGallery navigation works
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
