### PR TITLE
fix(desktop): skip-GPG env variable not injected as string

### DIFF
--- a/apps/desktop/scripts/build.js
+++ b/apps/desktop/scripts/build.js
@@ -116,13 +116,15 @@ build({
     'process.env.SENTRY_DSN_WEB': JSON.stringify(
       process.env.SENTRY_DSN_WEB || '',
     ),
-    'process.env.ONEKEY_ALLOW_SKIP_GPG_VERIFICATION': (
-      process.env.ONEKEY_ALLOW_SKIP_GPG_VERIFICATION
-        ? process.env.ONEKEY_ALLOW_SKIP_GPG_VERIFICATION === 'true'
-        : process.env.NODE_ENV !== 'production'
-    )
-      ? 'true'
-      : 'false',
+    'process.env.ONEKEY_ALLOW_SKIP_GPG_VERIFICATION': JSON.stringify(
+      (
+        process.env.ONEKEY_ALLOW_SKIP_GPG_VERIFICATION
+          ? process.env.ONEKEY_ALLOW_SKIP_GPG_VERIFICATION === 'true'
+          : process.env.NODE_ENV !== 'production'
+      )
+        ? 'true'
+        : 'false',
+    ),
   },
 })
   .then(() => {


### PR DESCRIPTION
## Summary
- esbuild `define` was injecting `ONEKEY_ALLOW_SKIP_GPG_VERIFICATION` as boolean `true` instead of string `"true"`
- This caused `process.env.ONEKEY_ALLOW_SKIP_GPG_VERIFICATION === 'true'` to always evaluate to `false` at runtime
- Wrapped the define value with `JSON.stringify()` to ensure correct string comparison

## Test plan
- [x] Build with `ONEKEY_ALLOW_SKIP_GPG_VERIFICATION=true NODE_ENV=production` → `isSkipGpgVerificationAllowed` returns `true`
- [x] Build without the env var in production → returns `false`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
