### PR TITLE
fix: use supabase email for prime purchase

### DIFF
--- a/packages/kit/src/views/Prime/components/PrimePurchaseDialog/PrimePurchaseDialog.tsx
+++ b/packages/kit/src/views/Prime/components/PrimePurchaseDialog/PrimePurchaseDialog.tsx
@@ -30,7 +30,7 @@ export function usePrimePurchaseCallback({
   onPurchase?: () => void;
 } = {}) {
   const { purchasePackageNative, purchasePackageWeb } = usePrimePayment();
-  const { user } = useOneKeyAuth();
+  const { supabaseUser } = useOneKeyAuth();
   const intl = useIntl();
 
   const purchaseByWebview = usePurchasePackageWebview();
@@ -122,7 +122,7 @@ export function usePrimePurchaseCallback({
         if (selectedSubscriptionPeriod) {
           await purchasePackageWeb?.({
             subscriptionPeriod: selectedSubscriptionPeriod,
-            email: user?.email || '',
+            email: supabaseUser?.email || '',
             locale: intl.locale,
             featureName,
           });
@@ -139,12 +139,12 @@ export function usePrimePurchaseCallback({
       }
     },
     [
+      onPurchase,
       purchaseByNative,
       intl,
-      onPurchase,
-      purchasePackageWeb,
       purchaseByWebview,
-      user?.email,
+      purchasePackageWeb,
+      supabaseUser,
     ],
   );
 


### PR DESCRIPTION
## Summary
- switch Prime web purchase flow to use `supabaseUser.email` instead of the masked OneKey auth email
- ensure RevenueCat receives the raw email needed for checkout autofill

## Test plan
- [x] `ReadLints` on `PrimePurchaseDialog.tsx`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Prime/components/PrimePurchaseDialog/PrimePurchaseDialog.tsx`
- [x] `npx tsgo -p ./tsconfig.json --noEmit --tsBuildInfoFile "$(yarn config get cacheFolder)/.app-mono-ts-cache" --pretty`
- [x] runtime verification confirmed `supabaseUser.email` is passed through to `customerEmail`


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
