### PR TITLE
fix(ios): prevent PagerView crash on duplicate states in queue

### DIFF
--- a/patches/react-native-pager-view+7.0.1.patch
+++ b/patches/react-native-pager-view+7.0.1.patch
@@ -81,7 +81,7 @@ index d5b82ff..adfb9a2 100644
      }
  
 diff --git a/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm b/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm
-index d52f532..e27b02e 100644
+index d52f532..b72d2ab 100644
 --- a/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm
 +++ b/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm
 @@ -29,6 +29,7 @@ @implementation RNCPagerViewComponentView {
@@ -170,7 +170,7 @@ index d52f532..e27b02e 100644
      [self disableSwipe];
      
      _destinationIndex = index;
-@@ -223,25 +255,61 @@ - (void)goTo:(NSInteger)index animated:(BOOL)animated {
+@@ -223,25 +255,71 @@ - (void)goTo:(NSInteger)index animated:(BOOL)animated {
  - (void)setPagerViewControllers:(NSInteger)index
                        direction:(UIPageViewControllerNavigationDirection)direction
                         animated:(BOOL)animated{
@@ -186,10 +186,10 @@ index d52f532..e27b02e 100644
 +    if (index < 0 || index >= _nativeChildrenViewControllers.count) {
 +        NSLog(@"[PagerView] setPagerViewControllers blocked: index %ld out of bounds (count=%lu)",
 +              (long)index, (unsigned long)_nativeChildrenViewControllers.count);
-         [self enableSwipe];
-         return;
-     }
-   
++        [self enableSwipe];
++        return;
++    }
++  
 +    // Validate view controller and its view
 +    UIViewController *targetVC = [_nativeChildrenViewControllers objectAtIndex:index];
 +    if (targetVC == nil || targetVC.view == nil) {
@@ -203,6 +203,16 @@ index d52f532..e27b02e 100644
 +    // Target page views are expected to have nil superview/window before being added to pageViewController
 +    // Checking for nil superview/window would block all legitimate page transitions
 +
++    // Prevent calling setViewControllers during an ongoing animated transition.
++    // UIPageViewController's internal _UIQueuingScrollView does not support
++    // concurrent enqueued transitions and will crash with
++    // "Duplicate states in queue" (NSInternalInconsistencyException).
++    if (transitioning && animated) {
++        NSLog(@"[PagerView] setPagerViewControllers blocked: already transitioning (index=%ld)", (long)index);
+         [self enableSwipe];
+         return;
+     }
+ 
 +    NSLog(@"[PagerView] setPagerViewControllers SUCCESS: index=%ld animated=%d", (long)index, animated);
 +
      transitioning = YES;
@@ -237,7 +247,7 @@ index d52f532..e27b02e 100644
              strongSelf->_currentIndex = index;
          }
          [strongSelf updateLayoutMetrics:strongSelf->_layoutMetrics oldLayoutMetrics:strongSelf->_oldLayoutMetrics];
-@@ -252,6 +320,11 @@ - (void)setPagerViewControllers:(NSInteger)index
+@@ -252,6 +330,11 @@ - (void)setPagerViewControllers:(NSInteger)index
  - (UIViewController *)nextControllerForController:(UIViewController *)controller
                                        inDirection:(UIPageViewControllerNavigationDirection)direction {
      NSUInteger numberOfPages = _nativeChildrenViewControllers.count;
@@ -249,7 +259,7 @@ index d52f532..e27b02e 100644
      NSInteger index = [_nativeChildrenViewControllers indexOfObject:controller];
      
      if (index == NSNotFound) {
-@@ -274,13 +347,22 @@ - (UIViewController *)currentlyDisplayed {
+@@ -274,13 +357,22 @@ - (UIViewController *)currentlyDisplayed {
  #pragma mark - UIScrollViewDelegate
  
  - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView {
@@ -272,7 +282,7 @@ index d52f532..e27b02e 100644
      eventEmitter->onPageScrollStateChanged(RNCViewPagerEventEmitter::OnPageScrollStateChanged{.pageScrollState =  RNCViewPagerEventEmitter::OnPageScrollStateChangedPageScrollState::Settling });
      
      if (!_overdrag) {
-@@ -300,12 +382,21 @@ - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoi
+@@ -300,12 +392,21 @@ - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoi
  }
  
  - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
@@ -294,7 +304,7 @@ index d52f532..e27b02e 100644
      BOOL isHorizontal = [self isHorizontal];
      CGFloat contentOffset = isHorizontal ? scrollView.contentOffset.x : scrollView.contentOffset.y;
      CGFloat frameSize = isHorizontal ? scrollView.frame.size.width : scrollView.frame.size.height;
-@@ -357,13 +448,18 @@ - (void)pageViewController:(UIPageViewController *)pageViewController
+@@ -357,13 +458,18 @@ - (void)pageViewController:(UIPageViewController *)pageViewController
          didFinishAnimating:(BOOL)finished
     previousViewControllers:(nonnull NSArray<UIViewController *> *)previousViewControllers
         transitionCompleted:(BOOL)completed {
@@ -314,7 +324,7 @@ index d52f532..e27b02e 100644
      }
  }
  
-@@ -427,10 +523,12 @@ - (BOOL)isLtrLayout {
+@@ -427,10 +533,12 @@ - (BOOL)isLtrLayout {
  
  - (void)sendScrollEventsForPosition:(NSInteger)position offset:(CGFloat)offset {
      const auto eventEmitter = [self pagerEventEmitter];


### PR DESCRIPTION
## Summary
- 修复 iOS 上 PagerView 快速切换 tab 时因 `Duplicate states in queue` 导致的致命崩溃
- 在 `setPagerViewControllers` 方法中增加 `transitioning` 状态守卫，防止在上一次动画过渡未完成时重复调用 `setViewControllers`
- 清理 patch 文件中误包含的 `android/build/` 构建产物

## Root Cause
`UIPageViewController` 内部的 `_UIQueuingScrollView` 不支持并发的入队过渡。当用户快速切换 tab 或程序化页面同步与用户操作重叠时，两次 `setViewControllers:direction:animated:completion:` 调用会导致队列中出现重复状态，触发 `NSInternalInconsistencyException` 断言崩溃。

现有 patch 已有 recycling、nil、边界检查等守卫，但缺少对 `transitioning` 状态的检查。

## Fix
```objc
if (transitioning && animated) {
    NSLog(@"[PagerView] setPagerViewControllers blocked: already transitioning");
    [self enableSwipe];
    return;
}
```

## Test plan
- [ ] iOS 上快速连续点击 Earn 区域的 Assets/Portfolio/FAQs tab，确认不崩溃
- [ ] 从其他页面导航回 TabDiscovery 后立即点击 tab，确认不崩溃
- [ ] 正常 tab 切换功能不受影响
- [ ] Android 行为无变化

Sentry Event: `6f5ce7dc764d49189bed67414df232e4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
