### PR TITLE
chore: update pr-impact-analysis action to v1 thin client architecture

### DIFF
--- a/.github/workflows/pr-impact-analysis.yml
+++ b/.github/workflows/pr-impact-analysis.yml
@@ -13,19 +13,9 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: PR Impact Analysis
-        # TODO: switch to OneKeyHQ/actions/pr-impact-analysis@main after https://github.com/OneKeyHQ/actions/pull/78 is merged
-        uses: originalix/actions/pr-impact-analysis@feat/pr-impact
+      - name: Analyze PR Impact
+        uses: originalix/actions/pr-impact-analysis@fix/pr-analysis-v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          llm-api-key: ${{ secrets.PIA_LLM_API_KEY }}
-          llm-api-base-url: ${{ secrets.PIA_LLM_API_BASE_URL }}
-          llm-model: ${{ vars.PIA_LLM_MODEL }}
-          jira-base-url: ${{ secrets.PIA_JIRA_BASE_URL }}
-          jira-email: ${{ secrets.PIA_JIRA_EMAIL }}
-          jira-api-token: ${{ secrets.PIA_JIRA_API_TOKEN }}
-          jira-project-key: 'OK'
-          jira-assignee-id: ${{ vars.PIA_JIRA_ASSIGNEE_ID }}
+          worker-url: ${{ secrets.PR_ANALYSIS_WORKER_URL }}
+          worker-secret: ${{ secrets.PR_ANALYSIS_WORKER_SECRET }}


### PR DESCRIPTION
## Summary
- Update PR Impact Analysis workflow to use the new v1 thin client architecture
- Remove checkout step (action now fetches PR data via GitHub API)
- Replace 8 LLM/Jira inputs with 2 Worker inputs (config moved to Cloudflare Worker)

## Changes Detail
- **Action reference**: `originalix/actions/pr-impact-analysis@feat/pr-impact` → `originalix/actions/pr-impact-analysis@fix/pr-analysis-v1`
- **Removed**: `actions/checkout@v3` step (no longer needed)
- **Removed inputs**: `llm-api-key`, `llm-api-base-url`, `llm-model`, `jira-base-url`, `jira-email`, `jira-api-token`, `jira-project-key`, `jira-assignee-id`
- **Added inputs**: `worker-url`, `worker-secret`

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: CI/CD only
- **Risk Areas**: Requires `PR_ANALYSIS_WORKER_URL` and `PR_ANALYSIS_WORKER_SECRET` secrets to be configured in repo settings

## Test plan
- [ ] Verify `PR_ANALYSIS_WORKER_URL` and `PR_ANALYSIS_WORKER_SECRET` secrets are configured
- [ ] Merge a test PR to `x` branch and confirm the workflow runs successfully
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
