### PR TITLE
fix: enable page-level scroll and sticky tab header on market detail page

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/layout/DesktopInformationTabs.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/layout/DesktopInformationTabs.tsx
@@ -5,6 +5,7 @@ import { useIntl } from 'react-intl';
 import { Tabs, YStack } from '@onekeyhq/components';
 import { isHoldersTabSupported } from '@onekeyhq/shared/src/consts/marketConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   NUMBER_FORMATTER,
   formatDisplayNumber,
@@ -139,6 +140,7 @@ export function DesktopInformationTabs({
       key={tabsKey}
       renderTabBar={renderTabBar}
       onTabChange={handleTabChange}
+      disableScroll={!platformEnv.isNative}
     >
       {tabs}
     </Tabs.Container>

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/DesktopLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/DesktopLayout.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
+import type { RefObject } from 'react';
 
 import { Divider, Stack, XStack, YStack } from '@onekeyhq/components';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -23,6 +24,35 @@ const MARKET_DETAIL_LAYOUT = {
 } as const;
 
 const SCROLL_CONTAINER_STYLE = { overflowY: 'auto' } as const;
+const IFRAME_WHEEL_EVENT_TYPE = 'wheelEvent' as const;
+
+interface IIframeWheelEventMessage {
+  type: typeof IFRAME_WHEEL_EVENT_TYPE;
+  deltaY: number;
+}
+
+// Listen for wheel events forwarded from TradingView iframe via postMessage.
+// TradingView side needs: window.parent.postMessage({ type: 'wheelEvent', deltaY }, '*')
+function useIframeWheelPassthrough(scrollRef: RefObject<HTMLElement | null>) {
+  useEffect(() => {
+    if (!platformEnv.isWeb) {
+      return;
+    }
+    const handleMessage = (e: MessageEvent) => {
+      const data = e.data as IIframeWheelEventMessage | undefined;
+      if (
+        data?.type === IFRAME_WHEEL_EVENT_TYPE &&
+        typeof data.deltaY === 'number'
+      ) {
+        scrollRef.current?.scrollBy({ top: data.deltaY });
+      }
+    };
+    globalThis.addEventListener('message', handleMessage);
+    return () => {
+      globalThis.removeEventListener('message', handleMessage);
+    };
+  }, [scrollRef]);
+}
 
 export function DesktopLayout() {
   const { tokenAddress, networkId, tokenDetail, isNative, websocketConfig } =
@@ -58,8 +88,15 @@ export function DesktopLayout() {
     ],
   );
 
+  const scrollContainerRef = useRef<HTMLElement>(null);
+  useIframeWheelPassthrough(scrollContainerRef);
+
   return (
-    <Stack flex={1} style={SCROLL_CONTAINER_STYLE}>
+    <Stack
+      ref={scrollContainerRef as any}
+      flex={1}
+      style={SCROLL_CONTAINER_STYLE}
+    >
       <XStack>
         {/* Left column */}
         <YStack
@@ -82,7 +119,7 @@ export function DesktopLayout() {
           </Stack>
 
           <Stack
-            h={MARKET_DETAIL_LAYOUT.infoTabsHeight}
+            minHeight={MARKET_DETAIL_LAYOUT.infoTabsHeight}
             borderTopWidth="$px"
             borderTopColor="$borderSubdued"
           >

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/DesktopLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/DesktopLayout.tsx
@@ -2,6 +2,10 @@ import { useEffect, useMemo, useRef } from 'react';
 import type { RefObject } from 'react';
 
 import { Divider, Stack, XStack, YStack } from '@onekeyhq/components';
+import {
+  TRADING_VIEW_URL,
+  TRADING_VIEW_URL_TEST,
+} from '@onekeyhq/shared/src/config/appConfig';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 
@@ -31,14 +35,22 @@ interface IIframeWheelEventMessage {
   deltaY: number;
 }
 
+const ALLOWED_TRADING_VIEW_ORIGINS = new Set([
+  new URL(TRADING_VIEW_URL).origin,
+  new URL(TRADING_VIEW_URL_TEST).origin,
+]);
+
 // Listen for wheel events forwarded from TradingView iframe via postMessage.
 // TradingView side needs: window.parent.postMessage({ type: 'wheelEvent', deltaY }, '*')
 function useIframeWheelPassthrough(scrollRef: RefObject<HTMLElement | null>) {
   useEffect(() => {
-    if (!platformEnv.isWeb) {
+    if (platformEnv.isNative) {
       return;
     }
     const handleMessage = (e: MessageEvent) => {
+      if (!ALLOWED_TRADING_VIEW_ORIGINS.has(e.origin)) {
+        return;
+      }
       const data = e.data as IIframeWheelEventMessage | undefined;
       if (
         data?.type === IFRAME_WHEEL_EVENT_TYPE &&

--- a/packages/kit/src/views/UniversalSearch/pages/UniversalSearch.tsx
+++ b/packages/kit/src/views/UniversalSearch/pages/UniversalSearch.tsx
@@ -103,6 +103,15 @@ const getTabIndexForSearchType = (searchType: EUniversalSearchType): number => {
   return tabMapping[searchType];
 };
 
+const DEFAULT_SLICE_LIMIT = 5;
+const MARKET_SLICE_LIMIT = 3;
+const MARKET_TAB_INDEX = getTabIndexForSearchType(
+  EUniversalSearchType.V2MarketToken,
+);
+const PRIORITIZED_SECONDARY_TAB_INDEX = getTabIndexForSearchType(
+  EUniversalSearchType.Perp,
+);
+
 const SkeletonItem = () => (
   <XStack py="$2" alignItems="center">
     <Skeleton w="$10" h="$10" radius="round" />
@@ -131,7 +140,7 @@ function ListEmptyComponent() {
   );
 }
 
-const isMarketSection = (tabIndex: number) => tabIndex === 2;
+const isMarketSection = (tabIndex: number) => tabIndex === MARKET_TAB_INDEX;
 
 export function UniversalSearch({
   filterTypes,
@@ -336,8 +345,8 @@ export function UniversalSearch({
       const generateDataFn = (data: IUniversalSearchResultItem[]) => {
         return {
           data,
-          sliceData: data.slice(0, 5),
-          showMore: data.length > 5,
+          sliceData: data.slice(0, DEFAULT_SLICE_LIMIT),
+          showMore: data.length > DEFAULT_SLICE_LIMIT,
         };
       };
 
@@ -360,14 +369,15 @@ export function UniversalSearch({
           (_, index) => index !== googleSearchIndex,
         );
 
-        // Take first 5 non-Google results + always include Google search item
-        const slicedOtherResults = otherResults.slice(0, 5);
+        // Take first N non-Google results + always include Google search item
+        const slicedOtherResults = otherResults.slice(0, DEFAULT_SLICE_LIMIT);
         const sliceData = [...slicedOtherResults, googleSearchItem];
 
         return {
           data,
           sliceData,
-          showMore: otherResults.length > 5, // Only count non-Google items for showMore
+          // Only count non-Google items for showMore
+          showMore: otherResults.length > DEFAULT_SLICE_LIMIT,
         };
       };
 
@@ -395,7 +405,9 @@ export function UniversalSearch({
           title: intl.formatMessage({
             id: ETranslations.global_market,
           }),
-          ...generateDataFn(data),
+          data,
+          sliceData: data.slice(0, MARKET_SLICE_LIMIT),
+          showMore: data.length > MARKET_SLICE_LIMIT,
         });
       }
 
@@ -512,7 +524,6 @@ export function UniversalSearch({
               {section.title}
             </SizableText>
           </XStack>
-          {isMarketSection(section.tabIndex) ? <MarketTableHeader /> : null}
         </YStack>
       );
     },
@@ -552,7 +563,15 @@ export function UniversalSearch({
   );
 
   const renderItem = useCallback(
-    ({ item }: { item: IUniversalSearchResultItem }) => {
+    ({
+      item,
+      section,
+      index,
+    }: {
+      item: IUniversalSearchResultItem;
+      section: IUniversalSection;
+      index: number;
+    }) => {
       switch (item.type) {
         case EUniversalSearchType.Address:
           return (
@@ -570,10 +589,15 @@ export function UniversalSearch({
           );
         case EUniversalSearchType.V2MarketToken:
           return (
-            <UniversalSearchV2MarketTokenItem
-              item={item}
-              isTrending={searchStatus === ESearchStatus.init}
-            />
+            <>
+              {index === 0 && isMarketSection(section.tabIndex) ? (
+                <MarketTableHeader />
+              ) : null}
+              <UniversalSearchV2MarketTokenItem
+                item={item}
+                isTrending={searchStatus === ESearchStatus.init}
+              />
+            </>
           );
         case EUniversalSearchType.AccountAssets:
           return (
@@ -642,17 +666,23 @@ export function UniversalSearch({
       // When focused in Market tab, prioritize market section
       if (isFocusInMarketTab) {
         const marketSection = sectionsWithSliceData.find(
-          (section) => section.tabIndex === 2, // market tab index
+          (section) => section.tabIndex === MARKET_TAB_INDEX,
         );
-        const tokenSection = sectionsWithSliceData.find(
-          (section) => section.tabIndex === 3,
+        const prioritizedSecondarySection = sectionsWithSliceData.find(
+          (section) => section.tabIndex === PRIORITIZED_SECONDARY_TAB_INDEX,
         );
         const otherSections = sectionsWithSliceData.filter(
-          (section) => section.tabIndex !== 2 && section.tabIndex !== 3,
+          (section) =>
+            section.tabIndex !== MARKET_TAB_INDEX &&
+            section.tabIndex !== PRIORITIZED_SECONDARY_TAB_INDEX,
         );
 
         return marketSection
-          ? [marketSection, tokenSection, ...otherSections].filter(Boolean)
+          ? [
+              marketSection,
+              prioritizedSecondarySection,
+              ...otherSections,
+            ].filter(Boolean)
           : sectionsWithSliceData;
       }
 


### PR DESCRIPTION
https://onekeyhq.atlassian.net/browse/OK-50956
https://onekeyhq.atlassian.net/browse/OK-50837
https://onekeyhq.atlassian.net/browse/OK-50744

## Summary
- Disable Tabs internal scroll on web (`disableScroll={!platformEnv.isNative}`), matching Perps pattern, so the entire page scrolls together
- Change info tabs container from fixed `h={480}` to `minHeight={480}` for natural content flow
- Tab header (交易数/我的仓位/持币地址) now sticks to the top via CSS `position: sticky` relative to the page scroll container
- Add `useIframeWheelPassthrough` hook to receive wheel events from TradingView iframe via `postMessage` (requires TradingView side update to send events)

## Test plan
- [ ] Verify page-level scroll works on market detail page (web/desktop)
- [ ] Verify tab header (交易数/我的仓位/持币地址) sticks to top when scrolling
- [ ] Verify tab switching still works correctly
- [ ] Verify TradingView chart interactions (time selector, zoom, pan) are unaffected
- [ ] Verify mobile layout is unaffected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
