### PR TITLE
fix: use resetAboveMainRoute for scan navigation to avoid iOS window-nil freeze

### DIFF
--- a/.claude/skills/1k-feature-guides/references/rules/page-and-route.md
+++ b/.claude/skills/1k-feature-guides/references/rules/page-and-route.md
@@ -369,6 +369,29 @@ navigation.navigate(ERootRoutes.Main, {
 - Ensures proper back button behavior
 - Avoids memory leaks from accumulated screens
 
+### ⚠️ WARNING: `pop: true` Can Cause iOS Tab Freeze
+
+When `navigate(pop: true)` is called and the target tab's inner stack has pages to pop, the popped pages' `RNSScreenStack` instances get detached from the iOS window hierarchy (`window=NIL`). These orphaned stacks enter a retry storm (50 retries × 100ms × multiple timers), blocking the native main thread for ~5 seconds and freezing the tab transition.
+
+**Symptom**: Tab switch appears stuck; the user must touch the screen to advance the route.
+
+**Root cause**: `pop: true` pops the target tab's inner stack back to root. If those pages contain nested `RNSScreenStack` (e.g., UrlAccountPage), the popped stacks lose their window and retry indefinitely.
+
+**Mitigation**: `switchTab()` has been optimized to check the current active tab via `getRootState()` — if the target tab is already active, the `navigate(pop: true)` call is skipped entirely, avoiding the retry storm. If you need to navigate within the same tab, use `StackActions.replace` instead of pop + push to avoid orphaning screen stacks:
+
+```typescript
+// ❌ WRONG: switchTab(pop:true) then push causes retry storm on iOS
+navigation.switchTab(ETabRoutes.Home);  // pops existing pages
+navigation.push(newPage);               // pushes new page — but pop already caused freeze
+
+// ✅ CORRECT: Replace existing page in-place
+resetAboveMainRoute();                  // remove overlays
+await timerUtils.wait(100);
+rootNavigationRef.current?.dispatch(
+  StackActions.replace(targetRoute, params),  // no pop, no orphaned stacks
+);
+```
+
 ---
 
 ## Native Tab View Navigation Safety

--- a/packages/components/src/forms/Input/index.tsx
+++ b/packages/components/src/forms/Input/index.tsx
@@ -327,7 +327,7 @@ function BaseInput(
           /*
           const result = await start({
             handlers: [],
-            autoHandleResult: false,
+            autoExecuteParsedAction: false,
           });
           form.setValue('input', result.raw);
           */
@@ -336,7 +336,7 @@ function BaseInput(
           }
           const result = await startScanQrCode?.({
             handlers: [],
-            autoHandleResult: false,
+            autoExecuteParsedAction: false,
           });
           if (result?.raw) {
             onChangeText?.(result.raw || '');

--- a/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
@@ -135,22 +135,40 @@ export function NavigationContainer(props: IBasicNavigationContainerProps) {
   );
 }
 
+const getActiveTabFromRef = (
+  ref: typeof rootNavigationRef,
+): string | undefined => {
+  const s = ref.current?.getRootState();
+  if (!s) return undefined;
+  const main = s.routes?.find((r) => r.name === ERootRoutes.Main);
+  const idx = main?.state?.index ?? 0;
+  return main?.state?.routes?.[idx]?.name;
+};
+
 export const switchTab = (route: ETabRoutes) => {
-  // Skip if already on the target tab to avoid unnecessary navigate(pop:true)
-  // which triggers RNSScreenStack retry storms on iOS when the tab's inner
-  // stack has pages that get popped and orphaned (window=NIL).
-  const state = rootNavigationRef.current?.getRootState();
-  const mainRoute = state?.routes?.find((r) => r.name === ERootRoutes.Main);
-  const currentTabIndex = mainRoute?.state?.index ?? 0;
-  const currentTab = mainRoute?.state?.routes?.[currentTabIndex];
-  if (currentTab?.name === route) {
-    return;
-  }
+  // Skip per-ref navigate if already on the target tab to avoid unnecessary
+  // navigate(pop:true) which triggers RNSScreenStack retry storms on iOS
+  // when the tab's inner stack has pages that get popped and orphaned.
+  const rootActiveTab = getActiveTabFromRef(rootNavigationRef);
 
   defaultLogger.app.router.switchTab(route);
 
   setTimeout(() => {
-    tabletMainViewNavigationRef.current?.navigate(
+    const tabletActiveTab = getActiveTabFromRef(tabletMainViewNavigationRef);
+    if (tabletActiveTab !== undefined && tabletActiveTab !== route) {
+      tabletMainViewNavigationRef.current?.navigate(
+        ERootRoutes.Main,
+        {
+          screen: route,
+        },
+        {
+          pop: true,
+        },
+      );
+    }
+  });
+  if (rootActiveTab !== route) {
+    rootNavigationRef.current?.navigate(
       ERootRoutes.Main,
       {
         screen: route,
@@ -159,16 +177,7 @@ export const switchTab = (route: ETabRoutes) => {
         pop: true,
       },
     );
-  });
-  rootNavigationRef.current?.navigate(
-    ERootRoutes.Main,
-    {
-      screen: route,
-    },
-    {
-      pop: true,
-    },
-  );
+  }
 
   defaultLogger.app.router.switchTabDone(route);
 };

--- a/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
@@ -26,10 +26,7 @@ import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { updateRootViewBackgroundColor } from '@onekeyhq/shared/src/modules3rdParty/rootview-background';
 import { navigationIntegration } from '@onekeyhq/shared/src/modules3rdParty/sentry';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import type {
-  ETabRoutes,
-  ITabStackParamList,
-} from '@onekeyhq/shared/src/routes';
+import type { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalRoutes, ERootRoutes } from '@onekeyhq/shared/src/routes';
 import mmkvStorageInstance from '@onekeyhq/shared/src/storage/instance/mmkvStorageInstance';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';

--- a/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
@@ -135,12 +135,18 @@ export function NavigationContainer(props: IBasicNavigationContainerProps) {
   );
 }
 
-export const switchTab = <T extends ETabRoutes>(
-  route: T,
-  params?: {
-    params?: ITabStackParamList[T][keyof ITabStackParamList[T]];
-  },
-) => {
+export const switchTab = (route: ETabRoutes) => {
+  // Skip if already on the target tab to avoid unnecessary navigate(pop:true)
+  // which triggers RNSScreenStack retry storms on iOS when the tab's inner
+  // stack has pages that get popped and orphaned (window=NIL).
+  const state = rootNavigationRef.current?.getRootState();
+  const mainRoute = state?.routes?.find((r) => r.name === ERootRoutes.Main);
+  const currentTabIndex = mainRoute?.state?.index ?? 0;
+  const currentTab = mainRoute?.state?.routes?.[currentTabIndex];
+  if (currentTab?.name === route) {
+    return;
+  }
+
   defaultLogger.app.router.switchTab(route);
 
   setTimeout(() => {
@@ -148,7 +154,6 @@ export const switchTab = <T extends ETabRoutes>(
       ERootRoutes.Main,
       {
         screen: route,
-        params,
       },
       {
         pop: true,
@@ -159,7 +164,6 @@ export const switchTab = <T extends ETabRoutes>(
     ERootRoutes.Main,
     {
       screen: route,
-      params,
     },
     {
       pop: true,

--- a/packages/kit-bg/src/services/ServiceScanQRCode/utils/parseQRCode/type.ts
+++ b/packages/kit-bg/src/services/ServiceScanQRCode/utils/parseQRCode/type.ts
@@ -119,7 +119,13 @@ export type IQRCodeHandlerParseResult<T extends IBaseValue> =
 export type IQRCodeHandlerParseOutsideOptions = {
   handlers?: EQRCodeHandlerNames[];
   defaultHandler?: (value: string) => void;
-  autoHandleResult?: boolean;
+  /**
+   * When true, parse() executes built-in side effects for recognized payloads
+   * (navigation, WalletConnect connect, reward/update redirects, etc.).
+   * When false, parse() only returns parsed data and leaves follow-up actions
+   * to the caller.
+   */
+  autoExecuteParsedAction?: boolean;
   popNavigation?: boolean;
   account?: INetworkAccount;
   network?: IServerNetwork;

--- a/packages/kit/src/components/AccountSelector/hooks/useCreateQrWallet.tsx
+++ b/packages/kit/src/components/AccountSelector/hooks/useCreateQrWallet.tsx
@@ -117,7 +117,7 @@ export function useCreateQrWallet() {
       const scanResult = await startScan({
         handlers: [EQRCodeHandlerNames.animation],
         qrWalletScene: true,
-        autoHandleResult: false,
+        autoExecuteParsedAction: false,
       });
       const fullURText = scanResult.raw?.trim();
       console.log('startScan:', fullURText);

--- a/packages/kit/src/components/AddressInput/AddressInputHyperlinkText.tsx
+++ b/packages/kit/src/components/AddressInput/AddressInputHyperlinkText.tsx
@@ -77,7 +77,7 @@ export function AddressInputHyperlinkText({
       testID={testID ? `${testID}-message` : undefined}
       translationId={error?.message as ETranslations}
       defaultMessage={error?.message as ETranslations}
-      autoHandleResult={false}
+      autoExecuteParsedAction={false}
       onAction={onAction}
     />
   );

--- a/packages/kit/src/components/AddressInput/plugins/scan.tsx
+++ b/packages/kit/src/components/AddressInput/plugins/scan.tsx
@@ -41,7 +41,7 @@ export function ScanPlugin({
         EQRCodeHandlerNames.sui,
         EQRCodeHandlerNames.lightningNetwork,
       ],
-      autoHandleResult: false,
+      autoExecuteParsedAction: false,
     })) as IQRCodeHandlerParseResult<IChainValue>;
     console.log('scaned result', result);
     onChange?.({

--- a/packages/kit/src/components/Hardware/HardwareDialog.tsx
+++ b/packages/kit/src/components/Hardware/HardwareDialog.tsx
@@ -189,7 +189,7 @@ function WebDeviceAccessDialogContent({
       <HyperlinkText
         size="$bodyLg"
         translationId={ETranslations.device_reconnect_from_beginning}
-        autoHandleResult={false}
+        autoExecuteParsedAction={false}
         onAction={() => {
           void promptWebUsbDeviceAccess();
         }}

--- a/packages/kit/src/components/HyperlinkText/index.tsx
+++ b/packages/kit/src/components/HyperlinkText/index.tsx
@@ -26,7 +26,11 @@ export type IHyperlinkTextProps = {
     string,
     string | ReactElement | ((v: string) => ReactElement | string)
   >;
-  autoHandleResult?: boolean;
+  /**
+   * Whether a recognized URL should trigger built-in navigation/action side
+   * effects immediately, instead of returning parsed data for the caller.
+   */
+  autoExecuteParsedAction?: boolean;
   urlTextProps?: ISizableTextProps;
   actionTextProps?: ISizableTextProps;
   underlineTextProps?: ISizableTextProps;
@@ -53,7 +57,8 @@ export function HyperlinkText({
   onAction,
   children,
   values,
-  autoHandleResult = true,
+  // HyperlinkText is action-oriented, so auto execution is enabled by default.
+  autoExecuteParsedAction = true,
   urlTextProps,
   actionTextProps,
   underlineTextProps,
@@ -132,14 +137,14 @@ export function HyperlinkText({
                             EQRCodeHandlerNames.updatePreview,
                           ],
                           qrWalletScene: false,
-                          autoHandleResult,
+                          autoExecuteParsedAction,
                           defaultHandler: openUrlExternal,
                         });
                       }
                     }}
                   >
                     {isLinkString ? chunks : link}
-                    {autoHandleResult ? ' ↗' : null}
+                    {autoExecuteParsedAction ? ' ↗' : null}
                   </SizableText>
                 );
               },
@@ -201,7 +206,7 @@ export function HyperlinkText({
       onAction,
       urlTextProps,
       parseQRCode,
-      autoHandleResult,
+      autoExecuteParsedAction,
       scriptFontSize,
       subscriptsTextProps,
       underlineTextProps,

--- a/packages/kit/src/components/MoreActionButton/index.tsx
+++ b/packages/kit/src/components/MoreActionButton/index.tsx
@@ -155,7 +155,7 @@ function MoreActionContentHeader({
     await closePopover?.();
     await scanQrCode.start({
       handlers: scanQrCode.PARSE_HANDLER_NAMES.all,
-      autoHandleResult: true,
+      autoExecuteParsedAction: true,
       account,
       network,
       tokens: {
@@ -917,7 +917,7 @@ function MoreActionGeneralGrid() {
   const handleScan = useCallback(async () => {
     await scanQrCode.start({
       handlers: scanQrCode.PARSE_HANDLER_NAMES.all,
-      autoHandleResult: true,
+      autoExecuteParsedAction: true,
       account,
       network,
       tokens: {

--- a/packages/kit/src/hooks/useWalletBanner.ts
+++ b/packages/kit/src/hooks/useWalletBanner.ts
@@ -80,7 +80,7 @@ function useWalletBanner({
             EQRCodeHandlerNames.updatePreview,
           ],
           qrWalletScene: false,
-          autoHandleResult: true,
+          autoExecuteParsedAction: true,
           defaultHandler: openUrlExternal,
           account,
           network,

--- a/packages/kit/src/provider/Container/AirGapQrcodeDialogContainer/AirGapQrcodeDialogContainer.tsx
+++ b/packages/kit/src/provider/Container/AirGapQrcodeDialogContainer/AirGapQrcodeDialogContainer.tsx
@@ -43,7 +43,7 @@ export function AirGapQrcodeDialogContainer() {
             const result = await startScan({
               handlers: [EQRCodeHandlerNames.animation],
               qrWalletScene: true,
-              autoHandleResult: false,
+              autoExecuteParsedAction: false,
             });
             console.log(
               'AirGapQrcodeDialogContainer__startScan',

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/QRWalletGallery/QRWalletGallery.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/QRWalletGallery/QRWalletGallery.tsx
@@ -105,7 +105,7 @@ function CustomAppRequestDeviceQR() {
           const scanResult = await startScan({
             handlers: [EQRCodeHandlerNames.animation],
             qrWalletScene: true,
-            autoHandleResult: false,
+            autoExecuteParsedAction: false,
           });
           const animatedData = scanResult.data as IAnimationValue;
           const qrcode = animatedData.fullData || scanResult.raw || '';

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/QRWalletGallery/QRWalletGalleryImportAccount.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/QRWalletGallery/QRWalletGalleryImportAccount.tsx
@@ -46,7 +46,7 @@ UR:CRYPTO-HDKEY/2-2/LPAOAOCSGECYBAKIYLATHDDAJEECAAHDCXLTFSZMLYRTDLGMHFCNZCCTVWCM
           > = async () => {
             const scanResult = await scanQrCode.start({
               handlers: scanQrCode.PARSE_HANDLER_NAMES.animation,
-              autoHandleResult: false,
+              autoExecuteParsedAction: false,
               qrWalletScene: true,
               showProTutorial: true,
             });

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/ScanQrCode.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/ScanQrCode.tsx
@@ -44,7 +44,7 @@ const ScanQRCodeGallery = () => {
   const [map] = useAllTokenListMapAtom();
   const openScanQrCodeModal = useCallback(
     async (values: {
-      autoHandleResult: boolean;
+      autoExecuteParsedAction: boolean;
       qrWalletScene?: boolean;
       showProTutorial?: boolean;
     }) => {
@@ -75,7 +75,9 @@ const ScanQRCodeGallery = () => {
           title: '命令式弹出 Modal(自动处理)',
           element: (
             <Button
-              onPress={() => openScanQrCodeModal({ autoHandleResult: true })}
+              onPress={() =>
+                openScanQrCodeModal({ autoExecuteParsedAction: true })
+              }
             >
               打开
             </Button>
@@ -88,7 +90,7 @@ const ScanQRCodeGallery = () => {
             <Button
               onPress={() =>
                 openScanQrCodeModal({
-                  autoHandleResult: false,
+                  autoExecuteParsedAction: false,
                   qrWalletScene: true,
                   showProTutorial: false,
                 })
@@ -105,7 +107,7 @@ const ScanQRCodeGallery = () => {
             <Button
               onPress={() =>
                 openScanQrCodeModal({
-                  autoHandleResult: false,
+                  autoExecuteParsedAction: false,
                   qrWalletScene: true,
                   showProTutorial: true,
                 })

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/SecureQRToast.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/SecureQRToast.tsx
@@ -92,7 +92,7 @@ const SecureQRToastGallery = () => {
                   onConfirm: async () => {
                     await toast.close();
                     await scanQrCode.start({
-                      autoHandleResult: true,
+                      autoExecuteParsedAction: true,
                       handlers: scanQrCode.PARSE_HANDLER_NAMES.all,
                     });
                   },

--- a/packages/kit/src/views/Home/pages/urlAccount/urlAccountUtils.ts
+++ b/packages/kit/src/views/Home/pages/urlAccount/urlAccountUtils.ts
@@ -2,6 +2,7 @@ import { StackActions } from '@react-navigation/native';
 
 import {
   navigateFromOverlayToTab,
+  resetAboveMainRoute,
   rootNavigationRef,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
@@ -241,15 +242,26 @@ export const urlAccountNavigation = {
       realNetworkIdFallback: params.networkId || '',
       contextNetworkId: params.contextNetworkId || '',
     });
-    // Use navigateFromOverlayToTab to atomically remove overlay routes
-    // (FullScreenPush/ActionCenter) and switch tab. This avoids the native
-    // UITabBarController window-nil race where RNSScreenStack retries
-    // exhaust on stacks inside detached tab views.
+
+    const alreadyOnUrlAccountPage = isCurrentlyInUrlAccountPage();
+
     defaultLogger.app.router.switchTab(ETabRoutes.Home);
-    await navigateFromOverlayToTab({
-      targetTab: ETabRoutes.Home,
-      switchTab: (tab) => navigation.switchTab(tab),
-    });
+
+    if (alreadyOnUrlAccountPage) {
+      // When already on UrlAccountPage (e.g. second scan), skip
+      // switchTab(pop:true) which would pop the existing page and trigger
+      // expensive RNSScreenStack retry storms on orphaned screen stacks.
+      // Instead, just remove overlays and replace the page in-place.
+      resetAboveMainRoute();
+      await timerUtils.wait(100);
+    } else {
+      // Standard flow: remove overlays, switch tab (with pop), then push.
+      await navigateFromOverlayToTab({
+        targetTab: ETabRoutes.Home,
+        switchTab: (tab) => navigation.switchTab(tab),
+      });
+    }
+
     defaultLogger.app.router.switchTabDone(ETabRoutes.Home);
     const navState = rootNavigationRef.current?.getRootState();
     const focusedRoute = navState?.routes?.[navState?.index ?? 0];
@@ -267,12 +279,24 @@ export const urlAccountNavigation = {
       stackDepth: tabStack?.routes?.length,
       topRoute: tabStackTopRouteName,
     });
-    rootNavigationRef.current?.dispatch(
-      StackActions.push(ETabHomeRoutes.TabHomeUrlAccountPage, {
-        address: params.address,
-        networkId: networkSegment,
-      }),
-    );
+
+    const routeParams = {
+      address: params.address,
+      networkId: networkSegment,
+    };
+
+    if (alreadyOnUrlAccountPage) {
+      // Replace the existing UrlAccountPage with new params.
+      // This avoids pop+push cycle that causes iOS window-nil freeze.
+      rootNavigationRef.current?.dispatch(
+        StackActions.replace(ETabHomeRoutes.TabHomeUrlAccountPage, routeParams),
+      );
+    } else {
+      rootNavigationRef.current?.dispatch(
+        StackActions.push(ETabHomeRoutes.TabHomeUrlAccountPage, routeParams),
+      );
+    }
+
     const navStateAfter = rootNavigationRef.current?.getRootState();
     const focusedRouteAfter =
       navStateAfter?.routes?.[navStateAfter?.index ?? 0];

--- a/packages/kit/src/views/Market/marketUtils.ts
+++ b/packages/kit/src/views/Market/marketUtils.ts
@@ -1,3 +1,4 @@
+import { navigateFromOverlayToTab } from '@onekeyhq/components';
 import { WEB_APP_URL } from '@onekeyhq/shared/src/config/appConfig';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
@@ -81,5 +82,35 @@ export const marketNavigation = {
     return this.pushDetailPageFromDeeplinkV1(navigation, {
       coinGeckoId,
     });
+  },
+
+  // Safe version for navigating from overlay routes (scan modal, ActionCenter).
+  // Uses navigateFromOverlayToTab to atomically remove all overlay routes
+  // via reset, avoiding the native UITabBarController window-nil race
+  // condition where RNSScreenStack retries exhaust on detached tab views.
+  async pushDetailPageFromOverlay(
+    navigation: IAppNavigation,
+    {
+      coinGeckoId,
+    }: {
+      coinGeckoId: string;
+    },
+  ) {
+    await navigateFromOverlayToTab({
+      targetTab: ETabRoutes.Market,
+      switchTab: (tab) => navigation.switchTab(tab),
+    });
+    navigation.navigate(
+      ERootRoutes.Main,
+      {
+        screen: ETabRoutes.Market,
+        params: {
+          screen: ETabMarketRoutes.MarketDetail,
+          params: {
+            token: coinGeckoId,
+          },
+        },
+      },
+    );
   },
 };

--- a/packages/kit/src/views/Market/marketUtils.ts
+++ b/packages/kit/src/views/Market/marketUtils.ts
@@ -100,17 +100,14 @@ export const marketNavigation = {
       targetTab: ETabRoutes.Market,
       switchTab: (tab) => navigation.switchTab(tab),
     });
-    navigation.navigate(
-      ERootRoutes.Main,
-      {
-        screen: ETabRoutes.Market,
+    navigation.navigate(ERootRoutes.Main, {
+      screen: ETabRoutes.Market,
+      params: {
+        screen: ETabMarketRoutes.MarketDetail,
         params: {
-          screen: ETabMarketRoutes.MarketDetail,
-          params: {
-            token: coinGeckoId,
-          },
+          token: coinGeckoId,
         },
       },
-    );
+    });
   },
 };

--- a/packages/kit/src/views/Onboarding/pages/ImportWallet/ImportAddressCore.tsx
+++ b/packages/kit/src/views/Onboarding/pages/ImportWallet/ImportAddressCore.tsx
@@ -186,7 +186,7 @@ function ImportAddressCore({
                     onPress: async () => {
                       const result = await start({
                         handlers: [],
-                        autoHandleResult: false,
+                        autoExecuteParsedAction: false,
                       });
                       form.setValue('publicKeyValue', result.raw);
                     },

--- a/packages/kit/src/views/Onboarding/pages/ImportWallet/ImportSingleChainBase.tsx
+++ b/packages/kit/src/views/Onboarding/pages/ImportWallet/ImportSingleChainBase.tsx
@@ -201,7 +201,7 @@ export function ImportSingleChainBase({
                   onPress: async () => {
                     const result = await start({
                       handlers: [],
-                      autoHandleResult: false,
+                      autoExecuteParsedAction: false,
                     });
                     form.setValue('input', result.raw);
                   },

--- a/packages/kit/src/views/Perp/components/PerpTips.tsx
+++ b/packages/kit/src/views/Perp/components/PerpTips.tsx
@@ -47,7 +47,7 @@ export function PerpTips() {
                 EQRCodeHandlerNames.updatePreview,
               ],
               qrWalletScene: false,
-              autoHandleResult: true,
+              autoExecuteParsedAction: true,
               defaultHandler: openUrlExternal,
             });
           }

--- a/packages/kit/src/views/Prime/pages/PagePrimeTransfer/components/PrimeTransferHomeEnterLink.tsx
+++ b/packages/kit/src/views/Prime/pages/PagePrimeTransfer/components/PrimeTransferHomeEnterLink.tsx
@@ -292,7 +292,7 @@ export function PrimeTransferHomeEnterLink({
       onPress: async () => {
         const result = await start({
           handlers: [],
-          autoHandleResult: false,
+          autoExecuteParsedAction: false,
         });
         let text = result?.raw || '';
         if (text.startsWith(TRANSFER_DEEPLINK_URL)) {

--- a/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
+++ b/packages/kit/src/views/Receive/pages/ReceiveToken.tsx
@@ -724,7 +724,7 @@ function ReceiveToken() {
             color="$textSubdued"
             size="$bodyMd"
             translationId={ETranslations.wallet_receive_note_fresh_address}
-            autoHandleResult={false}
+            autoExecuteParsedAction={false}
             onAction={() => {
               console.log('HyperlinkText onAction');
               navigation.push(EModalReceiveRoutes.BtcAddresses, {

--- a/packages/kit/src/views/ScanQrCode/hooks/useParseQRCode.tsx
+++ b/packages/kit/src/views/ScanQrCode/hooks/useParseQRCode.tsx
@@ -8,10 +8,8 @@ import {
   Stack,
   Toast,
   ToastContent,
-  popActionCenterPages,
-  popScanModalPages,
+  resetAboveMainRoute,
   useClipboard,
-  waitForScanModalClosed,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
@@ -161,10 +159,13 @@ const useParseQRCode = () => {
 
       const closeScanPage = async () => {
         if (popNavigation) {
-          await popScanModalPages();
-          await popActionCenterPages();
-          // Wait until scan modal is no longer current (or 400ms max). Faster than fixed 350ms when stack updates early (OK-50182).
-          await waitForScanModalClosed();
+          // Atomically remove all overlay routes (scan modal, ActionCenter,
+          // FullScreenPush, etc.) via CommonActions.reset instead of sequential
+          // goBack() calls. This avoids the native UITabBarController
+          // window-nil race condition where RNSScreenStack retries exhaust on
+          // stacks inside detached tab views (OK-50182).
+          resetAboveMainRoute();
+          await timerUtils.wait(100);
         }
       };
 
@@ -220,10 +221,15 @@ const useParseQRCode = () => {
           {
             const { coinGeckoId } = result.data as IMarketDetailValue;
             if (coinGeckoId) {
-              await closeScanPage();
-              void marketNavigation.pushDetailPageFromDeeplink(navigation, {
-                coinGeckoId,
-              });
+              if (popNavigation) {
+                void marketNavigation.pushDetailPageFromOverlay(navigation, {
+                  coinGeckoId,
+                });
+              } else {
+                void marketNavigation.pushDetailPageFromDeeplink(navigation, {
+                  coinGeckoId,
+                });
+              }
             }
           }
           break;

--- a/packages/kit/src/views/ScanQrCode/hooks/useParseQRCode.tsx
+++ b/packages/kit/src/views/ScanQrCode/hooks/useParseQRCode.tsx
@@ -8,8 +8,11 @@ import {
   Stack,
   Toast,
   ToastContent,
+  popActionCenterPages,
+  popScanModalPages,
   resetAboveMainRoute,
   useClipboard,
+  waitForScanModalClosed,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
@@ -159,13 +162,22 @@ const useParseQRCode = () => {
 
       const closeScanPage = async () => {
         if (popNavigation) {
-          // Atomically remove all overlay routes (scan modal, ActionCenter,
-          // FullScreenPush, etc.) via CommonActions.reset instead of sequential
-          // goBack() calls. This avoids the native UITabBarController
-          // window-nil race condition where RNSScreenStack retries exhaust on
-          // stacks inside detached tab views (OK-50182).
-          resetAboveMainRoute();
-          await timerUtils.wait(100);
+          if (options?.autoHandleResult) {
+            // Atomically remove all overlay routes (scan modal, ActionCenter,
+            // FullScreenPush, etc.) via CommonActions.reset instead of
+            // sequential goBack() calls. This avoids the native
+            // UITabBarController window-nil race condition where
+            // RNSScreenStack retries exhaust on stacks inside detached tab
+            // views (OK-50182).
+            resetAboveMainRoute();
+            await timerUtils.wait(100);
+          } else {
+            // Preserve caller route for manual scan flows (e.g. onboarding
+            // import): only dismiss scan/action-center overlays.
+            await popScanModalPages();
+            await popActionCenterPages();
+            await waitForScanModalClosed();
+          }
         }
       };
 

--- a/packages/kit/src/views/ScanQrCode/hooks/useParseQRCode.tsx
+++ b/packages/kit/src/views/ScanQrCode/hooks/useParseQRCode.tsx
@@ -162,7 +162,7 @@ const useParseQRCode = () => {
 
       const closeScanPage = async () => {
         if (popNavigation) {
-          if (options?.autoHandleResult) {
+          if (options?.autoExecuteParsedAction) {
             // Atomically remove all overlay routes (scan modal, ActionCenter,
             // FullScreenPush, etc.) via CommonActions.reset instead of
             // sequential goBack() calls. This avoids the native
@@ -186,7 +186,8 @@ const useParseQRCode = () => {
         options,
       );
 
-      if (!options?.autoHandleResult) {
+      // Manual mode: close scanner overlays and return parsed data to caller.
+      if (!options?.autoExecuteParsedAction) {
         if (
           result.type !== EQRCodeHandlerType.ANIMATION_CODE ||
           (result.type === EQRCodeHandlerType.ANIMATION_CODE &&
@@ -196,6 +197,7 @@ const useParseQRCode = () => {
         }
         return result;
       }
+      // Auto-execution mode: run built-in route/action side effects by type.
       switch (result.type) {
         case EQRCodeHandlerType.REWARD_CENTER: {
           await closeScanPage();

--- a/packages/kit/src/views/ScanQrCode/hooks/useScanQrCode.ts
+++ b/packages/kit/src/views/ScanQrCode/hooks/useScanQrCode.ts
@@ -27,7 +27,9 @@ export default function useScanQrCode() {
   const parseQRCode = useParseQRCode();
   const start = useCallback(
     async ({
-      autoHandleResult = false,
+      // Keep manual mode by default so the caller can decide what to do with
+      // the parsed result.
+      autoExecuteParsedAction = false,
       handlers,
       account,
       network,
@@ -47,7 +49,7 @@ export default function useScanQrCode() {
               callback: async ({ value, popNavigation }) => {
                 if (value?.length > 0) {
                   const parseValue = await parseQRCode.parse(value, {
-                    autoHandleResult,
+                    autoExecuteParsedAction,
                     handlers,
                     account,
                     network,


### PR DESCRIPTION
Replace sequential goBack() calls in closeScanPage() with atomic
resetAboveMainRoute() to prevent UITabBarController window-nil race
condition that causes navigation to freeze after QR code scanning.
Add safe pushDetailPageFromOverlay() for market detail navigation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
