### PR TITLE
fix: sync market swap panel state and blocked-region refresh flow(OK-52557,OK-52400)

### DIFF
--- a/packages/kit-bg/src/services/ServiceStaking.ts
+++ b/packages/kit-bg/src/services/ServiceStaking.ts
@@ -2066,6 +2066,17 @@ class ServiceStaking extends ServiceBase {
   }
 
   @backgroundMethod()
+  async refreshBlockRegion() {
+    try {
+      await this.backgroundApi.serviceIpTable.runFullSpeedTest();
+    } catch (_error) {
+      // Fall back to the current connection info when the speed test fails.
+    }
+
+    return this.getBlockRegion();
+  }
+
+  @backgroundMethod()
   async getApyHistory(params: {
     networkId: string;
     provider: string;

--- a/packages/kit/src/views/Earn/hooks/useBlockRegion.test.tsx
+++ b/packages/kit/src/views/Earn/hooks/useBlockRegion.test.tsx
@@ -1,0 +1,90 @@
+/** @jest-environment jsdom */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { useBlockRegion } from './useBlockRegion';
+
+const mockGetBlockRegion = jest.fn<Promise<unknown>, []>();
+const mockRefreshBlockRegion = jest.fn<Promise<unknown>, []>();
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {
+    serviceStaking: {
+      getBlockRegion: () => mockGetBlockRegion(),
+      refreshBlockRegion: () => mockRefreshBlockRegion(),
+    },
+  },
+}));
+
+jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+
+  return {
+    usePromiseResult: (method: () => Promise<unknown>) => {
+      const methodRef = React.useRef(method);
+      const [result, setResult] = React.useState<unknown>(undefined);
+      const [isLoading, setIsLoading] = React.useState(false);
+
+      methodRef.current = method;
+
+      const run = React.useCallback(async () => {
+        setIsLoading(true);
+        try {
+          const nextResult = await methodRef.current();
+          setResult(nextResult);
+        } finally {
+          setIsLoading(false);
+        }
+      }, []);
+
+      React.useEffect(() => {
+        void run();
+      }, [run]);
+
+      return {
+        isLoading,
+        result,
+        run,
+        setResult,
+      };
+    },
+  };
+});
+
+describe('useBlockRegion', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads block-region state through the lightweight query by default', async () => {
+    mockGetBlockRegion.mockResolvedValue({ title: { text: 'Blocked' } });
+
+    renderHook(() => useBlockRegion());
+
+    await waitFor(() => {
+      expect(mockGetBlockRegion).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockRefreshBlockRegion).not.toHaveBeenCalled();
+  });
+
+  it('re-runs connection selection before refreshing block-region state', async () => {
+    mockGetBlockRegion.mockResolvedValue({ title: { text: 'Blocked' } });
+    mockRefreshBlockRegion.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useBlockRegion());
+
+    await waitFor(() => {
+      expect(mockGetBlockRegion).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      await result.current.refreshBlockResult();
+    });
+
+    expect(mockRefreshBlockRegion).toHaveBeenCalledTimes(1);
+    expect(mockGetBlockRegion).toHaveBeenCalledTimes(1);
+    expect(result.current.blockResult).toEqual({ blockData: null });
+  });
+});

--- a/packages/kit/src/views/Earn/hooks/useBlockRegion.ts
+++ b/packages/kit/src/views/Earn/hooks/useBlockRegion.ts
@@ -1,16 +1,20 @@
+import { useCallback, useRef } from 'react';
+
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 
 import { usePromiseResult } from '../../../hooks/usePromiseResult';
 
 export const useBlockRegion = () => {
+  const shouldRefreshConnectionRef = useRef(false);
   const {
     isLoading: isFetchingBlockResult,
     run: refreshBlockResult,
     result: blockResult,
   } = usePromiseResult(
     async () => {
-      const blockData =
-        await backgroundApiProxy.serviceStaking.getBlockRegion();
+      const blockData = shouldRefreshConnectionRef.current
+        ? await backgroundApiProxy.serviceStaking.refreshBlockRegion()
+        : await backgroundApiProxy.serviceStaking.getBlockRegion();
       return { blockData };
     },
     [],
@@ -20,5 +24,18 @@ export const useBlockRegion = () => {
     },
   );
 
-  return { isFetchingBlockResult, refreshBlockResult, blockResult };
+  const handleRefreshBlockResult = useCallback(async () => {
+    shouldRefreshConnectionRef.current = true;
+    try {
+      await refreshBlockResult();
+    } finally {
+      shouldRefreshConnectionRef.current = false;
+    }
+  }, [refreshBlockResult]);
+
+  return {
+    isFetchingBlockResult,
+    refreshBlockResult: handleRefreshBlockResult,
+    blockResult,
+  };
 };

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.test.tsx
@@ -12,6 +12,11 @@ import {
 } from './SwapPanelContent';
 
 const actionButtonMock = jest.fn();
+const setAmountEnterTypeMock = jest.fn();
+const setSlippageSettingMock = jest.fn();
+const resetAnalyticsMock = jest.fn();
+const logSwapActionMock = jest.fn();
+const tokenInputSectionMock = jest.fn();
 
 jest.mock('@onekeyhq/components', () => ({
   SizableText: ({ children }: { children?: ReactNode }) => (
@@ -31,8 +36,10 @@ jest.mock('react-intl', () => ({
 
 jest.mock('./hooks/useSwapAnalytics', () => ({
   useSwapAnalytics: () => ({
-    setAmountEnterType: jest.fn(),
-    logSwapAction: jest.fn(),
+    setAmountEnterType: setAmountEnterTypeMock,
+    setSlippageSetting: setSlippageSettingMock,
+    resetAnalytics: resetAnalyticsMock,
+    logSwapAction: logSwapActionMock,
   }),
 }));
 
@@ -46,7 +53,38 @@ jest.mock('./components/SwapPanelTop', () => ({
 }));
 
 jest.mock('./components/TokenInputSection', () => ({
-  TokenInputSection: () => <div data-testid="token-input" />,
+  TokenInputSection: jest
+    .requireActual<typeof import('react')>('react')
+    .forwardRef(
+      (
+        {
+          tradeType,
+          onChange,
+        }: {
+          tradeType: ESwapDirection;
+          onChange: (value: string) => void;
+        },
+        ref,
+      ) => {
+        const React = jest.requireActual<typeof import('react')>('react');
+        const setValue = jest.fn();
+        React.useImperativeHandle(ref, () => ({
+          setValue,
+        }));
+        tokenInputSectionMock({ tradeType, onChange, setValue });
+        return (
+          <button
+            data-testid={
+              tradeType === ESwapDirection.BUY ? 'buy-input' : 'sell-input'
+            }
+            onClick={() => onChange('')}
+            type="button"
+          >
+            token-input
+          </button>
+        );
+      },
+    ),
 }));
 
 jest.mock('./components/RateDisplay', () => ({
@@ -104,6 +142,7 @@ function createProps(): ISwapPanelContentProps {
       sellAmount: new BigNumber(1),
       setSellAmount: jest.fn(),
       setPaymentAmount: jest.fn(),
+      resetAmounts: jest.fn(),
       setPaymentToken: jest.fn(),
       tradeType: ESwapDirection.BUY,
       setTradeType: jest.fn(),
@@ -151,6 +190,11 @@ function createProps(): ISwapPanelContentProps {
 describe('SwapPanelContent', () => {
   beforeEach(() => {
     actionButtonMock.mockReset();
+    setAmountEnterTypeMock.mockReset();
+    setSlippageSettingMock.mockReset();
+    resetAnalyticsMock.mockReset();
+    logSwapActionMock.mockReset();
+    tokenInputSectionMock.mockReset();
   });
 
   it('routes the main action button to the review swap handler', () => {
@@ -188,5 +232,61 @@ describe('SwapPanelContent', () => {
         disabled: true,
       }),
     );
+  });
+
+  it('parses empty token input as zero instead of NaN', () => {
+    const props = createProps();
+
+    render(<SwapPanelContent {...props} />);
+
+    fireEvent.click(screen.getByTestId('buy-input'));
+
+    expect(props.swapPanel.setPaymentAmount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isZero: expect.any(Function),
+        isNaN: expect.any(Function),
+      }),
+    );
+
+    const amount = (props.swapPanel.setPaymentAmount as jest.Mock).mock
+      .calls[0][0] as BigNumber;
+    expect(amount.isZero()).toBe(true);
+    expect(amount.isNaN()).toBe(false);
+  });
+
+  it('resets panel amounts and analytics when the market token changes', () => {
+    const props = createProps();
+    const { rerender } = render(<SwapPanelContent {...props} />);
+
+    expect(props.swapPanel.resetAmounts).not.toHaveBeenCalled();
+    expect(resetAnalyticsMock).not.toHaveBeenCalled();
+
+    tokenInputSectionMock.mockClear();
+
+    rerender(
+      <SwapPanelContent
+        {...props}
+        currentMarketToken={{
+          networkId: 'evm--10',
+          contractAddress: '0xmarket-2',
+          symbol: 'ETH',
+          decimals: 18,
+          isNative: true,
+        }}
+      />,
+    );
+
+    expect(props.swapPanel.resetAmounts).toHaveBeenCalledTimes(1);
+    expect(resetAnalyticsMock).toHaveBeenCalledTimes(1);
+
+    const renderedInputs = tokenInputSectionMock.mock.calls.map(
+      ([renderedProps]) =>
+        renderedProps as {
+          setValue: jest.Mock;
+        },
+    );
+    expect(renderedInputs).toHaveLength(2);
+    expect(renderedInputs[0].setValue).toHaveBeenCalledWith('');
+    expect(renderedInputs[1].setValue).toHaveBeenCalledWith('');
   });
 });

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.tsx
@@ -94,6 +94,7 @@ export function SwapPanelContent(props: ISwapPanelContentProps) {
     paymentAmount,
     paymentToken,
     sellAmount,
+    resetAmounts,
     setSellAmount,
     setPaymentAmount,
     setPaymentToken,
@@ -106,8 +107,13 @@ export function SwapPanelContent(props: ISwapPanelContentProps) {
   const tokenSellInputRef = useRef<ITokenInputSectionRef>(null);
   const paymentAmountRef = useRef(paymentAmount);
   const sellAmountRef = useRef(sellAmount);
-  // Initialize analytics hook
-  const swapAnalytics = useSwapAnalytics();
+  const hasInitializedMarketTokenRef = useRef(false);
+  const {
+    logSwapAction,
+    resetAnalytics,
+    setAmountEnterType,
+    setSlippageSetting,
+  } = useSwapAnalytics();
   const intl = useIntl();
   if (paymentAmount !== paymentAmountRef.current) {
     paymentAmountRef.current = paymentAmount;
@@ -119,6 +125,10 @@ export function SwapPanelContent(props: ISwapPanelContentProps) {
   const currentInputAmount = useMemo(() => {
     return tradeType === ESwapDirection.BUY ? paymentAmount : sellAmount;
   }, [tradeType, paymentAmount, sellAmount]);
+
+  const parseAmountInput = useCallback((amount: string) => {
+    return new BigNumber(amount || 0);
+  }, []);
 
   const handleBalanceClick = useCallback(() => {
     const reserveGas = swapNativeTokenReserveGas.find(
@@ -214,9 +224,21 @@ export function SwapPanelContent(props: ISwapPanelContentProps) {
   }, [tradeType, balanceToken?.decimals, setPaymentAmount, setSellAmount]);
 
   useEffect(() => {
+    if (!hasInitializedMarketTokenRef.current) {
+      hasInitializedMarketTokenRef.current = true;
+      return;
+    }
+
+    resetAmounts();
+    resetAnalytics();
     tokenBuyInputRef.current?.setValue('');
     tokenSellInputRef.current?.setValue('');
-  }, [currentMarketToken?.networkId, currentMarketToken?.contractAddress]);
+  }, [
+    currentMarketToken?.networkId,
+    currentMarketToken?.contractAddress,
+    resetAmounts,
+    resetAnalytics,
+  ]);
 
   return (
     <YStack gap="$4">
@@ -238,12 +260,12 @@ export function SwapPanelContent(props: ISwapPanelContentProps) {
           style={tradeType === ESwapDirection.BUY ? {} : { display: 'none' }}
           tradeType={ESwapDirection.BUY}
           swapNativeTokenReserveGas={swapNativeTokenReserveGas}
-          onChange={(amount) => setPaymentAmount(new BigNumber(amount))}
+          onChange={(amount) => setPaymentAmount(parseAmountInput(amount))}
           selectedToken={paymentToken}
           selectableTokens={defaultTokens}
           onTokenChange={(token) => setPaymentToken(token)}
           balance={balance}
-          onAmountEnterTypeChange={swapAnalytics.setAmountEnterType}
+          onAmountEnterTypeChange={setAmountEnterType}
           disableNativeToken={disableNativeToken}
         />
         <TokenInputSection
@@ -251,12 +273,12 @@ export function SwapPanelContent(props: ISwapPanelContentProps) {
           style={tradeType === ESwapDirection.SELL ? {} : { display: 'none' }}
           tradeType={ESwapDirection.SELL}
           swapNativeTokenReserveGas={swapNativeTokenReserveGas}
-          onChange={(amount) => setSellAmount(new BigNumber(amount))}
+          onChange={(amount) => setSellAmount(parseAmountInput(amount))}
           selectedToken={balanceToken}
           selectableTokens={defaultTokens}
           onTokenChange={(token) => setPaymentToken(token)}
           balance={balance}
-          onAmountEnterTypeChange={swapAnalytics.setAmountEnterType}
+          onAmountEnterTypeChange={setAmountEnterType}
         />
 
         {/* Rate display */}
@@ -300,7 +322,7 @@ export function SwapPanelContent(props: ISwapPanelContentProps) {
         networkId={networkId}
         disabled={!!speedCheckError || isLoading}
         onSwapAction={() =>
-          swapAnalytics.logSwapAction({
+          logSwapAction({
             tradeType,
             networkId,
             paymentToken,
@@ -316,9 +338,7 @@ export function SwapPanelContent(props: ISwapPanelContentProps) {
           isMEV={swapMevNetConfig?.includes(swapPanel.networkId ?? '')}
           onSlippageChange={(item) => {
             setSlippage(item.value);
-            swapAnalytics.setSlippageSetting(
-              item.key === ESwapSlippageSegmentKey.CUSTOM,
-            );
+            setSlippageSetting(item.key === ESwapSlippageSegmentKey.CUSTOM);
           }}
         />
       )}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.test.tsx
@@ -74,6 +74,7 @@ jest.mock('./hooks/useSwapPanel', () => ({
   useSwapPanel: () => ({
     networkId: 'evm--1',
     setPaymentToken: jest.fn(),
+    resetAmounts: jest.fn(),
     paymentToken: {
       networkId: 'evm--1',
       contractAddress: '0xpay',

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
@@ -184,6 +184,7 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
       decimals: tokenDetail?.decimals || 0,
       logoURI: tokenDetail?.logoUrl || '',
       price: tokenDetail?.price || '',
+      isNative: !!tokenDetail?.isNative,
     },
     tradeToken: {
       networkId: paymentToken?.networkId || '',
@@ -191,9 +192,9 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
       symbol: paymentToken?.symbol || '',
       decimals: paymentToken?.decimals || 0,
       logoURI: paymentToken?.logoURI || '',
+      price: paymentToken?.price || '',
       isNative: paymentToken?.isNative || false,
     },
-    defaultTradeTokens: defaultTokens,
     provider,
     tradeType: tradeType || ESwapDirection.BUY,
     fromTokenAmount:

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
@@ -491,4 +491,76 @@ describe('useSpeedSwapActions', () => {
       expect(result.current.priceRate?.rate).toBeCloseTo(0.2);
     });
   });
+
+  it('falls back to remote price fetch when inline token prices are placeholder zeroes', async () => {
+    mockNetAccountPromiseResult = {
+      result: undefined,
+      run: mockNetAccountRun,
+    };
+
+    mockFetchSwapTokenDetails.mockImplementation(
+      ({
+        accountId,
+        networkId,
+        contractAddress,
+      }: IFetchSwapTokenDetailsParams) => {
+        if (accountId) {
+          return Promise.resolve([]);
+        }
+
+        const requestKey = `${networkId ?? ''}:${contractAddress ?? ''}`;
+        switch (requestKey) {
+          case `${usdcToken.networkId}:${usdcToken.contractAddress}`:
+            return Promise.resolve(
+              createTokenDetail({
+                networkId: usdcToken.networkId,
+                contractAddress: usdcToken.contractAddress,
+                symbol: usdcToken.symbol,
+                decimals: usdcToken.decimals,
+                price: '1',
+              }),
+            );
+          case `${tonMarketToken.networkId}:${tonMarketToken.contractAddress}`:
+            return Promise.resolve(
+              createTokenDetail({
+                networkId: tonMarketToken.networkId,
+                contractAddress: tonMarketToken.contractAddress,
+                symbol: tonMarketToken.symbol,
+                decimals: tonMarketToken.decimals,
+                price: '5',
+              }),
+            );
+          default:
+            return Promise.resolve([]);
+        }
+      },
+    );
+
+    const { result } = renderHook(() =>
+      useSpeedSwapActions(
+        createHookProps({
+          marketToken: {
+            ...tonMarketToken,
+            price: '5',
+          },
+          tradeToken: {
+            ...usdcToken,
+            price: '0',
+          },
+        }),
+      ),
+    );
+
+    await waitFor(() => {
+      expect(mockFetchSwapTokenDetails).toHaveBeenCalledTimes(2);
+      expect(result.current.priceRate).toEqual(
+        expect.objectContaining({
+          fromTokenSymbol: 'USDC',
+          toTokenSymbol: 'TON',
+          loading: false,
+        }),
+      );
+      expect(result.current.priceRate?.rate).toBeCloseTo(0.2);
+    });
+  });
 });

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
@@ -1,0 +1,494 @@
+/** @jest-environment jsdom */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import type {
+  ISwapToken,
+  ISwapTokenBase,
+} from '@onekeyhq/shared/types/swap/types';
+
+import { useSpeedSwapActions } from './useSpeedSwapActions';
+import { ESwapDirection } from './useTradeType';
+
+type IFetchSwapTokenDetailsParams = {
+  accountId?: string;
+  networkId?: string;
+  contractAddress?: string;
+  accountAddress?: string;
+  currency?: string;
+};
+
+type IFetchSwapNativeTokenConfigParams = {
+  networkId: string;
+};
+
+const mockFetchSwapTokenDetails: jest.MockedFunction<
+  (params: IFetchSwapTokenDetailsParams) => Promise<ISwapToken[]>
+> = jest.fn();
+const mockFetchSwapNativeTokenConfig: jest.MockedFunction<
+  (
+    params: IFetchSwapNativeTokenConfigParams,
+  ) => Promise<{ networkId: string; reserveGas: string }>
+> = jest.fn();
+const mockSetInAppNotificationAtom = jest.fn();
+const mockNavigationToTxConfirm = jest.fn();
+const mockNetAccountRun = jest.fn();
+const mockMarketDeriveInfoRun = jest.fn();
+
+let mockUsePromiseResultCallCount = 0;
+let mockNetAccountPromiseResult: {
+  result?: {
+    id: string;
+    addressDetail: {
+      address: string;
+      networkId: string;
+    };
+  };
+  run: jest.Mock;
+};
+let mockMarketDeriveInfoPromiseResult: {
+  result?: {
+    addressEncoding?: string;
+  };
+  run: jest.Mock;
+};
+let mockInAppNotificationAtomState: {
+  speedSwapApprovingTransaction?: {
+    status?: string;
+  };
+} = {};
+
+jest.mock('react-intl', () => ({
+  useIntl: () => ({
+    formatMessage: ({ id }: { id: string }) => id,
+  }),
+}));
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {
+    serviceSwap: {
+      fetchSwapTokenDetails: (params: IFetchSwapTokenDetailsParams) =>
+        mockFetchSwapTokenDetails(params),
+      fetchSwapNativeTokenConfig: (params: IFetchSwapNativeTokenConfigParams) =>
+        mockFetchSwapNativeTokenConfig(params),
+    },
+  },
+}));
+
+jest.mock('@onekeyhq/kit/src/hooks/useDebounce', () => ({
+  useDebounce: (value: string) => value,
+}));
+
+jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => ({
+  usePromiseResult: () => {
+    const nextResult =
+      mockUsePromiseResultCallCount % 2 === 0
+        ? mockNetAccountPromiseResult
+        : mockMarketDeriveInfoPromiseResult;
+    mockUsePromiseResultCallCount += 1;
+    return nextResult;
+  },
+}));
+
+jest.mock('@onekeyhq/kit/src/hooks/useSignatureConfirm', () => ({
+  useSignatureConfirm: () => ({
+    navigationToTxConfirm: mockNavigationToTxConfirm,
+  }),
+}));
+
+jest.mock('@onekeyhq/kit/src/states/jotai/contexts/accountSelector', () => ({
+  useActiveAccount: () => ({
+    activeAccount: {
+      account: {
+        id: 'account-1',
+      },
+      indexedAccount: undefined,
+      deriveType: 'default',
+    },
+  }),
+}));
+
+jest.mock('@onekeyhq/kit/src/states/jotai/contexts/marketV2/atoms', () => ({
+  useSelectedDeriveTypeAtom: () => [undefined],
+}));
+
+jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms', () => ({
+  useInAppNotificationAtom: () => [
+    mockInAppNotificationAtomState,
+    mockSetInAppNotificationAtom,
+  ],
+  useSettingsPersistAtom: () => [
+    {
+      currencyInfo: {
+        symbol: '$',
+      },
+      isFirstTimeSwap: false,
+    },
+  ],
+}));
+
+jest.mock('@onekeyhq/shared/src/eventBus/appEventBus', () => ({
+  EAppEventBusNames: {
+    NetworkDeriveTypeChanged: 'NetworkDeriveTypeChanged',
+    SwapSpeedApprovingReset: 'SwapSpeedApprovingReset',
+    SwapSpeedBalanceUpdate: 'SwapSpeedBalanceUpdate',
+    SwapSpeedBuildTxSuccess: 'SwapSpeedBuildTxSuccess',
+  },
+  appEventBus: {
+    on: jest.fn(),
+    off: jest.fn(),
+    emit: jest.fn(),
+  },
+}));
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return {
+    promise,
+    resolve,
+    reject,
+  };
+}
+
+function createTokenDetail(overrides: Partial<ISwapToken> = {}): ISwapToken[] {
+  return [
+    {
+      networkId: 'evm--1',
+      contractAddress: '0xtoken',
+      symbol: 'TOKEN',
+      decimals: 18,
+      ...overrides,
+    },
+  ];
+}
+
+const usdcToken: ISwapTokenBase = {
+  networkId: 'evm--1',
+  contractAddress: '0xusdc',
+  symbol: 'USDC',
+  decimals: 6,
+  isNative: false,
+};
+
+const usdtToken: ISwapTokenBase = {
+  networkId: 'evm--1',
+  contractAddress: '0xusdt',
+  symbol: 'USDT',
+  decimals: 6,
+  isNative: false,
+};
+
+const btcToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xbtc',
+  symbol: 'BTC',
+  decimals: 8,
+  isNative: false,
+};
+
+const tonMarketToken: ISwapToken = {
+  networkId: 'ton--239',
+  contractAddress: '0xton',
+  symbol: 'TON',
+  decimals: 9,
+  isNative: false,
+};
+
+function createHookProps({
+  marketToken = btcToken,
+  tradeToken = usdcToken,
+}: {
+  marketToken?: ISwapToken;
+  tradeToken?: ISwapTokenBase;
+} = {}) {
+  return {
+    marketToken,
+    tradeToken,
+    tradeType: ESwapDirection.BUY,
+    fromTokenAmount: '0',
+    provider: 'onekey',
+    spenderAddress: '0xspender',
+    slippage: 0.5,
+    antiMEV: false,
+  };
+}
+
+describe('useSpeedSwapActions', () => {
+  beforeEach(() => {
+    mockFetchSwapTokenDetails.mockReset();
+    mockFetchSwapNativeTokenConfig.mockReset();
+    mockSetInAppNotificationAtom.mockReset();
+    mockNavigationToTxConfirm.mockReset();
+    mockNetAccountRun.mockReset();
+    mockMarketDeriveInfoRun.mockReset();
+    mockUsePromiseResultCallCount = 0;
+    mockInAppNotificationAtomState = {};
+    mockFetchSwapNativeTokenConfig.mockResolvedValue({
+      networkId: 'evm--1',
+      reserveGas: '0.01',
+    });
+    mockNetAccountPromiseResult = {
+      result: {
+        id: 'net-account-1',
+        addressDetail: {
+          address: '0xuser',
+          networkId: 'evm--1',
+        },
+      },
+      run: mockNetAccountRun,
+    };
+    mockMarketDeriveInfoPromiseResult = {
+      result: undefined,
+      run: mockMarketDeriveInfoRun,
+    };
+  });
+
+  it('keeps the latest same-network balance when stablecoin balance requests resolve out of order', async () => {
+    const oldBalanceRequest = createDeferred<ISwapToken[]>();
+    const newBalanceRequest = createDeferred<ISwapToken[]>();
+
+    mockFetchSwapTokenDetails.mockImplementation(
+      ({
+        accountId,
+        contractAddress,
+      }: {
+        accountId?: string;
+        contractAddress?: string;
+      }) => {
+        if (!accountId) {
+          return Promise.resolve([]);
+        }
+        if (contractAddress === usdcToken.contractAddress) {
+          return oldBalanceRequest.promise;
+        }
+        if (contractAddress === usdtToken.contractAddress) {
+          return newBalanceRequest.promise;
+        }
+        return Promise.resolve([]);
+      },
+    );
+
+    const { result, rerender } = renderHook(
+      ({ tradeToken }: { tradeToken: ISwapTokenBase }) =>
+        useSpeedSwapActions(
+          createHookProps({
+            marketToken: {
+              ...btcToken,
+              price: '100000',
+            },
+            tradeToken: {
+              ...tradeToken,
+              price: '1',
+            },
+          }),
+        ),
+      {
+        initialProps: {
+          tradeToken: usdcToken,
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(mockFetchSwapTokenDetails).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({
+      tradeToken: usdtToken,
+    });
+
+    await waitFor(() => {
+      expect(mockFetchSwapTokenDetails).toHaveBeenCalledTimes(2);
+      expect(result.current.balanceToken.symbol).toBe('USDT');
+    });
+
+    await act(async () => {
+      newBalanceRequest.resolve(
+        createTokenDetail({
+          networkId: usdtToken.networkId,
+          contractAddress: usdtToken.contractAddress,
+          symbol: usdtToken.symbol,
+          decimals: usdtToken.decimals,
+          balanceParsed: '250',
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.balance?.toFixed()).toBe('250');
+      expect(result.current.fetchBalanceLoading).toBe(false);
+    });
+
+    await act(async () => {
+      oldBalanceRequest.resolve(
+        createTokenDetail({
+          networkId: usdcToken.networkId,
+          contractAddress: usdcToken.contractAddress,
+          symbol: usdcToken.symbol,
+          decimals: usdcToken.decimals,
+          balanceParsed: '100',
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.balanceToken.symbol).toBe('USDT');
+      expect(result.current.balance?.toFixed()).toBe('250');
+      expect(result.current.fetchBalanceLoading).toBe(false);
+    });
+  });
+
+  it('keeps the latest cross-network price when token detail requests resolve out of order', async () => {
+    const oldTradeTokenPriceRequest = createDeferred<ISwapToken[]>();
+    const oldMarketTokenPriceRequest = createDeferred<ISwapToken[]>();
+    const newTradeTokenPriceRequest = createDeferred<ISwapToken[]>();
+    const newMarketTokenPriceRequest = createDeferred<ISwapToken[]>();
+
+    mockNetAccountPromiseResult = {
+      result: undefined,
+      run: mockNetAccountRun,
+    };
+
+    mockFetchSwapTokenDetails.mockImplementation(
+      ({
+        accountId,
+        networkId,
+        contractAddress,
+      }: {
+        accountId?: string;
+        networkId?: string;
+        contractAddress?: string;
+      }) => {
+        if (accountId) {
+          return Promise.resolve([]);
+        }
+
+        const requestKey = `${networkId ?? ''}:${contractAddress ?? ''}`;
+        switch (requestKey) {
+          case `${usdcToken.networkId}:${usdcToken.contractAddress}`:
+            return oldTradeTokenPriceRequest.promise;
+          case `${btcToken.networkId}:${btcToken.contractAddress}`:
+            return oldMarketTokenPriceRequest.promise;
+          case `ton--239:0x11112222`:
+            return newTradeTokenPriceRequest.promise;
+          case `${tonMarketToken.networkId}:${tonMarketToken.contractAddress}`:
+            return newMarketTokenPriceRequest.promise;
+          default:
+            return Promise.resolve([]);
+        }
+      },
+    );
+
+    const { result, rerender } = renderHook(
+      ({
+        marketToken,
+        tradeToken,
+      }: {
+        marketToken: ISwapToken;
+        tradeToken: ISwapTokenBase;
+      }) =>
+        useSpeedSwapActions(
+          createHookProps({
+            marketToken,
+            tradeToken,
+          }),
+        ),
+      {
+        initialProps: {
+          marketToken: btcToken,
+          tradeToken: usdcToken,
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(mockFetchSwapTokenDetails).toHaveBeenCalledTimes(2);
+    });
+
+    rerender({
+      marketToken: tonMarketToken,
+      tradeToken: {
+        networkId: 'ton--239',
+        contractAddress: '0x11112222',
+        symbol: 'USDT',
+        decimals: 6,
+        isNative: false,
+      },
+    });
+
+    await waitFor(() => {
+      expect(mockFetchSwapTokenDetails).toHaveBeenCalledTimes(4);
+    });
+
+    await act(async () => {
+      newTradeTokenPriceRequest.resolve(
+        createTokenDetail({
+          networkId: 'ton--239',
+          contractAddress: '0x11112222',
+          symbol: 'USDT',
+          decimals: 6,
+          price: '1',
+        }),
+      );
+      newMarketTokenPriceRequest.resolve(
+        createTokenDetail({
+          networkId: tonMarketToken.networkId,
+          contractAddress: tonMarketToken.contractAddress,
+          symbol: tonMarketToken.symbol,
+          decimals: tonMarketToken.decimals,
+          price: '5',
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.priceRate).toEqual(
+        expect.objectContaining({
+          fromTokenSymbol: 'USDT',
+          toTokenSymbol: 'TON',
+          loading: false,
+        }),
+      );
+      expect(result.current.priceRate?.rate).toBeCloseTo(0.2);
+    });
+
+    await act(async () => {
+      oldTradeTokenPriceRequest.resolve(
+        createTokenDetail({
+          networkId: usdcToken.networkId,
+          contractAddress: usdcToken.contractAddress,
+          symbol: usdcToken.symbol,
+          decimals: usdcToken.decimals,
+          price: '1',
+        }),
+      );
+      oldMarketTokenPriceRequest.resolve(
+        createTokenDetail({
+          networkId: btcToken.networkId,
+          contractAddress: btcToken.contractAddress,
+          symbol: btcToken.symbol,
+          decimals: btcToken.decimals,
+          price: '100000',
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.priceRate).toEqual(
+        expect.objectContaining({
+          fromTokenSymbol: 'USDT',
+          toTokenSymbol: 'TON',
+          loading: false,
+        }),
+      );
+      expect(result.current.priceRate?.rate).toBeCloseTo(0.2);
+    });
+  });
+});

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -133,7 +133,6 @@ export function useSpeedSwapActions(props: {
   provider: string;
   spenderAddress: string;
   slippage: number;
-  defaultTradeTokens: ISwapTokenBase[];
   antiMEV: boolean;
   isCustomRpcUnavailable?: boolean;
   isReviewDialogOpen?: boolean;
@@ -147,7 +146,6 @@ export function useSpeedSwapActions(props: {
     provider,
     spenderAddress,
     slippage,
-    defaultTradeTokens,
     antiMEV,
     isCustomRpcUnavailable,
     isReviewDialogOpen,
@@ -185,6 +183,8 @@ export function useSpeedSwapActions(props: {
   const [checkSpenderAddress, setCheckSpenderAddress] = useState('');
   const [isStock, setIsStock] = useState(false);
   const speedCheckRequestIdRef = useRef(0);
+  const balanceRequestIdRef = useRef(0);
+  const priceRequestIdRef = useRef(0);
   const reviewExecutionSnapshotRef = useRef<
     IMarketReviewExecutionSnapshot | undefined
   >(undefined);
@@ -194,24 +194,20 @@ export function useSpeedSwapActions(props: {
   );
 
   const effectiveSpenderAddress = checkSpenderAddress || spenderAddress;
-
-  const [tradeTokenDetail, setTradeTokenDetail] =
-    useState<ISwapToken>(tradeToken);
-
   const { fromToken, toToken, balanceToken } = useMemo(() => {
     if (tradeType === ESwapDirection.BUY) {
       return {
-        fromToken: tradeTokenDetail,
+        fromToken: tradeToken,
         toToken: marketToken,
-        balanceToken: tradeTokenDetail,
+        balanceToken: tradeToken,
       };
     }
     return {
       fromToken: marketToken,
-      toToken: tradeTokenDetail,
+      toToken: tradeToken,
       balanceToken: marketToken,
     };
-  }, [tradeType, marketToken, tradeTokenDetail]);
+  }, [tradeType, marketToken, tradeToken]);
 
   // Use atom to get selected derive type from Market Detail page
   const [selectedDeriveType] = useSelectedDeriveTypeAtom();
@@ -293,38 +289,6 @@ export function useSpeedSwapActions(props: {
   const fromTokenAmountDebounced = useDebounce(fromTokenAmount, 300, {
     leading: true,
   });
-
-  const tradeTokenRef = useRef<ISwapToken>(undefined);
-  if (tradeTokenRef.current !== tradeToken) {
-    tradeTokenRef.current = tradeToken;
-  }
-  const tradeTokenNetworkId = tradeToken.networkId;
-  const tradeTokenContractAddress = tradeToken.contractAddress;
-  useEffect(() => {
-    void (async () => {
-      if (!tradeTokenNetworkId) return;
-      const tokenDetail =
-        await backgroundApiProxy.serviceSwap.fetchSwapTokenDetails({
-          networkId: tradeTokenNetworkId,
-          contractAddress: tradeTokenContractAddress,
-          currency: 'usd',
-        });
-      if (tokenDetail?.length) {
-        setTradeTokenDetail({
-          ...tokenDetail[0],
-          symbol: tradeTokenRef.current?.symbol ?? '',
-          logoURI: tokenDetail[0]?.logoURI
-            ? tokenDetail[0]?.logoURI
-            : (tradeTokenRef.current?.logoURI ?? ''),
-        });
-      }
-    })();
-  }, [
-    tradeType,
-    defaultTradeTokens,
-    tradeTokenNetworkId,
-    tradeTokenContractAddress,
-  ]);
 
   const buildReviewStepTexts = useCallback(
     (providerName?: string): ISwapReviewStepTexts => ({
@@ -2197,46 +2161,66 @@ export function useSpeedSwapActions(props: {
       orderFromToken?: ISwapTokenBase;
       orderToToken?: ISwapTokenBase;
     }) => {
-      if (
-        netAccountRes.result?.id &&
-        netAccountRes.result?.addressDetail.address &&
-        orderFromToken?.networkId ===
-          netAccountRes.result?.addressDetail.networkId &&
-        (equalTokenNoCaseSensitive({
-          token1: orderFromToken,
-          token2: {
-            networkId: balanceToken?.networkId,
-            contractAddress: balanceToken?.contractAddress,
-          },
-        }) ||
-          equalTokenNoCaseSensitive({
-            token1: orderToToken,
-            token2: {
-              networkId: balanceToken?.networkId,
-              contractAddress: balanceToken?.contractAddress,
-            },
-          }))
-      ) {
-        if (!balanceToken?.networkId) return;
-        setFetchBalanceLoading(true);
-        try {
-          const tokenDetail =
-            await backgroundApiProxy.serviceSwap.fetchSwapTokenDetails({
-              networkId: balanceToken?.networkId ?? '',
-              contractAddress: balanceToken?.contractAddress ?? '',
-              accountId: netAccountRes.result?.id ?? '',
-              accountAddress: netAccountRes.result?.addressDetail.address ?? '',
-              currency: 'usd',
-            });
-          if (tokenDetail?.length) {
-            setBalance(new BigNumber(tokenDetail[0].balanceParsed ?? 0));
-          }
-          setFetchBalanceLoading(false);
-        } catch (_e) {
+      const accountId = netAccountRes.result?.id;
+      const accountAddress = netAccountRes.result?.addressDetail.address;
+      const accountNetworkId = netAccountRes.result?.addressDetail.networkId;
+      const currentBalanceToken = {
+        networkId: balanceToken?.networkId,
+        contractAddress: balanceToken?.contractAddress,
+      };
+      const hasOrderContext = Boolean(orderFromToken || orderToToken);
+      const shouldRefreshBalance =
+        !hasOrderContext ||
+        (orderFromToken?.networkId === accountNetworkId &&
+          (equalTokenNoCaseSensitive({
+            token1: orderFromToken,
+            token2: currentBalanceToken,
+          }) ||
+            equalTokenNoCaseSensitive({
+              token1: orderToToken,
+              token2: currentBalanceToken,
+            })));
+
+      if (!accountId || !accountAddress || !balanceToken?.networkId) {
+        balanceRequestIdRef.current += 1;
+        setFetchBalanceLoading(false);
+        setBalance(new BigNumber(0));
+        return;
+      }
+
+      if (!shouldRefreshBalance) {
+        return;
+      }
+
+      const currentRequestId = balanceRequestIdRef.current + 1;
+      balanceRequestIdRef.current = currentRequestId;
+      setFetchBalanceLoading(true);
+
+      try {
+        const tokenDetail =
+          await backgroundApiProxy.serviceSwap.fetchSwapTokenDetails({
+            networkId: balanceToken.networkId,
+            contractAddress: balanceToken.contractAddress ?? '',
+            accountId,
+            accountAddress,
+            currency: 'usd',
+          });
+
+        if (currentRequestId !== balanceRequestIdRef.current) {
+          return;
+        }
+
+        setBalance(new BigNumber(tokenDetail?.[0]?.balanceParsed ?? 0));
+      } catch (_e) {
+        if (currentRequestId !== balanceRequestIdRef.current) {
+          return;
+        }
+
+        setBalance(new BigNumber(0));
+      } finally {
+        if (currentRequestId === balanceRequestIdRef.current) {
           setFetchBalanceLoading(false);
         }
-      } else {
-        setBalance(new BigNumber(0));
       }
     },
     [
@@ -2249,13 +2233,23 @@ export function useSpeedSwapActions(props: {
   );
 
   const fetchTokenPrice = useCallback(async () => {
-    setPriceRate((prev) => ({
-      ...prev,
+    const currentRequestId = priceRequestIdRef.current + 1;
+    priceRequestIdRef.current = currentRequestId;
+
+    setPriceRate({
+      rate: undefined,
+      fromTokenSymbol: fromToken.symbol,
+      toTokenSymbol: toToken.symbol,
       loading: true,
-    }));
+    });
     if (fromToken.price && toToken.price) {
       const fromTokenPriceBN = new BigNumber(fromToken.price || 0);
       const toTokenPriceBN = new BigNumber(toToken.price || 0);
+
+      if (currentRequestId !== priceRequestIdRef.current) {
+        return;
+      }
+
       setPriceRate({
         rate: toTokenPriceBN.isZero()
           ? 0
@@ -2265,7 +2259,20 @@ export function useSpeedSwapActions(props: {
         loading: false,
       });
     } else {
-      if (!fromToken?.networkId || !toToken?.networkId) return;
+      if (!fromToken?.networkId || !toToken?.networkId) {
+        if (currentRequestId !== priceRequestIdRef.current) {
+          return;
+        }
+
+        setPriceRate({
+          rate: undefined,
+          fromTokenSymbol: fromToken.symbol,
+          toTokenSymbol: toToken.symbol,
+          loading: false,
+        });
+        return;
+      }
+
       const [fromTokenPrice, toTokenPrice] = await Promise.all([
         backgroundApiProxy.serviceSwap.fetchSwapTokenDetails({
           networkId: fromToken.networkId ?? '',
@@ -2278,6 +2285,11 @@ export function useSpeedSwapActions(props: {
           currency: 'usd',
         }),
       ]);
+
+      if (currentRequestId !== priceRequestIdRef.current) {
+        return;
+      }
+
       if (fromTokenPrice?.length && toTokenPrice?.length) {
         const fromTokenPriceBN = new BigNumber(fromTokenPrice[0].price || 0);
         const toTokenPriceBN = new BigNumber(toTokenPrice[0].price || 0);
@@ -2289,12 +2301,15 @@ export function useSpeedSwapActions(props: {
           toTokenSymbol: toToken.symbol,
           loading: false,
         });
-      } else {
-        setPriceRate((prev) => ({
-          ...prev,
-          loading: false,
-        }));
+        return;
       }
+
+      setPriceRate({
+        rate: undefined,
+        fromTokenSymbol: fromToken.symbol,
+        toTokenSymbol: toToken.symbol,
+        loading: false,
+      });
     }
   }, [
     fromToken.price,
@@ -2486,17 +2501,7 @@ export function useSpeedSwapActions(props: {
   ]);
 
   useEffect(() => {
-    void syncTokensBalance({
-      orderFromToken: {
-        networkId: balanceToken?.networkId,
-        contractAddress: balanceToken?.contractAddress,
-        symbol: balanceToken?.symbol,
-        decimals: balanceToken?.decimals,
-        logoURI: balanceToken?.logoURI,
-        name: balanceToken?.name,
-        isNative: balanceToken?.isNative,
-      },
-    });
+    void syncTokensBalance({});
   }, [
     balanceToken?.contractAddress,
     balanceToken?.decimals,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -2235,6 +2235,13 @@ export function useSpeedSwapActions(props: {
   const fetchTokenPrice = useCallback(async () => {
     const currentRequestId = priceRequestIdRef.current + 1;
     priceRequestIdRef.current = currentRequestId;
+    const fromTokenPriceBN = new BigNumber(fromToken.price || 0);
+    const toTokenPriceBN = new BigNumber(toToken.price || 0);
+    const canUseInlineTokenPrices =
+      !fromTokenPriceBN.isNaN() &&
+      !toTokenPriceBN.isNaN() &&
+      fromTokenPriceBN.gt(0) &&
+      toTokenPriceBN.gt(0);
 
     setPriceRate({
       rate: undefined,
@@ -2242,10 +2249,7 @@ export function useSpeedSwapActions(props: {
       toTokenSymbol: toToken.symbol,
       loading: true,
     });
-    if (fromToken.price && toToken.price) {
-      const fromTokenPriceBN = new BigNumber(fromToken.price || 0);
-      const toTokenPriceBN = new BigNumber(toToken.price || 0);
-
+    if (canUseInlineTokenPrices) {
       if (currentRequestId !== priceRequestIdRef.current) {
         return;
       }
@@ -2291,12 +2295,16 @@ export function useSpeedSwapActions(props: {
       }
 
       if (fromTokenPrice?.length && toTokenPrice?.length) {
-        const fromTokenPriceBN = new BigNumber(fromTokenPrice[0].price || 0);
-        const toTokenPriceBN = new BigNumber(toTokenPrice[0].price || 0);
+        const fetchedFromTokenPriceBN = new BigNumber(
+          fromTokenPrice[0].price || 0,
+        );
+        const fetchedToTokenPriceBN = new BigNumber(toTokenPrice[0].price || 0);
         setPriceRate({
-          rate: toTokenPriceBN.isZero()
+          rate: fetchedToTokenPriceBN.isZero()
             ? 0
-            : fromTokenPriceBN.dividedBy(toTokenPriceBN).toNumber(),
+            : fetchedFromTokenPriceBN
+                .dividedBy(fetchedToTokenPriceBN)
+                .toNumber(),
           fromTokenSymbol: fromToken.symbol,
           toTokenSymbol: toToken.symbol,
           loading: false,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSwapPanel.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSwapPanel.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import BigNumber from 'bignumber.js';
 
@@ -17,6 +17,10 @@ export function useSwapPanel({
   const [paymentToken, setPaymentToken] = useState<IToken>();
   const [networkId, setNetworkId] = useState(initialNetworkId);
   const [slippage, setSlippage] = useState<number>(0.5);
+  const resetAmounts = useCallback(() => {
+    setPaymentAmount(new BigNumber(0));
+    setSellAmount(new BigNumber(0));
+  }, []);
 
   useEffect(() => {
     if (initialNetworkId) {
@@ -27,6 +31,7 @@ export function useSwapPanel({
   return {
     paymentAmount,
     setPaymentAmount,
+    resetAmounts,
 
     sellAmount,
     setSellAmount,


### PR DESCRIPTION
## Summary
- unify the Market Detail swap panel token source of truth by deriving `fromToken`, `toToken`, and `balanceToken` directly from the current market token and selected payment token
- add stale-response guards for balance and price refreshes so outdated token detail requests cannot overwrite the latest page state
- rerun IP connection selection before the blocked-region refresh action so the Earn blocked-state page can recover after connection conditions change
- reset panel amounts only when the market detail token actually changes and add regression tests for out-of-order balance, price, and blocked-region refresh behavior

## Intent & Context
This PR now covers two related bug fixes.

The original work fixes OK-52557, where switching tokens in Market Detail could leave the swap panel showing the wrong balance token or stale balance value. The original report started from stablecoin-to-stablecoin switching, and follow-up discussion confirmed the same symptom could also happen after switching between tokens on different networks.

The follow-up work fixes OK-52400, where the Earn blocked-region page showed a refresh button that did not actually recover the page after IP connection conditions changed.

## Root Cause
For OK-52557, the swap panel had split token state.
`SwapPanelContent` rendered the selected payment token, while `useSpeedSwapActions` derived balance-related state from a separate `tradeTokenDetail` branch. At the same time, balance and price refreshes did not guard against stale async responses, so older requests could arrive late and overwrite the latest token state.

For OK-52400, the blocked-region refresh action only re-ran `getBlockRegion()`. That method short-circuits when the current connection is still classified as an IP connection, so the refresh action never forced the app to recompute endpoint selection before checking the region gate again.

## Design Decisions
For OK-52557, the fix removes the secondary token identity path instead of adding more synchronization effects.
The selected payment token is now the single source of truth for the trade-side token, and async token detail fetches are treated as data refreshes only.
Request-id guards were added to balance and price refreshes so that only the latest response is allowed to update state.
The amount reset behavior was also narrowed so it runs only after an actual market token change, not on the initial mount.

For OK-52400, the fix keeps the normal blocked-region query lightweight and only upgrades the explicit manual refresh path.
A dedicated `refreshBlockRegion()` path now reruns IP endpoint selection first, then rechecks the blocked-region API. This avoids making every initial page load pay the cost of a full speed test while still making the refresh button actually useful.

## Changes Detail
- update `useSpeedSwapActions` to derive swap/balance tokens directly from `tradeToken` and `marketToken`, and guard balance/price refreshes against stale responses
- update `SwapPanelContent` and `useSwapPanel` to reset amount state safely on detail token changes and normalize empty input to zero instead of `NaN`
- add `refreshBlockRegion()` in `ServiceStaking` and route the Earn blocked-page refresh action through the stronger refresh path
- add hook-level regression tests that simulate out-of-order balance and price responses, plus coverage for blocked-region refresh behavior

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Desktop / Web / Extension
- **Risk Areas**: Market Detail swap panel state sync, amount reset timing, async balance and price refreshes, Earn blocked-region recovery flow

## Test plan
- [x] `yarn jest packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel --runInBand`
- [x] `yarn jest packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.test.tsx packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.test.tsx --runInBand`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx`
- [x] `npx eslint packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx`
- [x] `yarn jest packages/kit/src/views/Earn/hooks/useBlockRegion.test.tsx --runInBand`
- [x] `npx eslint packages/kit-bg/src/services/ServiceStaking.ts packages/kit/src/views/Earn/hooks/useBlockRegion.ts packages/kit/src/views/Earn/hooks/useBlockRegion.test.tsx`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
