### PR TITLE
fix: resolve nightly ESLint errors

### DIFF
--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -429,10 +429,8 @@ function HomeOverviewContainer() {
       if (!isCurrentAccountWorthReady && !isCurrentAccountDeFiReady) {
         return undefined;
       }
-    } else {
-      if (!isCurrentAccountWorthReady || !isCurrentAccountDeFiReady) {
-        return undefined;
-      }
+    } else if (!isCurrentAccountWorthReady || !isCurrentAccountDeFiReady) {
+      return undefined;
     }
 
     const tokenWorth =

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx
@@ -19,12 +19,12 @@ import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import type { IMarketTokenDetail } from '@onekeyhq/shared/types/marketV2';
 
 import { CommunityRecognizedBadge } from '../../../components/CommunityRecognizedBadge';
+import { MarketStarV2 } from '../../../components/MarketStarV2';
 import {
   StockIsOpenBadge,
   StockSourceLogo,
   SubtitleBadge,
 } from '../../../components/PerpsBadges';
-import { MarketStarV2 } from '../../../components/MarketStarV2';
 import { TokenSecurityAlert } from '../TokenSecurityAlert';
 
 import { useTokenDetailHeaderLeftActions } from './hooks/useTokenDetailHeaderLeftActions';

--- a/packages/kit/src/views/Perp/components/TokenSelector/FavoritesEmptyState.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/FavoritesEmptyState.tsx
@@ -10,9 +10,9 @@ import {
   XStack,
   YStack,
 } from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import { usePerpsAllAssetsFilteredAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
-import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { usePerpTokenFavoritesPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { getHyperliquidTokenImageUrl } from '@onekeyhq/shared/src/utils/perpsUtils';

--- a/packages/kit/src/views/ReferFriends/pages/InvitedByFriend/components/InvitedByFriendActions.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/InvitedByFriend/components/InvitedByFriendActions.tsx
@@ -18,6 +18,7 @@ import { useWalletBoundReferralCode } from '@onekeyhq/kit/src/views/ReferFriends
 import { EXT_RATE_URL } from '@onekeyhq/shared/src/config/appConfig';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { EOneKeyDeepLinkPath } from '@onekeyhq/shared/src/consts/deeplinkConsts';
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -191,7 +192,7 @@ function InvitedByFriendActions({
 
       const address = accounts?.[0];
       if (!address) {
-        throw new Error('No account returned from extension');
+        throw new OneKeyLocalError('No account returned from extension');
       }
 
       const networkId = getNetworkIdsMap().eth;

--- a/packages/shared/src/storage/secureStorage/webauthnPrf.ts
+++ b/packages/shared/src/storage/secureStorage/webauthnPrf.ts
@@ -2,8 +2,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Buffer } from 'buffer';
 
-import platformEnv from '../../platformEnv';
 import { BIOLOGY_AUTH_CANCEL_ERROR } from '../../../types/password';
+import platformEnv from '../../platformEnv';
 
 // Storage keys
 const PRF_CREDENTIAL_ID_KEY = '$secure_prf_credential_id$';


### PR DESCRIPTION
## Summary
- Auto-fix ESLint errors detected by nightly CI
- Closes #10582

## Changes
- Fixed import/order in `packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx`
- Fixed import/order in `packages/kit/src/views/Perp/components/TokenSelector/FavoritesEmptyState.tsx`
- Auto-fixed no-lonely-if in `packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx`
- Replaced direct throw new Error with `OneKeyLocalError` in `packages/kit/src/views/ReferFriends/pages/InvitedByFriend/components/InvitedByFriendActions.tsx`
- Fixed import/order in `packages/shared/src/storage/secureStorage/webauthnPrf.ts`

## Test plan
- [x] ESLint passes locally (`NODE_OPTIONS=--max-old-space-size=8192 npx eslint . --ext .ts,.tsx --max-warnings 0`)
- [x] CI checks pass

🤖 Auto-generated by Scriptoria ESLint fix automation

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
