### PR TITLE
feat: add data tracking for changelog and WhatsNew pages (OK-42586)

### DIFF
--- a/packages/kit/src/views/AppUpdate/components/UpdatePreviewActionButton/index.ext.tsx
+++ b/packages/kit/src/views/AppUpdate/components/UpdatePreviewActionButton/index.ext.tsx
@@ -3,6 +3,7 @@ import { useIntl } from 'react-intl';
 import { Page } from '@onekeyhq/components';
 import { useHelpLink } from '@onekeyhq/kit/src/hooks/useHelpLink';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 
 import type { IUpdatePreviewActionButton } from './type';
@@ -16,6 +17,9 @@ export const UpdatePreviewActionButton: IUpdatePreviewActionButton = () => {
     <Page.Footer
       confirmButtonProps={{
         onPress: () => {
+          defaultLogger.app.appUpdate.changelogUpdateClicked({
+            action: 'helpLink',
+          });
           openUrlExternal(helpLink);
         },
         iconAfter: 'ArrowTopRightOutline',

--- a/packages/kit/src/views/AppUpdate/components/UpdatePreviewActionButton/index.tsx
+++ b/packages/kit/src/views/AppUpdate/components/UpdatePreviewActionButton/index.tsx
@@ -14,8 +14,8 @@ import {
   EUpdateFileType,
   getUpdateFileType,
 } from '@onekeyhq/shared/src/appUpdate';
-import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EAppUpdateRoutes } from '@onekeyhq/shared/src/routes/appUpdate';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 

--- a/packages/kit/src/views/AppUpdate/components/UpdatePreviewActionButton/index.tsx
+++ b/packages/kit/src/views/AppUpdate/components/UpdatePreviewActionButton/index.tsx
@@ -14,6 +14,7 @@ import {
   EUpdateFileType,
   getUpdateFileType,
 } from '@onekeyhq/shared/src/appUpdate';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { EAppUpdateRoutes } from '@onekeyhq/shared/src/routes/appUpdate';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
@@ -43,6 +44,9 @@ export const UpdatePreviewActionButton: IUpdatePreviewActionButton = ({
 
   const handleToUpdate: IPageFooterProps['onConfirm'] = useCallback(() => {
     if (appUpdateInfo.data) {
+      defaultLogger.app.appUpdate.changelogUpdateClicked({
+        action: shouldOpenStore ? 'store' : 'download',
+      });
       if (shouldOpenStore && appUpdateInfo.data.storeUrl) {
         openUrlExternal(appUpdateInfo.data.storeUrl);
       } else if (

--- a/packages/kit/src/views/AppUpdate/pages/UpdatePreview.tsx
+++ b/packages/kit/src/views/AppUpdate/pages/UpdatePreview.tsx
@@ -18,8 +18,8 @@ import {
   displayAppUpdateVersion,
 } from '@onekeyhq/shared/src/appUpdate';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type {
   EAppUpdateRoutes,
   IAppUpdatePagesParamList,

--- a/packages/kit/src/views/AppUpdate/pages/UpdatePreview.tsx
+++ b/packages/kit/src/views/AppUpdate/pages/UpdatePreview.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { usePreventRemove } from '@react-navigation/core';
 import { useIntl } from 'react-intl';
@@ -19,6 +19,7 @@ import {
 } from '@onekeyhq/shared/src/appUpdate';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import type {
   EAppUpdateRoutes,
   IAppUpdatePagesParamList,
@@ -72,6 +73,17 @@ function UpdatePreview({
     : isForceUpdateParam;
   const changeLog = updateInfo?.changeLog;
   usePreventRemove(!!isForceUpdate, () => {});
+
+  const hasLoggedRef = useRef(false);
+  useEffect(() => {
+    if (updateInfo?.latestVersion && !hasLoggedRef.current) {
+      hasLoggedRef.current = true;
+      defaultLogger.app.appUpdate.changelogViewed({
+        toVersion: updateInfo.latestVersion,
+        isForceUpdate: !!isForceUpdate,
+      });
+    }
+  }, [updateInfo?.latestVersion, isForceUpdate]);
 
   const headerProps = useMemo(() => {
     const props: { title: string; headerLeft?: () => ReactNode } = {

--- a/packages/kit/src/views/AppUpdate/pages/WhatsNew.tsx
+++ b/packages/kit/src/views/AppUpdate/pages/WhatsNew.tsx
@@ -1,10 +1,11 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { useIntl } from 'react-intl';
 
 import { Markdown, Page, ScrollView } from '@onekeyhq/components';
 import { displayWhatsNewVersion } from '@onekeyhq/shared/src/appUpdate';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import { useAppChangeLog } from '../../../components/UpdateReminder/hooks';
@@ -15,6 +16,16 @@ function WhatsNew() {
   const intl = useIntl();
   const changeLog = useAppChangeLog();
   const navigation = useAppNavigation();
+  const mountTimeRef = useRef(Date.now());
+
+  useEffect(() => {
+    const mountTime = mountTimeRef.current;
+    return () => {
+      defaultLogger.app.appUpdate.whatsNewClosed({
+        durationMs: Date.now() - mountTime,
+      });
+    };
+  }, []);
   const handleClose = useCallback(() => {
     setTimeout(() => {
       void backgroundApiProxy.serviceAppUpdate.fetchAppUpdateInfo(true);

--- a/packages/shared/src/logger/scopes/app/scenes/appUpdate.ts
+++ b/packages/shared/src/logger/scopes/app/scenes/appUpdate.ts
@@ -359,6 +359,29 @@ export class AppUpdateScene extends BaseScene {
     return { ...payload, level };
   }
 
+  @LogToServer()
+  @LogToLocal()
+  public changelogViewed(params: {
+    toVersion: string;
+    isForceUpdate: boolean;
+  }) {
+    return params;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  public changelogUpdateClicked(params: {
+    action: 'store' | 'download' | 'helpLink';
+  }) {
+    return params;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  public whatsNewClosed(params: { durationMs: number }) {
+    return params;
+  }
+
   @LogToLocal({ level: 'info' })
   public log(message: string) {
     return message;


### PR DESCRIPTION
## Summary
- Add 3 Mixpanel tracking events to the app update changelog flow:
  - `changelogViewed` — fires when UpdatePreview page opens (with `toVersion`, `isForceUpdate`)
  - `changelogUpdateClicked` — fires when user taps the update button (with `action`: store/download/helpLink)
  - `whatsNewClosed` — fires when WhatsNew page closes (with `durationMs`)
- Covers all platforms: mobile (store), desktop (download), extension (helpLink)

## Test plan
- [ ] With an available update, open UpdatePreview → verify `changelogViewed` event in Mixpanel
- [ ] Tap update button → verify `changelogUpdateClicked` with correct `action` per platform
- [ ] After update, close WhatsNew → verify `whatsNewClosed` with reasonable `durationMs`
- [ ] Force update scenario → verify `isForceUpdate = true` in `changelogViewed`
- [ ] Staying on UpdatePreview without action should not fire duplicate events
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
