### PR TITLE
fix(prime): remove auto-scroll and highlight on subscription page

### DIFF
--- a/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeBenefitsList.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeBenefitsList.tsx
@@ -1,12 +1,4 @@
-import { useEffect } from 'react';
-
 import { useIntl } from 'react-intl';
-import Animated, {
-  useAnimatedStyle,
-  useSharedValue,
-  withDelay,
-  withTiming,
-} from 'react-native-reanimated';
 
 import type { IKeyOfIcons } from '@onekeyhq/components';
 import {
@@ -44,69 +36,47 @@ function PrimeBenefitsItem({
   subtitle,
   onPress,
   isComingSoon,
-  isHighlighted,
 }: {
   icon: IKeyOfIcons;
   title: string;
   subtitle: string;
   onPress: () => void;
   isComingSoon?: boolean;
-  isHighlighted?: boolean;
 }) {
   const intl = useIntl();
-  const highlightOpacity = useSharedValue(isHighlighted ? 1 : 0);
-
-  useEffect(() => {
-    if (isHighlighted) {
-      highlightOpacity.value = 1;
-      highlightOpacity.value = withDelay(
-        500,
-        withTiming(0, { duration: 1000 }),
-      );
-    }
-  }, [isHighlighted, highlightOpacity]);
-
-  const highlightStyle = useAnimatedStyle(() => ({
-    backgroundColor:
-      highlightOpacity.value > 0
-        ? `rgba(62, 220, 47, ${highlightOpacity.value * 0.15})`
-        : 'transparent',
-  }));
 
   return (
-    <Animated.View style={highlightStyle}>
-      <ListItem drillIn onPress={onPress}>
-        <YStack borderRadius="$3" borderCurve="continuous" bg="$brand4" p="$2">
-          <Icon name={icon} size="$6" color="$brand9" />
-        </YStack>
-        <ListItem.Text
-          userSelect="none"
-          flex={1}
-          primary={
-            <XStack alignItems="center">
-              <SizableText
-                textAlign="left"
-                size="$bodyLgMedium"
-                flexShrink={1}
-                numberOfLines={1}
-              >
-                {title}
-              </SizableText>
-              {isComingSoon ? (
-                <Badge ml="$2" badgeSize="sm" flexShrink={0}>
-                  <Badge.Text>
-                    {intl.formatMessage({
-                      id: ETranslations.id_prime_soon,
-                    })}
-                  </Badge.Text>
-                </Badge>
-              ) : null}
-            </XStack>
-          }
-          secondary={subtitle}
-        />
-      </ListItem>
-    </Animated.View>
+    <ListItem drillIn onPress={onPress}>
+      <YStack borderRadius="$3" borderCurve="continuous" bg="$brand4" p="$2">
+        <Icon name={icon} size="$6" color="$brand9" />
+      </YStack>
+      <ListItem.Text
+        userSelect="none"
+        flex={1}
+        primary={
+          <XStack alignItems="center">
+            <SizableText
+              textAlign="left"
+              size="$bodyLgMedium"
+              flexShrink={1}
+              numberOfLines={1}
+            >
+              {title}
+            </SizableText>
+            {isComingSoon ? (
+              <Badge ml="$2" badgeSize="sm" flexShrink={0}>
+                <Badge.Text>
+                  {intl.formatMessage({
+                    id: ETranslations.id_prime_soon,
+                  })}
+                </Badge.Text>
+              </Badge>
+            ) : null}
+          </XStack>
+        }
+        secondary={subtitle}
+      />
+    </ListItem>
   );
 }
 
@@ -114,12 +84,10 @@ export function PrimeBenefitsList({
   selectedSubscriptionPeriod,
   networkId,
   serverUserInfo,
-  fromFeature,
 }: {
   selectedSubscriptionPeriod: ISubscriptionPeriod;
   networkId?: string;
   serverUserInfo?: IPrimeServerUserInfo;
-  fromFeature?: EPrimeFeatures;
 }) {
   const navigation = useAppNavigation();
   const intl = useIntl();
@@ -169,7 +137,6 @@ export function PrimeBenefitsList({
         subtitle={intl.formatMessage({
           id: ETranslations.prime_bulk_send_desc,
         })}
-        isHighlighted={fromFeature === EPrimeFeatures.BulkSend}
         onPress={() => {
           if (isPrimeSubscriptionActive) {
             showBulkSendModeDialog({
@@ -204,7 +171,6 @@ export function PrimeBenefitsList({
         subtitle={intl.formatMessage({
           id: ETranslations.global_bulk_revoke_desc,
         })}
-        isHighlighted={fromFeature === EPrimeFeatures.BulkRevoke}
         onPress={() => {
           if (isPrimeSubscriptionActive) {
             void navigateToApprovalList({
@@ -235,7 +201,6 @@ export function PrimeBenefitsList({
         subtitle={intl.formatMessage({
           id: ETranslations.prime_bulk_copy_addresses_desc,
         })}
-        isHighlighted={fromFeature === EPrimeFeatures.BulkCopyAddresses}
         onPress={() => {
           if (platformEnv.isWebDappMode) {
             Toast.message({
@@ -286,7 +251,6 @@ export function PrimeBenefitsList({
             number: 100,
           },
         )}
-        isHighlighted={fromFeature === EPrimeFeatures.Notifications}
         onPress={() => {
           if (isPrimeSubscriptionActive) {
             navigation.navigate(EModalRoutes.NotificationsModal);
@@ -315,7 +279,6 @@ export function PrimeBenefitsList({
         subtitle={intl.formatMessage({
           id: ETranslations.prime_enhanced_dapp_security_desc,
         })}
-        isHighlighted={fromFeature === EPrimeFeatures.BlockaidSiteScan}
         onPress={() => {
           defaultLogger.prime.subscription.primeEntryClick({
             featureName: EPrimeFeatures.BlockaidSiteScan,
@@ -338,7 +301,6 @@ export function PrimeBenefitsList({
         subtitle={intl.formatMessage({
           id: ETranslations.prime_ai_translate_desc,
         })}
-        isHighlighted={fromFeature === EPrimeFeatures.DAppTranslate}
         onPress={() => {
           defaultLogger.prime.subscription.primeEntryClick({
             featureName: EPrimeFeatures.DAppTranslate,
@@ -361,7 +323,6 @@ export function PrimeBenefitsList({
         subtitle={intl.formatMessage({
           id: ETranslations.prime_extended_history_desc,
         })}
-        isHighlighted={fromFeature === EPrimeFeatures.ExtendedHistory}
         onPress={() => {
           defaultLogger.prime.subscription.primeEntryClick({
             featureName: EPrimeFeatures.ExtendedHistory,
@@ -389,7 +350,6 @@ export function PrimeBenefitsList({
             networkCount: 12,
           },
         )}
-        isHighlighted={fromFeature === EPrimeFeatures.HistoryExport}
         onPress={() => {
           defaultLogger.prime.subscription.primeEntryClick({
             featureName: EPrimeFeatures.HistoryExport,

--- a/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeDashboard.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeDashboard.tsx
@@ -18,7 +18,6 @@ import {
   XStack,
   YStack,
   useSafeAreaInsets,
-  useScrollView,
   useTheme,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
@@ -69,63 +68,6 @@ const FooterGradient = memo(() => {
 });
 
 FooterGradient.displayName = 'FooterGradient';
-
-function PrimeBenefitsScrollContainer({
-  fromFeature,
-  selectedSubscriptionPeriod,
-  networkId,
-  serverUserInfo,
-}: {
-  fromFeature: EPrimeFeatures | undefined;
-  selectedSubscriptionPeriod: ISubscriptionPeriod;
-  networkId: string | undefined;
-  serverUserInfo: IPrimeServerUserInfo | undefined;
-}) {
-  const { scrollViewRef } = useScrollView();
-  const hasScrolledRef = useRef(false);
-  const scrollTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-
-  useEffect(
-    () => () => {
-      if (scrollTimerRef.current) {
-        clearTimeout(scrollTimerRef.current);
-      }
-    },
-    [],
-  );
-
-  return (
-    <Stack
-      onLayout={
-        fromFeature
-          ? (e) => {
-              if (!hasScrolledRef.current) {
-                const layout = e?.nativeEvent?.layout;
-                if (!layout) return;
-                hasScrolledRef.current = true;
-                const layoutY = layout.y ?? 0;
-                scrollTimerRef.current = setTimeout(() => {
-                  if (typeof scrollViewRef?.current?.scrollTo === 'function') {
-                    scrollViewRef.current.scrollTo({
-                      y: Math.max(0, layoutY - 120),
-                      animated: true,
-                    });
-                  }
-                }, 300);
-              }
-            }
-          : undefined
-      }
-    >
-      <PrimeBenefitsList
-        selectedSubscriptionPeriod={selectedSubscriptionPeriod}
-        networkId={networkId}
-        serverUserInfo={serverUserInfo}
-        fromFeature={fromFeature}
-      />
-    </Stack>
-  );
-}
 
 function PrimeBanner({ isPrimeActive = false }: { isPrimeActive?: boolean }) {
   const intl = useIntl();
@@ -586,8 +528,7 @@ export default function PrimeDashboard({
             ) : null}
 
             {isPurchaseReady ? (
-              <PrimeBenefitsScrollContainer
-                fromFeature={fromFeature}
+              <PrimeBenefitsList
                 selectedSubscriptionPeriod={selectedSubscriptionPeriod}
                 networkId={route.params?.networkId}
                 serverUserInfo={serverUserInfo}


### PR DESCRIPTION
## Summary
- Remove auto-scroll (`PrimeBenefitsScrollContainer`) that jarred mobile users by scrolling past the Prime branding and pricing section
- Remove green highlight animation (`react-native-reanimated`) from benefit items
- Prime subscription page now always displays from the top, improving conversion flow consistency

Closes OK-53009

## Test plan
- [ ] Enter Prime page from a specific feature (e.g. Bulk Send) — page should show from top, no scroll
- [ ] Enter Prime page from Prime icon — same behavior, no scroll
- [ ] Verify benefit items have no green highlight flash
- [ ] Verify subscription flow still works (fromFeature tracking preserved)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
