### PR TITLE
refactor(header): move AccountSelector hooks into Home-only subcomponents

### DIFF
--- a/packages/kit/src/components/TabPageHeader/MDHeader.tsx
+++ b/packages/kit/src/components/TabPageHeader/MDHeader.tsx
@@ -23,6 +23,44 @@ import { LegacyUniversalSearchInput } from './LegacyUniversalSearchInput';
 
 import type { SharedValue } from 'react-native-reanimated';
 
+function HomeWalletConnectionRow({
+  headerPx,
+  selectedHeaderTab,
+  sceneName,
+  tabRoute,
+  customHeaderLeftItems,
+}: {
+  headerPx: string;
+  selectedHeaderTab?: ETranslations;
+  sceneName: EAccountSelectorSceneName;
+  tabRoute: ETabRoutes;
+  customHeaderLeftItems?: ReactNode;
+}) {
+  const {
+    activeAccount: { wallet, account },
+  } = useActiveAccount({ num: 0 });
+  const isSyncLoading = useIsAccountSelectorSyncLoading(0);
+  const hasNoUsableWallet = accountUtils.hasNoUsableWallet({
+    wallet,
+    account,
+  });
+
+  if (hasNoUsableWallet && !isSyncLoading) {
+    return null;
+  }
+
+  return (
+    <XStack alignItems="center" px={headerPx} h={44}>
+      <HeaderLeft
+        selectedHeaderTab={selectedHeaderTab}
+        sceneName={sceneName}
+        tabRoute={tabRoute}
+        customHeaderLeftItems={customHeaderLeftItems}
+      />
+    </XStack>
+  );
+}
+
 export function MDHeader({
   tabRoute,
   sceneName,
@@ -49,13 +87,6 @@ export function MDHeader({
   pageScrollPosition?: SharedValue<number>;
 }) {
   const { top } = useSafeAreaInsets();
-  const {
-    activeAccount: { wallet, account },
-  } = useActiveAccount({ num: 0 });
-  const hasNoUsableWallet = accountUtils.hasNoUsableWallet({
-    wallet,
-    account,
-  });
 
   const rightActions = useMemo(() => {
     return sceneName === EAccountSelectorSceneName.homeUrlAccount ? (
@@ -93,8 +124,6 @@ export function MDHeader({
     tabRoute === ETabRoutes.Home &&
     sceneName !== EAccountSelectorSceneName.homeUrlAccount;
 
-  const isSyncLoading = useIsAccountSelectorSyncLoading(0);
-
   return (
     <>
       <Page.Header headerShown={false} />
@@ -125,16 +154,13 @@ export function MDHeader({
                 <MoreActionButton />
               </XStack>
               {/* Row 2: Wallet connection (account + network + address) */}
-              {hasNoUsableWallet && !isSyncLoading ? null : (
-                <XStack alignItems="center" px={headerPx} h={44}>
-                  <HeaderLeft
-                    selectedHeaderTab={selectedHeaderTab}
-                    sceneName={sceneName}
-                    tabRoute={tabRoute}
-                    customHeaderLeftItems={customHeaderLeftItems}
-                  />
-                </XStack>
-              )}
+              <HomeWalletConnectionRow
+                headerPx={headerPx}
+                selectedHeaderTab={selectedHeaderTab}
+                sceneName={sceneName}
+                tabRoute={tabRoute}
+                customHeaderLeftItems={customHeaderLeftItems}
+              />
             </>
           ) : (
             <>

--- a/packages/kit/src/components/TabPageHeader/index.tsx
+++ b/packages/kit/src/components/TabPageHeader/index.tsx
@@ -28,11 +28,9 @@ import type { ITabPageHeaderProp } from './type';
 
 export { DiscoveryHeaderSegment };
 
-function InPageHeader({
+function HomeWalletConnectionInPage({
   tabRoute,
-  sceneName,
 }: {
-  sceneName: EAccountSelectorSceneName;
   tabRoute: ETabRoutes;
 }) {
   const {
@@ -44,30 +42,40 @@ function InPageHeader({
     account,
   });
 
-  const item = useMemo(() => {
-    if (
-      tabRoute === ETabRoutes.Home &&
-      sceneName !== EAccountSelectorSceneName.homeUrlAccount
-    ) {
-      if (hasNoUsableWallet && !isSyncLoading) {
-        return null;
-      }
-      return <WalletConnectionGroup tabRoute={tabRoute} />;
-    }
-    if (sceneName === EAccountSelectorSceneName.homeUrlAccount) {
-      return <UrlAccountPageHeader />;
-    }
-  }, [sceneName, tabRoute, hasNoUsableWallet, isSyncLoading]);
-
-  if (!item) {
+  if (hasNoUsableWallet && !isSyncLoading) {
     return null;
   }
 
   return (
     <XStack px="$pagePadding" pt="$5" pb="$2.5" bg="$bgApp" borderRadius="$4">
-      {item}
+      <WalletConnectionGroup tabRoute={tabRoute} />
     </XStack>
   );
+}
+
+function InPageHeader({
+  tabRoute,
+  sceneName,
+}: {
+  sceneName: EAccountSelectorSceneName;
+  tabRoute: ETabRoutes;
+}) {
+  if (
+    tabRoute === ETabRoutes.Home &&
+    sceneName !== EAccountSelectorSceneName.homeUrlAccount
+  ) {
+    return <HomeWalletConnectionInPage tabRoute={tabRoute} />;
+  }
+
+  if (sceneName === EAccountSelectorSceneName.homeUrlAccount) {
+    return (
+      <XStack px="$pagePadding" pt="$5" pb="$2.5" bg="$bgApp" borderRadius="$4">
+        <UrlAccountPageHeader />
+      </XStack>
+    );
+  }
+
+  return null;
 }
 
 function BaseDesktopTabPageHeader({

--- a/packages/kit/src/components/TabPageHeader/index.tsx
+++ b/packages/kit/src/components/TabPageHeader/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 
 import { Page, XStack, YStack, useMedia, useTheme } from '@onekeyhq/components';
 import { UniversalSearchInput } from '@onekeyhq/kit/src/components/TabPageHeader/UniversalSearchInput';

--- a/packages/kit/src/components/TabPageHeader/index.tsx
+++ b/packages/kit/src/components/TabPageHeader/index.tsx
@@ -28,11 +28,7 @@ import type { ITabPageHeaderProp } from './type';
 
 export { DiscoveryHeaderSegment };
 
-function HomeWalletConnectionInPage({
-  tabRoute,
-}: {
-  tabRoute: ETabRoutes;
-}) {
+function HomeWalletConnectionInPage({ tabRoute }: { tabRoute: ETabRoutes }) {
   const {
     activeAccount: { wallet, account },
   } = useActiveAccount({ num: 0 });

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.ext.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.ext.tsx
@@ -4,7 +4,6 @@ import { useRoute } from '@react-navigation/core';
 
 import { Page, Stack, XStack, YStack } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import { TabPageHeader } from '@onekeyhq/kit/src/components/TabPageHeader';
 import { LegacyUniversalSearchInput } from '@onekeyhq/kit/src/components/TabPageHeader/LegacyUniversalSearchInput';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -146,18 +145,4 @@ function MobileBrowser() {
   );
 }
 
-function MobileBrowserWithProvider() {
-  return (
-    <AccountSelectorProviderMirror
-      config={{
-        sceneName: EAccountSelectorSceneName.home,
-        sceneUrl: '',
-      }}
-      enabledNum={[0]}
-    >
-      <MobileBrowser />
-    </AccountSelectorProviderMirror>
-  );
-}
-
-export default memo(withBrowserProvider(MobileBrowserWithProvider));
+export default memo(withBrowserProvider(MobileBrowser));

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -21,7 +21,6 @@ import {
 import type { ITabContainerRef } from '@onekeyhq/components';
 import type { IPageNavigationProp } from '@onekeyhq/components/src/layouts/Navigation';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import { LazyPageContainer } from '@onekeyhq/kit/src/components/LazyPageContainer';
 import { TabletHomeContainer } from '@onekeyhq/kit/src/components/TabletHomeContainer';
 import { TabPageHeader } from '@onekeyhq/kit/src/components/TabPageHeader';
@@ -648,17 +647,9 @@ function MobileBrowser() {
 
 function BaseMobileBrowser() {
   return (
-    <AccountSelectorProviderMirror
-      config={{
-        sceneName: EAccountSelectorSceneName.home,
-        sceneUrl: '',
-      }}
-      enabledNum={[0]}
-    >
-      <LazyPageContainer>
-        <MobileBrowser />
-      </LazyPageContainer>
-    </AccountSelectorProviderMirror>
+    <LazyPageContainer>
+      <MobileBrowser />
+    </LazyPageContainer>
   );
 }
 


### PR DESCRIPTION
## Summary
- MDHeader / InPageHeader called useActiveAccount / useIsAccountSelectorSyncLoading at top level, forcing all TabPageHeader users to wrap with AccountSelectorProviderMirror
- Extract hooks into HomeWalletConnectionRow / HomeWalletConnectionInPage subcomponents that only render on Home tab (which always has the provider)
- Reverts #11179 Browser provider additions as they are no longer needed

## Test plan
- [ ] iOS/Android Discovery tab — no crash
- [ ] Extension Discovery tab — no crash
- [ ] Home tab: wallet connection row shows loading during wallet deletion
- [ ] Home tab: wallet connection row hides when no usable wallet
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
