### PR TITLE
chore: remove .env.* wildcard from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ yarn-error.log
 !.yarn/versions
 
 .env
-.env.*
 webpack.config.preview.json
 webpack.config.preview.devServer.json
 


### PR DESCRIPTION
## Summary
- Remove the `.env.*` wildcard pattern from `.gitignore` to allow tracking of `.env.version`, `.env.expo`, and `.env.example` files

## Intent & Context
The `.env.*` wildcard rule was overly broad — it prevented tracking of non-sensitive env files like `.env.version` (build versioning) and `.env.example` (template for developers). Removing the wildcard allows these files to be committed while `.env` (the actual secrets file) remains ignored.

## Changes Detail
- `.gitignore`: Removed the `.env.*` line. The `.env` entry still protects the primary secrets file.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: All (desktop, mobile, web, extension)
- **Risk Areas**: If any `.env.<something>` file with secrets exists locally, it could be accidentally committed. Developers should verify no sensitive `.env.*` files are present.

## Test plan
- [ ] Verify `.env` is still ignored by git
- [ ] Verify `.env.version` and `.env.example` are now trackable
- [ ] Confirm no sensitive `.env.*` files are accidentally staged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
