### PR TITLE
fix(send): quick-select tab search fixes (OK-52953, OK-52952)

### DIFF
--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -163,6 +163,31 @@ type IWalletGroup = {
 const NETWORK_ACCOUNTS_FETCH_CONCURRENCY = 4;
 const WALLET_GROUP_FETCH_CONCURRENCY = 6;
 
+// Collect every address that should match against the search key for a
+// given network account. For BTC with fresh-address mode (OK-52953) the
+// currently-shown address is only one of many rotating receive addresses;
+// the historical entries live on `IDBUtxoAccount.addresses` (path → addr).
+// Without including them a user searching an old receive address gets no
+// hit even though the address belongs to one of their own accounts.
+function collectAccountSearchAddresses(
+  account: INetworkAccount | undefined,
+): string[] {
+  if (!account) return [];
+  const seen = new Set<string>();
+  const push = (addr: string | undefined) => {
+    if (addr) seen.add(addr.toLowerCase());
+  };
+  push(account.address);
+  push(account.addressDetail?.address);
+  push(account.addressDetail?.masterAddress);
+  const utxoAddresses = (account as { addresses?: Record<string, string> })
+    .addresses;
+  if (utxoAddresses) {
+    for (const addr of Object.values(utxoAddresses)) push(addr);
+  }
+  return Array.from(seen);
+}
+
 // Get wallet accounts on the specified network (with derive type info)
 async function getWalletNetworkAccounts(
   wallet: IDBWallet,
@@ -367,11 +392,10 @@ function AccountRecipients({
             items: accounts,
             isNameMatch: (item) =>
               (item.account?.name ?? '').toLowerCase().includes(searchValue),
-            isAddressMatch: (item) => {
-              const address =
-                item.account?.address ?? item.account?.addressDetail?.address;
-              return address?.toLowerCase().includes(searchValue) ?? false;
-            },
+            isAddressMatch: (item) =>
+              collectAccountSearchAddresses(item.account).some((addr) =>
+                addr.includes(searchValue),
+              ),
           });
 
         if (sortedAccounts.length > 0) {

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -20,7 +20,10 @@ import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useDebounce } from '@onekeyhq/kit/src/hooks/useDebounce';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import type { IAddressNetworkItem } from '@onekeyhq/kit/src/views/AddressBook/type';
-import type { IDBWallet } from '@onekeyhq/kit-bg/src/dbs/local/types';
+import type {
+  IDBUtxoAccount,
+  IDBWallet,
+} from '@onekeyhq/kit-bg/src/dbs/local/types';
 import { useAddressBookPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/addressBooks';
 import type { IAccountDeriveInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 import { IMPL_EVM } from '@onekeyhq/shared/src/engine/engineConsts';
@@ -163,29 +166,24 @@ type IWalletGroup = {
 const NETWORK_ACCOUNTS_FETCH_CONCURRENCY = 4;
 const WALLET_GROUP_FETCH_CONCURRENCY = 6;
 
-// Collect every address that should match against the search key for a
-// given network account. For BTC with fresh-address mode (OK-52953) the
-// currently-shown address is only one of many rotating receive addresses;
-// the historical entries live on `IDBUtxoAccount.addresses` (path → addr).
-// Without including them a user searching an old receive address gets no
-// hit even though the address belongs to one of their own accounts.
+// Collect every address an account should be searchable by. For BTC with
+// fresh-address mode (OK-52953) the currently-shown address is one of
+// many rotating entries stored in `IDBUtxoAccount.addresses` (relPath →
+// addr); `customAddresses` covers user-added custom receive addresses.
+// Without these a user searching an old receive address gets no hit.
 function collectAccountSearchAddresses(
   account: INetworkAccount | undefined,
 ): string[] {
   if (!account) return [];
-  const seen = new Set<string>();
-  const push = (addr: string | undefined) => {
-    if (addr) seen.add(addr.toLowerCase());
-  };
-  push(account.address);
-  push(account.addressDetail?.address);
-  push(account.addressDetail?.masterAddress);
-  const utxoAddresses = (account as { addresses?: Record<string, string> })
-    .addresses;
-  if (utxoAddresses) {
-    for (const addr of Object.values(utxoAddresses)) push(addr);
-  }
-  return Array.from(seen);
+  const utxo = account as Partial<IDBUtxoAccount>;
+  const candidates = [
+    account.address,
+    account.addressDetail?.address,
+    account.addressDetail?.masterAddress,
+    ...(utxo.addresses ? Object.values(utxo.addresses) : []),
+    ...(utxo.customAddresses ? Object.values(utxo.customAddresses) : []),
+  ].filter((a): a is string => !!a);
+  return Array.from(new Set(candidates.map((a) => a.toLowerCase())));
 }
 
 // Get wallet accounts on the specified network (with derive type info)

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -861,6 +861,15 @@ export default function RecipientQuickSelect({
     addressBook: 0,
   });
 
+  // Set of tabs that should appear (excludes hideTabs and Lightning hidden tabs)
+  const visibleTabKeys = useMemo<IRecipientQuickSelectTab[]>(() => {
+    const isLightning = networkUtils.isLightningNetworkByNetworkId(networkId);
+    const all: IRecipientQuickSelectTab[] = isLightning
+      ? ['recent']
+      : ['recent', 'account', 'addressBook'];
+    return hideTabs?.length ? all.filter((t) => !hideTabs.includes(t)) : all;
+  }, [hideTabs, networkId]);
+
   // Track which tabs have been visited (once visited, stay mounted to avoid AbortError crashes)
   const [visitedTabs, setVisitedTabs] = useState<
     Record<IRecipientQuickSelectTab, boolean>
@@ -876,6 +885,25 @@ export default function RecipientQuickSelect({
       prev[activeTab] ? prev : { ...prev, [activeTab]: true },
     );
   }, [activeTab]);
+
+  // Pre-mount every visible tab (kept hidden via display:none until active)
+  // so each can fetch its data and report its match count without requiring
+  // the user to click in first. Without this, the addressBook tab label
+  // never showed its (N) count when a BTC chain landed on Accounts by
+  // default, and auto-switch couldn't jump to a non-mounted tab (OK-52952).
+  useEffect(() => {
+    setVisitedTabs((prev) => {
+      const next = { ...prev };
+      let changed = false;
+      for (const tab of visibleTabKeys) {
+        if (!next[tab]) {
+          next[tab] = true;
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [visibleTabKeys]);
 
   // For multi-derive chains (BTC/LTC), default to Accounts tab so
   // addresses are visible without manual tab switch (OK-52809).


### PR DESCRIPTION
## Summary

Two related Send quick-select bugs reported off the same flow.

### OK-52953 — Accounts tab search misses rotated BTC addresses

BTC fresh-address mode rotates the current receive address; historical entries live on `IDBUtxoAccount.addresses` (relPath → addr) and user-added ones on `customAddresses`. The old `isAddressMatch` only compared against the current receive address, so a user searching an old receive address got no hit even though the address belonged to one of their own accounts.

**Fix:** new `collectAccountSearchAddresses` helper that returns the de-duped lowercase set of `{ account.address, addressDetail.address, addressDetail.masterAddress, ...addresses, ...customAddresses }`. Wired into the `isAddressMatch` inside `filteredWalletGroups`.

Non-BTC chains are unaffected — for EVM/TRON/etc. the UTXO fields are undefined and `masterAddress` equals `account.address`, so the Set collapses to one entry.

### OK-52952 — AddressBook tab doesn't show match count / can't auto-switch

On BTC the flow lands on the Accounts tab by default (OK-52809). The addressBook tab's `visitedTabs` entry stayed `false` until the user clicked it, so its data never fetched and its `onMatchStatusChange` callback never fired. Consequences:
- Tab label never showed its `(N)` match count
- Auto-switch logic couldn't jump to it because `tabMatchStatus.addressBook` stayed `null`

**Fix:** derive `visibleTabKeys` from `hideTabs` + Lightning detection, and pre-mount every visible tab via a single `setVisitedTabs` effect. Tabs are still hidden with `display:none` until active — only their data fetch and match-status callback run eagerly.

## Jira

- OK-52953
- OK-52952

## Test plan

### OK-52953 — BTC fresh-address search
- [ ] BTC account with fresh-address mode ON, open Send → type an old receive address that belongs to your own account → Accounts tab shows the owning account
- [ ] Same for the master address (first / path 0/0)
- [ ] Same for a user-added custom receive address
- [ ] BTC with fresh-address OFF → search by current address still works (regression)
- [ ] EVM → search by address still works (single-entry path unchanged)
- [ ] LTC (same \`mergeDeriveAssetsEnabled\` pattern) → historical addresses searchable

### OK-52952 — AddressBook tab pre-mount
- [ ] BTC account, open Send page → initial tab is Accounts (BTC default)
- [ ] Type an address that matches an address book entry → AddressBook tab label shows the `(N)` count immediately, no click required
- [ ] If Accounts tab has zero matches and AddressBook has matches → auto-switch jumps to AddressBook
- [ ] Lightning network → AddressBook tab is not rendered at all (regression check)
- [ ] Swap flow with `hideTabs=['recent']` → hidden recent tab does not pre-mount