### PR TITLE
fix(perps): resolve duplicate footer in dApp mode and stabilize ticker price width OK-50932

### DIFF
--- a/packages/kit/src/components/Footer/Footer.tsx
+++ b/packages/kit/src/components/Footer/Footer.tsx
@@ -15,6 +15,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ERootRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 
+import { PerpFooterTicker } from '../../views/Perp/components/FooterTicker/PerpFooterTicker';
 import { PerpsProviderMirror } from '../../views/Perp/PerpsProviderMirror';
 import { NetworkStatus } from '../NetworkStatus';
 import { PerpRefreshButton } from '../PerpRefreshButton';
@@ -60,6 +61,62 @@ const getLinks = () => [
   },
 ];
 
+export function PerpFooterActions() {
+  const intl = useIntl();
+  const links = useMemo(() => getLinks(), []);
+
+  const menuTrigger = useMemo(
+    () => (
+      <Icon
+        name="DotHorOutline"
+        size="$5"
+        color="$iconSubdued"
+        cursor="pointer"
+        hoverStyle={{ color: '$icon' }}
+      />
+    ),
+    [],
+  );
+
+  return (
+    <>
+      <XStack
+        alignItems="center"
+        gap="$1"
+        cursor="pointer"
+        flexShrink={0}
+        hoverStyle={{ opacity: 0.6 }}
+        onPress={() => openUrlExternal(PERP_TELEGRAM_URL)}
+      >
+        <Icon name="TelegramBrand" size="$4" color="$iconSubdued" />
+        <SizableText size="$bodyMd" color="$textSubdued">
+          {intl.formatMessage({
+            id: ETranslations.perps_footer_help_us_better,
+          })}
+        </SizableText>
+      </XStack>
+      <ActionList
+        title={intl.formatMessage({ id: ETranslations.global_more })}
+        renderTrigger={menuTrigger}
+        sections={[
+          {
+            items: links.map((item) => ({
+              label: intl.formatMessage({ id: item.translationKey }),
+              onPress: () => {
+                if (item.onPress) {
+                  item.onPress();
+                } else if (item.href) {
+                  openUrlExternal(item.href);
+                }
+              },
+            })),
+          },
+        ]}
+      />
+    </>
+  );
+}
+
 export function Footer() {
   const intl = useIntl();
   const [currentTab, setCurrentTab] = useState<ETabRoutes | null>(null);
@@ -93,21 +150,6 @@ export function Footer() {
     [intl, links],
   );
 
-  const perpMenuTrigger = useMemo(
-    () => (
-      <Icon
-        name="DotHorOutline"
-        size="$5"
-        color="$iconSubdued"
-        cursor="pointer"
-        hoverStyle={{
-          color: '$icon',
-        }}
-      />
-    ),
-    [],
-  );
-
   if (currentTab === ETabRoutes.WebviewPerpTrade) {
     return null;
   }
@@ -126,7 +168,7 @@ export function Footer() {
       alignItems="center"
       justifyContent="space-between"
     >
-      <XStack gap="$2" alignItems="center">
+      <XStack gap="$2" alignItems="center" flexShrink={0}>
         <NetworkStatus />
         {isInPerpRoute ? (
           <PerpsProviderMirror>
@@ -135,42 +177,15 @@ export function Footer() {
         ) : null}
       </XStack>
 
-      <XStack gap="$3" alignItems="center">
+      {isInPerpRoute ? (
+        <PerpsProviderMirror>
+          <PerpFooterTicker />
+        </PerpsProviderMirror>
+      ) : null}
+
+      <XStack gap="$3" alignItems="center" flexShrink={0}>
         {isInPerpRoute ? (
-          <>
-            <XStack
-              alignItems="center"
-              gap="$1"
-              cursor="pointer"
-              hoverStyle={{ opacity: 0.6 }}
-              onPress={() => openUrlExternal(PERP_TELEGRAM_URL)}
-            >
-              <Icon name="TelegramBrand" size="$4" color="$iconSubdued" />
-              <SizableText size="$bodyMd" color="$textSubdued">
-                {intl.formatMessage({
-                  id: ETranslations.perps_footer_help_us_better,
-                })}
-              </SizableText>
-            </XStack>
-            <ActionList
-              title={intl.formatMessage({ id: ETranslations.global_more })}
-              renderTrigger={perpMenuTrigger}
-              sections={[
-                {
-                  items: links.map((item) => ({
-                    label: intl.formatMessage({ id: item.translationKey }),
-                    onPress: () => {
-                      if (item.onPress) {
-                        item.onPress();
-                      } else if (item.href) {
-                        openUrlExternal(item.href);
-                      }
-                    },
-                  })),
-                },
-              ]}
-            />
-          </>
+          <PerpFooterActions />
         ) : (
           <FooterNavigation>{linkItems}</FooterNavigation>
         )}

--- a/packages/kit/src/components/Footer/index.ts
+++ b/packages/kit/src/components/Footer/index.ts
@@ -1,1 +1,1 @@
-export { Footer } from './Footer';
+export { Footer, PerpFooterActions } from './Footer';

--- a/packages/kit/src/views/Perp/components/FavoritesBar/FavoriteTokenItem.tsx
+++ b/packages/kit/src/views/Perp/components/FavoritesBar/FavoriteTokenItem.tsx
@@ -13,14 +13,55 @@ import {
   usePerpsActiveAssetAtom,
   usePerpsActiveAssetCtxAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import perpsUtils, {
   formatPriceToSignificantDigits,
   getHyperliquidTokenImageUrl,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
+import {
+  MAX_DECIMALS_PERP,
+  MAX_SIGNIFICANT_FIGURES,
+} from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 
 export const TABULAR_NUMS_STYLE = {
   fontVariantNumeric: 'tabular-nums',
 } as const;
+
+/**
+ * Calculate stable minWidth (in ch units) for formatted price strings to
+ * prevent layout jitter caused by trailing-zero stripping in
+ * formatPriceToSignificantDigits. With tabular-nums, 1ch equals one digit width.
+ */
+export function getStablePriceMinWidth(priceStr: string): string | undefined {
+  // ch units are CSS-only, not supported on React Native
+  if (platformEnv.isNative) return undefined;
+  if (!priceStr || priceStr === '-' || priceStr === '0') return undefined;
+
+  const dotIndex = priceStr.indexOf('.');
+  if (dotIndex === -1) return undefined;
+
+  const intPart = priceStr.substring(0, dotIndex);
+  const intDigits = intPart === '0' ? 0 : intPart.length;
+
+  if (intDigits >= MAX_SIGNIFICANT_FIGURES) return undefined;
+
+  let maxDecimals: number;
+  if (intDigits === 0) {
+    // Leading zeros don't count as significant figures
+    const decimalPart = priceStr.substring(dotIndex + 1);
+    const leadingZeroMatch = decimalPart.match(/^(0*)/);
+    const leadingZeros = leadingZeroMatch ? leadingZeroMatch[1].length : 0;
+    maxDecimals = Math.min(
+      leadingZeros + MAX_SIGNIFICANT_FIGURES,
+      MAX_DECIMALS_PERP,
+    );
+  } else {
+    maxDecimals = MAX_SIGNIFICANT_FIGURES - intDigits;
+  }
+
+  const totalChars = intPart.length + 1 + maxDecimals;
+  return `${totalChars}ch`;
+}
 
 interface IFavoriteTokenItemProps {
   displayName: string;
@@ -70,11 +111,14 @@ const CtxPriceDisplay = memo(
       );
     }
 
+    const priceMinWidth = getStablePriceMinWidth(priceDisplay);
     return (
       <SizableText
         size="$bodySmMedium"
         color={color}
         style={TABULAR_NUMS_STYLE}
+        minWidth={priceMinWidth}
+        textAlign="right"
       >
         {priceDisplay}
       </SizableText>
@@ -123,11 +167,14 @@ const ActiveAssetPriceDisplay = memo(
       );
     }
 
+    const priceMinWidth = getStablePriceMinWidth(priceDisplay);
     return (
       <SizableText
         size="$bodySmMedium"
         color={color}
         style={TABULAR_NUMS_STYLE}
+        minWidth={priceMinWidth}
+        textAlign="right"
       >
         {priceDisplay}
       </SizableText>
@@ -142,6 +189,7 @@ export const PriceChangeDisplay = memo(
     const color = change >= 0 ? '$textSuccess' : '$textCritical';
     const sign = change >= 0 ? '+' : '';
     const price = markPrice ? formatPriceToSignificantDigits(markPrice) : '-';
+    const priceMinWidth = getStablePriceMinWidth(price);
     return (
       <>
         <SizableText
@@ -155,6 +203,8 @@ export const PriceChangeDisplay = memo(
           size="$bodySmMedium"
           color="$textSubdued"
           style={TABULAR_NUMS_STYLE}
+          minWidth={priceMinWidth}
+          textAlign="right"
         >
           {price}
         </SizableText>

--- a/packages/kit/src/views/Perp/components/PerpContentFooter.tsx
+++ b/packages/kit/src/views/Perp/components/PerpContentFooter.tsx
@@ -1,24 +1,16 @@
 import { useMemo } from 'react';
 import { useIntl } from 'react-intl';
 
-import {
-  Icon,
-  Page,
-  SizableText,
-  XStack,
-  useMedia,
-} from '@onekeyhq/components';
+import { Page, XStack, useMedia } from '@onekeyhq/components';
 import { usePerpsNetworkStatusAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 
+import { PerpFooterActions } from '../../../components/Footer';
 import { NetworkStatusBadge } from '../../../components/NetworkStatusBadge';
 import { PerpRefreshButton } from '../../../components/PerpRefreshButton';
 
 import { PerpFooterTicker } from './FooterTicker/PerpFooterTicker';
-
-const PERP_TELEGRAM_URL = 'https://t.me/OneKeyPerps';
 
 function PerpNetworkStatus() {
   const [networkStatus] = usePerpsNetworkStatusAtom();
@@ -38,9 +30,8 @@ function PerpNetworkStatus() {
 
 export function PerpContentFooter() {
   const { gtSm } = useMedia();
-  const intl = useIntl();
 
-  if (!platformEnv.isNative && gtSm) {
+  if (!platformEnv.isNative && !platformEnv.isWebDappMode && gtSm) {
     return (
       <Page.Footer>
         <XStack
@@ -57,21 +48,7 @@ export function PerpContentFooter() {
             <PerpRefreshButton />
           </XStack>
           <PerpFooterTicker />
-          <XStack
-            alignItems="center"
-            gap="$1"
-            cursor="pointer"
-            flexShrink={0}
-            hoverStyle={{ opacity: 0.6 }}
-            onPress={() => openUrlExternal(PERP_TELEGRAM_URL)}
-          >
-            <Icon name="TelegramBrand" size="$4" color="$iconSubdued" />
-            <SizableText size="$bodyMd" color="$textSubdued">
-              {intl.formatMessage({
-                id: ETranslations.perps_footer_help_us_better,
-              })}
-            </SizableText>
-          </XStack>
+          <PerpFooterActions />
         </XStack>
       </Page.Footer>
     );


### PR DESCRIPTION
## Summary
- Fix duplicate footer bar rendering in web dApp mode on perp route
- Extract shared `PerpFooterActions` component to deduplicate Telegram link + MoreMenu across two footer components
- Add `getStablePriceMinWidth` utility to prevent price ticker layout jitter caused by trailing-zero stripping

## Intent & Context
PR #10453 removed the `!isWebDappMode` guard from `PerpContentFooter` to show the footer ticker in dApp mode, but this caused two footer bars to render simultaneously — the global `Footer` (from Navigator.tsx) and `PerpContentFooter` (from Page.Footer). Additionally, the footer ticker prices visually "jump" when `formatPriceToSignificantDigits` strips trailing zeros (e.g., `123.40` → `123.4`), changing the rendered width.

## Root Cause
**Duplicate footer**: Two independent footer components (`Footer.tsx` at Navigator level, `PerpContentFooter.tsx` at Page level) both rendered when the `!isWebDappMode` guard was removed. The global Footer already handles dApp mode; PerpContentFooter is only needed for desktop web.

**Ticker jitter**: `formatPriceToSignificantDigits` strips trailing zeros (line 588-591 of perpsUtils.ts), causing price text width to fluctuate despite `tabular-nums` being applied.

## Design Decisions
- **Two-footer architecture preserved**: Global Footer handles dApp mode (all tabs, with ticker on perp route). PerpContentFooter handles desktop web only (`!isNative && !isWebDappMode && gtSm`). This matches the pre-#10453 design.
- **Shared `PerpFooterActions`**: Extracted Telegram link + MoreMenu ActionList into a single component in `Footer.tsx`, eliminating ~60 lines of duplicated code from `PerpContentFooter.tsx`. Both footers now share the same link data via `getLinks()`.
- **`ch` units for stable width**: `getStablePriceMinWidth` calculates the maximum possible character count for a price at its current magnitude, returning a `minWidth` in `ch` units. Combined with existing `tabular-nums`, this reserves stable space regardless of trailing-zero stripping. Guarded with `platformEnv.isNative` since `ch` is CSS-only.

## Changes Detail
- **Footer.tsx**: Add `PerpFooterActions` component; add `PerpFooterTicker` for perp route; add `flexShrink={0}` to left/right sections
- **Footer/index.ts**: Re-export `PerpFooterActions`
- **PerpContentFooter.tsx**: Restore `!isWebDappMode` guard; remove duplicated constants/components; use `PerpFooterActions`
- **FavoriteTokenItem.tsx**: Add `getStablePriceMinWidth` utility; apply `minWidth` + `textAlign="right"` to price display components

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Web (desktop + dApp mode)
- **Risk Areas**: Footer visibility conditions — verified against git history that the gtSm/gtMd dApp gap is pre-existing

## Test plan
- [ ] Web dApp mode: verify only one footer bar on perp route with ticker, Telegram link, and MoreMenu
- [ ] Web dApp mode: verify footer shows on non-perp routes without perp-specific elements
- [ ] Desktop web: verify PerpContentFooter renders with ticker, Telegram link, and MoreMenu
- [ ] Desktop web: verify price ticker values don't cause horizontal jitter when prices update
- [ ] Verify MoreMenu links work correctly in both footers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
