### PR TITLE
feat: align market confirm preview with swap(OK-52157)

### DIFF
--- a/packages/kit-bg/src/states/jotai/atoms/jotaiContextStoreMap.test.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/jotaiContextStoreMap.test.ts
@@ -1,0 +1,32 @@
+import { jotaiContextStore } from '@onekeyhq/kit/src/states/jotai/utils/jotaiContextStore';
+
+import { EJotaiContextStoreNames } from './jotaiContextStoreMap';
+
+describe('jotaiContextStoreMap', () => {
+  it('includes the market swap review store name', () => {
+    expect(EJotaiContextStoreNames.marketSwapReview).toBe('marketSwapReview');
+  });
+
+  it('creates an isolated store for market swap review', () => {
+    const marketStore = jotaiContextStore.getOrCreateStore({
+      storeName: EJotaiContextStoreNames.marketSwapReview,
+    });
+    const swapStore = jotaiContextStore.getOrCreateStore({
+      storeName: EJotaiContextStoreNames.swap,
+    });
+
+    expect(marketStore).not.toBe(swapStore);
+    expect(
+      jotaiContextStore.getOrCreateStore({
+        storeName: EJotaiContextStoreNames.marketSwapReview,
+      }),
+    ).toBe(marketStore);
+
+    jotaiContextStore.removeStore({
+      storeName: EJotaiContextStoreNames.marketSwapReview,
+    });
+    jotaiContextStore.removeStore({
+      storeName: EJotaiContextStoreNames.swap,
+    });
+  });
+});

--- a/packages/kit-bg/src/states/jotai/atoms/jotaiContextStoreMap.test.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/jotaiContextStoreMap.test.ts
@@ -1,32 +1,7 @@
-import { jotaiContextStore } from '@onekeyhq/kit/src/states/jotai/utils/jotaiContextStore';
-
 import { EJotaiContextStoreNames } from './jotaiContextStoreMap';
 
 describe('jotaiContextStoreMap', () => {
   it('includes the market swap review store name', () => {
     expect(EJotaiContextStoreNames.marketSwapReview).toBe('marketSwapReview');
-  });
-
-  it('creates an isolated store for market swap review', () => {
-    const marketStore = jotaiContextStore.getOrCreateStore({
-      storeName: EJotaiContextStoreNames.marketSwapReview,
-    });
-    const swapStore = jotaiContextStore.getOrCreateStore({
-      storeName: EJotaiContextStoreNames.swap,
-    });
-
-    expect(marketStore).not.toBe(swapStore);
-    expect(
-      jotaiContextStore.getOrCreateStore({
-        storeName: EJotaiContextStoreNames.marketSwapReview,
-      }),
-    ).toBe(marketStore);
-
-    jotaiContextStore.removeStore({
-      storeName: EJotaiContextStoreNames.marketSwapReview,
-    });
-    jotaiContextStore.removeStore({
-      storeName: EJotaiContextStoreNames.swap,
-    });
   });
 });

--- a/packages/kit-bg/src/states/jotai/atoms/jotaiContextStoreMap.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/jotaiContextStoreMap.ts
@@ -13,6 +13,7 @@ export enum EJotaiContextStoreNames {
   discoveryBrowser = 'discoveryBrowser',
   swap = 'swap',
   swapModal = 'swapModal',
+  marketSwapReview = 'marketSwapReview',
   marketWatchList = 'marketWatchList',
   marketWatchListV2 = 'marketWatchListV2',
   universalSearch = 'universalSearch',

--- a/packages/kit/src/states/jotai/utils/JotaiContextStoreMirrorTracker.tsx
+++ b/packages/kit/src/states/jotai/utils/JotaiContextStoreMirrorTracker.tsx
@@ -157,6 +157,10 @@ function JotaiContextRootProvidersAutoMountCmp() {
           case EJotaiContextStoreNames.swapModal: {
             return <SwapModalRootProvider key={key} />;
           }
+          case EJotaiContextStoreNames.marketSwapReview: {
+            // Market review owns its local store lifecycle inside the dialog.
+            return null;
+          }
           case EJotaiContextStoreNames.earn: {
             return <EarnProvider key={key} />;
           }

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewDialog.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewDialog.test.tsx
@@ -1,0 +1,232 @@
+/** @jest-environment jsdom */
+
+import type { ReactNode } from 'react';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import type {
+  IFetchQuoteResult,
+  ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
+import { EProtocolOfExchange } from '@onekeyhq/shared/types/swap/types';
+
+import { MarketSwapReviewDialog } from './MarketSwapReviewDialog';
+
+const useMarketSwapReviewActionsMock = jest.fn();
+const removeStoreMock = jest.fn();
+
+jest.mock('@onekeyhq/kit/src/states/jotai/utils/jotaiContextStore', () => ({
+  jotaiContextStore: {
+    removeStore: (...args: unknown[]) => {
+      removeStoreMock(...args);
+    },
+  },
+}));
+
+jest.mock('@onekeyhq/kit/src/components/AccountSelector', () => ({
+  AccountSelectorProviderMirror: ({
+    children,
+    enabledNum,
+  }: {
+    children?: ReactNode;
+    enabledNum: number[];
+  }) => (
+    <div data-enabled-num={enabledNum.join(',')} data-testid="account-selector">
+      {children}
+    </div>
+  ),
+}));
+
+jest.mock('@onekeyhq/kit/src/views/Swap/pages/SwapProviderMirror', () => ({
+  SwapProviderMirror: ({
+    children,
+    storeName,
+  }: {
+    children?: ReactNode;
+    storeName: string;
+  }) => (
+    <div data-store-name={storeName} data-testid="swap-provider">
+      {children}
+    </div>
+  ),
+}));
+
+jest.mock(
+  '@onekeyhq/kit/src/views/Swap/pages/components/PreSwapDialogContent',
+  () => ({
+    __esModule: true,
+    default: ({
+      disableGlobalApproveSync,
+      onConfirm,
+      onDone,
+    }: {
+      disableGlobalApproveSync?: boolean;
+      onConfirm: () => void;
+      onDone: () => void;
+    }) => (
+      <div
+        data-disable-global-approve-sync={
+          disableGlobalApproveSync ? 'true' : 'false'
+        }
+        data-testid="pre-swap-dialog-content"
+      >
+        <button data-testid="review-confirm" onClick={onConfirm} type="button">
+          confirm
+        </button>
+        <button data-testid="review-done" onClick={onDone} type="button">
+          done
+        </button>
+      </div>
+    ),
+  }),
+);
+
+jest.mock('./hooks/useMarketSwapReviewActions', () => ({
+  useMarketSwapReviewActions: (props: unknown) =>
+    useMarketSwapReviewActionsMock(props) as {
+      onConfirm: () => void;
+      preSwapBeforeStepActions: () => void;
+      preSwapStepsStart: () => void;
+    },
+}));
+
+jest.mock('./MarketSwapReviewInitializer', () => ({
+  MarketSwapReviewInitializer: ({
+    children,
+    reviewState,
+  }: {
+    children?: ReactNode;
+    reviewState: { steps: unknown[] };
+  }) => (
+    <div data-step-count={reviewState.steps.length} data-testid="initializer">
+      {children}
+    </div>
+  ),
+}));
+
+const fromToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xfrom',
+  symbol: 'ETH',
+  decimals: 18,
+  isNative: true,
+};
+
+const toToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xto',
+  symbol: 'USDC',
+  decimals: 6,
+  isNative: false,
+};
+
+function createQuoteResult(
+  overrides: Partial<IFetchQuoteResult> = {},
+): IFetchQuoteResult {
+  return {
+    protocol: EProtocolOfExchange.SWAP,
+    info: {
+      provider: 'onekey',
+      providerName: 'OneKey',
+    },
+    fromTokenInfo: fromToken,
+    toTokenInfo: toToken,
+    ...overrides,
+  };
+}
+
+describe('MarketSwapReviewDialog', () => {
+  beforeEach(() => {
+    removeStoreMock.mockClear();
+    useMarketSwapReviewActionsMock.mockReturnValue({
+      onConfirm: jest.fn(),
+      preSwapBeforeStepActions: jest.fn(),
+      preSwapStepsStart: jest.fn(),
+    });
+  });
+
+  it('uses the isolated market swap review store and binds the market review adapter', () => {
+    const onDone = jest.fn();
+    const adapter = {
+      prepareMarketSwapReview: jest.fn(),
+      sendMarketApproveTx: jest.fn(),
+      sendMarketSwapTx: jest.fn(),
+      sendMarketWrappedTx: jest.fn(),
+      sendMarketSignMessage: jest.fn(),
+      buildMarketApproveInfos: jest.fn(),
+    };
+
+    render(
+      <MarketSwapReviewDialog
+        onDone={onDone}
+        adapter={adapter}
+        reviewState={{
+          steps: [],
+          preSwapData: {
+            fromToken,
+            toToken,
+            fromTokenAmount: '1',
+            toTokenAmount: '2500',
+          },
+          quoteResult: createQuoteResult(),
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByTestId('account-selector').getAttribute('data-enabled-num'),
+    ).toBe('0');
+    expect(
+      screen.getByTestId('swap-provider').getAttribute('data-store-name'),
+    ).toBe(EJotaiContextStoreNames.marketSwapReview);
+    expect(
+      screen.getByTestId('initializer').getAttribute('data-step-count'),
+    ).toBe('0');
+    expect(
+      screen
+        .getByTestId('pre-swap-dialog-content')
+        .getAttribute('data-disable-global-approve-sync'),
+    ).toBe('true');
+    expect(useMarketSwapReviewActionsMock).toHaveBeenCalledWith({
+      adapter,
+    });
+
+    fireEvent.click(screen.getByTestId('review-confirm'));
+    fireEvent.click(screen.getByTestId('review-done'));
+
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up the isolated review store on unmount', () => {
+    const { unmount } = render(
+      <MarketSwapReviewDialog
+        onDone={jest.fn()}
+        adapter={{
+          prepareMarketSwapReview: jest.fn(),
+          sendMarketApproveTx: jest.fn(),
+          sendMarketSwapTx: jest.fn(),
+          sendMarketWrappedTx: jest.fn(),
+          sendMarketSignMessage: jest.fn(),
+          buildMarketApproveInfos: jest.fn(),
+        }}
+        reviewState={{
+          steps: [],
+          preSwapData: {
+            fromToken,
+            toToken,
+            fromTokenAmount: '1',
+            toTokenAmount: '2500',
+          },
+          quoteResult: createQuoteResult(),
+        }}
+      />,
+    );
+
+    unmount();
+
+    expect(removeStoreMock).toHaveBeenCalledWith({
+      storeName: EJotaiContextStoreNames.marketSwapReview,
+    });
+  });
+});

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewDialog.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewDialog.tsx
@@ -1,0 +1,73 @@
+import { useEffect } from 'react';
+
+import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
+import { jotaiContextStore } from '@onekeyhq/kit/src/states/jotai/utils/jotaiContextStore';
+import PreSwapDialogContent from '@onekeyhq/kit/src/views/Swap/pages/components/PreSwapDialogContent';
+import { SwapProviderMirror } from '@onekeyhq/kit/src/views/Swap/pages/SwapProviderMirror';
+import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
+
+import { useMarketSwapReviewActions } from './hooks/useMarketSwapReviewActions';
+import { MarketSwapReviewInitializer } from './MarketSwapReviewInitializer';
+
+import type { IMarketSwapReviewAdapter } from './hooks/useSpeedSwapActions';
+import type { IMarketSwapReviewState } from './MarketSwapReviewInitializer';
+
+function MarketSwapReviewDialogContent({
+  adapter,
+  onDone,
+}: {
+  adapter: IMarketSwapReviewAdapter;
+  onDone: () => void;
+}) {
+  const { onConfirm, preSwapBeforeStepActions, preSwapStepsStart } =
+    useMarketSwapReviewActions({
+      adapter,
+    });
+
+  return (
+    <PreSwapDialogContent
+      disableGlobalApproveSync
+      onConfirm={onConfirm}
+      onDone={onDone}
+      preSwapBeforeStepActions={preSwapBeforeStepActions}
+      preSwapStepsStart={preSwapStepsStart}
+    />
+  );
+}
+
+type IMarketSwapReviewDialogProps = {
+  onDone: () => void;
+  adapter: IMarketSwapReviewAdapter;
+  reviewState: IMarketSwapReviewState;
+};
+
+export function MarketSwapReviewDialog({
+  onDone,
+  adapter,
+  reviewState,
+}: IMarketSwapReviewDialogProps) {
+  useEffect(() => {
+    return () => {
+      jotaiContextStore.removeStore({
+        storeName: EJotaiContextStoreNames.marketSwapReview,
+      });
+    };
+  }, []);
+
+  return (
+    <AccountSelectorProviderMirror
+      config={{
+        sceneName: EAccountSelectorSceneName.swap,
+        sceneUrl: '',
+      }}
+      enabledNum={[0]}
+    >
+      <SwapProviderMirror storeName={EJotaiContextStoreNames.marketSwapReview}>
+        <MarketSwapReviewInitializer reviewState={reviewState}>
+          <MarketSwapReviewDialogContent adapter={adapter} onDone={onDone} />
+        </MarketSwapReviewInitializer>
+      </SwapProviderMirror>
+    </AccountSelectorProviderMirror>
+  );
+}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewInitializer.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewInitializer.test.tsx
@@ -1,0 +1,224 @@
+/** @jest-environment jsdom */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { createStore } from 'jotai';
+
+import {
+  ProviderJotaiContextSwap,
+  useSwapBuildTxFetchingAtom,
+  useSwapFromTokenAmountAtom,
+  useSwapQuoteListAtom,
+  useSwapSelectFromTokenAtom,
+  useSwapSelectToTokenAtom,
+  useSwapStepsAtom,
+  useSwapToTokenAmountAtom,
+  useSwapTypeSwitchAtom,
+} from '@onekeyhq/kit/src/states/jotai/contexts/swap/atoms';
+import { buildSwapReviewState } from '@onekeyhq/kit/src/views/Swap/utils/buildSwapReviewState';
+import type {
+  IFetchQuoteResult,
+  ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
+import {
+  EProtocolOfExchange,
+  ESwapTabSwitchType,
+} from '@onekeyhq/shared/types/swap/types';
+
+import { MarketSwapReviewInitializer } from './MarketSwapReviewInitializer';
+
+const fromToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xfrom',
+  symbol: 'ETH',
+  decimals: 18,
+  isNative: true,
+};
+
+const toToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xto',
+  symbol: 'USDC',
+  decimals: 6,
+  isNative: false,
+};
+
+const texts = {
+  wrap: 'Wrap',
+  approveAndSwap: 'Approve and Swap',
+  approveAndSign: 'Approve and Sign',
+  revokeApprove: 'Revoke Approve',
+  approveToken: 'Approve ETH',
+  approveTokenWithTarget: 'Approve ETH for OneKey',
+  signAndSubmit: 'Sign and Submit',
+  sign: 'Sign',
+  confirmSwap: 'Confirm Swap',
+  swap: 'Swap',
+};
+
+function createQuoteResult(
+  overrides: Partial<IFetchQuoteResult> = {},
+): IFetchQuoteResult {
+  return {
+    protocol: EProtocolOfExchange.SWAP,
+    info: {
+      provider: 'onekey',
+      providerName: 'OneKey',
+    },
+    fromTokenInfo: fromToken,
+    toTokenInfo: toToken,
+    ...overrides,
+  };
+}
+
+function StateProbe({ testId }: { testId: string }) {
+  const [swapType] = useSwapTypeSwitchAtom();
+  const [selectedFromToken] = useSwapSelectFromTokenAtom();
+  const [selectedToToken] = useSwapSelectToTokenAtom();
+  const [fromAmount] = useSwapFromTokenAmountAtom();
+  const [toAmount] = useSwapToTokenAmountAtom();
+  const [quoteList] = useSwapQuoteListAtom();
+  const [swapSteps] = useSwapStepsAtom();
+  const [buildTxFetching] = useSwapBuildTxFetchingAtom();
+
+  return (
+    <pre data-testid={testId}>
+      {JSON.stringify({
+        swapType,
+        fromToken: selectedFromToken?.symbol,
+        toToken: selectedToToken?.symbol,
+        fromAmount: fromAmount.value,
+        toAmount: toAmount.value,
+        quoteCount: quoteList.length,
+        steps: swapSteps.steps.map((step) => step.type),
+        buildTxFetching,
+      })}
+    </pre>
+  );
+}
+
+function getProbeState(testId: string) {
+  return JSON.parse(screen.getByTestId(testId).textContent ?? '{}') as {
+    swapType?: string;
+    fromToken?: string;
+    toToken?: string;
+    fromAmount?: string;
+    toAmount?: string;
+    quoteCount?: number;
+    steps?: string[];
+    buildTxFetching?: boolean;
+  };
+}
+
+describe('MarketSwapReviewInitializer', () => {
+  it('writes review state into the market review store without polluting another swap store', async () => {
+    const reviewState = buildSwapReviewState({
+      accountId: 'hd-1--m/44/60/0/0/0',
+      networkId: fromToken.networkId,
+      batchApproveAndSwapEnabled: true,
+      fromToken,
+      toToken,
+      fromTokenAmount: '1',
+      toTokenAmount: '2500',
+      quoteResult: createQuoteResult(),
+      swapType: ESwapTabSwitchType.SWAP,
+      shouldFallback: false,
+      supportPreBuild: true,
+      slippage: 1,
+      texts,
+    });
+    const marketStore = createStore();
+    const swapStore = createStore();
+
+    render(
+      <>
+        <ProviderJotaiContextSwap store={marketStore}>
+          <MarketSwapReviewInitializer reviewState={reviewState}>
+            <StateProbe testId="market-store" />
+          </MarketSwapReviewInitializer>
+        </ProviderJotaiContextSwap>
+        <ProviderJotaiContextSwap store={swapStore}>
+          <StateProbe testId="swap-store" />
+        </ProviderJotaiContextSwap>
+      </>,
+    );
+
+    await waitFor(() => {
+      expect(getProbeState('market-store')).toMatchObject({
+        swapType: ESwapTabSwitchType.SWAP,
+        fromToken: 'ETH',
+        toToken: 'USDC',
+        fromAmount: '1',
+        toAmount: '2500',
+        quoteCount: 1,
+        steps: ['send_tx'],
+        buildTxFetching: false,
+      });
+    });
+
+    const swapStoreState = getProbeState('swap-store');
+
+    expect(swapStoreState).toMatchObject({
+      swapType: ESwapTabSwitchType.SWAP,
+      fromAmount: '',
+      toAmount: '',
+      quoteCount: 0,
+      steps: [],
+      buildTxFetching: false,
+    });
+    expect(swapStoreState.fromToken).toBeUndefined();
+    expect(swapStoreState.toToken).toBeUndefined();
+  });
+
+  it('cleans review state on unmount', async () => {
+    const reviewState = buildSwapReviewState({
+      accountId: 'hd-1--m/44/60/0/0/0',
+      networkId: fromToken.networkId,
+      batchApproveAndSwapEnabled: true,
+      fromToken,
+      toToken,
+      fromTokenAmount: '1',
+      toTokenAmount: '2500',
+      quoteResult: createQuoteResult(),
+      swapType: ESwapTabSwitchType.SWAP,
+      shouldFallback: false,
+      supportPreBuild: true,
+      slippage: 1,
+      texts,
+    });
+    const marketStore = createStore();
+    const view = render(
+      <ProviderJotaiContextSwap store={marketStore}>
+        <MarketSwapReviewInitializer reviewState={reviewState}>
+          <StateProbe testId="market-store" />
+        </MarketSwapReviewInitializer>
+      </ProviderJotaiContextSwap>,
+    );
+
+    await waitFor(() => {
+      expect(getProbeState('market-store')).toMatchObject({
+        fromToken: 'ETH',
+        quoteCount: 1,
+      });
+    });
+
+    view.unmount();
+
+    render(
+      <ProviderJotaiContextSwap store={marketStore}>
+        <StateProbe testId="market-store-reset" />
+      </ProviderJotaiContextSwap>,
+    );
+
+    const resetState = getProbeState('market-store-reset');
+
+    expect(resetState).toMatchObject({
+      fromAmount: '',
+      toAmount: '',
+      quoteCount: 0,
+      steps: [],
+      buildTxFetching: false,
+    });
+    expect(resetState.fromToken).toBeUndefined();
+    expect(resetState.toToken).toBeUndefined();
+  });
+});

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewInitializer.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewInitializer.tsx
@@ -1,0 +1,118 @@
+import { type ReactNode, useEffect } from 'react';
+
+import {
+  useSwapBuildTxFetchingAtom,
+  useSwapFromTokenAmountAtom,
+  useSwapManualSelectQuoteProvidersAtom,
+  useSwapQuoteListAtom,
+  useSwapSelectFromTokenAtom,
+  useSwapSelectToTokenAtom,
+  useSwapStepNetFeeLevelAtom,
+  useSwapStepsAtom,
+  useSwapToTokenAmountAtom,
+  useSwapTypeSwitchAtom,
+} from '@onekeyhq/kit/src/states/jotai/contexts/swap/atoms';
+import type {
+  IFetchQuoteResult,
+  ISwapPreSwapData,
+  ISwapStep,
+} from '@onekeyhq/shared/types/swap/types';
+import {
+  ESwapNetworkFeeLevel,
+  ESwapTabSwitchType,
+} from '@onekeyhq/shared/types/swap/types';
+
+export type IMarketSwapReviewState = {
+  steps: ISwapStep[];
+  preSwapData: ISwapPreSwapData;
+  quoteResult?: IFetchQuoteResult;
+};
+
+type IMarketSwapReviewInitializerProps = {
+  children?: ReactNode;
+  reviewState: IMarketSwapReviewState;
+};
+
+export function MarketSwapReviewInitializer({
+  children,
+  reviewState,
+}: IMarketSwapReviewInitializerProps) {
+  const [, setSwapTypeSwitch] = useSwapTypeSwitchAtom();
+  const [, setSwapSelectFromToken] = useSwapSelectFromTokenAtom();
+  const [, setSwapSelectToToken] = useSwapSelectToTokenAtom();
+  const [, setSwapFromTokenAmount] = useSwapFromTokenAmountAtom();
+  const [, setSwapToTokenAmount] = useSwapToTokenAmountAtom();
+  const [, setSwapQuoteList] = useSwapQuoteListAtom();
+  const [, setSwapManualSelectQuoteProviders] =
+    useSwapManualSelectQuoteProvidersAtom();
+  const [, setSwapSteps] = useSwapStepsAtom();
+  const [, setSwapBuildTxFetching] = useSwapBuildTxFetchingAtom();
+  const [, setSwapStepNetFeeLevel] = useSwapStepNetFeeLevelAtom();
+
+  useEffect(() => {
+    setSwapTypeSwitch(
+      reviewState.preSwapData.swapType ?? ESwapTabSwitchType.SWAP,
+    );
+    setSwapSelectFromToken(reviewState.preSwapData.fromToken);
+    setSwapSelectToToken(reviewState.preSwapData.toToken);
+    setSwapFromTokenAmount({
+      value: reviewState.preSwapData.fromTokenAmount ?? '',
+      isInput: false,
+    });
+    setSwapToTokenAmount({
+      value: reviewState.preSwapData.toTokenAmount ?? '',
+      isInput: false,
+    });
+    setSwapQuoteList(reviewState.quoteResult ? [reviewState.quoteResult] : []);
+    setSwapManualSelectQuoteProviders(undefined);
+    setSwapSteps({
+      steps: reviewState.steps,
+      preSwapData: reviewState.preSwapData,
+      quoteResult: reviewState.quoteResult,
+    });
+    setSwapBuildTxFetching(false);
+    setSwapStepNetFeeLevel({
+      networkFeeLevel: ESwapNetworkFeeLevel.MEDIUM,
+    });
+
+    return () => {
+      setSwapTypeSwitch(ESwapTabSwitchType.SWAP);
+      setSwapSelectFromToken(undefined);
+      setSwapSelectToToken(undefined);
+      setSwapFromTokenAmount({
+        value: '',
+        isInput: false,
+      });
+      setSwapToTokenAmount({
+        value: '',
+        isInput: false,
+      });
+      setSwapQuoteList([]);
+      setSwapManualSelectQuoteProviders(undefined);
+      setSwapSteps({
+        steps: [],
+        preSwapData: {},
+      });
+      setSwapBuildTxFetching(false);
+      setSwapStepNetFeeLevel({
+        networkFeeLevel: ESwapNetworkFeeLevel.MEDIUM,
+      });
+    };
+  }, [
+    reviewState.preSwapData,
+    reviewState.quoteResult,
+    reviewState.steps,
+    setSwapBuildTxFetching,
+    setSwapFromTokenAmount,
+    setSwapManualSelectQuoteProviders,
+    setSwapQuoteList,
+    setSwapSelectFromToken,
+    setSwapSelectToToken,
+    setSwapStepNetFeeLevel,
+    setSwapSteps,
+    setSwapToTokenAmount,
+    setSwapTypeSwitch,
+  ]);
+
+  return children;
+}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.test.tsx
@@ -174,11 +174,9 @@ describe('SwapPanelContent', () => {
 
     render(<SwapPanelContent {...props} />);
 
-    const actionButton = screen.getByTestId(
-      'action-button',
-    ) as HTMLButtonElement;
+    const actionButton = screen.getByTestId('action-button');
 
-    expect(actionButton.disabled).toBe(true);
+    expect((actionButton as HTMLButtonElement).disabled).toBe(true);
     expect(actionButtonMock).toHaveBeenCalledWith(
       expect.objectContaining({
         disabled: true,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.test.tsx
@@ -1,0 +1,188 @@
+/** @jest-environment jsdom */
+
+import type { ReactNode } from 'react';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import BigNumber from 'bignumber.js';
+
+import { ESwapDirection } from './hooks/useTradeType';
+import {
+  type ISwapPanelContentProps,
+  SwapPanelContent,
+} from './SwapPanelContent';
+
+const actionButtonMock = jest.fn();
+
+jest.mock('@onekeyhq/components', () => ({
+  SizableText: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  YStack: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Toast: {
+    message: jest.fn(),
+  },
+}));
+
+jest.mock('react-intl', () => ({
+  useIntl: () => ({
+    formatMessage: ({ id }: { id: string }) => id,
+  }),
+}));
+
+jest.mock('./hooks/useSwapAnalytics', () => ({
+  useSwapAnalytics: () => ({
+    setAmountEnterType: jest.fn(),
+    logSwapAction: jest.fn(),
+  }),
+}));
+
+jest.mock('./components/TradeTypeSelector', () => ({
+  TradeTypeSelector: () => <div data-testid="trade-type" />,
+}));
+
+jest.mock('./components/SwapPanelTop', () => ({
+  __esModule: true,
+  default: () => <div data-testid="panel-top" />,
+}));
+
+jest.mock('./components/TokenInputSection', () => ({
+  TokenInputSection: () => <div data-testid="token-input" />,
+}));
+
+jest.mock('./components/RateDisplay', () => ({
+  RateDisplay: () => <div data-testid="rate-display" />,
+}));
+
+jest.mock('./components/SellForSelector', () => ({
+  __esModule: true,
+  default: () => <div data-testid="sell-selector" />,
+}));
+
+jest.mock('./components/SlippageSetting', () => ({
+  SlippageSetting: () => <div data-testid="slippage" />,
+}));
+
+jest.mock('./components/ActionButton', () => ({
+  ActionButton: (props: { onPress: () => void; disabled?: boolean }) => {
+    actionButtonMock(props);
+    return (
+      <button
+        data-testid="action-button"
+        disabled={props.disabled}
+        onClick={props.onPress}
+        type="button"
+      >
+        action
+      </button>
+    );
+  },
+}));
+
+function createProps(): ISwapPanelContentProps {
+  return {
+    activeAccount: {
+      account: {
+        id: 'account-1',
+      } as never,
+    } as never,
+    enableAddressTypeSelector: false,
+    swapPanel: {
+      paymentAmount: new BigNumber(1),
+      paymentToken: {
+        networkId: 'evm--1',
+        contractAddress: '0xpay',
+        symbol: 'USDC',
+        decimals: 6,
+        speedSwapDefaultAmount: [],
+      },
+      sellAmount: new BigNumber(1),
+      setSellAmount: jest.fn(),
+      setPaymentAmount: jest.fn(),
+      setPaymentToken: jest.fn(),
+      tradeType: ESwapDirection.BUY,
+      setTradeType: jest.fn(),
+      setSlippage: jest.fn(),
+      slippage: 1,
+      setNetworkId: jest.fn(),
+      networkId: 'evm--1',
+    },
+    isLoading: false,
+    balanceLoading: false,
+    slippageAutoValue: 1,
+    supportSpeedSwap: {
+      enabled: true,
+      onlySupportCrossChain: false,
+    },
+    defaultTokens: [],
+    balance: new BigNumber(10),
+    balanceToken: {
+      networkId: 'evm--1',
+      contractAddress: '0xpay',
+      symbol: 'USDC',
+      decimals: 6,
+      isNative: false,
+      price: '1',
+      speedSwapDefaultAmount: [],
+    },
+    onSwap: jest.fn(),
+    onWrappedSwap: jest.fn(),
+    swapMevNetConfig: [],
+    swapNativeTokenReserveGas: [],
+    isWrapped: false,
+    priceRate: undefined,
+    hasInitialReady: true,
+    currentMarketToken: {
+      networkId: 'evm--1',
+      contractAddress: '0xmarket',
+      symbol: 'BTC',
+      decimals: 8,
+      isNative: false,
+    },
+    speedCheckError: '',
+  };
+}
+
+describe('SwapPanelContent', () => {
+  beforeEach(() => {
+    actionButtonMock.mockReset();
+  });
+
+  it('routes the main action button to the review swap handler', () => {
+    const props = createProps();
+
+    render(<SwapPanelContent {...props} />);
+
+    fireEvent.click(screen.getByTestId('action-button'));
+
+    expect(props.onSwap).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes wrapped pairs through the wrapped review handler', () => {
+    const props = createProps();
+    props.isWrapped = true;
+
+    render(<SwapPanelContent {...props} />);
+
+    fireEvent.click(screen.getByTestId('action-button'));
+
+    expect(props.onWrappedSwap).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the preview entry while loading', () => {
+    const props = createProps();
+    props.isLoading = true;
+
+    render(<SwapPanelContent {...props} />);
+
+    const actionButton = screen.getByTestId(
+      'action-button',
+    ) as HTMLButtonElement;
+
+    expect(actionButton.disabled).toBe(true);
+    expect(actionButtonMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        disabled: true,
+      }),
+    );
+  });
+});

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.tsx
@@ -18,7 +18,6 @@ import type {
 import { ESwapSlippageSegmentKey } from '@onekeyhq/shared/types/swap/types';
 
 import { ActionButton } from './components/ActionButton';
-import { ApproveButton } from './components/ApproveButton';
 import { RateDisplay } from './components/RateDisplay';
 import SellForSelector from './components/SellForSelector';
 import { SlippageSetting } from './components/SlippageSetting';
@@ -44,11 +43,9 @@ export type ISwapPanelContentProps = {
     actionOtherToken?: ISwapToken;
     onlySupportCrossChain?: boolean;
   };
-  isApproved: boolean;
   defaultTokens: IToken[];
   balance: BigNumber;
   balanceToken?: IToken;
-  onApprove: () => void;
   onSwap: () => void;
   onWrappedSwap: () => void;
   swapMevNetConfig: string[];
@@ -79,11 +76,9 @@ export function SwapPanelContent(props: ISwapPanelContentProps) {
     slippageAutoValue,
     supportSpeedSwap,
     defaultTokens,
-    isApproved,
     balance,
     balanceToken,
     swapNativeTokenReserveGas,
-    onApprove,
     onSwap,
     swapMevNetConfig,
     priceRate,
@@ -290,36 +285,29 @@ export function SwapPanelContent(props: ISwapPanelContentProps) {
         </SizableText>
       ) : null}
 
-      {!isApproved &&
-      !speedCheckError &&
-      currentInputAmount.gt(0) &&
-      balance.gte(currentInputAmount) ? (
-        <ApproveButton onApprove={onApprove} loading={isLoading} />
-      ) : (
-        <ActionButton
-          supportSpeedSwap={!!supportSpeedSwap?.enabled}
-          onlySupportCrossChain={!!supportSpeedSwap?.onlySupportCrossChain}
-          loading={isLoading}
-          actionToken={supportSpeedSwap?.actionToken}
-          actionOtherToken={supportSpeedSwap?.actionOtherToken}
-          tradeType={tradeType}
-          onPress={isWrapped ? onWrappedSwap : onSwap}
-          amount={currentInputAmount.toFixed()}
-          token={balanceToken}
-          balance={balance}
-          isWrapped={isWrapped}
-          networkId={networkId}
-          disabled={!!speedCheckError}
-          onSwapAction={() =>
-            swapAnalytics.logSwapAction({
-              tradeType,
-              networkId,
-              paymentToken,
-              balanceToken,
-            })
-          }
-        />
-      )}
+      <ActionButton
+        supportSpeedSwap={!!supportSpeedSwap?.enabled}
+        onlySupportCrossChain={!!supportSpeedSwap?.onlySupportCrossChain}
+        loading={isLoading}
+        actionToken={supportSpeedSwap?.actionToken}
+        actionOtherToken={supportSpeedSwap?.actionOtherToken}
+        tradeType={tradeType}
+        onPress={isWrapped ? onWrappedSwap : onSwap}
+        amount={currentInputAmount.toFixed()}
+        token={balanceToken}
+        balance={balance}
+        isWrapped={isWrapped}
+        networkId={networkId}
+        disabled={!!speedCheckError || isLoading}
+        onSwapAction={() =>
+          swapAnalytics.logSwapAction({
+            tradeType,
+            networkId,
+            paymentToken,
+            balanceToken,
+          })
+        }
+      />
 
       {/* Slippage setting */}
       {isWrapped ? null : (

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.test.tsx
@@ -1,0 +1,267 @@
+/** @jest-environment jsdom */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { ESwapNetworkFeeLevel } from '@onekeyhq/shared/types/swap/types';
+
+import { SwapPanelWrap } from './SwapPanelWrap';
+
+const showDialogMock = jest.fn();
+const prepareMarketSwapReviewMock = jest.fn();
+const useSpeedSwapActionsMock = jest.fn();
+let mockSpeedCheckLoading = false;
+let mockCheckTokenAllowanceLoading = false;
+let mockSwapApprovingMatchLoading = false;
+
+jest.mock('react-intl', () => ({
+  useIntl: () => ({
+    formatMessage: ({ id }: { id: string }) => id,
+  }),
+}));
+
+jest.mock('@onekeyhq/components', () => ({
+  EInPageDialogType: {
+    inModalPage: 'inModalPage',
+    inTabPages: 'inTabPages',
+  },
+  Toast: {
+    error: jest.fn(),
+  },
+  useInPageDialog: () => ({
+    show: showDialogMock,
+  }),
+  useIsOverlayPage: () => false,
+}));
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('@onekeyhq/kit/src/hooks/useCustomRpcAvailability', () => ({
+  useCustomRpcAvailability: () => ({
+    isCustomRpcUnavailable: true,
+  }),
+}));
+
+jest.mock('../../hooks/useTokenDetail', () => ({
+  useTokenDetail: () => ({
+    networkId: 'evm--1',
+    isReady: true,
+    tokenDetail: {
+      address: '0xmarket',
+      symbol: 'BTC',
+      decimals: 8,
+      logoUrl: 'logo',
+      price: '100',
+      isNative: false,
+      supportSwap: {
+        enable: true,
+      },
+    },
+  }),
+}));
+
+jest.mock('./hooks/useSwapPanel', () => ({
+  useSwapPanel: () => ({
+    networkId: 'evm--1',
+    setPaymentToken: jest.fn(),
+    paymentToken: {
+      networkId: 'evm--1',
+      contractAddress: '0xpay',
+      symbol: 'USDC',
+      decimals: 6,
+      price: '1',
+      isNative: false,
+    },
+    paymentAmount: {
+      toFixed: () => '1',
+    },
+    sellAmount: {
+      toFixed: () => '1',
+    },
+    tradeType: 'buy',
+    setSlippage: jest.fn(),
+    slippage: 1,
+  }),
+}));
+
+jest.mock('./hooks/useSpeedSwapInit', () => ({
+  useSpeedSwapInit: () => ({
+    isLoading: false,
+    speedConfig: {
+      spenderAddress: '0xspender',
+      slippage: 1,
+    },
+    supportSpeedSwap: true,
+    onlySupportCrossChain: false,
+    defaultTokens: [
+      {
+        networkId: 'evm--1',
+        contractAddress: '0xpay',
+        symbol: 'USDC',
+        decimals: 6,
+        price: '1',
+        isNative: false,
+      },
+    ],
+    provider: 'onekey',
+    swapMevNetConfig: [],
+  }),
+}));
+
+jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => ({
+  usePromiseResult: () => ({
+    result: undefined,
+  }),
+}));
+
+jest.mock('@onekeyhq/kit/src/states/jotai/contexts/accountSelector', () => ({
+  useActiveAccount: () => ({
+    activeAccount: {
+      account: {
+        id: 'account-1',
+      },
+      wallet: {
+        id: 'wallet-1',
+      },
+    },
+  }),
+}));
+
+jest.mock('./hooks/useSpeedSwapActions', () => ({
+  useSpeedSwapActions: (...args: unknown[]) => {
+    useSpeedSwapActionsMock(...args);
+    return {
+      speedSwapBuildTxLoading: false,
+      swapApprovingMatchLoading: mockSwapApprovingMatchLoading,
+      checkTokenAllowanceLoading: mockCheckTokenAllowanceLoading,
+      balance: {
+        gte: () => true,
+      },
+      balanceToken: {
+        networkId: 'evm--1',
+        contractAddress: '0xpay',
+        symbol: 'USDC',
+        decimals: 6,
+        price: '1',
+        isNative: false,
+      },
+      fetchBalanceLoading: false,
+      priceRate: undefined,
+      swapNativeTokenReserveGas: [],
+      isWrapped: false,
+      speedCheckError: '',
+      speedCheckLoading: mockSpeedCheckLoading,
+      prepareMarketSwapReview: prepareMarketSwapReviewMock,
+      sendMarketApproveTx: jest.fn(),
+      sendMarketSwapTx: jest.fn(),
+      sendMarketWrappedTx: jest.fn(),
+      sendMarketSignMessage: jest.fn(),
+      buildMarketApproveInfos: jest.fn(),
+    };
+  },
+}));
+
+jest.mock('./MarketSwapReviewDialog', () => ({
+  MarketSwapReviewDialog: () => <div data-testid="market-review-dialog" />,
+}));
+
+jest.mock('./SwapPanelContent', () => ({
+  SwapPanelContent: ({
+    onSwap,
+    onWrappedSwap,
+  }: {
+    onSwap: () => void;
+    onWrappedSwap: () => void;
+  }) => (
+    <div>
+      <button data-testid="swap-action" onClick={onSwap} type="button">
+        swap
+      </button>
+      <button data-testid="wrap-action" onClick={onWrappedSwap} type="button">
+        wrap
+      </button>
+    </div>
+  ),
+}));
+
+describe('SwapPanelWrap', () => {
+  beforeEach(() => {
+    showDialogMock.mockReset();
+    prepareMarketSwapReviewMock.mockReset();
+    useSpeedSwapActionsMock.mockReset();
+    mockSpeedCheckLoading = false;
+    mockCheckTokenAllowanceLoading = false;
+    mockSwapApprovingMatchLoading = false;
+    showDialogMock.mockReturnValue({
+      close: jest.fn(),
+    });
+    prepareMarketSwapReviewMock.mockResolvedValue({
+      steps: [],
+      preSwapData: {},
+      quoteResult: undefined,
+    });
+  });
+
+  it('opens the market review dialog for the regular swap path', async () => {
+    render(<SwapPanelWrap />);
+
+    expect(useSpeedSwapActionsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isCustomRpcUnavailable: true,
+      }),
+    );
+
+    fireEvent.click(screen.getByTestId('swap-action'));
+
+    await waitFor(() => {
+      expect(prepareMarketSwapReviewMock).toHaveBeenCalledWith({
+        isWrap: false,
+        networkFeeLevel: ESwapNetworkFeeLevel.MEDIUM,
+      });
+    });
+    expect(showDialogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: ETranslations.global_review_order,
+      }),
+    );
+  });
+
+  it('opens the market review dialog for the wrap path', async () => {
+    render(<SwapPanelWrap />);
+
+    fireEvent.click(screen.getByTestId('wrap-action'));
+
+    await waitFor(() => {
+      expect(prepareMarketSwapReviewMock).toHaveBeenCalledWith({
+        isWrap: true,
+        networkFeeLevel: ESwapNetworkFeeLevel.MEDIUM,
+      });
+    });
+    expect(showDialogMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not open the preview while action state is still loading', () => {
+    mockSpeedCheckLoading = true;
+
+    render(<SwapPanelWrap />);
+
+    fireEvent.click(screen.getByTestId('swap-action'));
+
+    expect(prepareMarketSwapReviewMock).not.toHaveBeenCalled();
+    expect(showDialogMock).not.toHaveBeenCalled();
+  });
+
+  it('does not open the preview while approve is pending', () => {
+    mockSwapApprovingMatchLoading = true;
+
+    render(<SwapPanelWrap />);
+
+    fireEvent.click(screen.getByTestId('swap-action'));
+
+    expect(prepareMarketSwapReviewMock).not.toHaveBeenCalled();
+    expect(showDialogMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.test.tsx
@@ -2,6 +2,7 @@
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
+import { Toast } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { ESwapNetworkFeeLevel } from '@onekeyhq/shared/types/swap/types';
 
@@ -192,6 +193,7 @@ describe('SwapPanelWrap', () => {
     showDialogMock.mockReset();
     prepareMarketSwapReviewMock.mockReset();
     useSpeedSwapActionsMock.mockReset();
+    (Toast.error as jest.Mock).mockReset();
     mockSpeedCheckLoading = false;
     mockCheckTokenAllowanceLoading = false;
     mockSwapApprovingMatchLoading = false;
@@ -263,5 +265,19 @@ describe('SwapPanelWrap', () => {
 
     expect(prepareMarketSwapReviewMock).not.toHaveBeenCalled();
     expect(showDialogMock).not.toHaveBeenCalled();
+  });
+
+  it('uses a translation key fallback when review opening throws a non-error value', async () => {
+    prepareMarketSwapReviewMock.mockRejectedValueOnce('unknown failure');
+
+    render(<SwapPanelWrap />);
+
+    fireEvent.click(screen.getByTestId('swap-action'));
+
+    await waitFor(() => {
+      expect(Toast.error).toHaveBeenCalledWith({
+        title: ETranslations.global_unknown_error,
+      });
+    });
   });
 });

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
@@ -418,7 +418,9 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
           title:
             error instanceof Error
               ? error.message
-              : 'Market swap review open failed.',
+              : intl.formatMessage({
+                  id: ETranslations.global_unknown_error,
+                }),
         });
       }
     },

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
@@ -1,15 +1,26 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
+import type { IDialogInstance } from '@onekeyhq/components';
+import {
+  EInPageDialogType,
+  Toast,
+  useInPageDialog,
+  useIsOverlayPage,
+} from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { useCustomRpcAvailability } from '@onekeyhq/kit/src/hooks/useCustomRpcAvailability';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import { dismissKeyboard } from '@onekeyhq/shared/src/keyboard';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
-import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
+import {
+  ESwapNetworkFeeLevel,
+  type ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
 
 import { useTokenDetail } from '../../hooks/useTokenDetail';
 
@@ -17,6 +28,7 @@ import { useSpeedSwapActions } from './hooks/useSpeedSwapActions';
 import { useSpeedSwapInit } from './hooks/useSpeedSwapInit';
 import { useSwapPanel } from './hooks/useSwapPanel';
 import { ESwapDirection } from './hooks/useTradeType';
+import { MarketSwapReviewDialog } from './MarketSwapReviewDialog';
 import { SwapPanelContent } from './SwapPanelContent';
 
 import type { IToken } from './types';
@@ -28,10 +40,16 @@ interface ISwapPanelWrapProps {
 export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
   const { networkId, tokenDetail, isReady } = useTokenDetail();
   const intl = useIntl();
+  const isModalPage = useIsOverlayPage();
+  const inPageDialog = useInPageDialog(
+    isModalPage ? EInPageDialogType.inModalPage : EInPageDialogType.inTabPages,
+  );
   const swapPanel = useSwapPanel({
     networkId: networkId || 'evm--1',
   });
   const [hasInitialReady, setHasInitialReady] = useState(false);
+  const [isReviewDialogOpen, setIsReviewDialogOpen] = useState(false);
+  const reviewDialogRef = useRef<IDialogInstance | null>(null);
 
   const {
     setPaymentToken,
@@ -42,6 +60,9 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
     setSlippage,
     slippage,
   } = swapPanel;
+  const { isCustomRpcUnavailable } = useCustomRpcAvailability(
+    swapPanel.networkId,
+  );
 
   const {
     isLoading: speedSwapInitLoading,
@@ -178,20 +199,17 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
         ? paymentAmount.toFixed()
         : sellAmount.toFixed(),
     antiMEV: swapMevNetConfig?.includes(swapPanel.networkId ?? ''),
+    isCustomRpcUnavailable,
+    isReviewDialogOpen,
     onCloseDialog,
   };
 
   const speedSwapActions = useSpeedSwapActions(useSpeedSwapActionsParams);
 
   const {
-    speedSwapBuildTx,
-    speedSwapWrappedTx,
     speedSwapBuildTxLoading,
+    swapApprovingMatchLoading,
     checkTokenAllowanceLoading,
-    speedSwapApproveHandler,
-    speedSwapApproveActionLoading,
-    speedSwapApproveTransactionLoading,
-    shouldApprove,
     balance,
     balanceToken,
     fetchBalanceLoading,
@@ -200,6 +218,12 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
     isWrapped,
     speedCheckError,
     speedCheckLoading,
+    prepareMarketSwapReview,
+    sendMarketApproveTx,
+    sendMarketSwapTx,
+    sendMarketWrappedTx,
+    sendMarketSignMessage,
+    buildMarketApproveInfos,
   } = speedSwapActions;
 
   const { result: mergeDeriveAssetsEnabled } = usePromiseResult(async () => {
@@ -323,39 +347,103 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
     }
   }, [speedConfig?.slippage, setSlippage]);
 
-  const handleApprove = useCallback(() => {
-    void speedSwapApproveHandler();
-  }, [speedSwapApproveHandler]);
+  const reviewAdapter = useMemo(
+    () => ({
+      prepareMarketSwapReview,
+      sendMarketApproveTx,
+      sendMarketSwapTx,
+      sendMarketWrappedTx,
+      sendMarketSignMessage,
+      buildMarketApproveInfos,
+    }),
+    [
+      buildMarketApproveInfos,
+      prepareMarketSwapReview,
+      sendMarketApproveTx,
+      sendMarketSwapTx,
+      sendMarketWrappedTx,
+      sendMarketSignMessage,
+    ],
+  );
+
+  const isActionLoading = useMemo(() => {
+    return (
+      speedSwapBuildTxLoading ||
+      swapApprovingMatchLoading ||
+      checkTokenAllowanceLoading ||
+      speedCheckLoading
+    );
+  }, [
+    checkTokenAllowanceLoading,
+    speedCheckLoading,
+    speedSwapBuildTxLoading,
+    swapApprovingMatchLoading,
+  ]);
+
+  const openReviewDialog = useCallback(
+    async (isWrap?: boolean) => {
+      if (isActionLoading) {
+        return;
+      }
+
+      try {
+        const nextReviewState = await prepareMarketSwapReview({
+          isWrap,
+          networkFeeLevel: ESwapNetworkFeeLevel.MEDIUM,
+        });
+        void reviewDialogRef.current?.close();
+        setIsReviewDialogOpen(true);
+        const dialog = inPageDialog.show({
+          title: intl.formatMessage({
+            id: ETranslations.global_review_order,
+          }),
+          showFooter: false,
+          showCancelButton: false,
+          showConfirmButton: false,
+          onClose: () => {
+            reviewDialogRef.current = null;
+            setIsReviewDialogOpen(false);
+          },
+          renderContent: (
+            <MarketSwapReviewDialog
+              adapter={reviewAdapter}
+              reviewState={nextReviewState}
+              onDone={() => dialog.close()}
+            />
+          ),
+        });
+        reviewDialogRef.current = dialog;
+      } catch (error) {
+        Toast.error({
+          title:
+            error instanceof Error
+              ? error.message
+              : 'Market swap review open failed.',
+        });
+      }
+    },
+    [
+      inPageDialog,
+      intl,
+      isActionLoading,
+      prepareMarketSwapReview,
+      reviewAdapter,
+    ],
+  );
 
   const handleSwap = useCallback(() => {
-    void speedSwapBuildTx();
-  }, [speedSwapBuildTx]);
+    void openReviewDialog(false);
+  }, [openReviewDialog]);
 
   const handleWrappedSwap = useCallback(() => {
-    void speedSwapWrappedTx();
-  }, [speedSwapWrappedTx]);
+    void openReviewDialog(true);
+  }, [openReviewDialog]);
 
   useEffect(() => {
     return () => {
       dismissKeyboard();
     };
   }, []);
-
-  const isActionLoading = useMemo(() => {
-    return (
-      speedSwapApproveActionLoading ||
-      speedSwapApproveTransactionLoading ||
-      speedSwapBuildTxLoading ||
-      checkTokenAllowanceLoading ||
-      speedCheckLoading
-    );
-  }, [
-    speedSwapApproveActionLoading,
-    speedSwapApproveTransactionLoading,
-    speedSwapBuildTxLoading,
-    checkTokenAllowanceLoading,
-    speedCheckLoading,
-  ]);
 
   useEffect(() => {
     if (
@@ -405,11 +493,9 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
       isLoading={isActionLoading}
       hasInitialReady={hasInitialReady}
       onSwap={handleSwap}
-      isApproved={!shouldApprove}
       slippageAutoValue={speedConfig?.slippage}
       supportSpeedSwap={supportSpeedSwap}
       defaultTokens={filterDefaultTokens}
-      onApprove={handleApprove}
       onWrappedSwap={handleWrappedSwap}
       isWrapped={isWrapped}
       speedCheckError={speedCheckError}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketBuildExecutionUtils.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketBuildExecutionUtils.test.ts
@@ -1,0 +1,222 @@
+import type { IEncodedTx } from '@onekeyhq/core/src/types';
+import type {
+  EInternalDappEnum,
+  IStakeTx,
+} from '@onekeyhq/shared/types/staking';
+import type {
+  IFetchBuildTxResponse,
+  ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
+import { EProtocolOfExchange } from '@onekeyhq/shared/types/swap/types';
+
+import { buildMarketExecutionPayload } from './marketBuildExecutionUtils';
+
+const fromToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xfrom',
+  symbol: 'ETH',
+  decimals: 18,
+  isNative: true,
+};
+
+const toToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xto',
+  symbol: 'USDC',
+  decimals: 6,
+  isNative: false,
+};
+
+function createBuildRes(
+  overrides: Partial<IFetchBuildTxResponse> = {},
+): IFetchBuildTxResponse {
+  return {
+    result: {
+      protocol: EProtocolOfExchange.SWAP,
+      info: {
+        provider: 'provider-a',
+        providerName: 'Provider A',
+      },
+      fromTokenInfo: fromToken,
+      toTokenInfo: toToken,
+      fromAmount: '1',
+      toAmount: '1000',
+    },
+    ...overrides,
+  } as IFetchBuildTxResponse;
+}
+
+describe('marketBuildExecutionUtils', () => {
+  it('builds transfer info for provider orders like swft', async () => {
+    const result = await buildMarketExecutionPayload({
+      accountId: 'account-1',
+      buildRes: createBuildRes({
+        swftOrder: {
+          platformAddr: '0xplatform',
+          depositCoinAmt: '1',
+          memo: 'memo-1',
+        } as never,
+      }),
+      currentFromToken: fromToken,
+      currentToToken: toToken,
+      fromAmount: '1',
+      receivingAddress: '0xuser',
+      slippage: 1,
+      userAddress: '0xuser',
+      onBuildOkxSwapEncodedTx: jest.fn(),
+      onBuildLMSwapEncodedTx: jest.fn(),
+      onBuildInternalDappTx: jest.fn(),
+    });
+
+    expect(result.transferInfo).toEqual(
+      expect.objectContaining({
+        from: '0xuser',
+        to: '0xplatform',
+        amount: '1',
+        memo: 'memo-1',
+      }),
+    );
+    expect(result.encodedTx).toBeUndefined();
+  });
+
+  it('supports LM Tron build payloads', async () => {
+    const buildLMSwapEncodedTx = jest.fn<Promise<IEncodedTx>, [unknown]>();
+    buildLMSwapEncodedTx.mockResolvedValue({
+      data: '0xlm',
+    } as IEncodedTx);
+
+    const result = await buildMarketExecutionPayload({
+      accountId: 'account-1',
+      buildRes: createBuildRes({
+        LMTronObject: {
+          from: '0xfrom',
+          to: '0xto',
+          value: '0',
+          data: '0xlm',
+        },
+      }),
+      currentFromToken: fromToken,
+      currentToToken: toToken,
+      fromAmount: '1',
+      receivingAddress: '0xuser',
+      slippage: 1,
+      userAddress: '0xuser',
+      onBuildOkxSwapEncodedTx: jest.fn(),
+      onBuildLMSwapEncodedTx: buildLMSwapEncodedTx,
+      onBuildInternalDappTx: jest.fn(),
+    });
+
+    expect(buildLMSwapEncodedTx).toHaveBeenCalledTimes(1);
+    expect(result.encodedTx).toEqual({
+      data: '0xlm',
+    });
+  });
+
+  it('supports BTC and Sui internal dapp payloads', async () => {
+    const buildInternalDappTx = jest.fn<
+      Promise<IEncodedTx>,
+      [
+        {
+          accountId: string;
+          networkId: string;
+          tx: IStakeTx;
+          internalDappType: EInternalDappEnum;
+        },
+      ]
+    >();
+    buildInternalDappTx.mockResolvedValue({
+      data: '0xinternal',
+    } as IEncodedTx);
+
+    const btcResult = await buildMarketExecutionPayload({
+      accountId: 'account-1',
+      buildRes: createBuildRes({
+        btcData: {
+          hexStr: 'psbt-hex',
+          addressType: ['p2wpkh'],
+        },
+      }),
+      currentFromToken: {
+        ...fromToken,
+        networkId: 'btc--0',
+      },
+      currentToToken: toToken,
+      deriveAddressEncoding: 'p2wpkh',
+      fromAmount: '1',
+      receivingAddress: '0xuser',
+      slippage: 1,
+      userAddress: '0xuser',
+      onBuildOkxSwapEncodedTx: jest.fn(),
+      onBuildLMSwapEncodedTx: jest.fn(),
+      onBuildInternalDappTx: buildInternalDappTx,
+    });
+
+    const suiResult = await buildMarketExecutionPayload({
+      accountId: 'account-1',
+      buildRes: createBuildRes({
+        suiBase64Data: 'base64-tx',
+      }),
+      currentFromToken: {
+        ...fromToken,
+        networkId: 'sui--mainnet',
+      },
+      currentToToken: toToken,
+      fromAmount: '1',
+      receivingAddress: '0xuser',
+      slippage: 1,
+      userAddress: '0xuser',
+      onBuildOkxSwapEncodedTx: jest.fn(),
+      onBuildLMSwapEncodedTx: jest.fn(),
+      onBuildInternalDappTx: buildInternalDappTx,
+    });
+
+    expect(buildInternalDappTx).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        tx: {
+          psbtHex: 'psbt-hex',
+        },
+      }),
+    );
+    expect(buildInternalDappTx).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        tx: 'base64-tx',
+      }),
+    );
+    expect(btcResult.encodedTx).toEqual({
+      data: '0xinternal',
+    });
+    expect(suiResult.encodedTx).toEqual({
+      data: '0xinternal',
+    });
+  });
+
+  it('fails fast when BTC derivation encoding does not match the build tx', async () => {
+    await expect(
+      buildMarketExecutionPayload({
+        accountId: 'account-1',
+        buildRes: createBuildRes({
+          btcData: {
+            hexStr: 'psbt-hex',
+            addressType: ['p2wpkh'],
+          },
+        }),
+        btcDerivationRestrictionErrorMessage: 'Derivation restricted',
+        currentFromToken: {
+          ...fromToken,
+          networkId: 'btc--0',
+        },
+        currentToToken: toToken,
+        deriveAddressEncoding: 'p2tr',
+        fromAmount: '1',
+        receivingAddress: '0xuser',
+        slippage: 1,
+        userAddress: '0xuser',
+        onBuildOkxSwapEncodedTx: jest.fn(),
+        onBuildLMSwapEncodedTx: jest.fn(),
+        onBuildInternalDappTx: jest.fn(),
+      }),
+    ).rejects.toThrow('Derivation restricted');
+  });
+});

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketBuildExecutionUtils.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketBuildExecutionUtils.ts
@@ -1,0 +1,224 @@
+import BigNumber from 'bignumber.js';
+
+import type { EAddressEncodings, IEncodedTx } from '@onekeyhq/core/src/types';
+import type { ITransferInfo } from '@onekeyhq/kit-bg/src/vaults/types';
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import { toBigIntHex } from '@onekeyhq/shared/src/utils/numberUtils';
+import {
+  EInternalDappEnum,
+  type IStakeTx,
+} from '@onekeyhq/shared/types/staking';
+import type {
+  IFetchBuildTxResponse,
+  ISwapToken,
+  ISwapTxInfo,
+} from '@onekeyhq/shared/types/swap/types';
+import {
+  EProtocolOfExchange,
+  ESwapTabSwitchType,
+} from '@onekeyhq/shared/types/swap/types';
+
+function buildTransferTokenInfo(
+  token: IFetchBuildTxResponse['result']['fromTokenInfo'],
+) {
+  return {
+    ...token,
+    isNative: !!token.isNative,
+    address: token.contractAddress,
+    name: token.name ?? token.symbol,
+  };
+}
+
+export async function buildMarketExecutionPayload({
+  accountId,
+  buildRes,
+  btcDerivationRestrictionErrorMessage,
+  currentFromToken,
+  currentToToken,
+  deriveAddressEncoding,
+  fromAmount,
+  receivingAddress,
+  slippage,
+  swapType,
+  userAddress,
+  onBuildInternalDappTx,
+  onBuildLMSwapEncodedTx,
+  onBuildOkxSwapEncodedTx,
+}: {
+  accountId: string;
+  buildRes: IFetchBuildTxResponse;
+  btcDerivationRestrictionErrorMessage?: string;
+  currentFromToken: ISwapToken;
+  currentToToken: ISwapToken;
+  deriveAddressEncoding?: EAddressEncodings | string;
+  fromAmount: string;
+  receivingAddress: string;
+  slippage: number;
+  swapType?: ESwapTabSwitchType;
+  userAddress: string;
+  onBuildInternalDappTx: (params: {
+    accountId: string;
+    networkId: string;
+    tx: IStakeTx;
+    internalDappType: EInternalDappEnum;
+  }) => Promise<IEncodedTx>;
+  onBuildLMSwapEncodedTx: (params: {
+    accountId: string;
+    networkId: string;
+    lmTx: NonNullable<IFetchBuildTxResponse['LMTronObject']>;
+  }) => Promise<IEncodedTx>;
+  onBuildOkxSwapEncodedTx: (params: {
+    accountId: string;
+    networkId: string;
+    okxTx: NonNullable<IFetchBuildTxResponse['OKXTxObject']>;
+    fromTokenInfo: IFetchBuildTxResponse['result']['fromTokenInfo'];
+    type: ESwapTabSwitchType;
+  }) => Promise<IEncodedTx>;
+}): Promise<{
+  encodedTx?: IEncodedTx;
+  transferInfo?: ITransferInfo;
+  swapInfo: ISwapTxInfo;
+  skipSendTransAction: boolean;
+  orderId?: string;
+}> {
+  let transferInfo: ITransferInfo | undefined;
+  let encodedTx: IEncodedTx | undefined;
+
+  if (buildRes.swftOrder) {
+    transferInfo = {
+      from: userAddress,
+      tokenInfo: buildTransferTokenInfo(buildRes.result.fromTokenInfo),
+      to: buildRes.swftOrder.platformAddr,
+      amount: buildRes.swftOrder.depositCoinAmt,
+      memo: buildRes.swftOrder.memo,
+    };
+  } else if (buildRes.changellyOrder) {
+    transferInfo = {
+      from: userAddress,
+      tokenInfo: buildTransferTokenInfo(buildRes.result.fromTokenInfo),
+      to: buildRes.changellyOrder.payinAddress,
+      amount: buildRes.changellyOrder.amountExpectedFrom,
+      memo: buildRes.changellyOrder.payinExtraId,
+    };
+  } else if (buildRes.thorSwapCallData) {
+    transferInfo = {
+      from: userAddress,
+      tokenInfo: buildTransferTokenInfo(buildRes.result.fromTokenInfo),
+      to: buildRes.thorSwapCallData.vault,
+      opReturn: buildRes.thorSwapCallData.hasStreamingSwap
+        ? buildRes.thorSwapCallData.memoStreamingSwap
+        : buildRes.thorSwapCallData.memo,
+      amount: new BigNumber(buildRes.thorSwapCallData.amount)
+        .shiftedBy(-buildRes.result.fromTokenInfo.decimals)
+        .toFixed(),
+    };
+  } else if (buildRes.OKXTxObject) {
+    encodedTx = await onBuildOkxSwapEncodedTx({
+      accountId,
+      networkId: currentFromToken.networkId,
+      okxTx: buildRes.OKXTxObject,
+      fromTokenInfo: buildRes.result.fromTokenInfo,
+      type: swapType ?? ESwapTabSwitchType.SWAP,
+    });
+  } else if (buildRes.LMTronObject) {
+    encodedTx = await onBuildLMSwapEncodedTx({
+      accountId,
+      networkId: currentFromToken.networkId,
+      lmTx: buildRes.LMTronObject,
+    });
+  } else if (buildRes.tronTxData) {
+    encodedTx = buildRes.tronTxData;
+  } else if (buildRes.xrpTxData) {
+    encodedTx = buildRes.xrpTxData;
+  } else if (buildRes.tx) {
+    if (typeof buildRes.tx !== 'string' && buildRes.tx.data) {
+      encodedTx = {
+        ...buildRes.tx,
+        value: toBigIntHex(new BigNumber(buildRes.tx.value ?? 0)),
+        from: userAddress,
+      };
+    } else {
+      encodedTx = buildRes.tx as IEncodedTx;
+    }
+  } else if (buildRes.btcData || buildRes.suiBase64Data) {
+    let inputTx: IStakeTx | undefined;
+
+    if (buildRes.btcData) {
+      if (
+        !deriveAddressEncoding ||
+        !buildRes.btcData.addressType.includes(deriveAddressEncoding)
+      ) {
+        throw new OneKeyLocalError(
+          btcDerivationRestrictionErrorMessage ??
+            'BTC derivation path restriction.',
+        );
+      }
+
+      inputTx = {
+        psbtHex: buildRes.btcData.hexStr,
+      };
+    }
+
+    if (buildRes.suiBase64Data) {
+      inputTx = buildRes.suiBase64Data;
+    }
+
+    if (inputTx) {
+      encodedTx = await onBuildInternalDappTx({
+        accountId,
+        networkId: currentFromToken.networkId,
+        tx: inputTx,
+        internalDappType: EInternalDappEnum.Swap,
+      });
+    }
+  }
+
+  const swapInfo: ISwapTxInfo = {
+    protocol: buildRes.result.protocol ?? EProtocolOfExchange.SWAP,
+    sender: {
+      amount: buildRes.result.fromAmount ?? fromAmount,
+      token: currentFromToken,
+      accountInfo: {
+        accountId,
+        networkId: currentFromToken.networkId,
+      },
+    },
+    receiver: {
+      amount: buildRes.result.toAmount ?? '',
+      token: currentToToken,
+      accountInfo: {
+        accountId,
+        networkId: currentToToken.networkId,
+      },
+    },
+    accountAddress: userAddress,
+    receivingAddress,
+    swapBuildResData: {
+      ...buildRes,
+      result: {
+        ...buildRes.result,
+        slippage: buildRes.result.slippage ?? slippage,
+      },
+    },
+  };
+
+  return {
+    encodedTx,
+    transferInfo,
+    swapInfo,
+    skipSendTransAction: Boolean(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      buildRes.ctx?.cowSwapOrderId ||
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      buildRes.ctx?.oneInchFusionOrderHash,
+    ),
+    orderId:
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      buildRes.ctx?.cowSwapOrderId ??
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      buildRes.ctx?.oneInchFusionOrderHash ??
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      buildRes.ctx?.changeHeroOrderId ??
+      buildRes.orderId,
+  };
+}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.test.ts
@@ -1,0 +1,277 @@
+import type { IUnsignedTxPro } from '@onekeyhq/core/src/types';
+import { ESwapNetworkFeeLevel } from '@onekeyhq/shared/types/swap/types';
+
+const mockPrepareSendConfirmUnsignedTx = jest.fn();
+const mockGetVaultSettings = jest.fn();
+const mockBuildEstimateFeeParams = jest.fn();
+const mockBatchEstimateFee = jest.fn();
+const mockEstimateFee = jest.fn();
+const mockUpdateUnsignedTx = jest.fn();
+const mockPrecheckUnsignedTxs = jest.fn();
+const mockVerifyTransaction = jest.fn();
+const mockSignAndSendTransaction = jest.fn();
+const mockBuildDecodedTx = jest.fn();
+const mockSaveSendConfirmHistoryTxs = jest.fn();
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {
+    serviceSend: {
+      prepareSendConfirmUnsignedTx: mockPrepareSendConfirmUnsignedTx,
+      updateUnsignedTx: mockUpdateUnsignedTx,
+      precheckUnsignedTxs: mockPrecheckUnsignedTxs,
+      signAndSendTransaction: mockSignAndSendTransaction,
+      buildDecodedTx: mockBuildDecodedTx,
+    },
+    serviceNetwork: {
+      getVaultSettings: mockGetVaultSettings,
+    },
+    serviceGas: {
+      buildEstimateFeeParams: mockBuildEstimateFeeParams,
+      batchEstimateFee: mockBatchEstimateFee,
+      estimateFee: mockEstimateFee,
+    },
+    serviceTransaction: {
+      verifyTransaction: mockVerifyTransaction,
+    },
+    serviceHistory: {
+      saveSendConfirmHistoryTxs: mockSaveSendConfirmHistoryTxs,
+    },
+  },
+}));
+
+const { estimateMarketDirectGasInfos, sendMarketDirectUnsignedTxs } =
+  require('./marketDirectSendTx') as typeof import('./marketDirectSendTx');
+
+function createUnsignedTx(
+  overrides: Partial<IUnsignedTxPro> = {},
+): IUnsignedTxPro {
+  return {
+    encodedTx: {
+      data: '0xencoded',
+    } as never,
+    nonce: 1,
+    ...overrides,
+  } as IUnsignedTxPro;
+}
+
+function createEstimateFeeResult() {
+  return {
+    common: {
+      feeDecimals: 18,
+      feeSymbol: 'ETH',
+      nativeDecimals: 18,
+      nativeSymbol: 'ETH',
+      nativeTokenPrice: 3000,
+    },
+    gas: [
+      {
+        gasPrice: '1',
+        gasLimit: '21000',
+      },
+      {
+        gasPrice: '2',
+        gasLimit: '22000',
+      },
+      {
+        gasPrice: '3',
+        gasLimit: '23000',
+      },
+    ],
+  };
+}
+
+describe('marketDirectSendTx', () => {
+  beforeEach(() => {
+    mockPrepareSendConfirmUnsignedTx.mockReset();
+    mockGetVaultSettings.mockReset();
+    mockBuildEstimateFeeParams.mockReset();
+    mockBatchEstimateFee.mockReset();
+    mockEstimateFee.mockReset();
+    mockUpdateUnsignedTx.mockReset();
+    mockPrecheckUnsignedTxs.mockReset();
+    mockVerifyTransaction.mockReset();
+    mockSignAndSendTransaction.mockReset();
+    mockBuildDecodedTx.mockReset();
+    mockSaveSendConfirmHistoryTxs.mockReset();
+
+    mockGetVaultSettings.mockResolvedValue({});
+    mockBuildEstimateFeeParams.mockImplementation(async ({ encodedTx }) => ({
+      encodedTx,
+    }));
+    mockEstimateFee.mockResolvedValue(createEstimateFeeResult());
+    mockUpdateUnsignedTx.mockImplementation(async ({ unsignedTx }) => {
+      return unsignedTx as never;
+    });
+    mockPrecheckUnsignedTxs.mockResolvedValue(undefined);
+    mockVerifyTransaction.mockResolvedValue(undefined);
+    mockSignAndSendTransaction.mockResolvedValue({
+      txid: '0xtx',
+      rawTx: '0xraw',
+    });
+    mockBuildDecodedTx.mockResolvedValue({
+      txid: '0xtx',
+      networkId: 'evm--1',
+      totalFeeFiatValue: '0.12',
+      totalFeeInNative: '0.0001',
+    });
+    mockSaveSendConfirmHistoryTxs.mockResolvedValue(undefined);
+  });
+
+  it('sends a single unsigned tx through the direct sign-and-send path', async () => {
+    mockPrepareSendConfirmUnsignedTx.mockResolvedValue(createUnsignedTx());
+
+    const result = await sendMarketDirectUnsignedTxs({
+      accountAddress: '0xuser',
+      accountId: 'account-1',
+      networkId: 'evm--1',
+      buildUnsignedParams: {
+        accountId: 'account-1',
+        networkId: 'evm--1',
+        encodedTx: {
+          data: '0xencoded',
+        } as never,
+        isInternalSwap: true,
+      },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(mockPrepareSendConfirmUnsignedTx).toHaveBeenCalledTimes(1);
+    expect(mockEstimateFee).toHaveBeenCalledTimes(1);
+    expect(mockSignAndSendTransaction).toHaveBeenCalledTimes(1);
+    expect(mockSaveSendConfirmHistoryTxs).toHaveBeenCalledTimes(1);
+    expect(mockBatchEstimateFee).not.toHaveBeenCalled();
+  });
+
+  it('sends batch approve plus swap with batch fee estimation when supported', async () => {
+    const approveUnsignedTx = createUnsignedTx({
+      encodedTx: {
+        data: '0xapprove',
+      } as never,
+      nonce: 1,
+    });
+    const swapUnsignedTx = createUnsignedTx({
+      encodedTx: {
+        data: '0xswap',
+      } as never,
+      nonce: 2,
+    });
+
+    mockPrepareSendConfirmUnsignedTx.mockResolvedValue(swapUnsignedTx);
+    mockGetVaultSettings.mockResolvedValue({
+      supportBatchEstimateFee: {
+        'evm--1': true,
+      },
+    });
+    mockBatchEstimateFee.mockResolvedValue({
+      common: createEstimateFeeResult().common,
+      txFees: [createEstimateFeeResult(), createEstimateFeeResult()],
+    });
+
+    const result = await sendMarketDirectUnsignedTxs({
+      accountAddress: '0xuser',
+      accountId: 'account-1',
+      networkId: 'evm--1',
+      buildUnsignedParams: {
+        accountId: 'account-1',
+        networkId: 'evm--1',
+        encodedTx: {
+          data: '0xswap',
+        } as never,
+        isInternalSwap: true,
+      },
+      approveUnsignedTxArr: [approveUnsignedTx],
+    });
+
+    expect(result).toHaveLength(2);
+    expect(mockBatchEstimateFee).toHaveBeenCalledTimes(1);
+    expect(mockUpdateUnsignedTx).toHaveBeenCalledTimes(2);
+    expect(mockSignAndSendTransaction).toHaveBeenCalledTimes(2);
+    expect(mockSaveSendConfirmHistoryTxs).toHaveBeenCalledTimes(2);
+  });
+
+  it('builds gas infos from the selected fee level', async () => {
+    const preparedUnsignedTx = createUnsignedTx();
+    mockPrepareSendConfirmUnsignedTx.mockResolvedValue(preparedUnsignedTx);
+
+    const lowFeeResult = await estimateMarketDirectGasInfos({
+      accountAddress: '0xuser',
+      accountId: 'account-1',
+      networkId: 'evm--1',
+      networkFeeLevel: ESwapNetworkFeeLevel.LOW,
+      buildUnsignedParams: {
+        accountId: 'account-1',
+        networkId: 'evm--1',
+        encodedTx: {
+          data: '0xencoded',
+        } as never,
+        isInternalSwap: true,
+      },
+    });
+    const highFeeResult = await estimateMarketDirectGasInfos({
+      accountAddress: '0xuser',
+      accountId: 'account-1',
+      networkId: 'evm--1',
+      networkFeeLevel: ESwapNetworkFeeLevel.HIGH,
+      buildUnsignedParams: {
+        accountId: 'account-1',
+        networkId: 'evm--1',
+        encodedTx: {
+          data: '0xencoded',
+        } as never,
+        isInternalSwap: true,
+      },
+    });
+
+    expect(lowFeeResult.gasInfos[0].gasInfo.gas?.gasPrice).toBe('1');
+    expect(highFeeResult.gasInfos[0].gasInfo.gas?.gasPrice).toBe('3');
+    expect(lowFeeResult.gasFeeFiatValue).not.toBe(
+      highFeeResult.gasFeeFiatValue,
+    );
+    expect(lowFeeResult.preparedUnsignedTx).toBe(preparedUnsignedTx);
+    expect(highFeeResult.preparedUnsignedTx).toBe(preparedUnsignedTx);
+  });
+
+  it('preserves the selected fee level when send-time gas info must be rebuilt', async () => {
+    mockPrepareSendConfirmUnsignedTx.mockResolvedValue(createUnsignedTx());
+
+    await sendMarketDirectUnsignedTxs({
+      accountAddress: '0xuser',
+      accountId: 'account-1',
+      networkId: 'evm--1',
+      networkFeeLevel: ESwapNetworkFeeLevel.HIGH,
+      buildUnsignedParams: {
+        accountId: 'account-1',
+        networkId: 'evm--1',
+        encodedTx: {
+          data: '0xencoded',
+        } as never,
+        isInternalSwap: true,
+      },
+      gasInfos: [
+        {
+          encodeTx: {
+            data: '0xother',
+          } as never,
+          gasInfo: {
+            common: createEstimateFeeResult().common,
+            gas: {
+              gasPrice: '1',
+              gasLimit: '21000',
+            },
+          } as never,
+        },
+      ],
+    });
+
+    expect(mockUpdateUnsignedTx).toHaveBeenCalledWith(
+      expect.objectContaining({
+        feeInfo: expect.objectContaining({
+          gas: expect.objectContaining({
+            gasPrice: '3',
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.test.ts
@@ -40,8 +40,11 @@ jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
   },
 }));
 
-const { estimateMarketDirectGasInfos, sendMarketDirectUnsignedTxs } =
-  require('./marketDirectSendTx') as typeof import('./marketDirectSendTx');
+const {
+  estimateMarketApproveGasInfos,
+  estimateMarketDirectGasInfos,
+  sendMarketDirectUnsignedTxs,
+} = require('./marketDirectSendTx') as typeof import('./marketDirectSendTx');
 
 function createUnsignedTx(
   overrides: Partial<IUnsignedTxPro> = {},
@@ -230,6 +233,42 @@ describe('marketDirectSendTx', () => {
     );
     expect(lowFeeResult.preparedUnsignedTx).toBe(preparedUnsignedTx);
     expect(highFeeResult.preparedUnsignedTx).toBe(preparedUnsignedTx);
+  });
+
+  it('estimates approve-only gas infos from the selected fee level', async () => {
+    const resetApproveUnsignedTx = createUnsignedTx({
+      encodedTx: {
+        data: '0xreset',
+      } as never,
+      nonce: 1,
+    });
+    const approveUnsignedTx = createUnsignedTx({
+      encodedTx: {
+        data: '0xapprove',
+      } as never,
+      nonce: 2,
+    });
+
+    const lowFeeResult = await estimateMarketApproveGasInfos({
+      accountAddress: '0xuser',
+      accountId: 'account-1',
+      networkId: 'evm--1',
+      networkFeeLevel: ESwapNetworkFeeLevel.LOW,
+      approveUnsignedTxArr: [resetApproveUnsignedTx, approveUnsignedTx],
+    });
+    const highFeeResult = await estimateMarketApproveGasInfos({
+      accountAddress: '0xuser',
+      accountId: 'account-1',
+      networkId: 'evm--1',
+      networkFeeLevel: ESwapNetworkFeeLevel.HIGH,
+      approveUnsignedTxArr: [resetApproveUnsignedTx, approveUnsignedTx],
+    });
+
+    expect(lowFeeResult.gasInfos).toHaveLength(2);
+    expect(highFeeResult.gasInfos).toHaveLength(2);
+    expect(lowFeeResult.gasInfos[0].gasInfo.gas?.gasPrice).toBe('1');
+    expect(highFeeResult.gasInfos[0].gasInfo.gas?.gasPrice).toBe('3');
+    expect(mockEstimateFee).toHaveBeenCalledTimes(4);
   });
 
   it('preserves the selected fee level when send-time gas info must be rebuilt', async () => {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.ts
@@ -1,0 +1,537 @@
+import BigNumber from 'bignumber.js';
+import { isEqual } from 'lodash';
+
+import type { IEncodedTx, IUnsignedTxPro } from '@onekeyhq/core/src/types';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import type { IBuildUnsignedTxParams } from '@onekeyhq/kit-bg/src/vaults/types';
+import {
+  BATCH_APPROVE_GAS_FEE_RATIO_FOR_SWAP,
+  BATCH_SEND_TXS_FEE_UP_RATIO_FOR_SWAP,
+} from '@onekeyhq/shared/src/consts/walletConsts';
+import { OneKeyError } from '@onekeyhq/shared/src/errors';
+import { calculateFeeForSend } from '@onekeyhq/shared/src/utils/feeUtils';
+import type {
+  IFeeAlgo,
+  IFeeCkb,
+  IFeeDot,
+  IFeeInfoUnit,
+  IFeeSol,
+  IFeeSui,
+  IFeeTron,
+  IFeeUTXO,
+  IGasEIP1559,
+  IGasLegacy,
+} from '@onekeyhq/shared/types/fee';
+import { ESendPreCheckTimingEnum } from '@onekeyhq/shared/types/send';
+import type { ISwapGasInfo } from '@onekeyhq/shared/types/swap/types';
+import { ESwapNetworkFeeLevel } from '@onekeyhq/shared/types/swap/types';
+import type {
+  ISendTxBaseParams,
+  ISendTxOnSuccessData,
+} from '@onekeyhq/shared/types/tx';
+
+export type IMarketGasInfoEntry = {
+  encodeTx: IEncodedTx;
+  gasInfo: ISwapGasInfo;
+};
+
+type IMarketDirectSendParams = {
+  accountAddress: string;
+  accountId: string;
+  networkId: string;
+  buildUnsignedParams: ISendTxBaseParams & IBuildUnsignedTxParams;
+  approveUnsignedTxArr?: IUnsignedTxPro[];
+  gasInfos?: IMarketGasInfoEntry[];
+  networkFeeLevel?: ESwapNetworkFeeLevel;
+};
+
+type IEstimateMarketDirectGasInfosParams = Omit<
+  IMarketDirectSendParams,
+  'gasInfos'
+>;
+
+function pickFeeLevelValue<T>(
+  values: T[] | undefined,
+  networkFeeLevel?: ESwapNetworkFeeLevel,
+): T | undefined {
+  if (networkFeeLevel === ESwapNetworkFeeLevel.LOW) {
+    return values?.[0];
+  }
+
+  if (networkFeeLevel === ESwapNetworkFeeLevel.HIGH) {
+    return values?.[2] ?? values?.[1] ?? values?.[0];
+  }
+
+  return values?.[1] ?? values?.[0];
+}
+
+function buildUnsignedTxArr({
+  unsignedTx,
+  approveUnsignedTxArr,
+}: {
+  unsignedTx: IUnsignedTxPro;
+  approveUnsignedTxArr?: IUnsignedTxPro[];
+}) {
+  return approveUnsignedTxArr?.length
+    ? [...approveUnsignedTxArr, unsignedTx]
+    : [unsignedTx];
+}
+
+function findGasInfo(
+  gasInfos: IMarketGasInfoEntry[],
+  encodedTx: IEncodedTx,
+): IMarketGasInfoEntry | undefined {
+  return gasInfos.find(
+    (item) =>
+      isEqual(item.encodeTx, encodedTx) ||
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      ((item.encodeTx as any)?.rawSignTx &&
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (encodedTx as any)?.rawSignTx &&
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (item.encodeTx as any)?.rawSignTx ===
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          (encodedTx as any)?.rawSignTx),
+  );
+}
+
+function buildGasInfo(
+  gasRes: {
+    gas?: IGasLegacy[];
+    gasEIP1559?: IGasEIP1559[];
+    feeUTXO?: IFeeUTXO[];
+    feeTron?: IFeeTron[];
+    feeSol?: IFeeSol[];
+    feeCkb?: IFeeCkb[];
+    feeAlgo?: IFeeAlgo[];
+    feeDot?: IFeeDot[];
+    feeBudget?: IFeeSui[];
+  },
+  gasCommon: {
+    baseFee?: string;
+    feeDecimals: number;
+    feeSymbol: string;
+    nativeDecimals: number;
+    nativeSymbol: string;
+    nativeTokenPrice?: number;
+  },
+  networkFeeLevel?: ESwapNetworkFeeLevel,
+): ISwapGasInfo {
+  return {
+    common: gasCommon,
+    gas: pickFeeLevelValue(gasRes.gas, networkFeeLevel),
+    gasEIP1559: pickFeeLevelValue(gasRes.gasEIP1559, networkFeeLevel),
+    feeUTXO: pickFeeLevelValue(gasRes.feeUTXO, networkFeeLevel),
+    feeTron: pickFeeLevelValue(gasRes.feeTron, networkFeeLevel),
+    feeSol: pickFeeLevelValue(gasRes.feeSol, networkFeeLevel),
+    feeCkb: pickFeeLevelValue(gasRes.feeCkb, networkFeeLevel),
+    feeAlgo: pickFeeLevelValue(gasRes.feeAlgo, networkFeeLevel),
+    feeDot: pickFeeLevelValue(gasRes.feeDot, networkFeeLevel),
+    feeBudget: pickFeeLevelValue(gasRes.feeBudget, networkFeeLevel),
+  };
+}
+
+async function resolveMarketGasInfos({
+  accountAddress,
+  accountId,
+  networkId,
+  unsignedTx,
+  approveUnsignedTxArr,
+  networkFeeLevel,
+}: {
+  accountAddress: string;
+  accountId: string;
+  networkId: string;
+  unsignedTx: IUnsignedTxPro;
+  approveUnsignedTxArr?: IUnsignedTxPro[];
+  networkFeeLevel?: ESwapNetworkFeeLevel;
+}): Promise<IMarketGasInfoEntry[]> {
+  const gasInfos: IMarketGasInfoEntry[] = [];
+  const unsignedTxArr = buildUnsignedTxArr({
+    unsignedTx,
+    approveUnsignedTxArr,
+  });
+  const vaultSettings =
+    await backgroundApiProxy.serviceNetwork.getVaultSettings({
+      networkId,
+    });
+
+  if (
+    approveUnsignedTxArr?.length &&
+    vaultSettings.supportBatchEstimateFee?.[networkId]
+  ) {
+    const estimateFeeParamsArr = await Promise.all(
+      unsignedTxArr.map((item) =>
+        backgroundApiProxy.serviceGas.buildEstimateFeeParams({
+          networkId,
+          accountId,
+          encodedTx: item.encodedTx,
+        }),
+      ),
+    );
+
+    const gasResArr = await backgroundApiProxy.serviceGas.batchEstimateFee({
+      networkId,
+      accountId,
+      encodedTxs: estimateFeeParamsArr.map((item) => item.encodedTx ?? {}),
+    });
+
+    for (let i = 0; i < unsignedTxArr.length; i += 1) {
+      gasInfos.push({
+        encodeTx: unsignedTxArr[i].encodedTx,
+        gasInfo: buildGasInfo(
+          gasResArr.txFees[i],
+          gasResArr.common,
+          networkFeeLevel,
+        ),
+      });
+    }
+
+    return gasInfos;
+  }
+
+  if (approveUnsignedTxArr?.length) {
+    let lastTxUseGasInfo: IFeeInfoUnit | undefined;
+
+    for (let i = 0; i < unsignedTxArr.length; i += 1) {
+      const unsignedTxItem = unsignedTxArr[i];
+
+      if (i === unsignedTxArr.length - 1) {
+        const internalSwapGasLimit =
+          unsignedTxItem.swapInfo?.swapBuildResData.result.gasLimit;
+        const internalSwapRoutes =
+          unsignedTxItem.swapInfo?.swapBuildResData.result.routesData;
+        const baseGasLimit =
+          lastTxUseGasInfo?.gas?.gasLimit ??
+          lastTxUseGasInfo?.gasEIP1559?.gasLimit;
+
+        let specialGasLimit: string | undefined;
+        if (
+          typeof internalSwapGasLimit !== 'undefined' &&
+          internalSwapGasLimit !== null
+        ) {
+          specialGasLimit = new BigNumber(internalSwapGasLimit).toFixed();
+        } else if (internalSwapRoutes && internalSwapRoutes.length > 0) {
+          const allRoutesLength = internalSwapRoutes.reduce(
+            (acc, cur) => acc.plus(cur.subRoutes?.flat().length ?? 1),
+            new BigNumber(0),
+          );
+          specialGasLimit = new BigNumber(baseGasLimit ?? 0)
+            .times(
+              allRoutesLength
+                .plus(BATCH_SEND_TXS_FEE_UP_RATIO_FOR_SWAP)
+                .plus(BATCH_APPROVE_GAS_FEE_RATIO_FOR_SWAP),
+            )
+            .toFixed();
+        } else {
+          specialGasLimit = new BigNumber(baseGasLimit ?? 0)
+            .times(
+              new BigNumber(BATCH_SEND_TXS_FEE_UP_RATIO_FOR_SWAP).plus(
+                BATCH_APPROVE_GAS_FEE_RATIO_FOR_SWAP,
+              ),
+            )
+            .toFixed();
+        }
+
+        gasInfos.push({
+          encodeTx: unsignedTxItem.encodedTx,
+          gasInfo: {
+            common: lastTxUseGasInfo?.common,
+            gas: lastTxUseGasInfo?.gas
+              ? {
+                  ...lastTxUseGasInfo.gas,
+                  gasLimit: specialGasLimit ?? lastTxUseGasInfo.gas.gasLimit,
+                }
+              : undefined,
+            gasEIP1559: lastTxUseGasInfo?.gasEIP1559
+              ? {
+                  ...lastTxUseGasInfo.gasEIP1559,
+                  gasLimit:
+                    specialGasLimit ?? lastTxUseGasInfo.gasEIP1559.gasLimit,
+                }
+              : undefined,
+          },
+        });
+      } else {
+        const estimateFeeParams =
+          await backgroundApiProxy.serviceGas.buildEstimateFeeParams({
+            networkId,
+            accountId,
+            encodedTx: unsignedTxItem.encodedTx,
+          });
+        const gasRes = await backgroundApiProxy.serviceGas.estimateFee({
+          ...estimateFeeParams,
+          accountAddress,
+          networkId,
+          accountId,
+        });
+        const gasInfo = buildGasInfo(gasRes, gasRes.common, networkFeeLevel);
+
+        if (i === unsignedTxArr.length - 2) {
+          lastTxUseGasInfo = gasInfo as IFeeInfoUnit;
+        }
+
+        gasInfos.push({
+          encodeTx: unsignedTxItem.encodedTx,
+          gasInfo,
+        });
+      }
+    }
+
+    return gasInfos;
+  }
+
+  const estimateFeeParams =
+    await backgroundApiProxy.serviceGas.buildEstimateFeeParams({
+      networkId,
+      accountId,
+      encodedTx: unsignedTx.encodedTx,
+    });
+  const gasRes = await backgroundApiProxy.serviceGas.estimateFee({
+    ...estimateFeeParams,
+    accountAddress,
+    networkId,
+    accountId,
+  });
+
+  return [
+    {
+      encodeTx: unsignedTx.encodedTx,
+      gasInfo: buildGasInfo(gasRes, gasRes.common, networkFeeLevel),
+    },
+  ];
+}
+
+function buildGasFeeFiatValue(gasInfos: IMarketGasInfoEntry[]) {
+  const gasFeeFiatValue = gasInfos.reduce((acc, item) => {
+    const feeResult = calculateFeeForSend({
+      feeInfo: item.gasInfo as IFeeInfoUnit,
+      nativeTokenPrice: item.gasInfo.common?.nativeTokenPrice ?? 0,
+    });
+
+    return acc.plus(new BigNumber(feeResult.totalFiatMinForDisplay));
+  }, new BigNumber(0));
+
+  return gasFeeFiatValue.isZero() ? undefined : gasFeeFiatValue.toFixed();
+}
+
+export async function estimateMarketDirectGasInfos({
+  accountAddress,
+  accountId,
+  networkId,
+  buildUnsignedParams,
+  approveUnsignedTxArr,
+  networkFeeLevel,
+}: IEstimateMarketDirectGasInfosParams): Promise<{
+  gasInfos: IMarketGasInfoEntry[];
+  gasFeeFiatValue?: string;
+  preparedUnsignedTx: IUnsignedTxPro;
+}> {
+  if (!accountId || !networkId || !accountAddress) {
+    throw new OneKeyError('account error');
+  }
+
+  const buildUnsignedParamsCheckNonce = { ...buildUnsignedParams };
+  if (approveUnsignedTxArr?.length) {
+    buildUnsignedParamsCheckNonce.prevNonce =
+      approveUnsignedTxArr[approveUnsignedTxArr.length - 1].nonce;
+  }
+
+  const unsignedTx =
+    await backgroundApiProxy.serviceSend.prepareSendConfirmUnsignedTx({
+      ...buildUnsignedParamsCheckNonce,
+      isInternalSwap: true,
+    });
+
+  const gasInfos = await resolveMarketGasInfos({
+    accountAddress,
+    accountId,
+    networkId,
+    unsignedTx,
+    approveUnsignedTxArr,
+    networkFeeLevel,
+  });
+
+  return {
+    gasInfos,
+    gasFeeFiatValue: buildGasFeeFiatValue(gasInfos),
+    preparedUnsignedTx: unsignedTx,
+  };
+}
+
+async function updateUnsignedTxAndSendTx({
+  accountId,
+  networkId,
+  unsignedTxItem,
+  gasInfo,
+}: {
+  accountId: string;
+  networkId: string;
+  unsignedTxItem: IUnsignedTxPro;
+  gasInfo: ISwapGasInfo;
+}): Promise<ISendTxOnSuccessData> {
+  if (!gasInfo.common) {
+    throw new OneKeyError('gasInfo.common is required');
+  }
+
+  const updatedUnsignedTxItem =
+    await backgroundApiProxy.serviceSend.updateUnsignedTx({
+      networkId,
+      accountId,
+      unsignedTx: unsignedTxItem,
+      feeInfo: {
+        common: {
+          baseFee: gasInfo.common.baseFee,
+          feeDecimals: gasInfo.common.feeDecimals,
+          feeSymbol: gasInfo.common.feeSymbol,
+          nativeDecimals: gasInfo.common.nativeDecimals,
+          nativeSymbol: gasInfo.common.nativeSymbol,
+          nativeTokenPrice: gasInfo.common.nativeTokenPrice,
+        },
+        gas: gasInfo.gas,
+        gasEIP1559: gasInfo.gasEIP1559,
+        feeUTXO: gasInfo.feeUTXO,
+        feeTron: gasInfo.feeTron,
+        feeSol: gasInfo.feeSol,
+        feeCkb: gasInfo.feeCkb,
+        feeAlgo: gasInfo.feeAlgo,
+        feeDot: gasInfo.feeDot,
+        feeBudget: gasInfo.feeBudget,
+      },
+    });
+
+  await backgroundApiProxy.serviceSend.precheckUnsignedTxs({
+    networkId,
+    accountId,
+    unsignedTxs: [updatedUnsignedTxItem],
+    precheckTiming: ESendPreCheckTimingEnum.Confirm,
+  });
+
+  const {
+    totalNative,
+    total,
+    totalFiat,
+    totalFiatForDisplay,
+    totalNativeForDisplay,
+  } = calculateFeeForSend({
+    feeInfo: gasInfo as IFeeInfoUnit,
+    nativeTokenPrice: gasInfo.common.nativeTokenPrice ?? 0,
+  });
+
+  await backgroundApiProxy.serviceTransaction.verifyTransaction({
+    networkId,
+    accountId,
+    verifyTxTasks: ['feeInfo'],
+    verifyTxFeeInfoParams: {
+      feeAmount: totalNative,
+      feeTokenSymbol: gasInfo.common.nativeSymbol,
+      doubleConfirm: true,
+    },
+    encodedTx: updatedUnsignedTxItem.encodedTx,
+  });
+
+  const signedTx = await backgroundApiProxy.serviceSend.signAndSendTransaction({
+    networkId,
+    accountId,
+    unsignedTx: updatedUnsignedTxItem,
+    signOnly: false,
+  });
+
+  const decodedTx = await backgroundApiProxy.serviceSend.buildDecodedTx({
+    networkId,
+    accountId,
+    unsignedTx: updatedUnsignedTxItem,
+    feeInfo: {
+      feeInfo: gasInfo as IFeeInfoUnit,
+      total,
+      totalNative,
+      totalFiat,
+      totalNativeForDisplay,
+      totalFiatForDisplay,
+    },
+    saveToLocalHistory: true,
+  });
+
+  await backgroundApiProxy.serviceHistory.saveSendConfirmHistoryTxs({
+    networkId,
+    accountId,
+    data: {
+      signedTx,
+      decodedTx,
+      approveInfo: updatedUnsignedTxItem.approveInfo,
+      feeInfo: gasInfo as IFeeInfoUnit,
+    },
+  });
+
+  return {
+    signedTx,
+    decodedTx,
+    approveInfo: updatedUnsignedTxItem.approveInfo,
+    feeInfo: gasInfo as IFeeInfoUnit,
+  };
+}
+
+export async function sendMarketDirectUnsignedTxs({
+  accountAddress,
+  accountId,
+  networkId,
+  buildUnsignedParams,
+  approveUnsignedTxArr,
+  gasInfos = [],
+  networkFeeLevel,
+}: IMarketDirectSendParams): Promise<ISendTxOnSuccessData[]> {
+  if (!accountId || !networkId || !accountAddress) {
+    throw new OneKeyError('account error');
+  }
+
+  const buildUnsignedParamsCheckNonce = { ...buildUnsignedParams };
+  if (approveUnsignedTxArr?.length) {
+    buildUnsignedParamsCheckNonce.prevNonce =
+      approveUnsignedTxArr[approveUnsignedTxArr.length - 1].nonce;
+  }
+
+  const unsignedTx =
+    await backgroundApiProxy.serviceSend.prepareSendConfirmUnsignedTx({
+      ...buildUnsignedParamsCheckNonce,
+      isInternalSwap: true,
+    });
+
+  const results: ISendTxOnSuccessData[] = [];
+  const unsignedTxArr = buildUnsignedTxArr({
+    unsignedTx,
+    approveUnsignedTxArr,
+  });
+  let gasInfosFinal = gasInfos;
+
+  if (!unsignedTxArr.every((tx) => findGasInfo(gasInfosFinal, tx.encodedTx))) {
+    gasInfosFinal = await resolveMarketGasInfos({
+      accountAddress,
+      accountId,
+      networkId,
+      unsignedTx,
+      approveUnsignedTxArr,
+      networkFeeLevel,
+    });
+  }
+
+  for (const unsignedTxItem of unsignedTxArr) {
+    const gasInfo = findGasInfo(
+      gasInfosFinal,
+      unsignedTxItem.encodedTx,
+    )?.gasInfo;
+    if (!gasInfo) {
+      throw new OneKeyError('gas info not found');
+    }
+
+    results.push(
+      await updateUnsignedTxAndSendTx({
+        accountId,
+        networkId,
+        unsignedTxItem,
+        gasInfo,
+      }),
+    );
+  }
+
+  return results;
+}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.ts
@@ -302,6 +302,78 @@ async function resolveMarketGasInfos({
   ];
 }
 
+async function resolveExactUnsignedTxGasInfos({
+  accountAddress,
+  accountId,
+  networkId,
+  unsignedTxArr,
+  networkFeeLevel,
+}: {
+  accountAddress: string;
+  accountId: string;
+  networkId: string;
+  unsignedTxArr: IUnsignedTxPro[];
+  networkFeeLevel?: ESwapNetworkFeeLevel;
+}): Promise<IMarketGasInfoEntry[]> {
+  const gasInfos: IMarketGasInfoEntry[] = [];
+  const vaultSettings =
+    await backgroundApiProxy.serviceNetwork.getVaultSettings({
+      networkId,
+    });
+
+  if (
+    unsignedTxArr.length > 1 &&
+    vaultSettings.supportBatchEstimateFee?.[networkId]
+  ) {
+    const estimateFeeParamsArr = await Promise.all(
+      unsignedTxArr.map((item) =>
+        backgroundApiProxy.serviceGas.buildEstimateFeeParams({
+          networkId,
+          accountId,
+          encodedTx: item.encodedTx,
+        }),
+      ),
+    );
+
+    const gasResArr = await backgroundApiProxy.serviceGas.batchEstimateFee({
+      networkId,
+      accountId,
+      encodedTxs: estimateFeeParamsArr.map((item) => item.encodedTx ?? {}),
+    });
+
+    return unsignedTxArr.map((unsignedTxItem, index) => ({
+      encodeTx: unsignedTxItem.encodedTx,
+      gasInfo: buildGasInfo(
+        gasResArr.txFees[index],
+        gasResArr.common,
+        networkFeeLevel,
+      ),
+    }));
+  }
+
+  for (const unsignedTxItem of unsignedTxArr) {
+    const estimateFeeParams =
+      await backgroundApiProxy.serviceGas.buildEstimateFeeParams({
+        networkId,
+        accountId,
+        encodedTx: unsignedTxItem.encodedTx,
+      });
+    const gasRes = await backgroundApiProxy.serviceGas.estimateFee({
+      ...estimateFeeParams,
+      accountAddress,
+      networkId,
+      accountId,
+    });
+
+    gasInfos.push({
+      encodeTx: unsignedTxItem.encodedTx,
+      gasInfo: buildGasInfo(gasRes, gasRes.common, networkFeeLevel),
+    });
+  }
+
+  return gasInfos;
+}
+
 function buildGasFeeFiatValue(gasInfos: IMarketGasInfoEntry[]) {
   const gasFeeFiatValue = gasInfos.reduce((acc, item) => {
     const feeResult = calculateFeeForSend({
@@ -356,6 +428,47 @@ export async function estimateMarketDirectGasInfos({
     gasInfos,
     gasFeeFiatValue: buildGasFeeFiatValue(gasInfos),
     preparedUnsignedTx: unsignedTx,
+  };
+}
+
+export async function estimateMarketApproveGasInfos({
+  accountAddress,
+  accountId,
+  networkId,
+  approveUnsignedTxArr,
+  networkFeeLevel,
+}: {
+  accountAddress: string;
+  accountId: string;
+  networkId: string;
+  approveUnsignedTxArr: IUnsignedTxPro[];
+  networkFeeLevel?: ESwapNetworkFeeLevel;
+}): Promise<{
+  gasInfos: IMarketGasInfoEntry[];
+  gasFeeFiatValue?: string;
+}> {
+  if (!accountId || !networkId || !accountAddress) {
+    throw new OneKeyError('account error');
+  }
+
+  if (!approveUnsignedTxArr.length) {
+    return {
+      gasInfos: [],
+      gasFeeFiatValue: undefined,
+    };
+  }
+
+  const gasInfos = await resolveExactUnsignedTxGasInfos({
+    accountAddress,
+    accountId,
+    networkId,
+    unsignedTxArr: approveUnsignedTxArr,
+    networkFeeLevel,
+  });
+
+  return {
+    gasInfos,
+    gasFeeFiatValue: buildGasFeeFiatValue(gasInfos),
   };
 }
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketReviewAllowance.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketReviewAllowance.test.ts
@@ -1,0 +1,129 @@
+const mockFetchApproveAllowance = jest.fn();
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {
+    serviceSwap: {
+      fetchApproveAllowance: mockFetchApproveAllowance,
+    },
+  },
+}));
+
+const { resolveMarketReviewAllowanceState } =
+  require('./marketReviewAllowance') as typeof import('./marketReviewAllowance');
+
+describe('marketReviewAllowance', () => {
+  beforeEach(() => {
+    mockFetchApproveAllowance.mockReset();
+  });
+
+  it('returns approve-required state from the latest allowance response', async () => {
+    mockFetchApproveAllowance.mockResolvedValue({
+      isApproved: false,
+      allowanceTarget: '0xspender-next',
+      shouldResetApprove: false,
+    });
+
+    const result = await resolveMarketReviewAllowanceState({
+      amount: '1',
+      currentState: {
+        allowanceTarget: '0xspender-prev',
+        shouldApprove: false,
+        shouldResetApprove: false,
+      },
+      spenderAddress: '0xspender-prev',
+      token: {
+        networkId: 'evm--1',
+        contractAddress: '0xtoken',
+        symbol: 'USDC',
+        decimals: 6,
+      },
+      walletAddress: '0xuser',
+    });
+
+    expect(mockFetchApproveAllowance).toHaveBeenCalledWith({
+      networkId: 'evm--1',
+      tokenAddress: '0xtoken',
+      spenderAddress: '0xspender-prev',
+      walletAddress: '0xuser',
+      amount: '1',
+    });
+    expect(result).toEqual({
+      allowanceTarget: '0xspender-next',
+      shouldApprove: true,
+      shouldResetApprove: false,
+    });
+  });
+
+  it('fails fast when the allowance refresh fails for the same spender', async () => {
+    mockFetchApproveAllowance.mockRejectedValue(new Error('network error'));
+
+    await expect(
+      resolveMarketReviewAllowanceState({
+        amount: '1',
+        currentState: {
+          allowanceTarget: '0xspender-prev',
+          shouldApprove: true,
+          shouldResetApprove: true,
+        },
+        spenderAddress: '0xspender-prev',
+        token: {
+          networkId: 'evm--1',
+          contractAddress: '0xtoken',
+          symbol: 'USDC',
+          decimals: 6,
+        },
+        walletAddress: '0xuser',
+      }),
+    ).rejects.toThrow('Market allowance refresh failed.');
+  });
+
+  it('fails fast when the allowance refresh fails for a new spender', async () => {
+    mockFetchApproveAllowance.mockRejectedValue(new Error('network error'));
+
+    await expect(
+      resolveMarketReviewAllowanceState({
+        amount: '1',
+        currentState: {
+          allowanceTarget: '0xspender-prev',
+          shouldApprove: false,
+          shouldResetApprove: false,
+        },
+        spenderAddress: '0xspender-next',
+        token: {
+          networkId: 'evm--1',
+          contractAddress: '0xtoken',
+          symbol: 'USDC',
+          decimals: 6,
+        },
+        walletAddress: '0xuser',
+      }),
+    ).rejects.toThrow('Market allowance refresh failed.');
+  });
+
+  it('skips allowance refresh when approve is not applicable', async () => {
+    const result = await resolveMarketReviewAllowanceState({
+      amount: '0',
+      currentState: {
+        allowanceTarget: '0xspender-prev',
+        shouldApprove: true,
+        shouldResetApprove: true,
+      },
+      spenderAddress: '0xspender-prev',
+      token: {
+        networkId: 'evm--1',
+        contractAddress: '0xtoken',
+        symbol: 'USDC',
+        decimals: 6,
+      },
+      walletAddress: '0xuser',
+    });
+
+    expect(mockFetchApproveAllowance).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      allowanceTarget: '0xspender-prev',
+      shouldApprove: false,
+      shouldResetApprove: false,
+    });
+  });
+});

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketReviewAllowance.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketReviewAllowance.ts
@@ -1,0 +1,66 @@
+import BigNumber from 'bignumber.js';
+
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import type { ISwapTokenBase } from '@onekeyhq/shared/types/swap/types';
+
+export type IMarketReviewAllowanceState = {
+  allowanceTarget?: string;
+  shouldApprove: boolean;
+  shouldResetApprove: boolean;
+};
+
+type IResolveMarketReviewAllowanceStateParams = {
+  amount: string;
+  currentState: IMarketReviewAllowanceState;
+  isWrapped?: boolean;
+  spenderAddress?: string;
+  token: ISwapTokenBase;
+  walletAddress?: string;
+};
+
+export async function resolveMarketReviewAllowanceState({
+  amount,
+  currentState: _currentState,
+  isWrapped,
+  spenderAddress,
+  token,
+  walletAddress,
+}: IResolveMarketReviewAllowanceStateParams): Promise<IMarketReviewAllowanceState> {
+  const amountBN = new BigNumber(amount || 0);
+
+  if (
+    !spenderAddress ||
+    !walletAddress ||
+    amountBN.isNaN() ||
+    amountBN.lte(0) ||
+    token.isNative ||
+    !token.contractAddress ||
+    isWrapped
+  ) {
+    return {
+      allowanceTarget: spenderAddress,
+      shouldApprove: false,
+      shouldResetApprove: false,
+    };
+  }
+
+  try {
+    const approveRes =
+      await backgroundApiProxy.serviceSwap.fetchApproveAllowance({
+        networkId: token.networkId,
+        tokenAddress: token.contractAddress,
+        spenderAddress,
+        walletAddress,
+        amount,
+      });
+
+    return {
+      allowanceTarget: approveRes.allowanceTarget || spenderAddress,
+      shouldApprove: !approveRes.isApproved,
+      shouldResetApprove: !!approveRes.shouldResetApprove,
+    };
+  } catch {
+    throw new OneKeyLocalError('Market allowance refresh failed.');
+  }
+}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketReviewExecutionUtils.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketReviewExecutionUtils.test.ts
@@ -107,6 +107,38 @@ describe('marketReviewExecutionUtils', () => {
     expect(reviewState.preSwapData.supportNetworkFeeLevel).toBe(true);
   });
 
+  it('keeps approve fee editing visible for approve and sign flows', () => {
+    const reviewState = buildMarketReviewState({
+      accountId: 'account-1',
+      networkId: fromToken.networkId,
+      fromToken,
+      toToken,
+      fromTokenAmount: '1',
+      toTokenAmount: '2500',
+      quoteResult: createQuoteResult({
+        allowanceResult: {
+          allowanceTarget: '0xspender',
+          amount: '1',
+        },
+        swapShouldSignedData: {
+          unSignedInfo: {
+            origin: 'origin',
+            scope: 'scope',
+            signedType: 'eth_signTypedData_v4' as never,
+          },
+        } as never,
+      }),
+      slippage: 1,
+      texts,
+    });
+
+    expect(reviewState.steps.map((step) => step.type)).toEqual([
+      ESwapStepType.APPROVE_TX,
+      ESwapStepType.SIGN_MESSAGE,
+    ]);
+    expect(reviewState.preSwapData.supportNetworkFeeLevel).toBe(true);
+  });
+
   it('matches the selected tx fee info by encoded tx', () => {
     const feeInfo = findMarketTxConfirmFeeInfo({
       gasInfos: [

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketReviewExecutionUtils.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketReviewExecutionUtils.test.ts
@@ -1,0 +1,184 @@
+import type { IEncodedTx } from '@onekeyhq/core/src/types';
+import type {
+  IFetchQuoteResult,
+  ISwapApproveTransaction,
+  ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
+import {
+  EProtocolOfExchange,
+  ESwapApproveTransactionStatus,
+  ESwapStepType,
+} from '@onekeyhq/shared/types/swap/types';
+
+import {
+  buildMarketReviewState,
+  findMarketTxConfirmFeeInfo,
+  shouldAutoContinueMarketResetApprove,
+} from './marketReviewExecutionUtils';
+
+const fromToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xfrom',
+  symbol: 'ETH',
+  decimals: 18,
+  isNative: true,
+};
+
+const toToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xto',
+  symbol: 'USDC',
+  decimals: 6,
+  isNative: false,
+};
+
+const texts = {
+  wrap: 'Wrap',
+  approveAndSwap: 'Approve and Swap',
+  approveAndSign: 'Approve and Sign',
+  revokeApprove: 'Revoke Approve',
+  approveToken: 'Approve Token',
+  approveTokenWithTarget: 'Approve Token',
+  signAndSubmit: 'Sign and Submit',
+  sign: 'Sign',
+  confirmSwap: 'Confirm Swap',
+  swap: 'Swap',
+};
+
+function createQuoteResult(
+  overrides: Partial<IFetchQuoteResult> = {},
+): IFetchQuoteResult {
+  return {
+    protocol: EProtocolOfExchange.SWAP,
+    info: {
+      provider: 'onekey',
+      providerName: 'OneKey',
+    },
+    fromTokenInfo: fromToken,
+    toTokenInfo: toToken,
+    fromAmount: '1',
+    toAmount: '2500',
+    ...overrides,
+  };
+}
+
+describe('marketReviewExecutionUtils', () => {
+  it('keeps the Market review flow on separate approve then send steps', () => {
+    const reviewState = buildMarketReviewState({
+      accountId: 'account-1',
+      networkId: fromToken.networkId,
+      fromToken,
+      toToken,
+      fromTokenAmount: '1',
+      toTokenAmount: '2500',
+      quoteResult: createQuoteResult({
+        allowanceResult: {
+          allowanceTarget: '0xspender',
+          amount: '1',
+        },
+      }),
+      slippage: 1,
+      texts,
+    });
+
+    expect(reviewState.steps.map((step) => step.type)).toEqual([
+      ESwapStepType.APPROVE_TX,
+      ESwapStepType.SEND_TX,
+    ]);
+  });
+
+  it('keeps wrap preview prebuild enabled so fee switching stays connected', () => {
+    const reviewState = buildMarketReviewState({
+      accountId: 'account-1',
+      networkId: fromToken.networkId,
+      fromToken,
+      toToken,
+      fromTokenAmount: '1',
+      toTokenAmount: '1',
+      quoteResult: createQuoteResult({
+        isWrapped: true,
+        toAmount: '1',
+      }),
+      slippage: 1,
+      texts,
+    });
+
+    expect(reviewState.preSwapData.supportPreBuild).toBe(true);
+    expect(reviewState.preSwapData.supportNetworkFeeLevel).toBe(true);
+  });
+
+  it('matches the selected tx fee info by encoded tx', () => {
+    const feeInfo = findMarketTxConfirmFeeInfo({
+      gasInfos: [
+        {
+          encodeTx: {
+            data: '0xapprove',
+          } as IEncodedTx,
+          gasInfo: {
+            common: {
+              feeDecimals: 18,
+              feeSymbol: 'ETH',
+              nativeDecimals: 18,
+              nativeSymbol: 'ETH',
+            },
+            gas: {
+              gasPrice: '1',
+              gasLimit: '21000',
+            },
+          } as never,
+        },
+        {
+          encodeTx: {
+            data: '0xswap',
+          } as IEncodedTx,
+          gasInfo: {
+            common: {
+              feeDecimals: 18,
+              feeSymbol: 'ETH',
+              nativeDecimals: 18,
+              nativeSymbol: 'ETH',
+            },
+            gas: {
+              gasPrice: '3',
+              gasLimit: '23000',
+            },
+          } as never,
+        },
+      ],
+      encodedTx: {
+        data: '0xswap',
+      } as IEncodedTx,
+    });
+
+    expect(feeInfo?.gas?.gasPrice).toBe('3');
+  });
+
+  it('auto-continues reset approve only after the review dialog is closed', () => {
+    const approvedSwapInfo: ISwapApproveTransaction = {
+      fromToken,
+      toToken,
+      protocol: EProtocolOfExchange.SWAP,
+      swapType: 'swap' as never,
+      provider: 'onekey',
+      providerName: 'OneKey',
+      useAddress: '0xuser',
+      spenderAddress: '0xspender',
+      amount: '1',
+      status: ESwapApproveTransactionStatus.SUCCESS,
+      resetApproveValue: '1',
+    };
+
+    expect(
+      shouldAutoContinueMarketResetApprove({
+        approvedSwapInfo,
+        isReviewDialogOpen: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldAutoContinueMarketResetApprove({
+        approvedSwapInfo,
+        isReviewDialogOpen: false,
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketReviewExecutionUtils.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketReviewExecutionUtils.ts
@@ -1,0 +1,103 @@
+import { isEqual } from 'lodash';
+
+import type { IEncodedTx } from '@onekeyhq/core/src/types';
+import {
+  type ISwapReviewStepTexts,
+  buildSwapReviewState,
+} from '@onekeyhq/kit/src/views/Swap/utils/buildSwapReviewState';
+import type { IFeeInfoUnit } from '@onekeyhq/shared/types/fee';
+import type {
+  IFetchQuoteResult,
+  ISwapApproveTransaction,
+  ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
+import {
+  ESwapApproveTransactionStatus,
+  ESwapTabSwitchType,
+} from '@onekeyhq/shared/types/swap/types';
+
+import type { IMarketGasInfoEntry } from './marketDirectSendTx';
+
+export function buildMarketReviewState({
+  accountId,
+  networkId,
+  fromToken,
+  toToken,
+  fromTokenAmount,
+  toTokenAmount,
+  quoteResult,
+  shouldFallback,
+  slippage,
+  texts,
+}: {
+  accountId?: string;
+  networkId?: string;
+  fromToken?: ISwapToken;
+  toToken?: ISwapToken;
+  fromTokenAmount?: string;
+  toTokenAmount?: string;
+  quoteResult?: IFetchQuoteResult;
+  shouldFallback?: boolean;
+  slippage?: number;
+  texts: ISwapReviewStepTexts;
+}) {
+  return buildSwapReviewState({
+    accountId,
+    networkId,
+    // Market preview reuses the Swap interaction only.
+    // The old Market execution stays approve -> confirm -> send, no batch shortcut.
+    batchApproveAndSwapEnabled: false,
+    fromToken,
+    toToken,
+    fromTokenAmount,
+    toTokenAmount,
+    quoteResult,
+    swapType: ESwapTabSwitchType.SWAP,
+    shouldFallback,
+    // Old Market tx confirm supported fee editing for wrap/swap,
+    // so preview prebuild should stay enabled for every path.
+    supportPreBuild: true,
+    slippage,
+    texts,
+  });
+}
+
+export function findMarketTxConfirmFeeInfo({
+  gasInfos,
+  encodedTx,
+}: {
+  gasInfos?: IMarketGasInfoEntry[];
+  encodedTx?: IEncodedTx;
+}): IFeeInfoUnit | undefined {
+  if (!gasInfos?.length || !encodedTx) {
+    return undefined;
+  }
+
+  return gasInfos.find(
+    (item) =>
+      isEqual(item.encodeTx, encodedTx) ||
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      ((item.encodeTx as any)?.rawSignTx &&
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (encodedTx as any)?.rawSignTx &&
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (item.encodeTx as any)?.rawSignTx ===
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          (encodedTx as any)?.rawSignTx),
+  )?.gasInfo as IFeeInfoUnit | undefined;
+}
+
+export function shouldAutoContinueMarketResetApprove({
+  approvedSwapInfo,
+  isReviewDialogOpen,
+}: {
+  approvedSwapInfo?: ISwapApproveTransaction;
+  isReviewDialogOpen?: boolean;
+}) {
+  return Boolean(
+    !isReviewDialogOpen &&
+    approvedSwapInfo?.status === ESwapApproveTransactionStatus.SUCCESS &&
+    approvedSwapInfo.resetApproveValue &&
+    Number(approvedSwapInfo.resetApproveValue) > 0,
+  );
+}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketReviewExecutionUtils.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketReviewExecutionUtils.ts
@@ -9,14 +9,20 @@ import type { IFeeInfoUnit } from '@onekeyhq/shared/types/fee';
 import type {
   IFetchQuoteResult,
   ISwapApproveTransaction,
+  ISwapStep,
   ISwapToken,
 } from '@onekeyhq/shared/types/swap/types';
 import {
   ESwapApproveTransactionStatus,
+  ESwapStepType,
   ESwapTabSwitchType,
 } from '@onekeyhq/shared/types/swap/types';
 
 import type { IMarketGasInfoEntry } from './marketDirectSendTx';
+
+function shouldEnableMarketReviewFeeLevel(steps: ISwapStep[]) {
+  return steps.some((step) => step.type === ESwapStepType.APPROVE_TX);
+}
 
 export function buildMarketReviewState({
   accountId,
@@ -41,7 +47,7 @@ export function buildMarketReviewState({
   slippage?: number;
   texts: ISwapReviewStepTexts;
 }) {
-  return buildSwapReviewState({
+  const reviewState = buildSwapReviewState({
     accountId,
     networkId,
     // Market preview reuses the Swap interaction only.
@@ -60,6 +66,15 @@ export function buildMarketReviewState({
     slippage,
     texts,
   });
+
+  if (shouldEnableMarketReviewFeeLevel(reviewState.steps)) {
+    reviewState.preSwapData = {
+      ...reviewState.preSwapData,
+      supportNetworkFeeLevel: true,
+    };
+  }
+
+  return reviewState;
 }
 
 export function findMarketTxConfirmFeeInfo({

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.test.ts
@@ -4,6 +4,7 @@ import type {
 } from '@onekeyhq/shared/types/swap/types';
 
 import {
+  buildDefaultMarketSpeedCheckState,
   buildMarketReviewShouldFallback,
   mergeMarketBuildResultWithQuote,
   pickMarketQuoteResultByProvider,
@@ -79,6 +80,16 @@ describe('marketSwapBuildUtils', () => {
     ).toBe(true);
   });
 
+  it('builds a full default speed-check reset state', () => {
+    expect(buildDefaultMarketSpeedCheckState()).toEqual({
+      speedCheckError: '',
+      checkSpenderAddress: '',
+      isStock: false,
+      shouldApprove: false,
+      shouldResetApprove: false,
+    });
+  });
+
   it('detects when Market build data needs quote fallbacks', () => {
     expect(
       shouldFetchMarketQuoteFallbackData(
@@ -131,11 +142,13 @@ describe('marketSwapBuildUtils', () => {
       }),
       quoteResult: createQuoteResult({
         gasLimit: 45_678,
+        minToAmount: '950',
         routesData: [{ subRoutes: [[{}]] }] as never,
       }),
     });
 
     expect(merged.result.gasLimit).toBe(45_678);
+    expect(merged.result.minToAmount).toBe('950');
     expect(merged.result.routesData).toHaveLength(1);
   });
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.test.ts
@@ -1,0 +1,162 @@
+import type {
+  IFetchBuildTxResponse,
+  IFetchQuoteResult,
+} from '@onekeyhq/shared/types/swap/types';
+
+import {
+  buildMarketReviewShouldFallback,
+  mergeMarketBuildResultWithQuote,
+  pickMarketQuoteResultByProvider,
+  shouldFetchMarketQuoteFallbackData,
+} from './marketSwapBuildUtils';
+
+function createQuoteResult(
+  overrides: Partial<IFetchQuoteResult> = {},
+): IFetchQuoteResult {
+  return {
+    info: {
+      provider: 'provider-a',
+      providerName: 'Provider A',
+    },
+    fromTokenInfo: {
+      networkId: 'evm--1',
+      contractAddress: '0xfrom',
+      symbol: 'ETH',
+      decimals: 18,
+      isNative: true,
+    },
+    toTokenInfo: {
+      networkId: 'evm--1',
+      contractAddress: '0xto',
+      symbol: 'USDC',
+      decimals: 6,
+      isNative: false,
+    },
+    fromAmount: '1',
+    toAmount: '1000',
+    ...overrides,
+  };
+}
+
+function createBuildRes(
+  overrides: Partial<IFetchBuildTxResponse> = {},
+): IFetchBuildTxResponse {
+  return {
+    result: {
+      info: {
+        provider: 'provider-a',
+        providerName: 'Provider A',
+      },
+      fromTokenInfo: createQuoteResult().fromTokenInfo,
+      toTokenInfo: createQuoteResult().toTokenInfo,
+      fromAmount: '1',
+      toAmount: '1000',
+    },
+    ...overrides,
+  } as IFetchBuildTxResponse;
+}
+
+describe('marketSwapBuildUtils', () => {
+  it('aligns Market fallback logic with Swap fallback networks', () => {
+    expect(
+      buildMarketReviewShouldFallback({
+        networkId: 'tron--0x2b6653dc',
+      }),
+    ).toBe(true);
+    expect(
+      buildMarketReviewShouldFallback({
+        networkId: 'evm--1',
+      }),
+    ).toBe(false);
+  });
+
+  it('falls back when custom RPC is unavailable', () => {
+    expect(
+      buildMarketReviewShouldFallback({
+        networkId: 'evm--1',
+        isCustomRpcUnavailable: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('detects when Market build data needs quote fallbacks', () => {
+    expect(
+      shouldFetchMarketQuoteFallbackData(
+        createBuildRes({
+          result: {
+            ...createBuildRes().result,
+            gasLimit: 0,
+          },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldFetchMarketQuoteFallbackData(
+        createBuildRes({
+          result: {
+            ...createBuildRes().result,
+            gasLimit: 21_000,
+            routesData: [{ subRoutes: [] }] as never,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('picks the matching quote by provider and provider name', () => {
+    const matchedQuote = createQuoteResult({
+      info: {
+        provider: 'provider-b',
+        providerName: 'Provider B',
+      },
+    });
+    const fallbackQuote = createQuoteResult();
+
+    expect(
+      pickMarketQuoteResultByProvider({
+        quotes: [fallbackQuote, matchedQuote],
+        provider: 'provider-b',
+        providerName: 'Provider B',
+      }),
+    ).toBe(matchedQuote);
+  });
+
+  it('hydrates missing gasLimit and routesData from the selected quote', () => {
+    const merged = mergeMarketBuildResultWithQuote({
+      buildRes: createBuildRes({
+        result: {
+          ...createBuildRes().result,
+          gasLimit: 0,
+        },
+      }),
+      quoteResult: createQuoteResult({
+        gasLimit: 45_678,
+        routesData: [{ subRoutes: [[{}]] }] as never,
+      }),
+    });
+
+    expect(merged.result.gasLimit).toBe(45_678);
+    expect(merged.result.routesData).toHaveLength(1);
+  });
+
+  it('does not overwrite build result fields that are already present', () => {
+    const merged = mergeMarketBuildResultWithQuote({
+      buildRes: createBuildRes({
+        result: {
+          ...createBuildRes().result,
+          gasLimit: 12_345,
+          routesData: [{ subRoutes: [[{ id: 'build' }]] }] as never,
+        },
+      }),
+      quoteResult: createQuoteResult({
+        gasLimit: 45_678,
+        routesData: [{ subRoutes: [[{ id: 'quote' }]] }] as never,
+      }),
+    });
+
+    expect(merged.result.gasLimit).toBe(12_345);
+    expect(merged.result.routesData?.[0]?.subRoutes?.[0]?.[0]).toEqual({
+      id: 'build',
+    });
+  });
+});

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.ts
@@ -1,0 +1,91 @@
+import BigNumber from 'bignumber.js';
+
+import type {
+  IFetchBuildTxResponse,
+  IFetchQuoteResult,
+} from '@onekeyhq/shared/types/swap/types';
+import { SwapBuildShouldFallBackNetworkIds } from '@onekeyhq/shared/types/swap/types';
+
+export function buildMarketReviewShouldFallback({
+  networkId,
+  isCustomRpcUnavailable,
+}: {
+  networkId?: string;
+  isCustomRpcUnavailable?: boolean;
+}) {
+  return (
+    SwapBuildShouldFallBackNetworkIds.includes(networkId ?? '') ||
+    Boolean(isCustomRpcUnavailable)
+  );
+}
+
+export function shouldFetchMarketQuoteFallbackData(
+  buildRes?: IFetchBuildTxResponse,
+) {
+  const buildGasLimitBN = new BigNumber(buildRes?.result?.gasLimit ?? 0);
+
+  return (
+    buildGasLimitBN.isNaN() ||
+    buildGasLimitBN.isZero() ||
+    !buildRes?.result?.routesData?.length
+  );
+}
+
+export function pickMarketQuoteResultByProvider({
+  quotes,
+  provider,
+  providerName,
+}: {
+  quotes?: IFetchQuoteResult[];
+  provider?: string;
+  providerName?: string;
+}) {
+  if (!quotes?.length) {
+    return undefined;
+  }
+
+  return (
+    quotes.find(
+      (item) =>
+        item.info.provider === provider &&
+        item.info.providerName === providerName,
+    ) ??
+    quotes.find((item) => item.info.provider === provider) ??
+    quotes.find((item) => item.info.providerName === providerName)
+  );
+}
+
+export function mergeMarketBuildResultWithQuote({
+  buildRes,
+  quoteResult,
+}: {
+  buildRes: IFetchBuildTxResponse;
+  quoteResult?: IFetchQuoteResult;
+}) {
+  const nextBuildRes: IFetchBuildTxResponse = {
+    ...buildRes,
+    result: {
+      ...buildRes.result,
+    },
+  };
+
+  const buildGasLimitBN = new BigNumber(nextBuildRes.result?.gasLimit ?? 0);
+  const quoteGasLimitBN = new BigNumber(quoteResult?.gasLimit ?? 0);
+
+  if (
+    (buildGasLimitBN.isNaN() || buildGasLimitBN.isZero()) &&
+    !quoteGasLimitBN.isNaN() &&
+    !quoteGasLimitBN.isZero()
+  ) {
+    nextBuildRes.result.gasLimit = quoteGasLimitBN.toNumber();
+  }
+
+  if (
+    !nextBuildRes.result?.routesData?.length &&
+    quoteResult?.routesData?.length
+  ) {
+    nextBuildRes.result.routesData = quoteResult.routesData;
+  }
+
+  return nextBuildRes;
+}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.ts
@@ -19,6 +19,16 @@ export function buildMarketReviewShouldFallback({
   );
 }
 
+export function buildDefaultMarketSpeedCheckState() {
+  return {
+    speedCheckError: '',
+    checkSpenderAddress: '',
+    isStock: false,
+    shouldApprove: false,
+    shouldResetApprove: false,
+  };
+}
+
 export function shouldFetchMarketQuoteFallbackData(
   buildRes?: IFetchBuildTxResponse,
 ) {
@@ -85,6 +95,10 @@ export function mergeMarketBuildResultWithQuote({
     quoteResult?.routesData?.length
   ) {
     nextBuildRes.result.routesData = quoteResult.routesData;
+  }
+
+  if (!nextBuildRes.result?.minToAmount && quoteResult?.minToAmount) {
+    nextBuildRes.result.minToAmount = quoteResult.minToAmount;
   }
 
   return nextBuildRes;

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapReviewUtils.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapReviewUtils.test.ts
@@ -1,0 +1,182 @@
+import type {
+  IFetchQuoteResult,
+  ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
+import {
+  EProtocolOfExchange,
+  ESwapApproveTransactionStatus,
+  ESwapQuoteKind,
+} from '@onekeyhq/shared/types/swap/types';
+import type { ISendTxOnSuccessData } from '@onekeyhq/shared/types/tx';
+
+import {
+  assertMarketReviewQuoteResult,
+  buildMarketApproveInfos,
+  buildMarketSwapApprovingTransaction,
+  buildWrappedMarketQuoteResult,
+  extractMarketSwapSuccessResult,
+  normalizeMarketReviewQuoteResult,
+} from './marketSwapReviewUtils';
+
+const fromToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xfrom',
+  symbol: 'ETH',
+  decimals: 18,
+  isNative: true,
+};
+
+const toToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xto',
+  symbol: 'USDC',
+  decimals: 6,
+  isNative: false,
+};
+
+function createQuoteResult(
+  overrides: Partial<IFetchQuoteResult> = {},
+): IFetchQuoteResult {
+  return {
+    protocol: EProtocolOfExchange.SWAP,
+    info: {
+      provider: 'onekey',
+      providerName: 'OneKey',
+    },
+    fromTokenInfo: fromToken,
+    toTokenInfo: toToken,
+    fromAmount: '1',
+    toAmount: '2500',
+    kind: ESwapQuoteKind.SELL,
+    ...overrides,
+  };
+}
+
+describe('marketSwapReviewUtils', () => {
+  it('fails closed when review quote misses providerName', () => {
+    expect(() =>
+      assertMarketReviewQuoteResult(
+        createQuoteResult({
+          info: {
+            provider: 'onekey',
+            providerName: '',
+          },
+        }),
+      ),
+    ).toThrow('providerName');
+  });
+
+  it('removes allowance when market speed check says approval is not needed', () => {
+    const result = normalizeMarketReviewQuoteResult({
+      quoteResult: createQuoteResult({
+        allowanceResult: {
+          allowanceTarget: '0xspender',
+          amount: '1',
+        },
+      }),
+      shouldApprove: false,
+      shouldResetApprove: false,
+      spenderAddress: '0xspender',
+      amount: '1',
+    });
+
+    expect(result.allowanceResult).toBeUndefined();
+  });
+
+  it('injects allowance using the effective spender when approval is required', () => {
+    const result = normalizeMarketReviewQuoteResult({
+      quoteResult: createQuoteResult(),
+      shouldApprove: true,
+      shouldResetApprove: true,
+      spenderAddress: '0xspender',
+      amount: '1',
+    });
+
+    expect(result.allowanceResult).toEqual({
+      allowanceTarget: '0xspender',
+      amount: '1',
+      shouldResetApprove: true,
+    });
+  });
+
+  it('builds reset approve plus final approve infos for batch review sends', () => {
+    const approveInfos = buildMarketApproveInfos({
+      fromUserAddress: '0xuser',
+      quoteResult: createQuoteResult({
+        allowanceResult: {
+          allowanceTarget: '0xspender',
+          amount: '1',
+          shouldResetApprove: true,
+        },
+      }),
+    });
+
+    expect(approveInfos).toHaveLength(2);
+    expect(approveInfos[0].amount).toBe('0');
+    expect(approveInfos[0].isMax).toBe(false);
+    expect(approveInfos[1].amount).toBe('1');
+    expect(approveInfos[1].isMax).toBe(true);
+  });
+
+  it('builds a review-visible approving transaction payload', () => {
+    const result = buildMarketSwapApprovingTransaction({
+      quoteResult: createQuoteResult({
+        allowanceResult: {
+          allowanceTarget: '0xspender',
+          amount: '1',
+        },
+      }),
+      amount: '1',
+      useAddress: '0xuser',
+      spenderAddress: '0xspender',
+    });
+
+    expect(result.status).toBe(ESwapApproveTransactionStatus.PENDING);
+    expect(result.providerName).toBe('OneKey');
+    expect(result.resetApproveValue).toBe('0');
+  });
+
+  it('builds a wrapped quote result for wrap review flows', () => {
+    const result = buildWrappedMarketQuoteResult({
+      fromToken,
+      toToken,
+      amount: '2',
+      providerLogo: 'wrapped-logo',
+    });
+
+    expect(result.isWrapped).toBe(true);
+    expect(result.toAmount).toBe('2');
+    expect(result.info.providerLogo).toBe('wrapped-logo');
+  });
+
+  it('extracts the final swap transaction from batched send results', () => {
+    const result = extractMarketSwapSuccessResult([
+      {
+        signedTx: {
+          encodedTx: null,
+          txid: '0xapprove',
+          rawTx: '0xapprove-raw',
+        },
+        decodedTx: {},
+      } as ISendTxOnSuccessData,
+      {
+        signedTx: {
+          encodedTx: null,
+          txid: '0xswap',
+          rawTx: '0xswap-raw',
+          swapInfo: {} as never,
+        },
+        decodedTx: {
+          totalFeeFiatValue: '12.3',
+          totalFeeInNative: '0.01',
+        } as never,
+      } as ISendTxOnSuccessData,
+    ]);
+
+    expect(result).toEqual({
+      txHash: '0xswap',
+      gasFeeFiatValue: '12.3',
+      gasFeeInNative: '0.01',
+    });
+  });
+});

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapReviewUtils.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapReviewUtils.test.ts
@@ -10,8 +10,8 @@ import {
 import type { ISendTxOnSuccessData } from '@onekeyhq/shared/types/tx';
 
 import {
-  assertMarketSignedBuildInvariant,
   assertMarketReviewQuoteResult,
+  assertMarketSignedBuildInvariant,
   buildMarketApproveInfos,
   buildMarketSwapApprovingTransaction,
   buildWrappedMarketQuoteResult,
@@ -84,7 +84,7 @@ describe('marketSwapReviewUtils', () => {
     ).toThrow('signed order result');
   });
 
-  it('fails closed when a signed build result changes provider or min receive', () => {
+  it('fails closed when a signed build result changes provider, expected receive, or min receive', () => {
     expect(() =>
       assertMarketSignedBuildInvariant({
         reviewedQuoteResult: createQuoteResult({
@@ -100,6 +100,20 @@ describe('marketSwapReviewUtils', () => {
         skipSendTransAction: true,
       }),
     ).toThrow('provider changed');
+
+    expect(() =>
+      assertMarketSignedBuildInvariant({
+        reviewedQuoteResult: createQuoteResult({
+          minToAmount: '2400',
+          toAmount: '2500',
+        }),
+        rebuiltQuoteResult: createQuoteResult({
+          minToAmount: '2400',
+          toAmount: '2490',
+        }),
+        skipSendTransAction: true,
+      }),
+    ).toThrow('expected receive changed');
 
     expect(() =>
       assertMarketSignedBuildInvariant({

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapReviewUtils.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapReviewUtils.test.ts
@@ -10,6 +10,7 @@ import {
 import type { ISendTxOnSuccessData } from '@onekeyhq/shared/types/tx';
 
 import {
+  areMarketApproveAmountsEqual,
   assertMarketReviewQuoteResult,
   assertMarketSignedBuildInvariant,
   attachMarketOneInchFusionSignature,
@@ -66,6 +67,12 @@ describe('marketSwapReviewUtils', () => {
         }),
       ),
     ).toThrow('providerName');
+  });
+
+  it('matches approve amounts by numeric value instead of raw string only', () => {
+    expect(areMarketApproveAmountsEqual('1.0', '1')).toBe(true);
+    expect(areMarketApproveAmountsEqual('0.1000', '0.1')).toBe(true);
+    expect(areMarketApproveAmountsEqual('1.01', '1')).toBe(false);
   });
 
   it('fails closed when a signed build result tries to continue on-chain sending', () => {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapReviewUtils.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapReviewUtils.test.ts
@@ -10,6 +10,7 @@ import {
 import type { ISendTxOnSuccessData } from '@onekeyhq/shared/types/tx';
 
 import {
+  assertMarketSignedBuildInvariant,
   assertMarketReviewQuoteResult,
   buildMarketApproveInfos,
   buildMarketSwapApprovingTransaction,
@@ -64,6 +65,53 @@ describe('marketSwapReviewUtils', () => {
         }),
       ),
     ).toThrow('providerName');
+  });
+
+  it('fails closed when a signed build result tries to continue on-chain sending', () => {
+    expect(() =>
+      assertMarketSignedBuildInvariant({
+        reviewedQuoteResult: createQuoteResult({
+          minToAmount: '2400',
+          swapShouldSignedData: {
+            unSignedInfo: {},
+          } as never,
+        }),
+        rebuiltQuoteResult: createQuoteResult({
+          minToAmount: '2400',
+        }),
+        skipSendTransAction: false,
+      }),
+    ).toThrow('signed order result');
+  });
+
+  it('fails closed when a signed build result changes provider or min receive', () => {
+    expect(() =>
+      assertMarketSignedBuildInvariant({
+        reviewedQuoteResult: createQuoteResult({
+          minToAmount: '2400',
+        }),
+        rebuiltQuoteResult: createQuoteResult({
+          info: {
+            provider: 'other',
+            providerName: 'Other',
+          },
+          minToAmount: '2399',
+        }),
+        skipSendTransAction: true,
+      }),
+    ).toThrow('provider changed');
+
+    expect(() =>
+      assertMarketSignedBuildInvariant({
+        reviewedQuoteResult: createQuoteResult({
+          minToAmount: '2400',
+        }),
+        rebuiltQuoteResult: createQuoteResult({
+          minToAmount: '2399',
+        }),
+        skipSendTransAction: true,
+      }),
+    ).toThrow('min receive changed');
   });
 
   it('removes allowance when market speed check says approval is not needed', () => {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapReviewUtils.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapReviewUtils.test.ts
@@ -12,6 +12,7 @@ import type { ISendTxOnSuccessData } from '@onekeyhq/shared/types/tx';
 import {
   assertMarketReviewQuoteResult,
   assertMarketSignedBuildInvariant,
+  attachMarketOneInchFusionSignature,
   buildMarketApproveInfos,
   buildMarketSwapApprovingTransaction,
   buildWrappedMarketQuoteResult,
@@ -178,6 +179,43 @@ describe('marketSwapReviewUtils', () => {
     expect(approveInfos[0].isMax).toBe(false);
     expect(approveInfos[1].amount).toBe('1');
     expect(approveInfos[1].isMax).toBe(true);
+  });
+
+  it('fails closed when one-inch fusion context is missing', () => {
+    expect(() =>
+      attachMarketOneInchFusionSignature({
+        quoteResult: createQuoteResult({
+          quoteResultCtx: undefined,
+        }),
+        signature: '0xsig',
+      }),
+    ).toThrow('1inch fusion context missing');
+  });
+
+  it('attaches the one-inch fusion signature when the context is present', () => {
+    const quoteResult = createQuoteResult({
+      quoteResultCtx: {
+        oneInchFusionOrderCtx: {
+          orderStruct: { salt: '1' },
+          extension: '0xext',
+          quoteId: 'quote-1',
+          orderHash: '0xhash',
+        },
+      },
+    });
+
+    const result = attachMarketOneInchFusionSignature({
+      quoteResult,
+      signature: '0xsig',
+    });
+
+    expect(result.quoteResultCtx.oneInchFusionOrderCtx).toEqual({
+      orderStruct: { salt: '1' },
+      extension: '0xext',
+      quoteId: 'quote-1',
+      orderHash: '0xhash',
+      signature: '0xsig',
+    });
   });
 
   it('builds a review-visible approving transaction payload', () => {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapReviewUtils.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapReviewUtils.ts
@@ -1,3 +1,5 @@
+import BigNumber from 'bignumber.js';
+
 import type { IApproveInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import type {
@@ -26,6 +28,70 @@ export function assertMarketReviewQuoteResult(
     throw new OneKeyLocalError('Market swap review requires toAmount.');
   }
   return quoteResult;
+}
+
+function areQuoteAmountsEqual(value1?: string, value2?: string) {
+  if (!value1 && !value2) {
+    return true;
+  }
+
+  if (!value1 || !value2) {
+    return false;
+  }
+
+  const value1BN = new BigNumber(value1);
+  const value2BN = new BigNumber(value2);
+
+  if (value1BN.isNaN() || value2BN.isNaN()) {
+    return value1 === value2;
+  }
+
+  return value1BN.eq(value2BN);
+}
+
+export function assertMarketSignedBuildInvariant({
+  reviewedQuoteResult,
+  rebuiltQuoteResult,
+  skipSendTransAction,
+}: {
+  reviewedQuoteResult: IFetchQuoteResult;
+  rebuiltQuoteResult: IFetchQuoteResult;
+  skipSendTransAction: boolean;
+}) {
+  const reviewed = assertMarketReviewQuoteResult(reviewedQuoteResult);
+  const rebuilt = assertMarketReviewQuoteResult(rebuiltQuoteResult);
+
+  if (!skipSendTransAction) {
+    throw new OneKeyLocalError(
+      'Market sign review requires a signed order result.',
+    );
+  }
+
+  if (
+    reviewed.info.provider !== rebuilt.info.provider ||
+    reviewed.info.providerName !== rebuilt.info.providerName
+  ) {
+    throw new OneKeyLocalError(
+      'Market sign review provider changed after signing.',
+    );
+  }
+
+  if (!areQuoteAmountsEqual(reviewed.fromAmount, rebuilt.fromAmount)) {
+    throw new OneKeyLocalError(
+      'Market sign review amount changed after signing.',
+    );
+  }
+
+  if (
+    reviewed.minToAmount &&
+    !areQuoteAmountsEqual(reviewed.minToAmount, rebuilt.minToAmount)
+  ) {
+    throw new OneKeyLocalError(
+      'Market sign review min receive changed after signing.',
+    );
+  }
+
+  return rebuilt;
 }
 
 export function normalizeMarketReviewQuoteResult({

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapReviewUtils.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapReviewUtils.ts
@@ -82,6 +82,12 @@ export function assertMarketSignedBuildInvariant({
     );
   }
 
+  if (!areQuoteAmountsEqual(reviewed.toAmount, rebuilt.toAmount)) {
+    throw new OneKeyLocalError(
+      'Market sign review expected receive changed after signing.',
+    );
+  }
+
   if (
     reviewed.minToAmount &&
     !areQuoteAmountsEqual(reviewed.minToAmount, rebuilt.minToAmount)

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapReviewUtils.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapReviewUtils.ts
@@ -1,0 +1,186 @@
+import type { IApproveInfo } from '@onekeyhq/kit-bg/src/vaults/types';
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import type {
+  IFetchQuoteResult,
+  ISwapApproveTransaction,
+  ISwapTokenBase,
+} from '@onekeyhq/shared/types/swap/types';
+import {
+  EProtocolOfExchange,
+  ESwapApproveTransactionStatus,
+  ESwapQuoteKind,
+  ESwapTabSwitchType,
+} from '@onekeyhq/shared/types/swap/types';
+import type { ISendTxOnSuccessData } from '@onekeyhq/shared/types/tx';
+
+export function assertMarketReviewQuoteResult(
+  quoteResult?: IFetchQuoteResult,
+): IFetchQuoteResult {
+  if (!quoteResult?.info?.providerName) {
+    throw new OneKeyLocalError('Market swap review requires providerName.');
+  }
+  if (!quoteResult?.fromAmount) {
+    throw new OneKeyLocalError('Market swap review requires fromAmount.');
+  }
+  if (!quoteResult?.toAmount) {
+    throw new OneKeyLocalError('Market swap review requires toAmount.');
+  }
+  return quoteResult;
+}
+
+export function normalizeMarketReviewQuoteResult({
+  quoteResult,
+  shouldApprove,
+  shouldResetApprove,
+  spenderAddress,
+  amount,
+}: {
+  quoteResult: IFetchQuoteResult;
+  shouldApprove?: boolean;
+  shouldResetApprove?: boolean;
+  spenderAddress?: string;
+  amount: string;
+}): IFetchQuoteResult {
+  if (!shouldApprove || !spenderAddress) {
+    return {
+      ...quoteResult,
+      allowanceResult: undefined,
+    };
+  }
+
+  return {
+    ...quoteResult,
+    allowanceResult: {
+      allowanceTarget: spenderAddress,
+      amount: quoteResult.fromAmount ?? amount,
+      ...(shouldResetApprove ? { shouldResetApprove: true } : undefined),
+    },
+  };
+}
+
+export function buildWrappedMarketQuoteResult({
+  fromToken,
+  toToken,
+  amount,
+  providerLogo,
+}: {
+  fromToken: ISwapTokenBase;
+  toToken: ISwapTokenBase;
+  amount: string;
+  providerLogo?: string;
+}): IFetchQuoteResult {
+  return {
+    protocol: EProtocolOfExchange.SWAP,
+    info: {
+      provider: 'wrapped',
+      providerName: 'wrapped',
+      providerLogo,
+    },
+    fromTokenInfo: fromToken,
+    toTokenInfo: toToken,
+    fromAmount: amount,
+    toAmount: amount,
+    isWrapped: true,
+  };
+}
+
+export function buildMarketApproveInfos({
+  fromUserAddress,
+  quoteResult,
+}: {
+  fromUserAddress?: string;
+  quoteResult?: IFetchQuoteResult;
+}): IApproveInfo[] {
+  if (
+    !fromUserAddress ||
+    !quoteResult?.allowanceResult?.allowanceTarget ||
+    !quoteResult.fromAmount
+  ) {
+    return [];
+  }
+
+  const tokenInfo = {
+    ...quoteResult.fromTokenInfo,
+    isNative: !!quoteResult.fromTokenInfo.isNative,
+    address: quoteResult.fromTokenInfo.contractAddress,
+    name: quoteResult.fromTokenInfo.name ?? quoteResult.fromTokenInfo.symbol,
+  };
+
+  const approveInfos: IApproveInfo[] = [];
+
+  if (quoteResult.allowanceResult.shouldResetApprove) {
+    approveInfos.push({
+      owner: fromUserAddress,
+      spender: quoteResult.allowanceResult.allowanceTarget,
+      amount: '0',
+      isMax: false,
+      tokenInfo,
+      swapApproveRes: undefined,
+    });
+  }
+
+  approveInfos.push({
+    owner: fromUserAddress,
+    spender: quoteResult.allowanceResult.allowanceTarget,
+    amount: quoteResult.fromAmount,
+    isMax: true,
+    tokenInfo,
+    swapApproveRes: undefined,
+  });
+
+  return approveInfos;
+}
+
+export function buildMarketSwapApprovingTransaction({
+  quoteResult,
+  amount,
+  useAddress,
+  spenderAddress,
+  isResetApprove,
+}: {
+  quoteResult: IFetchQuoteResult;
+  amount: string;
+  useAddress: string;
+  spenderAddress: string;
+  isResetApprove?: boolean;
+}): ISwapApproveTransaction {
+  return {
+    swapType: ESwapTabSwitchType.SWAP,
+    protocol: quoteResult.protocol ?? EProtocolOfExchange.SWAP,
+    provider: quoteResult.info.provider,
+    providerName: quoteResult.info.providerName,
+    unSupportReceiveAddressDifferent:
+      quoteResult.unSupportReceiveAddressDifferent,
+    fromToken: quoteResult.fromTokenInfo,
+    toToken: quoteResult.toTokenInfo,
+    quoteId: quoteResult.quoteId ?? '',
+    amount,
+    toAmount: quoteResult.toAmount ?? '',
+    useAddress,
+    spenderAddress,
+    status: ESwapApproveTransactionStatus.PENDING,
+    kind: quoteResult.kind ?? ESwapQuoteKind.SELL,
+    resetApproveValue: !isResetApprove ? '0' : amount,
+    resetApproveIsMax: !isResetApprove,
+  };
+}
+
+export function extractMarketSwapSuccessResult(data: ISendTxOnSuccessData[]):
+  | {
+      txHash: string;
+      gasFeeFiatValue?: string;
+      gasFeeInNative?: string;
+    }
+  | undefined {
+  const swapItem = data.toReversed().find((item) => item.signedTx.swapInfo);
+
+  if (!swapItem) {
+    return undefined;
+  }
+
+  return {
+    txHash: swapItem.signedTx.txid,
+    gasFeeFiatValue: swapItem.decodedTx.totalFeeFiatValue,
+    gasFeeInNative: swapItem.decodedTx.totalFeeInNative,
+  };
+}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapReviewUtils.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapReviewUtils.ts
@@ -30,6 +30,21 @@ export function assertMarketReviewQuoteResult(
   return quoteResult;
 }
 
+export function areMarketApproveAmountsEqual(value1?: string, value2?: string) {
+  if (!value1 || !value2) {
+    return false;
+  }
+
+  const value1BN = new BigNumber(value1);
+  const value2BN = new BigNumber(value2);
+
+  if (value1BN.isNaN() || value2BN.isNaN()) {
+    return value1 === value2;
+  }
+
+  return value1BN.eq(value2BN);
+}
+
 function areQuoteAmountsEqual(value1?: string, value2?: string) {
   if (!value1 && !value2) {
     return true;

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapReviewUtils.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapReviewUtils.ts
@@ -203,6 +203,28 @@ export function buildMarketApproveInfos({
   return approveInfos;
 }
 
+export function attachMarketOneInchFusionSignature({
+  quoteResult,
+  signature,
+}: {
+  quoteResult: IFetchQuoteResult;
+  signature: string;
+}) {
+  const oneInchFusionOrderCtx =
+    quoteResult.quoteResultCtx?.oneInchFusionOrderCtx;
+
+  if (!quoteResult.quoteResultCtx || !oneInchFusionOrderCtx) {
+    throw new OneKeyLocalError('Market 1inch fusion context missing.');
+  }
+
+  quoteResult.quoteResultCtx.oneInchFusionOrderCtx = {
+    ...oneInchFusionOrderCtx,
+    signature,
+  };
+
+  return quoteResult;
+}
+
 export function buildMarketSwapApprovingTransaction({
   quoteResult,
   amount,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useMarketSwapReviewActions.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useMarketSwapReviewActions.test.tsx
@@ -1,0 +1,737 @@
+/** @jest-environment jsdom */
+
+import { type ReactNode, useMemo } from 'react';
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createStore } from 'jotai';
+
+import {
+  ProviderJotaiContextSwap,
+  swapStepNetFeeLevelAtom,
+  swapStepsAtom,
+  useSwapStepsAtom,
+} from '@onekeyhq/kit/src/states/jotai/contexts/swap/atoms';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import type {
+  IFetchQuoteResult,
+  ISwapPreSwapData,
+  ISwapStep,
+  ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
+import {
+  EProtocolOfExchange,
+  ESwapApproveTransactionStatus,
+  ESwapNetworkFeeLevel,
+  ESwapStepStatus,
+  ESwapStepType,
+  ESwapTabSwitchType,
+} from '@onekeyhq/shared/types/swap/types';
+
+import { useMarketSwapReviewActions } from './useMarketSwapReviewActions';
+
+import type { IMarketSwapReviewAdapter } from './useSpeedSwapActions';
+import type { IMarketSwapReviewState } from '../MarketSwapReviewInitializer';
+
+jest.mock('react-intl', () => ({
+  useIntl: () => ({
+    formatMessage: ({ id }: { id: string }) => id,
+  }),
+}));
+
+let inAppNotificationAtomState: {
+  speedSwapApprovingTransaction?: {
+    txId?: string;
+    status?: ESwapApproveTransactionStatus | string;
+  };
+} = {};
+
+jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms', () => ({
+  useInAppNotificationAtom: () => [inAppNotificationAtomState, jest.fn()],
+}));
+
+const fromToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xfrom',
+  symbol: 'ETH',
+  decimals: 18,
+  isNative: true,
+};
+
+const toToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xto',
+  symbol: 'USDC',
+  decimals: 6,
+  isNative: false,
+};
+
+function createQuoteResult(
+  overrides: Partial<IFetchQuoteResult> = {},
+): IFetchQuoteResult {
+  return {
+    protocol: EProtocolOfExchange.SWAP,
+    info: {
+      provider: 'onekey',
+      providerName: 'OneKey',
+    },
+    fromTokenInfo: fromToken,
+    toTokenInfo: toToken,
+    fromAmount: '1',
+    toAmount: '2500',
+    ...overrides,
+  };
+}
+
+function createReviewState({
+  steps,
+  quoteResult = createQuoteResult(),
+}: {
+  steps: ISwapStep[];
+  quoteResult?: IFetchQuoteResult;
+}): IMarketSwapReviewState {
+  return {
+    steps,
+    preSwapData: {
+      fromToken,
+      toToken,
+      fromTokenAmount: quoteResult.fromAmount,
+      toTokenAmount: quoteResult.toAmount,
+      swapType: ESwapTabSwitchType.SWAP,
+    } as ISwapPreSwapData,
+    quoteResult,
+  };
+}
+
+function createAdapter(): jest.Mocked<IMarketSwapReviewAdapter> {
+  return {
+    prepareMarketSwapReview: jest.fn(),
+    sendMarketApproveTx: jest.fn(),
+    sendMarketSwapTx: jest.fn(),
+    sendMarketWrappedTx: jest.fn(),
+    sendMarketSignMessage: jest.fn(),
+    buildMarketApproveInfos: jest.fn(),
+  };
+}
+
+type ISendMarketSwapParams = Parameters<
+  IMarketSwapReviewAdapter['sendMarketSwapTx']
+>[0];
+type ISendMarketWrappedParams = Parameters<
+  IMarketSwapReviewAdapter['sendMarketWrappedTx']
+>[0];
+
+function createWrapper(
+  reviewState: IMarketSwapReviewState,
+  networkFeeLevel: ESwapNetworkFeeLevel = ESwapNetworkFeeLevel.MEDIUM,
+) {
+  return function Wrapper({ children }: { children?: ReactNode }) {
+    const store = useMemo(() => {
+      const nextStore = createStore();
+      nextStore.set(swapStepsAtom(), {
+        steps: reviewState.steps,
+        preSwapData: reviewState.preSwapData,
+        quoteResult: reviewState.quoteResult,
+      } as never);
+      nextStore.set(swapStepNetFeeLevelAtom(), {
+        networkFeeLevel,
+      } as never);
+      return nextStore;
+    }, []);
+
+    return (
+      <ProviderJotaiContextSwap store={store}>
+        {children}
+      </ProviderJotaiContextSwap>
+    );
+  };
+}
+
+describe('useMarketSwapReviewActions', () => {
+  beforeEach(() => {
+    inAppNotificationAtomState = {};
+  });
+
+  it('refreshes review state before step actions', async () => {
+    const adapter = createAdapter();
+    const nextReviewState = createReviewState({
+      steps: [
+        {
+          type: ESwapStepType.SEND_TX,
+          status: ESwapStepStatus.READY,
+        },
+      ],
+      quoteResult: createQuoteResult({
+        toAmount: '2600',
+      }),
+    });
+    adapter.prepareMarketSwapReview.mockResolvedValue(nextReviewState);
+
+    const { result } = renderHook(
+      () => {
+        const actions = useMarketSwapReviewActions({ adapter });
+        const [swapSteps] = useSwapStepsAtom();
+        return {
+          actions,
+          swapSteps,
+        };
+      },
+      {
+        wrapper: createWrapper(
+          createReviewState({
+            steps: [
+              {
+                type: ESwapStepType.SEND_TX,
+                status: ESwapStepStatus.READY,
+              },
+            ],
+          }),
+        ),
+      },
+    );
+
+    await act(async () => {
+      await result.current.actions.preSwapBeforeStepActions(
+        createQuoteResult(),
+        fromToken,
+        toToken,
+      );
+    });
+
+    expect(adapter.prepareMarketSwapReview).toHaveBeenCalledWith({
+      fromAmount: '1',
+      fromToken,
+      toToken,
+      isWrap: undefined,
+      networkFeeLevel: ESwapNetworkFeeLevel.MEDIUM,
+      quoteResult: expect.objectContaining({
+        fromAmount: '1',
+      }),
+    });
+    expect(result.current.swapSteps.quoteResult?.toAmount).toBe('2600');
+    expect(result.current.swapSteps.preSwapData.stepBeforeActionsLoading).toBe(
+      false,
+    );
+  });
+
+  it('starts a send step through the market speed swap adapter', async () => {
+    const adapter = createAdapter();
+    adapter.sendMarketSwapTx.mockImplementation(
+      async (params: ISendMarketSwapParams) => {
+        params?.onBroadcast?.({
+          txHash: '0xswap',
+          orderId: 'order-1',
+        });
+      },
+    );
+
+    const { result } = renderHook(
+      () => {
+        const actions = useMarketSwapReviewActions({ adapter });
+        const [swapSteps] = useSwapStepsAtom();
+        return {
+          actions,
+          swapSteps,
+        };
+      },
+      {
+        wrapper: createWrapper(
+          createReviewState({
+            steps: [
+              {
+                type: ESwapStepType.SEND_TX,
+                status: ESwapStepStatus.READY,
+              },
+            ],
+          }),
+        ),
+      },
+    );
+
+    await act(async () => {
+      await result.current.actions.preSwapStepsStart();
+    });
+
+    await waitFor(() => {
+      expect(result.current.swapSteps.steps[0].status).toBe(
+        ESwapStepStatus.PENDING,
+      );
+    });
+    expect(result.current.swapSteps.steps[0].txHash).toBe('0xswap');
+    expect(adapter.sendMarketSwapTx).toHaveBeenCalledWith(
+      expect.objectContaining({
+        networkFeeLevel: ESwapNetworkFeeLevel.MEDIUM,
+      }),
+    );
+  });
+
+  it('uses the review store fee level when refreshing prebuild data', async () => {
+    const adapter = createAdapter();
+    adapter.prepareMarketSwapReview.mockResolvedValue(
+      createReviewState({
+        steps: [
+          {
+            type: ESwapStepType.SEND_TX,
+            status: ESwapStepStatus.READY,
+          },
+        ],
+      }),
+    );
+
+    const { result } = renderHook(
+      () => ({
+        actions: useMarketSwapReviewActions({ adapter }),
+      }),
+      {
+        wrapper: createWrapper(
+          createReviewState({
+            steps: [
+              {
+                type: ESwapStepType.SEND_TX,
+                status: ESwapStepStatus.READY,
+              },
+            ],
+          }),
+          ESwapNetworkFeeLevel.HIGH,
+        ),
+      },
+    );
+
+    await act(async () => {
+      await result.current.actions.preSwapBeforeStepActions(
+        createQuoteResult(),
+        fromToken,
+        toToken,
+      );
+    });
+
+    expect(adapter.prepareMarketSwapReview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        networkFeeLevel: ESwapNetworkFeeLevel.HIGH,
+      }),
+    );
+  });
+
+  it('starts an approve step through the review-visible swap approving state', async () => {
+    const adapter = createAdapter();
+    adapter.sendMarketApproveTx.mockImplementation(
+      async ({ onBroadcast, quoteResult }) => {
+        expect(quoteResult.fromAmount).toBe('1');
+        onBroadcast?.({
+          txHash: '0xapprove',
+          amount: '1',
+        });
+      },
+    );
+
+    const { result } = renderHook(
+      () => {
+        const actions = useMarketSwapReviewActions({ adapter });
+        const [swapSteps] = useSwapStepsAtom();
+        return {
+          actions,
+          swapSteps,
+        };
+      },
+      {
+        wrapper: createWrapper(
+          createReviewState({
+            steps: [
+              {
+                type: ESwapStepType.APPROVE_TX,
+                status: ESwapStepStatus.READY,
+                shouldWaitApproved: true,
+              },
+            ],
+            quoteResult: createQuoteResult({
+              allowanceResult: {
+                allowanceTarget: '0xspender',
+                amount: '1',
+              },
+            }),
+          }),
+        ),
+      },
+    );
+
+    await act(async () => {
+      await result.current.actions.preSwapStepsStart();
+    });
+
+    await waitFor(() => {
+      expect(result.current.swapSteps.steps[0].status).toBe(
+        ESwapStepStatus.PENDING,
+      );
+    });
+    expect(result.current.swapSteps.steps[0].txHash).toBe('0xapprove');
+    expect(result.current.swapSteps.steps[0].stepSubTitle).toBe(
+      ETranslations.swap_btn_approving,
+    );
+    expect(adapter.sendMarketApproveTx).toHaveBeenCalledWith(
+      expect.objectContaining({
+        networkFeeLevel: ESwapNetworkFeeLevel.MEDIUM,
+      }),
+    );
+  });
+
+  it('continues the review flow from speed approve status updates without using the swap approve state', async () => {
+    const adapter = createAdapter();
+    adapter.sendMarketApproveTx.mockImplementation(
+      async ({ onBroadcast, quoteResult }) => {
+        expect(quoteResult.fromAmount).toBe('1');
+        onBroadcast?.({
+          txHash: '0xapprove',
+          amount: '1',
+        });
+      },
+    );
+    adapter.sendMarketSwapTx.mockImplementation(
+      async (params: ISendMarketSwapParams) => {
+        params?.onBroadcast?.({
+          txHash: '0xswap',
+          orderId: 'order-1',
+        });
+      },
+    );
+
+    const { result, rerender } = renderHook(
+      () => {
+        const actions = useMarketSwapReviewActions({ adapter });
+        const [swapSteps] = useSwapStepsAtom();
+        return {
+          actions,
+          swapSteps,
+        };
+      },
+      {
+        wrapper: createWrapper(
+          createReviewState({
+            steps: [
+              {
+                type: ESwapStepType.APPROVE_TX,
+                status: ESwapStepStatus.READY,
+                shouldWaitApproved: true,
+              },
+              {
+                type: ESwapStepType.SEND_TX,
+                status: ESwapStepStatus.READY,
+              },
+            ],
+            quoteResult: createQuoteResult({
+              allowanceResult: {
+                allowanceTarget: '0xspender',
+                amount: '1',
+              },
+            }),
+          }),
+        ),
+      },
+    );
+
+    await act(async () => {
+      await result.current.actions.preSwapStepsStart();
+    });
+
+    await waitFor(() => {
+      expect(result.current.swapSteps.steps[0].status).toBe(
+        ESwapStepStatus.PENDING,
+      );
+    });
+
+    await act(async () => {
+      inAppNotificationAtomState = {
+        speedSwapApprovingTransaction: {
+          txId: '0xapprove',
+          status: ESwapApproveTransactionStatus.SUCCESS,
+        },
+      };
+      rerender();
+    });
+
+    await waitFor(() => {
+      expect(adapter.sendMarketSwapTx).toHaveBeenCalledWith(
+        expect.objectContaining({
+          networkFeeLevel: ESwapNetworkFeeLevel.MEDIUM,
+        }),
+      );
+      expect(result.current.swapSteps.steps[0].status).toBe(
+        ESwapStepStatus.SUCCESS,
+      );
+      expect(result.current.swapSteps.steps[1].status).toBe(
+        ESwapStepStatus.PENDING,
+      );
+    });
+  });
+
+  it('marks the approve step failed when the speed approve status fails after txId is cleared', async () => {
+    const adapter = createAdapter();
+    adapter.sendMarketApproveTx.mockImplementation(
+      async ({ onBroadcast, quoteResult }) => {
+        expect(quoteResult.fromAmount).toBe('1');
+        onBroadcast?.({
+          txHash: '0xapprove',
+          amount: '1',
+        });
+      },
+    );
+
+    const { result, rerender } = renderHook(
+      () => {
+        const actions = useMarketSwapReviewActions({ adapter });
+        const [swapSteps] = useSwapStepsAtom();
+        return {
+          actions,
+          swapSteps,
+        };
+      },
+      {
+        wrapper: createWrapper(
+          createReviewState({
+            steps: [
+              {
+                type: ESwapStepType.APPROVE_TX,
+                status: ESwapStepStatus.READY,
+                shouldWaitApproved: true,
+              },
+              {
+                type: ESwapStepType.SEND_TX,
+                status: ESwapStepStatus.READY,
+              },
+            ],
+            quoteResult: createQuoteResult({
+              allowanceResult: {
+                allowanceTarget: '0xspender',
+                amount: '1',
+              },
+            }),
+          }),
+        ),
+      },
+    );
+
+    await act(async () => {
+      await result.current.actions.preSwapStepsStart();
+    });
+
+    await waitFor(() => {
+      expect(result.current.swapSteps.steps[0].status).toBe(
+        ESwapStepStatus.PENDING,
+      );
+    });
+
+    await act(async () => {
+      inAppNotificationAtomState = {
+        speedSwapApprovingTransaction: {
+          status: ESwapApproveTransactionStatus.FAILED,
+        },
+      };
+      rerender();
+    });
+
+    await waitFor(() => {
+      expect(result.current.swapSteps.steps[0].status).toBe(
+        ESwapStepStatus.FAILED,
+      );
+    });
+    expect(adapter.sendMarketSwapTx).not.toHaveBeenCalled();
+  });
+
+  it('passes approve infos into batch approve and swap execution', async () => {
+    const adapter = createAdapter();
+    const approveInfos = [
+      {
+        owner: '0xuser',
+      },
+    ] as never[];
+    adapter.buildMarketApproveInfos.mockReturnValue(approveInfos as never);
+    adapter.sendMarketSwapTx.mockImplementation(
+      async (params: ISendMarketSwapParams) => {
+        params?.onBroadcast?.({
+          txHash: '0xbatch',
+          orderId: 'order-batch',
+        });
+      },
+    );
+
+    const quoteResult = createQuoteResult({
+      allowanceResult: {
+        allowanceTarget: '0xspender',
+        amount: '1',
+      },
+    });
+
+    const { result } = renderHook(
+      () => {
+        const actions = useMarketSwapReviewActions({ adapter });
+        const [swapSteps] = useSwapStepsAtom();
+        return {
+          actions,
+          swapSteps,
+        };
+      },
+      {
+        wrapper: createWrapper(
+          createReviewState({
+            steps: [
+              {
+                type: ESwapStepType.BATCH_APPROVE_SWAP,
+                status: ESwapStepStatus.READY,
+              },
+            ],
+            quoteResult,
+          }),
+        ),
+      },
+    );
+
+    await act(async () => {
+      await result.current.actions.preSwapStepsStart();
+    });
+
+    expect(adapter.buildMarketApproveInfos).toHaveBeenCalledWith(quoteResult);
+    expect(adapter.sendMarketSwapTx).toHaveBeenCalledWith(
+      expect.objectContaining({
+        approvesInfo: approveInfos,
+        networkFeeLevel: ESwapNetworkFeeLevel.MEDIUM,
+      }),
+    );
+    expect(result.current.swapSteps.steps[0].txHash).toBe('0xbatch');
+  });
+
+  it('starts a wrap step through the wrapped adapter path', async () => {
+    const adapter = createAdapter();
+    adapter.sendMarketWrappedTx.mockImplementation(
+      async (params: ISendMarketWrappedParams) => {
+        params?.onBroadcast?.({
+          txHash: '0xwrap',
+        });
+      },
+    );
+
+    const { result } = renderHook(
+      () => {
+        const actions = useMarketSwapReviewActions({ adapter });
+        const [swapSteps] = useSwapStepsAtom();
+        return {
+          actions,
+          swapSteps,
+        };
+      },
+      {
+        wrapper: createWrapper(
+          createReviewState({
+            steps: [
+              {
+                type: ESwapStepType.WRAP_TX,
+                status: ESwapStepStatus.READY,
+              },
+            ],
+            quoteResult: createQuoteResult({
+              isWrapped: true,
+              toAmount: '1',
+            }),
+          }),
+        ),
+      },
+    );
+
+    await act(async () => {
+      await result.current.actions.preSwapStepsStart();
+    });
+
+    expect(adapter.sendMarketWrappedTx).toHaveBeenCalledWith(
+      expect.objectContaining({
+        networkFeeLevel: ESwapNetworkFeeLevel.MEDIUM,
+      }),
+    );
+    expect(result.current.swapSteps.steps[0].txHash).toBe('0xwrap');
+  });
+
+  it('starts a sign step through the market review sign adapter path', async () => {
+    const adapter = createAdapter();
+    adapter.sendMarketSignMessage.mockImplementation(
+      async ({ networkFeeLevel, onBroadcast } = {}) => {
+        expect(networkFeeLevel).toBe(ESwapNetworkFeeLevel.MEDIUM);
+        onBroadcast?.({
+          orderId: 'order-sign',
+        });
+      },
+    );
+
+    const { result } = renderHook(
+      () => {
+        const actions = useMarketSwapReviewActions({ adapter });
+        const [swapSteps] = useSwapStepsAtom();
+        return {
+          actions,
+          swapSteps,
+        };
+      },
+      {
+        wrapper: createWrapper(
+          createReviewState({
+            steps: [
+              {
+                type: ESwapStepType.SIGN_MESSAGE,
+                status: ESwapStepStatus.READY,
+              },
+            ],
+            quoteResult: createQuoteResult({
+              swapShouldSignedData: {
+                unSignedInfo: {},
+              } as never,
+            }),
+          }),
+        ),
+      },
+    );
+
+    await act(async () => {
+      await result.current.actions.preSwapStepsStart();
+    });
+
+    expect(adapter.sendMarketSignMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        networkFeeLevel: ESwapNetworkFeeLevel.MEDIUM,
+      }),
+    );
+    expect(result.current.swapSteps.steps[0].orderId).toBe('order-sign');
+  });
+
+  it('marks the step failed when the market adapter throws', async () => {
+    const adapter = createAdapter();
+    adapter.sendMarketSwapTx.mockRejectedValue(new Error('send failed'));
+
+    const { result } = renderHook(
+      () => {
+        const actions = useMarketSwapReviewActions({ adapter });
+        const [swapSteps] = useSwapStepsAtom();
+        return {
+          actions,
+          swapSteps,
+        };
+      },
+      {
+        wrapper: createWrapper(
+          createReviewState({
+            steps: [
+              {
+                type: ESwapStepType.SEND_TX,
+                status: ESwapStepStatus.READY,
+              },
+            ],
+          }),
+        ),
+      },
+    );
+
+    await act(async () => {
+      await result.current.actions.preSwapStepsStart();
+    });
+
+    await waitFor(() => {
+      expect(result.current.swapSteps.steps[0].status).toBe(
+        ESwapStepStatus.FAILED,
+      );
+    });
+  });
+});

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useMarketSwapReviewActions.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useMarketSwapReviewActions.test.tsx
@@ -85,9 +85,11 @@ function createQuoteResult(
 function createReviewState({
   steps,
   quoteResult = createQuoteResult(),
+  preSwapData,
 }: {
   steps: ISwapStep[];
   quoteResult?: IFetchQuoteResult;
+  preSwapData?: Partial<ISwapPreSwapData>;
 }): IMarketSwapReviewState {
   return {
     steps,
@@ -97,6 +99,7 @@ function createReviewState({
       fromTokenAmount: quoteResult.fromAmount,
       toTokenAmount: quoteResult.toAmount,
       swapType: ESwapTabSwitchType.SWAP,
+      ...preSwapData,
     } as ISwapPreSwapData,
     quoteResult,
   };
@@ -311,6 +314,64 @@ describe('useMarketSwapReviewActions', () => {
     );
   });
 
+  it('clears stale network fee data when fee refresh fails', async () => {
+    const adapter = createAdapter();
+    adapter.prepareMarketSwapReview.mockRejectedValue(
+      new Error('prebuild failed'),
+    );
+
+    const { result } = renderHook(
+      () => {
+        const actions = useMarketSwapReviewActions({ adapter });
+        const [swapSteps] = useSwapStepsAtom();
+        return {
+          actions,
+          swapSteps,
+        };
+      },
+      {
+        wrapper: createWrapper(
+          createReviewState({
+            steps: [
+              {
+                type: ESwapStepType.SEND_TX,
+                status: ESwapStepStatus.READY,
+              },
+            ],
+            preSwapData: {
+              supportNetworkFeeLevel: true,
+              netWorkFee: {
+                gasFeeFiatValue: '12.34',
+                gasInfos: [
+                  {
+                    encodeTx: {
+                      data: '0xold',
+                    } as never,
+                    gasInfo: {} as never,
+                  },
+                ],
+              },
+            },
+          }),
+          ESwapNetworkFeeLevel.HIGH,
+        ),
+      },
+    );
+
+    await act(async () => {
+      await result.current.actions.preSwapBeforeStepActions(
+        createQuoteResult(),
+        fromToken,
+        toToken,
+      );
+    });
+
+    expect(result.current.swapSteps.preSwapData.stepBeforeActionsLoading).toBe(
+      false,
+    );
+    expect(result.current.swapSteps.preSwapData.netWorkFee).toBeUndefined();
+  });
+
   it('starts an approve step through the review-visible swap approving state', async () => {
     const adapter = createAdapter();
     adapter.sendMarketApproveTx.mockImplementation(
@@ -375,6 +436,14 @@ describe('useMarketSwapReviewActions', () => {
 
   it('continues the review flow from speed approve status updates without using the swap approve state', async () => {
     const adapter = createAdapter();
+    const staleGasInfos = [
+      {
+        encodeTx: {
+          data: '0xstale',
+        } as never,
+        gasInfo: {} as never,
+      },
+    ];
     adapter.sendMarketApproveTx.mockImplementation(
       async ({ onBroadcast, quoteResult }) => {
         expect(quoteResult.fromAmount).toBe('1');
@@ -416,6 +485,12 @@ describe('useMarketSwapReviewActions', () => {
                 status: ESwapStepStatus.READY,
               },
             ],
+            preSwapData: {
+              netWorkFee: {
+                gasFeeFiatValue: '8.88',
+                gasInfos: staleGasInfos,
+              },
+            },
             quoteResult: createQuoteResult({
               allowanceResult: {
                 allowanceTarget: '0xspender',
@@ -423,6 +498,7 @@ describe('useMarketSwapReviewActions', () => {
               },
             }),
           }),
+          ESwapNetworkFeeLevel.HIGH,
         ),
       },
     );
@@ -448,9 +524,16 @@ describe('useMarketSwapReviewActions', () => {
     });
 
     await waitFor(() => {
+      expect(adapter.sendMarketApproveTx).toHaveBeenCalledWith(
+        expect.objectContaining({
+          gasInfos: staleGasInfos,
+          networkFeeLevel: ESwapNetworkFeeLevel.HIGH,
+        }),
+      );
       expect(adapter.sendMarketSwapTx).toHaveBeenCalledWith(
         expect.objectContaining({
-          networkFeeLevel: ESwapNetworkFeeLevel.MEDIUM,
+          gasInfos: undefined,
+          networkFeeLevel: ESwapNetworkFeeLevel.HIGH,
         }),
       );
       expect(result.current.swapSteps.steps[0].status).toBe(
@@ -458,6 +541,9 @@ describe('useMarketSwapReviewActions', () => {
       );
       expect(result.current.swapSteps.steps[1].status).toBe(
         ESwapStepStatus.PENDING,
+      );
+      expect(result.current.swapSteps.preSwapData.netWorkFee?.gasInfos).toBe(
+        undefined,
       );
     });
   });

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useMarketSwapReviewActions.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useMarketSwapReviewActions.ts
@@ -1,0 +1,362 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import {
+  useSwapStepNetFeeLevelAtom,
+  useSwapStepsAtom,
+} from '@onekeyhq/kit/src/states/jotai/contexts/swap/atoms';
+import { useInAppNotificationAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import {
+  ESwapApproveTransactionStatus,
+  ESwapStepStatus,
+  ESwapStepType,
+  type IFetchQuoteResult,
+  type ISwapPreSwapData,
+  type ISwapStep,
+  type ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
+
+import type { IMarketSwapReviewAdapter } from './useSpeedSwapActions';
+import type { IMarketSwapReviewState } from '../MarketSwapReviewInitializer';
+
+function useReviewStepStateActions() {
+  const [, setSwapSteps] = useSwapStepsAtom();
+
+  const replaceReviewState = useCallback(
+    (reviewState: IMarketSwapReviewState) => {
+      setSwapSteps({
+        steps: reviewState.steps,
+        preSwapData: reviewState.preSwapData,
+        quoteResult: reviewState.quoteResult,
+      });
+    },
+    [setSwapSteps],
+  );
+
+  const updateStep = useCallback(
+    (stepIndex: number, partialStep: Partial<ISwapStep>) => {
+      setSwapSteps((prev) => {
+        const nextSteps = [...prev.steps];
+        nextSteps[stepIndex] = {
+          ...nextSteps[stepIndex],
+          ...partialStep,
+        };
+        return {
+          ...prev,
+          steps: nextSteps,
+        };
+      });
+    },
+    [setSwapSteps],
+  );
+
+  const setBeforeActionsLoading = useCallback(
+    (loading: boolean) => {
+      setSwapSteps((prev) => ({
+        ...prev,
+        preSwapData: {
+          ...prev.preSwapData,
+          stepBeforeActionsLoading: loading,
+        },
+      }));
+    },
+    [setSwapSteps],
+  );
+
+  return {
+    replaceReviewState,
+    updateStep,
+    setBeforeActionsLoading,
+  };
+}
+
+export function useMarketSwapReviewActions({
+  adapter,
+}: {
+  adapter: IMarketSwapReviewAdapter;
+}) {
+  const intl = useIntl();
+  const [swapStepsState] = useSwapStepsAtom();
+  const [swapStepNetFeeLevel] = useSwapStepNetFeeLevelAtom();
+  const [inAppNotificationAtom] = useInAppNotificationAtom();
+  const handledApproveStatusRef = useRef<string>('');
+  const latestApproveTxIdRef = useRef<string>('');
+  const { replaceReviewState, setBeforeActionsLoading, updateStep } =
+    useReviewStepStateActions();
+
+  const markStepFailed = useCallback(
+    (stepIndex: number) => {
+      updateStep(stepIndex, {
+        status: ESwapStepStatus.FAILED,
+        stepSubTitle: undefined,
+      });
+    },
+    [updateStep],
+  );
+
+  const preSwapBeforeStepActions = useCallback(
+    async (
+      data?: IFetchQuoteResult,
+      currentFromToken?: ISwapToken,
+      currentToToken?: ISwapToken,
+    ) => {
+      setBeforeActionsLoading(true);
+      try {
+        const reviewState = await adapter.prepareMarketSwapReview({
+          fromAmount: data?.fromAmount,
+          fromToken: currentFromToken,
+          toToken: currentToToken,
+          isWrap: data?.isWrapped,
+          quoteResult: data,
+          networkFeeLevel: swapStepNetFeeLevel.networkFeeLevel,
+        });
+        replaceReviewState({
+          ...reviewState,
+          preSwapData: {
+            ...reviewState.preSwapData,
+            stepBeforeActionsLoading: false,
+          },
+        });
+      } catch {
+        setBeforeActionsLoading(false);
+      }
+    },
+    [
+      adapter,
+      replaceReviewState,
+      setBeforeActionsLoading,
+      swapStepNetFeeLevel.networkFeeLevel,
+    ],
+  );
+
+  const preSwapStepsStart = useCallback(
+    async (swapStepsValues?: {
+      steps: ISwapStep[];
+      preSwapData: ISwapPreSwapData;
+      quoteResult?: IFetchQuoteResult;
+    }) => {
+      const steps = swapStepsValues?.steps ?? swapStepsState.steps;
+      const preSwapData =
+        swapStepsValues?.preSwapData ?? swapStepsState.preSwapData;
+      const quoteResult =
+        swapStepsValues?.quoteResult ?? swapStepsState.quoteResult;
+
+      if (!steps.length) {
+        return;
+      }
+
+      for (let i = 0; i < steps.length; i += 1) {
+        const step = steps[i];
+        const canStart =
+          step.status === ESwapStepStatus.READY ||
+          (step.canRetry && step.status === ESwapStepStatus.FAILED);
+
+        if (canStart) {
+          try {
+            updateStep(i, {
+              status: ESwapStepStatus.LOADING,
+              errorMessage: undefined,
+              stepSubTitle: undefined,
+            });
+
+            if (step.type === ESwapStepType.APPROVE_TX) {
+              if (!quoteResult) {
+                markStepFailed(i);
+                break;
+              }
+
+              await adapter.sendMarketApproveTx({
+                amount:
+                  quoteResult.fromAmount ?? preSwapData.fromTokenAmount ?? '0',
+                gasInfos: preSwapData.netWorkFee?.gasInfos,
+                isResetApprove: step.isResetApprove,
+                networkFeeLevel: swapStepNetFeeLevel.networkFeeLevel,
+                quoteResult,
+                onBroadcast: ({ txHash }) => {
+                  updateStep(i, {
+                    status: ESwapStepStatus.PENDING,
+                    txHash,
+                    stepSubTitle: intl.formatMessage({
+                      id: ETranslations.swap_btn_approving,
+                    }),
+                  });
+                },
+                onCancel: () => {
+                  markStepFailed(i);
+                },
+              });
+              break;
+            }
+
+            if (step.type === ESwapStepType.WRAP_TX) {
+              await adapter.sendMarketWrappedTx({
+                gasInfos: preSwapData.netWorkFee?.gasInfos,
+                networkFeeLevel: swapStepNetFeeLevel.networkFeeLevel,
+                onBroadcast: ({ txHash, orderId }) => {
+                  updateStep(i, {
+                    status: ESwapStepStatus.PENDING,
+                    txHash,
+                    orderId,
+                  });
+                },
+                onCancel: () => {
+                  markStepFailed(i);
+                },
+              });
+              break;
+            }
+
+            if (step.type === ESwapStepType.SEND_TX) {
+              await adapter.sendMarketSwapTx({
+                gasInfos: preSwapData.netWorkFee?.gasInfos,
+                networkFeeLevel: swapStepNetFeeLevel.networkFeeLevel,
+                onBroadcast: ({ txHash, orderId }) => {
+                  updateStep(i, {
+                    status: ESwapStepStatus.PENDING,
+                    txHash,
+                    orderId,
+                  });
+                },
+                onCancel: () => {
+                  markStepFailed(i);
+                },
+              });
+              break;
+            }
+
+            if (step.type === ESwapStepType.SIGN_MESSAGE) {
+              await adapter.sendMarketSignMessage({
+                networkFeeLevel: swapStepNetFeeLevel.networkFeeLevel,
+                onBroadcast: ({ txHash, orderId }) => {
+                  updateStep(i, {
+                    status: ESwapStepStatus.PENDING,
+                    txHash,
+                    orderId,
+                  });
+                },
+                onCancel: () => {
+                  markStepFailed(i);
+                },
+              });
+              break;
+            }
+
+            if (step.type === ESwapStepType.BATCH_APPROVE_SWAP) {
+              if (!quoteResult) {
+                markStepFailed(i);
+                break;
+              }
+
+              await adapter.sendMarketSwapTx({
+                approvesInfo: adapter.buildMarketApproveInfos(quoteResult),
+                gasInfos: preSwapData.netWorkFee?.gasInfos,
+                networkFeeLevel: swapStepNetFeeLevel.networkFeeLevel,
+                onBroadcast: ({ txHash, orderId }) => {
+                  updateStep(i, {
+                    status: ESwapStepStatus.PENDING,
+                    txHash,
+                    orderId,
+                  });
+                },
+                onCancel: () => {
+                  markStepFailed(i);
+                },
+              });
+              break;
+            }
+          } catch {
+            markStepFailed(i);
+            break;
+          }
+        }
+      }
+    },
+    [
+      adapter,
+      intl,
+      markStepFailed,
+      swapStepNetFeeLevel.networkFeeLevel,
+      swapStepsState,
+      updateStep,
+    ],
+  );
+
+  useEffect(() => {
+    const speedApprove = inAppNotificationAtom.speedSwapApprovingTransaction;
+    if (speedApprove?.txId) {
+      latestApproveTxIdRef.current = speedApprove.txId;
+    }
+
+    const trackedApproveTxId =
+      speedApprove?.txId ?? latestApproveTxIdRef.current ?? '';
+    const speedApproveKey = `${trackedApproveTxId || 'no-tx'}:${
+      speedApprove?.status ?? 'idle'
+    }`;
+
+    if (
+      speedApprove?.status === undefined ||
+      speedApprove.status === ESwapApproveTransactionStatus.PENDING ||
+      handledApproveStatusRef.current === speedApproveKey
+    ) {
+      return;
+    }
+
+    handledApproveStatusRef.current = speedApproveKey;
+
+    const approveStepStatus =
+      speedApprove.status === ESwapApproveTransactionStatus.SUCCESS
+        ? ESwapStepStatus.SUCCESS
+        : ESwapStepStatus.FAILED;
+    const stepIndex = swapStepsState.steps.findIndex(
+      (step) =>
+        step.txHash === trackedApproveTxId ||
+        (!trackedApproveTxId &&
+          step.type === ESwapStepType.APPROVE_TX &&
+          step.status === ESwapStepStatus.PENDING),
+    );
+
+    if (stepIndex === -1) {
+      return;
+    }
+
+    const nextSteps = [...swapStepsState.steps];
+    nextSteps[stepIndex] = {
+      ...nextSteps[stepIndex],
+      status: approveStepStatus,
+    };
+
+    updateStep(stepIndex, {
+      status: approveStepStatus,
+      stepSubTitle: undefined,
+    });
+
+    if (approveStepStatus !== ESwapStepStatus.SUCCESS) {
+      return;
+    }
+
+    void preSwapStepsStart({
+      steps: nextSteps,
+      preSwapData: swapStepsState.preSwapData,
+      quoteResult: swapStepsState.quoteResult,
+    });
+  }, [
+    inAppNotificationAtom.speedSwapApprovingTransaction,
+    preSwapStepsStart,
+    swapStepsState.preSwapData,
+    swapStepsState.quoteResult,
+    swapStepsState.steps,
+    updateStep,
+  ]);
+
+  const onConfirm = useCallback(() => {
+    void preSwapStepsStart();
+  }, [preSwapStepsStart]);
+
+  return {
+    onConfirm,
+    preSwapBeforeStepActions,
+    preSwapStepsStart,
+  };
+}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useMarketSwapReviewActions.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useMarketSwapReviewActions.ts
@@ -78,13 +78,37 @@ export function useMarketSwapReviewActions({
   adapter: IMarketSwapReviewAdapter;
 }) {
   const intl = useIntl();
-  const [swapStepsState] = useSwapStepsAtom();
+  const [swapStepsState, setSwapSteps] = useSwapStepsAtom();
   const [swapStepNetFeeLevel] = useSwapStepNetFeeLevelAtom();
   const [inAppNotificationAtom] = useInAppNotificationAtom();
   const handledApproveStatusRef = useRef<string>('');
   const latestApproveTxIdRef = useRef<string>('');
   const { replaceReviewState, setBeforeActionsLoading, updateStep } =
     useReviewStepStateActions();
+
+  const clearPreSwapGasInfos = useCallback(
+    (preSwapData: ISwapPreSwapData) => {
+      if (!preSwapData.netWorkFee?.gasInfos?.length) {
+        return preSwapData;
+      }
+
+      const nextPreSwapData: ISwapPreSwapData = {
+        ...preSwapData,
+        netWorkFee: {
+          ...preSwapData.netWorkFee,
+          gasInfos: undefined,
+        },
+      };
+
+      setSwapSteps((prev) => ({
+        ...prev,
+        preSwapData: nextPreSwapData,
+      }));
+
+      return nextPreSwapData;
+    },
+    [setSwapSteps],
+  );
 
   const markStepFailed = useCallback(
     (stepIndex: number) => {
@@ -120,13 +144,21 @@ export function useMarketSwapReviewActions({
           },
         });
       } catch {
-        setBeforeActionsLoading(false);
+        setSwapSteps((prev) => ({
+          ...prev,
+          preSwapData: {
+            ...prev.preSwapData,
+            stepBeforeActionsLoading: false,
+            netWorkFee: undefined,
+          },
+        }));
       }
     },
     [
       adapter,
       replaceReviewState,
       setBeforeActionsLoading,
+      setSwapSteps,
       swapStepNetFeeLevel.networkFeeLevel,
     ],
   );
@@ -336,12 +368,15 @@ export function useMarketSwapReviewActions({
       return;
     }
 
+    const nextPreSwapData = clearPreSwapGasInfos(swapStepsState.preSwapData);
+
     void preSwapStepsStart({
       steps: nextSteps,
-      preSwapData: swapStepsState.preSwapData,
+      preSwapData: nextPreSwapData,
       quoteResult: swapStepsState.quoteResult,
     });
   }, [
+    clearPreSwapGasInfos,
     inAppNotificationAtom.speedSwapApprovingTransaction,
     preSwapStepsStart,
     swapStepsState.preSwapData,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -74,6 +74,7 @@ import type {
 import { buildMarketExecutionPayload } from './marketBuildExecutionUtils';
 import {
   type IMarketGasInfoEntry,
+  estimateMarketApproveGasInfos,
   estimateMarketDirectGasInfos,
   sendMarketDirectUnsignedTxs,
 } from './marketDirectSendTx';
@@ -1041,29 +1042,47 @@ export function useSpeedSwapActions(props: {
           accountId: snapshot.accountId,
           networkId: snapshot.networkId,
         });
-        const feeState = await estimateMarketDirectGasInfos({
-          accountAddress: snapshot.accountAddress,
-          accountId: snapshot.accountId,
-          networkId: snapshot.networkId,
-          buildUnsignedParams: snapshot.buildUnsignedParams,
-          approveUnsignedTxArr,
-          networkFeeLevel,
-        });
-
         if (
-          !snapshot.buildUnsignedParams.encodedTx &&
-          feeState.preparedUnsignedTx.encodedTx
+          snapshot.quoteResult.swapShouldSignedData &&
+          approveUnsignedTxArr?.length
         ) {
-          snapshot.buildUnsignedParams = {
-            ...snapshot.buildUnsignedParams,
-            encodedTx: feeState.preparedUnsignedTx.encodedTx,
+          const feeState = await estimateMarketApproveGasInfos({
+            accountAddress: snapshot.accountAddress,
+            accountId: snapshot.accountId,
+            networkId: snapshot.networkId,
+            approveUnsignedTxArr,
+            networkFeeLevel,
+          });
+
+          netWorkFee = {
+            gasInfos: feeState.gasInfos,
+            gasFeeFiatValue: feeState.gasFeeFiatValue,
+          };
+        } else {
+          const feeState = await estimateMarketDirectGasInfos({
+            accountAddress: snapshot.accountAddress,
+            accountId: snapshot.accountId,
+            networkId: snapshot.networkId,
+            buildUnsignedParams: snapshot.buildUnsignedParams,
+            approveUnsignedTxArr,
+            networkFeeLevel,
+          });
+
+          if (
+            !snapshot.buildUnsignedParams.encodedTx &&
+            feeState.preparedUnsignedTx.encodedTx
+          ) {
+            snapshot.buildUnsignedParams = {
+              ...snapshot.buildUnsignedParams,
+              encodedTx: feeState.preparedUnsignedTx.encodedTx,
+            };
+          }
+
+          netWorkFee = {
+            gasInfos: feeState.gasInfos,
+            gasFeeFiatValue: feeState.gasFeeFiatValue,
           };
         }
-
-        netWorkFee = {
-          gasInfos: feeState.gasInfos,
-          gasFeeFiatValue: feeState.gasFeeFiatValue,
-        };
       } catch {
         netWorkFee = undefined;
       }

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -83,6 +83,7 @@ import {
   shouldAutoContinueMarketResetApprove,
 } from './marketReviewExecutionUtils';
 import {
+  buildDefaultMarketSpeedCheckState,
   buildMarketReviewShouldFallback,
   mergeMarketBuildResultWithQuote,
   pickMarketQuoteResultByProvider,
@@ -90,6 +91,7 @@ import {
 } from './marketSwapBuildUtils';
 import {
   assertMarketReviewQuoteResult,
+  assertMarketSignedBuildInvariant,
   buildMarketApproveInfos,
   buildMarketSwapApprovingTransaction,
   buildWrappedMarketQuoteResult,
@@ -226,6 +228,10 @@ export function useSpeedSwapActions(props: {
   const reviewExecutionSnapshotRef = useRef<
     IMarketReviewExecutionSnapshot | undefined
   >(undefined);
+  const defaultMarketSpeedCheckState = useMemo(
+    () => buildDefaultMarketSpeedCheckState(),
+    [],
+  );
 
   const effectiveSpenderAddress = checkSpenderAddress || spenderAddress;
 
@@ -1781,7 +1787,11 @@ export function useSpeedSwapActions(props: {
   const sendMarketSignMessage = useCallback<
     IMarketSwapReviewAdapter['sendMarketSignMessage']
   >(
-    async ({ networkFeeLevel, onBroadcast, onCancel } = {}) => {
+    async ({
+      networkFeeLevel: _networkFeeLevel,
+      onBroadcast,
+      onCancel,
+    } = {}) => {
       const snapshot = requireReviewExecutionSnapshot('swap');
 
       try {
@@ -1827,6 +1837,11 @@ export function useSpeedSwapActions(props: {
           buildRes,
           quoteResult: signedQuoteResult,
         });
+        const reviewedBuildResult = assertMarketSignedBuildInvariant({
+          reviewedQuoteResult: snapshot.quoteResult,
+          rebuiltQuoteResult: buildResFinal.result,
+          skipSendTransAction,
+        });
 
         reviewExecutionSnapshotRef.current = {
           kind: 'swap',
@@ -1834,7 +1849,13 @@ export function useSpeedSwapActions(props: {
           accountId: snapshot.accountId,
           networkId: snapshot.networkId,
           shouldFallback: snapshot.shouldFallback,
-          quoteResult: signedQuoteResult,
+          quoteResult: {
+            ...signedQuoteResult,
+            info: reviewedBuildResult.info,
+            fromAmount: reviewedBuildResult.fromAmount,
+            toAmount: reviewedBuildResult.toAmount,
+            minToAmount: reviewedBuildResult.minToAmount,
+          },
           buildUnsignedParams: {
             networkId: snapshot.networkId,
             accountId: snapshot.accountId,
@@ -1862,36 +1883,7 @@ export function useSpeedSwapActions(props: {
             userAddress: snapshot.accountAddress,
             status: ESwapEventAPIStatus.SUCCESS,
           });
-          return;
         }
-
-        const feeState = await estimateMarketDirectGasInfos({
-          accountAddress: snapshot.accountAddress,
-          accountId: snapshot.accountId,
-          networkId: snapshot.networkId,
-          buildUnsignedParams:
-            reviewExecutionSnapshotRef.current.buildUnsignedParams,
-          networkFeeLevel,
-        });
-        const data = await sendMarketDirectUnsignedTxs({
-          accountAddress: snapshot.accountAddress,
-          accountId: snapshot.accountId,
-          networkId: snapshot.networkId,
-          buildUnsignedParams:
-            reviewExecutionSnapshotRef.current.buildUnsignedParams,
-          gasInfos: feeState.gasInfos,
-          networkFeeLevel,
-        });
-        const result = await handleMarketSwapBuildTxSuccess(data);
-        if (result) {
-          onBroadcast?.(result);
-        }
-        logMarketCreateOrder({
-          buildRes: buildResFinal,
-          amount: swapInfo.sender.amount,
-          userAddress: snapshot.accountAddress,
-          status: ESwapEventAPIStatus.SUCCESS,
-        });
       } catch (error) {
         cancelSpeedSwapBuildTx();
         if (snapshot.buildRes) {
@@ -1914,7 +1906,6 @@ export function useSpeedSwapActions(props: {
       buildMarketExecutionFromBuildRes,
       cancelSpeedSwapBuildTx,
       handleMarketSignedOrderSuccess,
-      handleMarketSwapBuildTxSuccess,
       isUserCancelledError,
       logMarketCreateOrder,
       requireReviewExecutionSnapshot,
@@ -2187,11 +2178,13 @@ export function useSpeedSwapActions(props: {
     async (amount: string) => {
       const amountBN = new BigNumber(amount || 0);
       if (amountBN.isNaN() || amountBN.lte(0)) {
-        setSpeedCheckError('');
-        setCheckSpenderAddress('');
-        setIsStock(false);
-        setShouldApprove(false);
-        setShouldResetApprove(false);
+        setSpeedCheckError(defaultMarketSpeedCheckState.speedCheckError);
+        setCheckSpenderAddress(
+          defaultMarketSpeedCheckState.checkSpenderAddress,
+        );
+        setIsStock(defaultMarketSpeedCheckState.isStock);
+        setShouldApprove(defaultMarketSpeedCheckState.shouldApprove);
+        setShouldResetApprove(defaultMarketSpeedCheckState.shouldResetApprove);
         return;
       }
 
@@ -2255,6 +2248,7 @@ export function useSpeedSwapActions(props: {
       }
     },
     [
+      defaultMarketSpeedCheckState,
       fromToken.networkId,
       fromToken.contractAddress,
       fromToken.isNative,
@@ -2286,12 +2280,14 @@ export function useSpeedSwapActions(props: {
         fromTokenAmountDebouncedBN.toFixed(),
       );
     } else {
-      setSpeedCheckError('');
-      setCheckSpenderAddress('');
-      setShouldApprove(false);
-      setShouldResetApprove(false);
+      setSpeedCheckError(defaultMarketSpeedCheckState.speedCheckError);
+      setCheckSpenderAddress(defaultMarketSpeedCheckState.checkSpenderAddress);
+      setIsStock(defaultMarketSpeedCheckState.isStock);
+      setShouldApprove(defaultMarketSpeedCheckState.shouldApprove);
+      setShouldResetApprove(defaultMarketSpeedCheckState.shouldResetApprove);
     }
   }, [
+    defaultMarketSpeedCheckState,
     isWrapped,
     balance,
     fromToken.isNative,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -48,7 +48,6 @@ import { wrappedTokens } from '@onekeyhq/shared/types/swap/SwapProvider.constant
 import type {
   IFetchBuildTxResponse,
   IFetchQuoteResult,
-  IOneInchOrderStruct,
   ISwapApproveTransaction,
   ISwapNativeTokenReserveGas,
   ISwapToken,
@@ -93,6 +92,7 @@ import {
 import {
   assertMarketReviewQuoteResult,
   assertMarketSignedBuildInvariant,
+  attachMarketOneInchFusionSignature,
   buildMarketApproveInfos,
   buildMarketSwapApprovingTransaction,
   buildWrappedMarketQuoteResult,
@@ -1446,15 +1446,6 @@ export function useSpeedSwapActions(props: {
       }
 
       if (oneInchFusionOrder) {
-        const onInchFusionOrderInfo: {
-          orderStruct: IOneInchOrderStruct;
-          extension: string;
-          quoteId: string;
-          signature?: string;
-          orderHash: string;
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        } = signedQuoteResult.quoteResultCtx?.oneInchFusionOrderCtx;
-
         if (oneInchFusionOrder.makerAddress && oneInchFusionOrder.typedData) {
           const dataMessage = JSON.stringify(oneInchFusionOrder.typedData);
           const signature = await backgroundApiProxy.serviceSend.signMessage({
@@ -1471,11 +1462,10 @@ export function useSpeedSwapActions(props: {
             throw new OneKeyError('sign message failed');
           }
 
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          signedQuoteResult.quoteResultCtx.oneInchFusionOrderCtx = {
-            ...onInchFusionOrderInfo,
+          attachMarketOneInchFusionSignature({
+            quoteResult: signedQuoteResult,
             signature,
-          };
+          });
 
           return signedQuoteResult;
         }

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -90,6 +90,7 @@ import {
   shouldFetchMarketQuoteFallbackData,
 } from './marketSwapBuildUtils';
 import {
+  areMarketApproveAmountsEqual,
   assertMarketReviewQuoteResult,
   assertMarketSignedBuildInvariant,
   attachMarketOneInchFusionSignature,
@@ -611,8 +612,11 @@ export function useSpeedSwapActions(props: {
     ) => {
       return Boolean(
         approvingTransaction &&
-        (amount === approvingTransaction.amount ||
-          amount === approvingTransaction.resetApproveValue) &&
+        (areMarketApproveAmountsEqual(amount, approvingTransaction.amount) ||
+          areMarketApproveAmountsEqual(
+            amount,
+            approvingTransaction.resetApproveValue,
+          )) &&
         equalTokenNoCaseSensitive({
           token1: approvingTransaction.fromToken,
           token2: currentFromToken,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -8,26 +8,26 @@ import {
 } from '@cowprotocol/contracts';
 import BigNumber from 'bignumber.js';
 import { ethers } from 'ethers';
+import { cloneDeep } from 'lodash';
 import { useIntl } from 'react-intl';
 
-import { Dialog, Toast } from '@onekeyhq/components';
-import type { IEncodedTx } from '@onekeyhq/core/src/types';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { useDebounce } from '@onekeyhq/kit/src/hooks/useDebounce';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
-import { useSignatureConfirm } from '@onekeyhq/kit/src/hooks/useSignatureConfirm';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import { useSelectedDeriveTypeAtom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2/atoms';
+import { type ISwapReviewStepTexts } from '@onekeyhq/kit/src/views/Swap/utils/buildSwapReviewState';
 import {
   useInAppNotificationAtom,
   useSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type {
   IApproveInfo,
-  ITransferInfo,
+  IBuildUnsignedTxParams,
   IWrappedInfo,
 } from '@onekeyhq/kit-bg/src/vaults/types';
 import { presetNetworksMap } from '@onekeyhq/shared/src/config/presetNetworks';
+import { OneKeyError, OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -35,7 +35,6 @@ import {
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { ESwapEventAPIStatus } from '@onekeyhq/shared/src/logger/scopes/swap/scenes/swapEstimateFee';
-import { toBigIntHex } from '@onekeyhq/shared/src/utils/numberUtils';
 import stringUtils from '@onekeyhq/shared/src/utils/stringUtils';
 import {
   checkWrappedTokenPair,
@@ -47,6 +46,9 @@ import {
 } from '@onekeyhq/shared/types/message';
 import { wrappedTokens } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
 import type {
+  IFetchBuildTxResponse,
+  IFetchQuoteResult,
+  IOneInchOrderStruct,
   ISwapApproveTransaction,
   ISwapNativeTokenReserveGas,
   ISwapToken,
@@ -58,14 +60,108 @@ import {
   EProtocolOfExchange,
   ESwapApproveTransactionStatus,
   ESwapFetchCancelCause,
+  ESwapNetworkFeeLevel,
   ESwapQuoteKind,
   ESwapTabSwitchType,
   ESwapTxHistoryStatus,
   EWrappedType,
 } from '@onekeyhq/shared/types/swap/types';
-import type { ISendTxOnSuccessData } from '@onekeyhq/shared/types/tx';
+import type {
+  ISendTxBaseParams,
+  ISendTxOnSuccessData,
+} from '@onekeyhq/shared/types/tx';
 
+import { buildMarketExecutionPayload } from './marketBuildExecutionUtils';
+import {
+  type IMarketGasInfoEntry,
+  estimateMarketDirectGasInfos,
+  sendMarketDirectUnsignedTxs,
+} from './marketDirectSendTx';
+import { resolveMarketReviewAllowanceState } from './marketReviewAllowance';
+import {
+  buildMarketReviewState,
+  shouldAutoContinueMarketResetApprove,
+} from './marketReviewExecutionUtils';
+import {
+  buildMarketReviewShouldFallback,
+  mergeMarketBuildResultWithQuote,
+  pickMarketQuoteResultByProvider,
+  shouldFetchMarketQuoteFallbackData,
+} from './marketSwapBuildUtils';
+import {
+  assertMarketReviewQuoteResult,
+  buildMarketApproveInfos,
+  buildMarketSwapApprovingTransaction,
+  buildWrappedMarketQuoteResult,
+  extractMarketSwapSuccessResult,
+  normalizeMarketReviewQuoteResult,
+} from './marketSwapReviewUtils';
 import { ESwapDirection } from './useTradeType';
+
+import type { IMarketSwapReviewState } from '../MarketSwapReviewInitializer';
+
+export type IMarketSwapBroadcastResult = {
+  txHash?: string;
+  orderId?: string;
+  gasFeeFiatValue?: string;
+  gasFeeInNative?: string;
+};
+
+export type IMarketApproveBroadcastResult = {
+  txHash: string;
+  amount: string;
+};
+
+export type IMarketSwapReviewAdapter = {
+  prepareMarketSwapReview: (params?: {
+    fromAmount?: string;
+    fromToken?: ISwapToken;
+    toToken?: ISwapToken;
+    isWrap?: boolean;
+    quoteResult?: IFetchQuoteResult;
+    networkFeeLevel?: ESwapNetworkFeeLevel;
+  }) => Promise<IMarketSwapReviewState>;
+  sendMarketApproveTx: (params: {
+    amount: string;
+    gasInfos?: IMarketGasInfoEntry[];
+    isResetApprove?: boolean;
+    networkFeeLevel?: ESwapNetworkFeeLevel;
+    quoteResult: IFetchQuoteResult;
+    onBroadcast?: (result: IMarketApproveBroadcastResult) => void;
+    onCancel?: () => void;
+  }) => Promise<void>;
+  sendMarketSwapTx: (params?: {
+    approvesInfo?: IApproveInfo[];
+    gasInfos?: IMarketGasInfoEntry[];
+    networkFeeLevel?: ESwapNetworkFeeLevel;
+    onBroadcast?: (result: IMarketSwapBroadcastResult) => void;
+    onCancel?: () => void;
+  }) => Promise<void>;
+  sendMarketWrappedTx: (params?: {
+    gasInfos?: IMarketGasInfoEntry[];
+    networkFeeLevel?: ESwapNetworkFeeLevel;
+    onBroadcast?: (result: IMarketSwapBroadcastResult) => void;
+    onCancel?: () => void;
+  }) => Promise<void>;
+  sendMarketSignMessage: (params?: {
+    networkFeeLevel?: ESwapNetworkFeeLevel;
+    onBroadcast?: (result: IMarketSwapBroadcastResult) => void;
+    onCancel?: () => void;
+  }) => Promise<void>;
+  buildMarketApproveInfos: (quoteResult?: IFetchQuoteResult) => IApproveInfo[];
+};
+
+type IMarketReviewExecutionSnapshot = {
+  kind: 'swap' | 'wrap';
+  accountAddress: string;
+  accountId: string;
+  networkId: string;
+  shouldFallback: boolean;
+  quoteResult: IFetchQuoteResult;
+  buildUnsignedParams: ISendTxBaseParams & IBuildUnsignedTxParams;
+  swapInfo: ISwapTxInfo;
+  buildRes?: IFetchBuildTxResponse;
+};
 
 export function useSpeedSwapActions(props: {
   marketToken: ISwapToken;
@@ -77,6 +173,8 @@ export function useSpeedSwapActions(props: {
   slippage: number;
   defaultTradeTokens: ISwapTokenBase[];
   antiMEV: boolean;
+  isCustomRpcUnavailable?: boolean;
+  isReviewDialogOpen?: boolean;
   onCloseDialog?: () => void;
 }) {
   const {
@@ -89,6 +187,8 @@ export function useSpeedSwapActions(props: {
     slippage,
     defaultTradeTokens,
     antiMEV,
+    isCustomRpcUnavailable,
+    isReviewDialogOpen,
     // onCloseDialog,
   } = props;
 
@@ -106,9 +206,6 @@ export function useSpeedSwapActions(props: {
   const [swapNativeTokenReserveGas, setSwapNativeTokenReserveGas] = useState<
     ISwapNativeTokenReserveGas[]
   >([]);
-  const [{ isFirstTimeSwap }] = useSettingsPersistAtom();
-  const [speedSwapApproveActionLoading, setSpeedSwapApproveActionLoading] =
-    useState(false);
   const [priceRate, setPriceRate] = useState<
     | {
         rate?: number;
@@ -126,6 +223,9 @@ export function useSpeedSwapActions(props: {
   const [checkSpenderAddress, setCheckSpenderAddress] = useState('');
   const [isStock, setIsStock] = useState(false);
   const speedCheckRequestIdRef = useRef(0);
+  const reviewExecutionSnapshotRef = useRef<
+    IMarketReviewExecutionSnapshot | undefined
+  >(undefined);
 
   const effectiveSpenderAddress = checkSpenderAddress || spenderAddress;
 
@@ -175,6 +275,28 @@ export function useSpeedSwapActions(props: {
     }
   }, [account, balanceToken?.networkId, selectedDeriveType]);
 
+  const marketDeriveInfoRes = usePromiseResult(async () => {
+    if (!balanceToken?.networkId) {
+      return undefined;
+    }
+
+    const defaultDeriveType =
+      await backgroundApiProxy.serviceNetwork.getGlobalDeriveTypeOfNetwork({
+        networkId: balanceToken.networkId,
+      });
+
+    const effectiveDeriveType =
+      selectedDeriveType ??
+      defaultDeriveType ??
+      account?.deriveType ??
+      'default';
+
+    return backgroundApiProxy.serviceNetwork.getDeriveInfoOfNetwork({
+      networkId: balanceToken.networkId,
+      deriveType: effectiveDeriveType,
+    });
+  }, [account?.deriveType, balanceToken?.networkId, selectedDeriveType]);
+
   // Listen for derive type changes and re-fetch network account
   useEffect(() => {
     const handleDeriveTypeChanged = () => {
@@ -197,11 +319,6 @@ export function useSpeedSwapActions(props: {
     };
   }, [netAccountRes]);
 
-  const { navigationToTxConfirm, navigationToMessageConfirmAsync } =
-    useSignatureConfirm({
-      accountId: netAccountRes.result?.id ?? '',
-      networkId: marketToken?.networkId,
-    });
   const fromTokenAmountDebounced = useDebounce(fromTokenAmount, 300, {
     leading: true,
   });
@@ -238,154 +355,59 @@ export function useSpeedSwapActions(props: {
     tradeTokenContractAddress,
   ]);
 
-  const speedSwapApproveTransactionLoading = useMemo(() => {
-    const speedSwapApproveTransaction =
-      inAppNotificationAtom.speedSwapApprovingTransaction;
-    const fromTokenAmountDebouncedBN = new BigNumber(
-      fromTokenAmountDebounced ?? 0,
-    );
-    if (
-      speedSwapApproveTransaction &&
-      inAppNotificationAtom.speedSwapApprovingLoading &&
-      equalTokenNoCaseSensitive({
-        token1: speedSwapApproveTransaction.fromToken,
-        token2: fromToken,
-      }) &&
-      speedSwapApproveTransaction.amount ===
-        fromTokenAmountDebouncedBN.toFixed()
-    ) {
-      return true;
-    }
-    return false;
-  }, [
-    inAppNotificationAtom.speedSwapApprovingLoading,
-    inAppNotificationAtom.speedSwapApprovingTransaction,
-    fromToken,
-    fromTokenAmountDebounced,
-  ]);
-
-  // --- build tx
-
-  const handleSpeedSwapBuildTxSuccess = useCallback(
-    async (data: ISendTxOnSuccessData[]) => {
-      setSpeedSwapBuildTxLoading(false);
-      const transactionSignedInfo = data[0].signedTx;
-      const transactionDecodedInfo = data[0].decodedTx;
-      const txId = transactionSignedInfo.txid;
-      const { swapInfo } = transactionSignedInfo;
-      const {
-        totalFeeInNative,
-        totalFeeFiatValue,
-        networkId: txNetworkId,
-      } = transactionDecodedInfo;
-
-      if (swapInfo) {
-        appEventBus.emit(EAppEventBusNames.SwapSpeedBuildTxSuccess, {
-          fromToken,
-          toToken,
-          fromAmount: swapInfo.sender.amount,
-          toAmount: swapInfo.receiver.amount,
-        });
-
-        const fromNetworkPreset = Object.values(presetNetworksMap).find(
-          (item) => item.id === swapInfo.sender.token.networkId,
-        );
-        const toNetworkPreset = Object.values(presetNetworksMap).find(
-          (item) => item.id === swapInfo.receiver.token.networkId,
-        );
-        if (
-          swapInfo &&
-          (swapInfo.protocol === EProtocolOfExchange.SWAP ||
-            swapInfo.swapBuildResData.result.isWrapped)
-        ) {
-          const useOrderId = false;
-          const swapHistoryItem: ISwapTxHistory = {
-            status: ESwapTxHistoryStatus.PENDING,
-            currency: settingsAtom.currencyInfo?.symbol,
-            accountInfo: {
-              sender: {
-                accountId: swapInfo.sender.accountInfo?.accountId,
-                networkId: swapInfo.sender.accountInfo?.networkId,
-              },
-              receiver: {
-                accountId: swapInfo.receiver.accountInfo?.accountId,
-                networkId: swapInfo.receiver.accountInfo?.networkId,
-              },
-            },
-            baseInfo: {
-              toAmount: swapInfo.receiver.amount,
-              fromAmount: swapInfo.sender.amount,
-              fromToken: swapInfo.sender.token,
-              toToken: swapInfo.receiver.token,
-              fromNetwork: {
-                networkId: fromNetworkPreset?.id ?? '',
-                name: fromNetworkPreset?.name ?? '',
-                symbol: fromNetworkPreset?.symbol ?? '',
-                logoURI: fromNetworkPreset?.logoURI ?? '',
-                shortcode: fromNetworkPreset?.shortcode ?? '',
-              },
-              toNetwork: {
-                networkId: toNetworkPreset?.id ?? '',
-                name: toNetworkPreset?.name ?? '',
-                symbol: toNetworkPreset?.symbol ?? '',
-                logoURI: toNetworkPreset?.logoURI ?? '',
-                shortcode: toNetworkPreset?.shortcode ?? '',
-              },
-            },
-            txInfo: {
-              txId,
-              useOrderId,
-              gasFeeFiatValue: totalFeeFiatValue,
-              gasFeeInNative: totalFeeInNative,
-              sender: swapInfo.accountAddress,
-              receiver: swapInfo.receivingAddress,
-            },
-            date: {
-              created: Date.now(),
-              updated: Date.now(),
-            },
-            swapInfo: {
-              instantRate: swapInfo.swapBuildResData.result?.instantRate ?? '0',
-              provider: swapInfo.swapBuildResData.result?.info,
-              socketBridgeScanUrl:
-                swapInfo.swapBuildResData.socketBridgeScanUrl,
-              oneKeyFee:
-                swapInfo.swapBuildResData.result?.fee?.percentageFee ?? 0,
-              protocolFee:
-                swapInfo.swapBuildResData.result?.fee?.protocolFees ?? 0,
-              otherFeeInfos:
-                swapInfo.swapBuildResData.result?.fee?.otherFeeInfos ?? [],
-              orderId: swapInfo.swapBuildResData.orderId,
-              supportUrl: swapInfo.swapBuildResData.result?.supportUrl,
-              orderSupportUrl:
-                swapInfo.swapBuildResData.result?.orderSupportUrl,
-              oneKeyFeeExtraInfo:
-                swapInfo.swapBuildResData.result?.oneKeyFeeExtraInfo,
-            },
-            ctx: swapInfo.swapBuildResData.ctx,
-          };
-          await backgroundApiProxy.serviceSwap.addSwapHistoryItem(
-            swapHistoryItem,
-          );
-          if (
-            swapInfo.sender.token.networkId ===
-            swapInfo.receiver.token.networkId
-          ) {
-            void backgroundApiProxy.serviceNotification.blockNotificationForTxId(
-              {
-                networkId: txNetworkId,
-                tx: txId,
-              },
-            );
-          }
-        }
-      }
-    },
-    [settingsAtom.currencyInfo?.symbol, fromToken, toToken],
+  const buildReviewStepTexts = useCallback(
+    (providerName?: string): ISwapReviewStepTexts => ({
+      wrap: intl.formatMessage({
+        id: ETranslations.swap_page_button_wrap,
+      }),
+      approveAndSwap: intl.formatMessage({
+        id: ETranslations.swap_page_approve_and_swap,
+      }),
+      approveAndSign: intl.formatMessage({
+        id: ETranslations.swap_page_approve_and_sign,
+      }),
+      revokeApprove: intl.formatMessage(
+        {
+          id: ETranslations.global_revoke_approve,
+        },
+        {
+          symbol: fromToken.symbol,
+        },
+      ),
+      approveToken: intl.formatMessage(
+        {
+          id: ETranslations.swap_page_approve_button,
+        },
+        {
+          token: fromToken.symbol,
+        },
+      ),
+      approveTokenWithTarget: intl.formatMessage(
+        {
+          id: ETranslations.swap_page_approve_button,
+        },
+        {
+          token: fromToken.symbol,
+          target: providerName,
+        },
+      ),
+      signAndSubmit: intl.formatMessage({
+        id: ETranslations.swap_review_sign_and_submit,
+      }),
+      sign: intl.formatMessage({
+        id: ETranslations.global_sign,
+      }),
+      confirmSwap: intl.formatMessage({
+        id: ETranslations.swap_review_confirm_swap,
+      }),
+      swap: intl.formatMessage({
+        id: ETranslations.global_swap,
+      }),
+    }),
+    [fromToken.symbol, intl],
   );
 
   const cancelSpeedSwapBuildTx = useCallback(() => {
-    // todo cancel build tx
     setSpeedSwapBuildTxLoading(false);
   }, []);
 
@@ -394,581 +416,812 @@ export function useSpeedSwapActions(props: {
     [fromToken, toToken],
   );
 
-  const speedSwapBuildTx = useCallback(async () => {
-    setSpeedSwapBuildTxLoading(true);
-    const userAddress = netAccountRes.result?.addressDetail.address ?? '';
-    const accountId = netAccountRes.result?.id ?? '';
+  const persistMarketSwapHistoryItem = useCallback(
+    async ({
+      swapInfo,
+      txHash,
+      gasFeeFiatValue,
+      gasFeeInNative,
+    }: {
+      swapInfo: ISwapTxInfo;
+      txHash?: string;
+      gasFeeFiatValue?: string;
+      gasFeeInNative?: string;
+    }) => {
+      const txNetworkId = swapInfo.sender.token.networkId;
+      const historyOrderId =
+        swapInfo.swapBuildResData.swftOrder?.orderId ??
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        swapInfo.swapBuildResData.ctx?.cowSwapOrderId ??
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        swapInfo.swapBuildResData.ctx?.oneInchFusionOrderHash ??
+        swapInfo.swapBuildResData.orderId ??
+        swapInfo.swapBuildResData.result?.quoteId;
+      const fromNetworkPreset = Object.values(presetNetworksMap).find(
+        (item) => item.id === swapInfo.sender.token.networkId,
+      );
+      const toNetworkPreset = Object.values(presetNetworksMap).find(
+        (item) => item.id === swapInfo.receiver.token.networkId,
+      );
+      const useOrderId = Boolean(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        swapInfo.swapBuildResData.ctx?.cowSwapOrderId ||
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        swapInfo.swapBuildResData.ctx?.oneInchFusionOrderHash,
+      );
 
-    // isStock flow: quote-market/speed -> signMessage -> build
-    if (isStock) {
-      try {
-        const quoteRes =
-          await backgroundApiProxy.serviceSwap.fetchSpeedMarketQuote({
-            fromToken,
-            toToken,
-            fromTokenAmount: fromTokenAmountDebounced,
-            userAddress,
-            receivingAddress: userAddress,
-            slippagePercentage: slippage,
-            accountId,
-          });
-        if (!quoteRes?.swapShouldSignedData) {
-          setSpeedSwapBuildTxLoading(false);
-          Toast.error({
-            title:
-              quoteRes?.errorMessage ||
-              intl.formatMessage({
-                id: ETranslations.global_server_error,
-              }),
-          });
-          return;
-        }
-
-        let signedQuoteResultCtx = quoteRes.quoteResultCtx;
-        if (quoteRes.swapShouldSignedData) {
-          const {
-            unSignedInfo,
-            unSignedMessage,
-            unSignedData,
-            oneInchFusionOrder,
-          } = quoteRes.swapShouldSignedData;
-
-          if (oneInchFusionOrder) {
-            // 1inchFusion flow
-            const { makerAddress, typedData } = oneInchFusionOrder;
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            const fusionOrderCtx = signedQuoteResultCtx?.oneInchFusionOrderCtx;
-            if (makerAddress && typedData && fusionOrderCtx) {
-              const dataMessage = JSON.stringify(typedData);
-              const signHash = await navigationToMessageConfirmAsync({
-                unsignedMessage: {
-                  type:
-                    unSignedInfo.signedType ?? EMessageTypesEth.TYPED_DATA_V4,
-                  message: dataMessage,
-                  payload: [userAddress.toLowerCase(), dataMessage],
-                },
-                networkId: fromToken.networkId,
-                accountId,
-              });
-              if (!signHash) {
-                setSpeedSwapBuildTxLoading(false);
-                return;
-              }
-              signedQuoteResultCtx = {
-                ...signedQuoteResultCtx,
-                oneInchFusionOrderCtx: {
-                  ...fusionOrderCtx,
-                  signature: signHash,
-                },
-              };
-            }
-          } else if (
-            (unSignedMessage || unSignedData) &&
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            signedQuoteResultCtx?.cowSwapUnSignedOrder
-          ) {
-            // cowSwap flow
-            const unSignedOrder: {
-              sellTokenBalance: string;
-              buyTokenBalance: string;
-              validTo: number;
-              appData: string;
-              receiver: string;
-              buyAmount: string;
-              sellAmount: string;
-              partiallyFillable: boolean;
-            } =
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-              signedQuoteResultCtx?.cowSwapUnSignedOrder;
-            unSignedOrder.receiver = userAddress;
-
-            let dataMessage = unSignedMessage;
-            if (!dataMessage && unSignedData) {
-              const normalizeData = {
-                ...unSignedOrder,
-                sellTokenBalance:
-                  (unSignedOrder.sellTokenBalance as OrderBalance) ??
-                  OrderBalance.ERC20,
-                buyTokenBalance: normalizeBuyTokenBalance(
-                  unSignedOrder.buyTokenBalance as OrderBalance,
-                ),
-                validTo: timestamp(unSignedOrder.validTo),
-                appData: hashify(unSignedOrder.appData),
-              };
-              const populated =
-                await ethers.utils._TypedDataEncoder.resolveNames(
-                  unSignedData.domain,
-                  unSignedData.types,
-                  normalizeData,
-                  async (value: string) => value,
-                );
-              dataMessage = JSON.stringify(
-                ethers.utils._TypedDataEncoder.getPayload(
-                  populated.domain,
-                  unSignedData.types,
-                  populated.value,
-                ),
-              );
-            }
-            if (dataMessage) {
-              const signHash = await navigationToMessageConfirmAsync({
-                unsignedMessage: {
-                  type:
-                    unSignedInfo.signedType ?? EMessageTypesEth.TYPED_DATA_V4,
-                  message: dataMessage,
-                  payload: [userAddress.toLowerCase(), dataMessage],
-                },
-                networkId: fromToken.networkId,
-                accountId,
-              });
-              if (!signHash) {
-                setSpeedSwapBuildTxLoading(false);
-                return;
-              }
-              signedQuoteResultCtx = {
-                ...signedQuoteResultCtx,
-                cowSwapUnSignedOrder: unSignedOrder,
-                signedResult: {
-                  signature: signHash,
-                  signingScheme: ESigningScheme.EIP712,
-                },
-              };
-            }
-          }
-        }
-
-        const buildParams = {
-          fromToken,
-          toToken,
-          fromTokenAmount: fromTokenAmountDebounced,
-          provider: quoteRes.info?.provider || provider,
-          userAddress,
-          receivingAddress: userAddress,
-          slippagePercentage: slippage,
-          accountId,
-          protocol: EProtocolOfExchange.SWAP,
-          kind: ESwapQuoteKind.SELL,
-          quoteResultCtx: signedQuoteResultCtx,
+      if (
+        swapInfo.protocol === EProtocolOfExchange.SWAP ||
+        swapInfo.swapBuildResData.result.isWrapped
+      ) {
+        const swapHistoryItem: ISwapTxHistory = {
+          status: ESwapTxHistoryStatus.PENDING,
+          currency: settingsAtom.currencyInfo?.symbol,
+          accountInfo: {
+            sender: {
+              accountId: swapInfo.sender.accountInfo?.accountId,
+              networkId: swapInfo.sender.accountInfo?.networkId,
+            },
+            receiver: {
+              accountId: swapInfo.receiver.accountInfo?.accountId,
+              networkId: swapInfo.receiver.accountInfo?.networkId,
+            },
+          },
+          baseInfo: {
+            toAmount: swapInfo.receiver.amount,
+            fromAmount: swapInfo.sender.amount,
+            fromToken: swapInfo.sender.token,
+            toToken: swapInfo.receiver.token,
+            fromNetwork: {
+              networkId: fromNetworkPreset?.id ?? '',
+              name: fromNetworkPreset?.name ?? '',
+              symbol: fromNetworkPreset?.symbol ?? '',
+              logoURI: fromNetworkPreset?.logoURI ?? '',
+              shortcode: fromNetworkPreset?.shortcode ?? '',
+            },
+            toNetwork: {
+              networkId: toNetworkPreset?.id ?? '',
+              name: toNetworkPreset?.name ?? '',
+              symbol: toNetworkPreset?.symbol ?? '',
+              logoURI: toNetworkPreset?.logoURI ?? '',
+              shortcode: toNetworkPreset?.shortcode ?? '',
+            },
+          },
+          txInfo: {
+            txId: txHash,
+            useOrderId,
+            gasFeeFiatValue,
+            gasFeeInNative,
+            orderId: historyOrderId,
+            sender: swapInfo.accountAddress,
+            receiver: swapInfo.receivingAddress,
+          },
+          date: {
+            created: Date.now(),
+            updated: Date.now(),
+          },
+          swapInfo: {
+            instantRate: swapInfo.swapBuildResData.result?.instantRate ?? '0',
+            provider: swapInfo.swapBuildResData.result?.info,
+            socketBridgeScanUrl: swapInfo.swapBuildResData.socketBridgeScanUrl,
+            oneKeyFee:
+              swapInfo.swapBuildResData.result?.fee?.percentageFee ?? 0,
+            protocolFee:
+              swapInfo.swapBuildResData.result?.fee?.protocolFees ?? 0,
+            otherFeeInfos:
+              swapInfo.swapBuildResData.result?.fee?.otherFeeInfos ?? [],
+            orderId: historyOrderId,
+            supportUrl: swapInfo.swapBuildResData.result?.supportUrl,
+            orderSupportUrl: swapInfo.swapBuildResData.result?.orderSupportUrl,
+            oneKeyFeeExtraInfo:
+              swapInfo.swapBuildResData.result?.oneKeyFeeExtraInfo,
+          },
+          ctx: swapInfo.swapBuildResData.ctx,
         };
-        const buildRes =
-          await backgroundApiProxy.serviceSwap.fetchBuildSpeedSwapTx(
-            buildParams,
-          );
-        setSpeedSwapBuildTxLoading(false);
-        if (buildRes) {
+        await backgroundApiProxy.serviceSwap.addSwapHistoryItem(
+          swapHistoryItem,
+        );
+
+        if (
+          txHash &&
+          txNetworkId &&
+          swapInfo.sender.token.networkId === swapInfo.receiver.token.networkId
+        ) {
+          void backgroundApiProxy.serviceNotification.blockNotificationForTxId({
+            networkId: txNetworkId,
+            tx: txHash,
+          });
+        }
+      }
+
+      return {
+        orderId: historyOrderId,
+      };
+    },
+    [settingsAtom.currencyInfo?.symbol],
+  );
+
+  const handleMarketSwapBuildTxSuccess = useCallback(
+    async (data: ISendTxOnSuccessData[]) => {
+      setSpeedSwapBuildTxLoading(false);
+
+      const swapTxData = data
+        .toReversed()
+        .find((item) => item.signedTx.swapInfo);
+      const result = extractMarketSwapSuccessResult(data);
+      const swapInfo = swapTxData?.signedTx.swapInfo;
+
+      if (!swapInfo || !result) {
+        return undefined;
+      }
+
+      appEventBus.emit(EAppEventBusNames.SwapSpeedBuildTxSuccess, {
+        fromToken: swapInfo.sender.token,
+        toToken: swapInfo.receiver.token,
+        fromAmount: swapInfo.sender.amount,
+        toAmount: swapInfo.receiver.amount,
+      });
+
+      const historyResult = await persistMarketSwapHistoryItem({
+        swapInfo,
+        txHash: result.txHash,
+        gasFeeFiatValue: result.gasFeeFiatValue,
+        gasFeeInNative: result.gasFeeInNative,
+      });
+
+      return {
+        ...result,
+        orderId: historyResult.orderId,
+      };
+    },
+    [persistMarketSwapHistoryItem],
+  );
+
+  const handleMarketSignedOrderSuccess = useCallback(
+    async ({ swapInfo }: { swapInfo: ISwapTxInfo }) => {
+      setSpeedSwapBuildTxLoading(false);
+
+      appEventBus.emit(EAppEventBusNames.SwapSpeedBuildTxSuccess, {
+        fromToken: swapInfo.sender.token,
+        toToken: swapInfo.receiver.token,
+        fromAmount: swapInfo.sender.amount,
+        toAmount: swapInfo.receiver.amount,
+      });
+
+      return persistMarketSwapHistoryItem({
+        swapInfo,
+      });
+    },
+    [persistMarketSwapHistoryItem],
+  );
+
+  const matchApproveTransaction = useCallback(
+    (
+      approvingTransaction?: ISwapApproveTransaction,
+      amount?: string,
+      currentFromToken?: ISwapTokenBase,
+      currentToToken?: ISwapTokenBase,
+    ) => {
+      return Boolean(
+        approvingTransaction &&
+        (amount === approvingTransaction.amount ||
+          amount === approvingTransaction.resetApproveValue) &&
+        equalTokenNoCaseSensitive({
+          token1: approvingTransaction.fromToken,
+          token2: currentFromToken,
+        }) &&
+        equalTokenNoCaseSensitive({
+          token1: approvingTransaction.toToken,
+          token2: currentToToken,
+        }),
+      );
+    },
+    [],
+  );
+
+  const swapApprovingMatchLoading = useMemo(() => {
+    return (
+      inAppNotificationAtom.speedSwapApprovingLoading &&
+      matchApproveTransaction(
+        inAppNotificationAtom.speedSwapApprovingTransaction,
+        fromTokenAmount,
+        fromToken,
+        toToken,
+      )
+    );
+  }, [
+    fromTokenAmount,
+    fromToken,
+    inAppNotificationAtom.speedSwapApprovingLoading,
+    inAppNotificationAtom.speedSwapApprovingTransaction,
+    matchApproveTransaction,
+    toToken,
+  ]);
+
+  const buildMarketExecutionFromBuildRes = useCallback(
+    async ({
+      buildRes,
+      quoteResult,
+      currentFromToken,
+      currentToToken,
+      fromAmount,
+      userAddress,
+      accountId,
+    }: {
+      buildRes: IFetchBuildTxResponse;
+      quoteResult?: IFetchQuoteResult;
+      currentFromToken: ISwapToken;
+      currentToToken: ISwapToken;
+      fromAmount: string;
+      userAddress: string;
+      accountId: string;
+    }) => {
+      const buildResFinal = mergeMarketBuildResultWithQuote({
+        buildRes,
+        quoteResult,
+      });
+      return buildMarketExecutionPayload({
+        accountId,
+        buildRes: buildResFinal,
+        btcDerivationRestrictionErrorMessage: intl.formatMessage({
+          id: ETranslations.feedback_derivation_path_restriction,
+        }),
+        currentFromToken,
+        currentToToken,
+        deriveAddressEncoding: marketDeriveInfoRes.result?.addressEncoding,
+        fromAmount,
+        receivingAddress: userAddress,
+        slippage,
+        userAddress,
+        onBuildOkxSwapEncodedTx: (params) =>
+          backgroundApiProxy.serviceSwap.buildOkxSwapEncodedTx(params),
+        onBuildLMSwapEncodedTx: (params) =>
+          backgroundApiProxy.serviceSwap.buildLMSwapEncodedTx(params),
+        onBuildInternalDappTx: (params) =>
+          backgroundApiProxy.serviceStaking.buildInternalDappTx(params),
+      });
+    },
+    [intl, marketDeriveInfoRes.result?.addressEncoding, slippage],
+  );
+
+  const buildSpeedSwapTxData = useCallback(
+    async ({
+      fromAmount,
+      fromToken: currentFromToken,
+      toToken: currentToToken,
+    }: {
+      fromAmount?: string;
+      fromToken?: ISwapToken;
+      toToken?: ISwapToken;
+    } = {}) => {
+      const amount = fromAmount ?? fromTokenAmountDebounced;
+      const fromTokenFinal = currentFromToken ?? fromToken;
+      const toTokenFinal = currentToToken ?? toToken;
+      const userAddress = netAccountRes.result?.addressDetail.address ?? '';
+
+      if (!amount || !userAddress || !netAccountRes.result?.id) {
+        throw new OneKeyLocalError(
+          'Market swap review requires account and amount.',
+        );
+      }
+
+      setSpeedSwapBuildTxLoading(true);
+      try {
+        if (isStock) {
+          const quoteResult =
+            await backgroundApiProxy.serviceSwap.fetchSpeedMarketQuote({
+              fromToken: fromTokenFinal,
+              toToken: toTokenFinal,
+              fromTokenAmount: amount,
+              userAddress,
+              receivingAddress: userAddress,
+              slippagePercentage: slippage,
+              accountId: netAccountRes.result.id,
+            });
+
+          if (!quoteResult?.swapShouldSignedData) {
+            throw new OneKeyLocalError(
+              quoteResult?.errorMessage ??
+                'Market stock quote sign payload missing.',
+            );
+          }
+
+          const reviewBuildRes: IFetchBuildTxResponse = {
+            orderId: stringUtils.generateUUID(),
+            result: {
+              ...quoteResult,
+              slippage: quoteResult.slippage ?? slippage,
+            },
+          };
+
           const swapInfo: ISwapTxInfo = {
             protocol: EProtocolOfExchange.SWAP,
             sender: {
-              amount: fromTokenAmount,
-              token: fromToken,
-              accountInfo: { accountId, networkId: fromToken.networkId },
+              amount: quoteResult.fromAmount ?? amount,
+              token: fromTokenFinal,
+              accountInfo: {
+                accountId: netAccountRes.result.id,
+                networkId: fromTokenFinal.networkId,
+              },
             },
             receiver: {
-              amount: buildRes.result.toAmount ?? '',
-              token: toToken,
-              accountInfo: { accountId, networkId: toToken.networkId },
+              amount: quoteResult.toAmount ?? '0',
+              token: toTokenFinal,
+              accountInfo: {
+                accountId: netAccountRes.result.id,
+                networkId: toTokenFinal.networkId,
+              },
             },
             accountAddress: userAddress,
             receivingAddress: userAddress,
-            swapBuildResData: {
-              ...buildRes,
-              result: {
-                ...buildRes.result,
-                slippage: buildRes.result?.slippage ?? slippage,
-              },
-            },
+            swapBuildResData: reviewBuildRes,
           };
-          const fromNetworkPreset = Object.values(presetNetworksMap).find(
-            (item) => item.id === fromToken.networkId,
-          );
-          const toNetworkPreset = Object.values(presetNetworksMap).find(
-            (item) => item.id === toToken.networkId,
-          );
-          const swapHistoryItem: ISwapTxHistory = {
-            status: ESwapTxHistoryStatus.PENDING,
-            currency: settingsAtom.currencyInfo?.symbol,
-            accountInfo: {
-              sender: { accountId, networkId: fromToken.networkId },
-              receiver: { accountId, networkId: toToken.networkId },
-            },
-            baseInfo: {
-              toAmount: swapInfo.receiver.amount,
-              fromAmount: swapInfo.sender.amount,
-              fromToken,
-              toToken,
-              fromNetwork: {
-                networkId: fromNetworkPreset?.id ?? '',
-                name: fromNetworkPreset?.name ?? '',
-                symbol: fromNetworkPreset?.symbol ?? '',
-                logoURI: fromNetworkPreset?.logoURI ?? '',
-                shortcode: fromNetworkPreset?.shortcode ?? '',
-              },
-              toNetwork: {
-                networkId: toNetworkPreset?.id ?? '',
-                name: toNetworkPreset?.name ?? '',
-                symbol: toNetworkPreset?.symbol ?? '',
-                logoURI: toNetworkPreset?.logoURI ?? '',
-                shortcode: toNetworkPreset?.shortcode ?? '',
-              },
-            },
-            txInfo: {
-              txId: undefined,
-              useOrderId: true,
-              orderId:
-                buildRes.orderId ??
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                buildRes.ctx?.oneInchFusionOrderHash,
-              sender: userAddress,
-              receiver: userAddress,
-            },
-            date: { created: Date.now(), updated: Date.now() },
-            swapInfo: {
-              instantRate: buildRes.result?.instantRate ?? '0',
-              provider: buildRes.result?.info,
-              socketBridgeScanUrl: buildRes.socketBridgeScanUrl,
-              oneKeyFee: buildRes.result?.fee?.percentageFee ?? 0,
-              protocolFee: buildRes.result?.fee?.protocolFees ?? 0,
-              otherFeeInfos: buildRes.result?.fee?.otherFeeInfos ?? [],
-              orderId: buildRes.orderId ?? buildRes.result?.quoteId,
-              supportUrl: buildRes.result?.supportUrl,
-              orderSupportUrl: buildRes.result?.orderSupportUrl,
-              oneKeyFeeExtraInfo: buildRes.result?.oneKeyFeeExtraInfo,
-            },
-            ctx: buildRes.ctx,
-          };
-          await backgroundApiProxy.serviceSwap.addSwapHistoryItem(
-            swapHistoryItem,
-          );
-          appEventBus.emit(EAppEventBusNames.SwapSpeedBuildTxSuccess, {
-            fromToken,
-            toToken,
-            fromAmount: fromTokenAmount,
-            toAmount: buildRes.result.toAmount ?? '',
-          });
-          defaultLogger.swap.createSwapOrder.swapCreateOrder({
-            fromTokenAmount,
-            fromAddress: userAddress,
-            toAddress: userAddress,
-            toTokenAmount: buildRes.result?.toAmount ?? '',
-            status: ESwapEventAPIStatus.SUCCESS,
-            swapProvider: buildRes.result?.info.provider ?? '',
-            swapProviderName: buildRes.result?.info.providerName ?? '',
-            swapType: ESwapTabSwitchType.SWAP,
-            slippage: slippage.toString(),
-            sourceChain: fromToken.networkId ?? '',
-            receivedChain: toToken.networkId ?? '',
-            sourceTokenSymbol: fromToken.symbol ?? '',
-            receivedTokenSymbol: toToken.symbol ?? '',
-            feeType: buildRes.result?.fee?.percentageFee?.toString() ?? '0',
-            router: JSON.stringify(buildRes.result?.routesData ?? ''),
-            isFirstTime: isFirstTimeSwap,
-            createFrom: 'marketDex',
-          });
-        }
-        return buildRes;
-      } catch (_e) {
-        setSpeedSwapBuildTxLoading(false);
-        defaultLogger.swap.createSwapOrder.swapCreateOrder({
-          fromTokenAmount,
-          fromAddress: userAddress,
-          toAddress: userAddress,
-          toTokenAmount: '',
-          status: ESwapEventAPIStatus.FAIL,
-          swapProvider: '',
-          swapProviderName: '',
-          swapType: ESwapTabSwitchType.SWAP,
-          slippage: slippage.toString(),
-          sourceChain: fromToken.networkId ?? '',
-          receivedChain: toToken.networkId ?? '',
-          sourceTokenSymbol: fromToken.symbol ?? '',
-          receivedTokenSymbol: toToken.symbol ?? '',
-          feeType: '0',
-          router: '',
-          isFirstTime: isFirstTimeSwap,
-          createFrom: 'marketDex',
-        });
-      }
-      return;
-    }
 
-    const buildParams = {
-      fromToken,
-      toToken,
-      fromTokenAmount: fromTokenAmountDebounced,
-      provider,
-      userAddress,
-      receivingAddress: userAddress,
-      slippagePercentage: slippage,
-      accountId,
-      protocol: EProtocolOfExchange.SWAP,
-      kind: ESwapQuoteKind.SELL,
-    };
-    const buildRes =
-      await backgroundApiProxy.serviceSwap.fetchBuildSpeedSwapTx(buildParams);
-    if (!buildRes) {
-      setSpeedSwapBuildTxLoading(false);
-      return;
-    }
-    try {
-      let transferInfo: ITransferInfo | undefined;
-      let encodedTx: IEncodedTx | undefined;
-      if (buildRes?.OKXTxObject) {
-        encodedTx = await backgroundApiProxy.serviceSwap.buildOkxSwapEncodedTx({
-          accountId: netAccountRes.result?.id ?? '',
-          networkId: fromToken.networkId,
-          okxTx: buildRes.OKXTxObject,
-          fromTokenInfo: buildRes.result.fromTokenInfo,
-          type: ESwapTabSwitchType.SWAP,
-        });
-      } else if (buildRes?.tx) {
-        transferInfo = undefined;
-        if (typeof buildRes.tx !== 'string' && buildRes.tx.data) {
-          const valueHex = toBigIntHex(new BigNumber(buildRes.tx.value ?? 0));
-          encodedTx = {
-            ...buildRes?.tx,
-            value: valueHex,
-            from: userAddress,
+          return {
+            buildRes: reviewBuildRes,
+            encodedTx: undefined,
+            transferInfo: undefined,
+            swapInfo,
+            userAddress,
           };
-        } else {
-          encodedTx = buildRes.tx as string;
         }
+
+        const buildRes =
+          await backgroundApiProxy.serviceSwap.fetchBuildSpeedSwapTx({
+            fromToken: fromTokenFinal,
+            toToken: toTokenFinal,
+            fromTokenAmount: amount,
+            provider,
+            userAddress,
+            receivingAddress: userAddress,
+            slippagePercentage: slippage,
+            accountId: netAccountRes.result.id,
+            protocol: EProtocolOfExchange.SWAP,
+            kind: ESwapQuoteKind.SELL,
+          });
+
+        if (!buildRes) {
+          throw new OneKeyLocalError('Market swap review build failed.');
+        }
+
+        let quoteResultForBuild: IFetchQuoteResult | undefined;
+        if (shouldFetchMarketQuoteFallbackData(buildRes)) {
+          const quotes =
+            await backgroundApiProxy.serviceSwap.fetchSpeedSwapQuote({
+              fromToken: fromTokenFinal,
+              toToken: toTokenFinal,
+              fromTokenAmount: amount,
+              userAddress,
+              receivingAddress: userAddress,
+              slippagePercentage: slippage,
+              autoSlippage: false,
+              accountId: netAccountRes.result.id,
+              kind: ESwapQuoteKind.SELL,
+              protocol: ESwapTabSwitchType.SWAP,
+            });
+          quoteResultForBuild = pickMarketQuoteResultByProvider({
+            quotes,
+            provider: buildRes.result.info.provider,
+            providerName: buildRes.result.info.providerName,
+          });
+        }
+        const buildResFinal = mergeMarketBuildResultWithQuote({
+          buildRes,
+          quoteResult: quoteResultForBuild,
+        });
+
+        const { encodedTx, transferInfo, swapInfo } =
+          await buildMarketExecutionFromBuildRes({
+            buildRes: buildResFinal,
+            quoteResult: quoteResultForBuild,
+            currentFromToken: fromTokenFinal,
+            currentToToken: toTokenFinal,
+            fromAmount: amount,
+            userAddress,
+            accountId: netAccountRes.result.id,
+          });
+
+        return {
+          buildRes: buildResFinal,
+          encodedTx,
+          transferInfo,
+          swapInfo,
+          userAddress,
+        };
+      } finally {
+        setSpeedSwapBuildTxLoading(false);
       }
+    },
+    [
+      isStock,
+      fromTokenAmountDebounced,
+      fromToken,
+      netAccountRes.result?.addressDetail.address,
+      netAccountRes.result?.id,
+      provider,
+      slippage,
+      toToken,
+      buildMarketExecutionFromBuildRes,
+    ],
+  );
+
+  const buildWrappedSwapData = useCallback(
+    ({
+      fromAmount,
+      fromToken: currentFromToken,
+      toToken: currentToToken,
+    }: {
+      fromAmount?: string;
+      fromToken?: ISwapToken;
+      toToken?: ISwapToken;
+    } = {}) => {
+      const amount = fromAmount ?? fromTokenAmountDebounced;
+      const fromTokenFinal = currentFromToken ?? fromToken;
+      const toTokenFinal = currentToToken ?? toToken;
+      const userAddress = netAccountRes.result?.addressDetail.address ?? '';
+
+      if (!amount || !userAddress || !netAccountRes.result?.id) {
+        throw new OneKeyLocalError(
+          'Market wrap review requires account and amount.',
+        );
+      }
+
+      const wrappedType = fromTokenFinal.isNative
+        ? EWrappedType.DEPOSIT
+        : EWrappedType.WITHDRAW;
+      const wrappedInfo: IWrappedInfo = {
+        from: userAddress,
+        type: wrappedType,
+        contract:
+          wrappedType === EWrappedType.WITHDRAW
+            ? fromTokenFinal.contractAddress
+            : toTokenFinal.contractAddress,
+        amount,
+      };
+      const quoteResult = buildWrappedMarketQuoteResult({
+        fromToken: fromTokenFinal,
+        toToken: toTokenFinal,
+        amount,
+        providerLogo: wrappedTokens.find(
+          (item) => item.networkId === fromTokenFinal.networkId,
+        )?.logo,
+      });
       const swapInfo: ISwapTxInfo = {
         protocol: EProtocolOfExchange.SWAP,
         sender: {
-          amount: fromTokenAmount,
-          token: fromToken,
+          amount,
+          token: fromTokenFinal,
           accountInfo: {
-            accountId: netAccountRes.result?.id ?? '',
-            networkId: fromToken.networkId,
+            accountId: netAccountRes.result.id,
+            networkId: fromTokenFinal.networkId,
           },
         },
         receiver: {
-          amount: buildRes?.result.toAmount ?? '',
-          token: toToken,
+          amount,
+          token: toTokenFinal,
           accountInfo: {
-            accountId: netAccountRes.result?.id ?? '',
-            networkId: toToken.networkId,
+            accountId: netAccountRes.result.id,
+            networkId: toTokenFinal.networkId,
           },
         },
         accountAddress: userAddress,
         receivingAddress: userAddress,
         swapBuildResData: {
-          ...buildRes,
-          result: {
-            ...buildRes?.result,
-            slippage: buildRes?.result?.slippage ?? slippage,
-          },
-        },
-      };
-      // onCloseDialog?.();
-      await navigationToTxConfirm({
-        isInternalSwap: true,
-        transfersInfo: transferInfo ? [transferInfo] : undefined,
-        encodedTx,
-        swapInfo,
-        approvesInfo: [], // todo
-        onSuccess: handleSpeedSwapBuildTxSuccess,
-        onCancel: cancelSpeedSwapBuildTx,
-        disableMev: !antiMEV,
-      });
-
-      defaultLogger.swap.createSwapOrder.swapCreateOrder({
-        fromTokenAmount,
-        fromAddress: userAddress,
-        toAddress: userAddress,
-        toTokenAmount: buildRes.result?.toAmount ?? '',
-        status: ESwapEventAPIStatus.SUCCESS,
-        swapProvider: buildRes.result?.info.provider ?? '',
-        swapProviderName: buildRes.result?.info.providerName ?? '',
-        swapType: ESwapTabSwitchType.SWAP,
-        slippage: slippage.toString(),
-        sourceChain: fromToken.networkId ?? '',
-        receivedChain: toToken.networkId ?? '',
-        sourceTokenSymbol: fromToken.symbol ?? '',
-        receivedTokenSymbol: toToken.symbol ?? '',
-        feeType: buildRes.result?.fee?.percentageFee?.toString() ?? '0',
-        router: JSON.stringify(buildRes.result?.routesData ?? ''),
-        isFirstTime: isFirstTimeSwap,
-        createFrom: 'marketDex',
-      });
-
-      return buildRes;
-    } catch (_e) {
-      setSpeedSwapBuildTxLoading(false);
-      defaultLogger.swap.createSwapOrder.swapCreateOrder({
-        fromTokenAmount,
-        fromAddress: userAddress,
-        toAddress: userAddress,
-        toTokenAmount: buildRes.result?.toAmount ?? '',
-        status: ESwapEventAPIStatus.FAIL,
-        swapProvider: buildRes.result?.info.provider ?? '',
-        swapProviderName: buildRes.result?.info.providerName ?? '',
-        swapType: ESwapTabSwitchType.SWAP,
-        slippage: slippage.toString(),
-        sourceChain: fromToken.networkId ?? '',
-        receivedChain: toToken.networkId ?? '',
-        sourceTokenSymbol: fromToken.symbol ?? '',
-        receivedTokenSymbol: toToken.symbol ?? '',
-        feeType: buildRes.result?.fee?.percentageFee?.toString() ?? '0',
-        router: JSON.stringify(buildRes.result?.routesData ?? ''),
-        isFirstTime: isFirstTimeSwap,
-        createFrom: 'marketDex',
-      });
-    }
-  }, [
-    netAccountRes.result?.addressDetail.address,
-    netAccountRes.result?.id,
-    fromToken,
-    toToken,
-    fromTokenAmountDebounced,
-    provider,
-    slippage,
-    fromTokenAmount,
-    navigationToTxConfirm,
-    handleSpeedSwapBuildTxSuccess,
-    cancelSpeedSwapBuildTx,
-    antiMEV,
-    isFirstTimeSwap,
-    isStock,
-    settingsAtom.currencyInfo?.symbol,
-    navigationToMessageConfirmAsync,
-    intl,
-    // onCloseDialog,
-  ]);
-
-  const speedSwapWrappedTx = useCallback(async () => {
-    if (netAccountRes.result?.addressDetail.address) {
-      const wrappedType = fromToken.isNative
-        ? EWrappedType.DEPOSIT
-        : EWrappedType.WITHDRAW;
-      const wrappedInfo: IWrappedInfo = {
-        from: netAccountRes.result?.addressDetail.address,
-        type: wrappedType,
-        contract:
-          wrappedType === EWrappedType.WITHDRAW
-            ? fromToken.contractAddress
-            : toToken.contractAddress,
-        amount: fromTokenAmountDebounced,
-      };
-      const swapInfo: ISwapTxInfo = {
-        protocol: EProtocolOfExchange.SWAP,
-        sender: {
-          amount: fromTokenAmountDebounced,
-          token: fromToken,
-          accountInfo: {
-            accountId: netAccountRes.result?.id ?? '',
-            networkId: fromToken.networkId,
-          },
-        },
-        receiver: {
-          amount: fromTokenAmountDebounced,
-          token: toToken,
-          accountInfo: {
-            accountId: netAccountRes.result?.id ?? '',
-            networkId: toToken.networkId,
-          },
-        },
-        accountAddress: netAccountRes.result?.addressDetail.address,
-        receivingAddress: netAccountRes.result?.addressDetail.address,
-        swapBuildResData: {
           orderId: stringUtils.generateUUID(),
-          result: {
-            info: {
-              provider: 'wrapped',
-              providerName: 'wrapped',
-              providerLogo: wrappedTokens.find(
-                (item) => item.networkId === fromToken.networkId,
-              )?.logo,
-            },
-            fromTokenInfo: fromToken,
-            toTokenInfo: toToken,
-            fromAmount: fromTokenAmountDebounced,
-            toAmount: fromTokenAmountDebounced,
-          },
+          result: quoteResult,
         },
       };
-      setSpeedSwapBuildTxLoading(true);
-      await navigationToTxConfirm({
-        isInternalSwap: true,
+
+      return {
+        quoteResult,
         wrappedInfo,
         swapInfo,
-        onSuccess: handleSpeedSwapBuildTxSuccess,
-        onCancel: cancelSpeedSwapBuildTx,
-        disableMev: !antiMEV,
-      });
-    }
-  }, [
-    netAccountRes.result?.addressDetail.address,
-    netAccountRes.result?.id,
-    fromToken,
-    toToken,
-    fromTokenAmountDebounced,
-    navigationToTxConfirm,
-    handleSpeedSwapBuildTxSuccess,
-    cancelSpeedSwapBuildTx,
-    antiMEV,
-  ]);
-
-  // --- approve
-
-  const handleSpeedSwapApproveTxSuccess = useCallback(
-    async (data: ISendTxOnSuccessData[]) => {
-      if (data?.[0]) {
-        const transactionSignedInfo = data[0].signedTx;
-        const approveInfo = data[0].approveInfo;
-        const txId = transactionSignedInfo.txid;
-        if (
-          inAppNotificationAtom.speedSwapApprovingTransaction &&
-          !inAppNotificationAtom.speedSwapApprovingTransaction.resetApproveValue
-        ) {
-          void backgroundApiProxy.serviceNotification.blockNotificationForTxId({
-            networkId:
-              inAppNotificationAtom.speedSwapApprovingTransaction.fromToken
-                .networkId,
-            tx: txId,
-          });
-        }
-        setInAppNotificationAtom((prev) => {
-          if (prev.speedSwapApprovingTransaction) {
-            return {
-              ...prev,
-              speedSwapApprovingTransaction: {
-                ...prev.speedSwapApprovingTransaction,
-                txId,
-                resetApproveIsMax: !!approveInfo?.isMax,
-                ...(approveInfo
-                  ? {
-                      amount: approveInfo.amount,
-                    }
-                  : {}),
-              },
-            };
-          }
-          return prev;
-        });
-      }
+      };
     },
     [
-      inAppNotificationAtom.speedSwapApprovingTransaction,
-      setInAppNotificationAtom,
+      fromTokenAmountDebounced,
+      fromToken,
+      netAccountRes.result?.addressDetail.address,
+      netAccountRes.result?.id,
+      toToken,
     ],
   );
 
-  const cancelSpeedSwapApproveTx = useCallback(() => {
-    setInAppNotificationAtom((prev) => {
-      if (prev.speedSwapApprovingTransaction) {
-        return {
-          ...prev,
-          speedSwapApprovingTransaction: {
-            ...prev.speedSwapApprovingTransaction,
-            status: ESwapApproveTransactionStatus.CANCEL,
-          },
-        };
+  const logMarketCreateOrder = useCallback(
+    ({
+      buildRes,
+      amount,
+      userAddress,
+      status,
+    }: {
+      buildRes: IFetchBuildTxResponse;
+      amount: string;
+      userAddress: string;
+      status: ESwapEventAPIStatus;
+    }) => {
+      defaultLogger.swap.createSwapOrder.swapCreateOrder({
+        fromTokenAmount: amount,
+        fromAddress: userAddress,
+        toAddress: userAddress,
+        toTokenAmount: buildRes.result?.toAmount ?? '',
+        status,
+        swapProvider: buildRes.result?.info.provider ?? '',
+        swapProviderName: buildRes.result?.info.providerName ?? '',
+        swapType: ESwapTabSwitchType.SWAP,
+        slippage: slippage.toString(),
+        sourceChain: fromToken.networkId ?? '',
+        receivedChain: toToken.networkId ?? '',
+        sourceTokenSymbol: fromToken.symbol ?? '',
+        receivedTokenSymbol: toToken.symbol ?? '',
+        feeType: buildRes.result?.fee?.percentageFee?.toString() ?? '0',
+        router: JSON.stringify(buildRes.result?.routesData ?? ''),
+        isFirstTime: settingsAtom.isFirstTimeSwap,
+        createFrom: 'marketDex',
+      });
+    },
+    [
+      fromToken.networkId,
+      fromToken.symbol,
+      settingsAtom.isFirstTimeSwap,
+      slippage,
+      toToken.networkId,
+      toToken.symbol,
+    ],
+  );
+
+  const buildMarketApproveUnsignedTxArr = useCallback(
+    async ({
+      approveInfos,
+      accountId,
+      networkId,
+    }: {
+      approveInfos?: IApproveInfo[];
+      accountId: string;
+      networkId: string;
+    }) => {
+      if (!accountId || !networkId || !approveInfos?.length) {
+        return undefined;
       }
-      return prev;
-    });
-  }, [setInAppNotificationAtom]);
+
+      const unsignedTxArr = [];
+      let prevNonce: number | undefined;
+
+      for (const approveInfo of approveInfos) {
+        const unsignedTx =
+          await backgroundApiProxy.serviceSend.prepareSendConfirmUnsignedTx({
+            networkId,
+            accountId,
+            approveInfo,
+            prevNonce,
+            isInternalSwap: true,
+            disableMev: !antiMEV,
+          });
+        prevNonce = unsignedTx.nonce;
+        unsignedTxArr.push(unsignedTx);
+      }
+
+      return unsignedTxArr;
+    },
+    [antiMEV],
+  );
+
+  const buildMarketReviewStateFromSnapshot = useCallback(
+    async (
+      snapshot: IMarketReviewExecutionSnapshot,
+      networkFeeLevel: ESwapNetworkFeeLevel = ESwapNetworkFeeLevel.MEDIUM,
+    ) => {
+      const nextReviewState = buildMarketReviewState({
+        accountId: snapshot.accountId,
+        networkId: snapshot.networkId,
+        fromToken: snapshot.swapInfo.sender.token,
+        toToken: snapshot.swapInfo.receiver.token,
+        fromTokenAmount:
+          snapshot.quoteResult.fromAmount ?? snapshot.swapInfo.sender.amount,
+        toTokenAmount:
+          snapshot.quoteResult.toAmount ?? snapshot.swapInfo.receiver.amount,
+        quoteResult: snapshot.quoteResult,
+        shouldFallback: snapshot.shouldFallback,
+        slippage,
+        texts: buildReviewStepTexts(snapshot.quoteResult.info.providerName),
+      });
+
+      let netWorkFee: IMarketSwapReviewState['preSwapData']['netWorkFee'];
+      try {
+        const approveUnsignedTxArr = await buildMarketApproveUnsignedTxArr({
+          approveInfos: buildMarketApproveInfos({
+            fromUserAddress: snapshot.accountAddress,
+            quoteResult: snapshot.quoteResult,
+          }),
+          accountId: snapshot.accountId,
+          networkId: snapshot.networkId,
+        });
+        const feeState = await estimateMarketDirectGasInfos({
+          accountAddress: snapshot.accountAddress,
+          accountId: snapshot.accountId,
+          networkId: snapshot.networkId,
+          buildUnsignedParams: snapshot.buildUnsignedParams,
+          approveUnsignedTxArr,
+          networkFeeLevel,
+        });
+
+        if (
+          !snapshot.buildUnsignedParams.encodedTx &&
+          feeState.preparedUnsignedTx.encodedTx
+        ) {
+          snapshot.buildUnsignedParams = {
+            ...snapshot.buildUnsignedParams,
+            encodedTx: feeState.preparedUnsignedTx.encodedTx,
+          };
+        }
+
+        netWorkFee = {
+          gasInfos: feeState.gasInfos,
+          gasFeeFiatValue: feeState.gasFeeFiatValue,
+        };
+      } catch {
+        netWorkFee = undefined;
+      }
+
+      return {
+        steps: nextReviewState.steps,
+        preSwapData: {
+          ...nextReviewState.preSwapData,
+          swapBuildResultData: {
+            swapInfo: snapshot.swapInfo,
+            encodedTx: snapshot.buildUnsignedParams.encodedTx,
+            transferInfo: snapshot.buildUnsignedParams.transfersInfo?.[0],
+          },
+          netWorkFee,
+        },
+        quoteResult: snapshot.quoteResult,
+      };
+    },
+    [buildMarketApproveUnsignedTxArr, buildReviewStepTexts, slippage],
+  );
+
+  const prepareMarketSwapReview = useCallback<
+    IMarketSwapReviewAdapter['prepareMarketSwapReview']
+  >(
+    async ({
+      fromAmount,
+      fromToken: currentFromToken,
+      toToken: currentToToken,
+      isWrap,
+      quoteResult,
+      networkFeeLevel = ESwapNetworkFeeLevel.MEDIUM,
+    } = {}) => {
+      if (quoteResult && reviewExecutionSnapshotRef.current) {
+        return buildMarketReviewStateFromSnapshot(
+          reviewExecutionSnapshotRef.current,
+          networkFeeLevel,
+        );
+      }
+
+      const amount = fromAmount ?? fromTokenAmountDebounced;
+      const fromTokenFinal = currentFromToken ?? fromToken;
+      const toTokenFinal = currentToToken ?? toToken;
+
+      if (isWrap || isWrapped) {
+        const shouldFallback = buildMarketReviewShouldFallback({
+          networkId: fromTokenFinal.networkId,
+          isCustomRpcUnavailable,
+        });
+        const {
+          quoteResult: wrappedQuoteResult,
+          wrappedInfo,
+          swapInfo,
+        } = buildWrappedSwapData({
+          fromAmount: amount,
+          fromToken: fromTokenFinal,
+          toToken: toTokenFinal,
+        });
+        reviewExecutionSnapshotRef.current = {
+          kind: 'wrap',
+          accountAddress: swapInfo.accountAddress,
+          accountId: netAccountRes.result?.id ?? '',
+          networkId: fromTokenFinal.networkId,
+          shouldFallback,
+          quoteResult: wrappedQuoteResult,
+          buildUnsignedParams: {
+            networkId: fromTokenFinal.networkId,
+            accountId: netAccountRes.result?.id ?? '',
+            wrappedInfo,
+            swapInfo,
+            isInternalSwap: true,
+            disableMev: !antiMEV,
+          } as ISendTxBaseParams & IBuildUnsignedTxParams,
+          swapInfo,
+        };
+
+        return buildMarketReviewStateFromSnapshot(
+          reviewExecutionSnapshotRef.current,
+          networkFeeLevel,
+        );
+      }
+
+      const { buildRes, encodedTx, transferInfo, swapInfo, userAddress } =
+        await buildSpeedSwapTxData({
+          fromAmount: amount,
+          fromToken: fromTokenFinal,
+          toToken: toTokenFinal,
+        });
+      const allowanceState = await resolveMarketReviewAllowanceState({
+        amount,
+        currentState: {
+          allowanceTarget: effectiveSpenderAddress,
+          shouldApprove,
+          shouldResetApprove,
+        },
+        isWrapped,
+        spenderAddress: effectiveSpenderAddress,
+        token: fromTokenFinal,
+        walletAddress: netAccountRes.result?.addressDetail.address,
+      });
+      setShouldApprove(allowanceState.shouldApprove);
+      setShouldResetApprove(allowanceState.shouldResetApprove);
+      if (allowanceState.allowanceTarget !== effectiveSpenderAddress) {
+        setCheckSpenderAddress(allowanceState.allowanceTarget ?? '');
+      }
+      const normalizedQuoteResult = assertMarketReviewQuoteResult(
+        normalizeMarketReviewQuoteResult({
+          quoteResult: {
+            ...buildRes.result,
+            slippage: buildRes.result.slippage ?? slippage,
+          },
+          shouldApprove: allowanceState.shouldApprove,
+          shouldResetApprove: allowanceState.shouldResetApprove,
+          spenderAddress:
+            allowanceState.allowanceTarget ?? effectiveSpenderAddress,
+          amount,
+        }),
+      );
+      const shouldFallback = buildMarketReviewShouldFallback({
+        networkId: fromTokenFinal.networkId,
+        isCustomRpcUnavailable,
+      });
+      reviewExecutionSnapshotRef.current = {
+        kind: 'swap',
+        accountAddress: userAddress,
+        accountId: netAccountRes.result?.id ?? '',
+        networkId: fromTokenFinal.networkId,
+        shouldFallback,
+        quoteResult: normalizedQuoteResult,
+        buildUnsignedParams: {
+          networkId: fromTokenFinal.networkId,
+          accountId: netAccountRes.result?.id ?? '',
+          transfersInfo: transferInfo ? [transferInfo] : undefined,
+          encodedTx,
+          swapInfo,
+          isInternalSwap: true,
+          disableMev: !antiMEV,
+        } as ISendTxBaseParams & IBuildUnsignedTxParams,
+        swapInfo,
+        buildRes,
+      };
+
+      return buildMarketReviewStateFromSnapshot(
+        reviewExecutionSnapshotRef.current,
+        networkFeeLevel,
+      );
+    },
+    [
+      antiMEV,
+      buildMarketReviewStateFromSnapshot,
+      buildSpeedSwapTxData,
+      buildWrappedSwapData,
+      effectiveSpenderAddress,
+      fromToken,
+      fromTokenAmountDebounced,
+      isCustomRpcUnavailable,
+      isWrapped,
+      netAccountRes.result?.id,
+      netAccountRes.result?.addressDetail.address,
+      shouldApprove,
+      shouldResetApprove,
+      slippage,
+      toToken,
+    ],
+  );
 
   const checkTokenApproveAllowance = useCallback(
     async (amount: string, overrideSpenderAddress?: string) => {
@@ -1028,143 +1281,736 @@ export function useSpeedSwapActions(props: {
     ],
   );
 
-  const approveRun = useCallback(
+  const isUserCancelledError = useCallback((error: unknown) => {
+    const normalizedError = error as
+      | {
+          code?: number;
+          key?: string;
+          message?: string;
+        }
+      | undefined;
+
+    return (
+      normalizedError?.key === 'global.cancel' ||
+      normalizedError?.code === 803 ||
+      normalizedError?.code === -99_999 ||
+      normalizedError?.message?.toLowerCase().includes('reject') === true
+    );
+  }, []);
+
+  const requireReviewExecutionSnapshot = useCallback(
+    (kind?: IMarketReviewExecutionSnapshot['kind']) => {
+      const snapshot = reviewExecutionSnapshotRef.current;
+
+      if (!snapshot) {
+        throw new OneKeyLocalError('Market review snapshot missing.');
+      }
+
+      if (kind && snapshot.kind !== kind) {
+        throw new OneKeyLocalError('Market review snapshot type mismatch.');
+      }
+
+      return snapshot;
+    },
+    [],
+  );
+
+  const signMarketReviewQuoteResult = useCallback(
     async ({
-      amount,
-      isReset,
-      fromToken: fromTokenParam,
-      toToken: toTokenParam,
+      quoteResult,
+      accountId,
+      networkId,
+      accountAddress,
+      receivingAddress,
     }: {
-      spenderAddress: string;
-      amount: string;
-      isReset?: boolean;
-      fromToken: ISwapTokenBase;
-      toToken: ISwapTokenBase;
+      quoteResult: IFetchQuoteResult;
+      accountId: string;
+      networkId: string;
+      accountAddress: string;
+      receivingAddress: string;
+    }) => {
+      const signedQuoteResult = cloneDeep(quoteResult);
+      const signPayload = signedQuoteResult.swapShouldSignedData;
+
+      if (!signPayload) {
+        throw new OneKeyLocalError('Market sign payload missing.');
+      }
+
+      const {
+        unSignedInfo,
+        unSignedMessage,
+        unSignedData,
+        oneInchFusionOrder,
+      } = signPayload;
+
+      if (
+        (unSignedMessage || unSignedData) &&
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        signedQuoteResult.quoteResultCtx?.cowSwapUnSignedOrder
+      ) {
+        const unSignedOrder: {
+          sellTokenBalance: string;
+          buyTokenBalance: string;
+          validTo: number;
+          appData: string;
+          receiver: string;
+          buyAmount: string;
+          sellAmount: string;
+          partiallyFillable: boolean;
+        } =
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          signedQuoteResult.quoteResultCtx.cowSwapUnSignedOrder;
+
+        unSignedOrder.receiver = receivingAddress;
+        let dataMessage = unSignedMessage;
+
+        if (!dataMessage && unSignedData) {
+          const populated = await ethers.utils._TypedDataEncoder.resolveNames(
+            unSignedData.domain,
+            unSignedData.types,
+            {
+              ...unSignedOrder,
+              sellTokenBalance:
+                (unSignedOrder.sellTokenBalance as OrderBalance) ??
+                OrderBalance.ERC20,
+              buyTokenBalance: normalizeBuyTokenBalance(
+                unSignedOrder.buyTokenBalance as OrderBalance,
+              ),
+              validTo: timestamp(unSignedOrder.validTo),
+              appData: hashify(unSignedOrder.appData),
+            },
+            async (value: string) => value,
+          );
+
+          dataMessage = JSON.stringify(
+            ethers.utils._TypedDataEncoder.getPayload(
+              populated.domain,
+              unSignedData.types,
+              populated.value,
+            ),
+          );
+        }
+
+        if (!dataMessage) {
+          throw new OneKeyError('sign message failed');
+        }
+
+        const signature = await backgroundApiProxy.serviceSend.signMessage({
+          unsignedMessage: {
+            type: unSignedInfo.signedType ?? EMessageTypesEth.TYPED_DATA_V4,
+            message: dataMessage,
+            payload: [accountAddress.toLowerCase(), dataMessage],
+          },
+          networkId,
+          accountId,
+        });
+
+        if (!signature) {
+          throw new OneKeyError('sign message failed');
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        signedQuoteResult.quoteResultCtx.cowSwapUnSignedOrder = unSignedOrder;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        signedQuoteResult.quoteResultCtx.signedResult = {
+          signature,
+          signingScheme: ESigningScheme.EIP712,
+        };
+
+        return signedQuoteResult;
+      }
+
+      if (oneInchFusionOrder) {
+        const onInchFusionOrderInfo: {
+          orderStruct: IOneInchOrderStruct;
+          extension: string;
+          quoteId: string;
+          signature?: string;
+          orderHash: string;
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        } = signedQuoteResult.quoteResultCtx?.oneInchFusionOrderCtx;
+
+        if (oneInchFusionOrder.makerAddress && oneInchFusionOrder.typedData) {
+          const dataMessage = JSON.stringify(oneInchFusionOrder.typedData);
+          const signature = await backgroundApiProxy.serviceSend.signMessage({
+            unsignedMessage: {
+              type: unSignedInfo.signedType ?? EMessageTypesEth.TYPED_DATA_V4,
+              message: dataMessage,
+              payload: [accountAddress.toLowerCase(), dataMessage],
+            },
+            networkId,
+            accountId,
+          });
+
+          if (!signature) {
+            throw new OneKeyError('sign message failed');
+          }
+
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          signedQuoteResult.quoteResultCtx.oneInchFusionOrderCtx = {
+            ...onInchFusionOrderInfo,
+            signature,
+          };
+
+          return signedQuoteResult;
+        }
+      }
+
+      throw new OneKeyLocalError('Market sign payload is not supported.');
+    },
+    [],
+  );
+
+  const handleMarketApproveTxSuccess = useCallback(
+    ({
+      approveInfo,
+      approvingTransaction,
+      data,
+      isResetApprove,
+      networkId,
+      onBroadcast,
+    }: {
+      approveInfo: IApproveInfo;
+      approvingTransaction: ISwapApproveTransaction;
+      data: ISendTxOnSuccessData[];
+      isResetApprove?: boolean;
+      networkId: string;
+      onBroadcast?: (result: IMarketApproveBroadcastResult) => void;
+    }) => {
+      const txId = data[0]?.signedTx.txid;
+      const approveAmount = data[0]?.approveInfo?.amount ?? approveInfo.amount;
+
+      if (!txId) {
+        return;
+      }
+
+      if (!isResetApprove) {
+        void backgroundApiProxy.serviceNotification.blockNotificationForTxId({
+          networkId,
+          tx: txId,
+        });
+      }
+
+      setInAppNotificationAtom((prev) => {
+        return {
+          ...prev,
+          speedSwapApprovingTransaction: {
+            ...(prev.speedSwapApprovingTransaction ?? approvingTransaction),
+            txId,
+            amount: approveAmount,
+            resetApproveIsMax: !!data[0]?.approveInfo?.isMax,
+          },
+        };
+      });
+
+      onBroadcast?.({
+        txHash: txId,
+        amount: approveAmount,
+      });
+    },
+    [setInAppNotificationAtom],
+  );
+
+  const cancelMarketApproveTx = useCallback(() => {
+    setInAppNotificationAtom((prev) => {
+      if (!prev.speedSwapApprovingTransaction) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        speedSwapApprovingTransaction: {
+          ...prev.speedSwapApprovingTransaction,
+          status: ESwapApproveTransactionStatus.CANCEL,
+        },
+      };
+    });
+  }, [setInAppNotificationAtom]);
+
+  const startMarketApproveTx = useCallback(
+    async ({
+      accountAddress,
+      accountId,
+      networkId,
+      approveInfo,
+      approvingTransaction,
+      gasInfos,
+      networkFeeLevel,
+      onBroadcast,
+      onCancel,
+    }: {
+      accountAddress: string;
+      accountId: string;
+      networkId: string;
+      approveInfo: IApproveInfo;
+      approvingTransaction: ISwapApproveTransaction;
+      gasInfos?: IMarketGasInfoEntry[];
+      networkFeeLevel?: ESwapNetworkFeeLevel;
+      onBroadcast?: (result: IMarketApproveBroadcastResult) => void;
+      onCancel?: () => void;
     }) => {
       try {
-        setInAppNotificationAtom((pre) => ({
-          ...pre,
+        setInAppNotificationAtom((prev) => ({
+          ...prev,
           speedSwapApprovingLoading: true,
+          speedSwapApprovingTransaction: approvingTransaction,
         }));
-        setSpeedSwapApproveActionLoading(true);
-        const userAddress = netAccountRes.result?.addressDetail.address ?? '';
-        const approveInfo: IApproveInfo = {
-          owner: userAddress,
-          spender: effectiveSpenderAddress,
-          amount: isReset ? '0' : amount,
-          isMax: !isReset,
-          tokenInfo: {
-            ...fromTokenParam,
-            isNative: !!fromTokenParam.isNative,
-            address: fromTokenParam.contractAddress,
-            name: fromTokenParam.name ?? fromTokenParam.symbol,
-          },
-          swapApproveRes: undefined,
-        };
-        await navigationToTxConfirm({
-          approvesInfo: [approveInfo],
-          isInternalSwap: true,
-          onSuccess: handleSpeedSwapApproveTxSuccess,
-          onCancel: cancelSpeedSwapApproveTx,
-          disableMev: !antiMEV,
+
+        const data = await sendMarketDirectUnsignedTxs({
+          accountAddress,
+          accountId,
+          networkId,
+          buildUnsignedParams: {
+            accountId,
+            networkId,
+            approveInfo,
+            isInternalSwap: true,
+            disableMev: !antiMEV,
+          } as ISendTxBaseParams & IBuildUnsignedTxParams,
+          gasInfos,
+          networkFeeLevel,
         });
-        setInAppNotificationAtom((pre) => ({
-          ...pre,
-          speedSwapApprovingTransaction: {
-            swapType: ESwapTabSwitchType.SWAP,
-            protocol: EProtocolOfExchange.SWAP,
-            provider,
-            providerName: provider,
-            unSupportReceiveAddressDifferent: false,
-            fromToken: fromTokenParam,
-            toToken: toTokenParam,
-            amount,
-            toAmount: amount,
-            useAddress: userAddress,
-            spenderAddress: effectiveSpenderAddress,
-            status: ESwapApproveTransactionStatus.PENDING,
-            kind: ESwapQuoteKind.SELL,
-            resetApproveValue: !isReset ? '0' : amount,
-            resetApproveIsMax: !isReset,
-          },
-        }));
-        setSpeedSwapApproveActionLoading(false);
-      } catch (_e) {
-        setInAppNotificationAtom((pre) => ({
-          ...pre,
+        handleMarketApproveTxSuccess({
+          approveInfo,
+          approvingTransaction,
+          data,
+          isResetApprove: approveInfo.amount === '0',
+          networkId,
+          onBroadcast,
+        });
+      } catch (error) {
+        setInAppNotificationAtom((prev) => ({
+          ...prev,
           speedSwapApprovingLoading: false,
         }));
-        setSpeedSwapApproveActionLoading(false);
+        if (isUserCancelledError(error)) {
+          cancelMarketApproveTx();
+          onCancel?.();
+          return;
+        }
+        throw error;
       }
     },
     [
-      setInAppNotificationAtom,
-      netAccountRes.result?.addressDetail.address,
-      effectiveSpenderAddress,
-      navigationToTxConfirm,
-      handleSpeedSwapApproveTxSuccess,
-      cancelSpeedSwapApproveTx,
       antiMEV,
-      provider,
+      cancelMarketApproveTx,
+      handleMarketApproveTxSuccess,
+      isUserCancelledError,
+      setInAppNotificationAtom,
     ],
   );
 
-  const speedSwapApproveHandler = useCallback(async () => {
-    if (shouldResetApprove) {
-      Dialog.show({
-        onConfirmText: intl.formatMessage({
-          id: ETranslations.global_continue,
-        }),
-        onConfirm: () => {
-          void approveRun({
-            spenderAddress: effectiveSpenderAddress,
-            amount: fromTokenAmountDebounced,
-            isReset: shouldResetApprove,
-            fromToken,
-            toToken,
-          });
-        },
-        showCancelButton: true,
-        title: intl.formatMessage({
-          id: ETranslations.swap_page_provider_approve_usdt_dialog_title,
-        }),
-        description: intl.formatMessage({
-          id: ETranslations.swap_page_provider_approve_usdt_dialog_content,
-        }),
-        icon: 'ErrorOutline',
-      });
-    } else {
-      void approveRun({
-        spenderAddress: effectiveSpenderAddress,
-        amount: fromTokenAmountDebounced,
-        isReset: shouldResetApprove,
-        fromToken,
-        toToken,
-      });
-    }
-  }, [
-    approveRun,
-    fromToken,
-    fromTokenAmountDebounced,
-    intl,
-    shouldResetApprove,
-    effectiveSpenderAddress,
-    toToken,
-  ]);
-
-  const handleSwapSpeedApprovingReset = useCallback(
+  const handleMarketResetApprove = useCallback(
     ({ approvedSwapInfo }: { approvedSwapInfo: ISwapApproveTransaction }) => {
-      if (approvedSwapInfo.resetApproveValue) {
-        void approveRun({
-          spenderAddress: approvedSwapInfo.spenderAddress,
-          amount: approvedSwapInfo.resetApproveValue,
-          isReset: false,
-          fromToken: approvedSwapInfo.fromToken,
-          toToken: approvedSwapInfo.toToken,
+      if (
+        !shouldAutoContinueMarketResetApprove({
+          approvedSwapInfo,
+          isReviewDialogOpen,
+        })
+      ) {
+        return;
+      }
+
+      const userAddress =
+        netAccountRes.result?.addressDetail.address ??
+        approvedSwapInfo.useAddress;
+      const accountId = netAccountRes.result?.id ?? '';
+      if (!userAddress || !accountId || !approvedSwapInfo.resetApproveValue) {
+        return;
+      }
+
+      const nextApproveInfo: IApproveInfo = {
+        owner: userAddress,
+        spender: approvedSwapInfo.spenderAddress,
+        amount: approvedSwapInfo.resetApproveValue,
+        isMax: true,
+        tokenInfo: {
+          ...approvedSwapInfo.fromToken,
+          isNative: !!approvedSwapInfo.fromToken.isNative,
+          address: approvedSwapInfo.fromToken.contractAddress,
+          name:
+            approvedSwapInfo.fromToken.name ??
+            approvedSwapInfo.fromToken.symbol,
+        },
+        swapApproveRes: undefined,
+      };
+
+      const nextApprovingTransaction: ISwapApproveTransaction = {
+        ...approvedSwapInfo,
+        amount: approvedSwapInfo.resetApproveValue,
+        resetApproveValue: '0',
+        resetApproveIsMax: true,
+        status: ESwapApproveTransactionStatus.PENDING,
+        txId: undefined,
+      };
+
+      void startMarketApproveTx({
+        accountAddress: userAddress,
+        accountId,
+        networkId: approvedSwapInfo.fromToken.networkId,
+        approveInfo: nextApproveInfo,
+        approvingTransaction: nextApprovingTransaction,
+      });
+    },
+    [
+      isReviewDialogOpen,
+      netAccountRes.result?.addressDetail.address,
+      netAccountRes.result?.id,
+      startMarketApproveTx,
+    ],
+  );
+
+  useEffect(() => {
+    appEventBus.off(
+      EAppEventBusNames.SwapSpeedApprovingReset,
+      handleMarketResetApprove,
+    );
+    appEventBus.on(
+      EAppEventBusNames.SwapSpeedApprovingReset,
+      handleMarketResetApprove,
+    );
+
+    return () => {
+      appEventBus.off(
+        EAppEventBusNames.SwapSpeedApprovingReset,
+        handleMarketResetApprove,
+      );
+    };
+  }, [handleMarketResetApprove]);
+
+  const sendMarketSwapTx = useCallback<
+    IMarketSwapReviewAdapter['sendMarketSwapTx']
+  >(
+    async ({
+      approvesInfo,
+      gasInfos,
+      networkFeeLevel,
+      onBroadcast,
+      onCancel,
+    } = {}) => {
+      const snapshot = requireReviewExecutionSnapshot('swap');
+
+      try {
+        const approveUnsignedTxArr = await buildMarketApproveUnsignedTxArr({
+          approveInfos: approvesInfo,
+          accountId: snapshot.accountId,
+          networkId: snapshot.networkId,
         });
+        const data = await sendMarketDirectUnsignedTxs({
+          accountAddress: snapshot.accountAddress,
+          accountId: snapshot.accountId,
+          networkId: snapshot.networkId,
+          buildUnsignedParams: snapshot.buildUnsignedParams,
+          approveUnsignedTxArr,
+          gasInfos,
+          networkFeeLevel,
+        });
+        const result = await handleMarketSwapBuildTxSuccess(data);
+        if (result) {
+          onBroadcast?.(result);
+        }
+        logMarketCreateOrder({
+          buildRes: snapshot.buildRes as IFetchBuildTxResponse,
+          amount: snapshot.swapInfo.sender.amount,
+          userAddress: snapshot.accountAddress,
+          status: ESwapEventAPIStatus.SUCCESS,
+        });
+      } catch (error) {
+        cancelSpeedSwapBuildTx();
+        if (snapshot.buildRes) {
+          logMarketCreateOrder({
+            buildRes: snapshot.buildRes,
+            amount: snapshot.swapInfo.sender.amount,
+            userAddress: snapshot.accountAddress,
+            status: ESwapEventAPIStatus.FAIL,
+          });
+        }
+        if (isUserCancelledError(error)) {
+          onCancel?.();
+          return;
+        }
+        throw error;
       }
     },
-    [approveRun],
+    [
+      buildMarketApproveUnsignedTxArr,
+      cancelSpeedSwapBuildTx,
+      handleMarketSwapBuildTxSuccess,
+      isUserCancelledError,
+      logMarketCreateOrder,
+      requireReviewExecutionSnapshot,
+    ],
+  );
+
+  const sendMarketWrappedTx = useCallback<
+    IMarketSwapReviewAdapter['sendMarketWrappedTx']
+  >(
+    async ({ gasInfos, networkFeeLevel, onBroadcast, onCancel } = {}) => {
+      const snapshot = requireReviewExecutionSnapshot('wrap');
+
+      try {
+        const data = await sendMarketDirectUnsignedTxs({
+          accountAddress: snapshot.accountAddress,
+          accountId: snapshot.accountId,
+          networkId: snapshot.networkId,
+          buildUnsignedParams: snapshot.buildUnsignedParams,
+          gasInfos,
+          networkFeeLevel,
+        });
+        const result = await handleMarketSwapBuildTxSuccess(data);
+        if (result) {
+          onBroadcast?.(result);
+        }
+      } catch (error) {
+        cancelSpeedSwapBuildTx();
+        if (isUserCancelledError(error)) {
+          onCancel?.();
+          return;
+        }
+        throw error;
+      }
+    },
+    [
+      cancelSpeedSwapBuildTx,
+      handleMarketSwapBuildTxSuccess,
+      isUserCancelledError,
+      requireReviewExecutionSnapshot,
+    ],
+  );
+
+  const sendMarketSignMessage = useCallback<
+    IMarketSwapReviewAdapter['sendMarketSignMessage']
+  >(
+    async ({ networkFeeLevel, onBroadcast, onCancel } = {}) => {
+      const snapshot = requireReviewExecutionSnapshot('swap');
+
+      try {
+        const signedQuoteResult = await signMarketReviewQuoteResult({
+          quoteResult: snapshot.quoteResult,
+          accountId: snapshot.accountId,
+          networkId: snapshot.networkId,
+          accountAddress: snapshot.accountAddress,
+          receivingAddress: snapshot.swapInfo.receivingAddress,
+        });
+        const buildRes =
+          await backgroundApiProxy.serviceSwap.fetchBuildSpeedSwapTx({
+            fromToken: snapshot.swapInfo.sender.token,
+            toToken: snapshot.swapInfo.receiver.token,
+            fromTokenAmount:
+              signedQuoteResult.fromAmount ?? snapshot.swapInfo.sender.amount,
+            provider: signedQuoteResult.info.provider,
+            userAddress: snapshot.accountAddress,
+            receivingAddress: snapshot.swapInfo.receivingAddress,
+            slippagePercentage: signedQuoteResult.slippage ?? slippage,
+            quoteResultCtx: signedQuoteResult.quoteResultCtx,
+            accountId: snapshot.accountId,
+            protocol: signedQuoteResult.protocol ?? EProtocolOfExchange.SWAP,
+            kind: signedQuoteResult.kind ?? ESwapQuoteKind.SELL,
+          });
+
+        if (!buildRes) {
+          throw new OneKeyLocalError('Market sign build failed.');
+        }
+
+        const { encodedTx, transferInfo, swapInfo, skipSendTransAction } =
+          await buildMarketExecutionFromBuildRes({
+            buildRes,
+            quoteResult: signedQuoteResult,
+            currentFromToken: snapshot.swapInfo.sender.token,
+            currentToToken: snapshot.swapInfo.receiver.token,
+            fromAmount:
+              signedQuoteResult.fromAmount ?? snapshot.swapInfo.sender.amount,
+            userAddress: snapshot.accountAddress,
+            accountId: snapshot.accountId,
+          });
+        const buildResFinal = mergeMarketBuildResultWithQuote({
+          buildRes,
+          quoteResult: signedQuoteResult,
+        });
+
+        reviewExecutionSnapshotRef.current = {
+          kind: 'swap',
+          accountAddress: snapshot.accountAddress,
+          accountId: snapshot.accountId,
+          networkId: snapshot.networkId,
+          shouldFallback: snapshot.shouldFallback,
+          quoteResult: signedQuoteResult,
+          buildUnsignedParams: {
+            networkId: snapshot.networkId,
+            accountId: snapshot.accountId,
+            transfersInfo: transferInfo ? [transferInfo] : undefined,
+            encodedTx,
+            swapInfo,
+            isInternalSwap: true,
+            disableMev: !antiMEV,
+          } as ISendTxBaseParams & IBuildUnsignedTxParams,
+          swapInfo,
+          buildRes: buildResFinal,
+        };
+
+        if (skipSendTransAction) {
+          const result = await handleMarketSignedOrderSuccess({
+            swapInfo,
+          });
+
+          onBroadcast?.({
+            orderId: result.orderId,
+          });
+          logMarketCreateOrder({
+            buildRes: buildResFinal,
+            amount: swapInfo.sender.amount,
+            userAddress: snapshot.accountAddress,
+            status: ESwapEventAPIStatus.SUCCESS,
+          });
+          return;
+        }
+
+        const feeState = await estimateMarketDirectGasInfos({
+          accountAddress: snapshot.accountAddress,
+          accountId: snapshot.accountId,
+          networkId: snapshot.networkId,
+          buildUnsignedParams:
+            reviewExecutionSnapshotRef.current.buildUnsignedParams,
+          networkFeeLevel,
+        });
+        const data = await sendMarketDirectUnsignedTxs({
+          accountAddress: snapshot.accountAddress,
+          accountId: snapshot.accountId,
+          networkId: snapshot.networkId,
+          buildUnsignedParams:
+            reviewExecutionSnapshotRef.current.buildUnsignedParams,
+          gasInfos: feeState.gasInfos,
+          networkFeeLevel,
+        });
+        const result = await handleMarketSwapBuildTxSuccess(data);
+        if (result) {
+          onBroadcast?.(result);
+        }
+        logMarketCreateOrder({
+          buildRes: buildResFinal,
+          amount: swapInfo.sender.amount,
+          userAddress: snapshot.accountAddress,
+          status: ESwapEventAPIStatus.SUCCESS,
+        });
+      } catch (error) {
+        cancelSpeedSwapBuildTx();
+        if (snapshot.buildRes) {
+          logMarketCreateOrder({
+            buildRes: snapshot.buildRes,
+            amount: snapshot.swapInfo.sender.amount,
+            userAddress: snapshot.accountAddress,
+            status: ESwapEventAPIStatus.FAIL,
+          });
+        }
+        if (isUserCancelledError(error)) {
+          onCancel?.();
+          return;
+        }
+        throw error;
+      }
+    },
+    [
+      antiMEV,
+      buildMarketExecutionFromBuildRes,
+      cancelSpeedSwapBuildTx,
+      handleMarketSignedOrderSuccess,
+      handleMarketSwapBuildTxSuccess,
+      isUserCancelledError,
+      logMarketCreateOrder,
+      requireReviewExecutionSnapshot,
+      signMarketReviewQuoteResult,
+      slippage,
+    ],
+  );
+
+  const sendMarketApproveTx = useCallback<
+    IMarketSwapReviewAdapter['sendMarketApproveTx']
+  >(
+    async ({
+      amount,
+      gasInfos,
+      isResetApprove,
+      networkFeeLevel,
+      quoteResult,
+      onBroadcast,
+      onCancel,
+    }) => {
+      const snapshot = reviewExecutionSnapshotRef.current;
+      const userAddress =
+        snapshot?.accountAddress ??
+        netAccountRes.result?.addressDetail.address ??
+        '';
+      const accountId = snapshot?.accountId ?? netAccountRes.result?.id ?? '';
+      const spenderAddressFinal =
+        quoteResult.allowanceResult?.allowanceTarget ?? effectiveSpenderAddress;
+
+      if (!userAddress || !spenderAddressFinal || !accountId) {
+        throw new OneKeyLocalError(
+          'Market swap review approve requires spender and user.',
+        );
+      }
+
+      const approveInfo: IApproveInfo = {
+        owner: userAddress,
+        spender: spenderAddressFinal,
+        amount: isResetApprove ? '0' : amount,
+        isMax: !isResetApprove,
+        tokenInfo: {
+          ...quoteResult.fromTokenInfo,
+          isNative: !!quoteResult.fromTokenInfo.isNative,
+          address: quoteResult.fromTokenInfo.contractAddress,
+          name:
+            quoteResult.fromTokenInfo.name ?? quoteResult.fromTokenInfo.symbol,
+        },
+        swapApproveRes: undefined,
+      };
+
+      try {
+        await startMarketApproveTx({
+          accountAddress: userAddress,
+          accountId,
+          networkId: quoteResult.fromTokenInfo.networkId,
+          approveInfo,
+          approvingTransaction: buildMarketSwapApprovingTransaction({
+            quoteResult,
+            amount,
+            useAddress: userAddress,
+            spenderAddress: spenderAddressFinal,
+            isResetApprove,
+          }),
+          gasInfos,
+          networkFeeLevel,
+          onBroadcast,
+          onCancel,
+        });
+      } catch (error) {
+        setInAppNotificationAtom((prev) => ({
+          ...prev,
+          speedSwapApprovingLoading: false,
+        }));
+        if (isUserCancelledError(error)) {
+          return;
+        }
+        throw error;
+      }
+    },
+    [
+      effectiveSpenderAddress,
+      isUserCancelledError,
+      netAccountRes.result?.addressDetail.address,
+      netAccountRes.result?.id,
+      setInAppNotificationAtom,
+      startMarketApproveTx,
+    ],
+  );
+
+  const buildMarketApproveInfosForReview = useCallback(
+    (quoteResult?: IFetchQuoteResult) =>
+      buildMarketApproveInfos({
+        fromUserAddress: netAccountRes.result?.addressDetail.address,
+        quoteResult,
+      }),
+    [netAccountRes.result?.addressDetail.address],
   );
 
   const syncTokensBalance = useCallback(
@@ -1329,25 +2175,13 @@ export function useSpeedSwapActions(props: {
       syncTokensBalance,
     );
     appEventBus.on(EAppEventBusNames.SwapSpeedBalanceUpdate, syncTokensBalance);
-    appEventBus.off(
-      EAppEventBusNames.SwapSpeedApprovingReset,
-      handleSwapSpeedApprovingReset,
-    );
-    appEventBus.on(
-      EAppEventBusNames.SwapSpeedApprovingReset,
-      handleSwapSpeedApprovingReset,
-    );
     return () => {
       appEventBus.off(
         EAppEventBusNames.SwapSpeedBalanceUpdate,
         syncTokensBalance,
       );
-      appEventBus.off(
-        EAppEventBusNames.SwapSpeedApprovingReset,
-        handleSwapSpeedApprovingReset,
-      );
     };
-  }, [handleSwapSpeedApprovingReset, syncTokensBalance]);
+  }, [syncTokensBalance]);
 
   const runSpeedCheckAndAllowance = useCallback(
     async (amount: string) => {
@@ -1355,6 +2189,7 @@ export function useSpeedSwapActions(props: {
       if (amountBN.isNaN() || amountBN.lte(0)) {
         setSpeedCheckError('');
         setCheckSpenderAddress('');
+        setIsStock(false);
         setShouldApprove(false);
         setShouldResetApprove(false);
         return;
@@ -1455,7 +2290,6 @@ export function useSpeedSwapActions(props: {
       setCheckSpenderAddress('');
       setShouldApprove(false);
       setShouldResetApprove(false);
-      setIsStock(false);
     }
   }, [
     isWrapped,
@@ -1495,14 +2329,10 @@ export function useSpeedSwapActions(props: {
   ]);
 
   return {
-    speedSwapBuildTx,
-    speedSwapWrappedTx,
     speedSwapBuildTxLoading,
+    swapApprovingMatchLoading,
     checkTokenApproveAllowance,
     checkTokenAllowanceLoading,
-    speedSwapApproveHandler,
-    speedSwapApproveActionLoading,
-    speedSwapApproveTransactionLoading,
     shouldApprove,
     balance,
     balanceToken,
@@ -1512,5 +2342,11 @@ export function useSpeedSwapActions(props: {
     isWrapped,
     speedCheckError,
     speedCheckLoading,
+    prepareMarketSwapReview,
+    sendMarketApproveTx,
+    sendMarketSwapTx,
+    sendMarketWrappedTx,
+    sendMarketSignMessage,
+    buildMarketApproveInfos: buildMarketApproveInfosForReview,
   };
 }

--- a/packages/kit/src/views/Swap/hooks/useSwapState.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapState.ts
@@ -12,7 +12,6 @@ import {
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
 import {
   swapQuoteIntervalMaxCount,
@@ -30,7 +29,6 @@ import {
   ESwapQuoteKind,
   ESwapSlippageSegmentKey,
   ESwapTabSwitchType,
-  SwapBuildUseMultiplePopoversNetworkIds,
 } from '@onekeyhq/shared/types/swap/types';
 
 import { useDebounce } from '../../../hooks/useDebounce';
@@ -56,6 +54,7 @@ import {
   useSwapToTokenAmountAtom,
   useSwapTypeSwitchAtom,
 } from '../../../states/jotai/contexts/swap';
+import { buildSwapBatchTransferType } from '../utils/buildSwapReviewState';
 
 import { useSwapAddressInfo } from './useSwapAccount';
 
@@ -144,12 +143,6 @@ export function useSwapQuoteEventFetching() {
   return false;
 }
 
-export enum ESwapBatchTransferType {
-  CONTINUOUS_APPROVE_AND_SWAP = 'continuous_approve_and_swap',
-  BATCH_APPROVE_AND_SWAP = 'batch_approve_and_swap',
-  NORMAL = 'normal',
-}
-
 export function useSwapBatchTransferType(
   networkId?: string,
   accountId?: string,
@@ -157,31 +150,16 @@ export function useSwapBatchTransferType(
   swapShouldSignedData?: boolean,
   needApprove?: boolean,
 ) {
-  let type = ESwapBatchTransferType.NORMAL;
   const [settingsPersistAtom] = useSettingsPersistAtom();
-  if (settingsPersistAtom.swapBatchApproveAndSwap && needApprove) {
-    type = ESwapBatchTransferType.BATCH_APPROVE_AND_SWAP;
-  }
-  const isExternalAccount = accountUtils.isExternalAccount({
-    accountId: accountId ?? '',
+
+  return buildSwapBatchTransferType({
+    networkId,
+    accountId,
+    providerDisableBatchTransfer,
+    swapShouldSignedData,
+    needApprove,
+    batchApproveAndSwapEnabled: settingsPersistAtom.swapBatchApproveAndSwap,
   });
-  const isHDAccount = accountUtils.isHwOrQrAccount({
-    accountId: accountId ?? '',
-  });
-  if ((isExternalAccount || isHDAccount) && needApprove) {
-    type = ESwapBatchTransferType.CONTINUOUS_APPROVE_AND_SWAP;
-  }
-  const isUnSupportBatchTransferNet =
-    SwapBuildUseMultiplePopoversNetworkIds.includes(networkId ?? '');
-  if (
-    providerDisableBatchTransfer ||
-    isUnSupportBatchTransferNet ||
-    !settingsPersistAtom.swapBatchApproveAndSwap ||
-    swapShouldSignedData
-  ) {
-    type = ESwapBatchTransferType.NORMAL;
-  }
-  return type;
 }
 
 export function useSwapActionState() {

--- a/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
+++ b/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
@@ -51,6 +51,7 @@ import PreSwapTokenItem from '../../components/PreSwapTokenItem';
 interface IPreSwapDialogContentProps {
   onConfirm: () => void;
   onDone: () => void;
+  disableGlobalApproveSync?: boolean;
   preSwapBeforeStepActions: (
     data?: IFetchQuoteResult,
     currentFromToken?: ISwapToken,
@@ -66,6 +67,7 @@ interface IPreSwapDialogContentProps {
 const PreSwapDialogContent = ({
   onDone,
   onConfirm,
+  disableGlobalApproveSync = false,
   preSwapBeforeStepActions,
   preSwapStepsStart,
 }: IPreSwapDialogContentProps) => {
@@ -128,6 +130,10 @@ const PreSwapDialogContent = ({
     setShowPreSwapTipInfo(undefined);
   }, []);
   useEffect(() => {
+    if (disableGlobalApproveSync) {
+      return;
+    }
+
     if (
       inAppNotificationAtom.swapApprovingTransaction &&
       inAppNotificationAtom.swapApprovingTransaction.status !==
@@ -173,6 +179,7 @@ const PreSwapDialogContent = ({
       });
     }
   }, [
+    disableGlobalApproveSync,
     inAppNotificationAtom.swapApprovingTransaction,
     setSwapSteps,
     preSwapStepsStart,

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -52,6 +52,7 @@ import { MarketWatchListProviderMirrorV2 } from '@onekeyhq/kit/src/views/Market/
 import {
   EJotaiContextStoreNames,
   useInAppNotificationAtom,
+  useSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { dismissKeyboard } from '@onekeyhq/shared/src/keyboard';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -66,7 +67,6 @@ import {
   EModalSwapRoutes,
   type IModalSwapParamList,
 } from '@onekeyhq/shared/src/routes/swap';
-import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
@@ -88,8 +88,6 @@ import {
   ESwapProTradeType,
   ESwapQuoteKind,
   ESwapSelectTokenSource,
-  ESwapStepStatus,
-  ESwapStepType,
   ESwapTabSwitchType,
   LIMIT_PRICE_DEFAULT_DECIMALS,
   SwapBuildShouldFallBackNetworkIds,
@@ -110,12 +108,11 @@ import {
 } from '../../hooks/useSwapPro';
 import { useSwapQuote } from '../../hooks/useSwapQuote';
 import {
-  ESwapBatchTransferType,
-  useSwapBatchTransferType,
   useSwapQuoteEventFetching,
   useSwapQuoteLoading,
   useSwapSlippagePercentageModeInfo,
 } from '../../hooks/useSwapState';
+import { buildSwapReviewState } from '../../utils/buildSwapReviewState';
 import { SwapProviderMirror } from '../SwapProviderMirror';
 
 import PreSwapDialogContent from './PreSwapDialogContent';
@@ -143,6 +140,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
   const [quoteResult] = useSwapQuoteCurrentSelectAtom();
   const [alerts] = useSwapAlertsAtom();
   const [swapTypeSwitch] = useSwapTypeSwitchAtom();
+  const [settingsPersistAtom] = useSettingsPersistAtom();
   const toAddressInfo = useSwapAddressInfo(ESwapDirectionType.TO);
   const swapFromAddressInfo = useSwapAddressInfo(ESwapDirectionType.FROM);
   // Check custom RPC availability for the from network
@@ -514,13 +512,6 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
       }) || currentQuoteRes?.isWrapped,
     [fromSelectToken, toSelectToken, currentQuoteRes?.isWrapped],
   );
-  const swapBatchTransferType = useSwapBatchTransferType(
-    swapFromAddressInfo.networkId,
-    swapFromAddressInfo.accountInfo?.account?.id,
-    currentQuoteRes?.providerDisableBatchTransfer,
-    Boolean(currentQuoteRes?.swapShouldSignedData),
-    Boolean(currentQuoteRes?.allowanceResult),
-  );
 
   const supportPreBuild = useMemo(() => {
     if (isWrapped) {
@@ -537,255 +528,93 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     );
   }, [currentQuoteRes, fromSelectToken?.networkId, isWrapped]);
 
-  const createWrapStep = useCallback(
-    (quoteRes: IFetchQuoteResult) => {
-      return {
-        type: ESwapStepType.WRAP_TX,
-        status: ESwapStepStatus.READY,
-        data: quoteRes,
-        fromToken: fromSelectToken,
-        toToken: toSelectToken,
-        stepTitle: intl.formatMessage({
-          id: ETranslations.swap_page_button_wrap,
-        }),
-        stepActionsLabel: intl.formatMessage({
-          id: ETranslations.swap_page_button_wrap,
-        }),
-      };
-    },
-    [fromSelectToken, intl, toSelectToken],
-  );
-
-  const createApproveStep = useCallback(
-    (isResetApprove: boolean, stepActionsLabel: string, stepTitle: string) => {
-      return {
-        type: ESwapStepType.APPROVE_TX,
-        status: ESwapStepStatus.READY,
-        isResetApprove,
-        canRetry: true,
-        stepActionsLabel,
-        stepTitle,
-        shouldWaitApproved: true,
-      };
-    },
-    [],
-  );
-
-  const createSignStep = useCallback(() => {
-    return {
-      type: ESwapStepType.SIGN_MESSAGE,
-      status: ESwapStepStatus.READY,
-      stepTitle: intl.formatMessage({
-        id: ETranslations.swap_review_sign_and_submit,
+  const reviewStepTexts = useMemo(
+    () => ({
+      wrap: intl.formatMessage({
+        id: ETranslations.swap_page_button_wrap,
       }),
-      stepActionsLabel: intl.formatMessage({
-        id: ETranslations.global_sign,
-      }),
-    };
-  }, [intl]);
-
-  const createBatchApproveSwapStep = useCallback(() => {
-    return {
-      type: ESwapStepType.BATCH_APPROVE_SWAP,
-      status: ESwapStepStatus.READY,
-      stepTitle:
-        swapBatchTransferType ===
-        ESwapBatchTransferType.CONTINUOUS_APPROVE_AND_SWAP
-          ? `${intl.formatMessage({
-              id: ETranslations.swap_page_approve_and_swap,
-            })} [ 0 / ${
-              currentQuoteRes?.allowanceResult?.shouldResetApprove ? 3 : 2
-            } ]`
-          : intl.formatMessage({
-              id: ETranslations.swap_page_approve_and_swap,
-            }),
-      stepActionsLabel: intl.formatMessage({
+      approveAndSwap: intl.formatMessage({
         id: ETranslations.swap_page_approve_and_swap,
       }),
-    };
-  }, [
-    swapBatchTransferType,
-    intl,
-    currentQuoteRes?.allowanceResult?.shouldResetApprove,
-  ]);
-
-  const shouldSignEveryTime = useMemo(() => {
-    const isExternalAccount = accountUtils.isExternalAccount({
-      accountId: swapFromAddressInfo.accountInfo?.account?.id ?? '',
-    });
-    const isHDAccount = accountUtils.isHwOrQrAccount({
-      accountId: swapFromAddressInfo.accountInfo?.account?.id ?? '',
-    });
-    const isShouldApprove = Boolean(currentQuoteRes?.allowanceResult);
-    return (isExternalAccount || isHDAccount) && isShouldApprove;
-  }, [
-    currentQuoteRes?.allowanceResult,
-    swapFromAddressInfo.accountInfo?.account?.id,
-  ]);
-
-  const createSendTxStep = useCallback(() => {
-    return {
-      type: ESwapStepType.SEND_TX,
-      status: ESwapStepStatus.READY,
-      stepTitle: intl.formatMessage({
+      approveAndSign: intl.formatMessage({
+        id: ETranslations.swap_page_approve_and_sign,
+      }),
+      revokeApprove: intl.formatMessage(
+        {
+          id: ETranslations.global_revoke_approve,
+        },
+        {
+          symbol: fromSelectToken?.symbol,
+        },
+      ),
+      approveToken: intl.formatMessage(
+        {
+          id: ETranslations.swap_page_approve_button,
+        },
+        {
+          token: fromSelectToken?.symbol,
+        },
+      ),
+      approveTokenWithTarget: intl.formatMessage(
+        {
+          id: ETranslations.swap_page_approve_button,
+        },
+        {
+          token: fromSelectToken?.symbol,
+          target: currentQuoteRes?.info.providerName,
+        },
+      ),
+      signAndSubmit: intl.formatMessage({
+        id: ETranslations.swap_review_sign_and_submit,
+      }),
+      sign: intl.formatMessage({
+        id: ETranslations.global_sign,
+      }),
+      confirmSwap: intl.formatMessage({
         id: ETranslations.swap_review_confirm_swap,
       }),
-      stepActionsLabel: intl.formatMessage({
+      swap: intl.formatMessage({
         id: ETranslations.global_swap,
       }),
-    };
-  }, [intl]);
-
-  const needFetchGas = useMemo(() => {
-    if (
-      currentQuoteRes?.allowanceResult &&
-      !(
-        swapBatchTransferType ===
-          ESwapBatchTransferType.BATCH_APPROVE_AND_SWAP ||
-        swapBatchTransferType ===
-          ESwapBatchTransferType.CONTINUOUS_APPROVE_AND_SWAP
-      )
-    ) {
-      return true;
-    }
-    return false;
-  }, [currentQuoteRes?.allowanceResult, swapBatchTransferType]);
+    }),
+    [currentQuoteRes?.info.providerName, fromSelectToken?.symbol, intl],
+  );
 
   const parseQuoteResultToSteps = useCallback(() => {
-    let steps: ISwapStep[] = [];
-    if (currentQuoteRes?.isWrapped) {
-      steps = [createWrapStep(currentQuoteRes)];
-    } else if (currentQuoteRes?.swapShouldSignedData) {
-      if (currentQuoteRes?.allowanceResult) {
-        if (currentQuoteRes?.allowanceResult.shouldResetApprove) {
-          steps = [
-            createApproveStep(
-              true,
-              intl.formatMessage({
-                id: ETranslations.swap_page_approve_and_sign,
-              }),
-              intl.formatMessage(
-                {
-                  id: ETranslations.global_revoke_approve,
-                },
-                {
-                  symbol: fromSelectToken?.symbol,
-                },
-              ),
-            ),
-          ];
-        }
-        steps = [
-          ...steps,
-          createApproveStep(
-            false,
-            intl.formatMessage({
-              id: ETranslations.swap_page_approve_and_sign,
-            }),
-            intl.formatMessage(
-              {
-                id: ETranslations.swap_page_approve_button,
-              },
-              {
-                token: fromSelectToken?.symbol,
-              },
-            ),
-          ),
-        ];
-      }
-      steps = [...steps, createSignStep()];
-    } else if (
-      (swapBatchTransferType ===
-        ESwapBatchTransferType.BATCH_APPROVE_AND_SWAP ||
-        swapBatchTransferType ===
-          ESwapBatchTransferType.CONTINUOUS_APPROVE_AND_SWAP) &&
-      currentQuoteRes?.allowanceResult
-    ) {
-      steps = [createBatchApproveSwapStep()];
-    } else {
-      if (currentQuoteRes?.allowanceResult) {
-        if (currentQuoteRes?.allowanceResult.shouldResetApprove) {
-          steps = [
-            createApproveStep(
-              true,
-              intl.formatMessage({
-                id: ETranslations.swap_page_approve_and_swap,
-              }),
-              intl.formatMessage(
-                {
-                  id: ETranslations.global_revoke_approve,
-                },
-                {
-                  symbol: fromSelectToken?.symbol,
-                },
-              ),
-            ),
-          ];
-        }
-        steps = [
-          ...steps,
-          createApproveStep(
-            false,
-            intl.formatMessage({
-              id: ETranslations.swap_page_approve_and_swap,
-            }),
-            intl.formatMessage(
-              {
-                id: ETranslations.swap_page_approve_button,
-              },
-              {
-                token: fromSelectToken?.symbol,
-                target: currentQuoteRes?.info.providerName,
-              },
-            ),
-          ),
-        ];
-      }
-      steps = [...steps, createSendTxStep()];
+    if (!currentQuoteRes) {
+      return;
     }
+
+    const nextReviewState = buildSwapReviewState({
+      accountId: swapFromAddressInfo.accountInfo?.account?.id,
+      networkId: swapFromAddressInfo.networkId,
+      batchApproveAndSwapEnabled: settingsPersistAtom.swapBatchApproveAndSwap,
+      fromToken: fromSelectToken,
+      toToken: toSelectToken,
+      fromTokenAmount:
+        focusSwapPro && swapProTradeType === ESwapProTradeType.MARKET
+          ? swapProInputAmount
+          : fromTokenAmount.value,
+      toTokenAmount: swapToAmount.value,
+      quoteResult: currentQuoteRes,
+      swapType: swapTypeFinal,
+      shouldFallback:
+        SwapBuildShouldFallBackNetworkIds.includes(
+          fromSelectToken?.networkId ?? '',
+        ) || isCustomRpcUnavailable,
+      supportPreBuild,
+      slippage: swapSlippageRef.current.value,
+      texts: reviewStepTexts,
+    });
+
     setSwapSteps({
-      steps: [...steps],
-      preSwapData: {
-        swapType: swapTypeFinal,
-        fromToken: fromSelectToken,
-        toToken: toSelectToken,
-        shouldFallback:
-          SwapBuildShouldFallBackNetworkIds.includes(
-            fromSelectToken?.networkId ?? '',
-          ) || isCustomRpcUnavailable,
-        fromTokenAmount:
-          focusSwapPro && swapProTradeType === ESwapProTradeType.MARKET
-            ? swapProInputAmount
-            : fromTokenAmount.value,
-        toTokenAmount: swapToAmount.value,
-        providerInfo: currentQuoteRes?.info,
-        supportPreBuild,
-        needFetchGas,
-        minToAmount: currentQuoteRes?.minToAmount,
-        slippage:
-          currentQuoteRes?.protocol === EProtocolOfExchange.LIMIT ||
-          currentQuoteRes?.unSupportSlippage
-            ? undefined
-            : swapSlippageRef.current.value,
-        unSupportSlippage: currentQuoteRes?.unSupportSlippage ?? false,
-        isHWAndExBatchTransfer: shouldSignEveryTime,
-        fee: currentQuoteRes?.fee,
-        ...(!(
-          steps.length > 0 &&
-          steps[steps.length - 1].type === ESwapStepType.SIGN_MESSAGE
-        )
-          ? {
-              supportNetworkFeeLevel: true,
-            }
-          : {}),
-      },
-      quoteResult: { ...(currentQuoteRes as IFetchQuoteResult) },
+      steps: [...nextReviewState.steps],
+      preSwapData: nextReviewState.preSwapData,
+      quoteResult: { ...(nextReviewState.quoteResult as IFetchQuoteResult) },
     });
   }, [
     currentQuoteRes,
-    swapBatchTransferType,
     setSwapSteps,
-    swapTypeFinal,
     fromSelectToken,
     toSelectToken,
     focusSwapPro,
@@ -793,16 +622,13 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     swapProInputAmount,
     fromTokenAmount.value,
     swapToAmount.value,
+    swapTypeFinal,
+    swapFromAddressInfo.accountInfo?.account?.id,
+    swapFromAddressInfo.networkId,
+    settingsPersistAtom.swapBatchApproveAndSwap,
     supportPreBuild,
-    needFetchGas,
-    shouldSignEveryTime,
-    createWrapStep,
-    createSignStep,
-    createApproveStep,
-    intl,
-    createBatchApproveSwapStep,
-    createSendTxStep,
     isCustomRpcUnavailable,
+    reviewStepTexts,
   ]);
   const onActionHandler = useCallback(() => {
     if (

--- a/packages/kit/src/views/Swap/utils/buildSwapReviewState.test.ts
+++ b/packages/kit/src/views/Swap/utils/buildSwapReviewState.test.ts
@@ -1,0 +1,359 @@
+import type {
+  IFetchQuoteResult,
+  ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
+import {
+  EProtocolOfExchange,
+  ESwapBatchTransferType,
+  ESwapStepType,
+  ESwapTabSwitchType,
+} from '@onekeyhq/shared/types/swap/types';
+
+import {
+  buildSwapBatchTransferType,
+  buildSwapReviewState,
+} from './buildSwapReviewState';
+
+const fromToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xfrom',
+  symbol: 'ETH',
+  decimals: 18,
+  isNative: true,
+};
+
+const toToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xto',
+  symbol: 'USDC',
+  decimals: 6,
+  isNative: false,
+};
+
+const texts = {
+  wrap: 'Wrap',
+  approveAndSwap: 'Approve and Swap',
+  approveAndSign: 'Approve and Sign',
+  revokeApprove: 'Revoke Approve',
+  approveToken: 'Approve ETH',
+  approveTokenWithTarget: 'Approve ETH for OneKey',
+  signAndSubmit: 'Sign and Submit',
+  sign: 'Sign',
+  confirmSwap: 'Confirm Swap',
+  swap: 'Swap',
+};
+
+function createQuoteResult(
+  overrides: Partial<IFetchQuoteResult> = {},
+): IFetchQuoteResult {
+  return {
+    protocol: EProtocolOfExchange.SWAP,
+    info: {
+      provider: 'onekey',
+      providerName: 'OneKey',
+    },
+    fromTokenInfo: fromToken,
+    toTokenInfo: toToken,
+    ...overrides,
+  };
+}
+
+describe('buildSwapBatchTransferType', () => {
+  it('returns batch approve and swap for standard accounts when enabled', () => {
+    expect(
+      buildSwapBatchTransferType({
+        networkId: fromToken.networkId,
+        accountId: 'hd-1--m/44/60/0/0/0',
+        batchApproveAndSwapEnabled: true,
+        needApprove: true,
+      }),
+    ).toBe(ESwapBatchTransferType.BATCH_APPROVE_AND_SWAP);
+  });
+
+  it('returns continuous approve and swap for external accounts', () => {
+    expect(
+      buildSwapBatchTransferType({
+        networkId: fromToken.networkId,
+        accountId: 'external--60--0xabc',
+        batchApproveAndSwapEnabled: true,
+        needApprove: true,
+      }),
+    ).toBe(ESwapBatchTransferType.CONTINUOUS_APPROVE_AND_SWAP);
+  });
+
+  it('downgrades to normal when the provider disables batch transfer', () => {
+    expect(
+      buildSwapBatchTransferType({
+        networkId: fromToken.networkId,
+        accountId: 'hd-1--m/44/60/0/0/0',
+        batchApproveAndSwapEnabled: true,
+        needApprove: true,
+        providerDisableBatchTransfer: true,
+      }),
+    ).toBe(ESwapBatchTransferType.NORMAL);
+  });
+});
+
+describe('buildSwapReviewState', () => {
+  it('builds a normal send flow', () => {
+    const result = buildSwapReviewState({
+      accountId: 'hd-1--m/44/60/0/0/0',
+      networkId: fromToken.networkId,
+      batchApproveAndSwapEnabled: true,
+      fromToken,
+      toToken,
+      fromTokenAmount: '1',
+      toTokenAmount: '2500',
+      quoteResult: createQuoteResult(),
+      swapType: ESwapTabSwitchType.SWAP,
+      shouldFallback: false,
+      supportPreBuild: true,
+      slippage: 1,
+      texts,
+    });
+
+    expect(result.steps.map((step) => step.type)).toEqual([
+      ESwapStepType.SEND_TX,
+    ]);
+    expect(result.preSwapData.needFetchGas).toBe(false);
+    expect(result.preSwapData.supportNetworkFeeLevel).toBe(true);
+  });
+
+  it('builds a wrap flow', () => {
+    const result = buildSwapReviewState({
+      accountId: 'hd-1--m/44/60/0/0/0',
+      networkId: fromToken.networkId,
+      batchApproveAndSwapEnabled: true,
+      fromToken,
+      toToken,
+      fromTokenAmount: '1',
+      toTokenAmount: '1',
+      quoteResult: createQuoteResult({
+        isWrapped: true,
+      }),
+      swapType: ESwapTabSwitchType.SWAP,
+      shouldFallback: false,
+      supportPreBuild: false,
+      slippage: 1,
+      texts,
+    });
+
+    expect(result.steps.map((step) => step.type)).toEqual([
+      ESwapStepType.WRAP_TX,
+    ]);
+    expect(result.steps[0].stepTitle).toBe(texts.wrap);
+  });
+
+  it('builds an approve and sign flow', () => {
+    const result = buildSwapReviewState({
+      accountId: 'hd-1--m/44/60/0/0/0',
+      networkId: fromToken.networkId,
+      batchApproveAndSwapEnabled: true,
+      fromToken,
+      toToken,
+      fromTokenAmount: '1',
+      toTokenAmount: '2500',
+      quoteResult: createQuoteResult({
+        allowanceResult: {
+          allowanceTarget: '0xspender',
+          amount: '1',
+        },
+        swapShouldSignedData: {
+          unSignedInfo: {
+            origin: 'origin',
+            scope: 'scope',
+            signedType: 'eth_signTypedData_v4' as never,
+          },
+        },
+      }),
+      swapType: ESwapTabSwitchType.SWAP,
+      shouldFallback: false,
+      supportPreBuild: true,
+      slippage: 1,
+      texts,
+    });
+
+    expect(result.steps.map((step) => step.type)).toEqual([
+      ESwapStepType.APPROVE_TX,
+      ESwapStepType.SIGN_MESSAGE,
+    ]);
+    expect(result.preSwapData.supportNetworkFeeLevel).toBeUndefined();
+  });
+
+  it('builds an approve and send flow', () => {
+    const result = buildSwapReviewState({
+      accountId: 'hd-1--m/44/60/0/0/0',
+      networkId: fromToken.networkId,
+      batchApproveAndSwapEnabled: false,
+      fromToken,
+      toToken,
+      fromTokenAmount: '1',
+      toTokenAmount: '2500',
+      quoteResult: createQuoteResult({
+        allowanceResult: {
+          allowanceTarget: '0xspender',
+          amount: '1',
+        },
+      }),
+      swapType: ESwapTabSwitchType.SWAP,
+      shouldFallback: false,
+      supportPreBuild: true,
+      slippage: 1,
+      texts,
+    });
+
+    expect(result.steps.map((step) => step.type)).toEqual([
+      ESwapStepType.APPROVE_TX,
+      ESwapStepType.SEND_TX,
+    ]);
+    expect(result.preSwapData.needFetchGas).toBe(true);
+  });
+
+  it('builds a reset approve flow', () => {
+    const result = buildSwapReviewState({
+      accountId: 'hd-1--m/44/60/0/0/0',
+      networkId: fromToken.networkId,
+      batchApproveAndSwapEnabled: false,
+      fromToken,
+      toToken,
+      fromTokenAmount: '1',
+      toTokenAmount: '2500',
+      quoteResult: createQuoteResult({
+        allowanceResult: {
+          allowanceTarget: '0xspender',
+          amount: '1',
+          shouldResetApprove: true,
+        },
+      }),
+      swapType: ESwapTabSwitchType.SWAP,
+      shouldFallback: false,
+      supportPreBuild: true,
+      slippage: 1,
+      texts,
+    });
+
+    expect(result.steps.map((step) => step.type)).toEqual([
+      ESwapStepType.APPROVE_TX,
+      ESwapStepType.APPROVE_TX,
+      ESwapStepType.SEND_TX,
+    ]);
+    expect(result.steps[0].isResetApprove).toBe(true);
+    expect(result.steps[1].isResetApprove).toBe(false);
+  });
+
+  it('builds a batch approve and swap flow', () => {
+    const result = buildSwapReviewState({
+      accountId: 'hd-1--m/44/60/0/0/0',
+      networkId: fromToken.networkId,
+      batchApproveAndSwapEnabled: true,
+      fromToken,
+      toToken,
+      fromTokenAmount: '1',
+      toTokenAmount: '2500',
+      quoteResult: createQuoteResult({
+        allowanceResult: {
+          allowanceTarget: '0xspender',
+          amount: '1',
+        },
+      }),
+      swapType: ESwapTabSwitchType.SWAP,
+      shouldFallback: false,
+      supportPreBuild: true,
+      slippage: 1,
+      texts,
+    });
+
+    expect(result.batchTransferType).toBe(
+      ESwapBatchTransferType.BATCH_APPROVE_AND_SWAP,
+    );
+    expect(result.steps.map((step) => step.type)).toEqual([
+      ESwapStepType.BATCH_APPROVE_SWAP,
+    ]);
+    expect(result.preSwapData.needFetchGas).toBe(false);
+  });
+
+  it('builds a continuous approve and swap flow for external accounts', () => {
+    const result = buildSwapReviewState({
+      accountId: 'external--60--0xabc',
+      networkId: fromToken.networkId,
+      batchApproveAndSwapEnabled: true,
+      fromToken,
+      toToken,
+      fromTokenAmount: '1',
+      toTokenAmount: '2500',
+      quoteResult: createQuoteResult({
+        allowanceResult: {
+          allowanceTarget: '0xspender',
+          amount: '1',
+        },
+      }),
+      swapType: ESwapTabSwitchType.SWAP,
+      shouldFallback: false,
+      supportPreBuild: true,
+      slippage: 1,
+      texts,
+    });
+
+    expect(result.batchTransferType).toBe(
+      ESwapBatchTransferType.CONTINUOUS_APPROVE_AND_SWAP,
+    );
+    expect(result.steps.map((step) => step.type)).toEqual([
+      ESwapStepType.BATCH_APPROVE_SWAP,
+    ]);
+    expect(result.steps[0].stepTitle).toContain('[ 0 / 2 ]');
+    expect(result.preSwapData.isHWAndExBatchTransfer).toBe(true);
+  });
+
+  it('downgrades provider-disabled batch transfer to approve and send', () => {
+    const result = buildSwapReviewState({
+      accountId: 'hd-1--m/44/60/0/0/0',
+      networkId: fromToken.networkId,
+      batchApproveAndSwapEnabled: true,
+      fromToken,
+      toToken,
+      fromTokenAmount: '1',
+      toTokenAmount: '2500',
+      quoteResult: createQuoteResult({
+        allowanceResult: {
+          allowanceTarget: '0xspender',
+          amount: '1',
+        },
+        providerDisableBatchTransfer: true,
+      }),
+      swapType: ESwapTabSwitchType.SWAP,
+      shouldFallback: false,
+      supportPreBuild: true,
+      slippage: 1,
+      texts,
+    });
+
+    expect(result.batchTransferType).toBe(ESwapBatchTransferType.NORMAL);
+    expect(result.steps.map((step) => step.type)).toEqual([
+      ESwapStepType.APPROVE_TX,
+      ESwapStepType.SEND_TX,
+    ]);
+  });
+
+  it('removes slippage when the quote does not support it', () => {
+    const result = buildSwapReviewState({
+      accountId: 'hd-1--m/44/60/0/0/0',
+      networkId: fromToken.networkId,
+      batchApproveAndSwapEnabled: false,
+      fromToken,
+      toToken,
+      fromTokenAmount: '1',
+      toTokenAmount: '2500',
+      quoteResult: createQuoteResult({
+        unSupportSlippage: true,
+      }),
+      swapType: ESwapTabSwitchType.SWAP,
+      shouldFallback: true,
+      supportPreBuild: true,
+      slippage: 2,
+      texts,
+    });
+
+    expect(result.preSwapData.slippage).toBeUndefined();
+    expect(result.preSwapData.shouldFallback).toBe(true);
+  });
+});

--- a/packages/kit/src/views/Swap/utils/buildSwapReviewState.ts
+++ b/packages/kit/src/views/Swap/utils/buildSwapReviewState.ts
@@ -1,0 +1,318 @@
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import type {
+  ESwapTabSwitchType,
+  IFetchQuoteResult,
+  ISwapPreSwapData,
+  ISwapStep,
+  ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
+import {
+  EProtocolOfExchange,
+  ESwapBatchTransferType,
+  ESwapStepStatus,
+  ESwapStepType,
+  SwapBuildUseMultiplePopoversNetworkIds,
+} from '@onekeyhq/shared/types/swap/types';
+
+export type ISwapReviewStepTexts = {
+  wrap: string;
+  approveAndSwap: string;
+  approveAndSign: string;
+  revokeApprove: string;
+  approveToken: string;
+  approveTokenWithTarget: string;
+  signAndSubmit: string;
+  sign: string;
+  confirmSwap: string;
+  swap: string;
+};
+
+export type IBuildSwapBatchTransferTypeParams = {
+  networkId?: string;
+  accountId?: string;
+  providerDisableBatchTransfer?: boolean;
+  swapShouldSignedData?: boolean;
+  needApprove?: boolean;
+  batchApproveAndSwapEnabled?: boolean;
+};
+
+export function buildSwapBatchTransferType({
+  networkId,
+  accountId,
+  providerDisableBatchTransfer,
+  swapShouldSignedData,
+  needApprove,
+  batchApproveAndSwapEnabled,
+}: IBuildSwapBatchTransferTypeParams): ESwapBatchTransferType {
+  let type = ESwapBatchTransferType.NORMAL;
+
+  if (batchApproveAndSwapEnabled && needApprove) {
+    type = ESwapBatchTransferType.BATCH_APPROVE_AND_SWAP;
+  }
+
+  const isExternalAccount = accountUtils.isExternalAccount({
+    accountId: accountId ?? '',
+  });
+  const isHDAccount = accountUtils.isHwOrQrAccount({
+    accountId: accountId ?? '',
+  });
+
+  if ((isExternalAccount || isHDAccount) && needApprove) {
+    type = ESwapBatchTransferType.CONTINUOUS_APPROVE_AND_SWAP;
+  }
+
+  const isUnsupportedBatchTransferNetwork =
+    SwapBuildUseMultiplePopoversNetworkIds.includes(networkId ?? '');
+
+  if (
+    providerDisableBatchTransfer ||
+    isUnsupportedBatchTransferNetwork ||
+    !batchApproveAndSwapEnabled ||
+    swapShouldSignedData
+  ) {
+    type = ESwapBatchTransferType.NORMAL;
+  }
+
+  return type;
+}
+
+function buildShouldSignEveryTime({
+  accountId,
+  needApprove,
+}: {
+  accountId?: string;
+  needApprove?: boolean;
+}) {
+  const isExternalAccount = accountUtils.isExternalAccount({
+    accountId: accountId ?? '',
+  });
+  const isHDAccount = accountUtils.isHwOrQrAccount({
+    accountId: accountId ?? '',
+  });
+
+  return (isExternalAccount || isHDAccount) && Boolean(needApprove);
+}
+
+function createWrapStep(texts: ISwapReviewStepTexts): ISwapStep {
+  return {
+    type: ESwapStepType.WRAP_TX,
+    status: ESwapStepStatus.READY,
+    stepTitle: texts.wrap,
+    stepActionsLabel: texts.wrap,
+  };
+}
+
+function createApproveStep({
+  isResetApprove,
+  stepActionsLabel,
+  stepTitle,
+}: {
+  isResetApprove: boolean;
+  stepActionsLabel: string;
+  stepTitle: string;
+}): ISwapStep {
+  return {
+    type: ESwapStepType.APPROVE_TX,
+    status: ESwapStepStatus.READY,
+    isResetApprove,
+    canRetry: true,
+    stepActionsLabel,
+    stepTitle,
+    shouldWaitApproved: true,
+  };
+}
+
+function createSignStep(texts: ISwapReviewStepTexts): ISwapStep {
+  return {
+    type: ESwapStepType.SIGN_MESSAGE,
+    status: ESwapStepStatus.READY,
+    stepTitle: texts.signAndSubmit,
+    stepActionsLabel: texts.sign,
+  };
+}
+
+function createBatchApproveSwapStep({
+  texts,
+  batchTransferType,
+  shouldResetApprove,
+}: {
+  texts: ISwapReviewStepTexts;
+  batchTransferType: ESwapBatchTransferType;
+  shouldResetApprove?: boolean;
+}): ISwapStep {
+  return {
+    type: ESwapStepType.BATCH_APPROVE_SWAP,
+    status: ESwapStepStatus.READY,
+    stepTitle:
+      batchTransferType === ESwapBatchTransferType.CONTINUOUS_APPROVE_AND_SWAP
+        ? `${texts.approveAndSwap} [ 0 / ${shouldResetApprove ? 3 : 2} ]`
+        : texts.approveAndSwap,
+    stepActionsLabel: texts.approveAndSwap,
+  };
+}
+
+function createSendTxStep(texts: ISwapReviewStepTexts): ISwapStep {
+  return {
+    type: ESwapStepType.SEND_TX,
+    status: ESwapStepStatus.READY,
+    stepTitle: texts.confirmSwap,
+    stepActionsLabel: texts.swap,
+  };
+}
+
+export type IBuildSwapReviewStateInput = {
+  accountId?: string;
+  networkId?: string;
+  batchApproveAndSwapEnabled?: boolean;
+  fromToken?: ISwapToken;
+  toToken?: ISwapToken;
+  fromTokenAmount?: string;
+  toTokenAmount?: string;
+  quoteResult?: IFetchQuoteResult;
+  swapType: ESwapTabSwitchType;
+  shouldFallback?: boolean;
+  supportPreBuild: boolean;
+  slippage?: number;
+  texts: ISwapReviewStepTexts;
+};
+
+export function buildSwapReviewState({
+  accountId,
+  networkId,
+  batchApproveAndSwapEnabled,
+  fromToken,
+  toToken,
+  fromTokenAmount,
+  toTokenAmount,
+  quoteResult,
+  swapType,
+  shouldFallback,
+  supportPreBuild,
+  slippage,
+  texts,
+}: IBuildSwapReviewStateInput): {
+  batchTransferType: ESwapBatchTransferType;
+  steps: ISwapStep[];
+  preSwapData: ISwapPreSwapData;
+  quoteResult?: IFetchQuoteResult;
+} {
+  const needApprove = Boolean(quoteResult?.allowanceResult);
+  const batchTransferType = buildSwapBatchTransferType({
+    networkId,
+    accountId,
+    providerDisableBatchTransfer: quoteResult?.providerDisableBatchTransfer,
+    swapShouldSignedData: Boolean(quoteResult?.swapShouldSignedData),
+    needApprove,
+    batchApproveAndSwapEnabled,
+  });
+  const shouldSignEveryTime = buildShouldSignEveryTime({
+    accountId,
+    needApprove,
+  });
+  const needFetchGas =
+    needApprove &&
+    !(
+      batchTransferType === ESwapBatchTransferType.BATCH_APPROVE_AND_SWAP ||
+      batchTransferType === ESwapBatchTransferType.CONTINUOUS_APPROVE_AND_SWAP
+    );
+
+  let steps: ISwapStep[] = [];
+
+  if (quoteResult?.isWrapped) {
+    steps = [createWrapStep(texts)];
+  } else if (quoteResult?.swapShouldSignedData) {
+    if (quoteResult.allowanceResult) {
+      if (quoteResult.allowanceResult.shouldResetApprove) {
+        steps = [
+          createApproveStep({
+            isResetApprove: true,
+            stepActionsLabel: texts.approveAndSign,
+            stepTitle: texts.revokeApprove,
+          }),
+        ];
+      }
+
+      steps = [
+        ...steps,
+        createApproveStep({
+          isResetApprove: false,
+          stepActionsLabel: texts.approveAndSign,
+          stepTitle: texts.approveToken,
+        }),
+      ];
+    }
+
+    steps = [...steps, createSignStep(texts)];
+  } else if (
+    (batchTransferType === ESwapBatchTransferType.BATCH_APPROVE_AND_SWAP ||
+      batchTransferType ===
+        ESwapBatchTransferType.CONTINUOUS_APPROVE_AND_SWAP) &&
+    quoteResult?.allowanceResult
+  ) {
+    steps = [
+      createBatchApproveSwapStep({
+        texts,
+        batchTransferType,
+        shouldResetApprove: quoteResult.allowanceResult.shouldResetApprove,
+      }),
+    ];
+  } else {
+    if (quoteResult?.allowanceResult) {
+      if (quoteResult.allowanceResult.shouldResetApprove) {
+        steps = [
+          createApproveStep({
+            isResetApprove: true,
+            stepActionsLabel: texts.approveAndSwap,
+            stepTitle: texts.revokeApprove,
+          }),
+        ];
+      }
+
+      steps = [
+        ...steps,
+        createApproveStep({
+          isResetApprove: false,
+          stepActionsLabel: texts.approveAndSwap,
+          stepTitle: texts.approveTokenWithTarget,
+        }),
+      ];
+    }
+
+    steps = [...steps, createSendTxStep(texts)];
+  }
+
+  const preSwapData: ISwapPreSwapData = {
+    swapType,
+    fromToken,
+    toToken,
+    shouldFallback,
+    fromTokenAmount,
+    toTokenAmount,
+    providerInfo: quoteResult?.info,
+    supportPreBuild,
+    needFetchGas,
+    minToAmount: quoteResult?.minToAmount,
+    slippage:
+      quoteResult?.protocol === EProtocolOfExchange.LIMIT ||
+      quoteResult?.unSupportSlippage
+        ? undefined
+        : slippage,
+    unSupportSlippage: quoteResult?.unSupportSlippage ?? false,
+    isHWAndExBatchTransfer: shouldSignEveryTime,
+    fee: quoteResult?.fee,
+    allowanceResult: quoteResult?.allowanceResult,
+    ...(steps.length > 0 &&
+    steps[steps.length - 1].type !== ESwapStepType.SIGN_MESSAGE
+      ? {
+          supportNetworkFeeLevel: true,
+        }
+      : {}),
+  };
+
+  return {
+    batchTransferType,
+    steps,
+    preSwapData,
+    quoteResult,
+  };
+}


### PR DESCRIPTION
## Summary
- Extract the market confirm page v2 changes from #10915 onto `release/v6.1.0` without the intermediate `merge x` commits
- Align the market swap review flow with the swap confirm/review implementation by introducing dedicated review state builders, review actions, and dialog initialization logic
- Fix approval fee semantics, gas refresh after approve, sign review invariants, one-inch close handling, and pending amount normalization, with regression tests covering the new flow

## Intent & Context
This PR is the release-branch extraction of the market confirm page v2 work from #10915. The goal is to land only the market confirm related changes on `release/v6.1.0`, without pulling in the unrelated changes that came from multiple `merge x` commits on the original branch.

## Root Cause
The market detail v2 swap panel was still using a review/confirm flow that had drifted from the main swap implementation. That caused inconsistent preview behavior and edge-case issues around approve fee handling, gas refresh after approve, sign context lifecycle, and pending amount matching.

## Design Decisions
- Cherry-pick only the 8 market-confirm related commits from #10915 and exclude the intermediate `merge x` commits
- Exclude the unrelated imported-credential decrypt error fix and its revert, since they are not part of the market confirm scope
- Reuse the swap review state/building patterns inside the market swap panel so the two flows stay aligned and regressions are easier to cover with shared-style tests

## Changes Detail
- Add the market swap review initializer, dialog, action hooks, and execution/review/build utilities under `MarketDetailV2/components/SwapPanel`
- Update `useSpeedSwapActions`, `SwapMainLand`, `useSwapState`, and `buildSwapReviewState` to support the aligned review pipeline and approval handling
- Add targeted tests for review initialization, approve execution, review utility behavior, pending amount normalization, and panel rendering assertions

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Desktop / Web / Extension
- **Risk Areas**: Market swap review state transitions, approve flow handling, fee/gas refresh timing, and sign-context cleanup

## Test plan
- [ ] Verify the market detail v2 swap panel preview matches the swap review flow
- [ ] Verify approve then swap refreshes review gas and displays approve fee semantics correctly
- [ ] Verify pending amount matching and one-inch close handling behave correctly in review/sign flows
- [ ] Run the targeted market swap review test suite before merge
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10950" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
