### PR TITLE
fix(send): analytics matchCount and noResult false positives (OK-53075, OK-53073)

### DIFF
--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -936,6 +936,7 @@ export default function RecipientQuickSelect({
   // Use debounced search key for auto-switch logic
   const debouncedSearchKey = useDebounce(searchKey, 300);
   const trimmedSearchKey = normalizeSearchKey(debouncedSearchKey);
+  const isDebouncing = isSearchMode && searchKey !== debouncedSearchKey;
 
   // Track the search key at the time of last manual tab switch
   // Only allow auto-switch if user has typed something new
@@ -1035,6 +1036,7 @@ export default function RecipientQuickSelect({
     if (
       isSearchMode &&
       trimmedSearchKey &&
+      !isDebouncing &&
       allReported &&
       !anyTabHasMatches &&
       lastNoResultKeyRef.current !== trimmedSearchKey
@@ -1050,6 +1052,7 @@ export default function RecipientQuickSelect({
     tabMatchStatus,
     onMatchStatusChange,
     isSearchMode,
+    isDebouncing,
     trimmedSearchKey,
     networkId,
   ]);
@@ -1058,13 +1061,13 @@ export default function RecipientQuickSelect({
     () => ({
       isSearchMode: !!(isSearchMode && trimmedSearchKey),
       searchKeyLength: trimmedSearchKey.length,
-      // Only count tabs that are actually visible — hidden tabs (e.g. swap
-      // passes hideTabs={['recent']}) stay mounted but their counts would
-      // otherwise inflate the analytics matchCount.
-      matchCount: visibleTabKeys.reduce(
-        (sum, tab) => sum + (tabMatchCounts[tab] ?? 0),
-        0,
-      ),
+      matchCount:
+        isSearchMode && trimmedSearchKey
+          ? visibleTabKeys.reduce(
+              (sum, tab) => sum + (tabMatchCounts[tab] ?? 0),
+              0,
+            )
+          : 0,
     }),
     [isSearchMode, trimmedSearchKey, tabMatchCounts, visibleTabKeys],
   );


### PR DESCRIPTION
## Summary
- **OK-53075**: `getSearchContext` returns `matchCount=0` in non-search mode. Previously it summed all tab counts unconditionally, so selecting a recipient without searching reported `matchCount=19` (the total recipient count).
- **OK-53073**: `quickSelectSearchNoResult` event now skips firing during the debounce gap. Previously, when children temporarily reported `(false, 0)` during debounce (OK-53017 fix), the parent interpreted it as "all tabs have no results" and fired a false `noResult` event.

## Jira
- [OK-53075](https://onekeyhq.atlassian.net/browse/OK-53075)
- [OK-53073](https://onekeyhq.atlassian.net/browse/OK-53073)

## Test plan
- [ ] Select a recent recipient without searching — verify `matchCount=0` in analytics
- [ ] Search for a valid address that has matches — verify `quickSelectSearchNoResult` is NOT fired
- [ ] Search for a non-existent address — verify `quickSelectSearchNoResult` IS fired after debounce settles

[OK-53075]: https://onekeyhq.atlassian.net/browse/OK-53075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-53073]: https://onekeyhq.atlassian.net/browse/OK-53073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
