### PR TITLE
fix: improve tab navigation in password dialogs

### DIFF
--- a/packages/components/src/forms/Input/index.tsx
+++ b/packages/components/src/forms/Input/index.tsx
@@ -365,6 +365,7 @@ function BaseInput(
           onSecureTextEntryChange?.(!secureEntryState);
           setSecureEntryState(!secureEntryState);
         },
+        tabIndex: -1,
       });
     }
     return allAddOns;

--- a/packages/kit/src/components/Hardware/Hardware.tsx
+++ b/packages/kit/src/components/Hardware/Hardware.tsx
@@ -976,6 +976,7 @@ export function EnterPhase({
                 onPress: () => {
                   setSecureEntry1(!secureEntry1);
                 },
+                tabIndex: -1,
               },
             ]}
             {...(media.md && {

--- a/packages/kit/src/components/Password/components/PasswordSetup.tsx
+++ b/packages/kit/src/components/Password/components/PasswordSetup.tsx
@@ -227,6 +227,7 @@ const PasswordSetup = ({
                       setSecureEntry(!secureEntry);
                     },
                     testID: `password-eye-${secureEntry ? 'off' : 'on'}`,
+                    tabIndex: -1,
                   },
                 ]}
                 testID="password"
@@ -281,6 +282,7 @@ const PasswordSetup = ({
                     testID: `confirm-password-eye-${
                       secureReentry ? 'off' : 'on'
                     }`,
+                    tabIndex: -1,
                   },
                 ]}
                 testID="confirm-password"

--- a/packages/kit/src/components/Password/components/PasswordVerify.tsx
+++ b/packages/kit/src/components/Password/components/PasswordVerify.tsx
@@ -138,6 +138,7 @@ function PasswordVerify({
         onPress: () => {
           setSecureEntry(!secureEntry);
         },
+        tabIndex: -1,
       });
       actions.push({
         iconName: 'ArrowRightOutline',

--- a/packages/kit/src/views/AccountManagerStacks/pages/ExportKeys/ExportPrivateKeys.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/ExportKeys/ExportPrivateKeys.tsx
@@ -246,6 +246,7 @@ function ExportPrivateKeysPage({
       {
         testID: 'account-key-show-btn',
         iconName: secureEntry ? 'EyeOutline' : 'EyeOffOutline',
+        tabIndex: -1,
         onPress: async () => {
           const rawKeyValue = form.getValues('rawKeyContent') || '';
           if (!rawKeyValue || rawKeyValue === SECURE_ENTRY_PLACEHOLDER) {

--- a/packages/kit/src/views/CloudBackup/components/useResotrePasswordVerify.tsx
+++ b/packages/kit/src/views/CloudBackup/components/useResotrePasswordVerify.tsx
@@ -39,6 +39,7 @@ function RestorePasswordVerify() {
                 setSecureEntry(!secureEntry);
               },
               testID: `password-eye-${secureEntry ? 'off' : 'on'}`,
+              tabIndex: -1,
             },
           ]}
         />


### PR DESCRIPTION
Closes https://github.com/OneKeyHQ/app-monorepo/issues/7964

## Summary
- Add `tabIndex: -1` to all eye toggle buttons in password/passcode inputs so Tab key skips them and moves directly to the next input field
- Fix applies to both the `allowSecureTextEye` auto-generated button in the Input component and all manually defined eye addOns across the codebase
- Affected components: PasswordSetup, PasswordVerify, Hardware passphrase, ExportPrivateKeys, CloudBackup restore

## Known issue: Dialog focus trap is missing
Tamagui's `FocusScope` is commented out in `@tamagui/dialog/src/Dialog.tsx`, so focus can escape the dialog entirely after tabbing through all elements. This is a deeper issue that needs to be addressed separately at the Dialog component level. @huhuanming

## Test plan
- [ ] Open Set Passcode dialog on desktop → Tab from first password field should go directly to confirm password field (not the eye button)
- [ ] Press Enter in confirm password field → should trigger form submission
- [ ] Verify eye buttons are still clickable with mouse
- [ ] Test on Hardware passphrase dialog, Export Private Keys page, and Cloud Backup restore dialog
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10607" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
