### PR TITLE
feat: support HD passphrase wallets for non-hardware flows

### DIFF
--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -2176,7 +2176,7 @@ PODS:
     - SocketRocket
   - react-native-aes (3.2.1):
     - React-Core
-  - react-native-ble-plx (3.5.0):
+  - react-native-ble-plx (3.5.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -4764,7 +4764,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 94f4264de2cb156960cd82b338a403f4653f2fd9
   React-microtasksnativemodule: 6c4ee39a36958c39c97b074d28f360246a335e84
   react-native-aes: e38d08f68d27e85d14590b7ef0b404ceebf5f891
-  react-native-ble-plx: effae4e8e465c52768497f87abd2b95791eb2de2
+  react-native-ble-plx: 152b07bdf772c95e30c0251649d462b5154a0e13
   react-native-bottom-tabs: e33312fc663d163f0be73d3474dfb448ba38dad8
   react-native-capture-protection: a8abb2b0880aa1808e3724aa3fc7e56e72225a24
   react-native-cloud-fs: 03ad849da6cecc3cb58ed970ce4078a2e0814848

--- a/packages/core/src/chains/btc/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/btc/CoreChainSoftware.test.ts
@@ -98,6 +98,28 @@ describe('BTC Core tests', () => {
     });
   });
 
+  it('buildXfpFromMnemonic should respect passphrase and be deterministic', async () => {
+    const coreApi = new CoreChainHd();
+    const withoutPassphraseA = await coreApi.buildXfpFromMnemonic({
+      mnemonic: hdCredential.mnemonic,
+    });
+    const withoutPassphraseB = await coreApi.buildXfpFromMnemonic({
+      mnemonic: hdCredential.mnemonic,
+    });
+    const withPassphraseA = await coreApi.buildXfpFromMnemonic({
+      mnemonic: hdCredential.mnemonic,
+      passphrase: 'onekey-passphrase',
+    });
+    const withPassphraseB = await coreApi.buildXfpFromMnemonic({
+      mnemonic: hdCredential.mnemonic,
+      passphrase: 'onekey-passphrase',
+    });
+
+    expect(withoutPassphraseA.fullXfp).toBe(withoutPassphraseB.fullXfp);
+    expect(withPassphraseA.fullXfp).toBe(withPassphraseB.fullXfp);
+    expect(withoutPassphraseA.fullXfp).not.toBe(withPassphraseA.fullXfp);
+  });
+
   it.skip('signTransaction', async () => {
     const coreApi = new CoreChainHd();
     // TODO BTC tx mock

--- a/packages/core/src/chains/btc/CoreChainSoftware.ts
+++ b/packages/core/src/chains/btc/CoreChainSoftware.ts
@@ -299,8 +299,14 @@ export default class CoreChainSoftwareBtc extends CoreChainApiBase {
 
   // TODO use generateRootFingerprintHexAsync() instead
   // root fingerprint
-  async buildXfpFromMnemonic({ mnemonic }: { mnemonic: string }) {
-    const seed = await mnemonicToSeedAsync({ mnemonic });
+  async buildXfpFromMnemonic({
+    mnemonic,
+    passphrase,
+  }: {
+    mnemonic: string;
+    passphrase?: string;
+  }) {
+    const seed = await mnemonicToSeedAsync({ mnemonic, passphrase });
     const bip32 = getBitcoinBip32();
     const root = bip32.fromSeed(seed, getBtcForkNetwork('btc'));
 

--- a/packages/kit-bg/src/dbs/local/LocalDbBase.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.ts
@@ -819,13 +819,27 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
     let wallets = allWallets;
     const allDevices =
       option?.allDevices || (await this.getAllDevices()).devices;
-    const hiddenWalletsMap: Partial<{
+    const hiddenWalletsByDeviceMap: Partial<{
       [dbDeviceId: string]: IDBWallet[];
+    }> = {};
+    const hiddenHdWalletsByHashMap: Partial<{
+      [walletHash: string]: IDBWallet[];
     }> = {};
 
     const hwStandardWalletsMap: Partial<{
       [dbDeviceId: string]: IDBWallet | null;
     }> = {};
+    const hdStandardWalletHashMap: Partial<Record<string, boolean>> = {};
+
+    for (const wallet of wallets) {
+      if (
+        accountUtils.isHdWallet({ walletId: wallet.id }) &&
+        !accountUtils.isHdHiddenWallet({ wallet }) &&
+        wallet.hash
+      ) {
+        hdStandardWalletHashMap[wallet.hash] = true;
+      }
+    }
 
     // const label = device?.featuresInfo?.label; // standard hw wallet name/label
 
@@ -862,16 +876,27 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
           return false;
         }
       }
-      if (
-        nestedHiddenWallets &&
-        accountUtils.isHwHiddenWallet({ wallet }) &&
-        wallet.associatedDevice
-      ) {
-        const dbDeviceId = wallet.associatedDevice;
-        hiddenWalletsMap[dbDeviceId] = hiddenWalletsMap[dbDeviceId] || [];
-        hiddenWalletsMap[dbDeviceId]?.push(wallet);
-        if (hwStandardWalletsMap[dbDeviceId] === undefined) {
-          hwStandardWalletsMap[dbDeviceId] = null;
+      if (nestedHiddenWallets && accountUtils.isHiddenWallet({ wallet })) {
+        if (
+          accountUtils.isHwHiddenWallet({ wallet }) &&
+          wallet.associatedDevice
+        ) {
+          const dbDeviceId = wallet.associatedDevice;
+          hiddenWalletsByDeviceMap[dbDeviceId] =
+            hiddenWalletsByDeviceMap[dbDeviceId] || [];
+          hiddenWalletsByDeviceMap[dbDeviceId]?.push(wallet);
+          if (hwStandardWalletsMap[dbDeviceId] === undefined) {
+            hwStandardWalletsMap[dbDeviceId] = null;
+          }
+          return false;
+        }
+        if (accountUtils.isHdHiddenWallet({ wallet })) {
+          if (!wallet.hash || !hdStandardWalletHashMap[wallet.hash]) {
+            return true;
+          }
+          hiddenHdWalletsByHashMap[wallet.hash] =
+            hiddenHdWalletsByHashMap[wallet.hash] || [];
+          hiddenHdWalletsByHashMap[wallet.hash]?.push(wallet);
         }
         return false;
       }
@@ -882,15 +907,23 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
     } = {};
     wallets = await Promise.all(
       wallets.map(async (w) => {
+        let hiddenWallets: IDBWallet[] | undefined;
+        if (w.associatedDevice) {
+          hiddenWallets = (
+            hiddenWalletsByDeviceMap[w.associatedDevice] || []
+          ).filter((hw) => hw.id.startsWith(w.id));
+        } else if (
+          accountUtils.isHdWallet({ walletId: w.id }) &&
+          !accountUtils.isHdHiddenWallet({ wallet: w }) &&
+          w.hash
+        ) {
+          hiddenWallets = hiddenHdWalletsByHashMap[w.hash] || [];
+        }
         const newWallet: IDBWallet = await this.refillWalletInfo({
           refilledWalletsCache,
           allDevices,
           wallet: w,
-          hiddenWallets: w.associatedDevice
-            ? (hiddenWalletsMap[w.associatedDevice] || []).filter((hw) =>
-                hw.id.startsWith(w.id),
-              )
-            : undefined,
+          hiddenWallets,
         });
         if (includingAccounts) {
           await Promise.all([
@@ -989,7 +1022,10 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
       const { wallets } = await this.getWallets();
       if (walletType === WALLET_TYPE_HD) {
         const wallet = wallets.find((w) => {
-          const r = w.type === walletType && w.hash === walletHash;
+          const r =
+            w.type === walletType &&
+            w.hash === walletHash &&
+            (w.passphraseState || '') === (passphraseState || '');
           return r;
         });
         return wallet;
@@ -2105,6 +2141,8 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
       rs,
       walletHash,
       walletXfp,
+      passphraseState,
+      hiddenParentWalletId,
       isKeylessWallet,
       keylessDetailsInfo,
       skipAddHDNextIndexedAccount,
@@ -2127,7 +2165,18 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
         xfp: walletXfp || '',
       });
     }
-    const defaultWalletName = `Wallet ${context.nextHD}`;
+    const parentWallet =
+      passphraseState && hiddenParentWalletId
+        ? await this.getWalletSafe({
+            walletId: hiddenParentWalletId,
+          })
+        : undefined;
+    const hiddenDefaultWalletName =
+      passphraseState && parentWallet
+        ? accountUtils.buildHiddenWalletName({ parentWallet })
+        : undefined;
+    const defaultWalletName =
+      hiddenDefaultWalletName || `Wallet ${context.nextHD}`;
     const initWalletName = name || defaultWalletName;
 
     const firstAccountIndex = 0;
@@ -2155,6 +2204,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
         accounts: [],
         walletNo: context.nextWalletNo,
         deprecated: false,
+        passphraseState,
         isKeyless: !!isKeylessWallet,
         keylessDetails: keylessDetailsInfo
           ? JSON.stringify(keylessDetailsInfo)
@@ -2275,6 +2325,13 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
               return ctx;
             },
           });
+
+          if (passphraseState && hiddenParentWalletId) {
+            await this.txIncreaseParentWalletNextHiddenNum({
+              tx,
+              parentWalletId: hiddenParentWalletId,
+            });
+          }
         },
       });
     });

--- a/packages/kit-bg/src/dbs/local/LocalDbBase.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.ts
@@ -897,8 +897,10 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
           hiddenHdWalletsByHashMap[wallet.hash] =
             hiddenHdWalletsByHashMap[wallet.hash] || [];
           hiddenHdWalletsByHashMap[wallet.hash]?.push(wallet);
+          return false;
         }
-        return false;
+        // Keep unmatched hidden wallets visible instead of dropping them.
+        return true;
       }
       return true;
     });

--- a/packages/kit-bg/src/dbs/local/types.ts
+++ b/packages/kit-bg/src/dbs/local/types.ts
@@ -183,6 +183,8 @@ export type IDBCreateHDWalletParams = {
   name?: string;
   walletHash: string;
   walletXfp: string;
+  passphraseState?: string;
+  hiddenParentWalletId?: string;
   avatar?: IAvatarInfo;
   isKeylessWallet?: boolean;
   keylessDetailsInfo?: IKeylessWalletDetailsInfo;

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -3045,6 +3045,7 @@ class ServiceAccount extends ServiceBase {
 
   hdWalletHashAndXfpBuilder = async (options: {
     realMnemonic: string;
+    passphrase?: string;
   }): Promise<{
     hash: string;
     xfp: string;
@@ -3055,14 +3056,26 @@ class ServiceAccount extends ServiceBase {
 
     const { fullXfp: fulXfp } = await coreChainApi.btc.hd.buildXfpFromMnemonic({
       mnemonic: options.realMnemonic,
+      passphrase: options.passphrase,
     });
     return { hash, xfp: fulXfp };
+  };
+
+  buildHdWalletPassphraseState = async ({
+    walletXfp,
+  }: {
+    walletXfp: string;
+  }): Promise<string> => {
+    const text = `${walletXfp}--EC9E6887-7475-4B0A-A7A6-F5E24E053A3F`;
+    const buff = await sha256(bufferUtils.toBuffer(text, 'utf8'));
+    return bufferUtils.bytesToHex(buff).slice(0, 16);
   };
 
   @backgroundMethod()
   async createHDWallet({
     name,
     mnemonic,
+    mnemonicPassphrase,
     isWalletBackedUp,
     isKeylessWallet,
     avatarInfo,
@@ -3070,6 +3083,7 @@ class ServiceAccount extends ServiceBase {
     skipAddHDNextIndexedAccount,
   }: {
     mnemonic: string;
+    mnemonicPassphrase?: string;
     name?: string;
     isWalletBackedUp?: boolean;
     isKeylessWallet?: boolean;
@@ -3087,6 +3101,14 @@ class ServiceAccount extends ServiceBase {
     const { mnemonic: realMnemonic, mnemonicType } =
       await this.validateMnemonic(mnemonic);
 
+    let realPassphrase = '';
+    if (mnemonicPassphrase) {
+      ensureSensitiveTextEncoded(mnemonicPassphrase);
+      realPassphrase = await decodeSensitiveTextAsync({
+        encodedText: mnemonicPassphrase,
+      });
+    }
+
     if (mnemonicType === EMnemonicType.TON) {
       throw new OneKeyLocalError('TON mnemonic is not supported');
     }
@@ -3095,11 +3117,22 @@ class ServiceAccount extends ServiceBase {
 
     const walletHashAndXfp = await this.hdWalletHashAndXfpBuilder({
       realMnemonic,
+      passphrase: realPassphrase || undefined,
     });
+
+    const passphraseState = realPassphrase
+      ? await this.buildHdWalletPassphraseState({
+          walletXfp: walletHashAndXfp.xfp,
+        })
+      : undefined;
 
     let rs: IBip39RevealableSeedEncryptHex | undefined;
     try {
-      rs = await revealableSeedFromMnemonic(realMnemonic, password);
+      rs = await revealableSeedFromMnemonic(
+        realMnemonic,
+        password,
+        realPassphrase || undefined,
+      );
     } catch {
       throw new InvalidMnemonic();
     }
@@ -3119,7 +3152,103 @@ class ServiceAccount extends ServiceBase {
       avatarInfo,
       keylessDetailsInfo,
       skipAddHDNextIndexedAccount,
+      passphraseState,
     });
+  }
+
+  @backgroundMethod()
+  @toastIfError()
+  async createHDHiddenWallet({
+    walletId,
+    passphrase,
+  }: {
+    walletId: string;
+    passphrase: string;
+  }) {
+    const wallet = await this.getWalletSafe({
+      walletId,
+      withoutRefill: true,
+    });
+    if (!wallet || !accountUtils.isHdWallet({ walletId: wallet.id })) {
+      throw new OneKeyLocalError('createHDHiddenWallet ERROR: Not a HD wallet');
+    }
+    if (wallet.isKeyless) {
+      throw new OneKeyLocalError(
+        'createHDHiddenWallet ERROR: Keyless wallet is not supported',
+      );
+    }
+    if (accountUtils.isHdHiddenWallet({ wallet })) {
+      throw new OneKeyLocalError(
+        'createHDHiddenWallet ERROR: Hidden wallet is not supported',
+      );
+    }
+
+    ensureSensitiveTextEncoded(passphrase);
+    const realPassphrase = await decodeSensitiveTextAsync({
+      encodedText: passphrase,
+    });
+    if (!realPassphrase) {
+      throw new OneKeyLocalError(
+        'createHDHiddenWallet ERROR: passphrase is required',
+      );
+    }
+
+    const { password } =
+      await this.backgroundApi.servicePassword.promptPasswordVerifyByWallet({
+        walletId,
+        reason: EReasonForNeedPassword.CreateOrRemoveWallet,
+      });
+
+    const { mnemonic: realMnemonic } = await this.getCredentialDecrypt({
+      credentialId: walletId,
+      password,
+    });
+
+    const walletHashAndXfp = await this.hdWalletHashAndXfpBuilder({
+      realMnemonic,
+      passphrase: realPassphrase,
+    });
+
+    const passphraseState = await this.buildHdWalletPassphraseState({
+      walletXfp: walletHashAndXfp.xfp,
+    });
+
+    let rs: IBip39RevealableSeedEncryptHex | undefined;
+    try {
+      rs = await revealableSeedFromMnemonic(
+        realMnemonic,
+        password,
+        realPassphrase,
+      );
+    } catch {
+      throw new InvalidMnemonic();
+    }
+    const mnemonicFromRs = await mnemonicFromEntropy(rs, password);
+    if (realMnemonic !== mnemonicFromRs) {
+      throw new InvalidMnemonic();
+    }
+
+    const result = await this.createHDWalletWithRs({
+      rs,
+      password,
+      name: undefined,
+      walletHash: walletHashAndXfp.hash,
+      walletXfp: walletHashAndXfp.xfp,
+      isWalletBackedUp: wallet.backuped,
+      passphraseState,
+      hiddenParentWalletId: walletId,
+    });
+
+    if (result?.wallet?.id && !result.isOverrideWallet) {
+      const hiddenWalletImmediately =
+        await this.backgroundApi.serviceSetting.getHiddenWalletImmediately();
+      await this.setWalletTempStatus({
+        walletId: result.wallet.id,
+        isTemp: !hiddenWalletImmediately,
+      });
+    }
+
+    return result;
   }
 
   @backgroundMethod()
@@ -3167,6 +3296,8 @@ class ServiceAccount extends ServiceBase {
     isKeylessWallet,
     keylessDetailsInfo,
     skipAddHDNextIndexedAccount,
+    passphraseState,
+    hiddenParentWalletId,
   }: {
     rs: string;
     password: string;
@@ -3178,6 +3309,8 @@ class ServiceAccount extends ServiceBase {
     isKeylessWallet?: boolean;
     keylessDetailsInfo?: IKeylessWalletDetailsInfo;
     skipAddHDNextIndexedAccount?: boolean;
+    passphraseState?: string;
+    hiddenParentWalletId?: string;
   }): Promise<{
     wallet: IDBWallet;
     indexedAccount?: IDBIndexedAccount;
@@ -3203,7 +3336,11 @@ class ServiceAccount extends ServiceBase {
         excludeKeylessWallet: true,
       });
       const existsSameHashWallet = wallets.find(
-        (item) => walletHash && item.hash && item.hash === walletHash,
+        (item) =>
+          walletHash &&
+          item.hash &&
+          item.hash === walletHash &&
+          (item.passphraseState || '') === (passphraseState || ''),
       );
       if (existsSameHashWallet) {
         const indexedAccounts = await this.addIndexedAccount({
@@ -3236,6 +3373,8 @@ class ServiceAccount extends ServiceBase {
       isKeylessWallet,
       keylessDetailsInfo,
       skipAddHDNextIndexedAccount,
+      passphraseState,
+      hiddenParentWalletId,
     });
 
     if (result.wallet?.keylessDetailsInfo?.keylessOwnerId) {
@@ -3796,9 +3935,9 @@ class ServiceAccount extends ServiceBase {
     emitEvent?: boolean;
   }) {
     const checkIsNotHiddenWallet = (wallet: IDBWallet | undefined) => {
-      if (wallet && accountUtils.isHwHiddenWallet({ wallet })) {
+      if (wallet && accountUtils.isHiddenWallet({ wallet })) {
         throw new OneKeyLocalError(
-          'insertWalletOrder ERROR: Not supported for HW hidden wallet',
+          'insertWalletOrder ERROR: Not supported for hidden wallet',
         );
       }
     };
@@ -4257,6 +4396,12 @@ class ServiceAccount extends ServiceBase {
     for (const wallet of hdWallets) {
       const isKeylessWallet = wallet.isKeyless;
       if (isKeylessWallet) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      if (wallet.passphraseState) {
+        // Hidden HD wallet xfp depends on passphrase and cannot be reconstructed from mnemonic only.
+        // Keep existing values untouched to avoid overriding with the standard wallet xfp.
         // eslint-disable-next-line no-continue
         continue;
       }

--- a/packages/kit-bg/src/services/ServiceCloudBackup/index.ts
+++ b/packages/kit-bg/src/services/ServiceCloudBackup/index.ts
@@ -645,7 +645,31 @@ class ServiceCloudBackup extends ServiceBase {
         console.error('backup', e);
       }
 
-      for (const id of restoreList.HDWallets) {
+      const { wallets: localWalletsBeforeRestore } =
+        await serviceAccount.getAllWallets({
+          refillWalletInfo: false,
+          excludeKeylessWallet: true,
+        });
+      const standardHdWalletIdByHashMap = localWalletsBeforeRestore.reduce<
+        Record<string, string>
+      >((acc, wallet) => {
+        if (
+          wallet.type === WALLET_TYPE_HD &&
+          wallet.hash &&
+          !wallet.passphraseState
+        ) {
+          acc[wallet.hash] = wallet.id;
+        }
+        return acc;
+      }, {});
+
+      const hdWalletRestoreIds = [...restoreList.HDWallets].sort((a, b) => {
+        const aIsHidden = Boolean(privateData.wallets[a]?.passphraseState);
+        const bIsHidden = Boolean(privateData.wallets[b]?.passphraseState);
+        return Number(aIsHidden) - Number(bIsHidden);
+      });
+
+      for (const id of hdWalletRestoreIds) {
         const {
           version,
           name,
@@ -677,6 +701,12 @@ class ServiceCloudBackup extends ServiceBase {
           localPassword,
         );
 
+        if (passphraseState && (!backupWalletHash || !backupWalletXfp)) {
+          throw new OneKeyLocalError(
+            'Invalid hidden HD wallet backup data: hash/xfp is required.',
+          );
+        }
+
         const walletHashAndXfp =
           backupWalletHash && backupWalletXfp
             ? {
@@ -689,6 +719,11 @@ class ServiceCloudBackup extends ServiceBase {
                 },
               );
 
+        const hiddenParentWalletId =
+          passphraseState && walletHashAndXfp.hash
+            ? standardHdWalletIdByHashMap[walletHashAndXfp.hash]
+            : undefined;
+
         const { wallet, isOverrideWallet } =
           await serviceAccount.createHDWalletWithRs({
             rs: rsEncoded,
@@ -698,7 +733,11 @@ class ServiceCloudBackup extends ServiceBase {
             walletXfp: walletHashAndXfp.xfp,
             isWalletBackedUp: true,
             passphraseState,
+            hiddenParentWalletId,
           });
+        if (!passphraseState && walletHashAndXfp.hash) {
+          standardHdWalletIdByHashMap[walletHashAndXfp.hash] = wallet.id;
+        }
         await serviceAccount.restoreAccountsToWallet({
           walletId: wallet.id,
           accounts,

--- a/packages/kit-bg/src/services/ServiceCloudBackup/index.ts
+++ b/packages/kit-bg/src/services/ServiceCloudBackup/index.ts
@@ -188,6 +188,9 @@ class ServiceCloudBackup extends ServiceBase {
             id: walletId,
             name: wallet.name,
             type: wallet.type,
+            hash: wallet.hash,
+            xfp: wallet.xfp,
+            passphraseState: wallet.passphraseState,
             accounts: [],
             accountIds: [],
             indexedAccountUUIDs: [],
@@ -643,7 +646,15 @@ class ServiceCloudBackup extends ServiceBase {
       }
 
       for (const id of restoreList.HDWallets) {
-        const { version, name, accounts, avatar } = privateData.wallets[id];
+        const {
+          version,
+          name,
+          accounts,
+          avatar,
+          hash: backupWalletHash,
+          xfp: backupWalletXfp,
+          passphraseState,
+        } = privateData.wallets[id];
         if (version !== HDWALLET_BACKUP_VERSION) {
           return;
         }
@@ -667,9 +678,16 @@ class ServiceCloudBackup extends ServiceBase {
         );
 
         const walletHashAndXfp =
-          await this.backgroundApi.serviceAccount.hdWalletHashAndXfpBuilder({
-            realMnemonic: mnemonicFromRs,
-          });
+          backupWalletHash && backupWalletXfp
+            ? {
+                hash: backupWalletHash,
+                xfp: backupWalletXfp,
+              }
+            : await this.backgroundApi.serviceAccount.hdWalletHashAndXfpBuilder(
+                {
+                  realMnemonic: mnemonicFromRs,
+                },
+              );
 
         const { wallet, isOverrideWallet } =
           await serviceAccount.createHDWalletWithRs({
@@ -679,6 +697,7 @@ class ServiceCloudBackup extends ServiceBase {
             walletHash: walletHashAndXfp.hash,
             walletXfp: walletHashAndXfp.xfp,
             isWalletBackedUp: true,
+            passphraseState,
           });
         await serviceAccount.restoreAccountsToWallet({
           walletId: wallet.id,

--- a/packages/kit/src/components/WalletAvatar/WalletAvatar.tsx
+++ b/packages/kit/src/components/WalletAvatar/WalletAvatar.tsx
@@ -36,7 +36,7 @@ export function WalletAvatarBase({
   if (!theImg) {
     return null;
   }
-  const isHidden = accountUtils.isHwHiddenWallet({
+  const isHidden = accountUtils.isHiddenWallet({
     wallet,
   });
 

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -860,11 +860,13 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
       set,
       {
         mnemonic,
+        mnemonicPassphrase,
         isWalletBackedUp,
         isKeylessWallet,
         keylessDetailsInfo,
       }: {
         mnemonic: string;
+        mnemonicPassphrase?: string;
         isWalletBackedUp?: boolean;
         isKeylessWallet?: boolean;
         keylessDetailsInfo?: IKeylessWalletDetailsInfo;
@@ -876,6 +878,7 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
           let { wallet, indexedAccount, isOverrideWallet } =
             await serviceAccount.createHDWallet({
               mnemonic,
+              mnemonicPassphrase,
               isWalletBackedUp,
               isKeylessWallet,
               keylessDetailsInfo,
@@ -913,6 +916,41 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
           }
         },
       }),
+  );
+
+  createHDHiddenWallet = contextAtomMethod(
+    async (
+      _,
+      set,
+      {
+        walletId,
+        passphrase,
+      }: {
+        walletId: string;
+        passphrase: string;
+      },
+      options: {
+        addDefaultNetworkAccounts?: boolean;
+      } = {},
+    ) => {
+      const res = await serviceAccount.createHDHiddenWallet({
+        walletId,
+        passphrase,
+      });
+      const { wallet, indexedAccount, isOverrideWallet } = res;
+      await this.autoSelectToCreatedWallet.call(set, {
+        wallet,
+        indexedAccount,
+        isOverrideWallet,
+      });
+      if (options?.addDefaultNetworkAccounts && indexedAccount?.id) {
+        await this.addDefaultNetworkAccounts.call(set, {
+          wallet,
+          indexedAccount,
+        });
+      }
+      return res;
+    },
   );
 
   createHWWallet = contextAtomMethod(
@@ -2330,6 +2368,7 @@ export function useAccountSelectorActions() {
   const removeWallet = actions.removeWallet.use();
   const removeAccount = actions.removeAccount.use();
   const createHDWallet = actions.createHDWallet.use();
+  const createHDHiddenWallet = actions.createHDHiddenWallet.use();
   // const createHWWallet = actions.createHWWallet.use();
   const createHWHiddenWallet = actions.createHWHiddenWallet.use();
   const createHWWalletWithHidden = actions.createHWWalletWithHidden.use();
@@ -2370,6 +2409,7 @@ export function useAccountSelectorActions() {
     removeWallet,
     removeAccount,
     createHDWallet,
+    createHDHiddenWallet,
     createHWHiddenWallet,
     createHWWalletWithHidden,
     createHWWalletWithoutHidden,

--- a/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletEditButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletEditButton.tsx
@@ -73,8 +73,9 @@ function WalletEditButtonView({
   const showAddHiddenWalletButton = useMemo(() => {
     if (isKeyless) return false;
     return (
-      !accountUtils.isHwHiddenWallet({ wallet }) &&
-      accountUtils.isHwOrQrWallet({ walletId: wallet?.id })
+      !accountUtils.isHiddenWallet({ wallet }) &&
+      (accountUtils.isHwOrQrWallet({ walletId: wallet?.id }) ||
+        accountUtils.isHdWallet({ walletId: wallet?.id }))
     );
   }, [wallet, isKeyless]);
 

--- a/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletRemoveDialog.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletRemoveDialog.tsx
@@ -117,23 +117,20 @@ export function getTitleAndDescription({
     };
   }
 
+  if (accountUtils.isHiddenWallet({ wallet })) {
+    return {
+      isHwOrQr,
+      isKeyless: false,
+      title: appLocale.intl.formatMessage({
+        id: ETranslations.remove_wallet,
+      }),
+      description: appLocale.intl.formatMessage({
+        id: ETranslations.remove_hidden_wallet_desc,
+      }),
+    };
+  }
+
   if (isHwOrQr) {
-    if (
-      accountUtils.isHwHiddenWallet({
-        wallet,
-      })
-    ) {
-      return {
-        isHwOrQr,
-        isKeyless: false,
-        title: appLocale.intl.formatMessage({
-          id: ETranslations.remove_wallet,
-        }),
-        description: appLocale.intl.formatMessage({
-          id: ETranslations.remove_hidden_wallet_desc,
-        }),
-      };
-    }
     if (!isRemoveToMocked) {
       return {
         isHwOrQr,

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/hooks/useAddHiddenWallet.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/hooks/useAddHiddenWallet.tsx
@@ -8,6 +8,7 @@ import {
   Dialog,
   ESwitchSize,
   Icon,
+  Input,
   LinearGradient,
   SizableText,
   Switch,
@@ -173,6 +174,39 @@ function AddHiddenWalletDialogContent() {
   );
 }
 
+function AddHdHiddenWalletPassphraseContent({
+  onPassphraseChange,
+  onConfirmPassphraseChange,
+}: {
+  onPassphraseChange: (value: string) => void;
+  onConfirmPassphraseChange: (value: string) => void;
+}) {
+  const intl = useIntl();
+  return (
+    <YStack gap="$4">
+      <SizableText size="$bodyMd">
+        {intl.formatMessage({
+          id: ETranslations.global_passphrase_desc,
+        })}
+      </SizableText>
+      <Input
+        secureTextEntry
+        placeholder={intl.formatMessage({
+          id: ETranslations.global_enter_passphrase,
+        })}
+        onChangeText={onPassphraseChange}
+      />
+      <Input
+        secureTextEntry
+        placeholder={intl.formatMessage({
+          id: ETranslations.form_confirm_passphrase_placeholder,
+        })}
+        onChangeText={onConfirmPassphraseChange}
+      />
+    </YStack>
+  );
+}
+
 export function useAddHiddenWallet() {
   const intl = useIntl();
   const actions = useAccountSelectorActions();
@@ -213,6 +247,83 @@ export function useAddHiddenWallet() {
         }
       }
     },
+    [actions, intl],
+  );
+
+  const createHdHiddenWallet = useCallback(
+    async ({ wallet }: { wallet?: IDBWallet }) =>
+      new Promise<void>((resolve, reject) => {
+        const passphraseRef = { current: '' };
+        const confirmPassphraseRef = { current: '' };
+
+        Dialog.show({
+          title: intl.formatMessage({
+            id: ETranslations.global_add_hidden_wallet,
+          }),
+          onConfirmText: intl.formatMessage({
+            id: ETranslations.global_confirm,
+          }),
+          renderContent: (
+            <AddHdHiddenWalletPassphraseContent
+              onPassphraseChange={(value) => {
+                passphraseRef.current = value;
+              }}
+              onConfirmPassphraseChange={(value) => {
+                confirmPassphraseRef.current = value;
+              }}
+            />
+          ),
+          onConfirm: async ({ close }) => {
+            try {
+              if (!passphraseRef.current) {
+                Toast.error({
+                  title: intl.formatMessage({
+                    id: ETranslations.global_enter_passphrase,
+                  }),
+                });
+                return;
+              }
+              if (passphraseRef.current !== confirmPassphraseRef.current) {
+                Toast.error({
+                  title: intl.formatMessage({
+                    id: ETranslations.feedback_passphrase_not_matched,
+                  }),
+                });
+                return;
+              }
+
+              setIsLoading(true);
+              const encodedPassphrase =
+                await backgroundApiProxy.servicePassword.encodeSensitiveText({
+                  text: passphraseRef.current,
+                });
+              await close();
+              await actions.current.createHDHiddenWallet(
+                {
+                  walletId: wallet?.id || '',
+                  passphrase: encodedPassphrase,
+                },
+                {
+                  addDefaultNetworkAccounts: true,
+                },
+              );
+              Toast.success({
+                title: intl.formatMessage({
+                  id: ETranslations.global_success,
+                }),
+              });
+              resolve();
+            } catch (error) {
+              reject(error);
+            } finally {
+              setIsLoading(false);
+            }
+          },
+          onCancel: () => {
+            reject(new Error('User cancelled'));
+          },
+        });
+      }),
     [actions, intl],
   );
 
@@ -266,6 +377,9 @@ export function useAddHiddenWallet() {
 
   const createHiddenWallet = useCallback(
     async ({ wallet }: { wallet?: IDBWallet }) => {
+      if (accountUtils.isHdWallet({ walletId: wallet?.id })) {
+        await createHdHiddenWallet({ wallet });
+      }
       if (accountUtils.isHwWallet({ walletId: wallet?.id })) {
         await createHwHiddenWallet({ wallet });
       }
@@ -273,7 +387,7 @@ export function useAddHiddenWallet() {
         await createQrHiddenWallet({ wallet });
       }
     },
-    [createHwHiddenWallet, createQrHiddenWallet],
+    [createHdHiddenWallet, createHwHiddenWallet, createQrHiddenWallet],
   );
 
   const createHiddenWalletWithDialogConfirm = useCallback(

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/AccountSelectorWalletListSideBar.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/AccountSelectorWalletListSideBar.tsx
@@ -259,10 +259,12 @@ export function AccountSelectorWalletListSideBar({
       noop(reloadWalletsHook);
       if (
         wallet &&
-        accountUtils.isHwOrQrWallet({ walletId: wallet.id }) &&
-        !accountUtils.isHwHiddenWallet({ wallet }) &&
+        (accountUtils.isHwOrQrWallet({ walletId: wallet.id }) ||
+          accountUtils.isHdWallet({ walletId: wallet.id })) &&
+        !accountUtils.isHiddenWallet({ wallet }) &&
         isEditableRouteParams &&
         !wallet?.deprecated &&
+        !wallet?.isKeyless &&
         settings.showAddHiddenInWalletSidebar
       ) {
         if (
@@ -275,6 +277,14 @@ export function AccountSelectorWalletListSideBar({
           (wallet?.associatedDeviceInfo?.featuresInfo?.passphrase_protection ===
             true ||
             (wallet?.hiddenWallets?.length ?? 0) > 0)
+        ) {
+          shouldShowCreateHiddenWalletButton = true;
+        }
+
+        if (
+          accountUtils.isHdWallet({
+            walletId: wallet.id,
+          })
         ) {
           shouldShowCreateHiddenWalletButton = true;
         }
@@ -344,7 +354,7 @@ export function AccountSelectorWalletListSideBar({
         return;
       }
       // Hidden wallets (passphrase wallets) should never show connection status
-      if (accountUtils.isHwHiddenWallet({ wallet })) {
+      if (accountUtils.isHiddenWallet({ wallet })) {
         map.set(wallet.id, false);
         return;
       }

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/WalletListItem.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/WalletListItem.tsx
@@ -229,7 +229,8 @@ export function WalletListItem({
   }
   const hiddenWallets = wallet?.hiddenWallets;
   const isHwOrQrWallet = accountUtils.isHwOrQrWallet({ walletId: wallet?.id });
-  const isHiddenWallet = accountUtils.isHwHiddenWallet({ wallet });
+  const isHdWallet = accountUtils.isHdWallet({ walletId: wallet?.id });
+  const isHiddenWallet = accountUtils.isHiddenWallet({ wallet });
   const [settings, setSettings] = useSettingsPersistAtom();
 
   useEffect(() => {
@@ -264,7 +265,7 @@ export function WalletListItem({
     />
   );
 
-  if (isHwOrQrWallet && !isHiddenWallet) {
+  if ((isHwOrQrWallet || isHdWallet) && !isHiddenWallet) {
     const shouldShowCreateHiddenWalletButton =
       shouldShowCreateHiddenWalletButtonFn?.({
         wallet,

--- a/packages/kit/src/views/Onboarding/components/PhaseInputArea.tsx
+++ b/packages/kit/src/views/Onboarding/components/PhaseInputArea.tsx
@@ -13,7 +13,7 @@ import {
   useState,
 } from 'react';
 
-import { compact, range } from 'lodash';
+import { range } from 'lodash';
 import { useIntl } from 'react-intl';
 import { View } from 'react-native';
 
@@ -565,7 +565,9 @@ export function PhaseInputArea({
     useCallback(
       (index: number) =>
         index === phraseLengthNumber - 1 ||
-        compact(Object.values(form.getValues())).length === phraseLengthNumber
+        range(0, phraseLengthNumber).filter(
+          (_, i) => form.getValues()[`phrase${i + 1}`],
+        ).length === phraseLengthNumber
           ? 'done'
           : 'next',
       [form, phraseLengthNumber],
@@ -576,6 +578,8 @@ export function PhaseInputArea({
     Object.entries(defaultPhrasesMap).forEach(([key, value]) => {
       form.setValue(key, value);
     });
+    form.setValue('passphrase', '');
+    form.setValue('confirmPassphrase', '');
   }, [defaultPhrasesMap, form]);
 
   const handleChangePhraseLength = useCallback(

--- a/packages/kit/src/views/Onboarding/components/PhaseInputArea.tsx
+++ b/packages/kit/src/views/Onboarding/components/PhaseInputArea.tsx
@@ -38,6 +38,7 @@ import {
   Select,
   SizableText,
   Stack,
+  Toast,
   XStack,
   useForm,
   useIsKeyboardShown,
@@ -439,15 +440,18 @@ export function PhaseInputArea({
   showPhraseLengthSelector = true,
   showClearAllButton = true,
   defaultPhrases = [],
+  enablePassphrase = false,
 }: {
   onConfirm: (params: {
     mnemonic: string;
     mnemonicType: EMnemonicType;
+    mnemonicPassphrase?: string;
   }) => void;
   showPhraseLengthSelector?: boolean;
   showClearAllButton?: boolean;
   FooterComponent?: ReactElement;
   defaultPhrases?: string[];
+  enablePassphrase?: boolean;
 }) {
   const intl = useIntl();
 
@@ -469,8 +473,12 @@ export function PhaseInputArea({
     });
     return map;
   }, [defaultPhrases, phraseLengthNumber]);
-  const form = useForm({
-    defaultValues: defaultPhrasesMap,
+  const form = useForm<Record<string, string>>({
+    defaultValues: {
+      ...defaultPhrasesMap,
+      passphrase: '',
+      confirmPassphrase: '',
+    },
   });
 
   const invalidWordsLength = 0;
@@ -483,14 +491,43 @@ export function PhaseInputArea({
   };
 
   const handlePageFooterConfirm = useCallback(async () => {
-    const mnemonic: string = Object.values(form.getValues()).join(' ');
+    const values = form.getValues();
+    const mnemonic: string = range(0, phraseLengthNumber)
+      .map((_, i) => values[`phrase${i + 1}`] || '')
+      .join(' ');
     const mnemonicEncoded = await servicePassword.encodeSensitiveText({
       text: mnemonic,
     });
     const { mnemonicType } =
       await serviceAccount.validateMnemonic(mnemonicEncoded);
-    onConfirm({ mnemonic: mnemonicEncoded, mnemonicType });
-  }, [form, onConfirm, serviceAccount, servicePassword]);
+    let mnemonicPassphrase: string | undefined;
+    if (enablePassphrase) {
+      const passphrase = values.passphrase || '';
+      const confirmPassphrase = values.confirmPassphrase || '';
+      if (passphrase && passphrase !== confirmPassphrase) {
+        Toast.error({
+          title: intl.formatMessage({
+            id: ETranslations.feedback_passphrase_not_matched,
+          }),
+        });
+        return;
+      }
+      if (passphrase) {
+        mnemonicPassphrase = await servicePassword.encodeSensitiveText({
+          text: passphrase,
+        });
+      }
+    }
+    onConfirm({ mnemonic: mnemonicEncoded, mnemonicType, mnemonicPassphrase });
+  }, [
+    enablePassphrase,
+    form,
+    intl,
+    onConfirm,
+    phraseLengthNumber,
+    serviceAccount,
+    servicePassword,
+  ]);
 
   const {
     suggestions,
@@ -628,6 +665,38 @@ export function PhaseInputArea({
               </Stack>
             ))}
           </XStack>
+          {enablePassphrase ? (
+            <Stack px="$5" pt="$4" gap="$3">
+              <Form.Field
+                name="passphrase"
+                label={`${intl.formatMessage({
+                  id: ETranslations.global_passphrase,
+                })} (${intl.formatMessage({
+                  id: ETranslations.form_optional_indicator,
+                })})`}
+              >
+                <Input
+                  secureTextEntry
+                  placeholder={intl.formatMessage({
+                    id: ETranslations.global_enter_passphrase,
+                  })}
+                />
+              </Form.Field>
+              <Form.Field
+                name="confirmPassphrase"
+                label={intl.formatMessage({
+                  id: ETranslations.form_confirm_passphrase,
+                })}
+              >
+                <Input
+                  secureTextEntry
+                  placeholder={intl.formatMessage({
+                    id: ETranslations.form_confirm_passphrase_placeholder,
+                  })}
+                />
+              </Form.Field>
+            </Stack>
+          ) : null}
         </Form>
 
         <HeightTransition>

--- a/packages/kit/src/views/Onboarding/pages/FinalizeWalletSetup.tsx
+++ b/packages/kit/src/views/Onboarding/pages/FinalizeWalletSetup.tsx
@@ -57,6 +57,7 @@ function FinalizeWalletSetupPage({
   const [showStep, setShowStep] = useState(false);
   const navigation = useAppNavigation();
   const mnemonic = route?.params?.mnemonic;
+  const mnemonicPassphrase = route?.params?.mnemonicPassphrase;
   const mnemonicType = route?.params?.mnemonicType;
   const isWalletBackedUp = route?.params?.isWalletBackedUp;
   const isKeylessWallet = route?.params?.isKeylessWallet;
@@ -125,6 +126,7 @@ function FinalizeWalletSetupPage({
               }
               await actions.current.createHDWallet({
                 mnemonic,
+                mnemonicPassphrase,
                 isWalletBackedUp,
                 isKeylessWallet,
               });
@@ -145,6 +147,7 @@ function FinalizeWalletSetupPage({
     actions,
     intl,
     mnemonic,
+    mnemonicPassphrase,
     mnemonicType,
     popPage,
     isWalletBackedUp,

--- a/packages/kit/src/views/Onboarding/pages/ImportWallet/ImportKeyTag.tsx
+++ b/packages/kit/src/views/Onboarding/pages/ImportWallet/ImportKeyTag.tsx
@@ -65,9 +65,14 @@ export function ImportKeyTag() {
 
   const { isSoftwareWalletOnlyUser } = useUserWalletProfile();
   const handleConfirmPress = useCallback(
-    async (params: { mnemonic: string; mnemonicType: EMnemonicType }) => {
+    async (params: {
+      mnemonic: string;
+      mnemonicType: EMnemonicType;
+      mnemonicPassphrase?: string;
+    }) => {
       navigation.push(EOnboardingPages.FinalizeWalletSetup, {
         mnemonic: params.mnemonic,
+        mnemonicPassphrase: params.mnemonicPassphrase,
         mnemonicType: params.mnemonicType,
         isWalletBackedUp: true,
       });
@@ -88,6 +93,7 @@ export function ImportKeyTag() {
     () => (
       <PhaseInputArea
         defaultPhrases={[]}
+        enablePassphrase
         onConfirm={handleConfirmPress}
         FooterComponent={<KeyTagFooterComponent />}
       />

--- a/packages/kit/src/views/Onboarding/pages/ImportWallet/ImportRecoveryPhrase.tsx
+++ b/packages/kit/src/views/Onboarding/pages/ImportWallet/ImportRecoveryPhrase.tsx
@@ -20,13 +20,18 @@ export function ImportRecoveryPhrase() {
   const { isSoftwareWalletOnlyUser } = useUserWalletProfile();
 
   const handleConfirmPress = useCallback(
-    async (params: { mnemonic: string; mnemonicType: EMnemonicType }) => {
+    async (params: {
+      mnemonic: string;
+      mnemonicType: EMnemonicType;
+      mnemonicPassphrase?: string;
+    }) => {
       if (params.mnemonicType === EMnemonicType.TON) {
         // **** TON mnemonic case - Show dialog
         showTonMnemonicDialog({
           onConfirm: () => {
             navigation.push(EOnboardingPages.FinalizeWalletSetup, {
               mnemonic: params.mnemonic,
+              mnemonicPassphrase: params.mnemonicPassphrase,
               mnemonicType: params.mnemonicType,
               isWalletBackedUp: true,
             });
@@ -45,6 +50,7 @@ export function ImportRecoveryPhrase() {
 
       navigation.push(EOnboardingPages.FinalizeWalletSetup, {
         mnemonic: params.mnemonic,
+        mnemonicPassphrase: params.mnemonicPassphrase,
         mnemonicType: params.mnemonicType,
         isWalletBackedUp: true,
       });
@@ -64,6 +70,7 @@ export function ImportRecoveryPhrase() {
     () => (
       <PhaseInputArea
         defaultPhrases={[]}
+        enablePassphrase
         onConfirm={handleConfirmPress}
         FooterComponent={
           <Tutorials

--- a/packages/kit/src/views/Onboardingv2/components/PhaseInputArea.tsx
+++ b/packages/kit/src/views/Onboardingv2/components/PhaseInputArea.tsx
@@ -39,6 +39,7 @@ import {
   Select,
   SizableText,
   Stack,
+  Toast,
   XStack,
   useForm,
   useKeyboardEvent,
@@ -440,6 +441,7 @@ export interface IPhaseInputAreaInstance {
   submit: () => Promise<{
     mnemonic: string;
     mnemonicType: EMnemonicType;
+    mnemonicPassphrase?: string;
   }>;
 }
 
@@ -449,17 +451,20 @@ export function PhaseInputArea({
   showPhraseLengthSelector = true,
   showClearAllButton = true,
   defaultPhrases = [],
+  enablePassphrase = false,
   ref,
 }: {
   ref?: RefObject<IPhaseInputAreaInstance>;
   onConfirm?: (params: {
     mnemonic: string;
     mnemonicType: EMnemonicType;
+    mnemonicPassphrase?: string;
   }) => void;
   showPhraseLengthSelector?: boolean;
   showClearAllButton?: boolean;
   FooterComponent?: ReactElement;
   defaultPhrases?: string[];
+  enablePassphrase?: boolean;
 }) {
   const intl = useIntl();
 
@@ -481,8 +486,12 @@ export function PhaseInputArea({
     });
     return map;
   }, [defaultPhrases, phraseLengthNumber]);
-  const form = useForm({
-    defaultValues: defaultPhrasesMap,
+  const form = useForm<Record<string, string>>({
+    defaultValues: {
+      ...defaultPhrasesMap,
+      passphrase: '',
+      confirmPassphrase: '',
+    },
   });
 
   const invalidWordsLength = 0;
@@ -495,16 +504,49 @@ export function PhaseInputArea({
   };
 
   const handlePageFooterConfirm = useCallback(async () => {
-    const mnemonic: string = Object.values(form.getValues()).join(' ');
+    const values = form.getValues();
+    const mnemonic: string = range(0, phraseLengthNumber)
+      .map((_, i) => values[`phrase${i + 1}`] || '')
+      .join(' ');
     const mnemonicEncoded = await servicePassword.encodeSensitiveText({
       text: mnemonic,
     });
     const { mnemonicType } =
       await serviceAccount.validateMnemonic(mnemonicEncoded);
-    const result = { mnemonic: mnemonicEncoded, mnemonicType };
+    let mnemonicPassphrase: string | undefined;
+    if (enablePassphrase) {
+      const passphrase = values.passphrase || '';
+      const confirmPassphrase = values.confirmPassphrase || '';
+      if (passphrase && passphrase !== confirmPassphrase) {
+        Toast.error({
+          title: intl.formatMessage({
+            id: ETranslations.feedback_passphrase_not_matched,
+          }),
+        });
+        throw new Error('Passphrase not matched');
+      }
+      if (passphrase) {
+        mnemonicPassphrase = await servicePassword.encodeSensitiveText({
+          text: passphrase,
+        });
+      }
+    }
+    const result = {
+      mnemonic: mnemonicEncoded,
+      mnemonicType,
+      mnemonicPassphrase,
+    };
     onConfirm?.(result);
     return result;
-  }, [form, onConfirm, serviceAccount, servicePassword]);
+  }, [
+    enablePassphrase,
+    form,
+    intl,
+    onConfirm,
+    phraseLengthNumber,
+    serviceAccount,
+    servicePassword,
+  ]);
 
   const {
     suggestions,
@@ -647,6 +689,38 @@ export function PhaseInputArea({
             </Stack>
           ))}
         </XStack>
+        {enablePassphrase ? (
+          <Stack px="$1" pt="$4" gap="$3">
+            <Form.Field
+              name="passphrase"
+              label={`${intl.formatMessage({
+                id: ETranslations.global_passphrase,
+              })} (${intl.formatMessage({
+                id: ETranslations.form_optional_indicator,
+              })})`}
+            >
+              <Input
+                secureTextEntry
+                placeholder={intl.formatMessage({
+                  id: ETranslations.global_enter_passphrase,
+                })}
+              />
+            </Form.Field>
+            <Form.Field
+              name="confirmPassphrase"
+              label={intl.formatMessage({
+                id: ETranslations.form_confirm_passphrase,
+              })}
+            >
+              <Input
+                secureTextEntry
+                placeholder={intl.formatMessage({
+                  id: ETranslations.form_confirm_passphrase_placeholder,
+                })}
+              />
+            </Form.Field>
+          </Stack>
+        ) : null}
       </Form>
 
       <HeightTransition>

--- a/packages/kit/src/views/Onboardingv2/components/PhaseInputArea.tsx
+++ b/packages/kit/src/views/Onboardingv2/components/PhaseInputArea.tsx
@@ -584,7 +584,9 @@ export function PhaseInputArea({
     useCallback(
       (index: number) =>
         index === phraseLengthNumber - 1 ||
-        compact(Object.values(form.getValues())).length === phraseLengthNumber
+        range(0, phraseLengthNumber).filter(
+          (_, i) => form.getValues()[`phrase${i + 1}`],
+        ).length === phraseLengthNumber
           ? 'done'
           : 'next',
       [form, phraseLengthNumber],
@@ -595,6 +597,8 @@ export function PhaseInputArea({
     Object.entries(defaultPhrasesMap).forEach(([key, value]) => {
       form.setValue(key, value);
     });
+    form.setValue('passphrase', '');
+    form.setValue('confirmPassphrase', '');
   }, [defaultPhrasesMap, form]);
 
   const handleChangePhraseLength = useCallback(

--- a/packages/kit/src/views/Onboardingv2/pages/FinalizeWalletSetup.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/FinalizeWalletSetup.tsx
@@ -131,6 +131,7 @@ function FinalizeWalletSetupPage({
 
   const created = useRef(false);
   const mnemonic = route?.params?.mnemonic;
+  const mnemonicPassphrase = route?.params?.mnemonicPassphrase;
   const mnemonicType = route?.params?.mnemonicType;
   const keylessPackSetId = route?.params?.keylessPackSetId;
   const deviceData = route?.params?.deviceData;
@@ -264,6 +265,7 @@ function FinalizeWalletSetupPage({
             }
             await actions.current.createHDWallet({
               mnemonic,
+              mnemonicPassphrase,
               isWalletBackedUp,
               isKeylessWallet,
               keylessDetailsInfo,
@@ -317,6 +319,7 @@ function FinalizeWalletSetupPage({
     }
   }, [
     mnemonic,
+    mnemonicPassphrase,
     deviceData,
     isFirmwareVerified,
     keylessPackSetId,

--- a/packages/kit/src/views/Onboardingv2/pages/ImportKeyTag.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ImportKeyTag.tsx
@@ -65,9 +65,15 @@ export function ImportKeyTag() {
 
   const { isSoftwareWalletOnlyUser } = useUserWalletProfile();
   const handleConfirmPress = useCallback(
-    async (params: { mnemonic: string; mnemonicType: EMnemonicType }) => {
+    async (params: {
+      mnemonic: string;
+      mnemonicType: EMnemonicType;
+      mnemonicPassphrase?: string;
+    }) => {
       navigation.push(EOnboardingPagesV2.FinalizeWalletSetup, {
         mnemonic: params.mnemonic,
+        mnemonicPassphrase: params.mnemonicPassphrase,
+        mnemonicType: params.mnemonicType,
         isWalletBackedUp: true,
       });
       defaultLogger.account.wallet.walletAdded({
@@ -87,6 +93,7 @@ export function ImportKeyTag() {
     () => (
       <PhaseInputArea
         defaultPhrases={[]}
+        enablePassphrase
         onConfirm={handleConfirmPress}
         FooterComponent={<KeyTagFooterComponent />}
       />

--- a/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
@@ -188,10 +188,11 @@ export default function ImportPhraseOrPrivateKey() {
       setIsConfirming(true);
       if (phaseInputAreaRef.current) {
         try {
-          const { mnemonic, mnemonicType } =
+          const { mnemonic, mnemonicType, mnemonicPassphrase } =
             await phaseInputAreaRef.current.submit();
           navigation.push(EOnboardingPagesV2.FinalizeWalletSetup, {
             mnemonic,
+            mnemonicPassphrase,
             mnemonicType,
             isWalletBackedUp: true,
           });
@@ -314,6 +315,7 @@ export default function ImportPhraseOrPrivateKey() {
                       phaseInputAreaRef as RefObject<IPhaseInputAreaInstance>
                     }
                     defaultPhrases={[]}
+                    enablePassphrase
                   />
                 </YStack>
               ) : (

--- a/packages/shared/src/routes/onboarding.ts
+++ b/packages/shared/src/routes/onboarding.ts
@@ -113,6 +113,7 @@ export type IOnboardingParamList = {
   // finalize wallet setup
   [EOnboardingPages.FinalizeWalletSetup]: {
     mnemonic?: string;
+    mnemonicPassphrase?: string;
     mnemonicType?: EMnemonicType; // bip39 or ton
     isWalletBackedUp?: boolean;
     isKeylessWallet?: boolean;

--- a/packages/shared/src/routes/onboardingv2.ts
+++ b/packages/shared/src/routes/onboardingv2.ts
@@ -76,6 +76,7 @@ export type IOnboardingParamListV2 = {
   };
   [EOnboardingPagesV2.FinalizeWalletSetup]: {
     mnemonic?: string;
+    mnemonicPassphrase?: string;
     mnemonicType?: EMnemonicType;
     isWalletBackedUp?: boolean;
     isKeylessWallet?: boolean;

--- a/packages/shared/src/utils/accountUtils.test.ts
+++ b/packages/shared/src/utils/accountUtils.test.ts
@@ -87,3 +87,84 @@ describe('Lightning Path Transformation', () => {
     ).toThrow('buildLightningAccountId ERROR: invalid accountId');
   });
 });
+
+describe('Hidden Wallet Helpers', () => {
+  test('isHdHiddenWallet returns true for HD wallet with passphraseState', () => {
+    const wallet = {
+      id: 'hd-1',
+      passphraseState: 'abcd1234',
+    } as unknown as NonNullable<
+      Parameters<typeof accountUtils.isHdHiddenWallet>[0]['wallet']
+    >;
+    expect(accountUtils.isHdHiddenWallet({ wallet })).toBe(true);
+  });
+
+  test('isHdHiddenWallet returns false for HD wallet without passphraseState', () => {
+    const wallet = {
+      id: 'hd-1',
+      passphraseState: '',
+    } as unknown as NonNullable<
+      Parameters<typeof accountUtils.isHdHiddenWallet>[0]['wallet']
+    >;
+    expect(accountUtils.isHdHiddenWallet({ wallet })).toBe(false);
+  });
+
+  test('isHiddenWallet returns true for HW hidden wallet', () => {
+    const wallet = {
+      id: 'hw-1',
+      passphraseState: 'abcd1234',
+    } as unknown as NonNullable<
+      Parameters<typeof accountUtils.isHiddenWallet>[0]['wallet']
+    >;
+    expect(accountUtils.isHiddenWallet({ wallet })).toBe(true);
+  });
+
+  test('isHiddenWallet returns true for QR hidden wallet', () => {
+    const wallet = {
+      id: 'qr-1',
+      passphraseState: 'abcd1234',
+    } as unknown as NonNullable<
+      Parameters<typeof accountUtils.isHiddenWallet>[0]['wallet']
+    >;
+    expect(accountUtils.isHiddenWallet({ wallet })).toBe(true);
+  });
+
+  test('isHiddenWallet returns true for HD hidden wallet', () => {
+    const wallet = {
+      id: 'hd-1',
+      passphraseState: 'abcd1234',
+    } as unknown as NonNullable<
+      Parameters<typeof accountUtils.isHiddenWallet>[0]['wallet']
+    >;
+    expect(accountUtils.isHiddenWallet({ wallet })).toBe(true);
+  });
+
+  test('isHdHiddenWallet returns false for non-HD wallet even with passphraseState', () => {
+    const wallet = {
+      id: 'hw-1',
+      passphraseState: 'abcd1234',
+    } as unknown as NonNullable<
+      Parameters<typeof accountUtils.isHdHiddenWallet>[0]['wallet']
+    >;
+    expect(accountUtils.isHdHiddenWallet({ wallet })).toBe(false);
+  });
+
+  test('isHiddenWallet returns false for standard HD wallet', () => {
+    const wallet = {
+      id: 'hd-1',
+    } as unknown as NonNullable<
+      Parameters<typeof accountUtils.isHiddenWallet>[0]['wallet']
+    >;
+    expect(accountUtils.isHiddenWallet({ wallet })).toBe(false);
+  });
+
+  test('isHiddenWallet returns false for standard HW wallet', () => {
+    const wallet = {
+      id: 'hw-1',
+      passphraseState: '',
+    } as unknown as NonNullable<
+      Parameters<typeof accountUtils.isHiddenWallet>[0]['wallet']
+    >;
+    expect(accountUtils.isHiddenWallet({ wallet })).toBe(false);
+  });
+});

--- a/packages/shared/src/utils/accountUtils.ts
+++ b/packages/shared/src/utils/accountUtils.ts
@@ -267,6 +267,26 @@ function isHwHiddenWallet({
   );
 }
 
+function isHdHiddenWallet({
+  wallet,
+}: {
+  wallet: IDBWallet | undefined;
+}): boolean {
+  return Boolean(
+    wallet && isHdWallet({ walletId: wallet.id }) && wallet.passphraseState,
+  );
+}
+
+function isHiddenWallet({
+  wallet,
+}: {
+  wallet: IDBWallet | undefined;
+}): boolean {
+  return Boolean(
+    wallet && (isHwHiddenWallet({ wallet }) || isHdHiddenWallet({ wallet })),
+  );
+}
+
 function isImportedWallet({
   walletId,
 }: {
@@ -1174,6 +1194,8 @@ export default {
   isHwWallet,
   isHwOrQrWallet,
   isHwHiddenWallet,
+  isHdHiddenWallet,
+  isHiddenWallet,
   isWatchingWallet,
   isImportedWallet,
   isExternalWallet,


### PR DESCRIPTION
# Summary

* add HD passphrase support for non-hardware (software) wallet flows
* add HD hidden wallet creation with passphrase validation and parent linkage
* propagate passphrase-aware wallet identity through onboarding, ServiceAccount, local DB, and cloud backup/restore
* update hidden-wallet semantics to cover both HW/QR and HD hidden wallets
* add tests for hidden-wallet helper behavior and BTC passphrase/XFP determinism

# Validation
* `node .yarn/releases/yarn-4.12.0.cjs test --coverage` passed locally (54 suites, 0 failures)

# Details
Add HD passphrase support for non-hardware (software) wallets across onboarding, account creation, local DB, and cloud backup restore.

What this commit includes:

- Add optional mnemonic passphrase flow in onboarding/onboardingv2 import UIs and route params, and pass it through finalize wallet setup into createHDWallet.

- Extend BTC xfp derivation to accept BIP39 passphrase and propagate passphrase-aware xfp/hash creation in ServiceAccount.

- Implement createHDHiddenWallet for HD software wallets (non-hardware), including passphrase validation, password verification, hidden-parent linkage, and temp status handling.

- Persist and use passphraseState + hiddenParentWalletId in LocalDb HD wallet creation and hidden wallet indexing/grouping logic.

- Update hidden wallet semantics to cover both HW/QR and HD hidden wallets via new accountUtils helpers (isHdHiddenWallet, isHiddenWallet) and apply these checks in account-management UI paths.

- Include hidden wallet metadata (hash/xfp/passphraseState) in cloud backup and restore flow for HD wallets.

- Add/extend tests for hidden wallet helper behavior and BTC xfp passphrase determinism.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
