### PR TITLE
fix(browser): cancel pending showTabBar timer to prevent tab bar race condition(OK-46877)

### DIFF
--- a/packages/kit/src/views/Discovery/utils/tabBarUtils.ts
+++ b/packages/kit/src/views/Discovery/utils/tabBarUtils.ts
@@ -10,8 +10,19 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 const isNative = platformEnv.isNative;
 
+let showTabBarTimer: ReturnType<typeof setTimeout> | null = null;
+
+const cancelPendingShowTabBar = () => {
+  if (showTabBarTimer) {
+    clearTimeout(showTabBarTimer);
+    showTabBarTimer = null;
+  }
+};
+
 export const showTabBar = () => {
-  setTimeout(() => {
+  cancelPendingShowTabBar();
+  showTabBarTimer = setTimeout(() => {
+    showTabBarTimer = null;
     appEventBus.emit(EAppEventBusNames.HideTabBar, false);
   }, 100);
 };
@@ -27,6 +38,9 @@ export const useNotifyTabBarDisplay = isNative
       useEffect(() => {
         if (isTablet && isLandscape) {
           return;
+        }
+        if (hideTabBar) {
+          cancelPendingShowTabBar();
         }
         appEventBus.emit(EAppEventBusNames.HideTabBar, hideTabBar);
       }, [hideTabBar, isLandscape, isTablet]);


### PR DESCRIPTION
## Summary
- Fix bottom tab bar not auto-hiding when navigating back to an already-opened Dapp after minimizing, which caused multiple tab bars to stack (OneKey tab bar + browser toolbar + Dapp's own navigation)
- Root cause: `showTabBar()` uses a 100ms delayed `setTimeout` that could fire after `useNotifyTabBarDisplay` had already emitted `HideTabBar(true)`, overriding it with `HideTabBar(false)`
- Added a cancellable timer reference to `showTabBar()` and cancel any pending timer in `useNotifyTabBarDisplay` when hiding the tab bar

## Test plan
- [ ] Open a Dapp (e.g. PancakeSwap) in the Browser tab
- [ ] Tap the minimize icon (top-left) to return to Dashboard
- [ ] Quickly tap the opened tab thumbnail to re-enter the Dapp
- [ ] Verify the bottom main tab bar auto-hides and no multi-layer tab bar stacking occurs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
