### PR TITLE
feat(perps): support MarketBanner source for PerpsTokenListSection analytics(OK-51702)

### DIFF
--- a/packages/kit/src/views/Market/MarketBannerDetail/PerpsTokenListSection.tsx
+++ b/packages/kit/src/views/Market/MarketBannerDetail/PerpsTokenListSection.tsx
@@ -7,6 +7,7 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import { EPerpPageEnterSource } from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
 import { usePerpsNavigation } from '../hooks/usePerpsNavigation';
@@ -21,7 +22,9 @@ export function PerpsTokenListSection({
 }: {
   tokenListId: string;
 }) {
-  const { navigateToPerps } = usePerpsNavigation();
+  const { navigateToPerps } = usePerpsNavigation(
+    EPerpPageEnterSource.MarketBanner,
+  );
   const perpsColumns = usePerpsColumns();
   const { md } = useMedia();
   const intl = useIntl();

--- a/packages/kit/src/views/Market/hooks/usePerpsNavigation.ts
+++ b/packages/kit/src/views/Market/hooks/usePerpsNavigation.ts
@@ -8,13 +8,13 @@ import {
 } from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 
-export function usePerpsNavigation() {
+export function usePerpsNavigation(source?: EPerpPageEnterSource) {
   const navigation = useAppNavigation();
 
   const navigateToPerps = useCallback(
     (coin: string) => {
       setTimeout(async () => {
-        setPerpPageEnterSource(EPerpPageEnterSource.MarketList);
+        setPerpPageEnterSource(source ?? EPerpPageEnterSource.MarketList);
         navigation.switchTab(ETabRoutes.Perp);
         try {
           await backgroundApiProxy.serviceHyperliquid.changeActiveAsset({
@@ -25,7 +25,7 @@ export function usePerpsNavigation() {
         }
       }, 80);
     },
-    [navigation],
+    [navigation, source],
   );
 
   return { navigateToPerps };


### PR DESCRIPTION
## Summary
- Add optional `source` parameter to `usePerpsNavigation` hook to allow callers to specify analytics entry source
- `PerpsTokenListSection` (Market Banner Card → Detail page) now reports `MarketBanner` instead of `MarketList`

## Intent & Context
Growth team needs to distinguish Perps page entry sources for funnel analysis. The `usePerpsNavigation` hook is shared by 6 callers — 5 are regular Market token lists (`MarketList`), and 1 is the Market Banner Detail page (`PerpsTokenListSection`). Users reach this via a banner card above market tabs, which is a different entry path that should be tracked separately as `MarketBanner`.

## Design Decisions
- Made `source` an optional parameter on the existing hook rather than creating a separate hook or importing `setPerpPageEnterSource` in every call site — minimizes code change while keeping the API clean
- Default remains `MarketList` so existing 5 callers require zero changes
- The `setPerpPageEnterSource` call is inside `setTimeout` in the hook, so overriding from outside would cause a race condition — passing source as a hook parameter avoids this

## Changes Detail
- `usePerpsNavigation.ts`: Added optional `source?: EPerpPageEnterSource` parameter, defaults to `MarketList`
- `PerpsTokenListSection.tsx`: Passes `EPerpPageEnterSource.MarketBanner` to `usePerpsNavigation`

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: All (Extension / Mobile / Desktop / Web)
- **Risk Areas**: None — additive change to analytics source tracking only, no UI or logic changes

## Test plan
- [ ] Navigate to Perps from Market Banner Card → Detail page → token row: verify Mixpanel event shows `source: marketBanner`
- [ ] Navigate to Perps from Market Perps tab token list: verify event shows `source: marketList`
- [ ] Navigate to Perps from Market Watchlist: verify event shows `source: marketList`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
