### PR TITLE
feat(settings): enhance dev settings search with item-level filtering and bundle search

### DIFF
--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -1543,8 +1543,10 @@ class ServiceAppUpdate extends ServiceBase {
     const results = await Promise.all(
       versions.map(async (v) => {
         const bundles = await this.devFetchBundlesForVersion(v.version);
-        const match = bundles.find((b) =>
-          (b.commitHash || '').toLowerCase().startsWith(needle),
+        const match = bundles.find(
+          (b) =>
+            (b.commitHash || '').toLowerCase().startsWith(needle) ||
+            b.ciBundleVersion.includes(needle),
         );
         return match ? { version: v.version, bundle: match } : null;
       }),

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -1411,8 +1411,7 @@ class ServiceAppUpdate extends ServiceBase {
     { promise: true },
   );
 
-  @backgroundMethod()
-  async devFetchBundleVersions(): Promise<
+  private async _devFetchBundleVersions(): Promise<
     { version: string; bundleCount: number }[]
   > {
     try {
@@ -1442,7 +1441,11 @@ class ServiceAppUpdate extends ServiceBase {
   }
 
   @backgroundMethod()
-  async devFetchBundlesForVersion(version: string): Promise<
+  async devFetchBundleVersions() {
+    return this._devFetchBundleVersions();
+  }
+
+  private async _devFetchBundlesForVersion(version: string): Promise<
     {
       bundleVersion?: string;
       ciBundleVersion: string;
@@ -1519,6 +1522,11 @@ class ServiceAppUpdate extends ServiceBase {
   }
 
   @backgroundMethod()
+  async devFetchBundlesForVersion(version: string) {
+    return this._devFetchBundlesForVersion(version);
+  }
+
+  @backgroundMethod()
   async devSearchBundleByCommit(commitHash: string): Promise<
     {
       version: string;
@@ -1539,19 +1547,16 @@ class ServiceAppUpdate extends ServiceBase {
   > {
     const needle = commitHash.trim().toLowerCase();
     if (!needle) return [];
-    const versions = await this.devFetchBundleVersions();
-    const results = await Promise.all(
-      versions.map(async (v) => {
-        const bundles = await this.devFetchBundlesForVersion(v.version);
-        const match = bundles.find(
-          (b) =>
-            (b.commitHash || '').toLowerCase().startsWith(needle) ||
-            b.ciBundleVersion.toLowerCase().includes(needle),
-        );
-        return match ? { version: v.version, bundle: match } : null;
-      }),
+    // Only search the current app version's bundles — dev builds
+    // only switch bundles within the same major version.
+    const currentVersion = String(platformEnv.version);
+    const bundles = await this._devFetchBundlesForVersion(currentVersion);
+    const match = bundles.find(
+      (b) =>
+        (b.commitHash || '').toLowerCase().startsWith(needle) ||
+        (b.ciBundleVersion || '').toLowerCase().includes(needle),
     );
-    return results.filter((r): r is NonNullable<typeof r> => r !== null);
+    return match ? [{ version: currentVersion, bundle: match }] : [];
   }
 }
 

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -1546,7 +1546,7 @@ class ServiceAppUpdate extends ServiceBase {
         const match = bundles.find(
           (b) =>
             (b.commitHash || '').toLowerCase().startsWith(needle) ||
-            b.ciBundleVersion.includes(needle),
+            b.ciBundleVersion.toLowerCase().includes(needle),
         );
         return match ? { version: v.version, bundle: match } : null;
       }),

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/BundleCommitSearch.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/BundleCommitSearch.tsx
@@ -43,7 +43,7 @@ function checkIsCurrentBundle(
 const SEARCH_DEBOUNCE_MS = 500;
 
 export function BundleCommitSearch({ searchText }: { searchText: string }) {
-  const [searching, setSearching] = useState(false);
+  const [searching, setSearching] = useState(!!searchText.trim());
   const [searchResults, setSearchResults] = useState<
     { version: string; bundle: IBundleInfo }[]
   >([]);

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/BundleCommitSearch.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/BundleCommitSearch.tsx
@@ -1,0 +1,191 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { StyleSheet } from 'react-native';
+
+import {
+  Icon,
+  SizableText,
+  Spinner,
+  Stack,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { BundleUpdate } from '@onekeyhq/shared/src/modules3rdParty/auto-update';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import {
+  BundleItem,
+  normalizeCommitHash,
+} from '../../DevBundleSwitcher/BundleList';
+
+import type { IBundleInfo } from '../../DevBundleSwitcher/BundleList';
+
+const currentAppVersion = String(platformEnv.version);
+const currentBundleVersion = String(platformEnv.bundleVersion);
+const currentCommitHash = normalizeCommitHash(platformEnv.githubSHA);
+
+function checkIsCurrentBundle(
+  bundle: IBundleInfo,
+  version: string,
+  skipGpgAllowed: boolean,
+): boolean {
+  if (version !== currentAppVersion) return false;
+  if (skipGpgAllowed) {
+    const bundleCommitHash = normalizeCommitHash(bundle.commitHash);
+    if (bundleCommitHash && currentCommitHash) {
+      return bundleCommitHash === currentCommitHash;
+    }
+  }
+  return bundle.ciBundleVersion === currentBundleVersion;
+}
+
+const SEARCH_DEBOUNCE_MS = 500;
+
+export function BundleCommitSearch({ searchText }: { searchText: string }) {
+  const [searching, setSearching] = useState(false);
+  const [searchResults, setSearchResults] = useState<
+    { version: string; bundle: IBundleInfo }[]
+  >([]);
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [gpgSkipped, setGpgSkipped] = useState(false);
+  const [skipGpgVerificationAllowed, setSkipGpgVerificationAllowed] =
+    useState(false);
+  const [downloadedSet, setDownloadedSet] = useState<Set<string>>(new Set());
+  const searchIdRef = useRef(0);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const [skipGpg, isSkipAllowed] = await Promise.all([
+          backgroundApiProxy.serviceDevSetting.getSkipBundleGPGVerification(),
+          BundleUpdate.isSkipGpgVerificationAllowed().catch(() => false),
+        ]);
+        setGpgSkipped(skipGpg);
+        setSkipGpgVerificationAllowed(Boolean(isSkipAllowed));
+      } catch {
+        // ignore
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    const trimmed = searchText.trim();
+    if (!trimmed) {
+      searchIdRef.current += 1;
+      setSearchResults([]);
+      setSearching(false);
+      return;
+    }
+    searchIdRef.current += 1;
+    const currentSearchId = searchIdRef.current;
+    setSearching(true);
+
+    const timer = setTimeout(() => {
+      void (async () => {
+        try {
+          const results =
+            await backgroundApiProxy.serviceAppUpdate.devSearchBundleByCommit(
+              trimmed,
+            );
+          if (currentSearchId !== searchIdRef.current) return;
+          setSearchResults(results);
+
+          const downloaded = new Set<string>();
+          await Promise.all(
+            results.map(async (r) => {
+              try {
+                const exists = await BundleUpdate.isBundleExists(
+                  r.version,
+                  r.bundle.ciBundleVersion,
+                );
+                if (exists) {
+                  downloaded.add(`${r.version}:${r.bundle.ciBundleVersion}`);
+                }
+              } catch {
+                // ignore
+              }
+            }),
+          );
+          if (currentSearchId !== searchIdRef.current) return;
+          setDownloadedSet(downloaded);
+        } finally {
+          if (currentSearchId === searchIdRef.current) {
+            setSearching(false);
+          }
+        }
+      })();
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(timer);
+      searchIdRef.current += 1;
+    };
+  }, [searchText]);
+
+  const handleDownloadStart = useCallback(() => {
+    setIsDownloading(true);
+  }, []);
+
+  const handleDownloadEnd = useCallback(() => {
+    setIsDownloading(false);
+  }, []);
+
+  return (
+    <YStack px="$3" gap="$1.5" pb="$2">
+      <XStack alignItems="center" gap="$1.5" px="$1">
+        <Icon name="CodeOutline" size="$4" color="$textSubdued" />
+        <SizableText size="$bodySmMedium" color="$textSubdued">
+          Bundle Commit Search
+        </SizableText>
+      </XStack>
+      {searching ? (
+        <Stack py="$4" justifyContent="center" alignItems="center">
+          <Spinner size="small" />
+        </Stack>
+      ) : null}
+      {!searching && searchResults.length > 0
+        ? searchResults.map((result) => (
+            <YStack
+              key={`${result.version}-${result.bundle.ciBundleVersion}`}
+              gap="$1"
+            >
+              <SizableText size="$bodyXs" color="$textSubdued" px="$1">
+                {`v${result.version}`}
+              </SizableText>
+              <YStack
+                bg="$bgSubdued"
+                borderRadius="$3"
+                borderWidth={StyleSheet.hairlineWidth}
+                borderColor="$neutral3"
+                overflow="hidden"
+              >
+                <BundleItem
+                  bundle={result.bundle}
+                  version={result.version}
+                  isCurrentBundle={checkIsCurrentBundle(
+                    result.bundle,
+                    result.version,
+                    skipGpgVerificationAllowed,
+                  )}
+                  alreadyDownloaded={downloadedSet.has(
+                    `${result.version}:${result.bundle.ciBundleVersion}`,
+                  )}
+                  isDownloading={isDownloading}
+                  onDownloadStart={handleDownloadStart}
+                  onDownloadEnd={handleDownloadEnd}
+                  gpgSkipped={gpgSkipped}
+                  skipGpgVerificationAllowed={skipGpgVerificationAllowed}
+                />
+              </YStack>
+            </YStack>
+          ))
+        : null}
+      {!searching && searchResults.length === 0 ? (
+        <SizableText size="$bodyXs" color="$textDisabled" px="$1">
+          No bundles found for this commit
+        </SizableText>
+      ) : null}
+    </YStack>
+  );
+}

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/DevSettingsSearchContext.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/DevSettingsSearchContext.tsx
@@ -1,0 +1,24 @@
+import { createContext, useContext } from 'react';
+import type { PropsWithChildren } from 'react';
+
+const DevSettingsSearchContext = createContext('');
+
+export const DevSettingsSearchProvider = DevSettingsSearchContext.Provider;
+
+export function useMatchesDevSearch(
+  ...searchableTexts: (string | undefined | null)[]
+): boolean {
+  const query = useContext(DevSettingsSearchContext);
+  if (!query) return true;
+  const combined = searchableTexts.filter(Boolean).join(' ').toLowerCase();
+  return combined.includes(query);
+}
+
+export function SearchFilterItem({
+  keywords,
+  children,
+}: PropsWithChildren<{ keywords: string }>) {
+  const matches = useMatchesDevSearch(keywords);
+  if (!matches) return null;
+  return children;
+}

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/SectionFieldItem.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/SectionFieldItem.tsx
@@ -8,6 +8,8 @@ import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import type { IDevSettingsKeys } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 
+import { useMatchesDevSearch } from './DevSettingsSearchContext';
+
 interface ISectionFieldItem extends PropsWithChildren {
   name?: IDevSettingsKeys;
   title: IListItemProps['title'];
@@ -16,6 +18,8 @@ interface ISectionFieldItem extends PropsWithChildren {
   onValueChange?: (v: any) => void;
   onBeforeValueChange?: () => Promise<void>;
   icon?: IListItemProps['icon'];
+  /** Extra keywords for search matching (not displayed) */
+  searchKeywords?: string;
 }
 
 export function SectionFieldItem({
@@ -28,8 +32,14 @@ export function SectionFieldItem({
   testID = '',
   onBeforeValueChange,
   icon,
+  searchKeywords,
 }: IPropsWithTestId<ISectionFieldItem>) {
   const [devSetting] = useDevSettingsPersistAtom();
+  const matches = useMatchesDevSearch(
+    typeof title === 'string' ? title : undefined,
+    typeof subtitle === 'string' ? subtitle : undefined,
+    searchKeywords,
+  );
   const child = Children.only(children) as ReactElement;
   const value = name ? devSetting?.settings?.[name] : '';
   const handleChange = useCallback(
@@ -51,6 +61,7 @@ export function SectionFieldItem({
         onChange: handleChange,
       })
     : null;
+  if (!matches) return null;
   return (
     <ListItem
       icon={icon}

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/SectionPressItem.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/SectionPressItem.tsx
@@ -4,6 +4,8 @@ import { type IPropsWithTestId, useClipboard } from '@onekeyhq/components';
 import type { IListItemProps } from '@onekeyhq/kit/src/components/ListItem';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 
+import { useMatchesDevSearch } from './DevSettingsSearchContext';
+
 interface ISectionPressItem {
   title: string;
   icon?: IListItemProps['icon'];
@@ -11,6 +13,8 @@ interface ISectionPressItem {
   onPress?: () => void;
   copyable?: boolean;
   drillIn?: boolean;
+  /** Extra keywords for search matching (not displayed) */
+  searchKeywords?: string;
 }
 
 export function SectionPressItem({
@@ -18,15 +22,22 @@ export function SectionPressItem({
   icon,
   onPress,
   copyable,
+  searchKeywords,
   ...restProps
 }: IPropsWithTestId<ISectionPressItem>) {
   const { copyText } = useClipboard();
+  const matches = useMatchesDevSearch(
+    title,
+    typeof restProps.subtitle === 'string' ? restProps.subtitle : undefined,
+    searchKeywords,
+  );
   const handleCopy = useCallback(() => {
     copyText(title);
     setTimeout(() => {
       onPress?.();
     });
   }, [copyText, title, onPress]);
+  if (!matches) return null;
   return (
     <ListItem
       drillIn

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
@@ -82,8 +82,13 @@ import { showApiEndpointDialog } from '../../../components/ApiEndpointDialog';
 import { AddressBookDevSetting } from './AddressBookDevSetting';
 import { AsyncStorageDevSettings } from './AsyncStorageDevSettings';
 import { AutoJumpSetting } from './AutoJumpSetting';
+import { BundleCommitSearch } from './BundleCommitSearch';
 import { CrashDevSettings } from './CrashDevSettings';
 import { DeviceToken } from './DeviceToken';
+import {
+  DevSettingsSearchProvider,
+  SearchFilterItem,
+} from './DevSettingsSearchContext';
 import { HapticsPanel } from './HapticsPanel';
 import { ImagePanel } from './ImagePanel';
 import { IpTableSelector } from './IpTableSelector';
@@ -346,46 +351,64 @@ const BaseDevSettingsSection = () => {
         key: 'basic',
         title: 'Basic Info',
         description: '基本信息',
+        keywords:
+          '关闭开发者模式 启用测试网络节点 API Endpoint Management Switch web mode InstanceId BuildHash platformEnv Chrome DevTools Print Env Path USB通信方式 Device Info 设备信息 Copy Log Path',
       },
       {
         key: 'devtools',
         title: 'Dev Tools & Dev Settings',
         description: '开发者工具 开发环境设置',
+        keywords:
+          '开发者悬浮窗 RTL 禁止桌面快捷键 禁用IP直连 强制使用IP请求 Reset IP Table Cache Check Network info NotificationDevSettings Notification Payload Test AsyncStorageDevSettings AppNotificationBadge 角标 V4MigrationDevSettings Haptics Image',
       },
       {
         key: 'appUpdate',
         title: 'App & Firmware Updates',
         description: 'App update JS bundle firmware update',
+        keywords:
+          'App Update Test Simulate update failures JS Bundle Manager Manage and switch JS bundles Force Check Updates Firmware Update Dev Settings App/Bundle Update Status download progress strategy pending task bundle commit version branch hash 热更新 更新状态',
       },
       {
         key: 'performance',
         title: 'Performance & Crash & Error & Unit Tests',
         description: '性能 崩溃 错误 单元测试',
+        keywords:
+          'Performance Monitor UI FPS JS FPS 性能监控 DebugRenderTracker 组件渲染高亮 Perps渲染统计 Bg Api 可序列化检测 Analytics Dev Unit Tests Show Recovery Page crash counter',
       },
       {
         key: 'data',
         title: 'Data Management',
         description: '数据重置 清理 导出',
+        keywords:
+          '清空Market收藏数据 WatchList Mock Market Banner Data Clear App Data E2E Clear Discovery Data Clear Address Book Data Clear Wallets Accounts Data Clear Password Clear History Clear Settings Clear Wallet Connect Sessions Clear HD Wallet Hash XFP Clear Last DB Backup Timestamp Clear Cached Password Reset Spotlight Reset Invite Code Reset Hidden Sites Floating icon',
       },
       {
         key: 'webview',
         title: 'Webview & WebEmbed & TrandingView',
         description: 'Webview WebEmbed TrandingView',
+        keywords:
+          'WebEmbedDevConfig 禁止WebEmbedApi Electron Webview调试工具 Enable Native Webview Debugging check webview version 使用本地TradingView URL',
       },
       {
         key: 'galleries',
         title: 'UI Galleries',
         description: 'UI Galleries',
+        keywords:
+          'DesktopApiProxy Test PerpGallery CryptoGallery CloudBackupGallery AuthGallery KeylessWalletGallery StorageGallery',
       },
       {
         key: 'account',
         title: 'Account & Wallet & Prime & Network',
         description: '账户 钱包 Prime 链和网络',
+        keywords:
+          '允许添加相同助记词HD钱包 启用Keyless调试信息 启用Keyless云端同步 允许重置Keyless钱包 Add ServerNetwork Test Data 开启Prime 开启Prime Sandbox付款 In-App-Purchase Mac 内购 首页导出私钥临时入口 Export Accounts Data',
       },
       {
         key: 'transaction',
         title: 'Transaction & Signature',
         description: '交易 签名',
+        keywords:
+          'Sign Message 禁用Solana交易优先费 模拟交易费过高 始终只签名不广播 严格的签名Alert展示 signTypedData',
       },
     ],
     [],
@@ -426,12 +449,15 @@ const BaseDevSettingsSection = () => {
       {/* Search bar */}
       <Stack px="$3" pb="$2">
         <Input
-          placeholder="Search sections..."
+          placeholder="Search sections and items..."
           value={searchText}
           onChangeText={setSearchText}
           leftIconName="SearchOutline"
         />
       </Stack>
+      {searchText.trim() ? (
+        <BundleCommitSearch searchText={searchText} />
+      ) : null}
       <Accordion
         width="100%"
         type="multiple"
@@ -446,9 +472,17 @@ const BaseDevSettingsSection = () => {
             pinned: isPinned,
             onTogglePin: () => togglePin(sectionKey),
           };
+          const wrapWithSearch = (node: React.ReactNode) => (
+            <DevSettingsSearchProvider
+              key={sectionKey}
+              value={searchText.toLowerCase().trim()}
+            >
+              {node}
+            </DevSettingsSearchProvider>
+          );
           switch (sectionKey) {
             case 'basic':
-              return (
+              return wrapWithSearch(
                 <Accordion.Item value="basic" key="basic">
                   <DevSettingsAccordionTrigger
                     title="Basic Info"
@@ -504,21 +538,25 @@ const BaseDevSettingsSection = () => {
                         }}
                       />
                       {platformEnv.isWeb ? (
-                        <ListItem
-                          icon="SwitchHorOutline"
-                          drillIn
-                          onPress={() => {
-                            switchWebDappMode();
-                            globalThis.location.reload();
-                          }}
-                          title="Switch web mode"
-                          subtitle={`Current: ${
-                            isWebInDappMode() ? 'dapp' : 'wallet'
-                          } mode`}
-                          titleProps={{ color: '$textCritical' }}
-                        />
+                        <SearchFilterItem keywords="Switch web mode dapp wallet">
+                          <ListItem
+                            icon="SwitchHorOutline"
+                            drillIn
+                            onPress={() => {
+                              switchWebDappMode();
+                              globalThis.location.reload();
+                            }}
+                            title="Switch web mode"
+                            subtitle={`Current: ${
+                              isWebInDappMode() ? 'dapp' : 'wallet'
+                            } mode`}
+                            titleProps={{ color: '$textCritical' }}
+                          />
+                        </SearchFilterItem>
                       ) : null}
-                      <AutoJumpSetting />
+                      <SearchFilterItem keywords="AutoJump 自动跳转">
+                        <AutoJumpSetting />
+                      </SearchFilterItem>
                       <SectionPressItem
                         icon="InfoCircleOutline"
                         copyable
@@ -579,8 +617,12 @@ const BaseDevSettingsSection = () => {
                           });
                         }}
                       />
-                      <RegistrationID />
-                      <DeviceToken />
+                      <SearchFilterItem keywords="RegistrationID 推送注册">
+                        <RegistrationID />
+                      </SearchFilterItem>
+                      <SearchFilterItem keywords="DeviceToken 设备令牌">
+                        <DeviceToken />
+                      </SearchFilterItem>
                       {platformEnv.isDesktop ? (
                         <>
                           <SectionPressItem
@@ -680,10 +722,10 @@ const BaseDevSettingsSection = () => {
                       ) : null}
                     </Accordion.Content>
                   </Accordion.HeightAnimator>
-                </Accordion.Item>
+                </Accordion.Item>,
               );
             case 'devtools':
-              return (
+              return wrapWithSearch(
                 <Accordion.Item value="devtools" key="devtools">
                   <DevSettingsAccordionTrigger
                     title="Dev Tools & Dev Settings"
@@ -771,7 +813,9 @@ const BaseDevSettingsSection = () => {
                           });
                         }}
                       />
-                      <IpTableSelector />
+                      <SearchFilterItem keywords="IpTableSelector IP直连选择">
+                        <IpTableSelector />
+                      </SearchFilterItem>
                       <SectionPressItem
                         icon="ForkOutline"
                         title="Check Network info"
@@ -873,10 +917,10 @@ const BaseDevSettingsSection = () => {
                       />
                     </Accordion.Content>
                   </Accordion.HeightAnimator>
-                </Accordion.Item>
+                </Accordion.Item>,
               );
             case 'appUpdate':
-              return (
+              return wrapWithSearch(
                 <Accordion.Item value="appUpdate" key="appUpdate">
                   <DevSettingsAccordionTrigger
                     title="App & Firmware Updates"
@@ -903,6 +947,7 @@ const BaseDevSettingsSection = () => {
                         icon="CodeOutline"
                         title="JS Bundle Manager"
                         subtitle="Manage and switch JS bundles"
+                        searchKeywords="bundle commit version branch hash 热更新"
                         onPress={() => {
                           navigation.push(
                             EModalSettingRoutes.SettingDevBundleManagerModal,
@@ -943,6 +988,7 @@ const BaseDevSettingsSection = () => {
                         icon="ActivityOutline"
                         title="App/Bundle Update Status"
                         subtitle="Update state, strategy, download progress, pending task"
+                        searchKeywords="bundle commit 更新状态"
                         onPress={() => {
                           navigation.push(
                             EModalSettingRoutes.SettingDevBundleUpdateStatusModal,
@@ -951,10 +997,10 @@ const BaseDevSettingsSection = () => {
                       />
                     </Accordion.Content>
                   </Accordion.HeightAnimator>
-                </Accordion.Item>
+                </Accordion.Item>,
               );
             case 'performance':
-              return (
+              return wrapWithSearch(
                 <Accordion.Item value="performance" key="performance">
                   <DevSettingsAccordionTrigger
                     title="Performance & Crash & Error & Unit Tests"
@@ -967,50 +1013,54 @@ const BaseDevSettingsSection = () => {
                       animation="quick"
                       exitStyle={{ opacity: 0 }}
                     >
-                      <ListItem
-                        icon="PerformanceOutline"
-                        title="Performance Monitor(UI FPS/JS FPS)"
-                        subtitle="性能监控"
-                      >
-                        <Switch
-                          isUncontrolled
-                          size={ESwitchSize.small}
-                          defaultChecked={
-                            !!devSettings.settings?.showPerformanceMonitor
-                          }
-                          onChange={(v) => {
-                            void backgroundApiProxy.serviceDevSetting.updateDevSetting(
-                              'showPerformanceMonitor',
-                              v,
-                            );
-                            setTimeout(() => {
-                              void backgroundApiProxy.serviceApp.restartApp();
-                            }, 10);
-                          }}
-                        />
-                      </ListItem>
+                      <SearchFilterItem keywords="Performance Monitor UI FPS JS FPS 性能监控">
+                        <ListItem
+                          icon="PerformanceOutline"
+                          title="Performance Monitor(UI FPS/JS FPS)"
+                          subtitle="性能监控"
+                        >
+                          <Switch
+                            isUncontrolled
+                            size={ESwitchSize.small}
+                            defaultChecked={
+                              !!devSettings.settings?.showPerformanceMonitor
+                            }
+                            onChange={(v) => {
+                              void backgroundApiProxy.serviceDevSetting.updateDevSetting(
+                                'showPerformanceMonitor',
+                                v,
+                              );
+                              setTimeout(() => {
+                                void backgroundApiProxy.serviceApp.restartApp();
+                              }, 10);
+                            }}
+                          />
+                        </ListItem>
+                      </SearchFilterItem>
 
-                      <ListItem
-                        icon="LightBulbOutline"
-                        title="DebugRenderTracker 组件渲染高亮"
-                        subtitle="启用后会导致 FlatList 无法滚动，仅供测试"
-                      >
-                        <Switch
-                          isUncontrolled
-                          size={ESwitchSize.small}
-                          defaultChecked={
-                            appStorage.syncStorage.getBoolean(
-                              EAppSyncStorageKeys.onekey_debug_render_tracker,
-                            ) ?? false
-                          }
-                          onChange={(v) => {
-                            appStorage.syncStorage.set(
-                              EAppSyncStorageKeys.onekey_debug_render_tracker,
-                              v,
-                            );
-                          }}
-                        />
-                      </ListItem>
+                      <SearchFilterItem keywords="DebugRenderTracker 组件渲染高亮 FlatList">
+                        <ListItem
+                          icon="LightBulbOutline"
+                          title="DebugRenderTracker 组件渲染高亮"
+                          subtitle="启用后会导致 FlatList 无法滚动，仅供测试"
+                        >
+                          <Switch
+                            isUncontrolled
+                            size={ESwitchSize.small}
+                            defaultChecked={
+                              appStorage.syncStorage.getBoolean(
+                                EAppSyncStorageKeys.onekey_debug_render_tracker,
+                              ) ?? false
+                            }
+                            onChange={(v) => {
+                              appStorage.syncStorage.set(
+                                EAppSyncStorageKeys.onekey_debug_render_tracker,
+                                v,
+                              );
+                            }}
+                          />
+                        </ListItem>
+                      </SearchFilterItem>
 
                       <SectionFieldItem
                         icon="CreditCardOutline"
@@ -1021,22 +1071,24 @@ const BaseDevSettingsSection = () => {
                         <Switch size={ESwitchSize.small} />
                       </SectionFieldItem>
 
-                      <ListItem
-                        icon="LabOutline"
-                        title="Bg Api 可序列化检测"
-                        subtitle="启用后会影响性能, 仅在开发环境生效, 关闭 1 天后重新开启"
-                      >
-                        <Switch
-                          isUncontrolled
-                          size={ESwitchSize.small}
-                          defaultChecked={
-                            !isBgApiSerializableCheckingDisabled()
-                          }
-                          onChange={(v) => {
-                            toggleBgApiSerializableChecking(v);
-                          }}
-                        />
-                      </ListItem>
+                      <SearchFilterItem keywords="Bg Api 可序列化检测 serializable">
+                        <ListItem
+                          icon="LabOutline"
+                          title="Bg Api 可序列化检测"
+                          subtitle="启用后会影响性能, 仅在开发环境生效, 关闭 1 天后重新开启"
+                        >
+                          <Switch
+                            isUncontrolled
+                            size={ESwitchSize.small}
+                            defaultChecked={
+                              !isBgApiSerializableCheckingDisabled()
+                            }
+                            onChange={(v) => {
+                              toggleBgApiSerializableChecking(v);
+                            }}
+                          />
+                        </ListItem>
+                      </SearchFilterItem>
 
                       <SectionFieldItem
                         icon="ChartTrendingOutline"
@@ -1062,7 +1114,9 @@ const BaseDevSettingsSection = () => {
                         }}
                       />
 
-                      <SentryCrashSettings />
+                      <SearchFilterItem keywords="SentryCrashSettings Sentry Crash 崩溃">
+                        <SentryCrashSettings />
+                      </SearchFilterItem>
                       <SectionPressItem
                         icon="ShieldCheckDoneOutline"
                         title="Show Recovery Page on Next Launch"
@@ -1077,13 +1131,15 @@ const BaseDevSettingsSection = () => {
                           });
                         }}
                       />
-                      <CrashDevSettings />
+                      <SearchFilterItem keywords="CrashDevSettings Crash Test 崩溃测试">
+                        <CrashDevSettings />
+                      </SearchFilterItem>
                     </Accordion.Content>
                   </Accordion.HeightAnimator>
-                </Accordion.Item>
+                </Accordion.Item>,
               );
             case 'data':
-              return (
+              return wrapWithSearch(
                 <Accordion.Item value="data" key="data">
                   <DevSettingsAccordionTrigger
                     title="Data Management"
@@ -1306,13 +1362,15 @@ const BaseDevSettingsSection = () => {
                           void backgroundApiProxy.serviceSetting.clearFloatingIconHiddenSites();
                         }}
                       />
-                      <ResetInstanceId />
+                      <SearchFilterItem keywords="ResetInstanceId Reset Instance Id 重置实例ID">
+                        <ResetInstanceId />
+                      </SearchFilterItem>
                     </Accordion.Content>
                   </Accordion.HeightAnimator>
-                </Accordion.Item>
+                </Accordion.Item>,
               );
             case 'webview':
-              return (
+              return wrapWithSearch(
                 <Accordion.Item value="webview" key="webview">
                   <DevSettingsAccordionTrigger
                     title="Webview & WebEmbed & TrandingView"
@@ -1404,10 +1462,10 @@ const BaseDevSettingsSection = () => {
                       </SectionFieldItem>
                     </Accordion.Content>
                   </Accordion.HeightAnimator>
-                </Accordion.Item>
+                </Accordion.Item>,
               );
             case 'galleries':
-              return (
+              return wrapWithSearch(
                 <Accordion.Item value="galleries" key="galleries">
                   <DevSettingsAccordionTrigger
                     title="UI Galleries"
@@ -1488,10 +1546,10 @@ const BaseDevSettingsSection = () => {
                       />
                     </Accordion.Content>
                   </Accordion.HeightAnimator>
-                </Accordion.Item>
+                </Accordion.Item>,
               );
             case 'account':
-              return (
+              return wrapWithSearch(
                 <Accordion.Item value="account" key="account">
                   <DevSettingsAccordionTrigger
                     title="Account & Wallet & Prime & Network"
@@ -1504,7 +1562,9 @@ const BaseDevSettingsSection = () => {
                       animation="quick"
                       exitStyle={{ opacity: 0 }}
                     >
-                      <AddressBookDevSetting />
+                      <SearchFilterItem keywords="AddressBook 地址簿">
+                        <AddressBookDevSetting />
+                      </SearchFilterItem>
 
                       <SectionFieldItem
                         icon="WalletOutline"
@@ -1583,7 +1643,9 @@ const BaseDevSettingsSection = () => {
                         <Switch size={ESwitchSize.small} />
                       </SectionFieldItem>
 
-                      <TestAccountsDevSetting />
+                      <SearchFilterItem keywords="TestAccounts 测试账户">
+                        <TestAccountsDevSetting />
+                      </SearchFilterItem>
 
                       <SectionPressItem
                         icon="AppleBrand"
@@ -1643,10 +1705,10 @@ const BaseDevSettingsSection = () => {
                       />
                     </Accordion.Content>
                   </Accordion.HeightAnimator>
-                </Accordion.Item>
+                </Accordion.Item>,
               );
             case 'transaction':
-              return (
+              return wrapWithSearch(
                 <Accordion.Item value="transaction" key="transaction">
                   <DevSettingsAccordionTrigger
                     title="Transaction & Signature"
@@ -1722,7 +1784,7 @@ const BaseDevSettingsSection = () => {
                       </SectionFieldItem>
                     </Accordion.Content>
                   </Accordion.HeightAnimator>
-                </Accordion.Item>
+                </Accordion.Item>,
               );
             default:
               return null;

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
@@ -939,7 +939,7 @@ const BaseDevSettingsSection = () => {
                         icon="CodeOutline"
                         title="JS Bundle Manager"
                         subtitle="Manage and switch JS bundles"
-                        searchKeywords="bundle commit version branch hash 热更新"
+                        searchKeywords="bundle commit version branch hash"
                         onPress={() => {
                           navigation.push(
                             EModalSettingRoutes.SettingDevBundleManagerModal,

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
@@ -456,7 +456,7 @@ const BaseDevSettingsSection = () => {
         defaultValue={
           searchText ? visibleSectionKeys : visibleSectionKeys.slice(0, 1)
         }
-        key={visibleSectionKeys.join(',')}
+        key={`${searchText.trim() ? 'searching' : 'idle'}-${visibleSectionKeys.join(',')}`}
       >
         {visibleSectionKeys.map((sectionKey) => {
           const isPinned = pinnedSections.includes(sectionKey);

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
@@ -415,18 +415,10 @@ const BaseDevSettingsSection = () => {
   );
 
   const visibleSectionKeys = useMemo(() => {
-    const query = searchText.toLowerCase().trim();
-    let keys = sectionMeta.map((s) => s.key);
-    if (query) {
-      keys = sectionMeta
-        .filter(
-          (s) =>
-            s.title.toLowerCase().includes(query) ||
-            s.description.toLowerCase().includes(query) ||
-            (s.keywords && s.keywords.toLowerCase().includes(query)),
-        )
-        .map((s) => s.key);
-    }
+    // Show all sections — individual items are filtered by SearchFilterItem.
+    // This avoids the problem where item keywords missing from section-level
+    // keywords would make those items unreachable via search.
+    const keys = sectionMeta.map((s) => s.key);
     // Sort: pinned first
     const pinSet = new Set(pinnedSections);
     keys.sort((a, b) => {
@@ -435,7 +427,7 @@ const BaseDevSettingsSection = () => {
       return ap - bp;
     });
     return keys;
-  }, [searchText, sectionMeta, pinnedSections]);
+  }, [sectionMeta, pinnedSections]);
 
   if (!devSettings.enabled) {
     return null;


### PR DESCRIPTION
## Summary
- Add item-level search filtering to developer settings — individual items within sections are now searchable by title, subtitle, and hidden keywords
- Add bundle commit hash / bundle ID search powered by `devSearchBundleByCommit` API, with 500ms debounce and race condition handling
- Extend `devSearchBundleByCommit` to also match by `ciBundleVersion` (bundle ID)

## Changes
- **DevSettingsSearchContext.tsx** (new) — React context + `useMatchesDevSearch` hook + `SearchFilterItem` wrapper
- **BundleCommitSearch.tsx** (new) — Inline bundle search component reusing `BundleItem` from DevBundleSwitcher
- **SectionPressItem.tsx / SectionFieldItem.tsx** — Added `searchKeywords` prop for hidden search terms + self-filtering via context
- **index.tsx** — Added `keywords` to `sectionMeta`, wrapped sections with search provider, wrapped standalone components with `SearchFilterItem`
- **ServiceAppUpdate.ts** — Extended bundle search to match `ciBundleVersion`

## Test plan
- [ ] Search "渲染" → only matching items shown (not full section)
- [ ] Search "Market收藏" → shows "清空Market收藏数据" item only
- [ ] Search commit hash prefix (e.g. "b025e") → shows matching bundle after 500ms debounce
- [ ] Search bundle ID (e.g. "7707300") → shows matching bundle
- [ ] Rapid typing → no stale results, proper debounce behavior
- [ ] Clear search → all sections restored, no errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
