### PR TITLE
fix(ios): resolve UIViewControllerHierarchyInconsistency crash

### DIFF
--- a/patches/react-native-screens+4.23.0.patch
+++ b/patches/react-native-screens+4.23.0.patch
@@ -1,0 +1,51 @@
+diff --git a/node_modules/react-native-screens/ios/RNSScreenStack.mm b/node_modules/react-native-screens/ios/RNSScreenStack.mm
+index 498b81d..f5a2c3e 100644
+--- a/node_modules/react-native-screens/ios/RNSScreenStack.mm
++++ b/node_modules/react-native-screens/ios/RNSScreenStack.mm
+@@ -407,7 +407,16 @@
+     UIView *parentView = (UIView *)self.reactSuperview;
+     while (parentView) {
+       if (parentView.reactViewController) {
+-        [parentView.reactViewController addChildViewController:controller];
++        UIViewController *candidateParent = parentView.reactViewController;
++        // Skip UIHostingController to avoid hierarchy inconsistency when used
++        // inside SwiftUI containers (e.g. react-native-bottom-tabs TabView).
++        // UIHostingController gets re-parented by SwiftUI during layout updates,
++        // which causes UIViewControllerHierarchyInconsistency crashes.
++        if ([NSStringFromClass([candidateParent class]) containsString:@"UIHostingController"]) {
++          parentView = (UIView *)parentView.reactSuperview;
++          continue;
++        }
++        [candidateParent addChildViewController:controller];
+         [self addSubview:controller.view];
+ #if !TARGET_OS_TV
+         _controller.interactivePopGestureRecognizer.delegate = self;
+@@ -417,7 +426,7 @@
+         }
+ #endif // Check for iOS >= 26.0
+ #endif
+-        [controller didMoveToParentViewController:parentView.reactViewController];
++        [controller didMoveToParentViewController:candidateParent];
+         // On iOS pre 12 we observed that `willShowViewController` delegate method does not always
+         // get triggered when the navigation controller is instantiated. As the only thing we do in
+         // that delegate method is ask nav header to update to the current state it does not hurt to
+@@ -868,13 +877,17 @@
+ {
+   // When transitioning between screens, disable interactions on stack subview which wraps the screens
+   // and sink all gesture events. This should work for nested stacks and stack inside bottom tabs, inside stack.
+-  self.subviews[0].userInteractionEnabled = NO;
++  if (self.subviews.count > 0) {
++    self.subviews[0].userInteractionEnabled = NO;
++  }
+   [self addGestureRecognizer:_sinkEventsPanGestureRecognizer];
+ }
+
+ - (void)rnscreens_enableInteractions
+ {
+-  self.subviews[0].userInteractionEnabled = YES;
++  if (self.subviews.count > 0) {
++    self.subviews[0].userInteractionEnabled = YES;
++  }
+   [self removeGestureRecognizer:_sinkEventsPanGestureRecognizer];
+ }
+


### PR DESCRIPTION
## Summary
- Fix iOS crash `UIViewControllerHierarchyInconsistency: child view controller (RNSNavigationController) has wrong parent UIHostingController` affecting 122 users (632 events, escalating)
- Root cause: `react-native-screens`'s `reactAddControllerToClosestParent:` traverses the responder chain and adds `RNSNavigationController` as a child of `UIHostingController` (from `react-native-bottom-tabs` SwiftUI TabView). SwiftUI re-parents `UIHostingController` during layout, causing the hierarchy inconsistency
- Fix: skip `UIHostingController` instances when searching for the closest parent view controller, continuing up the view hierarchy to find a stable parent instead

## Changes
- Updated `patches/react-native-screens+4.20.0.patch` to add two new hunks to `reactAddControllerToClosestParent:` in `RNSScreenStack.mm`:
  1. Check if the candidate parent is a `UIHostingController` (via `NSStringFromClass` string check) and skip it
  2. Use a local `candidateParent` variable instead of calling `parentView.reactViewController` twice

## Test plan
- [ ] Build and run the iOS app
- [ ] Navigate between tabs using bottom tab bar (SwiftUI TabView integration)
- [ ] Push/pop screens within tab stacks
- [ ] Verify no `UIViewControllerHierarchyInconsistency` crash in Sentry after deployment
- [ ] Verify navigation gestures (swipe back) still work correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
