### PR TITLE
chore: add 1k-analytics skill and update skill catalog

### DIFF
--- a/.claude/skills/1k-analytics/SKILL.md
+++ b/.claude/skills/1k-analytics/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: 1k-analytics
+description: Analytics event tracking for OneKey. Use when adding tracking events, logging to server, user behavior tracking, or business metrics. Covers the @LogToServer decorator pattern, logger scope/scene architecture, and common pitfalls. Triggers on "埋点", "统计", "打点", "数据追踪", "日志", "analytics", "tracking event", "Mixpanel", "LogToServer", "trackEvent", "defaultLogger".
+allowed-tools: Read, Grep, Glob
+---
+
+# Analytics Event Tracking
+
+OneKey uses a decorator-based logger system to track user behavior events. Events are routed to the analytics server (Mixpanel) via `@LogToServer()` decorator on scene methods. **NEVER** call `analytics.trackEvent()` directly.
+
+## Quick Reference
+
+| Topic           | Guide                                                 | Key Files                            |
+| --------------- | ----------------------------------------------------- | ------------------------------------ |
+| Adding events   | [adding-events.md](references/rules/adding-events.md) | `packages/shared/src/logger/scopes/` |
+| Architecture    | [architecture.md](references/rules/architecture.md)   | `packages/shared/src/logger/base/`   |
+| Common pitfalls | [pitfalls.md](references/rules/pitfalls.md)           | —                                    |
+
+## Critical Rules
+
+1. **MUST use `@LogToServer()` decorator** — never call `analytics.trackEvent()` directly
+2. **Event method names use camelCase** — the method name becomes the event name sent to Mixpanel
+3. **Methods MUST return params synchronously** — never return a Promise
+4. **Deduplicate high-frequency events** — prevent Mixpanel usage spikes (e.g., use in-memory Set for per-session dedup)
+5. **Add events to existing scopes when possible** — only create new scopes for entirely new feature domains
+
+## Adding a Server Event (Quick Steps)
+
+### 1. Create or update a Scene class
+
+```typescript
+// packages/shared/src/logger/scopes/{scope}/scenes/{scene}.ts
+import { BaseScene } from '../../../base/baseScene';
+import { LogToServer } from '../../../base/decorators';
+
+export class MyScene extends BaseScene {
+  @LogToServer()
+  public myEventName(params: { key: string; value: string }) {
+    return params;
+  }
+}
+```
+
+### 2. Register scene in scope index
+
+```typescript
+// packages/shared/src/logger/scopes/{scope}/index.ts
+import { MyScene } from './scenes/myScene';
+
+export class MyScope extends BaseScope {
+  protected override scopeName = EScopeName.myScope;
+  myScene = this.createScene('myScene', MyScene);
+}
+```
+
+### 3. Call from business code
+
+```typescript
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+
+defaultLogger.myScope.myScene.myEventName({ key: 'foo', value: 'bar' });
+```
+
+## Decorator Types
+
+| Decorator         | Destination                            | Use Case                                 |
+| ----------------- | -------------------------------------- | ---------------------------------------- |
+| `@LogToServer()`  | Mixpanel analytics server              | User behavior tracking, business metrics |
+| `@LogToLocal()`   | Device local log (React Native logger) | Debugging, device-side diagnostics       |
+| `@LogToConsole()` | Console only                           | Dev-time debugging                       |
+
+Stack decorators for dual logging: `@LogToServer()` + `@LogToLocal()`.
+
+## Related Skills
+
+- `/1k-architecture` — Import hierarchy rules (logger is in `@onekeyhq/shared`)
+- `/1k-coding-patterns` — TypeScript and React conventions

--- a/.claude/skills/1k-analytics/references/rules/adding-events.md
+++ b/.claude/skills/1k-analytics/references/rules/adding-events.md
@@ -1,0 +1,193 @@
+# Adding Analytics Events
+
+## Step-by-Step Workflow
+
+### Step 1: Decide scope and scene
+
+Check existing scopes in `packages/shared/src/logger/logger.ts` (DefaultLogger class). Each scope maps to a feature domain:
+
+| Scope | Domain | Example scenes |
+|-------|--------|----------------|
+| `dex` | DEX/Market trading | banner, enter, swap, watchlist, list, actions, tradingView |
+| `transaction` | Send/receive | send, receive |
+| `hardware` | Hardware wallet | sdkLog, homescreen, verify, liteCard |
+| `market` | Market info (scopeName=`token`) | token |
+| `swap` | Token swapping | swap |
+| `ui` | UI interactions | button |
+| `app` | App lifecycle | bootstrap |
+| `update` | Firmware updates (scopeName=`app`) | app, firmware |
+
+**Rule:** Add to existing scope/scene if the event belongs to that domain. Only create a new scope for an entirely new feature domain.
+
+### Step 2: Define event params type
+
+Create or extend types in the scope's `types.ts` file:
+
+```typescript
+// packages/shared/src/logger/scopes/{scope}/types.ts
+export interface IMyEventParams {
+  deviceType: string;
+  firmwareType: 'btconly' | 'universal';
+}
+```
+
+Use specific types over `string` when possible. Use enums for fixed values:
+
+```typescript
+export enum EFirmwareTrackingType {
+  BtcOnly = 'btconly',
+  Universal = 'universal',
+}
+```
+
+### Step 3: Create scene method
+
+```typescript
+// packages/shared/src/logger/scopes/{scope}/scenes/{scene}.ts
+import { BaseScene } from '../../../base/baseScene';
+import { LogToServer } from '../../../base/decorators';
+
+export class MyFeatureScene extends BaseScene {
+  /**
+   * Track when user performs a specific action
+   */
+  @LogToServer()
+  public myFeatureAction(params: {
+    actionType: string;
+    source: string;
+  }) {
+    return params;
+  }
+}
+```
+
+Key rules:
+- Method name = Mixpanel event name (camelCase, e.g., `hwDeviceConnected`)
+- **MUST return params synchronously** — never `async`, never return a Promise
+- Use `@LogToServer()` for analytics events
+- Add `@LogToLocal()` below `@LogToServer()` if you also want device-side logging
+- Add JSDoc comment explaining what the event tracks
+
+### Step 4: Register scene in scope
+
+```typescript
+// packages/shared/src/logger/scopes/{scope}/index.ts
+import { BaseScope } from '../../base/baseScope';
+import { EScopeName } from '../../types';
+import { MyFeatureScene } from './scenes/myFeature';
+
+export class MyScope extends BaseScope {
+  protected override scopeName = EScopeName.myScope;
+
+  // ... existing scenes ...
+
+  myFeature = this.createScene('myFeature', MyFeatureScene);
+}
+```
+
+**Note:** Some scopes use a different `EScopeName` than their class name. For example, `MarketScope` uses `EScopeName.token` and `UpdateScope` uses `EScopeName.app`. Always check the actual scope file to confirm.
+
+### Step 5: (If new scope) Register in DefaultLogger and EScopeName
+
+Only needed when creating an entirely new scope:
+
+1. Add to `EScopeName` in `packages/shared/src/logger/types.ts`
+2. Create scope class in `packages/shared/src/logger/scopes/{newScope}/index.ts`
+3. Add instance to `DefaultLogger` in `packages/shared/src/logger/logger.ts`
+
+### Step 6: Call from business code
+
+```typescript
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+
+// In business logic
+defaultLogger.myScope.myFeature.myFeatureAction({
+  actionType: 'click',
+  source: 'homepage',
+});
+```
+
+## Full Example: Adding a new event to existing scope
+
+Goal: Track firmware switch start event.
+
+**1. Add method to existing scene** (`packages/shared/src/logger/scopes/update/scenes/firmware.ts`):
+
+```typescript
+import { BaseScene } from '../../../base/baseScene';
+import { LogToServer } from '../../../base/decorators';
+import type { IDeviceType } from '@onekeyfe/hd-core';
+import type { EFirmwareType } from '../../../../types/device';
+
+export class FirmwareScene extends BaseScene {
+  // ... existing methods ...
+
+  @LogToServer()
+  public firmwareSwitchStart(params: {
+    deviceType: IDeviceType | undefined;
+    fromFirmwareType: EFirmwareType | undefined;
+    toFirmwareType: EFirmwareType | undefined;
+  }) {
+    return params;
+  }
+}
+```
+
+**2. Call from UI** (`packages/kit/src/views/FirmwareUpdate/components/FirmwareChangeLogView.tsx`):
+
+```typescript
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+
+// Inside event handler, after user confirms
+if (fromFirmwareType !== toFirmwareType) {
+  defaultLogger.update.firmware.firmwareSwitchStart({
+    deviceType: result?.deviceType,
+    fromFirmwareType,
+    toFirmwareType,
+  });
+}
+```
+
+## Full Example: Adding a new scene to existing scope
+
+> This example is based on PR #10419 (proposed, not yet merged). It demonstrates the pattern for adding a new scene.
+
+Goal: Track hardware device connections.
+
+**1. Create new scene file** (`packages/shared/src/logger/scopes/hardware/scenes/connection.ts`):
+
+```typescript
+import { BaseScene } from '../../../base/baseScene';
+import { LogToServer } from '../../../base/decorators';
+import type { IDeviceType } from '@onekeyfe/hd-core';
+
+export class HardwareConnectionScene extends BaseScene {
+  @LogToServer()
+  public hwDeviceConnected(params: {
+    deviceType: IDeviceType;
+    firmwareType: 'btconly' | 'universal';
+  }) {
+    return params;
+  }
+}
+```
+
+**2. Register in scope index** (`packages/shared/src/logger/scopes/hardware/index.ts`):
+
+```typescript
+import { HardwareConnectionScene } from './scenes/connection';
+
+export class HardwareScope extends BaseScope {
+  // ... existing scenes ...
+  connection = this.createScene('connection', HardwareConnectionScene);
+}
+```
+
+**3. Call from service** (`packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts`):
+
+```typescript
+defaultLogger.hardware.connection.hwDeviceConnected({
+  deviceType,
+  firmwareType: firmwareType === EFirmwareType.BitcoinOnly ? 'btconly' : 'universal',
+});
+```

--- a/.claude/skills/1k-analytics/references/rules/architecture.md
+++ b/.claude/skills/1k-analytics/references/rules/architecture.md
@@ -1,0 +1,162 @@
+# Analytics Architecture
+
+## System Overview
+
+```
+Business Code
+  → defaultLogger.{scope}.{scene}.{method}(params)
+    → BaseScope Proxy (intercepts call, tracks timing)
+      → Scene Method (@LogToServer decorator wraps return in Metadata)
+        → logFn() routes by metadata.type
+          → 'server' → appGlobals.$analytics.trackEvent(methodName, params)
+            → POST /utility/v1/track/event (Mixpanel)
+          → 'local'  → React Native logger (device log file)
+          → 'console' → console.log (dev only)
+```
+
+## Directory Structure
+
+```
+packages/shared/src/logger/
+├── base/
+│   ├── baseScene.ts       # Base class for all scenes
+│   ├── baseScope.ts       # Proxy-based scope with scene caching
+│   ├── decorators.ts      # @LogToServer, @LogToLocal, @LogToConsole
+│   └── logFn.ts           # Event routing switch (server/local/console)
+├── scopes/                # 30+ scope directories
+│   ├── dex/
+│   │   ├── index.ts       # DexScope class, registers scenes
+│   │   ├── types.ts       # Event param interfaces and enums
+│   │   └── scenes/
+│   │       ├── banner.ts  # BannerScene (dexBannerEnter event)
+│   │       ├── enter.ts
+│   │       ├── swap.ts
+│   │       └── ...
+│   ├── hardware/
+│   │   ├── index.ts
+│   │   └── scenes/
+│   │       ├── sdk.ts       # HardwareSDKScene
+│   │       ├── homescreen.ts
+│   │       ├── verify.ts
+│   │       └── litecard.ts
+│   └── ...
+├── logger.ts              # DefaultLogger — instantiates all scopes
+├── types.ts               # EScopeName enum, Metadata class, IMethodDecoratorMetadata
+├── loggerConfig.ts        # Per-scope/scene enable/disable config
+├── stringifyFunc.ts       # Safe argument serialization (3000 char limit)
+└── extensions.ts          # React Native logger extensions
+```
+
+## Key Classes
+
+### BaseScene (`base/baseScene.ts`)
+
+Base class all scenes extend. Provides:
+- Timestamp management (`timestamp`, `lastTimestamp`, `resetTimestamp()`)
+- Duration tracking (automatic via BaseScope proxy)
+- Utility methods: `consoleLog()`, `consoleError()`
+- `registerRid()` — sends push notification RID to server via `@LogToServer()`
+
+### BaseScope (`base/baseScope.ts`)
+
+Uses **Proxy pattern** to intercept all scene method calls:
+- Lazy-instantiates scene classes on first use (cached)
+- Calculates `lastDuration` and `totalDuration` per method call
+- Validates methods exist and don't return Promises
+- Calls `logFn()` with serialized args + decorator metadata
+
+### Decorators (`base/decorators.ts`)
+
+Wraps scene methods to attach routing metadata:
+
+```typescript
+@LogToServer()                    // → metadata.type = 'server'
+@LogToLocal({ level: 'info' })    // → metadata.type = 'local'
+@LogToConsole()                   // → metadata.type = 'console'
+```
+
+Multiple decorators stack — a method with both `@LogToServer()` and `@LogToLocal()` sends to both destinations.
+
+### logFn (`base/logFn.ts`)
+
+Routes events based on `metadata.type` (wrapped in `setTimeout` for non-blocking):
+- `'server'`: Calls `appGlobals.$analytics.trackEvent(methodName, flattenedParams)`
+- `'local'`: Writes to React Native logger, handles repeat message dedup
+- `'console'`: Console output (dev only, respects per-scope config)
+
+### Analytics Service (`packages/shared/src/analytics/index.ts`)
+
+Handles server communication:
+- Caches events before initialization
+- Sends `POST /utility/v1/track/event` with `{eventName, eventProps}`
+- Includes device info and `distinct_id` (instance ID)
+- Skips sending in dev/E2E mode (unless `enableAnalyticsInDev`)
+- Web embed posts via `postMessage` to parent
+
+## User Profile Tracking
+
+`analytics.updateUserProfile()` is a separate API for setting persistent user attributes in Mixpanel (not events). This is intentionally called directly — NOT through the decorator system:
+
+```typescript
+import { analytics } from '@onekeyhq/shared/src/analytics';
+
+analytics.updateUserProfile({
+  walletCount: 3,
+  appWalletCount: 2,
+  hwWalletCount: 1,
+});
+```
+
+Use this only for aggregate user attributes (wallet counts, etc.), not for behavioral events.
+
+## Advanced Patterns
+
+### NO_LOG_OUTPUT sentinel
+
+Use `NO_LOG_OUTPUT` to conditionally suppress logging from within a scene method:
+
+```typescript
+import { NO_LOG_OUTPUT } from '../../../types';
+
+@LogToLocal()
+public serviceCall(params: { service: string }) {
+  if (isHighFrequencyCall(params.service)) {
+    return NO_LOG_OUTPUT; // suppress logging for noisy calls
+  }
+  return params;
+}
+```
+
+### Returning arrays for multi-destination data
+
+Scene methods can return arrays to pass different data to different decorators:
+
+```typescript
+@LogToServer()
+@LogToLocal({ level: 'error' })
+public failedAction(params: { type: string; error: Error }) {
+  return [{ type: params.type }, devOnlyData(params.error)];
+}
+```
+
+## Naming Conventions
+
+| Element | Convention | Example |
+|---------|-----------|---------|
+| Scope name | camelCase in `EScopeName` enum (may differ from class name!) | `dex`, `hardware`, `fiatCrypto` |
+| Scene name | camelCase string in `createScene()` | `'banner'`, `'sdkLog'` |
+| Scene class | PascalCase + `Scene` suffix | `BannerScene`, `HardwareSDKScene` |
+| Scope class | PascalCase + `Scope` suffix | `DexScope`, `HardwareScope` |
+| Event method | camelCase (becomes Mixpanel event name) | `dexBannerEnter`, `firmwareUpdateResult` |
+| Event params | TypeScript interface with `I` prefix | `IDexBannerEnterParams` |
+| Param enums | PascalCase with `E` prefix | `EEnterWay`, `ESwapType` |
+
+## Data Flow: @LogToServer Event
+
+1. Code calls `defaultLogger.dex.banner.dexBannerEnter({ bannerId: '123' })`
+2. `BaseScope` proxy intercepts → finds/creates `BannerScene` instance
+3. Calls `dexBannerEnter({ bannerId: '123' })` on the scene
+4. `@LogToServer()` decorator wraps return value: `new Metadata([{ bannerId: '123' }], { type: 'server', level: 'info' })`
+5. Proxy extracts metadata → calls `logFn()` with scope/scene/method names
+6. `logFn()` sees `type: 'server'` → calls `appGlobals.$analytics.trackEvent('dexBannerEnter', { bannerId: '123' })`
+7. Analytics service sends HTTP POST to `/utility/v1/track/event`

--- a/.claude/skills/1k-analytics/references/rules/pitfalls.md
+++ b/.claude/skills/1k-analytics/references/rules/pitfalls.md
@@ -1,0 +1,139 @@
+# Common Pitfalls
+
+## 1. Calling analytics directly
+
+**Problem:** Calling `analytics.trackEvent()` or `appGlobals.$analytics.trackEvent()` directly from business code.
+
+**Why it's wrong:** Bypasses the logger system, loses timing/duration tracking, inconsistent with codebase patterns, harder to search and maintain.
+
+**Fix:** Always use `defaultLogger.{scope}.{scene}.{method}(params)` with `@LogToServer()` decorator.
+
+```typescript
+// WRONG
+import { analytics } from '@onekeyhq/shared/src/analytics';
+analytics.trackEvent('myEvent', { key: 'value' });
+
+// WRONG
+import appGlobals from '@onekeyhq/shared/src/appGlobals';
+appGlobals.$analytics?.trackEvent('myEvent', { key: 'value' });
+
+// CORRECT
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+defaultLogger.myScope.myScene.myEvent({ key: 'value' });
+```
+
+**Exceptions:** Two legitimate direct calls exist:
+- `analytics.updateUserProfile()` — for setting persistent user attributes (wallet counts), not event tracking. See [architecture.md](architecture.md#user-profile-tracking).
+- Web embed `postMessage` handler — the parent WebView calls `analytics.trackEvent()` to relay events from the embedded context. Do not modify this pattern.
+
+## 2. Mixpanel usage spikes from high-frequency events
+
+**Problem:** Placing `@LogToServer()` events in callbacks that fire very frequently (e.g., `DEVICE.SUPPORT_FEATURES` fires on every hardware feature update, WebSocket messages, polling intervals).
+
+**Real-world case from PR #10419 review:**
+> "这个埋点有 mixpanel 用量暴增的风险，每次 features 请求都会执行一次"
+
+**Fix:** Deduplicate with in-memory Set or flag:
+
+```typescript
+// Per-session dedup with Set
+private connectedDeviceTracked = new Set<string>();
+
+// In the callback
+if (!this.connectedDeviceTracked.has(deviceId)) {
+  this.connectedDeviceTracked.add(deviceId);
+  defaultLogger.hardware.connection.hwDeviceConnected(params);
+}
+```
+
+**Other dedup strategies:**
+- **Per-session flag:** Boolean flag reset on app restart
+- **Throttle:** Use `lodash.throttle` for periodic events (e.g., at most once per minute)
+- **Conditional:** Only fire when state actually changes (e.g., `fromType !== toType`)
+
+## 3. Returning Promises from scene methods
+
+**Problem:** Scene methods decorated with `@LogToServer()` must return data synchronously. The BaseScope proxy validates this.
+
+```typescript
+// WRONG — returns a Promise
+@LogToServer()
+public async myEvent() {
+  const data = await fetchSomething();
+  return data;
+}
+
+// CORRECT — returns synchronous data
+@LogToServer()
+public myEvent(params: { key: string }) {
+  return params;
+}
+```
+
+**If you need async data in the event params:** Resolve async values before calling the logger method:
+
+```typescript
+// In business code
+const deviceType = await deviceUtils.getDeviceType(features);
+defaultLogger.hardware.connection.hwDeviceConnected({ deviceType });
+```
+
+## 4. Creating unnecessary new scopes
+
+**Problem:** Creating a new scope when the event belongs to an existing domain.
+
+**Rule:** Check `packages/shared/src/logger/logger.ts` for existing scopes. A firmware-related event should go under `update.firmware`, not a new `firmwareTracking` scope.
+
+## 5. Forgetting to add EScopeName for new scopes
+
+**Problem:** Creating a scope class but not adding the enum value to `EScopeName` in `packages/shared/src/logger/types.ts`.
+
+**Fix:** Always add to both:
+1. `EScopeName` enum in `types.ts`
+2. `DefaultLogger` class in `logger.ts`
+
+## 6. Logging sensitive data
+
+**Problem:** Including private keys, mnemonics, passwords, or PII in event params.
+
+**Rule:** Never log sensitive data in `@LogToServer()`. Only log identifiers, types, and behavioral metadata.
+
+For `@LogToLocal()` debugging, use `devOnlyData()` to safely include error details (returns placeholder in production):
+
+```typescript
+import { devOnlyData } from '@onekeyhq/shared/src/utils/devModeUtils';
+
+@LogToServer()
+@LogToLocal({ level: 'error' })
+public failToCreateTransaction(params: { error: string }) {
+  return [params, devOnlyData(error)]; // full error only in dev
+}
+```
+
+## 7. Inconsistent event naming
+
+**Problem:** Using snake_case or mixing naming styles for method names.
+
+**Rule:** Always use camelCase for method names. The method name becomes the Mixpanel event name automatically.
+
+```typescript
+// WRONG
+@LogToServer()
+public hw_device_connected(params: {...}) { return params; }
+
+// CORRECT
+@LogToServer()
+public hwDeviceConnected(params: {...}) { return params; }
+```
+
+## Self-Check Before Submitting
+
+- [ ] Using `@LogToServer()` decorator (not direct analytics calls)?
+- [ ] Event method returns params synchronously (not a Promise)?
+- [ ] High-frequency callback? Added dedup logic?
+- [ ] No sensitive data (keys, addresses, passwords) in `@LogToServer()` params?
+- [ ] Using `devOnlyData()` for error details in `@LogToLocal()`?
+- [ ] Method name is camelCase?
+- [ ] Added to existing scope/scene (not creating unnecessary new scope)?
+- [ ] TypeScript types defined for all params?
+- [ ] If using `@LogToLocal()`, set appropriate level (`error` for errors, `info` for normal)?

--- a/.claude/skills/1k-new-skill/SKILL.md
+++ b/.claude/skills/1k-new-skill/SKILL.md
@@ -97,22 +97,32 @@ Where:
 
 | Category | Skill | Merge candidates |
 |----------|-------|------------------|
-| Feature development | `1k-feature-guides` | New chains, socket events, notifications, pages, routes |
-| Code quality | `1k-code-quality` | Lint fixes, pre-commit tasks, documentation |
-| Sentry analysis | `1k-sentry-analysis` | Crash reports, AppHang, ANR fixes |
-| Test versions | `1k-test-version` | Upgrade testing, version migration |
-| Native module patches | `1k-patching-native-modules` | iOS/Android crash fixes, native code patches |
-| Error monitoring | `1k-sentry` | Error filtering, crash configuration |
+| Analytics/Tracking | `1k-analytics` | Event tracking, Mixpanel, LogToServer, defaultLogger |
 | Architecture | `1k-architecture` | Project structure, import rules |
+| Code quality | `1k-code-quality` | Lint fixes, pre-commit tasks, documentation |
+| Code review | `1k-code-review-pr` | PR review checklists |
 | Coding patterns | `1k-coding-patterns` | React patterns, TypeScript conventions |
-| Performance | `1k-performance` | Optimization, concurrent requests, memoization |
-| Error handling | `1k-error-handling` | Try/catch, error boundaries, user-facing errors |
-| State management | `1k-state-management` | Jotai atoms, global state |
+| Create PR | `1k-create-pr` | PR creation workflow |
 | Cross-platform | `1k-cross-platform` | Platform-specific code |
 | Date formatting | `1k-date-formatting` | Date/time display, locale formatting |
-| i18n | `1k-i18n` | Translations, locales |
-| Git workflow | `1k-git-workflow` | Branching, commits, PRs |
+| DeFi integration | `1k-defi-module-integration` | Staking, lending, Earn, Borrow modules |
 | Dev commands | `1k-dev-commands` | Build, test, lint commands |
+| Error handling | `1k-error-handling` | Try/catch, error boundaries, user-facing errors |
+| Feature development | `1k-feature-guides` | New chains, socket events, notifications, pages, routes |
+| Git workflow | `1k-git-workflow` | Branching, commits, PRs |
+| Group think | `1k-group-think` | Multi-agent collaborative analysis |
+| i18n | `1k-i18n` | Translations, locales |
+| Monitor PR CI | `1k-monitor-pr-ci` | CI check monitoring, PR status |
+| Native module patches | `1k-patching-native-modules` | iOS/Android crash fixes, native code patches |
+| Package upgrades | `1k-pkg-upgrade-review` | Dependency upgrade review, compatibility |
+| Performance | `1k-performance` | Optimization, concurrent requests, memoization |
+| Platform requirements | `1k-platform-requirements` | Min SDK/OS versions for all platforms |
+| Retrospective | `1k-retrospective` | Bug fix analysis, checklist updates |
+| Sentry analysis | `1k-sentry-analysis` | Crash reports, AppHang, ANR fixes |
+| Sentry config | `1k-sentry` | Error filtering, crash configuration |
+| State management | `1k-state-management` | Jotai atoms, global state |
+| Test versions | `1k-app-upgrade-test` | App auto-update testing, version migration |
+| UI recipes | `1k-ui-recipes` | Scroll offset, view transitions, keyboard avoidance |
 
 ### Merging workflow
 


### PR DESCRIPTION
## Summary
- Add `1k-analytics` skill for analytics event tracking (埋点) guidance
- Update `1k-new-skill` skill catalog from 16 to 26 entries to reflect all current skills

## Intent & Context
Based on PR #10419 review feedback where a contributor was told to use `@LogToServer` decorator instead of calling `analytics.trackEvent()` directly. Created a comprehensive skill to prevent this common mistake and document the full logger system.

## Changes Detail
- **`.claude/skills/1k-analytics/SKILL.md`**: Main skill entry with critical rules, quick reference, and decorator types
- **`references/rules/adding-events.md`**: Step-by-step guide for adding new analytics events with real codebase examples
- **`references/rules/architecture.md`**: Logger system architecture (BaseScope proxy, decorators, logFn routing, analytics service)
- **`references/rules/pitfalls.md`**: Common mistakes with fixes (direct analytics calls, Mixpanel spikes, async returns, sensitive data logging)
- **`.claude/skills/1k-new-skill/SKILL.md`**: Updated skill catalog table to include all 26 current `1k-*` skills

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: None (documentation only)

## Test plan
- [ ] Verify `1k-analytics` skill triggers on keywords: "埋点", "统计", "analytics", "LogToServer"
- [ ] Verify skill content accuracy against codebase patterns
- [ ] Reviewed by 3-agent team (accuracy, structure, completeness)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
