### PR TITLE
feat: add table-style layout for market search results

### DIFF
--- a/packages/kit/src/views/UniversalSearch/components/MarketTableHeader.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/MarketTableHeader.tsx
@@ -1,0 +1,58 @@
+import { useIntl } from 'react-intl';
+
+import { SizableText, XStack, useMedia } from '@onekeyhq/components';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+
+export const MARKET_NAME_COLUMN_WIDTH = 160;
+export const MARKET_DATA_COLUMN_WIDTH = '33.3333%';
+
+export function MarketTableHeader() {
+  const intl = useIntl();
+  const { gtMd } = useMedia();
+  return (
+    <XStack alignSelf="stretch" mx="$2" px="$3" py="$1.5" gap="$3" ai="center">
+      <XStack w={MARKET_NAME_COLUMN_WIDTH} gap="$1" ai="center" flexShrink={0}>
+        <XStack w="$8" ai="center" jc="center">
+          <SizableText size="$bodySm" color="$textSubdued">
+            #
+          </SizableText>
+        </XStack>
+        <SizableText size="$bodySm" color="$textSubdued" flex={1}>
+          {intl.formatMessage({ id: ETranslations.global_name }).toUpperCase()}
+        </SizableText>
+      </XStack>
+      <XStack flex={1} minWidth={0}>
+        <XStack
+          w={gtMd ? MARKET_DATA_COLUMN_WIDTH : undefined}
+          flex={gtMd ? undefined : 1}
+          jc="flex-end"
+        >
+          <SizableText size="$bodySm" color="$textSubdued" textAlign="right">
+            {intl
+              .formatMessage({ id: ETranslations.global_price })
+              .toUpperCase()}{' '}
+            / 24H
+          </SizableText>
+        </XStack>
+        {gtMd ? (
+          <XStack w={MARKET_DATA_COLUMN_WIDTH} jc="flex-end">
+            <SizableText size="$bodySm" color="$textSubdued" textAlign="right">
+              {intl
+                .formatMessage({ id: ETranslations.global_liquidity })
+                .toUpperCase()}
+            </SizableText>
+          </XStack>
+        ) : null}
+        {gtMd ? (
+          <XStack w={MARKET_DATA_COLUMN_WIDTH} jc="flex-end">
+            <SizableText size="$bodySm" color="$textSubdued" textAlign="right">
+              {intl
+                .formatMessage({ id: ETranslations.dexmarket_turnover })
+                .toUpperCase()}
+            </SizableText>
+          </XStack>
+        ) : null}
+      </XStack>
+    </XStack>
+  );
+}

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
@@ -7,13 +7,14 @@ import {
   IconButton,
   NumberSizeableText,
   SizableText,
+  Stack,
   XStack,
   YStack,
   rootNavigationRef,
   useClipboard,
   useMedia,
 } from '@onekeyhq/components';
-import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
+import { listItemPressStyle } from '@onekeyhq/shared/src/style';
 import { useMarketWatchListV2Atom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2/atoms';
 import { useUniversalSearchActions } from '@onekeyhq/kit/src/states/jotai/contexts/universalSearch';
 import { CommunityRecognizedBadge } from '@onekeyhq/kit/src/views/Market/components/CommunityRecognizedBadge';
@@ -132,6 +133,8 @@ interface IUniversalSearchMarketTokenItemProps {
   item: IUniversalSearchV2MarketToken;
   searchStatus: ESearchStatus;
 }
+const MARKET_NAME_COLUMN_WIDTH = 160;
+const MARKET_DATA_COLUMN_WIDTH = '33.3333%';
 
 export function UniversalSearchV2MarketTokenItem({
   item,
@@ -139,6 +142,7 @@ export function UniversalSearchV2MarketTokenItem({
 }: IUniversalSearchMarketTokenItemProps) {
   // Ensure market watch list atom is initialized
   const [{ isMounted }] = useMarketWatchListV2Atom();
+  const { gtMd } = useMedia();
   const universalSearchActions = useUniversalSearchActions();
   const toMarketDetailPage = useToDetailPage({
     switchToMarketTabFirst: true,
@@ -152,10 +156,14 @@ export function UniversalSearchV2MarketTokenItem({
     address,
     network,
     liquidity,
-    volume_24h: volume24h,
+    volume_24h,
+    volume24h: volume24hCamel,
+    priceChange24hPercent,
     isNative,
     communityRecognized,
   } = item.payload;
+
+  const volume24h = volume24hCamel || volume_24h;
 
   // Hide favorite button in extension popup and side panel
   const shouldShowFavoriteButton = useMemo(
@@ -209,52 +217,114 @@ export function UniversalSearchV2MarketTokenItem({
   }
 
   return (
-    <ListItem
-      jc="space-between"
+    <Stack
+      flexDirection="row"
+      alignItems="center"
+      gap="$3"
+      alignSelf="stretch"
+      py="$2"
+      px="$3"
+      mx="$2"
+      minHeight="$11"
+      borderRadius="$3"
+      borderCurve="continuous"
+      overflow="hidden"
       onPress={handlePress}
-      renderAvatar={
-        <MarketTokenIcon uri={logoUrl} size="lg" networkId={network} />
-      }
+      {...listItemPressStyle}
     >
-      <ListItem.Text
-        flex={1}
-        primary={
-          <XStack alignItems="center" gap="$1">
+      {/* # + NAME column */}
+      <XStack w={MARKET_NAME_COLUMN_WIDTH} gap="$1" ai="center" flexShrink={0}>
+        <XStack w="$8" ai="center" jc="center">
+          {shouldShowFavoriteButton ? (
+            <MarketStarV2
+              chainId={network}
+              contractAddress={address}
+              from={EWatchlistFrom.Search}
+              tokenSymbol={symbol}
+              size="small"
+              isNative={isNative}
+            />
+          ) : null}
+        </XStack>
+        <XStack ai="center" gap="$2" flex={1} minWidth={0}>
+          <MarketTokenIcon uri={logoUrl} size="sm" networkId={network} />
+          <YStack flex={1} minWidth={0}>
+            <XStack ai="center" gap="$1" minWidth={0}>
+              <SizableText
+                size="$bodyMdMedium"
+                numberOfLines={1}
+                flexShrink={1}
+              >
+                {symbol}
+              </SizableText>
+              {communityRecognized ? <CommunityRecognizedBadge /> : null}
+            </XStack>
             <SizableText
-              size="$bodyLgMedium"
+              size="$bodySm"
+              color="$textSubdued"
               numberOfLines={1}
-              maxWidth="$60"
-              flexShrink={1}
             >
-              {symbol}
+              {name}
             </SizableText>
-            {communityRecognized ? <CommunityRecognizedBadge /> : null}
-          </XStack>
-        }
-        secondary={<ContractAddress address={address} />}
-      />
-      <XStack alignItems="center">
-        <YStack alignItems="flex-end">
+          </YStack>
+        </XStack>
+      </XStack>
+
+      <XStack flex={1} minWidth={0}>
+        {/* PRICE / 24H column */}
+        <YStack
+          w={gtMd ? MARKET_DATA_COLUMN_WIDTH : undefined}
+          flex={gtMd ? undefined : 1}
+          ai="flex-end"
+        >
           <BaseMarketTokenPrice
             price={price}
-            size="$bodyLgMedium"
+            size="$bodyMd"
             tokenName={name}
             tokenSymbol={symbol}
           />
-          <MarketTokenLiquidity liquidity={liquidity} volume24h={volume24h} />
+          {priceChange24hPercent ? (
+            <NumberSizeableText
+              size="$bodySm"
+              formatter="priceChange"
+              color={
+                Number(priceChange24hPercent) >= 0
+                  ? '$textSuccess'
+                  : '$textCritical'
+              }
+              formatterOptions={{ showPlusMinusSigns: true }}
+            >
+              {priceChange24hPercent}
+            </NumberSizeableText>
+          ) : null}
         </YStack>
-        {shouldShowFavoriteButton ? (
-          <MarketStarV2
-            chainId={network}
-            contractAddress={address}
-            ml="$3"
-            from={EWatchlistFrom.Search}
-            tokenSymbol={symbol}
-            size="medium"
-            isNative={isNative}
-          />
+
+        {/* LIQUIDITY column - desktop only */}
+        {gtMd ? (
+          <XStack w={MARKET_DATA_COLUMN_WIDTH} jc="flex-end" ai="center">
+            <NumberSizeableText
+              size="$bodyMd"
+              formatter="marketCap"
+              formatterOptions={{ capAtMaxT: true }}
+            >
+              {BigNumber(liquidity).gt(0) ? liquidity : '--'}
+            </NumberSizeableText>
+          </XStack>
+        ) : null}
+
+        {/* VOLUME 24H column - desktop only */}
+        {gtMd ? (
+          <XStack w={MARKET_DATA_COLUMN_WIDTH} jc="flex-end" ai="center">
+            <NumberSizeableText
+              size="$bodyMd"
+              formatter="marketCap"
+              formatterOptions={{ capAtMaxT: true }}
+            >
+              {BigNumber(volume24h).gt(0) ? volume24h : '--'}
+            </NumberSizeableText>
+          </XStack>
         ) : null}
       </XStack>
-    </ListItem>
+    </Stack>
   );
 }

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
@@ -31,6 +31,7 @@ import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import type { IUniversalSearchV2MarketToken } from '@onekeyhq/shared/types/search';
 import { ESearchStatus } from '@onekeyhq/shared/types/search';
 
+import { MARKET_DATA_COLUMN_WIDTH, MARKET_NAME_COLUMN_WIDTH } from '../MarketTableHeader';
 import { MarketStarV2 } from '../../../Market/components/MarketStarV2';
 import { MarketTokenIcon } from '../../../Market/components/MarketTokenIcon';
 import { BaseMarketTokenPrice } from '../../../Market/components/MarketTokenPrice';
@@ -133,8 +134,6 @@ interface IUniversalSearchMarketTokenItemProps {
   item: IUniversalSearchV2MarketToken;
   searchStatus: ESearchStatus;
 }
-const MARKET_NAME_COLUMN_WIDTH = 160;
-const MARKET_DATA_COLUMN_WIDTH = '33.3333%';
 
 export function UniversalSearchV2MarketTokenItem({
   item,

--- a/packages/kit/src/views/UniversalSearch/pages/UniversalSearch.tsx
+++ b/packages/kit/src/views/UniversalSearch/pages/UniversalSearch.tsx
@@ -18,7 +18,6 @@ import {
   View,
   XStack,
   YStack,
-  useMedia,
 } from '@onekeyhq/components';
 import { DiscoveryBrowserProviderMirror } from '@onekeyhq/kit/src/views/Discovery/components/DiscoveryBrowserProviderMirror';
 import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -61,6 +60,7 @@ import {
   UniversalSearchV2MarketTokenItem,
 } from '../components/SearchResultItems';
 
+import { MarketTableHeader } from '../components/MarketTableHeader';
 import { RecentSearched } from './components/RecentSearched';
 import { UniversalSearchProviderMirror } from './UniversalSearchProviderMirror';
 
@@ -128,60 +128,6 @@ function ListEmptyComponent() {
 }
 
 const isMarketSection = (tabIndex: number) => tabIndex === 2;
-const MARKET_NAME_COLUMN_WIDTH = 160;
-const MARKET_DATA_COLUMN_WIDTH = '33.3333%';
-
-function MarketTableHeader() {
-  const intl = useIntl();
-  const { gtMd } = useMedia();
-  return (
-    <XStack alignSelf="stretch" mx="$2" px="$3" py="$1.5" gap="$3" ai="center">
-      {/* Matches row: star($8) + gap($1) + icon($8) + gap($2) + name */}
-      <XStack w={MARKET_NAME_COLUMN_WIDTH} gap="$1" ai="center" flexShrink={0}>
-        <XStack w="$8" ai="center" jc="center">
-          <SizableText size="$bodySm" color="$textSubdued">
-            #
-          </SizableText>
-        </XStack>
-        <SizableText size="$bodySm" color="$textSubdued" flex={1}>
-          {intl.formatMessage({ id: ETranslations.global_name }).toUpperCase()}
-        </SizableText>
-      </XStack>
-      <XStack flex={1} minWidth={0}>
-        <XStack
-          w={gtMd ? MARKET_DATA_COLUMN_WIDTH : undefined}
-          flex={gtMd ? undefined : 1}
-          jc="flex-end"
-        >
-          <SizableText size="$bodySm" color="$textSubdued" textAlign="right">
-            {intl
-              .formatMessage({ id: ETranslations.global_price })
-              .toUpperCase()}{' '}
-            / 24H
-          </SizableText>
-        </XStack>
-        {gtMd ? (
-          <XStack w={MARKET_DATA_COLUMN_WIDTH} jc="flex-end">
-            <SizableText size="$bodySm" color="$textSubdued" textAlign="right">
-              {intl
-                .formatMessage({ id: ETranslations.global_liquidity })
-                .toUpperCase()}
-            </SizableText>
-          </XStack>
-        ) : null}
-        {gtMd ? (
-          <XStack w={MARKET_DATA_COLUMN_WIDTH} jc="flex-end">
-            <SizableText size="$bodySm" color="$textSubdued" textAlign="right">
-              {intl
-                .formatMessage({ id: ETranslations.dexmarket_turnover })
-                .toUpperCase()}
-            </SizableText>
-          </XStack>
-        ) : null}
-      </XStack>
-    </XStack>
-  );
-}
 
 export function UniversalSearch({
   filterTypes,

--- a/packages/kit/src/views/UniversalSearch/pages/UniversalSearch.tsx
+++ b/packages/kit/src/views/UniversalSearch/pages/UniversalSearch.tsx
@@ -18,6 +18,7 @@ import {
   View,
   XStack,
   YStack,
+  useMedia,
 } from '@onekeyhq/components';
 import { DiscoveryBrowserProviderMirror } from '@onekeyhq/kit/src/views/Discovery/components/DiscoveryBrowserProviderMirror';
 import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -123,6 +124,62 @@ function ListEmptyComponent() {
       <SkeletonItem />
       <SkeletonItem />
     </YStack>
+  );
+}
+
+const isMarketSection = (tabIndex: number) => tabIndex === 2;
+const MARKET_NAME_COLUMN_WIDTH = 160;
+const MARKET_DATA_COLUMN_WIDTH = '33.3333%';
+
+function MarketTableHeader() {
+  const intl = useIntl();
+  const { gtMd } = useMedia();
+  return (
+    <XStack alignSelf="stretch" mx="$2" px="$3" py="$1.5" gap="$3" ai="center">
+      {/* Matches row: star($8) + gap($1) + icon($8) + gap($2) + name */}
+      <XStack w={MARKET_NAME_COLUMN_WIDTH} gap="$1" ai="center" flexShrink={0}>
+        <XStack w="$8" ai="center" jc="center">
+          <SizableText size="$bodySm" color="$textSubdued">
+            #
+          </SizableText>
+        </XStack>
+        <SizableText size="$bodySm" color="$textSubdued" flex={1}>
+          {intl.formatMessage({ id: ETranslations.global_name }).toUpperCase()}
+        </SizableText>
+      </XStack>
+      <XStack flex={1} minWidth={0}>
+        <XStack
+          w={gtMd ? MARKET_DATA_COLUMN_WIDTH : undefined}
+          flex={gtMd ? undefined : 1}
+          jc="flex-end"
+        >
+          <SizableText size="$bodySm" color="$textSubdued" textAlign="right">
+            {intl
+              .formatMessage({ id: ETranslations.global_price })
+              .toUpperCase()}{' '}
+            / 24H
+          </SizableText>
+        </XStack>
+        {gtMd ? (
+          <XStack w={MARKET_DATA_COLUMN_WIDTH} jc="flex-end">
+            <SizableText size="$bodySm" color="$textSubdued" textAlign="right">
+              {intl
+                .formatMessage({ id: ETranslations.global_liquidity })
+                .toUpperCase()}
+            </SizableText>
+          </XStack>
+        ) : null}
+        {gtMd ? (
+          <XStack w={MARKET_DATA_COLUMN_WIDTH} jc="flex-end">
+            <SizableText size="$bodySm" color="$textSubdued" textAlign="right">
+              {intl
+                .formatMessage({ id: ETranslations.dexmarket_turnover })
+                .toUpperCase()}
+            </SizableText>
+          </XStack>
+        ) : null}
+      </XStack>
+    </XStack>
   );
 }
 
@@ -450,11 +507,14 @@ export function UniversalSearch({
   const renderSectionHeader = useCallback(
     ({ section }: { section: IUniversalSection }) => {
       return (
-        <XStack bg="$bgApp" h="$9" ai="center">
-          <SizableText px="$5" size="$headingSm" color="$textSubdued">
-            {section.title}
-          </SizableText>
-        </XStack>
+        <YStack bg="$bgApp">
+          <XStack h="$9" ai="center">
+            <SizableText px="$5" size="$headingSm" color="$textSubdued">
+              {section.title}
+            </SizableText>
+          </XStack>
+          {isMarketSection(section.tabIndex) ? <MarketTableHeader /> : null}
+        </YStack>
       );
     },
     [],

--- a/packages/shared/types/market.ts
+++ b/packages/shared/types/market.ts
@@ -263,5 +263,8 @@ export interface IMarketSearchV2Token {
   decimals: number;
   liquidity: string;
   volume_24h: string;
+  volume24h?: string;
+  marketCap?: string;
+  priceChange24hPercent?: string;
   communityRecognized?: boolean;
 }


### PR DESCRIPTION
## Summary
- Redesign V2 market token search results in Universal Search modal to use a table layout
- Add column headers (#, NAME, PRICE/24H, LIQUIDITY, VOLUME 24H) for market sections
- Convert V2MarketTokenItem from ListItem to table row with star button, token icon, price + 24h change, liquidity, volume
- Responsive: Liquidity and Volume columns hidden on mobile, shown on desktop
- Add `priceChange24hPercent`, `volume24h`, `marketCap` fields to `IMarketSearchV2Token` type
- Other search sections (Accounts, DApps, Perp, Tokens) remain unchanged

## Test plan
- [ ] Open Universal Search modal, search for a token (e.g., "BTC", "ETH")
- [ ] Verify "Market" section shows table column headers
- [ ] Verify each row displays: star, icon, name, price with 24h%, liquidity, volume
- [ ] Verify liquidity/volume columns hide on narrow screens
- [ ] Verify star/favorite functionality works
- [ ] Verify clicking a token navigates to detail page
- [ ] Verify other sections (Wallets, DApps, Perp, Tokens, My Assets) unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
