### PR TITLE
fix: resolve iOS production navigation delay in onboarding page

### DIFF
--- a/development/spellCheckerSkipWords.txt
+++ b/development/spellCheckerSkipWords.txt
@@ -1400,3 +1400,4 @@ zerion
 Schedulable
 Roobert
 RNGH
+macrotask

--- a/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
@@ -183,6 +183,28 @@ export const popModalPages = async (maxRetryTimes = 10) => {
   await popModalPages(maxRetryTimes - 1);
 };
 
+/**
+ * Synchronously pop modal pages without delay for native platforms.
+ * On native platforms with native bottom tabs, avoid deferring navigation
+ * dispatch to a macrotask via timerUtils.wait(). Use goBack() directly
+ * so the navigation stays within the touch event context, preventing iOS
+ * from requiring an additional touch to flush the bridge call.
+ */
+export const popModalPagesOnNative = (maxRetryTimes = 10) => {
+  if (maxRetryTimes <= 0) {
+    return;
+  }
+  const rootState = rootNavigationRef.current?.getRootState();
+  const currentRoute = rootState?.routes?.[rootState.index];
+  if (currentRoute?.name !== ERootRoutes.Modal) {
+    return;
+  }
+  if (rootNavigationRef.current?.canGoBack?.()) {
+    rootNavigationRef.current?.goBack();
+    popModalPagesOnNative(maxRetryTimes - 1);
+  }
+};
+
 export const popToMainRoute = async (maxRetryTimes = 99) => {
   if (maxRetryTimes <= 0) {
     return;

--- a/packages/kit/src/views/Onboarding/hooks/useToOnBoardingPage.ts
+++ b/packages/kit/src/views/Onboarding/hooks/useToOnBoardingPage.ts
@@ -1,6 +1,9 @@
 import { useMemo } from 'react';
 
-import { rootNavigationRef } from '@onekeyhq/components';
+import {
+  popModalPagesOnNative,
+  rootNavigationRef,
+} from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -70,8 +73,20 @@ export const useToOnBoardingPage = () => {
             window.close();
           }
         } else {
-          await closeModalPages();
-          await timerUtils.wait(150);
+          // On native platforms with native bottom tabs, close modal and navigate
+          // directly without deferring to a delayed task. The await timerUtils.wait()
+          // + dispatch pattern causes navigation to be detached from the touch event
+          // context, and iOS production won't flush the bridge call until the next
+          // user interaction.
+          if (platformEnv.isNative) {
+            // Synchronously close all modal pages before navigating to onboarding.
+            // Modal and Onboarding are sibling root routes, so we need to close
+            // modal first before navigating.
+            popModalPagesOnNative();
+          } else {
+            await closeModalPages();
+            await timerUtils.wait(150);
+          }
           if (isOnboardingDone) {
             rootNavigationRef.current?.navigate(ERootRoutes.Onboarding, {
               screen: EOnboardingV2Routes.OnboardingV2,

--- a/packages/kit/src/views/Onboarding/hooks/useToOnBoardingPage.ts
+++ b/packages/kit/src/views/Onboarding/hooks/useToOnBoardingPage.ts
@@ -1,9 +1,6 @@
 import { useMemo } from 'react';
 
-import {
-  popModalPagesOnNative,
-  rootNavigationRef,
-} from '@onekeyhq/components';
+import { popModalPagesOnNative, rootNavigationRef } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';

--- a/packages/kit/src/views/Prime/pages/OneKeyId/index.tsx
+++ b/packages/kit/src/views/Prime/pages/OneKeyId/index.tsx
@@ -11,7 +11,7 @@ import {
   Stack,
   XStack,
   YStack,
-  popModalPages,
+  popModalPagesOnNative,
   rootNavigationRef,
   useUpdateEffect,
 } from '@onekeyhq/components';
@@ -39,17 +39,12 @@ function OneKeyIdPage() {
   const logoutRef = useRef<() => Promise<void>>(logout);
   const isFocused = useRouteIsFocused();
 
-  const popCurrentModal = useCallback(async () => {
-    await popModalPages();
-    await timerUtils.wait(350);
-  }, []);
-
   const toPrimePage = useCallback(() => {
     requestIdleCallback(async () => {
       try {
         if (isPrimeAvailable) {
           if (platformEnv.isNative) {
-            await popCurrentModal();
+            popModalPagesOnNative();
           }
           rootNavigationRef.current?.navigate(ERootRoutes.iOSFullScreen, {
             screen: EModalRoutes.PrimeModal,
@@ -64,19 +59,19 @@ function OneKeyIdPage() {
         });
       }
     });
-  }, [isPrimeAvailable, popCurrentModal]);
+  }, [isPrimeAvailable]);
 
   const handleLoggedOutWhileFocused = useCallback(async () => {
     if (!isLoggedIn && isFocused) {
       await timerUtils.wait(300);
-      await popCurrentModal();
+      popModalPagesOnNative();
       defaultLogger.prime.subscription.onekeyIdLogout({
         reason:
           'OneKeyIdPage: is focused and primePersistAtom is not logged in',
       });
       void logoutRef.current();
     }
-  }, [isLoggedIn, isFocused, popCurrentModal]);
+  }, [isLoggedIn, isFocused]);
 
   useUpdateEffect(() => {
     void handleLoggedOutWhileFocused();
@@ -110,7 +105,7 @@ function OneKeyIdPage() {
             <PrimeUserInfo
               onLogoutSuccess={async () => {
                 defaultLogger.referral.page.logoutOneKeyIDResult();
-                await popCurrentModal();
+                popModalPagesOnNative();
               }}
             />
           </Stack>


### PR DESCRIPTION
## Description

On native platforms with native bottom tabs, avoid deferring navigation dispatch to a macrotask via \+. This keeps the navigation within the touch event context, preventing iOS production from requiring an additional touch to flush the bridge call.

### Problem
- Modal and Onboarding are sibling root routes
- Using `{ pop: true }` in navigate options cannot close the modal stack because they are at the same level
- `await timerUtils.wait(150)` causes navigation to be detached from the touch event context
- On iOS production, the bridge call won't flush until the next user interaction

### Solution
- Add `popModalPagesOnNative()` for synchronous modal closing on native platforms
- Update `useToOnBoardingPage()` to:
  - Use `popModalPagesOnNative()` on native platforms (sync, no delay)
  - Keep `closeModalPages()` on non-native platforms (async with delay)

### Changes
- `packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx`: Add `popModalPagesOnNative()` function
- `packages/kit/src/views/Onboarding/hooks/useToOnBoardingPage.ts`: Use sync modal closing on native platforms

### Related
Similar fix pattern as commit 824cdc10dc (Earn asset list navigation delay fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
