### PR TITLE
fix: replace discovery home tab icon with EarthOutline

### DIFF
--- a/packages/kit/src/views/Discovery/components/DesktopCustomTabBarItem/index.tsx
+++ b/packages/kit/src/views/Discovery/components/DesktopCustomTabBarItem/index.tsx
@@ -209,7 +209,7 @@ function DesktopCustomTabBarItem({
         hideCloseButton={isCollapse}
         size="small"
         showAvatar={!isHomeTab}
-        icon={isHomeTab ? 'Ai3StarOutline' : undefined}
+        icon={isHomeTab ? 'EarthOutline' : undefined}
         shortcutKey={shortcutKey}
         key={id}
         selected={isActive}


### PR DESCRIPTION
## Summary
- Replace the default home tab icon in desktop Discovery from `Ai3StarOutline` (sparkles) to `EarthOutline` (globe/earth)
- `EarthOutline` better represents web browsing semantics and is not used elsewhere in the codebase
- Only affects the browser tab bar item for `type === 'home'` tabs; the fixed home navigation button is unchanged

## Test plan
- [ ] Open desktop app, navigate to Discovery
- [ ] Verify the home tab icon displays an earth/globe icon instead of sparkles
- [ ] Verify other browser tabs still show website favicons
- [ ] Verify the top fixed home button is unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
