### PR TITLE
fix: show manage subscription button after new Android purchase (OK-51238)

### DIFF
--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
@@ -230,6 +230,9 @@ class ServicePrime extends ServiceBase {
       primeSubscription = undefined;
     }
 
+    const serverManagementUrl =
+      serverUserInfo.subscriptions?.[0]?.managementUrl;
+
     await primePersistAtom.set((v): IPrimePersistAtomData => {
       const userEmail = serverUserInfo?.emails?.[0] || undefined;
       return {
@@ -246,6 +249,8 @@ class ServicePrime extends ServiceBase {
         isLoggedIn: true,
         isLoggedInOnServer: true,
         primeSubscription,
+        subscriptionManageUrl:
+          v.subscriptionManageUrl || serverManagementUrl,
         // salt: serverUserInfo.salt,
         // pwdHash: serverUserInfo.pwdHash,
       };

--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
@@ -249,8 +249,8 @@ class ServicePrime extends ServiceBase {
         isLoggedIn: true,
         isLoggedInOnServer: true,
         primeSubscription,
-        subscriptionManageUrl:
-          v.subscriptionManageUrl || serverManagementUrl,
+        // Fallback: use server managementUrl when local SDK hasn't set it yet
+        subscriptionManageUrl: v.subscriptionManageUrl || serverManagementUrl,
         // salt: serverUserInfo.salt,
         // pwdHash: serverUserInfo.pwdHash,
       };

--- a/packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.native.ts
+++ b/packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.native.ts
@@ -252,6 +252,18 @@ export function usePrimePaymentMethods(): IUsePrimePayment {
           makePurchaseResult?.customerInfo?.entitlements?.active?.Prime
             ?.isActive
         ) {
+          // Set subscriptionManageUrl immediately from purchase result,
+          // because the server may not yet have it (RevenueCat webhook delay).
+          setPrimePersistAtom(
+            (prev): IPrimeUserInfo =>
+              perfUtils.buildNewValueIfChanged(prev, {
+                ...prev,
+                subscriptionManageUrl:
+                  makePurchaseResult.customerInfo.managementURL ||
+                  prev.subscriptionManageUrl ||
+                  '',
+              }),
+          );
           await backgroundApiProxy.servicePrime.apiFetchPrimeUserInfo();
 
           // Track successful subscription
@@ -308,7 +320,7 @@ export function usePrimePaymentMethods(): IUsePrimePayment {
         await backgroundApiProxy.serviceApp.hideDialogLoading();
       }
     },
-    [isReady, intl, loginPurchasesSdk],
+    [isReady, intl, loginPurchasesSdk, setPrimePersistAtom],
   );
 
   return {


### PR DESCRIPTION
## Summary
- After a new subscription on Android, the "manage subscription" button was not displayed because `subscriptionManageUrl` was never populated from the server API response or purchase result
- Set `subscriptionManageUrl` immediately from `makePurchaseResult.customerInfo.managementURL` after native purchase (handles RevenueCat webhook delay)
- Extract `managementUrl` from `serverUserInfo.subscriptions[0]` as fallback in `updatePrimeAtomByServerUserInfo` (handles refresh/re-login scenarios)

## Test plan
- [ ] Reset app, log in, subscribe for the first time on Android
- [ ] Verify "manage subscription" button appears immediately after purchase
- [ ] Verify button still works after app restart / re-login
- [ ] Verify iOS and extension subscription flow are not affected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
