### PR TITLE
refactor(perps): merge 4 trigger order types into 2(OK-51926)

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
@@ -808,7 +808,8 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
   async orderTrigger(params: ITriggerOrderParams): Promise<IOrderResponse> {
     await this.checkAccountCanTrade();
     try {
-      const { isMarket, tpsl } = mapTriggerOrderType(params.triggerOrderType);
+      const { isMarket } = mapTriggerOrderType(params.triggerOrderType);
+      const { tpsl } = params;
 
       // Format trigger price
       const triggerPxDecimals = getValidPriceDecimals(params.triggerPx);

--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -437,7 +437,7 @@ export const {
     skipOrderConfirm: false,
     showTradeMarks: true,
     showChartLines: true,
-    lastTriggerOrderType: ETriggerOrderType.STOP_MARKET,
+    lastTriggerOrderType: ETriggerOrderType.TRIGGER_MARKET,
   },
 });
 

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -31,6 +31,7 @@ import {
   findTokensByAlias,
   formatPriceToSignificantDigits,
   getTriggerEffectivePrice,
+  inferTpsl,
   resolveTradingSize,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type { ITokenSearchAliases } from '@onekeyhq/shared/src/utils/perpsUtils';
@@ -1012,7 +1013,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       const formData = params.formData || get(tradingFormAtom());
       const slippage = params.slippage;
       const triggerOrderType =
-        formData.triggerOrderType ?? ETriggerOrderType.STOP_MARKET;
+        formData.triggerOrderType ?? ETriggerOrderType.TRIGGER_MARKET;
 
       return withToast({
         asyncFn: async () => {
@@ -1081,8 +1082,29 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
             });
 
             const isLimitTrigger =
-              triggerOrderType === ETriggerOrderType.STOP_LIMIT ||
-              triggerOrderType === ETriggerOrderType.TAKE_LIMIT;
+              triggerOrderType === ETriggerOrderType.TRIGGER_LIMIT;
+
+            // Infer TP/SL from side + triggerPrice vs midPrice
+            const midPriceBN = new BigNumber(
+              activeAssetCtxValue?.ctx?.midPrice ?? 0,
+            );
+            const triggerPriceBN = new BigNumber(formData.triggerPrice ?? 0);
+            if (
+              triggerPriceBN.isFinite() &&
+              triggerPriceBN.gt(0) &&
+              midPriceBN.isFinite() &&
+              midPriceBN.gt(0) &&
+              triggerPriceBN.eq(midPriceBN)
+            ) {
+              throw new OneKeyLocalError(
+                'Trigger price must differ from current price',
+              );
+            }
+            const tpsl = inferTpsl({
+              side: formData.side,
+              triggerPrice: triggerPriceBN,
+              currentPrice: midPriceBN,
+            });
 
             const result =
               await backgroundApiProxy.serviceHyperliquidExchange.orderTrigger({
@@ -1091,6 +1113,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
                 size: resolvedSize,
                 triggerPx: formData.triggerPrice ?? '',
                 triggerOrderType,
+                tpsl,
                 executionPx: isLimitTrigger
                   ? formData.executionPrice
                   : undefined,

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/atoms.ts
@@ -146,7 +146,7 @@ export const { atom: tradingFormAtom, use: useTradingFormAtom } =
     slValue: '',
     // Standalone trigger defaults
     orderMode: 'standard',
-    triggerOrderType: ETriggerOrderType.STOP_MARKET,
+    triggerOrderType: ETriggerOrderType.TRIGGER_MARKET,
     triggerPrice: '',
     executionPrice: '',
     triggerReduceOnly: true,

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/PerpGallery.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/PerpGallery.tsx
@@ -49,10 +49,8 @@ function demoError(error: unknown, apiName: string) {
 type IDemoOrderType =
   | 'market'
   | 'limit'
-  | 'stopMarket'
-  | 'stopLimit'
-  | 'takeMarket'
-  | 'takeLimit';
+  | 'triggerMarket'
+  | 'triggerLimit';
 
 type IDemoOrderTypeOption = {
   value: IDemoOrderType;
@@ -62,10 +60,8 @@ type IDemoOrderTypeOption = {
 const DEMO_ORDER_TYPE_OPTIONS: IDemoOrderTypeOption[] = [
   { value: 'market', label: 'Market' },
   { value: 'limit', label: 'Limit' },
-  { value: 'stopMarket', label: 'Stop Market' },
-  { value: 'stopLimit', label: 'Stop Limit' },
-  { value: 'takeMarket', label: 'Take Market' },
-  { value: 'takeLimit', label: 'Take Limit' },
+  { value: 'triggerMarket', label: 'Trigger Market' },
+  { value: 'triggerLimit', label: 'Trigger Limit' },
 ];
 
 function PerpOrderTypeInteractionDemo() {
@@ -78,14 +74,11 @@ function PerpOrderTypeInteractionDemo() {
   const [executionPrice, setExecutionPrice] = useState('67580');
   const [reduceOnly, setReduceOnly] = useState(false);
 
-  const isTriggerOrder =
-    orderType.startsWith('stop') || orderType.startsWith('take');
+  const isTriggerOrder = orderType.startsWith('trigger');
   const needsLimitPrice = orderType === 'limit';
-  const needsExecutionPrice =
-    orderType === 'stopLimit' || orderType === 'takeLimit';
-  const triggerTpsl = orderType.startsWith('take') ? 'tp' : 'sl';
-  const triggerIsMarket =
-    orderType === 'stopMarket' || orderType === 'takeMarket';
+  const needsExecutionPrice = orderType === 'triggerLimit';
+  const triggerTpsl = 'sl'; // inferred at submission time
+  const triggerIsMarket = orderType === 'triggerMarket';
 
   const payloadPreview = useMemo(() => {
     const base = {

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/PerpGallery.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/PerpGallery.tsx
@@ -46,11 +46,7 @@ function demoError(error: unknown, apiName: string) {
   }
 }
 
-type IDemoOrderType =
-  | 'market'
-  | 'limit'
-  | 'triggerMarket'
-  | 'triggerLimit';
+type IDemoOrderType = 'market' | 'limit' | 'triggerMarket' | 'triggerLimit';
 
 type IDemoOrderTypeOption = {
   value: IDemoOrderType;

--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -27,11 +27,7 @@ import {
   usePerpsTradingPreferencesAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import {
-  getTriggerDirectionRule,
-  parseDexCoin,
-  validateStandaloneTriggerPrice,
-} from '@onekeyhq/shared/src/utils/perpsUtils';
+import { parseDexCoin } from '@onekeyhq/shared/src/utils/perpsUtils';
 import { ETriggerOrderType } from '@onekeyhq/shared/types/hyperliquid/types';
 
 import { useOrderConfirm } from '../../hooks';
@@ -251,8 +247,7 @@ function SideButtonInternal({
           return;
         }
         const isLimitTrigger =
-          formData.triggerOrderType === ETriggerOrderType.STOP_LIMIT ||
-          formData.triggerOrderType === ETriggerOrderType.TAKE_LIMIT;
+          formData.triggerOrderType === ETriggerOrderType.TRIGGER_LIMIT;
         if (isLimitTrigger) {
           const ep = formData.executionPrice?.trim();
           if (!ep || new BigNumber(ep).lte(0)) {
@@ -264,50 +259,14 @@ function SideButtonInternal({
             return;
           }
         }
-        // Direction validation: triggerPrice vs mid price (per HL order-types doc)
         if (!midPriceBN.isFinite() || midPriceBN.lte(0)) {
           Toast.error({ title: 'Market price unavailable, please try again' });
           return;
         }
-        if (
-          !validateStandaloneTriggerPrice(
-            tp,
-            midPriceBN,
-            formData.triggerOrderType,
-            side,
-          )
-        ) {
-          const isStop =
-            formData.triggerOrderType === ETriggerOrderType.STOP_MARKET ||
-            formData.triggerOrderType === ETriggerOrderType.STOP_LIMIT;
-          const dirRule = getTriggerDirectionRule(
-            formData.triggerOrderType,
-            side,
-          );
-          let typeKey: ETranslations;
-          if (isStop) {
-            typeKey =
-              side === 'long'
-                ? ETranslations.perps_stop_loss_buy
-                : ETranslations.perps_stop_loss_sell;
-          } else {
-            typeKey =
-              side === 'long'
-                ? ETranslations.perps_take_profit_buy
-                : ETranslations.perps_take_profit_sell;
-          }
-          const dirKey =
-            dirRule === 'above'
-              ? ETranslations.perps_above
-              : ETranslations.perps_below;
+        // Trigger price must differ from current price for TP/SL inference
+        if (new BigNumber(tp).eq(midPriceBN)) {
           Toast.error({
-            title: intl.formatMessage(
-              { id: ETranslations.perps_pro_order_trigger_price },
-              {
-                type: intl.formatMessage({ id: typeKey }),
-                dir: intl.formatMessage({ id: dirKey }),
-              },
-            ),
+            title: 'Trigger price must differ from current price',
           });
           return;
         }

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
@@ -21,10 +21,11 @@ import {
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
-import { parseDexCoin } from '@onekeyhq/shared/src/utils/perpsUtils';
+import { inferTpsl, parseDexCoin } from '@onekeyhq/shared/src/utils/perpsUtils';
 import { ETriggerOrderType } from '@onekeyhq/shared/types/hyperliquid/types';
 
 import { useOrderConfirm, useTradingCalculationsForSide } from '../../../hooks';
+import { useTradingPrice } from '../../../hooks/useTradingPrice';
 import { PerpsProviderMirror } from '../../../PerpsProviderMirror';
 import {
   GetTradingButtonStyleProps,
@@ -75,32 +76,54 @@ function OrderConfirmContent({
 
   const isTriggerMode = formData.orderMode === 'trigger';
   const isLimitTrigger =
-    formData.triggerOrderType === ETriggerOrderType.STOP_LIMIT ||
-    formData.triggerOrderType === ETriggerOrderType.TAKE_LIMIT;
+    formData.triggerOrderType === ETriggerOrderType.TRIGGER_LIMIT;
+
+  const { midPriceBN } = useTradingPrice();
 
   const triggerTypeLabel = useMemo(() => {
     if (!isTriggerMode) return null;
     switch (formData.triggerOrderType) {
-      case ETriggerOrderType.STOP_MARKET:
-        return intl.formatMessage({
-          id: ETranslations.perp_order_stop_market,
-        });
-      case ETriggerOrderType.STOP_LIMIT:
-        return intl.formatMessage({
-          id: ETranslations.perp_order_stop_limit,
-        });
-      case ETriggerOrderType.TAKE_MARKET:
-        return intl.formatMessage({
-          id: ETranslations.perp_order_tp_market,
-        });
-      case ETriggerOrderType.TAKE_LIMIT:
-        return intl.formatMessage({
-          id: ETranslations.perp_order_tp_limit,
-        });
+      case ETriggerOrderType.TRIGGER_MARKET:
+        return 'Trigger Market';
+      case ETriggerOrderType.TRIGGER_LIMIT:
+        return 'Trigger Limit';
       default:
         return null;
     }
-  }, [isTriggerMode, formData.triggerOrderType, intl]);
+  }, [isTriggerMode, formData.triggerOrderType]);
+
+  const inferredTpslBadge = useMemo(() => {
+    if (!isTriggerMode || !formData.triggerPrice) return null;
+    const triggerPriceBN = new BigNumber(formData.triggerPrice);
+    if (
+      !triggerPriceBN.isFinite() ||
+      triggerPriceBN.lte(0) ||
+      !midPriceBN.isFinite() ||
+      midPriceBN.lte(0) ||
+      triggerPriceBN.eq(midPriceBN)
+    ) {
+      return null;
+    }
+    const tpsl = inferTpsl({
+      side: effectiveSide,
+      triggerPrice: triggerPriceBN,
+      currentPrice: midPriceBN,
+    });
+    if (tpsl === 'tp') {
+      return intl.formatMessage({
+        id:
+          effectiveSide === 'long'
+            ? ETranslations.perps_take_profit_buy
+            : ETranslations.perps_take_profit_sell,
+      });
+    }
+    return intl.formatMessage({
+      id:
+        effectiveSide === 'long'
+          ? ETranslations.perps_stop_loss_buy
+          : ETranslations.perps_stop_loss_sell,
+    });
+  }, [isTriggerMode, formData.triggerPrice, midPriceBN, effectiveSide, intl]);
 
   const actionText =
     effectiveSide === 'long'
@@ -207,7 +230,8 @@ function OrderConfirmContent({
           </SizableText>
           {triggerTypeLabel ? (
             <SizableText size="$bodyMdMedium" color={actionColor}>
-              {triggerTypeLabel} /{' '}
+              {triggerTypeLabel}
+              {inferredTpslBadge ? ` (${inferredTpslBadge})` : ''} /{' '}
               {intl.formatMessage({
                 id:
                   effectiveSide === 'long'

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -68,6 +68,17 @@ interface IPerpTradingFormProps {
 type IPrimaryOrderType = 'market' | 'limit' | 'trigger';
 type ITriggerDropdownValue = ETriggerOrderType | 'scale' | 'twap';
 
+// Migrate old persisted trigger order types to new values
+function migrateTriggerOrderType(raw: string): ETriggerOrderType {
+  if (raw === 'stopMarket' || raw === 'takeMarket') {
+    return ETriggerOrderType.TRIGGER_MARKET;
+  }
+  if (raw === 'stopLimit' || raw === 'takeLimit') {
+    return ETriggerOrderType.TRIGGER_LIMIT;
+  }
+  return raw as ETriggerOrderType;
+}
+
 const TRIGGER_MODE_TPSL_RESET: Partial<ITradingFormData> = {
   hasTpsl: false,
   tpTriggerPx: '',
@@ -128,11 +139,12 @@ function PerpTradingForm({
   // Derive primaryOrderType from formData.orderMode
   const primaryOrderType: IPrimaryOrderType =
     formData.orderMode === 'trigger' ? 'trigger' : formData.type;
-  // Trigger order type: prefer formData, fall back to persisted setting
-  const triggerOrderType =
+  // Trigger order type: prefer formData, fall back to persisted setting (with migration)
+  const triggerOrderType = migrateTriggerOrderType(
     formData.triggerOrderType ??
-    perpsCustomSettings.lastTriggerOrderType ??
-    ETriggerOrderType.STOP_MARKET;
+      perpsCustomSettings.lastTriggerOrderType ??
+      ETriggerOrderType.TRIGGER_MARKET,
+  );
   // Only triggerMenuOpen stays as local state (pure UI)
   const [triggerMenuOpen, setTriggerMenuOpen] = useState(false);
   // Trigger price and reduceOnly from atom
@@ -385,23 +397,15 @@ function PerpTradingForm({
   const triggerTypeOptions = useMemo(
     () => [
       {
-        label: intl.formatMessage({ id: ETranslations.perp_order_stop_market }),
-        value: ETriggerOrderType.STOP_MARKET as ITriggerDropdownValue,
+        label: 'Trigger Market',
+        value: ETriggerOrderType.TRIGGER_MARKET as ITriggerDropdownValue,
       },
       {
-        label: intl.formatMessage({ id: ETranslations.perp_order_stop_limit }),
-        value: ETriggerOrderType.STOP_LIMIT as ITriggerDropdownValue,
-      },
-      {
-        label: intl.formatMessage({ id: ETranslations.perp_order_tp_market }),
-        value: ETriggerOrderType.TAKE_MARKET as ITriggerDropdownValue,
-      },
-      {
-        label: intl.formatMessage({ id: ETranslations.perp_order_tp_limit }),
-        value: ETriggerOrderType.TAKE_LIMIT as ITriggerDropdownValue,
+        label: 'Trigger Limit',
+        value: ETriggerOrderType.TRIGGER_LIMIT as ITriggerDropdownValue,
       },
     ],
-    [intl],
+    [],
   );
   const mobileOrderTypeOptions = useMemo(
     () => [
@@ -414,20 +418,12 @@ function PerpTradingForm({
         value: 'limit' as string,
       },
       {
-        label: intl.formatMessage({ id: ETranslations.perp_order_stop_market }),
-        value: ETriggerOrderType.STOP_MARKET as string,
+        label: 'Trigger Market',
+        value: ETriggerOrderType.TRIGGER_MARKET as string,
       },
       {
-        label: intl.formatMessage({ id: ETranslations.perp_order_stop_limit }),
-        value: ETriggerOrderType.STOP_LIMIT as string,
-      },
-      {
-        label: intl.formatMessage({ id: ETranslations.perp_order_tp_market }),
-        value: ETriggerOrderType.TAKE_MARKET as string,
-      },
-      {
-        label: intl.formatMessage({ id: ETranslations.perp_order_tp_limit }),
-        value: ETriggerOrderType.TAKE_LIMIT as string,
+        label: 'Trigger Limit',
+        value: ETriggerOrderType.TRIGGER_LIMIT as string,
       },
     ],
     [intl],
@@ -436,13 +432,12 @@ function PerpTradingForm({
   const applyPrimaryOrderType = useCallback(
     (nextType: IPrimaryOrderType) => {
       if (nextType === 'trigger') {
-        // Use persisted trigger type when switching to trigger tab
-        const persistedType =
+        const persistedType = migrateTriggerOrderType(
           perpsCustomSettings.lastTriggerOrderType ??
-          ETriggerOrderType.STOP_MARKET;
+            ETriggerOrderType.TRIGGER_MARKET,
+        );
         const isLimitTrigger =
-          persistedType === ETriggerOrderType.STOP_LIMIT ||
-          persistedType === ETriggerOrderType.TAKE_LIMIT;
+          persistedType === ETriggerOrderType.TRIGGER_LIMIT;
         updateForm({
           ...TRIGGER_MODE_TPSL_RESET,
           orderMode: 'trigger',
@@ -469,20 +464,18 @@ function PerpTradingForm({
       if (nextType === 'scale' || nextType === 'twap') {
         return;
       }
-      const isLimitTrigger =
-        nextType === ETriggerOrderType.STOP_LIMIT ||
-        nextType === ETriggerOrderType.TAKE_LIMIT;
+      const migrated = migrateTriggerOrderType(nextType);
+      const isLimitTrigger = migrated === ETriggerOrderType.TRIGGER_LIMIT;
       updateForm({
         ...TRIGGER_MODE_TPSL_RESET,
         orderMode: 'trigger',
-        triggerOrderType: nextType,
+        triggerOrderType: migrated,
         type: isLimitTrigger ? 'limit' : 'market',
         bboPriceMode: null,
       });
-      // Persist last selected trigger type
       setPerpsCustomSettings({
         ...perpsCustomSettings,
-        lastTriggerOrderType: nextType,
+        lastTriggerOrderType: migrated,
       });
     },
     [updateForm, perpsCustomSettings, setPerpsCustomSettings],
@@ -490,8 +483,7 @@ function PerpTradingForm({
 
   const isTriggerMode = formData.orderMode === 'trigger';
   const isTriggerLimitOrder =
-    triggerOrderType === ETriggerOrderType.STOP_LIMIT ||
-    triggerOrderType === ETriggerOrderType.TAKE_LIMIT;
+    triggerOrderType === ETriggerOrderType.TRIGGER_LIMIT;
 
   const renderPriceInputSection = () => {
     if (isTriggerMode) {

--- a/packages/kit/src/views/Perp/hooks/useLiquidationPrice.test.ts
+++ b/packages/kit/src/views/Perp/hooks/useLiquidationPrice.test.ts
@@ -94,7 +94,7 @@ const resetMocks = () => {
   mockFormData = {
     side: 'long',
     orderMode: 'trigger',
-    triggerOrderType: ETriggerOrderType.STOP_LIMIT,
+    triggerOrderType: ETriggerOrderType.TRIGGER_LIMIT,
     triggerPrice: '100',
     executionPrice: '110',
     triggerReduceOnly: false,
@@ -156,7 +156,7 @@ describe('useLiquidationPrice', () => {
   });
 
   test('returns null when trigger market trigger price is missing', () => {
-    mockFormData.triggerOrderType = ETriggerOrderType.STOP_MARKET;
+    mockFormData.triggerOrderType = ETriggerOrderType.TRIGGER_MARKET;
     mockFormData.triggerPrice = '';
 
     const { result } = renderHook(() => useLiquidationPrice('long'));

--- a/packages/kit/src/views/Perp/hooks/useLiquidationPrice.ts
+++ b/packages/kit/src/views/Perp/hooks/useLiquidationPrice.ts
@@ -72,8 +72,7 @@ export function useLiquidationPrice(
 
     if (isTriggerMode) {
       const isLimitTrigger =
-        formData.triggerOrderType === ETriggerOrderType.STOP_LIMIT ||
-        formData.triggerOrderType === ETriggerOrderType.TAKE_LIMIT;
+        formData.triggerOrderType === ETriggerOrderType.TRIGGER_LIMIT;
       const rawTriggerPrice = isLimitTrigger
         ? formData.executionPrice?.trim()
         : formData.triggerPrice?.trim();

--- a/packages/kit/src/views/Perp/hooks/useOrderConfirm.ts
+++ b/packages/kit/src/views/Perp/hooks/useOrderConfirm.ts
@@ -9,10 +9,7 @@ import {
   useTradingLoadingAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import { usePerpsActiveAssetAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import {
-  formatPriceToSignificantDigits,
-  validateStandaloneTriggerPrice,
-} from '@onekeyhq/shared/src/utils/perpsUtils';
+import { formatPriceToSignificantDigits } from '@onekeyhq/shared/src/utils/perpsUtils';
 import { ETriggerOrderType } from '@onekeyhq/shared/types/hyperliquid/types';
 
 import { useOrderPrice } from './useOrderPrice';
@@ -59,7 +56,7 @@ export function useOrderConfirm(
       // Trigger mode: validate, snapshot, and submit (no TP/SL, no standard price validation)
       if (formDataSnapshot.orderMode === 'trigger') {
         const triggerOrderType =
-          formDataSnapshot.triggerOrderType ?? ETriggerOrderType.STOP_MARKET;
+          formDataSnapshot.triggerOrderType ?? ETriggerOrderType.TRIGGER_MARKET;
         const tp = formDataSnapshot.triggerPrice?.trim();
         if (!tp || new BigNumber(tp).lte(0)) {
           Toast.error({
@@ -69,8 +66,7 @@ export function useOrderConfirm(
           return;
         }
         const isLimitTrigger =
-          triggerOrderType === ETriggerOrderType.STOP_LIMIT ||
-          triggerOrderType === ETriggerOrderType.TAKE_LIMIT;
+          triggerOrderType === ETriggerOrderType.TRIGGER_LIMIT;
         if (isLimitTrigger) {
           const ep = formDataSnapshot.executionPrice?.trim();
           if (!ep || new BigNumber(ep).lte(0)) {
@@ -88,17 +84,10 @@ export function useOrderConfirm(
           });
           return;
         }
-        if (
-          !validateStandaloneTriggerPrice(
-            tp,
-            midPriceBN,
-            triggerOrderType,
-            side,
-          )
-        ) {
+        if (new BigNumber(tp).eq(midPriceBN)) {
           Toast.error({
             title: 'Order Failed',
-            message: 'Invalid trigger price direction',
+            message: 'Trigger price must differ from current price',
           });
           return;
         }

--- a/packages/shared/src/utils/perpsUtils.ts
+++ b/packages/shared/src/utils/perpsUtils.ts
@@ -1213,25 +1213,18 @@ export function sortPerpsAssetIndices({
 // ── Standalone Trigger Order Utilities ──
 
 /**
- * Map trigger order type to HyperLiquid `isMarket` and `tpsl` fields.
+ * Map trigger order type to HyperLiquid `isMarket` field.
  *
- * HyperLiquid uses:
  * - `isMarket: true` for market triggers, `false` for limit triggers
- * - `tpsl: 'tp'` for take-profit types, `'sl'` for stop types
  */
 function mapTriggerOrderType(triggerOrderType: ETriggerOrderType): {
   isMarket: boolean;
-  tpsl: 'tp' | 'sl';
 } {
   switch (triggerOrderType) {
-    case ETriggerOrderType.STOP_MARKET:
-      return { isMarket: true, tpsl: 'sl' };
-    case ETriggerOrderType.STOP_LIMIT:
-      return { isMarket: false, tpsl: 'sl' };
-    case ETriggerOrderType.TAKE_MARKET:
-      return { isMarket: true, tpsl: 'tp' };
-    case ETriggerOrderType.TAKE_LIMIT:
-      return { isMarket: false, tpsl: 'tp' };
+    case ETriggerOrderType.TRIGGER_MARKET:
+      return { isMarket: true };
+    case ETriggerOrderType.TRIGGER_LIMIT:
+      return { isMarket: false };
     default: {
       const _exhaustive: never = triggerOrderType;
       throw new OneKeyLocalError(
@@ -1242,86 +1235,29 @@ function mapTriggerOrderType(triggerOrderType: ETriggerOrderType): {
 }
 
 /**
- * Get the required trigger price direction rule for a standalone trigger order.
+ * Infer TP/SL direction from side, triggerPrice, and currentPrice.
  *
- * Returns 'above' if triggerPrice must be above mid price, 'below' if below.
+ * HL API tpsl semantics (standalone trigger orders):
+ * - tpsl='sl': buy triggers when price rises above triggerPx; sell triggers when price drops below
+ * - tpsl='tp': buy triggers when price drops below triggerPx; sell triggers when price rises above
  *
- * Rules (per HL order-types doc):
- * - Stop + Long (buy stop): trigger must be ABOVE mid (triggers when price rises)
- * - Stop + Short (sell stop): trigger must be BELOW mid (triggers when price drops)
- * - Take + Long (buy TP): trigger must be BELOW mid (triggers when price drops)
- * - Take + Short (sell TP): trigger must be ABOVE mid (triggers when price rises)
+ * So for order side:
+ * - Long (buy) + trigger > current → 'sl' (buy stop: triggers on price rise)
+ * - Long (buy) + trigger < current → 'tp' (buy TP: triggers on price drop)
+ * - Short (sell) + trigger > current → 'tp' (sell TP: triggers on price rise)
+ * - Short (sell) + trigger < current → 'sl' (sell stop: triggers on price drop)
  */
-function getTriggerDirectionRule(
-  triggerOrderType: ETriggerOrderType,
-  side: 'long' | 'short',
-): 'above' | 'below' {
-  const isStop =
-    triggerOrderType === ETriggerOrderType.STOP_MARKET ||
-    triggerOrderType === ETriggerOrderType.STOP_LIMIT;
-  const isLong = side === 'long';
-  // Stop + Long → above, Stop + Short → below
-  // Take + Long → below, Take + Short → above
-  if (isStop) {
-    return isLong ? 'above' : 'below';
+function inferTpsl(params: {
+  side: 'long' | 'short';
+  triggerPrice: BigNumber;
+  currentPrice: BigNumber;
+}): 'tp' | 'sl' {
+  const { side, triggerPrice, currentPrice } = params;
+  const isAbove = triggerPrice.gt(currentPrice);
+  if (side === 'long') {
+    return isAbove ? 'sl' : 'tp';
   }
-  return isLong ? 'below' : 'above';
-}
-
-/**
- * Validate that a standalone trigger price satisfies the direction constraint
- * relative to the current mark/mid price.
- *
- * @returns `true` if the trigger price is valid (on the correct side of mark price)
- */
-function validateStandaloneTriggerPrice(
-  triggerPrice: string | BigNumber,
-  markPrice: string | BigNumber,
-  triggerOrderType: ETriggerOrderType,
-  side: 'long' | 'short',
-): boolean {
-  const triggerPriceBN =
-    triggerPrice instanceof BigNumber
-      ? triggerPrice
-      : new BigNumber(triggerPrice);
-  const markPriceBN =
-    markPrice instanceof BigNumber ? markPrice : new BigNumber(markPrice);
-
-  if (
-    !triggerPriceBN.isFinite() ||
-    triggerPriceBN.lte(0) ||
-    !markPriceBN.isFinite() ||
-    markPriceBN.lte(0)
-  ) {
-    return false;
-  }
-
-  const direction = getTriggerDirectionRule(triggerOrderType, side);
-  if (direction === 'above') {
-    return triggerPriceBN.gt(markPriceBN);
-  }
-  return triggerPriceBN.lt(markPriceBN);
-}
-
-/**
- * Compute a reasonable default trigger price for a standalone trigger order.
- * Applies a small offset (±0.5%) from mid price based on the direction rule.
- */
-function getDefaultStandaloneTriggerPrice(
-  midPrice: string | BigNumber,
-  triggerOrderType: ETriggerOrderType,
-  side: 'long' | 'short',
-): string {
-  const midPriceBN =
-    midPrice instanceof BigNumber ? midPrice : new BigNumber(midPrice);
-
-  if (!midPriceBN.isFinite() || midPriceBN.lte(0)) {
-    return '';
-  }
-
-  const direction = getTriggerDirectionRule(triggerOrderType, side);
-  const multiplier = direction === 'above' ? 1.005 : 0.995;
-  return formatPriceToSignificantDigits(midPriceBN.multipliedBy(multiplier));
+  return isAbove ? 'tp' : 'sl';
 }
 
 /**
@@ -1339,9 +1275,7 @@ function getTriggerEffectivePrice(params: {
 }): BigNumber {
   const { triggerOrderType, triggerPrice, executionPrice, midPrice } = params;
 
-  const isLimitTrigger =
-    triggerOrderType === ETriggerOrderType.STOP_LIMIT ||
-    triggerOrderType === ETriggerOrderType.TAKE_LIMIT;
+  const isLimitTrigger = triggerOrderType === ETriggerOrderType.TRIGGER_LIMIT;
 
   if (isLimitTrigger && executionPrice) {
     const execBN = new BigNumber(executionPrice);
@@ -1464,9 +1398,7 @@ export {
   resolveTradingSizeBN,
   getHyperliquidTokenImageUrl,
   mapTriggerOrderType,
-  getTriggerDirectionRule,
-  validateStandaloneTriggerPrice,
-  getDefaultStandaloneTriggerPrice,
+  inferTpsl,
   getTriggerEffectivePrice,
 };
 export default {
@@ -1502,8 +1434,6 @@ export default {
   findTokensByAlias,
   getTokenSubtitle,
   mapTriggerOrderType,
-  getTriggerDirectionRule,
-  validateStandaloneTriggerPrice,
-  getDefaultStandaloneTriggerPrice,
+  inferTpsl,
   getTriggerEffectivePrice,
 };

--- a/packages/shared/types/hyperliquid/types.ts
+++ b/packages/shared/types/hyperliquid/types.ts
@@ -157,10 +157,8 @@ export interface IPositionTpslOrderParams {
 // ── Standalone Trigger Order Types ──
 
 export enum ETriggerOrderType {
-  STOP_MARKET = 'stopMarket',
-  STOP_LIMIT = 'stopLimit',
-  TAKE_MARKET = 'takeMarket',
-  TAKE_LIMIT = 'takeLimit',
+  TRIGGER_MARKET = 'triggerMarket',
+  TRIGGER_LIMIT = 'triggerLimit',
 }
 
 export interface ITriggerOrderParams {
@@ -169,6 +167,7 @@ export interface ITriggerOrderParams {
   size: string;
   triggerPx: string;
   triggerOrderType: ETriggerOrderType;
+  tpsl: 'tp' | 'sl';
   executionPx?: string; // required for limit triggers
   reduceOnly: boolean;
   slippage?: number;


### PR DESCRIPTION
## Summary
- Merge 4 trigger order types (stopMarket/stopLimit/takeMarket/takeLimit) into 2 (triggerMarket/triggerLimit)
- Auto-infer TP/SL direction from `side + triggerPrice vs midPrice`, eliminating manual stop/take selection
- Add migration for old persisted enum values to ensure seamless upgrade

## Intent & Context
The current Perps trigger order flow requires users to manually choose between 4 types (Stop Market / Stop Limit / Take Profit Market / Take Profit Limit). However, the TP/SL direction can be fully determined by comparing the trigger price against the current mid price combined with the order side. This manual selection is redundant and error-prone (users can select the wrong direction, causing validation errors). This refactor aligns with mainstream exchange UX by reducing the selection to just 2 types (Trigger Market / Trigger Limit).

## Design Decisions
- **Inference at action layer**: `inferTpsl()` runs at submission time using the latest `midPrice`, ensuring the API receives the correct `tpsl` value even if price fluctuates between form input and submission.
- **Equality guard**: `triggerPrice === midPrice` is rejected at 3 layers (TradingButtonGroup, useOrderConfirm, actions) since TP/SL cannot be inferred when prices are equal.
- **Read-time migration**: Old persisted values (`stopMarket` etc.) are migrated via `migrateTriggerOrderType()` when read, avoiding a separate data migration step.
- **Badge display in confirm modal**: Inferred TP/SL is shown as a badge in the order confirmation dialog so users can verify the direction before submitting.

## Changes Detail
- `packages/shared/types/hyperliquid/types.ts` — `ETriggerOrderType` enum: 4→2 values; added `tpsl` to `ITriggerOrderParams`
- `packages/shared/src/utils/perpsUtils.ts` — Added `inferTpsl()`, simplified `mapTriggerOrderType()`, updated `getTriggerEffectivePrice()`, removed 3 obsolete functions
- `packages/kit-bg/src/states/jotai/atoms/perps.ts` — Default `lastTriggerOrderType` → `TRIGGER_MARKET`
- `packages/kit/src/states/jotai/contexts/hyperliquid/atoms.ts` — Default `triggerOrderType` → `TRIGGER_MARKET`
- `packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts` — `orderTrigger()` reads `tpsl` from params
- `packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts` — Added `inferTpsl` call with midPrice equality guard
- `packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx` — 2 trigger options (desktop/mobile), migration function, simplified checks
- `packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx` — Replaced direction validation with equality check
- `packages/kit/src/views/Perp/hooks/useOrderConfirm.ts` — Same equality check replacement
- `packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx` — 2-case label, inferred TP/SL badge
- `packages/kit/src/views/Perp/hooks/useLiquidationPrice.ts` — Simplified `isLimitTrigger`
- `packages/kit/src/views/Perp/hooks/useLiquidationPrice.test.ts` — Updated mock enum values
- `packages/kit/src/views/Developer/pages/Gallery/Components/stories/PerpGallery.tsx` — Updated demo

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop / Mobile / Web / Extension (all platforms using Perps trading)
- **Risk Areas**: `inferTpsl` logic correctness — wrong inference would send incorrect `tpsl` to HyperLiquid API, causing orders to trigger in the wrong direction. Mitigated by 3-round code review verifying equivalence with old mapping.

## Test plan
- [ ] Trigger Market + Long + trigger > mid → confirm shows stop badge + API `tpsl='sl'`
- [ ] Trigger Market + Long + trigger < mid → confirm shows TP badge + API `tpsl='tp'`
- [ ] Trigger Limit + Short + trigger > mid → confirm shows TP badge + API `tpsl='tp'`
- [ ] Trigger Limit + Short + trigger < mid → confirm shows stop badge + API `tpsl='sl'`
- [ ] trigger === mid → toast error, cannot submit
- [ ] Desktop: trigger tab dropdown shows 2 options
- [ ] Mobile: unified dropdown shows 4 options (Market/Limit/Trigger Market/Trigger Limit)
- [ ] Old user upgrade (localStorage has old enum values) → auto migrates to new values
- [ ] reduce-only toggle works correctly
- [ ] Unit tests pass: `useLiquidationPrice.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
