### PR TITLE
fix(referral): remove duplicate loading on hardware sales reward page

### DIFF
--- a/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/index.tsx
@@ -6,7 +6,6 @@ import { useIntl } from 'react-intl';
 import {
   DatePicker,
   Page,
-  RefreshControl,
   ScrollView,
   Spinner,
   XStack,
@@ -307,9 +306,6 @@ function HardwareSalesRewardPageWrapper() {
           ) : (
             <ScrollView
               flex={1}
-              refreshControl={
-                <RefreshControl refreshing={isLoading} onRefresh={onRefresh} />
-              }
               contentContainerStyle={{ pb: '$5' }}
               onScroll={handleScroll}
               scrollEventThrottle={16}


### PR DESCRIPTION
## Summary
- Remove `RefreshControl` from HardwareSalesReward page `ScrollView`
- Fix double loading indicators during refresh (pull-to-refresh spinner + StatCard header refresh button both showing loading simultaneously)
- The StatCard header already provides a dedicated refresh button with loading state, making `RefreshControl` redundant

## Test plan
- [ ] Mobile: enter hardware sales reward page, confirm pull-down no longer triggers refresh animation
- [ ] Mobile: tap the refresh button in the StatCard header, confirm only one loading indicator shows
- [ ] Desktop: confirm page load and refresh behavior works normally
- [ ] Scroll to bottom to verify load-more pagination still works

Fixes OK-49446
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
