### PR TITLE
fix(market): perps watchlist tags, volume dollar sign, and remove favorite entry

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/MarketPerpsTokenListItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/MarketPerpsTokenListItem.tsx
@@ -63,6 +63,7 @@ const BasicMarketPerpsTokenListItem: FC<IMarketPerpsTokenListItemProps> = ({
                 color="$textSubdued"
                 numberOfLines={1}
                 formatter="marketCap"
+                formatterOptions={{ currency: '$' }}
                 userSelect="none"
               >
                 {item.volume24h ?? '0'}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenIdentityItem/TokenIdentityItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenIdentityItem/TokenIdentityItem.tsx
@@ -15,9 +15,11 @@ import { Token } from '@onekeyhq/kit/src/components/Token';
 import { useNetworkLogoUri } from '@onekeyhq/kit/src/hooks/useNetworkLogoUri';
 import { CommunityRecognizedBadge } from '@onekeyhq/kit/src/views/Market/components/CommunityRecognizedBadge';
 import {
+  LeverageBadge,
   StockSourceLogo,
   SubtitleBadge,
 } from '@onekeyhq/kit/src/views/Market/components/PerpsBadges';
+import { TokenTagsPopover } from '@onekeyhq/kit/src/views/Market/components/TokenTagsPopover';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { ECopyFrom } from '@onekeyhq/shared/src/logger/scopes/dex';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -83,6 +85,14 @@ interface ITokenIdentityItemProps {
    * Stock info for tokenized real-world assets.
    */
   stock?: IMarketStockInfo;
+  /**
+   * Max leverage for perpetual tokens (e.g. 40 for "40x").
+   */
+  maxLeverage?: number;
+  /**
+   * Subtitle for perpetual tokens (e.g. Chinese name tag).
+   */
+  perpsSubtitle?: string;
 }
 
 const BasicTokenIdentityItem: FC<ITokenIdentityItemProps> = ({
@@ -99,6 +109,8 @@ const BasicTokenIdentityItem: FC<ITokenIdentityItemProps> = ({
   copyFrom = ECopyFrom.Homepage,
   communityRecognized,
   stock,
+  maxLeverage,
+  perpsSubtitle,
 }) => {
   const { gtMd } = useMedia();
   const { copyText } = useClipboard();
@@ -167,9 +179,29 @@ const BasicTokenIdentityItem: FC<ITokenIdentityItemProps> = ({
           >
             {symbol}
           </SizableText>
-          <StockSourceLogo stock={stock} />
-          {communityRecognized ? <CommunityRecognizedBadge /> : null}
-          {stock?.subtitle ? <SubtitleBadge subtitle={stock.subtitle} /> : null}
+          {maxLeverage ? <LeverageBadge leverage={maxLeverage} /> : null}
+          {gtMd ? (
+            <>
+              <StockSourceLogo stock={stock} />
+              {communityRecognized ? <CommunityRecognizedBadge /> : null}
+              {stock?.subtitle ? (
+                <SubtitleBadge subtitle={stock.subtitle} />
+              ) : null}
+            </>
+          ) : (
+            <>
+              <TokenTagsPopover
+                communityRecognized={communityRecognized}
+                stock={stock}
+              />
+              {stock?.subtitle ? (
+                <SubtitleBadge subtitle={stock.subtitle} />
+              ) : null}
+            </>
+          )}
+          {!stock?.subtitle && perpsSubtitle ? (
+            <SubtitleBadge subtitle={perpsSubtitle} />
+          ) : null}
         </XStack>
         {shouldShowSecondRow ? (
           <XStack alignItems="center" gap="$1" height="$4">

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenListItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenListItem.tsx
@@ -90,6 +90,8 @@ const BasicTokenListItem: FC<ITokenListItemProps> = ({
           volume={item.turnover}
           communityRecognized={item.communityRecognized}
           stock={item.stock}
+          maxLeverage={item.maxLeverage}
+          perpsSubtitle={item.perpsSubtitle}
         />
       </XStack>
 

--- a/packages/kit/src/views/Market/components/TokenTagsPopover.tsx
+++ b/packages/kit/src/views/Market/components/TokenTagsPopover.tsx
@@ -1,0 +1,110 @@
+import { memo, useMemo } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import {
+  Icon,
+  Image,
+  Popover,
+  SizableText,
+  Stack,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import type { IMarketStockInfo } from '@onekeyhq/shared/types/marketV2';
+
+import type { GestureResponderEvent } from 'react-native';
+
+interface ITokenTagsPopoverProps {
+  communityRecognized?: boolean;
+  stock?: IMarketStockInfo;
+}
+
+function TokenTagsPopover({
+  communityRecognized,
+  stock,
+}: ITokenTagsPopoverProps) {
+  const intl = useIntl();
+
+  const hasStockSource = !!stock?.sourceLogoUri;
+  const hasTags = communityRecognized || hasStockSource;
+
+  const stockLabelId = useMemo(() => {
+    if (!stock?.source) return undefined;
+    if (stock.source === 'ondo') return ETranslations.dexmarket_tokenized_ondo;
+    if (stock.source === 'xstock')
+      return ETranslations.dexmarket_tokenized_xstock;
+    return undefined;
+  }, [stock?.source]);
+
+  if (!hasTags) {
+    return null;
+  }
+
+  const triggerIcons = (
+    <XStack alignItems="center" gap="$1">
+      {hasStockSource ? (
+        <Image
+          width={14}
+          height={14}
+          borderRadius="$full"
+          source={{ uri: stock.sourceLogoUri }}
+        />
+      ) : null}
+      {communityRecognized ? (
+        <Icon name="BadgeRecognizedSolid" size="$4" color="$iconSuccess" />
+      ) : null}
+    </XStack>
+  );
+
+  const handlePress = (e: GestureResponderEvent) => {
+    e.stopPropagation();
+  };
+
+  return (
+    <Stack onPress={handlePress}>
+      <Popover
+        title={intl.formatMessage({ id: ETranslations.send_tag })}
+        placement="bottom"
+        renderTrigger={triggerIcons}
+        renderContent={
+          <YStack px="$5" pb="$5" pt="$1" gap="$4">
+            {communityRecognized ? (
+              <XStack alignItems="center" gap="$3">
+                <Icon
+                  name="BadgeRecognizedSolid"
+                  size="$6"
+                  color="$iconSuccess"
+                />
+                <SizableText size="$bodyLgMedium" flex={1} flexWrap="wrap">
+                  {intl.formatMessage({
+                    id: ETranslations.dexmarket_communityRecognized,
+                  })}
+                </SizableText>
+              </XStack>
+            ) : null}
+            {hasStockSource ? (
+              <XStack alignItems="center" gap="$3">
+                <Image
+                  width={24}
+                  height={24}
+                  borderRadius="$full"
+                  source={{ uri: stock.sourceLogoUri }}
+                />
+                <SizableText size="$bodyLgMedium" flex={1} flexWrap="wrap">
+                  {stockLabelId
+                    ? intl.formatMessage({ id: stockLabelId })
+                    : stock?.title}
+                </SizableText>
+              </XStack>
+            ) : null}
+          </YStack>
+        }
+      />
+    </Stack>
+  );
+}
+
+const MemoTokenTagsPopover = memo(TokenTagsPopover);
+export { MemoTokenTagsPopover as TokenTagsPopover };

--- a/packages/kit/src/views/Perp/components/PerpSettingsDialog.tsx
+++ b/packages/kit/src/views/Perp/components/PerpSettingsDialog.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback } from 'react';
+import type { ReactNode } from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -9,13 +9,8 @@ import {
   Switch,
   YStack,
 } from '@onekeyhq/components';
-import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
-import {
-  usePerpTokenFavoritesPersistAtom,
-  usePerpsActiveAssetAtom,
-  usePerpsCustomSettingsAtom,
-} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { usePerpsCustomSettingsAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { PerpsProviderMirror } from '../PerpsProviderMirror';
@@ -33,46 +28,10 @@ function PerpSettingsPopoverContent({
 }: IPerpSettingsPopoverContentProps) {
   const [perpsCustomSettings, setPerpsCustomSettings] =
     usePerpsCustomSettingsAtom();
-  const [activeAsset] = usePerpsActiveAssetAtom();
-  const [favorites, setFavorites] = usePerpTokenFavoritesPersistAtom();
-  const isFavorite = favorites.favorites.includes(activeAsset.coin);
   const intl = useIntl();
-
-  const handleToggleFavorite = useCallback(() => {
-    setFavorites((prev) => {
-      const alreadyFavorite = prev.favorites.includes(activeAsset.coin);
-      void backgroundApiProxy.serviceMarketV2.syncToMarketWatchList({
-        coin: activeAsset.coin,
-        action: alreadyFavorite ? 'remove' : 'add',
-      });
-      return {
-        ...prev,
-        favorites: alreadyFavorite
-          ? prev.favorites.filter((f) => f !== activeAsset.coin)
-          : [...prev.favorites, activeAsset.coin],
-      };
-    });
-  }, [activeAsset.coin, setFavorites]);
 
   return (
     <YStack py="$3" px="$2">
-      <ListItem
-        mx="$0"
-        px="$2.5"
-        titleProps={{ size: '$bodyMdMedium' }}
-        title={intl.formatMessage({
-          id: isFavorite
-            ? ETranslations.market_remove_from_favorites
-            : ETranslations.market_add_to_favorites,
-        })}
-        icon={isFavorite ? 'StarSolid' : 'StarOutline'}
-        iconProps={{
-          color: isFavorite ? '$iconActive' : '$iconSubdued',
-          size: '$4',
-        }}
-        onPress={handleToggleFavorite}
-        cursor="default"
-      />
       <ListItem
         mx="$0"
         px="$2.5"


### PR DESCRIPTION
https://onekeyhq.atlassian.net/browse/OK-51891
https://onekeyhq.atlassian.net/browse/OK-51886
## Summary
- Show leverage badge (e.g. 40x) and subtitle tags for perps tokens in the watchlist (favorites) view
- Add dollar sign `$` prefix to volume display in the perps token list on mobile
- Add `TokenTagsPopover` component for mobile to consolidate community recognized and stock source badges into a single popover, with `stopPropagation` to prevent tap conflicts with parent row gestures
- Remove add-to-favorites/remove-from-favorites entry from the perps settings menu (both mobile and desktop)

## Test plan
- [ ] Verify perps tokens in watchlist show leverage badges (e.g. "40x") and subtitle tags
- [ ] Verify perps tab token list shows `$` prefix on volume (e.g. `$3.92B` instead of `3.92B`)
- [ ] Verify tapping tag icons in mobile list rows opens popover without navigating to detail page
- [ ] Verify watchlist drag/long-press gestures still work correctly near tag icons
- [ ] Verify perps settings menu no longer shows the add/remove favorites option on both mobile and desktop
- [ ] Verify desktop market list still renders badges correctly (no regression)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
