### PR TITLE
fix: add guard for undefined networkId in BulkCopyAddresses

### DIFF
--- a/packages/kit/src/views/BulkCopyAddresses/pages/BulkCopyAddresses.tsx
+++ b/packages/kit/src/views/BulkCopyAddresses/pages/BulkCopyAddresses.tsx
@@ -797,6 +797,9 @@ function BulkCopyAddresses({
 
   useEffect(() => {
     const getDefaultDeriveType = async () => {
+      if (!selectedNetworkId) {
+        return;
+      }
       const deriveType =
         await backgroundApiProxy.serviceNetwork.getGlobalDeriveTypeOfNetwork({
           networkId: selectedNetworkId,

--- a/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeBenefitsList.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeBenefitsList.tsx
@@ -175,6 +175,9 @@ export function PrimeBenefitsList({
               networkId,
               allNetworkFallbackToBtc: true,
             });
+            if (!fallbackNetworkId) {
+              return;
+            }
             navigation.navigate(EModalRoutes.BulkCopyAddressesModal, {
               screen: EModalBulkCopyAddressesRoutes.BulkCopyAddressesModal,
               params: {


### PR DESCRIPTION
## Summary
- Add null check for `selectedNetworkId` in `BulkCopyAddresses` `useEffect` before calling `getGlobalDeriveTypeOfNetwork`, preventing `TypeError: Cannot read properties of undefined (reading 'split')` crash
- Add guard in `PrimeBenefitsList` to prevent navigation to `BulkCopyAddressesModal` when `fallbackNetworkId` is undefined

## Test plan
- [ ] Navigate to PrimeDashboard -> click "Bulk Copy Addresses" when no network is selected
- [ ] Verify no crash occurs and the app handles the undefined networkId gracefully
- [ ] Verify normal flow (with valid networkId) still works correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
