### PR TITLE
fix: hide add token prompt for single-token chains

### DIFF
--- a/packages/kit/src/hooks/useManageToken.ts
+++ b/packages/kit/src/hooks/useManageToken.ts
@@ -1,16 +1,19 @@
 import { useCallback } from 'react';
 
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
-import type { IAccountDeriveTypes } from '@onekeyhq/kit-bg/src/vaults/types';
+import type {
+  IAccountDeriveTypes,
+  IVaultSettings,
+} from '@onekeyhq/kit-bg/src/vaults/types';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import {
   EModalAssetListRoutes,
   EModalRoutes,
 } from '@onekeyhq/shared/src/routes';
 
-// import backgroundApiProxy from '../background/instance/backgroundApiProxy';
+import backgroundApiProxy from '../background/instance/backgroundApiProxy';
 
-// import { usePromiseResult } from './usePromiseResult';
+import { usePromiseResult } from './usePromiseResult';
 
 function useManageToken({
   accountId,
@@ -29,13 +32,24 @@ function useManageToken({
 }) {
   const navigation = useAppNavigation();
 
-  // const { result: vaultSettings } = usePromiseResult(
-  //   () =>
-  //     backgroundApiProxy.serviceNetwork.getVaultSettings({
-  //       networkId,
-  //     }),
-  //   [networkId],
-  // );
+  const { result: vaultSettings } = usePromiseResult<
+    IVaultSettings | undefined
+  >(
+    async () => {
+      if (!networkId) {
+        return undefined;
+      }
+
+      return backgroundApiProxy.serviceNetwork.getVaultSettings({
+        networkId,
+      });
+    },
+    [networkId],
+    {
+      undefinedResultIfError: true,
+      undefinedResultIfReRun: true,
+    },
+  );
 
   const handleOnManageToken = useCallback(() => {
     if (!deriveType) {
@@ -63,7 +77,8 @@ function useManageToken({
   ]);
 
   return {
-    manageTokenEnabled: true,
+    manageTokenEnabled:
+      !!networkId && !!vaultSettings && !vaultSettings.isSingleToken,
     handleOnManageToken,
   };
 }


### PR DESCRIPTION
## Summary
- Hide the "Can't find your token? Add token" prompt for chains that only have a native token (BTC, XRP, Lightning, Nexa, DNX, Nostr, Filecoin)
- Restore `getVaultSettings` call in `useManageToken` hook to check `isSingleToken` flag
- Default to hidden when `networkId` is empty or vault settings haven't loaded yet

<img width="1393" height="289" alt="fix-hide-add-token-for-single-token-chains" src="https://github.com/user-attachments/assets/e72eadb3-54fd-4c77-ac59-e2410f47a24e" />


## Test plan
- [ ] Switch to BTC network → verify "Can't find your token?" prompt is NOT shown in token list footer
- [ ] Switch to ETH/SOL/other multi-token network → verify prompt still shows normally
- [ ] Search for a non-existent token on BTC → verify "Add custom token" button is NOT shown in empty state
- [ ] Search for a non-existent token on ETH → verify "Add custom token" button still shows
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
