### PR TITLE
feat: add stock info support and currency conversion for market tokens

### DIFF
--- a/packages/kit-bg/src/services/ServiceMarketV2.ts
+++ b/packages/kit-bg/src/services/ServiceMarketV2.ts
@@ -36,7 +36,10 @@ import type {
 import type { INotificationWatchlistToken } from '@onekeyhq/shared/types/notification';
 
 import { type IDBCloudSyncItem } from '../dbs/local/types';
-import { devSettingsPersistAtom } from '../states/jotai/atoms/devSettings';
+import {
+  devSettingsPersistAtom,
+  settingsPersistAtom,
+} from '../states/jotai/atoms';
 import { perpTokenFavoritesPersistAtom } from '../states/jotai/atoms/perps';
 
 import ServiceBase from './ServiceBase';
@@ -73,15 +76,21 @@ class ServiceMarketV2 extends ServiceBase {
     tokenAddress: string,
     networkId: string,
   ) {
+    const settings = await settingsPersistAtom.get();
+    const selectedCurrencyId = settings.currencyInfo?.id ?? 'usd';
     const client = await this.getClient(EServiceEndpointEnum.Utility);
+    const params: Record<string, string> = {
+      tokenAddress,
+      networkId,
+      currency: 'usd',
+    };
+    // When the user has selected a non-USD currency, request a converted price
+    if (selectedCurrencyId !== 'usd') {
+      params.convertCurrency = selectedCurrencyId;
+    }
     const response = await client.get<IMarketTokenDetailResponse>(
       '/utility/v2/market/token/detail',
-      {
-        params: {
-          tokenAddress,
-          networkId,
-        },
-      },
+      { params },
     );
     return response.data;
   }
@@ -162,6 +171,7 @@ class ServiceMarketV2 extends ServiceBase {
         limit,
         minLiquidity,
         maxLiquidity,
+        currency: 'usd',
       },
     });
     const { data } = response.data;
@@ -200,6 +210,7 @@ class ServiceMarketV2 extends ServiceBase {
         interval: innerInterval,
         timeFrom,
         timeTo,
+        currency: 'usd',
       },
     });
     const { data } = response.data;
@@ -227,6 +238,7 @@ class ServiceMarketV2 extends ServiceBase {
       params: {
         tokenAddress,
         networkId,
+        currency: 'usd',
         ...(cursor !== undefined && { cursor }),
         ...(limit !== undefined && { limit }),
       },
@@ -262,6 +274,7 @@ class ServiceMarketV2 extends ServiceBase {
           accountAddress,
           tokenAddress,
           networkId,
+          currency: 'usd',
           ...(cursor !== undefined && { cursor }),
           ...(timeFrom !== undefined && { timeFrom }),
           ...(timeTo !== undefined && { timeTo }),
@@ -295,6 +308,7 @@ class ServiceMarketV2 extends ServiceBase {
       params: {
         tokenAddress,
         networkId,
+        currency: 'usd',
       },
     });
     const { data } = response.data;
@@ -347,6 +361,7 @@ class ServiceMarketV2 extends ServiceBase {
       data: IMarketTokenBatchListResponse;
     }>('/utility/v2/market/token/list/batch', {
       tokenAddressList: missingTokens,
+      currency: 'usd',
     });
 
     const { data } = response.data;
@@ -672,6 +687,7 @@ class ServiceMarketV2 extends ServiceBase {
           accountAddress,
           tokenAddress,
           xpub,
+          currency: 'usd',
         },
       });
 
@@ -728,6 +744,7 @@ class ServiceMarketV2 extends ServiceBase {
       data: IMarketBannerTokenListResponse;
     }>(
       `/utility/v2/market/banner/token-list/${encodeURIComponent(tokenListId)}`,
+      { params: { currency: 'usd' } },
     );
     const { data } = response.data;
     return data.list;

--- a/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
@@ -11,7 +11,6 @@ import { ESwapTxHistoryStatus } from '@onekeyhq/shared/types/swap/types';
 
 import { useRouteIsFocused } from '../../../hooks/useRouteIsFocused';
 import { useThemeVariant } from '../../../hooks/useThemeVariant';
-import { useCurrency } from '../../Currency';
 import WebView from '../../WebView';
 import { useNavigationHandler, useTradingViewUrl } from '../hooks';
 
@@ -49,7 +48,6 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
   const marksTimeRange = useRef<IMarksTimeRange | null>(null);
   const theme = useThemeVariant();
   const isVisible = useRouteIsFocused();
-  const currencyInfo = useCurrency();
 
   const {
     tokenAddress = '',
@@ -120,7 +118,6 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     webRef,
     enabled: isVisible && dataSource === 'websocket' && !isHyperLiquidSource,
     chartType: '1m',
-    currency: currencyInfo.id,
   });
 
   // Load marks on page enter and refresh when swap transaction succeeds

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationPanel/InformationPanel.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationPanel/InformationPanel.tsx
@@ -1,10 +1,7 @@
-import { useMemo } from 'react';
-
 import { useIntl } from 'react-intl';
 
 import { SizableText, XStack, YStack } from '@onekeyhq/components';
 import { MarketTokenPrice } from '@onekeyhq/kit/src/views/Market/components/MarketTokenPrice';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
 
@@ -32,9 +29,15 @@ const marketCapFormatter: INumberFormatProps = {
   formatter: 'marketCap',
 };
 
+const usdCurrencyFormatter: INumberFormatProps = {
+  formatter: 'marketCap',
+  formatterOptions: {
+    currency: '$',
+  },
+};
+
 export function InformationPanel() {
   const intl = useIntl();
-  const [settings] = useSettingsPersistAtom();
   const { tokenDetail, networkId, tokenAddress } = useTokenDetail();
 
   // Directly use the security data hook to check if we have security data
@@ -42,16 +45,6 @@ export function InformationPanel() {
     tokenAddress,
     networkId,
   });
-
-  const currencyFormatter: INumberFormatProps = useMemo(() => {
-    const currencySymbol = settings.currencyInfo.symbol;
-    return {
-      formatter: 'marketCap',
-      formatterOptions: {
-        currency: currencySymbol,
-      },
-    };
-  }, [settings.currencyInfo.symbol]);
 
   if (!tokenDetail) return <InformationPanelSkeleton />;
 
@@ -68,12 +61,12 @@ export function InformationPanel() {
 
   const formattedMarketCap = formatStatValueWithFormatter(
     marketCap,
-    currencyFormatter,
+    usdCurrencyFormatter,
   );
 
   const formattedLiquidity = formatStatValueWithFormatter(
     liquidity,
-    currencyFormatter,
+    usdCurrencyFormatter,
   );
 
   const formattedHolders = formatStatValueWithFormatter(

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Holders/hooks/useHolderItemData.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Holders/hooks/useHolderItemData.ts
@@ -21,9 +21,11 @@ export function useHolderItemData({ item, index }: IUseHolderItemDataProps) {
     return '-';
   }, [item.percentage]);
 
+  const fiatValue = item.fiatValue;
+
   const hasValidData = useMemo(() => {
-    return Boolean(item.amount && item.fiatValue);
-  }, [item.amount, item.fiatValue]);
+    return Boolean(item.amount && fiatValue);
+  }, [item.amount, fiatValue]);
 
   return {
     rank,
@@ -31,6 +33,6 @@ export function useHolderItemData({ item, index }: IUseHolderItemDataProps) {
     hasValidData,
     accountAddress: item.accountAddress,
     amount: item.amount,
-    fiatValue: item.fiatValue,
+    fiatValue,
   };
 }

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Holders/layout/HolderItemNormal/HolderItemNormal.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Holders/layout/HolderItemNormal/HolderItemNormal.tsx
@@ -1,7 +1,6 @@
 import { memo } from 'react';
 
 import { NumberSizeableText, SizableText, XStack } from '@onekeyhq/components';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { IMarketTokenHolder } from '@onekeyhq/shared/types/marketV2';
 
 import { AddressDisplay } from '../../../AddressDisplay';
@@ -21,7 +20,6 @@ function HolderItemNormalBase({
   networkId,
 }: IHolderItemNormalProps) {
   const { styles } = useHoldersLayoutNormal();
-  const [settingsPersistAtom] = useSettingsPersistAtom();
   const { rank, displayPercentage, accountAddress, amount, fiatValue } =
     useHolderItemData({ item, index });
 
@@ -71,7 +69,7 @@ function HolderItemNormalBase({
         {...styles.value}
         formatter="marketCap"
         formatterOptions={{
-          currency: settingsPersistAtom.currencyInfo.symbol,
+          currency: '$',
         }}
       >
         {fiatValue}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Holders/layout/HolderItemSmall/HolderItemSmall.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Holders/layout/HolderItemSmall/HolderItemSmall.tsx
@@ -1,7 +1,6 @@
 import { memo } from 'react';
 
 import { NumberSizeableText, SizableText, XStack } from '@onekeyhq/components';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { IMarketTokenHolder } from '@onekeyhq/shared/types/marketV2';
 
 import { AddressDisplay } from '../../../AddressDisplay';
@@ -21,7 +20,6 @@ function HolderItemSmallBase({
   networkId,
 }: IHolderItemSmallProps) {
   const { styles } = useHoldersLayoutSmall();
-  const [settingsPersistAtom] = useSettingsPersistAtom();
   const { rank, displayPercentage, accountAddress, fiatValue } =
     useHolderItemData({ item, index });
 
@@ -59,7 +57,7 @@ function HolderItemSmallBase({
         {...styles.value}
         formatter="marketCap"
         formatterOptions={{
-          currency: settingsPersistAtom.currencyInfo.symbol,
+          currency: '$',
         }}
       >
         {fiatValue}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/layout/PortfolioItemNormal.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/layout/PortfolioItemNormal.tsx
@@ -1,7 +1,6 @@
 import { memo } from 'react';
 
 import { NumberSizeableText, XStack } from '@onekeyhq/components';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { IMarketAccountPortfolioItem } from '@onekeyhq/shared/types/marketV2';
 
 interface IPortfolioItemNormalProps {
@@ -10,8 +9,6 @@ interface IPortfolioItemNormalProps {
 }
 
 function PortfolioItemNormalBase({ item, index }: IPortfolioItemNormalProps) {
-  const [settingsPersistAtom] = useSettingsPersistAtom();
-
   return (
     <XStack
       h={40}
@@ -40,7 +37,7 @@ function PortfolioItemNormalBase({ item, index }: IPortfolioItemNormalProps) {
         autoFormatter="price-marketCap"
         autoFormatterThreshold={1000}
         formatterOptions={{
-          currency: settingsPersistAtom.currencyInfo.symbol,
+          currency: '$',
         }}
       >
         {item.totalPrice}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/layout/PortfolioItemSmall.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/layout/PortfolioItemSmall.tsx
@@ -1,7 +1,6 @@
 import { memo } from 'react';
 
 import { NumberSizeableText, XStack } from '@onekeyhq/components';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { IMarketAccountPortfolioItem } from '@onekeyhq/shared/types/marketV2';
 
 interface IPortfolioItemSmallProps {
@@ -10,8 +9,6 @@ interface IPortfolioItemSmallProps {
 }
 
 function PortfolioItemSmallBase({ item }: IPortfolioItemSmallProps) {
-  const [settingsPersistAtom] = useSettingsPersistAtom();
-
   return (
     <XStack
       px="$5"
@@ -36,7 +33,7 @@ function PortfolioItemSmallBase({ item }: IPortfolioItemSmallProps) {
         color="$text"
         autoFormatter="price-marketCap"
         formatterOptions={{
-          currency: settingsPersistAtom.currencyInfo.symbol,
+          currency: '$',
         }}
       >
         {item.totalPrice}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/TransactionsHistory.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/TransactionsHistory.tsx
@@ -13,7 +13,6 @@ import {
   useCurrentTabScrollY,
   useMedia,
 } from '@onekeyhq/components';
-import { useCurrency } from '@onekeyhq/kit/src/components/Currency';
 import { useRouteIsFocused } from '@onekeyhq/kit/src/hooks/useRouteIsFocused';
 import { useTokenDetail } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/hooks';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -60,7 +59,6 @@ export function TransactionsHistory({
   const { websocketConfig, isNative } = useTokenDetail();
   const isVisible = useRouteIsFocused();
   const { gtXl } = useMedia();
-  const currencyInfo = useCurrency();
 
   // Enable polling mode for native tokens (which don't have WebSocket support)
   // or for web non-xl screens without WebSocket txs enabled
@@ -88,7 +86,6 @@ export function TransactionsHistory({
     networkId,
     tokenAddress,
     enabled: !normalMode && isVisible,
-    currency: currencyInfo.id,
     onNewTransaction: addNewTransaction,
   });
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/hooks/useTransactionItemData.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/hooks/useTransactionItemData.ts
@@ -72,9 +72,10 @@ export function useTransactionItemData({ item }: IUseTransactionItemDataProps) {
     [isBuy, intl],
   );
 
+  const basePrice = baseToken.price;
   const value =
     item.volumeUSD ??
-    BigNumber(baseToken.amount).times(BigNumber(baseToken.price)).toNumber();
+    BigNumber(baseToken.amount).times(BigNumber(basePrice)).toNumber();
 
   return {
     isBuy,
@@ -84,7 +85,7 @@ export function useTransactionItemData({ item }: IUseTransactionItemDataProps) {
     quoteSign,
     typeColor,
     typeText,
-    price: baseToken.price,
+    price: basePrice,
     value,
     formattedTime,
   };

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/layout/TransactionItemNormal/TransactionItemNormal.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/layout/TransactionItemNormal/TransactionItemNormal.tsx
@@ -7,7 +7,6 @@ import {
   XStack,
   YStack,
 } from '@onekeyhq/components';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { IMarketTokenTransaction } from '@onekeyhq/shared/types/marketV2';
 
 import { AddressDisplay } from '../../../AddressDisplay';
@@ -39,7 +38,6 @@ function TransactionItemNormalBase({
     value,
     formattedTime,
   } = useTransactionItemData({ item });
-  const [settingsPersistAtom] = useSettingsPersistAtom();
 
   return (
     <XStack
@@ -86,7 +84,7 @@ function TransactionItemNormalBase({
             autoFormatter="price-marketCap"
             formatterOptions={{
               capAtMaxT: true,
-              currency: settingsPersistAtom.currencyInfo.symbol,
+              currency: '$',
             }}
           >
             {value}
@@ -97,7 +95,7 @@ function TransactionItemNormalBase({
             autoFormatter="price-marketCap"
             formatterOptions={{
               capAtMaxT: true,
-              currency: settingsPersistAtom.currencyInfo.symbol,
+              currency: '$',
             }}
           >
             {price}
@@ -111,7 +109,7 @@ function TransactionItemNormalBase({
             autoFormatter="price-marketCap"
             formatterOptions={{
               capAtMaxT: true,
-              currency: settingsPersistAtom.currencyInfo.symbol,
+              currency: '$',
             }}
             {...styles.price}
           >
@@ -124,7 +122,7 @@ function TransactionItemNormalBase({
             autoFormatter="price-marketCap"
             formatterOptions={{
               capAtMaxT: true,
-              currency: settingsPersistAtom.currencyInfo.symbol,
+              currency: '$',
             }}
             {...styles.value}
           >

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/layout/TransactionItemSmall/TransactionItemSmall.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/layout/TransactionItemSmall/TransactionItemSmall.tsx
@@ -7,7 +7,6 @@ import {
   XStack,
   YStack,
 } from '@onekeyhq/components';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { IMarketTokenTransaction } from '@onekeyhq/shared/types/marketV2';
 
 import { TransactionAmount } from '../../components/TransactionAmount';
@@ -21,7 +20,6 @@ interface ITransactionItemSmallProps {
 
 function TransactionItemSmallBase({ item }: ITransactionItemSmallProps) {
   const { styles } = useTransactionsLayoutSmall();
-  const [settingsPersistAtom] = useSettingsPersistAtom();
   const {
     baseToken,
     quoteToken,
@@ -73,7 +71,7 @@ function TransactionItemSmallBase({ item }: ITransactionItemSmallProps) {
           autoFormatter="price-marketCap"
           formatterOptions={{
             capAtMaxT: true,
-            currency: settingsPersistAtom.currencyInfo.symbol,
+            currency: '$',
           }}
         >
           {value}
@@ -86,7 +84,7 @@ function TransactionItemSmallBase({ item }: ITransactionItemSmallProps) {
           autoFormatter="price-marketCap"
           formatterOptions={{
             capAtMaxT: true,
-            currency: settingsPersistAtom.currencyInfo.symbol,
+            currency: '$',
           }}
         >
           {price}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenActivityOverview/components/VolumeRow.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenActivityOverview/components/VolumeRow.tsx
@@ -1,7 +1,6 @@
 import { useIntl } from 'react-intl';
 
 import { NumberSizeableText, SizableText, Stack } from '@onekeyhq/components';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { BuySellRatioBar } from './BuySellRatioBar';
@@ -20,7 +19,6 @@ export function VolumeRow({
     totalVolume !== undefined && totalVolume > 0 && buyVolume !== undefined
       ? (buyVolume / totalVolume) * 100
       : 0;
-  const [settingsPersistAtom] = useSettingsPersistAtom();
 
   // Show "--" when loading OR when data is undefined (field doesn't exist)
   const showTotalPlaceholder = isLoading || totalVolume === undefined;
@@ -40,7 +38,7 @@ export function VolumeRow({
               formatter="marketCap"
               size="$bodyMdMedium"
               formatterOptions={{
-                currency: settingsPersistAtom.currencyInfo.symbol,
+                currency: '$',
               }}
             >
               {totalVolume}
@@ -64,7 +62,7 @@ export function VolumeRow({
               size="$bodyMd"
               color="$textSubdued"
               formatterOptions={{
-                currency: settingsPersistAtom.currencyInfo.symbol,
+                currency: '$',
               }}
             >
               {buyVolume}
@@ -82,7 +80,7 @@ export function VolumeRow({
               size="$bodyMd"
               color="$textSubdued"
               formatterOptions={{
-                currency: settingsPersistAtom.currencyInfo.symbol,
+                currency: '$',
               }}
             >
               {sellVolume}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx
@@ -5,6 +5,7 @@ import { useWindowDimensions } from 'react-native';
 
 import {
   Divider,
+  Image,
   InteractiveIcon,
   SizableText,
   XStack,
@@ -19,6 +20,10 @@ import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import type { IMarketTokenDetail } from '@onekeyhq/shared/types/marketV2';
 
 import { CommunityRecognizedBadge } from '../../../components/CommunityRecognizedBadge';
+import {
+  StockIsOpenBadge,
+  SubtitleBadge,
+} from '../../../components/PerpsBadges';
 import { MarketStarV2 } from '../../../components/MarketStarV2';
 import { TokenSecurityAlert } from '../TokenSecurityAlert';
 
@@ -70,6 +75,7 @@ export function TokenDetailHeaderLeft({
     logoUrl = '',
     extraData,
     communityRecognized,
+    stock,
   } = tokenDetail || {};
 
   const { website, twitter } = extraData || {};
@@ -127,7 +133,19 @@ export function TokenDetailHeaderLeft({
             >
               {symbol}
             </SizableText>
+            {stock?.sourceLogoUri ? (
+              <Image
+                width={14}
+                height={14}
+                borderRadius="$full"
+                source={{ uri: stock.sourceLogoUri }}
+              />
+            ) : null}
             {communityRecognized ? <CommunityRecognizedBadge /> : null}
+            {stock?.subtitle ? (
+              <SubtitleBadge subtitle={stock.subtitle} />
+            ) : null}
+            {stock ? <StockIsOpenBadge isOpen={stock.isOpen} /> : null}
           </XStack>
 
           <XStack gap="$2" ai="center">

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderRight.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderRight.tsx
@@ -6,9 +6,9 @@ import {
   XStack,
   YStack,
 } from '@onekeyhq/components';
+import { useCurrency } from '@onekeyhq/kit/src/components/Currency';
 import { MarketTokenPrice } from '@onekeyhq/kit/src/views/Market/components/MarketTokenPrice';
 import { PriceChangePercentage } from '@onekeyhq/kit/src/views/Market/components/PriceChangePercentage';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IMarketTokenDetail } from '@onekeyhq/shared/types/marketV2';
@@ -47,11 +47,12 @@ export function TokenDetailHeaderRight({
   showStats,
 }: ITokenDetailHeaderRightProps) {
   const intl = useIntl();
-  const [settingsPersistAtom] = useSettingsPersistAtom();
+  const currencyInfo = useCurrency();
   const {
     name = '',
     symbol = '',
     price: currentPrice = '--',
+    priceConverted,
     priceChange24hPercent = '--',
     marketCap = '0',
     liquidity = '0',
@@ -80,16 +81,31 @@ export function TokenDetailHeaderRight({
     <XStack gap="$8" ai="center">
       {/* Price and Price Change */}
       <XStack ai="center" gap="$1.5">
-        <MarketTokenPrice
-          size="$headingXl"
-          price={currentPrice}
-          tokenName={name}
-          tokenSymbol={symbol}
-          lastUpdated={tokenDetail?.lastUpdated?.toString()}
-        />
-        <PriceChangePercentage size="$headingXs">
-          {priceChange24hPercent}
-        </PriceChangePercentage>
+        <XStack ai="center" jc="center" gap="$3">
+          <YStack ai="flex-end">
+            <MarketTokenPrice
+              size="$bodyLgMedium"
+              price={currentPrice}
+              tokenName={name}
+              tokenSymbol={symbol}
+              lastUpdated={tokenDetail?.lastUpdated?.toString()}
+            />
+            {priceConverted ? (
+              <NumberSizeableText
+                size="$bodySm"
+                color="$textSubdued"
+                formatter="price"
+                formatterOptions={{ currency: currencyInfo.symbol }}
+              >
+                {priceConverted}
+              </NumberSizeableText>
+            ) : null}
+          </YStack>
+
+          <PriceChangePercentage size="$headingXs">
+            {priceChange24hPercent}
+          </PriceChangePercentage>
+        </XStack>
       </XStack>
 
       <StatItem
@@ -101,7 +117,7 @@ export function TokenDetailHeaderRight({
             formatter="marketCap"
             formatterOptions={{
               capAtMaxT: true,
-              currency: settingsPersistAtom.currencyInfo.symbol,
+              currency: '$',
             }}
           >
             {marketCapValue}
@@ -117,7 +133,7 @@ export function TokenDetailHeaderRight({
             color="$text"
             formatter="marketCap"
             formatterOptions={{
-              currency: settingsPersistAtom.currencyInfo.symbol,
+              currency: '$',
             }}
           >
             {liquidityValue}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenSupplementaryInfo/TokenSupplementaryInfo.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenSupplementaryInfo/TokenSupplementaryInfo.tsx
@@ -9,7 +9,6 @@ import {
   XStack,
   YStack,
 } from '@onekeyhq/components';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
   NUMBER_FORMATTER,
@@ -23,8 +22,6 @@ const FALLBACK_VALUE = '--';
 type ISupplyValue = string | number | null | undefined;
 
 const toSupplyInput = (value: unknown): ISupplyValue => {
-  console.log('value', value);
-
   if (value === null || value === undefined) {
     return undefined;
   }
@@ -56,9 +53,7 @@ const formatCurrencyValue = (value: ISupplyValue, currencySymbol: string) => {
 
 export function TokenSupplementaryInfo() {
   const intl = useIntl();
-  const [settings] = useSettingsPersistAtom();
   const { tokenDetail } = useTokenDetail();
-  const currencySymbol = settings?.currencyInfo?.symbol ?? '$';
 
   const rows = useMemo(() => {
     if (!tokenDetail) {
@@ -85,7 +80,7 @@ export function TokenSupplementaryInfo() {
         label: intl.formatMessage({
           id: ETranslations.dexmarket_market_cap,
         }),
-        value: formatCurrencyValue(marketCap, currencySymbol),
+        value: formatCurrencyValue(marketCap, '$'),
         tooltip: intl.formatMessage({
           id: ETranslations.dexmarket_mc_tips,
         }),
@@ -93,13 +88,13 @@ export function TokenSupplementaryInfo() {
       {
         key: 'fdv',
         label: intl.formatMessage({ id: ETranslations.global_fdv }),
-        value: formatCurrencyValue(fdv, currencySymbol),
+        value: formatCurrencyValue(fdv, '$'),
         tooltip: intl.formatMessage({
           id: ETranslations.dexmarket_fdv_desc,
         }),
       },
     ];
-  }, [currencySymbol, intl, tokenDetail]);
+  }, [intl, tokenDetail]);
 
   if (!tokenDetail) {
     return null;

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenData.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenData.ts
@@ -21,6 +21,7 @@ export interface IMarketToken {
   sortIndex?: number;
   isNative?: boolean;
   communityRecognized?: boolean;
+  stock?: import('@onekeyhq/shared/types/marketV2').IMarketStockInfo;
   // Perps watchlist: coin name (e.g. "BTC"). When set, this is a perps token.
   perpsCoin?: string;
   // Perps: max leverage (e.g. 40)

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenIdentityItem/TokenIdentityItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenIdentityItem/TokenIdentityItem.tsx
@@ -74,7 +74,7 @@ interface ITokenIdentityItemProps {
    */
   communityRecognized?: boolean;
   /**
-   * Stock info for tokenized real-world assets (e.g. Ondo tokenized stocks).
+   * Stock info for tokenized real-world assets.
    */
   stock?: IMarketStockInfo;
 }

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenIdentityItem/TokenIdentityItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenIdentityItem/TokenIdentityItem.tsx
@@ -3,6 +3,7 @@ import { memo, useMemo } from 'react';
 
 import {
   Icon,
+  Image,
   NATIVE_HIT_SLOP,
   NumberSizeableText,
   SizableText,
@@ -14,11 +15,12 @@ import {
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import { useNetworkLogoUri } from '@onekeyhq/kit/src/hooks/useNetworkLogoUri';
 import { CommunityRecognizedBadge } from '@onekeyhq/kit/src/views/Market/components/CommunityRecognizedBadge';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { SubtitleBadge } from '@onekeyhq/kit/src/views/Market/components/PerpsBadges';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { ECopyFrom } from '@onekeyhq/shared/src/logger/scopes/dex';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import type { IMarketStockInfo } from '@onekeyhq/shared/types/marketV2';
 
 import type { GestureResponderEvent } from 'react-native';
 
@@ -71,6 +73,10 @@ interface ITokenIdentityItemProps {
    * Whether the token is community recognized.
    */
   communityRecognized?: boolean;
+  /**
+   * Stock info for tokenized real-world assets (e.g. Ondo tokenized stocks).
+   */
+  stock?: IMarketStockInfo;
 }
 
 const BasicTokenIdentityItem: FC<ITokenIdentityItemProps> = ({
@@ -85,12 +91,10 @@ const BasicTokenIdentityItem: FC<ITokenIdentityItemProps> = ({
   volume,
   copyFrom = ECopyFrom.Homepage,
   communityRecognized,
+  stock,
 }) => {
   const { gtMd } = useMedia();
   const { copyText } = useClipboard();
-  const [settings] = useSettingsPersistAtom();
-  const currency = settings.currencyInfo.symbol;
-
   // Use hook to get network logo with async fallback
   const effectiveNetworkLogoUri = useNetworkLogoUri({
     logoUri: networkLogoURI,
@@ -155,7 +159,16 @@ const BasicTokenIdentityItem: FC<ITokenIdentityItemProps> = ({
           >
             {symbol}
           </SizableText>
+          {stock?.sourceLogoUri ? (
+            <Image
+              width={14}
+              height={14}
+              borderRadius="$full"
+              source={{ uri: stock.sourceLogoUri }}
+            />
+          ) : null}
           {communityRecognized ? <CommunityRecognizedBadge /> : null}
+          {stock?.subtitle ? <SubtitleBadge subtitle={stock.subtitle} /> : null}
         </XStack>
         {shouldShowSecondRow ? (
           <XStack alignItems="center" gap="$1" height="$4">
@@ -165,7 +178,7 @@ const BasicTokenIdentityItem: FC<ITokenIdentityItemProps> = ({
                 color="$textSubdued"
                 numberOfLines={1}
                 formatter="marketCap"
-                formatterOptions={{ currency }}
+                formatterOptions={{ currency: '$' }}
               >
                 {volume}
               </NumberSizeableText>

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenListItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenListItem.tsx
@@ -2,7 +2,6 @@ import type { FC } from 'react';
 import { memo } from 'react';
 
 import { NumberSizeableText, XStack } from '@onekeyhq/components';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 
 import { PriceChangeBadge } from '../../PriceChangeBadge';
 
@@ -21,9 +20,6 @@ const BasicTokenListItem: FC<ITokenListItemProps> = ({
   onPress,
   onLongPress,
 }) => {
-  const [settings] = useSettingsPersistAtom();
-  const currency = settings.currencyInfo.symbol;
-
   return (
     <XStack
       pressStyle={{ opacity: 0.8 }}
@@ -43,6 +39,7 @@ const BasicTokenListItem: FC<ITokenListItemProps> = ({
           showVolume
           volume={item.turnover}
           communityRecognized={item.communityRecognized}
+          stock={item.stock}
         />
       </XStack>
 
@@ -53,7 +50,7 @@ const BasicTokenListItem: FC<ITokenListItemProps> = ({
           numberOfLines={1}
           size="$bodyLgMedium"
           formatter="price"
-          formatterOptions={{ currency }}
+          formatterOptions={{ currency: '$' }}
         >
           {item.price}
         </NumberSizeableText>

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsDesktop.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsDesktop.tsx
@@ -20,7 +20,6 @@ import {
   LeverageBadge,
   SubtitleBadge,
 } from '@onekeyhq/kit/src/views/Market/components/PerpsBadges';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
   ECopyFrom,
@@ -48,8 +47,6 @@ export const useColumnsDesktop = (
   copyFrom?: ECopyFrom,
 ): ITableColumn<IMarketToken>[] => {
   const { gtLg, gtXl } = useMedia();
-  const [settings] = useSettingsPersistAtom();
-  const currency = settings.currencyInfo.symbol;
   const intl = useIntl();
 
   return [
@@ -122,6 +119,7 @@ export const useColumnsDesktop = (
             showCopyButton
             copyFrom={copyFrom || ECopyFrom.Homepage}
             communityRecognized={record.communityRecognized}
+            stock={record.stock}
           />
         ),
       renderSkeleton: () => (
@@ -140,13 +138,12 @@ export const useColumnsDesktop = (
       title: intl.formatMessage({ id: ETranslations.global_price }),
       dataIndex: 'price',
       columnProps: { flex: 1 },
-      render: (text: string, record: IMarketToken) => {
-        const currencySymbol = record.perpsCoin ? '$' : currency;
+      render: (text: string) => {
         return (
           <NumberSizeableText
             size="$bodyMd"
             formatter={BigNumber(text).gt(1_000_000) ? 'marketCap' : 'price'}
-            formatterOptions={{ currency: currencySymbol, capAtMaxT: true }}
+            formatterOptions={{ currency: '$', capAtMaxT: true }}
           >
             {text}
           </NumberSizeableText>
@@ -186,7 +183,7 @@ export const useColumnsDesktop = (
             <NumberSizeableText
               size="$bodyMd"
               formatter="marketCap"
-              formatterOptions={{ currency, capAtMaxT: true }}
+              formatterOptions={{ currency: '$', capAtMaxT: true }}
             >
               {text === 0 ? '--' : text}
             </NumberSizeableText>
@@ -203,7 +200,7 @@ export const useColumnsDesktop = (
             <NumberSizeableText
               size="$bodyMd"
               formatter="marketCap"
-              formatterOptions={{ currency }}
+              formatterOptions={{ currency: '$' }}
             >
               {text === 0 ? '--' : text}
             </NumberSizeableText>
@@ -214,11 +211,11 @@ export const useColumnsDesktop = (
       title: intl.formatMessage({ id: ETranslations.dexmarket_turnover }),
       dataIndex: 'turnover',
       columnProps: { flex: 1.1 },
-      render: (text: number, record: IMarketToken) => (
+      render: (text: number) => (
         <NumberSizeableText
           size="$bodyMd"
           formatter="marketCap"
-          formatterOptions={{ currency: record.perpsCoin ? '$' : currency }}
+          formatterOptions={{ currency: '$' }}
         >
           {text === 0 ? '--' : text}
         </NumberSizeableText>

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsMobile.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsMobile.tsx
@@ -14,7 +14,6 @@ import {
   LeverageBadge,
   SubtitleBadge,
 } from '@onekeyhq/kit/src/views/Market/components/PerpsBadges';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { PriceChangeBadge } from '../../../PriceChangeBadge';
@@ -22,8 +21,6 @@ import { TokenIdentityItem } from '../../components/TokenIdentityItem';
 import { type IMarketToken } from '../../MarketTokenData';
 
 export const useColumnsMobile = (): ITableColumn<IMarketToken>[] => {
-  const [settings] = useSettingsPersistAtom();
-  const currency = settings.currencyInfo.symbol;
   const intl = useIntl();
 
   return [
@@ -93,6 +90,7 @@ export const useColumnsMobile = (): ITableColumn<IMarketToken>[] => {
               showVolume
               volume={record.turnover}
               communityRecognized={record.communityRecognized}
+              stock={record.stock}
             />
           </XStack>
         );
@@ -150,7 +148,7 @@ export const useColumnsMobile = (): ITableColumn<IMarketToken>[] => {
             size="$bodyLgMedium"
             formatter="price"
             formatterOptions={{
-              currency: record.perpsCoin ? '$' : currency,
+              currency: '$',
             }}
           >
             {record.price}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.ts
@@ -106,6 +106,7 @@ export function transformApiItemToToken(
     sortIndex,
     isNative: item.isNative,
     communityRecognized: item.communityRecognized,
+    stock: item.stock,
     walletInfo: {
       buy: safeNumber(item.buy24hCount),
       sell: safeNumber(item.sell24hCount),

--- a/packages/kit/src/views/Market/components/MarketTokenPrice.tsx
+++ b/packages/kit/src/views/Market/components/MarketTokenPrice.tsx
@@ -4,7 +4,6 @@ import { throttle } from 'lodash';
 
 import type { ISizableTextProps } from '@onekeyhq/components';
 import { NumberSizeableText } from '@onekeyhq/components';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 
 class MarketTokenPriceEvent {
   private tokenPriceMap = new Map<
@@ -136,9 +135,6 @@ export function MarketTokenPrice({
   tokenName: string;
   lastUpdated?: string;
 } & ISizableTextProps) {
-  const [settings] = useSettingsPersistAtom();
-  const currency = settings.currencyInfo.symbol;
-
   const lastUpdateDate = useMemo(() => {
     if (
       typeof lastUpdated === 'string' &&
@@ -164,7 +160,7 @@ export function MarketTokenPrice({
       userSelect="none"
       formatter="price"
       size={size}
-      formatterOptions={{ currency }}
+      formatterOptions={{ currency: '$' }}
       {...props}
     >
       {tokenPrice}
@@ -185,14 +181,12 @@ export function BaseMarketTokenPrice({
   tokenName: string;
   lastUpdated?: string;
 } & ISizableTextProps) {
-  const [settings] = useSettingsPersistAtom();
-  const currency = settings.currencyInfo.symbol;
   return (
     <NumberSizeableText
       userSelect="none"
       formatter="price"
       size={size}
-      formatterOptions={{ currency }}
+      formatterOptions={{ currency: '$' }}
       {...props}
     >
       {price}

--- a/packages/kit/src/views/Market/components/PerpsBadges.tsx
+++ b/packages/kit/src/views/Market/components/PerpsBadges.tsx
@@ -1,6 +1,9 @@
 import { memo } from 'react';
 
+import { useIntl } from 'react-intl';
+
 import { SizableText, XStack } from '@onekeyhq/components';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 const LeverageBadge = memo(({ leverage }: { leverage: number }) => (
   <XStack
@@ -32,23 +35,30 @@ const SubtitleBadge = memo(({ subtitle }: { subtitle: string }) => (
 ));
 SubtitleBadge.displayName = 'SubtitleBadge';
 
-const StockIsOpenBadge = memo(({ isOpen }: { isOpen: boolean }) => (
-  <XStack
-    borderRadius="$1"
-    bg={isOpen ? '$bgSuccess' : '$bgStrong'}
-    justifyContent="center"
-    alignItems="center"
-    px="$1.5"
-  >
-    <SizableText
-      fontSize={10}
-      color={isOpen ? '$textSuccess' : '$textSubdued'}
-      lineHeight={16}
+const StockIsOpenBadge = memo(({ isOpen }: { isOpen: boolean }) => {
+  const intl = useIntl();
+  return (
+    <XStack
+      borderRadius="$1"
+      bg={isOpen ? '$bgSuccess' : '$bgStrong'}
+      justifyContent="center"
+      alignItems="center"
+      px="$1.5"
     >
-      {isOpen ? '交易中' : '休市'}
-    </SizableText>
-  </XStack>
-));
+      <SizableText
+        fontSize={10}
+        color={isOpen ? '$textSuccess' : '$textSubdued'}
+        lineHeight={16}
+      >
+        {intl.formatMessage({
+          id: isOpen
+            ? ETranslations.dexmarket_stock_status_open
+            : ETranslations.dexmarket_stock_status_closed,
+        })}
+      </SizableText>
+    </XStack>
+  );
+});
 StockIsOpenBadge.displayName = 'StockIsOpenBadge';
 
 export { LeverageBadge, StockIsOpenBadge, SubtitleBadge };

--- a/packages/kit/src/views/Market/components/PerpsBadges.tsx
+++ b/packages/kit/src/views/Market/components/PerpsBadges.tsx
@@ -32,4 +32,23 @@ const SubtitleBadge = memo(({ subtitle }: { subtitle: string }) => (
 ));
 SubtitleBadge.displayName = 'SubtitleBadge';
 
-export { LeverageBadge, SubtitleBadge };
+const StockIsOpenBadge = memo(({ isOpen }: { isOpen: boolean }) => (
+  <XStack
+    borderRadius="$1"
+    bg={isOpen ? '$bgSuccess' : '$bgStrong'}
+    justifyContent="center"
+    alignItems="center"
+    px="$1.5"
+  >
+    <SizableText
+      fontSize={10}
+      color={isOpen ? '$textSuccess' : '$textSubdued'}
+      lineHeight={16}
+    >
+      {isOpen ? '交易中' : '休市'}
+    </SizableText>
+  </XStack>
+));
+StockIsOpenBadge.displayName = 'StockIsOpenBadge';
+
+export { LeverageBadge, StockIsOpenBadge, SubtitleBadge };

--- a/packages/kit/src/views/UniversalSearch/components/MarketTableHeader.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/MarketTableHeader.tsx
@@ -3,15 +3,14 @@ import { useIntl } from 'react-intl';
 import { SizableText, XStack, useMedia } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
-export const MARKET_NAME_COLUMN_WIDTH = 160;
-export const MARKET_DATA_COLUMN_WIDTH = '25%';
+export const MARKET_DATA_COLUMN_WIDTH = 120;
 
 export function MarketTableHeader() {
   const intl = useIntl();
   const { gtMd } = useMedia();
   return (
     <XStack alignSelf="stretch" mx="$2" px="$3" py="$1.5" gap="$3" ai="center">
-      <XStack w={MARKET_NAME_COLUMN_WIDTH} gap="$1" ai="center" flexShrink={0}>
+      <XStack flex={1} minWidth={0} gap="$1" ai="center">
         <XStack w="$8" ai="center" jc="center">
           <SizableText size="$bodySm" color="$textSubdued">
             #
@@ -21,12 +20,8 @@ export function MarketTableHeader() {
           {intl.formatMessage({ id: ETranslations.global_name }).toUpperCase()}
         </SizableText>
       </XStack>
-      <XStack flex={1} minWidth={0}>
-        <XStack
-          w={gtMd ? MARKET_DATA_COLUMN_WIDTH : undefined}
-          flex={gtMd ? undefined : 1}
-          jc="flex-end"
-        >
+      <XStack flexShrink={0} ai="center">
+        <XStack w={gtMd ? MARKET_DATA_COLUMN_WIDTH : undefined} jc="flex-end">
           <SizableText size="$bodySm" color="$textSubdued" textAlign="right">
             {intl
               .formatMessage({ id: ETranslations.global_price })
@@ -48,15 +43,6 @@ export function MarketTableHeader() {
             <SizableText size="$bodySm" color="$textSubdued" textAlign="right">
               {intl
                 .formatMessage({ id: ETranslations.dexmarket_turnover })
-                .toUpperCase()}
-            </SizableText>
-          </XStack>
-        ) : null}
-        {gtMd ? (
-          <XStack w={MARKET_DATA_COLUMN_WIDTH} jc="flex-end">
-            <SizableText size="$bodySm" color="$textSubdued" textAlign="right">
-              {intl
-                .formatMessage({ id: ETranslations.dexmarket_market_cap })
                 .toUpperCase()}
             </SizableText>
           </XStack>

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
@@ -5,6 +5,7 @@ import { useIntl } from 'react-intl';
 
 import {
   IconButton,
+  Image,
   NumberSizeableText,
   SizableText,
   Stack,
@@ -18,6 +19,7 @@ import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useMarketWatchListV2Atom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2/atoms';
 import { useUniversalSearchActions } from '@onekeyhq/kit/src/states/jotai/contexts/universalSearch';
 import { CommunityRecognizedBadge } from '@onekeyhq/kit/src/views/Market/components/CommunityRecognizedBadge';
+import { SubtitleBadge } from '@onekeyhq/kit/src/views/Market/components/PerpsBadges';
 import { useToDetailPage } from '@onekeyhq/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useToMarketDetailPage';
 import { ETranslations } from '@onekeyhq/shared/src/locale/enum/translations';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
@@ -36,10 +38,7 @@ import type { IUniversalSearchV2MarketToken } from '@onekeyhq/shared/types/searc
 import { MarketStarV2 } from '../../../Market/components/MarketStarV2';
 import { MarketTokenIcon } from '../../../Market/components/MarketTokenIcon';
 import { BaseMarketTokenPrice } from '../../../Market/components/MarketTokenPrice';
-import {
-  MARKET_DATA_COLUMN_WIDTH,
-  MARKET_NAME_COLUMN_WIDTH,
-} from '../MarketTableHeader';
+import { MARKET_DATA_COLUMN_WIDTH } from '../MarketTableHeader';
 
 export function ContractAddress({ address }: { address: string }) {
   const { copyText } = useClipboard();
@@ -165,18 +164,18 @@ export function UniversalSearchV2MarketTokenItem({
     // eslint-disable-next-line camelcase
     volume_24h,
     volume24h: volume24hCamel,
-    marketCap,
     priceChange24hPercent,
     isNative,
     communityRecognized,
+    stock,
   } = item.payload;
 
   // When network is empty, the item was converted from IMarketToken (trending/legacy)
   // and address contains coingeckoId for legacy navigation
-  const isLegacyNavigation = !network;
-
   // eslint-disable-next-line camelcase
   const volume24h = volume24hCamel || volume_24h;
+
+  const isLegacyNavigation = !network;
 
   // Hide favorite button in extension popup and side panel
   const shouldShowFavoriteButton = useMemo(
@@ -258,7 +257,7 @@ export function UniversalSearchV2MarketTokenItem({
       {...listItemPressStyle}
     >
       {/* # + NAME column */}
-      <XStack w={MARKET_NAME_COLUMN_WIDTH} gap="$1" ai="center" flexShrink={0}>
+      <XStack flex={1} minWidth={0} gap="$1" ai="center">
         <XStack w="$8" ai="center" jc="center">
           {shouldShowFavoriteButton ? (
             <MarketStarV2
@@ -282,7 +281,18 @@ export function UniversalSearchV2MarketTokenItem({
               >
                 {formatTokenSymbolForDisplay(symbol)}
               </SizableText>
+              {stock?.sourceLogoUri ? (
+                <Image
+                  width={14}
+                  height={14}
+                  borderRadius="$full"
+                  source={{ uri: stock.sourceLogoUri }}
+                />
+              ) : null}
               {communityRecognized ? <CommunityRecognizedBadge /> : null}
+              {stock?.subtitle ? (
+                <SubtitleBadge subtitle={stock.subtitle} />
+              ) : null}
             </XStack>
             <SizableText size="$bodySm" color="$textSubdued" numberOfLines={1}>
               {name}
@@ -291,13 +301,9 @@ export function UniversalSearchV2MarketTokenItem({
         </XStack>
       </XStack>
 
-      <XStack flex={1} minWidth={0}>
+      <XStack flexShrink={0} ai="center">
         {/* PRICE / 24H column */}
-        <YStack
-          w={gtMd ? MARKET_DATA_COLUMN_WIDTH : undefined}
-          flex={gtMd ? undefined : 1}
-          ai="flex-end"
-        >
+        <YStack w={MARKET_DATA_COLUMN_WIDTH} ai="flex-end">
           <BaseMarketTokenPrice
             price={price}
             size="$bodyMd"
@@ -342,19 +348,6 @@ export function UniversalSearchV2MarketTokenItem({
               formatterOptions={{ capAtMaxT: true }}
             >
               {BigNumber(volume24h).gt(0) ? volume24h : '--'}
-            </NumberSizeableText>
-          </XStack>
-        ) : null}
-
-        {/* MARKET CAP column - desktop only */}
-        {gtMd ? (
-          <XStack w={MARKET_DATA_COLUMN_WIDTH} jc="flex-end" ai="center">
-            <NumberSizeableText
-              size="$bodyMd"
-              formatter="marketCap"
-              formatterOptions={{ capAtMaxT: true }}
-            >
-              {marketCap && BigNumber(marketCap).gt(0) ? marketCap : '--'}
             </NumberSizeableText>
           </XStack>
         ) : null}

--- a/packages/shared/types/market.ts
+++ b/packages/shared/types/market.ts
@@ -1,3 +1,5 @@
+import type { IMarketStockInfo } from './marketV2';
+
 export interface IMarketCategory {
   categoryId: string;
   coingeckoIds: string[];
@@ -267,4 +269,5 @@ export interface IMarketSearchV2Token {
   marketCap?: string;
   priceChange24hPercent?: string;
   communityRecognized?: boolean;
+  stock?: IMarketStockInfo;
 }

--- a/packages/shared/types/marketV2.ts
+++ b/packages/shared/types/marketV2.ts
@@ -1,4 +1,6 @@
 export interface IMarketTokenDetail {
+  networkId?: string;
+  isNative?: boolean;
   address: string;
   logoUrl: string;
   name: string;
@@ -19,6 +21,7 @@ export interface IMarketTokenDetail {
     warningMessage?: string;
   };
   price?: string;
+  priceConverted?: string;
   priceChange1mPercent?: string;
   priceChange5mPercent?: string;
   priceChange30mPercent?: string;
@@ -90,6 +93,7 @@ export interface IMarketTokenDetail {
   vSell24h?: string;
   lastUpdated?: number;
   communityRecognized?: boolean;
+  stock?: IMarketStockInfo;
   [key: string]: unknown;
 }
 
@@ -109,6 +113,12 @@ export interface IMarketTokenListItemExtraData {
   website?: string;
   twitter?: string;
   [key: string]: unknown;
+}
+
+export interface IMarketStockInfo {
+  subtitle: string;
+  sourceLogoUri: string;
+  isOpen: boolean;
 }
 
 export interface IMarketTokenListItem {
@@ -182,6 +192,7 @@ export interface IMarketTokenListItem {
   chainId?: string;
   communityRecognized?: boolean;
   isNative?: boolean;
+  stock?: IMarketStockInfo;
 }
 
 export interface IMarketTokenListResponse {


### PR DESCRIPTION
## Summary
- Add `IMarketStockInfo` type and `stock` field to market token types for tokenized real-world asset support
- Display stock source logo, subtitle badge, and open/closed trading status in token list and detail views
- Add currency conversion support in token detail: shows USD price with user's local currency price below it

## Intent & Context
This change supports tokenized real-world assets (e.g., Ondo tokenized stocks) in the market module. These tokens carry additional metadata (`stock`) indicating the underlying asset's trading source, subtitle, and whether the market is currently open. The token detail view also now fetches a converted price in the user's selected currency and displays it as a secondary line below the USD price.

## Root Cause
N/A — this is a new feature addition.

## Design Decisions
- **`currency: 'usd'` hardcoded for list APIs**: Market list data from the API is always denominated in USD. Previously the currency symbol was read from user settings and applied as a display formatter hint, but since the data itself is always USD, this was misleading. Now `'$'` is passed directly to formatters for list views.
- **`convertCurrency` only for token detail**: The token detail API uniquely supports currency conversion server-side. When the user has selected a non-USD currency, the detail request includes `convertCurrency` and the response `priceConverted` field is shown as a secondary price line.
- **Stock badges reuse `PerpsBadges` infrastructure**: `SubtitleBadge` was already used for perps tokens. The new `StockIsOpenBadge` follows the same pattern for consistency.
- **`useCurrency` hook in `TokenDetailHeaderRight`**: Replaced direct `useSettingsPersistAtom` access with the `useCurrency` hook for cleaner currency symbol access.

## Changes Detail
- `packages/shared/types/marketV2.ts`: Added `IMarketStockInfo` interface; added `stock`, `priceConverted`, `networkId`, `isNative` fields to `IMarketTokenDetail` and `IMarketTokenListItem`
- `packages/shared/types/market.ts`: Added `stock` field to `IMarketSearchV2Token`
- `packages/kit-bg/src/services/ServiceMarketV2.ts`: Token detail API now reads user currency and sends `convertCurrency` param; all list/activity APIs now explicitly pass `currency: 'usd'`
- `packages/kit/src/views/Market/components/PerpsBadges.tsx`: Added `StockIsOpenBadge` component for trading status display
- `packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx`: Shows stock source logo, subtitle badge, and open/closed badge in token header
- `packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderRight.tsx`: Shows converted price below USD price; uses `useCurrency` hook; hardcodes `'$'` for market cap/liquidity formatters
- `packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenIdentityItem/TokenIdentityItem.tsx`: Shows stock source logo and subtitle badge in list items
- `packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsDesktop.tsx`: Passes `stock` to `TokenIdentityItem`; uses `'$'` for currency formatters
- `packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsMobile.tsx`: Same as desktop
- `packages/kit/src/views/Market/components/MarketTokenPrice.tsx`: Hardcodes `'$'` for price formatter (market data is always USD)
- `packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx`: Passes `stock` to `TokenIdentityItem`
- Various `InformationTabs` components: Remove unused `settingsPersistAtom` currency reads, use `'$'` directly

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile, Desktop, Web
- **Risk Areas**: The `convertCurrency` logic in `ServiceMarketV2.fetchTokenDetail` reads from `settingsPersistAtom` directly in the background service — this is an async read and follows the established pattern. The stock badge display is purely additive.

## Test plan
- [ ] Verify market token list shows stock source logo and subtitle badge for tokenized stock tokens (e.g., Ondo tokens)
- [ ] Verify `StockIsOpenBadge` shows correct open/closed state and color
- [ ] Verify token detail header shows both USD price and converted local currency price when user currency is non-USD
- [ ] Verify token detail header shows only USD price when user currency is USD
- [ ] Verify market cap and liquidity still display correctly with `'$'` symbol
- [ ] Verify non-stock tokens are unaffected (no badge displayed)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
