### PR TITLE
fix: mnemonic import suggestion popover stealing focus and keyboard overlap on mobile(OK-51709)

### DIFF
--- a/packages/components/src/actions/Popover/index.tsx
+++ b/packages/components/src/actions/Popover/index.tsx
@@ -427,6 +427,7 @@ function RawPopover({
       {/* floating panel */}
       {platformEnv.isNative ? null : (
         <TMPopover.Content
+          trapFocus={false}
           unstyled
           display={display}
           style={{

--- a/packages/components/src/composite/Dialog/index.tsx
+++ b/packages/components/src/composite/Dialog/index.tsx
@@ -306,7 +306,7 @@ function DialogFrame({
           width={platformEnv.isNativeIOSPad ? MAX_CONTENT_WIDTH : undefined}
           maxWidth={platformEnv.isNativeIOSPad ? MAX_CONTENT_WIDTH : undefined}
         >
-          <FocusScope trapped={effectiveTrapFocus} loop>
+          <FocusScope trapped={open && effectiveTrapFocus} loop>
             <Stack>
               {!disableDrag ? <SheetGrabber /> : null}
               {renderDialogContent}

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
@@ -343,6 +343,7 @@ function OverflowMoreButton({
         </YStack>
       </TMPopover.Trigger>
       <TMPopover.Content
+        trapFocus={false}
         unstyled
         w={200}
         p={0}

--- a/packages/kit/src/views/Onboardingv2/components/PhaseInputArea.tsx
+++ b/packages/kit/src/views/Onboardingv2/components/PhaseInputArea.tsx
@@ -42,7 +42,6 @@ import {
   XStack,
   useForm,
   useKeyboardEvent,
-  useKeyboardState,
   useMedia,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
@@ -571,8 +570,6 @@ export function PhaseInputArea({
     },
   }));
 
-  const { isVisible } = useKeyboardState?.() || { isVisible: true };
-
   const watched = useWatch({ control: form.control });
   const hasFilledPhrases = useMemo(
     () => compact(Object.values(watched)).length > 0,
@@ -670,9 +667,9 @@ export function PhaseInputArea({
         ) : null}
       </HeightTransition>
       {FooterComponent}
-      {isVisible ? (
+      {platformEnv.isNative ? (
         <Portal.Body container={Portal.Constant.SUGGESTION_LIST}>
-          {isVisible ? (
+          {suggestions.length > 0 ? (
             <SuggestionList
               suggestions={suggestions}
               onPressItem={updateInputValue}

--- a/packages/kit/src/views/Onboardingv2/components/useSuggestion.ts
+++ b/packages/kit/src/views/Onboardingv2/components/useSuggestion.ts
@@ -31,11 +31,11 @@ export const useSearchWords = () => {
       if (cachedSuggestions) {
         updateSuggestions(cachedSuggestions);
       } else {
-        const suggestionWords = wordLists.filter((text: string) =>
-          text.startsWith(value),
+        const shuffledWords = shuffle(
+          wordLists.filter((text: string) => text.startsWith(value)),
         );
-        ref.current.set(value, shuffle(suggestionWords));
-        updateSuggestions(suggestionWords);
+        ref.current.set(value, shuffledWords);
+        updateSuggestions(shuffledWords);
       }
       return suggestionsRef.current;
     },

--- a/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
@@ -281,7 +281,7 @@ export default function ImportPhraseOrPrivateKey() {
             id: ETranslations.import_phrase_or_private_key,
           })}
         />
-        <OnboardingLayout.Body constrained={false} bottomOffset={150}>
+        <OnboardingLayout.Body constrained={false} bottomOffset={200}>
           <OnboardingLayout.ConstrainedContent gap="$5">
             <SegmentControl
               value={selected}

--- a/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
@@ -369,26 +369,26 @@ export default function ImportPhraseOrPrivateKey() {
         </OnboardingLayout.Body>
         {!gtMd ? (
           <OnboardingLayout.Footer>
-            <YStack>
-              <Animated.View style={footerAnimatedStyle}>
-                <YStack>
-                  {isKeyboardVisible ? (
-                    <Stack
-                      mx="$-5"
-                      borderTopWidth={StyleSheet.hairlineWidth}
-                      borderColor="$borderSubdued"
-                    />
-                  ) : null}
-                  <XStack
-                    bg="$bgApp"
-                    alignItems="center"
-                    justifyContent="center"
-                    pt="$3"
-                    pb={500}
-                    mb={-500}
-                  >
-                    <YStack w="100%" gap="$3">
-                      {platformEnv.isNative ? (
+            {platformEnv.isNative ? (
+              <YStack>
+                <Animated.View style={footerAnimatedStyle}>
+                  <YStack>
+                    {isKeyboardVisible ? (
+                      <Stack
+                        mx="$-5"
+                        borderTopWidth={StyleSheet.hairlineWidth}
+                        borderColor="$borderSubdued"
+                      />
+                    ) : null}
+                    <XStack
+                      bg="$bgApp"
+                      alignItems="center"
+                      justifyContent="center"
+                      pt="$3"
+                      pb={500}
+                      mb={-500}
+                    >
+                      <YStack w="100%" gap="$3">
                         <HeightTransition>
                           <XStack onPress={noop}>
                             <Portal.Container
@@ -396,23 +396,37 @@ export default function ImportPhraseOrPrivateKey() {
                             />
                           </XStack>
                         </HeightTransition>
-                      ) : null}
-                      <Button
-                        size="large"
-                        variant="primary"
-                        onPress={handleConfirm}
-                        loading={isConfirming}
-                        w="100%"
-                      >
-                        {intl.formatMessage({
-                          id: ETranslations.global_confirm,
-                        })}
-                      </Button>
-                    </YStack>
-                  </XStack>
-                </YStack>
-              </Animated.View>
-            </YStack>
+                        <Button
+                          size="large"
+                          variant="primary"
+                          onPress={handleConfirm}
+                          loading={isConfirming}
+                          w="100%"
+                        >
+                          {intl.formatMessage({
+                            id: ETranslations.global_confirm,
+                          })}
+                        </Button>
+                      </YStack>
+                    </XStack>
+                  </YStack>
+                </Animated.View>
+              </YStack>
+            ) : (
+              <YStack w="100%" pb="$5">
+                <Button
+                  size="large"
+                  variant="primary"
+                  onPress={handleConfirm}
+                  loading={isConfirming}
+                  w="100%"
+                >
+                  {intl.formatMessage({
+                    id: ETranslations.global_confirm,
+                  })}
+                </Button>
+              </YStack>
+            )}
           </OnboardingLayout.Footer>
         ) : null}
       </OnboardingLayout>

--- a/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
@@ -17,8 +17,10 @@ import {
   SegmentControl,
   SizableText,
   TextAreaInput,
+  Stack,
   XStack,
   YStack,
+  useKeyboardState,
   useMedia,
   useReanimatedKeyboardAnimation,
 } from '@onekeyhq/components';
@@ -223,6 +225,7 @@ export default function ImportPhraseOrPrivateKey() {
   };
 
   const { height } = useReanimatedKeyboardAnimation();
+  const { isVisible: isKeyboardVisible } = useKeyboardState?.() || {};
 
   const renderHardwarePhrasesWarningTag = useCallback(
     (chunks: ReactNode[]) => (
@@ -346,13 +349,22 @@ export default function ImportPhraseOrPrivateKey() {
             <YStack>
               <Animated.View style={{ transform: [{ translateY: height }] }}>
                 <YStack>
+                  {isKeyboardVisible ? (
+                    <Stack
+                      mx="$-5"
+                      borderTopWidth={StyleSheet.hairlineWidth}
+                      borderColor="$borderSubdued"
+                    />
+                  ) : null}
                   <XStack
                     bg="$bgApp"
                     alignItems="center"
                     justifyContent="center"
-                    pt="$5"
+                    pt="$3"
+                    pb={500}
+                    mb={-500}
                   >
-                    <YStack w="100%">
+                    <YStack w="100%" gap="$3">
                       {platformEnv.isNative ? (
                         <XStack onPress={noop}>
                           <Portal.Container

--- a/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
@@ -370,13 +370,19 @@ export default function ImportPhraseOrPrivateKey() {
                     pb={500}
                     mb={-500}
                   >
-                    <YStack w="100%" gap="$3">
+                    <YStack
+                      w="100%"
+                      gap="$3"
+                      pb="$3"
+                    >
                       {platformEnv.isNative ? (
-                        <XStack onPress={noop}>
-                          <Portal.Container
-                            name={Portal.Constant.SUGGESTION_LIST}
-                          />
-                        </XStack>
+                        <HeightTransition>
+                          <XStack onPress={noop}>
+                            <Portal.Container
+                              name={Portal.Constant.SUGGESTION_LIST}
+                            />
+                          </XStack>
+                        </HeightTransition>
                       ) : null}
                       <Button
                         size="large"

--- a/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
@@ -16,8 +16,8 @@ import {
   Portal,
   SegmentControl,
   SizableText,
-  TextAreaInput,
   Stack,
+  TextAreaInput,
   XStack,
   YStack,
   useKeyboardEvent,
@@ -242,10 +242,7 @@ export default function ImportPhraseOrPrivateKey() {
   const footerAnimatedStyle = useAnimatedStyle(() => ({
     transform: [
       {
-        translateY:
-          height.value < 0
-            ? height.value + rootBottomPadding / 2
-            : 0,
+        translateY: height.value < 0 ? height.value + rootBottomPadding / 2 : 0,
       },
     ],
   }));

--- a/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
@@ -20,7 +20,7 @@ import {
   Stack,
   XStack,
   YStack,
-  useKeyboardState,
+  useKeyboardEvent,
   useMedia,
   useReanimatedKeyboardAnimation,
 } from '@onekeyhq/components';
@@ -225,7 +225,13 @@ export default function ImportPhraseOrPrivateKey() {
   };
 
   const { height } = useReanimatedKeyboardAnimation();
-  const { isVisible: isKeyboardVisible } = useKeyboardState?.() || {};
+  const [isKeyboardVisible, setIsKeyboardVisible] = useState(
+    selected === EOnboardingV2ImportPhraseOrPrivateKeyTab.Phrase,
+  );
+  useKeyboardEvent({
+    keyboardWillShow: () => setIsKeyboardVisible(true),
+    keyboardWillHide: () => setIsKeyboardVisible(false),
+  });
 
   const renderHardwarePhrasesWarningTag = useCallback(
     (chunks: ReactNode[]) => (

--- a/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
@@ -5,7 +5,7 @@ import { useRoute } from '@react-navigation/core';
 import { noop } from 'lodash';
 import { useIntl } from 'react-intl';
 import { StyleSheet } from 'react-native';
-import Animated from 'react-native-reanimated';
+import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 
 import type { IInputRef, ITextAreaInputProps } from '@onekeyhq/components';
 import {
@@ -23,6 +23,7 @@ import {
   useKeyboardEvent,
   useMedia,
   useReanimatedKeyboardAnimation,
+  useSafeAreaInsets,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -225,6 +226,7 @@ export default function ImportPhraseOrPrivateKey() {
   };
 
   const { height } = useReanimatedKeyboardAnimation();
+  const { bottom: safeAreaBottom } = useSafeAreaInsets();
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(
     selected === EOnboardingV2ImportPhraseOrPrivateKeyTab.Phrase,
   );
@@ -232,6 +234,21 @@ export default function ImportPhraseOrPrivateKey() {
     keyboardWillShow: () => setIsKeyboardVisible(true),
     keyboardWillHide: () => setIsKeyboardVisible(false),
   });
+
+  // The root layout adds pb: safeAreaBottom + 10 which creates a gap below
+  // the footer when keyboard is up. Compensate by translating down half that
+  // distance so the footer content is vertically centered.
+  const rootBottomPadding = safeAreaBottom + 10;
+  const footerAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      {
+        translateY:
+          height.value < 0
+            ? height.value + rootBottomPadding / 2
+            : 0,
+      },
+    ],
+  }));
 
   const renderHardwarePhrasesWarningTag = useCallback(
     (chunks: ReactNode[]) => (
@@ -353,7 +370,7 @@ export default function ImportPhraseOrPrivateKey() {
         {!gtMd ? (
           <OnboardingLayout.Footer>
             <YStack>
-              <Animated.View style={{ transform: [{ translateY: height }] }}>
+              <Animated.View style={footerAnimatedStyle}>
                 <YStack>
                   {isKeyboardVisible ? (
                     <Stack
@@ -370,11 +387,7 @@ export default function ImportPhraseOrPrivateKey() {
                     pb={500}
                     mb={-500}
                   >
-                    <YStack
-                      w="100%"
-                      gap="$3"
-                      pb="$3"
-                    >
+                    <YStack w="100%" gap="$3">
                       {platformEnv.isNative ? (
                         <HeightTransition>
                           <XStack onPress={noop}>


### PR DESCRIPTION
## Summary
- Fix mnemonic word suggestion display and interaction on mobile during phrase import
- Fix confirm button footer layout on non-native web at md breakpoint
- Fix keyboard scroll offset to avoid suggestion bar overlap
- Disable Popover `trapFocus` to prevent input focus loss on web (both in shared Popover component and DesktopLeftSideBar overflow menu)
- Fix shuffled suggestions display to use correct array

## Test plan
- [ ] Import mnemonic phrase on iOS — verify suggestions appear and can be tapped
- [ ] Import mnemonic phrase on Android — verify suggestions and keyboard behavior
- [ ] Import mnemonic phrase on web (md size) — verify confirm button layout
- [ ] Import mnemonic phrase on web (gtMd size) — verify Popover doesn't steal input focus
- [ ] Desktop left sidebar overflow menu — verify no focus issues when hovering
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
