### PR TITLE
fix(earn): prevent expanded content overlap on tab switch in TableList OK-51116 OK-50804

### DIFF
--- a/packages/kit/src/components/ListView/TableList.tsx
+++ b/packages/kit/src/components/ListView/TableList.tsx
@@ -494,6 +494,10 @@ function TableListRow<T>({
           opacity={isExpanded ? 1 : 0}
           maxHeight={isExpanded ? 1000 : 0}
           overflow="hidden"
+          {...(!isExpanded && {
+            pointerEvents: 'none' as const,
+            display: 'none' as const,
+          })}
         >
           {expandable.renderExpandedContent(item, index)}
         </YStack>


### PR DESCRIPTION
Add display:none + pointerEvents:none when row is collapsed to prevent spring animation desync from leaking expanded content after tab switch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
