### PR TITLE
chore: register import-js/order ESLint stub plugin and reorganize plugin files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,10 +21,16 @@ const path = require('path');
 const originalResolve = Module._resolveFilename;
 Module._resolveFilename = function (request, ...args) {
   if (request === 'eslint-plugin-onekey') {
-    return path.resolve(__dirname, 'development/plugins/eslint-plugin-onekey.js');
+    return path.resolve(
+      __dirname,
+      'development/plugins/eslint-plugin-onekey.js',
+    );
   }
   if (request === 'eslint-plugin-import-js') {
-    return path.resolve(__dirname, 'development/plugins/eslint-plugin-import-js.js');
+    return path.resolve(
+      __dirname,
+      'development/plugins/eslint-plugin-import-js.js',
+    );
   }
   return originalResolve.call(this, request, ...args);
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,10 @@ const path = require('path');
 const originalResolve = Module._resolveFilename;
 Module._resolveFilename = function (request, ...args) {
   if (request === 'eslint-plugin-onekey') {
-    return path.resolve(__dirname, 'development/lint/eslint-plugin-onekey.js');
+    return path.resolve(__dirname, 'development/plugins/eslint-plugin-onekey.js');
+  }
+  if (request === 'eslint-plugin-import-js') {
+    return path.resolve(__dirname, 'development/plugins/eslint-plugin-import-js.js');
   }
   return originalResolve.call(this, request, ...args);
 };
@@ -290,6 +293,7 @@ module.exports = {
     'react-hooks',
     'import',
     'onekey',
+    'import-js',
   ],
   settings: {
     'import/extensions': [
@@ -328,6 +332,7 @@ module.exports = {
     worker: true,
   },
   rules: {
+    'import-js/order': 'off',
     'import-path/parent-depth': ['error', 3],
     'import-path/forbidden': [
       'error',

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -7,7 +7,7 @@
     "eslint-plugin-ban",
     "eslint-plugin-prettier",
     { "name": "import-js", "specifier": "eslint-plugin-import" },
-    "./development/lint/eslint-plugin-onekey.js"
+    "./development/plugins/eslint-plugin-onekey.js"
   ],
   "extends": [
     "eslint-config-prettier",

--- a/development/plugins/eslint-plugin-import-js.js
+++ b/development/plugins/eslint-plugin-import-js.js
@@ -1,0 +1,15 @@
+/**
+ * Stub ESLint plugin so that `import-js/order` is recognized by ESLint.
+ * The actual rule lives in oxlint (.oxlintrc.json).
+ */
+module.exports = {
+  meta: { name: 'import-js' },
+  rules: {
+    order: {
+      meta: { type: 'layout', schema: [] },
+      create() {
+        return {};
+      },
+    },
+  },
+};

--- a/development/plugins/eslint-plugin-onekey.js
+++ b/development/plugins/eslint-plugin-onekey.js
@@ -2,7 +2,7 @@
  * Custom oxlint JS plugin for OneKey-specific lint rules.
  *
  * Usage in .oxlintrc.json:
- *   "jsPlugins": ["./development/lint/eslint-plugin-onekey.js"]
+ *   "jsPlugins": ["./development/plugins/eslint-plugin-onekey.js"]
  *   "rules": { "onekey/no-raw-error": "error" }
  */
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "_font": "node ./development/lint/font.js",
     "lint:project": "yarn _tsc && yarn _lint && concurrently --kill-others-on-fail \"yarn _electron\" \"yarn _folder\" \"yarn _lang\" \"yarn _packageVersions\" \"yarn _font\"",
     "lint": "yarn lint:project",
-    "eslint": "npx eslint . --ext .ts,.tsx --fix --cache --cache-location \"$(yarn config get cacheFolder)\"/.eslintcache'",
+    "eslint": "npx eslint . --ext .ts,.tsx --fix --cache --cache-location \"$(yarn config get cacheFolder)\"/.eslintcache",
     "oxlint": "npx oxlint --tsconfig ./tsconfig.json --type-aware . --fix",
     "lint:only": "npx oxlint --tsconfig ./tsconfig.json --type-aware . --fix --deny-warnings",
     "lint:staged": "git diff --cached --name-only --diff-filter=ACMR | grep -E '\\.(ts|tsx)$' | xargs -r npx oxlint --tsconfig ./tsconfig.json --type-aware --fix --deny-warnings",


### PR DESCRIPTION
## Summary
- Fix broken `yarn eslint` command (stray single quote in package.json script)
- Register `import-js/order` as a stub ESLint plugin so `eslint-disable import-js/order` comments no longer trigger "Definition for rule not found" errors (the actual rule lives in oxlint)
- Move ESLint plugin files from `development/lint/` to `development/plugins/` for better organization

## Test plan
- [x] Run `yarn eslint` — no Yarn shell parse error
- [x] Run ESLint on files with `/* eslint-disable import-js/order */` — no "Definition for rule not found" error
- [x] Run `yarn lint:only` (oxlint) — onekey plugin path resolves correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
