### PR TITLE
fix(borrow): refresh data when returning from swap/bridge modal

### DIFF
--- a/packages/kit/src/views/Borrow/components/BorrowDataGate.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowDataGate.tsx
@@ -5,6 +5,7 @@ import { useIsFocused } from '@react-navigation/core';
 import { isEmpty } from 'lodash';
 
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { useRouteIsFocused } from '@onekeyhq/kit/src/hooks/useRouteIsFocused';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import type { IBorrowReserveItem } from '@onekeyhq/shared/types/staking';
 
@@ -84,6 +85,17 @@ export const BorrowDataGate = ({
         : null,
     [market, marketProvider, marketAddress, accountId],
   );
+
+  // Reset staleness on modal dismiss so revalidateOnFocus triggers a fresh fetch.
+  // Must be declared BEFORE usePromiseResult so the effect fires first.
+  const isRouteFocused = useRouteIsFocused();
+  const prevRouteFocusedRef = useRef(isRouteFocused);
+  useEffect(() => {
+    if (isRouteFocused && !prevRouteFocusedRef.current) {
+      lastReservesUpdatedAtRef.current = null;
+    }
+    prevRouteFocusedRef.current = isRouteFocused;
+  }, [isRouteFocused]);
 
   const {
     result: reservesResult,

--- a/packages/kit/src/views/Staking/pages/ManagePosition/hooks/useManagePage.ts
+++ b/packages/kit/src/views/Staking/pages/ManagePosition/hooks/useManagePage.ts
@@ -116,7 +116,7 @@ export const useManagePage = ({
       reserveAddress,
       marketAddress,
     ],
-    { watchLoading: true },
+    { watchLoading: true, revalidateOnFocus: true },
   );
 
   const { managePageData, protocolList, earnAccount } = result || {};


### PR DESCRIPTION
## Summary

Fixes Borrow module data not refreshing when user returns from a swap/bridge modal (via the MORE button on Dashboard or swap/bridge buttons on supply/repay pages).

### Root Causes

**1. ManagePosition page (supply/repay):**
- `useManagePage` hook lacked `revalidateOnFocus: true`, so wallet balance and position data were never re-fetched on focus restoration.

**2. Dashboard reserves (SupplyCard walletBalance, net worth, APY):**
- `BorrowDataGate` uses a 1-minute staleness TTL (`BORROW_STALE_TTL`) that prevents data refresh when `revalidateOnFocus` triggers a re-fetch. Since tab screens never lose `useIsFocused` status during modal push, the staleness guard always returns cached data.

### Fixes

1. **`useManagePage.ts`**: Add `revalidateOnFocus: true` to `usePromiseResult` options.
2. **`BorrowDataGate.tsx`**: Add `useRouteIsFocused` (which detects modals via `rootRoutersLength`) to reset `lastReservesUpdatedAtRef` on modal dismiss. Declared before `usePromiseResult` to ensure the ref is cleared before `revalidateOnFocus` triggers the fetch.

### Key Design Decision

`useRouteIsFocused` is used alongside existing `useIsFocused` (not replacing it), specifically for staleness cache invalidation. The existing `useIsFocused` + `isActive` pattern continues to control view lifecycle. This minimizes blast radius.

## Test Plan

- [x] Open Borrow Dashboard → Supply card shows walletBalance
- [x] Click MORE → Swap → complete a swap → return to Dashboard → walletBalance updates
- [x] Click MORE → Bridge → complete a bridge → return to Dashboard → walletBalance updates
- [x] Open Supply page → note wallet balance → click Swap → complete swap → return → balance refreshes
- [x] Open Repay page → note wallet balance → click Bridge → complete bridge → return → balance refreshes
- [x] Switch tabs away from Borrow and back → data refreshes (acceptable extra API call)
- [x] Lock screen and unlock → data refreshes (acceptable extra API call)
- [x] Normal polling (1-minute interval) still works when staying on Dashboard