### PR TITLE
fix: adjust trade incognito tooltip(OK-52871)

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -345,7 +345,7 @@ const SwapActionsState = ({
               size="$5"
               color="$iconSubdued"
             />
-            {gtMd ? (
+            {!platformEnv.isNative && gtMd ? (
               <Tooltip
                 placement="top"
                 hovering

--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -11,15 +11,17 @@ import {
   Icon,
   LottieView,
   Page,
+  Popover,
   SizableText,
   Stack,
   Switch,
+  Tooltip,
   XStack,
-  YStack,
   resetToRoute,
   useIsOverlayPage,
   useMedia,
 } from '@onekeyhq/components';
+import { FormatHyperlinkText } from '@onekeyhq/kit/src/components/HyperlinkText';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useHelpLink } from '@onekeyhq/kit/src/hooks/useHelpLink';
 import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
@@ -148,7 +150,7 @@ const SwapActionsState = ({
   const quoting = useSwapQuoteEventFetching();
 
   const isModalPage = useIsOverlayPage();
-  const { md } = useMedia();
+  const { gtMd, md } = useMedia();
   const isDesktopModalPage = isModalPage && !md;
   const incognitoHelpLink = useHelpLink({
     path: 'articles/14430164',
@@ -156,19 +158,39 @@ const SwapActionsState = ({
   const incognitoTitle = intl.formatMessage({
     id: ETranslations.trade_incognito_incognito_mode,
   });
-  const incognitoReadMore = intl.formatMessage({
-    id: ETranslations.trade_incognito_read_more,
-  });
-  const incognitoTooltip = useMemo(
+  const incognitoTooltipDescription = useMemo(
     () =>
-      intl.formatMessage({
+      `${intl.formatMessage({
         id: ETranslations.trade_incognito_description,
-      }),
-    [intl],
+      })} <url>${incognitoHelpLink}<underline>${intl.formatMessage({
+        id: ETranslations.trade_incognito_read_more,
+      })}</underline></url>`,
+    [incognitoHelpLink, intl],
   );
-  const handleOpenIncognitoHelp = useCallback(() => {
-    openUrlExternal(incognitoHelpLink);
-  }, [incognitoHelpLink]);
+  const incognitoTooltipContent = useMemo(
+    () => (
+      <FormatHyperlinkText
+        autoExecuteParsedAction={false}
+        onAction={openUrlExternal}
+        size="$bodyLg"
+        color="$text"
+        urlTextProps={{
+          color: '$textInfo',
+        }}
+      >
+        {incognitoTooltipDescription}
+      </FormatHyperlinkText>
+    ),
+    [incognitoTooltipDescription],
+  );
+  const incognitoPopoverContent = useMemo(
+    () => (
+      <Stack px="$5" pt="$1" pb="$5">
+        {incognitoTooltipContent}
+      </Stack>
+    ),
+    [incognitoTooltipContent],
+  );
 
   const onActionHandlerBefore = useCallback(async () => {
     if (swapActionState.noConnectWallet) {
@@ -316,50 +338,62 @@ const SwapActionsState = ({
   const incognitoComponent = useMemo(
     () =>
       swapTypeSwitch === ESwapTabSwitchType.LIMIT ? null : (
-        <YStack gap="$1">
-          <XStack alignItems="center" gap="$2">
-            <XStack alignItems="center" gap="$1.5">
-              <Icon
-                name="AnonymousHiddenOutline"
-                size="$5"
-                color="$iconSubdued"
+        <XStack alignItems="center" gap="$2">
+          <XStack alignItems="center" gap="$1.5">
+            <Icon
+              name="AnonymousHiddenOutline"
+              size="$5"
+              color="$iconSubdued"
+            />
+            {gtMd ? (
+              <Tooltip
+                placement="top"
+                hovering
+                renderTrigger={
+                  <DashText
+                    size="$bodyMd"
+                    color="$textSubdued"
+                    dashColor="$textDisabled"
+                    dashThickness={0.5}
+                    cursor="help"
+                  >
+                    {incognitoTitle}
+                  </DashText>
+                }
+                renderContent={incognitoTooltipContent}
               />
-              <DashText
-                size="$bodyMd"
-                color="$textSubdued"
-                dashColor="$textDisabled"
-                dashThickness={0.5}
-                tooltip={incognitoTooltip}
-                tooltipTitle={incognitoTitle}
-              >
-                {incognitoTitle}
-              </DashText>
-            </XStack>
-            <Stack ml={platformEnv.isNative ? '$-2' : undefined}>
-              <Switch
-                size={ESwitchSize.extraSmall}
-                value={swapIncognitoMode}
-                onChange={onIncognitoModeChange}
+            ) : (
+              <Popover
+                title={incognitoTitle}
+                renderTrigger={
+                  <DashText
+                    size="$bodyMd"
+                    color="$textSubdued"
+                    dashColor="$textDisabled"
+                    dashThickness={0.5}
+                    cursor="help"
+                  >
+                    {incognitoTitle}
+                  </DashText>
+                }
+                renderContent={incognitoPopoverContent}
               />
-            </Stack>
+            )}
           </XStack>
-          <XStack alignSelf="flex-start" pl="$6" onPress={handleOpenIncognitoHelp}>
-            <SizableText
-              size="$bodySm"
-              color="$textInfo"
-              cursor="pointer"
-              textDecorationLine="underline"
-            >
-              {incognitoReadMore}
-            </SizableText>
-          </XStack>
-        </YStack>
+          <Stack ml={platformEnv.isNative ? '$-2' : undefined}>
+            <Switch
+              size={ESwitchSize.extraSmall}
+              value={swapIncognitoMode}
+              onChange={onIncognitoModeChange}
+            />
+          </Stack>
+        </XStack>
       ),
     [
-      handleOpenIncognitoHelp,
-      incognitoReadMore,
+      gtMd,
+      incognitoPopoverContent,
+      incognitoTooltipContent,
       incognitoTitle,
-      incognitoTooltip,
       onIncognitoModeChange,
       swapIncognitoMode,
       swapTypeSwitch,

--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -15,11 +15,13 @@ import {
   Stack,
   Switch,
   XStack,
+  YStack,
   resetToRoute,
   useIsOverlayPage,
   useMedia,
 } from '@onekeyhq/components';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { useHelpLink } from '@onekeyhq/kit/src/hooks/useHelpLink';
 import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
 import {
   useSwapActions,
@@ -47,6 +49,7 @@ import {
   ERootRoutes,
 } from '@onekeyhq/shared/src/routes';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 import {
   ESwapDirectionType,
   ESwapQuoteKind,
@@ -147,8 +150,14 @@ const SwapActionsState = ({
   const isModalPage = useIsOverlayPage();
   const { md } = useMedia();
   const isDesktopModalPage = isModalPage && !md;
+  const incognitoHelpLink = useHelpLink({
+    path: 'articles/14430164',
+  });
   const incognitoTitle = intl.formatMessage({
     id: ETranslations.trade_incognito_incognito_mode,
+  });
+  const incognitoReadMore = intl.formatMessage({
+    id: ETranslations.trade_incognito_read_more,
   });
   const incognitoTooltip = useMemo(
     () =>
@@ -157,6 +166,9 @@ const SwapActionsState = ({
       }),
     [intl],
   );
+  const handleOpenIncognitoHelp = useCallback(() => {
+    openUrlExternal(incognitoHelpLink);
+  }, [incognitoHelpLink]);
 
   const onActionHandlerBefore = useCallback(async () => {
     if (swapActionState.noConnectWallet) {
@@ -304,34 +316,48 @@ const SwapActionsState = ({
   const incognitoComponent = useMemo(
     () =>
       swapTypeSwitch === ESwapTabSwitchType.LIMIT ? null : (
-        <XStack alignItems="center" gap="$2">
-          <XStack alignItems="center" gap="$1.5">
-            <Icon
-              name="AnonymousHiddenOutline"
-              size="$5"
-              color="$iconSubdued"
-            />
-            <DashText
-              size="$bodyMd"
-              color="$textSubdued"
-              dashColor="$textDisabled"
-              dashThickness={0.5}
-              tooltip={incognitoTooltip}
-              tooltipTitle={incognitoTitle}
-            >
-              {incognitoTitle}
-            </DashText>
+        <YStack gap="$1">
+          <XStack alignItems="center" gap="$2">
+            <XStack alignItems="center" gap="$1.5">
+              <Icon
+                name="AnonymousHiddenOutline"
+                size="$5"
+                color="$iconSubdued"
+              />
+              <DashText
+                size="$bodyMd"
+                color="$textSubdued"
+                dashColor="$textDisabled"
+                dashThickness={0.5}
+                tooltip={incognitoTooltip}
+                tooltipTitle={incognitoTitle}
+              >
+                {incognitoTitle}
+              </DashText>
+            </XStack>
+            <Stack ml={platformEnv.isNative ? '$-2' : undefined}>
+              <Switch
+                size={ESwitchSize.extraSmall}
+                value={swapIncognitoMode}
+                onChange={onIncognitoModeChange}
+              />
+            </Stack>
           </XStack>
-          <Stack ml={platformEnv.isNative ? '$-2' : undefined}>
-            <Switch
-              size={ESwitchSize.extraSmall}
-              value={swapIncognitoMode}
-              onChange={onIncognitoModeChange}
-            />
-          </Stack>
-        </XStack>
+          <XStack alignSelf="flex-start" pl="$6" onPress={handleOpenIncognitoHelp}>
+            <SizableText
+              size="$bodySm"
+              color="$textInfo"
+              cursor="pointer"
+              textDecorationLine="underline"
+            >
+              {incognitoReadMore}
+            </SizableText>
+          </XStack>
+        </YStack>
       ),
     [
+      handleOpenIncognitoHelp,
+      incognitoReadMore,
       incognitoTitle,
       incognitoTooltip,
       onIncognitoModeChange,

--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -1,14 +1,12 @@
-import { memo, useCallback, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useMemo, useRef } from 'react';
 
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
-import type { ICheckedState } from '@onekeyhq/components';
 import {
   Badge,
   Button,
-  Checkbox,
-  Dialog,
+  DashText,
   ESwitchSize,
   Icon,
   LottieView,
@@ -17,14 +15,11 @@ import {
   Stack,
   Switch,
   XStack,
-  YStack,
   resetToRoute,
   useIsOverlayPage,
   useMedia,
 } from '@onekeyhq/components';
-import { FormatHyperlinkText } from '@onekeyhq/kit/src/components/HyperlinkText';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
-import { useHelpLink } from '@onekeyhq/kit/src/hooks/useHelpLink';
 import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
 import {
   useSwapActions,
@@ -52,7 +47,6 @@ import {
   ERootRoutes,
 } from '@onekeyhq/shared/src/routes';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
-import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 import {
   ESwapDirectionType,
   ESwapQuoteKind,
@@ -105,70 +99,6 @@ function PageFooter({
   );
 }
 
-function SwapIncognitoDialogContent({
-  onConfirm,
-}: {
-  onConfirm: () => Promise<void>;
-}) {
-  const intl = useIntl();
-  const [checked, setChecked] = useState<ICheckedState>(false);
-  const incognitoHelpLink = useHelpLink({
-    path: 'articles/14430164',
-  });
-
-  const description = useMemo(
-    () =>
-      `${intl.formatMessage({
-        id: ETranslations.trade_incognito_description,
-      })} <url>${incognitoHelpLink}<underline>${intl.formatMessage({
-        id: ETranslations.trade_incognito_read_more,
-      })}</underline></url>`,
-    [incognitoHelpLink, intl],
-  );
-
-  return (
-    <YStack gap="$4">
-      <FormatHyperlinkText
-        autoExecuteParsedAction={false}
-        onAction={openUrlExternal}
-        size="$bodyLg"
-        color="$text"
-        urlTextProps={{
-          color: '$textInfo',
-        }}
-      >
-        {description}
-      </FormatHyperlinkText>
-      <XStack alignItems="flex-start" gap="$2">
-        <Checkbox
-          labelContainerProps={{
-            flex: 1,
-          }}
-          label={intl.formatMessage({
-            id: ETranslations.trade_incognito_kyc_warning,
-          })}
-          value={checked}
-          onChange={setChecked}
-          labelProps={{
-            variant: '$bodyMd',
-            color: '$textSubdued',
-          }}
-        />
-      </XStack>
-      <Dialog.Footer
-        showCancelButton={false}
-        confirmButtonProps={{
-          disabled: !checked,
-        }}
-        onConfirm={onConfirm}
-        onConfirmText={intl.formatMessage({
-          id: ETranslations.global_confirm,
-        })}
-      />
-    </YStack>
-  );
-}
-
 const SwapActionsState = ({
   onPreSwap,
   onOpenRecipientAddress,
@@ -217,6 +147,21 @@ const SwapActionsState = ({
   const isModalPage = useIsOverlayPage();
   const { md } = useMedia();
   const isDesktopModalPage = isModalPage && !md;
+  const incognitoTitle = intl.formatMessage({
+    id: ETranslations.trade_incognito_incognito_mode,
+  });
+  const incognitoTooltip = useMemo(
+    () =>
+      [
+        intl.formatMessage({
+          id: ETranslations.trade_incognito_description,
+        }),
+        intl.formatMessage({
+          id: ETranslations.trade_incognito_kyc_warning,
+        }),
+      ].join('\n\n'),
+    [intl],
+  );
 
   const onActionHandlerBefore = useCallback(async () => {
     if (swapActionState.noConnectWallet) {
@@ -356,27 +301,9 @@ const SwapActionsState = ({
 
   const onIncognitoModeChange = useCallback(
     (value: boolean) => {
-      if (!value) {
-        applyIncognitoModeChange(false);
-        return;
-      }
-
-      void Dialog.show({
-        icon: 'AnonymousHiddenOutline',
-        title: intl.formatMessage({
-          id: ETranslations.trade_incognito_title,
-        }),
-        showFooter: false,
-        renderContent: (
-          <SwapIncognitoDialogContent
-            onConfirm={async () => {
-              applyIncognitoModeChange(true);
-            }}
-          />
-        ),
-      });
+      applyIncognitoModeChange(value);
     },
-    [applyIncognitoModeChange, intl],
+    [applyIncognitoModeChange],
   );
 
   const incognitoComponent = useMemo(
@@ -389,11 +316,16 @@ const SwapActionsState = ({
               size="$5"
               color="$iconSubdued"
             />
-            <SizableText size="$bodyMd" color="$textSubdued">
-              {intl.formatMessage({
-                id: ETranslations.trade_incognito_incognito_mode,
-              })}
-            </SizableText>
+            <DashText
+              size="$bodyMd"
+              color="$textSubdued"
+              dashColor="$textDisabled"
+              dashThickness={0.5}
+              tooltip={incognitoTooltip}
+              tooltipTitle={incognitoTitle}
+            >
+              {incognitoTitle}
+            </DashText>
           </XStack>
           <Stack ml={platformEnv.isNative ? '$-2' : undefined}>
             <Switch
@@ -404,7 +336,13 @@ const SwapActionsState = ({
           </Stack>
         </XStack>
       ),
-    [intl, onIncognitoModeChange, swapIncognitoMode, swapTypeSwitch],
+    [
+      incognitoTitle,
+      incognitoTooltip,
+      onIncognitoModeChange,
+      swapIncognitoMode,
+      swapTypeSwitch,
+    ],
   );
 
   const recipientComponent = useMemo(() => {

--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -152,14 +152,9 @@ const SwapActionsState = ({
   });
   const incognitoTooltip = useMemo(
     () =>
-      [
-        intl.formatMessage({
-          id: ETranslations.trade_incognito_description,
-        }),
-        intl.formatMessage({
-          id: ETranslations.trade_incognito_kyc_warning,
-        }),
-      ].join('\n\n'),
+      intl.formatMessage({
+        id: ETranslations.trade_incognito_description,
+      }),
     [intl],
   );
 


### PR DESCRIPTION
## Summary
- replace the interactive incognito confirmation dialog with a dashed-text tooltip entry in Trade
- keep the tooltip body content aligned with the previous dialog copy by reusing the same inline `Read more` hyperlink treatment inside the explanation text
- keep the mobile popover title aligned to `Incognito mode`, remove the old checkbox flow, and leave the existing incognito settings update and quote refresh logic unchanged

## Intent & Context
This PR addresses `OK-52871`, which asks for the Trade incognito explanation to move to the label itself: desktop should show it on hover, mobile should show it on tap, and the tooltip should not keep the old confirmation checkbox interaction.

## Root Cause
The previous implementation surfaced the incognito explanation only after toggling the switch on, via a confirmation dialog that mixed education with confirmation. That put the explanation behind the wrong trigger and coupled it to a checkbox flow that no longer matches the spec.

## Design Decisions
- Use desktop `Tooltip` plus mobile `Popover` so the trigger behavior matches the Jira description without changing the underlying incognito toggle logic.
- Keep the explanation content visually aligned with the previous dialog by reusing the same `FormatHyperlinkText` structure and inline `Read more` link instead of inventing a new tooltip layout.
- Remove only the obsolete checkbox/confirm interaction while preserving the existing help-center destination and swap state update flow.

## Changes Detail
- remove `SwapIncognitoDialogContent` and the dialog flow that used to gate turning incognito mode on
- render the `Incognito mode` label as dashed text and show its explanation through tooltip/popover on desktop/mobile respectively
- reuse the previous explanation copy and inline `Read more` hyperlink inside the tooltip content
- keep the switch applying the setting directly through the existing incognito settings update path

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Mobile / Responsive Swap UI
- **Risk Areas**: Tooltip/popover presentation and the inline help link behavior inside the new content container

## Test plan
- [ ] On desktop, hover the `Incognito mode` dashed label and verify the tooltip shows the explanation with the inline `Read more` hyperlink.
- [ ] On mobile or a narrow layout, tap the `Incognito mode` dashed label and verify the popover title is `Incognito mode` and the body copy matches the old dialog layout without the checkbox.
- [ ] Click `Read more` and verify it still opens the original help-center article.
- [ ] Toggle the incognito switch on and off and verify the swap quote refresh flow still updates correctly.
