### PR TITLE
fix: adjust batch create account column width ratios(OK-50366)

### DIFF
--- a/packages/kit/src/views/AccountManagerStacks/pages/BatchCreateAccount/BatchCreateAccountPreview.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/BatchCreateAccount/BatchCreateAccountPreview.tsx
@@ -622,7 +622,7 @@ function BatchCreateAccountPreviewPage({
         align: 'left',
         dataIndex: 'address',
         columnProps: {
-          flexGrow: 4,
+          flexGrow: 5,
           flexBasis: 0,
         },
         render: (_: any, account: IBatchCreateAccount) => (
@@ -660,7 +660,7 @@ function BatchCreateAccountPreviewPage({
         align: 'right',
         dataIndex: 'balance',
         columnProps: {
-          flexGrow: 4,
+          flexGrow: 3,
           flexBasis: 0,
         },
         render: (_: any, account: IBatchCreateAccount) => (


### PR DESCRIPTION
## Summary
- Adjust flexGrow ratios in batch create account preview table: increase address column from 4 to 5 and decrease balance column from 4 to 3, giving more space to addresses.

## Test plan
- [ ] Open batch create account preview page
- [ ] Verify address column has more space and is not truncated
- [ ] Verify balance column still displays correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
