### PR TITLE
Hide collateral repay tab entry

### DIFF
--- a/packages/kit/src/views/Borrow/components/BorrowRepayPosition.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowRepayPosition.tsx
@@ -93,6 +93,7 @@ type IBorrowRepayPositionProps = Omit<
 type IRepayMode = 'wallet' | 'collateral';
 
 const ARROW_OVERLAY_OFFSET = -13;
+const ENABLE_COLLATERAL_REPAY_ENTRY = false;
 
 function CollateralSelectContent({
   assets,
@@ -1097,11 +1098,12 @@ export function BorrowRepayPosition({
     },
   ];
 
-  // Show collateral repay when debt exists AND collateral data is either
-  // still loading (optimistic) or confirmed available. Falls back to
-  // wallet-only if the second API returns empty or fails.
+  // Hide the entry for this release while keeping the collateral repay flow
+  // implemented behind the flag.
   const isCollateralRepayEnabled =
-    !!debtBalance && (!!collateralLoading || collateralAssets.length > 0);
+    ENABLE_COLLATERAL_REPAY_ENTRY &&
+    !!debtBalance &&
+    (!!collateralLoading || collateralAssets.length > 0);
 
   if (!isCollateralRepayEnabled) {
     return (


### PR DESCRIPTION
## Summary
- hide the collateral repay tab entry in the borrow repay flow for this release
- keep the underlying collateral repay implementation behind a local flag for quick re-enable

## Testing
- npx eslint packages/kit/src/views/Borrow/components/BorrowRepayPosition.tsx --ext .ts,.tsx
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
