### PR TITLE
fix: correct caller detection and build_source fallback in bundle workflows

### DIFF
--- a/.github/workflows/release-desktop-bundle.yml
+++ b/.github/workflows/release-desktop-bundle.yml
@@ -73,7 +73,7 @@ jobs:
           fi
 
       - name: Override params from caller
-        if: ${{ github.event_name == 'workflow_call' }}
+        if: ${{ inputs.build_number }}
         run: |
           echo "BUILD_NUMBER=${{ inputs.build_number }}" >> $GITHUB_ENV
           echo "BUILD_BUNDLE_VERSION=${{ inputs.build_bundle_version }}" >> $GITHUB_ENV
@@ -207,4 +207,4 @@ jobs:
           artifact-version-code: '${{ env.BUILD_NUMBER }}'
           artifact-download-url: '${{ env.ARTIFACTS_URL }}'
           artifact-bundle-version: '${{ env.BUILD_BUNDLE_VERSION }}'
-          artifact-build-source: '${{ inputs.build_source }}'
+          artifact-build-source: '${{ inputs.build_source || ''daily-build'' }}'

--- a/.github/workflows/release-native-bundle.yml
+++ b/.github/workflows/release-native-bundle.yml
@@ -73,7 +73,7 @@ jobs:
           fi
 
       - name: Override params from caller
-        if: ${{ github.event_name == 'workflow_call' }}
+        if: ${{ inputs.build_number }}
         run: |
           echo "BUILD_NUMBER=${{ inputs.build_number }}" >> $GITHUB_ENV
           echo "BUILD_BUNDLE_VERSION=${{ inputs.build_bundle_version }}" >> $GITHUB_ENV
@@ -151,4 +151,4 @@ jobs:
           artifact-version-code: '${{ env.BUILD_NUMBER }}'
           artifact-download-url: '${{ env.ARTIFACTS_URL }}'
           artifact-bundle-version: '${{ env.BUILD_BUNDLE_VERSION }}'
-          artifact-build-source: '${{ inputs.build_source }}'
+          artifact-build-source: '${{ inputs.build_source || ''daily-build'' }}'


### PR DESCRIPTION
## Summary

- Fix override step condition: `github.event_name` is never `'workflow_call'` in reusable workflows — use `inputs.build_number` instead
- Fix `build_source` fallback: `inputs.build_source` is empty in `workflow_run` path, add `|| 'daily-build'` fallback

## Intent & Context

Follow-up fix for #10682. The `release-app-bundles` workflow's `workflow_call` to bundle workflows was not triggering the override step, causing `BUILD_NUMBER` to remain as `1` and `build_source` to be empty in the daily-build path.

## Root Cause

In GitHub Actions reusable workflows, `github.event_name` reflects the **caller's** trigger event (e.g., `workflow_dispatch`), not `workflow_call`. The condition `github.event_name == 'workflow_call'` always evaluates to false.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: All (workflow changes only)

## Test plan
- [ ] Trigger `release-app-bundles` workflow — verify override step executes (not skipped)
- [ ] Verify `BUILD_NUMBER` in artifacts matches the caller-provided value (not `1`)
- [ ] Verify daily-build path still works (override step skipped, `build_source` falls back to `daily-build`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
