### PR TITLE
fix(perps): batch bug fixes for trading form, token selector, and favorites(OK-51815 OK-51816 OK-51743 OK-51741 OK-50115)

### DIFF
--- a/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
@@ -129,7 +129,7 @@ function MobileTokenSelectorModal({
 
   const [{ assetsByDex }] = usePerpsAllAssetsFilteredAtom();
   const [{ assetCtxsByDex }] = usePerpsAllAssetCtxsAtom();
-  const { favoriteItems } = usePerpsFavorites();
+  const { favoriteItems, isReady: isFavoritesReady } = usePerpsFavorites();
   const [selectorConfig, setSelectorConfig] =
     usePerpTokenSelectorConfigPersistAtom();
   const [dynamicTabsRaw] = usePerpTokenSelectorTabsAtom();
@@ -162,9 +162,6 @@ function MobileTokenSelectorModal({
     }
     lastSortRef.current = { field, direction, activeTab: currentTab };
     ctxSnapshotRef.current = assetCtxsByDex;
-    if (sortChanged) {
-      listRef.current?.scrollToOffset?.({ offset: 0, animated: false });
-    }
   }, [
     selectorConfig?.direction,
     selectorConfig?.field,
@@ -538,6 +535,7 @@ function MobileTokenSelectorModal({
       <Page.Body>
         <YStack flex={1} mt="$2">
           <ListView
+            key={`${activeTab}-${selectorConfig?.field ?? ''}-${selectorConfig?.direction ?? ''}`}
             useFlashList
             ref={listRef}
             keyExtractor={keyExtractor}
@@ -552,7 +550,7 @@ function MobileTokenSelectorModal({
             data={mockedListData}
             renderItem={renderItem}
             ListEmptyComponent={
-              activeTab === 'favorites' && !searchQuery ? (
+              activeTab === 'favorites' && !searchQuery && isFavoritesReady ? (
                 <FavoritesEmptyState isMobile />
               ) : (
                 <XStack p="$5" justifyContent="center">

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -213,7 +213,6 @@ function BasePerpTokenSelectorContent({
             }) as any,
         );
       });
-      listRef.current?.scrollToOffset?.({ offset: 0, animated: false });
     },
     [setSelectorConfig],
   );
@@ -235,7 +234,7 @@ function BasePerpTokenSelectorContent({
     [closePopover, actions, onLoadingChange],
   );
 
-  const { favoriteItems } = usePerpsFavorites();
+  const { favoriteItems, isReady: isFavoritesReady } = usePerpsFavorites();
 
   // Freeze sort order while popover is open; refreshed on sort change or first data arrival.
   const ctxSnapshotRef = useRef(assetCtxsByDex);
@@ -451,7 +450,10 @@ function BasePerpTokenSelectorContent({
   );
 
   const showFavoritesEmpty =
-    activeTab === 'favorites' && activeTabData.length === 0 && !searchQuery;
+    activeTab === 'favorites' &&
+    activeTabData.length === 0 &&
+    !searchQuery &&
+    isFavoritesReady;
 
   const listEmptyComponent = useMemo(
     () =>
@@ -527,6 +529,7 @@ function BasePerpTokenSelectorContent({
               <FavoritesEmptyState />
             ) : (
               <ListView
+                key={activeTab}
                 useFlashList
                 ref={listRef}
                 keyExtractor={keyExtractor}

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
@@ -215,11 +215,17 @@ const TokenInfoCellDesktop = memo(() => {
           justifyContent="flex-start"
           gap="$1.5"
           alignItems="center"
-          pr="$1"
-          overflow="hidden"
           minWidth={0}
         >
           <FavoriteButton coin={token.name} />
+          <XStack
+            gap="$1.5"
+            alignItems="center"
+            overflow="hidden"
+            pr="$1"
+            flex={1}
+            minWidth={0}
+          >
           <Token
             size="xs"
             borderRadius="$full"
@@ -253,6 +259,7 @@ const TokenInfoCellDesktop = memo(() => {
                 withTooltip
               />
             ) : null}
+          </XStack>
           </XStack>
         </XStack>
       </DebugRenderTracker>

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
@@ -226,40 +226,40 @@ const TokenInfoCellDesktop = memo(() => {
             flex={1}
             minWidth={0}
           >
-          <Token
-            size="xs"
-            borderRadius="$full"
-            tokenImageUri={getHyperliquidTokenImageUrl(token.displayName)}
-            fallbackIcon="CryptoCoinOutline"
-          />
-          <SizableText size="$bodySmMedium" numberOfLines={1} flexShrink={1}>
-            {token.displayName}
-          </SizableText>
-          <XStack gap="$1" minWidth={0}>
-            <XStack
-              borderRadius="$1"
-              bg="$bgStrong"
-              justifyContent="center"
-              alignItems="center"
-              px="$1.5"
-            >
-              <SizableText
-                fontSize={10}
-                alignSelf="center"
-                color="$textSubdued"
-                lineHeight={16}
+            <Token
+              size="xs"
+              borderRadius="$full"
+              tokenImageUri={getHyperliquidTokenImageUrl(token.displayName)}
+              fallbackIcon="CryptoCoinOutline"
+            />
+            <SizableText size="$bodySmMedium" numberOfLines={1} flexShrink={1}>
+              {token.displayName}
+            </SizableText>
+            <XStack gap="$1" minWidth={0}>
+              <XStack
+                borderRadius="$1"
+                bg="$bgStrong"
+                justifyContent="center"
+                alignItems="center"
+                px="$1.5"
               >
-                {token.maxLeverage}x
-              </SizableText>
+                <SizableText
+                  fontSize={10}
+                  alignSelf="center"
+                  color="$textSubdued"
+                  lineHeight={16}
+                >
+                  {token.maxLeverage}x
+                </SizableText>
+              </XStack>
+              {token.subtitle && gtLg ? (
+                <SubtitleBadge
+                  subtitle={token.subtitle}
+                  maxWidth={DESKTOP_SUBTITLE_MAX_WIDTH}
+                  withTooltip
+                />
+              ) : null}
             </XStack>
-            {token.subtitle && gtLg ? (
-              <SubtitleBadge
-                subtitle={token.subtitle}
-                maxWidth={DESKTOP_SUBTITLE_MAX_WIDTH}
-                withTooltip
-              />
-            ) : null}
-          </XStack>
           </XStack>
         </XStack>
       </DebugRenderTracker>

--- a/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
@@ -222,6 +222,11 @@ export const SizeInput = memo(
     useEffect(() => {
       if (isSliderMode) return;
 
+      if (!prevValueRef.current) {
+        prevPriceRef.current = referencePrice;
+        return;
+      }
+
       const priceChanged = prevPriceRef.current !== referencePrice;
       if (priceChanged) {
         prevPriceRef.current = referencePrice;

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -872,7 +872,7 @@ function PerpTradingForm({
                         applyPrimaryOrderType(option.value);
                       }
                     }}
-                    cursor="default"
+                    cursor="pointer"
                   >
                     <SizableText
                       size="$bodyMdMedium"
@@ -909,6 +909,7 @@ function PerpTradingForm({
                     alignItems="center"
                     position="relative"
                     gap="$1"
+                    cursor="pointer"
                     onPress={(e) => {
                       if (disabledTrigger) return;
                       if (!isTriggerMode) {

--- a/packages/kit/src/views/Perp/components/TradingPanel/selectors/OrderTypeSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/selectors/OrderTypeSelector.tsx
@@ -54,7 +54,7 @@ export const OrderTypeSelector = memo<IOrderTypeSelectorProps>(
             justifyContent="space-between"
             px="$3"
             flex={1}
-            cursor="default"
+            cursor="pointer"
           >
             <SizableText size="$bodyMdMedium">{label}</SizableText>
             <Icon

--- a/packages/kit/src/views/Perp/hooks/usePerpsFavorites.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpsFavorites.ts
@@ -13,7 +13,10 @@ export type IFavoriteItem = {
   dexIndex: number;
 };
 
-export function usePerpsFavorites(): { favoriteItems: IFavoriteItem[] } {
+export function usePerpsFavorites(): {
+  favoriteItems: IFavoriteItem[];
+  isReady: boolean;
+} {
   const [favorites] = usePerpTokenFavoritesPersistAtom();
 
   // Fetch the full universe independently — must not read from the
@@ -66,5 +69,5 @@ export function usePerpsFavorites(): { favoriteItems: IFavoriteItem[] } {
     return items;
   }, [universe, favorites.favorites]);
 
-  return { favoriteItems };
+  return { favoriteItems, isReady: universe !== undefined };
 }


### PR DESCRIPTION
## Summary
- Fix trigger order not clearing button display state after submission
- Add cursor:pointer to Market/Limit/Trigger order type buttons on desktop hover
- Fix star icon hover shadow clipping in token selector rows
- Fix mobile token selector "Perps" tab showing blank and items disappearing on sort
- Fix Android favorites tab flashing "add favorites" empty state on every open
- Fix desktop token selector not scrolling to top on tab switch

## Intent & Context
Batch of Perps UI bug fixes reported by QA during App-6.1.0 testing cycle. Each fix addresses a specific user-facing issue that degrades the trading experience.

## Root Cause

**OK-51815 (Form not cleared):** In `SizeInput`, when `resetTradingForm()` clears both `size` and `triggerPrice` simultaneously, the `referencePrice` changes (falls back from triggerPrice to midPrice). The price-change effect fires in the same render cycle as the value-change effect, but reads the OLD `usdAmount` from its closure (not yet committed by setState). It then recalculates a token value and writes it back to `formData.size` via `onChange`, undoing the reset.

**OK-51816 (Cursor):** Order type tab buttons had `cursor="default"` instead of `cursor="pointer"`.

**OK-51743 (Star shadow clipping):** The `FavoriteButton` was inside an `overflow="hidden"` container, clipping its hover shadow on the left side.

**OK-51741 (Blank tab / disappearing items):** FlashList's internal layout cache and recycling mechanism doesn't properly handle significant data changes (tab switching from small to large datasets, or data reordering from sort changes). This is a known FlashList limitation — it preserves scroll offset and layout state across data changes, which causes blank renders or recycled items to disappear. **Trade-off note:** The fix uses React `key` prop (including activeTab + sort config) to force FlashList rebuild on tab/sort changes. This sacrifices FlashList's recycling optimization for correctness. For ~300 items with simple rows, the rebuild cost is negligible compared to the alternative of visible rendering bugs. A FlashList patch was considered but rejected — `key` is the idiomatic React solution for resetting component state, and the FlashList behavior (preserving scroll position) is correct for other use cases like real-time price updates.

**OK-50115 (Favorites flash):** `globalAtom({ persist: true })` initializes with `{ favorites: [] }` and loads persisted data asynchronously (`getOnInit = false` in jotaiStorage). On first render, favorites is empty, triggering `FavoritesEmptyState`. Android's slower storage makes the flash visible.

## Changes Detail
- `SizeInput.tsx`: Guard price-change effect with `prevValueRef.current` check — skip recalculation when value was externally cleared
- `PerpTradingForm.tsx`: Change `cursor="default"` to `cursor="pointer"` on Market/Limit tabs, add `cursor="pointer"` to Trigger dropdown
- `OrderTypeSelector.tsx`: Change `cursor="default"` to `cursor="pointer"` on mobile order type selector
- `PerpTokenSelectorRow.tsx`: Move `FavoriteButton` outside the `overflow="hidden"` container
- `MoblieTokenSelector.tsx`: Add composite `key` (tab + sort config) to FlashList, remove stale `scrollToOffset`, defer empty state until `isFavoritesReady`
- `PerpTokenSelector.tsx`: Add `key={activeTab}` to desktop FlashList, remove stale `scrollToOffset` from `setActiveTab`, defer empty state until `isFavoritesReady`
- `usePerpsFavorites.ts`: Expose `isReady` flag based on universe data load status

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop (OK-51816, OK-51743), Mobile (OK-51741, OK-50115), All (OK-51815)
- **Risk Areas**: FlashList key rebuild may cause brief re-render on tab/sort change; SizeInput guard could theoretically skip a legitimate price recalculation when the user manually clears input and price changes simultaneously (extremely unlikely edge case)

## Test plan
- [ ] Desktop: Hover Market/Limit/Trigger buttons — cursor should be pointer
- [ ] Desktop: Star icon hover shadow in token selector should not be clipped
- [ ] Desktop: Switch token selector tabs — list should start from top
- [ ] Mobile: Place a trigger order in USD mode — buttons should clear after submission
- [ ] Mobile: Switch between token selector tabs including "Perps" — no blank tab
- [ ] Mobile: Repeatedly sort within a small tab — no items should disappear
- [ ] Android: Open Perps with favorites tab active — should not flash "add favorites" page
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
