### PR TITLE
chore: use branch ref for pr-impact-analysis action

### DIFF
--- a/.github/workflows/pr-impact-analysis.yml
+++ b/.github/workflows/pr-impact-analysis.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: PR Impact Analysis
         # TODO: switch to OneKeyHQ/actions/pr-impact-analysis@main after https://github.com/OneKeyHQ/actions/pull/78 is merged
-        uses: originalix/actions/pr-impact-analysis@cad43fd0d9575dbac2dd17338dbde0d19bc04d7e
+        uses: originalix/actions/pr-impact-analysis@feat/pr-impact
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           llm-api-key: ${{ secrets.PIA_LLM_API_KEY }}


### PR DESCRIPTION
## Summary
- Switch pr-impact-analysis action from pinned commit SHA to `originalix/actions/pr-impact-analysis@feat/pr-impact` branch reference
- Enables faster iteration during active debugging without needing to update the SHA on every commit

## Test plan
- [ ] Merge a test PR into `x` and verify the workflow triggers correctly using the branch-referenced action
- [ ] Once debugging is complete, pin back to a specific SHA or tag for supply-chain security
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
