### PR TITLE
fix: annotate owned btc protocol outputs in psbt signing

### DIFF
--- a/packages/kit-bg/src/vaults/impls/btc/KeyringHardwareBtcBase.ts
+++ b/packages/kit-bg/src/vaults/impls/btc/KeyringHardwareBtcBase.ts
@@ -35,6 +35,8 @@ import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 
 import { KeyringHardwareBase } from '../../base/KeyringHardwareBase';
 
+import { resolvePsbtTaprootOwnedOutputs } from './resolvePsbtTaprootOwnedOutputs';
+
 import type VaultBtc from './Vault';
 import type { IDBAccount, IDBUtxoAccount } from '../../../dbs/local/types';
 import type {
@@ -257,33 +259,37 @@ export abstract class KeyringHardwareBtcBase extends KeyringHardwareBase {
       });
     }
 
-    for (let i = 0, len = psbt.txOutputs.length; i < len; i += 1) {
-      const output = psbt.txOutputs[i];
+    const psbtOwnedOutputs = await resolvePsbtTaprootOwnedOutputs({
+      network: btcNetwork,
+      outputAddresses: psbt.txOutputs.map((output) => output.address),
+      encodedTx: unsignedTx.encodedTx as IEncodedTxBtc,
+      dbAccount,
+      coreApi: checkIsDefined(this.coreApi),
+      vault: this.vault as VaultBtc,
+    });
+
+    Object.entries(psbtOwnedOutputs).forEach(([index, ownedOutput]) => {
       try {
-        // If the address is the change address
-        if (output.address === dbAccount.address && len > 1) {
-          psbt.updateOutput(i, {
-            tapInternalKey: Buffer.from(
-              checkIsDefined(dbAccount.pub),
-              'hex',
-            ).subarray(1, 33),
-            tapBip32Derivation: [
-              {
-                masterFingerprint: Buffer.from(fingerprint, 'hex'),
-                pubkey: Buffer.from(
-                  checkIsDefined(dbAccount.pub),
-                  'hex',
-                ).subarray(1, 33),
-                path: `${dbAccount.path}/${dbAccount.relPath ?? '0/0'}`,
-                leafHashes: [],
-              },
-            ],
-          });
-        }
+        const taprootPubkey = Buffer.from(ownedOutput.pubkey, 'hex').subarray(
+          1,
+          33,
+        );
+
+        psbt.updateOutput(Number(index), {
+          tapInternalKey: taprootPubkey,
+          tapBip32Derivation: [
+            {
+              masterFingerprint: Buffer.from(fingerprint, 'hex'),
+              pubkey: taprootPubkey,
+              path: ownedOutput.fullPath,
+              leafHashes: [],
+            },
+          ],
+        });
       } catch (err) {
         //
       }
-    }
+    });
 
     const response = await convertDeviceResponse(() =>
       sdk.btcSignPsbt(connectId, deviceId, {

--- a/packages/kit-bg/src/vaults/impls/btc/resolvePsbtTaprootOwnedOutputs.test.ts
+++ b/packages/kit-bg/src/vaults/impls/btc/resolvePsbtTaprootOwnedOutputs.test.ts
@@ -1,0 +1,125 @@
+import { resolvePsbtTaprootOwnedOutputs } from './resolvePsbtTaprootOwnedOutputs';
+
+describe('resolvePsbtTaprootOwnedOutputs', () => {
+  it('resolves inscription outputs owned by a different derived taproot address', async () => {
+    const vault = {
+      _getRelPathsToAddressByApi: jest.fn().mockResolvedValue({
+        relPaths: ['0/12'],
+        pathToAddresses: {
+          "m/86'/0'/0'/0/12": {
+            address: 'bc1pownedinscription',
+            relPath: '0/12',
+            fullPath: "m/86'/0'/0'/0/12",
+          },
+        },
+        addressToPath: {
+          bc1pownedinscription: {
+            address: 'bc1pownedinscription',
+            relPath: '0/12',
+            fullPath: "m/86'/0'/0'/0/12",
+          },
+        },
+      }),
+    };
+    const coreApi = {
+      getAddressFromXpub: jest.fn().mockResolvedValue({
+        addresses: {
+          '0/12': 'bc1pownedinscription',
+        },
+        publicKeys: {
+          '0/12':
+            '032222222222222222222222222222222222222222222222222222222222222222',
+        },
+        xpubSegwit: 'xpub-segwit',
+      }),
+    };
+
+    const result = await resolvePsbtTaprootOwnedOutputs({
+      network: { maximumFeeRate: 1000 } as any,
+      outputAddresses: ['bc1pexternal', 'bc1pownedinscription'],
+      encodedTx: {
+        outputs: [
+          {
+            address: 'bc1pexternal',
+            value: '1000',
+          },
+          {
+            address: 'bc1pownedinscription',
+            value: '546',
+            payload: {
+              isInscriptionStructure: true,
+            },
+          },
+        ],
+      } as any,
+      dbAccount: {
+        address: 'bc1pselected',
+        path: "m/86'/0'/0'",
+        relPath: '0/7',
+        pub: '033333333333333333333333333333333333333333333333333333333333333333',
+        xpub: 'xpub-main',
+        xpubSegwit: 'xpub-segwit',
+      } as any,
+      vault: vault as any,
+      coreApi: coreApi as any,
+    });
+
+    expect(result).toEqual({
+      1: {
+        fullPath: "m/86'/0'/0'/0/12",
+        pubkey:
+          '032222222222222222222222222222222222222222222222222222222222222222',
+      },
+    });
+    expect(vault._getRelPathsToAddressByApi).toHaveBeenCalledWith({
+      addresses: ['bc1pownedinscription'],
+      account: expect.objectContaining({
+        address: 'bc1pselected',
+      }),
+      xpubSegwit: 'xpub-segwit',
+    });
+    expect(coreApi.getAddressFromXpub).toHaveBeenCalledWith({
+      network: { maximumFeeRate: 1000 },
+      xpub: 'xpub-main',
+      relativePaths: ['0/12'],
+    });
+  });
+
+  it('does not annotate single-output transactions', async () => {
+    const vault = {
+      _getRelPathsToAddressByApi: jest.fn(),
+    };
+    const coreApi = {
+      getAddressFromXpub: jest.fn(),
+    };
+
+    const result = await resolvePsbtTaprootOwnedOutputs({
+      network: { maximumFeeRate: 1000 } as any,
+      outputAddresses: ['bc1powned'],
+      encodedTx: {
+        outputs: [
+          {
+            address: 'bc1powned',
+            value: '546',
+            payload: {
+              isInscriptionStructure: true,
+            },
+          },
+        ],
+      } as any,
+      dbAccount: {
+        address: 'bc1powned',
+        path: "m/86'/0'/0'",
+        relPath: '0/0',
+        pub: '033333333333333333333333333333333333333333333333333333333333333333',
+        xpub: 'xpub-main',
+      } as any,
+      vault: vault as any,
+      coreApi: coreApi as any,
+    });
+
+    expect(result).toEqual({});
+    expect(vault._getRelPathsToAddressByApi).not.toHaveBeenCalled();
+    expect(coreApi.getAddressFromXpub).not.toHaveBeenCalled();
+  });
+});

--- a/packages/kit-bg/src/vaults/impls/btc/resolvePsbtTaprootOwnedOutputs.ts
+++ b/packages/kit-bg/src/vaults/impls/btc/resolvePsbtTaprootOwnedOutputs.ts
@@ -1,0 +1,151 @@
+import type CoreChainSoftwareBtc from '@onekeyhq/core/src/chains/btc/CoreChainSoftware';
+import type {
+  IBtcForkNetwork,
+  IEncodedTxBtc,
+} from '@onekeyhq/core/src/chains/btc/types';
+
+import type { IDBUtxoAccount } from '../../../dbs/local/types';
+import type VaultBtc from './Vault';
+
+type IResolveOutputAccount = Parameters<
+  VaultBtc['_getRelPathsToAddressByApi']
+>[0]['account'];
+
+export type IResolvedPsbtTaprootOwnedOutput = {
+  fullPath: string;
+  pubkey: string;
+};
+
+export async function resolvePsbtTaprootOwnedOutputs({
+  network,
+  outputAddresses,
+  encodedTx,
+  dbAccount,
+  coreApi,
+  vault,
+}: {
+  network: IBtcForkNetwork;
+  outputAddresses: Array<string | undefined>;
+  encodedTx: IEncodedTxBtc;
+  dbAccount: Pick<
+    IDBUtxoAccount,
+    'address' | 'path' | 'pub' | 'relPath' | 'xpub' | 'xpubSegwit'
+  >;
+  coreApi: Pick<CoreChainSoftwareBtc, 'getAddressFromXpub'>;
+  vault: Pick<VaultBtc, '_getRelPathsToAddressByApi'>;
+}): Promise<Record<number, IResolvedPsbtTaprootOwnedOutput>> {
+  if (outputAddresses.length <= 1) {
+    return {};
+  }
+
+  const candidateOutputs = encodedTx.outputs
+    .map((encodedOutput, index) => {
+      const outputAddress = outputAddresses[index] ?? encodedOutput.address;
+      const isOwnedHint =
+        !!encodedOutput.payload?.isChange ||
+        !!encodedOutput.payload?.isInscriptionStructure;
+
+      if (!outputAddress || !isOwnedHint) {
+        return undefined;
+      }
+
+      return {
+        index,
+        outputAddress,
+      };
+    })
+    .filter((item) => !!item);
+
+  if (candidateOutputs.length === 0) {
+    return {};
+  }
+
+  const { addressToPath } = await vault._getRelPathsToAddressByApi({
+    addresses: Array.from(
+      new Set(candidateOutputs.map((item) => item?.outputAddress ?? '')),
+    ).filter(Boolean),
+    account: dbAccount as unknown as IResolveOutputAccount,
+    xpubSegwit: dbAccount.xpubSegwit,
+  });
+
+  const ownedOutputs = new Map<
+    number,
+    {
+      outputAddress: string;
+      relPath: string;
+      pubkey?: string;
+    }
+  >();
+  const relPathsToDerive = new Set<string>();
+
+  candidateOutputs.forEach((candidateOutput) => {
+    if (!candidateOutput) {
+      return;
+    }
+
+    const { index, outputAddress } = candidateOutput;
+
+    let relPath: string | undefined;
+    let pubkey: string | undefined;
+
+    if (outputAddress === dbAccount.address) {
+      relPath = dbAccount.relPath ?? '0/0';
+      pubkey = dbAccount.pub;
+    } else {
+      relPath = addressToPath[outputAddress]?.relPath;
+    }
+
+    if (!relPath) {
+      return;
+    }
+
+    ownedOutputs.set(index, {
+      outputAddress,
+      relPath,
+      pubkey,
+    });
+
+    if (!pubkey) {
+      relPathsToDerive.add(relPath);
+    }
+  });
+
+  if (ownedOutputs.size === 0) {
+    return {};
+  }
+
+  let derivedAddresses: Record<string, string> = {};
+  let derivedPublicKeys: Record<string, string> = {};
+
+  if (relPathsToDerive.size > 0) {
+    const derivedResult = await coreApi.getAddressFromXpub({
+      network,
+      xpub: dbAccount.xpub,
+      relativePaths: Array.from(relPathsToDerive),
+    });
+
+    derivedAddresses = derivedResult.addresses;
+    derivedPublicKeys = derivedResult.publicKeys;
+  }
+
+  const resolvedOutputs: Record<number, IResolvedPsbtTaprootOwnedOutput> = {};
+
+  ownedOutputs.forEach((ownedOutput, index) => {
+    const derivedPubkey =
+      ownedOutput.pubkey ??
+      (derivedAddresses[ownedOutput.relPath] === ownedOutput.outputAddress
+        ? derivedPublicKeys[ownedOutput.relPath]
+        : undefined);
+
+    if (!derivedPubkey) {
+      return;
+    }
+
+    resolvedOutputs[index] = {
+      fullPath: `${dbAccount.path}/${ownedOutput.relPath}`,
+      pubkey: derivedPubkey,
+    };
+  });
+
+  return resolvedOutputs;
+}


### PR DESCRIPTION
## Summary
- resolve wallet-owned Taproot PSBT outputs from existing change/inscription hints instead of only matching the selected account address
- annotate those owned outputs with the correct full derivation path and pubkey before hardware signing
- add a focused regression test for inscription outputs that belong to a different derived wallet address

## Verification
- node .yarn/releases/yarn-4.12.0.cjs jest packages/kit-bg/src/vaults/impls/btc/resolvePsbtTaprootOwnedOutputs.test.ts --runInBand
- node .yarn/releases/yarn-4.12.0.cjs exec eslint packages/kit-bg/src/vaults/impls/btc/KeyringHardwareBtcBase.ts packages/kit-bg/src/vaults/impls/btc/resolvePsbtTaprootOwnedOutputs.ts packages/kit-bg/src/vaults/impls/btc/resolvePsbtTaprootOwnedOutputs.test.ts --ext .ts
- node .yarn/releases/yarn-4.12.0.cjs exec tsc -p packages/kit-bg/tsconfig.json --noEmit --pretty false
  - still reports unrelated baseline type errors in existing dependencies and other packages; filtered output showed no errors from the touched BTC files

Closes #9757