### PR TITLE
fix(referral): increase responsive breakpoints for referral page layouts(OK-50009)

### DIFF
--- a/packages/kit/src/views/ReferFriends/components/RewardHeaderLayout.tsx
+++ b/packages/kit/src/views/ReferFriends/components/RewardHeaderLayout.tsx
@@ -62,7 +62,7 @@ export function ResponsiveThreeColumnLayout({
       px={px}
       flexDirection="row"
       alignItems="stretch"
-      $md={{
+      $lg={{
         flexDirection: 'column',
       }}
     >
@@ -70,7 +70,7 @@ export function ResponsiveThreeColumnLayout({
         flexGrow={1}
         flexShrink={1}
         flexBasis={0}
-        $md={{
+        $lg={{
           flexGrow: 0,
           flexShrink: 1,
           flexBasis: 'auto',
@@ -83,7 +83,7 @@ export function ResponsiveThreeColumnLayout({
         flexGrow={1}
         flexShrink={1}
         flexBasis={0}
-        $md={{
+        $lg={{
           flexGrow: 0,
           flexShrink: 1,
           flexBasis: 'auto',
@@ -96,7 +96,7 @@ export function ResponsiveThreeColumnLayout({
         flexGrow={1}
         flexShrink={1}
         flexBasis={0}
-        $md={{
+        $lg={{
           flexGrow: 0,
           flexShrink: 1,
           flexBasis: 'auto',

--- a/packages/kit/src/views/ReferFriends/components/StatCard.tsx
+++ b/packages/kit/src/views/ReferFriends/components/StatCard.tsx
@@ -8,6 +8,7 @@ import {
   Stack,
   XStack,
   YStack,
+  useMedia,
 } from '@onekeyhq/components';
 import type { ColorTokens } from '@onekeyhq/components/src/shared/tamagui';
 import { Currency } from '@onekeyhq/kit/src/components/Currency';
@@ -45,9 +46,15 @@ export function StatCard({
   fullWidth,
   valueColor = '$text',
 }: IStatCardProps) {
+  const { xl } = useMedia();
+  const isMediumScreen = isWide && xl;
+
   const getValueSize = () => {
     if (fullWidth) {
       return '$heading4xl';
+    }
+    if (isMediumScreen) {
+      return '$heading3xl';
     }
     return isWide ? '$heading5xl' : '$headingXl';
   };

--- a/packages/kit/src/views/ReferFriends/pages/PerpsReward/components/PerpsRecordTable.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/PerpsReward/components/PerpsRecordTable.tsx
@@ -356,7 +356,7 @@ export function PerpsRecordTable({
   hasUserSorted,
 }: IPerpsRecordTableProps) {
   const media = useMedia();
-  const isCompact = media.lg;
+  const isCompact = media.xl;
   const { columnWidths } = usePerpsTableColumns(isCompact);
   const themeVariant = useThemeVariant();
   const isDark = themeVariant === 'dark';


### PR DESCRIPTION
## Summary

- Increase three-column layout breakpoint from `$md` (768px) to `$lg` (1024px) so reward cards stack vertically earlier
- Add medium screen font size for StatCard values: `$heading3xl` (28px) for 768-1279px range, preventing large numbers from overflowing
- Increase Perps record table compact mode breakpoint from `$lg` (1024px) to `$xl` (1280px) so table enters horizontal-scroll mode earlier

## Test plan

- [ ] Verify three-column reward cards stack vertically when window width < 1024px
- [ ] Verify StatCard numbers use smaller font at medium screen widths (768-1279px)
- [ ] Verify Perps detail table enters compact scroll mode when window width < 1280px
- [ ] Verify layouts still look correct on full-width desktop screens
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
