### PR TITLE
fix(perps): hide refresh rate-limit toast on native

### DIFF
--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -23,6 +23,7 @@ import { PERPS_FILTERED_LEDGER_TYPES } from '@onekeyhq/shared/src/consts/perp';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
 import { memoFn } from '@onekeyhq/shared/src/utils/cacheUtils';
@@ -1395,11 +1396,13 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       now - this.lastRefreshAllPerpsDataTime <
       timerUtils.getTimeDurationMs({ seconds: 15 })
     ) {
-      Toast.message({
-        title: appLocale.intl.formatMessage({
-          id: ETranslations.global_request_limit,
-        }),
-      });
+      if (!platformEnv.isNative) {
+        Toast.message({
+          title: appLocale.intl.formatMessage({
+            id: ETranslations.global_request_limit,
+          }),
+        });
+      }
       return;
     }
     const didRefresh =


### PR DESCRIPTION
## Summary
- keep perps refresh rate-limit logic unchanged (15s)
- remove rate-limit toast on native platforms via `!platformEnv.isNative`
- keep toast behavior unchanged on non-native platforms

## Scope
- iOS / Android: no toast when refresh is rate-limited
- Other platforms: still show rate-limit toast
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
