### PR TITLE
fix(ios): make RNSScreenStack deferred updates deterministic and deduplicated

### DIFF
--- a/patches/react-native-screens+4.23.0.patch
+++ b/patches/react-native-screens+4.23.0.patch
@@ -37,7 +37,7 @@ index 7055a0d..81ee02b 100644
      }
  
 diff --git a/node_modules/react-native-screens/ios/RNSScreenStack.mm b/node_modules/react-native-screens/ios/RNSScreenStack.mm
-index e37e40a..38eabd4 100644
+index e37e40a..dc5708b 100644
 --- a/node_modules/react-native-screens/ios/RNSScreenStack.mm
 +++ b/node_modules/react-native-screens/ios/RNSScreenStack.mm
 @@ -31,6 +31,20 @@
@@ -229,18 +229,16 @@ index e37e40a..38eabd4 100644
          // On iOS pre 12 we observed that `willShowViewController` delegate method does not always
          // get triggered when the navigation controller is instantiated. As the only thing we do in
          // that delegate method is ask nav header to update to the current state it does not hurt to
-@@ -467,6 +582,10 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -467,6 +582,8 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
  {
    // prevent re-entry
    if (_updatingModals) {
 +    RNSScreenStackLog([NSString stringWithFormat:@"setModalViewControllers: RE-ENTRY blocked, scheduling update (presentedModals=%lu, newControllers=%lu)",
 +          (unsigned long)_presentedModals.count, (unsigned long)controllers.count]);
-+    _pendingContainerUpdate = YES;
-+    [self schedulePendingContainerUpdateRetry:@"setModalViewControllers-reentry"];
      _scheduleModalsUpdate = YES;
      return;
    }
-@@ -475,12 +594,22 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -475,12 +592,22 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
    // accidently trigger modal dismiss if we don't verify to run the below code only when an actual
    // change in the list of presented modal was made.
    if ([_presentedModals isEqualToArray:controllers]) {
@@ -263,15 +261,34 @@ index e37e40a..38eabd4 100644
      return;
    }
  
-@@ -521,6 +650,7 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -521,14 +648,21 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
    __weak RNSScreenStackView *weakSelf = self;
  
    void (^afterTransitions)(void) = ^{
+-    [weakSelf emitOnFinishTransitioningEvent];
+-    weakSelf.updatingModals = NO;
+-    if (weakSelf.scheduleModalsUpdate) {
++    RNSScreenStackView *strongSelf = weakSelf;
++    if (!strongSelf) {
++      return;
++    }
 +    RNSScreenStackLog(@"setModalViewControllers: afterTransitions called");
-     [weakSelf emitOnFinishTransitioningEvent];
-     weakSelf.updatingModals = NO;
-     if (weakSelf.scheduleModalsUpdate) {
-@@ -536,6 +666,7 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
++    [strongSelf emitOnFinishTransitioningEvent];
++    strongSelf.updatingModals = NO;
++    if (strongSelf.scheduleModalsUpdate) {
+       // if modals update was requested during setModalViewControllers we set scheduleModalsUpdate
+       // flag in order to perform updates at a later point. Here we are done with all modals
+       // transitions and check this flag again. If it was set, we reset the flag and execute updates.
+-      weakSelf.scheduleModalsUpdate = NO;
+-      [weakSelf updateContainer];
++      strongSelf.scheduleModalsUpdate = NO;
++      // Clear pending retry state because we are about to run an immediate update now.
++      strongSelf->_pendingContainerUpdate = NO;
++      [strongSelf updateContainer];
+     }
+     // we trigger the update of orientation here because, when dismissing the modal from JS,
+     // neither `viewWillAppear` nor `presentationControllerDidDismiss` are called, same for status bar.
+@@ -536,6 +670,7 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
    };
  
    void (^finish)(void) = ^{
@@ -279,7 +296,7 @@ index e37e40a..38eabd4 100644
      NSUInteger oldCount = weakSelf.presentedModals.count;
      if (changeRootIndex < oldCount) {
        [weakSelf.presentedModals removeObjectsInRange:NSMakeRange(changeRootIndex, oldCount - changeRootIndex)];
-@@ -544,10 +675,8 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -544,10 +679,8 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
          changeRootController.parentViewController != nil || changeRootController.presentingViewController != nil;
  
      if (!isAttached || changeRootIndex >= controllers.count) {
@@ -292,7 +309,7 @@ index e37e40a..38eabd4 100644
        afterTransitions();
        return;
      }
-@@ -624,16 +753,28 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -624,16 +757,28 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
                ? static_cast<RNSScreen *>(firstModalToBeDismissed).screenView.stackAnimation !=
                    RNSScreenStackAnimationNone
                : YES;
@@ -325,7 +342,7 @@ index e37e40a..38eabd4 100644
                                  finish();
                                }];
          }
-@@ -670,12 +811,24 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -670,12 +815,24 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
  {
    // when there is no change we return immediately
    if ([_controller.viewControllers isEqualToArray:controllers]) {
@@ -350,7 +367,7 @@ index e37e40a..38eabd4 100644
      return;
    }
    // when transition is ongoing, any updates made to the controller will not be reflected until the
-@@ -685,6 +838,9 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -685,6 +842,9 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
    // making any updated when transition is ongoing and schedule updates for when the transition
    // is complete.
    if (_controller.transitionCoordinator != nil) {
@@ -360,7 +377,7 @@ index e37e40a..38eabd4 100644
      if (!_updateScheduled) {
        _updateScheduled = YES;
        __weak RNSScreenStackView *weakSelf = self;
-@@ -693,8 +849,14 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -693,8 +853,14 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
              // do nothing here, we only want to be notified when transition is complete
            }
            completion:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
@@ -371,13 +388,13 @@ index e37e40a..38eabd4 100644
 +              return;
 +            }
 +            strongSelf->_updateScheduled = NO;
-+            strongSelf->_pendingContainerUpdate = YES;
-+            [strongSelf schedulePendingContainerUpdateRetry:@"setPushViewControllers-transition-completion"];
++            // A direct update is performed below, so clear pending retry state to avoid duplicate updates.
++            strongSelf->_pendingContainerUpdate = NO;
 +            [strongSelf updateContainer];
            }];
      }
      return;
-@@ -750,8 +912,15 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -750,8 +916,15 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
        NSMutableArray *newControllers = [NSMutableArray arrayWithArray:controllers];
        [newControllers removeLastObject];
  
@@ -393,7 +410,7 @@ index e37e40a..38eabd4 100644
      } else {
        // don't really know what this case could be, but may need to handle it
        // somehow
-@@ -765,6 +934,8 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -765,6 +938,8 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
  
  - (void)updateContainer
  {
@@ -402,7 +419,7 @@ index e37e40a..38eabd4 100644
    NSMutableArray<UIViewController *> *pushControllers = [NSMutableArray new];
    NSMutableArray<UIViewController *> *modalControllers = [NSMutableArray new];
    for (RNSScreenView *screen in _reactSubviews) {
-@@ -868,13 +1039,17 @@ - (void)rnscreens_disableInteractions
+@@ -868,13 +1043,17 @@ - (void)rnscreens_disableInteractions
  {
    // When transitioning between screens, disable interactions on stack subview which wraps the screens
    // and sink all gesture events. This should work for nested stacks and stack inside bottom tabs, inside stack.

--- a/patches/react-native-screens+4.23.0.patch
+++ b/patches/react-native-screens+4.23.0.patch
@@ -1,3 +1,5 @@
+diff --git a/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt b/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+index 7055a0d..81ee02b 100644
 --- a/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
 +++ b/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
 @@ -17,6 +17,7 @@ import com.facebook.react.modules.core.ReactChoreographer
@@ -35,7 +37,7 @@
      }
  
 diff --git a/node_modules/react-native-screens/ios/RNSScreenStack.mm b/node_modules/react-native-screens/ios/RNSScreenStack.mm
-index e37e40a..32ca9f6 100644
+index e37e40a..f76720e 100644
 --- a/node_modules/react-native-screens/ios/RNSScreenStack.mm
 +++ b/node_modules/react-native-screens/ios/RNSScreenStack.mm
 @@ -31,6 +31,20 @@
@@ -59,15 +61,77 @@ index e37e40a..32ca9f6 100644
  #import "UIView+RNSUtility.h"
  #import "integrations/RNSDismissibleModalProtocol.h"
  #import "utils/UINavigationBar+RNSUtility.h"
-@@ -212,6 +226,7 @@ @implementation RNSScreenStackView {
+@@ -212,6 +226,9 @@ @implementation RNSScreenStackView {
    RNSPercentDrivenInteractiveTransition *_interactionController;
    __weak RNSScreenStackManager *_manager;
    BOOL _updateScheduled;
 +  BOOL _pendingContainerUpdate; // Set when push/modal updates are skipped due to window==nil
++  BOOL _pendingUpdateRetryScheduled; // Prevent duplicate retry scheduling
++  NSInteger _pendingUpdateRetryCount; // Guard against infinite retry loops
    UIPanGestureRecognizer *_sinkEventsPanGestureRecognizer;
  #ifdef RCT_NEW_ARCH_ENABLED
    /// Screens that are subject of `ShadowViewMutation::Type::Delete` mutation
-@@ -355,6 +370,11 @@ - (void)presentationControllerDidDismiss:(UIPresentationController *)presentatio
+@@ -346,6 +363,59 @@ - (void)presentationControllerDidDismiss:(UIPresentationController *)presentatio
+   }
+ }
+ 
++- (void)schedulePendingContainerUpdateRetry:(NSString *)reason
++{
++  if (_pendingUpdateRetryScheduled) {
++    return;
++  }
++  _pendingUpdateRetryScheduled = YES;
++
++  __weak RNSScreenStackView *weakSelf = self;
++  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(16 * NSEC_PER_MSEC)), dispatch_get_main_queue(), ^{
++    RNSScreenStackView *strongSelf = weakSelf;
++    if (!strongSelf) {
++      return;
++    }
++
++    strongSelf->_pendingUpdateRetryScheduled = NO;
++
++    if (!strongSelf->_pendingContainerUpdate) {
++      strongSelf->_pendingUpdateRetryCount = 0;
++      return;
++    }
++
++    const BOOL windowReady = strongSelf.window != nil;
++    const BOOL transitionBusy = strongSelf->_controller.transitionCoordinator != nil;
++    const BOOL shouldRetryLater = !windowReady || transitionBusy;
++
++    RNSScreenStackLog([NSString
++        stringWithFormat:@"schedulePendingContainerUpdateRetry: reason=%@, pending=%d, window=%@, transition=%@, retryCount=%ld",
++                         reason ?: @"NIL",
++                         strongSelf->_pendingContainerUpdate,
++                         windowReady ? @"YES" : @"NIL",
++                         transitionBusy ? @"YES" : @"NIL",
++                         (long)strongSelf->_pendingUpdateRetryCount]);
++
++    if (shouldRetryLater) {
++      strongSelf->_pendingUpdateRetryCount += 1;
++      if (strongSelf->_pendingUpdateRetryCount > 45) {
++        RNSScreenStackLog(@"schedulePendingContainerUpdateRetry: retry limit reached, forcing updateContainer once");
++        strongSelf->_pendingContainerUpdate = NO;
++        strongSelf->_pendingUpdateRetryCount = 0;
++        [strongSelf updateContainer];
++        return;
++      }
++      [strongSelf schedulePendingContainerUpdateRetry:@"window-or-transition-not-ready"];
++      return;
++    }
++
++    RNSScreenStackLog(@"schedulePendingContainerUpdateRetry: conditions met, running updateContainer");
++    strongSelf->_pendingContainerUpdate = NO;
++    strongSelf->_pendingUpdateRetryCount = 0;
++    [strongSelf updateContainer];
++  });
++}
++
+ RNS_IGNORE_SUPER_CALL_BEGIN
+ - (NSArray<UIView *> *)reactSubviews
+ {
+@@ -355,6 +425,11 @@ - (void)presentationControllerDidDismiss:(UIPresentationController *)presentatio
  
  - (void)didMoveToWindow
  {
@@ -79,7 +143,7 @@ index e37e40a..32ca9f6 100644
    [super didMoveToWindow];
  #ifdef RCT_NEW_ARCH_ENABLED
    // for handling nested stacks
-@@ -367,6 +387,15 @@ - (void)didMoveToWindow
+@@ -367,6 +442,14 @@ - (void)didMoveToWindow
      [self maybeAddToParentAndUpdateContainer];
    }
  #endif
@@ -87,15 +151,14 @@ index e37e40a..32ca9f6 100644
 +  // When window is restored after a detach (e.g. iOS 26 SwiftUI TabView recreating
 +  // UITabBarController), retry any push/modal operations that were skipped due to window==nil.
 +  if (self.window != nil && _pendingContainerUpdate) {
-+    RNSScreenStackLog(@"didMoveToWindow: retrying pending container update after window restored");
-+    _pendingContainerUpdate = NO;
-+    [self updateContainer];
++    RNSScreenStackLog(@"didMoveToWindow: scheduling pending container update retry after window restored");
++    [self schedulePendingContainerUpdateRetry:@"didMoveToWindow"];
 +  }
 +
    if (self.window == nil) {
      // When hot reload happens that would remove the whole stack, disabling the interaction on a screen out transition
      // will not be matched with enabling the interactions on another screen's in transition. We need to make sure
-@@ -379,12 +408,11 @@ - (void)maybeAddToParentAndUpdateContainer
+@@ -379,12 +462,11 @@ - (void)maybeAddToParentAndUpdateContainer
  {
    BOOL wasScreenMounted = _controller.parentViewController != nil;
    if (!self.window && !wasScreenMounted) {
@@ -111,7 +174,7 @@ index e37e40a..32ca9f6 100644
    [self updateContainer];
    if (!wasScreenMounted) {
      // when stack hasn't been added to parent VC yet we do two things:
-@@ -405,10 +433,43 @@ - (void)reactAddControllerToClosestParent:(UIViewController *)controller
+@@ -405,10 +487,43 @@ - (void)reactAddControllerToClosestParent:(UIViewController *)controller
  {
    if (!controller.parentViewController) {
      UIView *parentView = (UIView *)self.reactSuperview;
@@ -157,7 +220,7 @@ index e37e40a..32ca9f6 100644
  #if !TARGET_OS_TV
          _controller.interactivePopGestureRecognizer.delegate = self;
  #if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
-@@ -417,7 +478,7 @@ - (void)reactAddControllerToClosestParent:(UIViewController *)controller
+@@ -417,7 +532,7 @@ - (void)reactAddControllerToClosestParent:(UIViewController *)controller
          }
  #endif // Check for iOS >= 26.0
  #endif
@@ -166,16 +229,18 @@ index e37e40a..32ca9f6 100644
          // On iOS pre 12 we observed that `willShowViewController` delegate method does not always
          // get triggered when the navigation controller is instantiated. As the only thing we do in
          // that delegate method is ask nav header to update to the current state it does not hurt to
-@@ -467,6 +528,8 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -467,6 +582,10 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
  {
    // prevent re-entry
    if (_updatingModals) {
 +    RNSScreenStackLog([NSString stringWithFormat:@"setModalViewControllers: RE-ENTRY blocked, scheduling update (presentedModals=%lu, newControllers=%lu)",
 +          (unsigned long)_presentedModals.count, (unsigned long)controllers.count]);
++    _pendingContainerUpdate = YES;
++    [self schedulePendingContainerUpdateRetry:@"setModalViewControllers-reentry"];
      _scheduleModalsUpdate = YES;
      return;
    }
-@@ -475,12 +538,21 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -475,12 +594,22 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
    // accidently trigger modal dismiss if we don't verify to run the below code only when an actual
    // change in the list of presented modal was made.
    if ([_presentedModals isEqualToArray:controllers]) {
@@ -194,10 +259,11 @@ index e37e40a..32ca9f6 100644
    if (self.window == nil && _presentedModals.lastObject.view.window == nil) {
 +    RNSScreenStackLog(@"setModalViewControllers: SKIPPED - both window and lastModal.window are nil! setting _pendingContainerUpdate=YES");
 +    _pendingContainerUpdate = YES;
++    [self schedulePendingContainerUpdateRetry:@"setModalViewControllers-window-nil"];
      return;
    }
  
-@@ -521,6 +593,7 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -521,6 +650,7 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
    __weak RNSScreenStackView *weakSelf = self;
  
    void (^afterTransitions)(void) = ^{
@@ -205,7 +271,7 @@ index e37e40a..32ca9f6 100644
      [weakSelf emitOnFinishTransitioningEvent];
      weakSelf.updatingModals = NO;
      if (weakSelf.scheduleModalsUpdate) {
-@@ -536,6 +609,7 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -536,6 +666,7 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
    };
  
    void (^finish)(void) = ^{
@@ -213,7 +279,7 @@ index e37e40a..32ca9f6 100644
      NSUInteger oldCount = weakSelf.presentedModals.count;
      if (changeRootIndex < oldCount) {
        [weakSelf.presentedModals removeObjectsInRange:NSMakeRange(changeRootIndex, oldCount - changeRootIndex)];
-@@ -544,10 +618,8 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -544,10 +675,8 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
          changeRootController.parentViewController != nil || changeRootController.presentingViewController != nil;
  
      if (!isAttached || changeRootIndex >= controllers.count) {
@@ -226,7 +292,7 @@ index e37e40a..32ca9f6 100644
        afterTransitions();
        return;
      }
-@@ -624,16 +696,23 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -624,16 +753,25 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
                ? static_cast<RNSScreen *>(firstModalToBeDismissed).screenView.stackAnimation !=
                    RNSScreenStackAnimationNone
                : YES;
@@ -251,10 +317,12 @@ index e37e40a..32ca9f6 100644
                animateAlongsideTransition:nil
                                completion:^(id<UIViewControllerTransitionCoordinatorContext> _) {
 +                                RNSScreenStackLog(@"setModalViewControllers: transitionCoordinator completion called");
++                                weakSelf->_pendingContainerUpdate = YES;
++                                [weakSelf schedulePendingContainerUpdateRetry:@"setModalViewControllers-transitionCoordinator-completion"];
                                  finish();
                                }];
          }
-@@ -670,12 +749,23 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -670,12 +808,24 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
  {
    // when there is no change we return immediately
    if ([_controller.viewControllers isEqualToArray:controllers]) {
@@ -275,18 +343,30 @@ index e37e40a..32ca9f6 100644
 +    RNSScreenStackLog([NSString stringWithFormat:@"setPushViewControllers: SKIPPED - window is nil! superview=%@, class=%@, setting _pendingContainerUpdate=YES",
 +          self.superview, NSStringFromClass([self.superview class])]);
 +    _pendingContainerUpdate = YES;
++    [self schedulePendingContainerUpdateRetry:@"setPushViewControllers-window-nil"];
      return;
    }
    // when transition is ongoing, any updates made to the controller will not be reflected until the
-@@ -685,6 +775,7 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -685,6 +835,9 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
    // making any updated when transition is ongoing and schedule updates for when the transition
    // is complete.
    if (_controller.transitionCoordinator != nil) {
 +    RNSScreenStackLog(@"setPushViewControllers: DEFERRED - transitionCoordinator active");
++    _pendingContainerUpdate = YES;
++    [self schedulePendingContainerUpdateRetry:@"setPushViewControllers-transition-active"];
      if (!_updateScheduled) {
        _updateScheduled = YES;
        __weak RNSScreenStackView *weakSelf = self;
-@@ -750,8 +841,15 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -694,6 +847,8 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
+           }
+           completion:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
+             self->_updateScheduled = NO;
++            weakSelf->_pendingContainerUpdate = YES;
++            [weakSelf schedulePendingContainerUpdateRetry:@"setPushViewControllers-transition-completion"];
+             [weakSelf updateContainer];
+           }];
+     }
+@@ -750,8 +905,15 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
        NSMutableArray *newControllers = [NSMutableArray arrayWithArray:controllers];
        [newControllers removeLastObject];
  
@@ -302,7 +382,7 @@ index e37e40a..32ca9f6 100644
      } else {
        // don't really know what this case could be, but may need to handle it
        // somehow
-@@ -765,6 +863,8 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -765,6 +927,8 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
  
  - (void)updateContainer
  {
@@ -311,7 +391,7 @@ index e37e40a..32ca9f6 100644
    NSMutableArray<UIViewController *> *pushControllers = [NSMutableArray new];
    NSMutableArray<UIViewController *> *modalControllers = [NSMutableArray new];
    for (RNSScreenView *screen in _reactSubviews) {
-@@ -868,13 +968,17 @@ - (void)rnscreens_disableInteractions
+@@ -868,13 +1032,17 @@ - (void)rnscreens_disableInteractions
  {
    // When transitioning between screens, disable interactions on stack subview which wraps the screens
    // and sink all gesture events. This should work for nested stacks and stack inside bottom tabs, inside stack.

--- a/patches/react-native-screens+4.23.0.patch
+++ b/patches/react-native-screens+4.23.0.patch
@@ -292,7 +292,7 @@ index e37e40a..f76720e 100644
        afterTransitions();
        return;
      }
-@@ -624,16 +753,25 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -624,16 +753,23 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
                ? static_cast<RNSScreen *>(firstModalToBeDismissed).screenView.stackAnimation !=
                    RNSScreenStackAnimationNone
                : YES;
@@ -357,15 +357,6 @@ index e37e40a..f76720e 100644
      if (!_updateScheduled) {
        _updateScheduled = YES;
        __weak RNSScreenStackView *weakSelf = self;
-@@ -694,6 +847,8 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
-           }
-           completion:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
-             self->_updateScheduled = NO;
-+            weakSelf->_pendingContainerUpdate = YES;
-+            [weakSelf schedulePendingContainerUpdateRetry:@"setPushViewControllers-transition-completion"];
-             [weakSelf updateContainer];
-           }];
-     }
 @@ -750,8 +905,15 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
        NSMutableArray *newControllers = [NSMutableArray arrayWithArray:controllers];
        [newControllers removeLastObject];

--- a/patches/react-native-screens+4.23.0.patch
+++ b/patches/react-native-screens+4.23.0.patch
@@ -71,7 +71,7 @@ index e37e40a..dc5708b 100644
    UIPanGestureRecognizer *_sinkEventsPanGestureRecognizer;
  #ifdef RCT_NEW_ARCH_ENABLED
    /// Screens that are subject of `ShadowViewMutation::Type::Delete` mutation
-@@ -346,6 +363,59 @@ - (void)presentationControllerDidDismiss:(UIPresentationController *)presentatio
+@@ -346,6 +363,58 @@ - (void)presentationControllerDidDismiss:(UIPresentationController *)presentatio
    }
  }
  
@@ -111,10 +111,9 @@ index e37e40a..dc5708b 100644
 +    if (shouldRetryLater) {
 +      strongSelf->_pendingUpdateRetryCount += 1;
 +      if (strongSelf->_pendingUpdateRetryCount > 45) {
-+        RNSScreenStackLog(@"schedulePendingContainerUpdateRetry: retry limit reached, forcing updateContainer once");
-+        strongSelf->_pendingContainerUpdate = NO;
++        RNSScreenStackLog(@"schedulePendingContainerUpdateRetry: retry limit reached, giving up (will retry on didMoveToWindow)");
 +        strongSelf->_pendingUpdateRetryCount = 0;
-+        [strongSelf updateContainer];
++        // Leave _pendingContainerUpdate = YES so didMoveToWindow can pick it up later.
 +        return;
 +      }
 +      [strongSelf schedulePendingContainerUpdateRetry:@"window-or-transition-not-ready"];

--- a/patches/react-native-screens+4.23.0.patch
+++ b/patches/react-native-screens+4.23.0.patch
@@ -37,7 +37,7 @@ index 7055a0d..81ee02b 100644
      }
  
 diff --git a/node_modules/react-native-screens/ios/RNSScreenStack.mm b/node_modules/react-native-screens/ios/RNSScreenStack.mm
-index e37e40a..f76720e 100644
+index e37e40a..38eabd4 100644
 --- a/node_modules/react-native-screens/ios/RNSScreenStack.mm
 +++ b/node_modules/react-native-screens/ios/RNSScreenStack.mm
 @@ -31,6 +31,20 @@
@@ -292,7 +292,7 @@ index e37e40a..f76720e 100644
        afterTransitions();
        return;
      }
-@@ -624,16 +753,25 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -624,16 +753,28 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
                ? static_cast<RNSScreen *>(firstModalToBeDismissed).screenView.stackAnimation !=
                    RNSScreenStackAnimationNone
                : YES;
@@ -317,12 +317,15 @@ index e37e40a..f76720e 100644
                animateAlongsideTransition:nil
                                completion:^(id<UIViewControllerTransitionCoordinatorContext> _) {
 +                                RNSScreenStackLog(@"setModalViewControllers: transitionCoordinator completion called");
-+                                weakSelf->_pendingContainerUpdate = YES;
-+                                [weakSelf schedulePendingContainerUpdateRetry:@"setModalViewControllers-transitionCoordinator-completion"];
++                                RNSScreenStackView *strongSelf = weakSelf;
++                                if (strongSelf) {
++                                  strongSelf->_pendingContainerUpdate = YES;
++                                  [strongSelf schedulePendingContainerUpdateRetry:@"setModalViewControllers-transitionCoordinator-completion"];
++                                }
                                  finish();
                                }];
          }
-@@ -670,12 +808,24 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -670,12 +811,24 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
  {
    // when there is no change we return immediately
    if ([_controller.viewControllers isEqualToArray:controllers]) {
@@ -347,7 +350,7 @@ index e37e40a..f76720e 100644
      return;
    }
    // when transition is ongoing, any updates made to the controller will not be reflected until the
-@@ -685,6 +835,9 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -685,6 +838,9 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
    // making any updated when transition is ongoing and schedule updates for when the transition
    // is complete.
    if (_controller.transitionCoordinator != nil) {
@@ -357,7 +360,24 @@ index e37e40a..f76720e 100644
      if (!_updateScheduled) {
        _updateScheduled = YES;
        __weak RNSScreenStackView *weakSelf = self;
-@@ -750,8 +905,15 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -693,8 +849,14 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
+             // do nothing here, we only want to be notified when transition is complete
+           }
+           completion:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
+-            self->_updateScheduled = NO;
+-            [weakSelf updateContainer];
++            RNSScreenStackView *strongSelf = weakSelf;
++            if (!strongSelf) {
++              return;
++            }
++            strongSelf->_updateScheduled = NO;
++            strongSelf->_pendingContainerUpdate = YES;
++            [strongSelf schedulePendingContainerUpdateRetry:@"setPushViewControllers-transition-completion"];
++            [strongSelf updateContainer];
+           }];
+     }
+     return;
+@@ -750,8 +912,15 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
        NSMutableArray *newControllers = [NSMutableArray arrayWithArray:controllers];
        [newControllers removeLastObject];
  
@@ -373,7 +393,7 @@ index e37e40a..f76720e 100644
      } else {
        // don't really know what this case could be, but may need to handle it
        // somehow
-@@ -765,6 +927,8 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -765,6 +934,8 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
  
  - (void)updateContainer
  {
@@ -382,7 +402,7 @@ index e37e40a..f76720e 100644
    NSMutableArray<UIViewController *> *pushControllers = [NSMutableArray new];
    NSMutableArray<UIViewController *> *modalControllers = [NSMutableArray new];
    for (RNSScreenView *screen in _reactSubviews) {
-@@ -868,13 +1032,17 @@ - (void)rnscreens_disableInteractions
+@@ -868,13 +1039,17 @@ - (void)rnscreens_disableInteractions
  {
    // When transitioning between screens, disable interactions on stack subview which wraps the screens
    // and sink all gesture events. This should work for nested stacks and stack inside bottom tabs, inside stack.

--- a/patches/react-native-screens+4.23.0.patch
+++ b/patches/react-native-screens+4.23.0.patch
@@ -292,7 +292,7 @@ index e37e40a..f76720e 100644
        afterTransitions();
        return;
      }
-@@ -624,16 +753,23 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -624,16 +753,25 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
                ? static_cast<RNSScreen *>(firstModalToBeDismissed).screenView.stackAnimation !=
                    RNSScreenStackAnimationNone
                : YES;


### PR DESCRIPTION
## Summary

This PR stabilizes iOS navigation recovery in our patched `react-native-screens` (`RNSScreenStack.mm`) by introducing a bounded retry pump for truly deferred updates, and by removing duplicate-update paths discovered during review.

It addresses cases where `updateContainer` is skipped while:
- the stack is temporarily detached from window (`window == nil`), or
- a transition is still in progress (`transitionCoordinator != nil`).

## Why this change

In iOS 26 + SwiftUI TabView reattachment scenarios, we observed multi-step navigation completion that sometimes required extra user interaction to continue (dismiss/push chain not flushed immediately).

The native retry pump makes deferred updates self-healing, while preserving determinism by:
- retrying only when needed,
- bounding retry attempts,
- avoiding duplicate `updateContainer` executions.

## Key state flags

- `_pendingContainerUpdate`
: Marks that an update is pending because a prior update path was deferred/skipped.

- `_pendingUpdateRetryScheduled`
: Ensures only one retry timer is active at a time.

- `_pendingUpdateRetryCount`
: Retry loop guard (max 45 ticks, ~720ms).

- `_updateScheduled`
: Existing guard for transition-coordinator completion scheduling in push flows.

- `_scheduleModalsUpdate`
: Existing re-entry guard for modal updates while `_updatingModals` is true.

## What changed

### 1) Added bounded retry pump

`schedulePendingContainerUpdateRetry(reason)` now:
- runs on main thread every ~16ms,
- waits for `window != nil` and `transitionCoordinator == nil`,
- executes `updateContainer` once conditions are ready,
- clears pending state when executing,
- stops at retry limit to avoid infinite loops.

### 2) Hooked retry into genuinely deferred paths

- `didMoveToWindow` when pending update exists
- `setPushViewControllers` when `window == nil`
- `setPushViewControllers` when transition is active
- `setModalViewControllers` when both stack window and last modal window are nil
- `setModalViewControllers` foreign modal dismissal path (`transitionCoordinator` completion)

### 3) Fixed duplicate-update risks from review

- Push transition completion now clears pending before immediate update:
  - `strongSelf->_pendingContainerUpdate = NO;`
  - then `[strongSelf updateContainer];`

- Modal `afterTransitions` scheduled-update path now clears pending before immediate update to avoid retry-timer double fire.

- Removed extra retry scheduling in modal re-entry (`_updatingModals`) path and rely on existing `_scheduleModalsUpdate` mechanism.

### 4) Fixed weak-pointer dereference safety

In completion blocks, replaced direct weak ivar dereference pattern with strong reference promotion before ivar access:
- `RNSScreenStackView *strongSelf = weakSelf; if (strongSelf) { ... }`

This avoids potential `EXC_BAD_ACCESS` from `weakSelf->...` style access.

## Flow diagrams

### Push path (deferred + completion)

```mermaid
flowchart TD
    A[setPushViewControllers] --> B{window == nil?}
    B -- Yes --> C[set pending=YES\nschedule retry]
    B -- No --> D{transitionCoordinator != nil?}
    D -- Yes --> E[set pending=YES\nschedule retry\nregister completion]
    D -- No --> F[direct push/update path]
    E --> G[transition completion]
    G --> H[strongSelf guard]
    H --> I[set _updateScheduled=NO]
    I --> J[set pending=NO]
    J --> K[updateContainer once]
```

### Modal path (re-entry and transition completion)

```mermaid
flowchart TD
    A[setModalViewControllers] --> B{_updatingModals?}
    B -- Yes --> C[_scheduleModalsUpdate=YES\nreturn]
    B -- No --> D{window unavailable?}
    D -- Yes --> E[set pending=YES\nschedule retry\nreturn]
    D -- No --> F[normal modal reconcile]
    F --> G{foreign modal isBeingDismissed?}
    G -- Yes --> H[transition completion]
    H --> I[strongSelf guard]
    I --> J[set pending=YES\nschedule retry]
    J --> K[finish -> afterTransitions]
    K --> L{_scheduleModalsUpdate?}
    L -- Yes --> M[set pending=NO\nupdateContainer once]
```

## Behavioral guarantees

- Deferred updates are proactively replayed without requiring extra user interaction.
- Retry is bounded and single-flight.
- Immediate completion-based updates are not duplicated by retry timers.
- Weak-pointer completion paths are safe.

## Test Plan

- [ ] Reproduce URL_ACCOUNT scan flow on iOS 26 device (e.g. iPhone 17 Pro).
- [ ] Verify dismiss + push chain completes without extra touch/click.
- [ ] Verify retry logs converge before retry limit in normal flows.
- [ ] Verify no duplicate `updateContainer` bursts in push/modal completion paths.
- [ ] Verify regular push/pop and modal flows remain stable.
- [ ] Verify Android behavior unchanged.
