### PR TITLE
fix: prevent duplicate OneKey ID login taps

### DIFF
--- a/packages/kit/src/views/Onboardingv2/pages/OneKeyIDLoginPage.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/OneKeyIDLoginPage.tsx
@@ -159,6 +159,8 @@ function OneKeyIDLoginPage() {
       if (loggingInProviderRef.current) {
         return;
       }
+      // Close the same-tick re-entry window before React state updates commit.
+      loggingInProviderRef.current = provider;
       try {
         setLoggingInProvider(provider);
         const result = await signInWithSocialLogin(provider);
@@ -195,6 +197,7 @@ function OneKeyIDLoginPage() {
           }
         }
       } finally {
+        loggingInProviderRef.current = null;
         setLoggingInProvider(null);
       }
     },
@@ -254,7 +257,7 @@ function OneKeyIDLoginPage() {
                 <OptionItem
                   icon="GoogleIllus"
                   title="Google"
-                  onPress={handleGoogleLogin}
+                  onPress={loggingInProvider ? undefined : handleGoogleLogin}
                   isLoading={
                     loggingInProvider === EOAuthSocialLoginProvider.Google
                   }
@@ -270,7 +273,7 @@ function OneKeyIDLoginPage() {
                     color: '$iconActive',
                     y: -1,
                   }}
-                  onPress={handleAppleLogin}
+                  onPress={loggingInProvider ? undefined : handleAppleLogin}
                   isLoading={
                     loggingInProvider === EOAuthSocialLoginProvider.Apple
                   }


### PR DESCRIPTION
## Summary
- Add a synchronous ref guard in `OneKeyIDLoginPage` before React state updates commit.
- Clear the guard when the social login flow finishes.
- Disable both social login entry taps while one provider login is already in progress.

## Intent & Context
This change fixes a duplicate-trigger gap in the OneKey ID social login entry. The issue under investigation was whether a user could trigger Apple or Google native authorization more than once by tapping the entry twice before the loading state committed.

## Root Cause
`OneKeyIDLoginPage` checked `loggingInProviderRef.current` before starting login, but only updated React state with `setLoggingInProvider(provider)`. That left a same-tick window where a second tap could re-enter the handler before the component re-rendered into a loading state.

## Design Decisions
The fix stays local to `OneKeyIDLoginPage` because the bug was in that page's re-entry window, while the `GetStarted` flow already has its own synchronous loading ref guard. The handler now writes to the ref immediately before any async work starts, and the UI also removes both button press handlers while a login is in flight so the visual and behavioral states stay aligned.

## Changes Detail
- Update `packages/kit/src/views/Onboardingv2/pages/OneKeyIDLoginPage.tsx` to set and clear `loggingInProviderRef` synchronously around the social login flow.
- Update both Apple and Google `OptionItem` entries to disable presses whenever any social login is already running.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile / Desktop / Web / Extension
- **Risk Areas**: OneKey ID onboarding social login interactions

## Test plan
- [x] Run `yarn lint:staged`
- [ ] Run `yarn tsc:staged` (blocked by pre-existing HyperLiquid type errors in `packages/kit-bg/src/services/ServiceHyperLiquid/*` and `packages/shared/types/hyperliquid/sdk.ts`)
- [ ] Manually verify that repeated taps on Apple or Google login during OneKey ID onboarding do not start a second login flow
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
