### PR TITLE
fix(ci): remove broken PATCH API call for workflow run name

### DIFF
--- a/.github/workflows/release-app-bundles.yml
+++ b/.github/workflows/release-app-bundles.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
   prepare-params:
@@ -22,20 +21,6 @@ jobs:
       branch: ${{ steps.params.outputs.branch }}
       commit: ${{ steps.params.outputs.commit }}
     steps:
-      - name: Set run name
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ inputs.pr_number }}
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          if [ -n "$PR_NUMBER" ]; then
-            NAME="Bundle PR #$PR_NUMBER"
-          else
-            NAME="Bundle $REF_NAME"
-          fi
-          gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }} \
-            -X PATCH -f name="$NAME"
-
       - name: Checkout Source Code
         uses: actions/checkout@v4
         if: ${{ !inputs.pr_number }}


### PR DESCRIPTION
## Summary
- Remove the "Set run name" step from `release-app-bundles.yml` that always fails with HTTP 404
- Remove the now-unnecessary `actions: write` permission

## Intent & Context
The bundle workflow ([run #23256211974](https://github.com/OneKeyHQ/app-monorepo/actions/runs/23256211974/job/67611781052)) fails at the very first step — "Set run name" — because it tries to PATCH a GitHub API endpoint that doesn't exist.

This was introduced in #10748 as an alternative to the `run-name` YAML field (which was removed in #10747 due to causing ghost workflow runs on every push).

## Root Cause
`PATCH /repos/{owner}/{repo}/actions/runs/{run_id}` is not a valid GitHub REST API endpoint. The GitHub Actions REST API only supports GET and DELETE on workflow runs, plus POST for actions like cancel/rerun. There is no API to rename a workflow run after creation.

The only mechanism to set custom run names is the `run-name` YAML field, but that causes phantom workflow entries when referencing `inputs.*` on `workflow_dispatch`-only workflows (known GitHub bug).

## Design Decisions
- **Removed the step entirely** rather than adding `continue-on-error: true`, since the API call can never succeed — silencing it would just add noise
- **Removed `actions: write` permission** — no longer needed, follows least-privilege principle
- **Did not restore `run-name`** — would reintroduce the ghost workflow runs issue from #10747

## Changes Detail
- `.github/workflows/release-app-bundles.yml`: Removed "Set run name" step and `actions: write` permission

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: CI only — no runtime code changes
- **Risk Areas**: None — this is a pure deletion of a broken step

## Test plan
- [ ] Trigger `release-app-bundles` workflow via `workflow_dispatch` and verify `prepare-params` job completes successfully
- [ ] Verify no ghost/phantom workflow runs appear on push to `x`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
