### PR TITLE
fix: order for invitation card

### DIFF
--- a/packages/kit/src/views/ReferFriends/pages/InviteReward/components/InvitationDetailsSection/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/InviteReward/components/InvitationDetailsSection/index.tsx
@@ -101,10 +101,10 @@ export function InvitationDetailsSection({
               nextDistribution={cumulativeRewards.nextDistribution}
             />
           }
-          secondColumn={
+          secondColumn={<OnChainReward onChain={Onchain} />}
+          thirdColumn={
             <PerpsReward perpsCumulativeRewards={perpsCumulativeRewards} />
           }
-          thirdColumn={<OnChainReward onChain={Onchain} />}
         />
       ) : (
         <YStack px="$pagePadding" gap="$4">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adjust the display order of reward cards (DeFi and Contracts) on the invitation details page to match the order of commission rates for the current tier.

---
[Slack Thread](https://onekeygroup.slack.com/archives/C01SZCKLJ0P/p1772614098451679?thread_ts=1772614098.451679&cid=C01SZCKLJ0P)

<p><a href="https://cursor.com/agents/bc-33c14066-8f6c-5cd8-a715-7f745495e48a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33c14066-8f6c-5cd8-a715-7f745495e48a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
