### PR TITLE
fix: token details loading, caching, and duplicate modal navigation(OK-52689 OK-52688)

### DIFF
--- a/packages/kit/src/hooks/useAppNavigation.ts
+++ b/packages/kit/src/hooks/useAppNavigation.ts
@@ -80,6 +80,140 @@ let lastPushAbleNavigation:
   | undefined;
 
 const PUSH_MODAL_LOCK_DURATION_MS = 300;
+const PENDING_MODAL_TARGET_TIMEOUT_MS = 1000;
+
+type IPendingModalTarget = {
+  modalType: ERootRoutes.Modal | ERootRoutes.iOSFullScreen;
+  route: string;
+  screen?: string;
+};
+
+type INavigationRouteWithNestedState = {
+  name?: string;
+  params?: unknown;
+  state?: {
+    index?: number;
+    routes?: Array<{
+      name?: string;
+      params?: unknown;
+      state?: {
+        index?: number;
+        routes?: Array<{
+          name?: string;
+        }>;
+      };
+    }>;
+  };
+};
+
+let pendingModalTargetKey: string | undefined;
+let pendingModalTargetTimer: ReturnType<typeof setTimeout> | undefined;
+let pendingModalTargetUnsubscribe: (() => void) | undefined;
+
+const buildPendingModalTargetKey = ({
+  modalType,
+  route,
+  screen,
+}: IPendingModalTarget) => `${modalType}::${route}::${screen ?? ''}`;
+
+const getNestedRouteScreenName = (route?: INavigationRouteWithNestedState) => {
+  const params = route?.params as { screen?: string } | undefined;
+  if (params?.screen) {
+    return params.screen;
+  }
+  const activeChildRoute = route?.state?.routes?.[route.state?.index ?? 0];
+  if (!activeChildRoute) {
+    return undefined;
+  }
+  const activeChildParams = activeChildRoute.params as
+    | { screen?: string }
+    | undefined;
+  const nestedRouteName =
+    activeChildRoute.state?.routes?.[activeChildRoute.state?.index ?? 0]?.name;
+  return activeChildParams?.screen ?? nestedRouteName ?? activeChildRoute.name;
+};
+
+const getRootRouteModalTarget = (
+  route?: INavigationRouteWithNestedState,
+): IPendingModalTarget | undefined => {
+  if (
+    route?.name !== ERootRoutes.Modal &&
+    route?.name !== ERootRoutes.iOSFullScreen
+  ) {
+    return undefined;
+  }
+
+  const params = route.params as
+    | {
+        screen?: string;
+        params?: {
+          screen?: string;
+        };
+      }
+    | undefined;
+  const activeChildRoute = route.state?.routes?.[route.state?.index ?? 0];
+  const modalRoute = params?.screen ?? activeChildRoute?.name;
+
+  if (!modalRoute) {
+    return undefined;
+  }
+
+  return {
+    modalType: route.name,
+    route: modalRoute,
+    screen:
+      params?.params?.screen ?? getNestedRouteScreenName(activeChildRoute),
+  };
+};
+
+const isSamePendingModalTarget = (
+  routeTarget: IPendingModalTarget | undefined,
+  target: IPendingModalTarget,
+) =>
+  routeTarget?.modalType === target.modalType &&
+  routeTarget.route === target.route &&
+  routeTarget.screen === target.screen;
+
+const clearPendingModalTarget = () => {
+  if (pendingModalTargetTimer) {
+    clearTimeout(pendingModalTargetTimer);
+  }
+  pendingModalTargetUnsubscribe?.();
+  pendingModalTargetKey = undefined;
+  pendingModalTargetTimer = undefined;
+  pendingModalTargetUnsubscribe = undefined;
+};
+
+const trackPendingModalTarget = (target: IPendingModalTarget) => {
+  clearPendingModalTarget();
+
+  const pendingKey = buildPendingModalTargetKey(target);
+  pendingModalTargetKey = pendingKey;
+
+  const checkAndClear = () => {
+    if (pendingModalTargetKey !== pendingKey) {
+      return;
+    }
+    const rootState = rootNavigationRef.current?.getState();
+    const currentRootRoute = rootState?.routes?.[rootState.index ?? 0];
+    const currentTarget = getRootRouteModalTarget(currentRootRoute);
+    if (isSamePendingModalTarget(currentTarget, target)) {
+      clearPendingModalTarget();
+    }
+  };
+
+  // Use navigation state listener instead of polling
+  pendingModalTargetUnsubscribe = rootNavigationRef.current?.addListener?.(
+    'state' as any,
+    checkAndClear,
+  );
+
+  // Timeout fallback: clear pending state even if state listener never fires
+  pendingModalTargetTimer = setTimeout(
+    clearPendingModalTarget,
+    PENDING_MODAL_TARGET_TIMEOUT_MS,
+  );
+};
 
 function useAppNavigation<
   P extends IPageNavigationProp<any> | IModalNavigationProp<any> =
@@ -117,20 +251,32 @@ function useAppNavigation<
       },
     ) => {
       const navigationInstance = navigationRef.current;
+      const target: IPendingModalTarget = {
+        modalType,
+        route,
+        screen: typeof params?.screen === 'string' ? params.screen : undefined,
+      };
 
       let rootNavigation = navigationInstance;
       while (rootNavigation?.getParent()) {
         rootNavigation = rootNavigation.getParent();
       }
 
-      const routeLength = rootNavigation?.getState?.()?.routes?.length ?? 1;
-      const existPageIndex = rootNavigation?.getState?.()?.routes?.findIndex(
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        (rootRoute) => params?.screen === rootRoute?.params?.params?.screen,
-      );
+      const rootState = rootNavigation?.getState?.();
+      const routeLength = rootState?.routes?.length ?? 1;
+      const existPageIndex =
+        rootState?.routes?.findIndex((rootRoute) =>
+          isSamePendingModalTarget(getRootRouteModalTarget(rootRoute), target),
+        ) ?? -1;
       if (existPageIndex !== -1 && existPageIndex === routeLength - 1) {
         return;
       }
+
+      if (pendingModalTargetKey === buildPendingModalTargetKey(target)) {
+        return;
+      }
+
+      trackPendingModalTarget(target);
 
       // TODO:
       // prevent pushModal from using unreleased Navigation instances during iOS modal animation by temporary exclusion,

--- a/packages/kit/src/hooks/useAppNavigation.ts
+++ b/packages/kit/src/hooks/useAppNavigation.ts
@@ -86,6 +86,7 @@ type IPendingModalTarget = {
   modalType: ERootRoutes.Modal | ERootRoutes.iOSFullScreen;
   route: string;
   screen?: string;
+  paramsKey?: string;
 };
 
 type INavigationRouteWithNestedState = {
@@ -114,7 +115,9 @@ const buildPendingModalTargetKey = ({
   modalType,
   route,
   screen,
-}: IPendingModalTarget) => `${modalType}::${route}::${screen ?? ''}`;
+  paramsKey,
+}: IPendingModalTarget) =>
+  `${modalType}::${route}::${screen ?? ''}::${paramsKey ?? ''}`;
 
 const getNestedRouteScreenName = (route?: INavigationRouteWithNestedState) => {
   const params = route?.params as { screen?: string } | undefined;
@@ -255,6 +258,9 @@ function useAppNavigation<
         modalType,
         route,
         screen: typeof params?.screen === 'string' ? params.screen : undefined,
+        paramsKey: params?.params
+          ? JSON.stringify(params.params)
+          : undefined,
       };
 
       let rootNavigation = navigationInstance;

--- a/packages/kit/src/hooks/useAppNavigation.ts
+++ b/packages/kit/src/hooks/useAppNavigation.ts
@@ -258,9 +258,7 @@ function useAppNavigation<
         modalType,
         route,
         screen: typeof params?.screen === 'string' ? params.screen : undefined,
-        paramsKey: params?.params
-          ? JSON.stringify(params.params)
-          : undefined,
+        paramsKey: params?.params ? JSON.stringify(params.params) : undefined,
       };
 
       let rootNavigation = navigationInstance;

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsDeFiBlock.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsDeFiBlock.tsx
@@ -18,6 +18,8 @@ import { EarnNavigation } from '@onekeyhq/kit/src/views/Earn/earnUtils';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { listItemPressStyle } from '@onekeyhq/shared/src/style';
+import cacheUtils from '@onekeyhq/shared/src/utils/cacheUtils';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
 interface ITokenDetailsDeFiBlockProps {
   networkId: string;
@@ -28,7 +30,11 @@ interface ITokenDetailsDeFiBlockProps {
 
 // Module-level cache: prevents skeleton flash on remount when scrolling
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const earnResultCache = new Map<string, any>();
+const earnResultCache = new cacheUtils.LRUCache<string, any>({
+  max: 50,
+  ttl: timerUtils.getTimeDurationMs({ minute: 10 }),
+  ttlAutopurge: true,
+});
 
 export function TokenDetailsDeFiBlock({
   networkId,

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback, useEffect, useMemo } from 'react';
 
 import { type IProps } from '.';
 
@@ -42,15 +42,30 @@ import {
 } from '@onekeyhq/shared/src/routes';
 import { listItemPressStyle } from '@onekeyhq/shared/src/style';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import cacheUtils from '@onekeyhq/shared/src/utils/cacheUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import {
   ESwapSource,
   ESwapTabSwitchType,
 } from '@onekeyhq/shared/types/swap/types';
+import type {
+  IAccountToken,
+  IFetchTokenDetailItem,
+} from '@onekeyhq/shared/types/token';
 
 import ActionBuy from './ActionBuy';
 import { useTokenDetailsContext } from './TokenDetailsContext';
 import { TokenDetailsDeFiBlock } from './TokenDetailsDeFiBlock';
+
+const tokenDetailsCache = new cacheUtils.LRUCache<
+  string,
+  IFetchTokenDetailItem
+>({
+  max: 100,
+  ttl: timerUtils.getTimeDurationMs({ minute: 10 }),
+  ttlAutopurge: true,
+});
 
 function TokenDetailsHeader(props: IProps) {
   const {
@@ -58,6 +73,8 @@ function TokenDetailsHeader(props: IProps) {
     networkId,
     walletId,
     tokenInfo,
+    tokenMap,
+    allowTokenMapAsInitialDetails = true,
     isAllNetworks,
     indexedAccountId,
     isTabView,
@@ -82,6 +99,44 @@ function TokenDetailsHeader(props: IProps) {
   });
 
   const tokenDetailsKey = `${accountId}_${networkId}`;
+  const tokenDetailsCacheKey = `${accountId}_${networkId}_${
+    tokenInfo.address ?? ''
+  }`;
+  const tokenMapKey = (tokenInfo as IAccountToken).$key;
+
+  const cachedTokenDetails = useMemo(() => {
+    const contextTokenDetails = tokenDetailsContext[tokenDetailsKey]?.data;
+    if (contextTokenDetails) {
+      return contextTokenDetails;
+    }
+
+    const memoryCachedTokenDetails =
+      tokenDetailsCache.get(tokenDetailsCacheKey);
+    if (memoryCachedTokenDetails) {
+      return memoryCachedTokenDetails;
+    }
+
+    const tokenFiat =
+      allowTokenMapAsInitialDetails && tokenMapKey
+        ? tokenMap?.[tokenMapKey]
+        : undefined;
+    if (!tokenFiat) {
+      return undefined;
+    }
+
+    return {
+      info: tokenInfo,
+      ...tokenFiat,
+    };
+  }, [
+    tokenDetailsContext,
+    tokenDetailsKey,
+    tokenDetailsCacheKey,
+    allowTokenMapAsInitialDetails,
+    tokenMap,
+    tokenMapKey,
+    tokenInfo,
+  ]);
 
   const { handleOnReceive } = useReceiveToken({
     accountId,
@@ -91,6 +146,18 @@ function TokenDetailsHeader(props: IProps) {
   });
 
   const { isFocused } = useTabIsRefreshingFocused();
+  const tokenDetailsPromiseOptions = useMemo(
+    () => ({
+      watchLoading: true,
+      overrideIsFocused: (isPageFocused: boolean) =>
+        isPageFocused && (isTabView ? isFocused : true),
+      debounced: POLLING_DEBOUNCE_INTERVAL,
+      ...(cachedTokenDetails !== undefined
+        ? { initResult: cachedTokenDetails }
+        : {}),
+    }),
+    [cachedTokenDetails, isFocused, isTabView],
+  );
   const { result: tokenDetailsResult, isLoading: isLoadingTokenDetails } =
     usePromiseResult(
       async () => {
@@ -110,6 +177,7 @@ function TokenDetailsHeader(props: IProps) {
         });
 
         if (!data) {
+          tokenDetailsCache.delete(tokenDetailsCacheKey);
           return undefined;
         }
 
@@ -117,6 +185,7 @@ function TokenDetailsHeader(props: IProps) {
           data.fiatValue = '0';
         }
 
+        tokenDetailsCache.set(tokenDetailsCacheKey, data);
         updateTokenDetails({
           accountId,
           networkId,
@@ -131,24 +200,40 @@ function TokenDetailsHeader(props: IProps) {
         tokenInfo.address,
         updateTokenMetadata,
         updateTokenDetails,
+        tokenDetailsCacheKey,
       ],
-      {
-        watchLoading: true,
-        overrideIsFocused: (isPageFocused) =>
-          isPageFocused && (isTabView ? isFocused : true),
-        debounced: POLLING_DEBOUNCE_INTERVAL,
-      },
+      tokenDetailsPromiseOptions,
     );
 
-  const tokenDetails =
-    tokenDetailsResult ?? tokenDetailsContext[tokenDetailsKey]?.data;
+  const tokenDetails = tokenDetailsResult ?? cachedTokenDetails;
+
+  useEffect(() => {
+    if (!cachedTokenDetails) {
+      return;
+    }
+
+    updateTokenMetadata({
+      price: cachedTokenDetails.price ?? 0,
+      priceChange24h: cachedTokenDetails.price24h ?? 0,
+      coingeckoId:
+        cachedTokenDetails.info?.coingeckoId ?? tokenInfo.coingeckoId ?? '',
+    });
+  }, [cachedTokenDetails, tokenInfo.coingeckoId, updateTokenMetadata]);
 
   const showLoadingState = useMemo(() => {
+    if (tokenDetails) {
+      return false;
+    }
     if (tokenDetailsContext[tokenDetailsKey]?.init) {
       return false;
     }
-    return isLoadingTokenDetails;
-  }, [tokenDetailsContext, tokenDetailsKey, isLoadingTokenDetails]);
+    return isLoadingTokenDetails ?? true;
+  }, [
+    tokenDetails,
+    tokenDetailsContext,
+    tokenDetailsKey,
+    isLoadingTokenDetails,
+  ]);
 
   const { isSoftwareWalletOnlyUser } = useUserWalletProfile();
 

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
@@ -101,7 +101,7 @@ function TokenDetailsHeader(props: IProps) {
   const tokenDetailsKey = `${accountId}_${networkId}`;
   const tokenDetailsCacheKey = `${accountId}_${networkId}_${
     tokenInfo.address ?? ''
-  }`;
+  }_${settings.currencyInfo.id}`;
   const tokenMapKey = (tokenInfo as IAccountToken).$key;
 
   const cachedTokenDetails = useMemo(() => {

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
@@ -208,7 +208,7 @@ function TokenDetailsHeader(props: IProps) {
   const tokenDetails = tokenDetailsResult ?? cachedTokenDetails;
 
   useEffect(() => {
-    if (!cachedTokenDetails) {
+    if (!cachedTokenDetails || tokenDetailsResult) {
       return;
     }
 
@@ -218,7 +218,12 @@ function TokenDetailsHeader(props: IProps) {
       coingeckoId:
         cachedTokenDetails.info?.coingeckoId ?? tokenInfo.coingeckoId ?? '',
     });
-  }, [cachedTokenDetails, tokenInfo.coingeckoId, updateTokenMetadata]);
+  }, [
+    cachedTokenDetails,
+    tokenDetailsResult,
+    tokenInfo.coingeckoId,
+    updateTokenMetadata,
+  ]);
 
   const showLoadingState = useMemo(() => {
     if (tokenDetails) {

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHistory.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHistory.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { SectionList } from '@onekeyhq/components';
 import { useTabIsRefreshingFocused } from '@onekeyhq/components';
@@ -24,10 +24,18 @@ import {
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalAssetDetailRoutes } from '@onekeyhq/shared/src/routes/assetDetails';
+import cacheUtils from '@onekeyhq/shared/src/utils/cacheUtils';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import type { IAccountHistoryTx } from '@onekeyhq/shared/types/history';
 import { EDecodedTxStatus } from '@onekeyhq/shared/types/tx';
 
 import type { IProps } from '.';
+
+const tokenHistoryCache = new cacheUtils.LRUCache<string, IAccountHistoryTx[]>({
+  max: 20,
+  ttl: timerUtils.getTimeDurationMs({ minute: 5 }),
+  ttlAutopurge: true,
+});
 
 function TokenDetailsHistory(props: IProps) {
   const navigation = useAppNavigation();
@@ -52,18 +60,57 @@ function TokenDetailsHistory(props: IProps) {
     }
   }, []);
 
-  const [historyInit, setHistoryInit] = useState(false);
   const { isFocused } = useTabIsRefreshingFocused();
   const [settings] = useSettingsPersistAtom();
   const [{ currencyMap }] = useCurrencyPersistAtom();
   const { updateAddressesInfo, setHasMoreOnChainHistory } =
     useHistoryListActions().current;
+  const historyCacheKey = useMemo(
+    () =>
+      [
+        accountId,
+        networkId,
+        tokenInfo.address ?? '',
+        settings.isFilterScamHistoryEnabled ? '1' : '0',
+        settings.isFilterLowValueHistoryEnabled ? '1' : '0',
+        settings.currencyInfo.id,
+      ].join('_'),
+    [
+      accountId,
+      networkId,
+      tokenInfo.address,
+      settings.isFilterScamHistoryEnabled,
+      settings.isFilterLowValueHistoryEnabled,
+      settings.currencyInfo.id,
+    ],
+  );
+  const cachedHistory = useMemo(
+    () => tokenHistoryCache.get(historyCacheKey),
+    [historyCacheKey],
+  );
+
+  const [historyInit, setHistoryInit] = useState(cachedHistory !== undefined);
+
+  useEffect(() => {
+    setHistoryInit(cachedHistory !== undefined);
+  }, [cachedHistory]);
 
   /**
    * since some tokens are slow to load history,
    * they are loaded separately from the token details
    * so as not to block the display of the top details.
    */
+  const historyPromiseOptions = useMemo(
+    () => ({
+      pollingInterval: POLLING_INTERVAL_FOR_HISTORY,
+      debounced: POLLING_DEBOUNCE_INTERVAL,
+      overrideIsFocused: (isPageFocused: boolean) =>
+        isPageFocused && (isTabView ? isFocused : true),
+      watchLoading: true,
+      ...(cachedHistory !== undefined ? { initResult: cachedHistory } : {}),
+    }),
+    [cachedHistory, isFocused, isTabView],
+  );
   const {
     result: tokenHistory,
     run,
@@ -84,10 +131,11 @@ function TokenDetailsHistory(props: IProps) {
           data: r.addressMap ?? {},
         });
         setHasMoreOnChainHistory(!!r.hasMoreOnChainHistory);
+        tokenHistoryCache.set(historyCacheKey, r.txs ?? []);
         setTimeout(() => {
           recomputeLayout();
         }, 300);
-        return r.txs;
+        return r.txs ?? [];
       } finally {
         setHistoryInit(true);
       }
@@ -103,15 +151,16 @@ function TokenDetailsHistory(props: IProps) {
       updateAddressesInfo,
       setHasMoreOnChainHistory,
       recomputeLayout,
+      historyCacheKey,
     ],
-    {
-      pollingInterval: POLLING_INTERVAL_FOR_HISTORY,
-      debounced: POLLING_DEBOUNCE_INTERVAL,
-      overrideIsFocused: (isPageFocused) =>
-        isPageFocused && (isTabView ? isFocused : true),
-      watchLoading: true,
-    },
+    historyPromiseOptions,
   );
+
+  const resolvedHistory = tokenHistory ?? cachedHistory ?? [];
+  const resolvedIsLoading =
+    !historyInit && cachedHistory === undefined
+      ? (isLoading ?? true)
+      : isLoading;
 
   const handleHistoryItemPress = useCallback(
     async (tx: IAccountHistoryTx) => {
@@ -169,8 +218,8 @@ function TokenDetailsHistory(props: IProps) {
       indexedAccountId={indexedAccountId}
       inTabList={inTabList}
       initialized={historyInit}
-      isLoading={isLoading}
-      data={tokenHistory ?? []}
+      isLoading={resolvedIsLoading}
+      data={resolvedHistory}
       onPressHistory={handleHistoryItemPress}
       ListHeaderComponent={ListHeaderComponent as React.ReactElement}
       isSingleAccount

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/index.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/index.tsx
@@ -68,6 +68,7 @@ import type {
   IAccountToken,
   IFetchTokenDetailItem,
   IToken,
+  ITokenFiat,
 } from '@onekeyhq/shared/types/token';
 
 import {
@@ -88,6 +89,8 @@ export type IProps = {
   networkId: string;
   walletId: string;
   tokenInfo: IToken;
+  tokenMap?: Record<string, ITokenFiat>;
+  allowTokenMapAsInitialDetails?: boolean;
   isBlocked?: boolean;
   riskyTokens?: string[];
   isAllNetworks?: boolean;
@@ -555,6 +558,7 @@ function TokenDetailsView() {
             networkId={token.networkId ?? ''}
             walletId={walletId}
             tokenInfo={token}
+            tokenMap={tokenMap}
             isAllNetworks={isAllNetworks}
             listViewContentContainerStyle={listViewContentContainerStyle}
             indexedAccountId={indexedAccountId}
@@ -585,6 +589,8 @@ function TokenDetailsView() {
               deriveInfo={item.deriveInfo}
               deriveType={item.deriveType}
               tokenInfo={tokenInfo}
+              tokenMap={tokenMap}
+              allowTokenMapAsInitialDetails={false}
               isAllNetworks={isAllNetworks}
               listViewContentContainerStyle={listViewContentContainerStyle}
               indexedAccountId={indexedAccountId}
@@ -600,6 +606,7 @@ function TokenDetailsView() {
             networkId={tokenInfo.networkId ?? ''}
             walletId={walletId}
             tokenInfo={tokenInfo}
+            tokenMap={tokenMap}
             isAllNetworks={isAllNetworks}
             listViewContentContainerStyle={listViewContentContainerStyle}
             indexedAccountId={indexedAccountId}
@@ -620,6 +627,7 @@ function TokenDetailsView() {
     refreshAllNetworkState,
     vaultSettings?.mergeDeriveAssetsEnabled,
     tokenInfo,
+    tokenMap,
     result?.networkAccounts,
     intl,
     uniqueTabNames,
@@ -734,6 +742,7 @@ function TokenDetailsView() {
         networkId={tokenInfo.networkId ?? networkId}
         walletId={walletId}
         tokenInfo={tokenInfo}
+        tokenMap={tokenMap}
         isAllNetworks={isAllNetworks}
         indexedAccountId={indexedAccountId}
         listViewContentContainerStyle={listViewContentContainerStyle}
@@ -746,6 +755,7 @@ function TokenDetailsView() {
     vaultSettings?.mergeDeriveAssetsEnabled,
     tokens,
     tokenInfo,
+    tokenMap,
     accountId,
     networkId,
     isAllNetworks,


### PR DESCRIPTION
## Summary
- Add LRU caching for token details, DeFi earn data, and transaction history to eliminate skeleton flash on remount
- Use tokenMap fiat data as initial display values so token details page shows content immediately instead of a loading state
- Prevent duplicate modal navigation by tracking pending modal targets with a state listener dedup mechanism

## Intent & Context
Token details page was showing unnecessary loading skeletons every time the user scrolled away and back, or re-entered the page. The loading state flickered even when data had been recently fetched. Additionally, duplicate modal screens could be pushed when tapping quickly or when navigation events fired multiple times.

## Root Cause
1. **Loading flash**: Token details, DeFi earn, and history data had no cross-mount caching. Every remount triggered a fresh fetch with full loading state, even if data was just fetched seconds ago.
2. **Missing initial values**: The token details header had no way to use already-available tokenMap fiat data (balance, fiatValue) as placeholder content while the full detail fetch was in-flight.
3. **Duplicate modals**: `pushModal` only checked if the exact same route was the top-most route in the stack, but didn't account for navigations that were already in-flight (pending). Rapid taps or state listener re-fires could push the same modal twice.

## Design Decisions
- **LRU caches with TTL**: Used `cacheUtils.LRUCache` with bounded size (20-100 entries) and TTL (5-10 min) to keep memory usage bounded while providing instant display on remount. This avoids unbounded `Map` growth.
- **tokenMap as initial details**: When cached token details aren't available, fall back to the tokenMap fiat data that's already loaded from the portfolio. This gives the user immediate content instead of a skeleton. Disabled for sub-account tabs (`allowTokenMapAsInitialDetails=false`) to avoid showing parent account data.
- **State listener dedup**: Replaced polling-based duplicate detection with a navigation state listener that tracks pending modal targets. Each pending target is identified by `modalType::route::screen` key and cleared either when the state confirms the modal appeared or after a 1-second timeout.

## Changes Detail
- `useAppNavigation.ts`: Added pending modal target tracking with state listener dedup to prevent duplicate modal pushes
- `TokenDetailsHeader.tsx`: Added LRU cache for token details, use tokenMap as initial values, improved loading state logic
- `TokenDetailsHistory.tsx`: Added LRU cache for transaction history, use cached data as initial render
- `TokenDetailsDeFiBlock.tsx`: Replaced unbounded `Map` cache with LRU cache with TTL
- `TokenDetails/index.tsx`: Pass `tokenMap` and `allowTokenMapAsInitialDetails` props through to sub-components

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Navigation dedup logic could theoretically prevent legitimate rapid navigation to different modals if keys collide (mitigated by including modalType+route+screen in the key). Cache TTL means stale data could briefly show before refresh completes.

## Test plan
- [ ] Open token details page — should show content immediately (no skeleton flash if data was recently viewed)
- [ ] Scroll away from token details tab and scroll back — no loading skeleton
- [ ] Tap a token from portfolio, verify price/balance show immediately from tokenMap
- [ ] Rapidly tap a token or action button — should not open duplicate modals
- [ ] Verify DeFi earn section loads without flash on remount
- [ ] Check transaction history section shows cached data on remount
- [ ] Wait >10 minutes and revisit — should show loading then fresh data (cache expired)
- [ ] Test on iOS, Android, and Extension platforms
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
