### PR TITLE
fix(android): guard against null socket in TcpReceiverTask

### DIFF
--- a/patches/react-native-tcp-socket+6.3.0.patch
+++ b/patches/react-native-tcp-socket+6.3.0.patch
@@ -1,0 +1,23 @@
+diff --git a/node_modules/react-native-tcp-socket/android/src/main/java/com/asterinet/react/tcpsocket/TcpSocketClient.java b/node_modules/react-native-tcp-socket/android/src/main/java/com/asterinet/react/tcpsocket/TcpSocketClient.java
+index 6ef8269..d2fcd1b 100644
+--- a/node_modules/react-native-tcp-socket/android/src/main/java/com/asterinet/react/tcpsocket/TcpSocketClient.java
++++ b/node_modules/react-native-tcp-socket/android/src/main/java/com/asterinet/react/tcpsocket/TcpSocketClient.java
+@@ -246,6 +246,9 @@ class TcpSocketClient extends TcpSocket {
+         public void run() {
+             int socketId = clientSocket.getId();
+             Socket socket = clientSocket.getSocket();
++            if (socket == null) {
++                return;
++            }
+             byte[] buffer = new byte[16384];
+             try {
+                 BufferedInputStream in = new BufferedInputStream(socket.getInputStream());
+@@ -259,7 +262,7 @@ class TcpSocketClient extends TcpSocket {
+                     }
+                 }
+             } catch (IOException | InterruptedException ioe) {
+-                if (receiverListener != null && !socket.isClosed() && !clientSocket.closed) {
++                if (receiverListener != null && socket != null && !socket.isClosed() && !clientSocket.closed) {
+                     receiverListener.onError(socketId, ioe);
+                 }
+             }


### PR DESCRIPTION
## Summary
- Patches `react-native-tcp-socket` to add null checks before accessing `socket.getInputStream()` in `TcpReceiverTask.run()`
- Prevents `NullPointerException` crash when socket connection is closed/destroyed before receiver task runs
- Also guards the catch block against null socket when calling `socket.isClosed()`

Fixes REACT-NATIVE-3FM

## Test plan
- [ ] Verify Network Doctor feature works on Android
- [ ] Verify TCP socket connections work normally
- [ ] Verify no crash when socket is closed during active read
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
