### PR TITLE
feat: integrate QA bundle upload into native and desktop bundle workflows

### DIFF
--- a/.github/workflows/release-desktop-bundle.yml
+++ b/.github/workflows/release-desktop-bundle.yml
@@ -114,14 +114,14 @@ jobs:
             "fileName": "$BUNDLE_FILE",
             "sha256": "$BUNDLE_SHA256",
             "size": $BUNDLE_SIZE,
-            "generatedAt": "$GENERATED_AT"
+            "generatedAt": "$GENERATED_AT",
             "appVersion": "$APP_VERSION",
             "buildNumber": "$BUILD_NUMBER",
             "bundleVersion": "$BUILD_BUNDLE_VERSION",
             "appType": "electron"
           }
           EOF
-      
+
       - name: Generate metadata.json.info
         run: |
           echo "current dir: $(pwd)"
@@ -140,10 +140,10 @@ jobs:
             "fileName": "$METADATA_FILE",
             "sha256": "$METADATA_SHA256",
             "size": $METADATA_SIZE,
-            "generatedAt": "$GENERATED_AT"
+            "generatedAt": "$GENERATED_AT",
             "appVersion": "$APP_VERSION",
             "buildNumber": "$BUILD_NUMBER",
-            "bundleVersion": "$BUILD_BUNDLE_VERSION"
+            "bundleVersion": "$BUILD_BUNDLE_VERSION",
             "appType": "electron"
           }
           EOF

--- a/.github/workflows/release-desktop-bundle.yml
+++ b/.github/workflows/release-desktop-bundle.yml
@@ -148,6 +148,14 @@ jobs:
           }
           EOF
 
+      - name: upload bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: onekey-desktop-bundle-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
+          path: |
+            ./apps/desktop/bundle-zip/*
+            !**/.DS_Store
+
       - name: Upload QA Bundles
         uses: originalix/actions/qa-bundle-upload@feat/qa-bundle-upload # TODO: replace with onekeyhq/actions/qa-bundle-upload@main after testing
         with:
@@ -156,14 +164,6 @@ jobs:
           bundle-dir: ./apps/desktop/bundle-zip
           commit-hash: ${{ github.sha }}
           branch: ${{ github.ref_name }}
-
-      - name: upload bundle
-        uses: actions/upload-artifact@v4
-        with:
-          name: onekey-desktop-bundle-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
-          path: |
-            ./apps/desktop/bundle-zip/*
-            !**/.DS_Store
 
       - name: 'Notify to Slack'
         if: ${{ github.event.workflow_run }}

--- a/.github/workflows/release-desktop-bundle.yml
+++ b/.github/workflows/release-desktop-bundle.yml
@@ -151,8 +151,8 @@ jobs:
       - name: Upload QA Bundles
         uses: originalix/actions/qa-bundle-upload@feat/qa-bundle-upload # TODO: replace with onekeyhq/actions/qa-bundle-upload@main after testing
         with:
-          server-url: ${{ secrets.UTILITY_SERVER_URL }}
-          upload-secret: ${{ secrets.JS_BUNDLE_UPLOAD_SECRET }}
+          server-url: ${{ secrets.QA_JS_BUNDLE_SERVER_URL }}
+          upload-secret: ${{ secrets.QA_JS_BUNDLE_UPLOAD_SECRET }}
           bundle-dir: ./apps/desktop/bundle-zip
           commit-hash: ${{ github.sha }}
           branch: ${{ github.ref_name }}

--- a/.github/workflows/release-desktop-bundle.yml
+++ b/.github/workflows/release-desktop-bundle.yml
@@ -147,7 +147,16 @@ jobs:
             "appType": "electron"
           }
           EOF
-      
+
+      - name: Upload QA Bundles
+        uses: originalix/actions/qa-bundle-upload@feat/qa-bundle-upload # TODO: replace with onekeyhq/actions/qa-bundle-upload@main after testing
+        with:
+          server-url: ${{ secrets.UTILITY_SERVER_URL }}
+          upload-secret: ${{ secrets.JS_BUNDLE_UPLOAD_SECRET }}
+          bundle-dir: ./apps/desktop/bundle-zip
+          commit-hash: ${{ github.sha }}
+          branch: ${{ github.ref_name }}
+
       - name: upload bundle
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release-native-bundle.yml
+++ b/.github/workflows/release-native-bundle.yml
@@ -99,6 +99,15 @@ jobs:
             ./apps/mobile/out-dir-bundle
             !**/.DS_Store
 
+      - name: Upload QA Bundles
+        uses: originalix/actions/qa-bundle-upload@feat/qa-bundle-upload # TODO: replace with onekeyhq/actions/qa-bundle-upload@main after testing
+        with:
+          server-url: ${{ secrets.UTILITY_SERVER_URL }}
+          upload-secret: ${{ secrets.JS_BUNDLE_UPLOAD_SECRET }}
+          bundle-dir: ./apps/mobile/out-dir-bundle-zip
+          commit-hash: ${{ github.sha }}
+          branch: ${{ github.ref_name }}
+
       - name: 'Notify to Slack'
         if: ${{ github.event.workflow_run }}
         uses: onekeyhq/actions/slack-notify-webhook@main

--- a/.github/workflows/release-native-bundle.yml
+++ b/.github/workflows/release-native-bundle.yml
@@ -102,8 +102,8 @@ jobs:
       - name: Upload QA Bundles
         uses: originalix/actions/qa-bundle-upload@feat/qa-bundle-upload # TODO: replace with onekeyhq/actions/qa-bundle-upload@main after testing
         with:
-          server-url: ${{ secrets.UTILITY_SERVER_URL }}
-          upload-secret: ${{ secrets.JS_BUNDLE_UPLOAD_SECRET }}
+          server-url: ${{ secrets.QA_JS_BUNDLE_SERVER_URL }}
+          upload-secret: ${{ secrets.QA_JS_BUNDLE_UPLOAD_SECRET }}
           bundle-dir: ./apps/mobile/out-dir-bundle-zip
           commit-hash: ${{ github.sha }}
           branch: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- Add `qa-bundle-upload` step to `release-native-bundle.yml` (iOS + Android) and `release-desktop-bundle.yml` (Electron)
- Fix invalid JSON syntax in desktop bundle `.info` heredocs (missing commas)
- New secrets required: `QA_JS_BUNDLE_SERVER_URL`, `QA_JS_BUNDLE_UPLOAD_SECRET`

## Intent & Context
Every successful JS bundle build should automatically upload to the QA Utility server for testing. The `qa-bundle-upload` action (currently at `originalix/actions/qa-bundle-upload@feat/qa-bundle-upload`) handles HMAC-signed multipart upload of bundle ZIPs with their `.info` metadata to the server endpoint.

## Root Cause
The desktop bundle workflow had pre-existing JSON syntax errors in its `.info` heredocs — missing commas after `"generatedAt"` and `"bundleVersion"` fields. These would cause `JSON.parse()` failures in any downstream consumer. Fixed as a prerequisite for the upload integration.

## Design Decisions
- **Action reference**: Using `originalix/actions/qa-bundle-upload@feat/qa-bundle-upload` (locked to development branch) during testing phase. TODO comments mark where to replace with `onekeyhq/actions/qa-bundle-upload@main` after validation.
- **No `continue-on-error`**: Upload failure stops the workflow — QA bundle delivery is considered a hard requirement.
- **Secret naming**: All secrets prefixed with `QA_JS_BUNDLE_` for clear namespacing.
- **Step placement**: Upload runs after bundle build/packaging but before (or alongside) artifact upload and Slack notification.

## Changes Detail
- **`release-native-bundle.yml`**: Added `Upload QA Bundles` step after artifact upload, before Slack notification. Points to `./apps/mobile/out-dir-bundle-zip` which contains `ios-bundle.zip` + `android-bundle.zip` with their `.info` files.
- **`release-desktop-bundle.yml`**: Fixed 3 missing commas in `.info` heredocs. Added `Upload QA Bundles` step after `.info` generation, before artifact upload. Points to `./apps/desktop/bundle-zip` which contains `electron-bundle.zip` + `electron-bundle.json.info`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: CI/CD workflows only (no app code changes)
- **Risk Areas**: New secrets (`QA_JS_BUNDLE_SERVER_URL`, `QA_JS_BUNDLE_UPLOAD_SECRET`) must be configured in repo settings before the workflow runs, otherwise the upload step will fail.

## Test plan
- [ ] Configure `QA_JS_BUNDLE_SERVER_URL` and `QA_JS_BUNDLE_UPLOAD_SECRET` in repo secrets
- [ ] Trigger `release-native-bundle` via `workflow_dispatch` and verify iOS + Android bundles upload successfully
- [ ] Trigger `release-desktop-bundle` via `workflow_dispatch` and verify Electron bundle uploads successfully
- [ ] Verify upload results in workflow logs (bundle version + download URL printed)
- [ ] After testing, replace `originalix/actions/qa-bundle-upload@feat/qa-bundle-upload` with `onekeyhq/actions/qa-bundle-upload@main`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
