### PR TITLE
fix(send): fix quick-select Next button disabled on ADA and other chains

### DIFF
--- a/packages/kit/src/components/AddressInput/index.tsx
+++ b/packages/kit/src/components/AddressInput/index.tsx
@@ -408,7 +408,8 @@ export function AddressInput(props: IAddressInputProps) {
   const { setError, clearErrors, watch } = useFormContext();
   const [loading, setLoading] = useState(false);
   const textRef = useRef('');
-  const rawAddress = watch([name, 'raw'].join('.'));
+  const fieldValue = watch(name);
+  const rawAddress = fieldValue?.raw;
 
   const [queryResult, setQueryResult] = useState<IAddressQueryResult>({});
   const [refreshNum, setRefreshNum] = useState(1);

--- a/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
@@ -1120,7 +1120,11 @@ function SendDataInputContainer() {
             })}
             confirmButtonProps={{
               loading: false,
-              disabled: !form.formState.isValid,
+              // Don't use form.formState.isValid here — the async address
+              // validation (AddressInput queryAddress) can leave isValid stale.
+              // toResolved && !toPending already gates address validity.
+              // handleNavigateToAmountInput calls form.trigger() as a final
+              // guard for memo/note/paymentId validation before navigating.
             }}
           />
         </Page.Footer>


### PR DESCRIPTION
## Summary

Fixes the issue where selecting a recent recipient (especially on ADA with long addresses) leaves the Next button disabled. Clearing and re-selecting the same address makes it work again.

### Root Cause

Two issues:

1. **AddressInput watcher miss**: `watch('to.raw')` (dot-path) may not fire when `form.setValue('to', {...})` replaces the entire parent object. This caused `queryAddress` not to trigger after quick-select, leaving `resolved` as undefined.

2. **formState.isValid stale**: `disabled: !form.formState.isValid` on the Next button used the stale result from the initial validation (when `pending: true`). After the async address query completed and set `resolved`, RHF did not always re-validate in time, leaving `isValid` false.

### Fix

1. `AddressInput`: `watch('to.raw')` → `watch('to')?.raw` — ensures any `form.setValue('to', {...})` triggers the watcher.

2. Remove `disabled: !form.formState.isValid` from Next button. Address validity is already gated by `toResolved && !toPending`. Memo/note validation is enforced by `form.trigger()` inside `handleNavigateToAmountInput`.

### Changed Files
- `packages/kit/src/components/AddressInput/index.tsx` (1 line)
- `packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx` (6 lines)

## Test plan
- [ ] ADA: select recent recipient → Next should be immediately available after validation
- [ ] EVM: same flow, verify no regression
- [ ] Memo chains (Cosmos/XRP): enter invalid memo → Next should still be clickable but navigation blocked by form.trigger()
- [ ] Allowlist enabled: select non-allowlisted address → error should show, Next hidden (toResolved is undefined)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
