### PR TITLE
fix: prevent double restart when rolling back to built-in bundle

### DIFF
--- a/packages/kit-bg/src/desktopApis/DesktopApiBundleUpdate.ts
+++ b/packages/kit-bg/src/desktopApis/DesktopApiBundleUpdate.ts
@@ -862,6 +862,14 @@ class DesktopApiAppBundleUpdate {
     );
   }
 
+  restart() {
+    this.getMainWindow()?.destroy();
+    if (!process.mas) {
+      app.relaunch();
+    }
+    app.exit(0);
+  }
+
   async clearAllJSBundleData() {
     await this.clearDownload();
     await this.clearBundleExtract();

--- a/packages/kit-bg/src/desktopApis/DesktopApiBundleUpdate.ts
+++ b/packages/kit-bg/src/desktopApis/DesktopApiBundleUpdate.ts
@@ -862,7 +862,7 @@ class DesktopApiAppBundleUpdate {
     );
   }
 
-  restart() {
+  async restart() {
     this.getMainWindow()?.destroy();
     if (!process.mas) {
       app.relaunch();

--- a/packages/kit-bg/src/services/ServiceAppUpdate.pendingInstallTask.test.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.pendingInstallTask.test.ts
@@ -1205,11 +1205,7 @@ describe('executeBundleSwitchTask rollback to builtin', () => {
     ).rejects.toThrow('BUILTIN_FALLBACK_RELAUNCH');
 
     expect(BundleUpdate.resetToBuiltInBundle).toHaveBeenCalled();
-    expect(BundleUpdate.switchBundle).toHaveBeenCalledWith({
-      appVersion: '',
-      bundleVersion: '',
-      signature: '',
-    });
+    expect(BundleUpdate.restart).toHaveBeenCalled();
   });
 
   test('upgrade target not found locally throws BUNDLE_MISSING', async () => {

--- a/packages/kit-bg/src/services/ServiceAppUpdate.pendingInstallTask.test.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.pendingInstallTask.test.ts
@@ -92,6 +92,7 @@ jest.mock('@onekeyhq/shared/src/modules3rdParty/auto-update', () => ({
     installBundle: jest.fn(async () => undefined),
     clearBundle: jest.fn(async () => undefined),
     resetToBuiltInBundle: jest.fn(async () => undefined),
+    restart: jest.fn(),
     switchBundle: jest.fn(async () => undefined),
     isBundleExists: jest.fn(async () => false),
     verifyExtractedBundle: jest.fn(async () => undefined),

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -1160,7 +1160,7 @@ class ServiceAppUpdate extends ServiceBase {
       //   1. isBundleExists("X.Y.Z", "0") → false
       //   2. targetBundle(0) < currentBundle → true (rollback)
       //   3. Fall into the existing builtin fallback path:
-      //      clearPendingInstallTask → resetToBuiltInBundle → switchBundle({empty})
+      //      clearPendingInstallTask → resetToBuiltInBundle → restart
       if (decision.decision === 'jsBundleRollbackToBuiltin') {
         await this.scheduleRollbackToBuiltinTask({
           reason: 'jsBundleRollbackToBuiltin',

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -123,7 +123,7 @@ class ServiceAppUpdate extends ServiceBase {
   // Schedule a pending task with targetBundleVersion="0" to rollback to
   // the builtin bundle on next cold start.  executeBundleSwitchTask will
   // detect the missing bundle and fall into the existing builtin fallback
-  // path: clearPendingInstallTask → resetToBuiltInBundle → switchBundle.
+  // path: clearPendingInstallTask → resetToBuiltInBundle → restart.
   // Returns true if the task was scheduled, false if skipped.
   private async scheduleRollbackToBuiltinTask({
     reason,

--- a/packages/kit-bg/src/services/servicePendingInstallTask.test.ts
+++ b/packages/kit-bg/src/services/servicePendingInstallTask.test.ts
@@ -66,6 +66,8 @@ jest.mock('@onekeyhq/shared/src/modules3rdParty/auto-update', () => ({
     verifyExtractedBundle: jest.fn(async () => undefined),
     clearBundle: jest.fn(async () => undefined),
     resetToBuiltInBundle: jest.fn(async () => undefined),
+    restart: jest.fn(),
+    getBuiltinBundleVersion: jest.fn(async () => ''),
     getNativeAppVersion: jest.fn(async () => '1.0.0'),
     getNativeBuildNumber: jest.fn(async () => '100'),
   },

--- a/packages/kit-bg/src/services/servicePendingInstallTask.ts
+++ b/packages/kit-bg/src/services/servicePendingInstallTask.ts
@@ -188,6 +188,16 @@ class ServicePendingInstallTask {
     );
   }
 
+  private async isRunningBuiltinBundle(): Promise<boolean> {
+    try {
+      const builtinVersion = await BundleUpdate.getBuiltinBundleVersion();
+      const currentVersion = String(platformEnv.bundleVersion || '');
+      return !!builtinVersion && currentVersion === builtinVersion;
+    } catch {
+      return false;
+    }
+  }
+
   @backgroundMethod()
   public async nextRequestSeq() {
     this.fallbackRequestSeqCounter += 1;
@@ -932,6 +942,20 @@ class ServicePendingInstallTask {
         Number.isFinite(targetBundle) &&
         targetBundle < currentBundle
       ) {
+        // If native already rolled back to builtin (e.g. bundle validation
+        // failed at native startup), we are already running the builtin
+        // bundle.  Just clear native metadata and the pending task — no
+        // restart needed.
+        const alreadyBuiltin = await this.isRunningBuiltinBundle();
+        if (alreadyBuiltin) {
+          defaultLogger.app.appUpdate.log(
+            `executeBundleSwitchTask: rollback target ${bundleVersion} not found locally, already on builtin — clearing without restart`,
+          );
+          await clearPendingInstallTask();
+          await BundleUpdate.resetToBuiltInBundle();
+          return;
+        }
+
         defaultLogger.app.appUpdate.log(
           `executeBundleSwitchTask: rollback target ${bundleVersion} not found locally, falling back to builtin`,
         );
@@ -942,13 +966,10 @@ class ServicePendingInstallTask {
         // re-persist the task as appliedWaitingVerify) is skipped.
         await clearPendingInstallTask();
         await BundleUpdate.resetToBuiltInBundle();
-        // switchBundle triggers app.exit(0) on desktop / restart on native,
-        // so the throw below is a safety net for unexpected survival.
-        await BundleUpdate.switchBundle({
-          appVersion: '',
-          bundleVersion: '',
-          signature: '',
-        });
+        BundleUpdate.restart();
+        // restart schedules app relaunch after 2.5s on native / app.exit(0)
+        // on desktop, so the throw below is a safety net for unexpected
+        // survival.
         throw new OneKeyLocalError('BUILTIN_FALLBACK_RELAUNCH');
       }
       throw new OneKeyLocalError(RETRY_TRIGGER_BUNDLE_MISSING);

--- a/packages/kit-bg/src/services/servicePendingInstallTask.ts
+++ b/packages/kit-bg/src/services/servicePendingInstallTask.ts
@@ -580,7 +580,7 @@ class ServicePendingInstallTask {
     // jsBundleRollbackToBuiltin is handled by fetchAppUpdateInfo which
     // creates a pending task with targetBundleVersion="0".  On next cold
     // start, executeBundleSwitchTask detects the missing bundle and falls
-    // back to builtin via resetToBuiltInBundle + switchBundle({empty}).
+    // back to builtin via resetToBuiltInBundle + restart.
 
     if (
       decision.decision !== 'appShellUpdate' &&
@@ -953,7 +953,9 @@ class ServicePendingInstallTask {
           );
           await clearPendingInstallTask();
           await BundleUpdate.resetToBuiltInBundle();
-          return;
+          // Throw to skip the caller's success path which would re-persist
+          // the cleared task as appliedWaitingVerify.
+          throw new OneKeyLocalError('BUILTIN_ALREADY_ACTIVE');
         }
 
         defaultLogger.app.appUpdate.log(
@@ -1406,13 +1408,20 @@ class ServicePendingInstallTask {
       } catch (error) {
         const durationMs = Date.now() - startedAt;
         const message = (error as Error)?.message ?? 'unknown';
-        // Builtin fallback already cleared the task and triggered relaunch.
-        // Do not re-persist or retry — the app is restarting with builtin.
-        if (message === 'BUILTIN_FALLBACK_RELAUNCH') {
+        // Builtin fallback already cleared the task and triggered relaunch,
+        // or native already rolled back so no restart is needed.
+        // Do not re-persist or retry.
+        if (
+          message === 'BUILTIN_FALLBACK_RELAUNCH' ||
+          message === 'BUILTIN_ALREADY_ACTIVE'
+        ) {
           defaultLogger.app.appUpdate.pendingSwitchResult({
             traceId,
             requestSeq,
-            result: 'builtin_fallback',
+            result:
+              message === 'BUILTIN_ALREADY_ACTIVE'
+                ? 'builtin_already_active'
+                : 'builtin_fallback',
             durationMs,
             ...this.buildTaskLogFields(runningTask),
           });

--- a/packages/kit/src/components/UpdateReminder/hooks.test.ts
+++ b/packages/kit/src/components/UpdateReminder/hooks.test.ts
@@ -63,6 +63,7 @@ jest.mock('@onekeyhq/shared/src/modules3rdParty/auto-update', () => {
     installBundle: jest.fn(),
     clearBundle: jest.fn(),
     resetToBuiltInBundle: jest.fn(),
+    restart: jest.fn(),
     isSkipGpgVerificationAllowed: jest.fn().mockResolvedValue(false),
   };
   (globalThis as any).__mockAppUpd = au;

--- a/packages/kit/src/views/Setting/pages/DevBundleManagerModal/index.tsx
+++ b/packages/kit/src/views/Setting/pages/DevBundleManagerModal/index.tsx
@@ -461,6 +461,7 @@ export default function DevBundleManagerModal() {
                       onConfirm: async () => {
                         try {
                           await BundleUpdate.resetToBuiltInBundle();
+                          BundleUpdate.restart();
                         } catch (error) {
                           showTestError(error);
                         }

--- a/packages/shared/src/modules3rdParty/auto-update/index.desktop.ts
+++ b/packages/shared/src/modules3rdParty/auto-update/index.desktop.ts
@@ -213,7 +213,7 @@ export const BundleUpdate: IBundleUpdate = {
   resetToBuiltInBundle: () =>
     globalThis.desktopApiProxy.bundleUpdate.resetToBuiltInBundle(),
   restart: () => {
-    globalThis.desktopApiProxy.bundleUpdate.restart();
+    void globalThis.desktopApiProxy.bundleUpdate.restart();
   },
   clearAllJSBundleData: () =>
     globalThis.desktopApiProxy.bundleUpdate.clearAllJSBundleData(),

--- a/packages/shared/src/modules3rdParty/auto-update/index.desktop.ts
+++ b/packages/shared/src/modules3rdParty/auto-update/index.desktop.ts
@@ -212,6 +212,9 @@ export const BundleUpdate: IBundleUpdate = {
   clearDownload: () => globalThis.desktopApiProxy.bundleUpdate.clearDownload(),
   resetToBuiltInBundle: () =>
     globalThis.desktopApiProxy.bundleUpdate.resetToBuiltInBundle(),
+  restart: () => {
+    globalThis.desktopApiProxy.bundleUpdate.restart();
+  },
   clearAllJSBundleData: () =>
     globalThis.desktopApiProxy.bundleUpdate.clearAllJSBundleData(),
   testVerification: () =>

--- a/packages/shared/src/modules3rdParty/auto-update/index.native.ts
+++ b/packages/shared/src/modules3rdParty/auto-update/index.native.ts
@@ -281,6 +281,8 @@ export const BundleUpdate: IBundleUpdate = {
   clearDownload: () => ReactNativeBundleUpdate.clearDownload(),
   resetToBuiltInBundle: async () => {
     await ReactNativeBundleUpdate.resetToBuiltInBundle();
+  },
+  restart: () => {
     setTimeout(() => {
       RNRestart.restart();
     }, 2500);

--- a/packages/shared/src/modules3rdParty/auto-update/index.ts
+++ b/packages/shared/src/modules3rdParty/auto-update/index.ts
@@ -48,6 +48,7 @@ export const BundleUpdate: IBundleUpdate = {
   clearBundle: () => Promise.resolve(),
   clearDownload: () => Promise.resolve(),
   resetToBuiltInBundle: () => Promise.resolve(),
+  restart: () => {},
   isSkipGpgVerificationAllowed: () => Promise.resolve(false),
   clearAllJSBundleData: () =>
     Promise.resolve({ success: false, message: 'Not supported on web' }),

--- a/packages/shared/src/modules3rdParty/auto-update/type.ts
+++ b/packages/shared/src/modules3rdParty/auto-update/type.ts
@@ -121,6 +121,8 @@ export interface IBundleUpdate {
   clearBundle: IClearBundle;
   clearDownload: () => Promise<void>;
   resetToBuiltInBundle: () => Promise<void>;
+  /** Restart the app (RNRestart on native, app.relaunch on desktop). */
+  restart: () => void;
   isSkipGpgVerificationAllowed: () => Promise<boolean>;
   clearAllJSBundleData: () => Promise<{ success: boolean; message: string }>;
   getFallbackBundles: () => Promise<IJSBundle[]>;


### PR DESCRIPTION
## Summary

- **Problem**: When rolling back to the built-in bundle, if the native layer already performed the rollback (e.g. bundle validation failed at startup), the JS pending task system would redundantly call `resetToBuiltInBundle()` + restart, causing a **double restart** for the user.
- **Root cause**: Native's `currentBundleMainJSBundle()` returns nil on validation failure and loads the built-in bundle, but does NOT clear the `currentBundleVersion` metadata. JS then sees the pending task, executes the rollback again, and triggers an unnecessary restart.
- **Fix**: 
  1. Split `resetToBuiltInBundle` and `restart` into separate operations across all platforms (native/desktop/web)
  2. Add `isRunningBuiltinBundle()` check — compares `platformEnv.bundleVersion` with `getBuiltinBundleVersion()`  
  3. In `executeBundleSwitchTask`, if already on the built-in bundle, only clear metadata + pending task without restarting
  4. All existing callers of `resetToBuiltInBundle` updated to explicitly call `BundleUpdate.restart()` where needed

## Test plan

- [ ] Apply a custom bundle, then simulate native validation failure (e.g. delete bundle directory) → app should only restart once (native rollback), not twice
- [ ] Dev settings "Reset to Built-in Bundle" button still works (resets + restarts)
- [ ] Normal bundle upgrade flow unaffected
- [ ] Desktop rollback-to-builtin flow works correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
