### PR TITLE
fix: prevent range input overflow on desktop by allowing container flex shrink(OK-50424)

### DIFF
--- a/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/components/TableLayout.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/components/TableLayout.tsx
@@ -413,6 +413,7 @@ function AmountCard() {
                   placeholder="0"
                   keyboardType="decimal-pad"
                   containerProps={{
+                    flex: 1,
                     borderWidth: 0,
                   }}
                   bg="transparent"
@@ -470,6 +471,7 @@ function AmountCard() {
                   placeholder="0"
                   keyboardType="decimal-pad"
                   containerProps={{
+                    flex: 1,
                     borderWidth: 0,
                   }}
                   bg="transparent"


### PR DESCRIPTION
## Summary
- Add `flex: 1` to the Input `containerProps` in the BulkSend range amount inputs (min and max) in `TableLayout.tsx`
- This gives the GroupFrame container `flex-shrink: 1` (via CSS `flex: 1` = `grow:1 shrink:1 basis:0`), overriding Tamagui's web default `flex-shrink: 0`
- Prevents the input content from overflowing the parent container, which caused the fiat value and token symbol row to disappear when typing long numbers

## Test plan
- [ ] Desktop: Navigate to BulkSend → One-to-Many → Range mode
- [ ] Type a long decimal number in min/max input
- [ ] Verify the fiat value ($xx.xx) and token symbol (ETH) below the input remain visible
- [ ] Verify keyboard arrow keys work without causing the bottom row to disappear
- [ ] Verify mouse horizontal scroll within the input works correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
