### PR TITLE
fix(perp): correct token pair suffix on mobile market detail page

### DIFF
--- a/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
+++ b/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
@@ -73,7 +73,7 @@ function MobilePerpMarket() {
   const renderHeaderTitle = useCallback(() => {
     const parsedCoin = coin ? parseDexCoin(coin) : null;
     const displayCoin = parsedCoin?.displayName || coin || '';
-    const pairLabel = displayCoin ? `${displayCoin}USD` : '--';
+    const pairLabel = displayCoin ? `${displayCoin}USDC` : '--';
     return (
       <XStack alignItems="center" gap="$2">
         <NavBackButton


### PR DESCRIPTION
https://onekeyhq.atlassian.net/browse/OK-52010
## Summary
- Fix mobile perp market detail page header displaying "SOLUSD" instead of "SOLUSDC"
- The hardcoded suffix `USD` was introduced in commit `93a5099f85` (#9336) when `parseDexCoin` was added — it should have been `USDC` to match the homepage (`PerpTokenSelector.tsx:690`)

## Test plan
- [ ] Open perps on mobile, navigate to any token's detail/chart page
- [ ] Verify header shows correct pair name (e.g., "SOLUSDC" instead of "SOLUSD")
- [ ] Verify homepage token selector still displays correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10796" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
