### PR TITLE
fix: show empty state instead of perpetual loading on approval list for empty wallets (OK-51240)

### DIFF
--- a/packages/kit/src/views/ApprovalManagement/pages/ApprovalList.tsx
+++ b/packages/kit/src/views/ApprovalManagement/pages/ApprovalList.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { useRoute } from '@react-navigation/native';
 import { CanceledError } from 'axios';
-import { isEmpty, isNil, pickBy } from 'lodash';
+import { isNil, pickBy } from 'lodash';
 import { useIntl } from 'react-intl';
 import { useDebouncedCallback } from 'use-debounce';
 
@@ -197,13 +197,11 @@ function ApprovalList() {
 
   useEffect(() => {
     if (!isNil(approvalsProp)) {
-      if (!isEmpty(approvalsProp)) {
-        approvalListInitRef.current = true;
-        updateApprovalListState({
-          isRefreshing: false,
-          initialized: true,
-        });
-      }
+      approvalListInitRef.current = true;
+      updateApprovalListState({
+        isRefreshing: false,
+        initialized: true,
+      });
       updateApprovalList({ data: approvalsProp });
     }
     if (!isNil(tokenMapProp)) {


### PR DESCRIPTION
## Summary

- Fix approval management page showing perpetual loading skeleton when the wallet has no approvals
- Root cause: `initialized` was only set to `true` when `approvalsProp` was non-empty, so an empty array `[]` left `initialized` as `false` forever, keeping the skeleton visible
- Removed the `!isEmpty()` guard so `initialized: true` is set whenever `approvalsProp` is received (not nil), allowing `EmptyApproval` component to render correctly

## Test plan

- [ ] Navigate to approval management page with an empty wallet (no token approvals)
- [ ] Verify it shows the empty state instead of a loading skeleton
- [ ] Navigate to approval management page with a wallet that has approvals and verify the list renders correctly
- [ ] Verify refresh behavior still works (pull to refresh / network switch)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
