### PR TITLE
fix: add missing optional chaining in SimpleDbEntityAccountValue

### DIFF
--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
@@ -27,8 +27,8 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
 
     return accounts.map(({ accountId }) => ({
       accountId,
-      value: rawData?.data[accountId]?.value,
-      currency: rawData?.data[accountId]?.currency,
+      value: rawData?.data?.[accountId]?.value,
+      currency: rawData?.data?.[accountId]?.currency,
     }));
   }
 
@@ -94,8 +94,8 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
 
     return accounts.map(({ accountId }) => ({
       accountId,
-      value: rawData?.all[accountId]?.value,
-      currency: rawData?.all[accountId]?.currency,
+      value: rawData?.all?.[accountId]?.value,
+      currency: rawData?.all?.[accountId]?.currency,
     }));
   }
 }


### PR DESCRIPTION
## Summary
- Fixes Sentry issue **DESKTOP-WINMS-AX** (`TypeError: Cannot read properties of undefined`) which affected 11 users with 193 occurrences since 2025-09-13
- Added optional chaining (`?.`) on `rawData.data` and `rawData.all` property accesses in `SimpleDbEntityAccountValue` to prevent crashes when the DB entity has been initialized but its `data` or `all` sub-objects are undefined
- Applied the same defensive fix to both `getAccountsValue` and `getAllNetworkAccountsValue` methods

## Root Cause
In `SimpleDbEntityAccountValue`, the methods `getAccountsValue` and `getAllNetworkAccountsValue` use expressions like `rawData?.data[accountId]?.value` and `rawData?.all[accountId]?.value`. The optional chaining after `rawData` protects against `rawData` being nullish, but when `rawData` exists with `data` or `all` as `undefined` (e.g., first launch, partial DB initialization), the bracket access `undefined[accountId]` throws a TypeError.

## Fix
Changed property access from:
```ts
rawData?.data[accountId]?.value   // crashes if rawData.data is undefined
rawData?.all[accountId]?.value    // crashes if rawData.all is undefined
```
To:
```ts
rawData?.data?.[accountId]?.value   // safely returns undefined
rawData?.all?.[accountId]?.value    // safely returns undefined
```

## Test plan
- [ ] Verify account value display works correctly on Desktop Windows
- [ ] Verify no regression on account value updates across all platforms
- [ ] Confirm the fix resolves the Sentry error by monitoring DESKTOP-WINMS-AX after deployment