### PR TITLE
fix(earn): show skeleton loading during Pendle quote fetching

### DIFF
--- a/packages/kit/src/views/Earn/pages/EarnProtocolDetails/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnProtocolDetails/index.tsx
@@ -302,7 +302,7 @@ function ChartSection({
   return (
     <YStack gap="$3">
       {/* High and Low values */}
-      {gtMd && high !== null && low !== null ? (
+      {gtMd && !isPendleProvider && high !== null && low !== null ? (
         <XStack gap="$4" pt="$6">
           <YStack>
             <SizableText size="$bodySm" color="$textSubdued">

--- a/packages/kit/src/views/Staking/components/ManagePageV2ReceiveInput.tsx
+++ b/packages/kit/src/views/Staking/components/ManagePageV2ReceiveInput.tsx
@@ -30,11 +30,13 @@ export function ManagePageV2ReceiveInput({
   config,
   fiatSymbol,
   payFiatValue,
+  loading,
 }: {
   receive?: IStakeTransactionConfirmation['receive'];
   config?: IManagePageV2ReceiveInputConfig;
   fiatSymbol?: string;
   payFiatValue?: string;
+  loading?: boolean;
 }) {
   const intl = useIntl();
 
@@ -122,6 +124,7 @@ export function ManagePageV2ReceiveInput({
       tokenSelectorTriggerProps={receiveTokenSelectorTriggerProps}
       inputProps={{
         placeholder: '0',
+        loading,
       }}
       balanceProps={
         config?.balance
@@ -134,6 +137,7 @@ export function ManagePageV2ReceiveInput({
         value: receiveFiatValue,
         currency: receiveFiatValue !== '0' ? fiatSymbol : undefined,
         moreComponent: priceImpactComponent,
+        loading,
       }}
       onSelectPercentageStage={() => {}}
     />

--- a/packages/kit/src/views/Staking/components/ProtocolDetails/PendlePtConvergenceChart/PendlePtConvergenceChart.native.tsx
+++ b/packages/kit/src/views/Staking/components/ProtocolDetails/PendlePtConvergenceChart/PendlePtConvergenceChart.native.tsx
@@ -1,9 +1,9 @@
-import { useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { View } from 'react-native';
 import WebView from 'react-native-webview';
 
-import { Stack, useTheme } from '@onekeyhq/components';
+import { Skeleton, Stack, useTheme } from '@onekeyhq/components';
 
 import {
   COLORS,
@@ -270,8 +270,30 @@ export function PendlePtConvergenceChart({
     ],
   );
 
+  const [webViewReady, setWebViewReady] = useState(false);
+  const prevHtmlRef = useRef(htmlContent);
+  useEffect(() => {
+    if (prevHtmlRef.current !== htmlContent) {
+      prevHtmlRef.current = htmlContent;
+      setWebViewReady(false);
+    }
+  }, [htmlContent]);
+  const handleLoadEnd = useCallback(() => setWebViewReady(true), []);
+
   return (
     <Stack width={NATIVE_SVG_WIDTH} maxWidth="100%" height={NATIVE_SVG_HEIGHT}>
+      {!webViewReady ? (
+        <Stack
+          position="absolute"
+          top={0}
+          left={0}
+          right={0}
+          bottom={0}
+          zIndex={1}
+        >
+          <Skeleton w="100%" h="100%" borderRadius="$2" />
+        </Stack>
+      ) : null}
       <View style={{ flex: 1 }}>
         <WebView
           source={{ html: htmlContent }}
@@ -288,6 +310,7 @@ export function PendlePtConvergenceChart({
           domStorageEnabled={false}
           mixedContentMode="never"
           onShouldStartLoadWithRequest={({ url }) => url === 'about:blank'}
+          onLoadEnd={handleLoadEnd}
         />
       </View>
     </Stack>

--- a/packages/kit/src/views/Staking/components/ProtocolDetails/PendleSharedComponents.tsx
+++ b/packages/kit/src/views/Staking/components/ProtocolDetails/PendleSharedComponents.tsx
@@ -5,7 +5,9 @@ import {
   Divider,
   Icon,
   Popover,
+  Skeleton,
   SizableText,
+  Stack,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -30,9 +32,13 @@ type IPendleRewardRowProps = {
     description: IEarnText;
     tooltip?: IEarnTooltip;
   };
+  loading?: boolean;
 };
 
-export const PendleRewardRow: FC<IPendleRewardRowProps> = ({ reward }) => {
+export const PendleRewardRow: FC<IPendleRewardRowProps> = ({
+  reward,
+  loading,
+}) => {
   const descriptionLines = reward.description.text
     .split('\n')
     .map((line) => line.trim())
@@ -62,25 +68,37 @@ export const PendleRewardRow: FC<IPendleRewardRowProps> = ({ reward }) => {
         <EarnTooltip title={reward.title.text} tooltip={reward.tooltip} />
       </XStack>
       <YStack gap="$0.5" alignItems="flex-end" flexShrink={1} maxWidth="65%">
-        <XStack gap="$1" alignItems="center" flexWrap="wrap">
-          <SizableText
-            size={reward.description.size || '$bodyMdMedium'}
-            color={reward.description.color ?? '$text'}
-            textAlign="right"
-          >
-            {primaryMainText}
-          </SizableText>
-          {primarySuffixText ? (
-            <SizableText size="$bodyMd" color="$textSubdued">
-              {primarySuffixText}
-            </SizableText>
-          ) : null}
-        </XStack>
-        {secondaryDescriptionText ? (
-          <SizableText size="$bodySm" color="$textSubdued" textAlign="right">
-            {secondaryDescriptionText}
-          </SizableText>
-        ) : null}
+        {loading ? (
+          <Stack py="$0.5">
+            <Skeleton h="$3.5" w="$16" />
+          </Stack>
+        ) : (
+          <>
+            <XStack gap="$1" alignItems="center" flexWrap="wrap">
+              <SizableText
+                size={reward.description.size || '$bodyMdMedium'}
+                color={reward.description.color ?? '$text'}
+                textAlign="right"
+              >
+                {primaryMainText}
+              </SizableText>
+              {primarySuffixText ? (
+                <SizableText size="$bodyMd" color="$textSubdued">
+                  {primarySuffixText}
+                </SizableText>
+              ) : null}
+            </XStack>
+            {secondaryDescriptionText ? (
+              <SizableText
+                size="$bodySm"
+                color="$textSubdued"
+                textAlign="right"
+              >
+                {secondaryDescriptionText}
+              </SizableText>
+            ) : null}
+          </>
+        )}
       </YStack>
     </XStack>
   );
@@ -95,16 +113,40 @@ type IPendleSummarySectionProps = {
     tooltip?: IEarnTooltip;
   }>;
   tipText?: IEarnText;
+  loading?: boolean;
 };
+
+const SKELETON_PLACEHOLDER_COUNT = 3;
 
 export const PendleSummarySection: FC<IPendleSummarySectionProps> = ({
   rewardRows,
   tipText,
+  loading,
 }) => (
   <YStack gap="$3.5">
-    {rewardRows.map((reward, index) => (
-      <PendleRewardRow key={`${reward.title.text}-${index}`} reward={reward} />
-    ))}
+    {rewardRows.length > 0
+      ? rewardRows.map((reward, index) => (
+          <PendleRewardRow
+            key={`${reward.title.text}-${index}`}
+            reward={reward}
+            loading={loading}
+          />
+        ))
+      : loading
+        ? Array.from({ length: SKELETON_PLACEHOLDER_COUNT }).map((_, index) => (
+            <XStack
+              key={`skeleton-row-${index}`}
+              gap="$3"
+              alignItems="center"
+              justifyContent="space-between"
+            >
+              <Skeleton h="$3.5" w="$20" />
+              <Stack py="$0.5">
+                <Skeleton h="$3.5" w="$16" />
+              </Stack>
+            </XStack>
+          ))
+        : null}
     {tipText ? (
       <EarnText
         text={tipText}
@@ -149,10 +191,12 @@ export function usePendleTransactionDetails({
   transactionConfirmation,
   amountValue,
   isPendleLikeLayout,
+  loading,
 }: {
   transactionConfirmation?: IStakeTransactionConfirmation;
   amountValue: string;
   isPendleLikeLayout: boolean;
+  loading?: boolean;
 }): ReactElement[] {
   return useMemo(() => {
     const items: ReactElement[] = [];
@@ -213,6 +257,13 @@ export function usePendleTransactionDetails({
             </CalculationListItem.Label>
           )}
           {(() => {
+            if (loading) {
+              return (
+                <Stack py="$0.5">
+                  <Skeleton h="$3.5" w="$16" />
+                </Stack>
+              );
+            }
             if (popupButton) {
               return (
                 <Popover
@@ -287,5 +338,5 @@ export function usePendleTransactionDetails({
     }
 
     return items;
-  }, [amountValue, isPendleLikeLayout, transactionConfirmation]);
+  }, [amountValue, isPendleLikeLayout, loading, transactionConfirmation]);
 }

--- a/packages/kit/src/views/Staking/components/UniversalStake/index.tsx
+++ b/packages/kit/src/views/Staking/components/UniversalStake/index.tsx
@@ -370,8 +370,12 @@ export function UniversalStake({
     ],
   );
 
+  const [transactionConfirmationLoading, setTransactionConfirmationLoading] =
+    useState(false);
+
   const debouncedFetchTransactionConfirmation = useDebouncedCallback(
     async (amount?: string) => {
+      setTransactionConfirmationLoading(true);
       try {
         const resp = await fetchTransactionConfirmation(amount || '0');
         setTransactionConfirmation(resp);
@@ -380,6 +384,8 @@ export function UniversalStake({
         }
       } catch {
         // keep stale state
+      } finally {
+        setTransactionConfirmationLoading(false);
       }
     },
     350,
@@ -548,6 +554,8 @@ export function UniversalStake({
     ICheckAmountAlert[]
   >([]);
   const [checkAmountLoading, setCheckAmountLoading] = useState(false);
+
+  const quoteLoading = checkAmountLoading || transactionConfirmationLoading;
 
   const checkAmount = useDebouncedCallback(
     async ({ amount, identity }: { amount: string; identity?: string }) => {
@@ -1184,6 +1192,7 @@ export function UniversalStake({
     receiveInputConfig,
     networkLogoURI: network?.logoURI,
     isQuoteExpired,
+    loading: quoteLoading,
   });
 
   // During approve/submit flow, don't show expired refresh — the transaction is in progress.
@@ -1363,6 +1372,7 @@ export function UniversalStake({
         <PendleSummarySection
           rewardRows={pendleRewardRows}
           tipText={pendleTipText}
+          loading={quoteLoading}
         />
       );
     }
@@ -1457,6 +1467,7 @@ export function UniversalStake({
     pendleRewardRows,
     pendleTipText,
     transactionConfirmation,
+    quoteLoading,
   ]);
 
   return (
@@ -1504,6 +1515,7 @@ export function UniversalStake({
             config={effectiveReceiveInputConfig}
             fiatSymbol={symbol}
             payFiatValue={currentValue}
+            loading={quoteLoading}
           />
         </YStack>
         {showReceiveInput ? (
@@ -1692,14 +1704,16 @@ export function UniversalStake({
                 </Accordion.Item>
               </Accordion>
             ) : null}
-            <TradeOrBuy
-              token={tokenInfo?.token as IToken}
-              accountId={accountId}
-              networkId={networkId}
-              containerStyle={{
-                pt: '$0',
-              }}
-            />
+            {isPendleProvider ? null : (
+              <TradeOrBuy
+                token={tokenInfo?.token as IToken}
+                accountId={accountId}
+                networkId={networkId}
+                containerStyle={{
+                  pt: '$0',
+                }}
+              />
+            )}
           </YStack>
         </YStack>
       ) : null}

--- a/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
+++ b/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
@@ -690,6 +690,11 @@ export function UniversalWithdraw({
   ]);
 
   const [checkAmountLoading, setCheckAmountLoading] = useState(false);
+  const [transactionConfirmationLoading, setTransactionConfirmationLoading] =
+    useState(false);
+
+  const quoteLoading = checkAmountLoading || transactionConfirmationLoading;
+
   const checkAmount = useDebouncedCallback(async (amount: string) => {
     if (isInvalidAmount(amount)) {
       return;
@@ -768,6 +773,7 @@ export function UniversalWithdraw({
 
   const debouncedFetchTransactionConfirmation = useDebouncedCallback(
     async (amount?: string) => {
+      setTransactionConfirmationLoading(true);
       try {
         const resp = await fetchTransactionConfirmation(amount || '0');
         setTransactionConfirmation(resp);
@@ -776,6 +782,8 @@ export function UniversalWithdraw({
         }
       } catch {
         // keep stale state
+      } finally {
+        setTransactionConfirmationLoading(false);
       }
     },
     350,
@@ -921,6 +929,7 @@ export function UniversalWithdraw({
     receiveInputConfig,
     networkLogoURI: network?.logoURI,
     isQuoteExpired,
+    loading: quoteLoading,
   });
 
   // During approve/submit flow, don't show expired refresh — the transaction is in progress.
@@ -1092,6 +1101,7 @@ export function UniversalWithdraw({
             config={effectiveReceiveInputConfig}
             fiatSymbol={symbol}
             payFiatValue={currentValue}
+            loading={quoteLoading}
           />
         </YStack>
         {showReceiveInput ? (
@@ -1258,6 +1268,7 @@ export function UniversalWithdraw({
             <PendleSummarySection
               rewardRows={pendleRewardRows}
               tipText={pendleTipText}
+              loading={quoteLoading}
             />
           ) : null}
           {hasSummarySection && !usePendleSummaryLayout ? (

--- a/packages/kit/src/views/Staking/hooks/usePendleLayoutState.ts
+++ b/packages/kit/src/views/Staking/hooks/usePendleLayoutState.ts
@@ -19,6 +19,7 @@ type IUsePendleLayoutStateParams = {
   receiveInputConfig: IManagePageV2ReceiveInputConfig | undefined;
   networkLogoURI: string | undefined;
   isQuoteExpired: boolean | undefined;
+  loading?: boolean;
 };
 
 export function usePendleLayoutState({
@@ -29,6 +30,7 @@ export function usePendleLayoutState({
   receiveInputConfig,
   networkLogoURI,
   isQuoteExpired,
+  loading,
 }: IUsePendleLayoutStateParams) {
   const isPendleProvider = useIsPendleProvider(providerName);
   const isPendleLikeLayout = isPendleProvider;
@@ -52,6 +54,7 @@ export function usePendleLayoutState({
     transactionConfirmation,
     amountValue,
     isPendleLikeLayout,
+    loading,
   });
 
   const pendleRewardRows = useMemo(
@@ -66,7 +69,8 @@ export function usePendleLayoutState({
     [isPendleLikeLayout, transactionConfirmation?.rewards],
   );
 
-  const usePendleSummaryLayout = pendleRewardRows.length > 0;
+  const isPendleLoading = isPendleLikeLayout && !!loading;
+  const usePendleSummaryLayout = pendleRewardRows.length > 0 || isPendleLoading;
 
   const transactionDetailsTriggerText =
     transactionConfirmation?.transactionDetails?.text;
@@ -77,10 +81,7 @@ export function usePendleLayoutState({
     !!transactionConfirmation?.tooltip ||
     (transactionConfirmation?.rewards?.length ?? 0) > 0;
   const hasSummarySection =
-    showApyHeader ||
-    (usePendleSummaryLayout
-      ? pendleRewardRows.length > 0
-      : hasLegacySummaryContent);
+    showApyHeader || usePendleSummaryLayout || hasLegacySummaryContent;
 
   const pendleTipText =
     isPendleLikeLayout && normalizedPendleTipText


### PR DESCRIPTION
## Summary
- Show skeleton loading for output amount, summary rewards, and transaction details while Pendle quote is being fetched (prevents "0" flash)
- Show placeholder skeleton rows on initial load before data arrives
- Add WebView loading skeleton for PendlePtConvergenceChart on native
- Hide TradeOrBuy section and High/Low APY for Pendle providers

## Changes
- `ManagePageV2ReceiveInput` — added `loading` prop for input/value skeletons
- `PendleSharedComponents` — skeleton support in `PendleRewardRow`, `PendleSummarySection` (3 placeholder rows), and `usePendleTransactionDetails`
- `UniversalStake` / `UniversalWithdraw` — track `transactionConfirmationLoading` separately, combine as `quoteLoading` to bridge debounce timing gap
- `usePendleLayoutState` — `isPendleLoading` ensures summary section mounts during loading
- `PendlePtConvergenceChart.native` — skeleton overlay until WebView `onLoadEnd`
- `UniversalStake` — hide `TradeOrBuy` for Pendle
- `EarnProtocolDetails` — hide High/Low APY for Pendle

## Test plan
- [x] Open Pendle buy/sell/redeem page, verify skeleton shows while quote loads (no "0" flash)
- [x] First load with empty data shows 3 skeleton placeholder rows in summary
- [x] Pendle asset detail page chart shows skeleton while WebView loads (native)
- [x] TradeOrBuy section hidden on Pendle stake page
- [x] High/Low APY hidden on Pendle detail page (desktop)
- [x] Non-Pendle providers unaffected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
