### PR TITLE
feat: add 1k-bundle-release skill for release branch management

### DIFF
--- a/.claude/skills/1k-bundle-release/SKILL.md
+++ b/.claude/skills/1k-bundle-release/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: 1k-bundle-release
+description: Release branch management — cherry-pick verified PRs to release branch, pre-release diff validation, and publish tracking. Use this skill whenever managing release branches, cherry-picking commits to a release branch, running pre-release diff checks, finalizing releases, or discussing the release branch workflow. Triggers on "bundle release", "cherry-pick to release", "release diff", "release publish", "发布管理", "cherry-pick 到 release", "release 分支", "release management", "bundle-release", "release-ready".
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob
+disable-model-invocation: true
+---
+
+# Release Branch Management
+
+Automates the cherry-pick, diff-check, and publish workflow for release branches. This skill handles getting verified code from `x` onto the release branch and tracking what ships in each release.
+
+## Context
+
+OneKey ships periodic App Shell releases (tagged `v{X.Y.Z}` on the `x` branch). After each App Shell release, a release branch (`release/v{X.Y.Z}`) is created from the tag to accumulate verified changes via cherry-pick. Only the latest App Shell version's release branch is actively maintained.
+
+The core invariant: **every commit on the release branch must also exist on `x`**. The release branch is a curated subset of `x`, not a fork.
+
+## Quick Reference
+
+| Subcommand | When to use | Guide |
+|------------|-------------|-------|
+| `cherry-pick` | Ready to bring verified PRs into the next release | [cherry-pick.md](references/rules/cherry-pick.md) |
+| `diff-check` | After cherry-picks, before publishing — verify integrity | [diff-check.md](references/rules/diff-check.md) |
+| `publish` | Diff checks passed, ready to finalize the release | [publish.md](references/rules/publish.md) |
+
+## Subcommand Routing
+
+Parse the argument passed to this skill:
+
+- **`cherry-pick`** → Read and follow [cherry-pick.md](references/rules/cherry-pick.md)
+- **`diff-check`** → Read and follow [diff-check.md](references/rules/diff-check.md)
+- **`publish`** → Read and follow [publish.md](references/rules/publish.md)
+- **No argument** → Show this quick reference and ask which subcommand to run
+
+## Typical Release Flow
+
+```
+/1k-bundle-release cherry-pick   ← Collect and apply verified PRs
+/1k-bundle-release diff-check    ← Verify subset integrity + review changeset
+/1k-bundle-release publish       ← Record release in tracking file
+```
+
+These three steps are designed to run in sequence, but each can also run independently (e.g., re-running diff-check after fixing an issue).
+
+## Label Convention
+
+| Label | Meaning |
+|-------|---------|
+| `release-ready` | This PR should be included in the next release |
+| `no-release` | Explicitly excluded — contains native changes or requires App Shell update |
+
+Developers add the `release-ready` label when creating PRs. No label = not included by default.
+
+## Key Files
+
+| File | Location | Purpose |
+|------|----------|---------|
+| Release tracking | `RELEASES.json` (release branch root) | Each entry: seq, commit SHA, date, PR list, notes |
+
+## Related Skills
+
+- `/1k-git-workflow` — Branch naming, commit conventions
+- `/commit` — Create commits
+- `/1k-create-pr` — Create pull requests

--- a/.claude/skills/1k-bundle-release/references/rules/cherry-pick.md
+++ b/.claude/skills/1k-bundle-release/references/rules/cherry-pick.md
@@ -1,0 +1,172 @@
+# Cherry-Pick Workflow
+
+Collects merged PRs labeled `release-ready`, analyzes file-level dependencies between them, and cherry-picks to the current release branch in topological order. Stops on conflicts to help resolve them interactively.
+
+## Pre-flight Checks
+
+Before starting, verify three things:
+
+### 1. On a release branch
+
+```bash
+current_branch=$(git branch --show-current)
+```
+
+The branch name must match `release/v*`. If not, list available release branches and ask the user to switch:
+
+```bash
+git branch -r | grep 'origin/release/'
+```
+
+### 2. Identify the App Shell tag
+
+The release branch name encodes the version — `release/v6.1.0` corresponds to tag `v6.1.0`:
+
+```bash
+app_version=$(git branch --show-current | sed 's|release/||')
+tag_date=$(git log -1 --format=%aI "$app_version")
+```
+
+`tag_date` is used to scope the PR query — only look at PRs merged after the tag was created.
+
+### 3. Working tree is clean
+
+```bash
+git status --porcelain
+```
+
+Must be empty. Cherry-picking with uncommitted changes risks losing work.
+
+## Step 1: Collect Pending PRs
+
+Query GitHub for merged PRs with the `release-ready` label, merged after the App Shell tag date:
+
+```bash
+gh pr list \
+  --state merged \
+  --label release-ready \
+  --search "merged:>$(echo $tag_date | cut -d'T' -f1)" \
+  --json number,title,mergeCommit,mergedAt \
+  --limit 500
+```
+
+From the JSON output, extract for each PR:
+- `number` — PR number (for display and tracking)
+- `title` — PR title (for the execution plan)
+- `mergeCommit.oid` — the merge commit SHA on `x` (this is what gets cherry-picked)
+- `mergedAt` — merge timestamp (for ordering)
+
+## Step 2: Filter Already Cherry-Picked
+
+`git cherry` compares two branches by patch content (not commit SHA), so it correctly detects cherry-picks even though they create new commits:
+
+```bash
+git cherry release/$app_version x
+```
+
+Output lines starting with `+` are not yet cherry-picked; `-` means already applied. Cross-reference the merge commit SHAs from Step 1 — only keep PRs whose commit shows `+`.
+
+If nothing remains, report "No pending cherry-picks" and exit.
+
+## Step 3: Dependency Analysis & Sorting
+
+Cherry-pick order matters because commits that touch the same files can conflict if applied out of order. Sorting by file dependencies reduces avoidable conflicts.
+
+For each pending commit, get its changed files:
+
+```bash
+git diff-tree --no-commit-id --name-only -r <commit-sha>
+```
+
+Build a dependency graph:
+- For each pair of commits (A, B) where A was merged before B:
+  - If they modify any of the same files → B depends on A
+- Topological sort: dependencies first, then dependents
+- Within the same dependency level, sort by `mergedAt` (earliest first)
+
+Present the execution plan:
+
+```
+Pending cherry-picks (in execution order):
+
+  1. #1234 — fix: resolve swap page crash (abc1234)
+     Files: packages/kit/src/views/Swap/...
+  2. #1256 — feat: add token search (def5678)
+     Files: packages/kit/src/views/Market/...
+  3. #1260 — fix: discovery banner width (ghi9012)
+     Files: packages/kit/src/views/Discovery/...
+     ⚠️  Depends on #1234 (shared file: packages/kit/src/components/Banner.tsx)
+
+Proceed? (y/n)
+```
+
+Wait for user confirmation.
+
+## Step 4: Execute Cherry-Picks
+
+For each commit in sorted order:
+
+```bash
+git cherry-pick -x <commit-sha>
+```
+
+The `-x` flag appends "(cherry picked from commit ...)" to the message, creating an audit trail.
+
+**On success:** Report progress and continue:
+```
+✅ [1/3] #1234 — fix: resolve swap page crash
+```
+
+**On conflict:** Enter conflict resolution mode (below).
+
+## Conflict Resolution Mode
+
+When `git cherry-pick` reports a conflict:
+
+### 1. Show what's conflicting
+
+```bash
+git diff --name-only --diff-filter=U   # list conflicting files
+```
+
+Then read each conflicting file to show the conflict markers.
+
+### 2. Analyze the cause
+
+Compare the file on both branches to understand why the conflict occurred:
+- **Prior cherry-pick overlap** — a previously cherry-picked commit changed the same area
+- **Un-picked divergence** — a commit on `x` that wasn't cherry-picked modified this code
+- **Trivial artifact** — import reordering, whitespace, formatting
+
+Understanding the cause helps propose the right resolution.
+
+### 3. Suggest resolution
+
+- For trivial conflicts (import ordering, whitespace): propose auto-resolution
+- For semantic conflicts: show both versions side-by-side and recommend which to keep, explaining why
+
+### 4. User chooses
+
+Offer four options:
+
+| Option | Action |
+|--------|--------|
+| **a) Accept suggestion** | Apply the resolution, `git add` conflicting files, `git cherry-pick --continue` |
+| **b) Manual edit** | User edits files, then confirm → `git add` + `git cherry-pick --continue` |
+| **c) Skip this PR** | `git cherry-pick --abort`, add to skipped list, continue next |
+| **d) Abort entire flow** | `git cherry-pick --abort`, report progress so far, exit |
+
+## Step 5: Completion Report
+
+```
+Cherry-pick complete!
+
+✅ Successfully cherry-picked:
+  - #1234 — fix: resolve swap page crash
+  - #1256 — feat: add token search
+
+⏭️  Skipped:
+  - #1260 — fix: discovery banner width (conflict — needs manual resolution)
+
+Next step: /1k-bundle-release diff-check
+```

--- a/.claude/skills/1k-bundle-release/references/rules/diff-check.md
+++ b/.claude/skills/1k-bundle-release/references/rules/diff-check.md
@@ -1,0 +1,126 @@
+# Diff Check Workflow
+
+Pre-release validation with two checks: (1) verify the release branch is a strict subset of `x`, and (2) display the changeset since the last release so the team knows exactly what's shipping.
+
+## Pre-flight Checks
+
+### 1. On a release branch
+
+```bash
+current_branch=$(git branch --show-current)
+# Must match: release/v*
+```
+
+### 2. Extract version
+
+```bash
+app_version=$(echo "$current_branch" | sed 's|release/||')
+```
+
+## Diff 1: Subset Verification
+
+This is the most important check. The release branch must be a pure subset of `x` — no commits should exist on release that aren't on `x`.
+
+```bash
+git log release/$app_version --not x --oneline
+```
+
+**If empty → ✅ Pass**
+
+```
+✅ Subset check passed — all release branch commits exist on x
+```
+
+**If not empty → ❌ Fail**
+
+```
+❌ Subset check FAILED — release branch has commits not on x:
+
+  abc1234 fix: conflict resolution for swap component
+  def5678 chore: merge artifact cleanup
+
+These must be reverse cherry-picked to x before publishing.
+```
+
+Explain to the user that these commits need to be cherry-picked to `x` first (they were likely created during conflict resolution on the release branch). After the user resolves this, they should re-run diff-check.
+
+## Diff 2: Changeset Since Last Release
+
+Shows what's changed since the last published release, so the team can scope smoke testing and write release notes.
+
+### Get the baseline commit
+
+Read `RELEASES.json` from the release branch root:
+
+```bash
+cat RELEASES.json
+```
+
+Parse the JSON and get the `commit` field from the entry with the highest `seq`.
+
+If the file doesn't exist or is empty (first release for this branch), fall back to the App Shell tag:
+
+```bash
+base_sha=$(git rev-parse $app_version)
+```
+
+### Show the changeset
+
+```bash
+# Commit history
+git log $base_sha..release/$app_version --oneline
+
+# File change statistics
+git diff --stat $base_sha..release/$app_version
+```
+
+### Identify included PRs
+
+Cherry-pick commits created with `-x` contain "(cherry picked from commit ...)" in their message. Extract those original commit SHAs and cross-reference with `gh` to get PR numbers:
+
+```bash
+# Extract original commit SHAs from cherry-pick messages
+git log $base_sha..release/$app_version --grep="cherry picked from" --format="%b" | grep -oP '(?<=cherry picked from commit )[a-f0-9]+'
+```
+
+## Supplementary: What's on `x` but NOT in release
+
+This helps the team understand what was intentionally left out:
+
+```bash
+git log x --not release/$app_version --oneline
+```
+
+Cross-reference with PRs:
+- **No `release-ready` label** → intentionally excluded, expected
+- **Has `release-ready` label but not cherry-picked** → might be an oversight, flag it:
+
+```
+⚠️  PRs with 'release-ready' label NOT in this release:
+  - #1280 — feat: add new chain support (merged 2026-03-14, not cherry-picked)
+```
+
+## Output Summary
+
+```
+=== Release Diff Check Report ===
+
+📋 Subset verification: ✅ Pass
+📦 Changes since last release (seq #2, sha: def5678):
+   - 3 commits, 8 files changed
+   - PRs included: #1270, #1275, #1278
+
+📋 Content on x not in this release:
+   - 12 commits without 'release-ready' label (expected)
+   - 1 commit with 'release-ready' label pending ⚠️
+
+Conclusion: ✅ Ready for /1k-bundle-release publish
+```
+
+Or if issues found:
+
+```
+Conclusion: ❌ Issues found — resolve before publishing
+  - Subset check failed (2 commits need reverse cherry-pick to x)
+  - 1 labeled PR not cherry-picked (#1280)
+```

--- a/.claude/skills/1k-bundle-release/references/rules/publish.md
+++ b/.claude/skills/1k-bundle-release/references/rules/publish.md
@@ -1,0 +1,109 @@
+# Publish Workflow
+
+Finalizes a release by recording it in `RELEASES.json` and committing the tracking file. This creates the audit trail and provides the commit SHA for triggering CI.
+
+## Pre-flight Checks
+
+### 1. On a release branch
+
+```bash
+current_branch=$(git branch --show-current)
+# Must match: release/v*
+```
+
+### 2. Subset check passes
+
+```bash
+result=$(git log $current_branch --not x --oneline)
+```
+
+Must be empty. If not, tell the user to run `/1k-bundle-release diff-check` first.
+
+### 3. Working tree clean
+
+```bash
+git status --porcelain
+```
+
+Only `RELEASES.json` may have changes (or nothing — both are fine).
+
+## Step 1: Collect Release Information
+
+### Current HEAD
+
+```bash
+commit_sha=$(git rev-parse HEAD)
+short_sha=$(git rev-parse --short HEAD)
+```
+
+### Included PRs
+
+Determine the baseline (last release commit or App Shell tag), then list what's new:
+
+```bash
+# Read RELEASES.json for last release SHA, or fall back to tag
+git log $base_sha..$commit_sha --oneline
+```
+
+Extract PR numbers from cherry-pick messages.
+
+### Sequence number
+
+If `RELEASES.json` exists and has entries: `seq = last_entry.seq + 1`
+If first release: `seq = 1`
+
+### Release notes
+
+Ask the user:
+
+> "Please provide release notes, or press Enter to auto-generate from PR titles:"
+
+If the user skips, auto-generate by joining PR titles:
+
+```
+Fix swap page crash (#1234), Add token search (#1256)
+```
+
+## Step 2: Update RELEASES.json
+
+Read the existing file (or initialize `[]` if first release). Append a new entry:
+
+```json
+{
+  "seq": 3,
+  "commit": "abc1234def5678",
+  "date": "2026-03-15T10:30:00Z",
+  "prs": ["#1234", "#1256", "#1260"],
+  "notes": "Fix swap page crash, add token search, fix discovery banner width"
+}
+```
+
+- **date**: ISO 8601 UTC
+- **commit**: full SHA (not short)
+- **prs**: array of PR number strings with `#` prefix
+- **notes**: user-provided or auto-generated
+
+Write the updated JSON with 2-space indentation.
+
+## Step 3: Commit
+
+```bash
+git add RELEASES.json
+git commit -m "chore: release #$seq"
+```
+
+## Step 4: Output
+
+```
+=== Release #3 Published ===
+
+📦 Commit: abc1234 (release/v6.1.0)
+📋 PRs: #1234, #1256, #1260
+📝 Notes: Fix swap page crash, add token search, fix discovery banner width
+
+To trigger CI build, use workflow_dispatch with:
+  Branch: release/v6.1.0
+  Commit: abc1234def5678
+
+Release recorded in RELEASES.json
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,3 +126,4 @@ For detailed guidance, use these skills (invoke with `/skill-name`):
 - **1k-i18n** - Internationalization guidelines
 - **1k-cross-platform** - Platform-specific development
 - **1k-adding-chains** - Adding new blockchain support
+- **1k-bundle-release** - Bundle hot update release management (cherry-pick, diff-check, publish)


### PR DESCRIPTION
## Summary
- Add new `1k-bundle-release` Claude Code skill that automates the release branch cherry-pick, diff-check, and publish workflow
- Add skill reference to CLAUDE.md skills list

## Intent & Context
The OneKey release process involves cherry-picking verified PRs from `x` to release branches, validating the changeset integrity, and tracking published releases. This skill codifies the entire workflow into three subcommands (`cherry-pick`, `diff-check`, `publish`) so Claude Code can guide or automate each step consistently.

## Design Decisions
- **Three-subcommand structure**: Separates concerns (collect → validate → publish) so each step can run independently or in sequence
- **Label-driven PR selection**: Uses `release-ready` / `no-release` GitHub labels to determine inclusion, keeping the decision at PR creation time
- **Dependency-aware cherry-pick ordering**: Builds a file-level dependency graph and topologically sorts commits to minimize avoidable conflicts
- **`git cherry` for deduplication**: Detects already-applied patches by content rather than SHA, which is correct for cherry-pick workflows
- **Interactive conflict resolution**: Stops on conflicts with analysis and four clear options (accept suggestion / manual edit / skip / abort)

## Changes Detail
- `SKILL.md` — Main skill entry point with subcommand routing and context
- `references/rules/cherry-pick.md` — Full cherry-pick workflow: pre-flight checks, PR collection, dependency sorting, conflict resolution
- `references/rules/diff-check.md` — Pre-release integrity validation: subset check, native change detection, changeset review
- `references/rules/publish.md` — Release finalization: RELEASES.json tracking, push, summary
- `CLAUDE.md` — Added `1k-bundle-release` to skills reference list

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: None (skill files only, no runtime code)
- **Risk Areas**: None — additive change with no impact on application code

## Test plan
- [x] Invoke `/1k-bundle-release` with no argument — shows quick reference
- [x] Invoke `/1k-bundle-release cherry-pick` — runs pre-flight checks correctly (detects non-release branch)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
