### PR TITLE
fix: resolve nightly ESLint errors

### DIFF
--- a/packages/kit/src/components/ListItem/index.tsx
+++ b/packages/kit/src/components/ListItem/index.tsx
@@ -8,7 +8,6 @@ import type {
 import { isValidElement, useCallback, useState } from 'react';
 
 import { Pressable } from 'react-native';
-import type { StyleProp, ViewStyle } from 'react-native';
 
 import {
   Divider,
@@ -43,6 +42,7 @@ import { useStatefulAction } from '../../hooks/useStatefulAction';
 import { AccountAvatar } from '../AccountAvatar';
 
 import type { IAccountAvatarProps } from '../AccountAvatar';
+import type { StyleProp, ViewStyle } from 'react-native';
 
 interface IListItemAvatarCornerIconProps extends IIconProps {
   containerProps?: IStackProps;

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/index.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/index.tsx
@@ -521,7 +521,7 @@ function TokenDetailsView() {
       const baseName = token.networkName || token.networkId || token.$key;
       nameCount.set(baseName, (nameCount.get(baseName) ?? 0) + 1);
     }
-    const result = new Map<string, string>();
+    const tabNameMap = new Map<string, string>();
     const usedNames = new Set<string>();
     for (const token of tokens) {
       const baseName = token.networkName || token.networkId || token.$key;
@@ -536,9 +536,9 @@ function TokenDetailsView() {
         name = `${name} ${i}`;
       }
       usedNames.add(name);
-      result.set(token.$key, name);
+      tabNameMap.set(token.$key, name);
     }
-    return result;
+    return tabNameMap;
   }, [tokens]);
 
   const tabs = useMemo(() => {


### PR DESCRIPTION
## Summary
- Auto-fix ESLint errors detected by nightly CI
- Closes #10806

## Changes
- packages/kit/src/components/ListItem/index.tsx: reordered type import to satisfy import/order
- packages/kit/src/views/AssetDetails/pages/TokenDetails/index.tsx: renamed inner result map to tabNameMap to satisfy @typescript-eslint/no-shadow

## Test plan
- [x] ESLint passes locally (NODE_OPTIONS=--max-old-space-size=8192 npx eslint . --ext .ts,.tsx --max-warnings 0)
- [x] CI checks pass

🤖 Auto-generated by Scriptoria ESLint fix automation

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
