### PR TITLE
fix(android): add null check in setTopActivity to prevent NullPointerException

### DIFF
--- a/patches/@onekeyfe+react-native-lite-card+1.1.18.patch
+++ b/patches/@onekeyfe+react-native-lite-card+1.1.18.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@onekeyfe/react-native-lite-card/android/src/main/java/com/onekeyfe/reactnativelitecard/utils/Utils.java b/node_modules/@onekeyfe/react-native-lite-card/android/src/main/java/com/onekeyfe/reactnativelitecard/utils/Utils.java
-index 6de5732..9fafb1d 100755
+index 6de5732..38c9a72 100755
 --- a/node_modules/@onekeyfe/react-native-lite-card/android/src/main/java/com/onekeyfe/reactnativelitecard/utils/Utils.java
 +++ b/node_modules/@onekeyfe/react-native-lite-card/android/src/main/java/com/onekeyfe/reactnativelitecard/utils/Utils.java
 @@ -324,7 +324,9 @@ public final class Utils {
@@ -13,7 +13,7 @@ index 6de5732..9fafb1d 100755
          }
  
          private void postStatus(final boolean isForeground) {
-@@ -348,14 +350,15 @@ public final class Utils {
+@@ -348,14 +350,19 @@ public final class Utils {
              if (activity == null || mActivityList == null) {
                  return;
              }
@@ -21,17 +21,22 @@ index 6de5732..9fafb1d 100755
 -                Activity lastActivity = mActivityList.getLast();
 -                if (lastActivity != null && !lastActivity.equals(activity)) {
 -                    mActivityList.remove(activity);
-+            synchronized (mActivityList) {
-+                if (mActivityList.contains(activity)) {
-+                    if (!mActivityList.isEmpty() && !activity.equals(mActivityList.getLast())) {
-+                        mActivityList.remove(activity);
+-                    mActivityList.addLast(activity);
++            try {
++                synchronized (mActivityList) {
++                    if (mActivityList.contains(activity)) {
++                        if (!mActivityList.isEmpty() && !activity.equals(mActivityList.getLast())) {
++                            mActivityList.remove(activity);
++                            mActivityList.addLast(activity);
++                        }
++                    } else {
 +                        mActivityList.addLast(activity);
 +                    }
-+                } else {
-                     mActivityList.addLast(activity);
                  }
 -            } else {
 -                mActivityList.addLast(activity);
++            } catch (Exception e) {
++                android.util.Log.w("OneKey", "setTopActivity error: " + e.getMessage());
              }
          }
  

--- a/patches/@onekeyfe+react-native-lite-card+1.1.18.patch
+++ b/patches/@onekeyfe+react-native-lite-card+1.1.18.patch
@@ -1,0 +1,37 @@
+diff --git a/node_modules/@onekeyfe/react-native-lite-card/android/src/main/java/com/onekeyfe/reactnativelitecard/utils/Utils.java b/node_modules/@onekeyfe/react-native-lite-card/android/src/main/java/com/onekeyfe/reactnativelitecard/utils/Utils.java
+index 6de5732..9fafb1d 100755
+--- a/node_modules/@onekeyfe/react-native-lite-card/android/src/main/java/com/onekeyfe/reactnativelitecard/utils/Utils.java
++++ b/node_modules/@onekeyfe/react-native-lite-card/android/src/main/java/com/onekeyfe/reactnativelitecard/utils/Utils.java
+@@ -324,7 +324,9 @@ public final class Utils {
+ 
+         @Override
+         public void onActivityDestroyed(Activity activity) {
+-            mActivityList.remove(activity);
++            synchronized (mActivityList) {
++                mActivityList.remove(activity);
++            }
+         }
+ 
+         private void postStatus(final boolean isForeground) {
+@@ -348,14 +350,15 @@ public final class Utils {
+             if (activity == null || mActivityList == null) {
+                 return;
+             }
+-            if (mActivityList.contains(activity)) {
+-                Activity lastActivity = mActivityList.getLast();
+-                if (lastActivity != null && !lastActivity.equals(activity)) {
+-                    mActivityList.remove(activity);
++            synchronized (mActivityList) {
++                if (mActivityList.contains(activity)) {
++                    if (!mActivityList.isEmpty() && !activity.equals(mActivityList.getLast())) {
++                        mActivityList.remove(activity);
++                        mActivityList.addLast(activity);
++                    }
++                } else {
+                     mActivityList.addLast(activity);
+                 }
+-            } else {
+-                mActivityList.addLast(activity);
+             }
+         }
+ 


### PR DESCRIPTION
## Summary
- Fixes Sentry issue [REACT-NATIVE-1XS](https://onekey-bb.sentry.io/issues/REACT-NATIVE-1XS) (2,021 events, 53 users affected)
- Adds a patch for `@onekeyfe/react-native-lite-card` to fix a `NullPointerException` in `Utils$ActivityLifecycleImpl.setTopActivity`
- Root cause: race condition between `setTopActivity` and `onActivityDestroyed` where `mActivityList.getLast()` could return null or throw `NoSuchElementException` when the list is concurrently emptied

## Changes
- Added `!mActivityList.isEmpty()` guard before calling `getLast()` to prevent `NoSuchElementException` when the list is emptied by a concurrent `onActivityDestroyed` callback
- Reversed the `equals()` call direction: `activity.equals(mActivityList.getLast())` instead of `mActivityList.getLast().equals(activity)` since `activity` is guaranteed non-null
- Wrapped the method body in a try-catch to guard against any remaining concurrent modification edge cases on the unsynchronized `LinkedList`

## Test plan
- [ ] Verify the patch applies cleanly during `yarn install` (patch-package postinstall)
- [ ] Build and run the Android app to confirm no regressions
- [ ] Monitor Sentry for issue REACT-NATIVE-1XS to confirm the crash is resolved after deployment