### PR TITLE
docs: use repo-local issue template link in bug rules

### DIFF
--- a/docs/BUG_RULES.md
+++ b/docs/BUG_RULES.md
@@ -40,7 +40,7 @@ All vulnerability reports must be submitted through one of the following channel
 1. **Public disclosure**: Create an issue in the [OneKey GitHub repository](https://github.com/OneKeyHQ/app-monorepo) tagged with the `bug` label.
 2. **Private disclosure**: Send an email to **dev@onekey.so** — recommended for high-severity vulnerabilities (P0/P1). Private submissions remain fully eligible for bounties.
 
-All submissions must follow the format defined in the [issue template](https://github.com/OneKeyHQ/app-monorepo/blob/onekey/docs/ISSUE_TEMPLATE.md). Reports must include:
+All submissions must follow the format defined in the [issue template](./ISSUE_TEMPLATE.md). Reports must include:
 
 * A clear description of the vulnerability
 * Step-by-step reproduction instructions


### PR DESCRIPTION
## Summary
- replace the branch-specific GitHub blob link in `docs/BUG_RULES.md` with a repo-local relative link
- keep the bug bounty submission guidance pointing at the same in-repo issue template

## Testing
- not run (docs-only change)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
