### PR TITLE
fix(swap,market): address recipient input, review fiat values, and iOS settings dialog layout (OK-53097)(OK-53090)(OK-53070)

### DIFF
--- a/packages/kit/src/components/AddressInput/index.tsx
+++ b/packages/kit/src/components/AddressInput/index.tsx
@@ -19,7 +19,6 @@ import {
   XStack,
   useFormContext,
 } from '@onekeyhq/components';
-import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useRouteIsFocused as useIsFocused } from '@onekeyhq/kit/src/hooks/useRouteIsFocused';
 import type {
@@ -53,6 +52,11 @@ import { useIsEnableTransferAllowList } from './hooks';
 import { ClipboardPlugin } from './plugins/clipboard';
 import { ScanPlugin } from './plugins/scan';
 import { SelectorPlugin } from './plugins/selector';
+import {
+  getAddressQueryResolvedAddress,
+  getAddressValidateTranslationId,
+  queryAddressWithFallback,
+} from './utils';
 
 import type { IScanPluginProps } from './plugins/scan';
 import type { IAccountSelectorActiveAccountInfo } from '../../states/jotai/contexts/accountSelector';
@@ -505,15 +509,9 @@ export function AddressInput(props: IAddressInputProps) {
           inputTypeRef.current = undefined;
         }
 
-        const result =
-          await backgroundApiProxy.serviceAccountProfile.queryAddress(params);
+        const result = await queryAddressWithFallback(params);
         if (result.input === textRef.current) {
           setQueryResult(result);
-        }
-      } catch {
-        // Treat unexpected validation errors as an unknown address state.
-        if (params.address === textRef.current) {
-          setQueryResult({ input: params.address, validStatus: 'unknown' });
         }
       } finally {
         setLoading(false);
@@ -596,39 +594,21 @@ export function AddressInput(props: IAddressInputProps) {
     ignoreSimilarAddressInAddressBook,
   ]);
 
-  const getValidateMessage = useCallback(
-    (status?: Exclude<IAddressValidateStatus, 'valid'>) => {
-      if (!status) return;
-      const message: Record<
-        Exclude<IAddressValidateStatus, 'valid'>,
-        ETranslations
-      > = {
-        'unknown': ETranslations.send_check_request_error,
-        'prohibit-send-to-self': ETranslations.send_cannot_send_to_self,
-        'invalid': ETranslations.send_address_invalid,
-        'address-not-allowlist': ETranslations.send_address_not_allowlist_error,
-      } as const;
-      return message[status];
-    },
-    [],
-  );
-
   useEffect(() => {
     if (Object.keys(queryResult).length === 0) return;
     if (queryResult.validStatus === 'valid') {
       clearErrors(name);
       onChange?.({
         raw: queryResult.input,
-        resolved:
-          queryResult.resolveAddress ??
-          queryResult.validAddress ??
-          queryResult.input?.trim(),
+        resolved: getAddressQueryResolvedAddress(queryResult),
         pending: false,
         isContract: queryResult.isContract,
         similarAddress: queryResult.similarAddress,
       });
     } else {
-      const translationId = getValidateMessage(queryResult.validStatus);
+      const translationId = getAddressValidateTranslationId(
+        queryResult.validStatus,
+      );
       onChange?.({
         raw: queryResult.input,
         pending: false,
@@ -643,15 +623,7 @@ export function AddressInput(props: IAddressInputProps) {
         similarAddress: queryResult.similarAddress,
       });
     }
-  }, [
-    queryResult,
-    intl,
-    clearErrors,
-    setError,
-    name,
-    onChange,
-    getValidateMessage,
-  ]);
+  }, [queryResult, intl, clearErrors, setError, name, onChange]);
 
   const handleClear = useCallback(() => {
     onChangeText({ text: '', inputType: EInputAddressChangeType.Manual });

--- a/packages/kit/src/components/AddressInput/utils.ts
+++ b/packages/kit/src/components/AddressInput/utils.ts
@@ -1,0 +1,51 @@
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+
+import type {
+  IAddressValidateStatus,
+  IQueryCheckAddressArgs,
+} from '@onekeyhq/shared/types/address';
+
+import type { IAddressQueryResult } from '.';
+
+export function getAddressValidateTranslationId(
+  status?: Exclude<IAddressValidateStatus, 'valid'>,
+) {
+  if (!status) {
+    return undefined;
+  }
+
+  const message: Record<
+    Exclude<IAddressValidateStatus, 'valid'>,
+    ETranslations
+  > = {
+    unknown: ETranslations.send_check_request_error,
+    'prohibit-send-to-self': ETranslations.send_cannot_send_to_self,
+    invalid: ETranslations.send_address_invalid,
+    'address-not-allowlist': ETranslations.send_address_not_allowlist_error,
+  };
+
+  return message[status];
+}
+
+export function getAddressQueryResolvedAddress(
+  result: Pick<
+    IAddressQueryResult,
+    'input' | 'resolveAddress' | 'validAddress'
+  >,
+) {
+  return result.resolveAddress ?? result.validAddress ?? result.input?.trim();
+}
+
+export async function queryAddressWithFallback(
+  params: IQueryCheckAddressArgs,
+): Promise<IAddressQueryResult> {
+  try {
+    return await backgroundApiProxy.serviceAccountProfile.queryAddress(params);
+  } catch {
+    return {
+      input: params.address,
+      validStatus: 'unknown',
+    };
+  }
+}

--- a/packages/kit/src/components/AddressInput/utils.ts
+++ b/packages/kit/src/components/AddressInput/utils.ts
@@ -1,6 +1,5 @@
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-
 import type {
   IAddressValidateStatus,
   IQueryCheckAddressArgs,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
@@ -12,7 +12,10 @@ import type {
   ISwapTokenBase,
 } from '@onekeyhq/shared/types/swap/types';
 
-import { useSpeedSwapActions } from './useSpeedSwapActions';
+import {
+  buildMarketReviewTokens,
+  useSpeedSwapActions,
+} from './useSpeedSwapActions';
 import { ESwapDirection } from './useTradeType';
 
 type IFetchSwapTokenDetailsParams = {
@@ -763,5 +766,43 @@ describe('useSpeedSwapActions', () => {
     });
 
     expect(mockFetchSwapTokenDetails).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildMarketReviewTokens', () => {
+  it('applies the live payment token price to the buy review from token', () => {
+    const reviewTokens = buildMarketReviewTokens({
+      tradeType: ESwapDirection.BUY,
+      fromToken: {
+        ...usdcToken,
+        price: '0',
+      } as ISwapToken,
+      toToken: {
+        ...tonMarketToken,
+        price: '5',
+      },
+      tradeTokenPrice: new BigNumber(2),
+    });
+
+    expect(reviewTokens.fromToken.price).toBe('2');
+    expect(reviewTokens.toToken.price).toBe('5');
+  });
+
+  it('applies the live payment token price to the sell review to token', () => {
+    const reviewTokens = buildMarketReviewTokens({
+      tradeType: ESwapDirection.SELL,
+      fromToken: {
+        ...tonMarketToken,
+        price: '5',
+      },
+      toToken: {
+        ...usdcToken,
+        price: '0',
+      } as ISwapToken,
+      tradeTokenPrice: new BigNumber(2),
+    });
+
+    expect(reviewTokens.fromToken.price).toBe('5');
+    expect(reviewTokens.toToken.price).toBe('2');
   });
 });

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -126,6 +126,42 @@ type IMarketReviewExecutionSnapshot = {
   buildRes?: IFetchBuildTxResponse;
 };
 
+export function buildMarketReviewTokens({
+  tradeType,
+  fromToken,
+  toToken,
+  tradeTokenPrice,
+}: {
+  tradeType: ESwapDirection;
+  fromToken: ISwapToken;
+  toToken: ISwapToken;
+  tradeTokenPrice?: BigNumber;
+}) {
+  if (!tradeTokenPrice || tradeTokenPrice.isNaN() || !tradeTokenPrice.gt(0)) {
+    return { fromToken, toToken };
+  }
+
+  const resolvedPrice = tradeTokenPrice.toFixed();
+
+  if (tradeType === ESwapDirection.BUY) {
+    return {
+      fromToken: {
+        ...fromToken,
+        price: resolvedPrice,
+      },
+      toToken,
+    };
+  }
+
+  return {
+    fromToken,
+    toToken: {
+      ...toToken,
+      price: resolvedPrice,
+    },
+  };
+}
+
 export function useSpeedSwapActions(props: {
   marketToken: ISwapToken;
   tradeToken: ISwapTokenBase;
@@ -213,6 +249,18 @@ export function useSpeedSwapActions(props: {
   const tradeTokenPriceKey = `${tradeToken.networkId ?? ''}:${tradeToken.contractAddress ?? ''}`;
   const { price: liveTradeTokenPrice, tokenKey: liveTradeTokenPriceKey } =
     usePaymentTokenPrice(tradeToken, tradeToken.networkId);
+  const effectiveTradeTokenPrice = useMemo(() => {
+    if (liveTradeTokenPriceKey === tradeTokenPriceKey) {
+      return liveTradeTokenPrice ?? new BigNumber(tradeToken.price || 0);
+    }
+
+    return new BigNumber(tradeToken.price || 0);
+  }, [
+    liveTradeTokenPrice,
+    liveTradeTokenPriceKey,
+    tradeToken.price,
+    tradeTokenPriceKey,
+  ]);
 
   // Use atom to get selected derive type from Market Detail page
   const [selectedDeriveType] = useSelectedDeriveTypeAtom();
@@ -1106,10 +1154,17 @@ export function useSpeedSwapActions(props: {
       const amount = fromAmount ?? fromTokenAmountDebounced;
       const fromTokenFinal = currentFromToken ?? fromToken;
       const toTokenFinal = currentToToken ?? toToken;
+      const { fromToken: reviewFromToken, toToken: reviewToToken } =
+        buildMarketReviewTokens({
+          tradeType,
+          fromToken: fromTokenFinal,
+          toToken: toTokenFinal,
+          tradeTokenPrice: effectiveTradeTokenPrice,
+        });
 
       if (isWrap || isWrapped) {
         const shouldFallback = buildMarketReviewShouldFallback({
-          networkId: fromTokenFinal.networkId,
+          networkId: reviewFromToken.networkId,
           isCustomRpcUnavailable,
         });
         const {
@@ -1118,18 +1173,18 @@ export function useSpeedSwapActions(props: {
           swapInfo,
         } = buildWrappedSwapData({
           fromAmount: amount,
-          fromToken: fromTokenFinal,
-          toToken: toTokenFinal,
+          fromToken: reviewFromToken,
+          toToken: reviewToToken,
         });
         reviewExecutionSnapshotRef.current = {
           kind: 'wrap',
           accountAddress: swapInfo.accountAddress,
           accountId: netAccountRes.result?.id ?? '',
-          networkId: fromTokenFinal.networkId,
+          networkId: reviewFromToken.networkId,
           shouldFallback,
           quoteResult: wrappedQuoteResult,
           buildUnsignedParams: {
-            networkId: fromTokenFinal.networkId,
+            networkId: reviewFromToken.networkId,
             accountId: netAccountRes.result?.id ?? '',
             wrappedInfo,
             swapInfo,
@@ -1152,8 +1207,8 @@ export function useSpeedSwapActions(props: {
       ] = await Promise.all([
         buildSpeedSwapTxData({
           fromAmount: amount,
-          fromToken: fromTokenFinal,
-          toToken: toTokenFinal,
+          fromToken: reviewFromToken,
+          toToken: reviewToToken,
         }),
         resolveMarketReviewAllowanceState({
           amount,
@@ -1164,7 +1219,7 @@ export function useSpeedSwapActions(props: {
           },
           isWrapped,
           spenderAddress: currentSpenderAddress,
-          token: fromTokenFinal,
+          token: reviewFromToken,
           walletAddress: netAccountRes.result?.addressDetail.address,
         }),
       ]);
@@ -1187,18 +1242,18 @@ export function useSpeedSwapActions(props: {
         }),
       );
       const shouldFallback = buildMarketReviewShouldFallback({
-        networkId: fromTokenFinal.networkId,
+        networkId: reviewFromToken.networkId,
         isCustomRpcUnavailable,
       });
       reviewExecutionSnapshotRef.current = {
         kind: 'swap',
         accountAddress: userAddress,
         accountId: netAccountRes.result?.id ?? '',
-        networkId: fromTokenFinal.networkId,
+        networkId: reviewFromToken.networkId,
         shouldFallback,
         quoteResult: normalizedQuoteResult,
         buildUnsignedParams: {
-          networkId: fromTokenFinal.networkId,
+          networkId: reviewFromToken.networkId,
           accountId: netAccountRes.result?.id ?? '',
           transfersInfo: transferInfo ? [transferInfo] : undefined,
           encodedTx,
@@ -1230,6 +1285,8 @@ export function useSpeedSwapActions(props: {
       shouldApprove,
       shouldResetApprove,
       slippage,
+      effectiveTradeTokenPrice,
+      tradeType,
       toToken,
     ],
   );
@@ -2272,10 +2329,6 @@ export function useSpeedSwapActions(props: {
   const fetchTokenPrice = useCallback(async () => {
     const currentRequestId = priceRequestIdRef.current + 1;
     priceRequestIdRef.current = currentRequestId;
-    const effectiveTradeTokenPrice =
-      liveTradeTokenPriceKey === tradeTokenPriceKey
-        ? (liveTradeTokenPrice ?? new BigNumber(tradeToken.price || 0))
-        : new BigNumber(tradeToken.price || 0);
     const fromTokenPriceBN =
       tradeType === ESwapDirection.BUY
         ? effectiveTradeTokenPrice
@@ -2377,8 +2430,8 @@ export function useSpeedSwapActions(props: {
       loading: false,
     });
   }, [
+    effectiveTradeTokenPrice,
     tradeType,
-    tradeToken.price,
     fromToken.price,
     fromToken.symbol,
     fromToken.networkId,
@@ -2387,9 +2440,6 @@ export function useSpeedSwapActions(props: {
     toToken.symbol,
     toToken.networkId,
     toToken.contractAddress,
-    liveTradeTokenPrice,
-    liveTradeTokenPriceKey,
-    tradeTokenPriceKey,
   ]);
 
   useEffect(() => {

--- a/packages/kit/src/views/Swap/hooks/useSwapAccount.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapAccount.ts
@@ -27,7 +27,10 @@ import {
   useSwapToAnotherAccountAddressAtom,
 } from '../../../states/jotai/contexts/swap';
 
-import { shouldUseSwapCustomRecipientAddress } from './useSwapAccount.utils';
+import {
+  shouldShowSwapRecipientAddressInfo,
+  shouldUseSwapCustomRecipientAddress,
+} from './useSwapAccount.utils';
 
 import type { IAccountSelectorActiveAccountInfo } from '../../../states/jotai/contexts/accountSelector';
 
@@ -394,44 +397,17 @@ export function useSwapAddressInfo(type: ESwapDirectionType) {
 }
 
 export function useSwapRecipientAddressInfo(enable: boolean) {
-  const fromAccountInfo = useSwapAddressInfo(ESwapDirectionType.FROM);
   const swapToAddressInfo = useSwapAddressInfo(ESwapDirectionType.TO);
   const [toToken] = useSwapSelectToTokenAtom();
   const [{ swapToAnotherAccountSwitchOn }] = useSettingsAtom();
   const [swapToAnotherAddressInfo] = useSwapToAnotherAccountAddressAtom();
-  const getToNetWorkAddressFromAccountId = usePromiseResult(
-    async () => {
-      if (!enable) {
-        return null;
-      }
-      if (
-        swapToAddressInfo.networkId &&
-        !networkUtils.isAllNetwork({
-          networkId: swapToAddressInfo.networkId,
-        }) &&
-        fromAccountInfo.accountInfo?.account?.id &&
-        fromAccountInfo.accountInfo?.indexedAccount?.id
-      ) {
-        const accountInfos =
-          await backgroundApiProxy.serviceStaking.getEarnAccount({
-            accountId: fromAccountInfo.accountInfo?.account?.id,
-            networkId: swapToAddressInfo.networkId,
-            indexedAccountId: fromAccountInfo.accountInfo?.indexedAccount?.id,
-          });
-        return accountInfos;
-      }
-    },
-    [
-      enable,
-      swapToAddressInfo.networkId,
-      fromAccountInfo.accountInfo?.account?.id,
-      fromAccountInfo.accountInfo?.indexedAccount?.id,
-    ],
-    {},
-  );
 
   const getToAddressAccountInfos = usePromiseResult(
     async () => {
+      if (!enable) {
+        return undefined;
+      }
+
       if (
         swapToAnotherAddressInfo.networkId &&
         swapToAnotherAddressInfo.address
@@ -446,41 +422,44 @@ export function useSwapRecipientAddressInfo(enable: boolean) {
         }
       }
     },
-    [swapToAnotherAddressInfo.address, swapToAnotherAddressInfo.networkId],
+    [
+      enable,
+      swapToAnotherAddressInfo.address,
+      swapToAnotherAddressInfo.networkId,
+    ],
     {},
   );
+
   if (
-    swapToAddressInfo.address === swapToAnotherAddressInfo.address &&
-    swapToAnotherAccountSwitchOn
+    enable &&
+    shouldShowSwapRecipientAddressInfo({
+      swapToAnotherAccountSwitchOn,
+      selectedRecipientAddress: swapToAnotherAddressInfo.address,
+      selectedRecipientNetworkId: swapToAnotherAddressInfo.networkId,
+      toTokenNetworkId: toToken?.networkId,
+      toAddressNetworkId: swapToAddressInfo.networkId,
+    })
   ) {
-    if (
-      ((getToNetWorkAddressFromAccountId?.result?.accountAddress &&
-        getToNetWorkAddressFromAccountId?.result?.accountAddress !==
-          swapToAnotherAddressInfo.address) ||
-        !getToNetWorkAddressFromAccountId?.result?.accountAddress) &&
-      swapToAnotherAddressInfo.networkId ===
-        (toToken?.networkId ?? swapToAddressInfo.networkId)
-    ) {
-      return {
-        accountInfo:
-          swapToAnotherAddressInfo.accountInfo?.account?.address ===
-          swapToAnotherAddressInfo.address
-            ? {
-                walletName: swapToAnotherAddressInfo.accountInfo?.wallet?.name,
-                accountName: swapToAnotherAddressInfo.accountInfo?.accountName,
-                accountId: swapToAnotherAddressInfo.accountInfo?.account?.id,
-              }
-            : getToAddressAccountInfos.result,
-        showAddress: accountUtils.shortenAddress({
-          address: swapToAnotherAddressInfo.address,
-          leadingLength: 6,
-          trailingLength: 6,
-        }),
-        isExtAccount:
-          swapToAnotherAddressInfo.accountInfo?.account?.address !==
-            swapToAnotherAddressInfo.address &&
-          !getToAddressAccountInfos.result,
-      };
-    }
+    const isRecipientExternalAccount =
+      swapToAnotherAddressInfo.accountInfo?.account?.address !==
+        swapToAnotherAddressInfo.address && !getToAddressAccountInfos.result;
+
+    return {
+      accountInfo:
+        swapToAnotherAddressInfo.accountInfo?.account?.address ===
+        swapToAnotherAddressInfo.address
+          ? {
+              walletName: swapToAnotherAddressInfo.accountInfo?.wallet?.name,
+              accountName: swapToAnotherAddressInfo.accountInfo?.accountName,
+              accountId: swapToAnotherAddressInfo.accountInfo?.account?.id,
+            }
+          : getToAddressAccountInfos.result,
+      showAddress: accountUtils.shortenAddress({
+        address: swapToAnotherAddressInfo.address,
+        leadingLength: 6,
+        trailingLength: 6,
+      }),
+      isExtAccount: isRecipientExternalAccount,
+    };
   }
 }

--- a/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.test.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.test.ts
@@ -1,6 +1,9 @@
 import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
 
-import { shouldUseSwapCustomRecipientAddress } from './useSwapAccount.utils';
+import {
+  shouldShowSwapRecipientAddressInfo,
+  shouldUseSwapCustomRecipientAddress,
+} from './useSwapAccount.utils';
 
 describe('shouldUseSwapCustomRecipientAddress', () => {
   it('keeps a confirmed custom recipient when the TO account is still empty', () => {
@@ -43,5 +46,43 @@ describe('shouldUseSwapCustomRecipientAddress', () => {
         isAllNetwork: true,
       }),
     ).toBe(true);
+  });
+});
+
+describe('shouldShowSwapRecipientAddressInfo', () => {
+  it('shows the selected recipient info when the selected network matches the target token network', () => {
+    expect(
+      shouldShowSwapRecipientAddressInfo({
+        swapToAnotherAccountSwitchOn: true,
+        selectedRecipientAddress: '0x1234',
+        selectedRecipientNetworkId: 'evm--1',
+        toTokenNetworkId: 'evm--1',
+        toAddressNetworkId: 'evm--1',
+      }),
+    ).toBe(true);
+  });
+
+  it('falls back when the selected recipient belongs to another network', () => {
+    expect(
+      shouldShowSwapRecipientAddressInfo({
+        swapToAnotherAccountSwitchOn: true,
+        selectedRecipientAddress: '0x1234',
+        selectedRecipientNetworkId: 'evm--1',
+        toTokenNetworkId: 'evm--10',
+        toAddressNetworkId: 'evm--10',
+      }),
+    ).toBe(false);
+  });
+
+  it('falls back when the recipient switch is off', () => {
+    expect(
+      shouldShowSwapRecipientAddressInfo({
+        swapToAnotherAccountSwitchOn: false,
+        selectedRecipientAddress: '0x1234',
+        selectedRecipientNetworkId: 'evm--1',
+        toTokenNetworkId: 'evm--1',
+        toAddressNetworkId: 'evm--1',
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.ts
@@ -10,6 +10,14 @@ type IShouldUseSwapCustomRecipientAddressParams = {
   isAllNetwork: boolean;
 };
 
+type IShouldShowSwapRecipientAddressInfoParams = {
+  swapToAnotherAccountSwitchOn: boolean;
+  selectedRecipientAddress?: string;
+  selectedRecipientNetworkId?: string;
+  toAddressNetworkId?: string;
+  toTokenNetworkId?: string;
+};
+
 export function shouldUseSwapCustomRecipientAddress({
   type,
   swapToAnotherAccountSwitchOn,
@@ -35,5 +43,25 @@ export function shouldUseSwapCustomRecipientAddress({
     isAllNetwork ||
     activeNetworkId === selectedRecipientNetworkId ||
     tokenNetworkId === selectedRecipientNetworkId
+  );
+}
+
+export function shouldShowSwapRecipientAddressInfo({
+  swapToAnotherAccountSwitchOn,
+  selectedRecipientAddress,
+  selectedRecipientNetworkId,
+  toAddressNetworkId,
+  toTokenNetworkId,
+}: IShouldShowSwapRecipientAddressInfoParams) {
+  if (
+    !swapToAnotherAccountSwitchOn ||
+    !selectedRecipientAddress ||
+    !selectedRecipientNetworkId
+  ) {
+    return false;
+  }
+
+  return (
+    selectedRecipientNetworkId === (toTokenNetworkId ?? toAddressNetworkId)
   );
 }

--- a/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.test.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.test.ts
@@ -7,7 +7,10 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import type { IAddressQueryResult } from '@onekeyhq/kit/src/components/AddressInput';
 import type { IQueryCheckAddressArgs } from '@onekeyhq/shared/types/address';
 
-import { useSwapIncognitoRecipientInput } from './useSwapIncognitoRecipientInput';
+import {
+  shouldBlockSwapActionForIncognitoRecipientInput,
+  useSwapIncognitoRecipientInput,
+} from './useSwapIncognitoRecipientInput';
 
 type ISettingsState = {
   swapToAnotherAccountSwitchOn: boolean;
@@ -372,5 +375,31 @@ describe('useSwapIncognitoRecipientInput', () => {
     await waitFor(() => {
       expect(result.current.inputText).toBe('');
     });
+  });
+});
+
+describe('shouldBlockSwapActionForIncognitoRecipientInput', () => {
+  it('blocks review while the recipient input is still unresolved', () => {
+    expect(
+      shouldBlockSwapActionForIncognitoRecipientInput({
+        enabled: true,
+        inputText: '0xrecipient',
+        loading: false,
+        queryResult: {},
+      }),
+    ).toBe(true);
+  });
+
+  it('allows review after the recipient input is validated', () => {
+    expect(
+      shouldBlockSwapActionForIncognitoRecipientInput({
+        enabled: true,
+        inputText: '0xrecipient',
+        loading: false,
+        queryResult: {
+          validStatus: 'valid',
+        },
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.test.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.test.ts
@@ -1,0 +1,255 @@
+/** @jest-environment jsdom */
+
+import type { SetStateAction } from 'react';
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import type { IAddressQueryResult } from '@onekeyhq/kit/src/components/AddressInput';
+import type { IQueryCheckAddressArgs } from '@onekeyhq/shared/types/address';
+
+import { useSwapIncognitoRecipientInput } from './useSwapIncognitoRecipientInput';
+
+type ISettingsState = {
+  swapToAnotherAccountSwitchOn: boolean;
+};
+
+type ISwapToAddressState = {
+  accountInfo?: unknown;
+  address?: string;
+  networkId?: string;
+};
+
+const mockQueryAddressWithFallback: jest.MockedFunction<
+  (params: IQueryCheckAddressArgs) => Promise<IAddressQueryResult>
+> = jest.fn();
+const mockSetSettings = jest.fn();
+const mockSetSwapToAddress = jest.fn();
+
+let mockSettingsState: ISettingsState = {
+  swapToAnotherAccountSwitchOn: false,
+};
+let mockSwapToAddressState: ISwapToAddressState = {};
+
+function applyStateUpdater<T>(state: T, updater: SetStateAction<T>): T {
+  return typeof updater === 'function'
+    ? (updater as (prevState: T) => T)(state)
+    : updater;
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return {
+    promise,
+    reject,
+    resolve,
+  };
+}
+
+async function flushDebounce() {
+  await act(async () => {
+    jest.advanceTimersByTime(300);
+    await Promise.resolve();
+  });
+}
+
+async function flushAsync() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+jest.mock('react-intl', () => ({
+  useIntl: () => ({
+    formatMessage: ({ id }: { id: string }) => id,
+  }),
+}));
+
+jest.mock('@onekeyhq/kit/src/components/AddressInput/utils', () => ({
+  getAddressQueryResolvedAddress: (result: {
+    input?: string;
+    resolveAddress?: string;
+    validAddress?: string;
+  }) => result.resolveAddress ?? result.validAddress ?? result.input?.trim(),
+  getAddressValidateTranslationId: () => undefined,
+  queryAddressWithFallback: (params: IQueryCheckAddressArgs) =>
+    mockQueryAddressWithFallback(params),
+}));
+
+jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms', () => ({
+  useSettingsAtom: () => [mockSettingsState, mockSetSettings],
+}));
+
+jest.mock('@onekeyhq/kit/src/states/jotai/contexts/swap', () => ({
+  useSwapToAnotherAccountAddressAtom: () => [
+    mockSwapToAddressState,
+    mockSetSwapToAddress,
+  ],
+}));
+
+describe('useSwapIncognitoRecipientInput', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    mockSettingsState = {
+      swapToAnotherAccountSwitchOn: false,
+    };
+    mockSwapToAddressState = {};
+
+    mockSetSettings.mockImplementation(
+      (updater: SetStateAction<ISettingsState>) => {
+        mockSettingsState = applyStateUpdater(mockSettingsState, updater);
+      },
+    );
+    mockSetSwapToAddress.mockImplementation(
+      (updater: SetStateAction<ISwapToAddressState>) => {
+        mockSwapToAddressState = applyStateUpdater(
+          mockSwapToAddressState,
+          updater,
+        );
+      },
+    );
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('ignores late validation results after the incognito input is hidden', async () => {
+    const pendingValidation = createDeferred<IAddressQueryResult>();
+    mockQueryAddressWithFallback.mockReturnValueOnce(pendingValidation.promise);
+
+    const { result, rerender } = renderHook(
+      (props: {
+        accountId?: string;
+        address?: string;
+        networkId?: string;
+        swapToAnotherAccountSwitchOn: boolean;
+        visible: boolean;
+      }) => useSwapIncognitoRecipientInput(props),
+      {
+        initialProps: {
+          visible: true,
+          networkId: 'evm--1',
+          accountId: 'account-1',
+          address: undefined,
+          swapToAnotherAccountSwitchOn: false,
+        },
+      },
+    );
+
+    act(() => {
+      result.current.onInputChange('0xrecipient');
+    });
+
+    await flushDebounce();
+
+    expect(mockQueryAddressWithFallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: 'account-1',
+        address: '0xrecipient',
+        networkId: 'evm--1',
+      }),
+    );
+
+    rerender({
+      visible: false,
+      networkId: 'evm--1',
+      accountId: 'account-1',
+      address: undefined,
+      swapToAnotherAccountSwitchOn: false,
+    });
+
+    await act(async () => {
+      pendingValidation.resolve({
+        input: '0xrecipient',
+        resolveAddress: '0xresolved-recipient',
+        validStatus: 'valid',
+      });
+      await pendingValidation.promise;
+    });
+
+    await flushAsync();
+
+    expect(mockSettingsState.swapToAnotherAccountSwitchOn).toBe(false);
+    expect(mockSwapToAddressState.address).toBeUndefined();
+    expect(result.current.inputText).toBe('');
+  });
+
+  it('revalidates the current input when the validation scope changes', async () => {
+    mockQueryAddressWithFallback
+      .mockResolvedValueOnce({
+        input: '0xrecipient',
+        resolveAddress: '0xresolved-1',
+        validStatus: 'valid',
+      })
+      .mockResolvedValueOnce({
+        input: '0xrecipient',
+        resolveAddress: '0xresolved-2',
+        validStatus: 'valid',
+      });
+
+    const { result, rerender } = renderHook(
+      (props: {
+        accountId?: string;
+        address?: string;
+        networkId?: string;
+        swapToAnotherAccountSwitchOn: boolean;
+        visible: boolean;
+      }) => useSwapIncognitoRecipientInput(props),
+      {
+        initialProps: {
+          visible: true,
+          networkId: 'evm--1',
+          accountId: 'account-1',
+          address: undefined,
+          swapToAnotherAccountSwitchOn: false,
+        },
+      },
+    );
+
+    act(() => {
+      result.current.onInputChange('0xrecipient');
+    });
+
+    await flushDebounce();
+
+    await waitFor(() => {
+      expect(mockSettingsState.swapToAnotherAccountSwitchOn).toBe(true);
+      expect(mockSwapToAddressState.address).toBe('0xresolved-1');
+    });
+
+    rerender({
+      visible: true,
+      networkId: 'evm--10',
+      accountId: 'account-2',
+      address: undefined,
+      swapToAnotherAccountSwitchOn: false,
+    });
+
+    expect(result.current.inputText).toBe('0xrecipient');
+    expect(mockSettingsState.swapToAnotherAccountSwitchOn).toBe(false);
+    expect(mockSwapToAddressState.address).toBeUndefined();
+
+    await flushDebounce();
+
+    await waitFor(() => {
+      expect(mockQueryAddressWithFallback).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          accountId: 'account-2',
+          address: '0xrecipient',
+          networkId: 'evm--10',
+        }),
+      );
+      expect(mockSettingsState.swapToAnotherAccountSwitchOn).toBe(true);
+      expect(mockSwapToAddressState.address).toBe('0xresolved-2');
+    });
+  });
+});

--- a/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.test.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.test.ts
@@ -19,6 +19,15 @@ type ISwapToAddressState = {
   networkId?: string;
 };
 
+type IHookProps = {
+  accountId?: string;
+  address?: string;
+  clearRecipientAddressOnHide?: boolean;
+  networkId?: string;
+  swapToAnotherAccountSwitchOn: boolean;
+  visible: boolean;
+};
+
 const mockQueryAddressWithFallback: jest.MockedFunction<
   (params: IQueryCheckAddressArgs) => Promise<IAddressQueryResult>
 > = jest.fn();
@@ -125,15 +134,11 @@ describe('useSwapIncognitoRecipientInput', () => {
     const pendingValidation = createDeferred<IAddressQueryResult>();
     mockQueryAddressWithFallback.mockReturnValueOnce(pendingValidation.promise);
 
-    const { result, rerender } = renderHook(
-      (props: {
-        accountId?: string;
-        address?: string;
-        clearRecipientAddressOnHide?: boolean;
-        networkId?: string;
-        swapToAnotherAccountSwitchOn: boolean;
-        visible: boolean;
-      }) => useSwapIncognitoRecipientInput(props),
+    const { result, rerender } = renderHook<
+      ReturnType<typeof useSwapIncognitoRecipientInput>,
+      IHookProps
+    >(
+      (props: IHookProps) => useSwapIncognitoRecipientInput(props),
       {
         initialProps: {
           visible: true,
@@ -198,15 +203,11 @@ describe('useSwapIncognitoRecipientInput', () => {
         validStatus: 'valid',
       });
 
-    const { result, rerender } = renderHook(
-      (props: {
-        accountId?: string;
-        address?: string;
-        clearRecipientAddressOnHide?: boolean;
-        networkId?: string;
-        swapToAnotherAccountSwitchOn: boolean;
-        visible: boolean;
-      }) => useSwapIncognitoRecipientInput(props),
+    const { result, rerender } = renderHook<
+      ReturnType<typeof useSwapIncognitoRecipientInput>,
+      IHookProps
+    >(
+      (props: IHookProps) => useSwapIncognitoRecipientInput(props),
       {
         initialProps: {
           visible: true,
@@ -266,15 +267,11 @@ describe('useSwapIncognitoRecipientInput', () => {
       validStatus: 'valid',
     });
 
-    const { result, rerender } = renderHook(
-      (props: {
-        accountId?: string;
-        address?: string;
-        clearRecipientAddressOnHide?: boolean;
-        networkId?: string;
-        swapToAnotherAccountSwitchOn: boolean;
-        visible: boolean;
-      }) => useSwapIncognitoRecipientInput(props),
+    const { result, rerender } = renderHook<
+      ReturnType<typeof useSwapIncognitoRecipientInput>,
+      IHookProps
+    >(
+      (props: IHookProps) => useSwapIncognitoRecipientInput(props),
       {
         initialProps: {
           visible: true,
@@ -321,15 +318,11 @@ describe('useSwapIncognitoRecipientInput', () => {
       validStatus: 'valid',
     });
 
-    const { result, rerender } = renderHook(
-      (props: {
-        accountId?: string;
-        address?: string;
-        clearRecipientAddressOnHide?: boolean;
-        networkId?: string;
-        swapToAnotherAccountSwitchOn: boolean;
-        visible: boolean;
-      }) => useSwapIncognitoRecipientInput(props),
+    const { result, rerender } = renderHook<
+      ReturnType<typeof useSwapIncognitoRecipientInput>,
+      IHookProps
+    >(
+      (props: IHookProps) => useSwapIncognitoRecipientInput(props),
       {
         initialProps: {
           visible: true,

--- a/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.test.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.test.ts
@@ -73,6 +73,12 @@ async function flushAsync() {
   });
 }
 
+function renderUseSwapIncognitoRecipientInput(initialProps: IHookProps) {
+  return renderHook(useSwapIncognitoRecipientInput, {
+    initialProps,
+  });
+}
+
 jest.mock('react-intl', () => ({
   useIntl: () => ({
     formatMessage: ({ id }: { id: string }) => id,
@@ -134,22 +140,14 @@ describe('useSwapIncognitoRecipientInput', () => {
     const pendingValidation = createDeferred<IAddressQueryResult>();
     mockQueryAddressWithFallback.mockReturnValueOnce(pendingValidation.promise);
 
-    const { result, rerender } = renderHook<
-      ReturnType<typeof useSwapIncognitoRecipientInput>,
-      IHookProps
-    >(
-      (props: IHookProps) => useSwapIncognitoRecipientInput(props),
-      {
-        initialProps: {
-          visible: true,
-          clearRecipientAddressOnHide: true,
-          networkId: 'evm--1',
-          accountId: 'account-1',
-          address: undefined,
-          swapToAnotherAccountSwitchOn: false,
-        },
-      },
-    );
+    const { result, rerender } = renderUseSwapIncognitoRecipientInput({
+      visible: true,
+      clearRecipientAddressOnHide: true,
+      networkId: 'evm--1',
+      accountId: 'account-1',
+      address: undefined,
+      swapToAnotherAccountSwitchOn: false,
+    });
 
     act(() => {
       result.current.onInputChange('0xrecipient');
@@ -203,22 +201,14 @@ describe('useSwapIncognitoRecipientInput', () => {
         validStatus: 'valid',
       });
 
-    const { result, rerender } = renderHook<
-      ReturnType<typeof useSwapIncognitoRecipientInput>,
-      IHookProps
-    >(
-      (props: IHookProps) => useSwapIncognitoRecipientInput(props),
-      {
-        initialProps: {
-          visible: true,
-          clearRecipientAddressOnHide: false,
-          networkId: 'evm--1',
-          accountId: 'account-1',
-          address: undefined,
-          swapToAnotherAccountSwitchOn: false,
-        },
-      },
-    );
+    const { result, rerender } = renderUseSwapIncognitoRecipientInput({
+      visible: true,
+      clearRecipientAddressOnHide: false,
+      networkId: 'evm--1',
+      accountId: 'account-1',
+      address: undefined,
+      swapToAnotherAccountSwitchOn: false,
+    });
 
     act(() => {
       result.current.onInputChange('0xrecipient');
@@ -267,22 +257,14 @@ describe('useSwapIncognitoRecipientInput', () => {
       validStatus: 'valid',
     });
 
-    const { result, rerender } = renderHook<
-      ReturnType<typeof useSwapIncognitoRecipientInput>,
-      IHookProps
-    >(
-      (props: IHookProps) => useSwapIncognitoRecipientInput(props),
-      {
-        initialProps: {
-          visible: true,
-          clearRecipientAddressOnHide: true,
-          networkId: 'evm--1',
-          accountId: 'account-1',
-          address: undefined,
-          swapToAnotherAccountSwitchOn: false,
-        },
-      },
-    );
+    const { result, rerender } = renderUseSwapIncognitoRecipientInput({
+      visible: true,
+      clearRecipientAddressOnHide: true,
+      networkId: 'evm--1',
+      accountId: 'account-1',
+      address: undefined,
+      swapToAnotherAccountSwitchOn: false,
+    });
 
     act(() => {
       result.current.onInputChange('0xrecipient');
@@ -318,22 +300,14 @@ describe('useSwapIncognitoRecipientInput', () => {
       validStatus: 'valid',
     });
 
-    const { result, rerender } = renderHook<
-      ReturnType<typeof useSwapIncognitoRecipientInput>,
-      IHookProps
-    >(
-      (props: IHookProps) => useSwapIncognitoRecipientInput(props),
-      {
-        initialProps: {
-          visible: true,
-          clearRecipientAddressOnHide: false,
-          networkId: 'evm--1',
-          accountId: 'account-1',
-          address: undefined,
-          swapToAnotherAccountSwitchOn: false,
-        },
-      },
-    );
+    const { result, rerender } = renderUseSwapIncognitoRecipientInput({
+      visible: true,
+      clearRecipientAddressOnHide: false,
+      networkId: 'evm--1',
+      accountId: 'account-1',
+      address: undefined,
+      swapToAnotherAccountSwitchOn: false,
+    });
 
     act(() => {
       result.current.onInputChange('0xrecipient');

--- a/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.test.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.test.ts
@@ -129,6 +129,7 @@ describe('useSwapIncognitoRecipientInput', () => {
       (props: {
         accountId?: string;
         address?: string;
+        clearRecipientAddressOnHide?: boolean;
         networkId?: string;
         swapToAnotherAccountSwitchOn: boolean;
         visible: boolean;
@@ -136,6 +137,7 @@ describe('useSwapIncognitoRecipientInput', () => {
       {
         initialProps: {
           visible: true,
+          clearRecipientAddressOnHide: true,
           networkId: 'evm--1',
           accountId: 'account-1',
           address: undefined,
@@ -160,6 +162,7 @@ describe('useSwapIncognitoRecipientInput', () => {
 
     rerender({
       visible: false,
+      clearRecipientAddressOnHide: true,
       networkId: 'evm--1',
       accountId: 'account-1',
       address: undefined,
@@ -199,6 +202,7 @@ describe('useSwapIncognitoRecipientInput', () => {
       (props: {
         accountId?: string;
         address?: string;
+        clearRecipientAddressOnHide?: boolean;
         networkId?: string;
         swapToAnotherAccountSwitchOn: boolean;
         visible: boolean;
@@ -206,6 +210,7 @@ describe('useSwapIncognitoRecipientInput', () => {
       {
         initialProps: {
           visible: true,
+          clearRecipientAddressOnHide: false,
           networkId: 'evm--1',
           accountId: 'account-1',
           address: undefined,
@@ -227,6 +232,7 @@ describe('useSwapIncognitoRecipientInput', () => {
 
     rerender({
       visible: true,
+      clearRecipientAddressOnHide: false,
       networkId: 'evm--10',
       accountId: 'account-2',
       address: undefined,
@@ -251,5 +257,115 @@ describe('useSwapIncognitoRecipientInput', () => {
       expect(mockSettingsState.swapToAnotherAccountSwitchOn).toBe(true);
       expect(mockSwapToAddressState.address).toBe('0xresolved-2');
     });
+  });
+
+  it('clears the confirmed recipient when the input is hidden without a fallback recipient UI', async () => {
+    mockQueryAddressWithFallback.mockResolvedValueOnce({
+      input: '0xrecipient',
+      resolveAddress: '0xresolved-recipient',
+      validStatus: 'valid',
+    });
+
+    const { result, rerender } = renderHook(
+      (props: {
+        accountId?: string;
+        address?: string;
+        clearRecipientAddressOnHide?: boolean;
+        networkId?: string;
+        swapToAnotherAccountSwitchOn: boolean;
+        visible: boolean;
+      }) => useSwapIncognitoRecipientInput(props),
+      {
+        initialProps: {
+          visible: true,
+          clearRecipientAddressOnHide: true,
+          networkId: 'evm--1',
+          accountId: 'account-1',
+          address: undefined,
+          swapToAnotherAccountSwitchOn: false,
+        },
+      },
+    );
+
+    act(() => {
+      result.current.onInputChange('0xrecipient');
+    });
+
+    await flushDebounce();
+
+    await waitFor(() => {
+      expect(mockSettingsState.swapToAnotherAccountSwitchOn).toBe(true);
+      expect(mockSwapToAddressState.address).toBe('0xresolved-recipient');
+    });
+
+    rerender({
+      visible: false,
+      clearRecipientAddressOnHide: true,
+      networkId: 'evm--1',
+      accountId: 'account-1',
+      address: mockSwapToAddressState.address,
+      swapToAnotherAccountSwitchOn: true,
+    });
+
+    await flushAsync();
+
+    expect(mockSettingsState.swapToAnotherAccountSwitchOn).toBe(false);
+    expect(mockSwapToAddressState.address).toBeUndefined();
+    expect(result.current.inputText).toBe('');
+  });
+
+  it('preserves the confirmed recipient when the input is hidden but another recipient UI remains available', async () => {
+    mockQueryAddressWithFallback.mockResolvedValueOnce({
+      input: '0xrecipient',
+      resolveAddress: '0xresolved-recipient',
+      validStatus: 'valid',
+    });
+
+    const { result, rerender } = renderHook(
+      (props: {
+        accountId?: string;
+        address?: string;
+        clearRecipientAddressOnHide?: boolean;
+        networkId?: string;
+        swapToAnotherAccountSwitchOn: boolean;
+        visible: boolean;
+      }) => useSwapIncognitoRecipientInput(props),
+      {
+        initialProps: {
+          visible: true,
+          clearRecipientAddressOnHide: false,
+          networkId: 'evm--1',
+          accountId: 'account-1',
+          address: undefined,
+          swapToAnotherAccountSwitchOn: false,
+        },
+      },
+    );
+
+    act(() => {
+      result.current.onInputChange('0xrecipient');
+    });
+
+    await flushDebounce();
+
+    await waitFor(() => {
+      expect(mockSettingsState.swapToAnotherAccountSwitchOn).toBe(true);
+      expect(mockSwapToAddressState.address).toBe('0xresolved-recipient');
+    });
+
+    rerender({
+      visible: false,
+      clearRecipientAddressOnHide: false,
+      networkId: 'evm--1',
+      accountId: 'account-1',
+      address: mockSwapToAddressState.address,
+      swapToAnotherAccountSwitchOn: true,
+    });
+
+    await flushAsync();
+
+    expect(mockSettingsState.swapToAnotherAccountSwitchOn).toBe(true);
+    expect(mockSwapToAddressState.address).toBe('0xresolved-recipient');
+    expect(result.current.inputText).toBe('');
   });
 });

--- a/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.test.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.test.ts
@@ -335,4 +335,42 @@ describe('useSwapIncognitoRecipientInput', () => {
     expect(mockSwapToAddressState.address).toBe('0xresolved-recipient');
     expect(result.current.inputText).toBe('');
   });
+
+  it('clears the input when the recipient is reset externally after the synced address is revalidated', async () => {
+    mockQueryAddressWithFallback.mockResolvedValueOnce({
+      input: '0xresolved-recipient',
+      resolveAddress: '0xresolved-recipient',
+      validStatus: 'valid',
+    });
+
+    const { result, rerender } = renderUseSwapIncognitoRecipientInput({
+      visible: true,
+      clearRecipientAddressOnHide: false,
+      networkId: 'evm--1',
+      accountId: 'account-1',
+      address: '0xresolved-recipient',
+      swapToAnotherAccountSwitchOn: true,
+    });
+
+    await flushDebounce();
+
+    await waitFor(() => {
+      expect(mockSettingsState.swapToAnotherAccountSwitchOn).toBe(true);
+      expect(mockSwapToAddressState.address).toBe('0xresolved-recipient');
+      expect(result.current.inputText).toBe('0xresolved-recipient');
+    });
+
+    rerender({
+      visible: true,
+      clearRecipientAddressOnHide: false,
+      networkId: 'evm--1',
+      accountId: 'account-1',
+      address: undefined,
+      swapToAnotherAccountSwitchOn: false,
+    });
+
+    await waitFor(() => {
+      expect(result.current.inputText).toBe('');
+    });
+  });
 });

--- a/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts
@@ -249,12 +249,14 @@ export function useSwapIncognitoRecipientInput({
       return;
     }
 
+    const nextText = swapToAnotherAccountSwitchOn && address ? address : '';
+
     if (skipExternalSyncRef.current) {
       skipExternalSyncRef.current = false;
-      return;
+      if (textRef.current === nextText) {
+        return;
+      }
     }
-
-    const nextText = swapToAnotherAccountSwitchOn && address ? address : '';
 
     if (textRef.current === nextText) {
       return;

--- a/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts
@@ -22,6 +22,23 @@ type IUseSwapIncognitoRecipientInputParams = {
   swapToAnotherAccountSwitchOn: boolean;
 };
 
+type IAddressValidationContext = {
+  accountId?: string;
+  networkId?: string;
+  queryText: string;
+};
+
+function isSameAddressValidationContext(
+  left: IAddressValidationContext,
+  right: IAddressValidationContext,
+) {
+  return (
+    left.accountId === right.accountId &&
+    left.networkId === right.networkId &&
+    left.queryText === right.queryText
+  );
+}
+
 export function useSwapIncognitoRecipientInput({
   visible,
   networkId,
@@ -37,8 +54,26 @@ export function useSwapIncognitoRecipientInput({
   const [loading, setLoading] = useState(false);
   const textRef = useRef('');
   const skipExternalSyncRef = useRef(false);
+  const validationContextRef = useRef<IAddressValidationContext>({
+    accountId,
+    networkId,
+    queryText: '',
+  });
+  const validationScopeRef = useRef<{
+    accountId?: string;
+    networkId?: string;
+  }>({
+    accountId,
+    networkId,
+  });
 
   const enabled = visible && !!networkId;
+
+  validationContextRef.current = {
+    accountId,
+    networkId,
+    queryText: inputText.trim(),
+  };
 
   const syncRecipientAddress = useCallback(
     (nextAddress?: string) => {
@@ -61,6 +96,30 @@ export function useSwapIncognitoRecipientInput({
     },
     [networkId, setSettings, setSwapToAddress],
   );
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const prevScope = validationScopeRef.current;
+    const nextScope = {
+      accountId,
+      networkId,
+    };
+
+    validationScopeRef.current = nextScope;
+
+    if (
+      prevScope.accountId === nextScope.accountId &&
+      prevScope.networkId === nextScope.networkId
+    ) {
+      return;
+    }
+
+    setQueryResult({});
+    syncRecipientAddress(undefined);
+  }, [accountId, enabled, networkId, syncRecipientAddress]);
 
   useEffect(() => {
     if (!enabled) {
@@ -96,6 +155,11 @@ export function useSwapIncognitoRecipientInput({
 
     setLoading(true);
     try {
+      const requestContext = {
+        accountId,
+        networkId,
+        queryText: currentText,
+      };
       const result = await queryAddressWithFallback({
         address: currentText,
         networkId,
@@ -107,9 +171,27 @@ export function useSwapIncognitoRecipientInput({
         enableAllowListValidation: true,
       });
 
-      if (result.input === textRef.current) {
-        setQueryResult(result);
+      if (
+        !isSameAddressValidationContext(
+          requestContext,
+          validationContextRef.current,
+        )
+      ) {
+        return;
       }
+
+      setQueryResult(result);
+
+      if (result.validStatus === 'valid') {
+        const resolvedAddress = getAddressQueryResolvedAddress(result);
+
+        if (resolvedAddress) {
+          syncRecipientAddress(resolvedAddress);
+        }
+        return;
+      }
+
+      syncRecipientAddress(undefined);
     } finally {
       setLoading(false);
     }
@@ -122,18 +204,6 @@ export function useSwapIncognitoRecipientInput({
 
     void queryAddress(inputText.trim());
   }, [enabled, inputText, queryAddress]);
-
-  useEffect(() => {
-    if (!enabled || queryResult.validStatus !== 'valid') {
-      return;
-    }
-
-    const resolvedAddress = getAddressQueryResolvedAddress(queryResult);
-
-    if (resolvedAddress) {
-      syncRecipientAddress(resolvedAddress);
-    }
-  }, [enabled, queryResult, syncRecipientAddress]);
 
   const handleInputChange = useCallback(
     (text: string) => {
@@ -153,6 +223,10 @@ export function useSwapIncognitoRecipientInput({
 
   const errorMessage = useMemo(() => {
     if (!inputText.trim() || loading || queryResult.validStatus === 'valid') {
+      return undefined;
+    }
+
+    if (!queryResult.validStatus) {
       return undefined;
     }
 

--- a/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useIntl } from 'react-intl';
+import { useDebouncedCallback } from 'use-debounce';
+
+import type { IAddressQueryResult } from '@onekeyhq/kit/src/components/AddressInput';
+import {
+  getAddressQueryResolvedAddress,
+  getAddressValidateTranslationId,
+  queryAddressWithFallback,
+} from '@onekeyhq/kit/src/components/AddressInput/utils';
+import { useSwapToAnotherAccountAddressAtom } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
+import { useSettingsAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import stringUtils from '@onekeyhq/shared/src/utils/stringUtils';
+
+type IUseSwapIncognitoRecipientInputParams = {
+  visible: boolean;
+  networkId?: string;
+  accountId?: string;
+  address?: string;
+  swapToAnotherAccountSwitchOn: boolean;
+};
+
+export function useSwapIncognitoRecipientInput({
+  visible,
+  networkId,
+  accountId,
+  address,
+  swapToAnotherAccountSwitchOn,
+}: IUseSwapIncognitoRecipientInputParams) {
+  const intl = useIntl();
+  const [, setSettings] = useSettingsAtom();
+  const [, setSwapToAddress] = useSwapToAnotherAccountAddressAtom();
+  const [inputText, setInputText] = useState('');
+  const [queryResult, setQueryResult] = useState<IAddressQueryResult>({});
+  const [loading, setLoading] = useState(false);
+  const textRef = useRef('');
+  const skipExternalSyncRef = useRef(false);
+
+  const enabled = visible && !!networkId;
+
+  const syncRecipientAddress = useCallback(
+    (nextAddress?: string) => {
+      skipExternalSyncRef.current = true;
+
+      setSettings((settings) => ({
+        ...settings,
+        swapToAnotherAccountSwitchOn: Boolean(nextAddress),
+      }));
+
+      setSwapToAddress((value) => ({
+        ...value,
+        networkId: nextAddress ? networkId : undefined,
+        address: nextAddress,
+        accountInfo:
+          nextAddress && value.address === nextAddress
+            ? value.accountInfo
+            : undefined,
+      }));
+    },
+    [networkId, setSettings, setSwapToAddress],
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    if (skipExternalSyncRef.current) {
+      skipExternalSyncRef.current = false;
+      return;
+    }
+
+    const nextText = swapToAnotherAccountSwitchOn && address ? address : '';
+
+    if (textRef.current === nextText) {
+      return;
+    }
+
+    textRef.current = nextText;
+    setInputText(nextText);
+    setQueryResult({});
+  }, [address, enabled, swapToAnotherAccountSwitchOn]);
+
+  const queryAddress = useDebouncedCallback(async (currentText: string) => {
+    if (!networkId) {
+      return;
+    }
+
+    if (!currentText) {
+      setLoading(false);
+      setQueryResult({});
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const result = await queryAddressWithFallback({
+        address: currentText,
+        networkId,
+        accountId,
+        enableAddressBook: true,
+        enableWalletName: true,
+        enableAddressInteractionStatus: true,
+        enableAddressContract: true,
+        enableAllowListValidation: true,
+      });
+
+      if (result.input === textRef.current) {
+        setQueryResult(result);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, 300);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    void queryAddress(inputText.trim());
+  }, [enabled, inputText, queryAddress]);
+
+  useEffect(() => {
+    if (!enabled || queryResult.validStatus !== 'valid') {
+      return;
+    }
+
+    const resolvedAddress = getAddressQueryResolvedAddress(queryResult);
+
+    if (resolvedAddress) {
+      syncRecipientAddress(resolvedAddress);
+    }
+  }, [enabled, queryResult, syncRecipientAddress]);
+
+  const handleInputChange = useCallback(
+    (text: string) => {
+      const nextText = stringUtils.stripLineBreaks(text);
+
+      if (textRef.current === nextText) {
+        return;
+      }
+
+      textRef.current = nextText;
+      setInputText(nextText);
+      setQueryResult({});
+      syncRecipientAddress(undefined);
+    },
+    [syncRecipientAddress],
+  );
+
+  const errorMessage = useMemo(() => {
+    if (!inputText.trim() || loading || queryResult.validStatus === 'valid') {
+      return undefined;
+    }
+
+    const translationId =
+      getAddressValidateTranslationId(queryResult.validStatus) ??
+      ETranslations.send_address_invalid;
+
+    return intl.formatMessage({
+      id: translationId,
+    });
+  }, [inputText, intl, loading, queryResult.validStatus]);
+
+  return {
+    enabled,
+    errorMessage,
+    inputText,
+    loading,
+    onInputChange: handleInputChange,
+    queryResult,
+  };
+}

--- a/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts
@@ -16,6 +16,7 @@ import stringUtils from '@onekeyhq/shared/src/utils/stringUtils';
 
 type IUseSwapIncognitoRecipientInputParams = {
   visible: boolean;
+  clearRecipientAddressOnHide?: boolean;
   networkId?: string;
   accountId?: string;
   address?: string;
@@ -45,6 +46,7 @@ function isSameAddressValidationContext(
 
 export function useSwapIncognitoRecipientInput({
   visible,
+  clearRecipientAddressOnHide,
   networkId,
   accountId,
   address,
@@ -211,6 +213,7 @@ export function useSwapIncognitoRecipientInput({
       };
       resetValidationState({
         clearInput: true,
+        clearRecipientAddress: clearRecipientAddressOnHide,
       });
       return;
     }
@@ -233,7 +236,13 @@ export function useSwapIncognitoRecipientInput({
     resetValidationState({
       clearRecipientAddress: true,
     });
-  }, [accountId, enabled, networkId, resetValidationState]);
+  }, [
+    accountId,
+    clearRecipientAddressOnHide,
+    enabled,
+    networkId,
+    resetValidationState,
+  ]);
 
   useEffect(() => {
     if (!enabled) {

--- a/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts
@@ -24,8 +24,10 @@ type IUseSwapIncognitoRecipientInputParams = {
 
 type IAddressValidationContext = {
   accountId?: string;
+  enabled: boolean;
   networkId?: string;
   queryText: string;
+  validationSessionId: number;
 };
 
 function isSameAddressValidationContext(
@@ -34,8 +36,10 @@ function isSameAddressValidationContext(
 ) {
   return (
     left.accountId === right.accountId &&
+    left.enabled === right.enabled &&
     left.networkId === right.networkId &&
-    left.queryText === right.queryText
+    left.queryText === right.queryText &&
+    left.validationSessionId === right.validationSessionId
   );
 }
 
@@ -54,10 +58,13 @@ export function useSwapIncognitoRecipientInput({
   const [loading, setLoading] = useState(false);
   const textRef = useRef('');
   const skipExternalSyncRef = useRef(false);
+  const validationSessionIdRef = useRef(0);
   const validationContextRef = useRef<IAddressValidationContext>({
     accountId,
+    enabled: false,
     networkId,
     queryText: '',
+    validationSessionId: validationSessionIdRef.current,
   });
   const validationScopeRef = useRef<{
     accountId?: string;
@@ -71,8 +78,10 @@ export function useSwapIncognitoRecipientInput({
 
   validationContextRef.current = {
     accountId,
+    enabled,
     networkId,
     queryText: inputText.trim(),
+    validationSessionId: validationSessionIdRef.current,
   };
 
   const syncRecipientAddress = useCallback(
@@ -97,73 +106,38 @@ export function useSwapIncognitoRecipientInput({
     [networkId, setSettings, setSwapToAddress],
   );
 
-  useEffect(() => {
-    if (!enabled) {
-      return;
-    }
-
-    const prevScope = validationScopeRef.current;
-    const nextScope = {
+  const queryAddress = useDebouncedCallback(async (currentText: string) => {
+    const requestContext = {
       accountId,
+      enabled,
       networkId,
+      queryText: currentText,
+      validationSessionId: validationSessionIdRef.current,
     };
 
-    validationScopeRef.current = nextScope;
-
-    if (
-      prevScope.accountId === nextScope.accountId &&
-      prevScope.networkId === nextScope.networkId
-    ) {
-      return;
-    }
-
-    setQueryResult({});
-    syncRecipientAddress(undefined);
-  }, [accountId, enabled, networkId, syncRecipientAddress]);
-
-  useEffect(() => {
-    if (!enabled) {
-      return;
-    }
-
-    if (skipExternalSyncRef.current) {
-      skipExternalSyncRef.current = false;
-      return;
-    }
-
-    const nextText = swapToAnotherAccountSwitchOn && address ? address : '';
-
-    if (textRef.current === nextText) {
-      return;
-    }
-
-    textRef.current = nextText;
-    setInputText(nextText);
-    setQueryResult({});
-  }, [address, enabled, swapToAnotherAccountSwitchOn]);
-
-  const queryAddress = useDebouncedCallback(async (currentText: string) => {
-    if (!networkId) {
+    if (!requestContext.enabled || !requestContext.networkId) {
       return;
     }
 
     if (!currentText) {
-      setLoading(false);
-      setQueryResult({});
+      if (
+        isSameAddressValidationContext(
+          requestContext,
+          validationContextRef.current,
+        )
+      ) {
+        setLoading(false);
+        setQueryResult({});
+      }
       return;
     }
 
     setLoading(true);
     try {
-      const requestContext = {
-        accountId,
-        networkId,
-        queryText: currentText,
-      };
       const result = await queryAddressWithFallback({
         address: currentText,
-        networkId,
-        accountId,
+        networkId: requestContext.networkId,
+        accountId: requestContext.accountId,
         enableAddressBook: true,
         enableWalletName: true,
         enableAddressInteractionStatus: true,
@@ -193,9 +167,94 @@ export function useSwapIncognitoRecipientInput({
 
       syncRecipientAddress(undefined);
     } finally {
-      setLoading(false);
+      if (
+        isSameAddressValidationContext(
+          requestContext,
+          validationContextRef.current,
+        )
+      ) {
+        setLoading(false);
+      }
     }
   }, 300);
+
+  const resetValidationState = useCallback(
+    ({
+      clearInput = false,
+      clearRecipientAddress = false,
+    }: {
+      clearInput?: boolean;
+      clearRecipientAddress?: boolean;
+    } = {}) => {
+      validationSessionIdRef.current += 1;
+      queryAddress.cancel();
+      setLoading(false);
+      setQueryResult({});
+
+      if (clearInput) {
+        textRef.current = '';
+        setInputText('');
+      }
+
+      if (clearRecipientAddress) {
+        syncRecipientAddress(undefined);
+      }
+    },
+    [queryAddress, syncRecipientAddress],
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      validationScopeRef.current = {
+        accountId,
+        networkId,
+      };
+      resetValidationState({
+        clearInput: true,
+      });
+      return;
+    }
+
+    const prevScope = validationScopeRef.current;
+    const nextScope = {
+      accountId,
+      networkId,
+    };
+
+    validationScopeRef.current = nextScope;
+
+    if (
+      prevScope.accountId === nextScope.accountId &&
+      prevScope.networkId === nextScope.networkId
+    ) {
+      return;
+    }
+
+    resetValidationState({
+      clearRecipientAddress: true,
+    });
+  }, [accountId, enabled, networkId, resetValidationState]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    if (skipExternalSyncRef.current) {
+      skipExternalSyncRef.current = false;
+      return;
+    }
+
+    const nextText = swapToAnotherAccountSwitchOn && address ? address : '';
+
+    if (textRef.current === nextText) {
+      return;
+    }
+
+    textRef.current = nextText;
+    setInputText(nextText);
+    setQueryResult({});
+  }, [address, enabled, swapToAnotherAccountSwitchOn]);
 
   useEffect(() => {
     if (!enabled) {
@@ -203,7 +262,9 @@ export function useSwapIncognitoRecipientInput({
     }
 
     void queryAddress(inputText.trim());
-  }, [enabled, inputText, queryAddress]);
+  }, [accountId, enabled, inputText, networkId, queryAddress]);
+
+  useEffect(() => () => queryAddress.cancel(), [queryAddress]);
 
   const handleInputChange = useCallback(
     (text: string) => {

--- a/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts
@@ -23,6 +23,13 @@ type IUseSwapIncognitoRecipientInputParams = {
   swapToAnotherAccountSwitchOn: boolean;
 };
 
+type IShouldBlockSwapActionForIncognitoRecipientInputParams = {
+  enabled: boolean;
+  inputText: string;
+  loading: boolean;
+  queryResult: Pick<IAddressQueryResult, 'validStatus'>;
+};
+
 type IAddressValidationContext = {
   accountId?: string;
   enabled: boolean;
@@ -42,6 +49,23 @@ function isSameAddressValidationContext(
     left.queryText === right.queryText &&
     left.validationSessionId === right.validationSessionId
   );
+}
+
+export function shouldBlockSwapActionForIncognitoRecipientInput({
+  enabled,
+  inputText,
+  loading,
+  queryResult,
+}: IShouldBlockSwapActionForIncognitoRecipientInputParams) {
+  if (!enabled || !inputText.trim()) {
+    return false;
+  }
+
+  if (loading) {
+    return true;
+  }
+
+  return queryResult.validStatus !== 'valid';
 }
 
 export function useSwapIncognitoRecipientInput({

--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -842,6 +842,19 @@ const SwapActionsState = ({
     recipientMetaRowComponent,
   ]);
 
+  const desktopModalRecipientSection = useMemo(() => {
+    if (!incognitoComponent && !incognitoRecipientInputComponent) {
+      return null;
+    }
+
+    return (
+      <Stack gap="$4">
+        {incognitoComponent}
+        {incognitoRecipientInputComponent}
+      </Stack>
+    );
+  }, [incognitoComponent, incognitoRecipientInputComponent]);
+
   const desktopFooterComponent = useMemo(
     () => (
       <Page.Footer>
@@ -867,7 +880,6 @@ const SwapActionsState = ({
               alignItems="center"
               overflow="hidden"
             >
-              {incognitoComponent}
               {recipientFooterComponent}
             </XStack>
             <Stack
@@ -901,7 +913,6 @@ const SwapActionsState = ({
       costSavingsComponent,
       desktopActionWidth,
       desktopActionWidthProps,
-      incognitoComponent,
       onActionHandlerBefore,
       onDesktopActionTagLayout,
       onSelectPercentageStage,
@@ -931,7 +942,7 @@ const SwapActionsState = ({
     <>
       {isDesktopModalPage ? (
         <>
-          {incognitoRecipientInputComponent}
+          {desktopModalRecipientSection}
           {desktopFooterComponent}
         </>
       ) : (

--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -253,10 +253,16 @@ const SwapActionsState = ({
     ],
   );
 
+  const clearRecipientAddressOnHide = useMemo(
+    () => swapIncognitoMode && !shouldShowRecipient,
+    [shouldShowRecipient, swapIncognitoMode],
+  );
+
   const incognitoRecipientInputComponent = useMemo(
     () => (
       <SwapIncognitoRecipientInput
         visible={shouldShowIncognitoRecipientInput}
+        clearRecipientAddressOnHide={clearRecipientAddressOnHide}
         networkId={toToken?.networkId ?? swapToAddressInfo.networkId}
         accountId={
           swapToAddressInfo.activeAccount?.account?.id ??
@@ -268,6 +274,7 @@ const SwapActionsState = ({
       />
     ),
     [
+      clearRecipientAddressOnHide,
       onOpenRecipientAddress,
       shouldShowIncognitoRecipientInput,
       swapToAnotherAccountAddress.address,

--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -63,6 +63,10 @@ import {
   useSwapRecipientAddressInfo,
 } from '../../hooks/useSwapAccount';
 import {
+  shouldBlockSwapActionForIncognitoRecipientInput,
+  useSwapIncognitoRecipientInput,
+} from '../../hooks/useSwapIncognitoRecipientInput';
+import {
   useSwapActionState,
   useSwapQuoteEventFetching,
   useSwapQuoteLoading,
@@ -173,50 +177,6 @@ const SwapActionsState = ({
     [incognitoTooltipContent],
   );
 
-  const onActionHandlerBefore = useCallback(async () => {
-    if (swapActionState.noConnectWallet) {
-      if (platformEnv.isWebDappMode) {
-        navigation.pushModal(EModalRoutes.OnboardingModal, {
-          screen: EOnboardingPages.ConnectWalletOptions,
-        });
-      } else {
-        resetToRoute(ERootRoutes.Onboarding, {
-          screen: EOnboardingV2Routes.OnboardingV2,
-          params: {
-            screen: EOnboardingPagesV2.GetStarted,
-          },
-        });
-      }
-      return;
-    }
-    if (swapActionState.isRefreshQuote) {
-      void quoteAction(
-        swapSlippageRef.current,
-        swapFromAddressInfo?.address,
-        swapFromAddressInfo?.accountInfo?.account?.id,
-        undefined,
-        undefined,
-        currentQuoteRes?.kind ?? ESwapQuoteKind.SELL,
-        true,
-        swapToAddressInfo?.address,
-        swapIncognitoMode,
-      );
-      return;
-    }
-    onPreSwap();
-  }, [
-    currentQuoteRes?.kind,
-    navigation,
-    onPreSwap,
-    quoteAction,
-    swapActionState.isRefreshQuote,
-    swapActionState.noConnectWallet,
-    swapIncognitoMode,
-    swapFromAddressInfo?.accountInfo?.account?.id,
-    swapFromAddressInfo?.address,
-    swapToAddressInfo?.address,
-  ]);
-
   const shouldShowRecipient = useMemo(
     () =>
       !!(
@@ -258,31 +218,99 @@ const SwapActionsState = ({
     [shouldShowRecipient, swapIncognitoMode],
   );
 
+  const incognitoRecipientInput = useSwapIncognitoRecipientInput({
+    visible: shouldShowIncognitoRecipientInput,
+    clearRecipientAddressOnHide,
+    networkId: toToken?.networkId ?? swapToAddressInfo.networkId,
+    accountId:
+      swapToAddressInfo.activeAccount?.account?.id ??
+      swapToAddressInfo.accountInfo?.account?.id,
+    address: swapToAnotherAccountAddress.address,
+    swapToAnotherAccountSwitchOn,
+  });
+
+  const shouldBlockIncognitoRecipientAction =
+    shouldBlockSwapActionForIncognitoRecipientInput({
+      enabled: incognitoRecipientInput.enabled,
+      inputText: incognitoRecipientInput.inputText,
+      loading: incognitoRecipientInput.loading,
+      queryResult: incognitoRecipientInput.queryResult,
+    });
+
+  const isActionDisabled =
+    swapActionState.disabled ||
+    swapActionState.isLoading ||
+    shouldBlockIncognitoRecipientAction;
+
+  const onActionHandlerBefore = useCallback(async () => {
+    if (shouldBlockIncognitoRecipientAction) {
+      return;
+    }
+
+    if (swapActionState.noConnectWallet) {
+      if (platformEnv.isWebDappMode) {
+        navigation.pushModal(EModalRoutes.OnboardingModal, {
+          screen: EOnboardingPages.ConnectWalletOptions,
+        });
+      } else {
+        resetToRoute(ERootRoutes.Onboarding, {
+          screen: EOnboardingV2Routes.OnboardingV2,
+          params: {
+            screen: EOnboardingPagesV2.GetStarted,
+          },
+        });
+      }
+      return;
+    }
+    if (swapActionState.isRefreshQuote) {
+      void quoteAction(
+        swapSlippageRef.current,
+        swapFromAddressInfo?.address,
+        swapFromAddressInfo?.accountInfo?.account?.id,
+        undefined,
+        undefined,
+        currentQuoteRes?.kind ?? ESwapQuoteKind.SELL,
+        true,
+        swapToAddressInfo?.address,
+        swapIncognitoMode,
+      );
+      return;
+    }
+    onPreSwap();
+  }, [
+    currentQuoteRes?.kind,
+    navigation,
+    onPreSwap,
+    quoteAction,
+    shouldBlockIncognitoRecipientAction,
+    swapActionState.isRefreshQuote,
+    swapActionState.noConnectWallet,
+    swapIncognitoMode,
+    swapFromAddressInfo?.accountInfo?.account?.id,
+    swapFromAddressInfo?.address,
+    swapToAddressInfo?.address,
+  ]);
+
   const incognitoRecipientInputComponent = useMemo(
     () => (
       <SwapIncognitoRecipientInput
         visible={shouldShowIncognitoRecipientInput}
-        clearRecipientAddressOnHide={clearRecipientAddressOnHide}
-        networkId={toToken?.networkId ?? swapToAddressInfo.networkId}
-        accountId={
-          swapToAddressInfo.activeAccount?.account?.id ??
-          swapToAddressInfo.accountInfo?.account?.id
-        }
-        address={swapToAnotherAccountAddress.address}
-        swapToAnotherAccountSwitchOn={swapToAnotherAccountSwitchOn}
+        errorMessage={incognitoRecipientInput.errorMessage}
+        inputText={incognitoRecipientInput.inputText}
+        loading={incognitoRecipientInput.loading}
         onOpenRecipientAddress={onOpenRecipientAddress}
+        onInputChange={incognitoRecipientInput.onInputChange}
+        queryResult={incognitoRecipientInput.queryResult}
       />
     ),
     [
-      clearRecipientAddressOnHide,
+      incognitoRecipientInput.errorMessage,
+      incognitoRecipientInput.inputText,
+      incognitoRecipientInput.loading,
+      incognitoRecipientInput.onInputChange,
+      incognitoRecipientInput.queryResult,
       onOpenRecipientAddress,
       shouldShowIncognitoRecipientInput,
-      swapToAnotherAccountAddress.address,
-      swapToAnotherAccountSwitchOn,
-      swapToAddressInfo.accountInfo?.account?.id,
-      swapToAddressInfo.activeAccount?.account?.id,
-      swapToAddressInfo.networkId,
-      toToken?.networkId,
     ],
   );
 
@@ -780,7 +808,7 @@ const SwapActionsState = ({
             onPress={onActionHandlerBefore}
             size={isDesktopModalPage ? 'medium' : 'large'}
             variant="primary"
-            disabled={swapActionState.disabled || swapActionState.isLoading}
+            disabled={isActionDisabled}
             borderRadius="$full"
           >
             {actionButtonChildren}
@@ -793,11 +821,10 @@ const SwapActionsState = ({
     [
       onActionHandlerBefore,
       actionButtonChildren,
+      isActionDisabled,
       isDesktopModalPage,
       recipientComponent,
       shouldShowRecipientInActionRow,
-      swapActionState.disabled,
-      swapActionState.isLoading,
       costSavingsComponent,
     ],
   );
@@ -899,7 +926,7 @@ const SwapActionsState = ({
                 onPress={onActionHandlerBefore}
                 size="medium"
                 variant="primary"
-                disabled={swapActionState.disabled || swapActionState.isLoading}
+                disabled={isActionDisabled}
                 borderRadius="$full"
                 {...(desktopActionWidth ? { width: '100%' } : {})}
               >
@@ -920,12 +947,11 @@ const SwapActionsState = ({
       costSavingsComponent,
       desktopActionWidth,
       desktopActionWidthProps,
+      isActionDisabled,
       onActionHandlerBefore,
       onDesktopActionTagLayout,
       onSelectPercentageStage,
       recipientFooterComponent,
-      swapActionState.disabled,
-      swapActionState.isLoading,
     ],
   );
 

--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -70,6 +70,7 @@ import {
 } from '../../hooks/useSwapState';
 import { buildSwapIncognitoSettingsUpdate } from '../../utils/incognitoSettings';
 
+import { SwapIncognitoRecipientInput } from './SwapIncognitoRecipientInput';
 import { PercentageStageOnKeyboard } from './SwapInputContainer';
 
 interface ISwapActionsStateProps {
@@ -138,7 +139,7 @@ const SwapActionsState = ({
   const incognitoTooltipDescription = useMemo(
     () =>
       `${intl.formatMessage({
-        id: ETranslations.trade_incognito_description,
+        id: ETranslations.trade_incognito_tooltips_new,
       })} <url>${incognitoHelpLink}<underline>${intl.formatMessage({
         id: ETranslations.trade_incognito_read_more,
       })}</underline></url>`,
@@ -219,16 +220,62 @@ const SwapActionsState = ({
   const shouldShowRecipient = useMemo(
     () =>
       !!(
+        !swapIncognitoMode &&
         swapEnableRecipientAddress &&
         swapProviderSupportReceiveAddress &&
         fromToken &&
         toToken
       ),
     [
+      swapIncognitoMode,
       swapEnableRecipientAddress,
       swapProviderSupportReceiveAddress,
       fromToken,
       toToken,
+    ],
+  );
+
+  const shouldShowIncognitoRecipientInput = useMemo(
+    () =>
+      !!(
+        swapIncognitoMode &&
+        swapProviderSupportReceiveAddress &&
+        fromToken &&
+        toToken &&
+        swapTypeSwitch !== ESwapTabSwitchType.LIMIT
+      ),
+    [
+      fromToken,
+      swapIncognitoMode,
+      swapProviderSupportReceiveAddress,
+      swapTypeSwitch,
+      toToken,
+    ],
+  );
+
+  const incognitoRecipientInputComponent = useMemo(
+    () => (
+      <SwapIncognitoRecipientInput
+        visible={shouldShowIncognitoRecipientInput}
+        networkId={toToken?.networkId ?? swapToAddressInfo.networkId}
+        accountId={
+          swapToAddressInfo.activeAccount?.account?.id ??
+          swapToAddressInfo.accountInfo?.account?.id
+        }
+        address={swapToAnotherAccountAddress.address}
+        swapToAnotherAccountSwitchOn={swapToAnotherAccountSwitchOn}
+        onOpenRecipientAddress={onOpenRecipientAddress}
+      />
+    ),
+    [
+      onOpenRecipientAddress,
+      shouldShowIncognitoRecipientInput,
+      swapToAnotherAccountAddress.address,
+      swapToAnotherAccountSwitchOn,
+      swapToAddressInfo.accountInfo?.account?.id,
+      swapToAddressInfo.activeAccount?.account?.id,
+      swapToAddressInfo.networkId,
+      toToken?.networkId,
     ],
   );
 
@@ -782,11 +829,13 @@ const SwapActionsState = ({
           : {})}
       >
         {metaRow}
+        {incognitoRecipientInputComponent}
         {actionRowComponent}
       </Stack>
     );
   }, [
     actionRowComponent,
+    incognitoRecipientInputComponent,
     incognitoComponent,
     showRecipientInMetaRow,
     isDesktopModalPage,
@@ -880,7 +929,14 @@ const SwapActionsState = ({
 
   return (
     <>
-      {isDesktopModalPage ? desktopFooterComponent : actionComponentCoverFooter}
+      {isDesktopModalPage ? (
+        <>
+          {incognitoRecipientInputComponent}
+          {desktopFooterComponent}
+        </>
+      ) : (
+        actionComponentCoverFooter
+      )}
     </>
   );
 };

--- a/packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import BigNumber from 'bignumber.js';
 import { debounce } from 'lodash';
 import { useIntl } from 'react-intl';
+import { useWindowDimensions } from 'react-native';
 
 import type { ColorTokens, IPageNavigationProp } from '@onekeyhq/components';
 import {
@@ -13,12 +14,15 @@ import {
   EPageType,
   HeightTransition,
   Icon,
+  ScrollView,
   SegmentControl,
   SizableText,
   Stack,
   Switch,
   XStack,
   YStack,
+  useKeyboardHeight,
+  useSafeAreaInsets,
 } from '@onekeyhq/components';
 import {
   HeaderButtonGroup,
@@ -131,6 +135,10 @@ const SwapSettingsSlippageItem = ({
     <XStack gap="$2">{rightTrigger}</XStack>
   </XStack>
 );
+
+const SWAP_SETTINGS_DIALOG_TOP_SAFE_GAP = 16;
+const SWAP_SETTINGS_DIALOG_CHROME_HEIGHT = 220;
+const SWAP_SETTINGS_DIALOG_MIN_CONTENT_HEIGHT = 120;
 
 const SwapSlippageCustomContent = ({
   swapSlippage,
@@ -260,9 +268,26 @@ const SwapSettingsDialogContent = () => {
   const [{ swapBatchApproveAndSwap }, setPersistSettings] =
     useSettingsPersistAtom();
   const [swapTypeSwitch] = useSwapTypeSwitchAtom();
+  const keyboardHeight = useKeyboardHeight();
+  const { top: safeAreaTop } = useSafeAreaInsets();
+  const { height: windowHeight } = useWindowDimensions();
   const focusSwapPro = useMemo(() => {
     return platformEnv.isNative && swapTypeSwitch === ESwapTabSwitchType.LIMIT;
   }, [swapTypeSwitch]);
+  const dialogContentMaxHeight = useMemo(() => {
+    if (!platformEnv.isNative || keyboardHeight <= 0) {
+      return undefined;
+    }
+
+    const availableHeight =
+      windowHeight -
+      keyboardHeight -
+      safeAreaTop -
+      SWAP_SETTINGS_DIALOG_TOP_SAFE_GAP -
+      SWAP_SETTINGS_DIALOG_CHROME_HEIGHT;
+
+    return Math.max(availableHeight, SWAP_SETTINGS_DIALOG_MIN_CONTENT_HEIGHT);
+  }, [keyboardHeight, safeAreaTop, windowHeight]);
   const rightTrigger = useMemo(
     () => (
       <SegmentControl
@@ -309,108 +334,117 @@ const SwapSettingsDialogContent = () => {
   );
   const dialogRef = useRef<ReturnType<typeof Dialog.show> | null>(null);
   return (
-    <YStack gap="$5">
-      {swapTypeSwitch !== ESwapTabSwitchType.LIMIT || focusSwapPro ? (
-        <>
-          <HeightTransition>
-            <YStack gap="$5">
-              <SwapSettingsSlippageItem
-                title={intl.formatMessage({
-                  id: ETranslations.swap_page_provider_slippage_tolerance,
-                })}
-                rightTrigger={rightTrigger}
-              />
-              {slippageItem.key === ESwapSlippageSegmentKey.CUSTOM ? (
-                <SwapSlippageCustomContent swapSlippage={slippageItem} />
-              ) : null}
-            </YStack>
-          </HeightTransition>
-          <Divider />
+    <ScrollView
+      mx="$-5"
+      px="$5"
+      pb="$5"
+      maxHeight={dialogContentMaxHeight}
+      keyboardShouldPersistTaps="handled"
+      showsVerticalScrollIndicator={false}
+    >
+      <YStack gap="$5">
+        {swapTypeSwitch !== ESwapTabSwitchType.LIMIT || focusSwapPro ? (
+          <>
+            <HeightTransition>
+              <YStack gap="$5">
+                <SwapSettingsSlippageItem
+                  title={intl.formatMessage({
+                    id: ETranslations.swap_page_provider_slippage_tolerance,
+                  })}
+                  rightTrigger={rightTrigger}
+                />
+                {slippageItem.key === ESwapSlippageSegmentKey.CUSTOM ? (
+                  <SwapSlippageCustomContent swapSlippage={slippageItem} />
+                ) : null}
+              </YStack>
+            </HeightTransition>
+            <Divider />
+            <SwapSettingsCommonItem
+              title={intl.formatMessage({
+                id: ETranslations.swap_page_settings_simple_mode,
+              })}
+              content={intl.formatMessage({
+                id: ETranslations.swap_page_settings_simple_mode_content,
+              })}
+              badgeContent="Beta"
+              value={swapBatchApproveAndSwap}
+              onChange={(v) => {
+                setPersistSettings((s) => ({
+                  ...s,
+                  swapBatchApproveAndSwap: v,
+                }));
+              }}
+            />
+          </>
+        ) : null}
+        {focusSwapPro ? null : (
           <SwapSettingsCommonItem
             title={intl.formatMessage({
-              id: ETranslations.swap_page_settings_simple_mode,
+              id: ETranslations.swap_page_settings_recipient_title,
             })}
             content={intl.formatMessage({
-              id: ETranslations.swap_page_settings_simple_mode_content,
+              id: ETranslations.swap_page_settings_recipient_content,
             })}
-            badgeContent="Beta"
-            value={swapBatchApproveAndSwap}
+            value={swapEnableRecipientAddress}
             onChange={(v) => {
-              setPersistSettings((s) => ({
-                ...s,
-                swapBatchApproveAndSwap: v,
-              }));
+              setNoPersistSettings((s) =>
+                buildSwapRecipientAddressSettingsUpdate(s, v),
+              );
             }}
           />
-        </>
-      ) : null}
-      {focusSwapPro ? null : (
-        <SwapSettingsCommonItem
-          title={intl.formatMessage({
-            id: ETranslations.swap_page_settings_recipient_title,
-          })}
-          content={intl.formatMessage({
-            id: ETranslations.swap_page_settings_recipient_content,
-          })}
-          value={swapEnableRecipientAddress}
-          onChange={(v) => {
-            setNoPersistSettings((s) =>
-              buildSwapRecipientAddressSettingsUpdate(s, v),
-            );
-          }}
-        />
-      )}
-      {swapTypeSwitch !== ESwapTabSwitchType.LIMIT ? (
-        <>
-          <SwapProviderSettingItem
-            title={intl.formatMessage({
-              id: ETranslations.swap_settings_manage_swap,
-            })}
-            onPress={() => {
-              dialogRef.current = Dialog.show({
-                title: intl.formatMessage({
-                  id: ETranslations.swap_settings_manage_swap,
-                }),
-                disableDrag: true,
-                renderContent: (
-                  <ProviderManageContainer
-                    onSaved={() => {
-                      void dialogRef.current?.close();
-                    }}
-                    isBridge={false}
-                  />
-                ),
-                showConfirmButton: false,
-                showCancelButton: false,
-              });
-            }}
-          />
-          <SwapProviderSettingItem
-            title={intl.formatMessage({
-              id: ETranslations.swap_settings_manage_bridge,
-            })}
-            onPress={() => {
-              dialogRef.current = Dialog.show({
-                title: intl.formatMessage({
-                  id: ETranslations.swap_settings_manage_bridge,
-                }),
-                disableDrag: true,
-                renderContent: (
-                  <ProviderManageContainer
-                    onSaved={() => {
-                      void dialogRef.current?.close();
-                    }}
-                    isBridge
-                  />
-                ),
-                showConfirmButton: false,
-                showCancelButton: false,
-              });
-            }}
-          />
-        </>
-      ) : null}
-    </YStack>
+        )}
+        {swapTypeSwitch !== ESwapTabSwitchType.LIMIT ? (
+          <>
+            <SwapProviderSettingItem
+              title={intl.formatMessage({
+                id: ETranslations.swap_settings_manage_swap,
+              })}
+              onPress={() => {
+                dialogRef.current = Dialog.show({
+                  title: intl.formatMessage({
+                    id: ETranslations.swap_settings_manage_swap,
+                  }),
+                  disableDrag: true,
+                  renderContent: (
+                    <ProviderManageContainer
+                      onSaved={() => {
+                        void dialogRef.current?.close();
+                      }}
+                      isBridge={false}
+                    />
+                  ),
+                  showConfirmButton: false,
+                  showCancelButton: false,
+                });
+              }}
+            />
+            <SwapProviderSettingItem
+              title={intl.formatMessage({
+                id: ETranslations.swap_settings_manage_bridge,
+              })}
+              onPress={() => {
+                dialogRef.current = Dialog.show({
+                  title: intl.formatMessage({
+                    id: ETranslations.swap_settings_manage_bridge,
+                  }),
+                  disableDrag: true,
+                  renderContent: (
+                    <ProviderManageContainer
+                      onSaved={() => {
+                        void dialogRef.current?.close();
+                      }}
+                      isBridge
+                    />
+                  ),
+                  showConfirmButton: false,
+                  showCancelButton: false,
+                });
+              }}
+            />
+          </>
+        ) : null}
+      </YStack>
+    </ScrollView>
   );
 };
 

--- a/packages/kit/src/views/Swap/pages/components/SwapIncognitoRecipientInput.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapIncognitoRecipientInput.tsx
@@ -1,0 +1,197 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import {
+  Badge,
+  IconButton,
+  SizableText,
+  Stack,
+  XStack,
+} from '@onekeyhq/components';
+import { AddressBadge } from '@onekeyhq/kit/src/components/AddressBadge';
+import { BaseInput } from '@onekeyhq/kit/src/components/BaseInput';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import { useSwapIncognitoRecipientInput } from '../../hooks/useSwapIncognitoRecipientInput';
+
+import type {
+  LayoutChangeEvent,
+  NativeSyntheticEvent,
+  TextInputContentSizeChangeEventData,
+} from 'react-native';
+
+type ISwapIncognitoRecipientInputProps = {
+  visible: boolean;
+  networkId?: string;
+  accountId?: string;
+  address?: string;
+  swapToAnotherAccountSwitchOn: boolean;
+  onOpenRecipientAddress: () => void;
+};
+
+function useSwapRecipientInputHeight() {
+  const [baseHeight, setBaseHeight] = useState<number>();
+  const [height, setHeight] = useState<number>();
+
+  const handleLayout = useCallback((event: LayoutChangeEvent) => {
+    const nextBaseHeight = Math.ceil(event.nativeEvent.layout.height);
+
+    setBaseHeight((prevHeight) => prevHeight ?? nextBaseHeight);
+    setHeight((prevHeight) => prevHeight ?? nextBaseHeight);
+  }, []);
+
+  const handleContentSizeChange = useCallback(
+    (event: NativeSyntheticEvent<TextInputContentSizeChangeEventData>) => {
+      if (!platformEnv.isNative) {
+        return;
+      }
+
+      const nextHeight = Math.max(
+        Math.ceil(event.nativeEvent.contentSize.height),
+        baseHeight ?? 0,
+      );
+
+      setHeight((prevHeight) =>
+        prevHeight === nextHeight ? prevHeight : nextHeight,
+      );
+    },
+    [baseHeight],
+  );
+
+  return {
+    height,
+    onContentSizeChange: handleContentSizeChange,
+    onLayout: handleLayout,
+  };
+}
+
+export function SwapIncognitoRecipientInput({
+  visible,
+  networkId,
+  accountId,
+  address,
+  swapToAnotherAccountSwitchOn,
+  onOpenRecipientAddress,
+}: ISwapIncognitoRecipientInputProps) {
+  const intl = useIntl();
+  const {
+    enabled,
+    errorMessage,
+    inputText,
+    loading,
+    onInputChange,
+    queryResult,
+  } = useSwapIncognitoRecipientInput({
+    visible,
+    networkId,
+    accountId,
+    address,
+    swapToAnotherAccountSwitchOn,
+  });
+  const { height, onContentSizeChange, onLayout } =
+    useSwapRecipientInputHeight();
+
+  const badgeItems = useMemo(() => {
+    if (loading || queryResult.validStatus !== 'valid') {
+      return null;
+    }
+
+    const interactionBadges = queryResult.addressBadges ?? [];
+
+    if (
+      !queryResult.walletAccountName &&
+      !queryResult.addressBookName &&
+      interactionBadges.length === 0
+    ) {
+      return null;
+    }
+
+    return (
+      <XStack gap="$2" alignItems="center" flexWrap="wrap">
+        {queryResult.walletAccountName ? (
+          <Badge badgeType="success" badgeSize="sm">
+            {queryResult.walletAccountName}
+          </Badge>
+        ) : null}
+        {queryResult.addressBookName ? (
+          <Badge badgeType="success" badgeSize="sm">
+            {queryResult.addressBookName}
+          </Badge>
+        ) : null}
+        {interactionBadges.map((badge) => (
+          <AddressBadge
+            key={`${badge.label}-${badge.type}`}
+            title={badge.label}
+            badgeType={badge.type}
+            content={badge.tip}
+            icon={badge.icon}
+          />
+        ))}
+      </XStack>
+    );
+  }, [
+    loading,
+    queryResult.addressBadges,
+    queryResult.addressBookName,
+    queryResult.validStatus,
+    queryResult.walletAccountName,
+  ]);
+
+  if (!enabled) {
+    return null;
+  }
+
+  return (
+    <Stack gap="$2">
+      <Stack position="relative">
+        <BaseInput
+          value={inputText}
+          onChangeText={onInputChange}
+          numberOfLines={1}
+          size="large"
+          placeholder={intl.formatMessage({
+            id: ETranslations.trade_enter_receiver_address_optional,
+          })}
+          error={!!errorMessage}
+          pr="$11"
+          scrollEnabled={false}
+          onLayout={onLayout}
+          onContentSizeChange={onContentSizeChange}
+          height={height}
+        />
+        <XStack
+          position="absolute"
+          top={0}
+          bottom={0}
+          right="$2"
+          alignItems="center"
+        >
+          <IconButton
+            variant="tertiary"
+            size="small"
+            icon="PeopleCircleOutline"
+            onPress={onOpenRecipientAddress}
+          />
+        </XStack>
+      </Stack>
+
+      {errorMessage ? (
+        <SizableText size="$bodyMd" color="$textCritical">
+          {errorMessage}
+        </SizableText>
+      ) : null}
+
+      {badgeItems}
+
+      {!errorMessage ? (
+        <SizableText size="$bodyMd" color="$textSubdued">
+          {intl.formatMessage({
+            id: ETranslations.swap_page_recipient_modal_do_not,
+          })}
+        </SizableText>
+      ) : null}
+    </Stack>
+  );
+}

--- a/packages/kit/src/views/Swap/pages/components/SwapIncognitoRecipientInput.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapIncognitoRecipientInput.tsx
@@ -24,6 +24,7 @@ import type {
 
 type ISwapIncognitoRecipientInputProps = {
   visible: boolean;
+  clearRecipientAddressOnHide?: boolean;
   networkId?: string;
   accountId?: string;
   address?: string;
@@ -69,6 +70,7 @@ function useSwapRecipientInputHeight() {
 
 export function SwapIncognitoRecipientInput({
   visible,
+  clearRecipientAddressOnHide,
   networkId,
   accountId,
   address,
@@ -85,6 +87,7 @@ export function SwapIncognitoRecipientInput({
     queryResult,
   } = useSwapIncognitoRecipientInput({
     visible,
+    clearRecipientAddressOnHide,
     networkId,
     accountId,
     address,

--- a/packages/kit/src/views/Swap/pages/components/SwapIncognitoRecipientInput.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapIncognitoRecipientInput.tsx
@@ -10,11 +10,10 @@ import {
   XStack,
 } from '@onekeyhq/components';
 import { AddressBadge } from '@onekeyhq/kit/src/components/AddressBadge';
+import type { IAddressQueryResult } from '@onekeyhq/kit/src/components/AddressInput';
 import { BaseInput } from '@onekeyhq/kit/src/components/BaseInput';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-
-import { useSwapIncognitoRecipientInput } from '../../hooks/useSwapIncognitoRecipientInput';
 
 import type {
   LayoutChangeEvent,
@@ -24,12 +23,12 @@ import type {
 
 type ISwapIncognitoRecipientInputProps = {
   visible: boolean;
-  clearRecipientAddressOnHide?: boolean;
-  networkId?: string;
-  accountId?: string;
-  address?: string;
-  swapToAnotherAccountSwitchOn: boolean;
+  errorMessage?: string;
+  inputText: string;
+  loading: boolean;
   onOpenRecipientAddress: () => void;
+  onInputChange: (text: string) => void;
+  queryResult: IAddressQueryResult;
 };
 
 function useSwapRecipientInputHeight() {
@@ -70,29 +69,14 @@ function useSwapRecipientInputHeight() {
 
 export function SwapIncognitoRecipientInput({
   visible,
-  clearRecipientAddressOnHide,
-  networkId,
-  accountId,
-  address,
-  swapToAnotherAccountSwitchOn,
+  errorMessage,
+  inputText,
+  loading,
   onOpenRecipientAddress,
+  onInputChange,
+  queryResult,
 }: ISwapIncognitoRecipientInputProps) {
   const intl = useIntl();
-  const {
-    enabled,
-    errorMessage,
-    inputText,
-    loading,
-    onInputChange,
-    queryResult,
-  } = useSwapIncognitoRecipientInput({
-    visible,
-    clearRecipientAddressOnHide,
-    networkId,
-    accountId,
-    address,
-    swapToAnotherAccountSwitchOn,
-  });
   const { height, onContentSizeChange, onLayout } =
     useSwapRecipientInputHeight();
 
@@ -142,7 +126,7 @@ export function SwapIncognitoRecipientInput({
     queryResult.walletAccountName,
   ]);
 
-  if (!enabled) {
+  if (!visible) {
     return null;
   }
 

--- a/packages/kit/src/views/Swap/utils/incognitoSettings.test.ts
+++ b/packages/kit/src/views/Swap/utils/incognitoSettings.test.ts
@@ -4,7 +4,7 @@ import {
 } from './incognitoSettings';
 
 describe('buildSwapIncognitoSettingsUpdate', () => {
-  it('enables recipient tag', () => {
+  it('keeps recipient setting untouched when incognito mode is enabled', () => {
     expect(
       buildSwapIncognitoSettingsUpdate(
         {
@@ -15,13 +15,13 @@ describe('buildSwapIncognitoSettingsUpdate', () => {
         true,
       ),
     ).toEqual({
-      swapEnableRecipientAddress: true,
+      swapEnableRecipientAddress: false,
       swapIncognitoMode: true,
       swapToAnotherAccountSwitchOn: false,
     });
   });
 
-  it('keeps recipient tag enabled when incognito mode is disabled', () => {
+  it('keeps recipient setting untouched when incognito mode is disabled', () => {
     expect(
       buildSwapIncognitoSettingsUpdate(
         {
@@ -37,15 +37,49 @@ describe('buildSwapIncognitoSettingsUpdate', () => {
       swapToAnotherAccountSwitchOn: true,
     });
   });
+
+  it('clears custom recipient when incognito mode is disabled and recipient setting is off', () => {
+    expect(
+      buildSwapIncognitoSettingsUpdate(
+        {
+          swapEnableRecipientAddress: false,
+          swapIncognitoMode: true,
+          swapToAnotherAccountSwitchOn: true,
+        },
+        false,
+      ),
+    ).toEqual({
+      swapEnableRecipientAddress: false,
+      swapIncognitoMode: false,
+      swapToAnotherAccountSwitchOn: false,
+    });
+  });
 });
 
 describe('buildSwapRecipientAddressSettingsUpdate', () => {
-  it('turns off incognito mode when recipient tag is manually disabled', () => {
+  it('keeps incognito mode on when recipient setting is manually disabled', () => {
     expect(
       buildSwapRecipientAddressSettingsUpdate(
         {
           swapEnableRecipientAddress: true,
           swapIncognitoMode: true,
+          swapToAnotherAccountSwitchOn: true,
+        },
+        false,
+      ),
+    ).toEqual({
+      swapEnableRecipientAddress: false,
+      swapIncognitoMode: true,
+      swapToAnotherAccountSwitchOn: true,
+    });
+  });
+
+  it('clears custom recipient when recipient setting is disabled outside incognito mode', () => {
+    expect(
+      buildSwapRecipientAddressSettingsUpdate(
+        {
+          swapEnableRecipientAddress: true,
+          swapIncognitoMode: false,
           swapToAnotherAccountSwitchOn: true,
         },
         false,

--- a/packages/kit/src/views/Swap/utils/incognitoSettings.ts
+++ b/packages/kit/src/views/Swap/utils/incognitoSettings.ts
@@ -14,14 +14,17 @@ export function buildSwapIncognitoSettingsUpdate<
     return {
       ...settings,
       swapIncognitoMode: true,
-      swapEnableRecipientAddress: true,
     };
   }
 
   return {
     ...settings,
     swapIncognitoMode: false,
-    swapEnableRecipientAddress: true,
+    ...(settings.swapEnableRecipientAddress
+      ? {}
+      : {
+          swapToAnotherAccountSwitchOn: false,
+        }),
   };
 }
 
@@ -38,7 +41,10 @@ export function buildSwapRecipientAddressSettingsUpdate<
   return {
     ...settings,
     swapEnableRecipientAddress: false,
-    swapToAnotherAccountSwitchOn: false,
-    swapIncognitoMode: false,
+    ...(settings.swapIncognitoMode
+      ? {}
+      : {
+          swapToAnotherAccountSwitchOn: false,
+        }),
   };
 }


### PR DESCRIPTION
## Summary
- decouple incognito recipient entry from the existing custom recipient toggle
- restore review fiat values in the market speed swap flow
- keep the Swap `Advanced settings` dialog below the iOS top safe area when the keyboard opens for custom slippage

## Intent & Context
This PR addresses `OK-53097`, `OK-53090`, and `OK-53070`.

- `OK-53097`: incognito mode still needs a recipient entry path even when the manual custom recipient setting is off
- `OK-53090`: review fiat values regressed in the market speed swap flow and needed to be restored
- `OK-53070`: on small iOS screens, opening custom slippage inside `Advanced settings` could push the dialog header under the notch / status area when the keyboard appeared

## Root Cause
- The previous Swap logic coupled incognito mode with `swapEnableRecipientAddress`, so turning off the manual recipient path also removed the path that incognito mode still needed
- The market speed swap review flow lost the expected fiat-value restoration path in `useSpeedSwapActions`
- The `Advanced settings` dialog relied on dialog-level keyboard avoidance alone. With fit-height sheet behavior and no local content height guard, the keyboard could push the whole sheet too high on small iOS devices

## Design Decisions
- Keep the recipient behavior split explicit in Swap: the legacy recipient path is still controlled by `swapEnableRecipientAddress`, while the incognito recipient path is controlled by `swapIncognitoMode`
- Restore the market review fiat-value path in the local speed swap actions hook with matching test coverage
- Avoid modifying shared input components. The mobile auto-expand behavior is implemented locally in the Swap incognito recipient input
- Keep the dialog layout fix local to the Swap settings dialog instead of changing shared `Dialog` behavior
- When the keyboard is shown on native, compute a local dialog content max height from window height, keyboard height, top safe area, and reserved dialog chrome so the sheet preserves a top safety gap instead of relying on a fixed compressed height

## Changes Detail
- `packages/kit/src/views/Swap/utils/incognitoSettings.ts`
  - decouple incognito mode from the custom recipient toggle
  - only clear recipient state when both paths are effectively off
- `packages/kit/src/views/Swap/utils/incognitoSettings.test.ts`
  - add coverage for the new decoupled behavior
- `packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx`
  - show the inline incognito recipient input only for the incognito path
  - keep the existing recipient display for the non-incognito path
  - switch to the updated tooltip copy
- `packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts`
  - manage inline recipient input state, debounce validation, and sync validated addresses back to Swap state
- `packages/kit/src/views/Swap/pages/components/SwapIncognitoRecipientInput.tsx`
  - render the inline input, local auto-height behavior, validation text, and badges
- `packages/kit/src/components/AddressInput/utils.ts`
  - share small address-query helpers used by both Swap and `AddressInput`
- `packages/kit/src/components/AddressInput/index.tsx`
  - reuse the shared address-query helpers instead of duplicating fallback and normalization logic
- `packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx`
  - restore review fiat values in the market speed swap flow
- `packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx`
  - add / update coverage for the restored fiat-value behavior
- `packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx`
  - wrap the settings body in a scrollable content area
  - dynamically cap content height during keyboard display so the dialog header stays below the iOS top safe area on small screens
- `packages/shared/src/locale/*`
  - add the required recipient placeholder and updated incognito tooltip locale strings

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Desktop / Web / Extension, with the new dialog layout change primarily affecting iOS native
- **Risk Areas**: recipient visibility rules, validated recipient state sync, market review fiat values, mobile input layout for long addresses, and iOS small-screen dialog layout under keyboard

## Test plan
- [ ] Turn on incognito mode with the manual recipient setting disabled and verify the inline recipient input still shows
- [ ] Turn off incognito mode and verify recipient entry falls back to the existing toggle behavior
- [ ] Verify review fiat values are restored in the market speed swap flow
- [ ] Enter a long address on mobile and verify the input expands instead of showing an internal scroll area
- [ ] Verify invalid and valid recipient states, including helper text and badges
- [ ] On iPhone 16e or another small iOS screen, open Swap > Advanced settings > Custom slippage and verify the header stays below the notch when the keyboard opens
- [x] Run `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx`
- [ ] Run `npx eslint packages/kit/src/components/AddressInput/index.tsx packages/kit/src/components/AddressInput/utils.ts packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts packages/kit/src/views/Swap/pages/components/SwapIncognitoRecipientInput.tsx packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx packages/kit/src/views/Swap/utils/incognitoSettings.ts packages/kit/src/views/Swap/utils/incognitoSettings.test.ts packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx`
- [ ] Run `yarn tsc:only`
- [ ] Run focused tests for Swap / Market changes as needed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
