### PR TITLE
Prioritize EVM detection for 64-hex private keys without `0x`

### DIFF
--- a/packages/shared/src/utils/networkDetectUtils.test.ts
+++ b/packages/shared/src/utils/networkDetectUtils.test.ts
@@ -303,6 +303,20 @@ describe('Network Detection by Private Key', () => {
   });
 
   describe('64 hex without 0x prefix - Multi-chain Detection', () => {
+    test('detects EVM and puts EVM first (64 hex no prefix)', async () => {
+      const privateKey =
+        'e37632253d40d954f56ebf0593c56c6cf52ecd46dbcc40b055334cba18d8bc5e';
+      const result = await networkDetectUtils.detectNetworkByPrivateKey({
+        privateKey,
+      });
+      expect(result.networks).toContainEqual(
+        networkDetectUtils.buildDetectedNetwork(presetNetworksMap.eth),
+      );
+      expect(result.networks[0]).toEqual(
+        networkDetectUtils.buildDetectedNetwork(presetNetworksMap.eth),
+      );
+    });
+
     test('detects TON (64 hex no prefix)', async () => {
       const privateKey =
         'e37632253d40d954f56ebf0593c56c6cf52ecd46dbcc40b055334cba18d8bc5e';

--- a/packages/shared/src/utils/networkDetectUtils.ts
+++ b/packages/shared/src/utils/networkDetectUtils.ts
@@ -464,9 +464,10 @@ async function detectNetworkByPrivateKeyFn({
     ];
   }
 
-  // 64 hex chars without 0x (could be: Ton, Tron, Kaspa, Nexa, etc.)
+  // 64 hex chars without 0x (could be: Ton, Tron, Kaspa, Nexa, etc.; can also be valid EVM private key)
   if (/^[0-9a-fA-F]{64}$/.test(pk)) {
     return [
+      ...buildSameImplResults(presetNetworksMap.eth),
       buildDetectedNetwork(presetNetworksMap.ton),
       buildDetectedNetwork(presetNetworksMap.tron),
       buildDetectedNetwork(presetNetworksMap.kaspa),


### PR DESCRIPTION
### Motivation
- 64-hex private keys without a `0x` prefix can also be valid EVM private keys, and the detection should prefer ETH in ambiguous cases.

### Description
- Updated the 64-hex no-prefix branch to include `...buildSameImplResults(presetNetworksMap.eth)` so EVM/ETH is considered and placed first in the results.
- Clarified the branch comment to note that a 64-hex string can be a valid EVM private key.
- Added a unit test `detects EVM and puts EVM first (64 hex no prefix)` to assert that ETH is included and appears as the first detected network.

### Testing
- Ran the unit tests for the network detection utilities (`packages/shared/src/utils/networkDetectUtils.test.ts`) including the new test, and they all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce77e6cd74833283f01c951b52b70e)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11031" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
