### PR TITLE
fix: improve market banner detail table layout and stock subtitle display(OK-52012)

### DIFF
--- a/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
+++ b/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
@@ -230,7 +230,7 @@ function MarketBannerDetailContent({ title }: { title: string }) {
             <Stack
               flex={1}
               className="normal-scrollbar"
-              style={{ overflowX: 'auto' }}
+              style={{ overflowX: 'auto', overflowY: 'hidden' }}
             >
               <Stack flex={1} minWidth={900}>
                 <MarketTokenListBase

--- a/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
+++ b/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
@@ -227,15 +227,23 @@ function MarketBannerDetailContent({ title }: { title: string }) {
           {isPerps ? (
             <PerpsTokenListSection tokenListId={tokenListId} />
           ) : (
-            <MarketTokenListBase
-              result={listResult}
-              onItemPress={handleItemPress}
-              hideTokenAge
-              clientSort
-              watchlistFrom={EWatchlistFrom.BannerList}
-              copyFrom={ECopyFrom.BannerList}
-              showEndReachedIndicator
-            />
+            <Stack
+              flex={1}
+              className="normal-scrollbar"
+              style={{ overflowX: 'auto' }}
+            >
+              <Stack flex={1} minWidth={900}>
+                <MarketTokenListBase
+                  result={listResult}
+                  onItemPress={handleItemPress}
+                  hideTokenAge
+                  clientSort
+                  watchlistFrom={EWatchlistFrom.BannerList}
+                  copyFrom={ECopyFrom.BannerList}
+                  showEndReachedIndicator
+                />
+              </Stack>
+            </Stack>
           )}
         </Stack>
       </Page.Body>

--- a/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
+++ b/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
@@ -218,33 +218,44 @@ function MarketBannerDetailContent({ title }: { title: string }) {
     return null;
   }, [isWebDesktop, gtMd, renderHeaderTitle, renderHeaderLeft]);
 
+  const renderTokenList = useMemo(() => {
+    if (isPerps) {
+      return <PerpsTokenListSection tokenListId={tokenListId} />;
+    }
+    const tokenList = (
+      <MarketTokenListBase
+        result={listResult}
+        onItemPress={handleItemPress}
+        hideTokenAge
+        clientSort
+        watchlistFrom={EWatchlistFrom.BannerList}
+        copyFrom={ECopyFrom.BannerList}
+        showEndReachedIndicator
+      />
+    );
+    if (platformEnv.isNative) {
+      return tokenList;
+    }
+    return (
+      <Stack
+        flex={1}
+        className="normal-scrollbar"
+        style={{ overflowX: 'auto', overflowY: 'hidden' }}
+      >
+        <Stack flex={1} minWidth={900}>
+          {tokenList}
+        </Stack>
+      </Stack>
+    );
+  }, [isPerps, tokenListId, listResult, handleItemPress]);
+
   return (
     <Page>
       {renderPageHeader}
       <Page.Body>
         <Stack flex={1} pt={gtMd ? 0 : top} px={gtMd ? '$4' : 0} gap="$4">
           {renderTitleSection}
-          {isPerps ? (
-            <PerpsTokenListSection tokenListId={tokenListId} />
-          ) : (
-            <Stack
-              flex={1}
-              className="normal-scrollbar"
-              style={{ overflowX: 'auto', overflowY: 'hidden' }}
-            >
-              <Stack flex={1} minWidth={900}>
-                <MarketTokenListBase
-                  result={listResult}
-                  onItemPress={handleItemPress}
-                  hideTokenAge
-                  clientSort
-                  watchlistFrom={EWatchlistFrom.BannerList}
-                  copyFrom={ECopyFrom.BannerList}
-                  showEndReachedIndicator
-                />
-              </Stack>
-            </Stack>
-          )}
+          {renderTokenList}
         </Stack>
       </Page.Body>
     </Page>

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketNormalTokenList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketNormalTokenList.tsx
@@ -45,6 +45,7 @@ function MarketNormalTokenList({
       tabIntegrated={tabIntegrated}
       tabName={tabName}
       listContainerProps={listContainerProps}
+      showStockSubtitle={false}
     />
   );
 }

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenListBase.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenListBase.tsx
@@ -114,6 +114,7 @@ type IMarketTokenListBaseProps = {
     position?: { x: number; y: number },
   ) => void;
   onScrollBegin?: () => void;
+  showStockSubtitle?: boolean;
 };
 
 function MarketTokenListBase({
@@ -136,19 +137,12 @@ function MarketTokenListBase({
   onItemLongPress,
   onItemContextMenu,
   onScrollBegin,
+  showStockSubtitle = true,
 }: IMarketTokenListBaseProps) {
   const intl = useIntl();
   const toMarketDetailPage = useToDetailPage();
   const { navigateToPerps } = usePerpsNavigation();
   const { md } = useMedia();
-
-  const marketTokenColumns = useMarketTokenColumns(
-    networkId,
-    isWatchlistMode,
-    hideTokenAge,
-    watchlistFrom,
-    copyFrom,
-  );
 
   const {
     data: rawData,
@@ -164,6 +158,21 @@ function MarketTokenListBase({
     currentSortBy,
     currentSortType,
   } = result;
+
+  const hasStock = useMemo(
+    () => rawData.some((item) => !!item.stock),
+    [rawData],
+  );
+
+  const marketTokenColumns = useMarketTokenColumns(
+    networkId,
+    isWatchlistMode,
+    hideTokenAge,
+    watchlistFrom,
+    copyFrom,
+    hasStock,
+    showStockSubtitle,
+  );
 
   // Client-side sorting: sort data locally when clientSort is enabled
   const data = useMemo(() => {

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenIdentityItem/TokenIdentityItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenIdentityItem/TokenIdentityItem.tsx
@@ -7,6 +7,7 @@ import {
   NumberSizeableText,
   SizableText,
   Stack,
+  Tooltip,
   XStack,
   useClipboard,
   useMedia,
@@ -93,6 +94,10 @@ interface ITokenIdentityItemProps {
    * Subtitle for perpetual tokens (e.g. Chinese name tag).
    */
   perpsSubtitle?: string;
+  /**
+   * Whether to show the stock subtitle. Defaults to true.
+   */
+  showStockSubtitle?: boolean;
 }
 
 const BasicTokenIdentityItem: FC<ITokenIdentityItemProps> = ({
@@ -111,6 +116,7 @@ const BasicTokenIdentityItem: FC<ITokenIdentityItemProps> = ({
   stock,
   maxLeverage,
   perpsSubtitle,
+  showStockSubtitle = true,
 }) => {
   const { gtMd } = useMedia();
   const { copyText } = useClipboard();
@@ -158,6 +164,29 @@ const BasicTokenIdentityItem: FC<ITokenIdentityItemProps> = ({
     return tokenLogoURI;
   };
 
+  const symbolText = (
+    <SizableText
+      size="$bodyLgMedium"
+      numberOfLines={1}
+      ellipsizeMode="tail"
+      maxWidth="$32"
+      flexShrink={1}
+    >
+      {symbol}
+    </SizableText>
+  );
+
+  const symbolElement =
+    !showStockSubtitle && stock?.subtitle ? (
+      <Tooltip
+        placement="top"
+        renderTrigger={symbolText}
+        renderContent={stock.subtitle}
+      />
+    ) : (
+      symbolText
+    );
+
   return (
     <XStack alignItems="center" gap="$3" userSelect="none">
       <Token
@@ -170,21 +199,13 @@ const BasicTokenIdentityItem: FC<ITokenIdentityItemProps> = ({
 
       <Stack flex={1} minWidth={0}>
         <XStack alignItems="center" gap="$1">
-          <SizableText
-            size="$bodyLgMedium"
-            numberOfLines={1}
-            ellipsizeMode="tail"
-            maxWidth="$32"
-            flexShrink={1}
-          >
-            {symbol}
-          </SizableText>
+          {symbolElement}
           {maxLeverage ? <LeverageBadge leverage={maxLeverage} /> : null}
           {gtMd ? (
             <>
               <StockSourceLogo stock={stock} />
               {communityRecognized ? <CommunityRecognizedBadge /> : null}
-              {stock?.subtitle ? (
+              {showStockSubtitle && stock?.subtitle ? (
                 <SubtitleBadge subtitle={stock.subtitle} />
               ) : null}
             </>
@@ -194,7 +215,7 @@ const BasicTokenIdentityItem: FC<ITokenIdentityItemProps> = ({
                 communityRecognized={communityRecognized}
                 stock={stock}
               />
-              {stock?.subtitle ? (
+              {showStockSubtitle && stock?.subtitle ? (
                 <SubtitleBadge subtitle={stock.subtitle} />
               ) : null}
             </>

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsDesktop.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsDesktop.tsx
@@ -84,11 +84,11 @@ export const useColumnsDesktop = (
     {
       title: intl.formatMessage({ id: ETranslations.global_name }),
       dataIndex: 'name',
-      columnWidth: isWatchlistMode
-        ? watchlistNameWidth
-        : hasStock && showStockSubtitle
-          ? 240
-          : 200,
+      columnWidth: (() => {
+        if (isWatchlistMode) return watchlistNameWidth;
+        if (hasStock && showStockSubtitle) return 240;
+        return 200;
+      })(),
       render: (_: unknown, record: IMarketToken) =>
         record.perpsCoin ? (
           <XStack

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsDesktop.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsDesktop.tsx
@@ -45,6 +45,8 @@ export const useColumnsDesktop = (
   hideTokenAge?: boolean,
   watchlistFrom?: EWatchlistFrom,
   copyFrom?: ECopyFrom,
+  hasStock?: boolean,
+  showStockSubtitle?: boolean,
 ): ITableColumn<IMarketToken>[] => {
   const { gtLg, gtXl } = useMedia();
   const intl = useIntl();
@@ -82,7 +84,11 @@ export const useColumnsDesktop = (
     {
       title: intl.formatMessage({ id: ETranslations.global_name }),
       dataIndex: 'name',
-      columnWidth: isWatchlistMode ? watchlistNameWidth : 200,
+      columnWidth: isWatchlistMode
+        ? watchlistNameWidth
+        : hasStock && showStockSubtitle
+          ? 240
+          : 200,
       render: (_: unknown, record: IMarketToken) =>
         record.perpsCoin ? (
           <XStack
@@ -131,6 +137,7 @@ export const useColumnsDesktop = (
             copyFrom={copyFrom || ECopyFrom.Homepage}
             communityRecognized={record.communityRecognized}
             stock={record.stock}
+            showStockSubtitle={showStockSubtitle}
           />
         ),
       renderSkeleton: () => (

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useMarketTokenColumns.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useMarketTokenColumns.tsx
@@ -18,6 +18,8 @@ export const useMarketTokenColumns = (
   hideTokenAge?: boolean,
   watchlistFrom?: EWatchlistFrom,
   copyFrom?: ECopyFrom,
+  hasStock?: boolean,
+  showStockSubtitle?: boolean,
 ): ITableColumn<IMarketToken>[] => {
   const desktopColumns = useColumnsDesktop(
     networkId,
@@ -25,6 +27,8 @@ export const useMarketTokenColumns = (
     hideTokenAge,
     watchlistFrom,
     copyFrom,
+    hasStock,
+    showStockSubtitle,
   );
   const mobileColumns = useColumnsMobile();
 


### PR DESCRIPTION
## Summary
- Add horizontal scroll container with `minWidth={900}` to market banner detail table for better desktop display
- Dynamically widen the name column (200→240) when stock items are present and subtitle is shown
- Hide stock subtitle in spot token list by default, show it via Tooltip on hover instead

## Intent & Context
The market banner detail page (e.g., US stocks list) had table layout issues on desktop — columns were too compressed. Additionally, stock subtitle badges were taking up space in the spot token list where they weren't needed, but should remain visible in banner detail and watchlist views.

## Design Decisions
- **Horizontal scroll + minWidth**: Wrapped table in a scroll container rather than modifying `MarketTokenListBase` globally, keeping the change scoped to banner detail only.
- **Dynamic column width**: Name column auto-widens only when both `hasStock` and `showStockSubtitle` are true, avoiding unnecessary width in non-stock lists.
- **Tooltip fallback**: When stock subtitle is hidden, the symbol text shows the subtitle via Tooltip on hover, preserving information accessibility without consuming layout space.
- **Default behavior**: `showStockSubtitle` defaults to `true` — only the spot token list explicitly opts out with `false`.

## Changes Detail
- **MarketBannerDetail.tsx**: Wrapped table in horizontal scroll container with `minWidth={900}`
- **TokenIdentityItem.tsx**: Added `showStockSubtitle` prop; when false, wraps symbol in Tooltip showing stock subtitle
- **useColumnsDesktop.tsx**: Dynamic name column width based on `hasStock && showStockSubtitle`; passes `showStockSubtitle` to `TokenIdentityItem`
- **useMarketTokenColumns.tsx**: Passes through `hasStock` and `showStockSubtitle` params
- **MarketTokenListBase.tsx**: Computes `hasStock` from data; added `showStockSubtitle` prop (default `true`)
- **MarketNormalTokenList.tsx**: Passes `showStockSubtitle={false}` to hide subtitle in spot list

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Web (mobile unaffected — uses different column hook and no hover interaction)
- **Risk Areas**: Column width change could affect table alignment in edge cases with very long stock names

## Test plan
- [ ] Open market banner detail page for a stock list (e.g., US stocks) — verify table has horizontal scroll and min width
- [ ] Verify name column is wider when stock items are present in banner detail
- [ ] Open spot token list — verify stock subtitle badges are hidden
- [ ] Hover over a stock symbol in spot list — verify Tooltip shows the subtitle
- [ ] Open watchlist with stocks — verify subtitle badges still display normally
- [ ] Resize desktop window to narrow width — verify horizontal scroll works on banner detail
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
