### PR TITLE
chore: add missing CI files to upgrade-test skill

### DIFF
--- a/.claude/skills/1k-app-upgrade-test/SKILL.md
+++ b/.claude/skills/1k-app-upgrade-test/SKILL.md
@@ -68,9 +68,15 @@ Update these files in order:
    - Update version in outputs section
 
 3. **`.github/workflows/release-android.yml`**
-   - Update versionName in android-build job
+   - Hardcode BUILD_NUMBER in "Write .env.version" step
 
-4. **`apps/mobile/android/app/build.gradle`**
+4. **`.github/workflows/release-ios.yml`**
+   - Hardcode BUILD_NUMBER in "Write .env.version" step
+
+5. **`.github/workflows/daily-build.yml`**
+   - Hardcode BUILD_NUMBER in "Setup ENV" step
+
+6. **`apps/mobile/android/app/build.gradle`**
    - Update versionCode
    - Update versionName
 
@@ -86,9 +92,11 @@ git push origin <test_version>
 
 | File | What to Update |
 |------|----------------|
-| `.env.version` | VERSION, BUILD_NUMBER |
-| `.github/actions/shared-env/action.yml` | outputs.version |
-| `.github/workflows/release-android.yml` | versionName |
+| `.env.version` | VERSION |
+| `.github/actions/shared-env/action.yml` | Hardcode BUILD_NUMBER, remove conditionals |
+| `.github/workflows/release-android.yml` | Hardcode BUILD_NUMBER in .env.version write |
+| `.github/workflows/release-ios.yml` | Hardcode BUILD_NUMBER in .env.version write |
+| `.github/workflows/daily-build.yml` | Hardcode BUILD_NUMBER in Setup ENV step |
 | `apps/mobile/android/app/build.gradle` | versionCode, versionName |
 
 ## Detailed Guide

--- a/.claude/skills/1k-app-upgrade-test/SKILL.md
+++ b/.claude/skills/1k-app-upgrade-test/SKILL.md
@@ -62,7 +62,6 @@ Update these files in order:
 
 1. **`.env.version`**
    - Set VERSION to test version
-   - Set BUILD_NUMBER to calculated value
 
 2. **`.github/actions/shared-env/action.yml`**
    - Update version in outputs section

--- a/.claude/skills/1k-app-upgrade-test/references/rules/upgrade-test-version.md
+++ b/.claude/skills/1k-app-upgrade-test/references/rules/upgrade-test-version.md
@@ -87,7 +87,34 @@ To:
 echo "BUILD_NUMBER=<calculated_build_number>" >> .env.version
 ```
 
-#### 4.4 Update `apps/mobile/android/app/build.gradle`
+#### 4.4 Update `.github/workflows/release-ios.yml`
+
+Same as release-android. In the "Write .env.version" step, change:
+
+```yaml
+echo "BUILD_NUMBER=${{ env.BUILD_NUMBER }}" >> .env.version
+```
+
+To:
+
+```yaml
+echo "BUILD_NUMBER=<calculated_build_number>" >> .env.version
+```
+
+#### 4.5 Update `.github/workflows/daily-build.yml`
+
+In the "Setup ENV" step, replace the BUILD_NUMBER calculation logic with a hardcoded value:
+
+```yaml
+- name: 'Setup ENV'
+  run: |
+    echo "Executed at: $(date '+%Y-%m-%d %H:%M:%S')"
+    echo "BUILD_NUMBER=<calculated_build_number>" >> $GITHUB_ENV
+```
+
+This ensures the entire CI pipeline from source to downstream workflows uses the same build number.
+
+#### 4.6 Update `apps/mobile/android/app/build.gradle`
 
 In the `defaultConfig` block, update:
 
@@ -117,6 +144,8 @@ git push -u origin <test_version>
 | `.env.version` | Update VERSION |
 | `.github/actions/shared-env/action.yml` | Hardcode BUILD_NUMBER, remove conditionals |
 | `.github/workflows/release-android.yml` | Hardcode BUILD_NUMBER in .env.version write |
+| `.github/workflows/release-ios.yml` | Hardcode BUILD_NUMBER in .env.version write |
+| `.github/workflows/daily-build.yml` | Hardcode BUILD_NUMBER in Setup ENV step |
 | `apps/mobile/android/app/build.gradle` | Update versionCode and versionName |
 
 ## Validation Checklist
@@ -126,5 +155,7 @@ Before pushing, verify:
 - [ ] `.env.version` VERSION field updated
 - [ ] Build number conditionals removed from shared-env
 - [ ] Build number hardcoded in release-android workflow
+- [ ] Build number hardcoded in release-ios workflow
+- [ ] Build number hardcoded in daily-build workflow
 - [ ] versionCode is numeric (build number)
 - [ ] versionName is quoted string (test version)


### PR DESCRIPTION
## Summary
- Added `release-ios.yml` and `daily-build.yml` to the list of files that need modification in the `1k-app-upgrade-test` skill
- Updated file descriptions in both SKILL.md and the detailed reference guide

## Intent & Context
While using the `1k-app-upgrade-test` skill to create test version `9906.12.0`, discovered that the skill was missing two CI files (`release-ios.yml` and `daily-build.yml`) from its modification checklist. This caused incomplete BUILD_NUMBER hardcoding across the CI pipeline, requiring manual follow-up fixes.

## Changes Detail
- **SKILL.md**: Added `release-ios.yml` (step 4) and `daily-build.yml` (step 5) to the workflow steps and "Files to Modify" table. Also corrected file change descriptions for accuracy.
- **upgrade-test-version.md**: Added sections 4.4 (release-ios) and 4.5 (daily-build) with detailed modification instructions. Updated File Locations Summary and Validation Checklist.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: N/A (skill documentation only)

## Test plan
- [ ] Invoke `/1k-app-upgrade-test` and verify all 6 files are listed in the workflow
- [ ] Confirm the validation checklist includes release-ios and daily-build checks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
