### PR TITLE
fix(desktop): guard timer callbacks against destroyed window

### DIFF
--- a/apps/desktop/app/app.ts
+++ b/apps/desktop/app/app.ts
@@ -412,14 +412,17 @@ function handleDeepLinkUrl(
 
       // Cold startup: cache the deep link for later processing
       if (!isAppReady) {
-        safelyMainWindow?.webContents.send(
+        safelyMainWindow.webContents.send(
           ipcMessageKeys.OPEN_DEEP_LINK_URL,
           eventData,
         );
       }
 
       // Hot startup: send directly to registered listener
-      mainWindow?.webContents.send(ipcMessageKeys.EVENT_OPEN_URL, eventData);
+      safelyMainWindow.webContents.send(
+        ipcMessageKeys.EVENT_OPEN_URL,
+        eventData,
+      );
     }
 
     isAppReady = true;
@@ -443,6 +446,11 @@ function systemIdleHandler(setIdleTime: number, event: Electron.IpcMainEvent) {
     return;
   }
   systemIdleInterval = setInterval(() => {
+    const sender = event.sender;
+    if (!sender || sender.isDestroyed()) {
+      clearInterval(systemIdleInterval);
+      return;
+    }
     const idleTime = powerMonitor.getSystemIdleTime();
     const systemState = powerMonitor.getSystemIdleState(setIdleTime);
     if (idleTime > setIdleTime || systemState === 'locked') {
@@ -653,7 +661,10 @@ async function createMainWindow() {
   });
 
   browserWindow.on('resize', () => {
-    store.setWinBounds(browserWindow.getBounds());
+    const safelyWindow = getSafelyBrowserWindow();
+    if (safelyWindow) {
+      store.setWinBounds(safelyWindow.getBounds());
+    }
   });
   browserWindow.on('closed', () => {
     mainWindow = null;
@@ -662,9 +673,11 @@ async function createMainWindow() {
   });
 
   browserWindow.webContents.on('devtools-opened', () => {
-    browserWindow.focus();
+    const safelyWindow = getSafelyBrowserWindow();
+    safelyWindow?.focus();
     setImmediate(() => {
-      browserWindow.focus();
+      const w = getSafelyBrowserWindow();
+      w?.focus();
     });
   });
 
@@ -1091,6 +1104,9 @@ app.on('activate', async () => {
 });
 
 app.on('before-quit', () => {
+  if (systemIdleInterval) {
+    clearInterval(systemIdleInterval);
+  }
   const safelyMainWindow = getSafelyMainWindow();
   if (safelyMainWindow) {
     safelyMainWindow.removeAllListeners();

--- a/apps/desktop/app/windowProgressBar.ts
+++ b/apps/desktop/app/windowProgressBar.ts
@@ -1,7 +1,7 @@
 import type { BrowserWindow } from 'electron';
 
 const checkWindowProgressBar = (window: BrowserWindow | undefined) => {
-  if (!window || window.setProgressBar === undefined) {
+  if (!window || window.isDestroyed() || window.setProgressBar === undefined) {
     return false;
   }
   return true;


### PR DESCRIPTION
## Summary
- Adds `isDestroyed()` checks before accessing BrowserWindow/webContents in timer callbacks
- Guards `systemIdleInterval` against destroyed sender webContents to prevent `event.reply()` on destroyed objects
- Uses `getSafelyBrowserWindow()` in resize and devtools-opened event handlers instead of direct `browserWindow` references
- Adds `isDestroyed()` check in `windowProgressBar` before calling `setProgressBar()`
- Ensures `safelyMainWindow` is used consistently in deep link `sendEventData()` instead of raw `mainWindow`
- Clears `systemIdleInterval` in the `before-quit` handler to prevent stale timer callbacks

Fixes DESKTOP-1Q6

## Test plan
- [ ] Verify desktop app starts and runs normally
- [ ] Close and re-open window (macOS dock click) — no crash
- [ ] Quit app during active operations — no crash
- [ ] Set system idle timeout, close window before idle fires — no crash
- [ ] Open/close devtools rapidly — no crash
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
