### PR TITLE
fix: tune Android TradingView gesture handoff and local debug URL ｜ OK-51881

### DIFF
--- a/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.native.tsx
+++ b/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.native.tsx
@@ -1,5 +1,5 @@
 import type { PropsWithChildren } from 'react';
-import { useCallback, useContext, useMemo } from 'react';
+import { useCallback, useContext, useMemo, useState } from 'react';
 
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
@@ -42,10 +42,15 @@ export function HeaderScrollGestureWrapper({
   const targetScrollY = useSharedValue(0);
   const containerWidth = useSharedValue(0);
   const isGestureEnabled = useSharedValue(true);
+  const [measuredWidth, setMeasuredWidth] = useState(0);
 
   const handleLayout = useCallback(
     (event: LayoutChangeEvent) => {
-      containerWidth.value = event.nativeEvent.layout.width;
+      const layoutWidth = event.nativeEvent.layout.width;
+      containerWidth.value = layoutWidth;
+      setMeasuredWidth((currentWidth) =>
+        currentWidth === layoutWidth ? currentWidth : layoutWidth,
+      );
     },
     [containerWidth],
   );
@@ -67,6 +72,16 @@ export function HeaderScrollGestureWrapper({
       0,
       Math.min(1, excludeRightEdgeRatio),
     );
+    const excludedRightEdgeWidth =
+      safeExcludeRightEdgeRatio > 0 && measuredWidth > 0
+        ? measuredWidth * safeExcludeRightEdgeRatio
+        : 0;
+    const gestureHitSlop =
+      excludedRightEdgeWidth > 0
+        ? {
+            right: -excludedRightEdgeWidth,
+          }
+        : undefined;
     const shouldIgnoreByStartX = (x: number) => {
       'worklet';
 
@@ -78,9 +93,15 @@ export function HeaderScrollGestureWrapper({
       return x >= excludedStartX;
     };
 
-    const verticalPanGesture = Gesture.Pan()
+    let verticalPanGesture = Gesture.Pan()
       .activeOffsetY(panActiveOffsetY)
-      .failOffsetX(panFailOffsetX)
+      .failOffsetX(panFailOffsetX);
+
+    if (gestureHitSlop) {
+      verticalPanGesture = verticalPanGesture.hitSlop(gestureHitSlop);
+    }
+
+    verticalPanGesture = verticalPanGesture
       .cancelsTouchesInView(cancelChildTouches)
       .onStart((e) => {
         'worklet';
@@ -129,9 +150,15 @@ export function HeaderScrollGestureWrapper({
       return Gesture.Simultaneous(Gesture.Native(), verticalPanGesture);
     }
 
-    const horizontalPanGesture = Gesture.Pan()
+    let horizontalPanGesture = Gesture.Pan()
       .activeOffsetX([-10, 10])
-      .failOffsetY([-10, 10])
+      .failOffsetY([-10, 10]);
+
+    if (gestureHitSlop) {
+      horizontalPanGesture = horizontalPanGesture.hitSlop(gestureHitSlop);
+    }
+
+    horizontalPanGesture = horizontalPanGesture
       .cancelsTouchesInView(cancelChildTouches)
       .onStart((e) => {
         'worklet';
@@ -185,6 +212,7 @@ export function HeaderScrollGestureWrapper({
     simultaneousWithNativeGesture,
     cancelChildTouches,
     containerWidth,
+    measuredWidth,
     isGestureEnabled,
   ]);
 

--- a/packages/kit/src/components/TradingView/hooks/useTradingViewUrl.ts
+++ b/packages/kit/src/components/TradingView/hooks/useTradingViewUrl.ts
@@ -24,10 +24,13 @@ export function useTradingViewUrl(options: IUseTradingViewUrlOptions = {}) {
   const systemLocale = useLocaleVariant();
   const theme = useThemeVariant();
   const [devSettings] = useDevSettingsPersistAtom();
+  const localTradingViewUrl = platformEnv.isNativeAndroid
+    ? 'http://10.0.2.2:5173/'
+    : 'http://localhost:5173/';
 
   const baseUrl = useMemo(() => {
     if (devSettings.enabled && devSettings.settings?.useLocalTradingViewUrl) {
-      return 'http://localhost:5173/';
+      return localTradingViewUrl;
     }
 
     if (devSettings.enabled) {
@@ -35,7 +38,11 @@ export function useTradingViewUrl(options: IUseTradingViewUrlOptions = {}) {
     }
 
     return TRADING_VIEW_URL;
-  }, [devSettings.enabled, devSettings.settings?.useLocalTradingViewUrl]);
+  }, [
+    devSettings.enabled,
+    devSettings.settings?.useLocalTradingViewUrl,
+    localTradingViewUrl,
+  ]);
 
   const finalUrl = useMemo(() => {
     const timezone = getTradingViewTimezone(calendars);

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -186,6 +186,16 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
   );
 
   const informationHeader = useMemo(() => {
+    const chartAreaHorizontalSwipeHandler = platformEnv.isNativeAndroid
+      ? undefined
+      : handleHeaderHorizontalSwipe;
+    const chartAreaPanFailOffsetX: [number, number] = platformEnv.isNativeAndroid
+      ? [-12, 12]
+      : [-40, 40];
+    const chartAreaExcludeRightEdgeRatio = platformEnv.isNativeAndroid
+      ? 0.16
+      : 0.1;
+
     return (
       <YStack bg="$bgApp" pointerEvents="box-none">
         <HeaderScrollGestureWrapper
@@ -202,10 +212,10 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
         <Stack position="relative">
           <HeaderScrollGestureWrapper
             panActiveOffsetY={[-4, 4]}
-            panFailOffsetX={[-40, 40]}
-            excludeRightEdgeRatio={0.1}
+            panFailOffsetX={chartAreaPanFailOffsetX}
+            excludeRightEdgeRatio={chartAreaExcludeRightEdgeRatio}
             scrollScale={1}
-            onHorizontalSwipe={handleHeaderHorizontalSwipe}
+            onHorizontalSwipe={chartAreaHorizontalSwipeHandler}
             horizontalSwipeThreshold={24}
             horizontalSwipeVelocityThreshold={900}
             simultaneousWithNativeGesture

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -189,9 +189,8 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
     const chartAreaHorizontalSwipeHandler = platformEnv.isNativeAndroid
       ? undefined
       : handleHeaderHorizontalSwipe;
-    const chartAreaPanFailOffsetX: [number, number] = platformEnv.isNativeAndroid
-      ? [-12, 12]
-      : [-40, 40];
+    const chartAreaPanFailOffsetX: [number, number] =
+      platformEnv.isNativeAndroid ? [-12, 12] : [-40, 40];
     const chartAreaExcludeRightEdgeRatio = platformEnv.isNativeAndroid
       ? 0.16
       : 0.1;

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
@@ -197,6 +197,9 @@ const BaseDevSettingsSection = () => {
   const intl = useIntl();
   const navigation = useAppNavigation();
   const { copyText } = useClipboard();
+  const localTradingViewUrlSubtitle = platformEnv.isNativeAndroid
+    ? 'http://10.0.2.2:5173/'
+    : 'http://localhost:5173/';
 
   const handleDevModeOnChange = useCallback(() => {
     Dialog.show({
@@ -1154,7 +1157,7 @@ const BaseDevSettingsSection = () => {
                 title="使用本地 TradingView URL"
                 subtitle={
                   devSettings.settings?.useLocalTradingViewUrl
-                    ? 'http://localhost:5173/'
+                    ? localTradingViewUrlSubtitle
                     : 'https://tradingview.onekeytest.com/'
                 }
               >


### PR DESCRIPTION
## Summary

This PR adjusts the Android-side TradingView integration in `app-monorepo`.

Changes included:
- reduce `HeaderScrollGestureWrapper` interference with horizontal gestures inside the chart area on Android
- expand the Android chart-area right edge exclusion zone
- disable chart-area horizontal tab swipe handling on Android so horizontal pan can be handed to TradingView itself
- support Android emulator local TradingView debugging by switching the local URL from `localhost:5173` to `10.0.2.2:5173`
- update the Dev Settings subtitle so the displayed local TradingView URL matches Android emulator behavior

## Why

There were two separate issues on Android:
1. chart-area gestures were still competing with the outer RN wrapper
2. Android emulator could not actually load the local TradingView dev server because `localhost` points to the emulator itself, not the host machine

This PR handles the app-side handoff and local debugging path.

## Scope

Files changed:
- `packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx`
- `packages/kit/src/components/TradingView/hooks/useTradingViewUrl.ts`
- `packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx`

## Testing

Tested locally with:
- eslint on changed files

Manual verification target:
- Android chart area horizontal pan should be less likely to be intercepted by tab switching
- Android emulator should load local TradingView from `http://10.0.2.2:5173/` when `useLocalTradingViewUrl` is enabled

## Notes

- iOS behavior is unchanged
- unrelated `Podfile.lock` changes are intentionally not included in this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
