### PR TITLE
fix: resolve perp withdraw tab text truncation in Account Overview

### DIFF
--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -1288,7 +1288,6 @@ function DepositWithdrawContent({
           height: '100%',
           justifyContent: 'center',
           alignItems: 'center',
-          width: 80,
         }}
         value={selectedAction}
         onChange={onChangeSegmentControl}


### PR DESCRIPTION
## Summary
- Remove hardcoded `width: 80` from `SegmentControl` item style props in the perp Account Overview modal
- This fixed the "Withdraw" tab text being truncated to "Withdra" due to insufficient width

## Test plan
- [ ] Open Account Overview modal on perps page
- [ ] Verify "Withdraw" tab text displays fully without truncation
- [ ] Verify "Deposit" tab still displays correctly
- [ ] Test on both iOS and Android
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
