### PR TITLE
feat: add commit hash search to dev bundle switcher

### DIFF
--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -1403,9 +1403,7 @@ class ServiceAppUpdate extends ServiceBase {
         return match ? { version: v.version, bundle: match } : null;
       }),
     );
-    return results.filter(
-      (r): r is NonNullable<typeof r> => r !== null,
-    );
+    return results.filter((r): r is NonNullable<typeof r> => r !== null);
   }
 }
 

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -1371,6 +1371,42 @@ class ServiceAppUpdate extends ServiceBase {
       return [];
     }
   }
+
+  @backgroundMethod()
+  async devSearchBundleByCommit(commitHash: string): Promise<
+    {
+      version: string;
+      bundle: {
+        bundleVersion?: string;
+        ciBundleVersion: string;
+        downloadUrl: string;
+        sha256: string;
+        signature?: string;
+        fileSize: number;
+        commitHash?: string;
+        branch?: string;
+        prTitle?: string;
+        changeLog?: string;
+        buildNumber?: string;
+      };
+    }[]
+  > {
+    const needle = commitHash.trim().toLowerCase();
+    if (!needle) return [];
+    const versions = await this.devFetchBundleVersions();
+    const results = await Promise.all(
+      versions.map(async (v) => {
+        const bundles = await this.devFetchBundlesForVersion(v.version);
+        const match = bundles.find((b) =>
+          (b.commitHash || '').toLowerCase().startsWith(needle),
+        );
+        return match ? { version: v.version, bundle: match } : null;
+      }),
+    );
+    return results.filter(
+      (r): r is NonNullable<typeof r> => r !== null,
+    );
+  }
 }
 
 export default ServiceAppUpdate;

--- a/packages/kit/src/views/Setting/pages/DevBundleSwitcher/BundleList.tsx
+++ b/packages/kit/src/views/Setting/pages/DevBundleSwitcher/BundleList.tsx
@@ -35,7 +35,7 @@ import type { RouteProp } from '@react-navigation/core';
 
 const PLACEHOLDER_SIGNATURE = 'dev-no-signature';
 
-type IBundleInfo = {
+export type IBundleInfo = {
   bundleVersion?: string;
   ciBundleVersion: string;
   downloadUrl: string;
@@ -49,7 +49,7 @@ type IBundleInfo = {
   buildNumber?: string;
 };
 
-function normalizeCommitHash(commitHash?: string) {
+export function normalizeCommitHash(commitHash?: string) {
   return String(commitHash || '')
     .trim()
     .toLowerCase();
@@ -61,7 +61,7 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-function BundleItem({
+export function BundleItem({
   bundle,
   version,
   isCurrentBundle,

--- a/packages/kit/src/views/Setting/pages/DevBundleSwitcher/VersionList.tsx
+++ b/packages/kit/src/views/Setting/pages/DevBundleSwitcher/VersionList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { StyleSheet } from 'react-native';
 
@@ -16,9 +16,7 @@ import {
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
-import {
-  BundleUpdate,
-} from '@onekeyhq/shared/src/modules3rdParty/auto-update';
+import { BundleUpdate } from '@onekeyhq/shared/src/modules3rdParty/auto-update';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalSettingRoutes } from '@onekeyhq/shared/src/routes';
 
@@ -99,6 +97,7 @@ export default function SettingDevBundleVersionList() {
   const [skipGpgVerificationAllowed, setSkipGpgVerificationAllowed] =
     useState(false);
   const [downloadedSet, setDownloadedSet] = useState<Set<string>>(new Set());
+  const searchIdRef = useRef(0);
 
   const currentAppVersion = String(platformEnv.version);
   const currentBundleVersion = String(platformEnv.bundleVersion);
@@ -125,10 +124,13 @@ export default function SettingDevBundleVersionList() {
     setSearchText(text);
     const trimmed = text.trim();
     if (!trimmed) {
+      searchIdRef.current += 1;
       setSearchResults([]);
       setSearching(false);
       return;
     }
+    searchIdRef.current += 1;
+    const currentSearchId = searchIdRef.current;
     setSearching(true);
     void (async () => {
       try {
@@ -136,6 +138,7 @@ export default function SettingDevBundleVersionList() {
           await backgroundApiProxy.serviceAppUpdate.devSearchBundleByCommit(
             trimmed,
           );
+        if (currentSearchId !== searchIdRef.current) return;
         setSearchResults(results);
 
         // Check which bundles are already downloaded
@@ -155,9 +158,12 @@ export default function SettingDevBundleVersionList() {
             }
           }),
         );
+        if (currentSearchId !== searchIdRef.current) return;
         setDownloadedSet(downloaded);
       } finally {
-        setSearching(false);
+        if (currentSearchId === searchIdRef.current) {
+          setSearching(false);
+        }
       }
     })();
   }, []);
@@ -208,7 +214,8 @@ export default function SettingDevBundleVersionList() {
                   <Stack py="$10" justifyContent="center" alignItems="center">
                     <Spinner size="large" />
                   </Stack>
-                ) : searchResults.length > 0 ? (
+                ) : null}
+                {!searching && searchResults.length > 0 ? (
                   <>
                     <SizableText size="$bodyXs" color="$textSubdued" px="$1">
                       {`${searchResults.length} RESULT${searchResults.length !== 1 ? 'S' : ''}`}
@@ -267,7 +274,8 @@ export default function SettingDevBundleVersionList() {
                       </YStack>
                     ))}
                   </>
-                ) : (
+                ) : null}
+                {!searching && searchResults.length === 0 ? (
                   <YStack py="$10" alignItems="center" gap="$2">
                     <Icon
                       name="SearchOutline"
@@ -278,7 +286,7 @@ export default function SettingDevBundleVersionList() {
                       No bundles found
                     </SizableText>
                   </YStack>
-                )}
+                ) : null}
               </YStack>
             ) : (
               <>

--- a/packages/kit/src/views/Setting/pages/DevBundleSwitcher/VersionList.tsx
+++ b/packages/kit/src/views/Setting/pages/DevBundleSwitcher/VersionList.tsx
@@ -7,6 +7,7 @@ import {
   Divider,
   Icon,
   Page,
+  SearchBar,
   SizableText,
   Spinner,
   Stack,
@@ -15,8 +16,15 @@ import {
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import {
+  BundleUpdate,
+} from '@onekeyhq/shared/src/modules3rdParty/auto-update';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalSettingRoutes } from '@onekeyhq/shared/src/routes';
+
+import { BundleItem, normalizeCommitHash } from './BundleList';
+
+import type { IBundleInfo } from './BundleList';
 
 type IVersionInfo = { version: string; bundleCount: number };
 
@@ -74,20 +82,92 @@ function VersionRow({
   );
 }
 
+type ISearchResult = {
+  version: string;
+  bundle: IBundleInfo;
+};
+
 export default function SettingDevBundleVersionList() {
   const navigation = useAppNavigation();
   const [loading, setLoading] = useState(true);
   const [versions, setVersions] = useState<IVersionInfo[]>([]);
+  const [searchText, setSearchText] = useState('');
+  const [searching, setSearching] = useState(false);
+  const [searchResults, setSearchResults] = useState<ISearchResult[]>([]);
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [gpgSkipped, setGpgSkipped] = useState(false);
+  const [skipGpgVerificationAllowed, setSkipGpgVerificationAllowed] =
+    useState(false);
+  const [downloadedSet, setDownloadedSet] = useState<Set<string>>(new Set());
 
   const currentAppVersion = String(platformEnv.version);
+  const currentBundleVersion = String(platformEnv.bundleVersion);
+  const currentCommitHash = normalizeCommitHash(platformEnv.githubSHA);
 
   useEffect(() => {
-    void backgroundApiProxy.serviceAppUpdate
-      .devFetchBundleVersions()
-      .then(setVersions)
-      .finally(() => {
+    void (async () => {
+      try {
+        const [versionData, skipGpg, isSkipAllowed] = await Promise.all([
+          backgroundApiProxy.serviceAppUpdate.devFetchBundleVersions(),
+          backgroundApiProxy.serviceDevSetting.getSkipBundleGPGVerification(),
+          BundleUpdate.isSkipGpgVerificationAllowed().catch(() => false),
+        ]);
+        setVersions(versionData);
+        setGpgSkipped(skipGpg);
+        setSkipGpgVerificationAllowed(Boolean(isSkipAllowed));
+      } finally {
         setLoading(false);
-      });
+      }
+    })();
+  }, []);
+
+  const handleSearch = useCallback((text: string) => {
+    setSearchText(text);
+    const trimmed = text.trim();
+    if (!trimmed) {
+      setSearchResults([]);
+      setSearching(false);
+      return;
+    }
+    setSearching(true);
+    void (async () => {
+      try {
+        const results =
+          await backgroundApiProxy.serviceAppUpdate.devSearchBundleByCommit(
+            trimmed,
+          );
+        setSearchResults(results);
+
+        // Check which bundles are already downloaded
+        const downloaded = new Set<string>();
+        await Promise.all(
+          results.map(async (r) => {
+            try {
+              const exists = await BundleUpdate.isBundleExists(
+                r.version,
+                r.bundle.ciBundleVersion,
+              );
+              if (exists) {
+                downloaded.add(r.bundle.ciBundleVersion);
+              }
+            } catch {
+              // ignore
+            }
+          }),
+        );
+        setDownloadedSet(downloaded);
+      } finally {
+        setSearching(false);
+      }
+    })();
+  }, []);
+
+  const handleDownloadStart = useCallback(() => {
+    setIsDownloading(true);
+  }, []);
+
+  const handleDownloadEnd = useCallback(() => {
+    setIsDownloading(false);
   }, []);
 
   const { currentVersion, otherVersions } = useMemo(() => {
@@ -103,6 +183,8 @@ export default function SettingDevBundleVersionList() {
     [navigation],
   );
 
+  const isSearching = searchText.trim().length > 0;
+
   return (
     <Page scrollEnabled>
       <Page.Header title="Remote Bundles" />
@@ -113,67 +195,160 @@ export default function SettingDevBundleVersionList() {
           </Stack>
         ) : (
           <YStack px="$5" py="$4" gap="$4">
-            {/* Current version - pinned to top */}
-            {currentVersion ? (
-              <YStack gap="$1.5">
-                <SizableText size="$bodyXs" color="$textSubdued" px="$1">
-                  CURRENT VERSION
-                </SizableText>
-                <YStack
-                  bg="$bgSubdued"
-                  borderRadius="$3"
-                  borderWidth={StyleSheet.hairlineWidth}
-                  borderColor="$borderSuccess"
-                  overflow="hidden"
-                >
-                  <VersionRow
-                    item={currentVersion}
-                    isCurrent
-                    onPress={() => handlePress(currentVersion.version)}
-                  />
-                </YStack>
-              </YStack>
-            ) : null}
+            {/* Search bar */}
+            <SearchBar
+              placeholder="Search by commit hash"
+              onSearchTextChange={handleSearch}
+            />
 
-            {/* Other versions */}
-            {otherVersions.length > 0 ? (
+            {/* Search results */}
+            {isSearching ? (
               <YStack gap="$1.5">
-                <SizableText size="$bodyXs" color="$textSubdued" px="$1">
-                  OTHER VERSIONS
-                </SizableText>
-                <YStack
-                  bg="$bgSubdued"
-                  borderRadius="$3"
-                  borderWidth={StyleSheet.hairlineWidth}
-                  borderColor="$neutral3"
-                  overflow="hidden"
-                >
-                  {otherVersions.map((item, index) => (
-                    <YStack key={item.version}>
-                      {index > 0 ? (
-                        <XStack mx="$4">
-                          <Divider />
-                        </XStack>
-                      ) : null}
+                {searching ? (
+                  <Stack py="$10" justifyContent="center" alignItems="center">
+                    <Spinner size="large" />
+                  </Stack>
+                ) : searchResults.length > 0 ? (
+                  <>
+                    <SizableText size="$bodyXs" color="$textSubdued" px="$1">
+                      {`${searchResults.length} RESULT${searchResults.length !== 1 ? 'S' : ''}`}
+                    </SizableText>
+                    {searchResults.map((result) => (
+                      <YStack
+                        key={`${result.version}-${result.bundle.ciBundleVersion}`}
+                        gap="$1"
+                      >
+                        <SizableText
+                          size="$bodyXs"
+                          color="$textSubdued"
+                          px="$1"
+                        >
+                          {`v${result.version}`}
+                        </SizableText>
+                        <YStack
+                          bg="$bgSubdued"
+                          borderRadius="$3"
+                          borderWidth={StyleSheet.hairlineWidth}
+                          borderColor="$neutral3"
+                          overflow="hidden"
+                        >
+                          <BundleItem
+                            bundle={result.bundle}
+                            version={result.version}
+                            isCurrentBundle={(() => {
+                              if (result.version !== currentAppVersion) {
+                                return false;
+                              }
+                              if (skipGpgVerificationAllowed) {
+                                const bundleCommitHash = normalizeCommitHash(
+                                  result.bundle.commitHash,
+                                );
+                                if (bundleCommitHash && currentCommitHash) {
+                                  return bundleCommitHash === currentCommitHash;
+                                }
+                              }
+                              return (
+                                result.bundle.ciBundleVersion ===
+                                currentBundleVersion
+                              );
+                            })()}
+                            alreadyDownloaded={downloadedSet.has(
+                              result.bundle.ciBundleVersion,
+                            )}
+                            isDownloading={isDownloading}
+                            onDownloadStart={handleDownloadStart}
+                            onDownloadEnd={handleDownloadEnd}
+                            gpgSkipped={gpgSkipped}
+                            skipGpgVerificationAllowed={
+                              skipGpgVerificationAllowed
+                            }
+                          />
+                        </YStack>
+                      </YStack>
+                    ))}
+                  </>
+                ) : (
+                  <YStack py="$10" alignItems="center" gap="$2">
+                    <Icon
+                      name="SearchOutline"
+                      size="$10"
+                      color="$iconDisabled"
+                    />
+                    <SizableText color="$textDisabled">
+                      No bundles found
+                    </SizableText>
+                  </YStack>
+                )}
+              </YStack>
+            ) : (
+              <>
+                {/* Current version - pinned to top */}
+                {currentVersion ? (
+                  <YStack gap="$1.5">
+                    <SizableText size="$bodyXs" color="$textSubdued" px="$1">
+                      CURRENT VERSION
+                    </SizableText>
+                    <YStack
+                      bg="$bgSubdued"
+                      borderRadius="$3"
+                      borderWidth={StyleSheet.hairlineWidth}
+                      borderColor="$borderSuccess"
+                      overflow="hidden"
+                    >
                       <VersionRow
-                        item={item}
-                        isCurrent={false}
-                        onPress={() => handlePress(item.version)}
+                        item={currentVersion}
+                        isCurrent
+                        onPress={() => handlePress(currentVersion.version)}
                       />
                     </YStack>
-                  ))}
-                </YStack>
-              </YStack>
-            ) : null}
+                  </YStack>
+                ) : null}
 
-            {versions.length === 0 ? (
-              <YStack py="$10" alignItems="center" gap="$2">
-                <Icon name="InboxOutline" size="$10" color="$iconDisabled" />
-                <SizableText color="$textDisabled">
-                  No versions available
-                </SizableText>
-              </YStack>
-            ) : null}
+                {/* Other versions */}
+                {otherVersions.length > 0 ? (
+                  <YStack gap="$1.5">
+                    <SizableText size="$bodyXs" color="$textSubdued" px="$1">
+                      OTHER VERSIONS
+                    </SizableText>
+                    <YStack
+                      bg="$bgSubdued"
+                      borderRadius="$3"
+                      borderWidth={StyleSheet.hairlineWidth}
+                      borderColor="$neutral3"
+                      overflow="hidden"
+                    >
+                      {otherVersions.map((item, index) => (
+                        <YStack key={item.version}>
+                          {index > 0 ? (
+                            <XStack mx="$4">
+                              <Divider />
+                            </XStack>
+                          ) : null}
+                          <VersionRow
+                            item={item}
+                            isCurrent={false}
+                            onPress={() => handlePress(item.version)}
+                          />
+                        </YStack>
+                      ))}
+                    </YStack>
+                  </YStack>
+                ) : null}
+
+                {versions.length === 0 ? (
+                  <YStack py="$10" alignItems="center" gap="$2">
+                    <Icon
+                      name="InboxOutline"
+                      size="$10"
+                      color="$iconDisabled"
+                    />
+                    <SizableText color="$textDisabled">
+                      No versions available
+                    </SizableText>
+                  </YStack>
+                ) : null}
+              </>
+            )}
           </YStack>
         )}
       </Page.Body>

--- a/packages/kit/src/views/Setting/pages/DevBundleSwitcher/VersionList.tsx
+++ b/packages/kit/src/views/Setting/pages/DevBundleSwitcher/VersionList.tsx
@@ -151,7 +151,7 @@ export default function SettingDevBundleVersionList() {
                 r.bundle.ciBundleVersion,
               );
               if (exists) {
-                downloaded.add(r.bundle.ciBundleVersion);
+                downloaded.add(`${r.version}:${r.bundle.ciBundleVersion}`);
               }
             } catch {
               // ignore
@@ -260,7 +260,7 @@ export default function SettingDevBundleVersionList() {
                               );
                             })()}
                             alreadyDownloaded={downloadedSet.has(
-                              result.bundle.ciBundleVersion,
+                              `${result.version}:${result.bundle.ciBundleVersion}`,
                             )}
                             isDownloading={isDownloading}
                             onDownloadStart={handleDownloadStart}


### PR DESCRIPTION
## Summary
- Add search bar to the Remote Bundles page in developer mode
- Search bundles by commit hash across all versions (prefix match)
- Search results show full bundle items with download/switch actions inline, no need to navigate to version detail page

## Test plan
- [ ] Open developer mode → JS Bundle Manager → Remote Bundles
- [ ] Verify search bar appears at the top
- [ ] Type a partial commit hash (e.g. `4c90c189`) and confirm matching bundle is shown
- [ ] Verify download and switch buttons work directly from search results
- [ ] Clear search and confirm version list is shown again
- [ ] Test on desktop, web, and mobile platforms
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
