### PR TITLE
chore: sync release/v6.1.0 to x (2026-03-26)

### DIFF
--- a/development/spellCheckerSkipWords.txt
+++ b/development/spellCheckerSkipWords.txt
@@ -13,6 +13,7 @@ _j_msgid
 oxlintrc
 0x1fffffffffffff
 skillshare
+worktree
 googleusercontent
 0xf7ad23226db5c1c00ca0ca1468fd49c8f8bbc1489bc1c382de5adc557a69c229
 0xffffffffffffffffn


### PR DESCRIPTION
## Summary

Sync release/v6.1.0 branch changes to x. Most commits were already present on x via prior sync PRs (#10867, #10904). Net new change is adding "worktree" to spellCheckerSkipWords.txt.

## Synced Commits

- `183615b51b` fix(ci): prevent reusable workflow jobs from being skipped in release-app-bundles (#10818)
- `b552e549bd` fix(perp): correct token pair suffix from USD to USDC on mobile market detail page (#10821)
- `510c16b66d` fix: quote tips add check box (#10827)
- `e2e84db3d6` fix: optimize release bundle ci (#10858)
- `ef9c421677` fix(desktop): replace electron-is-dev with NODE_ENV check in react-native-mock (#10859)
- `4e0b0ac147` fix: cherry-pick oxlint rules for import order and raw Error (#10851)
- `165f0b4135` fix(ci): improve bundle build workflow for PR builds (#10861)
- `512fb68835` chore: register import-js/order ESLint stub plugin and reorganize plugin files (#10857) (#10862)
- `299a3cd711` ci: enable native change check on PRs targeting release branches (#10864)
- `fc7cf97dbf` fix: pass checkout_ref to shared-env and override GITHUB_SHA in release-web
- `eba9f30009` fix: RecentHistory card not showing pending transactions (OK-52117) (#10852)
- `0c7c73f46c` fix: clamp tron resources, tab bar offset on approvals, android token history layout (#10836)
- `74f13a8e71` feat(borrow): port collateral repay flow (#10822)
- `4f42b1048a` fix: hide DeFi earn banner when all protocols have 0% APR (#10870)
- `7929145eca` fix(fiat-crypto): optimize Buy token list ordering (OK-51718) (#10847)
- `5830a610ba` feat: OK-51514 support search address on account selector (#10846)
- `b6bc389351` feat: worktree command v6.1.0 (#10880)
- `c659d1252c` feat(swap): support URL query param to select swap tab on web (#10869)
- `ec38f767b3` Feat/speed swap stock quote sign (#10823)
- `474489bb1d` fix: use featuresDeviceId only for standard wallet existence check (#10838) OK-51680
- `5dc284a10a` fix: Android UI fixes — ListItem overlap & Switch disabled state (#10882)
- `9ceb0a7816` fix: restore desktop history list layout (#10896)

## Skipped Commits

| Commit | Title | Reason |
|--------|-------|--------|
| `f0e01a0d9f` | fix(usePromiseResult): guard cancelIdleCallback behind platformEnv.isNative (#10812) | Already on x (identical patch-id) |
| `7c5a713089` | ci: add web build to release-app-bundles orchestrator (#10816) (#10817) | Already on x (identical patch-id) |
| `d2dec6ee6f` | feat(lint): enable no-shadow and no-use-before-define rules (#10809) | Already on x (identical patch-id) |
| `62e27f7d7b` | Add BUILD_NUMBER to .env.version file | Release-specific — x uses VERSION=6.2.0 without BUILD_NUMBER |
| `a9615ce323` | chore: release #1 | Release-specific — creates RELEASES.json (bundle release metadata) |

## Conflict Resolutions

### 1. `.github/workflows/release-app-bundles.yml` — commits `183615b51b`, `e2e84db3d6`
- **x side**: Has `inputs.build_web &&` guard plus `!cancelled() && !failure()`, PR validation with `head_sha`/`head_ref` outputs and behind-by check
- **release side**: Only has `!cancelled() && !failure()` guard, simpler PR validation without metadata extraction
- **Resolution**: Kept x's version — it is a strict superset of the release changes, with additional `inputs.build_web` conditional and PR up-to-date validation. Both commits resolved as empty (no net change).

### 2. `.eslintrc.js`, `.oxlintrc.json`, 20+ app entry files — commit `4e0b0ac147`
- **x side**: Uses `// oxlint-disable import-js/order` comment-based disables, has `react_perf` rules enabled per-override for packages/components
- **release side**: Uses `eslint-disable` comments for import order, `react_perf` rules globally disabled
- **Resolution**: Kept x's version — more evolved lint configuration with granular overrides. Only net change was adding `development/lint/eslint-plugin-onekey.js`.

### 3. `.eslintrc.js`, `package.json`, `development/plugins/eslint-plugin-onekey.js` — commit `512fb68835`
- **x side**: Already has eslint-plugin-onekey registered via `5e5031f41e` (non-cherry-pick version of same PR #10857)
- **release side**: Cherry-pick of #10857 with slightly different file organization
- **Resolution**: Kept x's version — same logical change already applied. Net change: removed `development/lint/eslint-plugin-onekey.js` (moved to `development/plugins/`).

### 4. `TxActionCommon.tsx`, `TxActionTransfer.tsx` — commit `0c7c73f46c`
- **x side**: Uses `tableLayout` conditional spreads (`{...(!tableLayout && { textAlign: 'right' })}`) and `changeMaxWidth` variable
- **release side**: Uses unconditional `textAlign="right"` and `mobileChangeMaxWidth` with platform-specific widths
- **Resolution**: Merged both — kept x's `tableLayout` conditionals (needed for desktop table layout feature) and adopted release's `mobileChangeMaxWidth` logic for platform-specific width handling. Later restored to `changeMaxWidth` by commit `9ceb0a7816`.

### 5. `packages/kit-bg/src/vaults/impls/sol/sdkSol/ClientSol.ts` — commit `74f13a8e71`
- **x side**: Has `GET_MULTIPLE_ACCOUNTS_INFO = 'getMultipleAccounts'` enum member
- **release side**: Does not have this enum member
- **Resolution**: Kept x's version — additional enum member is needed by existing x-branch code.

### 6. Locale files (18 JSON files + `translations.ts`) — commit `74f13a8e71`
- **x side**: Has additional `perp_portfolio_*` translation keys from perpetual trading feature
- **release side**: Adds borrow-related translation keys
- **Resolution**: Kept x's version — all borrow translations already present on x from prior sync. Commit resolved as empty.

### 7. `.skillshare/skills/1k-bundle-release/SKILL.md` — commit `b6bc389351`
- **x side**: Skills directory renamed from `.claude/` to `.skillshare/`, includes audit subcommand
- **release side**: Still uses `.claude/` path, adds PR subcommand and worktree script
- **Resolution**: Kept x's version (`.skillshare/` path with audit subcommand). PR rules file already existed at new path. Net change: added "worktree" to spellCheckerSkipWords.txt.

### 8. `packages/components/src/forms/Switch/index.tsx` — commit `5dc284a10a`
- **x side**: Has `nativeProps` extracted into a `useMemo` hook with platform-specific Android opacity styling
- **release side**: Inlines the same nativeProps object directly in JSX
- **Resolution**: Kept x's version — `useMemo` avoids unnecessary re-renders, and contains the identical Android disabled-state fix.

### 9. `TxActionCommon.tsx`, `TxActionTransfer.tsx`, `spellCheckerSkipWords.txt` — commit `9ceb0a7816`
- **x side**: Already has `changeMaxWidth` variable and `tableLayout` conditionals
- **release side**: Restores `changeMaxWidth` naming (reverting `mobileChangeMaxWidth` from #10836) and adds `tableLayout` support
- **Resolution**: Merged — used `changeMaxWidth` (matching x's variable definition) and kept existing `tableLayout` conditionals. Added "crosschain" to spellcheck words.

---

Automatically executed by Claude Code cloud scheduled task.

https://claude.ai/code/session_01SmvbLEtVhdEap7sC93TZ7U
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
