### PR TITLE
fix(ios): follow system appearance when theme=system

### DIFF
--- a/packages/components/src/hocs/Provider/hooks/useProviderValue.ts
+++ b/packages/components/src/hocs/Provider/hooks/useProviderValue.ts
@@ -4,7 +4,11 @@ import type { HyperlinkText } from '@onekeyhq/kit/src/components/HyperlinkText';
 import type { ILocaleSymbol } from '@onekeyhq/shared/src/locale';
 
 export type ISettingConfigContextValue = {
+  // Resolved theme variant actually used for rendering.
   theme: 'light' | 'dark';
+  // Raw user setting ("system"/"auto" vs forced light/dark). Optional for
+  // hosts that don't have a persisted settings store.
+  themeSetting?: 'light' | 'dark' | 'system';
   locale: ILocaleSymbol;
   HyperlinkText: typeof HyperlinkText;
 };

--- a/packages/components/src/hocs/Provider/index.tsx
+++ b/packages/components/src/hocs/Provider/index.tsx
@@ -17,9 +17,16 @@ import type { TamaguiConfig } from 'tamagui';
 
 export type IUIProviderProps = PropsWithChildren<{
   /**
-   * default theme variant
+   * Resolved theme variant used for rendering.
    */
   theme: 'light' | 'dark';
+
+  /**
+   * Raw user theme setting (system/auto vs forced light/dark).
+   * Optional for hosts that don't have a persisted settings store.
+   */
+  themeSetting?: 'light' | 'dark' | 'system';
+
   /**
    * default locale symbol
    */
@@ -46,6 +53,7 @@ function FontProvider({ children }: IFontProviderProps) {
 export function ConfigProvider({
   children,
   theme,
+  themeSetting,
   locale,
   HyperlinkText,
   onLocaleChange,
@@ -53,10 +61,11 @@ export function ConfigProvider({
   const providerValue = useMemo(
     () => ({
       theme,
+      themeSetting,
       locale,
       HyperlinkText,
     }),
-    [theme, locale, HyperlinkText],
+    [theme, themeSetting, locale, HyperlinkText],
   );
 
   const config = useMemo(

--- a/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
@@ -75,11 +75,12 @@ export const useOnRouterChange = (callback: IRouterChangeEvent) => {
 
 const useUpdateRootViewBackgroundColor = (
   color: string,
-  theme: 'light' | 'dark',
+  themeVariant: 'light' | 'dark',
+  themeSetting?: 'light' | 'dark' | 'system',
 ) => {
   useEffect(() => {
-    updateRootViewBackgroundColor(color, theme);
-  }, [color, theme]);
+    updateRootViewBackgroundColor(color, themeVariant, themeSetting);
+  }, [color, themeVariant, themeSetting]);
 };
 
 const useNativeDevTools =
@@ -100,10 +101,10 @@ export function NavigationContainer(props: IBasicNavigationContainerProps) {
       isTabletMainView ? tabletMainViewNavigationRef : rootNavigationRef,
     );
   }, [isTabletMainView]);
-  const { theme: themeName } = useSettingConfig();
+  const { theme: themeName, themeSetting } = useSettingConfig();
   const theme = useTheme();
 
-  useUpdateRootViewBackgroundColor(theme.bgApp.val, themeName);
+  useUpdateRootViewBackgroundColor(theme.bgApp.val, themeName, themeSetting);
 
   const themeOptions = useMemo(() => {
     return {

--- a/packages/kit/src/provider/ThemeProvider.tsx
+++ b/packages/kit/src/provider/ThemeProvider.tsx
@@ -5,11 +5,14 @@ import { ConfigProvider } from '@onekeyhq/components';
 import { HyperlinkText } from '@onekeyhq/kit/src/components/HyperlinkText';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
+import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+
 import backgroundApiProxy from '../background/instance/backgroundApiProxy';
 import { useLocaleVariant } from '../hooks/useLocaleVariant';
 import { useThemeVariant } from '../hooks/useThemeVariant';
 
 function BasicThemeProvider({ children }: PropsWithChildren<unknown>) {
+  const [{ theme: themeSetting }] = useSettingsPersistAtom();
   const themeVariant = useThemeVariant();
   const localeVariant = useLocaleVariant();
 
@@ -25,6 +28,7 @@ function BasicThemeProvider({ children }: PropsWithChildren<unknown>) {
     return (
       <ConfigProvider
         theme={themeVariant as any}
+        themeSetting={themeSetting}
         locale={localeVariant}
         HyperlinkText={HyperlinkText}
         onLocaleChange={handleLocalChange}
@@ -32,7 +36,7 @@ function BasicThemeProvider({ children }: PropsWithChildren<unknown>) {
         {children}
       </ConfigProvider>
     );
-  }, [themeVariant, localeVariant, handleLocalChange, children]);
+  }, [themeSetting, themeVariant, localeVariant, handleLocalChange, children]);
 }
 
 export const ThemeProvider = memo(BasicThemeProvider);

--- a/packages/shared/src/modules3rdParty/rootview-background/index.native.tsx
+++ b/packages/shared/src/modules3rdParty/rootview-background/index.native.tsx
@@ -6,12 +6,18 @@ import platformEnv from '../../platformEnv';
 
 export const updateRootViewBackgroundColor: IUpdateRootViewBackgroundColor = (
   color: string,
-  theme: 'light' | 'dark',
+  themeVariant: 'light' | 'dark',
+  themeSetting?: 'light' | 'dark' | 'system',
 ) => {
   const parsedColor = colord(color);
   const { r, g, b, a } = parsedColor.toRgb();
   ReactNativeDeviceUtils.changeBackgroundColor(r, g, b, Math.round(a * 255));
+
   if (platformEnv.isNativeIOS) {
-    ReactNativeDeviceUtils.setUserInterfaceStyle(theme);
+    // If the user picked "System/Auto", stop overriding iOS UI style so
+    // `Appearance.getColorScheme()` reflects the real system setting.
+    ReactNativeDeviceUtils.setUserInterfaceStyle(
+      themeSetting === 'system' ? 'unspecified' : themeVariant,
+    );
   }
 };

--- a/packages/shared/src/modules3rdParty/rootview-background/index.tsx
+++ b/packages/shared/src/modules3rdParty/rootview-background/index.tsx
@@ -6,10 +6,10 @@ export const THEME_PRELOAD_STORAGE_KEY = 'ONEKEY_THEME_PRELOAD';
 
 export const updateRootViewBackgroundColor: IUpdateRootViewBackgroundColor = (
   color: string,
-  theme: 'light' | 'dark',
+  themeVariant: 'light' | 'dark',
 ) => {
   setTimeout(() => {
-    localStorage.setItem(THEME_PRELOAD_STORAGE_KEY, theme);
+    localStorage.setItem(THEME_PRELOAD_STORAGE_KEY, themeVariant);
     const meta = document.querySelector('meta[name="theme-color"]');
     if (meta) {
       meta.setAttribute('content', color);
@@ -19,7 +19,7 @@ export const updateRootViewBackgroundColor: IUpdateRootViewBackgroundColor = (
       void (async () => {
         try {
           await globalThis.chrome?.storage?.local?.set({
-            [THEME_PRELOAD_STORAGE_KEY]: theme,
+            [THEME_PRELOAD_STORAGE_KEY]: themeVariant,
           });
         } catch {
           // ignore
@@ -28,7 +28,7 @@ export const updateRootViewBackgroundColor: IUpdateRootViewBackgroundColor = (
     }
     // startup theme on desktop: apps/desktop/app/app.ts 213L
     if (platformEnv.isDesktop) {
-      void globalThis.desktopApiProxy.system.changeTheme(theme);
+      void globalThis.desktopApiProxy.system.changeTheme(themeVariant);
     }
   });
 };

--- a/packages/shared/src/modules3rdParty/rootview-background/type.ts
+++ b/packages/shared/src/modules3rdParty/rootview-background/type.ts
@@ -1,4 +1,5 @@
 export type IUpdateRootViewBackgroundColor = (
   color: string,
-  theme: 'light' | 'dark',
+  themeVariant: 'light' | 'dark',
+  themeSetting?: 'light' | 'dark' | 'system',
 ) => void;


### PR DESCRIPTION
Problem:
- When user selects Theme=System/Auto, app doesn\x27t follow iOS system appearance.
- Root cause: we were forcing iOS UIUserInterfaceStyle to the resolved light/dark variant, which can make Appearance.getColorScheme() reflect the forced override.

Fix:
- Thread raw theme setting (light/dark/system) alongside resolved theme variant.
- On iOS, when themeSetting==="system", call setUserInterfaceStyle("unspecified") so the app follows the OS.

Files:
- packages/shared/src/modules3rdParty/rootview-background/index.native.tsx
- packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
- packages/kit/src/provider/ThemeProvider.tsx
- plus small type/context plumbing.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
