### PR TITLE
fix(discovery): fix white screen when tapping Discovery page header tabs (Market/DeFi/Browser) on mobile

### DIFF
--- a/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
+++ b/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
@@ -266,7 +266,7 @@ function OuterTabPagerViewComponent({
     prevActiveIndexRef.current = activePageIndex;
     if (prev === activePageIndex) return;
 
-    requestAnimationFrame(() => {
+    const rafId = requestAnimationFrame(() => {
       // Only scroll PagerView for programmatic switches (header tab taps).
       // For user-gesture swipes, PagerView already handles scrolling natively.
       if (!wasUserDragRef.current) {
@@ -280,6 +280,7 @@ function OuterTabPagerViewComponent({
         earnTabsRef?.current?.syncCurrentPage();
       }
     });
+    return () => cancelAnimationFrame(rafId);
   }, [activePageIndex, marketTabsRef, earnTabsRef, earnBorrowPagerRef]);
 
   const marketPage = useMemo(

--- a/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
+++ b/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
@@ -208,19 +208,18 @@ function OuterTabPagerViewComponent({
     (e: PagerViewOnPageSelectedEvent) => {
       const position = e.nativeEvent.position;
       const tab = INDEX_TO_TAB[position];
-      currentOuterIndexRef.current = position;
-      setActivePageIndex(position);
 
-      // Mark page as visited (lazy mount) — only in onPageSelected,
-      // not during render, to prevent offscreenPageLimit pre-renders
-      // from defeating lazy loading.
-      markPagesVisited([position]);
-
-      // Persist tab only for user-gesture swipes.
-      // iOS may emit synthetic onPageSelected during freeze/unfreeze.
+      // Only update state for user-gesture swipes.
+      // iOS may emit synthetic onPageSelected during freeze/unfreeze,
+      // which would override activePageIndex and cancel the deferred
+      // setPage() rAF for programmatic tab switches.
       if (!wasUserDragRef.current) {
         return;
       }
+
+      currentOuterIndexRef.current = position;
+      setActivePageIndex(position);
+      markPagesVisited([position]);
 
       // Update atom only if tab actually changed
       if (tab && tab !== selectedHeaderTabRef.current) {

--- a/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
+++ b/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
@@ -71,6 +71,7 @@ function OuterTabPagerViewComponent({
   const currentOuterIndexRef = useRef(initialPage);
   const [activePageIndex, setActivePageIndex] = useState(initialPage);
   const wasUserDragRef = useRef(false);
+  const isProgrammaticSwitchRef = useRef(false);
   const [isOuterPageTransitioning, setIsOuterPageTransitioning] =
     useState(false);
   const isOuterPageTransitioningRef = useRef(false);
@@ -140,6 +141,7 @@ function OuterTabPagerViewComponent({
     }
     if (index !== undefined && index !== currentOuterIndexRef.current) {
       const previousIndex = currentOuterIndexRef.current;
+      isProgrammaticSwitchRef.current = true;
       setTransitioning(true);
       setVisiblePair([previousIndex, index]);
       // Update current index immediately to prevent redundant setPage calls
@@ -268,7 +270,8 @@ function OuterTabPagerViewComponent({
     const rafId = requestAnimationFrame(() => {
       // Only scroll PagerView for programmatic switches (header tab taps).
       // For user-gesture swipes, PagerView already handles scrolling natively.
-      if (!wasUserDragRef.current) {
+      if (isProgrammaticSwitchRef.current) {
+        isProgrammaticSwitchRef.current = false;
         outerPagerRef.current?.setPage(activePageIndex);
       }
 

--- a/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
+++ b/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
@@ -142,10 +142,17 @@ function OuterTabPagerViewComponent({
       const previousIndex = currentOuterIndexRef.current;
       setTransitioning(true);
       setVisiblePair([previousIndex, index]);
-      outerPagerRef.current?.setPage(index);
       // Update current index immediately to prevent redundant setPage calls
       currentOuterIndexRef.current = index;
       setActivePageIndex(index);
+      // NOTE: setPage() is NOT called here. react-freeze (Suspense with
+      // fallback=null) removes native views when frozen. The state updates
+      // above are batched and won't unfreeze the target page until the next
+      // render commit. Calling setPage() here would scroll PagerView to a
+      // page whose native views haven't been re-created yet, causing a
+      // white flash on iOS. Instead, setPage() is deferred to the
+      // prevActiveIndexRef effect below, which runs after the render that
+      // unfreezes the target page.
     }
   }, [markPagesVisited, selectedHeaderTab, setTransitioning, setVisiblePair]);
 
@@ -168,8 +175,15 @@ function OuterTabPagerViewComponent({
 
   // During horizontal swipe, pre-mount the neighbor page and keep only
   // the current + target pages unfrozen to avoid black frames.
+  // IMPORTANT: Only run for user-gesture swipes, NOT programmatic setPage().
+  // When setPage() scrolls across a non-adjacent page (e.g. page 0 → 2),
+  // intermediate onPageScroll events would overwrite visiblePair from [0,2]
+  // to [0,1], freezing the target page mid-animation → white flash.
   const handleOuterPageScroll = useCallback(
     (e: PagerViewOnPageScrollEvent) => {
+      if (!wasUserDragRef.current) {
+        return;
+      }
       const { position, offset } = e.nativeEvent;
       if (offset <= 0) {
         return;
@@ -232,23 +246,20 @@ function OuterTabPagerViewComponent({
     [activePageIndex, isOuterPageTransitioning, visiblePagePair],
   );
 
-  // --- Freeze/unfreeze resync ---
+  // --- Freeze/unfreeze resync & programmatic page scroll ---
   //
-  // Why useEffect on activeIndex instead of requestAnimationFrame in onPageSelected:
+  // This effect runs AFTER the render commit that unfreezes the target page.
+  // It handles two tasks:
   //
-  // The freeze/unfreeze sync is driven by `activePageIndex`, which updates
-  // immediately from PagerView selection events (or programmatic tab changes).
-  // If we schedule sync in onPageSelected via requestAnimationFrame, the rAF may fire
-  // before the render commit that applies the new freeze state.
+  // 1. Scroll PagerView to the target page (programmatic tab switches only).
+  //    setPage() must be called here — NOT in the selectedHeaderTab effect —
+  //    because react-freeze v1 uses Suspense with fallback=null, which removes
+  //    native views when frozen. Calling setPage() before the unfreeze render
+  //    scrolls PagerView to a blank page, causing a white flash on iOS.
   //
-  // - iOS: UIScrollView ignores setContentOffset while the view is suspended by
-  //   react-freeze (Suspense), so the sync is a no-op and the PagerView resets to page 0.
-  // - Android: ViewPager2 (RecyclerView-based) is more tolerant — it queues the
-  //   setCurrentItem call and applies it even during layout transitions, so the issue
-  //   does not manifest.
-  //
-  // By using useEffect on activePageIndex, we guarantee the sync runs AFTER the render
-  // commit that unfreezes the page, so the native PagerView is active and responsive.
+  // 2. Sync inner tab containers (Market/Earn) after freeze/unfreeze.
+  //    iOS UIScrollView ignores setContentOffset while suspended by react-freeze,
+  //    so syncing must happen after the render commit that unfreezes the page.
   const prevActiveIndexRef = useRef(activePageIndex);
   useEffect(() => {
     const prev = prevActiveIndexRef.current;
@@ -256,6 +267,12 @@ function OuterTabPagerViewComponent({
     if (prev === activePageIndex) return;
 
     requestAnimationFrame(() => {
+      // Only scroll PagerView for programmatic switches (header tab taps).
+      // For user-gesture swipes, PagerView already handles scrolling natively.
+      if (!wasUserDragRef.current) {
+        outerPagerRef.current?.setPage(activePageIndex);
+      }
+
       if (activePageIndex === 0) {
         marketTabsRef?.current?.syncCurrentPage();
       } else if (activePageIndex === 1) {


### PR DESCRIPTION
## Summary
- Defer `PagerView.setPage()` to run after the react-freeze unfreeze render commit, preventing PagerView from scrolling to a page whose native views haven't been re-created yet
- Skip `handleOuterPageScroll` during programmatic transitions (`!wasUserDragRef.current`) to prevent intermediate scroll events from overwriting `visiblePagePair` and re-freezing the target page mid-animation
- Adjacent tab switches (e.g. Market→DeFi) and non-adjacent switches (e.g. Market→Browser) are both fixed

## Root Cause
`react-freeze` v1 uses Suspense with `fallback=null`, which **removes native views** when frozen. Two issues caused white screens:

1. **All tab taps**: `setPage()` was called in the same effect that batched the unfreeze state updates — PagerView scrolled before React committed the render that recreates the native views
2. **Non-adjacent tab taps** (Market↔Browser): `onPageScroll` intermediate events overwrote `visiblePair` from `[0,2]` to `[0,1]` as PagerView scrolled through the middle page, re-freezing the target page mid-animation

## Test plan
- [ ] iOS: Tap Market → Browser header tab, verify no white screen
- [ ] iOS: Tap Browser → Market header tab, verify no white screen
- [ ] iOS: Tap Market → DeFi and DeFi → Browser, verify still works
- [ ] iOS: Swipe between all tabs, verify gesture navigation still works
- [ ] Android: Repeat all above tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
