### PR TITLE
fix(Market): resolve market foldable detail layout overlap ｜ OK-51898

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderLeft.tsx
@@ -1,7 +1,4 @@
-import { useMemo } from 'react';
-
 import { SUI_TYPE_ARG } from '@mysten/sui/utils';
-import { useWindowDimensions } from 'react-native';
 
 import {
   Divider,
@@ -9,7 +6,6 @@ import {
   SizableText,
   XStack,
   YStack,
-  useIsSplitView,
   useMedia,
 } from '@onekeyhq/components';
 import { Token } from '@onekeyhq/kit/src/components/Token';
@@ -47,11 +43,6 @@ export function TokenDetailHeaderLeft({
   showMediaAndSecurity = true,
   isNative = false,
 }: ITokenDetailHeaderLeftProps) {
-  const isLandscape = useIsSplitView();
-  const { width: windowScreenWidth } = useWindowDimensions();
-  const screenWidth = useMemo(() => {
-    return isLandscape ? windowScreenWidth / 2 : windowScreenWidth;
-  }, [isLandscape, windowScreenWidth]);
   const { md } = useMedia();
 
   // Use hook to get network logo with async fallback
@@ -103,17 +94,8 @@ export function TokenDetailHeaderLeft({
   ) : null;
 
   return (
-    <XStack
-      ai="center"
-      gap="$3"
-      jc="space-between"
-      {...(md
-        ? {
-            width: screenWidth - 60,
-          }
-        : {})}
-    >
-      <XStack gap="$3" ai="center">
+    <XStack ai="center" flex={1} gap="$3" jc="space-between" minWidth={0}>
+      <XStack gap="$3" ai="center" flex={1} minWidth={0}>
         {md ? (
           <Token
             size="md"
@@ -129,7 +111,7 @@ export function TokenDetailHeaderLeft({
           </>
         )}
 
-        <YStack>
+        <YStack flex={1} minWidth={0}>
           <XStack ai="center" gap="$1">
             {md ? (
               <SizableText

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenSelector/MarketTokenSelector.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenSelector/MarketTokenSelector.tsx
@@ -192,7 +192,9 @@ function BaseMarketTokenSelectorContent() {
                 key={item.id}
                 id={item.id}
                 name={item.name}
-                isFocused={!startListSelect && item.id === selectedCategory}
+                isFocused={Boolean(
+                  !startListSelect && item.id === selectedCategory,
+                )}
                 onPress={handleCategoryChange}
               />
             ))}
@@ -206,7 +208,7 @@ function BaseMarketTokenSelectorContent() {
           timeRange="1h"
           onItemPress={handleSelectToken}
           pollingInterval={TOKEN_SELECTOR_POLLING_INTERVAL}
-          isWatchlistMode={!searchValueDebounce && startListSelect}
+          isWatchlistMode={Boolean(!searchValueDebounce && startListSelect)}
           searchQuery={searchValueDebounce}
           searchLoading={searchLoading}
           searchResults={searchTokenList}

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -52,11 +52,13 @@ function MobileTradingViewTouchBridge({
   networkId,
   tokenSymbol,
   dataSource,
+  pageWidth,
 }: {
   tokenAddress: string;
   networkId: string;
   tokenSymbol: string;
   dataSource: 'websocket' | 'polling';
+  pageWidth?: number;
 }) {
   const handleTouchScroll = useMobileTabTouchScrollBridge();
 
@@ -66,6 +68,7 @@ function MobileTradingViewTouchBridge({
       networkId={networkId}
       tokenSymbol={tokenSymbol}
       dataSource={dataSource}
+      pageWidth={pageWidth}
       onTouchScroll={handleTouchScroll}
     />
   );
@@ -279,6 +282,7 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
                       dataSource={
                         websocketConfig?.kline ? 'websocket' : 'polling'
                       }
+                      pageWidth={effectivePageWidth}
                     />
                   );
                 }
@@ -290,6 +294,7 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
                     dataSource={
                       websocketConfig?.kline ? 'websocket' : 'polling'
                     }
+                    pageWidth={effectivePageWidth}
                   />
                 );
               })()}
@@ -311,6 +316,7 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
       </YStack>
     );
   }, [
+    effectivePageWidth,
     handleHeaderHorizontalSwipe,
     networkId,
     tokenAddress,
@@ -434,7 +440,12 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
       />
       <ScrollView horizontal ref={scrollViewRef} flex={1} scrollEnabled={false}>
         {tabNames.map((_, index) => (
-          <YStack key={index} h={height} w={effectivePageWidth}>
+          <YStack
+            key={index}
+            h={height}
+            overflow="hidden"
+            w={effectivePageWidth}
+          >
             {renderItem({ index })}
           </YStack>
         ))}


### PR DESCRIPTION
## Summary
- fix Market detail layout on foldable devices in split/folded mode
- avoid header content using half-width calculation, so the detail header can render with the correct available width
- pass the effective page width into TradingView and hide page overflow to prevent K-line and overview content from overlapping across pages
- fix `MarketTokenSelector` boolean prop typing to avoid `boolean | null` errors

## Changes
- update `TokenDetailHeaderLeft` to rely on flexible layout instead of manual half-screen width logic
- update `MobileLayout` to pass `effectivePageWidth` to TradingView and add hidden overflow for each horizontal page
- update `MarketTokenSelector` to use explicit boolean values for `isFocused` and `isWatchlistMode`

## Notes
- this PR only includes the Market foldable layout fix files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
