### PR TITLE
fix: resolve collapsible tab context mismatch causing market watchlist crash

### DIFF
--- a/packages/components/src/composite/Tabs/TabsDraggableFlatList.tsx
+++ b/packages/components/src/composite/Tabs/TabsDraggableFlatList.tsx
@@ -10,7 +10,7 @@ import {
   useTabNameContext,
   useTabsContext,
   useUpdateScrollViewContentSize,
-} from 'react-native-collapsible-tab-view/lib/module/hooks';
+} from 'react-native-collapsible-tab-view';
 import DraggableFlatList from 'react-native-draggable-flatlist';
 
 import type { FlatList as RNFlatList } from 'react-native';

--- a/packages/components/src/composite/Tabs/collapsible-tab-view-hooks.d.ts
+++ b/packages/components/src/composite/Tabs/collapsible-tab-view-hooks.d.ts
@@ -1,3 +1,4 @@
-declare module 'react-native-collapsible-tab-view/lib/module/hooks' {
-  export * from 'react-native-collapsible-tab-view/lib/typescript/src/hooks';
-}
+// This file previously declared types for the deep import path
+// 'react-native-collapsible-tab-view/lib/module/hooks'.
+// Now we import directly from 'react-native-collapsible-tab-view',
+// so types are resolved via the package's "types" field.

--- a/patches/react-native-collapsible-tab-view+8.0.1.patch
+++ b/patches/react-native-collapsible-tab-view+8.0.1.patch
@@ -7,7 +7,7 @@ index 83c5549..aaeca52 100644
  };
  export { Container, Tab, Lazy, FlatList, ScrollView, SectionList, FlashList, MasonryFlashList, };
 -export { useCurrentTabScrollY, useHeaderMeasurements, useFocusedTab, useAnimatedTabIndex, useCollapsibleStyle, } from './hooks';
-+export { useCurrentTabScrollY, useHeaderMeasurements, useFocusedTab, useAnimatedTabIndex, useCollapsibleStyle, useTabNameContext } from './hooks';
++export { useCurrentTabScrollY, useHeaderMeasurements, useFocusedTab, useAnimatedTabIndex, useCollapsibleStyle, useTabNameContext, useTabsContext, useAfterMountEffect, useChainCallback, useScrollHandlerY, useSharedAnimatedRef, useUpdateScrollViewContentSize } from './hooks';
  export type { HeaderMeasurements } from './hooks';
  export { MaterialTabBar } from './MaterialTabBar/TabBar';
  export { MaterialTabItem } from './MaterialTabBar/TabItem';
@@ -978,11 +978,17 @@ diff --git a/node_modules/react-native-collapsible-tab-view/src/index.tsx b/node
 index 3d0be9d..94c928f 100644
 --- a/node_modules/react-native-collapsible-tab-view/src/index.tsx
 +++ b/node_modules/react-native-collapsible-tab-view/src/index.tsx
-@@ -58,6 +58,7 @@ export {
+@@ -58,6 +58,13 @@ export {
    useFocusedTab,
    useAnimatedTabIndex,
    useCollapsibleStyle,
 +  useTabNameContext,
++  useTabsContext,
++  useAfterMountEffect,
++  useChainCallback,
++  useScrollHandlerY,
++  useSharedAnimatedRef,
++  useUpdateScrollViewContentSize,
  } from './hooks'
  export type { HeaderMeasurements } from './hooks'
  


### PR DESCRIPTION
## Summary
- Fix `useTabNameContext must be inside a TabNameContext` crash on iOS market watchlist page
- Import collapsible tab hooks from package root instead of deep `lib/module/` subpath

## Intent & Context
The market watchlist page on iOS crashes with `useTabNameContext must be inside a TabNameContext` when rendering the draggable token list. The `TabsDraggableFlatList` component fails to find the collapsible tab context despite being correctly nested inside `Tabs.Container` and `Tabs.Tab`.

## Root Cause
The `react-native-collapsible-tab-view` package declares `"react-native": "src/index.tsx"` in its `package.json`. Metro bundler uses this field to resolve the package entry to `src/`, so all library components (`Container`, `Tab`, `Lazy`, etc.) load from `src/` and use `TabNameContext` from `src/Context.tsx`.

However, `TabsDraggableFlatList.tsx` imported hooks from the hardcoded deep path `react-native-collapsible-tab-view/lib/module/hooks`. This file internally imports `TabNameContext` from `lib/module/Context.js`, which creates its **own** `React.createContext()` — a **different** context object.

Result: the Provider uses context from `src/Context.tsx`, but the consumer uses context from `lib/module/Context.js`. React context lookup fails → `useContext()` returns `undefined` → hook throws.

## Design Decisions
- Export all needed internal hooks (`useAfterMountEffect`, `useChainCallback`, `useScrollHandlerY`, `useSharedAnimatedRef`, `useTabsContext`, `useUpdateScrollViewContentSize`) from the main package entry via the existing patch
- Change `TabsDraggableFlatList.tsx` import to use `react-native-collapsible-tab-view` (package root) instead of the deep `lib/module/hooks` subpath
- This ensures Metro resolves everything through `src/` via the `"react-native"` field, unifying the context instances

## Changes Detail
- `patches/react-native-collapsible-tab-view+8.0.1.patch`: Extended hook exports in `src/index.tsx` and `lib/typescript/src/index.d.ts`
- `packages/components/src/composite/Tabs/TabsDraggableFlatList.tsx`: Changed import from `lib/module/hooks` to package root
- `packages/components/src/composite/Tabs/collapsible-tab-view-hooks.d.ts`: Removed obsolete module declaration for old import path

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: iOS (Mobile) — where the crash was observed; potentially all native platforms
- **Risk Areas**: Only import path and re-exports changed; no behavioral change to the tab system itself

## Test plan
- [ ] Open the Market page on iOS
- [ ] Navigate to the Watchlist tab
- [ ] Verify the token list renders without crashing
- [ ] Long-press a token to verify drag reorder still works
- [ ] Switch between Watchlist/Spot/Perps tabs to verify tab context is maintained