### PR TITLE
fix: handle recovery.html in desktop file protocol interceptor

### DIFF
--- a/apps/desktop/app/app.ts
+++ b/apps/desktop/app/app.ts
@@ -1027,16 +1027,24 @@ async function createMainWindow() {
     logger.info('driveLetter >>>> ', driveLetter);
     const indexHtmlPath =
       globalThis.$desktopMainAppFunctions?.getBundleIndexHtmlPath?.();
-    const useJsBundle = globalThis.$desktopMainAppFunctions?.useJsBundle?.();
+    let useJsBundle = globalThis.$desktopMainAppFunctions?.useJsBundle?.();
     const bundleDirPath = getBundleDirPath();
-    const metadata = bundleDirPath
-      ? await getMetadata({
+    let metadata: Record<string, string> = {};
+    if (bundleDirPath) {
+      try {
+        metadata = await getMetadata({
           bundleDir: bundleDirPath,
           appVersion: bundleData.appVersion,
           bundleVersion: bundleData.bundleVersion,
           signature: bundleData.signature,
-        })
-      : {};
+        });
+      } catch (e) {
+        // GPG verification failed or metadata unreadable — disable JS bundle
+        // so the interceptor falls back to the builtin bundle in the asar.
+        logger.error('getMetadata failed, falling back to builtin bundle:', e);
+        useJsBundle = false;
+      }
+    }
     session.defaultSession.protocol.interceptFileProtocol(
       PROTOCOL,
       (request, callback) => {

--- a/apps/desktop/app/app.ts
+++ b/apps/desktop/app/app.ts
@@ -58,6 +58,7 @@ import * as store from './libs/store';
 import './libs/react-native-mmkv-desktop-main';
 import { getBackgroundColor } from './libs/utils';
 import initProcess from './process';
+import { createRecoveryWindow } from './recoveryWindow';
 import {
   getAppStaticResourcesPath,
   getResourcesPath,
@@ -495,6 +496,33 @@ const defaultSize = 1200;
 const minWidth = 1024;
 const minHeight = 800;
 async function createMainWindow() {
+  // === Boot Recovery Check (must be first) ===
+  const currentAppVersion = app.getVersion();
+  const storedFailVersion = store.getBootFailAppVersion();
+  if (storedFailVersion && storedFailVersion !== currentAppVersion) {
+    store.resetConsecutiveBootFailCount();
+    logger.info(
+      'Boot fail counter reset due to version change',
+      storedFailVersion,
+      '→',
+      currentAppVersion,
+    );
+  }
+  store.setBootFailAppVersion(currentAppVersion);
+  const bootFailCount = store.incrementConsecutiveBootFailCount();
+  logger.info('Boot fail count:', bootFailCount);
+  if (bootFailCount >= 3) {
+    logger.error('Recovery page triggered', {
+      crashCount: bootFailCount,
+      appVersion: currentAppVersion,
+    });
+    const recoveryWin = createRecoveryWindow();
+    recoveryWin.on('closed', () => {
+      mainWindow = null;
+    });
+    return recoveryWin;
+  }
+
   // https://github.com/electron/electron/issues/16168
   const { screen } = require('electron');
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call
@@ -655,40 +683,7 @@ async function createMainWindow() {
     browserWindow.webContents.openDevTools();
   }
 
-  // === Boot Recovery Check ===
-  // Version-aware counter reset
-  const currentAppVersion = app.getVersion();
-  const storedFailVersion = store.getBootFailAppVersion();
-  if (storedFailVersion && storedFailVersion !== currentAppVersion) {
-    store.resetConsecutiveBootFailCount();
-    logger.info(
-      'Boot fail counter reset due to version change',
-      storedFailVersion,
-      '→',
-      currentAppVersion,
-    );
-  }
-  store.setBootFailAppVersion(currentAppVersion);
-
-  // Increment FIRST, then check NEW value (avoids off-by-one)
-  const bootFailCount = store.incrementConsecutiveBootFailCount();
-  logger.info('Boot fail count:', bootFailCount);
-
-  if (bootFailCount >= 3) {
-    logger.error('Recovery page triggered', {
-      crashCount: bootFailCount,
-      appVersion: currentAppVersion,
-    });
-
-    const recoveryUrl = formatUrl({
-      pathname: path.join(__dirname, 'recovery.html'),
-      protocol: PROTOCOL,
-      slashes: true,
-    });
-    void browserWindow.loadURL(recoveryUrl);
-  } else {
-    void browserWindow.loadURL(src);
-  }
+  void browserWindow.loadURL(src);
 
   // Set main window reference for OAuth server
   setMainWindowForOAuthServer(browserWindow);
@@ -862,103 +857,6 @@ async function createMainWindow() {
       logger.info('Consecutive boot fail count set to', count);
     },
   );
-
-  ipcMain.removeHandler(ipcMessageKeys.RECOVERY_EXPORT_LOGS);
-  ipcMain.handle(ipcMessageKeys.RECOVERY_EXPORT_LOGS, async () => {
-    try {
-      const { dialog } = await import('electron');
-      const logDir = path.dirname(logger.transports.file.getFile().path);
-      const logFiles = fs.readdirSync(logDir).filter((f) => f.endsWith('.log'));
-      if (logFiles.length === 0) {
-        return { error: 'No log files found' };
-      }
-      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-      const result = await dialog.showSaveDialog({
-        defaultPath: `onekey-logs-${timestamp}.zip`,
-        filters: [{ name: 'ZIP', extensions: ['zip'] }],
-      });
-      if (result.canceled || !result.filePath) {
-        return {};
-      }
-      const AdmZip = (await import('adm-zip')).default;
-      const zip = new AdmZip();
-      for (const file of logFiles) {
-        zip.addLocalFile(path.join(logDir, file));
-      }
-      zip.writeZip(result.filePath);
-      return {};
-    } catch (e: any) {
-      logger.error('Recovery export logs failed:', e);
-      return { error: e?.message || String(e) };
-    }
-  });
-
-  ipcMain.removeHandler(ipcMessageKeys.RECOVERY_TRY_AGAIN);
-  ipcMain.handle(ipcMessageKeys.RECOVERY_TRY_AGAIN, async () => {
-    store.resetConsecutiveBootFailCount();
-    if (process.mas) {
-      // MAS cannot relaunch programmatically, return signal for UI to show prompt
-      return { needsManualRestart: true };
-    }
-    app.relaunch();
-    app.exit(0);
-  });
-
-  ipcMain.removeHandler(ipcMessageKeys.RECOVERY_AUTO_REPAIR);
-  ipcMain.handle(ipcMessageKeys.RECOVERY_AUTO_REPAIR, async () => {
-    const errors: string[] = [];
-    try {
-      store.clearUpdateBundleData();
-    } catch (e: any) {
-      errors.push(`clearUpdateBundleData: ${e?.message}`);
-    }
-    try {
-      store.clearFallbackUpdateBundleData();
-    } catch (e: any) {
-      errors.push(`clearFallbackUpdateBundleData: ${e?.message}`);
-    }
-    try {
-      store.clearASCFile();
-    } catch (e: any) {
-      errors.push(`clearASCFile: ${e?.message}`);
-    }
-    try {
-      store.clearUpdateBuildNumber();
-    } catch (e: any) {
-      errors.push(`clearUpdateBuildNumber: ${e?.message}`);
-    }
-    try {
-      const bundleDir = path.join(app.getPath('userData'), 'onekey-bundle');
-      if (fs.existsSync(bundleDir)) {
-        fs.rmSync(bundleDir, { recursive: true, force: true });
-      }
-    } catch (e: any) {
-      errors.push(`deleteBundleDir: ${e?.message}`);
-    }
-    try {
-      const bundleDownloadDir = path.join(
-        app.getPath('userData'),
-        'onekey-bundle-download',
-      );
-      if (fs.existsSync(bundleDownloadDir)) {
-        fs.rmSync(bundleDownloadDir, { recursive: true, force: true });
-      }
-    } catch (e: any) {
-      errors.push(`deleteBundleDownloadDir: ${e?.message}`);
-    }
-    // Clear recovery-related keys from MMKV persistent store (electron-store backed)
-    try {
-      store.clearMmkvRecoveryKeys();
-    } catch (e: any) {
-      errors.push(`clearMmkvKeys: ${e?.message}`);
-    }
-    store.resetConsecutiveBootFailCount();
-    if (errors.length > 0) {
-      logger.error('Recovery auto repair partial errors:', errors);
-    }
-    // Don't relaunch here — return result to renderer, let user confirm before restart
-    return errors.length > 0 ? { error: errors.join('; ') } : {};
-  });
 
   ipcMain.removeAllListeners(CALL_DESKTOP_API_EVENT_NAME);
   desktopApi.desktopApiSetup();
@@ -1303,12 +1201,20 @@ if (!singleInstance && !process.mas) {
     );
     const locale = await initLocale();
     logger.info('locale >>>> ', locale);
-    startServices();
 
     if (!mainWindow) {
       mainWindow = await createMainWindow();
-      initMenu();
     }
+
+    // In recovery mode, skip normal app initialization.
+    // createMainWindow() increments bootFailCount; if >= 3 it returned
+    // a standalone recovery window that doesn't need these services.
+    if (store.getConsecutiveBootFailCount() >= 3) {
+      return;
+    }
+
+    startServices();
+    initMenu();
     void initChildProcess();
   });
 }

--- a/apps/desktop/app/app.ts
+++ b/apps/desktop/app/app.ts
@@ -664,7 +664,7 @@ async function createMainWindow() {
   }
 
   /* eslint-disable no-nested-ternary */
-  const src = isPerfCiMode
+  let src = isPerfCiMode
     ? formatUrl({
         pathname: perfIndexHtmlPath,
         protocol: PROTOCOL,
@@ -1030,6 +1030,7 @@ async function createMainWindow() {
     let useJsBundle = globalThis.$desktopMainAppFunctions?.useJsBundle?.();
     const bundleDirPath = getBundleDirPath();
     let metadata: Record<string, string> = {};
+    let metadataFailed = false;
     if (bundleDirPath) {
       try {
         metadata = await getMetadata({
@@ -1043,6 +1044,7 @@ async function createMainWindow() {
         // so the interceptor falls back to the builtin bundle in the asar.
         logger.error('getMetadata failed, falling back to builtin bundle:', e);
         useJsBundle = false;
+        metadataFailed = true;
       }
     }
     session.defaultSession.protocol.interceptFileProtocol(
@@ -1110,6 +1112,17 @@ async function createMainWindow() {
         }
       },
     );
+    // When getMetadata failed, src still points to the bundle path which the
+    // interceptor cannot resolve with useJsBundle=false. Recompute and reload
+    // now that the interceptor is registered and will serve builtin files.
+    if (metadataFailed) {
+      src = formatUrl({
+        pathname: 'index.html',
+        protocol: PROTOCOL,
+        slashes: true,
+      });
+      void browserWindow.loadURL(src);
+    }
     const safelyBrowserWindow = getSafelyBrowserWindow();
     safelyBrowserWindow?.webContents.on(
       'did-fail-load',

--- a/apps/desktop/app/app.ts
+++ b/apps/desktop/app/app.ts
@@ -1206,7 +1206,10 @@ if (!singleInstance && !process.mas) {
       mainWindow = await createMainWindow();
     }
 
-    // In recovery mode, skip normal app initialization.
+    // Menu is needed in both normal and recovery mode
+    initMenu();
+
+    // In recovery mode, skip heavy app initialization.
     // createMainWindow() increments bootFailCount; if >= 3 it returned
     // a standalone recovery window that doesn't need these services.
     if (store.getConsecutiveBootFailCount() >= 3) {
@@ -1214,7 +1217,6 @@ if (!singleInstance && !process.mas) {
     }
 
     startServices();
-    initMenu();
     void initChildProcess();
   });
 }

--- a/apps/desktop/app/bundle.ts
+++ b/apps/desktop/app/bundle.ts
@@ -216,20 +216,27 @@ export const getMetadata = async ({
   appVersion: string;
   bundleVersion: string;
   signature: string;
-}) => {
+}): Promise<Record<string, string>> => {
   const metadataPath = path.join(bundleDir, '..', 'metadata.json');
   // Intentionally global in QA skip-gpg builds: startup metadata verification
   // follows build-time policy rather than per-request runtime toggles.
   const allowSkipGPG =
     String(process.env.ONEKEY_ALLOW_SKIP_GPG_VERIFICATION) === 'true';
-  if (!allowSkipGPG) {
-    await verifyMetadataFileSha256({ appVersion, bundleVersion, signature });
+  try {
+    if (!allowSkipGPG) {
+      await verifyMetadataFileSha256({ appVersion, bundleVersion, signature });
+    }
+    const metadata = JSON.parse(
+      fs.readFileSync(metadataPath, 'utf8'),
+    ) as Record<string, string>;
+    return metadata;
+  } catch (e) {
+    // GPG verification failed or metadata file unreadable — fall back to
+    // the builtin bundle by returning empty metadata. This prevents the
+    // app from crashing on startup with an invalid/corrupt JS bundle.
+    logger.error('getMetadata failed, falling back to builtin bundle:', e);
+    return {};
   }
-  const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8')) as Record<
-    string,
-    string
-  >;
-  return metadata;
 };
 
 const TEST_SIGNATURE = `

--- a/apps/desktop/app/bundle.ts
+++ b/apps/desktop/app/bundle.ts
@@ -222,21 +222,14 @@ export const getMetadata = async ({
   // follows build-time policy rather than per-request runtime toggles.
   const allowSkipGPG =
     String(process.env.ONEKEY_ALLOW_SKIP_GPG_VERIFICATION) === 'true';
-  try {
-    if (!allowSkipGPG) {
-      await verifyMetadataFileSha256({ appVersion, bundleVersion, signature });
-    }
-    const metadata = JSON.parse(
-      fs.readFileSync(metadataPath, 'utf8'),
-    ) as Record<string, string>;
-    return metadata;
-  } catch (e) {
-    // GPG verification failed or metadata file unreadable — fall back to
-    // the builtin bundle by returning empty metadata. This prevents the
-    // app from crashing on startup with an invalid/corrupt JS bundle.
-    logger.error('getMetadata failed, falling back to builtin bundle:', e);
-    return {};
+  if (!allowSkipGPG) {
+    await verifyMetadataFileSha256({ appVersion, bundleVersion, signature });
   }
+  const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8')) as Record<
+    string,
+    string
+  >;
+  return metadata;
 };
 
 const TEST_SIGNATURE = `

--- a/apps/desktop/app/recoveryWindow.ts
+++ b/apps/desktop/app/recoveryWindow.ts
@@ -1,0 +1,167 @@
+import fs from 'fs';
+import path from 'path';
+import { format as formatUrl } from 'url';
+
+import { BrowserWindow, app, ipcMain, session } from 'electron';
+import logger from 'electron-log/main';
+
+import { ipcMessageKeys } from './config';
+import * as store from './libs/store';
+import { getAppStaticResourcesPath } from './resoucePath';
+
+const isMac = process.platform === 'darwin';
+
+/**
+ * Create a standalone recovery window with its own IPC handlers.
+ * This is completely independent from the normal createMainWindow flow —
+ * no getMetadata, no interceptFileProtocol, no bundle verification.
+ */
+export function createRecoveryWindow(): BrowserWindow {
+  const { screen } = require('electron');
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  const display = screen.getPrimaryDisplay();
+  const dimensions = display.workAreaSize;
+  const appStaticResourcesPath = getAppStaticResourcesPath();
+
+  // Clear any previously registered file protocol interceptor so
+  // recovery.html loads via the default file:// handler from the asar.
+  session.defaultSession.protocol.uninterceptProtocol('file');
+
+  const browserWindow = new BrowserWindow({
+    show: true,
+    title: 'OneKey',
+    titleBarStyle: 'hidden',
+    trafficLightPosition: { x: 20, y: 20 },
+    autoHideMenuBar: true,
+    frame: true,
+    resizable: true,
+    width: Math.min(800, dimensions.width),
+    height: Math.min(600, dimensions.height),
+    backgroundColor: '#0F0F0F',
+    webPreferences: {
+      spellcheck: false,
+      webviewTag: false,
+      webSecurity: true,
+      contextIsolation: false,
+      preload: path.join(__dirname, 'preload.js'),
+      sandbox: false,
+      nodeIntegration: false,
+    },
+    icon: path.join(appStaticResourcesPath, 'images/icons/512x512.png'),
+  });
+
+  const recoveryUrl = formatUrl({
+    pathname: path.join(__dirname, 'recovery.html'),
+    protocol: 'file',
+    slashes: true,
+  });
+  void browserWindow.loadURL(recoveryUrl);
+
+  // === IPC Handlers ===
+
+  ipcMain.removeHandler(ipcMessageKeys.RECOVERY_EXPORT_LOGS);
+  ipcMain.handle(ipcMessageKeys.RECOVERY_EXPORT_LOGS, async () => {
+    try {
+      const { dialog } = await import('electron');
+      const logDir = path.dirname(logger.transports.file.getFile().path);
+      const logFiles = fs.readdirSync(logDir).filter((f) => f.endsWith('.log'));
+      if (logFiles.length === 0) {
+        return { error: 'No log files found' };
+      }
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const result = await dialog.showSaveDialog({
+        defaultPath: `onekey-logs-${timestamp}.zip`,
+        filters: [{ name: 'ZIP', extensions: ['zip'] }],
+      });
+      if (result.canceled || !result.filePath) {
+        return {};
+      }
+      const AdmZip = (await import('adm-zip')).default;
+      const zip = new AdmZip();
+      for (const file of logFiles) {
+        zip.addLocalFile(path.join(logDir, file));
+      }
+      zip.writeZip(result.filePath);
+      return {};
+    } catch (e: any) {
+      logger.error('Recovery export logs failed:', e);
+      return { error: e?.message || String(e) };
+    }
+  });
+
+  ipcMain.removeHandler(ipcMessageKeys.RECOVERY_TRY_AGAIN);
+  ipcMain.handle(ipcMessageKeys.RECOVERY_TRY_AGAIN, async () => {
+    store.resetConsecutiveBootFailCount();
+    if (process.mas) {
+      return { needsManualRestart: true };
+    }
+    app.relaunch();
+    app.exit(0);
+  });
+
+  ipcMain.removeHandler(ipcMessageKeys.RECOVERY_AUTO_REPAIR);
+  ipcMain.handle(ipcMessageKeys.RECOVERY_AUTO_REPAIR, async () => {
+    const errors: string[] = [];
+    try {
+      store.clearUpdateBundleData();
+    } catch (e: any) {
+      errors.push(`clearUpdateBundleData: ${e?.message}`);
+    }
+    try {
+      store.clearFallbackUpdateBundleData();
+    } catch (e: any) {
+      errors.push(`clearFallbackUpdateBundleData: ${e?.message}`);
+    }
+    try {
+      store.clearASCFile();
+    } catch (e: any) {
+      errors.push(`clearASCFile: ${e?.message}`);
+    }
+    try {
+      store.clearUpdateBuildNumber();
+    } catch (e: any) {
+      errors.push(`clearUpdateBuildNumber: ${e?.message}`);
+    }
+    try {
+      const bundleDir = path.join(app.getPath('userData'), 'onekey-bundle');
+      if (fs.existsSync(bundleDir)) {
+        fs.rmSync(bundleDir, { recursive: true, force: true });
+      }
+    } catch (e: any) {
+      errors.push(`deleteBundleDir: ${e?.message}`);
+    }
+    try {
+      const bundleDownloadDir = path.join(
+        app.getPath('userData'),
+        'onekey-bundle-download',
+      );
+      if (fs.existsSync(bundleDownloadDir)) {
+        fs.rmSync(bundleDownloadDir, { recursive: true, force: true });
+      }
+    } catch (e: any) {
+      errors.push(`deleteBundleDownloadDir: ${e?.message}`);
+    }
+    try {
+      store.clearMmkvRecoveryKeys();
+    } catch (e: any) {
+      errors.push(`clearMmkvKeys: ${e?.message}`);
+    }
+    store.resetConsecutiveBootFailCount();
+    if (errors.length > 0) {
+      logger.error('Recovery auto repair partial errors:', errors);
+    }
+    return errors.length > 0 ? { error: errors.join('; ') } : {};
+  });
+
+  // Mac: hide instead of close
+  // @ts-expect-error
+  browserWindow.on('close', (event: Event) => {
+    if (isMac) {
+      event.preventDefault();
+      browserWindow.blur();
+      browserWindow.hide();
+    }
+  });
+
+  return browserWindow;
+}

--- a/apps/desktop/app/recoveryWindow.ts
+++ b/apps/desktop/app/recoveryWindow.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { format as formatUrl } from 'url';
 
 import { BrowserWindow, app, ipcMain, session } from 'electron';
+import isDev from 'electron-is-dev';
 import logger from 'electron-log/main';
 
 import { ipcMessageKeys } from './config';
@@ -56,6 +57,10 @@ export function createRecoveryWindow(): BrowserWindow {
     slashes: true,
   });
   void browserWindow.loadURL(recoveryUrl);
+
+  if (isDev) {
+    browserWindow.webContents.openDevTools();
+  }
 
   // === IPC Handlers ===
 

--- a/apps/desktop/app/recoveryWindow.ts
+++ b/apps/desktop/app/recoveryWindow.ts
@@ -11,6 +11,8 @@ import * as store from './libs/store';
 import { getAppStaticResourcesPath } from './resoucePath';
 
 const isMac = process.platform === 'darwin';
+const isWin = process.platform === 'win32';
+const isLinux = process.platform === 'linux';
 
 /**
  * Create a standalone recovery window with its own IPC handlers.
@@ -32,6 +34,14 @@ export function createRecoveryWindow(): BrowserWindow {
     show: true,
     title: 'OneKey',
     titleBarStyle: 'hidden',
+    titleBarOverlay:
+      isWin || isLinux
+        ? {
+            height: 52,
+            color: '#00000000',
+            symbolColor: '#ffffff',
+          }
+        : false,
     trafficLightPosition: { x: 20, y: 20 },
     autoHideMenuBar: true,
     frame: true,


### PR DESCRIPTION
## Summary
- The production `interceptFileProtocol` rewrites all `file://` URLs to the `build/` directory, but `recovery.html` lives in `dist/`
- Since `loadURL` is async (`void`), the interceptor is registered before the URL actually loads, causing `recovery.html` path to be rewritten incorrectly
- This resulted in `Not allowed to load local resource: file:///...app.asar/dist/recovery.html` at runtime
- Added an early return in the interceptor to serve `recovery.html` directly from `dist/`

## Test plan
- [ ] Build desktop app (`yarn build:mac` or equivalent)
- [ ] Force recovery mode (set consecutive boot fail count >= 3 in electron-store)
- [ ] Verify recovery page loads correctly with Export Logs / Try Again / Auto Repair buttons
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
