### PR TITLE
chore: optimize bundle-release skill with shared branch detection and audit subcommand

### DIFF
--- a/.skillshare/skills/1k-bundle-release/SKILL.md
+++ b/.skillshare/skills/1k-bundle-release/SKILL.md
@@ -13,7 +13,41 @@ Manages the bundle release workflow: developers branch from `release/*`, PRs tar
 
 OneKey ships periodic App Shell releases (tagged `v{X.Y.Z}` on the `x` branch). After each App Shell release, a release branch (`release/v{X.Y.Z}`) is created from the tag. Bundle release features are developed directly on this branch — PRs target `release/*`, not `x`. After bundle publishing, changes are synced back to `x` via rebase.
 
-**Release branch auto-detection:** All subcommands read `VERSION` from `.env.version` and construct `release/v${VERSION}` automatically.
+**Release branch auto-detection:** All subcommands use the shared detection logic below to determine the release branch. On a `release/v*` branch it's used directly; otherwise the latest release branch is discovered from the remote.
+
+## Release Branch Detection (Shared)
+
+All subcommands MUST use this logic instead of reading `.env.version` directly. The reason: `.env.version` on `x` contains the **next** version (e.g., `6.2.0`), while the release branch uses the **current** version (e.g., `release/v6.1.0`). Reading `.env.version` from `x` produces the wrong branch name.
+
+```bash
+current_branch=$(git branch --show-current)
+
+if [[ "$current_branch" == release/v* ]]; then
+  # Already on a release branch — use it directly
+  RELEASE_BRANCH="$current_branch"
+else
+  # Not on a release branch — find the latest one from remote
+  git fetch origin
+  RELEASE_BRANCH=$(git branch -r \
+    | grep 'origin/release/v' \
+    | grep -v mock \
+    | sed 's|origin/||' \
+    | sort -V \
+    | tail -1 \
+    | tr -d ' ')
+fi
+
+if [[ -z "$RELEASE_BRANCH" ]]; then
+  echo "No release branch found on origin."
+  exit 1
+fi
+```
+
+After detection, confirm with the user:
+
+> "Detected release branch: `$RELEASE_BRANCH`. Proceed? (y/n)"
+
+If the user wants a different branch, let them specify it manually.
 
 ## Quick Reference
 
@@ -53,7 +87,7 @@ These steps are designed to run in sequence, but each can also run independently
 
 | File | Location | Purpose |
 |------|----------|---------|
-| Version source | `.env.version` (`VERSION` field) | Determines release branch name |
+| Version source | Auto-detected from current branch or remote `release/v*` branches | Determines release branch name |
 | Release tracking | `RELEASES.json` (release branch root) | Each entry: seq, commit SHA, date, PR list, notes |
 
 ## Related Skills

--- a/.skillshare/skills/1k-bundle-release/SKILL.md
+++ b/.skillshare/skills/1k-bundle-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 1k-bundle-release
-description: Release branch management — checkout from release, prepare builds, pre-release diff checks, publish tracking, and sync back to x. Use this skill when managing release branches, creating branches for bundle releases, running pre-release diff checks, finalizing releases, or syncing release changes to x. Triggers on "bundle release", "release diff", "release publish", "release sync", "release checkout", "发布管理", "release 分支", "release management", "bundle-release", "bundle branch".
+description: Release branch management — checkout from release, prepare builds, pre-release diff checks, security audits, publish tracking, and sync back to x. Use this skill when managing release branches, creating branches for bundle releases, running pre-release diff checks, auditing release security, finalizing releases, or syncing release changes to x. Triggers on "bundle release", "release diff", "release publish", "release sync", "release checkout", "release audit", "发布管理", "release 分支", "release management", "bundle-release", "bundle branch", "发布审计", "安全审计 release".
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 disable-model-invocation: true
 ---
@@ -55,7 +55,8 @@ If the user wants a different branch, let them specify it manually.
 |------------|-------------|-------|
 | `checkout` | Start working on a bundle release feature | [checkout.md](references/rules/checkout.md) |
 | `prepare` | Set BUILD_NUMBER before triggering CI | [prepare.md](references/rules/prepare.md) |
-| `diff-check` | Before publishing — review changeset | [diff-check.md](references/rules/diff-check.md) |
+| `diff-check` | Before publishing — quick changeset review | [diff-check.md](references/rules/diff-check.md) |
+| `audit` | Before publishing — full security & supply-chain audit | [audit.md](references/rules/audit.md) |
 | `publish` | Diff check passed — record release | [publish.md](references/rules/publish.md) |
 | `sync` | After publishing — rebase to x | [sync.md](references/rules/sync.md) |
 
@@ -66,6 +67,7 @@ Parse the argument passed to this skill:
 - **`checkout [branch-name]`** → Read and follow [checkout.md](references/rules/checkout.md)
 - **`prepare`** → Read and follow [prepare.md](references/rules/prepare.md)
 - **`diff-check`** → Read and follow [diff-check.md](references/rules/diff-check.md)
+- **`audit`** → Read and follow [audit.md](references/rules/audit.md)
 - **`publish`** → Read and follow [publish.md](references/rules/publish.md)
 - **`sync`** → Read and follow [sync.md](references/rules/sync.md)
 - **No argument** → Show this quick reference and ask which subcommand to run
@@ -76,7 +78,8 @@ Parse the argument passed to this skill:
 /1k-bundle-release checkout feat/my-fix   ← Branch from release/* to start work
   ... develop, create PR targeting release/*, QA verifies, merge ...
 /1k-bundle-release prepare                ← Set BUILD_NUMBER
-/1k-bundle-release diff-check             ← Review changeset before publishing
+/1k-bundle-release diff-check             ← Quick changeset review
+/1k-bundle-release audit                  ← Full security audit (optional, recommended)
 /1k-bundle-release publish                ← Record release in RELEASES.json
 /1k-bundle-release sync                   ← Rebase changes to x
 ```

--- a/.skillshare/skills/1k-bundle-release/references/rules/audit.md
+++ b/.skillshare/skills/1k-bundle-release/references/rules/audit.md
@@ -1,0 +1,352 @@
+# Audit Workflow
+
+Standalone pre-release security and supply-chain audit. Can run independently or after `diff-check` — if `diff-check` was already executed in the same conversation, reuse its context to avoid redundant work.
+
+## Why This Matters
+
+Bundle releases ship directly to users' devices. A compromised dependency, leaked secret, or signing-flow regression can result in loss of user funds. This audit catches issues before they reach production.
+
+## Pre-flight Checks
+
+### 1. Reuse or detect context
+
+Check whether a `diff-check` was already run in this conversation. If so, the following variables are already known — reuse them directly without re-running detection or fetching:
+
+- `RELEASE_BRANCH` — the target release branch
+- `base_sha` / `tag_sha` — baseline commit (from RELEASES.json or App Shell tag)
+- Changeset data (commit list, file stats, PR numbers)
+
+If no prior `diff-check` context exists, run the standard detection:
+
+1. Use the **Release Branch Detection** logic from SKILL.md
+2. Confirm with the user before proceeding
+3. Fetch latest: `git fetch origin "$RELEASE_BRANCH" x`
+4. Determine baselines:
+   - `tag_sha` from App Shell tag: `git rev-parse "v${VERSION}"`
+   - `last_release_sha` from RELEASES.json (highest `seq` entry), or same as `tag_sha` if first release
+
+### 2. Codex MCP readiness
+
+Check whether Codex MCP is available for cross-validation.
+
+1. Confirm `mcp__codex__codex` exists in available tools
+2. Send probe: `"Health check: respond with 'OK' if you can process requests."`
+3. Retrieve response via `mcp__codex__codex-reply`
+
+| Result | Action |
+|--------|--------|
+| Tool not found | Warn: "⚠️ Codex MCP 未找到，审计将以降级模式继续（无交叉验证）。" Set `CODEX_AVAILABLE = false` |
+| Probe fails | Warn: "⚠️ Codex MCP 连接失败，降级模式继续。" Set `CODEX_AVAILABLE = false` |
+| Valid response | Log: "✅ Codex MCP 就绪。" Set `CODEX_AVAILABLE = true` |
+
+Proceed regardless — Codex enhances but does not gate the audit.
+
+## Report Setup
+
+```
+base_sha_short="${tag_sha:0:8}"
+RELEASE_BRANCH_SAFE=$(echo "$RELEASE_BRANCH" | tr '/' '__')
+REPORT_FILE="security-audit__${base_sha_short}__to__${RELEASE_BRANCH_SAFE}.md"
+```
+
+---
+
+## Execution Steps
+
+### Step A — Collect Context
+
+If reusing diff-check context, this data is already available. Otherwise collect:
+
+- List changed files: `git diff --name-status "$tag_sha..$RELEASE_BRANCH"`
+- Count stats: `git diff --stat "$tag_sha..$RELEASE_BRANCH"`
+
+### Step B — Collect Key Diffs
+
+Focus on security-relevant file categories:
+
+```bash
+# Source code changes
+git diff "$tag_sha..$RELEASE_BRANCH" -- '*.ts' '*.tsx' '*.js'
+
+# Dependency changes
+git diff "$tag_sha..$RELEASE_BRANCH" -- '**/package.json' 'yarn.lock'
+
+# CI/CD changes
+git diff "$tag_sha..$RELEASE_BRANCH" -- '.github/workflows/**'
+
+# Build configs
+git diff "$tag_sha..$RELEASE_BRANCH" -- 'eas.json' 'app.json' 'app.config.*'
+```
+
+For large diffs, prioritize security-critical paths:
+- `packages/kit-bg/src/vaults/` — vault and signing logic
+- `packages/shared/src/appCrypto/` — cryptographic operations
+- `packages/kit-bg/src/services/` — background services
+- `packages/kit/src/views/` — user-facing flows that handle sensitive data
+
+### Step C — Dependency Delta
+
+For each changed `package.json`:
+- Compute: added / removed / updated direct dependencies (include workspace path)
+- Version policy checks:
+  - `*` / `latest` → **🔴 High risk**
+  - `^` / `~` → **🟡 Medium risk** (release determinism concern)
+- If deps changed but `yarn.lock` unchanged → **🔴 High risk** (lockfile out of sync)
+
+### Step D — Lockfile Determinism (Best-Effort)
+
+```bash
+# Detect Yarn flavor
+yarn -v
+
+# Try immutable install
+yarn install --immutable  # Yarn Berry
+# or
+yarn install --frozen-lockfile  # Yarn Classic
+```
+
+Record anomalies: `resolutions`, `patches`, non-registry sources, unexpected network downloads.
+
+If this step cannot complete (e.g., env constraints), note it and move on.
+
+### Step E — Known Vulnerability Scanning (Best-Effort)
+
+```bash
+yarn audit        # if available
+osv-scanner --lockfile yarn.lock  # if available
+```
+
+If tools are missing, note "not run + reason" and continue.
+
+### Step F — New Dependency Deep Inspection
+
+For each **newly added direct dependency** found in Step C:
+
+1. Inspect `node_modules/<pkg>/package.json`:
+   - `preinstall`, `install`, `postinstall` scripts
+   - Entry points: `main`, `module`, `exports`
+   - Binary/native artifacts: `bin/`, `.node`
+
+2. Keyword scan (case-insensitive) in installed code:
+   - **Sensitive**: `privateKey|mnemonic|seed|keystore|passphrase`
+   - **Storage**: `localStorage|indexedDB|AsyncStorage|keychain`
+   - **Network**: `fetch|axios|XMLHttpRequest|WebSocket`
+   - **Dynamic exec**: `eval|new Function|child_process|spawn|exec`
+   - **Install hooks**: `preinstall|postinstall`
+
+3. If hits exist: include path + line + short snippet, explain expected vs suspicious behavior
+4. Assign risk rating: Low / Medium / High
+
+### Step G — Source Diff Security Review
+
+Within the `$tag_sha..$RELEASE_BRANCH` diffs, prioritize reviewing:
+
+| Priority | Area | What to look for |
+|----------|------|------------------|
+| 🔴 Critical | Signing / key handling / mnemonic | Any modification to vault logic, transaction signing, seed derivation |
+| 🔴 Critical | Secret leakage | console.log/error with sensitive data, analytics tracking private info |
+| 🟠 High | Network layer / RPC / telemetry | New endpoints, outbound requests, WebSocket changes |
+| 🟠 High | Storage layer | Local/secure storage changes, encryption modifications |
+| 🟡 Medium | Logging / analytics / error reporting | New data being collected or transmitted |
+| 🟡 Medium | Dynamic execution | eval, new Function, child_process in new code |
+
+Output: list of suspicious changes, each with summary, impact assessment, and evidence excerpt.
+
+### Step H — CI/CD & Build Pipeline Risks
+
+Inspect `.github/workflows/**` and build configs in the diff:
+
+- `uses: ...@latest` → **🔴 High risk**
+- Floating tags not pinned to SHA → **🟠 Medium risk**
+- `permissions:` with over-broad scopes
+- Remote script execution patterns (`curl|bash`, remote downloads)
+- Install safety (`--ignore-scripts`, etc.)
+- Build hooks that download remote code, run arbitrary scripts, or leak env into logs
+
+### Step I — Codex MCP Cross-Validation
+
+**Skip if `CODEX_AVAILABLE = false`.**
+
+The purpose is to get an independent second opinion. Codex reviews the same diff without seeing primary findings, so its conclusions serve as genuine cross-validation.
+
+#### I.1 — Send audit request
+
+Prepare diff summary and send to `mcp__codex__codex`:
+
+```
+Security audit for OneKey crypto wallet monorepo (bundle release).
+Comparing ${tag_sha} → ${RELEASE_BRANCH}.
+
+Changed files:
+${CHANGED_FILES_LIST}
+
+Full diff:
+${DIFF_CONTENT}
+
+Review focus areas:
+1. Secret/PII leakage — mnemonic, private key, seed, API key exposure
+2. Supply-chain risks — new/updated dependencies, install scripts
+3. Auth/signing flow changes — key handling, transaction signing, vault logic
+4. Network layer — new RPC endpoints, telemetry, WebSocket changes
+5. Storage layer — local/secure storage, encryption, keychain access
+6. CI/CD pipeline — workflow permissions, unpinned actions, remote scripts
+7. Dynamic execution — eval, new Function, child_process patterns
+
+For each finding report: file path, line, severity, category, description, suggested fix.
+```
+
+If diff > 50KB, chunk by category:
+1. Dependency changes (`package.json` + `yarn.lock`)
+2. Security-critical source diffs (vault, signing, crypto, auth)
+3. CI/CD and build config changes
+4. Remaining source diffs
+
+#### I.2 — Retrieve and parse response
+
+Call `mcp__codex__codex-reply`. Extract findings with: file path, line, severity, category, description, suggested fix.
+
+### Step J — Merge and Cross-Validate
+
+Combine primary findings (Steps C–H) with Codex findings (Step I).
+
+#### Cross-validation rules
+
+| Scenario | Action | Confidence |
+|----------|--------|------------|
+| Both found same issue | Mark `{Cross-validated ✅}` | Auto-promote to 🔵 High |
+| Primary-only | Include normally | Keep original assessment |
+| Codex-only | Include with `[Codex]` tag, review against source | Default 🟠 Medium |
+| Conflicting assessment | Include both, flag for human review | ⚪ Low |
+
+#### Deduplication
+Same issue flagged by both → keep more detailed description, note both sources.
+
+#### Confidence levels
+
+| Tag | Meaning |
+|-----|---------|
+| 🔵 High | Confirmed from code or cross-validated by both reviewers |
+| 🟠 Medium | Likely issue, single reviewer or needs context |
+| ⚪ Low | Possible issue, needs human judgment |
+
+---
+
+## Audit Result Classification
+
+| Findings | Conclusion |
+|----------|------------|
+| No 🔴 Critical or 🟠 High findings | ✅ Security audit passed |
+| 🟠 High findings only (no Critical) | ⚠️ Review required — list findings, recommend human review before publishing |
+| Any 🔴 Critical finding | 🚫 Publishing blocked — must fix Critical issues first |
+
+---
+
+## Output Summary
+
+IMPORTANT: Do NOT put compare URLs inside code blocks — render as clickable markdown links.
+
+---
+
+=== Security Audit Report ===
+
+🔒 **Audit range**: $tag_sha_short → $RELEASE_BRANCH
+- $file_count files changed, +$insertions / -$deletions lines
+- Codex cross-validation: ✅ Enabled / ⚠️ Degraded
+
+📋 **Findings**: N Critical, M High, K Medium, L Low
+- [list key findings here]
+
+📄 Full report: `$REPORT_FILE`
+
+**Result**: ✅ Passed / ⚠️ Review required / 🚫 Blocked
+
+Next: `/1k-bundle-release publish` (if passed)
+
+---
+
+## Report Template (Chinese)
+
+Write to `$REPORT_FILE`:
+
+```markdown
+# 安全预审报告（${tag_sha_short} → ${RELEASE_BRANCH}）
+
+## 审计概要
+- **审计范围**: ${tag_sha_short} → ${RELEASE_BRANCH}
+- **变更文件数**: X 个文件, +Y / -Z 行
+- **Codex 交叉验证**: ✅ 已启用 / ⚠️ 降级模式（原因）
+- **审计日期**: YYYY-MM-DD
+
+## 风险总览
+
+| 等级 | 数量 | 交叉验证数 |
+|------|------|------------|
+| 🔴 Critical | N | M |
+| 🟠 High | N | M |
+| 🟡 Medium | N | M |
+| 🟢 Low | N | M |
+
+## Codex 交叉验证摘要
+<!-- Include only if CODEX_AVAILABLE = true -->
+
+| # | 发现 | Primary | Codex | 状态 | 置信度 |
+|---|------|---------|-------|------|--------|
+| 1 | 描述 | ✅ | ✅ | Cross-validated ✅ | 🔵 High |
+
+**一致性统计**: N 项交叉验证 / M 项仅 Primary / K 项仅 Codex
+
+## 依赖变更分析 (Step C)
+...
+
+## Lockfile 确定性检查 (Step D)
+...
+
+## 已知漏洞扫描 (Step E)
+...
+
+## 新依赖深度检查 (Step F)
+...
+
+## 源码安全审查 (Step G)
+...
+
+## CI/CD 管道风险 (Step H)
+...
+
+## 发现的问题（合并后）
+
+### [🔴 Critical] [🔵 High] 问题标题 {Cross-validated ✅}
+**文件**: `path/to/file.tsx:42`
+**类型**: secret-leak / supply-chain / auth-bypass / network / storage / ci-cd
+**来源**: Primary + Codex
+**描述**: ...
+**证据**:
+```
+代码片段
+```
+**修复建议**: ...
+
+---
+
+## 修复清单
+
+| 优先级 | 置信度 | 文件 | 类型 | 来源 | 描述 |
+|--------|--------|------|------|------|------|
+| 🔴 | 🔵 | file.tsx:42 | secret-leak | Both | 描述 |
+
+## 测试建议
+1. ...
+
+## 审计方法说明
+- Primary 审计: AI 逐步执行 Steps A–H
+- Codex 交叉验证: 独立 AI 审查同一 diff（Step I）
+- 合并策略: 交叉验证提升置信度，冲突标记人工复核（Step J）
+```
+
+---
+
+## Safety Rules
+
+- **Never** print or paste secrets: mnemonics, seed phrases, private keys, API keys, tokens
+- If command output may contain secrets, redact before writing to report
+- Prefer short excerpts; do not paste large code blocks verbatim

--- a/.skillshare/skills/1k-bundle-release/references/rules/checkout.md
+++ b/.skillshare/skills/1k-bundle-release/references/rules/checkout.md
@@ -4,16 +4,17 @@ Creates a development branch from the latest release branch. Reads VERSION from 
 
 ## Pre-flight Checks
 
-### 1. Read release branch name
+### 1. Detect release branch
 
-```bash
-VERSION=$(grep -E '^VERSION=' .env.version | cut -d '=' -f 2)
-RELEASE_BRANCH="release/v${VERSION}"
-```
+Use the **Release Branch Detection** logic from SKILL.md:
 
-If `.env.version` doesn't exist or VERSION is empty, stop:
+1. If already on a `release/v*` branch → use it directly
+2. Otherwise → find the latest `release/v*` from remote (excluding `mock` branches)
+3. Confirm with the user before proceeding
 
-> "Cannot read VERSION from .env.version. Ensure the file exists and contains a VERSION= line."
+If no release branch is found, stop:
+
+> "No release branch found on origin. Has the App Shell been released and the branch created?"
 
 ### 2. Working tree is clean
 
@@ -27,13 +28,11 @@ If not empty, stop:
 
 ### 3. Verify release branch exists on remote
 
+The detection logic already fetches from origin and validates the branch exists. If the branch was detected from remote listing, this is inherently verified. If the user specified a branch manually, confirm it exists:
+
 ```bash
 git ls-remote --heads origin "$RELEASE_BRANCH"
 ```
-
-If empty, stop:
-
-> "Release branch `$RELEASE_BRANCH` does not exist on origin. Has the App Shell been released and the branch created?"
 
 ## Step 1: Get branch name
 

--- a/.skillshare/skills/1k-bundle-release/references/rules/diff-check.md
+++ b/.skillshare/skills/1k-bundle-release/references/rules/diff-check.md
@@ -28,37 +28,56 @@ git fetch origin "$RELEASE_BRANCH" x
 
 Shows what changed since the last published release for smoke testing scope and release notes.
 
-### Get the baseline commit
+### Determine baselines
 
-Read `RELEASES.json` from the release branch root:
+Two baselines are needed to show both full and incremental views:
 
-```bash
-cat RELEASES.json
-```
-
-Parse the JSON and get the `commit` field from the entry with the highest `seq`.
-
-If the file doesn't exist or is empty (first release for this branch), fall back to the App Shell tag:
+1. **App Shell tag** — the starting point of this release branch:
 
 ```bash
-base_sha=$(git rev-parse "v${VERSION}")
+# Extract version from RELEASE_BRANCH (e.g., "release/v6.1.0" → "6.1.0")
+VERSION="${RELEASE_BRANCH#release/v}"
+tag_sha=$(git rev-parse "v${VERSION}")
 ```
+
+2. **Last bundle release** — read `RELEASES.json` from the release branch:
+
+```bash
+git show "$RELEASE_BRANCH:RELEASES.json" 2>/dev/null
+```
+
+Parse the JSON and get the `commit` field from the entry with the highest `seq`. If the file doesn't exist or is empty (first bundle release), `last_release_sha` is the same as `tag_sha`.
 
 ### Show the changeset
 
-```bash
-# Commit history
-git log $base_sha..$RELEASE_BRANCH --oneline
+Display both views — full (since tag) and incremental (since last bundle release):
 
-# File change statistics
-git diff --stat $base_sha..$RELEASE_BRANCH
+```bash
+# === Full changeset (tag → HEAD) ===
+git log $tag_sha..$RELEASE_BRANCH --oneline
+git diff --stat $tag_sha..$RELEASE_BRANCH
+
+# === Incremental changeset (last release → HEAD) ===
+# Only show if last_release_sha != tag_sha (i.e., not the first release)
+git log $last_release_sha..$RELEASE_BRANCH --oneline
+git diff --stat $last_release_sha..$RELEASE_BRANCH
 ```
 
-### Generate GitHub compare link
+### Generate GitHub compare links
 
 ```bash
 repo_url=$(git remote get-url origin | sed 's/git@github.com:/https:\/\/github.com\//' | sed 's/\.git$//')
-echo "${repo_url}/compare/${base_sha}...${RELEASE_BRANCH}"
+
+# Full: tag → release branch
+echo "${repo_url}/compare/${tag_sha}...${RELEASE_BRANCH}"
+
+# Incremental: last release → release branch (only if different from full)
+if [ "$last_release_sha" != "$tag_sha" ]; then
+  echo "${repo_url}/compare/${last_release_sha}...${RELEASE_BRANCH}"
+fi
+
+# Sync gap: what's on release but not yet on x
+echo "${repo_url}/compare/x...${RELEASE_BRANCH}"
 ```
 
 ### Identify included PRs
@@ -67,10 +86,16 @@ Since PRs are merged directly to the release branch, extract PR numbers from com
 - Merge commit: `Merge pull request #1234 from user/branch`
 - Squash merge: `feat: description (#1234)`
 
-Extract all PR numbers with:
+Extract from both ranges:
 
 ```bash
-git log $base_sha..$RELEASE_BRANCH --format="%s" | grep -oE '#[0-9]+' | sort -u
+# Full (all PRs since tag)
+git log $tag_sha..$RELEASE_BRANCH --format="%s" | grep -oE '#[0-9]+' | sort -u
+
+# Incremental (new PRs since last release, only if applicable)
+if [ "$last_release_sha" != "$tag_sha" ]; then
+  git log $last_release_sha..$RELEASE_BRANCH --format="%s" | grep -oE '#[0-9]+' | sort -u
+fi
 ```
 
 ## Check 2: Sync Status (Informational)
@@ -93,15 +118,28 @@ If count > 0:
 
 ## Output Summary
 
-```
+IMPORTANT: Do NOT put compare URLs inside code blocks — they must be rendered as clickable markdown links. Use this format:
+
+---
+
 === Release Diff Check Report ===
 
-📦 Changes since last release (seq #$last_seq, sha: $base_sha):
-   - $commit_count commits, $file_count files changed
-   - PRs included: #1270, #1275, #1278
-   - 🔗 Compare: $compare_url
+📦 **Full changeset** (tag v$VERSION → $RELEASE_BRANCH):
+- $full_commit_count commits, $full_file_count files changed
+- PRs included: #1270, #1275, #1278
+- 🔗 Compare: $full_compare_url
 
-ℹ️  Sync status: $unsync_count commit(s) pending sync to x
+📦 **Incremental changeset** (seq #$last_seq → $RELEASE_BRANCH):
+*Only shown when last_release_sha ≠ tag_sha (i.e., not the first bundle release)*
+- $incr_commit_count new commits, $incr_file_count files changed
+- New PRs: #1290, #1292
+- 🔗 Compare: $incr_compare_url
 
-Conclusion: ✅ Ready for /1k-bundle-release publish
-```
+🔄 **Sync gap** ($RELEASE_BRANCH vs x):
+- 🔗 Compare: $sync_compare_url
+
+ℹ️ Sync status: $unsync_count commit(s) pending sync to x
+
+Conclusion: ✅ Ready for `/1k-bundle-release publish`
+
+💡 Tip: Run `/1k-bundle-release audit` for a full security audit before publishing.

--- a/.skillshare/skills/1k-bundle-release/references/rules/diff-check.md
+++ b/.skillshare/skills/1k-bundle-release/references/rules/diff-check.md
@@ -4,15 +4,15 @@ Pre-release validation: displays the changeset since the last release so the tea
 
 ## Pre-flight Checks
 
-### 1. Read release branch
+### 1. Detect release branch
 
-```bash
-VERSION=$(grep -E '^VERSION=' .env.version | cut -d '=' -f 2)
-RELEASE_BRANCH="release/v${VERSION}"
-current_branch=$(git branch --show-current)
-```
+Use the **Release Branch Detection** logic from SKILL.md:
 
-If current branch is not the expected release branch, offer to switch:
+1. If already on a `release/v*` branch → use it directly
+2. Otherwise → find the latest `release/v*` from remote (excluding `mock` branches)
+3. Confirm with the user before proceeding
+
+If not on the release branch, offer to switch:
 
 > "You're on `$current_branch`, but the release branch is `$RELEASE_BRANCH`. Switch now? (y/n)"
 

--- a/.skillshare/skills/1k-bundle-release/references/rules/prepare.md
+++ b/.skillshare/skills/1k-bundle-release/references/rules/prepare.md
@@ -4,15 +4,15 @@ Prepares the release branch for bundle CI by writing `BUILD_NUMBER` to `.env.ver
 
 ## Pre-flight Checks
 
-### 1. Read release branch and verify
+### 1. Detect release branch
 
-```bash
-VERSION=$(grep -E '^VERSION=' .env.version | cut -d '=' -f 2)
-RELEASE_BRANCH="release/v${VERSION}"
-current_branch=$(git branch --show-current)
-```
+Use the **Release Branch Detection** logic from SKILL.md:
 
-If current branch is not the expected release branch, offer to switch:
+1. If already on a `release/v*` branch → use it directly
+2. Otherwise → find the latest `release/v*` from remote (excluding `mock` branches)
+3. Confirm with the user before proceeding
+
+If not on the release branch, offer to switch:
 
 > "You're on `$current_branch`, but the release branch is `$RELEASE_BRANCH`. Switch now? (y/n)"
 

--- a/.skillshare/skills/1k-bundle-release/references/rules/publish.md
+++ b/.skillshare/skills/1k-bundle-release/references/rules/publish.md
@@ -4,15 +4,15 @@ Finalizes a release by recording it in `RELEASES.json` and committing the tracki
 
 ## Pre-flight Checks
 
-### 1. Read release branch and verify
+### 1. Detect release branch
 
-```bash
-VERSION=$(grep -E '^VERSION=' .env.version | cut -d '=' -f 2)
-RELEASE_BRANCH="release/v${VERSION}"
-current_branch=$(git branch --show-current)
-```
+Use the **Release Branch Detection** logic from SKILL.md:
 
-If current branch is not the expected release branch, offer to switch:
+1. If already on a `release/v*` branch → use it directly
+2. Otherwise → find the latest `release/v*` from remote (excluding `mock` branches)
+3. Confirm with the user before proceeding
+
+If not on the release branch, offer to switch:
 
 > "You're on `$current_branch`, but the release branch is `$RELEASE_BRANCH`. Switch now? (y/n)"
 

--- a/.skillshare/skills/1k-bundle-release/references/rules/sync.md
+++ b/.skillshare/skills/1k-bundle-release/references/rules/sync.md
@@ -4,12 +4,13 @@ Syncs release branch changes to `x` via rebase after a bundle release. Creates a
 
 ## Pre-flight Checks
 
-### 1. Read release branch name
+### 1. Detect release branch
 
-```bash
-VERSION=$(grep -E '^VERSION=' .env.version | cut -d '=' -f 2)
-RELEASE_BRANCH="release/v${VERSION}"
-```
+Use the **Release Branch Detection** logic from SKILL.md:
+
+1. If already on a `release/v*` branch → use it directly
+2. Otherwise → find the latest `release/v*` from remote (excluding `mock` branches)
+3. Confirm with the user before proceeding
 
 ### 2. Confirm latest release is published
 
@@ -36,6 +37,8 @@ git fetch origin "$RELEASE_BRANCH" x
 Create a sync branch based on `x`, not on the release branch:
 
 ```bash
+# Extract version from RELEASE_BRANCH (e.g., "release/v6.1.0" → "6.1.0")
+VERSION="${RELEASE_BRANCH#release/v}"
 SYNC_BRANCH="sync/${VERSION}-$(date +%Y%m%d)"
 git checkout -b "$SYNC_BRANCH" origin/x
 ```


### PR DESCRIPTION
## Summary
- Refactored all bundle-release subcommands to use shared release branch detection logic instead of reading `.env.version` directly (which gives wrong branch name when run from `x`)
- Added standalone `audit` subcommand for pre-release security and supply-chain audits with Codex MCP cross-validation
- Enhanced `diff-check` with dual baselines (tag + last release) and multiple compare URLs

## Intent & Context
The `.env.version` on `x` contains the **next** version (e.g., `6.2.0`), while the release branch uses the **current** version (e.g., `release/v6.1.0`). This mismatch caused subcommands to target the wrong release branch when invoked from `x`. The shared detection logic resolves this by auto-detecting from the current branch or discovering the latest release branch from remote.

The `audit` subcommand was added to formalize the pre-release security review process, supporting dependency delta analysis, source diff security review, CI/CD pipeline inspection, and optional Codex MCP cross-validation.

## Design Decisions
- **Shared detection over per-file logic**: Centralized in SKILL.md so all subcommands stay consistent. Each rule file references the shared logic instead of duplicating it.
- **Dual baselines in diff-check**: Shows both full changeset (since App Shell tag) and incremental (since last bundle release) to give complete context for both first-time and subsequent releases.
- **Audit as separate subcommand**: Kept distinct from `diff-check` (quick review) to allow teams to choose their review depth. Audit reuses diff-check context when run in the same conversation.

## Changes Detail
- `SKILL.md` — Added shared Release Branch Detection section, `audit` subcommand routing, updated quick reference table
- `references/rules/audit.md` — New: full security audit workflow (Steps A–J) with Codex cross-validation
- `references/rules/checkout.md` — Switched to shared detection logic
- `references/rules/diff-check.md` — Dual baselines, multiple compare URLs, incremental changeset view
- `references/rules/prepare.md` — Switched to shared detection logic
- `references/rules/publish.md` — Switched to shared detection logic
- `references/rules/sync.md` — Switched to shared detection logic, extract VERSION from branch name

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: N/A (skill files only, no runtime code)
- **Risk Areas**: Release branch detection logic — incorrect detection could cause subcommands to target wrong branch

## Test plan
- [ ] Run `/1k-bundle-release checkout` from `x` branch — should detect latest remote release branch, not use `.env.version`
- [ ] Run `/1k-bundle-release diff-check` — should show both full and incremental changesets with clickable compare URLs
- [ ] Run `/1k-bundle-release audit` — should execute security audit workflow
- [ ] Verify all subcommands confirm detected branch with user before proceeding
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10893" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
