### PR TITLE
fix(ci): desktop build improvements and preload crash fix

### DIFF
--- a/.github/workflows/release-desktop-all.yml
+++ b/.github/workflows/release-desktop-all.yml
@@ -211,14 +211,6 @@ jobs:
           path: |
             ./apps/desktop/build-electron/*-universal.dmg
 
-      - name: Upload all Mac ZIPs
-        if: steps.phase1_dmg.outcome == 'success'
-        uses: actions/upload-artifact@v4
-        with:
-          name: onekey-desktop-mac-zips-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
-          path: |
-            ./apps/desktop/build-electron/*.zip
-
       - name: Upload x64 Mac DMG
         if: steps.phase1_dmg.outcome == 'success'
         uses: actions/upload-artifact@v4
@@ -234,6 +226,14 @@ jobs:
           name: onekey-desktop-mac-arm64-dmg-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
           path: |
             ./apps/desktop/build-electron/*-arm64.dmg
+
+      - name: Upload all Mac ZIPs
+        if: steps.phase1_dmg.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: onekey-desktop-mac-zips-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
+          path: |
+            ./apps/desktop/build-electron/*.zip
 
       - name: 'Notify to Slack - Mac DMG'
         if: always() && github.event_name == 'workflow_run' && steps.phase1_dmg.outcome == 'success'

--- a/.github/workflows/release-desktop-all.yml
+++ b/.github/workflows/release-desktop-all.yml
@@ -404,6 +404,12 @@ jobs:
           $artifacts_url = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
           "ARTIFACTS_URL=$artifacts_url" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
+      - name: Exclude workspace from Windows Defender
+        shell: pwsh
+        run: |
+          Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+          Add-MpPreference -ExclusionPath "${{ runner.temp }}"
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
@@ -473,6 +479,16 @@ jobs:
           name: onekey-desktop-win-arm64-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
           path: |
             ./apps/desktop/build-electron/*-arm64.exe
+
+      - name: Upload universal Windows exe
+        if: steps.phase1_nsis.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: onekey-desktop-win-universal-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
+          path: |
+            ./apps/desktop/build-electron/*.exe
+            !./apps/desktop/build-electron/*-x64.exe
+            !./apps/desktop/build-electron/*-arm64.exe
 
       - name: Upload Windows autoupdate metadata
         if: steps.phase1_nsis.outcome == 'success'

--- a/.github/workflows/release-desktop-all.yml
+++ b/.github/workflows/release-desktop-all.yml
@@ -211,6 +211,14 @@ jobs:
           path: |
             ./apps/desktop/build-electron/*-universal.dmg
 
+      - name: Upload all Mac ZIPs
+        if: steps.phase1_dmg.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: onekey-desktop-mac-zips-${{ env.BUILD_APP_VERSION }}-${{ env.BUILD_NUMBER }}-${{ env.BUILD_BUNDLE_VERSION }}-${{ github.sha }}
+          path: |
+            ./apps/desktop/build-electron/*.zip
+
       - name: Upload x64 Mac DMG
         if: steps.phase1_dmg.outcome == 'success'
         uses: actions/upload-artifact@v4

--- a/apps/desktop/app/libs/react-native-mock.ts
+++ b/apps/desktop/app/libs/react-native-mock.ts
@@ -1,4 +1,8 @@
-import isDev from 'electron-is-dev';
+// Avoid `electron-is-dev` here — it accesses `electron.app` which is
+// undefined in the preload/renderer process and would crash at load time.
+// esbuild already defines process.env.NODE_ENV at build time, so this is
+// equivalent and works in both main and preload contexts.
+const isDev = process.env.NODE_ENV !== 'production';
 
 export const Platform = {};
 

--- a/apps/desktop/electron-builder.config.js
+++ b/apps/desktop/electron-builder.config.js
@@ -93,6 +93,6 @@ module.exports = {
     'artifactName': 'OneKey-Wallet-${version}-linux-${arch}.${ext}',
     'executableName': 'onekey-wallet',
     'category': 'Utility',
-    'target': [{ target: 'AppImage', arch: ['x64', 'arm64'] }],
+    'target': ['AppImage'],
   },
 };

--- a/apps/desktop/scripts/afterPack.js
+++ b/apps/desktop/scripts/afterPack.js
@@ -97,8 +97,7 @@ exports.default = async function fileOperation(context) {
         } catch {
           return;
         }
-        const pkgRelative = path.relative(unpackedDir, fullPath);
-        console.log(`[prebuilds] Scanning: ${pkgRelative}`);
+        console.log(`[prebuilds] Scanning: ${fullPath}`);
         for (const prebuild of prebuildEntries) {
           if (prebuild.isDirectory()) {
             processPrebuildEntry(fullPath, prebuild.name);


### PR DESCRIPTION
## Summary
- Add Windows Defender exclusion for workspace and runner temp directories to speed up CI builds
- Add universal Windows exe upload step in release-desktop-all workflow
- Remove hardcoded arch from Linux AppImage target so CLI flags take effect
- Fix preload crash: replace `electron-is-dev` with `process.env.NODE_ENV` check in `react-native-mock.ts` — `electron.app` is undefined in preload/renderer process
- Add upload step for all Mac ZIP artifacts (x64, arm64, universal), placed after arm64 DMG upload
- Log full absolute path in afterPack prebuilds scanning for easier debugging

## Test plan
- [ ] Verify desktop app starts without preload crash on all architectures (x64, arm64, universal)
- [ ] Verify Mac ZIPs artifact contains all 3 zip files
- [ ] Verify Windows universal exe is uploaded
- [ ] Verify Linux AppImage respects CLI arch flags
- [ ] Verify Windows CI build completes faster with Defender exclusion