### PR TITLE
docs: clarify iOS README commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ Run these commands from the root directory:
 | Command | Description |
 |---------|-------------|
 | `yarn app:web` | Start web dev server (port 3000) |
-| `yarn app:ios` | Run iOS app via USB-connected device |
+| `yarn app:ios` | Run the iOS app in the default simulator |
+| `yarn app:ios:device` | Run the iOS app on a connected device |
 | `yarn app:android` | Run Android app |
 | `yarn app:desktop` | Run desktop (Electron) app |
 | `yarn app:ext` | Run browser extension |


### PR DESCRIPTION
## Summary
- clarify that `yarn app:ios` runs the default iOS simulator
- add the existing `yarn app:ios:device` command to the README command table for connected-device runs
- keep the README aligned with the actual root package scripts and avoid describing the simulator command as a USB-device workflow

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
