### PR TITLE
fix(desktop): prevent OTP input focus loss in dialog (OK-51771)

### DIFF
--- a/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/OtpInput.tsx
+++ b/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/OtpInput.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { forwardRef, useImperativeHandle } from 'react';
+import { forwardRef, useImperativeHandle, useMemo } from 'react';
 
 import { Platform, Pressable, Text, View } from 'react-native';
 
@@ -61,6 +61,12 @@ export const OtpInput = forwardRef<IOtpInputRef, IOtpInputProps>(
     }));
 
     useOnWebPaste(inputRef, textInputProps?.onPaste);
+
+    const autoComplete = useMemo(() => {
+      if (platformEnv.isDesktop) return 'off' as const;
+      if (Platform.OS === 'android') return 'sms-otp' as const;
+      return 'one-time-code' as const;
+    }, []);
 
     const generatePinCodeContainerStyle = (
       isFocusedContainer: boolean,
@@ -145,11 +151,7 @@ export const OtpInput = forwardRef<IOtpInputRef, IOtpInputProps>(
           ref={inputRef}
           autoFocus={autoFocus}
           secureTextEntry={secureTextEntry}
-          autoComplete={(() => {
-            if (platformEnv.isDesktop) return 'off';
-            if (Platform.OS === 'android') return 'sms-otp';
-            return 'one-time-code';
-          })()}
+          autoComplete={autoComplete}
           aria-disabled={disabled}
           editable={!disabled}
           testID="otp-input-hidden"

--- a/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/OtpInput.tsx
+++ b/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/OtpInput.tsx
@@ -141,19 +141,15 @@ export const OtpInput = forwardRef<IOtpInputRef, IOtpInputProps>(
           onChangeText={handleTextChange}
           maxLength={numberOfDigits}
           inputMode={type === 'numeric' ? type : 'text'}
-          textContentType={
-            platformEnv.isDesktop ? undefined : 'oneTimeCode'
-          }
+          textContentType={platformEnv.isDesktop ? undefined : 'oneTimeCode'}
           ref={inputRef}
           autoFocus={autoFocus}
           secureTextEntry={secureTextEntry}
-          autoComplete={
-            platformEnv.isDesktop
-              ? 'off'
-              : Platform.OS === 'android'
-                ? 'sms-otp'
-                : 'one-time-code'
-          }
+          autoComplete={(() => {
+            if (platformEnv.isDesktop) return 'off';
+            if (Platform.OS === 'android') return 'sms-otp';
+            return 'one-time-code';
+          })()}
           aria-disabled={disabled}
           editable={!disabled}
           testID="otp-input-hidden"

--- a/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/OtpInput.tsx
+++ b/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/OtpInput.tsx
@@ -3,6 +3,8 @@ import { forwardRef, useImperativeHandle } from 'react';
 
 import { Platform, Pressable, Text, View } from 'react-native';
 
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
 import { useOnWebPaste } from '../../../Input';
 import TextInput from '../../../Input/TextInput';
 
@@ -107,7 +109,7 @@ export const OtpInput = forwardRef<IOtpInputRef, IOtpInputProps>(
 
             return (
               <Pressable
-                key={`${char}-${index}`}
+                key={index}
                 disabled={disabled}
                 onPress={handlePress}
                 style={generatePinCodeContainerStyle(isFocusedContainer, char)}
@@ -139,11 +141,19 @@ export const OtpInput = forwardRef<IOtpInputRef, IOtpInputProps>(
           onChangeText={handleTextChange}
           maxLength={numberOfDigits}
           inputMode={type === 'numeric' ? type : 'text'}
-          textContentType="oneTimeCode"
+          textContentType={
+            platformEnv.isDesktop ? undefined : 'oneTimeCode'
+          }
           ref={inputRef}
           autoFocus={autoFocus}
           secureTextEntry={secureTextEntry}
-          autoComplete={Platform.OS === 'android' ? 'sms-otp' : 'one-time-code'}
+          autoComplete={
+            platformEnv.isDesktop
+              ? 'off'
+              : Platform.OS === 'android'
+                ? 'sms-otp'
+                : 'one-time-code'
+          }
           aria-disabled={disabled}
           editable={!disabled}
           testID="otp-input-hidden"

--- a/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/OtpInput.types.ts
+++ b/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/OtpInput.types.ts
@@ -14,7 +14,7 @@ export interface IOtpInputProps {
   onFilled?: (text: string) => void;
   onFocus?: () => void;
   onBlur?: () => void;
-  blurOnFilled?: boolean;
+
   hideStick?: boolean;
   focusStickBlinkingDuration?: number;
   secureTextEntry?: boolean;

--- a/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
+++ b/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
@@ -19,7 +19,6 @@ export const useOtpInput = ({
   numberOfDigits = 6,
   disabled,
   autoFocus = true,
-  blurOnFilled,
   type,
   onFocus,
   onBlur,
@@ -28,7 +27,6 @@ export const useOtpInput = ({
   const [text, setText] = useState('');
   const [isFocused, setIsFocused] = useState(autoFocus);
   const inputRef = useRef<TextInput>(null);
-  const isIntentionalBlurRef = useRef(false);
   const focusedInputIndex = text.length;
   const placeholder = useMemo(
     () =>
@@ -58,10 +56,6 @@ export const useOtpInput = ({
     onTextChange?.(v);
     if (v.length === numberOfDigits) {
       onFilled?.(v);
-      if (blurOnFilled) {
-        isIntentionalBlurRef.current = true;
-        inputRef.current?.blur();
-      }
     }
   };
 
@@ -91,19 +85,14 @@ export const useOtpInput = ({
     // (e.g. due to FocusScope trap in Dialog, browser quirks, or cursor
     // interactions). When relatedTarget is null it means no other element
     // is receiving focus, so we auto-refocus to keep the input active.
-    // Skip auto-refocus for intentional blurs (e.g. blurOnFilled).
     if (!platformEnv.isNative) {
-      if (isIntentionalBlurRef.current) {
-        isIntentionalBlurRef.current = false;
-      } else {
-        const nativeEvent = (e as unknown as { nativeEvent?: FocusEvent })
-          ?.nativeEvent;
-        if (nativeEvent && !nativeEvent.relatedTarget) {
-          setTimeout(() => {
-            inputRef.current?.focus();
-          }, 0);
-          return;
-        }
+      const nativeEvent = (e as unknown as { nativeEvent?: FocusEvent })
+        ?.nativeEvent;
+      if (nativeEvent && !nativeEvent.relatedTarget) {
+        setTimeout(() => {
+          inputRef.current?.focus();
+        }, 0);
+        return;
       }
     }
     setIsFocused(false);

--- a/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
+++ b/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
@@ -2,8 +2,14 @@ import { useMemo, useRef, useState } from 'react';
 
 import { Keyboard } from 'react-native';
 
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
 import type { IOtpInputProps } from './OtpInput.types';
-import type { TextInput } from 'react-native';
+import type {
+  NativeSyntheticEvent,
+  TextInput,
+  TextInputFocusEventData,
+} from 'react-native';
 
 const regexMap = {
   alpha: /[^a-zA-Z]/,
@@ -80,7 +86,23 @@ export const useOtpInput = ({
     onFocus?.();
   };
 
-  const handleBlur = () => {
+  const handleBlur = (
+    e?: NativeSyntheticEvent<TextInputFocusEventData>,
+  ) => {
+    // On desktop/web, the hidden OTP input can lose focus unexpectedly
+    // (e.g. due to FocusScope trap in Dialog, browser quirks, or cursor
+    // interactions). When relatedTarget is null it means no other element
+    // is receiving focus, so we auto-refocus to keep the input active.
+    if (platformEnv.isDesktop || platformEnv.isRuntimeBrowser) {
+      const nativeEvent = (e as unknown as { nativeEvent?: FocusEvent })
+        ?.nativeEvent;
+      if (nativeEvent && !nativeEvent.relatedTarget) {
+        setTimeout(() => {
+          inputRef.current?.focus();
+        }, 0);
+        return;
+      }
+    }
     setIsFocused(false);
     onBlur?.();
   };

--- a/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
+++ b/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
@@ -85,8 +85,9 @@ export const useOtpInput = ({
     // interactions). When relatedTarget is null it means no other element
     // is receiving focus, so we auto-refocus to keep the input active.
     if (!platformEnv.isNative) {
-      const relatedTarget = (e as { nativeEvent?: { relatedTarget?: EventTarget | null } })
-        ?.nativeEvent?.relatedTarget;
+      const relatedTarget = (
+        e as { nativeEvent?: { relatedTarget?: EventTarget | null } }
+      )?.nativeEvent?.relatedTarget;
       if (e && !relatedTarget) {
         setTimeout(() => {
           inputRef.current?.focus();

--- a/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
+++ b/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
@@ -5,7 +5,7 @@ import { Keyboard } from 'react-native';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import type { IOtpInputProps } from './OtpInput.types';
-import type { TextInput } from 'react-native';
+import type { NativeSyntheticEvent, TargetedEvent, TextInput } from 'react-native';
 
 const regexMap = {
   alpha: /[^a-zA-Z]/,
@@ -78,16 +78,15 @@ export const useOtpInput = ({
     onFocus?.();
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const handleBlur = (e?: any) => {
+  const handleBlur = (e?: NativeSyntheticEvent<TargetedEvent>) => {
     // On desktop/web, the hidden OTP input can lose focus unexpectedly
     // (e.g. due to FocusScope trap in Dialog, browser quirks, or cursor
     // interactions). When relatedTarget is null it means no other element
     // is receiving focus, so we auto-refocus to keep the input active.
     if (!platformEnv.isNative) {
       const relatedTarget = (
-        e as { nativeEvent?: { relatedTarget?: EventTarget | null } }
-      )?.nativeEvent?.relatedTarget;
+        e?.nativeEvent as { relatedTarget?: EventTarget | null } | undefined
+      )?.relatedTarget;
       if (e && !relatedTarget) {
         setTimeout(() => {
           inputRef.current?.focus();

--- a/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
+++ b/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
@@ -5,7 +5,7 @@ import { Keyboard } from 'react-native';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import type { IOtpInputProps } from './OtpInput.types';
-import type { NativeSyntheticEvent, TextInput } from 'react-native';
+import type { NativeSyntheticEvent, TextInput, TextInputFocusEventData } from 'react-native';
 
 const regexMap = {
   alpha: /[^a-zA-Z]/,
@@ -73,13 +73,15 @@ export const useOtpInput = ({
     inputRef.current?.focus();
   };
 
-  const handleFocus = () => {
+  const handleFocus = (
+    _e?: NativeSyntheticEvent<TextInputFocusEventData>,
+  ) => {
     setIsFocused(true);
     onFocus?.();
   };
 
   const handleBlur = (
-    e?: NativeSyntheticEvent<Record<string, unknown>>,
+    e?: NativeSyntheticEvent<TextInputFocusEventData>,
   ) => {
     // On desktop/web, the hidden OTP input can lose focus unexpectedly
     // (e.g. due to FocusScope trap in Dialog, browser quirks, or cursor

--- a/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
+++ b/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
@@ -78,16 +78,16 @@ export const useOtpInput = ({
     onFocus?.();
   };
 
-  const handleBlur = (
-    e?: { nativeEvent?: { relatedTarget?: EventTarget | null } },
-  ) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handleBlur = (e?: any) => {
     // On desktop/web, the hidden OTP input can lose focus unexpectedly
     // (e.g. due to FocusScope trap in Dialog, browser quirks, or cursor
     // interactions). When relatedTarget is null it means no other element
     // is receiving focus, so we auto-refocus to keep the input active.
     if (!platformEnv.isNative) {
-      const nativeEvent = e?.nativeEvent;
-      if (nativeEvent && !nativeEvent.relatedTarget) {
+      const relatedTarget = (e as { nativeEvent?: { relatedTarget?: EventTarget | null } })
+        ?.nativeEvent?.relatedTarget;
+      if (e && !relatedTarget) {
         setTimeout(() => {
           inputRef.current?.focus();
         }, 0);

--- a/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
+++ b/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
@@ -5,7 +5,11 @@ import { Keyboard } from 'react-native';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import type { IOtpInputProps } from './OtpInput.types';
-import type { NativeSyntheticEvent, TargetedEvent, TextInput } from 'react-native';
+import type {
+  NativeSyntheticEvent,
+  TargetedEvent,
+  TextInput,
+} from 'react-native';
 
 const regexMap = {
   alpha: /[^a-zA-Z]/,

--- a/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
+++ b/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
@@ -5,11 +5,7 @@ import { Keyboard } from 'react-native';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import type { IOtpInputProps } from './OtpInput.types';
-import type {
-  NativeSyntheticEvent,
-  TextInput,
-  TextInputFocusEventData,
-} from 'react-native';
+import type { NativeSyntheticEvent, TextInput } from 'react-native';
 
 const regexMap = {
   alpha: /[^a-zA-Z]/,
@@ -87,7 +83,7 @@ export const useOtpInput = ({
   };
 
   const handleBlur = (
-    e?: NativeSyntheticEvent<TextInputFocusEventData>,
+    e?: NativeSyntheticEvent<Record<string, unknown>>,
   ) => {
     // On desktop/web, the hidden OTP input can lose focus unexpectedly
     // (e.g. due to FocusScope trap in Dialog, browser quirks, or cursor

--- a/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
+++ b/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
@@ -93,7 +93,7 @@ export const useOtpInput = ({
     // (e.g. due to FocusScope trap in Dialog, browser quirks, or cursor
     // interactions). When relatedTarget is null it means no other element
     // is receiving focus, so we auto-refocus to keep the input active.
-    if (platformEnv.isDesktop || platformEnv.isRuntimeBrowser) {
+    if (!platformEnv.isNative) {
       const nativeEvent = (e as unknown as { nativeEvent?: FocusEvent })
         ?.nativeEvent;
       if (nativeEvent && !nativeEvent.relatedTarget) {

--- a/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
+++ b/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
@@ -5,7 +5,7 @@ import { Keyboard } from 'react-native';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import type { IOtpInputProps } from './OtpInput.types';
-import type { NativeSyntheticEvent, TextInput, TextInputFocusEventData } from 'react-native';
+import type { TextInput } from 'react-native';
 
 const regexMap = {
   alpha: /[^a-zA-Z]/,
@@ -73,23 +73,20 @@ export const useOtpInput = ({
     inputRef.current?.focus();
   };
 
-  const handleFocus = (
-    _e?: NativeSyntheticEvent<TextInputFocusEventData>,
-  ) => {
+  const handleFocus = () => {
     setIsFocused(true);
     onFocus?.();
   };
 
   const handleBlur = (
-    e?: NativeSyntheticEvent<TextInputFocusEventData>,
+    e?: { nativeEvent?: { relatedTarget?: EventTarget | null } },
   ) => {
     // On desktop/web, the hidden OTP input can lose focus unexpectedly
     // (e.g. due to FocusScope trap in Dialog, browser quirks, or cursor
     // interactions). When relatedTarget is null it means no other element
     // is receiving focus, so we auto-refocus to keep the input active.
     if (!platformEnv.isNative) {
-      const nativeEvent = (e as unknown as { nativeEvent?: FocusEvent })
-        ?.nativeEvent;
+      const nativeEvent = e?.nativeEvent;
       if (nativeEvent && !nativeEvent.relatedTarget) {
         setTimeout(() => {
           inputRef.current?.focus();

--- a/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
+++ b/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/useOtpInput.ts
@@ -28,6 +28,7 @@ export const useOtpInput = ({
   const [text, setText] = useState('');
   const [isFocused, setIsFocused] = useState(autoFocus);
   const inputRef = useRef<TextInput>(null);
+  const isIntentionalBlurRef = useRef(false);
   const focusedInputIndex = text.length;
   const placeholder = useMemo(
     () =>
@@ -58,6 +59,7 @@ export const useOtpInput = ({
     if (v.length === numberOfDigits) {
       onFilled?.(v);
       if (blurOnFilled) {
+        isIntentionalBlurRef.current = true;
         inputRef.current?.blur();
       }
     }
@@ -89,14 +91,19 @@ export const useOtpInput = ({
     // (e.g. due to FocusScope trap in Dialog, browser quirks, or cursor
     // interactions). When relatedTarget is null it means no other element
     // is receiving focus, so we auto-refocus to keep the input active.
+    // Skip auto-refocus for intentional blurs (e.g. blurOnFilled).
     if (!platformEnv.isNative) {
-      const nativeEvent = (e as unknown as { nativeEvent?: FocusEvent })
-        ?.nativeEvent;
-      if (nativeEvent && !nativeEvent.relatedTarget) {
-        setTimeout(() => {
-          inputRef.current?.focus();
-        }, 0);
-        return;
+      if (isIntentionalBlurRef.current) {
+        isIntentionalBlurRef.current = false;
+      } else {
+        const nativeEvent = (e as unknown as { nativeEvent?: FocusEvent })
+          ?.nativeEvent;
+        if (nativeEvent && !nativeEvent.relatedTarget) {
+          setTimeout(() => {
+            inputRef.current?.focus();
+          }, 0);
+          return;
+        }
       }
     }
     setIsFocused(false);


### PR DESCRIPTION
## Summary
- On desktop, the hidden OTP input (`opacity: 0`) can intermittently lose focus due to browser quirks or cursor interactions
- Dialog's FocusScope trap then redirects focus to the container div instead of the input, causing the typed value to be lost when the user resumes typing
- Auto-refocus the hidden input when blur has no `relatedTarget` (no other element wants focus), only on non-native platforms
- Use stable Pressable keys (index-only) to prevent unnecessary DOM remounts
- Disable `autoComplete`/`textContentType` on desktop to avoid browser OTP autofill interference
- Remove unused `blurOnFilled` prop

## Test plan
- [ ] Desktop: Open OTP verification code dialog, type 3 digits, wait a few seconds, continue typing — input should not clear
- [ ] Desktop: Click confirm button after entering 6 digits — should work normally
- [ ] iOS/Android: OTP input behavior unchanged
- [ ] Web: OTP paste functionality still works

Fixes: https://onekeyhq.atlassian.net/browse/OK-51771