### PR TITLE
fix: reset import method to Address when network doesn't support publ…

### DIFF
--- a/packages/kit/src/views/Onboarding/pages/ImportWallet/hooks/useImportAddressForm.ts
+++ b/packages/kit/src/views/Onboarding/pages/ImportWallet/hooks/useImportAddressForm.ts
@@ -210,6 +210,12 @@ export function useImportAddressForm({
     [networkIdText, networksResp.publicKeyExportEnabled],
   );
 
+  useEffect(() => {
+    if (!isKeyExportEnabled && method === EImportMethod.PublicKey) {
+      setMethod(EImportMethod.Address);
+    }
+  }, [isKeyExportEnabled, method]);
+
   const { isSoftwareWalletOnlyUser } = useUserWalletProfile();
   const isPublicKeyImport = useMemo(
     () => method === EImportMethod.PublicKey && isKeyExportEnabled,


### PR DESCRIPTION
…ic key export

When user switches from PublicKey tab to a network that doesn't support public key export, the method state was not reset to Address. This caused isEnable to still check validateResult (public key validation) instead of address validation, keeping the confirm button disabled even after entering a valid address.

Fixes OK-50413
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
