### PR TITLE
fix: resolve nightly ESLint errors

### DIFF
--- a/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSync.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSync.tsx
@@ -711,26 +711,27 @@ export default function PagePrimeCloudSync() {
     void backgroundApiProxy.servicePrimeCloudSync.showAlertDialogIfLocalPasswordNotSet();
   }, []);
 
+  const renderDebugHeaderRight = useCallback(
+    () => (
+      <Button
+        variant="tertiary"
+        onPress={() => {
+          navigation.navigate(EPrimePages.PrimeCloudSyncDebug);
+        }}
+      >
+        Debug
+      </Button>
+    ),
+    [navigation],
+  );
+
   return (
     <Page scrollEnabled>
       <Page.Header
         title={intl.formatMessage({
           id: ETranslations.global_onekey_cloud,
         })}
-        headerRight={
-          platformEnv.isDev
-            ? () => (
-                <Button
-                  variant="tertiary"
-                  onPress={() => {
-                    navigation.navigate(EPrimePages.PrimeCloudSyncDebug);
-                  }}
-                >
-                  Debug
-                </Button>
-              )
-            : undefined
-        }
+        headerRight={platformEnv.isDev ? renderDebugHeaderRight : undefined}
       />
       <Page.Body>
         <AppDataSection />


### PR DESCRIPTION
## Summary
- Auto-fix ESLint failures detected by nightly CI
- Closes #10860

## Changes
- Updated `packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSync.tsx`
- Extracted `Page.Header` `headerRight` inline render function into a stable `useCallback` (`renderDebugHeaderRight`) to satisfy `react/no-unstable-nested-components`
- Kept behavior unchanged for dev-only debug navigation button

## Test plan
- [x] ESLint passes locally (`NODE_OPTIONS=--max-old-space-size=8192 npx eslint . --ext .ts,.tsx --max-warnings 0`)
- [ ] CI checks pass

🤖 Auto-generated by Scriptoria ESLint fix automation

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
