### PR TITLE
fix(desktop): add core24 base to snap config to resolve GLIBC mismatch

### DIFF
--- a/apps/desktop/electron-builder-snap.config.js
+++ b/apps/desktop/electron-builder-snap.config.js
@@ -19,7 +19,7 @@ module.exports = {
   },
   // Refer: https://canonical-snap.readthedocs-hosted.com/reference/development/interfaces/raw-usb-interface/
   'snap': {
-    'base': 'core24',
+    'base': 'core22',
     'plugs': ['default', 'raw-usb'],
   },
 };

--- a/apps/desktop/electron-builder-snap.config.js
+++ b/apps/desktop/electron-builder-snap.config.js
@@ -19,6 +19,7 @@ module.exports = {
   },
   // Refer: https://canonical-snap.readthedocs-hosted.com/reference/development/interfaces/raw-usb-interface/
   'snap': {
+    'base': 'core24',
     'plugs': ['default', 'raw-usb'],
   },
 };


### PR DESCRIPTION
## Summary

- Add `base: 'core24'` to the snap configuration in `electron-builder-snap.config.js`
- Without a base declaration, snapcraft defaults to core18 which ships GLIBC 2.27, but bundled libraries require GLIBC 2.33/2.34/2.38
- core24 provides GLIBC 2.39, which satisfies all requirements
- Snap packages are self-contained, so this does not affect host system compatibility

## Test plan

- [ ] Build the snap package with the updated config
- [ ] Verify the snap installs and launches without GLIBC version errors
- [ ] Confirm USB device connectivity still works via the `raw-usb` plug

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
