### PR TITLE
fix(market): fix watchlist blank space and banner flash on mobile

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerList.tsx
@@ -62,12 +62,15 @@ const MarketBannerListSkeleton = memo(MarketBannerListSkeletonComponent);
 function MarketBannerListComponent() {
   const toMarketBannerDetail = useToMarketBannerDetail();
   const { md } = useMedia();
-  const { bannerList, isLoading } = useMarketBannerList();
+  const { bannerList, isLoading, isFetched } = useMarketBannerList();
 
   // md = true when screen width <= 767px (small screen)
   const isSmallScreen = md;
 
-  if (isLoading) {
+  // Only show skeleton on initial load (before first fetch completes).
+  // Skip skeleton on re-fetch to avoid header height flicker when
+  // navigating back with no banners.
+  if (isLoading && !isFetched) {
     return <MarketBannerListSkeleton isSmallScreen={isSmallScreen} />;
   }
 

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/useMarketBannerList.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/useMarketBannerList.ts
@@ -6,6 +6,7 @@ import type { IMarketBannerItem } from '@onekeyhq/shared/types/marketV2';
 export function useMarketBannerList(): {
   bannerList: IMarketBannerItem[];
   isLoading: boolean;
+  isFetched: boolean;
 } {
   const [devSettings] = useDevSettingsPersistAtom();
   const enableMockMarketBanner =
@@ -30,5 +31,6 @@ export function useMarketBannerList(): {
   return {
     bannerList: bannerList || [],
     isLoading: isLoading ?? false,
+    isFetched: bannerList !== undefined,
   };
 }

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MobileMarketWatchlistFlatList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MobileMarketWatchlistFlatList.tsx
@@ -869,6 +869,9 @@ function MobileMarketWatchlistFlatListImpl({
     if (showSkeleton) {
       return <TokenListSkeleton count={10} />;
     }
+    if (watchlist.length === 0) {
+      return <MarketRecommendList recommendedTokens={recommendedTokens} />;
+    }
     return (
       <Stack alignItems="center" justifyContent="center" p="$8" mt="$10">
         <SizableText size="$bodyLg" color="$textSubdued">
@@ -876,7 +879,7 @@ function MobileMarketWatchlistFlatListImpl({
         </SizableText>
       </Stack>
     );
-  }, [showSkeleton, intl]);
+  }, [showSkeleton, intl, watchlist.length, recommendedTokens]);
 
   const tabBarHeight = useScrollContentTabBarOffset();
   const contentContainerStyle = useMemo(
@@ -892,15 +895,6 @@ function MobileMarketWatchlistFlatListImpl({
   // Wait for data to be loaded
   if (!watchlistState.isMounted) {
     return <Tabs.ScrollView />;
-  }
-
-  // Show recommend list when watchlist is empty
-  if (watchlist.length === 0) {
-    return (
-      <Tabs.ScrollView>
-        <MarketRecommendList recommendedTokens={recommendedTokens} />
-      </Tabs.ScrollView>
-    );
   }
 
   return (


### PR DESCRIPTION
https://onekeyhq.atlassian.net/browse/OK-51850
## Summary

- **Fix blank space when adding tokens from recommend list in sticky header state**: Always render `DraggableFlatListComponent` and show `MarketRecommendList` via `ListEmptyComponent` instead of switching between `Tabs.ScrollView` and `DraggableFlatList`, which caused `react-native-collapsible-tab-view` to retain stale scroll offset.

- **Fix white flash when navigating back from token detail with no banners**: Add `isFetched` flag to distinguish initial load from re-fetch. Only show banner skeleton on initial load to prevent header height flicker caused by `usePromiseResult` `revalidateOnReconnect` triggering skeleton on every focus regain when banner list is empty.

## Test plan

- [ ] Mobile: Empty watchlist → add tokens from recommend list in sticky header state → no blank space
- [ ] Mobile: Watchlist with tokens → tap token → navigate back → no white flash (with and without banners)
- [ ] Mobile: First load of market page → banner skeleton shows normally
- [ ] Mobile: Watchlist empty state shows recommend list correctly
- [ ] Mobile: Watchlist with items shows token list correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10708" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
