### PR TITLE
fix(android): prevent ViewPager2 crash during layout computation

### DIFF
--- a/patches/react-native-pager-view+7.0.1.patch
+++ b/patches/react-native-pager-view+7.0.1.patch
@@ -95,7 +95,7 @@ index d5b82ff..5f1a084 100644
      }
  
 diff --git a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
-index fd3530e..5b9d739 100644
+index fd3530e..a4ded6f 100644
 --- a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
 +++ b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
 @@ -1,14 +1,34 @@
@@ -169,22 +169,26 @@ index fd3530e..5b9d739 100644
      for (index in 1..childrenViews.size) {
        val child = childrenViews[index-1]
        if (child.parent?.parent != null) {
-@@ -64,6 +101,10 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
+@@ -64,6 +101,14 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
    }
  
    fun removeChildAt(index: Int) {
 +    if (isComputingLayout()) {
-+      handler.post { removeChildAt(index) }
++      // Capture child by identity to avoid stale-index removal after deferral
++      if (index >= 0 && index < childrenViews.size) {
++        val child = childrenViews[index]
++        handler.post { removeChild(child) }
++      }
 +      return
 +    }
      if (index >= 0 && index < childrenViews.size) {
        childrenViews.removeAt(index)
        notifyItemRemoved(index)
 diff --git a/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm b/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm
-index d52f532..753dd8c 100644
+index d52f532..9421287 100644
 --- a/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm
 +++ b/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm
-@@ -29,6 +29,12 @@ @implementation RNCPagerViewComponentView {
+@@ -29,6 +29,14 @@ @implementation RNCPagerViewComponentView {
      BOOL _overdrag;
      NSString *_layoutDirection;
      BOOL _scrollEnabled;
@@ -194,18 +198,21 @@ index d52f532..753dd8c 100644
 +    NSUInteger _generation;
 +    // _transitionId: async guard for superseded transitions, incremented each setPagerViewControllers call
 +    NSUInteger _transitionId;
++    // _pendingGoToIndex: stores the latest blocked animated transition target, drained after current transition completes
++    NSInteger _pendingGoToIndex;
  }
  
  // Needed because of this: https://github.com/facebook/react-native/pull/37274
-@@ -80,6 +86,7 @@ - (instancetype)initWithFrame:(CGRect)frame
+@@ -80,6 +88,8 @@ - (instancetype)initWithFrame:(CGRect)frame
          _layoutDirection = @"ltr";
          _overdrag = NO;
          _scrollEnabled = YES;
 +        _isBeingRecycled = NO;
++        _pendingGoToIndex = -1;
      }
-     
+ 
      return self;
-@@ -96,6 +103,9 @@ - (void)willMoveToSuperview:(UIView *)newSuperview {
+@@ -96,6 +106,9 @@ - (void)willMoveToSuperview:(UIView *)newSuperview {
  #pragma mark - React API
  
  - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index {
@@ -215,7 +222,7 @@ index d52f532..753dd8c 100644
      UIViewController *vc = [UIViewController new];
      [vc.view addSubview:childComponentView];
      [_nativeChildrenViewControllers insertObject:vc atIndex:index];
-@@ -103,13 +113,23 @@ - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childCompone
+@@ -103,13 +116,23 @@ - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childCompone
  }
  
  - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index {
@@ -240,7 +247,7 @@ index d52f532..753dd8c 100644
      }
  }
  
-@@ -127,10 +147,22 @@ -(void)updateLayoutMetrics:(const facebook::react::LayoutMetrics &)layoutMetrics
+@@ -127,10 +150,23 @@ -(void)updateLayoutMetrics:(const facebook::react::LayoutMetrics &)layoutMetrics
  
  
  -(void)prepareForRecycle {
@@ -259,11 +266,12 @@ index d52f532..753dd8c 100644
      _nativePageViewController = nil;
      _currentIndex = -1;
      _scrollEnabled = YES;
++    _pendingGoToIndex = -1;
 +    _isBeingRecycled = NO;
  }
  
  - (void)shouldDismissKeyboard:(RNCViewPagerKeyboardDismissMode)dismissKeyboard {
-@@ -200,6 +232,14 @@ - (void)enableSwipe {
+@@ -200,6 +236,14 @@ - (void)enableSwipe {
  - (void)goTo:(NSInteger)index animated:(BOOL)animated {
      NSInteger numberOfPages = _nativeChildrenViewControllers.count;
      
@@ -278,7 +286,7 @@ index d52f532..753dd8c 100644
      [self disableSwipe];
      
      _destinationIndex = index;
-@@ -223,7 +263,50 @@ - (void)goTo:(NSInteger)index animated:(BOOL)animated {
+@@ -223,28 +267,105 @@ - (void)goTo:(NSInteger)index animated:(BOOL)animated {
  - (void)setPagerViewControllers:(NSInteger)index
                        direction:(UIPageViewControllerNavigationDirection)direction
                         animated:(BOOL)animated{
@@ -325,12 +333,16 @@ index d52f532..753dd8c 100644
 +    // the internal _UIQueuingScrollView queue, so they are safe during an ongoing transition.
 +    if (transitioning && animated) {
 +#ifdef DEBUG
-+        NSLog(@"[PagerView] setPagerViewControllers blocked: already transitioning (index=%ld)", (long)index);
++        NSLog(@"[PagerView] setPagerViewControllers deferred: already transitioning (index=%ld)", (long)index);
 +#endif
++        _pendingGoToIndex = index;
          [self enableSwipe];
          return;
      }
-@@ -231,18 +314,41 @@ - (void)setPagerViewControllers:(NSInteger)index
+ 
++    // Clear any pending transition since we are now starting a fresh one
++    _pendingGoToIndex = -1;
++
      transitioning = YES;
  
      __weak RNCPagerViewComponentView *weakSelf = self;
@@ -376,8 +388,17 @@ index d52f532..753dd8c 100644
 +            }
          }
          [strongSelf updateLayoutMetrics:strongSelf->_layoutMetrics oldLayoutMetrics:strongSelf->_oldLayoutMetrics];
++
++        // Drain pending transition that was blocked while this animation was in-flight
++        NSInteger pending = strongSelf->_pendingGoToIndex;
++        if (pending >= 0 && pending != index) {
++            strongSelf->_pendingGoToIndex = -1;
++            [strongSelf goTo:pending animated:YES];
++        }
      }];
-@@ -252,6 +358,11 @@ - (void)setPagerViewControllers:(NSInteger)index
+ }
+ 
+@@ -252,6 +373,11 @@ - (void)setPagerViewControllers:(NSInteger)index
  - (UIViewController *)nextControllerForController:(UIViewController *)controller
                                        inDirection:(UIPageViewControllerNavigationDirection)direction {
      NSUInteger numberOfPages = _nativeChildrenViewControllers.count;
@@ -389,7 +410,7 @@ index d52f532..753dd8c 100644
      NSInteger index = [_nativeChildrenViewControllers indexOfObject:controller];
      
      if (index == NSNotFound) {
-@@ -274,13 +385,22 @@ - (UIViewController *)currentlyDisplayed {
+@@ -274,13 +400,22 @@ - (UIViewController *)currentlyDisplayed {
  #pragma mark - UIScrollViewDelegate
  
  - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView {
@@ -412,7 +433,7 @@ index d52f532..753dd8c 100644
      eventEmitter->onPageScrollStateChanged(RNCViewPagerEventEmitter::OnPageScrollStateChanged{.pageScrollState =  RNCViewPagerEventEmitter::OnPageScrollStateChangedPageScrollState::Settling });
      
      if (!_overdrag) {
-@@ -300,12 +420,21 @@ - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoi
+@@ -300,12 +435,21 @@ - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoi
  }
  
  - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
@@ -434,7 +455,7 @@ index d52f532..753dd8c 100644
      BOOL isHorizontal = [self isHorizontal];
      CGFloat contentOffset = isHorizontal ? scrollView.contentOffset.x : scrollView.contentOffset.y;
      CGFloat frameSize = isHorizontal ? scrollView.frame.size.width : scrollView.frame.size.height;
-@@ -357,13 +486,18 @@ - (void)pageViewController:(UIPageViewController *)pageViewController
+@@ -357,13 +501,18 @@ - (void)pageViewController:(UIPageViewController *)pageViewController
          didFinishAnimating:(BOOL)finished
     previousViewControllers:(nonnull NSArray<UIViewController *> *)previousViewControllers
         transitionCompleted:(BOOL)completed {
@@ -454,7 +475,7 @@ index d52f532..753dd8c 100644
      }
  }
  
-@@ -427,10 +561,12 @@ - (BOOL)isLtrLayout {
+@@ -427,10 +576,12 @@ - (BOOL)isLtrLayout {
  
  - (void)sendScrollEventsForPosition:(NSInteger)position offset:(CGFloat)offset {
      const auto eventEmitter = [self pagerEventEmitter];

--- a/patches/react-native-pager-view+7.0.1.patch
+++ b/patches/react-native-pager-view+7.0.1.patch
@@ -80,19 +80,90 @@ index d5b82ff..adfb9a2 100644
          }
      }
  
+diff --git a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
+index fd3530e..91c2166 100644
+--- a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
++++ b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
+@@ -1,14 +1,29 @@
+ package com.reactnativepagerview
+ 
++import android.os.Handler
++import android.os.Looper
+ import android.view.View
+ import android.view.ViewGroup
+ import android.widget.FrameLayout
++import androidx.recyclerview.widget.RecyclerView
+ import androidx.recyclerview.widget.RecyclerView.Adapter
+ import java.util.*
+ 
+ 
+ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
+   private val childrenViews: ArrayList<View> = ArrayList()
++  private var recyclerView: RecyclerView? = null
++  private val handler = Handler(Looper.getMainLooper())
++
++  override fun onAttachedToRecyclerView(rv: RecyclerView) {
++    super.onAttachedToRecyclerView(rv)
++    recyclerView = rv
++  }
++
++  override fun onDetachedFromRecyclerView(rv: RecyclerView) {
++    super.onDetachedFromRecyclerView(rv)
++    recyclerView = null
++  }
+ 
+   override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewPagerViewHolder {
+     return ViewPagerViewHolder.create(parent)
+@@ -34,9 +49,18 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
+     return childrenViews.size
+   }
+ 
++  private fun safeNotify(action: () -> Unit) {
++    val rv = recyclerView
++    if (rv != null && rv.isComputingLayout) {
++      handler.post(action)
++    } else {
++      action()
++    }
++  }
++
+   fun addChild(child: View, index: Int) {
+     childrenViews.add(index, child)
+-    notifyItemInserted(index)
++    safeNotify { notifyItemInserted(index) }
+   }
+ 
+   fun getChildAt(index: Int): View {
+@@ -60,13 +84,13 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
+     }
+     val removedChildrenCount = childrenViews.size
+     childrenViews.clear()
+-    notifyItemRangeRemoved(0, removedChildrenCount)
++    safeNotify { notifyItemRangeRemoved(0, removedChildrenCount) }
+   }
+ 
+   fun removeChildAt(index: Int) {
+     if (index >= 0 && index < childrenViews.size) {
+       childrenViews.removeAt(index)
+-      notifyItemRemoved(index)
++      safeNotify { notifyItemRemoved(index) }
+     }
+   }
+ }
 diff --git a/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm b/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm
-index d52f532..e27b02e 100644
+index d52f532..5184f4d 100644
 --- a/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm
 +++ b/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm
-@@ -29,6 +29,7 @@ @implementation RNCPagerViewComponentView {
+@@ -29,6 +29,8 @@ @implementation RNCPagerViewComponentView {
      BOOL _overdrag;
      NSString *_layoutDirection;
      BOOL _scrollEnabled;
 +    BOOL _isBeingRecycled;
++    NSUInteger _generation;
  }
  
  // Needed because of this: https://github.com/facebook/react-native/pull/37274
-@@ -80,6 +81,7 @@ - (instancetype)initWithFrame:(CGRect)frame
+@@ -80,6 +82,7 @@ - (instancetype)initWithFrame:(CGRect)frame
          _layoutDirection = @"ltr";
          _overdrag = NO;
          _scrollEnabled = YES;
@@ -100,7 +171,7 @@ index d52f532..e27b02e 100644
      }
      
      return self;
-@@ -96,6 +98,9 @@ - (void)willMoveToSuperview:(UIView *)newSuperview {
+@@ -96,6 +99,9 @@ - (void)willMoveToSuperview:(UIView *)newSuperview {
  #pragma mark - React API
  
  - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index {
@@ -110,7 +181,7 @@ index d52f532..e27b02e 100644
      UIViewController *vc = [UIViewController new];
      [vc.view addSubview:childComponentView];
      [_nativeChildrenViewControllers insertObject:vc atIndex:index];
-@@ -103,13 +108,23 @@ - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childCompone
+@@ -103,13 +109,23 @@ - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childCompone
  }
  
  - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index {
@@ -135,11 +206,12 @@ index d52f532..e27b02e 100644
      }
  }
  
-@@ -127,10 +142,21 @@ -(void)updateLayoutMetrics:(const facebook::react::LayoutMetrics &)layoutMetrics
+@@ -127,10 +143,22 @@ -(void)updateLayoutMetrics:(const facebook::react::LayoutMetrics &)layoutMetrics
  
  
  -(void)prepareForRecycle {
 +    _isBeingRecycled = YES;
++    _generation++;
 +
 +    // Cancel any ongoing transitions
 +    if (_nativePageViewController != nil && transitioning) {
@@ -157,44 +229,52 @@ index d52f532..e27b02e 100644
  }
  
  - (void)shouldDismissKeyboard:(RNCViewPagerKeyboardDismissMode)dismissKeyboard {
-@@ -200,6 +226,12 @@ - (void)enableSwipe {
+@@ -200,6 +228,14 @@ - (void)enableSwipe {
  - (void)goTo:(NSInteger)index animated:(BOOL)animated {
      NSInteger numberOfPages = _nativeChildrenViewControllers.count;
      
 +    // Check recycling state BEFORE disableSwipe to avoid state inconsistency
 +    if (_isBeingRecycled) {
++#ifdef DEBUG
 +        NSLog(@"[PagerView] goTo blocked: view is being recycled (index=%ld)", (long)index);
++#endif
 +        return;
 +    }
 +
      [self disableSwipe];
      
      _destinationIndex = index;
-@@ -223,25 +255,61 @@ - (void)goTo:(NSInteger)index animated:(BOOL)animated {
+@@ -223,7 +259,50 @@ - (void)goTo:(NSInteger)index animated:(BOOL)animated {
  - (void)setPagerViewControllers:(NSInteger)index
                        direction:(UIPageViewControllerNavigationDirection)direction
                         animated:(BOOL)animated{
 -    if (_nativePageViewController == nil) {
 +    if (_nativePageViewController == nil || _isBeingRecycled) {
++#ifdef DEBUG
 +        NSLog(@"[PagerView] setPagerViewControllers blocked: pageVC=%@ recycled=%d index=%ld",
 +              _nativePageViewController ? @"EXISTS" : @"NIL", _isBeingRecycled, (long)index);
++#endif
 +        [self enableSwipe];
 +        return;
 +    }
 +
 +    // Validate index bounds
 +    if (index < 0 || index >= _nativeChildrenViewControllers.count) {
++#ifdef DEBUG
 +        NSLog(@"[PagerView] setPagerViewControllers blocked: index %ld out of bounds (count=%lu)",
 +              (long)index, (unsigned long)_nativeChildrenViewControllers.count);
-         [self enableSwipe];
-         return;
-     }
-   
++#endif
++        [self enableSwipe];
++        return;
++    }
++
 +    // Validate view controller and its view
 +    UIViewController *targetVC = [_nativeChildrenViewControllers objectAtIndex:index];
 +    if (targetVC == nil || targetVC.view == nil) {
++#ifdef DEBUG
 +        NSLog(@"[PagerView] setPagerViewControllers blocked: targetVC=%@ view=%@ index=%ld",
 +              targetVC ? @"EXISTS" : @"NIL", targetVC.view ? @"EXISTS" : @"NIL", (long)index);
++#endif
 +        [self enableSwipe];
 +        return;
 +    }
@@ -203,12 +283,25 @@ index d52f532..e27b02e 100644
 +    // Target page views are expected to have nil superview/window before being added to pageViewController
 +    // Checking for nil superview/window would block all legitimate page transitions
 +
-+    NSLog(@"[PagerView] setPagerViewControllers SUCCESS: index=%ld animated=%d", (long)index, animated);
-+
++    // Prevent calling setViewControllers during an ongoing animated transition.
++    // UIPageViewController's internal _UIQueuingScrollView does not support
++    // concurrent enqueued transitions and will crash with
++    // "Duplicate states in queue" (NSInternalInconsistencyException).
++    // Note: Non-animated transitions (animated=NO) are synchronous and bypass
++    // the internal _UIQueuingScrollView queue, so they are safe during an ongoing transition.
++    if (transitioning && animated) {
++#ifdef DEBUG
++        NSLog(@"[PagerView] setPagerViewControllers blocked: already transitioning (index=%ld)", (long)index);
++#endif
+         [self enableSwipe];
+         return;
+     }
+@@ -231,17 +310,30 @@ - (void)setPagerViewControllers:(NSInteger)index
      transitioning = YES;
  
      __weak RNCPagerViewComponentView *weakSelf = self;
 -    [_nativePageViewController setViewControllers:@[[_nativeChildrenViewControllers objectAtIndex:index]]
++    NSUInteger capturedGeneration = _generation;
 +    [_nativePageViewController setViewControllers:@[targetVC]
                                          direction:direction
                                           animated:animated
@@ -221,7 +314,8 @@ index d52f532..e27b02e 100644
 +
 +        strongSelf->transitioning = NO;
 +
-+        if (strongSelf->_isBeingRecycled) {
++        // View was recycled and possibly reused since this animation started
++        if (strongSelf->_isBeingRecycled || strongSelf->_generation != capturedGeneration) {
 +            return;
 +        }
 +
@@ -237,7 +331,7 @@ index d52f532..e27b02e 100644
              strongSelf->_currentIndex = index;
          }
          [strongSelf updateLayoutMetrics:strongSelf->_layoutMetrics oldLayoutMetrics:strongSelf->_oldLayoutMetrics];
-@@ -252,6 +320,11 @@ - (void)setPagerViewControllers:(NSInteger)index
+@@ -252,6 +344,11 @@ - (void)setPagerViewControllers:(NSInteger)index
  - (UIViewController *)nextControllerForController:(UIViewController *)controller
                                        inDirection:(UIPageViewControllerNavigationDirection)direction {
      NSUInteger numberOfPages = _nativeChildrenViewControllers.count;
@@ -249,7 +343,7 @@ index d52f532..e27b02e 100644
      NSInteger index = [_nativeChildrenViewControllers indexOfObject:controller];
      
      if (index == NSNotFound) {
-@@ -274,13 +347,22 @@ - (UIViewController *)currentlyDisplayed {
+@@ -274,13 +371,22 @@ - (UIViewController *)currentlyDisplayed {
  #pragma mark - UIScrollViewDelegate
  
  - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView {
@@ -272,7 +366,7 @@ index d52f532..e27b02e 100644
      eventEmitter->onPageScrollStateChanged(RNCViewPagerEventEmitter::OnPageScrollStateChanged{.pageScrollState =  RNCViewPagerEventEmitter::OnPageScrollStateChangedPageScrollState::Settling });
      
      if (!_overdrag) {
-@@ -300,12 +382,21 @@ - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoi
+@@ -300,12 +406,21 @@ - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoi
  }
  
  - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
@@ -294,7 +388,7 @@ index d52f532..e27b02e 100644
      BOOL isHorizontal = [self isHorizontal];
      CGFloat contentOffset = isHorizontal ? scrollView.contentOffset.x : scrollView.contentOffset.y;
      CGFloat frameSize = isHorizontal ? scrollView.frame.size.width : scrollView.frame.size.height;
-@@ -357,13 +448,18 @@ - (void)pageViewController:(UIPageViewController *)pageViewController
+@@ -357,13 +472,18 @@ - (void)pageViewController:(UIPageViewController *)pageViewController
          didFinishAnimating:(BOOL)finished
     previousViewControllers:(nonnull NSArray<UIViewController *> *)previousViewControllers
         transitionCompleted:(BOOL)completed {
@@ -314,7 +408,7 @@ index d52f532..e27b02e 100644
      }
  }
  
-@@ -427,10 +523,12 @@ - (BOOL)isLtrLayout {
+@@ -427,10 +547,12 @@ - (BOOL)isLtrLayout {
  
  - (void)sendScrollEventsForPosition:(NSInteger)position offset:(CGFloat)offset {
      const auto eventEmitter = [self pagerEventEmitter];
@@ -322,12 +416,12 @@ index d52f532..e27b02e 100644
 -        .position = static_cast<double>(position),
 -        .offset = offset
 -    });
-+     if (eventEmitter && eventEmitter != nullptr) {
++    if (eventEmitter) {
 +        eventEmitter->onPageScroll(RNCViewPagerEventEmitter::OnPageScroll{
 +            .position = static_cast<double>(position),
 +            .offset = offset
 +        });
-+     }
++    }
    
      // This is temporary workaround to allow animations based on onPageScroll event
      // until Fabric implements proper NativeAnimationDriver,

--- a/patches/react-native-pager-view+7.0.1.patch
+++ b/patches/react-native-pager-view+7.0.1.patch
@@ -25,26 +25,27 @@ index 8ec286a..a46ba48 100644
          if (root == null) {
              return
 diff --git a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/PagerViewViewManagerImpl.kt b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/PagerViewViewManagerImpl.kt
-index d5b82ff..45d08a5 100644
+index d5b82ff..5f1a084 100644
 --- a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/PagerViewViewManagerImpl.kt
 +++ b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/PagerViewViewManagerImpl.kt
-@@ -7,8 +7,11 @@ import com.facebook.react.uimanager.PixelUtil
+@@ -7,8 +7,12 @@ import com.facebook.react.uimanager.PixelUtil
  import android.os.Handler
  import android.os.Looper
  import android.view.Choreographer
 +import android.util.Log
 +import androidx.recyclerview.widget.RecyclerView
++import java.util.WeakHashMap
  
  object PagerViewViewManagerImpl {
 +    private const val TAG = "PagerView"
      const val NAME = "RNCViewPager"
  
      private var refreshFrameCallback: Choreographer.FrameCallback? = null
-@@ -26,6 +29,25 @@ object PagerViewViewManagerImpl {
+@@ -26,6 +30,25 @@ object PagerViewViewManagerImpl {
          view.setCurrentItem(selectedTab, scrollSmooth)
      }
  
-+    private var originalTouchSlop: Int? = null
++    private val originalTouchSlopMap = WeakHashMap<ViewPager2, Int>()
 +
 +    fun ViewPager2.reduceDragSensitivity(value: Int) {
 +        try {
@@ -53,9 +54,9 @@ index d5b82ff..45d08a5 100644
 +            val recyclerView = recyclerViewField.get(this) as? RecyclerView ?: return
 +            val touchSlopField = RecyclerView::class.java.getDeclaredField("mTouchSlop")
 +            touchSlopField.isAccessible = true
-+            // Store original value on first call to prevent accumulation on re-renders
-+            val baseSlop = originalTouchSlop ?: (touchSlopField.get(recyclerView) as Int).also {
-+                originalTouchSlop = it
++            // Store original value per instance to prevent accumulation on re-renders
++            val baseSlop = originalTouchSlopMap[this] ?: (touchSlopField.get(recyclerView) as Int).also {
++                originalTouchSlopMap[this] = it
 +            }
 +            touchSlopField.set(recyclerView, baseSlop * value)
 +        } catch (e: Exception) {
@@ -66,7 +67,7 @@ index d5b82ff..45d08a5 100644
      fun addView(host: NestedScrollableHost, child: View?, index: Int) {
          if (child == null) {
              return
-@@ -161,10 +183,22 @@ object PagerViewViewManagerImpl {
+@@ -161,10 +184,22 @@ object PagerViewViewManagerImpl {
  
      private fun refreshViewChildrenLayout(view: View) {
          view.post {
@@ -94,10 +95,10 @@ index d5b82ff..45d08a5 100644
      }
  
 diff --git a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
-index fd3530e..0d6b5b1 100644
+index fd3530e..5b9d739 100644
 --- a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
 +++ b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
-@@ -1,14 +1,30 @@
+@@ -1,14 +1,34 @@
  package com.reactnativepagerview
  
 +import android.os.Handler
@@ -107,10 +108,14 @@ index fd3530e..0d6b5b1 100644
  import android.widget.FrameLayout
 +import androidx.recyclerview.widget.RecyclerView
  import androidx.recyclerview.widget.RecyclerView.Adapter
++import android.util.Log
  import java.util.*
  
  
  class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
++  private companion object {
++    private const val TAG = "PagerView"
++  }
    private val childrenViews: ArrayList<View> = ArrayList()
 +  private var recyclerView: RecyclerView? = null
 +  private val handler = Handler(Looper.getMainLooper())
@@ -128,7 +133,7 @@ index fd3530e..0d6b5b1 100644
  
    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewPagerViewHolder {
      return ViewPagerViewHolder.create(parent)
-@@ -34,9 +50,19 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
+@@ -34,9 +54,22 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
      return childrenViews.size
    }
  
@@ -145,22 +150,26 @@ index fd3530e..0d6b5b1 100644
 +      return
 +    }
 +    val safeIndex = index.coerceIn(0, childrenViews.size)
++    if (safeIndex != index) {
++      Log.w(TAG, "addChild index $index out of bounds (size=${childrenViews.size}), clamped to $safeIndex")
++    }
 +    childrenViews.add(safeIndex, child)
 +    notifyItemInserted(safeIndex)
    }
  
    fun getChildAt(index: Int): View {
-@@ -58,12 +84,20 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
-         (child.parent.parent as ViewGroup).removeView(child.parent as View)
-       }
-     }
+@@ -52,6 +85,10 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
+   }
+ 
+   fun removeAll() {
 +    if (isComputingLayout()) {
 +      handler.post { removeAll() }
 +      return
 +    }
-     val removedChildrenCount = childrenViews.size
-     childrenViews.clear()
-     notifyItemRangeRemoved(0, removedChildrenCount)
+     for (index in 1..childrenViews.size) {
+       val child = childrenViews[index-1]
+       if (child.parent?.parent != null) {
+@@ -64,6 +101,10 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
    }
  
    fun removeChildAt(index: Int) {

--- a/patches/react-native-pager-view+7.0.1.patch
+++ b/patches/react-native-pager-view+7.0.1.patch
@@ -25,35 +25,48 @@ index 8ec286a..a46ba48 100644
          if (root == null) {
              return
 diff --git a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/PagerViewViewManagerImpl.kt b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/PagerViewViewManagerImpl.kt
-index d5b82ff..adfb9a2 100644
+index d5b82ff..45d08a5 100644
 --- a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/PagerViewViewManagerImpl.kt
 +++ b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/PagerViewViewManagerImpl.kt
-@@ -7,6 +7,7 @@ import com.facebook.react.uimanager.PixelUtil
+@@ -7,8 +7,11 @@ import com.facebook.react.uimanager.PixelUtil
  import android.os.Handler
  import android.os.Looper
  import android.view.Choreographer
++import android.util.Log
 +import androidx.recyclerview.widget.RecyclerView
  
  object PagerViewViewManagerImpl {
++    private const val TAG = "PagerView"
      const val NAME = "RNCViewPager"
-@@ -26,6 +27,16 @@ object PagerViewViewManagerImpl {
+ 
+     private var refreshFrameCallback: Choreographer.FrameCallback? = null
+@@ -26,6 +29,25 @@ object PagerViewViewManagerImpl {
          view.setCurrentItem(selectedTab, scrollSmooth)
      }
  
++    private var originalTouchSlop: Int? = null
++
 +    fun ViewPager2.reduceDragSensitivity(value: Int) {
-+        val recyclerViewField = ViewPager2::class.java.getDeclaredField("mRecyclerView")
-+        recyclerViewField.isAccessible = true
-+        val recyclerView = recyclerViewField.get(this) as RecyclerView
-+        val touchSlopField = RecyclerView::class.java.getDeclaredField("mTouchSlop")
-+        touchSlopField.isAccessible = true
-+        val touchSlop = touchSlopField.get(recyclerView) as Int
-+        touchSlopField.set(recyclerView, touchSlop*value)
++        try {
++            val recyclerViewField = ViewPager2::class.java.getDeclaredField("mRecyclerView")
++            recyclerViewField.isAccessible = true
++            val recyclerView = recyclerViewField.get(this) as? RecyclerView ?: return
++            val touchSlopField = RecyclerView::class.java.getDeclaredField("mTouchSlop")
++            touchSlopField.isAccessible = true
++            // Store original value on first call to prevent accumulation on re-renders
++            val baseSlop = originalTouchSlop ?: (touchSlopField.get(recyclerView) as Int).also {
++                originalTouchSlop = it
++            }
++            touchSlopField.set(recyclerView, baseSlop * value)
++        } catch (e: Exception) {
++            Log.w(TAG, "Failed to adjust drag sensitivity", e)
++        }
 +    }
 +
      fun addView(host: NestedScrollableHost, child: View?, index: Int) {
          if (child == null) {
              return
-@@ -161,10 +172,22 @@ object PagerViewViewManagerImpl {
+@@ -161,10 +183,22 @@ object PagerViewViewManagerImpl {
  
      private fun refreshViewChildrenLayout(view: View) {
          view.post {
@@ -81,7 +94,7 @@ index d5b82ff..adfb9a2 100644
      }
  
 diff --git a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
-index fd3530e..4db4e04 100644
+index fd3530e..0d6b5b1 100644
 --- a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
 +++ b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
 @@ -1,14 +1,30 @@
@@ -115,7 +128,7 @@ index fd3530e..4db4e04 100644
  
    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewPagerViewHolder {
      return ViewPagerViewHolder.create(parent)
-@@ -34,7 +50,16 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
+@@ -34,9 +50,19 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
      return childrenViews.size
    }
  
@@ -125,14 +138,19 @@ index fd3530e..4db4e04 100644
 +  }
 +
    fun addChild(child: View, index: Int) {
+-    childrenViews.add(index, child)
+-    notifyItemInserted(index)
 +    if (isComputingLayout()) {
 +      handler.post { addChild(child, index) }
 +      return
 +    }
-     childrenViews.add(index, child)
-     notifyItemInserted(index)
++    val safeIndex = index.coerceIn(0, childrenViews.size)
++    childrenViews.add(safeIndex, child)
++    notifyItemInserted(safeIndex)
    }
-@@ -58,12 +83,20 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
+ 
+   fun getChildAt(index: Int): View {
+@@ -58,12 +84,20 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
          (child.parent.parent as ViewGroup).removeView(child.parent as View)
        }
      }

--- a/patches/react-native-pager-view+7.0.1.patch
+++ b/patches/react-native-pager-view+7.0.1.patch
@@ -95,7 +95,7 @@ index d5b82ff..5f1a084 100644
      }
  
 diff --git a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
-index fd3530e..a4ded6f 100644
+index fd3530e..8988ac3 100644
 --- a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
 +++ b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
 @@ -1,14 +1,34 @@
@@ -158,7 +158,22 @@ index fd3530e..a4ded6f 100644
    }
  
    fun getChildAt(index: Int): View {
-@@ -52,6 +85,10 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
+@@ -44,14 +77,22 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
+   }
+ 
+   fun removeChild(child: View) {
++    if (isComputingLayout()) {
++      handler.post { removeChild(child) }
++      return
++    }
+     val index = childrenViews.indexOf(child)
+-    
+-    if(index > -1) {
+-      removeChildAt(index)
++    if (index >= 0) {
++      childrenViews.removeAt(index)
++      notifyItemRemoved(index)
+     }
    }
  
    fun removeAll() {
@@ -169,7 +184,7 @@ index fd3530e..a4ded6f 100644
      for (index in 1..childrenViews.size) {
        val child = childrenViews[index-1]
        if (child.parent?.parent != null) {
-@@ -64,6 +101,14 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
+@@ -64,6 +105,14 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
    }
  
    fun removeChildAt(index: Int) {

--- a/patches/react-native-pager-view+7.0.1.patch
+++ b/patches/react-native-pager-view+7.0.1.patch
@@ -81,10 +81,10 @@ index d5b82ff..adfb9a2 100644
      }
  
 diff --git a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
-index fd3530e..560ee03 100644
+index fd3530e..4db4e04 100644
 --- a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
 +++ b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
-@@ -1,14 +1,29 @@
+@@ -1,14 +1,30 @@
  package com.reactnativepagerview
  
 +import android.os.Handler
@@ -109,12 +109,13 @@ index fd3530e..560ee03 100644
 +
 +  override fun onDetachedFromRecyclerView(rv: RecyclerView) {
 +    super.onDetachedFromRecyclerView(rv)
++    handler.removeCallbacksAndMessages(null)
 +    recyclerView = null
 +  }
  
    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewPagerViewHolder {
      return ViewPagerViewHolder.create(parent)
-@@ -34,7 +49,16 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
+@@ -34,7 +50,16 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
      return childrenViews.size
    }
  
@@ -131,7 +132,7 @@ index fd3530e..560ee03 100644
      childrenViews.add(index, child)
      notifyItemInserted(index)
    }
-@@ -58,12 +82,20 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
+@@ -58,12 +83,20 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
          (child.parent.parent as ViewGroup).removeView(child.parent as View)
        }
      }
@@ -153,7 +154,7 @@ index fd3530e..560ee03 100644
        childrenViews.removeAt(index)
        notifyItemRemoved(index)
 diff --git a/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm b/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm
-index d52f532..3febffd 100644
+index d52f532..753dd8c 100644
 --- a/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm
 +++ b/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm
 @@ -29,6 +29,12 @@ @implementation RNCPagerViewComponentView {
@@ -302,7 +303,7 @@ index d52f532..3febffd 100644
          [self enableSwipe];
          return;
      }
-@@ -231,17 +314,37 @@ - (void)setPagerViewControllers:(NSInteger)index
+@@ -231,18 +314,41 @@ - (void)setPagerViewControllers:(NSInteger)index
      transitioning = YES;
  
      __weak RNCPagerViewComponentView *weakSelf = self;
@@ -320,31 +321,36 @@ index d52f532..3febffd 100644
 +            return;
 +        }
 +
-+        strongSelf->transitioning = NO;
-+
 +        // View was recycled and possibly reused since this animation started
 +        if (strongSelf->_isBeingRecycled || strongSelf->_generation != capturedGeneration) {
++            // Do NOT reset transitioning here — a new lifecycle owns that state
 +            return;
 +        }
 +
 +        // A newer transition was started, this completion is stale
 +        if (strongSelf->_transitionId != capturedTransitionId) {
++            // Do NOT reset transitioning — the newer transition owns that state
 +            return;
 +        }
 +
++        // Only reset transitioning when this completion corresponds to the current transition
++        strongSelf->transitioning = NO;
++
          [strongSelf enableSwipe];
++        strongSelf->_currentIndex = index;
          if (strongSelf->_eventEmitter != nullptr ) {
              const auto eventEmitter = [strongSelf pagerEventEmitter];
 -            int position = (int) index;
 -            eventEmitter->onPageSelected(RNCViewPagerEventEmitter::OnPageSelected{.position =  static_cast<double>(position)});
+-            strongSelf->_currentIndex = index;
 +            if (eventEmitter) {
 +                int position = (int) index;
 +                eventEmitter->onPageSelected(RNCViewPagerEventEmitter::OnPageSelected{.position =  static_cast<double>(position)});
 +            }
-             strongSelf->_currentIndex = index;
          }
          [strongSelf updateLayoutMetrics:strongSelf->_layoutMetrics oldLayoutMetrics:strongSelf->_oldLayoutMetrics];
-@@ -252,6 +355,11 @@ - (void)setPagerViewControllers:(NSInteger)index
+     }];
+@@ -252,6 +358,11 @@ - (void)setPagerViewControllers:(NSInteger)index
  - (UIViewController *)nextControllerForController:(UIViewController *)controller
                                        inDirection:(UIPageViewControllerNavigationDirection)direction {
      NSUInteger numberOfPages = _nativeChildrenViewControllers.count;
@@ -356,7 +362,7 @@ index d52f532..3febffd 100644
      NSInteger index = [_nativeChildrenViewControllers indexOfObject:controller];
      
      if (index == NSNotFound) {
-@@ -274,13 +382,22 @@ - (UIViewController *)currentlyDisplayed {
+@@ -274,13 +385,22 @@ - (UIViewController *)currentlyDisplayed {
  #pragma mark - UIScrollViewDelegate
  
  - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView {
@@ -379,7 +385,7 @@ index d52f532..3febffd 100644
      eventEmitter->onPageScrollStateChanged(RNCViewPagerEventEmitter::OnPageScrollStateChanged{.pageScrollState =  RNCViewPagerEventEmitter::OnPageScrollStateChangedPageScrollState::Settling });
      
      if (!_overdrag) {
-@@ -300,12 +417,21 @@ - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoi
+@@ -300,12 +420,21 @@ - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoi
  }
  
  - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
@@ -401,7 +407,7 @@ index d52f532..3febffd 100644
      BOOL isHorizontal = [self isHorizontal];
      CGFloat contentOffset = isHorizontal ? scrollView.contentOffset.x : scrollView.contentOffset.y;
      CGFloat frameSize = isHorizontal ? scrollView.frame.size.width : scrollView.frame.size.height;
-@@ -357,13 +483,18 @@ - (void)pageViewController:(UIPageViewController *)pageViewController
+@@ -357,13 +486,18 @@ - (void)pageViewController:(UIPageViewController *)pageViewController
          didFinishAnimating:(BOOL)finished
     previousViewControllers:(nonnull NSArray<UIViewController *> *)previousViewControllers
         transitionCompleted:(BOOL)completed {
@@ -421,7 +427,7 @@ index d52f532..3febffd 100644
      }
  }
  
-@@ -427,10 +558,12 @@ - (BOOL)isLtrLayout {
+@@ -427,10 +561,12 @@ - (BOOL)isLtrLayout {
  
  - (void)sendScrollEventsForPosition:(NSInteger)position offset:(CGFloat)offset {
      const auto eventEmitter = [self pagerEventEmitter];

--- a/patches/react-native-pager-view+7.0.1.patch
+++ b/patches/react-native-pager-view+7.0.1.patch
@@ -200,7 +200,7 @@ index fd3530e..8988ac3 100644
        childrenViews.removeAt(index)
        notifyItemRemoved(index)
 diff --git a/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm b/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm
-index d52f532..9421287 100644
+index d52f532..0eda5f7 100644
 --- a/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm
 +++ b/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm
 @@ -29,6 +29,14 @@ @implementation RNCPagerViewComponentView {
@@ -286,7 +286,7 @@ index d52f532..9421287 100644
  }
  
  - (void)shouldDismissKeyboard:(RNCViewPagerKeyboardDismissMode)dismissKeyboard {
-@@ -200,6 +236,14 @@ - (void)enableSwipe {
+@@ -200,12 +236,21 @@ - (void)enableSwipe {
  - (void)goTo:(NSInteger)index animated:(BOOL)animated {
      NSInteger numberOfPages = _nativeChildrenViewControllers.count;
      
@@ -301,7 +301,14 @@ index d52f532..9421287 100644
      [self disableSwipe];
      
      _destinationIndex = index;
-@@ -223,28 +267,105 @@ - (void)goTo:(NSInteger)index animated:(BOOL)animated {
+     
+     
+     if (numberOfPages == 0 || index < 0 || index > numberOfPages - 1) {
++        [self enableSwipe];
+         return;
+     }
+     
+@@ -223,28 +268,105 @@ - (void)goTo:(NSInteger)index animated:(BOOL)animated {
  - (void)setPagerViewControllers:(NSInteger)index
                        direction:(UIPageViewControllerNavigationDirection)direction
                         animated:(BOOL)animated{
@@ -311,10 +318,10 @@ index d52f532..9421287 100644
 +        NSLog(@"[PagerView] setPagerViewControllers blocked: pageVC=%@ recycled=%d index=%ld",
 +              _nativePageViewController ? @"EXISTS" : @"NIL", _isBeingRecycled, (long)index);
 +#endif
-+        [self enableSwipe];
-+        return;
-+    }
-+
+         [self enableSwipe];
+         return;
+     }
+ 
 +    // Validate index bounds
 +    if (index < 0 || index >= _nativeChildrenViewControllers.count) {
 +#ifdef DEBUG
@@ -351,10 +358,10 @@ index d52f532..9421287 100644
 +        NSLog(@"[PagerView] setPagerViewControllers deferred: already transitioning (index=%ld)", (long)index);
 +#endif
 +        _pendingGoToIndex = index;
-         [self enableSwipe];
-         return;
-     }
- 
++        [self enableSwipe];
++        return;
++    }
++
 +    // Clear any pending transition since we are now starting a fresh one
 +    _pendingGoToIndex = -1;
 +
@@ -413,7 +420,7 @@ index d52f532..9421287 100644
      }];
  }
  
-@@ -252,6 +373,11 @@ - (void)setPagerViewControllers:(NSInteger)index
+@@ -252,6 +374,11 @@ - (void)setPagerViewControllers:(NSInteger)index
  - (UIViewController *)nextControllerForController:(UIViewController *)controller
                                        inDirection:(UIPageViewControllerNavigationDirection)direction {
      NSUInteger numberOfPages = _nativeChildrenViewControllers.count;
@@ -425,7 +432,7 @@ index d52f532..9421287 100644
      NSInteger index = [_nativeChildrenViewControllers indexOfObject:controller];
      
      if (index == NSNotFound) {
-@@ -274,13 +400,22 @@ - (UIViewController *)currentlyDisplayed {
+@@ -274,13 +401,24 @@ - (UIViewController *)currentlyDisplayed {
  #pragma mark - UIScrollViewDelegate
  
  - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView {
@@ -440,7 +447,10 @@ index d52f532..9421287 100644
  }
  
  - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset {
-     
+-    
++    if (_isBeingRecycled) {
++        return;
++    }
      const auto eventEmitter = [self pagerEventEmitter];
 +    if (!eventEmitter) {
 +        return;
@@ -448,7 +458,7 @@ index d52f532..9421287 100644
      eventEmitter->onPageScrollStateChanged(RNCViewPagerEventEmitter::OnPageScrollStateChanged{.pageScrollState =  RNCViewPagerEventEmitter::OnPageScrollStateChangedPageScrollState::Settling });
      
      if (!_overdrag) {
-@@ -300,12 +435,21 @@ - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoi
+@@ -300,12 +438,21 @@ - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoi
  }
  
  - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
@@ -470,7 +480,7 @@ index d52f532..9421287 100644
      BOOL isHorizontal = [self isHorizontal];
      CGFloat contentOffset = isHorizontal ? scrollView.contentOffset.x : scrollView.contentOffset.y;
      CGFloat frameSize = isHorizontal ? scrollView.frame.size.width : scrollView.frame.size.height;
-@@ -357,13 +501,18 @@ - (void)pageViewController:(UIPageViewController *)pageViewController
+@@ -357,13 +504,18 @@ - (void)pageViewController:(UIPageViewController *)pageViewController
          didFinishAnimating:(BOOL)finished
     previousViewControllers:(nonnull NSArray<UIViewController *> *)previousViewControllers
         transitionCompleted:(BOOL)completed {
@@ -490,7 +500,7 @@ index d52f532..9421287 100644
      }
  }
  
-@@ -427,10 +576,12 @@ - (BOOL)isLtrLayout {
+@@ -427,10 +579,12 @@ - (BOOL)isLtrLayout {
  
  - (void)sendScrollEventsForPosition:(NSInteger)position offset:(CGFloat)offset {
      const auto eventEmitter = [self pagerEventEmitter];

--- a/patches/react-native-pager-view+7.0.1.patch
+++ b/patches/react-native-pager-view+7.0.1.patch
@@ -81,7 +81,7 @@ index d5b82ff..adfb9a2 100644
      }
  
 diff --git a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
-index fd3530e..91c2166 100644
+index fd3530e..560ee03 100644
 --- a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
 +++ b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
 @@ -1,14 +1,29 @@
@@ -114,56 +114,62 @@ index fd3530e..91c2166 100644
  
    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewPagerViewHolder {
      return ViewPagerViewHolder.create(parent)
-@@ -34,9 +49,18 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
+@@ -34,7 +49,16 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
      return childrenViews.size
    }
  
-+  private fun safeNotify(action: () -> Unit) {
++  private fun isComputingLayout(): Boolean {
 +    val rv = recyclerView
-+    if (rv != null && rv.isComputingLayout) {
-+      handler.post(action)
-+    } else {
-+      action()
-+    }
++    return rv != null && rv.isComputingLayout
 +  }
 +
    fun addChild(child: View, index: Int) {
++    if (isComputingLayout()) {
++      handler.post { addChild(child, index) }
++      return
++    }
      childrenViews.add(index, child)
--    notifyItemInserted(index)
-+    safeNotify { notifyItemInserted(index) }
+     notifyItemInserted(index)
    }
- 
-   fun getChildAt(index: Int): View {
-@@ -60,13 +84,13 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
+@@ -58,12 +82,20 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
+         (child.parent.parent as ViewGroup).removeView(child.parent as View)
+       }
      }
++    if (isComputingLayout()) {
++      handler.post { removeAll() }
++      return
++    }
      val removedChildrenCount = childrenViews.size
      childrenViews.clear()
--    notifyItemRangeRemoved(0, removedChildrenCount)
-+    safeNotify { notifyItemRangeRemoved(0, removedChildrenCount) }
+     notifyItemRangeRemoved(0, removedChildrenCount)
    }
  
    fun removeChildAt(index: Int) {
++    if (isComputingLayout()) {
++      handler.post { removeChildAt(index) }
++      return
++    }
      if (index >= 0 && index < childrenViews.size) {
        childrenViews.removeAt(index)
--      notifyItemRemoved(index)
-+      safeNotify { notifyItemRemoved(index) }
-     }
-   }
- }
+       notifyItemRemoved(index)
 diff --git a/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm b/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm
-index d52f532..5184f4d 100644
+index d52f532..3febffd 100644
 --- a/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm
 +++ b/node_modules/react-native-pager-view/ios/RNCPagerViewComponentView.mm
-@@ -29,6 +29,8 @@ @implementation RNCPagerViewComponentView {
+@@ -29,6 +29,12 @@ @implementation RNCPagerViewComponentView {
      BOOL _overdrag;
      NSString *_layoutDirection;
      BOOL _scrollEnabled;
++    // _isBeingRecycled: synchronous guard, only true during prepareForRecycle execution
 +    BOOL _isBeingRecycled;
++    // _generation: async guard for recycle-and-reuse, incremented in prepareForRecycle
 +    NSUInteger _generation;
++    // _transitionId: async guard for superseded transitions, incremented each setPagerViewControllers call
++    NSUInteger _transitionId;
  }
  
  // Needed because of this: https://github.com/facebook/react-native/pull/37274
-@@ -80,6 +82,7 @@ - (instancetype)initWithFrame:(CGRect)frame
+@@ -80,6 +86,7 @@ - (instancetype)initWithFrame:(CGRect)frame
          _layoutDirection = @"ltr";
          _overdrag = NO;
          _scrollEnabled = YES;
@@ -171,7 +177,7 @@ index d52f532..5184f4d 100644
      }
      
      return self;
-@@ -96,6 +99,9 @@ - (void)willMoveToSuperview:(UIView *)newSuperview {
+@@ -96,6 +103,9 @@ - (void)willMoveToSuperview:(UIView *)newSuperview {
  #pragma mark - React API
  
  - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index {
@@ -181,7 +187,7 @@ index d52f532..5184f4d 100644
      UIViewController *vc = [UIViewController new];
      [vc.view addSubview:childComponentView];
      [_nativeChildrenViewControllers insertObject:vc atIndex:index];
-@@ -103,13 +109,23 @@ - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childCompone
+@@ -103,13 +113,23 @@ - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childCompone
  }
  
  - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index {
@@ -206,7 +212,7 @@ index d52f532..5184f4d 100644
      }
  }
  
-@@ -127,10 +143,22 @@ -(void)updateLayoutMetrics:(const facebook::react::LayoutMetrics &)layoutMetrics
+@@ -127,10 +147,22 @@ -(void)updateLayoutMetrics:(const facebook::react::LayoutMetrics &)layoutMetrics
  
  
  -(void)prepareForRecycle {
@@ -229,7 +235,7 @@ index d52f532..5184f4d 100644
  }
  
  - (void)shouldDismissKeyboard:(RNCViewPagerKeyboardDismissMode)dismissKeyboard {
-@@ -200,6 +228,14 @@ - (void)enableSwipe {
+@@ -200,6 +232,14 @@ - (void)enableSwipe {
  - (void)goTo:(NSInteger)index animated:(BOOL)animated {
      NSInteger numberOfPages = _nativeChildrenViewControllers.count;
      
@@ -244,7 +250,7 @@ index d52f532..5184f4d 100644
      [self disableSwipe];
      
      _destinationIndex = index;
-@@ -223,7 +259,50 @@ - (void)goTo:(NSInteger)index animated:(BOOL)animated {
+@@ -223,7 +263,50 @@ - (void)goTo:(NSInteger)index animated:(BOOL)animated {
  - (void)setPagerViewControllers:(NSInteger)index
                        direction:(UIPageViewControllerNavigationDirection)direction
                         animated:(BOOL)animated{
@@ -296,12 +302,14 @@ index d52f532..5184f4d 100644
          [self enableSwipe];
          return;
      }
-@@ -231,17 +310,30 @@ - (void)setPagerViewControllers:(NSInteger)index
+@@ -231,17 +314,37 @@ - (void)setPagerViewControllers:(NSInteger)index
      transitioning = YES;
  
      __weak RNCPagerViewComponentView *weakSelf = self;
 -    [_nativePageViewController setViewControllers:@[[_nativeChildrenViewControllers objectAtIndex:index]]
 +    NSUInteger capturedGeneration = _generation;
++    _transitionId++;
++    NSUInteger capturedTransitionId = _transitionId;
 +    [_nativePageViewController setViewControllers:@[targetVC]
                                          direction:direction
                                           animated:animated
@@ -319,6 +327,11 @@ index d52f532..5184f4d 100644
 +            return;
 +        }
 +
++        // A newer transition was started, this completion is stale
++        if (strongSelf->_transitionId != capturedTransitionId) {
++            return;
++        }
++
          [strongSelf enableSwipe];
          if (strongSelf->_eventEmitter != nullptr ) {
              const auto eventEmitter = [strongSelf pagerEventEmitter];
@@ -331,7 +344,7 @@ index d52f532..5184f4d 100644
              strongSelf->_currentIndex = index;
          }
          [strongSelf updateLayoutMetrics:strongSelf->_layoutMetrics oldLayoutMetrics:strongSelf->_oldLayoutMetrics];
-@@ -252,6 +344,11 @@ - (void)setPagerViewControllers:(NSInteger)index
+@@ -252,6 +355,11 @@ - (void)setPagerViewControllers:(NSInteger)index
  - (UIViewController *)nextControllerForController:(UIViewController *)controller
                                        inDirection:(UIPageViewControllerNavigationDirection)direction {
      NSUInteger numberOfPages = _nativeChildrenViewControllers.count;
@@ -343,7 +356,7 @@ index d52f532..5184f4d 100644
      NSInteger index = [_nativeChildrenViewControllers indexOfObject:controller];
      
      if (index == NSNotFound) {
-@@ -274,13 +371,22 @@ - (UIViewController *)currentlyDisplayed {
+@@ -274,13 +382,22 @@ - (UIViewController *)currentlyDisplayed {
  #pragma mark - UIScrollViewDelegate
  
  - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView {
@@ -366,7 +379,7 @@ index d52f532..5184f4d 100644
      eventEmitter->onPageScrollStateChanged(RNCViewPagerEventEmitter::OnPageScrollStateChanged{.pageScrollState =  RNCViewPagerEventEmitter::OnPageScrollStateChangedPageScrollState::Settling });
      
      if (!_overdrag) {
-@@ -300,12 +406,21 @@ - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoi
+@@ -300,12 +417,21 @@ - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoi
  }
  
  - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
@@ -388,7 +401,7 @@ index d52f532..5184f4d 100644
      BOOL isHorizontal = [self isHorizontal];
      CGFloat contentOffset = isHorizontal ? scrollView.contentOffset.x : scrollView.contentOffset.y;
      CGFloat frameSize = isHorizontal ? scrollView.frame.size.width : scrollView.frame.size.height;
-@@ -357,13 +472,18 @@ - (void)pageViewController:(UIPageViewController *)pageViewController
+@@ -357,13 +483,18 @@ - (void)pageViewController:(UIPageViewController *)pageViewController
          didFinishAnimating:(BOOL)finished
     previousViewControllers:(nonnull NSArray<UIViewController *> *)previousViewControllers
         transitionCompleted:(BOOL)completed {
@@ -408,7 +421,7 @@ index d52f532..5184f4d 100644
      }
  }
  
-@@ -427,10 +547,12 @@ - (BOOL)isLtrLayout {
+@@ -427,10 +558,12 @@ - (BOOL)isLtrLayout {
  
  - (void)sendScrollEventsForPosition:(NSInteger)position offset:(CGFloat)offset {
      const auto eventEmitter = [self pagerEventEmitter];


### PR DESCRIPTION
## Summary
- Fix fatal `IllegalStateException` crash on Android when `ViewPagerAdapter.removeChildAt()` calls `notifyItemRemoved()` while ViewPager2's internal RecyclerView is computing layout
- Add `safeNotify()` helper that defers adapter notifications to the next frame when RecyclerView is busy, applied to `addChild`, `removeChildAt`, and `removeAll`
- Crash reproduced when users switch accounts in AccountSelector and navigate back to TabHome

## Root Cause
Fabric's mount item dispatcher can issue `removeViewAt` during the same choreographer frame callback where ViewPager2's RecyclerView is already computing layout. This triggers `RecyclerView.assertNotInLayoutOrScroll()` which throws `IllegalStateException`.

## Test plan
- [ ] Switch accounts on Android (open AccountSelector → select different account → return to TabHome)
- [ ] Rapidly switch between accounts multiple times
- [ ] Verify tab content renders correctly after account switch
- [ ] Verify no crashes in Sentry after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
