### PR TITLE
feat(referral): enhance date picker with year navigation, presets sidebar, and month display fix(OK-50022)

### DIFF
--- a/packages/components/src/composite/DatePicker/Calendar.tsx
+++ b/packages/components/src/composite/DatePicker/Calendar.tsx
@@ -19,6 +19,7 @@ interface ICalendarProps {
   onMonthSelect?: (date: Date) => void;
   minDate?: Date;
   maxDate?: Date;
+  showPreviousMonth?: boolean;
 }
 
 export const Calendar = memo(
@@ -28,6 +29,7 @@ export const Calendar = memo(
     onMonthSelect,
     minDate,
     maxDate,
+    showPreviousMonth,
   }: ICalendarProps) => {
     const { data, propGetters } = useDatePickerContext();
     const { calendars } = data;
@@ -64,17 +66,23 @@ export const Calendar = memo(
     const panelProps = { mode, onYearSelect, onMonthSelect, minDate, maxDate };
 
     if (isDualPanelRange) {
+      // When showPreviousMonth is true, offsets=[-1] generates:
+      //   calendars[0]=current month, calendars[1]=previous month
+      // Swap panel order so left=previous month, right=current month
+      const leftIndex = showPreviousMonth ? 1 : 0;
+      const rightIndex = showPreviousMonth ? 0 : 1;
+
       return (
         <Stack flexDirection="row" gap="$6">
           <CalendarPanel
-            calendarIndex={0}
+            calendarIndex={leftIndex}
             showNav="prev"
             isDualPanel
             {...panelProps}
           />
           <Stack width={1} bg="$neutral3" alignSelf="stretch" />
           <CalendarPanel
-            calendarIndex={1}
+            calendarIndex={rightIndex}
             showNav="next"
             isDualPanel
             {...panelProps}

--- a/packages/components/src/composite/DatePicker/CalendarHeader.tsx
+++ b/packages/components/src/composite/DatePicker/CalendarHeader.tsx
@@ -7,7 +7,7 @@ import { IconButton } from '../../actions/IconButton';
 import type { ICalendarHeaderProps } from './type';
 
 function NavSpacer() {
-  return <Stack width="$10" height="$4" />;
+  return <Stack width="$10" height="$6" />;
 }
 
 export const CalendarHeader = memo(

--- a/packages/components/src/composite/DatePicker/CalendarHeader.tsx
+++ b/packages/components/src/composite/DatePicker/CalendarHeader.tsx
@@ -1,10 +1,14 @@
 import { memo } from 'react';
 
-import { IconButton } from '../../actions/IconButton';
 import { useMedia } from '../../hooks';
 import { SizableText, Stack, XStack } from '../../primitives';
+import { IconButton } from '../../actions/IconButton';
 
 import type { ICalendarHeaderProps } from './type';
+
+function NavSpacer() {
+  return <Stack width="$10" height="$4" />;
+}
 
 export const CalendarHeader = memo(
   ({
@@ -12,11 +16,15 @@ export const CalendarHeader = memo(
     year,
     onPrevMonth,
     onNextMonth,
+    onPrevYear,
+    onNextYear,
     onMonthClick,
     onYearClick,
     mode,
     isPrevDisabled,
     isNextDisabled,
+    isPrevYearDisabled,
+    isNextYearDisabled,
   }: ICalendarHeaderProps) => {
     const media = useMedia();
     const iconSize = 'medium' as const;
@@ -25,61 +33,97 @@ export const CalendarHeader = memo(
 
     const showPrevButton = onPrevMonth && !isPrevDisabled;
     const showNextButton = onNextMonth && !isNextDisabled;
+    const showPrevYearButton = onPrevYear && !isPrevYearDisabled;
+    const showNextYearButton = onNextYear && !isNextYearDisabled;
     const yearClickable = showMonthYear && onYearClick;
 
     return (
-      <XStack
-        justifyContent="space-between"
-        alignItems="center"
-        paddingHorizontal="$2"
-        marginBottom="$3"
-        $md={{ marginTop: '$2' }}
-      >
-        {showPrevButton ? (
-          <IconButton
-            icon="ChevronLeftSmallOutline"
-            variant="tertiary"
-            size={iconSize}
-            onPress={onPrevMonth}
-          />
-        ) : (
-          <Stack width="$10" />
-        )}
-        <XStack gap="$1">
-          {showMonthYear && month ? (
+      <Stack paddingHorizontal="$2" marginBottom="$3" $md={{ marginTop: '$2' }}>
+        {/* Title - absolute center */}
+        <XStack
+          position="absolute"
+          top={0}
+          left={0}
+          right={0}
+          bottom={0}
+          justifyContent="center"
+          alignItems="center"
+          pointerEvents="none"
+          gap="$1"
+        >
+          {showMonthYear && month && (
             <SizableText
               size={titleSize}
               color="$text"
               cursor="default"
               userSelect="none"
+              pointerEvents="auto"
               onPress={onMonthClick}
               hoverStyle={onMonthClick ? { color: '$textSubdued' } : undefined}
             >
               {month}
             </SizableText>
-          ) : null}
+          )}
           <SizableText
             size={titleSize}
             color="$text"
             cursor="default"
             userSelect="none"
+            pointerEvents="auto"
             onPress={yearClickable ? onYearClick : undefined}
             hoverStyle={yearClickable ? { color: '$textSubdued' } : undefined}
           >
             {year}
           </SizableText>
         </XStack>
-        {showNextButton ? (
-          <IconButton
-            icon="ChevronRightSmallOutline"
-            variant="tertiary"
-            size={iconSize}
-            onPress={onNextMonth}
-          />
-        ) : (
-          <Stack width="$10" />
-        )}
-      </XStack>
+        {/* Buttons */}
+        <XStack justifyContent="space-between" alignItems="center">
+          <XStack alignItems="center">
+            {showPrevYearButton ? (
+              <IconButton
+                icon="ChevronDoubleLeftOutline"
+                variant="tertiary"
+                size={iconSize}
+                onPress={onPrevYear}
+              />
+            ) : (
+              <NavSpacer />
+            )}
+            {showPrevButton ? (
+              <IconButton
+                icon="ChevronLeftSmallOutline"
+                variant="tertiary"
+                size={iconSize}
+                onPress={onPrevMonth}
+              />
+            ) : (
+              <NavSpacer />
+            )}
+          </XStack>
+          <XStack alignItems="center">
+            {showNextButton ? (
+              <IconButton
+                icon="ChevronRightSmallOutline"
+                variant="tertiary"
+                size={iconSize}
+                onPress={onNextMonth}
+              />
+            ) : (
+              <NavSpacer />
+            )}
+            {showNextYearButton ? (
+              <IconButton
+                icon="ChevronDoubleRightOutline"
+                variant="tertiary"
+                size={iconSize}
+                onPress={onNextYear}
+              />
+            ) : (
+              <NavSpacer />
+            )}
+          </XStack>
+        </XStack>
+      </Stack>
     );
   },
 );

--- a/packages/components/src/composite/DatePicker/CalendarPanel.tsx
+++ b/packages/components/src/composite/DatePicker/CalendarPanel.tsx
@@ -1,18 +1,16 @@
-import { useCallback, useMemo, useState } from 'react';
-
 import { useDatePickerContext } from '@rehookify/datepicker';
+import { useCallback, useMemo, useState } from 'react';
 
 import { YStack } from '../../primitives';
 
 import { CalendarHeader } from './CalendarHeader';
 import { DayGrid } from './DayGrid';
 import { MonthGrid } from './MonthGrid';
-import { callOnClick } from './utils';
 import { YearGrid, YearRangeHeader } from './YearGrid';
+import { callOnClick } from './utils';
 
 import type { DatePickerMode } from './type';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 type ViewMode = 'day' | 'month' | 'year';
 
 function useNavDisabled(calendarIndex: number, minDate?: Date, maxDate?: Date) {
@@ -21,7 +19,13 @@ function useNavDisabled(calendarIndex: number, minDate?: Date, maxDate?: Date) {
   const cal = calendars[calendarIndex];
 
   return useMemo(() => {
-    if (!cal) return { isPrevDisabled: false, isNextDisabled: false };
+    if (!cal)
+      return {
+        isPrevDisabled: false,
+        isNextDisabled: false,
+        isPrevYearDisabled: false,
+        isNextYearDisabled: false,
+      };
 
     const currentMonthDay = cal.days.find((d) => d.inCurrentMonth);
     const calYear = currentMonthDay
@@ -39,7 +43,20 @@ function useNavDisabled(calendarIndex: number, minDate?: Date, maxDate?: Date) {
         (calYear === maxDate.getFullYear() && calMonth >= maxDate.getMonth())
       : false;
 
-    return { isPrevDisabled, isNextDisabled };
+    const isPrevYearDisabled = minDate
+      ? calYear <= minDate.getFullYear()
+      : false;
+
+    const isNextYearDisabled = maxDate
+      ? calYear >= maxDate.getFullYear()
+      : false;
+
+    return {
+      isPrevDisabled,
+      isNextDisabled,
+      isPrevYearDisabled,
+      isNextYearDisabled,
+    };
   }, [cal, minDate, maxDate]);
 }
 
@@ -71,11 +88,12 @@ export function CalendarPanel({
 
   const [viewMode, setViewMode] = useState<ViewMode>('day');
 
-  const { isPrevDisabled, isNextDisabled } = useNavDisabled(
-    calendarIndex,
-    minDate,
-    maxDate,
-  );
+  const {
+    isPrevDisabled,
+    isNextDisabled,
+    isPrevYearDisabled,
+    isNextYearDisabled,
+  } = useNavDisabled(calendarIndex, minDate, maxDate);
 
   const getOffset = useCallback(
     () => (viewMode === 'day' ? { months: 1 } : { years: 1 }),
@@ -89,6 +107,14 @@ export function CalendarPanel({
   const handleNextMonth = useCallback(() => {
     callOnClick(addOffset(getOffset()));
   }, [getOffset, addOffset]);
+
+  const handlePrevYear = useCallback(() => {
+    callOnClick(subtractOffset({ years: 1 }));
+  }, [subtractOffset]);
+
+  const handleNextYear = useCallback(() => {
+    callOnClick(addOffset({ years: 1 }));
+  }, [addOffset]);
 
   if (!cal) return null;
 
@@ -105,8 +131,16 @@ export function CalendarPanel({
           year={cal.year}
           onPrevMonth={showPrevNav ? handlePrevMonth : undefined}
           onNextMonth={showNextNav ? handleNextMonth : undefined}
-          isPrevDisabled={showPrevNav ? isPrevDisabled : false}
-          isNextDisabled={showNextNav ? isNextDisabled : false}
+          onPrevYear={
+            showPrevNav && viewMode === 'day' ? handlePrevYear : undefined
+          }
+          onNextYear={
+            showNextNav && viewMode === 'day' ? handleNextYear : undefined
+          }
+          isPrevDisabled={showPrevNav && isPrevDisabled}
+          isNextDisabled={showNextNav && isNextDisabled}
+          isPrevYearDisabled={showPrevNav && isPrevYearDisabled}
+          isNextYearDisabled={showNextNav && isNextYearDisabled}
           onMonthClick={
             viewMode === 'day' && !isRangeDualPanel
               ? () => setViewMode('month')
@@ -119,25 +153,25 @@ export function CalendarPanel({
         />
       )}
 
-      {viewMode === 'day' ? (
+      {viewMode === 'day' && (
         <DayGrid
           calendarIndex={calendarIndex}
           hideOutOfMonth={false}
           fullWidth={mode === 'range'}
         />
-      ) : null}
-      {viewMode === 'month' ? (
+      )}
+      {viewMode === 'month' && (
         <MonthGrid
           onSelect={() => setViewMode('day')}
           onMonthSelect={onMonthSelect}
         />
-      ) : null}
-      {viewMode === 'year' ? (
+      )}
+      {viewMode === 'year' && (
         <YearGrid
           onSelect={() => setViewMode('month')}
           onYearSelect={onYearSelect}
         />
-      ) : null}
+      )}
     </YStack>
   );
 }

--- a/packages/components/src/composite/DatePicker/PresetsSidebar.tsx
+++ b/packages/components/src/composite/DatePicker/PresetsSidebar.tsx
@@ -1,0 +1,96 @@
+import { memo, useCallback, useMemo } from 'react';
+
+import { SizableText, Stack, YStack } from '../../primitives';
+
+import type { IDateRange, IDateRangePreset } from './type';
+
+function isSameDay(a: Date | null, b: Date | null): boolean {
+  if (!a || !b) return false;
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+function PresetItem({
+  label,
+  isActive,
+  onPress,
+}: {
+  label: string;
+  isActive: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Stack
+      paddingHorizontal="$3"
+      paddingVertical="$2"
+      borderRadius="$2"
+      cursor="pointer"
+      backgroundColor={isActive ? '$bgActive' : 'transparent'}
+      hoverStyle={{ backgroundColor: isActive ? '$bgActive' : '$bgHover' }}
+      pressStyle={{ backgroundColor: '$bgActive' }}
+      onPress={onPress}
+    >
+      <SizableText
+        size="$bodyMd"
+        color={isActive ? '$text' : '$textSubdued'}
+        userSelect="none"
+      >
+        {label}
+      </SizableText>
+    </Stack>
+  );
+}
+
+export const PresetsSidebar = memo(
+  ({
+    presets,
+    value,
+    onSelect,
+  }: {
+    presets: IDateRangePreset[];
+    value?: IDateRange;
+    onSelect: (range: IDateRange) => void;
+  }) => {
+    const activeIndex = useMemo(() => {
+      if (!value?.start || !value?.end) return -1;
+      return presets.findIndex((preset) => {
+        const range = preset.getRange();
+        return (
+          isSameDay(range.start, value.start) && isSameDay(range.end, value.end)
+        );
+      });
+    }, [presets, value]);
+
+    const handlePress = useCallback(
+      (preset: IDateRangePreset) => {
+        onSelect(preset.getRange());
+      },
+      [onSelect],
+    );
+
+    return (
+      <YStack
+        width={156}
+        borderRightWidth={1}
+        borderRightColor="$neutral3"
+        paddingVertical="$1"
+        paddingHorizontal="$1"
+        gap="$0.5"
+      >
+        {presets.map((preset, index) => (
+          <PresetItem
+            key={preset.label}
+            label={preset.label}
+            isActive={index === activeIndex}
+            onPress={() => handlePress(preset)}
+          />
+        ))}
+      </YStack>
+    );
+  },
+);
+
+PresetsSidebar.displayName = 'PresetsSidebar';

--- a/packages/components/src/composite/DatePicker/index.tsx
+++ b/packages/components/src/composite/DatePicker/index.tsx
@@ -1,17 +1,17 @@
-import { useCallback, useMemo, useState } from 'react';
-import type { ReactElement } from 'react';
-
 import { DatePickerProvider } from '@rehookify/datepicker';
+import { useCallback, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-
-import { Popover } from '../../actions/Popover';
-import { YStack } from '../../primitives';
 import { withStaticProperties } from '../../shared/tamagui';
+
+import { useMedia } from '../../hooks';
+import { Popover } from '../../actions/Popover';
+import { XStack, YStack } from '../../primitives';
 
 import { Calendar } from './Calendar';
 import { DatePickerTrigger } from './DatePickerTrigger';
+import { PresetsSidebar } from './PresetsSidebar';
 
 import type {
   DatePickerMode,
@@ -19,11 +19,13 @@ import type {
   IDatePickerProps,
   IDatePickerRenderTriggerProps,
   IDateRange,
+  IDateRangePreset,
   IMonthPickerProps,
   IMultiSelectPickerProps,
   IRangePickerProps,
   IYearPickerProps,
 } from './type';
+import type { ReactElement } from 'react';
 
 const WEEK_START_MONDAY = 1 as const;
 
@@ -35,7 +37,13 @@ const createPickerConfig = (
   mode: 'single' | 'range' | 'multiple' = 'single',
   calendarMode?: 'static',
   locale?: string,
+  showPreviousMonth?: boolean,
 ) => {
+  let offsets: number[] | undefined;
+  if (mode === 'range') {
+    offsets = showPreviousMonth ? [-1] : [1];
+  }
+
   const config: React.ComponentProps<typeof DatePickerProvider>['config'] = {
     selectedDates,
     onDatesChange: handleDatesChange,
@@ -48,7 +56,7 @@ const createPickerConfig = (
     calendar: {
       startDay: WEEK_START_MONDAY,
       mode: calendarMode,
-      offsets: mode === 'range' ? [1] : undefined,
+      offsets,
     },
     locale: locale ? { locale } : undefined,
   };
@@ -228,6 +236,59 @@ function BasicDatePicker({
   );
 }
 
+function RangePickerContent({
+  config,
+  minDate,
+  maxDate,
+  showPreviousMonth,
+  presets,
+  value,
+  onChange,
+  close,
+}: {
+  config: React.ComponentProps<typeof DatePickerProvider>['config'];
+  minDate?: Date;
+  maxDate?: Date;
+  showPreviousMonth?: boolean;
+  presets?: IDateRangePreset[];
+  value?: IDateRange;
+  onChange?: (range: IDateRange) => void;
+  close: () => void;
+}) {
+  const media = useMedia();
+  const hasPresets = presets && presets.length > 0 && media.gtMd;
+
+  const handlePresetSelect = useCallback(
+    (range: IDateRange) => {
+      onChange?.(range);
+      close();
+    },
+    [onChange, close],
+  );
+
+  return (
+    <XStack>
+      {hasPresets ? (
+        <PresetsSidebar
+          presets={presets}
+          value={value}
+          onSelect={handlePresetSelect}
+        />
+      ) : null}
+      <YStack padding="$3" minWidth={280} flex={1} $gtMd={{ padding: '$4' }}>
+        <DatePickerProvider config={config}>
+          <Calendar
+            mode="range"
+            minDate={minDate}
+            maxDate={maxDate}
+            showPreviousMonth={showPreviousMonth}
+          />
+        </DatePickerProvider>
+      </YStack>
+    </XStack>
+  );
+}
+
 function RangePicker({
   value,
   onChange,
@@ -240,6 +301,8 @@ function RangePicker({
   maxDate,
   floatingPanelProps,
   sheetProps,
+  showPreviousMonth,
+  presets,
 }: IRangePickerProps) {
   const { placeholder, title, locale } = usePickerI18n(
     placeholderProp,
@@ -250,6 +313,8 @@ function RangePicker({
     disabled,
     onOpenChange,
   });
+  const media = useMedia();
+  const hasPresets = presets && presets.length > 0 && media.gtMd;
 
   const selectedDates = useMemo(
     () =>
@@ -281,9 +346,19 @@ function RangePicker({
         'range',
         undefined,
         locale,
+        showPreviousMonth,
       ),
-    [selectedDates, handleDatesChange, minDate, maxDate, locale],
+    [
+      selectedDates,
+      handleDatesChange,
+      minDate,
+      maxDate,
+      locale,
+      showPreviousMonth,
+    ],
   );
+
+  const panelWidth = hasPresets ? 780 : 624;
 
   return (
     <PickerPopover
@@ -291,8 +366,8 @@ function RangePicker({
       isOpen={isOpen}
       onOpenChange={handleOpenChange}
       floatingPanelProps={{
-        w: 624,
-        maxWidth: 624,
+        w: panelWidth,
+        maxWidth: panelWidth,
         ...floatingPanelProps,
       }}
       sheetProps={sheetProps}
@@ -305,11 +380,16 @@ function RangePicker({
         onClear: () => onChange?.({ start: null, end: null }),
       })}
       renderContent={
-        <YStack padding="$3" minWidth={280} $gtMd={{ padding: '$4' }}>
-          <DatePickerProvider config={config}>
-            <Calendar mode="range" minDate={minDate} maxDate={maxDate} />
-          </DatePickerProvider>
-        </YStack>
+        <RangePickerContent
+          config={config}
+          minDate={minDate}
+          maxDate={maxDate}
+          showPreviousMonth={showPreviousMonth}
+          presets={presets}
+          value={value}
+          onChange={onChange}
+          close={close}
+        />
       }
     />
   );

--- a/packages/components/src/composite/DatePicker/type.ts
+++ b/packages/components/src/composite/DatePicker/type.ts
@@ -42,6 +42,8 @@ export interface IRangePickerProps extends IDatePickerBaseProps {
   mode?: 'range';
   value?: IDateRange;
   onChange?: (range: IDateRange) => void;
+  showPreviousMonth?: boolean;
+  presets?: IDateRangePreset[];
 }
 
 export interface IYearPickerProps extends IDatePickerBaseProps {
@@ -93,14 +95,23 @@ export interface IDayCellProps {
   onPress: (date: string) => void;
 }
 
+export interface IDateRangePreset {
+  label: string;
+  getRange: () => IDateRange;
+}
+
 export interface ICalendarHeaderProps {
   month: string;
   year: string;
   onPrevMonth?: () => void;
   onNextMonth?: () => void;
+  onPrevYear?: () => void;
+  onNextYear?: () => void;
   onMonthClick?: () => void;
   onYearClick?: () => void;
   mode?: DatePickerMode;
   isPrevDisabled?: boolean;
   isNextDisabled?: boolean;
+  isPrevYearDisabled?: boolean;
+  isNextYearDisabled?: boolean;
 }

--- a/packages/components/src/primitives/Icon/react/outline/ChevronDoubleLeft.tsx
+++ b/packages/components/src/primitives/Icon/react/outline/ChevronDoubleLeft.tsx
@@ -7,7 +7,7 @@ const SvgChevronDoubleLeft = (props: SvgProps) => (
     accessibilityRole="image"
     {...props}
   >
-    <Path d="m12.586 8 4 4-4 4L14 17.414 19.414 12 14 6.586zm-7 0 4 4-4 4L7 17.414 12.414 12 7 6.586z" />
+    <Path d="m11.414 8-4 4 4 4L10 17.414 4.586 12 10 6.586zm7 0-4 4 4 4L17 17.414 11.586 12 17 6.586z" />
   </Svg>
 );
 export default SvgChevronDoubleLeft;

--- a/packages/components/src/primitives/Icon/react/outline/ChevronDoubleRight.tsx
+++ b/packages/components/src/primitives/Icon/react/outline/ChevronDoubleRight.tsx
@@ -7,7 +7,7 @@ const SvgChevronDoubleRight = (props: SvgProps) => (
     accessibilityRole="image"
     {...props}
   >
-    <Path d="M12.414 12 7 17.414 5.586 16l4-4-4-4L7 6.586zm7 0L14 17.414 12.586 16l4-4-4-4L14 6.586z" />
+    <Path d="m12.586 8 4 4-4 4L14 17.414 19.414 12 14 6.586zm-7 0 4 4-4 4L7 17.414 12.414 12 7 6.586z" />
   </Svg>
 );
 export default SvgChevronDoubleRight;

--- a/packages/kit/src/views/ReferFriends/hooks/useDatePresets.ts
+++ b/packages/kit/src/views/ReferFriends/hooks/useDatePresets.ts
@@ -2,8 +2,27 @@ import { useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import type { IDateRangePreset } from '@onekeyhq/components';
+import type { IDateRange, IDateRangePreset } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+
+function startOfDay(date: Date): Date {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function endOfDay(date: Date): Date {
+  const d = new Date(date);
+  d.setHours(23, 59, 59, 999);
+  return d;
+}
+
+function makeRange(getStart: (now: Date) => Date): () => IDateRange {
+  return () => {
+    const now = new Date();
+    return { start: startOfDay(getStart(now)), end: endOfDay(now) };
+  };
+}
 
 export function useDatePresets(): IDateRangePreset[] {
   const intl = useIntl();
@@ -12,14 +31,7 @@ export function useDatePresets(): IDateRangePreset[] {
     () => [
       {
         label: intl.formatMessage({ id: ETranslations.date_today }),
-        getRange: () => {
-          const now = new Date();
-          const start = new Date(now);
-          start.setHours(0, 0, 0, 0);
-          const end = new Date(now);
-          end.setHours(23, 59, 59, 999);
-          return { start, end };
-        },
+        getRange: makeRange((now) => now),
       },
       {
         label: intl.formatMessage({ id: ETranslations.date_yesterday }),
@@ -27,84 +39,54 @@ export function useDatePresets(): IDateRangePreset[] {
           const now = new Date();
           const start = new Date(now);
           start.setDate(start.getDate() - 1);
-          start.setHours(0, 0, 0, 0);
-          const end = new Date(start);
-          end.setHours(23, 59, 59, 999);
-          return { start, end };
+          return { start: startOfDay(start), end: endOfDay(start) };
         },
       },
       {
         label: 'This week',
-        getRange: () => {
-          const now = new Date();
+        getRange: makeRange((now) => {
           const start = new Date(now);
-          // Monday as start of week
           const day = start.getDay();
           const diff = day === 0 ? 6 : day - 1;
           start.setDate(start.getDate() - diff);
-          start.setHours(0, 0, 0, 0);
-          const end = new Date(now);
-          end.setHours(23, 59, 59, 999);
-          return { start, end };
-        },
+          return start;
+        }),
       },
       {
         label: 'This month',
-        getRange: () => {
-          const now = new Date();
-          const start = new Date(now.getFullYear(), now.getMonth(), 1);
-          start.setHours(0, 0, 0, 0);
-          const end = new Date(now);
-          end.setHours(23, 59, 59, 999);
-          return { start, end };
-        },
+        getRange: makeRange(
+          (now) => new Date(now.getFullYear(), now.getMonth(), 1),
+        ),
       },
       {
         label: intl.formatMessage({ id: ETranslations.referral_filter_30 }),
-        getRange: () => {
-          const now = new Date();
+        getRange: makeRange((now) => {
           const start = new Date(now);
           start.setDate(start.getDate() - 29);
-          start.setHours(0, 0, 0, 0);
-          const end = new Date(now);
-          end.setHours(23, 59, 59, 999);
-          return { start, end };
-        },
+          return start;
+        }),
       },
       {
         label: 'Last 6 months',
-        getRange: () => {
-          const now = new Date();
+        getRange: makeRange((now) => {
           const start = new Date(now);
           start.setMonth(start.getMonth() - 6);
-          start.setHours(0, 0, 0, 0);
-          const end = new Date(now);
-          end.setHours(23, 59, 59, 999);
-          return { start, end };
-        },
+          return start;
+        }),
       },
       {
         label: 'Last 1 year',
-        getRange: () => {
-          const now = new Date();
+        getRange: makeRange((now) => {
           const start = new Date(now);
           start.setFullYear(start.getFullYear() - 1);
-          start.setHours(0, 0, 0, 0);
-          const end = new Date(now);
-          end.setHours(23, 59, 59, 999);
-          return { start, end };
-        },
+          return start;
+        }),
       },
       {
         label: intl.formatMessage({
           id: ETranslations.referral_filter_alltime,
         }),
-        getRange: () => {
-          const start = new Date('2024-01-01T00:00:00.000');
-          const end = new Date();
-          end.setHours(23, 59, 59, 999);
-          return { start, end };
-        },
+        getRange: makeRange(() => new Date('2024-01-01T00:00:00.000')),
       },
     ],
     [intl],

--- a/packages/kit/src/views/ReferFriends/hooks/useDatePresets.ts
+++ b/packages/kit/src/views/ReferFriends/hooks/useDatePresets.ts
@@ -1,0 +1,112 @@
+import { useMemo } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import type { IDateRangePreset } from '@onekeyhq/components';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+
+export function useDatePresets(): IDateRangePreset[] {
+  const intl = useIntl();
+
+  return useMemo(
+    () => [
+      {
+        label: intl.formatMessage({ id: ETranslations.date_today }),
+        getRange: () => {
+          const now = new Date();
+          const start = new Date(now);
+          start.setHours(0, 0, 0, 0);
+          const end = new Date(now);
+          end.setHours(23, 59, 59, 999);
+          return { start, end };
+        },
+      },
+      {
+        label: intl.formatMessage({ id: ETranslations.date_yesterday }),
+        getRange: () => {
+          const now = new Date();
+          const start = new Date(now);
+          start.setDate(start.getDate() - 1);
+          start.setHours(0, 0, 0, 0);
+          const end = new Date(start);
+          end.setHours(23, 59, 59, 999);
+          return { start, end };
+        },
+      },
+      {
+        label: 'This week',
+        getRange: () => {
+          const now = new Date();
+          const start = new Date(now);
+          // Monday as start of week
+          const day = start.getDay();
+          const diff = day === 0 ? 6 : day - 1;
+          start.setDate(start.getDate() - diff);
+          start.setHours(0, 0, 0, 0);
+          const end = new Date(now);
+          end.setHours(23, 59, 59, 999);
+          return { start, end };
+        },
+      },
+      {
+        label: 'This month',
+        getRange: () => {
+          const now = new Date();
+          const start = new Date(now.getFullYear(), now.getMonth(), 1);
+          start.setHours(0, 0, 0, 0);
+          const end = new Date(now);
+          end.setHours(23, 59, 59, 999);
+          return { start, end };
+        },
+      },
+      {
+        label: intl.formatMessage({ id: ETranslations.referral_filter_30 }),
+        getRange: () => {
+          const now = new Date();
+          const start = new Date(now);
+          start.setDate(start.getDate() - 29);
+          start.setHours(0, 0, 0, 0);
+          const end = new Date(now);
+          end.setHours(23, 59, 59, 999);
+          return { start, end };
+        },
+      },
+      {
+        label: 'Last 6 months',
+        getRange: () => {
+          const now = new Date();
+          const start = new Date(now);
+          start.setMonth(start.getMonth() - 6);
+          start.setHours(0, 0, 0, 0);
+          const end = new Date(now);
+          end.setHours(23, 59, 59, 999);
+          return { start, end };
+        },
+      },
+      {
+        label: 'Last 1 year',
+        getRange: () => {
+          const now = new Date();
+          const start = new Date(now);
+          start.setFullYear(start.getFullYear() - 1);
+          start.setHours(0, 0, 0, 0);
+          const end = new Date(now);
+          end.setHours(23, 59, 59, 999);
+          return { start, end };
+        },
+      },
+      {
+        label: intl.formatMessage({
+          id: ETranslations.referral_filter_alltime,
+        }),
+        getRange: () => {
+          const start = new Date('2024-01-01T00:00:00.000');
+          const end = new Date();
+          end.setHours(23, 59, 59, 999);
+          return { start, end };
+        },
+      },
+    ],
+    [intl],
+  );
+}

--- a/packages/kit/src/views/ReferFriends/pages/EarnReward/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/EarnReward/index.tsx
@@ -27,6 +27,7 @@ import {
   ReferFriendsDetailHeader,
   ReferFriendsPageContainer,
 } from '../../components';
+import { useDatePresets } from '../../hooks/useDatePresets';
 import { useRewardFilter } from '../../hooks/useRewardFilter';
 
 import { EarnRewardsTab } from './components';
@@ -99,6 +100,8 @@ function EarnRewardPageWrapper() {
     }
   }, [filterState.timeRange]);
 
+  const presets = useDatePresets();
+
   const effectiveTimeRange =
     filterState.startTime && filterState.endTime
       ? undefined
@@ -112,6 +115,8 @@ function EarnRewardPageWrapper() {
             value={currentDatePickerValue}
             onChange={handleDateRangeChange}
             maxDate={maxDate}
+            showPreviousMonth
+            presets={presets}
           />
         </YStack>
         <XStack gap="$3">
@@ -134,6 +139,7 @@ function EarnRewardPageWrapper() {
       currentDatePickerValue,
       handleDateRangeChange,
       maxDate,
+      presets,
       filterState,
       updateFilter,
       effectiveTimeRange,

--- a/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/index.tsx
@@ -34,6 +34,7 @@ import {
   ReferFriendsDetailHeader,
   ReferFriendsPageContainer,
 } from '../../components';
+import { useDatePresets } from '../../hooks/useDatePresets';
 import { useRewardFilter } from '../../hooks/useRewardFilter';
 
 import { HardwareRecordsList } from './components/HardwareRecordsList';
@@ -139,6 +140,8 @@ function HardwareSalesRewardPageWrapper() {
   const currentDatePickerValue = intermediateDateRange ?? datePickerValue;
   const maxDate = useMemo(() => new Date(), []);
 
+  const presets = useDatePresets();
+
   const effectiveTimeRange =
     filterState.startTime && filterState.endTime
       ? undefined
@@ -152,6 +155,8 @@ function HardwareSalesRewardPageWrapper() {
             value={currentDatePickerValue}
             onChange={handleDateRangeChange}
             maxDate={maxDate}
+            showPreviousMonth
+            presets={presets}
           />
         </YStack>
         <XStack gap="$3">
@@ -172,6 +177,7 @@ function HardwareSalesRewardPageWrapper() {
       currentDatePickerValue,
       handleDateRangeChange,
       maxDate,
+      presets,
       filterState,
       updateFilter,
       effectiveTimeRange,

--- a/packages/kit/src/views/ReferFriends/pages/PerpsReward/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/PerpsReward/index.tsx
@@ -32,6 +32,7 @@ import {
   ReferFriendsDetailHeader,
   ReferFriendsPageContainer,
 } from '../../components';
+import { useDatePresets } from '../../hooks/useDatePresets';
 import { useRewardFilter } from '../../hooks/useRewardFilter';
 
 import { PerpsDetailsSection } from './components/PerpsDetailsSection';
@@ -366,6 +367,7 @@ function PerpsRewardPageWrapper() {
 
   // Max date for DatePicker (today)
   const maxDate = useMemo(() => new Date(), []);
+  const presets = useDatePresets();
 
   const toolbar = useMemo(
     () => (
@@ -375,6 +377,8 @@ function PerpsRewardPageWrapper() {
             value={currentDatePickerValue}
             onChange={handleDateRangeChange}
             maxDate={maxDate}
+            showPreviousMonth
+            presets={presets}
           />
         </YStack>
         <XStack gap="$3">
@@ -396,6 +400,7 @@ function PerpsRewardPageWrapper() {
       currentDatePickerValue,
       handleDateRangeChange,
       maxDate,
+      presets,
       filterState,
       updateFilter,
       effectiveTimeRange,


### PR DESCRIPTION
## Summary
- Add year navigation buttons (`<<` `>>`) to calendar header alongside month navigation (`<` `>`)
- Add presets sidebar with quick date range selections (Today, Yesterday, This week, This month, Last 30 days, Last 6 months, Last 1 year, All time)
- Fix calendar to open showing [previous month, current month] via `showPreviousMonth` prop
- Fix `ChevronDoubleLeft`/`ChevronDoubleRight` SVG icon paths rendering wrong direction
- Center month/year title using absolute positioning in calendar header

## Test plan
- [ ] Open Referral > Earn Reward, click date picker
- [ ] Verify calendar opens with [previous month, current month]
- [ ] Verify `<<` `>>` navigates year, `<` `>` navigates month
- [ ] Verify presets sidebar shows on desktop, clicking applies date range
- [ ] Verify month/year title is centered in both panels
- [ ] Same checks on HardwareSalesReward and PerpsReward pages
- [ ] Verify mobile: presets sidebar hidden
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
