### PR TITLE
fix: split useOneKeyWalletDetection web implementation

### DIFF
--- a/packages/kit/src/hooks/useWebDapp/useOneKeyWalletDetection.desktop.ts
+++ b/packages/kit/src/hooks/useWebDapp/useOneKeyWalletDetection.desktop.ts
@@ -1,0 +1,15 @@
+import { useCallback } from 'react';
+
+import type { IExternalConnectionInfo } from '@onekeyhq/shared/types/externalWallet.types';
+
+export function useOneKeyWalletDetection() {
+  const getOneKeyConnectionInfo = useCallback((): IExternalConnectionInfo | null => {
+    return null;
+  }, []);
+
+  return {
+    isOneKeyInstalled: false,
+    oneKeyProviderInfo: null,
+    getOneKeyConnectionInfo,
+  };
+}

--- a/packages/kit/src/hooks/useWebDapp/useOneKeyWalletDetection.ext.ts
+++ b/packages/kit/src/hooks/useWebDapp/useOneKeyWalletDetection.ext.ts
@@ -1,0 +1,15 @@
+import { useCallback } from 'react';
+
+import type { IExternalConnectionInfo } from '@onekeyhq/shared/types/externalWallet.types';
+
+export function useOneKeyWalletDetection() {
+  const getOneKeyConnectionInfo = useCallback((): IExternalConnectionInfo | null => {
+    return null;
+  }, []);
+
+  return {
+    isOneKeyInstalled: false,
+    oneKeyProviderInfo: null,
+    getOneKeyConnectionInfo,
+  };
+}

--- a/packages/kit/src/hooks/useWebDapp/useOneKeyWalletDetection.ts
+++ b/packages/kit/src/hooks/useWebDapp/useOneKeyWalletDetection.ts
@@ -1,125 +1,15 @@
-import { useCallback, useMemo, useSyncExternalStore } from 'react';
+import { useCallback } from 'react';
 
-import { createStore } from 'mipd';
-
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IExternalConnectionInfo } from '@onekeyhq/shared/types/externalWallet.types';
 
-import type { EIP6963ProviderDetail } from 'mipd';
-
-const ONE_KEY_RDNS_PATTERNS = ['so.onekey.app.wallet'];
-
-// ---------------------------------------------------------------------------
-// Module-level singleton MIPD store + useSyncExternalStore glue
-// ---------------------------------------------------------------------------
-const sharedMipdStore = platformEnv.isWeb ? createStore() : undefined;
-
-let cachedProviders: readonly EIP6963ProviderDetail[] =
-  sharedMipdStore?.getProviders() ?? [];
-
-const listeners = new Set<() => void>();
-
-sharedMipdStore?.subscribe((updated) => {
-  cachedProviders = updated;
-  listeners.forEach((l) => l());
-});
-
-function subscribe(listener: () => void) {
-  listeners.add(listener);
-  return () => listeners.delete(listener);
-}
-
-function getSnapshot() {
-  return cachedProviders;
-}
-
-function findOneKeyProvider(providers: readonly EIP6963ProviderDetail[]) {
-  return providers.find((provider) => {
-    if (!provider?.info) return false;
-    const rdns = provider.info.rdns?.toLowerCase() ?? '';
-    const name = provider.info.name?.toLowerCase() ?? '';
-    return (
-      ONE_KEY_RDNS_PATTERNS.some((p) => rdns.includes(p)) ||
-      name.includes('onekey')
-    );
-  });
-}
-
-// ---------------------------------------------------------------------------
-// useEIP6963Providers — returns the latest provider list, auto-updates
-// ---------------------------------------------------------------------------
-function useEIP6963Providers() {
-  return useSyncExternalStore(subscribe, getSnapshot);
-}
-
-// ---------------------------------------------------------------------------
-// useOneKeyWalletDetection
-// ---------------------------------------------------------------------------
 export function useOneKeyWalletDetection() {
-  const isOneKeyExtWalletInstalled = !!globalThis.$onekey?.$private?.isOneKey;
-  const providers = useEIP6963Providers();
-
-  const oneKeyEIP6963Provider = useMemo(
-    () => findOneKeyProvider(providers),
-    [providers],
-  );
-
-  const getOneKeyConnectionInfo =
-    useCallback((): IExternalConnectionInfo | null => {
-      // Prefer the cached provider from subscribe; fall back to a fresh read.
-      const provider =
-        oneKeyEIP6963Provider ??
-        findOneKeyProvider(sharedMipdStore?.getProviders() ?? []);
-
-      if (provider) {
-        return {
-          evmEIP6963: {
-            info: provider.info,
-          },
-        };
-      }
-
-      if (isOneKeyExtWalletInstalled) {
-        return {
-          evmInjected: {
-            global: 'ethereum',
-            name: 'OneKey Wallet',
-          },
-        };
-      }
-
-      return null;
-    }, [oneKeyEIP6963Provider, isOneKeyExtWalletInstalled]);
-
-  const isOneKeyInstalled = useMemo(() => {
-    return !!oneKeyEIP6963Provider || isOneKeyExtWalletInstalled;
-  }, [oneKeyEIP6963Provider, isOneKeyExtWalletInstalled]);
-
-  const oneKeyProviderInfo = useMemo(() => {
-    if (oneKeyEIP6963Provider) {
-      return {
-        name: oneKeyEIP6963Provider.info.name,
-        icon: oneKeyEIP6963Provider.info.icon,
-        rdns: oneKeyEIP6963Provider.info.rdns,
-        uuid: oneKeyEIP6963Provider.info.uuid,
-      };
-    }
-
-    if (isOneKeyExtWalletInstalled) {
-      return {
-        name: 'OneKey Wallet',
-        icon: '',
-        rdns: 'injected',
-        uuid: 'onekey-injected',
-      };
-    }
-
+  const getOneKeyConnectionInfo = useCallback((): IExternalConnectionInfo | null => {
     return null;
-  }, [oneKeyEIP6963Provider, isOneKeyExtWalletInstalled]);
+  }, []);
 
   return {
-    isOneKeyInstalled,
-    oneKeyProviderInfo,
+    isOneKeyInstalled: false,
+    oneKeyProviderInfo: null,
     getOneKeyConnectionInfo,
   };
 }

--- a/packages/kit/src/hooks/useWebDapp/useOneKeyWalletDetection.web.ts
+++ b/packages/kit/src/hooks/useWebDapp/useOneKeyWalletDetection.web.ts
@@ -1,0 +1,124 @@
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
+
+import { createStore } from 'mipd';
+
+import type { IExternalConnectionInfo } from '@onekeyhq/shared/types/externalWallet.types';
+
+import type { EIP6963ProviderDetail } from 'mipd';
+
+const ONE_KEY_RDNS_PATTERNS = ['so.onekey.app.wallet'];
+
+// ---------------------------------------------------------------------------
+// Module-level singleton MIPD store + useSyncExternalStore glue
+// ---------------------------------------------------------------------------
+const sharedMipdStore = createStore();
+
+let cachedProviders: readonly EIP6963ProviderDetail[] =
+  sharedMipdStore.getProviders() ?? [];
+
+const listeners = new Set<() => void>();
+
+sharedMipdStore.subscribe((updated) => {
+  cachedProviders = updated;
+  listeners.forEach((l) => l());
+});
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function getSnapshot() {
+  return cachedProviders;
+}
+
+function findOneKeyProvider(providers: readonly EIP6963ProviderDetail[]) {
+  return providers.find((provider) => {
+    if (!provider?.info) return false;
+    const rdns = provider.info.rdns?.toLowerCase() ?? '';
+    const name = provider.info.name?.toLowerCase() ?? '';
+    return (
+      ONE_KEY_RDNS_PATTERNS.some((p) => rdns.includes(p)) ||
+      name.includes('onekey')
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useEIP6963Providers — returns the latest provider list, auto-updates
+// ---------------------------------------------------------------------------
+function useEIP6963Providers() {
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+// ---------------------------------------------------------------------------
+// useOneKeyWalletDetection
+// ---------------------------------------------------------------------------
+export function useOneKeyWalletDetection() {
+  const isOneKeyExtWalletInstalled = !!globalThis.$onekey?.$private?.isOneKey;
+  const providers = useEIP6963Providers();
+
+  const oneKeyEIP6963Provider = useMemo(
+    () => findOneKeyProvider(providers),
+    [providers],
+  );
+
+  const getOneKeyConnectionInfo =
+    useCallback((): IExternalConnectionInfo | null => {
+      // Prefer the cached provider from subscribe; fall back to a fresh read.
+      const provider =
+        oneKeyEIP6963Provider ??
+        findOneKeyProvider(sharedMipdStore.getProviders() ?? []);
+
+      if (provider) {
+        return {
+          evmEIP6963: {
+            info: provider.info,
+          },
+        };
+      }
+
+      if (isOneKeyExtWalletInstalled) {
+        return {
+          evmInjected: {
+            global: 'ethereum',
+            name: 'OneKey Wallet',
+          },
+        };
+      }
+
+      return null;
+    }, [oneKeyEIP6963Provider, isOneKeyExtWalletInstalled]);
+
+  const isOneKeyInstalled = useMemo(() => {
+    return !!oneKeyEIP6963Provider || isOneKeyExtWalletInstalled;
+  }, [oneKeyEIP6963Provider, isOneKeyExtWalletInstalled]);
+
+  const oneKeyProviderInfo = useMemo(() => {
+    if (oneKeyEIP6963Provider) {
+      return {
+        name: oneKeyEIP6963Provider.info.name,
+        icon: oneKeyEIP6963Provider.info.icon,
+        rdns: oneKeyEIP6963Provider.info.rdns,
+        uuid: oneKeyEIP6963Provider.info.uuid,
+      };
+    }
+
+    if (isOneKeyExtWalletInstalled) {
+      return {
+        name: 'OneKey Wallet',
+        icon: '',
+        rdns: 'injected',
+        uuid: 'onekey-injected',
+      };
+    }
+
+    return null;
+  }, [oneKeyEIP6963Provider, isOneKeyExtWalletInstalled]);
+
+  return {
+    isOneKeyInstalled,
+    oneKeyProviderInfo,
+    getOneKeyConnectionInfo,
+  };
+}


### PR DESCRIPTION
### Motivation
- Prevent web-only initialization (`createStore()` / MIPD / EIP-6963 detection) from running in non-web bundles (mobile/desktop/extension) which caused unwanted native initialization and increased bundle/runtime risk. 
- Follow the project cross-platform pattern of using platform-specific file suffixes so only web builds include the web detection logic.

### Description
- Convert `packages/kit/src/hooks/useWebDapp/useOneKeyWalletDetection.ts` into a no-op fallback that always returns `isOneKeyInstalled: false`, `oneKeyProviderInfo: null`, and `getOneKeyConnectionInfo(): null` to avoid loading web-only code on non-web platforms. 
- Add `packages/kit/src/hooks/useWebDapp/useOneKeyWalletDetection.web.ts` containing the original MIPD-based detection logic (module-level `createStore()`, provider subscription, `useSyncExternalStore` glue, `findOneKeyProvider`, `getOneKeyConnectionInfo`, and exported hook API). 
- Preserve the existing hook API so current callers remain compatible while ensuring only web bundles execute the detection logic.

### Testing
- Ran `git status`/diff to verify the two-file change and staged files successfully; changes committed locally. 
- Attempted `yarn lint:staged` but it could not run in this environment due to missing Yarn `node_modules` state file so linting was not executed here. 
- Attempted `yarn tsc:staged` but it could not run in this environment for the same reason so type checks were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf9ce8d41083329e09a3ffe44175bb)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
