### PR TITLE
fix(perps): hide FavoritesBar in expand view to fix layout break (OK-52898)

### DIFF
--- a/packages/kit/src/views/Perp/layouts/PerpDesktopLayout.tsx
+++ b/packages/kit/src/views/Perp/layouts/PerpDesktopLayout.tsx
@@ -124,7 +124,7 @@ function PerpDesktopLayout() {
     >
       <YStack flex={chartExpanded ? 1 : undefined}>
         <PerpTips />
-        <FavoritesBar />
+        {!chartExpanded && <FavoritesBar />}
 
         <YStack
           flex={chartExpanded ? 1 : undefined}

--- a/packages/kit/src/views/Perp/layouts/PerpDesktopLayout.web.tsx
+++ b/packages/kit/src/views/Perp/layouts/PerpDesktopLayout.web.tsx
@@ -119,7 +119,7 @@ function PerpDesktopLayout() {
     >
       <YStack flex={chartExpanded ? 1 : undefined}>
         <PerpTips />
-        <FavoritesBar />
+        {!chartExpanded && <FavoritesBar />}
 
         <YStack
           flex={chartExpanded ? 1 : undefined}


### PR DESCRIPTION
## Summary

- When `chartExpanded=true`, `FavoritesBar` was still rendered and occupied 40px in the flex container
- This prevented the chart from filling the full viewport height
- The bug only appeared **when the user had favorites** because `FavoritesBar` returns `null` with no favorites

## Root Cause

In `chartExpanded` mode, the layout switches to a `flex=1` chain intended to make the chart fill the viewport. However `FavoritesBar` was not conditionally hidden like other panels (Trading Panel, Order Info Panel), so it competed for height in the flex container.

## Fix

Conditionally hide `FavoritesBar` when `chartExpanded=true` in both layout files, consistent with how other panels are handled.

## Test plan

- [ ] Open Perps with favorites added
- [ ] Click the expand view button on the chart
- [ ] Verify chart fills the full viewport with no layout break
- [ ] Exit expand view — verify FavoritesBar reappears correctly
- [ ] Repeat with no favorites — verify expand view still works
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
