### PR TITLE
fix(referral): change accept button text to claim(OK-52987)

### DIFF
--- a/packages/kit/src/views/Home/pages/referralLanding/ReferralLandingPage.tsx
+++ b/packages/kit/src/views/Home/pages/referralLanding/ReferralLandingPage.tsx
@@ -353,7 +353,7 @@ function ReferralLandingPage() {
               onPress={handleMobileWebJoin}
             >
               {intl.formatMessage({
-                id: ETranslations.referral_accept,
+                id: ETranslations.wallet_subsidy_claim,
               })}
             </Button>
           </XStack>

--- a/packages/kit/src/views/ReferFriends/pages/InvitedByFriend/components/InvitedByFriendActions.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/InvitedByFriend/components/InvitedByFriendActions.tsx
@@ -313,7 +313,7 @@ function InvitedByFriendActions({
         loading={isBinding}
         disabled={isBinding}
       >
-        {intl.formatMessage({ id: ETranslations.referral_accept })}
+        {intl.formatMessage({ id: ETranslations.wallet_subsidy_claim })}
       </Button>
     </XStack>
   );


### PR DESCRIPTION
## Summary
- Change referral invitation button text from "Accept" to "Claim" by switching i18n key from `referral_accept` to `wallet_subsidy_claim`
- Affects both the in-app referral dialog (`InvitedByFriendActions`) and the mobile web landing page (`ReferralLandingPage`)

## Test plan
- [ ] Open referral invitation dialog, verify button shows "领取" (zh) / "Claim" (en)
- [ ] Open mobile web referral landing page, verify the same
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
