### PR TITLE
fix: format PnL values with subscript notation and K/M/B abbreviation(OK-52396)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/components/PnlCell.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/components/PnlCell.tsx
@@ -2,7 +2,7 @@ import { memo } from 'react';
 
 import BigNumber from 'bignumber.js';
 
-import { SizableText, YStack } from '@onekeyhq/components';
+import { NumberSizeableText, SizableText, YStack } from '@onekeyhq/components';
 
 function PnlCellBase({
   usdValue,
@@ -32,9 +32,23 @@ function PnlCellBase({
 
   return (
     <YStack w={columnWidth} flex={flexValue} alignItems="flex-end">
-      <SizableText size="$bodySmMedium" color={displayColor}>
-        {isValid ? `${prefix}$${valueBN.abs().toFixed(2)}` : '--'}
-      </SizableText>
+      {isValid ? (
+        <NumberSizeableText
+          size="$bodySmMedium"
+          color={displayColor}
+          autoFormatter="price-marketCap"
+          autoFormatterThreshold={1000}
+          formatterOptions={{
+            currency: `${prefix}$`,
+          }}
+        >
+          {valueBN.abs().toString()}
+        </NumberSizeableText>
+      ) : (
+        <SizableText size="$bodySmMedium" color="$textSubdued">
+          --
+        </SizableText>
+      )}
       <SizableText size="$bodySm" color={displayColor}>
         {isValid ? `${percent}%` : '--'}
       </SizableText>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/components/PnlCell.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/components/PnlCell.tsx
@@ -42,7 +42,7 @@ function PnlCellBase({
             currency: `${prefix}$`,
           }}
         >
-          {valueBN.abs().toString()}
+          {valueBN.abs().toFixed()}
         </NumberSizeableText>
       ) : (
         <SizableText size="$bodySmMedium" color="$textSubdued">


### PR DESCRIPTION
## Summary
- Replace manual `toFixed(2)` formatting in PnlCell with `NumberSizeableText` using `autoFormatter="price-marketCap"` for proper number formatting

## Intent & Context
The market detail "My Positions" tab P&L values (unrealized and total) were rendered with simple `toFixed(2)`, which doesn't handle very small decimals or very large numbers properly.

## Root Cause
PnlCell used raw `SizableText` with `valueBN.abs().toFixed(2)`, bypassing the shared number formatting utilities that support subscript notation and unit abbreviation.

## Changes Detail
- **PnlCell.tsx**: Replaced `SizableText` with `NumberSizeableText` using `autoFormatter="price-marketCap"` and `autoFormatterThreshold={1000}`. Values < 1000 use the `price` formatter (subscript notation for >5 leading zeros), values >= 1000 use the `marketCap` formatter (K/M/B/T abbreviation).

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: P&L display formatting only — no logic or data changes

## Test plan
- [ ] Open market detail for any token, switch to "My Positions" tab
- [ ] Verify very small P&L values show subscript notation (e.g., 0.0₇2146)
- [ ] Verify large P&L values show K/M/B abbreviation (e.g., +$1.23K)
- [ ] Verify +/- signs and colors still display correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
