### PR TITLE
fix: disable predictive back gesture to prevent gesture back exiting app on Pixel

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -71,6 +71,7 @@
   </queries>
   <application
   android:usesCleartextTraffic="false"
+  android:enableOnBackInvokedCallback="false"
    android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:theme="@style/AppTheme" android:largeHeap="true" android:supportsRtl="true">
     <meta-data
         android:name="com.google.android.play.billingclient.version"


### PR DESCRIPTION
## Summary
- On Pixel devices, pressing the physical back button on the Home page puts the app in the background. After resuming the app and navigating to a sub-page, gesture back exits the app instead of navigating back
- Root cause: Android 13+ predictive back gesture is incompatible with React Native's BackHandler which relies on the deprecated `onBackPressed()` API
- Fix: explicitly set `android:enableOnBackInvokedCallback="false"` in AndroidManifest.xml to disable predictive back and ensure gesture back uses the legacy path

## Test plan
- [ ] Reproduce on Pixel: Home page → press back → resume app → navigate to sub-page → gesture back, verify it no longer exits the app
- [ ] Verify gesture back navigates to the previous page normally
- [ ] Verify physical back button behavior is unaffected