### PR TITLE
Make account selector atoms serializable (Map -> plain object) and add serializable typing to `globalAtom`

### DIFF
--- a/packages/kit-bg/src/states/jotai/atoms/accountSelectorValues.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/accountSelectorValues.ts
@@ -24,18 +24,28 @@ export type IAccountSelectorDeFiItem =
 
 // Outer key is selector instance `num`, inner key is accountId.
 // This scoping prevents concurrent selectors from overwriting each other.
+export type IAccountSelectorValueMapAtom = Record<
+  string,
+  Record<string, IAccountSelectorValueItem>
+>;
+
+export type IAccountSelectorDeFiMapAtom = Record<
+  string,
+  Record<string, IAccountSelectorDeFiItem>
+>;
+
 export const {
   target: accountSelectorValuesMapAtom,
   use: useAccountSelectorValuesMapAtom,
-} = globalAtom<Map<number, Map<string, IAccountSelectorValueItem>>>({
+} = globalAtom<IAccountSelectorValueMapAtom>({
   name: EAtomNames.accountSelectorValuesMapAtom,
-  initialValue: new Map(),
+  initialValue: {},
 });
 
 export const {
   target: accountSelectorDeFiMapAtom,
   use: useAccountSelectorDeFiMapAtom,
-} = globalAtom<Map<number, Map<string, IAccountSelectorDeFiItem>>>({
+} = globalAtom<IAccountSelectorDeFiMapAtom>({
   name: EAtomNames.accountSelectorDeFiMapAtom,
-  initialValue: new Map(),
+  initialValue: {},
 });

--- a/packages/kit-bg/src/states/jotai/utils/index.ts
+++ b/packages/kit-bg/src/states/jotai/utils/index.ts
@@ -26,6 +26,31 @@ import type {
 } from '../types';
 import type { Atom, PrimitiveAtom, WritableAtom } from 'jotai';
 
+// JSON primitive values.
+export type ISerializablePrimitive = string | number | boolean | null;
+
+// Serializable atom values (TypeScript type-check level, not runtime lint).
+// NOTE: `undefined` is intentionally included for transient states.
+export type ISerializableValue =
+  | ISerializablePrimitive
+  | undefined
+  | ISerializableValue[]
+  | {
+      [key: string]: ISerializableValue;
+    };
+
+type INonSerializableValue =
+  | bigint
+  | symbol
+  | ((...args: any[]) => unknown)
+  | Map<unknown, unknown>
+  | Set<unknown>
+  | WeakMap<object, unknown>
+  | WeakSet<object>
+  | Promise<unknown>;
+
+type IAssertSerializable<T> = T extends INonSerializableValue ? never : T;
+
 export function makeCrossAtom<T extends () => any>(name: string, fn: T) {
   const atomBuilder = memoizee(fn, {
     primitive: true,
@@ -188,7 +213,7 @@ export function globalAtom<Value>({
   persist,
 }: {
   name: EAtomNames;
-  initialValue: Value;
+  initialValue: IAssertSerializable<Value>;
   persist?: boolean;
 }) {
   const storageName = persist ? name : undefined;

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAccountListItem.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAccountListItem.tsx
@@ -108,8 +108,14 @@ export function AccountSelectorAccountListItem({
   const [addressCreationState] = useIndexedAccountAddressCreationStateAtom();
   const [valuesMapAll] = useAccountSelectorValuesMapAtom();
   const [deFiMapAll] = useAccountSelectorDeFiMapAtom();
-  const valuesMap = useMemo(() => valuesMapAll.get(num), [valuesMapAll, num]);
-  const deFiMap = useMemo(() => deFiMapAll.get(num), [deFiMapAll, num]);
+  const valuesMap = useMemo(() => valuesMapAll[String(num)], [
+    valuesMapAll,
+    num,
+  ]);
+  const deFiMap = useMemo(() => deFiMapAll[String(num)], [
+    deFiMapAll,
+    num,
+  ]);
 
   const account = useMemo(
     () => (isOthersUniversal ? (item as IDBAccount) : undefined),
@@ -191,12 +197,12 @@ export function AccountSelectorAccountListItem({
   const subTitleInfo = useMemo(() => buildSubTitleInfo(), [buildSubTitleInfo]);
 
   const accountValue = useMemo(
-    () => valuesMap?.get(item.id),
+    () => valuesMap?.[item.id],
     [valuesMap, item.id],
   );
 
   const accountDeFiOverview = useMemo(
-    () => deFiMap?.get(item.id),
+    () => deFiMap?.[item.id],
     [deFiMap, item.id],
   );
 

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/useAccountSelectorValuesLoader.ts
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/useAccountSelectorValuesLoader.ts
@@ -33,16 +33,18 @@ export function useAccountSelectorValuesLoader({
   const loadingIdRef = useRef(0);
 
   useEffect(() => {
+    const selectorKey = String(num);
+
     if (!accountsForValuesQuery || accountsForValuesQuery.length === 0) {
       void (async () => {
         const prev = await accountSelectorValuesMapAtom.get();
-        const next = new Map(prev);
-        next.delete(num);
+        const next = { ...prev };
+        delete next[selectorKey];
         await accountSelectorValuesMapAtom.set(next);
 
         const prevD = await accountSelectorDeFiMapAtom.get();
-        const nextD = new Map(prevD);
-        nextD.delete(num);
+        const nextD = { ...prevD };
+        delete nextD[selectorKey];
         await accountSelectorDeFiMapAtom.set(nextD);
       })();
       return;
@@ -56,15 +58,19 @@ export function useAccountSelectorValuesLoader({
       {
         const prev = await accountSelectorValuesMapAtom.get();
         if (isCancelled(currentLoadId, loadingIdRef)) return;
-        const next = new Map(prev);
-        next.set(num, new Map());
+        const next = {
+          ...prev,
+          [selectorKey]: {},
+        };
         await accountSelectorValuesMapAtom.set(next);
       }
       {
         const prev = await accountSelectorDeFiMapAtom.get();
         if (isCancelled(currentLoadId, loadingIdRef)) return;
-        const next = new Map(prev);
-        next.set(num, new Map());
+        const next = {
+          ...prev,
+          [selectorKey]: {},
+        };
         await accountSelectorDeFiMapAtom.set(next);
       }
 
@@ -88,33 +94,35 @@ export function useAccountSelectorValuesLoader({
           // Merge values into this selector's sub-map
           const prevAll = await accountSelectorValuesMapAtom.get();
           if (isCancelled(currentLoadId, loadingIdRef)) return;
-          const newAll = new Map(prevAll);
-          const subMap = new Map<string, IAccountSelectorValueItem>(
-            prevAll.get(num),
-          );
+          const subMap: Record<string, IAccountSelectorValueItem> = {
+            ...(prevAll[selectorKey] ?? {}),
+          };
           accountsValue?.forEach((v) => {
             if (v) {
-              subMap.set(v.accountId, v);
+              subMap[v.accountId] = v;
             }
           });
-          newAll.set(num, subMap);
-          await accountSelectorValuesMapAtom.set(newAll);
+          await accountSelectorValuesMapAtom.set({
+            ...prevAll,
+            [selectorKey]: subMap,
+          });
 
           if (isCancelled(currentLoadId, loadingIdRef)) return;
 
           // Merge DeFi into this selector's sub-map
           const prevAllD = await accountSelectorDeFiMapAtom.get();
           if (isCancelled(currentLoadId, loadingIdRef)) return;
-          const newAllD = new Map(prevAllD);
-          const subMapD = new Map<string, IAccountSelectorDeFiItem>(
-            prevAllD.get(num),
-          );
+          const subMapD: Record<string, IAccountSelectorDeFiItem> = {
+            ...(prevAllD[selectorKey] ?? {}),
+          };
           batch.forEach((account, batchIdx) => {
             const overview = accountsDeFiOverview?.[batchIdx];
-            subMapD.set(account.accountId, overview);
+            subMapD[account.accountId] = overview;
           });
-          newAllD.set(num, subMapD);
-          await accountSelectorDeFiMapAtom.set(newAllD);
+          await accountSelectorDeFiMapAtom.set({
+            ...prevAllD,
+            [selectorKey]: subMapD,
+          });
         } catch (_error) {
           // Batch failed, continue with next batch
         }


### PR DESCRIPTION
### Motivation

- Convert Map-based atom state to plain serializable objects so selector data can be persisted and safely passed through storage and IPC.
- Add TypeScript typing to ensure `globalAtom` initial values are JSON-serializable and catch non-serializable types early.

### Description

- Replace `Map<number, Map<string, ...>>` usage for account selector values and DeFi data with plain object maps and introduce `IAccountSelectorValueMapAtom` and `IAccountSelectorDeFiMapAtom` types. 
- Update `accountSelectorValuesMapAtom` and `accountSelectorDeFiMapAtom` initial values from `new Map()` to `{}` and adjust their `globalAtom` declaration types. 
- Add serializable type definitions (`ISerializablePrimitive`, `ISerializableValue`, `INonSerializableValue`, and `IAssertSerializable`) and change `globalAtom` to require its `initialValue` to be `IAssertSerializable<Value>`. 
- Update consumers to use string-keyed object access instead of `Map` methods, including `useAccountSelectorValuesMapAtom` consumers in `AccountSelectorAccountListItem.tsx` and the batching/merge logic in `useAccountSelectorValuesLoader.ts`, converting `Map` manipulations to object spread and property assignment.

### Testing

- Ran TypeScript type checking and compilation which succeeded without errors. 
- Ran project unit tests which passed. 
- Built the application (development build) and verified no runtime errors during the account selector flows in automated checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b12d37347c8332b8dfe0cf70b40724)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
