### PR TITLE
fix: simplify SwapTips and PerpTips layout

### DIFF
--- a/packages/kit/src/views/Perp/components/PerpTips.tsx
+++ b/packages/kit/src/views/Perp/components/PerpTips.tsx
@@ -4,13 +4,7 @@ import { useIntl } from 'react-intl';
 
 import {
   Alert,
-  Button,
-  Icon,
-  SizableText,
-  Stack,
-  XStack,
   YStack,
-  useMedia,
 } from '@onekeyhq/components';
 import { usePerpsCommonConfigPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -24,7 +18,6 @@ import useParseQRCode from '../../ScanQrCode/hooks/useParseQRCode';
 
 export function PerpTips() {
   const intl = useIntl();
-  const { gtMd } = useMedia();
   const [{ perpConfigCommon }, setPerpsCommonConfigPersistAtom] =
     usePerpsCommonConfigPersistAtom();
   const parseQRCode = useParseQRCode();
@@ -75,14 +68,15 @@ export function PerpTips() {
     return null;
   }
   return (
-    <YStack borderBottomWidth="$px" borderBottomColor="$borderSubdued">
+    <YStack>
       <Alert
-        flex={1}
-        bg="$bgInfo"
-        type="default"
+        type="info"
         fullBleed
         borderWidth={0}
-        alignItems={gtMd ? 'center' : 'flex-start'}
+        icon="InfoCircleSolid"
+        title={perpConfigCommon?.perpBannerConfig?.title}
+        description={perpConfigCommon?.perpBannerConfig?.description}
+        action={action}
         closable={!!perpConfigCommon?.perpBannerConfig?.canClose}
         onClose={() => {
           if (perpConfigCommon?.perpBannerConfig?.id) {
@@ -97,52 +91,7 @@ export function PerpTips() {
             }));
           }
         }}
-      >
-        <XStack gap="$3" alignItems={gtMd ? 'center' : 'flex-start'} flex={1}>
-          <Stack p="$1" bg="$bgInfo" borderRadius="$full" flexShrink={0}>
-            <Icon name="InfoCircleSolid" size="$4" color="$iconInfo" />
-          </Stack>
-          <YStack gap="$1" flex={1}>
-            {perpConfigCommon?.perpBannerConfig?.title ? (
-              <SizableText size="$bodyMdMedium" color="$textSubdued">
-                {perpConfigCommon.perpBannerConfig.title}
-              </SizableText>
-            ) : null}
-            {perpConfigCommon?.perpBannerConfig?.description ? (
-              <SizableText size="$bodyMd" color="$textSubdued">
-                {perpConfigCommon.perpBannerConfig.description}
-              </SizableText>
-            ) : null}
-            {!gtMd && action ? (
-              <Button
-                size="small"
-                variant="secondary"
-                onPress={action.onPrimaryPress}
-                flexShrink={0}
-                alignSelf="flex-start"
-                px="$3"
-                py="$0.5"
-                mt="$0.5"
-              >
-                <SizableText size="$bodySm">{action.primary}</SizableText>
-              </Button>
-            ) : null}
-          </YStack>
-          {gtMd && action ? (
-            <Button
-              size="small"
-              variant="secondary"
-              onPress={action.onPrimaryPress}
-              flexShrink={0}
-              alignSelf="center"
-              px="$3"
-              py="$0.5"
-            >
-              <SizableText size="$bodySm">{action.primary}</SizableText>
-            </Button>
-          ) : null}
-        </XStack>
-      </Alert>
+      />
     </YStack>
   );
 }

--- a/packages/kit/src/views/Swap/pages/components/SwapTipsContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapTipsContainer.tsx
@@ -2,14 +2,8 @@ import { useIntl } from 'react-intl';
 
 import {
   Alert,
-  Button,
   EPageType,
-  Icon,
-  SizableText,
-  Stack,
-  XStack,
   YStack,
-  useMedia,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { useSwapTipsAtom } from '@onekeyhq/kit/src/states/jotai/contexts/swap/atoms';
@@ -22,7 +16,6 @@ interface ISwapTipsContainerProps {
 
 const SwapTipsContainer = ({ pageType }: ISwapTipsContainerProps) => {
   const [swapTips, setSwapTips] = useSwapTipsAtom();
-  const { gtMd } = useMedia();
   const intl = useIntl();
   // Don't show tips in modal
   if (!swapTips || pageType === EPageType.modal) {
@@ -48,62 +41,18 @@ const SwapTipsContainer = ({ pageType }: ISwapTipsContainerProps) => {
     : undefined;
 
   return (
-    <YStack borderBottomWidth="$px" borderBottomColor="$borderSubdued">
+    <YStack>
       <Alert
-        flex={1}
-        type="default"
-        bg="$bgInfo"
+        type="info"
         fullBleed
         borderWidth={0}
-        alignItems={gtMd ? 'center' : 'flex-start'}
+        icon="InfoCircleSolid"
+        title={swapTips.title}
+        description={swapTips.description}
+        action={action}
         closable={!!swapTips.userCanClose}
         onClose={handleClose}
-      >
-        <XStack gap="$3" alignItems={gtMd ? 'center' : 'flex-start'} flex={1}>
-          <Stack p="$1" bg="$bgInfo" borderRadius="$full" flexShrink={0}>
-            <Icon name="InfoCircleSolid" size="$4" color="$iconInfo" />
-          </Stack>
-          <YStack gap="$1" flex={1}>
-            {swapTips.title ? (
-              <SizableText size="$bodyMdMedium" color="$textSubdued">
-                {swapTips.title}
-              </SizableText>
-            ) : null}
-            {swapTips.description ? (
-              <SizableText size="$bodyMd" color="$textSubdued">
-                {swapTips.description}
-              </SizableText>
-            ) : null}
-            {!gtMd && action ? (
-              <Button
-                size="small"
-                variant="secondary"
-                onPress={action.onPrimaryPress}
-                flexShrink={0}
-                alignSelf="flex-start"
-                px="$3"
-                py="$0.5"
-                mt="$0.5"
-              >
-                <SizableText size="$bodySm">{action.primary}</SizableText>
-              </Button>
-            ) : null}
-          </YStack>
-          {gtMd && action ? (
-            <Button
-              size="small"
-              variant="secondary"
-              onPress={action.onPrimaryPress}
-              flexShrink={0}
-              alignSelf="center"
-              px="$3"
-              py="$0.5"
-            >
-              <SizableText size="$bodySm">{action.primary}</SizableText>
-            </Button>
-          ) : null}
-        </XStack>
-      </Alert>
+      />
     </YStack>
   );
 };


### PR DESCRIPTION
## Summary
- Simplify SwapTips and PerpTips to use Alert's built-in `icon`, `title`, `description`, `action` props instead of custom children with deeply nested flex containers
- Fix iOS layout issue where the tip banner height was calculated incorrectly due to 3 levels of nested `flex={1}`
- Remove bottom border from tip banners

## Test plan
- [x] Verify SwapTips banner displays correctly on iOS (title, description, action button, close button)
- [x] Verify PerpTips banner displays correctly on iOS
- [x] Verify desktop layout is not affected
- [x] Verify tips can be closed and "了解更多" button works
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
