### PR TITLE
fix(market): improve token detail bottom buttons UI

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanel.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanel.tsx
@@ -14,6 +14,7 @@ import {
   XStack,
   YStack,
   useMedia,
+  useSafeAreaInsets,
 } from '@onekeyhq/components';
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import { useAccountSelectorTrigger } from '@onekeyhq/kit/src/components/AccountSelector/hooks/useAccountSelectorTrigger';
@@ -88,6 +89,7 @@ export function SwapPanel({
 }) {
   const intl = useIntl();
   const media = useMedia();
+  const { bottom } = useSafeAreaInsets();
   const currencyInfo = useCurrency();
   const navigation = useAppNavigation();
   const myPositionInfo = useMemo(() => {
@@ -199,7 +201,7 @@ export function SwapPanel({
             )}
           </XStack>
         </XStack>
-        <Stack px="$5" pb="$4" pt="$2">
+        <Stack px="$5" pb={bottom || '$4'} pt="$2">
           <SwapPanelFooterButtons
             onTrade={handleTrade}
             onInstant={handleInstant}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelFooterButtons.android.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelFooterButtons.android.tsx
@@ -45,7 +45,7 @@ function SwapPanelFooterButtons({ onTrade, onInstant }: IProps) {
     <XStack gap="$2.5">
       <GestureDetector gesture={tradeGesture}>
         <View style={{ flex: 1 }}>
-          <Button size="large" variant="primary">
+          <Button size="large" variant="secondary">
             {intl.formatMessage({ id: ETranslations.dexmarket_details_trade })}
           </Button>
         </View>
@@ -58,7 +58,7 @@ function SwapPanelFooterButtons({ onTrade, onInstant }: IProps) {
             bg="$buttonSuccess"
             icon="FlashSolid"
           >
-            {intl.formatMessage({ id: ETranslations.marketdex_instant_mode })}
+            {intl.formatMessage({ id: ETranslations.dexmarket_quick_buy })}
           </Button>
         </View>
       </GestureDetector>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelFooterButtons.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelFooterButtons.tsx
@@ -12,7 +12,7 @@ function SwapPanelFooterButtons({ onTrade, onInstant }: IProps) {
   const intl = useIntl();
   return (
     <XStack gap="$2.5">
-      <Button size="large" variant="primary" flex={1} onPress={onTrade}>
+      <Button size="large" variant="secondary" flex={1} onPress={onTrade}>
         {intl.formatMessage({ id: ETranslations.dexmarket_details_trade })}
       </Button>
       <Button
@@ -23,7 +23,7 @@ function SwapPanelFooterButtons({ onTrade, onInstant }: IProps) {
         onPress={onInstant}
         icon="FlashSolid"
       >
-        {intl.formatMessage({ id: ETranslations.marketdex_instant_mode })}
+        {intl.formatMessage({ id: ETranslations.dexmarket_quick_buy })}
       </Button>
     </XStack>
   );

--- a/packages/shared/src/locale/enum/translations.ts
+++ b/packages/shared/src/locale/enum/translations.ts
@@ -697,6 +697,7 @@
   dexmarket_pro_slip_auto = 'dexmarket.pro_slip_auto',
   dexmarket_pro_total = 'dexmarket.pro_total',
   dexmarket_pro_trigger_price = 'dexmarket.pro_trigger_price',
+  dexmarket_quick_buy = 'dexmarket.quick_buy',
   dexmarket_search_result_liq = 'dexmarket.search_result_liq',
   dexmarket_search_result_vol = 'dexmarket.search_result_vol',
   dexmarket_security_result_cautions = 'dexmarket.security_result_cautions',

--- a/packages/shared/src/locale/json/bn.json
+++ b/packages/shared/src/locale/json/bn.json
@@ -692,6 +692,7 @@
   "dexmarket.pro_slip_auto": "অটো",
   "dexmarket.pro_total": "মোট",
   "dexmarket.pro_trigger_price": "ট্রিগার মূল্য",
+  "dexmarket.quick_buy": "দ্রুত কিনুন",
   "dexmarket.search_result_liq": "তারল্য",
   "dexmarket.search_result_vol": "২৪ ঘণ্টার ভলিউম",
   "dexmarket.security_result_cautions": "{number} সতর্কতা",

--- a/packages/shared/src/locale/json/de.json
+++ b/packages/shared/src/locale/json/de.json
@@ -692,6 +692,7 @@
   "dexmarket.pro_slip_auto": "Automatisch",
   "dexmarket.pro_total": "Gesamt",
   "dexmarket.pro_trigger_price": "Auslöserpreis",
+  "dexmarket.quick_buy": "Schnellkauf",
   "dexmarket.search_result_liq": "Liquidität",
   "dexmarket.search_result_vol": "24h-Vol",
   "dexmarket.security_result_cautions": "{number} Warnhinweise",

--- a/packages/shared/src/locale/json/en_US.json
+++ b/packages/shared/src/locale/json/en_US.json
@@ -692,6 +692,7 @@
   "dexmarket.pro_slip_auto": "Auto",
   "dexmarket.pro_total": "Total",
   "dexmarket.pro_trigger_price": "Trigger Price",
+  "dexmarket.quick_buy": "Quick buy",
   "dexmarket.search_result_liq": "Liq",
   "dexmarket.search_result_vol": "24h Vol",
   "dexmarket.security_result_cautions": "{number} Cautions",

--- a/packages/shared/src/locale/json/es.json
+++ b/packages/shared/src/locale/json/es.json
@@ -692,6 +692,7 @@
   "dexmarket.pro_slip_auto": "Automático",
   "dexmarket.pro_total": "Total",
   "dexmarket.pro_trigger_price": "Precio de activación",
+  "dexmarket.quick_buy": "Compra rápida",
   "dexmarket.search_result_liq": "Liquidez",
   "dexmarket.search_result_vol": "Volumen 24h",
   "dexmarket.security_result_cautions": "{number} advertencias",

--- a/packages/shared/src/locale/json/fr_FR.json
+++ b/packages/shared/src/locale/json/fr_FR.json
@@ -692,6 +692,7 @@
   "dexmarket.pro_slip_auto": "Auto",
   "dexmarket.pro_total": "Total",
   "dexmarket.pro_trigger_price": "Prix de déclenchement",
+  "dexmarket.quick_buy": "Achat rapide",
   "dexmarket.search_result_liq": "Liquidité",
   "dexmarket.search_result_vol": "Volume 24h",
   "dexmarket.security_result_cautions": "{number} Avertissements",

--- a/packages/shared/src/locale/json/hi_IN.json
+++ b/packages/shared/src/locale/json/hi_IN.json
@@ -692,6 +692,7 @@
   "dexmarket.pro_slip_auto": "ऑटो",
   "dexmarket.pro_total": "कुल",
   "dexmarket.pro_trigger_price": "ट्रिगर मूल्य",
+  "dexmarket.quick_buy": "त्वरित खरीद",
   "dexmarket.search_result_liq": "तरलता",
   "dexmarket.search_result_vol": "24 घंटे का वॉल्यूम",
   "dexmarket.security_result_cautions": "{number} सावधानियाँ",

--- a/packages/shared/src/locale/json/id.json
+++ b/packages/shared/src/locale/json/id.json
@@ -692,6 +692,7 @@
   "dexmarket.pro_slip_auto": "Otomatis",
   "dexmarket.pro_total": "Total",
   "dexmarket.pro_trigger_price": "Harga Pemicu",
+  "dexmarket.quick_buy": "Beli cepat",
   "dexmarket.search_result_liq": "Likuiditas",
   "dexmarket.search_result_vol": "Volume 24 jam",
   "dexmarket.security_result_cautions": "{number} Peringatan",

--- a/packages/shared/src/locale/json/it_IT.json
+++ b/packages/shared/src/locale/json/it_IT.json
@@ -692,6 +692,7 @@
   "dexmarket.pro_slip_auto": "Auto",
   "dexmarket.pro_total": "Totale",
   "dexmarket.pro_trigger_price": "Prezzo di Attivazione",
+  "dexmarket.quick_buy": "Acquisto rapido",
   "dexmarket.search_result_liq": "Liquidità",
   "dexmarket.search_result_vol": "Volume 24h",
   "dexmarket.security_result_cautions": "{number} Avvertenze",

--- a/packages/shared/src/locale/json/ja_JP.json
+++ b/packages/shared/src/locale/json/ja_JP.json
@@ -692,6 +692,7 @@
   "dexmarket.pro_slip_auto": "自動",
   "dexmarket.pro_total": "合計",
   "dexmarket.pro_trigger_price": "トリガー価格",
+  "dexmarket.quick_buy": "クイック購入",
   "dexmarket.search_result_liq": "流動性",
   "dexmarket.search_result_vol": "24時間取引高",
   "dexmarket.security_result_cautions": "{number} 件の注意事項",

--- a/packages/shared/src/locale/json/ko_KR.json
+++ b/packages/shared/src/locale/json/ko_KR.json
@@ -692,6 +692,7 @@
   "dexmarket.pro_slip_auto": "자동",
   "dexmarket.pro_total": "총액",
   "dexmarket.pro_trigger_price": "트리거 가격",
+  "dexmarket.quick_buy": "빠른 구매",
   "dexmarket.search_result_liq": "유동성",
   "dexmarket.search_result_vol": "24시간 거래량",
   "dexmarket.security_result_cautions": "{number} 주의사항",

--- a/packages/shared/src/locale/json/pt.json
+++ b/packages/shared/src/locale/json/pt.json
@@ -692,6 +692,7 @@
   "dexmarket.pro_slip_auto": "Automático",
   "dexmarket.pro_total": "Total",
   "dexmarket.pro_trigger_price": "Preço de Ativação",
+  "dexmarket.quick_buy": "Compra rápida",
   "dexmarket.search_result_liq": "Liquidez",
   "dexmarket.search_result_vol": "Volume 24h",
   "dexmarket.security_result_cautions": "{number} Avisos",

--- a/packages/shared/src/locale/json/pt_BR.json
+++ b/packages/shared/src/locale/json/pt_BR.json
@@ -692,6 +692,7 @@
   "dexmarket.pro_slip_auto": "Automático",
   "dexmarket.pro_total": "Total",
   "dexmarket.pro_trigger_price": "Preço de Ativação",
+  "dexmarket.quick_buy": "Compra rápida",
   "dexmarket.search_result_liq": "Liquidez",
   "dexmarket.search_result_vol": "Volume 24h",
   "dexmarket.security_result_cautions": "{number} Avisos",

--- a/packages/shared/src/locale/json/ru.json
+++ b/packages/shared/src/locale/json/ru.json
@@ -692,6 +692,7 @@
   "dexmarket.pro_slip_auto": "Авто",
   "dexmarket.pro_total": "Итого",
   "dexmarket.pro_trigger_price": "Триггерная цена",
+  "dexmarket.quick_buy": "Быстрая покупка",
   "dexmarket.search_result_liq": "Ликвидность",
   "dexmarket.search_result_vol": "24ч объем",
   "dexmarket.security_result_cautions": "{number} Предупреждения",

--- a/packages/shared/src/locale/json/th_TH.json
+++ b/packages/shared/src/locale/json/th_TH.json
@@ -692,6 +692,7 @@
   "dexmarket.pro_slip_auto": "อัตโนมัติ",
   "dexmarket.pro_total": "ยอดรวม",
   "dexmarket.pro_trigger_price": "ราคาเงื่อนไข",
+  "dexmarket.quick_buy": "ซื้อด่วน",
   "dexmarket.search_result_liq": "สภาพคล่อง",
   "dexmarket.search_result_vol": "ปริมาณ 24 ชั่วโมง",
   "dexmarket.security_result_cautions": "ข้อควรระวัง {number} ข้อ",

--- a/packages/shared/src/locale/json/uk_UA.json
+++ b/packages/shared/src/locale/json/uk_UA.json
@@ -692,6 +692,7 @@
   "dexmarket.pro_slip_auto": "Авто",
   "dexmarket.pro_total": "Всього",
   "dexmarket.pro_trigger_price": "Ціна спрацювання",
+  "dexmarket.quick_buy": "Швидка покупка",
   "dexmarket.search_result_liq": "Ліквідність",
   "dexmarket.search_result_vol": "Обсяг за 24 год",
   "dexmarket.security_result_cautions": "{number} Застережень",

--- a/packages/shared/src/locale/json/vi.json
+++ b/packages/shared/src/locale/json/vi.json
@@ -692,6 +692,7 @@
   "dexmarket.pro_slip_auto": "Tự động",
   "dexmarket.pro_total": "Tổng cộng",
   "dexmarket.pro_trigger_price": "Giá Kích Hoạt",
+  "dexmarket.quick_buy": "Mua nhanh",
   "dexmarket.search_result_liq": "Thanh khoản",
   "dexmarket.search_result_vol": "Khối lượng 24h",
   "dexmarket.security_result_cautions": "{number} Lưu ý",

--- a/packages/shared/src/locale/json/zh_CN.json
+++ b/packages/shared/src/locale/json/zh_CN.json
@@ -692,6 +692,7 @@
   "dexmarket.pro_slip_auto": "自动",
   "dexmarket.pro_total": "总共",
   "dexmarket.pro_trigger_price": "触发价格",
+  "dexmarket.quick_buy": "快速买卖",
   "dexmarket.search_result_liq": "流动性",
   "dexmarket.search_result_vol": "24小时成交量",
   "dexmarket.security_result_cautions": "{number} 注意项",

--- a/packages/shared/src/locale/json/zh_HK.json
+++ b/packages/shared/src/locale/json/zh_HK.json
@@ -692,6 +692,7 @@
   "dexmarket.pro_slip_auto": "自動",
   "dexmarket.pro_total": "總共",
   "dexmarket.pro_trigger_price": "觸發價格",
+  "dexmarket.quick_buy": "快速買賣",
   "dexmarket.search_result_liq": "流動性",
   "dexmarket.search_result_vol": "24小時成交量",
   "dexmarket.security_result_cautions": "{number} 個警告",

--- a/packages/shared/src/locale/json/zh_TW.json
+++ b/packages/shared/src/locale/json/zh_TW.json
@@ -692,6 +692,7 @@
   "dexmarket.pro_slip_auto": "自動",
   "dexmarket.pro_total": "累計",
   "dexmarket.pro_trigger_price": "觸發價格",
+  "dexmarket.quick_buy": "快速買賣",
   "dexmarket.search_result_liq": "流動性",
   "dexmarket.search_result_vol": "24小時交易量",
   "dexmarket.security_result_cautions": "{number} 注意項",


### PR DESCRIPTION
## Summary
- Add safe area bottom inset for Home Indicator on mobile devices
- Change Trade button variant from primary to secondary (matching design spec)
- Update Quick Buy button text key to `dexmarket_quick_buy`
- Sync latest locale translations

## Jira
[OK-50641](https://onekeyhq.atlassian.net/browse/OK-50641)

## Test plan
- [ ] Verify bottom buttons have proper spacing above Home Indicator on iPhone with notch
- [ ] Verify Trade button shows light/secondary style
- [ ] Verify Quick Buy button shows correct translated text
- [ ] Test on both iOS and Android
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


[OK-50641]: https://onekeyhq.atlassian.net/browse/OK-50641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ