### PR TITLE
feat: add sunset reminder for OneKey ID sync users (OK-52289)

### DIFF
--- a/packages/kit-bg/src/services/ServicePrimeCloudSync/ServicePrimeCloudSync.tsx
+++ b/packages/kit-bg/src/services/ServicePrimeCloudSync/ServicePrimeCloudSync.tsx
@@ -10,7 +10,7 @@ import {
 } from '@onekeyhq/shared/src/background/backgroundDecorators';
 import {
   ALWAYS_VERIFY_PASSCODE_WHEN_CHANGE_SET_MASTER_PASSWORD,
-  CLOUD_SYNC_ID_UNAVAILABLE_TOAST_ID,
+  CLOUD_SYNC_ID_SUNSET_REMINDER_TOAST_ID,
   EPrimeCloudSyncDataType,
   RESET_CLOUD_SYNC_MASTER_PASSWORD_UUID,
 } from '@onekeyhq/shared/src/consts/primeConsts';
@@ -112,26 +112,28 @@ class ServicePrimeCloudSync extends ServiceBase {
     super({ backgroundApi });
   }
 
-  private _lastIdSyncUnavailableToastTime = 0;
+  private _lastSunsetReminderTime = 0;
 
-  private async notifyIfOnekeyIdSyncUnavailable() {
+  private async notifyOnekeyIdSyncSunset() {
     const now = Date.now();
-    const ONE_HOUR = timerUtils.getTimeDurationMs({ hour: 1 });
-    if (now - this._lastIdSyncUnavailableToastTime < ONE_HOUR) return;
+    const ONE_DAY = timerUtils.getTimeDurationMs({ day: 1 });
+    if (now - this._lastSunsetReminderTime < ONE_DAY) return;
 
     const { isCloudSyncEnabled } = await primeCloudSyncPersistAtom.get();
     if (!isCloudSyncEnabled) return;
 
-    this._lastIdSyncUnavailableToastTime = now;
+    this._lastSunsetReminderTime = now;
 
     void this.backgroundApi.serviceApp.showToast({
-      method: 'error',
-      icon: 'CloudDisconnectedSolid',
+      method: 'warning',
       title: appLocale.intl.formatMessage({
-        id: ETranslations.cloud_sync_issue_toast_title,
+        id: ETranslations.switch_to_keyless_wallet_sync__title,
       }),
-      toastId: CLOUD_SYNC_ID_UNAVAILABLE_TOAST_ID,
-      errorCode: ECustomCloudSyncError.OnekeyIdSyncUnavailable,
+      message: appLocale.intl.formatMessage({
+        id: ETranslations.switch_to_keyless_wallet_sync__desc,
+      }),
+      toastId: CLOUD_SYNC_ID_SUNSET_REMINDER_TOAST_ID,
+      errorCode: ECustomCloudSyncError.OnekeyIdSyncSunsetReminder,
     });
   }
 
@@ -1223,9 +1225,6 @@ class ServicePrimeCloudSync extends ServiceBase {
       // const syncMode = await this.getActiveSyncMode();
 
       if (!(await this.isCloudSyncIsAvailable())) {
-        if (!throwError) {
-          void this.notifyIfOnekeyIdSyncUnavailable();
-        }
         return;
       }
       await this.ensureCloudSyncIsAvailable({
@@ -1280,12 +1279,11 @@ class ServicePrimeCloudSync extends ServiceBase {
       });
     } catch (error) {
       errorUtils.autoPrintErrorIgnore(error);
-      if (!throwError) {
-        void this.notifyIfOnekeyIdSyncUnavailable();
-      }
       if (throwError) {
         throw error;
       }
+    } finally {
+      void this.notifyOnekeyIdSyncSunset();
     }
 
     // the server data has been downloaded, but it may not have been updated to the business scenario, so it needs to be executed again

--- a/packages/kit/src/provider/Container/ErrorToastContainer/ErrorToasts.tsx
+++ b/packages/kit/src/provider/Container/ErrorToastContainer/ErrorToasts.tsx
@@ -9,7 +9,7 @@ import {
   useClipboard,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { CLOUD_SYNC_ID_UNAVAILABLE_TOAST_ID } from '@onekeyhq/shared/src/consts/primeConsts';
+import { CLOUD_SYNC_ID_SUNSET_REMINDER_TOAST_ID } from '@onekeyhq/shared/src/consts/primeConsts';
 import {
   ECustomCloudSyncError,
   ECustomOneKeyHardwareError,
@@ -143,7 +143,7 @@ function NeedFirmwareUpgradeFromWebButton() {
   );
 }
 
-function NavigateToCloudSyncButton() {
+function NavigateToCloudSyncSwitchButton() {
   const intl = useIntl();
 
   return (
@@ -151,14 +151,14 @@ function NavigateToCloudSyncButton() {
       variant="primary"
       size="small"
       onPress={() => {
-        Toast.dismiss(CLOUD_SYNC_ID_UNAVAILABLE_TOAST_ID);
+        Toast.dismiss(CLOUD_SYNC_ID_SUNSET_REMINDER_TOAST_ID);
         rootNavigationRef.current?.navigate(ERootRoutes.Modal, {
           screen: EModalRoutes.PrimeModal,
           params: { screen: EPrimePages.PrimeCloudSync },
         });
       }}
     >
-      {intl.formatMessage({ id: ETranslations.global_view_details })}
+      {intl.formatMessage({ id: ETranslations.switch_now__action })}
     </Button>
   );
 }
@@ -174,8 +174,8 @@ export function getErrorAction({
   }
 
   // Cloud sync: navigate to Cloud Sync settings page
-  if (errorCode === ECustomCloudSyncError.OnekeyIdSyncUnavailable) {
-    return <NavigateToCloudSyncButton />;
+  if (errorCode === ECustomCloudSyncError.OnekeyIdSyncSunsetReminder) {
+    return <NavigateToCloudSyncSwitchButton />;
   }
 
   // Default: show contact support + copy diagnostic info buttons

--- a/packages/shared/src/consts/primeConsts.ts
+++ b/packages/shared/src/consts/primeConsts.ts
@@ -35,7 +35,8 @@ export enum EPrimeEmailOTPScene {
   GetKeylessAuthShare = 'GetKeylessAuthShare',
 }
 
-export const CLOUD_SYNC_ID_UNAVAILABLE_TOAST_ID = 'cloud_sync_id_unavailable';
+export const CLOUD_SYNC_ID_SUNSET_REMINDER_TOAST_ID =
+  'cloud_sync_id_sunset_reminder';
 export const PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME = 144_000_000; // '1970/01/03'
 export const RESET_CLOUD_SYNC_MASTER_PASSWORD_UUID =
   '180B50C8-E4EC-40E9-9CF3-7DD71F2882F7';

--- a/packages/shared/src/errors/types/errorTypes.ts
+++ b/packages/shared/src/errors/types/errorTypes.ts
@@ -14,7 +14,7 @@ export enum ECustomOneKeyHardwareError {
 }
 
 export enum ECustomCloudSyncError {
-  OnekeyIdSyncUnavailable = 9001,
+  OnekeyIdSyncSunsetReminder = 9001,
 }
 
 export enum EOneKeyErrorClassNames {

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -75,7 +75,7 @@ export enum EFinalizeWalletSetupSteps {
 
 export type IEventBusPayloadShowToast = {
   // IToastProps
-  method: 'success' | 'error' | 'message';
+  method: 'success' | 'error' | 'message' | 'warning';
   title: string;
   message?: string;
   icon?: string;


### PR DESCRIPTION
## Summary
- Replace the old "cloud sync unavailable" error toast with a proactive sunset reminder for OneKey ID sync users
- When sync is triggered and the user is still on OneKey ID sync, show a warning toast: "Switch to Keyless Wallet Sync" with a "Switch Now" action button
- Clicking "Switch Now" navigates to Settings > OneKey Cloud migration page
- 24-hour in-memory cooldown prevents toast spam (resets on app restart)

## Changes
- **ServicePrimeCloudSync**: Replace `notifyIfOnekeyIdSyncUnavailable()` with `notifyOnekeyIdSyncSunset()` — fires in `finally` block of `startServerSyncFlowSilently()` so it triggers on every sync attempt regardless of outcome
- **ErrorToasts**: Rename button component, change text from "View Details" to "Switch Now"
- **primeConsts / errorTypes**: Rename constants and enum values accordingly
- **appEventBus**: Add `'warning'` to `ShowToast` method type union (component already supported it)

## Test plan
- [ ] OneKey ID sync user triggers sync (create account, edit label, etc.) → sees "Switch to Keyless Wallet Sync" warning toast with "Switch Now" button
- [ ] Click "Switch Now" → navigates to Settings > OneKey Cloud page
- [ ] Trigger sync again within 24h → toast does NOT reappear
- [ ] Keyless Wallet sync user triggers sync → no toast
- [ ] User with no cloud sync enabled → no toast
- [ ] App restart + trigger sync → toast reappears (cooldown reset)

[OK-52289](https://onekeyhq.atlassian.net/browse/OK-52289)

[OK-52289]: https://onekeyhq.atlassian.net/browse/OK-52289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
