### PR TITLE
fix(perp): guard against missing providerInfo in cross-chain deposit(OK-49575)

### DIFF
--- a/packages/kit-bg/src/vaults/base/VaultBase.ts
+++ b/packages/kit-bg/src/vaults/base/VaultBase.ts
@@ -1010,7 +1010,7 @@ export abstract class VaultBase extends VaultBaseChainOnly {
     const { swapData, swapInfo, swapToAddress } = params;
     const swapSendToken = swapInfo.sender.token;
     const swapReceiveToken = swapInfo.receiver.token;
-    const providerInfo = swapInfo.swapBuildResData.result.info;
+    const providerInfo = swapInfo.swapBuildResData.result?.info;
     const otherFeeInfos = swapInfo.swapBuildResData.result.fee?.otherFeeInfos;
     const otherFeeInfoTransfers: IDecodedTxTransferInfo[] = [];
 
@@ -1070,10 +1070,12 @@ export abstract class VaultBase extends VaultBaseChainOnly {
       from: swapInfo.accountAddress,
       to: swapToAddress ?? '',
       data: swapData,
-      application: {
-        name: providerInfo.providerName,
-        icon: providerInfo.providerLogo ?? '',
-      },
+      application: providerInfo
+        ? {
+            name: providerInfo.providerName,
+            icon: providerInfo.providerLogo ?? '',
+          }
+        : undefined,
       isInternalSwap: true,
       swapReceivedAddress: swapInfo.receivingAddress,
       swapReceivedNetworkId: swapInfo.receiver.token.networkId,

--- a/packages/kit-bg/src/vaults/base/VaultBase.ts
+++ b/packages/kit-bg/src/vaults/base/VaultBase.ts
@@ -1011,7 +1011,7 @@ export abstract class VaultBase extends VaultBaseChainOnly {
     const swapSendToken = swapInfo.sender.token;
     const swapReceiveToken = swapInfo.receiver.token;
     const providerInfo = swapInfo.swapBuildResData.result?.info;
-    const otherFeeInfos = swapInfo.swapBuildResData.result.fee?.otherFeeInfos;
+    const otherFeeInfos = swapInfo.swapBuildResData.result?.fee?.otherFeeInfos;
     const otherFeeInfoTransfers: IDecodedTxTransferInfo[] = [];
 
     let transfers: IDecodedTxTransferInfo[] = [

--- a/packages/kit/src/views/Perp/hooks/usePerpDeposit.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpDeposit.ts
@@ -344,6 +344,8 @@ const usePerpDeposit = (
           swapBuildResData: {
             result: {
               ...buildSwapRes.result,
+              // Fallback to outer info when inner result.info is missing
+              info: buildSwapRes.result.info ?? buildSwapRes.info,
             },
           },
         };


### PR DESCRIPTION
## Summary

- Fix crash when `result.info` is undefined in swap API response during Perps cross-chain deposit (e.g. Solana USDC)
- Add `info` fallback in `usePerpDeposit`: use outer `buildSwapRes.info` when inner `result.info` is missing
- Add optional chaining and conditional `application` in `VaultBase.buildInternalSwapAction` to prevent `providerName` access crash

**Root cause:** Certain provider/route combinations return `result.info` as undefined. `VaultBase:1013` crashes on `result.info.providerName`, the error is silently swallowed by `buildPerpDepositTx` catch block, and `handlePerpDepositTxSuccess` never executes — resulting in no Pending state and no success toast despite the transaction succeeding on-chain.

## Test plan

- [ ] Perps cross-chain deposit (Solana USDC): transaction shows Pending state and success toast
- [ ] Regular swap flow: no regression, provider info displays normally
- [ ] Signature confirmation page: renders correctly when provider info is missing
- [ ] `yarn tsc:staged` passes with no new errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
