### PR TITLE
feat(account): support batch removing existing accounts in Manage Accounts preview

### DIFF
--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAddAccountButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAddAccountButton.tsx
@@ -43,7 +43,7 @@ export function AccountSelectorAddAccountButton({
         primary={intl.formatMessage({
           id: platformEnv.isWebDappMode
             ? ETranslations.onboarding_connect_external_wallet
-            : ETranslations.global_account,
+            : ETranslations.global_add_account,
         })}
         primaryTextProps={{
           color: '$textSubdued',

--- a/packages/kit/src/views/AccountManagerStacks/pages/BatchCreateAccount/BatchCreateAccountPreview.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/BatchCreateAccount/BatchCreateAccountPreview.tsx
@@ -153,9 +153,19 @@ function BatchCreateAccountPreviewPage({
   const [normalSelectedIndexes, setNormalSelectedIndexes] = useState<{
     [pathIndex: number]: boolean;
   }>({});
+  const [deselectedExistingIndexes, setDeselectedExistingIndexes] = useState<{
+    [pathIndex: number]: true;
+  }>({});
+  const deselectedExistingAccountsRef = useRef<{
+    [pathIndex: number]: IBatchCreateAccount;
+  }>({});
   const selectedIndexesCount = useMemo(
     () => Object.values(normalSelectedIndexes).filter(Boolean).length,
     [normalSelectedIndexes],
+  );
+  const deselectedExistingCount = useMemo(
+    () => Object.values(deselectedExistingIndexes).filter(Boolean).length,
+    [deselectedExistingIndexes],
   );
 
   const pageSize = 10;
@@ -212,6 +222,8 @@ function BatchCreateAccountPreviewPage({
       setPage(minPage);
       setAdvancedExcludedIndexes({});
       setNormalSelectedIndexes({});
+      setDeselectedExistingIndexes({});
+      deselectedExistingAccountsRef.current = {};
       setFrom(values.from);
       setCount(values.count);
       setDeriveType(values.deriveType);
@@ -315,9 +327,11 @@ function BatchCreateAccountPreviewPage({
 
   useEffect(() => {
     if (networkId) {
-      // reset deriveType after network changed
+      // reset deriveType and deselection state after network changed
       setDeriveType(undefined);
       setResult([]);
+      setDeselectedExistingIndexes({});
+      deselectedExistingAccountsRef.current = {};
       // DeriveTypeSelectorFormInput shouldResetDeriveTypeWhenNetworkChanged will handle this internally
     }
   }, [networkId, setResult]);
@@ -385,6 +399,25 @@ function BatchCreateAccountPreviewPage({
       val: ICheckedState;
       accountsToSelect: IBatchCreateAccount[];
     }) => {
+      // Handle existing accounts deselection (for removal)
+      setDeselectedExistingIndexes((v) => {
+        const newValue = { ...v };
+        for (const a of accountsToSelect) {
+          if (a.existsInDb) {
+            const pathIndex = a.pathIndex ?? -1;
+            if (val) {
+              delete newValue[pathIndex];
+              delete deselectedExistingAccountsRef.current[pathIndex];
+            } else {
+              newValue[pathIndex] = true;
+              deselectedExistingAccountsRef.current[pathIndex] = a;
+            }
+          }
+        }
+        return newValue;
+      });
+
+      // Handle new accounts selection (for creation)
       if (isAdvancedMode) {
         if (val === true) {
           setAdvancedExcludedIndexes((v) => {
@@ -465,6 +498,8 @@ function BatchCreateAccountPreviewPage({
           onChange={(v) => {
             if (deriveType !== v) {
               setDeriveType(v);
+              setDeselectedExistingIndexes({});
+              deselectedExistingAccountsRef.current = {};
             }
           }}
           networkId={networkId || ''}
@@ -521,12 +556,20 @@ function BatchCreateAccountPreviewPage({
 
   const totalCount = useMemo<number>(() => {
     if (!isAdvancedMode) {
-      return selectedIndexesCount;
+      return selectedIndexesCount + deselectedExistingCount;
     }
     return (
-      countInt - Object.values(advanceExcludedIndexes).filter(Boolean).length
+      countInt -
+      Object.values(advanceExcludedIndexes).filter(Boolean).length -
+      deselectedExistingCount
     );
-  }, [advanceExcludedIndexes, countInt, isAdvancedMode, selectedIndexesCount]);
+  }, [
+    advanceExcludedIndexes,
+    countInt,
+    deselectedExistingCount,
+    isAdvancedMode,
+    selectedIndexesCount,
+  ]);
 
   const totalCountEstimate = useMemo(() => {
     if (totalCount > 0) {
@@ -551,6 +594,9 @@ function BatchCreateAccountPreviewPage({
   const getAccountCheckedState = useCallback(
     (account: IBatchCreateAccount) => {
       const pathIndex = account.pathIndex ?? -1;
+      if (account.existsInDb) {
+        return deselectedExistingIndexes[pathIndex] !== true;
+      }
       let checkedState: ICheckedState = false;
       if (isAdvancedMode) {
         checkedState = true;
@@ -560,12 +606,14 @@ function BatchCreateAccountPreviewPage({
       } else {
         checkedState = normalSelectedIndexes[pathIndex] ?? false;
       }
-      if (account.existsInDb) {
-        checkedState = 'indeterminate';
-      }
       return checkedState;
     },
-    [advanceExcludedIndexes, isAdvancedMode, normalSelectedIndexes],
+    [
+      advanceExcludedIndexes,
+      deselectedExistingIndexes,
+      isAdvancedMode,
+      normalSelectedIndexes,
+    ],
   );
 
   const columns = useMemo(
@@ -595,7 +643,6 @@ function BatchCreateAccountPreviewPage({
                 flex: 1,
                 pointerEvents: 'none',
               }}
-              disabled={account.existsInDb}
               value={checkedState}
               label={String((account.pathIndex ?? 0) + 1)}
               labelProps={
@@ -698,12 +745,10 @@ function BatchCreateAccountPreviewPage({
     (account: IBatchCreateAccount) => ({
       onPress: () => {
         const checkedState: ICheckedState = getAccountCheckedState(account);
-        if (checkedState !== 'indeterminate') {
-          selectCheckBox({
-            val: !checkedState,
-            accountsToSelect: [account],
-          });
-        }
+        selectCheckBox({
+          val: !checkedState,
+          accountsToSelect: [account],
+        });
       },
     }),
     [getAccountCheckedState, selectCheckBox],
@@ -749,7 +794,7 @@ function BatchCreateAccountPreviewPage({
     <Page scrollEnabled safeAreaEnabled>
       <Page.Header
         title={intl.formatMessage({
-          id: ETranslations.send_preview_button,
+          id: ETranslations.global_manage_accounts,
         })}
         dismissOnOverlayPress={false}
         headerRight={headerRight}
@@ -816,68 +861,107 @@ function BatchCreateAccountPreviewPage({
             }
             setPreviewError('');
 
-            let advancedParams:
-              | IBatchBuildAccountsAdvancedFlowParams
-              | undefined;
-            let normalParams: IBatchBuildAccountsNormalFlowParams | undefined;
-            if (isAdvancedMode) {
-              advancedParams = {
-                walletId,
-                networkId,
-                deriveType,
-                fromIndex: beginIndex,
-                toIndex: endIndex,
-                excludedIndexes: advanceExcludedIndexes,
-                saveToDb: true,
-                hideCheckingDeviceLoading: true,
-                showUIProgress: true,
-              };
-            } else {
-              normalParams = {
-                walletId,
-                networkId,
-                deriveType,
-                indexes: Object.entries(normalSelectedIndexes)
-                  .filter(([, v]) => v)
-                  .map(([k]) => parseInt(k, 10)),
-                saveToDb: true,
-                hideCheckingDeviceLoading: true,
-                showUIProgress: true,
-              };
-            }
-            if (!normalParams && !advancedParams) {
-              throw new OneKeyLocalError(
-                'startBatchCreateAccountsFlow params is undefined',
-              );
+            const accountsToRemove = Object.values(
+              deselectedExistingAccountsRef.current,
+            );
+
+            const hasNewAccounts =
+              isAdvancedMode ||
+              Object.values(normalSelectedIndexes).some(Boolean);
+
+            if (!hasNewAccounts && accountsToRemove.length === 0) {
+              return;
             }
 
-            showBatchCreateAccountProcessingDialog({
-              navigation,
-            });
-            await timerUtils.wait(600);
-
-            try {
-              const result =
-                await backgroundApiProxy.serviceBatchCreateAccount.startBatchCreateAccountsFlow(
-                  isAdvancedMode
-                    ? {
-                        mode: 'advanced',
-                        saveToCache: true,
-                        params: checkIsDefined(advancedParams),
-                      }
-                    : {
-                        mode: 'normal',
-                        saveToCache: true,
-                        params: checkIsDefined(normalParams),
-                      },
-                );
-
-              if (result?.accountsForCreate) {
-                setEditMode(false);
+            // Remove deselected existing accounts by their indexedAccount
+            if (accountsToRemove.length > 0) {
+              for (const account of accountsToRemove) {
+                if (account.indexedAccountId) {
+                  const indexedAccount =
+                    await backgroundApiProxy.serviceAccount.getIndexedAccount({
+                      id: account.indexedAccountId,
+                    });
+                  await backgroundApiProxy.serviceAccount.removeAccount({
+                    indexedAccount,
+                  });
+                }
               }
-            } catch (error) {
-              console.log(error);
-              throw error;
+            }
+
+            // Create new accounts if any selected
+            if (hasNewAccounts) {
+              let advancedParams:
+                | IBatchBuildAccountsAdvancedFlowParams
+                | undefined;
+              let normalParams:
+                | IBatchBuildAccountsNormalFlowParams
+                | undefined;
+              if (isAdvancedMode) {
+                advancedParams = {
+                  walletId,
+                  networkId,
+                  deriveType,
+                  fromIndex: beginIndex,
+                  toIndex: endIndex,
+                  excludedIndexes: {
+                    ...advanceExcludedIndexes,
+                    ...deselectedExistingIndexes,
+                  },
+                  saveToDb: true,
+                  hideCheckingDeviceLoading: true,
+                  showUIProgress: true,
+                };
+              } else {
+                normalParams = {
+                  walletId,
+                  networkId,
+                  deriveType,
+                  indexes: Object.entries(normalSelectedIndexes)
+                    .filter(([, v]) => v)
+                    .map(([k]) => parseInt(k, 10)),
+                  saveToDb: true,
+                  hideCheckingDeviceLoading: true,
+                  showUIProgress: true,
+                };
+              }
+              if (!normalParams && !advancedParams) {
+                throw new OneKeyLocalError(
+                  'startBatchCreateAccountsFlow params is undefined',
+                );
+              }
+
+              showBatchCreateAccountProcessingDialog({
+                navigation,
+              });
+              await timerUtils.wait(600);
+
+              try {
+                const result =
+                  await backgroundApiProxy.serviceBatchCreateAccount.startBatchCreateAccountsFlow(
+                    isAdvancedMode
+                      ? {
+                          mode: 'advanced',
+                          saveToCache: true,
+                          params: checkIsDefined(advancedParams),
+                        }
+                      : {
+                          mode: 'normal',
+                          saveToCache: true,
+                          params: checkIsDefined(normalParams),
+                        },
+                  );
+
+                if (result?.accountsForCreate) {
+                  setEditMode(false);
+                }
+              } catch (error) {
+                console.log(error);
+                throw error;
+              }
+            } else {
+              // Only removals, navigate back
+              setEditMode(false);
+              navigation.pop();
             }
           }}
         >
@@ -905,41 +989,23 @@ function BatchCreateAccountPreviewPage({
                   id: ETranslations.global_generate_amount_select,
                 })}
                 value={(() => {
-                  const notExistAccounts = accounts.filter(
-                    (account) => !account.existsInDb,
-                  );
+                  let allChecked = true;
+                  let allUnchecked = true;
 
-                  if (notExistAccounts.length === 0) {
-                    return 'indeterminate';
+                  for (const account of accounts) {
+                    const state = getAccountCheckedState(account);
+                    if (state) {
+                      allUnchecked = false;
+                    } else {
+                      allChecked = false;
+                    }
                   }
 
-                  // advanced mode
-                  if (isAdvancedMode) {
-                    const excludedAccounts = notExistAccounts.filter(
-                      (account) =>
-                        advanceExcludedIndexes?.[account.pathIndex ?? -1] ===
-                        true,
-                    );
-                    if (excludedAccounts.length === 0) {
-                      return true;
-                    }
-                    if (excludedAccounts.length === notExistAccounts.length) {
-                      return false;
-                    }
-                    return 'indeterminate';
-                  }
-
-                  // normal mode
-                  const selectedAccounts = notExistAccounts.filter(
-                    (account) =>
-                      normalSelectedIndexes[account.pathIndex ?? -1] === true,
-                  );
-                  if (selectedAccounts.length === 0) {
+                  if (accounts.length === 0) {
                     return false;
                   }
-                  if (selectedAccounts.length === notExistAccounts.length) {
-                    return true;
-                  }
+                  if (allChecked) return true;
+                  if (allUnchecked) return false;
                   return 'indeterminate';
                 })()}
               />

--- a/packages/kit/src/views/AccountManagerStacks/pages/BatchCreateAccount/BatchCreateAccountPreview.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/BatchCreateAccount/BatchCreateAccountPreview.tsx
@@ -401,19 +401,34 @@ function BatchCreateAccountPreviewPage({
     }) => {
       // Handle existing accounts deselection (for removal)
       setDeselectedExistingIndexes((v) => {
-        const newValue = { ...v };
+        const keysToRemove = new Set<number>();
+        const keysToAdd: Array<{
+          pathIndex: number;
+          account: IBatchCreateAccount;
+        }> = [];
         for (const a of accountsToSelect) {
           if (a.existsInDb) {
             const pathIndex = a.pathIndex ?? -1;
             if (val) {
-              delete newValue[pathIndex];
-              delete deselectedExistingAccountsRef.current[pathIndex];
+              keysToRemove.add(pathIndex);
             } else {
-              newValue[pathIndex] = true;
-              deselectedExistingAccountsRef.current[pathIndex] = a;
+              keysToAdd.push({ pathIndex, account: a });
             }
           }
         }
+        const newValue = Object.fromEntries(
+          Object.entries(v).filter(([k]) => !keysToRemove.has(Number(k))),
+        ) as typeof v;
+        const newRef = Object.fromEntries(
+          Object.entries(deselectedExistingAccountsRef.current).filter(
+            ([k]) => !keysToRemove.has(Number(k)),
+          ),
+        ) as typeof deselectedExistingAccountsRef.current;
+        for (const { pathIndex, account } of keysToAdd) {
+          newValue[pathIndex] = true;
+          newRef[pathIndex] = account;
+        }
+        deselectedExistingAccountsRef.current = newRef;
         return newValue;
       });
 
@@ -421,12 +436,14 @@ function BatchCreateAccountPreviewPage({
       if (isAdvancedMode) {
         if (val === true) {
           setAdvancedExcludedIndexes((v) => {
-            for (const a of accountsToSelect) {
-              if (!a.existsInDb) {
-                delete v[a.pathIndex ?? -1];
-              }
-            }
-            return { ...v };
+            const keysToRemove = new Set(
+              accountsToSelect
+                .filter((a) => !a.existsInDb)
+                .map((a) => a.pathIndex ?? -1),
+            );
+            return Object.fromEntries(
+              Object.entries(v).filter(([k]) => !keysToRemove.has(Number(k))),
+            ) as typeof v;
           });
         }
         if (val === false) {


### PR DESCRIPTION
## Summary
- Allow deselecting existing accounts in the batch create preview dialog (acts as remove account via indexedAccount)
- Rename preview dialog title from "Preview" to "Manage Accounts"
- Rename `[+]` add account button label from "Account" to "Add Account"

## Changes
- **BatchCreateAccountPreview.tsx**: Added `deselectedExistingIndexes` state to track toggled existing accounts. Existing accounts are now checkable (no longer disabled/indeterminate). On confirm, deselected existing accounts are removed via `removeAccount({ indexedAccount })`. Select All now uses unified `getAccountCheckedState` for all accounts.
- **AccountSelectorAddAccountButton.tsx**: Changed translation key from `global_account` to `global_add_account`.

## Screenshot
<img width="964" height="895" alt="Screenshot 2026-02-26 at 21 17 29" src="https://github.com/user-attachments/assets/9994481f-954b-4526-bbb4-06febe133dd9" />

## Test plan
- [ ] Open Manage Accounts dialog, verify title shows "Manage Accounts"
- [ ] Verify existing accounts show as checked (not indeterminate)
- [ ] Deselect existing accounts and confirm — verify they are removed
- [ ] Select new accounts and confirm — verify they are created
- [ ] Test Select All / deselect all with mixed existing + new accounts
- [ ] Verify [+] button in account list shows "Add Account"
- [ ] Test on both desktop and mobile platforms