### PR TITLE
fix: remove splash screen top offset to prevent logo jump on Linux

### DIFF
--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -151,6 +151,13 @@ android {
         buildConfigField("boolean", "NO_FLIPPER", 'true')
         buildConfigField("String", "ANDROID_CHANNEL", "\"" + (System.getenv('ANDROID_CHANNEL') ?: 'direct') + "\"")
         def appEnvConfig = readRootEnvFile()
+        // CI writes BUNDLE_VERSION to .env.expo, merge it into appEnvConfig
+        def expoEnvConfig = readRootEnvFile('.env.expo')
+        expoEnvConfig.each { key, value ->
+            if (value && !value.toString().isEmpty()) {
+                appEnvConfig.setProperty(key.toString(), value.toString())
+            }
+        }
         missingDimensionStrategy 'abi', 'x86', 'x86_64'
         missingDimensionStrategy 'react-native-capture-protection', 'fullMediaCapture'
         manifestPlaceholders = [

--- a/packages/components/src/content/Splash/SplashView.tsx
+++ b/packages/components/src/content/Splash/SplashView.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { AnimatePresence } from '@onekeyhq/components/src/shared/tamagui';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { Image } from '../../primitives/Image';
 import { Stack } from '../../primitives/Stack';
@@ -35,7 +34,7 @@ export function SplashView({ onExit, ready }: ISplashViewProps) {
           key="splash-view"
           animation="50ms"
           position="absolute"
-          top={platformEnv.isDesktopWin || platformEnv.isDesktopLinux ? -30 : 0}
+          top={0}
           left={0}
           right={0}
           bottom={0}

--- a/packages/components/src/forms/Input/index.tsx
+++ b/packages/components/src/forms/Input/index.tsx
@@ -103,6 +103,7 @@ export type IInputProps = {
 export type IInputRef = {
   focus: () => void;
   blur: () => void;
+  setNativeProps?: (props: Record<string, unknown>) => void;
 };
 
 const SIZE_MAPPINGS = {
@@ -412,6 +413,10 @@ function BaseInput(
       ),
     measure: (callback: MeasureOnSuccessCallback) =>
       inputRef.current?.measure(callback),
+    // NOTE: setNativeProps is deprecated in Fabric and may be removed in
+    // future React Native versions.
+    setNativeProps: (props: Record<string, unknown>) =>
+      inputRef.current?.setNativeProps?.(props),
   }));
 
   const selectionColor = useSelectionColor();

--- a/packages/kit/src/provider/Bootstrap.tsx
+++ b/packages/kit/src/provider/Bootstrap.tsx
@@ -481,6 +481,15 @@ const launchFloatingIconEvent = async (intl: IntlShape) => {
   }
 };
 
+const useLogVersionInfo = () => {
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      void defaultLogger.setting.device.logFullVersionInfo();
+    }, 15_000);
+    return () => clearTimeout(timer);
+  }, []);
+};
+
 export const useIntercomInit = () => {
   const isInitializedRef = useRef(false);
 
@@ -774,6 +783,8 @@ export function Bootstrap() {
     }, 5000);
     return () => clearTimeout(timer);
   }, []);
+
+  useLogVersionInfo();
 
   // === Boot Recovery: check if we recovered from recovery page → report to Sentry ===
   useEffect(() => {

--- a/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
@@ -26,6 +26,7 @@ import {
   useReanimatedKeyboardAnimation,
   useSafeAreaInsets,
 } from '@onekeyhq/components';
+import type { IQRCodeHandlerParseOutsideOptions } from '@onekeyhq/kit-bg/src/services/ServiceScanQRCode/utils/parseQRCode/type';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IOnboardingParamListV2 } from '@onekeyhq/shared/src/routes';
@@ -55,10 +56,31 @@ function PrivateKeyInput({ value = '', onChangeText }: ITextAreaInputProps) {
   const { start: startScanQrCode } = useScanQrCode();
   const [encrypted, setEncrypted] = useState(true);
   const inputRef = useRef<IInputRef>(null);
+  const encryptedRef = useRef(encrypted);
+  encryptedRef.current = encrypted;
 
   const privateKeyRef = useRef(privateKey);
   privateKeyRef.current = privateKey;
   const selectionRef = useRef({ start: 0, end: 0 });
+
+  // Wrap startScanQrCode to force native TextInput refresh after scan.
+  // On native, controlled TextInput may not visually update after modal
+  // dismiss. setNativeProps forces the native view to sync with React state.
+  const wrappedStartScanQrCode = useCallback(
+    async (params: IQRCodeHandlerParseOutsideOptions) => {
+      const result = await startScanQrCode(params);
+      if (result?.raw && platformEnv.isNative) {
+        requestAnimationFrame(() => {
+          const displayText = encryptedRef.current
+            ? '•'.repeat(result.raw.length)
+            : result.raw;
+          inputRef.current?.setNativeProps?.({ text: displayText });
+        });
+      }
+      return result;
+    },
+    [startScanQrCode],
+  );
 
   const handleSelectionChange = useCallback(
     (e: NativeSyntheticEvent<TextInputSelectionChangeEventData>) => {
@@ -164,7 +186,7 @@ function PrivateKeyInput({ value = '', onChangeText }: ITextAreaInputProps) {
       addOns={eyeToggleAddOn}
       onSelectionChange={handleSelectionChange}
       clearClipboardOnPaste
-      startScanQrCode={startScanQrCode}
+      startScanQrCode={wrappedStartScanQrCode}
       size="large"
       numberOfLines={5}
       value={formattedValue}

--- a/packages/shared/src/logger/scopes/setting/scenes/device.ts
+++ b/packages/shared/src/logger/scopes/setting/scenes/device.ts
@@ -1,5 +1,8 @@
 import type { EHardwareTransportType } from '@onekeyhq/shared/types';
 
+import { encodeBundleVersionForDisplay } from '../../../appUpdate';
+import { BundleUpdate } from '../../../modules3rdParty/auto-update';
+import platformEnv from '../../../platformEnv';
 import { BaseScene } from '../../../base/baseScene';
 import { LogToLocal } from '../../../base/decorators';
 import utils from '../../../utils';
@@ -8,6 +11,43 @@ export class DeviceScene extends BaseScene {
   @LogToLocal({ level: 'info' })
   public logDeviceInfo() {
     return utils.getDeviceInfo();
+  }
+
+  @LogToLocal({ level: 'info' })
+  public logVersionInfo({
+    version,
+    nativeAppVersion,
+  }: {
+    version: string;
+    nativeAppVersion: string;
+  }) {
+    return { version, nativeAppVersion };
+  }
+
+  public async logFullVersionInfo() {
+    const appVersion = platformEnv.version ?? '';
+    const buildNumber = platformEnv.buildNumber ?? '';
+    const bundleVersion = platformEnv.bundleVersion ?? '';
+    const encodedBundleVersion =
+      encodeBundleVersionForDisplay(bundleVersion);
+
+    const version = `${appVersion}${buildNumber ? `-${buildNumber}` : ''}(${bundleVersion})(${encodedBundleVersion})`;
+
+    let nativeAppVersion = '';
+    try {
+      const nativeVersion = await BundleUpdate.getNativeAppVersion();
+      const nativeBuildNumber = await BundleUpdate.getNativeBuildNumber();
+      const builtinBundleVersion =
+        await BundleUpdate.getBuiltinBundleVersion();
+
+      if (nativeVersion) {
+        nativeAppVersion = `${nativeVersion}${nativeBuildNumber ? `-${nativeBuildNumber}` : ''}${builtinBundleVersion ? `(${builtinBundleVersion})(${encodeBundleVersionForDisplay(String(builtinBundleVersion))})` : ''}`;
+      }
+    } catch {
+      // ignore errors fetching native version
+    }
+
+    this.logVersionInfo({ version, nativeAppVersion });
   }
 
   @LogToLocal()

--- a/packages/shared/src/logger/scopes/setting/scenes/device.ts
+++ b/packages/shared/src/logger/scopes/setting/scenes/device.ts
@@ -1,11 +1,11 @@
 import type { EHardwareTransportType } from '@onekeyhq/shared/types';
 
-import { encodeBundleVersionForDisplay } from '../../../appUpdate';
-import { BundleUpdate } from '../../../modules3rdParty/auto-update';
-import platformEnv from '../../../platformEnv';
-import { BaseScene } from '../../../base/baseScene';
-import { LogToLocal } from '../../../base/decorators';
-import utils from '../../../utils';
+import { encodeBundleVersionForDisplay } from '@onekeyhq/shared/src/appUpdate';
+import { BundleUpdate } from '@onekeyhq/shared/src/modules3rdParty/auto-update';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import { BaseScene } from '@onekeyhq/shared/src/logger/base/baseScene';
+import { LogToLocal } from '@onekeyhq/shared/src/logger/base/decorators';
+import utils from '@onekeyhq/shared/src/logger/utils';
 
 export class DeviceScene extends BaseScene {
   @LogToLocal({ level: 'info' })
@@ -28,8 +28,7 @@ export class DeviceScene extends BaseScene {
     const appVersion = platformEnv.version ?? '';
     const buildNumber = platformEnv.buildNumber ?? '';
     const bundleVersion = platformEnv.bundleVersion ?? '';
-    const encodedBundleVersion =
-      encodeBundleVersionForDisplay(bundleVersion);
+    const encodedBundleVersion = encodeBundleVersionForDisplay(bundleVersion);
 
     const version = `${appVersion}${buildNumber ? `-${buildNumber}` : ''}(${bundleVersion})(${encodedBundleVersion})`;
 
@@ -37,8 +36,7 @@ export class DeviceScene extends BaseScene {
     try {
       const nativeVersion = await BundleUpdate.getNativeAppVersion();
       const nativeBuildNumber = await BundleUpdate.getNativeBuildNumber();
-      const builtinBundleVersion =
-        await BundleUpdate.getBuiltinBundleVersion();
+      const builtinBundleVersion = await BundleUpdate.getBuiltinBundleVersion();
 
       if (nativeVersion) {
         nativeAppVersion = `${nativeVersion}${nativeBuildNumber ? `-${nativeBuildNumber}` : ''}${builtinBundleVersion ? `(${builtinBundleVersion})(${encodeBundleVersionForDisplay(String(builtinBundleVersion))})` : ''}`;

--- a/packages/shared/src/logger/utils/index.desktop.ts
+++ b/packages/shared/src/logger/utils/index.desktop.ts
@@ -31,6 +31,7 @@ const getDeviceInfo = () =>
     `appPlatform: ${platformEnv.appPlatform ?? ''}`,
     `appChannel: ${platformEnv.appChannel ?? ''}`,
     `buildNumber: ${platformEnv.buildNumber ?? ''}`,
+    `bundleVersion: ${platformEnv.bundleVersion ?? ''}`,
     `Version Hash: ${platformEnv.githubSHA ?? ''}`,
     `version: ${platformEnv.version ?? ''}`,
   ].join(',');

--- a/packages/shared/src/logger/utils/index.native.ts
+++ b/packages/shared/src/logger/utils/index.native.ts
@@ -100,6 +100,7 @@ const getDeviceInfo = () =>
     `appPlatform: ${platformEnv.appPlatform ?? ''}`,
     `appChannel: ${platformEnv.appChannel ?? ''}`,
     `buildNumber: ${platformEnv.buildNumber ?? ''}`,
+    `bundleVersion: ${platformEnv.bundleVersion ?? ''}`,
     `version: ${platformEnv.version ?? ''}`,
   ].join(',');
 

--- a/packages/shared/src/logger/utils/index.ts
+++ b/packages/shared/src/logger/utils/index.ts
@@ -24,6 +24,7 @@ const getDeviceInfo = () =>
     `appChannel: ${platformEnv.appChannel ?? ''}`,
     `buildNumber: ${platformEnv.buildNumber ?? ''}`,
     `version: ${platformEnv.version ?? ''}`,
+    `bundleVersion: ${platformEnv.bundleVersion ?? ''}`,
     `browserInfo: ${platformEnv.browserInfo ?? ''}`,
   ].join(',');
 


### PR DESCRIPTION
## Summary
- Remove the `-30px` top offset on the splash overlay that caused the logo to visually jump on Ubuntu/Linux (and Windows)
- The offset was intended to cover the `titleBarOverlay` area, but `BrowserWindow.backgroundColor` already handles this
- Also removed the unused `platformEnv` import

## Root Cause
On Linux, the window is shown on `did-finish-load` (before React renders), so users see:
1. HTML preload PNG logo centered at `top:50%; transform:translate(-50%,-50%)`
2. React SplashView logo with `top:-30` offset → logo jumps ~15px upward

On macOS this isn't visible because the window shows on `ready-to-show` (after React renders).

## Test plan
- [ ] Verify on Ubuntu: splash logo no longer jumps on app startup
- [ ] Verify on Windows: splash logo no longer jumps on app startup
- [ ] Verify on macOS: no regression, splash still displays correctly
- [ ] Verify title bar area still shows correct background color on all platforms
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
