### PR TITLE
fix(market): remove sort icon from non-sortable action column in pool tab

### DIFF
--- a/packages/kit/src/views/Market/components/MarketDetailPools.tsx
+++ b/packages/kit/src/views/Market/components/MarketDetailPools.tsx
@@ -256,14 +256,19 @@ export function MarketDetailPools({
   );
 
   const onHeaderRow = useCallback(
-    (column: ITableColumn<IDataSourceItem>) => ({
-      onSortTypeChange: (order: 'asc' | 'desc' | undefined) => {
-        handleSortTypeChange?.({
-          columnName: column.dataIndex,
-          order,
-        });
-      },
-    }),
+    (column: ITableColumn<IDataSourceItem>) => {
+      if (!column.title) {
+        return undefined;
+      }
+      return {
+        onSortTypeChange: (order: 'asc' | 'desc' | undefined) => {
+          handleSortTypeChange?.({
+            columnName: column.dataIndex,
+            order,
+          });
+        },
+      };
+    },
     [handleSortTypeChange],
   );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Remove the meaningless sort icon from the action column in the trading pool tab because it has no data to sort.

The `onHeaderRow` callback in `MarketDetailPools.tsx` unconditionally returned a sort handler for all columns, including the empty-titled action column. This caused a visual sort icon to appear, but clicking it had no effect on data sorting as the column lacked corresponding data. This fix prevents the sort icon from rendering on non-sortable columns.

---
[Slack Thread](https://onekeygroup.slack.com/archives/C022268A5EW/p1772597318418749?thread_ts=1772597318.418749&cid=C022268A5EW)

<p><a href="https://cursor.com/agents/bc-e30a5036-c50c-5225-a420-26ec84b49c54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e30a5036-c50c-5225-a420-26ec84b49c54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
