### PR TITLE
fix: unify text size to bodyLgMedium in onboarding pages

### DIFF
--- a/packages/kit/src/views/Onboardingv2/pages/AddExistingWallet.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/AddExistingWallet.tsx
@@ -233,14 +233,7 @@ export default function AddExistingWallet() {
                 <Icon name={icon} />
               </YStack>
               <YStack gap={2} flex={1}>
-                <SizableText
-                  size="$bodyMdMedium"
-                  $platform-native={{
-                    size: '$bodyLgMedium',
-                  }}
-                >
-                  {title}
-                </SizableText>
+                <SizableText size="$bodyLgMedium">{title}</SizableText>
                 {description ? (
                   <SizableText size="$bodySm" color="$textSubdued">
                     {Array.isArray(description)

--- a/packages/kit/src/views/Onboardingv2/pages/CreateOrImportWallet.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/CreateOrImportWallet.tsx
@@ -58,7 +58,7 @@ function CardTitle({
 }: { children: React.ReactNode } & ISizableTextProps) {
   return (
     <SizableText
-      size="$bodyMdMedium"
+      size="$bodyLgMedium"
       $platform-native={{
         size: '$bodyLgMedium',
       }}

--- a/packages/shared/src/locale/json/bn.json
+++ b/packages/shared/src/locale/json/bn.json
@@ -49,7 +49,7 @@
   "action_save": "সংরক্ষণ করুন",
   "add_existing_wallet_badge_phrases_length": "12–24 শব্দের পুনরুদ্ধার বাক্যাংশ সমর্থন করে",
   "add_existing_wallet_desc": "স্থানান্তর, পুনরুদ্ধার বা আমদানি",
-  "add_existing_wallet_title": "বিদ্যমান ওয়ালেট যোগ করুন",
+  "add_existing_wallet_title": "বিদ্যমান ওয়ালেট আমদানি করুন",
   "add_hidden_wallet_dialog_add_button_display": "ওয়ালেট তালিকায় \"Add Hidden Wallet\" দেখান",
   "add_hidden_wallet_dialog_add_button_display_toast": "আপনি ওয়ালেটের নামের পাশে থাকা \"•••\" বোতামে ট্যাপ করে একটি লুকানো ওয়ালেট যোগ করতে পারেন",
   "add_hidden_wallet_dialog_desc": "একটি হিডেন ওয়ালেট আপনার রিকভারি ফ্রেজে একটি Passphrase যোগ করে একটি আলাদা, সুরক্ষিত ওয়ালেট তৈরি করে।",

--- a/packages/shared/src/locale/json/de.json
+++ b/packages/shared/src/locale/json/de.json
@@ -49,7 +49,7 @@
   "action_save": "Speichern",
   "add_existing_wallet_badge_phrases_length": "Unterstützt Wiederherstellungsphrasen mit 12–24 Wörtern",
   "add_existing_wallet_desc": "Übertragen, wiederherstellen oder importieren",
-  "add_existing_wallet_title": "Vorhandenes Wallet hinzufügen",
+  "add_existing_wallet_title": "Bestehendes Wallet importieren",
   "add_hidden_wallet_dialog_add_button_display": "\"Verstecktes Wallet hinzufügen\" in der Wallet-Liste anzeigen",
   "add_hidden_wallet_dialog_add_button_display_toast": "Du kannst auf die Schaltfläche \"•••\" neben dem Wallet-Namen tippen, um ein verstecktes Wallet hinzuzufügen.",
   "add_hidden_wallet_dialog_desc": "Eine versteckte Wallet fügt deiner Wiederherstellungsphrase eine Passphrase hinzu, um eine separate, sichere Wallet zu erstellen.",

--- a/packages/shared/src/locale/json/en_US.json
+++ b/packages/shared/src/locale/json/en_US.json
@@ -49,7 +49,7 @@
   "action_save": "Save",
   "add_existing_wallet_badge_phrases_length": "Supports 12–24 word recovery phrases",
   "add_existing_wallet_desc": "Transfer, restore or import",
-  "add_existing_wallet_title": "Add existing wallet",
+  "add_existing_wallet_title": "Import existing wallet",
   "add_hidden_wallet_dialog_add_button_display": "Show \"Add Hidden Wallet\" on wallet list",
   "add_hidden_wallet_dialog_add_button_display_toast": "You can tap the \"•••\" button next to the wallet name to add a hidden wallet",
   "add_hidden_wallet_dialog_desc": "A hidden wallet adds a passphrase to your recovery phrase to create a separate, secure wallet.",

--- a/packages/shared/src/locale/json/es.json
+++ b/packages/shared/src/locale/json/es.json
@@ -49,7 +49,7 @@
   "action_save": "Guardar",
   "add_existing_wallet_badge_phrases_length": "Admite frases de recuperación de 12 a 24 palabras",
   "add_existing_wallet_desc": "Transferir, restaurar o importar",
-  "add_existing_wallet_title": "Agregar billetera existente",
+  "add_existing_wallet_title": "Importar una billetera existente",
   "add_hidden_wallet_dialog_add_button_display": "Mostrar \"Agregar billetera oculta\" en la lista de billeteras",
   "add_hidden_wallet_dialog_add_button_display_toast": "Puedes tocar el botón \"•••\" junto al nombre de la billetera para agregar una billetera oculta",
   "add_hidden_wallet_dialog_desc": "Una billetera oculta añade una Passphrase a tu frase de recuperación para crear una billetera separada y segura.",

--- a/packages/shared/src/locale/json/fr_FR.json
+++ b/packages/shared/src/locale/json/fr_FR.json
@@ -49,7 +49,7 @@
   "action_save": "Enregistrer",
   "add_existing_wallet_badge_phrases_length": "Prend en charge les phrases de récupération de 12 à 24 mots",
   "add_existing_wallet_desc": "Transférer, restaurer ou importer",
-  "add_existing_wallet_title": "Ajouter un portefeuille existant",
+  "add_existing_wallet_title": "Importer un portefeuille existant",
   "add_hidden_wallet_dialog_add_button_display": "Afficher « Ajouter un portefeuille caché » dans la liste des portefeuilles",
   "add_hidden_wallet_dialog_add_button_display_toast": "Vous pouvez appuyer sur le bouton \\\"•••\\\" à côté du nom du portefeuille pour ajouter un portefeuille caché",
   "add_hidden_wallet_dialog_desc": "Un portefeuille caché ajoute une Passphrase à votre phrase de récupération pour créer un portefeuille séparé et sécurisé.",

--- a/packages/shared/src/locale/json/hi_IN.json
+++ b/packages/shared/src/locale/json/hi_IN.json
@@ -49,7 +49,7 @@
   "action_save": "सहेजें",
   "add_existing_wallet_badge_phrases_length": "12–24 शब्दों वाले रिकवरी फ़्रेज़ का समर्थन करता है",
   "add_existing_wallet_desc": "ट्रांसफर, पुनर्स्थापना या आयात",
-  "add_existing_wallet_title": "मौजूदा वॉलेट जोड़ें",
+  "add_existing_wallet_title": "मौजूदा वॉलेट इम्पोर्ट करें",
   "add_hidden_wallet_dialog_add_button_display": "वॉलेट सूची में \"Add Hidden Wallet\" दिखाएँ",
   "add_hidden_wallet_dialog_add_button_display_toast": "आप वॉलेट के नाम के बगल में \"•••\" बटन पर टैप करके एक छुपा हुआ वॉलेट जोड़ सकते हैं।",
   "add_hidden_wallet_dialog_desc": "एक छिपा हुआ वॉलेट आपकी रिकवरी फ्रेज़ में एक Passphrase जोड़ता है, जिससे एक अलग और सुरक्षित वॉलेट बनता है।",

--- a/packages/shared/src/locale/json/id.json
+++ b/packages/shared/src/locale/json/id.json
@@ -49,7 +49,7 @@
   "action_save": "Simpan",
   "add_existing_wallet_badge_phrases_length": "Mendukung frasa pemulihan 12–24 kata",
   "add_existing_wallet_desc": "Transfer, memulihkan, atau mengimpor",
-  "add_existing_wallet_title": "Tambahkan dompet yang sudah ada",
+  "add_existing_wallet_title": "Impor dompet yang sudah ada",
   "add_hidden_wallet_dialog_add_button_display": "Tampilkan \"Tambah Dompet Tersembunyi\" di daftar dompet",
   "add_hidden_wallet_dialog_add_button_display_toast": "Anda dapat mengetuk tombol \"•••\" di sebelah nama dompet untuk menambahkan dompet tersembunyi",
   "add_hidden_wallet_dialog_desc": "Dompet tersembunyi menambahkan Passphrase ke frasa pemulihan Anda untuk membuat dompet terpisah yang aman.",

--- a/packages/shared/src/locale/json/it_IT.json
+++ b/packages/shared/src/locale/json/it_IT.json
@@ -49,7 +49,7 @@
   "action_save": "Salva",
   "add_existing_wallet_badge_phrases_length": "Supporta frasi di recupero da 12 a 24 parole",
   "add_existing_wallet_desc": "Trasferisci, ripristina o importa",
-  "add_existing_wallet_title": "Aggiungi portafoglio esistente",
+  "add_existing_wallet_title": "Importa un portafoglio esistente",
   "add_hidden_wallet_dialog_add_button_display": "Mostra \"Aggiungi portafoglio nascosto\" nell'elenco dei portafogli",
   "add_hidden_wallet_dialog_add_button_display_toast": "Puoi toccare il pulsante \"•••\" accanto al nome del portafoglio per aggiungere un portafoglio nascosto",
   "add_hidden_wallet_dialog_desc": "Un wallet nascosto aggiunge una Passphrase alla tua frase di recupero per creare un portafoglio separato e sicuro.",

--- a/packages/shared/src/locale/json/ja_JP.json
+++ b/packages/shared/src/locale/json/ja_JP.json
@@ -49,7 +49,7 @@
   "action_save": "保存",
   "add_existing_wallet_badge_phrases_length": "12～24語のリカバリーフレーズに対応",
   "add_existing_wallet_desc": "転送、復元、またはインポート",
-  "add_existing_wallet_title": "既存のウォレットを追加",
+  "add_existing_wallet_title": "既存ウォレットをインポート",
   "add_hidden_wallet_dialog_add_button_display": "ウォレットリストに「隠しウォレットを追加」を表示",
   "add_hidden_wallet_dialog_add_button_display_toast": "ウォレット名の横にある「•••」ボタンをタップすると、非表示ウォレットを追加できます。",
   "add_hidden_wallet_dialog_desc": "隠しウォレットは、リカバリーフレーズにPassphraseを追加することで、別の安全なウォレットを作成します。",

--- a/packages/shared/src/locale/json/ko_KR.json
+++ b/packages/shared/src/locale/json/ko_KR.json
@@ -49,7 +49,7 @@
   "action_save": "저장",
   "add_existing_wallet_badge_phrases_length": "12~24개 단어로 된 복구 구문 지원",
   "add_existing_wallet_desc": "전송, 복원 또는 가져오기",
-  "add_existing_wallet_title": "기존 지갑 추가",
+  "add_existing_wallet_title": "기존 지갑 가져오기",
   "add_hidden_wallet_dialog_add_button_display": "지갑 목록에 \"숨겨진 지갑 추가\" 표시",
   "add_hidden_wallet_dialog_add_button_display_toast": "지갑 이름 옆에 있는 \"•••\" 버튼을 탭하면 숨겨진 지갑을 추가할 수 있습니다.",
   "add_hidden_wallet_dialog_desc": "숨겨진 지갑은 복구 구문에 패스프레이즈를 추가하여 별도의 안전한 지갑을 만듭니다.",

--- a/packages/shared/src/locale/json/pt.json
+++ b/packages/shared/src/locale/json/pt.json
@@ -49,7 +49,7 @@
   "action_save": "Salvar",
   "add_existing_wallet_badge_phrases_length": "Suporta frases de recuperação de 12 a 24 palavras",
   "add_existing_wallet_desc": "Transferir, restaurar ou importar",
-  "add_existing_wallet_title": "Adicionar carteira existente",
+  "add_existing_wallet_title": "Importar carteira já existente",
   "add_hidden_wallet_dialog_add_button_display": "Mostrar \\\"Adicionar Carteira Oculta\\\" na lista de carteiras",
   "add_hidden_wallet_dialog_add_button_display_toast": "Você pode tocar no botão \\\"•••\\\" ao lado do nome da carteira para adicionar uma carteira oculta",
   "add_hidden_wallet_dialog_desc": "Uma carteira oculta adiciona uma Passphrase à sua frase de recuperação para criar uma carteira separada e segura.",

--- a/packages/shared/src/locale/json/pt_BR.json
+++ b/packages/shared/src/locale/json/pt_BR.json
@@ -49,7 +49,7 @@
   "action_save": "Salvar",
   "add_existing_wallet_badge_phrases_length": "Suporta frases de recuperação de 12 a 24 palavras",
   "add_existing_wallet_desc": "Transferir, restaurar ou importar",
-  "add_existing_wallet_title": "Adicionar carteira existente",
+  "add_existing_wallet_title": "Importar carteira já existente",
   "add_hidden_wallet_dialog_add_button_display": "Mostrar \\\"Adicionar Carteira Oculta\\\" na lista de carteiras",
   "add_hidden_wallet_dialog_add_button_display_toast": "Você pode tocar no botão \\\"•••\\\" ao lado do nome da carteira para adicionar uma carteira oculta",
   "add_hidden_wallet_dialog_desc": "Uma carteira oculta adiciona uma Passphrase à sua frase de recuperação para criar uma carteira separada e segura.",

--- a/packages/shared/src/locale/json/ru.json
+++ b/packages/shared/src/locale/json/ru.json
@@ -49,7 +49,7 @@
   "action_save": "Сохранить",
   "add_existing_wallet_badge_phrases_length": "Поддерживает мнемонические фразы восстановления из 12–24 слов",
   "add_existing_wallet_desc": "Перенести, восстановить или импортировать",
-  "add_existing_wallet_title": "Добавить существующий кошелёк",
+  "add_existing_wallet_title": "Импортировать уже созданный кошелёк",
   "add_hidden_wallet_dialog_add_button_display": "Показать «Добавить скрытый кошелёк» в списке кошельков",
   "add_hidden_wallet_dialog_add_button_display_toast": "Вы можете нажать кнопку «•••» рядом с названием кошелька, чтобы добавить скрытый кошелёк",
   "add_hidden_wallet_dialog_desc": "Скрытый кошелек добавляет Passphrase к вашей фразе восстановления, чтобы создать отдельный, защищённый кошелек.",

--- a/packages/shared/src/locale/json/th_TH.json
+++ b/packages/shared/src/locale/json/th_TH.json
@@ -49,7 +49,7 @@
   "action_save": "บันทึก",
   "add_existing_wallet_badge_phrases_length": "รองรับวลีการกู้คืน 12–24 คำ",
   "add_existing_wallet_desc": "ถ่ายโอน กู้คืน หรือ นำเข้า",
-  "add_existing_wallet_title": "เพิ่มกระเป๋าสตางค์ที่มีอยู่",
+  "add_existing_wallet_title": "นำเข้ากระเป๋าสตางค์เดิม",
   "add_hidden_wallet_dialog_add_button_display": "แสดง \"เพิ่มกระเป๋าเงินที่ซ่อนอยู่\" ในรายการกระเป๋าเงิน",
   "add_hidden_wallet_dialog_add_button_display_toast": "คุณสามารถแตะปุ่ม \"•••\" ถัดจากชื่อกระเป๋าเงินเพื่อเพิ่มกระเป๋าเงินที่ซ่อนไว้",
   "add_hidden_wallet_dialog_desc": "กระเป๋าเงินที่ซ่อนอยู่จะเพิ่ม Passphrase เข้าไปในวลีการกู้คืนของคุณ เพื่อสร้างกระเป๋าเงินแยกต่างหากที่ปลอดภัย",

--- a/packages/shared/src/locale/json/uk_UA.json
+++ b/packages/shared/src/locale/json/uk_UA.json
@@ -49,7 +49,7 @@
   "action_save": "Зберегти",
   "add_existing_wallet_badge_phrases_length": "Підтримує фрази відновлення з 12–24 слів",
   "add_existing_wallet_desc": "Перенести, відновити або імпортувати",
-  "add_existing_wallet_title": "Додати наявний гаманець",
+  "add_existing_wallet_title": "Імпортувати наявний гаманець",
   "add_hidden_wallet_dialog_add_button_display": "Показати \\\"Додати прихований гаманець\\\" у списку гаманців",
   "add_hidden_wallet_dialog_add_button_display_toast": "Ви можете натиснути кнопку \\\"•••\\\" поруч із назвою гаманця, щоб додати прихований гаманець",
   "add_hidden_wallet_dialog_desc": "Прихований гаманець додає Passphrase до вашої фрази відновлення, щоб створити окремий, захищений гаманець.",

--- a/packages/shared/src/locale/json/vi.json
+++ b/packages/shared/src/locale/json/vi.json
@@ -49,7 +49,7 @@
   "action_save": "Lưu",
   "add_existing_wallet_badge_phrases_length": "Hỗ trợ cụm từ khôi phục 12–24 từ",
   "add_existing_wallet_desc": "Chuyển, khôi phục hoặc nhập",
-  "add_existing_wallet_title": "Thêm ví hiện có",
+  "add_existing_wallet_title": "Nhập ví đã có",
   "add_hidden_wallet_dialog_add_button_display": "Hiển thị \"Thêm Ví Ẩn\" trên danh sách ví",
   "add_hidden_wallet_dialog_add_button_display_toast": "Bạn có thể nhấn vào nút \"•••\" bên cạnh tên ví để thêm một ví ẩn",
   "add_hidden_wallet_dialog_desc": "Ví ẩn thêm một Passphrase vào cụm từ khôi phục của bạn để tạo ra một ví riêng biệt và an toàn.",

--- a/packages/shared/src/locale/json/zh_CN.json
+++ b/packages/shared/src/locale/json/zh_CN.json
@@ -49,7 +49,7 @@
   "action_save": "保存",
   "add_existing_wallet_badge_phrases_length": "支持 12-24 个单词的助记词",
   "add_existing_wallet_desc": "传输、恢复或导入",
-  "add_existing_wallet_title": "添加现有钱包",
+  "add_existing_wallet_title": "导入现有钱包",
   "add_hidden_wallet_dialog_add_button_display": "在钱包列表上显示「添加隐藏钱包」",
   "add_hidden_wallet_dialog_add_button_display_toast": "您可以点击钱包名称右侧的「•••」按钮来添加隐藏钱包",
   "add_hidden_wallet_dialog_desc": "隐藏钱包通过在您的助记词上添加 Passphrase 来创建一个独立的、安全的钱包。",

--- a/packages/shared/src/locale/json/zh_HK.json
+++ b/packages/shared/src/locale/json/zh_HK.json
@@ -49,7 +49,7 @@
   "action_save": "儲存",
   "add_existing_wallet_badge_phrases_length": "支援 12–24 個字的助記詞",
   "add_existing_wallet_desc": "轉移、還原或匯入",
-  "add_existing_wallet_title": "添加現有錢包",
+  "add_existing_wallet_title": "導入現有錢包",
   "add_hidden_wallet_dialog_add_button_display": "在錢包列表上顯示「添加隱藏錢包」",
   "add_hidden_wallet_dialog_add_button_display_toast": "你可以點擊錢包名稱右側的「•••」按鈕來添加隱藏錢包",
   "add_hidden_wallet_dialog_desc": "隱藏錢包會在你的助記詞上添加 passphrase，以創建一個獨立、安全的錢包。",

--- a/packages/shared/src/locale/json/zh_TW.json
+++ b/packages/shared/src/locale/json/zh_TW.json
@@ -49,7 +49,7 @@
   "action_save": "保存",
   "add_existing_wallet_badge_phrases_length": "支援 12–24 個字的助記詞",
   "add_existing_wallet_desc": "轉移、還原或匯入",
-  "add_existing_wallet_title": "新增現有錢包",
+  "add_existing_wallet_title": "導入現有錢包",
   "add_hidden_wallet_dialog_add_button_display": "在錢包列表上顯示「新增隱藏錢包」",
   "add_hidden_wallet_dialog_add_button_display_toast": "您可以點擊錢包名稱右側的「•••」按鈕來新增隱藏錢包",
   "add_hidden_wallet_dialog_desc": "隱藏錢包會在您的助記詞中添加 Passphrase，以創建一個獨立且安全的錢包。",


### PR DESCRIPTION
## Summary
- Unified text size to `$bodyLgMedium` in onboarding pages (`AddExistingWallet` and `CreateOrImportWallet`)
- Removed redundant platform-specific size overrides where the native size was already `$bodyLgMedium`

## Test plan
- [ ] Verify text sizing on AddExistingWallet page (iOS, Android, Web)
- [ ] Verify text sizing on CreateOrImportWallet page (iOS, Android, Web)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
