### PR TITLE
fix(swap): fix recipient input, keyboard overlap, and fee display (OK-53072, OK-53209, OK-53214, OK-53216)

### DIFF
--- a/packages/kit/src/components/TxAction/TxActionSwapInfo.tsx
+++ b/packages/kit/src/components/TxAction/TxActionSwapInfo.tsx
@@ -103,11 +103,16 @@ function TxActionSwapInfo(props: IProps) {
       return null;
     }
 
-    if (new BigNumber(fee.percentageFee).gte(swapServiceFeeDefault)) {
+    const originPercentageFee = fee.percentOriginFee ?? swapServiceFeeDefault;
+
+    if (new BigNumber(fee.percentageFee).gte(originPercentageFee)) {
       return (
         <XStack alignItems="center" gap="$1">
           <SizableText {...textStyle}>{fee.percentageFee}%</SizableText>
-          <SwapServiceFeeOverview percentageFee={fee.percentageFee} />
+          <SwapServiceFeeOverview
+            percentageFee={fee.percentageFee}
+            percentOriginFee={fee.percentOriginFee}
+          />
         </XStack>
       );
     }
@@ -118,9 +123,12 @@ function TxActionSwapInfo(props: IProps) {
           {fee.percentageFee}%
         </SizableText>
         <SizableText textDecorationLine="line-through" {...textStyle}>
-          {swapServiceFeeDefault}%
+          {originPercentageFee}%
         </SizableText>
-        <SwapServiceFeeOverview percentageFee={fee.percentageFee} />
+        <SwapServiceFeeOverview
+          percentageFee={fee.percentageFee}
+          percentOriginFee={fee.percentOriginFee}
+        />
       </XStack>
     );
   }, [fee]);

--- a/packages/kit/src/views/SignatureConfirm/components/SwapInfo/SwapInfo.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/SwapInfo/SwapInfo.tsx
@@ -99,11 +99,16 @@ function SwapInfo(props: IProps) {
       return null;
     }
 
-    if (new BigNumber(fee.percentageFee).gte(swapServiceFeeDefault)) {
+    const originPercentageFee = fee.percentOriginFee ?? swapServiceFeeDefault;
+
+    if (new BigNumber(fee.percentageFee).gte(originPercentageFee)) {
       return (
         <XStack alignItems="center" gap="$1">
           <SizableText {...textStyle}>{fee.percentageFee}%</SizableText>
-          <SwapServiceFeeOverview percentageFee={fee.percentageFee} />
+          <SwapServiceFeeOverview
+            percentageFee={fee.percentageFee}
+            percentOriginFee={fee.percentOriginFee}
+          />
         </XStack>
       );
     }
@@ -114,9 +119,12 @@ function SwapInfo(props: IProps) {
           {fee.percentageFee}%
         </SizableText>
         <SizableText textDecorationLine="line-through" {...textStyle}>
-          {swapServiceFeeDefault}%
+          {originPercentageFee}%
         </SizableText>
-        <SwapServiceFeeOverview percentageFee={fee.percentageFee} />
+        <SwapServiceFeeOverview
+          percentageFee={fee.percentageFee}
+          percentOriginFee={fee.percentOriginFee}
+        />
       </XStack>
     );
   }, [fee]);

--- a/packages/kit/src/views/Swap/components/SwapProviderInfoItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProviderInfoItem.tsx
@@ -26,11 +26,13 @@ interface ISwapProviderInfoItemProps {
   onPress?: () => void;
   isLoading?: boolean;
   percentageFee?: number;
+  percentOriginFee?: number;
 }
 
 const SwapProviderInfoItemTitleContent = ({
   percentageFee,
-}: Pick<ISwapProviderInfoItemProps, 'percentageFee'>) => {
+  percentOriginFee,
+}: Pick<ISwapProviderInfoItemProps, 'percentageFee' | 'percentOriginFee'>) => {
   const intl = useIntl();
 
   return (
@@ -45,7 +47,10 @@ const SwapProviderInfoItemTitleContent = ({
           id: ETranslations.swap_page_provider_provider,
         })}
       </SizableText>
-      <SwapServiceFeeOverview percentageFee={percentageFee} />
+      <SwapServiceFeeOverview
+        percentageFee={percentageFee}
+        percentOriginFee={percentOriginFee}
+      />
     </XStack>
   );
 };
@@ -64,11 +69,15 @@ const SwapProviderInfoItem = ({
   onPress,
   isLoading,
   percentageFee,
+  percentOriginFee,
 }: ISwapProviderInfoItemProps) => {
   const intl = useIntl();
   return (
     <XStack justifyContent="space-between" alignItems="center">
-      <SwapProviderInfoItemTitleContentMemo percentageFee={percentageFee} />
+      <SwapProviderInfoItemTitleContentMemo
+        percentageFee={percentageFee}
+        percentOriginFee={percentOriginFee}
+      />
       {isLoading ? (
         <Stack py="$1">
           <Skeleton h="$3" w="$24" />

--- a/packages/kit/src/views/Swap/components/SwapServiceFeeOverview.tsx
+++ b/packages/kit/src/views/Swap/components/SwapServiceFeeOverview.tsx
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
 import { Icon, Popover, SizableText, Stack } from '@onekeyhq/components';
@@ -6,10 +7,17 @@ import { swapServiceFeeDefault } from '@onekeyhq/shared/types/swap/SwapProvider.
 
 export function SwapServiceFeeOverview({
   percentageFee,
+  percentOriginFee,
 }: {
   percentageFee?: number;
+  percentOriginFee?: number;
 }) {
   const intl = useIntl();
+  const displayFee =
+    typeof percentageFee === 'number' &&
+    new BigNumber(percentageFee).lt(percentOriginFee ?? swapServiceFeeDefault)
+      ? (percentOriginFee ?? swapServiceFeeDefault)
+      : (percentageFee ?? swapServiceFeeDefault);
   return (
     <Popover
       title={intl.formatMessage({
@@ -31,7 +39,7 @@ export function SwapServiceFeeOverview({
                 id: ETranslations.provider_popover_onekey_fee_content,
               },
               {
-                number: `${percentageFee ?? swapServiceFeeDefault}%`,
+                number: `${displayFee}%`,
               },
             )}
           </SizableText>

--- a/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts
@@ -83,7 +83,7 @@ export function useSwapIncognitoRecipientInput({
   const [queryResult, setQueryResult] = useState<IAddressQueryResult>({});
   const [loading, setLoading] = useState(false);
   const textRef = useRef('');
-  const skipExternalSyncRef = useRef(false);
+  const skipExternalSyncRef = useRef<string | null>(null);
   const validationSessionIdRef = useRef(0);
   const validationContextRef = useRef<IAddressValidationContext>({
     accountId,
@@ -112,7 +112,7 @@ export function useSwapIncognitoRecipientInput({
 
   const syncRecipientAddress = useCallback(
     (nextAddress?: string) => {
-      skipExternalSyncRef.current = true;
+      skipExternalSyncRef.current = nextAddress ?? '';
 
       setSettings((settings) => ({
         ...settings,
@@ -274,10 +274,11 @@ export function useSwapIncognitoRecipientInput({
     }
 
     const nextText = swapToAnotherAccountSwitchOn && address ? address : '';
+    const skipExternalSyncText = skipExternalSyncRef.current;
 
-    if (skipExternalSyncRef.current) {
-      skipExternalSyncRef.current = false;
-      if (textRef.current === nextText) {
+    if (skipExternalSyncText !== null) {
+      skipExternalSyncRef.current = null;
+      if (skipExternalSyncText === nextText) {
         return;
       }
     }

--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -180,7 +180,7 @@ const SwapActionsState = ({
   const shouldShowRecipient = useMemo(
     () =>
       !!(
-        !swapIncognitoMode &&
+        (swapTypeSwitch === ESwapTabSwitchType.LIMIT || !swapIncognitoMode) &&
         swapEnableRecipientAddress &&
         swapProviderSupportReceiveAddress &&
         fromToken &&
@@ -191,6 +191,7 @@ const SwapActionsState = ({
       swapEnableRecipientAddress,
       swapProviderSupportReceiveAddress,
       fromToken,
+      swapTypeSwitch,
       toToken,
     ],
   );

--- a/packages/kit/src/views/Swap/pages/components/SwapBridgeMdContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapBridgeMdContainer.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useRef } from 'react';
 
-import { type ScrollView as ScrollViewNative } from 'react-native';
-
 import {
   EPageType,
-  ScrollView,
+  KEYBOARD_AWARE_SCROLL_BOTTOM_OFFSET,
+  Keyboard,
   YStack,
   useScrollContentTabBarOffset,
 } from '@onekeyhq/components';
@@ -26,6 +25,8 @@ import SwapProTabListContainer from './SwapProTabListContainer';
 import SwapQuoteInput from './SwapQuoteInput';
 import SwapQuoteResult from './SwapQuoteResult';
 import SwapTipsContainer from './SwapTipsContainer';
+
+import type { KeyboardAwareScrollViewRef } from 'react-native-keyboard-controller';
 
 interface ISwapBridgeMdContainerProps {
   pageType: EPageType;
@@ -82,7 +83,8 @@ const SwapBridgeMdContainer = ({
   supportNetworksList,
 }: ISwapBridgeMdContainerProps) => {
   const tabBarHeight = useScrollContentTabBarOffset();
-  const scrollViewRef = useRef<ScrollViewNative>(null);
+  const scrollViewRef = useRef<KeyboardAwareScrollViewRef>(null);
+  const bottomOffset = KEYBOARD_AWARE_SCROLL_BOTTOM_OFFSET + 60;
   const onSearchClickCallback = useCallback(() => {
     onSelectToken(ESwapDirectionType.FROM);
     scrollViewRef.current?.scrollTo({
@@ -101,12 +103,13 @@ const SwapBridgeMdContainer = ({
     [onTokenPress],
   );
   return (
-    <ScrollView
+    <Keyboard.AwareScrollView
       keyboardShouldPersistTaps="handled"
       keyboardDismissMode="on-drag"
       ref={scrollViewRef}
       showsVerticalScrollIndicator={false}
       contentContainerStyle={{ paddingBottom: tabBarHeight }}
+      bottomOffset={bottomOffset}
     >
       <SwapTipsContainer pageType={swapTipsPageType} />
       <YStack
@@ -156,7 +159,7 @@ const SwapBridgeMdContainer = ({
           />
         ) : null}
       </YStack>
-    </ScrollView>
+    </Keyboard.AwareScrollView>
   );
 };
 

--- a/packages/kit/src/views/Swap/pages/components/SwapOldSwapBridgeLimitContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapOldSwapBridgeLimitContainer.tsx
@@ -2,10 +2,11 @@ import type { ReactNode } from 'react';
 import { useRef } from 'react';
 
 import { useIntl } from 'react-intl';
-import { type ScrollView as ScrollViewNative } from 'react-native';
 
 import {
   EPageType,
+  KEYBOARD_AWARE_SCROLL_BOTTOM_OFFSET,
+  Keyboard,
   ScrollView,
   SizableText,
   XStack,
@@ -35,6 +36,8 @@ import SwapPendingHistoryListComponent from './SwapPendingHistoryList';
 import SwapQuoteInput from './SwapQuoteInput';
 import SwapQuoteResult from './SwapQuoteResult';
 import SwapTipsContainer from './SwapTipsContainer';
+
+import type { KeyboardAwareScrollViewRef } from 'react-native-keyboard-controller';
 
 interface ISwapOldSwapBridgeLimitContainerProps {
   pageType?: EPageType;
@@ -90,7 +93,8 @@ const SwapOldSwapBridgeLimitContainer = ({
   swapRecentTokenPairs,
   headerContent,
 }: ISwapOldSwapBridgeLimitContainerProps) => {
-  const scrollViewRef = useRef<ScrollViewNative>(null);
+  const scrollViewRef = useRef<KeyboardAwareScrollViewRef>(null);
+  const bottomOffset = KEYBOARD_AWARE_SCROLL_BOTTOM_OFFSET + 60;
   const { gtLg } = useMedia();
   const intl = useIntl();
 
@@ -338,10 +342,11 @@ const SwapOldSwapBridgeLimitContainer = ({
   }
 
   return (
-    <ScrollView
+    <Keyboard.AwareScrollView
       keyboardShouldPersistTaps="handled"
       keyboardDismissMode="on-drag"
       ref={scrollViewRef}
+      bottomOffset={bottomOffset}
     >
       <SwapTipsContainer pageType={pageType} />
       {headerContent ? (
@@ -350,7 +355,7 @@ const SwapOldSwapBridgeLimitContainer = ({
         </YStack>
       ) : null}
       {mainContent}
-    </ScrollView>
+    </Keyboard.AwareScrollView>
   );
 };
 

--- a/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
@@ -236,6 +236,7 @@ const SwapQuoteResult = ({
             toToken={toToken}
             showLock={!!quoteResult?.allowanceResult}
             percentageFee={quoteResult?.fee?.percentageFee}
+            percentOriginFee={quoteResult?.fee?.percentOriginFee}
             onPress={
               quoteResult?.info.provider &&
               swapQuoteList?.length > 1 &&
@@ -324,6 +325,7 @@ const SwapQuoteResult = ({
                   toToken={toToken}
                   showLock={!!quoteResult?.allowanceResult}
                   percentageFee={quoteResult?.fee?.percentageFee}
+                  percentOriginFee={quoteResult?.fee?.percentOriginFee}
                   onPress={
                     quoteResult?.info.provider && onOpenProviderList
                       ? () => {

--- a/packages/kit/src/views/Swap/pages/components/SwapSwapMbContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapSwapMbContainer.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useRef } from 'react';
 
-import { type ScrollView as ScrollViewNative } from 'react-native';
-
 import {
   EPageType,
-  ScrollView,
+  KEYBOARD_AWARE_SCROLL_BOTTOM_OFFSET,
+  Keyboard,
   YStack,
   useScrollContentTabBarOffset,
 } from '@onekeyhq/components';
@@ -26,6 +25,8 @@ import SwapProTabListContainer from './SwapProTabListContainer';
 import SwapQuoteInput from './SwapQuoteInput';
 import SwapQuoteResult from './SwapQuoteResult';
 import SwapTipsContainer from './SwapTipsContainer';
+
+import type { KeyboardAwareScrollViewRef } from 'react-native-keyboard-controller';
 
 interface ISwapSwapMbContainerProps {
   pageType: EPageType;
@@ -82,7 +83,8 @@ const SwapSwapMbContainer = ({
   supportNetworksList,
 }: ISwapSwapMbContainerProps) => {
   const tabBarHeight = useScrollContentTabBarOffset();
-  const scrollViewRef = useRef<ScrollViewNative>(null);
+  const scrollViewRef = useRef<KeyboardAwareScrollViewRef>(null);
+  const bottomOffset = KEYBOARD_AWARE_SCROLL_BOTTOM_OFFSET + 60;
   const onSearchClickCallback = useCallback(() => {
     onSelectToken(ESwapDirectionType.FROM);
     scrollViewRef.current?.scrollTo({
@@ -101,12 +103,13 @@ const SwapSwapMbContainer = ({
     [onTokenPress],
   );
   return (
-    <ScrollView
+    <Keyboard.AwareScrollView
       keyboardShouldPersistTaps="handled"
       keyboardDismissMode="on-drag"
       ref={scrollViewRef}
       showsVerticalScrollIndicator={false}
       contentContainerStyle={{ paddingBottom: tabBarHeight }}
+      bottomOffset={bottomOffset}
     >
       <SwapTipsContainer pageType={swapTipsPageType} />
       <YStack
@@ -156,7 +159,7 @@ const SwapSwapMbContainer = ({
           />
         ) : null}
       </YStack>
-    </ScrollView>
+    </Keyboard.AwareScrollView>
   );
 };
 

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -639,6 +639,7 @@ export interface IQuoteResultFeeOtherFeeInfo {
 }
 export interface IFetchQuoteFee {
   percentageFee: number; // oneKey fee percentage
+  percentOriginFee?: number;
   protocolFees?: number;
   estimatedFeeFiatValue?: number;
   otherFeeInfos?: IQuoteResultFeeOtherFeeInfo[];


### PR DESCRIPTION
## Summary
- use backend `percentOriginFee` as the original service fee in swap confirm and overview copy when available, while keeping the `0.3%` fallback for legacy responses
- switch the mobile swap containers to `Keyboard.AwareScrollView` with a bottom offset so recipient-related inputs are not covered by the keyboard
- preserve manually edited recipient addresses by skipping external recipient sync only when it matches the exact synced value
- keep the recipient entry visible for limit swap when the provider supports receive addresses, even in incognito mode

## Issue Scope
- OK-53072: show the backend-provided original service fee in swap confirm instead of always falling back to `0.3%`
- OK-53209: resolve keyboard overlap on swap recipient-related inputs
- OK-53214: preserve recipient edits during recipient address sync
- OK-53216: show the limit recipient entry when the flow supports a custom receive address

## Design Decisions
- keep `percentOriginFee` optional in the shared fee type so older backend payloads remain compatible
- limit the keyboard-aware scroll changes to the mobile swap containers that host the affected inputs
- make the recipient sync guard value-aware instead of boolean-based so user edits are not discarded by unrelated external updates
- only relax recipient visibility rules for limit swap, preserving the existing gating for other swap modes

## Risk Assessment
- **Risk Level**: Low to Medium
- **Affected Platforms**: Mobile / Extension / Desktop / Web
- **Risk Areas**: Swap recipient input flow, limit recipient visibility, and swap confirm service-fee presentation

## Test plan
- [x] Run `yarn lint:staged`
- [x] Run `yarn tsc:staged`
- [ ] Verify a discounted swap confirm flow shows the backend `percentOriginFee`
- [ ] Verify a legacy response without `percentOriginFee` still falls back to `0.3%`
- [ ] Verify recipient input stays visible above the keyboard on the affected mobile swap pages
- [ ] Verify manual recipient edits are preserved during quote/address sync updates
- [ ] Verify limit swap still shows the recipient entry when receive-address support is enabled

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
