### PR TITLE
fix(notification): filter out watchlist tokens with empty networkId(OK-50860)

### DIFF
--- a/packages/kit-bg/src/services/ServiceMarketV2.ts
+++ b/packages/kit-bg/src/services/ServiceMarketV2.ts
@@ -626,7 +626,10 @@ class ServiceMarketV2 extends ServiceBase {
 
     // Only filter out symbol-less tokens when batch succeeded;
     // if batch failed, return all entries to avoid wiping server-side watchlist.
-    return batchSucceeded ? tokens.filter((t) => t.symbol) : tokens;
+    // Always filter out tokens with empty networkId to avoid server validation errors.
+    return batchSucceeded
+      ? tokens.filter((t) => t.symbol && t.networkId)
+      : tokens.filter((t) => t.networkId);
   }
 
   private _fetchMarketTokenSecurityCached = memoizee(


### PR DESCRIPTION
## Summary
- Filter out watchlist tokens with empty `networkId` before syncing to notification server to prevent API validation errors.

## Intent & Context
The notification server API (`/notification/v1/watchlist/tokens`) returns error code 80007 with message `"tokens[0].networkId" is not allowed to be empty` when watchlist data contains tokens with empty `chainId`. This happens when `buildWatchlistTokensForNotification()` maps `item.chainId` to `networkId` without validating it.

## Root Cause
`buildWatchlistTokensForNotification()` in `ServiceMarketV2` builds the token list from watchlist data and maps `item.chainId` → `networkId`. Some watchlist items can have an empty `chainId` (e.g., corrupted data or edge cases), which causes the server-side validation to reject the entire request.

## Changes Detail
- `packages/kit-bg/src/services/ServiceMarketV2.ts`: Added `t.networkId` filter condition to both branches (batch succeeded and batch failed) when returning tokens from `buildWatchlistTokensForNotification()`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: All (Extension / Mobile / Desktop / Web)
- **Risk Areas**: Only affects the filtering logic before sending data to notification server. No functional behavior change for valid tokens.

## Test plan
- [ ] Add a watchlist token with valid chainId, verify it syncs to notification server successfully
- [ ] Verify no 80007 errors in notification server logs after the fix
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
