### PR TITLE
fix: unify market token tags popover across detail page and search results

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx
@@ -137,26 +137,20 @@ export function TokenDetailHeaderLeft({
               {symbol}
             </SizableText>
             {md ? (
-              <>
-                <TokenTagsPopover
-                  communityRecognized={communityRecognized}
-                  stock={stock}
-                />
-                {stock?.subtitle ? (
-                  <SubtitleBadge subtitle={stock.subtitle} />
-                ) : null}
-                {stock ? <StockIsOpenBadge stock={stock} /> : null}
-              </>
+              <TokenTagsPopover
+                communityRecognized={communityRecognized}
+                stock={stock}
+              />
             ) : (
               <>
                 <StockSourceLogo stock={stock} />
                 {communityRecognized ? <CommunityRecognizedBadge /> : null}
-                {stock?.subtitle ? (
-                  <SubtitleBadge subtitle={stock.subtitle} />
-                ) : null}
-                {stock ? <StockIsOpenBadge stock={stock} /> : null}
               </>
             )}
+            {stock?.subtitle ? (
+              <SubtitleBadge subtitle={stock.subtitle} />
+            ) : null}
+            {stock ? <StockIsOpenBadge stock={stock} /> : null}
           </XStack>
 
           <XStack gap="$2" ai="center">

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx
@@ -25,6 +25,7 @@ import {
   StockSourceLogo,
   SubtitleBadge,
 } from '../../../components/PerpsBadges';
+import { TokenTagsPopover } from '../../../components/TokenTagsPopover';
 import { TokenSecurityAlert } from '../TokenSecurityAlert';
 
 import { useTokenDetailHeaderLeftActions } from './hooks/useTokenDetailHeaderLeftActions';
@@ -135,12 +136,27 @@ export function TokenDetailHeaderLeft({
             >
               {symbol}
             </SizableText>
-            <StockSourceLogo stock={stock} />
-            {communityRecognized ? <CommunityRecognizedBadge /> : null}
-            {stock?.subtitle ? (
-              <SubtitleBadge subtitle={stock.subtitle} />
-            ) : null}
-            {stock ? <StockIsOpenBadge stock={stock} /> : null}
+            {md ? (
+              <>
+                <TokenTagsPopover
+                  communityRecognized={communityRecognized}
+                  stock={stock}
+                />
+                {stock?.subtitle ? (
+                  <SubtitleBadge subtitle={stock.subtitle} />
+                ) : null}
+                {stock ? <StockIsOpenBadge stock={stock} /> : null}
+              </>
+            ) : (
+              <>
+                <StockSourceLogo stock={stock} />
+                {communityRecognized ? <CommunityRecognizedBadge /> : null}
+                {stock?.subtitle ? (
+                  <SubtitleBadge subtitle={stock.subtitle} />
+                ) : null}
+                {stock ? <StockIsOpenBadge stock={stock} /> : null}
+              </>
+            )}
           </XStack>
 
           <XStack gap="$2" ai="center">

--- a/packages/kit/src/views/Market/components/TokenTagsPopover.tsx
+++ b/packages/kit/src/views/Market/components/TokenTagsPopover.tsx
@@ -86,12 +86,19 @@ function TokenTagsPopover({
             ) : null}
             {hasStockSource ? (
               <XStack alignItems="center" gap="$3">
-                <Image
-                  width={24}
-                  height={24}
-                  borderRadius="$full"
-                  source={{ uri: stock.sourceLogoUri }}
-                />
+                <Stack
+                  width="$6"
+                  height="$6"
+                  alignItems="center"
+                  justifyContent="center"
+                >
+                  <Image
+                    width={20}
+                    height={20}
+                    borderRadius="$full"
+                    source={{ uri: stock.sourceLogoUri }}
+                  />
+                </Stack>
                 <SizableText size="$bodyLgMedium" flex={1} flexWrap="wrap">
                   {stockLabelId
                     ? intl.formatMessage({ id: stockLabelId })

--- a/packages/kit/src/views/Market/components/TokenTagsPopover.tsx
+++ b/packages/kit/src/views/Market/components/TokenTagsPopover.tsx
@@ -16,6 +16,10 @@ import type { IMarketStockInfo } from '@onekeyhq/shared/types/marketV2';
 
 import type { GestureResponderEvent } from 'react-native';
 
+const handlePress = (e: GestureResponderEvent) => {
+  e.stopPropagation();
+};
+
 interface ITokenTagsPopoverProps {
   communityRecognized?: boolean;
   stock?: IMarketStockInfo;
@@ -57,10 +61,6 @@ function TokenTagsPopover({
       ) : null}
     </XStack>
   );
-
-  const handlePress = (e: GestureResponderEvent) => {
-    e.stopPropagation();
-  };
 
   return (
     <Stack onPress={handlePress}>

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
@@ -308,21 +308,16 @@ export function UniversalSearchV2MarketTokenItem({
                 <>
                   <StockSourceLogo stock={stock} />
                   {communityRecognized ? <CommunityRecognizedBadge /> : null}
-                  {stock?.subtitle ? (
-                    <SubtitleBadge subtitle={stock.subtitle} />
-                  ) : null}
                 </>
               ) : (
-                <>
-                  <TokenTagsPopover
-                    communityRecognized={communityRecognized}
-                    stock={stock}
-                  />
-                  {stock?.subtitle ? (
-                    <SubtitleBadge subtitle={stock.subtitle} />
-                  ) : null}
-                </>
+                <TokenTagsPopover
+                  communityRecognized={communityRecognized}
+                  stock={stock}
+                />
               )}
+              {stock?.subtitle ? (
+                <SubtitleBadge subtitle={stock.subtitle} />
+              ) : null}
             </XStack>
             <XStack ai="center" gap="$0.5" minWidth={0}>
               {name ? (

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
@@ -22,6 +22,7 @@ import {
   StockSourceLogo,
   SubtitleBadge,
 } from '@onekeyhq/kit/src/views/Market/components/PerpsBadges';
+import { TokenTagsPopover } from '@onekeyhq/kit/src/views/Market/components/TokenTagsPopover';
 import { useToDetailPage } from '@onekeyhq/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useToMarketDetailPage';
 import { ETranslations } from '@onekeyhq/shared/src/locale/enum/translations';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
@@ -303,11 +304,25 @@ export function UniversalSearchV2MarketTokenItem({
               >
                 {formatTokenSymbolForDisplay(symbol)}
               </SizableText>
-              <StockSourceLogo stock={stock} />
-              {communityRecognized ? <CommunityRecognizedBadge /> : null}
-              {stock?.subtitle ? (
-                <SubtitleBadge subtitle={stock.subtitle} />
-              ) : null}
+              {gtMd ? (
+                <>
+                  <StockSourceLogo stock={stock} />
+                  {communityRecognized ? <CommunityRecognizedBadge /> : null}
+                  {stock?.subtitle ? (
+                    <SubtitleBadge subtitle={stock.subtitle} />
+                  ) : null}
+                </>
+              ) : (
+                <>
+                  <TokenTagsPopover
+                    communityRecognized={communityRecognized}
+                    stock={stock}
+                  />
+                  {stock?.subtitle ? (
+                    <SubtitleBadge subtitle={stock.subtitle} />
+                  ) : null}
+                </>
+              )}
             </XStack>
             <XStack ai="center" gap="$0.5" minWidth={0}>
               {name ? (


### PR DESCRIPTION
https://onekeyhq.atlassian.net/browse/OK-51975
## Summary
- Use `TokenTagsPopover` on mobile for token detail header and search results to match the watchlist behavior, showing the "标签" title with detailed badge descriptions
- Fix stock source logo (e.g. Ondo) size in popover content to visually align with the community recognized icon
- Desktop behavior remains unchanged (individual badges with tooltips)

## Changes
- `TokenDetailHeaderLeft.tsx`: Use `TokenTagsPopover` when `md` (mobile), individual badges otherwise
- `UniversalSearchV2MarketTokenItem.tsx`: Use `TokenTagsPopover` when `!gtMd` (mobile), individual badges otherwise
- `TokenTagsPopover.tsx`: Wrap stock source image in a `$6` container with 20px image to match `Icon` visual weight

## Test plan
- [ ] Open Market watchlist, tap token badges → verify "标签" popover shows correctly
- [ ] Open token detail page, tap token badges → verify same "标签" popover format
- [ ] Open search, search for a token with badges → verify same "标签" popover format
- [ ] On desktop, verify individual badges with tooltips still work as before
- [ ] Verify Ondo logo size matches community recognized icon in popover
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
