### PR TITLE
fix(ci): harden release-app-bundles security and fix PR checkout bug

### DIFF
--- a/.github/workflows/release-app-bundles.yml
+++ b/.github/workflows/release-app-bundles.yml
@@ -7,14 +7,9 @@ on:
         description: 'PR number to build (optional, builds from PR head ref)'
         required: false
         type: string
-      build_web:
-        description: 'Build Web bundle'
-        required: false
-        type: boolean
-        default: false
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: read
 
 jobs:
@@ -90,11 +85,11 @@ jobs:
         uses: actions/checkout@v4
         if: ${{ !inputs.pr_number }}
 
-      - name: Checkout PR head commit
+      - name: Checkout PR head commit (pinned to validated SHA)
         if: ${{ inputs.pr_number }}
         uses: actions/checkout@v4
         with:
-          ref: refs/pull/${{ inputs.pr_number }}/head
+          ref: ${{ needs.validate-pr.outputs.head_sha }}
 
       - name: Generate build parameters
         id: params
@@ -207,7 +202,7 @@ jobs:
 
   web-bundle:
     needs: prepare-params
-    if: ${{ inputs.build_web && !cancelled() && !failure() }}
+    if: ${{ !cancelled() && !failure() }}
     uses: ./.github/workflows/release-web.yml
     with:
       build_number: ${{ needs.prepare-params.outputs.build_number }}

--- a/.github/workflows/release-desktop-bundle.yml
+++ b/.github/workflows/release-desktop-bundle.yml
@@ -96,6 +96,7 @@ jobs:
       - name: Run Shared Env Setup
         uses: ./.github/actions/shared-env
         with:
+          checkout_ref: ${{ inputs.checkout_ref || '' }}
           env_file_name: '.env'
           sentry_project: 'desktop'
           covalent_key: ${{ secrets.COVALENT_KEY }}
@@ -110,9 +111,9 @@ jobs:
 
       - name: 'Setup ENV'
         run: |
-          eval "$(node -e 'const v=require("./apps/desktop/package.json").version; console.log("pkg_version="+v)')"
-          echo '$pkg_version='$pkg_version
-          echo "PKG_VERSION=$pkg_version" >> $GITHUB_ENV
+          pkg_version=$(node -p "require('./apps/desktop/package.json').version")
+          echo "pkg_version=$pkg_version"
+          printf 'PKG_VERSION=%s\n' "$pkg_version" >> "$GITHUB_ENV"
           artifacts_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           echo "ARTIFACTS_URL=$artifacts_url" >> $GITHUB_ENV
           if [ -z "${{ env.BUILD_BUNDLE_VERSION }}" ]; then

--- a/.github/workflows/release-native-bundle.yml
+++ b/.github/workflows/release-native-bundle.yml
@@ -96,6 +96,7 @@ jobs:
       - name: Run Shared Env Setup
         uses: ./.github/actions/shared-env
         with:
+          checkout_ref: ${{ inputs.checkout_ref || '' }}
           env_file_name: '.env'
           sentry_project: 'react-native'
           covalent_key: ${{ secrets.COVALENT_KEY }}

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -108,9 +108,9 @@ jobs:
 
       - name: Setup ENV
         run: |
-          eval "$(node -e 'const v=require("./apps/web/package.json").version; console.log("pkg_version="+v)')"
-          echo '$pkg_version='$pkg_version
-          echo "PKG_VERSION=$pkg_version" >> $GITHUB_ENV
+          pkg_version=$(node -p "require('./apps/web/package.json').version")
+          echo "pkg_version=$pkg_version"
+          printf 'PKG_VERSION=%s\n' "$pkg_version" >> "$GITHUB_ENV"
 
           # For test environment, use GitHub Pages URL
           echo "PUBLIC_URL=https://${{ env.TEST_ENDPOINT }}/" >> $GITHUB_ENV
@@ -191,6 +191,7 @@ jobs:
             ./apps/web/web-build/
 
       - name: Deploy Github Pages
+        if: ${{ github.event_name != 'workflow_call' }}
         uses: OneKeyHQ/actions/gh-pages@86ad045e18da7958f659995ee2f9df375dd03ef4 # pin to SHA
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -243,9 +244,9 @@ jobs:
 
       - name: Setup ENV
         run: |
-          eval "$(node -e 'const v=require("./apps/web/package.json").version; console.log("pkg_version="+v)')"
-          echo '$pkg_version='$pkg_version
-          echo "PKG_VERSION=$pkg_version" >> $GITHUB_ENV
+          pkg_version=$(node -p "require('./apps/web/package.json').version")
+          echo "pkg_version=$pkg_version"
+          printf 'PKG_VERSION=%s\n' "$pkg_version" >> "$GITHUB_ENV"
 
           # For production environment, use production URL
           echo "PUBLIC_URL=https://app-assets.onekey.so/${{ github.sha }}-${{ env.BUILD_NUMBER }}/" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- Fix shared-env second checkout overriding PR code in native-bundle and desktop-bundle workflows
- Fix TOCTOU race condition in PR validation vs checkout
- Fix shell injection via `eval "$(node -e ...)"` in reusable workflows
- Downgrade `contents` permission from `write` to `read` by removing gh-pages deploy dependency

## Intent & Context
A security audit (cross-validated by Codex) identified 3 CI/CD vulnerabilities in the release bundle pipeline. Separately, a runtime bug was discovered where bundles built from PR numbers were silently built from the wrong commit (the `x` branch instead of the PR head).

## Root Cause
**Checkout bug**: `shared-env` composite action contains its own `actions/checkout` step. When `release-native-bundle.yml` and `release-desktop-bundle.yml` called `shared-env` without passing `checkout_ref`, the second checkout defaulted to `github.ref` (the `x` branch), overwriting the PR code that was correctly checked out in the first step. The `COMMIT` env var was still correct, but the actual source code being compiled was from `x`.

**TOCTOU**: `validate-pr` extracted and validated `head_sha`, but `prepare-params` checked out the mutable `refs/pull/N/head` ref. An attacker could force-push between validation and checkout.

**Shell injection**: `eval "$(node -e '...require(package.json).version...')"` allowed a crafted `package.json` version field to execute arbitrary shell commands during CI.

**Permission scope**: `contents: write` was set at workflow level but only needed by the gh-pages deploy step in `release-web.yml`.

## Design Decisions
- **Pass `checkout_ref` rather than removing checkout from shared-env**: Minimal change, consistent with how `release-web.yml` already works. Avoids breaking other workflows that depend on shared-env's checkout.
- **Always build web bundle**: Removed `build_web` toggle; web bundle is now always built alongside native and desktop. This simplifies the workflow and removes the only reason `contents: write` was needed (gh-pages deploy is now skipped in `workflow_call` context).
- **`node -p` instead of `eval`**: Direct variable assignment without shell interpretation. No functional change.

## Changes Detail
- `release-app-bundles.yml`: Remove `build_web` input, always build web, downgrade `contents: write` → `read`, use immutable SHA for PR checkout
- `release-native-bundle.yml`: Pass `checkout_ref` to shared-env
- `release-desktop-bundle.yml`: Pass `checkout_ref` to shared-env, replace `eval` with safe `node -p`
- `release-web.yml`: Skip gh-pages deploy when called via `workflow_call`, replace `eval` with safe `node -p` (2 places)

## Risk Assessment
- **Risk Level**: Medium — CI workflow changes affect all release builds
- **Affected Platforms**: All (desktop, mobile, web bundles)
- **Risk Areas**: The `contents: read` downgrade is safe because gh-pages deploy is conditionally skipped, but should be verified by triggering a test run

## Test plan
- [ ] Trigger `release-app-bundles` with a PR number and verify the built bundle uses the correct PR commit (not `x` branch)
- [ ] Trigger `release-app-bundles` without a PR number and verify all 3 bundle jobs (native, desktop, web) complete
- [ ] Trigger `release-web` directly via `workflow_dispatch` and verify gh-pages deploy to `app.onekeytest.com` still works
- [ ] Verify Slack notifications contain correct branch/commit info
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10922" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
