### PR TITLE
fix: enable snapcraft destructive mode for arm64 snap build

### DIFF
--- a/.github/workflows/release-desktop-snap.yml
+++ b/.github/workflows/release-desktop-snap.yml
@@ -73,10 +73,10 @@ jobs:
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
 
-      - name: Configure Snapcraft to use LXD on arm64
+      - name: Configure Snapcraft destructive mode for arm64
         if: ${{ matrix.arch == 'arm64' }}
         run: |
-          echo "SNAPCRAFT_BUILD_ENVIRONMENT=lxd" >> $GITHUB_ENV
+          echo "SNAP_DESTRUCTIVE_MODE=true" >> $GITHUB_ENV
 
       - name: 'Setup ENV'
         run: |

--- a/.github/workflows/release-desktop-snap.yml
+++ b/.github/workflows/release-desktop-snap.yml
@@ -73,6 +73,11 @@ jobs:
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
 
+      - name: Configure Snapcraft to use LXD on arm64
+        if: ${{ matrix.arch == 'arm64' }}
+        run: |
+          echo "SNAPCRAFT_BUILD_ENVIRONMENT=lxd" >> $GITHUB_ENV
+
       - name: 'Setup ENV'
         run: |
           eval "$(node -e 'const v=require("./apps/desktop/package.json").version; console.log("pkg_version="+v)')"


### PR DESCRIPTION
## Summary
- On arm64, electron-builder has no snap template and falls back to calling `snapcraft`, which requires multipass (unavailable on `ubuntu-24.04-arm` runners)
- Set `SNAP_DESTRUCTIVE_MODE=true` so `app-builder` passes `--destructive-mode` to snapcraft, building directly on the host without any container environment
- Only affects arm64 builds; amd64 continues using snap templates as before

## Test plan
- [x] CI verified on `fix/snap-arm64-lxd-env` branch with `workflow_dispatch`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
