### PR TITLE
fix: add null check in getAllNetworkAccountsValue to prevent TypeError

### DIFF
--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
@@ -24,11 +24,12 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
 
   async getAccountsValue({ accounts }: { accounts: { accountId: string }[] }) {
     const rawData = await this.getRawData();
+    const data = rawData?.data;
 
     return accounts.map(({ accountId }) => ({
       accountId,
-      value: rawData?.data[accountId]?.value,
-      currency: rawData?.data[accountId]?.currency,
+      value: data?.[accountId]?.value,
+      currency: data?.[accountId]?.currency,
     }));
   }
 
@@ -91,11 +92,12 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
     accounts: { accountId: string }[];
   }) {
     const rawData = await this.getRawData();
+    const all = rawData?.all;
 
     return accounts.map(({ accountId }) => ({
       accountId,
-      value: rawData?.all[accountId]?.value,
-      currency: rawData?.all[accountId]?.currency,
+      value: all?.[accountId]?.value,
+      currency: all?.[accountId]?.currency,
     }));
   }
 }

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityLocalHistory.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityLocalHistory.ts
@@ -155,8 +155,8 @@ export class SimpleDbEntityLocalHistory extends SimpleDbEntityBase<ILocalHistory
     const now = Date.now();
     const rawData = await this.getRawData();
 
-    let finalPendingTxs = rawData?.pendingTxs[key] ?? [];
-    let finalConfirmedTxs = rawData?.confirmedTxs[key] ?? [];
+    let finalPendingTxs = rawData?.pendingTxs?.[key] ?? [];
+    let finalConfirmedTxs = rawData?.confirmedTxs?.[key] ?? [];
 
     if (pendingTxs) {
       finalPendingTxs = uniqBy(
@@ -446,7 +446,7 @@ export class SimpleDbEntityLocalHistory extends SimpleDbEntityBase<ILocalHistory
 
     const key = buildAccountLocalAssetsKey({ networkId, accountAddress, xpub });
 
-    let accountPendingTxs = (await this.getRawData())?.pendingTxs[key] ?? [];
+    let accountPendingTxs = (await this.getRawData())?.pendingTxs?.[key] ?? [];
 
     accountPendingTxs = this._arrangeLocalTxs({
       txs: accountPendingTxs,
@@ -472,7 +472,7 @@ export class SimpleDbEntityLocalHistory extends SimpleDbEntityBase<ILocalHistory
     const key = buildAccountLocalAssetsKey({ networkId, accountAddress, xpub });
 
     let accountConfirmedTxs =
-      (await this.getRawData())?.confirmedTxs[key] || [];
+      (await this.getRawData())?.confirmedTxs?.[key] || [];
 
     accountConfirmedTxs = this._arrangeLocalTxs({
       txs: accountConfirmedTxs,


### PR DESCRIPTION
## Summary
- Fixes Sentry issue REACT-NATIVE-PR (`TypeError: Cannot convert undefined value to object`) with 4,801 events
- The `getAllNetworkAccountsValue` and `getAccountsValue` functions in `SimpleDbEntityAccountValue` accessed `rawData.all[accountId]` and `rawData.data[accountId]` without guarding against `rawData.all` or `rawData.data` being `undefined`. When `rawData` exists but its `all`/`data` properties are `undefined`, this causes a TypeError.
- Fixed by extracting the sub-objects with optional chaining (`rawData?.all`, `rawData?.data`) and then using optional chaining on the bracket access (`all?.[accountId]`, `data?.[accountId]`)

## Test plan
- [ ] Verify the fix compiles without TypeScript errors
- [ ] Confirm that account value queries still return correct data when `rawData.all` and `rawData.data` are populated
- [ ] Confirm that account value queries return `undefined` values gracefully when db has no stored data
- [ ] Test on iOS (primary affected platform per Sentry) that chain selector and account views load without crashes

Fixes REACT-NATIVE-PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
