### PR TITLE
fix(cli): fix NPM publish workflow and update marketplace naming

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,21 +1,32 @@
 {
-  "name": "onekey-plugins",
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "onekey-agent-skills",
+  "description": "OneKey wallet skills for AI coding assistants — wallet management, token swap, market data, and security audit",
   "owner": {
     "name": "OneKey",
     "email": "dev@onekey.so"
   },
   "metadata": {
-    "description": "Official OneKey plugins for Claude Code"
+    "description": "OneKey wallet skills for balance queries, token transfers, swap execution, market analysis, and token security auditing"
   },
   "plugins": [
     {
-      "name": "onekey",
+      "name": "onekey-skills",
       "source": {
         "source": "git-subdir",
         "url": "OneKeyHQ/app-monorepo",
         "path": "apps/cli"
       },
-      "description": "OneKey crypto wallet CLI skills — wallet, swap, market, security"
+      "description": "4 OneKey wallet skills — wallet (balance, transfer, history), swap (quote, execute, status), market (search, price, trending, kline), and security (token audit, risk classification)",
+      "version": "0.1.0",
+      "author": { "name": "OneKey" },
+      "homepage": "https://onekey.so",
+      "repository": "https://github.com/OneKeyHQ/app-monorepo",
+      "license": "Apache-2.0",
+      "keywords": ["skills", "onekey", "wallet", "crypto", "defi", "swap", "market", "security", "web3", "blockchain"],
+      "category": "web3",
+      "tags": ["skills", "wallet", "swap", "market", "security", "defi", "token", "blockchain"],
+      "strict": false
     }
   ]
 }

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -43,7 +43,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: yarn
@@ -56,14 +55,14 @@ jobs:
 
       - name: Publish to NPM
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd apps/cli
           IS_PRERELEASE="${{ needs.get-version.outputs.is_prerelease }}"
           if [ "$IS_PRERELEASE" = "true" ]; then
-            npm publish --access public --dist-tag next
+            yarn npm publish --access public --tag next
           else
-            npm publish --access public --dist-tag latest
+            yarn npm publish --access public --tag latest
           fi
 
       - name: Summary

--- a/apps/cli/.claude-plugin/plugin.json
+++ b/apps/cli/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "onekey",
+  "name": "onekey-skills",
   "description": "OneKey crypto wallet CLI skills for Claude Code",
   "version": "0.1.0",
   "author": {


### PR DESCRIPTION
## Summary
- Fix CLI publish workflow that was packaging `next@16.2.2` instead of `@onekeyfe/cli` due to npm/Yarn Berry workspace incompatibility
- Update Claude Code marketplace and plugin naming to align with competitor conventions (OKX, Trust Wallet)

## Intent & Context
The CLI publish GitHub Actions workflow (`cli-publish.yml`) was failing because `npm publish` in a Yarn 4 Berry workspace incorrectly resolved the package — it tried to publish the Next.js framework (34MB, 8064 files) instead of the actual CLI package. Additionally, the marketplace naming was generic and lacked metadata for discoverability.

## Root Cause
In a Yarn 4 Berry monorepo, `npm publish` (a different package manager) cannot correctly resolve workspace packages. The `actions/setup-node@v4` with `registry-url` generates an `.npmrc` that further confuses npm's package resolution. The auth also failed because `NODE_AUTH_TOKEN` is the npm env var, not Yarn Berry's.

## Design Decisions
- **`yarn npm publish` over `npm publish`**: Yarn Berry's native publish command correctly resolves workspace packages. Verified locally with `--dry-run` (3 files, correct package name) vs npm's broken resolution (8064 files, wrong package).
- **Removed `registry-url` from setup-node**: Yarn Berry doesn't need the `.npmrc` that `actions/setup-node` generates; it uses `YARN_NPM_AUTH_TOKEN` env var instead.
- **Marketplace naming `onekey-agent-skills`/`onekey-skills`**: Aligned with OKX (`onchainos-skills`) and Trust Wallet (`tw-agent-skills`) naming patterns. Added `$schema`, `keywords`, `category`, `tags` for marketplace discoverability.

## Changes Detail
- `.github/workflows/cli-publish.yml`: Replace `npm publish` with `yarn npm publish`, `NODE_AUTH_TOKEN` with `YARN_NPM_AUTH_TOKEN`, remove `registry-url`
- `.claude-plugin/marketplace.json`: Rename to `onekey-agent-skills`, add schema/keywords/category/tags metadata
- `apps/cli/.claude-plugin/plugin.json`: Rename plugin to `onekey-skills`

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: CI/CD only (no runtime code changes)
- **Risk Areas**: NPM publish step — already validated with successful publish run

## Test plan
- [x] `npm pack --dry-run` from `apps/cli` shows correct 3 files
- [x] `yarn npm publish --dry-run` shows correct package name and files
- [x] CI publish workflow succeeded: https://github.com/OneKeyHQ/app-monorepo/actions/runs/23932325510
- [x] Package live on npm: `npm view @onekeyfe/cli`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
