### PR TITLE
fix(market): include full banner item data in dex banner log

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/useToMarketBannerDetail.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/useToMarketBannerDetail.ts
@@ -15,7 +15,7 @@ export function useToMarketBannerDetail() {
 
   const toMarketBannerDetail = useCallback(
     (item: IMarketBannerItem) => {
-      defaultLogger.dex.banner.dexBannerEnter({ bannerId: item._id });
+      defaultLogger.dex.banner.dexBannerEnter({ bannerId: item._id, ...item });
 
       const params = {
         tokenListId: item.tokenListId,


### PR DESCRIPTION
## Summary
- Spread full `IMarketBannerItem` object into `dexBannerEnter` logger call to capture complete banner metadata for analytics

## Intent & Context
Previously, only `bannerId` was logged when a user clicked a market banner. This change includes all banner item fields (e.g., `tokenListId`, banner content, etc.) to provide richer analytics data for understanding banner engagement.

## Changes Detail
- `useToMarketBannerDetail.ts`: Changed `{ bannerId: item._id }` to `{ bannerId: item._id, ...item }` in the `dexBannerEnter` logger call

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Only affects logging — no functional or UI changes

## Test plan
- [ ] Navigate to Market tab and click a banner
- [ ] Verify banner detail page opens correctly (no regression)
- [ ] Check logger output includes full banner item data
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
