### PR TITLE
fix: resolve iOS production navigation delay in Earn asset list

### DIFF
--- a/packages/kit/src/views/Earn/earnUtils.ts
+++ b/packages/kit/src/views/Earn/earnUtils.ts
@@ -77,7 +77,20 @@ export async function safePushToEarnRoute(
         tab: ETranslations.global_earn,
       });
     });
+    // On native platforms with native bottom tabs, navigate directly without
+    // deferring to a macrotask. The await timerUtils.wait(0) + dispatch pattern
+    // causes navigation to be detached from the touch event context, and iOS
+    // production won't flush the bridge call until the next user interaction.
+    (rootNavigationRef.current ?? navigation).navigate(ERootRoutes.Main, {
+      screen: targetTab,
+      params: {
+        screen: route,
+        params,
+      },
+    });
+    return;
   }
+
   await timerUtils.wait(0);
 
   const rootNavigation = rootNavigationRef.current;

--- a/packages/kit/src/views/Earn/earnUtils.ts
+++ b/packages/kit/src/views/Earn/earnUtils.ts
@@ -78,9 +78,10 @@ export async function safePushToEarnRoute(
       });
     });
     // On native platforms with native bottom tabs, navigate directly without
-    // deferring to a macrotask. The await timerUtils.wait(0) + dispatch pattern
-    // causes navigation to be detached from the touch event context, and iOS
-    // production won't flush the bridge call until the next user interaction.
+    // deferring to a delayed task. The await timerUtils.wait(0) + dispatch
+    // pattern causes navigation to be detached from the touch event context,
+    // and iOS production won't flush the bridge call until the next user
+    // interaction.
     (rootNavigationRef.current ?? navigation).navigate(ERootRoutes.Main, {
       screen: targetTab,
       params: {

--- a/packages/kit/src/views/Prime/pages/OneKeyId/index.tsx
+++ b/packages/kit/src/views/Prime/pages/OneKeyId/index.tsx
@@ -44,26 +44,24 @@ function OneKeyIdPage() {
     await timerUtils.wait(350);
   }, []);
 
-  const toPrimePage = useCallback(() => {
-    requestIdleCallback(async () => {
-      try {
-        if (isPrimeAvailable) {
-          if (platformEnv.isNative) {
-            await popCurrentModal();
-          }
-          rootNavigationRef.current?.navigate(ERootRoutes.iOSFullScreen, {
-            screen: EModalRoutes.PrimeModal,
-            params: {
-              screen: EPrimePages.PrimeDashboard,
-            },
-          });
+  const toPrimePage = useCallback(async () => {
+    try {
+      if (isPrimeAvailable) {
+        if (platformEnv.isNative) {
+          await popCurrentModal();
         }
-      } catch (e) {
-        defaultLogger.prime.subscription.onekeyIdLogout({
-          reason: `OneKeyIdPage: toPrimePage navigation error: ${String(e)}`,
+        rootNavigationRef.current?.navigate(ERootRoutes.iOSFullScreen, {
+          screen: EModalRoutes.PrimeModal,
+          params: {
+            screen: EPrimePages.PrimeDashboard,
+          },
         });
       }
-    });
+    } catch (e) {
+      defaultLogger.prime.subscription.onekeyIdLogout({
+        reason: `OneKeyIdPage: toPrimePage navigation error: ${String(e)}`,
+      });
+    }
   }, [isPrimeAvailable, popCurrentModal]);
 
   const handleLoggedOutWhileFocused = useCallback(async () => {

--- a/packages/kit/src/views/Prime/pages/OneKeyId/index.tsx
+++ b/packages/kit/src/views/Prime/pages/OneKeyId/index.tsx
@@ -44,24 +44,26 @@ function OneKeyIdPage() {
     await timerUtils.wait(350);
   }, []);
 
-  const toPrimePage = useCallback(async () => {
-    try {
-      if (isPrimeAvailable) {
-        if (platformEnv.isNative) {
-          await popCurrentModal();
+  const toPrimePage = useCallback(() => {
+    requestIdleCallback(async () => {
+      try {
+        if (isPrimeAvailable) {
+          if (platformEnv.isNative) {
+            await popCurrentModal();
+          }
+          rootNavigationRef.current?.navigate(ERootRoutes.iOSFullScreen, {
+            screen: EModalRoutes.PrimeModal,
+            params: {
+              screen: EPrimePages.PrimeDashboard,
+            },
+          });
         }
-        rootNavigationRef.current?.navigate(ERootRoutes.iOSFullScreen, {
-          screen: EModalRoutes.PrimeModal,
-          params: {
-            screen: EPrimePages.PrimeDashboard,
-          },
+      } catch (e) {
+        defaultLogger.prime.subscription.onekeyIdLogout({
+          reason: `OneKeyIdPage: toPrimePage navigation error: ${String(e)}`,
         });
       }
-    } catch (e) {
-      defaultLogger.prime.subscription.onekeyIdLogout({
-        reason: `OneKeyIdPage: toPrimePage navigation error: ${String(e)}`,
-      });
-    }
+    });
   }, [isPrimeAvailable, popCurrentModal]);
 
   const handleLoggedOutWhileFocused = useCallback(async () => {


### PR DESCRIPTION
## Summary
- On native platforms with native bottom tabs (`react-native-bottom-tabs`), the `safePushToEarnRoute` function deferred navigation dispatch via `await timerUtils.wait(0)` + `StackActions.push/replace`, causing the dispatch to land in a macrotask detached from the original touch event context
- iOS production (TestFlight) would not flush the pending native bridge call until the next user interaction (scroll/touch), resulting in a "tap does nothing until you swipe" symptom
- Fix: on native platforms, use `navigate()` with nested params directly (synchronous, within touch context) instead of the `wait(0)` + manual state query + dispatch path
- Non-native platforms (web/desktop/extension) are unaffected and retain existing behavior

## Test plan
- [ ] Verify on iOS TestFlight: tap a token in the Earn Available Assets list navigates immediately without requiring additional touch
- [ ] Verify on Android: navigation still works correctly
- [ ] Verify on Web/Desktop: no regression in Earn navigation behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
