### PR TITLE
fix: rename Ripple to XRP Ledger

### DIFF
--- a/packages/engine/src/vaults/impl/xrp/settings.ts
+++ b/packages/engine/src/vaults/impl/xrp/settings.ts
@@ -27,7 +27,7 @@ const settings: IVaultSettings = Object.freeze({
 
   accountNameInfo: {
     default: {
-      prefix: 'RIPPLE',
+      prefix: 'XRP Ledger',
       category: `44'/${COINTYPE_XRP}'`,
       template: `m/44'/${COINTYPE_XRP}'/${INDEX_PLACEHOLDER}'/0/0`,
       coinType: COINTYPE_XRP,

--- a/packages/shared/src/config/presetNetworks.ts
+++ b/packages/shared/src/config/presetNetworks.ts
@@ -4005,7 +4005,7 @@ const serverPresetNetworks = [
     'impl': 'xrp',
     'isTestnet': false,
     'logoURI': 'https://common.onekey-asset.com/chain/xrp.png',
-    'name': 'Ripple',
+    'name': 'XRP Ledger',
     'rpcURLs': [
       {
         'url': 'wss://s1.ripple.com',
@@ -4024,7 +4024,7 @@ const serverPresetNetworks = [
       },
     ],
     'shortcode': 'xrp',
-    'shortname': 'Ripple',
+    'shortname': 'XRP Ledger',
     'symbol': 'XRP',
     'feeMeta': {
       'code': 'xrp',


### PR DESCRIPTION
## Summary
- Rename network display name from "Ripple" to "XRP Ledger" (name, shortname, account prefix)
- CoinGecko API ID (`'native': 'ripple'`) and RPC URLs left unchanged as they are technical identifiers

## Jira
https://onekeyhq.atlassian.net/browse/OK-50582

## Test plan
- [ ] Verify XRP network shows as "XRP Ledger" in network selector
- [ ] Verify new XRP accounts are named "XRP Ledger #1" instead of "RIPPLE #1"
- [ ] Verify XRP price fetching still works (CoinGecko ID unchanged)
- [ ] Regression test on send/receive/swap flows for XRP
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
