### PR TITLE
fix(android): prevent ConcurrentModificationException in foldable device listener

### DIFF
--- a/patches/@onekeyfe+react-native-device-utils+1.1.18.patch
+++ b/patches/@onekeyfe+react-native-device-utils+1.1.18.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@onekeyfe/react-native-device-utils/android/src/main/java/com/margelo/nitro/reactnativedeviceutils/ReactNativeDeviceUtils.kt b/node_modules/@onekeyfe/react-native-device-utils/android/src/main/java/com/margelo/nitro/reactnativedeviceutils/ReactNativeDeviceUtils.kt
-index f99af72..c3a5d12 100644
+index f99af72..519995e 100644
 --- a/node_modules/@onekeyfe/react-native-device-utils/android/src/main/java/com/margelo/nitro/reactnativedeviceutils/ReactNativeDeviceUtils.kt
 +++ b/node_modules/@onekeyfe/react-native-device-utils/android/src/main/java/com/margelo/nitro/reactnativedeviceutils/ReactNativeDeviceUtils.kt
 @@ -6,6 +6,7 @@ import android.content.Context
@@ -33,7 +33,7 @@ index f99af72..c3a5d12 100644
 +      try {
 +        listener.callback(isSpanning)
 +      } catch (e: Exception) {
-+        Log.e("OneKey", "Error in listener callback", e)
++        Log.e("OneKey", "Error in spanning listener callback", e)
 +      }
      }
    }

--- a/patches/@onekeyfe+react-native-device-utils+1.1.18.patch
+++ b/patches/@onekeyfe+react-native-device-utils+1.1.18.patch
@@ -1,8 +1,9 @@
 diff --git a/node_modules/@onekeyfe/react-native-device-utils/android/src/main/java/com/margelo/nitro/reactnativedeviceutils/ReactNativeDeviceUtils.kt b/node_modules/@onekeyfe/react-native-device-utils/android/src/main/java/com/margelo/nitro/reactnativedeviceutils/ReactNativeDeviceUtils.kt
-index f99af72..a1b2c3d 100644
+index f99af72..c3a5d12 100644
 --- a/node_modules/@onekeyfe/react-native-device-utils/android/src/main/java/com/margelo/nitro/reactnativedeviceutils/ReactNativeDeviceUtils.kt
 +++ b/node_modules/@onekeyfe/react-native-device-utils/android/src/main/java/com/margelo/nitro/reactnativedeviceutils/ReactNativeDeviceUtils.kt
-@@ -6,6 +6,7 @@ import android.graphics.Color
+@@ -6,6 +6,7 @@ import android.content.Context
+ import android.graphics.Color
  import android.graphics.Rect
  import android.os.Build
 +import android.util.Log
@@ -18,7 +19,7 @@ index f99af72..a1b2c3d 100644
    private var isObservingLayoutChanges = false
    private var nextListenerId = 0.0
    private var isDualScreenDeviceDetected: Boolean? = null
-@@ -697,9 +698,16 @@ class ReactNativeDeviceUtils : HybridReactNativeDeviceUtilsSpec(), LifecycleEven
+@@ -697,9 +698,15 @@ class ReactNativeDeviceUtils : HybridReactNativeDeviceUtilsSpec(), LifecycleEven
    }
  
    fun callSpanningChangedListeners(isSpanning: Boolean) {
@@ -32,7 +33,7 @@ index f99af72..a1b2c3d 100644
 +      try {
 +        listener.callback(isSpanning)
 +      } catch (e: Exception) {
-+        Log.e("OneKey", "Error in spanning listener callback", e)
++        Log.e("OneKey", "Error in listener callback", e)
 +      }
      }
    }

--- a/patches/@onekeyfe+react-native-device-utils+1.1.18.patch
+++ b/patches/@onekeyfe+react-native-device-utils+1.1.18.patch
@@ -1,0 +1,47 @@
+diff --git a/node_modules/@onekeyfe/react-native-device-utils/android/src/main/java/com/margelo/nitro/reactnativedeviceutils/ReactNativeDeviceUtils.kt b/node_modules/@onekeyfe/react-native-device-utils/android/src/main/java/com/margelo/nitro/reactnativedeviceutils/ReactNativeDeviceUtils.kt
+index f99af72..8ae8314 100644
+--- a/node_modules/@onekeyfe/react-native-device-utils/android/src/main/java/com/margelo/nitro/reactnativedeviceutils/ReactNativeDeviceUtils.kt
++++ b/node_modules/@onekeyfe/react-native-device-utils/android/src/main/java/com/margelo/nitro/reactnativedeviceutils/ReactNativeDeviceUtils.kt
+@@ -220,7 +220,7 @@ class ReactNativeDeviceUtils : HybridReactNativeDeviceUtilsSpec(), LifecycleEven
+   private var layoutInfoConsumer: Consumer<WindowLayoutInfo>? = null
+   private var windowInfoTracker: WindowInfoTracker? = null
+   private var callbackAdapter: WindowInfoTrackerCallbackAdapter? = null
+-  private var spanningChangedListeners: MutableList<Listener> = CopyOnWriteArrayList()
++  private val spanningChangedListeners: CopyOnWriteArrayList<Listener> = CopyOnWriteArrayList()
+   private var isObservingLayoutChanges = false
+   private var nextListenerId = 0.0
+   private var isDualScreenDeviceDetected: Boolean? = null
+@@ -697,9 +697,19 @@ class ReactNativeDeviceUtils : HybridReactNativeDeviceUtilsSpec(), LifecycleEven
+   }
+ 
+   fun callSpanningChangedListeners(isSpanning: Boolean) {
+-    // Create a snapshot to avoid ConcurrentModificationException when listeners modify the list during callbacks
+-    for (listener in spanningChangedListeners.toList()) {
+-      listener.callback(isSpanning)
++    // CopyOnWriteArrayList provides snapshot-based iteration that never throws
++    // ConcurrentModificationException, even if listeners are added/removed during iteration.
++    // Do NOT call .toList() here as it creates a regular ArrayList that is not thread-safe.
++    try {
++      for (listener in spanningChangedListeners) {
++        try {
++          listener.callback(isSpanning)
++        } catch (e: Exception) {
++          // Ignore individual listener errors to avoid breaking the iteration
++        }
++      }
++    } catch (e: Exception) {
++      // Safety net: catch any unexpected iteration errors
+     }
+   }
+ 
+@@ -712,7 +722,9 @@ class ReactNativeDeviceUtils : HybridReactNativeDeviceUtilsSpec(), LifecycleEven
+   }
+ 
+     override fun removeSpanningChangedListener(id: Double) {
+-        spanningChangedListeners.removeIf { it.id == id }
++        synchronized(this) {
++            spanningChangedListeners.removeIf { it.id == id }
++        }
+     }
+ 
+   private fun startObservingLayoutChanges() {

--- a/patches/@onekeyfe+react-native-device-utils+1.1.18.patch
+++ b/patches/@onekeyfe+react-native-device-utils+1.1.18.patch
@@ -1,8 +1,15 @@
 diff --git a/node_modules/@onekeyfe/react-native-device-utils/android/src/main/java/com/margelo/nitro/reactnativedeviceutils/ReactNativeDeviceUtils.kt b/node_modules/@onekeyfe/react-native-device-utils/android/src/main/java/com/margelo/nitro/reactnativedeviceutils/ReactNativeDeviceUtils.kt
-index f99af72..8ae8314 100644
+index f99af72..a1b2c3d 100644
 --- a/node_modules/@onekeyfe/react-native-device-utils/android/src/main/java/com/margelo/nitro/reactnativedeviceutils/ReactNativeDeviceUtils.kt
 +++ b/node_modules/@onekeyfe/react-native-device-utils/android/src/main/java/com/margelo/nitro/reactnativedeviceutils/ReactNativeDeviceUtils.kt
-@@ -220,7 +220,7 @@ class ReactNativeDeviceUtils : HybridReactNativeDeviceUtilsSpec(), LifecycleEven
+@@ -6,6 +6,7 @@ import android.graphics.Color
+ import android.graphics.Rect
+ import android.os.Build
++import android.util.Log
+ import androidx.preference.PreferenceManager
+ import androidx.core.content.ContextCompat
+ import androidx.core.util.Consumer
+@@ -220,7 +221,7 @@ class ReactNativeDeviceUtils : HybridReactNativeDeviceUtilsSpec(), LifecycleEven
    private var layoutInfoConsumer: Consumer<WindowLayoutInfo>? = null
    private var windowInfoTracker: WindowInfoTracker? = null
    private var callbackAdapter: WindowInfoTrackerCallbackAdapter? = null
@@ -11,7 +18,7 @@ index f99af72..8ae8314 100644
    private var isObservingLayoutChanges = false
    private var nextListenerId = 0.0
    private var isDualScreenDeviceDetected: Boolean? = null
-@@ -697,9 +697,19 @@ class ReactNativeDeviceUtils : HybridReactNativeDeviceUtilsSpec(), LifecycleEven
+@@ -697,9 +698,16 @@ class ReactNativeDeviceUtils : HybridReactNativeDeviceUtilsSpec(), LifecycleEven
    }
  
    fun callSpanningChangedListeners(isSpanning: Boolean) {
@@ -21,27 +28,12 @@ index f99af72..8ae8314 100644
 +    // CopyOnWriteArrayList provides snapshot-based iteration that never throws
 +    // ConcurrentModificationException, even if listeners are added/removed during iteration.
 +    // Do NOT call .toList() here as it creates a regular ArrayList that is not thread-safe.
-+    try {
-+      for (listener in spanningChangedListeners) {
-+        try {
-+          listener.callback(isSpanning)
-+        } catch (e: Exception) {
-+          // Ignore individual listener errors to avoid breaking the iteration
-+        }
++    for (listener in spanningChangedListeners) {
++      try {
++        listener.callback(isSpanning)
++      } catch (e: Exception) {
++        Log.e("OneKey", "Error in spanning listener callback", e)
 +      }
-+    } catch (e: Exception) {
-+      // Safety net: catch any unexpected iteration errors
      }
    }
  
-@@ -712,7 +722,9 @@ class ReactNativeDeviceUtils : HybridReactNativeDeviceUtilsSpec(), LifecycleEven
-   }
- 
-     override fun removeSpanningChangedListener(id: Double) {
--        spanningChangedListeners.removeIf { it.id == id }
-+        synchronized(this) {
-+            spanningChangedListeners.removeIf { it.id == id }
-+        }
-     }
- 
-   private fun startObservingLayoutChanges() {


### PR DESCRIPTION
## Summary
- Fixes Sentry issue [REACT-NATIVE-3PB](https://onekey-bb.sentry.io/issues/REACT-NATIVE-3PB) (544 events, 115 users affected)
- Patches `@onekeyfe/react-native-device-utils` to fix a `ConcurrentModificationException` crash in `callSpanningChangedListeners` on Samsung foldable devices (primarily Galaxy Z Flip7 / SM-F7660)
- The root cause: `.toList()` on a `CopyOnWriteArrayList` creates a regular `ArrayList` that lacks thread-safe iteration. When window layout callbacks arrive from the main executor while listeners are being added/removed concurrently, the `ArrayList` iterator detects structural modification and throws `ConcurrentModificationException`

## Changes
- **Iterate `CopyOnWriteArrayList` directly** instead of calling `.toList()` -- `CopyOnWriteArrayList` provides snapshot-based iteration that never throws `ConcurrentModificationException`
- **Declare `spanningChangedListeners` as `val`** with explicit `CopyOnWriteArrayList<Listener>` type to prevent accidental reassignment to a non-thread-safe list
- **Add `synchronized` block** to `removeSpanningChangedListener` for consistency with `addSpanningChangedListener`
- **Add try-catch safety net** around listener callbacks to prevent one failing listener from crashing the app

## Test plan
- [ ] Build and run the Android app on a Samsung foldable device (Galaxy Z Fold/Flip)
- [ ] Open and close the fold repeatedly while navigating through the app
- [ ] Verify no crashes in `callSpanningChangedListeners`
- [ ] Verify spanning state changes are still detected correctly on foldable devices
- [ ] Run a smoke test on a non-foldable Android device to confirm no regressions