### PR TITLE
fix(send): skip allowlist prompt for own wallet accounts (OK-52726)

### DIFF
--- a/packages/kit-bg/src/services/ServiceAccountProfile.ts
+++ b/packages/kit-bg/src/services/ServiceAccountProfile.ts
@@ -422,7 +422,7 @@ class ServiceAccountProfile extends ServiceBase {
       }
     }
 
-    if (enableWalletName && resolveAddress) {
+    if ((enableWalletName || enableAllowListValidation) && resolveAddress) {
       let walletAccountItems: {
         walletName: string;
         accountName: string;

--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -864,6 +864,7 @@ function SendAmountInputContainer() {
         enableAddressBook: true,
         enableAddressContract: true,
         enableVerifySendFundToSelf: true,
+        enableWalletName: true,
         enableAllowListValidation,
         ignoreSimilarAddressInAddressBook: true,
         enableCheckSimilarAddressInAddressBook: true,


### PR DESCRIPTION
## Summary
- Add `enableWalletName: true` to the `queryAddress` call in SendAmountInput page
- This allows the allowlist validation to detect own wallet accounts and skip the "add to address book" prompt

**Root cause**: `ServiceAccountProfile.queryAddress` already has logic to skip the allowlist check for own accounts (`isOwnAccount`), but it depends on `walletAccountId` being populated. The `walletAccountId` is only set when `enableWalletName` is true. The SendAmountInput page was missing this flag, so own wallet accounts were treated as unknown addresses.

## Jira
OK-52726

## Test plan
- [ ] Enable transfer allowlist in Settings > Protection
- [ ] Send to an address that belongs to your own HD/HW wallet
- [ ] Verify no "add to address book" prompt appears
- [ ] Send to an external address not in address book
- [ ] Verify the allowlist prompt still works correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
