### PR TITLE
feat(discovery): add DApp translate tracking and activate Prime feature

### DIFF
--- a/packages/kit/src/components/WebView/useWebViewTranslate.ts
+++ b/packages/kit/src/components/WebView/useWebViewTranslate.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   ETranslateDisplayMode,
@@ -64,6 +65,7 @@ function handleTranslateRequest(
   tabId: string,
   data: ITranslateRequest,
   engine: ETranslateEngine,
+  onSuccess?: () => void,
 ): void {
   const handler = async () => {
     try {
@@ -73,6 +75,7 @@ function handleTranslateRequest(
         engine,
       );
       sendTranslationResponse(tabId, data.id, translations, data.sessionId);
+      onSuccess?.();
     } catch (err) {
       console.error('[Translate] API error:', err);
       sendTranslationResponse(tabId, data.id, data.texts, data.sessionId);
@@ -108,10 +111,19 @@ export function useWebViewTranslate(
   onNavigate?: () => void,
   engine: ETranslateEngine = ETranslateEngine.standard,
   displayMode: ETranslateDisplayMode = ETranslateDisplayMode.replace,
+  dappUrl?: string,
 ) {
   const translatingRef = useRef(false);
   const desktopCleanupRef = useRef<(() => void) | null>(null);
   const startTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hasLoggedSuccessRef = useRef(false);
+  const activeSessionIdRef = useRef<string | null>(null);
+  const engineRef = useRef(engine);
+  const displayModeRef = useRef(displayMode);
+  const dappUrlRef = useRef(dappUrl);
+  engineRef.current = engine;
+  displayModeRef.current = displayMode;
+  dappUrlRef.current = dappUrl;
 
   useEffect(() => () => unregisterTranslateHandler(tabId), [tabId]);
 
@@ -119,6 +131,7 @@ export function useWebViewTranslate(
   useEffect(() => {
     onTabNavigation(tabId, () => {
       translatingRef.current = false;
+      activeSessionIdRef.current = null;
       unregisterTranslateHandler(tabId);
       if (startTimerRef.current) {
         clearTimeout(startTimerRef.current);
@@ -135,6 +148,27 @@ export function useWebViewTranslate(
       if (startTimerRef.current) {
         clearTimeout(startTimerRef.current);
         startTimerRef.current = null;
+      }
+    },
+    [],
+  );
+
+  // Stable callback — reads current values from refs to avoid cascading callback recreations.
+  // sessionId guard prevents stale in-flight requests from consuming the new session's dedup slot.
+  const logTranslateSuccess = useCallback(
+    (targetLang: string, sessionId?: string) => {
+      if (
+        !hasLoggedSuccessRef.current &&
+        sessionId &&
+        sessionId === activeSessionIdRef.current
+      ) {
+        hasLoggedSuccessRef.current = true;
+        defaultLogger.prime.usage.dappTranslateSuccess({
+          engine: engineRef.current,
+          targetLang,
+          displayMode: displayModeRef.current,
+          dappDomain: dappUrlRef.current ?? '',
+        });
       }
     },
     [],
@@ -158,7 +192,9 @@ export function useWebViewTranslate(
             event.message.slice(TRANSLATE_CONSOLE_PREFIX.length),
           ) as ITranslateRequest;
           if (data.type === TRANSLATE_REQUEST_TYPE) {
-            handleTranslateRequest(tabId, data, engine);
+            handleTranslateRequest(tabId, data, engine, () =>
+              logTranslateSuccess(data.targetLang, data.sessionId),
+            );
           }
         } catch {
           // ignore parse errors
@@ -174,7 +210,7 @@ export function useWebViewTranslate(
       );
       desktopCleanupRef.current = null;
     };
-  }, [tabId, engine]);
+  }, [tabId, engine, logTranslateSuccess]);
 
   const ensureInjected = useCallback(() => {
     // Re-injection is needed after page navigation clears the old context;
@@ -185,8 +221,13 @@ export function useWebViewTranslate(
 
   const startTranslate = useCallback(
     (targetLang = 'zh') => {
+      const sid = generateSessionId();
+      activeSessionIdRef.current = sid;
+      hasLoggedSuccessRef.current = false;
       registerTranslateHandler(tabId, (data) =>
-        handleTranslateRequest(tabId, data, engine),
+        handleTranslateRequest(tabId, data, engine, () =>
+          logTranslateSuccess(data.targetLang, data.sessionId),
+        ),
       );
       ensureInjected();
       if (startTimerRef.current) {
@@ -195,7 +236,6 @@ export function useWebViewTranslate(
       translatingRef.current = true;
       startTimerRef.current = setTimeout(() => {
         startTimerRef.current = null;
-        const sid = generateSessionId();
         injectScript(
           tabId,
           createMessageInjectedScript({
@@ -208,7 +248,7 @@ export function useWebViewTranslate(
         );
       }, 50);
     },
-    [tabId, ensureInjected, engine, displayMode],
+    [tabId, ensureInjected, engine, displayMode, logTranslateSuccess],
   );
 
   const stopTranslate = useCallback(() => {
@@ -225,6 +265,7 @@ export function useWebViewTranslate(
     );
     unregisterTranslateHandler(tabId);
     desktopCleanupRef.current?.();
+    activeSessionIdRef.current = null;
     translatingRef.current = false;
   }, [tabId]);
 
@@ -242,6 +283,7 @@ export function useWebViewTranslate(
     );
     unregisterTranslateHandler(tabId);
     desktopCleanupRef.current?.();
+    activeSessionIdRef.current = null;
     translatingRef.current = false;
   }, [tabId]);
 

--- a/packages/kit/src/views/Discovery/hooks/usePageTranslation.tsx
+++ b/packages/kit/src/views/Discovery/hooks/usePageTranslation.tsx
@@ -15,9 +15,12 @@ import {
 import { useWebViewTranslate } from '@onekeyhq/kit/src/components/WebView/useWebViewTranslate';
 import { useTranslateSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations, LOCALES_OPTION } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { ETranslateDisplayMode, ETranslateEngine } from '../types';
+
+import { useWebTabDataById } from './useWebTabs';
 
 function TranslateSettings() {
   const intl = useIntl();
@@ -281,6 +284,7 @@ export function usePageTranslation(tabId: string) {
   const [settings] = useTranslateSettingsPersistAtom();
   const [isTranslated, setIsTranslated] = useState(false);
   const resolvedTargetLang = useResolvedTargetLang();
+  const { tab } = useWebTabDataById(tabId);
 
   const onNavigate = useCallback(() => {
     setIsTranslated(false);
@@ -291,13 +295,29 @@ export function usePageTranslation(tabId: string) {
     onNavigate,
     settings.engine,
     settings.displayMode,
+    tab?.url,
   );
 
   const handleTranslate = useCallback(() => {
     const willTranslate = !translatingRef.current;
     toggleTranslate(resolvedTargetLang);
     setIsTranslated(willTranslate);
-  }, [toggleTranslate, translatingRef, resolvedTargetLang]);
+
+    defaultLogger.discovery.translation.dappTranslateToggle({
+      action: willTranslate ? 'enable' : 'disable',
+      engine: settings.engine,
+      targetLang: resolvedTargetLang,
+      displayMode: settings.displayMode,
+      dappDomain: tab?.url ?? '',
+    });
+  }, [
+    toggleTranslate,
+    translatingRef,
+    resolvedTargetLang,
+    settings.engine,
+    settings.displayMode,
+    tab?.url,
+  ]);
 
   return {
     isTranslated,

--- a/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeBenefitsList.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeBenefitsList.tsx
@@ -20,6 +20,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalBulkCopyAddressesRoutes } from '@onekeyhq/shared/src/routes/bulkCopyAddresses';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes/modal';
 import { EPrimeFeatures, EPrimePages } from '@onekeyhq/shared/src/routes/prime';
+import { ETabRoutes } from '@onekeyhq/shared/src/routes/tab';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import type { IPrimeServerUserInfo } from '@onekeyhq/shared/types/prime/primeTypes';
 
@@ -269,6 +270,32 @@ export function PrimeBenefitsList({
         }}
       />
 
+      <PrimeBenefitsItem
+        icon="TranslateOutline"
+        title={intl.formatMessage({
+          id: ETranslations.prime_ai_translate_title,
+        })}
+        subtitle={intl.formatMessage({
+          id: ETranslations.prime_ai_translate_desc,
+        })}
+        onPress={() => {
+          if (isPrimeSubscriptionActive) {
+            navigation.switchTab(ETabRoutes.Discovery);
+          } else {
+            defaultLogger.prime.subscription.primeEntryClick({
+              featureName: EPrimeFeatures.DAppTranslate,
+              entryPoint: 'primePage',
+            });
+            navigation.navigate(EPrimePages.PrimeFeatures, {
+              showAllFeatures: true,
+              selectedFeature: EPrimeFeatures.DAppTranslate,
+              selectedSubscriptionPeriod,
+              serverUserInfo,
+            });
+          }
+        }}
+      />
+
       {/* Coming soon features */}
       <PrimeBenefitsItem
         isComingSoon
@@ -287,28 +314,6 @@ export function PrimeBenefitsList({
           navigation.navigate(EPrimePages.PrimeFeatures, {
             showAllFeatures: true,
             selectedFeature: EPrimeFeatures.BlockaidSiteScan,
-            selectedSubscriptionPeriod,
-            serverUserInfo,
-          });
-        }}
-      />
-      <PrimeBenefitsItem
-        isComingSoon
-        icon="TranslateOutline"
-        title={intl.formatMessage({
-          id: ETranslations.prime_ai_translate_title,
-        })}
-        subtitle={intl.formatMessage({
-          id: ETranslations.prime_ai_translate_desc,
-        })}
-        onPress={() => {
-          defaultLogger.prime.subscription.primeEntryClick({
-            featureName: EPrimeFeatures.DAppTranslate,
-            entryPoint: 'primePage',
-          });
-          navigation.navigate(EPrimePages.PrimeFeatures, {
-            showAllFeatures: true,
-            selectedFeature: EPrimeFeatures.DAppTranslate,
             selectedSubscriptionPeriod,
             serverUserInfo,
           });

--- a/packages/shared/src/logger/scopes/discovery/index.ts
+++ b/packages/shared/src/logger/scopes/discovery/index.ts
@@ -3,6 +3,7 @@ import { EScopeName } from '../../types';
 
 import { BrowserScene } from './scenes/browser';
 import { DappScene } from './scenes/dapp';
+import { TranslationScene } from './scenes/translation';
 
 export class DiscoveryScope extends BaseScope {
   protected override scopeName = EScopeName.discovery;
@@ -10,4 +11,6 @@ export class DiscoveryScope extends BaseScope {
   browser = this.createScene('browser', BrowserScene);
 
   dapp = this.createScene('dapp', DappScene);
+
+  translation = this.createScene('translation', TranslationScene);
 }

--- a/packages/shared/src/logger/scopes/discovery/scenes/translation.ts
+++ b/packages/shared/src/logger/scopes/discovery/scenes/translation.ts
@@ -1,0 +1,21 @@
+import type {
+  ETranslateDisplayMode,
+  ETranslateEngine,
+} from '@onekeyhq/shared/types/discovery';
+
+import { BaseScene } from '../../../base/baseScene';
+import { LogToLocal, LogToServer } from '../../../base/decorators';
+
+export class TranslationScene extends BaseScene {
+  @LogToServer()
+  @LogToLocal()
+  public dappTranslateToggle(params: {
+    action: 'enable' | 'disable';
+    engine: ETranslateEngine;
+    targetLang: string;
+    displayMode: ETranslateDisplayMode;
+    dappDomain: string;
+  }) {
+    return params;
+  }
+}

--- a/packages/shared/src/logger/scopes/prime/scenes/usage.ts
+++ b/packages/shared/src/logger/scopes/prime/scenes/usage.ts
@@ -1,4 +1,8 @@
 import type { EBulkSendMode } from '@onekeyhq/shared/types/bulkSend';
+import type {
+  ETranslateDisplayMode,
+  ETranslateEngine,
+} from '@onekeyhq/shared/types/discovery';
 
 import { BaseScene } from '../../../base/baseScene';
 import { LogToServer } from '../../../base/decorators';
@@ -56,6 +60,26 @@ export class PrimeUsageScene extends BaseScene {
   public bulkRevokeSuccess({ revokeCount }: { revokeCount: number }) {
     return {
       revokeCount,
+    };
+  }
+
+  @LogToServer()
+  public dappTranslateSuccess({
+    engine,
+    targetLang,
+    displayMode,
+    dappDomain,
+  }: {
+    engine: ETranslateEngine;
+    targetLang: string;
+    displayMode: ETranslateDisplayMode;
+    dappDomain: string;
+  }) {
+    return {
+      engine,
+      targetLang,
+      displayMode,
+      dappDomain,
     };
   }
 }


### PR DESCRIPTION
## Summary
- Add two client-side analytics events: `dappTranslateToggle` (discovery.translation) for user toggle actions, and `dappTranslateSuccess` (prime.usage) for per-session first successful translation
- Session-based dedup logic (`activeSessionIdRef` + `hasLoggedSuccessRef`) ensures success is logged only once per translate session
- Move DApp AI Translate from "Coming soon" to active Prime feature in PrimeBenefitsList, with subscription-based navigation (subscribed → Discovery tab, unsubscribed → PrimeFeatures intro page)

## Test plan
- [ ] Toggle translate on a DApp page, verify `dappTranslateToggle` fires with action=enable; click restore, verify action=disable
- [ ] After enabling translate, verify `dappTranslateSuccess` fires only once per session (not per text chunk)
- [ ] In Prime dashboard, confirm AI Translate has no "Soon" badge and appears in active features section
- [ ] As subscribed user, click AI Translate → should navigate to Discovery/Browser tab
- [ ] As unsubscribed user, click AI Translate → should navigate to PrimeFeatures intro page
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
