### PR TITLE
fix: resolve perps deposit duplicate toast, IP restriction recovery, and external wallet error handling OK-50425 OK-49628 OK-49643 OK-49630

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -283,6 +283,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       Date.now() - this._lastMessageAt <
         HYPERLIQUID_REFRESH_DATA_FLOW_THRESHOLD_MS;
 
+    void this.backgroundApi.serviceHyperliquid.updatePerpsConfigByServer();
     if (isSocketOpen && isDataFlowing) {
       // connection is healthy, no-op — just show pull-to-refresh animation
       await timerUtils.wait(3000);

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -965,6 +965,7 @@ function DepositWithdrawContent({
                   toAmount: amount,
                   fromAmount: amount,
                   isArbUSDCOrder: true,
+                  skipToast: true,
                 });
               }
               void backgroundApiProxy.serviceHyperliquidSubscription.enableLedgerUpdatesSubscription();

--- a/packages/shared/src/utils/hyperLiquidErrorResolver.ts
+++ b/packages/shared/src/utils/hyperLiquidErrorResolver.ts
@@ -197,6 +197,19 @@ export async function convertHyperLiquidResponse<T>(
   try {
     return await fn();
   } catch (error) {
+    // Unwrap AbstractWalletError from @nktkas/hyperliquid SDK.
+    // The SDK wraps all signing errors in AbstractWalletError with the
+    // original error preserved in `cause`. Rethrowing `cause` restores
+    // OneKey's own error types (hardware errors, user cancel, etc.)
+    // so that existing i18n and toast handling works correctly.
+    const walletError = error as { name?: string; cause?: Error };
+    if (
+      walletError.name === 'AbstractWalletError' &&
+      walletError.cause instanceof Error
+    ) {
+      throw walletError.cause;
+    }
+
     const apiError = error as IHyperLiquidApiRequestError;
     const { response } = apiError;
 


### PR DESCRIPTION
## Summary
- **OK-49628**: Skip duplicate toast for Arb USDC deposit — `TxConfirmActions` already shows "Transaction Submitted", so `handlePerpDepositTxSuccess` now passes `skipToast: true` to avoid double toast
- **OK-50425/OK-49643**: Refresh button now calls `updatePerpsConfigByServer()` to re-fetch server config, so IP restriction (`ipDisablePerp`) can be cleared after switching VPN without killing the app
- **OK-49630**: Unwrap `AbstractWalletError` from HyperLiquid SDK in `convertHyperLiquidResponse`, restoring OneKey's native error types (hardware errors, user cancel, etc.) for correct i18n and toast handling

## Test plan
- [ ] Arb USDC deposit: verify only 1 "Transaction Submitted" toast appears (not 2), then "Deposit Success" toast when confirmed
- [ ] Non-Arb token deposit: verify toast still shows normally
- [ ] Enable VPN → open Perps → see IP restricted state → disable VPN → tap refresh → verify trading buttons re-enable
- [ ] External wallet (WalletConnect): attempt enable trading / place order, cancel on external app → verify correct error toast instead of raw SDK error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
