### PR TITLE
fix(ListItem): strip pressStyle from inner Stack to fix native touch

### DIFF
--- a/packages/kit/src/components/ListItem/index.tsx
+++ b/packages/kit/src/components/ListItem/index.tsx
@@ -5,7 +5,7 @@ import type {
   ReactElement,
   ReactNode,
 } from 'react';
-import { isValidElement, useCallback, useState } from 'react';
+import { isValidElement, useCallback, useMemo, useState } from 'react';
 
 import { Pressable } from 'react-native';
 
@@ -343,6 +343,24 @@ const ListItemComponent = Stack.styleable<IListItemProps, any, any>(
     const [nativePressed, setNativePressed] = useState(false);
     const handlePressIn = useCallback(() => setNativePressed(true), []);
     const handlePressOut = useCallback(() => setNativePressed(false), []);
+
+    // On native with Pressable wrapper, strip pressStyle/hoverStyle from rest
+    // to prevent the inner Stack from claiming the touch responder via Tamagui's
+    // usePressability. Without this, Tamagui attaches onStartShouldSetResponder
+    // to the inner Stack (because pressStyle triggers attachPress), which steals
+    // the responder from the outer Pressable and prevents onPress from firing.
+    const { contentRest, nativePressStyle } = useMemo(() => {
+      if (useNativePressable) {
+        const {
+          pressStyle: _pressStyle,
+          hoverStyle: _hoverStyle,
+          ...filtered
+        } = rest as any;
+        return { contentRest: filtered, nativePressStyle: _pressStyle };
+      }
+      return { contentRest: rest, nativePressStyle: undefined };
+    }, [useNativePressable, rest]);
+
     const content = (
       <Stack
         ref={ref}
@@ -360,8 +378,10 @@ const ListItemComponent = Stack.styleable<IListItemProps, any, any>(
           opacity: 0.5,
         })}
         {...(useWebPress ? listItemPressStyle : undefined)}
-        {...rest}
-        {...(nativePressed ? { bg: '$bgActive' } : undefined)}
+        {...contentRest}
+        {...(nativePressed
+          ? (nativePressStyle ?? { bg: '$bgActive' })
+          : undefined)}
       >
         {childrenBefore}
         {renderWithFallback(

--- a/packages/kit/src/components/ListItem/index.tsx
+++ b/packages/kit/src/components/ListItem/index.tsx
@@ -345,10 +345,10 @@ const ListItemComponent = Stack.styleable<IListItemProps, any, any>(
     const handlePressOut = useCallback(() => setNativePressed(false), []);
 
     // On native with Pressable wrapper, strip pressStyle/hoverStyle from rest
-    // to prevent the inner Stack from claiming the touch responder via Tamagui's
-    // usePressability. Without this, Tamagui attaches onStartShouldSetResponder
-    // to the inner Stack (because pressStyle triggers attachPress), which steals
-    // the responder from the outer Pressable and prevents onPress from firing.
+    // to prevent the inner Stack from claiming the touch responder. Without this,
+    // Tamagui attaches onStartShouldSetResponder to the inner Stack (because
+    // pressStyle triggers attachPress), which steals the responder from the
+    // outer Pressable and prevents onPress from firing.
     const { contentRest, nativePressStyle } = useMemo(() => {
       if (useNativePressable) {
         const {

--- a/packages/kit/src/components/ListItem/index.tsx
+++ b/packages/kit/src/components/ListItem/index.tsx
@@ -5,7 +5,7 @@ import type {
   ReactElement,
   ReactNode,
 } from 'react';
-import { isValidElement, useCallback, useMemo, useState } from 'react';
+import { isValidElement, useCallback, useState } from 'react';
 
 import { Pressable } from 'react-native';
 
@@ -349,17 +349,13 @@ const ListItemComponent = Stack.styleable<IListItemProps, any, any>(
     // Tamagui attaches onStartShouldSetResponder to the inner Stack (because
     // pressStyle triggers attachPress), which steals the responder from the
     // outer Pressable and prevents onPress from firing.
-    const { contentRest, nativePressStyle } = useMemo(() => {
-      if (useNativePressable) {
-        const {
-          pressStyle: _pressStyle,
-          hoverStyle: _hoverStyle,
-          ...filtered
-        } = rest as any;
-        return { contentRest: filtered, nativePressStyle: _pressStyle };
-      }
-      return { contentRest: rest, nativePressStyle: undefined };
-    }, [useNativePressable, rest]);
+    let contentRest: typeof rest = rest;
+    let nativePressStyle: IStackProps['pressStyle'];
+    if (useNativePressable) {
+      const { pressStyle, hoverStyle, ...filtered } = rest;
+      contentRest = filtered;
+      nativePressStyle = pressStyle;
+    }
 
     const content = (
       <Stack


### PR DESCRIPTION
## Summary
- On native, ListItem wraps content in a `Pressable` for scroll-vs-tap disambiguation
- When callers pass `pressStyle` (e.g. BulkSend's AssetSelectorTrigger), Tamagui's `usePressability` attaches `onStartShouldSetResponder` to the inner Stack, stealing the touch responder from the outer `Pressable` and preventing `onPress` from firing
- Strip `pressStyle`/`hoverStyle` from the inner Stack props and apply the caller's `pressStyle` via the `nativePressed` state instead

## Test plan
- [ ] Verify BulkSend asset selector (ETH row) responds to tap on iOS
- [ ] Verify press visual feedback (bg change) works on the asset selector
- [ ] Verify other ListItem press interactions still work (e.g. token list, settings)
- [ ] Verify web/desktop ListItem behavior is unaffected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
