### PR TITLE
chore: disable edge swipe gesture between discovery sub-tabs

### DIFF
--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -59,7 +59,6 @@ import { HandleRebuildBrowserData } from '../../components/HandleData/HandleRebu
 import HeaderRightToolBar from '../../components/HeaderRightToolBar';
 import MobileBrowserBottomBar from '../../components/MobileBrowser/MobileBrowserBottomBar';
 import { useDAppNotifyChanges } from '../../hooks/useDAppNotifyChanges';
-import { useEdgeSwipeDetection } from '../../hooks/useEdgeSwipeDetection';
 import useMobileBottomBarAnimation from '../../hooks/useMobileBottomBarAnimation';
 import {
   useActiveTabId,
@@ -339,48 +338,8 @@ function MobileBrowser() {
     handleGoBackHome,
   });
 
-  // Edge swipe detection for switching between Market / Browser / Earn
   const marketTabsRef = useRef<ITabContainerRef>(null);
   const earnTabsRef = useRef<ITabContainerRef>(null);
-
-  const MARKET_TAB_COUNT = 2;
-  const EARN_TAB_COUNT = 3;
-
-  const switchToMarket = useCallback(() => {
-    void backgroundApiProxy.serviceSetting.setSelectedBrowserTab(
-      ETranslations.global_market,
-    );
-  }, []);
-  const switchToBrowser = useCallback(() => {
-    void backgroundApiProxy.serviceSetting.setSelectedBrowserTab(
-      ETranslations.global_browser,
-    );
-  }, []);
-  const switchToEarn = useCallback(() => {
-    void backgroundApiProxy.serviceSetting.setSelectedBrowserTab(
-      ETranslations.global_earn,
-    );
-  }, []);
-
-  // Tab order (left → right): Market → Earn → Browser
-  const marketSwipeHandlers = useEdgeSwipeDetection({
-    tabsRef: marketTabsRef,
-    tabCount: MARKET_TAB_COUNT,
-    onSwipeLeft: switchToEarn, // Market → Earn
-  });
-
-  const earnSwipeHandlers = useEdgeSwipeDetection({
-    tabsRef: earnTabsRef,
-    tabCount: EARN_TAB_COUNT,
-    onSwipeLeft: switchToBrowser, // Earn → Browser
-    onSwipeRight: switchToMarket, // Earn → Market
-  });
-
-  const browserSwipeHandlers = useEdgeSwipeDetection({
-    tabCount: 1,
-    onSwipeRight: switchToEarn, // Browser → Earn
-    screenEdgeWidth: 30,
-  });
 
   const INITIAL_TAB_PAGE_HEIGHT_IOS = 153;
   const INITIAL_TAB_PAGE_HEIGHT_ANDROID = 100;
@@ -449,7 +408,6 @@ function MobileBrowser() {
         {/* Market Tab */}
         {isShowContent ? (
           <View
-            {...marketSwipeHandlers}
             style={{
               flex: 1,
               display:
@@ -477,7 +435,6 @@ function MobileBrowser() {
           <HandleRebuildBrowserData />
           <Stack flex={1}>
             <View
-              {...browserSwipeHandlers}
               style={{
                 display: showDiscoveryPage ? 'flex' : 'none',
                 flex: showDiscoveryPage ? 1 : undefined,
@@ -509,7 +466,6 @@ function MobileBrowser() {
         </Stack>
         {isShowContent ? (
           <View
-            {...earnSwipeHandlers}
             style={{
               flex: 1,
               display:


### PR DESCRIPTION
## Summary
- Remove edge swipe detection for switching between Market, Earn, and Browser tabs in the mobile Discovery page
- Resolves gesture conflicts between inner PagerView/ScrollView swipes and outer tab switching
- Users can still switch tabs via the header segment control (tap to switch)

## Changes
- Removed `useEdgeSwipeDetection` hook usage and import from `Browser.native.tsx`
- Removed swipe handler callbacks (`switchToMarket`, `switchToBrowser`, `switchToEarn`)
- Removed spread of swipe handlers on Market, Browser, and Earn tab containers
- Kept `useEdgeSwipeDetection` hook file intact for potential future re-enablement

## Test plan
- [ ] Verify Market / Earn / Browser tabs switch correctly via header segment tap
- [ ] Verify no gesture conflicts in Market tab (inner PagerView scrolling)
- [ ] Verify no gesture conflicts in Earn tab (inner PagerView scrolling)
- [ ] Verify Browser WebView scrolling works without interference
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
