### PR TITLE
fix: perps portfolio PnL review fixes

### DIFF
--- a/packages/kit/src/components/LightweightChart/hooks/useChartConfig.ts
+++ b/packages/kit/src/components/LightweightChart/hooks/useChartConfig.ts
@@ -22,6 +22,7 @@ interface IUseChartConfigProps {
   showHorzGridLines?: boolean;
   priceScaleMargins?: { top: number; bottom: number };
   priceFormatter?: (price: number) => string;
+  priceFormatterType?: 'usd' | 'percent';
   fontSize?: number;
   seriesType?: 'area' | 'baseline';
   baselineOptions?: BaselineSeriesPartialOptions;
@@ -40,6 +41,7 @@ export function useChartConfig({
   showHorzGridLines = false,
   priceScaleMargins,
   priceFormatter,
+  priceFormatterType,
   fontSize,
   seriesType,
   baselineOptions,
@@ -75,7 +77,8 @@ export function useChartConfig({
       secondaryLineColor,
       secondaryLineWidth,
       priceFormatter,
-      priceFormatterType: priceFormatter ? 'usd' : 'percent',
+      priceFormatterType:
+        priceFormatterType ?? (priceFormatter ? 'usd' : 'percent'),
       fontSize,
       seriesType,
       baselineOptions,
@@ -96,6 +99,7 @@ export function useChartConfig({
       showHorzGridLines,
       priceScaleMargins,
       priceFormatter,
+      priceFormatterType,
       fontSize,
       seriesType,
       baselineOptions,

--- a/packages/shared/src/utils/perpsUtils.ts
+++ b/packages/shared/src/utils/perpsUtils.ts
@@ -1376,7 +1376,7 @@ export function getTokenSubtitle(
  * Format a number as USD string using numberFormat 'value' formatter.
  * Optionally shows +/- sign for non-zero values.
  */
-function formatPerpsUsd(
+export function formatPerpsUsd(
   value: number | null | undefined,
   showSign = false,
 ): string {
@@ -1399,7 +1399,7 @@ function formatPerpsUsd(
 /**
  * Format a number as compact USD (K/M/B suffixes) using numberFormat 'marketCap' formatter.
  */
-function formatPerpsCompactUsd(value: number): string {
+export function formatPerpsCompactUsd(value: number): string {
   if (value === 0) return '$0';
   const bn = new BigNumber(value);
   const abs = bn.abs().toFixed();
@@ -1419,7 +1419,7 @@ function formatPerpsCompactUsd(value: number): string {
  */
 type IPerpsValueColor = '$text' | '$green11' | '$red11';
 
-function getPerpsValueColor(
+export function getPerpsValueColor(
   value: number | null | undefined,
 ): IPerpsValueColor {
   if (value === null || value === undefined || value === 0) return '$text';
@@ -1433,7 +1433,7 @@ function getPerpsValueColor(
  * NOTE: Keep in sync with `usdPriceFormatter` in LightweightChart/utils/htmlTemplate.ts
  * (native WebView cannot use TS functions, so the logic is duplicated as inline JS).
  */
-function formatChartUsdPrice(price: number): string {
+export function formatChartUsdPrice(price: number): string {
   const abs = Math.abs(price);
   const sign = price < 0 ? '-' : '';
   if (abs >= 1_000_000) {
@@ -1480,10 +1480,6 @@ export {
   mapTriggerOrderType,
   inferTpsl,
   getTriggerEffectivePrice,
-  formatPerpsUsd,
-  formatPerpsCompactUsd,
-  getPerpsValueColor,
-  formatChartUsdPrice,
 };
 export default {
   formatAssetCtx,


### PR DESCRIPTION
## Summary
- `useChartConfig.ts`: `priceFormatterType` 改为显式 prop，避免从 `priceFormatter` 存在与否硬编码推导
- `perpsUtils.ts`: `formatPerpsUsd` 等 4 个函数改为 `export function` 直接导出，修复 circular dependency 导致的 `TypeError: formatPerpsUsd is not a function`

## Test plan
- [ ] 打开 portfolio modal，确认无 runtime error
- [ ] 确认 PnL 图表正常渲染且价格格式正确
- [ ] 确认 perps 交易页面其他引用 formatPerpsUsd 的地方正常
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
