### PR TITLE
fix(referral): add optional chaining for postConfig nested properties

### DIFF
--- a/packages/kit/src/views/ReferFriends/pages/ReferAFriend/components/ReferAFriendHowToPhase/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/ReferAFriend/components/ReferAFriendHowToPhase/index.tsx
@@ -42,7 +42,7 @@ export function ReferAFriendHowToPhase({
                   id: ETranslations.referral_intro_p2_desc_bullet1,
                 },
                 {
-                  amount: `${inviterRebate.amount}${inviterRebate.unit}`,
+                  amount: `${inviterRebate?.amount ?? ''}${inviterRebate?.unit ?? ''}`,
                 },
               ),
             },
@@ -53,7 +53,7 @@ export function ReferAFriendHowToPhase({
                   id: ETranslations.referral_intro_p2_desc_bullet2,
                 },
                 {
-                  amount: `${theirDiscount.amount}${theirDiscount.unit}`,
+                  amount: `${theirDiscount?.amount ?? ''}${theirDiscount?.unit ?? ''}`,
                 },
               ),
             },

--- a/packages/kit/src/views/ReferFriends/pages/ReferAFriend/components/ReferAFriendIntroPhase/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/ReferAFriend/components/ReferAFriendIntroPhase/index.tsx
@@ -28,7 +28,7 @@ export function ReferAFriendIntroPhase({
           id: ETranslations.referral_intro_p1_desc_bullet1,
         },
         {
-          amount: `${postConfig.commissionRate.amount}${postConfig.commissionRate.unit}`,
+          amount: `${postConfig.commissionRate?.amount ?? ''}${postConfig.commissionRate?.unit ?? ''}`,
         },
       ),
     },
@@ -39,7 +39,7 @@ export function ReferAFriendIntroPhase({
           id: ETranslations.referral_intro_p1_desc_bullet2,
         },
         {
-          amount: `${postConfig.friendDiscount.unit}${postConfig.friendDiscount.amount}`,
+          amount: `${postConfig.friendDiscount?.unit ?? ''}${postConfig.friendDiscount?.amount ?? ''}`,
         },
       ),
     },
@@ -63,7 +63,7 @@ export function ReferAFriendIntroPhase({
                   size="$heading2xl"
                   color="$textSuccess"
                 >
-                  {`${postConfig.referralReward.unit}${postConfig.referralReward.amount}`}
+                  {`${postConfig.referralReward?.unit ?? ''}${postConfig.referralReward?.amount ?? ''}`}
                 </SizableText>
               ),
             },


### PR DESCRIPTION
## Summary

- Fix `TypeError: Cannot read property 'amount' of undefined` crash in ReferAFriend page
- Add optional chaining (`?.`) and fallback defaults (`?? ''`) for `postConfig` nested properties in both `ReferAFriendHowToPhase` and `ReferAFriendIntroPhase` components
- API `/rebate/v1/invite/post-config` may return partial config missing `inviterRebate`, `theirDiscount`, `commissionRate`, `friendDiscount`, or `referralReward` fields

## Test plan

- [ ] Navigate to ReferAFriend page (step 1 IntroPhase) — should render without crash
- [ ] Tap to proceed to step 2 (HowToPhase) — should render without crash
- [ ] Verify amounts display correctly when API returns complete config
- [ ] Verify page degrades gracefully (empty strings) when API returns partial config
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
