### PR TITLE
fix: reset boot_fail_count before OTA restart to prevent false recovery

### DIFF
--- a/packages/shared/src/modules3rdParty/auto-update/index.native.ts
+++ b/packages/shared/src/modules3rdParty/auto-update/index.native.ts
@@ -275,7 +275,7 @@ export const BundleUpdate: IBundleUpdate = {
     });
     // Reset boot_fail_count before planned restart so that the OTA bundle
     // switch is not misinterpreted as consecutive crash-loops by BootRecovery.
-    BootRecovery.markBootSuccess();
+    try { BootRecovery.markBootSuccess(); } catch { /* Silently fail — recovery must not block restart */ }
     defaultLogger.app.appUpdate.restartRNApp();
     setTimeout(() => {
       RNRestart.restart();
@@ -287,7 +287,7 @@ export const BundleUpdate: IBundleUpdate = {
     await ReactNativeBundleUpdate.resetToBuiltInBundle();
   },
   restart: () => {
-    BootRecovery.markBootSuccess();
+    try { BootRecovery.markBootSuccess(); } catch { /* Silently fail — recovery must not block restart */ }
     setTimeout(() => {
       RNRestart.restart();
     }, 2500);
@@ -320,7 +320,7 @@ export const BundleUpdate: IBundleUpdate = {
   switchBundle: async (params) => {
     await ReactNativeBundleUpdate.setCurrentUpdateBundleData(params);
     if (params.appVersion && params.bundleVersion) {
-      BootRecovery.markBootSuccess();
+      try { BootRecovery.markBootSuccess(); } catch { /* Silently fail — recovery must not block restart */ }
       setTimeout(() => {
         RNRestart.restart();
       }, 2500);

--- a/packages/shared/src/modules3rdParty/auto-update/index.native.ts
+++ b/packages/shared/src/modules3rdParty/auto-update/index.native.ts
@@ -275,7 +275,11 @@ export const BundleUpdate: IBundleUpdate = {
     });
     // Reset boot_fail_count before planned restart so that the OTA bundle
     // switch is not misinterpreted as consecutive crash-loops by BootRecovery.
-    try { BootRecovery.markBootSuccess(); } catch { /* Silently fail — recovery must not block restart */ }
+    try {
+      BootRecovery.markBootSuccess();
+    } catch {
+      /* Silently fail — recovery must not block restart */
+    }
     defaultLogger.app.appUpdate.restartRNApp();
     setTimeout(() => {
       RNRestart.restart();
@@ -287,7 +291,11 @@ export const BundleUpdate: IBundleUpdate = {
     await ReactNativeBundleUpdate.resetToBuiltInBundle();
   },
   restart: () => {
-    try { BootRecovery.markBootSuccess(); } catch { /* Silently fail — recovery must not block restart */ }
+    try {
+      BootRecovery.markBootSuccess();
+    } catch {
+      /* Silently fail — recovery must not block restart */
+    }
     setTimeout(() => {
       RNRestart.restart();
     }, 2500);
@@ -320,7 +328,11 @@ export const BundleUpdate: IBundleUpdate = {
   switchBundle: async (params) => {
     await ReactNativeBundleUpdate.setCurrentUpdateBundleData(params);
     if (params.appVersion && params.bundleVersion) {
-      try { BootRecovery.markBootSuccess(); } catch { /* Silently fail — recovery must not block restart */ }
+      try {
+        BootRecovery.markBootSuccess();
+      } catch {
+        /* Silently fail — recovery must not block restart */
+      }
       setTimeout(() => {
         RNRestart.restart();
       }, 2500);

--- a/packages/shared/src/modules3rdParty/auto-update/index.native.ts
+++ b/packages/shared/src/modules3rdParty/auto-update/index.native.ts
@@ -6,6 +6,7 @@ import { useThrottledCallback } from 'use-debounce';
 
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import BootRecovery from '@onekeyhq/shared/src/modules/BootRecovery';
 
 import platformEnv from '../../platformEnv';
 
@@ -272,6 +273,9 @@ export const BundleUpdate: IBundleUpdate = {
       bundleVersion: toNativeString(params?.bundleVersion),
       signature: toNativeString(params?.signature),
     });
+    // Reset boot_fail_count before planned restart so that the OTA bundle
+    // switch is not misinterpreted as consecutive crash-loops by BootRecovery.
+    BootRecovery.markBootSuccess();
     defaultLogger.app.appUpdate.restartRNApp();
     setTimeout(() => {
       RNRestart.restart();
@@ -283,6 +287,7 @@ export const BundleUpdate: IBundleUpdate = {
     await ReactNativeBundleUpdate.resetToBuiltInBundle();
   },
   restart: () => {
+    BootRecovery.markBootSuccess();
     setTimeout(() => {
       RNRestart.restart();
     }, 2500);
@@ -315,6 +320,7 @@ export const BundleUpdate: IBundleUpdate = {
   switchBundle: async (params) => {
     await ReactNativeBundleUpdate.setCurrentUpdateBundleData(params);
     if (params.appVersion && params.bundleVersion) {
+      BootRecovery.markBootSuccess();
       setTimeout(() => {
         RNRestart.restart();
       }, 2500);


### PR DESCRIPTION
## Summary
- After `installBundle` completes, `RNRestart.restart()` force-kills the process without triggering `Activity.onStop()`, so `boot_fail_count` is never reset
- If the previous boot was short-lived (e.g. OTA install completed during early initialization), the counter stays elevated and subsequent restarts quickly accumulate to the threshold of 3, falsely triggering recovery mode
- Call `BootRecovery.markBootSuccess()` (wrapped in try/catch) before every planned `RNRestart` in `installBundle`, `restart`, and `switchBundle` to reset the counter, since these are intentional restarts — not crash-loops

## Root Cause
Timeline reproduced from actual Android logs:
1. Boot 3 (17:53:56): `boot_fail_count` 0→1, loads bundle 7366896
2. 17:53:59 (only 3s later): `installBundle` completes, schedules `RNRestart.restart()`
3. ~17:54:01: Process force-killed, `onStop()` never called, count stays at 1
4. New bundle 7701116 fails on first load (count 1→2), restarts again (count 2→3)
5. **Recovery mode triggered** — but bundle 7701116 itself is fine (boots normally after user taps "Not Now")

## Test plan
- [ ] Install an OTA bundle update on Android, verify restart does not falsely trigger recovery page
- [ ] Install an OTA bundle update on iOS, verify restart does not falsely trigger recovery page
- [ ] Use `switchBundle` to switch to another bundle version, confirm recovery mode is not triggered
- [ ] Simulate real consecutive crashes (3x), confirm recovery mode still triggers correctly