### PR TITLE
fix: add missing optional chaining for account value db access

### DIFF
--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
@@ -27,8 +27,8 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
 
     return accounts.map(({ accountId }) => ({
       accountId,
-      value: rawData?.data[accountId]?.value,
-      currency: rawData?.data[accountId]?.currency,
+      value: rawData?.data?.[accountId]?.value,
+      currency: rawData?.data?.[accountId]?.currency,
     }));
   }
 
@@ -94,8 +94,8 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
 
     return accounts.map(({ accountId }) => ({
       accountId,
-      value: rawData?.all[accountId]?.value,
-      currency: rawData?.all[accountId]?.currency,
+      value: rawData?.all?.[accountId]?.value,
+      currency: rawData?.all?.[accountId]?.currency,
     }));
   }
 }


### PR DESCRIPTION
## Summary
- Fixes Sentry issue [DESKTOP-MAS-MR](https://onekey-bb.sentry.io/issues/DESKTOP-MAS-MR) (226 events, 14 users)
- Adds missing optional chaining (`?.`) on `rawData.data` and `rawData.all` property access in `SimpleDbEntityAccountValue` to prevent `TypeError: Cannot read properties of undefined` when the database record exists but its `data` or `all` sub-properties are not yet initialized
- Affects both `getAccountsValue` and `getAllNetworkAccountsValue` methods

## Root Cause
When `rawData` is defined (not null/undefined) but `rawData.all` or `rawData.data` is `undefined` (e.g., fresh DB state or partial writes), the expression `rawData?.all[accountId]` skips the nullish check on `rawData` but still tries to index into `undefined`, throwing a TypeError. The fix changes these to `rawData?.all?.[accountId]` and `rawData?.data?.[accountId]`.

## Test plan
- [ ] Verify account value display works correctly on Desktop MAS
- [ ] Test with a fresh account that has no stored account values
- [ ] Confirm existing accounts with stored values still display correctly