### PR TITLE
chore(lint): enable react_perf oxlint rules for packages/components

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -9,10 +9,17 @@
     { "name": "import-js", "specifier": "eslint-plugin-import" },
     "./development/plugins/eslint-plugin-onekey.js"
   ],
-  "extends": [
-    "eslint-config-prettier",
+  "extends": ["eslint-config-prettier"],
+  "plugins": [
+    "unicorn",
+    "typescript",
+    "oxc",
+    "react",
+    "react_perf",
+    "import",
+    "jest",
+    "jsx-a11y"
   ],
-  "plugins": ["unicorn", "typescript", "oxc", "react", "import", "jest", "jsx-a11y"],
   // NOTE: JavaScript ESLint plugins (experimental feature) are not used yet
   // because some plugin configurations are not compatible with oxlint
   // https://oxc.rs/docs/guide/usage/linter/migrate-from-eslint.html#local-custom-eslint-plugins
@@ -224,8 +231,11 @@
         "additionalHooks": "(usePromiseResult|useAsyncCall|useUpdateEffect|useDeepCompareEffect)"
       }
     ],
-    "react/jsx-curly-brace-presence": ["error", { "props": "never", "children": "never" }],
-    // react_perf rules — disabled, too many existing violations to fix at once
+    "react/jsx-curly-brace-presence": [
+      "error",
+      { "props": "never", "children": "never" }
+    ],
+    // react_perf rules — enabled only for packages/components (see overrides)
     "react_perf/jsx-no-new-function-as-prop": "off",
     "react_perf/jsx-no-new-object-as-prop": "off",
     "react_perf/jsx-no-new-array-as-prop": "off",
@@ -444,7 +454,7 @@
   // Package-specific rules (migrated from ESLint overrides)
   "overrides": [
     {
-      // packages/components - cannot import from kit or kit-bg
+      // packages/components - cannot import from kit or kit-bg + react_perf rules
       "files": [
         "packages/components/src/**/*.ts",
         "packages/components/src/**/*.tsx"
@@ -461,7 +471,11 @@
               }
             ]
           }
-        ]
+        ],
+        "react_perf/jsx-no-new-function-as-prop": "error",
+        "react_perf/jsx-no-new-object-as-prop": "error",
+        "react_perf/jsx-no-new-array-as-prop": "error",
+        "react_perf/jsx-no-jsx-as-prop": "error"
       }
     },
     {
@@ -584,8 +598,7 @@
     {
       // Test files - relax some rules
       "files": ["test/**/*.js", "test/**/*.ts", "**/*.test.ts"],
-      "rules": {
-      }
+      "rules": {}
     },
     {
       // JS/JSX files - disable TypeScript-specific rules
@@ -606,7 +619,7 @@
         "typescript/no-unsafe-call": "off",
         "typescript/no-unsafe-return": "off",
         "typescript/no-unsafe-function-type": "off",
-        "typescript/no-empty-object-type": "off",
+        "typescript/no-empty-object-type": "off"
       }
     }
   ],

--- a/development/spellCheckerSkipWords.txt
+++ b/development/spellCheckerSkipWords.txt
@@ -1416,3 +1416,6 @@ pwdhash
 wesbos
 entrancy
 vbyte
+prefs
+Prefs
+oxlintrc

--- a/packages/components/src/actions/ActionList/index.tsx
+++ b/packages/components/src/actions/ActionList/index.tsx
@@ -62,6 +62,25 @@ const PROCESSING_RESET_DELAY = 350;
 const FALLBACK_MODAL_NAVIGATOR_CONTEXT = { portalId: '' };
 const FALLBACK_PAGE_CONTEXT = { footerRef: { current: null } as any };
 
+const ACTION_LIST_ITEM_MD = { py: '$2.5', borderRadius: '$3' } as const;
+const ACTION_LIST_ICON_MD = { size: '$6' } as const;
+const ACTION_LIST_TEXT_MD = { size: '$bodyLg' } as const;
+const ACTION_LIST_HOVER_STYLE = { bg: '$bgHover' } as const;
+const ACTION_LIST_PRESS_STYLE = { bg: '$bgActive' } as const;
+const ACTION_LIST_ENABLED_STYLE = {
+  hoverStyle: ACTION_LIST_HOVER_STYLE,
+  pressStyle: ACTION_LIST_PRESS_STYLE,
+} as const;
+const ACTION_LIST_CONTENT_STYLE = {
+  p: '$1',
+  $md: { p: '$3', pt: '$0' },
+} as const;
+const ACTION_LIST_FLOATING_PANEL_PROPS = { width: '$56' } as const;
+const ACTION_LIST_MD_HEADING = {
+  size: '$headingSm',
+  paddingVertical: '$2.5',
+} as const;
+
 export function ActionListSkeletonItem() {
   return (
     <XStack
@@ -132,24 +151,12 @@ export function ActionListItem(
       py="$1.5"
       borderWidth={0}
       borderRadius="$2"
-      $md={{
-        py: '$2.5',
-        borderRadius: '$3',
-      }}
+      $md={ACTION_LIST_ITEM_MD}
       borderCurve="continuous"
       opacity={disabled ? 0.5 : 1}
       disabled={disabled}
       aria-disabled={disabled}
-      {...(!disabled && {
-        hoverStyle: { bg: '$bgHover' },
-        pressStyle: { bg: '$bgActive' },
-        // focusable: true,
-        // focusVisibleStyle: {
-        //   outlineColor: '$focusRing',
-        //   outlineStyle: 'solid',
-        //   outlineWidth: 2,
-        // },
-      })}
+      {...(!disabled && ACTION_LIST_ENABLED_STYLE)}
       onPress={isLoading ? undefined : sharedOnPress}
       testID={testID}
     >
@@ -159,7 +166,7 @@ export function ActionListItem(
             name={icon}
             size="$5"
             mr="$3"
-            $md={{ size: '$6' }}
+            $md={ACTION_LIST_ICON_MD}
             color={destructive ? '$iconCritical' : '$icon'}
             {...iconProps}
           />
@@ -172,7 +179,7 @@ export function ActionListItem(
               size="$bodyMd"
               width="100%"
               flexShrink={1}
-              $md={{ size: '$bodyLg' }}
+              $md={ACTION_LIST_TEXT_MD}
               color={destructive ? '$textCritical' : '$text'}
             >
               {label}
@@ -322,17 +329,20 @@ function BasicActionList({
     renderItemsAsync,
   ]);
 
-  const renderActionListItem = (item: IActionListItemProps) => (
-    <ActionListItem
-      onPress={item.onPress}
-      key={item.label}
-      disabled={item.disabled}
-      {...item}
-      onClose={() => {
-        handleActionListClose();
-        item.onClose?.();
-      }}
-    />
+  const renderActionListItem = useCallback(
+    (item: IActionListItemProps) => (
+      <ActionListItem
+        onPress={item.onPress}
+        key={item.label}
+        disabled={item.disabled}
+        {...item}
+        onClose={() => {
+          handleActionListClose();
+          item.onClose?.();
+        }}
+      />
+    ),
+    [handleActionListClose],
   );
 
   const trigger = useMemo(() => {
@@ -343,54 +353,66 @@ function BasicActionList({
     );
   }, [disabled, renderTrigger, handleActionListOpen]);
 
+  const renderContentMemo = useMemo(
+    () => (
+      <YStack {...ACTION_LIST_CONTENT_STYLE}>
+        {items?.map(renderActionListItem)}
+        {sections?.map((section, sectionIdx) => (
+          <YStack key={sectionIdx}>
+            {sectionIdx > 0 && section.items.length > 0 ? (
+              <Divider mx="$2" my="$1" />
+            ) : null}
+            {section.title ? (
+              <Heading
+                size="$headingXs"
+                $md={ACTION_LIST_MD_HEADING}
+                py="$1.5"
+                px="$2"
+                color="$textSubdued"
+              >
+                {section.title}
+              </Heading>
+            ) : null}
+            {section.items.map(renderActionListItem)}
+          </YStack>
+        ))}
+
+        {/* custom render items */}
+        {renderItems?.({
+          handleActionListClose,
+          handleActionListOpen,
+        })}
+
+        {/* custom async render items - show skeleton while loading */}
+        {renderItemsAsync && !asyncItems ? (
+          <>
+            <ActionListSkeletonItem />
+            <ActionListSkeletonItem />
+          </>
+        ) : (
+          asyncItems
+        )}
+      </YStack>
+    ),
+    [
+      items,
+      sections,
+      renderActionListItem,
+      renderItems,
+      renderItemsAsync,
+      asyncItems,
+      handleActionListClose,
+      handleActionListOpen,
+    ],
+  );
+
   return (
     <Popover
       title={title || intl.formatMessage({ id: ETranslations.explore_options })}
       open={isOpen}
       onOpenChange={handleOpenStatusChange}
-      renderContent={
-        <YStack p="$1" $md={{ p: '$3', pt: '$0' }}>
-          {items?.map(renderActionListItem)}
-          {sections?.map((section, sectionIdx) => (
-            <YStack key={sectionIdx}>
-              {sectionIdx > 0 && section.items.length > 0 ? (
-                <Divider mx="$2" my="$1" />
-              ) : null}
-              {section.title ? (
-                <Heading
-                  size="$headingXs"
-                  $md={{ size: '$headingSm', paddingVertical: '$2.5' }}
-                  py="$1.5"
-                  px="$2"
-                  color="$textSubdued"
-                >
-                  {section.title}
-                </Heading>
-              ) : null}
-              {section.items.map(renderActionListItem)}
-            </YStack>
-          ))}
-
-          {/* custom render items */}
-          {renderItems?.({
-            handleActionListClose,
-            handleActionListOpen,
-          })}
-
-          {/* custom async render items - show skeleton while loading */}
-          {renderItemsAsync && !asyncItems ? (
-            <>
-              <ActionListSkeletonItem />
-              <ActionListSkeletonItem />
-            </>
-          ) : (
-            asyncItems
-          )}
-        </YStack>
-      }
-      floatingPanelProps={{
-        width: '$56',
-      }}
+      renderContent={renderContentMemo}
+      floatingPanelProps={ACTION_LIST_FLOATING_PANEL_PROPS}
       {...props}
       renderTrigger={trigger}
     />
@@ -524,11 +546,14 @@ function ActionListFrame(props: IActionListProps) {
 
   const modalNavigatorContext = useModalNavigatorContext();
   const pageContextValue = usePageContext();
-  const contexts = {
-    modalNavigatorContext,
-    pageContextValue,
-  };
-  const handleActionListOpen = () => {
+  const contexts = useMemo(
+    () => ({
+      modalNavigatorContext,
+      pageContextValue,
+    }),
+    [modalNavigatorContext, pageContextValue],
+  );
+  const handleActionListOpen = useCallback(() => {
     if (isProcessing.current) return;
 
     isProcessing.current = true;
@@ -536,7 +561,7 @@ function ActionListFrame(props: IActionListProps) {
     setTimeout(() => {
       isProcessing.current = false;
     }, PROCESSING_RESET_DELAY);
-  };
+  }, [popoverProps, contexts]);
 
   if (gtMd) {
     return <BasicActionList {...props} />;

--- a/packages/components/src/actions/ActionList/index.tsx
+++ b/packages/components/src/actions/ActionList/index.tsx
@@ -336,6 +336,7 @@ function BasicActionList({
         key={item.label}
         disabled={item.disabled}
         {...item}
+        // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
         onClose={() => {
           handleActionListClose();
           item.onClose?.();
@@ -439,6 +440,7 @@ const showActionList = (
   const { triggerPosition, ...restProps } = props;
   dismissKeyboard();
 
+  // eslint-disable-next-line react-perf/jsx-no-jsx-as-prop
   const triggerElement =
     triggerPosition && !platformEnv.isNative ? (
       <Stack width={1} height={1} />
@@ -448,6 +450,7 @@ const showActionList = (
   // eslint-disable-next-line prefer-const
   let ref: { destroy: () => void };
 
+  // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
   const handleOpenChange = (isOpen: boolean) => {
     restProps.onOpenChange?.(isOpen);
     if (!isOpen) {
@@ -505,6 +508,7 @@ const showActionList = (
   const content =
     triggerPosition && !platformEnv.isNative ? (
       <Stack
+        // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
         style={{
           position: 'fixed' as const,
           left: triggerPosition.x,

--- a/packages/components/src/actions/InteractiveIcon/index.tsx
+++ b/packages/components/src/actions/InteractiveIcon/index.tsx
@@ -3,6 +3,8 @@ import { NATIVE_HIT_SLOP } from '../../utils/getFontSize';
 
 import type { IIconProps, IKeyOfIcons } from '../../primitives';
 
+const groupHoverStyle = { color: '$iconHover' } as const;
+
 export interface IInteractiveIconProps {
   icon: IKeyOfIcons;
   onPress: () => void;
@@ -27,7 +29,7 @@ export function InteractiveIcon({
         name={icon}
         size={size}
         color="$iconSubdued"
-        $group-hover={{ color: '$iconHover' }}
+        $group-hover={groupHoverStyle}
       />
     </Stack>
   );

--- a/packages/components/src/actions/Pagination/index.tsx
+++ b/packages/components/src/actions/Pagination/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { ButtonFrame, SizableText, XStack } from '../../primitives';
 import { IconButton } from '../IconButton';
@@ -6,6 +6,8 @@ import { IconButton } from '../IconButton';
 import { DOTS, usePagination } from './usePagination';
 
 import type { IXStackProps } from '../../primitives';
+
+const pressStyleConst = { bg: '$bgActive' } as const;
 
 export interface IPaginationProps extends IXStackProps {
   current: number;
@@ -92,8 +94,8 @@ function PaginationFrame({
             borderRadius="$2"
             borderCurve="continuous"
             userSelect="none"
-            pressStyle={{ bg: '$bgActive' }}
-            hoverStyle={{ bg: active ? '$bgStrong' : '$bgHover' }}
+            pressStyle={pressStyleConst}
+            hoverStyle={active ? activeHoverStyle : inactiveHoverStyle}
             bg={active ? '$bgStrong' : '$transparent'}
             onPress={() => onPageChange(page)}
             role="button"

--- a/packages/components/src/actions/Pagination/index.tsx
+++ b/packages/components/src/actions/Pagination/index.tsx
@@ -8,6 +8,8 @@ import { DOTS, usePagination } from './usePagination';
 import type { IXStackProps } from '../../primitives';
 
 const pressStyleConst = { bg: '$bgActive' } as const;
+const activeHoverStyle = { bg: '$bgStrong' } as const;
+const inactiveHoverStyle = { bg: '$bgHover' } as const;
 
 export interface IPaginationProps extends IXStackProps {
   current: number;

--- a/packages/components/src/actions/Pagination/index.tsx
+++ b/packages/components/src/actions/Pagination/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 
 import { ButtonFrame, SizableText, XStack } from '../../primitives';
 import { IconButton } from '../IconButton';

--- a/packages/components/src/actions/Pagination/index.tsx
+++ b/packages/components/src/actions/Pagination/index.tsx
@@ -11,6 +11,47 @@ const pressStyleConst = { bg: '$bgActive' } as const;
 const activeHoverStyle = { bg: '$bgStrong' } as const;
 const inactiveHoverStyle = { bg: '$bgHover' } as const;
 
+function PageButton({
+  page,
+  active,
+  onPageChange,
+}: {
+  page: number;
+  active: boolean;
+  onPageChange: (page: number) => void;
+}) {
+  const handlePress = useCallback(() => {
+    onPageChange(page);
+  }, [onPageChange, page]);
+
+  return (
+    <ButtonFrame
+      borderWidth={0}
+      key={page}
+      py="$1"
+      px="$2.5"
+      borderRadius="$2"
+      borderCurve="continuous"
+      userSelect="none"
+      pressStyle={pressStyleConst}
+      hoverStyle={active ? activeHoverStyle : inactiveHoverStyle}
+      bg={active ? '$bgStrong' : '$transparent'}
+      onPress={handlePress}
+      role="button"
+      aria-label={`Page ${page}${active ? ', current page' : ''}`}
+      aria-current={active ? 'page' : undefined}
+    >
+      <SizableText
+        size="$bodyMdMedium"
+        textAlign="center"
+        color={active ? '$text' : '$textSubdued'}
+      >
+        {page}
+      </SizableText>
+    </ButtonFrame>
+  );
+}
+
 export interface IPaginationProps extends IXStackProps {
   current: number;
   total: number;
@@ -88,30 +129,12 @@ function PaginationFrame({
         }
         const active = page === effectiveCurrent;
         return (
-          <ButtonFrame
-            borderWidth={0}
+          <PageButton
             key={page}
-            py="$1"
-            px="$2.5"
-            borderRadius="$2"
-            borderCurve="continuous"
-            userSelect="none"
-            pressStyle={pressStyleConst}
-            hoverStyle={active ? activeHoverStyle : inactiveHoverStyle}
-            bg={active ? '$bgStrong' : '$transparent'}
-            onPress={() => onPageChange(page)}
-            role="button"
-            aria-label={`Page ${page}${active ? ', current page' : ''}`}
-            aria-current={active ? 'page' : undefined}
-          >
-            <SizableText
-              size="$bodyMdMedium"
-              textAlign="center"
-              color={active ? '$text' : '$textSubdued'}
-            >
-              {page}
-            </SizableText>
-          </ButtonFrame>
+            page={page}
+            active={active}
+            onPageChange={onPageChange}
+          />
         );
       })}
       {showControls ? (

--- a/packages/components/src/actions/Popover/index.tsx
+++ b/packages/components/src/actions/Popover/index.tsx
@@ -58,6 +58,20 @@ const gtMdShFrameStyle = {
   maxWidth: 480,
   mx: 'auto',
 } as const;
+
+const POPOVER_ENTER_STYLE = { scale: 0.95, opacity: 0 } as const;
+const POPOVER_EXIT_STYLE = { scale: 0.95, opacity: 0 } as const;
+const POPOVER_PLATFORM_WEB_STYLE = {
+  outlineColor: '$neutral3',
+  outlineStyle: 'solid',
+  outlineWidth: '$px',
+  boxShadow:
+    '0 4px 6px -4px rgba(0, 0, 0, 0.10), 0 10px 15px -3px rgba(0, 0, 0, 0.10)',
+} as const;
+const POPOVER_PLATFORM_NATIVE = { elevation: 20 } as const;
+const OVERLAY_ENTER_STYLE = { opacity: 0 } as const;
+const OVERLAY_EXIT_STYLE = { opacity: 0 } as const;
+const WORD_BREAK_ALL_STYLE = { wordBreak: 'break-all' } as const;
 export interface IPopoverProps extends TMPopoverProps {
   title: string | ReactElement;
   description?: string;
@@ -410,6 +424,14 @@ function RawPopover({
   const isShowNativeKeepChildrenMountedBackdrop =
     platformEnv.isNative && props.keepChildrenMounted;
   const maxScrollViewHeight = getMaxScrollViewHeight();
+  const transformOriginStyle = useMemo(
+    () => ({ transformOrigin }),
+    [transformOrigin],
+  );
+  const scrollViewStyle = useMemo(
+    () => ({ maxHeight: maxScrollViewHeight }),
+    [maxScrollViewHeight],
+  );
   return (
     <TMPopover
       offset={8}
@@ -430,33 +452,20 @@ function RawPopover({
           trapFocus={false}
           unstyled
           display={display}
-          style={{
-            transformOrigin,
-          }}
-          enterStyle={{
-            scale: 0.95,
-            opacity: 0,
-          }}
-          exitStyle={{ scale: 0.95, opacity: 0 }}
+          style={transformOriginStyle}
+          enterStyle={POPOVER_ENTER_STYLE}
+          exitStyle={POPOVER_EXIT_STYLE}
           w="$96"
           bg="$bg"
           borderRadius="$3"
-          $platform-web={{
-            outlineColor: '$neutral3',
-            outlineStyle: 'solid',
-            outlineWidth: '$px',
-            boxShadow:
-              '0 4px 6px -4px rgba(0, 0, 0, 0.10), 0 10px 15px -3px rgba(0, 0, 0, 0.10)',
-          }}
-          $platform-native={{
-            elevation: 20,
-          }}
+          $platform-web={POPOVER_PLATFORM_WEB_STYLE}
+          $platform-native={POPOVER_PLATFORM_NATIVE}
           animation="popoverQuick"
           {...floatingPanelProps}
         >
           <TMPopover.ScrollView
             testID="TMPopover-ScrollView"
-            style={{ maxHeight: maxScrollViewHeight }}
+            style={scrollViewStyle}
           >
             {content}
           </TMPopover.ScrollView>
@@ -494,8 +503,8 @@ function RawPopover({
                   zIndex={sheetProps?.zIndex || zIndex}
                   backgroundColor="$bgBackdrop"
                   animation="quick"
-                  enterStyle={{ opacity: 0 }}
-                  exitStyle={{ opacity: 0 }}
+                  enterStyle={OVERLAY_ENTER_STYLE}
+                  exitStyle={OVERLAY_EXIT_STYLE}
                 />
               )}
               <TMPopover.Sheet.Frame
@@ -523,9 +532,7 @@ function RawPopover({
                         <SizableText
                           size="$headingXl"
                           color="$text"
-                          style={{
-                            wordBreak: 'break-all',
-                          }}
+                          style={WORD_BREAK_ALL_STYLE}
                         >
                           {title}
                         </SizableText>
@@ -635,6 +642,11 @@ function BasicPopover({
     );
   }
 
+  const webSheetProps = useMemo(
+    () => ({ ...sheetProps, modal: true }),
+    [sheetProps],
+  );
+
   // on web, we add the popover into the RNRootView
   return (
     <RawPopover
@@ -644,7 +656,7 @@ function BasicPopover({
       onOpenChange={md ? onOpenChange : undefined}
       openPopover={openPopover}
       closePopover={closePopover}
-      sheetProps={{ ...sheetProps, modal: true }}
+      sheetProps={webSheetProps}
       renderTrigger={renderTrigger}
       trackID={trackID}
       keepChildrenMounted={keepChildrenMounted}
@@ -663,26 +675,35 @@ function Tooltip({
 }: IPopoverTooltip & {
   iconSize?: IIconButtonProps['iconSize'];
 }) {
+  const triggerMemo = useMemo(
+    () => (
+      <IconButton
+        iconColor="$iconSubdued"
+        iconSize={iconSize}
+        icon="InfoCircleOutline"
+        variant="tertiary"
+        {...triggerProps}
+      />
+    ),
+    [iconSize, triggerProps],
+  );
+
+  const contentMemo = useMemo(
+    () =>
+      renderContent || (
+        <YStack p="$5">
+          <SizableText size="$bodyLg">{tooltip}</SizableText>
+        </YStack>
+      ),
+    [renderContent, tooltip],
+  );
+
   return (
     <BasicPopover
       placement={placement}
       title={title}
-      renderTrigger={
-        <IconButton
-          iconColor="$iconSubdued"
-          iconSize={iconSize}
-          icon="InfoCircleOutline"
-          variant="tertiary"
-          {...triggerProps}
-        />
-      }
-      renderContent={
-        renderContent || (
-          <YStack p="$5">
-            <SizableText size="$bodyLg">{tooltip}</SizableText>
-          </YStack>
-        )
-      }
+      renderTrigger={triggerMemo}
+      renderContent={contentMemo}
     />
   );
 }

--- a/packages/components/src/actions/Popover/index.tsx
+++ b/packages/components/src/actions/Popover/index.tsx
@@ -622,6 +622,11 @@ function BasicPopover({
   const modalNavigatorContext = useModalNavigatorContext();
   const pageContextValue = usePageContext();
 
+  const webSheetProps = useMemo(
+    () => ({ ...sheetProps, modal: true }),
+    [sheetProps],
+  );
+
   if (platformEnv.isNative) {
     // on native and ipad, we add the popover to the RNScreen.FULL_WINDOW_OVERLAY
     return (
@@ -641,11 +646,6 @@ function BasicPopover({
       </>
     );
   }
-
-  const webSheetProps = useMemo(
-    () => ({ ...sheetProps, modal: true }),
-    [sheetProps],
-  );
 
   // on web, we add the popover into the RNRootView
   return (

--- a/packages/components/src/actions/SegmentControl/index.tsx
+++ b/packages/components/src/actions/SegmentControl/index.tsx
@@ -8,6 +8,15 @@ import { SizableText, XStack, YStack } from '../../primitives';
 
 import type { IXStackProps } from '../../primitives';
 
+const gtMdStyle = { zIndex: 4 } as const;
+const hoverStyleConst = { bg: '$bgHover' } as const;
+const pressStyleConst = { bg: '$bgActive' } as const;
+const focusVisibleStyleConst = {
+  outlineWidth: 2,
+  outlineColor: '$focusRing',
+  outlineStyle: 'solid',
+} as const;
+
 export interface ISegmentControlProps extends IXStackProps {
   fullWidth?: boolean;
   value: string | number;
@@ -52,29 +61,21 @@ function SegmentControlItem({
     <YStack
       py="$1.5"
       px="$3.5"
-      $gtMd={{ zIndex: 4 }}
+      $gtMd={gtMdStyle}
       onPress={handleChange}
       borderRadius="$full"
       borderCurve="continuous"
       userSelect="none"
       focusable={!disabled}
-      focusVisibleStyle={{
-        outlineWidth: 2,
-        outlineColor: '$focusRing',
-        outlineStyle: 'solid',
-      }}
+      focusVisibleStyle={focusVisibleStyleConst}
       testID={testID}
       {...(active
         ? {
             bg: activeBackgroundColor ?? '$bgPrimary',
           }
         : {
-            hoverStyle: {
-              bg: '$bgHover',
-            },
-            pressStyle: {
-              bg: '$bgActive',
-            },
+            hoverStyle: hoverStyleConst,
+            pressStyle: pressStyleConst,
           })}
       {...(disabled && {
         opacity: 0.5,

--- a/packages/components/src/actions/Toast/ShowCustom.tsx
+++ b/packages/components/src/actions/Toast/ShowCustom.tsx
@@ -24,6 +24,9 @@ import { Trigger } from '../Trigger';
 
 import type { GestureResponderEvent } from 'react-native';
 
+const toastEnterStyle = { opacity: 0, scale: 0.8, y: -20 } as const;
+const toastExitStyle = { opacity: 0, scale: 0.8, y: -20 } as const;
+
 // eslint-disable-next-line import/no-cycle
 export type IShowToasterProps = PropsWithChildren<{
   onClose?: (extra?: { flag?: string }) => Promise<void> | void;
@@ -168,8 +171,8 @@ function BasicShowToaster({
             justifyContent="center"
             open={isOpen}
             borderRadius={0}
-            enterStyle={{ opacity: 0, scale: 0.8, y: -20 }}
-            exitStyle={{ opacity: 0, scale: 0.8, y: -20 }}
+            enterStyle={toastEnterStyle}
+            exitStyle={toastExitStyle}
             duration={duration}
             w={platformEnv.isNative ? pageWidth : undefined}
             maxWidth={platformEnv.isNative ? '$96' : undefined}

--- a/packages/components/src/actions/Toast/Toaster.tsx
+++ b/packages/components/src/actions/Toast/Toaster.tsx
@@ -9,6 +9,8 @@ import { TOAST_Z_INDEX } from '@onekeyhq/shared/src/utils/overlayUtils';
 import { useThemeName } from '../../hooks/useStyle';
 import { Stack } from '../../primitives';
 
+const toasterStyle = { zIndex: TOAST_Z_INDEX } as const;
+
 function Toaster() {
   const media = useMedia();
   const themeName = useThemeName();
@@ -23,9 +25,7 @@ function Toaster() {
     >
       <WebToaster
         closeButton
-        style={{
-          zIndex: TOAST_Z_INDEX,
-        }}
+        style={toasterStyle}
         visibleToasts={3}
         position={media.md ? 'top-center' : 'bottom-right'}
         theme={themeName}

--- a/packages/components/src/actions/Toast/index.tsx
+++ b/packages/components/src/actions/Toast/index.tsx
@@ -271,6 +271,7 @@ function toastMessage({
     warning: '$iconCaution',
     info: '$iconInfo',
   };
+  // eslint-disable-next-line react-perf/jsx-no-jsx-as-prop
   const iconElement = icon ? (
     <Icon
       name={icon}
@@ -457,6 +458,7 @@ export const Toast = {
         }
       | undefined;
 
+    // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
     const handleClose = (extra?: { flag?: string }) =>
       new Promise<void>((resolve) => {
         // Remove the React node after the animation has finished.

--- a/packages/components/src/actions/Toast/index.tsx
+++ b/packages/components/src/actions/Toast/index.tsx
@@ -1,5 +1,5 @@
 import type { RefObject } from 'react';
-import { createRef, useEffect, useMemo } from 'react';
+import { createRef, useCallback, useEffect, useMemo } from 'react';
 
 import { useWindowDimensions } from 'react-native';
 
@@ -71,6 +71,10 @@ const iconMap = {
   loading: <Spinner size="small" />,
 };
 
+const underlineTextPropsStatic = {
+  color: '$textSubdued' as const,
+};
+
 function RenderLines({
   size,
   children: text,
@@ -98,9 +102,7 @@ function RenderLines({
           color={color}
           textTransform="none"
           userSelect="none"
-          underlineTextProps={{
-            color: '$textSubdued',
-          }}
+          underlineTextProps={underlineTextPropsStatic}
           size={size}
           wordWrap="break-word"
           translationId={line as ETranslations}
@@ -110,6 +112,14 @@ function RenderLines({
     </YStack>
   );
 }
+
+const platformWebOverflowStyle = {
+  overflow: 'hidden' as const,
+};
+
+const platformAndroidPaddingStyle = {
+  paddingTop: '$0.5' as const,
+};
 
 export function ToastContent({
   title,
@@ -137,25 +147,25 @@ export function ToastContent({
     },
     [onClose],
   );
+  const platformNativeStyle = useMemo(
+    () => ({
+      maxHeight: height - 200,
+      width: Math.min(pageWidth, 640) - 64,
+    }),
+    [height, pageWidth],
+  );
   return (
     <YStack
       flex={1}
       maxWidth={maxWidth}
       maxHeight={height - 100}
-      $platform-native={{
-        maxHeight: height - 200,
-        width: Math.min(pageWidth, 640) - 64,
-      }}
-      $platform-web={{
-        overflow: 'hidden',
-      }}
+      $platform-native={platformNativeStyle}
+      $platform-web={platformWebOverflowStyle}
     >
       <XStack gap={icon ? '$2' : 0}>
         {icon ? (
           <View
-            $platform-android={{
-              paddingTop: '$0.5',
-            }}
+            $platform-android={platformAndroidPaddingStyle}
             width="$5.5"
             height="$5.5"
           >
@@ -306,26 +316,38 @@ function ToastNotificationContent({
     },
     [onClose],
   );
-  const handlePress = () => {
+  const handlePress = useCallback(() => {
     onPress?.();
-  };
+  }, [onPress]);
+  const iconImageSource = useMemo(
+    () => (iconImageUri ? { uri: iconImageUri } : undefined),
+    [iconImageUri],
+  );
   const IconElement = useMemo(() => {
-    if (iconImageUri) {
-      return <Image source={{ uri: iconImageUri }} size={18} />;
+    if (iconImageUri && iconImageSource) {
+      return <Image source={iconImageSource} size={18} />;
     }
     return (
       <Icon size={18} name={icon || 'SpeakerPromoteOutline'} color="$icon" />
     );
-  }, [iconImageUri, icon]);
+  }, [iconImageUri, iconImageSource, icon]);
+  const imageSource = useMemo(
+    () => (imageUri ? { uri: imageUri } : undefined),
+    [imageUri],
+  );
+  const platformNativeWidthStyle = useMemo(
+    () => ({
+      width: Math.min(pageWidth, 640) - 64,
+    }),
+    [pageWidth],
+  );
   return (
     <XStack
       gap="$2"
       cursor="pointer"
       onPress={handlePress}
       flex={1}
-      $platform-native={{
-        width: Math.min(pageWidth, 640) - 64,
-      }}
+      $platform-native={platformNativeWidthStyle}
     >
       <XStack
         bg="$bgStrong"
@@ -350,8 +372,8 @@ function ToastNotificationContent({
           {message}
         </SizableText>
       </YStack>
-      {imageUri ? (
-        <Image borderRadius="$1" size="$12" source={{ uri: imageUri }} />
+      {imageUri && imageSource ? (
+        <Image borderRadius="$1" size="$12" source={imageSource} />
       ) : null}
     </XStack>
   );

--- a/packages/components/src/actions/Toast/showMessage.native.tsx
+++ b/packages/components/src/actions/Toast/showMessage.native.tsx
@@ -5,6 +5,7 @@ import { View, XStack } from '../../primitives';
 import type { IToastMessageOptions } from './type';
 
 const shadowOffset = { width: 0, height: 3 } as const;
+const platformAndroidStyle = { elevation: 7 } as const;
 
 export function dismissToast(id: string) {
   toast.dismiss(id);
@@ -36,9 +37,7 @@ export function showMessage({
           shadowOffset={shadowOffset}
           shadowOpacity={0.15}
           shadowRadius={4.65}
-          $platform-android={{
-            elevation: 7,
-          }}
+          $platform-android={platformAndroidStyle}
         >
           {renderContent({ width })}
         </View>

--- a/packages/components/src/actions/Toast/showMessage.native.tsx
+++ b/packages/components/src/actions/Toast/showMessage.native.tsx
@@ -4,6 +4,8 @@ import { View, XStack } from '../../primitives';
 
 import type { IToastMessageOptions } from './type';
 
+const shadowOffset = { width: 0, height: 3 } as const;
+
 export function dismissToast(id: string) {
   toast.dismiss(id);
 }
@@ -31,10 +33,7 @@ export function showMessage({
           py="$3"
           borderRadius="$2"
           shadowColor="#181821"
-          shadowOffset={{
-            width: 0,
-            height: 3,
-          }}
+          shadowOffset={shadowOffset}
           shadowOpacity={0.15}
           shadowRadius={4.65}
           $platform-android={{

--- a/packages/components/src/actions/Tooltip/index.tsx
+++ b/packages/components/src/actions/Tooltip/index.tsx
@@ -28,6 +28,9 @@ import { TooltipContext } from './context';
 import type { ITooltipProps } from './type';
 import type { ISizableTextProps } from '../../primitives';
 
+const tooltipEnterStyle = { scale: 0.95, opacity: 0 } as const;
+const tooltipExitStyle = { scale: 0.95, opacity: 0 } as const;
+
 const useHoverTooltip = () => {
   const [isHovered, setIsHovered] = useState(false);
   const showTooltipRef = useRef(isHovered);
@@ -290,11 +293,8 @@ export function Tooltip({
           {...contentProps}
           elevation={10}
           style={contentStyle}
-          enterStyle={{
-            scale: 0.95,
-            opacity: 0,
-          }}
-          exitStyle={{ scale: 0.95, opacity: 0 }}
+          enterStyle={tooltipEnterStyle}
+          exitStyle={tooltipExitStyle}
           animation="quick"
           onHoverIn={handleHoverIn}
           onHoverOut={handleHoverOut}

--- a/packages/components/src/composite/Banner/CloseButton.tsx
+++ b/packages/components/src/composite/Banner/CloseButton.tsx
@@ -4,6 +4,8 @@ import { IconButton } from '../../actions/IconButton';
 import { useHoverOpacity } from '../../hooks/useHoverOpacity';
 import { Stack } from '../../primitives/Stack';
 
+const closeButtonIconProps = { color: '$whiteA10' } as const;
+
 const CloseButton: React.FC<{ onPress: () => void; isHovering?: boolean }> = ({
   onPress,
   isHovering,
@@ -19,9 +21,7 @@ const CloseButton: React.FC<{ onPress: () => void; isHovering?: boolean }> = ({
         onPress={onPress}
         aria-label="Close"
         testID="banner-close-button"
-        iconProps={{
-          color: '$whiteA10',
-        }}
+        iconProps={closeButtonIconProps}
       />
     </Stack>
   );

--- a/packages/components/src/composite/Banner/PaginationButton.tsx
+++ b/packages/components/src/composite/Banner/PaginationButton.tsx
@@ -39,10 +39,13 @@ export function PaginationButton({
   const defaultIcon =
     direction === 'previous' ? 'ChevronLeftOutline' : 'ChevronRightOutline';
   const icon = iconSize === 'small' ? smallIcon : defaultIcon;
-  const positionStyle =
-    direction === 'previous'
-      ? { left: positionOffset }
-      : { right: positionOffset };
+  const positionStyle = useMemo(
+    () =>
+      direction === 'previous'
+        ? { left: positionOffset }
+        : { right: positionOffset },
+    [direction, positionOffset],
+  );
   const hoverOpacity = useHoverOpacity(isHovering);
 
   const opacity = useSharedValue(isVisible ? 1 : 0);

--- a/packages/components/src/composite/Banner/PaginationButton.tsx
+++ b/packages/components/src/composite/Banner/PaginationButton.tsx
@@ -80,10 +80,7 @@ export function PaginationButton({
   );
 
   return (
-    <Animated.View
-      pointerEvents="box-none"
-      style={containerStyle}
-    >
+    <Animated.View pointerEvents="box-none" style={containerStyle}>
       <IconButton
         disabled={!isVisible}
         variant={variant}

--- a/packages/components/src/composite/Banner/PaginationButton.tsx
+++ b/packages/components/src/composite/Banner/PaginationButton.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import Animated, {
   useAnimatedStyle,
@@ -55,28 +55,38 @@ export function PaginationButton({
     opacity: opacity.value,
   }));
 
+  const containerStyle = useMemo(
+    () => [
+      animatedStyle,
+      {
+        position: 'absolute' as const,
+        top: 0,
+        bottom: 0,
+        justifyContent: 'center' as const,
+        alignItems: 'center' as const,
+        ...positionStyle,
+        zIndex,
+      },
+    ],
+    [animatedStyle, positionStyle, zIndex],
+  );
+
+  const iconProps = useMemo(
+    () => ({ opacity: hoverOpacity.opacity }),
+    [hoverOpacity.opacity],
+  );
+
   return (
     <Animated.View
       pointerEvents="box-none"
-      style={[
-        animatedStyle,
-        {
-          position: 'absolute',
-          top: 0,
-          bottom: 0,
-          justifyContent: 'center',
-          alignItems: 'center',
-          ...positionStyle,
-          zIndex,
-        },
-      ]}
+      style={containerStyle}
     >
       <IconButton
         disabled={!isVisible}
         variant={variant}
         icon={icon}
         onPress={onPress}
-        iconProps={{ opacity: hoverOpacity.opacity }}
+        iconProps={iconProps}
         theme={theme}
         onMouseEnter={onMouseEnter}
       />

--- a/packages/components/src/composite/Banner/index.tsx
+++ b/packages/components/src/composite/Banner/index.tsx
@@ -138,6 +138,21 @@ function PaginationDot({
   );
 }
 
+function BannerCloseButtonWrapper({
+  onBannerClose,
+  bannerId,
+  isHovering,
+}: {
+  onBannerClose?: (bannerId: string) => void;
+  bannerId: string;
+  isHovering: boolean;
+}) {
+  const handleClose = useCallback(() => {
+    onBannerClose?.(bannerId);
+  }, [onBannerClose, bannerId]);
+  return <CloseButton onPress={handleClose} isHovering={isHovering} />;
+}
+
 export function Banner<T extends IBannerData>({
   data,
   onItemPress,
@@ -208,27 +223,12 @@ export function Banner<T extends IBannerData>({
             {...indicatorContainerStyle}
           >
             {data.map((_, index) => (
-              <Stack
+              <PaginationDot
                 key={index}
-                p="$1"
-                borderRadius="$full"
-                onPress={(event) => {
-                  event?.stopPropagation?.();
-                  goToIndex(index);
-                }}
-              >
-                <Stack
-                  shadowColor="$blackA1"
-                  shadowOpacity={0.1}
-                  shadowRadius={3}
-                  w="$3"
-                  $gtMd={paginationDotGtMdStyle}
-                  h="$1"
-                  borderRadius="$full"
-                  bg="$whiteA12"
-                  opacity={currentIndex === index ? 1 : 0.5}
-                />
-              </Stack>
+                index={index}
+                currentIndex={currentIndex}
+                goToIndex={goToIndex}
+              />
             ))}
           </XStack>
         ) : null}
@@ -254,10 +254,9 @@ export function Banner<T extends IBannerData>({
         ) : null}
 
         {showCloseButton ? (
-          <CloseButton
-            onPress={() => {
-              onBannerClose?.(data[currentIndex]?.bannerId ?? '');
-            }}
+          <BannerCloseButtonWrapper
+            onBannerClose={onBannerClose}
+            bannerId={data[currentIndex]?.bannerId ?? ''}
             isHovering={isHovering}
           />
         ) : null}

--- a/packages/components/src/composite/Banner/index.tsx
+++ b/packages/components/src/composite/Banner/index.tsx
@@ -110,7 +110,7 @@ function PaginationDot({
   goToIndex: (index: number) => void;
 }) {
   const handlePress = useCallback(
-    (event: any) => {
+    (event: { stopPropagation?: () => void }) => {
       event?.stopPropagation?.();
       goToIndex(index);
     },

--- a/packages/components/src/composite/Banner/index.tsx
+++ b/packages/components/src/composite/Banner/index.tsx
@@ -22,6 +22,10 @@ import type {
   IXStackProps,
 } from '../../primitives';
 
+const paginationDotGtMdStyle = {
+  w: '$4' as const,
+};
+
 export interface IBannerData {
   title?: string;
   titleTextProps?: ISizableTextProps;
@@ -96,6 +100,44 @@ function BannerItem<T extends IBannerData>({
   );
 }
 
+function PaginationDot({
+  index,
+  currentIndex,
+  goToIndex,
+}: {
+  index: number;
+  currentIndex: number;
+  goToIndex: (index: number) => void;
+}) {
+  const handlePress = useCallback(
+    (event: any) => {
+      event?.stopPropagation?.();
+      goToIndex(index);
+    },
+    [goToIndex, index],
+  );
+  return (
+    <Stack
+      key={index}
+      p="$1"
+      borderRadius="$full"
+      onPress={handlePress}
+    >
+      <Stack
+        shadowColor="$blackA1"
+        shadowOpacity={0.1}
+        shadowRadius={3}
+        w="$3"
+        $gtMd={paginationDotGtMdStyle}
+        h="$1"
+        borderRadius="$full"
+        bg="$whiteA12"
+        opacity={currentIndex === index ? 1 : 0.5}
+      />
+    </Stack>
+  );
+}
+
 export function Banner<T extends IBannerData>({
   data,
   onItemPress,
@@ -141,6 +183,11 @@ export function Banner<T extends IBannerData>({
     [data, itemContainerStyle, itemTitleContainerStyle, onItemPress],
   );
 
+  const handlePaginationMouseEnter = useCallback(
+    () => setIsHoveringThrottled(true),
+    [setIsHoveringThrottled],
+  );
+
   const renderPagination = useCallback(
     ({
       currentIndex,
@@ -175,9 +222,7 @@ export function Banner<T extends IBannerData>({
                   shadowOpacity={0.1}
                   shadowRadius={3}
                   w="$3"
-                  $gtMd={{
-                    w: '$4',
-                  }}
+                  $gtMd={paginationDotGtMdStyle}
                   h="$1"
                   borderRadius="$full"
                   bg="$whiteA12"
@@ -195,7 +240,7 @@ export function Banner<T extends IBannerData>({
               direction="previous"
               onPress={gotToPrevIndex}
               theme="light"
-              onMouseEnter={() => setIsHoveringThrottled(true)}
+              onMouseEnter={handlePaginationMouseEnter}
             />
 
             <PaginationButton
@@ -203,7 +248,7 @@ export function Banner<T extends IBannerData>({
               direction="next"
               onPress={goToNextIndex}
               theme="light"
-              onMouseEnter={() => setIsHoveringThrottled(true)}
+              onMouseEnter={handlePaginationMouseEnter}
             />
           </>
         ) : null}
@@ -226,11 +271,32 @@ export function Banner<T extends IBannerData>({
       showCloseButton,
       showPaginationButton,
       hoverOpacity,
-      setIsHoveringThrottled,
+      handlePaginationMouseEnter,
     ],
   );
 
   const keyExtractor = useCallback((item: T) => item.bannerId, []);
+
+  const handlePointerMoveTrue = useCallback(
+    () => setIsHoveringThrottled(true),
+    [setIsHoveringThrottled],
+  );
+  const handleMouseEnterTrue = useCallback(
+    () => setIsHoveringThrottled(true),
+    [setIsHoveringThrottled],
+  );
+  const handleMouseLeaveFalse = useCallback(
+    () => setIsHoveringThrottled(false),
+    [setIsHoveringThrottled],
+  );
+  const handlePointerEnterTrue = useCallback(
+    () => setIsHoveringThrottled(true),
+    [setIsHoveringThrottled],
+  );
+  const handlePointerLeaveFalse = useCallback(
+    () => setIsHoveringThrottled(false),
+    [setIsHoveringThrottled],
+  );
 
   const isFocused = useIsFocused();
 
@@ -240,9 +306,9 @@ export function Banner<T extends IBannerData>({
 
   return (
     <Stack
-      onPointerMove={() => setIsHoveringThrottled(true)}
-      onMouseEnter={() => setIsHoveringThrottled(true)}
-      onMouseLeave={() => setIsHoveringThrottled(false)}
+      onPointerMove={handlePointerMoveTrue}
+      onMouseEnter={handleMouseEnterTrue}
+      onMouseLeave={handleMouseLeaveFalse}
       w="100%"
     >
       <Swiper
@@ -257,12 +323,8 @@ export function Banner<T extends IBannerData>({
         renderPagination={renderPagination}
         overflow="hidden"
         borderRadius="$3"
-        onPointerEnter={() => {
-          setIsHoveringThrottled(true);
-        }}
-        onPointerLeave={() => {
-          setIsHoveringThrottled(false);
-        }}
+        onPointerEnter={handlePointerEnterTrue}
+        onPointerLeave={handlePointerLeaveFalse}
         {...(props as any)}
       />
     </Stack>

--- a/packages/components/src/composite/Banner/index.tsx
+++ b/packages/components/src/composite/Banner/index.tsx
@@ -117,12 +117,7 @@ function PaginationDot({
     [goToIndex, index],
   );
   return (
-    <Stack
-      key={index}
-      p="$1"
-      borderRadius="$full"
-      onPress={handlePress}
-    >
+    <Stack key={index} p="$1" borderRadius="$full" onPress={handlePress}>
       <Stack
         shadowColor="$blackA1"
         shadowOpacity={0.1}

--- a/packages/components/src/composite/Carousel/PaginationItem.tsx
+++ b/packages/components/src/composite/Carousel/PaginationItem.tsx
@@ -11,6 +11,8 @@ export type IPaginationItemProps = {
   onPress: () => void;
 };
 
+const hoverStyleConst = { bg: '$bgHover' } as const;
+
 export function PaginationItem({
   dotStyle,
   activeDotStyle,
@@ -21,9 +23,7 @@ export function PaginationItem({
       onPress={onPress}
       p="$1"
       borderRadius="$full"
-      hoverStyle={{
-        bg: '$bgHover',
-      }}
+      hoverStyle={hoverStyleConst}
     >
       <YStack
         w="$1.5"

--- a/packages/components/src/composite/Carousel/index.tsx
+++ b/packages/components/src/composite/Carousel/index.tsx
@@ -334,10 +334,7 @@ export function Carousel<T>({
                 {...pagerProps}
               >
                 {data.map((item, index) => (
-                  <Stack
-                    key={index}
-                    style={pageItemStyle}
-                  >
+                  <Stack key={index} style={pageItemStyle}>
                     {renderItem({ item, index })}
                   </Stack>
                 ))}
@@ -369,9 +366,7 @@ export function Carousel<T>({
                     data: item,
                     dotStyle,
                     activeDotStyle:
-                      index === pageIndex
-                        ? defaultActiveDotStyle
-                        : undefined,
+                      index === pageIndex ? defaultActiveDotStyle : undefined,
                     onPress: () => onPressPagination(index),
                   },
                   index,

--- a/packages/components/src/composite/Carousel/index.tsx
+++ b/packages/components/src/composite/Carousel/index.tsx
@@ -285,7 +285,7 @@ export function Carousel<T>({
   const pagerViewStyle = useMemo(
     () => ({
       width: (pageWidthProp || layout.width) as number,
-      height: pageWidthProp ? '100%' : layout.height,
+      height: (pageWidthProp ? '100%' : layout.height) as number | `${number}%`,
     }),
     [pageWidthProp, layout.width, layout.height],
   );

--- a/packages/components/src/composite/Carousel/index.tsx
+++ b/packages/components/src/composite/Carousel/index.tsx
@@ -215,10 +215,13 @@ export function Carousel<T>({
     };
   });
 
-  const onPressPagination = (index: number) => {
-    setPage(index);
-    debouncedSetPageIndex(index);
-  };
+  const onPressPagination = useCallback(
+    (index: number) => {
+      setPage(index);
+      debouncedSetPageIndex(index);
+    },
+    [setPage, debouncedSetPageIndex],
+  );
 
   const onPageSelected = useCallback(
     (e: NativeSyntheticEvent<Readonly<{ position: number }>>) => {
@@ -271,6 +274,35 @@ export function Carousel<T>({
 
   const value = useMemo(() => ({ pageIndex }), [pageIndex]);
 
+  const containerSizeStyle = useMemo(
+    () => ({
+      width: pageWidthProp || layout.width,
+      height: pageWidthProp ? '100%' : layout.height,
+    }),
+    [pageWidthProp, layout.width, layout.height],
+  );
+
+  const pagerViewStyle = useMemo(
+    () => ({
+      width: (pageWidthProp || layout.width) as number,
+      height: pageWidthProp ? '100%' : layout.height,
+    }),
+    [pageWidthProp, layout.width, layout.height],
+  );
+
+  const pageItemStyle = useMemo(
+    () => ({
+      width: pageWidth,
+      height: '100%' as const,
+    }),
+    [pageWidth],
+  );
+
+  const defaultActiveDotStyle = useMemo(
+    () => activeDotStyle || { bg: '$bgPrimary' as const },
+    [activeDotStyle],
+  );
+
   return (
     <CarouselContext.Provider value={value}>
       <YStack userSelect="none" ref={containerRef as any}>
@@ -284,20 +316,14 @@ export function Carousel<T>({
         >
           {pageWidthProp || (layout.width > 0 && layout.height > 0) ? (
             <Stack
-              style={{
-                width: pageWidthProp || layout.width,
-                height: pageWidthProp ? '100%' : layout.height,
-              }}
+              style={containerSizeStyle}
               key={
                 pageWidthProp ? undefined : `${layout.width}-${layout.height}`
               }
             >
               <PagerView
                 ref={pagerRef as RefObject<NativePagerView>}
-                style={{
-                  width: (pageWidthProp || layout.width) as number,
-                  height: pageWidthProp ? '100%' : layout.height,
-                }}
+                style={pagerViewStyle}
                 initialPage={defaultIndex}
                 pageWidth={pageWidth}
                 onPageSelected={onPageSelected}
@@ -310,10 +336,7 @@ export function Carousel<T>({
                 {data.map((item, index) => (
                   <Stack
                     key={index}
-                    style={{
-                      width: pageWidth,
-                      height: '100%',
-                    }}
+                    style={pageItemStyle}
                   >
                     {renderItem({ item, index })}
                   </Stack>
@@ -335,7 +358,7 @@ export function Carousel<T>({
               <IconButton
                 icon="ChevronLeftSmallOutline"
                 variant="tertiary"
-                onPress={() => scrollToPreviousPage()}
+                onPress={scrollToPreviousPage}
                 disabled={data.length <= 1}
               />
             ) : null}
@@ -347,7 +370,7 @@ export function Carousel<T>({
                     dotStyle,
                     activeDotStyle:
                       index === pageIndex
-                        ? activeDotStyle || { bg: '$bgPrimary' }
+                        ? defaultActiveDotStyle
                         : undefined,
                     onPress: () => onPressPagination(index),
                   },
@@ -359,7 +382,7 @@ export function Carousel<T>({
               <IconButton
                 icon="ChevronRightSmallOutline"
                 variant="tertiary"
-                onPress={() => scrollToNextPage()}
+                onPress={scrollToNextPage}
                 disabled={data.length <= 1}
               />
             ) : null}

--- a/packages/components/src/composite/DatePicker/Calendar.tsx
+++ b/packages/components/src/composite/DatePicker/Calendar.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 
 import { useDatePickerContext } from '@rehookify/datepicker';
 
@@ -37,14 +37,24 @@ export const Calendar = memo(
     const media = useMedia();
     const { month, year } = calendars[0];
 
+    const handlePrevYear = useCallback(
+      () => callOnClick(subtractOffset({ years: 1 })),
+      [subtractOffset],
+    );
+
+    const handleNextYear = useCallback(
+      () => callOnClick(addOffset({ years: 1 })),
+      [addOffset],
+    );
+
     if (mode === 'month') {
       return (
         <YStack>
           <CalendarHeader
             month={month}
             year={year}
-            onPrevMonth={() => callOnClick(subtractOffset({ years: 1 }))}
-            onNextMonth={() => callOnClick(addOffset({ years: 1 }))}
+            onPrevMonth={handlePrevYear}
+            onNextMonth={handleNextYear}
             mode={mode}
           />
           <MonthGrid onMonthSelect={onMonthSelect} />

--- a/packages/components/src/composite/DatePicker/CalendarHeader.tsx
+++ b/packages/components/src/composite/DatePicker/CalendarHeader.tsx
@@ -6,6 +6,9 @@ import { SizableText, Stack, XStack } from '../../primitives';
 
 import type { ICalendarHeaderProps } from './type';
 
+const mdStyle = { marginTop: '$2' } as const;
+const hoverSubduedStyle = { color: '$textSubdued' } as const;
+
 function NavSpacer() {
   return <Stack width="$10" height="$6" />;
 }
@@ -38,7 +41,7 @@ export const CalendarHeader = memo(
     const yearClickable = showMonthYear && onYearClick;
 
     return (
-      <Stack paddingHorizontal="$2" marginBottom="$3" $md={{ marginTop: '$2' }}>
+      <Stack paddingHorizontal="$2" marginBottom="$3" $md={mdStyle}>
         {/* Title - absolute center */}
         <XStack
           position="absolute"
@@ -59,7 +62,7 @@ export const CalendarHeader = memo(
               userSelect="none"
               pointerEvents="auto"
               onPress={onMonthClick}
-              hoverStyle={onMonthClick ? { color: '$textSubdued' } : undefined}
+              hoverStyle={onMonthClick ? hoverSubduedStyle : undefined}
             >
               {month}
             </SizableText>
@@ -71,7 +74,7 @@ export const CalendarHeader = memo(
             userSelect="none"
             pointerEvents="auto"
             onPress={yearClickable ? onYearClick : undefined}
-            hoverStyle={yearClickable ? { color: '$textSubdued' } : undefined}
+            hoverStyle={yearClickable ? hoverSubduedStyle : undefined}
           >
             {year}
           </SizableText>

--- a/packages/components/src/composite/DatePicker/CalendarPanel.tsx
+++ b/packages/components/src/composite/DatePicker/CalendarPanel.tsx
@@ -153,9 +153,7 @@ export function CalendarPanel({
               ? setViewModeToMonth
               : undefined
           }
-          onYearClick={
-            !isRangeDualPanel ? setViewModeToYear : undefined
-          }
+          onYearClick={!isRangeDualPanel ? setViewModeToYear : undefined}
           mode={mode}
         />
       )}
@@ -168,16 +166,10 @@ export function CalendarPanel({
         />
       ) : null}
       {viewMode === 'month' ? (
-        <MonthGrid
-          onSelect={setViewModeToDay}
-          onMonthSelect={onMonthSelect}
-        />
+        <MonthGrid onSelect={setViewModeToDay} onMonthSelect={onMonthSelect} />
       ) : null}
       {viewMode === 'year' ? (
-        <YearGrid
-          onSelect={setViewModeToMonth}
-          onYearSelect={onYearSelect}
-        />
+        <YearGrid onSelect={setViewModeToMonth} onYearSelect={onYearSelect} />
       ) : null}
     </YStack>
   );

--- a/packages/components/src/composite/DatePicker/CalendarPanel.tsx
+++ b/packages/components/src/composite/DatePicker/CalendarPanel.tsx
@@ -4,6 +4,9 @@ import { useDatePickerContext } from '@rehookify/datepicker';
 
 import { YStack } from '../../primitives';
 
+const dualPanelStyle = { flex: 1, flexBasis: 0 } as const;
+const emptyStyle = {} as const;
+
 import { CalendarHeader } from './CalendarHeader';
 import { DayGrid } from './DayGrid';
 import { MonthGrid } from './MonthGrid';
@@ -88,6 +91,9 @@ export function CalendarPanel({
   const isRangeDualPanel = mode === 'range' && isDualPanel;
 
   const [viewMode, setViewMode] = useState<IViewMode>('day');
+  const setViewModeToDay = useCallback(() => setViewMode('day'), []);
+  const setViewModeToMonth = useCallback(() => setViewMode('month'), []);
+  const setViewModeToYear = useCallback(() => setViewMode('year'), []);
 
   const {
     isPrevDisabled,
@@ -123,7 +129,7 @@ export function CalendarPanel({
   const showNextNav = showNav === 'both' || showNav === 'next';
 
   return (
-    <YStack {...(isDualPanel ? { flex: 1, flexBasis: 0 } : {})}>
+    <YStack {...(isDualPanel ? dualPanelStyle : emptyStyle)}>
       {viewMode === 'year' ? (
         <YearRangeHeader />
       ) : (
@@ -144,11 +150,11 @@ export function CalendarPanel({
           isNextYearDisabled={showNextNav ? isNextYearDisabled : undefined}
           onMonthClick={
             viewMode === 'day' && !isRangeDualPanel
-              ? () => setViewMode('month')
+              ? setViewModeToMonth
               : undefined
           }
           onYearClick={
-            !isRangeDualPanel ? () => setViewMode('year') : undefined
+            !isRangeDualPanel ? setViewModeToYear : undefined
           }
           mode={mode}
         />
@@ -163,13 +169,13 @@ export function CalendarPanel({
       ) : null}
       {viewMode === 'month' ? (
         <MonthGrid
-          onSelect={() => setViewMode('day')}
+          onSelect={setViewModeToDay}
           onMonthSelect={onMonthSelect}
         />
       ) : null}
       {viewMode === 'year' ? (
         <YearGrid
-          onSelect={() => setViewMode('month')}
+          onSelect={setViewModeToMonth}
           onYearSelect={onYearSelect}
         />
       ) : null}

--- a/packages/components/src/composite/DatePicker/CalendarPanel.tsx
+++ b/packages/components/src/composite/DatePicker/CalendarPanel.tsx
@@ -4,9 +4,6 @@ import { useDatePickerContext } from '@rehookify/datepicker';
 
 import { YStack } from '../../primitives';
 
-const dualPanelStyle = { flex: 1, flexBasis: 0 } as const;
-const emptyStyle = {} as const;
-
 import { CalendarHeader } from './CalendarHeader';
 import { DayGrid } from './DayGrid';
 import { MonthGrid } from './MonthGrid';
@@ -14,6 +11,9 @@ import { callOnClick } from './utils';
 import { YearGrid, YearRangeHeader } from './YearGrid';
 
 import type { DatePickerMode } from './type';
+
+const dualPanelStyle = { flex: 1, flexBasis: 0 } as const;
+const emptyStyle = {} as const;
 
 type IViewMode = 'day' | 'month' | 'year';
 

--- a/packages/components/src/composite/DatePicker/DatePickerTrigger.tsx
+++ b/packages/components/src/composite/DatePicker/DatePickerTrigger.tsx
@@ -105,6 +105,20 @@ export const DatePickerTrigger = memo(
       [onClear],
     );
 
+    const addOns = useMemo(
+      () => [
+        hasValue && onClear
+          ? {
+              iconName: 'XCircleOutline' as const,
+              onPress: handleClearPress,
+            }
+          : {
+              iconName: 'CalendarOutline' as const,
+            },
+      ],
+      [hasValue, onClear, handleClearPress],
+    );
+
     return (
       <Input
         value={hasValue ? displayValue : ''}
@@ -112,16 +126,7 @@ export const DatePickerTrigger = memo(
         placeholder={placeholder || displayValue}
         readonly
         size="small"
-        addOns={[
-          hasValue && onClear
-            ? {
-                iconName: 'XCircleOutline' as const,
-                onPress: handleClearPress,
-              }
-            : {
-                iconName: 'CalendarOutline' as const,
-              },
-        ]}
+        addOns={addOns}
       />
     );
   },

--- a/packages/components/src/composite/DatePicker/DayCell.tsx
+++ b/packages/components/src/composite/DatePicker/DayCell.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 
 import { SizableText, Stack } from '../../primitives';
 
@@ -8,22 +8,11 @@ const CELL_SIZE = '$10'; // 40px
 
 export const DayCell = memo(
   ({ day, onPress, hideOutOfMonth, fullWidth }: IDayCellProps) => {
-    const handlePress = () => {
+    const handlePress = useCallback(() => {
       if (!day.disabled) {
         onPress(day.date);
       }
-    };
-
-    if (hideOutOfMonth && !day.inCurrentMonth) {
-      return (
-        <Stack
-          flexBasis="14.28%"
-          flexGrow={0}
-          flexShrink={0}
-          height={CELL_SIZE}
-        />
-      );
-    }
+    }, [day.disabled, day.date, onPress]);
 
     const isSameDayRange =
       day.inCurrentMonth && day.range === 'range-start range-end';
@@ -67,6 +56,27 @@ export const DayCell = memo(
           : '$text';
     /* eslint-enable no-nested-ternary */
 
+    const hoverStyleValue = useMemo(
+      () =>
+        day.disabled
+          ? {}
+          : {
+              bg: isSelected ? innerBg : '$bgHover',
+            },
+      [day.disabled, isSelected, innerBg],
+    );
+
+    if (hideOutOfMonth && !day.inCurrentMonth) {
+      return (
+        <Stack
+          flexBasis="14.28%"
+          flexGrow={0}
+          flexShrink={0}
+          height={CELL_SIZE}
+        />
+      );
+    }
+
     return (
       <Stack
         flexBasis="14.28%"
@@ -93,13 +103,7 @@ export const DayCell = memo(
             borderBottomLeftRadius: 0,
           })}
           bg={innerBg}
-          hoverStyle={
-            day.disabled
-              ? {}
-              : {
-                  bg: isSelected ? innerBg : '$bgHover',
-                }
-          }
+          hoverStyle={hoverStyleValue}
           onPress={handlePress}
         >
           <SizableText

--- a/packages/components/src/composite/DatePicker/DayGrid.tsx
+++ b/packages/components/src/composite/DatePicker/DayGrid.tsx
@@ -1,11 +1,54 @@
-import { useCallback } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 
+import type { DPDay } from '@rehookify/datepicker';
 import { useDatePickerContext } from '@rehookify/datepicker';
 
 import { SizableText, Stack, YStack } from '../../primitives';
 
 import { DayCell } from './DayCell';
 import { callOnClick } from './utils';
+
+const DayCellWrapper = memo(
+  ({
+    dpDay,
+    disabled,
+    hideOutOfMonth,
+    fullWidth,
+    onPress,
+  }: {
+    dpDay: DPDay;
+    disabled: boolean;
+    hideOutOfMonth?: boolean;
+    fullWidth?: boolean;
+    onPress: (date: string) => void;
+  }) => {
+    const dateStr = dpDay.$date.toString();
+    const day = useMemo(
+      () => ({
+        day: dpDay.$date.getDate().toString(),
+        date: dateStr,
+        active: dpDay.now,
+        inCurrentMonth: dpDay.inCurrentMonth,
+        selected: dpDay.selected,
+        disabled,
+        range: dpDay.range || undefined,
+      }),
+      [dateStr, dpDay.$date, dpDay.now, dpDay.inCurrentMonth, dpDay.selected, dpDay.range, disabled],
+    );
+
+    return (
+      <DayCell
+        key={dateStr}
+        hideOutOfMonth={hideOutOfMonth}
+        fullWidth={fullWidth}
+        day={day}
+        onPress={onPress}
+      />
+    );
+  },
+);
+
+DayCellWrapper.displayName = 'DayCellWrapper';
 
 export function DayGrid({
   calendarIndex,
@@ -53,26 +96,16 @@ export function DayGrid({
         ))}
       </Stack>
       <Stack flexWrap="wrap" flexDirection="row" rowGap="$1">
-        {cal.days.map((day) => {
-          const dateStr = day.$date.toString();
-          return (
-            <DayCell
-              key={dateStr}
-              hideOutOfMonth={hideOutOfMonth}
-              fullWidth={fullWidth}
-              day={{
-                day: day.$date.getDate().toString(),
-                date: dateStr,
-                active: day.now,
-                inCurrentMonth: day.inCurrentMonth,
-                selected: day.selected,
-                disabled: dayButton(day).disabled || false,
-                range: day.range || undefined,
-              }}
-              onPress={handleDayPress}
-            />
-          );
-        })}
+        {cal.days.map((day) => (
+          <DayCellWrapper
+            key={day.$date.toString()}
+            dpDay={day}
+            disabled={dayButton(day).disabled || false}
+            hideOutOfMonth={hideOutOfMonth}
+            fullWidth={fullWidth}
+            onPress={handleDayPress}
+          />
+        ))}
       </Stack>
     </YStack>
   );

--- a/packages/components/src/composite/DatePicker/DayGrid.tsx
+++ b/packages/components/src/composite/DatePicker/DayGrid.tsx
@@ -33,7 +33,15 @@ const DayCellWrapper = memo(
         disabled,
         range: dpDay.range || undefined,
       }),
-      [dateStr, dpDay.$date, dpDay.now, dpDay.inCurrentMonth, dpDay.selected, dpDay.range, disabled],
+      [
+        dateStr,
+        dpDay.$date,
+        dpDay.now,
+        dpDay.inCurrentMonth,
+        dpDay.selected,
+        dpDay.range,
+        disabled,
+      ],
     );
 
     return (

--- a/packages/components/src/composite/DatePicker/DayGrid.tsx
+++ b/packages/components/src/composite/DatePicker/DayGrid.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import { useDatePickerContext } from '@rehookify/datepicker';
 
 import { SizableText, Stack, YStack } from '../../primitives';
@@ -18,6 +20,16 @@ export function DayGrid({
   const { calendars, weekDays } = data;
   const { dayButton } = propGetters;
   const cal = calendars[calendarIndex];
+
+  const handleDayPress = useCallback(
+    (dateStr: string) => {
+      const matchedDay = cal?.days.find((d) => d.$date.toString() === dateStr);
+      if (matchedDay) {
+        callOnClick(dayButton(matchedDay));
+      }
+    },
+    [cal, dayButton],
+  );
 
   if (!cal) return null;
 
@@ -57,7 +69,7 @@ export function DayGrid({
                 disabled: dayButton(day).disabled || false,
                 range: day.range || undefined,
               }}
-              onPress={() => callOnClick(dayButton(day))}
+              onPress={handleDayPress}
             />
           );
         })}

--- a/packages/components/src/composite/DatePicker/DayGrid.tsx
+++ b/packages/components/src/composite/DatePicker/DayGrid.tsx
@@ -1,7 +1,6 @@
 import { memo, useCallback, useMemo } from 'react';
 
-import type { DPDay } from '@rehookify/datepicker';
-import { useDatePickerContext } from '@rehookify/datepicker';
+import { type DPDay, useDatePickerContext } from '@rehookify/datepicker';
 
 import { SizableText, Stack, YStack } from '../../primitives';
 

--- a/packages/components/src/composite/DatePicker/MonthGrid.tsx
+++ b/packages/components/src/composite/DatePicker/MonthGrid.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useMemo } from 'react';
 
+import type { DPMonth } from '@rehookify/datepicker';
 import { useDatePickerContext } from '@rehookify/datepicker';
 
 import { SizableText, Stack } from '../../primitives';
@@ -14,8 +15,8 @@ const MonthCell = memo(
     month: m,
     onPress,
   }: {
-    month: { $date: Date; month: string; active: boolean };
-    onPress: (m: { $date: Date; month: string; active: boolean }) => void;
+    month: DPMonth;
+    onPress: (m: DPMonth) => void;
   }) => {
     const handlePress = useCallback(() => {
       onPress(m);

--- a/packages/components/src/composite/DatePicker/MonthGrid.tsx
+++ b/packages/components/src/composite/DatePicker/MonthGrid.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback } from 'react';
 
 import type { DPMonth } from '@rehookify/datepicker';
 import { useDatePickerContext } from '@rehookify/datepicker';

--- a/packages/components/src/composite/DatePicker/MonthGrid.tsx
+++ b/packages/components/src/composite/DatePicker/MonthGrid.tsx
@@ -1,7 +1,6 @@
 import { memo, useCallback } from 'react';
 
-import type { DPMonth } from '@rehookify/datepicker';
-import { useDatePickerContext } from '@rehookify/datepicker';
+import { type DPMonth, useDatePickerContext } from '@rehookify/datepicker';
 
 import { SizableText, Stack } from '../../primitives';
 

--- a/packages/components/src/composite/DatePicker/MonthGrid.tsx
+++ b/packages/components/src/composite/DatePicker/MonthGrid.tsx
@@ -1,8 +1,51 @@
+import { memo, useCallback, useMemo } from 'react';
+
 import { useDatePickerContext } from '@rehookify/datepicker';
 
 import { SizableText, Stack } from '../../primitives';
 
 import { callOnClick } from './utils';
+
+const activeHoverStyle = { bg: '$bgPrimary' } as const;
+const inactiveHoverStyle = { bg: '$bgHover' } as const;
+
+const MonthCell = memo(
+  ({
+    month: m,
+    onPress,
+  }: {
+    month: { $date: Date; month: string; active: boolean };
+    onPress: (m: { $date: Date; month: string; active: boolean }) => void;
+  }) => {
+    const handlePress = useCallback(() => {
+      onPress(m);
+    }, [onPress, m]);
+
+    return (
+      <Stack
+        flexBasis="31%"
+        flexGrow={1}
+        height="$11"
+        alignItems="center"
+        justifyContent="center"
+        borderRadius="$2"
+        bg={m.active ? '$bgPrimary' : 'transparent'}
+        hoverStyle={m.active ? activeHoverStyle : inactiveHoverStyle}
+        onPress={handlePress}
+      >
+        <SizableText
+          size="$bodyMd"
+          color={m.active ? '$textInverse' : '$text'}
+          userSelect="none"
+        >
+          {m.month}
+        </SizableText>
+      </Stack>
+    );
+  },
+);
+
+MonthCell.displayName = 'MonthCell';
 
 export function MonthGrid({
   onSelect,
@@ -15,35 +58,23 @@ export function MonthGrid({
   const { months } = data;
   const { monthButton } = propGetters;
 
+  const handleMonthPress = useCallback(
+    (m: (typeof months)[number]) => {
+      callOnClick(monthButton(m));
+      onMonthSelect?.(m.$date);
+      onSelect?.();
+    },
+    [monthButton, onMonthSelect, onSelect],
+  );
+
   return (
     <Stack flexWrap="wrap" flexDirection="row" gap="$2" padding="$2">
       {months.map((m) => (
-        <Stack
+        <MonthCell
           key={m.$date.toString()}
-          flexBasis="31%"
-          flexGrow={1}
-          height="$11"
-          alignItems="center"
-          justifyContent="center"
-          borderRadius="$2"
-          bg={m.active ? '$bgPrimary' : 'transparent'}
-          hoverStyle={{
-            bg: m.active ? '$bgPrimary' : '$bgHover',
-          }}
-          onPress={() => {
-            callOnClick(monthButton(m));
-            onMonthSelect?.(m.$date);
-            onSelect?.();
-          }}
-        >
-          <SizableText
-            size="$bodyMd"
-            color={m.active ? '$textInverse' : '$text'}
-            userSelect="none"
-          >
-            {m.month}
-          </SizableText>
-        </Stack>
+          month={m}
+          onPress={handleMonthPress}
+        />
       ))}
     </Stack>
   );

--- a/packages/components/src/composite/DatePicker/PresetsSidebar.tsx
+++ b/packages/components/src/composite/DatePicker/PresetsSidebar.tsx
@@ -13,15 +13,25 @@ function isSameDay(a: Date | null, b: Date | null): boolean {
   );
 }
 
+const activeHoverStyle = { backgroundColor: '$bgActive' } as const;
+const inactiveHoverStyle = { backgroundColor: '$bgHover' } as const;
+const pressStyleConst = { backgroundColor: '$bgActive' } as const;
+
 function PresetItem({
   label,
   isActive,
+  preset,
   onPress,
 }: {
   label: string;
   isActive: boolean;
-  onPress: () => void;
+  preset: IDateRangePreset;
+  onPress: (preset: IDateRangePreset) => void;
 }) {
+  const handlePress = useCallback(() => {
+    onPress(preset);
+  }, [onPress, preset]);
+
   return (
     <Stack
       paddingHorizontal="$3"
@@ -29,9 +39,9 @@ function PresetItem({
       borderRadius="$2"
       cursor="pointer"
       backgroundColor={isActive ? '$bgActive' : 'transparent'}
-      hoverStyle={{ backgroundColor: isActive ? '$bgActive' : '$bgHover' }}
-      pressStyle={{ backgroundColor: '$bgActive' }}
-      onPress={onPress}
+      hoverStyle={isActive ? activeHoverStyle : inactiveHoverStyle}
+      pressStyle={pressStyleConst}
+      onPress={handlePress}
     >
       <SizableText
         size="$bodyMd"
@@ -85,7 +95,8 @@ export const PresetsSidebar = memo(
             key={preset.label}
             label={preset.label}
             isActive={index === activeIndex}
-            onPress={() => handlePress(preset)}
+            preset={preset}
+            onPress={handlePress}
           />
         ))}
       </YStack>

--- a/packages/components/src/composite/DatePicker/YearGrid.tsx
+++ b/packages/components/src/composite/DatePicker/YearGrid.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 
 import { useDatePickerContext } from '@rehookify/datepicker';
 
@@ -6,6 +6,49 @@ import { SizableText, Stack } from '../../primitives';
 
 import { CalendarHeader } from './CalendarHeader';
 import { callOnClick } from './utils';
+
+const activeHoverStyle = { bg: '$bgPrimary' } as const;
+const inactiveHoverStyle = { bg: '$bgHover' } as const;
+
+const YearCell = memo(
+  ({
+    year,
+    isActive,
+    onPress,
+  }: {
+    year: { $date: Date; year: number };
+    isActive: boolean;
+    onPress: (y: { $date: Date; year: number }) => void;
+  }) => {
+    const handlePress = useCallback(() => {
+      onPress(year);
+    }, [onPress, year]);
+
+    return (
+      <Stack
+        flexBasis="31%"
+        flexGrow={1}
+        height="$11"
+        alignItems="center"
+        justifyContent="center"
+        borderRadius="$2"
+        bg={isActive ? '$bgPrimary' : 'transparent'}
+        hoverStyle={isActive ? activeHoverStyle : inactiveHoverStyle}
+        onPress={handlePress}
+      >
+        <SizableText
+          size="$bodyMd"
+          color={isActive ? '$textInverse' : '$text'}
+          userSelect="none"
+        >
+          {year.year}
+        </SizableText>
+      </Stack>
+    );
+  },
+);
+
+YearCell.displayName = 'YearCell';
 
 export function YearGrid({
   onSelect,
@@ -19,37 +62,26 @@ export function YearGrid({
   const { yearButton } = propGetters;
   const selectedYear = calendars[0].year;
 
+  const handleYearPress = useCallback(
+    (y: { $date: Date; year: number }) => {
+      callOnClick(yearButton(y as any));
+      onYearSelect?.(y.year);
+      onSelect?.();
+    },
+    [yearButton, onYearSelect, onSelect],
+  );
+
   return (
     <Stack flexWrap="wrap" flexDirection="row" gap="$2" padding="$2">
       {years.map((y) => {
         const isActive = y.year === Number(selectedYear);
         return (
-          <Stack
+          <YearCell
             key={y.$date.toString()}
-            flexBasis="31%"
-            flexGrow={1}
-            height="$11"
-            alignItems="center"
-            justifyContent="center"
-            borderRadius="$2"
-            bg={isActive ? '$bgPrimary' : 'transparent'}
-            hoverStyle={{
-              bg: isActive ? '$bgPrimary' : '$bgHover',
-            }}
-            onPress={() => {
-              callOnClick(yearButton(y));
-              onYearSelect?.(y.year);
-              onSelect?.();
-            }}
-          >
-            <SizableText
-              size="$bodyMd"
-              color={isActive ? '$textInverse' : '$text'}
-              userSelect="none"
-            >
-              {y.year}
-            </SizableText>
-          </Stack>
+            year={y}
+            isActive={isActive}
+            onPress={handleYearPress}
+          />
         );
       })}
     </Stack>
@@ -66,12 +98,22 @@ export function YearRangeHeader() {
     [years],
   );
 
+  const handlePrevYears = useCallback(
+    () => callOnClick(previousYearsButton()),
+    [previousYearsButton],
+  );
+
+  const handleNextYears = useCallback(
+    () => callOnClick(nextYearsButton()),
+    [nextYearsButton],
+  );
+
   return (
     <CalendarHeader
       month=""
       year={yearRange}
-      onPrevMonth={() => callOnClick(previousYearsButton())}
-      onNextMonth={() => callOnClick(nextYearsButton())}
+      onPrevMonth={handlePrevYears}
+      onNextMonth={handleNextYears}
       mode="year"
     />
   );

--- a/packages/components/src/composite/DatePicker/index.tsx
+++ b/packages/components/src/composite/DatePicker/index.tsx
@@ -163,6 +163,7 @@ function renderPickerTrigger({
 }
 
 const SINGLE_PANEL_PROPS = { w: 300, minWidth: 300 } as const;
+const GTMD_PADDING_4 = { padding: '$4' } as const;
 
 function BasicDatePicker({
   value,
@@ -286,7 +287,7 @@ function RangePickerContent({
           onSelect={handlePresetSelect}
         />
       ) : null}
-      <YStack padding="$3" minWidth={280} flex={1} $gtMd={{ padding: '$4' }}>
+      <YStack padding="$3" minWidth={280} flex={1} $gtMd={GTMD_PADDING_4}>
         <DatePickerProvider config={config}>
           <Calendar
             mode="range"
@@ -393,7 +394,16 @@ function RangePicker({
         close={close}
       />
     ),
-    [config, minDate, maxDate, showPreviousMonth, presets, value, onChange, close],
+    [
+      config,
+      minDate,
+      maxDate,
+      showPreviousMonth,
+      presets,
+      value,
+      onChange,
+      close,
+    ],
   );
 
   return (
@@ -471,12 +481,28 @@ function YearPicker({
     [onChange, close],
   );
 
+  const yearFloatingPanelProps = useMemo(
+    () => ({ ...SINGLE_PANEL_PROPS, ...floatingPanelProps }),
+    [floatingPanelProps],
+  );
+
+  const yearContent = useMemo(
+    () => (
+      <YStack padding="$3" minWidth={280}>
+        <DatePickerProvider config={config}>
+          <Calendar mode="year" onYearSelect={handleYearSelect} />
+        </DatePickerProvider>
+      </YStack>
+    ),
+    [config, handleYearSelect],
+  );
+
   return (
     <PickerPopover
       title={title}
       isOpen={isOpen}
       onOpenChange={handleOpenChange}
-      floatingPanelProps={{ ...SINGLE_PANEL_PROPS, ...floatingPanelProps }}
+      floatingPanelProps={yearFloatingPanelProps}
       sheetProps={sheetProps}
       renderTrigger={renderPickerTrigger({
         renderTrigger,
@@ -486,13 +512,7 @@ function YearPicker({
         disabled,
         onClear: () => onChange?.(null),
       })}
-      renderContent={
-        <YStack padding="$3" minWidth={280}>
-          <DatePickerProvider config={config}>
-            <Calendar mode="year" onYearSelect={handleYearSelect} />
-          </DatePickerProvider>
-        </YStack>
-      }
+      renderContent={yearContent}
     />
   );
 }
@@ -552,12 +572,28 @@ function MonthPicker({
     [onChange, close],
   );
 
+  const monthFloatingPanelProps = useMemo(
+    () => ({ ...SINGLE_PANEL_PROPS, ...floatingPanelProps }),
+    [floatingPanelProps],
+  );
+
+  const monthContent = useMemo(
+    () => (
+      <YStack padding="$3" minWidth={280}>
+        <DatePickerProvider config={config}>
+          <Calendar mode="month" onMonthSelect={handleMonthSelect} />
+        </DatePickerProvider>
+      </YStack>
+    ),
+    [config, handleMonthSelect],
+  );
+
   return (
     <PickerPopover
       title={title}
       isOpen={isOpen}
       onOpenChange={handleOpenChange}
-      floatingPanelProps={{ ...SINGLE_PANEL_PROPS, ...floatingPanelProps }}
+      floatingPanelProps={monthFloatingPanelProps}
       sheetProps={sheetProps}
       renderTrigger={renderPickerTrigger({
         renderTrigger,
@@ -567,13 +603,7 @@ function MonthPicker({
         disabled,
         onClear: () => onChange?.(null),
       })}
-      renderContent={
-        <YStack padding="$3" minWidth={280}>
-          <DatePickerProvider config={config}>
-            <Calendar mode="month" onMonthSelect={handleMonthSelect} />
-          </DatePickerProvider>
-        </YStack>
-      }
+      renderContent={monthContent}
     />
   );
 }
@@ -620,12 +650,28 @@ function MultiSelectPicker({
     [value, handleDatesChange, minDate, maxDate, locale],
   );
 
+  const multiFloatingPanelProps = useMemo(
+    () => ({ ...SINGLE_PANEL_PROPS, ...floatingPanelProps }),
+    [floatingPanelProps],
+  );
+
+  const multiContent = useMemo(
+    () => (
+      <YStack padding="$3" minWidth={280}>
+        <DatePickerProvider config={config}>
+          <Calendar mode="multiple" />
+        </DatePickerProvider>
+      </YStack>
+    ),
+    [config],
+  );
+
   return (
     <PickerPopover
       title={title}
       isOpen={isOpen}
       onOpenChange={handleOpenChange}
-      floatingPanelProps={{ ...SINGLE_PANEL_PROPS, ...floatingPanelProps }}
+      floatingPanelProps={multiFloatingPanelProps}
       sheetProps={sheetProps}
       renderTrigger={renderPickerTrigger({
         renderTrigger,
@@ -635,13 +681,7 @@ function MultiSelectPicker({
         disabled,
         onClear: () => onChange?.([]),
       })}
-      renderContent={
-        <YStack padding="$3" minWidth={280}>
-          <DatePickerProvider config={config}>
-            <Calendar mode="multiple" />
-          </DatePickerProvider>
-        </YStack>
-      }
+      renderContent={multiContent}
     />
   );
 }

--- a/packages/components/src/composite/DatePicker/index.tsx
+++ b/packages/components/src/composite/DatePicker/index.tsx
@@ -211,12 +211,28 @@ function BasicDatePicker({
     [selectedDates, handleDatesChange, minDate, maxDate, locale],
   );
 
+  const mergedFloatingPanelProps = useMemo(
+    () => ({ ...SINGLE_PANEL_PROPS, ...floatingPanelProps }),
+    [floatingPanelProps],
+  );
+
+  const pickerContent = useMemo(
+    () => (
+      <YStack padding="$3" minWidth={280}>
+        <DatePickerProvider config={config}>
+          <Calendar mode="date" />
+        </DatePickerProvider>
+      </YStack>
+    ),
+    [config],
+  );
+
   return (
     <PickerPopover
       title={title}
       isOpen={isOpen}
       onOpenChange={handleOpenChange}
-      floatingPanelProps={{ ...SINGLE_PANEL_PROPS, ...floatingPanelProps }}
+      floatingPanelProps={mergedFloatingPanelProps}
       sheetProps={sheetProps}
       renderTrigger={renderPickerTrigger({
         renderTrigger,
@@ -226,13 +242,7 @@ function BasicDatePicker({
         disabled,
         onClear: () => onChange?.(null),
       })}
-      renderContent={
-        <YStack padding="$3" minWidth={280}>
-          <DatePickerProvider config={config}>
-            <Calendar mode="date" />
-          </DatePickerProvider>
-        </YStack>
-      }
+      renderContent={pickerContent}
     />
   );
 }
@@ -361,16 +371,37 @@ function RangePicker({
 
   const panelWidth = hasPresets ? 780 : 624;
 
+  const rangeFloatingPanelProps = useMemo(
+    () => ({
+      w: panelWidth,
+      maxWidth: panelWidth,
+      ...floatingPanelProps,
+    }),
+    [panelWidth, floatingPanelProps],
+  );
+
+  const rangeContent = useMemo(
+    () => (
+      <RangePickerContent
+        config={config}
+        minDate={minDate}
+        maxDate={maxDate}
+        showPreviousMonth={showPreviousMonth}
+        presets={presets}
+        value={value}
+        onChange={onChange}
+        close={close}
+      />
+    ),
+    [config, minDate, maxDate, showPreviousMonth, presets, value, onChange, close],
+  );
+
   return (
     <PickerPopover
       title={title}
       isOpen={isOpen}
       onOpenChange={handleOpenChange}
-      floatingPanelProps={{
-        w: panelWidth,
-        maxWidth: panelWidth,
-        ...floatingPanelProps,
-      }}
+      floatingPanelProps={rangeFloatingPanelProps}
       sheetProps={sheetProps}
       renderTrigger={renderPickerTrigger({
         renderTrigger,
@@ -380,18 +411,7 @@ function RangePicker({
         disabled,
         onClear: () => onChange?.({ start: null, end: null }),
       })}
-      renderContent={
-        <RangePickerContent
-          config={config}
-          minDate={minDate}
-          maxDate={maxDate}
-          showPreviousMonth={showPreviousMonth}
-          presets={presets}
-          value={value}
-          onChange={onChange}
-          close={close}
-        />
-      }
+      renderContent={rangeContent}
     />
   );
 }

--- a/packages/components/src/composite/DatePicker/index.tsx
+++ b/packages/components/src/composite/DatePicker/index.tsx
@@ -163,7 +163,7 @@ function renderPickerTrigger({
 }
 
 const SINGLE_PANEL_PROPS = { w: 300, minWidth: 300 } as const;
-const GTMD_PADDING_4 = { padding: '$4' } as const;
+const GT_MD_PADDING_4 = { padding: '$4' } as const;
 
 function BasicDatePicker({
   value,
@@ -287,7 +287,7 @@ function RangePickerContent({
           onSelect={handlePresetSelect}
         />
       ) : null}
-      <YStack padding="$3" minWidth={280} flex={1} $gtMd={GTMD_PADDING_4}>
+      <YStack padding="$3" minWidth={280} flex={1} $gtMd={GT_MD_PADDING_4}>
         <DatePickerProvider config={config}>
           <Calendar
             mode="range"

--- a/packages/components/src/composite/Dialog/Content.native.tsx
+++ b/packages/components/src/composite/Dialog/Content.native.tsx
@@ -9,6 +9,7 @@ import { Spinner, Stack, YStack } from '../../primitives';
 import type { IDialogContentProps } from './type';
 import type { LayoutChangeEvent, View } from 'react-native';
 
+const exitStyleConst = { opacity: 0 } as const;
 const MAX_ANIMATION_DURATION = 550;
 export function Content({
   children,
@@ -132,9 +133,7 @@ export function Content({
                 alignContent="center"
                 justifyContent="center"
                 flex={1}
-                exitStyle={{
-                  opacity: 0,
-                }}
+                exitStyle={exitStyleConst}
               >
                 <Spinner size="large" />
               </Stack>

--- a/packages/components/src/composite/Dialog/Footer.tsx
+++ b/packages/components/src/composite/Dialog/Footer.tsx
@@ -20,6 +20,8 @@ import { useDialogInstance } from './hooks';
 
 import type { IDialogFooterProps } from './type';
 
+const mdSizeLargeStyle = { size: 'large' } as any;
+
 const useConfirmButtonDisabled = (
   props: IDialogFooterProps['confirmButtonProps'],
 ) => {
@@ -144,11 +146,7 @@ export function Footer(props: IDialogFooterProps) {
             <Button
               flexGrow={1}
               flexBasis={0}
-              $md={
-                {
-                  size: 'large',
-                } as any
-              }
+              $md={mdSizeLargeStyle}
               onPress={onCancel}
               {...cancelButtonProps}
             >
@@ -163,11 +161,7 @@ export function Footer(props: IDialogFooterProps) {
               flexBasis={0}
               loading={confirmLoading}
               disabled={confirmButtonDisabled}
-              $md={
-                {
-                  size: 'large',
-                } as any
-              }
+              $md={mdSizeLargeStyle}
               {...restConfirmButtonProps}
               onPress={onConfirmWithLoading}
             >

--- a/packages/components/src/composite/Dialog/Header.tsx
+++ b/packages/components/src/composite/Dialog/Header.tsx
@@ -12,6 +12,8 @@ import type { IDialogHeaderContextType, IDialogHeaderProps } from './type';
 import type { IRichSizeableTextProps } from '../../content/RichSizeableText';
 import type { ColorTokens, ISizableTextProps } from '../../primitives';
 
+const closeButtonIconProps = { color: '$iconSubdued' } as const;
+
 export const DialogHeaderContext = createContext<IDialogHeaderContextType>(
   {} as IDialogHeaderContextType,
 );
@@ -154,9 +156,7 @@ function BasicDialogHeader({
           right="$5"
           top="$5"
           icon="CrossedSmallOutline"
-          iconProps={{
-            color: '$iconSubdued',
-          }}
+          iconProps={closeButtonIconProps}
           size="small"
           hotKey
           onPress={onClose}

--- a/packages/components/src/composite/Dialog/index.tsx
+++ b/packages/components/src/composite/Dialog/index.tsx
@@ -597,6 +597,7 @@ function dialogShow({
           resolve();
         }, 300);
       });
+  // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
   const isExist = () => !!instanceRef?.current;
   const element = (() => {
     if (dialogContainer) {
@@ -677,6 +678,7 @@ const dialogDebugMessage = (
     }
     return stringUtils.stableStringify(props.debugMessage, null, 4);
   })();
+  // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
   const copyContent = async () => {
     await setStringAsync(dataContent);
     console.log('dialogDebugMessage: object >>> ', props.debugMessage);

--- a/packages/components/src/composite/Dialog/index.tsx
+++ b/packages/components/src/composite/Dialog/index.tsx
@@ -383,31 +383,21 @@ function DialogFrame({
               onEscapeKeyDown={handleEscapeKeyDown as any}
               key="content"
               testID={testID}
-              animateOnly={['transform', 'opacity']}
-              animation={[
-                'quick',
-                {
-                  opacity: {
-                    overshootClamping: true,
-                  },
-                },
-              ]}
-              enterStyle={{ opacity: 0, scale: 0.85 }}
-              exitStyle={{ opacity: 0, scale: 0.85 }}
+              animateOnly={DIALOG_ANIMATE_ONLY_TRANSFORM_OPACITY}
+              animation={DIALOG_CONTENT_ANIMATION}
+              enterStyle={DIALOG_CONTENT_ENTER_EXIT_STYLE}
+              exitStyle={DIALOG_CONTENT_ENTER_EXIT_STYLE}
               borderRadius="$4"
               borderWidth="$0"
-              $theme-dark={{
-                outlineColor: '$neutral5',
-              }}
+              $theme-dark={DIALOG_THEME_DARK}
               outlineWidth={1}
               outlineOffset={0}
               outlineColor="$neutral3"
-              style={{
-                outlineStyle: 'solid',
-                ...(!platformEnv.isNative && !open && forceMount
-                  ? ({ contentVisibility: 'hidden' } as any)
-                  : {}),
-              }}
+              style={
+                !platformEnv.isNative && !open && forceMount
+                  ? DIALOG_CONTENT_VISIBILITY_HIDDEN
+                  : DIALOG_OUTLINE_STYLE
+              }
               bg="$bg"
               width={MAX_CONTENT_WIDTH}
               p="$0"

--- a/packages/components/src/composite/Dialog/index.tsx
+++ b/packages/components/src/composite/Dialog/index.tsx
@@ -100,6 +100,27 @@ export const FIX_SHEET_PROPS: IYStackProps = {
 
 const MAX_CONTENT_WIDTH = 400;
 
+const DIALOG_ENTER_STYLE_OPACITY = { opacity: 0 } as any;
+const DIALOG_EXIT_STYLE_OPACITY = { opacity: 0 } as any;
+const DIALOG_ANIMATE_ONLY_OPACITY = ['opacity'] as string[];
+const DIALOG_ANIMATE_ONLY_TRANSFORM_OPACITY = [
+  'transform',
+  'opacity',
+] as string[];
+const DIALOG_CONTENT_ANIMATION: [
+  string,
+  { opacity: { overshootClamping: boolean } },
+] = ['quick', { opacity: { overshootClamping: true } }];
+const DIALOG_CONTENT_ENTER_EXIT_STYLE = { opacity: 0, scale: 0.85 };
+const DIALOG_THEME_DARK = { outlineColor: '$neutral5' } as const;
+const DIALOG_OUTLINE_STYLE = { outlineStyle: 'solid' } as const;
+const DIALOG_CONTENT_VISIBILITY_HIDDEN = {
+  outlineStyle: 'solid',
+  contentVisibility: 'hidden',
+} as any;
+const DIALOG_HIDDEN_STYLE = { contentVisibility: 'hidden' } as any;
+const EMPTY_DIALOG_STYLE = {} as const;
+
 const DEFAULT_KEYBOARD_HEIGHT = 330;
 const useSafeKeyboardAnimationStyle = () => {
   const keyboardHeightValue = useSharedValue(0);
@@ -286,8 +307,8 @@ function DialogFrame({
         <Sheet.Overlay
           {...FIX_SHEET_PROPS}
           animation="quick"
-          enterStyle={{ opacity: 0 } as any}
-          exitStyle={{ opacity: 0 } as any}
+          enterStyle={DIALOG_ENTER_STYLE_OPACITY}
+          exitStyle={DIALOG_EXIT_STYLE_OPACITY}
           backgroundColor="$bgBackdrop"
           zIndex={sheetProps?.zIndex || zIndex}
           {...sheetOverlayProps}
@@ -341,21 +362,17 @@ function DialogFrame({
             <TMDialog.Overlay
               key="overlay"
               backgroundColor="$bgBackdrop"
-              animateOnly={['opacity']}
+              animateOnly={DIALOG_ANIMATE_ONLY_OPACITY}
               animation="quick"
               forceMount={forceMount || undefined}
-              enterStyle={{
-                opacity: 0,
-              }}
-              exitStyle={{
-                opacity: 0,
-              }}
+              enterStyle={DIALOG_ENTER_STYLE_OPACITY}
+              exitStyle={DIALOG_EXIT_STYLE_OPACITY}
               onPress={handleBackdropPress}
               zIndex={floatingPanelProps?.zIndex || zIndex}
               style={
                 !platformEnv.isNative && !open && forceMount
-                  ? ({ contentVisibility: 'hidden' } as any)
-                  : {}
+                  ? DIALOG_HIDDEN_STYLE
+                  : EMPTY_DIALOG_STYLE
               }
             />
             {/* /* fix missing title warnings in html dialog element on Web */}

--- a/packages/components/src/composite/Dialog/index.tsx
+++ b/packages/components/src/composite/Dialog/index.tsx
@@ -107,10 +107,10 @@ const DIALOG_ANIMATE_ONLY_TRANSFORM_OPACITY = [
   'transform',
   'opacity',
 ] as string[];
-const DIALOG_CONTENT_ANIMATION = [
-  'quick' as const,
-  { opacity: { overshootClamping: true } },
-] as const;
+const DIALOG_CONTENT_ANIMATION: [
+  'quick',
+  { opacity: { overshootClamping: boolean } },
+] = ['quick', { opacity: { overshootClamping: true } }];
 const DIALOG_CONTENT_ENTER_EXIT_STYLE = { opacity: 0, scale: 0.85 };
 const DIALOG_THEME_DARK = { outlineColor: '$neutral5' } as const;
 const DIALOG_OUTLINE_STYLE = { outlineStyle: 'solid' } as const;

--- a/packages/components/src/composite/Dialog/index.tsx
+++ b/packages/components/src/composite/Dialog/index.tsx
@@ -107,10 +107,10 @@ const DIALOG_ANIMATE_ONLY_TRANSFORM_OPACITY = [
   'transform',
   'opacity',
 ] as string[];
-const DIALOG_CONTENT_ANIMATION: [
-  string,
-  { opacity: { overshootClamping: boolean } },
-] = ['quick', { opacity: { overshootClamping: true } }];
+const DIALOG_CONTENT_ANIMATION = [
+  'quick' as const,
+  { opacity: { overshootClamping: true } },
+] as const;
 const DIALOG_CONTENT_ENTER_EXIT_STYLE = { opacity: 0, scale: 0.85 };
 const DIALOG_THEME_DARK = { outlineColor: '$neutral5' } as const;
 const DIALOG_OUTLINE_STYLE = { outlineStyle: 'solid' } as const;

--- a/packages/components/src/composite/ImageCrop/index.tsx
+++ b/packages/components/src/composite/ImageCrop/index.tsx
@@ -18,6 +18,8 @@ import {
 } from './type';
 
 import type { IStackStyle } from '../../primitives';
+
+const cropGtMdStyle = { height: 'calc(100vh - 180px)' };
 import type { CropperRef } from 'react-mobile-cropper';
 import type { LayoutChangeEvent } from 'react-native';
 
@@ -126,7 +128,7 @@ function BasicImageCrop({
     <>
       <Stack
         onLayout={onStackLayout}
-        $gtMd={{ height: 'calc(100vh - 180px)' }}
+        $gtMd={cropGtMdStyle}
         height="calc(100vh - 172px)"
       >
         <Cropper

--- a/packages/components/src/composite/ImageCrop/index.tsx
+++ b/packages/components/src/composite/ImageCrop/index.tsx
@@ -1,5 +1,11 @@
 /* eslint-disable camelcase */
-import { type ChangeEvent, useCallback, useMemo, useRef, useState } from 'react';
+import {
+  type ChangeEvent,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { Cropper } from 'react-mobile-cropper';
 import 'react-mobile-cropper/dist/style.css';
@@ -139,10 +145,7 @@ function BasicImageCrop({
           className="onekey-img-cropper"
         />
       </Stack>
-      <Dialog.Footer
-        onCancel={onCancel}
-        onConfirm={handleConfirm}
-      />
+      <Dialog.Footer onCancel={onCancel} onConfirm={handleConfirm} />
     </>
   );
 }

--- a/packages/components/src/composite/ImageCrop/index.tsx
+++ b/packages/components/src/composite/ImageCrop/index.tsx
@@ -176,6 +176,7 @@ const openPicker: IOpenPickerFunc = ({ width, height }) =>
               renderContent: (
                 <BasicImageCrop
                   src={imageSrc}
+                  // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
                   defaultSize={{
                     width,
                     height,
@@ -208,11 +209,13 @@ const openCropImage = (
       renderContent: (
         <BasicImageCrop
           src={image}
+          // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
           defaultSize={{
             width,
             height,
           }}
           onConfirm={resolve as any}
+          // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
           onCancel={() => {
             void dialog?.close();
             reject(new Error('User cancelled'));

--- a/packages/components/src/composite/ImageCrop/index.tsx
+++ b/packages/components/src/composite/ImageCrop/index.tsx
@@ -24,10 +24,10 @@ import {
 } from './type';
 
 import type { IStackStyle } from '../../primitives';
-
-const cropGtMdStyle = { height: 'calc(100vh - 180px)' };
 import type { CropperRef } from 'react-mobile-cropper';
 import type { LayoutChangeEvent } from 'react-native';
+
+const cropGtMdStyle = { height: 'calc(100vh - 180px)' };
 
 const MINE_TYPE = RESULT_MINE_TYPE;
 const resizeImage = (

--- a/packages/components/src/composite/ImageCrop/index.tsx
+++ b/packages/components/src/composite/ImageCrop/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { type ChangeEvent, useCallback, useRef, useState } from 'react';
+import { type ChangeEvent, useCallback, useMemo, useRef, useState } from 'react';
 
 import { Cropper } from 'react-mobile-cropper';
 import 'react-mobile-cropper/dist/style.css';
@@ -91,6 +91,37 @@ function BasicImageCrop({
     }
   }, []);
 
+  const stencilProps = useMemo(
+    () => ({
+      aspectRatio: defaultSize.width / defaultSize.height,
+    }),
+    [defaultSize.width, defaultSize.height],
+  );
+
+  const handleConfirm = useCallback(async () => {
+    if (cropperRef.current && cropperRef.current.getCanvas()) {
+      const canvas = cropperRef.current.getCanvas();
+      if (canvas) {
+        const { width, height } = defaultSize;
+        const imageWidth = cropRectRef.current.width;
+        const imageHeight = cropRectRef.current.height;
+        let base64String = canvas.toDataURL(MINE_TYPE, 1.0);
+        if (imageHeight > height || imageWidth > width) {
+          base64String = await resizeImage(base64String, width, height);
+        }
+        onConfirm({
+          data: base64String,
+          cropRect: cropRectRef.current,
+          path: '',
+          size: base64String.length,
+          width: Math.min(imageWidth, width),
+          height: Math.min(imageHeight, height),
+          mime: MINE_TYPE,
+        });
+      }
+    }
+  }, [defaultSize, onConfirm]);
+
   return (
     <>
       <Stack
@@ -102,37 +133,13 @@ function BasicImageCrop({
           src={src}
           onChange={onChange}
           ref={cropperRef}
-          stencilProps={{
-            aspectRatio: defaultSize.width / defaultSize.height,
-          }}
+          stencilProps={stencilProps}
           className="onekey-img-cropper"
         />
       </Stack>
       <Dialog.Footer
         onCancel={onCancel}
-        onConfirm={async () => {
-          if (cropperRef.current && cropperRef.current.getCanvas()) {
-            const canvas = cropperRef.current.getCanvas();
-            if (canvas) {
-              const { width, height } = defaultSize;
-              const imageWidth = cropRectRef.current.width;
-              const imageHeight = cropRectRef.current.height;
-              let base64String = canvas.toDataURL(MINE_TYPE, 1.0);
-              if (imageHeight > height || imageWidth > width) {
-                base64String = await resizeImage(base64String, width, height);
-              }
-              onConfirm({
-                data: base64String,
-                cropRect: cropRectRef.current,
-                path: '',
-                size: base64String.length,
-                width: Math.min(imageWidth, width),
-                height: Math.min(imageHeight, height),
-                mime: MINE_TYPE,
-              });
-            }
-          }
-        }}
+        onConfirm={handleConfirm}
       />
     </>
   );

--- a/packages/components/src/composite/SegmentSlider/index.tsx
+++ b/packages/components/src/composite/SegmentSlider/index.tsx
@@ -28,12 +28,16 @@ const Mark = ({
   backgroundColor,
   borderColor,
   onPress,
+  index,
+  onPressIndex,
 }: {
   slideOver?: boolean;
   markColor?: string;
   backgroundColor?: string;
   borderColor?: string;
   onPress?: () => void;
+  index?: number;
+  onPressIndex?: (index: number) => void;
 }) => {
   const markStyle = useMemo(
     () => ({
@@ -47,8 +51,16 @@ const Mark = ({
     [slideOver, markColor, backgroundColor, borderColor],
   );
 
+  const handlePress = useCallback(() => {
+    if (onPress) {
+      onPress();
+    } else if (onPressIndex !== undefined && index !== undefined) {
+      onPressIndex(index);
+    }
+  }, [onPress, onPressIndex, index]);
+
   return (
-    <TouchableWithoutFeedback onPress={onPress}>
+    <TouchableWithoutFeedback onPress={handlePress}>
       <View style={markStyle} />
     </TouchableWithoutFeedback>
   );
@@ -83,7 +95,7 @@ const MarkWithAnimatedView = ({
   markColor,
   backgroundColor,
   borderColor,
-  onPress,
+  onPressIndex,
   centerOrigin = false,
   minValue = 0,
   maxValue = 100,
@@ -94,7 +106,7 @@ const MarkWithAnimatedView = ({
   markColor?: string;
   backgroundColor?: string;
   borderColor?: string;
-  onPress?: () => void;
+  onPressIndex?: (index: number) => void;
   centerOrigin?: boolean;
   minValue?: number;
   maxValue?: number;
@@ -136,7 +148,8 @@ const MarkWithAnimatedView = ({
     <Animated.View style={combinedStyle}>
       <Mark
         slideOver
-        onPress={onPress}
+        index={index}
+        onPressIndex={onPressIndex}
         markColor={markColor}
         backgroundColor={backgroundColor}
         borderColor={borderColor}
@@ -318,9 +331,8 @@ export function SegmentSlider({
             key={index}
             markColor={bgPrimaryColor}
             backgroundColor={bgColor}
-            onPress={() => {
-              handlePressSegment(index);
-            }}
+            index={index}
+            onPressIndex={handlePressSegment}
             borderColor={neutral5Color}
           />
           <MarkWithAnimatedView
@@ -330,9 +342,7 @@ export function SegmentSlider({
             markColor={bgPrimaryColor}
             backgroundColor={bgColor}
             borderColor={neutral5Color}
-            onPress={() => {
-              handlePressSegment(index);
-            }}
+            onPressIndex={handlePressSegment}
             centerOrigin={centerOrigin}
             minValue={minValue}
             maxValue={maxValue}

--- a/packages/components/src/composite/SegmentSlider/index.tsx
+++ b/packages/components/src/composite/SegmentSlider/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { StyleSheet, TouchableWithoutFeedback, View } from 'react-native';
 import { Slider } from 'react-native-awesome-slider';

--- a/packages/components/src/composite/SegmentSlider/index.tsx
+++ b/packages/components/src/composite/SegmentSlider/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { StyleSheet, TouchableWithoutFeedback, View } from 'react-native';
 import { Slider } from 'react-native-awesome-slider';
@@ -35,18 +35,21 @@ const Mark = ({
   borderColor?: string;
   onPress?: () => void;
 }) => {
+  const markStyle = useMemo(
+    () => ({
+      width: markWidth,
+      height: markWidth,
+      backgroundColor: slideOver ? markColor : backgroundColor,
+      borderWidth: 1,
+      borderColor: slideOver ? markColor : borderColor,
+      borderRadius: markWidth / 2,
+    }),
+    [slideOver, markColor, backgroundColor, borderColor],
+  );
+
   return (
     <TouchableWithoutFeedback onPress={onPress}>
-      <View
-        style={{
-          width: markWidth,
-          height: markWidth,
-          backgroundColor: slideOver ? markColor : backgroundColor,
-          borderWidth: 1,
-          borderColor: slideOver ? markColor : borderColor,
-          borderRadius: markWidth / 2,
-        }}
-      />
+      <View style={markStyle} />
     </TouchableWithoutFeedback>
   );
 };
@@ -58,18 +61,19 @@ const Thumb = ({
   backgroundColor?: string;
   borderColor?: string;
 }) => {
-  return (
-    <View
-      style={{
-        width: thumbWidth,
-        height: thumbWidth,
-        backgroundColor,
-        borderWidth: 1,
-        borderColor,
-        borderRadius: thumbWidth / 2,
-      }}
-    />
+  const thumbStyle = useMemo(
+    () => ({
+      width: thumbWidth,
+      height: thumbWidth,
+      backgroundColor,
+      borderWidth: 1,
+      borderColor,
+      borderRadius: thumbWidth / 2,
+    }),
+    [backgroundColor, borderColor],
   );
+
+  return <View style={thumbStyle} />;
 };
 
 const MarkWithAnimatedView = ({
@@ -123,8 +127,13 @@ const MarkWithAnimatedView = ({
       opacity: index <= progressStep ? 1 : 0,
     };
   });
+  const combinedStyle = useMemo(
+    () => [{ ...StyleSheet.absoluteFillObject }, style],
+    [style],
+  );
+
   return (
-    <Animated.View style={[{ ...StyleSheet.absoluteFillObject }, style]}>
+    <Animated.View style={combinedStyle}>
       <Mark
         slideOver
         onPress={onPress}

--- a/packages/components/src/composite/Table/index.tsx
+++ b/packages/components/src/composite/Table/index.tsx
@@ -423,6 +423,25 @@ function BasicTable<T>({
   const effectiveStickyHeader =
     stickyHeader && (!tabIntegrated || !platformEnv.isNative);
 
+  const getItemLayout = useCallback(
+    (_: any, index: number) => ({
+      length: itemSize || DEFAULT_ROW_HEIGHT,
+      offset: index * (itemSize || DEFAULT_ROW_HEIGHT),
+      index,
+    }),
+    [itemSize],
+  );
+
+  const listHeaderComponent = useMemo(
+    () => (
+      <>
+        {TableHeaderComponent}
+        {effectiveStickyHeader ? null : headerRow}
+      </>
+    ),
+    [TableHeaderComponent, effectiveStickyHeader, headerRow],
+  );
+
   const list = useMemo(
     () =>
       draggable ? (
@@ -441,18 +460,9 @@ function BasicTable<T>({
           scrollEventThrottle={100}
           data={dataSource}
           renderItem={renderSortableItem}
-          getItemLayout={(_, index) => ({
-            length: itemSize || DEFAULT_ROW_HEIGHT,
-            offset: index * (itemSize || DEFAULT_ROW_HEIGHT),
-            index,
-          })}
+          getItemLayout={getItemLayout}
           renderPlaceholder={renderPlaceholder}
-          ListHeaderComponent={
-            <>
-              {TableHeaderComponent}
-              {effectiveStickyHeader ? null : headerRow}
-            </>
-          }
+          ListHeaderComponent={listHeaderComponent}
           onDragBegin={handleDragBegin}
           onDragEnd={onDragEnd}
           keyExtractor={keyExtractor}
@@ -477,12 +487,7 @@ function BasicTable<T>({
           scrollEventThrottle={100}
           data={dataSource}
           renderItem={handleRenderItem}
-          ListHeaderComponent={
-            <>
-              {TableHeaderComponent}
-              {effectiveStickyHeader ? null : headerRow}
-            </>
-          }
+          ListHeaderComponent={listHeaderComponent}
           ListFooterComponent={TableFooterComponent}
           ListEmptyComponent={TableEmptyComponent}
           extraData={extraData}
@@ -501,10 +506,9 @@ function BasicTable<T>({
       handleScroll,
       dataSource,
       renderSortableItem,
+      getItemLayout,
       renderPlaceholder,
-      TableHeaderComponent,
-      effectiveStickyHeader,
-      headerRow,
+      listHeaderComponent,
       handleDragBegin,
       onDragEnd,
       keyExtractor,
@@ -517,7 +521,6 @@ function BasicTable<T>({
       useFlashList,
       estimatedItemSize,
       handleRenderItem,
-      itemSize,
       tabIntegrated,
     ],
   );

--- a/packages/components/src/composite/Table/index.tsx
+++ b/packages/components/src/composite/Table/index.tsx
@@ -32,6 +32,7 @@ import type {
 } from 'react-native';
 
 const DEFAULT_ROW_HEIGHT = 60;
+const defaultEstimatedListSize = { width: 370, height: 525 };
 
 const renderContent = (text?: string) => (
   <SizableText size="$bodyMd" color="$textSubdued" userSelect="none">
@@ -286,7 +287,7 @@ function BasicTable<T>({
   onDragEnd,
   showHeader = true,
   estimatedItemSize = DEFAULT_ROW_HEIGHT,
-  estimatedListSize = { width: 370, height: 525 },
+  estimatedListSize = defaultEstimatedListSize,
   stickyHeader = true,
   stickyHeaderHiddenOnScroll = false,
   showBackToTopButton = false,

--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -76,10 +76,7 @@ export function ContainerChild({
       >
         {Children.map(children, (child, index) => {
           return (
-            <div
-              style={childDivStyle}
-              key={index}
-            >
+            <div style={childDivStyle} key={index}>
               {child}
             </div>
           );

--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -28,6 +28,13 @@ import type {
 import type { SharedValue } from 'react-native-reanimated';
 import type { WindowScrollerChildProps } from 'react-virtualized';
 
+const scrollSnapStyle = { scrollSnapType: 'x' } as const;
+const childDivStyle = {
+  width: '100%',
+  flexShrink: 0,
+  scrollSnapAlign: 'center',
+} as const;
+
 export function ContainerChild({
   children,
   listContainerRef,
@@ -64,16 +71,12 @@ export function ContainerChild({
         ref={listContainerRef as any}
         width={containerWidth || props.width}
         overflow="hidden"
-        style={{ scrollSnapType: 'x' }}
+        style={scrollSnapStyle}
       >
         {Children.map(children, (child, index) => {
           return (
             <div
-              style={{
-                width: '100%',
-                flexShrink: 0,
-                scrollSnapAlign: 'center',
-              }}
+              style={childDivStyle}
               key={index}
             >
               {child}
@@ -389,7 +392,7 @@ export function Container({
       flex={1}
       className="onekey-tabs-container"
       position="relative"
-      style={disableScroll ? undefined : { overflowY: 'scroll' }}
+      style={disableScroll ? undefined : overflowYScrollStyle}
       ref={ref as React.RefObject<HTMLDivElement>}
     >
       {scrollElement ? (

--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -28,6 +28,7 @@ import type {
 import type { SharedValue } from 'react-native-reanimated';
 import type { WindowScrollerChildProps } from 'react-virtualized';
 
+const overflowYScrollStyle = { overflowY: 'scroll' } as const;
 const scrollSnapStyle = { scrollSnapType: 'x' } as const;
 const childDivStyle = {
   width: '100%',
@@ -418,14 +419,7 @@ export function Container({
                 <>
                   <YStack
                     position="relative"
-                    width={containerWidth ? undefined : width}
-                    style={
-                      containerWidth
-                        ? {
-                            width: containerWidth,
-                          }
-                        : undefined
-                    }
+                    width={containerWidth || width}
                     onLayout={handlerStickyHeaderLayout}
                   >
                     {renderHeader?.({

--- a/packages/components/src/composite/Tabs/TabBar.tsx
+++ b/packages/components/src/composite/Tabs/TabBar.tsx
@@ -781,6 +781,7 @@ export function TabBar({
         return (
           <View
             key={name}
+            // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
             onLayout={(e: LayoutChangeEvent) => {
               const { x, width } = e.nativeEvent.layout;
               handleItemLayout(index, { x, width });

--- a/packages/components/src/composite/Tabs/TabBar.tsx
+++ b/packages/components/src/composite/Tabs/TabBar.tsx
@@ -30,6 +30,15 @@ import type { SharedValue } from 'react-native-reanimated';
 
 type IItemLayout = { x: number; width: number };
 
+const TAB_HOVER_STYLE = { bg: '$bgHover' } as const;
+const TAB_PRESS_STYLE = { bg: '$bgActive' } as const;
+const TAB_LIST_VIEW_STYLE = { flexShrink: 1 } as const;
+const TAB_CONTENT_CONTAINER_STYLE = { pr: 16 } as const;
+const PILL_SCROLL_CONTENT_STYLE = {
+  px: '$pagePadding',
+  py: '$2',
+} as const;
+
 export type ITabBarVariant = 'default' | 'pill';
 
 const animatedTextStyles = StyleSheet.create({
@@ -63,11 +72,13 @@ function AnimatedPillText({
     return { color };
   });
 
+  const combinedStyle = useMemo(
+    () => [animatedTextStyles.text, animatedColorStyle],
+    [animatedColorStyle],
+  );
+
   return (
-    <Animated.Text
-      style={[animatedTextStyles.text, animatedColorStyle]}
-      numberOfLines={1}
-    >
+    <Animated.Text style={combinedStyle} numberOfLines={1}>
       {name}
     </Animated.Text>
   );
@@ -115,10 +126,10 @@ export function TabBarItem({
         borderRadius="$full"
         bg={pillBg}
         hoverStyle={
-          isFocused || animatedPillIndicator ? undefined : { bg: '$bgHover' }
+          isFocused || animatedPillIndicator ? undefined : TAB_HOVER_STYLE
         }
         pressStyle={
-          isFocused || animatedPillIndicator ? undefined : { bg: '$bgActive' }
+          isFocused || animatedPillIndicator ? undefined : TAB_PRESS_STYLE
         }
         key={name}
         onPress={handlePress}
@@ -224,6 +235,11 @@ function AnimatedTabBarItem({
     [index, onItemLayout],
   );
 
+  const combinedTextStyle = useMemo(
+    () => [animatedTextStyles.text, animatedTextStyle],
+    [animatedTextStyle],
+  );
+
   return (
     <YStack
       h={44}
@@ -237,10 +253,7 @@ function AnimatedTabBarItem({
       {...tabItemStyle}
       {...(isFocused ? focusedTabStyle : undefined)}
     >
-      <Animated.Text
-        style={[animatedTextStyles.text, animatedTextStyle]}
-        numberOfLines={1}
-      >
+      <Animated.Text style={combinedTextStyle} numberOfLines={1}>
         {name}
       </Animated.Text>
     </YStack>
@@ -300,25 +313,28 @@ function AnimatedIndicator({
     return { transform: [{ translateX }], width };
   });
 
+  const indicatorBaseStyle = useMemo(
+    () => ({
+      position: 'absolute' as const,
+      bottom: 0,
+      left: 0,
+      height: 2,
+      borderRadius: 1,
+      backgroundColor: indicatorColor,
+    }),
+    [indicatorColor],
+  );
+
+  const combinedIndicatorStyle = useMemo(
+    () => [indicatorBaseStyle, animatedStyle],
+    [indicatorBaseStyle, animatedStyle],
+  );
+
   if (itemsLayout.length === 0) {
     return null;
   }
 
-  return (
-    <Animated.View
-      style={[
-        {
-          position: 'absolute',
-          bottom: 0,
-          left: 0,
-          height: 2,
-          borderRadius: 1,
-          backgroundColor: indicatorColor,
-        },
-        animatedStyle,
-      ]}
-    />
-  );
+  return <Animated.View style={combinedIndicatorStyle} />;
 }
 
 function AnimatedPillTabBarItem({
@@ -359,6 +375,11 @@ function AnimatedPillTabBarItem({
     [index, onItemLayout],
   );
 
+  const combinedPillTextStyle = useMemo(
+    () => [animatedTextStyles.text, animatedTextStyle],
+    [animatedTextStyle],
+  );
+
   return (
     <YStack
       ai="center"
@@ -372,10 +393,7 @@ function AnimatedPillTabBarItem({
       cursor="default"
       zIndex={1}
     >
-      <Animated.Text
-        style={[animatedTextStyles.text, animatedTextStyle]}
-        numberOfLines={1}
-      >
+      <Animated.Text style={combinedPillTextStyle} numberOfLines={1}>
         {name}
       </Animated.Text>
     </YStack>
@@ -455,25 +473,28 @@ function AnimatedPillIndicator({
     return { transform: [{ translateX: left }], width: right - left };
   });
 
+  const pillBaseStyle = useMemo(
+    () => ({
+      position: 'absolute' as const,
+      top: 0,
+      left: 0,
+      bottom: 0,
+      borderRadius: 9999,
+      backgroundColor: bgColor,
+    }),
+    [bgColor],
+  );
+
+  const combinedPillStyle = useMemo(
+    () => [pillBaseStyle, animatedStyle],
+    [pillBaseStyle, animatedStyle],
+  );
+
   if (itemsLayout.length === 0) {
     return null;
   }
 
-  return (
-    <Animated.View
-      style={[
-        {
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          bottom: 0,
-          borderRadius: 9999,
-          backgroundColor: bgColor,
-        },
-        animatedStyle,
-      ]}
-    />
-  );
+  return <Animated.View style={combinedPillStyle} />;
 }
 
 export interface ITabBarProps extends TabBarProps<string> {
@@ -561,10 +582,7 @@ function PillTabBarContent({
           onScroll={handleScroll}
           onLayout={handleLayout}
           onContentSizeChange={handleContentSizeChange}
-          contentContainerStyle={{
-            px: '$pagePadding',
-            py: '$2',
-          }}
+          contentContainerStyle={PILL_SCROLL_CONTENT_STYLE}
         >
           <XStack position="relative" gap="$2" ai="center">
             {pillIndicator}
@@ -910,17 +928,13 @@ export function TabBar({
     >
       <XStack alignItems="center" gap="$2" justifyContent="space-between">
         <ListView
-          style={{
-            flexShrink: 1,
-          }}
+          style={TAB_LIST_VIEW_STYLE}
           useFlashList
           data={tabNames}
           ref={listViewRef}
           horizontal
           pr="$4"
-          contentContainerStyle={{
-            pr: 16,
-          }}
+          contentContainerStyle={TAB_CONTENT_CONTAINER_STYLE}
           renderItem={handleRenderItem as any}
           showsHorizontalScrollIndicator={false}
         />

--- a/packages/components/src/composite/Tabs/TabsDraggableFlatList.tsx
+++ b/packages/components/src/composite/Tabs/TabsDraggableFlatList.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useMemo } from 'react';
+import { forwardRef, useCallback, useEffect, useMemo } from 'react';
 import type { ReactElement, Ref } from 'react';
 
 import {
@@ -75,12 +75,15 @@ function TabsDraggableFlatListImpl<T>(
 
   const memoStyle = useMemo(() => [_style, style], [_style, style]);
 
+  const containerStyleMemo = useMemo(() => ({ flex: 1 as const }), []);
+  const handleMomentumScrollEnd = useCallback(() => {}, []);
+
   return (
     <DraggableFlatList<T>
       {...rest}
       onLayout={onLayout}
       ref={ref as any}
-      containerStyle={{ flex: 1 }}
+      containerStyle={containerStyleMemo}
       style={memoStyle as any}
       contentContainerStyle={memoContentContainerStyle as any}
       progressViewOffset={progressViewOffset}
@@ -91,7 +94,7 @@ function TabsDraggableFlatListImpl<T>(
       contentOffset={memoContentOffset}
       automaticallyAdjustContentInsets={false}
       // workaround for: https://github.com/software-mansion/react-native-reanimated/issues/2735
-      onMomentumScrollEnd={() => {}}
+      onMomentumScrollEnd={handleMomentumScrollEnd}
     />
   );
 }

--- a/packages/components/src/composite/Tabs/index.native.tsx
+++ b/packages/components/src/composite/Tabs/index.native.tsx
@@ -1,8 +1,4 @@
-import {
-  type PropsWithChildren,
-  forwardRef,
-  useMemo,
-} from 'react';
+import { type PropsWithChildren, forwardRef, useMemo } from 'react';
 
 import { Tabs as NativeTabs } from 'react-native-collapsible-tab-view';
 

--- a/packages/components/src/composite/Tabs/index.native.tsx
+++ b/packages/components/src/composite/Tabs/index.native.tsx
@@ -1,7 +1,6 @@
 import {
   type PropsWithChildren,
   forwardRef,
-  useCallback,
   useMemo,
 } from 'react';
 

--- a/packages/components/src/composite/Tabs/index.native.tsx
+++ b/packages/components/src/composite/Tabs/index.native.tsx
@@ -1,4 +1,4 @@
-import { type PropsWithChildren, forwardRef } from 'react';
+import { type PropsWithChildren, forwardRef, useCallback, useMemo } from 'react';
 
 import { Tabs as NativeTabs } from 'react-native-collapsible-tab-view';
 
@@ -11,23 +11,34 @@ interface IExtendedContainerProps extends CollapsibleProps {
   useNativeHeaderAnimation?: boolean;
 }
 
+const renderTabBarDefault = (tabProps: any) => <TabBar {...tabProps} />;
+
 const Container = forwardRef<any, PropsWithChildren<IExtendedContainerProps>>(
   ({ children, pagerProps, headerContainerStyle, ...props }, ref) => {
+    const mergedHeaderContainerStyle = useMemo(
+      () => ({
+        shadowOpacity: 0,
+        elevation: 0,
+        ...(headerContainerStyle as any),
+      }),
+      [headerContainerStyle],
+    );
+
+    const mergedPagerProps = useMemo(
+      () =>
+        ({
+          scrollSensitivity: 4,
+          ...pagerProps,
+        }) as any,
+      [pagerProps],
+    );
+
     return (
       <NativeTabs.Container
         ref={ref}
-        headerContainerStyle={{
-          shadowOpacity: 0,
-          elevation: 0,
-          ...(headerContainerStyle as any),
-        }}
-        pagerProps={
-          {
-            scrollSensitivity: 4,
-            ...pagerProps,
-          } as any
-        }
-        renderTabBar={(tabProps: any) => <TabBar {...tabProps} />}
+        headerContainerStyle={mergedHeaderContainerStyle}
+        pagerProps={mergedPagerProps}
+        renderTabBar={renderTabBarDefault}
         {...props}
       >
         {children}

--- a/packages/components/src/composite/Tabs/index.native.tsx
+++ b/packages/components/src/composite/Tabs/index.native.tsx
@@ -1,4 +1,9 @@
-import { type PropsWithChildren, forwardRef, useCallback, useMemo } from 'react';
+import {
+  type PropsWithChildren,
+  forwardRef,
+  useCallback,
+  useMemo,
+} from 'react';
 
 import { Tabs as NativeTabs } from 'react-native-collapsible-tab-view';
 

--- a/packages/components/src/composite/Tabs/index.native.tsx
+++ b/packages/components/src/composite/Tabs/index.native.tsx
@@ -21,11 +21,12 @@ const renderTabBarDefault = (tabProps: any) => <TabBar {...tabProps} />;
 const Container = forwardRef<any, PropsWithChildren<IExtendedContainerProps>>(
   ({ children, pagerProps, headerContainerStyle, ...props }, ref) => {
     const mergedHeaderContainerStyle = useMemo(
-      () => ({
-        shadowOpacity: 0,
-        elevation: 0,
-        ...(headerContainerStyle as any),
-      }),
+      () =>
+        ({
+          shadowOpacity: 0,
+          elevation: 0,
+          ...(headerContainerStyle as Record<string, unknown>),
+        }) as typeof headerContainerStyle,
       [headerContainerStyle],
     );
 
@@ -34,7 +35,7 @@ const Container = forwardRef<any, PropsWithChildren<IExtendedContainerProps>>(
         ({
           scrollSensitivity: 4,
           ...pagerProps,
-        }) as any,
+        }) as typeof pagerProps,
       [pagerProps],
     );
 

--- a/packages/components/src/content/BlurView/index.tsx
+++ b/packages/components/src/content/BlurView/index.tsx
@@ -1,5 +1,5 @@
 import type { ForwardedRef } from 'react';
-import { forwardRef } from 'react';
+import { forwardRef, useMemo } from 'react';
 
 import { BlurView as NativeBlurView } from 'expo-blur';
 import { type View as IView, type ViewStyle } from 'react-native';
@@ -39,15 +39,20 @@ function BasicBlurView(
     resolveValues: 'auto',
   });
 
+  const optimizationViewStyle = useMemo(
+    () => ({
+      ...(style as ViewStyle),
+      overflow: 'hidden' as const,
+    }),
+    [style],
+  );
+
+  const fallbackContentStyle = useMemo(() => ({ flex: 1 as const }), []);
+
   return (
-    <OptimizationView
-      style={{
-        ...(style as ViewStyle),
-        overflow: 'hidden',
-      }}
-    >
+    <OptimizationView style={optimizationViewStyle}>
       <NativeBlurView
-        style={contentStyle ? (resolvedContentStyle as ViewStyle) : { flex: 1 }}
+        style={contentStyle ? (resolvedContentStyle as ViewStyle) : fallbackContentStyle}
         tint={themeName}
         experimentalBlurMethod={experimentalBlurMethod || 'dimezisBlurView'}
         {...restProps}

--- a/packages/components/src/content/BlurView/index.tsx
+++ b/packages/components/src/content/BlurView/index.tsx
@@ -52,7 +52,11 @@ function BasicBlurView(
   return (
     <OptimizationView style={optimizationViewStyle}>
       <NativeBlurView
-        style={contentStyle ? (resolvedContentStyle as ViewStyle) : fallbackContentStyle}
+        style={
+          contentStyle
+            ? (resolvedContentStyle as ViewStyle)
+            : fallbackContentStyle
+        }
         tint={themeName}
         experimentalBlurMethod={experimentalBlurMethod || 'dimezisBlurView'}
         {...restProps}

--- a/packages/components/src/content/Breadcrumb/index.tsx
+++ b/packages/components/src/content/Breadcrumb/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import {
   createStyledContext,
@@ -131,6 +131,34 @@ const BreadcrumbLinkText = styled(SizableText, {
   } as const,
 });
 
+function BreadcrumbItemWrapper({
+  item,
+  onItemPress,
+  element,
+}: {
+  item: IBreadcrumbItem;
+  onItemPress: (item: IBreadcrumbItem) => void;
+  element: React.ReactNode;
+}) {
+  const handlePress = useCallback(() => {
+    onItemPress(item);
+  }, [onItemPress, item]);
+
+  return (
+    <BreadcrumbItem
+      role={
+        !platformEnv.isNative && (item.onClick || item.href)
+          ? 'button'
+          : undefined
+      }
+      onPress={handlePress}
+      disabled={!item.onClick ? !item.href : undefined}
+    >
+      {element}
+    </BreadcrumbItem>
+  );
+}
+
 export type IBreadcrumbProps = IXStackProps & {
   items: IBreadcrumbItem[];
   breadcrumbSize?: IBreadcrumbSize;
@@ -197,17 +225,11 @@ const BreadcrumbComponent = BreadcrumbFrame.styleable<
       }
 
       return (
-        <BreadcrumbItem
-          role={
-            !platformEnv.isNative && (item.onClick || item.href)
-              ? 'button'
-              : undefined
-          }
-          onPress={() => handleItemPress(item)}
-          disabled={!item.onClick ? !item.href : undefined}
-        >
-          {element}
-        </BreadcrumbItem>
+        <BreadcrumbItemWrapper
+          item={item}
+          onItemPress={handleItemPress}
+          element={element}
+        />
       );
     },
     [breadcrumbSize, handleItemPress, renderItem],

--- a/packages/components/src/content/Breadcrumb/index.tsx
+++ b/packages/components/src/content/Breadcrumb/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 
 import {
   createStyledContext,

--- a/packages/components/src/content/ConfirmHighlighter/index.tsx
+++ b/packages/components/src/content/ConfirmHighlighter/index.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { MotiView } from 'moti';
 
 import {
@@ -16,6 +18,30 @@ interface IConfirmHighlighter extends Partial<IStackProps> {
   borderRadius?: IStackProps['borderRadius'];
 }
 
+const motiFromStyle = {
+  borderWidth: 0,
+  opacity: 0,
+  //  WARN  (ADVICE) View #10569 of type RCTView has a shadow set but cannot calculate shadow efficiently. Consider setting a background color to fix this, or apply the shadow to a more specific component.
+  shadowOpacity: platformEnv.isNative ? undefined : 0.5,
+};
+
+const motiAnimateStyle = {
+  borderWidth: 2,
+  opacity: 1,
+  shadowOpacity: platformEnv.isNative ? undefined : 1,
+};
+
+const motiTransition = {
+  type: 'timing',
+  duration: 1000,
+  loop: true,
+} as any;
+
+const shadowOffset = {
+  width: 0,
+  height: 0,
+};
+
 export function ConfirmHighlighter({
   highlight,
   children,
@@ -25,48 +51,35 @@ export function ConfirmHighlighter({
   const theme = useTheme();
   const highlightColor = theme.brand11.val;
 
+  const motiStyle = useMemo(
+    () => ({
+      position: 'absolute' as const,
+      left: -2,
+      top: -2,
+      right: -2,
+      bottom: -2,
+      borderRadius:
+        typeof borderRadius !== 'number'
+          ? getTokenValue(borderRadius as Token, 'size')
+          : borderRadius,
+      borderColor: highlightColor,
+      shadowColor: highlightColor,
+      shadowRadius: 10,
+      shadowOpacity: platformEnv.isNative ? undefined : 1,
+      shadowOffset,
+    }),
+    [borderRadius, highlightColor],
+  );
+
   return (
     <Stack borderRadius={borderRadius} {...rest}>
       {children}
       {highlight ? (
         <MotiView
-          from={{
-            borderWidth: 0,
-            opacity: 0,
-            //  WARN  (ADVICE) View #10569 of type RCTView has a shadow set but cannot calculate shadow efficiently. Consider setting a background color to fix this, or apply the shadow to a more specific component.
-            shadowOpacity: platformEnv.isNative ? undefined : 0.5,
-          }}
-          animate={{
-            borderWidth: 2,
-            opacity: 1,
-            shadowOpacity: platformEnv.isNative ? undefined : 1,
-          }}
-          transition={
-            {
-              type: 'timing',
-              duration: 1000,
-              loop: true,
-            } as any
-          }
-          style={{
-            position: 'absolute',
-            left: -2,
-            top: -2,
-            right: -2,
-            bottom: -2,
-            borderRadius:
-              typeof borderRadius !== 'number'
-                ? getTokenValue(borderRadius as Token, 'size')
-                : borderRadius,
-            borderColor: highlightColor,
-            shadowColor: highlightColor,
-            shadowRadius: 10,
-            shadowOpacity: platformEnv.isNative ? undefined : 1,
-            shadowOffset: {
-              width: 0,
-              height: 0,
-            },
-          }}
+          from={motiFromStyle}
+          animate={motiAnimateStyle}
+          transition={motiTransition}
+          style={motiStyle}
         />
       ) : null}
     </Stack>

--- a/packages/components/src/content/HeightTransition/index.tsx
+++ b/packages/components/src/content/HeightTransition/index.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps } from 'react';
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { StyleSheet } from 'react-native';
 import Animated, {
@@ -76,13 +76,18 @@ function HeightTransition({
     [hide, measuredHeight, isMounted],
   );
 
+  const handleLayout = useCallback(
+    ({ nativeEvent }: { nativeEvent: { layout: { height: number } } }) => {
+      measuredHeight.value = Math.ceil(nativeEvent.layout.height);
+    },
+    [measuredHeight],
+  );
+
   return (
     <Animated.View style={[styles.hidden, style, containerStyle]}>
       <Animated.View
         style={[StyleSheet.absoluteFill, styles.autoBottom, childStyle]}
-        onLayout={({ nativeEvent }) => {
-          measuredHeight.value = Math.ceil(nativeEvent.layout.height);
-        }}
+        onLayout={handleLayout}
       >
         {children}
       </Animated.View>

--- a/packages/components/src/content/HeightTransition/index.tsx
+++ b/packages/components/src/content/HeightTransition/index.tsx
@@ -95,10 +95,7 @@ function HeightTransition({
 
   return (
     <Animated.View style={outerStyle}>
-      <Animated.View
-        style={innerStyle}
-        onLayout={handleLayout}
-      >
+      <Animated.View style={innerStyle} onLayout={handleLayout}>
         {children}
       </Animated.View>
     </Animated.View>

--- a/packages/components/src/content/HeightTransition/index.tsx
+++ b/packages/components/src/content/HeightTransition/index.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps } from 'react';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
 import { StyleSheet } from 'react-native';
 import Animated, {
@@ -83,10 +83,20 @@ function HeightTransition({
     [measuredHeight],
   );
 
+  const outerStyle = useMemo(
+    () => [styles.hidden, style, containerStyle],
+    [style, containerStyle],
+  );
+
+  const innerStyle = useMemo(
+    () => [StyleSheet.absoluteFill, styles.autoBottom, childStyle],
+    [childStyle],
+  );
+
   return (
-    <Animated.View style={[styles.hidden, style, containerStyle]}>
+    <Animated.View style={outerStyle}>
       <Animated.View
-        style={[StyleSheet.absoluteFill, styles.autoBottom, childStyle]}
+        style={innerStyle}
         onLayout={handleLayout}
       >
         {children}

--- a/packages/components/src/content/Markdown/index.tsx
+++ b/packages/components/src/content/Markdown/index.tsx
@@ -14,6 +14,8 @@ function hasParents(parents: ASTNode[], type: string) {
   return parents.findIndex((el) => el.type === type) > -1;
 }
 
+const gtMdStyle = { h: '$5' } as const;
+
 const basicRules: MarkdownProps['rules'] = {
   heading1: (node, children) => (
     <Stack key={node.key} mt="$9">
@@ -59,7 +61,7 @@ const basicRules: MarkdownProps['rules'] = {
       return (
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         <XStack key={node.key} gap="$2">
-          <Stack ai="center" jc="center" w="$4.5" h="$6" $gtMd={{ h: '$5' }}>
+          <Stack ai="center" jc="center" w="$4.5" h="$6" $gtMd={gtMdStyle}>
             <Stack bg="$textDisabled" w={5} h={5} borderRadius="$full" />
           </Stack>
           <Stack flexShrink={1}>{children}</Stack>

--- a/packages/components/src/content/NetworkStatusBadge/index.tsx
+++ b/packages/components/src/content/NetworkStatusBadge/index.tsx
@@ -1,12 +1,15 @@
 import { useMemo } from 'react';
 import type { ComponentProps, ReactElement } from 'react';
 
+
 import { useIntl } from 'react-intl';
 
 import { Stack } from '@onekeyhq/components/src/primitives';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { Badge } from '../Badge';
+
+const fontVariant = ['tabular-nums'] as const;
 
 export type INetworkStatusBadgeProps = {
   connected: boolean;
@@ -87,7 +90,7 @@ export function NetworkStatusBadge({
         <Badge.Text
           size="$bodySmMedium"
           fontFamily="$monoRegular"
-          fontVariant={['tabular-nums']}
+          fontVariant={fontVariant}
           minWidth={40}
           textAlign="right"
         >

--- a/packages/components/src/content/NetworkStatusBadge/index.tsx
+++ b/packages/components/src/content/NetworkStatusBadge/index.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import type { ComponentProps, ReactElement } from 'react';
 
-
 import { useIntl } from 'react-intl';
 
 import { Stack } from '@onekeyhq/components/src/primitives';

--- a/packages/components/src/content/NetworkStatusBadge/index.tsx
+++ b/packages/components/src/content/NetworkStatusBadge/index.tsx
@@ -9,7 +9,7 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { Badge } from '../Badge';
 
-const fontVariant = ['tabular-nums'] as const;
+const fontVariant: ['tabular-nums'] = ['tabular-nums'];
 
 export type INetworkStatusBadgeProps = {
   connected: boolean;

--- a/packages/components/src/content/OneKeyLogo/index.tsx
+++ b/packages/components/src/content/OneKeyLogo/index.tsx
@@ -7,6 +7,25 @@ import type { GetProps } from '@tamagui/core';
 
 type IOneKeyLogoProps = GetProps<typeof XStack>;
 
+const decorativeLogoFallback = (
+  <Skeleton borderRadius={13} width={58} height={58} />
+);
+
+const decorativeWebStyle = {
+  boxShadow:
+    '0 8px 12px 0 rgba(4, 31, 0, 0.08), 0 1px 2px 0 rgba(4, 31, 0, 0.10), 0 0 2px 0 rgba(4, 31, 0, 0.10)',
+};
+
+const decorativeNativeStyle = {
+  elevation: 1,
+};
+
+const decorativeAnimateOnly = ['transform'];
+
+const decorativeHoverStyle = {
+  scale: 0.95,
+};
+
 export function OneKeyLogo({
   px = '$4',
   py = '$3',
@@ -22,26 +41,19 @@ export function OneKeyLogo({
 export function DecorativeOneKeyLogo() {
   return (
     <YStack
-      $platform-web={{
-        boxShadow:
-          '0 8px 12px 0 rgba(4, 31, 0, 0.08), 0 1px 2px 0 rgba(4, 31, 0, 0.10), 0 0 2px 0 rgba(4, 31, 0, 0.10)',
-      }}
-      $platform-native={{
-        elevation: 1,
-      }}
+      $platform-web={decorativeWebStyle}
+      $platform-native={decorativeNativeStyle}
       borderRadius={13}
       animation="quick"
-      animateOnly={['transform']}
-      hoverStyle={{
-        scale: 0.95,
-      }}
+      animateOnly={decorativeAnimateOnly}
+      hoverStyle={decorativeHoverStyle}
     >
       <Image
         source={require('@onekeyhq/kit/assets/onboarding/logo-decorative.png')}
         width={58}
         height={58}
         zIndex={1}
-        fallback={<Skeleton borderRadius={13} width={58} height={58} />}
+        fallback={decorativeLogoFallback}
       />
     </YStack>
   );

--- a/packages/components/src/content/Progress/Progress.tsx
+++ b/packages/components/src/content/Progress/Progress.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import {
   ThemeableStack,
@@ -190,6 +190,14 @@ const Progress = withStaticProperties(
         : undefined;
       const [width, setWidth] = useState(0);
 
+      const handleLayout = useCallback(
+        (e: LayoutChangeEvent) => {
+          setWidth(e.nativeEvent.layout.width);
+          IProgressProps.onLayout?.(e);
+        },
+        [IProgressProps],
+      );
+
       return (
         <ProgressProvider
           scope={__scopeProgress}
@@ -211,10 +219,7 @@ const Progress = withStaticProperties(
               size,
             })}
             {...IProgressProps}
-            onLayout={(e) => {
-              setWidth(e.nativeEvent.layout.width);
-              IProgressProps.onLayout?.(e);
-            }}
+            onLayout={handleLayout}
             ref={forwardedRef}
           />
         </ProgressProvider>

--- a/packages/components/src/content/PulseContainer/index.tsx
+++ b/packages/components/src/content/PulseContainer/index.tsx
@@ -27,11 +27,12 @@ function BasicPulseContainer({
     }).start();
   }, [isActive, activeOpacity, duration, opacityAnim]);
 
-  const animatedStyle = useMemo(() => ({ opacity: opacityAnim }), [opacityAnim]);
-
-  return (
-    <Animated.View style={animatedStyle}>{children}</Animated.View>
+  const animatedStyle = useMemo(
+    () => ({ opacity: opacityAnim }),
+    [opacityAnim],
   );
+
+  return <Animated.View style={animatedStyle}>{children}</Animated.View>;
 }
 
 export const PulseContainer = memo(BasicPulseContainer);

--- a/packages/components/src/content/PulseContainer/index.tsx
+++ b/packages/components/src/content/PulseContainer/index.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { memo, useEffect, useRef } from 'react';
+import { memo, useEffect, useMemo, useRef } from 'react';
 
 import { Animated, Easing } from 'react-native';
 
@@ -27,8 +27,10 @@ function BasicPulseContainer({
     }).start();
   }, [isActive, activeOpacity, duration, opacityAnim]);
 
+  const animatedStyle = useMemo(() => ({ opacity: opacityAnim }), [opacityAnim]);
+
   return (
-    <Animated.View style={{ opacity: opacityAnim }}>{children}</Animated.View>
+    <Animated.View style={animatedStyle}>{children}</Animated.View>
   );
 }
 

--- a/packages/components/src/content/RichSizeableText/index.tsx
+++ b/packages/components/src/content/RichSizeableText/index.tsx
@@ -19,6 +19,31 @@ type ILinkItemType = ISizableTextProps & {
   url: string | undefined;
 };
 
+function LinkText({
+  link,
+  children,
+}: {
+  link: ILinkItemType;
+  children: React.ReactNode;
+}) {
+  const handlePress = useCallback(() => {
+    if (link.url) {
+      openUrlExternal(link.url ?? '');
+    }
+  }, [link.url]);
+
+  return (
+    <SizableText
+      color="$textInfo"
+      cursor="pointer"
+      onPress={handlePress}
+      {...link}
+    >
+      {children}
+    </SizableText>
+  );
+}
+
 /**
  * @deprecated This component is deprecated. Please use HyperlinkText instead.
  * @see HyperlinkText in @onekeyhq/kit/src/components/HyperlinkText
@@ -29,12 +54,6 @@ export function RichSizeableText({
   i18NValues,
   ...rest
 }: IRichSizeableTextProps) {
-  const onLinkDidPress = useCallback((link: ILinkItemType) => {
-    if (link.url) {
-      openUrlExternal(link?.url ?? '');
-    }
-  }, []);
-
   const formattedMessageValues = useMemo(
     () =>
       ({
@@ -42,18 +61,9 @@ export function RichSizeableText({
           ? Object.keys(linkList).reduce(
               (values, key) => {
                 // eslint-disable-next-line react/no-unstable-nested-components
-                values[key] = (text) => {
+                values[key] = (text: React.ReactNode) => {
                   const link = linkList[key];
-                  return (
-                    <SizableText
-                      color="$textInfo"
-                      cursor="pointer"
-                      onPress={() => onLinkDidPress(link)}
-                      {...link}
-                    >
-                      {text}
-                    </SizableText>
-                  );
+                  return <LinkText link={link}>{text}</LinkText>;
                 };
                 return values;
               },
@@ -65,7 +75,7 @@ export function RichSizeableText({
           : {}),
         ...i18NValues,
       }) as Record<string, any>,
-    [linkList, i18NValues, onLinkDidPress],
+    [linkList, i18NValues],
   );
 
   return (

--- a/packages/components/src/content/RichSizeableText/index.tsx
+++ b/packages/components/src/content/RichSizeableText/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
@@ -34,42 +34,47 @@ export function RichSizeableText({
       openUrlExternal(link?.url ?? '');
     }
   }, []);
+
+  const formattedMessageValues = useMemo(
+    () =>
+      ({
+        ...(linkList
+          ? Object.keys(linkList).reduce(
+              (values, key) => {
+                // eslint-disable-next-line react/no-unstable-nested-components
+                values[key] = (text) => {
+                  const link = linkList[key];
+                  return (
+                    <SizableText
+                      color="$textInfo"
+                      cursor="pointer"
+                      onPress={() => onLinkDidPress(link)}
+                      {...link}
+                    >
+                      {text}
+                    </SizableText>
+                  );
+                };
+                return values;
+              },
+              {} as Record<
+                string,
+                string | ((value: any) => React.JSX.Element)
+              >,
+            )
+          : {}),
+        ...i18NValues,
+      }) as Record<string, any>,
+    [linkList, i18NValues, onLinkDidPress],
+  );
+
   return (
     <SizableText size="$bodyLg" color="$textSubdued" {...rest}>
       {linkList || i18NValues ? (
         <FormattedMessage
           id={children as ETranslations}
           defaultMessage={children}
-          values={
-            {
-              ...(linkList
-                ? Object.keys(linkList).reduce(
-                    (values, key) => {
-                      // eslint-disable-next-line react/no-unstable-nested-components
-                      values[key] = (text) => {
-                        const link = linkList[key];
-                        return (
-                          <SizableText
-                            color="$textInfo"
-                            cursor="pointer"
-                            onPress={() => onLinkDidPress(link)}
-                            {...link}
-                          >
-                            {text}
-                          </SizableText>
-                        );
-                      };
-                      return values;
-                    },
-                    {} as Record<
-                      string,
-                      string | ((value: any) => React.JSX.Element)
-                    >,
-                  )
-                : {}),
-              ...i18NValues,
-            } as Record<string, any>
-          }
+          values={formattedMessageValues}
         />
       ) : (
         children

--- a/packages/components/src/content/Splash/SplashView.tsx
+++ b/packages/components/src/content/Splash/SplashView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { AnimatePresence } from '@onekeyhq/components/src/shared/tamagui';
 
@@ -6,6 +6,8 @@ import { Image } from '../../primitives/Image';
 import { Stack } from '../../primitives/Stack';
 
 import type { ISplashViewProps } from './type';
+
+const exitStyle = { opacity: 0 };
 
 const removePreloadElements = () => {
   document.documentElement.style.removeProperty('background-color');
@@ -26,6 +28,13 @@ export function SplashView({ onExit, ready }: ISplashViewProps) {
     });
   }, [hideSplash, ready]);
 
+  const splashSource = useMemo(
+    () => ({
+      uri: require('../../../assets/splash.svg'),
+    }),
+    [],
+  );
+
   return (
     <AnimatePresence onExitComplete={onExit}>
       {showLoading ? (
@@ -40,9 +49,7 @@ export function SplashView({ onExit, ready }: ISplashViewProps) {
           bottom={0}
           opacity={1}
           flex={1}
-          exitStyle={{
-            opacity: 0,
-          }}
+          exitStyle={exitStyle}
         >
           <Stack
             width="100vw"
@@ -53,9 +60,7 @@ export function SplashView({ onExit, ready }: ISplashViewProps) {
             <Stack w={80} h={80}>
               <Image
                 flex={1}
-                source={{
-                  uri: require('../../../assets/splash.svg'),
-                }}
+                source={splashSource}
               />
             </Stack>
           </Stack>

--- a/packages/components/src/content/Splash/SplashView.tsx
+++ b/packages/components/src/content/Splash/SplashView.tsx
@@ -58,10 +58,7 @@ export function SplashView({ onExit, ready }: ISplashViewProps) {
             alignItems="center"
           >
             <Stack w={80} h={80}>
-              <Image
-                flex={1}
-                source={splashSource}
-              />
+              <Image flex={1} source={splashSource} />
             </Stack>
           </Stack>
         </Stack>

--- a/packages/components/src/forms/Checkbox/index.tsx
+++ b/packages/components/src/forms/Checkbox/index.tsx
@@ -18,6 +18,11 @@ import type { GestureResponderEvent, ViewStyle } from 'react-native';
 
 export type ICheckedState = CheckedState;
 
+const focusVisibleStyle = {
+  outlineOffset: 2,
+  outlineColor: '$focusRing',
+} as any;
+
 export type ICheckboxProps = IFormFieldProps<
   ICheckedState,
   Omit<TMCheckboxProps, 'size' | 'onCheckedChange' | 'checked' | 'value'> & {
@@ -94,12 +99,7 @@ function RawCheckbox({
         borderRadius="$1"
         alignItems="center"
         justifyContent="center"
-        focusVisibleStyle={
-          {
-            outlineOffset: 2,
-            outlineColor: '$focusRing',
-          } as any
-        }
+        focusVisibleStyle={focusVisibleStyle}
         hitSlop={NATIVE_HIT_SLOP}
         maxHeight="$5"
         {...(checkboxProps as IYStackProps)}

--- a/packages/components/src/forms/Form/index.tsx
+++ b/packages/components/src/forms/Form/index.tsx
@@ -135,6 +135,11 @@ const getChildProps = (
   }
 };
 
+const errorAnimationStyle = {
+  opacity: 0,
+  y: -6,
+};
+
 export function FieldDescription(props: ISizableTextProps) {
   return (
     <SizableText size="$bodyMd" pt="$1.5" color="$textSubdued" {...props} />
@@ -207,86 +212,95 @@ function Field({
       description
     );
   }, [description]);
+
+  const renderField = useCallback(
+    ({ field }: { field: ControllerRenderProps<any, string> }) => (
+      <Fieldset p="$0" m="$0" borderWidth={0} {...(display ? { display } : {})}>
+        <Stack
+          gap={horizontal ? '$1' : undefined}
+          flexDirection={horizontal ? 'row' : 'column'}
+          jc={horizontal ? 'space-between' : undefined}
+          alignItems={horizontal ? 'center' : undefined}
+          mb={horizontal ? '$1.5' : undefined}
+        >
+          <YStack flexShrink={horizontal ? 1 : undefined}>
+            {label ? (
+              <XStack
+                mb={horizontal ? undefined : '$1.5'}
+                justifyContent="space-between"
+              >
+                <XStack>
+                  <Label htmlFor={name}>{label}</Label>
+                  {optional ? (
+                    <SizableText size="$bodyMd" color="$textSubdued" pl="$1">
+                      {`(${intl.formatMessage({
+                        id: ETranslations.form_optional_indicator,
+                      })})`}
+                    </SizableText>
+                  ) : null}
+                </XStack>
+                {renderLabelAddon()}
+              </XStack>
+            ) : null}
+            {horizontal ? descriptionElement : null}
+          </YStack>
+          {Children.map(children as ReactNode[], (child) =>
+            isValidElement(child)
+              ? cloneElement(child, getChildProps(child, field, error))
+              : child,
+          )}
+        </Stack>
+        <HeightTransition>
+          {error?.message ? (
+            <SizableText
+              pt="$1.5"
+              animation="quick"
+              enterStyle={errorAnimationStyle}
+              exitStyle={errorAnimationStyle}
+              textAlign={errorMessageAlign}
+            >
+              {renderErrorMessage ? (
+                renderErrorMessage({ error })
+              ) : (
+                <SizableText
+                  color="$textCritical"
+                  size="$bodyMd"
+                  textAlign={errorMessageAlign}
+                  key={error?.message}
+                  testID={`${testID}-message`}
+                >
+                  {error?.message}
+                </SizableText>
+              )}
+            </SizableText>
+          ) : null}
+        </HeightTransition>
+        {horizontal ? null : descriptionElement}
+      </Fieldset>
+    ),
+    [
+      children,
+      descriptionElement,
+      display,
+      error,
+      errorMessageAlign,
+      horizontal,
+      intl,
+      label,
+      name,
+      optional,
+      renderErrorMessage,
+      renderLabelAddon,
+      testID,
+    ],
+  );
+
   return (
     <Controller
       name={name}
       control={control}
       rules={rules}
-      render={({ field }) => (
-        <Fieldset
-          p="$0"
-          m="$0"
-          borderWidth={0}
-          {...(display ? { display } : {})}
-        >
-          <Stack
-            gap={horizontal ? '$1' : undefined}
-            flexDirection={horizontal ? 'row' : 'column'}
-            jc={horizontal ? 'space-between' : undefined}
-            alignItems={horizontal ? 'center' : undefined}
-            mb={horizontal ? '$1.5' : undefined}
-          >
-            <YStack flexShrink={horizontal ? 1 : undefined}>
-              {label ? (
-                <XStack
-                  mb={horizontal ? undefined : '$1.5'}
-                  justifyContent="space-between"
-                >
-                  <XStack>
-                    <Label htmlFor={name}>{label}</Label>
-                    {optional ? (
-                      <SizableText size="$bodyMd" color="$textSubdued" pl="$1">
-                        {`(${intl.formatMessage({
-                          id: ETranslations.form_optional_indicator,
-                        })})`}
-                      </SizableText>
-                    ) : null}
-                  </XStack>
-                  {renderLabelAddon()}
-                </XStack>
-              ) : null}
-              {horizontal ? descriptionElement : null}
-            </YStack>
-            {Children.map(children as ReactNode[], (child) =>
-              isValidElement(child)
-                ? cloneElement(child, getChildProps(child, field, error))
-                : child,
-            )}
-          </Stack>
-          <HeightTransition>
-            {error?.message ? (
-              <SizableText
-                pt="$1.5"
-                animation="quick"
-                enterStyle={{
-                  opacity: 0,
-                  y: -6,
-                }}
-                exitStyle={{
-                  opacity: 0,
-                  y: -6,
-                }}
-                textAlign={errorMessageAlign}
-              >
-                {renderErrorMessage ? (
-                  renderErrorMessage({ error })
-                ) : (
-                  <SizableText
-                    color="$textCritical"
-                    size="$bodyMd"
-                    textAlign={errorMessageAlign}
-                    key={error?.message}
-                    testID={`${testID}-message`}
-                  >
-                    {error?.message}
-                  </SizableText>
-                )}
-              </SizableText>
-            ) : null}
-          </HeightTransition>
-          {horizontal ? null : descriptionElement}
-        </Fieldset>
-      )}
+      render={renderField}
     />
   );
 }

--- a/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/OtpInput.tsx
+++ b/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/OtpInput.tsx
@@ -92,13 +92,36 @@ export const OtpInput = forwardRef<IOtpInputRef, IOtpInputProps>(
       return stylesArray;
     };
 
-    const placeholderStyle = {
-      opacity: placeholder ? 0.5 : pinCodeTextStyle?.opacity || 1,
-      ...(placeholder ? placeholderTextStyle : {}),
-    };
+    const placeholderStyle = useMemo(
+      () => ({
+        opacity: placeholder ? 0.5 : pinCodeTextStyle?.opacity || 1,
+        ...(placeholder ? placeholderTextStyle : {}),
+      }),
+      [placeholder, pinCodeTextStyle?.opacity, placeholderTextStyle],
+    );
+
+    const containerViewStyle = useMemo(
+      () => [styles.container, containerStyle, inputsContainerStyle],
+      [containerStyle, inputsContainerStyle],
+    );
+
+    const hiddenInputStyle = useMemo(
+      () => [styles.hiddenInput, textInputProps?.style],
+      [textInputProps?.style],
+    );
+
+    const codeTextPlaceholderStyle = useMemo(
+      () => [styles.codeText, pinCodeTextStyle, placeholderStyle],
+      [pinCodeTextStyle, placeholderStyle],
+    );
+
+    const codeTextNormalStyle = useMemo(
+      () => [styles.codeText, pinCodeTextStyle],
+      [pinCodeTextStyle],
+    );
 
     return (
-      <View style={[styles.container, containerStyle, inputsContainerStyle]}>
+      <View style={containerViewStyle}>
         {Array(numberOfDigits)
           .fill(0)
           .map((_, index) => {
@@ -129,11 +152,11 @@ export const OtpInput = forwardRef<IOtpInputRef, IOtpInputProps>(
                   />
                 ) : (
                   <Text
-                    style={[
-                      styles.codeText,
-                      pinCodeTextStyle,
-                      isPlaceholderCell ? placeholderStyle : {},
-                    ]}
+                    style={
+                      isPlaceholderCell
+                        ? codeTextPlaceholderStyle
+                        : codeTextNormalStyle
+                    }
                   >
                     {char && secureTextEntry ? '•' : char}
                   </Text>
@@ -160,7 +183,7 @@ export const OtpInput = forwardRef<IOtpInputRef, IOtpInputProps>(
           caretHidden={Platform.OS === 'ios'}
           accessibilityLabel="OTP input field"
           {...textInputProps}
-          style={[styles.hiddenInput, textInputProps?.style]}
+          style={hiddenInputStyle}
         />
       </View>
     );

--- a/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/VerticalStick.tsx
+++ b/packages/components/src/forms/OTPInput/OtpEntry/OtpInput/VerticalStick.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { memo, useEffect, useRef } from 'react';
+import { memo, useEffect, useMemo, useRef } from 'react';
 
 import { Animated, View } from 'react-native';
 
@@ -45,16 +45,23 @@ function BasicVerticalStick({
     };
   }, [focusStickBlinkingDuration, opacityAnim]);
 
+  const animatedStyle = useMemo(
+    () => ({ opacity: opacityAnim }),
+    [opacityAnim],
+  );
+
+  const stickStyle = useMemo(
+    () => [
+      styles.stick,
+      focusColor ? { backgroundColor: focusColor } : {},
+      style,
+    ],
+    [focusColor, style],
+  );
+
   return (
-    <Animated.View style={{ opacity: opacityAnim }}>
-      <View
-        style={[
-          styles.stick,
-          focusColor ? { backgroundColor: focusColor } : {},
-          style,
-        ]}
-        testID="otp-input-stick"
-      />
+    <Animated.View style={animatedStyle}>
+      <View style={stickStyle} testID="otp-input-stick" />
     </Animated.View>
   );
 }

--- a/packages/components/src/forms/OTPInput/index.tsx
+++ b/packages/components/src/forms/OTPInput/index.tsx
@@ -82,40 +82,57 @@ export function OTPInput(
     [numberOfDigits, onTextChange],
   );
 
+  const otpTheme = useMemo(
+    () => ({
+      pinCodeTextStyle: {
+        fontSize: 20,
+        fontWeight: 'bold' as const,
+        color: theme.text.val,
+      },
+      pinCodeContainerStyle: {
+        width: 50,
+        height: 50,
+        borderWidth: 1,
+        borderColor:
+          innerStatus === 'error' ? theme.red9.val : theme.neutral7.val,
+      },
+      filledPinCodeContainerStyle: {
+        borderWidth: 2,
+        backgroundColor: theme.gray2.val,
+      },
+      focusedPinCodeContainerStyle: {
+        borderWidth: 2,
+        borderColor:
+          innerStatus === 'error' ? theme.red9.val : theme.borderActive.val,
+      },
+    }),
+    [
+      innerStatus,
+      theme.text.val,
+      theme.red9.val,
+      theme.neutral7.val,
+      theme.gray2.val,
+      theme.borderActive.val,
+    ],
+  );
+
+  const mergedTextInputProps = useMemo(
+    () => ({
+      ...textInputProps,
+      onPaste: handleOnPaste,
+    }),
+    [textInputProps, handleOnPaste],
+  );
+
   return (
     <OtpInput
       ref={ref}
-      theme={{
-        pinCodeTextStyle: {
-          fontSize: 20,
-          fontWeight: 'bold',
-          color: theme.text.val,
-        },
-        pinCodeContainerStyle: {
-          width: 50,
-          height: 50,
-          borderWidth: 1,
-          borderColor:
-            innerStatus === 'error' ? theme.red9.val : theme.neutral7.val,
-        },
-        filledPinCodeContainerStyle: {
-          borderWidth: 2,
-          backgroundColor: theme.gray2.val,
-        },
-        focusedPinCodeContainerStyle: {
-          borderWidth: 2,
-          borderColor:
-            innerStatus === 'error' ? theme.red9.val : theme.borderActive.val,
-        },
-      }}
+      theme={otpTheme}
       focusColor={theme.text.val}
       numberOfDigits={numberOfDigits}
       autoFocus={autoFocus}
       onTextChange={onTextChange}
-      textInputProps={{
-        ...textInputProps,
-        onPaste: handleOnPaste,
-      }}
+      textInputProps={mergedTextInputProps}
       {...rest}
     />
   );

--- a/packages/components/src/forms/Radio/index.tsx
+++ b/packages/components/src/forms/Radio/index.tsx
@@ -8,6 +8,11 @@ import { NATIVE_HIT_SLOP } from '../../utils/getFontSize';
 
 import type { IFormFieldProps } from '../types';
 
+const radioFocusVisibleStyle = {
+  outlineOffset: 2,
+  outlineColor: '$focusRing',
+};
+
 export type IRadioProps = IFormFieldProps<
   string,
   {
@@ -24,6 +29,56 @@ export type IRadioProps = IFormFieldProps<
     gap?: string;
   }
 >;
+
+function RadioOptionLabel({
+  v,
+  orientation,
+  optionDisabled,
+  label,
+  description,
+  optionChildren,
+  handleValueChange,
+}: {
+  v: string;
+  orientation: 'vertical' | 'horizontal';
+  optionDisabled?: boolean;
+  label: string;
+  description?: string;
+  optionChildren?: React.ReactNode;
+  handleValueChange: (v: string) => void;
+}) {
+  const handlePress = useCallback(() => {
+    handleValueChange(v);
+  }, [handleValueChange, v]);
+
+  return (
+    <YStack
+      userSelect="none"
+      py={orientation === 'horizontal' ? '$0' : '$2'}
+      my={orientation === 'horizontal' ? '$0' : '$-2'}
+      flex={orientation === 'horizontal' ? undefined : 1}
+      onPress={handlePress}
+    >
+      <Label
+        htmlFor={v}
+        variant="$bodyLgMedium"
+        color={optionDisabled ? '$textDisabled' : '$text'}
+      >
+        {label}
+      </Label>
+      {description ? (
+        <SizableText
+          size="$bodyMd"
+          color={optionDisabled ? '$textDisabled' : '$textSubdued'}
+          pt="$0.5"
+        >
+          {description}
+        </SizableText>
+      ) : null}
+      {optionChildren}
+    </YStack>
+  );
+}
 
 export function Radio({
   value,
@@ -101,10 +156,7 @@ export function Radio({
                   borderColor={value === v ? '$transparent' : '$borderStrong'}
                   backgroundColor={value === v ? '$bgPrimary' : '$transparent'}
                   borderRadius="$full"
-                  focusVisibleStyle={{
-                    outlineOffset: 2,
-                    outlineColor: '$focusRing',
-                  }}
+                  focusVisibleStyle={radioFocusVisibleStyle}
                   hitSlop={NATIVE_HIT_SLOP}
                   disabled={optionDisabled}
                 >
@@ -116,31 +168,15 @@ export function Radio({
                     borderRadius="$full"
                   />
                 </RadioGroup.Item>
-                <YStack
-                  userSelect="none"
-                  py={orientation === 'horizontal' ? '$0' : '$2'}
-                  my={orientation === 'horizontal' ? '$0' : '$-2'}
-                  flex={orientation === 'horizontal' ? undefined : 1}
-                  onPress={() => handleValueChange(v)}
-                >
-                  <Label
-                    htmlFor={v}
-                    variant="$bodyLgMedium"
-                    color={optionDisabled ? '$textDisabled' : '$text'}
-                  >
-                    {label}
-                  </Label>
-                  {description ? (
-                    <SizableText
-                      size="$bodyMd"
-                      color={optionDisabled ? '$textDisabled' : '$textSubdued'}
-                      pt="$0.5"
-                    >
-                      {description}
-                    </SizableText>
-                  ) : null}
-                  {optionChildren}
-                </YStack>
+                <RadioOptionLabel
+                  v={v}
+                  orientation={orientation}
+                  optionDisabled={optionDisabled}
+                  label={label}
+                  description={description}
+                  optionChildren={optionChildren}
+                  handleValueChange={handleValueChange}
+                />
               </ItemContainer>
             );
           },

--- a/packages/components/src/forms/Select/index.tsx
+++ b/packages/components/src/forms/Select/index.tsx
@@ -346,7 +346,7 @@ function SelectContent() {
   const mergedSheetProps = useMemo(
     () => ({
       dismissOnSnapToBottom: true,
-      snapPointsMode: usingPercentSnapPoints ? 'percent' : 'fit',
+      snapPointsMode: usingPercentSnapPoints ? ('percent' as const) : ('fit' as const),
       snapPoints: usingPercentSnapPoints ? [65] : undefined,
       ...sheetProps,
     }),

--- a/packages/components/src/forms/Select/index.tsx
+++ b/packages/components/src/forms/Select/index.tsx
@@ -96,6 +96,10 @@ function SelectTrigger({ renderTrigger }: ISelectTriggerProps) {
   );
 }
 
+const selectItemGtMdStyle = {
+  size: '$bodyMd' as const,
+};
+
 function SelectItemView({
   label,
   description,
@@ -107,9 +111,7 @@ function SelectItemView({
     <>
       <SizableText
         size="$bodyLg"
-        $gtMd={{
-          size: '$bodyMd',
-        }}
+        $gtMd={selectItemGtMdStyle}
         numberOfLines={2}
       >
         {label}
@@ -127,6 +129,14 @@ function SelectItemView({
     </>
   );
 }
+
+const selectItemMdStyle = {
+  py: '$2.5' as const,
+  borderRadius: '$3' as const,
+};
+
+const selectItemHoverStyle = { bg: '$bgHover' as const };
+const selectItemPressStyle = { bg: '$bgActive' as const };
 
 function SelectItem({
   onSelect,
@@ -153,14 +163,11 @@ function SelectItem({
         px="$2"
         py="$1.5"
         borderRadius="$2"
-        $md={{
-          py: '$2.5',
-          borderRadius: '$3',
-        }}
+        $md={selectItemMdStyle}
         borderCurve="continuous"
         opacity={disabled ? 0.5 : 1}
-        hoverStyle={disabled ? undefined : { bg: '$bgHover' }}
-        pressStyle={disabled ? undefined : { bg: '$bgActive' }}
+        hoverStyle={disabled ? undefined : selectItemHoverStyle}
+        pressStyle={disabled ? undefined : selectItemPressStyle}
         onPress={handleSelect}
         testID={testID}
         alignItems="center"
@@ -221,6 +228,8 @@ const useRenderPopoverTrigger = () => {
   );
 };
 
+const sectionHeaderMdStyle = { size: '$headingSm' as const, py: '$2.5' as const };
+
 const requestIdleCallback = (callback: () => void) => {
   setTimeout(callback, 150);
 };
@@ -279,7 +288,7 @@ function SelectContent() {
     ({ section }: { section: ISelectSection }) => (
       <Heading
         size="$headingXs"
-        $md={{ size: '$headingSm', py: '$2.5' }}
+        $md={sectionHeaderMdStyle}
         py="$1.5"
         px="$2"
         color="$textSubdued"
@@ -295,6 +304,8 @@ function SelectContent() {
       `${String(item.value)}-${item.label}-${index}`,
     [],
   );
+
+  const sectionSeparator = useMemo(() => <Stack h="$2" />, []);
 
   const renderContent = useMemo(
     () => {
@@ -315,7 +326,7 @@ function SelectContent() {
         <SectionList
           sections={sections}
           renderSectionHeader={renderSectionHeader}
-          SectionSeparatorComponent={<Stack h="$2" />}
+          SectionSeparatorComponent={sectionSeparator}
           {...(listProps as any)}
         />
       ) : (
@@ -332,23 +343,31 @@ function SelectContent() {
   const popoverTrigger = useRenderPopoverTrigger();
   const usingPercentSnapPoints =
     usingPercentSnapPointsFromContext || (items?.length && items?.length > 10);
+  const mergedSheetProps = useMemo(
+    () => ({
+      dismissOnSnapToBottom: true,
+      snapPointsMode: usingPercentSnapPoints ? 'percent' : 'fit',
+      snapPoints: usingPercentSnapPoints ? [65] : undefined,
+      ...sheetProps,
+    }),
+    [usingPercentSnapPoints, sheetProps],
+  );
+  const mergedFloatingPanelProps = useMemo(
+    () => ({
+      maxHeight: platformEnv.isNative ? undefined : '60vh',
+      width: '$56',
+      ...floatingPanelProps,
+    }),
+    [floatingPanelProps],
+  );
   return (
     <Popover
       title={title || ''}
       open={isOpen}
       onOpenChange={handleOpenChange}
       keepChildrenMounted={!platformEnv.isNative}
-      sheetProps={{
-        dismissOnSnapToBottom: true,
-        snapPointsMode: usingPercentSnapPoints ? 'percent' : 'fit',
-        snapPoints: usingPercentSnapPoints ? [65] : undefined,
-        ...sheetProps,
-      }}
-      floatingPanelProps={{
-        maxHeight: platformEnv.isNative ? undefined : '60vh',
-        width: '$56',
-        ...floatingPanelProps,
-      }}
+      sheetProps={mergedSheetProps}
+      floatingPanelProps={mergedFloatingPanelProps}
       placement={placement}
       renderTrigger={popoverTrigger}
       renderContent={renderContent}

--- a/packages/components/src/forms/Select/index.tsx
+++ b/packages/components/src/forms/Select/index.tsx
@@ -109,11 +109,7 @@ function SelectItemView({
 }) {
   return (
     <>
-      <SizableText
-        size="$bodyLg"
-        $gtMd={selectItemGtMdStyle}
-        numberOfLines={2}
-      >
+      <SizableText size="$bodyLg" $gtMd={selectItemGtMdStyle} numberOfLines={2}>
         {label}
       </SizableText>
       {description ? (
@@ -228,7 +224,10 @@ const useRenderPopoverTrigger = () => {
   );
 };
 
-const sectionHeaderMdStyle = { size: '$headingSm' as const, py: '$2.5' as const };
+const sectionHeaderMdStyle = {
+  size: '$headingSm' as const,
+  py: '$2.5' as const,
+};
 
 const requestIdleCallback = (callback: () => void) => {
   setTimeout(callback, 150);
@@ -346,7 +345,9 @@ function SelectContent() {
   const mergedSheetProps = useMemo(
     () => ({
       dismissOnSnapToBottom: true,
-      snapPointsMode: usingPercentSnapPoints ? ('percent' as const) : ('fit' as const),
+      snapPointsMode: usingPercentSnapPoints
+        ? ('percent' as const)
+        : ('fit' as const),
       snapPoints: usingPercentSnapPoints ? [65] : undefined,
       ...sheetProps,
     }),

--- a/packages/components/src/forms/Slider/index.native.tsx
+++ b/packages/components/src/forms/Slider/index.native.tsx
@@ -109,6 +109,14 @@ export function Slider({
     />
   );
 
+  const handlePressMin = useCallback(() => {
+    handleValueChange(min);
+  }, [handleValueChange, min]);
+
+  const handlePressMax = useCallback(() => {
+    handleValueChange(max);
+  }, [handleValueChange, max]);
+
   const value = props.value ?? props.defaultValue;
   return segments ? (
     <YStack position="relative" onLayout={handleLayout}>
@@ -123,9 +131,7 @@ export function Slider({
         >
           <XStack
             left={platformEnv.isNativeAndroid ? 12 : 2}
-            onPress={() => {
-              handleValueChange(min);
-            }}
+            onPress={handlePressMin}
           >
             <SliderSegment key={-1} marked />
           </XStack>
@@ -141,9 +147,7 @@ export function Slider({
           ))}
           <XStack
             right={platformEnv.isNativeAndroid ? 12 : 2}
-            onPress={() => {
-              handleValueChange(max);
-            }}
+            onPress={handlePressMax}
           >
             <SliderSegment key={segments ?? 1} marked={value === max} />
           </XStack>

--- a/packages/components/src/forms/Slider/index.tsx
+++ b/packages/components/src/forms/Slider/index.tsx
@@ -89,6 +89,19 @@ export const Slider = ({
     onSlideEnd?.();
   }, [onSlideEnd]);
 
+  const sliderValue = useMemo(
+    () =>
+      value !== undefined && value !== null ? [value] : undefined,
+    [value],
+  );
+  const sliderDefaultValue = useMemo(
+    () =>
+      defaultValue !== undefined && defaultValue !== null
+        ? [defaultValue]
+        : undefined,
+    [defaultValue],
+  );
+
   const sliderContent = useMemo(() => {
     return (
       <TMSlider
@@ -99,12 +112,8 @@ export const Slider = ({
         min={min}
         opacity={disabled ? 0.5 : 1}
         disabled={disabled}
-        value={value !== undefined && value !== null ? [value] : undefined}
-        defaultValue={
-          defaultValue !== undefined && defaultValue !== null
-            ? [defaultValue]
-            : undefined
-        }
+        value={sliderValue}
+        defaultValue={sliderDefaultValue}
         onValueChange={handleValueChange}
         // "onSlideStart does not work on the Web Platform"
         // onSlideStart={handleSlideStart}
@@ -132,7 +141,7 @@ export const Slider = ({
       </TMSlider>
     );
   }, [
-    defaultValue,
+    sliderDefaultValue,
     disabled,
     handleSlideEnd,
     handleSlideMove,
@@ -141,7 +150,7 @@ export const Slider = ({
     min,
     props,
     segments,
-    value,
+    sliderValue,
   ]);
   const handleMinPress = useCallback(() => {
     handleValueChange([min]);

--- a/packages/components/src/forms/Slider/index.tsx
+++ b/packages/components/src/forms/Slider/index.tsx
@@ -90,8 +90,7 @@ export const Slider = ({
   }, [onSlideEnd]);
 
   const sliderValue = useMemo(
-    () =>
-      value !== undefined && value !== null ? [value] : undefined,
+    () => (value !== undefined && value !== null ? [value] : undefined),
     [value],
   );
   const sliderDefaultValue = useMemo(
@@ -193,11 +192,7 @@ export const Slider = ({
           justifyContent="space-between"
           top={-layout.height / 2}
         >
-          <SliderSegment
-            key={-1}
-            isActive
-            onPress={handleMinPress}
-          />
+          <SliderSegment key={-1} isActive onPress={handleMinPress} />
           {segmentItems.map((item, index) => (
             <SliderSegment
               key={item.index}

--- a/packages/components/src/forms/Slider/index.tsx
+++ b/packages/components/src/forms/Slider/index.tsx
@@ -10,6 +10,10 @@ import { NATIVE_HIT_SLOP } from '../../utils/getFontSize';
 import type { IBaseSliderProps } from './type';
 import type { LayoutChangeEvent } from 'react-native';
 
+const thumbFocusVisibleStyle = {
+  outlineColor: '$borderActive' as const,
+};
+
 function SliderSegment({
   onPress,
   isActive,
@@ -123,9 +127,7 @@ export const Slider = ({
           borderWidth="$px"
           borderColor="$borderStrong"
           elevation={1}
-          focusVisibleStyle={{
-            outlineColor: '$borderActive',
-          }}
+          focusVisibleStyle={thumbFocusVisibleStyle}
         />
       </TMSlider>
     );
@@ -141,6 +143,36 @@ export const Slider = ({
     segments,
     value,
   ]);
+  const handleMinPress = useCallback(() => {
+    handleValueChange([min]);
+  }, [handleValueChange, min]);
+
+  const handleMaxPress = useCallback(() => {
+    handleValueChange([max]);
+  }, [handleValueChange, max]);
+
+  const segmentItems = useMemo(
+    () =>
+      segments
+        ? Array.from({ length: (segments ?? 1) - 1 }).map((_, index) => ({
+            index,
+            isActive: value
+              ? ((index + 1) / segments) * (max - min) + min <= value
+              : false,
+            segmentValue: min + ((max - min) * (index + 1)) / segments,
+          }))
+        : [],
+    [segments, value, max, min],
+  );
+
+  const segmentPressHandlers = useMemo(
+    () =>
+      segmentItems.map((item) => () => {
+        handleValueChange([item.segmentValue]);
+      }),
+    [segmentItems, handleValueChange],
+  );
+
   return segments ? (
     <YStack position="relative" onLayout={handleLayout}>
       {sliderContent}
@@ -155,31 +187,19 @@ export const Slider = ({
           <SliderSegment
             key={-1}
             isActive
-            onPress={() => {
-              handleValueChange([min]);
-            }}
+            onPress={handleMinPress}
           />
-          {Array.from({ length: (segments ?? 1) - 1 }).map((_, index) => (
+          {segmentItems.map((item, index) => (
             <SliderSegment
-              key={index}
-              isActive={
-                value
-                  ? ((index + 1) / segments) * (max - min) + min <= value
-                  : false
-              }
-              onPress={() => {
-                handleValueChange([
-                  min + ((max - min) * (index + 1)) / segments,
-                ]);
-              }}
+              key={item.index}
+              isActive={item.isActive}
+              onPress={segmentPressHandlers[index]}
             />
           ))}
           <SliderSegment
             key={segments ?? 1}
             isActive={value === max}
-            onPress={() => {
-              handleValueChange([max]);
-            }}
+            onPress={handleMaxPress}
           />
         </XStack>
       ) : null}

--- a/packages/components/src/forms/Switch/index.tsx
+++ b/packages/components/src/forms/Switch/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { TMSwitch, useTheme } from '@onekeyhq/components/src/shared/tamagui';
 import type { GetProps } from '@onekeyhq/components/src/shared/tamagui';
@@ -35,6 +35,29 @@ export function Switch({
 
   const checked = isUncontrolled ? stateChecked : value;
 
+  const handleCheckedChange = useCallback(
+    (v: boolean) => {
+      if (isUncontrolled) {
+        setStateChecked(v);
+      }
+      onChange?.(v);
+    },
+    [isUncontrolled, onChange],
+  );
+
+  const nativeProps = useMemo(
+    () => ({
+      disabled,
+      ios_backgroundColor: theme.neutral5.val,
+      trackColor: {
+        false: theme.neutral5.val,
+        true: theme.bgPrimary.val,
+      },
+      thumbColor: theme.bg.val,
+    }),
+    [disabled, theme.neutral5.val, theme.bgPrimary.val, theme.bg.val],
+  );
+
   return (
     <TMSwitch
       tag="span"
@@ -42,12 +65,7 @@ export function Switch({
       unstyled
       checked={checked}
       defaultChecked={defaultChecked}
-      onCheckedChange={(v) => {
-        if (isUncontrolled) {
-          setStateChecked(v);
-        }
-        onChange?.(v);
-      }}
+      onCheckedChange={handleCheckedChange}
       native
       w={size === 'small' ? 38 : 54}
       h={size === 'small' ? '$6' : '$8'}
@@ -59,15 +77,7 @@ export function Switch({
       borderColor="$transparent"
       opacity={disabled ? 0.5 : 1}
       disabled={disabled}
-      nativeProps={{
-        disabled,
-        ios_backgroundColor: theme.neutral5.val,
-        trackColor: {
-          false: theme.neutral5.val,
-          true: theme.bgPrimary.val,
-        },
-        thumbColor: theme.bg.val,
-      }}
+      nativeProps={nativeProps}
       {...restProps}
     >
       <TMSwitch.Thumb

--- a/packages/components/src/forms/TextArea/Input.tsx
+++ b/packages/components/src/forms/TextArea/Input.tsx
@@ -41,7 +41,7 @@ const textAreaAddOnsItemProps = {
     bg: '$bgActive',
     borderRadius: '$5',
   },
-};
+} as const;
 
 const textAreaInputComponentStyle = {
   h: undefined,

--- a/packages/components/src/forms/TextArea/Input.tsx
+++ b/packages/components/src/forms/TextArea/Input.tsx
@@ -18,6 +18,35 @@ export type ITextAreaInputProps = Omit<IInputProps, 'size'> &
 const defaultAlignVertical: TextAreaProps['verticalAlign'] =
   platformEnv.isNative ? 'top' : undefined;
 
+const textAreaContainerProps = {
+  flexDirection: 'column' as const,
+};
+
+const textAreaAddOnsContainerProps = {
+  justifyContent: 'flex-end' as const,
+  paddingBottom: '$2',
+  borderRadius: 0,
+  gap: '$2',
+  paddingRight: '$1',
+};
+
+const textAreaAddOnsItemProps = {
+  width: '$10',
+  height: '$10',
+  hoverStyle: {
+    bg: '$bgHover',
+    borderRadius: '$5',
+  },
+  pressStyle: {
+    bg: '$bgActive',
+    borderRadius: '$5',
+  },
+};
+
+const textAreaInputComponentStyle = {
+  h: undefined,
+};
+
 function BaseTextArea(
   { size, verticalAlign, allowSecureTextEye, ...props }: ITextAreaInputProps,
   forwardedRef: Ref<TextInput>,
@@ -36,37 +65,16 @@ function BaseTextArea(
   useAutoScrollToTop(ref);
   return (
     <Input
-      containerProps={{
-        flexDirection: 'column',
-      }}
-      addOnsContainerProps={{
-        justifyContent: 'flex-end',
-        paddingBottom: '$2',
-        borderRadius: 0,
-        gap: '$2',
-        paddingRight: '$1',
-      }}
-      addOnsItemProps={{
-        width: '$10',
-        height: '$10',
-        hoverStyle: {
-          bg: '$bgHover',
-          borderRadius: '$5',
-        },
-        pressStyle: {
-          bg: '$bgActive',
-          borderRadius: '$5',
-        },
-      }}
+      containerProps={textAreaContainerProps}
+      addOnsContainerProps={textAreaAddOnsContainerProps}
+      addOnsItemProps={textAreaAddOnsItemProps}
       InputComponent={TMTextArea}
       ref={ref}
       fontSize={getFontSize('$bodyLg')}
       py={size === 'large' ? '$3.5' : '$2.5'}
       numberOfLines={3}
       borderCurve="continuous"
-      InputComponentStyle={{
-        h: undefined,
-      }}
+      InputComponentStyle={textAreaInputComponentStyle}
       verticalAlign={verticalAlign || defaultAlignVertical}
       allowSecureTextEye={effectiveAllowSecureTextEye}
       {...props}

--- a/packages/components/src/layouts/DesktopDragZoneBox/index.desktop.tsx
+++ b/packages/components/src/layouts/DesktopDragZoneBox/index.desktop.tsx
@@ -4,18 +4,17 @@ import { Stack } from '../../primitives';
 
 import type { IDesktopDragZoneBoxProps } from './index.type';
 
+const dragZoneStyle = {
+  userSelect: 'none',
+  cursor: 'default',
+} as const;
+
 function BaseDesktopDragZoneBox({
   children,
   ...rest
 }: IDesktopDragZoneBoxProps) {
   return (
-    <Stack
-      {...rest}
-      style={{
-        userSelect: 'none',
-        cursor: 'default',
-      }}
-    >
+    <Stack {...rest} style={dragZoneStyle}>
       {children}
     </Stack>
   );
@@ -36,10 +35,7 @@ function DesktopDragZoneBoxMac({
       key="false"
       {...rest}
       className="app-region-drag"
-      style={{
-        userSelect: 'none',
-        cursor: 'default',
-      }}
+      style={dragZoneStyle}
     >
       {children}
     </Stack>

--- a/packages/components/src/layouts/DesktopDragZoneBox/index.tsx
+++ b/packages/components/src/layouts/DesktopDragZoneBox/index.tsx
@@ -4,18 +4,15 @@ import { Stack } from '../../primitives';
 
 import type { IDesktopDragZoneBoxProps } from './index.type';
 
+const dragZoneStyle = {
+  userSelect: 'none',
+  cursor: 'default',
+} as const;
+
 export const DesktopDragZoneBox: FC<IDesktopDragZoneBoxProps> = ({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   renderAs,
   ...rest
-}) => (
-  <Stack
-    {...rest}
-    style={{
-      userSelect: 'none',
-      cursor: 'default',
-    }}
-  />
-);
+}) => <Stack {...rest} style={dragZoneStyle} />;
 
 export * from './index.type';

--- a/packages/components/src/layouts/ListView/list.native.tsx
+++ b/packages/components/src/layouts/ListView/list.native.tsx
@@ -1,5 +1,5 @@
 import type { ForwardedRef, MutableRefObject } from 'react';
-import { forwardRef } from 'react';
+import { forwardRef, useMemo } from 'react';
 
 import { FlashList } from '@shopify/flash-list';
 
@@ -82,12 +82,15 @@ function BaseListView<T>(
     },
   );
 
+  const wrapperStyle = useMemo(
+    () => [{ flex: 1, minHeight: 2 }, style as StyleProp<ViewStyle>],
+    [style],
+  );
+
   return (
     // FlashList doesn't support the style, so we have to wrap it,
     // and we set default flex = 1 just like FlatList
-    <OptimizationView
-      style={[{ flex: 1, minHeight: 2 }, style as StyleProp<ViewStyle>]}
-    >
+    <OptimizationView style={wrapperStyle}>
       <FlashList<T>
         ref={ref as any}
         ListHeaderComponentStyle={listHeaderStyle}

--- a/packages/components/src/layouts/Navigation/BottomTabs/NativeBottomTabView.tsx
+++ b/packages/components/src/layouts/Navigation/BottomTabs/NativeBottomTabView.tsx
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+import { useCallback } from 'react';
+
 import TabView from '@onekeyfe/react-native-tab-view';
 import {
   CommonActions,
@@ -26,96 +28,161 @@ export function NativeBottomTabView({
   tabBar,
   ...rest
 }: Props) {
+  const renderScene = useCallback(
+    ({ route }: { route: Route<string> }) => descriptors[route.key]?.render(),
+    [descriptors],
+  );
+  const getActiveTintColor = useCallback(
+    ({ route }: { route: Route<string> }) =>
+      descriptors[route.key]?.options.tabBarActiveTintColor,
+    [descriptors],
+  );
+  const getLabelText = useCallback(
+    ({ route }: { route: Route<string> }) => {
+      const options = descriptors[route.key]?.options;
+
+      if (options?.tabBarLabel !== undefined) {
+        return options.tabBarLabel;
+      }
+      if (options?.title !== undefined) {
+        return options.title;
+      }
+      return (route as Route<string>).name;
+    },
+    [descriptors],
+  );
+  const getBadge = useCallback(
+    ({ route }: { route: Route<string> }) =>
+      descriptors[route.key]?.options.tabBarBadge,
+    [descriptors],
+  );
+  const getBadgeBackgroundColor = useCallback(
+    ({ route }: { route: Route<string> }) =>
+      descriptors[route.key]?.options.tabBarBadgeBackgroundColor,
+    [descriptors],
+  );
+  const getBadgeTextColor = useCallback(
+    ({ route }: { route: Route<string> }) =>
+      descriptors[route.key]?.options.tabBarBadgeTextColor,
+    [descriptors],
+  );
+  const getHidden = useCallback(
+    ({ route }: { route: Route<string> }) => {
+      const options = descriptors[route.key]?.options;
+      return options?.tabBarItemHidden === true;
+    },
+    [descriptors],
+  );
+  const getTestID = useCallback(
+    ({ route }: { route: Route<string> }) =>
+      descriptors[route.key]?.options.tabBarButtonTestID,
+    [descriptors],
+  );
+  const getRole = useCallback(
+    ({ route }: { route: Route<string> }) =>
+      descriptors[route.key]?.options.role,
+    [descriptors],
+  );
+  const tabBarCallback = useCallback(
+    () => (tabBar ? tabBar({ state, descriptors, navigation }) : undefined),
+    [tabBar, state, descriptors, navigation],
+  );
+  const getIcon = useCallback(
+    ({ route, focused }: { route: Route<string>; focused: boolean }) => {
+      const options = descriptors[route.key]?.options;
+
+      if (options?.tabBarIcon) {
+        const { tabBarIcon } = options;
+        return tabBarIcon({ focused });
+      }
+
+      return null;
+    },
+    [descriptors],
+  );
+  const getLazy = useCallback(
+    ({ route }: { route: Route<string> }) =>
+      descriptors[route.key]?.options.lazy ?? true,
+    [descriptors],
+  );
+  const getFreezeOnBlur = useCallback(
+    ({ route }: { route: Route<string> }) =>
+      descriptors[route.key]?.options.freezeOnBlur,
+    [descriptors],
+  );
+  const getSceneStyle = useCallback(
+    ({ route }: { route: Route<string> }) =>
+      descriptors[route.key]?.options.sceneStyle,
+    [descriptors],
+  );
+  const onTabLongPress = useCallback(
+    (index: number) => {
+      const route = state.routes[index];
+      if (!route) {
+        return;
+      }
+
+      navigation.emit({
+        type: 'tabLongPress',
+        target: route.key,
+      });
+    },
+    [state.routes, navigation],
+  );
+  const getPreventsDefault = useCallback(
+    ({ route }: { route: Route<string> }) =>
+      descriptors[route.key]?.options.preventsDefault,
+    [descriptors],
+  );
+  const onIndexChange = useCallback(
+    (index: number) => {
+      const focused = index === state.index;
+      const route = state.routes[index];
+      if (!route) {
+        return;
+      }
+
+      const event = navigation.emit({
+        type: 'tabPress',
+        target: route.key,
+        canPreventDefault: true,
+      });
+
+      if (
+        !focused &&
+        !event.defaultPrevented &&
+        !descriptors[route.key]?.options.preventsDefault
+      ) {
+        navigation.dispatch({
+          ...CommonActions.navigate(route),
+          target: state.key,
+        });
+      }
+    },
+    [state.index, state.routes, state.key, navigation, descriptors],
+  );
+
   return (
     <TabView
       {...rest}
       navigationState={state}
-      renderScene={({ route }) => descriptors[route.key]?.render()}
-      getActiveTintColor={({ route }) => {
-        return descriptors[route.key]?.options.tabBarActiveTintColor;
-      }}
-      getLabelText={({ route }) => {
-        const options = descriptors[route.key]?.options;
-
-        if (options?.tabBarLabel !== undefined) {
-          return options.tabBarLabel;
-        }
-        if (options?.title !== undefined) {
-          return options.title;
-        }
-        return (route as Route<string>).name;
-      }}
-      getBadge={({ route }) => descriptors[route.key]?.options.tabBarBadge}
-      getBadgeBackgroundColor={({ route }) =>
-        descriptors[route.key]?.options.tabBarBadgeBackgroundColor
-      }
-      getBadgeTextColor={({ route }) =>
-        descriptors[route.key]?.options.tabBarBadgeTextColor
-      }
-      getHidden={({ route }) => {
-        const options = descriptors[route.key]?.options;
-        return options?.tabBarItemHidden === true;
-      }}
-      getTestID={({ route }) =>
-        descriptors[route.key]?.options.tabBarButtonTestID
-      }
-      getRole={({ route }) => descriptors[route.key]?.options.role}
-      tabBar={
-        tabBar ? () => tabBar({ state, descriptors, navigation }) : undefined
-      }
-      getIcon={({ route, focused }) => {
-        const options = descriptors[route.key]?.options;
-
-        if (options?.tabBarIcon) {
-          const { tabBarIcon } = options;
-          return tabBarIcon({ focused });
-        }
-
-        return null;
-      }}
-      getLazy={({ route }) => descriptors[route.key]?.options.lazy ?? true}
-      getFreezeOnBlur={({ route }) =>
-        descriptors[route.key]?.options.freezeOnBlur
-      }
-      getSceneStyle={({ route }) => descriptors[route.key]?.options.sceneStyle}
-      onTabLongPress={(index) => {
-        const route = state.routes[index];
-        if (!route) {
-          return;
-        }
-
-        navigation.emit({
-          type: 'tabLongPress',
-          target: route.key,
-        });
-      }}
-      getPreventsDefault={({ route }) =>
-        descriptors[route.key]?.options.preventsDefault
-      }
-      onIndexChange={(index) => {
-        const focused = index === state.index;
-        const route = state.routes[index];
-        if (!route) {
-          return;
-        }
-
-        const event = navigation.emit({
-          type: 'tabPress',
-          target: route.key,
-          canPreventDefault: true,
-        });
-
-        if (
-          !focused &&
-          !event.defaultPrevented &&
-          !descriptors[route.key]?.options.preventsDefault
-        ) {
-          navigation.dispatch({
-            ...CommonActions.navigate(route),
-            target: state.key,
-          });
-        }
-      }}
+      renderScene={renderScene}
+      getActiveTintColor={getActiveTintColor}
+      getLabelText={getLabelText}
+      getBadge={getBadge}
+      getBadgeBackgroundColor={getBadgeBackgroundColor}
+      getBadgeTextColor={getBadgeTextColor}
+      getHidden={getHidden}
+      getTestID={getTestID}
+      getRole={getRole}
+      tabBar={tabBar ? tabBarCallback : undefined}
+      getIcon={getIcon}
+      getLazy={getLazy}
+      getFreezeOnBlur={getFreezeOnBlur}
+      getSceneStyle={getSceneStyle}
+      onTabLongPress={onTabLongPress}
+      getPreventsDefault={getPreventsDefault}
+      onIndexChange={onIndexChange}
     />
   );
 }

--- a/packages/components/src/layouts/Navigation/BottomTabs/NativeBottomTabView.tsx
+++ b/packages/components/src/layouts/Navigation/BottomTabs/NativeBottomTabView.tsx
@@ -47,7 +47,7 @@ export function NativeBottomTabView({
       if (options?.title !== undefined) {
         return options.title;
       }
-      return (route).name;
+      return route.name;
     },
     [descriptors],
   );

--- a/packages/components/src/layouts/Navigation/BottomTabs/NativeBottomTabView.tsx
+++ b/packages/components/src/layouts/Navigation/BottomTabs/NativeBottomTabView.tsx
@@ -47,7 +47,7 @@ export function NativeBottomTabView({
       if (options?.title !== undefined) {
         return options.title;
       }
-      return (route as Route<string>).name;
+      return (route).name;
     },
     [descriptors],
   );

--- a/packages/components/src/layouts/Navigation/Header/HeaderIconButton.tsx
+++ b/packages/components/src/layouts/Navigation/Header/HeaderIconButton.tsx
@@ -2,12 +2,14 @@ import { IconButton } from '../../../actions/IconButton';
 
 import type { IIconButtonProps } from '../../../actions/IconButton';
 
+const headerTooltipProps = {
+  placement: 'bottom',
+} as const;
+
 function HeaderIconButton(props: IIconButtonProps) {
   return (
     <IconButton
-      tooltipProps={{
-        placement: 'bottom',
-      }}
+      tooltipProps={headerTooltipProps}
       variant="tertiary"
       focusVisibleStyle={undefined}
       {...props}

--- a/packages/components/src/layouts/Navigation/Header/HeaderSearchBar.tsx
+++ b/packages/components/src/layouts/Navigation/Header/HeaderSearchBar.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useMedia } from '@onekeyhq/components/src/hooks/useStyle';
 
@@ -98,20 +98,25 @@ function HeaderSearchBar({
     [onSearchButtonPress],
   );
 
+  const searchBarContainerProps = useMemo(
+    () => ({
+      alignSelf: 'stretch' as const,
+      mb: '$4' as const,
+      $gtMd: {
+        ...(!isModalScreen && {
+          width: '$52' as const,
+          alignSelf: 'auto' as const,
+          mb: '$0' as const,
+        }),
+      },
+    }),
+    [isModalScreen],
+  );
+
   return (
     <XStack px="$5" w="100%">
       <SearchBar
-        containerProps={{
-          alignSelf: 'stretch',
-          mb: '$4',
-          $gtMd: {
-            ...(!isModalScreen && {
-              width: '$52',
-              alignSelf: 'auto',
-              mb: '$0',
-            }),
-          },
-        }}
+        containerProps={searchBarContainerProps}
         {...(media.gtMd &&
           !isModalScreen && {
             size: 'small',

--- a/packages/components/src/layouts/Navigation/Header/HeaderView.tsx
+++ b/packages/components/src/layouts/Navigation/Header/HeaderView.tsx
@@ -42,6 +42,8 @@ const HEADER_TITLE_BASE_STYLE = {
 } as const;
 const EMPTY_HEADER_RIGHT_CONTAINER_STYLE = {} as const;
 const EMPTY_HEADER_TITLE_CONTAINER_STYLE = {} as const;
+const EMPTY_OPTIONS = {} as const;
+const GTMD_FLEX_DIRECTION_ROW = { flexDirection: 'row' } as const;
 
 function getHeaderTitle(
   options: { title?: string; headerTitle?: HeaderOptions['headerTitle'] },
@@ -108,7 +110,7 @@ function HeaderView({
     // native HeaderSearchBar in packages/components/src/layouts/Page/PageHeader.tsx
     headerSearchBarOptions,
     headerTitleStyle,
-  } = options || {};
+  } = options || EMPTY_OPTIONS;
   const theme = useTheme();
   const state = navigation?.getState();
   const canGoBack = headerBack !== undefined;
@@ -189,6 +191,72 @@ function HeaderView({
     () => `${title}-${routeName}`,
     [title, routeName],
   );
+  const stackStyle = useMemo(
+    () =>
+      headerTransparent && !platformEnv.isNativeAndroid
+        ? HEADER_TRANSPARENT_STYLE
+        : EMPTY_HEADER_STYLE,
+    [headerTransparent],
+  );
+
+  const innerGtMd = useMemo(
+    () => (platformEnv.isNativeAndroid ? undefined : GTMD_FLEX_1),
+    [],
+  );
+
+  const headerRightContainerStyleMemo = useMemo(
+    () =>
+      isOnboardingScreen ? FLEX_GROW_0_STYLE : headerRightContainerStyle,
+    [isOnboardingScreen, headerRightContainerStyle],
+  );
+
+  const headerRightView = useCallback(
+    typeof headerRight === 'function'
+      ? ({ tintColor }: { tintColor?: string }) => {
+          const ele = headerRight({ tintColor, canGoBack });
+          return ele;
+        }
+      : () => headerRight as any,
+    [headerRight, canGoBack],
+  );
+
+  const headerTitleView = useCallback(
+    typeof headerTitle === 'function'
+      ? ({
+          children,
+          tintColor,
+        }: {
+          children: string;
+          tintColor?: string;
+        }) => headerTitle({ children, tintColor })
+      : () => null,
+    [headerTitle],
+  );
+
+  const headerTitleStyleMemo = useMemo(
+    () =>
+      headerTitleStyle
+        ? { ...HEADER_TITLE_BASE_STYLE, ...(headerTitleStyle as any) }
+        : HEADER_TITLE_BASE_STYLE,
+    [headerTitleStyle],
+  );
+
+  const headerTitleContainerStyleMemo = useMemo(
+    () => ({
+      marginHorizontal: 0,
+      ...(headerTitleContainerStyle as any),
+      ...(isOnboardingScreen
+        ? { flex: 1, alignItems: 'center' }
+        : undefined),
+    }),
+    [headerTitleContainerStyle, isOnboardingScreen],
+  );
+
+  const headerStyleMemo = useMemo(
+    () => [{ height: headerHeight }, headerStyle],
+    [headerHeight, headerStyle],
+  );
+
   if (!headerShown) {
     return null;
   }
@@ -199,19 +267,13 @@ function HeaderView({
         alignItems="center"
         bg={headerBackgroundColor}
         pt={isOnboardingScreen ? '$10' : undefined}
-        style={
-          headerTransparent && !platformEnv.isNativeAndroid
-            ? { position: 'absolute', right: 0, left: 0 }
-            : {}
-        }
+        style={stackStyle}
         pointerEvents="box-none"
-        {...(!isModelScreen && {
-          $gtMd: platformEnv.isNativeAndroid
-            ? undefined
-            : {
-                flexDirection: 'row',
-              },
-        })}
+        $gtMd={
+          !isModelScreen && !platformEnv.isNativeAndroid
+            ? GTMD_FLEX_DIRECTION_ROW
+            : undefined
+        }
       >
         <Stack
           alignSelf="stretch"
@@ -223,13 +285,7 @@ function HeaderView({
               ? WINDOWS_OVERLAY_BUTTONS_WIDTH
               : undefined
           }
-          $gtMd={
-            platformEnv.isNativeAndroid
-              ? undefined
-              : {
-                  flex: 1,
-                }
-          }
+          $gtMd={innerGtMd}
         >
           <Header
             layout={layout}
@@ -237,45 +293,24 @@ function HeaderView({
             key={headerViewKey}
             headerTintColor={theme.text.val}
             headerLeft={headerLeftView as any}
-            headerRightContainerStyle={
-              isOnboardingScreen ? { flexGrow: 0 } : headerRightContainerStyle
-            }
+            headerRightContainerStyle={headerRightContainerStyleMemo}
             headerTitleAllowFontScaling={false}
             headerRight={
               typeof headerRight === 'function'
-                ? ({ tintColor }) => {
-                    const ele = headerRight({ tintColor, canGoBack });
-                    return ele;
-                  }
+                ? headerRightView
                 : (headerRight as any)
             }
             headerTitle={
               typeof headerTitle === 'function'
-                ? ({ children, tintColor }) =>
-                    headerTitle({ children, tintColor })
+                ? headerTitleView
                 : headerTitle
             }
             headerTitleAlign={headerTitleAlign}
-            headerTitleStyle={{
-              lineHeight: 28,
-              fontWeight: '600',
-              ...(headerTitleStyle as any),
-            }}
-            headerTitleContainerStyle={{
-              marginHorizontal: 0,
-              ...(headerTitleContainerStyle as any),
-              ...(isOnboardingScreen
-                ? { flex: 1, alignItems: 'center' }
-                : undefined),
-            }}
+            headerTitleStyle={headerTitleStyleMemo}
+            headerTitleContainerStyle={headerTitleContainerStyleMemo}
             headerTransparent
             headerBackground={headerBackground}
-            headerStyle={[
-              {
-                height: headerHeight,
-              },
-              headerStyle,
-            ]}
+            headerStyle={headerStyleMemo}
           />
         </Stack>
         {headerSearchBarOptions ? (

--- a/packages/components/src/layouts/Navigation/Header/HeaderView.tsx
+++ b/packages/components/src/layouts/Navigation/Header/HeaderView.tsx
@@ -34,7 +34,7 @@ const HEADER_TRANSPARENT_STYLE = {
   left: 0,
 } as const;
 const EMPTY_HEADER_STYLE = {} as const;
-const GTMD_FLEX_1 = { flex: 1 } as const;
+const GT_MD_FLEX_1 = { flex: 1 } as const;
 const FLEX_GROW_0_STYLE = { flexGrow: 0 } as const;
 const HEADER_TITLE_BASE_STYLE = {
   lineHeight: 28,
@@ -43,7 +43,7 @@ const HEADER_TITLE_BASE_STYLE = {
 const EMPTY_HEADER_RIGHT_CONTAINER_STYLE = {} as const;
 const EMPTY_HEADER_TITLE_CONTAINER_STYLE = {} as const;
 const EMPTY_OPTIONS = {} as const;
-const GTMD_FLEX_DIRECTION_ROW = { flexDirection: 'row' } as const;
+const GT_MD_FLEX_DIRECTION_ROW = { flexDirection: 'row' } as const;
 
 function getHeaderTitle(
   options: { title?: string; headerTitle?: HeaderOptions['headerTitle'] },
@@ -200,7 +200,7 @@ function HeaderView({
   );
 
   const innerGtMd = useMemo(
-    () => (platformEnv.isNativeAndroid ? undefined : GTMD_FLEX_1),
+    () => (platformEnv.isNativeAndroid ? undefined : GT_MD_FLEX_1),
     [],
   );
 
@@ -265,7 +265,7 @@ function HeaderView({
         pointerEvents="box-none"
         $gtMd={
           !isModelScreen && !platformEnv.isNativeAndroid
-            ? GTMD_FLEX_DIRECTION_ROW
+            ? GT_MD_FLEX_DIRECTION_ROW
             : undefined
         }
       >

--- a/packages/components/src/layouts/Navigation/Header/HeaderView.tsx
+++ b/packages/components/src/layouts/Navigation/Header/HeaderView.tsx
@@ -205,31 +205,27 @@ function HeaderView({
   );
 
   const headerRightContainerStyleMemo = useMemo(
-    () =>
-      isOnboardingScreen ? FLEX_GROW_0_STYLE : headerRightContainerStyle,
+    () => (isOnboardingScreen ? FLEX_GROW_0_STYLE : headerRightContainerStyle),
     [isOnboardingScreen, headerRightContainerStyle],
   );
 
   const headerRightView = useCallback(
-    typeof headerRight === 'function'
-      ? ({ tintColor }: { tintColor?: string }) => {
-          const ele = headerRight({ tintColor, canGoBack });
-          return ele;
-        }
-      : () => headerRight as any,
+    ({ tintColor }: { tintColor?: string }) => {
+      if (typeof headerRight === 'function') {
+        return headerRight({ tintColor, canGoBack });
+      }
+      return headerRight as any;
+    },
     [headerRight, canGoBack],
   );
 
   const headerTitleView = useCallback(
-    typeof headerTitle === 'function'
-      ? ({
-          children,
-          tintColor,
-        }: {
-          children: string;
-          tintColor?: string;
-        }) => headerTitle({ children, tintColor })
-      : () => null,
+    ({ children, tintColor }: { children: string; tintColor?: string }) => {
+      if (typeof headerTitle === 'function') {
+        return headerTitle({ children, tintColor });
+      }
+      return null;
+    },
     [headerTitle],
   );
 
@@ -245,9 +241,7 @@ function HeaderView({
     () => ({
       marginHorizontal: 0,
       ...(headerTitleContainerStyle as any),
-      ...(isOnboardingScreen
-        ? { flex: 1, alignItems: 'center' }
-        : undefined),
+      ...(isOnboardingScreen ? { flex: 1, alignItems: 'center' } : undefined),
     }),
     [headerTitleContainerStyle, isOnboardingScreen],
   );
@@ -301,9 +295,7 @@ function HeaderView({
                 : (headerRight as any)
             }
             headerTitle={
-              typeof headerTitle === 'function'
-                ? headerTitleView
-                : headerTitle
+              typeof headerTitle === 'function' ? headerTitleView : headerTitle
             }
             headerTitleAlign={headerTitleAlign}
             headerTitleStyle={headerTitleStyleMemo}

--- a/packages/components/src/layouts/Navigation/Header/HeaderView.tsx
+++ b/packages/components/src/layouts/Navigation/Header/HeaderView.tsx
@@ -214,7 +214,7 @@ function HeaderView({
       if (typeof headerRight === 'function') {
         return headerRight({ tintColor, canGoBack });
       }
-      return headerRight as any;
+      return headerRight as React.ReactNode;
     },
     [headerRight, canGoBack],
   );
@@ -232,7 +232,10 @@ function HeaderView({
   const headerTitleStyleMemo = useMemo(
     () =>
       headerTitleStyle
-        ? { ...HEADER_TITLE_BASE_STYLE, ...(headerTitleStyle as any) }
+        ? {
+            ...HEADER_TITLE_BASE_STYLE,
+            ...(headerTitleStyle as Record<string, unknown>),
+          }
         : HEADER_TITLE_BASE_STYLE,
     [headerTitleStyle],
   );
@@ -240,8 +243,10 @@ function HeaderView({
   const headerTitleContainerStyleMemo = useMemo(
     () => ({
       marginHorizontal: 0,
-      ...(headerTitleContainerStyle as any),
-      ...(isOnboardingScreen ? { flex: 1, alignItems: 'center' } : undefined),
+      ...(headerTitleContainerStyle as Record<string, unknown>),
+      ...(isOnboardingScreen
+        ? { flex: 1, alignItems: 'center' as const }
+        : undefined),
     }),
     [headerTitleContainerStyle, isOnboardingScreen],
   );

--- a/packages/components/src/layouts/Navigation/Header/HeaderView.tsx
+++ b/packages/components/src/layouts/Navigation/Header/HeaderView.tsx
@@ -28,6 +28,21 @@ import type {
   Layout,
 } from '@react-navigation/elements';
 
+const HEADER_TRANSPARENT_STYLE = {
+  position: 'absolute',
+  right: 0,
+  left: 0,
+} as const;
+const EMPTY_HEADER_STYLE = {} as const;
+const GTMD_FLEX_1 = { flex: 1 } as const;
+const FLEX_GROW_0_STYLE = { flexGrow: 0 } as const;
+const HEADER_TITLE_BASE_STYLE = {
+  lineHeight: 28,
+  fontWeight: '600',
+} as const;
+const EMPTY_HEADER_RIGHT_CONTAINER_STYLE = {} as const;
+const EMPTY_HEADER_TITLE_CONTAINER_STYLE = {} as const;
+
 function getHeaderTitle(
   options: { title?: string; headerTitle?: HeaderOptions['headerTitle'] },
   fallback: string,
@@ -88,8 +103,8 @@ function HeaderView({
     headerStyle,
     headerBackground,
     headerShown = true,
-    headerRightContainerStyle = {},
-    headerTitleContainerStyle = {},
+    headerRightContainerStyle = EMPTY_HEADER_RIGHT_CONTAINER_STYLE,
+    headerTitleContainerStyle = EMPTY_HEADER_TITLE_CONTAINER_STYLE,
     // native HeaderSearchBar in packages/components/src/layouts/Page/PageHeader.tsx
     headerSearchBarOptions,
     headerTitleStyle,

--- a/packages/components/src/layouts/Navigation/Modal/createOnBoardingNavigator.tsx
+++ b/packages/components/src/layouts/Navigation/Modal/createOnBoardingNavigator.tsx
@@ -36,7 +36,43 @@ import type {
 import type { GestureResponderEvent } from 'react-native';
 
 const MODAL_ANIMATED_VIEW_REF_LIST: TamaguiElement[] = [];
+const modalTransitionStyle = {
+  transition: 'transform .25s cubic-bezier(0.4, 0, 0.2, 1)',
+  willChange: 'transform',
+};
 let ROOT_NAVIGATION_INDEX_LISTENER: (() => void) | undefined;
+
+const hiddenContentVisibilityStyle = { contentVisibility: 'hidden' as const };
+
+function RouteWrapper({
+  routeIndex,
+  isCurrentRoute,
+  stackChildrenRefList,
+  render,
+}: {
+  routeIndex: number;
+  isCurrentRoute: boolean;
+  stackChildrenRefList: React.MutableRefObject<TamaguiElement[]>;
+  render: () => React.ReactNode;
+}) {
+  const refCallback = useCallback(
+    (ref: TamaguiElement | null) => {
+      if (ref) {
+        stackChildrenRefList.current[routeIndex] = ref;
+      }
+    },
+    [stackChildrenRefList, routeIndex],
+  );
+  const style =
+    !platformEnv.isNative && !isCurrentRoute
+      ? hiddenContentVisibilityStyle
+      : undefined;
+  return (
+    <Stack ref={refCallback} flex={1} bg="$bg" style={style}>
+      {render()}
+    </Stack>
+  );
+}
 
 type IProps = DefaultNavigatorOptions<
   ParamListBase,
@@ -153,21 +189,12 @@ function OnBoardingModalNavigator({
     const { render } = routeDescriptor;
     const isCurrentRoute = routeIndex === state.index;
     routeDescriptor.render = () => (
-      <Stack
-        ref={(ref) => {
-          if (ref) {
-            stackChildrenRefList.current[routeIndex] = ref;
-          }
-        }}
-        flex={1}
-        bg="$bg"
-        style={{
-          contentVisibility:
-            !platformEnv.isNative && !isCurrentRoute ? 'hidden' : undefined,
-        }}
-      >
-        {render()}
-      </Stack>
+      <RouteWrapper
+        routeIndex={routeIndex}
+        isCurrentRoute={isCurrentRoute}
+        stackChildrenRefList={stackChildrenRefList}
+        render={render}
+      />
     );
   });
 
@@ -176,6 +203,15 @@ function OnBoardingModalNavigator({
       portalId: createPortalId(),
     }),
     [],
+  );
+
+  const modalViewRefCallback = useCallback(
+    (ref: TamaguiElement | null) => {
+      if (ref) {
+        MODAL_ANIMATED_VIEW_REF_LIST[currentRouteIndex] = ref;
+      }
+    },
+    [currentRouteIndex],
   );
 
   return (
@@ -194,15 +230,8 @@ function OnBoardingModalNavigator({
               height="100%"
               borderTopStartRadius="$6"
               borderTopEndRadius="$6"
-              ref={(ref) => {
-                if (ref) {
-                  MODAL_ANIMATED_VIEW_REF_LIST[currentRouteIndex] = ref;
-                }
-              }}
-              style={{
-                transition: 'transform .25s cubic-bezier(0.4, 0, 0.2, 1)',
-                willChange: 'transform',
-              }}
+              ref={modalViewRefCallback}
+              style={modalTransitionStyle}
             >
               <StackView
                 {...(rest as any)}

--- a/packages/components/src/layouts/Navigation/Modal/createWebModalNavigator.tsx
+++ b/packages/components/src/layouts/Navigation/Modal/createWebModalNavigator.tsx
@@ -59,6 +59,64 @@ type IProps = DefaultNavigatorOptions<
   IModalNavigationConfig;
 
 const backdropId = 'app-modal-stacks-backdrop';
+
+const backdropStyle = {
+  opacity: 0,
+  backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  transition: 'opacity .25s cubic-bezier(0.4, 0, 0.2, 1)',
+  willChange: 'opacity',
+};
+
+const dragRegionStyle = {
+  WebkitAppRegion: 'drag',
+} as any;
+
+const modalStyleGtMd = {
+  transition:
+    'opacity .25s cubic-bezier(0.175, 0.885, 0.32, 1.275), transform .25s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
+  willChange: 'opacity, transform',
+};
+
+const modalStyleMd = {
+  transition: 'transform .25s cubic-bezier(0.4, 0, 0.2, 1)',
+  willChange: 'transform',
+};
+
+const routeStyleFirst = {
+  transform: [{ translateX: 0 }],
+  transition: 'transform .25s cubic-bezier(0.4, 0, 0.2, 1)',
+  willChange: 'transform',
+  shadowColor: 'black',
+  shadowOpacity: 0.3,
+  shadowRadius: 10,
+  shadowOffset: { width: -5, height: 0 },
+};
+
+const containerGtMdStyle = {
+  justifyContent: 'center',
+  alignItems: 'center',
+};
+
+const modalScreenGtMdStyle = {
+  width: '90%',
+  height: '90%',
+  maxWidth: '$160',
+  maxHeight: '$160',
+  borderRadius: '$4',
+  outlineWidth: '$px',
+  outlineStyle: 'solid',
+  outlineColor: '$borderSubdued',
+};
+
+const routeStyleNonFirst = {
+  transform: [{ translateX: 640 }],
+  transition: 'transform .25s cubic-bezier(0.4, 0, 0.2, 1)',
+  willChange: 'transform',
+  shadowColor: 'black',
+  shadowOpacity: 0.3,
+  shadowRadius: 10,
+  shadowOffset: { width: -5, height: 0 },
+};
 function WebModalNavigator({
   initialRouteName,
   children,
@@ -272,6 +330,21 @@ function WebModalNavigator({
     isPagePressIn.current = true;
   }, []);
 
+  const backdropRefCallback = useCallback((ref: TamaguiElement | null) => {
+    if (ref) {
+      MODAL_ANIMATED_BACKDROP_VIEW_REF = ref;
+    }
+  }, []);
+
+  const modalScreenRefCallback = useCallback(
+    (ref: TamaguiElement | null) => {
+      if (ref) {
+        MODAL_ANIMATED_VIEW_REF_LIST[currentRouteIndex] = ref;
+      }
+    },
+    [currentRouteIndex],
+  );
+
   state.routes.forEach((route, routeIndex) => {
     const routeDescriptor = descriptors[route.key];
     // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -285,15 +358,7 @@ function WebModalNavigator({
         }}
         flex={1}
         bg="$bg"
-        style={{
-          transform: [{ translateX: routeIndex !== 0 ? 640 : 0 }],
-          transition: 'transform .25s cubic-bezier(0.4, 0, 0.2, 1)',
-          willChange: 'transform',
-          shadowColor: 'black',
-          shadowOpacity: 0.3,
-          shadowRadius: 10,
-          shadowOffset: { width: -5, height: 0 },
-        }}
+        style={routeIndex !== 0 ? routeStyleNonFirst : routeStyleFirst}
       >
         {render()}
       </Stack>
@@ -319,10 +384,7 @@ function WebModalNavigator({
         <>
           <Stack
             flex={1}
-            $gtMd={{
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}
+            $gtMd={containerGtMdStyle}
             onPress={platformEnv.isNative ? handleBackdropClick : undefined}
             onPressIn={
               platformEnv.isNative ? undefined : onPageContainerPressIn
@@ -334,26 +396,13 @@ function WebModalNavigator({
             {hasModalRoute && !isExistBackdrop ? (
               <YStack
                 testID={backdropId}
-                ref={(ref) => {
-                  if (ref) {
-                    MODAL_ANIMATED_BACKDROP_VIEW_REF = ref;
-                  }
-                }}
+                ref={backdropRefCallback}
                 fullscreen
-                style={{
-                  opacity: 0,
-                  backgroundColor: 'rgba(0, 0, 0, 0.5)',
-                  transition: 'opacity .25s cubic-bezier(0.4, 0, 0.2, 1)',
-                  willChange: 'opacity',
-                }}
+                style={backdropStyle}
               >
                 {platformEnv.isDesktopMac ? (
                   <XStack
-                    style={
-                      {
-                        WebkitAppRegion: 'drag',
-                      } as any
-                    }
+                    style={dragRegionStyle}
                     position="absolute"
                     top={0}
                     h={48}
@@ -375,33 +424,9 @@ function WebModalNavigator({
               height="100%"
               borderTopStartRadius="$6"
               borderTopEndRadius="$6"
-              $gtMd={{
-                width: '90%',
-                height: '90%',
-                maxWidth: '$160',
-                maxHeight: '$160',
-                borderRadius: '$4',
-                outlineWidth: '$px',
-                outlineStyle: 'solid',
-                outlineColor: '$borderSubdued',
-              }}
-              ref={(ref) => {
-                if (ref) {
-                  MODAL_ANIMATED_VIEW_REF_LIST[currentRouteIndex] = ref;
-                }
-              }}
-              style={
-                media.gtMd
-                  ? {
-                      transition:
-                        'opacity .25s cubic-bezier(0.175, 0.885, 0.32, 1.275), transform .25s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
-                      willChange: 'opacity, transform',
-                    }
-                  : {
-                      transition: 'transform .25s cubic-bezier(0.4, 0, 0.2, 1)',
-                      willChange: 'transform',
-                    }
-              }
+              $gtMd={modalScreenGtMdStyle}
+              ref={modalScreenRefCallback}
+              style={media.gtMd ? modalStyleGtMd : modalStyleMd}
             >
               <StackView
                 {...rest}

--- a/packages/components/src/layouts/Navigation/Modal/createWebModalNavigator.tsx
+++ b/packages/components/src/layouts/Navigation/Modal/createWebModalNavigator.tsx
@@ -58,6 +58,32 @@ type IProps = DefaultNavigatorOptions<
   StackRouterOptions &
   IModalNavigationConfig;
 
+function ModalRouteWrapper({
+  routeIndex,
+  stackChildrenRefList,
+  children,
+  style,
+}: {
+  routeIndex: number;
+  stackChildrenRefList: React.MutableRefObject<TamaguiElement[]>;
+  children: React.ReactNode;
+  style: any;
+}) {
+  const refCallback = useCallback(
+    (ref: TamaguiElement | null) => {
+      if (ref) {
+        stackChildrenRefList.current[routeIndex] = ref;
+      }
+    },
+    [routeIndex, stackChildrenRefList],
+  );
+  return (
+    <Stack ref={refCallback} flex={1} bg="$bg" style={style}>
+      {children}
+    </Stack>
+  );
+}
+
 const backdropId = 'app-modal-stacks-backdrop';
 
 const backdropStyle = {
@@ -95,7 +121,7 @@ const routeStyleFirst = {
 const containerGtMdStyle = {
   justifyContent: 'center',
   alignItems: 'center',
-};
+} as const;
 
 const modalScreenGtMdStyle = {
   width: '90%',
@@ -106,7 +132,7 @@ const modalScreenGtMdStyle = {
   outlineWidth: '$px',
   outlineStyle: 'solid',
   outlineColor: '$borderSubdued',
-};
+} as const;
 
 const routeStyleNonFirst = {
   transform: [{ translateX: 640 }],
@@ -350,18 +376,13 @@ function WebModalNavigator({
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const { render } = routeDescriptor;
     routeDescriptor.render = () => (
-      <Stack
-        ref={(ref) => {
-          if (ref) {
-            stackChildrenRefList.current[routeIndex] = ref;
-          }
-        }}
-        flex={1}
-        bg="$bg"
+      <ModalRouteWrapper
+        routeIndex={routeIndex}
+        stackChildrenRefList={stackChildrenRefList}
         style={routeIndex !== 0 ? routeStyleNonFirst : routeStyleFirst}
       >
         {render()}
-      </Stack>
+      </ModalRouteWrapper>
     );
   });
 

--- a/packages/components/src/layouts/Navigation/Navigator/ModalFlowNavigator.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/ModalFlowNavigator.tsx
@@ -41,47 +41,6 @@ const ModalStack = hasStackNavigatorModal
   ? createStackNavigator()
   : createWebModalNavigator();
 
-function ModalFlowScreen<RouteName extends string, P extends ParamListBase>({
-  name,
-  component,
-  options,
-  translationId,
-  shouldPopOnClickBackdrop,
-  dismissOnOverlayPress,
-  intl,
-}: IModalFlowNavigatorConfig<RouteName, P> & {
-  intl: ReturnType<typeof useIntl>;
-}) {
-  const customOptions: IModalNavigationOptions = useMemo(
-    () => ({
-      ...(typeof options === 'function' ? {} : options),
-      shouldPopOnClickBackdrop,
-      dismissOnOverlayPress,
-      title: translationId
-        ? intl.formatMessage({
-            id: translationId as ETranslations,
-          })
-        : '',
-    }),
-    [
-      options,
-      shouldPopOnClickBackdrop,
-      dismissOnOverlayPress,
-      translationId,
-      intl,
-    ],
-  );
-  const key = `Modal-Flow-${name as string}`;
-  return (
-    <ModalStack.Screen
-      key={key}
-      name={name}
-      component={component}
-      options={customOptions}
-    />
-  );
-}
-
 const OnBoardingStack = hasStackNavigatorModal
   ? createStackNavigator()
   : createOnBoardingNavigator();
@@ -143,13 +102,36 @@ function ModalFlowNavigator<RouteName extends string, P extends ParamListBase>({
   return (
     <PageTypeContext.Provider value={contextValue}>
       <ModalStackComponent.Navigator screenOptions={makeScreenOptions}>
-        {config.map((screenConfig) => (
-          <ModalFlowScreen
-            key={`Modal-Flow-${screenConfig.name as string}`}
-            {...screenConfig}
-            intl={intl}
-          />
-        ))}
+        {config.map(
+          ({
+            name,
+            component,
+            options,
+            translationId,
+            shouldPopOnClickBackdrop,
+            dismissOnOverlayPress,
+          }) => {
+            // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
+            const customOptions: IModalNavigationOptions = {
+              ...(typeof options === 'function' ? {} : options),
+              shouldPopOnClickBackdrop,
+              dismissOnOverlayPress,
+              title: translationId
+                ? intl.formatMessage({
+                    id: translationId as ETranslations,
+                  })
+                : '',
+            };
+            return (
+              <ModalStack.Screen
+                key={`Modal-Flow-${name as string}`}
+                name={name}
+                component={component}
+                options={customOptions}
+              />
+            );
+          },
+        )}
       </ModalStackComponent.Navigator>
     </PageTypeContext.Provider>
   );

--- a/packages/components/src/layouts/Navigation/Navigator/ModalFlowNavigator.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/ModalFlowNavigator.tsx
@@ -41,6 +41,47 @@ const ModalStack = hasStackNavigatorModal
   ? createStackNavigator()
   : createWebModalNavigator();
 
+function ModalFlowScreen<RouteName extends string, P extends ParamListBase>({
+  name,
+  component,
+  options,
+  translationId,
+  shouldPopOnClickBackdrop,
+  dismissOnOverlayPress,
+  intl,
+}: IModalFlowNavigatorConfig<RouteName, P> & {
+  intl: ReturnType<typeof useIntl>;
+}) {
+  const customOptions: IModalNavigationOptions = useMemo(
+    () => ({
+      ...(typeof options === 'function' ? {} : options),
+      shouldPopOnClickBackdrop,
+      dismissOnOverlayPress,
+      title: translationId
+        ? intl.formatMessage({
+            id: translationId as ETranslations,
+          })
+        : '',
+    }),
+    [
+      options,
+      shouldPopOnClickBackdrop,
+      dismissOnOverlayPress,
+      translationId,
+      intl,
+    ],
+  );
+  const key = `Modal-Flow-${name as string}`;
+  return (
+    <ModalStack.Screen
+      key={key}
+      name={name}
+      component={component}
+      options={customOptions}
+    />
+  );
+}
+
 const OnBoardingStack = hasStackNavigatorModal
   ? createStackNavigator()
   : createOnBoardingNavigator();
@@ -102,36 +143,13 @@ function ModalFlowNavigator<RouteName extends string, P extends ParamListBase>({
   return (
     <PageTypeContext.Provider value={contextValue}>
       <ModalStackComponent.Navigator screenOptions={makeScreenOptions}>
-        {config.map(
-          ({
-            name,
-            component,
-            options,
-            translationId,
-            shouldPopOnClickBackdrop,
-            dismissOnOverlayPress,
-          }) => {
-            const customOptions: IModalNavigationOptions = {
-              ...(typeof options === 'function' ? {} : options),
-              shouldPopOnClickBackdrop,
-              dismissOnOverlayPress,
-              title: translationId
-                ? intl.formatMessage({
-                    id: translationId as ETranslations,
-                  })
-                : '',
-            };
-            const key = `Modal-Flow-${name as string}`;
-            return (
-              <ModalStack.Screen
-                key={key}
-                name={name}
-                component={component}
-                options={customOptions}
-              />
-            );
-          },
-        )}
+        {config.map((screenConfig) => (
+          <ModalFlowScreen
+            key={`Modal-Flow-${screenConfig.name as string}`}
+            {...screenConfig}
+            intl={intl}
+          />
+        ))}
       </ModalStackComponent.Navigator>
     </PageTypeContext.Provider>
   );

--- a/packages/components/src/layouts/Navigation/Navigator/RootStackNavigator.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/RootStackNavigator.tsx
@@ -110,18 +110,23 @@ export function RootStackNavigator<
     [config, getOptionsWithType],
   );
 
+  const mergedScreenOptions = useMemo(
+    () => ({
+      ...presetScreenOptions,
+      ...screenOptions,
+    }),
+    [presetScreenOptions, screenOptions],
+  );
+
   return useMemo(
     () => (
       <RootStack.Navigator
         initialRouteName={initialRouteName}
-        screenOptions={{
-          ...presetScreenOptions,
-          ...screenOptions,
-        }}
+        screenOptions={mergedScreenOptions}
       >
         {renderedScreens}
       </RootStack.Navigator>
     ),
-    [initialRouteName, presetScreenOptions, renderedScreens, screenOptions],
+    [initialRouteName, mergedScreenOptions, renderedScreens],
   );
 }

--- a/packages/components/src/layouts/Navigation/Navigator/RootStackNavigator.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/RootStackNavigator.tsx
@@ -95,7 +95,7 @@ export function RootStackNavigator<
       config
         .filter(({ disable }) => !disable)
         .map(({ name, component, type, options }) => {
-          const screenOptions = (optionsInfo: IScreenOptionsInfo<any>) => ({
+          const routeScreenOptions = (optionsInfo: IScreenOptionsInfo<any>) => ({
             ...(typeof options === 'function'
               ? options(optionsInfo as any)
               : options),
@@ -106,7 +106,7 @@ export function RootStackNavigator<
               key={name}
               name={name}
               component={component}
-              options={screenOptions}
+              options={routeScreenOptions}
             />
           );
         }),

--- a/packages/components/src/layouts/Navigation/Navigator/RootStackNavigator.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/RootStackNavigator.tsx
@@ -95,7 +95,9 @@ export function RootStackNavigator<
       config
         .filter(({ disable }) => !disable)
         .map(({ name, component, type, options }) => {
-          const routeScreenOptions = (optionsInfo: IScreenOptionsInfo<any>) => ({
+          const routeScreenOptions = (
+            optionsInfo: IScreenOptionsInfo<any>,
+          ) => ({
             ...(typeof options === 'function'
               ? options(optionsInfo as any)
               : options),

--- a/packages/components/src/layouts/Navigation/Navigator/RootStackNavigator.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/RootStackNavigator.tsx
@@ -95,6 +95,7 @@ export function RootStackNavigator<
       config
         .filter(({ disable }) => !disable)
         .map(({ name, component, type, options }) => {
+          // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
           const routeScreenOptions = (
             optionsInfo: IScreenOptionsInfo<any>,
           ) => ({

--- a/packages/components/src/layouts/Navigation/Navigator/RootStackNavigator.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/RootStackNavigator.tsx
@@ -94,19 +94,22 @@ export function RootStackNavigator<
     () =>
       config
         .filter(({ disable }) => !disable)
-        .map(({ name, component, type, options }) => (
-          <RootStack.Screen
-            key={name}
-            name={name}
-            component={component}
-            options={(optionsInfo) => ({
-              ...(typeof options === 'function'
-                ? options(optionsInfo as any)
-                : options),
-              ...getOptionsWithType(type, optionsInfo),
-            })}
-          />
-        )),
+        .map(({ name, component, type, options }) => {
+          const screenOptions = (optionsInfo: IScreenOptionsInfo<any>) => ({
+            ...(typeof options === 'function'
+              ? options(optionsInfo as any)
+              : options),
+            ...getOptionsWithType(type, optionsInfo),
+          });
+          return (
+            <RootStack.Screen
+              key={name}
+              name={name}
+              component={component}
+              options={screenOptions}
+            />
+          );
+        }),
     [config, getOptionsWithType],
   );
 

--- a/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.native.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.native.tsx
@@ -73,6 +73,16 @@ export const TabSubStackNavigator = TabSubStackNavigatorMemo;
 
 const NativeTab = createNativeBottomTabNavigator();
 
+const extraScreenOptions = {
+  tabBarItemHidden: true,
+};
+
+const nativeTabScreenOptions = {
+  freezeOnBlur: true,
+  preventsDefault: false,
+  lazy: false,
+};
+
 export function TabStackNavigator<RouteName extends string>({
   config,
   extraConfig,
@@ -117,24 +127,28 @@ export function TabStackNavigator<RouteName extends string>({
           <TabSubStackNavigator config={children} />
         );
 
+        const options = {
+          // Type assertion needed because our INativeTabBarIcon uses string for sfSymbol
+          // while react-native-bottom-tabs expects SFSymbol type from sf-symbols-typescript
+          tabBarIcon: nativeTabBarIcon as any,
+          tabBarLabel: intl.formatMessage({ id: translationId }),
+        };
+
+        const listeners = {
+          tabPress: () => {
+            handleTabPress(name);
+            if (trackId) {
+              defaultLogger.app.page.tabBarClick(trackId);
+            }
+          },
+        };
+
         return (
           <NativeTab.Screen
             key={name}
             name={name}
-            options={{
-              // Type assertion needed because our INativeTabBarIcon uses string for sfSymbol
-              // while react-native-bottom-tabs expects SFSymbol type from sf-symbols-typescript
-              tabBarIcon: nativeTabBarIcon as any,
-              tabBarLabel: intl.formatMessage({ id: translationId }),
-            }}
-            listeners={{
-              tabPress: () => {
-                handleTabPress(name);
-                if (trackId) {
-                  defaultLogger.app.page.tabBarClick(trackId);
-                }
-              },
-            }}
+            options={options}
+            listeners={listeners}
           >
             {ScreenComponent}
           </NativeTab.Screen>
@@ -152,9 +166,7 @@ export function TabStackNavigator<RouteName extends string>({
         <NativeTab.Screen
           key={extraConfig.name}
           name={extraConfig.name}
-          options={{
-            tabBarItemHidden: true,
-          }}
+          options={extraScreenOptions}
         >
           {ExtraScreenComponent}
         </NativeTab.Screen>,
@@ -176,6 +188,14 @@ export function TabStackNavigator<RouteName extends string>({
         return tabBarHidden;
     }
   }, [tabBarHidden, splitViewType, isLandscape]);
+  const tabBarStyle = useMemo(
+    () =>
+      platformEnv.isNativeAndroid
+        ? { backgroundColor: theme.bg.val }
+        : undefined,
+    [theme.bg.val],
+  );
+
   return (
     <NativeTab.Navigator
       labeled
@@ -186,16 +206,8 @@ export function TabStackNavigator<RouteName extends string>({
       tabBarHidden={hidden}
       tabBarActiveTintColor={theme.iconActive.val}
       tabBarInactiveTintColor={theme.iconSubdued.val}
-      tabBarStyle={
-        platformEnv.isNativeAndroid
-          ? { backgroundColor: theme.bg.val }
-          : undefined
-      }
-      screenOptions={{
-        freezeOnBlur: true,
-        preventsDefault: false,
-        lazy: false,
-      }}
+      tabBarStyle={tabBarStyle}
+      screenOptions={nativeTabScreenOptions}
     >
       {tabScreens}
     </NativeTab.Navigator>

--- a/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.native.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.native.tsx
@@ -42,27 +42,30 @@ function BasicTabSubStackNavigator({
     <Stack.Navigator>
       {config
         .filter(({ disable }) => !disable)
-        .map(({ name, component, translationId, headerShown = true }) => (
-          <Stack.Screen
-            key={name}
-            name={name}
-            component={component}
-            options={({ navigation }: { navigation: any }) => ({
-              freezeOnBlur: true,
-              title: translationId
-                ? intl.formatMessage({
-                    id: translationId,
-                  })
-                : '',
-              ...makeTabScreenOptions({
-                navigation,
-                bgColor: theme.bgApp.val,
-                titleColor: theme.text.val,
-              }),
-              headerShown,
-            })}
-          />
-        ))}
+        .map(({ name, component, translationId, headerShown = true }) => {
+          const screenOptions = ({ navigation }: { navigation: any }) => ({
+            freezeOnBlur: true,
+            title: translationId
+              ? intl.formatMessage({
+                  id: translationId,
+                })
+              : '',
+            ...makeTabScreenOptions({
+              navigation,
+              bgColor: theme.bgApp.val,
+              titleColor: theme.text.val,
+            }),
+            headerShown,
+          });
+          return (
+            <Stack.Screen
+              key={name}
+              name={name}
+              component={component}
+              options={screenOptions}
+            />
+          );
+        })}
     </Stack.Navigator>
   );
 }

--- a/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.native.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.native.tsx
@@ -43,6 +43,7 @@ function BasicTabSubStackNavigator({
       {config
         .filter(({ disable }) => !disable)
         .map(({ name, component, translationId, headerShown = true }) => {
+          // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
           const screenOptions = ({ navigation }: { navigation: any }) => ({
             freezeOnBlur: true,
             title: translationId
@@ -130,6 +131,7 @@ export function TabStackNavigator<RouteName extends string>({
           <TabSubStackNavigator config={children} />
         );
 
+        // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
         const options = {
           // Type assertion needed because our INativeTabBarIcon uses string for sfSymbol
           // while react-native-bottom-tabs expects SFSymbol type from sf-symbols-typescript
@@ -137,6 +139,7 @@ export function TabStackNavigator<RouteName extends string>({
           tabBarLabel: intl.formatMessage({ id: translationId }),
         };
 
+        // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
         const listeners = {
           tabPress: () => {
             handleTabPress(name);

--- a/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.tsx
@@ -63,6 +63,14 @@ export const TabSubStackNavigator = TabSubStackNavigatorMemo;
 
 const Tab = createBottomTabNavigator();
 
+const emptyTabBar = () => null;
+
+const tabScreenOptions = {
+  headerShown: false,
+  freezeOnBlur: true,
+  lazy: false,
+};
+
 const useTabBarPosition = platformEnv.isNative
   ? () => 'bottom' as const
   : () => {
@@ -153,12 +161,8 @@ export function TabStackNavigator<RouteName extends string>({
 
   return (
     <Tab.Navigator
-      tabBar={showTabBar ? tabBarCallback : () => null}
-      screenOptions={{
-        headerShown: false,
-        freezeOnBlur: true,
-        lazy: false,
-      }}
+      tabBar={showTabBar ? tabBarCallback : emptyTabBar}
+      screenOptions={tabScreenOptions}
     >
       {tabScreens}
     </Tab.Navigator>

--- a/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.tsx
@@ -33,6 +33,7 @@ function BasicTabSubStackNavigator({
       {config
         .filter(({ disable }) => !disable)
         .map(({ name, component, translationId, headerShown = true }) => {
+          // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
           const screenOptions = ({ navigation }: { navigation: any }) => ({
             freezeOnBlur: true,
             title: translationId
@@ -123,6 +124,7 @@ export function TabStackNavigator<RouteName extends string>({
 
   const tabScreens = useMemo(() => {
     const screens = tabComponents.map(({ name, children, ...options }) => {
+      // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
       const screenOptions = {
         ...options,
         tabBarLabel: intl.formatMessage({ id: options.translationId }),
@@ -144,6 +146,7 @@ export function TabStackNavigator<RouteName extends string>({
       const children = () => (
         <TabSubStackNavigator config={extraConfig.children} />
       );
+      // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
       const extraScreenOptions = {
         freezeOnBlur: true,
         tabBarPosition,

--- a/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.tsx
@@ -32,27 +32,30 @@ function BasicTabSubStackNavigator({
     <Stack.Navigator>
       {config
         .filter(({ disable }) => !disable)
-        .map(({ name, component, translationId, headerShown = true }) => (
-          <Stack.Screen
-            key={name}
-            name={name}
-            component={component}
-            options={({ navigation }: { navigation: any }) => ({
-              freezeOnBlur: true,
-              title: translationId
-                ? intl.formatMessage({
-                    id: translationId,
-                  })
-                : '',
-              ...makeTabScreenOptions({
-                navigation,
-                bgColor: theme.bgApp.val,
-                titleColor: theme.text.val,
-              }),
-              headerShown,
-            })}
-          />
-        ))}
+        .map(({ name, component, translationId, headerShown = true }) => {
+          const screenOptions = ({ navigation }: { navigation: any }) => ({
+            freezeOnBlur: true,
+            title: translationId
+              ? intl.formatMessage({
+                  id: translationId,
+                })
+              : '',
+            ...makeTabScreenOptions({
+              navigation,
+              bgColor: theme.bgApp.val,
+              titleColor: theme.text.val,
+            }),
+            headerShown,
+          });
+          return (
+            <Stack.Screen
+              key={name}
+              name={name}
+              component={component}
+              options={screenOptions}
+            />
+          );
+        })}
     </Stack.Navigator>
   );
 }
@@ -119,38 +122,42 @@ export function TabStackNavigator<RouteName extends string>({
   const tabBarPosition = useTabBarPosition();
 
   const tabScreens = useMemo(() => {
-    const screens = tabComponents.map(({ name, children, ...options }) => (
-      <Tab.Screen
-        key={name}
-        name={name}
-        options={{
-          ...options,
-          tabBarLabel: intl.formatMessage({ id: options.translationId }),
-          tabBarPosition,
-          // @ts-expect-error Custom property for tab bar handling
-          collapseTabBarLabel: options.collapseSideBarTranslationId
-            ? intl.formatMessage({ id: options.collapseSideBarTranslationId })
-            : undefined,
-          hideOnTabBar: options.hideOnTabBar,
-          tabbarOnPress: options.tabbarOnPress,
-        }}
-      >
-        {children}
-      </Tab.Screen>
-    ));
+    const screens = tabComponents.map(({ name, children, ...options }) => {
+      const screenOptions = {
+        ...options,
+        tabBarLabel: intl.formatMessage({ id: options.translationId }),
+        tabBarPosition,
+        // @ts-expect-error Custom property for tab bar handling
+        collapseTabBarLabel: options.collapseSideBarTranslationId
+          ? intl.formatMessage({ id: options.collapseSideBarTranslationId })
+          : undefined,
+        hideOnTabBar: options.hideOnTabBar,
+        tabbarOnPress: options.tabbarOnPress,
+      };
+      return (
+        <Tab.Screen
+          key={name}
+          name={name}
+          options={screenOptions}
+        >
+          {children}
+        </Tab.Screen>
+      );
+    });
 
     if (extraConfig) {
       const children = () => (
         <TabSubStackNavigator config={extraConfig.children} />
       );
+      const extraScreenOptions = {
+        freezeOnBlur: true,
+        tabBarPosition,
+      };
       screens.push(
         <Tab.Screen
           key={extraConfig.name}
           name={extraConfig.name}
-          options={{
-            freezeOnBlur: true,
-            tabBarPosition,
-          }}
+          options={extraScreenOptions}
         >
           {children}
         </Tab.Screen>,

--- a/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.tsx
@@ -127,19 +127,14 @@ export function TabStackNavigator<RouteName extends string>({
         ...options,
         tabBarLabel: intl.formatMessage({ id: options.translationId }),
         tabBarPosition,
-        // @ts-expect-error Custom property for tab bar handling
         collapseTabBarLabel: options.collapseSideBarTranslationId
           ? intl.formatMessage({ id: options.collapseSideBarTranslationId })
           : undefined,
         hideOnTabBar: options.hideOnTabBar,
         tabbarOnPress: options.tabbarOnPress,
-      };
+      } as any;
       return (
-        <Tab.Screen
-          key={name}
-          name={name}
-          options={screenOptions}
-        >
+        <Tab.Screen key={name} name={name} options={screenOptions}>
           {children}
         </Tab.Screen>
       );
@@ -152,7 +147,7 @@ export function TabStackNavigator<RouteName extends string>({
       const extraScreenOptions = {
         freezeOnBlur: true,
         tabBarPosition,
-      };
+      } as any;
       screens.push(
         <Tab.Screen
           key={extraConfig.name}

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/SubmenuColumn.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/SubmenuColumn.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import type { ReactElement } from 'react';
 
 import { Stack, XStack, YStack } from '@onekeyhq/components/src/primitives';
@@ -14,10 +15,22 @@ export interface ISubmenuColumnProps {
   isExpanded?: boolean;
 }
 
+// @ts-expect-error - Electron drag region
+const dragRegionStyle = { WebkitAppRegion: 'drag' } as const;
+
 export function SubmenuColumn({
   webPageTabBar,
   isExpanded = false,
 }: ISubmenuColumnProps) {
+  const boxShadowStyle = useMemo(
+    () => ({
+      boxShadow: isExpanded
+        ? '10px 0 30px -10px rgba(0, 0, 0, 0.10)'
+        : 'none',
+    }),
+    [isExpanded],
+  );
+
   return (
     <Stack width={COLLAPSED_SUBMENU_WIDTH} flex={1}>
       {/* Desktop drag area - always bgSidebar, not affected by expand */}
@@ -29,10 +42,7 @@ export function SubmenuColumn({
           right={0}
           h={HEADER_ALIGNMENT_HEIGHT}
           zIndex={11}
-          style={{
-            // @ts-expect-error - Electron drag region
-            WebkitAppRegion: 'drag',
-          }}
+          style={dragRegionStyle}
         />
       ) : null}
       {/* Content area that expands on hover */}
@@ -53,11 +63,7 @@ export function SubmenuColumn({
         borderBottomWidth={1}
         borderRightWidth={1}
         borderColor={isExpanded ? '$neutral3' : 'transparent'}
-        style={{
-          boxShadow: isExpanded
-            ? '10px 0 30px -10px rgba(0, 0, 0, 0.10)'
-            : 'none',
-        }}
+        style={boxShadowStyle}
       >
         {webPageTabBar}
       </YStack>

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/SubmenuColumn.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/SubmenuColumn.tsx
@@ -15,8 +15,7 @@ export interface ISubmenuColumnProps {
   isExpanded?: boolean;
 }
 
-// @ts-expect-error - Electron drag region
-const dragRegionStyle = { WebkitAppRegion: 'drag' } as const;
+const dragRegionStyle = { WebkitAppRegion: 'drag' } as any;
 
 export function SubmenuColumn({
   webPageTabBar,
@@ -24,9 +23,7 @@ export function SubmenuColumn({
 }: ISubmenuColumnProps) {
   const boxShadowStyle = useMemo(
     () => ({
-      boxShadow: isExpanded
-        ? '10px 0 30px -10px rgba(0, 0, 0, 0.10)'
-        : 'none',
+      boxShadow: isExpanded ? '10px 0 30px -10px rgba(0, 0, 0, 0.10)' : 'none',
     }),
     [isExpanded],
   );

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/VerticalDivider.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/VerticalDivider.tsx
@@ -1,4 +1,3 @@
-
 import { LinearGradient } from '@onekeyhq/components/src/content/LinearGradient';
 import { useThemeName } from '@onekeyhq/components/src/hooks/useStyle';
 

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/VerticalDivider.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/VerticalDivider.tsx
@@ -3,25 +3,25 @@ import { useMemo } from 'react';
 import { LinearGradient } from '@onekeyhq/components/src/content/LinearGradient';
 import { useThemeName } from '@onekeyhq/components/src/hooks/useStyle';
 
-const locations = [0, 0.04, 0.5, 0.8, 1] as const;
-const gradientStart = [0, 0] as const;
-const gradientEnd = [0, 1] as const;
+const locations: [number, number, ...number[]] = [0, 0.04, 0.5, 0.8, 1];
+const gradientStart: [number, number] = [0, 0];
+const gradientEnd: [number, number] = [0, 1];
 
-const darkColors = [
+const darkColors: string[] = [
   'rgba(0, 0, 0, 0)',
   'rgba(0, 0, 0, 0)',
   'rgba(220, 220, 220, 0.12)',
   'rgba(0, 0, 0, 0)',
   'rgba(0, 0, 0, 0)',
-] as const;
+];
 
-const lightColors = [
+const lightColors: string[] = [
   'rgba(0, 0, 0, 0)',
   'rgba(0, 0, 0, 0)',
   'rgba(0, 0, 0, 0.1)',
   'rgba(0, 0, 0, 0)',
   'rgba(0, 0, 0, 0)',
-] as const;
+];
 
 export function VerticalDivider() {
   const themeName = useThemeName();

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/VerticalDivider.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/VerticalDivider.tsx
@@ -1,5 +1,27 @@
+import { useMemo } from 'react';
+
 import { LinearGradient } from '@onekeyhq/components/src/content/LinearGradient';
 import { useThemeName } from '@onekeyhq/components/src/hooks/useStyle';
+
+const locations = [0, 0.04, 0.5, 0.8, 1] as const;
+const gradientStart = [0, 0] as const;
+const gradientEnd = [0, 1] as const;
+
+const darkColors = [
+  'rgba(0, 0, 0, 0)',
+  'rgba(0, 0, 0, 0)',
+  'rgba(220, 220, 220, 0.12)',
+  'rgba(0, 0, 0, 0)',
+  'rgba(0, 0, 0, 0)',
+] as const;
+
+const lightColors = [
+  'rgba(0, 0, 0, 0)',
+  'rgba(0, 0, 0, 0)',
+  'rgba(0, 0, 0, 0.1)',
+  'rgba(0, 0, 0, 0)',
+  'rgba(0, 0, 0, 0)',
+] as const;
 
 export function VerticalDivider() {
   const themeName = useThemeName();
@@ -9,16 +31,10 @@ export function VerticalDivider() {
     <LinearGradient
       width={1}
       height="100%"
-      colors={[
-        'rgba(0, 0, 0, 0)',
-        'rgba(0, 0, 0, 0)',
-        isDark ? 'rgba(220, 220, 220, 0.12)' : 'rgba(0, 0, 0, 0.1)',
-        'rgba(0, 0, 0, 0)',
-        'rgba(0, 0, 0, 0)',
-      ]}
-      locations={[0, 0.04, 0.5, 0.8, 1]}
-      start={[0, 0]}
-      end={[0, 1]}
+      colors={isDark ? darkColors : lightColors}
+      locations={locations}
+      start={gradientStart}
+      end={gradientEnd}
     />
   );
 }

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/VerticalDivider.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/VerticalDivider.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 
 import { LinearGradient } from '@onekeyhq/components/src/content/LinearGradient';
 import { useThemeName } from '@onekeyhq/components/src/hooks/useStyle';

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
@@ -44,10 +44,10 @@ const ESTIMATED_TAB_ITEM_HEIGHT = 70;
 const TAB_BAR_STYLE_WIDTH_40 = { width: 40 };
 const TAB_BAR_STYLE_ARRAY_WIDTH_40 = [{ width: 40 }];
 const ENTER_EXIT_STYLE = { scale: 0.95, opacity: 0 };
-const OVERFLOW_ANIMATION: [
-  string,
-  { opacity: { overshootClamping: boolean } },
-] = ['quick', { opacity: { overshootClamping: true } }];
+const OVERFLOW_ANIMATION = [
+  'quick' as const,
+  { opacity: { overshootClamping: true } },
+] as const;
 const PLATFORM_WEB_SHADOW_STYLE = {
   outlineColor: '$neutral3',
   outlineStyle: 'solid',

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
@@ -41,6 +41,24 @@ import type { GestureResponderEvent, LayoutChangeEvent } from 'react-native';
 // Estimated height per tab item (icon ~40px + gap + label ~16-30px + padding 12px)
 const ESTIMATED_TAB_ITEM_HEIGHT = 70;
 
+const TAB_BAR_STYLE_WIDTH_40 = { width: 40 };
+const TAB_BAR_STYLE_ARRAY_WIDTH_40 = [{ width: 40 }];
+const ENTER_EXIT_STYLE = { scale: 0.95, opacity: 0 };
+const OVERFLOW_ANIMATION: [
+  string,
+  { opacity: { overshootClamping: boolean } },
+] = ['quick', { opacity: { overshootClamping: true } }];
+const PLATFORM_WEB_SHADOW_STYLE = {
+  outlineColor: '$neutral3',
+  outlineStyle: 'solid',
+  outlineWidth: '$px',
+  boxShadow:
+    '0 4px 6px -4px rgba(0, 0, 0, 0.10), 0 10px 15px -3px rgba(0, 0, 0, 0.10)',
+} as const;
+const HOVER_STYLE_BG_HOVER = { bg: '$bgHover' } as const;
+const PRESS_STYLE_BG_ACTIVE = { bg: '$bgActive' } as const;
+const PLATFORM_WEB_APP_REGION_DRAG = { 'app-region': 'drag' } as const;
+
 let lastBrowserRoute: string = ETabRoutes.Discovery;
 
 function DesktopWinSidebarTop() {
@@ -101,6 +119,14 @@ function TabItemView({
     [onPress, onPressOut, options],
   );
 
+  const tabBarStyleMemo = useMemo(
+    () =>
+      options.tabBarStyle
+        ? [options.tabBarStyle, TAB_BAR_STYLE_WIDTH_40]
+        : TAB_BAR_STYLE_ARRAY_WIDTH_40,
+    [options.tabBarStyle],
+  );
+
   const contentMemo = useMemo(
     () =>
       options.hideOnTabBar ? null : (
@@ -122,7 +148,7 @@ function TabItemView({
             trackId={options.trackId}
             aria-current={isActive ? 'page' : undefined}
             selected={isActive}
-            tabBarStyle={[options.tabBarStyle, { width: 40 }]}
+            tabBarStyle={tabBarStyleMemo}
             // @ts-expect-error
             icon={options?.tabBarIcon?.(isActive) as IKeyOfIcons}
             label=""
@@ -150,6 +176,7 @@ function TabItemView({
       isContainerHovered,
       options,
       route.name,
+      tabBarStyleMemo,
     ],
   );
 
@@ -231,26 +258,31 @@ function SidebarBottomItem({
       : undefined) ??
     route.name;
 
+  const renderTriggerMemo = useMemo(
+    () => (
+      <YStack
+        p="$2"
+        borderRadius="$2"
+        bg={isActive ? '$bgActive' : undefined}
+        hoverStyle={HOVER_STYLE_BG_HOVER}
+        pressStyle={PRESS_STYLE_BG_ACTIVE}
+        cursor="default"
+        onPress={onPress}
+      >
+        <Icon
+          name={iconName}
+          size="$6"
+          color={isActive ? '$iconActive' : '$iconSubdued'}
+        />
+      </YStack>
+    ),
+    [isActive, onPress, iconName],
+  );
+
   return (
     <Tooltip
       placement="right"
-      renderTrigger={
-        <YStack
-          p="$2"
-          borderRadius="$2"
-          bg={isActive ? '$bgActive' : undefined}
-          hoverStyle={{ bg: '$bgHover' }}
-          pressStyle={{ bg: '$bgActive' }}
-          cursor="default"
-          onPress={onPress}
-        >
-          <Icon
-            name={iconName}
-            size="$6"
-            color={isActive ? '$iconActive' : '$iconSubdued'}
-          />
-        </YStack>
-      }
+      renderTrigger={renderTriggerMemo}
       renderContent={label}
     />
   );
@@ -288,8 +320,8 @@ function OverflowMenuItem({
       bg={isActive ? '$bgActive' : undefined}
       cursor="default"
       userSelect="none"
-      hoverStyle={{ bg: '$bgHover' }}
-      pressStyle={{ bg: '$bgActive' }}
+      hoverStyle={HOVER_STYLE_BG_HOVER}
+      pressStyle={PRESS_STYLE_BG_ACTIVE}
       onPress={onPress}
     >
       <Icon
@@ -301,6 +333,48 @@ function OverflowMenuItem({
         {label}
       </SizableText>
     </XStack>
+  );
+}
+
+function OverflowMenuItemWithHandler({
+  route,
+  isActive,
+  options,
+  handleTabPress,
+  setIsOpen,
+}: {
+  route: NavigationState['routes'][0];
+  isActive: boolean;
+  options: BottomTabNavigationOptions & {
+    collapseTabBarLabel?: string;
+  };
+  handleTabPress: (
+    route: NavigationState['routes'][0],
+    isActive: boolean,
+    options?: {
+      tabbarOnPress?: () => void;
+      onPressWhenSelected?: () => void;
+      callback?: () => void;
+    },
+  ) => void;
+  setIsOpen: (value: boolean) => void;
+}) {
+  const handlePress = useCallback(() => {
+    handleTabPress(route, isActive, {
+      tabbarOnPress: (options as { tabbarOnPress?: () => void }).tabbarOnPress,
+      onPressWhenSelected: (options as { onPressWhenSelected?: () => void })
+        .onPressWhenSelected,
+      callback: () => setIsOpen(false),
+    });
+  }, [handleTabPress, route, isActive, options, setIsOpen]);
+
+  return (
+    <OverflowMenuItem
+      route={route}
+      isActive={isActive}
+      options={options}
+      onPress={handlePress}
+    />
   );
 }
 
@@ -351,6 +425,11 @@ function OverflowMoreButton({
     }
   }, []);
 
+  const handleContentHoverIn = useCallback(() => {
+    clearTimer();
+    setIsOpen(true);
+  }, [clearTimer]);
+
   useEffect(() => () => clearTimer(), [clearTimer]);
 
   const moreLabel = intl.formatMessage({ id: ETranslations.global_more });
@@ -375,7 +454,7 @@ function OverflowMoreButton({
           <DesktopTabItem
             isContainerHovered={isHovered || isOpen}
             selected={isAnyOverflowActive}
-            tabBarStyle={{ width: 40 }}
+            tabBarStyle={TAB_BAR_STYLE_WIDTH_40}
             icon={isAnyOverflowActive ? 'DotHorSolid' : 'DotHorOutline'}
             label=""
             showTooltip={false}
@@ -399,54 +478,83 @@ function OverflowMoreButton({
         p={0}
         bg="$bg"
         borderRadius="$3"
-        enterStyle={{ scale: 0.95, opacity: 0 }}
-        exitStyle={{ scale: 0.95, opacity: 0 }}
-        animation={['quick', { opacity: { overshootClamping: true } }]}
-        onHoverIn={() => {
-          clearTimer();
-          setIsOpen(true);
-        }}
+        enterStyle={ENTER_EXIT_STYLE}
+        exitStyle={ENTER_EXIT_STYLE}
+        animation={OVERFLOW_ANIMATION}
+        onHoverIn={handleContentHoverIn}
         onHoverOut={handleHoverOut}
-        $platform-web={{
-          outlineColor: '$neutral3',
-          outlineStyle: 'solid',
-          outlineWidth: '$px',
-          boxShadow:
-            '0 4px 6px -4px rgba(0, 0, 0, 0.10), 0 10px 15px -3px rgba(0, 0, 0, 0.10)',
-        }}
+        $platform-web={PLATFORM_WEB_SHADOW_STYLE}
       >
         <YStack p="$1">
           {overflowRoutes.map((route) => {
-            const focusedRouteName = state.routes[state.index]?.name;
+            const currentFocusedRouteName = state.routes[state.index]?.name;
             const isActive = isRouteActive(
               route,
-              focusedRouteName,
+              currentFocusedRouteName,
               extraConfig?.name,
             );
             const { options } = descriptors[route.key];
 
             return (
-              <OverflowMenuItem
+              <OverflowMenuItemWithHandler
                 key={route.key}
                 route={route}
                 isActive={isActive}
                 options={options}
-                onPress={() =>
-                  handleTabPress(route, isActive, {
-                    tabbarOnPress: (options as { tabbarOnPress?: () => void })
-                      .tabbarOnPress,
-                    onPressWhenSelected: (
-                      options as { onPressWhenSelected?: () => void }
-                    ).onPressWhenSelected,
-                    callback: () => setIsOpen(false),
-                  })
-                }
+                handleTabPress={handleTabPress}
+                setIsOpen={setIsOpen}
               />
             );
           })}
         </YStack>
       </TMPopover.Content>
     </TMPopover>
+  );
+}
+
+function VisibleTabItemView({
+  route,
+  isActive,
+  options,
+  handleTabPress,
+}: {
+  route: NavigationState['routes'][0];
+  isActive: boolean;
+  options: BottomTabNavigationOptions & {
+    actionList?: IActionListSection[];
+    tabbarOnPress?: () => void;
+    onPressWhenSelected?: () => void;
+    trackId?: string;
+    collapseTabBarLabel?: string;
+    hideOnTabBar?: boolean;
+  };
+  handleTabPress: (
+    route: NavigationState['routes'][0],
+    isActive: boolean,
+  ) => void;
+}) {
+  const handlePress = useCallback(() => {
+    // When clicking the Discovery sidebar icon, restore the last
+    // active browser route (Discovery or MultiTabBrowser) so that
+    // switching to another tab and back preserves the dApp page.
+    if (
+      route.name === ETabRoutes.Discovery &&
+      !isActive &&
+      lastBrowserRoute !== ETabRoutes.Discovery
+    ) {
+      switchTab(lastBrowserRoute as ETabRoutes);
+    } else {
+      handleTabPress(route, isActive);
+    }
+  }, [route, isActive, handleTabPress]);
+
+  return (
+    <TabItemView
+      route={route}
+      onPress={handlePress}
+      isActive={isActive}
+      options={options}
+    />
   );
 }
 
@@ -542,23 +650,34 @@ export function DesktopLeftSideBar({
     ? isRouteActive(deviceRoute, focusedRouteName, extraConfig?.name)
     : false;
 
+  const containerStyle = useMemo(
+    () => ({
+      backgroundColor: theme.bgSidebar.val,
+      paddingTop: top,
+      zIndex: 2,
+    }),
+    [theme.bgSidebar.val, top],
+  );
+
+  const handleDevicePress = useCallback(() => {
+    if (!deviceRoute) return;
+    handleTabPress(deviceRoute, isDeviceActive);
+    const { trackId } = descriptors[deviceRoute.key].options as {
+      trackId?: string;
+    };
+    if (trackId) {
+      defaultLogger.app.page.tabBarClick(trackId);
+    }
+  }, [deviceRoute, isDeviceActive, handleTabPress, descriptors]);
+
   return (
-    <XStack
-      testID="Desktop-AppSideBar-Container"
-      style={{
-        backgroundColor: theme.bgSidebar.val,
-        paddingTop: top,
-        zIndex: 2,
-      }}
-    >
+    <XStack testID="Desktop-AppSideBar-Container" style={containerStyle}>
       <YStack w={MIN_SIDEBAR_WIDTH}>
         {/* eslint-disable no-nested-ternary */}
         {platformEnv.isDesktopMac ? (
           // @ts-expect-error https://www.electronjs.org/docs/latest/tutorial/custom-window-interactions
           <XStack
-            $platform-web={{
-              'app-region': 'drag',
-            }}
+            $platform-web={PLATFORM_WEB_APP_REGION_DRAG}
             h={52}
             ai="center"
             jc="flex-end"
@@ -596,25 +715,12 @@ export function DesktopLeftSideBar({
                   extraConfig?.name,
                 );
                 return (
-                  <TabItemView
+                  <VisibleTabItemView
                     key={route.key}
                     route={route}
-                    onPress={() => {
-                      // When clicking the Discovery sidebar icon, restore the last
-                      // active browser route (Discovery or MultiTabBrowser) so that
-                      // switching to another tab and back preserves the dApp page.
-                      if (
-                        route.name === ETabRoutes.Discovery &&
-                        !isActive &&
-                        lastBrowserRoute !== ETabRoutes.Discovery
-                      ) {
-                        switchTab(lastBrowserRoute as ETabRoutes);
-                      } else {
-                        handleTabPress(route, isActive);
-                      }
-                    }}
                     isActive={isActive}
                     options={descriptors[route.key].options}
+                    handleTabPress={handleTabPress}
                   />
                 );
               })}
@@ -635,16 +741,7 @@ export function DesktopLeftSideBar({
                   route={deviceRoute}
                   isActive={isDeviceActive}
                   options={descriptors[deviceRoute.key].options}
-                  onPress={() => {
-                    handleTabPress(deviceRoute, isDeviceActive);
-                    const { trackId } = descriptors[deviceRoute.key]
-                      .options as {
-                      trackId?: string;
-                    };
-                    if (trackId) {
-                      defaultLogger.app.page.tabBarClick(trackId);
-                    }
-                  }}
+                  onPress={handleDevicePress}
                 />
               </YStack>
             ) : null}

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopLeftSideBar.tsx
@@ -44,10 +44,10 @@ const ESTIMATED_TAB_ITEM_HEIGHT = 70;
 const TAB_BAR_STYLE_WIDTH_40 = { width: 40 };
 const TAB_BAR_STYLE_ARRAY_WIDTH_40 = [{ width: 40 }];
 const ENTER_EXIT_STYLE = { scale: 0.95, opacity: 0 };
-const OVERFLOW_ANIMATION = [
-  'quick' as const,
-  { opacity: { overshootClamping: true } },
-] as const;
+const OVERFLOW_ANIMATION: [
+  'quick',
+  { opacity: { overshootClamping: boolean } },
+] = ['quick', { opacity: { overshootClamping: true } }];
 const PLATFORM_WEB_SHADOW_STYLE = {
   outlineColor: '$neutral3',
   outlineStyle: 'solid',

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopTabItem.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopTabItem.tsx
@@ -45,6 +45,8 @@ import type {
   ViewStyle,
 } from 'react-native';
 
+const emptyFragment = <></>;
+
 export interface IDesktopTabItemProps {
   hideCloseButton?: boolean;
   size?: 'small' | 'medium';
@@ -78,21 +80,25 @@ function BasicDesktopTabItemImage({
   avatarSrc?: string;
   selected?: boolean;
 }) {
+  const fallbackElement = useMemo(
+    () => (
+      <Image.Fallback bg="$bgSidebar" delayMs={180}>
+        <Icon
+          size="$4.5"
+          name="GlobusOutline"
+          color={selected ? '$iconActive' : '$iconSubdued'}
+        />
+      </Image.Fallback>
+    ),
+    [selected],
+  );
   return (
     <Image
       borderRadius="$1"
       size="$4.5"
       m="$px"
       source={avatarSrc}
-      fallback={
-        <Image.Fallback bg="$bgSidebar" delayMs={180}>
-          <Icon
-            size="$4.5"
-            name="GlobusOutline"
-            color={selected ? '$iconActive' : '$iconSubdued'}
-          />
-        </Image.Fallback>
-      }
+      fallback={fallbackElement}
     />
   );
 }
@@ -176,6 +182,21 @@ export function DesktopTabItem(
       }
     },
     [onPress, selected, trackId, onPressWhenSelected],
+  );
+  const handleRenderItems = useCallback(
+    ({ handleActionListOpen }: { handleActionListOpen: () => void }) => {
+      openActionList.current = handleActionListOpen;
+      return undefined;
+    },
+    [],
+  );
+  const handleActionListOpenChange = useCallback(
+    (isOpened: boolean) => {
+      reportPopoverOpen(isOpened);
+      setIsContextMenuOpened(isOpened);
+      setIsHovered(isOpened);
+    },
+    [reportPopoverOpen],
   );
   const trigger = useMemo(
     () => (
@@ -280,16 +301,9 @@ export function DesktopTabItem(
             title=""
             placement="right-start"
             sections={actionList}
-            renderTrigger={<></>}
-            renderItems={({ handleActionListOpen }) => {
-              openActionList.current = handleActionListOpen;
-              return undefined;
-            }}
-            onOpenChange={(isOpened) => {
-              reportPopoverOpen(isOpened);
-              setIsContextMenuOpened(isOpened);
-              setIsHovered(isOpened);
-            }}
+            renderTrigger={emptyFragment}
+            renderItems={handleRenderItems}
+            onOpenChange={handleActionListOpenChange}
           />
         ) : null}
         {children}
@@ -318,7 +332,8 @@ export function DesktopTabItem(
       closeButtonIcon,
       closeButtonTitle,
       actionList,
-      reportPopoverOpen,
+      handleRenderItems,
+      handleActionListOpenChange,
       intl,
       onClose,
       children,

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopTabItem.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopTabItem.tsx
@@ -198,20 +198,33 @@ export function DesktopTabItem(
     },
     [reportPopoverOpen],
   );
+  const tabItemGtMdStyle = useMemo(
+    () =>
+      ({
+        flexDirection: 'row',
+        px: '$2',
+        bg: selected ? '$bgActive' : undefined,
+        borderRadius: '$2',
+      }) as any,
+    [selected],
+  );
+  const defaultCloseButtonTitle = useMemo(
+    () => (
+      <Tooltip.Text shortcutKey={EShortcutEvents.CloseTab}>
+        {intl.formatMessage({
+          id: ETranslations.global_close,
+        })}
+      </Tooltip.Text>
+    ),
+    [intl],
+  );
   const trigger = useMemo(
     () => (
       <YStack
         {...tabBarItemStyle}
         alignItems="center"
         py="$2"
-        $gtMd={
-          {
-            flexDirection: 'row',
-            px: '$2',
-            bg: selected ? '$bgActive' : undefined,
-            borderRadius: '$2',
-          } as any
-        }
+        $gtMd={tabItemGtMdStyle}
         userSelect="none"
         {...((!selected && {
           pressStyle: {
@@ -282,15 +295,7 @@ export function DesktopTabItem(
             {...(closeButtonIcon ? { iconSize: '$4', p: '$1' } : { p: '$0.5' })}
             variant="tertiary"
             focusVisibleStyle={undefined}
-            title={
-              closeButtonTitle ?? (
-                <Tooltip.Text shortcutKey={EShortcutEvents.CloseTab}>
-                  {intl.formatMessage({
-                    id: ETranslations.global_close,
-                  })}
-                </Tooltip.Text>
-              )
-            }
+            title={closeButtonTitle ?? defaultCloseButtonTitle}
             m={-3}
             testID="browser-bar-options"
             onPress={onClose}
@@ -311,6 +316,7 @@ export function DesktopTabItem(
     ),
     [
       tabBarItemStyle,
+      tabItemGtMdStyle,
       selected,
       isContextMenuOpened,
       isHovered,
@@ -331,10 +337,10 @@ export function DesktopTabItem(
       alwaysShowCloseButton,
       closeButtonIcon,
       closeButtonTitle,
+      defaultCloseButtonTitle,
       actionList,
       handleRenderItems,
       handleActionListOpenChange,
-      intl,
       onClose,
       children,
     ],

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopTabItem.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopTabItem.tsx
@@ -205,7 +205,7 @@ export function DesktopTabItem(
         px: '$2',
         bg: selected ? '$bgActive' : undefined,
         borderRadius: '$2',
-      }) as any,
+      }) as IStackStyle,
     [selected],
   );
   const defaultCloseButtonTitle = useMemo(

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/Menu.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/Menu.tsx
@@ -9,6 +9,29 @@ import type {
   IMenuItem,
 } from '@onekeyhq/kit-bg/src/desktopApis/DesktopApiSystem';
 
+const MENU_ICON_STYLE = {
+  width: 16,
+  height: 16,
+  marginRight: 8,
+  flexShrink: 0,
+} as const;
+
+const MENU_CONTAINER_STYLE = {
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: '2px',
+  padding: '4px 8px',
+} as const;
+
+const MENU_ITEM_RELATIVE_STYLE = { position: 'relative' } as const;
+
+const MENU_TRIGGER_BASE_STYLE = {
+  padding: '4px 8px',
+  width: 'auto',
+  fontSize: '13px',
+} as const;
+
 function MenuItemComponent({
   item,
   onClose,
@@ -43,6 +66,16 @@ function MenuItemComponent({
       });
   }, [item.commandId, item.enabled, item.submenu, onClose]);
 
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        handleClick();
+      }
+    },
+    [handleClick],
+  );
+
   if (item.type === 'separator') {
     return <div className="desktop-menu-separator" />;
   }
@@ -59,12 +92,7 @@ function MenuItemComponent({
       tabIndex={0}
       className={`desktop-menu-item ${!item.enabled ? 'disabled' : ''}`}
       onClick={handleClick}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          handleClick();
-        }
-      }}
+      onKeyDown={handleKeyDown}
     >
       {/* eslint-disable no-nested-ternary */}
       {iconDataUrl ? (
@@ -72,22 +100,12 @@ function MenuItemComponent({
           src={iconDataUrl}
           alt=""
           className="desktop-menu-item-icon"
-          style={{
-            width: 16,
-            height: 16,
-            marginRight: 8,
-            flexShrink: 0,
-          }}
+          style={MENU_ICON_STYLE}
         />
       ) : item.icon ? (
         <span
           className="desktop-menu-item-icon-placeholder"
-          style={{
-            width: 16,
-            height: 16,
-            marginRight: 8,
-            flexShrink: 0,
-          }}
+          style={MENU_ICON_STYLE}
         />
       ) : null}
       {/* eslint-enable no-nested-ternary */}
@@ -218,13 +236,7 @@ export function Menu() {
       className={`desktop-menu-container ${
         themeName === 'light' ? 'light-theme' : ''
       }`}
-      style={{
-        display: 'flex',
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: '2px',
-        padding: '4px 8px',
-      }}
+      style={MENU_CONTAINER_STYLE}
     >
       {menu.items.map((menuItem, index) => {
         if (!menuItem.submenu || menuItem.submenu.items.length === 0) {
@@ -232,38 +244,17 @@ export function Menu() {
         }
 
         return (
-          <div
+          <MenuTriggerItem
             key={`menu-${index}`}
-            className="desktop-menu-container"
-            style={{ position: 'relative' }}
-          >
-            <div
-              role="menuitem"
-              tabIndex={0}
-              className="desktop-menu-trigger"
-              onClick={() => handleMenuTriggerClick(index)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  handleMenuTriggerClick(index);
-                }
-              }}
-              onMouseEnter={() => handleMenuTriggerHover(index)}
-              style={{
-                padding: '4px 8px',
-                width: 'auto',
-                fontSize: '13px',
-                color: themeName === 'light' ? '#1a1a1a' : '#e5e5e5',
-              }}
-            >
-              {menuItem.label}
-            </div>
-            <MenuDropdown
-              items={menuItem.submenu.items}
-              isOpen={isOpen ? activeMenuIndex === index : false}
-              onClose={handleClose}
-            />
-          </div>
+            menuItem={menuItem}
+            index={index}
+            isOpen={isOpen}
+            activeMenuIndex={activeMenuIndex}
+            handleMenuTriggerClick={handleMenuTriggerClick}
+            handleMenuTriggerHover={handleMenuTriggerHover}
+            handleClose={handleClose}
+            themeName={themeName}
+          />
         );
       })}
     </div>

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/Menu.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/Menu.tsx
@@ -208,10 +208,7 @@ function MenuTriggerItem({
   );
 
   return (
-    <div
-      className="desktop-menu-container"
-      style={MENU_ITEM_RELATIVE_STYLE}
-    >
+    <div className="desktop-menu-container" style={MENU_ITEM_RELATIVE_STYLE}>
       <div
         role="menuitem"
         tabIndex={0}

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/Menu.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/Menu.tsx
@@ -162,6 +162,76 @@ function MenuDropdown({
   );
 }
 
+function MenuTriggerItem({
+  menuItem,
+  index,
+  isOpen,
+  activeMenuIndex,
+  handleMenuTriggerClick,
+  handleMenuTriggerHover,
+  handleClose,
+  themeName,
+}: {
+  menuItem: IMenuItem;
+  index: number;
+  isOpen: boolean;
+  activeMenuIndex: number | null;
+  handleMenuTriggerClick: (index: number) => void;
+  handleMenuTriggerHover: (index: number) => void;
+  handleClose: () => void;
+  themeName: string;
+}) {
+  const handleClick = useCallback(() => {
+    handleMenuTriggerClick(index);
+  }, [handleMenuTriggerClick, index]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        handleMenuTriggerClick(index);
+      }
+    },
+    [handleMenuTriggerClick, index],
+  );
+
+  const handleHover = useCallback(() => {
+    handleMenuTriggerHover(index);
+  }, [handleMenuTriggerHover, index]);
+
+  const triggerStyle = useMemo(
+    () => ({
+      ...MENU_TRIGGER_BASE_STYLE,
+      color: themeName === 'light' ? '#1a1a1a' : '#e5e5e5',
+    }),
+    [themeName],
+  );
+
+  return (
+    <div
+      className="desktop-menu-container"
+      style={MENU_ITEM_RELATIVE_STYLE}
+    >
+      <div
+        role="menuitem"
+        tabIndex={0}
+        className="desktop-menu-trigger"
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        onMouseEnter={handleHover}
+        style={triggerStyle}
+      >
+        {menuItem.label}
+      </div>
+      <MenuDropdown
+        items={menuItem.submenu!.items}
+        isOpen={isOpen ? activeMenuIndex === index : false}
+        onClose={handleClose}
+      />
+    </div>
+  );
+}
+
 export function Menu() {
   const [menu, setMenu] = useState<IMenu | null>(null);
   const [isOpen, setIsOpen] = useState(false);
@@ -305,6 +375,16 @@ export function MenuHamburger() {
     setIsOpen((prev) => !prev);
   }, []);
 
+  const handleToggleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        toggleMenu();
+      }
+    },
+    [toggleMenu],
+  );
+
   const allItems = useMemo(() => {
     // Flatten all menu items for hamburger menu display
     const itemArray: IMenuItem[] = [];
@@ -321,12 +401,16 @@ export function MenuHamburger() {
   }, [menu]);
 
   // Compute dropdown position from trigger element
-  const dropdownPosition = useMemo(() => {
+  const dropdownStyle = useMemo(() => {
     if (isOpen && triggerRef.current) {
       const rect = triggerRef.current.getBoundingClientRect();
-      return { top: rect.top, left: rect.right };
+      return {
+        position: 'fixed' as const,
+        top: rect.top,
+        left: rect.right,
+      };
     }
-    return { top: 0, left: 0 };
+    return { position: 'fixed' as const, top: 0, left: 0 };
   }, [isOpen]);
 
   if (
@@ -352,12 +436,7 @@ export function MenuHamburger() {
           aria-label="Menu"
           className="desktop-menu-trigger"
           onClick={toggleMenu}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              toggleMenu();
-            }
-          }}
+          onKeyDown={handleToggleKeyDown}
         >
           <Icon
             name="MenuOutline"
@@ -374,11 +453,7 @@ export function MenuHamburger() {
               className={`desktop-menu-dropdown open ${
                 themeName === 'light' ? 'light-theme' : ''
               }`}
-              style={{
-                position: 'fixed',
-                top: dropdownPosition.top,
-                left: dropdownPosition.left,
-              }}
+              style={dropdownStyle}
             >
               {allItems.map((item, index) => (
                 <MenuItemComponent

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/MobileBottomTabBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/MobileBottomTabBar.tsx
@@ -35,6 +35,11 @@ import type {
 } from '@react-navigation/bottom-tabs';
 import type { RouteProp } from '@react-navigation/native';
 
+const tabBarRowStyle = {
+  flexDirection: 'row' as const,
+  justifyContent: 'space-around' as const,
+};
+
 export type IMobileBottomTabBarProps = BottomTabBarProps & {
   backgroundColor?: string;
   trackId?: string;
@@ -167,12 +172,7 @@ export default function MobileBottomTabBar({
       borderTopColor="$borderSubdued"
       pb={bottom}
     >
-      <View
-        style={{
-          flexDirection: 'row',
-          justifyContent: 'space-around',
-        }}
-      >
+      <View style={tabBarRowStyle}>
         {tabs}
       </View>
     </Stack>

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/MobileBottomTabBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/MobileBottomTabBar.tsx
@@ -172,9 +172,7 @@ export default function MobileBottomTabBar({
       borderTopColor="$borderSubdued"
       pb={bottom}
     >
-      <View style={tabBarRowStyle}>
-        {tabs}
-      </View>
+      <View style={tabBarRowStyle}>{tabs}</View>
     </Stack>
   );
 }

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/MobileBottomTabBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/MobileBottomTabBar.tsx
@@ -122,6 +122,7 @@ export default function MobileBottomTabBar({
           return null;
         }
 
+        // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
         const onPress = () => {
           // Check if custom tabbarOnPress exists, use it instead of default navigation
           const customPress = (options as { tabbarOnPress?: () => void })

--- a/packages/components/src/layouts/Page/BasicPage.native.tsx
+++ b/packages/components/src/layouts/Page/BasicPage.native.tsx
@@ -20,6 +20,8 @@ import {
 
 import type { IBasicPageProps } from './type';
 
+const exitStyleFadeOut = { opacity: 0 };
+
 function Loading() {
   return (
     <Stack flex={1} alignContent="center" justifyContent="center">
@@ -86,9 +88,7 @@ function AbsoluteContainer({ children }: PropsWithChildren) {
       opacity={1}
       flex={1}
       animation="quick"
-      exitStyle={{
-        opacity: 0,
-      }}
+      exitStyle={exitStyleFadeOut}
     >
       {children}
     </Stack>

--- a/packages/components/src/layouts/Page/PageContainer.native.tsx
+++ b/packages/components/src/layouts/Page/PageContainer.native.tsx
@@ -56,6 +56,11 @@ export function PageContainer({ children, lazyLoad, fullPage }: IPageProps) {
     [scrollViewRef],
   );
 
+  const scrollViewStyle = useMemo(
+    () => [{ flex: 1 }, style] as StyleProp<ViewStyle>,
+    [style],
+  );
+
   return useMemo(
     () => (
       <BasicPage lazyLoad={lazyLoad} fullPage={fullPage}>
@@ -65,7 +70,7 @@ export function PageContainer({ children, lazyLoad, fullPage }: IPageProps) {
             scrollEventThrottle={30}
             {...(nativeProps as Record<string, unknown>)}
             onScroll={handleScroll}
-            style={[{ flex: 1 }, style] as StyleProp<ViewStyle>}
+            style={scrollViewStyle}
             contentContainerStyle={contentContainerStyle}
             bottomOffset={KEYBOARD_AWARE_SCROLL_BOTTOM_OFFSET}
           >
@@ -85,7 +90,7 @@ export function PageContainer({ children, lazyLoad, fullPage }: IPageProps) {
       scrollEnabled,
       nativeProps,
       handleScroll,
-      style,
+      scrollViewStyle,
       contentContainerStyle,
       contextValue,
       children,

--- a/packages/components/src/layouts/Page/PageFooter.tsx
+++ b/packages/components/src/layouts/Page/PageFooter.tsx
@@ -17,7 +17,8 @@ import type { IPageFooterProps } from './type';
 
 const Placeholder = () => {
   const bottom = useSafeAreaBottom();
-  return bottom > 0 ? <OptimizationView style={{ height: bottom }} /> : null;
+  const style = useMemo(() => ({ height: bottom }), [bottom]);
+  return bottom > 0 ? <OptimizationView style={style} /> : null;
 };
 
 const PageFooterContainer = ({

--- a/packages/components/src/layouts/Page/PageFooterActions.tsx
+++ b/packages/components/src/layouts/Page/PageFooterActions.tsx
@@ -15,6 +15,27 @@ import type { IPageNavigationProp } from '../Navigation';
 
 type IActionButtonProps = Omit<IButtonProps, 'children'>;
 
+const cancelButtonMdStyle = {
+  flexGrow: 1,
+  flexBasis: 0,
+  size: 'large',
+} as any;
+
+const confirmButtonMdStyle = {
+  flexGrow: 1,
+  flexBasis: 0,
+  size: 'large',
+} as any;
+
+const footerActionsGtMdStyle = {
+  flexDirection: 'row',
+  alignItems: 'center',
+} as const;
+
+const footerButtonContainerGtMdStyle = {
+  ml: 'auto',
+} as any;
+
 export type IFooterActionsProps = {
   onConfirm?: (
     close: (extra?: { flag?: string }) => void,
@@ -92,13 +113,7 @@ export function FooterCancelButton({
   }, [onCancel, pop, popStack]);
   return (
     <Button
-      $md={
-        {
-          flexGrow: 1,
-          flexBasis: 0,
-          size: 'large',
-        } as any
-      }
+      $md={cancelButtonMdStyle}
       onPress={handleCancel}
       testID="page-footer-cancel"
       {...props}
@@ -124,13 +139,7 @@ export function FooterConfirmButton({
 
   return (
     <Button
-      $md={
-        {
-          flexGrow: 1,
-          flexBasis: 0,
-          size: 'large',
-        } as any
-      }
+      $md={confirmButtonMdStyle}
       variant="primary"
       onPress={handleConfirm}
       testID="page-footer-confirm"
@@ -175,23 +184,11 @@ export function FooterActions({
     ) : null;
   }, [confirmButton, confirmButtonProps, onConfirm, onConfirmText]);
   return (
-    <Stack
-      p="$5"
-      $gtMd={{
-        flexDirection: 'row',
-        alignItems: 'center',
-      }}
-      bg="$bgApp"
-      {...restProps}
-    >
+    <Stack p="$5" $gtMd={footerActionsGtMdStyle} bg="$bgApp" {...restProps}>
       {children}
       <XStack
         gap="$2.5"
-        $gtMd={
-          {
-            ml: 'auto',
-          } as any
-        }
+        $gtMd={footerButtonContainerGtMdStyle}
         {...(buttonContainerProps as IXStackProps)}
       >
         {renderCancelButton()}

--- a/packages/components/src/layouts/SearchBar/index.tsx
+++ b/packages/components/src/layouts/SearchBar/index.tsx
@@ -1,5 +1,5 @@
 import type { CompositionEvent } from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 import { useDebouncedCallback } from 'use-debounce';
@@ -117,6 +117,30 @@ export function SearchBar({
     [onSearchTextChange],
   );
   const intl = useIntl();
+
+  const clearAddOns = useMemo(
+    () => [
+      {
+        iconName: 'XCircleOutline' as const,
+        onPress: handleClearValue,
+        testID: `${testID || ''}-clear`,
+      },
+    ],
+    [handleClearValue, testID],
+  );
+
+  const resolvedContainerProps = useMemo(
+    () => ({
+      w: '100%' as const,
+      borderRadius: '$full' as const,
+      bg: '$bgStrong' as const,
+      borderColor: '$transparent' as const,
+      overflow: 'hidden' as const,
+      ...containerProps,
+    }),
+    [containerProps],
+  );
+
   return (
     <Input
       ref={inputRef}
@@ -137,24 +161,11 @@ export function SearchBar({
       {...rest}
       {...(value?.length &&
         !rest.addOns?.length && {
-          addOns: [
-            {
-              iconName: 'XCircleOutline',
-              onPress: handleClearValue,
-              testID: `${testID || ''}-clear`,
-            },
-          ],
+          addOns: clearAddOns,
         })}
       onCompositionStart={handleCompositionStart}
       onCompositionEnd={handleCompositionEnd}
-      containerProps={{
-        w: '100%',
-        borderRadius: '$full',
-        bg: '$bgStrong',
-        borderColor: '$transparent',
-        overflow: 'hidden',
-        ...containerProps,
-      }}
+      containerProps={resolvedContainerProps}
     />
   );
 }

--- a/packages/components/src/layouts/SortableCell/index.tsx
+++ b/packages/components/src/layouts/SortableCell/index.tsx
@@ -19,6 +19,13 @@ import { Stack, XStack } from '../../primitives/Stack';
 
 import type { PressableProps, View } from 'react-native';
 
+const enterStyleAnimated = platformEnv.isNativeAndroid
+  ? undefined
+  : {
+      opacity: 0,
+      scale: 0,
+    };
+
 export type ISortableCellProps = StackProps & {
   isEditing?: boolean;
   shadowProps?: Omit<GetProps<typeof ShadowDecorator>, 'children'>;
@@ -53,14 +60,7 @@ function BaseSortableCell(
                 icon="MinusCircleSolid"
                 variant="destructive"
                 animation="quick"
-                enterStyle={
-                  platformEnv.isNativeAndroid
-                    ? undefined
-                    : {
-                        opacity: 0,
-                        scale: 0,
-                      }
-                }
+                enterStyle={enterStyleAnimated}
               />
             ) : null}
           </AnimatePresence>
@@ -74,14 +74,7 @@ function BaseSortableCell(
                 icon="MenuOutline"
                 onPressIn={drag}
                 animation="quick"
-                enterStyle={
-                  platformEnv.isNativeAndroid
-                    ? undefined
-                    : {
-                        opacity: 0,
-                        scale: 0,
-                      }
-                }
+                enterStyle={enterStyleAnimated}
               />
             ) : null}
           </AnimatePresence>

--- a/packages/components/src/layouts/SortableListView/index.native.tsx
+++ b/packages/components/src/layouts/SortableListView/index.native.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback } from 'react';
+import { forwardRef, useCallback, useMemo } from 'react';
 import type { ForwardedRef } from 'react';
 
 import DraggableFlatList, {
@@ -28,6 +28,8 @@ import type {
   DragEndParams,
   RenderItem,
 } from 'react-native-draggable-flatlist';
+
+const ANIMATION_CONFIG = { damping: 25, stiffness: 400, mass: 0.4 };
 
 function BaseSortableListView<T>(
   {
@@ -101,6 +103,11 @@ function BaseSortableListView<T>(
     [onDragEnd],
   );
 
+  const resolvedContainerStyle = useMemo(
+    () => [{ flex: 1 }, rawContainerStyle],
+    [rawContainerStyle],
+  );
+
   const ListComponent = tabIntegrated
     ? TabsDraggableFlatList
     : DraggableFlatList;
@@ -112,7 +119,7 @@ function BaseSortableListView<T>(
       onDragBegin={reloadOnDragBegin}
       onDragEnd={reloadOnDragEnd}
       activationDistance={enabled ? activeDistance : 100_000}
-      containerStyle={[{ flex: 1 }, rawContainerStyle]}
+      containerStyle={resolvedContainerStyle}
       columnWrapperStyle={columnWrapperStyle ? columnStyle : undefined}
       ListHeaderComponentStyle={listHeaderStyle}
       ListFooterComponentStyle={listFooterStyle}
@@ -122,7 +129,7 @@ function BaseSortableListView<T>(
       renderItem={renderItem as RenderItem<T>}
       keyboardDismissMode="on-drag"
       keyboardShouldPersistTaps="handled"
-      animationConfig={{ damping: 25, stiffness: 400, mass: 0.4 }}
+      animationConfig={ANIMATION_CONFIG}
       {...restProps}
     />
   );

--- a/packages/components/src/layouts/SortableListView/index.tsx
+++ b/packages/components/src/layouts/SortableListView/index.tsx
@@ -399,7 +399,8 @@ function BaseSortableListView<T>(
                   <div
                     style={
                       layout
-                        ? {
+                        ? // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
+                          {
                             height: layout.length + insertHeight,
                           }
                         : EMPTY_STYLE
@@ -409,7 +410,8 @@ function BaseSortableListView<T>(
                 <Item
                   style={
                     !isSticky
-                      ? {
+                      ? // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
+                        {
                           position: useFlashList ? undefined : 'absolute',
                           top: (layout?.offset ?? 0) + (contentPaddingTop ?? 0),
                           height: useFlashList ? undefined : layout?.length,
@@ -428,6 +430,7 @@ function BaseSortableListView<T>(
                   )}
                   isDragging={false}
                   item={item}
+                  // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
                   getIndex={() => index}
                   renderItem={renderItem as any}
                   provided={provided}
@@ -469,7 +472,9 @@ function BaseSortableListView<T>(
           item={data[rubric.source.index]}
           renderItem={renderItem}
           provided={provided}
+          // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
           getIndex={() => rubric.source.index}
+          // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
           style={{
             boxShadow: isDropping ? 'none' : '0 4px 24px rgba(0, 0, 0, 0.12)',
             borderRadius: 12,
@@ -521,6 +526,7 @@ function BaseSortableListView<T>(
             const ListViewComponent = useFlashList ? FlashList : ListView;
             return (
               <ListViewComponent
+                // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
                 ref={(_ref: any) => {
                   if (_ref) {
                     if (typeof ref === 'function') {
@@ -561,6 +567,7 @@ function BaseSortableListView<T>(
                   }
                 }}
                 data={data}
+                // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
                 contentContainerStyle={{
                   ...rawContentContainerStyle,
                   paddingBottom: overridePaddingBottom,

--- a/packages/components/src/layouts/SortableListView/index.tsx
+++ b/packages/components/src/layouts/SortableListView/index.tsx
@@ -47,6 +47,8 @@ import type {
 import type {
   DragStart,
   DraggableProvided,
+  DraggableRubric,
+  DraggableStateSnapshot,
   DropResult,
 } from 'react-beautiful-dnd';
 import type {
@@ -161,7 +163,13 @@ function CellContainer<T>({
   const animatedViewStyle = useMemo(
     () =>
       height
-        ? { ...(props as Record<string, any>).style, height }
+        ? {
+            ...((props as Record<string, unknown>).style as Record<
+              string,
+              unknown
+            >),
+            height,
+          }
         : props.style,
     [height, props.style],
   );
@@ -447,7 +455,11 @@ function BaseSortableListView<T>(
   useEffect(() => () => stopAutoScroll(), [stopAutoScroll]);
 
   const renderClone = useCallback(
-    (provided: DraggableProvided, snapshot: any, rubric: any) => {
+    (
+      provided: DraggableProvided,
+      snapshot: DraggableStateSnapshot,
+      rubric: DraggableRubric,
+    ) => {
       const isDropping = snapshot.isDropAnimating;
       return (
         <Item

--- a/packages/components/src/layouts/SortableListView/index.tsx
+++ b/packages/components/src/layouts/SortableListView/index.tsx
@@ -107,14 +107,18 @@ function Item<T>({
     ...provided.draggableProps,
     ...dragHandleProps,
   };
+  const mergedStyle = useMemo(
+    () => ({
+      ...draggableProps.style,
+      ...style,
+    }),
+    [draggableProps.style, style],
+  );
   return (
     <div
       ref={provided.innerRef}
       {...draggableProps}
-      style={{
-        ...draggableProps.style,
-        ...style,
-      }}
+      style={mergedStyle}
     >
       {renderItem({
         item,
@@ -158,15 +162,16 @@ function CellContainer<T>({
     }
   }, [height, index, ref]);
 
+  const animatedViewStyle = useMemo(
+    () =>
+      height
+        ? { ...(props as Record<string, any>).style, height }
+        : props.style,
+    [height, props.style],
+  );
+
   return (
-    <Animated.View
-      {...(props as Record<string, any>)}
-      style={
-        height
-          ? { ...(props as Record<string, any>).style, height }
-          : props.style
-      }
-    >
+    <Animated.View {...(props as Record<string, any>)} style={animatedViewStyle}>
       <div ref={containerRef as any}>{children}</div>
     </Animated.View>
   );
@@ -175,6 +180,17 @@ function CellContainer<T>({
 // Auto-scroll edge zone size (px) and max speed (px per frame)
 const AUTOSCROLL_EDGE_PX = 80;
 const AUTOSCROLL_MAX_SPEED_PX = 15;
+
+const LIST_CONTAINER_STYLE = {
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  minHeight: 0,
+} as const;
+const EMPTY_OBJECT = {} as Record<string, any>;
+const EMPTY_STYLE = {} as const;
+const EMPTY_CONTENT_CONTAINER_STYLE = {} as Record<string, unknown>;
+const EMPTY_STICKY_INDICES: number[] = [];
 
 function findScrollableAncestor(el: HTMLElement | null): HTMLElement | null {
   let current = el?.parentElement ?? null;
@@ -201,8 +217,8 @@ function BaseSortableListView<T>(
     keyExtractor,
     useFlashList,
     getItemLayout,
-    contentContainerStyle = {},
-    stickyHeaderIndices = [],
+    contentContainerStyle = EMPTY_CONTENT_CONTAINER_STYLE,
+    stickyHeaderIndices = EMPTY_STICKY_INDICES,
     ListHeaderComponent,
     getItemDragDisabled,
     scrollEnabled = true,
@@ -379,7 +395,7 @@ function BaseSortableListView<T>(
                         ? {
                             height: layout.length + insertHeight,
                           }
-                        : {}
+                        : EMPTY_STYLE
                     }
                   />
                 ) : null}
@@ -392,7 +408,7 @@ function BaseSortableListView<T>(
                           height: useFlashList ? undefined : layout?.length,
                           width: '100%',
                         }
-                      : {}
+                      : EMPTY_STYLE
                   }
                   drag={noop}
                   dragProps={Object.keys(dragHandleProps).reduce(
@@ -431,16 +447,41 @@ function BaseSortableListView<T>(
   // Cleanup auto-scroll on unmount
   useEffect(() => () => stopAutoScroll(), [stopAutoScroll]);
 
+  const renderClone = useCallback(
+    (provided: DraggableProvided, snapshot: any, rubric: any) => {
+      const isDropping = snapshot.isDropAnimating;
+      return (
+        <Item
+          isDragging={!isDropping}
+          dragProps={EMPTY_OBJECT}
+          drag={noop}
+          item={data[rubric.source.index]}
+          renderItem={renderItem}
+          provided={provided}
+          getIndex={() => rubric.source.index}
+          style={{
+            boxShadow: isDropping
+              ? 'none'
+              : '0 4px 24px rgba(0, 0, 0, 0.12)',
+            borderRadius: 12,
+            // Ensure clone renders above Dialog/Sheet overlays
+            zIndex: DRAG_CLONE_Z_INDEX,
+            // Speed up drop animation
+            ...(isDropping
+              ? {
+                  transition:
+                    'transform 0.08s ease, box-shadow 0.08s ease',
+                }
+              : {}),
+          }}
+        />
+      );
+    },
+    [data, renderItem],
+  );
+
   return (
-    <div
-      ref={listContainerRef}
-      style={{
-        display: 'flex',
-        flex: 1,
-        flexDirection: 'column',
-        minHeight: 0,
-      }}
-    >
+    <div ref={listContainerRef} style={LIST_CONTAINER_STYLE as any}>
       <DragDropContext
         onDragStart={reloadOnDragStart}
         onDragEnd={reloadOnDragEnd}
@@ -453,35 +494,7 @@ function BaseSortableListView<T>(
           isDropDisabled={false}
           isCombineEnabled={false}
           ignoreContainerClipping={!scrollEnabled}
-          renderClone={(provided, snapshot, rubric) => {
-            const isDropping = snapshot.isDropAnimating;
-            return (
-              <Item
-                isDragging={!isDropping}
-                dragProps={{}}
-                drag={noop}
-                item={data[rubric.source.index]}
-                renderItem={renderItem}
-                provided={provided}
-                getIndex={() => rubric.source.index}
-                style={{
-                  boxShadow: isDropping
-                    ? 'none'
-                    : '0 4px 24px rgba(0, 0, 0, 0.12)',
-                  borderRadius: 12,
-                  // Ensure clone renders above Dialog/Sheet overlays
-                  zIndex: DRAG_CLONE_Z_INDEX,
-                  // Speed up drop animation
-                  ...(isDropping
-                    ? {
-                        transition:
-                          'transform 0.08s ease, box-shadow 0.08s ease',
-                      }
-                    : {}),
-                }}
-              />
-            );
-          }}
+          renderClone={renderClone}
           getContainerForClone={getBody}
         >
           {(provided, snapshot) => {

--- a/packages/components/src/layouts/SortableListView/index.tsx
+++ b/packages/components/src/layouts/SortableListView/index.tsx
@@ -115,11 +115,7 @@ function Item<T>({
     [draggableProps.style, style],
   );
   return (
-    <div
-      ref={provided.innerRef}
-      {...draggableProps}
-      style={mergedStyle}
-    >
+    <div ref={provided.innerRef} {...draggableProps} style={mergedStyle}>
       {renderItem({
         item,
         drag,
@@ -171,7 +167,10 @@ function CellContainer<T>({
   );
 
   return (
-    <Animated.View {...(props as Record<string, any>)} style={animatedViewStyle}>
+    <Animated.View
+      {...(props as Record<string, any>)}
+      style={animatedViewStyle}
+    >
       <div ref={containerRef as any}>{children}</div>
     </Animated.View>
   );
@@ -460,17 +459,14 @@ function BaseSortableListView<T>(
           provided={provided}
           getIndex={() => rubric.source.index}
           style={{
-            boxShadow: isDropping
-              ? 'none'
-              : '0 4px 24px rgba(0, 0, 0, 0.12)',
+            boxShadow: isDropping ? 'none' : '0 4px 24px rgba(0, 0, 0, 0.12)',
             borderRadius: 12,
             // Ensure clone renders above Dialog/Sheet overlays
             zIndex: DRAG_CLONE_Z_INDEX,
             // Speed up drop animation
             ...(isDropping
               ? {
-                  transition:
-                    'transform 0.08s ease, box-shadow 0.08s ease',
+                  transition: 'transform 0.08s ease, box-shadow 0.08s ease',
                 }
               : {}),
           }}

--- a/packages/components/src/layouts/SwipeableCell/index.tsx
+++ b/packages/components/src/layouts/SwipeableCell/index.tsx
@@ -1,4 +1,10 @@
-import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+import {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+} from 'react';
 import type { ComponentType, ForwardedRef } from 'react';
 
 import { Animated } from 'react-native';
@@ -26,6 +32,66 @@ type ISwipeableSwipeDirection = 'left' | 'right';
 
 type ISwipeableSwipeProgress = Animated.AnimatedInterpolation<string | number>;
 
+function SwipeableCellItem({
+  item,
+  index,
+  itemList,
+  isRightDirection,
+  progress,
+  close,
+}: {
+  item: ISwipeableCellItemProps;
+  index: number;
+  itemList: Array<ISwipeableCellItemProps>;
+  isRightDirection: boolean;
+  progress: ISwipeableSwipeProgress;
+  close?: () => void;
+}) {
+  const x = progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [
+      itemList
+        .slice(
+          isRightDirection ? index : 0,
+          isRightDirection ? itemList.length : index + 1,
+        )
+        .map((_item) => _item.width)
+        .reduce((previous, current) => previous + current, 0) *
+        (isRightDirection ? 1 : -1),
+      0,
+    ],
+  });
+  const animatedStyle = useMemo(
+    () => ({
+      zIndex: isRightDirection ? index : itemList.length - index,
+      transform: [
+        {
+          translateX: x,
+        },
+      ],
+    }),
+    [isRightDirection, index, itemList.length, x],
+  );
+  const handlePress = useCallback(() => {
+    item.onPress({ close });
+  }, [item, close]);
+
+  return (
+    <Animated.View style={animatedStyle}>
+      <Stack
+        bg={item.backgroundColor}
+        w={item.width}
+        h="100%"
+        justifyContent="center"
+        alignItems="center"
+        onPress={handlePress}
+      >
+        <SizableText color="white">{item.title}</SizableText>
+      </Stack>
+    </Animated.View>
+  );
+}
+
 function SwipeableCellContainer({
   close,
   progress,
@@ -39,46 +105,17 @@ function SwipeableCellContainer({
 }) {
   return (
     <XStack>
-      {itemList.map((item, index) => {
-        const x = progress.interpolate({
-          inputRange: [0, 1],
-          outputRange: [
-            itemList
-              .slice(
-                isRightDirection ? index : 0,
-                isRightDirection ? itemList.length : index + 1,
-              )
-              .map((_item) => _item.width)
-              .reduce((previous, current) => previous + current, 0) *
-              (isRightDirection ? 1 : -1),
-            0,
-          ],
-        });
-        return (
-          <Animated.View
-            key={index}
-            style={{
-              zIndex: isRightDirection ? index : itemList.length - index,
-              transform: [
-                {
-                  translateX: x,
-                },
-              ],
-            }}
-          >
-            <Stack
-              bg={item.backgroundColor}
-              w={item.width}
-              h="100%"
-              justifyContent="center"
-              alignItems="center"
-              onPress={() => item.onPress({ close })}
-            >
-              <SizableText color="white">{item.title}</SizableText>
-            </Stack>
-          </Animated.View>
-        );
-      })}
+      {itemList.map((item, index) => (
+        <SwipeableCellItem
+          key={index}
+          item={item}
+          index={index}
+          itemList={itemList}
+          isRightDirection={isRightDirection}
+          progress={progress}
+          close={close}
+        />
+      ))}
     </XStack>
   );
 }

--- a/packages/components/src/layouts/Swiper/index.tsx
+++ b/packages/components/src/layouts/Swiper/index.tsx
@@ -24,9 +24,11 @@ import type { ISwiperProps, ISwiperRef } from './type';
 import type { IYStackProps } from '../../primitives';
 import type { ListRenderItemInfo } from 'react-native';
 
+const EMPTY_DATA: readonly never[] = [];
+
 function BaseSwiperFlatList<T>(
   {
-    data = [],
+    data = EMPTY_DATA as unknown as T[],
     renderItem,
     index = 0,
     renderPagination,
@@ -276,25 +278,33 @@ function BaseSwiperFlatList<T>(
     };
   }, [finishMouseDrag, getPointerX, handleMouseMove, isWeb]);
 
-  const mouseDragProps = isWeb
-    ? {
-        onMouseDown: (event: MouseEvent) => handleMouseDown(event),
-        onClickCapture: (event: MouseEvent) => {
-          if (shouldPreventNextClickRef.current) {
-            event.preventDefault();
-            event.stopPropagation();
-            shouldPreventNextClickRef.current = false;
+  const handleClickCapture = useCallback((event: MouseEvent) => {
+    if (shouldPreventNextClickRef.current) {
+      event.preventDefault();
+      event.stopPropagation();
+      shouldPreventNextClickRef.current = false;
+    }
+  }, []);
+
+  const handleClick = useCallback((event: MouseEvent) => {
+    if (shouldPreventNextClickRef.current) {
+      event.preventDefault();
+      event.stopPropagation();
+      shouldPreventNextClickRef.current = false;
+    }
+  }, []);
+
+  const mouseDragProps = useMemo(
+    () =>
+      isWeb
+        ? {
+            onMouseDown: handleMouseDown,
+            onClickCapture: handleClickCapture,
+            onClick: handleClick,
           }
-        },
-        onClick: (event: MouseEvent) => {
-          if (shouldPreventNextClickRef.current) {
-            event.preventDefault();
-            event.stopPropagation();
-            shouldPreventNextClickRef.current = false;
-          }
-        },
-      }
-    : {};
+        : {},
+    [isWeb, handleMouseDown, handleClickCapture, handleClick],
+  );
 
   return (
     <YStack

--- a/packages/components/src/primitives/Button/index.tsx
+++ b/packages/components/src/primitives/Button/index.tsx
@@ -251,6 +251,30 @@ const ButtonComponent = ButtonFrame.styleable<IButtonProps, any, any>(
       onPress: onPressProp,
     });
 
+    const mergedHoverStyle = useMemo(
+      () => ({
+        ...sharedFrameStyles.hoverStyle,
+        ...props.hoverStyle,
+      }),
+      [sharedFrameStyles.hoverStyle, props.hoverStyle],
+    );
+
+    const mergedFocusVisibleStyle = useMemo(
+      () => ({
+        ...sharedFrameStyles.focusVisibleStyle,
+        ...props.focusVisibleStyle,
+      }),
+      [sharedFrameStyles.focusVisibleStyle, props.focusVisibleStyle],
+    );
+
+    const mergedPressStyle = useMemo(
+      () => ({
+        ...sharedFrameStyles.pressStyle,
+        ...props.pressStyle,
+      }),
+      [sharedFrameStyles.pressStyle, props.pressStyle],
+    );
+
     const handlePressWithLoading = useMemo(() => {
       if (!onPressLoadingEnabled || !onPress) {
         return onPress;
@@ -280,18 +304,9 @@ const ButtonComponent = ButtonFrame.styleable<IButtonProps, any, any>(
         disabled={!!disabled || !!isLoading}
         aria-disabled={!!disabled || !!isLoading}
         {...sharedFrameStyles}
-        hoverStyle={{
-          ...sharedFrameStyles.hoverStyle,
-          ...props.hoverStyle,
-        }}
-        focusVisibleStyle={{
-          ...sharedFrameStyles.focusVisibleStyle,
-          ...props.focusVisibleStyle,
-        }}
-        pressStyle={{
-          ...sharedFrameStyles.pressStyle,
-          ...props.pressStyle,
-        }}
+        hoverStyle={mergedHoverStyle}
+        focusVisibleStyle={mergedFocusVisibleStyle}
+        pressStyle={mergedPressStyle}
         {...rest}
         onPress={handlePressWithLoading}
         onLongPress={onLongPress}

--- a/packages/components/src/primitives/GradientMask/index.tsx
+++ b/packages/components/src/primitives/GradientMask/index.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { Stack } from '@onekeyhq/components/src/primitives/Stack';
 import { useTheme } from '@onekeyhq/components/src/shared/tamagui';
 
@@ -11,6 +13,12 @@ interface IGradientMaskProps {
   width?: number;
 }
 
+const animateOnlyProps = ['opacity', 'width'];
+const START_LEFT: [number, number] = [0, 0];
+const START_RIGHT: [number, number] = [1, 0];
+const END_LEFT: [number, number] = [1, 0];
+const END_RIGHT: [number, number] = [0, 0];
+
 export function GradientMask({
   position,
   opacity = 1,
@@ -18,6 +26,11 @@ export function GradientMask({
 }: IGradientMaskProps) {
   const theme = useTheme();
   const positionProps = position === 'left' ? { left: 0 } : { right: 0 };
+
+  const colors = useMemo(
+    () => [theme.bgApp.val, `${theme.bgApp.val}00`],
+    [theme.bgApp.val],
+  );
 
   return (
     <Stack
@@ -30,15 +43,15 @@ export function GradientMask({
       pointerEvents="none"
       opacity={opacity}
       animation="fast"
-      animateOnly={['opacity', 'width']}
+      animateOnly={animateOnlyProps}
       {...positionProps}
     >
       <LinearGradient
         width="100%"
         height="100%"
-        colors={[theme.bgApp.val, `${theme.bgApp.val}00`]}
-        start={position === 'left' ? [0, 0] : [1, 0]}
-        end={position === 'left' ? [1, 0] : [0, 0]}
+        colors={colors}
+        start={position === 'left' ? START_LEFT : START_RIGHT}
+        end={position === 'left' ? END_LEFT : END_RIGHT}
       />
     </Stack>
   );

--- a/packages/components/src/primitives/Icon/index.tsx
+++ b/packages/components/src/primitives/Icon/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useState } from 'react';
+import { forwardRef, useEffect, useMemo, useState } from 'react';
 
 import {
   type GetProps,
@@ -94,16 +94,19 @@ function IconLoader({
     });
   }, [name]);
 
+  const placeholderStyle = useMemo(
+    () => ({
+      width: props.width,
+      height: props.height,
+    }),
+    [props.width, props.height],
+  );
+
   const Svg = ComponentMaps[name];
   return Svg ? (
     <Svg {...props} />
   ) : (
-    <OptimizationView
-      style={{
-        width: props.width,
-        height: props.height,
-      }}
-    />
+    <OptimizationView style={placeholderStyle} />
   );
 }
 

--- a/packages/components/src/primitives/Image/ImageV2.native.tsx
+++ b/packages/components/src/primitives/Image/ImageV2.native.tsx
@@ -103,21 +103,20 @@ export function ImageV2({
     [onError, reFetchImage],
   );
 
+  const fallbackStyle = useMemo(
+    () => ({
+      overflow: 'hidden' as const,
+      display: 'flex' as const,
+      alignItems: 'center' as const,
+      justifyContent: 'center' as const,
+      ...style,
+    }),
+    [style],
+  );
+
   if (!image) {
     if (hasError || isEmptyResolvedSource(source as ImageSource | null)) {
-      return (
-        <Stack
-          style={{
-            overflow: 'hidden',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            ...style,
-          }}
-        >
-          {fallback}
-        </Stack>
-      );
+      return <Stack style={fallbackStyle}>{fallback}</Stack>;
     }
     return skeleton || <Skeleton width={style.width} height={style.height} />;
   }

--- a/packages/components/src/primitives/Image/ImageV2.tsx
+++ b/packages/components/src/primitives/Image/ImageV2.tsx
@@ -20,6 +20,11 @@ import type {
   ImageStyle,
 } from 'expo-image';
 
+const fullSizeStyle = {
+  width: '100%' as const,
+  height: '100%' as const,
+};
+
 export function ImageV2({
   style: defaultStyle,
   animated,
@@ -119,10 +124,7 @@ export function ImageV2({
     return (
       <ImageComponent
         source={resolvedSource}
-        style={{
-          width: '100%',
-          height: '100%',
-        }}
+        style={fullSizeStyle}
         onError={handleError}
         onLoad={handleLoad}
         onLoadEnd={handleLoadEnd}
@@ -144,16 +146,19 @@ export function ImageV2({
     resolvedSource,
   ]);
 
+  const containerStyle = useMemo(
+    () => ({
+      overflow: 'hidden' as const,
+      display: 'flex' as const,
+      alignItems: 'center' as const,
+      justifyContent: 'center' as const,
+      ...style,
+    }),
+    [style],
+  );
+
   return (
-    <YStack
-      style={{
-        overflow: 'hidden',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        ...style,
-      }}
-    >
+    <YStack style={containerStyle}>
       {content}
 
       {isLoading ? (

--- a/packages/components/src/primitives/Skeleton/BaseSkeleton.native.tsx
+++ b/packages/components/src/primitives/Skeleton/BaseSkeleton.native.tsx
@@ -40,6 +40,17 @@ export function BaseSkeleton(
     return (restProps.radius as number) || DEFAULT_RADIUS;
   }, [restProps.radius]);
 
+  const skeletonStyle = useMemo(
+    () => [
+      style as any,
+      {
+        height: (style.height as number) || DEFAULT_SKELETON_SIZE,
+        width: (style.width as number) || '100%',
+      },
+    ],
+    [style],
+  );
+
   const isGroupLoading = useIsGroupLoading();
   return isGroupLoading === undefined || isGroupLoading ? (
     <Stack
@@ -53,13 +64,7 @@ export function BaseSkeleton(
       {...restProps}
     >
       <SkeletonView
-        style={[
-          style as any,
-          {
-            height: (style.height as number) || DEFAULT_SKELETON_SIZE,
-            width: (style.width as number) || '100%',
-          },
-        ]}
+        style={skeletonStyle}
         shimmerSpeed={3}
         shimmerGradientColors={colors}
       />

--- a/packages/components/src/primitives/Skeleton/BaseSkeleton.native.tsx
+++ b/packages/components/src/primitives/Skeleton/BaseSkeleton.native.tsx
@@ -42,7 +42,7 @@ export function BaseSkeleton(
 
   const skeletonStyle = useMemo(
     () => [
-      style as any,
+      style as Record<string, unknown>,
       {
         height: (style.height as number) || DEFAULT_SKELETON_SIZE,
         width: (style.width as number) || '100%',

--- a/packages/components/src/utils/DebugRenderTracker.tsx
+++ b/packages/components/src/utils/DebugRenderTracker.tsx
@@ -1,13 +1,15 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import type { ComponentType, FC, ReactNode } from 'react';
-import { useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import appStorage from '@onekeyhq/shared/src/storage/appStorage';
 import { EAppSyncStorageKeys } from '@onekeyhq/shared/src/storage/syncStorage';
 
 import { Toast } from '../actions/Toast';
+
+const cursorZoomInStyle = { cursor: 'zoom-in' } as const;
 
 const css1 = 'debug-render-tracker-animated-bg';
 const css2 = 'debug-render-tracker-animated-bg0';
@@ -43,6 +45,23 @@ function DebugRenderTracker(
   const classRef = useRef<typeof css1 | typeof css2>(css1);
   const renderTimesRef = useRef(0);
 
+  const handleClick = useCallback(() => {
+    Toast.message({
+      title: `DebugRenderTracker`,
+      message: `${props.name || '[UnknownTrackerName]'}: ${
+        renderTimesRef.current
+      }`,
+    });
+    setRefresh(new Date().getTime());
+  }, [props.name]);
+
+  const badgeTextStyle = useMemo(
+    () => ({
+      transform: `translate(${offsetX || 0}px, ${offsetY || 0}px)`,
+    }),
+    [offsetX, offsetY],
+  );
+
   if (process.env.NODE_ENV !== 'production') {
     if (platformEnv.isRuntimeBrowser) {
       const isDebugRenderTrackerEnabled = appStorage.syncStorage.getBoolean(
@@ -53,32 +72,15 @@ function DebugRenderTracker(
         renderTimesRef.current += 1;
 
         const divElement = (
-          <div
-            className={classRef.current}
-            style={{
-              ...containerStyle,
-            }}
-          >
+          <div className={classRef.current} style={containerStyle}>
             <div
-              onClick={() => {
-                Toast.message({
-                  title: `DebugRenderTracker`,
-                  message: `${props.name || '[UnknownTrackerName]'}: ${
-                    renderTimesRef.current
-                  }`,
-                });
-                setRefresh(new Date().getTime());
-              }}
-              style={{
-                cursor: 'zoom-in',
-              }}
+              onClick={handleClick}
+              style={cursorZoomInStyle}
               className={`debug-render-tracker-times-badge ${position}`}
             >
               <div
                 className="debug-render-tracker-times-badge-text"
-                style={{
-                  transform: `translate(${offsetX || 0}px, ${offsetY || 0}px)`,
-                }}
+                style={badgeTextStyle}
               >
                 {renderTimesRef.current}
               </div>


### PR DESCRIPTION
## Summary
- Add `react_perf` plugin to oxlint and enable all 4 rules scoped to `packages/components` via overrides
- Fix 329 out of 356 violations by extracting constants, `useMemo`, and `useCallback`
- Suppress 27 unfixable violations (imperative functions, `.map()` callbacks) with `eslint-disable-next-line`

### Rules enabled
| Rule | Scope |
|---|---|
| `jsx-no-new-function-as-prop` | `packages/components` |
| `jsx-no-new-object-as-prop` | `packages/components` |
| `jsx-no-new-array-as-prop` | `packages/components` |
| `jsx-no-jsx-as-prop` | `packages/components` |

### Fix patterns applied
- **Static values** → module-level constants (`as const`)
- **Props/state-dependent values** → `useMemo`
- **Callbacks** → `useCallback`
- **Inline JSX** → `useMemo`
- **Map items needing individual props** → extracted sub-components

## Test plan
- [x] `yarn lint` passes (TypeScript + oxlint + all checks)
- [ ] Verify no visual regressions on desktop/mobile/web
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
