### PR TITLE
fix(ci): prevent reusable workflow jobs from being skipped in release-app-bundles

### DIFF
--- a/.github/workflows/release-app-bundles.yml
+++ b/.github/workflows/release-app-bundles.yml
@@ -116,6 +116,7 @@ jobs:
 
   desktop-bundle:
     needs: prepare-params
+    if: ${{ !cancelled() && !failure() }}
     uses: ./.github/workflows/release-desktop-bundle.yml
     with:
       build_number: ${{ needs.prepare-params.outputs.build_number }}
@@ -144,6 +145,7 @@ jobs:
 
   native-bundle:
     needs: prepare-params
+    if: ${{ !cancelled() && !failure() }}
     uses: ./.github/workflows/release-native-bundle.yml
     with:
       build_number: ${{ needs.prepare-params.outputs.build_number }}
@@ -172,6 +174,7 @@ jobs:
 
   web-bundle:
     needs: prepare-params
+    if: ${{ !cancelled() && !failure() }}
     uses: ./.github/workflows/release-web.yml
     with:
       build_number: ${{ needs.prepare-params.outputs.build_number }}


### PR DESCRIPTION
## Summary
- Add `if: ${{ !cancelled() && !failure() }}` to all three reusable workflow jobs (`desktop-bundle`, `native-bundle`, `web-bundle`) in `release-app-bundles.yml`

## Intent & Context
The `release-app-bundles` workflow was completely broken — all bundle build jobs were being skipped despite `prepare-params` completing successfully. This was discovered when [run #23405984012](https://github.com/OneKeyHQ/app-monorepo/actions/runs/23405984012) showed all three bundle jobs skipped with 0 steps executed.

## Root Cause
GitHub Actions evaluates the `needs` dependency chain **transitively** for reusable workflow jobs (those using `uses:`), unlike regular jobs which only check direct dependencies.

The dependency chain is:
```
validate-pr (skipped) → prepare-params (success via always()) → bundle jobs (reusable workflows)
```

When `release-app-bundles` is triggered via `workflow_dispatch` without a `pr_number`, `validate-pr` is skipped (its `if` condition is false). `prepare-params` handles this correctly with `if: always() && (result == 'success' || result == 'skipped')`. However, the downstream reusable workflow jobs see `validate-pr` as skipped in their transitive chain and the default `success()` condition causes them to skip as well.

This behavior is specific to reusable workflows — regular jobs only evaluate direct `needs` dependencies.

## Design Decisions
- Used `!cancelled() && !failure()` rather than `always()` to preserve the correct behavior of stopping bundle jobs if `prepare-params` actually fails or is cancelled
- This is the minimal fix — an alternative would be restructuring the workflow to remove `validate-pr` from the `needs` chain entirely, but that would be a larger change

## Changes Detail
- `.github/workflows/release-app-bundles.yml`: Added `if: ${{ !cancelled() && !failure() }}` to `desktop-bundle`, `native-bundle`, and `web-bundle` job definitions

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: None (CI-only change)
- **Risk Areas**: None — this is a pure CI fix that restores intended behavior

## Test plan
- [ ] Re-run `release-app-bundles` workflow via `workflow_dispatch` without `pr_number` and verify all three bundle jobs start executing
- [ ] Run with a valid `pr_number` and verify `validate-pr` + bundle jobs all execute correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
