### PR TITLE
fix: show loading indicator instead of no-wallet during wallet deletion (OK-51091, OK-51094)

### DIFF
--- a/packages/kit/src/components/AccountSelector/AccountSelectorTrigger/AccountSelectorTriggerHome.tsx
+++ b/packages/kit/src/components/AccountSelector/AccountSelectorTrigger/AccountSelectorTriggerHome.tsx
@@ -1,4 +1,11 @@
-import { useActiveAccount } from '../../../states/jotai/contexts/accountSelector';
+import { Spinner } from '@onekeyhq/components';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+
+import {
+  useActiveAccount,
+  useIsAccountSelectorSyncLoading,
+} from '../../../states/jotai/contexts/accountSelector';
 
 import { AccountSelectorTriggerBase } from './AccountSelectorTriggerBase';
 
@@ -16,12 +23,23 @@ export function AccountSelectorTriggerHome({
   hideAddress?: boolean;
 }) {
   const {
-    activeAccount: { network, vaultSettings },
+    activeAccount: { network, vaultSettings, wallet, account },
   } = useActiveAccount({
     num,
   });
   const resolvedLinkNetworkId =
     linkNetworkId ?? (!network?.isAllNetworks ? network?.id : undefined);
+  const isSyncLoading = useIsAccountSelectorSyncLoading(num);
+
+  if (
+    !platformEnv.isWebDappMode &&
+    accountUtils.hasNoUsableWallet({ wallet, account })
+  ) {
+    if (isSyncLoading) {
+      return <Spinner size="small" />;
+    }
+    return null;
+  }
 
   return (
     <AccountSelectorTriggerBase

--- a/packages/kit/src/components/TabPageHeader/HeaderRight.tsx
+++ b/packages/kit/src/components/TabPageHeader/HeaderRight.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { useMemo } from 'react';
 
-import { useMedia } from '@onekeyhq/components';
+import { Spinner, useMedia } from '@onekeyhq/components';
 import { HeaderButtonGroup } from '@onekeyhq/components/src/layouts/Navigation/Header';
 import { NetworkSelectorTriggerHome } from '@onekeyhq/kit/src/components/AccountSelector/NetworkSelectorTrigger';
 import { LegacyUniversalSearchInput } from '@onekeyhq/kit/src/components/TabPageHeader/LegacyUniversalSearchInput';
@@ -11,7 +11,10 @@ import { ETabRoutes } from '@onekeyhq/shared/src/routes/tab';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
-import { useActiveAccount } from '../../states/jotai/contexts/accountSelector';
+import {
+  useActiveAccount,
+  useIsAccountSelectorSyncLoading,
+} from '../../states/jotai/contexts/accountSelector';
 import TabCountButton from '../../views/Discovery/components/MobileBrowser/TabCountButton';
 import { HistoryIconButton } from '../../views/Discovery/pages/components/HistoryIconButton';
 import { AllNetworksManagerTrigger } from '../AccountSelector';
@@ -29,8 +32,18 @@ export function MoreAction() {
 
 export function SelectorTrigger() {
   const {
-    activeAccount: { network, wallet },
+    activeAccount: { network, wallet, account },
   } = useActiveAccount({ num: 0 });
+  const isSyncLoading = useIsAccountSelectorSyncLoading(0);
+
+  const hasNoUsableWallet = accountUtils.hasNoUsableWallet({ wallet, account });
+
+  if (!platformEnv.isWebDappMode && hasNoUsableWallet) {
+    if (isSyncLoading) {
+      return <Spinner size="small" />;
+    }
+    return null;
+  }
 
   if (
     network?.isAllNetworks &&

--- a/packages/kit/src/components/TabPageHeader/MDHeader.tsx
+++ b/packages/kit/src/components/TabPageHeader/MDHeader.tsx
@@ -4,8 +4,13 @@ import { Page, View, XStack, useSafeAreaInsets } from '@onekeyhq/components';
 import type { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
+import {
+  useActiveAccount,
+  useIsAccountSelectorSyncLoading,
+} from '../../states/jotai/contexts/accountSelector';
 import { HomeTokenListProviderMirror } from '../../views/Home/components/HomeTokenListProvider/HomeTokenListProviderMirror';
 import { MoreActionButton } from '../MoreActionButton';
 
@@ -44,6 +49,14 @@ export function MDHeader({
   pageScrollPosition?: SharedValue<number>;
 }) {
   const { top } = useSafeAreaInsets();
+  const {
+    activeAccount: { wallet, account },
+  } = useActiveAccount({ num: 0 });
+  const hasNoUsableWallet = accountUtils.hasNoUsableWallet({
+    wallet,
+    account,
+  });
+
   const rightActions = useMemo(() => {
     return sceneName === EAccountSelectorSceneName.homeUrlAccount ? (
       <XStack flexShrink={1}>
@@ -80,6 +93,8 @@ export function MDHeader({
     tabRoute === ETabRoutes.Home &&
     sceneName !== EAccountSelectorSceneName.homeUrlAccount;
 
+  const isSyncLoading = useIsAccountSelectorSyncLoading(0);
+
   return (
     <>
       <Page.Header headerShown={false} />
@@ -110,14 +125,16 @@ export function MDHeader({
                 <MoreActionButton />
               </XStack>
               {/* Row 2: Wallet connection (account + network + address) */}
-              <XStack alignItems="center" px={headerPx} h={44}>
-                <HeaderLeft
-                  selectedHeaderTab={selectedHeaderTab}
-                  sceneName={sceneName}
-                  tabRoute={tabRoute}
-                  customHeaderLeftItems={customHeaderLeftItems}
-                />
-              </XStack>
+              {hasNoUsableWallet && !isSyncLoading ? null : (
+                <XStack alignItems="center" px={headerPx} h={44}>
+                  <HeaderLeft
+                    selectedHeaderTab={selectedHeaderTab}
+                    sceneName={sceneName}
+                    tabRoute={tabRoute}
+                    customHeaderLeftItems={customHeaderLeftItems}
+                  />
+                </XStack>
+              )}
             </>
           ) : (
             <>

--- a/packages/kit/src/components/TabPageHeader/components/WalletConnectionGroup.tsx
+++ b/packages/kit/src/components/TabPageHeader/components/WalletConnectionGroup.tsx
@@ -2,7 +2,7 @@ import { type ReactNode, memo, useCallback, useMemo, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { SizableText, XStack, useMedia } from '@onekeyhq/components';
+import { SizableText, Spinner, XStack, useMedia } from '@onekeyhq/components';
 import {
   AccountSelectorActiveAccountHome,
   AccountSelectorTriggerHome,
@@ -19,7 +19,10 @@ import { ETabRoutes } from '@onekeyhq/shared/src/routes/tab';
 import { ESpotlightTour } from '@onekeyhq/shared/src/spotlight';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 
-import { useActiveAccount } from '../../../states/jotai/contexts/accountSelector';
+import {
+  useActiveAccount,
+  useIsAccountSelectorSyncLoading,
+} from '../../../states/jotai/contexts/accountSelector';
 import { AllNetworksManagerTrigger } from '../../AccountSelector/AllNetworksManagerTrigger';
 
 function AccountSelectorTriggerWithSpotlight({
@@ -84,11 +87,16 @@ export function WalletConnectionGroup({
   const { md } = useMedia();
   const isMobileLayout = md || platformEnv.isNative;
   const {
-    activeAccount: { wallet, network },
+    activeAccount: { wallet, network, account },
   } = useActiveAccount({
     num: 0,
   });
   const [isFocus, setIsFocus] = useState(false);
+
+  const hasNoUsableWallet = accountUtils.hasNoUsableWallet({
+    wallet,
+    account,
+  });
 
   const isNonBackedUpWallet = useMemo(() => {
     return wallet && wallet.type === WALLET_TYPE_HD && !wallet.backuped;
@@ -144,6 +152,19 @@ export function WalletConnectionGroup({
       wallet?.id,
     ],
   );
+
+  const isSyncLoading = useIsAccountSelectorSyncLoading(0);
+
+  if (
+    !platformEnv.isWebDappMode &&
+    hasNoUsableWallet &&
+    tabRoute === ETabRoutes.Home
+  ) {
+    if (isSyncLoading) {
+      return <Spinner size="small" />;
+    }
+    return null;
+  }
 
   if (isMobileLayout) {
     return (

--- a/packages/kit/src/components/TabPageHeader/index.tsx
+++ b/packages/kit/src/components/TabPageHeader/index.tsx
@@ -4,9 +4,8 @@ import { Page, XStack, YStack, useMedia, useTheme } from '@onekeyhq/components';
 import { UniversalSearchInput } from '@onekeyhq/kit/src/components/TabPageHeader/UniversalSearchInput';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
-import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
-
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import {
   useActiveAccount,

--- a/packages/kit/src/components/TabPageHeader/index.tsx
+++ b/packages/kit/src/components/TabPageHeader/index.tsx
@@ -6,6 +6,12 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+
+import {
+  useActiveAccount,
+  useIsAccountSelectorSyncLoading,
+} from '../../states/jotai/contexts/accountSelector';
 import { HistoryIconButton } from '../../views/Discovery/pages/components/HistoryIconButton';
 
 import {
@@ -30,17 +36,29 @@ function InPageHeader({
   sceneName: EAccountSelectorSceneName;
   tabRoute: ETabRoutes;
 }) {
+  const {
+    activeAccount: { wallet, account },
+  } = useActiveAccount({ num: 0 });
+  const isSyncLoading = useIsAccountSelectorSyncLoading(0);
+  const hasNoUsableWallet = accountUtils.hasNoUsableWallet({
+    wallet,
+    account,
+  });
+
   const item = useMemo(() => {
     if (
       tabRoute === ETabRoutes.Home &&
       sceneName !== EAccountSelectorSceneName.homeUrlAccount
     ) {
+      if (hasNoUsableWallet && !isSyncLoading) {
+        return null;
+      }
       return <WalletConnectionGroup tabRoute={tabRoute} />;
     }
     if (sceneName === EAccountSelectorSceneName.homeUrlAccount) {
       return <UrlAccountPageHeader />;
     }
-  }, [sceneName, tabRoute]);
+  }, [sceneName, tabRoute, hasNoUsableWallet, isSyncLoading]);
 
   if (!item) {
     return null;

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -72,6 +72,7 @@ import {
   accountSelectorContextDataAtom,
   accountSelectorEditModeAtom,
   accountSelectorStorageReadyAtom,
+  accountSelectorSyncLoadingAtom,
   accountSelectorUpdateMetaAtom,
   activeAccountsAtom,
   contextAtomMethod,
@@ -1364,16 +1365,27 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
     ) => {
       // TODO add home scene check
       const num = 0;
-      await serviceAccount.removeWallet({
-        walletId,
-        isRemoveToMocked,
+      set(accountSelectorSyncLoadingAtom(), {
+        ...get(accountSelectorSyncLoadingAtom()),
+        [num]: { isLoading: true },
       });
-      set(accountSelectorEditModeAtom(), false);
+      try {
+        await serviceAccount.removeWallet({
+          walletId,
+          isRemoveToMocked,
+        });
+        set(accountSelectorEditModeAtom(), false);
 
-      await this.autoSelectNextAccount.call(set, {
-        num,
-        triggerBy: EAccountSelectorAutoSelectTriggerBy.removeWallet,
-      });
+        await this.autoSelectNextAccount.call(set, {
+          num,
+          triggerBy: EAccountSelectorAutoSelectTriggerBy.removeWallet,
+        });
+      } finally {
+        set(accountSelectorSyncLoadingAtom(), {
+          ...get(accountSelectorSyncLoadingAtom()),
+          [num]: { isLoading: false },
+        });
+      }
     },
   );
 

--- a/packages/kit/src/states/jotai/contexts/accountSelector/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/atoms.ts
@@ -152,6 +152,11 @@ export const {
   }>
 >({});
 
+export function useIsAccountSelectorSyncLoading(num: number): boolean {
+  const [syncLoading] = useAccountSelectorSyncLoadingAtom();
+  return !!syncLoading?.[num]?.isLoading;
+}
+
 export interface IAccountSelectorActiveAccountInfo {
   ready: boolean;
   isOthersWallet?: boolean;

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -11,6 +11,7 @@ import {
   Keyboard,
   Page,
   ScrollView,
+  Spinner,
   Stack,
   Tabs,
   YStack,
@@ -46,7 +47,10 @@ import {
   useAccountOverviewActions,
   useApprovalsInfoAtom,
 } from '../../../states/jotai/contexts/accountOverview';
-import { useActiveAccount } from '../../../states/jotai/contexts/accountSelector';
+import {
+  useActiveAccount,
+  useIsAccountSelectorSyncLoading,
+} from '../../../states/jotai/contexts/accountSelector';
 import { deferHeavyWorkUntilUIIdle } from '../../../utils/deferHeavyWork';
 import { NetworkUnsupportedWarning } from '../../Staking/components/ProtocolDetails/NetworkUnsupportedWarning';
 import { HomeSupportedWallet } from '../components/HomeSupportedWallet';
@@ -98,6 +102,29 @@ const AndroidScrollContainer = platformEnv.isNativeAndroid
   : ({ children }: IAndroidScrollContainerProps) => {
       return children;
     };
+
+function NoWalletContent({ tabBarHeight }: { tabBarHeight: number }) {
+  const isSyncLoading = useIsAccountSelectorSyncLoading(0);
+  if (isSyncLoading) {
+    return (
+      <Stack flex={1} justifyContent="center" alignItems="center">
+        <Spinner size="large" />
+      </Stack>
+    );
+  }
+  return (
+    <ScrollView
+      h="100%"
+      contentContainerStyle={{
+        justifyContent: 'center',
+        flexGrow: 1,
+        pb: tabBarHeight,
+      }}
+    >
+      {platformEnv.isWebDappMode ? <WebDappEmptyView /> : <EmptyWallet />}
+    </ScrollView>
+  );
+}
 
 export function HomePageView({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -591,25 +618,19 @@ export function HomePageView({
     setTabPageHeight(height);
   }, []);
 
+  const hasNoUsableWallet = accountUtils.hasNoUsableWallet({
+    wallet,
+    account,
+  });
+
   const homePage = useMemo(() => {
     if (!ready) {
       return <TabPageHeader sceneName={sceneName} tabRoute={ETabRoutes.Home} />;
     }
 
-    let content = (
-      <ScrollView
-        h="100%"
-        contentContainerStyle={{
-          justifyContent: 'center',
-          flexGrow: 1,
-          pb: tabBarHeight,
-        }}
-      >
-        {platformEnv.isWebDappMode ? <WebDappEmptyView /> : <EmptyWallet />}
-      </ScrollView>
-    );
+    let content = <NoWalletContent tabBarHeight={tabBarHeight} />;
 
-    if (wallet) {
+    if (!hasNoUsableWallet) {
       content = platformEnv.isNative ? (
         <AndroidScrollContainer>{homePageContent}</AndroidScrollContainer>
       ) : (
@@ -650,7 +671,7 @@ export function HomePageView({
     );
   }, [
     ready,
-    wallet,
+    hasNoUsableWallet,
     tabPageHeight,
     sceneName,
     handleTabPageLayout,

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -103,7 +103,7 @@ const AndroidScrollContainer = platformEnv.isNativeAndroid
       return children;
     };
 
-function NoWalletContent({ tabBarHeight }: { tabBarHeight: number }) {
+function NoWalletContent({ tabBarHeight = 0 }: { tabBarHeight?: number }) {
   const isSyncLoading = useIsAccountSelectorSyncLoading(0);
   if (isSyncLoading) {
     return (

--- a/packages/shared/src/utils/accountUtils.ts
+++ b/packages/shared/src/utils/accountUtils.ts
@@ -720,6 +720,18 @@ function isOthersWallet({ walletId }: { walletId: string }): boolean {
   );
 }
 
+function hasNoUsableWallet({
+  wallet,
+  account,
+}: {
+  wallet: IDBWallet | undefined;
+  account: { id: string } | undefined;
+}): boolean {
+  return (
+    !wallet || (isOthersWallet({ walletId: wallet?.id ?? '' }) && !account)
+  );
+}
+
 function isOthersAccount({
   accountId,
 }: {
@@ -1210,6 +1222,7 @@ export default {
   isAllNetworkMockAddress,
   isAccountCompatibleWithNetwork,
   isOthersWallet,
+  hasNoUsableWallet,
   isOthersAccount,
   isUrlAccountFn,
   isTonMnemonicCredentialId,


### PR DESCRIPTION
## Summary
- When deleting a wallet (with other wallets still present), the UI briefly flashed the "No Wallet" empty state. Now shows a loading spinner during the async wallet switch transition using `accountSelectorSyncLoadingAtom`.
- Hide account selector and header components gracefully during wallet removal by checking sync loading state across `HomePageView`, `AccountSelectorTriggerHome`, `SelectorTrigger`, `WalletConnectionGroup`, `MDHeader`, and `InPageHeader`.
- Extract `accountUtils.hasNoUsableWallet()` to replace duplicated no-wallet detection logic, replacing the coarse `if (wallet)` check with a precise `!wallet || (isOthersWallet && !account)` condition.
- Extract `useIsAccountSelectorSyncLoading(num)` hook to centralize sync loading reads.
- Extract `NoWalletContent` component to isolate sync loading subscription from the `HomePageView` page memo.

<img width="1854" height="1007" alt="Screenshot 2026-03-09 at 22 00 46" src="https://github.com/user-attachments/assets/4bf96a14-8e09-4cb1-8194-ff01e178e39f" />

## Jira
- OK-51091
- OK-51094

## Test plan
- [ ] Create multiple wallets, delete one wallet — verify no "No Wallet" flash, spinner shown briefly instead
- [ ] Delete the last wallet — verify "No Wallet" empty state still shows correctly
- [ ] Web dapp mode with no wallet — verify Connect button still shows
- [ ] Verify Android/iOS Home header Row 2 hides when no usable wallet
- [ ] URL account scenario (Discovery tab) — verify SelectorTrigger behaves correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
