### PR TITLE
fix: RecentHistory card not showing pending transactions (OK-52117)

### DIFF
--- a/packages/kit-bg/src/services/ServiceHistory.ts
+++ b/packages/kit-bg/src/services/ServiceHistory.ts
@@ -535,13 +535,13 @@ class ServiceHistory extends ServiceBase {
     ]);
 
     const localHistoryConfirmedTxs =
-      await this.getAccountLocalHistoryPendingTxs({
+      await this.getAccountLocalHistoryConfirmedTxs({
         networkId,
         accountAddress,
         xpub,
       });
     const localHistoryPendingTxs =
-      await this.getAccountLocalHistoryConfirmedTxs({
+      await this.getAccountLocalHistoryPendingTxs({
         networkId,
         accountAddress,
         xpub,

--- a/packages/kit-bg/src/services/ServiceHistory.ts
+++ b/packages/kit-bg/src/services/ServiceHistory.ts
@@ -540,12 +540,11 @@ class ServiceHistory extends ServiceBase {
         accountAddress,
         xpub,
       });
-    const localHistoryPendingTxs =
-      await this.getAccountLocalHistoryPendingTxs({
-        networkId,
-        accountAddress,
-        xpub,
-      });
+    const localHistoryPendingTxs = await this.getAccountLocalHistoryPendingTxs({
+      networkId,
+      accountAddress,
+      xpub,
+    });
 
     const result = unionBy(
       [...localHistoryPendingTxs, ...localHistoryConfirmedTxs],


### PR DESCRIPTION
## Summary

- Fix swapped method calls in `ServiceHistory.getAccountsLocalHistoryTxs` (single-network path, line 537-548)
- `getAccountLocalHistoryPendingTxs` and `getAccountLocalHistoryConfirmedTxs` were called with reversed variable assignments, causing confirmed txs to appear before pending txs in the result array
- Combined with `updateHistoryData` limit=5 truncation logic in RecentHistory card, pending transactions were never displayed on initial load

## Impact
- Single-network mode: RecentHistory card initial load now correctly shows pending transactions
- Account/network switching: pending transactions persist correctly after re-initialization
- All Networks mode: not affected (method calls were already correct)
- History Tab: not affected (no limit truncation)

## Root Cause
Bug introduced in commit 335f38e00d (feat: home assets cache OK-32199 #5861), never correct since.

## Test Plan
- [ ] Send a transaction on a single network, verify pending tx appears in RecentHistory card immediately
- [ ] Switch accounts/networks, verify pending tx still displays correctly after switching back
- [ ] Verify All Networks mode history remains unaffected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
