### PR TITLE
refactor(keyless-sync): improve credential cache lifecycle

### DIFF
--- a/packages/components/src/composite/Dialog/index.tsx
+++ b/packages/components/src/composite/Dialog/index.tsx
@@ -362,7 +362,6 @@ function DialogFrame({
             <TMDialog.Title display="none" />
             <TMDialog.Content
               elevate
-              // @ts-expect-error
               trapFocus={effectiveTrapFocus}
               onEscapeKeyDown={handleEscapeKeyDown as any}
               key="content"

--- a/packages/components/src/composite/Dialog/index.tsx
+++ b/packages/components/src/composite/Dialog/index.tsx
@@ -362,6 +362,7 @@ function DialogFrame({
             <TMDialog.Title display="none" />
             <TMDialog.Content
               elevate
+              // @ts-expect-error
               trapFocus={effectiveTrapFocus}
               onEscapeKeyDown={handleEscapeKeyDown as any}
               key="content"

--- a/packages/kit-bg/src/dbs/local/LocalDbBase.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.ts
@@ -653,30 +653,24 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
     tx: ILocalDBTransaction;
   }): Promise<IKeylessCloudSyncCredential | null> {
     try {
-      const keylessWallet = await this.txGetKeylessWallet({ tx });
-      const keylessWalletId = keylessWallet?.id;
+      // const keylessWallet = await this.txGetKeylessWallet({ tx });
+      // const keylessWalletId = keylessWallet?.id;
+      const keylessWalletId =
+        await this.backgroundApi.serviceKeylessCloudSync.getCurrentCloudSyncKeylessWalletId();
       if (!keylessWalletId) {
         return null;
       }
-      const credential =
-        await keylessSyncCredentialStorage.getCredential(keylessWalletId);
-      return credential;
+      return await this.backgroundApi.serviceKeylessCloudSync.getKeylessCloudSyncCredential();
+      // const credential =
+      //   this.backgroundApi.serviceKeylessCloudSync.getKeylessCloudSyncCredentialCacheSync(
+      //     keylessWalletId,
+      //   );
+      // return credential ?? null;
     } catch (error) {
       console.error('[LocalDb] Failed to get keyless credential:', error);
       return null;
     }
   }
-
-  /**
-   * Get Keyless credential (wrapped with transaction)
-   * @returns Keyless credential or null if conditions not met
-   */
-  async getKeylessCloudSyncCredential(): Promise<IKeylessCloudSyncCredential | null> {
-    return this.withTransaction(EIndexedDBBucketNames.account, async (tx) => {
-      return this.txGetKeylessCloudSyncCredential({ tx });
-    });
-  }
-
   // #endregion
 
   // #region ---------------------------------------------- wallet
@@ -1701,6 +1695,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
 
   async addHDNextIndexedAccount({ walletId }: { walletId: string }) {
     let indexedAccountId = '';
+
     await this.withTransaction(EIndexedDBBucketNames.account, async (tx) => {
       ({ indexedAccountId } = await this.txAddHDNextIndexedAccount({
         tx,
@@ -1989,6 +1984,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
   }) {
     if (items?.length) {
       // EIndexedDBBucketNames.cloudSync
+
       await this.withTransaction(EIndexedDBBucketNames.account, async (tx) => {
         await this.txAddAndUpdateSyncItems({
           tx,
@@ -4037,6 +4033,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
       })();
 
     // db transaction: add accounts to wallet
+
     const addResults = await this.withTransaction(
       EIndexedDBBucketNames.account,
       async (tx) => {

--- a/packages/kit-bg/src/dbs/local/LocalDbBaseContainer.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBaseContainer.ts
@@ -1,14 +1,15 @@
 import { cloneDeep, isString } from 'lodash';
 
+import appGlobals from '@onekeyhq/shared/src/appGlobals';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import cacheUtils, { memoizee } from '@onekeyhq/shared/src/utils/cacheUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
 import indexedUtils from './indexed/indexedDBUtils';
 import { ELocalDBStoreNames } from './localDBStoreNames';
+import { EIndexedDBBucketNames } from './types';
 
 import type {
-  EIndexedDBBucketNames,
   IDBAccount,
   IDBDevice,
   IDBIndexedAccount,
@@ -57,6 +58,11 @@ export abstract class LocalDbBaseContainer implements ILocalDBAgent {
     if (!isString(bucketName)) {
       // throw new Error('bucketName is required');
     }
+
+    if (bucketName === EIndexedDBBucketNames.account) {
+      await appGlobals.$backgroundApiProxy.serviceKeylessCloudSync.hydrateKeylessSyncCredentialFromStorageIfNeeded();
+    }
+
     const db = await this.readyDb;
     // TODO default to readOnly: true
     return db.withTransaction(bucketName, task, options);

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -411,6 +411,11 @@ class ServiceAccount extends ServiceBase {
 
     const wallets: IDBWallet[] = r.wallets;
 
+    await this.backgroundApi.serviceKeylessCloudSync.syncPersistedCurrentCloudSyncKeylessWalletIdWithWallets(
+      wallets,
+      { whenNoKeyless: 'skip' },
+    );
+
     return {
       ...r,
       wallets,

--- a/packages/kit-bg/src/services/ServiceKeylessCloudSync/ServiceKeylessCloudSync.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessCloudSync/ServiceKeylessCloudSync.ts
@@ -1,6 +1,11 @@
 /* eslint-disable no-continue */
 import { Semaphore } from 'async-mutex';
-import { backgroundClass } from '@onekeyhq/shared/src/background/backgroundDecorators';
+
+import {
+  backgroundClass,
+  backgroundMethod,
+  toastIfError,
+} from '@onekeyhq/shared/src/background/backgroundDecorators';
 import { EPrimeCloudSyncDataType } from '@onekeyhq/shared/src/consts/primeConsts';
 import { OneKeyError } from '@onekeyhq/shared/src/errors';
 import errorUtils from '@onekeyhq/shared/src/errors/utils/errorUtils';
@@ -23,15 +28,12 @@ import type {
 } from '@onekeyhq/shared/types/prime/primeCloudSyncTypes';
 
 import localDb from '../../dbs/local/localDb';
-import {
-  devSettingsPersistAtom,
-  primeCloudSyncPersistAtom,
-} from '../../states/jotai/atoms';
+import { primeCloudSyncPersistAtom } from '../../states/jotai/atoms';
 import ServiceBase from '../ServiceBase';
+import keylessSyncCredentialStorage from '../ServiceKeylessWallet/utils/keylessSyncCredentialStorage';
 import cloudSyncItemBuilder from '../ServicePrimeCloudSync/cloudSyncItemBuilder';
 import { keylessCloudSyncApi } from '../ServicePrimeCloudSync/keylessCloudSyncApi';
 import keylessCloudSyncUtils from '../ServicePrimeCloudSync/keylessCloudSyncUtils';
-import keylessSyncCredentialStorage from '../ServiceKeylessWallet/utils/keylessSyncCredentialStorage';
 
 import type { IDBCloudSyncItem, IDBWallet } from '../../dbs/local/types';
 
@@ -53,15 +55,17 @@ class ServiceKeylessCloudSync extends ServiceBase {
   }
 
   async getKeylessCloudSyncCredential(): Promise<IKeylessCloudSyncCredential | null> {
-    return localDb.getKeylessCloudSyncCredential();
-  }
-
-  async isKeylessCloudSyncFeatureEnabledInDev(): Promise<boolean> {
-    const devSettings = await devSettingsPersistAtom.get();
-    return (
-      !!devSettings?.enabled &&
-      !!devSettings?.settings?.enableKeylessCloudSyncFeature
-    );
+    const keylessWalletId = await this.getCurrentCloudSyncKeylessWalletId();
+    if (!keylessWalletId) {
+      return null;
+    }
+    const credential =
+      this.getKeylessCloudSyncCredentialCacheSync(keylessWalletId);
+    if (credential) {
+      return credential;
+    }
+    await this.hydrateKeylessSyncCredentialFromStorageIfNeeded();
+    return this.getKeylessCloudSyncCredentialCacheSync(keylessWalletId) ?? null;
   }
 
   async getActiveSyncMode(): Promise<ECloudSyncMode> {
@@ -70,10 +74,7 @@ class ServiceKeylessCloudSync extends ServiceBase {
     if (isCloudSyncEnabled) {
       return ECloudSyncMode.OnekeyId;
     }
-    if (
-      isCloudSyncEnabledKeyless &&
-      (await this.isKeylessCloudSyncFeatureEnabledInDev())
-    ) {
+    if (isCloudSyncEnabledKeyless) {
       return ECloudSyncMode.Keyless;
     }
     return ECloudSyncMode.None;
@@ -389,21 +390,30 @@ class ServiceKeylessCloudSync extends ServiceBase {
 
   async syncPersistedCurrentCloudSyncKeylessWalletIdWithWallets(
     wallets: IDBWallet[],
-  ): Promise<string | null> {
-    const currentCloudSyncKeylessWalletId =
+    options?: {
+      /**
+       * When `wallets` contains no keyless wallet:
+       * - `'clear'`: persist `currentCloudSyncKeylessWalletId` as `null` (default).
+       * - `'skip'`: do not change persisted value (e.g. filtered `getWallets` list).
+       */
+      whenNoKeyless?: 'clear' | 'skip';
+    },
+  ): Promise<void> {
+    const whenNoKeyless = options?.whenNoKeyless ?? 'clear';
+    const currentCloudSyncKeylessWalletId: string | null =
       wallets
         .filter((wallet) => wallet.isKeyless)
-        .toSorted((a, b) => a.id.localeCompare(b.id))[0]?.id ?? null;
-    if (
-      this.currentCloudSyncKeylessWalletIdCache ===
-      currentCloudSyncKeylessWalletId
-    ) {
-      return currentCloudSyncKeylessWalletId;
+        .toSorted((a, b) => a.id.localeCompare(b.id))[0]?.id || null;
+    if (!currentCloudSyncKeylessWalletId && whenNoKeyless === 'skip') {
+      return;
     }
+    this.currentCloudSyncKeylessWalletIdCache = currentCloudSyncKeylessWalletId;
     await this.setPersistedCurrentCloudSyncKeylessWalletId(
       currentCloudSyncKeylessWalletId,
     );
-    return currentCloudSyncKeylessWalletId;
+    if (!currentCloudSyncKeylessWalletId) {
+      await keylessSyncCredentialStorage.removeAllCredentials();
+    }
   }
 
   async getCurrentCloudSyncKeylessWalletId(): Promise<string | null> {
@@ -424,10 +434,7 @@ class ServiceKeylessCloudSync extends ServiceBase {
       this.currentCloudSyncKeylessWalletIdCache = null;
       return this.currentCloudSyncKeylessWalletIdCache;
     }
-    const keylessWallet = await this.getKeylessWallet();
-    const walletId = keylessWallet?.id ?? null;
-    await this.setPersistedCurrentCloudSyncKeylessWalletId(walletId);
-    return walletId;
+    return null;
   }
 
   setKeylessCloudSyncCredentialCache(
@@ -439,6 +446,37 @@ class ServiceKeylessCloudSync extends ServiceBase {
       keylessCloudSyncCredential.keylessWalletId,
       keylessCloudSyncCredential,
     );
+  }
+
+  /**
+   * Load encrypted keyless sync credential into memory before a long IndexedDB
+   * transaction. Never await storage reads while an IDB tx is open.
+   */
+  @backgroundMethod()
+  async hydrateKeylessSyncCredentialFromStorageIfNeeded(): Promise<void> {
+    const keylessWalletId = await this.getCurrentCloudSyncKeylessWalletId();
+    if (!keylessWalletId) {
+      return;
+    }
+    if (this.getKeylessCloudSyncCredentialCacheSync(keylessWalletId)) {
+      return;
+    }
+    const credential =
+      await keylessSyncCredentialStorage.getCredential(keylessWalletId);
+    if (!credential) {
+      return;
+    }
+    if (credential.keylessWalletId !== keylessWalletId) {
+      await keylessSyncCredentialStorage.removeAllCredentials();
+      return;
+    }
+    this.setKeylessCloudSyncCredentialCache(credential);
+  }
+
+  getKeylessCloudSyncCredentialCacheSync(
+    keylessWalletId: string,
+  ): IKeylessCloudSyncCredential | undefined {
+    return this.keylessCloudSyncCredentialCache.get(keylessWalletId);
   }
 
   async getKeylessCloudSyncCredentialCache({
@@ -484,8 +522,11 @@ class ServiceKeylessCloudSync extends ServiceBase {
       }
       const existing =
         await keylessSyncCredentialStorage.getCredential(walletId);
-      if (existing) {
+      if (existing?.keylessWalletId === walletId) {
         return;
+      }
+      if (existing) {
+        await keylessSyncCredentialStorage.removeAllCredentials();
       }
       // Credential missing — re-derive from seed while password is available
       try {
@@ -529,8 +570,7 @@ class ServiceKeylessCloudSync extends ServiceBase {
   }
 
   async setCloudSyncEnabledKeyless(enabled: boolean): Promise<boolean> {
-    const shouldEnableKeyless =
-      enabled && (await this.isKeylessCloudSyncFeatureEnabledInDev());
+    const shouldEnableKeyless = enabled;
 
     if (shouldEnableKeyless) {
       const keylessWallet = await this.getKeylessWallet();
@@ -568,17 +608,24 @@ class ServiceKeylessCloudSync extends ServiceBase {
     }));
     await this.backgroundApi.servicePrimeCloudSync.clearCachedSyncCredential();
 
+    if (shouldEnableKeyless) {
+      // Re-hydrate credential cache after clearing stale entries
+      await this.hydrateKeylessSyncCredentialFromStorageIfNeeded();
+    }
+
     // Remove persisted credential when disabling keyless sync
     if (!shouldEnableKeyless) {
       const currentWalletId = await this.getCurrentCloudSyncKeylessWalletId();
       if (currentWalletId) {
-        await keylessSyncCredentialStorage.removeCredential(currentWalletId);
+        await keylessSyncCredentialStorage.removeAllCredentials();
       }
     }
 
     return shouldEnableKeyless;
   }
 
+  @backgroundMethod()
+  @toastIfError()
   async toggleCloudSyncKeyless({
     enabled,
     silentEnable = false,
@@ -589,10 +636,6 @@ class ServiceKeylessCloudSync extends ServiceBase {
     forceEnable?: boolean;
   }) {
     try {
-      if (enabled && !(await this.isKeylessCloudSyncFeatureEnabledInDev())) {
-        await this.setCloudSyncEnabledKeyless(false);
-        return;
-      }
       if (enabled) {
         const { success } = await this.prepareCloudSyncKeyless({
           silentEnable,
@@ -640,15 +683,16 @@ class ServiceKeylessCloudSync extends ServiceBase {
     }
   }
 
+  @backgroundMethod()
   async autoEnableCloudSyncKeyless() {
-    if (!(await this.isKeylessCloudSyncFeatureEnabledInDev())) {
-      return;
-    }
-    const { wallets } = await localDb.getAllWallets();
+    const { wallets } = await this.backgroundApi.serviceAccount.getAllWallets();
     await this.syncPersistedCurrentCloudSyncKeylessWalletIdWithWallets(wallets);
     const { isCloudSyncEnabledKeyless, isCloudSyncEnabled } =
       await primeCloudSyncPersistAtom.get();
     if (isCloudSyncEnabledKeyless) {
+      return;
+    }
+    if (isCloudSyncEnabled) {
       return;
     }
     // If ID sync is active, sync ID data first before switching (auto-migration)

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -804,7 +804,7 @@ class ServiceKeylessWallet extends ServiceBase {
     });
 
     // Remove persisted credential before wallet deletion
-    await keylessSyncCredentialStorage.removeCredential(walletId);
+    await keylessSyncCredentialStorage.removeAllCredentials();
     this.backgroundApi.serviceKeylessCloudSync.clearKeylessCloudSyncCredentialCache(
       { keylessWalletId: walletId },
     );

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessSyncCredentialStorage.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/utils/keylessSyncCredentialStorage.ts
@@ -83,12 +83,6 @@ async function getCredential(
   return credential;
 }
 
-async function removeCredential(keylessWalletId: string): Promise<void> {
-  const map = await readMap();
-  delete map[keylessWalletId];
-  await writeMap(map);
-}
-
 async function removeAllCredentials(): Promise<void> {
   await keylessStorageUtils.storageRemoveItem(STORAGE_KEY);
 }
@@ -96,6 +90,5 @@ async function removeAllCredentials(): Promise<void> {
 export default {
   saveCredential,
   getCredential,
-  removeCredential,
   removeAllCredentials,
 };

--- a/packages/kit-bg/src/services/ServicePrimeCloudSync/ServicePrimeCloudSync.tsx
+++ b/packages/kit-bg/src/services/ServicePrimeCloudSync/ServicePrimeCloudSync.tsx
@@ -177,10 +177,6 @@ class ServicePrimeCloudSync extends ServiceBase {
     return this.backgroundApi.serviceKeylessCloudSync.getKeylessCloudSyncCredential();
   }
 
-  async isKeylessCloudSyncFeatureEnabledInDev(): Promise<boolean> {
-    return this.backgroundApi.serviceKeylessCloudSync.isKeylessCloudSyncFeatureEnabledInDev();
-  }
-
   @backgroundMethod()
   async getActiveSyncMode(): Promise<ECloudSyncMode> {
     return this.backgroundApi.serviceKeylessCloudSync.getActiveSyncMode();
@@ -1606,13 +1602,6 @@ class ServicePrimeCloudSync extends ServiceBase {
   }
 
   @backgroundMethod()
-  async setCloudSyncEnabledKeyless(enabled: boolean): Promise<boolean> {
-    return this.backgroundApi.serviceKeylessCloudSync.setCloudSyncEnabledKeyless(
-      enabled,
-    );
-  }
-
-  @backgroundMethod()
   @toastIfError()
   async toggleCloudSync({ enabled }: { enabled: boolean }) {
     const shouldTrackEnableFlow = enabled;
@@ -1666,29 +1655,6 @@ class ServicePrimeCloudSync extends ServiceBase {
       }
       void this.backgroundApi.servicePrime.apiFetchPrimeUserInfo();
     }
-  }
-
-  @backgroundMethod()
-  @toastIfError()
-  async toggleCloudSyncKeyless({
-    enabled,
-    silentEnable = false,
-    forceEnable = false,
-  }: {
-    enabled: boolean;
-    silentEnable?: boolean;
-    forceEnable?: boolean;
-  }) {
-    return this.backgroundApi.serviceKeylessCloudSync.toggleCloudSyncKeyless({
-      enabled,
-      silentEnable,
-      forceEnable,
-    });
-  }
-
-  @backgroundMethod()
-  async autoEnableCloudSyncKeyless() {
-    return this.backgroundApi.serviceKeylessCloudSync.autoEnableCloudSyncKeyless();
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
@@ -46,8 +46,6 @@ export interface IDevSettings {
   allowDeleteKeylessKey?: boolean;
   // show Keyless-related debug dialogs/logs in UI (dev only)
   enableKeylessDebugInfo?: boolean;
-  // show Keyless cloud sync switch in OneKey Cloud page (dev only)
-  enableKeylessCloudSyncFeature?: boolean;
 
   showPrimeTest?: boolean;
   usePrimeSandboxPayment?: boolean;
@@ -108,7 +106,6 @@ export const {
       strictSignatureAlert: false,
       enableAnalyticsRequest: false,
       enableKeylessDebugInfo: false,
-      enableKeylessCloudSyncFeature: false,
       showPrimeTest: true,
       usePrimeSandboxPayment: platformEnv.isDev,
       showPerformanceMonitor: true,

--- a/packages/kit-bg/src/states/jotai/atoms/prime.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/prime.ts
@@ -39,7 +39,7 @@ export const {
 
 export type IPrimeCloudSyncPersistAtomData = {
   isCloudSyncEnabled: boolean;
-  lastSyncTime?: number;
+  lastSyncTime?: number; // lastSyncTimeLegacy
   lastSyncTimeOneKeyId?: number;
   lastSyncTimeKeyless?: number;
 

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -909,7 +909,7 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
             });
           }
           if (wallet.isKeyless) {
-            void backgroundApiProxy.servicePrimeCloudSync.autoEnableCloudSyncKeyless();
+            void backgroundApiProxy.serviceKeylessCloudSync.autoEnableCloudSyncKeyless();
           }
         },
       }),

--- a/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSync.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSync.tsx
@@ -28,13 +28,13 @@ import { usePrimeCloudSyncPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/
 import { ELockDuration } from '@onekeyhq/shared/src/consts/appAutoLockConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ERootRoutes } from '@onekeyhq/shared/src/routes';
 import {
   EOnboardingPagesV2,
   EOnboardingV2OneKeyIDLoginMode,
   EOnboardingV2Routes,
 } from '@onekeyhq/shared/src/routes/onboardingv2';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EPrimePages } from '@onekeyhq/shared/src/routes/prime';
 import { formatDistanceToNow } from '@onekeyhq/shared/src/utils/dateUtils';
 import { isNeverLockDuration } from '@onekeyhq/shared/src/utils/passwordUtils';
@@ -341,11 +341,13 @@ function AppDataSection() {
           noDebounceUpload: true,
         });
         // Enable KW first, then disable ID — safer order to avoid stuck middle state
-        await backgroundApiProxy.servicePrimeCloudSync.toggleCloudSyncKeyless({
-          enabled: true,
-          silentEnable: true,
-          forceEnable: true,
-        });
+        await backgroundApiProxy.serviceKeylessCloudSync.toggleCloudSyncKeyless(
+          {
+            enabled: true,
+            forceEnable: true,
+            silentEnable: false,
+          },
+        );
         await backgroundApiProxy.servicePrimeCloudSync.toggleCloudSync({
           enabled: false,
         });
@@ -406,7 +408,7 @@ function AppDataSection() {
     if (isSubmittingRef.current) return;
     try {
       isSubmittingRef.current = true;
-      await backgroundApiProxy.servicePrimeCloudSync.toggleCloudSyncKeyless({
+      await backgroundApiProxy.serviceKeylessCloudSync.toggleCloudSyncKeyless({
         enabled: value,
       });
     } finally {

--- a/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSyncDebug.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSyncDebug.tsx
@@ -534,7 +534,7 @@ function ScenarioPanel() {
       <Button
         size="small"
         onPress={async () => {
-          await backgroundApiProxy.servicePrimeCloudSync.toggleCloudSyncKeyless(
+          await backgroundApiProxy.serviceKeylessCloudSync.toggleCloudSyncKeyless(
             { enabled: !config.isCloudSyncEnabledKeyless },
           );
           Toast.success({

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
@@ -1525,15 +1525,6 @@ const BaseDevSettingsSection = () => {
                       </SectionFieldItem>
 
                       <SectionFieldItem
-                        icon="CloudOutline"
-                        name="enableKeylessCloudSyncFeature"
-                        title="启用 Keyless 云端同步"
-                        subtitle="开启后在 OneKey Cloud 展示 Keyless 同步开关"
-                      >
-                        <Switch size={ESwitchSize.small} />
-                      </SectionFieldItem>
-
-                      <SectionFieldItem
                         icon="WalletOutline"
                         name="allowDeleteKeylessKey"
                         title="允许重置 Keyless 钱包"


### PR DESCRIPTION
## Summary
- Re-hydrate credential cache after clearing stale entries during enable flow (write → clear → re-write pattern)
- Remove `isKeylessCloudSyncFeatureEnabledInDev` gate to enable keyless sync for all users
- Use `keylessSyncCredentialStorage` instead of `localDb` for credential management
- Fix credential repair logic to validate `walletId` match before skipping
- Add `@backgroundMethod` / `@toastIfError` decorators to `toggleCloudSyncKeyless` and `autoEnableCloudSyncKeyless`

## Test plan
- [ ] Enable keyless cloud sync, verify credential cache is correctly hydrated after toggle
- [ ] Disable then re-enable keyless cloud sync, verify credentials are properly re-derived and cached
- [ ] Switch between different keyless wallets, verify stale credential cache is cleared and replaced
- [ ] Verify cloud sync data round-trip (upload + download) works after enable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
