### PR TITLE
fix(ci): remove run-name causing ghost workflow runs on every push

### DIFF
--- a/.github/workflows/release-app-bundles.yml
+++ b/.github/workflows/release-app-bundles.yml
@@ -1,5 +1,4 @@
 name: release-app-bundles
-run-name: ${{ inputs.pr_number && format('Bundle PR #{0}', inputs.pr_number) || format('Bundle {0}', github.ref_name) }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Remove `run-name` expression from `release-app-bundles.yml` that was causing phantom failed workflow runs on every push event across all branches

## Intent & Context
After merging #10743 which added `run-name` with an `inputs.pr_number` expression to the bundle workflow, every push to any branch started creating ghost failed runs for `release-app-bundles.yml`. The workflow is `workflow_dispatch`-only, so these push-triggered runs were entirely unintended and polluting the Actions tab with failures.

## Root Cause
GitHub Actions has a known quirk: when a `workflow_dispatch`-only workflow has a `run-name` field with expressions referencing `inputs.*`, GitHub evaluates the workflow file on **every push event** to resolve the `run-name`. Since the `inputs` context is unavailable during push events, GitHub creates a phantom run with zero jobs that immediately reports failure.

**Evidence:** Before the `run-name` addition, all runs were `workflow_dispatch` and successful. After the addition, every push to any branch created a failed ghost run (0 jobs, no logs, 404 on log download).

## Design Decisions
- Chose to remove `run-name` entirely rather than attempt a workaround, since there's no reliable way to use `inputs` in `run-name` for `workflow_dispatch`-only workflows without triggering this GitHub behavior
- The `checkout_ref` parameter additions from the same PR (#10743) are kept as they are correct and unrelated to this issue

## Changes Detail
- `.github/workflows/release-app-bundles.yml`: Removed the `run-name` line that referenced `inputs.pr_number`

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: CI only — no app code changes
- **Risk Areas**: None — this is a single-line removal of a cosmetic CI feature that was causing failures

## Test plan
- [ ] Verify no more ghost `release-app-bundles` runs appear on subsequent pushes to `x` or feature branches
- [ ] Verify `workflow_dispatch` manual triggers still work correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
