### PR TITLE
fix: improve market mobile network selector dialog scrolling(OK-52410 OK-52413 OK-52414)

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MobileNetworkDropdown/MobileNetworkDropdown.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MobileNetworkDropdown/MobileNetworkDropdown.tsx
@@ -10,8 +10,8 @@ import {
   Stack,
   XStack,
 } from '@onekeyhq/components';
-import { ChainSelectorListView } from '@onekeyhq/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorListView';
-import type { IServerNetworkMatch } from '@onekeyhq/kit/src/views/ChainSelector/types';
+import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
+import { NetworkAvatarBase } from '@onekeyhq/kit/src/components/NetworkAvatar';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import type { IServerNetwork } from '@onekeyhq/shared/types';
@@ -34,23 +34,46 @@ function NetworkDropdownContent({
   onSelect: (network: IServerNetwork) => void;
   closePopover: () => void;
 }) {
-  const networksForListView = networks as IServerNetworkMatch[];
-
-  const handleNetworkPress = useCallback(
-    (network: IServerNetworkMatch) => {
-      onSelect(network as IServerNetwork);
-      closePopover();
-    },
-    [onSelect, closePopover],
-  );
+  const intl = useIntl();
 
   return (
     <Stack pt="$4">
-      <ChainSelectorListView
-        networkId={selectedNetworkId}
-        networks={networksForListView}
-        onPressItem={handleNetworkPress}
-      />
+      {networks.map((item) => {
+        const { isAllNetworks } = item;
+        return (
+          <ListItem
+            key={item.id}
+            h={48}
+            renderAvatar={
+              <NetworkAvatarBase
+                logoURI={item.logoURI}
+                isCustomNetwork={item.isCustomNetwork}
+                networkName={item.name}
+                isAllNetworks={isAllNetworks}
+                allNetworksIconProps={{
+                  color: '$iconActive',
+                }}
+                size="$8"
+              />
+            }
+            title={
+              isAllNetworks
+                ? intl.formatMessage({
+                    id: ETranslations.global_all_networks,
+                  })
+                : item.name
+            }
+            onPress={() => {
+              onSelect(item);
+              closePopover();
+            }}
+          >
+            {selectedNetworkId === item.id ? (
+              <ListItem.CheckMark key="checkmark" />
+            ) : null}
+          </ListItem>
+        );
+      })}
     </Stack>
   );
 }
@@ -86,7 +109,7 @@ function MobileNetworkDropdownImpl({
     () => (
       <XStack gap="$1" alignItems="center" cursor="pointer" userSelect="none">
         {isAllNetworks || !selectedNetwork?.logoURI ? (
-          <Icon name="AllNetworksSolid" size="$4.5" color="$icon" />
+          <Icon name="AllNetworksSolid" size="$4.5" color="$iconStrong" />
         ) : (
           <Image
             width={18}
@@ -120,6 +143,10 @@ function MobileNetworkDropdownImpl({
       placement="bottom-start"
       floatingPanelProps={{
         maxWidth: 384,
+      }}
+      sheetProps={{
+        snapPoints: [60],
+        snapPointsMode: 'percent',
       }}
       renderTrigger={renderTrigger}
       renderContent={RenderContent}


### PR DESCRIPTION
## Summary
- Fix market mobile spot list network selector dialog not scrolling when content overflows
- Replace virtualized FlashList with flat `.map()` rendering to resolve nested scroll conflict inside Popover's Sheet.ScrollView on React Native
- Increase AllNetworksSolid icon contrast with `$iconStrong` color token

## Intent & Context
The market mobile spot list network selector dialog had too much content (many network options) but could not scroll on native platforms. Users reported the dialog content overflowing without any scroll capability.

## Root Cause
The Popover component on native renders content inside `TMPopover.Sheet.ScrollView`. The previous implementation used `ChainSelectorListView` which internally uses a `ListView` (FlashList). Nesting a FlashList inside a ScrollView on React Native causes scroll gesture conflicts — the inner FlashList cannot properly intercept scroll events, resulting in no scrolling.

Additionally, the Popover's default `snapPointsMode="fit"` caused the Sheet to expand to full content height without capping at screen bounds, further preventing scroll behavior.

## Design Decisions
- **Flat `.map()` over FlashList**: Market networks list is small (<50 items), so virtualization is unnecessary. Flat rendering allows the parent Sheet.ScrollView to handle scrolling naturally. This is the same trade-off pattern used elsewhere in the codebase.
- **`snapPoints: [60]` with `snapPointsMode: 'percent'`**: Constrains Sheet to 60% screen height per user request. This is the established codebase pattern for long-content Popovers (see `TokenDetailsTabToolbar`, `SelectPrivateKeyNetwork`, etc.).
- **`item.isAllNetworks` over `networkUtils.isAllNetwork()`**: Simplified to use the property directly from `IServerNetwork`, consistent with other ChainSelector components.

## Changes Detail
- `MobileNetworkDropdown.tsx`: Replaced `ChainSelectorListView` with direct `ListItem` + `NetworkAvatarBase` rendering via `.map()`. Added `sheetProps` for scroll constraint. Changed icon color to `$iconStrong`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile (iOS, Android)
- **Risk Areas**: Network selector UI only; no logic or data changes

## Test plan
- [ ] Open Market > Spot tab on mobile
- [ ] Tap the network selector (shows "全部" / "All" with network icon)
- [ ] Verify the dialog opens at ~60% screen height
- [ ] Verify the network list scrolls smoothly when content overflows
- [ ] Verify selecting a network works correctly and closes the dialog
- [ ] Verify the AllNetworksSolid icon has good contrast in both light and dark mode
- [ ] Test on both iOS and Android
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
