### PR TITLE
fix: clamp tron resources, tab bar offset on approvals, android token history layout(OK-51997,OK-51937,OK-51934)

### DIFF
--- a/packages/kit/src/components/Resource/TronResource.tsx
+++ b/packages/kit/src/components/Resource/TronResource.tsx
@@ -34,6 +34,10 @@ const DONUT_COLOR = '#818cf8';
 const DONUT_SIZE = 40;
 const DONUT_STROKE = 4;
 
+function clampResourceAvailable(value: BigNumber) {
+  return value.isNegative() ? new BigNumber(0) : value;
+}
+
 function useTronAccountResources({
   accountId,
   networkId,
@@ -86,17 +90,21 @@ function useTronAccountResources({
         const netTotal = new BigNumber(resources.NetLimit ?? 0).plus(
           resources.freeNetLimit ?? 0,
         );
-        const netAvailable = netTotal
-          .minus(resources.NetUsed ?? 0)
-          .minus(resources.freeNetUsed ?? 0);
+        const netAvailable = clampResourceAvailable(
+          netTotal
+            .minus(resources.NetUsed ?? 0)
+            .minus(resources.freeNetUsed ?? 0),
+        );
 
         const energyTotal = new BigNumber(resources.EnergyLimit ?? 0).plus(
           resources.freeEnergyLimit ?? 0,
         );
 
-        const energyAvailable = energyTotal
-          .minus(resources.EnergyUsed ?? 0)
-          .minus(resources.freeEnergyUsed ?? 0);
+        const energyAvailable = clampResourceAvailable(
+          energyTotal
+            .minus(resources.EnergyUsed ?? 0)
+            .minus(resources.freeEnergyUsed ?? 0),
+        );
 
         const result = { netAvailable, netTotal, energyAvailable, energyTotal };
         lastResultRef.current = result;

--- a/packages/kit/src/components/TxAction/TxActionCommon.tsx
+++ b/packages/kit/src/components/TxAction/TxActionCommon.tsx
@@ -19,6 +19,7 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { formatTime } from '@onekeyhq/shared/src/utils/dateUtils';
 import { buildAddressMapInfoKey } from '@onekeyhq/shared/src/utils/historyUtils';
 import {
@@ -132,7 +133,7 @@ function TxActionCommonTitle({
   const intl = useIntl();
 
   return (
-    <XStack alignItems="center">
+    <XStack alignItems="center" minWidth={0}>
       <SizableText numberOfLines={1} flexShrink={1} size="$bodyLgMedium">
         {title}
       </SizableText>
@@ -261,7 +262,9 @@ function TxActionCommonChange({
 }) {
   return (
     <SizableText
+      minWidth={0}
       numberOfLines={1}
+      textAlign="right"
       size="$bodyLgMedium"
       {...(change?.includes('+') && {
         color: '$textSuccess',
@@ -278,7 +281,13 @@ function TxActionCommonChangeDescription({
   changeDescription: string;
 }) {
   return (
-    <SizableText size="$bodyMd" color="$textSubdued" numberOfLines={1}>
+    <SizableText
+      size="$bodyMd"
+      color="$textSubdued"
+      numberOfLines={1}
+      minWidth={0}
+      textAlign="right"
+    >
       {changeDescription || '-'}
     </SizableText>
   );
@@ -357,6 +366,10 @@ function TxActionCommonListView(
   } = props;
   const [settings] = useSettingsPersistAtom();
   const currencySymbol = settings.currencyInfo.symbol;
+  let mobileChangeMaxWidth: '50%' | '65%' | undefined;
+  if (!tableLayout) {
+    mobileChangeMaxWidth = platformEnv.isNativeAndroid ? '65%' : '50%';
+  }
 
   return (
     <ListItem
@@ -379,6 +392,7 @@ function TxActionCommonListView(
         {/* token, title and subtitle */}
         <XStack
           flex={1}
+          minWidth={0}
           gap="$3"
           {...(tableLayout && {
             flexGrow: 2,
@@ -394,7 +408,7 @@ function TxActionCommonListView(
               compact={compact}
             />
           ) : null}
-          <Stack flex={1}>
+          <Stack flex={1} minWidth={0}>
             <TxActionCommonTitle
               title={title}
               status={status}
@@ -430,7 +444,9 @@ function TxActionCommonListView(
         </XStack>
         {/* changes */}
         <Stack
-          maxWidth="50%"
+          minWidth={0}
+          flexShrink={1}
+          maxWidth={mobileChangeMaxWidth}
           alignItems="flex-end"
           {...(tableLayout && {
             alignItems: 'unset',

--- a/packages/kit/src/components/TxAction/TxActionTransfer.tsx
+++ b/packages/kit/src/components/TxAction/TxActionTransfer.tsx
@@ -408,8 +408,12 @@ function TxActionTransferListView(props: ITxActionProps) {
         tokenSymbol: changeSymbol,
         showPlusMinusSigns: true,
       }}
+      minWidth={0}
+      maxWidth="100%"
       numberOfLines={1}
       size="$bodyLgMedium"
+      textAlign="right"
+      flexShrink={1}
       {...((change as string)?.includes('+') && {
         color: '$textSuccess',
       })}
@@ -436,8 +440,11 @@ function TxActionTransferListView(props: ITxActionProps) {
       }}
       size="$bodyMd"
       color="$textSubdued"
+      minWidth={0}
+      maxWidth="100%"
       numberOfLines={1}
-      maxWidth="$40"
+      textAlign="right"
+      flexShrink={1}
     >
       {changeDescription as string}
     </NumberSizeableTextWrapper>
@@ -447,6 +454,10 @@ function TxActionTransferListView(props: ITxActionProps) {
       size="$bodyMd"
       color="$textSubdued"
       formatter="value"
+      minWidth={0}
+      maxWidth="100%"
+      textAlign="right"
+      flexShrink={1}
     >
       -
     </NumberSizeableTextWrapper>

--- a/packages/kit/src/views/Home/pages/ApprovalListPage.tsx
+++ b/packages/kit/src/views/Home/pages/ApprovalListPage.tsx
@@ -14,6 +14,7 @@ import {
   XStack,
   YStack,
   useMedia,
+  useScrollContentTabBarOffset,
 } from '@onekeyhq/components';
 import { getNetworksSupportBulkRevokeApproval } from '@onekeyhq/shared/src/config/presetNetworks';
 import {
@@ -177,6 +178,7 @@ function ApprovalListPageContent() {
   const intl = useIntl();
   const media = useMedia();
   const navigation = useAppNavigation();
+  const tabBarHeight = useScrollContentTabBarOffset();
 
   const approvalListActions = useApprovalListActions();
   const [{ approvals }] = useApprovalListAtom();
@@ -386,6 +388,11 @@ function ApprovalListPageContent() {
               networkId={networkId ?? ''}
               indexedAccountId={indexedAccountId}
               onPress={handleApprovalOnPress}
+              listViewStyleProps={{
+                contentContainerStyle: {
+                  pb: tabBarHeight,
+                },
+              }}
               {...(media.gtLg && {
                 tableLayout: true,
               })}


### PR DESCRIPTION
## Summary
- **fix(tron)**: Clamp negative resource availability values to zero to prevent UI displaying negative bandwidth/energy
- **fix(home)**: Add tab bar offset to approval list page so content isn't hidden behind the bottom tab bar
- **fix(android)**: Fix token history amounts being truncated on Android by adding proper `minWidth`, `textAlign`, and `flexShrink` constraints to transaction list items

## Root Cause
1. **Tron resources**: When `NetUsed + freeNetUsed` exceeds `NetLimit + freeNetLimit` (or similarly for energy), the computed available value goes negative, causing display issues.
2. **Approval list**: The approval list page was missing `useScrollContentTabBarOffset` padding, so list items at the bottom were obscured by the tab bar.
3. **Android token history**: The transaction amount and fiat value text were being clipped because the layout lacked `minWidth: 0` on flex containers and `textAlign: right` / `flexShrink: 1` on text elements — particularly visible on Android where a wider `maxWidth: 65%` is needed for the change column.

## Changes Detail
- `TronResource.tsx` — Added `clampResourceAvailable()` helper that floors BigNumber values at 0; applied to both net and energy available calculations.
- `TxActionCommon.tsx` — Added `minWidth: 0` to flex containers in the list view layout; set `textAlign: right` on change/description text; used platform-aware `maxWidth` (65% on Android, 50% elsewhere).
- `TxActionTransfer.tsx` — Added `minWidth: 0`, `textAlign: right`, `flexShrink: 1`, and `maxWidth: 100%` to `NumberSizeableTextWrapper` elements for proper text truncation.
- `ApprovalListPage.tsx` — Added `useScrollContentTabBarOffset` hook and applied `pb: tabBarHeight` to list content container.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile (Android primarily for token history), all platforms for Tron resources and approval list
- **Risk Areas**: Layout changes in transaction history list items could affect other token types — visual verification recommended

## Test plan
- [ ] Verify Tron resource page shows 0 (not negative) when usage exceeds limits
- [ ] Verify approval list scrolls fully past bottom tab bar on mobile
- [ ] Verify token history amounts display fully on Android (no truncation)
- [ ] Verify token history layout is not broken on iOS/desktop
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
