### PR TITLE
fix: hide Settings tab in universal search on Web platform (OK-51024)

### DIFF
--- a/packages/kit/src/views/UniversalSearch/pages/UniversalSearch.tsx
+++ b/packages/kit/src/views/UniversalSearch/pages/UniversalSearch.tsx
@@ -204,9 +204,10 @@ export function UniversalSearch({
         intl.formatMessage({
           id: ETranslations.global_universal_search_tabs_dapps,
         }),
-      intl.formatMessage({
-        id: ETranslations.global_settings,
-      }),
+      !platformEnv.isWeb &&
+        intl.formatMessage({
+          id: ETranslations.global_settings,
+        }),
     ].filter(Boolean);
   }, [intl]);
 
@@ -461,8 +462,8 @@ export function UniversalSearch({
         });
       }
 
-      // Settings search runs locally (no backend needed)
-      const settingsResults = searchSettings(input);
+      // Settings search runs locally (no backend needed), hidden on Web
+      const settingsResults = platformEnv.isWeb ? [] : searchSettings(input);
       if (settingsResults.length > 0) {
         const data = settingsResults as IUniversalSearchResultItem[];
         searchResultSections.push({


### PR DESCRIPTION
## Summary
- Hide the Settings tab in the universal search tab bar on the Web platform (`platformEnv.isWeb`)
- Skip settings search results when running on Web

## Test plan
- [ ] Open universal search on Web platform → Settings tab should not appear
- [ ] Open universal search on Desktop/Mobile/Extension → Settings tab should still appear and work
- [ ] Search for a settings keyword on Web → no Settings section in results
- [ ] Search for a settings keyword on non-Web platforms → Settings section appears as before
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
