### PR TITLE
fix: wallet issues for web dapp mode and manage accounts(OK-51678,OK-51676,OK-51666)

### DIFF
--- a/packages/kit/src/components/AccountSelector/AccountSelectorTrigger/AccountSelectorTriggerBase.tsx
+++ b/packages/kit/src/components/AccountSelector/AccountSelectorTrigger/AccountSelectorTriggerBase.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -14,8 +14,11 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IAccountSelectorRouteParamsExtraConfig } from '@onekeyhq/shared/src/routes';
 import { EShortcutEvents } from '@onekeyhq/shared/src/shortcuts/shortcuts.enum';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import { useShortcutsOnRouteFocused } from '../../../hooks/useShortcutsOnRouteFocused';
+import { useAccountSelectorSceneInfo } from '../../../states/jotai/contexts/accountSelector';
 import { AccountAvatar } from '../../AccountAvatar';
 import { SpotlightView } from '../../Spotlight';
 import { useAccountSelectorTrigger } from '../hooks/useAccountSelectorTrigger';
@@ -41,6 +44,7 @@ export function AccountSelectorTriggerBase({
   showWalletName?: boolean;
   showConnectWalletModalInDappMode?: boolean;
 } & IAccountSelectorRouteParamsExtraConfig) {
+  const { sceneName } = useAccountSelectorSceneInfo();
   const {
     activeAccount: { account, dbAccount, indexedAccount, accountName, wallet },
     showAccountSelector,
@@ -59,12 +63,27 @@ export function AccountSelectorTriggerBase({
 
   const isWebDappModeWithNoWallet =
     platformEnv.isWebDappMode && !wallet && !accountName;
+  const isTriggerDisabled =
+    platformEnv.isWebDappMode &&
+    sceneName === EAccountSelectorSceneName.homeUrlAccount &&
+    !isWebDappModeWithNoWallet;
+  const displayLabel =
+    isTriggerDisabled && account?.address
+      ? accountUtils.shortenAddress({ address: account.address })
+      : displayAccountName;
+
+  const handleAccountSelectorPress = useCallback(() => {
+    if (isTriggerDisabled) {
+      return;
+    }
+    showAccountSelector();
+  }, [isTriggerDisabled, showAccountSelector]);
 
   const contentView = useMemo(
     () => (
       <XStack
         testID="AccountSelectorTriggerBase"
-        role="button"
+        role={isTriggerDisabled ? undefined : 'button'}
         alignItems="center"
         width="$full"
         // width="$80"
@@ -73,13 +92,19 @@ export function AccountSelectorTriggerBase({
         px="$1.5"
         mx="$-1.5"
         borderRadius="$2"
-        hoverStyle={{
-          bg: '$bgHover',
-        }}
-        pressStyle={{
-          bg: '$bgActive',
-        }}
-        onPress={showAccountSelector}
+        hoverStyle={isTriggerDisabled ? undefined : { bg: '$bgHover' }}
+        pressStyle={isTriggerDisabled ? undefined : { bg: '$bgActive' }}
+        focusable={!isTriggerDisabled}
+        focusVisibleStyle={
+          isTriggerDisabled
+            ? undefined
+            : {
+                outlineWidth: 2,
+                outlineColor: '$focusRing',
+                outlineStyle: 'solid',
+              }
+        }
+        onPress={handleAccountSelectorPress}
         userSelect="none"
       >
         {isWebDappModeWithNoWallet ? (
@@ -129,8 +154,8 @@ export function AccountSelectorTriggerBase({
                   maxWidth="$36"
                 >
                   {showWalletName
-                    ? `${walletName} / ${displayAccountName}`
-                    : displayAccountName}
+                    ? `${walletName} / ${displayLabel}`
+                    : displayLabel}
                 </SizableText>
               ) : (
                 <>
@@ -148,16 +173,18 @@ export function AccountSelectorTriggerBase({
                     flexShrink={1}
                     testID="account-name"
                   >
-                    {displayAccountName}
+                    {displayLabel}
                   </SizableText>
                 </>
               )}
             </Stack>
-            <Icon
-              name="ChevronDownSmallOutline"
-              size="$5"
-              color="$iconSubdued"
-            />
+            {isTriggerDisabled ? null : (
+              <Icon
+                name="ChevronDownSmallOutline"
+                size="$5"
+                color="$iconSubdued"
+              />
+            )}
           </>
         )}
       </XStack>
@@ -165,11 +192,12 @@ export function AccountSelectorTriggerBase({
     [
       account,
       dbAccount,
-      displayAccountName,
+      displayLabel,
+      handleAccountSelectorPress,
       horizontalLayout,
       indexedAccount,
       isWebDappModeWithNoWallet,
-      showAccountSelector,
+      isTriggerDisabled,
       showWalletAvatar,
       showWalletName,
       wallet,
@@ -189,7 +217,7 @@ export function AccountSelectorTriggerBase({
 
   useShortcutsOnRouteFocused(
     EShortcutEvents.AccountSelector,
-    showAccountSelector,
+    handleAccountSelectorPress,
   );
 
   return spotlightProps ? (

--- a/packages/kit/src/components/AccountSelector/AccountSelectorTrigger/AccountSelectorTriggerHome.tsx
+++ b/packages/kit/src/components/AccountSelector/AccountSelectorTrigger/AccountSelectorTriggerHome.tsx
@@ -20,6 +20,8 @@ export function AccountSelectorTriggerHome({
   } = useActiveAccount({
     num,
   });
+  const resolvedLinkNetworkId =
+    linkNetworkId ?? (!network?.isAllNetworks ? network?.id : undefined);
 
   return (
     <AccountSelectorTriggerBase
@@ -31,7 +33,7 @@ export function AccountSelectorTriggerHome({
       num={num}
       linkNetwork={!network?.isAllNetworks}
       hideAddress={hideAddress ?? vaultSettings?.mergeDeriveAssetsEnabled}
-      linkNetworkId={linkNetworkId}
+      linkNetworkId={resolvedLinkNetworkId}
       keepAllOtherAccounts
       allowSelectEmptyAccount
       spotlightProps={spotlightProps}

--- a/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/BatchCreateAccountButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/BatchCreateAccountButton.tsx
@@ -22,7 +22,7 @@ import networkUtils, {
 
 export function BatchCreateAccountButton({
   focusedWalletInfo,
-  activeAccount: _activeAccount,
+  activeAccount,
   onClose,
 }: {
   focusedWalletInfo:
@@ -68,16 +68,28 @@ export function BatchCreateAccountButton({
       });
 
     let defaultNetworkId: string | undefined;
+    const currentNetworkId = activeAccount.network?.id;
 
-    // 1. Prefer Ethereum if compatible and enabled
+    // 1. In single-chain mode, keep the manager aligned with the current network.
     if (
+      currentNetworkId &&
+      !networkUtils.isAllNetwork({ networkId: currentNetworkId }) &&
+      networkIdsCompatible?.includes(currentNetworkId) &&
+      isNetworkEnabled(currentNetworkId)
+    ) {
+      defaultNetworkId = currentNetworkId;
+    }
+
+    // 2. Prefer Ethereum if compatible and enabled
+    if (
+      !defaultNetworkId &&
       networkIdsCompatible?.includes(ethNetworkId) &&
       isNetworkEnabled(ethNetworkId)
     ) {
       defaultNetworkId = ethNetworkId;
     }
 
-    // 2. Fall back to first enabled EVM network
+    // 3. Fall back to first enabled EVM network
     if (!defaultNetworkId) {
       defaultNetworkId = networkIdsCompatible?.find(
         (id) =>
@@ -85,7 +97,7 @@ export function BatchCreateAccountButton({
       );
     }
 
-    // 3. Fall back to first enabled compatible network of any type
+    // 4. Fall back to first enabled compatible network of any type
     if (!defaultNetworkId) {
       defaultNetworkId =
         networkIdsCompatible?.find((id) => isNetworkEnabled(id)) ??
@@ -103,7 +115,7 @@ export function BatchCreateAccountButton({
         networkId: defaultNetworkId,
       },
     });
-  }, [focusedWalletInfo, navigation]);
+  }, [activeAccount.network?.id, focusedWalletInfo, navigation]);
 
   return (
     <ActionList.Item

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionMore.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionMore.tsx
@@ -7,10 +7,12 @@ import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/Acco
 import { useReviewControl } from '@onekeyhq/kit/src/components/ReviewControl';
 import { getRewardCenterConfig } from '@onekeyhq/kit/src/components/RewardCenter';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
-import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
+import {
+  useAccountSelectorSceneInfo,
+  useActiveAccount,
+} from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import { HomeTokenListProviderMirrorWrapper } from '../HomeTokenListProvider';
 
@@ -30,6 +32,7 @@ import { WalletActionVote } from './WalletActionVote';
 export function WalletActionMore() {
   const [devSettings] = useDevSettingsPersistAtom();
   const { activeAccount } = useActiveAccount({ num: 0 });
+  const { sceneName, sceneUrl } = useAccountSelectorSceneInfo();
   const { account, network } = activeAccount;
 
   const show = useReviewControl();
@@ -227,7 +230,8 @@ export function WalletActionMore() {
       return (
         <AccountSelectorProviderMirror
           config={{
-            sceneName: EAccountSelectorSceneName.home,
+            sceneName,
+            sceneUrl,
           }}
           enabledNum={[0]}
         >
@@ -250,6 +254,8 @@ export function WalletActionMore() {
       rewardCenterConfig,
       getActionCustomization,
       devSettings?.settings?.showDevExportPrivateKey,
+      sceneName,
+      sceneUrl,
     ],
   );
 


### PR DESCRIPTION
## Summary
- Disable account selector trigger in web dapp mode for URL account scenes, showing shortened address instead
- Keep manage accounts network selection in sync with the current chain in single-chain mode
- Use current scene context for URL wallet "more actions" instead of hardcoded `home` scene

## Intent & Context
Three related fixes for wallet UI issues in web dapp mode and the account management flow:
1. In URL account view (web dapp mode), the account selector should not be interactive — users viewing a URL-based account shouldn't be able to switch accounts via the trigger
2. When opening "Manage Accounts" in single-chain mode, the default network should match the currently selected chain rather than always defaulting to Ethereum
3. The "More Actions" menu in URL account scenes was using a hardcoded `home` scene, causing child actions (explorer, copy address, etc.) to operate on the wrong account context

## Root Cause
- **OK-51678**: `AccountSelectorTriggerBase` had no awareness of the `homeUrlAccount` scene, so the selector was always interactive in web dapp mode
- **OK-51676**: `BatchCreateAccountButton` ignored the current network when determining the default for batch account creation; `AccountSelectorTriggerHome` did not derive `linkNetworkId` from the active network in single-chain mode
- **OK-51666**: `WalletActionMore` hardcoded `EAccountSelectorSceneName.home` in its `AccountSelectorProviderMirror` config instead of reading the actual scene from context

## Changes Detail
- **AccountSelectorTriggerBase.tsx**: Added `isTriggerDisabled` logic for `homeUrlAccount` scene in web dapp mode — disables press handler, removes hover/press/focus styles, hides chevron icon, shows shortened address via `accountUtils.shortenAddress`
- **AccountSelectorTriggerHome.tsx**: Added `resolvedLinkNetworkId` that falls back to `network.id` when not in AllNetworks mode and no explicit `linkNetworkId` is provided
- **BatchCreateAccountButton.tsx**: Added priority step to use `activeAccount.network?.id` as default network when in single-chain mode before falling back to Ethereum
- **WalletActionMore.tsx**: Replaced hardcoded `EAccountSelectorSceneName.home` with `sceneName`/`sceneUrl` from `useAccountSelectorSceneInfo()` context hook

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Web (primary, dapp mode), all platforms (manage accounts sync)
- **Risk Areas**: `resolvedLinkNetworkId` derivation timing in `AccountSelectorTriggerHome` — depends on `network.isAllNetworks` being accurate at render time

## Test plan
- [ ] Web dapp mode + URL account route (`/<address>`): verify selector is non-interactive, shows shortened address, no chevron
- [ ] Web dapp mode + normal home: verify selector works normally
- [ ] Single-chain mode → open "Manage Accounts": verify default network matches current chain
- [ ] AllNetworks mode → open "Manage Accounts": verify fallback to Ethereum or first EVM network
- [ ] URL account scene → "More Actions" menu: verify explorer/copy/etc. use correct account context
- [ ] Desktop/Extension/Mobile: verify no behavior changes to account selector
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
