### PR TITLE
fix: fiat crypto token list sort instability on mobile

### DIFF
--- a/packages/kit/src/views/FiatCrypto/components/SellOrBuy/index.tsx
+++ b/packages/kit/src/views/FiatCrypto/components/SellOrBuy/index.tsx
@@ -81,7 +81,7 @@ const SellOrBuy = ({ title, type, networkId, accountId }: ISellOrBuyProps) => {
     return result.toSorted((a, b) => {
       const num1 = a.fiatValue ?? '0';
       const num2 = b.fiatValue ?? '0';
-      return BigNumber(num1).gt(num2) ? -1 : 1;
+      return BigNumber(num1).comparedTo(num2) * -1;
     });
   }, [tokens, getTokenFiatValue, networkId, type, account]);
 


### PR DESCRIPTION
## Summary

- Fix fiat crypto (Buy/Sell) token list ordering inconsistency between mobile and desktop in AllNetwork mode
- The sort comparator never returned `0` for equal fiatValues — `BigNumber.gt()` only returns `-1` or `1`, violating sort transitivity
- V8 (desktop) happened to preserve server order for equal items, but Hermes (mobile) produced non-deterministic ordering
- Replace with `BigNumber.comparedTo()` which correctly returns `-1`, `0`, `1`, ensuring stable sort across all JS engines
- Only affects tokens without fiatValue (no balance) — they now correctly maintain server-side ordering on all platforms

## Test plan

- [x] Tested on desktop: token list order matches server response for tokens without fiatValue
- [x] Tested on mobile: token list order now matches server response (previously inconsistent)
- [x] Tokens with fiatValue still sort by value descending as expected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
