### PR TITLE
fix(TokenDetails): ensure unique tab names for aggregate tokens

### DIFF
--- a/packages/kit/src/components/ListItem/index.tsx
+++ b/packages/kit/src/components/ListItem/index.tsx
@@ -5,7 +5,7 @@ import type {
   ReactElement,
   ReactNode,
 } from 'react';
-import { isValidElement, useCallback, useState } from 'react';
+import { isValidElement, useCallback, useMemo, useState } from 'react';
 
 import { Pressable } from 'react-native';
 
@@ -343,6 +343,24 @@ const ListItemComponent = Stack.styleable<IListItemProps, any, any>(
     const [nativePressed, setNativePressed] = useState(false);
     const handlePressIn = useCallback(() => setNativePressed(true), []);
     const handlePressOut = useCallback(() => setNativePressed(false), []);
+
+    // On native with Pressable wrapper, strip pressStyle/hoverStyle from rest
+    // to prevent the inner Stack from claiming the touch responder via Tamagui's
+    // usePressability. Without this, Tamagui attaches onStartShouldSetResponder
+    // to the inner Stack (because pressStyle triggers attachPress), which steals
+    // the responder from the outer Pressable and prevents onPress from firing.
+    const { contentRest, nativePressStyle } = useMemo(() => {
+      if (useNativePressable) {
+        const {
+          pressStyle: _pressStyle,
+          hoverStyle: _hoverStyle,
+          ...filtered
+        } = rest as any;
+        return { contentRest: filtered, nativePressStyle: _pressStyle };
+      }
+      return { contentRest: rest, nativePressStyle: undefined };
+    }, [useNativePressable, rest]);
+
     const content = (
       <Stack
         ref={ref}
@@ -360,8 +378,10 @@ const ListItemComponent = Stack.styleable<IListItemProps, any, any>(
           opacity: 0.5,
         })}
         {...(useWebPress ? listItemPressStyle : undefined)}
-        {...rest}
-        {...(nativePressed ? { bg: '$bgActive' } : undefined)}
+        {...contentRest}
+        {...(nativePressed
+          ? (nativePressStyle ?? { bg: '$bgActive' })
+          : undefined)}
       >
         {childrenBefore}
         {renderWithFallback(

--- a/packages/kit/src/components/ListItem/index.tsx
+++ b/packages/kit/src/components/ListItem/index.tsx
@@ -345,10 +345,10 @@ const ListItemComponent = Stack.styleable<IListItemProps, any, any>(
     const handlePressOut = useCallback(() => setNativePressed(false), []);
 
     // On native with Pressable wrapper, strip pressStyle/hoverStyle from rest
-    // to prevent the inner Stack from claiming the touch responder via Tamagui's
-    // usePressability. Without this, Tamagui attaches onStartShouldSetResponder
-    // to the inner Stack (because pressStyle triggers attachPress), which steals
-    // the responder from the outer Pressable and prevents onPress from firing.
+    // to prevent the inner Stack from claiming the touch responder. Without this,
+    // Tamagui attaches onStartShouldSetResponder to the inner Stack (because
+    // pressStyle triggers attachPress), which steals the responder from the
+    // outer Pressable and prevents onPress from firing.
     const { contentRest, nativePressStyle } = useMemo(() => {
       if (useNativePressable) {
         const {

--- a/packages/kit/src/components/ListItem/index.tsx
+++ b/packages/kit/src/components/ListItem/index.tsx
@@ -5,7 +5,7 @@ import type {
   ReactElement,
   ReactNode,
 } from 'react';
-import { isValidElement, useCallback, useMemo, useState } from 'react';
+import { isValidElement, useCallback, useState } from 'react';
 
 import { Pressable } from 'react-native';
 
@@ -349,17 +349,13 @@ const ListItemComponent = Stack.styleable<IListItemProps, any, any>(
     // Tamagui attaches onStartShouldSetResponder to the inner Stack (because
     // pressStyle triggers attachPress), which steals the responder from the
     // outer Pressable and prevents onPress from firing.
-    const { contentRest, nativePressStyle } = useMemo(() => {
-      if (useNativePressable) {
-        const {
-          pressStyle: _pressStyle,
-          hoverStyle: _hoverStyle,
-          ...filtered
-        } = rest as any;
-        return { contentRest: filtered, nativePressStyle: _pressStyle };
-      }
-      return { contentRest: rest, nativePressStyle: undefined };
-    }, [useNativePressable, rest]);
+    let contentRest: typeof rest = rest;
+    let nativePressStyle: IStackProps['pressStyle'];
+    if (useNativePressable) {
+      const { pressStyle, hoverStyle, ...filtered } = rest;
+      contentRest = filtered;
+      nativePressStyle = pressStyle;
+    }
 
     const content = (
       <Stack

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/index.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/index.tsx
@@ -514,7 +514,7 @@ function TokenDetailsView() {
   //   1. Use networkName as-is when unique (e.g. "Ethereum", "BNB Chain")
   //   2. Fallback to networkId if networkName is empty (e.g. "evm--1")
   //   3. Append networkShortName for duplicates (e.g. "Ethereum(ETH)", "Ethereum(ARB)")
-  //   4. Append numeric suffix as final dedup guard (e.g. "Ethereum(ETH) 2")
+  //   4. Append numeric suffix as final deduplicate guard (e.g. "Ethereum(ETH) 2")
   const uniqueTabNames = useMemo(() => {
     const nameCount = new Map<string, number>();
     for (const token of tokens) {
@@ -755,6 +755,7 @@ function TokenDetailsView() {
     pageWidth,
     handleTabIndexChange,
     lastActiveTabName,
+    uniqueTabNames,
   ]);
 
   const headerTitle = useCallback(() => {

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/index.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/index.tsx
@@ -544,7 +544,10 @@ function TokenDetailsView() {
   const tabs = useMemo(() => {
     if (tokens.length > 1) {
       return tokens.map((token) => (
-        <Tabs.Tab key={token.$key} name={uniqueTabNames.get(token.$key) ?? token.$key}>
+        <Tabs.Tab
+          key={token.$key}
+          name={uniqueTabNames.get(token.$key) ?? token.$key}
+        >
           <TokenDetailsViews
             inTabList
             isTabView

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/index.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/index.tsx
@@ -214,12 +214,14 @@ function TokenDetailsView() {
               aggregateTokens.push({
                 ...originalToken,
                 accountId: originalToken.accountId ?? tokenAccountId ?? '',
+                networkShortName: tokenNetwork?.shortname ?? '',
               });
             } else {
               aggregateTokens.push({
                 ...aggregateToken,
                 accountId: tokenAccountId ?? '',
                 networkName: tokenNetwork?.name ?? '',
+                networkShortName: tokenNetwork?.shortname ?? '',
                 $key: buildTokenListMapKey({
                   networkId: aggregateToken.networkId ?? '',
                   accountAddress: tokenAccountAddress ?? '',
@@ -506,10 +508,43 @@ function TokenDetailsView() {
   }, [activeTabIndex, tokens, updateTokenMetadata]);
 
   const listViewContentContainerStyle = useMemo(() => ({ pt: '$5' }), []);
+  // Build unique tab names for aggregate tokens to avoid
+  // "Tab names must be unique" crash in collapsible-tab-view.
+  // Naming rules:
+  //   1. Use networkName as-is when unique (e.g. "Ethereum", "BNB Chain")
+  //   2. Fallback to networkId if networkName is empty (e.g. "evm--1")
+  //   3. Append networkShortName for duplicates (e.g. "Ethereum(ETH)", "Ethereum(ARB)")
+  //   4. Append numeric suffix as final dedup guard (e.g. "Ethereum(ETH) 2")
+  const uniqueTabNames = useMemo(() => {
+    const nameCount = new Map<string, number>();
+    for (const token of tokens) {
+      const baseName = token.networkName || token.networkId || token.$key;
+      nameCount.set(baseName, (nameCount.get(baseName) ?? 0) + 1);
+    }
+    const result = new Map<string, string>();
+    const usedNames = new Set<string>();
+    for (const token of tokens) {
+      const baseName = token.networkName || token.networkId || token.$key;
+      let name = baseName;
+      if ((nameCount.get(baseName) ?? 0) > 1) {
+        const suffix = token.networkShortName || token.networkId || '';
+        name = suffix ? `${baseName}(${suffix})` : baseName;
+      }
+      if (usedNames.has(name)) {
+        let i = 2;
+        while (usedNames.has(`${name} ${i}`)) i += 1;
+        name = `${name} ${i}`;
+      }
+      usedNames.add(name);
+      result.set(token.$key, name);
+    }
+    return result;
+  }, [tokens]);
+
   const tabs = useMemo(() => {
     if (tokens.length > 1) {
       return tokens.map((token) => (
-        <Tabs.Tab key={token.$key} name={token.networkName ?? ''}>
+        <Tabs.Tab key={token.$key} name={uniqueTabNames.get(token.$key) ?? token.$key}>
           <TokenDetailsViews
             inTabList
             isTabView
@@ -584,6 +619,7 @@ function TokenDetailsView() {
     tokenInfo,
     result?.networkAccounts,
     intl,
+    uniqueTabNames,
   ]);
 
   const pageWidth = useTabletModalPageWidth();
@@ -597,7 +633,8 @@ function TokenDetailsView() {
           {
             accountId: indexedAccountId ?? accountId,
             aggregateTokenId: tokenInfo.$key,
-            lastActiveTabName: activeToken.networkName ?? '',
+            lastActiveTabName:
+              uniqueTabNames.get(activeToken.$key) ?? activeToken.$key,
           },
         );
 
@@ -636,6 +673,7 @@ function TokenDetailsView() {
       allNetworksState.enabledNetworks,
       intl,
       refreshAllNetworkState,
+      uniqueTabNames,
     ],
   );
 
@@ -671,7 +709,9 @@ function TokenDetailsView() {
                   <TokenDetailsTabToolbar
                     tokens={tokens}
                     onSelected={(token) => {
-                      tabsRef.current?.jumpToTab(token.networkName ?? '');
+                      tabsRef.current?.jumpToTab(
+                        uniqueTabNames.get(token.$key) ?? token.$key,
+                      );
                     }}
                   />
                 )}

--- a/packages/shared/types/token.ts
+++ b/packages/shared/types/token.ts
@@ -24,6 +24,7 @@ export type IToken = {
   order?: number;
   networkId?: string;
   networkName?: string;
+  networkShortName?: string;
   accountId?: string;
   mergeAssets?: boolean;
 

--- a/patches/react-native-collapsible-tab-view+8.0.1.patch
+++ b/patches/react-native-collapsible-tab-view+8.0.1.patch
@@ -874,7 +874,7 @@ index 2bd6b9c..80c7377 100644
        contentOffset={memoContentOffset}
        automaticallyAdjustContentInsets={false}
 diff --git a/node_modules/react-native-collapsible-tab-view/src/hooks.tsx b/node_modules/react-native-collapsible-tab-view/src/hooks.tsx
-index ba7dffa..7e961e9 100644
+index ba7dffa..f2d3c16 100644
 --- a/node_modules/react-native-collapsible-tab-view/src/hooks.tsx
 +++ b/node_modules/react-native-collapsible-tab-view/src/hooks.tsx
 @@ -8,7 +8,7 @@ import {
@@ -886,30 +886,24 @@ index ba7dffa..7e961e9 100644
  import { ContainerRef, RefComponent } from 'react-native-collapsible-tab-view'
  import { PagerViewOnPageScrollEvent } from 'react-native-pager-view'
  import Animated, {
-@@ -101,7 +101,13 @@ export function useTabProps<T extends TabName>(
+@@ -101,7 +101,10 @@ export function useTabProps<T extends TabName>(
   */
  export function useTabsContext(): ContextType<TabName> {
    const c = useContext(Context)
 -  if (!c) throw new Error('useTabsContext must be inside a Tabs.Container')
 +  if (!c) {
-+    if (__DEV__) {
-+      throw new Error('useTabsContext must be inside a Tabs.Container')
-+    }
 +    console.error('useTabsContext must be inside a Tabs.Container')
 +    return {} as ContextType<TabName>
 +  }
    return c
  }
  
-@@ -114,23 +120,38 @@ export function useTabsContext(): ContextType<TabName> {
+@@ -114,23 +117,35 @@ export function useTabsContext(): ContextType<TabName> {
   */
  export function useTabNameContext(): TabName {
    const c = useContext(TabNameContext)
 -  if (!c) throw new Error('useTabNameContext must be inside a TabNameContext')
 +  if (!c) {
-+    if (__DEV__) {
-+      throw new Error('useTabNameContext must be inside a TabNameContext')
-+    }
 +    console.error('useTabNameContext must be inside a TabNameContext')
 +    return '' as TabName
 +  }
@@ -945,7 +939,7 @@ index ba7dffa..7e961e9 100644
  }
  /**
   * Hook to access some key styles that make the whole thing work.
-@@ -265,10 +286,13 @@ export const useScrollHandlerY = (name: TabName) => {
+@@ -265,10 +280,13 @@ export const useScrollHandlerY = (name: TabName) => {
      accScrollY,
      offset,
      headerScrollDistance,
@@ -959,7 +953,7 @@ index ba7dffa..7e961e9 100644
    } = useTabsContext()
  
    const enabled = useSharedValue(false)
-@@ -296,10 +320,13 @@ export const useScrollHandlerY = (name: TabName) => {
+@@ -296,10 +314,13 @@ export const useScrollHandlerY = (name: TabName) => {
    useAnimatedReaction(
      () => scrollAnimation.value,
      (val) => {
@@ -974,7 +968,7 @@ index ba7dffa..7e961e9 100644
    )
  
    const onMomentumEnd = () => {
-@@ -403,6 +430,14 @@ export const useScrollHandlerY = (name: TabName) => {
+@@ -403,6 +424,14 @@ export const useScrollHandlerY = (name: TabName) => {
                accDiffClamp.value = Math.max(0, nextValue)
              }
            }
@@ -989,7 +983,7 @@ index ba7dffa..7e961e9 100644
          }
        },
        onBeginDrag: () => {
-@@ -465,6 +500,9 @@ export const useScrollHandlerY = (name: TabName) => {
+@@ -465,6 +494,9 @@ export const useScrollHandlerY = (name: TabName) => {
        return isChangingPane
      },
      (isSyncNeeded, wasSyncNeeded) => {
@@ -999,7 +993,7 @@ index ba7dffa..7e961e9 100644
        if (
          isSyncNeeded &&
          isSyncNeeded !== wasSyncNeeded &&
-@@ -505,10 +543,68 @@ export const useScrollHandlerY = (name: TabName) => {
+@@ -505,10 +537,68 @@ export const useScrollHandlerY = (name: TabName) => {
          }
        }
      },
@@ -1070,7 +1064,7 @@ index ba7dffa..7e961e9 100644
  }
  
  type ForwardRefType<T> =
-@@ -579,11 +675,11 @@ export function useAfterMountEffect(
+@@ -579,11 +669,11 @@ export function useAfterMountEffect(
  export function useConvertAnimatedToValue<T>(
    animatedValue: Animated.SharedValue<T>
  ) {


### PR DESCRIPTION
## Summary
- Fix "Tab names must be unique" crash (white screen) in TokenDetails when aggregate tokens have empty or duplicate `networkName`
- Build unique tab name map with fallback chain: `networkName` → `networkId`, disambiguate duplicates via `networkShortName` (e.g. `Ethereum(ETH)`, `Ethereum(ARB)`)
- Add `networkShortName` field to `IToken` type, populated from `IServerNetwork.shortname`
- Clean up debug logging (`ScrollGuard` console.log) and `__DEV__` throw from collapsible-tab-view patch

## Test plan
- [ ] Open aggregate token details (e.g. USDT across multiple chains) — tabs should display correctly
- [ ] Verify tab switching and `lastActiveTabName` persistence work across sessions
- [ ] Confirm no white screen crash on tokens with empty `networkName`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
