### PR TITLE
fix(ios): stabilize modal pagesheet updateBounds

### DIFF
--- a/packages/components/src/layouts/Navigation/GlobalScreenOptions.native.ts
+++ b/packages/components/src/layouts/Navigation/GlobalScreenOptions.native.ts
@@ -33,7 +33,7 @@ export function makeModalOpenAnimationOptions(info: {
 }): IStackNavigationOptions {
   if (platformEnv.isNativeIOS) {
     return {
-      animation: 'slide_from_bottom',
+      animation: 'default',
     };
   }
 
@@ -114,8 +114,7 @@ export function makeModalScreenOptions(info: {
 }): IStackNavigationOptions {
   return {
     headerShown: false,
-    // presentation: platformEnv.isNativeIOS ? 'modal' : 'transparentModal',
-    presentation: 'modal',
+    presentation: platformEnv.isNativeIOS ? 'pageSheet' : 'modal',
     ...makeModalOpenAnimationOptions(info),
   };
 }

--- a/packages/components/src/layouts/Page/BasicPage.native.tsx
+++ b/packages/components/src/layouts/Page/BasicPage.native.tsx
@@ -8,11 +8,9 @@ import {
   useThemeName,
 } from '@onekeyhq/components/src/shared/tamagui';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import { ERootRoutes } from '@onekeyhq/shared/src/routes';
 
 import { useIsModalPage, useIsOverlayPage } from '../../hocs';
 import { Spinner, Stack, View, YStack } from '../../primitives';
-import { rootNavigationRef } from '../Navigation';
 
 import { useIsIpadModalPage, useTabBarHeight } from './hooks';
 import {
@@ -97,31 +95,23 @@ function AbsoluteContainer({ children }: PropsWithChildren) {
   );
 }
 
-function LoadingScreen({
+function LoadingScreenAndroid({
   children,
   fullPage,
 }: PropsWithChildren<{ fullPage: boolean }>) {
   const [showLoading, changeLoadingVisibleStatus] = useState(true);
   const [showChildren, changeChildrenVisibleStatus] = useState(false);
-  const isModalPage = useIsModalPage();
-  const isiOSModalPage = platformEnv.isNativeIOS && isModalPage;
 
   useEffect(() => {
-    setTimeout(
-      () => {
-        changeChildrenVisibleStatus(true);
-        setTimeout(
-          () => {
-            requestIdleCallback(() => {
-              changeLoadingVisibleStatus(false);
-            });
-          },
-          isiOSModalPage ? 380 : 150,
-        );
-      },
-      platformEnv.isNativeAndroid ? 10 : 0,
-    );
-  }, [isiOSModalPage]);
+    setTimeout(() => {
+      changeChildrenVisibleStatus(true);
+      setTimeout(() => {
+        requestIdleCallback(() => {
+          changeLoadingVisibleStatus(false);
+        });
+      }, 150);
+    }, 10);
+  }, []);
 
   const minHeight = useMinHeight(fullPage);
   return (
@@ -138,54 +128,20 @@ function LoadingScreen({
   );
 }
 
-const AbsoluteLoadingContainer = platformEnv.isNativeIOS
-  ? ({ children }: PropsWithChildren) => {
-      const [showLoading, changeLoadingVisibleStatus] = useState(true);
-      const [showChildren, changeChildrenVisibleStatus] = useState(false);
-      const isModalPage = useIsModalPage();
-      const shouldShowLoading = useMemo(() => {
-        if (!isModalPage) {
-          return false;
-        }
-        const rootState = rootNavigationRef.current?.getRootState();
-        const modalRoute = rootState?.routes[rootState.index];
-        if (modalRoute?.name !== ERootRoutes.Modal) {
-          return false;
-        }
+function LoadingScreen({
+  children,
+  fullPage,
+}: PropsWithChildren<{ fullPage: boolean }>) {
+  if (platformEnv.isNativeIOS) {
+    return <>{children}</>;
+  }
 
-        // The first modal page pushed hasn't generated its own navigation state yet,
-        // so we show blank loading for a smoother transition animation.
-        if (!modalRoute.state) {
-          return true;
-        }
-        // Pages within the modal's stack (index > 0) don't need blank loading,
-        // only the first modal page (index === 0) requires it.
-        if (modalRoute.state?.index === 0) {
-          return false;
-        }
-        return false;
-      }, [isModalPage]);
-      useEffect(() => {
-        setTimeout(() => {
-          changeChildrenVisibleStatus(true);
-          setTimeout(() => {
-            requestIdleCallback(() => {
-              changeLoadingVisibleStatus(false);
-            });
-          }, 380);
-        }, 1);
-      }, [isModalPage]);
+  return (
+    <LoadingScreenAndroid fullPage={fullPage}>{children}</LoadingScreenAndroid>
+  );
+}
 
-      return shouldShowLoading ? (
-        <>
-          {showChildren ? children : null}
-          {showLoading ? <AbsoluteContainer /> : null}
-        </>
-      ) : (
-        children
-      );
-    }
-  : ({ children }: PropsWithChildren) => children;
+const AbsoluteLoadingContainer = ({ children }: PropsWithChildren) => children;
 
 export function BasicPage({
   children,

--- a/packages/components/src/layouts/Page/BasicPage.native.tsx
+++ b/packages/components/src/layouts/Page/BasicPage.native.tsx
@@ -7,6 +7,7 @@ import {
   AnimatePresence,
   useThemeName,
 } from '@onekeyhq/components/src/shared/tamagui';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { useIsModalPage, useIsOverlayPage } from '../../hocs';
@@ -150,9 +151,40 @@ export function BasicPage({
 }: IBasicPageProps) {
   const { layout, onPageLayout } = useIPadModalPageSizeChange();
   const isIpadModalPage = useIsIpadModalPage();
+  const isModalPage = useIsModalPage();
   const content = useMemo(() => {
     return (
-      <Stack bg="$bgApp" flex={1}>
+      <Stack
+        bg="$bgApp"
+        flex={1}
+        {...(platformEnv.isNativeIOS && isModalPage && {
+          borderWidth: 2,
+          borderColor: 'red',
+        })}
+        onLayout={
+          platformEnv.isNativeIOS && isModalPage
+            ? (e: {
+                nativeEvent: {
+                  layout: {
+                    x: number;
+                    y: number;
+                    width: number;
+                    height: number;
+                  };
+                };
+              }) => {
+                const { x, y, width, height } = e.nativeEvent.layout;
+                defaultLogger.app.page.debugLayout(
+                  'BasicPage',
+                  x,
+                  y,
+                  width,
+                  height,
+                );
+              }
+            : undefined
+        }
+      >
         {platformEnv.isNativeIOS ? <PageStatusBar /> : undefined}
         {lazyLoad ? (
           <LoadingScreen fullPage={fullPage}>{children}</LoadingScreen>
@@ -161,7 +193,7 @@ export function BasicPage({
         )}
       </Stack>
     );
-  }, [children, lazyLoad, fullPage]);
+  }, [children, lazyLoad, fullPage, isModalPage]);
   return isIpadModalPage ? (
     <YStack flex={1} onLayout={onPageLayout}>
       <iPadModalPageContext.Provider value={layout}>

--- a/packages/kit/src/views/AddressBook/components/AddressBookListContent.tsx
+++ b/packages/kit/src/views/AddressBook/components/AddressBookListContent.tsx
@@ -1,7 +1,15 @@
-import { type FC, useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  type FC,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { groupBy } from 'lodash';
 import { useIntl } from 'react-intl';
+import type { LayoutChangeEvent } from 'react-native';
 
 import {
   Empty,
@@ -14,6 +22,7 @@ import {
   useMedia,
 } from '@onekeyhq/components';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IFuseResultMatch } from '@onekeyhq/shared/src/modules3rdParty/fuse';
@@ -134,9 +143,24 @@ const RenderEmptyAddressBook: FC<IRenderEmptyAddressBookProps> = ({
 }) => {
   const intl = useIntl();
   const navigation = useAppNavigation();
+  const emptyLayoutCountRef = useRef(0);
   return (
     <Empty
       flex={1}
+      borderWidth={2}
+      borderColor="yellow"
+      testID="ab-empty"
+      onLayout={(e: LayoutChangeEvent) => {
+        emptyLayoutCountRef.current += 1;
+        const { x, y, width, height } = e.nativeEvent.layout;
+        defaultLogger.app.page.debugLayout(
+          `Empty #${emptyLayoutCountRef.current}`,
+          x,
+          y,
+          width,
+          height,
+        );
+      }}
       illustration="SearchDocument"
       title={intl.formatMessage({
         id: ETranslations.address_book_no_results_title_migration,
@@ -305,9 +329,23 @@ export const AddressBookListContent = ({
 
   const estimatedItemSize = useMemo(() => (media.md ? 80 : 60), [media.md]);
 
+  // DEBUG: track initial layout dimensions for modal shift investigation
+  const layoutCountRef = useRef(0);
+  const handleRootLayout = useCallback((e: LayoutChangeEvent) => {
+    layoutCountRef.current += 1;
+    const { x, y, width, height } = e.nativeEvent.layout;
+    defaultLogger.app.page.debugLayout(
+      `AddressBook #${layoutCountRef.current}`,
+      x,
+      y,
+      width,
+      height,
+    );
+  }, []);
+
   return (
-    <Stack flex={1}>
-      <Stack px="$5" pb="$2">
+    <Stack flex={1} onLayout={handleRootLayout} borderWidth={2} borderColor="blue" testID="ab-root">
+      <Stack px="$5" pb="$2" borderWidth={1} borderColor="green" testID="ab-search-wrap">
         <SearchBar
           placeholder={intl.formatMessage({ id: ETranslations.global_search })}
           value={searchKey}

--- a/packages/kit/src/views/AddressBook/components/AddressBookListContent.tsx
+++ b/packages/kit/src/views/AddressBook/components/AddressBookListContent.tsx
@@ -136,6 +136,7 @@ const RenderEmptyAddressBook: FC<IRenderEmptyAddressBookProps> = ({
   const navigation = useAppNavigation();
   return (
     <Empty
+      flex={1}
       illustration="SearchDocument"
       title={intl.formatMessage({
         id: ETranslations.address_book_no_results_title_migration,
@@ -164,6 +165,7 @@ const RenderNoSearchResult = () => {
   const intl = useIntl();
   return (
     <Empty
+      flex={1}
       illustration="SearchDocument"
       title={intl.formatMessage({
         id: ETranslations.address_book_no_results_title,

--- a/packages/kit/src/views/AddressBook/components/AddressBookSectionList/index.native.tsx
+++ b/packages/kit/src/views/AddressBook/components/AddressBookSectionList/index.native.tsx
@@ -20,6 +20,7 @@ export const AddressBookSectionList: FC<IAddressBookSectionListProps> = ({
     renderItem={renderItem}
     renderSectionHeader={renderSectionHeader}
     ListEmptyComponent={ListEmptyComponent}
+    contentContainerStyle={{ flexGrow: 1 }}
     SectionSeparatorComponent={null}
     keyExtractor={keyExtractor as any}
   />

--- a/packages/kit/src/views/AddressBook/components/AddressBookSectionList/index.tsx
+++ b/packages/kit/src/views/AddressBook/components/AddressBookSectionList/index.tsx
@@ -25,6 +25,7 @@ export const AddressBookSectionList: FC<IAddressBookSectionListProps> = ({
       renderItem={renderItem}
       renderSectionHeader={renderSectionHeader}
       ListEmptyComponent={ListEmptyComponent}
+      contentContainerStyle={{ flexGrow: 1 }}
       keyExtractor={keyExtractor as any}
       windowSize={40}
       ListFooterComponent={<YStack h={bottom || '$3'} />}

--- a/packages/kit/src/views/AddressBook/components/ContentContainer.tsx
+++ b/packages/kit/src/views/AddressBook/components/ContentContainer.tsx
@@ -18,7 +18,7 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 const ContentSpinner = () => (
-  <Stack h="100%" justifyContent="center" alignItems="center">
+  <Stack h="100%" justifyContent="center" alignItems="center" testID="ab-loading">
     <Spinner size="large" />
   </Stack>
 );

--- a/packages/kit/src/views/AddressBook/pages/ListItem/index.tsx
+++ b/packages/kit/src/views/AddressBook/pages/ListItem/index.tsx
@@ -76,7 +76,11 @@ function ListPage() {
           error={Boolean(!isLoading && !result)}
           unsafe={result?.isSafe === false}
         >
-          <AddressBookListContent items={result?.items ?? []} showActions />
+          <AddressBookListContent
+            items={result?.items ?? []}
+            showActions
+            hideEmptyAddButton={!gtMd}
+          />
         </ContentContainer>
       </Page.Body>
       {gtMd ? null : (

--- a/packages/shared/src/logger/base/logFn.ts
+++ b/packages/shared/src/logger/base/logFn.ts
@@ -34,7 +34,9 @@ export const logFn = ({
   setTimeout(async () => {
     const config = await defaultLoggerConfig.savedLoggerConfigAsync;
     const shouldLogToConsole =
-      !platformEnv.isDev || !!config?.enabled?.[scopeName]?.[sceneName];
+      !platformEnv.isDev ||
+      !!config?.enabled?.[scopeName]?.[sceneName] ||
+      methodName === 'debugLayout';
     const prefix = `${scopeName} => ${sceneName} => ${methodName} : `;
     let msg = `${prefix} ${rawMsg}`;
     if (metadata.type === 'local') {

--- a/packages/shared/src/logger/scopes/app/scenes/page.ts
+++ b/packages/shared/src/logger/scopes/app/scenes/page.ts
@@ -93,4 +93,15 @@ export class PageScene extends BaseScene {
   public removeUnlockJob() {
     return {};
   }
+
+  @LogToLocal({ level: 'info' })
+  public debugLayout(
+    tag: string,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  ) {
+    return { tag, x, y, width, height };
+  }
 }

--- a/patches/react-native+0.81.5.patch
+++ b/patches/react-native+0.81.5.patch
@@ -1,3 +1,7 @@
+diff --git a/node_modules/react-native/.DS_Store b/node_modules/react-native/.DS_Store
+new file mode 100644
+index 0000000..100a183
+Binary files /dev/null and b/node_modules/react-native/.DS_Store differ
 diff --git a/node_modules/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js b/node_modules/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
 index 05bddcb..5211253 100644
 --- a/node_modules/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
@@ -465,25 +469,61 @@ index 577bebe..ad0f253 100644
  #pragma mark - RCTBackedTextInputDelegate
  
  - (BOOL)textInputShouldBeginEditing
-diff --git a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
-index 89b666d..246c9cf 100644
---- a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
-+++ b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
-@@ -869,7 +869,13 @@ public open class ReactViewGroup public constructor(context: Context?) :
-     if (_overflow != Overflow.VISIBLE || getTag(R.id.filter) != null) {
-       clipToPaddingBox(this, canvas)
+diff --git a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm b/node_modules/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+index a99f103..27865c2 100644
+--- a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
++++ b/node_modules/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+@@ -828,6 +828,19 @@ - (UIView *)currentContainerView
+ }
+ 
+ - (void)invalidateLayer
++{
++  // During modal transition, prevent backgroundColor and layer changes from being animated.
++  extern BOOL RNSModalTransitionInProgress;
++  if (RNSModalTransitionInProgress) {
++    [UIView performWithoutAnimation:^{
++      [self _invalidateLayerImpl];
++    }];
++  } else {
++    [self _invalidateLayerImpl];
++  }
++}
++
++- (void)_invalidateLayerImpl
+ {
+   CALayer *layer = self.layer;
+ 
+diff --git a/node_modules/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm b/node_modules/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
+index 9f50554..23eaaa8 100644
+--- a/node_modules/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
++++ b/node_modules/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
+@@ -103,8 +103,24 @@ - (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics
+     } else {
+       // Note: Changing `frame` when `layer.transform` is not the `identity transform` is undefined behavior.
+       // Therefore, we must use `center` and `bounds`.
+-      self.center = CGPoint{CGRectGetMidX(frame), CGRectGetMidY(frame)};
+-      self.bounds = CGRect{CGPointZero, frame.size};
++      //
++      // When a modal transition is in progress, Fabric may mount recycled views
++      // whose stale frames differ from the new layout. Without performWithoutAnimation,
++      // UIKit captures the center/bounds change as an implicit animation within the
++      // modal presentation's animation block, causing visible content displacement.
++      extern BOOL RNSModalTransitionInProgress;
++      if (RNSModalTransitionInProgress) {
++        [UIView performWithoutAnimation:^{
++          self.center = CGPoint{CGRectGetMidX(frame), CGRectGetMidY(frame)};
++          self.bounds = CGRect{CGPointZero, frame.size};
++          // Force immediate layout so that subviews (e.g. RCTParagraphTextView)
++          // also get their frames set within performWithoutAnimation scope.
++          [self layoutIfNeeded];
++        }];
++      } else {
++        self.center = CGPoint{CGRectGetMidX(frame), CGRectGetMidY(frame)};
++        self.bounds = CGRect{CGPointZero, frame.size};
++      }
      }
--    super.dispatchDraw(canvas)
-+    try {
-+      super.dispatchDraw(canvas)
-+    } catch (e: NullPointerException) {
-+      // Race condition: child view removed during draw cycle by reanimated mount transaction.
-+      // The view hierarchy will be re-drawn correctly on the next frame.
-+      // Tracking: https://github.com/software-mansion/react-native-reanimated/issues/8422
-+    }
    }
  
-   override fun drawChild(canvas: Canvas, child: View, drawingTime: Long): Boolean {
 diff --git a/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm b/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
 index 2a67797..57f7c7a 100644
 --- a/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm

--- a/patches/react-native-screens+4.23.0.patch
+++ b/patches/react-native-screens+4.23.0.patch
@@ -36,6 +36,75 @@ index 7055a0d..81ee02b 100644
          }
      }
  
+diff --git a/node_modules/react-native-screens/ios/RNSScreen.mm b/node_modules/react-native-screens/ios/RNSScreen.mm
+index 1c44762..3ed576d 100644
+--- a/node_modules/react-native-screens/ios/RNSScreen.mm
++++ b/node_modules/react-native-screens/ios/RNSScreen.mm
+@@ -1621,6 +1621,7 @@ @implementation RNSScreen {
+   BOOL _isSwiping;
+   BOOL _shouldNotify;
+   BOOL _isRemovedFromParent;
++  BOOL _shouldApplyDeferredModalBoundsUpdate;
+ }
+ 
+ #pragma mark - Common
+@@ -1643,6 +1644,18 @@ - (instancetype)initWithView:(UIView *)view
+ - (void)viewWillAppear:(BOOL)animated
+ {
+   [super viewWillAppear:animated];
++
++  // Workaround for react-native-screens issue #1779 / #2587:
++  // edgesForExtendedLayout is normally set in the navigationController:willShowViewController:
++  // delegate callback, which fires AFTER the first layout pass. This causes the initial
++  // content height to be too tall (not accounting for the navigation bar), producing a
++  // visible layout shift. By setting it early in viewWillAppear, the first Yoga layout
++  // already has the correct content insets.
++  RNSScreenStackHeaderConfig *config = [self.screenView findHeaderConfig];
++  if (config != nil && config.shouldHeaderBeVisible && !config.translucent) {
++    self.edgesForExtendedLayout = UIRectEdgeAll & ~UIRectEdgeTop;
++  }
++
+   if (!_isSwiping) {
+     [self.screenView notifyWillAppear];
+     if (self.transitionCoordinator.isInteractive) {
+@@ -1719,6 +1732,13 @@ - (void)viewDidAppear:(BOOL)animated
+   } else {
+     [self.screenView notifyGestureCancel];
+   }
++#ifdef RCT_NEW_ARCH_ENABLED
++  if (_shouldApplyDeferredModalBoundsUpdate && self.screenView.isPresentedAsNativeModal) {
++    _shouldApplyDeferredModalBoundsUpdate = NO;
++    [self calculateAndNotifyHeaderHeightChangeIsModal:YES];
++    [self.screenView updateBounds];
++  }
++#endif
+ 
+   _isSwiping = NO;
+   _shouldNotify = YES;
+@@ -1764,15 +1784,21 @@ - (void)viewDidLayoutSubviews
+   // screen size
+   BOOL isDisplayedWithinUINavController = [self.parentViewController isKindOfClass:[RNSNavigationController class]];
+   BOOL isTabScreen = [self.parentViewController isKindOfClass:RNSTabBarController.class];
++  BOOL isModalTransitionInProgress = self.screenView.isPresentedAsNativeModal && self.transitionCoordinator != nil;
+ 
+   // Calculate header height on modal open
+-  if (self.screenView.isPresentedAsNativeModal) {
++  if (self.screenView.isPresentedAsNativeModal && !isModalTransitionInProgress) {
+     [self calculateAndNotifyHeaderHeightChangeIsModal:YES];
+   }
+ 
+   if (isDisplayedWithinUINavController || isTabScreen || self.screenView.isPresentedAsNativeModal) {
+ #ifdef RCT_NEW_ARCH_ENABLED
+-    [self.screenView updateBounds];
++    if (self.screenView.isPresentedAsNativeModal && isModalTransitionInProgress) {
++      _shouldApplyDeferredModalBoundsUpdate = YES;
++    } else {
++      [self.screenView updateBounds];
++      _shouldApplyDeferredModalBoundsUpdate = NO;
++    }
+ #else
+     if (!CGRectEqualToRect(_lastViewFrame, self.screenView.frame)) {
+       _lastViewFrame = self.screenView.frame;
 diff --git a/node_modules/react-native-screens/ios/RNSScreenStack.mm b/node_modules/react-native-screens/ios/RNSScreenStack.mm
 index e37e40a..1e95f36 100644
 --- a/node_modules/react-native-screens/ios/RNSScreenStack.mm

--- a/patches/react-native-screens+4.23.0.patch
+++ b/patches/react-native-screens+4.23.0.patch
@@ -37,10 +37,10 @@ index 7055a0d..81ee02b 100644
      }
  
 diff --git a/node_modules/react-native-screens/ios/RNSScreen.mm b/node_modules/react-native-screens/ios/RNSScreen.mm
-index 1c44762..06e7139 100644
+index 1c44762..a9cb115 100644
 --- a/node_modules/react-native-screens/ios/RNSScreen.mm
 +++ b/node_modules/react-native-screens/ios/RNSScreen.mm
-@@ -49,6 +49,91 @@
+@@ -49,6 +49,104 @@
  constexpr NSInteger SHEET_FIT_TO_CONTENTS = -1;
  constexpr NSInteger SHEET_LARGEST_UNDIMMED_DETENT_NONE = -1;
  
@@ -70,6 +70,18 @@ index 1c44762..06e7139 100644
 +static NSString *RNSClassSummary(id obj)
 +{
 +  return obj == nil ? @"nil" : NSStringFromClass([obj class]);
++}
++
++static NSString *RNSWallTimeString(void)
++{
++  static NSDateFormatter *formatter;
++  static dispatch_once_t onceToken;
++  dispatch_once(&onceToken, ^{
++    formatter = [NSDateFormatter new];
++    formatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
++    formatter.dateFormat = @"yyyy-MM-dd HH:mm:ss.SSS";
++  });
++  return [formatter stringFromDate:[NSDate date]];
 +}
 +
 +static NSString *RNSTransitionSummary(UIViewController *controller)
@@ -108,8 +120,9 @@ index 1c44762..06e7139 100644
 +
 +static void RNSScreenLogInfo(NSString *message)
 +{
-+  NSString *fullMessage = [NSString stringWithFormat:@"%@ (ts=%.6f main=%@)",
++  NSString *fullMessage = [NSString stringWithFormat:@"%@ (wall=%@ ts=%.6f main=%@)",
 +                                                     message,
++                                                     RNSWallTimeString(),
 +                                                     CFAbsoluteTimeGetCurrent(),
 +                                                     RNSBoolString([NSThread isMainThread])];
 +  NSLog(@"[RNSScreen] %@", fullMessage);
@@ -132,7 +145,7 @@ index 1c44762..06e7139 100644
  struct ContentWrapperBox {
    __weak RNSScreenContentWrapper *contentWrapper{nil};
    float contentHeightErrata{0.f};
-@@ -201,6 +286,24 @@ - (void)updateBounds
+@@ -201,6 +299,24 @@ - (void)updateBounds
          ? 0
          : [_controller calculateHeaderHeightIsModal:self.isPresentedAsNativeModal];
  
@@ -157,7 +170,7 @@ index 1c44762..06e7139 100644
      auto newState = react::RNSScreenState{RCTSizeFromCGSize(self.bounds.size), {0, effectiveContentOffsetY}};
  
      _state->updateState(
-@@ -1323,6 +1426,12 @@ - (void)dispatchSafeAreaDidChangeNotification
+@@ -1323,6 +1439,12 @@ - (void)dispatchSafeAreaDidChangeNotification
  - (void)safeAreaInsetsDidChange
  {
    [super safeAreaInsetsDidChange];
@@ -170,7 +183,7 @@ index 1c44762..06e7139 100644
    [self dispatchSafeAreaDidChangeNotification];
  }
  
-@@ -1621,6 +1730,7 @@ @implementation RNSScreen {
+@@ -1621,6 +1743,7 @@ @implementation RNSScreen {
    BOOL _isSwiping;
    BOOL _shouldNotify;
    BOOL _isRemovedFromParent;
@@ -178,7 +191,7 @@ index 1c44762..06e7139 100644
  }
  
  #pragma mark - Common
-@@ -1643,6 +1753,18 @@ - (instancetype)initWithView:(UIView *)view
+@@ -1643,6 +1766,18 @@ - (instancetype)initWithView:(UIView *)view
  - (void)viewWillAppear:(BOOL)animated
  {
    [super viewWillAppear:animated];
@@ -197,7 +210,7 @@ index 1c44762..06e7139 100644
    if (!_isSwiping) {
      [self.screenView notifyWillAppear];
      if (self.transitionCoordinator.isInteractive) {
-@@ -1659,6 +1781,28 @@ - (void)viewWillAppear:(BOOL)animated
+@@ -1659,6 +1794,28 @@ - (void)viewWillAppear:(BOOL)animated
    // as per documentation of these methods
    _goingForward = [self isBeingPresented] || [self isMovingToParentViewController];
  
@@ -226,7 +239,7 @@ index 1c44762..06e7139 100644
    [RNSScreenWindowTraits updateWindowTraits];
    if (_shouldNotify) {
      _closing = NO;
-@@ -1697,6 +1841,21 @@ - (void)viewWillDisappear:(BOOL)animated
+@@ -1697,6 +1854,21 @@ - (void)viewWillDisappear:(BOOL)animated
    // as per documentation of these methods
    _goingForward = !([self isBeingDismissed] || [self isMovingFromParentViewController]);
  
@@ -248,7 +261,7 @@ index 1c44762..06e7139 100644
    if (_shouldNotify) {
      _closing = YES;
      [self notifyTransitionProgress:0.0 closing:_closing goingForward:_goingForward];
-@@ -1719,6 +1878,29 @@ - (void)viewDidAppear:(BOOL)animated
+@@ -1719,6 +1891,29 @@ - (void)viewDidAppear:(BOOL)animated
    } else {
      [self.screenView notifyGestureCancel];
    }
@@ -278,7 +291,7 @@ index 1c44762..06e7139 100644
  
    _isSwiping = NO;
    _shouldNotify = YES;
-@@ -1744,6 +1926,20 @@ - (void)viewDidDisappear:(BOOL)animated
+@@ -1744,6 +1939,20 @@ - (void)viewDidDisappear:(BOOL)animated
      [self notifyTransitionProgress:1.0 closing:YES goingForward:_goingForward];
    }
  
@@ -299,7 +312,7 @@ index 1c44762..06e7139 100644
    _isSwiping = NO;
    _shouldNotify = YES;
  
-@@ -1753,6 +1949,19 @@ - (void)viewDidDisappear:(BOOL)animated
+@@ -1753,6 +1962,19 @@ - (void)viewDidDisappear:(BOOL)animated
    }
  }
  
@@ -319,7 +332,7 @@ index 1c44762..06e7139 100644
  - (void)viewDidLayoutSubviews
  {
    [super viewDidLayoutSubviews];
-@@ -1764,15 +1973,46 @@ - (void)viewDidLayoutSubviews
+@@ -1764,15 +1986,46 @@ - (void)viewDidLayoutSubviews
    // screen size
    BOOL isDisplayedWithinUINavController = [self.parentViewController isKindOfClass:[RNSNavigationController class]];
    BOOL isTabScreen = [self.parentViewController isKindOfClass:RNSTabBarController.class];
@@ -368,7 +381,7 @@ index 1c44762..06e7139 100644
  #else
      if (!CGRectEqualToRect(_lastViewFrame, self.screenView.frame)) {
        _lastViewFrame = self.screenView.frame;
-@@ -1864,6 +2104,22 @@ - (CGFloat)calculateHeaderHeightIsModal:(BOOL)isModal
+@@ -1864,6 +2117,22 @@ - (CGFloat)calculateHeaderHeightIsModal:(BOOL)isModal
  - (void)calculateAndNotifyHeaderHeightChangeIsModal:(BOOL)isModal
  {
    CGFloat totalHeight = [self calculateHeaderHeightIsModal:isModal];
@@ -391,7 +404,7 @@ index 1c44762..06e7139 100644
    [self.screenView notifyHeaderHeightChange:totalHeight];
  }
  
-@@ -1927,8 +2183,16 @@ - (BOOL)isRemovedFromParent
+@@ -1927,8 +2196,16 @@ - (BOOL)isRemovedFromParent
  
  - (void)setupProgressNotification
  {
@@ -408,7 +421,7 @@ index 1c44762..06e7139 100644
        // If the transition is not animated, there is no point to set up animation
        // and completion callbacks. This helps prevent issues with dismissed modals having
        // "artifical animation duration" instead of being removed instantly.
-@@ -1938,7 +2202,24 @@ - (void)setupProgressNotification
+@@ -1938,7 +2215,24 @@ - (void)setupProgressNotification
  
      _fakeView.alpha = 0.0;
  
@@ -433,7 +446,7 @@ index 1c44762..06e7139 100644
        [[context containerView] addSubview:self->_fakeView];
        self->_fakeView.alpha = 1.0;
        self->_animationTimer = [CADisplayLink displayLinkWithTarget:self selector:@selector(handleAnimation)];
-@@ -1948,10 +2229,25 @@ - (void)setupProgressNotification
+@@ -1948,10 +2242,25 @@ - (void)setupProgressNotification
      [self.transitionCoordinator
          animateAlongsideTransition:animation
                          completion:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
@@ -459,7 +472,7 @@ index 1c44762..06e7139 100644
    }
  }
  
-@@ -1969,9 +2265,22 @@ - (void)handleAnimation
+@@ -1969,9 +2278,22 @@ - (void)handleAnimation
  - (void)notifyTransitionProgress:(double)progress closing:(BOOL)closing goingForward:(BOOL)goingForward
  {
    if ([self.view isKindOfClass:[RNSScreenView class]]) {
@@ -484,18 +497,32 @@ index 1c44762..06e7139 100644
  }
  
 diff --git a/node_modules/react-native-screens/ios/RNSScreenStack.mm b/node_modules/react-native-screens/ios/RNSScreenStack.mm
-index e37e40a..1e95f36 100644
+index e37e40a..fb0ad52 100644
 --- a/node_modules/react-native-screens/ios/RNSScreenStack.mm
 +++ b/node_modules/react-native-screens/ios/RNSScreenStack.mm
-@@ -31,6 +31,55 @@
+@@ -31,6 +31,69 @@
  #import "RNSTabsScreenViewController.h"
  #import "RNSViewInteractionAware.h"
  #import "UIScrollView+RNScreens.h"
 +
 +// MARK: - OneKey Native Logger Bridge (ObjC, for RNSScreenStack diagnostics)
++static NSString *RNSStackWallTimeString(void) {
++  static NSDateFormatter *formatter;
++  static dispatch_once_t onceToken;
++  dispatch_once(&onceToken, ^{
++    formatter = [NSDateFormatter new];
++    formatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
++    formatter.dateFormat = @"yyyy-MM-dd HH:mm:ss.SSS";
++  });
++  return [formatter stringFromDate:[NSDate date]];
++}
++
 +static void RNSScreenStackLog(NSString *message) {
-+  NSString *fullMessage = [NSString stringWithFormat:@"[RNSScreenStack] %@ (ts=%.6f, main=%d)",
-+                           message, CFAbsoluteTimeGetCurrent(), [NSThread isMainThread]];
++  NSString *fullMessage = [NSString stringWithFormat:@"[RNSScreenStack] %@ (wall=%@ ts=%.6f, main=%d)",
++                           message,
++                           RNSStackWallTimeString(),
++                           CFAbsoluteTimeGetCurrent(),
++                           [NSThread isMainThread]];
 +  Class logClass = NSClassFromString(@"ReactNativeNativeLogger.OneKeyLog");
 +  if (logClass) {
 +#pragma clang diagnostic push
@@ -543,7 +570,7 @@ index e37e40a..1e95f36 100644
  #import "UIView+RNSUtility.h"
  #import "integrations/RNSDismissibleModalProtocol.h"
  #import "utils/UINavigationBar+RNSUtility.h"
-@@ -212,6 +261,11 @@ @implementation RNSScreenStackView {
+@@ -212,6 +275,11 @@ @implementation RNSScreenStackView {
    RNSPercentDrivenInteractiveTransition *_interactionController;
    __weak RNSScreenStackManager *_manager;
    BOOL _updateScheduled;
@@ -555,7 +582,7 @@ index e37e40a..1e95f36 100644
    UIPanGestureRecognizer *_sinkEventsPanGestureRecognizer;
  #ifdef RCT_NEW_ARCH_ENABLED
    /// Screens that are subject of `ShadowViewMutation::Type::Delete` mutation
-@@ -267,6 +321,24 @@ - (void)initCommonProps
+@@ -267,6 +335,24 @@ - (void)initCommonProps
    // the header will render in collapsed state which is perhaps a bug
    // in UIKit but ¯\_(ツ)_/¯
    [_controller setViewControllers:@[ [UIViewController new] ]];
@@ -580,7 +607,7 @@ index e37e40a..1e95f36 100644
  }
  
  #pragma mark - helper methods
-@@ -300,6 +372,153 @@ - (void)emitOnFinishTransitioningEvent
+@@ -300,6 +386,153 @@ - (void)emitOnFinishTransitioningEvent
  #endif
  }
  
@@ -734,7 +761,7 @@ index e37e40a..1e95f36 100644
  - (void)navigationController:(UINavigationController *)navigationController
        willShowViewController:(UIViewController *)viewController
                      animated:(BOOL)animated
-@@ -355,6 +574,13 @@ - (void)presentationControllerDidDismiss:(UIPresentationController *)presentatio
+@@ -355,6 +588,13 @@ - (void)presentationControllerDidDismiss:(UIPresentationController *)presentatio
  
  - (void)didMoveToWindow
  {
@@ -748,7 +775,7 @@ index e37e40a..1e95f36 100644
    [super didMoveToWindow];
  #ifdef RCT_NEW_ARCH_ENABLED
    // for handling nested stacks
-@@ -367,6 +593,14 @@ - (void)didMoveToWindow
+@@ -367,6 +607,14 @@ - (void)didMoveToWindow
      [self maybeAddToParentAndUpdateContainer];
    }
  #endif
@@ -763,7 +790,7 @@ index e37e40a..1e95f36 100644
    if (self.window == nil) {
      // When hot reload happens that would remove the whole stack, disabling the interaction on a screen out transition
      // will not be matched with enabling the interactions on another screen's in transition. We need to make sure
-@@ -375,16 +609,29 @@ - (void)didMoveToWindow
+@@ -375,16 +623,29 @@ - (void)didMoveToWindow
    }
  }
  
@@ -797,7 +824,7 @@ index e37e40a..1e95f36 100644
    [self updateContainer];
    if (!wasScreenMounted) {
      // when stack hasn't been added to parent VC yet we do two things:
-@@ -405,10 +652,43 @@ - (void)reactAddControllerToClosestParent:(UIViewController *)controller
+@@ -405,10 +666,43 @@ - (void)reactAddControllerToClosestParent:(UIViewController *)controller
  {
    if (!controller.parentViewController) {
      UIView *parentView = (UIView *)self.reactSuperview;
@@ -843,7 +870,7 @@ index e37e40a..1e95f36 100644
  #if !TARGET_OS_TV
          _controller.interactivePopGestureRecognizer.delegate = self;
  #if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
-@@ -417,7 +697,7 @@ - (void)reactAddControllerToClosestParent:(UIViewController *)controller
+@@ -417,7 +711,7 @@ - (void)reactAddControllerToClosestParent:(UIViewController *)controller
          }
  #endif // Check for iOS >= 26.0
  #endif
@@ -852,7 +879,7 @@ index e37e40a..1e95f36 100644
          // On iOS pre 12 we observed that `willShowViewController` delegate method does not always
          // get triggered when the navigation controller is instantiated. As the only thing we do in
          // that delegate method is ask nav header to update to the current state it does not hurt to
-@@ -467,6 +747,8 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -467,6 +761,8 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
  {
    // prevent re-entry
    if (_updatingModals) {
@@ -861,7 +888,7 @@ index e37e40a..1e95f36 100644
      _scheduleModalsUpdate = YES;
      return;
    }
-@@ -475,12 +757,22 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -475,12 +771,22 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
    // accidently trigger modal dismiss if we don't verify to run the below code only when an actual
    // change in the list of presented modal was made.
    if ([_presentedModals isEqualToArray:controllers]) {
@@ -884,7 +911,7 @@ index e37e40a..1e95f36 100644
      return;
    }
  
-@@ -521,6 +813,7 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -521,6 +827,7 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
    __weak RNSScreenStackView *weakSelf = self;
  
    void (^afterTransitions)(void) = ^{
@@ -892,7 +919,7 @@ index e37e40a..1e95f36 100644
      [weakSelf emitOnFinishTransitioningEvent];
      weakSelf.updatingModals = NO;
      if (weakSelf.scheduleModalsUpdate) {
-@@ -536,6 +829,7 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -536,6 +843,7 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
    };
  
    void (^finish)(void) = ^{
@@ -900,7 +927,7 @@ index e37e40a..1e95f36 100644
      NSUInteger oldCount = weakSelf.presentedModals.count;
      if (changeRootIndex < oldCount) {
        [weakSelf.presentedModals removeObjectsInRange:NSMakeRange(changeRootIndex, oldCount - changeRootIndex)];
-@@ -544,10 +838,13 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -544,10 +852,13 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
          changeRootController.parentViewController != nil || changeRootController.presentingViewController != nil;
  
      if (!isAttached || changeRootIndex >= controllers.count) {
@@ -918,7 +945,7 @@ index e37e40a..1e95f36 100644
        afterTransitions();
        return;
      }
-@@ -624,16 +921,23 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -624,16 +935,23 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
                ? static_cast<RNSScreen *>(firstModalToBeDismissed).screenView.stackAnimation !=
                    RNSScreenStackAnimationNone
                : YES;
@@ -946,7 +973,7 @@ index e37e40a..1e95f36 100644
                                  finish();
                                }];
          }
-@@ -670,12 +974,30 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -670,12 +988,30 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
  {
    // when there is no change we return immediately
    if ([_controller.viewControllers isEqualToArray:controllers]) {
@@ -978,7 +1005,7 @@ index e37e40a..1e95f36 100644
      return;
    }
    // when transition is ongoing, any updates made to the controller will not be reflected until the
-@@ -685,6 +1007,7 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -685,6 +1021,7 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
    // making any updated when transition is ongoing and schedule updates for when the transition
    // is complete.
    if (_controller.transitionCoordinator != nil) {
@@ -986,7 +1013,7 @@ index e37e40a..1e95f36 100644
      if (!_updateScheduled) {
        _updateScheduled = YES;
        __weak RNSScreenStackView *weakSelf = self;
-@@ -750,8 +1073,15 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -750,8 +1087,15 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
        NSMutableArray *newControllers = [NSMutableArray arrayWithArray:controllers];
        [newControllers removeLastObject];
  
@@ -1002,7 +1029,7 @@ index e37e40a..1e95f36 100644
      } else {
        // don't really know what this case could be, but may need to handle it
        // somehow
-@@ -765,6 +1095,9 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -765,6 +1109,9 @@ - (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
  
  - (void)updateContainer
  {
@@ -1012,7 +1039,7 @@ index e37e40a..1e95f36 100644
    NSMutableArray<UIViewController *> *pushControllers = [NSMutableArray new];
    NSMutableArray<UIViewController *> *modalControllers = [NSMutableArray new];
    for (RNSScreenView *screen in _reactSubviews) {
-@@ -816,6 +1149,10 @@ - (void)layoutSubviews
+@@ -816,6 +1163,10 @@ - (void)layoutSubviews
        modal.view.frame = correctFrame;
      }
    }
@@ -1023,7 +1050,7 @@ index e37e40a..1e95f36 100644
  }
  
  - (void)dismissOnReload
-@@ -868,13 +1205,17 @@ - (void)rnscreens_disableInteractions
+@@ -868,13 +1219,17 @@ - (void)rnscreens_disableInteractions
  {
    // When transitioning between screens, disable interactions on stack subview which wraps the screens
    // and sink all gesture events. This should work for nested stacks and stack inside bottom tabs, inside stack.

--- a/patches/react-native-screens+4.23.0.patch
+++ b/patches/react-native-screens+4.23.0.patch
@@ -37,10 +37,52 @@ index 7055a0d..81ee02b 100644
      }
  
 diff --git a/node_modules/react-native-screens/ios/RNSScreen.mm b/node_modules/react-native-screens/ios/RNSScreen.mm
-index 1c44762..3ed576d 100644
+index 1c44762..d9d24a9 100644
 --- a/node_modules/react-native-screens/ios/RNSScreen.mm
 +++ b/node_modules/react-native-screens/ios/RNSScreen.mm
-@@ -1621,6 +1621,7 @@ @implementation RNSScreen {
+@@ -49,6 +49,24 @@
+ constexpr NSInteger SHEET_FIT_TO_CONTENTS = -1;
+ constexpr NSInteger SHEET_LARGEST_UNDIMMED_DETENT_NONE = -1;
+ 
++static void RNSScreenLogInfo(NSString *message)
++{
++  Class logClass = NSClassFromString(@"ReactNativeNativeLogger.OneKeyLog");
++  if (logClass == nil) {
++    logClass = NSClassFromString(@"OneKeyLog");
++  }
++  if (logClass == nil) {
++    return;
++  }
++  SEL sel = NSSelectorFromString(@"info::");
++  if (![logClass respondsToSelector:sel]) {
++    return;
++  }
++  typedef void (*LogFunc)(id, SEL, NSString *, NSString *);
++  LogFunc func = (LogFunc)[logClass methodForSelector:sel];
++  func(logClass, sel, @"RNSScreen", message);
++}
++
+ struct ContentWrapperBox {
+   __weak RNSScreenContentWrapper *contentWrapper{nil};
+   float contentHeightErrata{0.f};
+@@ -201,6 +219,16 @@ - (void)updateBounds
+         ? 0
+         : [_controller calculateHeaderHeightIsModal:self.isPresentedAsNativeModal];
+ 
++    if (self.isPresentedAsNativeModal) {
++      RNSScreenLogInfo([NSString
++          stringWithFormat:@"updateBounds modal bounds=(%.1f,%.1f) contentOffsetY=%.1f controller=%p view=%p",
++                           self.bounds.size.width,
++                           self.bounds.size.height,
++                           effectiveContentOffsetY,
++                           _controller,
++                           self]);
++    }
++
+     auto newState = react::RNSScreenState{RCTSizeFromCGSize(self.bounds.size), {0, effectiveContentOffsetY}};
+ 
+     _state->updateState(
+@@ -1621,6 +1649,7 @@ @implementation RNSScreen {
    BOOL _isSwiping;
    BOOL _shouldNotify;
    BOOL _isRemovedFromParent;
@@ -48,7 +90,7 @@ index 1c44762..3ed576d 100644
  }
  
  #pragma mark - Common
-@@ -1643,6 +1644,18 @@ - (instancetype)initWithView:(UIView *)view
+@@ -1643,6 +1672,18 @@ - (instancetype)initWithView:(UIView *)view
  - (void)viewWillAppear:(BOOL)animated
  {
    [super viewWillAppear:animated];
@@ -67,12 +109,18 @@ index 1c44762..3ed576d 100644
    if (!_isSwiping) {
      [self.screenView notifyWillAppear];
      if (self.transitionCoordinator.isInteractive) {
-@@ -1719,6 +1732,13 @@ - (void)viewDidAppear:(BOOL)animated
+@@ -1719,6 +1760,19 @@ - (void)viewDidAppear:(BOOL)animated
    } else {
      [self.screenView notifyGestureCancel];
    }
 +#ifdef RCT_NEW_ARCH_ENABLED
 +  if (_shouldApplyDeferredModalBoundsUpdate && self.screenView.isPresentedAsNativeModal) {
++    RNSScreenLogInfo([NSString
++        stringWithFormat:@"viewDidAppear apply deferred update bounds=(%.1f,%.1f) controller=%p screen=%p",
++                         self.screenView.bounds.size.width,
++                         self.screenView.bounds.size.height,
++                         self,
++                         self.screenView]);
 +    _shouldApplyDeferredModalBoundsUpdate = NO;
 +    [self calculateAndNotifyHeaderHeightChangeIsModal:YES];
 +    [self.screenView updateBounds];
@@ -81,7 +129,7 @@ index 1c44762..3ed576d 100644
  
    _isSwiping = NO;
    _shouldNotify = YES;
-@@ -1764,15 +1784,21 @@ - (void)viewDidLayoutSubviews
+@@ -1764,15 +1818,34 @@ - (void)viewDidLayoutSubviews
    // screen size
    BOOL isDisplayedWithinUINavController = [self.parentViewController isKindOfClass:[RNSNavigationController class]];
    BOOL isTabScreen = [self.parentViewController isKindOfClass:RNSTabBarController.class];
@@ -97,8 +145,21 @@ index 1c44762..3ed576d 100644
  #ifdef RCT_NEW_ARCH_ENABLED
 -    [self.screenView updateBounds];
 +    if (self.screenView.isPresentedAsNativeModal && isModalTransitionInProgress) {
++      RNSScreenLogInfo([NSString
++          stringWithFormat:@"viewDidLayoutSubviews defer updateBounds bounds=(%.1f,%.1f) coordinator=%p controller=%p",
++                           self.screenView.bounds.size.width,
++                           self.screenView.bounds.size.height,
++                           self.transitionCoordinator,
++                           self]);
 +      _shouldApplyDeferredModalBoundsUpdate = YES;
 +    } else {
++      if (self.screenView.isPresentedAsNativeModal) {
++        RNSScreenLogInfo([NSString
++            stringWithFormat:@"viewDidLayoutSubviews immediate updateBounds bounds=(%.1f,%.1f) controller=%p",
++                             self.screenView.bounds.size.width,
++                             self.screenView.bounds.size.height,
++                             self]);
++      }
 +      [self.screenView updateBounds];
 +      _shouldApplyDeferredModalBoundsUpdate = NO;
 +    }

--- a/patches/react-native-screens+4.23.0.patch
+++ b/patches/react-native-screens+4.23.0.patch
@@ -1,49 +1,15 @@
-diff --git a/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt b/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
-index 7055a0d..81ee02b 100644
---- a/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
-+++ b/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
-@@ -17,6 +17,7 @@ import com.facebook.react.modules.core.ReactChoreographer
- import com.facebook.react.uimanager.ThemedReactContext
- import com.facebook.react.uimanager.UIManagerHelper
- import com.swmansion.rnscreens.Screen.ActivityState
-+import android.util.Log
- import com.swmansion.rnscreens.events.ScreenDismissedEvent
- import com.swmansion.rnscreens.gamma.common.FragmentProviding
- 
-@@ -291,7 +292,24 @@ open class ScreenContainer(
-         }
- 
-         if (hasFragments) {
--            transaction.commitNowAllowingStateLoss()
-+            // Guard against "FragmentManager is already executing transactions" crash.
-+            // This race condition occurs when onDetachedFromWindow triggers removeMyFragments
-+            // while performUpdates -> onUpdate is already committing a transaction on the same
-+            // FragmentManager within the same UI frame (e.g. during rapid navigation).
-+            // On catch, we defer the removal to the next frame where the FragmentManager
-+            // will no longer be in a transaction.
-+            // See: https://github.com/software-mansion/react-native-screens/issues/2318
-+            // See: https://github.com/software-mansion/react-native-screens/issues/1506
-+            try {
-+                transaction.commitNowAllowingStateLoss()
-+            } catch (e: IllegalStateException) {
-+                Log.w("ScreenContainer", "FragmentManager already executing transactions, deferring fragment removal", e)
-+                post {
-+                    if (!fragmentManager.isDestroyed) {
-+                        removeMyFragments(fragmentManager)
-+                    }
-+                }
-+            }
-         }
-     }
- 
 diff --git a/node_modules/react-native-screens/ios/RNSScreen.mm b/node_modules/react-native-screens/ios/RNSScreen.mm
-index 1c44762..a9cb115 100644
+index 1c44762..13b9b56 100644
 --- a/node_modules/react-native-screens/ios/RNSScreen.mm
 +++ b/node_modules/react-native-screens/ios/RNSScreen.mm
-@@ -49,6 +49,104 @@
+@@ -49,6 +49,150 @@
  constexpr NSInteger SHEET_FIT_TO_CONTENTS = -1;
  constexpr NSInteger SHEET_LARGEST_UNDIMMED_DETENT_NONE = -1;
  
++// Global flag: set to YES during modal presentation transition so that
++// Fabric's updateLayoutMetrics can wrap frame changes in performWithoutAnimation.
++BOOL RNSModalTransitionInProgress = NO;
++
 +static NSString *RNSBoolString(BOOL value)
 +{
 +  return value ? @"YES" : @"NO";
@@ -70,6 +36,45 @@ index 1c44762..a9cb115 100644
 +static NSString *RNSClassSummary(id obj)
 +{
 +  return obj == nil ? @"nil" : NSStringFromClass([obj class]);
++}
++
++static NSString *RNSAffineTransformSummary(CGAffineTransform transform)
++{
++  return [NSString stringWithFormat:@"{a=%.3f,b=%.3f,c=%.3f,d=%.3f,tx=%.3f,ty=%.3f}",
++                                    transform.a,
++                                    transform.b,
++                                    transform.c,
++                                    transform.d,
++                                    transform.tx,
++                                    transform.ty];
++}
++
++static NSString *RNSCATransformSummary(CATransform3D transform)
++{
++  return [NSString stringWithFormat:@"{m11=%.3f,m12=%.3f,m21=%.3f,m22=%.3f,m33=%.3f,m41=%.3f,m42=%.3f,m43=%.3f}",
++                                    transform.m11,
++                                    transform.m12,
++                                    transform.m21,
++                                    transform.m22,
++                                    transform.m33,
++                                    transform.m41,
++                                    transform.m42,
++                                    transform.m43];
++}
++
++static NSString *RNSPresentationLayerSummary(UIView *view)
++{
++  CALayer *presentationLayer = view.layer.presentationLayer;
++  if (presentationLayer == nil) {
++    return @"pres=nil";
++  }
++  return [NSString stringWithFormat:@"presFrame=%@ presBounds=%@ presPos={x=%.1f,y=%.1f} presOpacity=%.3f presTransform=%@",
++                                    RNSRectSummary(presentationLayer.frame),
++                                    RNSRectSummary(presentationLayer.bounds),
++                                    presentationLayer.position.x,
++                                    presentationLayer.position.y,
++                                    presentationLayer.opacity,
++                                    RNSCATransformSummary(presentationLayer.transform)];
 +}
 +
 +static NSString *RNSWallTimeString(void)
@@ -104,12 +109,15 @@ index 1c44762..a9cb115 100644
 +static NSString *RNSScreenViewStateSummary(UIView *view, UIViewController *controller)
 +{
 +  UIWindow *window = view.window ?: controller.view.window;
-+  return [NSString stringWithFormat:@"bounds=%@ frame=%@ insets=%@ alpha=%.3f hidden=%@ window=%p parent=%@ presenting=%@ presented=%@ modalStyle=%ld %@",
++  return [NSString stringWithFormat:@"bounds=%@ frame=%@ insets=%@ alpha=%.3f hidden=%@ viewTransform=%@ layerTransform=%@ %@ window=%p parent=%@ presenting=%@ presented=%@ modalStyle=%ld %@",
 +                                    RNSRectSummary(view.bounds),
 +                                    RNSRectSummary(view.frame),
 +                                    RNSInsetsSummary(view.safeAreaInsets),
 +                                    view.alpha,
 +                                    RNSBoolString(view.isHidden),
++                                    RNSAffineTransformSummary(view.transform),
++                                    RNSCATransformSummary(view.layer.transform),
++                                    RNSPresentationLayerSummary(view),
 +                                    window,
 +                                    RNSClassSummary(controller.parentViewController),
 +                                    RNSClassSummary(controller.presentingViewController),
@@ -145,10 +153,11 @@ index 1c44762..a9cb115 100644
  struct ContentWrapperBox {
    __weak RNSScreenContentWrapper *contentWrapper{nil};
    float contentHeightErrata{0.f};
-@@ -201,6 +299,24 @@ - (void)updateBounds
+@@ -201,7 +345,33 @@ - (void)updateBounds
          ? 0
          : [_controller calculateHeaderHeightIsModal:self.isPresentedAsNativeModal];
  
+-    auto newState = react::RNSScreenState{RCTSizeFromCGSize(self.bounds.size), {0, effectiveContentOffsetY}};
 +    if (self.isModal || self.isPresentedAsNativeModal) {
 +      NSString *headerConfigSummary =
 +          config == nil
@@ -167,10 +176,19 @@ index 1c44762..a9cb115 100644
 +                           RNSScreenViewStateSummary(self, _controller)]);
 +    }
 +
-     auto newState = react::RNSScreenState{RCTSizeFromCGSize(self.bounds.size), {0, effectiveContentOffsetY}};
++    CGSize boundsSize = self.bounds.size;
++    RNSScreenLogInfo([NSString stringWithFormat:
++        @"updateBounds → Fabric setState bounds={%.1f, %.1f} offsetY=%.1f window=%p safeArea=%@",
++        boundsSize.width, boundsSize.height,
++        effectiveContentOffsetY,
++        self.window,
++        RNSInsetsSummary(self.safeAreaInsets)]);
++
++    auto newState = react::RNSScreenState{RCTSizeFromCGSize(boundsSize), {0, effectiveContentOffsetY}};
  
      _state->updateState(
-@@ -1323,6 +1439,12 @@ - (void)dispatchSafeAreaDidChangeNotification
+         std::move(newState)
+@@ -1323,6 +1493,12 @@ - (void)dispatchSafeAreaDidChangeNotification
  - (void)safeAreaInsetsDidChange
  {
    [super safeAreaInsetsDidChange];
@@ -183,18 +201,253 @@ index 1c44762..a9cb115 100644
    [self dispatchSafeAreaDidChangeNotification];
  }
  
-@@ -1621,6 +1743,7 @@ @implementation RNSScreen {
+@@ -1359,6 +1535,15 @@ + (BOOL)shouldBeRecycled
+ 
+ - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+ {
++  if (self.isModal || self.isPresentedAsNativeModal) {
++    RNSScreenLogInfo([NSString stringWithFormat:
++        @"mountChildComponentView class=%@ index=%ld childFrame=%@ screenBounds=%@ window=%p",
++        NSStringFromClass([childComponentView class]),
++        (long)index,
++        NSStringFromCGRect(childComponentView.frame),
++        NSStringFromCGRect(self.bounds),
++        self.window]);
++  }
+   if ([childComponentView isKindOfClass:RNSScreenContentWrapper.class]) {
+     auto contentWrapper = (RNSScreenContentWrapper *)childComponentView;
+     contentWrapper.delegate = self;
+@@ -1621,6 +1806,7 @@ @implementation RNSScreen {
    BOOL _isSwiping;
    BOOL _shouldNotify;
    BOOL _isRemovedFromParent;
-+  BOOL _shouldApplyDeferredModalBoundsUpdate;
++  BOOL _isModalTransitionDisablingAnimations;
  }
  
  #pragma mark - Common
-@@ -1643,6 +1766,18 @@ - (instancetype)initWithView:(UIView *)view
+@@ -1640,9 +1826,237 @@ - (instancetype)initWithView:(UIView *)view
+ }
+ 
+ // TODO: Find out why this is executed when screen is going out
++// DEBUG: recursively dump views with non-identity transform during modal transition
++- (void)dumpTransformsForView:(UIView *)view depth:(int)depth tag:(NSString *)tag
++{
++  CGAffineTransform t = view.transform;
++  CATransform3D lt = view.layer.transform;
++  BOOL viewTransformIsIdentity = CGAffineTransformIsIdentity(t);
++  BOOL layerTransformIsIdentity = CATransform3DIsIdentity(lt);
++  // Also check presentation layer
++  CALayer *pLayer = view.layer.presentationLayer;
++  CATransform3D pt = pLayer ? pLayer.transform : CATransform3DIdentity;
++  BOOL presTransformIsIdentity = pLayer ? CATransform3DIsIdentity(pt) : YES;
++
++  if (!viewTransformIsIdentity || !layerTransformIsIdentity || !presTransformIsIdentity) {
++    NSString *indent = [@"" stringByPaddingToLength:depth * 2 withString:@" " startingAtIndex:0];
++    RNSScreenLogInfo([NSString stringWithFormat:
++        @"[TransformDump:%@] %@%@ frame=%@ view.transform=[%.3f,%.3f,%.3f,%.3f,%.3f,%.3f] layer3D=[%.3f,%.3f,%.3f,%.3f] pLayer3D=[%.3f,%.3f,%.3f,%.3f] pLayerFrame=%@",
++        tag, indent, NSStringFromClass([view class]),
++        NSStringFromCGRect(view.frame),
++        t.a, t.b, t.c, t.d, t.tx, t.ty,
++        lt.m11, lt.m22, lt.m33, lt.m44,
++        pt.m11, pt.m22, pt.m33, pt.m44,
++        pLayer ? NSStringFromCGRect(pLayer.frame) : @"nil"]);
++  }
++  for (UIView *sub in view.subviews) {
++    [self dumpTransformsForView:sub depth:depth + 1 tag:tag];
++  }
++}
++
++// Hook setFrame: on UIView to track frame changes on views with specific testIDs
++#import <objc/runtime.h>
++
++static BOOL RNSFrameHookInstalled = NO;
++static NSSet<NSString *> *RNSTrackedTestIDs = nil;
++
++static void RNSInstallFrameHook(void) {
++  if (RNSFrameHookInstalled) return;
++  RNSFrameHookInstalled = YES;
++  RNSTrackedTestIDs = [NSSet setWithArray:@[@"ab-search-wrap", @"ab-root", @"ab-empty", @"ab-loading"]];
++
++  Class cls = NSClassFromString(@"RCTViewComponentView");
++  if (!cls) return;
++
++  SEL origSel = @selector(setFrame:);
++  Method origMethod = class_getInstanceMethod(cls, origSel);
++  if (!origMethod) return;
++
++  typedef void (*FrameIMP)(id, SEL, CGRect);
++  __block FrameIMP origIMP = (FrameIMP)method_getImplementation(origMethod);
++
++  FrameIMP newIMP = (FrameIMP)imp_implementationWithBlock(^(UIView *self, CGRect frame) {
++    NSString *testId = self.accessibilityIdentifier;
++    if (testId && [RNSTrackedTestIDs containsObject:testId]) {
++      CGRect oldFrame = self.frame;
++      RNSScreenLogInfo([NSString stringWithFormat:
++          @"[setFrame] id=%@ old=%@ new=%@ delta={dw=%.1f,dh=%.1f}",
++          testId,
++          NSStringFromCGRect(oldFrame),
++          NSStringFromCGRect(frame),
++          frame.size.width - oldFrame.size.width,
++          frame.size.height - oldFrame.size.height]);
++    }
++    origIMP(self, origSel, frame);
++  });
++
++  method_setImplementation(origMethod, (IMP)newIMP);
++}
++
++// Dump child view hierarchy downward (max depth, max children per level)
++static void RNSDumpChildViews(UIView *view, int depth, int maxDepth, NSString *tag) {
++  if (depth > maxDepth) return;
++  NSString *indent = [@"" stringByPaddingToLength:depth * 2 withString:@" " startingAtIndex:0];
++
++  // Check presentation layer for position differences
++  CALayer *pLayer = view.layer.presentationLayer;
++  CGRect pFrame = pLayer ? pLayer.frame : view.frame;
++  BOOL framesDiffer = !CGRectEqualToRect(view.frame, pFrame);
++
++  NSString *testId = view.accessibilityIdentifier ?: @"";
++  RNSScreenLogInfo([NSString stringWithFormat:
++      @"[ChildDump:%@] %@%@ frame=%@ pFrame=%@ diff=%@ subs=%lu id=%@ hidden=%d alpha=%.1f",
++      tag, indent,
++      NSStringFromClass([view class]),
++      NSStringFromCGRect(view.frame),
++      NSStringFromCGRect(pFrame),
++      framesDiffer ? @"YES" : @"no",
++      (unsigned long)view.subviews.count,
++      testId,
++      view.isHidden,
++      view.alpha]);
++
++  NSArray<UIView *> *subs = view.subviews;
++  for (NSUInteger i = 0; i < subs.count; i++) {
++    RNSDumpChildViews(subs[i], depth + 1, maxDepth, tag);
++  }
++}
++
++// Recursively disable implicit animations on all sublayers during modal transition.
++// Fabric mount items update child view frames asynchronously; when these frame changes
++// land inside UIKit's modal presentation CATransaction, they get implicitly animated,
++// causing visible content displacement while borders/containers remain stable.
++static void RNSDisableImplicitAnimationsRecursively(CALayer *layer, BOOL disable) {
++  if (disable) {
++    // Setting actions to @{} with NSNull for common keys suppresses implicit animations
++    layer.actions = @{
++      @"position": [NSNull null],
++      @"bounds": [NSNull null],
++      @"frame": [NSNull null],
++      @"opacity": [NSNull null],
++      @"backgroundColor": [NSNull null],
++    };
++  } else {
++    layer.actions = nil;
++  }
++  for (CALayer *sublayer in layer.sublayers) {
++    RNSDisableImplicitAnimationsRecursively(sublayer, disable);
++  }
++}
++
  - (void)viewWillAppear:(BOOL)animated
  {
    [super viewWillAppear:animated];
++
++  // Install frame hook once to track setFrame: calls on tracked views
++  RNSInstallFrameHook();
++
++  // Disable implicit animations on ALL sublayers in the content tree during modal
++  // presentation. Re-enable in viewDidAppear after transition completes.
++  if (self.screenView.isPresentedAsNativeModal && animated) {
++    _isModalTransitionDisablingAnimations = YES;
++    RNSModalTransitionInProgress = YES;
++
++    // Dump presentationController / containerView info
++    UIPresentationController *pc = self.presentationController;
++    UIView *containerView = pc.containerView;
++    UIView *presentedView = pc.presentedView;
++    RNSScreenLogInfo([NSString stringWithFormat:
++        @"[ModalPresentation] pcClass=%@ containerView=%p containerFrame=%@ presentedView=%p presentedFrame=%@ self.view=%p selfFrame=%@ selfBounds=%@",
++        NSStringFromClass([pc class]),
++        containerView,
++        containerView ? NSStringFromCGRect(containerView.frame) : @"nil",
++        presentedView,
++        presentedView ? NSStringFromCGRect(presentedView.frame) : @"nil",
++        self.view,
++        NSStringFromCGRect(self.view.frame),
++        NSStringFromCGRect(self.view.bounds)]);
++
++    // Walk presentedView → self.view to see all intermediate containers
++    UIView *walk = self.view;
++    int depth = 0;
++    while (walk && depth < 15) {
++      RNSScreenLogInfo([NSString stringWithFormat:
++          @"[ModalHierarchy] depth=%d class=%@ frame=%@ bounds=%@ transform=[%.3f,%.3f,%.3f,%.3f,%.3f,%.3f] clipsToBounds=%d",
++          depth,
++          NSStringFromClass([walk class]),
++          NSStringFromCGRect(walk.frame),
++          NSStringFromCGRect(walk.bounds),
++          walk.transform.a, walk.transform.b, walk.transform.c, walk.transform.d, walk.transform.tx, walk.transform.ty,
++          walk.clipsToBounds]);
++      walk = walk.superview;
++      depth++;
++    }
++
++    // Also dump at +200ms to see if anything changes
++    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)),
++                   dispatch_get_main_queue(), ^{
++      UIPresentationController *pc2 = self.presentationController;
++      UIView *cv2 = pc2.containerView;
++      UIView *pv2 = pc2.presentedView;
++      RNSScreenLogInfo([NSString stringWithFormat:
++          @"[ModalPresentation+200ms] containerFrame=%@ presentedFrame=%@ selfFrame=%@ selfBounds=%@",
++          cv2 ? NSStringFromCGRect(cv2.frame) : @"nil",
++          pv2 ? NSStringFromCGRect(pv2.frame) : @"nil",
++          NSStringFromCGRect(self.view.frame),
++          NSStringFromCGRect(self.view.bounds)]);
++
++      UIView *walk2 = self.view;
++      int d2 = 0;
++      while (walk2 && d2 < 15) {
++        RNSScreenLogInfo([NSString stringWithFormat:
++            @"[ModalHierarchy+200ms] depth=%d class=%@ frame=%@ bounds=%@ transform=[%.3f,%.3f,%.3f,%.3f,%.3f,%.3f]",
++            d2,
++            NSStringFromClass([walk2 class]),
++            NSStringFromCGRect(walk2.frame),
++            NSStringFromCGRect(walk2.bounds),
++            walk2.transform.a, walk2.transform.b, walk2.transform.c, walk2.transform.d, walk2.transform.tx, walk2.transform.ty]);
++        walk2 = walk2.superview;
++        d2++;
++      }
++    });
++
++    // Find the innermost RNSScreenView and dump from there
++    void (^dumpInnermost)(NSString *tag) = ^(NSString *tag) {
++      UIView *innermost = self.view;
++      // Walk down to find the deepest RNSScreenView
++      UIView *candidate = self.view;
++      NSMutableArray<UIView *> *stack = [NSMutableArray arrayWithObject:candidate];
++      while (stack.count > 0) {
++        UIView *v = stack.lastObject;
++        [stack removeLastObject];
++        if ([v isKindOfClass:NSClassFromString(@"RNSScreenView")] && v != self.view) {
++          innermost = v;
++        }
++        for (UIView *sub in v.subviews) {
++          [stack addObject:sub];
++        }
++      }
++      RNSScreenLogInfo([NSString stringWithFormat:@"[InnerDump:%@] starting from %@ frame=%@",
++          tag, NSStringFromClass([innermost class]), NSStringFromCGRect(innermost.frame)]);
++      RNSDumpChildViews(innermost, 0, 25, tag);
++    };
++    dumpInnermost(@"t=0");
++    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.015 * NSEC_PER_SEC)),
++                   dispatch_get_main_queue(), ^{ dumpInnermost(@"t+15ms"); });
++    for (int i = 1; i <= 20; i++) {
++      NSString *label = [NSString stringWithFormat:@"t+%dms", i * 30];
++      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(i * 0.03 * NSEC_PER_SEC)),
++                     dispatch_get_main_queue(), ^{ dumpInnermost(label); });
++    }
++  }
 +
 +  // Workaround for react-native-screens issue #1779 / #2587:
 +  // edgesForExtendedLayout is normally set in the navigationController:willShowViewController:
@@ -210,7 +463,7 @@ index 1c44762..a9cb115 100644
    if (!_isSwiping) {
      [self.screenView notifyWillAppear];
      if (self.transitionCoordinator.isInteractive) {
-@@ -1659,6 +1794,28 @@ - (void)viewWillAppear:(BOOL)animated
+@@ -1659,6 +2073,28 @@ - (void)viewWillAppear:(BOOL)animated
    // as per documentation of these methods
    _goingForward = [self isBeingPresented] || [self isMovingToParentViewController];
  
@@ -239,7 +492,7 @@ index 1c44762..a9cb115 100644
    [RNSScreenWindowTraits updateWindowTraits];
    if (_shouldNotify) {
      _closing = NO;
-@@ -1697,6 +1854,21 @@ - (void)viewWillDisappear:(BOOL)animated
+@@ -1697,6 +2133,21 @@ - (void)viewWillDisappear:(BOOL)animated
    // as per documentation of these methods
    _goingForward = !([self isBeingDismissed] || [self isMovingFromParentViewController]);
  
@@ -261,37 +514,29 @@ index 1c44762..a9cb115 100644
    if (_shouldNotify) {
      _closing = YES;
      [self notifyTransitionProgress:0.0 closing:_closing goingForward:_goingForward];
-@@ -1719,6 +1891,29 @@ - (void)viewDidAppear:(BOOL)animated
+@@ -1711,6 +2162,13 @@ - (void)viewDidAppear:(BOOL)animated
+     [RNSScreenView.viewInteractionManagerInstance enableInteractionsForLastSubtree];
+   }
+   [super viewDidAppear:animated];
++
++  // Re-enable animations after modal transition completes.
++  if (_isModalTransitionDisablingAnimations) {
++    _isModalTransitionDisablingAnimations = NO;
++    RNSModalTransitionInProgress = NO;
++  }
++
+   if (!_isSwiping || _shouldNotify) {
+     // we are going forward or dismissing without swipe
+     // or successfully swiped back
+@@ -1719,7 +2177,6 @@ - (void)viewDidAppear:(BOOL)animated
    } else {
      [self.screenView notifyGestureCancel];
    }
-+  if (self.screenView.isModal || self.screenView.isPresentedAsNativeModal) {
-+    RNSScreenLogInfo([NSString
-+        stringWithFormat:@"viewDidAppear animated=%@ swiping=%@ shouldNotify=%@ deferredPending=%@ controller=%p screen=%p %@",
-+                         RNSBoolString(animated),
-+                         RNSBoolString(_isSwiping),
-+                         RNSBoolString(_shouldNotify),
-+                         RNSBoolString(_shouldApplyDeferredModalBoundsUpdate),
-+                         self,
-+                         self.screenView,
-+                         RNSScreenViewStateSummary(self.screenView, self)]);
-+  }
-+#ifdef RCT_NEW_ARCH_ENABLED
-+  if (_shouldApplyDeferredModalBoundsUpdate && self.screenView.isPresentedAsNativeModal) {
-+    RNSScreenLogInfo([NSString
-+        stringWithFormat:@"viewDidAppear apply deferred update controller=%p screen=%p %@",
-+                         self,
-+                         self.screenView,
-+                         RNSScreenViewStateSummary(self.screenView, self)]);
-+    _shouldApplyDeferredModalBoundsUpdate = NO;
-+    [self calculateAndNotifyHeaderHeightChangeIsModal:YES];
-+    [self.screenView updateBounds];
-+  }
-+#endif
- 
+-
    _isSwiping = NO;
    _shouldNotify = YES;
-@@ -1744,6 +1939,20 @@ - (void)viewDidDisappear:(BOOL)animated
+ }
+@@ -1744,6 +2201,20 @@ - (void)viewDidDisappear:(BOOL)animated
      [self notifyTransitionProgress:1.0 closing:YES goingForward:_goingForward];
    }
  
@@ -312,76 +557,56 @@ index 1c44762..a9cb115 100644
    _isSwiping = NO;
    _shouldNotify = YES;
  
-@@ -1753,6 +1962,19 @@ - (void)viewDidDisappear:(BOOL)animated
+@@ -1753,9 +2224,20 @@ - (void)viewDidDisappear:(BOOL)animated
    }
  }
  
 +- (void)viewWillLayoutSubviews
 +{
 +  [super viewWillLayoutSubviews];
-+  if (self.screenView.isModal || self.screenView.isPresentedAsNativeModal) {
-+    RNSScreenLogInfo([NSString
-+        stringWithFormat:@"viewWillLayoutSubviews deferredPending=%@ controller=%p screen=%p %@",
-+                         RNSBoolString(_shouldApplyDeferredModalBoundsUpdate),
-+                         self,
-+                         self.screenView,
-+                         RNSScreenViewStateSummary(self.screenView, self)]);
-+  }
 +}
 +
  - (void)viewDidLayoutSubviews
  {
-   [super viewDidLayoutSubviews];
-@@ -1764,15 +1986,46 @@ - (void)viewDidLayoutSubviews
+-  [super viewDidLayoutSubviews];
++  if (_isModalTransitionDisablingAnimations) {
++    [UIView performWithoutAnimation:^{
++      [super viewDidLayoutSubviews];
++    }];
++  } else {
++    [super viewDidLayoutSubviews];
++  }
+ 
+   // The below code makes the screen view adapt dimensions provided by the system. We take these
+   // into account only when the view is mounted under RNSNavigationController in which case system
+@@ -1764,6 +2246,7 @@ - (void)viewDidLayoutSubviews
    // screen size
    BOOL isDisplayedWithinUINavController = [self.parentViewController isKindOfClass:[RNSNavigationController class]];
    BOOL isTabScreen = [self.parentViewController isKindOfClass:RNSTabBarController.class];
 +  BOOL isModalTransitionInProgress = self.screenView.isPresentedAsNativeModal && self.transitionCoordinator != nil;
-+
-+  if (self.screenView.isModal || self.screenView.isPresentedAsNativeModal) {
-+    RNSScreenLogInfo([NSString
-+        stringWithFormat:@"viewDidLayoutSubviews navController=%@ tabScreen=%@ modalTransition=%@ deferredPending=%@ controller=%p screen=%p %@",
-+                         RNSBoolString(isDisplayedWithinUINavController),
-+                         RNSBoolString(isTabScreen),
-+                         RNSBoolString(isModalTransitionInProgress),
-+                         RNSBoolString(_shouldApplyDeferredModalBoundsUpdate),
-+                         self,
-+                         self.screenView,
-+                         RNSScreenViewStateSummary(self.screenView, self)]);
-+  }
  
    // Calculate header height on modal open
--  if (self.screenView.isPresentedAsNativeModal) {
-+  if (self.screenView.isPresentedAsNativeModal && !isModalTransitionInProgress) {
-     [self calculateAndNotifyHeaderHeightChangeIsModal:YES];
-   }
+   if (self.screenView.isPresentedAsNativeModal) {
+@@ -1772,7 +2255,17 @@ - (void)viewDidLayoutSubviews
  
    if (isDisplayedWithinUINavController || isTabScreen || self.screenView.isPresentedAsNativeModal) {
  #ifdef RCT_NEW_ARCH_ENABLED
 -    [self.screenView updateBounds];
-+    if (self.screenView.isPresentedAsNativeModal && isModalTransitionInProgress) {
-+      RNSScreenLogInfo([NSString
-+          stringWithFormat:@"viewDidLayoutSubviews defer updateBounds coordinator=%p controller=%p screen=%p %@",
-+                           self.transitionCoordinator,
-+                           self,
-+                           self.screenView,
-+                           RNSScreenViewStateSummary(self.screenView, self)]);
-+      _shouldApplyDeferredModalBoundsUpdate = YES;
-+    } else {
-+      if (self.screenView.isPresentedAsNativeModal) {
-+        RNSScreenLogInfo([NSString
-+            stringWithFormat:@"viewDidLayoutSubviews immediate updateBounds controller=%p screen=%p %@",
-+                             self,
-+                             self.screenView,
-+                             RNSScreenViewStateSummary(self.screenView, self)]);
-+      }
++    // During modal presentation transition, subview layout changes get caught
++    // by UIKit's implicit animation CATransaction, causing visible scale/shift
++    // artifacts. Disable implicit animations so layout snaps to final state.
++    if (isModalTransitionInProgress) {
++      [CATransaction begin];
++      [CATransaction setDisableActions:YES];
 +      [self.screenView updateBounds];
-+      _shouldApplyDeferredModalBoundsUpdate = NO;
++      [CATransaction commit];
++    } else {
++      [self.screenView updateBounds];
 +    }
  #else
      if (!CGRectEqualToRect(_lastViewFrame, self.screenView.frame)) {
        _lastViewFrame = self.screenView.frame;
-@@ -1864,6 +2117,22 @@ - (CGFloat)calculateHeaderHeightIsModal:(BOOL)isModal
+@@ -1864,6 +2357,22 @@ - (CGFloat)calculateHeaderHeightIsModal:(BOOL)isModal
  - (void)calculateAndNotifyHeaderHeightChangeIsModal:(BOOL)isModal
  {
    CGFloat totalHeight = [self calculateHeaderHeightIsModal:isModal];
@@ -404,7 +629,7 @@ index 1c44762..a9cb115 100644
    [self.screenView notifyHeaderHeightChange:totalHeight];
  }
  
-@@ -1927,8 +2196,16 @@ - (BOOL)isRemovedFromParent
+@@ -1927,8 +2436,16 @@ - (BOOL)isRemovedFromParent
  
  - (void)setupProgressNotification
  {
@@ -421,7 +646,7 @@ index 1c44762..a9cb115 100644
        // If the transition is not animated, there is no point to set up animation
        // and completion callbacks. This helps prevent issues with dismissed modals having
        // "artifical animation duration" instead of being removed instantly.
-@@ -1938,7 +2215,24 @@ - (void)setupProgressNotification
+@@ -1938,7 +2455,24 @@ - (void)setupProgressNotification
  
      _fakeView.alpha = 0.0;
  
@@ -446,7 +671,7 @@ index 1c44762..a9cb115 100644
        [[context containerView] addSubview:self->_fakeView];
        self->_fakeView.alpha = 1.0;
        self->_animationTimer = [CADisplayLink displayLinkWithTarget:self selector:@selector(handleAnimation)];
-@@ -1948,10 +2242,25 @@ - (void)setupProgressNotification
+@@ -1948,10 +2482,25 @@ - (void)setupProgressNotification
      [self.transitionCoordinator
          animateAlongsideTransition:animation
                          completion:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
@@ -472,7 +697,7 @@ index 1c44762..a9cb115 100644
    }
  }
  
-@@ -1969,9 +2278,22 @@ - (void)handleAnimation
+@@ -1969,9 +2518,22 @@ - (void)handleAnimation
  - (void)notifyTransitionProgress:(double)progress closing:(BOOL)closing goingForward:(BOOL)goingForward
  {
    if ([self.view isKindOfClass:[RNSScreenView class]]) {

--- a/patches/react-native-screens+4.23.0.patch
+++ b/patches/react-native-screens+4.23.0.patch
@@ -37,15 +37,82 @@ index 7055a0d..81ee02b 100644
      }
  
 diff --git a/node_modules/react-native-screens/ios/RNSScreen.mm b/node_modules/react-native-screens/ios/RNSScreen.mm
-index 1c44762..d9d24a9 100644
+index 1c44762..06e7139 100644
 --- a/node_modules/react-native-screens/ios/RNSScreen.mm
 +++ b/node_modules/react-native-screens/ios/RNSScreen.mm
-@@ -49,6 +49,24 @@
+@@ -49,6 +49,91 @@
  constexpr NSInteger SHEET_FIT_TO_CONTENTS = -1;
  constexpr NSInteger SHEET_LARGEST_UNDIMMED_DETENT_NONE = -1;
  
++static NSString *RNSBoolString(BOOL value)
++{
++  return value ? @"YES" : @"NO";
++}
++
++static NSString *RNSRectSummary(CGRect rect)
++{
++  return [NSString stringWithFormat:@"{x=%.1f,y=%.1f,w=%.1f,h=%.1f}",
++                                    rect.origin.x,
++                                    rect.origin.y,
++                                    rect.size.width,
++                                    rect.size.height];
++}
++
++static NSString *RNSInsetsSummary(UIEdgeInsets insets)
++{
++  return [NSString stringWithFormat:@"{t=%.1f,l=%.1f,b=%.1f,r=%.1f}",
++                                    insets.top,
++                                    insets.left,
++                                    insets.bottom,
++                                    insets.right];
++}
++
++static NSString *RNSClassSummary(id obj)
++{
++  return obj == nil ? @"nil" : NSStringFromClass([obj class]);
++}
++
++static NSString *RNSTransitionSummary(UIViewController *controller)
++{
++  id<UIViewControllerTransitionCoordinator> coordinator = controller.transitionCoordinator;
++  if (coordinator == nil) {
++    return @"tc=nil";
++  }
++  id<UIViewControllerTransitionCoordinatorContext> context =
++      (id<UIViewControllerTransitionCoordinatorContext>)coordinator;
++  return [NSString stringWithFormat:@"tc=%p animated=%@ interactive=%@ cancelled=%@ percent=%.3f velocity=%.3f",
++                                    coordinator,
++                                    RNSBoolString(coordinator.isAnimated),
++                                    RNSBoolString(coordinator.isInteractive),
++                                    RNSBoolString(context.isCancelled),
++                                    context.percentComplete,
++                                    context.completionVelocity];
++}
++
++static NSString *RNSScreenViewStateSummary(UIView *view, UIViewController *controller)
++{
++  UIWindow *window = view.window ?: controller.view.window;
++  return [NSString stringWithFormat:@"bounds=%@ frame=%@ insets=%@ alpha=%.3f hidden=%@ window=%p parent=%@ presenting=%@ presented=%@ modalStyle=%ld %@",
++                                    RNSRectSummary(view.bounds),
++                                    RNSRectSummary(view.frame),
++                                    RNSInsetsSummary(view.safeAreaInsets),
++                                    view.alpha,
++                                    RNSBoolString(view.isHidden),
++                                    window,
++                                    RNSClassSummary(controller.parentViewController),
++                                    RNSClassSummary(controller.presentingViewController),
++                                    RNSClassSummary(controller.presentedViewController),
++                                    (long)controller.modalPresentationStyle,
++                                    RNSTransitionSummary(controller)];
++}
++
 +static void RNSScreenLogInfo(NSString *message)
 +{
++  NSString *fullMessage = [NSString stringWithFormat:@"%@ (ts=%.6f main=%@)",
++                                                     message,
++                                                     CFAbsoluteTimeGetCurrent(),
++                                                     RNSBoolString([NSThread isMainThread])];
++  NSLog(@"[RNSScreen] %@", fullMessage);
 +  Class logClass = NSClassFromString(@"ReactNativeNativeLogger.OneKeyLog");
 +  if (logClass == nil) {
 +    logClass = NSClassFromString(@"OneKeyLog");
@@ -59,30 +126,51 @@ index 1c44762..d9d24a9 100644
 +  }
 +  typedef void (*LogFunc)(id, SEL, NSString *, NSString *);
 +  LogFunc func = (LogFunc)[logClass methodForSelector:sel];
-+  func(logClass, sel, @"RNSScreen", message);
++  func(logClass, sel, @"RNSScreen", fullMessage);
 +}
 +
  struct ContentWrapperBox {
    __weak RNSScreenContentWrapper *contentWrapper{nil};
    float contentHeightErrata{0.f};
-@@ -201,6 +219,16 @@ - (void)updateBounds
+@@ -201,6 +286,24 @@ - (void)updateBounds
          ? 0
          : [_controller calculateHeaderHeightIsModal:self.isPresentedAsNativeModal];
  
-+    if (self.isPresentedAsNativeModal) {
++    if (self.isModal || self.isPresentedAsNativeModal) {
++      NSString *headerConfigSummary =
++          config == nil
++          ? @"header=nil"
++          : [NSString stringWithFormat:@"header{visible=%@ translucent=%@ largeTitle=%@}",
++                                     RNSBoolString(config.shouldHeaderBeVisible),
++                                     RNSBoolString(config.translucent),
++                                     RNSBoolString(config.largeTitle)];
 +      RNSScreenLogInfo([NSString
-+          stringWithFormat:@"updateBounds modal bounds=(%.1f,%.1f) contentOffsetY=%.1f controller=%p view=%p",
-+                           self.bounds.size.width,
-+                           self.bounds.size.height,
++          stringWithFormat:@"updateBounds contentOffsetY=%.1f syncShadow=%@ controller=%p view=%p %@ %@",
 +                           effectiveContentOffsetY,
++                           RNSBoolString(_synchronousShadowStateUpdatesEnabled),
 +                           _controller,
-+                           self]);
++                           self,
++                           headerConfigSummary,
++                           RNSScreenViewStateSummary(self, _controller)]);
 +    }
 +
      auto newState = react::RNSScreenState{RCTSizeFromCGSize(self.bounds.size), {0, effectiveContentOffsetY}};
  
      _state->updateState(
-@@ -1621,6 +1649,7 @@ @implementation RNSScreen {
+@@ -1323,6 +1426,12 @@ - (void)dispatchSafeAreaDidChangeNotification
+ - (void)safeAreaInsetsDidChange
+ {
+   [super safeAreaInsetsDidChange];
++  if (self.isModal || self.isPresentedAsNativeModal) {
++    RNSScreenLogInfo([NSString stringWithFormat:@"safeAreaInsetsDidChange controller=%p view=%p %@",
++                                                self.controller,
++                                                self,
++                                                RNSScreenViewStateSummary(self, self.controller)]);
++  }
+   [self dispatchSafeAreaDidChangeNotification];
+ }
+ 
+@@ -1621,6 +1730,7 @@ @implementation RNSScreen {
    BOOL _isSwiping;
    BOOL _shouldNotify;
    BOOL _isRemovedFromParent;
@@ -90,7 +178,7 @@ index 1c44762..d9d24a9 100644
  }
  
  #pragma mark - Common
-@@ -1643,6 +1672,18 @@ - (instancetype)initWithView:(UIView *)view
+@@ -1643,6 +1753,18 @@ - (instancetype)initWithView:(UIView *)view
  - (void)viewWillAppear:(BOOL)animated
  {
    [super viewWillAppear:animated];
@@ -109,18 +197,79 @@ index 1c44762..d9d24a9 100644
    if (!_isSwiping) {
      [self.screenView notifyWillAppear];
      if (self.transitionCoordinator.isInteractive) {
-@@ -1719,6 +1760,19 @@ - (void)viewDidAppear:(BOOL)animated
+@@ -1659,6 +1781,28 @@ - (void)viewWillAppear:(BOOL)animated
+   // as per documentation of these methods
+   _goingForward = [self isBeingPresented] || [self isMovingToParentViewController];
+ 
++  if (self.screenView.isModal || self.screenView.isPresentedAsNativeModal) {
++    NSString *headerConfigSummary =
++        config == nil
++        ? @"header=nil"
++        : [NSString stringWithFormat:@"header{visible=%@ translucent=%@ largeTitle=%@}",
++                                   RNSBoolString(config.shouldHeaderBeVisible),
++                                   RNSBoolString(config.translucent),
++                                   RNSBoolString(config.largeTitle)];
++    RNSScreenLogInfo([NSString
++        stringWithFormat:@"viewWillAppear animated=%@ swiping=%@ shouldNotify=%@ goingForward=%@ beingPresented=%@ movingToParent=%@ controller=%p screen=%p %@ %@",
++                         RNSBoolString(animated),
++                         RNSBoolString(_isSwiping),
++                         RNSBoolString(_shouldNotify),
++                         RNSBoolString(_goingForward),
++                         RNSBoolString([self isBeingPresented]),
++                         RNSBoolString([self isMovingToParentViewController]),
++                         self,
++                         self.screenView,
++                         headerConfigSummary,
++                         RNSScreenViewStateSummary(self.screenView, self)]);
++  }
++
+   [RNSScreenWindowTraits updateWindowTraits];
+   if (_shouldNotify) {
+     _closing = NO;
+@@ -1697,6 +1841,21 @@ - (void)viewWillDisappear:(BOOL)animated
+   // as per documentation of these methods
+   _goingForward = !([self isBeingDismissed] || [self isMovingFromParentViewController]);
+ 
++  if (self.screenView.isModal || self.screenView.isPresentedAsNativeModal) {
++    RNSScreenLogInfo([NSString
++        stringWithFormat:@"viewWillDisappear animated=%@ swiping=%@ shouldNotify=%@ goingForward=%@ beingDismissed=%@ movingFromParent=%@ dismissCount=%d controller=%p screen=%p %@",
++                         RNSBoolString(animated),
++                         RNSBoolString(_isSwiping),
++                         RNSBoolString(_shouldNotify),
++                         RNSBoolString(_goingForward),
++                         RNSBoolString([self isBeingDismissed]),
++                         RNSBoolString([self isMovingFromParentViewController]),
++                         _dismissCount,
++                         self,
++                         self.screenView,
++                         RNSScreenViewStateSummary(self.screenView, self)]);
++  }
++
+   if (_shouldNotify) {
+     _closing = YES;
+     [self notifyTransitionProgress:0.0 closing:_closing goingForward:_goingForward];
+@@ -1719,6 +1878,29 @@ - (void)viewDidAppear:(BOOL)animated
    } else {
      [self.screenView notifyGestureCancel];
    }
++  if (self.screenView.isModal || self.screenView.isPresentedAsNativeModal) {
++    RNSScreenLogInfo([NSString
++        stringWithFormat:@"viewDidAppear animated=%@ swiping=%@ shouldNotify=%@ deferredPending=%@ controller=%p screen=%p %@",
++                         RNSBoolString(animated),
++                         RNSBoolString(_isSwiping),
++                         RNSBoolString(_shouldNotify),
++                         RNSBoolString(_shouldApplyDeferredModalBoundsUpdate),
++                         self,
++                         self.screenView,
++                         RNSScreenViewStateSummary(self.screenView, self)]);
++  }
 +#ifdef RCT_NEW_ARCH_ENABLED
 +  if (_shouldApplyDeferredModalBoundsUpdate && self.screenView.isPresentedAsNativeModal) {
 +    RNSScreenLogInfo([NSString
-+        stringWithFormat:@"viewDidAppear apply deferred update bounds=(%.1f,%.1f) controller=%p screen=%p",
-+                         self.screenView.bounds.size.width,
-+                         self.screenView.bounds.size.height,
++        stringWithFormat:@"viewDidAppear apply deferred update controller=%p screen=%p %@",
 +                         self,
-+                         self.screenView]);
++                         self.screenView,
++                         RNSScreenViewStateSummary(self.screenView, self)]);
 +    _shouldApplyDeferredModalBoundsUpdate = NO;
 +    [self calculateAndNotifyHeaderHeightChangeIsModal:YES];
 +    [self.screenView updateBounds];
@@ -129,11 +278,64 @@ index 1c44762..d9d24a9 100644
  
    _isSwiping = NO;
    _shouldNotify = YES;
-@@ -1764,15 +1818,34 @@ - (void)viewDidLayoutSubviews
+@@ -1744,6 +1926,20 @@ - (void)viewDidDisappear:(BOOL)animated
+     [self notifyTransitionProgress:1.0 closing:YES goingForward:_goingForward];
+   }
+ 
++  if (self.screenView.isModal || self.screenView.isPresentedAsNativeModal) {
++    RNSScreenLogInfo([NSString
++        stringWithFormat:@"viewDidDisappear animated=%@ swiping=%@ shouldNotify=%@ dismissCount=%d preventNativeDismiss=%@ removedFromParent=%@ controller=%p screen=%p %@",
++                         RNSBoolString(animated),
++                         RNSBoolString(_isSwiping),
++                         RNSBoolString(_shouldNotify),
++                         _dismissCount,
++                         RNSBoolString(self.screenView.preventNativeDismiss),
++                         RNSBoolString(_isRemovedFromParent),
++                         self,
++                         self.screenView,
++                         RNSScreenViewStateSummary(self.screenView, self)]);
++  }
++
+   _isSwiping = NO;
+   _shouldNotify = YES;
+ 
+@@ -1753,6 +1949,19 @@ - (void)viewDidDisappear:(BOOL)animated
+   }
+ }
+ 
++- (void)viewWillLayoutSubviews
++{
++  [super viewWillLayoutSubviews];
++  if (self.screenView.isModal || self.screenView.isPresentedAsNativeModal) {
++    RNSScreenLogInfo([NSString
++        stringWithFormat:@"viewWillLayoutSubviews deferredPending=%@ controller=%p screen=%p %@",
++                         RNSBoolString(_shouldApplyDeferredModalBoundsUpdate),
++                         self,
++                         self.screenView,
++                         RNSScreenViewStateSummary(self.screenView, self)]);
++  }
++}
++
+ - (void)viewDidLayoutSubviews
+ {
+   [super viewDidLayoutSubviews];
+@@ -1764,15 +1973,46 @@ - (void)viewDidLayoutSubviews
    // screen size
    BOOL isDisplayedWithinUINavController = [self.parentViewController isKindOfClass:[RNSNavigationController class]];
    BOOL isTabScreen = [self.parentViewController isKindOfClass:RNSTabBarController.class];
 +  BOOL isModalTransitionInProgress = self.screenView.isPresentedAsNativeModal && self.transitionCoordinator != nil;
++
++  if (self.screenView.isModal || self.screenView.isPresentedAsNativeModal) {
++    RNSScreenLogInfo([NSString
++        stringWithFormat:@"viewDidLayoutSubviews navController=%@ tabScreen=%@ modalTransition=%@ deferredPending=%@ controller=%p screen=%p %@",
++                         RNSBoolString(isDisplayedWithinUINavController),
++                         RNSBoolString(isTabScreen),
++                         RNSBoolString(isModalTransitionInProgress),
++                         RNSBoolString(_shouldApplyDeferredModalBoundsUpdate),
++                         self,
++                         self.screenView,
++                         RNSScreenViewStateSummary(self.screenView, self)]);
++  }
  
    // Calculate header height on modal open
 -  if (self.screenView.isPresentedAsNativeModal) {
@@ -146,19 +348,19 @@ index 1c44762..d9d24a9 100644
 -    [self.screenView updateBounds];
 +    if (self.screenView.isPresentedAsNativeModal && isModalTransitionInProgress) {
 +      RNSScreenLogInfo([NSString
-+          stringWithFormat:@"viewDidLayoutSubviews defer updateBounds bounds=(%.1f,%.1f) coordinator=%p controller=%p",
-+                           self.screenView.bounds.size.width,
-+                           self.screenView.bounds.size.height,
++          stringWithFormat:@"viewDidLayoutSubviews defer updateBounds coordinator=%p controller=%p screen=%p %@",
 +                           self.transitionCoordinator,
-+                           self]);
++                           self,
++                           self.screenView,
++                           RNSScreenViewStateSummary(self.screenView, self)]);
 +      _shouldApplyDeferredModalBoundsUpdate = YES;
 +    } else {
 +      if (self.screenView.isPresentedAsNativeModal) {
 +        RNSScreenLogInfo([NSString
-+            stringWithFormat:@"viewDidLayoutSubviews immediate updateBounds bounds=(%.1f,%.1f) controller=%p",
-+                             self.screenView.bounds.size.width,
-+                             self.screenView.bounds.size.height,
-+                             self]);
++            stringWithFormat:@"viewDidLayoutSubviews immediate updateBounds controller=%p screen=%p %@",
++                             self,
++                             self.screenView,
++                             RNSScreenViewStateSummary(self.screenView, self)]);
 +      }
 +      [self.screenView updateBounds];
 +      _shouldApplyDeferredModalBoundsUpdate = NO;
@@ -166,6 +368,121 @@ index 1c44762..d9d24a9 100644
  #else
      if (!CGRectEqualToRect(_lastViewFrame, self.screenView.frame)) {
        _lastViewFrame = self.screenView.frame;
+@@ -1864,6 +2104,22 @@ - (CGFloat)calculateHeaderHeightIsModal:(BOOL)isModal
+ - (void)calculateAndNotifyHeaderHeightChangeIsModal:(BOOL)isModal
+ {
+   CGFloat totalHeight = [self calculateHeaderHeightIsModal:isModal];
++  if (self.screenView.isModal || self.screenView.isPresentedAsNativeModal) {
++    UINavigationController *navctr = [self getVisibleNavigationControllerIsModal:isModal];
++    CGSize statusBarSize = [self getStatusBarHeightIsModal:isModal];
++    RNSScreenLogInfo([NSString
++        stringWithFormat:@"calculateAndNotifyHeaderHeightChange isModal=%@ total=%.1f navController=%p navHidden=%@ navBarFrame=%@ statusBar={w=%.1f,h=%.1f} controller=%p screen=%p %@",
++                         RNSBoolString(isModal),
++                         totalHeight,
++                         navctr,
++                         navctr == nil ? @"nil" : RNSBoolString(navctr.isNavigationBarHidden),
++                         navctr == nil ? @"nil" : RNSRectSummary(navctr.navigationBar.frame),
++                         statusBarSize.width,
++                         statusBarSize.height,
++                         self,
++                         self.screenView,
++                         RNSScreenViewStateSummary(self.screenView, self)]);
++  }
+   [self.screenView notifyHeaderHeightChange:totalHeight];
+ }
+ 
+@@ -1927,8 +2183,16 @@ - (BOOL)isRemovedFromParent
+ 
+ - (void)setupProgressNotification
+ {
++  BOOL shouldLogModalState = self.screenView.isModal || self.screenView.isPresentedAsNativeModal;
+   if (self.transitionCoordinator != nil) {
+     if (!self.transitionCoordinator.isAnimated) {
++      if (shouldLogModalState) {
++        RNSScreenLogInfo([NSString
++            stringWithFormat:@"setupProgressNotification skipped non-animated controller=%p screen=%p %@",
++                             self,
++                             self.screenView,
++                             RNSScreenViewStateSummary(self.screenView, self)]);
++      }
+       // If the transition is not animated, there is no point to set up animation
+       // and completion callbacks. This helps prevent issues with dismissed modals having
+       // "artifical animation duration" instead of being removed instantly.
+@@ -1938,7 +2202,24 @@ - (void)setupProgressNotification
+ 
+     _fakeView.alpha = 0.0;
+ 
++    if (shouldLogModalState) {
++      RNSScreenLogInfo([NSString
++          stringWithFormat:@"setupProgressNotification begin controller=%p screen=%p %@",
++                           self,
++                           self.screenView,
++                           RNSScreenViewStateSummary(self.screenView, self)]);
++    }
++
+     auto animation = ^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
++      if (shouldLogModalState) {
++        RNSScreenLogInfo([NSString
++            stringWithFormat:@"setupProgressNotification animateAlongsideTransition begin cancelled=%@ percent=%.3f controller=%p screen=%p %@",
++                             RNSBoolString(context.isCancelled),
++                             context.percentComplete,
++                             self,
++                             self.screenView,
++                             RNSScreenViewStateSummary(self.screenView, self)]);
++      }
+       [[context containerView] addSubview:self->_fakeView];
+       self->_fakeView.alpha = 1.0;
+       self->_animationTimer = [CADisplayLink displayLinkWithTarget:self selector:@selector(handleAnimation)];
+@@ -1948,10 +2229,25 @@ - (void)setupProgressNotification
+     [self.transitionCoordinator
+         animateAlongsideTransition:animation
+                         completion:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
++                          if (shouldLogModalState) {
++                            RNSScreenLogInfo([NSString
++                                stringWithFormat:@"setupProgressNotification animateAlongsideTransition completion cancelled=%@ percent=%.3f controller=%p screen=%p %@",
++                                                 RNSBoolString(context.isCancelled),
++                                                 context.percentComplete,
++                                                 self,
++                                                 self.screenView,
++                                                 RNSScreenViewStateSummary(self.screenView, self)]);
++                          }
+                           [self->_animationTimer setPaused:YES];
+                           [self->_animationTimer invalidate];
+                           [self->_fakeView removeFromSuperview];
+                         }];
++  } else if (shouldLogModalState) {
++    RNSScreenLogInfo([NSString
++        stringWithFormat:@"setupProgressNotification skipped coordinator=nil controller=%p screen=%p %@",
++                         self,
++                         self.screenView,
++                         RNSScreenViewStateSummary(self.screenView, self)]);
+   }
+ }
+ 
+@@ -1969,9 +2265,22 @@ - (void)handleAnimation
+ - (void)notifyTransitionProgress:(double)progress closing:(BOOL)closing goingForward:(BOOL)goingForward
+ {
+   if ([self.view isKindOfClass:[RNSScreenView class]]) {
++    RNSScreenView *screenView = (RNSScreenView *)self.view;
++    if (screenView.isModal || screenView.isPresentedAsNativeModal) {
++      RNSScreenLogInfo([NSString
++          stringWithFormat:@"transitionProgress progress=%.3f closing=%@ goingForward=%@ alpha=%.3f bounds=%@ frame=%@ insets=%@ %@",
++                           progress,
++                           RNSBoolString(closing),
++                           RNSBoolString(goingForward),
++                           _currentAlpha,
++                           RNSRectSummary(screenView.bounds),
++                           RNSRectSummary(screenView.frame),
++                           RNSInsetsSummary(screenView.safeAreaInsets),
++                           RNSTransitionSummary(self)]);
++    }
+     // if the view is already snapshot, there is not sense in sending progress since on JS side
+     // the component is already not present
+-    [(RNSScreenView *)self.view notifyTransitionProgress:progress closing:closing goingForward:goingForward];
++    [screenView notifyTransitionProgress:progress closing:closing goingForward:goingForward];
+   }
+ }
+ 
 diff --git a/node_modules/react-native-screens/ios/RNSScreenStack.mm b/node_modules/react-native-screens/ios/RNSScreenStack.mm
 index e37e40a..1e95f36 100644
 --- a/node_modules/react-native-screens/ios/RNSScreenStack.mm


### PR DESCRIPTION
## Summary
- defer `RNSScreen.updateBounds` while iOS native modal/pageSheet transition is in progress
- apply one deferred bounds sync after `viewDidAppear` to avoid transient compressed layouts
- add native `react-native-native-log` diagnostics around modal `updateBounds` decisions

## Testing
- not run (not requested)

## Notes
- patch excludes Android generated build outputs
- branch only contains the `react-native-screens` patch change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
