### PR TITLE
fix: standardize build number logic in daily-build and dev env

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -57,10 +57,10 @@ jobs:
       - name: 'Setup ENV'
         run: |
           echo "Executed at: $(date '+%Y-%m-%d %H:%M:%S')"
-          DATE=`date "+%Y%m%d"`
+          DATE=`date "+%y%m%d"`
           run_number=$(($GITHUB_RUN_NUMBER % 100))
           run_number=$(printf "%02d" $run_number)
-          build_number="${DATE}${run_number}"
+          build_number="10${DATE}${run_number}"
           echo '$build_number='$build_number
           echo "BUILD_NUMBER=$build_number" >> $GITHUB_ENV
 

--- a/development/env.js
+++ b/development/env.js
@@ -21,7 +21,8 @@ if (process.env.NODE_ENV !== 'production') {
   // console.log('process.env', process.env);
 
   process.env.BUILD_NUMBER =
-    process.env.BUILD_NUMBER || `${dateFns.format(Date.now(), 'MMddHHmm')}-dev`;
+    process.env.BUILD_NUMBER ||
+    `10${dateFns.format(Date.now(), 'yyMMdd')}00-dev`;
   process.env.BUNDLE_VERSION = process.env.BUNDLE_VERSION || '1000000';
 }
 


### PR DESCRIPTION
This PR standardizes the build number generation logic to use the 10YYMMDDXX format across both Daily Build workflows and the local development environment, aligning it with the new v6.2.0 release standard and preventing potential versioning conflicts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
