### PR TITLE
fix(send): show Recent tab for Lightning, skip amount page for LNURL/Address (OK-52672, OK-52507, OK-52671)

### DIFF
--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -767,11 +767,9 @@ export default function RecipientQuickSelect({
 }: IRecipientQuickSelectProps) {
   const intl = useIntl();
   // Use controlled state from parent if provided, otherwise use local state
-  const isLightningNetwork =
-    networkUtils.isLightningNetworkByNetworkId(networkId);
   const [localActiveTab, setLocalActiveTab] =
     useState<IRecipientQuickSelectTab>(
-      isLightningNetwork || hideTabs?.includes('recent') ? 'account' : 'recent',
+      hideTabs?.includes('recent') ? 'account' : 'recent',
     );
   const activeTab = activeTabProp ?? localActiveTab;
   const setActiveTab = onActiveTabChange ?? setLocalActiveTab;
@@ -884,29 +882,25 @@ export default function RecipientQuickSelect({
 
     const options: { label: string; value: IRecipientQuickSelectTab }[] = [];
 
-    // Lightning invoices are one-time, hide Recent tab to avoid showing them
+    options.push({
+      label: formatLabel(
+        intl.formatMessage({ id: ETranslations.global_recents }),
+        'recent',
+      ),
+      value: 'recent',
+    });
+
     if (!isLightning) {
       options.push({
         label: formatLabel(
-          intl.formatMessage({ id: ETranslations.global_recents }),
-          'recent',
+          intl.formatMessage({
+            id: ETranslations.global_accounts,
+          }),
+          'account',
         ),
-        value: 'recent',
+        value: 'account',
       });
-    }
 
-    options.push({
-      label: formatLabel(
-        intl.formatMessage({
-          id: ETranslations.global_accounts,
-        }),
-        'account',
-      ),
-      value: 'account',
-    });
-
-    // Lightning network doesn't support address book
-    if (!isLightning) {
       options.push({
         label: formatLabel(
           intl.formatMessage({ id: ETranslations.address_book_title }),

--- a/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
@@ -56,6 +56,7 @@ import {
 } from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import hexUtils from '@onekeyhq/shared/src/utils/hexUtils';
+import { isReusableLightningRecipient } from '@onekeyhq/shared/src/utils/lnUrlUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import { EInputAddressChangeType } from '@onekeyhq/shared/types/address';
@@ -377,12 +378,44 @@ function SendDataInputContainer() {
       // Reuse the matching amount-input route for the active modal stack.
       const toVal = form.getValues('to') as IAddressInputValue | undefined;
 
-      // For Lightning invoices, decode the invoice to extract embedded amount
-      let invoiceAmount: string | undefined;
-      let isInvoiceAmountLocked = false;
       const isLightning = networkUtils.isLightningNetworkByNetworkId(
         currentAccount.networkId,
       );
+
+      // For LNURL / Lightning Address, skip amount page — LnurlPayRequestModal
+      // handles amount input, comment, and metadata display (OK-52507, OK-52671).
+      // Must check before invoice decode to avoid passing LNURL to decodedInvoice.
+      const rawInput = (toVal?.raw ?? '').trim();
+      if (isLightning && account && isReusableLightningRecipient(rawInput)) {
+        const transfersInfo: ITransferInfo[] = [
+          {
+            from: account.address,
+            to: rawInput,
+            amount: '0',
+            tokenInfo: tokenInfo ?? undefined,
+          },
+        ];
+        await signatureConfirm.navigationToTxConfirm({
+          transfersInfo,
+          sameModal: true,
+          onSuccess,
+          onFail,
+          onCancel,
+          transferPayload: {
+            amountToSend: '0',
+            isMaxSend: false,
+            isNFT: false,
+            originalRecipient: rawInput,
+            isToContract: false,
+          },
+          isInternalTransfer: true,
+        });
+        return;
+      }
+
+      // For Lightning invoices, decode the invoice to extract embedded amount
+      let invoiceAmount: string | undefined;
+      let isInvoiceAmountLocked = false;
       if (isLightning && toResolved) {
         try {
           const isZeroAmount =
@@ -1106,23 +1139,18 @@ function SendDataInputContainer() {
               />
             ) : null}
             {renderDataInput()}
-            {/* Lightning Network uses invoices/LNURL, not addresses — hide quick select */}
-            {networkUtils.isLightningNetworkByNetworkId(
-              currentAccount.networkId,
-            ) ? null : (
-              <RecipientQuickSelect
-                accountId={currentAccount.accountId}
-                networkId={currentAccount.networkId}
-                senderDeriveType={senderDeriveType}
-                searchKey={toAddressRaw}
-                isSearchMode={!!toAddressRaw?.trim()}
-                activeTab={quickSelectActiveTab}
-                onActiveTabChange={setQuickSelectActiveTab}
-                onInputTypeChange={handleAddressInputChangeType}
-                onMatchStatusChange={setHasQuickSelectMatches}
-                onSelect={handleQuickSelectRecipient}
-              />
-            )}
+            <RecipientQuickSelect
+              accountId={currentAccount.accountId}
+              networkId={currentAccount.networkId}
+              senderDeriveType={senderDeriveType}
+              searchKey={toAddressRaw}
+              isSearchMode={!!toAddressRaw?.trim()}
+              activeTab={quickSelectActiveTab}
+              onActiveTabChange={setQuickSelectActiveTab}
+              onInputTypeChange={handleAddressInputChangeType}
+              onMatchStatusChange={setHasQuickSelectMatches}
+              onSelect={handleQuickSelectRecipient}
+            />
           </Form>
         </AccountSelectorProviderMirror>
       </Page.Body>

--- a/packages/kit/src/views/Send/pages/SendDataInput/useRecentRecipientsData.ts
+++ b/packages/kit/src/views/Send/pages/SendDataInput/useRecentRecipientsData.ts
@@ -6,6 +6,7 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import type { IAddressQueryResult } from '@onekeyhq/kit/src/components/AddressInput';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { checkIsScamTx } from '@onekeyhq/shared/src/utils/historyUtils';
+import { isReusableLightningRecipient } from '@onekeyhq/shared/src/utils/lnUrlUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import type {
   IAccountHistoryTx,
@@ -385,6 +386,15 @@ export function useRecentRecipientsData({
           } catch {
             recipientAddresses = [];
           }
+        }
+
+        // For Lightning, filter out one-time invoices before querying addresses
+        const isLightning =
+          networkUtils.isLightningNetworkByNetworkId(networkId);
+        if (isLightning) {
+          recipientAddresses = recipientAddresses.filter((addr) =>
+            isReusableLightningRecipient(addr),
+          );
         }
 
         const addressInfoResults = await Promise.all(

--- a/packages/shared/src/utils/lnUrlUtils.ts
+++ b/packages/shared/src/utils/lnUrlUtils.ts
@@ -73,3 +73,8 @@ export const findLnurl = memoizee(
     maxAge: timerUtils.getTimeDurationMs({ seconds: 10 }),
   },
 );
+
+export const isReusableLightningRecipient = (input?: string): boolean => {
+  if (!input) return false;
+  return isLightningAddress(input) || !!findLnurl(input);
+};


### PR DESCRIPTION
## Summary

- Restore `RecipientQuickSelect` for Lightning network send flow — it was completely hidden
- Show only the **Recent** tab for Lightning (Accounts and AddressBook tabs hidden)
- Filter out one-time raw invoices (`lnbc1...`) before `queryAddress` API calls, keeping only reusable recipients (LNURL and Lightning Address)
- **Skip SendAmountInput for LNURL / Lightning Address** — go directly to LnurlPayRequestModal which already handles amount input, comment, and metadata display
- **Fix LNURL decode error** — check LNURL before invoice decode to avoid passing LNURL strings to `decodedInvoice`
- Add shared `isReusableLightningRecipient()` utility in `lnUrlUtils.ts`

## Flow Changes

### LNURL / Lightning Address (before → after)
```
Before: SendDataInput → SendAmountInput (decode error) → LnurlPayRequestModal → TxConfirm
After:  SendDataInput → LnurlPayRequestModal (amount + comment) → TxConfirm
```

### Lightning Invoice (unchanged)
- Fixed-amount: `SendDataInput → TxConfirm` (skips amount page)
- Zero-amount: `SendDataInput → SendAmountInput → TxConfirm`

## Changes

| File | Change |
|------|--------|
| `SendDataInputContainer.tsx` | Remove Lightning guard on RecipientQuickSelect; detect LNURL before invoice decode; skip SendAmountInput for LNURL/Address |
| `RecipientQuickSelect.tsx` | Always show Recent tab; hide Accounts + AddressBook for Lightning |
| `useRecentRecipientsData.ts` | Pre-filter invoices for Lightning before `queryAddress` calls |
| `lnUrlUtils.ts` | New `isReusableLightningRecipient` combining `isLightningAddress` + `findLnurl` |

## Test plan

- [ ] LNURL send: address input → Next → goes directly to LnurlPayRequestModal (no SendAmountInput, no decode error)
- [ ] Lightning Address send: same as above
- [ ] Lightning invoice (fixed-amount): skips amount page, goes to TxConfirm
- [ ] Lightning invoice (zero-amount): shows SendAmountInput as before
- [ ] Lightning Recent tab: shows LNURL/Lightning Address recipients, not raw invoices
- [ ] Lightning Recent tab: empty state when no reusable recipients
- [ ] Non-Lightning send: all tabs and flow unchanged