### PR TITLE
fix: prevent amount text clipping in BulkSend range input on Android(OK-50264)

### DIFF
--- a/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/components/AmountInput.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/components/AmountInput.tsx
@@ -356,6 +356,7 @@ export function RangeAmountInput() {
               px="$0"
               {...(platformEnv.isNativeAndroid && {
                 includeFontPadding: false,
+                h: 44,
               })}
             />
           </XStack>
@@ -406,6 +407,7 @@ export function RangeAmountInput() {
               px="$0"
               {...(platformEnv.isNativeAndroid && {
                 includeFontPadding: false,
+                h: 44,
               })}
             />
           </XStack>


### PR DESCRIPTION
## Summary
- Fix amount text clipping in BulkSend RangeAmountInput on Android by setting explicit height on min/max input fields

## Root Cause
The RangeAmountInput uses `fontSize={28}` but the default Input height of 36px minus vertical padding leaves only ~24px for content. On Android, this causes the bottom of digits to be visually clipped. The issue only affects Android due to platform differences in text rendering and font padding.

## Changes Detail
- **AmountInput.tsx**: Added `h: 44` to both min and max Input components inside the existing `platformEnv.isNativeAndroid` guard block, giving 32px of usable content area which comfortably fits the 28px font size.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile (Android only)
- **Risk Areas**: Minimal — change is scoped to Android-only props within an existing platform guard, no logic changes

## Test plan
- [ ] Open BulkSend flow on Android
- [ ] Select "Range" amount mode
- [ ] Enter amounts in both min and max fields
- [ ] Verify digits are not clipped at the bottom
- [ ] Verify iOS BulkSend range input is unaffected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
