### PR TITLE
fix: unify currency between native subscription page and webview payment (OK-51235)

### DIFF
--- a/apps/web-embed/pages/PageWebEmbedPrimePurchase.tsx
+++ b/apps/web-embed/pages/PageWebEmbedPrimePurchase.tsx
@@ -90,6 +90,7 @@ export default function PageWebEmbedPrimePurchase() {
     primeUserEmail,
     subscriptionPeriod,
     locale,
+    currency,
     mode,
     featureName,
   } = webEmbedQueryParams || {};
@@ -119,6 +120,7 @@ export default function PageWebEmbedPrimePurchase() {
         subscriptionPeriod,
         email: primeUserEmail,
         locale,
+        currency,
         featureName: validFeatureName,
       });
 
@@ -156,6 +158,7 @@ export default function PageWebEmbedPrimePurchase() {
     apiKey,
     purchasePackageWeb,
     locale,
+    currency,
     featureName,
   ]);
 

--- a/packages/kit/src/views/Prime/components/PrimePurchaseDialog/PrimePurchaseDialog.tsx
+++ b/packages/kit/src/views/Prime/components/PrimePurchaseDialog/PrimePurchaseDialog.tsx
@@ -60,9 +60,11 @@ export function usePrimePurchaseCallback({
   const purchase = useCallback(
     async ({
       selectedSubscriptionPeriod,
+      currency,
       featureName,
     }: {
       selectedSubscriptionPeriod: ISubscriptionPeriod;
+      currency?: string;
       featureName?: EPrimeFeatures;
     }) => {
       try {
@@ -102,6 +104,7 @@ export function usePrimePurchaseCallback({
                       onPress: () => {
                         void purchaseByWebview({
                           selectedSubscriptionPeriod,
+                          currency,
                           featureName,
                         });
                       },
@@ -113,6 +116,7 @@ export function usePrimePurchaseCallback({
           } else {
             void purchaseByWebview({
               selectedSubscriptionPeriod,
+              currency,
               featureName,
             });
           }
@@ -124,6 +128,7 @@ export function usePrimePurchaseCallback({
             subscriptionPeriod: selectedSubscriptionPeriod,
             email: supabaseUser?.email || '',
             locale: intl.locale,
+            currency,
             featureName,
           });
           // await backgroundApiProxy.servicePrime.initRevenuecatPurchases({
@@ -199,8 +204,12 @@ export const PrimePurchaseDialog = (props: {
           disabled: !packages,
         }}
         onConfirm={() => {
+          const currency = packages?.find(
+            (p) => p.subscriptionPeriod === selectedSubscriptionPeriod,
+          )?.currencyCode;
           return purchase({
             selectedSubscriptionPeriod,
+            currency,
             featureName,
           });
         }}

--- a/packages/kit/src/views/Prime/components/PrimePurchaseDialog/usePurchasePackageWebview.ts
+++ b/packages/kit/src/views/Prime/components/PrimePurchaseDialog/usePurchasePackageWebview.ts
@@ -21,9 +21,11 @@ export function usePurchasePackageWebview() {
   const purchasePackageWebview = useCallback(
     async ({
       selectedSubscriptionPeriod,
+      currency,
       featureName,
     }: {
       selectedSubscriptionPeriod: ISubscriptionPeriod | undefined;
+      currency?: string;
       featureName?: EPrimeFeatures;
     }) => {
       if (!selectedSubscriptionPeriod) {
@@ -46,6 +48,7 @@ export function usePurchasePackageWebview() {
           locale: intl.locale,
           mode: platformEnv.isDev ? 'dev' : 'prod',
           apiKey: apiKey || '',
+          ...(currency ? { currency } : {}),
           ...(featureName ? { featureName } : {}),
         },
       });

--- a/packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.native.ts
+++ b/packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.native.ts
@@ -188,6 +188,7 @@ export function usePrimePaymentMethods(): IUsePrimePayment {
 
       packages.push({
         subscriptionPeriod: subscriptionPeriod as ISubscriptionPeriod,
+        currencyCode,
         pricePerYear: pricePerYear || 0,
         pricePerYearString: `${new BigNumber(pricePerYear || 0).toFixed(
           2,

--- a/packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.web-embed.ts
+++ b/packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.web-embed.ts
@@ -40,6 +40,7 @@ export function usePrimePaymentMethods(): IUsePrimePayment {
       '') as ISubscriptionPeriod;
     const locale = searchParams.get('locale') || 'en';
     const mode = (searchParams.get('mode') || 'prod') as 'dev' | 'prod';
+    const currency = searchParams.get('currency') || undefined;
     const featureName = searchParams.get('featureName') || '';
     return {
       apiKey,
@@ -47,6 +48,7 @@ export function usePrimePaymentMethods(): IUsePrimePayment {
       primeUserEmail,
       subscriptionPeriod,
       locale,
+      currency,
       mode,
       featureName,
     };
@@ -104,7 +106,9 @@ export function usePrimePaymentMethods(): IUsePrimePayment {
       throw new OneKeyLocalError('PrimeAuth Not ready');
     }
 
-    const offerings = await Purchases.getSharedInstance().getOfferings();
+    const offerings = await Purchases.getSharedInstance().getOfferings(
+      params.currency ? { currency: params.currency } : undefined,
+    );
 
     const packages: IPackage[] =
       offerings?.current?.availablePackages?.map((p) => {
@@ -122,6 +126,7 @@ export function usePrimePaymentMethods(): IUsePrimePayment {
 
         return {
           subscriptionPeriod: normalPeriodDuration as ISubscriptionPeriod,
+          currencyCode,
           pricePerYear: Number(pricePerYear),
           pricePerYearString: `${pricePerYear} ${currencyCode}`,
           pricePerMonth: Number(pricePerMonth),
@@ -136,24 +141,27 @@ export function usePrimePaymentMethods(): IUsePrimePayment {
     });
 
     return packages;
-  }, [initSdk, isReady]);
+  }, [initSdk, isReady, params.currency]);
 
   const purchasePackageWeb = useCallback(
     async ({
       subscriptionPeriod,
       email,
       locale,
+      currency,
       featureName,
     }: {
       subscriptionPeriod: string;
       email: string;
       locale?: string; // https://www.revenuecat.com/docs/tools/paywalls/creating-paywalls#supported-locales
+      currency?: string;
       featureName?: EPrimeFeatures;
     }) => {
       console.log('purchasePackageWeb77632723>>>>>>', {
         subscriptionPeriod,
         email,
         locale,
+        currency,
         featureName,
       });
 
@@ -177,7 +185,9 @@ export function usePrimePaymentMethods(): IUsePrimePayment {
           'purchasePackageWeb77632723>>>>>> getOfferings',
           typeof Purchases.getSharedInstance().getOfferings,
         );
-        const offerings = await Purchases.getSharedInstance().getOfferings();
+        const offerings = await Purchases.getSharedInstance().getOfferings(
+          currency ? { currency } : undefined,
+        );
         console.log('purchasePackageWeb77632723>>>>>> offerings', {
           offerings,
         });

--- a/packages/kit/src/views/Prime/hooks/usePrimePaymentMethodsWeb.ts
+++ b/packages/kit/src/views/Prime/hooks/usePrimePaymentMethodsWeb.ts
@@ -121,6 +121,7 @@ export function usePrimePaymentMethodsWeb(): IUsePrimePayment {
 
         return {
           subscriptionPeriod: normalPeriodDuration as ISubscriptionPeriod,
+          currencyCode,
           pricePerYear: Number(pricePerYear),
           pricePerYearString: `${pricePerYear} ${currencyCode}`,
           pricePerMonth: Number(pricePerMonth),
@@ -142,11 +143,13 @@ export function usePrimePaymentMethodsWeb(): IUsePrimePayment {
       subscriptionPeriod,
       email,
       locale,
+      currency,
       featureName,
     }: {
       subscriptionPeriod: string;
       email: string;
       locale?: string; // https://www.revenuecat.com/docs/tools/paywalls/creating-paywalls#supported-locales
+      currency?: string;
       featureName?: EPrimeFeatures;
     }) => {
       await initSdk({ loginRequired: true });
@@ -162,7 +165,9 @@ export function usePrimePaymentMethodsWeb(): IUsePrimePayment {
         //   }),
         // });
 
-        const offerings = await Purchases.getSharedInstance().getOfferings();
+        const offerings = await Purchases.getSharedInstance().getOfferings(
+          currency ? { currency } : undefined,
+        );
 
         if (!offerings.current) {
           throw new OneKeyLocalError(

--- a/packages/kit/src/views/Prime/hooks/usePrimePaymentTypes.ts
+++ b/packages/kit/src/views/Prime/hooks/usePrimePaymentTypes.ts
@@ -13,6 +13,7 @@ export type ISubscriptionPeriod = 'P1Y' | 'P1M';
 
 export type IPackage = {
   subscriptionPeriod: ISubscriptionPeriod;
+  currencyCode: string;
   pricePerMonth: number;
   pricePerMonthString: string;
   pricePerYear: number;
@@ -37,6 +38,7 @@ export type IUsePrimePayment = {
     primeUserEmail: string;
     subscriptionPeriod: ISubscriptionPeriod;
     locale: string;
+    currency?: string;
     mode: 'dev' | 'prod';
     featureName?: string;
   };
@@ -54,11 +56,13 @@ export type IUsePrimePayment = {
         subscriptionPeriod,
         email,
         locale,
+        currency,
         featureName,
       }: {
         subscriptionPeriod: ISubscriptionPeriod;
         email: string;
         locale?: string;
+        currency?: string;
         featureName?: EPrimeFeatures;
       }) => Promise<PurchaseResult>)
     | undefined;


### PR DESCRIPTION
## Summary
- On Android, the subscription page displays prices from the Native SDK (e.g. HKD based on store region), but the WebView payment page uses the Web SDK which determines currency via IP geolocation (e.g. JPY), causing a currency mismatch
- Pass the native SDK's `currencyCode` through WebView query params to RevenueCat Web SDK's `getOfferings({ currency })`, ensuring Stripe checkout uses the same currency as displayed in the app
- If the currency is not configured in RevenueCat Web Billing dashboard, the SDK silently falls back to the default currency

## Test plan
- [ ] Android (without Google Play): verify subscription page currency matches Stripe checkout currency
- [ ] Android (with Google Play): select "Purchase by Webview" and verify currency matches
- [ ] Web/Desktop: verify purchase flow still works (currency param is optional, falls back to IP-based detection)
- [ ] iOS: verify native purchase flow is unaffected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
