### PR TITLE
fix(market): fix K-line and Overview overlap on foldable screens ｜ OK-51898

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { noop } from 'lodash';
 import { useIntl } from 'react-intl';
@@ -117,6 +117,16 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
   }, [bottom, top, isIOSModalPage]);
 
   const width = usePageWidth();
+  const [containerWidth, setContainerWidth] = useState<number>(0);
+  const effectivePageWidth = useMemo(() => {
+    if (containerWidth > 0) {
+      return containerWidth;
+    }
+    if (typeof width === 'number' && width > 0) {
+      return width;
+    }
+    return Dimensions.get('window').width;
+  }, [containerWidth, width]);
 
   const scrollViewRef = useRef<IScrollViewRef>(null);
   const focusedTab = useSharedValue(tabNames[0]);
@@ -129,12 +139,41 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
     (tabName: string) => {
       focusedTab.value = tabName;
       scrollViewRef.current?.scrollTo({
-        x: width * tabNames.indexOf(tabName),
+        x: effectivePageWidth * tabNames.indexOf(tabName),
         animated: true,
       });
     },
-    [focusedTab, tabNames, width],
+    [focusedTab, tabNames, effectivePageWidth],
   );
+
+  const handleContainerLayout = useCallback(
+    (event: { nativeEvent: { layout: { width: number } } }) => {
+      const nextWidth = Math.round(event.nativeEvent.layout.width);
+      if (nextWidth > 0) {
+        setContainerWidth((prevWidth) =>
+          prevWidth === nextWidth ? prevWidth : nextWidth,
+        );
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const activeTabIndex = tabNames.indexOf(focusedTab.value);
+    if (activeTabIndex < 0 || effectivePageWidth <= 0) {
+      return;
+    }
+
+    // Keep horizontal pages aligned after fold/unfold or split-width changes.
+    const alignTimer = setTimeout(() => {
+      scrollViewRef.current?.scrollTo({
+        x: effectivePageWidth * activeTabIndex,
+        animated: false,
+      });
+    }, 0);
+
+    return () => clearTimeout(alignTimer);
+  }, [effectivePageWidth, focusedTab, tabNames]);
 
   const handleHeaderHorizontalSwipe = useCallback(
     (direction: 'left' | 'right') => {
@@ -386,7 +425,7 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
   };
 
   return (
-    <YStack flex={1} position="relative">
+    <YStack flex={1} position="relative" onLayout={handleContainerLayout}>
       <Tabs.TabBar
         divider={false}
         onTabPress={handleTabChange}
@@ -395,7 +434,7 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
       />
       <ScrollView horizontal ref={scrollViewRef} flex={1} scrollEnabled={false}>
         {tabNames.map((_, index) => (
-          <YStack key={index} h={height} w={width}>
+          <YStack key={index} h={height} w={effectivePageWidth}>
             {renderItem({ index })}
           </YStack>
         ))}

--- a/packages/kit/src/views/Market/components/TokenDetailTabs.tsx
+++ b/packages/kit/src/views/Market/components/TokenDetailTabs.tsx
@@ -10,10 +10,12 @@ import {
   useIsIpadModalPage,
   useIsOverlayPage,
   useMedia,
+  useSplitSubView,
   useTabContainerWidth,
 } from '@onekeyhq/components';
 import type { IDeferredPromise } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IMarketTokenDetail } from '@onekeyhq/shared/types/market';
 
 import { MarketDetailLinks } from './MarketDetailLinks';
@@ -116,6 +118,16 @@ function BasicTokenDetailTabs({
 
   const pageWidth = useTabContainerWidth();
   const isIpadModalPage = useIsIpadModalPage();
+  const isSplitSubView = useSplitSubView();
+  const resolvedTabWidth =
+    typeof pageWidth === 'number' &&
+    (isIpadModalPage || isSplitSubView || platformEnv.isNative)
+      ? pageWidth
+      : undefined;
+  const containerKey = useMemo(
+    () => `${tabConfigs.length}-${resolvedTabWidth ?? 'auto'}`,
+    [resolvedTabWidth, tabConfigs.length],
+  );
   return (
     <Tabs.Container
       containerStyle={{
@@ -123,7 +135,7 @@ function BasicTokenDetailTabs({
         ...(md ? { marginTop: 20 } : undefined),
         ...(isModalPage ? { marginTop: 20 } : undefined),
       }}
-      width={isIpadModalPage ? (pageWidth as number) : undefined}
+      width={resolvedTabWidth}
       renderHeader={() => (
         <YStack
           bg="$bgApp"
@@ -137,7 +149,7 @@ function BasicTokenDetailTabs({
         </YStack>
       )}
       renderTabBar={(props) => <Tabs.TabBar {...props} />}
-      key={tabConfigs.length}
+      key={containerKey}
     >
       {tabConfigs.map((tab) => (
         <Tabs.Tab key={tab.title} name={tab.title}>


### PR DESCRIPTION
## Summary
This PR fixes a layout overlap issue in Market Token Detail on foldable devices, where K-line and Overview content could overlap after fold/unfold or split-width changes.

## What Changed
- Updated `MobileLayout.tsx`:
- Added container width tracking via `onLayout`.
- Introduced `effectivePageWidth` to keep horizontal page width consistent with the real container width.
- Realigned horizontal scroll position when width changes (e.g. fold/unfold, split view resize).

- Updated `TokenDetailTabs.tsx`:
- Added `resolvedTabWidth` logic for native/split/modal scenarios.
- Updated `Tabs.Container` width to use resolved width.
- Added a width-aware `key` to force safe container remount when tab width changes.

## Result
- Chart and Overview tabs stay aligned with the actual viewport width.
- No content overlap after fold/unfold or split-width transitions.

## Testing
- Verified on a real foldable device.
- Tested tab switching between Chart and Overview.
- Tested fold/unfold transitions.
- Tested split-width changes.
- Confirmed overlap issue is resolved.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
