### PR TITLE
fix(market): add missing display props to watchlist edit dialog(OK-51972)

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/useOpenMarketWatchlistEditDialog.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/useOpenMarketWatchlistEditDialog.tsx
@@ -158,8 +158,12 @@ function MarketWatchlistEditDialogContent({
                 networkId={item.networkId}
                 symbol={item.symbol}
                 address={item.address}
+                showVolume
+                volume={item.turnover}
                 communityRecognized={item.communityRecognized}
                 stock={item.stock}
+                maxLeverage={item.maxLeverage}
+                perpsSubtitle={item.perpsSubtitle}
               />
             </YStack>
             <XStack gap="$1">


### PR DESCRIPTION
## Summary
- Add missing `showVolume`, `volume`, `maxLeverage`, and `perpsSubtitle` props to `TokenIdentityItem` in the watchlist edit dialog
- Aligns the edit dialog display with the normal watchlist list view

## Intent & Context
The watchlist edit dialog (introduced in OK-51778) rendered `TokenIdentityItem` with incomplete props, causing two visual inconsistencies:
1. **Perpetual/Contract watchlist**: Missing tags (e.g., "Tech", "Pre-IPO") and trading volume
2. **Spot watchlist**: Showing raw contract addresses instead of trading volume

## Root Cause
When the edit dialog was created, `TokenIdentityItem` was only given basic identity props (symbol, address, logo). The display-related props (`showVolume`, `volume`, `maxLeverage`, `perpsSubtitle`) were omitted.

Inside `TokenIdentityItem`, when `showVolume` is falsy, it falls back to showing the contract address (`shouldShowAddress = !showVolume && Boolean(address)`). This caused spot tokens to display their contract address instead of volume in the edit list.

## Changes Detail
- `useOpenMarketWatchlistEditDialog.tsx`: Added 4 missing props to `TokenIdentityItem` to match the normal list rendering in `TokenListItem.tsx`

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile / Desktop / Web / Extension (all platforms with the edit dialog)
- **Risk Areas**: Purely additive prop changes; no logic or data flow modifications

## Test plan
- [ ] Open Market → Watchlist tab with spot tokens → Open edit dialog → Verify volume is shown (not contract address)
- [ ] Open Market → Watchlist tab with perpetual/contract tokens → Open edit dialog → Verify leverage badge and category tags are shown
- [ ] Verify edit dialog drag-to-reorder and remove still work correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
