### PR TITLE
fix(perps): handle flat API response in deposit quote build OK-50548

### DIFF
--- a/packages/kit/src/views/Perp/hooks/usePerpDeposit.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpDeposit.ts
@@ -343,9 +343,10 @@ const usePerpDeposit = (
           receivingAddress: result?.perpReceiverAddress ?? '',
           swapBuildResData: {
             result: {
-              ...buildSwapRes.result,
-              // Fallback to outer info when inner result.info is missing
-              info: buildSwapRes.result.info ?? buildSwapRes.info,
+              // API returns flat structure — buildSwapRes.result may be undefined,
+              // fall back to buildSwapRes itself which contains the same fields
+              ...(buildSwapRes.result ?? buildSwapRes),
+              info: buildSwapRes.result?.info ?? buildSwapRes.info,
             },
           },
         };


### PR DESCRIPTION
## Summary
- Fix crash when clicking deposit button in Perps: `TypeError: Cannot read properties of undefined (reading 'info')` at `usePerpDeposit.ts:348`
- Root cause: `perp-deposit-quote` API returns a flat structure where `gasLimit`/`slippage`/`routesData`/`info` are at the top level, not nested under `result.result` as the TypeScript type expects
- Fix: fall back to `buildSwapRes` itself when `buildSwapRes.result` is undefined, since it contains the same fields

## Test plan
- [ ] Select ETH as deposit token, enter amount to get a quote, click deposit button — should no longer crash
- [ ] Verify transaction builds and sends correctly
- [ ] Verify gasLimit and routesData are properly passed through