### PR TITLE
fix: allow onekeytest.com subdomains to call private provider API

### DIFF
--- a/packages/kit-bg/src/apis/backgroundApiPermissions.ts
+++ b/packages/kit-bg/src/apis/backgroundApiPermissions.ts
@@ -86,6 +86,7 @@ export function isProviderApiPrivateAllowedOrigin(origin?: string) {
   return (
     origin &&
     (origin?.endsWith('.onekey.so') ||
+      origin?.endsWith('.onekeytest.com') ||
       PROVIDER_API_PRIVATE_WHITE_LIST_ORIGIN.includes(origin))
   );
 }


### PR DESCRIPTION
## Summary
- Add `.onekeytest.com` suffix matching to the private provider API origin allowlist
- Fixes `learning.onekeytest.com` being rejected when calling `$private` methods like `wallet_getRookieGuideInfo`

## Intent & Context
The rookie guide feature on `https://learning.onekeytest.com` was failing with error: `[https://learning.onekeytest.com] is not allowed to call $private methods: wallet_getRookieGuideInfo`. The test environment subdomains needed access to private provider APIs.

## Root Cause
The `isProviderApiPrivateAllowedOrigin` function in `backgroundApiPermissions.ts` only matched origins ending with `.onekey.so` via suffix check. The allowlist included `https://onekeytest.com` as an exact match, but subdomains like `learning.onekeytest.com` were not covered by either the suffix check or the explicit list.

## Design Decisions
Added `.onekeytest.com` suffix matching (mirroring the existing `.onekey.so` pattern) rather than adding individual subdomain entries. This ensures all current and future test environment subdomains are covered without requiring allowlist updates for each new subdomain.

## Changes Detail
- `packages/kit-bg/src/apis/backgroundApiPermissions.ts`: Added `origin?.endsWith('.onekeytest.com')` check to `isProviderApiPrivateAllowedOrigin`

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Broadens private API access to all `.onekeytest.com` subdomains — acceptable since this is the test environment domain

## Test plan
- [ ] Verify `learning.onekeytest.com` can successfully call `wallet_getRookieGuideInfo`
- [ ] Verify `*.onekey.so` origins still work
- [ ] Verify arbitrary external origins are still blocked from `$private` methods
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
