### PR TITLE
docs: fix broken README references in docs/i18n/README.jp.md

### DIFF
--- a/docs/i18n/README.jp.md
+++ b/docs/i18n/README.jp.md
@@ -1,8 +1,8 @@
 
 ## 🌍 環境設定
 
-1. [node.js LTS バージョン (>= 16)] をインストールする(https://nodejs.org/en/)
-2. [yarnパッケージ管理ツール]（https://yarnpkg.com/）バージョン1.18.0をインストールします。 （最新バージョンのyarnをインストールした後、ルートディレクトリで `yarn policy set-version 1.18.0`を実行します）
+1. [node.js LTS バージョン (>= 16)](https://nodejs.org/en/) をインストールする
+2. [yarnパッケージ管理ツール](https://yarnpkg.com/) バージョン1.18.0をインストールします。 （最新バージョンのyarnをインストールした後、ルートディレクトリで `yarn policy set-version 1.18.0`を実行します）
 3. インストール [git lfs](https://git-lfs.github.com/) (いくつかのバイナリのプルおよびアップデートに必要)
 4. iOSプロジェクトを開始するには、ローカルXCodeバージョンが13.3以上であることを確認してください
 5. Androidプロジェクトを開始するには、ローカルJDKバージョンが11以上であることを確認してください


### PR DESCRIPTION
## Summary
- Automated README maintenance for `OneKeyHQ/app-monorepo` focused on dead links and stale API references.

## Changed files
- `docs/i18n/README.jp.md`: 2 edit(s)

## Validation
- Reviewed README Markdown files only.
- Kept edits minimal and localized to broken references or outdated API endpoints.

Automated README maintenance pass focused on dead links and stale API references. If this saved you time, coffee on Base is always appreciated: 0x85a7d7eefac69d5f90615cf72a4dcc5657370e2c
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
