### PR TITLE
fix: prevent error toast flooding when network is unstable

### DIFF
--- a/packages/components/src/actions/Toast/index.tsx
+++ b/packages/components/src/actions/Toast/index.tsx
@@ -252,6 +252,9 @@ function toastMessage({
   onClose,
 }: IToastBaseProps) {
   const handleClose = handleToastId({ title, toastId, duration, onClose });
+  if (handleClose === undefined) {
+    return;
+  }
   return showMessage({
     renderContent: (props) => (
       <ToastContent
@@ -355,6 +358,9 @@ function toastNotification({
   onClose,
 }: IToastNotificationProps) {
   const handleClose = handleToastId({ title, toastId, duration, onClose });
+  if (handleClose === undefined) {
+    return;
+  }
   return showMessage({
     renderContent: (_props) => (
       <ToastNotificationContent

--- a/packages/kit/src/provider/Container/ErrorToastContainer/ErrorToastContainer.tsx
+++ b/packages/kit/src/provider/Container/ErrorToastContainer/ErrorToastContainer.tsx
@@ -6,14 +6,20 @@ import {
   EAppEventBusNames,
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { getErrorAction } from './ErrorToasts';
 
-// Get deduplication ID for HTTP status codes to prevent toast spam
-// @param httpStatusCode - HTTP status code (e.g., 403, 429, 503)
+// Get deduplication ID for error types to prevent toast spam
 const getDeduplicationId = (
   httpStatusCode?: number,
+  i18nKey?: string,
 ): { id: string | undefined; forceDeduplicate: boolean } => {
+  // Network connectivity errors - force deduplicate
+  if (i18nKey === ETranslations.global_network_error) {
+    return { id: 'error_network', forceDeduplicate: true };
+  }
+
   if (!httpStatusCode) return { id: undefined, forceDeduplicate: false };
 
   // Forbidden - force deduplicate
@@ -41,7 +47,10 @@ export function ErrorToastContainer() {
       const statusCodeForDeduplicate =
         p.httpStatusCode ??
         (typeof p.errorCode === 'number' ? p.errorCode : undefined);
-      const deduplication = getDeduplicationId(statusCodeForDeduplicate);
+      const deduplication = getDeduplicationId(
+        statusCodeForDeduplicate,
+        p.i18nKey,
+      );
       // For critical errors (403, 429, 5xx), force deduplication to prevent toast spam
       // Otherwise, respect custom toastId from caller
       const toastId = deduplication.forceDeduplicate

--- a/packages/kit/src/provider/Container/InAppNotification/index.tsx
+++ b/packages/kit/src/provider/Container/InAppNotification/index.tsx
@@ -517,7 +517,7 @@ const InAppNotification = () => {
               isRead: false,
             });
           }, 80);
-          toast.close();
+          toast?.close();
         },
       });
     };

--- a/packages/shared/src/errors/utils/errorToastUtils.ts
+++ b/packages/shared/src/errors/utils/errorToastUtils.ts
@@ -51,6 +51,10 @@ function fixAxiosAbortCancelError(error: unknown) {
 }
 
 let lastToastErrorInstance: IOneKeyError | undefined;
+let lastToastMessage: string | undefined;
+let lastToastTime = 0;
+const TOAST_MESSAGE_DEDUP_MS = 5000;
+
 function showToastOfError(error: IOneKeyError | unknown | undefined) {
   fixAxiosAbortCancelError(error);
   const err = error as IOneKeyError | undefined;
@@ -92,16 +96,24 @@ function showToastOfError(error: IOneKeyError | unknown | undefined) {
   }
   const isTriggered = err?.$$autoToastErrorTriggered;
   const isSameError = lastToastErrorInstance === err;
+  const now = Date.now();
+  const isSameMessage =
+    err?.message &&
+    err.message === lastToastMessage &&
+    now - lastToastTime < TOAST_MESSAGE_DEDUP_MS;
   // TODO log error to file if developer mode on
   if (
     err &&
     err?.autoToast &&
     !isTriggered &&
     !isSameError &&
+    !isSameMessage &&
     !shouldMuteToast
   ) {
     err.$$autoToastErrorTriggered = true;
     lastToastErrorInstance = err;
+    lastToastMessage = err.message;
+    lastToastTime = Date.now();
     void (async () => {
       const diagnosticText = await buildDiagnosticText(err);
 

--- a/packages/shared/src/errors/utils/errorToastUtils.ts
+++ b/packages/shared/src/errors/utils/errorToastUtils.ts
@@ -53,7 +53,7 @@ function fixAxiosAbortCancelError(error: unknown) {
 let lastToastErrorInstance: IOneKeyError | undefined;
 let lastToastMessage: string | undefined;
 let lastToastTime = 0;
-const TOAST_MESSAGE_DEDUP_MS = 5000;
+const TOAST_MESSAGE_DEDUPLICATE_MS = 5000;
 
 function showToastOfError(error: IOneKeyError | unknown | undefined) {
   fixAxiosAbortCancelError(error);
@@ -100,7 +100,7 @@ function showToastOfError(error: IOneKeyError | unknown | undefined) {
   const isSameMessage =
     err?.message &&
     err.message === lastToastMessage &&
-    now - lastToastTime < TOAST_MESSAGE_DEDUP_MS;
+    now - lastToastTime < TOAST_MESSAGE_DEDUPLICATE_MS;
   // TODO log error to file if developer mode on
   if (
     err &&


### PR DESCRIPTION
## Summary

When the network is unstable, multiple API requests fail simultaneously and each generates a toast notification. These toasts stack up and fill the entire screen. The root cause is a multi layer deduplication system that has three gaps allowing duplicate toasts through.

**Fix 1: handleToastId return value ignored (Toast component)**
The `handleToastId` function in `Toast/index.tsx` correctly detects duplicate toasts and returns `undefined`, but both `toastMessage()` and `toastNotification()` never check the return value. They proceed to call `showMessage()` regardless, making the entire dedup mechanism a no op. This fix adds the missing return value check.

**Fix 2: Network errors bypass ErrorToastContainer dedup**
`ErrorToastContainer` force deduplicates HTTP 403, 429, and 5xx errors, but network connectivity errors have no `httpStatusCode` and fall through without dedup. This fix detects network errors via `i18nKey` (`global_network_error`) and assigns them a force deduplicated toast ID.

**Fix 3: Same message flooding in showToastOfError**
`showToastOfError` only deduplicates by object reference (`lastToastErrorInstance === err`), but each failed request creates a new error instance, so reference comparison always fails. This fix adds a message level throttle that suppresses identical error messages within a 5 second window.

## Test plan

- [ ] Simulate unstable network (throttle to offline/online repeatedly) and verify only one error toast appears instead of many
- [ ] Verify airplane mode still shows a single network error toast
- [ ] Verify HTTP 403/429/5xx dedup still works as before
- [ ] Verify normal (non duplicate) error toasts still display correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
