### PR TITLE
fix: preserve dApp tab state when switching desktop browser tab(OK-52009)

### DIFF
--- a/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
@@ -41,6 +41,8 @@ import type { GestureResponderEvent, LayoutChangeEvent } from 'react-native';
 // Estimated height per tab item (icon ~40px + gap + label ~16-30px + padding 12px)
 const ESTIMATED_TAB_ITEM_HEIGHT = 70;
 
+let lastBrowserRoute: string = ETabRoutes.Discovery;
+
 function DesktopWinSidebarTop() {
   return (
     <XStack h={52} ai="center" jc="center" px="$4" className="app-region-drag">
@@ -470,6 +472,15 @@ export function DesktopLeftSideBar({
   // Current focused route for browser submenu
   const focusedRouteName = state.routes[state.index]?.name;
 
+  // Track last active browser route (Discovery or MultiTabBrowser)
+  useEffect(() => {
+    if (focusedRouteName === ETabRoutes.Discovery) {
+      lastBrowserRoute = ETabRoutes.Discovery;
+    } else if (extraConfig?.name && focusedRouteName === extraConfig.name) {
+      lastBrowserRoute = extraConfig.name;
+    }
+  }, [focusedRouteName, extraConfig?.name]);
+
   const [maxVisibleCount, setMaxVisibleCount] = useState(0);
   const handleTabsContainerLayout = useCallback((event: LayoutChangeEvent) => {
     const height = event.nativeEvent.layout.height;
@@ -588,7 +599,20 @@ export function DesktopLeftSideBar({
                   <TabItemView
                     key={route.key}
                     route={route}
-                    onPress={() => handleTabPress(route, isActive)}
+                    onPress={() => {
+                      // When clicking the Discovery sidebar icon, restore the last
+                      // active browser route (Discovery or MultiTabBrowser) so that
+                      // switching to another tab and back preserves the dApp page.
+                      if (
+                        route.name === ETabRoutes.Discovery &&
+                        !isActive &&
+                        lastBrowserRoute !== ETabRoutes.Discovery
+                      ) {
+                        switchTab(lastBrowserRoute as ETabRoutes);
+                      } else {
+                        handleTabPress(route, isActive);
+                      }
+                    }}
                     isActive={isActive}
                     options={descriptors[route.key].options}
                   />

--- a/packages/kit/src/views/Discovery/pages/DesktopCustomTabBar/index.tsx
+++ b/packages/kit/src/views/Discovery/pages/DesktopCustomTabBar/index.tsx
@@ -47,6 +47,10 @@ import { withBrowserProvider } from '../Browser/WithBrowserProvider';
 
 const TIMESTAMP_DIFF_MULTIPLIER = 2;
 
+// Persist the last active tab ID across component mount/unmount cycles
+// so that returning to MultiTabBrowser restores the previously viewed dApp.
+let savedActiveTabId = '';
+
 function DesktopCustomTabBar({ isExpanded }: { isExpanded?: boolean }) {
   const intl = useIntl();
   const isCollapsed = !(isExpanded ?? false);
@@ -133,9 +137,22 @@ function DesktopCustomTabBar({ isExpanded }: { isExpanded?: boolean }) {
   const [isDiscoveryFocused, setIsDiscoveryFocused] = useState(false);
   useListenTabFocusState(ETabRoutes.Discovery, setIsDiscoveryFocused);
 
+  // Use a ref so the useListenTabFocusState callback (captured on mount)
+  // always reads the current activeTabId value.
+  const activeTabIdRef = useRef(activeTabId);
+  activeTabIdRef.current = activeTabId;
+
   useListenTabFocusState(ETabRoutes.MultiTabBrowser, (isFocus: boolean) => {
     if (!isFocus) {
+      // Save active tab before clearing so it can be restored when returning
+      if (activeTabIdRef.current) {
+        savedActiveTabId = activeTabIdRef.current;
+      }
       setCurrentWebTab('');
+    } else if (savedActiveTabId) {
+      // Restore the previously active tab when MultiTabBrowser regains focus
+      setCurrentWebTab(savedActiveTabId);
+      savedActiveTabId = '';
     }
   });
 
@@ -154,6 +171,8 @@ function DesktopCustomTabBar({ isExpanded }: { isExpanded?: boolean }) {
 
   const onTabPress = useCallback(
     (id: string) => {
+      // Clear saved tab so the restore callback won't overwrite this explicit selection
+      savedActiveTabId = '';
       navigation.switchTab(ETabRoutes.MultiTabBrowser);
       setCurrentWebTab(id);
     },
@@ -165,6 +184,7 @@ function DesktopCustomTabBar({ isExpanded }: { isExpanded?: boolean }) {
       switch (eventName) {
         case EShortcutEvents.ReOpenLastClosedTab:
           if (reOpenLastClosedTab()) {
+            savedActiveTabId = '';
             navigation.switchTab(ETabRoutes.MultiTabBrowser);
           }
           break;
@@ -286,6 +306,7 @@ function DesktopCustomTabBar({ isExpanded }: { isExpanded?: boolean }) {
           onPress={(e) => {
             e.stopPropagation();
             if (platformEnv.isDesktop) {
+              savedActiveTabId = '';
               addBrowserHomeTab();
               navigation.switchTab(ETabRoutes.MultiTabBrowser);
             } else {


### PR DESCRIPTION
## Summary
- When switching from a dApp page to another top-level tab (Home, Swap, etc.) and back, the browser now correctly returns to the previously viewed dApp instead of resetting to the Discovery dashboard.
- Tracks the last active browser route (Discovery vs MultiTabBrowser) in the sidebar, so clicking the Browser icon navigates back to the correct route.
- Saves and restores the active browser tab ID across MultiTabBrowser focus/unfocus cycles, while ensuring explicit tab clicks are not overridden by the restore logic.

## Test plan
- [ ] Open a dApp in the desktop browser, switch to Home tab, click Browser icon → should return to the dApp page
- [ ] From browser homepage, switch to Home tab, click Browser icon → should return to browser homepage
- [ ] While on browser homepage, click a specific dApp tab in the sidebar → should navigate directly to that tab
- [ ] Create a new tab, reopen closed tab → should work as before without interference
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10850" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
