### PR TITLE
fix: move Device tab to bottom of desktop sidebar

### DIFF
--- a/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
@@ -613,7 +613,8 @@ export function DesktopLeftSideBar({
                   options={descriptors[deviceRoute.key].options}
                   onPress={() => {
                     handleTabPress(deviceRoute, isDeviceActive);
-                    const { trackId } = descriptors[deviceRoute.key].options as {
+                    const { trackId } = descriptors[deviceRoute.key]
+                      .options as {
                       trackId?: string;
                     };
                     if (trackId) {

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 
+import { Tooltip } from '@onekeyhq/components/src/actions';
 import type { IActionListSection } from '@onekeyhq/components/src/actions';
 import { useSafeAreaInsets } from '@onekeyhq/components/src/hooks';
 import type { IKeyOfIcons } from '@onekeyhq/components/src/primitives';
@@ -203,6 +204,53 @@ function useTabAction(navigation: BottomTabBarProps['navigation']) {
       options?.callback?.();
     },
     [navigation],
+  );
+}
+
+function SidebarBottomItem({
+  route,
+  isActive,
+  options,
+  onPress,
+}: {
+  route: NavigationState['routes'][0];
+  isActive: boolean;
+  options: BottomTabNavigationOptions & {
+    collapseTabBarLabel?: string;
+  };
+  onPress: () => void;
+}) {
+  // @ts-expect-error tabBarIcon returns icon name string, not ReactNode
+  const iconName = options?.tabBarIcon?.(isActive) as IKeyOfIcons;
+  const label =
+    options.collapseTabBarLabel ??
+    (typeof options.tabBarLabel === 'string'
+      ? options.tabBarLabel
+      : undefined) ??
+    route.name;
+
+  return (
+    <Tooltip
+      placement="right"
+      renderTrigger={
+        <YStack
+          p="$2"
+          borderRadius="$2"
+          bg={isActive ? '$bgActive' : undefined}
+          hoverStyle={{ bg: '$bgHover' }}
+          pressStyle={{ bg: '$bgActive' }}
+          cursor="default"
+          onPress={onPress}
+        >
+          <Icon
+            name={iconName}
+            size="$6"
+            color={isActive ? '$iconActive' : '$iconSubdued'}
+          />
+        </YStack>
+      }
+      renderContent={label}
+    />
   );
 }
 
@@ -430,7 +478,8 @@ export function DesktopLeftSideBar({
     setMaxVisibleCount((prev) => (prev === count ? prev : count));
   }, []);
 
-  const { visibleRoutes, overflowRoutes } = useMemo(() => {
+  const { visibleRoutes, overflowRoutes, deviceRoute } = useMemo(() => {
+    let deviceRoute: (typeof routes)[0] | undefined;
     const validRoutes = routes.filter((route) => {
       const { options } = descriptors[route.key] as {
         options: {
@@ -439,6 +488,10 @@ export function DesktopLeftSideBar({
         };
       };
       if (options.hiddenIcon || options.hideOnTabBar) {
+        return false;
+      }
+      if (route.name === ETabRoutes.DeviceManagement) {
+        deviceRoute = route;
         return false;
       }
       if (isShowWebTabBar && route.name === extraConfig?.name) {
@@ -451,12 +504,14 @@ export function DesktopLeftSideBar({
       return {
         visibleRoutes: validRoutes,
         overflowRoutes: [] as typeof validRoutes,
+        deviceRoute,
       };
     }
     const visibleCount = Math.max(0, maxVisibleCount - 1);
     return {
       visibleRoutes: validRoutes.slice(0, visibleCount),
       overflowRoutes: validRoutes.slice(visibleCount),
+      deviceRoute,
     };
   }, [
     routes,
@@ -471,6 +526,10 @@ export function DesktopLeftSideBar({
       isRouteActive(route, focusedRouteName, extraConfig?.name),
     );
   }, [overflowRoutes, focusedRouteName, extraConfig?.name]);
+
+  const isDeviceActive = deviceRoute
+    ? isRouteActive(deviceRoute, focusedRouteName, extraConfig?.name)
+    : false;
 
   return (
     <XStack
@@ -546,6 +605,16 @@ export function DesktopLeftSideBar({
                 />
               ) : null}
             </YStack>
+            {deviceRoute ? (
+              <YStack px="$3" pb="$2" alignItems="center">
+                <SidebarBottomItem
+                  route={deviceRoute}
+                  isActive={isDeviceActive}
+                  options={descriptors[deviceRoute.key].options}
+                  onPress={() => handleTabPress(deviceRoute, isDeviceActive)}
+                />
+              </YStack>
+            ) : null}
             {bottomMenu}
           </YStack>
         </YStack>

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
@@ -611,7 +611,15 @@ export function DesktopLeftSideBar({
                   route={deviceRoute}
                   isActive={isDeviceActive}
                   options={descriptors[deviceRoute.key].options}
-                  onPress={() => handleTabPress(deviceRoute, isDeviceActive)}
+                  onPress={() => {
+                    handleTabPress(deviceRoute, isDeviceActive);
+                    const { trackId } = descriptors[deviceRoute.key].options as {
+                      trackId?: string;
+                    };
+                    if (trackId) {
+                      defaultLogger.app.page.tabBarClick(trackId);
+                    }
+                  }}
                 />
               </YStack>
             ) : null}

--- a/packages/kit/src/components/MoreActionButton/index.tsx
+++ b/packages/kit/src/components/MoreActionButton/index.tsx
@@ -1541,7 +1541,7 @@ function MoreButtonWithDot({
     return (
       <YStack p="$2" borderRadius="$2" hoverStyle={{ bg: '$bgHover' }}>
         <Stack position="relative">
-          <Icon name="DotGridOutline" size="$5" />
+          <Icon name="DotGridOutline" size="$6" />
           {desktopDot}
         </Stack>
       </YStack>

--- a/packages/kit/src/components/MoreActionButton/index.tsx
+++ b/packages/kit/src/components/MoreActionButton/index.tsx
@@ -1541,7 +1541,7 @@ function MoreButtonWithDot({
     return (
       <YStack p="$2" borderRadius="$2" hoverStyle={{ bg: '$bgHover' }}>
         <Stack position="relative">
-          <Icon name="DotGridOutline" size="$6" />
+          <Icon name="DotGridOutline" size="$6" color="$iconSubdued" />
           {desktopDot}
         </Stack>
       </YStack>


### PR DESCRIPTION
<img width="400" alt="CleanShot 2026-03-18 at 17 49 44@2x" src="https://github.com/user-attachments/assets/e08bae8c-dbdb-42fb-a89c-b1b770a4f93c" />


## Summary
- Move the DeviceManagement tab from the regular sidebar tab list to the bottom, positioned above the MoreActionButton
- Style the Device tab as a compact icon button with tooltip, matching the MoreActionButton style
- Bump icon sizes from $5 to $6 for both the Device button and MoreActionButton on desktop

## Test plan
- [x] Verify Device tab appears at the bottom of the desktop sidebar, above the More button
- [x] Verify Device tab shows active state (background + icon color) when selected
- [x] Verify tooltip appears on hover
- [x] Verify navigation works when clicking the Device tab
- [x] Verify Device tab disappears on narrow viewports (modal fallback unchanged)
- [x] Verify no changes on mobile/native platforms

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
