### PR TITLE
fix(perp): correct token pair suffix from USD to USDC on mobile market detail page

### DIFF
--- a/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
+++ b/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
@@ -73,7 +73,7 @@ function MobilePerpMarket() {
   const renderHeaderTitle = useCallback(() => {
     const parsedCoin = coin ? parseDexCoin(coin) : null;
     const displayCoin = parsedCoin?.displayName || coin || '';
-    const pairLabel = displayCoin ? `${displayCoin}USD` : '--';
+    const pairLabel = displayCoin ? `${displayCoin}USDC` : '--';
     return (
       <XStack alignItems="center" gap="$2">
         <NavBackButton


### PR DESCRIPTION
## Summary
- Fix incorrect token pair suffix displaying "USD" instead of "USDC" on mobile perpetual market detail page

## 热更新
- 已验证 ✅ @ziying
- bundle：`62e27f7d`

## Test plan
- [x] Open mobile perp market detail page
- [x] Verify token pair displays correct "USDC" suffix instead of "USD"