### PR TITLE
fix: use USD currency symbol in market detail portfolio(OK-52384)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/layout/PortfolioItemNormal.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/layout/PortfolioItemNormal.tsx
@@ -7,7 +7,6 @@ import {
   YStack,
 } from '@onekeyhq/components';
 import { Token } from '@onekeyhq/kit/src/components/Token';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { IMarketAccountPortfolioItem } from '@onekeyhq/shared/types/marketV2';
 
 import { PnlCell } from '../components/PnlCell';
@@ -23,8 +22,6 @@ function PortfolioItemNormalBase({
   tokenLogoUrl,
   columnWidth,
 }: IPortfolioItemNormalProps) {
-  const [settingsPersistAtom] = useSettingsPersistAtom();
-
   const pnl = item.pnl;
   const isPnlSupported = pnl?.isPnlSupported ?? false;
 
@@ -54,7 +51,7 @@ function PortfolioItemNormalBase({
           autoFormatter="price-marketCap"
           autoFormatterThreshold={1000}
           formatterOptions={{
-            currency: settingsPersistAtom.currencyInfo.symbol,
+            currency: '$',
           }}
         >
           {item.totalPrice}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/layout/PortfolioItemSmall.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/layout/PortfolioItemSmall.tsx
@@ -1,7 +1,6 @@
 import { memo } from 'react';
 
 import { NumberSizeableText, XStack, YStack } from '@onekeyhq/components';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { IMarketAccountPortfolioItem } from '@onekeyhq/shared/types/marketV2';
 
 import { PnlCell } from '../components/PnlCell';
@@ -11,8 +10,6 @@ interface IPortfolioItemSmallProps {
 }
 
 function PortfolioItemSmallBase({ item }: IPortfolioItemSmallProps) {
-  const [settingsPersistAtom] = useSettingsPersistAtom();
-
   const pnl = item.pnl;
   const isPnlSupported = pnl?.isPnlSupported ?? false;
 
@@ -25,7 +22,7 @@ function PortfolioItemSmallBase({ item }: IPortfolioItemSmallProps) {
           autoFormatter="price-marketCap"
           autoFormatterThreshold={1000}
           formatterOptions={{
-            currency: settingsPersistAtom.currencyInfo.symbol,
+            currency: '$',
           }}
         >
           {item.totalPrice}


### PR DESCRIPTION
## Summary
- Hardcode USD (`$`) as the currency symbol in market detail portfolio position list instead of using the user's local currency setting

## Intent & Context
The market detail page's "My Positions" tab was displaying token balances using the user's local currency symbol (e.g., `¥` for CNY/JPY) instead of always showing USD (`$`). Since market data and portfolio values in this view are denominated in USD, the currency symbol should be fixed to `$`.

## Root Cause
`PortfolioItemNormal.tsx` and `PortfolioItemSmall.tsx` were using `settingsPersistAtom.currencyInfo.symbol` to determine the currency symbol for the balance display. This pulls from the user's locale/currency preference, which could be any currency (¥, €, £, etc.), but the underlying values are always in USD.

## Changes Detail
- **PortfolioItemNormal.tsx**: Changed `currency` from `settingsPersistAtom.currencyInfo.symbol` to `'$'`, removed unused `useSettingsPersistAtom` import and hook call
- **PortfolioItemSmall.tsx**: Same changes as above

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Currency display only — no logic or data changes

## Test plan
- [ ] Open market detail page for any token (e.g., SOL, BTC)
- [ ] Switch to "My Positions" tab
- [ ] Verify balance shows `$` symbol regardless of user's local currency setting
- [ ] Test with non-USD locale (e.g., CNY, JPY) to confirm `$` is always displayed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
