### PR TITLE
fix(send): add derive type switcher for BTC/LTC in Accounts tab (OK-52678)

### DIFF
--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -427,7 +427,12 @@ function AccountRecipients({
 
       // Filter accounts by selected derive type (for multi-derive chains)
       const walletId = group?.walletId ?? '';
-      const activeDeriveType = walletDeriveType[walletId] ?? senderDeriveType;
+      const rawDeriveType = walletDeriveType[walletId] ?? senderDeriveType;
+      // Validate against available options; fall back to first option if not found
+      const activeDeriveType =
+        rawDeriveType && deriveTypeMap.has(rawDeriveType)
+          ? rawDeriveType
+          : deriveTypeOptions[0]?.deriveType;
       let filteredAccounts = allAccounts;
       if (hasMultipleDeriveTypes && activeDeriveType) {
         const filtered = allAccounts.filter(

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -5,12 +5,12 @@ import { useIntl } from 'react-intl';
 import Animated, { FadeIn } from 'react-native-reanimated';
 
 import {
+  ActionList,
   Badge,
+  Button,
   Empty,
-  Icon,
   MatchSizeableText,
   SegmentControl,
-  SizableText,
   Stack,
   XStack,
   YStack,
@@ -239,6 +239,12 @@ function AccountRecipients({
           return [];
         }
 
+        const vaultSettings =
+          await backgroundApiProxy.serviceNetwork.getVaultSettings({
+            networkId,
+          });
+        const showAllDeriveTypes = !!vaultSettings?.mergeDeriveAssetsEnabled;
+
         // Fetch wallets, filter non-backed-up, include accounts
         const { wallets } = await backgroundApiProxy.serviceAccount.getWallets({
           ignoreEmptySingletonWalletAccounts: true,
@@ -255,9 +261,11 @@ function AccountRecipients({
           (wallet: IDBWallet, walletName: string) =>
           async (): Promise<IWalletGroup | null> => {
             let accounts = await getWalletNetworkAccounts(wallet, networkId);
-            // Filter by sender's derive type to avoid showing duplicate accounts
-            // (e.g. bip44 + ledger-live for same indexed account on EVM)
-            if (senderDeriveType) {
+            // For chains with multiple derive types (BTC/LTC), keep all
+            // accounts so users can switch derive type via header menu.
+            // For other chains, filter by sender's derive type to avoid
+            // showing duplicates (e.g. bip44 + ledger-live on EVM).
+            if (senderDeriveType && !showAllDeriveTypes) {
               const filtered = accounts.filter(
                 (a) => !a.deriveType || a.deriveType === senderDeriveType,
               );
@@ -375,21 +383,6 @@ function AccountRecipients({
     return [...nameMatchedGroups, ...addressOnlyGroups];
   }, [walletGroups, isSearchActive, searchValue]);
 
-  // Notify parent of match status and count
-  const accountMatchCount = useMemo(
-    () =>
-      filteredWalletGroups.reduce(
-        (sum, group) => sum + (group?.accounts?.length ?? 0),
-        0,
-      ),
-    [filteredWalletGroups],
-  );
-  useEffect(() => {
-    // Skip reporting stale counts during debounce gap to prevent badge flickering
-    if (isDebouncing) return;
-    onMatchStatusChange?.(accountMatchCount > 0, accountMatchCount);
-  }, [accountMatchCount, onMatchStatusChange, isDebouncing]);
-
   // Handle account selection
   const handleSelectAccount = useCallback(
     (item: IAccountWithDeriveInfo) => {
@@ -402,17 +395,10 @@ function AccountRecipients({
     [onInputTypeChange, onSelect],
   );
 
-  // Get derive type label
-  const getDeriveLabel = useCallback(
-    (deriveInfo?: IAccountDeriveInfo) => {
-      if (!deriveInfo) return undefined;
-      if (deriveInfo.labelKey) {
-        return intl.formatMessage({ id: deriveInfo.labelKey });
-      }
-      return deriveInfo.label;
-    },
-    [intl],
-  );
+  // Derive type selection per wallet group (for BTC/LTC multi-derive chains)
+  const [walletDeriveType, setWalletDeriveType] = useState<
+    Record<string, string>
+  >({});
 
   // Convert wallet groups to sections format for SectionList
   const sections = useMemo(() => {
@@ -420,33 +406,74 @@ function AccountRecipients({
       return [];
     }
     return filteredWalletGroups.map((group) => {
-      // Check if this wallet group has multiple derive types
-      const accounts = group?.accounts ?? [];
-      const deriveTypes = new Set(
-        accounts
-          .map((item) => item.deriveInfo?.label || item.deriveInfo?.labelKey)
-          .filter(Boolean),
-      );
-      const hasMultipleDeriveTypes = deriveTypes.size > 1;
+      const allAccounts = group?.accounts ?? [];
+
+      // Collect unique derive types for this wallet group
+      const deriveTypeMap = new Map<
+        string,
+        { label: string; deriveType: string }
+      >();
+      for (const item of allAccounts) {
+        const dt = item.deriveType;
+        if (dt && !deriveTypeMap.has(dt)) {
+          const label = item.deriveInfo?.labelKey
+            ? intl.formatMessage({ id: item.deriveInfo.labelKey })
+            : (item.deriveInfo?.label ?? dt);
+          deriveTypeMap.set(dt, { label, deriveType: dt });
+        }
+      }
+      const deriveTypeOptions = Array.from(deriveTypeMap.values());
+      const hasMultipleDeriveTypes = deriveTypeOptions.length > 1;
+
+      // Filter accounts by selected derive type (for multi-derive chains)
+      const walletId = group?.walletId ?? '';
+      const activeDeriveType = walletDeriveType[walletId] ?? senderDeriveType;
+      let filteredAccounts = allAccounts;
+      if (hasMultipleDeriveTypes && activeDeriveType) {
+        const filtered = allAccounts.filter(
+          (a) => !a.deriveType || a.deriveType === activeDeriveType,
+        );
+        if (filtered.length > 0) {
+          filteredAccounts = filtered;
+        }
+      }
 
       return {
         title: group?.walletName ?? '',
-        walletId: group?.walletId ?? '',
+        walletId,
         wallet: group?.wallet,
         hasMultipleDeriveTypes,
-        data: accounts,
+        deriveTypeOptions,
+        activeDeriveType,
+        data: filteredAccounts,
       };
     });
-  }, [filteredWalletGroups]);
+  }, [filteredWalletGroups, walletDeriveType, senderDeriveType, intl]);
+
+  // Count visible accounts (after derive type filtering)
+  const accountMatchCount = useMemo(
+    () => sections.reduce((sum, s) => sum + (s.data?.length ?? 0), 0),
+    [sections],
+  );
+
+  useEffect(() => {
+    if (isDebouncing) return;
+    onMatchStatusChange?.(accountMatchCount > 0, accountMatchCount);
+  }, [accountMatchCount, onMatchStatusChange, isDebouncing]);
 
   // Flatten sections for simple rendering with section headers
   type IFlatItem =
-    | { type: 'header'; title: string; walletId: string }
+    | {
+        type: 'header';
+        title: string;
+        walletId: string;
+        hasMultipleDeriveTypes: boolean;
+        deriveTypeOptions: { label: string; deriveType: string }[];
+        activeDeriveType?: string;
+      }
     | {
         type: 'account';
         account: INetworkAccount;
-        deriveInfo?: IAccountDeriveInfo;
-        hasMultipleDeriveTypes: boolean;
         walletId: string;
         walletName: string;
         wallet?: IDBWallet;
@@ -462,6 +489,9 @@ function AccountRecipients({
             type: 'header',
             title: section.title,
             walletId: section.walletId,
+            hasMultipleDeriveTypes: section.hasMultipleDeriveTypes,
+            deriveTypeOptions: section.deriveTypeOptions,
+            activeDeriveType: section.activeDeriveType,
           });
         }
         // Add account items
@@ -469,8 +499,6 @@ function AccountRecipients({
           items.push({
             type: 'account',
             account: item.account,
-            deriveInfo: item.deriveInfo,
-            hasMultipleDeriveTypes: section.hasMultipleDeriveTypes,
             walletId: section.walletId,
             walletName: section.title,
             wallet: section.wallet,
@@ -521,6 +549,9 @@ function AccountRecipients({
         // Render section header with collapse toggle
         if (item.type === 'header') {
           const isCollapsed = !!collapsedWallets[item.walletId];
+          const activeLabel = item.deriveTypeOptions.find(
+            (o) => o.deriveType === item.activeDeriveType,
+          )?.label;
           return (
             <XStack
               key={`header-${item.walletId}`}
@@ -528,28 +559,45 @@ function AccountRecipients({
               pt="$4"
               pb="$2"
               alignItems="center"
-              onPress={() => toggleCollapse(item.walletId)}
-              cursor="pointer"
-              hoverStyle={{ opacity: 0.7 }}
+              gap="$4"
             >
-              <SizableText
-                size="$headingXs"
-                color="$textSubdued"
-                numberOfLines={1}
-                flexShrink={1}
-              >
-                {item.title}
-              </SizableText>
-              <Icon
-                name={
+              <Button
+                size="small"
+                variant="tertiary"
+                onPress={() => toggleCollapse(item.walletId)}
+                iconAfter={
                   isCollapsed
                     ? 'ChevronRightSmallOutline'
                     : 'ChevronDownSmallOutline'
                 }
-                size="$4.5"
-                color="$iconSubdued"
-                ml="$1"
-              />
+              >
+                {item.title}
+              </Button>
+              {item.hasMultipleDeriveTypes ? (
+                <ActionList
+                  title={intl.formatMessage({
+                    id: ETranslations.address_type_selector_title,
+                  })}
+                  items={item.deriveTypeOptions.map((option) => ({
+                    label: option.label,
+                    onPress: () => {
+                      setWalletDeriveType((prev) => ({
+                        ...prev,
+                        [item.walletId]: option.deriveType,
+                      }));
+                    },
+                  }))}
+                  renderTrigger={
+                    <Button
+                      size="small"
+                      variant="tertiary"
+                      iconAfter="ChevronDownSmallSolid"
+                    >
+                      {activeLabel ?? ''}
+                    </Button>
+                  }
+                />
+              ) : null}
             </XStack>
           );
         }
@@ -563,20 +611,9 @@ function AccountRecipients({
         if (!item.account) {
           return null;
         }
-        const {
-          account,
-          deriveInfo,
-          hasMultipleDeriveTypes,
-          walletId,
-          wallet,
-        } = item;
+        const { account, walletId, wallet } = item;
         const itemAddress =
           account.address ?? account.addressDetail?.address ?? '';
-        // Show derive label only when multiple derive types exist in this group
-        // (after filtering by senderDeriveType, usually only one type remains)
-        const deriveLabel = hasMultipleDeriveTypes
-          ? getDeriveLabel(deriveInfo)
-          : undefined;
         const itemKey = `${account.id ?? 'no-id'}-${itemAddress}`;
 
         // Wallet name is already shown in the section header, only show account name
@@ -592,11 +629,10 @@ function AccountRecipients({
               address: itemAddress || account.id || '',
               // Only show address in secondary text when it's a real address
               displayAddress: itemAddress,
-              deriveLabel,
               walletId,
               wallet,
             }}
-            onPress={() => handleSelectAccount({ account, deriveInfo })}
+            onPress={() => handleSelectAccount({ account })}
           />
         );
       })}


### PR DESCRIPTION
## Summary

For BTC/LTC and other chains with multiple derivation paths, the Accounts tab in send flow now includes a derive type switcher next to each wallet group header, allowing users to select addresses from different paths (Native SegWit / SegWit / Legacy).

## Changes

- Detect `mergeDeriveAssetsEnabled` chains via `getVaultSettings`
- Load all derive type accounts (skip `senderDeriveType` filter for these chains)
- Add per-wallet-group derive type state with `ActionList` switcher in header
- Filter displayed accounts by selected derive type
- Unify wallet collapse toggle and derive type button to same `Button variant="tertiary"` style
- Remove redundant `deriveLabel` from account items (header shows active type)

## Test plan

- [ ] BTC send → Accounts tab → derive type switcher visible, switch between Native SegWit / SegWit / Legacy
- [ ] LTC send → same behavior
- [ ] EVM send → no derive type switcher, behavior unchanged
- [ ] Select account after switching derive type → correct address filled
- [ ] Wallet collapse/expand still works alongside derive type switcher
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
