### PR TITLE
fix: prevent Intercom messenger auto-opening on desktop cold start(OK-51873)

### DIFF
--- a/packages/shared/src/modules3rdParty/intercom/index.ts
+++ b/packages/shared/src/modules3rdParty/intercom/index.ts
@@ -9,8 +9,27 @@ import { getCustomerJWT, getInstanceId } from './utils';
 
 import type { InitType } from '@intercom/messenger-js-sdk/dist/types';
 
+const clearIntercomOpenOnBoot = (appId: string) => {
+  try {
+    const key = `intercom.intercom-state-${appId}`;
+    const raw = localStorage.getItem(key);
+    if (raw) {
+      const state = JSON.parse(raw);
+      if (state.openOnBoot?.metadata?.articleIds?.length) {
+        delete state.openOnBoot;
+        localStorage.setItem(key, JSON.stringify(state));
+      }
+    }
+  } catch {
+    // ignore
+  }
+};
+
 export const initIntercom = async (settings?: Partial<InitType>) => {
   const APP_ID = settings?.app_id || process.env.INTERCOM_APP_ID || 'vbbj4ssb';
+
+  // Clear previous session's openOnBoot state to prevent auto-opening messenger on cold start
+  clearIntercomOpenOnBoot(APP_ID);
 
   Intercom({
     app_id: APP_ID,


### PR DESCRIPTION
## Summary
- Clear Intercom `openOnBoot` state from localStorage before SDK initialization to prevent messenger window from auto-opening on desktop cold start

## Intent & Context
On desktop, if a user had previously opened an Intercom article, cold starting the app would always pop up the Intercom messenger window automatically. This is disruptive UX — the messenger should only appear when explicitly triggered by the user clicking "Contact Us".

## Root Cause
The Intercom JS SDK persists its state to localStorage under `intercom.intercom-state-{app_id}`. When an article is opened, the SDK stores an `openOnBoot` field with `metadata.articleIds` and `openArticleStandalone: true`. On the next cold start, `initIntercom()` initializes the SDK, which reads this localStorage state and auto-restores the messenger to its previous open state.

The existing `hide_default_launcher: true` setting only controls the launcher button visibility — it has no effect on the messenger window's state restoration behavior. Intercom provides no configuration option to disable this auto-restore.

## Design Decisions
- **Chosen approach**: Clear `openOnBoot` from localStorage before SDK initialization. This prevents the auto-restore at its source — the SDK simply has no state to restore.
- **Alternative considered**: Using `onShow` callback with a flag to detect and `hide()` auto-restored windows. Rejected because it would cause a brief visual flash of the messenger before hiding.
- **Alternative considered**: Calling `shutdown()` + `boot()` to reset all state. Rejected because it clears visitor identity and conversation history.
- **Selective clearing**: Only clears `openOnBoot` when `metadata.articleIds` has content, preserving normal state where `metadata` is empty `{}`.

## Changes Detail
- `packages/shared/src/modules3rdParty/intercom/index.ts`: Added `clearIntercomOpenOnBoot()` helper that reads the Intercom state from localStorage, checks for article-related `openOnBoot` data, and deletes it before SDK initialization.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop (web SDK path only; native/extension use different Intercom implementations)
- **Risk Areas**: localStorage manipulation before SDK init — wrapped in try/catch, fails silently

## Test plan
- [ ] Open an Intercom article on desktop via "Contact Us" or help link
- [ ] Close the app completely (cold quit)
- [ ] Relaunch the app — verify Intercom messenger does NOT auto-open
- [ ] Click "Contact Us" — verify Intercom messenger opens normally
- [ ] Verify no errors in console related to Intercom initialization
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
