### PR TITLE
feat(swap): support URL query param to select swap tab on web

### DIFF
--- a/packages/kit/src/views/Swap/pages/SwapPageContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/SwapPageContainer.tsx
@@ -1,15 +1,38 @@
+import { useMemo } from 'react';
+
 import { Page } from '@onekeyhq/components';
-import { ETabRoutes } from '@onekeyhq/shared/src/routes';
+import { ETabRoutes, ETabSwapRoutes } from '@onekeyhq/shared/src/routes';
+import type { ITabSwapParamList } from '@onekeyhq/shared/src/routes';
 import { useDebugComponentRemountLog } from '@onekeyhq/shared/src/utils/debug/debugUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
+import { ESwapTabSwitchType } from '@onekeyhq/shared/types/swap/types';
 
 import { TabletHomeContainer } from '../../../components/TabletHomeContainer';
 import { TabPageHeader } from '../../../components/TabPageHeader';
+import { useAppRoute } from '../../../hooks/useAppRoute';
 
 import SwapMainLandWithPageType from './components/SwapMainLand';
 
+const TAB_PARAM_MAP: Record<string, ESwapTabSwitchType> = {
+  swap: ESwapTabSwitchType.SWAP,
+  bridge: ESwapTabSwitchType.BRIDGE,
+  crosschain: ESwapTabSwitchType.BRIDGE,
+  limit: ESwapTabSwitchType.LIMIT,
+};
+
 const SwapPageContainer = () => {
   useDebugComponentRemountLog({ name: 'SwapPageContainer' });
+
+  const route =
+    useAppRoute<ITabSwapParamList, ETabSwapRoutes.TabSwap>();
+  const tabParam = route.params?.tab;
+
+  const swapInitParams = useMemo(() => {
+    if (!tabParam) return undefined;
+    const swapTabSwitchType = TAB_PARAM_MAP[tabParam.toLowerCase()];
+    if (!swapTabSwitchType) return undefined;
+    return { swapTabSwitchType };
+  }, [tabParam]);
 
   return (
     <Page fullPage>
@@ -19,7 +42,7 @@ const SwapPageContainer = () => {
           tabRoute={ETabRoutes.Swap}
         />
         <Page.Body>
-          <SwapMainLandWithPageType />
+          <SwapMainLandWithPageType swapInitParams={swapInitParams} />
         </Page.Body>
       </TabletHomeContainer>
     </Page>

--- a/packages/shared/src/routes/tabSwap.ts
+++ b/packages/shared/src/routes/tabSwap.ts
@@ -3,5 +3,5 @@ export enum ETabSwapRoutes {
 }
 
 export type ITabSwapParamList = {
-  [ETabSwapRoutes.TabSwap]: undefined;
+  [ETabSwapRoutes.TabSwap]: { tab?: string } | undefined;
 };


### PR DESCRIPTION
## Summary
- Add `?tab=` URL query parameter support for the web swap page
- Supported values: `swap`, `bridge`, `crosschain` (alias for bridge), `limit`
- Example: `/swap?tab=limit` navigates directly to the Limit tab
- Follows the same pattern as Earn page's `?tab=` / `?mode=` URL param handling

## Test plan
- [ ] Visit `/swap` — default Swap tab (unchanged behavior)
- [ ] Visit `/swap?tab=limit` — opens Limit tab
- [ ] Visit `/swap?tab=bridge` — opens Bridge tab
- [ ] Visit `/swap?tab=crosschain` — opens Bridge tab
- [ ] Visit `/swap?tab=swap` — opens Swap tab
- [ ] Visit `/swap?tab=invalid` — falls back to default Swap tab
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10868" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
