### PR TITLE
fix: handle single-token chain selection in bulk send(OK-52198)

### DIFF
--- a/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AssetSelectorTrigger.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AssetSelectorTrigger.tsx
@@ -113,6 +113,28 @@ function AssetSelectorTrigger() {
         }
 
         if (accountId) {
+          const vaultSettings =
+            await backgroundApiProxy.serviceNetwork.getVaultSettings({
+              networkId: _network.id,
+            });
+
+          if (vaultSettings.isSingleToken) {
+            const nativeToken =
+              await backgroundApiProxy.serviceToken.getNativeToken({
+                accountId,
+                networkId: _network.id,
+                tokenInfoOnly: true,
+              });
+
+            if (nativeToken) {
+              setSelectedToken(nativeToken);
+              setSelectedAccountId(accountId);
+              setSelectedNetworkId(_network.id);
+              navigation.popStack();
+              return;
+            }
+          }
+
           navigation.push(EChainSelectorPages.TokenSelector, {
             activeAccountId: accountId,
             activeNetworkId: _network.id,

--- a/packages/kit/src/views/ChainSelector/pages/ChainSelector.tsx
+++ b/packages/kit/src/views/ChainSelector/pages/ChainSelector.tsx
@@ -91,7 +91,8 @@ export default function ChainSelectorPage({
               },
             );
           // Raw values use compound keys "accountId_networkId" (via buildAccountValueKey).
-          // Extract plain networkId keys for display lookup.
+          // Multiple concrete accounts can map to the same network (for example BTC
+          // address types under one indexed account), so aggregate by networkId here.
           const rawValues = accountsValue[0]?.value ?? {};
           const formattedValues: Record<string, string> = {};
           const walletId = accountUtils.getWalletIdFromAccountId({
@@ -106,7 +107,11 @@ export default function ChainSelectorPage({
               SEPERATOR,
             ) as [string, string, string];
             if (walletId === _walletId && networkId) {
-              formattedValues[networkId] = val;
+              formattedValues[networkId] = new BigNumber(
+                formattedValues[networkId] ?? '0',
+              )
+                .plus(val ?? '0')
+                .toFixed();
             }
           }
           accountNetworkValues = formattedValues;


### PR DESCRIPTION
## Summary
- Bypass the token selector in Bulk Send when the chosen network is single-token and immediately bind the native token.
- Keep the existing token-selector flow for multi-token networks.
- Aggregate per-network account values in Chain Selector when multiple concrete accounts map to the same indexed account.

## Intent & Context
This change fixes a Bulk Send asset-selection bug tracked as OK-52198. Selecting a single-token network should immediately resolve to that network's native asset, but the flow still routed through token selection and could leave the picker in an invalid state. The same entry path also depends on network values in Chain Selector, so the supporting account-value display needed to stay accurate for accounts that fan out into multiple concrete accounts on one network.

## Root Cause
The Bulk Send asset trigger assumed every selected network should open Token Selector, even for vaults marked as `isSingleToken`. Separately, Chain Selector flattened compound account-value keys by overwriting `formattedValues[networkId]`, so only the last concrete account's value survived when several accounts shared the same network under one indexed account.

## Design Decisions
Bulk Send now checks `vaultSettings.isSingleToken` immediately after resolving the target account and fetches the native token with `tokenInfoOnly` before updating the selected asset state. Multi-token networks continue to use the existing Token Selector route so the change stays tightly scoped. The value fix lives in shared Chain Selector aggregation logic so any caller using `showNetworkValues` gets correct per-network totals.

## Changes Detail
- `AssetSelectorTrigger`: short-circuit single-token network selection to the native token and only push Token Selector for multi-token networks.
- `ChainSelectorPage`: sum values per `networkId` instead of overwriting them when multiple concrete accounts share the same indexed account.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Bulk Send asset switching, Chain Selector value ordering/display for multi-account networks

## Test plan
- [ ] In Bulk Send, switch to a single-token network and confirm the native token is selected without opening Token Selector.
- [ ] In Bulk Send, switch to a multi-token network and confirm Token Selector still opens and applies the chosen token.
- [ ] Verify Chain Selector network values are summed correctly for an indexed account that exposes multiple concrete accounts on the same network.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
