### PR TITLE
fix: add requestIdleCallback polyfill for older browsers

### DIFF
--- a/packages/shared/src/polyfills/polyfillsPlatform.ext.ts
+++ b/packages/shared/src/polyfills/polyfillsPlatform.ext.ts
@@ -4,6 +4,7 @@ import 'globalthis';
 
 import './globalShim';
 import './setimmediateShim';
+import './requestIdleCallbackShim';
 import './extensionApiShim/extensionApiShim';
 import './indexedDBShim/indexedDBShim';
 import './xhrShim';

--- a/packages/shared/src/polyfills/polyfillsPlatform.web.js
+++ b/packages/shared/src/polyfills/polyfillsPlatform.web.js
@@ -3,6 +3,7 @@
 /* eslint-disable import-js/order */
 // check  polyfillsPlatform.ext.ts  or   polyfillsPlatform.native.js
 import './setimmediateShim';
+import './requestIdleCallbackShim';
 import './globalShim';
 import './indexedDBShim/indexedDBShim';
 

--- a/packages/shared/src/polyfills/requestIdleCallbackShim.ts
+++ b/packages/shared/src/polyfills/requestIdleCallbackShim.ts
@@ -1,0 +1,25 @@
+// Safari < 18.4 does not support requestIdleCallback / cancelIdleCallback.
+// Provide a setTimeout-based fallback so call-sites work everywhere.
+
+// eslint-disable-next-line unicorn/prefer-global-this
+const _global = typeof globalThis !== 'undefined' ? globalThis : (self as any);
+
+if (typeof _global.requestIdleCallback !== 'function') {
+  _global.requestIdleCallback = (
+    cb: IdleRequestCallback,
+    _options?: IdleRequestOptions,
+  ): number =>
+    setTimeout(() => {
+      const start = Date.now();
+      cb({
+        didTimeout: false,
+        timeRemaining: () => Math.max(0, 50 - (Date.now() - start)),
+      });
+    }, 1) as unknown as number;
+}
+
+if (typeof _global.cancelIdleCallback !== 'function') {
+  _global.cancelIdleCallback = (id: number): void => {
+    clearTimeout(id);
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a `requestIdleCallback` / `cancelIdleCallback` polyfill (setTimeout-based fallback) for browsers that lack native support (Safari < 18.4, older WebViews)
- Imports the shim in web and extension polyfill entry points so it loads before any app code

## Test plan
- [ ] Verify web app loads without errors on Safari < 18.4
- [ ] Verify extension works on older Chromium versions
- [ ] Confirm no regressions on browsers that already support `requestIdleCallback`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
