### PR TITLE
Fix Earn mobile search dialog and Pendle chevron OK-51509 OK-51506 OK-51505

### DIFF
--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -140,8 +140,16 @@ function BasicEarnHome({
     return total.toFixed();
   }, [hideSmallAssets, portfolioData]);
 
+  const refreshEarnData = useCallback(async () => {
+    await backgroundApiProxy.serviceStaking.clearAvailableAssetsCache();
+    actions.current.triggerRefresh();
+    await refreshEarnDataRaw();
+  }, [actions, refreshEarnDataRaw]);
+
   const pendingTxsFilter = useCallback((tx: IStakePendingTx) => {
-    return [EEarnLabels.Stake, EEarnLabels.Withdraw].includes(
+    // Pendle redeem/unstake is recorded as Sell, but it should still trigger
+    // the same earn portfolio refresh flow once the pending tx settles.
+    return [EEarnLabels.Stake, EEarnLabels.Withdraw, EEarnLabels.Sell].includes(
       tx.stakingInfo.label,
     );
   }, []);
@@ -155,10 +163,10 @@ function BasicEarnHome({
 
   useEffect(() => {
     if (previousIsPendingRef.current && !isPending) {
-      void refreshEarnDataRaw();
+      void refreshEarnData();
     }
     previousIsPendingRef.current = isPending;
-  }, [isPending, refreshEarnDataRaw]);
+  }, [isPending, refreshEarnData]);
 
   const [borrowNetworkIds, setBorrowNetworkIds] = useState<string[]>([]);
   const borrowRefreshHandlerRef = useRef<(() => Promise<void>) | null>(null);
@@ -205,12 +213,6 @@ function BasicEarnHome({
       prevBorrowPendingIdsRef.current = nextIds;
     }
   }, [borrowPendingTxs]);
-
-  const refreshEarnData = useCallback(async () => {
-    await backgroundApiProxy.serviceStaking.clearAvailableAssetsCache();
-    actions.current.triggerRefresh();
-    await refreshEarnDataRaw();
-  }, [actions, refreshEarnDataRaw]);
 
   const navigation = useAppNavigation();
 

--- a/packages/kit/src/views/Earn/components/AvailableAssetsTabViewList.tsx
+++ b/packages/kit/src/views/Earn/components/AvailableAssetsTabViewList.tsx
@@ -38,6 +38,7 @@ import { EarnNavigation } from '../earnUtils';
 
 import { AprText } from './AprText';
 import { showEarnAssetSearchDialog } from './EarnAssetSearchPopover';
+import { buildEarnAvailableAssetCategoryTabs } from './earnCategoryTabs';
 
 export function AvailableAssetsTabViewList() {
   const [{ availableAssetsByType = {}, refreshTrigger = 0 }] = useEarnAtom();
@@ -54,22 +55,7 @@ export function AvailableAssetsTabViewList() {
   const activeNetworkId = activeAccount.network?.id;
 
   const tabData = useMemo(
-    () => [
-      {
-        title: intl.formatMessage({ id: ETranslations.defi_simple_earn }),
-        type: EAvailableAssetsTypeEnum.SimpleEarn,
-      },
-      {
-        title: intl.formatMessage({ id: ETranslations.earn_fixed_income }),
-        type: EAvailableAssetsTypeEnum.FixedRate,
-      },
-      {
-        title: intl.formatMessage({
-          id: ETranslations.wallet_defi_position_module_staked,
-        }),
-        type: EAvailableAssetsTypeEnum.Staking,
-      },
-    ],
+    () => buildEarnAvailableAssetCategoryTabs(intl),
     [intl],
   );
 
@@ -456,6 +442,9 @@ export function AvailableAssetsTabViewList() {
 
         showEarnAssetSearchDialog({
           availableAssetsByType: completeData,
+          initialCategoryType:
+            tabData[selectedTabIndex]?.type ??
+            EAvailableAssetsTypeEnum.SimpleEarn,
           onAssetSelect: (asset, categoryType) => {
             void navigateToAsset(asset, categoryType);
           },
@@ -464,7 +453,13 @@ export function AvailableAssetsTabViewList() {
         setSearchLoading(false);
       }
     })();
-  }, [availableAssetsByType, actions, navigateToAsset]);
+  }, [
+    availableAssetsByType,
+    actions,
+    navigateToAsset,
+    selectedTabIndex,
+    tabData,
+  ]);
 
   // Cleanup on unmount to prevent memory leaks
   useEffect(() => {

--- a/packages/kit/src/views/Earn/components/EarnAssetSearchPopover.tsx
+++ b/packages/kit/src/views/Earn/components/EarnAssetSearchPopover.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 
 import { useIntl } from 'react-intl';
-import { useWindowDimensions } from 'react-native';
+import { Dimensions, useWindowDimensions } from 'react-native';
 
 import {
   Badge,
@@ -12,6 +12,7 @@ import {
   SizableText,
   XStack,
   YStack,
+  useSafeAreaInsets,
 } from '@onekeyhq/components';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { Token } from '@onekeyhq/kit/src/components/Token';
@@ -21,12 +22,15 @@ import type { IEarnAvailableAsset } from '@onekeyhq/shared/types/earn';
 import { EAvailableAssetsTypeEnum } from '@onekeyhq/shared/types/earn';
 
 import { AprText } from './AprText';
+import { buildEarnAvailableAssetCategoryTabs } from './earnCategoryTabs';
 
 type ICategoryKey = EAvailableAssetsTypeEnum;
 
 type IAvailableAssetsByType = Partial<
   Record<EAvailableAssetsTypeEnum, IEarnAvailableAsset[]>
 >;
+
+const DEFAULT_CATEGORY_TYPE = EAvailableAssetsTypeEnum.SimpleEarn;
 
 function CategoryTabs({
   selected,
@@ -105,9 +109,11 @@ function SearchResultItem({
 
 function EarnAssetSearchDialogContent({
   availableAssetsByType,
+  initialCategoryType = DEFAULT_CATEGORY_TYPE,
   onAssetSelect,
 }: {
   availableAssetsByType: IAvailableAssetsByType;
+  initialCategoryType?: EAvailableAssetsTypeEnum;
   onAssetSelect: (
     asset: IEarnAvailableAsset,
     categoryType: EAvailableAssetsTypeEnum,
@@ -115,35 +121,33 @@ function EarnAssetSearchDialogContent({
 }) {
   const intl = useIntl();
   const { height: windowHeight } = useWindowDimensions();
+  const { top, bottom } = useSafeAreaInsets();
   const [searchText, setSearchText] = useState('');
-  const [selectedCategory, setSelectedCategory] = useState<ICategoryKey>(
-    EAvailableAssetsTypeEnum.SimpleEarn,
-  );
+  const [selectedCategory, setSelectedCategory] =
+    useState<ICategoryKey>(initialCategoryType);
 
   const dialogContentHeight = useMemo(() => {
-    if (!windowHeight) {
-      return 360;
+    const screenHeight = Dimensions.get('screen').height;
+    const stableWindowHeight = Math.max(windowHeight || 0, screenHeight || 0);
+
+    if (!stableWindowHeight) {
+      return 520;
     }
-    return Math.min(Math.max(windowHeight - 280, 320), 520);
-  }, [windowHeight]);
+
+    // Keep the sheet height stable when the keyboard shrinks windowHeight.
+    const availableHeight = Math.max(stableWindowHeight - top - bottom, 360);
+    const preferredHeight = Math.round(availableHeight * 0.78);
+    const maxDialogHeight = Math.max(availableHeight - 32, 280);
+
+    return Math.min(Math.max(preferredHeight, 480), maxDialogHeight, 680);
+  }, [bottom, top, windowHeight]);
 
   const categoryTabs = useMemo(
-    () => [
-      {
-        key: EAvailableAssetsTypeEnum.SimpleEarn as ICategoryKey,
-        label: intl.formatMessage({ id: ETranslations.global_earn }),
-      },
-      {
-        key: EAvailableAssetsTypeEnum.FixedRate as ICategoryKey,
-        label: intl.formatMessage({ id: ETranslations.earn_fixed_income }),
-      },
-      {
-        key: EAvailableAssetsTypeEnum.Staking as ICategoryKey,
-        label: intl.formatMessage({
-          id: ETranslations.wallet_defi_position_module_staked,
-        }),
-      },
-    ],
+    () =>
+      buildEarnAvailableAssetCategoryTabs(intl).map((tab) => ({
+        key: tab.type,
+        label: tab.title,
+      })),
     [intl],
   );
 
@@ -227,16 +231,20 @@ function EarnAssetSearchDialogContent({
 
 export function showEarnAssetSearchDialog({
   availableAssetsByType,
+  initialCategoryType = DEFAULT_CATEGORY_TYPE,
   onAssetSelect,
 }: {
   availableAssetsByType: IAvailableAssetsByType;
+  initialCategoryType?: EAvailableAssetsTypeEnum;
   onAssetSelect: (
     asset: IEarnAvailableAsset,
     categoryType: EAvailableAssetsTypeEnum,
   ) => void;
 }) {
   const dialog = Dialog.show({
-    title: appLocale.intl.formatMessage({ id: ETranslations.global_earn }),
+    title: appLocale.intl.formatMessage({
+      id: ETranslations.earn_available_assets,
+    }),
     showFooter: false,
     contentContainerProps: {
       px: '$0',
@@ -245,6 +253,7 @@ export function showEarnAssetSearchDialog({
     renderContent: (
       <EarnAssetSearchDialogContent
         availableAssetsByType={availableAssetsByType}
+        initialCategoryType={initialCategoryType}
         onAssetSelect={(asset, categoryType) => {
           void dialog.close();
           onAssetSelect(asset, categoryType);

--- a/packages/kit/src/views/Earn/components/earnCategoryTabs.ts
+++ b/packages/kit/src/views/Earn/components/earnCategoryTabs.ts
@@ -1,0 +1,45 @@
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { EAvailableAssetsTypeEnum } from '@onekeyhq/shared/types/earn';
+
+import type { IntlShape } from 'react-intl';
+
+export type IEarnAvailableAssetCategoryTab = {
+  title: string;
+  type: EAvailableAssetsTypeEnum;
+};
+
+function getEarnAvailableAssetCategoryTranslationId(
+  categoryType: EAvailableAssetsTypeEnum,
+) {
+  switch (categoryType) {
+    case EAvailableAssetsTypeEnum.FixedRate:
+      return ETranslations.earn_fixed_income;
+    case EAvailableAssetsTypeEnum.Staking:
+      return ETranslations.wallet_defi_position_module_staked;
+    case EAvailableAssetsTypeEnum.SimpleEarn:
+    default:
+      return ETranslations.defi_simple_earn;
+  }
+}
+
+export function getEarnAvailableAssetCategoryTitle(
+  intl: Pick<IntlShape, 'formatMessage'>,
+  categoryType: EAvailableAssetsTypeEnum,
+) {
+  return intl.formatMessage({
+    id: getEarnAvailableAssetCategoryTranslationId(categoryType),
+  });
+}
+
+export function buildEarnAvailableAssetCategoryTabs(
+  intl: Pick<IntlShape, 'formatMessage'>,
+): IEarnAvailableAssetCategoryTab[] {
+  return [
+    EAvailableAssetsTypeEnum.SimpleEarn,
+    EAvailableAssetsTypeEnum.FixedRate,
+    EAvailableAssetsTypeEnum.Staking,
+  ].map((type) => ({
+    type,
+    title: getEarnAvailableAssetCategoryTitle(intl, type),
+  }));
+}

--- a/packages/kit/src/views/Staking/components/ProtocolDetails/PendleSharedComponents.tsx
+++ b/packages/kit/src/views/Staking/components/ProtocolDetails/PendleSharedComponents.tsx
@@ -191,7 +191,7 @@ export const PendleAccordionTriggerContent: FC<
     >
       {triggerText}
     </SizableText>
-    <YStack animation="quick" rotate={open && !isDisabled ? '0deg' : '180deg'}>
+    <YStack animation="quick" rotate={open && !isDisabled ? '180deg' : '0deg'}>
       <Icon
         name="ChevronDownSmallSolid"
         color={isDisabled ? '$iconDisabled' : '$iconSubdued'}


### PR DESCRIPTION
## Summary
- sync the mobile Earn search dialog title with the All assets i18n key and inherit the selected tab from the parent view
- increase the dialog height so the keyboard leaves more stable top gesture space on mobile
- align the Pendle transaction details chevron direction with FAQ behavior

## Testing
- npx eslint packages/kit/src/views/Earn/components/earnCategoryTabs.ts packages/kit/src/views/Earn/components/EarnAssetSearchPopover.tsx packages/kit/src/views/Earn/components/AvailableAssetsTabViewList.tsx packages/kit/src/views/Staking/components/ProtocolDetails/PendleSharedComponents.tsx --ext .ts,.tsx --cache --cache-location /tmp/onekey-eslint-cache

## Related
- OK-51505
- OK-51506