### PR TITLE
fix(market): wrap swap dialog content in ScrollView to prevent keyboard occlusion (OK-51633)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
-import { SizableText, Toast, YStack } from '@onekeyhq/components';
+import { ScrollView, SizableText, Toast, YStack } from '@onekeyhq/components';
 import type { IAccountSelectorActiveAccountInfo } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import { validateAmountInput } from '@onekeyhq/kit/src/utils/validateAmountInput';
 import type { useSwapPanel } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSwapPanel';
@@ -224,7 +224,13 @@ export function SwapPanelContent(props: ISwapPanelContentProps) {
   }, [currentMarketToken?.networkId, currentMarketToken?.contractAddress]);
 
   return (
-    <YStack gap="$4">
+    <ScrollView
+      showsVerticalScrollIndicator={false}
+      bounces={false}
+      keyboardShouldPersistTaps="handled"
+      keyboardDismissMode="on-drag"
+    >
+      <YStack gap="$4">
       {/* Trade type selector */}
       <TradeTypeSelector value={tradeType} onChange={setTradeType} />
 
@@ -334,6 +340,7 @@ export function SwapPanelContent(props: ISwapPanelContentProps) {
           }}
         />
       )}
-    </YStack>
+      </YStack>
+    </ScrollView>
   );
 }

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.tsx
@@ -231,115 +231,115 @@ export function SwapPanelContent(props: ISwapPanelContentProps) {
       keyboardDismissMode="on-drag"
     >
       <YStack gap="$4">
-      {/* Trade type selector */}
-      <TradeTypeSelector value={tradeType} onChange={setTradeType} />
+        {/* Trade type selector */}
+        <TradeTypeSelector value={tradeType} onChange={setTradeType} />
 
-      <YStack gap="$3">
-        {/* Token input section */}
-        <SwapPanelTop
-          enableAddressTypeSelector={enableAddressTypeSelector}
-          activeAccount={activeAccount}
-          balance={balance}
-          balanceToken={balanceToken}
-          balanceLoading={balanceLoading}
-          handleBalanceClick={handleBalanceClick}
-        />
-        <TokenInputSection
-          ref={tokenBuyInputRef}
-          style={tradeType === ESwapDirection.BUY ? {} : { display: 'none' }}
-          tradeType={ESwapDirection.BUY}
-          swapNativeTokenReserveGas={swapNativeTokenReserveGas}
-          onChange={(amount) => setPaymentAmount(new BigNumber(amount))}
-          selectedToken={paymentToken}
-          selectableTokens={defaultTokens}
-          onTokenChange={(token) => setPaymentToken(token)}
-          balance={balance}
-          onAmountEnterTypeChange={swapAnalytics.setAmountEnterType}
-          disableNativeToken={disableNativeToken}
-        />
-        <TokenInputSection
-          ref={tokenSellInputRef}
-          style={tradeType === ESwapDirection.SELL ? {} : { display: 'none' }}
-          tradeType={ESwapDirection.SELL}
-          swapNativeTokenReserveGas={swapNativeTokenReserveGas}
-          onChange={(amount) => setSellAmount(new BigNumber(amount))}
-          selectedToken={balanceToken}
-          selectableTokens={defaultTokens}
-          onTokenChange={(token) => setPaymentToken(token)}
-          balance={balance}
-          onAmountEnterTypeChange={swapAnalytics.setAmountEnterType}
-        />
-
-        {/* Rate display */}
-        <RateDisplay
-          rate={priceRate?.rate}
-          fromTokenSymbol={priceRate?.fromTokenSymbol}
-          toTokenSymbol={priceRate?.toTokenSymbol}
-          loading={priceRate?.loading}
-        />
-
-        {/* Balance display */}
-        {tradeType === ESwapDirection.SELL ? (
-          <SellForSelector
-            defaultTokens={defaultTokens}
-            currentSelectToken={balanceToken as ISwapTokenBase}
-            onTokenSelect={(token) => setPaymentToken(token as IToken)}
-            symbol={paymentToken?.symbol ?? '-'}
-            isLoading={!hasInitialReady}
+        <YStack gap="$3">
+          {/* Token input section */}
+          <SwapPanelTop
+            enableAddressTypeSelector={enableAddressTypeSelector}
+            activeAccount={activeAccount}
+            balance={balance}
+            balanceToken={balanceToken}
+            balanceLoading={balanceLoading}
+            handleBalanceClick={handleBalanceClick}
           />
+          <TokenInputSection
+            ref={tokenBuyInputRef}
+            style={tradeType === ESwapDirection.BUY ? {} : { display: 'none' }}
+            tradeType={ESwapDirection.BUY}
+            swapNativeTokenReserveGas={swapNativeTokenReserveGas}
+            onChange={(amount) => setPaymentAmount(new BigNumber(amount))}
+            selectedToken={paymentToken}
+            selectableTokens={defaultTokens}
+            onTokenChange={(token) => setPaymentToken(token)}
+            balance={balance}
+            onAmountEnterTypeChange={swapAnalytics.setAmountEnterType}
+            disableNativeToken={disableNativeToken}
+          />
+          <TokenInputSection
+            ref={tokenSellInputRef}
+            style={tradeType === ESwapDirection.SELL ? {} : { display: 'none' }}
+            tradeType={ESwapDirection.SELL}
+            swapNativeTokenReserveGas={swapNativeTokenReserveGas}
+            onChange={(amount) => setSellAmount(new BigNumber(amount))}
+            selectedToken={balanceToken}
+            selectableTokens={defaultTokens}
+            onTokenChange={(token) => setPaymentToken(token)}
+            balance={balance}
+            onAmountEnterTypeChange={swapAnalytics.setAmountEnterType}
+          />
+
+          {/* Rate display */}
+          <RateDisplay
+            rate={priceRate?.rate}
+            fromTokenSymbol={priceRate?.fromTokenSymbol}
+            toTokenSymbol={priceRate?.toTokenSymbol}
+            loading={priceRate?.loading}
+          />
+
+          {/* Balance display */}
+          {tradeType === ESwapDirection.SELL ? (
+            <SellForSelector
+              defaultTokens={defaultTokens}
+              currentSelectToken={balanceToken as ISwapTokenBase}
+              onTokenSelect={(token) => setPaymentToken(token as IToken)}
+              symbol={paymentToken?.symbol ?? '-'}
+              isLoading={!hasInitialReady}
+            />
+          ) : null}
+        </YStack>
+
+        {speedCheckError ? (
+          <SizableText size="$bodyMd" color="$textCritical">
+            {speedCheckError}
+          </SizableText>
         ) : null}
-      </YStack>
 
-      {speedCheckError ? (
-        <SizableText size="$bodyMd" color="$textCritical">
-          {speedCheckError}
-        </SizableText>
-      ) : null}
+        {!isApproved &&
+        !speedCheckError &&
+        currentInputAmount.gt(0) &&
+        balance.gte(currentInputAmount) ? (
+          <ApproveButton onApprove={onApprove} loading={isLoading} />
+        ) : (
+          <ActionButton
+            supportSpeedSwap={!!supportSpeedSwap?.enabled}
+            onlySupportCrossChain={!!supportSpeedSwap?.onlySupportCrossChain}
+            loading={isLoading}
+            actionToken={supportSpeedSwap?.actionToken}
+            actionOtherToken={supportSpeedSwap?.actionOtherToken}
+            tradeType={tradeType}
+            onPress={isWrapped ? onWrappedSwap : onSwap}
+            amount={currentInputAmount.toFixed()}
+            token={balanceToken}
+            balance={balance}
+            isWrapped={isWrapped}
+            networkId={networkId}
+            disabled={!!speedCheckError}
+            onSwapAction={() =>
+              swapAnalytics.logSwapAction({
+                tradeType,
+                networkId,
+                paymentToken,
+                balanceToken,
+              })
+            }
+          />
+        )}
 
-      {!isApproved &&
-      !speedCheckError &&
-      currentInputAmount.gt(0) &&
-      balance.gte(currentInputAmount) ? (
-        <ApproveButton onApprove={onApprove} loading={isLoading} />
-      ) : (
-        <ActionButton
-          supportSpeedSwap={!!supportSpeedSwap?.enabled}
-          onlySupportCrossChain={!!supportSpeedSwap?.onlySupportCrossChain}
-          loading={isLoading}
-          actionToken={supportSpeedSwap?.actionToken}
-          actionOtherToken={supportSpeedSwap?.actionOtherToken}
-          tradeType={tradeType}
-          onPress={isWrapped ? onWrappedSwap : onSwap}
-          amount={currentInputAmount.toFixed()}
-          token={balanceToken}
-          balance={balance}
-          isWrapped={isWrapped}
-          networkId={networkId}
-          disabled={!!speedCheckError}
-          onSwapAction={() =>
-            swapAnalytics.logSwapAction({
-              tradeType,
-              networkId,
-              paymentToken,
-              balanceToken,
-            })
-          }
-        />
-      )}
-
-      {/* Slippage setting */}
-      {isWrapped ? null : (
-        <SlippageSetting
-          autoDefaultValue={slippageAutoValue}
-          isMEV={swapMevNetConfig?.includes(swapPanel.networkId ?? '')}
-          onSlippageChange={(item) => {
-            setSlippage(item.value);
-            swapAnalytics.setSlippageSetting(
-              item.key === ESwapSlippageSegmentKey.CUSTOM,
-            );
-          }}
-        />
-      )}
+        {/* Slippage setting */}
+        {isWrapped ? null : (
+          <SlippageSetting
+            autoDefaultValue={slippageAutoValue}
+            isMEV={swapMevNetConfig?.includes(swapPanel.networkId ?? '')}
+            onSlippageChange={(item) => {
+              setSlippage(item.value);
+              swapAnalytics.setSlippageSetting(
+                item.key === ESwapSlippageSegmentKey.CUSTOM,
+              );
+            }}
+          />
+        )}
       </YStack>
     </ScrollView>
   );


### PR DESCRIPTION
## Summary
- Wrap `SwapPanelContent` in a `ScrollView` so that when the system keyboard opens in the Market quick buy/sell dialog, the slippage settings at the bottom remain accessible by scrolling
- Dialog's existing `useSafeKeyboardAnimationStyle` handles pushing content above the keyboard; the `ScrollView` provides scrollability as a safety net for smaller screens

## Test plan
- [ ] Open Market Token Details → tap quick buy/sell button → dialog opens
- [ ] Tap the amount input field → keyboard appears
- [ ] Verify slippage settings are visible above the keyboard (no blank gap)
- [ ] Verify scrolling down reveals slippage settings if partially hidden
- [ ] Verify dragging the content dismisses the keyboard (`keyboardDismissMode="on-drag"`)
- [ ] Verify tapping buttons (purchase, slippage) works while keyboard is open (`keyboardShouldPersistTaps="handled"`)
- [ ] Verify no visual regression when keyboard is dismissed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
