### PR TITLE
fix: pass checkout_ref to shared-env in release-web to prevent code overwrite

### DIFF
--- a/.github/actions/shared-env/action.yml
+++ b/.github/actions/shared-env/action.yml
@@ -2,6 +2,11 @@ name: Shared Environment Variables Setup
 description: Setup environment variables for the project
 
 inputs:
+  checkout_ref:
+    required: false
+    type: string
+    default: ''
+    description: "Git ref to checkout (commit SHA, branch, or tag). If empty, defaults to the triggering event ref."
   additional_env:
     required: false
     type: string
@@ -60,6 +65,7 @@ runs:
       uses: actions/checkout@v3
       with:
         lfs: true
+        ref: ${{ inputs.checkout_ref || '' }}
 
     - name: Download workflow parameters
       if: ${{ github.event.workflow_run }}

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -85,6 +85,7 @@ jobs:
       - name: Run Shared Env Setup
         uses: ./.github/actions/shared-env
         with:
+          checkout_ref: ${{ inputs.checkout_ref || '' }}
           env_file_name: '.env'
           sentry_project: 'web'
           covalent_key: ${{ secrets.COVALENT_KEY }}
@@ -217,6 +218,7 @@ jobs:
       - name: Run Shared Env Setup
         uses: ./.github/actions/shared-env
         with:
+          checkout_ref: ${{ inputs.checkout_ref || '' }}
           env_file_name: '.env'
           sentry_project: 'web'
           covalent_key: ${{ secrets.COVALENT_KEY }}
@@ -334,6 +336,7 @@ jobs:
       - name: Run Shared Env Setup
         uses: ./.github/actions/shared-env
         with:
+          checkout_ref: ${{ inputs.checkout_ref || '' }}
           env_file_name: '.env'
           sentry_project: 'web'
           covalent_key: ${{ secrets.COVALENT_KEY }}


### PR DESCRIPTION
## Summary
- Add `checkout_ref` input to `shared-env` composite action and forward it to the internal `actions/checkout` step
- Pass `checkout_ref` from all 3 jobs in `release-web.yml` (test-web, build-production, notify) to `shared-env`

## Intent & Context
When `release-app-bundles` is triggered with a PR number to build web bundles for a specific PR, the deployed site at app.onekeytest.com shows the wrong version (6.2.0 from `x` branch instead of 6.1.0 from the PR).

## Root Cause
The `shared-env` composite action (`.github/actions/shared-env/action.yml`) contains its own `actions/checkout@v3` step **without a `ref` parameter**. When `release-web.yml` is invoked via `workflow_call` from `release-app-bundles`, the execution flow is:

1. `release-web.yml` checkout → `cf4f798` (PR commit, correct) ✅
2. `shared-env/action.yml` checkout → **no `ref`**, defaults to `github.sha` → `deaa688` (x branch HEAD) ❌

This second checkout silently overwrites the workspace with x branch code. All subsequent steps (dotenv, build, deploy) use x branch code instead of the PR code.

**Evidence from CI logs (run [#23527699027](https://github.com/OneKeyHQ/app-monorepo/actions/runs/23527699027)):**
```
git checkout --progress --force cf4f7985621d4158ce9ff5c6597877bd106f3328  ← parent workflow (correct)
git checkout --progress --force -B x refs/remotes/origin/x                ← shared-env (overwrites!)
```

## Design Decisions
- Added `checkout_ref` as an optional input to `shared-env` (default: `''`) to maintain backward compatibility — existing callers (daily-build, standalone workflows) continue to work unchanged
- Only modified `release-web.yml` since desktop-bundle and native-bundle are confirmed to produce correct bundles through their existing flow

## Changes Detail
- **`.github/actions/shared-env/action.yml`**: New `checkout_ref` input, forwarded to `ref:` in the internal checkout step
- **`.github/workflows/release-web.yml`**: All 3 jobs (test-web, build-production, notify) pass `checkout_ref` to shared-env

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Web (app.onekeytest.com deployment and production web build)
- **Risk Areas**: The `shared-env` action is used by 15 workflows, but the change is backward-compatible — when `checkout_ref` is not provided, `ref: ''` behaves identically to the previous no-ref behavior

## Test plan
- [ ] Trigger `release-app-bundles` with a PR number targeting a release branch (e.g. `release/v6.1.0`)
- [ ] Verify `test-web` job logs show the PR commit SHA in **both** checkout steps (parent and shared-env)
- [ ] Verify app.onekeytest.com shows the correct version from the PR branch
- [ ] Verify daily-build triggered `release-web` still works (no `checkout_ref` passed → default behavior)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
