### PR TITLE
Revert iOS tab switching animation fixes

### DIFF
--- a/patches/react-native-bottom-tabs+1.1.0.patch
+++ b/patches/react-native-bottom-tabs+1.1.0.patch
@@ -4,7 +4,7 @@ index 23cd875..3fe0e1d 100644
 +++ b/node_modules/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
 @@ -38,6 +38,12 @@ import com.google.android.material.navigation.NavigationBarView.LABEL_VISIBILITY
  import com.google.android.material.transition.platform.MaterialFadeThrough
-
+ 
  class ExtendedBottomNavigationView(context: Context) : BottomNavigationView(context) {
 +  init {
 +    // Disable automatic window insets handling to prevent extra padding
@@ -31,55 +31,25 @@ index 23cd875..3fe0e1d 100644
 +      onTabBarMeasuredListener?.invoke(tabBarHeight)
 +    }
    }
-
+ 
    fun updateItems(items: MutableList<TabInfo>) {
 diff --git a/node_modules/react-native-bottom-tabs/ios/TabViewImpl.swift b/node_modules/react-native-bottom-tabs/ios/TabViewImpl.swift
 index 72938be..a7a3c15 100644
 --- a/node_modules/react-native-bottom-tabs/ios/TabViewImpl.swift
 +++ b/node_modules/react-native-bottom-tabs/ios/TabViewImpl.swift
-@@ -80,18 +80,22 @@ struct TabViewImpl: View {
+@@ -80,7 +80,7 @@ struct TabViewImpl: View {
          .configureAppearance(props: props, tabBar: tabBar)
        #endif
        .tintColor(props.selectedActiveTintColor)
 -      .getSidebarAdaptable(enabled: props.sidebarAdaptable ?? false)
--      .onChange(of: props.selectedPage ?? "") { newValue in
--        #if !os(macOS)
--          if props.disablePageAnimations {
--            UIView.setAnimationsEnabled(false)
--            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
--              UIView.setAnimationsEnabled(true)
--            }
--          }
--        #endif
--        #if os(tvOS) || os(macOS) || os(visionOS)
--          onSelect(newValue)
--        #endif
--      }
 +      .applyTabViewStyle(sidebarAdaptable: props.sidebarAdaptable ?? false)
-+      .onChange(of: props.selectedPage ?? "") { newValue in
-+        #if os(tvOS) || os(macOS) || os(visionOS)
-+          onSelect(newValue)
-+        #endif
-+      }
-+      // Use SwiftUI transaction to disable tab switching animations instead of
-+      // the fragile UIView.setAnimationsEnabled(false) global hack.
-+      // The global approach could leave UITabBarController in an inconsistent
-+      // internal transition state when the disable/re-enable timing races with
-+      // the SwiftUI TabView transition, causing a probabilistic UI freeze.
-+      #if !os(macOS)
-+      .transaction { transaction in
-+        if props.disablePageAnimations {
-+          transaction.disableAnimations = true
-+        }
-+      }
-+      #endif
-   }
-
-   func emitHapticFeedback(longPress: Bool = false) {
-@@ -214,6 +218,40 @@ extension View {
+       .onChange(of: props.selectedPage ?? "") { newValue in
+         #if !os(macOS)
+           if props.disablePageAnimations {
+@@ -214,6 +214,40 @@ extension View {
      }
    }
-
+ 
 +  @ViewBuilder
 +  func applyTabViewStyle(sidebarAdaptable: Bool) -> some View {
 +    if #available(iOS 18.0, macOS 15.0, tvOS 18.0, visionOS 2.0, *) {
@@ -117,23 +87,6 @@ index 72938be..a7a3c15 100644
    @ViewBuilder
    func tabBadge(_ data: String?) -> some View {
      if #available(iOS 15.0, macOS 15.0, visionOS 2.0, tvOS 15.0, *) {
-diff --git a/node_modules/react-native-bottom-tabs/ios/TabViewProvider.swift b/node_modules/react-native-bottom-tabs/ios/TabViewProvider.swift
---- a/node_modules/react-native-bottom-tabs/ios/TabViewProvider.swift
-+++ b/node_modules/react-native-bottom-tabs/ios/TabViewProvider.swift
-@@ -86,7 +86,12 @@
-
-   @objc public var selectedPage: NSString? {
-     didSet {
--      props.selectedPage = selectedPage as? String
-+      let newValue = selectedPage as? String
-+      // Deduplicate: only update @Published when the value actually changes.
-+      // This prevents a redundant SwiftUI re-render when the JS round-trip
-+      // sets the same selectedPage that SwiftUI's binding already set.
-+      guard props.selectedPage != newValue else { return }
-+      props.selectedPage = newValue
-     }
-   }
-
 diff --git a/node_modules/react-native-bottom-tabs/lib/module/TabView.js b/node_modules/react-native-bottom-tabs/lib/module/TabView.js
 index 3ab92c7..81ca149 100644
 --- a/node_modules/react-native-bottom-tabs/lib/module/TabView.js
@@ -175,7 +128,7 @@ index 41b9cb3..af65f18 100644
 +   */
 +  tabBarHidden?: boolean;
  }
-
+ 
  const ANDROID_MAX_TABS = 100;
 @@ -392,7 +396,7 @@ const TabView = <Route extends BaseRoute>({
          // When rendering a custom tab bar, icons can be React elements, which will not be properly resolved.

--- a/patches/react-native-bottom-tabs+1.1.0.patch
+++ b/patches/react-native-bottom-tabs+1.1.0.patch
@@ -4,7 +4,7 @@ index 23cd875..3fe0e1d 100644
 +++ b/node_modules/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
 @@ -38,6 +38,12 @@ import com.google.android.material.navigation.NavigationBarView.LABEL_VISIBILITY
  import com.google.android.material.transition.platform.MaterialFadeThrough
- 
+
  class ExtendedBottomNavigationView(context: Context) : BottomNavigationView(context) {
 +  init {
 +    // Disable automatic window insets handling to prevent extra padding
@@ -31,19 +31,18 @@ index 23cd875..3fe0e1d 100644
 +      onTabBarMeasuredListener?.invoke(tabBarHeight)
 +    }
    }
- 
+
    fun updateItems(items: MutableList<TabInfo>) {
 diff --git a/node_modules/react-native-bottom-tabs/ios/TabViewImpl.swift b/node_modules/react-native-bottom-tabs/ios/TabViewImpl.swift
-index 72938be..32db031 100644
+index 72938be..a7a3c15 100644
 --- a/node_modules/react-native-bottom-tabs/ios/TabViewImpl.swift
 +++ b/node_modules/react-native-bottom-tabs/ios/TabViewImpl.swift
-@@ -80,20 +80,19 @@ struct TabViewImpl: View {
+@@ -80,18 +80,22 @@ struct TabViewImpl: View {
          .configureAppearance(props: props, tabBar: tabBar)
        #endif
        .tintColor(props.selectedActiveTintColor)
 -      .getSidebarAdaptable(enabled: props.sidebarAdaptable ?? false)
-+      .applyTabViewStyle(sidebarAdaptable: props.sidebarAdaptable ?? false)
-       .onChange(of: props.selectedPage ?? "") { newValue in
+-      .onChange(of: props.selectedPage ?? "") { newValue in
 -        #if !os(macOS)
 -          if props.disablePageAnimations {
 -            UIView.setAnimationsEnabled(false)
@@ -52,24 +51,35 @@ index 72938be..32db031 100644
 -            }
 -          }
 -        #endif
-         #if os(tvOS) || os(macOS) || os(visionOS)
-           onSelect(newValue)
-         #endif
-       }
+-        #if os(tvOS) || os(macOS) || os(visionOS)
+-          onSelect(newValue)
+-        #endif
+-      }
++      .applyTabViewStyle(sidebarAdaptable: props.sidebarAdaptable ?? false)
++      .onChange(of: props.selectedPage ?? "") { newValue in
++        #if os(tvOS) || os(macOS) || os(visionOS)
++          onSelect(newValue)
++        #endif
++      }
++      // Use SwiftUI transaction to disable tab switching animations instead of
++      // the fragile UIView.setAnimationsEnabled(false) global hack.
++      // The global approach could leave UITabBarController in an inconsistent
++      // internal transition state when the disable/re-enable timing races with
++      // the SwiftUI TabView transition, causing a probabilistic UI freeze.
 +      #if !os(macOS)
 +      .transaction { transaction in
 +        if props.disablePageAnimations {
-+          transaction.disablesAnimations = true
++          transaction.disableAnimations = true
 +        }
 +      }
 +      #endif
    }
- 
+
    func emitHapticFeedback(longPress: Bool = false) {
-@@ -214,6 +213,40 @@ extension View {
+@@ -214,6 +218,40 @@ extension View {
      }
    }
- 
+
 +  @ViewBuilder
 +  func applyTabViewStyle(sidebarAdaptable: Bool) -> some View {
 +    if #available(iOS 18.0, macOS 15.0, tvOS 18.0, visionOS 2.0, *) {
@@ -108,11 +118,10 @@ index 72938be..32db031 100644
    func tabBadge(_ data: String?) -> some View {
      if #available(iOS 15.0, macOS 15.0, visionOS 2.0, tvOS 15.0, *) {
 diff --git a/node_modules/react-native-bottom-tabs/ios/TabViewProvider.swift b/node_modules/react-native-bottom-tabs/ios/TabViewProvider.swift
-index 013032f..3a4697a 100644
 --- a/node_modules/react-native-bottom-tabs/ios/TabViewProvider.swift
 +++ b/node_modules/react-native-bottom-tabs/ios/TabViewProvider.swift
-@@ -85,7 +85,12 @@ public final class TabInfo: NSObject {
- 
+@@ -86,7 +86,12 @@
+
    @objc public var selectedPage: NSString? {
      didSet {
 -      props.selectedPage = selectedPage as? String
@@ -124,7 +133,7 @@ index 013032f..3a4697a 100644
 +      props.selectedPage = newValue
      }
    }
- 
+
 diff --git a/node_modules/react-native-bottom-tabs/lib/module/TabView.js b/node_modules/react-native-bottom-tabs/lib/module/TabView.js
 index 3ab92c7..81ca149 100644
 --- a/node_modules/react-native-bottom-tabs/lib/module/TabView.js
@@ -166,7 +175,7 @@ index 41b9cb3..af65f18 100644
 +   */
 +  tabBarHidden?: boolean;
  }
- 
+
  const ANDROID_MAX_TABS = 100;
 @@ -392,7 +396,7 @@ const TabView = <Route extends BaseRoute>({
          // When rendering a custom tab bar, icons can be React elements, which will not be properly resolved.


### PR DESCRIPTION
This reverts commits:
- 9ea73cac87: fix: correct SwiftUI Transaction property name in patch (#10256)
- f28a48f204: fix: replace UIView animation disable hack with SwiftUI transaction to prevent iOS tab switching freeze (#10253)

Reverting back to the original UIView.setAnimationsEnabled approach.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
