### PR TITLE
fix(swap): use useHelpLink for incognito docs(OK-51893)

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -23,6 +23,7 @@ import {
   useMedia,
 } from '@onekeyhq/components';
 import { FormatHyperlinkText } from '@onekeyhq/kit/src/components/HyperlinkText';
+import { useHelpLink } from '@onekeyhq/kit/src/hooks/useHelpLink';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
 import {
@@ -40,7 +41,6 @@ import {
   useSettingsAtom,
   useSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import { SWAP_INCOGNITO_HELP_URL } from '@onekeyhq/shared/src/config/appConfig';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
@@ -110,15 +110,18 @@ function SwapIncognitoDialogContent({
 }) {
   const intl = useIntl();
   const [checked, setChecked] = useState<ICheckedState>(false);
+  const incognitoHelpLink = useHelpLink({
+    path: 'articles/14430164',
+  });
 
   const description = useMemo(
     () =>
       `${intl.formatMessage({
         id: ETranslations.trade_incognito_description,
-      })} <url>${SWAP_INCOGNITO_HELP_URL}<underline>${intl.formatMessage({
+      })} <url>${incognitoHelpLink}<underline>${intl.formatMessage({
         id: ETranslations.trade_incognito_read_more,
       })}</underline></url>`,
-    [intl],
+    [incognitoHelpLink, intl],
   );
 
   return (

--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -23,8 +23,8 @@ import {
   useMedia,
 } from '@onekeyhq/components';
 import { FormatHyperlinkText } from '@onekeyhq/kit/src/components/HyperlinkText';
-import { useHelpLink } from '@onekeyhq/kit/src/hooks/useHelpLink';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { useHelpLink } from '@onekeyhq/kit/src/hooks/useHelpLink';
 import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
 import {
   useSwapActions,

--- a/packages/shared/src/config/appConfig.ts
+++ b/packages/shared/src/config/appConfig.ts
@@ -132,8 +132,6 @@ export const ONEKEY_HEALTH_CHECK_URL = '/wallet/v1/health';
 export const SUPPORT_URL = 'https://help.onekey.so/hc/requests/new';
 
 export const SWAP_FAQ_HELP_URL = 'https://help.onekey.so/articles/13608266';
-export const SWAP_INCOGNITO_HELP_URL =
-  'https://help.onekey.so/articles/14430164';
 
 export const HYPERLIQUID_EXPLORER_URL = 'https://hypurrscan.io/address/';
 


### PR DESCRIPTION
## Summary
- replace the incognito dialog help article URL with `useHelpLink({ path: 'articles/14430164' })`
- remove the single-use `SWAP_INCOGNITO_HELP_URL` config constant
- keep the target help article unchanged while aligning with the repo's help-link convention

## Intent & Context
This is a follow-up fix for the merged incognito mode work in #11017.

That PR shipped the correct help article, but the dialog used a hardcoded help-center URL path via app config instead of the repo-standard `useHelpLink` hook. This PR brings the implementation back in line with existing help-center link patterns.

## Root Cause
The merged implementation focused on updating the article target and extracting the URL into config, but it missed the existing convention used across the codebase for help-center links.

As a result, the incognito dialog diverged from the standard `useHelpLink` flow that centralizes help-center URL construction.

## Design Decisions
Use `useHelpLink` directly inside the incognito dialog content instead of keeping a dedicated config constant.

This keeps the article path explicit, avoids a single-use app config export, and matches existing patterns used by other help/documentation entry points.

## Changes Detail
- `packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx`: use `useHelpLink({ path: 'articles/14430164' })` for the incognito dialog "Read more" link
- `packages/shared/src/config/appConfig.ts`: remove `SWAP_INCOGNITO_HELP_URL`

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile / Desktop / Web / Extension
- **Risk Areas**: swap incognito dialog help-link opening

## Test plan
- [ ] Open the Swap incognito dialog and verify `Read more` opens the expected help-center article
- [ ] Run `./node_modules/.bin/eslint packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx packages/shared/src/config/appConfig.ts -f unix`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
