### PR TITLE
fix: resolve iOS production navigation delays in Earn

### DIFF
--- a/packages/kit/src/views/Earn/earnUtils.ts
+++ b/packages/kit/src/views/Earn/earnUtils.ts
@@ -70,30 +70,6 @@ export async function safePushToEarnRoute(
     ? ETabRoutes.Discovery
     : ETabRoutes.Earn;
 
-  navigation.switchTab(targetTab);
-  if (platformEnv.isNative) {
-    void timerUtils.wait(150).then(() => {
-      appEventBus.emit(EAppEventBusNames.SwitchDiscoveryTabInNative, {
-        tab: ETranslations.global_earn,
-      });
-    });
-    // On native platforms with native bottom tabs, navigate directly without
-    // deferring to a delayed task. The await timerUtils.wait(0) + dispatch
-    // pattern causes navigation to be detached from the touch event context,
-    // and iOS production won't flush the bridge call until the next user
-    // interaction.
-    (rootNavigationRef.current ?? navigation).navigate(ERootRoutes.Main, {
-      screen: targetTab,
-      params: {
-        screen: route,
-        params,
-      },
-    });
-    return;
-  }
-
-  await timerUtils.wait(0);
-
   const rootNavigation = rootNavigationRef.current;
   const findTargetStack = (state?: NavigationState) => {
     if (!state) return undefined;
@@ -114,6 +90,53 @@ export async function safePushToEarnRoute(
     const targetKey = tabState?.key ?? tabRoute.key;
     return { targetKey, tabState };
   };
+
+  // On native, query state BEFORE switchTab. All tab states are already
+  // available since lazy: false, so we don't depend on switchTab's state
+  // synchronization timing with native bottom tabs.
+  const preQueryState = platformEnv.isNative && rootNavigation
+    ? findTargetStack(rootNavigation.getRootState?.())
+    : undefined;
+
+  navigation.switchTab(targetTab);
+  if (platformEnv.isNative) {
+    void timerUtils.wait(150).then(() => {
+      appEventBus.emit(EAppEventBusNames.SwitchDiscoveryTabInNative, {
+        tab: ETranslations.global_earn,
+      });
+    });
+
+    // Use pre-queried state to dispatch push synchronously within the touch
+    // event context. This avoids timerUtils.wait(0) which defers the dispatch
+    // to a task that iOS production won't flush until the next interaction.
+    const targetKey = preQueryState?.targetKey;
+    if (rootNavigation && targetKey) {
+      const { tabState } = preQueryState;
+      const topRoute = tabState?.routes?.[tabState.index || 0];
+      if (topRoute?.name === route) {
+        const action = StackActions.replace(route, params);
+        // @ts-expect-error target is added at runtime for navigator selection
+        action.target = targetKey;
+        rootNavigation.dispatch(action);
+      } else {
+        const action = StackActions.push(route, params);
+        // @ts-expect-error target is added at runtime for navigator selection
+        action.target = targetKey;
+        rootNavigation.dispatch(action);
+      }
+    } else {
+      (rootNavigation ?? navigation).navigate(ERootRoutes.Main, {
+        screen: targetTab,
+        params: {
+          screen: route,
+          params,
+        },
+      });
+    }
+    return;
+  }
+
+  await timerUtils.wait(0);
 
   if (!rootNavigation) {
     navigation.navigate(ERootRoutes.Main, {
@@ -263,15 +286,22 @@ export const EarnNavigation = {
   ) {
     if (platformEnv.isNative) {
       await navigation.popToMainRoute();
-      await timerUtils.wait(50);
+      // On native with native bottom tabs, execute synchronously to keep
+      // within the touch event context. Timer waits push operations to
+      // delayed tasks that iOS production won't flush until the next touch.
       switchTab(ETabRoutes.Discovery);
-      await timerUtils.wait(50);
       appEventBus.emit(EAppEventBusNames.SwitchDiscoveryTabInNative, {
         tab: ETranslations.global_earn,
       });
-    } else {
-      switchTab(ETabRoutes.Earn);
+      navigation.popToTop();
+      appEventBus.emit(EAppEventBusNames.SwitchEarnMode, { mode: 'earn' });
+      appEventBus.emit(EAppEventBusNames.SwitchEarnTab, {
+        tab: params?.tab ?? 'assets',
+      });
+      return;
     }
+
+    switchTab(ETabRoutes.Earn);
     await timerUtils.wait(50);
     navigation.popToTop();
     await timerUtils.wait(80);

--- a/packages/kit/src/views/Earn/earnUtils.ts
+++ b/packages/kit/src/views/Earn/earnUtils.ts
@@ -91,15 +91,6 @@ export async function safePushToEarnRoute(
     return { targetKey, tabState };
   };
 
-  // On native, query state BEFORE switchTab. All tab states are already
-  // available since lazy: false, so we don't depend on switchTab's state
-  // synchronization timing with native bottom tabs.
-  const preQueryState =
-    platformEnv.isNative && rootNavigation
-      ? findTargetStack(rootNavigation.getRootState?.())
-      : undefined;
-
-  navigation.switchTab(targetTab);
   if (platformEnv.isNative) {
     void timerUtils.wait(150).then(() => {
       appEventBus.emit(EAppEventBusNames.SwitchDiscoveryTabInNative, {
@@ -107,11 +98,30 @@ export async function safePushToEarnRoute(
       });
     });
 
-    // Use pre-queried state to dispatch push synchronously within the touch
-    // event context. This avoids timerUtils.wait(0) which defers the dispatch
-    // to a task that iOS production won't flush until the next interaction.
+    // EarnHome is not registered in the Discovery tab's stack navigator on
+    // native, so navigating to it would fail. Switching to the Earn sub-tab
+    // via the event above is sufficient to show the Earn home view.
+    if (route === ETabEarnRoutes.EarnHome) {
+      navigation.switchTab(targetTab);
+      return;
+    }
+
+    // Pre-query the Discovery tab's stack state. All tab states are available
+    // since lazy: false, so this works before any tab switch.
+    const preQueryState = rootNavigation
+      ? findTargetStack(rootNavigation.getRootState?.())
+      : undefined;
     const targetKey = preQueryState?.targetKey;
+
     if (rootNavigation && targetKey) {
+      // Push the route onto the Discovery stack BEFORE switching tabs.
+      // StackActions.push with target dispatches directly to the child stack
+      // navigator without updating the tab navigator's selectedPage. By
+      // pushing first and switching tab after, the two state changes are
+      // separated: the push updates only the Discovery stack, then switchTab
+      // updates only the tab selection. This avoids the iOS Release issue
+      // where simultaneous selectedPage + children changes caused the native
+      // tab bar to drop the selectedPage update.
       const { tabState } = preQueryState;
       const topRoute = tabState?.routes?.[tabState.index || 0];
       if (topRoute?.name === route) {
@@ -125,7 +135,9 @@ export async function safePushToEarnRoute(
         action.target = targetKey;
         rootNavigation.dispatch(action);
       }
+      navigation.switchTab(targetTab);
     } else {
+      navigation.switchTab(targetTab);
       (rootNavigation ?? navigation).navigate(ERootRoutes.Main, {
         screen: targetTab,
         params: {
@@ -136,6 +148,8 @@ export async function safePushToEarnRoute(
     }
     return;
   }
+
+  navigation.switchTab(targetTab);
 
   await timerUtils.wait(0);
 
@@ -287,15 +301,17 @@ export const EarnNavigation = {
   ) {
     if (platformEnv.isNative) {
       await navigation.popToMainRoute();
-      // On native with native bottom tabs, execute synchronously to keep
-      // within the touch event context. Timer waits push operations to
-      // delayed tasks that iOS production won't flush until the next touch.
       switchTab(ETabRoutes.Discovery);
       appEventBus.emit(EAppEventBusNames.SwitchDiscoveryTabInNative, {
         tab: ETranslations.global_earn,
       });
       navigation.popToTop();
       appEventBus.emit(EAppEventBusNames.SwitchEarnMode, { mode: 'earn' });
+      // Delay SwitchEarnTab to allow EarnMainTabs to mount and register
+      // its listener after popToMainRoute triggers a re-render. Since we
+      // already awaited popToMainRoute above, we are no longer in the
+      // synchronous touch event context, so timers will flush normally.
+      await timerUtils.wait(150);
       appEventBus.emit(EAppEventBusNames.SwitchEarnTab, {
         tab: params?.tab ?? 'assets',
       });

--- a/packages/kit/src/views/Earn/earnUtils.ts
+++ b/packages/kit/src/views/Earn/earnUtils.ts
@@ -94,9 +94,10 @@ export async function safePushToEarnRoute(
   // On native, query state BEFORE switchTab. All tab states are already
   // available since lazy: false, so we don't depend on switchTab's state
   // synchronization timing with native bottom tabs.
-  const preQueryState = platformEnv.isNative && rootNavigation
-    ? findTargetStack(rootNavigation.getRootState?.())
-    : undefined;
+  const preQueryState =
+    platformEnv.isNative && rootNavigation
+      ? findTargetStack(rootNavigation.getRootState?.())
+      : undefined;
 
   navigation.switchTab(targetTab);
   if (platformEnv.isNative) {

--- a/packages/shared/src/locale/json/zh_HK.json
+++ b/packages/shared/src/locale/json/zh_HK.json
@@ -2633,7 +2633,7 @@
   "perp.position_tp_sl": "止盈/止損",
   "perp.position_view_orders": "查看訂單",
   "perp.setting_desc": "啟用後，下單時將跳過確認環節，直接提交訂單",
-  "perp.setting_interface": "永續合約介面",
+  "perp.setting_interface": "永續合約界面",
   "perp.setting_interface_native_desc": "使用應用原生組件，響應更快，體驗更流暢",
   "perp.setting_interface_native_title": "原生界面",
   "perp.setting_interface_web_desc": "載入 Hyperliuqid 網頁版本，更多功能",

--- a/packages/shared/src/locale/json/zh_TW.json
+++ b/packages/shared/src/locale/json/zh_TW.json
@@ -2633,7 +2633,7 @@
   "perp.position_tp_sl": "止盈/止損",
   "perp.position_view_orders": "查看訂單",
   "perp.setting_desc": "啟用後，下單時將跳過確認環節，直接提交訂單",
-  "perp.setting_interface": "永續合約介面",
+  "perp.setting_interface": "永續合約界面",
   "perp.setting_interface_native_desc": "使用應用原生組件，響應更快，體驗更流暢",
   "perp.setting_interface_native_title": "原生界面",
   "perp.setting_interface_web_desc": "載入 Hyperliuqid 網頁版本，更多功能",


### PR DESCRIPTION
## Summary
- **safePushToEarnRoute**: pre-query target stack key BEFORE `switchTab()` (all tab states available since `lazy: false`), then dispatch `StackActions.push` synchronously within the touch event context. This preserves the navigation stack (fixing `popToTop` breakage from cross-tab entry) while avoiding `timerUtils.wait(0)` that iOS production defers until next user interaction
- **popToEarnHome**: remove timer waits between navigation operations on native to keep `switchTab` + `popToTop` + event emissions within the same synchronous execution context

Supersedes #10251 which used `navigate()` that resets the target tab's stack when crossing tabs.

## Test plan
- [ ] iOS TestFlight: tap token in Earn Available Assets list → navigates immediately
- [ ] iOS TestFlight: tap token from Banner / single-asset direct entry → navigates immediately
- [ ] iOS TestFlight: tap "Positions" on protocol details → pops back and switches to portfolio tab
- [ ] Android: no regression in Earn navigation
- [ ] Web/Desktop: no regression in Earn navigation

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
