### PR TITLE
fix: move favorite star button next to token icon on desktop

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeader.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeader.tsx
@@ -8,11 +8,9 @@ import {
   XStack,
   useMedia,
 } from '@onekeyhq/components';
-import { EWatchlistFrom } from '@onekeyhq/shared/src/logger/scopes/dex';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 
-import { MarketStarV2 } from '../../../components/MarketStarV2';
 import { useTokenDetail } from '../../hooks/useTokenDetail';
 
 import { ShareButton } from './ShareButton';
@@ -26,7 +24,6 @@ import type {
 } from 'react-native';
 
 const SCROLL_THRESHOLD = 2;
-const SCROLL_BREAKPOINT = 720;
 
 export function TokenDetailHeader({
   showStats = true,
@@ -39,40 +36,26 @@ export function TokenDetailHeader({
 }) {
   const { lg, md } = useMedia();
   const { tokenDetail, networkId, isNative, isStockToken } = useTokenDetail();
-  const [containerWidth, setContainerWidth] = useState(0);
   const [scrollX, setScrollX] = useState(0);
   const [scrollViewWidth, setScrollViewWidth] = useState(0);
   const [contentWidth, setContentWidth] = useState(0);
-
-  const shouldScroll = useMemo(() => {
-    if (!containerWidth) {
-      return false;
-    }
-    return containerWidth < SCROLL_BREAKPOINT;
-  }, [containerWidth]);
 
   const networkData = useMemo(() => {
     return networkId ? networkUtils.getLocalNetworkInfo(networkId) : undefined;
   }, [networkId]);
 
   const shouldShowRightGradient = useMemo(() => {
-    if (!shouldScroll) {
-      return false;
-    }
     return (
       contentWidth > scrollViewWidth &&
       scrollX < contentWidth - scrollViewWidth - SCROLL_THRESHOLD
     );
-  }, [contentWidth, scrollViewWidth, scrollX, shouldScroll]);
+  }, [contentWidth, scrollViewWidth, scrollX]);
 
   const handleScroll = useCallback(
     (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-      if (!shouldScroll) {
-        return;
-      }
       setScrollX(event.nativeEvent.contentOffset.x);
     },
-    [shouldScroll],
+    [],
   );
 
   const handleLayout = useCallback((event: LayoutChangeEvent) => {
@@ -81,10 +64,6 @@ export function TokenDetailHeader({
 
   const handleContentSizeChange = useCallback((width: number) => {
     setContentWidth(width);
-  }, []);
-
-  const handleContainerLayout = useCallback((event: LayoutChangeEvent) => {
-    setContainerWidth(event.nativeEvent.layout.width);
   }, []);
 
   const renderHeaderContent = () => (
@@ -97,7 +76,6 @@ export function TokenDetailHeader({
       jc="flex-start"
       ai="center"
       gap="$6"
-      minWidth={SCROLL_BREAKPOINT}
       {...containerProps}
     >
       <TokenDetailHeaderLeft
@@ -118,28 +96,16 @@ export function TokenDetailHeader({
         />
       )}
 
-      {/* Spacer to push buttons to the right */}
-      {!platformEnv.isNative && !md && networkId ? (
+      {/* Share button pushed to the right on desktop */}
+      {!platformEnv.isNative && !md && networkId && isNative ? (
         <>
           <Stack flex={1} />
-          <XStack gap="$3" ai="center">
-            <MarketStarV2
-              chainId={networkId}
-              contractAddress={tokenDetail?.address ?? ''}
-              size="medium"
-              from={EWatchlistFrom.Detail}
-              tokenSymbol={tokenDetail?.symbol ?? ''}
-              isNative={isNative}
-            />
-            {isNative ? (
-              <ShareButton
-                networkId={networkId}
-                address={tokenDetail?.address ?? ''}
-                isNative={isNative}
-                useIconButton
-              />
-            ) : null}
-          </XStack>
+          <ShareButton
+            networkId={networkId}
+            address={tokenDetail?.address ?? ''}
+            isNative={isNative}
+            useIconButton
+          />
         </>
       ) : null}
     </XStack>
@@ -148,11 +114,10 @@ export function TokenDetailHeader({
   return (
     <XStack
       position="relative"
-      onLayout={handleContainerLayout}
       borderBottomWidth="$px"
       borderBottomColor="$borderSubdued"
     >
-      {shouldScroll && !platformEnv.isNative && !md ? (
+      {!platformEnv.isNative && !md ? (
         <>
           <ScrollView
             horizontal

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx
@@ -122,7 +122,10 @@ export function TokenDetailHeaderLeft({
             fallbackIcon="CryptoCoinOutline"
           />
         ) : (
-          <MarketTokenSelector />
+          <>
+            {marketStar}
+            <MarketTokenSelector />
+          </>
         )}
 
         <YStack>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenSelector/MarketTokenSelector.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenSelector/MarketTokenSelector.tsx
@@ -212,8 +212,12 @@ function BaseMarketTokenSelector() {
             gap="$2"
             alignItems="center"
             cursor="pointer"
-            hoverStyle={{ opacity: 0.8 }}
-            pressStyle={{ opacity: 0.6 }}
+            bg="$bgApp"
+            px="$2"
+            py="$1.5"
+            borderRadius="$full"
+            hoverStyle={{ bg: '$bgHover' }}
+            pressStyle={{ bg: '$bgActive' }}
           >
             <Token
               size="md"


### PR DESCRIPTION
https://onekeyhq.atlassian.net/browse/OK-52686
## Summary
- Move the star/favorite button from the right side to left of the token logo on desktop/web market token detail page
- Always wrap header content in horizontal ScrollView on desktop to prevent overlapping with the trading panel when window is narrowed
- Add pill-style hover/press background to MarketTokenSelector, matching PerpTokenSelector style

## Test plan
- [ ] Desktop/Web large screen: verify star button appears to the left of token logo
- [ ] Desktop/Web narrow window: verify header scrolls horizontally without overlapping the trading panel
- [ ] Desktop/Web hover on token selector: verify pill background highlight effect
- [ ] Mobile: verify star and share button positions unchanged (still on right side)
- [ ] Native token (e.g. ETH) detail page: verify right-side ShareButton still shows
- [ ] Non-native token (ERC20) detail page: verify ShareButton in social links area works
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
