### PR TITLE
fix(send): fix memo field not working on mobile (OK-52850)

### DIFF
--- a/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
@@ -13,7 +13,6 @@ import type {
 } from '@onekeyhq/components';
 import {
   Alert,
-  Button,
   Form,
   Page,
   SizableText,
@@ -29,7 +28,6 @@ import {
   type IAddressInputValue,
 } from '@onekeyhq/kit/src/components/AddressInput';
 import { renderAddressSecurityHeaderRightButton } from '@onekeyhq/kit/src/components/AddressInput/AddressSecurityHeaderRightButton';
-import { BaseInput } from '@onekeyhq/kit/src/components/BaseInput';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import { useAccountData } from '@onekeyhq/kit/src/hooks/useAccountData';
@@ -562,31 +560,29 @@ function SendDataInputContainer() {
     if (isNumericMemo) {
       memoInputLines = memoValue?.length ? 2 : 1;
     }
-    const clearMemoExtension = memoValue ? (
-      <XStack justifyContent="flex-end">
-        <Button
-          size="small"
-          variant="secondary"
-          icon="BroomOutline"
-          onPress={() =>
-            form.setValue('memo', '', {
-              shouldValidate: true,
-            })
-          }
-        >
-          {intl.formatMessage({
-            id: ETranslations.global_clear,
-          })}
-        </Button>
-      </XStack>
-    ) : undefined;
-
     return (
       <>
         <Form.Field
           label={intl.formatMessage({ id: ETranslations.send_tag })}
           optional
           name="memo"
+          labelAddon={
+            memoValue ? (
+              <SizableText
+                size="$bodyMd"
+                color="$textSubdued"
+                cursor="pointer"
+                hoverStyle={{ color: '$text' }}
+                onPress={() =>
+                  form.setValue('memo', '', {
+                    shouldValidate: true,
+                  })
+                }
+              >
+                {intl.formatMessage({ id: ETranslations.global_clear })}
+              </SizableText>
+            ) : undefined
+          }
           rules={{
             maxLength: supportsMemoValidation
               ? undefined
@@ -604,7 +600,7 @@ function SendDataInputContainer() {
             validate: validateMemoField,
           }}
         >
-          <BaseInput
+          <TextArea
             numberOfLines={memoInputLines}
             size={media.gtMd ? 'medium' : 'large'}
             placeholder={intl.formatMessage({
@@ -613,7 +609,6 @@ function SendDataInputContainer() {
             keyboardType={
               isNumericMemo && platformEnv.isNative ? 'number-pad' : undefined
             }
-            extension={clearMemoExtension}
           />
         </Form.Field>
       </>


### PR DESCRIPTION
## Summary
- Fix **[OK-52850](https://onekeyhq.atlassian.net/browse/OK-52850)**: memo field on mobile — typing memo gets auto-deleted because `BaseInput` (kit component) is unrecognized by Form's `getChildProps` switch statement
- `getChildProps` only maps `onChangeText` for `Input`/`TextAreaInput`/`TextArea` (components package). `BaseInput` falls into `default` case which passes `onChange` — on React Native this receives a native event object instead of a string, corrupting the form value
- Replace `BaseInput` with `TextArea` (recognized by Form), move clear button from `extension` prop to `labelAddon` (matching paymentId/note pattern)

## Test plan
- [ ] Mobile (iOS/Android): Send on a chain with memo (Cosmos/XRP/Stellar/TON) — type memo, verify it persists
- [ ] Mobile: Clear button in memo label works correctly
- [ ] Desktop/Web: Memo input still works as before
- [ ] PaymentId (DNX) and Note (Algorand) fields unaffected

[OK-52850]: https://onekeyhq.atlassian.net/browse/OK-52850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ