### PR TITLE
fix: upgrade axios to 1.15.0 for CVE-2025-62718 SSRF vulnerability

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@onekeyhq/core": "workspace:*",
     "@onekeyhq/shared": "workspace:*",
-    "axios": "^1.13.2",
+    "axios": "1.15.0",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",
     "tsup": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -287,7 +287,7 @@
     "@typescript-eslint/parser": "^8.4.0",
     "@typescript/native-preview": "^7.0.0-dev.20260127.1",
     "agentation": "^3.0.2",
-    "axios": "^1.13.2",
+    "axios": "1.15.0",
     "babel-loader": "^9.1.3",
     "babel-plugin-catch-logger": "0.1.13",
     "babel-plugin-import": "^1.13.5",
@@ -363,7 +363,7 @@
     "worker-rspack-loader": "^3.1.2"
   },
   "resolutions": {
-    "axios": "^1.13.2",
+    "axios": "1.15.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-server-dom-webpack": "19.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8265,7 +8265,7 @@ __metadata:
   dependencies:
     "@onekeyhq/core": "workspace:*"
     "@onekeyhq/shared": "workspace:*"
-    axios: "npm:^1.13.2"
+    axios: "npm:1.15.0"
     chalk: "npm:^4.1.2"
     commander: "npm:^12.0.0"
     tsup: "npm:^8.0.0"
@@ -9280,7 +9280,7 @@ __metadata:
     agentation: "npm:^3.0.2"
     allotment: "npm:^1.20.5"
     array.prototype.toreversed: "npm:^1.1.2"
-    axios: "npm:^1.13.2"
+    axios: "npm:1.15.0"
     babel-loader: "npm:^9.1.3"
     babel-plugin-catch-logger: "npm:0.1.13"
     babel-plugin-import: "npm:^1.13.5"
@@ -21500,14 +21500,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.13.2":
-  version: 1.13.2
-  resolution: "axios@npm:1.13.2"
+"axios@npm:1.15.0":
+  version: 1.15.0
+  resolution: "axios@npm:1.15.0"
   dependencies:
-    follow-redirects: "npm:^1.15.6"
-    form-data: "npm:^4.0.4"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10/ae4e06dcd18289f2fd18179256d550d27f9a53ecb2f9c59f2ccc4efd1d7151839ba8c3e0fb533dac793e4a59a576ca8689a19244dce5c396680837674a47a867
+    follow-redirects: "npm:^1.15.11"
+    form-data: "npm:^4.0.5"
+    proxy-from-env: "npm:^2.1.0"
+  checksum: 10/d39a2c0ebc7ff4739401b282e726cc2673377949d6c46d60eb619458f8d7a2f7eadbcada7097f4dbc7d5c59abb4d3bf6fac33d474412bc3415d3f5aa7ed45530
   languageName: node
   linkType: hard
 
@@ -30191,13 +30191,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.6":
-  version: 1.15.6
-  resolution: "follow-redirects@npm:1.15.6"
+"follow-redirects@npm:^1.15.11":
+  version: 1.15.11
+  resolution: "follow-redirects@npm:1.15.11"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10/70c7612c4cab18e546e36b991bbf8009a1a41cf85354afe04b113d1117569abf760269409cb3eb842d9f7b03d62826687086b081c566ea7b1e6613cf29030bf7
+  checksum: 10/07372fd74b98c78cf4d417d68d41fdaa0be4dcacafffb9e67b1e3cf090bc4771515e65020651528faab238f10f9b9c0d9707d6c1574a6c0387c5de1042cde9ba
   languageName: node
   linkType: hard
 
@@ -30285,7 +30285,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.0, form-data@npm:^4.0.4":
+"form-data@npm:^4.0.0":
   version: 4.0.4
   resolution: "form-data@npm:4.0.4"
   dependencies:
@@ -30295,6 +30295,19 @@ __metadata:
     hasown: "npm:^2.0.2"
     mime-types: "npm:^2.1.12"
   checksum: 10/a4b62e21932f48702bc468cc26fb276d186e6b07b557e3dd7cc455872bdbb82db7db066844a64ad3cf40eaf3a753c830538183570462d3649fdfd705601cbcfb
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "form-data@npm:4.0.5"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    es-set-tostringtag: "npm:^2.1.0"
+    hasown: "npm:^2.0.2"
+    mime-types: "npm:^2.1.12"
+  checksum: 10/52ecd6e927c8c4e215e68a7ad5e0f7c1031397439672fd9741654b4a94722c4182e74cc815b225dcb5be3f4180f36428f67c6dd39eaa98af0dcfdd26c00c19cd
   languageName: node
   linkType: hard
 
@@ -39915,6 +39928,13 @@ __metadata:
   version: 1.1.0
   resolution: "proxy-from-env@npm:1.1.0"
   checksum: 10/f0bb4a87cfd18f77bc2fba23ae49c3b378fb35143af16cc478171c623eebe181678f09439707ad80081d340d1593cd54a33a0113f3ccb3f4bc9451488780ee23
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "proxy-from-env@npm:2.1.0"
+  checksum: 10/fbbaf4dab2a6231dc9e394903a5f66f20475e36b734335790b46feb9da07c37d6b32e2c02e3e2ea4d4b23774c53d8562e5b7cc73282cb43f4a597b7eacaee2ee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Upgrade axios from 1.13.2 to 1.15.0 to fix critical SSRF vulnerability (CVE-2025-62718)
- Pin axios version exactly (no `^` prefix) in dependencies and resolutions

## Intent & Context
GitHub Dependabot alert #497 flagged a critical (CVSS 9.3) vulnerability in axios < 1.15.0. Axios did not correctly normalize hostnames when checking `NO_PROXY` rules — requests to loopback addresses like `localhost.` (trailing dot) or `[::1]` (IPv6 literal) would bypass `NO_PROXY` matching and go through a configured proxy, enabling SSRF attacks.

## Root Cause
Axios performed literal string comparison instead of normalizing hostnames before checking `NO_PROXY`, violating RFC 1034 §3.1 and RFC 3986 §3.2.2. Fixed upstream in axios 1.15.0 via [axios/axios#10661](https://github.com/axios/axios/pull/10661).

## Changes Detail
- `package.json` — Updated axios in both `dependencies` and `resolutions` from `^1.13.2` to `1.15.0` (pinned)
- `apps/cli/package.json` — Updated axios dependency from `^1.13.2` to `1.15.0` (pinned)
- `yarn.lock` — Regenerated to reflect the version change across all transitive dependencies

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: All (Extension / Mobile / Desktop / Web)
- **Risk Areas**: axios is widely used across the codebase, but 1.13.2 → 1.15.0 is a minor version bump with no breaking changes

## Test plan
- [x] `yarn install` completes without errors
- [x] `yarn why axios` confirms all instances resolve to 1.15.0
- [x] `yarn lint` passes
- [ ] Verify network requests work correctly on each platform
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
