### PR TITLE
fix: prevent Prime 'Coming Soon' badge clipping on narrow screens(OK-52528)

### DIFF
--- a/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeBenefitsList.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeBenefitsList.tsx
@@ -83,12 +83,17 @@ function PrimeBenefitsItem({
           userSelect="none"
           flex={1}
           primary={
-            <XStack>
-              <SizableText textAlign="left" size="$bodyLgMedium">
+            <XStack alignItems="center">
+              <SizableText
+                textAlign="left"
+                size="$bodyLgMedium"
+                flexShrink={1}
+                numberOfLines={1}
+              >
                 {title}
               </SizableText>
               {isComingSoon ? (
-                <Badge ml="$2" badgeSize="sm">
+                <Badge ml="$2" badgeSize="sm" flexShrink={0}>
                   <Badge.Text>
                     {intl.formatMessage({
                       id: ETranslations.id_prime_soon,


### PR DESCRIPTION
## Summary
- Fix the "Coming Soon" (即将推出) badge being clipped or distorted on narrow screens (iPhone SE) for longer translations (Spanish, French, Indonesian, Portuguese, Russian)
- Add `flexShrink={1}` and `numberOfLines={1}` to the title text so it truncates instead of pushing the badge off-screen
- Add `flexShrink={0}` on the Badge to prevent it from being compressed
- Follows the same pattern used in the menu display name + Prime badge (`MoreActionButton`)

## Test plan
- [ ] Verify on iPhone SE (narrow screen) with affected languages: es, fr, id, pt, pt-BR, ru
- [ ] Confirm badge displays fully without clipping or border distortion
- [ ] Confirm title truncates with ellipsis when too long
- [ ] Verify no regression on wider screens
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
