### PR TITLE
fix(app-update): use fresh response for changelogViewed isForceUpdate (OK-53186)

### DIFF
--- a/packages/kit/src/views/AppUpdate/pages/UpdatePreview.tsx
+++ b/packages/kit/src/views/AppUpdate/pages/UpdatePreview.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { usePreventRemove } from '@react-navigation/core';
 import { useIntl } from 'react-intl';
@@ -65,6 +65,12 @@ function UpdatePreview({
       .fetchAppUpdateInfo(true)
       .then((response) => {
         setUpdateInfo(response);
+        if (response?.latestVersion) {
+          defaultLogger.app.appUpdate.changelogViewed({
+            toVersion: response.latestVersion,
+            isForceUpdate: isForceUpdateStrategy(response.updateStrategy),
+          });
+        }
       });
   }, []);
 
@@ -73,17 +79,6 @@ function UpdatePreview({
     : isForceUpdateParam;
   const changeLog = updateInfo?.changeLog;
   usePreventRemove(!!isForceUpdate, () => {});
-
-  const hasLoggedRef = useRef(false);
-  useEffect(() => {
-    if (updateInfo?.latestVersion && !hasLoggedRef.current) {
-      hasLoggedRef.current = true;
-      defaultLogger.app.appUpdate.changelogViewed({
-        toVersion: updateInfo.latestVersion,
-        isForceUpdate: !!isForceUpdate,
-      });
-    }
-  }, [updateInfo?.latestVersion, isForceUpdate]);
 
   const headerProps = useMemo(() => {
     const props: { title: string; headerLeft?: () => ReactNode } = {


### PR DESCRIPTION
## Summary

Fix QA-reported issue where `changelogViewed` Mixpanel event always logged `isForceUpdate: false` even when force update was configured on the server.

### Root cause

In `UpdatePreview.tsx`, the previous tracking effect captured `isForceUpdate` derived from `useState(appUpdateInfo)`'s initial snapshot, then locked itself with `hasLoggedRef` on first run.

On mount the persisted atom may not yet reflect the latest server strategy (default `manual`, `latestVersion = '0.0.0'`). The effect fired immediately with stale `isForceUpdate: false`, then `fetchAppUpdateInfo(true)` resolved later with `updateStrategy: force` — too late, ref already locked.

### Fix

Move the `defaultLogger.app.appUpdate.changelogViewed` call into the `.then()` of the existing `fetchAppUpdateInfo(true)` call. The log now reads `updateStrategy` and `latestVersion` directly from the fresh server response, eliminating the race.

Also drops the now-redundant `hasLoggedRef` (the outer effect uses `[]` deps and the promise resolves at most once).

## Test plan

- [ ] Configure force update on server, open UpdatePreview → verify `changelogViewed` logs `isForceUpdate: true`
- [ ] Configure non-force update, open UpdatePreview → verify `isForceUpdate: false`
- [ ] Re-enter UpdatePreview multiple times → each entry logs once
- [ ] No log fired when `latestVersion` is missing from response
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
