### PR TITLE
fix(discovery): add AccountSelectorProviderMirror to Browser pages

### DIFF
--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.ext.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.ext.tsx
@@ -4,6 +4,7 @@ import { useRoute } from '@react-navigation/core';
 
 import { Page, Stack, XStack, YStack } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import { TabPageHeader } from '@onekeyhq/kit/src/components/TabPageHeader';
 import { LegacyUniversalSearchInput } from '@onekeyhq/kit/src/components/TabPageHeader/LegacyUniversalSearchInput';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -145,4 +146,18 @@ function MobileBrowser() {
   );
 }
 
-export default memo(withBrowserProvider(MobileBrowser));
+function MobileBrowserWithProvider() {
+  return (
+    <AccountSelectorProviderMirror
+      config={{
+        sceneName: EAccountSelectorSceneName.home,
+        sceneUrl: '',
+      }}
+      enabledNum={[0]}
+    >
+      <MobileBrowser />
+    </AccountSelectorProviderMirror>
+  );
+}
+
+export default memo(withBrowserProvider(MobileBrowserWithProvider));

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -21,6 +21,7 @@ import {
 import type { ITabContainerRef } from '@onekeyhq/components';
 import type { IPageNavigationProp } from '@onekeyhq/components/src/layouts/Navigation';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import { LazyPageContainer } from '@onekeyhq/kit/src/components/LazyPageContainer';
 import { TabletHomeContainer } from '@onekeyhq/kit/src/components/TabletHomeContainer';
 import { TabPageHeader } from '@onekeyhq/kit/src/components/TabPageHeader';
@@ -647,9 +648,17 @@ function MobileBrowser() {
 
 function BaseMobileBrowser() {
   return (
-    <LazyPageContainer>
-      <MobileBrowser />
-    </LazyPageContainer>
+    <AccountSelectorProviderMirror
+      config={{
+        sceneName: EAccountSelectorSceneName.home,
+        sceneUrl: '',
+      }}
+      enabledNum={[0]}
+    >
+      <LazyPageContainer>
+        <MobileBrowser />
+      </LazyPageContainer>
+    </AccountSelectorProviderMirror>
   );
 }
 


### PR DESCRIPTION
## Summary
- MDHeader now directly calls `useActiveAccount()` and `useIsAccountSelectorSyncLoading()`, requiring `AccountSelectorProviderMirror` in the component tree
- `Browser.native.tsx` and `Browser.ext.tsx` were only wrapped with `DiscoveryBrowserProviderMirror`, missing `AccountSelectorProviderMirror`, causing "useContextStore ERROR: store not initialized" crash on the Discovery tab
- Added `AccountSelectorProviderMirror` to both files, matching the pattern in `DashboardContainer.tsx`

## Test plan
- [ ] Open the app on iOS, navigate to the Discovery tab — should no longer crash
- [ ] Verify wallet connection row shows/hides correctly in Discovery tab header
- [ ] Test on extension popup — Discovery tab should render without error
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
