### PR TITLE
feat: move PRF master key cache to background and call biologyAuthUtils directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 __generated__
-
+.cursor/debug*.log
 .expo-shared
 .expo
 .DS_Store

--- a/apps/ext/src/ui/renderPassKeyPage.tsx
+++ b/apps/ext/src/ui/renderPassKeyPage.tsx
@@ -8,6 +8,7 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import { useWebAuthActions } from '@onekeyhq/kit/src/components/BiologyAuthComponent/hooks/useWebAuthActions';
 import { GlobalJotaiReady } from '@onekeyhq/kit/src/components/GlobalJotaiReady';
 import { ThemeProvider } from '@onekeyhq/kit/src/provider/ThemeProvider';
+import { biologyAuthUtils } from '@onekeyhq/kit-bg/src/services/ServicePassword/biologyAuthUtils';
 import {
   usePasswordAtom,
   usePasswordModeAtom,
@@ -70,9 +71,7 @@ const usePassKeyOperations = () => {
       } else {
         // No cached password — try secure storage (WebAuthn PRF)
         try {
-          result =
-            (await backgroundApiProxy.servicePassword.getWebAuthPassword()) ??
-            undefined;
+          result = (await biologyAuthUtils.getPassword()) ?? undefined;
         } catch {
           // Fallback to credential-only verification
           result = await checkWebAuth();

--- a/apps/ext/src/ui/renderPassKeyPage.tsx
+++ b/apps/ext/src/ui/renderPassKeyPage.tsx
@@ -18,6 +18,7 @@ import {
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { EPassKeyWindowType } from '@onekeyhq/shared/src/utils/extUtils';
+import { verifiedWebAuth } from '@onekeyhq/shared/src/webAuth';
 import { EPasswordVerifyStatus } from '@onekeyhq/shared/types/password';
 
 import { setupExtUIEventOnPassKeyPage } from '../background/extUI';
@@ -27,8 +28,7 @@ const params = new URLSearchParams(globalThis.location.href.split('?').pop());
 const type = params.get('type') as EPassKeyWindowType;
 
 const usePassKeyOperations = () => {
-  const { setWebAuthEnable, verifiedPasswordWebAuth, checkWebAuth } =
-    useWebAuthActions();
+  const { setWebAuthEnable, verifiedPasswordWebAuth } = useWebAuthActions();
 
   const [{ passwordPromptPromiseTriggerData }] =
     usePasswordPromptPromiseTriggerAtom();
@@ -73,12 +73,27 @@ const usePassKeyOperations = () => {
         try {
           result = (await biologyAuthUtils.getPassword()) ?? undefined;
         } catch {
-          // Fallback to credential-only verification
-          result = await checkWebAuth();
+          // getPassword failed — fall back to credential-only verification.
+          // Call verifiedWebAuth directly instead of checkWebAuth() to avoid
+          // a redundant biologyAuthUtils.getPassword() call inside it.
+          // Note: checkExtWebAuth is unnecessary here — this IS the PassKey
+          // window, so WebAuthn works directly without needing another window.
+          const cred = await verifiedWebAuth(webAuthCredentialId);
+          result = cred?.id === webAuthCredentialId;
         }
       }
 
       if (result) {
+        // If we got a real password string, verify and cache it
+        if (typeof result === 'string' && result) {
+          await backgroundApiProxy.servicePassword.verifyPassword({
+            password: result,
+            passwordMode,
+          });
+        }
+
+        // Only set verified status and reset error counters AFTER
+        // password verification succeeds (matches PasswordVerifyContainer pattern)
         setPasswordAtom((v) => ({
           ...v,
           passwordVerifyStatus: {
@@ -91,14 +106,6 @@ const usePassKeyOperations = () => {
             passwordErrorAttempts: 0,
             passwordErrorProtectionTime: 0,
           }));
-        }
-
-        // If we got a real password string, verify and cache it
-        if (typeof result === 'string' && result) {
-          await backgroundApiProxy.servicePassword.verifyPassword({
-            password: result,
-            passwordMode,
-          });
         }
 
         // Password Dialog
@@ -155,7 +162,6 @@ const usePassKeyOperations = () => {
       closeWindow();
     }
   }, [
-    checkWebAuth,
     enablePasswordErrorProtection,
     intl,
     passwordMode,

--- a/apps/ext/src/ui/renderPassKeyPage.tsx
+++ b/apps/ext/src/ui/renderPassKeyPage.tsx
@@ -143,6 +143,13 @@ const usePassKeyOperations = () => {
           }),
         },
       }));
+      // Cancel any pending password prompt dialog so caller fails immediately
+      // instead of hanging until the 5-minute timeout
+      if (passwordPromptPromiseTriggerData?.idNumber) {
+        await backgroundApiProxy.servicePassword.cancelPasswordPromptDialog(
+          passwordPromptPromiseTriggerData.idNumber,
+        );
+      }
     } finally {
       console.log('close from renderPassKeyPage');
       closeWindow();

--- a/apps/ext/src/ui/renderPassKeyPage.tsx
+++ b/apps/ext/src/ui/renderPassKeyPage.tsx
@@ -10,6 +10,7 @@ import { GlobalJotaiReady } from '@onekeyhq/kit/src/components/GlobalJotaiReady'
 import { ThemeProvider } from '@onekeyhq/kit/src/provider/ThemeProvider';
 import {
   usePasswordAtom,
+  usePasswordModeAtom,
   usePasswordPersistAtom,
   usePasswordPromptPromiseTriggerAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -32,6 +33,7 @@ const usePassKeyOperations = () => {
     usePasswordPromptPromiseTriggerAtom();
   const [{ webAuthCredentialId }] = usePasswordPersistAtom();
   const [{ passwordVerifyStatus }, setPasswordAtom] = usePasswordAtom();
+  const [passwordMode] = usePasswordModeAtom();
   const intl = useIntl();
   const [{ enablePasswordErrorProtection }, setPasswordPersist] =
     usePasswordPersistAtom();
@@ -62,9 +64,21 @@ const usePassKeyOperations = () => {
       !!(await backgroundApiProxy.servicePassword.getCachedPassword());
 
     try {
-      const result = hasCachedPassword
-        ? await verifiedPasswordWebAuth()
-        : await checkWebAuth();
+      let result: string | boolean | undefined;
+      if (hasCachedPassword) {
+        result = await verifiedPasswordWebAuth();
+      } else {
+        // No cached password — try secure storage (WebAuthn PRF)
+        try {
+          result =
+            (await backgroundApiProxy.servicePassword.getWebAuthPassword()) ??
+            undefined;
+        } catch {
+          // Fallback to credential-only verification
+          result = await checkWebAuth();
+        }
+      }
+
       if (result) {
         setPasswordAtom((v) => ({
           ...v,
@@ -79,6 +93,15 @@ const usePassKeyOperations = () => {
             passwordErrorProtectionTime: 0,
           }));
         }
+
+        // If we got a real password string, verify and cache it
+        if (typeof result === 'string' && result) {
+          await backgroundApiProxy.servicePassword.verifyPassword({
+            password: result,
+            passwordMode,
+          });
+        }
+
         // Password Dialog
         if (passwordPromptPromiseTriggerData?.idNumber) {
           await backgroundApiProxy.servicePassword.resolvePasswordPromptDialog(
@@ -119,6 +142,7 @@ const usePassKeyOperations = () => {
     checkWebAuth,
     enablePasswordErrorProtection,
     intl,
+    passwordMode,
     passwordPromptPromiseTriggerData?.idNumber,
     setPasswordAtom,
     setPasswordPersist,

--- a/apps/ext/src/ui/renderPassKeyPage.tsx
+++ b/apps/ext/src/ui/renderPassKeyPage.tsx
@@ -102,11 +102,15 @@ const usePassKeyOperations = () => {
         }
 
         // Password Dialog
-        if (passwordPromptPromiseTriggerData?.idNumber) {
+        if (
+          typeof result === 'string' &&
+          result &&
+          passwordPromptPromiseTriggerData?.idNumber
+        ) {
           await backgroundApiProxy.servicePassword.resolvePasswordPromptDialog(
             passwordPromptPromiseTriggerData?.idNumber,
             {
-              password: result as string,
+              password: result,
             },
           );
         } else {

--- a/apps/ext/src/ui/renderPassKeyPage.tsx
+++ b/apps/ext/src/ui/renderPassKeyPage.tsx
@@ -114,6 +114,12 @@ const usePassKeyOperations = () => {
             },
           );
         } else {
+          // Cancel the pending password prompt dialog if we can't provide a real password
+          if (passwordPromptPromiseTriggerData?.idNumber) {
+            await backgroundApiProxy.servicePassword.cancelPasswordPromptDialog(
+              passwordPromptPromiseTriggerData.idNumber,
+            );
+          }
           await backgroundApiProxy.servicePassword.unLockApp();
         }
       } else {

--- a/packages/kit-bg/src/services/ServiceApp.ts
+++ b/packages/kit-bg/src/services/ServiceApp.ts
@@ -40,6 +40,7 @@ import { appIsLocked } from '../states/jotai/atoms';
 import { devSettingsPersistAtom } from '../states/jotai/atoms/devSettings';
 
 import ServiceBase from './ServiceBase';
+import { biologyAuthUtils } from './ServicePassword/biologyAuthUtils';
 
 import type { ISimpleDBAppStatus } from '../dbs/simple/entity/SimpleDbEntityAppStatus';
 
@@ -91,7 +92,7 @@ class ServiceApp extends ServiceBase {
 
     // clean secure storage (WebAuth password)
     try {
-      await this.backgroundApi.servicePassword.deleteWebAuthPassword();
+      await biologyAuthUtils.deletePassword();
     } catch {
       console.error('deleteWebAuthPassword error');
     }

--- a/packages/kit-bg/src/services/ServiceApp.ts
+++ b/packages/kit-bg/src/services/ServiceApp.ts
@@ -89,6 +89,13 @@ class ServiceApp extends ServiceBase {
     }
     defaultLogger.setting.page.clearDataStep('appStorage-clear');
 
+    // clean secure storage (WebAuth password)
+    try {
+      await this.backgroundApi.servicePassword.deleteWebAuthPassword();
+    } catch {
+      console.error('deleteWebAuthPassword error');
+    }
+
     try {
       appStorage.syncStorage.clearAll();
     } catch {

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessStorageUtils.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessStorageUtils.ts
@@ -13,7 +13,7 @@ let _secureStorageSupported: boolean | null = null;
 async function isSecureStorageSupported(): Promise<boolean> {
   if (_secureStorageSupported === null) {
     _secureStorageSupported =
-      await appStorage.secureStorage.supportSecureStorage();
+      await appStorage.secureStorage.supportSecureStorageWithoutInteraction();
   }
   return _secureStorageSupported;
 }

--- a/packages/kit-bg/src/services/ServicePassword/biologyAuthUtils.ts
+++ b/packages/kit-bg/src/services/ServicePassword/biologyAuthUtils.ts
@@ -1,8 +1,10 @@
+import { ensureSensitiveTextEncoded } from '@onekeyhq/core/src/secret';
 import {
   decodeSensitiveTextAsync,
   encodeKeyPrefix,
   encodeSensitiveTextAsync,
 } from '@onekeyhq/core/src/secret/encryptors/aes256';
+import appGlobals from '@onekeyhq/shared/src/appGlobals';
 import biologyAuth from '@onekeyhq/shared/src/biologyAuth';
 import type { IBiologyAuth } from '@onekeyhq/shared/src/biologyAuth/types';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
@@ -26,10 +28,13 @@ class BiologyAuthUtils implements IBiologyAuth {
   }
 
   savePassword = async (password: string) => {
+    ensureSensitiveTextEncoded(password);
     if (!(await appStorage.secureStorage.supportSecureStorage())) {
       return;
     }
-    let text = await decodeSensitiveTextAsync({ encodedText: password });
+    const key =
+      await appGlobals.$backgroundApiProxy.servicePassword.getBgSensitiveTextEncodeKey();
+    let text = await decodeSensitiveTextAsync({ encodedText: password, key });
     const settings = await settingsPersistAtom.get();
     text = await encodeSensitiveTextAsync({
       text,
@@ -54,7 +59,9 @@ class BiologyAuthUtils implements IBiologyAuth {
         encodedText: text,
         key: `${encodeKeyPrefix}${settings.sensitiveEncodeKey}`,
       });
-      text = await encodeSensitiveTextAsync({ text });
+      const key =
+        await appGlobals.$backgroundApiProxy.servicePassword.getBgSensitiveTextEncodeKey();
+      text = await encodeSensitiveTextAsync({ text, key });
       return text;
     }
     throw new OneKeyLocalError('No password');

--- a/packages/kit-bg/src/services/ServicePassword/biologyAuthUtils.ts
+++ b/packages/kit-bg/src/services/ServicePassword/biologyAuthUtils.ts
@@ -68,6 +68,7 @@ class BiologyAuthUtils implements IBiologyAuth {
   };
 
   deletePassword = async () => {
+    if (!(await appStorage.secureStorage.supportSecureStorage())) return;
     await appStorage.secureStorage.removeSecureItem(
       SECURE_STORAGE_PASSWORD_KEY,
     );

--- a/packages/kit-bg/src/services/ServicePassword/biologyAuthUtils.ts
+++ b/packages/kit-bg/src/services/ServicePassword/biologyAuthUtils.ts
@@ -10,6 +10,8 @@ import appStorage from '@onekeyhq/shared/src/storage/appStorage';
 
 import { settingsPersistAtom } from '../../states/jotai/atoms/settings';
 
+const SECURE_STORAGE_PASSWORD_KEY = 'password';
+
 class BiologyAuthUtils implements IBiologyAuth {
   isSupportBiologyAuth() {
     return biologyAuth.isSupportBiologyAuth();
@@ -33,14 +35,19 @@ class BiologyAuthUtils implements IBiologyAuth {
       text,
       key: `${encodeKeyPrefix}${settings.sensitiveEncodeKey}`,
     });
-    await appStorage.secureStorage.setSecureItem('password', text);
+    await appStorage.secureStorage.setSecureItem(
+      SECURE_STORAGE_PASSWORD_KEY,
+      text,
+    );
   };
 
   getPassword = async () => {
     if (!(await appStorage.secureStorage.supportSecureStorage())) {
       throw new OneKeyLocalError('No password');
     }
-    let text = await appStorage.secureStorage.getSecureItem('password');
+    let text = await appStorage.secureStorage.getSecureItem(
+      SECURE_STORAGE_PASSWORD_KEY,
+    );
     if (text) {
       const settings = await settingsPersistAtom.get();
       text = await decodeSensitiveTextAsync({
@@ -54,8 +61,24 @@ class BiologyAuthUtils implements IBiologyAuth {
   };
 
   deletePassword = async () => {
-    if (!(await appStorage.secureStorage.supportSecureStorage())) return;
-    await appStorage.secureStorage.removeSecureItem('password');
+    await appStorage.secureStorage.removeSecureItem(
+      SECURE_STORAGE_PASSWORD_KEY,
+    );
+  };
+
+  hasPassword = async (): Promise<boolean> => {
+    if (!(await appStorage.secureStorage.supportSecureStorage())) {
+      return false;
+    }
+    if (appStorage.secureStorage.hasSecureItem) {
+      return appStorage.secureStorage.hasSecureItem(
+        SECURE_STORAGE_PASSWORD_KEY,
+      );
+    }
+    const value = await appStorage.secureStorage.getSecureItem(
+      SECURE_STORAGE_PASSWORD_KEY,
+    );
+    return !!value;
   };
 }
 export const biologyAuthUtils = new BiologyAuthUtils();

--- a/packages/kit-bg/src/services/ServicePassword/index.ts
+++ b/packages/kit-bg/src/services/ServicePassword/index.ts
@@ -80,6 +80,14 @@ export default class ServicePassword extends ServiceBase {
   private cachedPasswordTimeOutObject: ReturnType<typeof setTimeout> | null =
     null;
 
+  private cachedPrfMasterKeyHex: string | null = null;
+
+  private cachedPrfMasterKeyTimestamp = 0;
+
+  private readonly PRF_MASTER_KEY_CACHE_DURATION_MS = 5 * 60 * 1000;
+
+  private skipPrfCacheFlag = false;
+
   private passwordPromptTTL: number = timerUtils.getTimeDurationMs({
     minute: 5,
   });
@@ -203,6 +211,44 @@ export default class ServicePassword extends ServiceBase {
 
     // TODO clear cached sync credential only when app is locked
     void this.backgroundApi.servicePrimeCloudSync.clearCachedSyncCredential();
+    await this.clearCachedPrfMasterKey();
+  }
+
+  // PRF master key cache (stored in background memory)
+  @backgroundMethod()
+  async getCachedPrfMasterKey(): Promise<string | null> {
+    if (this.skipPrfCacheFlag) {
+      return null;
+    }
+    if (!this.cachedPrfMasterKeyHex) {
+      return null;
+    }
+    const now = Date.now();
+    if (
+      now - this.cachedPrfMasterKeyTimestamp >=
+      this.PRF_MASTER_KEY_CACHE_DURATION_MS
+    ) {
+      await this.clearCachedPrfMasterKey();
+      return null;
+    }
+    return this.cachedPrfMasterKeyHex;
+  }
+
+  @backgroundMethod()
+  async setCachedPrfMasterKey(hex: string): Promise<void> {
+    this.cachedPrfMasterKeyHex = hex;
+    this.cachedPrfMasterKeyTimestamp = Date.now();
+  }
+
+  @backgroundMethod()
+  async clearCachedPrfMasterKey(): Promise<void> {
+    this.cachedPrfMasterKeyHex = null;
+    this.cachedPrfMasterKeyTimestamp = 0;
+  }
+
+  @backgroundMethod()
+  async setSkipPrfCache(skip: boolean): Promise<void> {
+    this.skipPrfCacheFlag = skip;
   }
 
   async setCachedPassword({ password }: { password: string }): Promise<string> {
@@ -282,27 +328,6 @@ export default class ServicePassword extends ServiceBase {
   }
 
   // biologyAuth&WebAuth ------------------------------
-
-  @backgroundMethod()
-  async getWebAuthPassword(): Promise<string | null> {
-    return biologyAuthUtils.getPassword();
-  }
-
-  @backgroundMethod()
-  async saveWebAuthPassword(password: string): Promise<void> {
-    ensureSensitiveTextEncoded(password);
-    await biologyAuthUtils.savePassword(password);
-  }
-
-  @backgroundMethod()
-  async hasWebAuthPassword(): Promise<boolean> {
-    return biologyAuthUtils.hasPassword();
-  }
-
-  @backgroundMethod()
-  async deleteWebAuthPassword(): Promise<void> {
-    await biologyAuthUtils.deletePassword();
-  }
 
   async saveBiologyAuthPassword(password: string): Promise<void> {
     ensureSensitiveTextEncoded(password);
@@ -731,33 +756,41 @@ export default class ServicePassword extends ServiceBase {
         const cachedPassword = await this.getCachedPassword();
         if (cachedPassword) {
           ensureSensitiveTextEncoded(cachedPassword);
-          return Promise.resolve({
+          return {
             password: cachedPassword,
-          });
+          };
         }
       }
 
       const isPasswordSet = await this.checkPasswordSet();
       this.clearPasswordPromptTimeout();
-      const res = new Promise((resolve, reject) => {
-        const promiseId = this.backgroundApi.servicePromise.createCallback({
-          resolve,
-          reject,
+      // Skip PRF master key cache whenever the password dialog is shown,
+      // forcing a real WebAuthn interaction for biometric verification.
+      // Don't clear the cache — user may cancel and cache should remain valid.
+      await this.setSkipPrfCache(true);
+      try {
+        const res = new Promise((resolve, reject) => {
+          const promiseId = this.backgroundApi.servicePromise.createCallback({
+            resolve,
+            reject,
+          });
+          void this.showPasswordPromptDialog({
+            idNumber: promiseId,
+            type: isPasswordSet
+              ? EPasswordPromptType.PASSWORD_VERIFY
+              : EPasswordPromptType.PASSWORD_SETUP,
+            dialogProps: options?.dialogProps,
+          });
         });
-        void this.showPasswordPromptDialog({
-          idNumber: promiseId,
-          type: isPasswordSet
-            ? EPasswordPromptType.PASSWORD_VERIFY
-            : EPasswordPromptType.PASSWORD_SETUP,
-          dialogProps: options?.dialogProps,
-        });
-      });
-      const result = await (res as Promise<IPasswordRes>);
-      ensureSensitiveTextEncoded(result.password);
+        const result = await (res as Promise<IPasswordRes>);
+        ensureSensitiveTextEncoded(result.password);
 
-      // wait PromptPasswordDialog close animation
-      await timerUtils.wait(600);
-      return result;
+        // wait PromptPasswordDialog close animation
+        await timerUtils.wait(600);
+        return result;
+      } finally {
+        await this.setSkipPrfCache(false);
+      }
     });
   }
 

--- a/packages/kit-bg/src/services/ServicePassword/index.ts
+++ b/packages/kit-bg/src/services/ServicePassword/index.ts
@@ -282,6 +282,28 @@ export default class ServicePassword extends ServiceBase {
   }
 
   // biologyAuth&WebAuth ------------------------------
+
+  @backgroundMethod()
+  async getWebAuthPassword(): Promise<string | null> {
+    return biologyAuthUtils.getPassword();
+  }
+
+  @backgroundMethod()
+  async saveWebAuthPassword(password: string): Promise<void> {
+    ensureSensitiveTextEncoded(password);
+    await biologyAuthUtils.savePassword(password);
+  }
+
+  @backgroundMethod()
+  async hasWebAuthPassword(): Promise<boolean> {
+    return biologyAuthUtils.hasPassword();
+  }
+
+  @backgroundMethod()
+  async deleteWebAuthPassword(): Promise<void> {
+    await biologyAuthUtils.deletePassword();
+  }
+
   async saveBiologyAuthPassword(password: string): Promise<void> {
     ensureSensitiveTextEncoded(password);
     /* The password also needs to be stored when the system closes the fingerprint identification,

--- a/packages/kit-bg/src/states/jotai/atoms/password.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/password.ts
@@ -140,6 +140,7 @@ export const {
   const { webAuthCredentialId } = get(passwordPersistAtom.atom());
   const isSupport = await isSupportWebAuth();
   const isEnable = isSupport && webAuthCredentialId?.length > 0;
+
   return { isSupport, isEnable };
 });
 

--- a/packages/kit/src/components/BiologyAuthComponent/hooks/useWebAuthActions.ts
+++ b/packages/kit/src/components/BiologyAuthComponent/hooks/useWebAuthActions.ts
@@ -4,7 +4,6 @@ import { useIntl } from 'react-intl';
 
 import { Toast } from '@onekeyhq/components';
 import { usePasswordPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import extUtils, {
@@ -54,6 +53,21 @@ export const useWebAuthActions = () => {
             ...v,
             webAuthCredentialId: webAuthCredentialId ?? '',
           }));
+          // Save password to secure storage for biometric unlock
+          try {
+            if (platformEnv.isExtension) {
+              await backgroundApiProxy.servicePassword.promptPasswordVerify();
+            }
+            const cachedPassword =
+              await backgroundApiProxy.servicePassword.getCachedPassword();
+            if (cachedPassword) {
+              await backgroundApiProxy.servicePassword.saveWebAuthPassword(
+                cachedPassword,
+              );
+            }
+          } catch (e) {
+            console.error('Failed to save password to secure storage:', e);
+          }
         }
       }
       return webAuthCredentialId;
@@ -71,18 +85,33 @@ export const useWebAuthActions = () => {
   const verifiedPasswordWebAuth = useCallback(async () => {
     const checkCachePassword =
       await backgroundApiProxy.servicePassword.getCachedPassword();
-    if (!checkCachePassword) {
-      throw new OneKeyLocalError('No password cached not support web auth');
+    if (checkCachePassword) {
+      await checkExtWebAuth(EPassKeyWindowType.unlock);
+      // web auth must be called in ui context for extension
+      const cred = await verifiedWebAuth(credId);
+      if (cred?.id === credId) {
+        return checkCachePassword;
+      }
+      return undefined;
     }
-    await checkExtWebAuth(EPassKeyWindowType.unlock);
-    // web auth must be called in ui context for extension
-    const cred = await verifiedWebAuth(credId);
-    if (cred?.id === credId) {
-      return checkCachePassword;
-    }
+    // No cached password — try secure storage (triggers WebAuthn PRF)
+    const securePassword =
+      await backgroundApiProxy.servicePassword.getWebAuthPassword();
+      
+    return securePassword ?? undefined;
   }, [credId]);
 
   const checkWebAuth = useCallback(async () => {
+    // Try secure storage first (WebAuthn PRF)
+    try {
+      const securePassword =
+        await backgroundApiProxy.servicePassword.getWebAuthPassword();
+      if (securePassword) {
+        return securePassword;
+      }
+    } catch {
+      // Fallback to credential-only verification
+    }
     await checkExtWebAuth(EPassKeyWindowType.unlock);
     const cred = await verifiedWebAuth(credId);
     return cred?.id === credId;

--- a/packages/kit/src/components/BiologyAuthComponent/hooks/useWebAuthActions.ts
+++ b/packages/kit/src/components/BiologyAuthComponent/hooks/useWebAuthActions.ts
@@ -103,14 +103,19 @@ export const useWebAuthActions = () => {
       return undefined;
     }
     // No cached password — try secure storage (triggers WebAuthn PRF)
-    const securePassword = await biologyAuthUtils.getPassword();
-    if (securePassword) {
-      // Verify password correctness and cache it
-      const verified = await backgroundApiProxy.servicePassword.verifyPassword({
-        password: securePassword,
-        passwordMode,
-      });
-      return verified;
+    try {
+      const securePassword = await biologyAuthUtils.getPassword();
+      if (securePassword) {
+        // Verify password correctness and cache it
+        const verified =
+          await backgroundApiProxy.servicePassword.verifyPassword({
+            password: securePassword,
+            passwordMode,
+          });
+        return verified;
+      }
+    } catch {
+      // No secure password stored — fall through
     }
     return undefined;
   }, [credId, passwordMode]);

--- a/packages/kit/src/components/BiologyAuthComponent/hooks/useWebAuthActions.ts
+++ b/packages/kit/src/components/BiologyAuthComponent/hooks/useWebAuthActions.ts
@@ -62,7 +62,11 @@ export const useWebAuthActions = () => {
           // Save password to secure storage for biometric unlock
           try {
             if (platformEnv.isExtension) {
-              await backgroundApiProxy.servicePassword.promptPasswordVerify();
+              const isPasswordSet =
+                await backgroundApiProxy.servicePassword.checkPasswordSet();
+              if (isPasswordSet) {
+                await backgroundApiProxy.servicePassword.promptPasswordVerify();
+              }
             }
             const cachedPassword =
               await backgroundApiProxy.servicePassword.getCachedPassword();

--- a/packages/kit/src/components/BiologyAuthComponent/hooks/useWebAuthActions.ts
+++ b/packages/kit/src/components/BiologyAuthComponent/hooks/useWebAuthActions.ts
@@ -3,7 +3,12 @@ import { useCallback } from 'react';
 import { useIntl } from 'react-intl';
 
 import { Toast } from '@onekeyhq/components';
-import { usePasswordPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { biologyAuthUtils } from '@onekeyhq/kit-bg/src/services/ServicePassword/biologyAuthUtils';
+import {
+  usePasswordModeAtom,
+  usePasswordPersistAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import extUtils, {
@@ -37,6 +42,7 @@ export const useWebAuthActions = () => {
   const intl = useIntl();
   const [{ webAuthCredentialId: credId }, setPasswordPersist] =
     usePasswordPersistAtom();
+  const [passwordMode] = usePasswordModeAtom();
   const setWebAuthEnable = useCallback(
     async (enable: boolean) => {
       let webAuthCredentialId: string | undefined;
@@ -61,9 +67,7 @@ export const useWebAuthActions = () => {
             const cachedPassword =
               await backgroundApiProxy.servicePassword.getCachedPassword();
             if (cachedPassword) {
-              await backgroundApiProxy.servicePassword.saveWebAuthPassword(
-                cachedPassword,
-              );
+              await biologyAuthUtils.savePassword(cachedPassword);
             }
           } catch (e) {
             console.error('Failed to save password to secure storage:', e);
@@ -95,19 +99,30 @@ export const useWebAuthActions = () => {
       return undefined;
     }
     // No cached password — try secure storage (triggers WebAuthn PRF)
-    const securePassword =
-      await backgroundApiProxy.servicePassword.getWebAuthPassword();
-      
-    return securePassword ?? undefined;
-  }, [credId]);
+    const securePassword = await biologyAuthUtils.getPassword();
+    if (securePassword) {
+      // Verify password correctness and cache it
+      const verified = await backgroundApiProxy.servicePassword.verifyPassword({
+        password: securePassword,
+        passwordMode,
+      });
+      return verified;
+    }
+    return undefined;
+  }, [credId, passwordMode]);
 
   const checkWebAuth = useCallback(async () => {
     // Try secure storage first (WebAuthn PRF)
     try {
-      const securePassword =
-        await backgroundApiProxy.servicePassword.getWebAuthPassword();
+      const securePassword = await biologyAuthUtils.getPassword();
       if (securePassword) {
-        return securePassword;
+        // Verify password correctness and cache it
+        const verified =
+          await backgroundApiProxy.servicePassword.verifyPassword({
+            password: securePassword,
+            passwordMode,
+          });
+        return verified;
       }
     } catch {
       // Fallback to credential-only verification
@@ -115,7 +130,7 @@ export const useWebAuthActions = () => {
     await checkExtWebAuth(EPassKeyWindowType.unlock);
     const cred = await verifiedWebAuth(credId);
     return cred?.id === credId;
-  }, [credId]);
+  }, [credId, passwordMode]);
 
   return {
     setWebAuthEnable,

--- a/packages/kit/src/components/Password/container/PasswordSetupContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordSetupContainer.tsx
@@ -10,7 +10,6 @@ import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms'
 import {
   usePasswordBiologyAuthInfoAtom,
   usePasswordModeAtom,
-  usePasswordPersistAtom,
   usePasswordWebAuthInfoAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms/password';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -78,7 +77,6 @@ const PasswordSetupContainer = ({
   const [loading, setLoading] = useState(false);
   const [{ isSupport }] = usePasswordWebAuthInfoAtom();
   const [{ isBiologyAuthSwitchOn }] = useSettingsPersistAtom();
-  const [{ webAuthCredentialId }] = usePasswordPersistAtom();
   const [passwordMode] = usePasswordModeAtom();
   const { setWebAuthEnable } = useWebAuthActions();
   const onSetupPassword = useCallback(
@@ -105,11 +103,7 @@ const PasswordSetupContainer = ({
           );
         isPasswordSetSuccess = true;
         // Save password to secure storage for biometric unlock on extension
-        if (
-          platformEnv.isExtension &&
-          isBiologyAuthSwitchOn &&
-          webAuthRes
-        ) {
+        if (platformEnv.isExtension && isBiologyAuthSwitchOn && webAuthRes) {
           try {
             await biologyAuthUtils.savePassword(setUpPasswordRes);
           } catch (e) {
@@ -192,7 +186,6 @@ const PasswordSetupContainer = ({
       onSetupRes,
       pageMode,
       setWebAuthEnable,
-      webAuthCredentialId,
     ],
   );
 

--- a/packages/kit/src/components/Password/container/PasswordSetupContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordSetupContainer.tsx
@@ -104,10 +104,11 @@ const PasswordSetupContainer = ({
           );
         isPasswordSetSuccess = true;
         // Save password to secure storage for biometric unlock on extension
+        // Save password to secure storage for biometric unlock on extension
         if (
           platformEnv.isExtension &&
           isBiologyAuthSwitchOn &&
-          webAuthCredentialId
+          res
         ) {
           try {
             await biologyAuthUtils.savePassword(setUpPasswordRes);

--- a/packages/kit/src/components/Password/container/PasswordSetupContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordSetupContainer.tsx
@@ -102,9 +102,13 @@ const PasswordSetupContainer = ({
             mode,
           );
         isPasswordSetSuccess = true;
-        // Save password to secure storage for biometric unlock on extension
+        // Save password to secure storage for biometric unlock on extension.
+        // Clear skipPrfCache first — the flag is set during promptPasswordVerify
+        // to force real WebAuthn for the biometric button, but password setup
+        // has already succeeded here so it's safe to use cache.
         if (platformEnv.isExtension && isBiologyAuthSwitchOn && webAuthRes) {
           try {
+            await backgroundApiProxy.servicePassword.setSkipPrfCache(false);
             await biologyAuthUtils.savePassword(setUpPasswordRes);
           } catch (e) {
             console.error('Failed to save password to secure storage:', e);

--- a/packages/kit/src/components/Password/container/PasswordSetupContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordSetupContainer.tsx
@@ -89,9 +89,10 @@ const PasswordSetupContainer = ({
       setLoading(true);
       let isPasswordSetSuccess = false;
       try {
+        let webAuthRes: string | undefined;
         if (isBiologyAuthSwitchOn && isSupport) {
-          const res = await setWebAuthEnable(true);
-          if (!res) return;
+          webAuthRes = await setWebAuthEnable(true);
+          if (!webAuthRes) return;
         }
         const encodePassword =
           await backgroundApiProxy.servicePassword.encodeSensitiveText({
@@ -104,11 +105,10 @@ const PasswordSetupContainer = ({
           );
         isPasswordSetSuccess = true;
         // Save password to secure storage for biometric unlock on extension
-        // Save password to secure storage for biometric unlock on extension
         if (
           platformEnv.isExtension &&
           isBiologyAuthSwitchOn &&
-          res
+          webAuthRes
         ) {
           try {
             await biologyAuthUtils.savePassword(setUpPasswordRes);

--- a/packages/kit/src/components/Password/container/PasswordSetupContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordSetupContainer.tsx
@@ -4,11 +4,13 @@ import { useIntl } from 'react-intl';
 
 import { SizableText, Stack, Toast, XStack } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { biologyAuthUtils } from '@onekeyhq/kit-bg/src/services/ServicePassword/biologyAuthUtils';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
   usePasswordBiologyAuthInfoAtom,
   usePasswordModeAtom,
-  // usePasswordPersistAtom,
+  usePasswordPersistAtom,
   usePasswordWebAuthInfoAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms/password';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -76,7 +78,7 @@ const PasswordSetupContainer = ({
   const [loading, setLoading] = useState(false);
   const [{ isSupport }] = usePasswordWebAuthInfoAtom();
   const [{ isBiologyAuthSwitchOn }] = useSettingsPersistAtom();
-  // const [, setPasswordPersist] = usePasswordPersistAtom();
+  const [{ webAuthCredentialId }] = usePasswordPersistAtom();
   const [passwordMode] = usePasswordModeAtom();
   const { setWebAuthEnable } = useWebAuthActions();
   const onSetupPassword = useCallback(
@@ -101,6 +103,18 @@ const PasswordSetupContainer = ({
             mode,
           );
         isPasswordSetSuccess = true;
+        // Save password to secure storage for biometric unlock on extension
+        if (
+          platformEnv.isExtension &&
+          isBiologyAuthSwitchOn &&
+          webAuthCredentialId
+        ) {
+          try {
+            await biologyAuthUtils.savePassword(setUpPasswordRes);
+          } catch (e) {
+            console.error('Failed to save password to secure storage:', e);
+          }
+        }
         Toast.success({
           title: intl.formatMessage({ id: ETranslations.auth_passcode_set }),
         });
@@ -177,6 +191,7 @@ const PasswordSetupContainer = ({
       onSetupRes,
       pageMode,
       setWebAuthEnable,
+      webAuthCredentialId,
     ],
   );
 

--- a/packages/kit/src/components/Password/container/PasswordUpdateContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordUpdateContainer.tsx
@@ -4,8 +4,12 @@ import { useIntl } from 'react-intl';
 
 import { Toast } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { usePasswordModeAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { biologyAuthUtils } from '@onekeyhq/kit-bg/src/services/ServicePassword/biologyAuthUtils';
+import { usePasswordModeAtom, usePasswordPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EPasswordMode } from '@onekeyhq/shared/types/password';
 
 import PasswordSetup from '../components/PasswordSetup';
@@ -23,6 +27,8 @@ const PasswordUpdateContainer = ({
   const [loading, setLoading] = useState(false);
   const intl = useIntl();
   const [passwordMode] = usePasswordModeAtom();
+  const [{ webAuthCredentialId }] = usePasswordPersistAtom();
+  const [{ isBiologyAuthSwitchOn }] = useSettingsPersistAtom();
   const onUpdatePassword = useCallback(
     async (data: IPasswordSetupForm) => {
       const { confirmPassword, confirmPassCode, passwordMode: mode } = data;
@@ -41,6 +47,18 @@ const PasswordUpdateContainer = ({
             mode,
           );
         onUpdateRes(updatedPassword);
+        // Save new password to secure storage for biometric unlock on extension
+        if (
+          platformEnv.isExtension &&
+          isBiologyAuthSwitchOn &&
+          webAuthCredentialId
+        ) {
+          try {
+            await biologyAuthUtils.savePassword(updatedPassword);
+          } catch (e) {
+            console.error('Failed to save new password to secure storage:', e);
+          }
+        }
         Toast.success({
           title: intl.formatMessage({ id: ETranslations.auth_passcode_set }),
         });
@@ -54,7 +72,7 @@ const PasswordUpdateContainer = ({
       }
       setLoading(false);
     },
-    [oldEncodedPassword, onUpdateRes, intl],
+    [oldEncodedPassword, onUpdateRes, intl, isBiologyAuthSwitchOn, webAuthCredentialId],
   );
   return (
     <PasswordSetup

--- a/packages/kit/src/components/Password/container/PasswordUpdateContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordUpdateContainer.tsx
@@ -50,13 +50,16 @@ const PasswordUpdateContainer = ({
             mode,
           );
         onUpdateRes(updatedPassword);
-        // Save new password to secure storage for biometric unlock on extension
+        // Save new password to secure storage for biometric unlock on extension.
+        // Clear skipPrfCache to avoid an unexpected WebAuthn prompt if this
+        // dialog was opened within a promptPasswordVerify flow.
         if (
           platformEnv.isExtension &&
           isBiologyAuthSwitchOn &&
           webAuthCredentialId
         ) {
           try {
+            await backgroundApiProxy.servicePassword.setSkipPrfCache(false);
             await biologyAuthUtils.savePassword(updatedPassword);
           } catch (e) {
             console.error('Failed to save new password to secure storage:', e);

--- a/packages/kit/src/components/Password/container/PasswordUpdateContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordUpdateContainer.tsx
@@ -6,8 +6,11 @@ import { Toast } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { biologyAuthUtils } from '@onekeyhq/kit-bg/src/services/ServicePassword/biologyAuthUtils';
-import { usePasswordModeAtom, usePasswordPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  usePasswordModeAtom,
+  usePasswordPersistAtom,
+  useSettingsPersistAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EPasswordMode } from '@onekeyhq/shared/types/password';
@@ -72,7 +75,13 @@ const PasswordUpdateContainer = ({
       }
       setLoading(false);
     },
-    [oldEncodedPassword, onUpdateRes, intl, isBiologyAuthSwitchOn, webAuthCredentialId],
+    [
+      oldEncodedPassword,
+      onUpdateRes,
+      intl,
+      isBiologyAuthSwitchOn,
+      webAuthCredentialId,
+    ],
   );
   return (
     <PasswordSetup

--- a/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
@@ -261,11 +261,13 @@ const PasswordVerifyContainer = ({
           } catch {
             // No secure password stored — fall through to credential-only
           }
-          // Fallback: old behavior (credential-only verification)
+          // Fallback: old behavior (credential-only verification).
+          // Call checkWebAuth directly — note it may retry getPassword()
+          // internally but the PRF master key should be cached from the
+          // first attempt, avoiding a redundant user prompt.
           const result = await checkWebAuth();
           if (result) {
             await callOnVerifyRes(typeof result === 'string' ? result : '');
-
             setVerifiedStatus();
           } else {
             throw new OneKeyLocalError('biology auth verify error');

--- a/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
@@ -264,7 +264,8 @@ const PasswordVerifyContainer = ({
           // Fallback: old behavior (credential-only verification)
           const result = await checkWebAuth();
           if (result) {
-            await callOnVerifyRes('');
+            await callOnVerifyRes(typeof result === 'string' ? result : '');
+
             setVerifiedStatus();
           } else {
             throw new OneKeyLocalError('biology auth verify error');

--- a/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
@@ -398,13 +398,17 @@ const PasswordVerifyContainer = ({
         }
         await callOnVerifyRes(verifiedPassword);
         setVerifiedStatus();
-        // Save to secure storage for future biometric unlock on extension
+        // Save to secure storage for future biometric unlock on extension.
+        // Clear skipPrfCache first — the flag is set during promptPasswordVerify
+        // to force real WebAuthn for the biometric button, but password
+        // verification has already succeeded here so it's safe to use cache.
         if (
           platformEnv.isExtension &&
           isBiologyAuthSwitchOn &&
           webAuthCredentialId
         ) {
           try {
+            await backgroundApiProxy.servicePassword.setSkipPrfCache(false);
             await biologyAuthUtils.savePassword(verifiedPassword);
           } catch (e) {
             console.error('Failed to save password to secure storage:', e);

--- a/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
@@ -5,8 +5,6 @@ import { useIntl } from 'react-intl';
 
 import { SizableText, Stack } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { biologyAuthUtils } from '@onekeyhq/kit-bg/src/services/ServicePassword/biologyAuthUtils';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
   usePasswordAtom,
@@ -88,17 +86,21 @@ const PasswordVerifyContainer = ({
   }, [webAuthCredentialId, isBiologyAuthSwitchOn]);
 
   useEffect(() => {
-    if (isEnable && isBiologyAuthSwitchOn) {
+    const shouldCheck =
+      (isEnable || (platformEnv.isExtension && !!webAuthCredentialId)) &&
+      isBiologyAuthSwitchOn;
+    if (shouldCheck) {
       void (async () => {
         try {
-          const securePassword = await biologyAuthUtils.getPassword();
-          setHasSecurePassword(!!securePassword);
+          const hasPassword =
+            await backgroundApiProxy.servicePassword.hasWebAuthPassword();
+          setHasSecurePassword(hasPassword);
         } catch (_e) {
           setHasSecurePassword(false);
         }
       })();
     }
-  }, [isEnable, isBiologyAuthSwitchOn]);
+  }, [isEnable, isBiologyAuthSwitchOn, webAuthCredentialId]);
 
   const passwordVerifyStatusRef = useRef(passwordVerifyStatus);
   useEffect(() => {
@@ -148,7 +150,7 @@ const PasswordVerifyContainer = ({
         isBiologyAuthSwitchOn &&
         verifyPeriodBiologyEnable &&
         ((isEnable && hasSecurePassword) ||
-          (!!webAuthCredentialId && !!hasCachedPassword))
+          (!!webAuthCredentialId && (!!hasCachedPassword || hasSecurePassword)))
       );
     },
     [
@@ -242,6 +244,24 @@ const PasswordVerifyContainer = ({
       }));
       try {
         if (isExtLockNoCachePassword) {
+          // Try to retrieve password from secure storage (WebAuthn PRF)
+          try {
+            const securePassword =
+              await backgroundApiProxy.servicePassword.getWebAuthPassword();
+            if (securePassword) {
+              const verifiedPassword =
+                await backgroundApiProxy.servicePassword.verifyPassword({
+                  password: securePassword,
+                  passwordMode,
+                });
+              await callOnVerifyRes(verifiedPassword);
+              setVerifiedStatus();
+              return;
+            }
+          } catch {
+            // No secure password stored — fall through to credential-only
+          }
+          // Fallback: old behavior (credential-only verification)
           const result = await checkWebAuth();
           if (result) {
             await callOnVerifyRes('');
@@ -374,6 +394,20 @@ const PasswordVerifyContainer = ({
         }
         await callOnVerifyRes(verifiedPassword);
         setVerifiedStatus();
+        // Save to secure storage for future biometric unlock on extension
+        if (
+          platformEnv.isExtension &&
+          isBiologyAuthSwitchOn &&
+          webAuthCredentialId
+        ) {
+          try {
+            await backgroundApiProxy.servicePassword.saveWebAuthPassword(
+              verifiedPassword,
+            );
+          } catch (e) {
+            console.error('Failed to save password to secure storage:', e);
+          }
+        }
       } catch (e) {
         const errorWithFlag = e as Error & { isCallbackError?: boolean };
         const isCallbackError = errorWithFlag?.isCallbackError === true;
@@ -455,6 +489,8 @@ const PasswordVerifyContainer = ({
       unlockPeriodPasswordArray,
       callOnVerifyRes,
       setVerifiedStatus,
+      isBiologyAuthSwitchOn,
+      webAuthCredentialId,
     ],
   );
 

--- a/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
@@ -5,6 +5,8 @@ import { useIntl } from 'react-intl';
 
 import { SizableText, Stack } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { biologyAuthUtils } from '@onekeyhq/kit-bg/src/services/ServicePassword/biologyAuthUtils';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
   usePasswordAtom,
@@ -92,8 +94,7 @@ const PasswordVerifyContainer = ({
     if (shouldCheck) {
       void (async () => {
         try {
-          const hasPassword =
-            await backgroundApiProxy.servicePassword.hasWebAuthPassword();
+          const hasPassword = await biologyAuthUtils.hasPassword();
           setHasSecurePassword(hasPassword);
         } catch (_e) {
           setHasSecurePassword(false);
@@ -246,8 +247,7 @@ const PasswordVerifyContainer = ({
         if (isExtLockNoCachePassword) {
           // Try to retrieve password from secure storage (WebAuthn PRF)
           try {
-            const securePassword =
-              await backgroundApiProxy.servicePassword.getWebAuthPassword();
+            const securePassword = await biologyAuthUtils.getPassword();
             if (securePassword) {
               const verifiedPassword =
                 await backgroundApiProxy.servicePassword.verifyPassword({
@@ -290,6 +290,7 @@ const PasswordVerifyContainer = ({
           }
         }
       } catch (e: any) {
+        console.error('onBiologyAuthenticate error', e);
         const error = e as {
           message?: string;
           cause?: string;
@@ -401,9 +402,7 @@ const PasswordVerifyContainer = ({
           webAuthCredentialId
         ) {
           try {
-            await backgroundApiProxy.servicePassword.saveWebAuthPassword(
-              verifiedPassword,
-            );
+            await biologyAuthUtils.savePassword(verifiedPassword);
           } catch (e) {
             console.error('Failed to save password to secure storage:', e);
           }

--- a/packages/shared/src/buildTimeEnv.js
+++ b/packages/shared/src/buildTimeEnv.js
@@ -20,6 +20,7 @@ const isE2E = process.env.E2E_MODE === 'true';
 
 const enablePerfMonitor = process.env.PERF_MONITOR_ENABLED === '1';
 
+
 module.exports = {
   isJest,
   isDev,

--- a/packages/shared/src/buildTimeEnv.js
+++ b/packages/shared/src/buildTimeEnv.js
@@ -20,7 +20,6 @@ const isE2E = process.env.E2E_MODE === 'true';
 
 const enablePerfMonitor = process.env.PERF_MONITOR_ENABLED === '1';
 
-
 module.exports = {
   isJest,
   isDev,

--- a/packages/shared/src/storage/SupabaseStorage/SupabaseStorage.ts
+++ b/packages/shared/src/storage/SupabaseStorage/SupabaseStorage.ts
@@ -9,7 +9,7 @@ import { SUPABASE_STORAGE_KEY_PREFIX } from './consts';
 const shouldUseSecureStorage = cacheUtils.memoizee(
   async () => {
     const isSupportSecureStorage =
-      await secureStorageInstance.supportSecureStorage();
+      await secureStorageInstance.supportSecureStorageWithoutInteraction();
     if (!isSupportSecureStorage) {
       return false;
     }

--- a/packages/shared/src/storage/secureStorage/index.desktop.ts
+++ b/packages/shared/src/storage/secureStorage/index.desktop.ts
@@ -37,6 +37,9 @@ const storage: ISecureStorage = {
     const value = await getSecureItem(key);
     return !!value;
   },
+  async supportSecureStorageWithoutInteraction(): Promise<boolean> {
+    return supportSecureStorage();
+  },
   setSecureItemWithBiometrics(_key, _data, _options) {
     // TODO: mac use keychain to set secure item
     throw new OneKeyLocalError('use webauthn/keychain to set secure item');

--- a/packages/shared/src/storage/secureStorage/index.desktop.ts
+++ b/packages/shared/src/storage/secureStorage/index.desktop.ts
@@ -33,6 +33,10 @@ const storage: ISecureStorage = {
   getSecureItem,
   removeSecureItem,
   supportSecureStorage,
+  async hasSecureItem(key: string): Promise<boolean> {
+    const value = await getSecureItem(key);
+    return !!value;
+  },
   setSecureItemWithBiometrics(_key, _data, _options) {
     // TODO: mac use keychain to set secure item
     throw new OneKeyLocalError('use webauthn/keychain to set secure item');

--- a/packages/shared/src/storage/secureStorage/index.native.ts
+++ b/packages/shared/src/storage/secureStorage/index.native.ts
@@ -27,6 +27,10 @@ const storage: ISecureStorage = {
   getSecureItem,
   removeSecureItem,
   supportSecureStorage,
+  async hasSecureItem(key: string): Promise<boolean> {
+    const value = await getItemAsync(key, keychainOptions);
+    return !!value;
+  },
   setSecureItemWithBiometrics(key, data, options) {
     return setItemAsync(key, data, {
       ...keychainOptions,

--- a/packages/shared/src/storage/secureStorage/index.native.ts
+++ b/packages/shared/src/storage/secureStorage/index.native.ts
@@ -31,6 +31,9 @@ const storage: ISecureStorage = {
     const value = await getItemAsync(key, keychainOptions);
     return !!value;
   },
+  async supportSecureStorageWithoutInteraction(): Promise<boolean> {
+    return supportSecureStorage();
+  },
   setSecureItemWithBiometrics(key, data, options) {
     return setItemAsync(key, data, {
       ...keychainOptions,

--- a/packages/shared/src/storage/secureStorage/index.ts
+++ b/packages/shared/src/storage/secureStorage/index.ts
@@ -275,6 +275,10 @@ const storage: ISecureStorage = {
     if (platformEnv.isExtensionBackground) {
       return false;
     }
+    // Only enable PRF-based secure storage for extension UI, not bare web platform
+    if (!platformEnv.isExtension) {
+      return false;
+    }
     return isPrfSupported();
   },
 

--- a/packages/shared/src/storage/secureStorage/index.ts
+++ b/packages/shared/src/storage/secureStorage/index.ts
@@ -286,6 +286,10 @@ const storage: ISecureStorage = {
     return !!encryptedData;
   },
 
+  async supportSecureStorageWithoutInteraction(): Promise<boolean> {
+    return false;
+  },
+
   async setSecureItemWithBiometrics(
     key: string,
     data: string,

--- a/packages/shared/src/storage/secureStorage/index.ts
+++ b/packages/shared/src/storage/secureStorage/index.ts
@@ -1,6 +1,7 @@
 /* oxlint-disable @typescript-eslint/no-unused-vars, @cspell/spellchecker */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { OneKeyLocalError } from '../../errors';
+import platformEnv from '../../platformEnv';
 import { webStorage } from '../instance/webStorageInstance';
 
 import {
@@ -267,14 +268,19 @@ const storage: ISecureStorage = {
   },
 
   async supportSecureStorage(): Promise<boolean> {
-    // Synchronous check - basic browser support
-    // For full PRF support check, use isPrfSupported() async function
-    // return isPrfSupported();
+    // WebAuthn PRF requires UI context — not available in extension background/service worker
+    if (platformEnv.isExtensionBackground) {
+      return false;
+    }
+    return isPrfSupported();
+  },
 
-    // TODO: remove this after test
-    // Note: On extension and web platforms, creating a mnemonic wallet will always require biometric verification by design,
-    // regardless of whether the user chooses to enable biometrics. This is because the password UI component does not synchronize this state.
-    return false;
+  async hasSecureItem(key: string): Promise<boolean> {
+    const encryptedData = await webStorage.getItem(
+      getSecureKey(key),
+      undefined,
+    );
+    return !!encryptedData;
   },
 
   async setSecureItemWithBiometrics(

--- a/packages/shared/src/storage/secureStorage/index.ts
+++ b/packages/shared/src/storage/secureStorage/index.ts
@@ -1,7 +1,9 @@
 /* oxlint-disable @typescript-eslint/no-unused-vars, @cspell/spellchecker */
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import appGlobals from '../../appGlobals';
 import { OneKeyLocalError } from '../../errors';
 import platformEnv from '../../platformEnv';
+import bufferUtils from '../../utils/bufferUtils';
 import { webStorage } from '../instance/webStorageInstance';
 
 import {
@@ -29,25 +31,29 @@ const SECURE_STORAGE_KEY_PREFIX = '$secure$:';
 // Storage key for credential transports (for user hints)
 const PRF_CREDENTIAL_TRANSPORTS_KEY = '$secure_prf_credential_transports$';
 
-// Master key cache (in-memory only, cleared on page reload)
-let cachedMasterKey: Uint8Array | null = null;
-let masterKeyCacheTimestamp = 0;
-// Cache duration: 5 minutes (can be adjusted based on security requirements)
-const MASTER_KEY_CACHE_DURATION_MS = 5 * 60 * 1000;
-
-// Clear the master key cache
-function clearMasterKeyCache(): void {
-  cachedMasterKey = null;
-  masterKeyCacheTimestamp = 0;
+// PRF master key cache helpers — cache is stored in background (ServicePassword)
+async function getCachedPrfMasterKey(): Promise<Uint8Array | null> {
+  try {
+    const hex =
+      await appGlobals.$backgroundApiProxy.servicePassword.getCachedPrfMasterKey();
+    if (hex) {
+      return bufferUtils.hexToBytes(hex);
+    }
+  } catch {
+    // background not ready
+  }
+  return null;
 }
 
-// Check if cached master key is still valid
-function isMasterKeyCacheValid(): boolean {
-  if (!cachedMasterKey) {
-    return false;
+async function setCachedPrfMasterKey(masterKey: Uint8Array): Promise<void> {
+  try {
+    const hex = bufferUtils.bytesToHex(masterKey);
+    await appGlobals.$backgroundApiProxy.servicePassword.setCachedPrfMasterKey(
+      hex,
+    );
+  } catch {
+    // background not ready
   }
-  const now = Date.now();
-  return now - masterKeyCacheTimestamp < MASTER_KEY_CACHE_DURATION_MS;
 }
 
 // Get stored salt
@@ -165,12 +171,13 @@ async function getPrfKey(options?: {
 
 /**
  * Get the master key (unwrap from storage or create new)
- * Master key is cached in memory for better UX
+ * Master key is cached in background (ServicePassword) for better UX
  */
 async function getMasterKey(): Promise<Uint8Array | null> {
   // Return cached master key if valid
-  if (isMasterKeyCacheValid() && cachedMasterKey) {
-    return cachedMasterKey;
+  const cached = await getCachedPrfMasterKey();
+  if (cached) {
+    return cached;
   }
 
   // Get PRF key first
@@ -188,9 +195,7 @@ async function getMasterKey(): Promise<Uint8Array | null> {
     // Unwrap existing master key
     try {
       const masterKey = await unwrapMasterKey(prfKey, wrappedMasterKey);
-      // Cache the master key
-      cachedMasterKey = masterKey;
-      masterKeyCacheTimestamp = Date.now();
+      await setCachedPrfMasterKey(masterKey);
       return masterKey;
     } catch (error) {
       console.error('Failed to unwrap master key:', error);
@@ -205,9 +210,7 @@ async function getMasterKey(): Promise<Uint8Array | null> {
   const wrapped = await wrapMasterKey(prfKey, masterKey);
   await storeWrappedMasterKey(wrapped);
 
-  // Cache the master key
-  cachedMasterKey = masterKey;
-  masterKeyCacheTimestamp = Date.now();
+  await setCachedPrfMasterKey(masterKey);
 
   return masterKey;
 }
@@ -331,7 +334,6 @@ async function getStoredAuthenticatorDescription(): Promise<string> {
 export {
   getStoredCredentialTransports,
   getStoredAuthenticatorDescription,
-  clearMasterKeyCache,
   TRANSPORT_DESCRIPTIONS,
   getTransportDescription,
 };

--- a/packages/shared/src/storage/secureStorage/types.ts
+++ b/packages/shared/src/storage/secureStorage/types.ts
@@ -10,5 +10,6 @@ export interface ISecureStorage {
   getSecureItem(key: string): Promise<string | null>;
   removeSecureItem(key: string): Promise<void>;
   supportSecureStorage(): Promise<boolean>;
+  supportSecureStorageWithoutInteraction(): Promise<boolean>;
   hasSecureItem?(key: string): Promise<boolean>;
 }

--- a/packages/shared/src/storage/secureStorage/types.ts
+++ b/packages/shared/src/storage/secureStorage/types.ts
@@ -10,4 +10,5 @@ export interface ISecureStorage {
   getSecureItem(key: string): Promise<string | null>;
   removeSecureItem(key: string): Promise<void>;
   supportSecureStorage(): Promise<boolean>;
+  hasSecureItem?(key: string): Promise<boolean>;
 }

--- a/packages/shared/src/webAuth/index.ts
+++ b/packages/shared/src/webAuth/index.ts
@@ -15,7 +15,7 @@ export const base64Decode = function (base64: string): Uint8Array {
 };
 
 const isContextSupportWebAuth = Boolean(
-  platformEnv.isExtChrome && globalThis?.navigator?.credentials,
+  platformEnv.isExtension && globalThis?.navigator?.credentials,
 );
 
 const isUserVerifyingPlatformAuthenticatorAvailable = async () => {
@@ -39,11 +39,15 @@ const isCMA = async () => {
 export const isSupportWebAuth = async () => {
   let isSupport = false;
   if (!platformEnv.isE2E && isContextSupportWebAuth) {
-    isSupport =
-      (await isUserVerifyingPlatformAuthenticatorAvailable()) &&
-      (await isCMA());
+    const isUvPaaAvailable =
+      await isUserVerifyingPlatformAuthenticatorAvailable();
+    const isConditionalMediationAvailable = await isCMA();
+    isSupport = isUvPaaAvailable && isConditionalMediationAvailable;
   }
-  return isSupport && !!navigator?.credentials;
+
+  const finalSupport = isSupport && !!navigator?.credentials;
+
+  return finalSupport;
 };
 
 export const verifiedWebAuth = async (credId: string) => {


### PR DESCRIPTION
## Summary

- Move in-memory PRF master key cache from `secureStorage` module to `ServicePassword` background service for better lifecycle management across extension contexts (popup/background/content script)
- Replace `backgroundApiProxy.servicePassword` WebAuth wrapper methods (`getWebAuthPassword`, `saveWebAuthPassword`, `deleteWebAuthPassword`, `hasWebAuthPassword`) with direct `biologyAuthUtils` calls from UI layer, reducing unnecessary IPC round-trips
- Add `skipPrfCache` flag in `ServicePassword` to force real WebAuthn interaction when password dialog is shown, ensuring biometric verification is not silently bypassed by cache
- Save updated password to secure storage after password change when biometric unlock is enabled (extension)
- Verify and cache password after retrieving from secure storage via WebAuthn PRF

## Test plan

- [ ] Extension: Verify biometric (WebAuthn) unlock still works after locking
- [ ] Extension: Change password and verify biometric unlock uses new password
- [ ] Extension: Disable and re-enable biometric unlock
- [ ] Extension: Verify password dialog forces real WebAuthn interaction (not cached)
- [ ] Extension: Verify cache is cleared on app lock
- [ ] Desktop/Mobile: Verify no regressions in password flow (changes are extension-focused)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
