### PR TITLE
feat (OK-50452): add horizontal swipe to switch network selector tabs on native

### DIFF
--- a/packages/kit/src/views/ChainSelector/components/UnifiedNetworkSelector/index.tsx
+++ b/packages/kit/src/views/ChainSelector/components/UnifiedNetworkSelector/index.tsx
@@ -1,3 +1,4 @@
+import type { RefObject } from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useRoute } from '@react-navigation/core';
@@ -11,6 +12,7 @@ import {
   Stack,
   YStack,
 } from '@onekeyhq/components';
+import { PagerView } from '@onekeyhq/components/src/composite/Carousel/pager';
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import { useAccountSelectorCreateAddress } from '@onekeyhq/kit/src/components/AccountSelector/hooks/useAccountSelectorCreateAddress';
 import type { IAllNetworkAccountInfo } from '@onekeyhq/kit-bg/src/services/ServiceAllNetwork/ServiceAllNetwork';
@@ -47,6 +49,10 @@ import { TabSwitcher } from './TabSwitcher';
 import type { IServerNetworkMatch } from '../../types';
 import type { ITabType } from './TabSwitcher';
 import type { RouteProp } from '@react-navigation/core';
+import type NativePagerView from 'react-native-pager-view';
+
+const TAB_TO_INDEX: Record<ITabType, number> = { portfolio: 0, network: 1 };
+const INDEX_TO_TAB: ITabType[] = ['portfolio', 'network'];
 
 function UnifiedNetworkSelector() {
   const intl = useIntl();
@@ -178,6 +184,25 @@ function UnifiedNetworkSelector() {
   // Use ref to track activeTab for closures (e.g. onSuccess in navigation)
   const activeTabRef = useRef(activeTab);
   activeTabRef.current = activeTab;
+
+  const pagerRef = useRef<NativePagerView>(null);
+
+  const handleTabChange = useCallback((tab: ITabType) => {
+    setActiveTab(tab);
+    if (platformEnv.isNative) {
+      pagerRef.current?.setPage(TAB_TO_INDEX[tab]);
+    }
+  }, []);
+
+  const handlePageSelected = useCallback(
+    (e: { nativeEvent: { position: number } }) => {
+      const newTab = INDEX_TO_TAB[e.nativeEvent.position];
+      if (newTab && newTab !== activeTabRef.current) {
+        setActiveTab(newTab);
+      }
+    },
+    [],
+  );
 
   // Load networks data for portfolio tab
   const { run: refreshPortfolioData } = usePromiseResult(async () => {
@@ -472,7 +497,7 @@ function UnifiedNetworkSelector() {
   // Header title renderer
   const renderHeaderTitle = useCallback(() => {
     if (showTabSwitcher) {
-      return <TabSwitcher activeTab={activeTab} onTabChange={setActiveTab} />;
+      return <TabSwitcher activeTab={activeTab} onTabChange={handleTabChange} />;
     }
 
     // Show simple title for network-only mode
@@ -488,7 +513,7 @@ function UnifiedNetworkSelector() {
         </SizableText>
       </YStack>
     );
-  }, [showTabSwitcher, activeTab, intl]);
+  }, [showTabSwitcher, activeTab, handleTabChange, intl]);
 
   // Header right button
   const renderHeaderRight = useCallback(
@@ -564,43 +589,114 @@ function UnifiedNetworkSelector() {
       />
       <Page.Body>
         {showTabSwitcher ? (
-          <Stack flex={1} display={activeTab === 'portfolio' ? 'flex' : 'none'}>
-            <PortfolioContent
+          platformEnv.isNative ? (
+            <PagerView
+              ref={pagerRef as RefObject<NativePagerView>}
+              style={{ flex: 1 }}
+              initialPage={TAB_TO_INDEX[initialTab]}
+              onPageSelected={handlePageSelected}
+              keyboardDismissMode="on-drag"
+              pageWidth="100%"
+            >
+              <Stack flex={1}>
+                <PortfolioContent
+                  walletId={walletId}
+                  accountId={accountId}
+                  indexedAccountId={indexedAccountId}
+                  networksState={networksState}
+                  setNetworksState={setNetworksState}
+                  enabledNetworks={enabledNetworks}
+                  searchKey={searchKey}
+                  setSearchKey={setSearchKey}
+                  isCreatingEnabledAddresses={isCreatingEnabledAddresses}
+                  setIsCreatingEnabledAddresses={setIsCreatingEnabledAddresses}
+                  isCreatingMissingAddresses={isCreatingMissingAddresses}
+                  setIsCreatingMissingAddresses={setIsCreatingMissingAddresses}
+                  missingAddressCount={missingAddressCount}
+                  setMissingAddressCount={setMissingAddressCount}
+                  networks={networks}
+                  accountNetworkValues={accountNetworkValues}
+                  accountNetworkValueCurrency={accountNetworkValueCurrency}
+                  accountDeFiOverview={accountDeFiOverview}
+                />
+              </Stack>
+              <Stack flex={1}>
+                <NetworkContent
+                  walletId={walletId}
+                  accountId={accountId}
+                  indexedAccountId={indexedAccountId}
+                  networkId={networkId}
+                  networkIds={networkIds}
+                  onPressItem={handleNetworkPressItem}
+                  onAddCustomNetwork={handleAddCustomNetwork}
+                  onEditCustomNetwork={handleEditCustomNetwork}
+                  searchText={searchKey}
+                  setSearchText={setSearchKey}
+                />
+              </Stack>
+            </PagerView>
+          ) : (
+            <>
+              <Stack
+                flex={1}
+                display={activeTab === 'portfolio' ? 'flex' : 'none'}
+              >
+                <PortfolioContent
+                  walletId={walletId}
+                  accountId={accountId}
+                  indexedAccountId={indexedAccountId}
+                  networksState={networksState}
+                  setNetworksState={setNetworksState}
+                  enabledNetworks={enabledNetworks}
+                  searchKey={searchKey}
+                  setSearchKey={setSearchKey}
+                  isCreatingEnabledAddresses={isCreatingEnabledAddresses}
+                  setIsCreatingEnabledAddresses={setIsCreatingEnabledAddresses}
+                  isCreatingMissingAddresses={isCreatingMissingAddresses}
+                  setIsCreatingMissingAddresses={setIsCreatingMissingAddresses}
+                  missingAddressCount={missingAddressCount}
+                  setMissingAddressCount={setMissingAddressCount}
+                  networks={networks}
+                  accountNetworkValues={accountNetworkValues}
+                  accountNetworkValueCurrency={accountNetworkValueCurrency}
+                  accountDeFiOverview={accountDeFiOverview}
+                />
+              </Stack>
+              <Stack
+                flex={1}
+                display={activeTab === 'network' ? 'flex' : 'none'}
+              >
+                <NetworkContent
+                  walletId={walletId}
+                  accountId={accountId}
+                  indexedAccountId={indexedAccountId}
+                  networkId={networkId}
+                  networkIds={networkIds}
+                  onPressItem={handleNetworkPressItem}
+                  onAddCustomNetwork={handleAddCustomNetwork}
+                  onEditCustomNetwork={handleEditCustomNetwork}
+                  searchText={searchKey}
+                  setSearchText={setSearchKey}
+                />
+              </Stack>
+            </>
+          )
+        ) : (
+          <Stack flex={1}>
+            <NetworkContent
               walletId={walletId}
               accountId={accountId}
               indexedAccountId={indexedAccountId}
-              networksState={networksState}
-              setNetworksState={setNetworksState}
-              enabledNetworks={enabledNetworks}
-              searchKey={searchKey}
-              setSearchKey={setSearchKey}
-              isCreatingEnabledAddresses={isCreatingEnabledAddresses}
-              setIsCreatingEnabledAddresses={setIsCreatingEnabledAddresses}
-              isCreatingMissingAddresses={isCreatingMissingAddresses}
-              setIsCreatingMissingAddresses={setIsCreatingMissingAddresses}
-              missingAddressCount={missingAddressCount}
-              setMissingAddressCount={setMissingAddressCount}
-              networks={networks}
-              accountNetworkValues={accountNetworkValues}
-              accountNetworkValueCurrency={accountNetworkValueCurrency}
-              accountDeFiOverview={accountDeFiOverview}
+              networkId={networkId}
+              networkIds={networkIds}
+              onPressItem={handleNetworkPressItem}
+              onAddCustomNetwork={handleAddCustomNetwork}
+              onEditCustomNetwork={handleEditCustomNetwork}
+              searchText={searchKey}
+              setSearchText={setSearchKey}
             />
           </Stack>
-        ) : null}
-        <Stack flex={1} display={activeTab === 'network' ? 'flex' : 'none'}>
-          <NetworkContent
-            walletId={walletId}
-            accountId={accountId}
-            indexedAccountId={indexedAccountId}
-            networkId={networkId}
-            networkIds={networkIds}
-            onPressItem={handleNetworkPressItem}
-            onAddCustomNetwork={handleAddCustomNetwork}
-            onEditCustomNetwork={handleEditCustomNetwork}
-            searchText={searchKey}
-            setSearchText={setSearchKey}
-          />
-        </Stack>
+        )}
       </Page.Body>
       {activeTab === 'portfolio' && (
         <Page.Footer>

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -335,7 +335,7 @@ export function HomePageView({
       {
         id: EHomeWalletTab.Portfolio,
         name: intl.formatMessage({
-          id: ETranslations.global_crypto,
+          id: ETranslations.dexmarket_spot,
         }),
         component: <PortfolioContainerWithProvider />,
       },

--- a/packages/kit/src/views/Home/pages/TabHeaderSettings.tsx
+++ b/packages/kit/src/views/Home/pages/TabHeaderSettings.tsx
@@ -238,7 +238,7 @@ function BasicTabHeaderSettings({ focusedTab }: { focusedTab: string }) {
   const portfolioName = useMemo(
     () =>
       intl.formatMessage({
-        id: ETranslations.global_crypto,
+        id: ETranslations.dexmarket_spot,
       }),
     [intl],
   );


### PR DESCRIPTION
https://github.com/user-attachments/assets/08d1f8b2-21e1-437f-b0e3-4365fa2921ac

## Summary
- Add `PagerView` to the `UnifiedNetworkSelector` modal on iOS/Android, allowing horizontal swipe gestures to switch between Portfolio and Network tabs
- Bidirectional sync: tapping the SegmentControl animates the pager, swiping updates the SegmentControl
- Web behavior is unchanged (keeps existing `display: flex/none` toggle)

## Test plan
- [ ] iOS/Android: Open network selector modal → swipe left/right → SegmentControl updates
- [ ] iOS/Android: Tap SegmentControl → content animates to correct page
- [ ] Verify footer only shows on Portfolio tab, disappears when swiping to Network
- [ ] When `defaultTab` is `network`, modal opens on Network page
- [ ] Single-tab mode (`showTabSwitcher === false`) shows NetworkContent only, no swipe
- [ ] Web: behavior unchanged, no swipe, display toggle works as before
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
