### PR TITLE
fix(dnx): throw NotImplemented() to align error i18n with SCDO

### DIFF
--- a/packages/kit-bg/src/vaults/impls/dnx/KeyringHd.ts
+++ b/packages/kit-bg/src/vaults/impls/dnx/KeyringHd.ts
@@ -1,8 +1,6 @@
 import coreChainApi from '@onekeyhq/core/src/instance/coreChainApi';
 import type { ISignedTxPro } from '@onekeyhq/core/src/types';
-import { NotImplemented, OneKeyLocalError } from '@onekeyhq/shared/src/errors';
-import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
+import { NotImplemented } from '@onekeyhq/shared/src/errors';
 
 import { KeyringHdBase } from '../../base/KeyringHdBase';
 
@@ -13,22 +11,18 @@ export class KeyringHd extends KeyringHdBase {
   override coreApi = coreChainApi.dynex.hd;
 
   override async getPrivateKeys(): Promise<IGetPrivateKeysResult> {
-    throw new NotImplemented('Method not implemented');
+    throw new NotImplemented();
   }
 
   override async prepareAccounts(): Promise<IDBAccount[]> {
-    throw new OneKeyLocalError(
-      appLocale.intl.formatMessage({
-        id: ETranslations.global_bulk_add_account_dnx_error,
-      }),
-    );
+    throw new NotImplemented();
   }
 
   override async signTransaction(): Promise<ISignedTxPro> {
-    throw new NotImplemented('Method not implemented');
+    throw new NotImplemented();
   }
 
   override async signMessage(): Promise<string[]> {
-    throw new NotImplemented('Method not implemented');
+    throw new NotImplemented();
   }
 }


### PR DESCRIPTION
### Motivation
- Make DNX `KeyringHd` unsupported paths follow the same `NotImplemented` error flow as SCDO so the UI can display the standard i18n message instead of a DNX-specific English string.

### Description
- Replace explicit `throw new NotImplemented('Method not implemented')` and a DNX-specific `OneKeyLocalError` in `packages/kit-bg/src/vaults/impls/dnx/KeyringHd.ts` with `throw new NotImplemented()` so the default i18n key is preserved.
- Remove unused `OneKeyLocalError`, `ETranslations`, and `appLocale` imports and clean up the file to match SCDO behavior.

### Testing
- Ran `yarn lint:staged` which could not run in this environment (failed: missing `node_modules` state file).
- Ran `yarn tsc:staged` which could not run in this environment (failed: missing `node_modules` state file).
- Ran `yarn test` which could not run in this environment (failed: missing `node_modules` state file).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c549b9f5808332a6841446671e2f18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
