### PR TITLE
fix: universal search token symbol display (OK-50835)

### DIFF
--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchMarketTokenItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchMarketTokenItem.tsx
@@ -7,6 +7,7 @@ import { useMarketWatchListAtom } from '@onekeyhq/kit/src/states/jotai/contexts/
 import { useUniversalSearchActions } from '@onekeyhq/kit/src/states/jotai/contexts/universalSearch';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EUniversalSearchPages } from '@onekeyhq/shared/src/routes/universalSearch';
+import { formatTokenSymbolForDisplay } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type { IUniversalSearchMarketToken } from '@onekeyhq/shared/types/search';
 import { ESearchStatus } from '@onekeyhq/shared/types/search';
 
@@ -69,7 +70,7 @@ export function UniversalSearchMarketTokenItem({
       jc="space-between"
       onPress={handlePress}
       renderAvatar={<MarketTokenIcon uri={image} size="lg" />}
-      title={symbol.toUpperCase()}
+      title={formatTokenSymbolForDisplay(symbol)}
       subtitle={name}
       subtitleProps={{
         numberOfLines: 1,

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
@@ -30,6 +30,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EUniversalSearchPages } from '@onekeyhq/shared/src/routes/universalSearch';
 import { listItemPressStyle } from '@onekeyhq/shared/src/style';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import { formatTokenSymbolForDisplay } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type { IUniversalSearchV2MarketToken } from '@onekeyhq/shared/types/search';
 
 import { MarketStarV2 } from '../../../Market/components/MarketStarV2';
@@ -276,7 +277,7 @@ export function UniversalSearchV2MarketTokenItem({
                 numberOfLines={1}
                 flexShrink={1}
               >
-                {symbol}
+                {formatTokenSymbolForDisplay(symbol)}
               </SizableText>
               {communityRecognized ? <CommunityRecognizedBadge /> : null}
             </XStack>

--- a/packages/kit/src/views/UniversalSearch/pages/components/RecentSearched.tsx
+++ b/packages/kit/src/views/UniversalSearch/pages/components/RecentSearched.tsx
@@ -16,6 +16,7 @@ import {
 } from '@onekeyhq/kit/src/states/jotai/contexts/universalSearch';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import { formatTokenSymbolForDisplay } from '@onekeyhq/shared/src/utils/tokenUtils';
 import {
   EUniversalSearchType,
   type IIUniversalRecentSearchItem,
@@ -39,7 +40,8 @@ function SearchTextItem({
     let result: string;
     switch (searchType) {
       case EUniversalSearchType.MarketToken:
-        result = itemText.toUpperCase();
+      case EUniversalSearchType.V2MarketToken:
+        result = formatTokenSymbolForDisplay(itemText);
         break;
       case EUniversalSearchType.Address:
         result = accountUtils.shortenAddress({

--- a/packages/shared/src/utils/tokenUtils.ts
+++ b/packages/shared/src/utils/tokenUtils.ts
@@ -28,6 +28,19 @@ export const caseSensitiveNetworkImpl = [
   'ton',
 ];
 
+/**
+ * Display token symbol preserving API casing for mixed-case symbols (e.g. fAI, aPolWBTC)
+ * while converting short all-lowercase tickers to uppercase (e.g. btc -> BTC, eth -> ETH).
+ */
+export function formatTokenSymbolForDisplay(symbol: string): string {
+  if (!symbol || typeof symbol !== 'string') return symbol;
+  const trimmed = symbol.trim();
+  if (trimmed.length <= 5 && trimmed === trimmed.toLowerCase()) {
+    return trimmed.toUpperCase();
+  }
+  return trimmed;
+}
+
 export function getMergedTokenData({
   tokens,
   smallBalanceTokens,


### PR DESCRIPTION
## Summary
Fix token symbol display in universal search popular list to match API response.
https://onekeyhq.atlassian.net/browse/OK-50835

## Changes
- **formatTokenSymbolForDisplay**: preserve mixed-case symbols (e.g. fAI, aPolWBTC); uppercase short all-lowercase tickers (e.g. btc -> BTC)
- Apply to market token items and recent search list
- ServiceUniversalSearch: type-safe v2Items and consumer contract for V2MarketToken
- DappHeader: languageKey/currencyKey state and typed setters

Resolves OK-50835.

---
Opened from fork: https://github.com/0xchloe996/app-monorepo/pull/21

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
