### PR TITLE
ci: add web build to release-app-bundles orchestrator

### DIFF
--- a/.github/workflows/release-app-bundles.yml
+++ b/.github/workflows/release-app-bundles.yml
@@ -9,7 +9,7 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: read
 
 jobs:

--- a/.github/workflows/release-app-bundles.yml
+++ b/.github/workflows/release-app-bundles.yml
@@ -169,3 +169,26 @@ jobs:
       QA_JS_BUNDLE_UPLOAD_SECRET: ${{ secrets.QA_JS_BUNDLE_UPLOAD_SECRET }}
       SLACK_NOTIFICATION_WEBHOOK: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
       ACTION_SIGN_SECERT_KEY: ${{ secrets.ACTION_SIGN_SECERT_KEY }}
+
+  web-bundle:
+    needs: prepare-params
+    uses: ./.github/workflows/release-web.yml
+    with:
+      build_number: ${{ needs.prepare-params.outputs.build_number }}
+      build_bundle_version: ${{ needs.prepare-params.outputs.build_bundle_version }}
+      build_source: ${{ needs.prepare-params.outputs.build_source }}
+      branch: ${{ needs.prepare-params.outputs.branch }}
+      commit: ${{ needs.prepare-params.outputs.commit }}
+      checkout_ref: ${{ needs.prepare-params.outputs.commit }}
+    secrets:
+      COVALENT_KEY: ${{ secrets.COVALENT_KEY }}
+      SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}
+      SENTRY_DSN_REACT_NATIVE: ${{ secrets.SENTRY_DSN_REACT_NATIVE }}
+      SENTRY_DSN_WEB: ${{ secrets.SENTRY_DSN_WEB }}
+      SENTRY_DSN_DESKTOP: ${{ secrets.SENTRY_DSN_DESKTOP }}
+      SENTRY_DSN_MAS: ${{ secrets.SENTRY_DSN_MAS }}
+      SENTRY_DSN_SNAP: ${{ secrets.SENTRY_DSN_SNAP }}
+      SENTRY_DSN_WINMS: ${{ secrets.SENTRY_DSN_WINMS }}
+      SENTRY_DSN_EXT: ${{ secrets.SENTRY_DSN_EXT }}
+      SLACK_NOTIFICATION_WEBHOOK: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+      ACTION_SIGN_SECERT_KEY: ${{ secrets.ACTION_SIGN_SECERT_KEY }}

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -312,10 +312,12 @@ jobs:
   notify:
     runs-on: ubuntu-24.04
     needs: [test-web, build-production]
-    if: ${{ github.event.workflow_run && always() }}
+    if: ${{ always() && (github.event.workflow_run || inputs.build_number) }}
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout_ref || '' }}
 
       - name: Run Shared Env Setup
         uses: ./.github/actions/shared-env
@@ -337,6 +339,42 @@ jobs:
           artifacts_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           echo "ARTIFACTS_URL=$artifacts_url" >> $GITHUB_ENV
 
+      - name: Override params from caller
+        if: ${{ inputs.build_number }}
+        run: |
+          echo "BUILD_NUMBER=${{ inputs.build_number }}" >> $GITHUB_ENV
+          echo "BUILD_BUNDLE_VERSION=${{ inputs.build_bundle_version }}" >> $GITHUB_ENV
+          sed -i "s/^BUNDLE_VERSION=.*/BUNDLE_VERSION=${{ inputs.build_bundle_version }}/" .env
+          sed -i "s/^CI_BUILD_NUMBER=.*/CI_BUILD_NUMBER=${{ inputs.build_number }}/" .env
+
+      - name: Resolve branch and commit
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_COMMIT: ${{ inputs.commit }}
+          WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WR_COMMIT: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if [ -n "$INPUT_BRANCH" ]; then
+            BRANCH="$INPUT_BRANCH"
+            COMMIT="$INPUT_COMMIT"
+          elif [ -n "$WR_COMMIT" ]; then
+            BRANCH="$WR_BRANCH"
+            COMMIT="$WR_COMMIT"
+          else
+            BRANCH="${{ github.ref_name }}"
+            COMMIT="${{ github.sha }}"
+          fi
+          {
+            echo "BRANCH<<GHEOF"
+            echo "$BRANCH"
+            echo "GHEOF"
+          } >> "$GITHUB_ENV"
+          {
+            echo "COMMIT<<GHEOF"
+            echo "$COMMIT"
+            echo "GHEOF"
+          } >> "$GITHUB_ENV"
+
       - name: 'Notify to Slack'
         uses: onekeyhq/actions/slack-notify-webhook@86ad045e18da7958f659995ee2f9df375dd03ef4 # pin to SHA
         with:
@@ -350,3 +388,6 @@ jobs:
           artifact-download-url: '${{ env.ARTIFACTS_URL }}'
           artifact-skip-gpg: '${{ env.ONEKEY_ALLOW_SKIP_GPG_VERIFICATION }}'
           artifact-bundle-version: '${{ env.BUILD_BUNDLE_VERSION }}'
+          artifact-build-source: '${{ inputs.build_source || ''daily-build'' }}'
+          artifact-branch: '${{ env.BRANCH }}'
+          artifact-commit: '${{ env.COMMIT }}'

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -7,6 +7,50 @@ on:
     types:
       - completed
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      build_number:
+        type: string
+        required: true
+      build_bundle_version:
+        type: string
+        required: true
+      build_source:
+        type: string
+        required: false
+        default: 'daily-build'
+      branch:
+        type: string
+        required: false
+      commit:
+        type: string
+        required: false
+      checkout_ref:
+        type: string
+        required: false
+    secrets:
+      COVALENT_KEY:
+        required: false
+      SENTRY_TOKEN:
+        required: false
+      SENTRY_DSN_REACT_NATIVE:
+        required: false
+      SENTRY_DSN_WEB:
+        required: false
+      SENTRY_DSN_DESKTOP:
+        required: false
+      SENTRY_DSN_MAS:
+        required: false
+      SENTRY_DSN_SNAP:
+        required: false
+      SENTRY_DSN_WINMS:
+        required: false
+      SENTRY_DSN_EXT:
+        required: false
+      SLACK_NOTIFICATION_WEBHOOK:
+        required: false
+      ACTION_SIGN_SECERT_KEY:
+        required: false
 
 env:
   NODE_ENV: production

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -68,10 +68,19 @@ jobs:
         run: |
           echo "Executed at: $(date '+%Y-%m-%d %H:%M:%S')"
 
+      - name: Validate workflow_run source
+        if: github.event_name == 'workflow_run'
+        run: |
+          if [ "${{ github.event.workflow_run.head_repository.full_name }}" != "${{ github.repository }}" ]; then
+            echo "::error::Rejecting workflow_run from fork repository"
+            exit 1
+          fi
+
       - name: Checkout Source Code
         uses: actions/checkout@v4
         with:
           lfs: true
+          ref: ${{ inputs.checkout_ref || '' }}
 
       - name: Run Shared Env Setup
         uses: ./.github/actions/shared-env
@@ -105,6 +114,48 @@ jobs:
           # For test environment, use GitHub Pages URL
           echo "PUBLIC_URL=https://${{ env.TEST_ENDPOINT }}/" >> $GITHUB_ENV
 
+      - name: Override params from caller
+        if: ${{ inputs.build_number }}
+        run: |
+          echo "BUILD_NUMBER=${{ inputs.build_number }}" >> $GITHUB_ENV
+          echo "BUILD_BUNDLE_VERSION=${{ inputs.build_bundle_version }}" >> $GITHUB_ENV
+          sed -i "s/^BUNDLE_VERSION=.*/BUNDLE_VERSION=${{ inputs.build_bundle_version }}/" .env
+          sed -i "s/^CI_BUILD_NUMBER=.*/CI_BUILD_NUMBER=${{ inputs.build_number }}/" .env
+
+      - name: Resolve branch and commit
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_COMMIT: ${{ inputs.commit }}
+          WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WR_COMMIT: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if [ -n "$INPUT_BRANCH" ]; then
+            BRANCH="$INPUT_BRANCH"
+            COMMIT="$INPUT_COMMIT"
+          elif [ -n "$WR_COMMIT" ]; then
+            BRANCH="$WR_BRANCH"
+            COMMIT="$WR_COMMIT"
+          else
+            BRANCH="${{ github.ref_name }}"
+            COMMIT="${{ github.sha }}"
+          fi
+          {
+            echo "BRANCH<<GHEOF"
+            echo "$BRANCH"
+            echo "GHEOF"
+          } >> "$GITHUB_ENV"
+          {
+            echo "COMMIT<<GHEOF"
+            echo "$COMMIT"
+            echo "GHEOF"
+          } >> "$GITHUB_ENV"
+          COMMIT_MESSAGE=$(git log -1 --pretty=%s "$COMMIT" 2>/dev/null || echo "")
+          {
+            echo "COMMIT_MESSAGE<<GHEOF"
+            echo "$COMMIT_MESSAGE"
+            echo "GHEOF"
+          } >> "$GITHUB_ENV"
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=${{ github.workspace }}/.yarn" >> "$GITHUB_OUTPUT"
@@ -126,7 +177,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: app-monorepo-test-${{ github.sha }}-${{ env.BUILD_NUMBER }}
+          name: app-monorepo-test-${{ env.COMMIT }}-${{ env.BUILD_NUMBER }}
           path: |
             ./apps/web/web-build/
 

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -194,10 +194,19 @@ jobs:
 
     if: ${{ !github.event.workflow_run || (github.event.workflow_run && github.event.workflow_run.conclusion == 'success') }}
     steps:
+      - name: Validate workflow_run source
+        if: github.event_name == 'workflow_run'
+        run: |
+          if [ "${{ github.event.workflow_run.head_repository.full_name }}" != "${{ github.repository }}" ]; then
+            echo "::error::Rejecting workflow_run from fork repository"
+            exit 1
+          fi
+
       - name: Checkout Source Code
         uses: actions/checkout@v4
         with:
           lfs: true
+          ref: ${{ inputs.checkout_ref || '' }}
 
       - name: Run Shared Env Setup
         uses: ./.github/actions/shared-env
@@ -231,6 +240,50 @@ jobs:
           # For production environment, use production URL
           echo "PUBLIC_URL=https://app-assets.onekey.so/${{ github.sha }}-${{ env.BUILD_NUMBER }}/" >> $GITHUB_ENV
 
+      - name: Override params from caller
+        if: ${{ inputs.build_number }}
+        run: |
+          echo "BUILD_NUMBER=${{ inputs.build_number }}" >> $GITHUB_ENV
+          echo "BUILD_BUNDLE_VERSION=${{ inputs.build_bundle_version }}" >> $GITHUB_ENV
+          sed -i "s/^BUNDLE_VERSION=.*/BUNDLE_VERSION=${{ inputs.build_bundle_version }}/" .env
+          sed -i "s/^CI_BUILD_NUMBER=.*/CI_BUILD_NUMBER=${{ inputs.build_number }}/" .env
+
+      - name: Resolve branch and commit
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_COMMIT: ${{ inputs.commit }}
+          WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WR_COMMIT: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if [ -n "$INPUT_BRANCH" ]; then
+            BRANCH="$INPUT_BRANCH"
+            COMMIT="$INPUT_COMMIT"
+          elif [ -n "$WR_COMMIT" ]; then
+            BRANCH="$WR_BRANCH"
+            COMMIT="$WR_COMMIT"
+          else
+            BRANCH="${{ github.ref_name }}"
+            COMMIT="${{ github.sha }}"
+          fi
+          {
+            echo "BRANCH<<GHEOF"
+            echo "$BRANCH"
+            echo "GHEOF"
+          } >> "$GITHUB_ENV"
+          {
+            echo "COMMIT<<GHEOF"
+            echo "$COMMIT"
+            echo "GHEOF"
+          } >> "$GITHUB_ENV"
+          COMMIT_MESSAGE=$(git log -1 --pretty=%s "$COMMIT" 2>/dev/null || echo "")
+          {
+            echo "COMMIT_MESSAGE<<GHEOF"
+            echo "$COMMIT_MESSAGE"
+            echo "GHEOF"
+          } >> "$GITHUB_ENV"
+          # Override PUBLIC_URL with resolved commit (replaces github.sha set by Setup ENV)
+          echo "PUBLIC_URL=https://app-assets.onekey.so/${COMMIT}-${{ env.BUILD_NUMBER }}/" >> $GITHUB_ENV
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=${{ github.workspace }}/.yarn" >> "$GITHUB_OUTPUT"
@@ -252,7 +305,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: app-monorepo-${{ github.sha }}-${{ env.BUILD_NUMBER }}
+          name: app-monorepo-${{ env.COMMIT }}-${{ env.BUILD_NUMBER }}
           path: |
             ./apps/web/web-build/
 

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -139,6 +139,11 @@ jobs:
             BRANCH="${{ github.ref_name }}"
             COMMIT="${{ github.sha }}"
           fi
+          # Validate commit SHA format to prevent env injection
+          if [[ ! "$COMMIT" =~ ^[0-9a-f]{7,40}$ ]]; then
+            echo "::error::Invalid commit SHA format: $COMMIT"
+            exit 1
+          fi
           {
             echo "BRANCH<<GHEOF"
             echo "$BRANCH"
@@ -265,6 +270,11 @@ jobs:
             BRANCH="${{ github.ref_name }}"
             COMMIT="${{ github.sha }}"
           fi
+          # Validate commit SHA format to prevent env injection
+          if [[ ! "$COMMIT" =~ ^[0-9a-f]{7,40}$ ]]; then
+            echo "::error::Invalid commit SHA format: $COMMIT"
+            exit 1
+          fi
           {
             echo "BRANCH<<GHEOF"
             echo "$BRANCH"
@@ -363,6 +373,11 @@ jobs:
           else
             BRANCH="${{ github.ref_name }}"
             COMMIT="${{ github.sha }}"
+          fi
+          # Validate commit SHA format to prevent env injection
+          if [[ ! "$COMMIT" =~ ^[0-9a-f]{7,40}$ ]]; then
+            echo "::error::Invalid commit SHA format: $COMMIT"
+            exit 1
           fi
           {
             echo "BRANCH<<GHEOF"

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -144,21 +144,22 @@ jobs:
             echo "::error::Invalid commit SHA format: $COMMIT"
             exit 1
           fi
+          DELIMITER=$(uuidgen)
           {
-            echo "BRANCH<<GHEOF"
+            echo "BRANCH<<${DELIMITER}"
             echo "$BRANCH"
-            echo "GHEOF"
+            echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
           {
-            echo "COMMIT<<GHEOF"
+            echo "COMMIT<<${DELIMITER}"
             echo "$COMMIT"
-            echo "GHEOF"
+            echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
           COMMIT_MESSAGE=$(git log -1 --pretty=%s "$COMMIT" 2>/dev/null || echo "")
           {
-            echo "COMMIT_MESSAGE<<GHEOF"
+            echo "COMMIT_MESSAGE<<${DELIMITER}"
             echo "$COMMIT_MESSAGE"
-            echo "GHEOF"
+            echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
 
       - name: Get yarn cache directory path
@@ -275,21 +276,22 @@ jobs:
             echo "::error::Invalid commit SHA format: $COMMIT"
             exit 1
           fi
+          DELIMITER=$(uuidgen)
           {
-            echo "BRANCH<<GHEOF"
+            echo "BRANCH<<${DELIMITER}"
             echo "$BRANCH"
-            echo "GHEOF"
+            echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
           {
-            echo "COMMIT<<GHEOF"
+            echo "COMMIT<<${DELIMITER}"
             echo "$COMMIT"
-            echo "GHEOF"
+            echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
           COMMIT_MESSAGE=$(git log -1 --pretty=%s "$COMMIT" 2>/dev/null || echo "")
           {
-            echo "COMMIT_MESSAGE<<GHEOF"
+            echo "COMMIT_MESSAGE<<${DELIMITER}"
             echo "$COMMIT_MESSAGE"
-            echo "GHEOF"
+            echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
           # Override PUBLIC_URL with resolved commit (replaces github.sha set by Setup ENV)
           echo "PUBLIC_URL=https://app-assets.onekey.so/${COMMIT}-${{ env.BUILD_NUMBER }}/" >> $GITHUB_ENV
@@ -379,15 +381,16 @@ jobs:
             echo "::error::Invalid commit SHA format: $COMMIT"
             exit 1
           fi
+          DELIMITER=$(uuidgen)
           {
-            echo "BRANCH<<GHEOF"
+            echo "BRANCH<<${DELIMITER}"
             echo "$BRANCH"
-            echo "GHEOF"
+            echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
           {
-            echo "COMMIT<<GHEOF"
+            echo "COMMIT<<${DELIMITER}"
             echo "$COMMIT"
-            echo "GHEOF"
+            echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
 
       - name: 'Notify to Slack'


### PR DESCRIPTION
## Summary

- Add `workflow_call` trigger to `release-web.yml` with same input schema as `release-desktop-bundle.yml`
- Add fork validation, param override, and branch/commit resolution to all three web jobs (`test-web`, `build-production`, `notify`)
- Fix `PUBLIC_URL` and artifact names to use resolved commit instead of `github.sha` (incorrect in `workflow_call` context)
- Update Slack notify condition to fire on `workflow_run` (daily-build) and `workflow_call` (app-bundles) but NOT standalone `workflow_dispatch`
- Add `artifact-build-source`, `artifact-branch`, `artifact-commit` to Slack notify for bundle thread integration
- Add `web-bundle` job to `release-app-bundles.yml` parallel to desktop and native bundles

## Trigger behavior

| Trigger | test-web | build-production | Slack notify |
|---|---|---|---|
| `workflow_run` (daily-build) | ✅ | ✅ | ✅ |
| `workflow_call` (app-bundles) | ✅ | ✅ | ✅ |
| `workflow_dispatch` (manual) | ✅ | ✅ | ❌ |

## Slack thread integration

Web notifications join the same Slack thread as desktop/native bundles via shared `buildNumber + buildSource + bundleVersion` KV key. No changes to `slack-notify-webhook` action or `eas-notice` worker.

## Test plan

- [ ] Trigger `release-app-bundles` manually → verify web-bundle job runs alongside desktop/native
- [ ] Trigger `release-app-bundles` with `pr_number` → verify correct checkout and artifact naming
- [ ] Trigger `release-web` standalone via `workflow_dispatch` → verify no Slack notification, existing behavior unchanged
- [ ] Verify Slack notification lands in bundle thread with Web status
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
