### PR TITLE
fix: guard toMessageObject call in hd-core device disconnect handler

### DIFF
--- a/patches/@onekeyfe+hd-core+1.1.23.patch
+++ b/patches/@onekeyfe+hd-core+1.1.23.patch
@@ -1,8 +1,10 @@
 diff --git a/node_modules/@onekeyfe/hd-core/dist/index.js b/node_modules/@onekeyfe/hd-core/dist/index.js
-index 50d671d..a1b2c3d 100644
+index 50d671d..ad255ef 100644
 --- a/node_modules/@onekeyfe/hd-core/dist/index.js
 +++ b/node_modules/@onekeyfe/hd-core/dist/index.js
-@@ -40640,12 +40640,31 @@ const closePopup = () => {
+@@ -40638,14 +40638,38 @@ const removeDeviceListener = (device) => {
+ const closePopup = () => {
+     postMessage(createUiMessage(UI_REQUEST.CLOSE_UI_WINDOW));
  };
 +const deviceToSafeObject = (device) => {
 +    var _a, _b, _c, _d;
@@ -21,26 +23,33 @@ index 50d671d..a1b2c3d 100644
 +        firmwareVersion: null,
 +        bleFirmwareVersion: null,
 +        unavailableCapabilities: {},
++        instanceId: device.instanceId,
++        sdkInstanceId: device.sdkInstanceId,
++        createdAt: device.createdAt,
 +    };
 +};
  const onDeviceConnectHandler = (device) => {
++    var _a;
      const env = DataManager.getSettings('env');
 -    const deviceObject = DataManager.isBleConnect(env) ? device : device.toMessageObject();
-+    const deviceObject = DataManager.isBleConnect(env) ? device : typeof device.toMessageObject === 'function' ? device.toMessageObject() : deviceToSafeObject(device);
++    const deviceObject = DataManager.isBleConnect(env) ? device : (_a = (typeof device.toMessageObject === 'function' ? device.toMessageObject() : null)) !== null && _a !== void 0 ? _a : deviceToSafeObject(device);
      postMessage(createDeviceMessage(DEVICE.CONNECT, { device: deviceObject }));
  };
  const onDeviceDisconnectHandler = (device) => {
++    var _a;
      const env = DataManager.getSettings('env');
 -    const deviceObject = DataManager.isBleConnect(env) ? device : device.toMessageObject();
-+    const deviceObject = DataManager.isBleConnect(env) ? device : typeof device.toMessageObject === 'function' ? device.toMessageObject() : deviceToSafeObject(device);
++    const deviceObject = DataManager.isBleConnect(env) ? device : (_a = (typeof device.toMessageObject === 'function' ? device.toMessageObject() : null)) !== null && _a !== void 0 ? _a : deviceToSafeObject(device);
      postMessage(createDeviceMessage(DEVICE.DISCONNECT, { device: deviceObject }));
  };
  const onDevicePinHandler = (...[device, type, callback]) => __awaiter(void 0, void 0, void 0, function* () {
 diff --git a/node_modules/@onekeyfe/hd-core/src/core/index.ts b/node_modules/@onekeyfe/hd-core/src/core/index.ts
-index d625c30..b4c5d6e 100644
+index d625c30..f90b6e8 100644
 --- a/node_modules/@onekeyfe/hd-core/src/core/index.ts
 +++ b/node_modules/@onekeyfe/hd-core/src/core/index.ts
-@@ -1008,13 +1008,38 @@ const closePopup = () => {
+@@ -1006,15 +1006,43 @@ const closePopup = () => {
+   postMessage(createUiMessage(UI_REQUEST.CLOSE_UI_WINDOW));
+ };
  
 +const deviceToSafeObject = (device: Device): KnownDevice => ({
 +  connectId: device.mainId || null,
@@ -57,6 +66,9 @@ index d625c30..b4c5d6e 100644
 +  firmwareVersion: null,
 +  bleFirmwareVersion: null,
 +  unavailableCapabilities: {},
++  instanceId: device.instanceId,
++  sdkInstanceId: device.sdkInstanceId,
++  createdAt: device.createdAt,
 +});
 +
  const onDeviceConnectHandler = (device: Device) => {
@@ -64,9 +76,9 @@ index d625c30..b4c5d6e 100644
 -  const deviceObject = DataManager.isBleConnect(env) ? device : device.toMessageObject();
 +  const deviceObject = DataManager.isBleConnect(env)
 +    ? device
-+    : typeof device.toMessageObject === 'function'
-+      ? device.toMessageObject()
-+      : deviceToSafeObject(device);
++    : (typeof device.toMessageObject === 'function'
++        ? device.toMessageObject()
++        : null) ?? deviceToSafeObject(device);
    postMessage(createDeviceMessage(DEVICE.CONNECT, { device: deviceObject as KnownDevice }));
  };
  
@@ -75,9 +87,8 @@ index d625c30..b4c5d6e 100644
 -  const deviceObject = DataManager.isBleConnect(env) ? device : device.toMessageObject();
 +  const deviceObject = DataManager.isBleConnect(env)
 +    ? device
-+    : typeof device.toMessageObject === 'function'
-+      ? device.toMessageObject()
-+      : deviceToSafeObject(device);
++    : (typeof device.toMessageObject === 'function'
++        ? device.toMessageObject()
++        : null) ?? deviceToSafeObject(device);
    postMessage(createDeviceMessage(DEVICE.DISCONNECT, { device: deviceObject as KnownDevice }));
  };
- 

--- a/patches/@onekeyfe+hd-core+1.1.23.patch
+++ b/patches/@onekeyfe+hd-core+1.1.23.patch
@@ -1,0 +1,47 @@
+diff --git a/node_modules/@onekeyfe/hd-core/dist/index.js b/node_modules/@onekeyfe/hd-core/dist/index.js
+index 50d671d..1d04f84 100644
+--- a/node_modules/@onekeyfe/hd-core/dist/index.js
++++ b/node_modules/@onekeyfe/hd-core/dist/index.js
+@@ -40640,12 +40640,12 @@ const closePopup = () => {
+ };
+ const onDeviceConnectHandler = (device) => {
+     const env = DataManager.getSettings('env');
+-    const deviceObject = DataManager.isBleConnect(env) ? device : device.toMessageObject();
++    const deviceObject = DataManager.isBleConnect(env) ? device : typeof device.toMessageObject === 'function' ? device.toMessageObject() : device;
+     postMessage(createDeviceMessage(DEVICE.CONNECT, { device: deviceObject }));
+ };
+ const onDeviceDisconnectHandler = (device) => {
+     const env = DataManager.getSettings('env');
+-    const deviceObject = DataManager.isBleConnect(env) ? device : device.toMessageObject();
++    const deviceObject = DataManager.isBleConnect(env) ? device : typeof device.toMessageObject === 'function' ? device.toMessageObject() : device;
+     postMessage(createDeviceMessage(DEVICE.DISCONNECT, { device: deviceObject }));
+ };
+ const onDevicePinHandler = (...[device, type, callback]) => __awaiter(void 0, void 0, void 0, function* () {
+diff --git a/node_modules/@onekeyfe/hd-core/src/core/index.ts b/node_modules/@onekeyfe/hd-core/src/core/index.ts
+index d625c30..2adf89e 100644
+--- a/node_modules/@onekeyfe/hd-core/src/core/index.ts
++++ b/node_modules/@onekeyfe/hd-core/src/core/index.ts
+@@ -1008,13 +1008,21 @@ const closePopup = () => {
+ 
+ const onDeviceConnectHandler = (device: Device) => {
+   const env = DataManager.getSettings('env');
+-  const deviceObject = DataManager.isBleConnect(env) ? device : device.toMessageObject();
++  const deviceObject = DataManager.isBleConnect(env)
++    ? device
++    : typeof device.toMessageObject === 'function'
++      ? device.toMessageObject()
++      : device;
+   postMessage(createDeviceMessage(DEVICE.CONNECT, { device: deviceObject as KnownDevice }));
+ };
+ 
+ const onDeviceDisconnectHandler = (device: Device) => {
+   const env = DataManager.getSettings('env');
+-  const deviceObject = DataManager.isBleConnect(env) ? device : device.toMessageObject();
++  const deviceObject = DataManager.isBleConnect(env)
++    ? device
++    : typeof device.toMessageObject === 'function'
++      ? device.toMessageObject()
++      : device;
+   postMessage(createDeviceMessage(DEVICE.DISCONNECT, { device: deviceObject as KnownDevice }));
+ };
+ 

--- a/patches/@onekeyfe+hd-core+1.1.23.patch
+++ b/patches/@onekeyfe+hd-core+1.1.23.patch
@@ -1,28 +1,64 @@
 diff --git a/node_modules/@onekeyfe/hd-core/dist/index.js b/node_modules/@onekeyfe/hd-core/dist/index.js
-index 50d671d..1d04f84 100644
+index 50d671d..a1b2c3d 100644
 --- a/node_modules/@onekeyfe/hd-core/dist/index.js
 +++ b/node_modules/@onekeyfe/hd-core/dist/index.js
-@@ -40640,12 +40640,12 @@ const closePopup = () => {
+@@ -40640,12 +40640,31 @@ const closePopup = () => {
  };
++const deviceToSafeObject = (device) => {
++    var _a, _b, _c, _d;
++    return {
++        connectId: device.mainId || null,
++        uuid: '',
++        deviceId: ((_a = device.features) === null || _a === void 0 ? void 0 : _a.device_id) || null,
++        deviceType: null,
++        commType: ((_b = device.originalDescriptor) === null || _b === void 0 ? void 0 : _b.commType) || null,
++        path: ((_d = (_c = device.originalDescriptor) === null || _c === void 0 ? void 0 : _c.path) !== null && _d !== void 0 ? _d : ''),
++        label: 'OneKey',
++        bleName: null,
++        name: 'OneKey',
++        mode: 'normal',
++        features: device.features,
++        firmwareVersion: null,
++        bleFirmwareVersion: null,
++        unavailableCapabilities: {},
++    };
++};
  const onDeviceConnectHandler = (device) => {
      const env = DataManager.getSettings('env');
 -    const deviceObject = DataManager.isBleConnect(env) ? device : device.toMessageObject();
-+    const deviceObject = DataManager.isBleConnect(env) ? device : typeof device.toMessageObject === 'function' ? device.toMessageObject() : device;
++    const deviceObject = DataManager.isBleConnect(env) ? device : typeof device.toMessageObject === 'function' ? device.toMessageObject() : deviceToSafeObject(device);
      postMessage(createDeviceMessage(DEVICE.CONNECT, { device: deviceObject }));
  };
  const onDeviceDisconnectHandler = (device) => {
      const env = DataManager.getSettings('env');
 -    const deviceObject = DataManager.isBleConnect(env) ? device : device.toMessageObject();
-+    const deviceObject = DataManager.isBleConnect(env) ? device : typeof device.toMessageObject === 'function' ? device.toMessageObject() : device;
++    const deviceObject = DataManager.isBleConnect(env) ? device : typeof device.toMessageObject === 'function' ? device.toMessageObject() : deviceToSafeObject(device);
      postMessage(createDeviceMessage(DEVICE.DISCONNECT, { device: deviceObject }));
  };
  const onDevicePinHandler = (...[device, type, callback]) => __awaiter(void 0, void 0, void 0, function* () {
 diff --git a/node_modules/@onekeyfe/hd-core/src/core/index.ts b/node_modules/@onekeyfe/hd-core/src/core/index.ts
-index d625c30..2adf89e 100644
+index d625c30..b4c5d6e 100644
 --- a/node_modules/@onekeyfe/hd-core/src/core/index.ts
 +++ b/node_modules/@onekeyfe/hd-core/src/core/index.ts
-@@ -1008,13 +1008,21 @@ const closePopup = () => {
+@@ -1008,13 +1008,38 @@ const closePopup = () => {
  
++const deviceToSafeObject = (device: Device): KnownDevice => ({
++  connectId: device.mainId || null,
++  uuid: '',
++  deviceId: device.features?.device_id || null,
++  deviceType: null,
++  commType: device.originalDescriptor?.commType || null,
++  path: device.originalDescriptor?.path ?? '',
++  label: 'OneKey',
++  bleName: null,
++  name: 'OneKey',
++  mode: 'normal' as any,
++  features: device.features as any,
++  firmwareVersion: null,
++  bleFirmwareVersion: null,
++  unavailableCapabilities: {},
++});
++
  const onDeviceConnectHandler = (device: Device) => {
    const env = DataManager.getSettings('env');
 -  const deviceObject = DataManager.isBleConnect(env) ? device : device.toMessageObject();
@@ -30,7 +66,7 @@ index d625c30..2adf89e 100644
 +    ? device
 +    : typeof device.toMessageObject === 'function'
 +      ? device.toMessageObject()
-+      : device;
++      : deviceToSafeObject(device);
    postMessage(createDeviceMessage(DEVICE.CONNECT, { device: deviceObject as KnownDevice }));
  };
  
@@ -41,7 +77,7 @@ index d625c30..2adf89e 100644
 +    ? device
 +    : typeof device.toMessageObject === 'function'
 +      ? device.toMessageObject()
-+      : device;
++      : deviceToSafeObject(device);
    postMessage(createDeviceMessage(DEVICE.DISCONNECT, { device: deviceObject as KnownDevice }));
  };
  


### PR DESCRIPTION
## Summary
Fix DESKTOP-MAS-Z2: `TypeError: e.toMessageObject is not a function` in hd-core device disconnect/connect handlers (135 events, 72 users).

### Root Cause
When a device disconnects, the device object in the pool may have lost its prototype chain (e.g. due to serialization/deserialization or cross-context transfer), causing `toMessageObject` to be `undefined`. The `onDeviceConnectHandler` and `onDeviceDisconnectHandler` call `device.toMessageObject()` without checking if the method exists, causing a `TypeError` on the non-BLE code path.

Note: `isBleConnect(env)` already returns `true` for `desktop-web-ble` connections, so BLE devices take the early-return branch. The crash occurs on the `else` branch when a device object has lost its prototype (plain object without class methods).

### Fix
- Added a `typeof device.toMessageObject === 'function'` guard before calling `toMessageObject()`.
- When the method is unavailable **or returns `null`** (e.g. for unacquired devices), falls back to `deviceToSafeObject(device)` using nullish coalescing (`??`).
- The `deviceToSafeObject` fallback constructs a valid `KnownDevice` object by extracting all relevant fields from the raw device: `connectId`, `deviceId`, `path`, `commType`, `features`, `instanceId`, `sdkInstanceId`, `createdAt`, etc.

### Test Plan
- [ ] Connect a hardware wallet via USB on Desktop
- [ ] Disconnect the hardware wallet (physically or via system settings)
- [ ] Verify no `TypeError: e.toMessageObject is not a function` error occurs
- [ ] Verify the disconnect event is still properly handled and the UI updates accordingly
- [ ] Connect a hardware wallet via Bluetooth on Desktop MAS
- [ ] Disconnect the BLE hardware wallet and verify correct behavior
- [ ] Monitor Sentry for recurrence of DESKTOP-MAS-Z2