### PR TITLE
fix: Restore the standard Accordion animation pattern

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
@@ -410,8 +410,13 @@ const SwapQuoteResult = ({
               />
             )}
           </Accordion.Trigger>
-          <Accordion.HeightAnimator animation="quick" overflow="hidden">
-            <Accordion.Content gap="$4" p="$0">
+          <Accordion.HeightAnimator animation="quick">
+            <Accordion.Content
+              gap="$4"
+              p="$0"
+              animation="quick"
+              exitStyle={{ opacity: 0 }}
+            >
               <Divider mt="$4" />
               {swapProviderSupportReceiveAddress &&
               swapEnableRecipientAddress ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Restore the standard Accordion animation pattern in `SwapQuoteResult` to fix content clipping.

The `overflow="hidden"` on `Accordion.HeightAnimator` caused the last line of content to be clipped due to height measurement inaccuracies. This `overflow="hidden"` was originally added to prevent content overflow during collapse after `exitStyle={{ opacity: 0 }}` was removed from `Accordion.Content` to fix visual flickering. This PR reintroduces `exitStyle={{ opacity 0 }}` to `Accordion.Content`, which is the standard and correct way to handle content disappearance during collapse, making `overflow="hidden"` redundant and resolving the clipping bug.

---
[Slack Thread](https://onekeygroup.slack.com/archives/C026693UM62/p1772604710914679?thread_ts=1772604710.914679&cid=C026693UM62)

<p><a href="https://cursor.com/agents/bc-ede434cf-c1ed-572f-8756-7c0aa19a4376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ede434cf-c1ed-572f-8756-7c0aa19a4376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
