### PR TITLE
fix: prevent false rollback to builtin when jsBundleCount > 0

### DIFF
--- a/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/MainApplication.java
+++ b/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/MainApplication.java
@@ -124,6 +124,8 @@ public class MainApplication extends Application implements ReactApplication {
       DefaultNewArchitectureEntryPoint.load();
     }
 
+    OneKeyLog.info("BootRecovery", "boot_fail_count: " + oldCount + " -> " + newCount + ", shouldShowRecovery: " + shouldShowRecovery);
+
     if (shouldShowRecovery) {
         // Skip heavy initialization (React Native, Expo, JPush).
         // RecoveryActivity is a plain Android Activity and doesn't need them.

--- a/apps/mobile/ios/AppDelegate.swift
+++ b/apps/mobile/ios/AppDelegate.swift
@@ -55,6 +55,8 @@ public class AppDelegate: ExpoAppDelegate {
     defaults.set(newCount, forKey: BootRecoveryKeys.consecutiveBootFailCount)
     defaults.synchronize()
 
+    NitroModuleBridge.logInfo("BootRecovery", "boot_fail_count: \(oldCount) -> \(newCount), shouldShowRecovery: \(newCount >= 3)")
+
     if newCount >= 3 {
       // Skip super.application() and React Native initialization entirely.
       // Create our own window — this replaces the system launch storyboard.

--- a/packages/kit-bg/src/desktopApis/DesktopApiBundleUpdate.ts
+++ b/packages/kit-bg/src/desktopApis/DesktopApiBundleUpdate.ts
@@ -825,13 +825,15 @@ class DesktopApiAppBundleUpdate {
     updateBundleData: IDesktopStoreUpdateBundleData,
   ) {
     store.setUpdateBundleData(updateBundleData);
-    // Destroy window first to ensure renderer process is fully terminated
-    // before relaunch, preventing webview custom element double registration
-    this.getMainWindow()?.destroy();
-    if (!process.mas) {
-      app.relaunch();
+    if (updateBundleData.appVersion && updateBundleData.bundleVersion) {
+      // Destroy window first to ensure renderer process is fully terminated
+      // before relaunch, preventing webview custom element double registration
+      this.getMainWindow()?.destroy();
+      if (!process.mas) {
+        app.relaunch();
+      }
+      app.exit(0);
     }
-    app.exit(0);
   }
 
   async clearBundleExtract() {

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -1080,9 +1080,13 @@ class ServiceAppUpdate extends ServiceBase {
       } catch {
         // ignore — default to false
       }
-      // jsBundleCount > 0 means bundles exist on server but none newer
-      // than what the client has (server filtered via $ne query).
-      // Don't treat absent jsBundleVersion as a rollback signal.
+      // When the server finds appVersion and bundleVersion match the
+      // client's current versions, it returns a response like:
+      //   { version: "5.x.x", jsBundleCount: 3, jsBundleVersion: undefined }
+      // jsBundleCount > 0 indicates bundles exist on server, but
+      // jsBundleVersion is omitted (no newer bundle available).
+      // In this case, don't treat the absent jsBundleVersion as a
+      // rollback signal — the client is already on the latest bundle.
       if (
         typeof releaseInfo?.jsBundleCount === 'number' &&
         releaseInfo.jsBundleCount > 0 &&

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -1085,7 +1085,8 @@ class ServiceAppUpdate extends ServiceBase {
       // Don't treat absent jsBundleVersion as a rollback signal.
       if (
         typeof releaseInfo?.jsBundleCount === 'number' &&
-        releaseInfo.jsBundleCount > 0
+        releaseInfo.jsBundleCount > 0 &&
+        !releaseInfo.jsBundleVersion
       ) {
         hasActiveCustomBundle = false;
       }

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -1085,8 +1085,7 @@ class ServiceAppUpdate extends ServiceBase {
       // Don't treat absent jsBundleVersion as a rollback signal.
       if (
         typeof releaseInfo?.jsBundleCount === 'number' &&
-        releaseInfo.jsBundleCount > 0 &&
-        !releaseInfo.jsBundleVersion
+        releaseInfo.jsBundleCount > 0
       ) {
         hasActiveCustomBundle = false;
       }

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -1080,6 +1080,16 @@ class ServiceAppUpdate extends ServiceBase {
       } catch {
         // ignore — default to false
       }
+      // jsBundleCount > 0 means bundles exist on server but none newer
+      // than what the client has (server filtered via $ne query).
+      // Don't treat absent jsBundleVersion as a rollback signal.
+      if (
+        typeof releaseInfo?.jsBundleCount === 'number' &&
+        releaseInfo.jsBundleCount > 0 &&
+        !releaseInfo.jsBundleVersion
+      ) {
+        hasActiveCustomBundle = false;
+      }
       const decision = resolveUpdateDecision({
         currentAppVersion: platformEnv.version,
         currentBundleVersion: platformEnv.bundleVersion,

--- a/packages/kit-bg/src/services/servicePendingInstallTask.ts
+++ b/packages/kit-bg/src/services/servicePendingInstallTask.ts
@@ -934,11 +934,11 @@ class ServicePendingInstallTask {
         await BundleUpdate.resetToBuiltInBundle();
         // switchBundle triggers app.exit(0) on desktop / restart on native,
         // so the throw below is a safety net for unexpected survival.
-        // await BundleUpdate.switchBundle({
-        //   appVersion: '',
-        //   bundleVersion: '',
-        //   signature: '',
-        // });
+        await BundleUpdate.switchBundle({
+          appVersion: '',
+          bundleVersion: '',
+          signature: '',
+        });
         throw new OneKeyLocalError('BUILTIN_FALLBACK_RELAUNCH');
       }
       throw new OneKeyLocalError(RETRY_TRIGGER_BUNDLE_MISSING);

--- a/packages/kit-bg/src/services/servicePendingInstallTask.ts
+++ b/packages/kit-bg/src/services/servicePendingInstallTask.ts
@@ -934,11 +934,11 @@ class ServicePendingInstallTask {
         await BundleUpdate.resetToBuiltInBundle();
         // switchBundle triggers app.exit(0) on desktop / restart on native,
         // so the throw below is a safety net for unexpected survival.
-        await BundleUpdate.switchBundle({
-          appVersion: '',
-          bundleVersion: '',
-          signature: '',
-        });
+        // await BundleUpdate.switchBundle({
+        //   appVersion: '',
+        //   bundleVersion: '',
+        //   signature: '',
+        // });
         throw new OneKeyLocalError('BUILTIN_FALLBACK_RELAUNCH');
       }
       throw new OneKeyLocalError(RETRY_TRIGGER_BUNDLE_MISSING);

--- a/packages/kit/src/views/Setting/pages/DevAppUpdateModalSettingModal/index.tsx
+++ b/packages/kit/src/views/Setting/pages/DevAppUpdateModalSettingModal/index.tsx
@@ -199,6 +199,21 @@ export default function DevAppUpdateTestModal() {
           <Button variant="secondary" onPress={copyAppUpdateInfo}>
             Copy App Update Info
           </Button>
+
+          <Button
+            variant="secondary"
+            onPress={async () => {
+              const task =
+                await backgroundApiProxy.servicePendingInstallTask.getPendingInstallTask();
+              const text = task
+                ? JSON.stringify(task, null, 2)
+                : 'No pending install task';
+              copyText(text);
+              Toast.success({ title: 'Copied' });
+            }}
+          >
+            Copy Pending Install Task
+          </Button>
         </YStack>
       </Page.Body>
     </Page>

--- a/packages/shared/src/modules3rdParty/auto-update/index.native.ts
+++ b/packages/shared/src/modules3rdParty/auto-update/index.native.ts
@@ -311,8 +311,8 @@ export const BundleUpdate: IBundleUpdate = {
     ReactNativeBundleUpdate.verifyExtractedBundle(appVersion, bundleVersion),
   listLocalBundles: () => ReactNativeBundleUpdate.listLocalBundles(),
   switchBundle: async (params) => {
+    await ReactNativeBundleUpdate.setCurrentUpdateBundleData(params);
     if (params.appVersion && params.bundleVersion) {
-      await ReactNativeBundleUpdate.setCurrentUpdateBundleData(params);
       setTimeout(() => {
         RNRestart.restart();
       }, 2500);

--- a/packages/shared/src/modules3rdParty/auto-update/index.native.ts
+++ b/packages/shared/src/modules3rdParty/auto-update/index.native.ts
@@ -311,10 +311,12 @@ export const BundleUpdate: IBundleUpdate = {
     ReactNativeBundleUpdate.verifyExtractedBundle(appVersion, bundleVersion),
   listLocalBundles: () => ReactNativeBundleUpdate.listLocalBundles(),
   switchBundle: async (params) => {
-    await ReactNativeBundleUpdate.setCurrentUpdateBundleData(params);
-    setTimeout(() => {
-      RNRestart.restart();
-    }, 2500);
+    if (params.appVersion && params.bundleVersion) {
+      await ReactNativeBundleUpdate.setCurrentUpdateBundleData(params);
+      setTimeout(() => {
+        RNRestart.restart();
+      }, 2500);
+    }
   },
   getNativeAppVersion: () => ReactNativeBundleUpdate.getNativeAppVersion(),
   getNativeBuildNumber: () => ReactNativeBundleUpdate.getNativeBuildNumber(),


### PR DESCRIPTION
## Summary
- When the server returns `jsBundleCount > 0` but no `jsBundleVersion`, it means the client already has the latest bundle (server filtered via `$ne` query)
- Previously, `resolveUpdateDecision` treated the absent `jsBundleVersion` as "no bundle available" and triggered `jsBundleRollbackToBuiltin`, causing a **upgrade → rollback → upgrade loop**
- Fix: set `hasActiveCustomBundle = false` when `jsBundleCount > 0` and `jsBundleVersion` is absent, so the decision resolves to `none` (no action needed)

## Root cause
In `ServiceAppUpdate.ts`, the `fetchAppUpdateInfo` flow passes `hasActiveCustomBundle = true` to `resolveUpdateDecision` when the client has an active custom bundle. When `remoteBundleVersion` is absent, `resolveUpdateDecision` interprets this as "server says no bundle should be running" and returns `jsBundleRollbackToBuiltin`. However, `jsBundleCount > 0` means bundles DO exist on the server — the client just already has the latest one.

## Test plan
- [ ] Configure server with shell + old bundle + new bundle for the same app version
- [ ] Install the old bundle on client, verify it upgrades to the new bundle
- [ ] Once on the new bundle, verify it does NOT rollback to shell when `jsBundleCount > 0`
- [ ] Set `jsBundleCount = 0` (delete all hot-update records), verify it DOES rollback to shell
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
