### PR TITLE
fix: show '--' instead of '$0' for zero volume on home market list

### DIFF
--- a/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import BigNumber from 'bignumber.js';
 import { isEmpty } from 'lodash';
 import { useIntl } from 'react-intl';
 
@@ -300,7 +299,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
                 currency: '$',
               }}
             >
-              {new BigNumber(record.volume24h).isNaN() ? '-' : record.volume24h}
+              {!record.volume24h ? '--' : record.volume24h}
             </NumberSizeableText>
           ),
         },
@@ -348,9 +347,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
                     currency: '$',
                   }}
                 >
-                  {new BigNumber(record.volume24h).isNaN()
-                    ? '-'
-                    : record.volume24h}
+                  {!record.volume24h ? '--' : record.volume24h}
                 </NumberSizeableText>
               </YStack>
             </XStack>


### PR DESCRIPTION
https://onekeyhq.atlassian.net/browse/OK-51995
## Summary
- When main coins like BTC have no volume data (volume24h = 0), the home page watchlist displayed `$0` instead of `--`
- Aligned with market page behavior which already shows `--` for zero volume
- Simplified check from `BigNumber.isNaN()/isZero()` to a simple falsy check, removed unused `BigNumber` import

## Test plan
- [ ] Verify BTC (volume24h = 0) shows `--` on home page watchlist (both desktop table and mobile layout)
- [ ] Verify tokens with volume (e.g. SOL) still display correct amount
- [ ] Verify market page still shows `--` for zero volume (no regression)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
