### PR TITLE
fix: inject x-onekey-* headers for dev bundle switcher requests

### DIFF
--- a/jest-setup.js
+++ b/jest-setup.js
@@ -71,6 +71,34 @@ jest.mock('expo-localization', () => ({
   locale: '',
 }));
 
+jest.mock('expo-device', () => ({
+  deviceType: null,
+  DeviceType: {
+    UNKNOWN: 0,
+    PHONE: 1,
+    TABLET: 2,
+    DESKTOP: 3,
+    TV: 4,
+  },
+  brand: null,
+  manufacturer: null,
+  modelName: null,
+  designName: null,
+  productName: null,
+  deviceYearClass: null,
+  totalMemory: null,
+  supportedCpuArchitectures: null,
+  osName: null,
+  osVersion: null,
+  osBuildId: null,
+  osInternalBuildId: null,
+  osBuildFingerprint: null,
+  platformApiLevel: null,
+  deviceName: null,
+  modelId: null,
+  isDevice: false,
+}));
+
 jest.mock('react-native-mmkv', () => ({
   __esModule: true,
   createMMKV: MockMMKV.createMMKV,

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -19,6 +19,7 @@ import {
   backgroundMethod,
 } from '@onekeyhq/shared/src/background/backgroundDecorators';
 import { buildServiceEndpoint } from '@onekeyhq/shared/src/config/appConfig';
+import { getRequestHeaders } from '@onekeyhq/shared/src/request/Interceptor';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
@@ -1388,14 +1389,25 @@ class ServiceAppUpdate extends ServiceBase {
   // ---- Dev Bundle Switcher ----
 
   private getDevBundleSwitcherClient = memoizee(
-    async () =>
-      appApiClient.getBasicClient({
+    async () => {
+      const client = await appApiClient.getBasicClient({
         name: EServiceEndpointEnum.Utility,
         endpoint: buildServiceEndpoint({
           serviceName: EServiceEndpointEnum.Utility,
           env: 'test',
         }),
-      }),
+      });
+      // The test endpoint is not in the prod domain whitelist, so the global
+      // interceptor skips x-onekey-* headers. Inject them explicitly here.
+      client.interceptors.request.use(async (config) => {
+        const headers = await getRequestHeaders();
+        Object.entries(headers).forEach(([key, val]) => {
+          config.headers[key] = val;
+        });
+        return config;
+      });
+      return client;
+    },
     { promise: true },
   );
 

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -19,7 +19,6 @@ import {
   backgroundMethod,
 } from '@onekeyhq/shared/src/background/backgroundDecorators';
 import { buildServiceEndpoint } from '@onekeyhq/shared/src/config/appConfig';
-import { getRequestHeaders } from '@onekeyhq/shared/src/request/Interceptor';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
@@ -29,6 +28,7 @@ import {
   BundleUpdate,
 } from '@onekeyhq/shared/src/modules3rdParty/auto-update';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import { getRequestHeaders } from '@onekeyhq/shared/src/request/Interceptor';
 import { memoizee } from '@onekeyhq/shared/src/utils/cacheUtils';
 import { generateUUID } from '@onekeyhq/shared/src/utils/miscUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';


### PR DESCRIPTION
## Summary
- Dev Bundle Switcher client hardcodes `env: 'test'`, generating `https://utility.onekeytest.com` as baseURL
- In production builds, the domain whitelist only contains `*.onekeycn.com`, so the global axios interceptor skips `x-onekey-*` header injection for test endpoints
- Fix: add a request interceptor on the dev bundle switcher client to explicitly inject headers, without touching any shared/production code

## Test plan
- [x] Verify `/utility/v1/app-update/bundles` requests include `x-onekey-*` headers in production builds
- [x] Verify dev bundle switcher UI loads bundle list correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
