### PR TITLE
fix(usePromiseResult): guard cancelIdleCallback for Safari/WKWebView

### DIFF
--- a/packages/kit/src/hooks/usePromiseResult.ts
+++ b/packages/kit/src/hooks/usePromiseResult.ts
@@ -351,7 +351,9 @@ export function usePromiseResult<T>(
       prevFocusedRef.current = isFocusedRefValue;
 
       return () => {
-        idleHandles.forEach(cancelIdleCallback);
+        if (platformEnv.isNative) {
+          idleHandles.forEach(cancelIdleCallback);
+        }
       };
     }
   }, [isFocusedRefValue, resetDefer, resolveDefer, runWithPollingNonce]);


### PR DESCRIPTION
## Summary
- Fix `ReferenceError: Can't find variable: cancelIdleCallback` on iOS WKWebView (Safari)
- The cleanup function in `usePromiseResult` referenced `cancelIdleCallback` unconditionally, but this API doesn't exist in Safari/WKWebView
- Added `platformEnv.isNative` guard to the cleanup, mirroring the existing guard on the push side

## Test plan
- [x] Existing `usePromiseResult` tests pass
- [x] Verify no crash on iOS Safari/WKWebView when navigating to `/perps`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
