### PR TITLE
fix: migrate keyless ownerId on reset pin

### DIFF
--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -1230,10 +1230,12 @@ class ServiceKeylessWallet extends ServiceBase {
   async buildKeylessOwnerIdFromSocialToken(params: {
     token: string;
     hashId: string; // return from server
+    providerOverride?: EOAuthSocialLoginProvider;
   }): Promise<string> {
-    const { token, hashId } = params;
+    const { token, hashId, providerOverride } = params;
     const socialUserId = this.buildKeylessSocialUserIdFromToken({ token });
-    const provider = this.buildKeylessProviderFromSocialToken({ token });
+    const provider =
+      providerOverride ?? this.buildKeylessProviderFromSocialToken({ token });
     const devSettings = await devSettingsPersistAtom.get();
     const isTestEndpointEnabled = Boolean(
       devSettings.enabled && devSettings.settings?.enableTestEndpoint,
@@ -1254,6 +1256,14 @@ class ServiceKeylessWallet extends ServiceBase {
       bufferUtils.toBuffer(raw, 'utf-8'),
     );
     return bufferUtils.bytesToHex(hashBytes);
+  }
+
+  private getAlternativeKeylessProvider(
+    provider: EOAuthSocialLoginProvider,
+  ): EOAuthSocialLoginProvider {
+    return provider === EOAuthSocialLoginProvider.Google
+      ? EOAuthSocialLoginProvider.Apple
+      : EOAuthSocialLoginProvider.Google;
   }
 
   buildKeylessProviderFromSocialToken(params: {
@@ -1598,9 +1608,7 @@ class ServiceKeylessWallet extends ServiceBase {
         !this.fixedKeylessProviderMap[socialUserId]
       ) {
         this.fixedKeylessProviderMap[socialUserId] =
-          socialProvider === EOAuthSocialLoginProvider.Google
-            ? EOAuthSocialLoginProvider.Apple
-            : EOAuthSocialLoginProvider.Google;
+          this.getAlternativeKeylessProvider(socialProvider);
         void this.backgroundApi.serviceApp.showDialogLoading({
           title:
             'Provider fixed done, please try again, do not refresh the page or exit the app.',
@@ -1711,19 +1719,38 @@ class ServiceKeylessWallet extends ServiceBase {
     this.fixedKeylessProviderMap = {};
 
     // 1. Get ownerId from token
-    const ownerId = await this.buildKeylessOwnerIdFromSocialToken({
+    const socialProvider = this.buildKeylessProviderFromSocialToken({ token });
+    const targetOwnerId = await this.buildKeylessOwnerIdFromSocialToken({
       token,
       hashId,
+      providerOverride: socialProvider,
     });
     defaultLogger.wallet.keyless.resetKeylessOwnerIdGenerated();
 
     // 3. Get mnemonicPassword from secure storage
-    const mnemonicPassword =
+    let mnemonicPasswordSourceOwnerId = targetOwnerId;
+    let mnemonicPassword =
       await keylessMnemonicPasswordStorage.getMnemonicPasswordFromStorage({
-        ownerId,
+        ownerId: mnemonicPasswordSourceOwnerId,
         password,
         backgroundApi: this.backgroundApi,
       });
+    if (!mnemonicPassword) {
+      const fallbackProvider =
+        this.getAlternativeKeylessProvider(socialProvider);
+      mnemonicPasswordSourceOwnerId =
+        await this.buildKeylessOwnerIdFromSocialToken({
+          token,
+          hashId,
+          providerOverride: fallbackProvider,
+        });
+      mnemonicPassword =
+        await keylessMnemonicPasswordStorage.getMnemonicPasswordFromStorage({
+          ownerId: mnemonicPasswordSourceOwnerId,
+          password,
+          backgroundApi: this.backgroundApi,
+        });
+    }
     if (!mnemonicPassword) {
       defaultLogger.wallet.keyless.dataCorruptedError({
         reason:
@@ -1787,7 +1814,7 @@ class ServiceKeylessWallet extends ServiceBase {
       juiceboxShare,
       pin: newPin,
       backendShareX,
-      ownerId,
+      ownerId: targetOwnerId,
     });
     defaultLogger.wallet.keyless.resetKeylessJuiceboxShareUploaded({
       backendShareX,
@@ -1796,13 +1823,42 @@ class ServiceKeylessWallet extends ServiceBase {
     // Save tokens to secure storage (refreshToken with passcode, token without)
     if (refreshToken) {
       await keylessRefreshTokenStorage.saveTokensToStorage({
-        ownerId,
+        ownerId: targetOwnerId,
         refreshToken,
         token,
         password,
         backgroundApi: this.backgroundApi,
       });
       defaultLogger.wallet.keyless.resetKeylessTokensStored();
+    }
+
+    if (mnemonicPasswordSourceOwnerId !== targetOwnerId) {
+      await keylessMnemonicPasswordStorage.saveMnemonicPasswordToStorage({
+        ownerId: targetOwnerId,
+        mnemonicPassword,
+        password,
+        backgroundApi: this.backgroundApi,
+      });
+    }
+
+    const socialUserIdHash = await accountUtils.hashKeylessSocialUserId({
+      socialUserId: this.buildKeylessSocialUserIdFromToken({ token }),
+    });
+    const shouldUpdateKeylessDetailsInfo =
+      keylessWallet.keylessDetailsInfo?.keylessOwnerId !== targetOwnerId ||
+      keylessWallet.keylessDetailsInfo?.keylessProvider !== socialProvider ||
+      keylessWallet.keylessDetailsInfo?.socialUserIdHash !== socialUserIdHash;
+    if (shouldUpdateKeylessDetailsInfo) {
+      const nextKeylessDetailsInfo: IKeylessWalletDetailsInfo = {
+        ...keylessWallet.keylessDetailsInfo,
+        keylessOwnerId: targetOwnerId,
+        keylessProvider: socialProvider,
+        socialUserIdHash,
+      };
+      await localDb.updateKeylessWalletDetailsInfo({
+        walletId: keylessWallet.id,
+        keylessDetailsInfo: nextKeylessDetailsInfo,
+      });
     }
 
     void this.apiResetPinConfirmStatus({ token });

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -1560,17 +1560,37 @@ class ServiceKeylessWallet extends ServiceBase {
       token,
     });
     defaultLogger.wallet.keyless.verifyKeylessBackendShareRetrieved();
-    const socialProvider: EOAuthSocialLoginProvider =
+    let socialProvider: EOAuthSocialLoginProvider =
       this.buildKeylessProviderFromSocialToken({
         token,
       });
-    const socialUserId: string = this.buildKeylessSocialUserIdFromToken({
-      token,
-    });
-    const ownerId = await this.buildKeylessOwnerIdFromSocialToken({
+    let ownerId = await this.buildKeylessOwnerIdFromSocialToken({
       token,
       hashId,
     });
+    const socialUserId: string = this.buildKeylessSocialUserIdFromToken({
+      token,
+    });
+    if (
+      dangerousRetryByFixedProvider &&
+      !this.fixedKeylessProviderMap[socialUserId]
+    ) {
+      const decodedToken = stringUtils.decodeJWT(token) as ISupabaseJWTPayload;
+      const providerOnCreate = decodedToken?.app_metadata
+        ?.provider as EOAuthSocialLoginProvider;
+      if (providerOnCreate) {
+        const alternativeProvider =
+          this.getAlternativeKeylessProvider(providerOnCreate);
+        if (alternativeProvider !== socialProvider) {
+          socialProvider = alternativeProvider;
+          ownerId = await this.buildKeylessOwnerIdFromSocialToken({
+            token,
+            hashId,
+            providerOverride: socialProvider,
+          });
+        }
+      }
+    }
     defaultLogger.wallet.keyless.verifyKeylessOwnerIdGenerated();
 
     if (mode === EOnboardingV2OneKeyIDLoginMode.KeylessVerifyPinOnly) {

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -1567,6 +1567,7 @@ class ServiceKeylessWallet extends ServiceBase {
     let ownerId = await this.buildKeylessOwnerIdFromSocialToken({
       token,
       hashId,
+      providerOverride: socialProvider,
     });
     const socialUserId: string = this.buildKeylessSocialUserIdFromToken({
       token,
@@ -1615,6 +1616,12 @@ class ServiceKeylessWallet extends ServiceBase {
         token,
         pin,
       });
+      if (
+        dangerousRetryByFixedProvider &&
+        !this.fixedKeylessProviderMap[socialUserId]
+      ) {
+        this.fixedKeylessProviderMap[socialUserId] = socialProvider;
+      }
     } catch (error) {
       const isPinErrorByInstance = error instanceof IncorrectPinError;
       const isPinErrorByClassName = errorUtils.isErrorByClassName({

--- a/packages/shared/src/keylessWallet/keylessWalletTypes.ts
+++ b/packages/shared/src/keylessWallet/keylessWalletTypes.ts
@@ -127,7 +127,7 @@ export type ISupabaseJWTPayload = JWTPayload & {
      2. Even if they subsequently log in using Apple, the field will not update to reflect Apple.
      This remains the case as long as the same Gmail address is associated with both the Apple and Google accounts.
     */
-    // provider: string;
+    provider: string;
   };
   user_metadata: {
     sub: string;


### PR DESCRIPTION
## Summary
- add provider fallback when loading mnemonicPassword during keyless reset PIN
- migrate reset flow writes to the token-derived ownerId after recovery succeeds
- only rewrite local keyless details when ownerId/provider/socialUserIdHash actually changed

## Testing
- node ./development/lint/eslint packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
