### PR TITLE
chore: remove cross-OS native prebuilds in afterPack

### DIFF
--- a/apps/desktop/scripts/afterPack.js
+++ b/apps/desktop/scripts/afterPack.js
@@ -112,9 +112,7 @@ exports.default = async function fileOperation(context) {
           (p) => prebuildName === p || prebuildName.startsWith(`${p}-`),
         );
         if (!isKnownPlatform) {
-          console.log(
-            `[prebuilds]   Skipped (non-standard): ${prebuildName}`,
-          );
+          console.log(`[prebuilds]   Skipped (non-standard): ${prebuildName}`);
           return;
         }
         if (

--- a/apps/desktop/scripts/afterPack.js
+++ b/apps/desktop/scripts/afterPack.js
@@ -39,6 +39,86 @@ exports.default = async function fileOperation(context) {
     console.log('remove file finish..');
   }
 
+  // Remove unused native prebuilds for other OS platforms.
+  // Many packages (serialport, noble, usb, bufferutil, etc.) bundle prebuilds
+  // for all platforms but each build only needs its own OS. Removing cross-OS
+  // prebuilds reduces package size and eliminates snap linter warnings.
+  // Keep all arch variants for the same OS to avoid breaking fallbacks
+  // (e.g., Windows ARM64 runs x64 binaries via WoW64 emulation).
+  // Only process standard "os-arch" named directories (e.g., "linux-x64",
+  // "darwin-x64+arm64"); skip non-standard names (e.g., "node", "apple").
+  const resourcesDir = path.join(
+    appOutDir,
+    electronPlatformName === 'darwin' || electronPlatformName === 'mas'
+      ? `${appName}.app/Contents/Resources`
+      : 'resources',
+  );
+  const unpackedDir = path.join(resourcesDir, 'app.asar.unpacked');
+  if (fs.existsSync(unpackedDir)) {
+    const platformPrefix =
+      electronPlatformName === 'mas' ? 'darwin' : electronPlatformName;
+    const knownPlatforms = ['android', 'darwin', 'linux', 'win32'];
+    let removedCount = 0;
+
+    const findPrebuildsRecursive = (dir) => {
+      let entries;
+      try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const fullPath = path.join(dir, entry.name);
+        if (entry.name === 'prebuilds') {
+          let prebuildEntries;
+          try {
+            prebuildEntries = fs.readdirSync(fullPath, {
+              withFileTypes: true,
+            });
+          } catch {
+            continue;
+          }
+          const pkgRelative = path.relative(unpackedDir, fullPath);
+          console.log(`[prebuilds] Scanning: ${pkgRelative}`);
+          for (const prebuild of prebuildEntries) {
+            if (!prebuild.isDirectory()) continue;
+            const prebuildName = prebuild.name;
+            // Only process dirs with known OS prefix (e.g., "linux-x64")
+            // Skip non-standard names like "node", "apple" to be safe
+            const isKnownPlatform = knownPlatforms.some(
+              (p) => prebuildName === p || prebuildName.startsWith(`${p}-`),
+            );
+            if (!isKnownPlatform) {
+              console.log(`[prebuilds]   Skipped (non-standard): ${prebuildName}`);
+              continue;
+            }
+            if (
+              prebuildName === platformPrefix ||
+              prebuildName.startsWith(`${platformPrefix}-`)
+            ) {
+              console.log(`[prebuilds]   Kept: ${prebuildName}`);
+              continue;
+            }
+            try {
+              fs.rmSync(path.join(fullPath, prebuildName), { recursive: true });
+              console.log(`[prebuilds]   Removed: ${prebuildName}`);
+              removedCount += 1;
+            } catch (err) {
+              console.warn(`[prebuilds]   Failed to remove ${prebuildName}: ${err.message}`);
+            }
+          }
+        } else if (entry.name !== '.cache' && entry.name !== '.git') {
+          findPrebuildsRecursive(fullPath);
+        }
+      }
+    };
+
+    console.log(`[prebuilds] Cleaning cross-OS prebuilds (keeping: ${platformPrefix}-*)`);
+    findPrebuildsRecursive(unpackedDir);
+    console.log(`[prebuilds] Done. Removed ${removedCount} directories.`);
+  }
+
   if (electronPlatformName === 'darwin' || electronPlatformName === 'win32') {
     await context.packager.addElectronFuses(context, {
       version: FuseVersion.V1,

--- a/apps/desktop/scripts/afterPack.js
+++ b/apps/desktop/scripts/afterPack.js
@@ -60,6 +60,7 @@ exports.default = async function fileOperation(context) {
     const knownPlatforms = ['android', 'darwin', 'linux', 'win32'];
     let removedCount = 0;
 
+    // cspell:ignore prebuilds
     const findPrebuildsRecursive = (dir) => {
       let entries;
       try {
@@ -68,53 +69,66 @@ exports.default = async function fileOperation(context) {
         return;
       }
       for (const entry of entries) {
-        if (!entry.isDirectory()) continue;
-        const fullPath = path.join(dir, entry.name);
-        if (entry.name === 'prebuilds') {
-          let prebuildEntries;
-          try {
-            prebuildEntries = fs.readdirSync(fullPath, {
-              withFileTypes: true,
-            });
-          } catch {
-            continue;
+        if (entry.isDirectory()) {
+          const fullPath = path.join(dir, entry.name);
+          if (entry.name === 'prebuilds') {
+            processPrebuildsDir(fullPath);
+          } else if (entry.name !== '.cache' && entry.name !== '.git') {
+            findPrebuildsRecursive(fullPath);
           }
-          const pkgRelative = path.relative(unpackedDir, fullPath);
-          console.log(`[prebuilds] Scanning: ${pkgRelative}`);
-          for (const prebuild of prebuildEntries) {
-            if (!prebuild.isDirectory()) continue;
-            const prebuildName = prebuild.name;
-            // Only process dirs with known OS prefix (e.g., "linux-x64")
-            // Skip non-standard names like "node", "apple" to be safe
-            const isKnownPlatform = knownPlatforms.some(
-              (p) => prebuildName === p || prebuildName.startsWith(`${p}-`),
-            );
-            if (!isKnownPlatform) {
-              console.log(`[prebuilds]   Skipped (non-standard): ${prebuildName}`);
-              continue;
-            }
-            if (
-              prebuildName === platformPrefix ||
-              prebuildName.startsWith(`${platformPrefix}-`)
-            ) {
-              console.log(`[prebuilds]   Kept: ${prebuildName}`);
-              continue;
-            }
-            try {
-              fs.rmSync(path.join(fullPath, prebuildName), { recursive: true });
-              console.log(`[prebuilds]   Removed: ${prebuildName}`);
-              removedCount += 1;
-            } catch (err) {
-              console.warn(`[prebuilds]   Failed to remove ${prebuildName}: ${err.message}`);
-            }
-          }
-        } else if (entry.name !== '.cache' && entry.name !== '.git') {
-          findPrebuildsRecursive(fullPath);
         }
       }
     };
 
-    console.log(`[prebuilds] Cleaning cross-OS prebuilds (keeping: ${platformPrefix}-*)`);
+    const processPrebuildsDir = (fullPath) => {
+      let prebuildEntries;
+      try {
+        prebuildEntries = fs.readdirSync(fullPath, {
+          withFileTypes: true,
+        });
+      } catch {
+        return;
+      }
+      const pkgRelative = path.relative(unpackedDir, fullPath);
+      console.log(`[prebuilds] Scanning: ${pkgRelative}`);
+      for (const prebuild of prebuildEntries) {
+        if (prebuild.isDirectory()) {
+          processPrebuildEntry(fullPath, prebuild.name);
+        }
+      }
+    };
+
+    const processPrebuildEntry = (parentDir, prebuildName) => {
+      // Only process dirs with known OS prefix (e.g., "linux-x64")
+      // Skip non-standard names like "node", "apple" to be safe
+      const isKnownPlatform = knownPlatforms.some(
+        (p) => prebuildName === p || prebuildName.startsWith(`${p}-`),
+      );
+      if (!isKnownPlatform) {
+        console.log(`[prebuilds]   Skipped (non-standard): ${prebuildName}`);
+        return;
+      }
+      if (
+        prebuildName === platformPrefix ||
+        prebuildName.startsWith(`${platformPrefix}-`)
+      ) {
+        console.log(`[prebuilds]   Kept: ${prebuildName}`);
+        return;
+      }
+      try {
+        fs.rmSync(path.join(parentDir, prebuildName), { recursive: true });
+        console.log(`[prebuilds]   Removed: ${prebuildName}`);
+        removedCount += 1;
+      } catch (err) {
+        console.warn(
+          `[prebuilds]   Failed to remove ${prebuildName}: ${err.message}`,
+        );
+      }
+    };
+
+    console.log(
+      `[prebuilds] Cleaning cross-OS prebuilds (keeping: ${platformPrefix}-*)`,
+    );
     findPrebuildsRecursive(unpackedDir);
     console.log(`[prebuilds] Done. Removed ${removedCount} directories.`);
   }

--- a/apps/desktop/scripts/afterPack.js
+++ b/apps/desktop/scripts/afterPack.js
@@ -47,90 +47,104 @@ exports.default = async function fileOperation(context) {
   // (e.g., Windows ARM64 runs x64 binaries via WoW64 emulation).
   // Only process standard "os-arch" named directories (e.g., "linux-x64",
   // "darwin-x64+arm64"); skip non-standard names (e.g., "node", "apple").
-  const resourcesDir = path.join(
-    appOutDir,
-    electronPlatformName === 'darwin' || electronPlatformName === 'mas'
-      ? `${appName}.app/Contents/Resources`
-      : 'resources',
-  );
-  const unpackedDir = path.join(resourcesDir, 'app.asar.unpacked');
-  if (fs.existsSync(unpackedDir)) {
-    const platformPrefix =
-      electronPlatformName === 'mas' ? 'darwin' : electronPlatformName;
-    const knownPlatforms = ['android', 'darwin', 'linux', 'win32'];
-    let removedCount = 0;
+  //
+  // Skip cleanup for macOS universal temp directories (e.g. mac-universal-x64-temp).
+  // @electron/universal merges x64-temp and arm64-temp by comparing asar contents.
+  // If we delete prebuilds from the unpacked dir but the asar index still
+  // references them, the merge fails with ENOENT.
+  const isUniversalTemp = appOutDir.includes('-universal-');
+  if (!isUniversalTemp) {
+    const resourcesDir = path.join(
+      appOutDir,
+      electronPlatformName === 'darwin' || electronPlatformName === 'mas'
+        ? `${appName}.app/Contents/Resources`
+        : 'resources',
+    );
+    const unpackedDir = path.join(resourcesDir, 'app.asar.unpacked');
+    if (fs.existsSync(unpackedDir)) {
+      const platformPrefix =
+        electronPlatformName === 'mas' ? 'darwin' : electronPlatformName;
+      const knownPlatforms = ['android', 'darwin', 'linux', 'win32'];
+      let removedCount = 0;
 
-    // cspell:ignore prebuilds
-    const findPrebuildsRecursive = (dir) => {
-      let entries;
-      try {
-        entries = fs.readdirSync(dir, { withFileTypes: true });
-      } catch {
-        return;
-      }
-      for (const entry of entries) {
-        if (entry.isDirectory()) {
-          const fullPath = path.join(dir, entry.name);
-          if (entry.name === 'prebuilds') {
-            processPrebuildsDir(fullPath);
-          } else if (entry.name !== '.cache' && entry.name !== '.git') {
-            findPrebuildsRecursive(fullPath);
+      // cspell:ignore prebuilds
+      const findPrebuildsRecursive = (dir) => {
+        let entries;
+        try {
+          entries = fs.readdirSync(dir, { withFileTypes: true });
+        } catch {
+          return;
+        }
+        for (const entry of entries) {
+          if (entry.isDirectory()) {
+            const fullPath = path.join(dir, entry.name);
+            if (entry.name === 'prebuilds') {
+              processPrebuildsDir(fullPath);
+            } else if (entry.name !== '.cache' && entry.name !== '.git') {
+              findPrebuildsRecursive(fullPath);
+            }
           }
         }
-      }
-    };
+      };
 
-    const processPrebuildsDir = (fullPath) => {
-      let prebuildEntries;
-      try {
-        prebuildEntries = fs.readdirSync(fullPath, {
-          withFileTypes: true,
-        });
-      } catch {
-        return;
-      }
-      const pkgRelative = path.relative(unpackedDir, fullPath);
-      console.log(`[prebuilds] Scanning: ${pkgRelative}`);
-      for (const prebuild of prebuildEntries) {
-        if (prebuild.isDirectory()) {
-          processPrebuildEntry(fullPath, prebuild.name);
+      const processPrebuildsDir = (fullPath) => {
+        let prebuildEntries;
+        try {
+          prebuildEntries = fs.readdirSync(fullPath, {
+            withFileTypes: true,
+          });
+        } catch {
+          return;
         }
-      }
-    };
+        const pkgRelative = path.relative(unpackedDir, fullPath);
+        console.log(`[prebuilds] Scanning: ${pkgRelative}`);
+        for (const prebuild of prebuildEntries) {
+          if (prebuild.isDirectory()) {
+            processPrebuildEntry(fullPath, prebuild.name);
+          }
+        }
+      };
 
-    const processPrebuildEntry = (parentDir, prebuildName) => {
-      // Only process dirs with known OS prefix (e.g., "linux-x64")
-      // Skip non-standard names like "node", "apple" to be safe
-      const isKnownPlatform = knownPlatforms.some(
-        (p) => prebuildName === p || prebuildName.startsWith(`${p}-`),
-      );
-      if (!isKnownPlatform) {
-        console.log(`[prebuilds]   Skipped (non-standard): ${prebuildName}`);
-        return;
-      }
-      if (
-        prebuildName === platformPrefix ||
-        prebuildName.startsWith(`${platformPrefix}-`)
-      ) {
-        console.log(`[prebuilds]   Kept: ${prebuildName}`);
-        return;
-      }
-      try {
-        fs.rmSync(path.join(parentDir, prebuildName), { recursive: true });
-        console.log(`[prebuilds]   Removed: ${prebuildName}`);
-        removedCount += 1;
-      } catch (err) {
-        console.warn(
-          `[prebuilds]   Failed to remove ${prebuildName}: ${err.message}`,
+      const processPrebuildEntry = (parentDir, prebuildName) => {
+        // Only process dirs with known OS prefix (e.g., "linux-x64")
+        // Skip non-standard names like "node", "apple" to be safe
+        const isKnownPlatform = knownPlatforms.some(
+          (p) => prebuildName === p || prebuildName.startsWith(`${p}-`),
         );
-      }
-    };
+        if (!isKnownPlatform) {
+          console.log(
+            `[prebuilds]   Skipped (non-standard): ${prebuildName}`,
+          );
+          return;
+        }
+        if (
+          prebuildName === platformPrefix ||
+          prebuildName.startsWith(`${platformPrefix}-`)
+        ) {
+          console.log(`[prebuilds]   Kept: ${prebuildName}`);
+          return;
+        }
+        try {
+          fs.rmSync(path.join(parentDir, prebuildName), { recursive: true });
+          console.log(`[prebuilds]   Removed: ${prebuildName}`);
+          removedCount += 1;
+        } catch (err) {
+          console.warn(
+            `[prebuilds]   Failed to remove ${prebuildName}: ${err.message}`,
+          );
+        }
+      };
 
+      console.log(
+        `[prebuilds] Cleaning cross-OS prebuilds (keeping: ${platformPrefix}-*)`,
+      );
+      findPrebuildsRecursive(unpackedDir);
+      console.log(`[prebuilds] Done. Removed ${removedCount} directories.`);
+    }
+  } else {
     console.log(
-      `[prebuilds] Cleaning cross-OS prebuilds (keeping: ${platformPrefix}-*)`,
+      `[prebuilds] Skipping cleanup for universal temp build: ${appOutDir}`,
     );
-    findPrebuildsRecursive(unpackedDir);
-    console.log(`[prebuilds] Done. Removed ${removedCount} directories.`);
   }
 
   if (electronPlatformName === 'darwin' || electronPlatformName === 'win32') {


### PR DESCRIPTION
## Summary

Many native packages bundle prebuilds for **all** OS platforms, but each desktop build only needs its own OS. Add a generic `afterPack` step that recursively finds all `prebuilds/` directories under `app.asar.unpacked/` and removes cross-OS entries.

All arch variants for the same OS are kept to avoid breaking fallbacks (e.g., Windows ARM64 runs x64 binaries via WoW64 emulation). Directories matching the exact platform name (e.g., `android`, `apple`, `node` for Realm) are also handled.

## Affected packages

| Package | Prebuilds bundled | Removed per build |
|---|---|---|
| `@serialport/bindings-cpp` | android-arm, android-arm64, darwin-x64+arm64, linux-arm, linux-arm64, linux-x64, win32-ia32, win32-x64 | 6 of 8 |
| `@stoprocent/noble` | android-arm, android-arm64, darwin-x64+arm64, linux-arm, linux-arm64, linux-x64, win32-ia32, win32-x64 | 6 of 8 |
| `@stoprocent/bluetooth-hci-socket` | android-arm, android-arm64, darwin-x64+arm64, linux-arm, linux-arm64, linux-x64, win32-ia32, win32-x64 | 6 of 8 |
| `usb` | android-arm, android-arm64, darwin-x64+arm64, linux-arm, linux-arm64, linux-ia32, linux-x64, win32-arm64, win32-ia32, win32-x64 | 7 of 10 |
| `bufferutil` | darwin-x64+arm64, linux-x64, win32-ia32, win32-x64 | 2 of 4 |
| `utf-8-validate` | darwin-x64+arm64, linux-x64, win32-ia32, win32-x64 | 2 of 4 |
| `secp256k1` | darwin-arm64, linux-x64, win32-x64 | 2 of 3 |
| `blake-hash` | darwin-x64, linux-x64, win32-x64 | 2 of 3 |
| `keccak` | darwin-x64, linux-x64, win32-x64 | 2 of 3 |
| `realm` | android, apple, node | 2 of 3 |

## Per-platform keep/remove

| Build Platform | Keeps (prefix) | Removes |
|---|---|---|
| macOS (darwin/mas) | `darwin-*`, `darwin`, `apple` | android-\*, linux-\*, win32-\*, node |
| Windows (win32) | `win32-*` | android-\*, darwin-\*, linux-\*, apple, node |
| Linux (snap/AppImage) | `linux-*` | android-\*, darwin-\*, win32-\*, apple, node |

## Test plan
- [ ] Verify macOS build succeeds and hardware wallet USB/BLE works
- [ ] Verify Windows build succeeds and hardware wallet USB works
- [ ] Verify Linux snap build succeeds and linter warnings about cross-platform prebuilds are gone