### PR TITLE
docs: add keyboard avoidance recipe to 1k-ui-recipes skill

### DIFF
--- a/.claude/skills/1k-ui-recipes/SKILL.md
+++ b/.claude/skills/1k-ui-recipes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 1k-ui-recipes
-description: UI recipes for scroll offset (useScrollContentTabBarOffset), view transitions (startViewTransition), horizontal scroll in collapsible tab headers (CollapsibleTabContext), and Android bottom tab touch interception workaround.
+description: UI recipes for scroll offset (useScrollContentTabBarOffset), view transitions (startViewTransition), horizontal scroll in collapsible tab headers (CollapsibleTabContext), Android bottom tab touch interception workaround, and keyboard avoidance for input fields.
 allowed-tools: Read, Grep, Glob
 ---
 
@@ -16,6 +16,7 @@ Bite-sized solutions for common UI issues.
 | Smooth State Transitions | [start-view-transition.md](references/rules/start-view-transition.md) | Wrap heavy state updates in `startViewTransition` for fade on web |
 | Horizontal Scroll in Collapsible Tab Headers | [collapsible-tab-horizontal-scroll.md](references/rules/collapsible-tab-horizontal-scroll.md) | Bidirectional `Gesture.Pan()` + programmatic `scrollTo` via `CollapsibleTabContext` |
 | Android Bottom Tab Touch Interception | [android-bottom-tab-touch-intercept.md](references/rules/android-bottom-tab-touch-intercept.md) | **Temporary** — `GestureDetector` + `Gesture.Tap()` in `.android.tsx` to bypass native tab bar touch stealing |
+| Keyboard Avoidance for Input Fields | [keyboard-avoidance.md](references/rules/keyboard-avoidance.md) | `KeyboardAwareScrollView` auto-scroll, Footer animated padding, `useKeyboardHeight` / `useKeyboardEvent` hooks |
 
 ## Critical Rules Summary
 
@@ -75,6 +76,42 @@ const tapGesture = useMemo(
 ```
 
 > Use `.android.tsx` file extension so other platforms are unaffected.
+
+### 5. Keyboard Avoidance for Input Fields
+
+Standard `Page` and `Dialog` components handle keyboard avoidance automatically. Only add manual handling for custom layouts.
+
+- **Page inputs**: Automatic — `PageContainer` wraps with `KeyboardAwareScrollView` (90px `bottomOffset`)
+- **Page Footer**: Automatic — animates `paddingBottom` via `useReanimatedKeyboardAnimation`
+- **Dialog Footer**: Automatic — listens via `useKeyboardEventWithoutNavigation`
+- **Custom layout**: Use `Keyboard.AwareScrollView` with custom `bottomOffset`
+
+```typescript
+import { Keyboard } from '@onekeyhq/components';
+
+// Custom scrollable area with keyboard avoidance
+<Keyboard.AwareScrollView bottomOffset={150}>
+  {/* inputs */}
+</Keyboard.AwareScrollView>
+
+// Dismiss keyboard before navigation
+await Keyboard.dismissWithDelay();
+```
+
+Hooks for custom behavior:
+
+```typescript
+import { useKeyboardHeight, useKeyboardEvent } from '@onekeyhq/components';
+
+const height = useKeyboardHeight(); // 0 when hidden
+
+useKeyboardEvent({
+  keyboardWillShow: (e) => { /* e.endCoordinates.height */ },
+  keyboardWillHide: () => { /* ... */ },
+});
+```
+
+> Use `useKeyboardEventWithoutNavigation` for components outside NavigationContainer (Dialog, Modal).
 
 ---
 

--- a/.claude/skills/1k-ui-recipes/references/rules/keyboard-avoidance.md
+++ b/.claude/skills/1k-ui-recipes/references/rules/keyboard-avoidance.md
@@ -1,0 +1,117 @@
+# Keyboard Avoidance for Input Fields
+
+## Overview
+
+The project uses `react-native-keyboard-controller` wrapped in a unified `Keyboard` component (`packages/components/src/content/Keyboard/`). Web falls back to no-op / plain ScrollView.
+
+## Strategy 1: KeyboardAwareScrollView (Auto-scroll)
+
+`PageContainer` automatically wraps children with `KeyboardAwareScrollView` when `scrollEnabled` is true. No extra code needed for standard `Page` usage.
+
+**File**: `packages/components/src/layouts/Page/PageContainer.native.tsx`
+
+```typescript
+<KeyboardAwareScrollView
+  bottomOffset={KEYBOARD_AWARE_SCROLL_BOTTOM_OFFSET} // 90px default
+  style={[{ flex: 1 }, style]}
+>
+  {children}
+</KeyboardAwareScrollView>
+```
+
+**Constant**: `packages/components/src/content/Keyboard/constant.ts`
+
+```typescript
+export const KEYBOARD_AWARE_SCROLL_BOTTOM_OFFSET = 90;
+```
+
+Custom `bottomOffset` when needed:
+
+```typescript
+<Keyboard.AwareScrollView bottomOffset={150}>
+  {/* content */}
+</Keyboard.AwareScrollView>
+```
+
+## Strategy 2: Footer Animated Padding
+
+### Page Footer
+
+**File**: `packages/components/src/layouts/Page/PageFooter.tsx`
+
+Uses `useReanimatedKeyboardAnimation` to animate `paddingBottom` so bottom buttons follow the keyboard.
+
+```typescript
+const { height: keyboardHeight } = useReanimatedKeyboardAnimation();
+const animatedStyle = useAnimatedStyle(() => ({
+  paddingBottom: Math.max(Math.abs(keyboardHeight.value) - tabBarHeight, 0),
+}));
+```
+
+### Dialog Footer
+
+**File**: `packages/components/src/composite/Dialog/Footer.tsx`
+
+Dialogs live outside NavigationContainer, so they use `useKeyboardEventWithoutNavigation`:
+
+```typescript
+useKeyboardEventWithoutNavigation({
+  keyboardWillShow: (e) => {
+    keyboardHeightValue.value = e.endCoordinates.height - bottom;
+  },
+  keyboardWillHide: () => {
+    keyboardHeightValue.value = 0;
+  },
+});
+```
+
+## Strategy 3: Custom Hooks
+
+**File**: `packages/components/src/hooks/useKeyboard.ts`
+
+| Hook | Usage |
+|------|-------|
+| `useKeyboardHeight()` | Returns current keyboard height (0 when hidden) |
+| `useKeyboardEvent({ keyboardWillShow, keyboardWillHide })` | Fires only when current screen is focused (`useIsFocused`) |
+| `useKeyboardEventWithoutNavigation(...)` | Same but no Navigation dependency — for Dialog / Modal |
+
+## Keyboard Dismissal
+
+**File**: `packages/shared/src/keyboard/index.native.ts`
+
+```typescript
+import { Keyboard } from '@onekeyhq/components';
+
+Keyboard.dismiss();                  // close immediately
+await Keyboard.dismissWithDelay();   // close + wait 80ms (useful before navigation)
+```
+
+## Decision Table
+
+| Scenario | Approach | Extra code? |
+|----------|----------|-------------|
+| Input in a standard `Page` | Automatic via `PageContainer` | No |
+| Bottom buttons in `Page` | Automatic via `Page.Footer` | No |
+| Input in `Dialog` | Automatic via `Dialog.Footer` | No |
+| Custom layout (e.g. Onboarding) | `Keyboard.AwareScrollView` + `bottomOffset` | Yes |
+| Layout adjusted by keyboard state | `useKeyboardHeight()` / `useKeyboardEvent()` | Yes |
+| Dismiss keyboard before action | `Keyboard.dismiss()` / `Keyboard.dismissWithDelay()` | Yes |
+
+## Cross-Platform Behavior
+
+| Platform | AwareScrollView | Footer animation | useKeyboardHeight |
+|----------|----------------|-----------------|-------------------|
+| iOS | Auto-scroll | Animated padding | Real height |
+| Android | Auto-scroll | Animated padding | Real height |
+| Web | Falls back to ScrollView | Disabled | Returns 0 |
+
+## Key Files
+
+- `packages/components/src/content/Keyboard/index.native.tsx` — Native Keyboard wrapper
+- `packages/components/src/content/Keyboard/index.tsx` — Web fallback
+- `packages/components/src/content/Keyboard/constant.ts` — Constants
+- `packages/components/src/layouts/Page/PageContainer.native.tsx` — Page keyboard handling
+- `packages/components/src/layouts/Page/PageFooter.tsx` — Page Footer animation
+- `packages/components/src/composite/Dialog/Footer.tsx` — Dialog Footer animation
+- `packages/components/src/hooks/useKeyboard.ts` — Keyboard hooks
+- `packages/shared/src/keyboard/index.native.ts` — Dismiss utilities


### PR DESCRIPTION
## Summary
- Add keyboard avoidance reference doc to `1k-ui-recipes` skill covering `KeyboardAwareScrollView` auto-scroll, Footer animated padding, and custom keyboard hooks
- Update SKILL.md with new recipe entry in Quick Reference table and Critical Rules Summary section
- Document cross-platform behavior (iOS/Android/Web) and decision table for choosing the right approach

## Test plan
- [ ] Verify `1k-ui-recipes` skill loads correctly in Claude Code
- [ ] Confirm reference doc links resolve properly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
