### PR TITLE
fix: move snap arm64 build to self-hosted runner

### DIFF
--- a/.github/workflows/release-desktop-snap.yml
+++ b/.github/workflows/release-desktop-snap.yml
@@ -20,18 +20,20 @@ env:
   ONEKEY_ALLOW_SKIP_GPG_VERIFICATION: ${{ github.event.inputs.ONEKEY_ALLOW_SKIP_GPG_VERIFICATION || 'false' }}
 
 jobs:
-  
+
   release-desktop-snap:
+    name: release-desktop-snap-${{ matrix.arch }}
     strategy:
+      fail-fast: false
       matrix:
         node-version: [24.x]
-        arch: [amd64, arm64]
         include:
           - arch: amd64
             runs-on: ubuntu-24.04
             build-flag: --x64
+          # arm64 Snap 需要在已预装并验证过 Snapcraft provider 的自托管 runner 上构建。
           - arch: arm64
-            runs-on: ubuntu-24.04-arm
+            runs-on: onekey-snap-arm64
             build-flag: --arm64
     runs-on: ${{ matrix.runs-on }}
 
@@ -127,8 +129,52 @@ jobs:
             !./apps/desktop/build-electron/linux-arm64-unpacked
             !./apps/desktop/build-electron/builder-debug.yml
 
+  publish-desktop-snap:
+    name: publish-desktop-snap
+    needs: release-desktop-snap
+    runs-on: ubuntu-24.04
+    if: ${{ github.event.workflow_run && needs.release-desktop-snap.result == 'success' }}
+    steps:
+      - name: Show executed time
+        run: |
+          echo "Executed at: $(date '+%Y-%m-%d %H:%M:%S')"
+
+      - name: Checkout Source Code
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Run Shared Env Setup
+        uses: ./.github/actions/shared-env
+        with:
+          env_file_name: ".env"
+          sentry_project: 'desktop-snap'
+          covalent_key: ${{ secrets.COVALENT_KEY }}
+          sentry_token: ${{ secrets.SENTRY_TOKEN }}
+          sentry_dsn_react_native: ${{ secrets.SENTRY_DSN_REACT_NATIVE }}
+          sentry_dsn_web: ${{ secrets.SENTRY_DSN_WEB }}
+          sentry_dsn_desktop: ${{ secrets.SENTRY_DSN_DESKTOP }}
+          sentry_dsn_mas: ${{ secrets.SENTRY_DSN_MAS }}
+          sentry_dsn_snap: ${{ secrets.SENTRY_DSN_SNAP }}
+          sentry_dsn_winms: ${{ secrets.SENTRY_DSN_WINMS }}
+          sentry_dsn_ext: ${{ secrets.SENTRY_DSN_EXT }}
+
+      - name: Setup Publish ENV
+        run: |
+          artifacts_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          echo "ARTIFACTS_URL=$artifacts_url" >> $GITHUB_ENV
+
+      - name: Install Snapcraft
+        uses: samuelmeuli/action-snapcraft@v2
+
+      - name: Download Snap Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./apps/desktop/build-electron
+          pattern: onekey-desktop-snap-*-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
+          merge-multiple: true
+
       - name: Upload Artifacts to Snap Linux
-        if: ${{ github.event.workflow_run }}
         continue-on-error: true
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
@@ -136,7 +182,6 @@ jobs:
           snapcraft push ./apps/desktop/build-electron/*.snap --release edge
 
       - name: 'Notify to Slack'
-        if: ${{ github.event.workflow_run }}
         uses: onekeyhq/actions/slack-notify-webhook@main
         with:
           web-hook-url: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}


### PR DESCRIPTION
## 背景
- `release-desktop-snap` 在引入 `arm64` 后，GitHub hosted `ubuntu-24.04-arm` runner 上的 Snapcraft provider 不可用，导致 `arm64` Snap 构建失败。
- 当前方案改为让 `amd64` 继续使用 hosted runner，`arm64` 切到预先准备好的 self-hosted ARM64 runner。

## 变更
- 将 `arm64` 构建 runner 从 `ubuntu-24.04-arm` 改为 `onekey-snap-arm64`
- 为矩阵构建增加 `fail-fast: false`
- 将 Snap Store 推送和 Slack 通知从矩阵 build job 中拆出，改为在两个架构都构建成功后统一执行
- 在发布 job 中下载两个架构的 `.snap` 产物后再推送

## 验证
- 使用 Ruby 解析 `.github/workflows/release-desktop-snap.yml`，确认 YAML 语法有效
- 运行 `git diff --check`，确认没有格式问题

## 注意事项
- 需要在 GitHub 上注册并准备一个带 `onekey-snap-arm64` 标签的 self-hosted ARM64 Linux runner
- 该 runner 需要预装并验证可用的 Snapcraft/provider 环境
