### PR TITLE
fix(desktop): fix preload crash caused by electron-is-dev in renderer process

### DIFF
--- a/apps/desktop/app/libs/react-native-mock.ts
+++ b/apps/desktop/app/libs/react-native-mock.ts
@@ -1,4 +1,8 @@
-import isDev from 'electron-is-dev';
+// Avoid `electron-is-dev` here — it accesses `electron.app` which is
+// undefined in the preload/renderer process and would crash at load time.
+// esbuild already defines process.env.NODE_ENV at build time, so this is
+// equivalent and works in both main and preload contexts.
+const isDev = process.env.NODE_ENV !== 'production';
 
 export const Platform = {};
 


### PR DESCRIPTION
## Summary
- Replace `electron-is-dev` with `process.env.NODE_ENV` check in `react-native-mock.ts`
- `electron-is-dev` accesses `electron.app.isPackaged` which is undefined in the preload/renderer process, causing startup crash
- Dependency chain: `preload.ts` → `desktopApiProxy` → `shared/errors` → `locale/index.ts` → `platformEnv.ts` → `react-native` (aliased to `react-native-mock`) → `electron-is-dev`

## Test plan
- [ ] Verify desktop app starts without preload crash on all architectures (x64, arm64, universal)
- [ ] Verify `__DEV__` and `desktopApi.isDev` are correctly set in both dev and production builds
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
