### PR TITLE
feat: dual-channel Slack notification for bundle builds with branch/commit info

### DIFF
--- a/.github/workflows/release-app-bundles.yml
+++ b/.github/workflows/release-app-bundles.yml
@@ -13,7 +13,9 @@ jobs:
     outputs:
       build_number: ${{ steps.params.outputs.build_number }}
       build_bundle_version: ${{ steps.params.outputs.build_bundle_version }}
-      notify_slack: ${{ steps.params.outputs.notify_slack }}
+      build_source: ${{ steps.params.outputs.build_source }}
+      branch: ${{ steps.params.outputs.branch }}
+      commit: ${{ steps.params.outputs.commit }}
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -23,14 +25,14 @@ jobs:
         run: |
           # Read BUILD_NUMBER from .env.version
           BUILD_NUMBER=""
-          NOTIFY_SLACK="false"
+          BUILD_SOURCE="bundle-dev"
           if [ -f .env.version ]; then
             BUILD_NUMBER=$(grep -E '^BUILD_NUMBER=' .env.version | cut -d '=' -f 2 || true)
           fi
 
           if [ -n "$BUILD_NUMBER" ]; then
             echo "Found BUILD_NUMBER in .env.version: $BUILD_NUMBER"
-            NOTIFY_SLACK="true"
+            BUILD_SOURCE="bundle-release"
           else
             # Fallback: daily-build-dev format 1000MMDD{run_number % 100}
             DATE=$(date -u "+%m%d")
@@ -47,12 +49,14 @@ jobs:
 
           echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
           echo "build_bundle_version=$BUILD_BUNDLE_VERSION" >> $GITHUB_OUTPUT
-          echo "notify_slack=$NOTIFY_SLACK" >> $GITHUB_OUTPUT
+          echo "build_source=$BUILD_SOURCE" >> $GITHUB_OUTPUT
+          echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          echo "commit=${{ github.sha }}" >> $GITHUB_OUTPUT
 
           echo "Summary:"
           echo "  BUILD_NUMBER=$BUILD_NUMBER"
           echo "  BUILD_BUNDLE_VERSION=$BUILD_BUNDLE_VERSION"
-          echo "  NOTIFY_SLACK=$NOTIFY_SLACK"
+          echo "  BUILD_SOURCE=$BUILD_SOURCE"
 
   desktop-bundle:
     needs: prepare-params
@@ -60,8 +64,9 @@ jobs:
     with:
       build_number: ${{ needs.prepare-params.outputs.build_number }}
       build_bundle_version: ${{ needs.prepare-params.outputs.build_bundle_version }}
-      notify_slack: ${{ needs.prepare-params.outputs.notify_slack == 'true' }}
-      build_source: 'bundle-release'
+      build_source: ${{ needs.prepare-params.outputs.build_source }}
+      branch: ${{ needs.prepare-params.outputs.branch }}
+      commit: ${{ needs.prepare-params.outputs.commit }}
     secrets: inherit
 
   native-bundle:
@@ -70,6 +75,7 @@ jobs:
     with:
       build_number: ${{ needs.prepare-params.outputs.build_number }}
       build_bundle_version: ${{ needs.prepare-params.outputs.build_bundle_version }}
-      notify_slack: ${{ needs.prepare-params.outputs.notify_slack == 'true' }}
-      build_source: 'bundle-release'
+      build_source: ${{ needs.prepare-params.outputs.build_source }}
+      branch: ${{ needs.prepare-params.outputs.branch }}
+      commit: ${{ needs.prepare-params.outputs.commit }}
     secrets: inherit

--- a/.github/workflows/release-desktop-bundle.yml
+++ b/.github/workflows/release-desktop-bundle.yml
@@ -15,14 +15,16 @@ on:
       build_bundle_version:
         type: string
         required: true
-      notify_slack:
-        type: boolean
-        required: false
-        default: true
       build_source:
         type: string
         required: false
         default: 'daily-build'
+      branch:
+        type: string
+        required: false
+      commit:
+        type: string
+        required: false
 
 env:
   NODE_ENV: production
@@ -80,6 +82,26 @@ jobs:
           # Also update .env file since shared-env already wrote the old values
           sed -i "s/^BUNDLE_VERSION=.*/BUNDLE_VERSION=${{ inputs.build_bundle_version }}/" .env
           sed -i "s/^CI_BUILD_NUMBER=.*/CI_BUILD_NUMBER=${{ inputs.build_number }}/" .env
+
+      - name: Resolve branch and commit
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_COMMIT: ${{ inputs.commit }}
+          WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WR_COMMIT: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if [ -n "$INPUT_BRANCH" ]; then
+            BRANCH="$INPUT_BRANCH"
+            COMMIT="$INPUT_COMMIT"
+          elif [ -n "$WR_COMMIT" ]; then
+            BRANCH="$WR_BRANCH"
+            COMMIT="$WR_COMMIT"
+          else
+            BRANCH="${{ github.ref_name }}"
+            COMMIT="${{ github.sha }}"
+          fi
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+          echo "COMMIT=$COMMIT" >> $GITHUB_ENV
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -195,7 +217,6 @@ jobs:
           pr-title: ${{ github.event.pull_request.title || github.event.workflow_run.name || '' }}
 
       - name: 'Notify to Slack'
-        if: ${{ github.event.workflow_run || inputs.notify_slack }}
         uses: originalix/actions/slack-notify-webhook@feat/bundle-release-notification
         with:
           web-hook-url: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
@@ -208,3 +229,5 @@ jobs:
           artifact-download-url: '${{ env.ARTIFACTS_URL }}'
           artifact-bundle-version: '${{ env.BUILD_BUNDLE_VERSION }}'
           artifact-build-source: '${{ inputs.build_source || ''daily-build'' }}'
+          artifact-branch: '${{ env.BRANCH }}'
+          artifact-commit: '${{ env.COMMIT }}'

--- a/.github/workflows/release-desktop-bundle.yml
+++ b/.github/workflows/release-desktop-bundle.yml
@@ -212,8 +212,8 @@ jobs:
           server-url: ${{ secrets.QA_JS_BUNDLE_SERVER_URL }}
           upload-secret: ${{ secrets.QA_JS_BUNDLE_UPLOAD_SECRET }}
           bundle-dir: ./apps/desktop/bundle-zip
-          commit-hash: ${{ github.sha }}
-          branch: ${{ github.ref_name }}
+          commit-hash: ${{ env.COMMIT }}
+          branch: ${{ env.BRANCH }}
           pr-title: ${{ github.event.pull_request.title || github.event.workflow_run.name || '' }}
 
       - name: 'Notify to Slack'

--- a/.github/workflows/release-native-bundle.yml
+++ b/.github/workflows/release-native-bundle.yml
@@ -15,14 +15,16 @@ on:
       build_bundle_version:
         type: string
         required: true
-      notify_slack:
-        type: boolean
-        required: false
-        default: true
       build_source:
         type: string
         required: false
         default: 'daily-build'
+      branch:
+        type: string
+        required: false
+      commit:
+        type: string
+        required: false
 
 env:
   NODE_ENV: production
@@ -81,6 +83,26 @@ jobs:
           sed -i '' "s/^BUNDLE_VERSION=.*/BUNDLE_VERSION=${{ inputs.build_bundle_version }}/" .env
           sed -i '' "s/^CI_BUILD_NUMBER=.*/CI_BUILD_NUMBER=${{ inputs.build_number }}/" .env
 
+      - name: Resolve branch and commit
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_COMMIT: ${{ inputs.commit }}
+          WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WR_COMMIT: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if [ -n "$INPUT_BRANCH" ]; then
+            BRANCH="$INPUT_BRANCH"
+            COMMIT="$INPUT_COMMIT"
+          elif [ -n "$WR_COMMIT" ]; then
+            BRANCH="$WR_BRANCH"
+            COMMIT="$WR_COMMIT"
+          else
+            BRANCH="${{ github.ref_name }}"
+            COMMIT="${{ github.sha }}"
+          fi
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+          echo "COMMIT=$COMMIT" >> $GITHUB_ENV
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
@@ -138,7 +160,6 @@ jobs:
           pr-title: ${{ github.event.pull_request.title || github.event.workflow_run.name || '' }}
 
       - name: 'Notify to Slack'
-        if: ${{ github.event.workflow_run || inputs.notify_slack }}
         uses: originalix/actions/slack-notify-webhook@feat/bundle-release-notification
         continue-on-error: true
         with:
@@ -152,3 +173,5 @@ jobs:
           artifact-download-url: '${{ env.ARTIFACTS_URL }}'
           artifact-bundle-version: '${{ env.BUILD_BUNDLE_VERSION }}'
           artifact-build-source: '${{ inputs.build_source || ''daily-build'' }}'
+          artifact-branch: '${{ env.BRANCH }}'
+          artifact-commit: '${{ env.COMMIT }}'

--- a/.github/workflows/release-native-bundle.yml
+++ b/.github/workflows/release-native-bundle.yml
@@ -155,8 +155,8 @@ jobs:
           server-url: ${{ secrets.QA_JS_BUNDLE_SERVER_URL }}
           upload-secret: ${{ secrets.QA_JS_BUNDLE_UPLOAD_SECRET }}
           bundle-dir: ./apps/mobile/out-dir-bundle-zip
-          commit-hash: ${{ github.sha }}
-          branch: ${{ github.ref_name }}
+          commit-hash: ${{ env.COMMIT }}
+          branch: ${{ env.BRANCH }}
           pr-title: ${{ github.event.pull_request.title || github.event.workflow_run.name || '' }}
 
       - name: 'Notify to Slack'


### PR DESCRIPTION
## Summary
- Route `bundle-dev` builds to a separate Slack channel (`SLACK_BUNDLE_RELEASE_CHANNEL_ID`), while `bundle-release` and `daily-build` continue using the existing release channel
- Add branch name and commit SHA to all bundle notification messages for easier identification by devs and QA
- Always send Slack notifications for all bundle builds (remove `notify_slack` conditional gate)

## Intent & Context
Previously, `release-app-bundles.yml` only sent Slack notifications for release branches with a `BUILD_NUMBER` in `.env.version`. Non-release (dev) bundle builds were completely silent, making it difficult for developers and QA to discover and locate dev bundles. This change introduces a new `bundle-dev` build source that routes to a dedicated Slack channel, while preserving existing `bundle-release` and `daily-build` behavior unchanged.

## Design Decisions
- **Channel routing via `buildSource`**: Reuses the existing `buildSource` field (`bundle-release` / `daily-build` / `bundle-dev`) to determine which Slack channel to post to, avoiding new parameters
- **Branch/commit resolution by trigger type**: A "Resolve branch and commit" step handles three trigger paths (`workflow_call`, `workflow_run`, `workflow_dispatch`) with correct precedence, using env vars to avoid shell injection
- **Always notify**: Removed `notify_slack` boolean entirely — all bundle builds now send notifications, simplifying the logic
- **Backward compatible**: Worker changes accept new fields as optional, allowing phased deployment (worker first, then action, then workflows)

## Changes Detail
- **`release-app-bundles.yml`**: Replace `notify_slack` with `build_source` output (`bundle-release` when BUILD_NUMBER exists, `bundle-dev` otherwise). Add `branch` and `commit` outputs. Pass dynamic `build_source` to sub-workflows instead of hardcoded `'bundle-release'`
- **`release-desktop-bundle.yml`**: Remove `notify_slack` input, add `branch`/`commit` inputs. Add "Resolve branch and commit" step. Remove `if` condition on Notify step, add `artifact-branch`/`artifact-commit` params
- **`release-native-bundle.yml`**: Same changes as desktop, preserving `continue-on-error: true` on the Notify step

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: All (CI/CD pipeline change, not app code)
- **Risk Areas**: The workflow changes are backward-compatible — if the worker/action haven't been updated yet, the new inputs are silently ignored by GitHub Actions and the existing notification behavior continues unchanged

## Test plan
- [ ] Trigger `release-app-bundles.yml` on a branch without `.env.version` BUILD_NUMBER → verify `build_source` output is `bundle-dev`
- [ ] Trigger on a release branch with BUILD_NUMBER → verify `build_source` is `bundle-release`
- [ ] Verify `branch` and `commit` outputs are correctly populated
- [ ] After worker/action deployment: verify dev notifications appear in the new channel with branch/commit info
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
