### PR TITLE
fix(perps): navigate to detail page when tapping perps token in universal search

### DIFF
--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchPerpItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchPerpItem.tsx
@@ -1,18 +1,31 @@
 import { useCallback, useMemo } from 'react';
 
-import { NumberSizeableText, SizableText, XStack } from '@onekeyhq/components';
+import {
+  NumberSizeableText,
+  SizableText,
+  XStack,
+  rootNavigationRef,
+} from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { useMarketWatchListV2Atom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2/atoms';
 import { useUniversalSearchActions } from '@onekeyhq/kit/src/states/jotai/contexts/universalSearch';
 import {
   EPerpPageEnterSource,
   setPerpPageEnterSource,
 } from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
-import { ETabRoutes } from '@onekeyhq/shared/src/routes';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import { ERootRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
+import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
 import { XYZ_DEX_PREFIX } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import type { IUniversalSearchPerp } from '@onekeyhq/shared/types/search';
+
+import { MarketPerpsStarV2 } from '../../../Market/components/MarketStarV2';
+
+const shouldShowFavoriteButton =
+  !platformEnv.isExtensionUiPopup && !platformEnv.isExtensionUiSidePanel;
 
 interface IUniversalSearchPerpItemProps {
   item: IUniversalSearchPerp;
@@ -21,6 +34,7 @@ interface IUniversalSearchPerpItemProps {
 export function UniversalSearchPerpItem({
   item,
 }: IUniversalSearchPerpItemProps) {
+  const [{ isMounted }] = useMarketWatchListV2Atom();
   const navigation = useAppNavigation();
   const universalSearchActions = useUniversalSearchActions();
   const { assetType, logoUrl, name, maxLeverage, midPx, subtitle } =
@@ -44,6 +58,18 @@ export function UniversalSearchPerpItem({
         });
       } catch (error) {
         console.error('Failed to change active asset:', error);
+        return;
+      }
+      if (platformEnv.isNative) {
+        // rootNavigationRef needed because search modal's navigation context can't push into Perp tab's stack
+        setTimeout(() => {
+          rootNavigationRef.current?.navigate(ERootRoutes.Main, {
+            screen: ETabRoutes.Perp,
+            params: {
+              screen: EModalPerpRoutes.MobilePerpMarket,
+            },
+          });
+        }, 500);
       }
       setTimeout(() => {
         universalSearchActions.current.addIntoRecentSearchList({
@@ -62,12 +88,17 @@ export function UniversalSearchPerpItem({
       jc="space-between"
       onPress={handlePress}
       renderAvatar={
-        <Token
-          size="lg"
-          borderRadius="$full"
-          tokenImageUri={logoUrl}
-          fallbackIcon="CryptoCoinOutline"
-        />
+        <XStack alignItems="center" gap="$2">
+          {shouldShowFavoriteButton && isMounted ? (
+            <MarketPerpsStarV2 perpsCoin={coin} size="small" />
+          ) : null}
+          <Token
+            size="lg"
+            borderRadius="$full"
+            tokenImageUri={logoUrl}
+            fallbackIcon="CryptoCoinOutline"
+          />
+        </XStack>
       }
     >
       <ListItem.Text


### PR DESCRIPTION
## Summary
- On mobile, tapping a perps token in universal search now navigates directly to the MobilePerpMarket detail page (charts + orderbook + trading) instead of just switching to the Perp tab main page
- Desktop/web behavior unchanged — stays on Perp tab main page as before
- Added error handling: if `changeActiveAsset` fails, navigation and search history recording are skipped
- Added favorite star button (MarketPerpsStarV2) to perps search result items

## Test plan
- [ ] iOS/Android: universal search → tap perps token → verify enters MobilePerpMarket detail page → back returns to Perp tab
- [ ] Desktop/Web: universal search → tap perps token → verify stays on Perp tab main page (no detail page)
- [ ] Extension popup/side panel: verify no favorite star shown, navigation works
- [ ] Simulate `changeActiveAsset` failure → verify no navigation or search history recorded
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
