### PR TITLE
chore: remove unused flatted dependency

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -19,7 +19,6 @@
     "@types/webextension-polyfill": "^0.8.2",
     "async-mutex": "^0.3.2",
     "fast-safe-stringify": "^2.1.1",
-    "flatted": "^3.4.0",
     "js-base64": "3.7.5",
     "jsonschema": "^1.4.1",
     "localforage": "^1.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9539,7 +9539,6 @@ __metadata:
     "@types/webextension-polyfill": "npm:^0.8.2"
     async-mutex: "npm:^0.3.2"
     fast-safe-stringify: "npm:^2.1.1"
-    flatted: "npm:^3.4.0"
     folderslint: "npm:1.2.0"
     js-base64: "npm:3.7.5"
     jsonschema: "npm:^1.4.1"
@@ -29462,13 +29461,6 @@ __metadata:
   version: 3.3.3
   resolution: "flatted@npm:3.3.3"
   checksum: 10/8c96c02fbeadcf4e8ffd0fa24983241e27698b0781295622591fc13585e2f226609d95e422bcf2ef044146ffacb6b68b1f20871454eddf75ab3caa6ee5f4a1fe
-  languageName: node
-  linkType: hard
-
-"flatted@npm:^3.4.0":
-  version: 3.4.1
-  resolution: "flatted@npm:3.4.1"
-  checksum: 10/39a308e2ef82d2d8c80ebc74b67d4ff3f668be168137b649440b6735eb9c115d1e0c13ab0d9958b3d2ea9c85087ab7e14c14aa6f625a22b2916d89bbd91bc4a0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Remove unused `flatted` dependency from `@onekeyhq/shared` package

## Intent & Context
The `flatted` package was declared as a dependency in `packages/shared/package.json` but was never imported or used anywhere in the codebase. This removes it to keep dependencies clean.

## Changes Detail
- `packages/shared/package.json`: Removed `"flatted": "^3.4.0"` from dependencies
- `yarn.lock`: Updated lockfile to reflect the removal

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: None (unused dependency)

## Test plan
- [x] Verified no imports of `flatted` exist in the codebase
- [ ] CI passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
