### PR TITLE
feat(ci): support building bundles from PR number input

### DIFF
--- a/.github/workflows/release-app-bundles.yml
+++ b/.github/workflows/release-app-bundles.yml
@@ -1,4 +1,5 @@
 name: release-app-bundles
+run-name: ${{ inputs.pr_number && format('Bundle PR #{0}', inputs.pr_number) || format('Bundle {0}', github.ref_name) }}
 
 on:
   workflow_dispatch:
@@ -89,6 +90,7 @@ jobs:
       build_source: ${{ needs.prepare-params.outputs.build_source }}
       branch: ${{ needs.prepare-params.outputs.branch }}
       commit: ${{ needs.prepare-params.outputs.commit }}
+      checkout_ref: ${{ needs.prepare-params.outputs.commit }}
     secrets: inherit
 
   native-bundle:
@@ -100,4 +102,5 @@ jobs:
       build_source: ${{ needs.prepare-params.outputs.build_source }}
       branch: ${{ needs.prepare-params.outputs.branch }}
       commit: ${{ needs.prepare-params.outputs.commit }}
+      checkout_ref: ${{ needs.prepare-params.outputs.commit }}
     secrets: inherit

--- a/.github/workflows/release-desktop-bundle.yml
+++ b/.github/workflows/release-desktop-bundle.yml
@@ -25,6 +25,9 @@ on:
       commit:
         type: string
         required: false
+      checkout_ref:
+        type: string
+        required: false
 
 env:
   NODE_ENV: production
@@ -47,6 +50,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
+          ref: ${{ inputs.checkout_ref || '' }}
 
       - name: Run Shared Env Setup
         uses: ./.github/actions/shared-env

--- a/.github/workflows/release-native-bundle.yml
+++ b/.github/workflows/release-native-bundle.yml
@@ -25,6 +25,9 @@ on:
       commit:
         type: string
         required: false
+      checkout_ref:
+        type: string
+        required: false
 
 env:
   NODE_ENV: production
@@ -47,6 +50,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
+          ref: ${{ inputs.checkout_ref || '' }}
 
       - name: Run Shared Env Setup
         uses: ./.github/actions/shared-env


### PR DESCRIPTION
## Summary
- Add optional `pr_number` input to `release-app-bundles` workflow for building bundles directly from external contributor PRs
- Fix sub-workflows (`release-desktop-bundle`, `release-native-bundle`) to checkout the correct ref via `checkout_ref` parameter — previously they always checked out the default branch, ignoring PR code
- Add dynamic `run-name` so GitHub UI shows `Bundle PR #10734` instead of the misleading `x` branch label

## Test plan
- [ ] Trigger `release-app-bundles` without `pr_number` — should behave identically to before
- [ ] Trigger with a valid PR number — verify sub-workflows checkout the PR merge ref and built bundle contains PR changes
- [ ] Confirm GitHub Actions UI displays `Bundle PR #<number>` for PR builds and `Bundle <branch>` for branch builds
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
