### PR TITLE
fix: align DNX account creation error to NotImplemented (OK-51515)

### DIFF
--- a/packages/kit-bg/src/vaults/impls/dnx/KeyringHd.ts
+++ b/packages/kit-bg/src/vaults/impls/dnx/KeyringHd.ts
@@ -1,8 +1,6 @@
 import coreChainApi from '@onekeyhq/core/src/instance/coreChainApi';
 import type { ISignedTxPro } from '@onekeyhq/core/src/types';
-import { NotImplemented, OneKeyLocalError } from '@onekeyhq/shared/src/errors';
-import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
+import { NotImplemented } from '@onekeyhq/shared/src/errors';
 
 import { KeyringHdBase } from '../../base/KeyringHdBase';
 
@@ -17,11 +15,7 @@ export class KeyringHd extends KeyringHdBase {
   }
 
   override async prepareAccounts(): Promise<IDBAccount[]> {
-    throw new OneKeyLocalError(
-      appLocale.intl.formatMessage({
-        id: ETranslations.global_bulk_add_account_dnx_error,
-      }),
-    );
+    throw new NotImplemented('Method not implemented');
   }
 
   override async signTransaction(): Promise<ISignedTxPro> {


### PR DESCRIPTION
### Motivation
- When creating software wallet addresses for the DNX network from Account Manager the UI showed a DNX-specific localized error (`批量添加账户错误，请连接 OneKey Classic`) instead of the standard unsupported-feature message (`功能尚未实现`), so behavior should match other unsupported chains as described in OK-51515.

### Description
- Update `packages/kit-bg/src/vaults/impls/dnx/KeyringHd.ts` so `prepareAccounts()` throws `NotImplemented('Method not implemented')` and remove the now-unused DNX-specific localization/`OneKeyLocalError` imports, aligning DNX with the existing unsupported-feature error pattern.

### Testing
- Attempted automated checks `yarn lint:staged`, `yarn tsc:staged`, and `yarn test` in this environment but all failed to run due to a missing Yarn/node_modules state file (`Couldn't find the node_modules state file`), so no tests completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5238c254c833286d5aeb37e3b16c5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
