### PR TITLE
feat: add prepare subcommand to bundle-release skill

### DIFF
--- a/.claude/skills/1k-bundle-release/SKILL.md
+++ b/.claude/skills/1k-bundle-release/SKILL.md
@@ -19,6 +19,7 @@ The core invariant: **every commit on the release branch must also exist on `x`*
 
 | Subcommand | When to use | Guide |
 |------------|-------------|-------|
+| `prepare` | First step — write BUILD_NUMBER to .env.version and push | [prepare.md](references/rules/prepare.md) |
 | `cherry-pick` | Ready to bring verified PRs into the next release | [cherry-pick.md](references/rules/cherry-pick.md) |
 | `diff-check` | After cherry-picks, before publishing — verify integrity | [diff-check.md](references/rules/diff-check.md) |
 | `publish` | Diff checks passed, ready to finalize the release | [publish.md](references/rules/publish.md) |
@@ -27,6 +28,7 @@ The core invariant: **every commit on the release branch must also exist on `x`*
 
 Parse the argument passed to this skill:
 
+- **`prepare`** → Read and follow [prepare.md](references/rules/prepare.md)
 - **`cherry-pick`** → Read and follow [cherry-pick.md](references/rules/cherry-pick.md)
 - **`diff-check`** → Read and follow [diff-check.md](references/rules/diff-check.md)
 - **`publish`** → Read and follow [publish.md](references/rules/publish.md)
@@ -35,6 +37,7 @@ Parse the argument passed to this skill:
 ## Typical Release Flow
 
 ```
+/1k-bundle-release prepare       ← Set BUILD_NUMBER in .env.version and push
 /1k-bundle-release cherry-pick   ← Collect and apply verified PRs
 /1k-bundle-release diff-check    ← Verify subset integrity + review changeset
 /1k-bundle-release publish       ← Record release in tracking file

--- a/.claude/skills/1k-bundle-release/SKILL.md
+++ b/.claude/skills/1k-bundle-release/SKILL.md
@@ -43,7 +43,7 @@ Parse the argument passed to this skill:
 /1k-bundle-release publish       ← Record release in tracking file
 ```
 
-These three steps are designed to run in sequence, but each can also run independently (e.g., re-running diff-check after fixing an issue).
+These steps are designed to run in sequence, but each can also run independently (e.g., re-running diff-check after fixing an issue).
 
 ## Label Convention
 

--- a/.claude/skills/1k-bundle-release/references/rules/prepare.md
+++ b/.claude/skills/1k-bundle-release/references/rules/prepare.md
@@ -1,0 +1,106 @@
+# Prepare Workflow
+
+Prepares the release branch for bundle CI by writing `BUILD_NUMBER` to `.env.version`, then commits and pushes after user confirmation.
+
+## Pre-flight Checks
+
+### 1. On a release branch
+
+```bash
+current_branch=$(git branch --show-current)
+# Must match: release/*
+```
+
+If not on a `release/*` branch, **stop immediately**:
+
+> "You must be on a `release/*` branch to run this command. Current branch: `$current_branch`"
+
+### 2. Working tree clean
+
+```bash
+git status --porcelain
+```
+
+Must be empty. If not, tell the user to commit or stash first.
+
+### 3. Remote is up to date
+
+```bash
+git fetch origin $current_branch
+git log HEAD..origin/$current_branch --oneline
+```
+
+If remote has new commits, warn the user and suggest pulling first.
+
+## Step 1: Get BUILD_NUMBER from user
+
+Ask the user for the `BUILD_NUMBER` value (the native App Shell build number this bundle targets).
+
+Validate:
+- Non-empty, digits only
+- Typical format: `1026MMDD##` (e.g., `1026031801`)
+
+If invalid, explain the expected format and ask again.
+
+## Step 2: Write to .env.version
+
+Read `.env.version`. Append `BUILD_NUMBER=<value>` before the trailing comment line. If `BUILD_NUMBER=` already exists, replace it.
+
+Before:
+```
+# VERSION: https://semver.org/
+
+VERSION=6.1.0
+
+# Will auto add BUILD_NUMBER and BUNDLE_VERSION variable at CI job. Must give an empty line at end of this file.
+```
+
+After:
+```
+# VERSION: https://semver.org/
+
+VERSION=6.1.0
+
+BUILD_NUMBER=1026031801
+
+# Will auto add BUILD_NUMBER and BUNDLE_VERSION variable at CI job. Must give an empty line at end of this file.
+```
+
+## Step 3: Show diff and confirm
+
+Show the diff and target branch, then wait for user confirmation:
+
+```
+=== Prepare Bundle Release ===
+
+Branch: release/v6.1.0
+BUILD_NUMBER: 1026031801
+
+Diff:
+  (git diff .env.version output)
+
+Proceed with commit and push to origin/release/v6.1.0? (y/n)
+```
+
+Do NOT proceed without explicit user confirmation.
+
+## Step 4: Commit and push
+
+```bash
+git add .env.version
+git commit -m "chore: set BUILD_NUMBER=$BUILD_NUMBER for bundle release"
+git push origin $current_branch
+```
+
+## Step 5: Output
+
+```
+=== Bundle Release Prepared ===
+
+Branch: release/v6.1.0
+BUILD_NUMBER: 1026031801
+Commit: abc1234
+
+.env.version updated and pushed.
+Next step: trigger release-app-bundles workflow via workflow_dispatch on this branch.
+```


### PR DESCRIPTION
## Summary
- Add `prepare` subcommand to `1k-bundle-release` skill as the first step in the release flow
- Automates writing `BUILD_NUMBER` to `.env.version` with branch gating (`release/*` only)
- Shows diff and waits for user confirmation before commit & push

## Flow
```
/1k-bundle-release prepare       ← NEW: Set BUILD_NUMBER in .env.version and push
/1k-bundle-release cherry-pick   ← Collect and apply verified PRs
/1k-bundle-release diff-check    ← Verify subset integrity + review changeset
/1k-bundle-release publish       ← Record release in tracking file
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
