### PR TITLE
chore: upgrade agentation from v2.3.3 to v3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -286,7 +286,7 @@
     "@typescript-eslint/eslint-plugin": "^8.4.0",
     "@typescript-eslint/parser": "^8.4.0",
     "@typescript/native-preview": "^7.0.0-dev.20260127.1",
-    "agentation": "^2.3.3",
+    "agentation": "^3.0.2",
     "axios": "^1.13.2",
     "babel-loader": "^9.1.3",
     "babel-plugin-catch-logger": "0.1.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9275,7 +9275,7 @@ __metadata:
     "@wagmi/core": "npm:2.21.0"
     "@walletconnect/sign-client": "npm:2.21.9"
     "@walletconnect/universal-provider": "npm:2.21.9"
-    agentation: "npm:^2.3.3"
+    agentation: "npm:^3.0.2"
     allotment: "npm:^1.20.5"
     array.prototype.toreversed: "npm:^1.1.2"
     axios: "npm:^1.13.2"
@@ -20387,9 +20387,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agentation@npm:^2.3.3":
-  version: 2.3.3
-  resolution: "agentation@npm:2.3.3"
+"agentation@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "agentation@npm:3.0.2"
   peerDependencies:
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
@@ -20398,7 +20398,7 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 10/c7c0af104ea3b2b4c34eaef0253aae3324ceb971f9ee30f35f31045ddd73660c3021349fc0be7abef05a4bbd5bcf1460d8c9532e6b98217d29be0de0e34d22ec
+  checksum: 10/91f3ed9dadce95ca389ffb74656d0e3cd04a9683b075b2152a4e43dfff5f90b0a1d27d1425298ec92eda270a792e2fd6f3c3b72c8b12d596a5fa6c46e1750a8e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Upgrade `agentation` dev dependency from `^2.3.3` to `^3.0.2` (major version bump)

## Intent & Context
Routine dev dependency upgrade. Agentation is a visual feedback tool used only in web dev mode (`apps/web/App.tsx`) for annotating UI elements during development. The v3 release adds Layout Mode (drag-and-drop component placement, wireframing) and improves CSS specificity handling with `:where()`.

## Design Decisions
- Direct major version bump is safe because the package is only used as a lazy-loaded dev tool in the web app, and the public API (`Agentation` component export) remains unchanged.
- No code changes needed — `peerDependencies`, `exports`, `main`, and `types` are identical between v2 and v3.

## Changes Detail
- `package.json`: bump `agentation` version range
- `yarn.lock`: updated lockfile entries

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Web (dev mode only)
- **Risk Areas**: None — dev-only dependency with no production impact

## Test plan
- [ ] Run `yarn app:web` and verify the Agentation toolbar loads correctly in dev mode
- [ ] Verify Layout Mode (press L) works in the Agentation overlay
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
