### PR TITLE
fix: optimistically remove canceled orders from UI OK-49801

### DIFF
--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -72,6 +72,8 @@ type IChPositionLite = HL.IPerpsAssetPosition;
 class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
   private orderBookTickOptionsLoaded = false;
 
+  private canceledOrderIds = new Set<number>();
+
   private buildOpenOrdersByCoinMap(
     openOrders: HL.IPerpsFrontendOrder[],
     prevMap?: Record<string, HL.IPerpsFrontendOrder[]>,
@@ -234,7 +236,8 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       const prevOpenOrdersState = get(perpsActiveOpenOrdersAtom());
       const allOrders = data?.openOrders || [];
       const openOrders = allOrders.filter(
-        (order) => !order.coin.startsWith('@'),
+        (order) =>
+          !order.coin.startsWith('@') && !this.canceledOrderIds.has(order.oid),
       );
       const openOrdersByCoin = this.buildOpenOrdersByCoinMap(
         openOrders,
@@ -357,7 +360,8 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       const prevOpenOrdersState = get(perpsActiveOpenOrdersAtom());
       const allOrders = data?.orders || [];
       const openOrders = allOrders.filter(
-        (order) => !order.coin.startsWith('@'),
+        (order) =>
+          !order.coin.startsWith('@') && !this.canceledOrderIds.has(order.oid),
       );
       const openOrdersByCoin = this.buildOpenOrdersByCoinMap(
         openOrders,
@@ -787,6 +791,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       openOrdersByCoin: {},
     });
     perpsOpenOrdersByCoinAtomCache.clear();
+    this.canceledOrderIds.clear();
     const current = get(perpsLedgerUpdatesAtom());
     set(perpsLedgerUpdatesAtom(), {
       accountAddress: undefined,
@@ -816,6 +821,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       updates: [],
       isSubscribed: false,
     });
+    this.canceledOrderIds.clear();
     await this.changeActiveAsset.call(set, { coin: 'ETH', force: true });
   });
 
@@ -1080,6 +1086,27 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
                 oid: order.oid,
               })),
             );
+
+          // Track canceled order ids so UI can remove them immediately
+          for (const o of params.orders) {
+            this.canceledOrderIds.add(o.oid);
+          }
+
+          // Optimistically remove canceled orders from atom
+          const prev = get(perpsActiveOpenOrdersAtom());
+          const openOrders = prev.openOrders.filter(
+            (o) => !this.canceledOrderIds.has(o.oid),
+          );
+          const openOrdersByCoin = this.buildOpenOrdersByCoinMap(
+            openOrders,
+            prev.openOrdersByCoin,
+          );
+          set(perpsActiveOpenOrdersAtom(), {
+            ...prev,
+            openOrders,
+            openOrdersByCoin,
+          });
+
           return result;
         },
         actionType: EActionType.CANCEL_ORDER,


### PR DESCRIPTION
## Summary
- After canceling limit orders, UI relied entirely on WebSocket push to update. This caused canceled orders to linger, and clicking "Cancel All" would send stale oids to Hyperliquid, triggering API errors.
- Maintain a `canceledOids` Set in the actions class. On cancel success, add oids to Set and immediately remove them from the atom. Both WS handlers (`updateWebData2`, `updateOpenOrders`) also filter against the Set. Set is cleared on account switch.

## Changes
- `+1` property: `private canceledOids = new Set<number>()`
- `updateWebData2` / `updateOpenOrders`: append `&& !this.canceledOids.has(order.oid)` to existing filter
- `cancelOrder`: after API success, add oids to Set + optimistically update atom
- `clearActiveAccountData`: `this.canceledOids.clear()` on account switch

## Test plan
- [ ] Place a limit order → cancel it → confirm UI removes it immediately (no WS wait)
- [ ] Place 2-3 limit orders → cancel one → immediately click "Cancel All" → no API error
- [ ] After cancel, wait a few seconds for WS sync → confirm list stays consistent
- [ ] Switch accounts → confirm no stale oid interference
- [ ] Verify on desktop + web

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
