### PR TITLE
chore: remove unused serialport prebuilds per platform

### DIFF
--- a/apps/desktop/scripts/afterPack.js
+++ b/apps/desktop/scripts/afterPack.js
@@ -43,6 +43,8 @@ exports.default = async function fileOperation(context) {
   // The package bundles prebuilds for all platforms (android, linux, darwin,
   // win32) but each build only needs the matching one. Removing the rest
   // reduces package size and eliminates snap linter warnings.
+  // Arch enum: ia32=0, x64=1, armv7l=2, arm64=3, universal=4
+  const { arch } = context;
   const prebuildsBase = path.join(
     appOutDir,
     electronPlatformName === 'darwin' || electronPlatformName === 'mas'
@@ -51,18 +53,30 @@ exports.default = async function fileOperation(context) {
     'app.asar.unpacked/node_modules/@serialport/bindings-cpp/prebuilds',
   );
   if (fs.existsSync(prebuildsBase)) {
-    const keepPrefixes = {
-      darwin: ['darwin-'],
-      mas: ['darwin-'],
-      linux: ['linux-'],
-      win32: ['win32-'],
-    };
-    const keep = keepPrefixes[electronPlatformName] || [];
+    // Map (platform, arch) to the exact prebuild dir names to keep.
+    // darwin-x64+arm64 is a universal binary, always kept for darwin/mas.
+    // For universal builds, keep all dirs matching the platform.
+    const archSuffix = { 0: 'ia32', 1: 'x64', 2: 'arm', 3: 'arm64' };
+    const platformName =
+      electronPlatformName === 'mas' ? 'darwin' : electronPlatformName;
+    const isUniversal = arch === 4;
+
     for (const dir of fs.readdirSync(prebuildsBase)) {
-      if (!keep.some((prefix) => dir.startsWith(prefix))) {
-        const fullPath = path.join(prebuildsBase, dir);
-        fs.rmSync(fullPath, { recursive: true });
+      if (!dir.startsWith(`${platformName}-`)) {
+        // Wrong platform, always remove
+        fs.rmSync(path.join(prebuildsBase, dir), { recursive: true });
         console.log(`Removed unused prebuild: ${dir}`);
+      } else if (!isUniversal && archSuffix[arch]) {
+        // Right platform but check arch (skip for universal builds)
+        const dirArch = dir.slice(`${platformName}-`.length);
+        // darwin-x64+arm64 contains both arches, always keep
+        if (
+          !dirArch.includes(archSuffix[arch]) &&
+          !dirArch.includes('+')
+        ) {
+          fs.rmSync(path.join(prebuildsBase, dir), { recursive: true });
+          console.log(`Removed unused prebuild: ${dir}`);
+        }
       }
     }
   }

--- a/apps/desktop/scripts/afterPack.js
+++ b/apps/desktop/scripts/afterPack.js
@@ -39,12 +39,12 @@ exports.default = async function fileOperation(context) {
     console.log('remove file finish..');
   }
 
-  // Remove unused @serialport/bindings-cpp prebuilds for other platforms.
+  // Remove unused @serialport/bindings-cpp prebuilds for other OS platforms.
   // The package bundles prebuilds for all platforms (android, linux, darwin,
-  // win32) but each build only needs the matching one. Removing the rest
+  // win32) but each build only needs its own OS. Removing cross-OS prebuilds
   // reduces package size and eliminates snap linter warnings.
-  // Arch enum: ia32=0, x64=1, armv7l=2, arm64=3, universal=4
-  const { arch } = context;
+  // Keep all arch variants for the same OS to avoid breaking fallbacks
+  // (e.g., Windows ARM64 runs x64 binaries via WoW64 emulation).
   const prebuildsBase = path.join(
     appOutDir,
     electronPlatformName === 'darwin' || electronPlatformName === 'mas'
@@ -53,40 +53,12 @@ exports.default = async function fileOperation(context) {
     'app.asar.unpacked/node_modules/@serialport/bindings-cpp/prebuilds',
   );
   if (fs.existsSync(prebuildsBase)) {
-    // Map (platform, arch) to the exact prebuild dir names to keep.
-    // darwin-x64+arm64 is a universal binary, always kept for darwin/mas.
-    // For universal builds, keep all dirs matching the platform.
-    const archSuffix = { 0: 'ia32', 1: 'x64', 2: 'armv7l', 3: 'arm64' };
-    const platformName =
-      electronPlatformName === 'mas' ? 'darwin' : electronPlatformName;
-    const isUniversal = arch === 4;
-    const currentArch = archSuffix[arch];
-
-    // Windows ARM64 has no native prebuild; it runs x64 via WoW64 emulation.
-    // Keep win32-x64 as fallback.
-    const fallbackArch =
-      electronPlatformName === 'win32' && currentArch === 'arm64'
-        ? 'x64'
-        : null;
-
+    const platformPrefix =
+      electronPlatformName === 'mas' ? 'darwin-' : `${electronPlatformName}-`;
     for (const dir of fs.readdirSync(prebuildsBase)) {
-      if (!dir.startsWith(`${platformName}-`)) {
-        // Wrong platform, always remove
+      if (!dir.startsWith(platformPrefix)) {
         fs.rmSync(path.join(prebuildsBase, dir), { recursive: true });
         console.log(`Removed unused prebuild: ${dir}`);
-      } else if (!isUniversal && currentArch) {
-        // Right platform but check arch (skip for universal builds)
-        const dirArch = dir.slice(`${platformName}-`.length);
-        // Keep if: matches current arch, contains '+' (universal binary),
-        // or matches fallback arch (e.g., win32-x64 for win arm64)
-        const shouldKeep =
-          dirArch.includes(currentArch) ||
-          dirArch.includes('+') ||
-          (fallbackArch && dirArch.includes(fallbackArch));
-        if (!shouldKeep) {
-          fs.rmSync(path.join(prebuildsBase, dir), { recursive: true });
-          console.log(`Removed unused prebuild: ${dir}`);
-        }
       }
     }
   }

--- a/apps/desktop/scripts/afterPack.js
+++ b/apps/desktop/scripts/afterPack.js
@@ -39,6 +39,34 @@ exports.default = async function fileOperation(context) {
     console.log('remove file finish..');
   }
 
+  // Remove unused @serialport/bindings-cpp prebuilds for other platforms.
+  // The package bundles prebuilds for all platforms (android, linux, darwin,
+  // win32) but each build only needs the matching one. Removing the rest
+  // reduces package size and eliminates snap linter warnings.
+  const prebuildsBase = path.join(
+    appOutDir,
+    electronPlatformName === 'darwin' || electronPlatformName === 'mas'
+      ? `${appName}.app/Contents/Resources`
+      : 'resources',
+    'app.asar.unpacked/node_modules/@serialport/bindings-cpp/prebuilds',
+  );
+  if (fs.existsSync(prebuildsBase)) {
+    const keepPrefixes = {
+      darwin: ['darwin-'],
+      mas: ['darwin-'],
+      linux: ['linux-'],
+      win32: ['win32-'],
+    };
+    const keep = keepPrefixes[electronPlatformName] || [];
+    for (const dir of fs.readdirSync(prebuildsBase)) {
+      if (!keep.some((prefix) => dir.startsWith(prefix))) {
+        const fullPath = path.join(prebuildsBase, dir);
+        fs.rmSync(fullPath, { recursive: true });
+        console.log(`Removed unused prebuild: ${dir}`);
+      }
+    }
+  }
+
   if (electronPlatformName === 'darwin' || electronPlatformName === 'win32') {
     await context.packager.addElectronFuses(context, {
       version: FuseVersion.V1,

--- a/apps/desktop/scripts/afterPack.js
+++ b/apps/desktop/scripts/afterPack.js
@@ -56,24 +56,34 @@ exports.default = async function fileOperation(context) {
     // Map (platform, arch) to the exact prebuild dir names to keep.
     // darwin-x64+arm64 is a universal binary, always kept for darwin/mas.
     // For universal builds, keep all dirs matching the platform.
-    const archSuffix = { 0: 'ia32', 1: 'x64', 2: 'arm', 3: 'arm64' };
+    const archSuffix = { 0: 'ia32', 1: 'x64', 2: 'armv7l', 3: 'arm64' };
     const platformName =
       electronPlatformName === 'mas' ? 'darwin' : electronPlatformName;
     const isUniversal = arch === 4;
+    const currentArch = archSuffix[arch];
+
+    // Windows ARM64 has no native prebuild; it runs x64 via WoW64 emulation.
+    // Keep win32-x64 as fallback.
+    const fallbackArch =
+      electronPlatformName === 'win32' && currentArch === 'arm64'
+        ? 'x64'
+        : null;
 
     for (const dir of fs.readdirSync(prebuildsBase)) {
       if (!dir.startsWith(`${platformName}-`)) {
         // Wrong platform, always remove
         fs.rmSync(path.join(prebuildsBase, dir), { recursive: true });
         console.log(`Removed unused prebuild: ${dir}`);
-      } else if (!isUniversal && archSuffix[arch]) {
+      } else if (!isUniversal && currentArch) {
         // Right platform but check arch (skip for universal builds)
         const dirArch = dir.slice(`${platformName}-`.length);
-        // darwin-x64+arm64 contains both arches, always keep
-        if (
-          !dirArch.includes(archSuffix[arch]) &&
-          !dirArch.includes('+')
-        ) {
+        // Keep if: matches current arch, contains '+' (universal binary),
+        // or matches fallback arch (e.g., win32-x64 for win arm64)
+        const shouldKeep =
+          dirArch.includes(currentArch) ||
+          dirArch.includes('+') ||
+          (fallbackArch && dirArch.includes(fallbackArch));
+        if (!shouldKeep) {
           fs.rmSync(path.join(prebuildsBase, dir), { recursive: true });
           console.log(`Removed unused prebuild: ${dir}`);
         }


### PR DESCRIPTION
## Summary
- Remove unused `@serialport/bindings-cpp` prebuilds in `afterPack.js` based on target platform
- Each platform only keeps its matching prebuilds (e.g., macOS keeps `darwin-*`, Linux keeps `linux-*`)
- Reduces package size by ~600KB per build
- Eliminates snap linter warnings about unresolvable library dependencies on cross-platform binaries

## Platform prebuild mapping
| Build Target | Keeps | Removes |
|---|---|---|
| macOS (darwin/mas) | `darwin-x64+arm64` | android-*, linux-*, win32-* |
| Windows (win32) | `win32-x64`, `win32-ia32` | android-*, linux-*, darwin-* |
| Linux (snap) | `linux-*` | android-*, darwin-*, win32-* |

## Test plan
- [ ] Verify macOS build succeeds and hardware wallet USB works
- [ ] Verify Windows build succeeds and hardware wallet USB works
- [ ] Verify Linux snap build succeeds and snap linter warnings are gone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
