### PR TITLE
chore: sync release/v6.1.0 to x (2026-04-03)

### DIFF
--- a/.github/workflows/release-ready-merge-gate.yml
+++ b/.github/workflows/release-ready-merge-gate.yml
@@ -1,0 +1,43 @@
+name: release-ready-merge-gate
+
+on:
+  pull_request:
+    branches:
+      - 'release/*'
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+      - edited
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  release-ready-merge-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate release-ready label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const baseRef = pr?.base?.ref ?? '';
+            const labels = Array.isArray(pr?.labels) ? pr.labels : [];
+
+            if (!baseRef.startsWith('release/')) {
+              core.info(`Skipping merge gate because base ref '${baseRef}' does not target a release branch.`);
+              return;
+            }
+
+            const hasReleaseReadyLabel = labels.some((label) => label?.name === 'release-ready');
+
+            if (hasReleaseReadyLabel) {
+              core.info('Skipping merge gate because the release-ready label is present.');
+              return;
+            }
+
+            core.setFailed('PRs targeting release/* must have the release-ready label before merge.');

--- a/.skillshare/skills/1k-bundle-release/SKILL.md
+++ b/.skillshare/skills/1k-bundle-release/SKILL.md
@@ -84,7 +84,7 @@ Parse the argument passed to this skill:
   ... QA verifies, merge ...
 /1k-bundle-release diff-check             ← Quick changeset review
 /1k-bundle-release audit                  ← Full security audit (optional, recommended)
-/1k-bundle-release publish                ← Record release in RELEASES.json
+/1k-bundle-release publish                ← Record release in RELEASES.json (via PR)
 /1k-bundle-release sync                   ← Rebase changes to x
 ```
 

--- a/.skillshare/skills/1k-bundle-release/references/rules/publish.md
+++ b/.skillshare/skills/1k-bundle-release/references/rules/publish.md
@@ -91,21 +91,42 @@ Field details:
 
 Write the updated JSON with 2-space indentation.
 
-## Step 3: Commit and create PR
+## Step 3: Create branch, commit, and open PR
 
-`release/*` branches are protected — direct pushes bypass required status checks and review. Always create a PR instead:
+Never push directly to the release branch. Create a PR instead.
+
+### Create a branch and commit
 
 ```bash
-git checkout -b "chore/release-$seq" "$RELEASE_BRANCH"
+release_branch_name="chore/release-${seq}"
+git checkout -b "$release_branch_name"
 git add RELEASES.json
 git commit -m "chore: release #$seq"
-git push -u origin "chore/release-$seq"
+git push origin "$release_branch_name"
+```
 
+### Create PR targeting the release branch
+
+```bash
 gh pr create \
   --base "$RELEASE_BRANCH" \
-  --head "chore/release-$seq" \
   --title "chore: release #$seq" \
-  --body "Record bundle release #$seq in RELEASES.json."
+  --body "$(cat <<'EOF'
+## Summary
+- Record release #$seq in RELEASES.json
+- Commit: $short_sha
+- PRs included: $pr_list
+
+## Release Notes
+$notes
+EOF
+)"
+```
+
+After PR is created, switch back to the release branch:
+
+```bash
+git checkout "$RELEASE_BRANCH"
 ```
 
 After the PR is merged, the release is finalized.
@@ -113,15 +134,15 @@ After the PR is merged, the release is finalized.
 ## Step 4: Output
 
 ```
-=== Release #$seq Published ===
+=== Release #$seq PR Created ===
 
 📦 Commit: $short_sha ($RELEASE_BRANCH)
 📋 PRs: #1234, #1256, #1260
 📝 Notes: $notes
+🔗 PR: $pr_url
 
-To trigger CI build, use workflow_dispatch on branch: $RELEASE_BRANCH
+Merge the PR, then trigger CI build via workflow_dispatch on branch: $RELEASE_BRANCH
 
-Release recorded in RELEASES.json.
 Next step: /1k-bundle-release sync (sync changes to x)
 ```
 

--- a/.skillshare/skills/1k-bundle-release/references/rules/sync.md
+++ b/.skillshare/skills/1k-bundle-release/references/rules/sync.md
@@ -52,11 +52,27 @@ Get the list of release-only commits (not yet on x) using patch-id comparison:
 git cherry origin/x "origin/$RELEASE_BRANCH"
 ```
 
-Lines starting with `+` are new commits. For each `+` commit, cherry-pick onto the sync branch:
+Lines starting with `+` are new commits.
+
+### Filter out release-tracking commits
+
+Before cherry-picking or rebasing, **exclude commits that only modify release-tracking files**. These are release-branch-specific and must NOT be synced to `x`:
+
+- Commits matching `chore: release #*` (the publish tracking commits)
+- Commits that only touch `RELEASES.json`
+- Commits that only modify `.env.version` (BUILD_NUMBER changes)
+
+When using cherry-pick, skip these commits. When using rebase, drop them interactively or revert them after the rebase.
+
+### Cherry-pick approach
+
+For each `+` commit (excluding filtered ones above), cherry-pick onto the sync branch:
 
 ```bash
 git cherry-pick <commit-sha>
 ```
+
+### Rebase approach
 
 Alternatively, use rebase to replay all release-only commits at once:
 

--- a/.skillshare/skills/1k-monitor-pr-ci/SKILL.md
+++ b/.skillshare/skills/1k-monitor-pr-ci/SKILL.md
@@ -136,9 +136,19 @@ Unresolved threads: 3
 
 ### 1c. Decide next action
 
+Before choosing an action, classify the `gh pr checks` output into three buckets:
+
+- **Normal failed checks**: any failed check except `release-ready-merge-gate`
+- **Gate failure**: failed check named exactly `release-ready-merge-gate`
+- **Pending checks**: any check still pending or in progress
+
+If `release-ready-merge-gate` is failing, treat it as an expected merge blocker rather than a CI failure to auto-fix.
+
 | CI Status | Unresolved Threads | Action |
 |-----------|-------------------|--------|
-| Any fail | - | **Auto-fix** CI failure (Step 2) |
+| Normal failed checks | - | **Auto-fix** CI failure (Step 2) |
+| Gate failure | Has threads | **Address threads** (Step 3), then report blocked by missing `release-ready` |
+| Gate failure | No threads | **Stop waiting** and report blocked by missing `release-ready` |
 | Any pending | Has threads | **Address threads** (Step 3), keep waiting for CI |
 | Any pending | No threads | Wait, re-check |
 | All pass | Has threads | **Address threads** (Step 3) |
@@ -255,12 +265,31 @@ After pushing fixes, request re-review from the reviewers who left comments:
 
 3. Return to Step 1 (wait for CI to re-run)
 
+## Step 3g: Report release-ready gate blocker
+
+If the only remaining failed check is `release-ready-merge-gate`, stop the polling loop and report:
+
+```text
+CI is complete, but merge is blocked by the release-ready gate.
+
+Blocking check:
+- release-ready-merge-gate: expected failure until the PR gets the `release-ready` label
+
+Action:
+- Add the `release-ready` label to the PR, then run the monitor again if needed
+```
+
+Do not:
+- attempt to auto-fix this check
+- treat it as flaky infra
+- continue waiting for it to pass on its own
+
 ## Step 4: Final Report
 
-When all CI checks pass and no unresolved threads remain:
+When all normal CI checks pass and no unresolved threads remain:
 
 ```
-All CI checks passed! All review threads resolved.
+All normal CI checks passed. All review threads resolved.
 
 CI:
 | Check            | Status | Duration |
@@ -272,6 +301,8 @@ Review threads: 5 resolved, 0 remaining
 PR: <URL>
 Status: Ready for re-review / Ready to merge
 ```
+
+If `release-ready-merge-gate` is still failing, do not use this final report. Use the blocked-state report from Step 3g instead.
 
 ## Polling Rules
 


### PR DESCRIPTION
## Summary
- Sync 2 commits from release/v6.1.0 to x
- Update publish workflow to use PR instead of direct push (#10974)
- Enforce release-ready merge gate for release PRs (#11021)

## Synced Commits
| SHA | Title |
|-----|-------|
| e1423cae7d | chore: update publish workflow to use PR instead of direct push (#10974) |
| 8a972e0401 | [codex] enforce release-ready merge gate for release PRs (#11021) |

## Skipped Commits
| SHA | Title | Reason |
|-----|-------|--------|
| ae8fd672d5 | chore: release #4 | Release-tracking commit (RELEASES.json only) - not synced per sync rules |

## Conflict Resolutions

### 1. SKILL.md (commit e1423cae7d - #10974)
- **Triggering commit**: e1423cae7d "chore: update publish workflow to use PR instead of direct push (#10974)"
- **x side**: Had audit step listed between diff-check and publish; publish line showed "Record release in RELEASES.json"
- **release side**: No audit step; publish line showed "Record release in RELEASES.json (via PR)"
- **Resolution**: Kept both the audit step from x (added in prior sync) AND the "(via PR)" suffix from release, since the publish workflow now uses PRs. This preserves the full subcommand list while reflecting the updated publish mechanism.

### 2. publish.md (commit e1423cae7d - #10974)
- **Triggering commit**: e1423cae7d "chore: update publish workflow to use PR instead of direct push (#10974)"
- **x side**: Older PR creation format with simpler --body and git push -u origin
- **release side**: Newer format with detailed PR body template (Summary, Release Notes sections), separate subsections for branch creation and PR creation, and git checkout back to release branch after PR creation
- **Resolution**: Took the release side entirely - it represents the intended workflow update from #10974 with a more structured and informative PR body template.

---
Automatically executed by Claude Code cloud scheduled task.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
