### PR TITLE
fix: prevent Earn protocol details footer from being blocked by TabBar

### DIFF
--- a/packages/kit/src/views/Earn/pages/EarnProtocolDetails/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnProtocolDetails/index.tsx
@@ -13,6 +13,7 @@ import {
   XStack,
   YStack,
   useMedia,
+  useScrollContentTabBarOffset,
   useShare,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
@@ -665,6 +666,8 @@ const EarnProtocolDetailsPage = ({ route }: { route: IRouteProps }) => {
     return false;
   }, [symbol]);
 
+  const tabBarHeight = useScrollContentTabBarOffset();
+
   const pageFooter = useMemo(() => {
     if (gtMd) {
       return null;
@@ -684,10 +687,11 @@ const EarnProtocolDetailsPage = ({ route }: { route: IRouteProps }) => {
         confirmButtonProps={{
           variant: 'primary',
           onPress,
+          mb: tabBarHeight,
         }}
       />
     );
-  }, [gtMd, intl, handleOpenManageModal, isCustomProtocol]);
+  }, [gtMd, intl, handleOpenManageModal, tabBarHeight, isCustomProtocol]);
 
   return (
     <EarnPageContainer


### PR DESCRIPTION
## Summary

Fixed the issue where the bottom action button on the Earn protocol details page was being blocked by the TabBar.

## Changes

- Added \`useScrollContentTabBarOffset\` hook to get the TabBar height
- Added \`mb: tabBarHeight\` to the Page.Footer confirm button to prevent blocking

## Testing

- [ ] Test on iOS device/simulator
- [ ] Test on Android device/simulator