### PR TITLE
fix: improve bundle list UI and workflow build number format

### DIFF
--- a/.github/workflows/release-app-bundles.yml
+++ b/.github/workflows/release-app-bundles.yml
@@ -34,11 +34,11 @@ jobs:
             echo "Found BUILD_NUMBER in .env.version: $BUILD_NUMBER"
             BUILD_SOURCE="bundle-release"
           else
-            # Fallback: daily-build-dev format 1000MMDD{run_number % 100}
-            DATE=$(date -u "+%m%d")
+            # Fallback: bundle-dev format 10YYMMDD{run_number % 100}
+            DATE=$(date -u "+%y%m%d")
             RUN_MOD=$(( $GITHUB_RUN_NUMBER % 100 ))
             RUN_MOD=$(printf "%02d" $RUN_MOD)
-            BUILD_NUMBER="1000${DATE}${RUN_MOD}"
+            BUILD_NUMBER="10${DATE}${RUN_MOD}"
             echo "Generated BUILD_NUMBER: $BUILD_NUMBER"
           fi
 

--- a/.github/workflows/release-desktop-bundle.yml
+++ b/.github/workflows/release-desktop-bundle.yml
@@ -102,6 +102,8 @@ jobs:
           fi
           echo "BRANCH=$BRANCH" >> $GITHUB_ENV
           echo "COMMIT=$COMMIT" >> $GITHUB_ENV
+          COMMIT_MESSAGE=$(git log -1 --pretty=%s "$COMMIT" 2>/dev/null || echo "")
+          echo "COMMIT_MESSAGE=$COMMIT_MESSAGE" >> $GITHUB_ENV
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -214,7 +216,7 @@ jobs:
           bundle-dir: ./apps/desktop/bundle-zip
           commit-hash: ${{ env.COMMIT }}
           branch: ${{ env.BRANCH }}
-          pr-title: ${{ github.event.pull_request.title || github.event.workflow_run.name || '' }}
+          pr-title: ${{ env.COMMIT_MESSAGE }}
 
       - name: 'Notify to Slack'
         uses: originalix/actions/slack-notify-webhook@feat/bundle-release-notification

--- a/.github/workflows/release-native-bundle.yml
+++ b/.github/workflows/release-native-bundle.yml
@@ -102,6 +102,8 @@ jobs:
           fi
           echo "BRANCH=$BRANCH" >> $GITHUB_ENV
           echo "COMMIT=$COMMIT" >> $GITHUB_ENV
+          COMMIT_MESSAGE=$(git log -1 --pretty=%s "$COMMIT" 2>/dev/null || echo "")
+          echo "COMMIT_MESSAGE=$COMMIT_MESSAGE" >> $GITHUB_ENV
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -157,7 +159,7 @@ jobs:
           bundle-dir: ./apps/mobile/out-dir-bundle-zip
           commit-hash: ${{ env.COMMIT }}
           branch: ${{ env.BRANCH }}
-          pr-title: ${{ github.event.pull_request.title || github.event.workflow_run.name || '' }}
+          pr-title: ${{ env.COMMIT_MESSAGE }}
 
       - name: 'Notify to Slack'
         uses: originalix/actions/slack-notify-webhook@feat/bundle-release-notification

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -1297,6 +1297,7 @@ class ServiceAppUpdate extends ServiceBase {
   @backgroundMethod()
   async devFetchBundlesForVersion(version: string): Promise<
     {
+      bundleVersion?: string;
       ciBundleVersion: string;
       downloadUrl: string;
       sha256: string;
@@ -1306,6 +1307,7 @@ class ServiceAppUpdate extends ServiceBase {
       branch?: string;
       prTitle?: string;
       changeLog?: string;
+      buildNumber?: string;
     }[]
   > {
     try {
@@ -1313,6 +1315,7 @@ class ServiceAppUpdate extends ServiceBase {
       const response = await client.get<{
         code: number;
         data: {
+          bundleVersion?: string;
           ciBundleVersion: string;
           downloadUrl: string;
           sha256: string;
@@ -1321,6 +1324,7 @@ class ServiceAppUpdate extends ServiceBase {
           commitHash?: string;
           branch?: string;
           prTitle?: string;
+          buildNumber?: string;
         }[];
       }>('/utility/v1/app-update/bundles', {
         params: { version },
@@ -1338,6 +1342,7 @@ class ServiceAppUpdate extends ServiceBase {
           })),
         });
         return data.map((item) => ({
+          bundleVersion: item.bundleVersion,
           ciBundleVersion: item.ciBundleVersion,
           downloadUrl: item.downloadUrl,
           sha256: item.sha256,
@@ -1349,6 +1354,7 @@ class ServiceAppUpdate extends ServiceBase {
           changeLog: item.commitHash
             ? `${item.branch || ''} ${item.commitHash.slice(0, 8)}`.trim()
             : undefined,
+          buildNumber: item.buildNumber,
         }));
       }
       defaultLogger.app.jsBundleDev.fetchBundlesError({

--- a/packages/kit/src/views/Setting/pages/DevBundleSwitcher/BundleList.tsx
+++ b/packages/kit/src/views/Setting/pages/DevBundleSwitcher/BundleList.tsx
@@ -36,6 +36,7 @@ import type { RouteProp } from '@react-navigation/core';
 const PLACEHOLDER_SIGNATURE = 'dev-no-signature';
 
 type IBundleInfo = {
+  bundleVersion?: string;
   ciBundleVersion: string;
   downloadUrl: string;
   sha256: string;
@@ -45,6 +46,7 @@ type IBundleInfo = {
   branch?: string;
   prTitle?: string;
   changeLog?: string;
+  buildNumber?: string;
 };
 
 function normalizeCommitHash(commitHash?: string) {
@@ -253,20 +255,16 @@ function BundleItem({
 
   const downloadDisabled = isDownloading && status !== 'downloading';
 
-  const commitHashShort = bundle.commitHash
-    ? bundle.commitHash.slice(0, 8)
-    : undefined;
-
   return (
     <YStack px="$4" py="$3" gap="$2">
-      {/* Row 1: commitHash + badges + action button */}
+      {/* Row 1: bundleVersion + branch badge + status badges + action */}
       <XStack alignItems="center" justifyContent="space-between">
         <XStack alignItems="center" gap="$2" flex={1}>
           {isCurrentBundle ? (
             <Icon name="CheckRadioSolid" size="$4.5" color="$iconSuccess" />
           ) : null}
           <SizableText size="$bodyMdMedium">
-            {commitHashShort || bundle.ciBundleVersion}
+            {`#${bundle.ciBundleVersion}`}
           </SizableText>
           <Badge badgeType="default" badgeSize="sm">
             <Badge.Text>{bundle.branch || '-'}</Badge.Text>
@@ -294,22 +292,30 @@ function BundleItem({
         ) : null}
       </XStack>
 
-      {/* Row 2: prTitle */}
-      {bundle.prTitle ? (
-        <SizableText size="$bodySm" color="$textSubdued" numberOfLines={2}>
-          {bundle.prTitle}
+      {/* Row 2: buildNumber + ciBundleVersion (encoded) + fileSize */}
+      <SizableText size="$bodySm" color="$textSubdued">
+        {[
+          bundle.buildNumber,
+          encodeBundleVersionForDisplay(bundle.ciBundleVersion),
+          formatFileSize(bundle.fileSize),
+        ]
+          .filter(Boolean)
+          .join(' · ')}
+      </SizableText>
+
+      {/* Row 3: commitHash */}
+      {bundle.commitHash ? (
+        <SizableText size="$bodyXs" color="$textSubdued">
+          {bundle.commitHash.slice(0, 8)}
         </SizableText>
       ) : null}
 
-      {/* Row 3: ciBundleVersion + fileSize */}
-      <XStack alignItems="center" gap="$2">
-        <SizableText size="$bodyXs" color="$textDisabled">
-          {`#${bundle.ciBundleVersion} (${encodeBundleVersionForDisplay(bundle.ciBundleVersion)})`}
+      {/* Row 4: prTitle (least prominent) */}
+      {bundle.prTitle ? (
+        <SizableText size="$bodyXs" color="$textDisabled" numberOfLines={1}>
+          {bundle.prTitle}
         </SizableText>
-        <SizableText size="$bodyXs" color="$textDisabled">
-          {formatFileSize(bundle.fileSize)}
-        </SizableText>
-      </XStack>
+      ) : null}
 
       {/* Status: downloading */}
       {status === 'downloading' ? (


### PR DESCRIPTION
## Summary
- Improve bundle list UI visual hierarchy for better readability in DevBundleSwitcher
- Use commit message instead of PR title/workflow name for bundle notification context
- Fix BUILD_NUMBER format to include year, preventing cross-year collisions

## Intent & Context
Three related improvements to the bundle dev workflow:
1. The bundle list UI had poor visual hierarchy — commit hash, branch, build metadata, and PR title were not clearly prioritized. Reorganized the layout to surface the most useful info first.
2. Bundle Slack notifications were using `github.event.pull_request.title` or `github.event.workflow_run.name` for context, which are empty or generic when triggered via `workflow_dispatch`. Switched to extracting the actual commit message from the commit SHA.
3. The fallback BUILD_NUMBER format `1000MMDD{run%100}` had no year component, meaning builds on the same month+day in different years would produce identical build numbers. Changed to `10YYMMDD{run%100}` — same 10-digit length, no cross-year collision.

## Design Decisions
- **Bundle list layout**: Prioritized `ciBundleVersion` as primary identifier (Row 1), then `buildNumber · encodedVersion · fileSize` as metadata (Row 2), commit hash (Row 3), and PR title as least prominent (Row 4). This matches the information hierarchy developers actually need when picking a bundle.
- **Commit message extraction**: Used `git log -1 --pretty=%s "$COMMIT"` with fallback to empty string, keeping it simple and reliable across all trigger types.
- **BUILD_NUMBER format `10YYMMDD{run%100}`**: Keeps 10-digit length (no int32 overflow risk), naturally sorts higher than old `1000MMDD` numbers, and the `1000*` prefix check in `release-ios.yml`/`release-android.yml` is unaffected since those are on a completely separate pipeline.

## Changes Detail
- `packages/kit/src/views/Setting/pages/DevBundleSwitcher/BundleList.tsx` — Reorganized bundle item layout, added `bundleVersion` and `buildNumber` fields to type
- `packages/kit-bg/src/services/ServiceAppUpdate.ts` — Added `bundleVersion` and `buildNumber` to API response type and mapping
- `.github/workflows/release-native-bundle.yml` — Extract commit message into env var, pass as `pr-title`
- `.github/workflows/release-desktop-bundle.yml` — Same commit message extraction
- `.github/workflows/release-app-bundles.yml` — Changed date format from `%m%d` to `%y%m%d`, prefix from `1000` to `10`

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: All (bundle list UI is cross-platform; workflow changes are CI-only)
- **Risk Areas**: BUILD_NUMBER format change could affect any system that parses or compares build numbers — verified no downstream `1000` matching in bundle workflows

## Test plan
- [ ] Trigger `release-app-bundles` workflow on a test branch, verify BUILD_NUMBER format is `10YYMMDDXX`
- [ ] Verify Slack notification shows commit message instead of empty/generic text
- [ ] Open DevBundleSwitcher, verify bundle list displays with new layout hierarchy
- [ ] Verify bundle download and apply still works correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
