### PR TITLE
fix: sync market watchlist edit dialog with cloud sync

### DIFF
--- a/packages/kit-bg/src/services/ServiceKeylessCloudSync/ServiceKeylessCloudSync.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessCloudSync/ServiceKeylessCloudSync.ts
@@ -43,7 +43,15 @@ class ServiceKeylessCloudSync extends ServiceBase {
     super({ backgroundApi });
   }
 
+  // Keep the explicit "Switch Now" intent in memory until the keyless wallet is created.
+  private pendingAutoEnableCloudSyncKeyless = false;
+
   private repairCredentialMutex = new Semaphore(1);
+
+  @backgroundMethod()
+  async setPendingAutoEnableCloudSyncKeyless(enabled: boolean) {
+    this.pendingAutoEnableCloudSyncKeyless = enabled;
+  }
 
   async getKeylessWallet(): Promise<IDBWallet | null> {
     const keylessWallet =
@@ -690,17 +698,17 @@ class ServiceKeylessCloudSync extends ServiceBase {
   async autoEnableCloudSyncKeyless() {
     const { wallets } = await this.backgroundApi.serviceAccount.getAllWallets();
     await this.syncPersistedCurrentCloudSyncKeylessWalletIdWithWallets(wallets);
+    const shouldMigrateFromId = this.pendingAutoEnableCloudSyncKeyless;
     const { isCloudSyncEnabledKeyless, isCloudSyncEnabled } =
       await primeCloudSyncPersistAtom.get();
     if (isCloudSyncEnabledKeyless) {
+      this.pendingAutoEnableCloudSyncKeyless = false;
       return;
     }
-    if (isCloudSyncEnabled) {
+    if (isCloudSyncEnabled && !shouldMigrateFromId) {
       return;
     }
-    // If ID sync is active, sync ID data first before switching (auto-migration)
-    const isMigrationFromId = isCloudSyncEnabled;
-    if (isMigrationFromId) {
+    if (shouldMigrateFromId && isCloudSyncEnabled) {
       try {
         await this.backgroundApi.servicePrimeCloudSync.startServerSyncFlow({
           callerName: 'Auto-migration: ID sync before switch',
@@ -716,6 +724,7 @@ class ServiceKeylessCloudSync extends ServiceBase {
         silentEnable: true,
         forceEnable: true,
       });
+      this.pendingAutoEnableCloudSyncKeyless = false;
     } catch (error) {
       errorUtils.autoPrintErrorIgnore(error);
       void this.backgroundApi.serviceApp.showToast({

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketWatchlistTokenList.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketWatchlistTokenList.ts
@@ -30,7 +30,7 @@ export function getWatchlistTokenCache(): IMarketToken[] {
   return watchlistTokenCache;
 }
 
-function subscribeWatchlistTokenCache(cb: () => void) {
+export function subscribeWatchlistTokenCache(cb: () => void) {
   cacheListeners.add(cb);
   return () => {
     cacheListeners.delete(cb);
@@ -299,11 +299,8 @@ export function useMarketWatchlistTokenList({
   }, [refetchData]);
 
   useEffect(() => {
-    const prevLength = watchlistTokenCache.length;
     watchlistTokenCache = paginatedData;
-    if ((prevLength === 0) !== (paginatedData.length === 0)) {
-      cacheListeners.forEach((cb) => cb());
-    }
+    cacheListeners.forEach((cb) => cb());
   }, [paginatedData]);
 
   // Clear stale cache on unmount so re-mounting reads fresh data

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/useOpenMarketWatchlistEditDialog.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/useOpenMarketWatchlistEditDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -23,7 +23,10 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IMarketWatchListItemV2 } from '@onekeyhq/shared/types/market';
 
 import { TokenIdentityItem } from './components/TokenIdentityItem/TokenIdentityItem';
-import { getWatchlistTokenCache } from './hooks/useMarketWatchlistTokenList';
+import {
+  getWatchlistTokenCache,
+  subscribeWatchlistTokenCache,
+} from './hooks/useMarketWatchlistTokenList';
 
 import type { IMarketToken } from './MarketTokenData';
 
@@ -53,33 +56,20 @@ function tokenToWatchListItem(token: IMarketToken): IMarketWatchListItemV2 {
 }
 
 function MarketWatchlistEditDialogContent({
-  cachedTokens,
   onRemove,
   onSort,
 }: {
-  cachedTokens: IMarketToken[];
   onRemove: (item: IMarketToken) => Promise<void>;
   onSort: (params: IDragEndParamsWithItem<IMarketToken>) => void;
 }) {
   const intl = useIntl();
-  const [dataSource, setDataSource] = useState<IMarketToken[]>(() => [
-    ...cachedTokens,
-  ]);
-
-  const dataSourceRef = useRef(dataSource);
-  dataSourceRef.current = dataSource;
+  const dataSource = useSyncExternalStore(
+    subscribeWatchlistTokenCache,
+    getWatchlistTokenCache,
+  );
 
   const handleRemove = useCallback(
     async (item: IMarketToken) => {
-      const itemKey = getWatchlistTokenKey(item);
-      const originalIndex = dataSourceRef.current.findIndex(
-        (t) => getWatchlistTokenKey(t) === itemKey,
-      );
-      setDataSource((prev) =>
-        prev.filter(
-          (currentItem) => getWatchlistTokenKey(currentItem) !== itemKey,
-        ),
-      );
       try {
         await onRemove(item);
         Toast.success({
@@ -88,15 +78,7 @@ function MarketWatchlistEditDialogContent({
           }),
         });
       } catch {
-        setDataSource((prev) => {
-          const next = [...prev];
-          const insertAt =
-            originalIndex >= 0
-              ? Math.min(originalIndex, next.length)
-              : next.length;
-          next.splice(insertAt, 0, item);
-          return next;
-        });
+        // removal failed — data will remain unchanged via cache
       }
     },
     [intl, onRemove],
@@ -104,8 +86,6 @@ function MarketWatchlistEditDialogContent({
 
   const handleDragEnd = useCallback(
     (params: IDragEndParamsWithItem<IMarketToken>) => {
-      const { data } = params;
-      setDataSource(data);
       onSort(params);
     },
     [onSort],
@@ -229,17 +209,13 @@ export function useOpenMarketWatchlistEditDialog() {
       }),
       renderContent: (
         <MarketWatchlistEditDialogContent
-          cachedTokens={cached}
           onRemove={handleRemove}
           onSort={handleSort}
         />
       ),
       estimatedContentHeight: EDIT_DIALOG_HEIGHT,
       disableDrag: true,
-      showCancelButton: false,
-      onConfirmText: intl.formatMessage({
-        id: ETranslations.global_done,
-      }),
+      showFooter: false,
       onClose: async () => {
         dialogRef.current = null;
       },

--- a/packages/kit/src/views/Onboardingv2/pages/OneKeyIDLoginPage.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/OneKeyIDLoginPage.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from 'react';
 import { useCallback, useRef, useState } from 'react';
 
 import { useIntl } from 'react-intl';
@@ -35,23 +36,33 @@ import { OnboardingLayout } from '../components/OnboardingLayout';
 
 import { KeylessOnboardingDebugPanel } from './KeylessOnboardingDebugPanel';
 
+const optionItemNativePressableStyle = {
+  width: '100%',
+  flexGrow: 0,
+  flexShrink: 0,
+} as const;
+
 function OptionItem({
   icon,
   iconProps,
   title,
   isLoading,
   onPress,
+  mt,
 }: {
   icon: IKeyOfIcons;
   iconProps?: IIconProps;
   title: string;
   isLoading?: boolean;
   onPress?: () => void;
+  mt?: ComponentProps<typeof ListItem>['mt'];
 }) {
   return (
     <ListItem
       gap="$3"
       bg="$bg"
+      w="100%"
+      minHeight="$14"
       $platform-web={{
         boxShadow:
           '0 0 0 1px rgba(0, 0, 0, 0.04), 0 0 2px 0 rgba(0, 0, 0, 0.08), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
@@ -67,20 +78,28 @@ function OptionItem({
       }}
       borderRadius="$5"
       borderCurve="continuous"
+      overflow="hidden"
       p="$3"
       m="$0"
+      mt={mt}
+      nativePressableStyle={optionItemNativePressableStyle}
       onPress={onPress}
       nativePressableStyle={{ flexShrink: 0 }}
       userSelect="none"
     >
       <YStack
+        w="$10"
+        h="$10"
+        alignItems="center"
+        justifyContent="center"
+        flexShrink={0}
         borderRadius="$full"
         bg="$neutral2"
         borderWidth={StyleSheet.hairlineWidth}
         borderColor="$neutral2"
         p="$2"
       >
-        <Icon name={icon} {...iconProps} />
+        <Icon name={icon} size="$5" {...iconProps} />
       </YStack>
       <YStack gap={2} flex={1}>
         <SizableText size="$bodyLgMedium">{title}</SizableText>
@@ -245,6 +264,7 @@ function OneKeyIDLoginPage() {
                 <OptionItem
                   icon="AppleBrand"
                   title="Apple"
+                  mt={!requiredProvider ? '$3' : undefined}
                   iconProps={{
                     color: '$iconActive',
                     y: -1,

--- a/packages/kit/src/views/Onboardingv2/pages/OneKeyIDLoginPage.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/OneKeyIDLoginPage.tsx
@@ -84,7 +84,6 @@ function OptionItem({
       mt={mt}
       nativePressableStyle={optionItemNativePressableStyle}
       onPress={onPress}
-      nativePressableStyle={{ flexShrink: 0 }}
       userSelect="none"
     >
       <YStack

--- a/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSync.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSync.tsx
@@ -14,6 +14,7 @@ import {
   SizableText,
   Stack,
   Switch,
+  popModalPages,
   startViewTransition,
   useMedia,
 } from '@onekeyhq/components';
@@ -26,6 +27,7 @@ import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { usePasswordPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { usePrimeCloudSyncPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/prime';
+import appGlobals from '@onekeyhq/shared/src/appGlobals';
 import { ELockDuration } from '@onekeyhq/shared/src/consts/appAutoLockConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
@@ -54,6 +56,8 @@ function formatSyncLastUpdateTime(syncTime?: number): string {
   }
   return ' - ';
 }
+
+const listItemNativePressableStyle = { flexShrink: 0 } as const;
 
 function AutoLockUpdateDialogContent({
   onContinue,
@@ -293,8 +297,8 @@ function AppDataSection() {
   // --- Handlers ---
 
   // Navigate to KW creation flow (Scenario 1)
-  const handleCreateKeylessWallet = useCallback(() => {
-    navigation.navigate(ERootRoutes.Onboarding, {
+  const handleCreateKeylessWallet = useCallback(async () => {
+    const onboardingParams = {
       screen: EOnboardingV2Routes.OnboardingV2,
       params: {
         screen: EOnboardingPagesV2.OneKeyIDLogin,
@@ -302,7 +306,18 @@ function AppDataSection() {
           mode: EOnboardingV2OneKeyIDLoginMode.KeylessCreateOrRestore,
         },
       },
-    });
+    } as const;
+
+    if (platformEnv.isNative) {
+      await popModalPages();
+      appGlobals.$rootAppNavigation?.push(
+        ERootRoutes.Onboarding,
+        onboardingParams,
+      );
+      return;
+    }
+
+    navigation.navigate(ERootRoutes.Onboarding, onboardingParams);
   }, [navigation]);
 
   // Migrate ID → Keyless (Scenario 4 "Switch Now")
@@ -326,7 +341,7 @@ function AppDataSection() {
           await backgroundApiProxy.serviceKeylessCloudSync.setPendingAutoEnableCloudSyncKeyless(
             true,
           );
-          handleCreateKeylessWallet();
+          await handleCreateKeylessWallet();
         },
       });
       return;
@@ -600,6 +615,7 @@ function AppDataSection() {
             title={intl.formatMessage({ id: ETranslations.wallet_backup_now })}
             icon="RefreshCwOutline"
             drillIn
+            nativePressableStyle={listItemNativePressableStyle}
             onPress={handleManualSyncKeyless}
           />
         </>
@@ -647,6 +663,7 @@ function AppDataSection() {
             title={intl.formatMessage({ id: ETranslations.wallet_backup_now })}
             icon="RefreshCwOutline"
             drillIn
+            nativePressableStyle={listItemNativePressableStyle}
             onPress={handleSyncNowKwRemoved}
           />
         </>
@@ -694,6 +711,7 @@ function AppDataSection() {
             title={intl.formatMessage({ id: ETranslations.wallet_backup_now })}
             icon="RefreshCwOutline"
             drillIn
+            nativePressableStyle={listItemNativePressableStyle}
             onPress={handleManualSyncOneKeyId}
           />
           <ListItem
@@ -702,6 +720,7 @@ function AppDataSection() {
             })}
             icon="Key2Outline"
             drillIn
+            nativePressableStyle={listItemNativePressableStyle}
             onPress={async () => {
               try {
                 await backgroundApiProxy.serviceMasterPassword.startChangePassword();
@@ -747,16 +766,13 @@ export default function PagePrimeCloudSync() {
       />
       <Page.Body>
         <AppDataSection />
-        <Stack>
-          <MultipleClickStack
-            flex={1}
-            h="$10"
-            showDevBgColor
-            onPress={() => {
-              navigation.navigate(EPrimePages.PrimeCloudSyncDebug);
-            }}
-          />
-        </Stack>
+        <MultipleClickStack
+          h="$10"
+          showDevBgColor
+          onPress={() => {
+            navigation.navigate(EPrimePages.PrimeCloudSyncDebug);
+          }}
+        />
       </Page.Body>
     </Page>
   );

--- a/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSync.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSync.tsx
@@ -322,13 +322,21 @@ function AppDataSection() {
         onConfirmText: intl.formatMessage({
           id: ETranslations.create_and_switch__action,
         }),
-        onConfirm: () => handleCreateKeylessWallet(),
+        onConfirm: async () => {
+          await backgroundApiProxy.serviceKeylessCloudSync.setPendingAutoEnableCloudSyncKeyless(
+            true,
+          );
+          handleCreateKeylessWallet();
+        },
       });
       return;
     }
     // Has KW → proceed directly (no extra confirm — "Switch Now" is already explicit intent)
     isSubmittingRef.current = true;
     try {
+      await backgroundApiProxy.serviceKeylessCloudSync.setPendingAutoEnableCloudSyncKeyless(
+        false,
+      );
       await backgroundApiProxy.servicePassword.promptPasswordVerify();
       await backgroundApiProxy.serviceApp.showDialogLoading({
         title: intl.formatMessage({
@@ -739,14 +747,16 @@ export default function PagePrimeCloudSync() {
       />
       <Page.Body>
         <AppDataSection />
-        <MultipleClickStack
-          flex={1}
-          h="$10"
-          showDevBgColor
-          onPress={() => {
-            navigation.navigate(EPrimePages.PrimeCloudSyncDebug);
-          }}
-        />
+        <Stack>
+          <MultipleClickStack
+            flex={1}
+            h="$10"
+            showDevBgColor
+            onPress={() => {
+              navigation.navigate(EPrimePages.PrimeCloudSyncDebug);
+            }}
+          />
+        </Stack>
       </Page.Body>
     </Page>
   );

--- a/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSyncDebug.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSyncDebug.tsx
@@ -16,6 +16,7 @@ import {
   XStack,
   YStack,
   useClipboard,
+  useTabContainerWidth,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { useOneKeyAuth } from '@onekeyhq/kit/src/components/OneKeyAuth/useOneKeyAuth';
@@ -28,6 +29,7 @@ import {
   usePrimeMasterPasswordPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { EPrimeCloudSyncDataType } from '@onekeyhq/shared/src/consts/primeConsts';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import dateUtils from '@onekeyhq/shared/src/utils/dateUtils';
 import uriUtils from '@onekeyhq/shared/src/utils/uriUtils';
 import type {
@@ -629,7 +631,7 @@ function SyncItemTable({ activeTab }: { activeTab: ITabType }) {
   );
 
   return (
-    <YStack p="$1" gap="$1">
+    <YStack flex={1} minHeight={0} p="$1" gap="$1">
       <XStack gap="$1" alignItems="center">
         <Select
           title="数据类型"
@@ -717,6 +719,7 @@ function SyncItemTable({ activeTab }: { activeTab: ITabType }) {
         dataSource={displayItems}
         estimatedItemSize={40}
         keyExtractor={(item) => item.id}
+        tabIntegrated
       />
     </YStack>
   );
@@ -1059,6 +1062,8 @@ function DebugPanel() {
 }
 
 export default function PagePrimeCloudSyncDebug() {
+  const tabContainerWidth = useTabContainerWidth();
+
   const localItemsTable = useCallback(
     () => <SyncItemTable activeTab="local" />,
     [],
@@ -1070,15 +1075,27 @@ export default function PagePrimeCloudSyncDebug() {
   );
 
   const statusPanel = useCallback(() => {
-    return <StatusPanel />;
+    return (
+      <Tabs.ScrollView showsVerticalScrollIndicator={false}>
+        <StatusPanel />
+      </Tabs.ScrollView>
+    );
   }, []);
 
   const debugPanel = useCallback(() => {
-    return <DebugPanel />;
+    return (
+      <Tabs.ScrollView showsVerticalScrollIndicator={false}>
+        <DebugPanel />
+      </Tabs.ScrollView>
+    );
   }, []);
 
   const scenarioPanel = useCallback(() => {
-    return <ScenarioPanel />;
+    return (
+      <Tabs.ScrollView showsVerticalScrollIndicator={false}>
+        <ScenarioPanel />
+      </Tabs.ScrollView>
+    );
   }, []);
 
   const tabs = useMemo(() => {
@@ -1113,11 +1130,14 @@ export default function PagePrimeCloudSyncDebug() {
   ]);
 
   return (
-    <Page scrollEnabled>
+    <Page>
       <Page.Header title="云同步数据调试" />
       <Page.Body>
-        <Stack>
-          <Tabs.Container renderTabBar={(props) => <Tabs.TabBar {...props} />}>
+        <Stack flex={1} minHeight={0}>
+          <Tabs.Container
+            width={platformEnv.isNative ? Number(tabContainerWidth) : undefined}
+            renderTabBar={(props) => <Tabs.TabBar {...props} />}
+          >
             {tabs.map((tab) => (
               <Tabs.Tab key={tab.title} name={tab.title}>
                 {tab.page()}


### PR DESCRIPTION
## Summary
- Make the Market watchlist edit dialog subscribe to `watchlistTokenCache` via `useSyncExternalStore`, so it reflects real-time cloud sync (websocket) updates — matching the Favorites list behavior behind the dialog.
- Remove the Done button since edits (remove/reorder) are applied immediately without confirmation.
- Simplify dialog component by removing local state management and optimistic update logic.

## Test plan
- [ ] Open Market Favorites edit dialog on mobile
- [ ] From another device, add/remove a favorite via cloud sync
- [ ] Verify the edit dialog updates in real-time
- [ ] Verify drag-to-reorder still works correctly
- [ ] Verify delete from dialog removes the item immediately
- [ ] Verify the Done button is no longer shown
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
