### PR TITLE
fix: resolve missing app icon on Pixel devices, OK-51538

### DIFF
--- a/apps/mobile/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/apps/mobile/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@mipmap/ic_launcher_background"/>
-    <foreground android:drawable="@mipmap/ic_launcher_round"/>
+    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
     <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
 </adaptive-icon>


### PR DESCRIPTION
## Summary
- Fix circular reference in `ic_launcher_round.xml` where foreground drawable pointed to itself (`@mipmap/ic_launcher_round`) instead of the correct foreground layer (`@mipmap/ic_launcher_foreground`)
- This caused app icon to be missing on Pixel devices (Android 13+/API 33+) which strictly use adaptive-icon XML from `mipmap-anydpi-v26/`

## Test plan
- [ ] Install on Pixel device (or Android emulator with Pixel image) running Android 13+
- [ ] Verify app icon displays correctly on home screen
- [ ] Verify themed/monochrome icon works in Android 13+ themed icon mode
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
