### PR TITLE
fix(ReceiveSelector): fix ListItem overlap on native

### DIFF
--- a/packages/kit/src/components/ListItem/index.tsx
+++ b/packages/kit/src/components/ListItem/index.tsx
@@ -8,6 +8,7 @@ import type {
 import { isValidElement, useCallback, useState } from 'react';
 
 import { Pressable } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
 
 import {
   Divider,
@@ -275,6 +276,7 @@ export type IListItemProps = PropsWithChildren<
     childrenBefore?: ComponentType | ReactNode;
     disabled?: boolean;
     testID?: string;
+    nativePressableStyle?: StyleProp<ViewStyle>;
   } & IStackProps
 >;
 
@@ -318,6 +320,7 @@ const ListItemComponent = Stack.styleable<IListItemProps, any, any>(
       renderItemText,
       titleMatch,
       subTitleMatch,
+      nativePressableStyle,
       ...rest
     } = props;
 
@@ -438,7 +441,7 @@ const ListItemComponent = Stack.styleable<IListItemProps, any, any>(
           onPressIn={handlePressIn}
           onPressOut={handlePressOut}
           unstable_pressDelay={50}
-          style={{ flex: 1 }}
+          style={nativePressableStyle ?? { flex: 1 }}
         >
           {content}
         </Pressable>

--- a/packages/kit/src/components/ListItem/index.tsx
+++ b/packages/kit/src/components/ListItem/index.tsx
@@ -276,6 +276,7 @@ export type IListItemProps = PropsWithChildren<
     childrenBefore?: ComponentType | ReactNode;
     disabled?: boolean;
     testID?: string;
+    /** Style for the native Pressable wrapper. Only effective on native platforms. */
     nativePressableStyle?: StyleProp<ViewStyle>;
   } & IStackProps
 >;

--- a/packages/kit/src/views/Receive/pages/ReceiveSelector.tsx
+++ b/packages/kit/src/views/Receive/pages/ReceiveSelector.tsx
@@ -73,6 +73,7 @@ function ReceiveOptions({
       userSelect="none"
       bg="$neutral2"
       borderRadius="$4"
+      nativePressableStyle={{ flexShrink: 0 }}
       hoverStyle={{
         bg: '$neutral3',
       }}
@@ -493,6 +494,7 @@ function ReceiveSelectorContent() {
                 drillIn
                 onPress={() => handleExchangePress(config)}
                 gap="$4"
+                nativePressableStyle={{ flexShrink: 0 }}
               >
                 <Image
                   w="$10"


### PR DESCRIPTION
## Summary
- Add `nativePressableStyle` prop to `ListItem` to allow overriding the native `Pressable` wrapper style (defaults to `{ flex: 1 }`)
- Apply `flexShrink: 0` in `ReceiveSelector` to prevent ListItems from competing for vertical space and overlapping on iOS/Android

## Test plan
- [ ] Open Receive (接收) page on iOS/Android
- [ ] Verify all three sections (Buy crypto, Receive from wallet, Receive from exchange) display without overlapping
- [ ] Verify exchange list (Binance, OKX, Coinbase) is fully visible and not truncated
- [ ] Verify other pages using ListItem with `onPress` are not affected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
