### PR TITLE
fix(ios): camera preview not filling QR scan container

### DIFF
--- a/patches/react-native-camera-kit+17.0.1.patch
+++ b/patches/react-native-camera-kit+17.0.1.patch
@@ -1,9 +1,10 @@
 diff --git a/node_modules/react-native-camera-kit/ios/ReactNativeCameraKit/RealCamera.swift b/node_modules/react-native-camera-kit/ios/ReactNativeCameraKit/RealCamera.swift
+index 135a383..d7435c3 100644
 --- a/node_modules/react-native-camera-kit/ios/ReactNativeCameraKit/RealCamera.swift
 +++ b/node_modules/react-native-camera-kit/ios/ReactNativeCameraKit/RealCamera.swift
-@@ -112,35 +112,36 @@
+@@ -112,34 +112,35 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
      // MARK: - Public
-
+ 
      func setup(cameraType: CameraType, supportedBarcodeType: [CodeFormat]) {
 -        // cameraPreview.session = ... causes begin/commitConfiguration on the current thread
 -        // so it must be on the same thread as setupCaptureSession to avoid startRunning executing inbetween
@@ -15,7 +16,7 @@ diff --git a/node_modules/react-native-camera-kit/ios/ReactNativeCameraKit/RealC
 -
              self.initializeMotionManager()
 +        }
-
+ 
 -            // Setup the capture session.
 -            // In general, it is not safe to mutate an AVCaptureSession or any of its inputs, outputs, or connections from multiple threads at the same time.
 -            // Why not do all of this on the main queue?
@@ -24,12 +25,6 @@ diff --git a/node_modules/react-native-camera-kit/ios/ReactNativeCameraKit/RealC
 -            self.sessionQueue.async {
 -                self.setupResult = self.setupCaptureSession(
 -                    cameraType: cameraType, supportedBarcodeType: supportedBarcodeType)
--
--                self.addObservers()
--
--                if self.setupResult == .success {
--                    self.session.startRunning()
--                }
 +        // Setup the capture session.
 +        // In general, it is not safe to mutate an AVCaptureSession or any of its inputs, outputs, or connections from multiple threads at the same time.
 +        // Why not do all of this on the main queue?
@@ -38,16 +33,20 @@ diff --git a/node_modules/react-native-camera-kit/ios/ReactNativeCameraKit/RealC
 +        self.sessionQueue.async {
 +            self.setupResult = self.setupCaptureSession(
 +                cameraType: cameraType, supportedBarcodeType: supportedBarcodeType)
-
+ 
+-                self.addObservers()
++            self.addObservers()
+ 
+-                if self.setupResult == .success {
+-                    self.session.startRunning()
+-                }
++            if self.setupResult == .success {
++                self.session.startRunning()
++            }
+ 
 -                DispatchQueue.main.async {
 -                    self.setVideoOrientationToInterfaceOrientation()
 -                }
-+            self.addObservers()
-+
-+            if self.setupResult == .success {
-+                self.session.startRunning()
-             }
-+
 +            // Defer preview layer session assignment until after startRunning() completes.
 +            // Setting previewLayer.session internally triggers beginConfiguration/commitConfiguration
 +            // on the AVCaptureSession. If this overlaps with startRunning(), AVFoundation throws
@@ -56,12 +55,19 @@ diff --git a/node_modules/react-native-camera-kit/ios/ReactNativeCameraKit/RealC
 +            // sequencing of the AVCaptureSession configuration lifecycle. (Fixes REACT-NATIVE-1EZ)
 +            DispatchQueue.main.async {
 +                self.cameraPreview.session = self.session
-+                self.cameraPreview.previewLayer.videoGravity = .resizeAspect
++                self.cameraPreview.previewLayer.videoGravity = self.resizeMode == .cover ? .resizeAspectFill : .resizeAspect
 +                self.setVideoOrientationToInterfaceOrientation()
-+            }
+             }
          }
      }
-
+@@ -347,6 +348,7 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
+     }
+ 
+     func update(resizeMode: ResizeMode) {
++        self.resizeMode = resizeMode
+         DispatchQueue.main.async {
+             switch resizeMode {
+             case .cover:
 diff --git a/node_modules/react-native-camera-kit/src/Camera.android.tsx b/node_modules/react-native-camera-kit/src/Camera.android.tsx
 index 56cddbc..ae14ea0 100644
 --- a/node_modules/react-native-camera-kit/src/Camera.android.tsx
@@ -69,7 +75,7 @@ index 56cddbc..ae14ea0 100644
 @@ -8,15 +8,6 @@ import NativeCameraKitModule from './specs/NativeCameraKitModule';
  const Camera = React.forwardRef<CameraApi, CameraProps>((props, ref) => {
    const nativeRef = React.useRef(null);
-
+ 
 -  // RN doesn't support optional view props yet (sigh)
 -  // so we have to use -1 to indicate 'undefined'
 -  // All int/float/double props from src/specs/CameraNativeComponent.ts need be mentioned here
@@ -85,7 +91,7 @@ index 56cddbc..ae14ea0 100644
 @@ -29,7 +20,17 @@ const Camera = React.forwardRef<CameraApi, CameraProps>((props, ref) => {
      },
    }));
-
+ 
 -  const transformedProps: CameraProps = { ...props };
 +  // RN doesn't support optional view props yet (sigh)
 +  // so we have to use -1 to indicate 'undefined'
@@ -129,15 +135,15 @@ index 0845d6d..5a4f841 100644
 +    resetFocusTimeout: props.resetFocusTimeout ?? 0,
 +    resetFocusWhenMotionDetected: props.resetFocusWhenMotionDetected ?? true,
 +  };
-
+ 
    React.useImperativeHandle(ref, () => ({
      capture: async () => {
 @@ -34,7 +36,7 @@ const Camera = React.forwardRef<CameraApi, CameraProps>((props, ref) => {
    }));
-
+ 
    // @ts-expect-error props for codegen differ a bit from the user-facing ones
 -  return <NativeCamera style={{ minWidth: 100, minHeight: 100 }} ref={nativeRef} {...props} />;
 +  return <NativeCamera style={{ minWidth: 100, minHeight: 100 }} ref={nativeRef} {...propsWithDefaults} />;
  });
-
+ 
  export default Camera;


### PR DESCRIPTION
## Summary
- Fix iOS QR code scanner camera preview not filling the rounded rectangle container
- Root cause: race condition in `react-native-camera-kit` where `setup()` hardcodes `videoGravity = .resizeAspect` after async session setup, overwriting the `resizeMode="cover"` prop
- Patch `RealCamera.swift` to use `self.resizeMode` dynamically in `setup()` and persist the value in `update(resizeMode:)`

## Test plan
- [x] Open QR code scanner on iOS
- [x] Verify camera preview fills the entire rounded rectangle container (no white gaps)
- [x] Verify QR code scanning still works correctly
- [x] Verify Android QR scanner is not affected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
