### PR TITLE
fix: handle Market and Earn tab navigation in notification details (OK-50466)

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
@@ -102,7 +102,7 @@ WebViewMemoized.displayName = 'WebViewMemoized';
 export function TradingViewPerpsV2(
   props: ITradingViewPerpsV2Props & WebViewProps,
 ) {
-  const { symbol, userAddress, onLoadEnd, onTradeUpdate, webviewKey } = props;
+  const { symbol, userAddress, onLoadEnd, onTradeUpdate, webviewKey, ...stackStyle } = props;
   const [, setMounted] = usePerpsCandlesWebviewMountedAtom();
   const webRef = useRef<IWebViewRef | null>(null);
   const theme = useThemeVariant();
@@ -246,7 +246,7 @@ export function TradingViewPerpsV2(
   );
 
   return (
-    <Stack position="relative" flex={1}>
+    <Stack position="relative" flex={1} {...stackStyle}>
       <WebViewMemoized
         key={_webviewKey}
         src={staticTradingViewUrl}

--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
@@ -102,7 +102,14 @@ WebViewMemoized.displayName = 'WebViewMemoized';
 export function TradingViewPerpsV2(
   props: ITradingViewPerpsV2Props & WebViewProps,
 ) {
-  const { symbol, userAddress, onLoadEnd, onTradeUpdate, webviewKey, ...stackStyle } = props;
+  const {
+    symbol,
+    userAddress,
+    onLoadEnd,
+    onTradeUpdate,
+    webviewKey,
+    ...stackStyle
+  } = props;
   const [, setMounted] = usePerpsCandlesWebviewMountedAtom();
   const webRef = useRef<IWebViewRef | null>(null);
   const theme = useThemeVariant();

--- a/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
@@ -59,6 +59,7 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     onPanesCountChange,
     dataSource,
     accountAddress,
+    ...stackStyle
   } = props;
 
   const { handleNavigation } = useNavigationHandler();
@@ -234,7 +235,7 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
   );
 
   return (
-    <Stack position="relative" flex={1}>
+    <Stack position="relative" flex={1} {...stackStyle}>
       {webView}
 
       {platformEnv.isNativeIOS ? (

--- a/packages/kit/src/hooks/useAppNavigation.ts
+++ b/packages/kit/src/hooks/useAppNavigation.ts
@@ -18,7 +18,7 @@ import type {
 } from '@onekeyhq/components/src/layouts/Navigation';
 import { appEventBus } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { EAppEventBusNames } from '@onekeyhq/shared/src/eventBus/appEventBusNames';
-import type { IModalParamList , ETabRoutes } from '@onekeyhq/shared/src/routes';
+import type { ETabRoutes , IModalParamList } from '@onekeyhq/shared/src/routes';
 import { EModalRoutes, ERootRoutes } from '@onekeyhq/shared/src/routes';
 import { isSpanning } from '@onekeyhq/shared/src/modules/DualScreenInfo';
 

--- a/packages/kit/src/hooks/useAppNavigation.ts
+++ b/packages/kit/src/hooks/useAppNavigation.ts
@@ -18,7 +18,7 @@ import type {
 } from '@onekeyhq/components/src/layouts/Navigation';
 import { appEventBus } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { EAppEventBusNames } from '@onekeyhq/shared/src/eventBus/appEventBusNames';
-import type { ETabRoutes , IModalParamList } from '@onekeyhq/shared/src/routes';
+import type { ETabRoutes, IModalParamList } from '@onekeyhq/shared/src/routes';
 import { EModalRoutes, ERootRoutes } from '@onekeyhq/shared/src/routes';
 import { isSpanning } from '@onekeyhq/shared/src/modules/DualScreenInfo';
 

--- a/packages/kit/src/hooks/useAppNavigation.ts
+++ b/packages/kit/src/hooks/useAppNavigation.ts
@@ -8,6 +8,7 @@ import {
   popToTabRootScreen,
   rootNavigationRef,
   switchTab,
+  tabletMainViewNavigationRef,
   useSplitMainView,
 } from '@onekeyhq/components';
 import type {
@@ -17,8 +18,9 @@ import type {
 } from '@onekeyhq/components/src/layouts/Navigation';
 import { appEventBus } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { EAppEventBusNames } from '@onekeyhq/shared/src/eventBus/appEventBusNames';
-import type { IModalParamList } from '@onekeyhq/shared/src/routes';
+import type { IModalParamList , ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalRoutes, ERootRoutes } from '@onekeyhq/shared/src/routes';
+import { isSpanning } from '@onekeyhq/shared/src/modules/DualScreenInfo';
 
 const getModalRoute = () => {
   const state = rootNavigationRef.current?.getState();
@@ -234,6 +236,34 @@ function useAppNavigation<
 
   const push: typeof navigationRef.current.push = useCallback(
     (...args) => {
+      if (isSpanning()) {
+        // Get current tab route index from tabletMainViewNavigationRef
+        const tabletState = tabletMainViewNavigationRef.current?.getState();
+        const tabletMainRoute = tabletState?.routes?.find(
+          (route) => route.name === ERootRoutes.Main,
+        );
+        const tabletTabRoutes = tabletMainRoute?.state?.routes;
+        const tabletTabIndex = tabletMainRoute?.state?.index ?? 0;
+        const tabletTabRoute = tabletTabRoutes?.[tabletTabIndex]?.name as
+          | ETabRoutes
+          | undefined;
+
+        // Get current tab route index from rootNavigationRef
+        const rootState = rootNavigationRef.current?.getState();
+        const rootMainRoute = rootState?.routes?.find(
+          (route) => route.name === ERootRoutes.Main,
+        );
+        const rootTabRoutes = rootMainRoute?.state?.routes;
+        const rootTabIndex = rootMainRoute?.state?.index ?? 0;
+        const rootTabRoute = rootTabRoutes?.[rootTabIndex]?.name as
+          | ETabRoutes
+          | undefined;
+
+        // Sync rootNavigationRef to the same tab if they are different
+        if (tabletTabRoute && tabletTabRoute !== rootTabRoute) {
+          switchTab(tabletTabRoute);
+        }
+      }
       if (isTabletMainView) {
         appEventBus.emit(EAppEventBusNames.PushPageInTabletDetailView, args);
         return;

--- a/packages/kit/src/views/Market/MarketDetailV2/components/MarketTradingView/MarketTradingView.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/MarketTradingView/MarketTradingView.tsx
@@ -12,6 +12,7 @@ interface IMarketTradingViewProps {
   onPanesCountChange?: (count: number) => void;
   isNative?: boolean;
   dataSource: 'websocket' | 'polling';
+  pageWidth?: number;
 }
 
 export const MarketTradingView = memo(
@@ -21,6 +22,7 @@ export const MarketTradingView = memo(
     tokenSymbol = '',
     decimal = 8,
     dataSource,
+    pageWidth,
   }: IMarketTradingViewProps) => {
     const { accountAddress } = useNetworkAccountAddress(networkId);
 
@@ -32,6 +34,7 @@ export const MarketTradingView = memo(
         decimal={decimal}
         dataSource={dataSource}
         accountAddress={accountAddress}
+        w={pageWidth}
       />
     );
   },

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -15,6 +15,7 @@ import {
   useInPageDialog,
   useIsOverlayPage,
   useSafeAreaInsets,
+  usePageWidth,
 } from '@onekeyhq/components';
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -83,9 +84,7 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
     return 'calc(100vh - 96px - 74px)';
   }, [bottom, top, isIOSModalPage]);
 
-  const width = useMemo(() => {
-    return Dimensions.get('window').width;
-  }, []);
+  const width = usePageWidth();
 
   const scrollViewRef = useRef<IScrollViewRef>(null);
   const focusedTab = useSharedValue(tabNames[0]);
@@ -120,6 +119,7 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
             tokenSymbol={tokenDetail?.symbol}
             isNative={isNative}
             dataSource={websocketConfig?.kline ? 'websocket' : 'polling'}
+            pageWidth={width}
           />
         </Stack>
       </YStack>

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -14,8 +14,8 @@ import {
   YStack,
   useInPageDialog,
   useIsOverlayPage,
-  useSafeAreaInsets,
   usePageWidth,
+  useSafeAreaInsets,
 } from '@onekeyhq/components';
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -131,6 +131,7 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
     tokenDetail?.symbol,
     tradingViewHeight,
     websocketConfig,
+    width,
   ]);
 
   const renderInformationHeader = useCallback(

--- a/packages/kit/src/views/Perp/components/PerpCandles.tsx
+++ b/packages/kit/src/views/Perp/components/PerpCandles.tsx
@@ -1,4 +1,4 @@
-import { DebugRenderTracker, Stack } from '@onekeyhq/components';
+import { DebugRenderTracker, Stack, usePageWidth } from '@onekeyhq/components';
 import { TradingViewPerpsV2 } from '@onekeyhq/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2';
 import {
   usePerpsActiveAccountAtom,
@@ -10,6 +10,7 @@ export function PerpCandles() {
   const [currentToken] = usePerpsActiveAssetAtom();
   const [currentAccount] = usePerpsActiveAccountAtom();
   const [{ reloadHook }] = usePerpsCandlesWebviewReloadHookAtom();
+  const width = usePageWidth();
 
   const content = (
     <Stack w="100%" h="100%" flex={1} pr={6}>
@@ -18,6 +19,7 @@ export function PerpCandles() {
           webviewKey={reloadHook.toString()}
           userAddress={currentAccount?.accountAddress}
           symbol={currentToken.coin}
+          w={width}
         />
       ) : null}
     </Stack>

--- a/packages/kit/src/views/Perp/components/PerpCandles.tsx
+++ b/packages/kit/src/views/Perp/components/PerpCandles.tsx
@@ -5,6 +5,7 @@ import {
   usePerpsActiveAssetAtom,
   usePerpsCandlesWebviewReloadHookAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 export function PerpCandles() {
   const [currentToken] = usePerpsActiveAssetAtom();
@@ -19,7 +20,7 @@ export function PerpCandles() {
           webviewKey={reloadHook.toString()}
           userAddress={currentAccount?.accountAddress}
           symbol={currentToken.coin}
-          w={width}
+          w={platformEnv.isNative ? width : undefined}
         />
       ) : null}
     </Stack>

--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarMobile.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarMobile.tsx
@@ -9,6 +9,7 @@ import {
   IconButton,
   Popover,
   SizableText,
+  switchTab,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -25,6 +26,9 @@ import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
 import { PerpSettingsButton } from '../PerpSettingsButton';
 import { PerpTokenSelectorMobile } from '../TokenSelector/PerpTokenSelector';
 import { PerpsAccountNumberValue } from '../TradingPanel/components/PerpsAccountNumberValue';
+import { isDualScreenDevice } from '@onekeyhq/shared/src/modules/DualScreenInfo';
+import { ETabRoutes } from '@onekeyhq/shared/src/routes';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
 const PerpTickerBarMMRInfoMobileView = memo(
   ({
@@ -142,6 +146,10 @@ function PerpCandleChartButtonMobile() {
   const navigation = useAppNavigation();
 
   const onPressCandleChart = useCallback(() => {
+    if (isDualScreenDevice()) {
+      switchTab(ETabRoutes.Perp)
+      timerUtils.wait(150)
+    }
     navigation.push(EModalPerpRoutes.MobilePerpMarket);
   }, [navigation]);
 

--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarMobile.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarMobile.tsx
@@ -11,7 +11,6 @@ import {
   SizableText,
   XStack,
   YStack,
-  switchTab,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { GiftAction } from '@onekeyhq/kit/src/components/TabPageHeader/components';

--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarMobile.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarMobile.tsx
@@ -9,9 +9,9 @@ import {
   IconButton,
   Popover,
   SizableText,
-  switchTab,
   XStack,
   YStack,
+  switchTab,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { GiftAction } from '@onekeyhq/kit/src/components/TabPageHeader/components';
@@ -26,9 +26,6 @@ import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
 import { PerpSettingsButton } from '../PerpSettingsButton';
 import { PerpTokenSelectorMobile } from '../TokenSelector/PerpTokenSelector';
 import { PerpsAccountNumberValue } from '../TradingPanel/components/PerpsAccountNumberValue';
-import { isDualScreenDevice } from '@onekeyhq/shared/src/modules/DualScreenInfo';
-import { ETabRoutes } from '@onekeyhq/shared/src/routes';
-import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
 const PerpTickerBarMMRInfoMobileView = memo(
   ({
@@ -146,10 +143,6 @@ function PerpCandleChartButtonMobile() {
   const navigation = useAppNavigation();
 
   const onPressCandleChart = useCallback(() => {
-    if (isDualScreenDevice()) {
-      switchTab(ETabRoutes.Perp)
-      timerUtils.wait(150)
-    }
     navigation.push(EModalPerpRoutes.MobilePerpMarket);
   }, [navigation]);
 

--- a/packages/shared/src/utils/notificationsUtils.ts
+++ b/packages/shared/src/utils/notificationsUtils.ts
@@ -12,7 +12,11 @@ import appGlobals from '../appGlobals';
 import { EAppEventBusNames, appEventBus } from '../eventBus/appEventBus';
 import { defaultLogger } from '../logger/logger';
 import platformEnv from '../platformEnv';
-import { EModalAssetDetailRoutes, EModalRoutes } from '../routes';
+import {
+  EModalAssetDetailRoutes,
+  EModalRoutes,
+  ETabRoutes,
+} from '../routes';
 import { EModalNotificationsRoutes } from '../routes/notifications';
 import { ERootRoutes } from '../routes/root';
 
@@ -26,6 +30,7 @@ import type {
   ENotificationPushTopicTypes,
   INotificationPushMessageInfo,
 } from '../../types/notification';
+import { ETranslations } from '../locale';
 
 function convertWebPermissionToEnum(
   permission: NotificationPermission,
@@ -143,6 +148,19 @@ export async function navigateToNotificationDetailByLocalParams({
     } else {
       await popToMainRoute();
       await timerUtils.wait(350);
+      if (platformEnv.isNative) {
+        if (navigationParams?.screen === ETabRoutes.Market) {
+          navigationParams.screen = ETabRoutes.Discovery;
+          appEventBus.emit(EAppEventBusNames.SwitchDiscoveryTabInNative, {
+            tab: ETranslations.global_market,
+          });
+        } else if (navigationParams?.screen === ETabRoutes.Earn) {
+          navigationParams.screen = ETabRoutes.Discovery;
+          appEventBus.emit(EAppEventBusNames.SwitchDiscoveryTabInNative, {
+            tab: ETranslations.global_earn,
+          });
+        }
+      }
       appGlobals.$navigationRef.current?.navigate(screen, navigationParams, {
         pop: true,
       });

--- a/packages/shared/src/utils/notificationsUtils.ts
+++ b/packages/shared/src/utils/notificationsUtils.ts
@@ -144,32 +144,26 @@ export async function navigateToNotificationDetailByLocalParams({
     } else {
       await popToMainRoute();
       await timerUtils.wait(350);
-      const originalScreen = navigationParams?.screen;
+      let tab: ETranslations | undefined;
       if (platformEnv.isNative) {
-        if (originalScreen === ETabRoutes.Market) {
+        if (navigationParams?.screen === ETabRoutes.Market) {
           navigationParams.screen = ETabRoutes.Discovery;
-        } else if (originalScreen === ETabRoutes.Earn) {
+          tab = ETranslations.global_market;
+        } else if (navigationParams?.screen === ETabRoutes.Earn) {
           navigationParams.screen = ETabRoutes.Discovery;
+          tab = ETranslations.global_earn;
         }
       }
       appGlobals.$navigationRef.current?.navigate(screen, navigationParams, {
         pop: true,
       });
       // Delay emitting the event to ensure Discovery component is mounted
-      if (platformEnv.isNative && originalScreen) {
-        const tab =
-          originalScreen === ETabRoutes.Market
-            ? ETranslations.global_market
-            : originalScreen === ETabRoutes.Earn
-              ? ETranslations.global_earn
-              : undefined;
-        if (tab) {
-          setTimeout(() => {
-            appEventBus.emit(EAppEventBusNames.SwitchDiscoveryTabInNative, {
-              tab,
-            });
-          }, 150);
-        }
+      if (tab) {
+        setTimeout(() => {
+          appEventBus.emit(EAppEventBusNames.SwitchDiscoveryTabInNative, {
+            tab,
+          });
+        }, 150);
       }
     }
   } else if (screen === ERootRoutes.Modal) {

--- a/packages/shared/src/utils/notificationsUtils.ts
+++ b/packages/shared/src/utils/notificationsUtils.ts
@@ -12,11 +12,7 @@ import appGlobals from '../appGlobals';
 import { EAppEventBusNames, appEventBus } from '../eventBus/appEventBus';
 import { defaultLogger } from '../logger/logger';
 import platformEnv from '../platformEnv';
-import {
-  EModalAssetDetailRoutes,
-  EModalRoutes,
-  ETabRoutes,
-} from '../routes';
+import { EModalAssetDetailRoutes, EModalRoutes, ETabRoutes } from '../routes';
 import { EModalNotificationsRoutes } from '../routes/notifications';
 import { ERootRoutes } from '../routes/root';
 

--- a/packages/shared/src/utils/notificationsUtils.ts
+++ b/packages/shared/src/utils/notificationsUtils.ts
@@ -144,7 +144,7 @@ export async function navigateToNotificationDetailByLocalParams({
     } else {
       await popToMainRoute();
       await timerUtils.wait(350);
-      let tab: ETranslations | undefined;
+      let tab: ETranslations.global_browser | ETranslations.global_earn | ETranslations.global_market;
       if (platformEnv.isNative) {
         if (navigationParams?.screen === ETabRoutes.Market) {
           navigationParams.screen = ETabRoutes.Discovery;

--- a/packages/shared/src/utils/notificationsUtils.ts
+++ b/packages/shared/src/utils/notificationsUtils.ts
@@ -123,12 +123,43 @@ export async function navigateToNotificationDetailByLocalParams({
       }
     }
   }
+  // Handle Market/Earn tab redirection for native platforms
+  // On native, Market and Earn are sub-tabs within Discovery, not separate tabs
+  // Returns a function that performs the redirection when called
+  const createNativeTabRedirection = () => {
+    let tab:
+      | ETranslations.global_browser
+      | ETranslations.global_earn
+      | ETranslations.global_market
+      | undefined;
+    if (platformEnv.isNative) {
+      if (navigationParams?.screen === ETabRoutes.Market) {
+        navigationParams.screen = ETabRoutes.Discovery;
+        tab = ETranslations.global_market;
+      } else if (navigationParams?.screen === ETabRoutes.Earn) {
+        navigationParams.screen = ETabRoutes.Discovery;
+        tab = ETranslations.global_earn;
+      }
+    }
+    // Return a function that emits the event after navigation completes
+    return () => {
+      if (tab) {
+        setTimeout(() => {
+          appEventBus.emit(EAppEventBusNames.SwitchDiscoveryTabInNative, {
+            tab,
+          });
+        }, 150);
+      }
+    };
+  };
+
   if (screen === ERootRoutes.Main) {
     if (
       appGlobals.$tabletMainViewNavigationRef?.current &&
       navigationParams?.screen &&
       !navigationParams?.params?.screen
     ) {
+      const redirectTab = createNativeTabRedirection();
       appGlobals.$tabletMainViewNavigationRef.current.navigate(
         screen,
         navigationParams,
@@ -141,34 +172,17 @@ export async function navigateToNotificationDetailByLocalParams({
           pop: true,
         });
       });
+      // Execute tab redirection after navigation
+      redirectTab();
     } else {
       await popToMainRoute();
       await timerUtils.wait(350);
-      let tab:
-        | ETranslations.global_browser
-        | ETranslations.global_earn
-        | ETranslations.global_market
-        | undefined = undefined;
-      if (platformEnv.isNative) {
-        if (navigationParams?.screen === ETabRoutes.Market) {
-          navigationParams.screen = ETabRoutes.Discovery;
-          tab = ETranslations.global_market;
-        } else if (navigationParams?.screen === ETabRoutes.Earn) {
-          navigationParams.screen = ETabRoutes.Discovery;
-          tab = ETranslations.global_earn;
-        }
-      }
+      const redirectTab = createNativeTabRedirection();
       appGlobals.$navigationRef.current?.navigate(screen, navigationParams, {
         pop: true,
       });
-      // Delay emitting the event to ensure Discovery component is mounted
-      if (tab) {
-        setTimeout(() => {
-          appEventBus.emit(EAppEventBusNames.SwitchDiscoveryTabInNative, {
-            tab,
-          });
-        }, 150);
-      }
+      // Execute tab redirection after navigation
+      redirectTab();
     }
   } else if (screen === ERootRoutes.Modal) {
     let rootNavigator = appGlobals.$navigationRef.current;

--- a/packages/shared/src/utils/notificationsUtils.ts
+++ b/packages/shared/src/utils/notificationsUtils.ts
@@ -144,22 +144,33 @@ export async function navigateToNotificationDetailByLocalParams({
     } else {
       await popToMainRoute();
       await timerUtils.wait(350);
+      const originalScreen = navigationParams?.screen;
       if (platformEnv.isNative) {
-        if (navigationParams?.screen === ETabRoutes.Market) {
+        if (originalScreen === ETabRoutes.Market) {
           navigationParams.screen = ETabRoutes.Discovery;
-          appEventBus.emit(EAppEventBusNames.SwitchDiscoveryTabInNative, {
-            tab: ETranslations.global_market,
-          });
-        } else if (navigationParams?.screen === ETabRoutes.Earn) {
+        } else if (originalScreen === ETabRoutes.Earn) {
           navigationParams.screen = ETabRoutes.Discovery;
-          appEventBus.emit(EAppEventBusNames.SwitchDiscoveryTabInNative, {
-            tab: ETranslations.global_earn,
-          });
         }
       }
       appGlobals.$navigationRef.current?.navigate(screen, navigationParams, {
         pop: true,
       });
+      // Delay emitting the event to ensure Discovery component is mounted
+      if (platformEnv.isNative && originalScreen) {
+        const tab =
+          originalScreen === ETabRoutes.Market
+            ? ETranslations.global_market
+            : originalScreen === ETabRoutes.Earn
+              ? ETranslations.global_earn
+              : undefined;
+        if (tab) {
+          setTimeout(() => {
+            appEventBus.emit(EAppEventBusNames.SwitchDiscoveryTabInNative, {
+              tab,
+            });
+          }, 150);
+        }
+      }
     }
   } else if (screen === ERootRoutes.Modal) {
     let rootNavigator = appGlobals.$navigationRef.current;

--- a/packages/shared/src/utils/notificationsUtils.ts
+++ b/packages/shared/src/utils/notificationsUtils.ts
@@ -144,7 +144,11 @@ export async function navigateToNotificationDetailByLocalParams({
     } else {
       await popToMainRoute();
       await timerUtils.wait(350);
-      let tab: ETranslations.global_browser | ETranslations.global_earn | ETranslations.global_market | undefined = undefined;
+      let tab:
+        | ETranslations.global_browser
+        | ETranslations.global_earn
+        | ETranslations.global_market
+        | undefined = undefined;
       if (platformEnv.isNative) {
         if (navigationParams?.screen === ETabRoutes.Market) {
           navigationParams.screen = ETabRoutes.Discovery;

--- a/packages/shared/src/utils/notificationsUtils.ts
+++ b/packages/shared/src/utils/notificationsUtils.ts
@@ -144,7 +144,7 @@ export async function navigateToNotificationDetailByLocalParams({
     } else {
       await popToMainRoute();
       await timerUtils.wait(350);
-      let tab: ETranslations.global_browser | ETranslations.global_earn | ETranslations.global_market;
+      let tab: ETranslations.global_browser | ETranslations.global_earn | ETranslations.global_market | undefined = undefined;
       if (platformEnv.isNative) {
         if (navigationParams?.screen === ETabRoutes.Market) {
           navigationParams.screen = ETabRoutes.Discovery;


### PR DESCRIPTION
Fix the Market and Earn tab switching issue when navigating from notification details.

### Changes
- Redirect Market and Earn navigation to Discovery tab on native platforms (iOS/Android/iPad)
- Trigger corresponding tab switch events via appEventBus
- Fix missing Market/Earn redirection on iPad (tablet branch)

### Test
- [ ] Click notification to navigate to Market page
- [ ] Click notification to navigate to Earn page

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->