### PR TITLE
fix: i18n overflow on DeFi Earn/Borrow segment control (OK-52337)

### DIFF
--- a/packages/components/src/actions/SegmentControl/index.tsx
+++ b/packages/components/src/actions/SegmentControl/index.tsx
@@ -125,6 +125,7 @@ function SegmentControlFrame({
       backgroundColor={slotBackgroundColor ?? '$bgStrong'}
       borderRadius="$full"
       borderCurve="continuous"
+      overflow="hidden"
       h={32}
       {...rest}
     >

--- a/packages/kit/src/views/Earn/components/MarketSelector.tsx
+++ b/packages/kit/src/views/Earn/components/MarketSelector.tsx
@@ -103,7 +103,6 @@ const MarketSelectorDesktop = ({
     const baseProps = {
       elevation: 0,
       flexGrow: 1,
-      flexBasis: 0,
       '$platform-native': {
         elevation: 0,
       },
@@ -132,7 +131,7 @@ const MarketSelectorDesktop = ({
       <SegmentControl
         value={mode}
         options={options}
-        width={264}
+        minWidth={264}
         onChange={(value) => onModeChange?.(value as IEarnHomeMode)}
         slotBackgroundColor={backgroundColor}
         activeBackgroundColor={activeBackgroundColor}


### PR DESCRIPTION
## Summary
- Add `overflow: hidden` to `SegmentControl` component to clip child content within pill boundary
- Change `MarketSelector` desktop width from fixed `264` to `minWidth={264}` so container can expand for longer translations (e.g. Italian "Prendi in prestito", Spanish "Pedir prestado")
- Remove `flexBasis: 0` so tab items size from content width instead of forced equal split

## Test plan
- [ ] Verify DeFi Earn/Borrow tabs display correctly in Italian (Guadagna / Prendi in prestito)
- [ ] Verify DeFi Earn/Borrow tabs display correctly in Spanish (Ganar / Pedir prestado)
- [ ] Verify English layout is not affected
- [ ] Verify active tab pill background does not overflow container
- [ ] Test on desktop platform
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
