### PR TITLE
chore(desktop): upgrade @stoprocent/noble from 2.3.4 to 2.3.10

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@onekeyfe/electron-mac-icloud": "1.2.6",
     "@sentry/electron": "5.8.0",
-    "@stoprocent/noble": "2.3.4",
+    "@stoprocent/noble": "2.3.10",
     "adm-zip": "^0.5.10",
     "electron-check-biometric-auth-changed": "1.0.0",
     "electron-context-menu": "^3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9515,7 +9515,7 @@ __metadata:
     "@electron/remote": "npm:^2.0.1"
     "@onekeyfe/electron-mac-icloud": "npm:1.2.6"
     "@sentry/electron": "npm:5.8.0"
-    "@stoprocent/noble": "npm:2.3.4"
+    "@stoprocent/noble": "npm:2.3.10"
     "@types/adm-zip": "npm:^0"
     "@types/electron-localshortcut": "npm:^3.1.0"
     "@types/node-fetch": "npm:^2.6.1"
@@ -15424,8 +15424,8 @@ __metadata:
   linkType: hard
 
 "@stoprocent/bluetooth-hci-socket@npm:^2.2.3":
-  version: 2.2.3
-  resolution: "@stoprocent/bluetooth-hci-socket@npm:2.2.3"
+  version: 2.2.6
+  resolution: "@stoprocent/bluetooth-hci-socket@npm:2.2.6"
   dependencies:
     async: "npm:^3.2.6"
     debug: "npm:^4.3.7"
@@ -15461,6 +15461,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@stoprocent/noble@npm:2.3.10":
+  version: 2.3.10
+  resolution: "@stoprocent/noble@npm:2.3.10"
+  dependencies:
+    "@stoprocent/bluetooth-hci-socket": "npm:^2.2.3"
+    debug: "npm:^4.3.7"
+    node-addon-api: "npm:^8.1.0"
+    node-gyp: "npm:latest"
+    node-gyp-build: "npm:^4.8.1"
+  dependenciesMeta:
+    "@stoprocent/bluetooth-hci-socket":
+      optional: true
+  checksum: 10/12ab7ca4d03013880948d02b52df3e58e3b72b44e978f48c8343422e220247ee9f1118c4431ca762e3cce5809c2897f429d67099f1bc689d7515b5260eb3d2f8
+  languageName: node
+  linkType: hard
+
 "@stoprocent/noble@npm:2.3.16":
   version: 2.3.16
   resolution: "@stoprocent/noble@npm:2.3.16"
@@ -15475,22 +15491,6 @@ __metadata:
     "@stoprocent/bluetooth-hci-socket":
       optional: true
   checksum: 10/59e9a3c5abeb9fbc3efbbb3bf12ca282810e8aeaf8ca6a5921cb01dc4d027436c0fc99a63cee126ec461c2ab1cfef629acdfb03e419d42ee8b74d98d4a47b163
-  languageName: node
-  linkType: hard
-
-"@stoprocent/noble@npm:2.3.4":
-  version: 2.3.4
-  resolution: "@stoprocent/noble@npm:2.3.4"
-  dependencies:
-    "@stoprocent/bluetooth-hci-socket": "npm:^2.2.3"
-    debug: "npm:^4.3.7"
-    node-addon-api: "npm:^8.1.0"
-    node-gyp: "npm:latest"
-    node-gyp-build: "npm:^4.8.1"
-  dependenciesMeta:
-    "@stoprocent/bluetooth-hci-socket":
-      optional: true
-  checksum: 10/d797d2050b60fede51824502d9d64e44a23d75ba8bd6221840a448869f189319876917381cebdf75fde3e95a9a8e6dee24067742abcb897b73dc4f30e332f36f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Upgrade `@stoprocent/noble` (Bluetooth BLE library) from 2.3.4 to 2.3.10 in the desktop app
- Also updates transitive dependency `@stoprocent/bluetooth-hci-socket` from 2.2.3 to 2.2.6

## Intent & Context
Routine dependency upgrade to pick up bug fixes and improvements in the noble BLE library, which is used for hardware wallet Bluetooth communication on desktop.

## Changes Detail
- `apps/desktop/package.json`: Bump `@stoprocent/noble` version 2.3.4 → 2.3.10
- `yarn.lock`: Updated lock entries for `@stoprocent/noble` and `@stoprocent/bluetooth-hci-socket`

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop
- **Risk Areas**: Bluetooth hardware wallet connectivity on desktop

## Test plan
- [ ] Desktop app builds successfully
- [ ] Bluetooth hardware wallet pairing and communication works on macOS
- [ ] Bluetooth hardware wallet pairing and communication works on Windows/Linux
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
