### PR TITLE
feat(ci): support building bundles from PR number

### DIFF
--- a/.github/workflows/release-app-bundles.yml
+++ b/.github/workflows/release-app-bundles.yml
@@ -2,6 +2,11 @@ name: release-app-bundles
 
 on:
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to build (optional, builds from PR merge ref)'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -19,6 +24,13 @@ jobs:
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
+        if: ${{ !inputs.pr_number }}
+
+      - name: Checkout PR
+        if: ${{ inputs.pr_number }}
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ inputs.pr_number }}/merge
 
       - name: Generate build parameters
         id: params
@@ -50,13 +62,23 @@ jobs:
           echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
           echo "build_bundle_version=$BUILD_BUNDLE_VERSION" >> $GITHUB_OUTPUT
           echo "build_source=$BUILD_SOURCE" >> $GITHUB_OUTPUT
-          echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
-          echo "commit=${{ github.sha }}" >> $GITHUB_OUTPUT
+          if [ -n "${{ inputs.pr_number }}" ]; then
+            BRANCH="pull/${{ inputs.pr_number }}"
+            COMMIT=$(git rev-parse HEAD)
+          else
+            BRANCH="${{ github.ref_name }}"
+            COMMIT="${{ github.sha }}"
+          fi
+
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "commit=$COMMIT" >> $GITHUB_OUTPUT
 
           echo "Summary:"
           echo "  BUILD_NUMBER=$BUILD_NUMBER"
           echo "  BUILD_BUNDLE_VERSION=$BUILD_BUNDLE_VERSION"
           echo "  BUILD_SOURCE=$BUILD_SOURCE"
+          echo "  BRANCH=$BRANCH"
+          echo "  COMMIT=$COMMIT"
 
   desktop-bundle:
     needs: prepare-params


### PR DESCRIPTION
## Summary
- Add optional `pr_number` input to `release-app-bundles` workflow
- When provided, checks out `refs/pull/<number>/merge` instead of the current branch
- Enables bundle builds for external contributor PRs without manually pushing their branches to origin

## Test plan
- [ ] Trigger workflow without `pr_number` — should behave as before
- [ ] Trigger workflow with a valid PR number — should checkout and build from that PR's merge ref
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
