### PR TITLE
feat(swap): enhance value drop warning UI and add analytics

### DIFF
--- a/packages/kit/src/views/Swap/components/PreSwapTipInfo.tsx
+++ b/packages/kit/src/views/Swap/components/PreSwapTipInfo.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -10,22 +10,95 @@ import {
   YStack,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
-import type { IQuoteTip } from '@onekeyhq/shared/types/swap/types';
+import type { IQuoteTip, ISwapToken } from '@onekeyhq/shared/types/swap/types';
+
+const COUNTDOWN_SECONDS = 5;
 
 interface IPreSwapTipInfoProps {
   quoteShowTip: IQuoteTip;
   onConfirm: () => void;
   onCancel?: () => void;
+  fromToken?: ISwapToken;
+  toToken?: ISwapToken;
+  fromAmount: string;
+  toAmount: string;
 }
 
 const PreSwapTipInfo = ({
   quoteShowTip,
   onConfirm,
   onCancel,
+  fromToken,
+  toToken,
+  fromAmount,
+  toAmount,
 }: IPreSwapTipInfoProps) => {
   const intl = useIntl();
   const [checked, setChecked] = useState(false);
+  const [countdown, setCountdown] = useState(0);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => () => clearTimer(), [clearTimer]);
+
+  const buildEventParams = useCallback(
+    (isChecked: boolean) => ({
+      checked: quoteShowTip.showCheckbox ? isChecked : undefined,
+      fromTokenSymbol: fromToken?.symbol ?? '',
+      fromTokenAmount: fromAmount,
+      fromTokenFiatValue: fromToken?.fiatValue ?? '',
+      fromChainNetworkId: fromToken?.networkId ?? '',
+      toTokenSymbol: toToken?.symbol ?? '',
+      toTokenAmount: toAmount,
+      toTokenFiatValue: toToken?.fiatValue ?? '',
+      toChainNetworkId: toToken?.networkId ?? '',
+      valueDropPercent: quoteShowTip.title ?? '',
+    }),
+    [
+      fromToken,
+      toToken,
+      fromAmount,
+      toAmount,
+      quoteShowTip.title,
+      quoteShowTip.showCheckbox,
+    ],
+  );
+
+  const handleCheckboxChange = useCallback(
+    (checkedValue: string | boolean) => {
+      const isChecked = !!checkedValue;
+      setChecked(isChecked);
+      clearTimer();
+      if (isChecked) {
+        setCountdown(COUNTDOWN_SECONDS);
+        timerRef.current = setInterval(() => {
+          setCountdown((prev) => {
+            if (prev <= 1) {
+              return 0;
+            }
+            return prev - 1;
+          });
+        }, 1000);
+      } else {
+        setCountdown(0);
+      }
+    },
+    [clearTimer],
+  );
+
+  useEffect(() => {
+    if (countdown === 0 && timerRef.current) {
+      clearTimer();
+    }
+  }, [countdown, clearTimer]);
 
   const handleLearnMore = useCallback(() => {
     if (quoteShowTip.link) {
@@ -33,57 +106,87 @@ const PreSwapTipInfo = ({
     }
   }, [quoteShowTip.link]);
 
+  const handleConfirm = useCallback(() => {
+    defaultLogger.swap.valueDropTip.valueDropTipContinue(
+      buildEventParams(checked),
+    );
+    onConfirm();
+  }, [buildEventParams, checked, onConfirm]);
+
+  const handleCancel = useCallback(() => {
+    defaultLogger.swap.valueDropTip.valueDropTipCancel(
+      buildEventParams(checked),
+    );
+    onCancel?.();
+  }, [buildEventParams, checked, onCancel]);
+
+  const isCountingDown = checked && countdown > 0;
+  const isContinueDisabled = quoteShowTip.showCheckbox
+    ? !checked || isCountingDown
+    : false;
+
+  const continueText = isCountingDown
+    ? `${intl.formatMessage({ id: ETranslations.global_continue })} (${countdown})`
+    : intl.formatMessage({ id: ETranslations.global_continue });
+
   return (
     <YStack gap="$3">
-      {/* Title */}
-      <SizableText size="$bodyMd" fontWeight={600}>
-        {quoteShowTip.title}
-      </SizableText>
+      <YStack
+        gap="$2"
+        p="$3"
+        borderRadius="$3"
+        bg="$bgCritical"
+        borderWidth={1}
+        borderColor="$borderCritical"
+      >
+        <SizableText size="$bodyMd" fontWeight={600} color="$textCritical">
+          {quoteShowTip.title}
+        </SizableText>
+        <SizableText size="$bodyMd" color="$textSubdued">
+          {quoteShowTip.detail}
+        </SizableText>
+        {quoteShowTip.link ? (
+          <XStack alignSelf="flex-start" onPress={handleLearnMore}>
+            <SizableText
+              size="$bodyMd"
+              color="$textSubdued"
+              textDecorationLine="underline"
+              textDecorationColor="$textSubdued"
+              textDecorationStyle="dotted"
+            >
+              {intl.formatMessage({ id: ETranslations.global_learn_more })}
+            </SizableText>
+          </XStack>
+        ) : null}
+      </YStack>
 
-      {/* Detail */}
-      <SizableText size="$bodyMd" color="$textSubdued">
-        {quoteShowTip.detail}
-      </SizableText>
-
-      {/* Learn More Link */}
-      {quoteShowTip.link ? (
-        <XStack alignSelf="flex-start" onPress={handleLearnMore}>
-          <SizableText
-            size="$bodyMd"
-            color="$textSubdued"
-            textDecorationLine="underline"
-            textDecorationColor="$textSubdued"
-            textDecorationStyle="dotted"
-          >
-            {intl.formatMessage({ id: ETranslations.global_learn_more })}
-          </SizableText>
-        </XStack>
-      ) : null}
-
-      {/* Checkbox */}
       {quoteShowTip.showCheckbox ? (
         <Checkbox
           value={checked}
-          onChange={(checkedValue) => setChecked(!!checkedValue)}
+          onChange={handleCheckboxChange}
           label={quoteShowTip.checkboxLabel}
         />
       ) : null}
 
-      {/* Action Buttons */}
       <XStack gap="$3" pt="$2">
         {quoteShowTip.showCancelButton ? (
-          <Button flex={1} variant="secondary" size="medium" onPress={onCancel}>
+          <Button
+            flex={1}
+            variant="secondary"
+            size="medium"
+            onPress={handleCancel}
+          >
             {intl.formatMessage({ id: ETranslations.global_cancel })}
           </Button>
         ) : null}
         <Button
           flex={1}
-          variant="primary"
+          variant="destructive"
           size="medium"
-          onPress={onConfirm}
-          disabled={quoteShowTip.showCheckbox ? !checked : false}
+          onPress={handleConfirm}
+          disabled={isContinueDisabled}
         >
-          {intl.formatMessage({ id: ETranslations.global_continue })}
+          {continueText}
         </Button>
       </XStack>
     </YStack>

--- a/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
+++ b/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
@@ -417,6 +417,10 @@ const PreSwapDialogContent = ({
                   quoteShowTip={showPreSwapTipInfo}
                   onConfirm={tipOnConfirm}
                   onCancel={tipOnCancel}
+                  fromToken={preSwapData?.fromToken}
+                  toToken={preSwapData?.toToken}
+                  fromAmount={fromAmount}
+                  toAmount={toAmount}
                 />
               ) : (
                 <>

--- a/packages/shared/src/logger/scopes/swap/index.ts
+++ b/packages/shared/src/logger/scopes/swap/index.ts
@@ -11,6 +11,7 @@ import { SwapEstimateFeeScene } from './scenes/swapEstimateFee';
 import { SwapQuoteScene } from './scenes/swapQuote';
 import { SwapSendTxScene } from './scenes/swapSendTx';
 import { TokenSelectorSearchScene } from './scenes/tokenSelectorSearch';
+import { ValueDropTipScene } from './scenes/valueDropTip';
 
 export class SwapScope extends BaseScope {
   protected override scopeName = EScopeName.swap;
@@ -40,4 +41,6 @@ export class SwapScope extends BaseScope {
   swapEstimateFee = this.createScene('swapEstimateFee', SwapEstimateFeeScene);
 
   swapSendTx = this.createScene('swapSendTx', SwapSendTxScene);
+
+  valueDropTip = this.createScene('valueDropTip', ValueDropTipScene);
 }

--- a/packages/shared/src/logger/scopes/swap/scenes/valueDropTip.ts
+++ b/packages/shared/src/logger/scopes/swap/scenes/valueDropTip.ts
@@ -1,0 +1,29 @@
+import { BaseScene } from '../../../base/baseScene';
+import { LogToLocal, LogToServer } from '../../../base/decorators';
+
+export interface IValueDropTipEventParams {
+  checked: boolean | undefined;
+  fromTokenSymbol: string;
+  fromTokenAmount: string;
+  fromTokenFiatValue: string;
+  fromChainNetworkId: string;
+  toTokenSymbol: string;
+  toTokenAmount: string;
+  toTokenFiatValue: string;
+  toChainNetworkId: string;
+  valueDropPercent: string;
+}
+
+export class ValueDropTipScene extends BaseScene {
+  @LogToServer({ level: 'info' })
+  @LogToLocal({ level: 'info' })
+  public valueDropTipContinue(params: IValueDropTipEventParams) {
+    return params;
+  }
+
+  @LogToServer({ level: 'info' })
+  @LogToLocal({ level: 'info' })
+  public valueDropTipCancel(params: IValueDropTipEventParams) {
+    return params;
+  }
+}


### PR DESCRIPTION
## Summary
- Wrap value drop warning in a red critical card (`$bgCritical` + `$borderCritical`) to make the risk more visually prominent
- Change percentage title to red (`$textCritical`) and Continue button to `destructive` variant
- Add 5-second countdown timer: starts on checkbox check, resets on uncheck/re-check, Continue disabled during countdown and shows remaining seconds (e.g. `继续 (5)`)
- Add analytics tracking (`valueDropTipContinue` / `valueDropTipCancel`) with full order info (from/to token symbol, amount, fiat value, chain, value drop percent, checkbox state)

## Test plan
- [ ] Trigger a swap with high value drop to verify the red warning card appearance
- [ ] Verify checkbox → 5s countdown → Continue button enables flow
- [ ] Verify uncheck and re-check resets the countdown
- [ ] Verify Continue and Cancel emit correct Mixpanel events with order data
- [ ] Verify normal swap flow (no `quoteShowTip`) is unaffected
- [ ] Test on iOS, Android, Web, Desktop, Extension
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
