### PR TITLE
fix(ext): keep passkey switch default on in sidepanel password setup

### DIFF
--- a/packages/kit/src/components/Password/container/PasswordSetupContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordSetupContainer.tsx
@@ -47,10 +47,7 @@ const BiologyAuthContainer = ({
   );
 
   useEffect(() => {
-    if (
-      (platformEnv.isExtensionUiPopup || platformEnv.isExtensionUiSidePanel) &&
-      isBiologyAuthSwitchOn
-    ) {
+    if (platformEnv.isExtensionUiPopup && isBiologyAuthSwitchOn) {
       void backgroundApiProxy.serviceSetting.setBiologyAuthSwitchOn(false);
     }
   }, [isBiologyAuthSwitchOn]);


### PR DESCRIPTION
### Motivation
- Ensure the PassKey (biometry/webauth) toggle stays enabled by default when setting a password from the extension sidepanel; previously the toggle was being forced off for both popup and sidepanel extension UIs.

### Description
- Change the `useEffect` in `packages/kit/src/components/Password/container/PasswordSetupContainer.tsx` to only call `backgroundApiProxy.serviceSetting.setBiologyAuthSwitchOn(false)` when `platformEnv.isExtensionUiPopup` is true, removing the sidepanel branch so sidepanel setup no longer disables `isBiologyAuthSwitchOn`.

### Testing
- Attempted to run `eslint` against the modified file but automated linting could not run in this environment due to missing Yarn workspace state (`Couldn't find the node_modules state file`), so no automated checks were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9dd8cddec83329d567b5e49663407)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10952" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
