### PR TITLE
fix(perps): fix pageView source tracking and dedup OK-51651 OK-51661

### DIFF
--- a/packages/kit/src/hooks/useWalletBanner.ts
+++ b/packages/kit/src/hooks/useWalletBanner.ts
@@ -2,7 +2,13 @@ import { useCallback } from 'react';
 
 import type { IDBWallet } from '@onekeyhq/kit-bg/src/dbs/local/types';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import {
+  EPerpPageEnterSource,
+  setPerpPageEnterSource,
+} from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import { parseNotificationPayload } from '@onekeyhq/shared/src/utils/notificationsUtils';
+import { ETabRoutes } from '@onekeyhq/shared/src/routes/tab';
+import { ENotificationPushMessageMode } from '@onekeyhq/shared/types/notification';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 import type { IServerNetwork } from '@onekeyhq/shared/types';
 import type { INetworkAccount } from '@onekeyhq/shared/types/account';
@@ -68,6 +74,17 @@ function useWalletBanner({
 
       if (item.mode) {
         parseNotificationPayload(item.mode, item.payload, () => {});
+        if (item.mode === ENotificationPushMessageMode.page && item.payload) {
+          try {
+            const payloadObj = JSON.parse(item.payload);
+            if (
+              payloadObj?.screen === 'main' &&
+              payloadObj?.params?.screen === ETabRoutes.Perp
+            ) {
+              setPerpPageEnterSource(EPerpPageEnterSource.WalletBanner);
+            }
+          } catch {}
+        }
         return;
       }
 

--- a/packages/kit/src/hooks/useWalletBanner.ts
+++ b/packages/kit/src/hooks/useWalletBanner.ts
@@ -83,7 +83,9 @@ function useWalletBanner({
             ) {
               setPerpPageEnterSource(EPerpPageEnterSource.WalletBanner);
             }
-          } catch {}
+          } catch {
+            // ignore malformed payload
+          }
         }
         return;
       }

--- a/packages/kit/src/provider/Container/PageTrackerContainer/index.tsx
+++ b/packages/kit/src/provider/Container/PageTrackerContainer/index.tsx
@@ -1,6 +1,7 @@
 import { useOnRouterChange } from '@onekeyhq/components';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { ETabHomeRoutes } from '@onekeyhq/shared/src/routes';
+import { ETabRoutes } from '@onekeyhq/shared/src/routes/tab';
 
 import type { NavigationState, PartialState } from '@react-navigation/routers';
 
@@ -27,7 +28,8 @@ export default function PageTrackerContainer() {
         defaultLogger.app.page.pageView(ETabHomeRoutes.TabHome);
       } else {
         const page = getActiveRoute(state as IState);
-        if (page) {
+        // Perp has its own pageView with source tracking (perp.common.pageView)
+        if (page && page.name !== ETabRoutes.Perp) {
           defaultLogger.app.page.pageView(page.name);
         }
       }

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -862,11 +862,8 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       tpValue: '',
       slType: 'price',
       slValue: '',
-      // Keep orderMode and triggerOrderType (tab stays unchanged after submit)
-      // Only clear trigger values
       triggerPrice: '',
       executionPrice: '',
-      triggerReduceOnly: true,
     });
   });
 

--- a/packages/kit/src/views/Perp/pages/Perp.tsx
+++ b/packages/kit/src/views/Perp/pages/Perp.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
-import { useIsFocused } from '@react-navigation/native';
+import { useFocusEffect } from '@react-navigation/native';
 import { useIntl } from 'react-intl';
 
 import {
@@ -57,14 +57,21 @@ function PerpBodyContent() {
 }
 
 function PerpContent() {
-  const isFocused = useIsFocused();
-  useEffect(() => {
-    if (isFocused) {
-      defaultLogger.perp.common.pageView({
-        source: consumePerpPageEnterSource(),
-      });
-    }
-  }, [isFocused]);
+  const firedRef = useRef(false);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!firedRef.current) {
+        firedRef.current = true;
+        defaultLogger.perp.common.pageView({
+          source: consumePerpPageEnterSource(),
+        });
+      }
+      return () => {
+        firedRef.current = false;
+      };
+    }, []),
+  );
 
   const [tabPageHeight, setTabPageHeight] = useState(
     platformEnv.isNativeIOS ? 143 : 92,
@@ -163,6 +170,7 @@ function ExtPerpNull() {
 
 export default function Perp() {
   const canRenderPerp = useNativePerpFeatureGuard();
+
   if (!canRenderPerp) {
     return shouldOpenExpandExtPerp ? <ExtPerpNull /> : null;
   }

--- a/packages/kit/src/views/Perp/pages/Perp.tsx
+++ b/packages/kit/src/views/Perp/pages/Perp.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
 
-import { useFocusEffect } from '@react-navigation/native';
+import { useFocusEffect, useIsFocused } from '@react-navigation/native';
 import { useIntl } from 'react-intl';
 
 import {

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchPerpItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchPerpItem.tsx
@@ -35,8 +35,8 @@ export function UniversalSearchPerpItem({
   const tag = isPerpsType ? `${maxLeverage}X` : 'xyz';
 
   const handlePress = useCallback(() => {
+    setPerpPageEnterSource(EPerpPageEnterSource.UniversalSearch);
     setTimeout(async () => {
-      setPerpPageEnterSource(EPerpPageEnterSource.UniversalSearch);
       navigation.switchTab(ETabRoutes.Perp);
       try {
         await backgroundApiProxy.serviceHyperliquid.changeActiveAsset({

--- a/packages/shared/src/logger/scopes/perp/scenes/common.ts
+++ b/packages/shared/src/logger/scopes/perp/scenes/common.ts
@@ -6,7 +6,7 @@ export class CommonScene extends BaseScene {
   @LogToServer()
   @LogToLocal({ level: 'info' })
   public pageView({ source }: { source: EPerpPageEnterSource }) {
-    return { source };
+    return { source, pageName: 'Perp' };
   }
 
   @LogToServer()

--- a/packages/shared/src/logger/scopes/perp/type.ts
+++ b/packages/shared/src/logger/scopes/perp/type.ts
@@ -6,6 +6,7 @@ export enum EPerpPageEnterSource {
   Notification = 'notification',
   MarketList = 'marketList',
   MarketBanner = 'marketBanner',
+  WalletBanner = 'walletBanner',
   UniversalSearch = 'search',
   PopularTrading = 'popularTrading',
   Referral = 'referral',


### PR DESCRIPTION
## Summary

- **Double pageView fixed**: Switch `PerpContent` from `useIsFocused+useEffect` to `useFocusEffect+useRef` — prevents double-fire during web tab transitions and component remounts from config updates
- **UniversalSearch source fixed**: Move `setPerpPageEnterSource` outside `setTimeout` in `UniversalSearchPerpItem` so source is set before the modal closes and focus transitions
- **Wrong pageName fixed**: Add explicit `pageName: 'Perp'` in `perp.common.pageView` return value to prevent inheriting stale `UniversalSearch` pageName from navigation state during transition
- **Duplicate pageView removed**: Skip `app.page.pageView` auto-tracking for the Perp route in `PageTrackerContainer` — `perp.common.pageView` is the canonical event with source
- **WalletBanner source added**: Home page banner Perp navigation goes through the notification payload channel, override source to `walletBanner` after `parseNotificationPayload` (synchronous event bus)
- **Reduce-only checkbox fixed**: Remove `triggerReduceOnly: true` from `resetTradingForm` so user's unchecked state persists after order placement

## Test plan

- [ ] Navigate to Perps from tab bar / search / market list / market banner / popular trading / referral — verify each source value in analytics
- [ ] Navigate from home page wallet banner to Perps — verify `source: walletBanner`
- [ ] Navigate to Perps from web header — verify single pageView with correct source
- [ ] Open search while on Perps tab, click Perp result — verify single pageView with `source: search`
- [ ] Verify no duplicate pageView events on any navigation path
- [ ] Uncheck reduce-only on a trigger order, place order, verify checkbox stays unchecked
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
