### PR TITLE
fix(perp): portfolio PnL accuracy & UI fixes

### DIFF
--- a/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioContent.tsx
+++ b/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioContent.tsx
@@ -485,8 +485,8 @@ function PerpPortfolioContentComponent({
 
       {/* P&L + Win Rate summary */}
       <SectionBlock>
-        <XStack justifyContent="space-between" alignItems="center">
-          <YStack gap="$0.5">
+        <XStack alignItems="center">
+          <YStack flex={1} gap="$0.5">
             <SizableText size="$bodyXs" color="$textDisabled">
               {intl.formatMessage({
                 id: ETranslations.perp_portfolio_unrealized_pnl,
@@ -496,7 +496,7 @@ function PerpPortfolioContentComponent({
               {unrealizedPnl}
             </SizableText>
           </YStack>
-          <YStack gap="$0.5" alignItems="center">
+          <YStack flex={1} gap="$0.5" alignItems="center">
             <SizableText size="$bodyXs" color="$textDisabled">
               {intl.formatMessage({
                 id: ETranslations.perp_portfolio_total_pnl,
@@ -506,7 +506,7 @@ function PerpPortfolioContentComponent({
               {realizedPnl}
             </SizableText>
           </YStack>
-          <YStack gap="$0.5" alignItems="flex-end">
+          <YStack flex={1} gap="$0.5" alignItems="flex-end">
             <SizableText size="$bodyXs" color="$textDisabled">
               {intl.formatMessage({
                 id: ETranslations.perp_portfolio_open_positions,

--- a/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioContent.tsx
+++ b/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioContent.tsx
@@ -524,7 +524,64 @@ function PerpPortfolioContentComponent({
   // Win rate progress value (0-100)
   const winRateProgress = fillsStats.winRate ?? 0;
 
-  // ─── Portfolio Value (shared between mobile top + desktop stats) ────────────
+  // ─── Portfolio Value buttons (shared) ───────────────────────────────────────
+  const portfolioButtons = (
+    <XStack gap="$2">
+      <Button
+        flex={1}
+        borderRadius="$full"
+        size="medium"
+        bg="$brand8"
+        hoverStyle={{ bg: '$brand9' }}
+        pressStyle={{ bg: '$brand10' }}
+        color="$textOnColor"
+        iconColor="$iconOnColor"
+        icon="DownloadOutline"
+        onPress={() => showDepositWithdrawModal('deposit')}
+      >
+        {intl.formatMessage({
+          id: ETranslations.perp_trade_deposit,
+        })}
+      </Button>
+      <Button
+        flex={1}
+        borderRadius="$full"
+        size="medium"
+        variant="secondary"
+        icon="AlignTopOutline"
+        onPress={() => showDepositWithdrawModal('withdraw')}
+      >
+        {intl.formatMessage({
+          id: ETranslations.perp_trade_withdraw,
+        })}
+      </Button>
+    </XStack>
+  );
+
+  // ─── Portfolio Value — mobile layout ────────────────────────────────────────
+  const mobilePortfolioValueBlock = (
+    <YStack gap="$3">
+      <YStack gap="$1">
+        <SectionLabel>
+          {intl.formatMessage({ id: ETranslations.perp_portfolio_value })}
+        </SectionLabel>
+        <SizableText size="$heading4xl" color="$text">
+          {accountValue}
+        </SizableText>
+        <XStack gap="$1.5" alignItems="center">
+          <SizableText size="$bodySm" color="$textSubdued">
+            {intl.formatMessage({ id: ETranslations.perp_portfolio_available })}
+          </SizableText>
+          <SizableText size="$bodySm" color="$text">
+            {withdrawable}
+          </SizableText>
+        </XStack>
+      </YStack>
+      {portfolioButtons}
+    </YStack>
+  );
+
+  // ─── Portfolio Value — desktop layout ───────────────────────────────────────
   const portfolioValueBlock = (
     <SectionBlock gap="$3">
       <XStack justifyContent="space-between" alignItems="flex-start">
@@ -545,36 +602,7 @@ function PerpPortfolioContentComponent({
           </SizableText>
         </YStack>
       </XStack>
-      <XStack gap="$2">
-        <Button
-          flex={1}
-          borderRadius="$full"
-          size="medium"
-          bg="$brand8"
-          hoverStyle={{ bg: '$brand9' }}
-          pressStyle={{ bg: '$brand10' }}
-          color="$textOnColor"
-          iconColor="$iconOnColor"
-          icon="DownloadOutline"
-          onPress={() => showDepositWithdrawModal('deposit')}
-        >
-          {intl.formatMessage({
-            id: ETranslations.perp_trade_deposit,
-          })}
-        </Button>
-        <Button
-          flex={1}
-          borderRadius="$full"
-          size="medium"
-          variant="secondary"
-          icon="AlignTopOutline"
-          onPress={() => showDepositWithdrawModal('withdraw')}
-        >
-          {intl.formatMessage({
-            id: ETranslations.perp_trade_withdraw,
-          })}
-        </Button>
-      </XStack>
+      {portfolioButtons}
     </SectionBlock>
   );
 
@@ -765,18 +793,24 @@ function PerpPortfolioContentComponent({
           </XStack>
           {/* Win rate bar — green (win) + red (loss) */}
           <XStack height={4} borderRadius="$full" overflow="hidden">
-            <XStack
-              flex={winRateProgress}
-              bg="$green9"
-              borderTopLeftRadius="$full"
-              borderBottomLeftRadius="$full"
-            />
-            <XStack
-              flex={100 - winRateProgress}
-              bg="$red9"
-              borderTopRightRadius="$full"
-              borderBottomRightRadius="$full"
-            />
+            {fillsStats.winRate === null ? (
+              <XStack flex={1} bg="$neutral5" borderRadius="$full" />
+            ) : (
+              <>
+                <XStack
+                  flex={winRateProgress}
+                  bg="$green9"
+                  borderTopLeftRadius="$full"
+                  borderBottomLeftRadius="$full"
+                />
+                <XStack
+                  flex={100 - winRateProgress}
+                  bg="$red9"
+                  borderTopRightRadius="$full"
+                  borderBottomRightRadius="$full"
+                />
+              </>
+            )}
           </XStack>
         </YStack>
         {/* Avg Win / Loss — side by side cards */}
@@ -808,7 +842,7 @@ function PerpPortfolioContentComponent({
   if (isMobile) {
     return (
       <YStack gap="$4" px="$5" pb="$5">
-        {portfolioValueBlock}
+        {mobilePortfolioValueBlock}
         {chartPanel}
         {statsPanel}
       </YStack>

--- a/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioContent.tsx
+++ b/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioContent.tsx
@@ -246,8 +246,14 @@ function PerpPortfolioContentComponent({
   } | null>(null);
   const [containerWidth, setContainerWidth] = useState(0);
 
-  const { chartData, fillsStats, netDeposits, accountSummary, isLoading } =
-    usePerpPortfolioData(timePeriod);
+  const {
+    chartData,
+    fillsStats,
+    netDeposits,
+    accountSummary,
+    totalPnl,
+    isLoading,
+  } = usePerpPortfolioData(timePeriod);
 
   const chartSeriesData = useMemo((): IMarketTokenChart => {
     if (!chartData) return [];
@@ -269,8 +275,9 @@ function PerpPortfolioContentComponent({
   const unrealizedPnl = formatPerpsUsd(unrealizedPnlRaw, true);
   const unrealizedColor = getPerpsValueColor(unrealizedPnlRaw);
 
-  const realizedPnl = formatPerpsUsd(fillsStats.realizedPnl, true);
-  const realizedColor = getPerpsValueColor(fillsStats.realizedPnl);
+  const totalPnlVal = totalPnl ?? fillsStats.realizedPnl;
+  const realizedPnl = formatPerpsUsd(totalPnlVal, true);
+  const realizedColor = getPerpsValueColor(totalPnlVal);
 
   const vlm = chartData?.vlm
     ? formatPerpsCompactUsd(parseFloat(chartData.vlm))

--- a/packages/kit/src/views/Perp/components/Portfolio/usePerpPortfolioData.ts
+++ b/packages/kit/src/views/Perp/components/Portfolio/usePerpPortfolioData.ts
@@ -186,6 +186,13 @@ export function usePerpPortfolioData(timePeriod: IPortfolioTimePeriod) {
     };
   }, [tradesHistoryData, timePeriod, address]);
 
+  // Use the portfolio API's pnlHistory for Total P&L (includes fees & funding)
+  const totalPnl = useMemo(() => {
+    if (!chartData?.pnlHistory?.length) return null;
+    const lastEntry = chartData.pnlHistory[chartData.pnlHistory.length - 1];
+    return lastEntry?.[1] ?? null;
+  }, [chartData]);
+
   const netDeposits = useMemo(() => {
     if (!netDepositsData) return null;
     return netDepositsData
@@ -214,6 +221,7 @@ export function usePerpPortfolioData(timePeriod: IPortfolioTimePeriod) {
     fillsStats,
     netDeposits,
     accountSummary,
+    totalPnl,
     isLoading: isChartLoading,
   };
 }

--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarMobile.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarMobile.tsx
@@ -42,10 +42,12 @@ const PerpTickerBarMMRInfoMobileView = memo(
     crossMaintenanceMarginUsed: string;
   }) => {
     const intl = useIntl();
-    const color = useMemo(
-      () => (parseFloat(mmrPercent) <= 50 ? '$green11' : '$red11'),
-      [mmrPercent],
-    );
+    const color = useMemo(() => {
+      const pct = parseFloat(mmrPercent);
+      if (pct <= 40) return '$green11';
+      if (pct <= 70) return '$yellow11';
+      return '$red11';
+    }, [mmrPercent]);
     return (
       <Popover
         title={intl.formatMessage({

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useRoute } from '@react-navigation/native';
 import { BigNumber } from 'bignumber.js';
 import { useIntl } from 'react-intl';
 import { InputAccessoryView } from 'react-native';
+
+import type { RouteProp } from '@react-navigation/core';
 
 import type { IPageNavigationProp, useInTabDialog } from '@onekeyhq/components';
 import {
@@ -55,6 +57,10 @@ import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
+import {
+  EModalPerpRoutes,
+  type IModalPerpParamList,
+} from '@onekeyhq/shared/src/routes/perp';
 import { EModalReceiveRoutes } from '@onekeyhq/shared/src/routes/receive';
 import type { IModalSwapParamList } from '@onekeyhq/shared/src/routes/swap';
 import { EModalSwapRoutes } from '@onekeyhq/shared/src/routes/swap';
@@ -1905,6 +1911,14 @@ function DepositWithdrawContent({
 
 function MobileDepositWithdrawModal() {
   const navigation = useNavigation();
+  const route =
+    useRoute<
+      RouteProp<
+        IModalPerpParamList,
+        EModalPerpRoutes.MobileDepositWithdrawModal
+      >
+    >();
+  const actionType = route.params?.actionType ?? 'deposit';
   const [selectedAccount] = usePerpsActiveAccountAtom();
 
   const handleClose = useCallback(() => {
@@ -1954,7 +1968,7 @@ function MobileDepositWithdrawModal() {
         <PerpsProviderMirror>
           <YStack px="$4" flex={1}>
             <DepositWithdrawContent
-              params={{ actionType: 'deposit' }}
+              params={{ actionType }}
               selectedAccount={selectedAccount}
               onClose={handleClose}
               isMobile

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
@@ -74,7 +74,13 @@ function PerpAccountMMRView() {
         />
         <SizableText
           size="$bodySmMedium"
-          color={parseFloat(mmrPercent) <= 50 ? '$green11' : '$red11'}
+          color={
+            parseFloat(mmrPercent) <= 40
+              ? '$green11'
+              : parseFloat(mmrPercent) <= 70
+                ? '$yellow11'
+                : '$red11'
+          }
         >
           {mmrPercent}%
         </SizableText>

--- a/packages/kit/src/views/Perp/hooks/useShowDepositWithdrawModal.ts
+++ b/packages/kit/src/views/Perp/hooks/useShowDepositWithdrawModal.ts
@@ -26,6 +26,7 @@ export function useShowDepositWithdrawModal() {
       } else {
         navigation.pushModal(EModalRoutes.PerpModal, {
           screen: EModalPerpRoutes.MobileDepositWithdrawModal,
+          params: { actionType },
         });
       }
     },

--- a/packages/shared/src/routes/perp.ts
+++ b/packages/shared/src/routes/perp.ts
@@ -15,7 +15,7 @@ export type IModalPerpParamList = {
   [EModalPerpRoutes.MobilePerpMarket]: undefined;
   [EModalPerpRoutes.MobileTokenSelector]: undefined;
   [EModalPerpRoutes.MobileSetTpsl]: ISetTpslParams;
-  [EModalPerpRoutes.MobileDepositWithdrawModal]: undefined;
+  [EModalPerpRoutes.MobileDepositWithdrawModal]: { actionType?: 'deposit' | 'withdraw' };
   [EModalPerpRoutes.PerpsInviteeRewardModal]: undefined;
   [EModalPerpRoutes.MobilePortfolioPage]: undefined;
 };


### PR DESCRIPTION
## Summary

- **Total P&L 计算修正**：改用 portfolio API 的 `pnlHistory` 最后一个值，与 Hyperliquid 官方一致（原先用 `closedPnl` 求和，缺少 fees 和 funding payments）
- **MMR 颜色统一**：三处 MMR 颜色逻辑（Portfolio gauge、Account Panel、Mobile Ticker）统一为三档阈值 ≤40% 绿 / 40~70% 黄 / >70% 红
- **移动端提现 tab 修复**：点击提现按钮未定位到提现 tab（路由未传 `actionType` 参数）
- **Portfolio 移动端布局优化**：账户资产区块去除背景色，大数值字体放大至 `heading4xl`
- **无交易进度条修复**：无交易记录时 Win Rate 进度条显示灰色而非红色（OK-52150）
- **总盈亏居中对齐**：三列改为 `flex={1}` 等分布局，多语言下不再错位（OK-52152）

## Related Issues

- OK-52150 无交易账户显示红色进度条
- OK-52151 总盈亏与 HL 不一致
- OK-52152 总盈亏字段未居中对齐
- OK-52148 点击提现未定位到提现 tab

## Test plan

- [ ] 验证 Total P&L 与 Hyperliquid 官方数值一致
- [ ] 验证 MMR 在三个入口颜色显示正确
- [ ] 移动端点击「提现」按钮直接打开提现 tab
- [ ] 无持仓账户 Win Rate 进度条显示灰色
- [ ] 切换多语言，三列盈亏数据对齐正常
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
