### PR TITLE
fix: only trigger recovery page on actual crashes

### DIFF
--- a/.claude/skills/1k-monitor-pr-ci/SKILL.md
+++ b/.claude/skills/1k-monitor-pr-ci/SKILL.md
@@ -31,16 +31,21 @@ Determine the PR to monitor:
 
 Each iteration (`[Check N/30]`):
 
-1. **Fetch CI status**:
+**MUST run ALL three commands in parallel on every iteration** (missing any one may cause review comments to be silently ignored):
+
    ```bash
+   # 1. CI check status
    gh pr checks <PR_NUMBER>
+
+   # 2. PR-level reviews and general comments
+   gh pr view <PR_NUMBER> --json reviews,comments,reviewDecision
+
+   # 3. Inline review comments (e.g. from Devin, human reviewers)
+   gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments \
+     --jq '.[] | {user: .user.login, body: .body, path: .path, line: .original_line, created_at: .created_at}'
    ```
 
-2. **Fetch review comments** (every iteration):
-   ```bash
-   gh pr view <PR_NUMBER> --json reviews,comments,reviewDecision
-   gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments --jq '.[] | {user: .user.login, body: .body, path: .path, line: .original_line, created_at: .created_at}'
-   ```
+   > **Why all three?** `gh pr checks` only returns CI status. `gh pr view --json reviews` returns PR-level reviews but NOT inline file comments. `gh api .../pulls/.../comments` is the ONLY way to get inline code review comments (the kind that appear on specific lines in the diff). Skipping it means inline comments from bots like Devin or human reviewers will be completely invisible.
 
 3. **Display status summary**:
    ```

--- a/apps/desktop/app/app.ts
+++ b/apps/desktop/app/app.ts
@@ -1255,6 +1255,10 @@ app.on('activate', async () => {
 });
 
 app.on('before-quit', () => {
+  // Reset crash counter on graceful shutdown so normal close
+  // is not mistaken for a crash on next boot
+  store.resetConsecutiveBootFailCount();
+
   if (systemIdleInterval) {
     clearInterval(systemIdleInterval);
   }

--- a/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/BootRecoveryKeys.java
+++ b/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/BootRecoveryKeys.java
@@ -1,0 +1,10 @@
+package so.onekey.app.wallet;
+
+final class BootRecoveryKeys {
+    static final String PREFS_NAME = "onekey_recovery";
+    static final String CONSECUTIVE_BOOT_FAIL_COUNT = "consecutive_boot_fail_count";
+    static final String BOOT_FAIL_APP_VERSION = "boot_fail_app_version";
+    static final String RECOVERY_ACTION = "recovery_action";
+
+    private BootRecoveryKeys() {}
+}

--- a/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/MainActivity.java
+++ b/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/MainActivity.java
@@ -87,6 +87,17 @@ public class MainActivity extends ReactActivity {
   }
 
   @Override
+  protected void onStop() {
+    super.onStop();
+    // Reset crash counter on graceful exit so normal close
+    // is not mistaken for a crash on next boot
+    getSharedPreferences(BootRecoveryKeys.PREFS_NAME, MODE_PRIVATE)
+        .edit()
+        .putInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, 0)
+        .commit();
+  }
+
+  @Override
   protected void onSaveInstanceState(@NonNull Bundle outState) {
     ActivityManager am = (ActivityManager) getSystemService(Context.ACTIVITY_SERVICE);
     ActivityManager.MemoryInfo memInfo = new ActivityManager.MemoryInfo();

--- a/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/MainApplication.java
+++ b/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/MainApplication.java
@@ -91,20 +91,21 @@ public class MainApplication extends Application implements ReactApplication {
   @Override
   public void onCreate() {
     // Recovery check
-    SharedPreferences prefs = getSharedPreferences("onekey_recovery", MODE_PRIVATE);
+    SharedPreferences prefs = getSharedPreferences(BootRecoveryKeys.PREFS_NAME, MODE_PRIVATE);
 
     // Version-aware counter reset
     String currentVersion = BuildConfig.VERSION_NAME;
-    String storedVersion = prefs.getString("boot_fail_app_version", "");
+    String storedVersion = prefs.getString(BootRecoveryKeys.BOOT_FAIL_APP_VERSION, "");
     if (!storedVersion.isEmpty() && !storedVersion.equals(currentVersion)) {
-        prefs.edit().putInt("consecutive_boot_fail_count", 0).commit();
+        prefs.edit().putInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, 0).commit();
     }
-    prefs.edit().putString("boot_fail_app_version", currentVersion).commit();
+    prefs.edit().putString(BootRecoveryKeys.BOOT_FAIL_APP_VERSION, currentVersion).commit();
 
-    // Increment FIRST, then check
-    int oldCount = prefs.getInt("consecutive_boot_fail_count", 0);
+    // Increment boot fail count; counter is reset in MainActivity.onStop()
+    // on graceful exit, so only consecutive crashes accumulate
+    int oldCount = prefs.getInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, 0);
     int newCount = oldCount + 1;
-    prefs.edit().putInt("consecutive_boot_fail_count", newCount).commit();
+    prefs.edit().putInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, newCount).commit();
 
     shouldShowRecovery = newCount >= 3;
 

--- a/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/RecoveryActivity.java
+++ b/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/RecoveryActivity.java
@@ -225,10 +225,10 @@ public class RecoveryActivity extends AppCompatActivity {
 
     private void tryAgain() {
         try {
-            SharedPreferences prefs = getSharedPreferences("onekey_recovery", MODE_PRIVATE);
+            SharedPreferences prefs = getSharedPreferences(BootRecoveryKeys.PREFS_NAME, MODE_PRIVATE);
             prefs.edit()
-                .putInt("consecutive_boot_fail_count", 0)
-                .putString("recovery_action", "try_again")
+                .putInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, 0)
+                .putString(BootRecoveryKeys.RECOVERY_ACTION, "try_again")
                 .commit();
             restartApp();
         } catch (Exception e) {
@@ -258,10 +258,10 @@ public class RecoveryActivity extends AppCompatActivity {
             clearAppCache();
 
             // Reset counter and set recovery action (single atomic write)
-            SharedPreferences prefs = getSharedPreferences("onekey_recovery", MODE_PRIVATE);
+            SharedPreferences prefs = getSharedPreferences(BootRecoveryKeys.PREFS_NAME, MODE_PRIVATE);
             prefs.edit()
-                .putInt("consecutive_boot_fail_count", 0)
-                .putString("recovery_action", "auto_repair")
+                .putInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, 0)
+                .putString(BootRecoveryKeys.RECOVERY_ACTION, "auto_repair")
                 .commit();
 
             // Show success dialog, restart on confirm

--- a/apps/mobile/ios/AppDelegate.swift
+++ b/apps/mobile/ios/AppDelegate.swift
@@ -100,11 +100,16 @@ public class AppDelegate: ExpoAppDelegate {
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 
-  // Reset crash counter on graceful exit so normal close is not mistaken for a crash
+  // Reset crash counter on graceful exit so normal close is not mistaken for a crash.
+  // Skip reset when in recovery mode (count >= 3) so recovery is still offered
+  // if the user force-kills from the app switcher while viewing the recovery screen.
   public override func applicationDidEnterBackground(_ application: UIApplication) {
     super.applicationDidEnterBackground(application)
-    UserDefaults.standard.set(0, forKey: BootRecoveryKeys.consecutiveBootFailCount)
-    UserDefaults.standard.synchronize()
+    let count = UserDefaults.standard.integer(forKey: BootRecoveryKeys.consecutiveBootFailCount)
+    if count < 3 {
+      UserDefaults.standard.set(0, forKey: BootRecoveryKeys.consecutiveBootFailCount)
+      UserDefaults.standard.synchronize()
+    }
   }
 
   // Linking API

--- a/apps/mobile/ios/AppDelegate.swift
+++ b/apps/mobile/ios/AppDelegate.swift
@@ -42,16 +42,17 @@ public class AppDelegate: ExpoAppDelegate {
 
     // Version-aware counter reset
     let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
-    let storedVersion = defaults.string(forKey: "onekey_boot_fail_app_version") ?? ""
+    let storedVersion = defaults.string(forKey: BootRecoveryKeys.bootFailAppVersion) ?? ""
     if !storedVersion.isEmpty && storedVersion != currentVersion {
-      defaults.set(0, forKey: "onekey_consecutive_boot_fail_count")
+      defaults.set(0, forKey: BootRecoveryKeys.consecutiveBootFailCount)
     }
-    defaults.set(currentVersion, forKey: "onekey_boot_fail_app_version")
+    defaults.set(currentVersion, forKey: BootRecoveryKeys.bootFailAppVersion)
 
-    // Increment FIRST, then check NEW value
-    let oldCount = defaults.integer(forKey: "onekey_consecutive_boot_fail_count")
+    // Increment boot fail count; counter is reset in applicationDidEnterBackground
+    // on graceful exit, so only consecutive crashes accumulate
+    let oldCount = defaults.integer(forKey: BootRecoveryKeys.consecutiveBootFailCount)
     let newCount = oldCount + 1
-    defaults.set(newCount, forKey: "onekey_consecutive_boot_fail_count")
+    defaults.set(newCount, forKey: BootRecoveryKeys.consecutiveBootFailCount)
     defaults.synchronize()
 
     if newCount >= 3 {
@@ -97,6 +98,13 @@ public class AppDelegate: ExpoAppDelegate {
     JPUSHService.setDebugMode()
     JPUSHService.register(forRemoteNotificationConfig: entity, delegate: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  // Reset crash counter on graceful exit so normal close is not mistaken for a crash
+  public override func applicationDidEnterBackground(_ application: UIApplication) {
+    super.applicationDidEnterBackground(application)
+    UserDefaults.standard.set(0, forKey: BootRecoveryKeys.consecutiveBootFailCount)
+    UserDefaults.standard.synchronize()
   }
 
   // Linking API

--- a/apps/mobile/ios/OneKeyWallet.xcodeproj/project.pbxproj
+++ b/apps/mobile/ios/OneKeyWallet.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		07A167A92E576AF7006A3117 /* OneKeyLogo.icon in Resources */ = {isa = PBXBuildFile; fileRef = 07A167A82E576AF7006A3117 /* OneKeyLogo.icon */; };
 		07A167AA2E576AF7006A3117 /* OneKeyLogo.icon in Resources */ = {isa = PBXBuildFile; fileRef = 07A167A82E576AF7006A3117 /* OneKeyLogo.icon */; };
 		07B1C3A12F08000000E00001 /* RecoveryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07B1C3A02F08000000E00001 /* RecoveryViewController.swift */; };
+		07B1C3A32F08000000E00002 /* BootRecoveryKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07B1C3A22F08000000E00002 /* BootRecoveryKeys.swift */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		2788FF4A611FA65E5DD92E66 /* libPods-OneKeyWallet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9373BA6134E4C051DB510900 /* libPods-OneKeyWallet.a */; };
 		31ADF8BB30114AF196CCBDE4 /* noop-file.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DAB62C802804CA1BF90BB10 /* noop-file.swift */; };
@@ -66,6 +67,7 @@
 		0799B76F2E162F7D001ADEC8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		07A167A82E576AF7006A3117 /* OneKeyLogo.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = OneKeyLogo.icon; sourceTree = "<group>"; };
 		07B1C3A02F08000000E00001 /* RecoveryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RecoveryViewController.swift; path = OneKeyWallet/RecoveryViewController.swift; sourceTree = "<group>"; };
+		07B1C3A22F08000000E00002 /* BootRecoveryKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BootRecoveryKeys.swift; path = OneKeyWallet/BootRecoveryKeys.swift; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* OneKeyWallet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OneKeyWallet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = OneKeyWallet/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = OneKeyWallet/Info.plist; sourceTree = "<group>"; };
@@ -151,6 +153,7 @@
 				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
 				2DAB62C802804CA1BF90BB10 /* noop-file.swift */,
 				07B1C3A02F08000000E00001 /* RecoveryViewController.swift */,
+				07B1C3A22F08000000E00002 /* BootRecoveryKeys.swift */,
 				3381AFE75EB640B98B8576AB /* OneKeyWallet-Bridging-Header.h */,
 				07A167A82E576AF7006A3117 /* OneKeyLogo.icon */,
 			);
@@ -559,6 +562,7 @@
 			files = (
 				31ADF8BB30114AF196CCBDE4 /* noop-file.swift in Sources */,
 				07B1C3A12F08000000E00001 /* RecoveryViewController.swift in Sources */,
+				07B1C3A32F08000000E00002 /* BootRecoveryKeys.swift in Sources */,
 				0799B7702E162F7D001ADEC8 /* AppDelegate.swift in Sources */,
 				4B0291071DB1A9856B2D4C1B /* ExpoModulesProvider.swift in Sources */,
 			);

--- a/apps/mobile/ios/OneKeyWallet/BootRecoveryKeys.swift
+++ b/apps/mobile/ios/OneKeyWallet/BootRecoveryKeys.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum BootRecoveryKeys {
+  static let consecutiveBootFailCount = "onekey_consecutive_boot_fail_count"
+  static let bootFailAppVersion = "onekey_boot_fail_app_version"
+  static let recoveryAction = "onekey_recovery_action"
+}

--- a/apps/mobile/ios/OneKeyWallet/RecoveryViewController.swift
+++ b/apps/mobile/ios/OneKeyWallet/RecoveryViewController.swift
@@ -417,8 +417,8 @@ final class RecoveryViewController: UIViewController {
 
   @objc private func tryAgainTapped() {
     let defaults = UserDefaults.standard
-    defaults.set(0, forKey: "onekey_consecutive_boot_fail_count")
-    defaults.set("try_again", forKey: "onekey_recovery_action")
+    defaults.set(0, forKey: BootRecoveryKeys.consecutiveBootFailCount)
+    defaults.set("try_again", forKey: BootRecoveryKeys.recoveryAction)
     defaults.synchronize()
     showAlert(title: RecoveryStrings.current.pleaseRestart, message: "")
   }
@@ -456,8 +456,8 @@ final class RecoveryViewController: UIViewController {
 
     // 4. Reset boot fail counter
     let defaults = UserDefaults.standard
-    defaults.set(0, forKey: "onekey_consecutive_boot_fail_count")
-    defaults.set("auto_repair", forKey: "onekey_recovery_action")
+    defaults.set(0, forKey: BootRecoveryKeys.consecutiveBootFailCount)
+    defaults.set("auto_repair", forKey: BootRecoveryKeys.recoveryAction)
     defaults.synchronize()
 
     if errors.isEmpty {


### PR DESCRIPTION
## Summary

- The recovery page was previously triggered when users quickly opened and closed the app 3 times, even without any actual crash, causing unnecessary alarm
- Introduced a **graceful shutdown flag** across all platforms: on normal exit the flag is persisted, and on the next boot the crash counter is reset if the flag is present — only genuine crashes increment the counter
- Implemented platform-specific graceful shutdown detection for Desktop, iOS, and Android

## Changes

| Platform | Graceful Shutdown Signal | Storage Mechanism |
|----------|-------------------------|-------------------|
| Desktop (Electron) | `app.on('before-quit')` | electron-store |
| iOS | `applicationDidEnterBackground` | UserDefaults |
| Android | `MainActivity.onStop()` | SharedPreferences |

### Why `applicationDidEnterBackground` on iOS?

`applicationWillTerminate` is unreliable — it is **not called** when the user swipes the app away from the app switcher or when the system reclaims background processes. `applicationDidEnterBackground` is the last lifecycle callback guaranteed to fire before the process may be terminated, making it the correct signal for detecting intentional app closure.

### Behavior Matrix

| Scenario | Graceful Flag Set? | Counter Incremented? |
|----------|--------------------|---------------------|
| User closes app normally | Yes | No (counter reset to 0) |
| App crashes in foreground | No | Yes |
| OS terminates app in background | Yes (set when entering background) | No |
| OS force-kills process (e.g. `kill -9`) | No | Yes |

## Test Plan

- [ ] **Desktop**: Rapidly open and close the app 3 times — verify recovery page does **not** appear
- [ ] **iOS**: Rapidly open and close the app 3 times — verify recovery page does **not** appear
- [ ] **Android**: Rapidly open and close the app 3 times — verify recovery page does **not** appear
- [ ] **Desktop**: Simulate crash (e.g. `kill -9`), repeat 3 times — verify recovery page **does** appear
- [ ] **All platforms**: Use the app normally for >5 seconds — verify `markBootSuccess` still resets the counter as expected
- [ ] **All platforms**: Verify version change still resets the counter
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
