### PR TITLE
fix: use bgSubdued for LazyLoadPage in desktop mode UI(OK-52838)

### DIFF
--- a/packages/kit/src/components/LazyLoadPage/index.tsx
+++ b/packages/kit/src/components/LazyLoadPage/index.tsx
@@ -1,7 +1,11 @@
 import { memo } from 'react';
 import type { ComponentType } from 'react';
 
-import { Spinner, Stack } from '@onekeyhq/components';
+import {
+  Spinner,
+  Stack,
+  useIsDesktopModeUIInTabPages,
+} from '@onekeyhq/components';
 import LazyLoad from '@onekeyhq/shared/src/lazyLoad';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
@@ -33,12 +37,18 @@ export function LazyLoadPage<
     fallback ?? defaultFallback,
   );
   function LazyLoadPageContainer(props: IExtractComponentProps<T>) {
+    const isDesktopModeUI = useIsDesktopModeUIInTabPages();
+
     if (unStyle) {
       return <LazyLoadComponent {...props} />;
     }
 
     return (
-      <Stack flex={1} className="LazyLoadPageContainer" bg="$bgApp">
+      <Stack
+        flex={1}
+        className="LazyLoadPageContainer"
+        bg={isDesktopModeUI ? '$bgSubdued' : '$bgApp'}
+      >
         <LazyLoadComponent {...props} />
       </Stack>
     );


### PR DESCRIPTION
## Summary
- Use `$bgSubdued` instead of `$bgApp` as the background color for `LazyLoadPage` container when in desktop mode UI tab pages
- Import and use `useIsDesktopModeUIInTabPages` hook to detect desktop mode context

## Root Cause
In desktop mode UI, tab pages use `$bgSubdued` as the standard background color, but `LazyLoadPage` was hardcoded to use `$bgApp`, causing a visual mismatch with the surrounding layout.

## Changes Detail
- `packages/kit/src/components/LazyLoadPage/index.tsx`: Added `useIsDesktopModeUIInTabPages` import and conditionally applied `$bgSubdued` background when in desktop mode UI, falling back to `$bgApp` otherwise.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop (desktop mode UI)
- **Risk Areas**: Minimal — only affects background color of lazy-loaded page containers in desktop mode

## Test plan
- [ ] Verify LazyLoadPage background matches surrounding content in desktop mode UI tab pages
- [ ] Verify no visual regression on mobile and normal desktop mode
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
