### PR TITLE
fix: remove Stack wrapper around Pressable in ListItem

### DIFF
--- a/packages/kit/src/components/ListItem/index.tsx
+++ b/packages/kit/src/components/ListItem/index.tsx
@@ -343,29 +343,6 @@ const ListItemComponent = Stack.styleable<IListItemProps, any, any>(
     const [nativePressed, setNativePressed] = useState(false);
     const handlePressIn = useCallback(() => setNativePressed(true), []);
     const handlePressOut = useCallback(() => setNativePressed(false), []);
-    const nativeWrapperLayoutProps = {
-      ...(props.flex !== undefined ? { flex: props.flex } : undefined),
-      ...(props.flexGrow !== undefined
-        ? { flexGrow: props.flexGrow }
-        : undefined),
-      ...(props.flexShrink !== undefined
-        ? { flexShrink: props.flexShrink }
-        : undefined),
-      ...(props.flexBasis !== undefined
-        ? { flexBasis: props.flexBasis }
-        : undefined),
-      ...(props.width !== undefined ? { width: props.width } : undefined),
-      ...(props.minWidth !== undefined
-        ? { minWidth: props.minWidth }
-        : undefined),
-      ...(props.maxWidth !== undefined
-        ? { maxWidth: props.maxWidth }
-        : undefined),
-      ...(props.alignSelf !== undefined
-        ? { alignSelf: props.alignSelf }
-        : undefined),
-    };
-
     const content = (
       <Stack
         ref={ref}
@@ -440,17 +417,15 @@ const ListItemComponent = Stack.styleable<IListItemProps, any, any>(
       // unstable_pressDelay delays onPressIn so the bg highlight doesn't
       // briefly flash when the user starts a scroll gesture on a list item.
       return (
-        <Stack {...nativeWrapperLayoutProps}>
-          <Pressable
-            onPress={handleItemPress}
-            onPressIn={handlePressIn}
-            onPressOut={handlePressOut}
-            unstable_pressDelay={50}
-            style={{ flex: 1 }}
-          >
-            {content}
-          </Pressable>
-        </Stack>
+        <Pressable
+          onPress={handleItemPress}
+          onPressIn={handlePressIn}
+          onPressOut={handlePressOut}
+          unstable_pressDelay={50}
+          style={{ flex: 1 }}
+        >
+          {content}
+        </Pressable>
       );
     }
 


### PR DESCRIPTION
## Summary
- Remove `nativeWrapperLayoutProps` and outer `<Stack>` wrapper around `<Pressable>` in ListItem that was introduced in #10795
- The `Stack` wrapper caused layout collapse on pages like the Receive page (接收页面), breaking text display
- Use `style={{ flex: 1 }}` directly on `Pressable` instead

## Test plan
- [ ] Verify Receive (接收) page displays correctly on iOS/Android
- [ ] Verify Setting > Protection (风险保护) page ListItem layout is not collapsed
- [ ] Verify Earn page ListItem still works correctly
- [ ] Verify list item press/scroll behavior is unaffected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
