### PR TITLE
feat: add oxlint rules for import order, inline function props, and raw Error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,18 @@
 // require('./development/lint/eslint-rule-force-async-bg-api'); // TODO not working
 // require('./development/lint/eslint-rule-enforce-return-type');
 
+// Register local eslint-plugin-onekey so eslint-disable-next-line onekey/no-raw-error
+// comments don't cause "unknown rule" errors (the real rule lives in oxlint)
+const Module = require('module');
+const path = require('path');
+const originalResolve = Module._resolveFilename;
+Module._resolveFilename = function (request, ...args) {
+  if (request === 'eslint-plugin-onekey') {
+    return path.resolve(__dirname, 'development/lint/eslint-plugin-onekey.js');
+  }
+  return originalResolve.call(this, request, ...args);
+};
+
 const isDev = process.env.NODE_ENV !== 'production';
 const jsRules = {
   // --- Rules from wesbos config (previously inherited via extends: ['wesbos']) ---
@@ -277,6 +289,7 @@ module.exports = {
     'react',
     'react-hooks',
     'import',
+    'onekey',
   ],
   settings: {
     'import/extensions': [

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -5,12 +5,14 @@
     "eslint-plugin-import-path",
     "eslint-plugin-props-checker",
     "eslint-plugin-ban",
-    "eslint-plugin-prettier"
+    "eslint-plugin-prettier",
+    { "name": "import-js", "specifier": "eslint-plugin-import" },
+    "./development/lint/eslint-plugin-onekey.js"
   ],
   "extends": [
     "eslint-config-prettier",
   ],
-  "plugins": ["unicorn", "typescript", "oxc", "react", "import", "jest", "jsx-a11y"],
+  "plugins": ["unicorn", "typescript", "oxc", "react", "react_perf", "import", "jest", "jsx-a11y"],
   // NOTE: JavaScript ESLint plugins (experimental feature) are not used yet
   // because some plugin configurations are not compatible with oxlint
   // https://oxc.rs/docs/guide/usage/linter/migrate-from-eslint.html#local-custom-eslint-plugins
@@ -223,6 +225,12 @@
       }
     ],
     "react/jsx-curly-brace-presence": ["error", { "props": "never", "children": "never" }],
+    // Prevent inline functions as props — causes unnecessary re-renders and state loss
+    "react_perf/jsx-no-new-function-as-prop": "error",
+    // Disabled: too noisy in React Native with tamagui styled components
+    "react_perf/jsx-no-new-object-as-prop": "off",
+    "react_perf/jsx-no-new-array-as-prop": "off",
+    "react_perf/jsx-no-jsx-as-prop": "off",
     "typescript/no-unsafe-type-assertion": "off",
     "typescript/no-unnecessary-boolean-literal-compare": "off",
     // ============================================
@@ -308,6 +316,41 @@
     "import/no-duplicates": "error",
     "import/no-mutable-exports": "error",
     "import/no-self-import": "error",
+    // Import declaration ordering (via eslint-plugin-import JS plugin)
+    "import-js/order": [
+      "error",
+      {
+        "groups": [
+          "builtin",
+          "internal",
+          "index",
+          "external",
+          "parent",
+          "sibling",
+          "object",
+          "type"
+        ],
+        "pathGroups": [
+          {
+            "pattern": "react",
+            "group": "builtin",
+            "position": "before"
+          },
+          {
+            "pattern": "@onekeyhq/**",
+            "group": "external",
+            "position": "after"
+          }
+        ],
+        "alphabetize": {
+          "order": "asc",
+          "caseInsensitive": true
+        },
+        "newlines-between": "always",
+        "pathGroupsExcludedImportTypes": ["builtin"],
+        "warnOnUnassignedImports": true
+      }
+    ],
 
     // ============================================
     // Jest rules (for test files) - keep off as in ESLint config
@@ -391,7 +434,13 @@
     // namespace import issues - too many false positives
     "import/namespace": "off",
     // Allow using Object.assign instead of spread syntax
-    "prefer-object-spread": "off"
+    "prefer-object-spread": "off",
+
+    // ============================================
+    // Custom OneKey rules (JS plugin)
+    // ============================================
+    // Enforce OneKeyLocalError/OneKeyError instead of raw Error
+    "onekey/no-raw-error": "error"
   },
   // Package-specific rules (migrated from ESLint overrides)
   "overrides": [

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -12,7 +12,7 @@
   "extends": [
     "eslint-config-prettier",
   ],
-  "plugins": ["unicorn", "typescript", "oxc", "react", "react_perf", "import", "jest", "jsx-a11y"],
+  "plugins": ["unicorn", "typescript", "oxc", "react", "import", "jest", "jsx-a11y"],
   // NOTE: JavaScript ESLint plugins (experimental feature) are not used yet
   // because some plugin configurations are not compatible with oxlint
   // https://oxc.rs/docs/guide/usage/linter/migrate-from-eslint.html#local-custom-eslint-plugins
@@ -225,10 +225,8 @@
       }
     ],
     "react/jsx-curly-brace-presence": ["error", { "props": "never", "children": "never" }],
-    // Prevent inline functions as props — causes unnecessary re-renders and state loss
-    // warn for now (2527 existing violations), lint:staged --deny-warnings blocks new ones
-    "react_perf/jsx-no-new-function-as-prop": "warn",
-    // Disabled: too noisy in React Native with tamagui styled components
+    // react_perf rules — disabled, too many existing violations to fix at once
+    "react_perf/jsx-no-new-function-as-prop": "off",
     "react_perf/jsx-no-new-object-as-prop": "off",
     "react_perf/jsx-no-new-array-as-prop": "off",
     "react_perf/jsx-no-jsx-as-prop": "off",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -226,7 +226,8 @@
     ],
     "react/jsx-curly-brace-presence": ["error", { "props": "never", "children": "never" }],
     // Prevent inline functions as props — causes unnecessary re-renders and state loss
-    "react_perf/jsx-no-new-function-as-prop": "error",
+    // warn for now (2527 existing violations), lint:staged --deny-warnings blocks new ones
+    "react_perf/jsx-no-new-function-as-prop": "warn",
     // Disabled: too noisy in React Native with tamagui styled components
     "react_perf/jsx-no-new-object-as-prop": "off",
     "react_perf/jsx-no-new-array-as-prop": "off",
@@ -564,6 +565,22 @@
             ]
           }
         ]
+      }
+    },
+    {
+      // Development scripts, test tooling, and native modules — OneKeyLocalError doesn't apply
+      "files": [
+        "development/**/*.js",
+        "development/**/*.ts",
+        "development/**/*.mjs",
+        "apps/*/e2e/**/*.js",
+        "apps/*/harness/**/*.ts",
+        "apps/*/harness/**/*.mjs",
+        "apps/*/plugins/**/*.js",
+        "apps/desktop/native-modules/**/*.js"
+      ],
+      "rules": {
+        "onekey/no-raw-error": "off"
       }
     },
     {

--- a/apps/desktop/App.tsx
+++ b/apps/desktop/App.tsx
@@ -1,15 +1,14 @@
-/* eslint-disable @typescript-eslint/no-unused-vars, import/first, import/order */
+/* eslint-disable @typescript-eslint/no-unused-vars, import/first, import/order, import-js/order */
 import '@onekeyhq/shared/src/polyfills';
 import '@onekeyhq/shared/src/web/index.css';
-
 import { KitProvider } from '@onekeyhq/kit';
-
 import {
   initSentry,
   withSentryHOC,
 } from '@onekeyhq/shared/src/modules3rdParty/sentry';
 import { debugLandingLog } from '@onekeyhq/shared/src/performance/init';
 import { SentryErrorBoundaryFallback } from '@onekeyhq/kit/src/components/ErrorBoundary';
+
 import {
   ReanimatedLogLevel,
   configureReanimatedLogger,

--- a/apps/desktop/app/libs/react-native-mmkv-desktop-main.ts
+++ b/apps/desktop/app/libs/react-native-mmkv-desktop-main.ts
@@ -5,6 +5,8 @@
 import { ipcMain } from 'electron';
 import Store from 'electron-store';
 
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+
 const IPC_CHANNEL = 'mmkv:sync';
 const PERSISTENT_IDS = new Set(['onekey-app-setting']);
 
@@ -127,8 +129,7 @@ class MMKV {
   }
 
   recrypt(_key: string | undefined): void {
-    // eslint-disable-next-line no-restricted-syntax
-    throw new Error('Method not implemented.');
+    throw new OneKeyLocalError('Method not implemented.');
   }
 
   remove(key: string): boolean {

--- a/apps/desktop/app/libs/react-native-mmkv-mock.ts
+++ b/apps/desktop/app/libs/react-native-mmkv-mock.ts
@@ -1,6 +1,8 @@
 // Mock for react-native-mmkv
 // In-memory storage implementation for MMKV interface
 
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+
 class MMKV {
   private storage: Map<string, boolean | string | number | ArrayBuffer>;
 
@@ -41,8 +43,7 @@ class MMKV {
   }
 
   recrypt(_key: string | undefined): void {
-    // eslint-disable-next-line no-restricted-syntax
-    throw new Error('Method not implemented.');
+    throw new OneKeyLocalError('Method not implemented.');
   }
 
   remove(key: string): boolean {

--- a/apps/desktop/babel.config.js
+++ b/apps/desktop/babel.config.js
@@ -1,4 +1,5 @@
 const babelTools = require('../../development/babelTools');
+
 const packageJson = require('./package.json');
 
 module.exports = babelTools.normalizeConfig({

--- a/apps/desktop/electron-builder-ms.config.js
+++ b/apps/desktop/electron-builder-ms.config.js
@@ -1,6 +1,6 @@
 // oxlint-disable no-template-curly-in-string -- electron-builder template syntax
-const DLLs = require('./electron-dll.config');
 const baseElectronBuilderConfig = require('./electron-builder-base.config');
+const DLLs = require('./electron-dll.config');
 
 module.exports = {
   ...baseElectronBuilderConfig,

--- a/apps/desktop/electron-builder-win.config.js
+++ b/apps/desktop/electron-builder-win.config.js
@@ -1,6 +1,6 @@
 // oxlint-disable no-template-curly-in-string -- electron-builder template syntax
-const DLLs = require('./electron-dll.config');
 const baseElectronBuilderConfig = require('./electron-builder-base.config');
+const DLLs = require('./electron-dll.config');
 
 module.exports = {
   ...baseElectronBuilderConfig,

--- a/apps/desktop/index.js
+++ b/apps/desktop/index.js
@@ -1,6 +1,7 @@
 // oxlint-disable unicorn/prefer-global-this
 /* eslint-disable unicorn/prefer-global-this */
 /* eslint-disable import/first */
+/* eslint-disable import-js/order */
 import '@onekeyhq/shared/src/performance/init';
 
 if (typeof window !== 'undefined') {

--- a/apps/desktop/scripts/afterPack.js
+++ b/apps/desktop/scripts/afterPack.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+
 const { FuseVersion, FuseV1Options } = require('@electron/fuses');
 
 exports.default = async function fileOperation(context) {

--- a/apps/desktop/scripts/build.js
+++ b/apps/desktop/scripts/build.js
@@ -1,9 +1,11 @@
 require('../../../development/env');
 
-const path = require('path');
 const childProcess = require('child_process');
+const path = require('path');
+
 const { build } = require('esbuild');
 const glob = require('glob');
+
 const pkg = require('../app/package.json');
 
 const isProduction = process.env.NODE_ENV === 'production';

--- a/apps/desktop/scripts/dev.js
+++ b/apps/desktop/scripts/dev.js
@@ -1,5 +1,5 @@
-const path = require('path');
 const { execSync } = require('child_process');
+const path = require('path');
 
 const projectRoot = path.join(__dirname, '..');
 

--- a/apps/desktop/scripts/finalize-renderer-assets.js
+++ b/apps/desktop/scripts/finalize-renderer-assets.js
@@ -1,5 +1,6 @@
-const fs = require('fs-extra');
 const path = require('path');
+
+const fs = require('fs-extra');
 
 const root = path.join(__dirname, '..');
 const webBuildDir = path.join(root, 'web-build');

--- a/apps/ext/index.js
+++ b/apps/ext/index.js
@@ -1,6 +1,7 @@
 // oxlint-disable unicorn/prefer-global-this
 /* eslint-disable unicorn/prefer-global-this */
 /* eslint-disable import/first */
+/* eslint-disable import-js/order */
 
 import '@onekeyhq/shared/src/performance/init';
 

--- a/apps/ext/src/entry/background.ts
+++ b/apps/ext/src/entry/background.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/order */
+/* eslint-disable import/order, import-js/order */
 // fix missing setimmediate
 // eslint-disable-next-line import/order
 import 'setimmediate';

--- a/apps/ext/src/entry/content-script-init.ts
+++ b/apps/ext/src/entry/content-script-init.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/order */
+/* eslint-disable import/order, import-js/order */
 // eslint-disable-next-line import/order
 import '@onekeyhq/shared/src/polyfills/polyfillsExtContentScript';
 

--- a/apps/ext/src/entry/offscreen.ts
+++ b/apps/ext/src/entry/offscreen.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-template-expressions, import/order */
 import '@onekeyhq/shared/src/polyfills';
-
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
+
 import { startKeepAlivePolling } from '../background/keepAlive';
 import { offscreenSetup } from '../offscreen/offscreenSetup';
 

--- a/apps/ext/src/entry/ui.tsx
+++ b/apps/ext/src/entry/ui.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable import-js/order */
 // eslint-disable-next-line import/order
 import '@onekeyhq/shared/src/polyfills';
 

--- a/apps/ext/src/manifest/chrome_v3.js
+++ b/apps/ext/src/manifest/chrome_v3.js
@@ -1,6 +1,7 @@
 const isDev = process.env.NODE_ENV !== 'production';
 
 const excludeMatches = require('../content-script/excludeMatches');
+
 const common = require('./common');
 
 module.exports = {

--- a/apps/ext/src/manifest/firefox.js
+++ b/apps/ext/src/manifest/firefox.js
@@ -1,4 +1,5 @@
 const lodash = require('lodash');
+
 const chromeConfig = require('./chrome');
 
 module.exports = lodash.merge({}, chromeConfig, {

--- a/apps/ext/src/manifest/index.js
+++ b/apps/ext/src/manifest/index.js
@@ -1,8 +1,9 @@
 const lodash = require('lodash');
-const sharedManifest = require('./shared');
+
 const chromeManifest = require('./chrome');
 const chromeManifestV3 = require('./chrome_v3');
 const firefoxManifest = require('./firefox');
+const sharedManifest = require('./shared');
 
 let browserManifest = {};
 if (process.env.EXT_CHANNEL === 'firefox') {

--- a/apps/ext/src/ui/renderApp.tsx
+++ b/apps/ext/src/ui/renderApp.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable import-js/order */
 // fix missing setimmediate on react-dom
 // eslint-disable-next-line import/order
 import 'setimmediate';

--- a/apps/mobile/.detoxrc.js
+++ b/apps/mobile/.detoxrc.js
@@ -1,8 +1,8 @@
 // Detox config lives alongside the native app workspace so `yarn workspace @onekeyhq/mobile detox ...`
 // works without extra flags.
 
-const path = require('path');
 const { execSync } = require('child_process');
+const path = require('path');
 
 function tryDetectSimulatorDeviceType() {
   try {

--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+
 const babelTools = require('../../development/babelTools');
 
 console.log('process.env.TAMAGUI_TARGET: ', process.env.TAMAGUI_TARGET);

--- a/apps/mobile/build-bundle.js
+++ b/apps/mobile/build-bundle.js
@@ -1,8 +1,9 @@
 require('../../development/env');
 
-const crypto = require('crypto');
 const { execSync } = require('child_process');
+const crypto = require('crypto');
 const path = require('path');
+
 const fs = require('fs-extra');
 
 const mobileDirPath = __dirname;

--- a/apps/mobile/index.ts
+++ b/apps/mobile/index.ts
@@ -1,12 +1,16 @@
-/* eslint-disable import/order */
+/* eslint-disable import/order, import-js/order */
 import '@onekeyhq/shared/src/performance/init';
+
 import './jsReady';
 
 import { I18nManager } from 'react-native';
 import { registerRootComponent } from 'expo';
+
 import '@onekeyhq/shared/src/polyfills';
 import { initSentry } from '@onekeyhq/shared/src/modules3rdParty/sentry';
+
 import { ReactNativeDeviceUtils } from '@onekeyfe/react-native-device-utils';
+
 import App from './App';
 
 ReactNativeDeviceUtils.initEventListeners();

--- a/apps/mobile/jest-harness-setup.ts
+++ b/apps/mobile/jest-harness-setup.ts
@@ -7,6 +7,7 @@
 // - harness/jest-compat.ts  — describe/test/it wrappers, module mock mechanism, jest shim
 // - harness/snapshots.ts    — toMatchSnapshot / toMatchInlineSnapshot matchers
 
+/* eslint-disable import-js/order */
 import './harness/polyfills';
 // eslint-disable-next-line import/order
 import './harness/jest-compat';

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -5,13 +5,14 @@
  * This config extends '@react-native/metro-config' to support React Native >=0.73
  * For details see: https://github.com/react-native-community/template/blob/main/template/metro.config.js
  */
-const connect = require('connect');
+const path = require('path');
+
 const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
 const { withRozenite } = require('@rozenite/metro');
-const path = require('path');
+const { getSentryExpoConfig } = require('@sentry/react-native/metro');
+const connect = require('connect');
 const fs = require('fs-extra');
 const { resolve } = require('metro-resolver');
-const { getSentryExpoConfig } = require('@sentry/react-native/metro');
 // const { withRozeniteExpoAtlasPlugin } = require('@rozenite/expo-atlas-plugin'); // Uncomment if needed
 
 const projectRoot = __dirname;

--- a/apps/mobile/plugins/asyncRequireTpl.js
+++ b/apps/mobile/plugins/asyncRequireTpl.js
@@ -1,7 +1,7 @@
 // oxlint-disable unicorn/prefer-global-this
 /* eslint-disable unicorn/prefer-global-this */
-const asyncRequire = require('metro-runtime/src/modules/asyncRequire');
 const chunkModuleIdToHashMap = require('__CHUNK_MODULE_ID_TO_HASH_MAP__');
+const asyncRequire = require('metro-runtime/src/modules/asyncRequire');
 const { NativeModules } = require('react-native');
 
 const fetchHttpModule = async (hash) => {

--- a/apps/mobile/plugins/dynamicImports.js
+++ b/apps/mobile/plugins/dynamicImports.js
@@ -1,11 +1,12 @@
 /* eslint-disable import/no-dynamic-require */
-const path = require('path');
-const fs = require('fs-extra');
 const crypto = require('crypto');
+const path = require('path');
 
+const { default: generate } = require('@babel/generator');
 const parser = require('@babel/parser');
 const { default: traverse } = require('@babel/traverse');
-const { default: generate } = require('@babel/generator');
+const fs = require('fs-extra');
+
 const { fileToIdMap } = require('./map');
 
 const baseJSBundle = require(

--- a/apps/mobile/rn-harness.config.mjs
+++ b/apps/mobile/rn-harness.config.mjs
@@ -1,11 +1,11 @@
 import {
-  applePlatform,
-  appleSimulator,
-} from '@react-native-harness/platform-apple';
-import {
   androidEmulator,
   androidPlatform,
 } from '@react-native-harness/platform-android';
+import {
+  applePlatform,
+  appleSimulator,
+} from '@react-native-harness/platform-apple';
 
 // Override defaults via environment variables:
 //   HARNESS_IOS_DEVICE   - iOS simulator name (default: 'iPhone 17 Pro')

--- a/apps/mobile/svgx-transformer.js
+++ b/apps/mobile/svgx-transformer.js
@@ -5,8 +5,8 @@
  * This allows us to use SVG files as React Native components for tab icons
  * while keeping the default behavior for other files.
  */
-const svgTransformer = require('react-native-svg-transformer');
 const upstreamTransformer = require('@react-native/metro-babel-transformer');
+const svgTransformer = require('react-native-svg-transformer');
 
 module.exports.transform = async ({ src, filename, options }) => {
   if (filename.endsWith('.svgx')) {

--- a/apps/web-embed/index.js
+++ b/apps/web-embed/index.js
@@ -1,9 +1,14 @@
+/* eslint-disable import-js/order */
 import '@onekeyhq/shared/src/polyfills';
+
 import React, { Suspense, lazy } from 'react';
+
 import { createRoot } from 'react-dom/client';
 import { HashRouter, Route, Routes } from 'react-router-dom';
+
 import { EWebEmbedRoutePath } from '@onekeyhq/shared/src/consts/webEmbedConsts';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+
 import { init } from './utils/init';
 
 const PageIndex = lazy(() => import('./pages/PageIndex'));

--- a/apps/web/index.js
+++ b/apps/web/index.js
@@ -1,6 +1,7 @@
 // oxlint-disable unicorn/prefer-global-this
 /* eslint-disable unicorn/prefer-global-this */
 /* eslint-disable import/first */
+/* eslint-disable import-js/order */
 import '@onekeyhq/shared/src/performance/init';
 
 if (typeof globalThis !== 'undefined') {
@@ -8,15 +9,17 @@ if (typeof globalThis !== 'undefined') {
 }
 
 import '@onekeyhq/shared/src/polyfills';
+
 import { registerRootComponent } from 'expo';
 
+import { SentryErrorBoundaryFallback } from '@onekeyhq/kit/src/components/ErrorBoundary';
+import { initIntercom } from '@onekeyhq/shared/src/modules3rdParty/intercom';
 import {
   initSentry,
   withSentryHOC,
 } from '@onekeyhq/shared/src/modules3rdParty/sentry';
-import { SentryErrorBoundaryFallback } from '@onekeyhq/kit/src/components/ErrorBoundary';
-import { initIntercom } from '@onekeyhq/shared/src/modules3rdParty/intercom';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
+
 import App from './App';
 
 if (process.env.NODE_ENV !== 'production') {

--- a/apps/web/src/service-worker.js
+++ b/apps/web/src/service-worker.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-globals */
 /* eslint-disable unicorn/prefer-global-this */
+import { ExpirationPlugin } from 'workbox-expiration';
 import { precacheAndRoute } from 'workbox-precaching';
 import { NavigationRoute, registerRoute } from 'workbox-routing';
 import {
@@ -7,7 +8,6 @@ import {
   NetworkFirst,
   StaleWhileRevalidate,
 } from 'workbox-strategies';
-import { ExpirationPlugin } from 'workbox-expiration';
 
 // Skip waiting immediately on install so existing users with old SW get
 // the fix without needing to confirm the update prompt or close all tabs.

--- a/development/babelTools.js
+++ b/development/babelTools.js
@@ -1,5 +1,6 @@
 require('./env');
 const path = require('path');
+
 const developmentConsts = require('./developmentConsts');
 const envExposedToClient = require('./envExposedToClient');
 

--- a/development/debug-hardware-sdk.js
+++ b/development/debug-hardware-sdk.js
@@ -6,6 +6,7 @@
  * example: yarn debug:hardware-sdk -v 0.2.40
  */
 const { exec, execSync } = require('child_process');
+
 const argv = require('minimist')(process.argv.slice(2));
 
 const LIB_VERSION = argv.v || 'latest';

--- a/development/env.js
+++ b/development/env.js
@@ -1,6 +1,7 @@
 const path = require('path');
-const dotenv = require('dotenv');
+
 const dateFns = require('date-fns');
+const dotenv = require('dotenv');
 
 const results = [
   dotenv.config({

--- a/development/lint/electron.js
+++ b/development/lint/electron.js
@@ -1,8 +1,8 @@
-const path = require('path');
-const fs = require('fs-extra');
 const { execSync } = require('child_process');
-
+const path = require('path');
 const { exit } = require('process');
+
+const fs = require('fs-extra');
 
 const getTimestamp = () => new Date().toLocaleTimeString();
 const startTime = Date.now();

--- a/development/lint/eslint-plugin-onekey.js
+++ b/development/lint/eslint-plugin-onekey.js
@@ -1,0 +1,38 @@
+/**
+ * Custom oxlint JS plugin for OneKey-specific lint rules.
+ *
+ * Usage in .oxlintrc.json:
+ *   "jsPlugins": ["./development/lint/eslint-plugin-onekey.js"]
+ *   "rules": { "onekey/no-raw-error": "error" }
+ */
+
+const noRawError = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow throw new Error(), use OneKeyLocalError or OneKeyError instead',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      'ThrowStatement > NewExpression[callee.name="Error"]'(node) {
+        context.report({
+          node,
+          message:
+            'Direct use of "throw new Error" is not allowed. Use OneKeyLocalError or OneKeyError instead.',
+        });
+      },
+    };
+  },
+};
+
+const plugin = {
+  meta: { name: 'onekey' },
+  rules: {
+    'no-raw-error': noRawError,
+  },
+};
+
+module.exports = plugin;

--- a/development/lint/eslint.js
+++ b/development/lint/eslint.js
@@ -1,6 +1,6 @@
 const { execSync } = require('child_process');
-const { exit } = require('process');
 const os = require('os');
+const { exit } = require('process');
 
 const getTimestamp = () => new Date().toLocaleTimeString();
 

--- a/development/lint/eslint.js
+++ b/development/lint/eslint.js
@@ -21,20 +21,31 @@ try {
       ? Math.min(os.cpus().length, 4)
       : os.cpus().length;
   const fixFlag = isCI ? '' : ' --fix';
+  // In CI, use github format for inline PR annotations with file/line/rule info
+  const formatFlag = isCI ? ' --format github' : '';
   console.log(
     `Using ${cpus} threads for oxlint...${isCI ? ' (CI mode, no --fix)' : ''}`,
   );
   const oxlintResult = execSync(
-    `npx oxlint --tsconfig ./tsconfig.json --type-aware --threads=${cpus} .${fixFlag}`,
+    `npx oxlint --tsconfig ./tsconfig.json --type-aware --threads=${cpus} .${fixFlag}${formatFlag}`,
     { encoding: 'utf-8', stdio: 'pipe' },
   );
 
-  // Parse oxlint output for warnings/errors
-  // Example output: "Found 33 warnings and 0 errors."
-  const warningMatch = oxlintResult.match(/Found (\d+) warning/);
-  const errorMatch = oxlintResult.match(/(\d+) error/);
-  const warnings = warningMatch ? Number(warningMatch[1]) : 0;
-  const errors = errorMatch ? Number(errorMatch[1]) : 0;
+  let warnings = 0;
+  let errors = 0;
+
+  if (isCI) {
+    // github format: count ::error and ::warning lines
+    const lines = oxlintResult.split('\n');
+    errors = lines.filter((l) => l.startsWith('::error ')).length;
+    warnings = lines.filter((l) => l.startsWith('::warning ')).length;
+  } else {
+    // default format: parse summary line "Found 33 warnings and 0 errors."
+    const warningMatch = oxlintResult.match(/Found (\d+) warning/);
+    const errorMatch = oxlintResult.match(/(\d+) error/);
+    warnings = warningMatch ? Number(warningMatch[1]) : 0;
+    errors = errorMatch ? Number(errorMatch[1]) : 0;
+  }
 
   const oxlintDuration = ((Date.now() - oxlintStartTime) / 1000).toFixed(2);
 

--- a/development/lint/eslint.js
+++ b/development/lint/eslint.js
@@ -21,31 +21,20 @@ try {
       ? Math.min(os.cpus().length, 4)
       : os.cpus().length;
   const fixFlag = isCI ? '' : ' --fix';
-  // In CI, use github format for inline PR annotations with file/line/rule info
-  const formatFlag = isCI ? ' --format github' : '';
   console.log(
     `Using ${cpus} threads for oxlint...${isCI ? ' (CI mode, no --fix)' : ''}`,
   );
   const oxlintResult = execSync(
-    `npx oxlint --tsconfig ./tsconfig.json --type-aware --threads=${cpus} .${fixFlag}${formatFlag}`,
+    `npx oxlint --tsconfig ./tsconfig.json --type-aware --threads=${cpus} .${fixFlag}`,
     { encoding: 'utf-8', stdio: 'pipe' },
   );
 
-  let warnings = 0;
-  let errors = 0;
-
-  if (isCI) {
-    // github format: count ::error and ::warning lines
-    const lines = oxlintResult.split('\n');
-    errors = lines.filter((l) => l.startsWith('::error ')).length;
-    warnings = lines.filter((l) => l.startsWith('::warning ')).length;
-  } else {
-    // default format: parse summary line "Found 33 warnings and 0 errors."
-    const warningMatch = oxlintResult.match(/Found (\d+) warning/);
-    const errorMatch = oxlintResult.match(/(\d+) error/);
-    warnings = warningMatch ? Number(warningMatch[1]) : 0;
-    errors = errorMatch ? Number(errorMatch[1]) : 0;
-  }
+  // Parse oxlint output for warnings/errors
+  // Example output: "Found 33 warnings and 0 errors."
+  const warningMatch = oxlintResult.match(/Found (\d+) warning/);
+  const errorMatch = oxlintResult.match(/(\d+) error/);
+  const warnings = warningMatch ? Number(warningMatch[1]) : 0;
+  const errors = errorMatch ? Number(errorMatch[1]) : 0;
 
   const oxlintDuration = ((Date.now() - oxlintStartTime) / 1000).toFixed(2);
 

--- a/development/lint/font.js
+++ b/development/lint/font.js
@@ -15,8 +15,8 @@
 // cause the native-registered font and the expo-font-registered font to have different names,
 // making the native registration ineffective.
 
-const path = require('path');
 const fs = require('fs');
+const path = require('path');
 const { exit } = require('process');
 
 const getTimestamp = () => new Date().toLocaleTimeString();

--- a/development/lint/lang.js
+++ b/development/lint/lang.js
@@ -1,6 +1,7 @@
 const path = require('path');
-const fs = require('fs-extra');
 const { exit } = require('process');
+
+const fs = require('fs-extra');
 
 const getTimestamp = () => new Date().toLocaleTimeString();
 const startTime = Date.now();

--- a/development/lint/package-versions.js
+++ b/development/lint/package-versions.js
@@ -1,7 +1,7 @@
 const { execSync } = require('child_process');
-const { exit } = require('process');
 const fs = require('fs');
 const path = require('path');
+const { exit } = require('process');
 
 const getTimestamp = () => new Date().toLocaleTimeString();
 const startTime = Date.now();

--- a/development/lint/ts.js
+++ b/development/lint/ts.js
@@ -1,7 +1,8 @@
 const { execSync, execFileSync } = require('child_process');
-const { exit } = require('process');
-const { parse } = require('@aivenio/tsc-output-parser');
 const path = require('path');
+const { exit } = require('process');
+
+const { parse } = require('@aivenio/tsc-output-parser');
 
 const getTimestamp = () => new Date().toLocaleTimeString();
 const startTime = Date.now();

--- a/development/patch-fix.js
+++ b/development/patch-fix.js
@@ -1,7 +1,7 @@
+const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const process = require('process');
-const { execSync } = require('child_process');
 
 function getPatchTargets(patchesDir) {
   // Read all files in the patches directory

--- a/development/perf-ci/lib/notify.js
+++ b/development/perf-ci/lib/notify.js
@@ -1,9 +1,9 @@
 const path = require('path');
 
+const { postJobAnalytics, postSessionAnalytics } = require('./analytics');
 const { fileExists, readJson, writeJson } = require('./fs');
 const { postSlackWebhook } = require('./slack');
 const { buildPerfAlertModel, buildSlackPayload } = require('./slackPayload');
-const { postJobAnalytics, postSessionAnalytics } = require('./analytics');
 
 function trimTrailingSlash(value) {
   return String(value || '').replace(/\/+$/, '');

--- a/development/perf-ci/lib/perfServer.js
+++ b/development/perf-ci/lib/perfServer.js
@@ -1,6 +1,7 @@
+const { spawn } = require('child_process');
 const fs = require('fs');
 const path = require('path');
-const { spawn } = require('child_process');
+
 const { ensureDir } = require('./fs');
 
 async function checkPerfServer(serverUrl) {

--- a/development/perf-ci/lib/staticServer.js
+++ b/development/perf-ci/lib/staticServer.js
@@ -1,5 +1,5 @@
-const http = require('http');
 const fs = require('fs');
+const http = require('http');
 const path = require('path');
 
 const MIME_TYPES = {

--- a/development/perf-ci/run-android-perf-detox-debug.js
+++ b/development/perf-ci/run-android-perf-detox-debug.js
@@ -6,9 +6,9 @@
  * - Runs Detox Android Debug (Metro).
  */
 
+const { spawn } = require('child_process');
 const os = require('os');
 const path = require('path');
-const { spawn } = require('child_process');
 
 function main() {
   const repoRoot = path.join(__dirname, '..', '..');

--- a/development/perf-ci/run-android-perf-detox-release-daemon.js
+++ b/development/perf-ci/run-android-perf-detox-release-daemon.js
@@ -14,8 +14,8 @@
  *   node development/perf-ci/run-android-perf-detox-release-daemon.js --interval-minutes 300
  */
 
-const path = require('path');
 const { spawn } = require('child_process');
+const path = require('path');
 
 function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));

--- a/development/perf-ci/run-android-perf-detox-release.js
+++ b/development/perf-ci/run-android-perf-detox-release.js
@@ -6,9 +6,9 @@
  * - Runs Detox Android Release (no Metro).
  */
 
+const { spawn } = require('child_process');
 const os = require('os');
 const path = require('path');
-const { spawn } = require('child_process');
 
 function main() {
   const repoRoot = path.join(__dirname, '..', '..');

--- a/development/perf-ci/run-android-perf-detox.js
+++ b/development/perf-ci/run-android-perf-detox.js
@@ -37,8 +37,6 @@ const {
   ensureSessionsDirWritable,
   readSessionMetrics,
 } = require('./lib/session');
-const { postSlackWebhook } = require('./lib/slack');
-
 function hasFlag(name) {
   return process.argv.includes(name);
 }

--- a/development/perf-ci/run-android-perf-detox.js
+++ b/development/perf-ci/run-android-perf-detox.js
@@ -12,31 +12,32 @@
  * - Slack webhook notification on regression or failure
  */
 
-const path = require('path');
+const { spawn } = require('child_process');
 const fs = require('fs');
 const os = require('os');
-const { spawn } = require('child_process');
-const { execCmd } = require('./lib/exec');
-const { ensureDir, readJson, writeJson, fileExists } = require('./lib/fs');
-const { notifyPerfFailure, notifyPerfResult } = require('./lib/notify');
+const path = require('path');
 
 const { readPerfCiLocalConfig } = require('./lib/config');
 const { deriveSession, defaultDerivedOutPath } = require('./lib/derive');
+const { execCmd } = require('./lib/exec');
+const { ensureDir, readJson, writeJson, fileExists } = require('./lib/fs');
 const { nowId } = require('./lib/id');
+const { notifyPerfFailure, notifyPerfResult } = require('./lib/notify');
 const {
   ensurePerfServerRunning,
   checkPerfServer,
   stopChild,
 } = require('./lib/perfServer');
 const {
-  ensureSessionsDirWritable,
-  readSessionMetrics,
-} = require('./lib/session');
-const {
   aggregateRuns,
   checkRegression,
   extractDerivedDebugMetrics,
 } = require('./lib/regression');
+const {
+  ensureSessionsDirWritable,
+  readSessionMetrics,
+} = require('./lib/session');
+const { postSlackWebhook } = require('./lib/slack');
 
 function hasFlag(name) {
   return process.argv.includes(name);

--- a/development/perf-ci/run-desktop-perf-release-daemon.js
+++ b/development/perf-ci/run-desktop-perf-release-daemon.js
@@ -9,8 +9,8 @@
  *   node development/perf-ci/run-desktop-perf-release-daemon.js --interval-minutes 300
  */
 
-const path = require('path');
 const { spawn } = require('child_process');
+const path = require('path');
 
 function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));

--- a/development/perf-ci/run-desktop-perf-release.js
+++ b/development/perf-ci/run-desktop-perf-release.js
@@ -6,8 +6,8 @@
  * - Builds production desktop (main + renderer) and runs Electron in PERF_CI_MODE=1.
  */
 
-const path = require('path');
 const { spawn } = require('child_process');
+const path = require('path');
 
 function main() {
   const repoRoot = path.join(__dirname, '..', '..');

--- a/development/perf-ci/run-desktop-perf.js
+++ b/development/perf-ci/run-desktop-perf.js
@@ -41,8 +41,6 @@ const {
   readSessionMetrics,
   ensureSessionsDirWritable,
 } = require('./lib/session');
-const { postSlackWebhook } = require('./lib/slack');
-
 function ensureDirExists(p) {
   fs.mkdirSync(p, { recursive: true });
 }

--- a/development/perf-ci/run-desktop-perf.js
+++ b/development/perf-ci/run-desktop-perf.js
@@ -13,15 +13,15 @@
  * - optional Slack webhook notification on regression or failure
  */
 
+const { spawn } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { spawn } = require('child_process');
 
-const { execCmd } = require('./lib/exec');
-const { ensureDir, readJson, writeJson, fileExists } = require('./lib/fs');
 const { readPerfCiLocalConfig } = require('./lib/config');
 const { defaultDerivedOutPath, deriveSession } = require('./lib/derive');
+const { execCmd } = require('./lib/exec');
+const { ensureDir, readJson, writeJson, fileExists } = require('./lib/fs');
 const { nowId } = require('./lib/id');
 const { notifyPerfFailure, notifyPerfResult } = require('./lib/notify');
 const {
@@ -30,17 +30,18 @@ const {
   stopChild,
 } = require('./lib/perfServer');
 const {
+  aggregateRuns,
+  checkRegression,
+  extractDerivedDebugMetrics,
+} = require('./lib/regression');
+const {
   listSessionIds,
   waitForNewSessionId,
   waitForMark,
   readSessionMetrics,
   ensureSessionsDirWritable,
 } = require('./lib/session');
-const {
-  aggregateRuns,
-  checkRegression,
-  extractDerivedDebugMetrics,
-} = require('./lib/regression');
+const { postSlackWebhook } = require('./lib/slack');
 
 function ensureDirExists(p) {
   fs.mkdirSync(p, { recursive: true });

--- a/development/perf-ci/run-ext-perf-release-daemon.js
+++ b/development/perf-ci/run-ext-perf-release-daemon.js
@@ -9,8 +9,8 @@
  *   node development/perf-ci/run-ext-perf-release-daemon.js --interval-minutes 300
  */
 
-const path = require('path');
 const { spawn } = require('child_process');
+const path = require('path');
 
 function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));

--- a/development/perf-ci/run-ext-perf-release.js
+++ b/development/perf-ci/run-ext-perf-release.js
@@ -6,8 +6,8 @@
  * - Builds production extension and runs Chromium (headed) via Playwright.
  */
 
-const path = require('path');
 const { spawn } = require('child_process');
+const path = require('path');
 
 function main() {
   const repoRoot = path.join(__dirname, '..', '..');

--- a/development/perf-ci/run-ext-perf.js
+++ b/development/perf-ci/run-ext-perf.js
@@ -19,12 +19,12 @@ const path = require('path');
 
 const { chromium } = require('playwright-core');
 
-const { execCmd } = require('./lib/exec');
-const { ensureDir, readJson, writeJson, fileExists } = require('./lib/fs');
+const { findChromiumExecutable } = require('./lib/chromium');
 const { readPerfCiLocalConfig } = require('./lib/config');
 const { defaultDerivedOutPath, deriveSession } = require('./lib/derive');
+const { execCmd } = require('./lib/exec');
+const { ensureDir, readJson, writeJson, fileExists } = require('./lib/fs');
 const { nowId } = require('./lib/id');
-const { findChromiumExecutable } = require('./lib/chromium');
 const { notifyPerfFailure, notifyPerfResult } = require('./lib/notify');
 const {
   ensurePerfServerRunning,
@@ -32,17 +32,18 @@ const {
   stopChild,
 } = require('./lib/perfServer');
 const {
+  aggregateRuns,
+  checkRegression,
+  extractDerivedDebugMetrics,
+} = require('./lib/regression');
+const {
   listSessionIds,
   waitForNewSessionId,
   waitForMark,
   readSessionMetrics,
   ensureSessionsDirWritable,
 } = require('./lib/session');
-const {
-  aggregateRuns,
-  checkRegression,
-  extractDerivedDebugMetrics,
-} = require('./lib/regression');
+const { postSlackWebhook } = require('./lib/slack');
 
 function ensureDirExists(p) {
   fs.mkdirSync(p, { recursive: true });

--- a/development/perf-ci/run-ext-perf.js
+++ b/development/perf-ci/run-ext-perf.js
@@ -43,8 +43,6 @@ const {
   readSessionMetrics,
   ensureSessionsDirWritable,
 } = require('./lib/session');
-const { postSlackWebhook } = require('./lib/slack');
-
 function ensureDirExists(p) {
   fs.mkdirSync(p, { recursive: true });
 }

--- a/development/perf-ci/run-ios-perf-detox-debug.js
+++ b/development/perf-ci/run-ios-perf-detox-debug.js
@@ -6,9 +6,9 @@
  * - Runs Detox Debug (Metro).
  */
 
+const { spawn } = require('child_process');
 const os = require('os');
 const path = require('path');
-const { spawn } = require('child_process');
 
 function main() {
   const repoRoot = path.join(__dirname, '..', '..');

--- a/development/perf-ci/run-ios-perf-detox-release-daemon.js
+++ b/development/perf-ci/run-ios-perf-detox-release-daemon.js
@@ -14,8 +14,8 @@
  *   node development/perf-ci/run-ios-perf-detox-release-daemon.js --interval-minutes 300
  */
 
-const path = require('path');
 const { spawn } = require('child_process');
+const path = require('path');
 
 function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));

--- a/development/perf-ci/run-ios-perf-detox-release.js
+++ b/development/perf-ci/run-ios-perf-detox-release.js
@@ -6,9 +6,9 @@
  * - Runs Detox Release (no Metro).
  */
 
+const { spawn } = require('child_process');
 const os = require('os');
 const path = require('path');
-const { spawn } = require('child_process');
 
 function main() {
   const repoRoot = path.join(__dirname, '..', '..');

--- a/development/perf-ci/run-ios-perf-detox.js
+++ b/development/perf-ci/run-ios-perf-detox.js
@@ -12,29 +12,30 @@
  * - Slack webhook notification on regression or failure
  */
 
-const path = require('path');
 const os = require('os');
-const { execCmd } = require('./lib/exec');
-const { ensureDir, readJson, writeJson, fileExists } = require('./lib/fs');
-const { notifyPerfFailure, notifyPerfResult } = require('./lib/notify');
+const path = require('path');
 
 const { readPerfCiLocalConfig } = require('./lib/config');
 const { deriveSession, defaultDerivedOutPath } = require('./lib/derive');
+const { execCmd } = require('./lib/exec');
+const { ensureDir, readJson, writeJson, fileExists } = require('./lib/fs');
 const { nowId } = require('./lib/id');
+const { notifyPerfFailure, notifyPerfResult } = require('./lib/notify');
 const {
   ensurePerfServerRunning,
   checkPerfServer,
   stopChild,
 } = require('./lib/perfServer');
 const {
-  ensureSessionsDirWritable,
-  readSessionMetrics,
-} = require('./lib/session');
-const {
   aggregateRuns,
   checkRegression,
   extractDerivedDebugMetrics,
 } = require('./lib/regression');
+const {
+  ensureSessionsDirWritable,
+  readSessionMetrics,
+} = require('./lib/session');
+const { postSlackWebhook } = require('./lib/slack');
 
 function hasFlag(name) {
   return process.argv.includes(name);

--- a/development/perf-ci/run-ios-perf-detox.js
+++ b/development/perf-ci/run-ios-perf-detox.js
@@ -35,8 +35,6 @@ const {
   ensureSessionsDirWritable,
   readSessionMetrics,
 } = require('./lib/session');
-const { postSlackWebhook } = require('./lib/slack');
-
 function hasFlag(name) {
   return process.argv.includes(name);
 }

--- a/development/perf-ci/run-web-perf-prepare.js
+++ b/development/perf-ci/run-web-perf-prepare.js
@@ -16,10 +16,10 @@ const path = require('path');
 
 const { chromium } = require('playwright-core');
 
+const { findChromiumExecutable } = require('./lib/chromium');
+const { readPerfCiLocalConfig } = require('./lib/config');
 const { execCmd } = require('./lib/exec');
 const { ensureDir, fileExists } = require('./lib/fs');
-const { readPerfCiLocalConfig } = require('./lib/config');
-const { findChromiumExecutable } = require('./lib/chromium');
 const { startStaticServer } = require('./lib/staticServer');
 
 function ensureDirExists(p) {

--- a/development/perf-ci/run-web-perf-release-daemon.js
+++ b/development/perf-ci/run-web-perf-release-daemon.js
@@ -9,8 +9,8 @@
  *   node development/perf-ci/run-web-perf-release-daemon.js --interval-minutes 300
  */
 
-const path = require('path');
 const { spawn } = require('child_process');
+const path = require('path');
 
 function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));

--- a/development/perf-ci/run-web-perf-release.js
+++ b/development/perf-ci/run-web-perf-release.js
@@ -6,8 +6,8 @@
  * - Builds production web and runs Chromium via Playwright.
  */
 
-const path = require('path');
 const { spawn } = require('child_process');
+const path = require('path');
 
 function main() {
   const repoRoot = path.join(__dirname, '..', '..');

--- a/development/perf-ci/run-web-perf.js
+++ b/development/perf-ci/run-web-perf.js
@@ -20,13 +20,12 @@ const path = require('path');
 
 const { chromium } = require('playwright-core');
 
-const { execCmd } = require('./lib/exec');
-const { ensureDir, readJson, writeJson, fileExists } = require('./lib/fs');
+const { findChromiumExecutable } = require('./lib/chromium');
 const { readPerfCiLocalConfig } = require('./lib/config');
 const { defaultDerivedOutPath, deriveSession } = require('./lib/derive');
+const { execCmd } = require('./lib/exec');
+const { ensureDir, readJson, writeJson, fileExists } = require('./lib/fs');
 const { nowId } = require('./lib/id');
-const { findChromiumExecutable } = require('./lib/chromium');
-const { startStaticServer } = require('./lib/staticServer');
 const { notifyPerfFailure, notifyPerfResult } = require('./lib/notify');
 const {
   ensurePerfServerRunning,
@@ -34,17 +33,19 @@ const {
   stopChild,
 } = require('./lib/perfServer');
 const {
+  aggregateRuns,
+  checkRegression,
+  extractDerivedDebugMetrics,
+} = require('./lib/regression');
+const {
   ensureSessionsDirWritable,
   listSessionIds,
   waitForNewSessionId,
   waitForMark,
   readSessionMetrics,
 } = require('./lib/session');
-const {
-  aggregateRuns,
-  checkRegression,
-  extractDerivedDebugMetrics,
-} = require('./lib/regression');
+const { postSlackWebhook } = require('./lib/slack');
+const { startStaticServer } = require('./lib/staticServer');
 
 function hasFlag(name) {
   return process.argv.includes(name);

--- a/development/perf-ci/run-web-perf.js
+++ b/development/perf-ci/run-web-perf.js
@@ -44,7 +44,6 @@ const {
   waitForMark,
   readSessionMetrics,
 } = require('./lib/session');
-const { postSlackWebhook } = require('./lib/slack');
 const { startStaticServer } = require('./lib/staticServer');
 
 function hasFlag(name) {

--- a/development/performance-server/cli/derive-session.js
+++ b/development/performance-server/cli/derive-session.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+
 const {
   computeSessionDerived,
   computeSessionLowFpsHotspots,

--- a/development/performance-server/derived.js
+++ b/development/performance-server/derived.js
@@ -1,7 +1,9 @@
 const fs = require('fs');
 const path = require('path');
-const storage = require('./storage');
+
 const analyzer = require('../scripts/analyze-func-perf');
+
+const storage = require('./storage');
 
 const CALLBACKISH_FUNCTION_NAME_PATTERNS = [
   /^anonymous$/i,

--- a/development/performance-server/server.js
+++ b/development/performance-server/server.js
@@ -13,12 +13,14 @@
  *   PERF_OUTPUT_DIR  - Output directory (default: $HOME/perf-sessions)
  */
 
-const http = require('http');
 const fs = require('fs');
+const http = require('http');
 const path = require('path');
+
 const { WebSocketServer } = require('ws');
-const storage = require('./storage');
+
 const derivedLib = require('./derived');
+const storage = require('./storage');
 
 const PORT = parseInt(process.env.PERF_SERVER_PORT || '9527', 10);
 const PUBLIC_DIR = path.join(__dirname, 'public');

--- a/development/scripts/clean_workspace.js
+++ b/development/scripts/clean_workspace.js
@@ -1,6 +1,6 @@
+const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
 
 // Function to remove directory recursively
 function removeDir(dir) {

--- a/development/scripts/copy-injected.js
+++ b/development/scripts/copy-injected.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
+const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
 
 console.log('Copying injected files...');
 

--- a/development/scripts/i18n/build-locale-json-map.js
+++ b/development/scripts/i18n/build-locale-json-map.js
@@ -1,5 +1,6 @@
-const fs = require('fs-extra');
 const path = require('path');
+
+const fs = require('fs-extra');
 
 const localeJsonPath = path.join(
   __dirname,

--- a/development/scripts/i18n/i18n-add.js
+++ b/development/scripts/i18n/i18n-add.js
@@ -9,8 +9,8 @@
  *   LOKALISE_PROJECT_ID - Lokalise project ID
  */
 
-const https = require('https');
 const fs = require('fs');
+const https = require('https');
 const path = require('path');
 
 const LOCALE_JSON_PATH = path.join(

--- a/development/scripts/web-embed.js
+++ b/development/scripts/web-embed.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-const path = require('path');
 const fs = require('fs');
+const path = require('path');
 const { exit } = require('process');
 
 require('../env');

--- a/development/webpack/ext/devUtils.js
+++ b/development/webpack/ext/devUtils.js
@@ -1,11 +1,13 @@
-const fse = require('fs-extra');
 // const fs = require('fs');
-const lodash = require('lodash');
 const childProcess = require('child_process');
 const path = require('path');
+
+const fse = require('fs-extra');
 // const util = require('util');
 const stringify = require('json-stringify-safe');
+const lodash = require('lodash');
 const prettier = require('prettier');
+
 const manifest = require('../../../apps/ext/src/manifest');
 
 // TODO move to developmentConsts.js

--- a/development/webpack/ext/htmlLazyScript.js
+++ b/development/webpack/ext/htmlLazyScript.js
@@ -1,7 +1,9 @@
-const fse = require('fs-extra');
 const fs = require('fs');
 const path = require('path');
+
 const cheerio = require('cheerio');
+const fse = require('fs-extra');
+
 const devUtils = require('./devUtils');
 
 function doTaskInFolder({ folder }) {

--- a/development/webpack/ext/pluginsCopy.js
+++ b/development/webpack/ext/pluginsCopy.js
@@ -1,4 +1,5 @@
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+
 const manifestBuilder = require('./manifestBuilder');
 
 CopyWebpackPlugin.prototype.pluginName = 'CopyWebpackPlugin';

--- a/development/webpack/ext/pluginsHtml.js
+++ b/development/webpack/ext/pluginsHtml.js
@@ -1,11 +1,14 @@
-const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
-const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
+
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 const lodash = require('lodash');
-const indexHtmlParameter = require('../../indexHtmlParameter');
+const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
+
 const developmentConsts = require('../../developmentConsts');
-const devUtils = require('./devUtils');
+const indexHtmlParameter = require('../../indexHtmlParameter');
 const { isDev } = require('../constant');
+
+const devUtils = require('./devUtils');
 
 const platform = developmentConsts.platforms.ext;
 

--- a/development/webpack/ext/zip.js
+++ b/development/webpack/ext/zip.js
@@ -1,6 +1,7 @@
 require('../../env');
 const fs = require('fs');
 const path = require('path');
+
 const devUtils = require('./devUtils');
 
 const extFolder = path.resolve(__dirname, '../../../apps/ext');

--- a/development/webpack/utils.js
+++ b/development/webpack/utils.js
@@ -1,5 +1,7 @@
 const uniq = require('lodash/uniq');
+
 const { developmentConsts } = require('../babelTools');
+
 const { EXT_CHANNEL, TARGET_BROWSER } = require('./constant');
 
 exports.createResolveExtensions = function ({ platform, configName }) {

--- a/development/webpack/webpack.analyzer.config.js
+++ b/development/webpack/webpack.analyzer.config.js
@@ -1,4 +1,5 @@
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
+
 const {
   ENABLE_ANALYZER_HTML_REPORT,
   ENABLE_ANALYZER,

--- a/development/webpack/webpack.base.config.js
+++ b/development/webpack/webpack.base.config.js
@@ -1,13 +1,15 @@
-const webpack = require('webpack');
 const fs = require('fs');
 const path = require('path');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const webpackManifestPlugin = require('webpack-manifest-plugin');
-const ProgressBarPlugin = require('progress-bar-webpack-plugin');
-const notifier = require('node-notifier');
 const { exit } = require('process');
-const { createResolveExtensions } = require('./utils');
+
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const notifier = require('node-notifier');
+const ProgressBarPlugin = require('progress-bar-webpack-plugin');
+const webpack = require('webpack');
+const webpackManifestPlugin = require('webpack-manifest-plugin');
+
 const { isDev, PUBLIC_URL, NODE_ENV, ONEKEY_PROXY } = require('./constant');
+const { createResolveExtensions } = require('./utils');
 
 const IS_EAS_BUILD = !!process.env.EAS_BUILD;
 

--- a/development/webpack/webpack.desktop.config.js
+++ b/development/webpack/webpack.desktop.config.js
@@ -1,15 +1,17 @@
-const path = require('path');
-const { merge } = require('webpack-merge');
-
-const { SubresourceIntegrityPlugin } = require('webpack-subresource-integrity');
 const crypto = require('crypto');
 const fs = require('fs');
-const baseConfig = require('./webpack.base.config');
+const path = require('path');
+
+const { merge } = require('webpack-merge');
+const { SubresourceIntegrityPlugin } = require('webpack-subresource-integrity');
+
+const babelTools = require('../babelTools');
+
+const { NODE_ENV, ENABLE_ANALYZER } = require('./constant');
 const analyzerConfig = require('./webpack.analyzer.config');
+const baseConfig = require('./webpack.base.config');
 const developmentConfig = require('./webpack.development.config');
 const productionConfig = require('./webpack.prod.config');
-const { NODE_ENV, ENABLE_ANALYZER } = require('./constant');
-const babelTools = require('../babelTools');
 
 // Plugin to generate metadata.json with SHA512 hashes of all output files
 const BUILD_BUNDLE_UPDATE = process.env.BUILD_BUNDLE_UPDATE === 'true';

--- a/development/webpack/webpack.development.config.js
+++ b/development/webpack/webpack.development.config.js
@@ -1,8 +1,10 @@
-const path = require('path');
-const webpack = require('webpack');
 const fs = require('fs');
+const path = require('path');
+
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 const { createProxyMiddleware } = require('http-proxy-middleware');
+const webpack = require('webpack');
+
 const { WEB_PORT } = require('./constant');
 
 module.exports = ({ basePath }) => ({

--- a/development/webpack/webpack.ext.config.js
+++ b/development/webpack/webpack.ext.config.js
@@ -1,12 +1,10 @@
-const { merge, mergeWithRules, CustomizeRule } = require('webpack-merge');
 const path = require('path');
-const webpack = require('webpack');
 
-const baseConfig = require('./webpack.base.config');
-const analyzerConfig = require('./webpack.analyzer.config');
-const developmentConfig = require('./webpack.development.config');
-const productionConfig = require('./webpack.prod.config');
+const webpack = require('webpack');
+const { merge, mergeWithRules, CustomizeRule } = require('webpack-merge');
+
 const babelTools = require('../babelTools');
+
 const {
   WEB_PORT,
   isManifestV3,
@@ -14,12 +12,16 @@ const {
   isManifestV2,
   ENABLE_ANALYZER,
 } = require('./constant');
-const devUtils = require('./ext/devUtils');
-const utils = require('./utils');
-const codeSplit = require('./ext/codeSplit');
-const pluginsHtml = require('./ext/pluginsHtml');
-const pluginsCopy = require('./ext/pluginsCopy');
 const ChromeExtensionV3ViolationPlugin = require('./ext/ChromeExtensionV3ViolationPlugin');
+const codeSplit = require('./ext/codeSplit');
+const devUtils = require('./ext/devUtils');
+const pluginsCopy = require('./ext/pluginsCopy');
+const pluginsHtml = require('./ext/pluginsHtml');
+const utils = require('./utils');
+const analyzerConfig = require('./webpack.analyzer.config');
+const baseConfig = require('./webpack.base.config');
+const developmentConfig = require('./webpack.development.config');
+const productionConfig = require('./webpack.prod.config');
 // const htmlLazyScript = require('./ext/htmlLazyScript');
 
 const IS_DEV = isDev;

--- a/development/webpack/webpack.prod.config.js
+++ b/development/webpack/webpack.prod.config.js
@@ -1,9 +1,12 @@
-const TerserPlugin = require('terser-webpack-plugin');
-const { RetryChunkLoadPlugin } = require('webpack-retry-chunk-load-plugin');
 const path = require('path');
+
 const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 const webpack = require('webpack');
+const { RetryChunkLoadPlugin } = require('webpack-retry-chunk-load-plugin');
+
 const babelTools = require('../babelTools');
+
 const utils = require('./utils');
 
 const FILES_TO_DELETE_AFTER_UPLOAD = [

--- a/development/webpack/webpack.web-embed.config.js
+++ b/development/webpack/webpack.web-embed.config.js
@@ -1,11 +1,13 @@
+const path = require('path');
+
 const { merge } = require('webpack-merge');
 
-const path = require('path');
-const developmentConfig = require('./webpack.development.config');
-const productionConfig = require('./webpack.prod.config');
 const babelTools = require('../babelTools');
+
 const { PUBLIC_URL, NODE_ENV } = require('./constant');
 const baseConfig = require('./webpack.base.config');
+const developmentConfig = require('./webpack.development.config');
+const productionConfig = require('./webpack.prod.config');
 
 module.exports = ({
   basePath,

--- a/development/webpack/webpack.web.config.js
+++ b/development/webpack/webpack.web.config.js
@@ -1,15 +1,17 @@
 const path = require('path');
-const { merge } = require('webpack-merge');
-const DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack-plugin');
 
+const DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack-plugin');
+const { merge } = require('webpack-merge');
 const { SubresourceIntegrityPlugin } = require('webpack-subresource-integrity');
 const { InjectManifest } = require('workbox-webpack-plugin');
-const baseConfig = require('./webpack.base.config');
+
+const babelTools = require('../babelTools');
+
+const { ENABLE_ANALYZER, NODE_ENV } = require('./constant');
 const analyzerConfig = require('./webpack.analyzer.config');
+const baseConfig = require('./webpack.base.config');
 const developmentConfig = require('./webpack.development.config');
 const productionConfig = require('./webpack.prod.config');
-const babelTools = require('../babelTools');
-const { ENABLE_ANALYZER, NODE_ENV } = require('./constant');
 
 const webConfig = {
   plugins: [new DuplicatePackageCheckerPlugin()],

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 // https://jestjs.io/docs/configuration
-const { defaults } = require('jest-config');
 const util = require('node:util');
+
+const { defaults } = require('jest-config');
 const exec = util.promisify(require('node:child_process').exec);
 
 module.exports = async () => {

--- a/packages/components/src/primitives/GradientMask/index.tsx
+++ b/packages/components/src/primitives/GradientMask/index.tsx
@@ -1,5 +1,5 @@
-import { useTheme } from '@onekeyhq/components/src/shared/tamagui';
 import { Stack } from '@onekeyhq/components/src/primitives/Stack';
+import { useTheme } from '@onekeyhq/components/src/shared/tamagui';
 
 import { LinearGradient } from '../../content/LinearGradient';
 

--- a/packages/components/src/primitives/Icon/script.js
+++ b/packages/components/src/primitives/Icon/script.js
@@ -1,7 +1,8 @@
 const fs = require('fs');
 const path = require('path');
-const prettier = require('prettier');
+
 const lodash = require('lodash');
+const prettier = require('prettier');
 
 const base = path.resolve(__dirname, './react');
 const dirs = fs.readdirSync(base);

--- a/packages/kit-bg/src/apis/RemoteApiProxyBase.ts
+++ b/packages/kit-bg/src/apis/RemoteApiProxyBase.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable @typescript-eslint/no-unsafe-return,  @typescript-eslint/no-unsafe-member-access */
 
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import platformEnvLite from '@onekeyhq/shared/src/platformEnvLite';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
@@ -19,7 +20,9 @@ export function buildCallRemoteApiMethod<T extends IJsonRpcRequest>(
     // @ts-ignore
     const module = message?.module as any;
     if (!module) {
-      throw new Error('callRemoteApiMethod ERROR: module is required');
+      throw new OneKeyLocalError(
+        'callRemoteApiMethod ERROR: module is required',
+      );
     }
     const moduleInstance: any = await moduleGetter(module);
     if (moduleInstance && moduleInstance[method]) {
@@ -38,23 +41,25 @@ export function buildCallRemoteApiMethod<T extends IJsonRpcRequest>(
     if (remoteApiType === 'webEmbedApi') {
       errorMessage += ' please run "yarn app:web-embed:build" again';
       if (!platformEnvLite.isWebEmbed) {
-        throw new Error('webEmbedApi is only available in webEmbed');
+        throw new OneKeyLocalError('webEmbedApi is only available in webEmbed');
       }
     }
 
     if (remoteApiType === 'offscreenApi') {
       if (!platformEnvLite.isExtensionOffscreen) {
-        throw new Error('offscreenApi is only available in offscreen');
+        throw new OneKeyLocalError(
+          'offscreenApi is only available in offscreen',
+        );
       }
     }
 
     if (remoteApiType === 'desktopApi') {
       if (!platformEnvLite.isDesktop) {
-        throw new Error('desktopApi is only available in desktop');
+        throw new OneKeyLocalError('desktopApi is only available in desktop');
       }
     }
 
-    throw new Error(errorMessage);
+    throw new OneKeyLocalError(errorMessage);
   };
 }
 
@@ -104,7 +109,9 @@ abstract class RemoteApiProxyBase {
   ): any {
     const nameStr = name as string;
     if (this._moduleCreatedNames[nameStr]) {
-      throw new Error(`_createProxyService name duplicated. name=${nameStr}`);
+      throw new OneKeyLocalError(
+        `_createProxyService name duplicated. name=${nameStr}`,
+      );
     }
     this._moduleCreatedNames[nameStr] = true;
     const proxy: any = new Proxy(

--- a/packages/kit-bg/src/desktopApis/instance/desktopApiProxy.ts
+++ b/packages/kit-bg/src/desktopApis/instance/desktopApiProxy.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-restricted-syntax */
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import platformEnvLite from '@onekeyhq/shared/src/platformEnvLite';
 
 import { RemoteApiProxyBase } from '../../apis/RemoteApiProxyBase';
@@ -31,7 +32,9 @@ export class DesktopApiProxy extends RemoteApiProxyBase implements IDesktopApi {
 
   override checkEnvAvailable(): void {
     if (!platformEnvLite.isDesktop) {
-      throw new Error('DesktopApiProxy should only be used in Desktop env.');
+      throw new OneKeyLocalError(
+        'DesktopApiProxy should only be used in Desktop env.',
+      );
     }
   }
 

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -159,9 +159,9 @@ import {
 import { hardwareForceTransportAtom } from '../../states/jotai/atoms/desktopBluetooth';
 import { vaultFactory } from '../../vaults/factory';
 import { getVaultSettings } from '../../vaults/settings';
-import keylessCloudSyncUtils from '../ServicePrimeCloudSync/keylessCloudSyncUtils';
-import keylessSyncCredentialStorage from '../ServiceKeylessWallet/utils/keylessSyncCredentialStorage';
 import ServiceBase from '../ServiceBase';
+import keylessSyncCredentialStorage from '../ServiceKeylessWallet/utils/keylessSyncCredentialStorage';
+import keylessCloudSyncUtils from '../ServicePrimeCloudSync/keylessCloudSyncUtils';
 
 import type { ISimpleDBAppStatus } from '../../dbs/simple/entity/SimpleDbEntityAppStatus';
 import type {

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -74,8 +74,8 @@ import {
   primePersistAtom,
 } from '../../states/jotai/atoms';
 import { devSettingsPersistAtom } from '../../states/jotai/atoms/devSettings';
-import keylessCloudSyncUtils from '../ServicePrimeCloudSync/keylessCloudSyncUtils';
 import ServiceBase from '../ServiceBase';
+import keylessCloudSyncUtils from '../ServicePrimeCloudSync/keylessCloudSyncUtils';
 
 import keylessAuthPackCache from './utils/keylessAuthPackCache';
 import keylessDeviceKeyStorage from './utils/keylessDeviceKeyStorage';

--- a/packages/kit-bg/src/services/ServiceNotification/socketio-server/socketio-server.js
+++ b/packages/kit-bg/src/services/ServiceNotification/socketio-server/socketio-server.js
@@ -1,5 +1,6 @@
-const { Server } = require('socket.io');
 const http = require('http');
+
+const { Server } = require('socket.io');
 
 // 创建 HTTP 服务器
 const server = http.createServer();

--- a/packages/kit-bg/src/services/ServicePrimeCloudSync/keylessCloudSyncUtils.ts
+++ b/packages/kit-bg/src/services/ServicePrimeCloudSync/keylessCloudSyncUtils.ts
@@ -20,6 +20,7 @@ import {
   KEYLESS_SYNC_ENCRYPTION_SALT,
   KEYLESS_SYNC_SIGNING_SALT,
 } from '@onekeyhq/shared/src/consts/keylessCloudSyncConsts';
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 import stringUtils from '@onekeyhq/shared/src/utils/stringUtils';
 import type {
@@ -173,7 +174,7 @@ function generateNonce(): string {
   if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
     crypto.getRandomValues(randomBytes);
   } else {
-    throw new Error('Secure random number generator not available');
+    throw new OneKeyLocalError('Secure random number generator not available');
   }
   return bufferUtils.bytesToHex(randomBytes);
 }

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -16,7 +16,7 @@ import {
 } from '@onekeyhq/shared/src/background/backgroundDecorators';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { PERPS_NETWORK_ID } from '@onekeyhq/shared/src/consts/perp';
-import { OneKeyError } from '@onekeyhq/shared/src/errors';
+import { OneKeyError, OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -366,7 +366,7 @@ export default class ServiceSwap extends ServiceBase {
       return data?.data ?? [];
     } catch (e) {
       if (axios.isCancel(e)) {
-        throw new Error('swap fetch token cancel', {
+        throw new OneKeyLocalError('swap fetch token cancel', {
           cause: ESwapFetchCancelCause.SWAP_TOKENS_CANCEL,
         });
       } else {
@@ -653,8 +653,7 @@ export default class ServiceSwap extends ServiceBase {
       }
     } catch (e) {
       if (axios.isCancel(e)) {
-        // eslint-disable-next-line no-restricted-syntax
-        throw new Error('swap fetch quote cancel', {
+        throw new OneKeyLocalError('swap fetch quote cancel', {
           cause: ESwapFetchCancelCause.SWAP_QUOTE_CANCEL,
         });
       }
@@ -1081,10 +1080,12 @@ export default class ServiceSwap extends ServiceBase {
       return data?.data;
     } catch (e) {
       if (axios.isCancel(e)) {
-        // eslint-disable-next-line no-restricted-syntax
-        throw new Error('swap check token approve allowance cancel', {
-          cause: ESwapFetchCancelCause.SWAP_APPROVE_ALLOWANCE_CANCEL,
-        });
+        throw new OneKeyLocalError(
+          'swap check token approve allowance cancel',
+          {
+            cause: ESwapFetchCancelCause.SWAP_APPROVE_ALLOWANCE_CANCEL,
+          },
+        );
       }
       throw e;
     }
@@ -2387,8 +2388,7 @@ export default class ServiceSwap extends ServiceBase {
       }
     } catch (e) {
       if (axios.isCancel(e)) {
-        // eslint-disable-next-line no-restricted-syntax
-        throw new Error('swap speed fetch quote cancel', {
+        throw new OneKeyLocalError('swap speed fetch quote cancel', {
           cause: ESwapFetchCancelCause.SWAP_SPEED_QUOTE_CANCEL,
         });
       }

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -16,7 +16,7 @@ import {
 } from '@onekeyhq/shared/src/background/backgroundDecorators';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { PERPS_NETWORK_ID } from '@onekeyhq/shared/src/consts/perp';
-import { OneKeyError, OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import { OneKeyError } from '@onekeyhq/shared/src/errors';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -366,7 +366,8 @@ export default class ServiceSwap extends ServiceBase {
       return data?.data ?? [];
     } catch (e) {
       if (axios.isCancel(e)) {
-        throw new OneKeyLocalError('swap fetch token cancel', {
+        // oxlint-disable-next-line onekey/no-raw-error -- needs standard Error cause semantics
+        throw new Error('swap fetch token cancel', {
           cause: ESwapFetchCancelCause.SWAP_TOKENS_CANCEL,
         });
       } else {
@@ -653,7 +654,8 @@ export default class ServiceSwap extends ServiceBase {
       }
     } catch (e) {
       if (axios.isCancel(e)) {
-        throw new OneKeyLocalError('swap fetch quote cancel', {
+        // oxlint-disable-next-line onekey/no-raw-error -- needs standard Error cause semantics
+        throw new Error('swap fetch quote cancel', {
           cause: ESwapFetchCancelCause.SWAP_QUOTE_CANCEL,
         });
       }
@@ -1080,12 +1082,10 @@ export default class ServiceSwap extends ServiceBase {
       return data?.data;
     } catch (e) {
       if (axios.isCancel(e)) {
-        throw new OneKeyLocalError(
-          'swap check token approve allowance cancel',
-          {
-            cause: ESwapFetchCancelCause.SWAP_APPROVE_ALLOWANCE_CANCEL,
-          },
-        );
+        // oxlint-disable-next-line onekey/no-raw-error -- needs standard Error cause semantics
+        throw new Error('swap check token approve allowance cancel', {
+          cause: ESwapFetchCancelCause.SWAP_APPROVE_ALLOWANCE_CANCEL,
+        });
       }
       throw e;
     }
@@ -2388,7 +2388,8 @@ export default class ServiceSwap extends ServiceBase {
       }
     } catch (e) {
       if (axios.isCancel(e)) {
-        throw new OneKeyLocalError('swap speed fetch quote cancel', {
+        // oxlint-disable-next-line onekey/no-raw-error -- needs standard Error cause semantics
+        throw new Error('swap speed fetch quote cancel', {
           cause: ESwapFetchCancelCause.SWAP_SPEED_QUOTE_CANCEL,
         });
       }

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -366,7 +366,7 @@ export default class ServiceSwap extends ServiceBase {
       return data?.data ?? [];
     } catch (e) {
       if (axios.isCancel(e)) {
-        // oxlint-disable-next-line onekey/no-raw-error -- needs standard Error cause semantics
+        // eslint-disable-next-line no-restricted-syntax, onekey/no-raw-error -- needs standard Error cause semantics
         throw new Error('swap fetch token cancel', {
           cause: ESwapFetchCancelCause.SWAP_TOKENS_CANCEL,
         });
@@ -654,7 +654,7 @@ export default class ServiceSwap extends ServiceBase {
       }
     } catch (e) {
       if (axios.isCancel(e)) {
-        // oxlint-disable-next-line onekey/no-raw-error -- needs standard Error cause semantics
+        // eslint-disable-next-line no-restricted-syntax, onekey/no-raw-error -- needs standard Error cause semantics
         throw new Error('swap fetch quote cancel', {
           cause: ESwapFetchCancelCause.SWAP_QUOTE_CANCEL,
         });
@@ -1082,7 +1082,7 @@ export default class ServiceSwap extends ServiceBase {
       return data?.data;
     } catch (e) {
       if (axios.isCancel(e)) {
-        // oxlint-disable-next-line onekey/no-raw-error -- needs standard Error cause semantics
+        // eslint-disable-next-line no-restricted-syntax, onekey/no-raw-error -- needs standard Error cause semantics
         throw new Error('swap check token approve allowance cancel', {
           cause: ESwapFetchCancelCause.SWAP_APPROVE_ALLOWANCE_CANCEL,
         });
@@ -2388,7 +2388,7 @@ export default class ServiceSwap extends ServiceBase {
       }
     } catch (e) {
       if (axios.isCancel(e)) {
-        // oxlint-disable-next-line onekey/no-raw-error -- needs standard Error cause semantics
+        // eslint-disable-next-line no-restricted-syntax, onekey/no-raw-error -- needs standard Error cause semantics
         throw new Error('swap speed fetch quote cancel', {
           cause: ESwapFetchCancelCause.SWAP_SPEED_QUOTE_CANCEL,
         });

--- a/packages/kit-bg/src/vaults/impls/algo/Vault.ts
+++ b/packages/kit-bg/src/vaults/impls/algo/Vault.ts
@@ -1,6 +1,7 @@
 import BigNumber from 'bignumber.js';
 import { isArray, isEmpty, isNil } from 'lodash';
 
+import { NETWORK_REQUEST_ERROR_CODE } from '@onekeyhq/core/src/chains/algo/constants';
 import type {
   IEncodedTxAlgo,
   IEncodedTxGroupAlgo,
@@ -79,7 +80,6 @@ import type {
 } from '../../types';
 /* eslint-disable import/order */
 import type { FailedAttemptError } from 'p-retry';
-import { NETWORK_REQUEST_ERROR_CODE } from '@onekeyhq/core/src/chains/algo/constants';
 /* eslint-enable import/order */
 
 export default class Vault extends VaultBase {

--- a/packages/kit-bg/src/vaults/impls/xrp/Vault.ts
+++ b/packages/kit-bg/src/vaults/impls/xrp/Vault.ts
@@ -371,8 +371,7 @@ export default class Vault extends VaultBase {
         throw new OneKeyLocalError(accountInfo.error);
       }
       if (accountInfo.result?.error || accountInfo.result?.error_message) {
-        // eslint-disable-next-line no-restricted-syntax
-        throw new Error(
+        throw new OneKeyLocalError(
           accountInfo.result.error_message || accountInfo.result.error,
         );
       }

--- a/packages/kit/src/components/ListItem/index.tsx
+++ b/packages/kit/src/components/ListItem/index.tsx
@@ -8,7 +8,6 @@ import type {
 import { isValidElement, useCallback, useState } from 'react';
 
 import { Pressable } from 'react-native';
-import type { StyleProp, ViewStyle } from 'react-native';
 
 import {
   Divider,
@@ -43,6 +42,7 @@ import { useStatefulAction } from '../../hooks/useStatefulAction';
 import { AccountAvatar } from '../AccountAvatar';
 
 import type { IAccountAvatarProps } from '../AccountAvatar';
+import type { StyleProp, ViewStyle } from 'react-native';
 
 interface IListItemAvatarCornerIconProps extends IIconProps {
   containerProps?: IStackProps;

--- a/packages/kit/src/components/WalletConnect/WalletConnectModal.native.tsx
+++ b/packages/kit/src/components/WalletConnect/WalletConnectModal.native.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable import/order */
+/* eslint-disable import/order, import-js/order */
 import '@walletconnect/react-native-compat'; // polyfill for react-native
 
 import {
@@ -9,11 +9,9 @@ import {
   useRef,
   useState,
 } from 'react';
-
 import type { ErrorInfo, ReactNode } from 'react';
 
 import { ConstantsUtil } from '@reown/appkit-common-react-native';
-
 import {
   AppKit as AppKitModalNative,
   createAppKit,
@@ -26,6 +24,7 @@ import {
   StorageUtil,
 } from '@reown/appkit-scaffold-utils-react-native';
 
+import type { IOneKeyError } from '@onekeyhq/shared/src/errors/types/errorTypes';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -37,14 +36,14 @@ import {
   WALLET_CONNECT_CLIENT_META,
   WALLET_CONNECT_V2_PROJECT_ID,
 } from '@onekeyhq/shared/src/walletConnect/constant';
-
-import type { IOneKeyError } from '@onekeyhq/shared/src/errors/types/errorTypes';
 import type { IWalletConnectSession } from '@onekeyhq/shared/src/walletConnect/types';
-import type { IWalletConnectModalShared } from './types';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { ConstantsUtil as ConstantsUtilCore } from '@reown/appkit/core';
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { StorageUtil as StorageUtilCore } from '@reown/appkit-core-react-native';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { ConstantsUtil as ConstantsUtilCore } from '@reown/appkit/core';
+
+import type { IWalletConnectModalShared } from './types';
 
 /*
 WalletConnect SDK Deeplink Auto-Handling Mechanism:

--- a/packages/kit/src/routes/config/getStateFromPath.ext.ts
+++ b/packages/kit/src/routes/config/getStateFromPath.ext.ts
@@ -21,20 +21,22 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable prefer-const */
 /* eslint-disable no-cond-assign */
-import type {
-  InitialState,
-  NavigationState,
-  ParamListBase,
-  PartialState,
-} from '@react-navigation/routers';
+import {  arrayStartsWith, findFocusedRoute, getPatternParts, isArrayEqual, validatePathConfig } from '@react-navigation/core';
 import escape from 'escape-string-regexp';
 import * as queryString from 'query-string';
 
 
 // ---CHANGED Begin----: import from core instead of relative path
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+
 import type { PathConfig, PathConfigMap, PatternPart } from '@react-navigation/core';
-import {  arrayStartsWith, findFocusedRoute, getPatternParts, isArrayEqual, validatePathConfig } from '@react-navigation/core';
+import type {
+  InitialState,
+  NavigationState,
+  ParamListBase,
+  PartialState,
+} from '@react-navigation/routers';
+
 // ---CHANGED end----
 
 type Options<ParamList extends {}> = {

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/BulkSendAddressesInput.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/BulkSendAddressesInput.tsx
@@ -12,6 +12,7 @@ import { useAppRoute } from '@onekeyhq/kit/src/hooks/useAppRoute';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import { EmptyNoWalletView } from '@onekeyhq/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/EmptyView';
+import type { IAccountDeriveTypes } from '@onekeyhq/kit-bg/src/vaults/types';
 import {
   POLLING_DEBOUNCE_INTERVAL,
   POLLING_INTERVAL_FOR_TOKEN,
@@ -28,7 +29,6 @@ import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import bulkSendUtils from '@onekeyhq/shared/src/utils/bulkSendUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
-import type { IAccountDeriveTypes } from '@onekeyhq/kit-bg/src/vaults/types';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import { EBulkSendMode } from '@onekeyhq/shared/types/bulkSend';
 import type { IToken, ITokenFiat } from '@onekeyhq/shared/types/token';

--- a/packages/kit/src/views/Home/components/NotBakcedUp/ReferralCodeBlock.tsx
+++ b/packages/kit/src/views/Home/components/NotBakcedUp/ReferralCodeBlock.tsx
@@ -11,7 +11,6 @@ import {
 import { isNil } from 'lodash';
 // eslint-disable-next-line import/order
 import { useIntl } from 'react-intl';
-
 import {
   scrollTo,
   useAnimatedReaction,

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
@@ -27,13 +27,13 @@ import { MarketFilterBarSmall } from '../components/MarketFilterBarSmall';
 import { MarketListColumnHeader } from '../components/MarketListColumnHeader';
 import { MobileMarketPerpsFlatList } from '../components/MarketPerpsList';
 import { MarketPerpsCategorySelector } from '../components/MarketPerpsList/MarketPerpsCategorySelector';
+import { useIsWatchlistTokenCacheReady } from '../components/MarketTokenList/hooks/useMarketWatchlistTokenList';
 import {
   type IWatchlistFilterType,
   MarketWatchlistCategorySelector,
 } from '../components/MarketTokenList/MarketWatchlistCategorySelector';
 import { MobileMarketTokenFlatList } from '../components/MarketTokenList/MobileMarketTokenFlatList';
 import { MobileMarketWatchlistFlatList } from '../components/MarketTokenList/MobileMarketWatchlistFlatList';
-import { useIsWatchlistTokenCacheReady } from '../components/MarketTokenList/hooks/useMarketWatchlistTokenList';
 import { useOpenMarketWatchlistEditDialog } from '../components/MarketTokenList/useOpenMarketWatchlistEditDialog';
 
 import { useMarketTabsLogic } from './hooks';

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
@@ -28,13 +28,13 @@ import { MarketFilterBarSmall } from '../components/MarketFilterBarSmall';
 import { MarketListColumnHeader } from '../components/MarketListColumnHeader';
 import { MobileMarketPerpsFlatList } from '../components/MarketPerpsList';
 import { MarketPerpsCategorySelector } from '../components/MarketPerpsList/MarketPerpsCategorySelector';
+import { useIsWatchlistTokenCacheReady } from '../components/MarketTokenList/hooks/useMarketWatchlistTokenList';
 import {
   type IWatchlistFilterType,
   MarketWatchlistCategorySelector,
 } from '../components/MarketTokenList/MarketWatchlistCategorySelector';
 import { MobileMarketTokenFlatList } from '../components/MarketTokenList/MobileMarketTokenFlatList';
 import { MobileMarketWatchlistFlatList } from '../components/MarketTokenList/MobileMarketWatchlistFlatList';
-import { useIsWatchlistTokenCacheReady } from '../components/MarketTokenList/hooks/useMarketWatchlistTokenList';
 import { useOpenMarketWatchlistEditDialog } from '../components/MarketTokenList/useOpenMarketWatchlistEditDialog';
 
 import { useMarketTabsLogic } from './hooks';

--- a/packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.web-embed.ts
+++ b/packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.web-embed.ts
@@ -1,8 +1,10 @@
+/* eslint-disable import-js/order */
 import { useCallback, useMemo } from 'react';
 
 // load stripe js before revenuecat, otherwise revenuecat will create script tag load https://js.stripe.com/v3
 // eslint-disable-next-line import/order
 import '@onekeyhq/shared/src/modules3rdParty/stripe-v3';
+
 import { LogLevel, Purchases } from '@revenuecat/purchases-js';
 import { BigNumber } from 'bignumber.js';
 import { useSearchParams } from 'react-router-dom';

--- a/packages/qr-wallet-sdk/src/chains/AirGapTronSDK.ts
+++ b/packages/qr-wallet-sdk/src/chains/AirGapTronSDK.ts
@@ -36,6 +36,7 @@ export class AirGapTronSDK implements IAirGapSDK {
     raw: string;
   } {
     if (ur.type !== EURType.TronSignature) {
+      // oxlint-disable-next-line onekey/no-raw-error -- standalone SDK package without @onekeyhq/shared dependency
       throw new Error('type not match');
     }
     const sig = TronSignature.fromCBOR(ur.cbor);

--- a/packages/qr-wallet-sdk/src/chains/AirGapTronSDK.ts
+++ b/packages/qr-wallet-sdk/src/chains/AirGapTronSDK.ts
@@ -36,7 +36,7 @@ export class AirGapTronSDK implements IAirGapSDK {
     raw: string;
   } {
     if (ur.type !== EURType.TronSignature) {
-      // oxlint-disable-next-line onekey/no-raw-error -- standalone SDK package without @onekeyhq/shared dependency
+      // eslint-disable-next-line no-restricted-syntax, onekey/no-raw-error -- standalone SDK package without @onekeyhq/shared dependency
       throw new Error('type not match');
     }
     const sig = TronSignature.fromCBOR(ur.cbor);

--- a/packages/shared/src/appCrypto/cryptoSubtlePolyfill.js
+++ b/packages/shared/src/appCrypto/cryptoSubtlePolyfill.js
@@ -87,6 +87,7 @@ if (platformEnv.isNative) {
             hashHex = await rnAes.sha1(hexData);
             break;
           default:
+            // oxlint-disable-next-line onekey/no-raw-error -- polyfill runs before OneKeyLocalError is available
             throw new Error(
               `crypto.subtle.digest: Unsupported algorithm "${algorithm}"`,
             );

--- a/packages/shared/src/appCrypto/cryptoSubtlePolyfill.js
+++ b/packages/shared/src/appCrypto/cryptoSubtlePolyfill.js
@@ -87,7 +87,7 @@ if (platformEnv.isNative) {
             hashHex = await rnAes.sha1(hexData);
             break;
           default:
-            // oxlint-disable-next-line onekey/no-raw-error -- polyfill runs before OneKeyLocalError is available
+            // eslint-disable-next-line no-restricted-syntax, onekey/no-raw-error -- polyfill runs before OneKeyLocalError is available
             throw new Error(
               `crypto.subtle.digest: Unsupported algorithm "${algorithm}"`,
             );

--- a/packages/shared/src/errors/utils/errorUtils.ts
+++ b/packages/shared/src/errors/utils/errorUtils.ts
@@ -195,7 +195,7 @@ function isErrorByClassName({
 
 function getCurrentCallStackV1() {
   try {
-    // eslint-disable-next-line no-restricted-syntax
+    // oxlint-disable-next-line onekey/no-raw-error -- intentional: capturing raw stack trace
     throw new Error();
   } catch (e) {
     autoPrintErrorIgnore(e);
@@ -204,6 +204,7 @@ function getCurrentCallStackV1() {
 }
 
 function getCurrentCallStack() {
+  // oxlint-disable-next-line onekey/no-raw-error -- intentional: capturing raw stack trace
   const e = new Error();
   const stack = e.stack;
   return stack;

--- a/packages/shared/src/errors/utils/errorUtils.ts
+++ b/packages/shared/src/errors/utils/errorUtils.ts
@@ -195,7 +195,7 @@ function isErrorByClassName({
 
 function getCurrentCallStackV1() {
   try {
-    // oxlint-disable-next-line onekey/no-raw-error -- intentional: capturing raw stack trace
+    // eslint-disable-next-line no-restricted-syntax, onekey/no-raw-error -- intentional: capturing raw stack trace
     throw new Error();
   } catch (e) {
     autoPrintErrorIgnore(e);
@@ -204,7 +204,7 @@ function getCurrentCallStackV1() {
 }
 
 function getCurrentCallStack() {
-  // oxlint-disable-next-line onekey/no-raw-error -- intentional: capturing raw stack trace
+  // eslint-disable-next-line no-restricted-syntax, onekey/no-raw-error -- intentional: capturing raw stack trace
   const e = new Error();
   const stack = e.stack;
   return stack;

--- a/packages/shared/src/modules3rdParty/auto-update/useJsBundle.desktop.ts
+++ b/packages/shared/src/modules3rdParty/auto-update/useJsBundle.desktop.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-restricted-syntax */
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+
 export const getJsBundlePath = () => {
-  throw new Error('getJsBundlePath is not supported on desktop');
+  throw new OneKeyLocalError('getJsBundlePath is not supported on desktop');
 };
 
 export const getJsBundlePathAsync = async () => {
@@ -8,7 +10,7 @@ export const getJsBundlePathAsync = async () => {
 };
 
 export const useJsBundle = () => {
-  throw new Error('useJsBundle is not supported on desktop');
+  throw new OneKeyLocalError('useJsBundle is not supported on desktop');
 };
 
 export const useJsBundleAsync = async () => {

--- a/packages/shared/src/modules3rdParty/cross-crypto/index.native.js
+++ b/packages/shared/src/modules3rdParty/cross-crypto/index.native.js
@@ -27,9 +27,8 @@ if (process.env.NODE_ENV !== 'production') {
   };
 }
 
-const crypto = require('react-native-crypto');
-
 const { randomBytes } = require('@noble/hashes/utils');
+const crypto = require('react-native-crypto');
 const _uuid = require('react-native-uuid');
 
 // TODO polyfill randomUUID may cause RevenueCat not ready

--- a/packages/shared/src/polyfills/index.ts
+++ b/packages/shared/src/polyfills/index.ts
@@ -1,11 +1,11 @@
-/* eslint-disable import/order */
+/* eslint-disable import/order, import-js/order */
 // import { clearIntervalAsync, setIntervalAsync } from 'set-interval-async';
 
 // walletconnect react-native-compat polyfill
 import './walletConnectCompact';
 import './polyfillsPlatform';
-
 import './reactCreateElementShim';
+
 import '../modules3rdParty/cross-crypto/verify';
 import '../request';
 

--- a/packages/shared/src/polyfills/polyfillsPlatform.ext.ts
+++ b/packages/shared/src/polyfills/polyfillsPlatform.ext.ts
@@ -1,6 +1,7 @@
-/* eslint-disable import/order */
+/* eslint-disable import/order, import-js/order */
 import 'core-js/es7/global';
 import 'globalthis';
+
 import './globalShim';
 import './setimmediateShim';
 import './extensionApiShim/extensionApiShim';

--- a/packages/shared/src/polyfills/polyfillsPlatform.js
+++ b/packages/shared/src/polyfills/polyfillsPlatform.js
@@ -149,7 +149,7 @@ try {
     shimsInjectedLog('FileReader.prototype.readAsArrayBuffer');
     FileReader.prototype.readAsArrayBuffer = function (blob) {
       if (this.readyState === this.LOADING) {
-        // oxlint-disable-next-line onekey/no-raw-error -- polyfill runs before OneKeyLocalError is available
+        // eslint-disable-next-line no-restricted-syntax, onekey/no-raw-error -- polyfill runs before OneKeyLocalError is available
         throw new Error('InvalidStateError');
       }
       this._setReadyState(this.LOADING);

--- a/packages/shared/src/polyfills/polyfillsPlatform.js
+++ b/packages/shared/src/polyfills/polyfillsPlatform.js
@@ -2,6 +2,7 @@
 /* eslint-disable unicorn/prefer-global-this */
 /* eslint-disable no-inner-declarations */
 /* eslint-disable prefer-template */
+/* eslint-disable import-js/order */
 
 /* eslint-disable global-require, no-restricted-syntax, import/no-unresolved */
 require('./setimmediateShim');
@@ -25,6 +26,8 @@ const { shim: shimArrayToSorted } = require('array.prototype.tosorted');
 shimArrayToSorted();
 
 require('react-native-url-polyfill/auto');
+const { Base64 } = require('js-base64');
+
 const platformEnv = require('@onekeyhq/shared/src/platformEnv');
 
 const shimsInjectedLog = (str) => console.log(`Shims Injected log: ${str}`);
@@ -116,7 +119,6 @@ Shims Injected:
  */
 // Shim atob and btoa
 // js-base64 lib cannot import by `require` function in React Native 0.72.
-const { Base64 } = require('js-base64');
 
 if (!global.atob) {
   shimsInjectedLog('atob');
@@ -147,6 +149,7 @@ try {
     shimsInjectedLog('FileReader.prototype.readAsArrayBuffer');
     FileReader.prototype.readAsArrayBuffer = function (blob) {
       if (this.readyState === this.LOADING) {
+        // oxlint-disable-next-line onekey/no-raw-error -- polyfill runs before OneKeyLocalError is available
         throw new Error('InvalidStateError');
       }
       this._setReadyState(this.LOADING);

--- a/packages/shared/src/polyfills/polyfillsPlatform.web.js
+++ b/packages/shared/src/polyfills/polyfillsPlatform.web.js
@@ -1,5 +1,6 @@
 // oxlint-disable unicorn/prefer-global-this
 /* eslint-disable unicorn/prefer-global-this */
+/* eslint-disable import-js/order */
 // check  polyfillsPlatform.ext.ts  or   polyfillsPlatform.native.js
 import './setimmediateShim';
 import './globalShim';


### PR DESCRIPTION
## Summary

- Add `import-js/order` rule via JS plugin bridge (`eslint-plugin-import` aliased as `import-js` to avoid conflict with built-in import plugin) — enforces import declaration ordering with the same config as existing ESLint `import/order`
- Enable `react_perf/jsx-no-new-function-as-prop` — detects inline arrow functions passed as JSX props that cause unnecessary re-renders and state loss (other `react_perf` rules disabled as too noisy for RN/tamagui)
- Create custom `eslint-plugin-onekey` JS plugin with `no-raw-error` rule — forbids `throw new Error()`, enforces `OneKeyLocalError`/`OneKeyError` instead

These rules cover the 3 categories of issues fixed in #10837, catching them at lint time instead of nightly CI.

| Rule | Violations | Covers |
|---|---|---|
| `import-js/order` | 307 | import declaration ordering |
| `react_perf/jsx-no-new-function-as-prop` | 2527 | inline function components as props |
| `onekey/no-raw-error` | 82 | `throw new Error()` usage |

## Test plan

- [x] Verified all 3 rules detect the exact issues from PR #10837
- [x] Run full `yarn oxlint` and confirm rule output
- [x] Incrementally fix existing violations
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
