### PR TITLE
fix(lint): add eslint-plugin-react-perf stub for unknown rule warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,12 @@ Module._resolveFilename = function (request, ...args) {
       'development/plugins/eslint-plugin-import-js.js',
     );
   }
+  if (request === 'eslint-plugin-react-perf') {
+    return path.resolve(
+      __dirname,
+      'development/plugins/eslint-plugin-react-perf.js',
+    );
+  }
   return originalResolve.call(this, request, ...args);
 };
 
@@ -303,6 +309,7 @@ module.exports = {
     'import',
     'onekey',
     'import-js',
+    'react-perf',
   ],
   settings: {
     'import/extensions': [

--- a/development/plugins/eslint-plugin-react-perf.js
+++ b/development/plugins/eslint-plugin-react-perf.js
@@ -1,0 +1,20 @@
+/**
+ * Stub ESLint plugin so that `react-perf/*` disable comments are recognized
+ * by ESLint. The actual rules live in oxlint (.oxlintrc.json).
+ */
+const noop = {
+  meta: { type: 'suggestion', schema: [] },
+  create() {
+    return {};
+  },
+};
+
+module.exports = {
+  meta: { name: 'react-perf' },
+  rules: {
+    'jsx-no-new-function-as-prop': noop,
+    'jsx-no-new-object-as-prop': noop,
+    'jsx-no-new-array-as-prop': noop,
+    'jsx-no-jsx-as-prop': noop,
+  },
+};


### PR DESCRIPTION
## Summary
- Add stub `eslint-plugin-react-perf` so ESLint recognizes `react-perf/*` disable comments (e.g. `eslint-disable-next-line react-perf/jsx-no-new-function-as-prop`)
- Follows existing pattern used by `eslint-plugin-import-js` and `eslint-plugin-onekey` stubs
- The actual react-perf rules are enforced by oxlint in `.oxlintrc.json`

## Test plan
- [x] Verify `yarn lint:staged` passes without unknown rule warnings for `react-perf/*` comments
- [x] Verify oxlint still enforces `react-perf` rules in `packages/components`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
