### PR TITLE
ci: enable native change check on PRs targeting release branches

### DIFF
--- a/.github/workflows/pr-native-change-check.yml
+++ b/.github/workflows/pr-native-change-check.yml
@@ -1,6 +1,9 @@
 name: Native Change Check
 
 on:
+  pull_request:
+    branches:
+      - 'release/*'
   workflow_dispatch:
     inputs:
       base_ref:


### PR DESCRIPTION
## Summary
- Add `pull_request` trigger to `pr-native-change-check.yml` for PRs targeting `release/*` branches
- The workflow will automatically detect native changes (iOS/Android/Electron/DB schema) and post a warning comment on PRs

## Test plan
- [x] Verified on PR #10864 (release/v6.1.0)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
