### PR TITLE
fix: resolve hamburger menu first item click blocked by drag region

### DIFF
--- a/packages/components/src/layouts/Navigation/Tab/TabBar/Menu.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/Menu.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import type {
   IMenu,
@@ -250,7 +251,8 @@ export function Menu() {
 export function MenuHamburger() {
   const [menu, setMenu] = useState<IMenu | null>(null);
   const [isOpen, setIsOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
   const themeName = useThemeName();
 
   useEffect(() => {
@@ -264,9 +266,10 @@ export function MenuHamburger() {
   // Close menu when clicking outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
       if (
-        containerRef.current &&
-        !containerRef.current.contains(event.target as Node)
+        (!triggerRef.current || !triggerRef.current.contains(target)) &&
+        (!dropdownRef.current || !dropdownRef.current.contains(target))
       ) {
         setIsOpen(false);
       }
@@ -304,6 +307,15 @@ export function MenuHamburger() {
     return itemArray;
   }, [menu]);
 
+  // Compute dropdown position from trigger element
+  const dropdownPosition = useMemo(() => {
+    if (isOpen && triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect();
+      return { top: rect.top, left: rect.right };
+    }
+    return { top: 0, left: 0 };
+  }, [isOpen]);
+
   if (
     allItems.length === 0 ||
     !menu ||
@@ -314,20 +326,45 @@ export function MenuHamburger() {
   }
 
   return (
-    <div
-      ref={containerRef}
-      className={`desktop-menu-container ${
-        themeName === 'light' ? 'light-theme' : ''
-      }`}
-    >
-      <div className="desktop-menu-trigger" onClick={toggleMenu}>
-        <Icon
-          name="MenuOutline"
-          size="$5"
-          color={themeName === 'light' ? '$iconSubdued' : '$icon'}
-        />
+    <>
+      <div
+        ref={triggerRef}
+        className={`desktop-menu-container ${
+          themeName === 'light' ? 'light-theme' : ''
+        }`}
+      >
+        <div className="desktop-menu-trigger" onClick={toggleMenu}>
+          <Icon
+            name="MenuOutline"
+            size="$5"
+            color={themeName === 'light' ? '$iconSubdued' : '$icon'}
+          />
+        </div>
       </div>
-      <MenuDropdown items={allItems} isOpen={isOpen} onClose={handleClose} />
-    </div>
+      {isOpen
+        ? createPortal(
+            <div
+              ref={dropdownRef}
+              className={`desktop-menu-dropdown open ${
+                themeName === 'light' ? 'light-theme' : ''
+              }`}
+              style={{
+                position: 'fixed',
+                top: dropdownPosition.top,
+                left: dropdownPosition.left,
+              }}
+            >
+              {allItems.map((item, index) => (
+                <MenuItemComponent
+                  key={`${item.commandId}-${index}`}
+                  item={item}
+                  onClose={handleClose}
+                />
+              ))}
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
   );
 }

--- a/packages/shared/src/web/index.css
+++ b/packages/shared/src/web/index.css
@@ -421,7 +421,9 @@ w3m-modal {
 
 /* Light theme support */
 .light-theme .desktop-menu-dropdown,
-.light-theme .desktop-menu-submenu {
+.desktop-menu-dropdown.light-theme,
+.light-theme .desktop-menu-submenu,
+.desktop-menu-dropdown.light-theme .desktop-menu-submenu {
   --menu-bg: #ffffff;
   --menu-border: #e5e5e5;
   --menu-text: #1a1a1a;


### PR DESCRIPTION
## Summary
- Desktop hamburger menu's first item (e.g. "OneKey") was unclickable because it overlapped with the `-webkit-app-region: drag` title bar zone
- Chromium ignores `no-drag` on absolutely-positioned children extending outside their parent's layout bounds
- Fix: render the dropdown via `createPortal` to `document.body`, completely separating it from the drag region's DOM hierarchy
- Updated light-theme CSS selectors to support the portal-rendered dropdown

## Test plan
- [ ] Open desktop app, click hamburger menu (☰) in top-left sidebar
- [ ] Verify the first menu item ("OneKey") is clickable and shows its submenu on hover
- [ ] Verify all other menu items work correctly
- [ ] Test in both light and dark themes
- [ ] Verify clicking outside the menu closes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
