### PR TITLE
fix: add missing Upgrade component to mobile DeFi container | OK-51636

### DIFF
--- a/packages/kit/src/views/Home/pages/DeFiContainer.tsx
+++ b/packages/kit/src/views/Home/pages/DeFiContainer.tsx
@@ -44,6 +44,7 @@ function DeFiContainer() {
   return (
     <YStack gap="$6" pb="$5">
       <DeFiListBlock />
+      <Upgrade />
       <SupportHub />
       {addPaddingOnListFooter ? <Stack h="$16" /> : null}
     </YStack>


### PR DESCRIPTION
## Summary
- Added the missing `<Upgrade />` component to the mobile (non-table) layout in `DeFiContainer`, matching the desktop layout which already includes it.

## Test plan
- [ ] Verify the Upgrade component renders correctly on mobile DeFi tab
- [ ] Verify desktop layout remains unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
