### PR TITLE
fix: Add web-only resolve extensions and split OneKey wallet detection into web-specific implementation

### DIFF
--- a/development/rspack/utils.ts
+++ b/development/rspack/utils.ts
@@ -31,7 +31,13 @@ export function createResolveExtensions({
     // .ext.ts, .web.ts, .desktop.ts, .android.ts, .ios.ts, .native.ts
     ...['.ts', '.tsx', '.js', '.jsx'].map((ext) => `.${platform}${ext}`),
     ...(platform === 'web' || platform === 'webEmbed'
-      ? ['.web-only.ts', '.web-only.tsx', '.web-only.mjs', '.web-only.js', '.web-only.jsx']
+      ? [
+          '.web-only.ts',
+          '.web-only.tsx',
+          '.web-only.mjs',
+          '.web-only.js',
+          '.web-only.jsx',
+        ]
       : []),
     '.web.ts',
     '.web.tsx',

--- a/development/rspack/utils.ts
+++ b/development/rspack/utils.ts
@@ -30,6 +30,9 @@ export function createResolveExtensions({
       : []),
     // .ext.ts, .web.ts, .desktop.ts, .android.ts, .ios.ts, .native.ts
     ...['.ts', '.tsx', '.js', '.jsx'].map((ext) => `.${platform}${ext}`),
+    ...(platform === 'web' || platform === 'webEmbed'
+      ? ['.web-only.ts', '.web-only.tsx', '.web-only.mjs', '.web-only.js', '.web-only.jsx']
+      : []),
     '.web.ts',
     '.web.tsx',
     '.web.mjs',

--- a/development/webpack/utils.js
+++ b/development/webpack/utils.js
@@ -26,6 +26,9 @@ exports.createResolveExtensions = function ({ platform, configName }) {
       : []),
     // .ext.ts, .web.ts, .desktop.ts, .android.ts, .ios.ts, .native.ts
     ...['.ts', '.tsx', '.js', '.jsx'].map((ext) => `.${platform}${ext}`),
+    ...(platform === 'web' || platform === 'webEmbed'
+      ? ['.web-only.ts', '.web-only.tsx', '.web-only.mjs', '.web-only.js', '.web-only.jsx']
+      : []),
     '.web.ts',
     '.web.tsx',
     '.web.mjs',

--- a/development/webpack/utils.js
+++ b/development/webpack/utils.js
@@ -27,7 +27,13 @@ exports.createResolveExtensions = function ({ platform, configName }) {
     // .ext.ts, .web.ts, .desktop.ts, .android.ts, .ios.ts, .native.ts
     ...['.ts', '.tsx', '.js', '.jsx'].map((ext) => `.${platform}${ext}`),
     ...(platform === 'web' || platform === 'webEmbed'
-      ? ['.web-only.ts', '.web-only.tsx', '.web-only.mjs', '.web-only.js', '.web-only.jsx']
+      ? [
+          '.web-only.ts',
+          '.web-only.tsx',
+          '.web-only.mjs',
+          '.web-only.js',
+          '.web-only.jsx',
+        ]
       : []),
     '.web.ts',
     '.web.tsx',

--- a/packages/kit/src/hooks/useWebDapp/useOneKeyWalletDetection.ts
+++ b/packages/kit/src/hooks/useWebDapp/useOneKeyWalletDetection.ts
@@ -3,9 +3,10 @@ import { useCallback } from 'react';
 import type { IExternalConnectionInfo } from '@onekeyhq/shared/types/externalWallet.types';
 
 export function useOneKeyWalletDetection() {
-  const getOneKeyConnectionInfo = useCallback((): IExternalConnectionInfo | null => {
-    return null;
-  }, []);
+  const getOneKeyConnectionInfo =
+    useCallback((): IExternalConnectionInfo | null => {
+      return null;
+    }, []);
 
   return {
     isOneKeyInstalled: false,

--- a/packages/kit/src/hooks/useWebDapp/useOneKeyWalletDetection.ts
+++ b/packages/kit/src/hooks/useWebDapp/useOneKeyWalletDetection.ts
@@ -1,125 +1,15 @@
-import { useCallback, useMemo, useSyncExternalStore } from 'react';
+import { useCallback } from 'react';
 
-import { createStore } from 'mipd';
-
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IExternalConnectionInfo } from '@onekeyhq/shared/types/externalWallet.types';
 
-import type { EIP6963ProviderDetail } from 'mipd';
-
-const ONE_KEY_RDNS_PATTERNS = ['so.onekey.app.wallet'];
-
-// ---------------------------------------------------------------------------
-// Module-level singleton MIPD store + useSyncExternalStore glue
-// ---------------------------------------------------------------------------
-const sharedMipdStore = platformEnv.isWeb ? createStore() : undefined;
-
-let cachedProviders: readonly EIP6963ProviderDetail[] =
-  sharedMipdStore?.getProviders() ?? [];
-
-const listeners = new Set<() => void>();
-
-sharedMipdStore?.subscribe((updated) => {
-  cachedProviders = updated;
-  listeners.forEach((l) => l());
-});
-
-function subscribe(listener: () => void) {
-  listeners.add(listener);
-  return () => listeners.delete(listener);
-}
-
-function getSnapshot() {
-  return cachedProviders;
-}
-
-function findOneKeyProvider(providers: readonly EIP6963ProviderDetail[]) {
-  return providers.find((provider) => {
-    if (!provider?.info) return false;
-    const rdns = provider.info.rdns?.toLowerCase() ?? '';
-    const name = provider.info.name?.toLowerCase() ?? '';
-    return (
-      ONE_KEY_RDNS_PATTERNS.some((p) => rdns.includes(p)) ||
-      name.includes('onekey')
-    );
-  });
-}
-
-// ---------------------------------------------------------------------------
-// useEIP6963Providers — returns the latest provider list, auto-updates
-// ---------------------------------------------------------------------------
-function useEIP6963Providers() {
-  return useSyncExternalStore(subscribe, getSnapshot);
-}
-
-// ---------------------------------------------------------------------------
-// useOneKeyWalletDetection
-// ---------------------------------------------------------------------------
 export function useOneKeyWalletDetection() {
-  const isOneKeyExtWalletInstalled = !!globalThis.$onekey?.$private?.isOneKey;
-  const providers = useEIP6963Providers();
-
-  const oneKeyEIP6963Provider = useMemo(
-    () => findOneKeyProvider(providers),
-    [providers],
-  );
-
-  const getOneKeyConnectionInfo =
-    useCallback((): IExternalConnectionInfo | null => {
-      // Prefer the cached provider from subscribe; fall back to a fresh read.
-      const provider =
-        oneKeyEIP6963Provider ??
-        findOneKeyProvider(sharedMipdStore?.getProviders() ?? []);
-
-      if (provider) {
-        return {
-          evmEIP6963: {
-            info: provider.info,
-          },
-        };
-      }
-
-      if (isOneKeyExtWalletInstalled) {
-        return {
-          evmInjected: {
-            global: 'ethereum',
-            name: 'OneKey Wallet',
-          },
-        };
-      }
-
-      return null;
-    }, [oneKeyEIP6963Provider, isOneKeyExtWalletInstalled]);
-
-  const isOneKeyInstalled = useMemo(() => {
-    return !!oneKeyEIP6963Provider || isOneKeyExtWalletInstalled;
-  }, [oneKeyEIP6963Provider, isOneKeyExtWalletInstalled]);
-
-  const oneKeyProviderInfo = useMemo(() => {
-    if (oneKeyEIP6963Provider) {
-      return {
-        name: oneKeyEIP6963Provider.info.name,
-        icon: oneKeyEIP6963Provider.info.icon,
-        rdns: oneKeyEIP6963Provider.info.rdns,
-        uuid: oneKeyEIP6963Provider.info.uuid,
-      };
-    }
-
-    if (isOneKeyExtWalletInstalled) {
-      return {
-        name: 'OneKey Wallet',
-        icon: '',
-        rdns: 'injected',
-        uuid: 'onekey-injected',
-      };
-    }
-
+  const getOneKeyConnectionInfo = useCallback((): IExternalConnectionInfo | null => {
     return null;
-  }, [oneKeyEIP6963Provider, isOneKeyExtWalletInstalled]);
+  }, []);
 
   return {
-    isOneKeyInstalled,
-    oneKeyProviderInfo,
+    isOneKeyInstalled: false,
+    oneKeyProviderInfo: null,
     getOneKeyConnectionInfo,
   };
 }

--- a/packages/kit/src/hooks/useWebDapp/useOneKeyWalletDetection.web-only.ts
+++ b/packages/kit/src/hooks/useWebDapp/useOneKeyWalletDetection.web-only.ts
@@ -1,0 +1,124 @@
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
+
+import { createStore } from 'mipd';
+
+import type { IExternalConnectionInfo } from '@onekeyhq/shared/types/externalWallet.types';
+
+import type { EIP6963ProviderDetail } from 'mipd';
+
+const ONE_KEY_RDNS_PATTERNS = ['so.onekey.app.wallet'];
+
+// ---------------------------------------------------------------------------
+// Module-level singleton MIPD store + useSyncExternalStore glue
+// ---------------------------------------------------------------------------
+const sharedMipdStore = createStore();
+
+let cachedProviders: readonly EIP6963ProviderDetail[] =
+  sharedMipdStore.getProviders() ?? [];
+
+const listeners = new Set<() => void>();
+
+sharedMipdStore.subscribe((updated) => {
+  cachedProviders = updated;
+  listeners.forEach((l) => l());
+});
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function getSnapshot() {
+  return cachedProviders;
+}
+
+function findOneKeyProvider(providers: readonly EIP6963ProviderDetail[]) {
+  return providers.find((provider) => {
+    if (!provider?.info) return false;
+    const rdns = provider.info.rdns?.toLowerCase() ?? '';
+    const name = provider.info.name?.toLowerCase() ?? '';
+    return (
+      ONE_KEY_RDNS_PATTERNS.some((p) => rdns.includes(p)) ||
+      name.includes('onekey')
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useEIP6963Providers — returns the latest provider list, auto-updates
+// ---------------------------------------------------------------------------
+function useEIP6963Providers() {
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+// ---------------------------------------------------------------------------
+// useOneKeyWalletDetection
+// ---------------------------------------------------------------------------
+export function useOneKeyWalletDetection() {
+  const isOneKeyExtWalletInstalled = !!globalThis.$onekey?.$private?.isOneKey;
+  const providers = useEIP6963Providers();
+
+  const oneKeyEIP6963Provider = useMemo(
+    () => findOneKeyProvider(providers),
+    [providers],
+  );
+
+  const getOneKeyConnectionInfo =
+    useCallback((): IExternalConnectionInfo | null => {
+      // Prefer the cached provider from subscribe; fall back to a fresh read.
+      const provider =
+        oneKeyEIP6963Provider ??
+        findOneKeyProvider(sharedMipdStore.getProviders() ?? []);
+
+      if (provider) {
+        return {
+          evmEIP6963: {
+            info: provider.info,
+          },
+        };
+      }
+
+      if (isOneKeyExtWalletInstalled) {
+        return {
+          evmInjected: {
+            global: 'ethereum',
+            name: 'OneKey Wallet',
+          },
+        };
+      }
+
+      return null;
+    }, [oneKeyEIP6963Provider, isOneKeyExtWalletInstalled]);
+
+  const isOneKeyInstalled = useMemo(() => {
+    return !!oneKeyEIP6963Provider || isOneKeyExtWalletInstalled;
+  }, [oneKeyEIP6963Provider, isOneKeyExtWalletInstalled]);
+
+  const oneKeyProviderInfo = useMemo(() => {
+    if (oneKeyEIP6963Provider) {
+      return {
+        name: oneKeyEIP6963Provider.info.name,
+        icon: oneKeyEIP6963Provider.info.icon,
+        rdns: oneKeyEIP6963Provider.info.rdns,
+        uuid: oneKeyEIP6963Provider.info.uuid,
+      };
+    }
+
+    if (isOneKeyExtWalletInstalled) {
+      return {
+        name: 'OneKey Wallet',
+        icon: '',
+        rdns: 'injected',
+        uuid: 'onekey-injected',
+      };
+    }
+
+    return null;
+  }, [oneKeyEIP6963Provider, isOneKeyExtWalletInstalled]);
+
+  return {
+    isOneKeyInstalled,
+    oneKeyProviderInfo,
+    getOneKeyConnectionInfo,
+  };
+}


### PR DESCRIPTION
### Motivation

- Add support for `.web-only.*` module resolution so web-specific entrypoints are preferred during bundling for `web` and `webEmbed` platforms.
- Separate browser-only OneKey EIP-6963 detection logic from non-web builds to avoid browser-only dependencies on non-web targets.
- Keep the non-web hook lightweight and deterministic by returning no-op values when web APIs are not available.

### Description

- Augmented `createResolveExtensions` in `development/rspack/utils.ts` and `development/webpack/utils.js` to include `['.web-only.ts', '.web-only.tsx', '.web-only.mjs', '.web-only.js', '.web-only.jsx']` when `platform === 'web' || platform === 'webEmbed'` so web-only files are resolved first. 
- Refactored OneKey wallet detection by extracting the full browser implementation to a new file `packages/kit/src/hooks/useWebDapp/useOneKeyWalletDetection.web-only.ts` which uses `mipd` store, `useSyncExternalStore`, and provider detection logic.
- Simplified `packages/kit/src/hooks/useWebDapp/useOneKeyWalletDetection.ts` to a non-web no-op that returns `isOneKeyInstalled: false`, `oneKeyProviderInfo: null`, and a `getOneKeyConnectionInfo` callback that returns `null` to avoid web-only dependencies on non-web builds.

### Testing

- Ran TypeScript typecheck and local build to validate module changes and imports; the build succeeded.
- Executed the test suite (`yarn test`) to ensure no regressions in affected areas; tests passed.
- Verified bundler resolution changes by running the dev build for web and non-web targets and confirming `.web-only.*` files are considered for web builds and no-op hook does not import browser-only modules.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf9ce8d41083329e09a3ffe44175bb)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
