### PR TITLE
feat(ci): set bundle workflow run name via API instead of run-name field

### DIFF
--- a/.github/workflows/release-app-bundles.yml
+++ b/.github/workflows/release-app-bundles.yml
@@ -25,12 +25,13 @@ jobs:
       - name: Set run name
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          PR="${{ inputs.pr_number }}"
-          if [ -n "$PR" ]; then
-            NAME="Bundle PR #$PR"
+          if [ -n "$PR_NUMBER" ]; then
+            NAME="Bundle PR #$PR_NUMBER"
           else
-            NAME="Bundle ${{ github.ref_name }}"
+            NAME="Bundle $REF_NAME"
           fi
           gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }} \
             -X PATCH -f name="$NAME"

--- a/.github/workflows/release-app-bundles.yml
+++ b/.github/workflows/release-app-bundles.yml
@@ -22,6 +22,19 @@ jobs:
       branch: ${{ steps.params.outputs.branch }}
       commit: ${{ steps.params.outputs.commit }}
     steps:
+      - name: Set run name
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR="${{ inputs.pr_number }}"
+          if [ -n "$PR" ]; then
+            NAME="Bundle PR #$PR"
+          else
+            NAME="Bundle ${{ github.ref_name }}"
+          fi
+          gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }} \
+            -X PATCH -f name="$NAME"
+
       - name: Checkout Source Code
         uses: actions/checkout@v4
         if: ${{ !inputs.pr_number }}


### PR DESCRIPTION
## Summary
- Add a step to dynamically rename the workflow run via GitHub API, restoring the "Bundle PR #123" / "Bundle x" display in the Actions UI without using the `run-name` field

## Intent & Context
PR #10743 added `run-name` to improve readability when building bundles from PR numbers — the default display shows the commit message, making it hard to identify which PR a bundle build is for. However, `run-name` caused ghost failed runs on every push (fixed in #10747 by removing it). This PR restores the same UX via a safe alternative.

## Design Decisions
- **Why API rename instead of `run-name`**: The `run-name` field is evaluated at the workflow-file level by GitHub on all events (including push), even for `workflow_dispatch`-only workflows. This creates phantom failed runs. By moving the rename into a job step, it only executes when the workflow is actually triggered.
- **Placement**: Added as the first step in `prepare-params` before checkout, so the run name updates as early as possible.
- **Trade-off**: The run name shows the default value for a few seconds until the step completes. Negligible in practice.

## Changes Detail
- `.github/workflows/release-app-bundles.yml`: Added "Set run name" step that calls `gh api` to PATCH the run name based on whether `pr_number` input is provided

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: CI only
- **Risk Areas**: Requires `actions: write` permission on the token (already configured)

## Test plan
- [ ] Trigger workflow_dispatch without PR number -> run renamed to "Bundle x"
- [ ] Trigger workflow_dispatch with PR number -> run renamed to "Bundle PR #number"
- [ ] Push to any branch -> no ghost runs created for this workflow
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
