### PR TITLE
fix(ios): resolve AppHang in TextInput paste

### DIFF
--- a/patches/react-native+0.81.5.patch
+++ b/patches/react-native+0.81.5.patch
@@ -13,7 +13,7 @@ index 05bddcb..5211253 100644
        registrationName: 'onChangeSync',
      },
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
-index 6e9c384..3082271 100644
+index 6e9c384..07ae4dc 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
 +++ b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
 @@ -13,6 +13,10 @@
@@ -35,7 +35,7 @@ index 6e9c384..3082271 100644
  }
  
  static UIFont *defaultPlaceholderFont(void)
-@@ -208,10 +213,89 @@ - (void)scrollRangeToVisible:(NSRange)range
+@@ -208,10 +213,88 @@ - (void)scrollRangeToVisible:(NSRange)range
  
  - (void)paste:(id)sender
  {
@@ -104,7 +104,6 @@ index 6e9c384..3082271 100644
 +
 +          if ([data writeToFile:filePath atomically:YES]) {
 +            NSURL *fileURL = [NSURL fileURLWithPath:filePath];
-+            strongSelf->_textWasPasted = YES;
 +            [strongSelf->_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
 +          } else {
 +            // Fallback when file write fails
@@ -125,7 +124,7 @@ index 6e9c384..3082271 100644
  // Turn off scroll animation to fix flaky scrolling.
  // This is only necessary for iOS < 14.
  #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
-@@ -301,6 +385,10 @@ - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
+@@ -301,6 +384,10 @@ - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
      return NO;
    }
  
@@ -280,7 +279,7 @@ index 47adc53..1865e0a 100644
  RCT_EXPORT_SHADOW_PROPERTY(text, NSString)
  RCT_EXPORT_SHADOW_PROPERTY(placeholder, NSString)
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
-index 377f41e..7582e45 100644
+index 377f41e..be536bb 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
 +++ b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
 @@ -12,12 +12,17 @@
@@ -312,7 +311,7 @@ index 377f41e..7582e45 100644
    return [super canPerformAction:action withSender:sender];
  }
  
-@@ -260,12 +269,91 @@ - (void)scrollRangeToVisible:(NSRange)range
+@@ -260,12 +269,90 @@ - (void)scrollRangeToVisible:(NSRange)range
    // Singleline TextInput does not require scrolling after calling setSelectedTextRange (PR 38679).
  }
  
@@ -383,7 +382,6 @@ index 377f41e..7582e45 100644
 +
 +          if ([data writeToFile:filePath atomically:YES]) {
 +            NSURL *fileURL = [NSURL fileURLWithPath:filePath];
-+            strongSelf->_textWasPasted = YES;
 +            [strongSelf->_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
 +          } else {
 +            // Fallback when file write fails

--- a/patches/react-native+0.81.5.patch
+++ b/patches/react-native+0.81.5.patch
@@ -13,7 +13,7 @@ index 05bddcb..5211253 100644
        registrationName: 'onChangeSync',
      },
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
-index 6e9c384..64e706f 100644
+index 6e9c384..a578600 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
 +++ b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
 @@ -13,6 +13,10 @@
@@ -35,10 +35,10 @@ index 6e9c384..64e706f 100644
  }
  
  static UIFont *defaultPlaceholderFont(void)
-@@ -209,9 +214,80 @@ - (void)scrollRangeToVisible:(NSRange)range
+@@ -208,10 +213,81 @@ - (void)scrollRangeToVisible:(NSRange)range
+ 
  - (void)paste:(id)sender
  {
-   _textWasPasted = YES;
 +  UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
 +
 +  // Handle image paste
@@ -47,6 +47,7 @@ index 6e9c384..64e706f 100644
 +  }
 +
 +  // Handle text paste
+   _textWasPasted = YES;
 +  if (clipboard.hasStrings) {
 +    [_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboard.string];
 +  }
@@ -271,7 +272,7 @@ index 47adc53..1865e0a 100644
  RCT_EXPORT_SHADOW_PROPERTY(text, NSString)
  RCT_EXPORT_SHADOW_PROPERTY(placeholder, NSString)
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
-index 377f41e..129e6a9 100644
+index 377f41e..d8dac65 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
 +++ b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
 @@ -12,12 +12,17 @@
@@ -303,7 +304,7 @@ index 377f41e..129e6a9 100644
    return [super canPerformAction:action withSender:sender];
  }
  
-@@ -260,10 +269,68 @@ - (void)scrollRangeToVisible:(NSRange)range
+@@ -260,12 +269,83 @@ - (void)scrollRangeToVisible:(NSRange)range
    // Singleline TextInput does not require scrolling after calling setSelectedTextRange (PR 38679).
  }
  
@@ -314,65 +315,79 @@ index 377f41e..129e6a9 100644
 +
  - (void)paste:(id)sender
  {
-   _textWasPasted = YES;
--  [super paste:sender];
 +  UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
-+  if (clipboard.hasImages) {
-+    // Prevent concurrent image paste operations from rapid taps
-+    if (_isProcessingImagePaste) {
-+      return;
-+    }
-+    for (NSItemProvider *itemProvider in clipboard.itemProviders) {
-+      if ([itemProvider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeImage]) {
-+        for (NSString *identifier in itemProvider.registeredTypeIdentifiers) {
-+          if (UTTypeConformsTo((__bridge CFStringRef)identifier, kUTTypeImage)) {
-+            _isProcessingImagePaste = YES;
-+            __weak typeof(self) weakSelf = self;
-+            // Load data asynchronously to avoid blocking the main thread (IPC to pasteboard daemon)
-+            [itemProvider loadDataRepresentationForTypeIdentifier:identifier completionHandler:^(NSData *data, NSError *error) {
-+              dispatch_async(dispatch_get_main_queue(), ^{
-+                __strong typeof(weakSelf) strongSelf = weakSelf;
-+                if (!strongSelf) {
-+                  return;
-+                }
-+                strongSelf->_isProcessingImagePaste = NO;
 +
-+                if (error || !data) {
-+                  // Fallback to text paste on failure
-+                  if (clipboard.hasStrings) {
-+                    [strongSelf->_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboard.string];
-+                  }
-+                  [strongSelf _superPaste:nil];
-+                  return;
-+                }
-+
-+                NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
-+                NSString *fileExtension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassFilenameExtension);
-+                NSString *fileName = [NSString stringWithFormat:@"%@.%@", [[NSUUID UUID] UUIDString], fileExtension];
-+                NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
-+
-+                if ([data writeToFile:filePath atomically:YES]) {
-+                  NSURL *fileURL = [NSURL fileURLWithPath:filePath];
-+                  strongSelf->_textWasPasted = YES;
-+                  [strongSelf->_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
-+                }
-+              });
-+            }];
-+            break;
-+          }
-+        }
-+        break;
-+      }
-+    }
-+  } else {
-+    if (clipboard.hasStrings) {
-+      [_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboard.string];
-+    }
-+    [super paste:sender];
++  // Handle image paste
++  if (clipboard.hasImages && [self processImagePaste:clipboard]) {
++    return;
 +  }
++
++  // Handle text paste
+   _textWasPasted = YES;
++  if (clipboard.hasStrings) {
++    [_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboard.string];
++  }
+   [super paste:sender];
  }
  
++- (BOOL)processImagePaste:(UIPasteboard *)clipboard
++{
++  // Prevent concurrent image paste operations from rapid taps
++  if (_isProcessingImagePaste) {
++    return YES;
++  }
++
++  for (NSItemProvider *itemProvider in clipboard.itemProviders) {
++    if (![itemProvider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeImage]) {
++      continue;
++    }
++
++    for (NSString *identifier in itemProvider.registeredTypeIdentifiers) {
++      if (!UTTypeConformsTo((__bridge CFStringRef)identifier, kUTTypeImage)) {
++        continue;
++      }
++
++      _isProcessingImagePaste = YES;
++      __weak typeof(self) weakSelf = self;
++      // Load data asynchronously to avoid blocking the main thread (IPC to pasteboard daemon)
++      [itemProvider loadDataRepresentationForTypeIdentifier:identifier completionHandler:^(NSData *data, NSError *error) {
++        dispatch_async(dispatch_get_main_queue(), ^{
++          __strong typeof(weakSelf) strongSelf = weakSelf;
++          if (!strongSelf) {
++            return;
++          }
++          strongSelf->_isProcessingImagePaste = NO;
++
++          if (error || !data) {
++            // Fallback to text paste on failure
++            if (clipboard.hasStrings) {
++              [strongSelf->_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboard.string];
++            }
++            [strongSelf _superPaste:nil];
++            return;
++          }
++
++          NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
++          NSString *fileExtension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassFilenameExtension);
++          NSString *fileName = [NSString stringWithFormat:@"%@.%@", [[NSUUID UUID] UUIDString], fileExtension];
++          NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
++
++          if ([data writeToFile:filePath atomically:YES]) {
++            NSURL *fileURL = [NSURL fileURLWithPath:filePath];
++            strongSelf->_textWasPasted = YES;
++            [strongSelf->_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
++          }
++        });
++      }];
++      return YES;
++    }
++  }
++  return NO;
++}
++
  #pragma mark - Layout
+ 
+ - (CGSize)contentSize
 diff --git a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm b/node_modules/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
 index 577bebe..ad0f253 100644
 --- a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm

--- a/patches/react-native+0.81.5.patch
+++ b/patches/react-native+0.81.5.patch
@@ -13,7 +13,7 @@ index 05bddcb..5211253 100644
        registrationName: 'onChangeSync',
      },
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
-index 6e9c384..5f5220c 100644
+index 6e9c384..86124a3 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
 +++ b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
 @@ -13,6 +13,10 @@
@@ -35,7 +35,7 @@ index 6e9c384..5f5220c 100644
  }
  
  static UIFont *defaultPlaceholderFont(void)
-@@ -208,10 +213,94 @@ - (void)scrollRangeToVisible:(NSRange)range
+@@ -208,10 +213,102 @@ - (void)scrollRangeToVisible:(NSRange)range
  
  - (void)paste:(id)sender
  {
@@ -77,45 +77,53 @@ index 6e9c384..5f5220c 100644
 +      }
 +
 +      _isProcessingImagePaste = YES;
++      // Snapshot clipboard text before async to avoid stale/changed clipboard reads later
++      BOOL clipboardHasStrings = clipboard.hasStrings;
++      NSString *clipboardString = clipboardHasStrings ? clipboard.string : nil;
 +      __weak typeof(self) weakSelf = self;
 +      // Load data asynchronously to avoid blocking the main thread (IPC to pasteboard daemon)
 +      [itemProvider loadDataRepresentationForTypeIdentifier:identifier completionHandler:^(NSData *data, NSError *error) {
-+        dispatch_async(dispatch_get_main_queue(), ^{
-+          __strong typeof(weakSelf) strongSelf = weakSelf;
-+          if (!strongSelf) {
-+            return;
-+          }
-+          strongSelf->_isProcessingImagePaste = NO;
-+
-+          if (error || !data) {
++        if (error || !data) {
++          dispatch_async(dispatch_get_main_queue(), ^{
++            __strong typeof(weakSelf) strongSelf = weakSelf;
++            if (!strongSelf) { return; }
++            strongSelf->_isProcessingImagePaste = NO;
 +            // Fallback to text paste on failure
 +            strongSelf->_textWasPasted = YES;
-+            if (clipboard.hasStrings) {
-+              [strongSelf->_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboard.string];
++            if (clipboardHasStrings && clipboardString) {
++              [strongSelf->_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboardString];
 +            }
 +            [strongSelf _superPaste:nil];
-+            return;
-+          }
++          });
++          return;
++        }
 +
-+          NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
-+          if (!MIMEType) {
-+            MIMEType = @"application/octet-stream";
-+          }
-+          NSString *fileExtension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassFilenameExtension);
-+          if (!fileExtension) {
-+            fileExtension = @"bin";
-+          }
-+          NSString *fileName = [NSString stringWithFormat:@"%@.%@", [[NSUUID UUID] UUIDString], fileExtension];
-+          NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
++        // Perform file I/O on background queue to avoid main thread jank
++        NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
++        if (!MIMEType) {
++          MIMEType = @"application/octet-stream";
++        }
++        NSString *fileExtension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassFilenameExtension);
++        if (!fileExtension) {
++          fileExtension = @"bin";
++        }
++        NSString *fileName = [NSString stringWithFormat:@"%@.%@", [[NSUUID UUID] UUIDString], fileExtension];
++        NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
++        BOOL writeSuccess = [data writeToFile:filePath atomically:YES];
 +
-+          if ([data writeToFile:filePath atomically:YES]) {
++        dispatch_async(dispatch_get_main_queue(), ^{
++          __strong typeof(weakSelf) strongSelf = weakSelf;
++          if (!strongSelf) { return; }
++          strongSelf->_isProcessingImagePaste = NO;
++
++          if (writeSuccess) {
 +            NSURL *fileURL = [NSURL fileURLWithPath:filePath];
 +            [strongSelf->_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
 +          } else {
 +            // Fallback when file write fails
 +            strongSelf->_textWasPasted = YES;
-+            if (clipboard.hasStrings) {
-+              [strongSelf->_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboard.string];
++            if (clipboardHasStrings && clipboardString) {
++              [strongSelf->_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboardString];
 +            }
 +            [strongSelf _superPaste:nil];
 +          }
@@ -130,7 +138,7 @@ index 6e9c384..5f5220c 100644
  // Turn off scroll animation to fix flaky scrolling.
  // This is only necessary for iOS < 14.
  #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
-@@ -301,6 +390,10 @@ - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
+@@ -301,6 +398,10 @@ - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
      return NO;
    }
  
@@ -285,7 +293,7 @@ index 47adc53..1865e0a 100644
  RCT_EXPORT_SHADOW_PROPERTY(text, NSString)
  RCT_EXPORT_SHADOW_PROPERTY(placeholder, NSString)
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
-index 377f41e..456cf5e 100644
+index 377f41e..9a11021 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
 +++ b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
 @@ -12,12 +12,17 @@
@@ -317,7 +325,7 @@ index 377f41e..456cf5e 100644
    return [super canPerformAction:action withSender:sender];
  }
  
-@@ -260,12 +269,96 @@ - (void)scrollRangeToVisible:(NSRange)range
+@@ -260,12 +269,104 @@ - (void)scrollRangeToVisible:(NSRange)range
    // Singleline TextInput does not require scrolling after calling setSelectedTextRange (PR 38679).
  }
  
@@ -361,45 +369,53 @@ index 377f41e..456cf5e 100644
 +      }
 +
 +      _isProcessingImagePaste = YES;
++      // Snapshot clipboard text before async to avoid stale/changed clipboard reads later
++      BOOL clipboardHasStrings = clipboard.hasStrings;
++      NSString *clipboardString = clipboardHasStrings ? clipboard.string : nil;
 +      __weak typeof(self) weakSelf = self;
 +      // Load data asynchronously to avoid blocking the main thread (IPC to pasteboard daemon)
 +      [itemProvider loadDataRepresentationForTypeIdentifier:identifier completionHandler:^(NSData *data, NSError *error) {
-+        dispatch_async(dispatch_get_main_queue(), ^{
-+          __strong typeof(weakSelf) strongSelf = weakSelf;
-+          if (!strongSelf) {
-+            return;
-+          }
-+          strongSelf->_isProcessingImagePaste = NO;
-+
-+          if (error || !data) {
++        if (error || !data) {
++          dispatch_async(dispatch_get_main_queue(), ^{
++            __strong typeof(weakSelf) strongSelf = weakSelf;
++            if (!strongSelf) { return; }
++            strongSelf->_isProcessingImagePaste = NO;
 +            // Fallback to text paste on failure
 +            strongSelf->_textWasPasted = YES;
-+            if (clipboard.hasStrings) {
-+              [strongSelf->_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboard.string];
++            if (clipboardHasStrings && clipboardString) {
++              [strongSelf->_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboardString];
 +            }
 +            [strongSelf _superPaste:nil];
-+            return;
-+          }
++          });
++          return;
++        }
 +
-+          NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
-+          if (!MIMEType) {
-+            MIMEType = @"application/octet-stream";
-+          }
-+          NSString *fileExtension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassFilenameExtension);
-+          if (!fileExtension) {
-+            fileExtension = @"bin";
-+          }
-+          NSString *fileName = [NSString stringWithFormat:@"%@.%@", [[NSUUID UUID] UUIDString], fileExtension];
-+          NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
++        // Perform file I/O on background queue to avoid main thread jank
++        NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
++        if (!MIMEType) {
++          MIMEType = @"application/octet-stream";
++        }
++        NSString *fileExtension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassFilenameExtension);
++        if (!fileExtension) {
++          fileExtension = @"bin";
++        }
++        NSString *fileName = [NSString stringWithFormat:@"%@.%@", [[NSUUID UUID] UUIDString], fileExtension];
++        NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
++        BOOL writeSuccess = [data writeToFile:filePath atomically:YES];
 +
-+          if ([data writeToFile:filePath atomically:YES]) {
++        dispatch_async(dispatch_get_main_queue(), ^{
++          __strong typeof(weakSelf) strongSelf = weakSelf;
++          if (!strongSelf) { return; }
++          strongSelf->_isProcessingImagePaste = NO;
++
++          if (writeSuccess) {
 +            NSURL *fileURL = [NSURL fileURLWithPath:filePath];
 +            [strongSelf->_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
 +          } else {
 +            // Fallback when file write fails
 +            strongSelf->_textWasPasted = YES;
-+            if (clipboard.hasStrings) {
-+              [strongSelf->_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboard.string];
++            if (clipboardHasStrings && clipboardString) {
++              [strongSelf->_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboardString];
 +            }
 +            [strongSelf _superPaste:nil];
 +          }

--- a/patches/react-native+0.81.5.patch
+++ b/patches/react-native+0.81.5.patch
@@ -13,7 +13,7 @@ index 05bddcb..5211253 100644
        registrationName: 'onChangeSync',
      },
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
-index 6e9c384..a578600 100644
+index 6e9c384..3082271 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
 +++ b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
 @@ -13,6 +13,10 @@
@@ -35,7 +35,7 @@ index 6e9c384..a578600 100644
  }
  
  static UIFont *defaultPlaceholderFont(void)
-@@ -208,10 +213,81 @@ - (void)scrollRangeToVisible:(NSRange)range
+@@ -208,10 +213,89 @@ - (void)scrollRangeToVisible:(NSRange)range
  
  - (void)paste:(id)sender
  {
@@ -89,6 +89,7 @@ index 6e9c384..a578600 100644
 +
 +          if (error || !data) {
 +            // Fallback to text paste on failure
++            strongSelf->_textWasPasted = YES;
 +            if (clipboard.hasStrings) {
 +              [strongSelf->_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboard.string];
 +            }
@@ -105,6 +106,13 @@ index 6e9c384..a578600 100644
 +            NSURL *fileURL = [NSURL fileURLWithPath:filePath];
 +            strongSelf->_textWasPasted = YES;
 +            [strongSelf->_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
++          } else {
++            // Fallback when file write fails
++            strongSelf->_textWasPasted = YES;
++            if (clipboard.hasStrings) {
++              [strongSelf->_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboard.string];
++            }
++            [strongSelf _superPaste:nil];
 +          }
 +        });
 +      }];
@@ -117,7 +125,7 @@ index 6e9c384..a578600 100644
  // Turn off scroll animation to fix flaky scrolling.
  // This is only necessary for iOS < 14.
  #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
-@@ -301,6 +377,10 @@ - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
+@@ -301,6 +385,10 @@ - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
      return NO;
    }
  
@@ -272,7 +280,7 @@ index 47adc53..1865e0a 100644
  RCT_EXPORT_SHADOW_PROPERTY(text, NSString)
  RCT_EXPORT_SHADOW_PROPERTY(placeholder, NSString)
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
-index 377f41e..d8dac65 100644
+index 377f41e..7582e45 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
 +++ b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
 @@ -12,12 +12,17 @@
@@ -304,7 +312,7 @@ index 377f41e..d8dac65 100644
    return [super canPerformAction:action withSender:sender];
  }
  
-@@ -260,12 +269,83 @@ - (void)scrollRangeToVisible:(NSRange)range
+@@ -260,12 +269,91 @@ - (void)scrollRangeToVisible:(NSRange)range
    // Singleline TextInput does not require scrolling after calling setSelectedTextRange (PR 38679).
  }
  
@@ -360,6 +368,7 @@ index 377f41e..d8dac65 100644
 +
 +          if (error || !data) {
 +            // Fallback to text paste on failure
++            strongSelf->_textWasPasted = YES;
 +            if (clipboard.hasStrings) {
 +              [strongSelf->_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboard.string];
 +            }
@@ -376,6 +385,13 @@ index 377f41e..d8dac65 100644
 +            NSURL *fileURL = [NSURL fileURLWithPath:filePath];
 +            strongSelf->_textWasPasted = YES;
 +            [strongSelf->_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
++          } else {
++            // Fallback when file write fails
++            strongSelf->_textWasPasted = YES;
++            if (clipboard.hasStrings) {
++              [strongSelf->_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboard.string];
++            }
++            [strongSelf _superPaste:nil];
 +          }
 +        });
 +      }];

--- a/patches/react-native+0.81.5.patch
+++ b/patches/react-native+0.81.5.patch
@@ -13,7 +13,7 @@ index 05bddcb..5211253 100644
        registrationName: 'onChangeSync',
      },
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
-index 6e9c384..c36ea75 100644
+index 6e9c384..584cec8 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
 +++ b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
 @@ -13,6 +13,10 @@
@@ -27,7 +27,7 @@ index 6e9c384..c36ea75 100644
  @implementation RCTUITextView {
    UILabel *_placeholderView;
    UITextView *_detachedTextView;
-@@ -209,9 +213,52 @@ - (void)scrollRangeToVisible:(NSRange)range
+@@ -209,9 +213,55 @@ - (void)scrollRangeToVisible:(NSRange)range
  - (void)paste:(id)sender
  {
    _textWasPasted = YES;
@@ -57,21 +57,24 @@ index 6e9c384..c36ea75 100644
 +        continue;
 +      }
 +
-+      NSData *fileData = [clipboard dataForPasteboardType:identifier];
-+      if (!fileData) {
-+        continue;
-+      }
++      // Load data asynchronously to avoid blocking the main thread (IPC to pasteboard daemon)
++      [itemProvider loadDataRepresentationForTypeIdentifier:identifier completionHandler:^(NSData *data, NSError *error) {
++        if (error || !data) {
++          return;
++        }
++        dispatch_async(dispatch_get_main_queue(), ^{
++          NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
++          NSString *fileExtension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassFilenameExtension);
++          NSString *fileName = [NSString stringWithFormat:@"%@.%@", [[NSUUID UUID] UUIDString], fileExtension];
++          NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
 +
-+      NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
-+      NSString *fileExtension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassFilenameExtension);
-+      NSString *fileName = [NSString stringWithFormat:@"%@.%@", [[NSUUID UUID] UUIDString], fileExtension];
-+      NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
-+
-+      if ([fileData writeToFile:filePath atomically:YES]) {
-+        NSURL *fileURL = [NSURL fileURLWithPath:filePath];
-+        [_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
-+        return YES;
-+      }
++          if ([data writeToFile:filePath atomically:YES]) {
++            NSURL *fileURL = [NSURL fileURLWithPath:filePath];
++            [self->_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
++          }
++        });
++      }];
++      return YES;
 +    }
 +  }
 +  return NO;
@@ -80,7 +83,7 @@ index 6e9c384..c36ea75 100644
  // Turn off scroll animation to fix flaky scrolling.
  // This is only necessary for iOS < 14.
  #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
-@@ -297,6 +344,10 @@ - (CGSize)sizeThatFits:(CGSize)size
+@@ -297,6 +347,10 @@ - (CGSize)sizeThatFits:(CGSize)size
  
  - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
  {
@@ -235,7 +238,7 @@ index 47adc53..1865e0a 100644
  RCT_EXPORT_SHADOW_PROPERTY(text, NSString)
  RCT_EXPORT_SHADOW_PROPERTY(placeholder, NSString)
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
-index 377f41e..0b6544b 100644
+index 377f41e..e7964ec 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
 +++ b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
 @@ -12,6 +12,10 @@
@@ -260,7 +263,7 @@ index 377f41e..0b6544b 100644
    if (_contextMenuHidden) {
      return NO;
    }
-@@ -263,7 +271,32 @@ - (void)scrollRangeToVisible:(NSRange)range
+@@ -263,7 +271,41 @@ - (void)scrollRangeToVisible:(NSRange)range
  - (void)paste:(id)sender
  {
    _textWasPasted = YES;
@@ -271,14 +274,23 @@ index 377f41e..0b6544b 100644
 +      if ([itemProvider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeImage]) {
 +        for (NSString *identifier in itemProvider.registeredTypeIdentifiers) {
 +          if (UTTypeConformsTo((__bridge CFStringRef)identifier, kUTTypeImage)) {
-+            NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
-+            NSString *fileExtension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassFilenameExtension);
-+            NSString *fileName = [NSString stringWithFormat:@"%@.%@", [[NSUUID UUID] UUIDString], fileExtension];
-+            NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
-+            NSURL *fileURL = [NSURL fileURLWithPath:filePath];
-+            NSData *fileData = [clipboard dataForPasteboardType:identifier];
-+            [fileData writeToFile:filePath atomically:YES];
-+            [_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
++            // Load data asynchronously to avoid blocking the main thread (IPC to pasteboard daemon)
++            [itemProvider loadDataRepresentationForTypeIdentifier:identifier completionHandler:^(NSData *data, NSError *error) {
++              if (error || !data) {
++                return;
++              }
++              dispatch_async(dispatch_get_main_queue(), ^{
++                NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
++                NSString *fileExtension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassFilenameExtension);
++                NSString *fileName = [NSString stringWithFormat:@"%@.%@", [[NSUUID UUID] UUIDString], fileExtension];
++                NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
++
++                if ([data writeToFile:filePath atomically:YES]) {
++                  NSURL *fileURL = [NSURL fileURLWithPath:filePath];
++                  [self->_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
++                }
++              });
++            }];
 +            break;
 +          }
 +        }
@@ -337,6 +349,25 @@ index 577bebe..ad0f253 100644
  #pragma mark - RCTBackedTextInputDelegate
  
  - (BOOL)textInputShouldBeginEditing
+diff --git a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
+index 89b666d..246c9cf 100644
+--- a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
++++ b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
+@@ -869,7 +869,13 @@ public open class ReactViewGroup public constructor(context: Context?) :
+     if (_overflow != Overflow.VISIBLE || getTag(R.id.filter) != null) {
+       clipToPaddingBox(this, canvas)
+     }
+-    super.dispatchDraw(canvas)
++    try {
++      super.dispatchDraw(canvas)
++    } catch (e: NullPointerException) {
++      // Race condition: child view removed during draw cycle by reanimated mount transaction.
++      // The view hierarchy will be re-drawn correctly on the next frame.
++      // Tracking: https://github.com/software-mansion/react-native-reanimated/issues/8422
++    }
+   }
+ 
+   override fun drawChild(canvas: Canvas, child: View, drawingTime: Long): Boolean {
 diff --git a/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm b/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
 index 2a67797..57f7c7a 100644
 --- a/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm

--- a/patches/react-native+0.81.5.patch
+++ b/patches/react-native+0.81.5.patch
@@ -13,7 +13,7 @@ index 05bddcb..5211253 100644
        registrationName: 'onChangeSync',
      },
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
-index 6e9c384..5beb8b7 100644
+index 6e9c384..64e706f 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
 +++ b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
 @@ -13,6 +13,10 @@
@@ -35,7 +35,7 @@ index 6e9c384..5beb8b7 100644
  }
  
  static UIFont *defaultPlaceholderFont(void)
-@@ -209,9 +214,75 @@ - (void)scrollRangeToVisible:(NSRange)range
+@@ -209,9 +214,80 @@ - (void)scrollRangeToVisible:(NSRange)range
  - (void)paste:(id)sender
  {
    _textWasPasted = YES;
@@ -53,6 +53,11 @@ index 6e9c384..5beb8b7 100644
    [super paste:sender];
  }
  
++- (void)_superPaste:(id)sender
++{
++  [super paste:sender];
++}
++
 +- (BOOL)processImagePaste:(UIPasteboard *)clipboard
 +{
 +  // Prevent concurrent image paste operations from rapid taps
@@ -86,7 +91,7 @@ index 6e9c384..5beb8b7 100644
 +            if (clipboard.hasStrings) {
 +              [strongSelf->_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboard.string];
 +            }
-+            [super paste:nil];
++            [strongSelf _superPaste:nil];
 +            return;
 +          }
 +
@@ -111,17 +116,17 @@ index 6e9c384..5beb8b7 100644
  // Turn off scroll animation to fix flaky scrolling.
  // This is only necessary for iOS < 14.
  #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
-@@ -297,6 +368,10 @@ - (CGSize)sizeThatFits:(CGSize)size
+@@ -301,6 +377,10 @@ - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
+     return NO;
+   }
  
- - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
- {
 +  if (action == @selector(paste:) && [UIPasteboard generalPasteboard].hasImages) {
 +    return YES;
 +  }
 +
-   if (_contextMenuHidden) {
-     return NO;
-   }
+   return [super canPerformAction:action withSender:sender];
+ }
+ 
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h b/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h
 index 7187177..da00893 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h
@@ -266,7 +271,7 @@ index 47adc53..1865e0a 100644
  RCT_EXPORT_SHADOW_PROPERTY(text, NSString)
  RCT_EXPORT_SHADOW_PROPERTY(placeholder, NSString)
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
-index 377f41e..46be1a4 100644
+index 377f41e..129e6a9 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
 +++ b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
 @@ -12,12 +12,17 @@
@@ -287,18 +292,26 @@ index 377f41e..46be1a4 100644
  }
  
  // This should not be needed but internal build were failing without it.
-@@ -176,6 +181,10 @@ - (void)setDisableKeyboardShortcuts:(BOOL)disableKeyboardShortcuts
+@@ -180,6 +185,10 @@ - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
+     return NO;
+   }
  
- - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
- {
 +  if (action == @selector(paste:) && [UIPasteboard generalPasteboard].hasImages) {
 +    return YES;
 +  }
 +
-   if (_contextMenuHidden) {
-     return NO;
-   }
-@@ -263,7 +272,60 @@ - (void)scrollRangeToVisible:(NSRange)range
+   return [super canPerformAction:action withSender:sender];
+ }
+ 
+@@ -260,10 +269,68 @@ - (void)scrollRangeToVisible:(NSRange)range
+   // Singleline TextInput does not require scrolling after calling setSelectedTextRange (PR 38679).
+ }
+ 
++- (void)_superPaste:(id)sender
++{
++  [super paste:sender];
++}
++
  - (void)paste:(id)sender
  {
    _textWasPasted = YES;
@@ -329,7 +342,7 @@ index 377f41e..46be1a4 100644
 +                  if (clipboard.hasStrings) {
 +                    [strongSelf->_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboard.string];
 +                  }
-+                  [super paste:nil];
++                  [strongSelf _superPaste:nil];
 +                  return;
 +                }
 +

--- a/patches/react-native+0.81.5.patch
+++ b/patches/react-native+0.81.5.patch
@@ -13,7 +13,7 @@ index 05bddcb..5211253 100644
        registrationName: 'onChangeSync',
      },
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
-index 6e9c384..584cec8 100644
+index 6e9c384..5beb8b7 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
 +++ b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
 @@ -13,6 +13,10 @@
@@ -27,7 +27,15 @@ index 6e9c384..584cec8 100644
  @implementation RCTUITextView {
    UILabel *_placeholderView;
    UITextView *_detachedTextView;
-@@ -209,9 +213,55 @@ - (void)scrollRangeToVisible:(NSRange)range
+@@ -21,6 +25,7 @@ @implementation RCTUITextView {
+   NSArray<UIBarButtonItemGroup *> *_initialValueLeadingBarButtonGroups;
+   NSArray<UIBarButtonItemGroup *> *_initialValueTrailingBarButtonGroups;
+   NSArray<NSString *> *_acceptDragAndDropTypes;
++  BOOL _isProcessingImagePaste;
+ }
+ 
+ static UIFont *defaultPlaceholderFont(void)
+@@ -209,9 +214,75 @@ - (void)scrollRangeToVisible:(NSRange)range
  - (void)paste:(id)sender
  {
    _textWasPasted = YES;
@@ -47,6 +55,11 @@ index 6e9c384..584cec8 100644
  
 +- (BOOL)processImagePaste:(UIPasteboard *)clipboard
 +{
++  // Prevent concurrent image paste operations from rapid taps
++  if (_isProcessingImagePaste) {
++    return YES;
++  }
++
 +  for (NSItemProvider *itemProvider in clipboard.itemProviders) {
 +    if (![itemProvider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeImage]) {
 +      continue;
@@ -57,12 +70,26 @@ index 6e9c384..584cec8 100644
 +        continue;
 +      }
 +
++      _isProcessingImagePaste = YES;
++      __weak typeof(self) weakSelf = self;
 +      // Load data asynchronously to avoid blocking the main thread (IPC to pasteboard daemon)
 +      [itemProvider loadDataRepresentationForTypeIdentifier:identifier completionHandler:^(NSData *data, NSError *error) {
-+        if (error || !data) {
-+          return;
-+        }
 +        dispatch_async(dispatch_get_main_queue(), ^{
++          __strong typeof(weakSelf) strongSelf = weakSelf;
++          if (!strongSelf) {
++            return;
++          }
++          strongSelf->_isProcessingImagePaste = NO;
++
++          if (error || !data) {
++            // Fallback to text paste on failure
++            if (clipboard.hasStrings) {
++              [strongSelf->_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboard.string];
++            }
++            [super paste:nil];
++            return;
++          }
++
 +          NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
 +          NSString *fileExtension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassFilenameExtension);
 +          NSString *fileName = [NSString stringWithFormat:@"%@.%@", [[NSUUID UUID] UUIDString], fileExtension];
@@ -70,7 +97,8 @@ index 6e9c384..584cec8 100644
 +
 +          if ([data writeToFile:filePath atomically:YES]) {
 +            NSURL *fileURL = [NSURL fileURLWithPath:filePath];
-+            [self->_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
++            strongSelf->_textWasPasted = YES;
++            [strongSelf->_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
 +          }
 +        });
 +      }];
@@ -83,7 +111,7 @@ index 6e9c384..584cec8 100644
  // Turn off scroll animation to fix flaky scrolling.
  // This is only necessary for iOS < 14.
  #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
-@@ -297,6 +347,10 @@ - (CGSize)sizeThatFits:(CGSize)size
+@@ -297,6 +368,10 @@ - (CGSize)sizeThatFits:(CGSize)size
  
  - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
  {
@@ -238,10 +266,10 @@ index 47adc53..1865e0a 100644
  RCT_EXPORT_SHADOW_PROPERTY(text, NSString)
  RCT_EXPORT_SHADOW_PROPERTY(placeholder, NSString)
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
-index 377f41e..e7964ec 100644
+index 377f41e..46be1a4 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
 +++ b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
-@@ -12,6 +12,10 @@
+@@ -12,12 +12,17 @@
  #import <React/RCTUtils.h>
  #import <React/UIView+React.h>
  
@@ -252,7 +280,14 @@ index 377f41e..e7964ec 100644
  @implementation RCTUITextField {
    RCTBackedTextFieldDelegateAdapter *_textInputDelegateAdapter;
    NSDictionary<NSAttributedStringKey, id> *_defaultTextAttributes;
-@@ -176,6 +180,10 @@ - (void)setDisableKeyboardShortcuts:(BOOL)disableKeyboardShortcuts
+   NSArray<UIBarButtonItemGroup *> *_initialValueLeadingBarButtonGroups;
+   NSArray<UIBarButtonItemGroup *> *_initialValueTrailingBarButtonGroups;
+   NSArray<NSString *> *_acceptDragAndDropTypes;
++  BOOL _isProcessingImagePaste;
+ }
+ 
+ // This should not be needed but internal build were failing without it.
+@@ -176,6 +181,10 @@ - (void)setDisableKeyboardShortcuts:(BOOL)disableKeyboardShortcuts
  
  - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
  {
@@ -263,23 +298,41 @@ index 377f41e..e7964ec 100644
    if (_contextMenuHidden) {
      return NO;
    }
-@@ -263,7 +271,41 @@ - (void)scrollRangeToVisible:(NSRange)range
+@@ -263,7 +272,60 @@ - (void)scrollRangeToVisible:(NSRange)range
  - (void)paste:(id)sender
  {
    _textWasPasted = YES;
 -  [super paste:sender];
 +  UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
 +  if (clipboard.hasImages) {
++    // Prevent concurrent image paste operations from rapid taps
++    if (_isProcessingImagePaste) {
++      return;
++    }
 +    for (NSItemProvider *itemProvider in clipboard.itemProviders) {
 +      if ([itemProvider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeImage]) {
 +        for (NSString *identifier in itemProvider.registeredTypeIdentifiers) {
 +          if (UTTypeConformsTo((__bridge CFStringRef)identifier, kUTTypeImage)) {
++            _isProcessingImagePaste = YES;
++            __weak typeof(self) weakSelf = self;
 +            // Load data asynchronously to avoid blocking the main thread (IPC to pasteboard daemon)
 +            [itemProvider loadDataRepresentationForTypeIdentifier:identifier completionHandler:^(NSData *data, NSError *error) {
-+              if (error || !data) {
-+                return;
-+              }
 +              dispatch_async(dispatch_get_main_queue(), ^{
++                __strong typeof(weakSelf) strongSelf = weakSelf;
++                if (!strongSelf) {
++                  return;
++                }
++                strongSelf->_isProcessingImagePaste = NO;
++
++                if (error || !data) {
++                  // Fallback to text paste on failure
++                  if (clipboard.hasStrings) {
++                    [strongSelf->_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboard.string];
++                  }
++                  [super paste:nil];
++                  return;
++                }
++
 +                NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
 +                NSString *fileExtension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassFilenameExtension);
 +                NSString *fileName = [NSString stringWithFormat:@"%@.%@", [[NSUUID UUID] UUIDString], fileExtension];
@@ -287,7 +340,8 @@ index 377f41e..e7964ec 100644
 +
 +                if ([data writeToFile:filePath atomically:YES]) {
 +                  NSURL *fileURL = [NSURL fileURLWithPath:filePath];
-+                  [self->_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
++                  strongSelf->_textWasPasted = YES;
++                  [strongSelf->_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
 +                }
 +              });
 +            }];

--- a/patches/react-native+0.81.5.patch
+++ b/patches/react-native+0.81.5.patch
@@ -13,7 +13,7 @@ index 05bddcb..5211253 100644
        registrationName: 'onChangeSync',
      },
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
-index 6e9c384..07ae4dc 100644
+index 6e9c384..5f5220c 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
 +++ b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
 @@ -13,6 +13,10 @@
@@ -35,7 +35,7 @@ index 6e9c384..07ae4dc 100644
  }
  
  static UIFont *defaultPlaceholderFont(void)
-@@ -208,10 +213,88 @@ - (void)scrollRangeToVisible:(NSRange)range
+@@ -208,10 +213,94 @@ - (void)scrollRangeToVisible:(NSRange)range
  
  - (void)paste:(id)sender
  {
@@ -98,7 +98,13 @@ index 6e9c384..07ae4dc 100644
 +          }
 +
 +          NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
++          if (!MIMEType) {
++            MIMEType = @"application/octet-stream";
++          }
 +          NSString *fileExtension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassFilenameExtension);
++          if (!fileExtension) {
++            fileExtension = @"bin";
++          }
 +          NSString *fileName = [NSString stringWithFormat:@"%@.%@", [[NSUUID UUID] UUIDString], fileExtension];
 +          NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
 +
@@ -124,7 +130,7 @@ index 6e9c384..07ae4dc 100644
  // Turn off scroll animation to fix flaky scrolling.
  // This is only necessary for iOS < 14.
  #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
-@@ -301,6 +384,10 @@ - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
+@@ -301,6 +390,10 @@ - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
      return NO;
    }
  
@@ -279,7 +285,7 @@ index 47adc53..1865e0a 100644
  RCT_EXPORT_SHADOW_PROPERTY(text, NSString)
  RCT_EXPORT_SHADOW_PROPERTY(placeholder, NSString)
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
-index 377f41e..be536bb 100644
+index 377f41e..456cf5e 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
 +++ b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
 @@ -12,12 +12,17 @@
@@ -311,7 +317,7 @@ index 377f41e..be536bb 100644
    return [super canPerformAction:action withSender:sender];
  }
  
-@@ -260,12 +269,90 @@ - (void)scrollRangeToVisible:(NSRange)range
+@@ -260,12 +269,96 @@ - (void)scrollRangeToVisible:(NSRange)range
    // Singleline TextInput does not require scrolling after calling setSelectedTextRange (PR 38679).
  }
  
@@ -376,7 +382,13 @@ index 377f41e..be536bb 100644
 +          }
 +
 +          NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
++          if (!MIMEType) {
++            MIMEType = @"application/octet-stream";
++          }
 +          NSString *fileExtension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassFilenameExtension);
++          if (!fileExtension) {
++            fileExtension = @"bin";
++          }
 +          NSString *fileName = [NSString stringWithFormat:@"%@.%@", [[NSUUID UUID] UUIDString], fileExtension];
 +          NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
 +


### PR DESCRIPTION
## Summary
- Replace synchronous `[clipboard dataForPasteboardType:]` with async `[itemProvider loadDataRepresentationForTypeIdentifier:completionHandler:]` in both `RCTUITextView` and `RCTUITextField` paste handlers
- Prevents main thread blocking during cross-process clipboard IPC, which caused 5s+ AppHang on iPad (especially with Universal Clipboard / Handoff)
- Sentry error: `App Hanging: App hanging for at least 5000 ms` — culprit `-[RCTUITextView processImagePaste:]`

## Root Cause
The custom image paste patch calls `[clipboard dataForPasteboardType:]` synchronously on the main thread. This triggers IPC to the pasteboard daemon via `dispatch_semaphore_wait`, which can block for 5+ seconds on iPad when Universal Clipboard is active or clipboard data is large.

## Fix
Use `NSItemProvider`'s async `loadDataRepresentationForTypeIdentifier:completionHandler:` instead, then `dispatch_async` back to main thread for file writing and callback. The main thread is never blocked.

## Test plan
- [ ] Paste text into TextInput on iOS — still works normally
- [ ] Paste image into TextInput on iOS — image paste callback fires (async)
- [ ] Paste on iPad with Universal Clipboard enabled — no hang
- [ ] Verify no regression on Android paste behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
