### PR TITLE
fix(OK-52544): restore tokenMinAmount in send minimum amount validation

### DIFF
--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -403,6 +403,14 @@ function SendAmountInputContainer() {
     return false;
   }, [isLightningNetwork, isUseFiat, lnUnit]);
 
+  const tokenMinAmount = useMemo(() => {
+    const decimals = tokenDetails?.info.decimals;
+    if (decimals === undefined || Number.isNaN(decimals)) {
+      return '0';
+    }
+    return new BigNumber(1).shiftedBy(-decimals).toFixed();
+  }, [tokenDetails?.info.decimals]);
+
   const handleValidateTokenAmount = useCallback(
     async (value: string): Promise<string | undefined> => {
       if (!value) {
@@ -447,16 +455,22 @@ function SendAmountInputContainer() {
           '0')
         : (vaultSettings?.minTransferAmount ?? '0');
 
+      // Effective minimum: the larger of token precision minimum and chain minimum
+      const effectiveMin = BigNumber.max(
+        tokenMinAmount,
+        minTransferAmount,
+      ).toFixed();
+
       // Display min amount in the current unit (BTC or sats for Lightning)
       const displayMinAmount =
         isLightningNetwork && lnUnit === ELightningUnit.BTC
-          ? chainValueUtils.convertSatsToBtc(minTransferAmount)
-          : minTransferAmount;
+          ? chainValueUtils.convertSatsToBtc(effectiveMin)
+          : effectiveMin;
 
       if (
         !isUseFiat &&
-        !new BigNumber(minTransferAmount).isZero() &&
-        amountBNForValidation.isLessThan(minTransferAmount) &&
+        !new BigNumber(effectiveMin).isZero() &&
+        amountBNForValidation.isLessThan(effectiveMin) &&
         !amountBNForValidation.isZero()
       ) {
         return intl.formatMessage(
@@ -468,8 +482,8 @@ function SendAmountInputContainer() {
       if (
         isUseFiat &&
         priceBN.isGreaterThan(0) &&
-        !new BigNumber(minTransferAmount).isZero() &&
-        tokenAmountBN.isLessThan(minTransferAmount) &&
+        !new BigNumber(effectiveMin).isZero() &&
+        tokenAmountBN.isLessThan(effectiveMin) &&
         !tokenAmountBN.isZero()
       ) {
         return intl.formatMessage(
@@ -519,6 +533,7 @@ function SendAmountInputContainer() {
       tokenDetails?.balanceParsed,
       tokenDetails?.info.isNative,
       tokenDetails?.price,
+      tokenMinAmount,
       vaultSettings?.nativeMinTransferAmount,
       vaultSettings?.minTransferAmount,
       vaultSettings?.transferZeroNativeTokenEnabled,

--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -406,7 +406,7 @@ function SendAmountInputContainer() {
   const tokenMinAmount = useMemo(() => {
     const decimals = tokenDetails?.info.decimals;
     if (decimals === undefined || Number.isNaN(decimals)) {
-      return '0';
+      return undefined;
     }
     return new BigNumber(1).shiftedBy(-decimals).toFixed();
   }, [tokenDetails?.info.decimals]);
@@ -445,6 +445,13 @@ function SendAmountInputContainer() {
                 chainValueUtils.convertBtcToSats(tokenAmountBN.toFixed()),
               )
             : tokenAmountBN; // already in sats
+      }
+
+      // Block flow if token decimals is missing — server must return explicit decimals
+      if (tokenMinAmount === undefined) {
+        return intl.formatMessage({
+          id: ETranslations.send_amount_invalid,
+        });
       }
 
       // Minimum transfer amount check


### PR DESCRIPTION
## Summary

Restore the `tokenMinAmount` logic that was lost during the quick select refactor (`c092cc80e1`). This ensures the send error message displays the correct minimum transfer amount.

## Problem

The quick select PR refactored `SendDataInputContainer` into `SendAmountInputContainer` and dropped the `tokenMinAmount` variable. Previously, the minimum amount error message used:

```typescript
BigNumber.max(tokenMinAmount, minTransferAmount).toFixed()
```

Where `tokenMinAmount` = `10^(-decimals)` (the smallest unit for the token's precision).

After the refactor, the error message only uses `minTransferAmount` from vault settings. For chains/tokens where `minTransferAmount` is `'0'` or not configured, the error message displays `0` — giving users no actionable guidance about the actual minimum they can send.

## Fix

- Restore `tokenMinAmount` as a `useMemo` based on `tokenDetails.info.decimals`
- Compute `effectiveMin = BigNumber.max(tokenMinAmount, minTransferAmount)` 
- Use `effectiveMin` for both the validation threshold and the displayed error amount
- Lightning BTC unit conversion still applies on top of `effectiveMin`

### Examples

| Token | decimals | minTransferAmount | effectiveMin (displayed) |
|-------|----------|-------------------|--------------------------|
| ETH | 18 | 0 | 0.000000000000000001 |
| USDT (ERC-20) | 6 | 0 | 0.000001 |
| ADA | 6 | 1 | 1 |
| BTC | 8 | 0.00000546 | 0.00000546 |
| DOGE | 8 | 0.01 | 0.01 |

## Test plan

- [ ] Send flow: enter amount below token precision minimum on a chain with no minTransferAmount (e.g. EVM) — should show error with correct minimum
- [ ] Send flow: enter amount below minTransferAmount on ADA — should show error with `1`
- [ ] Send flow: enter valid amount — no error
- [ ] Lightning (BTC unit): minimum should display in BTC, not sats
- [ ] Fiat mode: minimum validation still triggers correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
