### PR TITLE
fix(ci): fix and optimize nightly RN harness tests

### DIFF
--- a/.github/workflows/react-native-unittest.yml
+++ b/.github/workflows/react-native-unittest.yml
@@ -1,4 +1,4 @@
-name: 03-harness-test
+name: 03-react-native-unittest
 
 on:
   schedule:
@@ -154,11 +154,11 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const title = `Nightly harness tests failed on ${new Date().toISOString().split('T')[0]}`;
+            const title = `Nightly RN unit tests failed on ${new Date().toISOString().split('T')[0]}`;
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: 'harness-test-failure',
+              labels: 'rn-unittest-failure',
               state: 'open',
             });
             if (issues.length > 0) {
@@ -173,7 +173,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title,
-                body: `The nightly harness test run failed.\n\n[View workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
-                labels: ['harness-test-failure'],
+                body: `The nightly RN unit test run failed.\n\n[View workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+                labels: ['rn-unittest-failure'],
               });
             }

--- a/.github/workflows/react-native-unittest.yml
+++ b/.github/workflows/react-native-unittest.yml
@@ -29,7 +29,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-          fetch-depth: 0
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
@@ -105,6 +104,8 @@ jobs:
           if [ -f .apk-build-commit ] && [ -f apps/mobile/android/app/build/outputs/apk/prod/debug/app-prod-debug.apk ]; then
             CACHED_COMMIT=$(cat .apk-build-commit)
             echo "Cached APK built from commit: $CACHED_COMMIT"
+            # Fetch the cached commit so git diff can compare
+            git fetch --depth=1 origin "$CACHED_COMMIT" 2>/dev/null || true
             if ./development/scripts/check-native-changes.sh "$CACHED_COMMIT"; then
               echo "No native changes since $CACHED_COMMIT — reusing cached APK"
               echo "rebuild=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/react-native-unittest.yml
+++ b/.github/workflows/react-native-unittest.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          fetch-depth: 0
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
@@ -87,7 +88,37 @@ jobs:
           NODE_OPTIONS: '--max_old_space_size=4096'
         run: yarn install --immutable
 
+      - name: Restore cached APK
+        id: apk-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            apps/mobile/android/app/build/outputs/apk/prod/debug/app-prod-debug.apk
+            .apk-build-commit
+          key: android-debug-apk-${{ github.sha }}
+          restore-keys: |
+            android-debug-apk-
+
+      - name: Check if native rebuild needed
+        id: native-check
+        run: |
+          if [ -f .apk-build-commit ] && [ -f apps/mobile/android/app/build/outputs/apk/prod/debug/app-prod-debug.apk ]; then
+            CACHED_COMMIT=$(cat .apk-build-commit)
+            echo "Cached APK built from commit: $CACHED_COMMIT"
+            if ./development/scripts/check-native-changes.sh "$CACHED_COMMIT"; then
+              echo "No native changes since $CACHED_COMMIT — reusing cached APK"
+              echo "rebuild=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "Native changes detected — rebuild required"
+              echo "rebuild=true" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "No cached APK found — build required"
+            echo "rebuild=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build Android Debug APK
+        if: steps.native-check.outputs.rebuild == 'true'
         timeout-minutes: 80
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -97,8 +128,21 @@ jobs:
         run: ./gradlew assembleProdDebug -PreactNativeArchitectures=x86_64
 
       - name: Stop Gradle daemon to free memory
+        if: steps.native-check.outputs.rebuild == 'true'
         working-directory: apps/mobile/android
         run: ./gradlew --stop
+
+      - name: Save APK cache
+        if: steps.native-check.outputs.rebuild == 'true'
+        run: echo "${{ github.sha }}" > .apk-build-commit
+      - name: Upload APK cache
+        if: steps.native-check.outputs.rebuild == 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            apps/mobile/android/app/build/outputs/apk/prod/debug/app-prod-debug.apk
+            .apk-build-commit
+          key: android-debug-apk-${{ github.sha }}
 
       - name: Start Android Emulator
         run: |

--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -179,7 +179,12 @@ android {
             resValue "string", "app_name", "OneKey Dev"
             signingConfig signingConfigs.debug
             ndk {
-                abiFilters "arm64-v8a", "x86_64"
+                def architectures = project.getProperties().get("reactNativeArchitectures")
+                if (architectures) {
+                    abiFilters(*architectures.split(","))
+                } else {
+                    abiFilters "arm64-v8a", "x86_64"
+                }
             }
         }
         release {

--- a/apps/mobile/harness/globalSetup.mjs
+++ b/apps/mobile/harness/globalSetup.mjs
@@ -22,13 +22,7 @@ function setAndroidHarnessFlag() {
   );
   execFileSync(
     'adb',
-    [
-      'shell',
-      'run-as',
-      'so.onekey.app.wallet',
-      'touch',
-      'files/harness_mode',
-    ],
+    ['shell', 'run-as', 'so.onekey.app.wallet', 'touch', 'files/harness_mode'],
     adbOpts,
   );
   console.log('[harness-globalSetup] Android harness_mode flag set');

--- a/apps/mobile/harness/globalSetup.mjs
+++ b/apps/mobile/harness/globalSetup.mjs
@@ -9,17 +9,27 @@ import { execFileSync } from 'node:child_process';
 function setAndroidHarnessFlag() {
   // Create a marker file in the app's data directory.
   // MainApplication.java checks for this file and skips recovery.
+  //
+  // Split into two adb calls because `adb shell` concatenates all
+  // arguments into a single string for the remote shell, which causes
+  // `&&` to be interpreted as a command separator — breaking the
+  // `run-as` scope.
+  const adbOpts = { stdio: 'pipe', timeout: 5000 };
+  execFileSync(
+    'adb',
+    ['shell', 'run-as', 'so.onekey.app.wallet', 'mkdir', '-p', 'files'],
+    adbOpts,
+  );
   execFileSync(
     'adb',
     [
       'shell',
       'run-as',
       'so.onekey.app.wallet',
-      'sh',
-      '-c',
-      'mkdir -p files && touch files/harness_mode',
+      'touch',
+      'files/harness_mode',
     ],
-    { stdio: 'pipe', timeout: 5000 },
+    adbOpts,
   );
   console.log('[harness-globalSetup] Android harness_mode flag set');
 }

--- a/development/lint/eslint.js
+++ b/development/lint/eslint.js
@@ -25,7 +25,7 @@ try {
     `Using ${cpus} threads for oxlint...${isCI ? ' (CI mode, no --fix)' : ''}`,
   );
   const oxlintResult = execSync(
-    `npx oxlint --tsconfig ./tsconfig.json --type-aware --threads=${cpus} .${fixFlag}`,
+    `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings --threads=${cpus} .${fixFlag}`,
     { encoding: 'utf-8', stdio: 'pipe' },
   );
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "lint": "yarn lint:project",
     "lint:all": "yarn lint --fix && yarn eslint --fix",
     "eslint": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" npx eslint . --ext .ts,.tsx --fix --cache --cache-location \"$(yarn config get cacheFolder)\"/.eslintcache",
-    "oxlint": "npx oxlint --tsconfig ./tsconfig.json --type-aware . --fix",
+    "oxlint": "npx oxlint --tsconfig ./tsconfig.json --type-aware . --fix --deny-warnings",
     "lint:only": "npx oxlint --tsconfig ./tsconfig.json --type-aware . --fix --deny-warnings",
     "lint:staged": "git diff --cached --name-only --diff-filter=ACMR | grep -E '\\.(ts|tsx)$' | xargs -r npx oxlint --tsconfig ./tsconfig.json --type-aware --fix --deny-warnings",
     "tsc:only": "npx tsgo -p ./tsconfig.json --noEmit --tsBuildInfoFile \"$(yarn config get cacheFolder)\"/.app-mono-ts-cache --pretty",

--- a/packages/components/src/layouts/SortableListView/index.tsx
+++ b/packages/components/src/layouts/SortableListView/index.tsx
@@ -164,7 +164,7 @@ function CellContainer<T>({
     () =>
       height
         ? {
-            ...((style as Record<string, unknown>) ?? {}),
+            ...(style as Record<string, unknown>),
             height,
           }
         : style,

--- a/packages/components/src/layouts/SortableListView/index.tsx
+++ b/packages/components/src/layouts/SortableListView/index.tsx
@@ -136,7 +136,7 @@ function CellContainer<T>({
 }: Omit<CellRendererProps<T>, 'ref'> & {
   ref: RefObject<HTMLDivElement>;
 }) {
-  const { ref, index } = props;
+  const { ref, index, style } = props;
   const containerRef = useRef<HTMLDivElement>(null);
   const [height, setHeight] = useState<number | undefined>(undefined);
   useLayoutEffect(() => {
@@ -164,14 +164,11 @@ function CellContainer<T>({
     () =>
       height
         ? {
-            ...((props as Record<string, unknown>).style as Record<
-              string,
-              unknown
-            >),
+            ...((style as Record<string, unknown>) ?? {}),
             height,
           }
-        : props.style,
-    [height, props.style],
+        : style,
+    [height, style],
   );
 
   return (


### PR DESCRIPTION
## Summary
- Fix `adb shell run-as` command quoting issue that broke harness test globalSetup on Android
- Add `--deny-warnings` to oxlint and fix `react-hooks/exhaustive-deps` lint warning in SortableListView
- Rename `harness-test.yml` workflow to `react-native-unittest.yml`
- Make debug `abiFilters` respect `-PreactNativeArchitectures` CLI property (skip arm64-v8a build on x86_64 emulator)
- Cache APK across runs and skip Gradle rebuild when no native changes detected (uses `check-native-changes.sh`)

## Test plan
- [ ] Trigger `03-react-native-unittest` workflow and verify it passes
- [ ] Verify APK cache is saved on first run
- [ ] Verify APK cache is restored and build is skipped on subsequent run with no native changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
