### PR TITLE
perf: conditionally subscribe to netinfo in usePromiseResult

### DIFF
--- a/packages/components/src/hooks/useNetInfo.test.tsx
+++ b/packages/components/src/hooks/useNetInfo.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { useRef } from 'react';
+
+jest.mock('./useVisibilityChange', () => ({
+  __esModule: true,
+  getCurrentVisibilityState: () => true,
+  onVisibilityStateChange: () => () => {},
+}));
+
+const netInfoModule: typeof import('./useNetInfo') = require('./useNetInfo');
+const { globalNetInfo, useNetInfo } = netInfoModule;
+
+function useNetInfoWithRenderCount(enabled: boolean) {
+  const renderCountRef = useRef(0);
+  renderCountRef.current += 1;
+
+  const state = useNetInfo(enabled);
+
+  return {
+    renderCount: renderCountRef.current,
+    state,
+  };
+}
+
+describe('useNetInfo', () => {
+  beforeEach(() => {
+    globalNetInfo.listeners = [];
+    globalNetInfo.state = { isInternetReachable: null };
+    globalNetInfo.prevIsInternetReachable = false;
+  });
+
+  it('does not subscribe to netinfo updates when disabled', () => {
+    const { result } = renderHook(() => useNetInfoWithRenderCount(false));
+
+    expect(result.current.renderCount).toBe(1);
+    expect(globalNetInfo.listeners).toHaveLength(0);
+
+    act(() => {
+      globalNetInfo.updateState({ isInternetReachable: false });
+    });
+
+    expect(result.current.renderCount).toBe(1);
+    expect(result.current.state.isRawInternetReachable).toBeNull();
+  });
+
+  it('subscribes to netinfo updates when enabled', () => {
+    const { result } = renderHook(() => useNetInfoWithRenderCount(true));
+
+    expect(result.current.renderCount).toBe(1);
+    expect(globalNetInfo.listeners).toHaveLength(1);
+
+    act(() => {
+      globalNetInfo.updateState({ isInternetReachable: false });
+    });
+
+    expect(result.current.renderCount).toBe(2);
+    expect(result.current.state.isInternetReachable).toBe(false);
+    expect(result.current.state.isRawInternetReachable).toBe(false);
+  });
+});

--- a/packages/components/src/hooks/useNetInfo.ts
+++ b/packages/components/src/hooks/useNetInfo.ts
@@ -190,26 +190,66 @@ export const refreshNetInfo = () => {
   globalNetInfo.refresh();
 };
 
-export const useNetInfo = () => {
+const buildReachabilityState = (
+  isInternetReachable: boolean | null,
+): IReachabilityState & {
+  isRawInternetReachable: boolean | null;
+} => ({
+  isInternetReachable: isInternetReachable ?? true,
+  isRawInternetReachable: isInternetReachable,
+});
+
+const mergeReachabilityState = (
+  prevState: IReachabilityState & {
+    isRawInternetReachable: boolean | null;
+  },
+  nextState: IReachabilityState & {
+    isRawInternetReachable: boolean | null;
+  },
+) => {
+  if (
+    prevState.isInternetReachable === nextState.isInternetReachable &&
+    prevState.isRawInternetReachable === nextState.isRawInternetReachable
+  ) {
+    return prevState;
+  }
+
+  return nextState;
+};
+
+export const useNetInfo = (enabled = true) => {
   const [reachabilityState, setReachabilityState] = useState<
     IReachabilityState & {
       isRawInternetReachable: boolean | null;
     }
   >(() => {
     const { isInternetReachable } = globalNetInfo.currentState();
-    return {
-      isInternetReachable: isInternetReachable ?? true,
-      isRawInternetReachable: isInternetReachable,
-    };
+    return buildReachabilityState(isInternetReachable);
   });
+
   useEffect(() => {
+    const { isInternetReachable } = globalNetInfo.currentState();
+    setReachabilityState((prevState) =>
+      mergeReachabilityState(
+        prevState,
+        buildReachabilityState(isInternetReachable),
+      ),
+    );
+
+    if (!enabled) {
+      return undefined;
+    }
+
     const remove = globalNetInfo.addEventListener(({ isInternetReachable }) => {
-      setReachabilityState({
-        isInternetReachable: isInternetReachable ?? true,
-        isRawInternetReachable: isInternetReachable,
-      });
+      setReachabilityState((prevState) =>
+        mergeReachabilityState(
+          prevState,
+          buildReachabilityState(isInternetReachable),
+        ),
+      );
     });
     return remove;
-  }, []);
+  }, [enabled]);
+
   return reachabilityState;
 };

--- a/packages/kit/src/hooks/usePromiseResult.test.tsx
+++ b/packages/kit/src/hooks/usePromiseResult.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/first */
+/* eslint-disable react-hooks/exhaustive-deps */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useRef } from 'react';
+
+jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
+  __esModule: true,
+  default: {
+    isNative: false,
+    isDesktop: false,
+    isWeb: true,
+    isRuntimeBrowser: true,
+    isRuntimeChrome: false,
+  },
+}));
+
+jest.mock('@onekeyhq/kit/src/hooks/useRouteIsFocused', () => ({
+  useRouteIsFocused: () => true,
+}));
+
+jest.mock('@onekeyhq/components', () => {
+  const deferredPromiseModule = require('../../../components/src/hooks/useDeferredPromise');
+  const netInfoModule = require('../../../components/src/hooks/useNetInfo');
+
+  return {
+    __esModule: true,
+    getCurrentVisibilityState: () => true,
+    onVisibilityStateChange: () => () => {},
+    useDeferredPromise: deferredPromiseModule.useDeferredPromise,
+    useNetInfo: netInfoModule.useNetInfo,
+  };
+});
+
+import { globalNetInfo } from '../../../components/src/hooks/useNetInfo';
+
+import { usePromiseResult } from './usePromiseResult';
+
+function usePromiseResultWithRenderCount(
+  method: () => Promise<string>,
+  options?: Parameters<typeof usePromiseResult<string>>[2],
+) {
+  const renderCountRef = useRef(0);
+  renderCountRef.current += 1;
+
+  const state = usePromiseResult(method, [method], options);
+
+  return {
+    renderCount: renderCountRef.current,
+    ...state,
+  };
+}
+
+describe('usePromiseResult', () => {
+  beforeEach(() => {
+    globalNetInfo.listeners = [];
+    globalNetInfo.state = { isInternetReachable: null };
+    globalNetInfo.prevIsInternetReachable = false;
+  });
+
+  it('does not rerender on netinfo updates when reconnect revalidation is disabled', async () => {
+    const method = jest.fn(async () => 'done');
+
+    const { result } = renderHook(() =>
+      usePromiseResultWithRenderCount(method),
+    );
+
+    await waitFor(() => {
+      expect(result.current.result).toBe('done');
+    });
+
+    const renderCountAfterLoad = result.current.renderCount;
+
+    expect(method).toHaveBeenCalledTimes(1);
+    expect(globalNetInfo.listeners).toHaveLength(0);
+
+    act(() => {
+      globalNetInfo.updateState({ isInternetReachable: false });
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(method).toHaveBeenCalledTimes(1);
+    expect(result.current.renderCount).toBe(renderCountAfterLoad);
+  });
+
+  it('revalidates when network recovers if reconnect revalidation is enabled', async () => {
+    globalNetInfo.state = { isInternetReachable: false };
+
+    const method = jest
+      .fn<Promise<string>, []>()
+      .mockResolvedValueOnce('first')
+      .mockResolvedValueOnce('second');
+
+    const { result } = renderHook(() =>
+      usePromiseResultWithRenderCount(method, {
+        revalidateOnReconnect: true,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.result).toBe('first');
+    });
+
+    expect(method).toHaveBeenCalledTimes(1);
+    expect(globalNetInfo.listeners).toHaveLength(1);
+
+    act(() => {
+      globalNetInfo.updateState({ isInternetReachable: true });
+    });
+
+    await waitFor(() => {
+      expect(result.current.result).toBe('second');
+    });
+
+    expect(method).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/kit/src/hooks/usePromiseResult.ts
+++ b/packages/kit/src/hooks/usePromiseResult.ts
@@ -293,7 +293,11 @@ export function usePromiseResult<T>(
     void runRef.current({ pollingNonce: pollingNonceRef.current });
   }, [runRef]);
 
-  const { isRawInternetReachable: isInternetReachable } = useNetInfo();
+  // Most callers don't need reconnect revalidation. Avoid subscribing them
+  // to global network polling updates, which can cause periodic rerenders.
+  const { isRawInternetReachable: isInternetReachable } = useNetInfo(
+    !!options.revalidateOnReconnect,
+  );
   const prevIsInternetReachableRef = useRef(isInternetReachable);
 
   useEffect(() => {


### PR DESCRIPTION
https://onekeyhq.atlassian.net/browse/OK-51667
## Summary
- Add `enabled` parameter to `useNetInfo` hook so callers can opt out of global network state polling
- `usePromiseResult` now only subscribes to netinfo when `revalidateOnReconnect` is enabled, reducing unnecessary rerenders for the majority of callers
- Add `mergeReachabilityState` for reference-stable state updates to avoid extra renders when state hasn't changed
- Add unit tests for both `useNetInfo` and `usePromiseResult`

## Test plan
- [ ] `yarn jest packages/components/src/hooks/useNetInfo.test.tsx` passes
- [ ] `yarn jest packages/kit/src/hooks/usePromiseResult.test.tsx` passes
- [ ] Verify network reconnect revalidation still works for hooks using `revalidateOnReconnect: true`
- [ ] Verify no regression in general data fetching behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
