### PR TITLE
perf: move scroll-driven animations to UI thread for smoother tab headers

### DIFF
--- a/packages/components/src/composite/Tabs/TabBar.tsx
+++ b/packages/components/src/composite/Tabs/TabBar.tsx
@@ -8,6 +8,7 @@ import Animated, {
   runOnJS,
   useAnimatedReaction,
   useAnimatedStyle,
+  useSharedValue,
 } from 'react-native-reanimated';
 import { useThrottledCallback } from 'use-debounce';
 
@@ -207,24 +208,44 @@ function AnimatedIndicator({
   const theme = useTheme();
   const indicatorColor = theme.text.val;
 
+  // Store layout data as SharedValues to avoid worklet recreation on re-render.
+  const xValuesSV = useSharedValue<number[]>([]);
+  const widthValuesSV = useSharedValue<number[]>([]);
+  const countSV = useSharedValue(0);
+
+  if (
+    itemsLayout.length !== countSV.value ||
+    itemsLayout.some(
+      (v, i) =>
+        xValuesSV.value[i] !== v.x || widthValuesSV.value[i] !== v.width,
+    )
+  ) {
+    xValuesSV.value = itemsLayout.map((v) => v.x);
+    widthValuesSV.value = itemsLayout.map((v) => v.width);
+    countSV.value = itemsLayout.length;
+  }
+
   const animatedStyle = useAnimatedStyle(() => {
-    if (itemsLayout.length < 2) {
-      const first = itemsLayout[0];
-      return first
-        ? { transform: [{ translateX: first.x }], width: first.width }
+    const count = countSV.value;
+    const xs = xValuesSV.value;
+    const ws = widthValuesSV.value;
+
+    if (count < 2) {
+      return count === 1
+        ? { transform: [{ translateX: xs[0] }], width: ws[0] }
         : {};
     }
-    const inputRange = itemsLayout.map((_, i) => i);
+    const inputRange = xs.map((_, i) => i);
     const translateX = interpolate(
       indexDecimal.value,
       inputRange,
-      itemsLayout.map((v) => v.x),
+      xs,
       Extrapolation.CLAMP,
     );
     const width = interpolate(
       indexDecimal.value,
       inputRange,
-      itemsLayout.map((v) => v.width),
+      ws,
       Extrapolation.CLAMP,
     );
     return { transform: [{ translateX }], width };
@@ -322,15 +343,33 @@ function AnimatedPillIndicator({
   const theme = useTheme();
   const bgColor = theme.bgPrimary.val;
 
-  // Pre-compute left/right edge arrays for the jelly effect
-  const leftEdges = itemsLayout.map((v) => v.x);
-  const rightEdges = itemsLayout.map((v) => v.x + v.width);
+  // Store layout edges as SharedValues so the worklet never needs to be
+  // recreated when itemsLayout changes — all reads stay on the UI thread.
+  const leftEdgesSV = useSharedValue<number[]>([]);
+  const rightEdgesSV = useSharedValue<number[]>([]);
+  const countSV = useSharedValue(0);
+
+  if (
+    itemsLayout.length !== countSV.value ||
+    itemsLayout.some(
+      (v, i) =>
+        leftEdgesSV.value[i] !== v.x ||
+        rightEdgesSV.value[i] !== v.x + v.width,
+    )
+  ) {
+    leftEdgesSV.value = itemsLayout.map((v) => v.x);
+    rightEdgesSV.value = itemsLayout.map((v) => v.x + v.width);
+    countSV.value = itemsLayout.length;
+  }
 
   const animatedStyle = useAnimatedStyle(() => {
-    if (itemsLayout.length < 2) {
-      const first = itemsLayout[0];
-      return first
-        ? { transform: [{ translateX: first.x }], width: first.width }
+    const count = countSV.value;
+    const lefts = leftEdgesSV.value;
+    const rights = rightEdgesSV.value;
+
+    if (count < 2) {
+      return count === 1
+        ? { transform: [{ translateX: lefts[0] }], width: rights[0] - lefts[0] }
         : {};
     }
 
@@ -341,28 +380,27 @@ function AnimatedPillIndicator({
 
     // At rest on a tab — no jelly needed
     if (floorIdx === ceilIdx || fraction === 0) {
-      const layout = itemsLayout[Math.min(floorIdx, itemsLayout.length - 1)];
-      return layout
-        ? { transform: [{ translateX: layout.x }], width: layout.width }
-        : {};
+      const idx = Math.max(0, Math.min(floorIdx, count - 1));
+      return {
+        transform: [{ translateX: lefts[idx] }],
+        width: rights[idx] - lefts[idx],
+      };
     }
 
-    const safeFloor = Math.max(0, Math.min(floorIdx, itemsLayout.length - 1));
-    const safeCeil = Math.max(0, Math.min(ceilIdx, itemsLayout.length - 1));
+    const safeFloor = Math.max(0, Math.min(floorIdx, count - 1));
+    const safeCeil = Math.max(0, Math.min(ceilIdx, count - 1));
 
-    const fromLeft = leftEdges[safeFloor];
-    const fromRight = rightEdges[safeFloor];
-    const toLeft = leftEdges[safeCeil];
-    const toRight = rightEdges[safeCeil];
+    const fromLeft = lefts[safeFloor];
+    const fromRight = rights[safeFloor];
+    const toLeft = lefts[safeCeil];
+    const toRight = rights[safeCeil];
 
     // Jelly/elastic effect: leading edge moves faster, trailing edge lags.
-    // ease-out (t => 1 - (1-t)^2): accelerates early — used for leading edge
-    // ease-in  (t => t^2):          accelerates late  — used for trailing edge
+    // ease-out (1-(1-t)^2): accelerates early — used for leading edge
+    // ease-in  (t^2):       accelerates late  — used for trailing edge
     const easeOut = 1 - (1 - fraction) * (1 - fraction);
     const easeIn = fraction * fraction;
 
-    // Moving right (floor → ceil): right edge leads, left edge trails
-    // Moving left would be the reverse, but indexDecimal always has floor < ceil
     const left = fromLeft + (toLeft - fromLeft) * easeIn;
     const right = fromRight + (toRight - fromRight) * easeOut;
 

--- a/packages/components/src/composite/Tabs/TabBar.tsx
+++ b/packages/components/src/composite/Tabs/TabBar.tsx
@@ -36,12 +36,10 @@ function AnimatedPillText({
   name,
   index: tabIndex,
   indexDecimal,
-  textSize,
 }: {
   name: string;
   index: number;
   indexDecimal: SharedValue<number>;
-  textSize: ISizableTextProps['size'];
 }) {
   const theme = useTheme();
   const activeColor = theme.textInverse.val;
@@ -87,11 +85,12 @@ export function TabBarItem({
   if (variant === 'pill') {
     // When animatedPillIndicator is active, the sliding background is rendered
     // by AnimatedPillIndicator — items should be transparent so it shows through.
-    const pillBg = animatedPillIndicator
-      ? 'transparent'
-      : isFocused
-        ? '$bgPrimary'
-        : '$bgStrong';
+    let pillBg: string = '$bgStrong';
+    if (animatedPillIndicator) {
+      pillBg = 'transparent';
+    } else if (isFocused) {
+      pillBg = '$bgPrimary';
+    }
 
     const useAnimatedText =
       animatedPillIndicator &&
@@ -124,7 +123,6 @@ export function TabBarItem({
             name={name}
             index={tabIndex}
             indexDecimal={indexDecimal}
-            textSize={resolvedTextSize}
           />
         ) : (
           <SizableText
@@ -404,8 +402,7 @@ function AnimatedPillIndicator({
     itemsLayout.length !== countSV.value ||
     itemsLayout.some(
       (v, i) =>
-        leftEdgesSV.value[i] !== v.x ||
-        rightEdgesSV.value[i] !== v.x + v.width,
+        leftEdgesSV.value[i] !== v.x || rightEdgesSV.value[i] !== v.x + v.width,
     )
   ) {
     leftEdgesSV.value = itemsLayout.map((v) => v.x);

--- a/packages/components/src/composite/Tabs/TabBar.tsx
+++ b/packages/components/src/composite/Tabs/TabBar.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import Animated, {
   Extrapolation,
   interpolate,
@@ -39,15 +39,8 @@ export function TabBarItem({
   focusedTabStyle,
   variant = 'default',
   textSize,
-}: {
-  name: string;
-  isFocused: boolean;
-  onPress: (name: string) => void;
-  tabItemStyle?: IYStackProps;
-  focusedTabStyle?: IYStackProps;
-  variant?: ITabBarVariant;
-  textSize?: ISizableTextProps['size'];
-}) {
+  animatedPillIndicator,
+}: ITabBarItemProps) {
   const handlePress = useCallback(() => {
     onPress(name);
   }, [name, onPress]);
@@ -55,6 +48,13 @@ export function TabBarItem({
   const resolvedTextSize = textSize ?? '$bodyLgMedium';
 
   if (variant === 'pill') {
+    // When animatedPillIndicator is active, the sliding background is rendered
+    // by AnimatedPillIndicator — items should be transparent so it shows through.
+    const pillBg = animatedPillIndicator
+      ? 'transparent'
+      : isFocused
+        ? '$bgPrimary'
+        : '$bgStrong';
     return (
       <YStack
         ai="center"
@@ -62,12 +62,17 @@ export function TabBarItem({
         px="$3.5"
         py="$1.5"
         borderRadius="$full"
-        bg={isFocused ? '$bgPrimary' : '$bgStrong'}
-        hoverStyle={isFocused ? undefined : { bg: '$bgHover' }}
-        pressStyle={isFocused ? undefined : { bg: '$bgActive' }}
+        bg={pillBg}
+        hoverStyle={
+          isFocused || animatedPillIndicator ? undefined : { bg: '$bgHover' }
+        }
+        pressStyle={
+          isFocused || animatedPillIndicator ? undefined : { bg: '$bgActive' }
+        }
         key={name}
         onPress={handlePress}
         cursor="default"
+        zIndex={1}
         {...tabItemStyle}
         {...(isFocused ? focusedTabStyle : undefined)}
       >
@@ -374,6 +379,9 @@ export interface ITabBarItemProps {
   focusedTabStyle?: IYStackProps;
   variant?: ITabBarVariant;
   textSize?: ISizableTextProps['size'];
+  // When true, the pill background is handled by AnimatedPillIndicator,
+  // so TabBarItem should not render its own background color.
+  animatedPillIndicator?: boolean;
 }
 
 const PILL_GRADIENT_THRESHOLD = 2;
@@ -510,6 +518,11 @@ export function TabBar({
     !renderItem &&
     !textSize;
 
+  // Pill indicator (background slide) should animate even when renderItem is
+  // provided — only the text rendering needs the guard.
+  const useAnimatedPillIndicator =
+    !!indexDecimal && variant === 'pill' && !scrollable;
+
   const handleItemLayout = useCallback(
     (index: number, layout: IItemLayout) => {
       itemsLayoutRef.current.set(index, layout);
@@ -602,8 +615,9 @@ export function TabBar({
         />
       ));
     }
-    return tabNames.map((name, index) =>
-      renderItem ? (
+    return tabNames.map((name, index) => {
+      const hasAnimatedIndicator = useAnimatedPillIndicator && !!renderItem;
+      const itemNode = renderItem ? (
         renderItem(
           {
             name,
@@ -613,6 +627,7 @@ export function TabBar({
             focusedTabStyle,
             variant,
             textSize,
+            animatedPillIndicator: hasAnimatedIndicator,
           },
           index,
         )
@@ -627,11 +642,27 @@ export function TabBar({
           variant={variant}
           textSize={textSize}
         />
-      ),
-    );
+      );
+      // Wrap with onLayout to collect layout data for animated pill indicator
+      if (useAnimatedPillIndicator && renderItem) {
+        return (
+          <View
+            key={name}
+            onLayout={(e: LayoutChangeEvent) => {
+              const { x, width } = e.nativeEvent.layout;
+              handleItemLayout(index, { x, width });
+            }}
+          >
+            {itemNode}
+          </View>
+        );
+      }
+      return itemNode;
+    });
   }, [
     useAnimatedDefault,
     useAnimatedPill,
+    useAnimatedPillIndicator,
     indexDecimal,
     currentTab,
     focusedTabStyle,
@@ -644,7 +675,7 @@ export function TabBar({
     variant,
   ]);
   const pillIndicator = useMemo(() => {
-    if (!useAnimatedPill || !indexDecimal) {
+    if (!useAnimatedPillIndicator || !indexDecimal) {
       return null;
     }
     if (itemsLayout.length !== tabNames.length) {
@@ -656,7 +687,7 @@ export function TabBar({
         itemsLayout={itemsLayout}
       />
     );
-  }, [useAnimatedPill, indexDecimal, itemsLayout, tabNames.length]);
+  }, [useAnimatedPillIndicator, indexDecimal, itemsLayout, tabNames.length]);
 
   const content = useMemo(() => {
     if (scrollable) {

--- a/packages/components/src/composite/Tabs/TabBar.tsx
+++ b/packages/components/src/composite/Tabs/TabBar.tsx
@@ -322,6 +322,10 @@ function AnimatedPillIndicator({
   const theme = useTheme();
   const bgColor = theme.bgPrimary.val;
 
+  // Pre-compute left/right edge arrays for the jelly effect
+  const leftEdges = itemsLayout.map((v) => v.x);
+  const rightEdges = itemsLayout.map((v) => v.x + v.width);
+
   const animatedStyle = useAnimatedStyle(() => {
     if (itemsLayout.length < 2) {
       const first = itemsLayout[0];
@@ -329,20 +333,40 @@ function AnimatedPillIndicator({
         ? { transform: [{ translateX: first.x }], width: first.width }
         : {};
     }
-    const inputRange = itemsLayout.map((_, i) => i);
-    const translateX = interpolate(
-      indexDecimal.value,
-      inputRange,
-      itemsLayout.map((v) => v.x),
-      Extrapolation.CLAMP,
-    );
-    const width = interpolate(
-      indexDecimal.value,
-      inputRange,
-      itemsLayout.map((v) => v.width),
-      Extrapolation.CLAMP,
-    );
-    return { transform: [{ translateX }], width };
+
+    const decimal = indexDecimal.value;
+    const floorIdx = Math.floor(decimal);
+    const ceilIdx = Math.ceil(decimal);
+    const fraction = decimal - floorIdx;
+
+    // At rest on a tab — no jelly needed
+    if (floorIdx === ceilIdx || fraction === 0) {
+      const layout = itemsLayout[Math.min(floorIdx, itemsLayout.length - 1)];
+      return layout
+        ? { transform: [{ translateX: layout.x }], width: layout.width }
+        : {};
+    }
+
+    const safeFloor = Math.max(0, Math.min(floorIdx, itemsLayout.length - 1));
+    const safeCeil = Math.max(0, Math.min(ceilIdx, itemsLayout.length - 1));
+
+    const fromLeft = leftEdges[safeFloor];
+    const fromRight = rightEdges[safeFloor];
+    const toLeft = leftEdges[safeCeil];
+    const toRight = rightEdges[safeCeil];
+
+    // Jelly/elastic effect: leading edge moves faster, trailing edge lags.
+    // ease-out (t => 1 - (1-t)^2): accelerates early — used for leading edge
+    // ease-in  (t => t^2):          accelerates late  — used for trailing edge
+    const easeOut = 1 - (1 - fraction) * (1 - fraction);
+    const easeIn = fraction * fraction;
+
+    // Moving right (floor → ceil): right edge leads, left edge trails
+    // Moving left would be the reverse, but indexDecimal always has floor < ceil
+    const left = fromLeft + (toLeft - fromLeft) * easeIn;
+    const right = fromRight + (toRight - fromRight) * easeOut;
+
+    return { transform: [{ translateX: left }], width: right - left };
   });
 
   if (itemsLayout.length === 0) {

--- a/packages/components/src/composite/Tabs/TabBar.tsx
+++ b/packages/components/src/composite/Tabs/TabBar.tsx
@@ -32,6 +32,40 @@ type IItemLayout = { x: number; width: number };
 
 export type ITabBarVariant = 'default' | 'pill';
 
+function AnimatedPillText({
+  name,
+  index: tabIndex,
+  indexDecimal,
+  textSize,
+}: {
+  name: string;
+  index: number;
+  indexDecimal: SharedValue<number>;
+  textSize: ISizableTextProps['size'];
+}) {
+  const theme = useTheme();
+  const activeColor = theme.textInverse.val;
+  const inactiveColor = theme.text.val;
+
+  const animatedColorStyle = useAnimatedStyle(() => {
+    const color = interpolateColor(
+      indexDecimal.value,
+      [tabIndex - 1, tabIndex, tabIndex + 1],
+      [inactiveColor, activeColor, inactiveColor],
+    );
+    return { color };
+  });
+
+  return (
+    <Animated.Text
+      style={[animatedTextStyles.text, animatedColorStyle]}
+      numberOfLines={1}
+    >
+      {name}
+    </Animated.Text>
+  );
+}
+
 export function TabBarItem({
   name,
   isFocused,
@@ -41,6 +75,8 @@ export function TabBarItem({
   variant = 'default',
   textSize,
   animatedPillIndicator,
+  indexDecimal,
+  index: tabIndex,
 }: ITabBarItemProps) {
   const handlePress = useCallback(() => {
     onPress(name);
@@ -56,6 +92,12 @@ export function TabBarItem({
       : isFocused
         ? '$bgPrimary'
         : '$bgStrong';
+
+    const useAnimatedText =
+      animatedPillIndicator &&
+      indexDecimal !== undefined &&
+      tabIndex !== undefined;
+
     return (
       <YStack
         ai="center"
@@ -77,13 +119,22 @@ export function TabBarItem({
         {...tabItemStyle}
         {...(isFocused ? focusedTabStyle : undefined)}
       >
-        <SizableText
-          size={resolvedTextSize}
-          color={isFocused ? '$textInverse' : '$text'}
-          userSelect="none"
-        >
-          {name}
-        </SizableText>
+        {useAnimatedText ? (
+          <AnimatedPillText
+            name={name}
+            index={tabIndex}
+            indexDecimal={indexDecimal}
+            textSize={resolvedTextSize}
+          />
+        ) : (
+          <SizableText
+            size={resolvedTextSize}
+            color={isFocused ? '$textInverse' : '$text'}
+            userSelect="none"
+          >
+            {name}
+          </SizableText>
+        )}
       </YStack>
     );
   }
@@ -444,6 +495,9 @@ export interface ITabBarItemProps {
   // When true, the pill background is handled by AnimatedPillIndicator,
   // so TabBarItem should not render its own background color.
   animatedPillIndicator?: boolean;
+  // Provided when animatedPillIndicator is true for UI-thread text color.
+  indexDecimal?: SharedValue<number>;
+  index?: number;
 }
 
 const PILL_GRADIENT_THRESHOLD = 2;
@@ -690,6 +744,8 @@ export function TabBar({
             variant,
             textSize,
             animatedPillIndicator: hasAnimatedIndicator,
+            indexDecimal: hasAnimatedIndicator ? indexDecimal : undefined,
+            index: hasAnimatedIndicator ? index : undefined,
           },
           index,
         )

--- a/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
+++ b/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
@@ -338,7 +338,13 @@ function OuterTabPagerViewComponent({
       }
     });
     return () => cancelAnimationFrame(rafId);
-  }, [activePageIndex, outerPagerRef, marketTabsRef, earnTabsRef, earnBorrowPagerRef]);
+  }, [
+    activePageIndex,
+    outerPagerRef,
+    marketTabsRef,
+    earnTabsRef,
+    earnBorrowPagerRef,
+  ]);
 
   const marketPage = useMemo(
     () =>

--- a/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
+++ b/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
@@ -3,6 +3,12 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Freeze } from 'react-freeze';
 import { StyleSheet, View } from 'react-native';
 import PagerView from 'react-native-pager-view';
+import Animated, {
+  runOnJS,
+  useAnimatedRef,
+  useEvent,
+  useHandler,
+} from 'react-native-reanimated';
 
 import type { ITabContainerRef } from '@onekeyhq/components';
 import { Stack } from '@onekeyhq/components';
@@ -16,6 +22,10 @@ import type {
   PagerViewOnPageSelectedEvent,
 } from 'react-native-pager-view';
 import type { SharedValue } from 'react-native-reanimated';
+
+// --- AnimatedPagerView: enables worklet-based onPageScroll on the UI thread ---
+
+const AnimatedPagerView = Animated.createAnimatedComponent(PagerView);
 
 // --- Styles (defined before component to satisfy no-use-before-define) ---
 
@@ -41,6 +51,32 @@ const INDEX_TO_TAB: ETranslations[] = [
   ETranslations.global_earn,
   ETranslations.global_browser,
 ];
+
+// --- Worklet-based page scroll handler (same pattern as collapsible-tab-view) ---
+
+function usePageScrollHandler(
+  handlers: {
+    onPageScroll: (
+      event: PagerViewOnPageScrollEvent['nativeEvent'],
+      context: Record<string, unknown>
+    ) => void;
+  },
+  dependencies?: unknown[]
+) {
+  const { context, doDependenciesDiffer } = useHandler(handlers, dependencies);
+
+  return useEvent<PagerViewOnPageScrollEvent['nativeEvent']>(
+    (event) => {
+      'worklet';
+      const { onPageScroll } = handlers;
+      if (onPageScroll && event.eventName.endsWith('onPageScroll')) {
+        onPageScroll(event, context);
+      }
+    },
+    ['onPageScroll'],
+    doDependenciesDiffer,
+  );
+}
 
 // --- Types ---
 
@@ -70,7 +106,7 @@ function OuterTabPagerViewComponent({
   pageScrollPosition,
 }: IOuterTabPagerViewProps) {
   const initialPage = TAB_TO_INDEX[selectedHeaderTab] ?? 0;
-  const outerPagerRef = useRef<PagerView>(null);
+  const outerPagerRef = useAnimatedRef<PagerView>();
   const currentOuterIndexRef = useRef(initialPage);
   const [activePageIndex, setActivePageIndex] = useState(initialPage);
   const wasUserDragRef = useRef(false);
@@ -178,21 +214,10 @@ function OuterTabPagerViewComponent({
     [setTransitioning, setVisiblePair],
   );
 
-  // During horizontal swipe, pre-mount the neighbor page and keep only
-  // the current + target pages unfrozen to avoid black frames.
-  // IMPORTANT: Only run for user-gesture swipes, NOT programmatic setPage().
-  // When setPage() scrolls across a non-adjacent page (e.g. page 0 → 2),
-  // intermediate onPageScroll events would overwrite visiblePair from [0,2]
-  // to [0,1], freezing the target page mid-animation → white flash.
-  const handleOuterPageScroll = useCallback(
-    (e: PagerViewOnPageScrollEvent) => {
-      const { position, offset } = e.nativeEvent;
-
-      // Always update the shared scroll position for smooth header animation
-      if (pageScrollPosition) {
-        pageScrollPosition.value = position + offset;
-      }
-
+  // JS-thread handler for freeze/unfreeze logic during user-gesture swipes.
+  // Called from the worklet-based onPageScroll via runOnJS.
+  const handlePageScrollJS = useCallback(
+    (position: number, offset: number) => {
       if (!wasUserDragRef.current) {
         return;
       }
@@ -211,8 +236,24 @@ function OuterTabPagerViewComponent({
       setVisiblePair([position, nextPosition]);
       markPagesVisited([position, nextPosition]);
     },
-    [markPagesVisited, pageScrollPosition, setVisiblePair],
+    [markPagesVisited, setVisiblePair],
   );
+
+  // Worklet-based onPageScroll: updates pageScrollPosition on the UI thread
+  // with zero bridge overhead, then dispatches freeze logic to JS thread.
+  const pageScrollHandler = usePageScrollHandler({
+    onPageScroll: (e) => {
+      'worklet';
+      const position = e.position as number;
+      const offset = e.offset as number;
+
+      if (pageScrollPosition) {
+        pageScrollPosition.value = position + offset;
+      }
+
+      runOnJS(handlePageScrollJS)(position, offset);
+    },
+  });
 
   // --- PagerView -> Atom sync (gesture swiping) ---
   const handleOuterPageSelected = useCallback(
@@ -337,7 +378,7 @@ function OuterTabPagerViewComponent({
   );
 
   return (
-    <PagerView
+    <AnimatedPagerView
       ref={outerPagerRef}
       style={styles.pager}
       initialPage={initialPage}
@@ -345,14 +386,14 @@ function OuterTabPagerViewComponent({
       overdrag
       overScrollMode="always"
       offscreenPageLimit={1}
-      onPageScroll={handleOuterPageScroll}
+      onPageScroll={pageScrollHandler}
       onPageScrollStateChanged={handleOuterPageScrollStateChanged}
       onPageSelected={handleOuterPageSelected}
     >
       {marketPage}
       {earnPage}
       {browserPage}
-    </PagerView>
+    </AnimatedPagerView>
   );
 }
 

--- a/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
+++ b/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
@@ -62,11 +62,14 @@ function usePageScrollHandler(
     ) => void;
   },
   dependencies?: unknown[]
-) {
+): (event: PagerViewOnPageScrollEvent) => void {
   const { context, doDependenciesDiffer } = useHandler(handlers, dependencies);
 
-  return useEvent<PagerViewOnPageScrollEvent['nativeEvent']>(
-    (event) => {
+  // Reanimated's useEvent return type (EventHandlerProcessed) doesn't match
+  // AnimatedPagerView's onPageScroll prop (DirectEventHandler), but they are
+  // compatible at runtime — Reanimated intercepts the native event internally.
+  return useEvent(
+    (event: { eventName: string } & PagerViewOnPageScrollEvent['nativeEvent']) => {
       'worklet';
       const { onPageScroll } = handlers;
       if (onPageScroll && event.eventName.endsWith('onPageScroll')) {
@@ -75,7 +78,7 @@ function usePageScrollHandler(
     },
     ['onPageScroll'],
     doDependenciesDiffer,
-  );
+  ) as unknown as (event: PagerViewOnPageScrollEvent) => void;
 }
 
 // --- Types ---

--- a/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
+++ b/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
@@ -58,10 +58,10 @@ function usePageScrollHandler(
   handlers: {
     onPageScroll: (
       event: PagerViewOnPageScrollEvent['nativeEvent'],
-      context: Record<string, unknown>
+      context: Record<string, unknown>,
     ) => void;
   },
-  dependencies?: unknown[]
+  dependencies?: unknown[],
 ): (event: PagerViewOnPageScrollEvent) => void {
   const { context, doDependenciesDiffer } = useHandler(handlers, dependencies);
 
@@ -69,7 +69,9 @@ function usePageScrollHandler(
   // AnimatedPagerView's onPageScroll prop (DirectEventHandler), but they are
   // compatible at runtime — Reanimated intercepts the native event internally.
   return useEvent(
-    (event: { eventName: string } & PagerViewOnPageScrollEvent['nativeEvent']) => {
+    (
+      event: { eventName: string } & PagerViewOnPageScrollEvent['nativeEvent'],
+    ) => {
       'worklet';
       const { onPageScroll } = handlers;
       if (onPageScroll && event.eventName.endsWith('onPageScroll')) {
@@ -247,8 +249,8 @@ function OuterTabPagerViewComponent({
   const pageScrollHandler = usePageScrollHandler({
     onPageScroll: (e) => {
       'worklet';
-      const position = e.position as number;
-      const offset = e.offset as number;
+      const position = e.position;
+      const offset = e.offset;
 
       if (pageScrollPosition) {
         pageScrollPosition.value = position + offset;
@@ -336,6 +338,7 @@ function OuterTabPagerViewComponent({
       }
     });
     return () => cancelAnimationFrame(rafId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activePageIndex, marketTabsRef, earnTabsRef, earnBorrowPagerRef]);
 
   const marketPage = useMemo(

--- a/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
+++ b/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
@@ -338,8 +338,7 @@ function OuterTabPagerViewComponent({
       }
     });
     return () => cancelAnimationFrame(rafId);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activePageIndex, marketTabsRef, earnTabsRef, earnBorrowPagerRef]);
+  }, [activePageIndex, outerPagerRef, marketTabsRef, earnTabsRef, earnBorrowPagerRef]);
 
   const marketPage = useMemo(
     () =>

--- a/packages/kit/src/views/Discovery/hooks/useMobileBottomBarAnimation.ts
+++ b/packages/kit/src/views/Discovery/hooks/useMobileBottomBarAnimation.ts
@@ -32,11 +32,7 @@ function useMobileBottomBarAnimation(activeTabId: string | null) {
   // WebView onScroll is JS-thread only, so we extract numeric values in JS
   // and dispatch via runOnUI to avoid an extra JS→UI hop for withTiming.
   const processScroll = useCallback(
-    (
-      contentOffsetY: number,
-      canScroll: boolean,
-      isOutOfBounds: boolean,
-    ) => {
+    (contentOffsetY: number, canScroll: boolean, isOutOfBounds: boolean) => {
       'worklet';
       if (isOutOfBounds) {
         lastScrollY.value = UNSET;

--- a/packages/kit/src/views/Discovery/hooks/useMobileBottomBarAnimation.ts
+++ b/packages/kit/src/views/Discovery/hooks/useMobileBottomBarAnimation.ts
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import {
+  runOnUI,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
@@ -16,61 +17,53 @@ import {
   MIN_TOGGLE_BROWSER_VISIBLE_DISTANCE,
 } from '../config/Animation.constants';
 
+// Sentinel for "undefined" in SharedValue (SharedValue<number> can't hold undefined)
+const UNSET = -1;
+
 function useMobileBottomBarAnimation(activeTabId: string | null) {
   const { bottom: bottomInset } = useSafeAreaInsets();
   const fullBarHeight = BROWSER_BOTTOM_BAR_HEIGHT + bottomInset;
   const toolbarHeight = useSharedValue(fullBarHeight);
   const toolbarOpacity = useSharedValue(MAX_OPACITY_BOTTOM_BAR);
-  const lastScrollY = useRef<number | undefined>(undefined);
-  const lastTurnScrollY = useRef<number | undefined>(undefined);
+  const lastScrollY = useSharedValue(UNSET);
+  const lastTurnScrollY = useSharedValue(UNSET);
 
-  const handleScroll = useCallback(
-    ({ nativeEvent }: IWebViewOnScrollEvent) => {
-      const { contentOffset, contentSize, contentInset, layoutMeasurement } =
-        nativeEvent;
-      const contentOffsetY = contentOffset.y;
-      if (
-        contentOffsetY < 0 ||
-        Math.round(contentOffsetY) >
-          Math.round(
-            contentSize.height -
-              (layoutMeasurement.height +
-                contentInset.top +
-                contentInset.bottom),
-          )
-      ) {
-        lastScrollY.current = undefined;
-        lastTurnScrollY.current = undefined;
+  // Direction detection + SharedValue writes run entirely on UI thread.
+  // WebView onScroll is JS-thread only, so we extract numeric values in JS
+  // and dispatch via runOnUI to avoid an extra JS→UI hop for withTiming.
+  const processScroll = useCallback(
+    (
+      contentOffsetY: number,
+      canScroll: boolean,
+      isOutOfBounds: boolean,
+    ) => {
+      'worklet';
+      if (isOutOfBounds) {
+        lastScrollY.value = UNSET;
+        lastTurnScrollY.value = UNSET;
         return;
       }
-      const webViewCanScroll =
-        Math.round(contentSize.height) >
-        Math.round(
-          layoutMeasurement.height + contentInset.top + contentInset.bottom,
-        ) +
-          MIN_TOGGLE_BROWSER_VISIBLE_DISTANCE +
-          fullBarHeight;
 
-      if (!webViewCanScroll) {
+      if (!canScroll) {
         toolbarHeight.value = withTiming(fullBarHeight);
         toolbarOpacity.value = withTiming(MAX_OPACITY_BOTTOM_BAR);
         return;
       }
 
       if (
-        lastScrollY.current === undefined ||
-        lastTurnScrollY.current === undefined ||
-        (contentOffsetY - lastScrollY.current) *
-          (lastScrollY.current - lastTurnScrollY.current) <
+        lastScrollY.value === UNSET ||
+        lastTurnScrollY.value === UNSET ||
+        (contentOffsetY - lastScrollY.value) *
+          (lastScrollY.value - lastTurnScrollY.value) <
           0
       ) {
-        lastTurnScrollY.current = lastScrollY.current;
+        lastTurnScrollY.value = lastScrollY.value;
       }
-      lastScrollY.current = contentOffsetY;
-      if (lastTurnScrollY.current === undefined) {
+      lastScrollY.value = contentOffsetY;
+      if (lastTurnScrollY.value === UNSET) {
         return;
       }
-      const distanceOffsetY = contentOffsetY - lastTurnScrollY.current;
+      const distanceOffsetY = contentOffsetY - lastTurnScrollY.value;
       if (Math.abs(distanceOffsetY) <= MIN_TOGGLE_BROWSER_VISIBLE_DISTANCE) {
         return;
       }
@@ -78,13 +71,44 @@ function useMobileBottomBarAnimation(activeTabId: string | null) {
 
       toolbarHeight.value = withTiming(height, {
         duration: DISPLAY_BOTTOM_BAR_DURATION,
-      }); // No gradual animation
+      });
       toolbarOpacity.value = withTiming(height / fullBarHeight, {
         duration: DISPLAY_BOTTOM_BAR_DURATION,
-      }); // No gradual animation
+      });
     },
-    [toolbarHeight, toolbarOpacity, fullBarHeight],
+    [
+      fullBarHeight,
+      lastScrollY,
+      lastTurnScrollY,
+      toolbarHeight,
+      toolbarOpacity,
+    ],
   );
+
+  const handleScroll = useCallback(
+    ({ nativeEvent }: IWebViewOnScrollEvent) => {
+      const { contentOffset, contentSize, contentInset, layoutMeasurement } =
+        nativeEvent;
+      const contentOffsetY = contentOffset.y;
+      const scrollableHeight =
+        contentSize.height -
+        (layoutMeasurement.height + contentInset.top + contentInset.bottom);
+      const isOutOfBounds =
+        contentOffsetY < 0 ||
+        Math.round(contentOffsetY) > Math.round(scrollableHeight);
+      const canScroll =
+        Math.round(contentSize.height) >
+        Math.round(
+          layoutMeasurement.height + contentInset.top + contentInset.bottom,
+        ) +
+          MIN_TOGGLE_BROWSER_VISIBLE_DISTANCE +
+          fullBarHeight;
+
+      runOnUI(processScroll)(contentOffsetY, canScroll, isOutOfBounds);
+    },
+    [fullBarHeight, processScroll],
+  );
+
   const toolbarAnimatedStyle = useAnimatedStyle(() => ({
     height: toolbarHeight.value,
     opacity: toolbarOpacity.value,
@@ -94,8 +118,11 @@ function useMobileBottomBarAnimation(activeTabId: string | null) {
   useEffect(() => {
     toolbarHeight.value = withTiming(fullBarHeight);
     toolbarOpacity.value = withTiming(MAX_OPACITY_BOTTOM_BAR);
-    lastScrollY.current = undefined;
-    lastTurnScrollY.current = undefined;
+    runOnUI(() => {
+      'worklet';
+      lastScrollY.value = UNSET;
+      lastTurnScrollY.value = UNSET;
+    })();
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTabId, fullBarHeight]);

--- a/packages/kit/src/views/Earn/components/EarnBorrowPagerView.native.tsx
+++ b/packages/kit/src/views/Earn/components/EarnBorrowPagerView.native.tsx
@@ -9,6 +9,11 @@ import {
 
 import { StyleSheet, View } from 'react-native';
 import PagerView from 'react-native-pager-view';
+import Animated, {
+  useAnimatedRef,
+  useEvent,
+  useHandler,
+} from 'react-native-reanimated';
 
 import type { IEarnHomeMode } from './MarketSelector';
 import type {
@@ -17,6 +22,10 @@ import type {
   PagerViewOnPageSelectedEvent,
 } from 'react-native-pager-view';
 import type { SharedValue } from 'react-native-reanimated';
+
+// --- AnimatedPagerView: enables worklet-based onPageScroll on the UI thread ---
+
+const AnimatedPagerView = Animated.createAnimatedComponent(PagerView);
 
 // --- Styles ---
 
@@ -32,6 +41,32 @@ const MODE_TO_INDEX: Record<IEarnHomeMode, number> = {
   borrow: 1,
 };
 const INDEX_TO_MODE: IEarnHomeMode[] = ['earn', 'borrow'];
+
+// --- Worklet-based page scroll handler (same pattern as collapsible-tab-view) ---
+
+function usePageScrollHandler(
+  handlers: {
+    onPageScroll: (
+      event: PagerViewOnPageScrollEvent['nativeEvent'],
+      context: Record<string, unknown>
+    ) => void;
+  },
+  dependencies?: unknown[]
+) {
+  const { context, doDependenciesDiffer } = useHandler(handlers, dependencies);
+
+  return useEvent<PagerViewOnPageScrollEvent['nativeEvent']>(
+    (event) => {
+      'worklet';
+      const { onPageScroll } = handlers;
+      if (onPageScroll && event.eventName.endsWith('onPageScroll')) {
+        onPageScroll(event, context);
+      }
+    },
+    ['onPageScroll'],
+    doDependenciesDiffer,
+  );
+}
 
 // --- Types ---
 
@@ -59,7 +94,7 @@ function EarnBorrowPagerViewComponent(
   }: IEarnBorrowPagerViewProps,
   ref: React.Ref<IEarnBorrowPagerViewRef>,
 ) {
-  const pagerRef = useRef<PagerView>(null);
+  const pagerRef = useAnimatedRef<PagerView>();
   const currentIndexRef = useRef(MODE_TO_INDEX[mode]);
   const modeRef = useRef(mode);
   modeRef.current = mode;
@@ -105,16 +140,16 @@ function EarnBorrowPagerViewComponent(
     [],
   );
 
-  // Sync scroll position to shared value for animated tab indicator
-  const handlePageScroll = useCallback(
-    (e: PagerViewOnPageScrollEvent) => {
+  // Worklet-based onPageScroll: updates pageScrollPosition on the UI thread
+  // with zero bridge overhead for smooth animated tab indicator.
+  const pageScrollHandler = usePageScrollHandler({
+    onPageScroll: (e) => {
+      'worklet';
       if (pageScrollPosition) {
-        pageScrollPosition.value =
-          e.nativeEvent.position + e.nativeEvent.offset;
+        pageScrollPosition.value = (e.position as number) + (e.offset as number);
       }
     },
-    [pageScrollPosition],
-  );
+  });
 
   // PagerView -> mode sync (gesture swiping only)
   const handlePageSelected = useCallback(
@@ -136,7 +171,7 @@ function EarnBorrowPagerViewComponent(
   );
 
   return (
-    <PagerView
+    <AnimatedPagerView
       ref={pagerRef}
       style={styles.pager}
       initialPage={MODE_TO_INDEX[mode]}
@@ -144,7 +179,7 @@ function EarnBorrowPagerViewComponent(
       overScrollMode="never"
       nestedScrollEnabled
       scrollSensitivity={4}
-      onPageScroll={handlePageScroll}
+      onPageScroll={pageScrollHandler}
       onPageScrollStateChanged={handlePageScrollStateChanged}
       onPageSelected={handlePageSelected}
     >
@@ -154,7 +189,7 @@ function EarnBorrowPagerViewComponent(
       <View key="borrow" style={styles.page}>
         {borrowContent}
       </View>
-    </PagerView>
+    </AnimatedPagerView>
   );
 }
 

--- a/packages/kit/src/views/Earn/components/EarnBorrowPagerView.native.tsx
+++ b/packages/kit/src/views/Earn/components/EarnBorrowPagerView.native.tsx
@@ -48,10 +48,10 @@ function usePageScrollHandler(
   handlers: {
     onPageScroll: (
       event: PagerViewOnPageScrollEvent['nativeEvent'],
-      context: Record<string, unknown>
+      context: Record<string, unknown>,
     ) => void;
   },
-  dependencies?: unknown[]
+  dependencies?: unknown[],
 ): (event: PagerViewOnPageScrollEvent) => void {
   const { context, doDependenciesDiffer } = useHandler(handlers, dependencies);
 
@@ -59,7 +59,9 @@ function usePageScrollHandler(
   // AnimatedPagerView's onPageScroll prop (DirectEventHandler), but they are
   // compatible at runtime — Reanimated intercepts the native event internally.
   return useEvent(
-    (event: { eventName: string } & PagerViewOnPageScrollEvent['nativeEvent']) => {
+    (
+      event: { eventName: string } & PagerViewOnPageScrollEvent['nativeEvent'],
+    ) => {
       'worklet';
       const { onPageScroll } = handlers;
       if (onPageScroll && event.eventName.endsWith('onPageScroll')) {
@@ -126,6 +128,7 @@ function EarnBorrowPagerViewComponent(
       pagerRef.current?.setPage(index);
       currentIndexRef.current = index;
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode]);
 
   // Track drag state: 'dragging' → wasUserDrag=true, 'idle' → wasUserDrag=false.
@@ -149,7 +152,8 @@ function EarnBorrowPagerViewComponent(
     onPageScroll: (e) => {
       'worklet';
       if (pageScrollPosition) {
-        pageScrollPosition.value = (e.position as number) + (e.offset as number);
+        pageScrollPosition.value =
+          (e.position) + (e.offset);
       }
     },
   });

--- a/packages/kit/src/views/Earn/components/EarnBorrowPagerView.native.tsx
+++ b/packages/kit/src/views/Earn/components/EarnBorrowPagerView.native.tsx
@@ -52,11 +52,14 @@ function usePageScrollHandler(
     ) => void;
   },
   dependencies?: unknown[]
-) {
+): (event: PagerViewOnPageScrollEvent) => void {
   const { context, doDependenciesDiffer } = useHandler(handlers, dependencies);
 
-  return useEvent<PagerViewOnPageScrollEvent['nativeEvent']>(
-    (event) => {
+  // Reanimated's useEvent return type (EventHandlerProcessed) doesn't match
+  // AnimatedPagerView's onPageScroll prop (DirectEventHandler), but they are
+  // compatible at runtime — Reanimated intercepts the native event internally.
+  return useEvent(
+    (event: { eventName: string } & PagerViewOnPageScrollEvent['nativeEvent']) => {
       'worklet';
       const { onPageScroll } = handlers;
       if (onPageScroll && event.eventName.endsWith('onPageScroll')) {
@@ -65,7 +68,7 @@ function usePageScrollHandler(
     },
     ['onPageScroll'],
     doDependenciesDiffer,
-  );
+  ) as unknown as (event: PagerViewOnPageScrollEvent) => void;
 }
 
 // --- Types ---

--- a/packages/kit/src/views/Earn/components/EarnBorrowPagerView.native.tsx
+++ b/packages/kit/src/views/Earn/components/EarnBorrowPagerView.native.tsx
@@ -151,8 +151,7 @@ function EarnBorrowPagerViewComponent(
     onPageScroll: (e) => {
       'worklet';
       if (pageScrollPosition) {
-        pageScrollPosition.value =
-          (e.position) + (e.offset);
+        pageScrollPosition.value = e.position + e.offset;
       }
     },
   });

--- a/packages/kit/src/views/Earn/components/EarnBorrowPagerView.native.tsx
+++ b/packages/kit/src/views/Earn/components/EarnBorrowPagerView.native.tsx
@@ -128,8 +128,7 @@ function EarnBorrowPagerViewComponent(
       pagerRef.current?.setPage(index);
       currentIndexRef.current = index;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mode]);
+  }, [mode, pagerRef]);
 
   // Track drag state: 'dragging' → wasUserDrag=true, 'idle' → wasUserDrag=false.
   // A user swipe sequence is: dragging → settling → onPageSelected → idle.


### PR DESCRIPTION
## Summary
- **OuterTabPagerView** (市场/DeFi/浏览器): Replace plain `PagerView` with `AnimatedPagerView` + worklet-based `usePageScrollHandler`, so `pageScrollPosition` updates happen entirely on the UI thread
- **EarnBorrowPagerView** (赚币/借币): Same optimization — `AnimatedPagerView` + worklet
- **useMobileBottomBarAnimation** (浏览器底部工具栏): Move direction detection logic and SharedValue writes to UI thread via `runOnUI`

### Before
```
Native onPageScroll → Bridge → JS Thread → SharedValue → UI Thread → useAnimatedStyle
(1-2 frame lag)
```

### After
```
Native onPageScroll → UI Thread worklet → SharedValue → useAnimatedStyle
(0 frame lag, same pattern as react-native-collapsible-tab-view)
```

## Test plan
- [ ] Swipe between Market/DeFi/Browser tabs — header text color animation should be smoother
- [ ] Swipe between Earn/Borrow tabs — tab indicator animation should be smoother
- [ ] Tap header tabs (programmatic switch) — should still work correctly
- [ ] Scroll in browser WebView — bottom bar should still show/hide correctly
- [ ] Test on both iOS and Android
- [ ] Verify freeze/unfreeze logic still works (no white flash when switching tabs)