### PR TITLE
fix: resolve nightly ESLint errors

### DIFF
--- a/packages/components/src/composite/Tabs/TabBar.tsx
+++ b/packages/components/src/composite/Tabs/TabBar.tsx
@@ -32,6 +32,15 @@ type IItemLayout = { x: number; width: number };
 
 export type ITabBarVariant = 'default' | 'pill';
 
+const animatedTextStyles = StyleSheet.create({
+  text: {
+    fontSize: fs(16),
+    fontWeight: '500',
+    lineHeight: fs(24),
+    fontFamily: 'Roobert-Medium',
+  },
+});
+
 function AnimatedPillText({
   name,
   index: tabIndex,
@@ -170,15 +179,6 @@ export function TabBarItem({
     </YStack>
   );
 }
-
-const animatedTextStyles = StyleSheet.create({
-  text: {
-    fontSize: fs(16),
-    fontWeight: '500',
-    lineHeight: fs(24),
-    fontFamily: 'Roobert-Medium',
-  },
-});
 
 function AnimatedTabBarItem({
   name,

--- a/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
+++ b/packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx
@@ -73,6 +73,7 @@ function usePageScrollHandler(
       event: { eventName: string } & PagerViewOnPageScrollEvent['nativeEvent'],
     ) => {
       'worklet';
+
       const { onPageScroll } = handlers;
       if (onPageScroll && event.eventName.endsWith('onPageScroll')) {
         onPageScroll(event, context);
@@ -249,6 +250,7 @@ function OuterTabPagerViewComponent({
   const pageScrollHandler = usePageScrollHandler({
     onPageScroll: (e) => {
       'worklet';
+
       const position = e.position;
       const offset = e.offset;
 

--- a/packages/kit/src/views/Discovery/hooks/useMobileBottomBarAnimation.ts
+++ b/packages/kit/src/views/Discovery/hooks/useMobileBottomBarAnimation.ts
@@ -34,6 +34,7 @@ function useMobileBottomBarAnimation(activeTabId: string | null) {
   const processScroll = useCallback(
     (contentOffsetY: number, canScroll: boolean, isOutOfBounds: boolean) => {
       'worklet';
+
       if (isOutOfBounds) {
         lastScrollY.value = UNSET;
         lastTurnScrollY.value = UNSET;
@@ -116,6 +117,7 @@ function useMobileBottomBarAnimation(activeTabId: string | null) {
     toolbarOpacity.value = withTiming(MAX_OPACITY_BOTTOM_BAR);
     runOnUI(() => {
       'worklet';
+
       lastScrollY.value = UNSET;
       lastTurnScrollY.value = UNSET;
     })();

--- a/packages/kit/src/views/Earn/components/EarnBorrowPagerView.native.tsx
+++ b/packages/kit/src/views/Earn/components/EarnBorrowPagerView.native.tsx
@@ -63,6 +63,7 @@ function usePageScrollHandler(
       event: { eventName: string } & PagerViewOnPageScrollEvent['nativeEvent'],
     ) => {
       'worklet';
+
       const { onPageScroll } = handlers;
       if (onPageScroll && event.eventName.endsWith('onPageScroll')) {
         onPageScroll(event, context);
@@ -150,6 +151,7 @@ function EarnBorrowPagerViewComponent(
   const pageScrollHandler = usePageScrollHandler({
     onPageScroll: (e) => {
       'worklet';
+
       if (pageScrollPosition) {
         pageScrollPosition.value = e.position + e.offset;
       }

--- a/packages/kit/src/views/Setting/pages/DevBundleUpdateStatus/index.tsx
+++ b/packages/kit/src/views/Setting/pages/DevBundleUpdateStatus/index.tsx
@@ -95,35 +95,6 @@ const STATUS_TO_STAGE: Record<
   [EAppUpdateStatus.updateIncomplete]: { index: 6, failed: true },
 };
 
-function buildUpdatePipeline(
-  info: IAppUpdateInfo,
-  downloadPercent: number,
-): IPipelineStep[] {
-  const stage = STATUS_TO_STAGE[info.status] ?? { index: -1 };
-  const activeIdx = stage.index;
-  const isFailed = !!stage.failed;
-
-  return UPDATE_PIPELINE_LABELS.map((label, i) => {
-    let state: IStepState = 'pending';
-    if (i < activeIdx) {
-      state = 'completed';
-    } else if (i === activeIdx) {
-      state = isFailed ? 'failed' : 'active';
-    }
-
-    // Attach details only to the active / failed step
-    let details: { label: string; value: string }[] | undefined;
-    if (i === activeIdx) {
-      details = buildActiveDetails(info, i, isFailed);
-    }
-
-    // Attach download percent for the download step when active
-    const pct = i === 1 && state === 'active' ? downloadPercent : undefined;
-
-    return { label, state, details, percent: pct };
-  });
-}
-
 function buildActiveDetails(
   info: IAppUpdateInfo,
   stageIdx: number,
@@ -185,6 +156,35 @@ function buildActiveDetails(
   }
 
   return rows;
+}
+
+function buildUpdatePipeline(
+  info: IAppUpdateInfo,
+  downloadPercent: number,
+): IPipelineStep[] {
+  const stage = STATUS_TO_STAGE[info.status] ?? { index: -1 };
+  const activeIdx = stage.index;
+  const isFailed = !!stage.failed;
+
+  return UPDATE_PIPELINE_LABELS.map((label, i) => {
+    let state: IStepState = 'pending';
+    if (i < activeIdx) {
+      state = 'completed';
+    } else if (i === activeIdx) {
+      state = isFailed ? 'failed' : 'active';
+    }
+
+    // Attach details only to the active / failed step
+    let details: { label: string; value: string }[] | undefined;
+    if (i === activeIdx) {
+      details = buildActiveDetails(info, i, isFailed);
+    }
+
+    // Attach download percent for the download step when active
+    const pct = i === 1 && state === 'active' ? downloadPercent : undefined;
+
+    return { label, state, details, percent: pct };
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
@@ -49,12 +49,12 @@ import {
   isRawSpanning,
   isSpanning,
 } from '@onekeyhq/shared/src/modules/DualScreenInfo';
-import { NativeLogger } from '@onekeyhq/shared/src/modules3rdParty/react-native-file-logger';
 import LaunchOptionsManager from '@onekeyhq/shared/src/modules/LaunchOptionsManager';
 import {
   requestPermissionsAsync,
   setBadgeCountAsync,
 } from '@onekeyhq/shared/src/modules3rdParty/expo-notifications';
+import { NativeLogger } from '@onekeyhq/shared/src/modules3rdParty/react-native-file-logger';
 import {
   getCurrentWebViewPackageInfo,
   isGooglePlayServicesAvailable,


### PR DESCRIPTION
## Summary
- Auto-fix ESLint errors detected by nightly CI
- Closes #10781

## Changes
- packages/components/src/composite/Tabs/TabBar.tsx: move animatedTextStyles definition above first usage to satisfy @typescript-eslint/no-use-before-define
- packages/kit/src/views/Discovery/components/OuterTabPagerView.tsx: add required newline after "worklet" directives
- packages/kit/src/views/Discovery/hooks/useMobileBottomBarAnimation.ts: add required newline after "worklet" directives
- packages/kit/src/views/Earn/components/EarnBorrowPagerView.native.tsx: add required newline after "worklet" directives
- packages/kit/src/views/Setting/pages/DevBundleUpdateStatus/index.tsx: reorder helper function declarations to satisfy @typescript-eslint/no-use-before-define
- packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx: fix import order warning

## Test plan
- [x] ESLint passes locally (NODE_OPTIONS=--max-old-space-size=8192 npx eslint . --ext .ts,.tsx --max-warnings 0)
- [ ] CI checks pass

🤖 Auto-generated by Scriptoria ESLint fix automation

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
