### PR TITLE
feat(referral): add tracking for referral link entry and accept invitation, OK-51214

### DIFF
--- a/packages/kit/src/routes/config/deeplink/index.ts
+++ b/packages/kit/src/routes/config/deeplink/index.ts
@@ -128,11 +128,11 @@ async function processDeepLinkUrlAccount(
                 page: page ?? '',
               });
             }
-            defaultLogger.referral.page.enterFromReferralLink(
-              code ?? '',
-              page ? `/app/${page}` : '/app',
-              'deep_link',
-            );
+            defaultLogger.referral.page.enterFromReferralLink({
+              referralCode: code ?? '',
+              landingPage: page ? `/app/${page}` : '/app',
+              utmSource: 'deep_link',
+            });
           }
           break;
         case EOneKeyDeepLinkPath.cross_device_transfer:

--- a/packages/kit/src/routes/config/deeplink/index.ts
+++ b/packages/kit/src/routes/config/deeplink/index.ts
@@ -128,6 +128,11 @@ async function processDeepLinkUrlAccount(
                 page: page ?? '',
               });
             }
+            defaultLogger.referral.page.enterFromReferralLink(
+              code ?? '',
+              page ? `/app/${page}` : '/app',
+              'deep_link',
+            );
           }
           break;
         case EOneKeyDeepLinkPath.cross_device_transfer:

--- a/packages/kit/src/routes/config/deeplink/index.ts
+++ b/packages/kit/src/routes/config/deeplink/index.ts
@@ -126,13 +126,9 @@ async function processDeepLinkUrlAccount(
               navigation.push(ETabHomeRoutes.TabHomeReferralLanding, {
                 code,
                 page: page ?? '',
+                fromDeepLink: true,
               });
             }
-            defaultLogger.referral.page.enterFromReferralLink({
-              referralCode: code ?? '',
-              landingPage: page ? `/app/${page}` : '/app',
-              utmSource: 'deep_link',
-            });
           }
           break;
         case EOneKeyDeepLinkPath.cross_device_transfer:

--- a/packages/kit/src/views/Home/pages/referralLanding/ReferralLandingPage.tsx
+++ b/packages/kit/src/views/Home/pages/referralLanding/ReferralLandingPage.tsx
@@ -119,10 +119,11 @@ function ReferralLandingPage() {
   const [appIsLocked] = useAppIsLockedAtom();
 
   const routeParams = route.params as
-    | { code: string; page?: string }
+    | { code: string; page?: string; fromDeepLink?: boolean }
     | undefined;
   const routeCode = routeParams?.code;
   const page = routeParams?.page;
+  const fromDeepLink = routeParams?.fromDeepLink;
 
   // Handle /r/invite?code=XXX case - extract code from URL query params
   let code = routeCode;
@@ -270,11 +271,12 @@ function ReferralLandingPage() {
         return;
       }
 
-      defaultLogger.referral.page.enterReferralGuide(code, 'app_landing');
+      const utmSource = fromDeepLink ? 'deep_link' : 'app_landing';
+      defaultLogger.referral.page.enterReferralGuide(code, utmSource);
       defaultLogger.referral.page.enterFromReferralLink({
         referralCode: code ?? '',
         landingPage: page ? `/app/${page}` : '/app',
-        utmSource: 'app_landing',
+        utmSource,
       });
 
       if (code && (page === 'perp' || page === 'perps')) {
@@ -315,7 +317,7 @@ function ReferralLandingPage() {
         clearTimeout(modalTimerId);
       }
     };
-  }, [appIsLocked, code, page, navigation, isMobileWeb]);
+  }, [appIsLocked, code, page, navigation, isMobileWeb, fromDeepLink]);
 
   if (isMobileWeb) {
     return (

--- a/packages/kit/src/views/Home/pages/referralLanding/ReferralLandingPage.tsx
+++ b/packages/kit/src/views/Home/pages/referralLanding/ReferralLandingPage.tsx
@@ -159,6 +159,11 @@ function ReferralLandingPage() {
       : '';
 
     defaultLogger.referral.page.enterReferralGuide(code, 'web_mobile_redirect');
+    defaultLogger.referral.page.enterFromReferralLink(
+      code ?? '',
+      page ? `/app/${page}` : '/app',
+      'web_mobile_redirect',
+    );
 
     const redirectToStore = () => {
       if (platformEnv.isWebMobileIOS) {
@@ -266,6 +271,11 @@ function ReferralLandingPage() {
       }
 
       defaultLogger.referral.page.enterReferralGuide(code, 'app_landing');
+      defaultLogger.referral.page.enterFromReferralLink(
+        code ?? '',
+        page ? `/app/${page}` : '/app',
+        'app_landing',
+      );
 
       if (code && (page === 'perp' || page === 'perps')) {
         try {

--- a/packages/kit/src/views/Home/pages/referralLanding/ReferralLandingPage.tsx
+++ b/packages/kit/src/views/Home/pages/referralLanding/ReferralLandingPage.tsx
@@ -159,11 +159,11 @@ function ReferralLandingPage() {
       : '';
 
     defaultLogger.referral.page.enterReferralGuide(code, 'web_mobile_redirect');
-    defaultLogger.referral.page.enterFromReferralLink(
-      code ?? '',
-      page ? `/app/${page}` : '/app',
-      'web_mobile_redirect',
-    );
+    defaultLogger.referral.page.enterFromReferralLink({
+      referralCode: code ?? '',
+      landingPage: page ? `/app/${page}` : '/app',
+      utmSource: 'web_mobile_redirect',
+    });
 
     const redirectToStore = () => {
       if (platformEnv.isWebMobileIOS) {
@@ -271,11 +271,11 @@ function ReferralLandingPage() {
       }
 
       defaultLogger.referral.page.enterReferralGuide(code, 'app_landing');
-      defaultLogger.referral.page.enterFromReferralLink(
-        code ?? '',
-        page ? `/app/${page}` : '/app',
-        'app_landing',
-      );
+      defaultLogger.referral.page.enterFromReferralLink({
+        referralCode: code ?? '',
+        landingPage: page ? `/app/${page}` : '/app',
+        utmSource: 'app_landing',
+      });
 
       if (code && (page === 'perp' || page === 'perps')) {
         try {

--- a/packages/kit/src/views/ReferFriends/pages/InvitedByFriend/components/InvitedByFriendActions.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/InvitedByFriend/components/InvitedByFriendActions.tsx
@@ -96,6 +96,10 @@ function WebWalletOptions({
   const intl = useIntl();
 
   const handleOpenDesktop = useCallback(() => {
+    defaultLogger.referral.page.acceptReferralInvitation({
+      referralCode,
+      acceptMethod: 'web_no_extension',
+    });
     const deepLinkUrl = uriUtils.buildDeepLinkUrl({
       path: EOneKeyDeepLinkPath.invited_by_friend,
       query: { code: referralCode, page },
@@ -104,8 +108,12 @@ function WebWalletOptions({
   }, [referralCode, page]);
 
   const handleGetExtension = useCallback(() => {
+    defaultLogger.referral.page.acceptReferralInvitation({
+      referralCode,
+      acceptMethod: 'web_no_extension',
+    });
     globalThis.open(EXT_RATE_URL.chrome, '_blank');
-  }, []);
+  }, [referralCode]);
 
   return (
     <YStack bg="$bgApp">
@@ -261,10 +269,6 @@ function InvitedByFriendActions({
         return;
       }
       // No extension → show options (desktop app / install extension)
-      defaultLogger.referral.page.acceptReferralInvitation({
-        referralCode,
-        acceptMethod: 'web_no_extension',
-      });
       setShowWebOptions(true);
       return;
     }

--- a/packages/kit/src/views/ReferFriends/pages/InvitedByFriend/components/InvitedByFriendActions.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/InvitedByFriend/components/InvitedByFriendActions.tsx
@@ -236,10 +236,10 @@ function InvitedByFriendActions({
 
   const handleJoin = useCallback(() => {
     if (activeAccount?.wallet) {
-      defaultLogger.referral.page.acceptReferralInvitation(
+      defaultLogger.referral.page.acceptReferralInvitation({
         referralCode,
-        'local_app',
-      );
+        acceptMethod: 'local_app',
+      });
       bindWalletInviteCode({
         wallet: activeAccount.wallet,
         defaultReferralCode: referralCode,
@@ -253,26 +253,26 @@ function InvitedByFriendActions({
     if (platformEnv.isWeb) {
       // Extension installed → bind directly
       if (getOneKeyExtensionProvider()) {
-        defaultLogger.referral.page.acceptReferralInvitation(
+        defaultLogger.referral.page.acceptReferralInvitation({
           referralCode,
-          'web_extension',
-        );
+          acceptMethod: 'web_extension',
+        });
         void bindViaExtension();
         return;
       }
       // No extension → show options (desktop app / install extension)
-      defaultLogger.referral.page.acceptReferralInvitation(
+      defaultLogger.referral.page.acceptReferralInvitation({
         referralCode,
-        'web_no_extension',
-      );
+        acceptMethod: 'web_no_extension',
+      });
       setShowWebOptions(true);
       return;
     }
 
-    defaultLogger.referral.page.acceptReferralInvitation(
+    defaultLogger.referral.page.acceptReferralInvitation({
       referralCode,
-      'local_app',
-    );
+      acceptMethod: 'local_app',
+    });
     bindWalletInviteCode({
       defaultReferralCode: referralCode,
       onSuccess: () => {

--- a/packages/kit/src/views/ReferFriends/pages/InvitedByFriend/components/InvitedByFriendActions.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/InvitedByFriend/components/InvitedByFriendActions.tsx
@@ -19,6 +19,7 @@ import { EXT_RATE_URL } from '@onekeyhq/shared/src/config/appConfig';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { EOneKeyDeepLinkPath } from '@onekeyhq/shared/src/consts/deeplinkConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import uriUtils from '@onekeyhq/shared/src/utils/uriUtils';
 
@@ -235,6 +236,10 @@ function InvitedByFriendActions({
 
   const handleJoin = useCallback(() => {
     if (activeAccount?.wallet) {
+      defaultLogger.referral.page.acceptReferralInvitation(
+        referralCode,
+        'local_app',
+      );
       bindWalletInviteCode({
         wallet: activeAccount.wallet,
         defaultReferralCode: referralCode,
@@ -248,14 +253,26 @@ function InvitedByFriendActions({
     if (platformEnv.isWeb) {
       // Extension installed → bind directly
       if (getOneKeyExtensionProvider()) {
+        defaultLogger.referral.page.acceptReferralInvitation(
+          referralCode,
+          'web_extension',
+        );
         void bindViaExtension();
         return;
       }
       // No extension → show options (desktop app / install extension)
+      defaultLogger.referral.page.acceptReferralInvitation(
+        referralCode,
+        'web_no_extension',
+      );
       setShowWebOptions(true);
       return;
     }
 
+    defaultLogger.referral.page.acceptReferralInvitation(
+      referralCode,
+      'local_app',
+    );
     bindWalletInviteCode({
       defaultReferralCode: referralCode,
       onSuccess: () => {

--- a/packages/shared/src/logger/scopes/referral/scenes/page.ts
+++ b/packages/shared/src/logger/scopes/referral/scenes/page.ts
@@ -82,4 +82,23 @@ export class PageScene extends BaseScene {
   public toggleReceivingAddressVisibility(isVisible: boolean) {
     return { isVisible };
   }
+
+  @LogToServer()
+  @LogToLocal({ level: 'info' })
+  public enterFromReferralLink(
+    referralCode: string,
+    landingPage: string,
+    utmSource: string,
+  ) {
+    return { referralCode, landingPage, utmSource };
+  }
+
+  @LogToServer()
+  @LogToLocal({ level: 'info' })
+  public acceptReferralInvitation(
+    referralCode: string,
+    acceptMethod: 'local_app' | 'web_extension' | 'web_no_extension',
+  ) {
+    return { referralCode, acceptMethod };
+  }
 }

--- a/packages/shared/src/logger/scopes/referral/scenes/page.ts
+++ b/packages/shared/src/logger/scopes/referral/scenes/page.ts
@@ -85,20 +85,20 @@ export class PageScene extends BaseScene {
 
   @LogToServer()
   @LogToLocal({ level: 'info' })
-  public enterFromReferralLink(
-    referralCode: string,
-    landingPage: string,
-    utmSource: string,
-  ) {
-    return { referralCode, landingPage, utmSource };
+  public enterFromReferralLink(params: {
+    referralCode: string;
+    landingPage: string;
+    utmSource: string;
+  }) {
+    return params;
   }
 
   @LogToServer()
   @LogToLocal({ level: 'info' })
-  public acceptReferralInvitation(
-    referralCode: string,
-    acceptMethod: 'local_app' | 'web_extension' | 'web_no_extension',
-  ) {
-    return { referralCode, acceptMethod };
+  public acceptReferralInvitation(params: {
+    referralCode: string;
+    acceptMethod: 'local_app' | 'web_extension' | 'web_no_extension';
+  }) {
+    return params;
   }
 }

--- a/packages/shared/src/routes/tabHome.ts
+++ b/packages/shared/src/routes/tabHome.ts
@@ -29,6 +29,7 @@ export type ITabHomeParamList = {
   [ETabHomeRoutes.TabHomeReferralLanding]: {
     code: string;
     page: string;
+    fromDeepLink?: boolean;
   };
   [ETabHomeRoutes.TabHomeReferralLandingWithoutPage]: {
     code: string;


### PR DESCRIPTION
## Summary

- Add `enterFromReferralLink` event: tracks users entering via referral links (`/r/{code}/app` and `/r/{code}/app/perps`) with `referralCode`, `landingPage`, and `utmSource` properties
- Add `acceptReferralInvitation` event: tracks users clicking the Accept button with `referralCode` and `acceptMethod` (`local_app` / `web_extension` / `web_no_extension`)

### Tracking coverage

| Entry point | `enterFromReferralLink` utmSource |
|---|---|
| Mobile web landing page | `web_mobile_redirect` |
| Desktop / Native landing page | `app_landing` |
| Deep link (`onekey-wallet://invited_by_friend`) | `deep_link` |

| Accept scenario | `acceptReferralInvitation` acceptMethod |
|---|---|
| Has wallet (Native/Desktop) | `local_app` |
| Web + Extension installed | `web_extension` |
| Web + No extension | `web_no_extension` |

### Changed files

- `packages/shared/src/logger/scopes/referral/scenes/page.ts` — 2 new logger methods
- `packages/kit/src/views/Home/pages/referralLanding/ReferralLandingPage.tsx` — 2 tracking calls
- `packages/kit/src/routes/config/deeplink/index.ts` — 1 tracking call
- `packages/kit/src/views/ReferFriends/pages/InvitedByFriend/components/InvitedByFriendActions.tsx` — 3 tracking calls

Closes https://onekeyhq.atlassian.net/browse/OK-51214
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
