### PR TITLE
fix(token-details): add null check for tokensDetails data

### DIFF
--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
@@ -100,13 +100,14 @@ function TokenDetailsHeader(props: IProps) {
             networkId,
             contractList: [tokenInfo.address],
           });
-        updateTokenMetadata({
-          price: tokensDetails[0]?.price ?? 0,
-          priceChange24h: tokensDetails[0]?.price24h ?? 0,
-          coingeckoId: tokensDetails[0]?.info?.coingeckoId ?? '',
-        });
 
-        const data = tokensDetails[0];
+        const data = tokensDetails?.[0];
+
+        updateTokenMetadata({
+          price: data?.price ?? 0,
+          priceChange24h: data?.price24h ?? 0,
+          coingeckoId: data?.info?.coingeckoId ?? '',
+        });
 
         if (!data) {
           return undefined;


### PR DESCRIPTION
## Summary
- Add optional chaining on `tokensDetails` array access to prevent `TypeError: Cannot read properties of undefined (reading 'fiatValue')` when `fetchTokensDetails` returns undefined/null
- Extract `data` variable before `updateTokenMetadata` to avoid redundant array access

Fixes DESKTOP-MAS-YZ (10 users, 31 events, regressed)

## Test plan
- [ ] Open token details page with a token that has no details available
- [ ] Verify no crash occurs when tokensDetails API returns empty/null
- [ ] Verify token metadata updates correctly for valid tokens
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
