### PR TITLE
fix(market): fix double currency conversion and watchlist UI issues

### DIFF
--- a/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
@@ -18,7 +18,6 @@ import {
   rootNavigationRef,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { useCurrency } from '@onekeyhq/kit/src/components/Currency';
 import { ListLoading } from '@onekeyhq/kit/src/components/Loading';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
@@ -179,7 +178,6 @@ function RecommendCardItem({
 
 function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
   const intl = useIntl();
-  const currencyInfo = useCurrency();
   const navigation = useAppNavigation();
   const navigateToMarketTab = useNavigateToMarketTab();
   const [favoriteTokens, setFavoriteTokens] = useState<IFavoriteTokenDisplay[]>(
@@ -243,7 +241,12 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
                       <LeverageBadge leverage={record.maxLeverage} />
                     ) : null}
                   </XStack>
-                  <SizableText size="$bodyMd" color="$textSubdued">
+                  <SizableText
+                    size="$bodyMd"
+                    color="$textSubdued"
+                    numberOfLines={1}
+                    maxWidth={200}
+                  >
                     {record.name}
                   </SizableText>
                 </YStack>
@@ -259,7 +262,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
               size="$bodyLgMedium"
               formatter="price"
               formatterOptions={{
-                currency: record.perpsCoin ? '$' : currencyInfo?.symbol,
+                currency: '$',
               }}
             >
               {record.price ?? '-'}
@@ -294,7 +297,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
               size="$bodyLgMedium"
               formatter="marketCap"
               formatterOptions={{
-                currency: record.perpsCoin ? '$' : currencyInfo?.symbol,
+                currency: '$',
               }}
             >
               {new BigNumber(record.volume24h).isNaN() ? '-' : record.volume24h}
@@ -342,7 +345,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
                   size="$bodyMd"
                   formatter="marketCap"
                   formatterOptions={{
-                    currency: record.perpsCoin ? '$' : currencyInfo?.symbol,
+                    currency: '$',
                   }}
                 >
                   {new BigNumber(record.volume24h).isNaN()
@@ -367,7 +370,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
                 size="$bodyLgMedium"
                 formatter="price"
                 formatterOptions={{
-                  currency: record.perpsCoin ? '$' : currencyInfo?.symbol,
+                  currency: '$',
                 }}
               >
                 {record.price ?? '-'}
@@ -385,7 +388,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
         },
       },
     ];
-  }, [intl, currencyInfo?.symbol, tableLayout]);
+  }, [intl, tableLayout]);
 
   const { isLoading, run: refreshData } = usePromiseResult(
     async () => {

--- a/packages/kit/src/views/Market/MarketDetailV1/MarketDetail.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV1/MarketDetail.tsx
@@ -88,7 +88,7 @@ function TokenDetailHeader({
           {name}
         </SizableText>
         <XStack ai="center" jc="space-between" pt="$2">
-          <Currency sourceCurrency="usd" size="$heading3xl">
+          <Currency size="$heading3xl">
             {currentPrice}
           </Currency>
         </XStack>

--- a/packages/kit/src/views/Market/MarketDetailV1/MarketDetail.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV1/MarketDetail.tsx
@@ -88,9 +88,7 @@ function TokenDetailHeader({
           {name}
         </SizableText>
         <XStack ai="center" jc="space-between" pt="$2">
-          <Currency size="$heading3xl">
-            {currentPrice}
-          </Currency>
+          <Currency size="$heading3xl">{currentPrice}</Currency>
         </XStack>
         <PriceChangePercentage pt="$0.5" width="100%">
           {performance.priceChangePercentage24h}

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchMarketTokenItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchMarketTokenItem.tsx
@@ -77,7 +77,7 @@ export function UniversalSearchMarketTokenItem({
       }}
     >
       <XStack>
-        <Currency sourceCurrency="usd" size="$bodyLgMedium">
+        <Currency size="$bodyLgMedium">
           {String(price)}
         </Currency>
       </XStack>

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchMarketTokenItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchMarketTokenItem.tsx
@@ -77,9 +77,7 @@ export function UniversalSearchMarketTokenItem({
       }}
     >
       <XStack>
-        <Currency size="$bodyLgMedium">
-          {String(price)}
-        </Currency>
+        <Currency size="$bodyLgMedium">{String(price)}</Currency>
       </XStack>
     </ListItem>
   );


### PR DESCRIPTION
https://onekeyhq.atlassian.net/browse/OK-51720
https://onekeyhq.atlassian.net/browse/OK-51719
https://onekeyhq.atlassian.net/browse/OK-51714
## Summary
- Fix double currency conversion in V1 market token prices: the V1 API (`/utility/v1/market/tokens` and `/utility/v1/market/detail`) returns prices already in the user's selected currency (via global `x-onekey-request-currency` header), but `<Currency sourceCurrency="usd">` was converting again from USD to user currency, inflating prices ~6.88x for CNY users
- Fix watchlist token name truncation: long names like "Circle Internet Group (Ondo Tokenized)" now truncate with ellipsis
- Fix watchlist price/volume currency symbol to always display `$`

## Test plan
- [ ] Set currency to CNY, search for BTC in universal search → Tokens section price should match API value, not ~6.88x inflated
- [ ] Open V1 token detail page → price should display correctly in user's currency
- [ ] Check wallet home watchlist with a long token name → should truncate with `...`
- [ ] Check wallet home watchlist price and volume columns → should show `$` symbol
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
