### PR TITLE
fix(onboarding): content clipping on PickYourDevice page in native large screen mode

### DIFF
--- a/packages/kit/src/views/Onboardingv2/pages/PickYourDevice.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/PickYourDevice.tsx
@@ -65,11 +65,14 @@ export default function PickYourDevice() {
             id: ETranslations.pick_your_device,
           })}
         />
-        <OnboardingLayout.Body scrollable={!gtMd} constrained={false}>
+        <OnboardingLayout.Body
+          scrollable={platformEnv.isNative || !gtMd}
+          constrained={false}
+        >
           <YStack
             gap="$5"
             $gtMd={{
-              height: '100%',
+              ...(!platformEnv.isNative && { height: '100%' }),
               flexDirection: 'row',
               flexWrap: 'wrap',
               alignContent: 'stretch',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes content clipping and non-scrollability on the "Pick Your Device" onboarding page for mobile apps in large screen mode.

On native platforms in large screen mode, `scrollable={!gtMd}` incorrectly disabled scrolling. Combined with `overflow: "hidden"` and a fixed `height: '100%'` on the content grid, this caused content to be clipped without a scroll mechanism. The fix ensures native platforms are always scrollable and removes the fixed height constraint for native.

---
[Slack Thread](https://onekeygroup.slack.com/archives/C022268A5EW/p1772596535714359?thread_ts=1772596535.714359&cid=C022268A5EW)

<p><a href="https://cursor.com/agents/bc-07d6ae6a-37a9-5a33-936b-faf14fe87787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07d6ae6a-37a9-5a33-936b-faf14fe87787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
