### PR TITLE
fix: market search trending list use table-style layout

### DIFF
--- a/packages/kit/src/views/UniversalSearch/components/MarketTableHeader.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/MarketTableHeader.tsx
@@ -4,7 +4,7 @@ import { SizableText, XStack, useMedia } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 export const MARKET_NAME_COLUMN_WIDTH = 160;
-export const MARKET_DATA_COLUMN_WIDTH = '33.3333%';
+export const MARKET_DATA_COLUMN_WIDTH = '25%';
 
 export function MarketTableHeader() {
   const intl = useIntl();
@@ -48,6 +48,15 @@ export function MarketTableHeader() {
             <SizableText size="$bodySm" color="$textSubdued" textAlign="right">
               {intl
                 .formatMessage({ id: ETranslations.dexmarket_turnover })
+                .toUpperCase()}
+            </SizableText>
+          </XStack>
+        ) : null}
+        {gtMd ? (
+          <XStack w={MARKET_DATA_COLUMN_WIDTH} jc="flex-end">
+            <SizableText size="$bodySm" color="$textSubdued" textAlign="right">
+              {intl
+                .formatMessage({ id: ETranslations.dexmarket_market_cap })
                 .toUpperCase()}
             </SizableText>
           </XStack>

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
@@ -31,7 +31,6 @@ import { EUniversalSearchPages } from '@onekeyhq/shared/src/routes/universalSear
 import { listItemPressStyle } from '@onekeyhq/shared/src/style';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import type { IUniversalSearchV2MarketToken } from '@onekeyhq/shared/types/search';
-import { ESearchStatus } from '@onekeyhq/shared/types/search';
 
 import { MarketStarV2 } from '../../../Market/components/MarketStarV2';
 import { MarketTokenIcon } from '../../../Market/components/MarketTokenIcon';
@@ -137,12 +136,10 @@ export function MarketTokenLiquidity({
 
 interface IUniversalSearchMarketTokenItemProps {
   item: IUniversalSearchV2MarketToken;
-  searchStatus: ESearchStatus;
 }
 
 export function UniversalSearchV2MarketTokenItem({
   item,
-  searchStatus,
 }: IUniversalSearchMarketTokenItemProps) {
   // Ensure market watch list atom is initialized
   const [{ isMounted }] = useMarketWatchListV2Atom();

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
@@ -14,6 +14,7 @@ import {
   useClipboard,
   useMedia,
 } from '@onekeyhq/components';
+import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useMarketWatchListV2Atom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2/atoms';
 import { useUniversalSearchActions } from '@onekeyhq/kit/src/states/jotai/contexts/universalSearch';
 import { CommunityRecognizedBadge } from '@onekeyhq/kit/src/views/Market/components/CommunityRecognizedBadge';
@@ -26,6 +27,7 @@ import {
   EWatchlistFrom,
 } from '@onekeyhq/shared/src/logger/scopes/dex';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import { EUniversalSearchPages } from '@onekeyhq/shared/src/routes/universalSearch';
 import { listItemPressStyle } from '@onekeyhq/shared/src/style';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import type { IUniversalSearchV2MarketToken } from '@onekeyhq/shared/types/search';
@@ -145,11 +147,13 @@ export function UniversalSearchV2MarketTokenItem({
   // Ensure market watch list atom is initialized
   const [{ isMounted }] = useMarketWatchListV2Atom();
   const { gtMd } = useMedia();
+  const appNavigation = useAppNavigation();
   const universalSearchActions = useUniversalSearchActions();
   const toMarketDetailPage = useToDetailPage({
     switchToMarketTabFirst: true,
     from: EEnterWay.Search,
   });
+
   const {
     logoUrl,
     price,
@@ -161,10 +165,15 @@ export function UniversalSearchV2MarketTokenItem({
     // eslint-disable-next-line camelcase
     volume_24h,
     volume24h: volume24hCamel,
+    marketCap,
     priceChange24hPercent,
     isNative,
     communityRecognized,
   } = item.payload;
+
+  // When network is empty, the item was converted from IMarketToken (trending)
+  // and address contains coingeckoId for legacy navigation
+  const isTrendingItem = !network;
 
   // eslint-disable-next-line camelcase
   const volume24h = volume24hCamel || volume_24h;
@@ -177,43 +186,54 @@ export function UniversalSearchV2MarketTokenItem({
   );
 
   const handlePress = useCallback(() => {
-    rootNavigationRef.current?.goBack();
-    setTimeout(async () => {
-      // Use toMarketDetailPage hook for navigation
-      void toMarketDetailPage({
-        tokenAddress: address,
-        networkId: network,
-        symbol,
-        isNative,
-      });
+    if (isTrendingItem) {
+      // Trending item: address contains coingeckoId, use legacy navigation
+      setTimeout(async () => {
+        appNavigation.push(EUniversalSearchPages.MarketDetail, {
+          token: address,
+        });
+        defaultLogger.market.token.searchToken({
+          tokenSymbol: symbol,
+          from: 'trendingList',
+        });
+      }, 80);
+    } else {
+      rootNavigationRef.current?.goBack();
+      setTimeout(async () => {
+        void toMarketDetailPage({
+          tokenAddress: address,
+          networkId: network,
+          symbol,
+          isNative,
+        });
 
-      defaultLogger.market.token.searchToken({
-        tokenSymbol: symbol,
-        from:
-          searchStatus === ESearchStatus.init ? 'trendingList' : 'searchList',
-      });
+        defaultLogger.market.token.searchToken({
+          tokenSymbol: symbol,
+          from: 'searchList',
+        });
 
-      // Only add to recent search list when not in trending section and symbol is not empty
-      if (searchStatus !== ESearchStatus.init && symbol?.trim()) {
-        setTimeout(() => {
-          universalSearchActions.current.addIntoRecentSearchList({
-            id: address,
-            text: symbol,
-            type: item.type,
-            timestamp: Date.now(),
-          });
-        }, 10);
-      }
-    }, 80);
+        if (symbol?.trim()) {
+          setTimeout(() => {
+            universalSearchActions.current.addIntoRecentSearchList({
+              id: address,
+              text: symbol,
+              type: item.type,
+              timestamp: Date.now(),
+            });
+          }, 10);
+        }
+      }, 80);
+    }
   }, [
+    isTrendingItem,
     address,
     network,
     symbol,
     isNative,
-    searchStatus,
     universalSearchActions,
     item.type,
     toMarketDetailPage,
+    appNavigation,
   ]);
 
   if (!isMounted) {
@@ -321,6 +341,19 @@ export function UniversalSearchV2MarketTokenItem({
               formatterOptions={{ capAtMaxT: true }}
             >
               {BigNumber(volume24h).gt(0) ? volume24h : '--'}
+            </NumberSizeableText>
+          </XStack>
+        ) : null}
+
+        {/* MARKET CAP column - desktop only */}
+        {gtMd ? (
+          <XStack w={MARKET_DATA_COLUMN_WIDTH} jc="flex-end" ai="center">
+            <NumberSizeableText
+              size="$bodyMd"
+              formatter="marketCap"
+              formatterOptions={{ capAtMaxT: true }}
+            >
+              {marketCap && BigNumber(marketCap).gt(0) ? marketCap : '--'}
             </NumberSizeableText>
           </XStack>
         ) : null}

--- a/packages/kit/src/views/UniversalSearch/pages/UniversalSearch.tsx
+++ b/packages/kit/src/views/UniversalSearch/pages/UniversalSearch.tsx
@@ -538,12 +538,7 @@ export function UniversalSearch({
             />
           );
         case EUniversalSearchType.V2MarketToken:
-          return (
-            <UniversalSearchV2MarketTokenItem
-              item={item}
-              searchStatus={searchStatus}
-            />
-          );
+          return <UniversalSearchV2MarketTokenItem item={item} />;
         case EUniversalSearchType.AccountAssets:
           return (
             <UniversalSearchAccountAssetItem

--- a/packages/kit/src/views/UniversalSearch/pages/UniversalSearch.tsx
+++ b/packages/kit/src/views/UniversalSearch/pages/UniversalSearch.tsx
@@ -246,23 +246,45 @@ export function UniversalSearch({
   ]);
 
   const fetchRecommendList = useCallback(async () => {
-    const searchResultSections: {
-      title: string;
-      data: IUniversalSearchResultItem[];
-    }[] = [];
+    const searchResultSections: IUniversalSection[] = [];
 
     const result =
       await backgroundApiProxy.serviceUniversalSearch.universalSearchRecommend({
         searchTypes: [EUniversalSearchType.MarketToken],
       });
     if (result?.[EUniversalSearchType.MarketToken]?.items) {
+      // Convert MarketToken items to V2MarketToken format for table-style rendering
+      const v2Items = result[EUniversalSearchType.MarketToken].items.map(
+        (item) => {
+          const token = item.payload;
+          return {
+            type: EUniversalSearchType.V2MarketToken,
+            payload: {
+              name: token.name,
+              symbol: token.symbol,
+              price: String(token.price),
+              address: token.coingeckoId,
+              network: '',
+              logoUrl: token.image,
+              isNative: false,
+              decimals: 0,
+              liquidity: '0',
+              volume_24h: String(token.totalVolume || 0),
+              marketCap: String(token.marketCap || 0),
+              priceChange24hPercent: String(
+                token.priceChangePercentage24H || 0,
+              ),
+            },
+          };
+        },
+      );
       searchResultSections.push({
+        tabIndex: 2,
         title: intl.formatMessage({ id: ETranslations.market_trending }),
-        data: result?.[EUniversalSearchType.MarketToken]
-          ?.items as IUniversalSearchResultItem[],
+        data: v2Items as IUniversalSearchResultItem[],
       });
     }
-    setRecommendSections(searchResultSections as IUniversalSection[]);
+    setRecommendSections(searchResultSections);
   }, [intl]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Make trending token list (Trending) display style consistent with Market search results (table style)
- Convert IMarketToken data to V2 format in fetchRecommendList, reusing UniversalSearchV2MarketTokenItem table component
- Add Market Cap column to table header and rows
- Trending items keep legacy coingeckoId navigation

## Changes
- `MarketTableHeader.tsx`: Adjust column width to 25%, add Market Cap column header
- `UniversalSearchV2MarketTokenItem.tsx`: Add Market Cap column rendering, support legacy navigation for trending data
- `UniversalSearch.tsx`: Convert trending data to V2 format, set tabIndex to show table header

## Test plan
- [ ] Open search page, verify trending list displays in table style
- [ ] Verify trending list fields: favorites, name, price/change, liquidity, 24h volume, market cap
- [ ] Click trending token, verify correct navigation to detail page
- [ ] Enter search keyword, verify search result table style is not affected
- [ ] Desktop: verify all columns display correctly
- [ ] Mobile: verify only name and price/change columns are shown