### PR TITLE
fix: perps tab hidden on app reset & footer missing in dApp mode(OK-50691 OK-50823)

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -185,18 +185,21 @@ export default class ServiceHyperliquid extends ServiceBase {
   }
 
   @backgroundMethod()
-  async updatePerpConfig({
-    referrerConfig,
-    customSettings,
-    customLocalStorage,
-    customLocalStorageV2,
-    commonConfig,
-    bannerConfig,
-    depositTokenConfig,
-    hyperLiquidErrorLocales,
-    tokenSearchAliases,
-    tokenSelectorTabs,
-  }: IPerpServerConfigResponse) {
+  async updatePerpConfig(
+    {
+      referrerConfig,
+      customSettings,
+      customLocalStorage,
+      customLocalStorageV2,
+      commonConfig,
+      bannerConfig,
+      depositTokenConfig,
+      hyperLiquidErrorLocales,
+      tokenSearchAliases,
+      tokenSelectorTabs,
+    }: IPerpServerConfigResponse,
+    options?: { fromServerConfig?: boolean },
+  ) {
     let shouldNotifyToDapp = false;
 
     // Check configVersion change before updating
@@ -237,14 +240,24 @@ export default class ServiceHyperliquid extends ServiceBase {
       (prev): IPerpsCommonConfigPersistAtom => {
         const newVal = perfUtils.buildNewValueIfChanged(prev, {
           ...prev,
+          ...(options?.fromServerConfig && { perpConfigLoaded: true }),
           perpConfigCommon: {
             ...prev.perpConfigCommon,
-            // usePerpWeb: true,
-            usePerpWeb: commonConfig?.usePerpWeb,
-            disablePerp: commonConfig?.disablePerp,
-            disablePerpActionPerp: commonConfig?.disablePerpActionPerp,
-            perpBannerConfig: bannerConfig,
-            ipDisablePerp: commonConfig?.ipDisablePerp,
+            usePerpWeb: commonConfig
+              ? commonConfig.usePerpWeb === true
+              : prev.perpConfigCommon.usePerpWeb,
+            disablePerp: commonConfig
+              ? commonConfig.disablePerp === true
+              : prev.perpConfigCommon.disablePerp,
+            disablePerpActionPerp: commonConfig
+              ? commonConfig.disablePerpActionPerp === true
+              : prev.perpConfigCommon.disablePerpActionPerp,
+            ipDisablePerp: commonConfig
+              ? commonConfig.ipDisablePerp === true
+              : prev.perpConfigCommon.ipDisablePerp,
+            perpBannerConfig: options?.fromServerConfig
+              ? bannerConfig
+              : (bannerConfig ?? prev.perpConfigCommon.perpBannerConfig),
           },
         });
         return newVal;
@@ -335,21 +348,24 @@ export default class ServiceHyperliquid extends ServiceBase {
       // TODO remove
       // resData.data.referrerRate = 65;
     }
-    await this.updatePerpConfig({
-      referrerConfig: resData?.data?.referrerConfig,
-      customSettings: resData?.data?.customSettings,
-      customLocalStorage: resData?.data?.customLocalStorage,
-      customLocalStorageV2: {
-        ...HYPER_LIQUID_CUSTOM_LOCAL_STORAGE_V2_PRESET,
-        ...resData?.data?.customLocalStorageV2,
+    await this.updatePerpConfig(
+      {
+        referrerConfig: resData?.data?.referrerConfig,
+        customSettings: resData?.data?.customSettings,
+        customLocalStorage: resData?.data?.customLocalStorage,
+        customLocalStorageV2: {
+          ...HYPER_LIQUID_CUSTOM_LOCAL_STORAGE_V2_PRESET,
+          ...resData?.data?.customLocalStorageV2,
+        },
+        commonConfig: resData?.data?.commonConfig ?? {},
+        bannerConfig: resData?.data?.bannerConfig,
+        depositTokenConfig: resData?.data?.depositTokenConfig,
+        hyperLiquidErrorLocales: resData?.data?.hyperLiquidErrorLocales,
+        tokenSearchAliases: resData?.data?.tokenSearchAliases,
+        tokenSelectorTabs: resData?.data?.tokenSelectorTabs,
       },
-      commonConfig: resData?.data?.commonConfig,
-      bannerConfig: resData?.data?.bannerConfig,
-      depositTokenConfig: resData?.data?.depositTokenConfig,
-      hyperLiquidErrorLocales: resData?.data?.hyperLiquidErrorLocales,
-      tokenSearchAliases: resData?.data?.tokenSearchAliases,
-      tokenSelectorTabs: resData?.data?.tokenSelectorTabs,
-    });
+      { fromServerConfig: true },
+    );
     return resData;
   }
 

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -243,18 +243,13 @@ export default class ServiceHyperliquid extends ServiceBase {
           ...(options?.fromServerConfig && { perpConfigLoaded: true }),
           perpConfigCommon: {
             ...prev.perpConfigCommon,
-            usePerpWeb: commonConfig
-              ? commonConfig.usePerpWeb === true
-              : prev.perpConfigCommon.usePerpWeb,
-            disablePerp: commonConfig
-              ? commonConfig.disablePerp === true
-              : prev.perpConfigCommon.disablePerp,
-            disablePerpActionPerp: commonConfig
-              ? commonConfig.disablePerpActionPerp === true
-              : prev.perpConfigCommon.disablePerpActionPerp,
-            ipDisablePerp: commonConfig
-              ? commonConfig.ipDisablePerp === true
-              : prev.perpConfigCommon.ipDisablePerp,
+            ...(commonConfig && {
+              usePerpWeb: commonConfig.usePerpWeb === true,
+              disablePerp: commonConfig.disablePerp === true,
+              disablePerpActionPerp:
+                commonConfig.disablePerpActionPerp === true,
+              ipDisablePerp: commonConfig.ipDisablePerp === true,
+            }),
             perpBannerConfig: options?.fromServerConfig
               ? bannerConfig
               : (bannerConfig ?? prev.perpConfigCommon.perpBannerConfig),

--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -313,6 +313,7 @@ export const {
 // #region Settings & Config
 export interface IPerpsCommonConfigPersistAtom {
   perpConfigCommon: IPerpCommonConfig;
+  perpConfigLoaded?: boolean;
 }
 export const {
   target: perpsCommonConfigPersistAtom,
@@ -322,8 +323,9 @@ export const {
   persist: true,
   initialValue: {
     perpConfigCommon: {
-      disablePerp: true, // Default to hide perps tab, will be overridden by server config
+      disablePerp: true, // Default to hide perps tab, gated by perpConfigLoaded
     },
+    perpConfigLoaded: false,
   },
 });
 

--- a/packages/kit/src/hooks/usePerpTabConfig.ts
+++ b/packages/kit/src/hooks/usePerpTabConfig.ts
@@ -8,10 +8,14 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EPerpUserType } from '@onekeyhq/shared/types/hyperliquid';
 
 export function usePerpTabConfig() {
-  const [{ perpConfigCommon }] = usePerpsCommonConfigPersistAtom();
+  const [{ perpConfigCommon, perpConfigLoaded }] =
+    usePerpsCommonConfigPersistAtom();
   const [{ perpUserConfig }] = usePerpsUserConfigPersistAtom();
+  const isPerpConfigLoaded = perpConfigLoaded ?? false;
 
-  const disablePerp = perpConfigCommon?.disablePerp;
+  const disablePerp = isPerpConfigLoaded
+    ? perpConfigCommon?.disablePerp
+    : false;
   const usePerpWeb = perpConfigCommon?.usePerpWeb;
   const currentUserType = perpUserConfig.currentUserType;
 

--- a/packages/kit/src/provider/Bootstrap.tsx
+++ b/packages/kit/src/provider/Bootstrap.tsx
@@ -394,36 +394,28 @@ export const useFetchMarketBasicConfig = () => {
 export const useFetchPerpConfig = () => {
   useEffect(() => {
     let cancelled = false;
-
-    const fetchPerpConfig = async (attempt: number) => {
-      if (attempt === 0) {
-        return backgroundApiProxy.serviceHyperliquid.updatePerpsConfigByServerWithCache();
-      }
-      return backgroundApiProxy.serviceHyperliquid.updatePerpsConfigByServer();
-    };
-
-    const fetchWithRetry = async () => {
-      for (
-        let attempt = 0;
-        attempt <= PERPS_CONFIG_FETCH_MAX_RETRIES;
-        attempt += 1
-      ) {
+    const run = async () => {
+      for (let i = 0; i <= PERPS_CONFIG_FETCH_MAX_RETRIES; i += 1) {
         if (cancelled) return;
         try {
-          await fetchPerpConfig(attempt);
+          if (i === 0) {
+            await backgroundApiProxy.serviceHyperliquid.updatePerpsConfigByServerWithCache();
+          } else {
+            await backgroundApiProxy.serviceHyperliquid.updatePerpsConfigByServer();
+          }
           return;
         } catch (error) {
           console.error(
-            `[useFetchPerpConfig] attempt ${attempt + 1} failed:`,
+            `[useFetchPerpConfig] attempt ${i + 1} failed:`,
             error,
           );
-          if (attempt < PERPS_CONFIG_FETCH_MAX_RETRIES) {
+          if (i < PERPS_CONFIG_FETCH_MAX_RETRIES) {
             await timerUtils.wait(PERPS_CONFIG_FETCH_RETRY_INTERVAL_MS);
           }
         }
       }
     };
-    void fetchWithRetry();
+    void run();
     return () => {
       cancelled = true;
     };

--- a/packages/kit/src/provider/Bootstrap.tsx
+++ b/packages/kit/src/provider/Bootstrap.tsx
@@ -28,6 +28,10 @@ import {
   getUpdateFileType,
 } from '@onekeyhq/shared/src/appUpdate';
 import {
+  PERPS_CONFIG_FETCH_MAX_RETRIES,
+  PERPS_CONFIG_FETCH_RETRY_INTERVAL_MS,
+} from '@onekeyhq/shared/src/consts/perp';
+import {
   EAppEventBusNames,
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
@@ -388,11 +392,42 @@ export const useFetchMarketBasicConfig = () => {
 };
 
 export const useFetchPerpConfig = () => {
-  useRunAfterTokensDone({
-    run: () => {
-      void backgroundApiProxy.serviceHyperliquid.updatePerpsConfigByServerWithCache();
-    },
-  });
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchPerpConfig = async (attempt: number) => {
+      if (attempt === 0) {
+        return backgroundApiProxy.serviceHyperliquid.updatePerpsConfigByServerWithCache();
+      }
+      return backgroundApiProxy.serviceHyperliquid.updatePerpsConfigByServer();
+    };
+
+    const fetchWithRetry = async () => {
+      for (
+        let attempt = 0;
+        attempt <= PERPS_CONFIG_FETCH_MAX_RETRIES;
+        attempt += 1
+      ) {
+        if (cancelled) return;
+        try {
+          await fetchPerpConfig(attempt);
+          return;
+        } catch (error) {
+          console.error(
+            `[useFetchPerpConfig] attempt ${attempt + 1} failed:`,
+            error,
+          );
+          if (attempt < PERPS_CONFIG_FETCH_MAX_RETRIES) {
+            await timerUtils.wait(PERPS_CONFIG_FETCH_RETRY_INTERVAL_MS);
+          }
+        }
+      }
+    };
+    void fetchWithRetry();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 };
 
 const launchFloatingIconEvent = async (intl: IntlShape) => {

--- a/packages/kit/src/provider/Bootstrap.tsx
+++ b/packages/kit/src/provider/Bootstrap.tsx
@@ -2,6 +2,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 
 import { CommonActions, StackActions } from '@react-navigation/native';
+import pRetry from 'p-retry';
 import { debounce, isEqual, noop, upperFirst } from 'lodash';
 import { useIntl } from 'react-intl';
 
@@ -393,32 +394,19 @@ export const useFetchMarketBasicConfig = () => {
 
 export const useFetchPerpConfig = () => {
   useEffect(() => {
-    let cancelled = false;
-    const run = async () => {
-      for (let i = 0; i <= PERPS_CONFIG_FETCH_MAX_RETRIES; i += 1) {
-        if (cancelled) return;
-        try {
-          if (i === 0) {
-            await backgroundApiProxy.serviceHyperliquid.updatePerpsConfigByServerWithCache();
-          } else {
-            await backgroundApiProxy.serviceHyperliquid.updatePerpsConfigByServer();
-          }
-          return;
-        } catch (error) {
-          console.error(
-            `[useFetchPerpConfig] attempt ${i + 1} failed:`,
-            error,
-          );
-          if (i < PERPS_CONFIG_FETCH_MAX_RETRIES) {
-            await timerUtils.wait(PERPS_CONFIG_FETCH_RETRY_INTERVAL_MS);
-          }
+    void pRetry(
+      (attemptNumber) => {
+        if (attemptNumber === 1) {
+          return backgroundApiProxy.serviceHyperliquid.updatePerpsConfigByServerWithCache();
         }
-      }
-    };
-    void run();
-    return () => {
-      cancelled = true;
-    };
+        return backgroundApiProxy.serviceHyperliquid.updatePerpsConfigByServer();
+      },
+      {
+        retries: PERPS_CONFIG_FETCH_MAX_RETRIES,
+        minTimeout: PERPS_CONFIG_FETCH_RETRY_INTERVAL_MS,
+        maxTimeout: PERPS_CONFIG_FETCH_RETRY_INTERVAL_MS,
+      },
+    ).catch(noop);
   }, []);
 };
 

--- a/packages/kit/src/views/Perp/components/PerpContentFooter.tsx
+++ b/packages/kit/src/views/Perp/components/PerpContentFooter.tsx
@@ -30,7 +30,7 @@ export function PerpContentFooter() {
   const { gtSm } = useMedia();
   const intl = useIntl();
 
-  if (!platformEnv.isNative && !platformEnv.isWebDappMode && gtSm) {
+  if (!platformEnv.isNative && gtSm) {
     return (
       <Page.Footer>
         <XStack

--- a/packages/kit/src/views/Setting/pages/Tab/config.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/config.tsx
@@ -154,7 +154,12 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
   const [devSettings] = useDevSettingsPersistAtom();
   const { isPrimeAvailable } = usePrimeAvailable();
   const { isLoggedIn } = useOneKeyAuth();
-  const [{ perpConfigCommon }] = usePerpsCommonConfigPersistAtom();
+  const [{ perpConfigCommon, perpConfigLoaded }] =
+    usePerpsCommonConfigPersistAtom();
+  const isPerpConfigLoaded = perpConfigLoaded ?? false;
+  const perpDisabled = isPerpConfigLoaded
+    ? perpConfigCommon.disablePerp
+    : false;
   const [settings] = useSettingsPersistAtom();
 
   const { cloudBackupFeatureInfo, startBackup } = useCloudBackup();
@@ -414,7 +419,7 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
                 },
           ],
           [
-            !perpConfigCommon.disablePerp && !perpConfigCommon.usePerpWeb
+            !perpDisabled && !perpConfigCommon.usePerpWeb
               ? {
                   icon: 'BrowserOutline',
                   title: intl.formatMessage({
@@ -825,7 +830,7 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
       cloudBackupFeatureInfo?.icon,
       cloudBackupFeatureInfo?.title,
       isPrimeAvailable,
-      perpConfigCommon.disablePerp,
+      perpDisabled,
       perpConfigCommon.usePerpWeb,
       isPasswordSet,
       biologyAuthIsSupport,

--- a/packages/shared/src/consts/perp.ts
+++ b/packages/shared/src/consts/perp.ts
@@ -82,3 +82,7 @@ export const PERPS_FILTERED_LEDGER_TYPES = new Set<string>([
 
 // Disable wallet binding on perps page
 export const DISABLE_PERPS_WALLET_BIND = false;
+
+// Perps config fetch retry
+export const PERPS_CONFIG_FETCH_MAX_RETRIES = 3;
+export const PERPS_CONFIG_FETCH_RETRY_INTERVAL_MS = 3000;


### PR DESCRIPTION
## Summary
- Fix perps tab disappearing after app reset by adding `perpConfigLoaded` flag to distinguish "not yet loaded" from "server disabled"
- Fix perps footer ticker not showing in web dApp mode by removing the `isWebDappMode` guard

## Intent & Context
Two perps UI issues:
1. **OK-50691**: After app reset, persisted atom defaults to `disablePerp: true` and config fetch was delayed behind `useRunAfterTokensDone` (up to 15s). The tab would be hidden until the server responded.
2. **OK-50823**: The perps footer (network status, refresh button, ticker bar, Telegram link) was explicitly excluded from web dApp mode via `!platformEnv.isWebDappMode` check, but this is no longer desired since the footer ticker feature was added.

## Root Cause
1. **OK-50691**: No distinction between "config not yet loaded" and "server explicitly disabled perps". The atom default `disablePerp: true` was treated the same as a server response. Additionally, `updatePerpConfig` could overwrite valid atom values with `undefined` when the server omitted fields.
2. **OK-50823**: `PerpContentFooter.tsx` had `!platformEnv.isWebDappMode` in the render condition, preventing the entire footer from rendering.

## Design Decisions
- **Tri-state logic**: `perpConfigLoaded` flag added to the persisted atom. When `false` (not loaded / after reset), `disablePerp` is treated as `false` (show tab). Only when `perpConfigLoaded: true` AND `disablePerp: true` does the tab hide.
- **`=== true` checks**: `updatePerpConfig` now uses explicit `=== true` comparisons so `undefined`/absent fields default to `false` instead of being passed through as `undefined`.
- **Immediate fetch with retry**: Config fetch moved from `useRunAfterTokensDone` to a direct `useEffect` with 3 retries at 3s intervals since the API has no dependency on auth tokens.
- **`commonConfig ?? {}`**: Server path normalizes absent `commonConfig` to empty object so the `=== true` path runs (all fields evaluate to `false`) rather than the preserve-old-value path.

## Changes Detail
| File | Change |
|------|--------|
| `packages/kit-bg/src/states/jotai/atoms/perps.ts` | Add `perpConfigLoaded` to interface & initial value |
| `packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts` | `options.fromServerConfig` param; `=== true` merge logic; `commonConfig ?? {}` normalization |
| `packages/kit/src/hooks/usePerpTabConfig.ts` | Gate `disablePerp` behind `perpConfigLoaded` |
| `packages/kit/src/views/Setting/pages/Tab/config.tsx` | Add `perpDisabled` local variable with tri-state logic |
| `packages/kit/src/provider/Bootstrap.tsx` | Immediate fetch with retry (3 retries, 3s interval) |
| `packages/shared/src/consts/perp.ts` | Add retry constants |
| `packages/kit/src/views/Perp/components/PerpContentFooter.tsx` | Remove `!isWebDappMode` guard |

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Web / Extension / Desktop / Mobile
- **Risk Areas**: Perps tab visibility logic change — could briefly show the tab to users in regions where perps is disabled (until the server config loads and hides it)

## Test plan
- [ ] Reset app → perps tab visible immediately, no delay
- [ ] After config loads, tab stays visible (normal case)
- [ ] Kill switch: mock server `disablePerp: true` → tab hides after fetch
- [ ] Network failure: block `/utility/v1/perp-config` → tab stays visible, retries 3 times
- [ ] Missing `commonConfig` in server response → tab stays visible
- [ ] Settings "Perp interface" option visible after reset
- [ ] Web dApp mode: perps footer (ticker, network status, refresh, Telegram) visible
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
