### PR TITLE
fix(market): improve watchlist drag sort UX across desktop and mobile

### DIFF
--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
-  - AutoSizeInput (1.1.38):
+  - AutoSizeInput (1.1.36):
     - boost
     - DoubleConversion
     - fast_float
@@ -39,7 +39,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - BackgroundThread (1.1.38):
+  - BackgroundThread (1.1.36):
     - boost
     - DoubleConversion
     - fast_float
@@ -101,7 +101,7 @@ PODS:
     - ExpoModulesCore
     - SPAlert (~> 4.2)
     - SPIndicator (~> 1.6)
-  - CloudKitModule (1.1.38):
+  - CloudKitModule (1.1.36):
     - boost
     - DoubleConversion
     - fast_float
@@ -330,7 +330,7 @@ PODS:
   - JPushRN (3.2.1):
     - React
   - JuiceboxSdk (0.3.2)
-  - KeychainModule (1.1.38):
+  - KeychainModule (1.1.36):
     - boost
     - DoubleConversion
     - fast_float
@@ -2391,7 +2391,7 @@ PODS:
     - React-Core
   - react-native-network-info (5.2.2):
     - React
-  - react-native-pager-view (1.1.38):
+  - react-native-pager-view (1.1.36):
     - boost
     - DoubleConversion
     - fast_float
@@ -2594,7 +2594,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-tab-view (1.1.38):
+  - react-native-tab-view (1.1.36):
     - boost
     - DoubleConversion
     - fast_float
@@ -2612,7 +2612,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-tab-view/common (= 1.1.38)
+    - react-native-tab-view/common (= 1.1.36)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -2623,7 +2623,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-tab-view/common (1.1.38):
+  - react-native-tab-view/common (1.1.36):
     - boost
     - DoubleConversion
     - fast_float
@@ -3303,7 +3303,7 @@ PODS:
     - React-perflogger (= 0.81.5)
     - React-utils (= 0.81.5)
     - SocketRocket
-  - ReactNativeAppUpdate (1.1.38):
+  - ReactNativeAppUpdate (1.1.36):
     - boost
     - DoubleConversion
     - fast_float
@@ -3334,7 +3334,7 @@ PODS:
     - ReactNativeNativeLogger
     - SocketRocket
     - Yoga
-  - ReactNativeBundleUpdate (1.1.38):
+  - ReactNativeBundleUpdate (1.1.36):
     - boost
     - DoubleConversion
     - fast_float
@@ -3395,7 +3395,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ReactNativeCheckBiometricAuthChanged (1.1.38):
+  - ReactNativeCheckBiometricAuthChanged (1.1.36):
     - boost
     - DoubleConversion
     - fast_float
@@ -3426,7 +3426,7 @@ PODS:
     - ReactNativeNativeLogger
     - SocketRocket
     - Yoga
-  - ReactNativeDeviceUtils (1.1.38):
+  - ReactNativeDeviceUtils (1.1.36):
     - boost
     - DoubleConversion
     - fast_float
@@ -3485,7 +3485,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ReactNativeGetRandomValues (1.1.38):
+  - ReactNativeGetRandomValues (1.1.36):
     - boost
     - DoubleConversion
     - fast_float
@@ -3516,7 +3516,7 @@ PODS:
     - ReactNativeNativeLogger
     - SocketRocket
     - Yoga
-  - ReactNativeLiteCard (1.1.38):
+  - ReactNativeLiteCard (1.1.36):
     - boost
     - DoubleConversion
     - fast_float
@@ -3545,7 +3545,7 @@ PODS:
     - ReactNativeNativeLogger
     - SocketRocket
     - Yoga
-  - ReactNativeNativeLogger (1.1.38):
+  - ReactNativeNativeLogger (1.1.36):
     - boost
     - CocoaLumberjack/Swift (~> 3.8)
     - DoubleConversion
@@ -3578,7 +3578,7 @@ PODS:
     - Yoga
   - ReactNativePasskeys (0.3.3):
     - ExpoModulesCore
-  - ReactNativePerfMemory (1.1.38):
+  - ReactNativePerfMemory (1.1.36):
     - boost
     - DoubleConversion
     - fast_float
@@ -3609,7 +3609,7 @@ PODS:
     - ReactNativeNativeLogger
     - SocketRocket
     - Yoga
-  - ReactNativeSplashScreen (1.1.38):
+  - ReactNativeSplashScreen (1.1.36):
     - boost
     - DoubleConversion
     - fast_float
@@ -4218,36 +4218,6 @@ PODS:
   - RNZipArchive/Core (7.0.2):
     - React-Core
     - SSZipArchive (~> 2.5.5)
-  - ScrollGuard (0.1.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - NitroModules
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-callinvoker
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
   - SDWebImage (5.21.7):
     - SDWebImage/Core (= 5.21.7)
   - SDWebImage/Core (5.21.7)
@@ -4257,7 +4227,7 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
   - Sentry/HybridSDK (8.56.2)
-  - Skeleton (1.1.38):
+  - Skeleton (1.1.36):
     - boost
     - DoubleConversion
     - fast_float
@@ -4497,7 +4467,6 @@ DEPENDENCIES:
   - RNSVG (from `../../../node_modules/react-native-svg`)
   - RNWorklets (from `../../../node_modules/react-native-worklets`)
   - RNZipArchive (from `../../../node_modules/react-native-zip-archive`)
-  - "ScrollGuard (from `../../../node_modules/@onekeyfe/react-native-scroll-guard`)"
   - "Skeleton (from `../../../node_modules/@onekeyfe/react-native-skeleton`)"
   - "SniConnect (from `../../../node_modules/@onekeyfe/react-native-sni-connect`)"
   - SocketRocket (~> 0.7.1)
@@ -4866,8 +4835,6 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native-worklets"
   RNZipArchive:
     :path: "../../../node_modules/react-native-zip-archive"
-  ScrollGuard:
-    :path: "../../../node_modules/@onekeyfe/react-native-scroll-guard"
   Skeleton:
     :path: "../../../node_modules/@onekeyfe/react-native-skeleton"
   SniConnect:
@@ -4878,12 +4845,12 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
-  AutoSizeInput: 2564539d9ae8c2e72049f5ccc3c86317f5f456dc
-  BackgroundThread: 33a96f8a8e17028cedf03212bca104205d8f72f5
+  AutoSizeInput: 3d7408a6842a739eac7304f795517ccb2cce9011
+  BackgroundThread: bed4bd4c0236fcfe21bc9c90ff6af1dced23e0dd
   BleUtils: 0fd18e5fd2732c89771dc79941c7320ac9c42015
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   Burnt: e3a3397e26172fca31a59bb27421475a58068836
-  CloudKitModule: ed0c22ead8cf8a90e8384b1e3de85e5f1624bb7c
+  CloudKitModule: 56096c586a0443310818490e5ee5bf3d485566b1
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CocoaLumberjack: 5644158777912b7de7469fa881f8a3f259c2512a
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
@@ -4933,7 +4900,7 @@ SPEC CHECKSUMS:
   JCoreRN: d985de509185b381c177fde4bb6bfc686089fdbd
   JPushRN: 807bc962b2f25860e5c0caa5fcb7b4910572b890
   JuiceboxSdk: b2222491ce92b263694c217ea202a54b66c5ec5f
-  KeychainModule: 9b2144ee99bf6542938158708f6b17f6792b48c7
+  KeychainModule: 2c6f9b75d67dd2d4baec2dc1775bf652ffb504b7
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
   lottie-react-native: 86fa7488b1476563f41071244aa73d5b738faf19
@@ -4988,12 +4955,12 @@ SPEC CHECKSUMS:
   react-native-keyboard-controller: dbf568b5d029cdc5b26667a7c2323b160c25dc00
   react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
   react-native-network-info: 703d4b16ff0ff6f03127728348251bf5f12b823a
-  react-native-pager-view: 78054710783390f012630831771cb0dfada91297
+  react-native-pager-view: 20b1375927239c13c10d5657240ae468eb6c033b
   react-native-performance-stats: 8820079bb3a8127f798f0e201d0ca1ab65735410
   react-native-ping: 589027e929c300b0b68cc5c34105f33610177055
   react-native-safe-area-context: c00143b4823773bba23f2f19f85663ae89ceb460
   react-native-slider: 663776e5683e257de8df8091abc2d93ff6ec67db
-  react-native-tab-view: b8f2e7f07f52ab877b14561cd5781d4eb3a55f93
+  react-native-tab-view: 86f1c55409c6dfce876f62b6581624914c817b4a
   react-native-tcp-socket: 120072c8020262032773f80f0daaf3964aaa08a1
   react-native-video: 7b821291837d8ba7b9d7574bfeb0cd651e910141
   react-native-view-shot: 6c008e58f4720de58370848201c5d4a082c6d4ca
@@ -5029,18 +4996,18 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 1bcd3527ac0390a1c898c114f81ff954be35ed79
   ReactCodegen: 0c47bcad3576258ef1a91e2ec1fd43afae72e85f
   ReactCommon: 5f0e5c09a64a2717215dd84380e1a747810406f2
-  ReactNativeAppUpdate: f4eebe90fc7c4ba862b77e465dea65dbf714d560
-  ReactNativeBundleUpdate: 64d0320738605be4955ef161abfceec4076cfb7a
+  ReactNativeAppUpdate: 341306dd1bbf12e8ae04f27aaddfad91dc7a20a4
+  ReactNativeBundleUpdate: 5b7d15af0e8c4252913ea02a11b2e68262c23aa3
   ReactNativeCameraKit: 84894fc476300e5d3b9f4e34f55ff75050ec5050
-  ReactNativeCheckBiometricAuthChanged: db83279cee4c84e51677a4f9eb11843cac0a0ce7
-  ReactNativeDeviceUtils: 6d066f1c99574038a4e5ebc83b308b59bbbcdfc2
+  ReactNativeCheckBiometricAuthChanged: 244ef2cb8e687694de029e3bfa1b9ee9c71fe03c
+  ReactNativeDeviceUtils: 8f105f1c5c2b7144fdda64d73a87159b7aab184a
   ReactNativeFs: fa4d6c721fedd16abb5a7eb5c591303f147677b5
-  ReactNativeGetRandomValues: 49d04b68a9015707137f604fe01668e674a2fbee
-  ReactNativeLiteCard: 986808b186aa40b663e546596f3cf2a62fc7f96c
-  ReactNativeNativeLogger: bb57d8b5d163a9d24fdcce9aff034005a110ae7e
+  ReactNativeGetRandomValues: 3d249a8a49b3a205fe866a648699c16f0299d3e7
+  ReactNativeLiteCard: dd3ef291344a7f2805f6c764be6b8c64f9cd59ba
+  ReactNativeNativeLogger: 71a7421e0ae451fa23b015aba916ea889fe5c427
   ReactNativePasskeys: 9e950e8cbf0e7d6aad9df4dcd21cee0efeb4e5cd
-  ReactNativePerfMemory: e76253b04f13fd83651fa397da8236f9fb76e123
-  ReactNativeSplashScreen: acb602e800bc55e9c3a24835fd0b61102548951e
+  ReactNativePerfMemory: 07e7e5ed5a6cddc5759654fd38a15ba5a2357f7f
+  ReactNativeSplashScreen: f5e8c4076c9bd782cdff9fd8b43b2a6a78d07ede
   RealmJS: 1c37c6bdfe060f4caa0f9175aa0eedb962622ee1
   RestartNewArch: 5a57520ab7d9131d21edf0e17ecf8116f8ab5b72
   RevenueCat: 7e1d0768fb287c9983173c9b28e39ccbeeb828a9
@@ -5059,12 +5026,11 @@ SPEC CHECKSUMS:
   RNSVG: d260beec1775108e1bd065a0ed666ff2c5565158
   RNWorklets: 8068c8af4b241eb2c19221310729e4c440bee023
   RNZipArchive: 4304f5100eab004eeb7349adc51997b3a28deb76
-  ScrollGuard: 53c1295e6188f207e849fbc0e58bfac4313ef526
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   Sentry: b53951377b78e21a734f5dc8318e333dbfc682d7
-  Skeleton: 994e7dc82c89588ae38db3287d4a99e83b2df25b
+  Skeleton: a42e021809e44c91b327a1335ebbb11f0384a8f0
   SniConnect: c92bce3bb3204c4cff031c0badb7aefaebee8f04
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SPAlert: 735da1f16a887e294719217572ce1f936d8c8782

--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
-  - AutoSizeInput (1.1.36):
+  - AutoSizeInput (1.1.38):
     - boost
     - DoubleConversion
     - fast_float
@@ -39,7 +39,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - BackgroundThread (1.1.36):
+  - BackgroundThread (1.1.38):
     - boost
     - DoubleConversion
     - fast_float
@@ -101,7 +101,7 @@ PODS:
     - ExpoModulesCore
     - SPAlert (~> 4.2)
     - SPIndicator (~> 1.6)
-  - CloudKitModule (1.1.36):
+  - CloudKitModule (1.1.38):
     - boost
     - DoubleConversion
     - fast_float
@@ -330,7 +330,7 @@ PODS:
   - JPushRN (3.2.1):
     - React
   - JuiceboxSdk (0.3.2)
-  - KeychainModule (1.1.36):
+  - KeychainModule (1.1.38):
     - boost
     - DoubleConversion
     - fast_float
@@ -2391,7 +2391,7 @@ PODS:
     - React-Core
   - react-native-network-info (5.2.2):
     - React
-  - react-native-pager-view (1.1.36):
+  - react-native-pager-view (1.1.38):
     - boost
     - DoubleConversion
     - fast_float
@@ -2594,7 +2594,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-tab-view (1.1.36):
+  - react-native-tab-view (1.1.38):
     - boost
     - DoubleConversion
     - fast_float
@@ -2612,7 +2612,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-tab-view/common (= 1.1.36)
+    - react-native-tab-view/common (= 1.1.38)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -2623,7 +2623,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-tab-view/common (1.1.36):
+  - react-native-tab-view/common (1.1.38):
     - boost
     - DoubleConversion
     - fast_float
@@ -3303,7 +3303,7 @@ PODS:
     - React-perflogger (= 0.81.5)
     - React-utils (= 0.81.5)
     - SocketRocket
-  - ReactNativeAppUpdate (1.1.36):
+  - ReactNativeAppUpdate (1.1.38):
     - boost
     - DoubleConversion
     - fast_float
@@ -3334,7 +3334,7 @@ PODS:
     - ReactNativeNativeLogger
     - SocketRocket
     - Yoga
-  - ReactNativeBundleUpdate (1.1.36):
+  - ReactNativeBundleUpdate (1.1.38):
     - boost
     - DoubleConversion
     - fast_float
@@ -3395,7 +3395,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ReactNativeCheckBiometricAuthChanged (1.1.36):
+  - ReactNativeCheckBiometricAuthChanged (1.1.38):
     - boost
     - DoubleConversion
     - fast_float
@@ -3426,7 +3426,7 @@ PODS:
     - ReactNativeNativeLogger
     - SocketRocket
     - Yoga
-  - ReactNativeDeviceUtils (1.1.36):
+  - ReactNativeDeviceUtils (1.1.38):
     - boost
     - DoubleConversion
     - fast_float
@@ -3485,7 +3485,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ReactNativeGetRandomValues (1.1.36):
+  - ReactNativeGetRandomValues (1.1.38):
     - boost
     - DoubleConversion
     - fast_float
@@ -3516,7 +3516,7 @@ PODS:
     - ReactNativeNativeLogger
     - SocketRocket
     - Yoga
-  - ReactNativeLiteCard (1.1.36):
+  - ReactNativeLiteCard (1.1.38):
     - boost
     - DoubleConversion
     - fast_float
@@ -3545,7 +3545,7 @@ PODS:
     - ReactNativeNativeLogger
     - SocketRocket
     - Yoga
-  - ReactNativeNativeLogger (1.1.36):
+  - ReactNativeNativeLogger (1.1.38):
     - boost
     - CocoaLumberjack/Swift (~> 3.8)
     - DoubleConversion
@@ -3578,7 +3578,7 @@ PODS:
     - Yoga
   - ReactNativePasskeys (0.3.3):
     - ExpoModulesCore
-  - ReactNativePerfMemory (1.1.36):
+  - ReactNativePerfMemory (1.1.38):
     - boost
     - DoubleConversion
     - fast_float
@@ -3609,7 +3609,7 @@ PODS:
     - ReactNativeNativeLogger
     - SocketRocket
     - Yoga
-  - ReactNativeSplashScreen (1.1.36):
+  - ReactNativeSplashScreen (1.1.38):
     - boost
     - DoubleConversion
     - fast_float
@@ -4218,6 +4218,36 @@ PODS:
   - RNZipArchive/Core (7.0.2):
     - React-Core
     - SSZipArchive (~> 2.5.5)
+  - ScrollGuard (0.1.1):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - NitroModules
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-callinvoker
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - SDWebImage (5.21.7):
     - SDWebImage/Core (= 5.21.7)
   - SDWebImage/Core (5.21.7)
@@ -4227,7 +4257,7 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
   - Sentry/HybridSDK (8.56.2)
-  - Skeleton (1.1.36):
+  - Skeleton (1.1.38):
     - boost
     - DoubleConversion
     - fast_float
@@ -4467,6 +4497,7 @@ DEPENDENCIES:
   - RNSVG (from `../../../node_modules/react-native-svg`)
   - RNWorklets (from `../../../node_modules/react-native-worklets`)
   - RNZipArchive (from `../../../node_modules/react-native-zip-archive`)
+  - "ScrollGuard (from `../../../node_modules/@onekeyfe/react-native-scroll-guard`)"
   - "Skeleton (from `../../../node_modules/@onekeyfe/react-native-skeleton`)"
   - "SniConnect (from `../../../node_modules/@onekeyfe/react-native-sni-connect`)"
   - SocketRocket (~> 0.7.1)
@@ -4835,6 +4866,8 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native-worklets"
   RNZipArchive:
     :path: "../../../node_modules/react-native-zip-archive"
+  ScrollGuard:
+    :path: "../../../node_modules/@onekeyfe/react-native-scroll-guard"
   Skeleton:
     :path: "../../../node_modules/@onekeyfe/react-native-skeleton"
   SniConnect:
@@ -4845,12 +4878,12 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
-  AutoSizeInput: 3d7408a6842a739eac7304f795517ccb2cce9011
-  BackgroundThread: bed4bd4c0236fcfe21bc9c90ff6af1dced23e0dd
+  AutoSizeInput: 2564539d9ae8c2e72049f5ccc3c86317f5f456dc
+  BackgroundThread: 33a96f8a8e17028cedf03212bca104205d8f72f5
   BleUtils: 0fd18e5fd2732c89771dc79941c7320ac9c42015
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   Burnt: e3a3397e26172fca31a59bb27421475a58068836
-  CloudKitModule: 56096c586a0443310818490e5ee5bf3d485566b1
+  CloudKitModule: ed0c22ead8cf8a90e8384b1e3de85e5f1624bb7c
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CocoaLumberjack: 5644158777912b7de7469fa881f8a3f259c2512a
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
@@ -4900,7 +4933,7 @@ SPEC CHECKSUMS:
   JCoreRN: d985de509185b381c177fde4bb6bfc686089fdbd
   JPushRN: 807bc962b2f25860e5c0caa5fcb7b4910572b890
   JuiceboxSdk: b2222491ce92b263694c217ea202a54b66c5ec5f
-  KeychainModule: 2c6f9b75d67dd2d4baec2dc1775bf652ffb504b7
+  KeychainModule: 9b2144ee99bf6542938158708f6b17f6792b48c7
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
   lottie-react-native: 86fa7488b1476563f41071244aa73d5b738faf19
@@ -4955,12 +4988,12 @@ SPEC CHECKSUMS:
   react-native-keyboard-controller: dbf568b5d029cdc5b26667a7c2323b160c25dc00
   react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
   react-native-network-info: 703d4b16ff0ff6f03127728348251bf5f12b823a
-  react-native-pager-view: 20b1375927239c13c10d5657240ae468eb6c033b
+  react-native-pager-view: 78054710783390f012630831771cb0dfada91297
   react-native-performance-stats: 8820079bb3a8127f798f0e201d0ca1ab65735410
   react-native-ping: 589027e929c300b0b68cc5c34105f33610177055
   react-native-safe-area-context: c00143b4823773bba23f2f19f85663ae89ceb460
   react-native-slider: 663776e5683e257de8df8091abc2d93ff6ec67db
-  react-native-tab-view: 86f1c55409c6dfce876f62b6581624914c817b4a
+  react-native-tab-view: b8f2e7f07f52ab877b14561cd5781d4eb3a55f93
   react-native-tcp-socket: 120072c8020262032773f80f0daaf3964aaa08a1
   react-native-video: 7b821291837d8ba7b9d7574bfeb0cd651e910141
   react-native-view-shot: 6c008e58f4720de58370848201c5d4a082c6d4ca
@@ -4996,18 +5029,18 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 1bcd3527ac0390a1c898c114f81ff954be35ed79
   ReactCodegen: 0c47bcad3576258ef1a91e2ec1fd43afae72e85f
   ReactCommon: 5f0e5c09a64a2717215dd84380e1a747810406f2
-  ReactNativeAppUpdate: 341306dd1bbf12e8ae04f27aaddfad91dc7a20a4
-  ReactNativeBundleUpdate: 5b7d15af0e8c4252913ea02a11b2e68262c23aa3
+  ReactNativeAppUpdate: f4eebe90fc7c4ba862b77e465dea65dbf714d560
+  ReactNativeBundleUpdate: 64d0320738605be4955ef161abfceec4076cfb7a
   ReactNativeCameraKit: 84894fc476300e5d3b9f4e34f55ff75050ec5050
-  ReactNativeCheckBiometricAuthChanged: 244ef2cb8e687694de029e3bfa1b9ee9c71fe03c
-  ReactNativeDeviceUtils: 8f105f1c5c2b7144fdda64d73a87159b7aab184a
+  ReactNativeCheckBiometricAuthChanged: db83279cee4c84e51677a4f9eb11843cac0a0ce7
+  ReactNativeDeviceUtils: 6d066f1c99574038a4e5ebc83b308b59bbbcdfc2
   ReactNativeFs: fa4d6c721fedd16abb5a7eb5c591303f147677b5
-  ReactNativeGetRandomValues: 3d249a8a49b3a205fe866a648699c16f0299d3e7
-  ReactNativeLiteCard: dd3ef291344a7f2805f6c764be6b8c64f9cd59ba
-  ReactNativeNativeLogger: 71a7421e0ae451fa23b015aba916ea889fe5c427
+  ReactNativeGetRandomValues: 49d04b68a9015707137f604fe01668e674a2fbee
+  ReactNativeLiteCard: 986808b186aa40b663e546596f3cf2a62fc7f96c
+  ReactNativeNativeLogger: bb57d8b5d163a9d24fdcce9aff034005a110ae7e
   ReactNativePasskeys: 9e950e8cbf0e7d6aad9df4dcd21cee0efeb4e5cd
-  ReactNativePerfMemory: 07e7e5ed5a6cddc5759654fd38a15ba5a2357f7f
-  ReactNativeSplashScreen: f5e8c4076c9bd782cdff9fd8b43b2a6a78d07ede
+  ReactNativePerfMemory: e76253b04f13fd83651fa397da8236f9fb76e123
+  ReactNativeSplashScreen: acb602e800bc55e9c3a24835fd0b61102548951e
   RealmJS: 1c37c6bdfe060f4caa0f9175aa0eedb962622ee1
   RestartNewArch: 5a57520ab7d9131d21edf0e17ecf8116f8ab5b72
   RevenueCat: 7e1d0768fb287c9983173c9b28e39ccbeeb828a9
@@ -5026,11 +5059,12 @@ SPEC CHECKSUMS:
   RNSVG: d260beec1775108e1bd065a0ed666ff2c5565158
   RNWorklets: 8068c8af4b241eb2c19221310729e4c440bee023
   RNZipArchive: 4304f5100eab004eeb7349adc51997b3a28deb76
+  ScrollGuard: 53c1295e6188f207e849fbc0e58bfac4313ef526
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   Sentry: b53951377b78e21a734f5dc8318e333dbfc682d7
-  Skeleton: a42e021809e44c91b327a1335ebbb11f0384a8f0
+  Skeleton: 994e7dc82c89588ae38db3287d4a99e83b2df25b
   SniConnect: c92bce3bb3204c4cff031c0badb7aefaebee8f04
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SPAlert: 735da1f16a887e294719217572ce1f936d8c8782

--- a/packages/components/src/composite/Table/index.tsx
+++ b/packages/components/src/composite/Table/index.tsx
@@ -357,22 +357,32 @@ function BasicTable<T>({
   }, [estimatedItemSize]);
 
   const renderSortableItem = useCallback(
-    ({ item, drag, dragProps, index, isActive }: IRenderItemParams<T>) => (
-      <TableRow
-        pressStyle={!showSkeleton}
-        isActive={isActive}
-        draggable={draggable}
-        dataSet={dragProps}
-        showSkeleton={showSkeleton}
-        drag={drag}
-        scrollAtRef={scrollAtRef}
-        item={item}
-        index={index}
-        columns={columns}
-        onRow={showSkeleton ? undefined : onRow}
-        rowProps={rowProps}
-      />
-    ),
+    ({ item, drag, dragProps, index, isActive }: IRenderItemParams<T>) => {
+      const row = (
+        <TableRow
+          pressStyle={!showSkeleton}
+          isActive={isActive}
+          draggable={draggable}
+          dataSet={dragProps}
+          showSkeleton={showSkeleton}
+          drag={drag}
+          scrollAtRef={scrollAtRef}
+          item={item}
+          index={index}
+          columns={columns}
+          onRow={showSkeleton ? undefined : onRow}
+          rowProps={rowProps}
+        />
+      );
+      if (platformEnv.isNative) {
+        return (
+          <SortableListView.ShadowDecorator>
+            {row}
+          </SortableListView.ShadowDecorator>
+        );
+      }
+      return row;
+    },
     [columns, draggable, onRow, rowProps, showSkeleton],
   );
   // On native, when tabIntegrated the header row MUST be inside the list

--- a/packages/components/src/composite/Table/index.tsx
+++ b/packages/components/src/composite/Table/index.tsx
@@ -7,6 +7,7 @@ import { globalRef } from 'react-native-draggable-flatlist/src/context/globalRef
 import { useMedia } from '@onekeyhq/components/src/hooks/useStyle';
 import {
   getTokenValue,
+  useThemeName,
   withStaticProperties,
 } from '@onekeyhq/components/src/shared/tamagui';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -67,6 +68,8 @@ function TableRow<T>({
   scrollAtRef?: RefObject<number>;
 }) {
   const { md } = useMedia();
+  const themeName = useThemeName();
+  const isDarkMode = themeName?.includes('dark');
   const onRowEvents = useMemo(() => onRow?.(item, index), [index, item, onRow]);
   const itemPressStyle = pressStyle ? listItemPressStyle : undefined;
   const isDragging = pressStyle && isActive;
@@ -136,7 +139,7 @@ function TableRow<T>({
   return (
     <XStack
       minHeight={DEFAULT_ROW_HEIGHT}
-      bg={isDragging ? '$bgActive' : '$bgApp'}
+      bg={isDragging && isDarkMode ? '$bgActive' : '$bgApp'}
       borderRadius="$3"
       dataSet={!platformEnv.isNative && draggable ? dataSet : undefined}
       onPressIn={!platformEnv.isNative ? handlePressIn : undefined}

--- a/packages/components/src/layouts/SortableListView/index.native.tsx
+++ b/packages/components/src/layouts/SortableListView/index.native.tsx
@@ -122,6 +122,7 @@ function BaseSortableListView<T>(
       renderItem={renderItem as RenderItem<T>}
       keyboardDismissMode="on-drag"
       keyboardShouldPersistTaps="handled"
+      animationConfig={{ damping: 25, stiffness: 400, mass: 0.4 }}
       {...restProps}
     />
   );

--- a/packages/components/src/layouts/SortableListView/index.tsx
+++ b/packages/components/src/layouts/SortableListView/index.tsx
@@ -220,7 +220,7 @@ function BaseSortableListView<T>(
     mouseY: number;
     scrollContainer: HTMLElement | null;
     cleanup?: () => void;
-  }>({ rafId: 0, mouseY: 0, scrollContainer: null });
+  }>({ rafId: 0, mouseY: -1, scrollContainer: null });
   const listContainerRef = useRef<HTMLDivElement>(null);
 
   const stopAutoScroll = useCallback(() => {
@@ -247,7 +247,11 @@ function BaseSortableListView<T>(
 
     const tick = () => {
       const { mouseY, scrollContainer } = autoScrollRef.current;
-      if (!scrollContainer) return;
+      // Skip until we have a real mouse position from the mousemove listener
+      if (!scrollContainer || mouseY < 0) {
+        autoScrollRef.current.rafId = requestAnimationFrame(tick);
+        return;
+      }
 
       const rect = scrollContainer.getBoundingClientRect();
       const distToTop = mouseY - rect.top;
@@ -548,6 +552,7 @@ function BaseSortableListView<T>(
                 keyExtractor={keyExtractor}
                 stickyHeaderIndices={stickyHeaderIndices}
                 ListHeaderComponent={ListHeaderComponent}
+                scrollEnabled={scrollEnabled}
                 {...(restProps as any)}
               />
             );

--- a/packages/components/src/layouts/SortableListView/index.tsx
+++ b/packages/components/src/layouts/SortableListView/index.tsx
@@ -460,7 +460,7 @@ function BaseSortableListView<T>(
             const isDropping = snapshot.isDropAnimating;
             return (
               <Item
-                isDragging={isDropping ? false : !!isDarkMode}
+                isDragging={!isDropping}
                 dragProps={{}}
                 drag={noop}
                 item={data[rubric.source.index]}

--- a/packages/components/src/layouts/SortableListView/index.tsx
+++ b/packages/components/src/layouts/SortableListView/index.tsx
@@ -237,6 +237,7 @@ function BaseSortableListView<T>(
     // page for lists that are simply non-scrollable (e.g. overflow:hidden pinned tabs).
     const container = findScrollableAncestor(listContainerRef.current);
     if (!container) return;
+    autoScrollRef.current.mouseY = -1; // Reset stale position from previous session
     autoScrollRef.current.scrollContainer = container;
 
     const onMouseMove = (e: MouseEvent) => {

--- a/packages/components/src/layouts/SortableListView/index.tsx
+++ b/packages/components/src/layouts/SortableListView/index.tsx
@@ -27,7 +27,6 @@ import Animated from 'react-native-reanimated';
 
 import {
   useStyle,
-  useThemeName,
   withStaticProperties,
 } from '@onekeyhq/components/src/shared/tamagui';
 import {
@@ -210,9 +209,6 @@ function BaseSortableListView<T>(
   }: ISortableListViewProps<T>,
   ref: ForwardedRef<ISortableListViewRef<T>> | undefined,
 ) {
-  const themeName = useThemeName();
-  const isDarkMode = themeName?.includes('dark');
-
   // Custom auto-scroll for when the list's own scroll is disabled
   // (e.g. inside Tabs.Container on web where outer container scrolls)
   const autoScrollRef = useRef<{

--- a/packages/components/src/layouts/SortableListView/index.tsx
+++ b/packages/components/src/layouts/SortableListView/index.tsx
@@ -27,6 +27,7 @@ import Animated from 'react-native-reanimated';
 
 import {
   useStyle,
+  useThemeName,
   withStaticProperties,
 } from '@onekeyhq/components/src/shared/tamagui';
 import {
@@ -171,6 +172,25 @@ function CellContainer<T>({
   );
 }
 
+// Auto-scroll edge zone size (px) and max speed (px per frame)
+const AUTOSCROLL_EDGE_PX = 80;
+const AUTOSCROLL_MAX_SPEED_PX = 15;
+
+function findScrollableAncestor(el: HTMLElement | null): HTMLElement | null {
+  let current = el?.parentElement ?? null;
+  while (current) {
+    const { overflowY } = getComputedStyle(current);
+    if (
+      (overflowY === 'auto' || overflowY === 'scroll') &&
+      current.scrollHeight > current.clientHeight
+    ) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+
 function BaseSortableListView<T>(
   {
     data,
@@ -185,19 +205,85 @@ function BaseSortableListView<T>(
     stickyHeaderIndices = [],
     ListHeaderComponent,
     getItemDragDisabled,
+    scrollEnabled = true,
     ...restProps
   }: ISortableListViewProps<T>,
   ref: ForwardedRef<ISortableListViewRef<T>> | undefined,
 ) {
+  const themeName = useThemeName();
+  const isDarkMode = themeName?.includes('dark');
+
+  // Custom auto-scroll for when the list's own scroll is disabled
+  // (e.g. inside Tabs.Container on web where outer container scrolls)
+  const autoScrollRef = useRef<{
+    rafId: number;
+    mouseY: number;
+    scrollContainer: HTMLElement | null;
+    cleanup?: () => void;
+  }>({ rafId: 0, mouseY: 0, scrollContainer: null });
+  const listContainerRef = useRef<HTMLDivElement>(null);
+
+  const stopAutoScroll = useCallback(() => {
+    autoScrollRef.current.cleanup?.();
+    autoScrollRef.current.cleanup = undefined;
+  }, []);
+
+  const startAutoScroll = useCallback(() => {
+    stopAutoScroll(); // Clean up any previous session defensively
+    if (scrollEnabled) return; // built-in auto-scroll works when scroll is enabled
+
+    // Only auto-scroll if a real scrollable ancestor exists (e.g. Tabs.Container).
+    // Do NOT fall back to document.documentElement — that would scroll the entire
+    // page for lists that are simply non-scrollable (e.g. overflow:hidden pinned tabs).
+    const container = findScrollableAncestor(listContainerRef.current);
+    if (!container) return;
+    autoScrollRef.current.scrollContainer = container;
+
+    const onMouseMove = (e: MouseEvent) => {
+      autoScrollRef.current.mouseY = e.clientY;
+    };
+    // eslint-disable-next-line unicorn/prefer-global-this
+    window.addEventListener('mousemove', onMouseMove);
+
+    const tick = () => {
+      const { mouseY, scrollContainer } = autoScrollRef.current;
+      if (!scrollContainer) return;
+
+      const rect = scrollContainer.getBoundingClientRect();
+      const distToTop = mouseY - rect.top;
+      const distToBottom = rect.bottom - mouseY;
+
+      if (distToTop < AUTOSCROLL_EDGE_PX && distToTop >= 0) {
+        const ratio = 1 - distToTop / AUTOSCROLL_EDGE_PX;
+        scrollContainer.scrollTop -= Math.ceil(ratio * AUTOSCROLL_MAX_SPEED_PX);
+      } else if (distToBottom < AUTOSCROLL_EDGE_PX && distToBottom >= 0) {
+        const ratio = 1 - distToBottom / AUTOSCROLL_EDGE_PX;
+        scrollContainer.scrollTop += Math.ceil(ratio * AUTOSCROLL_MAX_SPEED_PX);
+      }
+
+      autoScrollRef.current.rafId = requestAnimationFrame(tick);
+    };
+    autoScrollRef.current.rafId = requestAnimationFrame(tick);
+
+    autoScrollRef.current.cleanup = () => {
+      // eslint-disable-next-line unicorn/prefer-global-this
+      window.removeEventListener('mousemove', onMouseMove);
+      cancelAnimationFrame(autoScrollRef.current.rafId);
+      autoScrollRef.current.scrollContainer = null;
+    };
+  }, [scrollEnabled, stopAutoScroll]);
+
   const reloadOnDragStart = useCallback(
     (params: DragStart) => {
       appEventBus.emit(EAppEventBusNames.onDragBeginInListView, undefined);
       onDragBegin?.(params.source.index);
+      startAutoScroll();
     },
-    [onDragBegin],
+    [onDragBegin, startAutoScroll],
   );
   const reloadOnDragEnd = useCallback(
     (params: DropResult) => {
+      stopAutoScroll();
       appEventBus.emit(EAppEventBusNames.onDragEndInListView, undefined);
       if (!params.destination) {
         return;
@@ -220,7 +306,7 @@ function BaseSortableListView<T>(
 
       onDragEnd?.(p);
     },
-    [onDragEnd, data],
+    [onDragEnd, data, stopAutoScroll],
   );
 
   useEffect(
@@ -340,94 +426,135 @@ function BaseSortableListView<T>(
     ],
   );
 
+  // Cleanup auto-scroll on unmount
+  useEffect(() => () => stopAutoScroll(), [stopAutoScroll]);
+
   return (
-    <DragDropContext
-      onDragStart={reloadOnDragStart}
-      onDragEnd={reloadOnDragEnd}
+    <div
+      ref={listContainerRef}
+      style={{
+        display: 'flex',
+        flex: 1,
+        flexDirection: 'column',
+        minHeight: 0,
+      }}
     >
-      <Droppable
-        droppableId="droppable"
-        mode="virtual"
-        type="DEFAULT"
-        direction="vertical"
-        isDropDisabled={false}
-        isCombineEnabled={false}
-        ignoreContainerClipping={false}
-        renderClone={(provided, snapshot, rubric) => {
-          return (
-            <Item
-              isDragging
-              dragProps={{}}
-              drag={noop}
-              item={data[rubric.source.index]}
-              renderItem={renderItem}
-              provided={provided}
-              getIndex={() => rubric.source.index}
-            />
-          );
-        }}
-        getContainerForClone={getBody}
+      <DragDropContext
+        onDragStart={reloadOnDragStart}
+        onDragEnd={reloadOnDragEnd}
       >
-        {(provided, snapshot) => {
-          const paddingBottom = (rawContentContainerStyle?.paddingBottom ??
-            rawContentContainerStyle?.paddingVertical) as string;
-          let overridePaddingBottom = parseInt(paddingBottom ?? '0', 10);
-          if (snapshot?.draggingFromThisWith) {
-            const index = data.findIndex(
-              (item, _index) =>
-                keyExtractor(item, _index) === snapshot.draggingFromThisWith,
+        <Droppable
+          droppableId="droppable"
+          mode="virtual"
+          type="DEFAULT"
+          direction="vertical"
+          isDropDisabled={false}
+          isCombineEnabled={false}
+          ignoreContainerClipping={!scrollEnabled}
+          renderClone={(provided, snapshot, rubric) => {
+            const isDropping = snapshot.isDropAnimating;
+            return (
+              <Item
+                isDragging={isDropping ? false : !!isDarkMode}
+                dragProps={{}}
+                drag={noop}
+                item={data[rubric.source.index]}
+                renderItem={renderItem}
+                provided={provided}
+                getIndex={() => rubric.source.index}
+                style={{
+                  boxShadow: isDropping
+                    ? 'none'
+                    : '0 4px 24px rgba(0, 0, 0, 0.12)',
+                  borderRadius: 12,
+                  // Speed up drop animation
+                  ...(isDropping
+                    ? {
+                        transition:
+                          'transform 0.08s ease, box-shadow 0.08s ease',
+                      }
+                    : {}),
+                }}
+              />
             );
-            overridePaddingBottom += useFlashList
-              ? 0
-              : (getItemLayout?.(data, index)?.length ?? 0);
-          }
-          const ListViewComponent = useFlashList ? FlashList : ListView;
-          return (
-            <ListViewComponent
-              ref={(_ref: any) => {
-                if (_ref) {
-                  if (typeof ref === 'function') {
-                    ref(_ref);
-                  } else if (ref && 'current' in ref) {
-                    ref.current = _ref;
-                  }
-                  // FlashList
-                  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                  if (_ref?.getNativeScrollRef) {
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                    const scrollRef = _ref?.getNativeScrollRef();
-                    if (scrollRef) {
-                      provided.innerRef(scrollRef);
+          }}
+          getContainerForClone={getBody}
+        >
+          {(provided, snapshot) => {
+            const paddingBottom = (rawContentContainerStyle?.paddingBottom ??
+              rawContentContainerStyle?.paddingVertical) as string;
+            let overridePaddingBottom = parseInt(paddingBottom ?? '0', 10);
+            if (snapshot?.draggingFromThisWith) {
+              const index = data.findIndex(
+                (item, _index) =>
+                  keyExtractor(item, _index) === snapshot.draggingFromThisWith,
+              );
+              overridePaddingBottom += useFlashList
+                ? 0
+                : (getItemLayout?.(data, index)?.length ?? 0);
+            }
+            const ListViewComponent = useFlashList ? FlashList : ListView;
+            return (
+              <ListViewComponent
+                ref={(_ref: any) => {
+                  if (_ref) {
+                    if (typeof ref === 'function') {
+                      ref(_ref);
+                    } else if (ref && 'current' in ref) {
+                      ref.current = _ref;
+                    }
+
+                    // When scroll is disabled (e.g. inside Tabs.Container),
+                    // point react-beautiful-dnd to the actual scrolling ancestor
+                    // so it correctly calculates drop positions during drag.
+                    if (!scrollEnabled && listContainerRef.current) {
+                      const scrollAncestor = findScrollableAncestor(
+                        listContainerRef.current,
+                      );
+                      if (scrollAncestor) {
+                        provided.innerRef(scrollAncestor);
+                        return;
+                      }
+                    }
+
+                    // FlashList
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                    if (_ref?.getNativeScrollRef) {
+                      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                      const scrollRef = _ref?.getNativeScrollRef();
+                      if (scrollRef) {
+                        provided.innerRef(scrollRef);
+                      }
+                    }
+
+                    // FlatList
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                    if (_ref?._listRef?._scrollRef) {
+                      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                      provided.innerRef(_ref?._listRef?._scrollRef);
                     }
                   }
-
-                  // FlatList
-                  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                  if (_ref?._listRef?._scrollRef) {
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                    provided.innerRef(_ref?._listRef?._scrollRef);
-                  }
+                }}
+                data={data}
+                contentContainerStyle={{
+                  ...rawContentContainerStyle,
+                  paddingBottom: overridePaddingBottom,
+                }}
+                renderItem={reloadRenderItem as ListRenderItem<T>}
+                CellRendererComponent={
+                  useFlashList ? CellContainer : FragmentComponent
                 }
-              }}
-              data={data}
-              contentContainerStyle={{
-                ...rawContentContainerStyle,
-                paddingBottom: overridePaddingBottom,
-              }}
-              renderItem={reloadRenderItem as ListRenderItem<T>}
-              CellRendererComponent={
-                useFlashList ? CellContainer : FragmentComponent
-              }
-              getItemLayout={useFlashList ? undefined : getItemLayout}
-              keyExtractor={keyExtractor}
-              stickyHeaderIndices={stickyHeaderIndices}
-              ListHeaderComponent={ListHeaderComponent}
-              {...(restProps as any)}
-            />
-          );
-        }}
-      </Droppable>
-    </DragDropContext>
+                getItemLayout={useFlashList ? undefined : getItemLayout}
+                keyExtractor={keyExtractor}
+                stickyHeaderIndices={stickyHeaderIndices}
+                ListHeaderComponent={ListHeaderComponent}
+                {...(restProps as any)}
+              />
+            );
+          }}
+        </Droppable>
+      </DragDropContext>
+    </div>
   );
 }
 

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenListBase.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenListBase.tsx
@@ -345,13 +345,25 @@ function MarketTokenListBase({
       );
     }
 
-    // Show end indicator when no more data to load
-    if (showEndReachedIndicator && !canLoadMore && data.length > 0) {
+    // End indicator is rendered outside the Table when draggable,
+    // so it doesn't participate in absolute positioning during drag.
+    if (
+      !draggable &&
+      showEndReachedIndicator &&
+      !canLoadMore &&
+      data.length > 0
+    ) {
       return <ListEndIndicator />;
     }
 
     return null;
-  }, [isLoadingMore, showEndReachedIndicator, canLoadMore, data.length]);
+  }, [
+    isLoadingMore,
+    showEndReachedIndicator,
+    canLoadMore,
+    data.length,
+    draggable,
+  ]);
   const tabBarHeight = useScrollContentTabBarOffset();
 
   // On web with tabIntegrated, disable FlatList's own scroll so the outer
@@ -423,6 +435,12 @@ function MarketTokenListBase({
         style={{
           paddingTop: 4,
           overflowX: 'auto',
+          // Explicitly set overflowY to prevent browsers from implicitly
+          // changing it to 'auto' (CSS spec: setting one overflow axis to
+          // non-visible forces the other to auto). Without this, drag
+          // auto-scroll would bind to this horizontal wrapper instead of
+          // the real vertical scroll container (Tabs.Container).
+          overflowY: 'hidden',
           ...(md ? { marginLeft: 8, marginRight: 8 } : {}),
         }}
       >
@@ -478,6 +496,14 @@ function MarketTokenListBase({
           )}
           {webTabIntegrated ? (
             <div ref={endSentinelRef} style={{ height: 1 }} />
+          ) : null}
+          {/* Render end indicator outside the Table for draggable lists
+              so it doesn't participate in absolute positioning during drag. */}
+          {draggable &&
+          showEndReachedIndicator &&
+          !canLoadMore &&
+          data.length > 0 ? (
+            <ListEndIndicator />
           ) : null}
         </Stack>
       </Stack>

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MobileMarketWatchlistFlatList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MobileMarketWatchlistFlatList.tsx
@@ -60,7 +60,9 @@ const MANUAL_AUTOSCROLL_EDGE_PX = 72;
 const MANUAL_AUTOSCROLL_MAX_STEP_PX = 20;
 const SECOND_LEVEL_MENU_ANCHOR_X_RATIO = 0.48;
 const SECOND_LEVEL_MENU_ANCHOR_Y_OFFSET = 4;
-const WATCHLIST_CONTENT_PADDING_TOP = platformEnv.isNative ? 0 : 8;
+// On native, Tabs.DraggableFlatList uses useCollapsibleStyle() to inject
+// dynamic paddingTop based on actual header height. Do NOT override it.
+const WATCHLIST_CONTENT_PADDING_TOP = platformEnv.isNative ? undefined : 8;
 
 function MobileMarketWatchlistFlatListImpl({
   selectedFilter = 'all',
@@ -592,7 +594,9 @@ function MobileMarketWatchlistFlatListImpl({
   const tabBarHeight = useScrollContentTabBarOffset();
   const contentContainerStyle = useMemo(
     () => ({
-      paddingTop: WATCHLIST_CONTENT_PADDING_TOP,
+      ...(WATCHLIST_CONTENT_PADDING_TOP !== undefined
+        ? { paddingTop: WATCHLIST_CONTENT_PADDING_TOP }
+        : {}),
       paddingBottom: platformEnv.isNativeAndroid
         ? listContainerProps.paddingBottom
         : tabBarHeight,
@@ -653,6 +657,7 @@ function MobileMarketWatchlistFlatListImpl({
       activationDistance={DRAG_MOVE_THRESHOLD_PX}
       autoscrollThreshold={AUTOSCROLL_THRESHOLD_PX}
       autoscrollSpeed={AUTOSCROLL_SPEED_PX}
+      animationConfig={{ damping: 25, stiffness: 400, mass: 0.4 }}
       renderItem={renderItem}
       keyExtractor={keyExtractor}
       initialNumToRender={15}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenListItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenListItem.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import { memo } from 'react';
 
-import { NumberSizeableText, XStack } from '@onekeyhq/components';
+import { NumberSizeableText, XStack, useThemeName } from '@onekeyhq/components';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { PriceChangeBadge } from '../../PriceChangeBadge';
@@ -52,6 +52,8 @@ const BasicTokenListItem: FC<ITokenListItemProps> = ({
   onPressOut,
   isDragging,
 }) => {
+  const themeName = useThemeName();
+  const isDarkMode = themeName?.includes('dark');
   return (
     <XStack
       pressStyle={{ opacity: 0.8 }}
@@ -64,7 +66,7 @@ const BasicTokenListItem: FC<ITokenListItemProps> = ({
       py="$3"
       alignItems="center"
       borderRadius="$3"
-      bg={isDragging ? '$bgActive' : '$bgApp'}
+      bg={isDragging && isDarkMode ? '$bgActive' : '$bgApp'}
       style={isDragging ? DRAGGING_STYLE : undefined}
     >
       <XStack flex={1} alignItems="center" minWidth={0}>

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
@@ -187,8 +187,14 @@ function MobileLayoutComponent({
   const containerProps = useMemo(
     () => ({
       allowHeaderOverscroll: true,
+      // NOTE: renderHeader must never return a 0-height tree after it had
+      // a positive height, because react-native-collapsible-tab-view's
+      // useLayoutHeight guard ignores 0-height re-layouts once a positive
+      // height has been measured. Wrapping in a YStack with minHeight={1}
+      // ensures the layout callback always fires with height >= 1 so the
+      // library re-measures correctly when the banner disappears.
       renderHeader: () => (
-        <YStack bg="$bgApp" pointerEvents="box-none">
+        <YStack bg="$bgApp" pointerEvents="box-none" minHeight={1}>
           <MarketBannerList />
         </YStack>
       ),

--- a/packages/kit/src/views/Swap/pages/components/SwapProContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProContainer.tsx
@@ -197,7 +197,7 @@ const SwapProContainer = ({
           configLoading={isLoading}
         />
         <IconButton
-          icon="TradeOutline"
+          icon="TradingViewCandlesOutline"
           variant="tertiary"
           flexShrink={0}
           onPress={onProMarketDetail}


### PR DESCRIPTION
https://onekeyhq.atlassian.net/browse/OK-51822
https://onekeyhq.atlassian.net/browse/OK-51819
https://onekeyhq.atlassian.net/browse/OK-51794
https://onekeyhq.atlassian.net/browse/OK-51630
## Summary

- **Desktop/Web auto-scroll**: When dragging items in the watchlist inside `Tabs.Container`, automatically scrolls the outer container when the cursor nears the top/bottom edges. Correctly redirects `react-beautiful-dnd`'s `provided.innerRef` to the actual scroll ancestor for accurate drop position calculation.
- **Drag shadow effect**: Adds `boxShadow` on the web drag clone and `ShadowDecorator` on native. Theme-aware: light mode uses `$bgApp` background, dark mode uses `$bgActive`.
- **Faster drop animation**: Reduces web drop transition to 0.08s and native spring config (`damping: 25, stiffness: 400, mass: 0.4`) for snappier feel after releasing.
- **ListEndIndicator fix**: Renders the bottom indicator outside the `Table` for draggable lists, preventing it from overlapping with list items during drag (absolute positioning conflict).
- **Mobile paddingTop fix**: Lets `Tabs.DraggableFlatList` inject dynamic `paddingTop` via `useCollapsibleStyle()` instead of overriding with a hardcoded value. Fixes `renderHeader` wrapper with `minHeight={1}` to work around `react-native-collapsible-tab-view`'s height measurement guard that ignores 0-height re-layouts.
- **Horizontal scroll wrapper fix**: Adds `overflowY: 'hidden'` to the horizontal table scroll container to prevent browser implicit `overflowY: auto` from mis-targeting the scroll ancestor detection.

## Test plan

- [ ] Desktop/Web: Open market watchlist with 20+ items, drag an item from top to position 17+, verify auto-scroll works and drop lands at correct position
- [ ] Desktop/Web: Verify drag clone has shadow in both light and dark mode
- [ ] Desktop/Web: Verify ListEndIndicator stays at bottom during drag, no overlap
- [ ] iOS: Open market watchlist, long-press to drag, verify shadow appears on dragged item
- [ ] iOS: Verify drop animation is fast and smooth
- [ ] iOS: Switch between 自选/现货/合约 tabs, verify no blank space at top (with and without banner)
- [ ] Android: Same verification as iOS
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
