### PR TITLE
fix: OneKey ID iOS logout loading & web settings dropdown overlap (OK-50586)(OK-50494)

### DIFF
--- a/packages/kit/src/components/TabPageHeader/DappHeader.tsx
+++ b/packages/kit/src/components/TabPageHeader/DappHeader.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useMemo } from 'react';
+import { type ReactNode, useCallback, useMemo, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -56,7 +56,11 @@ import { UniversalSearchInput } from './UniversalSearchInput';
 
 import type { ITabPageHeaderProp } from './type';
 
-function LanguageListItem() {
+function LanguageListItem({
+  onOpenChange: onOpenChangeProp,
+}: {
+  onOpenChange?: (isOpen: boolean) => void;
+}) {
   const intl = useIntl();
   const { options, value, onChange } = useLanguageSelector();
   const label = useMemo(() => {
@@ -71,6 +75,7 @@ function LanguageListItem() {
       items={options}
       value={value}
       onChange={onChange}
+      onOpenChange={onOpenChangeProp}
       floatingPanelProps={{ maxHeight: 280 }}
       sheetProps={{
         disableDrag: true,
@@ -95,7 +100,11 @@ function LanguageListItem() {
   );
 }
 
-function CurrencyListItem() {
+function CurrencyListItem({
+  onOpenChange: onOpenChangeProp,
+}: {
+  onOpenChange?: (isOpen: boolean) => void;
+}) {
   const [settings] = useSettingsPersistAtom();
   const sections = useCurrencySections();
   const formatSections = useMemo(() => {
@@ -141,6 +150,7 @@ function CurrencyListItem() {
       sections={formatSections}
       value={settings.currencyInfo.id}
       onChange={handleChange}
+      onOpenChange={onOpenChangeProp}
       floatingPanelProps={{ maxHeight: 280 }}
       sheetProps={{
         disableDrag: true,
@@ -347,6 +357,44 @@ function SettingListItem() {
   );
 }
 
+function MoreDappActionContent() {
+  const [languageKey, setLanguageKey] = useState(0);
+  const [currencyKey, setCurrencyKey] = useState(0);
+
+  const handleLanguageOpenChange = useCallback((isOpen: boolean) => {
+    if (isOpen) {
+      setCurrencyKey((prev) => prev + 1);
+    }
+  }, []);
+
+  const handleCurrencyOpenChange = useCallback((isOpen: boolean) => {
+    if (isOpen) {
+      setLanguageKey((prev) => prev + 1);
+    }
+  }, []);
+
+  return (
+    <YStack py="$3">
+      <ThemeListItem />
+      <LanguageListItem
+        key={languageKey}
+        onOpenChange={handleLanguageOpenChange}
+      />
+      <CurrencyListItem
+        key={currencyKey}
+        onOpenChange={handleCurrencyOpenChange}
+      />
+      <DownloadOneKeyWalletListItem />
+      {/* <Web3GuideListItem /> */}
+      <YStack py="$1.5" px="$3">
+        <Divider />
+      </YStack>
+      <AnnouncementListItem />
+      <SettingListItem />
+    </YStack>
+  );
+}
+
 function MoreDappAction({ size }: { size?: 'small' | 'medium' }) {
   const intl = useIntl();
 
@@ -373,20 +421,7 @@ function MoreDappAction({ size }: { size?: 'small' | 'medium' }) {
           size={size}
         />
       }
-      renderContent={
-        <YStack py="$3">
-          <ThemeListItem />
-          <LanguageListItem />
-          <CurrencyListItem />
-          <DownloadOneKeyWalletListItem />
-          {/* <Web3GuideListItem /> */}
-          <YStack py="$1.5" px="$3">
-            <Divider />
-          </YStack>
-          <AnnouncementListItem />
-          <SettingListItem />
-        </YStack>
-      }
+      renderContent={<MoreDappActionContent />}
     />
   );
 }

--- a/packages/kit/src/views/Prime/pages/OneKeyId/index.tsx
+++ b/packages/kit/src/views/Prime/pages/OneKeyId/index.tsx
@@ -38,6 +38,7 @@ function OneKeyIdPage() {
   const { isLoggedIn, logout } = useOneKeyAuth();
   const logoutRef = useRef<() => Promise<void>>(logout);
   const isFocused = useRouteIsFocused();
+  const isExplicitLogoutRef = useRef(false);
 
   const toPrimePage = useCallback(() => {
     requestIdleCallback(async () => {
@@ -62,6 +63,9 @@ function OneKeyIdPage() {
   }, [isPrimeAvailable]);
 
   const handleLoggedOutWhileFocused = useCallback(async () => {
+    if (isExplicitLogoutRef.current) {
+      return;
+    }
     if (!isLoggedIn && isFocused) {
       await timerUtils.wait(300);
       popModalPagesOnNative();
@@ -76,6 +80,15 @@ function OneKeyIdPage() {
   useUpdateEffect(() => {
     void handleLoggedOutWhileFocused();
   }, [handleLoggedOutWhileFocused]);
+
+  const handleBeforeLogout = useCallback(() => {
+    isExplicitLogoutRef.current = true;
+  }, []);
+
+  const handleLogoutSuccess = useCallback(async () => {
+    defaultLogger.referral.page.logoutOneKeyIDResult();
+    popModalPagesOnNative();
+  }, []);
 
   return (
     <Page scrollEnabled>
@@ -103,10 +116,8 @@ function OneKeyIdPage() {
           </YStack>
           <Stack p="$5">
             <PrimeUserInfo
-              onLogoutSuccess={async () => {
-                defaultLogger.referral.page.logoutOneKeyIDResult();
-                popModalPagesOnNative();
-              }}
+              onBeforeLogout={handleBeforeLogout}
+              onLogoutSuccess={handleLogoutSuccess}
             />
           </Stack>
           <YStack>

--- a/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeUserInfo.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeUserInfo.tsx
@@ -80,9 +80,11 @@ export function PrimeUserBadge() {
 }
 
 export function PrimeUserInfo({
+  onBeforeLogout,
   onLogoutSuccess,
   ...stackProps
 }: {
+  onBeforeLogout?: () => void;
   onLogoutSuccess?: () => Promise<void>;
 } & ComponentProps<typeof XStack>) {
   const { user } = useOneKeyAuth();
@@ -114,7 +116,10 @@ export function PrimeUserInfo({
         {user?.displayEmail}
       </SizableText>
       <PrimeUserBadge />
-      <PrimeUserInfoMoreButton onLogoutSuccess={onLogoutSuccess} />
+      <PrimeUserInfoMoreButton
+        onBeforeLogout={onBeforeLogout}
+        onLogoutSuccess={onLogoutSuccess}
+      />
     </XStack>
   );
 }

--- a/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeUserInfoMoreButton.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeUserInfoMoreButton.tsx
@@ -28,9 +28,11 @@ import { usePrimePayment } from '../../hooks/usePrimePayment';
 
 function PrimeUserInfoMoreButtonDropDownMenu({
   handleActionListClose,
+  onBeforeLogout,
   onLogoutSuccess,
 }: {
   handleActionListClose: () => void;
+  onBeforeLogout?: () => void;
   onLogoutSuccess?: () => Promise<void>;
 }) {
   const { logout, user } = useOneKeyAuth();
@@ -192,6 +194,7 @@ function PrimeUserInfoMoreButtonDropDownMenu({
               id: ETranslations.prime_log_out,
             }),
             onConfirm: async () => {
+              onBeforeLogout?.();
               defaultLogger.prime.subscription.onekeyIdLogout({
                 reason: 'PrimeUserInfoMoreButton Logout Button',
               });
@@ -206,8 +209,10 @@ function PrimeUserInfoMoreButtonDropDownMenu({
 }
 
 export function PrimeUserInfoMoreButton({
+  onBeforeLogout,
   onLogoutSuccess,
 }: {
+  onBeforeLogout?: () => void;
   onLogoutSuccess?: () => Promise<void>;
 }) {
   const renderItems = useCallback(
@@ -219,10 +224,11 @@ export function PrimeUserInfoMoreButton({
     }) => (
       <PrimeUserInfoMoreButtonDropDownMenu
         handleActionListClose={handleActionListClose}
+        onBeforeLogout={onBeforeLogout}
         onLogoutSuccess={onLogoutSuccess}
       />
     ),
-    [onLogoutSuccess],
+    [onBeforeLogout, onLogoutSuccess],
   );
   return (
     <ActionList


### PR DESCRIPTION
## Summary

### 1. OK-50586: OneKey ID - iOS logout stuck on loading spinner
- **Root cause**: Race condition between the logout confirmation dialog's `onConfirm` and the `handleLoggedOutWhileFocused` effect. When `apiLogout()` updated the primePersistAtom, the effect fired `popModalPagesOnNative()`, dismissing the modal while the dialog was still processing — leaving an orphaned dialog with a permanent loading spinner.
- **Fix**: Add `isExplicitLogoutRef` flag set via `onBeforeLogout` callback before `logout()` starts, preventing the automatic effect from interfering with user-initiated logout.
- **Files**: `OneKeyId/index.tsx`, `PrimeUserInfo.tsx`, `PrimeUserInfoMoreButton.tsx`

### 2. OK-50494: Web - currency/language dropdown overlap in settings
- **Root cause**: Both Language and Currency `Select` components in the web header settings dropdown could open simultaneously, causing content overlap.
- **Fix**: Extract content into `MoreDappActionContent` component with key-based mutual exclusion — when one `Select` opens, the other is force-remounted (closed) via key increment.
- **Files**: `DappHeader.tsx`

## Affected Platforms
- **OK-50586**: iOS (native)
- **OK-50494**: Web

## Test plan
- [ ] iOS: OneKey ID settings → logout → verify no loading spinner stuck
- [ ] Web: Header settings → click currency then language rapidly → verify no overlap


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
