### PR TITLE
fix: show biometric auth in extension side panel

### DIFF
--- a/packages/kit/src/components/Password/container/PasswordSetupContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordSetupContainer.tsx
@@ -53,8 +53,7 @@ const BiologyAuthContainer = ({
   }, [isBiologyAuthSwitchOn]);
 
   return (biologyAuthIsSupport || webAuthIsSupport) &&
-    !platformEnv.isExtensionUiPopup &&
-    !platformEnv.isExtensionUiSidePanel ? (
+    !platformEnv.isExtensionUiPopup ? (
     <XStack justifyContent="space-between" alignItems="center">
       <SizableText size="$bodyMdMedium">{settingsTitle}</SizableText>
       <Stack>


### PR DESCRIPTION
## Summary
- Show the biometric auth setting row in the extension side panel password setup flow.
- Keep the row hidden in the extension popup where biometric auth is explicitly disabled.

## Intent & Context
The current password setup UI in extension hid the biometric auth entry in both popup and side panel surfaces. This change restores the entry in the side panel while keeping popup behavior unchanged.

## Root Cause
The visibility guard treated `isExtensionUiSidePanel` the same as `isExtensionUiPopup`, so the biometric auth setting was hidden for both surfaces even though only the popup should suppress it.

## Design Decisions
Narrow the visibility check from `!platformEnv.isExtensionUiPopup && !platformEnv.isExtensionUiSidePanel` to `!platformEnv.isExtensionUiPopup` so the fix stays limited to the rendering condition. Existing popup-specific behavior is left unchanged.

## Changes Detail
Updated `packages/kit/src/components/Password/container/PasswordSetupContainer.tsx` so `BiologyAuthContainer` can render in the extension side panel when biometric auth is supported.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension
- **Risk Areas**: Password setup UI visibility in the extension side panel

## Test plan
- [ ] Open extension side panel password setup and verify the biometric auth row is visible when supported.
- [ ] Open extension popup password setup and verify the biometric auth row remains hidden.
- [ ] Complete password setup in the extension side panel and verify the biometric auth flow still works.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/10984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
