### PR TITLE
fix: optimize browser submenu expand/collapse performance (OK-53056)

### DIFF
--- a/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/BrowserSubmenuColumn.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/BrowserSubmenuColumn.tsx
@@ -114,26 +114,62 @@ export function BrowserSubmenuColumn({
     if (!isHovered) return;
     if (typeof document === 'undefined') return;
 
+    // Cache the bounding rect so pointermove avoids forcing layout.
+    // Refresh on scroll/resize since those can shift the sidebar.
+    let cachedRect: DOMRect | null = null;
+    let rectRafId: number | null = null;
+    const updateCachedRect = () => {
+      if (rectRafId !== null) return;
+      rectRafId = requestAnimationFrame(() => {
+        rectRafId = null;
+        const container = containerRef.current;
+        if (container) {
+          cachedRect = container.getBoundingClientRect();
+        }
+      });
+    };
+    // Synchronous initial read — effect runs between frames, no layout thrash.
+    const container = containerRef.current;
+    if (container) {
+      cachedRect = container.getBoundingClientRect();
+    }
+    window.addEventListener('resize', updateCachedRect);
+    window.addEventListener('scroll', updateCachedRect, true);
+
+    let rafId: number | null = null;
+
     const handlePointerMove = (e: PointerEvent) => {
       lastPointerRef.current = { x: e.clientX, y: e.clientY };
-      // Don't collapse while a child popover (e.g. context menu) is open
       if (popoverCountRef.current > 0) return;
-      const container = containerRef.current;
-      if (!container) return;
-      const rect = container.getBoundingClientRect();
-      const isInside =
-        e.clientX >= rect.left &&
-        e.clientX <= rect.left + EXPANDED_SUBMENU_WIDTH &&
-        e.clientY >= rect.top &&
-        e.clientY <= rect.bottom;
-      if (!isInside) {
-        clearHoverTimer();
-        setIsHovered(false);
-      }
+
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        // Re-check: popover may have opened between scheduling and execution
+        if (popoverCountRef.current > 0) return;
+        if (!cachedRect) return;
+        const pointer = lastPointerRef.current;
+        if (!pointer) return;
+        const isInside =
+          pointer.x >= cachedRect.left &&
+          pointer.x <= cachedRect.left + EXPANDED_SUBMENU_WIDTH &&
+          pointer.y >= cachedRect.top &&
+          pointer.y <= cachedRect.bottom;
+        if (!isInside) {
+          clearHoverTimer();
+          setIsHovered(false);
+        }
+      });
     };
 
     document.addEventListener('pointermove', handlePointerMove);
-    return () => document.removeEventListener('pointermove', handlePointerMove);
+    return () => {
+      document.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('resize', updateCachedRect);
+      window.removeEventListener('scroll', updateCachedRect, true);
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      if (rectRafId !== null) cancelAnimationFrame(rectRafId);
+    };
   }, [isHovered, clearHoverTimer]);
 
   type ITabBarProps = { inSubmenu?: boolean; isExpanded?: boolean };

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/SubmenuColumn.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/SubmenuColumn.tsx
@@ -22,9 +22,12 @@ export function SubmenuColumn({
   webPageTabBar,
   isExpanded = false,
 }: ISubmenuColumnProps) {
-  const boxShadowStyle = useMemo(
+  const expandedStyle = useMemo(
     () => ({
       boxShadow: isExpanded ? '10px 0 30px -10px rgba(0, 0, 0, 0.10)' : 'none',
+      willChange: isExpanded ? ('width' as const) : ('auto' as const),
+      transition:
+        'background-color 150ms ease, border-color 150ms ease, border-radius 150ms ease, box-shadow 150ms ease',
     }),
     [isExpanded],
   );
@@ -62,7 +65,8 @@ export function SubmenuColumn({
         borderBottomWidth={1}
         borderRightWidth={1}
         borderColor={isExpanded ? '$neutral3' : 'transparent'}
-        style={boxShadowStyle}
+        overflow="hidden"
+        style={expandedStyle}
       >
         {webPageTabBar}
       </YStack>


### PR DESCRIPTION
## Summary
- Throttle `pointermove` handler with `requestAnimationFrame` and cache `getBoundingClientRect()` result to eliminate per-pixel forced layout reflows when the browser submenu is expanded
- Add CSS transitions for `background-color`, `border-color`, `border-radius`, and `box-shadow` so visual properties animate smoothly alongside the width spring animation
- Set `willChange: 'width'` only while expanding and add `overflow: hidden` to reduce compositor overhead

## Test plan
- [ ] Desktop: hover over Discovery sidebar icon, verify submenu expands/collapses smoothly without jank
- [ ] Verify right-click context menu on tab items still works correctly (popover race condition fix)
- [ ] Resize window while submenu is expanded, verify it still collapses correctly when cursor leaves
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
