### PR TITLE
fix(perps): replace disabled state with toast validation for trading buttons

### DIFF
--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -88,32 +88,11 @@ function SideButtonInternal({
   const marginRequired = useDebounce(marginRequiredRaw, 100);
   const liquidationPrice = useDebounce(liquidationPriceRaw, 100);
 
-  // Check if inputs are empty
-  const hasEmptyInputs = useMemo(() => {
-    if (
-      formData.type === 'limit' &&
-      (!formData.price || formData.price.trim() === '')
-    ) {
-      return true;
-    }
-    const isSliderMode = formData.sizeInputMode === 'slider';
-    if (isSliderMode) {
-      return !formData.sizePercent || formData.sizePercent <= 0;
-    }
-    return !formData.size || formData.size.trim() === '';
-  }, [
-    formData.type,
-    formData.price,
-    formData.size,
-    formData.sizeInputMode,
-    formData.sizePercent,
-  ]);
-
   const isMinimumOrderNotMetForSide = useMemo(() => {
-    if (hasEmptyInputs) return false;
-    if (!orderValue || !orderValue.isFinite()) return false;
+    if (!orderValue || !orderValue.isFinite() || orderValue.lte(0))
+      return false;
     return orderValue.lt(10);
-  }, [hasEmptyInputs, orderValue]);
+  }, [orderValue]);
 
   const isAccountLoading = useMemo<boolean>(() => {
     return (
@@ -127,10 +106,7 @@ function SideButtonInternal({
 
   const buttonDisabled = useMemo(() => {
     return (
-      hasEmptyInputs ||
-      !computedSizeForSide.gt(0) ||
       !perpsAccountStatus.canTrade ||
-      isMinimumOrderNotMetForSide ||
       isNoEnoughMargin ||
       isAccountLoading ||
       priceError === 'bbo_unavailable' ||
@@ -139,10 +115,7 @@ function SideButtonInternal({
           perpConfigCommon?.ipDisablePerp))
     );
   }, [
-    hasEmptyInputs,
-    computedSizeForSide,
     perpsAccountStatus.canTrade,
-    isMinimumOrderNotMetForSide,
     isNoEnoughMargin,
     isAccountLoading,
     priceError,
@@ -179,15 +152,6 @@ function SideButtonInternal({
       return intl.formatMessage({
         id: ETranslations.Perps_BBO_unavailable,
       });
-    if (isMinimumOrderNotMetForSide)
-      return intl.formatMessage(
-        {
-          id: ETranslations.perp_size_least,
-        },
-        {
-          amount: '$10',
-        },
-      );
     if (perpConfigCommon?.ipDisablePerp)
       return intl.formatMessage({
         id: ETranslations.perp_button_ip_restricted,
@@ -205,7 +169,6 @@ function SideButtonInternal({
       : intl.formatMessage({ id: ETranslations.perp_trade_short });
   }, [
     priceError,
-    isMinimumOrderNotMetForSide,
     isNoEnoughMargin,
     side,
     intl,
@@ -246,6 +209,42 @@ function SideButtonInternal({
 
   const handlePress = useDebouncedCallback(
     (): void => {
+      // Validate empty inputs - show toast instead of disabling button
+      // For limit orders, check price first
+      if (
+        formData.type === 'limit' &&
+        (!formData.price || formData.price.trim() === '')
+      ) {
+        Toast.message({
+          title: intl.formatMessage({
+            id: ETranslations.limit_enter_price,
+          }),
+        });
+        return;
+      }
+      // Then check size for all order types
+      const isSliderMode = formData.sizeInputMode === 'slider';
+      const hasSizeEmpty = isSliderMode
+        ? !formData.sizePercent || formData.sizePercent <= 0
+        : !formData.size || formData.size.trim() === '';
+      if (hasSizeEmpty || !computedSizeForSide.gt(0)) {
+        Toast.message({
+          title: intl.formatMessage({
+            id: ETranslations.perp_trade_amount_place_holder,
+          }),
+        });
+        return;
+      }
+      if (isMinimumOrderNotMetForSide) {
+        Toast.message({
+          title: intl.formatMessage(
+            { id: ETranslations.perp_size_least },
+            { amount: '$10' },
+          ),
+        });
+        return;
+      }
+
       // Validate TPSL only if user has filled in values
       const tpValue = formData.tpValue?.trim();
       const slValue = formData.slValue?.trim();


### PR DESCRIPTION
## Summary
- Remove disabled state for Long/Short buttons when inputs are empty or order value < $10
- Show toast messages on button press instead:
  - Limit order with no price → "Enter a price" / "输入价格"
  - No size entered → "Enter Amount" / "输入数量"
  - Order value < $10 → "Min $10"
- Clean up redundant `hasEmptyInputs` useMemo, simplify `isMinimumOrderNotMetForSide`
- Button text always shows "Long" / "Short" (no longer changes to "Min $10")
- Other disabled states unchanged: `isNoEnoughMargin`, loading, BBO unavailable, IP/action restrictions

## Changes
- `TradingButtonGroup.tsx` only (1 file)

## Test plan
- [ ] Market order: tap Long/Short with empty size → toast "Enter Amount"
- [ ] Limit order: tap with empty price → toast "Enter a price"
- [ ] Limit order: tap with price filled, empty size → toast "Enter Amount"
- [ ] Enter size < $10 notional → toast "Min $10"
- [ ] Enter valid size → proceeds to order confirm / place order
- [ ] Verify disabled states still work: insufficient margin, BBO unavailable, IP restricted
- [ ] Test on both mobile and desktop layouts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
