### PR TITLE
fix: switch to Home tab before pushing URL account page after QR scan

### DIFF
--- a/packages/kit/src/views/Home/pages/urlAccount/urlAccountUtils.ts
+++ b/packages/kit/src/views/Home/pages/urlAccount/urlAccountUtils.ts
@@ -218,6 +218,8 @@ export const urlAccountNavigation = {
       realNetworkIdFallback: params.networkId || '',
       contextNetworkId: params.contextNetworkId || '',
     });
+    navigation.switchTab(ETabRoutes.Home);
+    await timerUtils.wait(0);
     rootNavigationRef.current?.dispatch(
       StackActions.push(ETabHomeRoutes.TabHomeUrlAccountPage, {
         address: params.address,


### PR DESCRIPTION
When scanning a URL_ACCOUNT QR code from the Settings page, the scanner modal would dismiss but fail to navigate to the URL account result page.

Root cause: pushUrlAccountPage dispatches StackActions.push for a Home tab route (TabHomeUrlAccountPage) to rootNavigationRef. React Navigation forwards this action to the currently focused tab navigator. When the user is on the Settings tab, the action gets forwarded to the Settings navigator which doesn't have TabHomeUrlAccountPage, so the push is silently dropped.

Fix: Call navigation.switchTab(ETabRoutes.Home) before dispatching the push action, ensuring the Home tab is active. This matches the pattern used by AddressBook and pushOrReplaceUrlAccountPage.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
