### PR TITLE
fix: resolve Android market page Buy/Sell buttons not clickable

### DIFF
--- a/.claude/skills/1k-ui-recipes/SKILL.md
+++ b/.claude/skills/1k-ui-recipes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 1k-ui-recipes
-description: UI recipes for scroll offset (useScrollContentTabBarOffset), view transitions (startViewTransition), and horizontal scroll in collapsible tab headers (CollapsibleTabContext).
+description: UI recipes for scroll offset (useScrollContentTabBarOffset), view transitions (startViewTransition), horizontal scroll in collapsible tab headers (CollapsibleTabContext), and Android bottom tab touch interception workaround.
 allowed-tools: Read, Grep, Glob
 ---
 
@@ -15,6 +15,7 @@ Bite-sized solutions for common UI issues.
 | iOS Tab Bar Scroll Offset | [ios-tab-bar-scroll-offset.md](references/rules/ios-tab-bar-scroll-offset.md) | Use `useScrollContentTabBarOffset` for `paddingBottom` on iOS tab pages |
 | Smooth State Transitions | [start-view-transition.md](references/rules/start-view-transition.md) | Wrap heavy state updates in `startViewTransition` for fade on web |
 | Horizontal Scroll in Collapsible Tab Headers | [collapsible-tab-horizontal-scroll.md](references/rules/collapsible-tab-horizontal-scroll.md) | Bidirectional `Gesture.Pan()` + programmatic `scrollTo` via `CollapsibleTabContext` |
+| Android Bottom Tab Touch Interception | [android-bottom-tab-touch-intercept.md](references/rules/android-bottom-tab-touch-intercept.md) | **Temporary** — `GestureDetector` + `Gesture.Tap()` in `.android.tsx` to bypass native tab bar touch stealing |
 
 ## Critical Rules Summary
 
@@ -50,6 +51,30 @@ import { CollapsibleTabContext } from '@onekeyhq/components';
 ```
 
 > **Do NOT** import directly from `react-native-collapsible-tab-view/src/Context`. Always use the `@onekeyhq/components` re-export.
+
+### 4. Android Bottom Tab Touch Interception (Temporary Workaround)
+
+> **Temporary fix** — the root cause is `react-native-bottom-tabs` intercepting touches even when hidden. This workaround should be removed once the upstream issue is fixed.
+
+On Android, `react-native-bottom-tabs` intercepts touches in the tab bar region even when the tab bar is `GONE`. Buttons near the bottom of the screen become unclickable. Fix by creating a `.android.tsx` variant that wraps buttons with `GestureDetector` + `Gesture.Tap()`:
+
+```typescript
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { runOnJS } from 'react-native-reanimated';
+
+const tapGesture = useMemo(
+  () => Gesture.Tap().onEnd(() => { 'worklet'; runOnJS(onPress)(); }),
+  [onPress],
+);
+
+<GestureDetector gesture={tapGesture}>
+  <View>
+    <Button>Label</Button>
+  </View>
+</GestureDetector>
+```
+
+> Use `.android.tsx` file extension so other platforms are unaffected.
 
 ---
 

--- a/.claude/skills/1k-ui-recipes/references/rules/android-bottom-tab-touch-intercept.md
+++ b/.claude/skills/1k-ui-recipes/references/rules/android-bottom-tab-touch-intercept.md
@@ -1,0 +1,134 @@
+# Android Bottom Tab Touch Interception (Temporary Workaround)
+
+> **WARNING**: This is a **temporary workaround**. The root cause is in `react-native-bottom-tabs` — even when the tab bar is hidden (visibility GONE), it still intercepts touches in the tab bar region. This should be fixed upstream in `react-native-bottom-tabs` so that hidden tab bars do not consume touch events.
+
+## Problem
+
+On Android, buttons positioned near the bottom of the screen (in the tab bar region) are **not clickable** when using `react-native-bottom-tabs` as the native tab navigator. This happens even when the tab bar is hidden (e.g., on detail/modal pages).
+
+## Root Cause
+
+`react-native-bottom-tabs` renders a native Android view for the tab bar. Even when the tab bar visibility is set to `GONE`, the native view hierarchy still intercepts touch events in that region **before** React Native's JS touch system can dispatch them. Standard RN `onPress` / `Pressable` / `TouchableOpacity` handlers all fail because they rely on the RN touch pipeline, which never receives the event.
+
+## Why Standard Approaches Fail
+
+| Approach | Why It Fails |
+|----------|-------------|
+| `onPress` on Button/Pressable | RN touch system never receives the event — native view intercepts first |
+| `TouchableOpacity` / `TouchableWithoutFeedback` | Same issue — all RN touch primitives are blocked |
+| `pointerEvents="box-none"` | Does not affect native tab bar view interception |
+| Adjusting `zIndex` or `elevation` | The interception happens at the native level, not the RN layout level |
+
+## Solution: GestureDetector with Gesture.Tap (Android Only)
+
+`react-native-gesture-handler` (RNGH) intercepts touches at the `GestureHandlerRootView` (app root) level, **bypassing the native view hierarchy entirely**. Wrap buttons with `GestureDetector` + `Gesture.Tap()` on Android using a `.android.tsx` platform-specific file.
+
+### Pattern
+
+Create two files — a default version and an Android-specific version:
+
+**`MyFooterButtons.tsx`** (default — iOS, Web, etc.):
+
+```typescript
+import { Button } from '@onekeyhq/components';
+
+type IProps = {
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+function MyFooterButtons({ onConfirm, onCancel }: IProps) {
+  return (
+    <>
+      <Button onPress={onCancel}>Cancel</Button>
+      <Button onPress={onConfirm}>Confirm</Button>
+    </>
+  );
+}
+
+export default MyFooterButtons;
+```
+
+**`MyFooterButtons.android.tsx`** (Android — GestureDetector workaround):
+
+```typescript
+import { useMemo } from 'react';
+
+import { View } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { runOnJS } from 'react-native-reanimated';
+
+import { Button } from '@onekeyhq/components';
+
+// On Android, react-native-bottom-tabs intercepts touches in the tab bar
+// area even when hidden. RNGH bypasses native view hierarchy.
+
+type IProps = {
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+function MyFooterButtons({ onConfirm, onCancel }: IProps) {
+  const cancelGesture = useMemo(
+    () =>
+      Gesture.Tap().onEnd(() => {
+        'worklet';
+        runOnJS(onCancel)();
+      }),
+    [onCancel],
+  );
+
+  const confirmGesture = useMemo(
+    () =>
+      Gesture.Tap().onEnd(() => {
+        'worklet';
+        runOnJS(onConfirm)();
+      }),
+    [onConfirm],
+  );
+
+  return (
+    <>
+      <GestureDetector gesture={cancelGesture}>
+        <View>
+          <Button>Cancel</Button>
+        </View>
+      </GestureDetector>
+      <GestureDetector gesture={confirmGesture}>
+        <View>
+          <Button>Confirm</Button>
+        </View>
+      </GestureDetector>
+    </>
+  );
+}
+
+export default MyFooterButtons;
+```
+
+## Key Details
+
+1. **Platform-specific files**: Use `.android.tsx` so the workaround only applies to Android — iOS and other platforms use normal `onPress`
+2. **`Gesture.Tap()` + `runOnJS`**: The tap gesture runs on the UI thread (`'worklet'`), so use `runOnJS` to call JS callbacks
+3. **`<View>` wrapper**: `GestureDetector` requires a single native `View` child — wrap the Button in an RN `View`
+4. **Stable callbacks**: Pass `useCallback`-wrapped handlers as props, since they become dependencies of the `useMemo` gesture
+5. **No `onPress` on Button**: In the Android version, the Button itself should NOT have `onPress` — the tap is handled entirely by `GestureDetector`
+
+## Real Examples
+
+- `packages/kit/src/views/Perp/components/PerpMarketFooter.android.tsx` — Long/Short buttons on perp market page
+- `packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelFooterButtons.android.tsx` — Buy/Sell buttons on market detail page
+
+## TODO: Permanent Fix
+
+The proper fix is to patch or contribute upstream to `react-native-bottom-tabs` so that when the tab bar visibility is `GONE`, it does **not** intercept touch events. Once that is resolved, the `.android.tsx` GestureDetector variants can be removed and the default `onPress` handlers will work everywhere.
+
+## Checklist
+
+- [ ] Create `.android.tsx` variant — do NOT modify the default file
+- [ ] Use `Gesture.Tap().onEnd()` with `'worklet'` directive
+- [ ] Use `runOnJS` to bridge back to JS thread
+- [ ] Wrap each button in `<GestureDetector><View>...</View></GestureDetector>`
+- [ ] Remove `onPress` from Button in the Android variant
+- [ ] Ensure callback props are stable (`useCallback`)
+- [ ] Verify iOS/Web still work with the default (non-Android) component

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanel.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
@@ -34,6 +34,7 @@ import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 
 import { MarketWatchListProviderMirrorV2 } from '../../../MarketWatchListProviderMirrorV2';
 
+import SwapPanelFooterButtons from './SwapPanelFooterButtons';
 import { SwapPanelWrap } from './SwapPanelWrap';
 
 function LgTradeButton({
@@ -111,6 +112,25 @@ export function SwapPanel({
   }, [portfolioData, swapToken.contractAddress]);
 
   const [, setSwapProJumpTokenAtom] = useSwapProJumpTokenAtom();
+
+  const handleBuy = useCallback(() => {
+    setSwapProJumpTokenAtom({
+      token: swapToken,
+      direction: ESwapProJumpTokenDirection.BUY,
+    });
+    navigation.pop();
+    navigation.switchTab(ETabRoutes.Swap);
+  }, [setSwapProJumpTokenAtom, swapToken, navigation]);
+
+  const handleSell = useCallback(() => {
+    setSwapProJumpTokenAtom({
+      token: swapToken,
+      direction: ESwapProJumpTokenDirection.SELL,
+    });
+    navigation.pop();
+    navigation.switchTab(ETabRoutes.Swap);
+  }, [setSwapProJumpTokenAtom, swapToken, navigation]);
+
   if (!swapToken) {
     return (
       <Stack
@@ -155,46 +175,7 @@ export function SwapPanel({
               </>
             ) : null}
           </YStack>
-          <XStack gap="$2" alignItems="center">
-            <Button
-              size="small"
-              variant="primary"
-              w="$28"
-              h="$12"
-              bg="$buttonSuccess"
-              onPress={() => {
-                setSwapProJumpTokenAtom({
-                  token: swapToken,
-                  direction: ESwapProJumpTokenDirection.BUY,
-                });
-                navigation.pop();
-                navigation.switchTab(ETabRoutes.Swap);
-              }}
-            >
-              {intl.formatMessage({
-                id: ETranslations.global_buy,
-              })}
-            </Button>
-            <Button
-              w="$28"
-              h="$12"
-              size="small"
-              bg="$buttonCritical"
-              variant="primary"
-              onPress={() => {
-                setSwapProJumpTokenAtom({
-                  token: swapToken,
-                  direction: ESwapProJumpTokenDirection.SELL,
-                });
-                navigation.pop();
-                navigation.switchTab(ETabRoutes.Swap);
-              }}
-            >
-              {intl.formatMessage({
-                id: ETranslations.global_sell,
-              })}
-            </Button>
-          </XStack>
+          <SwapPanelFooterButtons onBuy={handleBuy} onSell={handleSell} />
         </XStack>
       </YStack>
     );

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelFooterButtons.android.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelFooterButtons.android.tsx
@@ -1,0 +1,80 @@
+import { useMemo } from 'react';
+
+import { useIntl } from 'react-intl';
+import { View } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { runOnJS } from 'react-native-reanimated';
+
+import { Button, XStack } from '@onekeyhq/components';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+
+// On Android, the native bottom tab navigator (react-native-bottom-tabs)
+// intercepts touches in the tab bar area, preventing RN's built-in touch
+// system from dispatching events to buttons in this region — even when the
+// tab bar is hidden (GONE). RNGH intercepts touches at the
+// GestureHandlerRootView (app root) level, bypassing the native view
+// hierarchy entirely.
+
+type IProps = {
+  onBuy: () => void;
+  onSell: () => void;
+};
+
+function SwapPanelFooterButtons({ onBuy, onSell }: IProps) {
+  const intl = useIntl();
+
+  const buyGesture = useMemo(
+    () =>
+      Gesture.Tap().onEnd(() => {
+        'worklet';
+        runOnJS(onBuy)();
+      }),
+    [onBuy],
+  );
+
+  const sellGesture = useMemo(
+    () =>
+      Gesture.Tap().onEnd(() => {
+        'worklet';
+        runOnJS(onSell)();
+      }),
+    [onSell],
+  );
+
+  return (
+    <XStack gap="$2" alignItems="center">
+      <GestureDetector gesture={buyGesture}>
+        <View>
+          <Button
+            size="small"
+            variant="primary"
+            w="$28"
+            h="$12"
+            bg="$buttonSuccess"
+          >
+            {intl.formatMessage({
+              id: ETranslations.global_buy,
+            })}
+          </Button>
+        </View>
+      </GestureDetector>
+      <GestureDetector gesture={sellGesture}>
+        <View>
+          <Button
+            w="$28"
+            h="$12"
+            size="small"
+            bg="$buttonCritical"
+            variant="primary"
+          >
+            {intl.formatMessage({
+              id: ETranslations.global_sell,
+            })}
+          </Button>
+        </View>
+      </GestureDetector>
+    </XStack>
+  );
+}
+
+export default SwapPanelFooterButtons;

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelFooterButtons.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelFooterButtons.tsx
@@ -1,0 +1,44 @@
+import { useIntl } from 'react-intl';
+
+import { Button, XStack } from '@onekeyhq/components';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+
+type IProps = {
+  onBuy: () => void;
+  onSell: () => void;
+};
+
+function SwapPanelFooterButtons({ onBuy, onSell }: IProps) {
+  const intl = useIntl();
+
+  return (
+    <XStack gap="$2" alignItems="center">
+      <Button
+        size="small"
+        variant="primary"
+        w="$28"
+        h="$12"
+        bg="$buttonSuccess"
+        onPress={onBuy}
+      >
+        {intl.formatMessage({
+          id: ETranslations.global_buy,
+        })}
+      </Button>
+      <Button
+        w="$28"
+        h="$12"
+        size="small"
+        bg="$buttonCritical"
+        variant="primary"
+        onPress={onSell}
+      >
+        {intl.formatMessage({
+          id: ETranslations.global_sell,
+        })}
+      </Button>
+    </XStack>
+  );
+}
+
+export default SwapPanelFooterButtons;


### PR DESCRIPTION
## Summary
- On Android, `react-native-bottom-tabs` intercepts touches in the tab bar region even when hidden, making the Buy/Sell buttons on the market detail page unclickable
- Created `SwapPanelFooterButtons.android.tsx` using `GestureDetector` + `Gesture.Tap()` from RNGH to bypass native touch interception (same pattern as `PerpMarketFooter.android.tsx`)
- Default `SwapPanelFooterButtons.tsx` keeps normal `onPress` for iOS/Web — no impact on other platforms

## Test plan
- [ ] Android: Open market detail page (e.g. BTC), verify Buy and Sell buttons are clickable
- [ ] iOS: Open market detail page, verify Buy and Sell buttons still work normally
- [ ] Verify tapping Buy navigates to Swap tab with correct token direction
- [ ] Verify tapping Sell navigates to Swap tab with correct token direction
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
