### PR TITLE
[codex] enforce release-ready merge gate for release PRs

### DIFF
--- a/.claude/skills/1k-monitor-pr-ci/SKILL.md
+++ b/.claude/skills/1k-monitor-pr-ci/SKILL.md
@@ -139,9 +139,19 @@ Unresolved threads: 3
 
 ### 1d. Decide next action
 
+Before choosing an action, classify the `gh pr checks` output into three buckets:
+
+- **Normal failed checks**: any failed check except `release-ready-merge-gate`
+- **Gate failure**: failed check named exactly `release-ready-merge-gate`
+- **Pending checks**: any check still pending or in progress
+
+If `release-ready-merge-gate` is failing, treat it as an expected merge blocker rather than a CI failure to auto-fix.
+
 | CI Status | Unresolved Threads | Action |
 |-----------|-------------------|--------|
-| Any fail | - | **Auto-fix** CI failure (Step 2) |
+| Normal failed checks | - | **Auto-fix** CI failure (Step 2) |
+| Gate failure | Has threads | **Address threads** (Step 3), then report blocked by missing `release-ready` |
+| Gate failure | No threads | **Stop waiting** and report blocked by missing `release-ready` |
 | Any pending | Has threads | **Address threads** (Step 3), keep waiting for CI |
 | Any pending | No threads | Wait, re-check |
 | All pass | Has threads | **Address threads** (Step 3) |
@@ -258,12 +268,31 @@ After pushing fixes, request re-review from the reviewers who left comments:
 
 3. Return to Step 1 (wait for CI to re-run)
 
+## Step 3g: Report release-ready gate blocker
+
+If the only remaining failed check is `release-ready-merge-gate`, stop the polling loop and report:
+
+```text
+CI is complete, but merge is blocked by the release-ready gate.
+
+Blocking check:
+- release-ready-merge-gate: expected failure until the PR gets the `release-ready` label
+
+Action:
+- Add the `release-ready` label to the PR, then run the monitor again if needed
+```
+
+Do not:
+- attempt to auto-fix this check
+- treat it as flaky infra
+- continue waiting for it to pass on its own
+
 ## Step 4: Final Report
 
-When all CI checks pass and no unresolved threads remain:
+When all normal CI checks pass and no unresolved threads remain:
 
 ```
-All CI checks passed! All review threads resolved.
+All normal CI checks passed. All review threads resolved.
 
 CI:
 | Check            | Status | Duration |
@@ -275,6 +304,8 @@ Review threads: 5 resolved, 0 remaining
 PR: <URL>
 Status: Ready for re-review / Ready to merge
 ```
+
+If `release-ready-merge-gate` is still failing, do not use this final report. Use the blocked-state report from Step 3g instead.
 
 ## Polling Rules
 

--- a/.github/workflows/release-ready-merge-gate.yml
+++ b/.github/workflows/release-ready-merge-gate.yml
@@ -1,0 +1,43 @@
+name: release-ready-merge-gate
+
+on:
+  pull_request:
+    branches:
+      - 'release/*'
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+      - edited
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  release-ready-merge-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate release-ready label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const baseRef = pr?.base?.ref ?? '';
+            const labels = Array.isArray(pr?.labels) ? pr.labels : [];
+
+            if (!baseRef.startsWith('release/')) {
+              core.info(`Skipping merge gate because base ref '${baseRef}' does not target a release branch.`);
+              return;
+            }
+
+            const hasReleaseReadyLabel = labels.some((label) => label?.name === 'release-ready');
+
+            if (hasReleaseReadyLabel) {
+              core.info('Skipping merge gate because the release-ready label is present.');
+              return;
+            }
+
+            core.setFailed('PRs targeting release/* must have the release-ready label before merge.');


### PR DESCRIPTION
## Summary
- add a dedicated `release-ready-merge-gate` workflow for PRs targeting `release/*`
- fail the merge gate when a release PR is missing the `release-ready` label
- update `1k-monitor-pr-ci` so this gate is treated as an expected blocker instead of a normal CI failure

## Why
PRs merged into `release/*` are intended for hot update rollout. This change makes the `release-ready` label a hard merge requirement for those PRs and prevents the internal CI monitor from repeatedly waiting on or trying to fix the expected gate failure.

## Validation
- verified workflow trigger, job name, and release-ready label gate logic in `.github/workflows/release-ready-merge-gate.yml`
- verified `1k-monitor-pr-ci` now classifies `release-ready-merge-gate` as a merge blocker instead of a normal failed CI check
- `git diff --check origin/release/v6.1.0..HEAD`
- verified `release/*` branch protection now includes required status check `release-ready-merge-gate`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
