### PR TITLE
feat(market): add tooltip to stock source logo showing title

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx
@@ -5,7 +5,6 @@ import { useWindowDimensions } from 'react-native';
 
 import {
   Divider,
-  Image,
   InteractiveIcon,
   SizableText,
   XStack,
@@ -22,6 +21,7 @@ import type { IMarketTokenDetail } from '@onekeyhq/shared/types/marketV2';
 import { CommunityRecognizedBadge } from '../../../components/CommunityRecognizedBadge';
 import {
   StockIsOpenBadge,
+  StockSourceLogo,
   SubtitleBadge,
 } from '../../../components/PerpsBadges';
 import { MarketStarV2 } from '../../../components/MarketStarV2';
@@ -133,14 +133,7 @@ export function TokenDetailHeaderLeft({
             >
               {symbol}
             </SizableText>
-            {stock?.sourceLogoUri ? (
-              <Image
-                width={14}
-                height={14}
-                borderRadius="$full"
-                source={{ uri: stock.sourceLogoUri }}
-              />
-            ) : null}
+            <StockSourceLogo stock={stock} />
             {communityRecognized ? <CommunityRecognizedBadge /> : null}
             {stock?.subtitle ? (
               <SubtitleBadge subtitle={stock.subtitle} />

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenIdentityItem/TokenIdentityItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenIdentityItem/TokenIdentityItem.tsx
@@ -3,7 +3,6 @@ import { memo, useMemo } from 'react';
 
 import {
   Icon,
-  Image,
   NATIVE_HIT_SLOP,
   NumberSizeableText,
   SizableText,

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenIdentityItem/TokenIdentityItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenIdentityItem/TokenIdentityItem.tsx
@@ -15,7 +15,10 @@ import {
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import { useNetworkLogoUri } from '@onekeyhq/kit/src/hooks/useNetworkLogoUri';
 import { CommunityRecognizedBadge } from '@onekeyhq/kit/src/views/Market/components/CommunityRecognizedBadge';
-import { SubtitleBadge } from '@onekeyhq/kit/src/views/Market/components/PerpsBadges';
+import {
+  StockSourceLogo,
+  SubtitleBadge,
+} from '@onekeyhq/kit/src/views/Market/components/PerpsBadges';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { ECopyFrom } from '@onekeyhq/shared/src/logger/scopes/dex';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -159,14 +162,7 @@ const BasicTokenIdentityItem: FC<ITokenIdentityItemProps> = ({
           >
             {symbol}
           </SizableText>
-          {stock?.sourceLogoUri ? (
-            <Image
-              width={14}
-              height={14}
-              borderRadius="$full"
-              source={{ uri: stock.sourceLogoUri }}
-            />
-          ) : null}
+          <StockSourceLogo stock={stock} />
           {communityRecognized ? <CommunityRecognizedBadge /> : null}
           {stock?.subtitle ? <SubtitleBadge subtitle={stock.subtitle} /> : null}
         </XStack>

--- a/packages/kit/src/views/Market/components/PerpsBadges.tsx
+++ b/packages/kit/src/views/Market/components/PerpsBadges.tsx
@@ -2,8 +2,15 @@ import { memo } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { SizableText, XStack } from '@onekeyhq/components';
+import {
+  Image,
+  SizableText,
+  Stack,
+  Tooltip,
+  XStack,
+} from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import type { IMarketStockInfo } from '@onekeyhq/shared/types/marketV2';
 
 const LeverageBadge = memo(({ leverage }: { leverage: number }) => (
   <XStack
@@ -61,4 +68,35 @@ const StockIsOpenBadge = memo(({ isOpen }: { isOpen: boolean }) => {
 });
 StockIsOpenBadge.displayName = 'StockIsOpenBadge';
 
-export { LeverageBadge, StockIsOpenBadge, SubtitleBadge };
+const StockSourceLogo = memo(
+  ({ stock }: { stock: IMarketStockInfo | undefined }) => {
+    if (!stock?.sourceLogoUri) {
+      return null;
+    }
+
+    const image = (
+      <Image
+        width={14}
+        height={14}
+        borderRadius="$full"
+        source={{ uri: stock.sourceLogoUri }}
+      />
+    );
+
+    if (stock.title) {
+      return (
+        <Tooltip
+          hovering
+          placement="top"
+          renderContent={stock.title}
+          renderTrigger={<Stack cursor="pointer">{image}</Stack>}
+        />
+      );
+    }
+
+    return image;
+  },
+);
+StockSourceLogo.displayName = 'StockSourceLogo';
+
+export { LeverageBadge, StockIsOpenBadge, StockSourceLogo, SubtitleBadge };

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
@@ -5,7 +5,6 @@ import { useIntl } from 'react-intl';
 
 import {
   IconButton,
-  Image,
   NumberSizeableText,
   SizableText,
   Stack,
@@ -19,7 +18,10 @@ import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useMarketWatchListV2Atom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2/atoms';
 import { useUniversalSearchActions } from '@onekeyhq/kit/src/states/jotai/contexts/universalSearch';
 import { CommunityRecognizedBadge } from '@onekeyhq/kit/src/views/Market/components/CommunityRecognizedBadge';
-import { SubtitleBadge } from '@onekeyhq/kit/src/views/Market/components/PerpsBadges';
+import {
+  StockSourceLogo,
+  SubtitleBadge,
+} from '@onekeyhq/kit/src/views/Market/components/PerpsBadges';
 import { useToDetailPage } from '@onekeyhq/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useToMarketDetailPage';
 import { ETranslations } from '@onekeyhq/shared/src/locale/enum/translations';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
@@ -281,14 +283,7 @@ export function UniversalSearchV2MarketTokenItem({
               >
                 {formatTokenSymbolForDisplay(symbol)}
               </SizableText>
-              {stock?.sourceLogoUri ? (
-                <Image
-                  width={14}
-                  height={14}
-                  borderRadius="$full"
-                  source={{ uri: stock.sourceLogoUri }}
-                />
-              ) : null}
+              <StockSourceLogo stock={stock} />
               {communityRecognized ? <CommunityRecognizedBadge /> : null}
               {stock?.subtitle ? (
                 <SubtitleBadge subtitle={stock.subtitle} />

--- a/packages/shared/types/marketV2.ts
+++ b/packages/shared/types/marketV2.ts
@@ -116,6 +116,7 @@ export interface IMarketTokenListItemExtraData {
 }
 
 export interface IMarketStockInfo {
+  title?: string;
   subtitle: string;
   sourceLogoUri: string;
   isOpen: boolean;


### PR DESCRIPTION
## Summary
- Add `title` field to `IMarketStockInfo` type for stock source tooltip
- Create shared `StockSourceLogo` component in `PerpsBadges.tsx` to render stock source logo with optional tooltip
- Replace duplicated inline Image rendering across 3 files with the shared component

## Intent & Context
The market API now returns a `title` field in the `stock` object (e.g. "Tokenized by Ondo Finance"). This title should be displayed as a tooltip when hovering over the stock source logo (e.g. Ondo logo) next to tokenized real-world asset tokens like AAPLon.

## Design Decisions
- **Shared `StockSourceLogo` component**: The same Image+Tooltip pattern was needed in 3 locations (market home list, token detail header, universal search results). Instead of duplicating the logic, extracted it into a shared `memo` component in `PerpsBadges.tsx`, which already houses other stock-related badge components (`SubtitleBadge`, `StockIsOpenBadge`).
- **`hovering` prop on Tooltip**: Standard Tamagui `Tooltip` `onOpenChange` mechanism didn't trigger reliably with `Image` as the trigger element. Using the `hovering` prop enables explicit `onHoverIn`/`onHoverOut` detection on `TMTooltip.Trigger`, bypassing the internal mechanism.
- **`Stack` wrapper around Image**: The `Image` component (expo-image based) doesn't properly forward hover events to `TMTooltip.Trigger`. Wrapping it in a `Stack` (native Tamagui component) ensures reliable hover detection.
- **`placement="top"`**: Tooltip displays above the logo to avoid being clipped by list items below.
- **Optional `title`**: When `stock.title` is absent, falls back to rendering the plain Image without tooltip.

## Changes Detail
- `packages/shared/types/marketV2.ts` — Added optional `title` field to `IMarketStockInfo`
- `packages/kit/src/views/Market/components/PerpsBadges.tsx` — New `StockSourceLogo` shared component with Image, optional Tooltip, and memo optimization
- `packages/kit/src/views/Market/MarketHomeV2/.../TokenIdentityItem.tsx` — Replaced inline Image with `<StockSourceLogo />`
- `packages/kit/src/views/Market/MarketDetailV2/.../TokenDetailHeaderLeft.tsx` — Replaced inline Image with `<StockSourceLogo />`
- `packages/kit/src/views/UniversalSearch/.../UniversalSearchV2MarketTokenItem.tsx` — Replaced inline Image with `<StockSourceLogo />`

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Web / Desktop / Extension (Tooltip is web-only; native Tooltip returns trigger directly)
- **Risk Areas**: Tooltip hover detection in virtualized lists (mitigated by using `hovering` prop)

## Test plan
- [ ] Search for a tokenized stock token (e.g. "AAPLon") and verify the Ondo logo shows a tooltip with "Tokenized by Ondo Finance" on hover
- [ ] Verify tooltip appears above the logo
- [ ] Navigate to token detail page and verify tooltip works on the stock logo there
- [ ] Verify tokens without `stock.title` still show the logo without tooltip
- [ ] Verify on mobile that the logo displays normally (no tooltip expected on native)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
