### PR TITLE
fix: skip missing .env files in env.js and setup:env script

### DIFF
--- a/development/env.js
+++ b/development/env.js
@@ -1,16 +1,19 @@
+const fs = require('fs');
 const path = require('path');
 
 const dateFns = require('date-fns');
 const dotenv = require('dotenv');
 
+const envPaths = [
+  // priority: high -> low
+  path.resolve(__dirname, '../.env.version'),
+  path.resolve(__dirname, '../.env.expo'),
+  path.resolve(__dirname, '../.env'),
+].filter((p) => fs.existsSync(p));
+
 const results = [
   dotenv.config({
-    path: [
-      // priority: high -> low
-      path.resolve(__dirname, '../.env.version'),
-      path.resolve(__dirname, '../.env.expo'),
-      path.resolve(__dirname, '../.env'),
-    ],
+    path: envPaths,
   }),
 ];
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "setup:env": "node -e \"const fs=require('fs');if(!fs.existsSync('.env'))fs.copyFileSync('.env.example','.env');\"",
+    "setup:env": "node -e \"const fs=require('fs');if(!fs.existsSync('.env')){if(fs.existsSync('.env.example')){fs.copyFileSync('.env.example','.env')}else{fs.writeFileSync('.env','')}}\"",
     "skills:sync": "node development/scripts/skillshare/install.js",
     "postinstall": "node development/scripts/postinstall.js",
     "copy:inject": "node development/scripts/copy-injected.js",


### PR DESCRIPTION
## Summary

- **fix(env.js)**: Filter out missing `.env` files before passing to `dotenv.config()` to prevent CI build failures when `.env.expo` is absent.
- **fix(package.json)**: Handle missing `.env.example` in `setup:env` script.

## Test plan
- [ ] Verify CI builds pass without `.env.expo` present
- [ ] Verify local dev setup (`yarn setup:env`) works correctly