### PR TITLE
feat(perp): add full-page mobile skeleton and optimize loading speed

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -957,27 +957,28 @@ export default class ServiceHyperliquid extends ServiceBase {
         }),
       );
 
-      // TODO reset exchange client if account not exists, or address not exists
-      await this.exchangeService.setup({
-        userAddress: accountAddress,
-        userAccountId: selectedAccount.accountId ?? undefined,
-      });
-
       if (!accountAddress) {
         throw new OneKeyLocalError(
           'Check perps account status ERROR: Account address is required',
         );
       }
 
+      // Run exchange setup and activation check in parallel
       let isActivated = false;
       if (hyperLiquidCache?.activatedUser?.[accountAddress] === true) {
         isActivated = true;
       }
-      if (!isActivated) {
-        const userRole = await infoClient.userRole({
-          user: accountAddress,
-        });
-        isActivated = userRole.role !== 'missing';
+      const [, userRoleResult] = await Promise.all([
+        this.exchangeService.setup({
+          userAddress: accountAddress,
+          userAccountId: selectedAccount.accountId ?? undefined,
+        }),
+        !isActivated
+          ? infoClient.userRole({ user: accountAddress })
+          : Promise.resolve(null),
+      ]);
+      if (!isActivated && userRoleResult) {
+        isActivated = userRoleResult.role !== 'missing';
       }
       if (!isActivated) {
         statusDetails.activatedOk = false;
@@ -997,19 +998,19 @@ export default class ServiceHyperliquid extends ServiceBase {
         hyperLiquidCache.activatedUser[accountAddress] = true;
         statusDetails.activatedOk = true;
 
-        // Builder fee must be approved before agent setup
-        await this.checkBuilderFeeStatus({
-          accountAddress,
-          accountId: selectedAccount.accountId,
-          isEnableTradingTrigger,
-          statusDetails,
-        });
-
-        const isRebateBound =
-          await this.checkInternalRebateBindingStatusWithCache({
+        // Run builderFee check in parallel with rebate check
+        const [, isRebateBound] = await Promise.all([
+          this.checkBuilderFeeStatus({
+            accountAddress,
+            accountId: selectedAccount.accountId,
+            isEnableTradingTrigger,
+            statusDetails,
+          }),
+          this.checkInternalRebateBindingStatusWithCache({
             accountId: selectedAccount.accountId,
             accountAddress,
-          });
+          }),
+        ]);
 
         // Clear local credentials to force new agent creation for rebate binding
         if (!isRebateBound) {

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -202,40 +202,46 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     return { requiredSubSpecsMap, params };
   }
 
+  private _hasInitialSubscription = false;
+
+  private async _updateSubscriptionsCore() {
+    const requiredSubInfo = await this.buildRequiredSubscriptionsMap();
+    if (!requiredSubInfo) {
+      return;
+    }
+
+    this.allSubSpecsMap = {
+      ...this.allSubSpecsMap,
+      ...requiredSubInfo.requiredSubSpecsMap,
+    };
+    if (isEmpty(this.allSubSpecsMap)) {
+      // debugger;
+    }
+    this.pendingSubSpecsMap = {
+      ...requiredSubInfo.requiredSubSpecsMap,
+    };
+
+    const newState: ISubscriptionState = { ...this._currentState };
+
+    this._applyStateUpdates(newState, requiredSubInfo.params);
+
+    console.log('updateSubscriptions____state', {
+      requiredSubSpecsMap: requiredSubInfo.requiredSubSpecsMap,
+      requiredParams: requiredSubInfo.params,
+      allSubSpecsMap: this.allSubSpecsMap,
+      pendingSubSpecsMap: this.pendingSubSpecsMap,
+      newState,
+    });
+
+    this._emitConnectionStatus();
+    this._executeSubscriptionChanges();
+
+    this._currentState = newState;
+  }
+
   _updateSubscriptionsDebounced = debounce(
     async () => {
-      const requiredSubInfo = await this.buildRequiredSubscriptionsMap();
-      if (!requiredSubInfo) {
-        return;
-      }
-
-      this.allSubSpecsMap = {
-        ...this.allSubSpecsMap,
-        ...requiredSubInfo.requiredSubSpecsMap,
-      };
-      if (isEmpty(this.allSubSpecsMap)) {
-        // debugger;
-      }
-      this.pendingSubSpecsMap = {
-        ...requiredSubInfo.requiredSubSpecsMap,
-      };
-
-      const newState: ISubscriptionState = { ...this._currentState };
-
-      this._applyStateUpdates(newState, requiredSubInfo.params);
-
-      console.log('updateSubscriptions____state', {
-        requiredSubSpecsMap: requiredSubInfo.requiredSubSpecsMap,
-        requiredParams: requiredSubInfo.params,
-        allSubSpecsMap: this.allSubSpecsMap,
-        pendingSubSpecsMap: this.pendingSubSpecsMap,
-        newState,
-      });
-
-      this._emitConnectionStatus();
-      this._executeSubscriptionChanges();
-
-      this._currentState = newState;
+      await this._updateSubscriptionsCore();
     },
     300,
     {
@@ -246,6 +252,12 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
   @backgroundMethod()
   async updateSubscriptions(): Promise<void> {
+    // Skip debounce on first subscription to speed up initial load
+    if (!this._hasInitialSubscription) {
+      this._hasInitialSubscription = true;
+      await this._updateSubscriptionsCore();
+      return;
+    }
     await this._updateSubscriptionsDebounced();
   }
 
@@ -583,6 +595,11 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       event,
     });
   };
+
+  @backgroundMethod()
+  async preWarmWebSocketConnection(): Promise<void> {
+    await this.getWebSocketClient();
+  }
 
   private async getWebSocketClient(): Promise<IHyperliquidWsClient> {
     if (this._client) {

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/PerpGallery.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/PerpGallery.tsx
@@ -10,6 +10,8 @@ import {
   XStack,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { EModalSettingRoutes } from '@onekeyhq/shared/src/routes';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { Layout } from './utils/Layout';
@@ -41,6 +43,19 @@ function demoError(error: unknown, apiName: string) {
   if (!platformEnv.isNative) {
     console.error('Hyperliquid API Error:', error);
   }
+}
+
+function SkeletonPreviewButton() {
+  const navigation = useAppNavigation();
+  return (
+    <Button
+      onPress={() => {
+        navigation.push(EModalSettingRoutes.SettingDevPerpSkeletonPreview);
+      }}
+    >
+      Open Full-Page Skeleton Preview
+    </Button>
+  );
 }
 
 export function PerpApiTests() {
@@ -514,6 +529,10 @@ const PerpGallery = () => (
     getFilePath={() => __CURRENT_FILE_PATH__}
     componentName="PerpGallery"
     elements={[
+      {
+        title: 'Mobile Full-Page Skeleton',
+        element: <SkeletonPreviewButton />,
+      },
       {
         title: 'Hyperliquid API Test 2862',
         element: <PerpApiTests />,

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/PerpMobileSkeleton.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/PerpMobileSkeleton.tsx
@@ -1,0 +1,24 @@
+import { YStack } from '@onekeyhq/components';
+
+import { PerpMobileLayoutSkeleton } from '../../../../../Perp/layouts/PerpMobileLayoutSkeleton';
+
+import { Layout } from './utils/Layout';
+
+const PerpMobileSkeletonGallery = () => (
+  <Layout
+    getFilePath={() => __CURRENT_FILE_PATH__}
+    componentName="PerpMobileSkeleton"
+    elements={[
+      {
+        title: 'Perp Mobile Full-Page Skeleton',
+        element: (
+          <YStack h={700} w="100%" bg="$bgApp" borderWidth="$px" borderColor="$borderSubdued" borderRadius="$4" overflow="hidden">
+            <PerpMobileLayoutSkeleton />
+          </YStack>
+        ),
+      },
+    ]}
+  />
+);
+
+export default PerpMobileSkeletonGallery;

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/PerpSkeletonPreview.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/PerpSkeletonPreview.tsx
@@ -1,0 +1,14 @@
+import { Page } from '@onekeyhq/components';
+
+import { PerpMobileLayoutSkeleton } from '../../../../../Perp/layouts/PerpMobileLayoutSkeleton';
+
+export default function PerpSkeletonPreview() {
+  return (
+    <Page>
+      <Page.Header title="Perp Skeleton Preview" />
+      <Page.Body>
+        <PerpMobileLayoutSkeleton />
+      </Page.Body>
+    </Page>
+  );
+}

--- a/packages/kit/src/views/Developer/pages/Gallery/index.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/index.tsx
@@ -208,6 +208,10 @@ const SkeletonGallery = LazyLoadPage(
   () =>
     import('@onekeyhq/kit/src/views/Developer/pages/Gallery/Components/stories/Skeleton'),
 );
+const PerpMobileSkeletonGallery = LazyLoadPage(
+  () =>
+    import('@onekeyhq/kit/src/views/Developer/pages/Gallery/Components/stories/PerpMobileSkeleton'),
+);
 const SliderGallery = LazyLoadPage(
   () =>
     import('@onekeyhq/kit/src/views/Developer/pages/Gallery/Components/stories/Slider'),
@@ -580,6 +584,10 @@ export const galleryScreenList: {
   },
   { name: EGalleryRoutes.ComponentListItem, component: ListItemGallery },
   { name: EGalleryRoutes.ComponentSkeleton, component: SkeletonGallery },
+  {
+    name: EGalleryRoutes.ComponentPerpMobileSkeleton,
+    component: PerpMobileSkeletonGallery,
+  },
   { name: EGalleryRoutes.ComponentCheckbox, component: CheckboxGallery },
   { name: EGalleryRoutes.ComponentActionList, component: ActionListGallery },
   { name: EGalleryRoutes.ComponentPopover, component: PopoverGallery },

--- a/packages/kit/src/views/Perp/components/OrderBook/DefaultLoadingNode.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/DefaultLoadingNode.tsx
@@ -116,10 +116,18 @@ export function DefaultLoadingNode({
         </XStack>
 
         <YStack gap="$1.5" flex={1}>
-          <Skeleton w="100%" h={MOBILE_ROW_HEIGHT} radius="round" />
-          <Skeleton w="80%" h={MOBILE_ROW_HEIGHT} radius="round" />
-          <Skeleton w="60%" h={MOBILE_ROW_HEIGHT} radius="round" />
-          <Skeleton w="40%" h={MOBILE_ROW_HEIGHT} radius="round" />
+          <XStack w="100%" h={MOBILE_ROW_HEIGHT}>
+            <Skeleton w="100%" h="100%" radius="round" />
+          </XStack>
+          <XStack w="80%" h={MOBILE_ROW_HEIGHT}>
+            <Skeleton w="100%" h="100%" radius="round" />
+          </XStack>
+          <XStack w="60%" h={MOBILE_ROW_HEIGHT}>
+            <Skeleton w="100%" h="100%" radius="round" />
+          </XStack>
+          <XStack w="40%" h={MOBILE_ROW_HEIGHT}>
+            <Skeleton w="100%" h="100%" radius="round" />
+          </XStack>
         </YStack>
       </YStack>
     );

--- a/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
+++ b/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
@@ -450,7 +450,7 @@ export function PerpOrderBook({
         entry === 'perpMobileMarket' ? 'mobileHorizontal' : 'mobileVertical';
     }
     return (
-      <YStack flex={1} p="$2" justifyContent="center" alignItems="center">
+      <YStack flex={1} justifyContent="center" alignItems="center">
         <DefaultLoadingNode
           variant={loadingVariant as IOrderBookVariant}
           symbol={

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -4,7 +4,6 @@ import { memo, useCallback, useEffect, useRef } from 'react';
 import { isEqual, noop } from 'lodash';
 
 import { useUpdateEffect } from '@onekeyhq/components';
-import { DelayedRender } from '@onekeyhq/components/src/hocs/DelayedRender';
 import {
   useAccountIsAutoCreatingAtom,
   useAppIsLockedAtom,
@@ -352,6 +351,8 @@ function useHyperliquidAccountSelect() {
       walletId: activeAccount?.wallet?.id || null,
       deriveType: globalDeriveType,
     });
+    // Pre-warm WebSocket connection in parallel with account status check
+    void backgroundApiProxy.serviceHyperliquidSubscription.preWarmWebSocketConnection();
     await checkPerpsAccountStatus();
   }, [
     actions,
@@ -651,9 +652,7 @@ function PerpsGlobalEffectsView() {
 
   return (
     <>
-      <DelayedRender delay={600}>
-        <WebSocketSubscriptionUpdate />
-      </DelayedRender>
+      <WebSocketSubscriptionUpdate />
       <AutoPauseSubscriptions />
     </>
   );

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -1141,7 +1141,11 @@ function DepositWithdrawContent({
 
   const depositTokenSelectComponent = useMemo(() => {
     if (balanceLoading && checkAccountSupport)
-      return <Skeleton w={40} h={14} radius="round" />;
+      return (
+        <XStack w={40} h={14}>
+          <Skeleton w="100%" h="100%" radius="round" />
+        </XStack>
+      );
     if (depositTokensWithPrice.length === 0)
       return (
         <SizableText size="$bodyMd" color="$textSubdued">
@@ -1406,7 +1410,9 @@ function DepositWithdrawContent({
           </SizableText>
           <XStack alignItems="center" gap="$2">
             {balanceLoading && checkAccountSupport ? (
-              <Skeleton w={80} h={14} />
+              <XStack w={80} h={14}>
+                <Skeleton w="100%" h="100%" />
+              </XStack>
             ) : (
               <>
                 <SizableText size="$bodyMd" color="$text">
@@ -1524,7 +1530,9 @@ function DepositWithdrawContent({
           ) : (
             <XStack gap="$1" alignItems="center" justifyContent="center">
               {perpDepositQuoteLoading ? (
-                <Skeleton w={60} h={14} />
+                <XStack w={60} h={14}>
+                  <Skeleton w="100%" h="100%" />
+                </XStack>
               ) : (
                 <XStack gap="$1">
                   <SizableText color="$text" size="$bodyMd">

--- a/packages/kit/src/views/Perp/layouts/PerpMobileLayout.tsx
+++ b/packages/kit/src/views/Perp/layouts/PerpMobileLayout.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useState } from 'react';
+import { memo, useCallback, useMemo, useRef, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 import { RefreshControl, ScrollView } from 'react-native';
@@ -20,6 +20,10 @@ import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
 import useAppNavigation from '../../../hooks/useAppNavigation';
 import { useHyperliquidActions } from '../../../states/jotai/contexts/hyperliquid';
 import {
+  usePerpsAccountLoadingInfoAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  useL2BookAtom,
   usePerpsActiveOpenOrdersLengthAtom,
   usePerpsActivePositionLengthAtom,
   usePerpsAllMidsAtom,
@@ -121,8 +125,19 @@ export function PerpMobileLayout() {
   }, [actions]);
 
   const [allMids] = usePerpsAllMidsAtom();
+  const [l2Book] = useL2BookAtom();
+  const [perpsAccountLoading] = usePerpsAccountLoadingInfoAtom();
   const [openOrdersLength] = usePerpsActiveOpenOrdersLengthAtom();
   const [positionsLength] = usePerpsActivePositionLengthAtom();
+
+  const hasInitialLoadRef = useRef(false);
+  const isInitialLoading =
+    allMids === null ||
+    l2Book === null ||
+    perpsAccountLoading.enableTradingLoading;
+  if (!isInitialLoading) {
+    hasInitialLoadRef.current = true;
+  }
 
   const positionsTabCount = useMemo(() => {
     if (positionsLength > 0) {
@@ -137,7 +152,7 @@ export function PerpMobileLayout() {
     }
     return '';
   }, [openOrdersLength]);
-  if (allMids === null) {
+  if (!hasInitialLoadRef.current && isInitialLoading) {
     return <PerpMobileLayoutSkeleton />;
   }
 

--- a/packages/kit/src/views/Perp/layouts/PerpMobileLayout.tsx
+++ b/packages/kit/src/views/Perp/layouts/PerpMobileLayout.tsx
@@ -22,7 +22,9 @@ import { useHyperliquidActions } from '../../../states/jotai/contexts/hyperliqui
 import {
   usePerpsActiveOpenOrdersLengthAtom,
   usePerpsActivePositionLengthAtom,
+  usePerpsAllMidsAtom,
 } from '../../../states/jotai/contexts/hyperliquid/atoms';
+import { PerpMobileLayoutSkeleton } from './PerpMobileLayoutSkeleton';
 import { PerpOpenOrdersList } from '../components/OrderInfoPanel/List/PerpOpenOrdersList';
 import { PerpPositionsList } from '../components/OrderInfoPanel/List/PerpPositionsList';
 import { PerpMobileNetworkAlert } from '../components/PerpMobileNetworkAlert';
@@ -118,6 +120,7 @@ export function PerpMobileLayout() {
     }
   }, [actions]);
 
+  const [allMids] = usePerpsAllMidsAtom();
   const [openOrdersLength] = usePerpsActiveOpenOrdersLengthAtom();
   const [positionsLength] = usePerpsActivePositionLengthAtom();
 
@@ -134,6 +137,10 @@ export function PerpMobileLayout() {
     }
     return '';
   }, [openOrdersLength]);
+  if (allMids === null) {
+    return <PerpMobileLayoutSkeleton />;
+  }
+
   return (
     <ScrollView
       style={{ flex: 1, backgroundColor: '$bgApp' }}

--- a/packages/kit/src/views/Perp/layouts/PerpMobileLayoutSkeleton.tsx
+++ b/packages/kit/src/views/Perp/layouts/PerpMobileLayoutSkeleton.tsx
@@ -1,0 +1,53 @@
+import { Skeleton, XStack, YStack } from '@onekeyhq/components';
+
+export function PerpMobileLayoutSkeleton() {
+  return (
+    <YStack flex={1} bg="$bgApp" px="$4" pt="$2" gap="$2.5">
+      {/* ── Row 1: Token name+badges (left) | icon buttons (right) ── */}
+      <XStack jc="space-between">
+        <Skeleton w={160} h={50} />
+        <Skeleton w={140} h={30} />
+      </XStack>
+
+      {/* ── Row 2+3: Funding rate + OrderBook (left) | Trading Panel (right) ── */}
+      <XStack gap="$6">
+        {/* Left column */}
+        <YStack flex={2} gap="$2.5">
+          {/* Funding rate / countdown */}
+          <Skeleton h={28} />
+          {/* Order book asks */}
+          <Skeleton h={90} />
+          {/* Mid price / spread */}
+          <Skeleton flex={1} w={80} />
+          {/* Order book bids */}
+          <Skeleton h={90} />
+          {/* Tick selector */}
+          <Skeleton h={28} />
+        </YStack>
+
+        {/* Right column */}
+        <YStack flex={3} gap="$2.5">
+          {/* Margin mode + Leverage + Order type + Available + Price + Size + Slider + TP/SL */}
+          <Skeleton h={280} />
+          {/* Cost + Est.Liq + Buy/Long button */}
+          <Skeleton h={40} radius={9999} />
+        </YStack>
+      </XStack>
+
+      {/* ── Bottom: Tab bar ── */}
+      <Skeleton h={30} my="4" />
+
+      {/* ── Empty state content ── */}
+      <XStack jc="space-between" gap="$20">
+        <Skeleton h={60} flex={4} />
+        <Skeleton h={20} flex={1} />
+      </XStack>
+      {/* ── Three bottom action blocks ── */}
+      <XStack gap="$10" pb="$4">
+        <Skeleton flex={1} h={36} />
+        <Skeleton flex={1} h={36} />
+        <Skeleton flex={1} h={36} />
+      </XStack>
+    </YStack>
+  );
+}

--- a/packages/kit/src/views/Perp/layouts/PerpMobileLayoutSkeleton.tsx
+++ b/packages/kit/src/views/Perp/layouts/PerpMobileLayoutSkeleton.tsx
@@ -2,17 +2,17 @@ import { Skeleton, XStack, YStack } from '@onekeyhq/components';
 
 export function PerpMobileLayoutSkeleton() {
   return (
-    <YStack flex={1} bg="$bgApp" px="$4" pt="$2" gap="$2.5">
+    <YStack flex={1} bg="$bgApp" px="$4" pt="$2" gap="$4">
       {/* ── Row 1: Token name+badges (left) | icon buttons (right) ── */}
       <XStack jc="space-between">
         <Skeleton w={160} h={50} />
-        <Skeleton w={140} h={30} />
+        <Skeleton w={140} h={30} radius={9999} />
       </XStack>
 
       {/* ── Row 2+3: Funding rate + OrderBook (left) | Trading Panel (right) ── */}
-      <XStack gap="$6">
+      <XStack gap="$9">
         {/* Left column */}
-        <YStack flex={2} gap="$2.5">
+        <YStack flex={2} gap="$4">
           {/* Funding rate / countdown */}
           <Skeleton h={28} />
           {/* Order book asks */}
@@ -26,7 +26,7 @@ export function PerpMobileLayoutSkeleton() {
         </YStack>
 
         {/* Right column */}
-        <YStack flex={3} gap="$2.5">
+        <YStack flex={3} gap="$4">
           {/* Margin mode + Leverage + Order type + Available + Price + Size + Slider + TP/SL */}
           <Skeleton h={280} />
           {/* Cost + Est.Liq + Buy/Long button */}
@@ -35,18 +35,21 @@ export function PerpMobileLayoutSkeleton() {
       </XStack>
 
       {/* ── Bottom: Tab bar ── */}
-      <Skeleton h={30} my="4" />
-
+      <XStack h={30} my="4">
+        <Skeleton />
+      </XStack>
       {/* ── Empty state content ── */}
       <XStack jc="space-between" gap="$20">
-        <Skeleton h={60} flex={4} />
-        <Skeleton h={20} flex={1} />
+        <Skeleton h={60} flex={2} />
+        <XStack h={20} flex={1}>
+          <Skeleton />
+        </XStack>
       </XStack>
       {/* ── Three bottom action blocks ── */}
       <XStack gap="$10" pb="$4">
-        <Skeleton flex={1} h={36} />
-        <Skeleton flex={1} h={36} />
-        <Skeleton flex={1} h={36} />
+        <Skeleton flex={1} h={36} radius={9999} />
+        <Skeleton flex={1} h={36} radius={9999} />
+        <Skeleton flex={1} h={36} radius={9999} />
       </XStack>
     </YStack>
   );

--- a/packages/kit/src/views/Setting/router/basicModalSettingRouter.ts
+++ b/packages/kit/src/views/Setting/router/basicModalSettingRouter.ts
@@ -68,6 +68,11 @@ const PerpGallery = LazyLoadPage(
     import('@onekeyhq/kit/src/views/Developer/pages/Gallery/Components/stories/PerpGallery'),
 );
 
+const PerpSkeletonPreview = LazyLoadPage(
+  () =>
+    import('@onekeyhq/kit/src/views/Developer/pages/Gallery/Components/stories/PerpSkeletonPreview'),
+);
+
 const CryptoGallery = LazyLoadPage(
   () =>
     import('@onekeyhq/kit/src/views/Developer/pages/Gallery/Components/stories/CryptoGallery'),
@@ -224,6 +229,10 @@ export const BasicModalSettingStack: IModalFlowNavigatorConfig<
   {
     name: EModalSettingRoutes.SettingDevPerpGalleryModal,
     component: PerpGallery,
+  },
+  {
+    name: EModalSettingRoutes.SettingDevPerpSkeletonPreview,
+    component: PerpSkeletonPreview,
   },
   {
     name: EModalSettingRoutes.SettingDevCryptoGalleryModal,

--- a/packages/shared/src/routes/gallery.ts
+++ b/packages/shared/src/routes/gallery.ts
@@ -74,6 +74,7 @@ export enum EGalleryRoutes {
   ComponentSend = 'component-Send',
   ComponentShortcut = 'component-Shortcut',
   ComponentSkeleton = 'component-Skeleton',
+  ComponentPerpMobileSkeleton = 'component-PerpMobileSkeleton',
   ComponentSlider = 'component-Slider',
   ComponentSegmentSlider = 'component-SegmentSlider',
   ComponentSortableListView = 'component-SortableListView',

--- a/packages/shared/src/routes/setting.ts
+++ b/packages/shared/src/routes/setting.ts
@@ -18,6 +18,7 @@ export enum EModalSettingRoutes {
   SettingDevUnitTestsModal = 'SettingDevUnitTestsModal',
   SettingDevDesktopApiProxyTestModal = 'SettingDevDesktopApiProxyTestModal',
   SettingDevPerpGalleryModal = 'SettingDevPerpGalleryModal',
+  SettingDevPerpSkeletonPreview = 'SettingDevPerpSkeletonPreview',
   SettingDevCryptoGalleryModal = 'SettingDevCryptoGalleryModal',
   SettingDevCloudBackupGalleryModal = 'SettingDevCloudBackupGalleryModal',
   SettingDevAuthGalleryModal = 'SettingDevAuthGalleryModal',
@@ -63,6 +64,7 @@ export type IModalSettingParamList = {
   [EModalSettingRoutes.SettingDevUnitTestsModal]: undefined;
   [EModalSettingRoutes.SettingDevDesktopApiProxyTestModal]: undefined;
   [EModalSettingRoutes.SettingDevPerpGalleryModal]: undefined;
+  [EModalSettingRoutes.SettingDevPerpSkeletonPreview]: undefined;
   [EModalSettingRoutes.SettingDevCryptoGalleryModal]: undefined;
   [EModalSettingRoutes.SettingDevCloudBackupGalleryModal]: undefined;
   [EModalSettingRoutes.SettingDevAuthGalleryModal]: undefined;


### PR DESCRIPTION
## Summary
- 新增 Perp 移动端全屏骨架图 loading，覆盖 allMids、l2Book、enableTradingLoading 等数据加载阶段
- 优化加载速度：移除 600ms DelayedRender、首次订阅跳过 300ms 防抖、并行化 API 调用、WebSocket 预热
- 全屏骨架图仅在首次加载时显示，切换币种不会触发
- 修复订单簿局部 loading padding 不对齐问题，skeleton 统一用 XStack 包裹
- 新增 dev gallery 骨架图预览页面，方便调试 UI

https://github.com/user-attachments/assets/85f7049d-c8fa-412b-9860-a404b25d268c


