### PR TITLE
feat(perps): add pageView analytics with entry source tracking

### DIFF
--- a/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopTabItem.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopTabItem.tsx
@@ -162,7 +162,7 @@ export function DesktopTabItem(
       } else {
         onPress?.(e);
       }
-      if (trackId === 'global-perp') {
+      if (trackId === 'global-perp' && !selected) {
         setPerpPageEnterSource(EPerpPageEnterSource.TabBar);
       }
       if (trackId) {

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopTabItem.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopTabItem.tsx
@@ -29,6 +29,10 @@ import type {
 } from '@onekeyhq/components/src/shared/tamagui';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import {
+  EPerpPageEnterSource,
+  setPerpPageEnterSource,
+} from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EShortcutEvents } from '@onekeyhq/shared/src/shortcuts/shortcuts.enum';
 
@@ -157,6 +161,9 @@ export function DesktopTabItem(
         // Removed: openActionList?.current?.() to avoid conflict with hover popover
       } else {
         onPress?.(e);
+      }
+      if (trackId === 'global-perp') {
+        setPerpPageEnterSource(EPerpPageEnterSource.TabBar);
       }
       if (trackId) {
         defaultLogger.app.page.tabBarClick(trackId);

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/MobileBottomTabBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/MobileBottomTabBar.tsx
@@ -75,7 +75,7 @@ export default function MobileBottomTabBar({
         });
       }
 
-      if (route.name === ETabRoutes.Perp) {
+      if (route.name === ETabRoutes.Perp && !isActive) {
         setPerpPageEnterSource(EPerpPageEnterSource.TabBar);
       }
 

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/MobileBottomTabBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/MobileBottomTabBar.tsx
@@ -16,6 +16,10 @@ import {
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EEnterWay } from '@onekeyhq/shared/src/logger/scopes/dex';
+import {
+  EPerpPageEnterSource,
+  setPerpPageEnterSource,
+} from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes/tab';
 import { ESwapSource } from '@onekeyhq/shared/types/swap/types';
@@ -69,6 +73,10 @@ export default function MobileBottomTabBar({
         defaultLogger.swap.enterSwap.enterSwap({
           enterFrom: ESwapSource.TAB,
         });
+      }
+
+      if (route.name === ETabRoutes.Perp) {
+        setPerpPageEnterSource(EPerpPageEnterSource.TabBar);
       }
 
       if (!isActive && !event.defaultPrevented) {

--- a/packages/kit/src/components/TabPageHeader/components/WebHeaderNavigation/WebHeaderNavigation.tsx
+++ b/packages/kit/src/components/TabPageHeader/components/WebHeaderNavigation/WebHeaderNavigation.tsx
@@ -15,6 +15,10 @@ import { usePerpTabConfig } from '@onekeyhq/kit/src/hooks/usePerpTabConfig';
 import { useToReferFriendsModalByRootNavigation } from '@onekeyhq/kit/src/hooks/useReferFriends';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
+  EPerpPageEnterSource,
+  setPerpPageEnterSource,
+} from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
+import {
   ERootRoutes,
   ETabEarnRoutes,
   ETabMarketRoutes,
@@ -168,6 +172,9 @@ function useWebHeaderNavigation({
         return;
       }
 
+      if (tabKey === ETabRoutes.Perp) {
+        setPerpPageEnterSource(EPerpPageEnterSource.TabBar);
+      }
       if (tabKey) {
         navigation.switchTab(tabKey as ETabRoutes);
       }

--- a/packages/kit/src/provider/Bootstrap.tsx
+++ b/packages/kit/src/provider/Bootstrap.tsx
@@ -57,6 +57,10 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { EPrimePages } from '@onekeyhq/shared/src/routes/prime';
 import { ERootRoutes } from '@onekeyhq/shared/src/routes/root';
+import {
+  EPerpPageEnterSource,
+  setPerpPageEnterSource,
+} from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import { EShortcutEvents } from '@onekeyhq/shared/src/shortcuts/shortcuts.enum';
 import { ESpotlightTour } from '@onekeyhq/shared/src/spotlight';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
@@ -287,6 +291,7 @@ const useDesktopEvents = platformEnv.isDesktop
             break;
           case EShortcutEvents.TabPerps:
             ensureModalClosedAndNavigate(() => {
+              setPerpPageEnterSource(EPerpPageEnterSource.Shortcut);
               navigation.switchTab(ETabRoutes.Perp);
             });
             break;

--- a/packages/kit/src/provider/Container/NotificationHandlerContainer/index.tsx
+++ b/packages/kit/src/provider/Container/NotificationHandlerContainer/index.tsx
@@ -5,6 +5,10 @@ import {
   EAppEventBusNames,
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
+import {
+  EPerpPageEnterSource,
+  setPerpPageEnterSource,
+} from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { navigateToNotificationDetailByLocalParams } from '@onekeyhq/shared/src/utils/notificationsUtils';
@@ -129,6 +133,10 @@ function BaseNotificationHandlerContainer() {
       const isPerpNavigation =
         payloadObj.screen === 'main' &&
         payloadObj.params?.screen === ETabRoutes.Perp;
+
+      if (isPerpNavigation) {
+        setPerpPageEnterSource(EPerpPageEnterSource.Notification);
+      }
 
       const perpToken = isPerpNavigation
         ? (payloadObj.params?.params as { token?: string } | undefined)

--- a/packages/kit/src/routes/Tab/router.ts
+++ b/packages/kit/src/routes/Tab/router.ts
@@ -203,6 +203,7 @@ export const useTabRouterConfig = (params?: IGetTabRouterParams) => {
         rewrite: perpTabShowWeb ? undefined : '/perps',
         exact: true,
         hiddenIcon: perpDisabled || perpTabShowWeb,
+        trackId: 'global-perp',
       },
       {
         name: ETabRoutes.Earn,

--- a/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
@@ -30,6 +30,10 @@ import {
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EWatchlistFrom } from '@onekeyhq/shared/src/logger/scopes/dex';
+import {
+  EPerpPageEnterSource,
+  setPerpPageEnterSource,
+} from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   ERootRoutes,
@@ -719,6 +723,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
           });
           return;
         }
+        setPerpPageEnterSource(EPerpPageEnterSource.PopularTrading);
         navigation.switchTab(ETabRoutes.Perp);
         void backgroundApiProxy.serviceHyperliquid.changeActiveAsset({
           coin: record.perpsCoin,

--- a/packages/kit/src/views/Home/pages/referralLanding/ReferralLandingPage.tsx
+++ b/packages/kit/src/views/Home/pages/referralLanding/ReferralLandingPage.tsx
@@ -28,6 +28,10 @@ import {
 import { EOneKeyDeepLinkPath } from '@onekeyhq/shared/src/consts/deeplinkConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import {
+  EPerpPageEnterSource,
+  setPerpPageEnterSource,
+} from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   EModalReferFriendsRoutes,
@@ -293,6 +297,9 @@ function ReferralLandingPage() {
       const pageLower = page?.toLowerCase() ?? '';
       const targetTabRoute = PAGE_TO_TAB_ROUTE[pageLower] ?? ETabRoutes.Market;
 
+      if (targetTabRoute === ETabRoutes.Perp) {
+        setPerpPageEnterSource(EPerpPageEnterSource.Referral);
+      }
       navigation.switchTab(targetTabRoute);
 
       modalTimerId = setTimeout(() => {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/PerpetualTradingBanner/PerpetualTradingBanner.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/PerpetualTradingBanner/PerpetualTradingBanner.tsx
@@ -14,6 +14,10 @@ import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useBannerClosePersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import {
+  EPerpPageEnterSource,
+  setPerpPageEnterSource,
+} from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 
 import { useTokenDetail } from '../../hooks/useTokenDetail';
@@ -54,6 +58,7 @@ export function PerpetualTradingBanner({
       hlTicker,
     });
     setTimeout(async () => {
+      setPerpPageEnterSource(EPerpPageEnterSource.MarketBanner);
       navigation.switchTab(ETabRoutes.Perp);
       try {
         await backgroundApiProxy.serviceHyperliquid.changeActiveAsset({

--- a/packages/kit/src/views/Market/hooks/usePerpsNavigation.ts
+++ b/packages/kit/src/views/Market/hooks/usePerpsNavigation.ts
@@ -2,6 +2,10 @@ import { useCallback } from 'react';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import {
+  EPerpPageEnterSource,
+  setPerpPageEnterSource,
+} from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 
 export function usePerpsNavigation() {
@@ -10,6 +14,7 @@ export function usePerpsNavigation() {
   const navigateToPerps = useCallback(
     (coin: string) => {
       setTimeout(async () => {
+        setPerpPageEnterSource(EPerpPageEnterSource.MarketList);
         navigation.switchTab(ETabRoutes.Perp);
         try {
           await backgroundApiProxy.serviceHyperliquid.changeActiveAsset({

--- a/packages/kit/src/views/Perp/pages/Perp.tsx
+++ b/packages/kit/src/views/Perp/pages/Perp.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { useIsFocused } from '@react-navigation/native';
 import { useIntl } from 'react-intl';
@@ -15,6 +15,8 @@ import { TabletHomeContainer } from '@onekeyhq/kit/src/components/TabletHomeCont
 import { DOWNLOAD_MOBILE_APP_URL } from '@onekeyhq/shared/src/config/appConfig';
 import { FLOAT_NAV_BAR_Z_INDEX } from '@onekeyhq/shared/src/consts/zIndexConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import { consumePerpPageEnterSource } from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes/tab';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
@@ -55,6 +57,15 @@ function PerpBodyContent() {
 }
 
 function PerpContent() {
+  const isFocused = useIsFocused();
+  useEffect(() => {
+    if (isFocused) {
+      defaultLogger.perp.common.pageView({
+        source: consumePerpPageEnterSource(),
+      });
+    }
+  }, [isFocused]);
+
   const [tabPageHeight, setTabPageHeight] = useState(
     platformEnv.isNativeIOS ? 143 : 92,
   );

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchPerpItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchPerpItem.tsx
@@ -6,6 +6,10 @@ import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useUniversalSearchActions } from '@onekeyhq/kit/src/states/jotai/contexts/universalSearch';
+import {
+  EPerpPageEnterSource,
+  setPerpPageEnterSource,
+} from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { XYZ_DEX_PREFIX } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import type { IUniversalSearchPerp } from '@onekeyhq/shared/types/search';
@@ -32,6 +36,7 @@ export function UniversalSearchPerpItem({
 
   const handlePress = useCallback(() => {
     setTimeout(async () => {
+      setPerpPageEnterSource(EPerpPageEnterSource.UniversalSearch);
       navigation.switchTab(ETabRoutes.Perp);
       try {
         await backgroundApiProxy.serviceHyperliquid.changeActiveAsset({

--- a/packages/shared/src/logger/scopes/perp/perpPageSource.ts
+++ b/packages/shared/src/logger/scopes/perp/perpPageSource.ts
@@ -1,0 +1,15 @@
+import { EPerpPageEnterSource } from './type';
+
+export { EPerpPageEnterSource };
+
+let _pendingSource: EPerpPageEnterSource | null = null;
+
+export function setPerpPageEnterSource(source: EPerpPageEnterSource) {
+  _pendingSource = source;
+}
+
+export function consumePerpPageEnterSource(): EPerpPageEnterSource {
+  const source = _pendingSource ?? EPerpPageEnterSource.DirectUrl;
+  _pendingSource = null;
+  return source;
+}

--- a/packages/shared/src/logger/scopes/perp/scenes/common.ts
+++ b/packages/shared/src/logger/scopes/perp/scenes/common.ts
@@ -1,7 +1,14 @@
 import { BaseScene } from '../../../base/baseScene';
 import { LogToLocal, LogToServer } from '../../../base/decorators';
+import type { EPerpPageEnterSource } from '../type';
 
 export class CommonScene extends BaseScene {
+  @LogToServer()
+  @LogToLocal({ level: 'info' })
+  public pageView({ source }: { source: EPerpPageEnterSource }) {
+    return { source };
+  }
+
   @LogToServer()
   @LogToLocal({ level: 'info' })
   public placeOrder({

--- a/packages/shared/src/logger/scopes/perp/type.ts
+++ b/packages/shared/src/logger/scopes/perp/type.ts
@@ -1,6 +1,18 @@
 import type { IPerpsDepositToken } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { ESwapTxHistoryStatus } from '@onekeyhq/shared/types/swap/types';
 
+export enum EPerpPageEnterSource {
+  TabBar = 'tabBar',
+  Notification = 'notification',
+  MarketList = 'marketList',
+  MarketBanner = 'marketBanner',
+  UniversalSearch = 'search',
+  PopularTrading = 'popularTrading',
+  Referral = 'referral',
+  Shortcut = 'shortcut',
+  DirectUrl = 'directUrl',
+}
+
 export interface IPerpDepositInitiateParams {
   userAddress: string;
   receiverAddress: string;


### PR DESCRIPTION
## Summary

- Add `EPerpPageEnterSource` enum covering all Perp page entry points (tabBar, notification, marketList, marketBanner, search, popularTrading, referral, shortcut, directUrl)
- New `perpPageSource.ts` module: `setPerpPageEnterSource` / `consumePerpPageEnterSource` using module-level pending state pattern
- Update `pageView()` event signature to accept `{ source }` param (sent to Mixpanel)
- `PerpContent` consumes source on `useIsFocused` — fires once per navigation, no duplicates
- Annotate all 8 entry call-sites with their respective source values
- Fix missing `trackId: 'global-perp'` on native Perp tab route

## Test plan

- [ ] Enter Perp via bottom tab bar → `source: 'tabBar'`
- [ ] Enter Perp via Market list / `usePerpsNavigation` → `source: 'marketList'`
- [ ] Enter Perp via Market detail perpetual banner → `source: 'marketBanner'`
- [ ] Enter Perp via Universal Search → `source: 'search'`
- [ ] Enter Perp via Popular Trading section → `source: 'popularTrading'`
- [ ] Enter Perp via Referral landing page → `source: 'referral'`
- [ ] Enter Perp via keyboard shortcut (desktop) → `source: 'shortcut'`
- [ ] Enter Perp via notification → `source: 'notification'`
- [ ] Open Perp directly via URL / app restore → `source: 'directUrl'`
- [ ] Navigate between sub-pages within Perp and return → no duplicate `pageView` fired
- [ ] `yarn lint:staged` and `yarn tsc:staged` pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
