### PR TITLE
fix: keep keyless same-email retry state after rate limit

### DIFF
--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -91,7 +91,7 @@ import type { IKeylessDialogAtomData } from '../../states/jotai/atoms';
 
 const juiceboxClientCache = new cacheUtils.LRUCache<string, JuiceboxClient>({
   max: 100,
-  ttl: timerUtils.getTimeDurationMs({ minute: 5 }),
+  ttl: timerUtils.getTimeDurationMs({ minute: 8 }),
   ttlAutopurge: true,
   dispose: (client) => {
     // Best-effort cleanup: clear any cached realm tokens when the client is evicted.

--- a/packages/kit/src/components/KeylessWallet/sameEmailAccountStatusUtils.test.ts
+++ b/packages/kit/src/components/KeylessWallet/sameEmailAccountStatusUtils.test.ts
@@ -1,0 +1,71 @@
+import { EOAuthSocialLoginProvider } from '@onekeyhq/shared/src/consts/authConsts';
+import { RequestLimitExceededError } from '@onekeyhq/shared/src/errors';
+import { EOneKeyErrorClassNames } from '@onekeyhq/shared/src/errors/types/errorTypes';
+
+import {
+  getPromotedSameEmailAccountStatusAfterAutoRetryRateLimit,
+  isKeylessSameEmailAutoRetryRateLimitError,
+} from './sameEmailAccountStatusUtils';
+
+describe('sameEmailAccountStatusUtils', () => {
+  it('detects request-limit errors from the automatic retry path', () => {
+    expect(
+      isKeylessSameEmailAutoRetryRateLimitError(
+        new RequestLimitExceededError(),
+      ),
+    ).toBe(true);
+
+    expect(
+      isKeylessSameEmailAutoRetryRateLimitError({
+        className: EOneKeyErrorClassNames.RequestLimitExceededError,
+      }),
+    ).toBe(true);
+  });
+
+  it('ignores non-request-limit errors', () => {
+    expect(
+      isKeylessSameEmailAutoRetryRateLimitError({
+        message: 'IncorrectPinError',
+      }),
+    ).toBe(false);
+  });
+
+  it('promotes the retry provider only for old-version same-email accounts', () => {
+    expect(
+      getPromotedSameEmailAccountStatusAfterAutoRetryRateLimit({
+        isSameEmailAccountAtOldVersion: true,
+        currentProvider: EOAuthSocialLoginProvider.Google,
+        retryProvider: EOAuthSocialLoginProvider.Apple,
+      }),
+    ).toEqual({
+      isSameEmailAccountAtOldVersion: true,
+      currentProvider: EOAuthSocialLoginProvider.Apple,
+      retryProvider: EOAuthSocialLoginProvider.Google,
+    });
+  });
+
+  it('does not promote when required providers are missing or unchanged', () => {
+    expect(
+      getPromotedSameEmailAccountStatusAfterAutoRetryRateLimit({
+        isSameEmailAccountAtOldVersion: false,
+        currentProvider: EOAuthSocialLoginProvider.Google,
+        retryProvider: EOAuthSocialLoginProvider.Apple,
+      }),
+    ).toBeUndefined();
+
+    expect(
+      getPromotedSameEmailAccountStatusAfterAutoRetryRateLimit({
+        isSameEmailAccountAtOldVersion: true,
+        currentProvider: EOAuthSocialLoginProvider.Google,
+      }),
+    ).toBeUndefined();
+
+    expect(
+      getPromotedSameEmailAccountStatusAfterAutoRetryRateLimit({
+        isSameEmailAccountAtOldVersion: true,
+        currentProvider: EOAuthSocialLoginProvider.Google,
+        retryProvider: EOAuthSocialLoginProvider.Google,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/kit/src/components/KeylessWallet/sameEmailAccountStatusUtils.ts
+++ b/packages/kit/src/components/KeylessWallet/sameEmailAccountStatusUtils.ts
@@ -1,0 +1,44 @@
+import type { EOAuthSocialLoginProvider } from '@onekeyhq/shared/src/consts/authConsts';
+import { RequestLimitExceededError } from '@onekeyhq/shared/src/errors';
+import { EOneKeyErrorClassNames } from '@onekeyhq/shared/src/errors/types/errorTypes';
+import errorUtils from '@onekeyhq/shared/src/errors/utils/errorUtils';
+
+export type IKeylessSameEmailAccountStatus = {
+  isSameEmailAccountAtOldVersion: boolean;
+  retryProvider?: EOAuthSocialLoginProvider;
+  currentProvider?: EOAuthSocialLoginProvider;
+};
+
+export function isKeylessSameEmailAutoRetryRateLimitError(
+  error: unknown,
+): boolean {
+  const isRateLimitErrorByInstance = error instanceof RequestLimitExceededError;
+  const isRateLimitErrorByClassName = errorUtils.isErrorByClassName({
+    error,
+    className: EOneKeyErrorClassNames.RequestLimitExceededError,
+  });
+
+  return isRateLimitErrorByInstance || isRateLimitErrorByClassName;
+}
+
+export function getPromotedSameEmailAccountStatusAfterAutoRetryRateLimit(
+  status: IKeylessSameEmailAccountStatus,
+): IKeylessSameEmailAccountStatus | undefined {
+  const { isSameEmailAccountAtOldVersion, currentProvider, retryProvider } =
+    status;
+
+  if (
+    !isSameEmailAccountAtOldVersion ||
+    !currentProvider ||
+    !retryProvider ||
+    currentProvider === retryProvider
+  ) {
+    return undefined;
+  }
+
+  return {
+    isSameEmailAccountAtOldVersion,
+    currentProvider: retryProvider,
+    retryProvider: currentProvider,
+  };
+}

--- a/packages/kit/src/components/KeylessWallet/useKeylessWallet.tsx
+++ b/packages/kit/src/components/KeylessWallet/useKeylessWallet.tsx
@@ -64,12 +64,12 @@ import {
   showAppleIDMismatchDialog,
   showGoogleDriveMismatchDialog,
 } from './AccountMismatchDialog';
+import {
+  getPromotedSameEmailAccountStatusAfterAutoRetryRateLimit,
+  isKeylessSameEmailAutoRetryRateLimitError,
+} from './sameEmailAccountStatusUtils';
 
-type IKeylessSameEmailAccountStatus = {
-  isSameEmailAccountAtOldVersion: boolean;
-  retryProvider?: EOAuthSocialLoginProvider;
-  currentProvider?: EOAuthSocialLoginProvider;
-};
+import type { IKeylessSameEmailAccountStatus } from './sameEmailAccountStatusUtils';
 
 export function useKeylessWalletFeatureIsEnabled(): boolean {
   return true;
@@ -318,7 +318,7 @@ export function useKeylessWalletMethods() {
 
 export const keylessOnboardingCache = new cacheUtils.LRUCache<string, string>({
   max: 1000,
-  ttl: timerUtils.getTimeDurationMs({ minute: 5 }),
+  ttl: timerUtils.getTimeDurationMs({ minute: 8 }),
   ttlAutopurge: true,
 });
 
@@ -404,6 +404,23 @@ export async function getKeylessOnboardingSameEmailAccountStatus(): Promise<IKey
       isSameEmailAccountAtOldVersion: false,
     };
   }
+}
+
+async function promoteKeylessOnboardingSameEmailRetryProviderAfterRateLimit({
+  status,
+}: {
+  status: IKeylessSameEmailAccountStatus;
+}) {
+  const nextStatus =
+    getPromotedSameEmailAccountStatusAfterAutoRetryRateLimit(status);
+
+  if (!nextStatus) {
+    return;
+  }
+
+  await cacheKeylessOnboardingSameEmailAccountStatus({
+    status: nextStatus,
+  });
 }
 
 async function cacheKeylessOnboardingCustomMnemonic({
@@ -1057,16 +1074,27 @@ export function useKeylessWallet() {
           sameEmailAccountStatus.retryProvider &&
           !dangerousRetryByFixedProvider
         ) {
-          await backgroundApiProxy.serviceKeylessWallet.apiVerifyKeylessJuiceboxPin(
-            {
-              token,
-              pin,
-              refreshToken,
-              mode,
-              dangerousRetryByFixedProvider: false,
-              providerOverride: sameEmailAccountStatus.retryProvider,
-            },
-          );
+          try {
+            await backgroundApiProxy.serviceKeylessWallet.apiVerifyKeylessJuiceboxPin(
+              {
+                token,
+                pin,
+                refreshToken,
+                mode,
+                dangerousRetryByFixedProvider: false,
+                providerOverride: sameEmailAccountStatus.retryProvider,
+              },
+            );
+          } catch (retryError) {
+            if (isKeylessSameEmailAutoRetryRateLimitError(retryError)) {
+              await promoteKeylessOnboardingSameEmailRetryProviderAfterRateLimit(
+                {
+                  status: sameEmailAccountStatus,
+                },
+              );
+            }
+            throw retryError;
+          }
         } else {
           throw error;
         }

--- a/packages/kit/src/components/KeylessWallet/useKeylessWallet.tsx
+++ b/packages/kit/src/components/KeylessWallet/useKeylessWallet.tsx
@@ -423,6 +423,57 @@ async function promoteKeylessOnboardingSameEmailRetryProviderAfterRateLimit({
   });
 }
 
+async function shouldPromoteKeylessOnboardingSameEmailRetryProviderAfterRateLimit({
+  token,
+  error,
+}: {
+  token: string;
+  error: unknown;
+}) {
+  if (!isKeylessSameEmailAutoRetryRateLimitError(error)) {
+    return false;
+  }
+
+  try {
+    const result =
+      await backgroundApiProxy.serviceKeylessWallet.apiCheckRateLimitStatus({
+        token,
+      });
+
+    return result.isRateLimited && result.retryAfterSeconds > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function syncKeylessOnboardingSameEmailRetryProviderAfterRateLimit({
+  token,
+  error,
+  status,
+}: {
+  token: string;
+  error: unknown;
+  status: IKeylessSameEmailAccountStatus;
+}) {
+  try {
+    if (
+      await shouldPromoteKeylessOnboardingSameEmailRetryProviderAfterRateLimit({
+        token,
+        error,
+      })
+    ) {
+      await promoteKeylessOnboardingSameEmailRetryProviderAfterRateLimit({
+        status,
+      });
+    }
+  } catch (syncError) {
+    console.error(
+      'Failed to sync keyless same-email retry provider after rate limit:',
+      syncError,
+    );
+  }
+}
+
 async function cacheKeylessOnboardingCustomMnemonic({
   customMnemonic,
 }: {
@@ -1086,13 +1137,11 @@ export function useKeylessWallet() {
               },
             );
           } catch (retryError) {
-            if (isKeylessSameEmailAutoRetryRateLimitError(retryError)) {
-              await promoteKeylessOnboardingSameEmailRetryProviderAfterRateLimit(
-                {
-                  status: sameEmailAccountStatus,
-                },
-              );
-            }
+            void syncKeylessOnboardingSameEmailRetryProviderAfterRateLimit({
+              token,
+              error: retryError,
+              status: sameEmailAccountStatus,
+            });
             throw retryError;
           }
         } else {

--- a/packages/shared/src/errors/errors/appErrors.ts
+++ b/packages/shared/src/errors/errors/appErrors.ts
@@ -119,6 +119,8 @@ export class RequestLimitExceededError extends OneKeyAppError {
       }),
     );
   }
+
+  override className = EOneKeyErrorClassNames.RequestLimitExceededError;
 }
 
 export class SystemDiskFullError extends OneKeyAppError {

--- a/packages/shared/src/errors/types/errorTypes.ts
+++ b/packages/shared/src/errors/types/errorTypes.ts
@@ -22,6 +22,7 @@ export enum EOneKeyErrorClassNames {
   OneKeyServerApiError = 'OneKeyServerApiError',
   LocalDBRecordNotFoundError = 'LocalDBRecordNotFoundError',
   PrimeTransferImportCancelledError = 'PrimeTransferImportCancelledError',
+  RequestLimitExceededError = 'RequestLimitExceededError',
   OneKeyValidatorError = 'OneKeyValidatorError',
   OneKeyValidatorTip = 'OneKeyValidatorTip',
   OneKeyAbortError = 'OneKeyAbortError',


### PR DESCRIPTION
## Summary
- extend the keyless onboarding and Juicebox client cache TTL from 5 to 8 minutes so same-email retry state survives longer cooldown windows
- preserve the auto-retry provider as the next manual provider when the same-email fallback attempt is blocked by Juicebox rate limiting
- add a dedicated helper and tests, and make `RequestLimitExceededError` detectable via `className`

## Testing
- yarn test packages/kit/src/components/KeylessWallet/sameEmailAccountStatusUtils.test.ts
- yarn exec eslint packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts packages/kit/src/components/KeylessWallet/useKeylessWallet.tsx packages/shared/src/errors/errors/appErrors.ts packages/shared/src/errors/types/errorTypes.ts packages/kit/src/components/KeylessWallet/sameEmailAccountStatusUtils.ts packages/kit/src/components/KeylessWallet/sameEmailAccountStatusUtils.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
