### PR TITLE
fix(iOS): prevent Fabric recycled-view frame animations during modal presentation

### DIFF
--- a/.skillshare/skills/1k-ui-recipes/SKILL.md
+++ b/.skillshare/skills/1k-ui-recipes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 1k-ui-recipes
-description: UI recipes for scroll offset (useScrollContentTabBarOffset), view transitions (startViewTransition), horizontal scroll in collapsible tab headers (CollapsibleTabContext), Android bottom tab touch interception workaround, keyboard avoidance for input fields, iOS overlay navigation freeze prevention (resetAboveMainRoute), and web keyboardDismissMode cross-tab input blur prevention.
+description: UI recipes for scroll offset (useScrollContentTabBarOffset), view transitions (startViewTransition), horizontal scroll in collapsible tab headers (CollapsibleTabContext), Android bottom tab touch interception workaround, keyboard avoidance for input fields, iOS overlay navigation freeze prevention (resetAboveMainRoute), web keyboardDismissMode cross-tab input blur prevention, and iOS modal Fabric frame animation fix (performWithoutAnimation for recycled views).
 allowed-tools: Read, Grep, Glob
 ---
 
@@ -19,6 +19,7 @@ Bite-sized solutions for common UI issues.
 | Keyboard Avoidance for Input Fields | [keyboard-avoidance.md](references/rules/keyboard-avoidance.md) | `KeyboardAwareScrollView` auto-scroll, Footer animated padding, `useKeyboardHeight` / `useKeyboardEvent` hooks |
 | iOS Overlay Navigation Freeze | [ios-overlay-navigation-freeze.md](references/rules/ios-overlay-navigation-freeze.md) | Use `resetAboveMainRoute()` instead of sequential `goBack()` to close overlays before navigating |
 | Web keyboardDismissMode Cross-Tab Blur | — | Never use `on-drag` on web; it globally blurs inputs via `TextInputState` |
+| iOS Modal Fabric Frame Animation | [ios-modal-fabric-frame-animation.md](references/rules/ios-modal-fabric-frame-animation.md) | Fabric recycled views retain stale frames; wrap `updateLayoutMetrics` in `performWithoutAnimation` during modal transition |
 
 ## Critical Rules Summary
 
@@ -176,6 +177,27 @@ On web, `react-native-web`'s `keyboardDismissMode="on-drag"` calls `dismissKeybo
 ```
 
 > **Key files**: `packages/components/src/composite/Carousel/pager.tsx`, `packages/components/src/composite/Carousel/index.tsx`
+
+### 8. iOS Modal Content Displacement During Presentation (Fabric)
+
+On iOS with Fabric (New Architecture), modal pages (pageSheet/formSheet) show content flying in from wrong positions during the slide-up animation. Root cause: Fabric recycles native views that retain stale frames; when mounted during modal transition, UIKit captures the frame correction as an implicit animation.
+
+**Fix**: Wrap Fabric's `updateLayoutMetrics` and `invalidateLayer` in `UIView.performWithoutAnimation:` during modal transitions using a global `RNSModalTransitionInProgress` flag.
+
+```objc
+// In UIView+ComponentViewProtocol.mm updateLayoutMetrics:
+extern BOOL RNSModalTransitionInProgress;
+if (RNSModalTransitionInProgress) {
+    [UIView performWithoutAnimation:^{
+        self.center = CGPoint{CGRectGetMidX(frame), CGRectGetMidY(frame)};
+        self.bounds = CGRect{CGPointZero, frame.size};
+        [self layoutIfNeeded];
+    }];
+}
+```
+
+> **Key files**: `patches/react-native-screens+4.23.0.patch`, `patches/react-native+0.81.5.patch`
+> **Reference**: [ios-modal-fabric-frame-animation.md](references/rules/ios-modal-fabric-frame-animation.md)
 
 ---
 

--- a/.skillshare/skills/1k-ui-recipes/references/rules/ios-modal-fabric-frame-animation.md
+++ b/.skillshare/skills/1k-ui-recipes/references/rules/ios-modal-fabric-frame-animation.md
@@ -1,0 +1,137 @@
+# iOS Modal Content Displacement During Presentation (Fabric)
+
+## Symptom
+
+When opening modal pages (pageSheet/formSheet) on iOS with Fabric (New Architecture), content visibly slides, scales, or "flies in" from wrong positions during the modal slide-up animation. Elements like search bars, icons, and text appear displaced or stretched for ~300ms, then snap to correct positions.
+
+Specific visual artifacts:
+- Content appears to scale up from a corner
+- Text appears stretched or at wrong font size
+- Icons fly in from unrelated positions (e.g., from where a previous icon was)
+- Background color flashes white/gray before settling to dark theme
+- Search bar wrapper animates from 20x20 to 394x48
+
+## Root Cause
+
+**Fabric view recycling + UIKit animation block capture.**
+
+1. Fabric recycles native `RCTViewComponentView` instances. A recycled view retains its **stale frame** from previous usage (e.g., a 20x20 icon view gets reused as a 394x48 search bar wrapper).
+
+2. When a modal is presented, UIKit opens an animation block for the slide-up transition.
+
+3. Fabric mounts recycled views and sets their correct frames via `updateLayoutMetrics` → `self.center` / `self.bounds`.
+
+4. These frame changes happen inside UIKit's animation block → UIKit captures them as **implicit animations**.
+
+5. The **presentation layer** animates from the stale frame to the correct frame over ~300ms (matching the modal transition duration), causing visible content displacement.
+
+### Evidence
+
+Native view dump at t+15ms after modal `viewWillAppear`:
+```
+ab-search-wrap:
+  model frame:         {4, 4, 394, 48}           ← correct (set by Fabric)
+  presentationFrame:   {349.74, 13.99, 20.28, 20.02}  ← stale (from recycled view)
+```
+
+The presentation layer then animates from `{349,14,20,20}` → `{4,4,394,48}` over 300ms.
+
+### Contributing factors
+
+- `updateBounds` height bouncing: 11 calls in 180ms (802→874→818→874→802→746) due to safeAreaInsets changes and header height calculations
+- `RCTParagraphComponentView.layoutSubviews` sets `_textView.frame = self.bounds` outside the `performWithoutAnimation` scope
+- `RCTViewComponentView.invalidateLayer` sets `layer.backgroundColor` which also gets implicitly animated
+
+## Fix
+
+**Patch `react-native-screens` and `react-native` (Fabric):**
+
+### 1. react-native-screens (`RNSScreen.mm`)
+
+Add a global flag that signals when a modal transition is in progress:
+
+```objc
+// Global flag
+BOOL RNSModalTransitionInProgress = NO;
+
+// viewWillAppear — set flag
+if (self.screenView.isPresentedAsNativeModal && animated) {
+    RNSModalTransitionInProgress = YES;
+}
+
+// viewDidAppear — clear flag
+if (self.screenView.isPresentedAsNativeModal) {
+    RNSModalTransitionInProgress = NO;
+}
+```
+
+### 2. react-native Fabric (`UIView+ComponentViewProtocol.mm`)
+
+Wrap frame changes in `performWithoutAnimation:` when the flag is active:
+
+```objc
+extern BOOL RNSModalTransitionInProgress;
+if (RNSModalTransitionInProgress) {
+    [UIView performWithoutAnimation:^{
+        self.center = CGPoint{CGRectGetMidX(frame), CGRectGetMidY(frame)};
+        self.bounds = CGRect{CGPointZero, frame.size};
+        [self layoutIfNeeded]; // Force RCTParagraphTextView frame update
+    }];
+} else {
+    self.center = CGPoint{CGRectGetMidX(frame), CGRectGetMidY(frame)};
+    self.bounds = CGRect{CGPointZero, frame.size};
+}
+```
+
+### 3. react-native Fabric (`RCTViewComponentView.mm`)
+
+Wrap `invalidateLayer` to prevent backgroundColor flash:
+
+```objc
+- (void)invalidateLayer {
+    extern BOOL RNSModalTransitionInProgress;
+    if (RNSModalTransitionInProgress) {
+        [UIView performWithoutAnimation:^{
+            [self _invalidateLayerImpl];
+        }];
+    } else {
+        [self _invalidateLayerImpl];
+    }
+}
+```
+
+## Why `performWithoutAnimation` works
+
+`UIView.performWithoutAnimation:` is Apple's API specifically designed to suppress implicit animations even inside an active animation block. The modal slide-up animation (on `UITransitionView`) is driven by `presentViewController:animated:` and is **not** affected — only the content frame corrections inside the block are made instant.
+
+## What didn't work (and why)
+
+| Approach | Why it failed |
+|---|---|
+| `CATransaction.setDisableActions:YES` | Only suppresses CALayer implicit actions, not UIView animation block captures |
+| `layer.actions = @{@"position": [NSNull null], ...}` | UIKit animation block overrides layer action delegates |
+| `layer.speed = 0` | Froze the wrong layout state, broke touch interactions and `viewDidAppear` timing |
+| Defer `updateBounds` to `viewDidAppear` | Other triggers (safeAreaInsets, header height) still caused relayout during animation |
+| Pre-set `additionalSafeAreaInsets` | Only fixes height delta, doesn't address recycled view stale frames |
+
+## Investigation methodology
+
+1. **Debug borders** (red/blue/green/yellow) on container components confirmed outer containers are always correct — only inner content is displaced
+2. **Native view hierarchy dump** (`presentationLayer.frame` vs `model frame`) at 30ms intervals confirmed the `diff=YES` on child views
+3. **`layer.speed = 0`** frozen state proved the first layout IS wrong (not just animated)
+4. **testID tracking** (`ab-root`, `ab-search-wrap`, `ab-empty`) identified specific views with stale presentation frames
+5. **setFrame hook** (swizzle `updateLayoutMetrics`) traced frame changes to Fabric's mount items
+
+## Key files
+
+- `patches/react-native-screens+4.23.0.patch` — `RNSModalTransitionInProgress` flag
+- `patches/react-native+0.81.5.patch` — `performWithoutAnimation` in `updateLayoutMetrics` and `invalidateLayer`
+- `node_modules/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm` — where Fabric sets `center`/`bounds`
+- `node_modules/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm` — where `invalidateLayer` renders backgroundColor
+- `node_modules/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm` — `_textView.frame = self.bounds` in `layoutSubviews`
+
+## Related issues
+
+- [react-native-screens #2983](https://github.com/software-mansion/react-native-screens/issues/2983) — modal animation glitches (Fabric only)
+- [react-native-screens #2802](https://github.com/software-mansion/react-native-screens/issues/2802) — updateBounds called repeatedly with bouncing values
+- [Lottie-iOS PR #932](https://github.com/airbnb/lottie-ios/pull/932) — same root cause pattern (implicit animation during layout)

--- a/packages/components/src/layouts/Page/BasicPage.native.tsx
+++ b/packages/components/src/layouts/Page/BasicPage.native.tsx
@@ -8,11 +8,9 @@ import {
   useThemeName,
 } from '@onekeyhq/components/src/shared/tamagui';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import { ERootRoutes } from '@onekeyhq/shared/src/routes';
 
 import { useIsModalPage, useIsOverlayPage } from '../../hocs';
 import { Spinner, Stack, View, YStack } from '../../primitives';
-import { rootNavigationRef } from '../Navigation';
 
 import { useIsIpadModalPage, useTabBarHeight } from './hooks';
 import {
@@ -97,31 +95,26 @@ function AbsoluteContainer({ children }: PropsWithChildren) {
   );
 }
 
-function LoadingScreen({
+// Loading screen for Android only. iOS modal pages use performWithoutAnimation
+// (patched in react-native) to prevent Fabric recycled-view frame animations,
+// so the loading overlay is no longer needed on iOS.
+function LoadingScreenAndroid({
   children,
   fullPage,
 }: PropsWithChildren<{ fullPage: boolean }>) {
   const [showLoading, changeLoadingVisibleStatus] = useState(true);
   const [showChildren, changeChildrenVisibleStatus] = useState(false);
-  const isModalPage = useIsModalPage();
-  const isiOSModalPage = platformEnv.isNativeIOS && isModalPage;
 
   useEffect(() => {
-    setTimeout(
-      () => {
-        changeChildrenVisibleStatus(true);
-        setTimeout(
-          () => {
-            requestIdleCallback(() => {
-              changeLoadingVisibleStatus(false);
-            });
-          },
-          isiOSModalPage ? 380 : 150,
-        );
-      },
-      platformEnv.isNativeAndroid ? 10 : 0,
-    );
-  }, [isiOSModalPage]);
+    setTimeout(() => {
+      changeChildrenVisibleStatus(true);
+      setTimeout(() => {
+        requestIdleCallback(() => {
+          changeLoadingVisibleStatus(false);
+        });
+      }, 150);
+    }, 10);
+  }, []);
 
   const minHeight = useMinHeight(fullPage);
   return (
@@ -138,54 +131,24 @@ function LoadingScreen({
   );
 }
 
-const AbsoluteLoadingContainer = platformEnv.isNativeIOS
-  ? ({ children }: PropsWithChildren) => {
-      const [showLoading, changeLoadingVisibleStatus] = useState(true);
-      const [showChildren, changeChildrenVisibleStatus] = useState(false);
-      const isModalPage = useIsModalPage();
-      const shouldShowLoading = useMemo(() => {
-        if (!isModalPage) {
-          return false;
-        }
-        const rootState = rootNavigationRef.current?.getRootState();
-        const modalRoute = rootState?.routes[rootState.index];
-        if (modalRoute?.name !== ERootRoutes.Modal) {
-          return false;
-        }
+function LoadingScreen({
+  children,
+  fullPage,
+}: PropsWithChildren<{ fullPage: boolean }>) {
+  // iOS: skip loading overlay — performWithoutAnimation fix handles animation artifacts
+  if (platformEnv.isNativeIOS) {
+    return <>{children}</>;
+  }
 
-        // The first modal page pushed hasn't generated its own navigation state yet,
-        // so we show blank loading for a smoother transition animation.
-        if (!modalRoute.state) {
-          return true;
-        }
-        // Pages within the modal's stack (index > 0) don't need blank loading,
-        // only the first modal page (index === 0) requires it.
-        if (modalRoute.state?.index === 0) {
-          return false;
-        }
-        return false;
-      }, [isModalPage]);
-      useEffect(() => {
-        setTimeout(() => {
-          changeChildrenVisibleStatus(true);
-          setTimeout(() => {
-            requestIdleCallback(() => {
-              changeLoadingVisibleStatus(false);
-            });
-          }, 380);
-        }, 1);
-      }, [isModalPage]);
+  return (
+    <LoadingScreenAndroid fullPage={fullPage}>{children}</LoadingScreenAndroid>
+  );
+}
 
-      return shouldShowLoading ? (
-        <>
-          {showChildren ? children : null}
-          {showLoading ? <AbsoluteContainer /> : null}
-        </>
-      ) : (
-        children
-      );
-    }
-  : ({ children }: PropsWithChildren) => children;
+// iOS: no longer needs loading container — performWithoutAnimation fix
+// prevents Fabric recycled-view frame animations during modal transitions.
+// Android: was already a passthrough.
+const AbsoluteLoadingContainer = ({ children }: PropsWithChildren) => children;
 
 export function BasicPage({
   children,

--- a/patches/react-native+0.81.5.patch
+++ b/patches/react-native+0.81.5.patch
@@ -1,7 +1,3 @@
-diff --git a/node_modules/react-native/.DS_Store b/node_modules/react-native/.DS_Store
-new file mode 100644
-index 0000000..100a183
-Binary files /dev/null and b/node_modules/react-native/.DS_Store differ
 diff --git a/node_modules/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js b/node_modules/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
 index 05bddcb..5211253 100644
 --- a/node_modules/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
@@ -524,6 +520,25 @@ index 9f50554..23eaaa8 100644
      }
    }
  
+diff --git a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
+index 89b666d..246c9cf 100644
+--- a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
++++ b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
+@@ -869,7 +869,13 @@ public open class ReactViewGroup public constructor(context: Context?) :
+     if (_overflow != Overflow.VISIBLE || getTag(R.id.filter) != null) {
+       clipToPaddingBox(this, canvas)
+     }
+-    super.dispatchDraw(canvas)
++    try {
++      super.dispatchDraw(canvas)
++    } catch (e: NullPointerException) {
++      // Race condition: child view removed during draw cycle by reanimated mount transaction.
++      // The view hierarchy will be re-drawn correctly on the next frame.
++      // Tracking: https://github.com/software-mansion/react-native-reanimated/issues/8422
++    }
+   }
+
+   override fun drawChild(canvas: Canvas, child: View, drawingTime: Long): Boolean {
 diff --git a/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm b/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
 index 2a67797..57f7c7a 100644
 --- a/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm

--- a/patches/react-native+0.81.5.patch
+++ b/patches/react-native+0.81.5.patch
@@ -1,3 +1,7 @@
+diff --git a/node_modules/react-native/.DS_Store b/node_modules/react-native/.DS_Store
+new file mode 100644
+index 0000000..100a183
+Binary files /dev/null and b/node_modules/react-native/.DS_Store differ
 diff --git a/node_modules/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js b/node_modules/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
 index 05bddcb..5211253 100644
 --- a/node_modules/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
@@ -465,25 +469,61 @@ index 577bebe..ad0f253 100644
  #pragma mark - RCTBackedTextInputDelegate
  
  - (BOOL)textInputShouldBeginEditing
-diff --git a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
-index 89b666d..246c9cf 100644
---- a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
-+++ b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
-@@ -869,7 +869,13 @@ public open class ReactViewGroup public constructor(context: Context?) :
-     if (_overflow != Overflow.VISIBLE || getTag(R.id.filter) != null) {
-       clipToPaddingBox(this, canvas)
+diff --git a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm b/node_modules/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+index a99f103..27865c2 100644
+--- a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
++++ b/node_modules/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+@@ -828,6 +828,19 @@ - (UIView *)currentContainerView
+ }
+ 
+ - (void)invalidateLayer
++{
++  // During modal transition, prevent backgroundColor and layer changes from being animated.
++  extern BOOL RNSModalTransitionInProgress;
++  if (RNSModalTransitionInProgress) {
++    [UIView performWithoutAnimation:^{
++      [self _invalidateLayerImpl];
++    }];
++  } else {
++    [self _invalidateLayerImpl];
++  }
++}
++
++- (void)_invalidateLayerImpl
+ {
+   CALayer *layer = self.layer;
+ 
+diff --git a/node_modules/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm b/node_modules/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
+index 9f50554..23eaaa8 100644
+--- a/node_modules/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
++++ b/node_modules/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
+@@ -103,8 +103,24 @@ - (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics
+     } else {
+       // Note: Changing `frame` when `layer.transform` is not the `identity transform` is undefined behavior.
+       // Therefore, we must use `center` and `bounds`.
+-      self.center = CGPoint{CGRectGetMidX(frame), CGRectGetMidY(frame)};
+-      self.bounds = CGRect{CGPointZero, frame.size};
++      //
++      // When a modal transition is in progress, Fabric may mount recycled views
++      // whose stale frames differ from the new layout. Without performWithoutAnimation,
++      // UIKit captures the center/bounds change as an implicit animation within the
++      // modal presentation's animation block, causing visible content displacement.
++      extern BOOL RNSModalTransitionInProgress;
++      if (RNSModalTransitionInProgress) {
++        [UIView performWithoutAnimation:^{
++          self.center = CGPoint{CGRectGetMidX(frame), CGRectGetMidY(frame)};
++          self.bounds = CGRect{CGPointZero, frame.size};
++          // Force immediate layout so that subviews (e.g. RCTParagraphTextView)
++          // also get their frames set within performWithoutAnimation scope.
++          [self layoutIfNeeded];
++        }];
++      } else {
++        self.center = CGPoint{CGRectGetMidX(frame), CGRectGetMidY(frame)};
++        self.bounds = CGRect{CGPointZero, frame.size};
++      }
      }
--    super.dispatchDraw(canvas)
-+    try {
-+      super.dispatchDraw(canvas)
-+    } catch (e: NullPointerException) {
-+      // Race condition: child view removed during draw cycle by reanimated mount transaction.
-+      // The view hierarchy will be re-drawn correctly on the next frame.
-+      // Tracking: https://github.com/software-mansion/react-native-reanimated/issues/8422
-+    }
    }
  
-   override fun drawChild(canvas: Canvas, child: View, drawingTime: Long): Boolean {
 diff --git a/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm b/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
 index 2a67797..57f7c7a 100644
 --- a/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm

--- a/patches/react-native-screens+4.23.0.patch
+++ b/patches/react-native-screens+4.23.0.patch
@@ -1,41 +1,44 @@
-diff --git a/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt b/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
-index 7055a0d..81ee02b 100644
---- a/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
-+++ b/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
-@@ -17,6 +17,7 @@ import com.facebook.react.modules.core.ReactChoreographer
- import com.facebook.react.uimanager.ThemedReactContext
- import com.facebook.react.uimanager.UIManagerHelper
- import com.swmansion.rnscreens.Screen.ActivityState
-+import android.util.Log
- import com.swmansion.rnscreens.events.ScreenDismissedEvent
- import com.swmansion.rnscreens.gamma.common.FragmentProviding
+diff --git a/node_modules/react-native-screens/ios/RNSScreen.mm b/node_modules/react-native-screens/ios/RNSScreen.mm
+index 1c44762..11a2e04 100644
+--- a/node_modules/react-native-screens/ios/RNSScreen.mm
++++ b/node_modules/react-native-screens/ios/RNSScreen.mm
+@@ -49,6 +49,12 @@
+ constexpr NSInteger SHEET_FIT_TO_CONTENTS = -1;
+ constexpr NSInteger SHEET_LARGEST_UNDIMMED_DETENT_NONE = -1;
  
-@@ -291,7 +292,24 @@ open class ScreenContainer(
-         }
- 
-         if (hasFragments) {
--            transaction.commitNowAllowingStateLoss()
-+            // Guard against "FragmentManager is already executing transactions" crash.
-+            // This race condition occurs when onDetachedFromWindow triggers removeMyFragments
-+            // while performUpdates -> onUpdate is already committing a transaction on the same
-+            // FragmentManager within the same UI frame (e.g. during rapid navigation).
-+            // On catch, we defer the removal to the next frame where the FragmentManager
-+            // will no longer be in a transaction.
-+            // See: https://github.com/software-mansion/react-native-screens/issues/2318
-+            // See: https://github.com/software-mansion/react-native-screens/issues/1506
-+            try {
-+                transaction.commitNowAllowingStateLoss()
-+            } catch (e: IllegalStateException) {
-+                Log.w("ScreenContainer", "FragmentManager already executing transactions, deferring fragment removal", e)
-+                post {
-+                    if (!fragmentManager.isDestroyed) {
-+                        removeMyFragments(fragmentManager)
-+                    }
-+                }
-+            }
-         }
-     }
- 
++// Global flag set during modal presentation transitions. Consumed by
++// UIView+ComponentViewProtocol (React Native Fabric) to wrap frame
++// changes in performWithoutAnimation, preventing UIKit from capturing
++// recycled-view frame corrections as implicit animations.
++BOOL RNSModalTransitionInProgress = NO;
++
+ struct ContentWrapperBox {
+   __weak RNSScreenContentWrapper *contentWrapper{nil};
+   float contentHeightErrata{0.f};
+@@ -1643,6 +1649,11 @@ - (instancetype)initWithView:(UIView *)view
+ - (void)viewWillAppear:(BOOL)animated
+ {
+   [super viewWillAppear:animated];
++
++  if (self.screenView.isPresentedAsNativeModal && animated) {
++    RNSModalTransitionInProgress = YES;
++  }
++
+   if (!_isSwiping) {
+     [self.screenView notifyWillAppear];
+     if (self.transitionCoordinator.isInteractive) {
+@@ -1711,6 +1722,11 @@ - (void)viewDidAppear:(BOOL)animated
+     [RNSScreenView.viewInteractionManagerInstance enableInteractionsForLastSubtree];
+   }
+   [super viewDidAppear:animated];
++
++  if (self.screenView.isPresentedAsNativeModal) {
++    RNSModalTransitionInProgress = NO;
++  }
++
+   if (!_isSwiping || _shouldNotify) {
+     // we are going forward or dismissing without swipe
+     // or successfully swiped back
 diff --git a/node_modules/react-native-screens/ios/RNSScreenStack.mm b/node_modules/react-native-screens/ios/RNSScreenStack.mm
 index e37e40a..1e95f36 100644
 --- a/node_modules/react-native-screens/ios/RNSScreenStack.mm

--- a/patches/react-native-screens+4.23.0.patch
+++ b/patches/react-native-screens+4.23.0.patch
@@ -65,7 +65,19 @@ index 1c44762..11a2e04 100644
    if (!_isSwiping) {
      [self.screenView notifyWillAppear];
      if (self.transitionCoordinator.isInteractive) {
-@@ -1711,6 +1722,11 @@ - (void)viewDidAppear:(BOOL)animated
+@@ -1681,6 +1692,11 @@ - (void)viewWillAppear:(BOOL)animated
+ - (void)viewWillDisappear:(BOOL)animated
+ {
+   [super viewWillDisappear:animated];
++
++  if (self.screenView.isPresentedAsNativeModal) {
++    RNSModalTransitionInProgress = NO;
++  }
++
+   // self.navigationController might be null when we are dismissing a modal
+   if (!self.transitionCoordinator.isInteractive && self.navigationController != nil) {
+     // user might have long pressed ios 14 back button item,
+@@ -1711,6 +1727,11 @@ - (void)viewDidAppear:(BOOL)animated
      [RNSScreenView.viewInteractionManagerInstance enableInteractionsForLastSubtree];
    }
    [super viewDidAppear:animated];

--- a/patches/react-native-screens+4.23.0.patch
+++ b/patches/react-native-screens+4.23.0.patch
@@ -1,3 +1,41 @@
+diff --git a/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt b/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+index 7055a0d..81ee02b 100644
+--- a/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
++++ b/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt
+@@ -17,6 +17,7 @@ import com.facebook.react.modules.core.ReactChoreographer
+ import com.facebook.react.uimanager.ThemedReactContext
+ import com.facebook.react.uimanager.UIManagerHelper
+ import com.swmansion.rnscreens.Screen.ActivityState
++import android.util.Log
+ import com.swmansion.rnscreens.events.ScreenDismissedEvent
+ import com.swmansion.rnscreens.gamma.common.FragmentProviding
+
+@@ -291,7 +292,24 @@ open class ScreenContainer(
+         }
+
+         if (hasFragments) {
+-            transaction.commitNowAllowingStateLoss()
++            // Guard against "FragmentManager is already executing transactions" crash.
++            // This race condition occurs when onDetachedFromWindow triggers removeMyFragments
++            // while performUpdates -> onUpdate is already committing a transaction on the same
++            // FragmentManager within the same UI frame (e.g. during rapid navigation).
++            // On catch, we defer the removal to the next frame where the FragmentManager
++            // will no longer be in a transaction.
++            // See: https://github.com/software-mansion/react-native-screens/issues/2318
++            // See: https://github.com/software-mansion/react-native-screens/issues/1506
++            try {
++                transaction.commitNowAllowingStateLoss()
++            } catch (e: IllegalStateException) {
++                Log.w("ScreenContainer", "FragmentManager already executing transactions, deferring fragment removal", e)
++                post {
++                    if (!fragmentManager.isDestroyed) {
++                        removeMyFragments(fragmentManager)
++                    }
++                }
++            }
+         }
+     }
+
 diff --git a/node_modules/react-native-screens/ios/RNSScreen.mm b/node_modules/react-native-screens/ios/RNSScreen.mm
 index 1c44762..11a2e04 100644
 --- a/node_modules/react-native-screens/ios/RNSScreen.mm

--- a/patches/react-native-screens+4.23.0.patch
+++ b/patches/react-native-screens+4.23.0.patch
@@ -53,30 +53,24 @@ index 1c44762..11a2e04 100644
  struct ContentWrapperBox {
    __weak RNSScreenContentWrapper *contentWrapper{nil};
    float contentHeightErrata{0.f};
-@@ -1643,6 +1649,11 @@ - (instancetype)initWithView:(UIView *)view
+@@ -1643,6 +1649,16 @@ - (instancetype)initWithView:(UIView *)view
  - (void)viewWillAppear:(BOOL)animated
  {
    [super viewWillAppear:animated];
 +
 +  if (self.screenView.isPresentedAsNativeModal && animated) {
 +    RNSModalTransitionInProgress = YES;
++    // Clear the flag when the transition finishes — whether it completed
++    // normally or was cancelled/interrupted. This avoids the stacking issue
++    // where another modal's viewWillDisappear could prematurely clear it.
++    [self.transitionCoordinator animateAlongsideTransition:nil completion:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
++      RNSModalTransitionInProgress = NO;
++    }];
 +  }
 +
    if (!_isSwiping) {
      [self.screenView notifyWillAppear];
      if (self.transitionCoordinator.isInteractive) {
-@@ -1681,6 +1692,11 @@ - (void)viewWillAppear:(BOOL)animated
- - (void)viewWillDisappear:(BOOL)animated
- {
-   [super viewWillDisappear:animated];
-+
-+  if (self.screenView.isPresentedAsNativeModal) {
-+    RNSModalTransitionInProgress = NO;
-+  }
-+
-   // self.navigationController might be null when we are dismissing a modal
-   if (!self.transitionCoordinator.isInteractive && self.navigationController != nil) {
-     // user might have long pressed ios 14 back button item,
 @@ -1711,6 +1727,11 @@ - (void)viewDidAppear:(BOOL)animated
      [RNSScreenView.viewInteractionManagerInstance enableInteractionsForLastSubtree];
    }

--- a/patches/react-native-screens+4.23.0.patch
+++ b/patches/react-native-screens+4.23.0.patch
@@ -9,10 +9,10 @@ index 7055a0d..81ee02b 100644
 +import android.util.Log
  import com.swmansion.rnscreens.events.ScreenDismissedEvent
  import com.swmansion.rnscreens.gamma.common.FragmentProviding
-
+ 
 @@ -291,7 +292,24 @@ open class ScreenContainer(
          }
-
+ 
          if (hasFragments) {
 -            transaction.commitNowAllowingStateLoss()
 +            // Guard against "FragmentManager is already executing transactions" crash.
@@ -35,9 +35,9 @@ index 7055a0d..81ee02b 100644
 +            }
          }
      }
-
+ 
 diff --git a/node_modules/react-native-screens/ios/RNSScreen.mm b/node_modules/react-native-screens/ios/RNSScreen.mm
-index 1c44762..11a2e04 100644
+index 1c44762..582527c 100644
 --- a/node_modules/react-native-screens/ios/RNSScreen.mm
 +++ b/node_modules/react-native-screens/ios/RNSScreen.mm
 @@ -49,6 +49,12 @@

--- a/patches/react-native-screens+4.23.0.patch
+++ b/patches/react-native-screens+4.23.0.patch
@@ -53,7 +53,7 @@ index 1c44762..11a2e04 100644
  struct ContentWrapperBox {
    __weak RNSScreenContentWrapper *contentWrapper{nil};
    float contentHeightErrata{0.f};
-@@ -1643,6 +1649,16 @@ - (instancetype)initWithView:(UIView *)view
+@@ -1643,6 +1649,17 @@ - (instancetype)initWithView:(UIView *)view
  - (void)viewWillAppear:(BOOL)animated
  {
    [super viewWillAppear:animated];
@@ -71,7 +71,7 @@ index 1c44762..11a2e04 100644
    if (!_isSwiping) {
      [self.screenView notifyWillAppear];
      if (self.transitionCoordinator.isInteractive) {
-@@ -1711,6 +1727,11 @@ - (void)viewDidAppear:(BOOL)animated
+@@ -1711,6 +1728,11 @@ - (void)viewDidAppear:(BOOL)animated
      [RNSScreenView.viewInteractionManagerInstance enableInteractionsForLastSubtree];
    }
    [super viewDidAppear:animated];


### PR DESCRIPTION
## Summary
Fix iOS modal pages showing layout distortion during presentation animation on Fabric (New Architecture). Content no longer visibly slides/scales from wrong positions during modal slide-up.

## Problem Flow (Before Fix)

```
┌─────────────────────────────────────────────────────────────────┐
│                    Modal Presentation Timeline                   │
├──────────┬──────────────────────────────────────────────────────┤
│          │                                                      │
│  t=0ms   │  presentViewController:animated:YES                  │
│          │  ┌──────────────────────────────────┐                │
│          │  │ UIKit opens animation block       │                │
│          │  │ (duration ~350ms)                 │                │
│          │  └──────────┬───────────────────────┘                │
│          │             │                                        │
│  t+15ms  │  Fabric mounts recycled views into modal             │
│          │  ┌──────────────────────────────────────────┐        │
│          │  │ RCTViewComponentView (recycled)           │        │
│          │  │                                          │        │
│          │  │  stale frame: {349, 14, 20, 20}          │        │
│          │  │  (was a 20×20 icon in previous screen)   │        │
│          │  │                                          │        │
│          │  │  Fabric calls:                           │        │
│          │  │    self.center = new_center  ──┐         │        │
│          │  │    self.bounds = new_bounds  ──┤         │        │
│          │  │                               │         │        │
│          │  │  correct frame: {4, 4, 394, 48}         │        │
│          │  └──────────────────────────────────────────┘        │
│          │                               │                      │
│          │             ┌─────────────────┘                      │
│          │             ▼                                        │
│          │  ┌──────────────────────────────────────────┐        │
│          │  │ ⚠️  UIKit captures frame change as        │        │
│          │  │    IMPLICIT ANIMATION inside the          │        │
│          │  │    modal's animation block!               │        │
│          │  │                                          │        │
│          │  │  presentationLayer animates:              │        │
│          │  │  {349,14,20,20} ───────▶ {4,4,394,48}   │        │
│          │  │  over 350ms                              │        │
│          │  └──────────────────────────────────────────┘        │
│          │                                                      │
│  t+30ms  │  User sees: search bar flying from top-right ❌      │
│  t+60ms  │  User sees: content scaling up from corner   ❌      │
│  t+150ms │  User sees: text stretched, icons displaced  ❌      │
│  t+300ms │  User sees: elements still settling          ❌      │
│  t+350ms │  Animation ends, layout correct              ✅      │
│          │                                                      │
└──────────┴──────────────────────────────────────────────────────┘
```

## Fix Flow (After Fix)

```
┌─────────────────────────────────────────────────────────────────┐
│                    Modal Presentation Timeline                   │
├──────────┬──────────────────────────────────────────────────────┤
│          │                                                      │
│  t=0ms   │  presentViewController:animated:YES                  │
│          │  ┌──────────────────────────────────┐                │
│          │  │ UIKit opens animation block       │                │
│          │  │ (duration ~350ms)                 │                │
│          │  └──────────┬───────────────────────┘                │
│          │             │                                        │
│          │  viewWillAppear:                                     │
│          │  ┌──────────────────────────────────┐                │
│          │  │ RNSModalTransitionInProgress = YES│  ← flag set   │
│          │  └──────────────────────────────────┘                │
│          │                                                      │
│  t+15ms  │  Fabric mounts recycled views into modal             │
│          │  ┌──────────────────────────────────────────┐        │
│          │  │ RCTViewComponentView (recycled)           │        │
│          │  │                                          │        │
│          │  │  stale frame: {349, 14, 20, 20}          │        │
│          │  │                                          │        │
│          │  │  updateLayoutMetrics detects flag:        │        │
│          │  │  ┌────────────────────────────────┐      │        │
│          │  │  │ [UIView performWithoutAnimation:│      │        │
│          │  │  │   self.center = new_center      │      │        │
│          │  │  │   self.bounds = new_bounds      │      │        │
│          │  │  │   [self layoutIfNeeded]         │      │        │
│          │  │  │ ]                               │      │        │
│          │  │  └────────────────────────────────┘      │        │
│          │  │                                          │        │
│          │  │  ✅ Frame set INSTANTLY to {4,4,394,48}  │        │
│          │  │  ✅ No implicit animation created        │        │
│          │  │  ✅ presentationLayer == modelLayer       │        │
│          │  └──────────────────────────────────────────┘        │
│          │                                                      │
│  t+30ms  │  User sees: content at correct position     ✅      │
│  t+150ms │  User sees: modal sliding up smoothly       ✅      │
│  t+350ms │  Modal fully visible                        ✅      │
│          │                                                      │
│          │  viewDidAppear:                                      │
│          │  ┌──────────────────────────────────┐                │
│          │  │ RNSModalTransitionInProgress = NO │  ← flag clear │
│          │  └──────────────────────────────────┘                │
│          │                                                      │
└──────────┴──────────────────────────────────────────────────────┘
```

## Architecture

```
┌─────────────────────────────────────────────────────────┐
│                   react-native-screens                   │
│                                                         │
│  RNSScreen.mm                                           │
│  ┌───────────────────────────────────────────────┐      │
│  │ BOOL RNSModalTransitionInProgress = NO;       │      │
│  │                                               │      │
│  │ viewWillAppear: → set YES                     │      │
│  │ viewDidAppear:  → set NO                      │      │
│  └───────────────────┬───────────────────────────┘      │
│                      │ extern                           │
└──────────────────────┼──────────────────────────────────┘
                       │
┌──────────────────────┼──────────────────────────────────┐
│                      ▼         react-native (Fabric)     │
│                                                         │
│  UIView+ComponentViewProtocol.mm                        │
│  ┌───────────────────────────────────────────────┐      │
│  │ updateLayoutMetrics:                          │      │
│  │   if (RNSModalTransitionInProgress) {         │      │
│  │     [UIView performWithoutAnimation:^{        │      │
│  │       self.center = ...;                      │      │
│  │       self.bounds = ...;                      │      │
│  │       [self layoutIfNeeded]; // text views    │      │
│  │     }];                                       │      │
│  │   }                                           │      │
│  └───────────────────────────────────────────────┘      │
│                                                         │
│  RCTViewComponentView.mm                                │
│  ┌───────────────────────────────────────────────┐      │
│  │ invalidateLayer:                              │      │
│  │   if (RNSModalTransitionInProgress) {         │      │
│  │     [UIView performWithoutAnimation:^{        │      │
│  │       [self _invalidateLayerImpl]; // bgColor │      │
│  │     }];                                       │      │
│  │   }                                           │      │
│  └───────────────────────────────────────────────┘      │
│                                                         │
└─────────────────────────────────────────────────────────┘
```

## Changes

### Native patches
- **`patches/react-native-screens+4.23.0.patch`** — `RNSModalTransitionInProgress` flag in `viewWillAppear`/`viewDidAppear`
- **`patches/react-native+0.81.5.patch`** — `performWithoutAnimation` in `updateLayoutMetrics` and `invalidateLayer`

### JS changes
- **`BasicPage.native.tsx`** — Remove iOS modal loading overlay (no longer needed with native fix, removes ~60 lines of complex loading state)

## What didn't work (investigated)

| Approach | Why it failed |
|---|---|
| `CATransaction.setDisableActions` | Only suppresses CALayer implicit actions, not UIView animation block captures |
| `layer.actions = @{NSNull}` | UIKit animation block overrides layer action delegates |
| `layer.speed = 0` | Froze wrong layout state, broke touch/gesture interactions |
| Defer `updateBounds` to `viewDidAppear` | Other triggers (safeAreaInsets, header) still caused relayout |

## Test plan
- [ ] Open any modal page (Address Book, Settings sub-pages) on iOS
- [ ] Verify content appears at correct positions from first frame (no sliding/scaling)
- [ ] Verify modal slide-up animation still plays smoothly
- [ ] Verify modal dismiss (swipe down) works correctly
- [ ] Verify non-modal navigation (push/pop) is unaffected
- [ ] Test on iPad (pageSheet presentation)
- [ ] Verify Android is unaffected (changes are iOS-only)