### PR TITLE
refactor(discovery): remove sign typed data reporting

### DIFF
--- a/packages/kit-bg/src/services/ServiceDiscovery.ts
+++ b/packages/kit-bg/src/services/ServiceDiscovery.ts
@@ -1,7 +1,4 @@
-import { sha256 } from '@noble/hashes/sha256';
-import { bytesToHex } from '@noble/hashes/utils';
 import { isNil, isNumber } from 'lodash';
-import { LRUCache } from 'lru-cache';
 import WebViewCleaner from 'react-native-webview-cleaner';
 
 import type {
@@ -51,16 +48,6 @@ import ServiceBase from './ServiceBase';
 
 @backgroundClass()
 class ServiceDiscovery extends ServiceBase {
-  private signedMessageCache: LRUCache<string, boolean>;
-
-  constructor({ backgroundApi }: { backgroundApi: any }) {
-    super({ backgroundApi });
-    this.signedMessageCache = new LRUCache<string, boolean>({
-      max: 100,
-      ttl: timerUtils.getTimeDurationMs({ minute: 60 }),
-    });
-  }
-
   @backgroundMethod()
   async fetchHistoryData(page = 1, pageSize = 15) {
     const start = (page - 1) * pageSize;
@@ -506,42 +493,6 @@ class ServiceDiscovery extends ServiceBase {
       });
     }
     return this.getBrowserBookmarks();
-  }
-
-  @backgroundMethod()
-  async postSignTypedDataMessage(params: {
-    networkId: string;
-    accountId: string;
-    origin: string;
-    typedData: string;
-  }) {
-    const { networkId, accountId, origin, typedData } = params;
-
-    const cacheKey = bytesToHex(
-      sha256(`${networkId}__${accountId}__${origin}__${typedData}`),
-    );
-
-    if (this.signedMessageCache.has(cacheKey)) {
-      return;
-    }
-
-    const accountAddress =
-      await this.backgroundApi.serviceAccount.getAccountAddressForApi({
-        networkId,
-        accountId,
-      });
-    const client = await this.getClient(EServiceEndpointEnum.Wallet);
-    try {
-      await client.post('/wallet/v1/network/sign-typed-data', {
-        accountAddress,
-        networkId,
-        data: JSON.parse(typedData),
-        origin,
-      });
-      this.signedMessageCache.set(cacheKey, true);
-    } catch {
-      // ignore error
-    }
   }
 }
 

--- a/packages/kit/src/views/DAppConnection/pages/SignMessageModal.tsx
+++ b/packages/kit/src/views/DAppConnection/pages/SignMessageModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 import { StyleSheet } from 'react-native';
@@ -144,23 +144,6 @@ function SignMessageModal() {
   const isSignTypedDataV3orV4Method =
     unsignedMessage.type === EMessageTypesEth.TYPED_DATA_V3 ||
     unsignedMessage.type === EMessageTypesEth.TYPED_DATA_V4;
-
-  useEffect(() => {
-    if (isSignTypedDataV3orV4Method) {
-      void backgroundApiProxy.serviceDiscovery.postSignTypedDataMessage({
-        networkId,
-        accountId,
-        origin: $sourceInfo?.origin ?? '',
-        typedData: unsignedMessage.message,
-      });
-    }
-  }, [
-    isSignTypedDataV3orV4Method,
-    $sourceInfo?.origin,
-    accountId,
-    networkId,
-    unsignedMessage.message,
-  ]);
 
   const subtitle = useMemo(() => {
     if (!currentNetwork?.name) {

--- a/packages/kit/src/views/SignatureConfirm/pages/MessageConfirm/MessageConfirm.tsx
+++ b/packages/kit/src/views/SignatureConfirm/pages/MessageConfirm/MessageConfirm.tsx
@@ -25,7 +25,6 @@ import {
 } from '@onekeyhq/shared/src/utils/txActionUtils';
 import { EDAppModalPageStatus } from '@onekeyhq/shared/types/dappConnection';
 import { EHostSecurityLevel } from '@onekeyhq/shared/types/discovery';
-import { EMessageTypesEth } from '@onekeyhq/shared/types/message';
 import {
   EParseTxComponentType,
   type IParseMessageResp,
@@ -101,12 +100,6 @@ function MessageConfirm() {
     isRiskSignMethod,
   } = useRiskDetection({ origin: sourceInfo?.origin ?? '', unsignedMessage });
 
-  const isSignTypedDataV3orV4Method =
-    unsignedMessage.type === EMessageTypesEth.TYPED_DATA_V3 ||
-    unsignedMessage.type === EMessageTypesEth.TYPED_DATA_V4;
-
-  const typedData = JSON.stringify(unsignedMessage);
-
   const { result, isLoading } = usePromiseResult(
     async () => {
       const accountAddress =
@@ -115,37 +108,16 @@ function MessageConfirm() {
           accountId,
         });
 
-      const requests:
-        | [Promise<IParseMessageResp | null>, Promise<void>]
-        | [Promise<IParseMessageResp | null>] = isSignTypedDataV3orV4Method
-        ? [
-            backgroundApiProxy.serviceSignatureConfirm.parseMessage({
-              networkId,
-              accountId,
-              accountAddress,
-              message: unsignedMessage.message,
-              swapInfo,
-            }),
-            backgroundApiProxy.serviceDiscovery.postSignTypedDataMessage({
-              networkId,
-              accountId,
-              origin: sourceInfo?.origin ?? '',
-              typedData,
-            }),
-          ]
-        : [
-            backgroundApiProxy.serviceSignatureConfirm.parseMessage({
-              networkId,
-              accountId,
-              accountAddress,
-              message: unsignedMessage.message,
-              swapInfo,
-            }),
-          ];
-
       const resp = await promiseAllSettledEnhanced(
-        // @ts-ignore
-        requests,
+        [
+          backgroundApiProxy.serviceSignatureConfirm.parseMessage({
+            networkId,
+            accountId,
+            accountAddress,
+            message: unsignedMessage.message,
+            swapInfo,
+          }),
+        ],
         {
           continueOnError: true,
         },
@@ -191,15 +163,7 @@ function MessageConfirm() {
         isConfirmationRequired: m?.isConfirmationRequired,
       };
     },
-    [
-      networkId,
-      accountId,
-      isSignTypedDataV3orV4Method,
-      unsignedMessage.message,
-      swapInfo,
-      sourceInfo?.origin,
-      typedData,
-    ],
+    [networkId, accountId, unsignedMessage.message, swapInfo],
     {
       watchLoading: true,
     },


### PR DESCRIPTION
## Summary
- remove `serviceDiscovery.postSignTypedDataMessage` and its typed-data reporting request
- stop triggering typed-data reporting from the dapp sign modal and the signature confirm page
- keep the existing typed-data parsing and signing flow unchanged

## Intent & Context
The change was made because the user explicitly requested that `serviceDiscovery.postSignTypedDataMessage` should be removed and no longer recorded. The goal is to stop reporting signed typed-data payloads while preserving the existing approval and signing experience.

## Root Cause
Typed-data signing still triggered a background reporting path from two UI entry points. Both the dapp sign modal and the signature confirm page invoked `serviceDiscovery.postSignTypedDataMessage`, which then sent the typed data to the wallet service endpoint and cached the request.

## Design Decisions
The reporting method was removed entirely instead of being left as a no-op so future callers cannot continue relying on it accidentally. The UI changes were kept minimal by only deleting the reporting calls and simplifying the async request path in the signature confirm page.

## Changes Detail
- remove the typed-data reporting method, request cache, and related imports from `ServiceDiscovery`
- delete the `useEffect` side effect in the dapp sign modal that posted typed-data messages for V3/V4 signing
- simplify the signature confirm page to only parse the message before rendering, without the extra reporting promise

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: DApp typed-data sign request flow, especially V3/V4 confirmation entry points

## Test plan
- [ ] Run `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit-bg/src/services/ServiceDiscovery.ts packages/kit/src/views/DAppConnection/pages/SignMessageModal.tsx packages/kit/src/views/SignatureConfirm/pages/MessageConfirm/MessageConfirm.tsx`
- [ ] Verify a DApp typed-data V3/V4 sign request still opens and completes from the DApp connection flow
- [ ] Verify a typed-data sign request still renders correctly in the signature confirm flow without additional reporting requests

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
