### PR TITLE
fix: prevent biology auth deadlock, fix dialog navigation crash, and clean up unused code(OK-50427)

### DIFF
--- a/packages/components/src/composite/Dialog/Footer.tsx
+++ b/packages/components/src/composite/Dialog/Footer.tsx
@@ -19,7 +19,7 @@ import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
-import { useKeyboardEvent, useSafeAreaInsets } from '../../hooks';
+import { useKeyboardEventWithoutNavigation, useSafeAreaInsets } from '../../hooks';
 import { Button, XStack } from '../../primitives';
 
 import { DialogContext } from './context';
@@ -119,7 +119,7 @@ const useSafeKeyboardAnimationStyle = () => {
     paddingBottom: keyboardHeightValue.value + bottom,
   }));
 
-  useKeyboardEvent({
+  useKeyboardEventWithoutNavigation({
     keyboardWillShow: (e) => {
       const height = e.endCoordinates.height;
       const keyboardHeight = height < 0 ? DEFAULT_KEYBOARD_HEIGHT : height;

--- a/packages/components/src/composite/Dialog/Footer.tsx
+++ b/packages/components/src/composite/Dialog/Footer.tsx
@@ -19,7 +19,10 @@ import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
-import { useKeyboardEventWithoutNavigation, useSafeAreaInsets } from '../../hooks';
+import {
+  useKeyboardEventWithoutNavigation,
+  useSafeAreaInsets,
+} from '../../hooks';
 import { Button, XStack } from '../../primitives';
 
 import { DialogContext } from './context';

--- a/packages/kit/src/components/BiologyAuthComponent/container/BiologyAuthSwitchContainer.tsx
+++ b/packages/kit/src/components/BiologyAuthComponent/container/BiologyAuthSwitchContainer.tsx
@@ -25,11 +25,11 @@ const BiologyAuthSwitchContainer = ({
   const [{ isSupport }] = usePasswordBiologyAuthInfoAtom();
   const [settings] = useSettingsPersistAtom();
   const onChange = useCallback(
-    async (checked: boolean) => {
-      try {
-        // https://github.com/facebook/react/issues/31819
-        // Page flicker caused by Suspense throttling behavior.
-        startViewTransition(async () => {
+    (checked: boolean) => {
+      // https://github.com/facebook/react/issues/31819
+      // Page flicker caused by Suspense throttling behavior.
+      startViewTransition(async () => {
+        try {
           const isPasswordSet =
             await backgroundApiProxy.servicePassword.checkPasswordSet();
           // When password is not set, skip promptPasswordVerify to avoid deadlock:
@@ -42,28 +42,28 @@ const BiologyAuthSwitchContainer = ({
             checked,
             skipAuth,
           );
-        });
-      } catch (e) {
-        const error = e as { message?: string; name?: string };
-        if (error?.name === BIOLOGY_AUTH_CANCEL_ERROR) {
+        } catch (e) {
+          const error = e as { message?: string; name?: string };
+          if (error?.name === BIOLOGY_AUTH_CANCEL_ERROR) {
+            Toast.error({
+              title: intl.formatMessage(
+                {
+                  id: ETranslations.auth_biometric_cancel,
+                },
+                { biometric: title },
+              ),
+            });
+            return;
+          }
           Toast.error({
-            title: intl.formatMessage(
-              {
-                id: ETranslations.auth_biometric_cancel,
-              },
-              { biometric: title },
-            ),
+            title: intl.formatMessage({
+              id: platformEnv.isDesktopWin
+                ? ETranslations.global_windows_hello_set_error
+                : ETranslations.global_touch_id_set_error,
+            }),
           });
-          return;
         }
-        Toast.error({
-          title: intl.formatMessage({
-            id: platformEnv.isDesktopWin
-              ? ETranslations.global_windows_hello_set_error
-              : ETranslations.global_touch_id_set_error,
-          }),
-        });
-      }
+      });
     },
     [intl, skipAuth, title],
   );

--- a/packages/kit/src/components/BiologyAuthComponent/container/BiologyAuthSwitchContainer.tsx
+++ b/packages/kit/src/components/BiologyAuthComponent/container/BiologyAuthSwitchContainer.tsx
@@ -30,7 +30,14 @@ const BiologyAuthSwitchContainer = ({
         // https://github.com/facebook/react/issues/31819
         // Page flicker caused by Suspense throttling behavior.
         startViewTransition(async () => {
-          await backgroundApiProxy.servicePassword.promptPasswordVerify();
+          const isPasswordSet =
+            await backgroundApiProxy.servicePassword.checkPasswordSet();
+          // When password is not set, skip promptPasswordVerify to avoid deadlock:
+          // promptPasswordVerify would show PASSWORD_SETUP dialog, but this switch
+          // is already inside that dialog, causing the mutex to never release.
+          if (isPasswordSet) {
+            await backgroundApiProxy.servicePassword.promptPasswordVerify();
+          }
           await backgroundApiProxy.servicePassword.setBiologyAuthEnable(
             checked,
             skipAuth,

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountValue.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountValue.tsx
@@ -69,7 +69,7 @@ function AccountValue(accountValue: {
       return new BigNumber(value ?? '0')
         .plus(
           accountDeFiOverview?.overview?.[linkedNetworkId ?? '']?.netWorth ??
-          '0',
+            '0',
         )
         .toFixed();
     }
@@ -108,10 +108,10 @@ function AccountValue(accountValue: {
     ) {
       const tokensValue =
         value[
-        accountUtils.buildAccountValueKey({
-          accountId: linkedAccountId,
-          networkId: linkedNetworkId,
-        })
+          accountUtils.buildAccountValueKey({
+            accountId: linkedAccountId,
+            networkId: linkedNetworkId,
+          })
         ];
       const accountDeFiValue =
         accountDeFiOverview?.overview?.[linkedNetworkId]?.netWorth;
@@ -140,7 +140,7 @@ function AccountValue(accountValue: {
         networkInfoMap[networkId] &&
         (networkInfoMap[networkId].mergeDeriveAssetsEnabled ||
           networkInfoMap[networkId].deriveType.toLowerCase() ===
-          deriveType.toLowerCase())
+            deriveType.toLowerCase())
       ) {
         return new BigNumber(acc ?? '0').plus(v ?? '0').toFixed();
       }
@@ -206,12 +206,12 @@ function AccountValueWithSpotlight({
   accountDeFiOverview,
 }: {
   accountValue:
-  | {
-    accountId: string;
-    currency: string | undefined;
-    value: Record<string, string> | string | undefined;
-  }
-  | undefined;
+    | {
+        accountId: string;
+        currency: string | undefined;
+        value: Record<string, string> | string | undefined;
+      }
+    | undefined;
   isOthersUniversal: boolean;
   index: number;
   linkedAccountId?: string;

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -18,7 +18,7 @@ import {
   useSplitMainView,
   useSplitSubView,
 } from '@onekeyhq/components';
-import type { ITabContainerRef } from '@onekeyhq/components';
+// import type { ITabContainerRef } from '@onekeyhq/components';
 import type { IPageNavigationProp } from '@onekeyhq/components/src/layouts/Navigation';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { LazyPageContainer } from '@onekeyhq/kit/src/components/LazyPageContainer';
@@ -59,7 +59,7 @@ import { HandleRebuildBrowserData } from '../../components/HandleData/HandleRebu
 import HeaderRightToolBar from '../../components/HeaderRightToolBar';
 import MobileBrowserBottomBar from '../../components/MobileBrowser/MobileBrowserBottomBar';
 import { useDAppNotifyChanges } from '../../hooks/useDAppNotifyChanges';
-import { useEdgeSwipeDetection } from '../../hooks/useEdgeSwipeDetection';
+// import { useEdgeSwipeDetection } from '../../hooks/useEdgeSwipeDetection';
 import useMobileBottomBarAnimation from '../../hooks/useMobileBottomBarAnimation';
 import {
   useActiveTabId,
@@ -340,47 +340,48 @@ function MobileBrowser() {
   });
 
   // Edge swipe detection for switching between Market / Browser / Earn
-  const marketTabsRef = useRef<ITabContainerRef>(null);
-  const earnTabsRef = useRef<ITabContainerRef>(null);
+  // Disabled for this version
+  // const marketTabsRef = useRef<ITabContainerRef>(null);
+  // const earnTabsRef = useRef<ITabContainerRef>(null);
 
-  const MARKET_TAB_COUNT = 2;
-  const EARN_TAB_COUNT = 3;
+  // const MARKET_TAB_COUNT = 2;
+  // const EARN_TAB_COUNT = 3;
 
-  const switchToMarket = useCallback(() => {
-    void backgroundApiProxy.serviceSetting.setSelectedBrowserTab(
-      ETranslations.global_market,
-    );
-  }, []);
-  const switchToBrowser = useCallback(() => {
-    void backgroundApiProxy.serviceSetting.setSelectedBrowserTab(
-      ETranslations.global_browser,
-    );
-  }, []);
-  const switchToEarn = useCallback(() => {
-    void backgroundApiProxy.serviceSetting.setSelectedBrowserTab(
-      ETranslations.global_earn,
-    );
-  }, []);
+  // const switchToMarket = useCallback(() => {
+  //   void backgroundApiProxy.serviceSetting.setSelectedBrowserTab(
+  //     ETranslations.global_market,
+  //   );
+  // }, []);
+  // const switchToBrowser = useCallback(() => {
+  //   void backgroundApiProxy.serviceSetting.setSelectedBrowserTab(
+  //     ETranslations.global_browser,
+  //   );
+  // }, []);
+  // const switchToEarn = useCallback(() => {
+  //   void backgroundApiProxy.serviceSetting.setSelectedBrowserTab(
+  //     ETranslations.global_earn,
+  //   );
+  // }, []);
 
   // Tab order (left → right): Market → Earn → Browser
-  const marketSwipeHandlers = useEdgeSwipeDetection({
-    tabsRef: marketTabsRef,
-    tabCount: MARKET_TAB_COUNT,
-    onSwipeLeft: switchToEarn, // Market → Earn
-  });
+  // const marketSwipeHandlers = useEdgeSwipeDetection({
+  //   tabsRef: marketTabsRef,
+  //   tabCount: MARKET_TAB_COUNT,
+  //   onSwipeLeft: switchToEarn, // Market → Earn
+  // });
 
-  const earnSwipeHandlers = useEdgeSwipeDetection({
-    tabsRef: earnTabsRef,
-    tabCount: EARN_TAB_COUNT,
-    onSwipeLeft: switchToBrowser, // Earn → Browser
-    onSwipeRight: switchToMarket, // Earn → Market
-  });
+  // const earnSwipeHandlers = useEdgeSwipeDetection({
+  //   tabsRef: earnTabsRef,
+  //   tabCount: EARN_TAB_COUNT,
+  //   onSwipeLeft: switchToBrowser, // Earn → Browser
+  //   onSwipeRight: switchToMarket, // Earn → Market
+  // });
 
-  const browserSwipeHandlers = useEdgeSwipeDetection({
-    tabCount: 1,
-    onSwipeRight: switchToEarn, // Browser → Earn
-    screenEdgeWidth: 30,
-  });
+  // const browserSwipeHandlers = useEdgeSwipeDetection({
+  //   tabCount: 1,
+  //   onSwipeRight: switchToEarn, // Browser → Earn
+  //   screenEdgeWidth: 30,
+  // });
 
   const INITIAL_TAB_PAGE_HEIGHT_IOS = 153;
   const INITIAL_TAB_PAGE_HEIGHT_ANDROID = 100;
@@ -449,7 +450,6 @@ function MobileBrowser() {
         {/* Market Tab */}
         {isShowContent ? (
           <View
-            {...marketSwipeHandlers}
             style={{
               flex: 1,
               display:
@@ -460,7 +460,6 @@ function MobileBrowser() {
           >
             <MarketHomeWithProvider
               isFocused={selectedHeaderTab === ETranslations.global_market}
-              tabsRef={marketTabsRef}
             />
           </View>
         ) : null}
@@ -477,7 +476,6 @@ function MobileBrowser() {
           <HandleRebuildBrowserData />
           <Stack flex={1}>
             <View
-              {...browserSwipeHandlers}
               style={{
                 display: showDiscoveryPage ? 'flex' : 'none',
                 flex: showDiscoveryPage ? 1 : undefined,
@@ -509,7 +507,6 @@ function MobileBrowser() {
         </Stack>
         {isShowContent ? (
           <View
-            {...earnSwipeHandlers}
             style={{
               flex: 1,
               display:
@@ -522,7 +519,6 @@ function MobileBrowser() {
               showHeader={false}
               showContent={selectedHeaderTab === ETranslations.global_earn}
               defaultTab={earnTab}
-              tabsRef={earnTabsRef}
             />
           </View>
         ) : null}

--- a/packages/kit/src/views/Prime/components/PrimeLoginPasswordDialog/PrimeLoginPasswordDialog.tsx
+++ b/packages/kit/src/views/Prime/components/PrimeLoginPasswordDialog/PrimeLoginPasswordDialog.tsx
@@ -16,7 +16,7 @@ import {
   XStack,
   YStack,
   useForm,
-  useKeyboardEvent,
+  useKeyboardEventWithoutNavigation,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import type { IPrimeLoginDialogAtomPasswordData } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -215,7 +215,7 @@ export function PrimeLoginPasswordDialog({
 
   // OK-42373
   // Hide status bar when keyboard is shown
-  useKeyboardEvent({
+  useKeyboardEventWithoutNavigation({
     keyboardWillShow: () => {
       StatusBar.setHidden(true);
     },


### PR DESCRIPTION
## Summary
- **Fix biology auth deadlock**: Skip `promptPasswordVerify` when password is not set to avoid a deadlock caused by showing the PASSWORD_SETUP dialog inside itself
- **Fix dialog navigation crash**: Replace `useKeyboardEvent` with `useKeyboardEventWithoutNavigation` in `Dialog/Footer.tsx` and `PrimeLoginPasswordDialog.tsx` to prevent "Couldn't find a navigation object" crash when dialogs render outside NavigationContainer (e.g., in AppStateLock resetApp flow)
- **Disable edge swipe detection**: Comment out left/right swipe gesture detection for switching between Market / Browser / Earn tabs — not shipping in this version
- **Remove tablet navigation ref**: Clean up unused `$tabletMainViewNavigationRef` from appGlobals, NavigationContainer, and notification navigation logic
- **Clean up tab components**: Remove `syncCurrentPage` from tab container, simplify native Tabs Container (drop forwardRef), remove PagerView re-sync on focus in HomePageView
- **Update collapsible-tab-view patch**: Improve error handling, scroll handler fixes, and remove stale workarounds

## Test plan
- [ ] Toggle biology auth switch when no password is set — should not deadlock
- [ ] Toggle biology auth switch when password is set — should prompt for password as before
- [ ] Trigger `resetApp` from lock screen — should show reset dialog without navigation crash
- [ ] Verify Discovery page Market / Browser / Earn tabs work normally
- [ ] Verify Home page tab switching works correctly after bottom tab navigation
- [ ] Verify notification deep links navigate correctly