### PR TITLE
fix: use lxd provider for snap arm64 build

### DIFF
--- a/.github/workflows/release-desktop-snap.yml
+++ b/.github/workflows/release-desktop-snap.yml
@@ -31,9 +31,8 @@ jobs:
           - arch: amd64
             runs-on: ubuntu-24.04
             build-flag: --x64
-          # arm64 Snap 需要在已预装并验证过 Snapcraft provider 的自托管 runner 上构建。
           - arch: arm64
-            runs-on: onekey-snap-arm64
+            runs-on: ubuntu-24.04-arm
             build-flag: --arm64
     runs-on: ${{ matrix.runs-on }}
 
@@ -75,6 +74,13 @@ jobs:
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
 
+      - name: Configure Snapcraft provider for arm64
+        if: ${{ matrix.arch == 'arm64' }}
+        run: |
+          sudo snap set snapcraft provider=lxd
+          snap get snapcraft provider
+          sg lxd -c 'snapcraft --version'
+
       - name: 'Setup ENV'
         run: |
           eval "$(node -e 'const v=require("./apps/desktop/package.json").version; console.log("pkg_version="+v)')"
@@ -114,7 +120,12 @@ jobs:
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           CSC_LINK: './sign.p12'
           SNAP: true
-        run: cd apps/desktop && npx cross-env NODE_ENV=production yarn clean:build && yarn build:renderer && yarn build:main && yarn install-app-deps && npx electron-builder build -l --config electron-builder-snap.config.js ${{ matrix.build-flag }} --publish never
+        run: |
+          if [ "${{ matrix.arch }}" = 'arm64' ]; then
+            sg lxd -c 'cd apps/desktop && export SNAPCRAFT_BUILD_ENVIRONMENT=lxd && npx cross-env NODE_ENV=production yarn clean:build && yarn build:renderer && yarn build:main && yarn install-app-deps && npx electron-builder build -l --config electron-builder-snap.config.js ${{ matrix.build-flag }} --publish never'
+          else
+            cd apps/desktop && npx cross-env NODE_ENV=production yarn clean:build && yarn build:renderer && yarn build:main && yarn install-app-deps && npx electron-builder build -l --config electron-builder-snap.config.js ${{ matrix.build-flag }} --publish never
+          fi
 
       - name: Upload Artifacts Release
         uses: actions/upload-artifact@v4
@@ -175,6 +186,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload Artifacts to Snap Linux
+        if: ${{ github.event.workflow_run }}
         continue-on-error: true
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
@@ -182,6 +194,7 @@ jobs:
           snapcraft push ./apps/desktop/build-electron/*.snap --release edge
 
       - name: 'Notify to Slack'
+        if: ${{ github.event.workflow_run }}
         uses: onekeyhq/actions/slack-notify-webhook@main
         with:
           web-hook-url: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}

--- a/.github/workflows/release-desktop-snap.yml
+++ b/.github/workflows/release-desktop-snap.yml
@@ -74,13 +74,6 @@ jobs:
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
 
-      - name: Configure Snapcraft provider for arm64
-        if: ${{ matrix.arch == 'arm64' }}
-        run: |
-          sudo snap set snapcraft provider=lxd
-          snap get snapcraft provider
-          sg lxd -c 'snapcraft --version'
-
       - name: 'Setup ENV'
         run: |
           eval "$(node -e 'const v=require("./apps/desktop/package.json").version; console.log("pkg_version="+v)')"

--- a/.github/workflows/release-desktop-snap.yml
+++ b/.github/workflows/release-desktop-snap.yml
@@ -20,18 +20,20 @@ env:
   ONEKEY_ALLOW_SKIP_GPG_VERIFICATION: ${{ github.event.inputs.ONEKEY_ALLOW_SKIP_GPG_VERIFICATION || 'false' }}
 
 jobs:
-  
+
   release-desktop-snap:
+    name: release-desktop-snap-${{ matrix.arch }}
     strategy:
+      fail-fast: false
       matrix:
         node-version: [24.x]
-        arch: [amd64, arm64]
         include:
           - arch: amd64
             runs-on: ubuntu-24.04
             build-flag: --x64
+          # arm64 Snap 需要在已预装并验证过 Snapcraft provider 的自托管 runner 上构建。
           - arch: arm64
-            runs-on: ubuntu-24.04-arm
+            runs-on: onekey-snap-arm64
             build-flag: --arm64
     runs-on: ${{ matrix.runs-on }}
 
@@ -127,8 +129,52 @@ jobs:
             !./apps/desktop/build-electron/linux-arm64-unpacked
             !./apps/desktop/build-electron/builder-debug.yml
 
+  publish-desktop-snap:
+    name: publish-desktop-snap
+    needs: release-desktop-snap
+    runs-on: ubuntu-24.04
+    if: ${{ github.event.workflow_run && needs.release-desktop-snap.result == 'success' }}
+    steps:
+      - name: Show executed time
+        run: |
+          echo "Executed at: $(date '+%Y-%m-%d %H:%M:%S')"
+
+      - name: Checkout Source Code
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Run Shared Env Setup
+        uses: ./.github/actions/shared-env
+        with:
+          env_file_name: ".env"
+          sentry_project: 'desktop-snap'
+          covalent_key: ${{ secrets.COVALENT_KEY }}
+          sentry_token: ${{ secrets.SENTRY_TOKEN }}
+          sentry_dsn_react_native: ${{ secrets.SENTRY_DSN_REACT_NATIVE }}
+          sentry_dsn_web: ${{ secrets.SENTRY_DSN_WEB }}
+          sentry_dsn_desktop: ${{ secrets.SENTRY_DSN_DESKTOP }}
+          sentry_dsn_mas: ${{ secrets.SENTRY_DSN_MAS }}
+          sentry_dsn_snap: ${{ secrets.SENTRY_DSN_SNAP }}
+          sentry_dsn_winms: ${{ secrets.SENTRY_DSN_WINMS }}
+          sentry_dsn_ext: ${{ secrets.SENTRY_DSN_EXT }}
+
+      - name: Setup Publish ENV
+        run: |
+          artifacts_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          echo "ARTIFACTS_URL=$artifacts_url" >> $GITHUB_ENV
+
+      - name: Install Snapcraft
+        uses: samuelmeuli/action-snapcraft@v2
+
+      - name: Download Snap Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./apps/desktop/build-electron
+          pattern: onekey-desktop-snap-*-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
+          merge-multiple: true
+
       - name: Upload Artifacts to Snap Linux
-        if: ${{ github.event.workflow_run }}
         continue-on-error: true
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
@@ -136,7 +182,6 @@ jobs:
           snapcraft push ./apps/desktop/build-electron/*.snap --release edge
 
       - name: 'Notify to Slack'
-        if: ${{ github.event.workflow_run }}
         uses: onekeyhq/actions/slack-notify-webhook@main
         with:
           web-hook-url: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}


### PR DESCRIPTION
## 背景
- `release-desktop-snap` 在引入 `arm64` 后，GitHub hosted `ubuntu-24.04-arm` runner 上默认的 Snapcraft provider 无法完成 Snap 构建。
- 仓库当前没有可用的 `onekey-snap-arm64` self-hosted runner，因此改为继续使用 GitHub Actions hosted ARM runner，并优先尝试 LXD provider。

## 变更
- 将 `arm64` 构建 runner 回退为 `ubuntu-24.04-arm`
- 为 `arm64` job 增加 Snapcraft provider 配置：`snap set snapcraft provider=lxd`
- 在 `arm64` 的 Snap 构建步骤里通过 `sg lxd` 执行，并显式导出 `SNAPCRAFT_BUILD_ENVIRONMENT=lxd`
- 恢复 Snap Store 推送和 Slack 通知两个 step 的 `if: ${{ github.event.workflow_run }}` 条件

## 验证
- 使用 Ruby 解析 `.github/workflows/release-desktop-snap.yml`，确认 YAML 语法有效
- 运行 `git diff --check`，确认没有格式问题

## 风险与观察点
- 这是基于 GitHub hosted ARM runner 的最小尝试方案，是否成功仍取决于 `ubuntu-24.04-arm` 上的 LXD/Snapcraft 实际可用性
- 若 LXD 方案仍失败，再评估将 Snap 构建迁移到独立 `snapcraft.yaml` + remote-build
