### PR TITLE
fix: reduce horizontal padding on wallet action card buttons(OK-50426)

### DIFF
--- a/packages/kit/src/views/Home/components/WalletActions/RawActions.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/RawActions.tsx
@@ -67,7 +67,7 @@ function ActionItem({
         borderRadius="$4"
         pt="$2.5"
         pb="$1"
-        px="$4"
+        px="$1"
         userSelect="none"
         hoverStyle={{ bg: '$bgStrongHover' }}
         pressStyle={{ bg: '$bgStrongActive' }}
@@ -247,7 +247,7 @@ function ActionMore({
         borderRadius="$4"
         pt="$2.5"
         pb="$1"
-        px="$4"
+        px="$1"
         userSelect="none"
         hoverStyle={{ bg: '$bgStrongHover' }}
         pressStyle={{ bg: '$bgStrongActive' }}


### PR DESCRIPTION
## Summary
- Reduce horizontal padding (`px`) from `$4` to `$1` on wallet action card-style buttons (`ActionItem` and `ActionMore`) to improve layout on mobile screens

## Test plan
- [ ] Verify wallet action buttons (Buy, Send, Receive, Swap, etc.) display correctly on mobile viewport
- [ ] Verify "More" action button padding matches other action buttons
- [ ] Verify desktop pill button style is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
