### PR TITLE
fix(ext): disable automatic biometric trigger on unlock screen

### DIFF
--- a/packages/kit/src/components/Password/components/PasswordVerify.tsx
+++ b/packages/kit/src/components/Password/components/PasswordVerify.tsx
@@ -238,6 +238,7 @@ function PasswordVerify({
         return;
       }
       if (
+        !platformEnv.isExtension &&
         isEnable &&
         !passwordInput &&
         status.value === EPasswordVerifyStatus.DEFAULT &&
@@ -267,6 +268,7 @@ function PasswordVerify({
     if (now - lastTime.current > 1000) {
       lastTime.current = now;
       if (
+        !platformEnv.isExtension &&
         isEnable &&
         !passwordInput &&
         status.value === EPasswordVerifyStatus.DEFAULT &&


### PR DESCRIPTION
### Motivation
- Make browser extension (plugin) unlock behave like other platforms by requiring the user to manually tap the biometric button instead of automatically invoking biometric auth, to avoid stuck/hidden prompts reported in the extension.

### Description
- Add `!platformEnv.isExtension` guards to the automatic biometric triggers in `PasswordVerify` so the initial `onBiologyAuth()` call and the app-foreground `onActive` auto-trigger are skipped for the extension; other platform behavior is unchanged (file: `packages/kit/src/components/Password/components/PasswordVerify.tsx`).

### Testing
- Ran `git status --short && git diff -- packages/kit/src/components/Password/components/PasswordVerify.tsx` to verify the change was applied and committed successfully. 
- Attempted to run `yarn run eslint packages/kit/src/components/Password/components/PasswordVerify.tsx`, but lint could not run because the environment is missing the repository `node_modules` state, so automated lint checks were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d74a167a9c8332b601543239957c86)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
