### PR TITLE
fix(components): web Carousel dismissKeyboard causes cross-tab input blur(OK-51667)

### DIFF
--- a/.claude/skills/1k-ui-recipes/SKILL.md
+++ b/.claude/skills/1k-ui-recipes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 1k-ui-recipes
-description: UI recipes for scroll offset (useScrollContentTabBarOffset), view transitions (startViewTransition), horizontal scroll in collapsible tab headers (CollapsibleTabContext), Android bottom tab touch interception workaround, keyboard avoidance for input fields, and iOS overlay navigation freeze prevention (resetAboveMainRoute).
+description: UI recipes for scroll offset (useScrollContentTabBarOffset), view transitions (startViewTransition), horizontal scroll in collapsible tab headers (CollapsibleTabContext), Android bottom tab touch interception workaround, keyboard avoidance for input fields, iOS overlay navigation freeze prevention (resetAboveMainRoute), and web keyboardDismissMode cross-tab input blur prevention.
 allowed-tools: Read, Grep, Glob
 ---
 
@@ -18,6 +18,7 @@ Bite-sized solutions for common UI issues.
 | Android Bottom Tab Touch Interception | [android-bottom-tab-touch-intercept.md](references/rules/android-bottom-tab-touch-intercept.md) | **Temporary** — `GestureDetector` + `Gesture.Tap()` in `.android.tsx` to bypass native tab bar touch stealing |
 | Keyboard Avoidance for Input Fields | [keyboard-avoidance.md](references/rules/keyboard-avoidance.md) | `KeyboardAwareScrollView` auto-scroll, Footer animated padding, `useKeyboardHeight` / `useKeyboardEvent` hooks |
 | iOS Overlay Navigation Freeze | [ios-overlay-navigation-freeze.md](references/rules/ios-overlay-navigation-freeze.md) | Use `resetAboveMainRoute()` instead of sequential `goBack()` to close overlays before navigating |
+| Web keyboardDismissMode Cross-Tab Blur | — | Never use `on-drag` on web; it globally blurs inputs via `TextInputState` |
 
 ## Critical Rules Summary
 
@@ -145,6 +146,36 @@ rootNavigationRef.current?.navigate(targetRoute);
 
 > **Key file**: `packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx`
 > **Reference**: commit `2cabd040` (OK-50182) — same fix applied to scan QR code navigation.
+
+### 7. Web: ScrollView `keyboardDismissMode="on-drag"` Causes Cross-Tab Input Blur
+
+On web, `react-native-web`'s `keyboardDismissMode="on-drag"` calls `dismissKeyboard()` on every scroll event. `dismissKeyboard()` uses `TextInputState` — a **global singleton** that tracks the currently focused input across the entire app, not scoped to individual tabs. This means a ScrollView scrolling on a **background tab** (e.g. Home) will blur an input on the **active tab** (e.g. Perps).
+
+**Symptom**: Input fields lose focus periodically (~every 5 seconds) without user interaction.
+
+**Root cause chain**:
+1. Carousel on Home tab has `autoPlayInterval={5000}` → triggers scroll every 5s
+2. Web PagerView uses `<ScrollView keyboardDismissMode="on-drag">` → `dismissKeyboard()` on scroll
+3. `dismissKeyboard()` → `TextInputState.blurTextInput(currentlyFocusedField())` → blurs Perps input
+
+**Fix (two layers)**:
+- `Carousel/pager.tsx` (web-only): Force `keyboardDismissMode="none"` — web has no virtual keyboard, so dismiss is pure side-effect
+- `Carousel/index.tsx`: Pause auto-play via `IntersectionObserver` when the Carousel is not visible in viewport
+
+**Rules**:
+- **NEVER** use `keyboardDismissMode="on-drag"` on web ScrollViews that may run in background tabs. On web, it globally blurs the focused input via `TextInputState`.
+- For Carousel/PagerView, the web `pager.tsx` already forces `"none"`. For standalone ScrollViews, wrap with `platformEnv.isNative` if `on-drag` is needed only on mobile.
+- Background Carousel auto-play should be paused when not visible (`IntersectionObserver`).
+
+```typescript
+// ❌ WRONG: Will blur inputs on other tabs when this ScrollView scrolls
+<ScrollView keyboardDismissMode="on-drag" />
+
+// ✅ CORRECT: Only use on-drag on native
+<ScrollView keyboardDismissMode={platformEnv.isNative ? 'on-drag' : 'none'} />
+```
+
+> **Key files**: `packages/components/src/composite/Carousel/pager.tsx`, `packages/components/src/composite/Carousel/index.tsx`
 
 ---
 

--- a/packages/components/src/composite/Carousel/index.tsx
+++ b/packages/components/src/composite/Carousel/index.tsx
@@ -142,27 +142,61 @@ export function Carousel<T>({
   }, [data.length, debouncedSetPageIndex, setPage]);
 
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isPageVisibleRef = useRef(true);
+
+  const stopAutoPlay = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
 
   const startAutoPlay = useCallback(() => {
-    if (loop) {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-      }
+    if (loop && isPageVisibleRef.current) {
+      stopAutoPlay();
       timerRef.current = setTimeout(() => {
         scrollToNextPage();
         startAutoPlay();
       }, autoPlayInterval);
     }
-  }, [loop, autoPlayInterval, scrollToNextPage]);
+  }, [loop, autoPlayInterval, scrollToNextPage, stopAutoPlay]);
+
+  // Pause auto-play when the Carousel is not visible in the viewport
+  // (e.g. user switched to another in-app tab). This avoids unnecessary
+  // scroll events firing in the background which can blur focused inputs
+  // on other pages via react-native-web's dismissKeyboard().
+  const containerRef = useRef<HTMLElement>(null);
+  useEffect(() => {
+    if (platformEnv.isNative || !loop) return;
+    const el = containerRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        const nowVisible = entry?.isIntersecting ?? true;
+        const prevVisible = isPageVisibleRef.current;
+        isPageVisibleRef.current = nowVisible;
+        if (nowVisible && !prevVisible) {
+          startAutoPlay();
+        } else if (!nowVisible && prevVisible) {
+          stopAutoPlay();
+        }
+      },
+      { threshold: 0.1 },
+    );
+    observer.observe(el);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [loop, startAutoPlay, stopAutoPlay]);
 
   useEffect(() => {
     startAutoPlay();
     return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-      }
+      stopAutoPlay();
     };
-  }, [loop, autoPlayInterval, scrollToNextPage, startAutoPlay]);
+  }, [loop, autoPlayInterval, scrollToNextPage, startAutoPlay, stopAutoPlay]);
 
   useImperativeHandle(instanceRef, () => {
     return {
@@ -239,7 +273,7 @@ export function Carousel<T>({
 
   return (
     <CarouselContext.Provider value={value}>
-      <YStack userSelect="none">
+      <YStack userSelect="none" ref={containerRef as any}>
         <XStack
           {...(containerStyle as any)}
           onLayout={handleLayout}

--- a/packages/components/src/composite/Carousel/index.tsx
+++ b/packages/components/src/composite/Carousel/index.tsx
@@ -267,6 +267,8 @@ export function Carousel<T>({
                 initialPage={defaultIndex}
                 pageWidth={pageWidth}
                 onPageSelected={onPageSelected}
+                // Only effective on native; web PagerView ignores this and uses "none"
+                // to avoid globally blurring focused inputs via dismissKeyboard().
                 keyboardDismissMode="on-drag"
                 disableAnimation={disableAnimation}
                 {...pagerProps}

--- a/packages/components/src/composite/Carousel/pager.tsx
+++ b/packages/components/src/composite/Carousel/pager.tsx
@@ -320,7 +320,11 @@ export function PagerView({
       style={style}
       horizontal
       pagingEnabled
-      keyboardDismissMode={keyboardDismissMode as any}
+      // On web, keyboardDismissMode="on-drag" causes react-native-web's
+      // dismissKeyboard() to blur the globally-tracked focused input on every
+      // scroll event — even for inputs on other (background) tabs. Since web
+      // has no virtual keyboard to dismiss, always use "none" here.
+      keyboardDismissMode="none"
       ref={scrollViewRef}
       showsHorizontalScrollIndicator={false}
       scrollEventThrottle={150}


### PR DESCRIPTION
## Summary

- Fix input fields (e.g. Perps Trigger Price) losing focus periodically on web desktop
- Root cause: `Carousel` component's web `PagerView` uses `keyboardDismissMode="on-drag"`, which calls `react-native-web`'s `dismissKeyboard()` on every scroll event. `dismissKeyboard()` uses `TextInputState` — a **global singleton** that blurs the focused input across the **entire app**, not scoped to individual tabs
- When the Home tab's `SupportHub` Carousel auto-plays (every 5s), it triggers scroll events that blur inputs on other tabs (e.g. Perps)

### Root cause chain

```
Home tab SupportHub Carousel (autoPlayInterval=5000)
  → PagerView (web) <ScrollView keyboardDismissMode="on-drag">
    → ScrollView._handleScroll()
      → dismissKeyboard()
        → TextInputState.blurTextInput(currentlyFocusedField())
          → Perps Trigger Price input.blur()  // globally tracked, cross-tab!
```

### Fix (two layers)

1. **`Carousel/pager.tsx`** (web-only PagerView): Force `keyboardDismissMode="none"` — web has no virtual keyboard, so `on-drag` is pure side-effect
2. **`Carousel/index.tsx`**: Pause auto-play via `IntersectionObserver` when the Carousel is not visible in viewport — prevents unnecessary background scroll events entirely

### Impact

- All Carousel instances on web are fixed (SupportHub, Earn Banner, DeviceGetStarted, etc.)
- Native behavior unchanged — `pager.native.tsx` uses the real `react-native-pager-view` which handles `keyboardDismissMode` natively
- No visual or behavioral changes for users — only eliminates the unwanted blur side-effect

## Test plan

- [ ] Open Wallet tab (ensure SupportHub Carousel banner is visible), then switch to Perps tab
- [ ] Select Stop Market order type, click Trigger Price input, type numbers
- [ ] Verify input maintains focus for >30 seconds without auto-blur
- [ ] Switch back to Wallet tab, verify Carousel still auto-plays normally
- [ ] Verify Carousel pauses when switching away from Wallet tab (check no scroll events in console)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
