### PR TITLE
ci: add web build to release-app-bundles orchestrator (#10816)

### DIFF
--- a/.github/workflows/release-app-bundles.yml
+++ b/.github/workflows/release-app-bundles.yml
@@ -9,7 +9,7 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: read
 
 jobs:
@@ -167,5 +167,28 @@ jobs:
       ASC_PROVIDER: ${{ secrets.ASC_PROVIDER }}
       QA_JS_BUNDLE_SERVER_URL: ${{ secrets.QA_JS_BUNDLE_SERVER_URL }}
       QA_JS_BUNDLE_UPLOAD_SECRET: ${{ secrets.QA_JS_BUNDLE_UPLOAD_SECRET }}
+      SLACK_NOTIFICATION_WEBHOOK: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
+      ACTION_SIGN_SECERT_KEY: ${{ secrets.ACTION_SIGN_SECERT_KEY }}
+
+  web-bundle:
+    needs: prepare-params
+    uses: ./.github/workflows/release-web.yml
+    with:
+      build_number: ${{ needs.prepare-params.outputs.build_number }}
+      build_bundle_version: ${{ needs.prepare-params.outputs.build_bundle_version }}
+      build_source: ${{ needs.prepare-params.outputs.build_source }}
+      branch: ${{ needs.prepare-params.outputs.branch }}
+      commit: ${{ needs.prepare-params.outputs.commit }}
+      checkout_ref: ${{ needs.prepare-params.outputs.commit }}
+    secrets:
+      COVALENT_KEY: ${{ secrets.COVALENT_KEY }}
+      SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}
+      SENTRY_DSN_REACT_NATIVE: ${{ secrets.SENTRY_DSN_REACT_NATIVE }}
+      SENTRY_DSN_WEB: ${{ secrets.SENTRY_DSN_WEB }}
+      SENTRY_DSN_DESKTOP: ${{ secrets.SENTRY_DSN_DESKTOP }}
+      SENTRY_DSN_MAS: ${{ secrets.SENTRY_DSN_MAS }}
+      SENTRY_DSN_SNAP: ${{ secrets.SENTRY_DSN_SNAP }}
+      SENTRY_DSN_WINMS: ${{ secrets.SENTRY_DSN_WINMS }}
+      SENTRY_DSN_EXT: ${{ secrets.SENTRY_DSN_EXT }}
       SLACK_NOTIFICATION_WEBHOOK: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}
       ACTION_SIGN_SECERT_KEY: ${{ secrets.ACTION_SIGN_SECERT_KEY }}

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -7,6 +7,50 @@ on:
     types:
       - completed
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      build_number:
+        type: string
+        required: true
+      build_bundle_version:
+        type: string
+        required: true
+      build_source:
+        type: string
+        required: false
+        default: 'daily-build'
+      branch:
+        type: string
+        required: false
+      commit:
+        type: string
+        required: false
+      checkout_ref:
+        type: string
+        required: false
+    secrets:
+      COVALENT_KEY:
+        required: false
+      SENTRY_TOKEN:
+        required: false
+      SENTRY_DSN_REACT_NATIVE:
+        required: false
+      SENTRY_DSN_WEB:
+        required: false
+      SENTRY_DSN_DESKTOP:
+        required: false
+      SENTRY_DSN_MAS:
+        required: false
+      SENTRY_DSN_SNAP:
+        required: false
+      SENTRY_DSN_WINMS:
+        required: false
+      SENTRY_DSN_EXT:
+        required: false
+      SLACK_NOTIFICATION_WEBHOOK:
+        required: false
+      ACTION_SIGN_SECERT_KEY:
+        required: false
 
 env:
   NODE_ENV: production
@@ -24,10 +68,19 @@ jobs:
         run: |
           echo "Executed at: $(date '+%Y-%m-%d %H:%M:%S')"
 
+      - name: Validate workflow_run source
+        if: github.event_name == 'workflow_run'
+        run: |
+          if [ "${{ github.event.workflow_run.head_repository.full_name }}" != "${{ github.repository }}" ]; then
+            echo "::error::Rejecting workflow_run from fork repository"
+            exit 1
+          fi
+
       - name: Checkout Source Code
         uses: actions/checkout@v4
         with:
           lfs: true
+          ref: ${{ inputs.checkout_ref || '' }}
 
       - name: Run Shared Env Setup
         uses: ./.github/actions/shared-env
@@ -61,6 +114,54 @@ jobs:
           # For test environment, use GitHub Pages URL
           echo "PUBLIC_URL=https://${{ env.TEST_ENDPOINT }}/" >> $GITHUB_ENV
 
+      - name: Override params from caller
+        if: ${{ inputs.build_number }}
+        run: |
+          echo "BUILD_NUMBER=${{ inputs.build_number }}" >> $GITHUB_ENV
+          echo "BUILD_BUNDLE_VERSION=${{ inputs.build_bundle_version }}" >> $GITHUB_ENV
+          sed -i "s/^BUNDLE_VERSION=.*/BUNDLE_VERSION=${{ inputs.build_bundle_version }}/" .env
+          sed -i "s/^CI_BUILD_NUMBER=.*/CI_BUILD_NUMBER=${{ inputs.build_number }}/" .env
+
+      - name: Resolve branch and commit
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_COMMIT: ${{ inputs.commit }}
+          WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WR_COMMIT: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if [ -n "$INPUT_BRANCH" ]; then
+            BRANCH="$INPUT_BRANCH"
+            COMMIT="$INPUT_COMMIT"
+          elif [ -n "$WR_COMMIT" ]; then
+            BRANCH="$WR_BRANCH"
+            COMMIT="$WR_COMMIT"
+          else
+            BRANCH="${{ github.ref_name }}"
+            COMMIT="${{ github.sha }}"
+          fi
+          # Validate commit SHA format to prevent env injection
+          if [[ ! "$COMMIT" =~ ^[0-9a-f]{7,40}$ ]]; then
+            echo "::error::Invalid commit SHA format: $COMMIT"
+            exit 1
+          fi
+          DELIMITER=$(uuidgen)
+          {
+            echo "BRANCH<<${DELIMITER}"
+            echo "$BRANCH"
+            echo "${DELIMITER}"
+          } >> "$GITHUB_ENV"
+          {
+            echo "COMMIT<<${DELIMITER}"
+            echo "$COMMIT"
+            echo "${DELIMITER}"
+          } >> "$GITHUB_ENV"
+          COMMIT_MESSAGE=$(git log -1 --pretty=%s "$COMMIT" 2>/dev/null || echo "")
+          {
+            echo "COMMIT_MESSAGE<<${DELIMITER}"
+            echo "$COMMIT_MESSAGE"
+            echo "${DELIMITER}"
+          } >> "$GITHUB_ENV"
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=${{ github.workspace }}/.yarn" >> "$GITHUB_OUTPUT"
@@ -82,7 +183,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: app-monorepo-test-${{ github.sha }}-${{ env.BUILD_NUMBER }}
+          name: app-monorepo-test-${{ env.COMMIT }}-${{ env.BUILD_NUMBER }}
           path: |
             ./apps/web/web-build/
 
@@ -99,10 +200,19 @@ jobs:
 
     if: ${{ !github.event.workflow_run || (github.event.workflow_run && github.event.workflow_run.conclusion == 'success') }}
     steps:
+      - name: Validate workflow_run source
+        if: github.event_name == 'workflow_run'
+        run: |
+          if [ "${{ github.event.workflow_run.head_repository.full_name }}" != "${{ github.repository }}" ]; then
+            echo "::error::Rejecting workflow_run from fork repository"
+            exit 1
+          fi
+
       - name: Checkout Source Code
         uses: actions/checkout@v4
         with:
           lfs: true
+          ref: ${{ inputs.checkout_ref || '' }}
 
       - name: Run Shared Env Setup
         uses: ./.github/actions/shared-env
@@ -136,6 +246,56 @@ jobs:
           # For production environment, use production URL
           echo "PUBLIC_URL=https://app-assets.onekey.so/${{ github.sha }}-${{ env.BUILD_NUMBER }}/" >> $GITHUB_ENV
 
+      - name: Override params from caller
+        if: ${{ inputs.build_number }}
+        run: |
+          echo "BUILD_NUMBER=${{ inputs.build_number }}" >> $GITHUB_ENV
+          echo "BUILD_BUNDLE_VERSION=${{ inputs.build_bundle_version }}" >> $GITHUB_ENV
+          sed -i "s/^BUNDLE_VERSION=.*/BUNDLE_VERSION=${{ inputs.build_bundle_version }}/" .env
+          sed -i "s/^CI_BUILD_NUMBER=.*/CI_BUILD_NUMBER=${{ inputs.build_number }}/" .env
+
+      - name: Resolve branch and commit
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_COMMIT: ${{ inputs.commit }}
+          WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WR_COMMIT: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if [ -n "$INPUT_BRANCH" ]; then
+            BRANCH="$INPUT_BRANCH"
+            COMMIT="$INPUT_COMMIT"
+          elif [ -n "$WR_COMMIT" ]; then
+            BRANCH="$WR_BRANCH"
+            COMMIT="$WR_COMMIT"
+          else
+            BRANCH="${{ github.ref_name }}"
+            COMMIT="${{ github.sha }}"
+          fi
+          # Validate commit SHA format to prevent env injection
+          if [[ ! "$COMMIT" =~ ^[0-9a-f]{7,40}$ ]]; then
+            echo "::error::Invalid commit SHA format: $COMMIT"
+            exit 1
+          fi
+          DELIMITER=$(uuidgen)
+          {
+            echo "BRANCH<<${DELIMITER}"
+            echo "$BRANCH"
+            echo "${DELIMITER}"
+          } >> "$GITHUB_ENV"
+          {
+            echo "COMMIT<<${DELIMITER}"
+            echo "$COMMIT"
+            echo "${DELIMITER}"
+          } >> "$GITHUB_ENV"
+          COMMIT_MESSAGE=$(git log -1 --pretty=%s "$COMMIT" 2>/dev/null || echo "")
+          {
+            echo "COMMIT_MESSAGE<<${DELIMITER}"
+            echo "$COMMIT_MESSAGE"
+            echo "${DELIMITER}"
+          } >> "$GITHUB_ENV"
+          # Override PUBLIC_URL with resolved commit (replaces github.sha set by Setup ENV)
+          echo "PUBLIC_URL=https://app-assets.onekey.so/${COMMIT}-${{ env.BUILD_NUMBER }}/" >> $GITHUB_ENV
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=${{ github.workspace }}/.yarn" >> "$GITHUB_OUTPUT"
@@ -157,17 +317,19 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: app-monorepo-${{ github.sha }}-${{ env.BUILD_NUMBER }}
+          name: app-monorepo-${{ env.COMMIT }}-${{ env.BUILD_NUMBER }}
           path: |
             ./apps/web/web-build/
 
   notify:
     runs-on: ubuntu-24.04
     needs: [test-web, build-production]
-    if: ${{ github.event.workflow_run && always() }}
+    if: ${{ always() && (github.event.workflow_run || inputs.build_number) }}
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout_ref || '' }}
 
       - name: Run Shared Env Setup
         uses: ./.github/actions/shared-env
@@ -189,6 +351,48 @@ jobs:
           artifacts_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           echo "ARTIFACTS_URL=$artifacts_url" >> $GITHUB_ENV
 
+      - name: Override params from caller
+        if: ${{ inputs.build_number }}
+        run: |
+          echo "BUILD_NUMBER=${{ inputs.build_number }}" >> $GITHUB_ENV
+          echo "BUILD_BUNDLE_VERSION=${{ inputs.build_bundle_version }}" >> $GITHUB_ENV
+          sed -i "s/^BUNDLE_VERSION=.*/BUNDLE_VERSION=${{ inputs.build_bundle_version }}/" .env
+          sed -i "s/^CI_BUILD_NUMBER=.*/CI_BUILD_NUMBER=${{ inputs.build_number }}/" .env
+
+      - name: Resolve branch and commit
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_COMMIT: ${{ inputs.commit }}
+          WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WR_COMMIT: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if [ -n "$INPUT_BRANCH" ]; then
+            BRANCH="$INPUT_BRANCH"
+            COMMIT="$INPUT_COMMIT"
+          elif [ -n "$WR_COMMIT" ]; then
+            BRANCH="$WR_BRANCH"
+            COMMIT="$WR_COMMIT"
+          else
+            BRANCH="${{ github.ref_name }}"
+            COMMIT="${{ github.sha }}"
+          fi
+          # Validate commit SHA format to prevent env injection
+          if [[ ! "$COMMIT" =~ ^[0-9a-f]{7,40}$ ]]; then
+            echo "::error::Invalid commit SHA format: $COMMIT"
+            exit 1
+          fi
+          DELIMITER=$(uuidgen)
+          {
+            echo "BRANCH<<${DELIMITER}"
+            echo "$BRANCH"
+            echo "${DELIMITER}"
+          } >> "$GITHUB_ENV"
+          {
+            echo "COMMIT<<${DELIMITER}"
+            echo "$COMMIT"
+            echo "${DELIMITER}"
+          } >> "$GITHUB_ENV"
+
       - name: 'Notify to Slack'
         uses: onekeyhq/actions/slack-notify-webhook@86ad045e18da7958f659995ee2f9df375dd03ef4 # pin to SHA
         with:
@@ -202,3 +406,6 @@ jobs:
           artifact-download-url: '${{ env.ARTIFACTS_URL }}'
           artifact-skip-gpg: '${{ env.ONEKEY_ALLOW_SKIP_GPG_VERIFICATION }}'
           artifact-bundle-version: '${{ env.BUILD_BUNDLE_VERSION }}'
+          artifact-build-source: '${{ inputs.build_source || ''daily-build'' }}'
+          artifact-branch: '${{ env.BRANCH }}'
+          artifact-commit: '${{ env.COMMIT }}'


### PR DESCRIPTION
* ci(release-web): add workflow_call trigger with inputs and secrets

* ci(release-web): add fork validation, param override, and commit resolution to test-web

* ci(release-web): add param override and commit resolution to build-production

* ci(release-web): update notify job with condition fix, param override, and Slack fields

* ci(release-app-bundles): add web-bundle job alongside desktop and native

* ci(release-web): add commit SHA validation to prevent env injection (CodeQL)

* ci(release-web): use UUID delimiters for GITHUB_ENV heredocs (CodeQL fix)

* ci(release-app-bundles): grant contents:write for gh-pages deploy in web-bundle
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10817" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
