### PR TITLE
fix(ios): touch TOCropViewController sources to invalidate EAS build …OK-51551

### DIFF
--- a/apps/mobile/ios/Podfile
+++ b/apps/mobile/ios/Podfile
@@ -252,6 +252,17 @@ target 'OneKeyWallet' do
       else
         Pod::UI.puts "TOCropView rotation fix already applied or source changed"
       end
+
+      # Force Xcode to recompile TOCropViewController when EAS build cache
+      # restores stale .o files. Touch all source files so their mtime is
+      # guaranteed to be newer than any cached object file.
+      tocrop_dir = File.join(__dir__, 'Pods', 'TOCropViewController')
+      if Dir.exist?(tocrop_dir)
+        Dir.glob(File.join(tocrop_dir, '**', '*.{m,h}')).each do |f|
+          FileUtils.touch(f)
+        end
+        Pod::UI.puts "Touched TOCropViewController sources to invalidate build cache"
+      end
     end
 
     # This is necessary for Xcode 14, because it signs resource bundles by default


### PR DESCRIPTION
…cache (OK-51551)

EAS build cache can restore stale .o files newer than patched sources, causing Xcode to skip recompilation of the TOCropView rotation fix.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10683" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
