### PR TITLE
fix(send): use send-time memo, truncate long memo, store Algo note (OK-53026, OK-53077)

### DIFF
--- a/packages/kit/src/views/Send/pages/SendDataInput/RecentRecipients.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecentRecipients.tsx
@@ -398,8 +398,7 @@ function RecentRecipients(props: IRecentRecipientsProps) {
               name:
                 recipient.addressBookName ?? recipient.walletAccountName ?? '',
               address: canonicalAddress,
-              memo: recipient.addressMemo || recipient.recipientMemo,
-              note: recipient.addressNote,
+              memo: recipient.recipientMemo,
               lastTransferTime: recipient.lastTransferTime,
               lastTransferNetworkName: recipient.lastTransferNetworkName,
               isAddressBook: recipient.isAddressBook,
@@ -415,8 +414,7 @@ function RecentRecipients(props: IRecentRecipientsProps) {
             onPress={() => {
               onSelect?.({
                 address: canonicalAddress,
-                memo: recipient.addressMemo || recipient.recipientMemo,
-                note: recipient.addressNote,
+                memo: recipient.recipientMemo,
               });
             }}
           />

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -132,7 +132,11 @@ const QuickSelectListItem = memo(
           return (
             <MatchSizeableText size="$bodyMd" color="$textSubdued">
               {item.memo || item.note
-                ? `${showAddr} · ${item.memo || item.note}`
+                ? `${showAddr} · ${accountUtils.shortenAddress({
+                    address: item.memo || item.note,
+                    leadingLength: 6,
+                    trailingLength: 4,
+                  })}`
                 : showAddr}
             </MatchSizeableText>
           );

--- a/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmActions/TxConfirmActions.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmActions/TxConfirmActions.tsx
@@ -424,6 +424,7 @@ function TxConfirmActions(props: IProps) {
           address: addressToSave,
           memo:
             transferPayload?.memo ||
+            transferPayload?.note ||
             (transferPayload?.paymentId
               ? String(transferPayload.paymentId)
               : undefined),


### PR DESCRIPTION
## Summary

### OK-53026: Use send-time memo in recent list, not address book
Recent recipients list was sourcing memo/tag/note from address book (`addressMemo`/`addressNote`), which caused:
1. **Memo disappears when address book entry is deleted**
2. **Ambiguous memo** — same address with multiple address book entries (different memos) shows non-deterministic result

Now uses `recipientMemo` only (from send-time storage or chain history). Address book memo is no longer used for recent list display.

Data source priority: `Send-time stored memo > Chain history extracted memo`

### OK-53077: Truncate long memo in address book tab
Address book tab now truncates long memo/note with middle ellipsis, matching the recent tab behavior. Short memos (e.g. XRP destination tags) still display in full.

### Algo note storage
`TxConfirmActions` now stores Algo `note` on send success. Previously only `memo` (Cosmos/TON/Stellar/XRP) and `paymentId` (DNX) were persisted.

| Chain | Field | Stored on send |
|---|---|---|
| Cosmos, TON, Stellar, XRP | `withMemo` | `transferPayload.memo` ✅ |
| DNX | `withPaymentId` | `transferPayload.paymentId` ✅ |
| Algo | `withNote` | `transferPayload.note` ✅ (new) |

## Jira
- [OK-53026](https://onekeyhq.atlassian.net/browse/OK-53026)
- [OK-53077](https://onekeyhq.atlassian.net/browse/OK-53077)

## Test plan
- [ ] Cosmos: send with memo → delete address book entry → memo still shows in recent list
- [ ] XRP: send with destination tag → delete address book entry → tag still shows
- [ ] Algo: send with note → note shows in recent list
- [ ] Same address with two address book entries (different memos) → recent list shows the actual sent memo
- [ ] Address book tab: long memo shows truncated with middle ellipsis
- [ ] Address book tab: short memo (XRP tag) shows in full

[OK-53026]: https://onekeyhq.atlassian.net/browse/OK-53026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ