### PR TITLE
fix(borrow): ensure dashboard net worth/APY auto-refreshes on mobile

### DIFF
--- a/packages/kit/src/views/Borrow/components/BorrowDataGate.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowDataGate.tsx
@@ -141,6 +141,7 @@ export const BorrowDataGate = ({
       undefinedResultIfError: true,
       pollingInterval: isViewActive ? BORROW_POLLING_INTERVAL : undefined,
       revalidateOnFocus: true,
+      alwaysSetState: true,
     },
   );
 


### PR DESCRIPTION
## Context

Follow-up to #10077. The previous PR addressed Borrow Dashboard display issues on desktop (no-wallet warning visibility and `hasConnectedWallet` guard). During post-merge verification on mobile, a separate issue was discovered: **net worth and net APY values in the Borrow Dashboard do not auto-refresh on mobile after a repay (or supply/borrow/withdraw) transaction is confirmed on-chain.** The desktop version refreshes correctly; only mobile is affected.

## Issue Recording



https://github.com/user-attachments/assets/placeholder

_The recording shows the mobile Borrow Dashboard after a repay transaction. Net worth and net APY remain stale after the transaction is confirmed on-chain, requiring a manual refresh to update._

## Root Cause

The Borrow Dashboard's net worth and net APY values come from `reserves.data.overview` which is fetched inside `BorrowDataGate` via `usePromiseResult`. The `usePromiseResult` hook has a focus-gating mechanism:

```ts
// usePromiseResult.ts — shouldSetState()
const shouldSetState = (config?: IRunnerConfig) => {
  let flag = true;
  if (checkIsMounted && !isMountedRef.current) flag = false;
  if (checkIsFocused && !isFocusedRef.current) flag = false;   // ← gate
  if (alwaysSetState || config?.alwaysSetState) flag = true;    // ← override
  return flag;
};
```

When `shouldSetState()` returns `false`, the **entire runner body is skipped** — no fetch is made and no state is set.

The focus check uses `useRouteIsFocused`, which is stricter than React Navigation's `useIsFocused()`:

```ts
// useRouteIsFocused.ts
return (
  !isLocked &&
  isFocused &&
  rootRoutersLength >= getRootRoutersLength()  // modal/route-stack check
);
```

On mobile, several common scenarios cause `useRouteIsFocused` to return `false` while the user logically remains on the Borrow page:
- **Modal navigation** (repay/supply confirmation screens push root routes, causing `getRootRoutersLength()` to exceed the captured `rootRoutersLength`)
- **App lock screen** activation
- **Tab switching** during a pending transaction

When the pending-transaction monitor fires `refreshAllBorrowData()` after a repay is confirmed:

```
TX confirmed → useStakingPendingTxsByInfo (isPending: true→false)
  → 3s delay (BORROW_PENDING_REFRESH_DELAY)
  → handleBorrowPendingRefresh
  → refreshAllBorrowData()
  → refreshReservesWithForce()  // increments forceRefreshCounter
  → usePromiseResult.run()
  → shouldSetState() → false (mobile not "focused")
  → ❌ entire fetch skipped, stale data remains
```

**The inconsistency:** Two other Borrow Dashboard data sources — `useBorrowHealthFactor` and `useBorrowRewards` — already set `alwaysSetState: true` and refresh correctly on mobile. Only the reserves fetch (which provides net worth and net APY) was missing this flag:

| Data Source | `alwaysSetState` | Mobile Refresh |
|---|---|---|
| `useBorrowHealthFactor` (health factor) | `true` ✅ | Works |
| `useBorrowRewards` (claimable rewards) | `true` ✅ | Works |
| `BorrowDataGate` reserves (net worth, net APY) | **missing** ❌ | **Broken** |

## Fix

Add `alwaysSetState: true` to the reserves `usePromiseResult` options in `BorrowDataGate.tsx`, aligning with the existing pattern used by the other two hooks.

## Why This Works

The fix ensures that when `refreshReservesWithForce()` is called after a transaction, the fetch result is **always written to state**, regardless of the transient focus status reported by `useRouteIsFocused`.

The complete refresh path after the fix:

```
TX confirmed → useStakingPendingTxsByInfo (isPending: true→false)
  → 3s delay
  → refreshReservesWithForce()
  → forceRefreshCounterRef incremented
  → usePromiseResult.run()
  → shouldSetState() → true (alwaysSetState overrides focus check)     ✅ Gate 1 passed
  → BorrowDataGate callback:
      shouldForceRefresh = forceRefreshCounter > lastForceRefreshCounter → true
      → API fetch proceeds even if isViewActive is false               ✅ Gate 2 passed
  → setResult(newData)
  → BorrowContext.setReserves({ data: newData })
  → Overview re-renders with updated net worth / net APY               ✅
```

Both gates in the data path are now satisfied:
1. **`shouldSetState()`** — `alwaysSetState: true` bypasses the focus check
2. **BorrowDataGate internal guard** — `shouldForceRefresh` is `true` because `refreshReservesWithForce` incremented the force counter

This is safe because:
- Setting state on an unfocused (but mounted) component is a no-op in React 18+ if unmounted, and a valid update if merely hidden via `display: none` (which is how mobile toggles earn/borrow modes)
- The same pattern is already proven stable in `useBorrowHealthFactor` and `useBorrowRewards`

## Acceptance Criteria

After a repay transaction is confirmed on-chain, net worth and net APY auto-refresh without manual intervention — matching the existing desktop behavior and the behavior of health factor / claimable rewards on mobile.

## Files Changed

- `packages/kit/src/views/Borrow/components/BorrowDataGate.tsx` — add `alwaysSetState: true` to reserves `usePromiseResult` options