### PR TITLE
fix(security): upgrade systeminformation to fix command injection vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
     "socket.io-client": "^4.7.5",
     "sonner": "^1.4.41",
     "stream-browserify": "^3.0.0",
-    "systeminformation": "^5.27.14",
+    "systeminformation": "5.31.4",
     "tamagui": "1.108.0",
     "text-encoding": "^0.7.0",
     "timeout-signal": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9183,7 +9183,7 @@ __metadata:
     sonner: "npm:^1.4.41"
     stream-browserify: "npm:^3.0.0"
     style-loader: "npm:^3.3.3"
-    systeminformation: "npm:^5.27.14"
+    systeminformation: "npm:5.31.4"
     tamagui: "npm:1.108.0"
     tamagui-loader: "npm:1.108.0"
     text-encoding: "npm:^0.7.0"
@@ -43956,12 +43956,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"systeminformation@npm:^5.27.14":
-  version: 5.27.14
-  resolution: "systeminformation@npm:5.27.14"
+"systeminformation@npm:5.31.4":
+  version: 5.31.4
+  resolution: "systeminformation@npm:5.31.4"
   bin:
     systeminformation: lib/cli.js
-  checksum: 10/bf8194000e1a4af47acf16a9bc41b715dbd6bde15cb09dc52626f8c8d77ebc1c62b939343ae153b7cbc08486c5d841128019bfe4e5d71c42c14e1089a32c97a1
+  checksum: 10/8b42b0ff666ff748535324223aad2a71a61a3828a477331d245933beed2291cd5a2ca9fe68d565341cf484d79175685ff90ba708197cd58c2fd2658f6ef8fb14
   conditions: (os=darwin | os=linux | os=win32 | os=freebsd | os=openbsd | os=netbsd | os=sunos | os=android)
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Summary

- Upgrade `systeminformation` from `5.27.14` to `5.31.4` (pinned, no caret)
- Fixes **2 known command injection vulnerabilities** (both rated **High**):
  - **CVE: Command Injection via unsanitized `locate` output in `versions()`** — patched in 5.31.0
  - **CVE: Command Injection via unsanitized interface parameter in `wifi.js` retry path** — patched in 5.30.8

## Risk & Impact Assessment

### Vulnerabilities (Why this matters)

Both are **command injection** vulnerabilities in `systeminformation`. An attacker who can influence system state (e.g., filenames on disk for `versions()`, or WiFi interface names for `wifi.js`) could execute arbitrary OS commands in the context of the Electron main process — which has **full system access** on the Desktop app.

Our codebase uses `si.system()`, `si.cpu()`, `si.osInfo()` in `packages/kit-bg/src/desktopApis/DesktopApiSystem.ts` — **not** the vulnerable `versions()` or `wifi` APIs directly. However, defense-in-depth requires patching since:
1. The vulnerable code ships in the bundle regardless of which APIs we call
2. Future code changes could inadvertently call vulnerable APIs
3. Transitive internal calls within the library could theoretically reach vulnerable paths

### Upgrade Risk (What could break)

- **Low risk**: `system()`, `cpu()`, `osInfo()` APIs have no breaking changes in 5.x series
- Version is **pinned** (`5.31.4`, no `^`) to prevent unintended future upgrades
- Only affects **Desktop** platform (Electron main process)

## Test Plan

- [ ] Desktop app launches successfully
- [ ] System info collection works (check Sentry device context reporting)
- [ ] No regression in `getSystemInfo()` call in DesktopApiSystem
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
