### PR TITLE
fix: prioritize EVM matching for raw 64-char private key import

### DIFF
--- a/packages/shared/src/utils/networkDetectUtils.test.ts
+++ b/packages/shared/src/utils/networkDetectUtils.test.ts
@@ -303,6 +303,20 @@ describe('Network Detection by Private Key', () => {
   });
 
   describe('64 hex without 0x prefix - Multi-chain Detection', () => {
+    test('detects EVM and puts EVM first (64 hex no prefix)', async () => {
+      const privateKey =
+        'e37632253d40d954f56ebf0593c56c6cf52ecd46dbcc40b055334cba18d8bc5e';
+      const result = await networkDetectUtils.detectNetworkByPrivateKey({
+        privateKey,
+      });
+      expect(result.networks).toContainEqual(
+        networkDetectUtils.buildDetectedNetwork(presetNetworksMap.eth),
+      );
+      expect(result.networks[0]).toEqual(
+        networkDetectUtils.buildDetectedNetwork(presetNetworksMap.eth),
+      );
+    });
+
     test('detects TON (64 hex no prefix)', async () => {
       const privateKey =
         'e37632253d40d954f56ebf0593c56c6cf52ecd46dbcc40b055334cba18d8bc5e';

--- a/packages/shared/src/utils/networkDetectUtils.ts
+++ b/packages/shared/src/utils/networkDetectUtils.ts
@@ -464,9 +464,10 @@ async function detectNetworkByPrivateKeyFn({
     ];
   }
 
-  // 64 hex chars without 0x (could be: Ton, Tron, Kaspa, Nexa, etc.)
+  // 64 hex chars without 0x (can also be valid EVM private key)
   if (/^[0-9a-fA-F]{64}$/.test(pk)) {
     return [
+      ...buildSameImplResults(presetNetworksMap.eth),
       buildDetectedNetwork(presetNetworksMap.ton),
       buildDetectedNetwork(presetNetworksMap.tron),
       buildDetectedNetwork(presetNetworksMap.kaspa),


### PR DESCRIPTION
### Motivation
- Users reported that EVM private keys exported without a `0x` prefix (e.g. from Binance) were not being recognized as EVM and the UI highlighted other chains, causing confusion. 
- The intent is to treat both `0x...` and raw `...` 64-hex strings as valid EVM private keys and surface EVM-compatible networks first in the smart network suggestions.

### Description
- Update `detectNetworkByPrivateKeyFn` in `packages/shared/src/utils/networkDetectUtils.ts` to treat raw 64-hex private keys as EVM candidates by prepending `...buildSameImplResults(presetNetworksMap.eth)` to the non-`0x` 64-hex branch so EVM networks are returned first. 
- Keep existing non-EVM detections (TON/TRON/Kaspa/Nexa) for backward compatibility. 
- Add a unit test in `packages/shared/src/utils/networkDetectUtils.test.ts` asserting that a 64-hex private key without `0x` includes EVM in the results and that the first result (`result.networks[0]`) is the EVM detection.

### Testing
- Added unit test coverage in `packages/shared/src/utils/networkDetectUtils.test.ts` to validate EVM is detected and prioritized for raw 64-hex keys. 
- Attempted to run the test with `yarn test packages/shared/src/utils/networkDetectUtils.test.ts`, but the test run could not complete in this environment due to missing install state (`Couldn't find the node_modules state file`), so automated tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce77e6cd74833283f01c951b52b70e)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
