### PR TITLE
fix: defer jsBundleRollbackToBuiltin to next cold start via pending task

### DIFF
--- a/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
@@ -265,6 +265,38 @@ export function resetAboveMainRoute() {
   );
 }
 
+/**
+ * Atomically remove only the ScanQrCodeModal route from the navigation state
+ * via CommonActions.reset, preserving all other routes (e.g. onboarding).
+ * This avoids the goBack() animated dismiss that causes RNSScreenStack
+ * window=NIL and blocks Fabric commits on the underlying page.
+ */
+export function resetScanModalRoute() {
+  const state = rootNavigationRef.current?.getRootState();
+  if (!state) {
+    return;
+  }
+  const filteredRoutes = state.routes.filter((route) => {
+    if (route.name !== ERootRoutes.Modal) {
+      return true;
+    }
+    const screenName =
+      (route.params as { screen?: string })?.screen ||
+      route.state?.routes?.[route.state?.index || 0]?.name;
+    return screenName !== EModalRoutes.ScanQrCodeModal;
+  });
+  if (filteredRoutes.length === state.routes.length) {
+    return;
+  }
+  rootNavigationRef.current?.dispatch(
+    CommonActions.reset({
+      ...state,
+      routes: filteredRoutes,
+      index: filteredRoutes.length - 1,
+    }),
+  );
+}
+
 export const popToMainRoute = async () => {
   resetAboveMainRoute();
   await timerUtils.wait(100);

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -366,6 +366,7 @@ class ServiceAppUpdate extends ServiceBase {
         summary: normalizeOptionalString(data.summary),
         jsBundleVersion: normalizeOptionalString(data.jsBundleVersion),
         fileSize: normalizeOptionalNumber(data.fileSize),
+        jsBundleCount: normalizeOptionalNumber(data.jsBundleCount),
         jsBundle: data.jsBundle
           ? {
               downloadUrl: normalizeOptionalString(data.jsBundle.downloadUrl),

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -139,8 +139,7 @@ class ServiceAppUpdate extends ServiceBase {
     if (
       existingTask &&
       (existingTask.status === EPendingInstallTaskStatus.running ||
-        existingTask.status ===
-          EPendingInstallTaskStatus.appliedWaitingVerify)
+        existingTask.status === EPendingInstallTaskStatus.appliedWaitingVerify)
     ) {
       defaultLogger.app.appUpdate.log(
         `fetchAppUpdateInfo: ${reason} rollback skipped — existing task in progress`,

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -1101,7 +1101,7 @@ class ServiceAppUpdate extends ServiceBase {
 
       // Rollback to builtin: no download needed — schedule a pending task
       // with targetBundleVersion="0" so the reset happens on next cold start,
-      // consistent with jsBundleRollback behaviour.
+      // consistent with jsBundleRollback behavior.
       //
       // On cold start, executeBundleSwitchTask will:
       //   1. isBundleExists("X.Y.Z", "0") → false

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -7,6 +7,9 @@ import type {
 } from '@onekeyhq/shared/src/appUpdate';
 import {
   EAppUpdateStatus,
+  EPendingInstallTaskAction,
+  EPendingInstallTaskStatus,
+  EPendingInstallTaskType,
   EUpdateStrategy,
   isFirstLaunchAfterUpdated,
   resolveUpdateDecision,
@@ -34,7 +37,11 @@ import { appUpdatePersistAtom } from '../states/jotai/atoms';
 import { devSettingsPersistAtom } from '../states/jotai/atoms/devSettings';
 
 import ServiceBase from './ServiceBase';
-import { PLACEHOLDER_SIGNATURE } from './servicePendingInstallTask';
+import {
+  PLACEHOLDER_SIGNATURE,
+  getPendingInstallTask,
+  setPendingInstallTask,
+} from './servicePendingInstallTask';
 
 let syncTimerId: ReturnType<typeof setTimeout>;
 let downloadTimeoutId: ReturnType<typeof setTimeout>;
@@ -111,6 +118,60 @@ class ServiceAppUpdate extends ServiceBase {
       retryCount: task?.retryCount ?? null,
       nextRetryAt: task?.nextRetryAt ?? null,
     };
+  }
+
+  // Schedule a pending task with targetBundleVersion="0" to rollback to
+  // the builtin bundle on next cold start.  executeBundleSwitchTask will
+  // detect the missing bundle and fall into the existing builtin fallback
+  // path: clearPendingInstallTask → resetToBuiltInBundle → switchBundle.
+  // Returns true if the task was scheduled, false if skipped.
+  private async scheduleRollbackToBuiltinTask({
+    reason,
+    requestSeq,
+    appVersion,
+  }: {
+    reason: string;
+    requestSeq: number;
+    appVersion: string;
+  }): Promise<boolean> {
+    // Don't overwrite in-progress tasks (running / appliedWaitingVerify)
+    const existingTask = await getPendingInstallTask();
+    if (
+      existingTask &&
+      (existingTask.status === EPendingInstallTaskStatus.running ||
+        existingTask.status ===
+          EPendingInstallTaskStatus.appliedWaitingVerify)
+    ) {
+      defaultLogger.app.appUpdate.log(
+        `fetchAppUpdateInfo: ${reason} rollback skipped — existing task in progress`,
+      );
+      return false;
+    }
+
+    defaultLogger.app.appUpdate.log(
+      `fetchAppUpdateInfo: ${reason} — scheduling rollback to builtin for next cold start`,
+    );
+    const now = Date.now();
+    await setPendingInstallTask({
+      taskId: `jsbundle:${appVersion}:builtin`,
+      revision: requestSeq,
+      action: EPendingInstallTaskAction.switchBundle,
+      type: EPendingInstallTaskType.jsBundleSwitch,
+      targetAppVersion: appVersion,
+      targetBundleVersion: '0',
+      scheduledEnvAppVersion: platformEnv.version || '',
+      scheduledEnvBundleVersion: String(platformEnv.bundleVersion || ''),
+      createdAt: now,
+      expiresAt: now + timerUtils.getTimeDurationMs({ day: 7 }),
+      retryCount: 0,
+      status: EPendingInstallTaskStatus.pending,
+      payload: {
+        appVersion,
+        bundleVersion: '0',
+        signature: PLACEHOLDER_SIGNATURE,
+      },
+    });
+    return true;
   }
 
   private getTargetKey(taskOrTarget: {
@@ -966,6 +1027,47 @@ class ServiceAppUpdate extends ServiceBase {
       },
       releaseInfo ? 'info' : 'warn',
     );
+    // jsBundleCount === 0 means the server has no hot-update records for
+    // this version — admin removed them.  If the client has an active
+    // custom bundle, schedule a rollback to builtin on next cold start.
+    // jsBundleCount > 0 means hot-update records exist but the client
+    // already has the same bundleVersion (filtered by server's $ne query)
+    // — no action needed, fall through to normal flow.
+    if (
+      typeof releaseInfo?.jsBundleCount === 'number' &&
+      releaseInfo.jsBundleCount === 0
+    ) {
+      let hasActiveCustomBundle = false;
+      try {
+        const jsBundlePath = await BundleUpdate.getJsBundlePath();
+        hasActiveCustomBundle = !!jsBundlePath;
+      } catch {
+        // ignore — default to false
+      }
+
+      if (hasActiveCustomBundle) {
+        defaultLogger.app.appUpdate.appUpdateDecisionResolved({
+          traceId,
+          requestSeq,
+          decision: 'jsBundleRollbackToBuiltin',
+          reason: 'jsBundleCount_is_zero',
+          allowRollback: true,
+          currentAppVersion: platformEnv.version || '',
+          currentBundleVersion: String(platformEnv.bundleVersion || ''),
+          targetAppVersion: null,
+          targetBundleVersion: null,
+          ...this.buildTaskLogFields(null),
+        });
+        await this.scheduleRollbackToBuiltinTask({
+          reason: 'jsBundleCount_is_zero',
+          requestSeq,
+          appVersion: platformEnv.version || '',
+        });
+        const latest = await appUpdatePersistAtom.get();
+        return latest;
+      }
+    }
+
     if (releaseInfo?.version || releaseInfo?.jsBundleVersion) {
       let hasActiveCustomBundle = false;
       try {
@@ -998,45 +1100,21 @@ class ServiceAppUpdate extends ServiceBase {
         decision.isValid ? 'info' : 'warn',
       );
 
-      // Rollback to builtin: no download needed, just clear bundle data and
-      // relaunch.  The app will load from its embedded resources on restart.
+      // Rollback to builtin: no download needed — schedule a pending task
+      // with targetBundleVersion="0" so the reset happens on next cold start,
+      // consistent with jsBundleRollback behaviour.
+      //
+      // On cold start, executeBundleSwitchTask will:
+      //   1. isBundleExists("X.Y.Z", "0") → false
+      //   2. targetBundle(0) < currentBundle → true (rollback)
+      //   3. Fall into the existing builtin fallback path:
+      //      clearPendingInstallTask → resetToBuiltInBundle → switchBundle({empty})
       if (decision.decision === 'jsBundleRollbackToBuiltin') {
-        defaultLogger.app.appUpdate.log(
-          'fetchAppUpdateInfo: jsBundleRollbackToBuiltin — resetting to builtin bundle',
-        );
-        try {
-          // Clear stored bundle data so next launch uses builtin resources.
-          await BundleUpdate.resetToBuiltInBundle();
-          // Trigger app relaunch (switchBundle with empty values will destroy
-          // the window, relaunch, and exit — getBundleIndexHtmlPath returns
-          // undefined for empty appVersion/bundleVersion).
-          await BundleUpdate.switchBundle({
-            appVersion: '',
-            bundleVersion: '',
-            signature: '',
-          });
-        } catch (error) {
-          defaultLogger.app.appUpdate.log(
-            `rollbackToBuiltin failed: ${
-              (error as Error)?.message || 'unknown'
-            }`,
-          );
-          // Transition to failed state so startFailedRecoveryTimer can retry.
-          // Persist releaseInfo + updateAt so the atom is not stale when the
-          // recovery timer fires and isNeedSyncAppUpdateInfo re-evaluates.
-          // Clear latestVersion so isFirstLaunchAfterUpdated's fallback branch
-          // does not treat this failure as a successful first launch (which
-          // would short-circuit the recovery timer by resetting to done).
-          await appUpdatePersistAtom.set((prev) => ({
-            ...prev,
-            ...releaseInfo,
-            latestVersion: undefined,
-            updateAt: Date.now(),
-            status: EAppUpdateStatus.failed,
-            errorText: undefined,
-          }));
-          this.startFailedRecoveryTimer();
-        }
+        await this.scheduleRollbackToBuiltinTask({
+          reason: 'jsBundleRollbackToBuiltin',
+          requestSeq,
+          appVersion: releaseInfo.version || platformEnv.version || '',
+        });
         const latest = await appUpdatePersistAtom.get();
         return latest;
       }

--- a/packages/kit-bg/src/services/servicePendingInstallTask.ts
+++ b/packages/kit-bg/src/services/servicePendingInstallTask.ts
@@ -557,8 +557,10 @@ class ServicePendingInstallTask {
       stage,
     });
 
-    // jsBundleRollbackToBuiltin is handled by fetchAppUpdateInfo directly
-    // (no download needed — just reset and relaunch).
+    // jsBundleRollbackToBuiltin is handled by fetchAppUpdateInfo which
+    // creates a pending task with targetBundleVersion="0".  On next cold
+    // start, executeBundleSwitchTask detects the missing bundle and falls
+    // back to builtin via resetToBuiltInBundle + switchBundle({empty}).
 
     if (
       decision.decision !== 'appShellUpdate' &&

--- a/packages/kit/src/views/ScanQrCode/hooks/useParseQRCode.tsx
+++ b/packages/kit/src/views/ScanQrCode/hooks/useParseQRCode.tsx
@@ -11,6 +11,7 @@ import {
   popActionCenterPages,
   popScanModalPages,
   resetAboveMainRoute,
+  resetScanModalRoute,
   resetToRoute,
   useClipboard,
   waitForScanModalClosed,
@@ -174,11 +175,13 @@ const useParseQRCode = () => {
             resetAboveMainRoute();
             await timerUtils.wait(100);
           } else {
-            // Preserve caller route for manual scan flows (e.g. onboarding
-            // import): only dismiss scan/action-center overlays.
-            await popScanModalPages();
+            // Atomically remove only the ScanQrCodeModal route, preserving
+            // caller routes (e.g. onboarding). This avoids goBack() animated
+            // dismiss which causes RNSScreenStack window=NIL and blocks
+            // Fabric commits on the underlying page.
+            resetScanModalRoute();
             await popActionCenterPages();
-            await waitForScanModalClosed();
+            await timerUtils.wait(100);
           }
         }
       };

--- a/packages/kit/src/views/ScanQrCode/hooks/useParseQRCode.tsx
+++ b/packages/kit/src/views/ScanQrCode/hooks/useParseQRCode.tsx
@@ -9,12 +9,10 @@ import {
   Toast,
   ToastContent,
   popActionCenterPages,
-  popScanModalPages,
   resetAboveMainRoute,
   resetScanModalRoute,
   resetToRoute,
   useClipboard,
-  waitForScanModalClosed,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';

--- a/packages/kit/src/views/Setting/pages/DevBundleManagerModal/index.tsx
+++ b/packages/kit/src/views/Setting/pages/DevBundleManagerModal/index.tsx
@@ -245,9 +245,7 @@ async function enableIgnoreServerBundleUpdate() {
     'ignoreServerBundleUpdate',
     true,
   );
-  // Clear both update atom and pending install task so any queued
-  // rollback/upgrade is fully discarded (they are stored separately).
-  await backgroundApiProxy.serviceAppUpdate.reset();
+  // await backgroundApiProxy.serviceAppUpdate.reset();
   await backgroundApiProxy.servicePendingInstallTask.clearPendingInstallTask();
 }
 
@@ -267,9 +265,7 @@ function IgnoreServerBundleUpdateToggle() {
       value,
     );
     if (value) {
-      // Clear both update atom and pending install task so any queued
-      // rollback/upgrade is fully discarded.
-      await backgroundApiProxy.serviceAppUpdate.reset();
+      // await backgroundApiProxy.serviceAppUpdate.reset();
       await backgroundApiProxy.servicePendingInstallTask.clearPendingInstallTask();
     }
   }, []);

--- a/packages/kit/src/views/Setting/pages/DevBundleSwitcher/BundleList.tsx
+++ b/packages/kit/src/views/Setting/pages/DevBundleSwitcher/BundleList.tsx
@@ -175,7 +175,7 @@ export function BundleItem({
       'ignoreServerBundleUpdate',
       true,
     );
-    await backgroundApiProxy.serviceAppUpdate.reset();
+    // await backgroundApiProxy.serviceAppUpdate.reset();
     await backgroundApiProxy.servicePendingInstallTask.clearPendingInstallTask();
     defaultLogger.app.jsBundleDev.installBundle({
       version,

--- a/packages/kit/src/views/Setting/pages/DevBundleSwitcher/LocalBundleList.tsx
+++ b/packages/kit/src/views/Setting/pages/DevBundleSwitcher/LocalBundleList.tsx
@@ -164,7 +164,7 @@ export default function SettingDevLocalBundleList() {
         'ignoreServerBundleUpdate',
         true,
       );
-      await backgroundApiProxy.serviceAppUpdate.reset();
+      // await backgroundApiProxy.serviceAppUpdate.reset();
       await backgroundApiProxy.servicePendingInstallTask.clearPendingInstallTask();
       await BundleUpdate.switchBundle({
         ...bundle,

--- a/packages/shared/src/appUpdate/type.ts
+++ b/packages/shared/src/appUpdate/type.ts
@@ -139,6 +139,11 @@ export interface IBasicAppUpdateInfo {
 
 export interface IResponseAppUpdateInfo extends IBasicAppUpdateInfo {
   version?: string;
+  // Number of hot-update (jsBundle) records for this version in the server DB.
+  // When 0, the server has no bundle configured — client should rollback to
+  // builtin if it has an active custom bundle.
+  // When > 0 and jsBundleVersion is absent, the client is already up to date.
+  jsBundleCount?: number;
 }
 
 export interface IAppUpdateInfo extends IBasicAppUpdateInfo {


### PR DESCRIPTION
## Summary
- `jsBundleRollbackToBuiltin` no longer directly calls `resetToBuiltInBundle + switchBundle` (which caused immediate restart). Instead creates a pending task with `targetBundleVersion="0"`, executed on next cold start via existing builtin fallback path in `executeBundleSwitchTask`
- Added `jsBundleCount` field to `IResponseAppUpdateInfo`. When server returns `jsBundleCount === 0` in the `else` branch (no version/jsBundleVersion), client schedules rollback to builtin. When `jsBundleCount > 0`, client is already up to date — no action
- Also checks `jsBundleCount` in the `jsBundleRollbackToBuiltin` handler for the case when server returns `version` but no `jsBundleVersion` (fullUpdate doc exists)

## Related
- Server PR: https://github.com/OneKeyHQ/server-service-utility/pull/410

## Test plan
- [ ] Verify normal upgrade flow still works (server returns `jsBundleVersion`)
- [ ] Verify same-version scenario: server returns `{jsBundleCount: N}` where N > 0, client stays on current bundle
- [ ] Delete hot-update record from server DB, verify client receives `jsBundleCount: 0` and rolls back to builtin on next cold start
- [ ] Verify no immediate restart — rollback happens on cold start only
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
