### PR TITLE
fix: disable native header animation for market in nested pager on Android(OK-51793)

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
@@ -260,7 +260,7 @@ function MobileLayoutComponent({
         renderTabBar={renderTabBar}
         initialTabName={initialTabName}
         onTabChange={onTabChangeHandler}
-        useNativeHeaderAnimation={platformEnv.isNativeAndroid}
+        useNativeHeaderAnimation={platformEnv.isNativeAndroid && !nestedPager}
         pagerProps={
           nestedPager ? ({ nestedScrollEnabled: true } as any) : undefined
         }


### PR DESCRIPTION
## Summary
- Disable `useNativeHeaderAnimation` when Market's `Tabs.Container` is nested inside Discovery's outer PagerView on Android
- Falls back to Reanimated-based header animation (same path as iOS) when `nestedPager=true`

## Intent & Context
The Market homepage has a collapsible header (banner) with a sticky second-level tab bar. When scrolling down, the banner should collapse and the tab bar should stick to the top. This works on iOS but is broken on Android.

## Root Cause
`useNativeHeaderAnimation` was originally developed for the standalone Home page (commit `17c6093227`) where it works correctly. When it was later applied to the Market page inside Discovery's `OuterTabPagerView` (commit `2bc96977af`), the combination of:

1. **RN native Animated driver** (`RNAnimated.event` + `useNativeDriver: true`) for scroll-to-header binding
2. **ViewPager2** (Android's PagerView implementation based on RecyclerView) intercepting/modifying nested scroll events
3. **react-freeze** potentially disrupting native Animated node connections during page freeze/unfreeze

causes the native Animated scroll event listener to not properly receive scroll events from the FlatList, resulting in the header animation (and sticky tab behavior) not working.

iOS is unaffected because it never uses `useNativeHeaderAnimation` — it always uses Reanimated's worklet-based scroll handling, which runs on the UI thread independently and is compatible with ViewPager2 nesting.

## Design Decisions
- **Conditional disable over full removal**: Only disable `useNativeHeaderAnimation` when `nestedPager=true`. The standalone Market page and Home page retain the native animation for zero-frame-lag header sync.
- **Reanimated fallback is proven**: iOS already uses this path successfully. The only trade-off is a potential 1-frame lag on Android in the nested scenario, which is negligible compared to a completely broken sticky tab.

## Changes Detail
- `packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx`: Changed `useNativeHeaderAnimation={platformEnv.isNativeAndroid}` to `useNativeHeaderAnimation={platformEnv.isNativeAndroid && !nestedPager}`

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Android (Mobile)
- **Risk Areas**: The Reanimated fallback path is the same one iOS uses successfully. No new code paths introduced.

## Test plan
- [ ] Android: Open Discovery → Market tab, scroll down — banner should collapse, second-level tab bar should stick to top
- [ ] Android: Switch between Watchlist/Spot/Perps tabs — sub-headers should render correctly under sticky tab bar
- [ ] Android: Swipe between Market/Earn/Browser in Discovery outer pager, then return to Market — sticky behavior should still work
- [ ] iOS: Verify no regression — sticky tab behavior unchanged
- [ ] Android Home page: Verify collapsible header still works (not affected by this change)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
