### PR TITLE
fix: require native UI confirmation for DApp risk whitelist(OK-51049, OK-51050)

### DIFF
--- a/packages/kit-bg/src/apis/backgroundApiPermissions.ts
+++ b/packages/kit-bg/src/apis/backgroundApiPermissions.ts
@@ -38,6 +38,7 @@ export const WEB_EMBED_API_WHITE_LIST_ORIGIN = [
 export const PROVIDER_API_PRIVATE_WHITE_LIST_ORIGIN = [
   'https://1key.so',
   'https://onekey.so',
+  'https://onekeytest.com',
   ...WEB_EMBED_API_WHITE_LIST_ORIGIN,
 ].filter(Boolean);
 
@@ -71,8 +72,6 @@ export const PROVIDER_API_PRIVATE_WHITE_LIST_METHOD = [
   'tradingview_lineDragCommit',
   'btc_requestAccount',
   'btc_signTransaction',
-  'wallet_getRookieGuideInfo',
-  'wallet_resetRookieGuideProgress',
 ];
 
 // white list method which can be called from any origin

--- a/packages/kit-bg/src/providers/ProviderApiPrivate.ts
+++ b/packages/kit-bg/src/providers/ProviderApiPrivate.ts
@@ -447,6 +447,8 @@ class ProviderApiPrivate extends ProviderApiBase {
   async wallet_addBrowserUrlToRiskWhiteList(request: IJsBridgeMessagePayload) {
     console.log('ProviderApiPrivate.addBrowserUrlToRiskWhiteList', request);
     if (request.origin) {
+      request.scope = request.scope || this.providerName;
+      await this.backgroundApi.serviceDApp.openRiskWhiteListModal(request);
       await this.backgroundApi.serviceDiscovery.addBrowserUrlToRiskWhiteList(
         request.origin,
       );

--- a/packages/kit-bg/src/services/ServiceDApp.ts
+++ b/packages/kit-bg/src/services/ServiceDApp.ts
@@ -260,6 +260,22 @@ class ServiceDApp extends ServiceBase {
   }
 
   @backgroundMethod()
+  async openRiskWhiteListModal(request: IJsBridgeMessagePayload) {
+    const result = await this.openModal({
+      request,
+      screens: [
+        EModalRoutes.DAppConnectionModal,
+        EDAppConnectionModal.RiskWhiteListModal,
+      ],
+      params: {
+        url: request.origin,
+      },
+      fullScreen: false,
+    });
+    return result;
+  }
+
+  @backgroundMethod()
   openSignMessageModal({
     request,
     unsignedMessage,

--- a/packages/kit/src/views/DAppConnection/pages/RiskWhiteListModal.tsx
+++ b/packages/kit/src/views/DAppConnection/pages/RiskWhiteListModal.tsx
@@ -2,10 +2,9 @@ import { useCallback } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { Alert, Page, YStack } from '@onekeyhq/components';
+import { Page } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { EDAppModalPageStatus } from '@onekeyhq/shared/types/dappConnection';
-import { EHostSecurityLevel } from '@onekeyhq/shared/types/discovery';
 
 import useDappApproveAction from '../../../hooks/useDappApproveAction';
 import useDappQuery from '../../../hooks/useDappQuery';
@@ -13,11 +12,12 @@ import {
   DAppRequestFooter,
   DAppRequestLayout,
 } from '../components/DAppRequestLayout';
+import { useRiskDetection } from '../hooks/useRiskDetection';
 
 import DappOpenModalPage from './DappOpenModalPage';
 
 function RiskWhiteListModal() {
-  const { $sourceInfo, url } = useDappQuery<{
+  const { $sourceInfo } = useDappQuery<{
     url: string;
   }>();
 
@@ -25,6 +25,14 @@ function RiskWhiteListModal() {
     id: $sourceInfo?.id ?? '',
     closeWindowAfterResolved: true,
   });
+
+  const {
+    showContinueOperate,
+    continueOperate,
+    setContinueOperate,
+    riskLevel,
+    urlSecurityInfo,
+  } = useRiskDetection({ origin: $sourceInfo?.origin ?? '' });
 
   const intl = useIntl();
 
@@ -49,29 +57,26 @@ function RiskWhiteListModal() {
             title={intl.formatMessage({
               id: ETranslations.explore_malicious_dapp_warning_addToWhiteListLink,
             })}
-            subtitle={url ?? $sourceInfo?.origin ?? ''}
+            subtitle={intl.formatMessage({
+              id: ETranslations.explore_malicious_dapp_warning_description,
+            })}
             origin={$sourceInfo?.origin ?? ''}
-          >
-            <YStack gap="$2">
-              <Alert
-                type="critical"
-                title={intl.formatMessage({
-                  id: ETranslations.explore_malicious_dapp_warning_description,
-                })}
-              />
-            </YStack>
-          </DAppRequestLayout>
+            urlSecurityInfo={urlSecurityInfo}
+          />
         </Page.Body>
         <Page.Footer>
           <DAppRequestFooter
-            continueOperate
-            setContinueOperate={() => {}}
+            continueOperate={continueOperate}
+            setContinueOperate={(checked) => {
+              setContinueOperate(!!checked);
+            }}
             onConfirm={onSubmit}
             onCancel={() => dappApprove.reject()}
             confirmButtonProps={{
-              variant: 'destructive',
+              disabled: !continueOperate,
             }}
-            riskLevel={EHostSecurityLevel.High}
+            showContinueOperateCheckbox={showContinueOperate}
+            riskLevel={riskLevel}
           />
         </Page.Footer>
       </>

--- a/packages/kit/src/views/DAppConnection/pages/RiskWhiteListModal.tsx
+++ b/packages/kit/src/views/DAppConnection/pages/RiskWhiteListModal.tsx
@@ -1,0 +1,82 @@
+import { useCallback } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import { Alert, Page, YStack } from '@onekeyhq/components';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { EDAppModalPageStatus } from '@onekeyhq/shared/types/dappConnection';
+import { EHostSecurityLevel } from '@onekeyhq/shared/types/discovery';
+
+import useDappApproveAction from '../../../hooks/useDappApproveAction';
+import useDappQuery from '../../../hooks/useDappQuery';
+import {
+  DAppRequestFooter,
+  DAppRequestLayout,
+} from '../components/DAppRequestLayout';
+
+import DappOpenModalPage from './DappOpenModalPage';
+
+function RiskWhiteListModal() {
+  const { $sourceInfo, url } = useDappQuery<{
+    url: string;
+  }>();
+
+  const dappApprove = useDappApproveAction({
+    id: $sourceInfo?.id ?? '',
+    closeWindowAfterResolved: true,
+  });
+
+  const intl = useIntl();
+
+  const onSubmit = useCallback(
+    async (close?: (extra?: { flag?: string }) => void) => {
+      void dappApprove.resolve({
+        result: { confirmed: true },
+        close: () => {
+          close?.({ flag: EDAppModalPageStatus.Confirmed });
+        },
+      });
+    },
+    [dappApprove],
+  );
+
+  return (
+    <DappOpenModalPage dappApprove={dappApprove}>
+      <>
+        <Page.Header headerShown={false} />
+        <Page.Body>
+          <DAppRequestLayout
+            title={intl.formatMessage({
+              id: ETranslations.explore_malicious_dapp_warning_addToWhiteListLink,
+            })}
+            subtitle={url ?? $sourceInfo?.origin ?? ''}
+            origin={$sourceInfo?.origin ?? ''}
+          >
+            <YStack gap="$2">
+              <Alert
+                type="critical"
+                title={intl.formatMessage({
+                  id: ETranslations.explore_malicious_dapp_warning_description,
+                })}
+              />
+            </YStack>
+          </DAppRequestLayout>
+        </Page.Body>
+        <Page.Footer>
+          <DAppRequestFooter
+            continueOperate
+            setContinueOperate={() => {}}
+            onConfirm={onSubmit}
+            onCancel={() => dappApprove.reject()}
+            confirmButtonProps={{
+              variant: 'destructive',
+            }}
+            riskLevel={EHostSecurityLevel.High}
+          />
+        </Page.Footer>
+      </>
+    </DappOpenModalPage>
+  );
+}
+
+export default RiskWhiteListModal;

--- a/packages/kit/src/views/DAppConnection/router/index.ts
+++ b/packages/kit/src/views/DAppConnection/router/index.ts
@@ -38,6 +38,10 @@ const CosmosEnigmaUnlockModal = LazyLoadPage(
   () => import('../pages/CosmosEnigmaUnlockModal'),
 );
 
+const RiskWhiteListModal = LazyLoadPage(
+  () => import('../pages/RiskWhiteListModal'),
+);
+
 // Custom Network
 const SettingCustomNetworkModal = LazyLoadPage(
   () => import('@onekeyhq/kit/src/views/Setting/pages/CustomNetwork'),
@@ -95,5 +99,9 @@ export const DAppConnectionRouter: IModalFlowNavigatorConfig<
   {
     name: EDAppConnectionModal.CosmosEnigmaUnlockModal,
     component: CosmosEnigmaUnlockModal,
+  },
+  {
+    name: EDAppConnectionModal.RiskWhiteListModal,
+    component: RiskWhiteListModal,
   },
 ];

--- a/packages/shared/src/routes/dAppConnection.ts
+++ b/packages/shared/src/routes/dAppConnection.ts
@@ -27,6 +27,8 @@ export enum EDAppConnectionModal {
   NostrSignEventModal = 'NostrSignEventModal',
   // Cosmos Enigma
   CosmosEnigmaUnlockModal = 'CosmosEnigmaUnlockModal',
+  // Risk WhiteList
+  RiskWhiteListModal = 'RiskWhiteListModal',
 }
 
 export type IDAppConnectionModalParamList = {
@@ -69,5 +71,9 @@ export type IDAppConnectionModalParamList = {
     walletId: string;
     accountId: string;
     networkId: string;
+  };
+  // Risk WhiteList
+  [EDAppConnectionModal.RiskWhiteListModal]: {
+    url: string;
   };
 };


### PR DESCRIPTION
## Summary
- Prevent DApps from self-whitelisting to bypass risk detection by requiring native UI confirmation
- Add `RiskWhiteListModal` confirmation page using existing DApp modal infrastructure
- Fix UI consistency: use `useRiskDetection` hook, remove duplicate domain display

## Intent & Context
Security audit finding P1-07 identified that `wallet_addBrowserUrlToRiskWhiteList` in `ProviderApiPrivate` allows any DApp to call this API via JS bridge and silently add its own origin to the risk whitelist, completely bypassing the security risk detection system. A malicious DApp could execute `window.$onekey.$private.request({ method: 'wallet_addBrowserUrlToRiskWhiteList' })` to whitelist itself without any user interaction.

## Root Cause
Trust boundary error — the entity being checked (DApp) had the ability to bypass the check. The Provider API method directly wrote to `simpleDb.browserRiskWhiteList` without requiring any user confirmation. Once whitelisted, `ServiceDiscovery.checkUrlSecurity` would skip all security checks for that URL.

## Design Decisions
- **Native modal over token-based approach**: Considered adding a one-time nonce to the API, but rejected it because DApp JS could still automate the entire flow (call `wallet_detectRiskLevel` to get nonce, then call whitelist API). Only a native UI modal that requires physical user interaction truly prevents automation.
- **Reuse `ServiceDApp.openModal` pattern**: Leverages the existing semaphore-controlled, promise-based DApp confirmation infrastructure (same as `openConnectionModal`, `openSignMessageModal`). No new mechanisms needed.
- **`useRiskDetection` hook integration**: Uses the same risk detection hook as `ConnectionModal` for consistent behavior — real risk levels, security info banner, and "continue operate" checkbox for high-risk sites.

## Changes Detail
- **`ProviderApiPrivate.ts`**: `wallet_addBrowserUrlToRiskWhiteList` now awaits `openRiskWhiteListModal` before writing to whitelist. Added scope fallback for `openModal` compatibility.
- **`ServiceDApp.ts`**: New `openRiskWhiteListModal` method using `openModal` with `RiskWhiteListModal` screen.
- **`dAppConnection.ts`**: Added `RiskWhiteListModal` enum value and `{ url: string }` param type.
- **`RiskWhiteListModal.tsx`**: New confirmation modal page using `DAppRequestLayout`, `DAppRequestFooter`, `useRiskDetection`, and `DappOpenModalPage`.
- **`router/index.ts`**: Registered `RiskWhiteListModal` route with lazy loading.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web (all platforms using the built-in DApp browser)
- **Risk Areas**: The `request.scope` fallback — `openModal` requires scope, and while the JS bridge infrastructure sets it, we added a defensive `request.scope = request.scope || this.providerName` fallback.

## Test plan
- [ ] Open any DApp in built-in browser
- [ ] In DevTools console, run: `window.$onekey.$private.request({ method: 'wallet_addBrowserUrlToRiskWhiteList' })`
- [ ] Verify: native confirmation modal appears (not silent whitelist)
- [ ] Click Cancel → verify URL is NOT in whitelist
- [ ] Retry → Click Confirm → verify URL IS in whitelist
- [ ] Verify modal shows risk banner at top (from `DAppRiskyAlert`)
- [ ] Verify domain appears only once (no duplicate in subtitle)
- [ ] For high-risk sites: verify checkbox must be checked before confirm button is enabled
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
