### PR TITLE
fix(iOS): set modal root contentStyle backgroundColor to match theme

### DIFF
--- a/packages/components/src/layouts/Navigation/GlobalScreenOptions.native.ts
+++ b/packages/components/src/layouts/Navigation/GlobalScreenOptions.native.ts
@@ -120,7 +120,9 @@ export function makeModalScreenOptions(info: {
   };
 }
 
-export function makeRootModalStackOptions(): IStackNavigationOptions {
+export function makeRootModalStackOptions(params?: {
+  bgColor?: string;
+}): IStackNavigationOptions {
   const options: IStackNavigationOptions = {
     headerShown: false,
   };
@@ -129,6 +131,12 @@ export function makeRootModalStackOptions(): IStackNavigationOptions {
     // animation gets a little stuck
     options.animation = 'none';
   }
+
+  if (params?.bgColor) {
+    // @ts-expect-error
+    options.contentStyle = { backgroundColor: params.bgColor };
+  }
+
   return options;
 }
 

--- a/packages/components/src/layouts/Navigation/GlobalScreenOptions.native.ts
+++ b/packages/components/src/layouts/Navigation/GlobalScreenOptions.native.ts
@@ -133,7 +133,6 @@ export function makeRootModalStackOptions(params?: {
   }
 
   if (params?.bgColor) {
-    // @ts-expect-error
     options.contentStyle = { backgroundColor: params.bgColor };
   }
 

--- a/packages/components/src/layouts/Navigation/GlobalScreenOptions.ts
+++ b/packages/components/src/layouts/Navigation/GlobalScreenOptions.ts
@@ -154,7 +154,9 @@ export function makeOnboardingScreenOptions(info: {
   };
 }
 
-export function makeRootModalStackOptions(): StackNavigationOptions {
+export function makeRootModalStackOptions(_params?: {
+  bgColor?: string;
+}): StackNavigationOptions {
   return {
     detachPreviousScreen: false,
     headerShown: false,

--- a/packages/components/src/layouts/Navigation/Navigator/RootModalNavigator.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/RootModalNavigator.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { ThemeProvider } from '@react-navigation/native';
 
+import { useTheme } from '../../../hooks';
 import { makeRootModalStackOptions } from '../GlobalScreenOptions';
 import { createStackNavigator } from '../StackNavigator';
 
@@ -30,7 +31,13 @@ export function RootModalNavigator<RouteName extends string>({
   config,
   pageType,
 }: IModalNavigatorProps<RouteName> & { pageType?: EPageType }) {
-  const screenOptions = useMemo(() => makeRootModalStackOptions(), []);
+  const theme = useTheme();
+  const bgColor = theme.bgApp.val;
+
+  const screenOptions = useMemo(
+    () => makeRootModalStackOptions({ bgColor }),
+    [bgColor],
+  );
 
   const modalComponents = useMemo(
     () =>


### PR DESCRIPTION
## Summary
- Pass `bgApp` color to `makeRootModalStackOptions` so the root modal screen gets a themed `contentStyle.backgroundColor`
- Prevents the default white background flash during iOS modal presentation transitions
- Web/desktop signature updated for type compatibility (unused param)

## Test plan
- [ ] Open any modal on iOS (e.g. Settings → 网络), verify no white background flash during transition
- [ ] Verify Android modal transitions still work correctly
- [ ] Verify web modal overlays still have transparent background
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
