### PR TITLE
OK-52305 feat(wallet): add contract approvals entry to More dropdown

### DIFF
--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionApprovals.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionApprovals.tsx
@@ -8,7 +8,7 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
-import { useNavigateToApprovalList } from '../../../Home/hooks/useNavigateToApprovalList';
+import { useNavigateToApprovalList } from '../../hooks/useNavigateToApprovalList';
 
 export function WalletActionApprovals({ onClose }: { onClose: () => void }) {
   const intl = useIntl();

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionApprovals.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionApprovals.tsx
@@ -5,6 +5,7 @@ import { useIntl } from 'react-intl';
 import { ActionList } from '@onekeyhq/components';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
 import { useNavigateToApprovalList } from '../../../Home/hooks/useNavigateToApprovalList';
@@ -17,6 +18,11 @@ export function WalletActionApprovals({ onClose }: { onClose: () => void }) {
   const navigateToApprovalList = useNavigateToApprovalList();
 
   const handlePress = useCallback(async () => {
+    defaultLogger.wallet.walletActions.actionApprovals({
+      walletType: wallet?.type ?? '',
+      networkId: network?.id ?? '',
+      source: 'homePage',
+    });
     onClose();
     await timerUtils.wait(150);
     void navigateToApprovalList({
@@ -31,6 +37,7 @@ export function WalletActionApprovals({ onClose }: { onClose: () => void }) {
     network?.id,
     account?.id,
     wallet?.id,
+    wallet?.type,
     account?.indexedAccountId,
   ]);
 

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionApprovals.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionApprovals.tsx
@@ -1,0 +1,48 @@
+import { useCallback } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import { ActionList } from '@onekeyhq/components';
+import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
+
+import { useNavigateToApprovalList } from '../../../Home/hooks/useNavigateToApprovalList';
+
+export function WalletActionApprovals({ onClose }: { onClose: () => void }) {
+  const intl = useIntl();
+  const { activeAccount } = useActiveAccount({ num: 0 });
+  const { network, account, wallet } = activeAccount;
+
+  const navigateToApprovalList = useNavigateToApprovalList();
+
+  const handlePress = useCallback(async () => {
+    onClose();
+    await timerUtils.wait(150);
+    void navigateToApprovalList({
+      networkId: network?.id,
+      accountId: account?.id,
+      walletId: wallet?.id,
+      indexedAccountId: account?.indexedAccountId,
+    });
+  }, [
+    onClose,
+    navigateToApprovalList,
+    network?.id,
+    account?.id,
+    wallet?.id,
+    account?.indexedAccountId,
+  ]);
+
+  return (
+    <ActionList.Item
+      trackID="wallet-action-approvals"
+      icon="ShieldCheckDoneOutline"
+      label={intl.formatMessage({
+        id: ETranslations.global_approvals,
+      })}
+      onClose={() => {}}
+      onPress={handlePress}
+    />
+  );
+}

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionMore.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionMore.tsx
@@ -74,7 +74,12 @@ export function WalletActionMore() {
       return true;
     }
     return networksSupportApproval[network?.id ?? ''] ?? false;
-  }, [network?.isAllNetworks, network?.id, account?.id, account?.createAtNetwork]);
+  }, [
+    network?.isAllNetworks,
+    network?.id,
+    account?.id,
+    account?.createAtNetwork,
+  ]);
 
   const renderItemsAsync = useCallback(
     async ({

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionMore.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionMore.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { Divider } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
@@ -12,12 +12,16 @@ import {
   useActiveAccount,
 } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { getNetworksSupportBulkRevokeApproval } from '@onekeyhq/shared/src/config/presetNetworks';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 
 import { HomeTokenListProviderMirrorWrapper } from '../HomeTokenListProvider';
 
 import { RawActions } from './RawActions';
 import { useWalletActionConfig } from './useWalletActionConfig';
+import { WalletActionApprovals } from './WalletActionApprovals';
 import { WalletActionBulkSend } from './WalletActionBulkSend';
 import { WalletActionBuy } from './WalletActionBuy';
 import { WalletActionCopy } from './WalletActionCopy';
@@ -54,6 +58,23 @@ export function WalletActionMore() {
   const displaySignAndVerify = usePromiseResult(async () => {
     return vaultSettings?.enabledInternalSignAndVerify;
   }, [vaultSettings]);
+
+  const isApprovalEnabled = useMemo(() => {
+    const networksSupportApproval = getNetworksSupportBulkRevokeApproval();
+    if (network?.isAllNetworks) {
+      if (
+        accountUtils.isOthersAccount({
+          accountId: account?.id ?? '',
+        })
+      ) {
+        return networkUtils.isEvmNetwork({
+          networkId: account?.createAtNetwork ?? '',
+        });
+      }
+      return true;
+    }
+    return networksSupportApproval[network?.id ?? ''] ?? false;
+  }, [network?.isAllNetworks, network?.id, account?.id, account?.createAtNetwork]);
 
   const renderItemsAsync = useCallback(
     async ({
@@ -118,6 +139,8 @@ export function WalletActionMore() {
               return displaySignAndVerify.result;
             case 'reward':
               return !!rewardCenterConfig;
+            case 'approvals':
+              return isApprovalEnabled;
             default:
               return config.moreActions.includes(action);
           }
@@ -160,6 +183,13 @@ export function WalletActionMore() {
                   rewardCenterConfig={rewardCenterConfig}
                 />
               ) : null;
+            case 'approvals':
+              return (
+                <WalletActionApprovals
+                  key="approvals"
+                  onClose={handleActionListClose}
+                />
+              );
             case 'vote':
               return (
                 <WalletActionVote
@@ -252,6 +282,7 @@ export function WalletActionMore() {
       vaultSettings?.copyAddressDisabled,
       displaySignAndVerify.result,
       rewardCenterConfig,
+      isApprovalEnabled,
       getActionCustomization,
       devSettings?.settings?.showDevExportPrivateKey,
       sceneName,

--- a/packages/kit/src/views/Home/components/WalletActions/networkConfigs.ts
+++ b/packages/kit/src/views/Home/components/WalletActions/networkConfigs.ts
@@ -23,8 +23,26 @@ export const defaultWalletActionsConfig: INetworkWalletActionsConfig = {
     ? ['send', 'receive', 'swap']
     : ['send', 'receive', 'buy'],
   moreActions: isExtPopupOrSidePanel
-    ? ['buy', 'explorer', 'copy', 'approvals', 'bulkSend', 'sign', 'reward', 'export']
-    : ['swap', 'explorer', 'copy', 'approvals', 'bulkSend', 'sign', 'reward', 'export'],
+    ? [
+        'buy',
+        'explorer',
+        'copy',
+        'approvals',
+        'bulkSend',
+        'sign',
+        'reward',
+        'export',
+      ]
+    : [
+        'swap',
+        'explorer',
+        'copy',
+        'approvals',
+        'bulkSend',
+        'sign',
+        'reward',
+        'export',
+      ],
   moreActionGroups: [
     {
       type: 'trading',

--- a/packages/kit/src/views/Home/components/WalletActions/networkConfigs.ts
+++ b/packages/kit/src/views/Home/components/WalletActions/networkConfigs.ts
@@ -23,8 +23,8 @@ export const defaultWalletActionsConfig: INetworkWalletActionsConfig = {
     ? ['send', 'receive', 'swap']
     : ['send', 'receive', 'buy'],
   moreActions: isExtPopupOrSidePanel
-    ? ['buy', 'explorer', 'copy', 'bulkSend', 'sign', 'reward', 'export']
-    : ['swap', 'explorer', 'copy', 'bulkSend', 'sign', 'reward', 'export'],
+    ? ['buy', 'explorer', 'copy', 'approvals', 'bulkSend', 'sign', 'reward', 'export']
+    : ['swap', 'explorer', 'copy', 'approvals', 'bulkSend', 'sign', 'reward', 'export'],
   moreActionGroups: [
     {
       type: 'trading',
@@ -33,7 +33,7 @@ export const defaultWalletActionsConfig: INetworkWalletActionsConfig = {
     },
     {
       type: 'tools',
-      actions: ['explorer', 'copy', 'bulkSend', 'sign', 'reward'],
+      actions: ['explorer', 'copy', 'approvals', 'bulkSend', 'sign', 'reward'],
       order: 2,
     },
     {

--- a/packages/kit/src/views/Home/components/WalletActions/types.ts
+++ b/packages/kit/src/views/Home/components/WalletActions/types.ts
@@ -14,6 +14,7 @@ export type IWalletActionType =
   | 'reward'
   | 'export'
   | 'vote'
+  | 'approvals'
   | 'custom';
 
 export type IMoreActionGroupType = 'trading' | 'tools' | 'developer' | 'others';

--- a/packages/shared/src/logger/scopes/wallet/scenes/walletActions.ts
+++ b/packages/shared/src/logger/scopes/wallet/scenes/walletActions.ts
@@ -101,6 +101,13 @@ export class WalletActionsScene extends BaseScene {
   }
 
   @LogToServer()
+  public actionApprovals(
+    params: Omit<IWalletActionBaseParams, 'isSoftwareWalletOnlyUser'>,
+  ) {
+    return params;
+  }
+
+  @LogToServer()
   public actionStaking(params: IWalletActionBaseParams) {
     return params;
   }


### PR DESCRIPTION
## Summary
- Add an "Approvals" action item to the home page wallet "More" dropdown menu
- Users can navigate directly to the approval management page to review and manage contract approvals
- Only displayed for supported EVM networks: Ethereum, BSC, Polygon, Arbitrum, Avalanche, Optimism, Base
- Respects All Networks mode visibility rules based on wallet and account type

## Test plan
- [x] Verify "Approvals" menu item appears for all supported EVM networks (ETH, BSC, Polygon, Arbitrum, Avalanche, Optimism, Base)
- [x] Verify menu item is hidden for unsupported networks (BTC, TRX, SOL, etc.)
- [x] Verify All Networks mode: visible for HD/HW wallets, visible for imported EVM accounts, hidden for imported non-EVM accounts
- [ ] Verify click navigates to approval list page on Desktop/Web (tab route), Mobile (modal), and Extension (expand tab)
- [x] Verify i18n label displays correctly across languages
- [ ] Regression: existing menu items still function normally

## Jira
[OK-52305](https://onekeyhq.atlassian.net/browse/OK-52305)

[OK-52305]: https://onekeyhq.atlassian.net/browse/OK-52305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10953" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
