### PR TITLE
fix(ci): override GITHUB_SHA in .env with resolved PR commit

### DIFF
--- a/.github/workflows/release-app-bundles.yml
+++ b/.github/workflows/release-app-bundles.yml
@@ -7,14 +7,9 @@ on:
         description: 'PR number to build (optional, builds from PR head ref)'
         required: false
         type: string
-      build_web:
-        description: 'Build Web bundle'
-        required: false
-        type: boolean
-        default: false
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: read
 
 jobs:
@@ -90,11 +85,11 @@ jobs:
         uses: actions/checkout@v4
         if: ${{ !inputs.pr_number }}
 
-      - name: Checkout PR head commit
+      - name: Checkout PR head commit (pinned to validated SHA)
         if: ${{ inputs.pr_number }}
         uses: actions/checkout@v4
         with:
-          ref: refs/pull/${{ inputs.pr_number }}/head
+          ref: ${{ needs.validate-pr.outputs.head_sha }}
 
       - name: Generate build parameters
         id: params
@@ -207,7 +202,7 @@ jobs:
 
   web-bundle:
     needs: prepare-params
-    if: ${{ inputs.build_web && !cancelled() && !failure() }}
+    if: ${{ !cancelled() && !failure() }}
     uses: ./.github/workflows/release-web.yml
     with:
       build_number: ${{ needs.prepare-params.outputs.build_number }}

--- a/.github/workflows/release-app-bundles.yml
+++ b/.github/workflows/release-app-bundles.yml
@@ -211,6 +211,8 @@ jobs:
       branch: ${{ needs.prepare-params.outputs.branch }}
       commit: ${{ needs.prepare-params.outputs.commit }}
       checkout_ref: ${{ needs.prepare-params.outputs.commit }}
+      skip_pages_deploy: true
+      test_endpoint: app-bundle.onekeytest.com
     secrets:
       COVALENT_KEY: ${{ secrets.COVALENT_KEY }}
       SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}

--- a/.github/workflows/release-desktop-bundle.yml
+++ b/.github/workflows/release-desktop-bundle.yml
@@ -96,6 +96,7 @@ jobs:
       - name: Run Shared Env Setup
         uses: ./.github/actions/shared-env
         with:
+          checkout_ref: ${{ inputs.checkout_ref || '' }}
           env_file_name: '.env'
           sentry_project: 'desktop'
           covalent_key: ${{ secrets.COVALENT_KEY }}
@@ -110,9 +111,9 @@ jobs:
 
       - name: 'Setup ENV'
         run: |
-          eval "$(node -e 'const v=require("./apps/desktop/package.json").version; console.log("pkg_version="+v)')"
-          echo '$pkg_version='$pkg_version
-          echo "PKG_VERSION=$pkg_version" >> $GITHUB_ENV
+          pkg_version=$(node -p "require('./apps/desktop/package.json').version")
+          echo "pkg_version=$pkg_version"
+          printf 'PKG_VERSION=%s\n' "$pkg_version" >> "$GITHUB_ENV"
           artifacts_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           echo "ARTIFACTS_URL=$artifacts_url" >> $GITHUB_ENV
           if [ -z "${{ env.BUILD_BUNDLE_VERSION }}" ]; then

--- a/.github/workflows/release-desktop-bundle.yml
+++ b/.github/workflows/release-desktop-bundle.yml
@@ -146,21 +146,27 @@ jobs:
             BRANCH="${{ github.ref_name }}"
             COMMIT="${{ github.sha }}"
           fi
+          # Validate commit SHA format to prevent env injection
+          if [[ ! "$COMMIT" =~ ^[0-9a-f]{7,40}$ ]]; then
+            echo "::error::Invalid commit SHA format: $COMMIT"
+            exit 1
+          fi
+          DELIMITER=$(uuidgen)
           {
-            echo "BRANCH<<GHEOF"
+            echo "BRANCH<<${DELIMITER}"
             echo "$BRANCH"
-            echo "GHEOF"
+            echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
           {
-            echo "COMMIT<<GHEOF"
+            echo "COMMIT<<${DELIMITER}"
             echo "$COMMIT"
-            echo "GHEOF"
+            echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
           COMMIT_MESSAGE=$(git log -1 --pretty=%s "$COMMIT" 2>/dev/null || echo "")
           {
-            echo "COMMIT_MESSAGE<<GHEOF"
+            echo "COMMIT_MESSAGE<<${DELIMITER}"
             echo "$COMMIT_MESSAGE"
-            echo "GHEOF"
+            echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
           # Override GITHUB_SHA in .env with resolved commit (shared-env writes github.sha which is wrong for workflow_call)
           sed -i "s/^GITHUB_SHA=.*/GITHUB_SHA=$COMMIT/" .env

--- a/.github/workflows/release-desktop-bundle.yml
+++ b/.github/workflows/release-desktop-bundle.yml
@@ -162,6 +162,8 @@ jobs:
             echo "$COMMIT_MESSAGE"
             echo "GHEOF"
           } >> "$GITHUB_ENV"
+          # Override GITHUB_SHA in .env with resolved commit (shared-env writes github.sha which is wrong for workflow_call)
+          sed -i "s/^GITHUB_SHA=.*/GITHUB_SHA=$COMMIT/" .env
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/release-desktop-bundle.yml
+++ b/.github/workflows/release-desktop-bundle.yml
@@ -168,10 +168,13 @@ jobs:
             echo "$COMMIT_MESSAGE"
             echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
-          # Override GITHUB_SHA with resolved commit (shared-env writes github.sha which is wrong for workflow_call)
-          # Must update both .env file AND $GITHUB_ENV because dotenv does not override existing env vars
+          # Override commit SHA for the build. GITHUB_SHA is a built-in GitHub Actions
+          # env var that cannot be reliably overridden via $GITHUB_ENV. Instead, set
+          # WORKFLOW_GITHUB_SHA which takes priority in platformEnv.githubSHA.
           sed -i "s/^GITHUB_SHA=.*/GITHUB_SHA=$COMMIT/" .env
           echo "GITHUB_SHA=$COMMIT" >> $GITHUB_ENV
+          echo "WORKFLOW_GITHUB_SHA=$COMMIT" >> $GITHUB_ENV
+          echo "WORKFLOW_GITHUB_SHA=$COMMIT" >> .env
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/release-desktop-bundle.yml
+++ b/.github/workflows/release-desktop-bundle.yml
@@ -168,8 +168,10 @@ jobs:
             echo "$COMMIT_MESSAGE"
             echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
-          # Override GITHUB_SHA in .env with resolved commit (shared-env writes github.sha which is wrong for workflow_call)
+          # Override GITHUB_SHA with resolved commit (shared-env writes github.sha which is wrong for workflow_call)
+          # Must update both .env file AND $GITHUB_ENV because dotenv does not override existing env vars
           sed -i "s/^GITHUB_SHA=.*/GITHUB_SHA=$COMMIT/" .env
+          echo "GITHUB_SHA=$COMMIT" >> $GITHUB_ENV
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/release-native-bundle.yml
+++ b/.github/workflows/release-native-bundle.yml
@@ -96,6 +96,7 @@ jobs:
       - name: Run Shared Env Setup
         uses: ./.github/actions/shared-env
         with:
+          checkout_ref: ${{ inputs.checkout_ref || '' }}
           env_file_name: '.env'
           sentry_project: 'react-native'
           covalent_key: ${{ secrets.COVALENT_KEY }}

--- a/.github/workflows/release-native-bundle.yml
+++ b/.github/workflows/release-native-bundle.yml
@@ -146,21 +146,27 @@ jobs:
             BRANCH="${{ github.ref_name }}"
             COMMIT="${{ github.sha }}"
           fi
+          # Validate commit SHA format to prevent env injection
+          if [[ ! "$COMMIT" =~ ^[0-9a-f]{7,40}$ ]]; then
+            echo "::error::Invalid commit SHA format: $COMMIT"
+            exit 1
+          fi
+          DELIMITER=$(uuidgen)
           {
-            echo "BRANCH<<GHEOF"
+            echo "BRANCH<<${DELIMITER}"
             echo "$BRANCH"
-            echo "GHEOF"
+            echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
           {
-            echo "COMMIT<<GHEOF"
+            echo "COMMIT<<${DELIMITER}"
             echo "$COMMIT"
-            echo "GHEOF"
+            echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
           COMMIT_MESSAGE=$(git log -1 --pretty=%s "$COMMIT" 2>/dev/null || echo "")
           {
-            echo "COMMIT_MESSAGE<<GHEOF"
+            echo "COMMIT_MESSAGE<<${DELIMITER}"
             echo "$COMMIT_MESSAGE"
-            echo "GHEOF"
+            echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
           # Override GITHUB_SHA in .env with resolved commit (shared-env writes github.sha which is wrong for workflow_call)
           sed -i "s/^GITHUB_SHA=.*/GITHUB_SHA=$COMMIT/" .env

--- a/.github/workflows/release-native-bundle.yml
+++ b/.github/workflows/release-native-bundle.yml
@@ -162,6 +162,8 @@ jobs:
             echo "$COMMIT_MESSAGE"
             echo "GHEOF"
           } >> "$GITHUB_ENV"
+          # Override GITHUB_SHA in .env with resolved commit (shared-env writes github.sha which is wrong for workflow_call)
+          sed -i "s/^GITHUB_SHA=.*/GITHUB_SHA=$COMMIT/" .env
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/release-native-bundle.yml
+++ b/.github/workflows/release-native-bundle.yml
@@ -168,10 +168,13 @@ jobs:
             echo "$COMMIT_MESSAGE"
             echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
-          # Override GITHUB_SHA with resolved commit (shared-env writes github.sha which is wrong for workflow_call)
-          # Must update both .env file AND $GITHUB_ENV because dotenv does not override existing env vars
+          # Override commit SHA for the build. GITHUB_SHA is a built-in GitHub Actions
+          # env var that cannot be reliably overridden via $GITHUB_ENV. Instead, set
+          # WORKFLOW_GITHUB_SHA which takes priority in platformEnv.githubSHA.
           sed -i "s/^GITHUB_SHA=.*/GITHUB_SHA=$COMMIT/" .env
           echo "GITHUB_SHA=$COMMIT" >> $GITHUB_ENV
+          echo "WORKFLOW_GITHUB_SHA=$COMMIT" >> $GITHUB_ENV
+          echo "WORKFLOW_GITHUB_SHA=$COMMIT" >> .env
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/release-native-bundle.yml
+++ b/.github/workflows/release-native-bundle.yml
@@ -168,8 +168,10 @@ jobs:
             echo "$COMMIT_MESSAGE"
             echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
-          # Override GITHUB_SHA in .env with resolved commit (shared-env writes github.sha which is wrong for workflow_call)
+          # Override GITHUB_SHA with resolved commit (shared-env writes github.sha which is wrong for workflow_call)
+          # Must update both .env file AND $GITHUB_ENV because dotenv does not override existing env vars
           sed -i "s/^GITHUB_SHA=.*/GITHUB_SHA=$COMMIT/" .env
+          echo "GITHUB_SHA=$COMMIT" >> $GITHUB_ENV
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -108,9 +108,9 @@ jobs:
 
       - name: Setup ENV
         run: |
-          eval "$(node -e 'const v=require("./apps/web/package.json").version; console.log("pkg_version="+v)')"
-          echo '$pkg_version='$pkg_version
-          echo "PKG_VERSION=$pkg_version" >> $GITHUB_ENV
+          pkg_version=$(node -p "require('./apps/web/package.json').version")
+          echo "pkg_version=$pkg_version"
+          printf 'PKG_VERSION=%s\n' "$pkg_version" >> "$GITHUB_ENV"
 
           # For test environment, use GitHub Pages URL
           echo "PUBLIC_URL=https://${{ env.TEST_ENDPOINT }}/" >> $GITHUB_ENV
@@ -191,6 +191,7 @@ jobs:
             ./apps/web/web-build/
 
       - name: Deploy Github Pages
+        if: ${{ github.event_name != 'workflow_call' }}
         uses: OneKeyHQ/actions/gh-pages@86ad045e18da7958f659995ee2f9df375dd03ef4 # pin to SHA
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -243,9 +244,9 @@ jobs:
 
       - name: Setup ENV
         run: |
-          eval "$(node -e 'const v=require("./apps/web/package.json").version; console.log("pkg_version="+v)')"
-          echo '$pkg_version='$pkg_version
-          echo "PKG_VERSION=$pkg_version" >> $GITHUB_ENV
+          pkg_version=$(node -p "require('./apps/web/package.json').version")
+          echo "pkg_version=$pkg_version"
+          printf 'PKG_VERSION=%s\n' "$pkg_version" >> "$GITHUB_ENV"
 
           # For production environment, use production URL
           echo "PUBLIC_URL=https://app-assets.onekey.so/${{ github.sha }}-${{ env.BUILD_NUMBER }}/" >> $GITHUB_ENV

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -170,8 +170,10 @@ jobs:
             echo "$COMMIT_MESSAGE"
             echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
-          # Override GITHUB_SHA in .env with resolved commit (shared-env writes github.sha which is wrong for workflow_call)
+          # Override GITHUB_SHA with resolved commit (shared-env writes github.sha which is wrong for workflow_call)
+          # Must update both .env file AND $GITHUB_ENV because dotenv does not override existing env vars
           sed -i "s/^GITHUB_SHA=.*/GITHUB_SHA=$COMMIT/" .env
+          echo "GITHUB_SHA=$COMMIT" >> $GITHUB_ENV
           # Override PUBLIC_URL with resolved commit for bundle releases (like production)
           if [ -n "${{ inputs.build_number }}" ]; then
             echo "PUBLIC_URL=https://${TEST_ENDPOINT}/${COMMIT}-${{ env.BUILD_NUMBER }}/" >> "$GITHUB_ENV"
@@ -310,8 +312,10 @@ jobs:
             echo "$COMMIT_MESSAGE"
             echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
-          # Override GITHUB_SHA in .env with resolved commit (shared-env writes github.sha which is wrong for workflow_call)
+          # Override GITHUB_SHA with resolved commit (shared-env writes github.sha which is wrong for workflow_call)
+          # Must update both .env file AND $GITHUB_ENV because dotenv does not override existing env vars
           sed -i "s/^GITHUB_SHA=.*/GITHUB_SHA=$COMMIT/" .env
+          echo "GITHUB_SHA=$COMMIT" >> $GITHUB_ENV
           # Override PUBLIC_URL with resolved commit (replaces github.sha set by Setup ENV)
           echo "PUBLIC_URL=https://app-assets.onekey.so/${COMMIT}-${{ env.BUILD_NUMBER }}/" >> $GITHUB_ENV
 

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -170,10 +170,13 @@ jobs:
             echo "$COMMIT_MESSAGE"
             echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
-          # Override GITHUB_SHA with resolved commit (shared-env writes github.sha which is wrong for workflow_call)
-          # Must update both .env file AND $GITHUB_ENV because dotenv does not override existing env vars
+          # Override commit SHA for the build. GITHUB_SHA is a built-in GitHub Actions
+          # env var that cannot be reliably overridden via $GITHUB_ENV. Instead, set
+          # WORKFLOW_GITHUB_SHA which takes priority in platformEnv.githubSHA.
           sed -i "s/^GITHUB_SHA=.*/GITHUB_SHA=$COMMIT/" .env
           echo "GITHUB_SHA=$COMMIT" >> $GITHUB_ENV
+          echo "WORKFLOW_GITHUB_SHA=$COMMIT" >> $GITHUB_ENV
+          echo "WORKFLOW_GITHUB_SHA=$COMMIT" >> .env
           # Override PUBLIC_URL with resolved commit for bundle releases (like production)
           if [ -n "${{ inputs.build_number }}" ]; then
             echo "PUBLIC_URL=https://${TEST_ENDPOINT}/${COMMIT}-${{ env.BUILD_NUMBER }}/" >> "$GITHUB_ENV"
@@ -312,10 +315,13 @@ jobs:
             echo "$COMMIT_MESSAGE"
             echo "${DELIMITER}"
           } >> "$GITHUB_ENV"
-          # Override GITHUB_SHA with resolved commit (shared-env writes github.sha which is wrong for workflow_call)
-          # Must update both .env file AND $GITHUB_ENV because dotenv does not override existing env vars
+          # Override commit SHA for the build. GITHUB_SHA is a built-in GitHub Actions
+          # env var that cannot be reliably overridden via $GITHUB_ENV. Instead, set
+          # WORKFLOW_GITHUB_SHA which takes priority in platformEnv.githubSHA.
           sed -i "s/^GITHUB_SHA=.*/GITHUB_SHA=$COMMIT/" .env
           echo "GITHUB_SHA=$COMMIT" >> $GITHUB_ENV
+          echo "WORKFLOW_GITHUB_SHA=$COMMIT" >> $GITHUB_ENV
+          echo "WORKFLOW_GITHUB_SHA=$COMMIT" >> .env
           # Override PUBLIC_URL with resolved commit (replaces github.sha set by Setup ENV)
           echo "PUBLIC_URL=https://app-assets.onekey.so/${COMMIT}-${{ env.BUILD_NUMBER }}/" >> $GITHUB_ENV
 

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -28,6 +28,14 @@ on:
       checkout_ref:
         type: string
         required: false
+      skip_pages_deploy:
+        type: boolean
+        required: false
+        default: false
+      test_endpoint:
+        type: string
+        required: false
+        default: ''
     secrets:
       COVALENT_KEY:
         required: false
@@ -60,7 +68,7 @@ jobs:
   test-web:
     runs-on: ubuntu-24.04
     env:
-      TEST_ENDPOINT: app.onekeytest.com
+      TEST_ENDPOINT: ${{ inputs.test_endpoint || 'app.onekeytest.com' }}
 
     if: ${{ !github.event.workflow_run || (github.event.workflow_run && github.event.workflow_run.conclusion == 'success') }}
     steps:
@@ -164,6 +172,10 @@ jobs:
           } >> "$GITHUB_ENV"
           # Override GITHUB_SHA in .env with resolved commit (shared-env writes github.sha which is wrong for workflow_call)
           sed -i "s/^GITHUB_SHA=.*/GITHUB_SHA=$COMMIT/" .env
+          # Override PUBLIC_URL with resolved commit for bundle releases (like production)
+          if [ -n "${{ inputs.build_number }}" ]; then
+            echo "PUBLIC_URL=https://${TEST_ENDPOINT}/${COMMIT}-${{ env.BUILD_NUMBER }}/" >> "$GITHUB_ENV"
+          fi
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -191,7 +203,7 @@ jobs:
             ./apps/web/web-build/
 
       - name: Deploy Github Pages
-        if: ${{ github.event_name != 'workflow_call' }}
+        if: ${{ !inputs.skip_pages_deploy }}
         uses: OneKeyHQ/actions/gh-pages@86ad045e18da7958f659995ee2f9df375dd03ef4 # pin to SHA
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Override `GITHUB_SHA` in `.env` with resolved PR commit in native-bundle and desktop-bundle workflows
- Fixes the app displaying the release branch HEAD commit instead of the actual PR commit in JS Bundle Manager

## Intent & Context
Follow-up to #10922. After fixing the checkout bug, the source code was correctly built from the PR commit, but the app still displayed the wrong Commit Hash. This is because `shared-env` writes `github.sha` (the caller workflow's SHA = release branch HEAD) into `.env`'s `GITHUB_SHA` field, which is what the app reads for display. The `COMMIT` env var was correct but was never written back to `.env`.

## Root Cause
`shared-env/action.yml` line 127 writes `github_sha=${{ github.sha }}` and line 194 writes it to `.env`. In a `workflow_call` context, `github.sha` is the caller's SHA (release branch HEAD), not the PR commit. `release-web.yml` already had a `sed` override for this, but `release-native-bundle.yml` and `release-desktop-bundle.yml` did not.

## Changes Detail
- `release-native-bundle.yml`: Add `sed -i "s/^GITHUB_SHA=.*/GITHUB_SHA=$COMMIT/" .env` after resolving commit
- `release-desktop-bundle.yml`: Same override added

## Risk Assessment
- **Risk Level**: Low — only affects the commit hash written to `.env`, no build logic change
- **Affected Platforms**: Mobile (native bundle), Desktop (desktop bundle)

## Test plan
- [ ] Trigger `release-app-bundles` with a PR number and verify the app's JS Bundle Manager shows the PR head commit, not the release branch HEAD
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
