### PR TITLE
fix: resolve nightly ESLint errors

### DIFF
--- a/apps/desktop/app/app.ts
+++ b/apps/desktop/app/app.ts
@@ -52,11 +52,12 @@ import {
 import { ipcMessageKeys } from './config';
 import { ElectronTranslations, i18nText, initLocale } from './i18n';
 import { scheduleCrashDumpCleanup } from './libs/crashDumpCleanup';
-import { registerShortcuts, unregisterShortcuts } from './libs/shortcuts';
-import * as store from './libs/store';
 // Side-effect import: registers synchronous IPC handler for renderer MMKV access
 import './libs/react-native-mmkv-desktop-main';
+import { registerShortcuts, unregisterShortcuts } from './libs/shortcuts';
+import * as store from './libs/store';
 import { getBackgroundColor } from './libs/utils';
+import './logger';
 import initProcess from './process';
 import { createRecoveryWindow } from './recoveryWindow';
 import {
@@ -67,9 +68,6 @@ import {
 import { initSentry } from './sentry';
 import { startServices } from './service';
 import { setMainWindowForOAuthServer } from './service/oauthLocalServer/oauthLocalServer';
-
-// Logger initialization (file rotation, sanitization, rate limiting)
-import './logger';
 
 initSentry();
 

--- a/apps/desktop/app/recoveryWindow.ts
+++ b/apps/desktop/app/recoveryWindow.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import path from 'path';
-
 import { fileURLToPath, format as formatUrl } from 'url';
 
 import { BrowserWindow, app, ipcMain, session } from 'electron';

--- a/packages/components/src/forms/Input/index.tsx
+++ b/packages/components/src/forms/Input/index.tsx
@@ -415,8 +415,8 @@ function BaseInput(
       inputRef.current?.measure(callback),
     // NOTE: setNativeProps is deprecated in Fabric and may be removed in
     // future React Native versions.
-    setNativeProps: (props: Record<string, unknown>) =>
-      inputRef.current?.setNativeProps?.(props),
+    setNativeProps: (nativeProps: Record<string, unknown>) =>
+      inputRef.current?.setNativeProps?.(nativeProps),
   }));
 
   const selectionColor = useSelectionColor();

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
@@ -479,7 +479,7 @@ export function DesktopLeftSideBar({
   }, []);
 
   const { visibleRoutes, overflowRoutes, deviceRoute } = useMemo(() => {
-    let deviceRoute: (typeof routes)[0] | undefined;
+    let currentDeviceRoute: (typeof routes)[0] | undefined;
     const validRoutes = routes.filter((route) => {
       const { options } = descriptors[route.key] as {
         options: {
@@ -491,7 +491,7 @@ export function DesktopLeftSideBar({
         return false;
       }
       if (route.name === ETabRoutes.DeviceManagement) {
-        deviceRoute = route;
+        currentDeviceRoute = route;
         return false;
       }
       if (isShowWebTabBar && route.name === extraConfig?.name) {
@@ -504,14 +504,14 @@ export function DesktopLeftSideBar({
       return {
         visibleRoutes: validRoutes,
         overflowRoutes: [] as typeof validRoutes,
-        deviceRoute,
+        deviceRoute: currentDeviceRoute,
       };
     }
     const visibleCount = Math.max(0, maxVisibleCount - 1);
     return {
       visibleRoutes: validRoutes.slice(0, visibleCount),
       overflowRoutes: validRoutes.slice(visibleCount),
-      deviceRoute,
+      deviceRoute: currentDeviceRoute,
     };
   }, [
     routes,

--- a/packages/components/src/primitives/ScrollGuard/index.tsx
+++ b/packages/components/src/primitives/ScrollGuard/index.tsx
@@ -2,15 +2,16 @@ import type { PropsWithChildren } from 'react';
 
 import type { ViewStyle } from 'react-native';
 
-export enum ScrollGuardDirection {
+export enum EScrollGuardDirection {
   HORIZONTAL = 'horizontal',
   VERTICAL = 'vertical',
   BOTH = 'both',
 }
+export { EScrollGuardDirection as ScrollGuardDirection };
 
 export interface IScrollGuardProps {
   style?: ViewStyle;
-  direction?: ScrollGuardDirection;
+  direction?: EScrollGuardDirection;
 }
 
 export function ScrollGuard({

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -982,7 +982,7 @@ class ServiceAppUpdate extends ServiceBase {
         defaultLogger.app.appUpdate.log(
           'fetchAppUpdateInfo: skipped — ignoreServerBundleUpdate is enabled',
         );
-        return appUpdatePersistAtom.get();
+        return await appUpdatePersistAtom.get();
       }
     } catch {
       // ignore — proceed with normal flow

--- a/packages/kit/src/components/AccountSelector/hooks/useCreateQrWallet.tsx
+++ b/packages/kit/src/components/AccountSelector/hooks/useCreateQrWallet.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { InvalidSchemeError } from '@ngraveio/bc-ur/dist/errors';
 import { useIntl } from 'react-intl';
 
+import { resetToRoute } from '@onekeyhq/components';
 import type {
   IDBDevice,
   IDBWallet,
@@ -13,7 +14,6 @@ import type {
 } from '@onekeyhq/kit-bg/src/services/ServiceScanQRCode/utils/parseQRCode/type';
 import type { AirGapUR, IAirGapUrJson } from '@onekeyhq/qr-wallet-sdk';
 import { airGapUrUtils } from '@onekeyhq/qr-wallet-sdk';
-import { resetToRoute } from '@onekeyhq/components';
 import {
   OneKeyErrorAirGapDeviceMismatch,
   OneKeyErrorAirGapWalletMismatch,

--- a/packages/kit/src/components/KeylessWallet/useKeylessWallet.tsx
+++ b/packages/kit/src/components/KeylessWallet/useKeylessWallet.tsx
@@ -1237,7 +1237,7 @@ export function useVerifyKeylessPinChecking() {
           if (!selectedAccount?.walletId) {
             return undefined;
           }
-          return backgroundApiProxy.serviceAccount.getWallet({
+          return await backgroundApiProxy.serviceAccount.getWallet({
             walletId: selectedAccount.walletId,
           });
         } catch {

--- a/packages/kit/src/provider/Bootstrap.tsx
+++ b/packages/kit/src/provider/Bootstrap.tsx
@@ -42,10 +42,10 @@ import {
   EPerpPageEnterSource,
   setPerpPageEnterSource,
 } from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
+import BootRecovery from '@onekeyhq/shared/src/modules/BootRecovery';
 import { electronUpdateListeners } from '@onekeyhq/shared/src/modules3rdParty/auto-update/electronUpdateListeners';
 import { initIntercom } from '@onekeyhq/shared/src/modules3rdParty/intercom';
 import performance from '@onekeyhq/shared/src/performance';
-import BootRecovery from '@onekeyhq/shared/src/modules/BootRecovery';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   EDiscoveryModalRoutes,

--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -14,8 +14,8 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { appEventBus } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { EAppEventBusNames } from '@onekeyhq/shared/src/eventBus/appEventBusNames';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   type ETabEarnRoutes,
   ETabRoutes,

--- a/packages/kit/src/views/Market/MarketDetailV2/MarketDetailV2.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/MarketDetailV2.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useLayoutEffect } from 'react';
 
 import { useFocusEffect } from '@react-navigation/native';
+
 import type { IPageScreenProps } from '@onekeyhq/components';
 import {
   Page,

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenListBase.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenListBase.tsx
@@ -479,7 +479,7 @@ function MarketTokenListBase({
                     }
               }
               stickyHeader
-              showHeader={showTableHeader && !useDesktopPortal}
+              showHeader={showTableHeader ? !useDesktopPortal : null}
               scrollEnabled={!webTabIntegrated}
               draggable={draggable}
               tabIntegrated={tabIntegrated}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenListBase.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenListBase.tsx
@@ -479,7 +479,7 @@ function MarketTokenListBase({
                     }
               }
               stickyHeader
-              showHeader={showTableHeader ? !useDesktopPortal : null}
+              showHeader={showTableHeader ? !useDesktopPortal : false}
               scrollEnabled={!webTabIntegrated}
               draggable={draggable}
               tabIntegrated={tabIntegrated}

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
@@ -307,7 +307,7 @@ function MobileLayoutComponent({
         initialTabName={initialTabName}
         onTabChange={onTabChangeHandler}
         useNativeHeaderAnimation={
-          platformEnv.isNativeAndroid ? !nestedPager : null
+          platformEnv.isNativeAndroid ? !nestedPager : false
         }
         pagerProps={
           nestedPager ? ({ nestedScrollEnabled: true } as any) : undefined

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
@@ -306,7 +306,9 @@ function MobileLayoutComponent({
         renderTabBar={renderTabBar}
         initialTabName={initialTabName}
         onTabChange={onTabChangeHandler}
-        useNativeHeaderAnimation={platformEnv.isNativeAndroid && !nestedPager}
+        useNativeHeaderAnimation={
+          platformEnv.isNativeAndroid ? !nestedPager : null
+        }
         pagerProps={
           nestedPager ? ({ nestedScrollEnabled: true } as any) : undefined
         }

--- a/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
@@ -8,7 +8,6 @@ import { StyleSheet } from 'react-native';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 
 import type { IInputRef, ITextAreaInputProps } from '@onekeyhq/components';
-import type { IKeyOfIcons } from '@onekeyhq/components/src/primitives';
 import {
   Button,
   HeightTransition,
@@ -26,6 +25,7 @@ import {
   useReanimatedKeyboardAnimation,
   useSafeAreaInsets,
 } from '@onekeyhq/components';
+import type { IKeyOfIcons } from '@onekeyhq/components/src/primitives';
 import type { IQRCodeHandlerParseOutsideOptions } from '@onekeyhq/kit-bg/src/services/ServiceScanQRCode/utils/parseQRCode/type';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';

--- a/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
+++ b/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
@@ -30,13 +30,13 @@ import {
 
 import { Token } from '../../../components/Token';
 import useAppNavigation from '../../../hooks/useAppNavigation';
-import { FavoriteButton } from '../components/TokenSelector/PerpTokenSelectorRow';
 import { useMobileTabTouchScrollBridge } from '../../../hooks/useMobileTabTouchScrollBridge';
 import { useThemeVariant } from '../../../hooks/useThemeVariant';
 import { PerpCandles } from '../components/PerpCandles';
 import PerpMarketFooter from '../components/PerpMarketFooter';
 import { PerpOrderBook } from '../components/PerpOrderBook';
 import { MobilePerpMarketHeader } from '../components/TickerBar/MobilePerpMarketHeader';
+import { FavoriteButton } from '../components/TokenSelector/PerpTokenSelectorRow';
 import { PerpsAccountSelectorProviderMirror } from '../PerpsAccountSelectorProviderMirror';
 import { PerpsProviderMirror } from '../PerpsProviderMirror';
 

--- a/packages/kit/src/views/Setting/pages/DevBundleManagerModal/index.tsx
+++ b/packages/kit/src/views/Setting/pages/DevBundleManagerModal/index.tsx
@@ -17,8 +17,8 @@ import {
   XStack,
   YStack,
 } from '@onekeyhq/components';
-import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import SkipGPGVerificationToggle from '@onekeyhq/kit/src/views/Setting/pages/DevAppUpdateModalSettingModal/SkipGPGVerificationToggle';
 import { encodeBundleVersionForDisplay } from '@onekeyhq/shared/src/appUpdate';
 import type { IJSBundle } from '@onekeyhq/shared/src/modules3rdParty/auto-update';

--- a/packages/shared/src/appUpdate/index.ts
+++ b/packages/shared/src/appUpdate/index.ts
@@ -242,6 +242,13 @@ export const displayFullVersion = (
   return parts.join('');
 };
 
+export function isLastUpdateJsBundle(): boolean {
+  const data = syncStorage.getObject<IWhatsNewShownData>(
+    EAppSyncStorageKeys.onekey_whats_new_shown,
+  );
+  return data?.isJsBundleUpdate === true;
+}
+
 export const displayWhatsNewVersion = () =>
   displayFullVersion(
     APP_VERSION,
@@ -308,13 +315,6 @@ export const markWhatsNewShown = (isJsBundleUpdate?: boolean): void => {
     bundleVersions: versions,
     isJsBundleUpdate,
   });
-};
-
-export const isLastUpdateJsBundle = (): boolean => {
-  const data = syncStorage.getObject<IWhatsNewShownData>(
-    EAppSyncStorageKeys.onekey_whats_new_shown,
-  );
-  return data?.isJsBundleUpdate === true;
 };
 
 export const isFirstLaunchAfterUpdated = (appUpdateInfo: IAppUpdateInfo) => {

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -33,6 +33,7 @@ import type {
   INotificationViewDialogPayload,
 } from '../../types/notification';
 import type { IPrimeTransferData } from '../../types/prime/primeTransferTypes';
+import type { IRookieShareData } from '../../types/rookieGuide';
 import type {
   ESwapCrossChainStatus,
   ESwapTxHistoryStatus,
@@ -48,7 +49,6 @@ import type { IOneKeyError } from '../errors/types/errorTypes';
 import type { EModalRoutes, ETabRoutes } from '../routes';
 import type { IWalletConnectSession } from '../walletConnect/types';
 import type { FuseResult } from 'fuse.js';
-import type { IRookieShareData } from '../../types/rookieGuide';
 
 // Supported hardware error types for dialog display
 export const HARDWARE_ERROR_DIALOG_TYPES = {

--- a/packages/shared/src/logger/logger.ts
+++ b/packages/shared/src/logger/logger.ts
@@ -21,6 +21,7 @@ import { PerpScope } from './scopes/perp';
 import { PrimeScope } from './scopes/prime';
 import { ReferralScope } from './scopes/referral';
 import { RewardScope } from './scopes/reward';
+import { RookieGuideScope } from './scopes/rookieGuide';
 import { ScanQrCodeScope } from './scopes/scanQrCode';
 import { SettingScope } from './scopes/setting';
 import { SignatureRecordScope } from './scopes/signatureRecord';
@@ -32,7 +33,6 @@ import { UIScope } from './scopes/ui';
 import { UniversalSearchScope } from './scopes/universalSearch';
 import { UpdateScope } from './scopes/update';
 import { WalletScope } from './scopes/wallet';
-import { RookieGuideScope } from './scopes/rookieGuide';
 
 export class DefaultLogger {
   account = new AccountScope();

--- a/packages/shared/src/logger/scopes/setting/scenes/device.ts
+++ b/packages/shared/src/logger/scopes/setting/scenes/device.ts
@@ -1,11 +1,10 @@
-import type { EHardwareTransportType } from '@onekeyhq/shared/types';
-
 import { encodeBundleVersionForDisplay } from '@onekeyhq/shared/src/appUpdate';
-import { BundleUpdate } from '@onekeyhq/shared/src/modules3rdParty/auto-update';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { BaseScene } from '@onekeyhq/shared/src/logger/base/baseScene';
 import { LogToLocal } from '@onekeyhq/shared/src/logger/base/decorators';
 import utils from '@onekeyhq/shared/src/logger/utils';
+import { BundleUpdate } from '@onekeyhq/shared/src/modules3rdParty/auto-update';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import type { EHardwareTransportType } from '@onekeyhq/shared/types';
 
 export class DeviceScene extends BaseScene {
   @LogToLocal({ level: 'info' })


### PR DESCRIPTION
## Summary
- Auto-fix ESLint errors detected by nightly CI
- Closes #10699

## Changes
- Fixed `import/order` in desktop and shared/kit files (including `apps/desktop/app/app.ts`, bootstrap/logger/event bus, and several view/hooks files)
- Fixed `@typescript-eslint/no-shadow` in:
  - `packages/components/src/forms/Input/index.tsx`
  - `packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx`
- Fixed `@typescript-eslint/naming-convention` by renaming enum to `EScrollGuardDirection` and keeping compatibility export alias in `packages/components/src/primitives/ScrollGuard/index.tsx`
- Fixed `@typescript-eslint/return-await` in:
  - `packages/kit-bg/src/services/ServiceAppUpdate.ts`
  - `packages/kit/src/components/KeylessWallet/useKeylessWallet.tsx`
- Fixed `@typescript-eslint/no-use-before-define` by hoisting `isLastUpdateJsBundle` as function declaration in `packages/shared/src/appUpdate/index.ts`
- Fixed `react/jsx-no-leaked-render` expressions in market layout/list files via explicit ternary null fallback

## Test plan
- [x] ESLint passes locally (`NODE_OPTIONS=--max-old-space-size=8192 npx eslint . --ext .ts,.tsx --max-warnings 0`)
- [x] CI checks pass

🤖 Auto-generated by Scriptoria ESLint fix automation

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
