### PR TITLE
fix: preserve swap custom recipient selection(OK-52848)

### DIFF
--- a/packages/kit/src/views/Swap/hooks/useSwapAccount.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapAccount.ts
@@ -27,6 +27,8 @@ import {
   useSwapToAnotherAccountAddressAtom,
 } from '../../../states/jotai/contexts/swap';
 
+import { shouldUseSwapCustomRecipientAddress } from './useSwapAccount.utils';
+
 import type { IAccountSelectorActiveAccountInfo } from '../../../states/jotai/contexts/accountSelector';
 
 /**
@@ -301,26 +303,28 @@ export function useSwapAddressInfo(type: ESwapDirectionType) {
       accountInfo: undefined,
       activeAccount: undefined,
     };
+    // Keep the confirmed custom recipient even when cross-chain TO account
+    // resolution has not materialized a network account yet.
     if (
-      type === ESwapDirectionType.TO &&
-      swapToAnotherAccountSwitchOn &&
-      swapToAnotherAccountAddressAtom.address &&
-      swapToAnotherAccountAddressAtom.networkId &&
-      swapToAnotherAccountAddressAtom.accountInfo &&
-      swapToAnotherAccountAddressAtom.accountInfo.account &&
-      activeAccount &&
-      activeAccount.account &&
-      (activeAccount.network?.id ===
-        swapToAnotherAccountAddressAtom.networkId ||
-        isAllNetwork)
+      shouldUseSwapCustomRecipientAddress({
+        type,
+        swapToAnotherAccountSwitchOn,
+        selectedRecipientAddress: swapToAnotherAccountAddressAtom.address,
+        selectedRecipientNetworkId: swapToAnotherAccountAddressAtom.networkId,
+        activeNetworkId: activeAccount.network?.id,
+        tokenNetworkId,
+        isAllNetwork,
+      })
     ) {
       return {
         ...res,
         address: swapToAnotherAccountAddressAtom.address ?? '',
         networkId: swapToAnotherAccountAddressAtom.networkId ?? '',
-        accountInfo: {
-          ...swapToAnotherAccountAddressAtom.accountInfo,
-        },
+        accountInfo: swapToAnotherAccountAddressAtom.accountInfo
+          ? {
+              ...swapToAnotherAccountAddressAtom.accountInfo,
+            }
+          : undefined,
         activeAccount: {
           ...activeAccount,
         },

--- a/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.test.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.test.ts
@@ -1,0 +1,47 @@
+import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
+
+import { shouldUseSwapCustomRecipientAddress } from './useSwapAccount.utils';
+
+describe('shouldUseSwapCustomRecipientAddress', () => {
+  it('keeps a confirmed custom recipient when the TO account is still empty', () => {
+    expect(
+      shouldUseSwapCustomRecipientAddress({
+        type: ESwapDirectionType.TO,
+        swapToAnotherAccountSwitchOn: true,
+        selectedRecipientAddress: '0x1234',
+        selectedRecipientNetworkId: 'evm--1',
+        activeNetworkId: 'evm--1',
+        tokenNetworkId: 'evm--1',
+        isAllNetwork: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('falls back when the confirmed recipient belongs to another network', () => {
+    expect(
+      shouldUseSwapCustomRecipientAddress({
+        type: ESwapDirectionType.TO,
+        swapToAnotherAccountSwitchOn: true,
+        selectedRecipientAddress: '0x1234',
+        selectedRecipientNetworkId: 'evm--1',
+        activeNetworkId: 'evm--10',
+        tokenNetworkId: 'evm--10',
+        isAllNetwork: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('allows the confirmed recipient on all-network accounts', () => {
+    expect(
+      shouldUseSwapCustomRecipientAddress({
+        type: ESwapDirectionType.TO,
+        swapToAnotherAccountSwitchOn: true,
+        selectedRecipientAddress: '0x1234',
+        selectedRecipientNetworkId: 'evm--1',
+        activeNetworkId: 'onekeyall--all',
+        tokenNetworkId: 'evm--1',
+        isAllNetwork: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.ts
@@ -1,0 +1,39 @@
+import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
+
+type IShouldUseSwapCustomRecipientAddressParams = {
+  type: ESwapDirectionType;
+  swapToAnotherAccountSwitchOn: boolean;
+  selectedRecipientAddress?: string;
+  selectedRecipientNetworkId?: string;
+  activeNetworkId?: string;
+  tokenNetworkId?: string;
+  isAllNetwork: boolean;
+};
+
+export function shouldUseSwapCustomRecipientAddress({
+  type,
+  swapToAnotherAccountSwitchOn,
+  selectedRecipientAddress,
+  selectedRecipientNetworkId,
+  activeNetworkId,
+  tokenNetworkId,
+  isAllNetwork,
+}: IShouldUseSwapCustomRecipientAddressParams) {
+  if (type !== ESwapDirectionType.TO) {
+    return false;
+  }
+
+  if (
+    !swapToAnotherAccountSwitchOn ||
+    !selectedRecipientAddress ||
+    !selectedRecipientNetworkId
+  ) {
+    return false;
+  }
+
+  return (
+    isAllNetwork ||
+    activeNetworkId === selectedRecipientNetworkId ||
+    tokenNetworkId === selectedRecipientNetworkId
+  );
+}

--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -417,7 +417,7 @@ const SwapActionsState = ({
           <Stack>
             <Icon name="AddedPeopleOutline" size="$5" color="$iconSubdued" />
           </Stack>
-          <XStack flex={1} flexWrap="wrap" gap="$1.5">
+          <XStack flex={1} flexWrap="wrap" gap="$1.5" minWidth={0}>
             <SizableText flexShrink={0} size="$bodyMd" color="$textSubdued">
               {intl.formatMessage({
                 id: ETranslations.swap_page_recipient_send_to,
@@ -437,8 +437,8 @@ const SwapActionsState = ({
             </SizableText>
             {swapRecipientAddressInfo?.showAddress ? (
               <SizableText
-                numberOfLines={1}
-                flexShrink={0}
+                flexShrink={1}
+                minWidth={0}
                 size="$bodyMd"
                 color="$textSubdued"
               >
@@ -477,15 +477,11 @@ const SwapActionsState = ({
     }
 
     return (
-      <XStack
-        flex={isDesktopModalPage ? undefined : 1}
-        justifyContent={isDesktopModalPage ? undefined : 'flex-end'}
-        minWidth={0}
-      >
+      <XStack minWidth={0} maxWidth="100%">
         <XStack
           gap="$1.5"
           flexWrap="wrap"
-          justifyContent={isDesktopModalPage ? 'flex-start' : 'flex-end'}
+          justifyContent="flex-start"
           maxWidth="100%"
         >
           <Stack>
@@ -493,7 +489,7 @@ const SwapActionsState = ({
           </Stack>
           <XStack
             flexWrap="wrap"
-            justifyContent={isDesktopModalPage ? 'flex-start' : 'flex-end'}
+            justifyContent="flex-start"
             gap="$1.5"
             minWidth={0}
           >
@@ -516,8 +512,8 @@ const SwapActionsState = ({
             </SizableText>
             {swapRecipientAddressInfo?.showAddress ? (
               <SizableText
-                numberOfLines={1}
                 flexShrink={1}
+                minWidth={0}
                 size="$bodyMd"
                 color="$textSubdued"
               >
@@ -539,7 +535,6 @@ const SwapActionsState = ({
       </XStack>
     );
   }, [
-    isDesktopModalPage,
     intl,
     onOpenRecipientAddress,
     shouldShowRecipientInMetaRow,
@@ -678,6 +673,7 @@ const SwapActionsState = ({
         <XStack
           gap="$4"
           alignItems="center"
+          flexWrap="wrap"
           justifyContent="space-between"
           width="100%"
         >


### PR DESCRIPTION
## Summary
- preserve the confirmed custom recipient address when the swap TO account has not materialized yet in cross-chain flows
- keep the selected recipient visible on the swap page after confirmation and allow the recipient row to wrap cleanly when space is tight
- add a focused regression test for the custom recipient guard logic

## Intent & Context
This change fixes the swap recipient regression reported in OK-52848. After a user selected a custom recipient address and confirmed it, the swap page still showed the add-recipient placeholder and downstream quote/build flows fell back to the default destination address.

## Root Cause
The confirmed custom recipient was written into swap state correctly, but `useSwapAddressInfo(TO)` required both `swapToAnotherAccountAddressAtom.accountInfo.account` and the current TO `activeAccount.account` to exist before it would honor that custom recipient. In cross-chain scenarios the TO side can have network context without a materialized account entity, so the selected recipient was discarded and the UI plus receiving address payload both fell back.

## Design Decisions
The fix stays narrow and only changes recipient resolution for the TO side after confirmation. We now keep using the confirmed custom recipient as long as the recipient switch is on and the selected recipient network still matches the active target context. The layout adjustment in `SwapActionsState` keeps the existing single-line behavior when space is available, but lets the recipient row wrap and stay left-aligned when the row overflows.

## Changes Detail
- `packages/kit/src/views/Swap/hooks/useSwapAccount.ts`: relax the TO-side custom recipient guard so a confirmed recipient remains effective in cross-chain empty-account cases
- `packages/kit/src/views/Swap/hooks/useSwapAccount.utils.ts`: extract the custom recipient guard into a focused helper
- `packages/kit/src/views/Swap/hooks/useSwapAccount.utils.test.ts`: add regression coverage for matching, mismatching, and all-network scenarios
- `packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx`: update recipient row wrapping/alignment so overflow wraps onto the next line cleanly

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Desktop / Web
- **Risk Areas**: swap recipient state resolution, recipient row layout wrapping

## Test plan
- [ ] In a cross-chain swap flow, select a custom recipient address and confirm that the swap page shows the chosen address instead of the add-recipient placeholder
- [ ] Verify quote/build uses the selected receiving address after confirmation
- [ ] Verify the recipient row stays on one line when there is enough width and wraps left-aligned when space is constrained
- [x] `yarn jest packages/kit/src/views/Swap/hooks/useSwapAccount.utils.test.ts packages/kit/src/views/Swap/utils/incognitoSettings.test.ts --runInBand`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `npx oxlint packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx`
- [x] `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
