### PR TITLE
fix(desktop): add toMessageObject to BLE device events

### DIFF
--- a/patches/@onekeyfe+hd-transport-web-device+1.1.23.patch
+++ b/patches/@onekeyfe+hd-transport-web-device+1.1.23.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/@onekeyfe/hd-transport-web-device/dist/index.js b/node_modules/@onekeyfe/hd-transport-web-device/dist/index.js
+--- a/node_modules/@onekeyfe/hd-transport-web-device/dist/index.js
++++ b/node_modules/@onekeyfe/hd-transport-web-device/dist/index.js
+@@ -381,6 +381,7 @@
+                         (_a = this.emitter) === null || _a === void 0 ? void 0 : _a.emit('device-disconnect', {
+                             name: disconnectedDevice.name,
+                             id: disconnectedDevice.id,
+                             connectId: disconnectedDevice.id,
++                            toMessageObject: function () { return this; },
+                         });
+@@ -389,6 +390,7 @@
+                 (_b = this.emitter) === null || _b === void 0 ? void 0 : _b.emit('device-connect', {
+                     name: device.name,
+                     id: device.id,
+                     connectId: device.id,
++                    toMessageObject: function () { return this; },
+                 });


### PR DESCRIPTION
## Summary
- Patches `@onekeyfe/hd-transport-web-device` to add `toMessageObject()` method to device objects emitted on `device-disconnect` and `device-connect` events
- Fixes `TypeError: e.toMessageObject is not a function` crash on Desktop MAS (Sentry DESKTOP-MAS-19J)
- Root cause: BLE transport emits plain `{ name, id, connectId }` objects, but `hd-core`'s `onDeviceDisconnectHandler` calls `device.toMessageObject()` which doesn't exist on plain objects

## Test plan
- [ ] Verify Desktop MAS build succeeds with the patch applied
- [ ] Connect a hardware wallet via BLE on Desktop MAS, then disconnect it — confirm no crash
- [ ] Verify `device-disconnect` and `device-connect` events still work correctly
- [ ] Monitor Sentry DESKTOP-MAS-19J for regression after deployment
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
