### PR TITLE
fix(ListItem): add nativePressableStyle to prevent overlap in YStack containers

### DIFF
--- a/packages/kit/src/views/ApprovalManagement/hooks/useBulkRevoke.tsx
+++ b/packages/kit/src/views/ApprovalManagement/hooks/useBulkRevoke.tsx
@@ -170,6 +170,7 @@ function useBulkRevoke() {
             <ListItem
               mx="$0"
               drillIn
+              nativePressableStyle={{ flexShrink: 0 }}
               borderWidth={StyleSheet.hairlineWidth}
               borderColor="$borderSubdued"
               icon="HandPinchOutline"
@@ -190,6 +191,7 @@ function useBulkRevoke() {
             <ListItem
               mx="$0"
               drillIn
+              nativePressableStyle={{ flexShrink: 0 }}
               icon="FlashOutline"
               borderWidth={StyleSheet.hairlineWidth}
               borderColor="$borderSubdued"

--- a/packages/kit/src/views/KeyTag/pages/UserOptions/index.tsx
+++ b/packages/kit/src/views/KeyTag/pages/UserOptions/index.tsx
@@ -98,6 +98,7 @@ const UserOptions = () => {
               })}
               drillIn
               onPress={onBackup}
+              nativePressableStyle={{ flexShrink: 0 }}
               renderIcon={
                 <Stack bg="$bgStrong" p="$2" borderRadius="$3">
                   <Icon name="FolderUploadOutline" size="$6" color="$icon" />
@@ -112,6 +113,7 @@ const UserOptions = () => {
               })}
               drillIn
               onPress={onImport}
+              nativePressableStyle={{ flexShrink: 0 }}
               renderIcon={
                 <Stack bg="$bgStrong" p="$2" borderRadius="$3">
                   <Icon name="FolderDownloadOutline" size="$6" color="$icon" />

--- a/packages/kit/src/views/Onboarding/pages/ConnectHardwareWallet/SelectAddWalletTypeDialog.tsx
+++ b/packages/kit/src/views/Onboarding/pages/ConnectHardwareWallet/SelectAddWalletTypeDialog.tsx
@@ -41,6 +41,7 @@ export function SelectAddWalletTypeDialogContent({
             id: ETranslations.global_standard_wallet_desc,
           })}
           onPress={onAddStandardWalletPress}
+          nativePressableStyle={{ flexShrink: 0 }}
         >
           <ListItem.DrillIn />
         </ListItem>
@@ -64,6 +65,7 @@ export function SelectAddWalletTypeDialogContent({
             id: ETranslations.global_hidden_wallet_desc,
           })}
           onPress={onAddHiddenWalletPress}
+          nativePressableStyle={{ flexShrink: 0 }}
         >
           <ListItem.DrillIn />
         </ListItem>


### PR DESCRIPTION
## Summary
- Follow-up to #10803: apply `nativePressableStyle={{ flexShrink: 0 }}` to remaining ListItems with `onPress` inside `YStack` containers
- Fixes potential native overlap in:
  - **SelectAddWalletTypeDialog** — 2 ListItems (Standard/Hidden wallet selection)
  - **KeyTag UserOptions** — 2 ListItems (Backup/Import)
  - **useBulkRevoke Dialog** — 2 ListItems (One-by-one/Bulk revoke method selection)

## Test plan
- [ ] Open hardware wallet "Add Wallet Type" dialog on iOS/Android — verify Standard and Hidden wallet options display without overlapping
- [ ] Open KeyTag page on iOS/Android — verify Backup and Import options display without overlapping
- [ ] Open bulk revoke method dialog on iOS/Android — verify One-by-one and Bulk options display without overlapping
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
