### PR TITLE
fix: backfill extension secure password after manual verify

### DIFF
--- a/packages/kit-bg/src/services/ServicePassword/biologyAuthUtils.ts
+++ b/packages/kit-bg/src/services/ServicePassword/biologyAuthUtils.ts
@@ -81,7 +81,7 @@ class BiologyAuthUtils implements IBiologyAuth {
     );
   };
 
-  hasSecurePasswordWithoutAuth = async (): Promise<boolean> => {
+  private hasSecurePasswordWithoutAuth = async (): Promise<boolean> => {
     if (!platformEnv.isExtension) {
       return false;
     }
@@ -98,6 +98,8 @@ class BiologyAuthUtils implements IBiologyAuth {
 
   hasPassword = async (): Promise<boolean> => {
     if (platformEnv.isExtension) {
+      // Extension PRF storage can check password-item existence by key
+      // without triggering a WebAuthn prompt.
       return this.hasSecurePasswordWithoutAuth();
     }
     if (!(await appStorage.secureStorage.supportSecureStorage())) {

--- a/packages/kit-bg/src/services/ServicePassword/biologyAuthUtils.ts
+++ b/packages/kit-bg/src/services/ServicePassword/biologyAuthUtils.ts
@@ -85,7 +85,7 @@ class BiologyAuthUtils implements IBiologyAuth {
     if (!(await appStorage.secureStorage.supportSecureStorage())) {
       return false;
     }
-    if (platformEnv.isExtension && appStorage.secureStorage.hasSecureItem) {
+    if (appStorage.secureStorage.hasSecureItem) {
       // Extension PRF storage can check password-item existence by key
       // without triggering a WebAuthn prompt.
       return appStorage.secureStorage.hasSecureItem(

--- a/packages/kit-bg/src/services/ServicePassword/biologyAuthUtils.ts
+++ b/packages/kit-bg/src/services/ServicePassword/biologyAuthUtils.ts
@@ -10,6 +10,7 @@ import type { IBiologyAuth } from '@onekeyhq/shared/src/biologyAuth/types';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import appStorage from '@onekeyhq/shared/src/storage/appStorage';
 import type { ISecureStorageSetOptions } from '@onekeyhq/shared/src/storage/secureStorage/types';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { BIOLOGY_AUTH_CANCEL_ERROR } from '@onekeyhq/shared/types/password';
 
 import { settingsPersistAtom } from '../../states/jotai/atoms/settings';
@@ -80,14 +81,27 @@ class BiologyAuthUtils implements IBiologyAuth {
     );
   };
 
-  hasPassword = async (): Promise<boolean> => {
+  hasSecurePasswordWithoutAuth = async (): Promise<boolean> => {
+    if (!platformEnv.isExtension) {
+      return false;
+    }
     if (!(await appStorage.secureStorage.supportSecureStorage())) {
       return false;
     }
-    if (appStorage.secureStorage.hasSecureItem) {
-      return appStorage.secureStorage.hasSecureItem(
-        SECURE_STORAGE_PASSWORD_KEY,
-      );
+    if (!appStorage.secureStorage.hasSecureItem) {
+      return false;
+    }
+    return appStorage.secureStorage.hasSecureItem(
+      SECURE_STORAGE_PASSWORD_KEY,
+    );
+  };
+
+  hasPassword = async (): Promise<boolean> => {
+    if (platformEnv.isExtension) {
+      return this.hasSecurePasswordWithoutAuth();
+    }
+    if (!(await appStorage.secureStorage.supportSecureStorage())) {
+      return false;
     }
     const value = await appStorage.secureStorage.getSecureItem(
       SECURE_STORAGE_PASSWORD_KEY,

--- a/packages/kit-bg/src/services/ServicePassword/biologyAuthUtils.ts
+++ b/packages/kit-bg/src/services/ServicePassword/biologyAuthUtils.ts
@@ -10,7 +10,6 @@ import type { IBiologyAuth } from '@onekeyhq/shared/src/biologyAuth/types';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import appStorage from '@onekeyhq/shared/src/storage/appStorage';
 import type { ISecureStorageSetOptions } from '@onekeyhq/shared/src/storage/secureStorage/types';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { BIOLOGY_AUTH_CANCEL_ERROR } from '@onekeyhq/shared/types/password';
 
 import { settingsPersistAtom } from '../../states/jotai/atoms/settings';

--- a/packages/kit-bg/src/services/ServicePassword/biologyAuthUtils.ts
+++ b/packages/kit-bg/src/services/ServicePassword/biologyAuthUtils.ts
@@ -81,29 +81,16 @@ class BiologyAuthUtils implements IBiologyAuth {
     );
   };
 
-  private hasSecurePasswordWithoutAuth = async (): Promise<boolean> => {
-    if (!platformEnv.isExtension) {
-      return false;
-    }
+  hasPassword = async (): Promise<boolean> => {
     if (!(await appStorage.secureStorage.supportSecureStorage())) {
       return false;
     }
-    if (!appStorage.secureStorage.hasSecureItem) {
-      return false;
-    }
-    return appStorage.secureStorage.hasSecureItem(
-      SECURE_STORAGE_PASSWORD_KEY,
-    );
-  };
-
-  hasPassword = async (): Promise<boolean> => {
-    if (platformEnv.isExtension) {
+    if (platformEnv.isExtension && appStorage.secureStorage.hasSecureItem) {
       // Extension PRF storage can check password-item existence by key
       // without triggering a WebAuthn prompt.
-      return this.hasSecurePasswordWithoutAuth();
-    }
-    if (!(await appStorage.secureStorage.supportSecureStorage())) {
-      return false;
+      return appStorage.secureStorage.hasSecureItem(
+        SECURE_STORAGE_PASSWORD_KEY,
+      );
     }
     const value = await appStorage.secureStorage.getSecureItem(
       SECURE_STORAGE_PASSWORD_KEY,

--- a/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
@@ -94,9 +94,7 @@ const PasswordVerifyContainer = ({
     if (shouldCheck) {
       void (async () => {
         try {
-          const hasPassword = platformEnv.isExtension
-            ? await biologyAuthUtils.hasSecurePasswordWithoutAuth()
-            : await biologyAuthUtils.hasPassword();
+          const hasPassword = await biologyAuthUtils.hasPassword();
           setHasSecurePassword(hasPassword);
         } catch (_e) {
           setHasSecurePassword(false);
@@ -408,17 +406,14 @@ const PasswordVerifyContainer = ({
         // This runs for any successful manual password verification flow.
         if (platformEnv.isExtension && isBiologyAuthSwitchOn) {
           try {
-            const hasSecurePasswordNow =
-              await biologyAuthUtils.hasSecurePasswordWithoutAuth();
+            const hasSecurePasswordNow = await biologyAuthUtils.hasPassword();
             if (!hasSecurePasswordNow) {
               await backgroundApiProxy.servicePassword.setSkipPrfCache(false);
               const prfCredentialId =
                 await biologyAuthUtils.savePasswordForPasskey(verifiedPassword, {
                   repairBrokenState: true,
                 });
-              setHasSecurePassword(
-                await biologyAuthUtils.hasSecurePasswordWithoutAuth(),
-              );
+              setHasSecurePassword(await biologyAuthUtils.hasPassword());
               if (prfCredentialId && prfCredentialId !== webAuthCredentialId) {
                 setPasswordPersist((v) => ({
                   ...v,

--- a/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
@@ -410,9 +410,12 @@ const PasswordVerifyContainer = ({
             if (!hasSecurePasswordNow) {
               await backgroundApiProxy.servicePassword.setSkipPrfCache(false);
               const prfCredentialId =
-                await biologyAuthUtils.savePasswordForPasskey(verifiedPassword, {
-                  repairBrokenState: true,
-                });
+                await biologyAuthUtils.savePasswordForPasskey(
+                  verifiedPassword,
+                  {
+                    repairBrokenState: true,
+                  },
+                );
               setHasSecurePassword(await biologyAuthUtils.hasPassword());
               if (prfCredentialId && prfCredentialId !== webAuthCredentialId) {
                 setPasswordPersist((v) => ({

--- a/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
@@ -94,7 +94,9 @@ const PasswordVerifyContainer = ({
     if (shouldCheck) {
       void (async () => {
         try {
-          const hasPassword = await biologyAuthUtils.hasPassword();
+          const hasPassword = platformEnv.isExtension
+            ? await biologyAuthUtils.hasSecurePasswordWithoutAuth()
+            : await biologyAuthUtils.hasPassword();
           setHasSecurePassword(hasPassword);
         } catch (_e) {
           setHasSecurePassword(false);
@@ -401,25 +403,33 @@ const PasswordVerifyContainer = ({
         }
         await callOnVerifyRes(verifiedPassword);
         setVerifiedStatus();
-        // Save to secure storage for future biometric unlock on extension.
-        // Clear skipPrfCache first — the flag is set during promptPasswordVerify
-        // to force real WebAuthn for the biometric button, but password
-        // verification has already succeeded here so it's safe to use cache.
+        // Backfill secure storage once for migrated extension users whose
+        // biometric switch is on but password was never stored with PRF.
+        // This runs for any successful manual password verification flow.
         if (platformEnv.isExtension && isBiologyAuthSwitchOn) {
           try {
-            await backgroundApiProxy.servicePassword.setSkipPrfCache(false);
-            const prfCredentialId =
-              await biologyAuthUtils.savePasswordForPasskey(verifiedPassword, {
-                repairBrokenState: true,
-              });
-            if (prfCredentialId && prfCredentialId !== webAuthCredentialId) {
-              setPasswordPersist((v) => ({
-                ...v,
-                webAuthCredentialId: prfCredentialId,
-              }));
+            const hasSecurePasswordNow =
+              await biologyAuthUtils.hasSecurePasswordWithoutAuth();
+            if (!hasSecurePasswordNow) {
+              await backgroundApiProxy.servicePassword.setSkipPrfCache(false);
+              const prfCredentialId =
+                await biologyAuthUtils.savePasswordForPasskey(verifiedPassword, {
+                  repairBrokenState: true,
+                });
+              setHasSecurePassword(
+                await biologyAuthUtils.hasSecurePasswordWithoutAuth(),
+              );
+              if (prfCredentialId && prfCredentialId !== webAuthCredentialId) {
+                setPasswordPersist((v) => ({
+                  ...v,
+                  webAuthCredentialId: prfCredentialId,
+                }));
+              }
+            } else if (!hasSecurePassword) {
+              setHasSecurePassword(true);
             }
           } catch (e) {
-            console.error('Failed to save password to secure storage:', e);
+            console.error('Failed to backfill secure storage password:', e);
           }
         }
       } catch (e) {
@@ -496,6 +506,7 @@ const PasswordVerifyContainer = ({
       passwordVerifyStatus.value,
       pageMode,
       resetApp,
+      hasSecurePassword,
       setPasswordAtom,
       setPasswordErrorProtectionTimeMinutesSurplus,
       setPasswordPersist,


### PR DESCRIPTION
## Summary
- backfill the extension secure password only after successful manual password verification when biometric is enabled and the password secure item is missing
- add `hasSecurePasswordWithoutAuth()` so extension password existence checks are explicit and key-specific
- avoid repeated extra biometric prompts for migrated users once the secure password has been stored

## Testing
- `git diff --check`
- `yarn eslint packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx` could not run in this worktree because the Yarn install state file is missing
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
