### PR TITLE
feat(perp): improve spot market metadata handling

### DIFF
--- a/apps/mobile/ios/vendor/TOCropViewController.podspec
+++ b/apps/mobile/ios/vendor/TOCropViewController.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name     = 'TOCropViewController'
+  s.version  = '2.8.1'
+  s.license  =  { :type => 'MIT', :file => 'native-views/TOCropViewController/LICENSE' }
+  s.summary  = 'A view controller that enables cropping and rotation of UIImage objects.'
+  s.homepage = 'https://github.com/OneKeyHQ/app-modules'
+  s.author   = 'Tim Oliver'
+  s.source   = { :git => 'https://github.com/OneKeyHQ/app-modules.git', :commit => '2ba1a0b' }
+  s.platform = :ios, '12.0'
+  s.source_files = 'native-views/TOCropViewController/Objective-C/TOCropViewController/**/*.{h,m}'
+  s.exclude_files = 'native-views/TOCropViewController/Objective-C/TOCropViewController/include/**/*.h'
+  s.resource_bundles = {
+    'TOCropViewControllerBundle' => ['native-views/TOCropViewController/Objective-C/TOCropViewController/**/*.{lproj,xcprivacy}']
+  }
+  s.requires_arc = true
+end

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPerp.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPerp.ts
@@ -7,6 +7,8 @@ import type { ITokenSearchAliases } from '@onekeyhq/shared/src/utils/perpsUtils'
 import type {
   IMarginTableMap as IMarginTablesMap,
   IPerpsUniverse,
+  ISpotToken,
+  ISpotUniverse,
 } from '@onekeyhq/shared/types/hyperliquid/sdk';
 import type {
   IHyperLiquidErrorLocaleItem,
@@ -64,6 +66,8 @@ export interface ISimpleDbPerpData {
   perpsSharePromptShown?: boolean; // whether the once-per-app Perps share prompt has been shown
   tokenSearchAliases?: ITokenSearchAliases; // token search aliases from server
   tokenSelectorTabs?: IPerpDynamicTab[]; // dynamic token selector tabs from server
+  spotTokens?: ISpotToken[]; // all spot tokens metadata
+  spotUniverses?: ISpotUniverse[]; // spot trading pairs with resolved names
 }
 
 export class SimpleDbEntityPerp extends SimpleDbEntityBase<ISimpleDbPerpData> {
@@ -374,6 +378,35 @@ export class SimpleDbEntityPerp extends SimpleDbEntityBase<ISimpleDbPerpData> {
       (prev): ISimpleDbPerpData => ({
         ...prev,
         perpsSharePromptShown: shown,
+      }),
+    );
+  }
+
+  @backgroundMethod()
+  async getSpotMeta(): Promise<{
+    tokens: ISpotToken[];
+    universes: ISpotUniverse[];
+  }> {
+    const config = await this.getPerpData();
+    return {
+      tokens: config.spotTokens || [],
+      universes: config.spotUniverses || [],
+    };
+  }
+
+  @backgroundMethod()
+  async setSpotMeta({
+    tokens,
+    universes,
+  }: {
+    tokens: ISpotToken[];
+    universes: ISpotUniverse[];
+  }) {
+    await this.setPerpData(
+      (prev): ISimpleDbPerpData => ({
+        ...prev,
+        spotTokens: tokens,
+        spotUniverses: universes,
       }),
     );
   }

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -1071,24 +1071,22 @@ export default class ServiceHyperliquid extends ServiceBase {
     const meta = result[0];
     if (meta?.tokens && meta?.universe) {
       const tokens = meta.tokens;
-      const universes: ISpotUniverse[] = meta.universe.map(
-        (item) => {
-          const baseTokenIdx = item.tokens[0];
-          const quoteTokenIdx = item.tokens[1];
-          const baseToken = tokens[baseTokenIdx];
-          const quoteToken = tokens[quoteTokenIdx];
-          const baseName = baseToken?.name ?? '';
-          const quoteName = quoteToken?.name ?? 'USDC';
-          return {
-            ...item,
-            assetId: SPOT_ASSET_ID_OFFSET + item.index,
-            baseName,
-            quoteName,
-            displayName: perpsUtils.getSpotTokenDisplayName(baseName),
-            baseSzDecimals: baseToken?.szDecimals ?? 0,
-          };
-        },
-      );
+      const universes: ISpotUniverse[] = meta.universe.map((item) => {
+        const baseTokenIdx = item.tokens[0];
+        const quoteTokenIdx = item.tokens[1];
+        const baseToken = tokens[baseTokenIdx];
+        const quoteToken = tokens[quoteTokenIdx];
+        const baseName = baseToken?.name ?? '';
+        const quoteName = quoteToken?.name ?? 'USDC';
+        return {
+          ...item,
+          assetId: SPOT_ASSET_ID_OFFSET + item.index,
+          baseName,
+          quoteName,
+          displayName: perpsUtils.getSpotTokenDisplayName(baseName),
+          baseSzDecimals: baseToken?.szDecimals ?? 0,
+        };
+      });
       await this.backgroundApi.simpleDb.perp.setSpotMeta({
         tokens,
         universes,
@@ -1344,27 +1342,29 @@ export default class ServiceHyperliquid extends ServiceBase {
         }),
       );
 
-      // TODO reset exchange client if account not exists, or address not exists
-      await this.exchangeService.setup({
-        userAddress: accountAddress,
-        userAccountId: selectedAccount.accountId ?? undefined,
-      });
-
       if (!accountAddress) {
         throw new OneKeyLocalError(
           'Check perps account status ERROR: Account address is required',
         );
       }
 
+      // Run exchange client setup and activation check in parallel —
+      // setup is local-only, userRole uses the info client (independent).
       let isActivated = false;
       if (hyperLiquidCache?.activatedUser?.[accountAddress] === true) {
         isActivated = true;
       }
-      if (!isActivated) {
-        const userRole = await infoClient.userRole({
-          user: accountAddress,
-        });
-        isActivated = userRole.role !== 'missing';
+      const [, userRoleResult] = await Promise.all([
+        this.exchangeService.setup({
+          userAddress: accountAddress,
+          userAccountId: selectedAccount.accountId ?? undefined,
+        }),
+        !isActivated
+          ? infoClient.userRole({ user: accountAddress })
+          : Promise.resolve(null),
+      ]);
+      if (!isActivated && userRoleResult) {
+        isActivated = userRoleResult.role !== 'missing';
       }
       if (!isActivated) {
         statusDetails.activatedOk = false;
@@ -1388,19 +1388,21 @@ export default class ServiceHyperliquid extends ServiceBase {
         // So account value displays correctly before enable trading
         void this.fetchUserAbstraction(accountAddress);
 
-        // Builder fee must be approved before agent setup
-        await this.checkBuilderFeeStatus({
-          accountAddress,
-          accountId: selectedAccount.accountId,
-          isEnableTradingTrigger,
-          statusDetails,
-        });
-
-        const isRebateBound =
-          await this.checkInternalRebateBindingStatusWithCache({
+        // Builder fee check and rebate binding check are independent — run in parallel.
+        // Both must complete before checkAgentStatus (builder fee must be approved,
+        // and credentials may be cleared based on rebate result).
+        const [, isRebateBound] = await Promise.all([
+          this.checkBuilderFeeStatus({
+            accountAddress,
+            accountId: selectedAccount.accountId,
+            isEnableTradingTrigger,
+            statusDetails,
+          }),
+          this.checkInternalRebateBindingStatusWithCache({
             accountId: selectedAccount.accountId,
             accountAddress,
-          });
+          }),
+        ]);
 
         // Clear local credentials to force new agent creation for rebate binding
         if (!isRebateBound) {

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -1109,7 +1109,7 @@ export default class ServiceHyperliquid extends ServiceBase {
           const quoteName = quoteToken?.name ?? 'USDC';
           return {
             ...item,
-            assetId: item.index,
+            assetId: 10_000 + item.index,
             baseName,
             quoteName,
             displayName: perpsUtils.getSpotTokenDisplayName(baseName),

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -704,6 +704,12 @@ export default class ServiceHyperliquid extends ServiceBase {
 
   async updateActiveSpotAssetCtx(data: IWsActiveSpotAssetCtx | undefined) {
     const activeSpotAsset = await spotActiveAssetAtom.get();
+    console.log('updateActiveSpotAssetCtx__debug', {
+      activeCoin: activeSpotAsset?.coin,
+      dataCoin: data?.coin,
+      hasCtx: !!data?.ctx,
+      match: activeSpotAsset?.coin === data?.coin,
+    });
     if (activeSpotAsset?.coin === data?.coin && data?.coin && data?.ctx) {
       await spotActiveAssetCtxAtom.set(
         (_prev): ISpotActiveAssetCtxAtom => ({

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -1199,6 +1199,9 @@ export default class ServiceHyperliquid extends ServiceBase {
 
     await perpsAbstractionModeAtom.set(undefined);
     await perpsSpotBalancesAtom.set(undefined);
+    // Also reset the UI-facing spot balances atom so stale balances from
+    // the previous account don't flash before the new SPOT_STATE arrives.
+    await spotBalancesAtom.set({ balances: [], isLoaded: false });
     await perpsActiveAccountAtom.set(perpsAccount);
     return perpsAccount;
   }

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -1086,6 +1086,40 @@ export default class ServiceHyperliquid extends ServiceBase {
     return this.backgroundApi.simpleDb.perp.getSpotMeta();
   }
 
+  @backgroundMethod()
+  async refreshSpotMeta() {
+    const { infoClient } = hyperLiquidApiClients;
+    const result = await infoClient.spotMetaAndAssetCtxs();
+    const meta = result[0];
+    if (meta?.tokens && meta?.universe) {
+      const tokens = meta.tokens;
+      const universes: ISpotUniverse[] = meta.universe.map(
+        (item) => {
+          const baseTokenIdx = item.tokens[0];
+          const quoteTokenIdx = item.tokens[1];
+          const baseToken = tokens[baseTokenIdx];
+          const quoteToken = tokens[quoteTokenIdx];
+          const baseName = baseToken?.name ?? '';
+          const quoteName = quoteToken?.name ?? 'USDC';
+          return {
+            ...item,
+            assetId: item.index,
+            baseName,
+            quoteName,
+            displayName: perpsUtils.getSpotTokenDisplayName(baseName),
+            baseSzDecimals: baseToken?.szDecimals ?? 0,
+          };
+        },
+      );
+      await this.backgroundApi.simpleDb.perp.setSpotMeta({
+        tokens,
+        universes,
+      });
+      // Rebuild cached mappings from fresh data
+      this._rebuildSpotMappings(universes);
+    }
+  }
+
   hideSelectAccountLoadingTimer: ReturnType<typeof setTimeout> | undefined;
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -32,6 +32,7 @@ import type { IApiClientResponse } from '@onekeyhq/shared/types/endpoint';
 import { EServiceEndpointEnum } from '@onekeyhq/shared/types/endpoint';
 import { EHyperLiquidAbstractionMode } from '@onekeyhq/shared/types/hyperliquid';
 import {
+  SPOT_ASSET_ID_OFFSET,
   XYZ_ASSET_ID_OFFSET,
   XYZ_DEX_PREFIX,
 } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
@@ -1103,7 +1104,7 @@ export default class ServiceHyperliquid extends ServiceBase {
           const quoteName = quoteToken?.name ?? 'USDC';
           return {
             ...item,
-            assetId: 10_000 + item.index,
+            assetId: SPOT_ASSET_ID_OFFSET + item.index,
             baseName,
             quoteName,
             displayName: perpsUtils.getSpotTokenDisplayName(baseName),

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -32,6 +32,7 @@ import type { IApiClientResponse } from '@onekeyhq/shared/types/endpoint';
 import { EServiceEndpointEnum } from '@onekeyhq/shared/types/endpoint';
 import { EHyperLiquidAbstractionMode } from '@onekeyhq/shared/types/hyperliquid';
 import {
+  CACHE_TIME_QUANTIZE_MS,
   SPOT_ASSET_ID_OFFSET,
   XYZ_ASSET_ID_OFFSET,
   XYZ_DEX_PREFIX,
@@ -120,10 +121,7 @@ export default class ServiceHyperliquid extends ServiceBase {
 
   public maxBuilderFee: number = FALLBACK_MAX_BUILDER_FEE;
 
-  // Throttled spot price atom writer — both updateSpotAssetCtxsMap and
-  // extractSpotPricesFromAllMids feed into this to limit re-renders
-  // Authoritative spot price cache — avoids async atom reads in the hot path.
-  // Written to atom on a throttled schedule.
+  // Avoids async atom reads in the hot path — written to atom on a throttled schedule
   private _spotPriceCache: Record<string, ISpotAssetCtxEntry> = {};
 
   private _spotPriceDirty = false;
@@ -131,7 +129,7 @@ export default class ServiceHyperliquid extends ServiceBase {
   private _spotPriceFlushTimer: ReturnType<typeof setTimeout> | null = null;
 
   private _flushSpotPrices(map: Record<string, ISpotAssetCtxEntry>) {
-    // Field-level merge into cache: allMids only sets markPx, spotAssetCtxs sets full entry
+    // allMids only sets markPx, spotAssetCtxs sets full entry — merge so neither overwrites the other
     for (const [key, entry] of Object.entries(map)) {
       const existing = this._spotPriceCache[key];
       if (existing) {
@@ -143,10 +141,8 @@ export default class ServiceHyperliquid extends ServiceBase {
     this._spotPriceDirty = true;
 
     if (!this._spotPriceFlushTimer) {
-      // Leading edge: flush immediately
       void spotAssetCtxsMapAtom.set({ ...this._spotPriceCache });
       this._spotPriceDirty = false;
-      // Then throttle subsequent flushes
       this._spotPriceFlushTimer = setTimeout(() => {
         this._spotPriceFlushTimer = null;
         if (this._spotPriceDirty) {
@@ -157,16 +153,11 @@ export default class ServiceHyperliquid extends ServiceBase {
     }
   }
 
-  // Cached spot symbol mappings — rebuilt on refreshSpotMeta(),
-  // reused by WS handlers and future trading logic without hitting SimpleDb
+  // Cached in-memory so WS handlers don't need async SimpleDb reads on the hot path
   private _spotMappings: {
-    // pair name (@107, PURR/USDC) → base token name (HYPE, PURR)
     pairToBaseName: Record<string, string>;
-    // base token name → spot asset ID (10000 + index)
     baseNameToAssetId: Record<string, number>;
-    // base token name → size decimals for order sizing
     baseNameToSzDecimals: Record<string, number>;
-    // base token name → pair name (for subscription coin params)
     baseNameToPairName: Record<string, string>;
   } = {
     pairToBaseName: {},
@@ -433,14 +424,13 @@ export default class ServiceHyperliquid extends ServiceBase {
     return this._updatePerpsConfigByServerWithCache();
   }
 
-  // TODO: Change maxAge back to { hour: 1 } before production release
   _updatePerpsConfigByServerWithCache = cacheUtils.memoizee(
     async () => {
       return this.updatePerpsConfigByServer();
     },
     {
       max: 20,
-      maxAge: 0,
+      maxAge: timerUtils.getTimeDurationMs({ hour: 1 }),
       promise: true,
     },
   );
@@ -506,7 +496,10 @@ export default class ServiceHyperliquid extends ServiceBase {
       return current.fills;
     }
 
-    const now = Date.now();
+    // Quantize to 10-second boundary so near-simultaneous callers
+    // produce identical memoizee keys and share a single request.
+    const now =
+      Math.floor(Date.now() / CACHE_TIME_QUANTIZE_MS) * CACHE_TIME_QUANTIZE_MS;
     const historyDuration = timerUtils.getTimeDurationMs({ year: 2 });
     const twoYearsAgo = now - historyDuration;
 
@@ -706,8 +699,6 @@ export default class ServiceHyperliquid extends ServiceBase {
     // to a brief flash of empty state while waiting for the new WS update.
   }
 
-  // Called from spotAssetCtxs WS — provides full context for token selector
-  // Key is pair name (@107, PURR/USDC) matching universe.name
   async updateSpotAssetCtxsMap(data: IWsSpotAssetCtxs) {
     if (!Array.isArray(data) || data.length === 0) return;
 
@@ -725,7 +716,6 @@ export default class ServiceHyperliquid extends ServiceBase {
     this._flushSpotPrices(map);
   }
 
-  // Called from allMids WS — updates only markPx, keyed by pair name (@107, PURR/USDC)
   async extractSpotPricesFromAllMids(mids: Record<string, string>) {
     const map: Record<string, ISpotAssetCtxEntry> = {};
     for (const [coin, price] of Object.entries(mids)) {
@@ -917,7 +907,6 @@ export default class ServiceHyperliquid extends ServiceBase {
 
     const balances = spotStateData?.spotState?.balances || [];
 
-    // Write to standalone spot balances atom (spot trading UI)
     await spotBalancesAtom.set({ balances, isLoaded: true });
 
     // Calculate total USD value from spot balances
@@ -1035,7 +1024,7 @@ export default class ServiceHyperliquid extends ServiceBase {
       baseNameToPairName,
     };
 
-    // Write display map atom so UI can resolve @N → display name synchronously
+    // UI needs synchronous @N → display name resolution (no async SimpleDb lookup)
     const displayMap: Record<string, string> = {};
     for (const u of universes) {
       displayMap[u.name] = perpsUtils.getSpotTokenDisplayName(u.baseName);
@@ -1043,7 +1032,7 @@ export default class ServiceHyperliquid extends ServiceBase {
     void spotPairDisplayMapAtom.set(displayMap);
   }
 
-  // Lazily rebuild from SimpleDb if service was restarted without refreshSpotMeta
+  // Service may restart without refreshSpotMeta — rebuild from SimpleDb on first access
   private async _ensureSpotMappings() {
     if (Object.keys(this._spotMappings.pairToBaseName).length > 0) return;
     const { universes } = await this.backgroundApi.simpleDb.perp.getSpotMeta();
@@ -1104,7 +1093,6 @@ export default class ServiceHyperliquid extends ServiceBase {
         tokens,
         universes,
       });
-      // Rebuild cached mappings from fresh data
       this._rebuildSpotMappings(universes);
     }
   }
@@ -1446,26 +1434,6 @@ export default class ServiceHyperliquid extends ServiceBase {
             agentCredential,
           });
 
-          void (async () => {
-            const cacheKey = [
-              agentCredential.userAddress.toLowerCase(),
-              agentCredential.agentAddress.toLowerCase(),
-              agentCredential.agentName,
-            ].join('-');
-            if (!hyperLiquidCache?.referrerCodeSetDone?.[cacheKey]) {
-              const { referralCode } =
-                await this.backgroundApi.simpleDb.perp.getPerpData();
-              try {
-                // referrer code can be approved by agent
-                await this.exchangeService.setReferrerCode({
-                  code: referralCode || HYPERLIQUID_REFERRAL_CODE,
-                });
-              } finally {
-                hyperLiquidCache.referrerCodeSetDone[cacheKey] = true;
-              }
-            }
-          })();
-
           statusDetails.internalRebateBoundOk = true;
           statusDetails.referralCodeOk = true;
 
@@ -1509,6 +1477,30 @@ export default class ServiceHyperliquid extends ServiceBase {
           }),
         );
       }, 0);
+    }
+
+    // Deferred: bind referral code after loading resolves.
+    // Non-blocking, non-critical — avoids bandwidth contention during critical path.
+    if (agentCredential) {
+      void (async () => {
+        const cacheKey = [
+          agentCredential.userAddress.toLowerCase(),
+          agentCredential.agentAddress.toLowerCase(),
+          agentCredential.agentName,
+        ].join('-');
+        if (!hyperLiquidCache?.referrerCodeSetDone?.[cacheKey]) {
+          const { referralCode } =
+            await this.backgroundApi.simpleDb.perp.getPerpData();
+          try {
+            // referrer code can be approved by agent
+            await this.exchangeService.setReferrerCode({
+              code: referralCode || HYPERLIQUID_REFERRAL_CODE,
+            });
+          } finally {
+            hyperLiquidCache.referrerCodeSetDone[cacheKey] = true;
+          }
+        }
+      })();
     }
   }
 

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -45,10 +45,13 @@ import type {
   IPerpsActiveAssetData,
   IPerpsActiveAssetDataRaw,
   IPerpsUniverse,
+  ISpotUniverse,
   IUserFillsByTimeParameters,
   IUserFillsParameters,
   IWsActiveAssetCtx,
+  IWsActiveSpotAssetCtx,
   IWsAllDexsClearinghouseState,
+  IWsSpotAssetCtxs,
   IWsSpotState,
   IWsWebData2,
 } from '@onekeyhq/shared/types/hyperliquid/sdk';
@@ -73,7 +76,16 @@ import {
   perpsLastUsedLeverageAtom,
   perpsSpotBalancesAtom,
   perpsTradesHistoryDataAtom,
+  spotActiveAssetAtom,
+  spotActiveAssetCtxAtom,
+  spotAssetCtxsMapAtom,
+  spotBalancesAtom,
+  spotPairDisplayMapAtom,
 } from '../../states/jotai/atoms';
+import type {
+  ISpotActiveAssetCtxAtom,
+  ISpotAssetCtxEntry,
+} from '../../states/jotai/atoms/spot';
 import ServiceBase from '../ServiceBase';
 
 import { hyperLiquidApiClients } from './hyperLiquidApiClients';
@@ -106,6 +118,61 @@ export default class ServiceHyperliquid extends ServiceBase {
   public builderAddress: IHex = FALLBACK_BUILDER_ADDRESS;
 
   public maxBuilderFee: number = FALLBACK_MAX_BUILDER_FEE;
+
+  // Throttled spot price atom writer — both updateSpotAssetCtxsMap and
+  // extractSpotPricesFromAllMids feed into this to limit re-renders
+  // Authoritative spot price cache — avoids async atom reads in the hot path.
+  // Written to atom on a throttled schedule.
+  private _spotPriceCache: Record<string, ISpotAssetCtxEntry> = {};
+
+  private _spotPriceDirty = false;
+
+  private _spotPriceFlushTimer: ReturnType<typeof setTimeout> | null = null;
+
+  private _flushSpotPrices(map: Record<string, ISpotAssetCtxEntry>) {
+    // Field-level merge into cache: allMids only sets markPx, spotAssetCtxs sets full entry
+    for (const [key, entry] of Object.entries(map)) {
+      const existing = this._spotPriceCache[key];
+      if (existing) {
+        this._spotPriceCache[key] = { ...existing, ...entry };
+      } else {
+        this._spotPriceCache[key] = entry;
+      }
+    }
+    this._spotPriceDirty = true;
+
+    if (!this._spotPriceFlushTimer) {
+      // Leading edge: flush immediately
+      void spotAssetCtxsMapAtom.set({ ...this._spotPriceCache });
+      this._spotPriceDirty = false;
+      // Then throttle subsequent flushes
+      this._spotPriceFlushTimer = setTimeout(() => {
+        this._spotPriceFlushTimer = null;
+        if (this._spotPriceDirty) {
+          void spotAssetCtxsMapAtom.set({ ...this._spotPriceCache });
+          this._spotPriceDirty = false;
+        }
+      }, 1000);
+    }
+  }
+
+  // Cached spot symbol mappings — rebuilt on refreshSpotMeta(),
+  // reused by WS handlers and future trading logic without hitting SimpleDb
+  private _spotMappings: {
+    // pair name (@107, PURR/USDC) → base token name (HYPE, PURR)
+    pairToBaseName: Record<string, string>;
+    // base token name → spot asset ID (10000 + index)
+    baseNameToAssetId: Record<string, number>;
+    // base token name → size decimals for order sizing
+    baseNameToSzDecimals: Record<string, number>;
+    // base token name → pair name (for subscription coin params)
+    baseNameToPairName: Record<string, string>;
+  } = {
+    pairToBaseName: {},
+    baseNameToAssetId: {},
+    baseNameToSzDecimals: {},
+    baseNameToPairName: {},
+  };
 
   constructor({ backgroundApi }: { backgroundApi: any }) {
     super({ backgroundApi });
@@ -561,15 +628,36 @@ export default class ServiceHyperliquid extends ServiceBase {
   async getSymbolsMetaMap({ coins }: { coins: string[] }) {
     const { universesByDex, marginTablesMapByDex } =
       await this.getTradingUniverse();
+    const { universes: spotUniverses } =
+      await this.backgroundApi.simpleDb.perp.getSpotMeta();
     const map: Partial<{
       [coin: string]: {
         coin: string;
         assetId: number;
         universe: IPerpsUniverse | undefined;
         marginTable: IMarginTable | undefined;
+        isSpot?: boolean;
+        spotUniverse?: ISpotUniverse;
       };
     }> = {};
     coins.forEach((coin) => {
+      if (perpsUtils.isSpotInstrument(coin)) {
+        const spotUni = spotUniverses.find(
+          (item: ISpotUniverse) => item.name === coin,
+        );
+        if (isNil(spotUni?.assetId)) {
+          throw new OneKeyLocalError(`Asset id not found for coin: ${coin}`);
+        }
+        map[coin] = {
+          assetId: spotUni.assetId,
+          coin,
+          universe: undefined,
+          marginTable: undefined,
+          isSpot: true,
+          spotUniverse: spotUni,
+        };
+        return;
+      }
       const dexIndex = this.detectDexIndexByCoin(coin);
       const universes = universesByDex?.[dexIndex];
       const marginTables = marginTablesMapByDex?.[dexIndex];
@@ -611,6 +699,53 @@ export default class ServiceHyperliquid extends ServiceBase {
       if (activeAssetCtx?.coin !== activeAsset?.coin) {
         await perpsActiveAssetCtxAtom.set(undefined);
       }
+    }
+  }
+
+  async updateActiveSpotAssetCtx(data: IWsActiveSpotAssetCtx | undefined) {
+    const activeSpotAsset = await spotActiveAssetAtom.get();
+    if (activeSpotAsset?.coin === data?.coin && data?.coin && data?.ctx) {
+      await spotActiveAssetCtxAtom.set(
+        (_prev): ISpotActiveAssetCtxAtom => ({
+          coin: data.coin,
+          assetId: activeSpotAsset?.assetId,
+          ctx: perpsUtils.formatSpotAssetCtx(data.ctx),
+        }),
+      );
+    }
+    // Don't clear to undefined — stale data from the previous coin is preferable
+    // to a brief flash of empty state while waiting for the new WS update.
+  }
+
+  // Called from spotAssetCtxs WS — provides full context for token selector
+  // Key is pair name (@107, PURR/USDC) matching universe.name
+  async updateSpotAssetCtxsMap(data: IWsSpotAssetCtxs) {
+    if (!Array.isArray(data) || data.length === 0) return;
+
+    const map: Record<string, ISpotAssetCtxEntry> = {};
+    data.forEach((ctx) => {
+      if (ctx?.coin && ctx?.markPx) {
+        map[ctx.coin] = {
+          markPx: ctx.markPx,
+          prevDayPx: ctx.prevDayPx,
+          dayNtlVlm: ctx.dayNtlVlm,
+          circulatingSupply: ctx.circulatingSupply,
+        };
+      }
+    });
+    this._flushSpotPrices(map);
+  }
+
+  // Called from allMids WS — updates only markPx, keyed by pair name (@107, PURR/USDC)
+  async extractSpotPricesFromAllMids(mids: Record<string, string>) {
+    const map: Record<string, ISpotAssetCtxEntry> = {};
+    for (const [coin, price] of Object.entries(mids)) {
+      if (perpsUtils.isSpotInstrument(coin) && price) {
+        map[coin] = { markPx: price };
+      }
+    }
+    if (Object.keys(map).length > 0) {
+      this._flushSpotPrices(map);
     }
   }
 
@@ -793,6 +928,9 @@ export default class ServiceHyperliquid extends ServiceBase {
 
     const balances = spotStateData?.spotState?.balances || [];
 
+    // Write to standalone spot balances atom (spot trading UI)
+    await spotBalancesAtom.set({ balances, isLoaded: true });
+
     // Calculate total USD value from spot balances
     // Price lookup: USDC (token=0) → 1:1, others → allMids.mids[coin] (perp mid price by token name)
     // Note: allMids["HYPE"]=36.20 is the correct USD price
@@ -886,6 +1024,66 @@ export default class ServiceHyperliquid extends ServiceBase {
       if (!prev || prev.spotTotalUsd !== undefined) return prev;
       return { ...prev, spotTotalUsd: computed };
     });
+  }
+
+  private _rebuildSpotMappings(universes: ISpotUniverse[]) {
+    const pairToBaseName: Record<string, string> = {};
+    const baseNameToAssetId: Record<string, number> = {};
+    const baseNameToSzDecimals: Record<string, number> = {};
+    const baseNameToPairName: Record<string, string> = {};
+
+    for (const u of universes) {
+      pairToBaseName[u.name] = u.baseName;
+      baseNameToAssetId[u.baseName] = u.assetId;
+      baseNameToSzDecimals[u.baseName] = u.baseSzDecimals;
+      baseNameToPairName[u.baseName] = u.name;
+    }
+
+    this._spotMappings = {
+      pairToBaseName,
+      baseNameToAssetId,
+      baseNameToSzDecimals,
+      baseNameToPairName,
+    };
+
+    // Write display map atom so UI can resolve @N → display name synchronously
+    const displayMap: Record<string, string> = {};
+    for (const u of universes) {
+      displayMap[u.name] = perpsUtils.getSpotTokenDisplayName(u.baseName);
+    }
+    void spotPairDisplayMapAtom.set(displayMap);
+  }
+
+  // Lazily rebuild from SimpleDb if service was restarted without refreshSpotMeta
+  private async _ensureSpotMappings() {
+    if (Object.keys(this._spotMappings.pairToBaseName).length > 0) return;
+    const { universes } = await this.backgroundApi.simpleDb.perp.getSpotMeta();
+    if (universes.length > 0) {
+      this._rebuildSpotMappings(universes);
+    }
+  }
+
+  @backgroundMethod()
+  async getSpotAssetId(tokenName: string): Promise<number | undefined> {
+    await this._ensureSpotMappings();
+    return this._spotMappings.baseNameToAssetId[tokenName];
+  }
+
+  @backgroundMethod()
+  async getSpotSzDecimals(tokenName: string): Promise<number | undefined> {
+    await this._ensureSpotMappings();
+    return this._spotMappings.baseNameToSzDecimals[tokenName];
+  }
+
+  @backgroundMethod()
+  async getSpotPairName(tokenName: string): Promise<string | undefined> {
+    await this._ensureSpotMappings();
+    return this._spotMappings.baseNameToPairName[tokenName];
+  }
+
+  @backgroundMethod()
+  async getSpotMeta() {
+    return this.backgroundApi.simpleDb.perp.getSpotMeta();
   }
 
   hideSelectAccountLoadingTimer: ReturnType<typeof setTimeout> | undefined;

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -283,13 +283,6 @@ export default class ServiceHyperliquid extends ServiceBase {
 
     // If configVersion changed, remove all agent credentials
     if (isConfigVersionChanged) {
-      console.log(
-        '[ServiceHyperliquid] configVersion changed:',
-        prevConfigVersion,
-        '->',
-        newConfigVersion,
-        ', removing all agent credentials',
-      );
       defaultLogger.perp.agentLifeCycle.trackReason({
         reason: 'config_version_changed_reset',
         statusDetails: {
@@ -388,12 +381,7 @@ export default class ServiceHyperliquid extends ServiceBase {
 
   async removeAllAgentCredentialsAndResetStatus() {
     // Remove all agent credentials from local db
-    const removedCount = await localDb.removeAllHyperLiquidAgentCredentials();
-    console.log(
-      '[ServiceHyperliquid] Removed',
-      removedCount,
-      'agent credentials',
-    );
+    await localDb.removeAllHyperLiquidAgentCredentials();
 
     // Clear related caches
     this.fetchExtraAgentsWithCache.clear();
@@ -1721,7 +1709,6 @@ export default class ServiceHyperliquid extends ServiceBase {
                   agentName: agentNameToRemove,
                 },
               );
-              console.log('approveAgentResult::', approveAgentResult);
               defaultLogger.perp.agentLifeCycle.trackReason({
                 reason: 'agent_removed_for_slot_recovery',
                 accountAddress,
@@ -1758,11 +1745,10 @@ export default class ServiceHyperliquid extends ServiceBase {
                       (agent) => agent.name === agentNameToRemove,
                     )
                   ) {
-                    console.log('Agent removal confirmed:', agentNameToRemove);
                     break;
                   }
                 } catch (error) {
-                  console.log('Polling request failed:', error);
+                  console.error('Polling request failed:', error);
                 }
 
                 // Wait 500ms before next poll attempt
@@ -1819,7 +1805,6 @@ export default class ServiceHyperliquid extends ServiceBase {
             }
           } catch (error) {
             const requestError = error as IApiRequestError | undefined;
-            console.log('approveAgentError::', requestError);
             const errorResponse = (
               requestError as {
                 response?: { status?: string; response?: string };
@@ -1839,7 +1824,6 @@ export default class ServiceHyperliquid extends ServiceBase {
           await timerUtils.wait(500);
         }
 
-        console.log('approveAgentResult::', approveAgentResult);
         if (
           approveAgentResult &&
           approveAgentResult.status === 'ok' &&
@@ -2104,7 +2088,6 @@ export default class ServiceHyperliquid extends ServiceBase {
         ) {
           statusDetails.builderFeeOk = true;
         }
-        console.log('approveBuilderFeeResult::', approveBuilderFeeResult);
       }
     }
   }

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -704,12 +704,6 @@ export default class ServiceHyperliquid extends ServiceBase {
 
   async updateActiveSpotAssetCtx(data: IWsActiveSpotAssetCtx | undefined) {
     const activeSpotAsset = await spotActiveAssetAtom.get();
-    console.log('updateActiveSpotAssetCtx__debug', {
-      activeCoin: activeSpotAsset?.coin,
-      dataCoin: data?.coin,
-      hasCtx: !!data?.ctx,
-      match: activeSpotAsset?.coin === data?.coin,
-    });
     if (activeSpotAsset?.coin === data?.coin && data?.coin && data?.ctx) {
       await spotActiveAssetCtxAtom.set(
         (_prev): ISpotActiveAssetCtxAtom => ({

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
@@ -39,6 +39,7 @@ import {
   mapTriggerOrderType,
   parseSignatureToRSV,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
+import { SPOT_ASSET_ID_OFFSET } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import type {
   IApiErrorResponse,
   IApiRequestResult,
@@ -678,6 +679,14 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
   @backgroundMethod()
   async placeSpotOrder(params: ISpotOrderParams): Promise<IOrderResponse> {
     await this.checkAccountCanTrade();
+    if (
+      typeof params.assetId !== 'number' ||
+      params.assetId < SPOT_ASSET_ID_OFFSET
+    ) {
+      throw new OneKeyLocalError(
+        `placeSpotOrder: invalid spot assetId ${params.assetId}, must be >= ${SPOT_ASSET_ID_OFFSET}`,
+      );
+    }
     try {
       const isMarket = params.orderType === 'market';
 

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
@@ -34,6 +34,7 @@ import { convertHyperLiquidResponse } from '@onekeyhq/shared/src/utils/hyperLiqu
 import {
   MAX_DECIMALS_PERP,
   formatPriceToSignificantDigits,
+  formatSpotPriceToValid,
   getValidPriceDecimals,
   mapTriggerOrderType,
   parseSignatureToRSV,
@@ -57,6 +58,7 @@ import type {
   IPlaceOrderParams,
   IPositionTpslOrderParams,
   ISetReferrerRequest,
+  ISpotOrderParams,
   ITriggerOrderParams,
   IUpdateIsolatedMarginRequest,
   IWithdrawParams,
@@ -685,6 +687,68 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
       return response;
     } catch (error) {
       throw new OneKeyLocalError(`Failed to place order: ${String(error)}`);
+    }
+  }
+
+  private _calculateSpotSlippagePrice(params: {
+    markPrice: string;
+    isBuy: boolean;
+    slippage: number;
+    szDecimals: number;
+  }): string {
+    const price = new BigNumber(params.markPrice);
+    const slippageMultiplier = params.isBuy
+      ? new BigNumber(1).plus(params.slippage)
+      : new BigNumber(1).minus(params.slippage);
+    const adjustedPrice = price.multipliedBy(slippageMultiplier);
+    return formatSpotPriceToValid(adjustedPrice.toFixed(), params.szDecimals);
+  }
+
+  @backgroundMethod()
+  async placeSpotOrder(params: ISpotOrderParams): Promise<IOrderResponse> {
+    await this.checkAccountCanTrade();
+    try {
+      const isMarket = params.orderType === 'market';
+
+      const price = isMarket
+        ? this._calculateSpotSlippagePrice({
+            markPrice: params.limitPx,
+            isBuy: params.isBuy,
+            slippage: params.slippage || this.slippage,
+            szDecimals: params.szDecimals || 0,
+          })
+        : params.limitPx;
+
+      const orderParams: IOrderParams = {
+        a: params.assetId,
+        b: params.isBuy,
+        p: price,
+        s: params.sz,
+        r: false, // spot orders never use reduceOnly
+        t: isMarket
+          ? { limit: { tif: params.tif || 'Ioc' } }
+          : { limit: { tif: params.tif || 'Gtc' } },
+      };
+
+      const response = await this.placeOrderRaw(
+        {
+          orders: [orderParams],
+          grouping: 'na',
+        },
+        {
+          action: 'placeSpotOrder',
+          originalParams: params,
+          extra: {
+            isMarket,
+            isSpot: true,
+          },
+        },
+      );
+      return response;
+    } catch (error) {
+      throw new OneKeyLocalError(
+        `Failed to place spot order: ${String(error)}`,
+      );
     }
   }
 

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
@@ -211,35 +211,6 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
     }
   }
 
-  // @backgroundMethod()
-  // async getOnekeyWalletClient(params: {
-  //   userAddress: IHex;
-  //   userAccountId?: string;
-  // }): Promise<ExchangeClient> {
-  //   const transport = new HttpTransport();
-
-  //   let wallet: WalletHyperliquidProxy | WalletHyperliquidOnekey;
-
-  //   if (params.userAccountId) {
-  //     wallet =
-  //       await this.backgroundApi.serviceHyperliquidWallet.getOnekeyWallet({
-  //         userAccountId: params.userAccountId,
-  //       });
-  //   } else {
-  //     const proxyWallet =
-  //       await this.backgroundApi.serviceHyperliquidWallet.getProxyWallet({
-  //         userAddress: params.userAddress,
-  //       });
-  //     wallet = proxyWallet.wallet;
-  //   }
-
-  //   return new ExchangeClient({
-  //     transport,
-  //     wallet,
-  //     signatureChainId: PERPS_EVM_CHAIN_ID_HEX,
-  //   });
-  // }
-
   /**
    * Check if agent is ready based on local status only
    */

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
@@ -695,7 +695,7 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
         b: params.isBuy,
         p: price,
         s: params.sz,
-        r: false, // spot orders never use reduceOnly
+        r: false,
         t: isMarket
           ? { limit: { tif: params.tif || 'Ioc' } }
           : { limit: { tif: params.tif || 'Gtc' } },

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -705,9 +705,11 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         ESubscriptionType.USER_FILLS,
         ESubscriptionType.USER_NON_FUNDING_LEDGER_UPDATES,
         // Spot subscription types
+        // Note: ACTIVE_SPOT_ASSET_CTX shares wire type "activeAssetCtx" with perps
+        // and is not registered here — spot ctx events are dispatched as ACTIVE_ASSET_CTX
+        // and routed by coin format (@N / BASE/QUOTE) in the handler.
         ESubscriptionType.SPOT_STATE,
         ESubscriptionType.SPOT_ASSET_CTXS,
-        ESubscriptionType.ACTIVE_SPOT_ASSET_CTX,
       ];
       const removeAllSubscriptionHandlers = () => {
         allTypes.forEach((type) => {
@@ -728,23 +730,12 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       const wsRequester = innerTransport._postRequest as {
         request: (method: string, payload: any) => Promise<void>;
       };
-      // const payload = { type: "activeAssetCtx", ...params };
-      console.log('getWebSocketClient__wsRequester', wsRequester);
-      // Map SDK channel types to Hyperliquid wire types
-      // (some SDK types use different channel names for event dispatch)
-      const getWireType = (type: ESubscriptionType): string => {
-        if (type === ESubscriptionType.ACTIVE_SPOT_ASSET_CTX) {
-          return 'activeAssetCtx'; // spot shares wire type with perps
-        }
-        return type;
-      };
-
       const subscribe = async <T extends ESubscriptionType>(
         type: T,
         params: IPerpsSubscriptionParams[T],
       ) => {
         return wsRequester.request('subscribe', {
-          type: getWireType(type),
+          type,
           ...params,
         });
       };
@@ -753,7 +744,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         params: IPerpsSubscriptionParams[T],
       ) => {
         return wsRequester.request('unsubscribe', {
-          type: getWireType(type),
+          type,
           ...params,
         });
       };
@@ -969,9 +960,11 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         (subInfo) => subInfo.spec,
       ),
     ];
-    allSpecs.forEach((spec) => {
-      void this._destroySubscription(spec);
-    });
+    // Await all unsubscribes before clearing the active set so that the
+    // server has fully acknowledged the teardown before we forget about them.
+    await Promise.all(
+      allSpecs.map((spec) => this._destroySubscription(spec)),
+    );
     this._activeSubscriptions.clear();
     void perpsNetworkStatusAtom.set((prev): IPerpsNetworkStatus => {
       return {
@@ -1163,11 +1156,6 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
             data as IWsActiveAssetCtx,
           );
         }
-      } else if (subscriptionType === ESubscriptionType.ACTIVE_SPOT_ASSET_CTX) {
-        // SDK dispatches spot activeAssetCtx on channel "activeSpotAssetCtx"
-        void this.backgroundApi.serviceHyperliquid.updateActiveSpotAssetCtx(
-          data as IWsActiveSpotAssetCtx,
-        );
       } else if (subscriptionType === ESubscriptionType.ACTIVE_ASSET_DATA) {
         void this.backgroundApi.serviceHyperliquid.updateActiveAssetData(
           data as IPerpsActiveAssetDataRaw,

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -426,6 +426,17 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   }
 
   @backgroundMethod()
+  async setRouteSubscriptionState(params: {
+    enableLedgerUpdates: boolean;
+    spotAssetCtxsEnabled: boolean;
+    spotEnabled: boolean;
+  }): Promise<void> {
+    this._currentState.enableLedgerUpdates = params.enableLedgerUpdates;
+    this._currentState.spotAssetCtxsEnabled = params.spotAssetCtxsEnabled;
+    this._currentState.spotEnabled = params.spotEnabled;
+  }
+
+  @backgroundMethod()
   async forceReloadCandlesWebview(): Promise<void> {
     await perpsCandlesWebviewReloadHookAtom.set({
       reloadHook: Date.now(),

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -512,14 +512,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     const readyState = socket?.readyState;
     this._lastReadyState = readyState;
     void perpsWebSocketReadyStateAtom.set({ readyState });
-    console.log('hyperliquidWebSocket__event__error', {
-      readyState,
-      code: (event as any)?.code,
-      message: (event as any)?.message,
-      reason: (event as any)?.reason,
-      args,
-      event,
-    });
+    // WS error event — readyState tracked via perpsWebSocketReadyStateAtom
   };
 
   socketCloseHandler: (event: WebSocketEventMap['close']) => void = (
@@ -530,14 +523,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     const readyState = socket?.readyState;
     this._lastReadyState = readyState;
     void perpsWebSocketReadyStateAtom.set({ readyState });
-    console.log('hyperliquidWebSocket__event__close', {
-      readyState,
-      code: event.code,
-      reason: event.reason,
-      wasClean: event.wasClean,
-      args,
-      event,
-    });
+    // WS close event — readyState tracked via perpsWebSocketReadyStateAtom
     this._activeSubscriptions.clear();
     this._stopPingLoop();
     void perpsNetworkStatusAtom.set((prev): IPerpsNetworkStatus => {
@@ -557,11 +543,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     const readyState = socket?.readyState;
     this._lastReadyState = readyState;
     void perpsWebSocketReadyStateAtom.set({ readyState });
-    console.log('hyperliquidWebSocket__event__open', {
-      readyState,
-      args,
-      event,
-    });
+    // WS open event — readyState tracked via perpsWebSocketReadyStateAtom
 
     const prevNetworkStatus = await perpsNetworkStatusAtom.get();
     const wasConnected = prevNetworkStatus?.connected;
@@ -683,10 +665,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         ESubscriptionType.ALL_DEXS_ASSET_CTXS,
         ESubscriptionType.USER_FILLS,
         ESubscriptionType.USER_NON_FUNDING_LEDGER_UPDATES,
-        // Spot subscription types
-        // Note: ACTIVE_SPOT_ASSET_CTX shares wire type "activeAssetCtx" with perps
-        // and is not registered here — spot ctx events are dispatched as ACTIVE_ASSET_CTX
-        // and routed by coin format (@N / BASE/QUOTE) in the handler.
+        ESubscriptionType.ACTIVE_SPOT_ASSET_CTX,
         ESubscriptionType.SPOT_STATE,
         ESubscriptionType.SPOT_ASSET_CTXS,
       ];
@@ -987,7 +966,6 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       if (subscriptionType === ESubscriptionType.ALL_MIDS) {
         // Cache allMids in background for spot balance USD calculation
         hyperLiquidCache.allMids = data as IWsAllMids;
-        // Extract @N spot prices from allMids (always available, serves Balance tab)
         const allMidsData = data as { mids?: Record<string, string> };
         if (allMidsData?.mids) {
           void this.backgroundApi.serviceHyperliquid.extractSpotPricesFromAllMids(
@@ -1084,9 +1062,16 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       }
 
       if (subscriptionType === ESubscriptionType.SPOT_ASSET_CTXS) {
-        // Writes directly to spotAssetCtxsMapAtom — no eventBus needed
         void this.backgroundApi.serviceHyperliquid.updateSpotAssetCtxsMap(
           data as IWsSpotAssetCtxs,
+        );
+        this._updateNetworkLiveness();
+        return;
+      }
+
+      if (subscriptionType === ESubscriptionType.ACTIVE_SPOT_ASSET_CTX) {
+        void this.backgroundApi.serviceHyperliquid.updateActiveSpotAssetCtx(
+          data as IWsActiveSpotAssetCtx,
         );
         this._updateNetworkLiveness();
         return;
@@ -1096,6 +1081,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         const coinStr = (data as { coin?: string })?.coin ?? '';
         const isSpotData = coinStr.startsWith('@') || coinStr.includes('/');
         if (isSpotData) {
+          // Fallback: some server versions may still send spot data on "activeAssetCtx"
           void this.backgroundApi.serviceHyperliquid.updateActiveSpotAssetCtx(
             data as IWsActiveSpotAssetCtx,
           );

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -214,29 +214,35 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     return { requiredSubSpecsMap, params };
   }
 
+  private _hasInitialSubscription = false;
+
+  private async _updateSubscriptionsCore() {
+    const requiredSubInfo = await this.buildRequiredSubscriptionsMap();
+    if (!requiredSubInfo) {
+      return;
+    }
+
+    this.allSubSpecsMap = {
+      ...this.allSubSpecsMap,
+      ...requiredSubInfo.requiredSubSpecsMap,
+    };
+    this.pendingSubSpecsMap = {
+      ...requiredSubInfo.requiredSubSpecsMap,
+    };
+
+    const newState: ISubscriptionState = { ...this._currentState };
+
+    this._applyStateUpdates(newState, requiredSubInfo.params);
+
+    this._emitConnectionStatus();
+    this._executeSubscriptionChanges();
+
+    this._currentState = newState;
+  }
+
   _updateSubscriptionsDebounced = debounce(
     async () => {
-      const requiredSubInfo = await this.buildRequiredSubscriptionsMap();
-      if (!requiredSubInfo) {
-        return;
-      }
-
-      this.allSubSpecsMap = {
-        ...this.allSubSpecsMap,
-        ...requiredSubInfo.requiredSubSpecsMap,
-      };
-      this.pendingSubSpecsMap = {
-        ...requiredSubInfo.requiredSubSpecsMap,
-      };
-
-      const newState: ISubscriptionState = { ...this._currentState };
-
-      this._applyStateUpdates(newState, requiredSubInfo.params);
-
-      this._emitConnectionStatus();
-      this._executeSubscriptionChanges();
-
-      this._currentState = newState;
+      await this._updateSubscriptionsCore();
     },
     300,
     {
@@ -247,6 +253,12 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
   @backgroundMethod()
   async updateSubscriptions(): Promise<void> {
+    // Skip debounce on first subscription to speed up initial load
+    if (!this._hasInitialSubscription) {
+      this._hasInitialSubscription = true;
+      await this._updateSubscriptionsCore();
+      return;
+    }
     await this._updateSubscriptionsDebounced();
   }
 
@@ -446,6 +458,9 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     this._stopPingLoop();
     await this._closeClient();
     this._currentState.isConnected = false;
+    // Reset so the first post-reconnect updateSubscriptions() skips debounce
+    // for fast recovery (critical for iOS foreground resume).
+    this._hasInitialSubscription = false;
     this._emitConnectionStatus();
   }
 
@@ -896,9 +911,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     ];
     // Await all unsubscribes before clearing the active set so that the
     // server has fully acknowledged the teardown before we forget about them.
-    await Promise.all(
-      allSpecs.map((spec) => this._destroySubscription(spec)),
-    );
+    await Promise.all(allSpecs.map((spec) => this._destroySubscription(spec)));
     this._activeSubscriptions.clear();
     void perpsNetworkStatusAtom.set((prev): IPerpsNetworkStatus => {
       return {

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -26,10 +26,12 @@ import type {
   IPerpsSubscriptionParams,
   IWebSocketTransportOptions,
   IWsActiveAssetCtx,
+  IWsActiveSpotAssetCtx,
   IWsAllDexsAssetCtxs,
   IWsAllDexsClearinghouseState,
   IWsAllMids,
   IWsOpenOrders,
+  IWsSpotAssetCtxs,
   IWsSpotState,
   IWsUserFills,
   IWsWebData2,
@@ -52,7 +54,9 @@ import {
   perpsTradesHistoryRefreshHookAtom,
   perpsWebSocketDataUpdateTimesAtom,
   perpsWebSocketReadyStateAtom,
+  tradingModeAtom,
 } from '../../states/jotai/atoms/perps';
+import { spotActiveAssetAtom } from '../../states/jotai/atoms/spot';
 import ServiceBase from '../ServiceBase';
 
 import hyperLiquidCache from './hyperLiquidCache';
@@ -121,6 +125,10 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     isConnected: false,
     l2BookOptions: undefined,
     enableLedgerUpdates: false,
+    spotEnabled: false,
+    spotAssetCtxsEnabled: false,
+    currentSpotSymbol: undefined,
+    tradingMode: 'perp',
   };
 
   private _networkTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
@@ -143,15 +151,22 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
     const activeAccount = await perpsActiveAccountAtom.get();
     const activeAsset = await perpsActiveAssetAtom.get();
+    const spotActiveAsset = await spotActiveAssetAtom.get();
+    const currentMode = (await tradingModeAtom.get()) ?? 'perp';
+    const currentCoin =
+      currentMode === 'spot' ? spotActiveAsset?.coin : activeAsset?.coin;
+    const currentAssetId =
+      currentMode === 'spot' ? spotActiveAsset?.assetId : activeAsset?.assetId;
     let activeOrderBookOptions = await perpsActiveOrderBookOptionsAtom.get();
 
     if (
       activeOrderBookOptions?.coin &&
-      activeOrderBookOptions?.coin !== activeAsset.coin
+      activeOrderBookOptions?.coin !== currentCoin
     ) {
       const syncedOptions = {
         ...activeOrderBookOptions,
-        coin: activeAsset.coin,
+        coin: currentCoin,
+        assetId: currentAssetId,
       };
       await perpsActiveOrderBookOptionsAtom.set(syncedOptions);
       activeOrderBookOptions = syncedOptions;
@@ -181,12 +196,17 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
           }
         : undefined;
     delete l2BookOptions?.assetId;
+    const currentSpotSymbol = spotActiveAsset?.coin || undefined;
     const params: ISubscriptionState = {
       isConnected,
       l2BookOptions,
-      currentSymbol: activeAsset?.coin,
+      currentSymbol: currentCoin,
       currentUser: activeAccount?.accountAddress,
       enableLedgerUpdates: this._currentState.enableLedgerUpdates,
+      spotEnabled: this._currentState.spotEnabled,
+      spotAssetCtxsEnabled: this._currentState.spotAssetCtxsEnabled,
+      currentSpotSymbol,
+      tradingMode: currentMode,
     };
 
     const requiredSubSpecsMap = calculateRequiredSubscriptionsMap(params);
@@ -659,7 +679,10 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         ESubscriptionType.ALL_DEXS_ASSET_CTXS,
         ESubscriptionType.USER_FILLS,
         ESubscriptionType.USER_NON_FUNDING_LEDGER_UPDATES,
+        // Spot subscription types
         ESubscriptionType.SPOT_STATE,
+        ESubscriptionType.SPOT_ASSET_CTXS,
+        ESubscriptionType.ACTIVE_SPOT_ASSET_CTX,
       ];
       const removeAllSubscriptionHandlers = () => {
         allTypes.forEach((type) => {
@@ -682,18 +705,21 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       };
       // const payload = { type: "activeAssetCtx", ...params };
       console.log('getWebSocketClient__wsRequester', wsRequester);
+      // Map SDK channel types to Hyperliquid wire types
+      // (some SDK types use different channel names for event dispatch)
+      const getWireType = (type: ESubscriptionType): string => {
+        if (type === ESubscriptionType.ACTIVE_SPOT_ASSET_CTX) {
+          return 'activeAssetCtx'; // spot shares wire type with perps
+        }
+        return type;
+      };
+
       const subscribe = async <T extends ESubscriptionType>(
         type: T,
         params: IPerpsSubscriptionParams[T],
       ) => {
-        // for (let i = 0; i < 100; i += 1) {
-        //   void wsRequester.request('subscribe', {
-        //     type,
-        //     ...params,
-        //   });
-        // }
         return wsRequester.request('subscribe', {
-          type,
+          type: getWireType(type),
           ...params,
         });
       };
@@ -702,7 +728,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         params: IPerpsSubscriptionParams[T],
       ) => {
         return wsRequester.request('unsubscribe', {
-          type,
+          type: getWireType(type),
           ...params,
         });
       };
@@ -995,6 +1021,13 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       if (subscriptionType === ESubscriptionType.ALL_MIDS) {
         // Cache allMids in background for spot balance USD calculation
         hyperLiquidCache.allMids = data as IWsAllMids;
+        // Extract @N spot prices from allMids (always available, serves Balance tab)
+        const allMidsData = data as { mids?: Record<string, string> };
+        if (allMidsData?.mids) {
+          void this.backgroundApi.serviceHyperliquid.extractSpotPricesFromAllMids(
+            allMidsData.mids,
+          );
+        }
         // Re-trigger spot calculation if it was deferred (SPOT_STATE arrived before ALL_MIDS)
         void this.backgroundApi.serviceHyperliquid.recalculateSpotTotalUsd();
         // Emit to frontend (PerpsGlobalEffects listens for allMids updates)
@@ -1084,9 +1117,31 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         return;
       }
 
+      if (subscriptionType === ESubscriptionType.SPOT_ASSET_CTXS) {
+        // Writes directly to spotAssetCtxsMapAtom — no eventBus needed
+        void this.backgroundApi.serviceHyperliquid.updateSpotAssetCtxsMap(
+          data as IWsSpotAssetCtxs,
+        );
+        this._updateNetworkLiveness();
+        return;
+      }
+
       if (subscriptionType === ESubscriptionType.ACTIVE_ASSET_CTX) {
-        void this.backgroundApi.serviceHyperliquid.updateActiveAssetCtx(
-          data as IWsActiveAssetCtx,
+        const coinStr = (data as { coin?: string })?.coin ?? '';
+        const isSpotData = coinStr.startsWith('@') || coinStr.includes('/');
+        if (isSpotData) {
+          void this.backgroundApi.serviceHyperliquid.updateActiveSpotAssetCtx(
+            data as IWsActiveSpotAssetCtx,
+          );
+        } else {
+          void this.backgroundApi.serviceHyperliquid.updateActiveAssetCtx(
+            data as IWsActiveAssetCtx,
+          );
+        }
+      } else if (subscriptionType === ESubscriptionType.ACTIVE_SPOT_ASSET_CTX) {
+        // SDK dispatches spot activeAssetCtx on channel "activeSpotAssetCtx"
+        void this.backgroundApi.serviceHyperliquid.updateActiveSpotAssetCtx(
+          data as IWsActiveSpotAssetCtx,
         );
       } else if (subscriptionType === ESubscriptionType.ACTIVE_ASSET_DATA) {
         void this.backgroundApi.serviceHyperliquid.updateActiveAssetData(

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -1154,7 +1154,6 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       if (subscriptionType === ESubscriptionType.ACTIVE_ASSET_CTX) {
         const coinStr = (data as { coin?: string })?.coin ?? '';
         const isSpotData = coinStr.startsWith('@') || coinStr.includes('/');
-        console.log('ACTIVE_ASSET_CTX__debug', { coinStr, isSpotData });
         if (isSpotData) {
           void this.backgroundApi.serviceHyperliquid.updateActiveSpotAssetCtx(
             data as IWsActiveSpotAssetCtx,

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -524,9 +524,11 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     ...args
   ) => {
     const socket = event.target as WebSocket | undefined;
-    void perpsWebSocketReadyStateAtom.set({ readyState: socket?.readyState });
+    const readyState = socket?.readyState;
+    this._lastReadyState = readyState;
+    void perpsWebSocketReadyStateAtom.set({ readyState });
     console.log('hyperliquidWebSocket__event__error', {
-      readyState: socket?.readyState,
+      readyState,
       code: (event as any)?.code,
       message: (event as any)?.message,
       reason: (event as any)?.reason,
@@ -540,9 +542,11 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     ...args
   ) => {
     const socket = event.target as WebSocket | undefined;
-    void perpsWebSocketReadyStateAtom.set({ readyState: socket?.readyState });
+    const readyState = socket?.readyState;
+    this._lastReadyState = readyState;
+    void perpsWebSocketReadyStateAtom.set({ readyState });
     console.log('hyperliquidWebSocket__event__close', {
-      readyState: socket?.readyState,
+      readyState,
       code: event.code,
       reason: event.reason,
       wasClean: event.wasClean,
@@ -565,9 +569,11 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     ...args
   ) => {
     const socket = event.target as WebSocket | undefined;
-    void perpsWebSocketReadyStateAtom.set({ readyState: socket?.readyState });
+    const readyState = socket?.readyState;
+    this._lastReadyState = readyState;
+    void perpsWebSocketReadyStateAtom.set({ readyState });
     console.log('hyperliquidWebSocket__event__open', {
-      readyState: socket?.readyState,
+      readyState,
       args,
       event,
     });
@@ -594,14 +600,22 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     this._startPingLoop();
   };
 
+  private _lastReadyState: number | undefined;
+
   socketMessageHandler: (event: WebSocketEventMap['message']) => void = (
     event,
     ...args
   ) => {
     const socket = event.target as WebSocket | undefined;
-    void perpsWebSocketReadyStateAtom.set({ readyState: socket?.readyState });
+    const readyState = socket?.readyState;
+    // Only write readyState atom when it actually changes to avoid
+    // triggering downstream re-renders on every WS message
+    if (readyState !== this._lastReadyState) {
+      this._lastReadyState = readyState;
+      void perpsWebSocketReadyStateAtom.set({ readyState });
+    }
     console.log('hyperliquidWebSocket__event__message', {
-      readyState: socket?.readyState,
+      readyState,
       args,
       event,
     });

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment */
 /* spell-checker: disable */
 import { SubscriptionClient, WebSocketTransport } from '@nktkas/hyperliquid';
-import { cloneDeep, debounce, isEmpty } from 'lodash';
+import { cloneDeep, debounce } from 'lodash';
 
 import {
   backgroundClass,
@@ -225,9 +225,6 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         ...this.allSubSpecsMap,
         ...requiredSubInfo.requiredSubSpecsMap,
       };
-      if (isEmpty(this.allSubSpecsMap)) {
-        // debugger;
-      }
       this.pendingSubSpecsMap = {
         ...requiredSubInfo.requiredSubSpecsMap,
       };
@@ -235,14 +232,6 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       const newState: ISubscriptionState = { ...this._currentState };
 
       this._applyStateUpdates(newState, requiredSubInfo.params);
-
-      console.log('updateSubscriptions____state', {
-        requiredSubSpecsMap: requiredSubInfo.requiredSubSpecsMap,
-        requiredParams: requiredSubInfo.params,
-        allSubSpecsMap: this.allSubSpecsMap,
-        pendingSubSpecsMap: this.pendingSubSpecsMap,
-        newState,
-      });
 
       this._emitConnectionStatus();
       this._executeSubscriptionChanges();
@@ -313,7 +302,6 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       // socket is open but no recent data (possible half-open), rebuild subscriptions
       await this._cleanupAllSubscriptions();
       await timerUtils.wait(50);
-      console.log('updateSubscriptions__by__refreshAllPerpsData');
       await this.updateSubscriptions();
     }
 
@@ -361,12 +349,10 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   @backgroundMethod()
   async resumeSubscriptions(): Promise<void> {
     await this.enableSubscriptionsHandler();
-    console.log('updateSubscriptions__by__resumeSubscriptions');
 
     // Reconnect if socket is CLOSED (iOS closes WebSocket when app is in background)
     const client = await this.getWebSocketClient();
     if (client?.transport?.socket?.readyState === WebSocket.CLOSED) {
-      console.log('resumeSubscriptions__reconnecting_closed_socket');
       await this.disconnect();
       await this.getWebSocketClient();
     }
@@ -421,7 +407,6 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       return;
     }
     this._currentState.enableLedgerUpdates = true;
-    console.log('updateSubscriptions__by__enableLedgerUpdatesSubscription');
     await this.updateSubscriptions();
   }
 
@@ -584,7 +569,6 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     await timerUtils.wait(600); // wait network status atom update
 
     if (!wasConnected) {
-      console.log('updateSubscriptions__by__socketOpen');
       // resubscribe when reconnecting
       await this.updateSubscriptions();
     }
@@ -614,11 +598,6 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       this._lastReadyState = readyState;
       void perpsWebSocketReadyStateAtom.set({ readyState });
     }
-    console.log('hyperliquidWebSocket__event__message', {
-      readyState,
-      args,
-      event,
-    });
   };
 
   private async getWebSocketClient(): Promise<IHyperliquidWsClient> {
@@ -827,23 +806,12 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         toDestroySubscriptions.push(spec);
       }
     });
-    if (toDestroySubscriptions.length) {
-      console.log('toDestroySubscriptions__info', toDestroySubscriptions);
-    } else {
-      console.log(
-        'toDestroySubscriptions__info__no_to_destroy',
-        toDestroySubscriptions,
-      );
-    }
     toDestroySubscriptions.forEach((spec) => {
-      console.log('destroyUnusedSubscriptions__destroy___2222', spec.key);
       void this._destroySubscription(spec);
     });
   }
 
   private _executeSubscriptionChanges(): void {
-    console.log('_executeSubscriptionChanges___start');
-
     const toCreateSubscriptions: ISubscriptionSpec<ESubscriptionType>[] = [];
     Object.values(this.pendingSubSpecsMap).forEach((spec) => {
       if (!this._activeSubscriptions.has(spec.key)) {
@@ -854,7 +822,6 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     this.destroyUnusedSubscriptions();
 
     toCreateSubscriptions.forEach((spec) => {
-      console.log('destroyUnusedSubscriptions__create', spec.key);
       void this._createSubscription(spec);
     });
     // this.destroyUnusedSubscriptions();
@@ -865,9 +832,6 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   ): Promise<void> {
     // eslint-disable-next-line no-param-reassign
     spec = cloneDeep(spec);
-    if (spec.key.includes('l2Book')) {
-      // debugger;
-    }
 
     const addSubCache = () => {
       if (!this.allSubSpecsMap[spec.key]) {
@@ -887,7 +851,6 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     }
 
     try {
-      console.log('createSubscription', spec.key);
       const sdkSubscription = await this._createSubscriptionDirect(spec);
       this._activeSubscriptions.set(spec.key, {
         key: spec.key,
@@ -897,13 +860,6 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         lastActivity: Date.now(),
         isActive: true,
       });
-      if (spec.key.includes('l2Book')) {
-        console.log(
-          'createSubscription__done',
-          sdkSubscription,
-          this._activeSubscriptions,
-        );
-      }
     } catch (error) {
       console.error(
         `[ServiceHyperliquidSubscription.createSubscription] Failed to create subscription ${spec.type}:`,
@@ -925,7 +881,6 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
           this._activeSubscriptions.delete(spec.key);
         };
         try {
-          console.log('destroyUnusedSubscriptions__destroy', spec.key);
           const client = await this.getWebSocketClient();
           if (!client) {
             return;
@@ -1006,13 +961,6 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
           const userFills = event?.detail as IWsUserFills;
           const isSnapshot = userFills?.isSnapshot;
           const fillsLength = userFills?.fills?.length;
-          console.log(
-            'userFills__handleSubscriptionData',
-            userFills?.user,
-            isSnapshot,
-            fillsLength,
-            userFills,
-          );
           if (userFills?.user && fillsLength > 0 && !isSnapshot) {
             this.hasNewUserFills = true;
           }

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -1140,6 +1140,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       if (subscriptionType === ESubscriptionType.ACTIVE_ASSET_CTX) {
         const coinStr = (data as { coin?: string })?.coin ?? '';
         const isSpotData = coinStr.startsWith('@') || coinStr.includes('/');
+        console.log('ACTIVE_ASSET_CTX__debug', { coinStr, isSpotData });
         if (isSpotData) {
           void this.backgroundApi.serviceHyperliquid.updateActiveSpotAssetCtx(
             data as IWsActiveSpotAssetCtx,

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
@@ -1,10 +1,7 @@
 import { PERPS_EMPTY_ADDRESS } from '@onekeyhq/shared/src/consts/perp';
 import stringUtils from '@onekeyhq/shared/src/utils/stringUtils';
 import type {
-  IEventActiveAssetCtxParameters,
-  IEventActiveAssetDataParameters,
   IEventAllDexsClearinghouseStateParameters,
-  IEventBboParameters,
   IEventL2BookParameters,
   IEventOpenOrdersParameters,
   IEventUserFillsParameters,
@@ -81,6 +78,16 @@ export const SUBSCRIPTION_TYPE_INFO: {
     eventType: EPerpsSubscriptionCategory.ACCOUNT,
     priority: 3,
   },
+  [ESubscriptionType.SPOT_ASSET_CTXS]: {
+    eventType: EPerpsSubscriptionCategory.MARKET,
+    priority: 2,
+  },
+  // ACTIVE_SPOT_ASSET_CTX shares wire type "activeAssetCtx" with perps.
+  // Not used directly — spot mode reuses ACTIVE_ASSET_CTX with coin format detection in WS handler.
+  [ESubscriptionType.ACTIVE_SPOT_ASSET_CTX]: {
+    eventType: EPerpsSubscriptionCategory.MARKET,
+    priority: 2,
+  },
 };
 
 export interface ISubscriptionSpec<T extends ESubscriptionType> {
@@ -96,6 +103,14 @@ export interface ISubscriptionState {
   isConnected: boolean;
   l2BookOptions?: IL2BookOptions | null;
   enableLedgerUpdates?: boolean;
+  // Spot balance subscription (Balances tab)
+  spotEnabled?: boolean;
+  // Spot asset contexts subscription (Token selector Spot tab)
+  spotAssetCtxsEnabled?: boolean;
+  // Active spot pair for BBO/ACTIVE_ASSET_CTX subscriptions (e.g. "@107")
+  currentSpotSymbol?: string;
+  // Trading mode — per-asset subscriptions are exclusive based on this
+  tradingMode?: 'perp' | 'spot';
 }
 
 export interface ISubscriptionDiff {
@@ -162,41 +177,59 @@ export function calculateRequiredSubscriptions(
     }),
   );
 
-  if (state.currentSymbol) {
-    const activeAssetCtxParams: IEventActiveAssetCtxParameters = {
-      coin: state.currentSymbol,
-    };
+  // Per-asset subscriptions are MUTUALLY EXCLUSIVE — only one mode active at a time
+  // to avoid duplicate BBO/ctx data and unnecessary bandwidth
+  if (state.tradingMode === 'spot' && state.currentSpotSymbol) {
+    // Spot mode: reuse ACTIVE_ASSET_CTX with spot coin
+    // (wire protocol is the same "activeAssetCtx", server returns spot data for @N coins)
     specs.push(
       buildSubscriptionSpec({
         type: ESubscriptionType.ACTIVE_ASSET_CTX,
-        params: activeAssetCtxParams,
+        params: { coin: state.currentSpotSymbol },
       }),
     );
-
-    // BBO subscription for trading price reference
-    const bboParams: IEventBboParameters = {
-      coin: state.currentSymbol,
-    };
     specs.push(
       buildSubscriptionSpec({
         type: ESubscriptionType.BBO,
-        params: bboParams,
+        params: { coin: state.currentSpotSymbol },
       }),
     );
-
-    const activeAssetDataParams: IEventActiveAssetDataParameters = {
-      coin: state.currentSymbol,
-      user: state.currentUser || PERPS_EMPTY_ADDRESS,
-    };
+    if (state.l2BookOptions) {
+      specs.push(
+        buildSubscriptionSpec({
+          type: ESubscriptionType.L2_BOOK,
+          params: {
+            coin: state.currentSpotSymbol,
+            nSigFigs: state.l2BookOptions.nSigFigs ?? null,
+            mantissa: state.l2BookOptions.mantissa ?? null,
+          },
+        }),
+      );
+    }
+  } else if (state.currentSymbol) {
+    // Perps mode: subscribe to perps asset context + BBO + asset data + order book
+    specs.push(
+      buildSubscriptionSpec({
+        type: ESubscriptionType.ACTIVE_ASSET_CTX,
+        params: { coin: state.currentSymbol },
+      }),
+    );
+    specs.push(
+      buildSubscriptionSpec({
+        type: ESubscriptionType.BBO,
+        params: { coin: state.currentSymbol },
+      }),
+    );
     specs.push(
       buildSubscriptionSpec({
         type: ESubscriptionType.ACTIVE_ASSET_DATA,
-        params: activeAssetDataParams,
+        params: {
+          coin: state.currentSymbol,
+          user: state.currentUser || PERPS_EMPTY_ADDRESS,
+        },
       }),
     );
-
     if (state.l2BookOptions) {
-      // Create L2_BOOK subscription with default parameters if no custom params are provided
       const l2BookParams: IEventL2BookParameters = {
         coin: state.currentSymbol,
         nSigFigs: state.l2BookOptions.nSigFigs ?? null,
@@ -295,6 +328,16 @@ export function calculateRequiredSubscriptions(
   } else {
     // WebData3 requires a user address.
     // If no user, we likely only need market data (handled above).
+  }
+
+  // Spot: global asset contexts (token selector, independent of balance subscription)
+  if (state.spotAssetCtxsEnabled) {
+    specs.push(
+      buildSubscriptionSpec({
+        type: ESubscriptionType.SPOT_ASSET_CTXS,
+        params: {},
+      }),
+    );
   }
 
   return specs.toSorted((a, b) => a.priority - b.priority);

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
@@ -265,14 +265,16 @@ export function calculateRequiredSubscriptions(
         },
       }),
     );
-    specs.push(
-      buildSubscriptionSpec({
-        type: ESubscriptionType.SPOT_STATE,
-        params: {
-          user: state.currentUser,
-        },
-      }),
-    );
+    if (state.spotEnabled) {
+      specs.push(
+        buildSubscriptionSpec({
+          type: ESubscriptionType.SPOT_STATE,
+          params: {
+            user: state.currentUser,
+          },
+        }),
+      );
+    }
     const userFillsParams: IEventUserFillsParameters = {
       user: state.currentUser,
       aggregateByTime: true,
@@ -295,7 +297,6 @@ export function calculateRequiredSubscriptions(
         }),
       );
     }
-
   }
 
   if (state.spotAssetCtxsEnabled) {

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
@@ -82,8 +82,8 @@ export const SUBSCRIPTION_TYPE_INFO: {
     eventType: EPerpsSubscriptionCategory.MARKET,
     priority: 2,
   },
-  // ACTIVE_SPOT_ASSET_CTX shares wire type "activeAssetCtx" with perps.
-  // Not used directly — spot mode reuses ACTIVE_ASSET_CTX with coin format detection in WS handler.
+  // Shares wire type "activeAssetCtx" with perps — spot mode reuses
+  // ACTIVE_ASSET_CTX and relies on coin format detection in the WS handler
   [ESubscriptionType.ACTIVE_SPOT_ASSET_CTX]: {
     eventType: EPerpsSubscriptionCategory.MARKET,
     priority: 2,
@@ -103,13 +103,10 @@ export interface ISubscriptionState {
   isConnected: boolean;
   l2BookOptions?: IL2BookOptions | null;
   enableLedgerUpdates?: boolean;
-  // Spot balance subscription (Balances tab)
   spotEnabled?: boolean;
-  // Spot asset contexts subscription (Token selector Spot tab)
   spotAssetCtxsEnabled?: boolean;
-  // Active spot pair for BBO/ACTIVE_ASSET_CTX subscriptions (e.g. "@107")
   currentSpotSymbol?: string;
-  // Trading mode — per-asset subscriptions are exclusive based on this
+  // Per-asset subscriptions are mutually exclusive based on this
   tradingMode?: 'perp' | 'spot';
 }
 
@@ -153,7 +150,6 @@ export function calculateRequiredSubscriptions(
 ): ISubscriptionSpec<ESubscriptionType>[] {
   const specs: ISubscriptionSpec<ESubscriptionType>[] = [];
 
-  // Market Data: All Mids across all DEXes (main + XYZ)
   const allMidsParams: IWsAllMidsParameters = {
     dex: 'ALL_DEXS',
   };
@@ -174,11 +170,9 @@ export function calculateRequiredSubscriptions(
     }),
   );
 
-  // Per-asset subscriptions are MUTUALLY EXCLUSIVE — only one mode active at a time
-  // to avoid duplicate BBO/ctx data and unnecessary bandwidth
+  // Per-asset subscriptions are mutually exclusive — avoids duplicate BBO/ctx data
   if (state.tradingMode === 'spot' && state.currentSpotSymbol) {
-    // Spot mode: reuse ACTIVE_ASSET_CTX with spot coin
-    // (wire protocol is the same "activeAssetCtx", server returns spot data for @N coins)
+    // Wire protocol is the same "activeAssetCtx"; server returns spot data for @N coins
     specs.push(
       buildSubscriptionSpec({
         type: ESubscriptionType.ACTIVE_ASSET_CTX,
@@ -204,7 +198,6 @@ export function calculateRequiredSubscriptions(
       );
     }
   } else if (state.currentSymbol) {
-    // Perps mode: subscribe to perps asset context + BBO + asset data + order book
     specs.push(
       buildSubscriptionSpec({
         type: ESubscriptionType.ACTIVE_ASSET_CTX,
@@ -303,12 +296,8 @@ export function calculateRequiredSubscriptions(
       );
     }
 
-    // Note: per-asset ACTIVE_ASSET_DATA is added in the per-asset block above
-    // (perps mode only). Global WebData3 covers the rest of the user state.
   }
-  // else: no user address — only market data subscriptions are needed.
 
-  // Spot: global asset contexts (token selector, independent of balance subscription)
   if (state.spotAssetCtxsEnabled) {
     specs.push(
       buildSubscriptionSpec({

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
@@ -153,11 +153,8 @@ export function calculateRequiredSubscriptions(
 ): ISubscriptionSpec<ESubscriptionType>[] {
   const specs: ISubscriptionSpec<ESubscriptionType>[] = [];
 
-  // Market Data: All Mids (Global)
-  // TODO: verify if 'dex' parameter is supported in sdk/types for IWsAllMidsParameters
-  // The user log shows {"type":"allMids","dex":"ALL_DEXS"}, so we include it.
+  // Market Data: All Mids across all DEXes (main + XYZ)
   const allMidsParams: IWsAllMidsParameters = {
-    // @ts-ignore
     dex: 'ALL_DEXS',
   };
   specs.push(
@@ -286,8 +283,6 @@ export function calculateRequiredSubscriptions(
     const userFillsParams: IEventUserFillsParameters = {
       user: state.currentUser,
       aggregateByTime: true,
-      // @ts-ignore
-      // reversed: true, // not working
     };
     specs.push(
       buildSubscriptionSpec({
@@ -308,27 +303,10 @@ export function calculateRequiredSubscriptions(
       );
     }
 
-    // Legacy or specific per-asset data (Optional, based on need.
-    // Usually WebData3 covers general state, but if specific asset data needed:
-    // User log implies global subscriptions are preferred.)
-    /*
-    if (state.currentSymbol) {
-      const activeAssetDataParams: IEventActiveAssetDataParameters = {
-        user: state.currentUser,
-        coin: state.currentSymbol,
-      };
-      specs.push(
-        buildSubscriptionSpec({
-          type: ESubscriptionType.ACTIVE_ASSET_DATA,
-          params: activeAssetDataParams,
-        }),
-      );
-    }
-    */
-  } else {
-    // WebData3 requires a user address.
-    // If no user, we likely only need market data (handled above).
+    // Note: per-asset ACTIVE_ASSET_DATA is added in the per-asset block above
+    // (perps mode only). Global WebData3 covers the rest of the user state.
   }
+  // else: no user address — only market data subscriptions are needed.
 
   // Spot: global asset contexts (token selector, independent of balance subscription)
   if (state.spotAssetCtxsEnabled) {

--- a/packages/kit-bg/src/states/jotai/atomNames.ts
+++ b/packages/kit-bg/src/states/jotai/atomNames.ts
@@ -109,6 +109,7 @@ export enum EAtomNames {
   spotTradesHistoryDataAtom = 'spotTradesHistoryDataAtom',
   spotAssetCtxsMapAtom = 'spotAssetCtxsMapAtom',
   spotActiveOpenOrdersAtom = 'spotActiveOpenOrdersAtom',
+  spotPairDisplayMapAtom = 'spotPairDisplayMapAtom',
   // network doctor
   networkDoctorStateAtom = 'networkDoctorStateAtom',
 

--- a/packages/kit-bg/src/states/jotai/atomNames.ts
+++ b/packages/kit-bg/src/states/jotai/atomNames.ts
@@ -106,7 +106,6 @@ export enum EAtomNames {
   spotBalancesAtom = 'spotBalancesAtom',
   spotTokenSelectorConfigPersistAtom = 'spotTokenSelectorConfigPersistAtom',
   spotTokenFavoritesPersistAtom = 'spotTokenFavoritesPersistAtom',
-  spotTradesHistoryDataAtom = 'spotTradesHistoryDataAtom',
   spotAssetCtxsMapAtom = 'spotAssetCtxsMapAtom',
   spotActiveOpenOrdersAtom = 'spotActiveOpenOrdersAtom',
   spotPairDisplayMapAtom = 'spotPairDisplayMapAtom',

--- a/packages/kit-bg/src/states/jotai/atomNames.ts
+++ b/packages/kit-bg/src/states/jotai/atomNames.ts
@@ -98,6 +98,17 @@ export enum EAtomNames {
   perpsAbstractionModeAtom = 'perpsAbstractionModeAtom',
   perpsSpotBalancesAtom = 'perpsSpotBalancesAtom',
   perpsFooterTickerModePersistAtom = 'perpsFooterTickerModePersistAtom',
+  // trading mode
+  tradingModeAtom = 'tradingModeAtom',
+  // spot
+  spotActiveAssetAtom = 'spotActiveAssetAtom',
+  spotActiveAssetCtxAtom = 'spotActiveAssetCtxAtom',
+  spotBalancesAtom = 'spotBalancesAtom',
+  spotTokenSelectorConfigPersistAtom = 'spotTokenSelectorConfigPersistAtom',
+  spotTokenFavoritesPersistAtom = 'spotTokenFavoritesPersistAtom',
+  spotTradesHistoryDataAtom = 'spotTradesHistoryDataAtom',
+  spotAssetCtxsMapAtom = 'spotAssetCtxsMapAtom',
+  spotActiveOpenOrdersAtom = 'spotActiveOpenOrdersAtom',
   // network doctor
   networkDoctorStateAtom = 'networkDoctorStateAtom',
 

--- a/packages/kit-bg/src/states/jotai/atoms/index.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/index.ts
@@ -22,6 +22,7 @@ export * from './bannerClose';
 export * from './allNetworks';
 export * from './desktopBluetooth';
 export * from './perps';
+export * from './spot';
 export * from './networkDoctor';
 export * from './swap';
 export * from './market';

--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -373,6 +373,15 @@ export const {
   initialValue: undefined,
 });
 
+// #region Trading Mode
+export type ITradingMode = 'perp' | 'spot';
+export const { target: tradingModeAtom, use: useTradingModeAtom } =
+  globalAtom<ITradingMode>({
+    name: EAtomNames.tradingModeAtom,
+    initialValue: 'perp',
+  });
+// #endregion
+
 // Token Selector Config (Persisted)
 export const {
   target: perpTokenSelectorConfigPersistAtom,

--- a/packages/kit-bg/src/states/jotai/atoms/spot.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/spot.ts
@@ -1,0 +1,150 @@
+import type {
+  IPerpsFrontendOrder,
+  ISpotBalance,
+  ISpotFormattedAssetCtx,
+  ISpotTokenSelectorConfig,
+  ISpotUniverse,
+  ITradesHistoryData,
+} from '@onekeyhq/shared/types/hyperliquid';
+
+import { EAtomNames } from '../atomNames';
+import { globalAtom } from '../utils';
+
+// #region Active Asset
+export interface ISpotActiveAssetAtom {
+  coin: string; // e.g. "@107" or "PURR/USDC"
+  assetId: number | undefined;
+  universe: ISpotUniverse | undefined;
+}
+export const { target: spotActiveAssetAtom, use: useSpotActiveAssetAtom } =
+  globalAtom<ISpotActiveAssetAtom>({
+    name: EAtomNames.spotActiveAssetAtom,
+    persist: true,
+    initialValue: {
+      coin: '',
+      assetId: undefined,
+      universe: undefined,
+    },
+  });
+
+export type ISpotActiveAssetCtxAtom =
+  | {
+      coin: string;
+      assetId: number | undefined;
+      ctx: ISpotFormattedAssetCtx;
+    }
+  | undefined;
+export const {
+  target: spotActiveAssetCtxAtom,
+  use: useSpotActiveAssetCtxAtom,
+} = globalAtom<ISpotActiveAssetCtxAtom>({
+  name: EAtomNames.spotActiveAssetCtxAtom,
+  initialValue: undefined,
+});
+// #endregion
+
+// #region Balances
+export interface ISpotBalancesAtom {
+  balances: ISpotBalance[];
+  isLoaded: boolean;
+}
+export const { target: spotBalancesAtom, use: useSpotBalancesAtom } =
+  globalAtom<ISpotBalancesAtom>({
+    name: EAtomNames.spotBalancesAtom,
+    initialValue: {
+      balances: [],
+      isLoaded: false,
+    },
+  });
+// #endregion
+
+// #region Token Selector
+export const {
+  target: spotTokenSelectorConfigPersistAtom,
+  use: useSpotTokenSelectorConfigPersistAtom,
+} = globalAtom<ISpotTokenSelectorConfig | null>({
+  name: EAtomNames.spotTokenSelectorConfigPersistAtom,
+  persist: true,
+  initialValue: {
+    field: 'volume24h',
+    direction: 'desc',
+    activeTab: 'all',
+  },
+});
+
+export interface ISpotTokenFavorites {
+  favorites: string[];
+}
+export const {
+  target: spotTokenFavoritesPersistAtom,
+  use: useSpotTokenFavoritesPersistAtom,
+} = globalAtom<ISpotTokenFavorites>({
+  name: EAtomNames.spotTokenFavoritesPersistAtom,
+  persist: true,
+  initialValue: {
+    favorites: [],
+  },
+});
+// #endregion
+
+// #region Open Orders
+export interface ISpotActiveOpenOrdersAtom {
+  accountAddress: string | undefined;
+  openOrders: IPerpsFrontendOrder[];
+}
+export const {
+  target: spotActiveOpenOrdersAtom,
+  use: useSpotActiveOpenOrdersAtom,
+} = globalAtom<ISpotActiveOpenOrdersAtom>({
+  name: EAtomNames.spotActiveOpenOrdersAtom,
+  initialValue: {
+    accountAddress: undefined,
+    openOrders: [],
+  },
+});
+// #endregion
+
+// #region Spot Pair Display Map
+// Maps pair names (@107, PURR/USDC) to display base names (HYPE, PURR)
+// Built once during refreshSpotMeta, used by trade history/orders to show readable names
+export type ISpotPairDisplayMap = Record<string, string>;
+export const {
+  target: spotPairDisplayMapAtom,
+  use: useSpotPairDisplayMapAtom,
+} = globalAtom<ISpotPairDisplayMap>({
+  name: EAtomNames.spotPairDisplayMapAtom,
+  initialValue: {},
+});
+// #endregion
+
+// #region Spot Asset Prices
+export interface ISpotAssetCtxEntry {
+  markPx: string;
+  prevDayPx?: string;
+  dayNtlVlm?: string;
+  circulatingSupply?: string;
+}
+// coin → context mapping, used by Balance tab (price/PNL) and Token selector (24h change, volume)
+export type ISpotAssetCtxsMap = Record<string, ISpotAssetCtxEntry>;
+export const { target: spotAssetCtxsMapAtom, use: useSpotAssetCtxsMapAtom } =
+  globalAtom<ISpotAssetCtxsMap>({
+    name: EAtomNames.spotAssetCtxsMapAtom,
+    initialValue: {},
+  });
+// #endregion
+
+// #region Trades History
+export type ISpotTradesHistoryDataAtom = ITradesHistoryData;
+export const {
+  target: spotTradesHistoryDataAtom,
+  use: useSpotTradesHistoryDataAtom,
+} = globalAtom<ISpotTradesHistoryDataAtom>({
+  name: EAtomNames.spotTradesHistoryDataAtom,
+  initialValue: {
+    fills: [],
+    isLoaded: false,
+    latestTime: 0,
+    accountAddress: undefined,
+  },
+});
+// #endregion

--- a/packages/kit-bg/src/states/jotai/atoms/spot.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/spot.ts
@@ -4,7 +4,6 @@ import type {
   ISpotFormattedAssetCtx,
   ISpotTokenSelectorConfig,
   ISpotUniverse,
-  ITradesHistoryData,
 } from '@onekeyhq/shared/types/hyperliquid';
 
 import { EAtomNames } from '../atomNames';
@@ -117,17 +116,3 @@ export const { target: spotAssetCtxsMapAtom, use: useSpotAssetCtxsMapAtom } =
     name: EAtomNames.spotAssetCtxsMapAtom,
     initialValue: {},
   });
-
-export type ISpotTradesHistoryDataAtom = ITradesHistoryData;
-export const {
-  target: spotTradesHistoryDataAtom,
-  use: useSpotTradesHistoryDataAtom,
-} = globalAtom<ISpotTradesHistoryDataAtom>({
-  name: EAtomNames.spotTradesHistoryDataAtom,
-  initialValue: {
-    fills: [],
-    isLoaded: false,
-    latestTime: 0,
-    accountAddress: undefined,
-  },
-});

--- a/packages/kit-bg/src/states/jotai/atoms/spot.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/spot.ts
@@ -10,9 +10,8 @@ import type {
 import { EAtomNames } from '../atomNames';
 import { globalAtom } from '../utils';
 
-// #region Active Asset
 export interface ISpotActiveAssetAtom {
-  coin: string; // e.g. "@107" or "PURR/USDC"
+  coin: string;
   assetId: number | undefined;
   universe: ISpotUniverse | undefined;
 }
@@ -41,9 +40,7 @@ export const {
   name: EAtomNames.spotActiveAssetCtxAtom,
   initialValue: undefined,
 });
-// #endregion
 
-// #region Balances
 export interface ISpotBalancesAtom {
   balances: ISpotBalance[];
   isLoaded: boolean;
@@ -56,9 +53,7 @@ export const { target: spotBalancesAtom, use: useSpotBalancesAtom } =
       isLoaded: false,
     },
   });
-// #endregion
 
-// #region Token Selector
 export const {
   target: spotTokenSelectorConfigPersistAtom,
   use: useSpotTokenSelectorConfigPersistAtom,
@@ -85,9 +80,7 @@ export const {
     favorites: [],
   },
 });
-// #endregion
 
-// #region Open Orders
 export interface ISpotActiveOpenOrdersAtom {
   accountAddress: string | undefined;
   openOrders: IPerpsFrontendOrder[];
@@ -102,11 +95,7 @@ export const {
     openOrders: [],
   },
 });
-// #endregion
 
-// #region Spot Pair Display Map
-// Maps pair names (@107, PURR/USDC) to display base names (HYPE, PURR)
-// Built once during refreshSpotMeta, used by trade history/orders to show readable names
 export type ISpotPairDisplayMap = Record<string, string>;
 export const {
   target: spotPairDisplayMapAtom,
@@ -115,25 +104,20 @@ export const {
   name: EAtomNames.spotPairDisplayMapAtom,
   initialValue: {},
 });
-// #endregion
 
-// #region Spot Asset Prices
 export interface ISpotAssetCtxEntry {
   markPx: string;
   prevDayPx?: string;
   dayNtlVlm?: string;
   circulatingSupply?: string;
 }
-// coin → context mapping, used by Balance tab (price/PNL) and Token selector (24h change, volume)
 export type ISpotAssetCtxsMap = Record<string, ISpotAssetCtxEntry>;
 export const { target: spotAssetCtxsMapAtom, use: useSpotAssetCtxsMapAtom } =
   globalAtom<ISpotAssetCtxsMap>({
     name: EAtomNames.spotAssetCtxsMapAtom,
     initialValue: {},
   });
-// #endregion
 
-// #region Trades History
 export type ISpotTradesHistoryDataAtom = ITradesHistoryData;
 export const {
   target: spotTradesHistoryDataAtom,
@@ -147,4 +131,3 @@ export const {
     accountAddress: undefined,
   },
 });
-// #endregion

--- a/packages/kit/src/hooks/usePerpFeatureGuard.ts
+++ b/packages/kit/src/hooks/usePerpFeatureGuard.ts
@@ -12,7 +12,7 @@ import { usePerpTabConfig } from './usePerpTabConfig';
 export function usePerpFeatureGuard() {
   useFocusEffect(
     useCallback(() => {
-      void backgroundApiProxy.serviceHyperliquid.updatePerpsConfigByServer();
+      void backgroundApiProxy.serviceHyperliquid.updatePerpsConfigByServerWithCache();
     }, []),
   );
 

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -1360,6 +1360,18 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       const formData = params.formData || get(tradingFormAtom());
       const env = get(tradingFormEnvAtom());
 
+      // Guard: spot order requires a valid assetId from loaded spot meta.
+      // If spot meta failed to load, spotActiveAssetAtom.assetId is undefined
+      // and we must not forward `a: undefined` to the exchange.
+      if (
+        typeof params.assetId !== 'number' ||
+        !Number.isFinite(params.assetId)
+      ) {
+        throw new OneKeyLocalError(
+          'Spot asset metadata not loaded. Please try again.',
+        );
+      }
+
       return withToast({
         asyncFn: async () => {
           set(tradingLoadingAtom(), true);
@@ -1385,6 +1397,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
                 limitPx: params.price,
                 orderType: formData.type,
                 slippage: params.slippage,
+                szDecimals: env.szDecimals,
               },
             );
           } finally {

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -21,6 +21,7 @@ import {
   spotActiveAssetAtom,
   spotActiveAssetCtxAtom,
   spotActiveOpenOrdersAtom,
+  spotAssetCtxsMapAtom,
   spotBalancesAtom,
   tradingModeAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -36,6 +37,7 @@ import { memoFn } from '@onekeyhq/shared/src/utils/cacheUtils';
 import {
   findTokensByAlias,
   formatPriceToSignificantDigits,
+  formatSpotAssetCtx,
   getTriggerEffectivePrice,
   inferTpsl,
   isSpotInstrument,
@@ -568,11 +570,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     };
   }
 
-  /**
-   * Compare two IActiveTradeInstrument values by their meaningful fields.
-   * Used to skip redundant atom writes that would create new object
-   * references and trigger downstream re-renders.
-   */
+  /** Skip redundant atom writes to avoid downstream re-renders. */
   private static _isTradeInstrumentEqual(
     a: IActiveTradeInstrument,
     b: IActiveTradeInstrument,
@@ -640,10 +638,6 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     try {
       const stored =
         await backgroundApiProxy.simpleDb.perp.getOrderBookTickOptions();
-      console.log(
-        'orderBookTickOptionsAtom__ensureOrderBookTickOptionsLoaded',
-        stored,
-      );
       set(orderBookTickOptionsAtom(), stored);
     } catch (error) {
       console.error('Failed to load order book tick options:', error);
@@ -692,7 +686,6 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
         next[symbol] = option;
       }
 
-      console.log('orderBookTickOptionsAtom__setOrderBookTickOption', next);
       set(orderBookTickOptionsAtom(), next);
 
       try {
@@ -795,7 +788,29 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
 
       await this.clearActiveAssetData.call(set);
       await tradingModeAtom.set('spot');
-      await spotActiveAssetCtxAtom.set(undefined);
+
+      // Seed ticker bar from cached data to avoid skeleton flash
+      const ctxsMap = await spotAssetCtxsMapAtom.get();
+      const cached = ctxsMap[coin];
+      if (cached) {
+        await spotActiveAssetCtxAtom.set({
+          coin,
+          assetId: spotUniverse?.assetId,
+          ctx: formatSpotAssetCtx({
+            markPx: cached.markPx,
+            midPx: null,
+            prevDayPx: cached.prevDayPx ?? '0',
+            dayNtlVlm: cached.dayNtlVlm ?? '0',
+            circulatingSupply: cached.circulatingSupply ?? '0',
+            totalSupply: '0',
+            dayBaseVlm: '0',
+            coin,
+          }),
+        });
+      } else {
+        await spotActiveAssetCtxAtom.set(undefined);
+      }
+
       await spotActiveAssetAtom.set({
         coin,
         assetId: spotUniverse?.assetId,
@@ -864,8 +879,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
   setTradeRouteViewState = contextAtomMethod(
     (get, set, patch: Partial<ITradeRouteViewState>) => {
       const current = get(tradeRouteViewStateAtom());
-      // Skip atom write when all patched values are identical to current
-      // to avoid creating a new object reference that triggers re-renders
+      // Avoid new object reference when nothing actually changed
       const keys = Object.keys(patch) as Array<keyof ITradeRouteViewState>;
       const hasChange = keys.some((k) => current[k] !== patch[k]);
       if (!hasChange) {
@@ -904,7 +918,6 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       await backgroundApiProxy.serviceHyperliquidSubscription.connect();
     }
     try {
-      console.log('updateSubscriptions__by__atomActions');
       await backgroundApiProxy.serviceHyperliquidSubscription.updateSubscriptions();
     } catch (error) {
       console.error(
@@ -1360,9 +1373,8 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       const formData = params.formData || get(tradingFormAtom());
       const env = get(tradingFormEnvAtom());
 
-      // Guard: spot order requires a valid assetId from loaded spot meta.
-      // If spot meta failed to load, spotActiveAssetAtom.assetId is undefined
-      // and we must not forward `a: undefined` to the exchange.
+      // If spot meta failed to load, assetId is undefined —
+      // we must not forward that to the exchange.
       if (
         typeof params.assetId !== 'number' ||
         !Number.isFinite(params.assetId)

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -71,10 +71,10 @@ import {
   perpsOpenOrdersByCoinAtomCache,
   perpsTokenSearchAliasesAtom,
   subscriptionActiveAtom,
+  tradeRouteViewStateAtom,
   tradingFormAtom,
   tradingFormEnvAtom,
   tradingLoadingAtom,
-  tradeRouteViewStateAtom,
 } from './atoms';
 import { EActionType, withToast } from './utils';
 
@@ -568,6 +568,18 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     };
   }
 
+  /**
+   * Compare two IActiveTradeInstrument values by their meaningful fields.
+   * Used to skip redundant atom writes that would create new object
+   * references and trigger downstream re-renders.
+   */
+  private static _isTradeInstrumentEqual(
+    a: IActiveTradeInstrument,
+    b: IActiveTradeInstrument,
+  ): boolean {
+    return a.mode === b.mode && a.coin === b.coin && a.assetId === b.assetId;
+  }
+
   updateL2Book = contextAtomMethod(async (get, set, data: HL.IBook) => {
     const activeCoin = await this._getActiveCoin();
     if (!data) {
@@ -713,10 +725,13 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     async (get, set, { coin, force }: { coin: string; force?: boolean }) => {
       const activeAsset = await perpsActiveAssetAtom.get();
       if (activeAsset?.coin === coin && !force) {
-        set(
-          activeTradeInstrumentAtom(),
-          await this._buildActiveTradeInstrument('perp'),
-        );
+        const next = await this._buildActiveTradeInstrument('perp');
+        const prev = get(activeTradeInstrumentAtom());
+        if (
+          !ContextJotaiActionsHyperliquid._isTradeInstrumentEqual(prev, next)
+        ) {
+          set(activeTradeInstrumentAtom(), next);
+        }
         return;
       }
 
@@ -756,7 +771,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
 
   changeActiveSpotAsset = contextAtomMethod(
     async (
-      _get,
+      get,
       set,
       {
         coin,
@@ -767,10 +782,13 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       if (currentSpotAsset?.coin === coin) {
         const currentMode = await tradingModeAtom.get();
         if (currentMode === 'spot') {
-          set(
-            activeTradeInstrumentAtom(),
-            await this._buildActiveTradeInstrument('spot'),
-          );
+          const next = await this._buildActiveTradeInstrument('spot');
+          const prev = get(activeTradeInstrumentAtom());
+          if (
+            !ContextJotaiActionsHyperliquid._isTradeInstrumentEqual(prev, next)
+          ) {
+            set(activeTradeInstrumentAtom(), next);
+          }
           return;
         }
       }
@@ -846,6 +864,13 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
   setTradeRouteViewState = contextAtomMethod(
     (get, set, patch: Partial<ITradeRouteViewState>) => {
       const current = get(tradeRouteViewStateAtom());
+      // Skip atom write when all patched values are identical to current
+      // to avoid creating a new object reference that triggers re-renders
+      const keys = Object.keys(patch) as Array<keyof ITradeRouteViewState>;
+      const hasChange = keys.some((k) => current[k] !== patch[k]);
+      if (!hasChange) {
+        return;
+      }
       set(tradeRouteViewStateAtom(), {
         ...current,
         ...patch,

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -17,6 +17,12 @@ import {
   perpsActiveAssetCtxAtom,
   perpsActiveAssetDataAtom,
   perpsDepositOrderAtom,
+  perpsTradingPreferencesAtom,
+  spotActiveAssetAtom,
+  spotActiveAssetCtxAtom,
+  spotActiveOpenOrdersAtom,
+  spotBalancesAtom,
+  tradingModeAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { IAccountDeriveTypes } from '@onekeyhq/kit-bg/src/vaults/types';
 import { PERPS_FILTERED_LEDGER_TYPES } from '@onekeyhq/shared/src/consts/perp';
@@ -32,11 +38,15 @@ import {
   formatPriceToSignificantDigits,
   getTriggerEffectivePrice,
   inferTpsl,
+  isSpotInstrument,
   resolveTradingSize,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type { ITokenSearchAliases } from '@onekeyhq/shared/src/utils/perpsUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
-import type { IPerpsAssetPosition } from '@onekeyhq/shared/types/hyperliquid';
+import type {
+  IPerpsAssetPosition,
+  ISpotUniverse,
+} from '@onekeyhq/shared/types/hyperliquid';
 import type * as HL from '@onekeyhq/shared/types/hyperliquid/sdk';
 import {
   EPerpsSizeInputMode,
@@ -46,6 +56,7 @@ import {
 } from '@onekeyhq/shared/types/hyperliquid/types';
 
 import {
+  activeTradeInstrumentAtom,
   bboAtom,
   connectionStateAtom,
   contextAtomMethod,
@@ -61,11 +72,17 @@ import {
   perpsTokenSearchAliasesAtom,
   subscriptionActiveAtom,
   tradingFormAtom,
+  tradingFormEnvAtom,
   tradingLoadingAtom,
+  tradeRouteViewStateAtom,
 } from './atoms';
 import { EActionType, withToast } from './utils';
 
-import type { ITradingFormData } from './atoms';
+import type {
+  IActiveTradeInstrument,
+  ITradeRouteViewState,
+  ITradingFormData,
+} from './atoms';
 
 type IChStateLite = {
   assetPositions?: HL.IPerpsAssetPosition[];
@@ -239,18 +256,27 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
 
       const prevOpenOrdersState = get(perpsActiveOpenOrdersAtom());
       const allOrders = data?.openOrders || [];
-      const openOrders = allOrders.filter(
+      const perpOrders = allOrders.filter(
         (order) =>
-          !order.coin.startsWith('@') && !this.canceledOrderIds.has(order.oid),
+          !isSpotInstrument(order.coin) &&
+          !this.canceledOrderIds.has(order.oid),
+      );
+      const spotOrders = allOrders.filter(
+        (order) =>
+          isSpotInstrument(order.coin) && !this.canceledOrderIds.has(order.oid),
       );
       const openOrdersByCoin = this.buildOpenOrdersByCoinMap(
-        openOrders,
+        perpOrders,
         prevOpenOrdersState?.openOrdersByCoin,
       );
       set(perpsActiveOpenOrdersAtom(), {
         accountAddress: activeAccountAddress,
-        openOrders,
+        openOrders: perpOrders,
         openOrdersByCoin,
+      });
+      void spotActiveOpenOrdersAtom.set({
+        accountAddress: activeAccountAddress,
+        openOrders: spotOrders,
       });
     } else {
       const activePosition = get(perpsActivePositionAtom());
@@ -272,6 +298,10 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
           openOrdersByCoin: {},
         });
       }
+      void spotActiveOpenOrdersAtom.set({
+        accountAddress: activeAccountAddress,
+        openOrders: [],
+      });
     }
   });
 
@@ -357,24 +387,37 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
             openOrders: [],
             openOrdersByCoin: {},
           });
+          void spotActiveOpenOrdersAtom.set({
+            accountAddress: activeAccountAddress,
+            openOrders: [],
+          });
         }
         return;
       }
 
       const prevOpenOrdersState = get(perpsActiveOpenOrdersAtom());
       const allOrders = data?.orders || [];
-      const openOrders = allOrders.filter(
+      const perpOrders = allOrders.filter(
         (order) =>
-          !order.coin.startsWith('@') && !this.canceledOrderIds.has(order.oid),
+          !isSpotInstrument(order.coin) &&
+          !this.canceledOrderIds.has(order.oid),
+      );
+      const spotOrders = allOrders.filter(
+        (order) =>
+          isSpotInstrument(order.coin) && !this.canceledOrderIds.has(order.oid),
       );
       const openOrdersByCoin = this.buildOpenOrdersByCoinMap(
-        openOrders,
+        perpOrders,
         prevOpenOrdersState?.openOrdersByCoin,
       );
       set(perpsActiveOpenOrdersAtom(), {
         accountAddress: activeAccountAddress,
-        openOrders,
+        openOrders: perpOrders,
         openOrdersByCoin,
+      });
+      void spotActiveOpenOrdersAtom.set({
+        accountAddress: activeAccountAddress,
+        openOrders: spotOrders,
       });
     },
   );
@@ -492,29 +535,62 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     },
   );
 
+  private async _getActiveCoin(): Promise<string> {
+    const mode = await tradingModeAtom.get();
+    if (mode === 'spot') {
+      const spotAsset = await spotActiveAssetAtom.get();
+      return spotAsset?.coin ?? '';
+    }
+    const perpAsset = await perpsActiveAssetAtom.get();
+    return perpAsset?.coin ?? '';
+  }
+
+  private async _buildActiveTradeInstrument(
+    mode?: 'perp' | 'spot',
+  ): Promise<IActiveTradeInstrument> {
+    const nextMode = mode ?? (await tradingModeAtom.get()) ?? 'perp';
+    if (nextMode === 'spot') {
+      const spotAsset = await spotActiveAssetAtom.get();
+      return {
+        mode: 'spot',
+        coin: spotAsset?.coin ?? '',
+        assetId: spotAsset?.assetId,
+        universe: spotAsset?.universe,
+      };
+    }
+
+    const perpAsset = await perpsActiveAssetAtom.get();
+    return {
+      mode: 'perp',
+      coin: perpAsset?.coin ?? '',
+      assetId: perpAsset?.assetId,
+      universe: perpAsset?.universe,
+    };
+  }
+
   updateL2Book = contextAtomMethod(async (get, set, data: HL.IBook) => {
-    const activeAsset = await perpsActiveAssetAtom.get();
+    const activeCoin = await this._getActiveCoin();
     if (!data) {
       return;
     }
-    if (activeAsset?.coin === data.coin) {
+    if (activeCoin === data.coin) {
       set(l2BookAtom(), data);
     } else {
       const currentBook = get(l2BookAtom());
-      if (currentBook?.coin && currentBook?.coin !== activeAsset?.coin) {
+      if (currentBook?.coin && currentBook?.coin !== activeCoin) {
         set(l2BookAtom(), null);
       }
     }
   });
 
   updateBbo = contextAtomMethod(async (get, set, data: HL.IWsBbo) => {
-    const activeAsset = await perpsActiveAssetAtom.get();
+    const activeCoin = await this._getActiveCoin();
     if (!data) {
       return;
     }
-    if (activeAsset?.coin !== data.coin) {
+    if (activeCoin !== data.coin) {
       const currentBbo = get(bboAtom());
-      if (currentBbo?.coin && currentBbo?.coin !== activeAsset?.coin) {
+      if (currentBbo?.coin && currentBbo?.coin !== activeCoin) {
         set(bboAtom(), null);
       }
       return;
@@ -637,6 +713,10 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     async (get, set, { coin, force }: { coin: string; force?: boolean }) => {
       const activeAsset = await perpsActiveAssetAtom.get();
       if (activeAsset?.coin === coin && !force) {
+        set(
+          activeTradeInstrumentAtom(),
+          await this._buildActiveTradeInstrument('perp'),
+        );
         return;
       }
 
@@ -644,6 +724,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       const shouldUpdateLimitPrice = form.type === 'limit';
 
       await this.clearActiveAssetData.call(set);
+      await tradingModeAtom.set('perp');
       await backgroundApiProxy.serviceHyperliquid.changeActiveAsset({
         coin,
       });
@@ -666,6 +747,109 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       }
 
       this.updateTradingForm.call(set, nextFormUpdates);
+      set(
+        activeTradeInstrumentAtom(),
+        await this._buildActiveTradeInstrument('perp'),
+      );
+    },
+  );
+
+  changeActiveSpotAsset = contextAtomMethod(
+    async (
+      _get,
+      set,
+      {
+        coin,
+        spotUniverse,
+      }: { coin: string; spotUniverse: ISpotUniverse | undefined },
+    ) => {
+      const currentSpotAsset = await spotActiveAssetAtom.get();
+      if (currentSpotAsset?.coin === coin) {
+        const currentMode = await tradingModeAtom.get();
+        if (currentMode === 'spot') {
+          set(
+            activeTradeInstrumentAtom(),
+            await this._buildActiveTradeInstrument('spot'),
+          );
+          return;
+        }
+      }
+
+      await this.clearActiveAssetData.call(set);
+      await tradingModeAtom.set('spot');
+      await spotActiveAssetCtxAtom.set(undefined);
+      await spotActiveAssetAtom.set({
+        coin,
+        assetId: spotUniverse?.assetId,
+        universe: spotUniverse,
+      });
+
+      this.updateTradingForm.call(set, {
+        size: '',
+        price: '',
+        orderMode: 'standard',
+        type: 'market',
+        bboPriceMode: null,
+        hasTpsl: false,
+        sizeInputMode: EPerpsSizeInputMode.MANUAL,
+        sizePercent: 0,
+        triggerPrice: '',
+        executionPrice: '',
+      });
+      // Spot doesn't have margin mode -- force to usd if currently set to margin
+      const currentPrefs = await perpsTradingPreferencesAtom.get();
+      if (currentPrefs.sizeInputUnit === 'margin') {
+        await perpsTradingPreferencesAtom.set({
+          ...currentPrefs,
+          sizeInputUnit: 'usd',
+        });
+      }
+      set(
+        activeTradeInstrumentAtom(),
+        await this._buildActiveTradeInstrument('spot'),
+      );
+    },
+  );
+
+  switchTradeInstrument = contextAtomMethod(
+    async (
+      _get,
+      set,
+      params: {
+        mode: 'perp' | 'spot';
+        coin: string;
+        force?: boolean;
+        spotUniverse?: ISpotUniverse;
+      },
+    ) => {
+      if (params.mode === 'spot') {
+        let spotUniverse = params.spotUniverse;
+        if (!spotUniverse) {
+          const { universes } =
+            await backgroundApiProxy.serviceHyperliquid.getSpotMeta();
+          spotUniverse = universes.find((item) => item.name === params.coin);
+        }
+        await this.changeActiveSpotAsset.call(set, {
+          coin: params.coin,
+          spotUniverse,
+        });
+        return;
+      }
+
+      await this.changeActiveAsset.call(set, {
+        coin: params.coin,
+        force: params.force,
+      });
+    },
+  );
+
+  setTradeRouteViewState = contextAtomMethod(
+    (get, set, patch: Partial<ITradeRouteViewState>) => {
+      const current = get(tradeRouteViewStateAtom());
+      set(tradeRouteViewStateAtom(), {
+        ...current,
+        ...patch,
+      });
     },
   );
 
@@ -781,6 +965,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     set(l2BookAtom(), null);
     await perpsActiveAssetCtxAtom.set(undefined);
     await perpsActiveAssetDataAtom.set(undefined);
+    await spotActiveAssetCtxAtom.set(undefined);
 
     set(
       tradingFormAtom(),
@@ -816,6 +1001,12 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     await perpsActiveAccountSummaryAtom.set(undefined);
     await perpsActiveAccountStatusInfoAtom.set(undefined);
     await perpsActiveAssetDataAtom.set(undefined);
+    // Prevent stale spot data from showing under the wrong account
+    await spotBalancesAtom.set({ balances: [], isLoaded: false });
+    void spotActiveOpenOrdersAtom.set({
+      accountAddress: undefined,
+      openOrders: [],
+    });
   });
 
   // reset all data
@@ -1130,6 +1321,56 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     },
   );
 
+  placeSpotOrder = contextAtomMethod(
+    async (
+      get,
+      set,
+      params: {
+        assetId: number;
+        formData?: ITradingFormData;
+        price: string;
+        slippage?: number;
+      },
+    ) => {
+      const formData = params.formData || get(tradingFormAtom());
+      const env = get(tradingFormEnvAtom());
+
+      return withToast({
+        asyncFn: async () => {
+          set(tradingLoadingAtom(), true);
+          try {
+            const resolvedSize = resolveTradingSize({
+              sizeInputMode: formData.sizeInputMode,
+              manualSize: formData.size,
+              sizePercent: formData.sizePercent,
+              side: formData.side,
+              price: params.price,
+              markPrice: env.markPrice,
+              maxTradeSzs: env.maxTradeSzs,
+              leverageValue: 1,
+              fallbackLeverage: 1,
+              szDecimals: env.szDecimals,
+            });
+
+            return await backgroundApiProxy.serviceHyperliquidExchange.placeSpotOrder(
+              {
+                assetId: params.assetId,
+                isBuy: formData.side === 'long',
+                sz: resolvedSize,
+                limitPx: params.price,
+                orderType: formData.type,
+                slippage: params.slippage,
+              },
+            );
+          } finally {
+            set(tradingLoadingAtom(), false);
+          }
+        },
+        actionType: EActionType.PLACE_ORDER,
+      });
+    },
+  );
+
   submitOrder = contextAtomMethod(
     async (
       get,
@@ -1142,6 +1383,16 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       },
     ) => {
       const formData = params.formData || get(tradingFormAtom());
+      const tradingMode = await tradingModeAtom.get();
+
+      if (tradingMode === 'spot') {
+        return this.placeSpotOrder.call(set, {
+          assetId: params.assetId,
+          formData,
+          slippage: params.slippage,
+          price: params.price,
+        });
+      }
 
       if (formData.orderMode === 'trigger') {
         return this.triggerOrder.call(set, {
@@ -1617,6 +1868,7 @@ export function useHyperliquidActions() {
   const setTradingLoading = actions.setTradingLoading.use();
 
   const placeOrder = actions.placeOrder.use();
+  const placeSpotOrder = actions.placeSpotOrder.use();
   const orderOpen = actions.orderOpen.use();
   const triggerOrder = actions.triggerOrder.use();
   const submitOrder = actions.submitOrder.use();
@@ -1633,6 +1885,9 @@ export function useHyperliquidActions() {
     actions.ensureOrderBookTickOptionsLoaded.use();
   const setOrderBookTickOption = actions.setOrderBookTickOption.use();
   const changeActiveAsset = actions.changeActiveAsset.use();
+  const changeActiveSpotAsset = actions.changeActiveSpotAsset.use();
+  const switchTradeInstrument = actions.switchTradeInstrument.use();
+  const setTradeRouteViewState = actions.setTradeRouteViewState.use();
   const changeActivePerpsAccount = actions.changeActivePerpsAccount.use();
   const updateAllAssetsFiltered = actions.updateAllAssetsFiltered.use();
   const ensureTradingEnabled = actions.ensureTradingEnabled.use();
@@ -1655,6 +1910,7 @@ export function useHyperliquidActions() {
     updateBbo,
     updateConnectionState,
     changeActiveAsset,
+    changeActiveSpotAsset,
     changeActivePerpsAccount,
     updateAllDexsClearinghouseState,
     updateOpenOrders,
@@ -1672,6 +1928,7 @@ export function useHyperliquidActions() {
     setTradingLoading,
 
     placeOrder,
+    placeSpotOrder,
     orderOpen,
     triggerOrder,
     submitOrder,
@@ -1689,5 +1946,7 @@ export function useHyperliquidActions() {
     refreshAllPerpsData,
     getTokenSzDecimals,
     getMidPrice,
+    switchTradeInstrument,
+    setTradeRouteViewState,
   });
 }

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/atoms.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from 'bignumber.js';
+import { selectAtom } from 'jotai/utils';
 
 import { createJotaiContext } from '@onekeyhq/kit/src/states/jotai/utils/createJotaiContext';
 import {
@@ -412,6 +413,40 @@ export const {
   };
 });
 
+// Field-by-field equality for IPerpsAssetCtx (all primitive strings + one string[] | null).
+// Used by selectAtom to return the previous reference when data is unchanged,
+// which causes Jotai to skip the notification chain → derived atoms not
+// re-evaluated → row components not re-rendered.
+function isPerpsCtxEqual(
+  a: HL.IPerpsAssetCtx | null,
+  b: HL.IPerpsAssetCtx | null,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  if (
+    a.markPx !== b.markPx ||
+    a.midPx !== b.midPx ||
+    a.funding !== b.funding ||
+    a.openInterest !== b.openInterest ||
+    a.prevDayPx !== b.prevDayPx ||
+    a.dayNtlVlm !== b.dayNtlVlm ||
+    a.oraclePx !== b.oraclePx ||
+    a.premium !== b.premium ||
+    a.dayBaseVlm !== b.dayBaseVlm
+  ) {
+    return false;
+  }
+  // impactPxs: string[] | null
+  const ai = a.impactPxs;
+  const bi = b.impactPxs;
+  if (ai === bi) return true;
+  if (!ai || !bi || ai.length !== bi.length) return false;
+  for (let i = 0; i < ai.length; i += 1) {
+    if (ai[i] !== bi[i]) return false;
+  }
+  return true;
+}
+
 export const perpsCtxByCoinAtomCache = new Map<
   string,
   ReturnType<typeof contextAtomComputed<HL.IPerpsAssetCtx | null>>
@@ -422,10 +457,23 @@ function getOrCreateCtxByCoinAtom(dexIndex: number, assetId: number) {
   let entry = perpsCtxByCoinAtomCache.get(key);
   if (!entry) {
     const ctxIndex = dexIndex === 1 ? assetId - XYZ_ASSET_ID_OFFSET : assetId;
-    entry = contextAtomComputed((get) => {
-      const { assetCtxsByDex } = get(perpsAllAssetCtxsAtom());
-      return assetCtxsByDex?.[dexIndex]?.[ctxIndex] ?? null;
-    });
+    // selectAtom passes prevSlice to the selector. Returning prevSlice when
+    // fields are unchanged makes Jotai's Object.is check pass, so the derived
+    // atom's value stays the same reference → dependents skip re-evaluation.
+    const selectedAtom = selectAtom(
+      perpsAllAssetCtxsAtom(),
+      (
+        { assetCtxsByDex }: { assetCtxsByDex: HL.IPerpsAssetCtx[][] },
+        prevCtx?: HL.IPerpsAssetCtx | null,
+      ) => {
+        const newCtx = assetCtxsByDex?.[dexIndex]?.[ctxIndex] ?? null;
+        if (prevCtx !== undefined && isPerpsCtxEqual(prevCtx, newCtx)) {
+          return prevCtx;
+        }
+        return newCtx;
+      },
+    );
+    entry = contextAtomComputed((get) => get(selectedAtom));
     perpsCtxByCoinAtomCache.set(key, entry);
   }
   return entry;

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/atoms.ts
@@ -87,6 +87,47 @@ export const {
 export const { atom: subscriptionActiveAtom, use: useSubscriptionActiveAtom } =
   contextAtom<boolean>(false);
 
+export type IActiveTradeInstrument =
+  | {
+      mode: 'perp';
+      coin: string;
+      assetId: number | undefined;
+      universe: HL.IPerpsUniverse | undefined;
+    }
+  | {
+      mode: 'spot';
+      coin: string;
+      assetId: number | undefined;
+      universe: HL.ISpotUniverse | undefined;
+    };
+
+export const {
+  atom: activeTradeInstrumentAtom,
+  use: useActiveTradeInstrumentAtom,
+} = contextAtom<IActiveTradeInstrument>({
+  mode: 'perp',
+  coin: '',
+  assetId: undefined,
+  universe: undefined,
+});
+
+export interface ITradeRouteViewState {
+  routeFocused: boolean;
+  tokenSelectorOpen: boolean;
+  tokenSelectorTab: string;
+  infoPanelTab: string;
+}
+
+export const {
+  atom: tradeRouteViewStateAtom,
+  use: useTradeRouteViewStateAtom,
+} = contextAtom<ITradeRouteViewState>({
+  routeFocused: false,
+  tokenSelectorOpen: false,
+  tokenSelectorTab: 'all',
+  infoPanelTab: 'Positions',
+});
+
 export type IBBOPriceMode =
   | null
   | { type: 'counterparty'; level: number }

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/index.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/index.ts
@@ -7,6 +7,8 @@ export {
   useOrderBookTickOptionsAtom,
   usePerpsActiveOpenOrdersAtom,
   usePerpsOpenOrdersByCoin,
+  useActiveTradeInstrumentAtom,
+  useTradeRouteViewStateAtom,
   useTradingFormAtom,
   useTradingFormEnvAtom,
   useTradingFormComputedAtom,
@@ -17,7 +19,12 @@ export {
   usePerpsLedgerUpdatesAtom,
 } from './atoms';
 
-export type { ITradingFormData, IBBOPriceMode } from './atoms';
+export type {
+  ITradingFormData,
+  IBBOPriceMode,
+  IActiveTradeInstrument,
+  ITradeRouteViewState,
+} from './atoms';
 
 export { useHyperliquidActions } from './actions';
 

--- a/packages/kit/src/views/Perp/components/FavoritesBar/FavoriteTokenItem.tsx
+++ b/packages/kit/src/views/Perp/components/FavoritesBar/FavoriteTokenItem.tsx
@@ -7,11 +7,14 @@ import {
   XStack,
 } from '@onekeyhq/components';
 import { Token } from '@onekeyhq/kit/src/components/Token';
+import { useActiveTradeInstrumentAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import { usePerpsCtxByCoin } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
 import {
   type IPerpFavoritesDisplayMode,
   usePerpsActiveAssetAtom,
   usePerpsActiveAssetCtxAtom,
+  useSpotActiveAssetCtxAtom,
+  useSpotAssetCtxsMapAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import perpsUtils, {
@@ -68,32 +71,62 @@ interface IFavoriteTokenItemProps {
   coinName: string;
   dexIndex: number;
   assetId: number;
+  imageTokenName: string;
+  mode: 'perp' | 'spot';
   onPress: () => void;
   displayMode?: IPerpFavoritesDisplayMode;
 }
 
+function formatSpotPriceEntry(spotEntry?: {
+  markPx?: string;
+  prevDayPx?: string;
+}) {
+  const markPrice = spotEntry?.markPx ?? '0';
+  const markPriceNumber = Number(markPrice);
+  const prevDayPriceNumber = Number(spotEntry?.prevDayPx ?? '0');
+  const change24hPercent =
+    Number.isFinite(prevDayPriceNumber) && prevDayPriceNumber > 0
+      ? ((markPriceNumber - prevDayPriceNumber) / prevDayPriceNumber) * 100
+      : 0;
+
+  return {
+    change24hPercent: Number.isFinite(change24hPercent) ? change24hPercent : 0,
+    markPrice,
+  };
+}
+
 const CtxPriceDisplay = memo(
   ({
+    coinName,
     dexIndex,
     assetId,
     displayMode = 'price',
+    mode,
   }: {
+    coinName: string;
     dexIndex: number;
     assetId: number;
     displayMode?: IPerpFavoritesDisplayMode;
+    mode: 'perp' | 'spot';
   }) => {
     const ctx = usePerpsCtxByCoin(dexIndex, assetId);
+    const [spotPriceMap] = useSpotAssetCtxsMapAtom();
     const formattedCtx = useMemo(() => perpsUtils.formatAssetCtx(ctx), [ctx]);
+    const formattedSpotCtx = useMemo(
+      () => formatSpotPriceEntry(spotPriceMap[coinName]),
+      [coinName, spotPriceMap],
+    );
+    const displayCtx = mode === 'spot' ? formattedSpotCtx : formattedCtx;
 
-    const priceDisplay = formattedCtx?.markPrice
-      ? formatPriceToSignificantDigits(formattedCtx.markPrice)
+    const priceDisplay = displayCtx?.markPrice
+      ? formatPriceToSignificantDigits(displayCtx.markPrice)
       : '-';
 
-    const change24hPercent = formattedCtx?.change24hPercent ?? 0;
+    const change24hPercent = displayCtx?.change24hPercent ?? 0;
     const color = change24hPercent >= 0 ? '$textSuccess' : '$textCritical';
 
     const skeletonWidth = displayMode === 'price' ? 46 : 60;
-    if (formattedCtx?.markPrice === '0') {
+    if (displayCtx?.markPrice === '0') {
       return <Skeleton width={skeletonWidth} height={16} />;
     }
 
@@ -129,23 +162,37 @@ CtxPriceDisplay.displayName = 'CtxPriceDisplay';
 
 const ActiveAssetPriceDisplay = memo(
   ({
+    coinName,
     dexIndex,
     assetId,
     displayMode = 'price',
+    mode,
   }: {
+    coinName: string;
     dexIndex: number;
     assetId: number;
     displayMode?: IPerpFavoritesDisplayMode;
+    mode: 'perp' | 'spot';
   }) => {
     const [assetCtx] = usePerpsActiveAssetCtxAtom();
+    const [spotActiveAssetCtx] = useSpotActiveAssetCtxAtom();
     const fallbackCtx = usePerpsCtxByCoin(dexIndex, assetId);
+    const [spotPriceMap] = useSpotAssetCtxsMapAtom();
     const formattedFallback = useMemo(
       () => perpsUtils.formatAssetCtx(fallbackCtx),
       [fallbackCtx],
     );
+    const formattedSpotFallback = useMemo(
+      () => formatSpotPriceEntry(spotPriceMap[coinName]),
+      [coinName, spotPriceMap],
+    );
 
     const activeCtx = assetCtx?.ctx;
-    const ctx = activeCtx?.markPrice ? activeCtx : formattedFallback;
+    const spotCtx = spotActiveAssetCtx?.ctx;
+    let ctx = activeCtx?.markPrice ? activeCtx : formattedFallback;
+    if (mode === 'spot') {
+      ctx = spotCtx?.markPrice ? spotCtx : formattedSpotFallback;
+    }
 
     const priceDisplay = ctx?.markPrice
       ? formatPriceToSignificantDigits(ctx.markPrice)
@@ -219,11 +266,18 @@ function FavoriteTokenItem({
   coinName,
   dexIndex,
   assetId,
+  imageTokenName,
+  mode,
   onPress,
   displayMode = 'price',
 }: IFavoriteTokenItemProps) {
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const [activeAsset] = usePerpsActiveAssetAtom();
-  const isActiveToken = activeAsset?.coin === coinName;
+  const isActiveToken =
+    mode === 'spot'
+      ? activeTradeInstrument.mode === 'spot' &&
+        activeTradeInstrument.coin === coinName
+      : activeAsset?.coin === coinName;
 
   return (
     <XStack
@@ -242,7 +296,7 @@ function FavoriteTokenItem({
       <Token
         size="xs"
         borderRadius="$full"
-        tokenImageUri={getHyperliquidTokenImageUrl(displayName)}
+        tokenImageUri={getHyperliquidTokenImageUrl(imageTokenName)}
         fallbackIcon="CryptoCoinOutline"
       />
       <SizableText size="$bodySmMedium" color="$text">
@@ -250,15 +304,19 @@ function FavoriteTokenItem({
       </SizableText>
       {isActiveToken ? (
         <ActiveAssetPriceDisplay
+          coinName={coinName}
           dexIndex={dexIndex}
           assetId={assetId}
           displayMode={displayMode}
+          mode={mode}
         />
       ) : (
         <CtxPriceDisplay
+          coinName={coinName}
           dexIndex={dexIndex}
           assetId={assetId}
           displayMode={displayMode}
+          mode={mode}
         />
       )}
     </XStack>

--- a/packages/kit/src/views/Perp/components/FavoritesBar/FavoriteTokenItem.tsx
+++ b/packages/kit/src/views/Perp/components/FavoritesBar/FavoriteTokenItem.tsx
@@ -189,7 +189,8 @@ const ActiveAssetPriceDisplay = memo(
 
     const activeCtx = assetCtx?.ctx;
     const spotCtx = spotActiveAssetCtx?.ctx;
-    let ctx = activeCtx?.markPrice ? activeCtx : formattedFallback;
+    let ctx: { markPrice?: string; change24hPercent?: number } =
+      activeCtx?.markPrice ? activeCtx : formattedFallback;
     if (mode === 'spot') {
       ctx = spotCtx?.markPrice ? spotCtx : formattedSpotFallback;
     }

--- a/packages/kit/src/views/Perp/components/FavoritesBar/FavoritesBar.web.tsx
+++ b/packages/kit/src/views/Perp/components/FavoritesBar/FavoritesBar.web.tsx
@@ -11,7 +11,10 @@ import { noop } from 'lodash';
 import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
 
 import { Icon, SizableText, Stack, XStack } from '@onekeyhq/components';
-import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import {
+  useActiveTradeInstrumentAtom,
+  useHyperliquidActions,
+} from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
   type IPerpFavoritesDisplayMode,
   usePerpTokenFavoritesPersistAtom,
@@ -149,7 +152,8 @@ const ScrollButton = memo(
 ScrollButton.displayName = 'ScrollButton';
 
 function FavoritesBar() {
-  const { favoriteItems } = usePerpsFavorites();
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
+  const { favoriteItems } = usePerpsFavorites({ mode: 'current' });
   const actions = useHyperliquidActions();
   const hasFavorites = favoriteItems.length > 0;
 
@@ -209,6 +213,8 @@ function FavoritesBar() {
             coinName={item.coinName}
             dexIndex={item.dexIndex}
             assetId={item.assetId}
+            imageTokenName={item.imageTokenName}
+            mode={item.mode}
             displayMode={displayMode}
             onPress={noop}
           />
@@ -267,14 +273,14 @@ function FavoritesBar() {
   }, []);
 
   useEffect(() => {
-    if (hasFavorites) {
+    if (hasFavorites && activeTradeInstrument.mode === 'perp') {
       const currentActions = actions.current;
       currentActions.markAllAssetCtxsRequired();
       return () => {
         currentActions.markAllAssetCtxsNotRequired();
       };
     }
-  }, [actions, hasFavorites]);
+  }, [actions, activeTradeInstrument.mode, hasFavorites]);
 
   if (!hasFavorites) {
     return null;
@@ -337,10 +343,13 @@ function FavoritesBar() {
                           coinName={item.coinName}
                           dexIndex={item.dexIndex}
                           assetId={item.assetId}
+                          imageTokenName={item.imageTokenName}
+                          mode={item.mode}
                           displayMode={displayMode}
                           onPress={() =>
-                            void actions.current.changeActiveAsset({
+                            void actions.current.switchTradeInstrument({
                               coin: item.coinName,
+                              mode: item.mode,
                             })
                           }
                         />

--- a/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerItem.tsx
+++ b/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerItem.tsx
@@ -1,10 +1,13 @@
 import { memo, useMemo } from 'react';
 
 import { SizableText, XStack } from '@onekeyhq/components';
+import { useActiveTradeInstrumentAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import { usePerpsCtxByCoin } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
 import {
   usePerpsActiveAssetAtom,
   usePerpsActiveAssetCtxAtom,
+  useSpotActiveAssetCtxAtom,
+  useSpotAssetCtxsMapAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import perpsUtils from '@onekeyhq/shared/src/utils/perpsUtils';
 
@@ -15,18 +18,54 @@ interface IFooterTickerItemProps {
   coinName: string;
   dexIndex: number;
   assetId: number;
+  mode: 'perp' | 'spot';
   onPress: () => void;
+}
+
+function formatSpotPriceEntry(spotEntry?: {
+  markPx?: string;
+  prevDayPx?: string;
+}) {
+  const markPrice = spotEntry?.markPx ?? '0';
+  const markPriceNumber = Number(markPrice);
+  const prevDayPriceNumber = Number(spotEntry?.prevDayPx ?? '0');
+  const change24hPercent =
+    Number.isFinite(prevDayPriceNumber) && prevDayPriceNumber > 0
+      ? ((markPriceNumber - prevDayPriceNumber) / prevDayPriceNumber) * 100
+      : 0;
+
+  return {
+    change24hPercent: Number.isFinite(change24hPercent) ? change24hPercent : 0,
+    markPrice,
+  };
 }
 
 // Price display for non-active tokens (reads from batch asset ctxs)
 const CtxPrice = memo(
-  ({ dexIndex, assetId }: { dexIndex: number; assetId: number }) => {
+  ({
+    coinName,
+    dexIndex,
+    assetId,
+    mode,
+  }: {
+    coinName: string;
+    dexIndex: number;
+    assetId: number;
+    mode: 'perp' | 'spot';
+  }) => {
     const ctx = usePerpsCtxByCoin(dexIndex, assetId);
+    const [spotPriceMap] = useSpotAssetCtxsMapAtom();
     const formatted = useMemo(() => perpsUtils.formatAssetCtx(ctx), [ctx]);
+    const formattedSpot = useMemo(
+      () => formatSpotPriceEntry(spotPriceMap[coinName]),
+      [coinName, spotPriceMap],
+    );
+    const displayCtx = mode === 'spot' ? formattedSpot : formatted;
+
     return (
       <PriceChangeDisplay
-        change={formatted?.change24hPercent ?? 0}
-        markPrice={formatted?.markPrice}
+        change={displayCtx?.change24hPercent ?? 0}
+        markPrice={displayCtx?.markPrice}
       />
     );
   },
@@ -35,16 +74,36 @@ CtxPrice.displayName = 'CtxPrice';
 
 // Price display for the currently active token (higher update frequency)
 const ActivePrice = memo(
-  ({ dexIndex, assetId }: { dexIndex: number; assetId: number }) => {
+  ({
+    coinName,
+    dexIndex,
+    assetId,
+    mode,
+  }: {
+    coinName: string;
+    dexIndex: number;
+    assetId: number;
+    mode: 'perp' | 'spot';
+  }) => {
     const [assetCtx] = usePerpsActiveAssetCtxAtom();
+    const [spotActiveAssetCtx] = useSpotActiveAssetCtxAtom();
     const fallbackCtx = usePerpsCtxByCoin(dexIndex, assetId);
+    const [spotPriceMap] = useSpotAssetCtxsMapAtom();
     const formattedFallback = useMemo(
       () => perpsUtils.formatAssetCtx(fallbackCtx),
       [fallbackCtx],
     );
+    const formattedSpotFallback = useMemo(
+      () => formatSpotPriceEntry(spotPriceMap[coinName]),
+      [coinName, spotPriceMap],
+    );
 
     const activeCtx = assetCtx?.ctx;
-    const ctx = activeCtx?.markPrice ? activeCtx : formattedFallback;
+    const spotCtx = spotActiveAssetCtx?.ctx;
+    let ctx = activeCtx?.markPrice ? activeCtx : formattedFallback;
+    if (mode === 'spot') {
+      ctx = spotCtx?.markPrice ? spotCtx : formattedSpotFallback;
+    }
 
     return (
       <PriceChangeDisplay
@@ -61,10 +120,16 @@ function FooterTickerItem({
   coinName,
   dexIndex,
   assetId,
+  mode,
   onPress,
 }: IFooterTickerItemProps) {
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const [activeAsset] = usePerpsActiveAssetAtom();
-  const isActive = activeAsset?.coin === coinName;
+  const isActive =
+    mode === 'spot'
+      ? activeTradeInstrument.mode === 'spot' &&
+        activeTradeInstrument.coin === coinName
+      : activeAsset?.coin === coinName;
 
   return (
     <XStack
@@ -84,9 +149,19 @@ function FooterTickerItem({
         {displayName}
       </SizableText>
       {isActive ? (
-        <ActivePrice dexIndex={dexIndex} assetId={assetId} />
+        <ActivePrice
+          coinName={coinName}
+          dexIndex={dexIndex}
+          assetId={assetId}
+          mode={mode}
+        />
       ) : (
-        <CtxPrice dexIndex={dexIndex} assetId={assetId} />
+        <CtxPrice
+          coinName={coinName}
+          dexIndex={dexIndex}
+          assetId={assetId}
+          mode={mode}
+        />
       )}
     </XStack>
   );

--- a/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerItem.tsx
+++ b/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerItem.tsx
@@ -100,7 +100,8 @@ const ActivePrice = memo(
 
     const activeCtx = assetCtx?.ctx;
     const spotCtx = spotActiveAssetCtx?.ctx;
-    let ctx = activeCtx?.markPrice ? activeCtx : formattedFallback;
+    let ctx: { markPrice?: string; change24hPercent?: number } =
+      activeCtx?.markPrice ? activeCtx : formattedFallback;
     if (mode === 'spot') {
       ctx = spotCtx?.markPrice ? spotCtx : formattedSpotFallback;
     }

--- a/packages/kit/src/views/Perp/components/FooterTicker/PerpFooterTicker.web.tsx
+++ b/packages/kit/src/views/Perp/components/FooterTicker/PerpFooterTicker.web.tsx
@@ -1,7 +1,10 @@
 import { memo, useEffect } from 'react';
 
 import { XStack } from '@onekeyhq/components';
-import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import {
+  useActiveTradeInstrumentAtom,
+  useHyperliquidActions,
+} from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import { usePerpsFooterTickerModePersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 
 import { usePerpsFavorites } from '../../hooks/usePerpsFavorites';
@@ -27,8 +30,12 @@ const PopularTickerList = memo(() => {
           coinName={item.coinName}
           dexIndex={item.dexIndex}
           assetId={item.assetId}
+          mode={item.mode}
           onPress={() =>
-            void actions.current.changeActiveAsset({ coin: item.coinName })
+            void actions.current.switchTradeInstrument({
+              coin: item.coinName,
+              mode: item.mode,
+            })
           }
         />
       ))}
@@ -39,7 +46,7 @@ PopularTickerList.displayName = 'PopularTickerList';
 
 // Ticker list for Favorites mode
 const FavoritesTickerList = memo(() => {
-  const { favoriteItems } = usePerpsFavorites();
+  const { favoriteItems } = usePerpsFavorites({ mode: 'current' });
   const actions = useHyperliquidActions();
 
   if (!favoriteItems.length) return null;
@@ -53,8 +60,12 @@ const FavoritesTickerList = memo(() => {
           coinName={item.coinName}
           dexIndex={item.dexIndex}
           assetId={item.assetId}
+          mode={item.mode}
           onPress={() =>
-            void actions.current.changeActiveAsset({ coin: item.coinName })
+            void actions.current.switchTradeInstrument({
+              coin: item.coinName,
+              mode: item.mode,
+            })
           }
         />
       ))}
@@ -64,20 +75,21 @@ const FavoritesTickerList = memo(() => {
 FavoritesTickerList.displayName = 'FavoritesTickerList';
 
 function PerpFooterTicker() {
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const [footerMode] = usePerpsFooterTickerModePersistAtom();
   const actions = useHyperliquidActions();
   const isVisible = footerMode.mode !== 'none';
 
   // Request batch asset ctx updates when footer is visible
   useEffect(() => {
-    if (isVisible) {
+    if (isVisible && activeTradeInstrument.mode === 'perp') {
       const currentActions = actions.current;
       currentActions.markAllAssetCtxsRequired();
       return () => {
         currentActions.markAllAssetCtxsNotRequired();
       };
     }
-  }, [actions, isVisible]);
+  }, [actions, activeTradeInstrument.mode, isVisible]);
 
   // Embedded inside PerpContentFooter — no own container, just fills flex space
   if (!isVisible) {

--- a/packages/kit/src/views/Perp/components/OrderBook/useAggregatedBook.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/useAggregatedBook.tsx
@@ -1,7 +1,6 @@
 import BigNumber from 'bignumber.js';
 
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
-import { formatWithPrecision } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type { IBookLevel } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
 import { type ITickParam } from './tickSizeUtils';
@@ -55,7 +54,11 @@ const withDisplayFields = (
     displayCumSize: formatOrderBookValue(level.cumSize, variant),
   }));
 
-// Aggregates in 1 iteration using BigNumber for precision
+// Aggregates levels by tick size in one pass.
+// Size/cumSize tracking uses native Number — display-only values with ≤8 significant
+// digits, no precision loss. BigNumber is kept only for price tick rounding because
+// native floor/ceil can silently misalign on IEEE 754 boundary values (e.g.
+// 40.93 * 100 = 4092.9999... in float64), which BigNumber handles correctly.
 export function aggregateLevels(
   levels: IOBLevel[],
   maxLevelsPerSide: number,
@@ -71,8 +74,8 @@ export function aggregateLevels(
     };
   }
 
-  let cumSizeBN = new BigNumber(0);
-  let maxSizeBN = new BigNumber(0);
+  let cumSize = 0;
+  let maxSize = 0;
   let currLevel: IOBLevel = {
     price: '0',
     size: '0',
@@ -80,15 +83,13 @@ export function aggregateLevels(
   };
   const aggregatedLevels: IOBLevel[] = [currLevel];
 
-  // Pre-compute BigNumber tick factors for fast path rounding
   const tickSizeBN = new BigNumber(tickSize);
   const invTickSizeBN = new BigNumber(1).dividedBy(tickSizeBN);
 
   for (let i = 0; i < levels.length; i += 1) {
     const level = levels[i];
-    const levelSizeBN = new BigNumber(level.size);
-    cumSizeBN = cumSizeBN.plus(levelSizeBN);
-    // Fast path: avoid validation and duplicate toFixed
+    const levelSize = parseFloat(level.size);
+    cumSize += levelSize;
     const roundedPrice =
       roundingMode === 'floor'
         ? floorToTickFast(
@@ -105,22 +106,22 @@ export function aggregateLevels(
     if (currLevel.price === '0' || roundedPrice === currLevel.price) {
       // Add to current level.
       currLevel.price = roundedPrice;
-      const currLevelSizeBN = new BigNumber(currLevel.size).plus(levelSizeBN);
-      currLevel.size = formatWithPrecision(currLevelSizeBN, sizeDecimals);
-      currLevel.cumSize = formatWithPrecision(cumSizeBN, sizeDecimals);
+      currLevel.size = (parseFloat(currLevel.size) + levelSize).toFixed(
+        sizeDecimals,
+      );
+      currLevel.cumSize = cumSize.toFixed(sizeDecimals);
     } else {
       // Create and push new level.
       currLevel = {
         price: roundedPrice,
         size: level.size,
-        cumSize: formatWithPrecision(cumSizeBN, sizeDecimals),
+        cumSize: cumSize.toFixed(sizeDecimals),
       };
       aggregatedLevels.push(currLevel);
     }
 
-    // Update largest level size using BigNumber comparison.
-    if (maxSizeBN.isLessThan(levelSizeBN)) {
-      maxSizeBN = levelSizeBN;
+    if (levelSize > maxSize) {
+      maxSize = levelSize;
     }
 
     // Exit if reached max levels.
@@ -131,7 +132,7 @@ export function aggregateLevels(
 
   return {
     aggregatedLevels,
-    maxSize: formatWithPrecision(maxSizeBN, sizeDecimals),
+    maxSize: maxSize.toFixed(sizeDecimals),
   };
 }
 
@@ -144,7 +145,7 @@ function getMaxSizeFromPrefix(
     Math.max(count - 1, 0),
     Math.max(prefixMaxSizes.length - 1, 0),
   );
-  return prefixMaxSizes[idx] ?? formatWithPrecision(0, sizeDecimals);
+  return prefixMaxSizes[idx] ?? (0).toFixed(sizeDecimals);
 }
 
 function sumAndSlice(
@@ -176,25 +177,28 @@ function sumAndSlice(
   };
 }
 
-// Convert HL.IBookLevel to IOBLevel format using BigNumber for precision
+// Convert HL.IBookLevel to IOBLevel format.
+// Native Number is used instead of BigNumber throughout: HL price/size values are
+// standard decimal strings well within float64 precision, and this is display-only
+// formatting with no financial arithmetic. BigNumber would add 10-50x overhead
+// with zero precision benefit here.
 function convertHLBookLevelsToIOBLevels(
   levels: IBookLevel[],
   priceDecimals: number,
   sizeDecimals: number,
 ): { levels: IOBLevel[]; prefixMaxSizes: string[] } {
-  let cumSizeBN = new BigNumber(0);
-  let runningMaxSizeBN = new BigNumber(0);
+  let cumSize = 0;
+  let runningMax = 0;
   const prefixMaxSizes: string[] = [];
   const converted: IOBLevel[] = levels.map((level) => {
-    const priceBN = new BigNumber(level.px);
-    const sizeBN = new BigNumber(level.sz);
-    cumSizeBN = cumSizeBN.plus(sizeBN);
-    runningMaxSizeBN = BigNumber.maximum(sizeBN, runningMaxSizeBN);
-    prefixMaxSizes.push(runningMaxSizeBN.toFixed(sizeDecimals));
+    const size = parseFloat(level.sz);
+    cumSize += size;
+    if (size > runningMax) runningMax = size;
+    prefixMaxSizes.push(runningMax.toFixed(sizeDecimals));
     return {
-      price: formatWithPrecision(priceBN, priceDecimals),
-      size: formatWithPrecision(sizeBN, sizeDecimals),
-      cumSize: formatWithPrecision(cumSizeBN, sizeDecimals),
+      price: parseFloat(level.px).toFixed(priceDecimals),
+      size: size.toFixed(sizeDecimals),
+      cumSize: cumSize.toFixed(sizeDecimals),
     };
   });
   return { levels: converted, prefixMaxSizes };

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/BalanceRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/BalanceRow.tsx
@@ -1,6 +1,12 @@
 import { memo, useMemo } from 'react';
 
-import { SizableText, XStack, YStack } from '@onekeyhq/components';
+import {
+  IconButton,
+  SizableText,
+  XStack,
+  YStack,
+  useClipboard,
+} from '@onekeyhq/components';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
@@ -48,13 +54,39 @@ function getCoinLabel(item: IBalanceDisplayItem): string {
   return item.type === 'perps' ? `${item.coin} (Perps)` : `${item.coin} (Spot)`;
 }
 
+function ContractAddressCell({
+  contract,
+  size = '$bodyXs',
+}: {
+  contract?: string;
+  size?: '$bodyXs' | '$bodySmMedium';
+}) {
+  const { copyText } = useClipboard();
+  if (!contract) return null;
+  const shortened = `${contract.slice(0, 6)}...${contract.slice(-4)}`;
+  return (
+    <XStack gap="$1" alignItems="center">
+      <SizableText size={size} color="$textSubdued">
+        {shortened}
+      </SizableText>
+      <IconButton
+        size="small"
+        variant="tertiary"
+        icon="Copy3Outline"
+        iconProps={{ size: '$3', color: '$iconSubdued' }}
+        onPress={(e) => {
+          e?.stopPropagation?.();
+          copyText(contract);
+        }}
+      />
+    </XStack>
+  );
+}
+
 function BalanceRowMobile({ item }: IBalanceRowProps) {
   const label = getCoinLabel(item);
   const pnlText = formatPnlText(item.pnl, item.pnlPercent);
   const pnlColor = getPnlColor(item.pnl);
-  const contractShort = item.contract
-    ? `${item.contract.slice(0, 6)}...${item.contract.slice(-4)}`
-    : '';
 
   return (
     <ListItem py="$2.5" px="$5">
@@ -62,11 +94,7 @@ function BalanceRowMobile({ item }: IBalanceRowProps) {
         <XStack justifyContent="space-between" alignItems="center">
           <XStack gap="$1.5" alignItems="center">
             <SizableText size="$bodyMdMedium">{label}</SizableText>
-            {contractShort ? (
-              <SizableText size="$bodyXs" color="$textSubdued">
-                {contractShort}
-              </SizableText>
-            ) : null}
+            <ContractAddressCell contract={item.contract} />
           </XStack>
           <SizableText size="$bodyMdMedium">
             {numberFormat(item.usdcValue, balanceCurrencyFormatter)}
@@ -99,9 +127,7 @@ function BalanceRowDesktop({ item, columnConfigs, index }: IBalanceRowProps) {
       available: `${item.available} ${item.coin}`,
       usdcValue: numberFormat(item.usdcValue, balanceCurrencyFormatter),
       pnl: pnlText,
-      contract: item.contract
-        ? `${item.contract.slice(0, 6)}...${item.contract.slice(-4)}`
-        : '',
+      contract: '',
     };
     return columnConfigs.map((col) => ({
       ...col,
@@ -123,12 +149,19 @@ function BalanceRowDesktop({ item, columnConfigs, index }: IBalanceRowProps) {
           alignItems="center"
           justifyContent={calcCellAlign(cell.align)}
         >
-          <SizableText
-            size="$bodySmMedium"
-            color={cell.key === 'pnl' ? pnlColor : undefined}
-          >
-            {cell.cellValue}
-          </SizableText>
+          {cell.key === 'contract' ? (
+            <ContractAddressCell
+              contract={item.contract}
+              size="$bodySmMedium"
+            />
+          ) : (
+            <SizableText
+              size="$bodySmMedium"
+              color={cell.key === 'pnl' ? pnlColor : undefined}
+            >
+              {cell.cellValue}
+            </SizableText>
+          )}
         </XStack>
       ))}
     </XStack>

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/BalanceRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/BalanceRow.tsx
@@ -66,7 +66,7 @@ function ContractAddressCell({
   const shortened = `${contract.slice(0, 6)}...${contract.slice(-4)}`;
   return (
     <XStack gap="$1" alignItems="center">
-      <SizableText size={size} color="$textSubdued">
+      <SizableText size={size} color="$textSubdued" fontFamily="$monoRegular">
         {shortened}
       </SizableText>
       <IconButton

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/BalanceRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/BalanceRow.tsx
@@ -28,6 +28,7 @@ interface IBalanceRowProps {
   columnConfigs: IColumnConfig[];
   isMobile?: boolean;
   index: number;
+  onChangeAsset?: () => void;
 }
 
 function formatPnlText(pnl?: string, pnlPercent?: number): string {
@@ -83,17 +84,24 @@ function ContractAddressCell({
   );
 }
 
-function BalanceRowMobile({ item }: IBalanceRowProps) {
+function BalanceRowMobile({ item, onChangeAsset }: IBalanceRowProps) {
   const label = getCoinLabel(item);
   const pnlText = formatPnlText(item.pnl, item.pnlPercent);
   const pnlColor = getPnlColor(item.pnl);
+  const isAssetClickable = !!item.isAssetClickable;
 
   return (
     <ListItem py="$2.5" px="$5">
       <YStack flex={1} gap="$0.5">
         <XStack justifyContent="space-between" alignItems="center">
           <XStack gap="$1.5" alignItems="center">
-            <SizableText size="$bodyMdMedium">{label}</SizableText>
+            <SizableText
+              size="$bodyMdMedium"
+              color={isAssetClickable ? '$green11' : undefined}
+              onPress={onChangeAsset}
+            >
+              {label}
+            </SizableText>
             <ContractAddressCell contract={item.contract} />
           </XStack>
           <SizableText size="$bodyMdMedium">
@@ -115,10 +123,16 @@ function BalanceRowMobile({ item }: IBalanceRowProps) {
   );
 }
 
-function BalanceRowDesktop({ item, columnConfigs, index }: IBalanceRowProps) {
+function BalanceRowDesktop({
+  item,
+  columnConfigs,
+  index,
+  onChangeAsset,
+}: IBalanceRowProps) {
   const label = getCoinLabel(item);
   const pnlText = formatPnlText(item.pnl, item.pnlPercent);
   const pnlColor = getPnlColor(item.pnl);
+  const isAssetClickable = !!item.isAssetClickable;
 
   const cells = useMemo(() => {
     const cellValues: Record<string, string> = {
@@ -135,10 +149,44 @@ function BalanceRowDesktop({ item, columnConfigs, index }: IBalanceRowProps) {
     }));
   }, [item, label, pnlText, columnConfigs]);
 
+  const renderCellContent = (cell: (typeof cells)[number]) => {
+    if (cell.key === 'contract') {
+      return (
+        <ContractAddressCell contract={item.contract} size="$bodySmMedium" />
+      );
+    }
+
+    if (cell.key === 'coin') {
+      return (
+        <SizableText
+          size="$bodySmMedium"
+          fontWeight={600}
+          color={isAssetClickable ? '$green11' : undefined}
+          onPress={onChangeAsset}
+          cursor={isAssetClickable ? 'pointer' : 'default'}
+          hoverStyle={isAssetClickable ? { fontWeight: 600 } : undefined}
+          pressStyle={isAssetClickable ? { fontWeight: 600 } : undefined}
+        >
+          {cell.cellValue}
+        </SizableText>
+      );
+    }
+
+    return (
+      <SizableText
+        size="$bodySmMedium"
+        color={cell.key === 'pnl' ? pnlColor : undefined}
+      >
+        {cell.cellValue}
+      </SizableText>
+    );
+  };
+
   return (
     <XStack
-      py="$2"
+      py="$1.5"
       px="$5"
+      minHeight={48}
       bg={index % 2 === 0 ? '$bgApp' : '$bg'}
       hoverStyle={{ bg: '$bgHover' }}
     >
@@ -149,19 +197,7 @@ function BalanceRowDesktop({ item, columnConfigs, index }: IBalanceRowProps) {
           alignItems="center"
           justifyContent={calcCellAlign(cell.align)}
         >
-          {cell.key === 'contract' ? (
-            <ContractAddressCell
-              contract={item.contract}
-              size="$bodySmMedium"
-            />
-          ) : (
-            <SizableText
-              size="$bodySmMedium"
-              color={cell.key === 'pnl' ? pnlColor : undefined}
-            >
-              {cell.cellValue}
-            </SizableText>
-          )}
+          {renderCellContent(cell)}
         </XStack>
       ))}
     </XStack>

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/BalanceRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/BalanceRow.tsx
@@ -1,0 +1,135 @@
+import { memo, useMemo } from 'react';
+
+import { SizableText, XStack, YStack } from '@onekeyhq/components';
+import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
+import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
+import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+
+import { calcCellAlign, getColumnStyle } from '../utils';
+
+import type { IColumnConfig } from '../List/CommonTableListView';
+import type { IBalanceDisplayItem } from '../List/SpotBalanceList';
+
+const balanceCurrencyFormatter: INumberFormatProps = {
+  formatter: 'balance',
+  formatterOptions: {
+    currency: '$',
+  },
+};
+
+interface IBalanceRowProps {
+  item: IBalanceDisplayItem;
+  columnConfigs: IColumnConfig[];
+  isMobile?: boolean;
+  index: number;
+}
+
+function formatPnlText(pnl?: string, pnlPercent?: number): string {
+  if (!pnl || parseFloat(pnl) === 0) return '';
+  const sign = parseFloat(pnl) > 0 ? '+' : '';
+  const formatted = numberFormat(pnl, balanceCurrencyFormatter);
+  const pct = pnlPercent?.toFixed(1) ?? '0';
+  return `${sign}${formatted} (${sign}${pct}%)`;
+}
+
+function getPnlColor(pnl?: string): string | undefined {
+  if (!pnl) return undefined;
+  const val = parseFloat(pnl);
+  if (val > 0) return '$textSuccess';
+  if (val < 0) return '$textCritical';
+  return undefined;
+}
+
+// Only add suffix when the same coin appears in both spot and perps (e.g. USDC).
+// Other tokens show without suffix, matching Hyperliquid's convention.
+function getCoinLabel(item: IBalanceDisplayItem): string {
+  if (!item.needsSuffix) return item.coin;
+  // TODO: add i18n keys for "Perps" / "Spot" suffixes
+  return item.type === 'perps' ? `${item.coin} (Perps)` : `${item.coin} (Spot)`;
+}
+
+function BalanceRowMobile({ item }: IBalanceRowProps) {
+  const label = getCoinLabel(item);
+  const pnlText = formatPnlText(item.pnl, item.pnlPercent);
+  const pnlColor = getPnlColor(item.pnl);
+
+  return (
+    <ListItem py="$2.5" px="$5">
+      <YStack flex={1} gap="$0.5">
+        <XStack justifyContent="space-between" alignItems="center">
+          <SizableText size="$bodyMdMedium">{label}</SizableText>
+          <SizableText size="$bodyMdMedium">
+            {numberFormat(item.usdcValue, balanceCurrencyFormatter)}
+          </SizableText>
+        </XStack>
+        <XStack justifyContent="space-between" alignItems="center">
+          <SizableText size="$bodySm" color="$textSubdued">
+            {`${item.total} ${item.coin}`}
+          </SizableText>
+          {pnlText ? (
+            <SizableText size="$bodySm" color={pnlColor}>
+              {pnlText}
+            </SizableText>
+          ) : null}
+        </XStack>
+      </YStack>
+    </ListItem>
+  );
+}
+
+function BalanceRowDesktop({ item, columnConfigs, index }: IBalanceRowProps) {
+  const label = getCoinLabel(item);
+  const pnlText = formatPnlText(item.pnl, item.pnlPercent);
+  const pnlColor = getPnlColor(item.pnl);
+
+  const cells = useMemo(() => {
+    const cellValues: Record<string, string> = {
+      coin: label,
+      total: `${item.total} ${item.coin}`,
+      available: `${item.available} ${item.coin}`,
+      usdcValue: numberFormat(item.usdcValue, balanceCurrencyFormatter),
+      pnl: pnlText,
+      contract: item.contract
+        ? `${item.contract.slice(0, 6)}...${item.contract.slice(-4)}`
+        : '',
+    };
+    return columnConfigs.map((col) => ({
+      ...col,
+      cellValue: cellValues[col.key] || '',
+    }));
+  }, [item, label, pnlText, columnConfigs]);
+
+  return (
+    <XStack
+      py="$2"
+      px="$5"
+      bg={index % 2 === 0 ? '$bgApp' : '$bg'}
+      hoverStyle={{ bg: '$bgHover' }}
+    >
+      {cells.map((cell) => (
+        <XStack
+          key={cell.key}
+          {...getColumnStyle(cell)}
+          alignItems="center"
+          justifyContent={calcCellAlign(cell.align)}
+        >
+          <SizableText
+            size="$bodySmMedium"
+            color={cell.key === 'pnl' ? pnlColor : undefined}
+          >
+            {cell.cellValue}
+          </SizableText>
+        </XStack>
+      ))}
+    </XStack>
+  );
+}
+
+function BalanceRowInner({ isMobile, ...rest }: IBalanceRowProps) {
+  if (isMobile) {
+    return <BalanceRowMobile isMobile={isMobile} {...rest} />;
+  }
+  return <BalanceRowDesktop {...rest} />;
+}
+
+export const BalanceRow = memo(BalanceRowInner);

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/BalanceRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/BalanceRow.tsx
@@ -52,12 +52,22 @@ function BalanceRowMobile({ item }: IBalanceRowProps) {
   const label = getCoinLabel(item);
   const pnlText = formatPnlText(item.pnl, item.pnlPercent);
   const pnlColor = getPnlColor(item.pnl);
+  const contractShort = item.contract
+    ? `${item.contract.slice(0, 6)}...${item.contract.slice(-4)}`
+    : '';
 
   return (
     <ListItem py="$2.5" px="$5">
       <YStack flex={1} gap="$0.5">
         <XStack justifyContent="space-between" alignItems="center">
-          <SizableText size="$bodyMdMedium">{label}</SizableText>
+          <XStack gap="$1.5" alignItems="center">
+            <SizableText size="$bodyMdMedium">{label}</SizableText>
+            {contractShort ? (
+              <SizableText size="$bodyXs" color="$textSubdued">
+                {contractShort}
+              </SizableText>
+            ) : null}
+          </XStack>
           <SizableText size="$bodyMdMedium">
             {numberFormat(item.usdcValue, balanceCurrencyFormatter)}
           </SizableText>

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
@@ -6,12 +6,16 @@ import { useIntl } from 'react-intl';
 import { Button, SizableText, XStack, YStack } from '@onekeyhq/components';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import { useSpotPairDisplayMapAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { formatTime } from '@onekeyhq/shared/src/utils/dateUtils';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
+  formatSpotPairDisplayName,
+  getSpotTokenDisplayName,
   getValidPriceDecimals,
+  isSpotInstrument,
   parseDexCoin,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type { IPerpsFrontendOrder } from '@onekeyhq/shared/types/hyperliquid/sdk';
@@ -65,9 +69,21 @@ const OpenOrdersRow = memo(
     const actions = useHyperliquidActions();
     const intl = useIntl();
     const { coin, side, orderType: originalOrderType, reduceOnly } = order;
+    const [spotDisplayMap] = useSpotPairDisplayMapAtom();
     const assetInfo = useMemo(() => {
-      const parsedCoin = parseDexCoin(coin);
-      const assetSymbol = parsedCoin.displayName;
+      const isSpot = isSpotInstrument(coin);
+      const assetSymbol = (() => {
+        if (!isSpot) {
+          return parseDexCoin(coin).displayName;
+        }
+        const displayName = spotDisplayMap[coin];
+        if (displayName) return displayName;
+        if (coin.includes('/')) {
+          const [baseName] = coin.split('/');
+          return getSpotTokenDisplayName(baseName);
+        }
+        return coin;
+      })();
       const orderType = (() => {
         switch (originalOrderType) {
           case 'Market':
@@ -99,6 +115,11 @@ const OpenOrdersRow = memo(
         }
       })();
       const type = (() => {
+        if (isSpot) {
+          return side === 'B'
+            ? intl.formatMessage({ id: ETranslations.global_buy })
+            : intl.formatMessage({ id: ETranslations.global_sell });
+        }
         if (side === 'B') {
           if (reduceOnly) {
             return intl.formatMessage({
@@ -121,12 +142,19 @@ const OpenOrdersRow = memo(
       const typeColor = side === 'B' ? '$green11' : '$red11';
       return {
         assetSymbol,
+        isSpot,
         rawCoin: coin,
         type,
         orderType,
         typeColor,
       };
     }, [coin, side, originalOrderType, reduceOnly, intl]);
+    const handleSwitchInstrument = useCallback(() => {
+      void actions.current.switchTradeInstrument({
+        mode: assetInfo.isSpot ? 'spot' : 'perp',
+        coin: assetInfo.rawCoin,
+      });
+    }, [actions, assetInfo.isSpot, assetInfo.rawCoin]);
     const dateInfo = useMemo(() => {
       const timeDate = new Date(order.timestamp);
       const date = formatTime(timeDate, {
@@ -216,14 +244,7 @@ const OpenOrdersRow = memo(
             width="100%"
             alignItems="center"
           >
-            <YStack
-              onPress={() =>
-                actions.current.changeActiveAsset({
-                  coin: assetInfo.rawCoin,
-                })
-              }
-              cursor="default"
-            >
+            <YStack onPress={handleSwitchInstrument} cursor="default">
               <SizableText
                 numberOfLines={1}
                 ellipsizeMode="tail"
@@ -381,11 +402,7 @@ const OpenOrdersRow = memo(
               {...getColumnStyle(columnConfigs[1])}
               justifyContent="center"
               alignItems={calcCellAlign(columnConfigs[1].align)}
-              onPress={() =>
-                actions.current.changeActiveAsset({
-                  coin: assetInfo.rawCoin,
-                })
-              }
+              onPress={handleSwitchInstrument}
               cursor="default"
             >
               <SizableText

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
@@ -15,12 +15,16 @@ import {
 } from '@onekeyhq/components';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import { useSpotPairDisplayMapAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { formatTime } from '@onekeyhq/shared/src/utils/dateUtils';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
+  formatSpotPairDisplayName,
+  getSpotTokenDisplayName,
   getValidPriceDecimals,
+  isSpotInstrument,
   parseDexCoin,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type { IFill } from '@onekeyhq/shared/types/hyperliquid/sdk';
@@ -63,19 +67,37 @@ const TradesHistoryRow = memo(
   }: ITradesHistoryRowProps) => {
     const canShare = useMemo(() => {
       return (
+        !isSpotInstrument(fill.coin) &&
         fill.closedPnl &&
         !new BigNumber(fill.closedPnl).isZero() &&
         !fill.liquidation &&
         onShare
       );
-    }, [fill.closedPnl, fill.liquidation, onShare]);
+    }, [fill.closedPnl, fill.coin, fill.liquidation, onShare]);
     const actions = useHyperliquidActions();
     const intl = useIntl();
+    const [spotDisplayMap] = useSpotPairDisplayMapAtom();
     const assetSymbol = useMemo(() => {
-      const parsed = parseDexCoin(fill.coin);
-      return parsed.displayName;
-    }, [fill.coin]);
+      if (!isSpotInstrument(fill.coin)) {
+        return parseDexCoin(fill.coin).displayName;
+      }
+      // Resolve @107 → HYPE via display map atom
+      const displayName = spotDisplayMap[fill.coin];
+      if (displayName) return displayName;
+      // Fallback: canonical pairs like PURR/USDC
+      if (fill.coin.includes('/')) {
+        const [baseName] = fill.coin.split('/');
+        return getSpotTokenDisplayName(baseName);
+      }
+      return fill.coin;
+    }, [fill.coin, spotDisplayMap]);
     const rawCoin = fill.coin;
+    const handleSwitchInstrument = useCallback(() => {
+      void actions.current.switchTradeInstrument({
+        mode: isSpotInstrument(rawCoin) ? 'spot' : 'perp',
+        coin: rawCoin,
+      });
+    }, [actions, rawCoin]);
     const dateInfo = useMemo(() => {
       const timeDate = new Date(fill.time);
       const date = formatTime(timeDate, {
@@ -88,6 +110,15 @@ const TradesHistoryRow = memo(
     }, [fill.time]);
 
     const directionInfo = useMemo(() => {
+      if (isSpotInstrument(fill.coin)) {
+        return {
+          directionStr:
+            fill.side === 'B'
+              ? intl.formatMessage({ id: ETranslations.global_buy })
+              : intl.formatMessage({ id: ETranslations.global_sell }),
+          directionColor: fill.side === 'B' ? '$green11' : '$red11',
+        };
+      }
       const side = fill.side;
       let directionColor = '$green11';
       if (side === 'A') {
@@ -106,7 +137,7 @@ const TradesHistoryRow = memo(
       }
 
       return { directionStr, directionColor };
-    }, [fill.dir, fill.side, fill.liquidation]);
+    }, [fill.coin, fill.dir, fill.side, fill.liquidation, intl]);
 
     const tradeBaseInfo = useMemo(() => {
       const price = fill.px;
@@ -198,10 +229,8 @@ const TradesHistoryRow = memo(
               <XStack
                 gap="$2"
                 alignItems="center"
-                // cursor="pointer"
-                // onPress={() =>
-                //   actions.current.changeActiveAsset({ coin: assetSymbol })
-                // }
+                onPress={handleSwitchInstrument}
+                cursor="default"
               >
                 <SizableText size="$bodyMdMedium">{assetSymbol}</SizableText>
                 <SizableText
@@ -356,9 +385,7 @@ const TradesHistoryRow = memo(
               {...getColumnStyle(columnConfigs[1])}
               justifyContent={calcCellAlign(columnConfigs[1].align)}
               alignItems="center"
-              onPress={() =>
-                actions.current.changeActiveAsset({ coin: rawCoin })
-              }
+              onPress={handleSwitchInstrument}
               cursor="default"
             >
               <SizableText

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpOpenOrdersList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpOpenOrdersList.tsx
@@ -5,14 +5,17 @@ import { useIntl } from 'react-intl';
 
 import type { IDebugRenderTrackerProps } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import {
+  useActiveTradeInstrumentAtom,
+  useHyperliquidActions,
+} from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
   useOrderFilterByCurrentTokenAtom,
   usePerpsActiveOpenOrdersAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
 import {
   usePerpsActiveAccountAtom,
-  usePerpsActiveAssetAtom,
+  useSpotActiveOpenOrdersAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IPerpsFrontendOrder } from '@onekeyhq/shared/types/hyperliquid/sdk';
@@ -35,12 +38,15 @@ function PerpOpenOrdersList({
   disableListScroll,
 }: IPerpOpenOrdersListProps) {
   const intl = useIntl();
-  const [{ openOrders }] = usePerpsActiveOpenOrdersAtom();
+  const [{ openOrders: perpOpenOrders }] = usePerpsActiveOpenOrdersAtom();
+  const [{ openOrders: spotOpenOrders }] = useSpotActiveOpenOrdersAtom();
   const [currentUser] = usePerpsActiveAccountAtom();
   const [filterByCurrentToken] = useOrderFilterByCurrentTokenAtom();
-  const [activeAsset] = usePerpsActiveAssetAtom();
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const actions = useHyperliquidActions();
   const [currentListPage, setCurrentListPage] = useState(1);
+  const isSpot = activeTradeInstrument.mode === 'spot';
+  const openOrders = isSpot ? spotOpenOrders : perpOpenOrders;
   useEffect(() => {
     noop(currentUser?.accountAddress);
     setCurrentListPage(1);
@@ -54,14 +60,16 @@ function PerpOpenOrdersList({
     if (isMobile && filterByCurrentToken) {
       setCurrentListPage(1);
     }
-  }, [activeAsset?.coin, isMobile, filterByCurrentToken]);
+  }, [activeTradeInstrument?.coin, isMobile, filterByCurrentToken]);
 
   const filteredOrders = useMemo(() => {
-    if (!isMobile || !filterByCurrentToken || !activeAsset?.coin) {
+    if (!isMobile || !filterByCurrentToken || !activeTradeInstrument?.coin) {
       return openOrders;
     }
-    return openOrders.filter((order) => order.coin === activeAsset.coin);
-  }, [openOrders, isMobile, filterByCurrentToken, activeAsset?.coin]);
+    return openOrders.filter(
+      (order) => order.coin === activeTradeInstrument.coin,
+    );
+  }, [openOrders, isMobile, filterByCurrentToken, activeTradeInstrument]);
 
   const columnsConfig: IColumnConfig[] = useMemo(
     () => [
@@ -155,12 +163,13 @@ function PerpOpenOrdersList({
         align: 'right',
         flex: 1,
         fixed: true,
-        ...(openOrders.length > 0 && {
-          onPress: () => showCancelAllOrdersDialog(),
-        }),
+        ...(!isSpot &&
+          openOrders.length > 0 && {
+            onPress: () => showCancelAllOrdersDialog(),
+          }),
       },
     ],
-    [intl, openOrders.length],
+    [intl, isSpot, openOrders.length],
   );
 
   const handleCancelOrder = useCallback(

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/SpotBalanceList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/SpotBalanceList.tsx
@@ -1,0 +1,283 @@
+import type { ReactElement } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import BigNumber from 'bignumber.js';
+import { useIntl } from 'react-intl';
+
+import type { IDebugRenderTrackerProps } from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import {
+  usePerpsActiveAccountAtom,
+  usePerpsActiveAccountSummaryAtom,
+  useSpotAssetCtxsMapAtom,
+  useSpotBalancesAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+
+import { BalanceRow } from '../Components/BalanceRow';
+
+import { CommonTableListView, type IColumnConfig } from './CommonTableListView';
+
+export interface IBalanceDisplayItem {
+  coin: string;
+  type: 'spot' | 'perps';
+  total: string;
+  available: string;
+  usdcValue: string;
+  pnl?: string;
+  pnlPercent?: number;
+  contract?: string;
+  usdcValueNum: number;
+  // True when the same coin appears in both spot and perps (e.g. USDC)
+  needsSuffix: boolean;
+}
+
+interface ISpotBalanceListProps {
+  isMobile?: boolean;
+  useTabsList?: boolean;
+  disableListScroll?: boolean;
+  ListHeaderComponent?: ReactElement | null;
+}
+
+function SpotBalanceList({
+  isMobile,
+  useTabsList,
+  disableListScroll,
+  ListHeaderComponent,
+}: ISpotBalanceListProps) {
+  const intl = useIntl();
+  const [{ balances, isLoaded }] = useSpotBalancesAtom();
+  const [accountSummary] = usePerpsActiveAccountSummaryAtom();
+  const [currentUser] = usePerpsActiveAccountAtom();
+  const [priceMap] = useSpotAssetCtxsMapAtom();
+  const actions = useHyperliquidActions();
+  const [currentListPage, setCurrentListPage] = useState(1);
+
+  useEffect(() => {
+    setCurrentListPage(1);
+  }, [currentUser?.accountAddress]);
+
+  // Build baseName → markPx lookup
+  // priceMap is keyed by pair name (@107, PURR/USDC), but balances use token names (HYPE, PURR)
+  const [spotUniverses, setSpotUniverses] = useState<
+    { name: string; baseName: string; quoteName: string }[]
+  >([]);
+  useEffect(() => {
+    void backgroundApiProxy.serviceHyperliquid
+      .getSpotMeta()
+      .then(({ universes }) => {
+        setSpotUniverses(
+          universes.map((u) => ({
+            name: u.name,
+            baseName: u.baseName,
+            quoteName: u.quoteName,
+          })),
+        );
+      });
+  }, []);
+
+  const tokenPriceLookup = useMemo(() => {
+    const lookup: Record<string, string> = {};
+    // First pass: prefer USDC-quoted pairs for accurate USD value
+    for (const u of spotUniverses) {
+      if (u.quoteName === 'USDC') {
+        const ctx = priceMap[u.name];
+        if (ctx?.markPx) {
+          lookup[u.baseName] = ctx.markPx;
+        }
+      }
+    }
+    // Second pass: fill remaining from any quote
+    for (const u of spotUniverses) {
+      if (!lookup[u.baseName]) {
+        const ctx = priceMap[u.name];
+        if (ctx?.markPx) {
+          lookup[u.baseName] = ctx.markPx;
+        }
+      }
+    }
+    return lookup;
+  }, [priceMap, spotUniverses]);
+
+  const allBalances: IBalanceDisplayItem[] = useMemo(() => {
+    const items: IBalanceDisplayItem[] = [];
+
+    const spotCoinNames = new Set(balances.map((b) => b.coin));
+    const hasPerpsUsdc = !!accountSummary?.totalRawUsd;
+
+    balances.forEach((b) => {
+      const totalBN = new BigNumber(b.total);
+      const holdBN = new BigNumber(b.hold);
+      const availableBN = BigNumber.max(totalBN.minus(holdBN), 0);
+      const entryNtlBN = new BigNumber(b.entryNtl || '0');
+
+      const isStable =
+        b.coin === 'USDC' || b.coin === 'USDT' || b.coin === 'USDB';
+
+      const midPrice = tokenPriceLookup[b.coin];
+      let usdcValueBN: BigNumber;
+      if (isStable) {
+        usdcValueBN = totalBN;
+      } else if (midPrice) {
+        usdcValueBN = totalBN.multipliedBy(midPrice);
+      } else {
+        usdcValueBN = entryNtlBN;
+      }
+
+      let pnl: string | undefined;
+      let pnlPercent: number | undefined;
+      if (!isStable && !entryNtlBN.isZero() && midPrice) {
+        const pnlBN = usdcValueBN.minus(entryNtlBN);
+        pnl = pnlBN.toFixed(2);
+        pnlPercent = pnlBN.dividedBy(entryNtlBN).multipliedBy(100).toNumber();
+      }
+
+      const needsSuffix = b.coin === 'USDC' && hasPerpsUsdc;
+
+      items.push({
+        coin: b.coin,
+        type: 'spot',
+        total: b.total,
+        available: availableBN.toFixed(),
+        usdcValue: usdcValueBN.toFixed(2),
+        pnl,
+        pnlPercent,
+        needsSuffix,
+        usdcValueNum: usdcValueBN.toNumber(),
+      });
+    });
+
+    if (accountSummary?.totalRawUsd) {
+      const perpsUsdcBN = new BigNumber(accountSummary.totalRawUsd);
+      if (perpsUsdcBN.isGreaterThan(0)) {
+        items.push({
+          coin: 'USDC',
+          type: 'perps',
+          total: perpsUsdcBN.toFixed(),
+          available: accountSummary.withdrawable || '0',
+          usdcValue: perpsUsdcBN.toFixed(2),
+          needsSuffix: spotCoinNames.has('USDC'),
+          usdcValueNum: perpsUsdcBN.toNumber(),
+        });
+      }
+    }
+
+    return items.toSorted((a, b) => {
+      const valueDiff = Math.abs(b.usdcValueNum) - Math.abs(a.usdcValueNum);
+      if (valueDiff !== 0) return valueDiff;
+      return new BigNumber(b.total).comparedTo(new BigNumber(a.total));
+    });
+  }, [balances, accountSummary, tokenPriceLookup]);
+
+  // Filter out zero-balance tokens
+  const filteredBalances = useMemo(
+    () => allBalances.filter((b) => !new BigNumber(b.total).isZero()),
+    [allBalances],
+  );
+
+  const columnsConfig: IColumnConfig[] = useMemo(
+    () => [
+      {
+        key: 'coin',
+        title: intl.formatMessage({ id: ETranslations.global_asset }),
+        minWidth: 120,
+        align: 'left',
+      },
+      {
+        key: 'total',
+        title: intl.formatMessage({ id: ETranslations.global_balance }),
+        minWidth: 160,
+        align: 'left',
+        flex: 1,
+      },
+      {
+        key: 'available',
+        title: intl.formatMessage({ id: ETranslations.global_available }),
+        minWidth: 160,
+        align: 'left',
+        flex: 1,
+      },
+      {
+        key: 'usdcValue',
+        title: intl.formatMessage({ id: ETranslations.global_value }),
+        minWidth: 100,
+        align: 'left',
+        flex: 1,
+      },
+      {
+        key: 'pnl',
+        // TODO: add i18n key — domain term consistent with Hyperliquid UI
+        title: 'PNL (ROE %)',
+        minWidth: 140,
+        align: 'left',
+        flex: 1,
+      },
+      {
+        key: 'contract',
+        title: intl.formatMessage({ id: ETranslations.global_contract }),
+        minWidth: 120,
+        align: 'left',
+        flex: 1,
+      },
+    ],
+    [intl],
+  );
+
+  const totalMinWidth = useMemo(
+    () =>
+      columnsConfig.reduce(
+        (sum, col) => sum + (col.width || col.minWidth || 0),
+        0,
+      ),
+    [columnsConfig],
+  );
+
+  const renderBalanceRow = useCallback(
+    (item: IBalanceDisplayItem, index: number) => (
+      <BalanceRow
+        key={`${item.coin}-${item.type}`}
+        item={item}
+        isMobile={isMobile}
+        columnConfigs={columnsConfig}
+        index={index}
+      />
+    ),
+    [isMobile, columnsConfig],
+  );
+
+  return (
+    <CommonTableListView
+      onPullToRefresh={async () => {
+        await actions.current.refreshAllPerpsData();
+      }}
+      listViewDebugRenderTrackerProps={useMemo(
+        (): IDebugRenderTrackerProps => ({
+          name: 'SpotBalanceList',
+          position: 'top-left',
+        }),
+        [],
+      )}
+      useTabsList={useTabsList}
+      disableListScroll={disableListScroll}
+      currentListPage={currentListPage}
+      setCurrentListPage={setCurrentListPage}
+      enablePagination={!isMobile}
+      columns={columnsConfig}
+      minTableWidth={totalMinWidth}
+      data={filteredBalances}
+      isMobile={isMobile}
+      renderRow={renderBalanceRow}
+      listLoading={currentUser?.accountAddress ? !isLoaded : false}
+      emptyMessage={intl.formatMessage({
+        id: ETranslations.global_no_data,
+      })}
+      emptySubMessage={intl.formatMessage({
+        id: ETranslations.perp_trade_history_empty_desc,
+      })}
+      ListHeaderComponent={ListHeaderComponent}
+    />
+  );
+}
+
+export { SpotBalanceList };

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/SpotBalanceList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/SpotBalanceList.tsx
@@ -14,6 +14,7 @@ import {
   useSpotBalancesAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { getSpotTokenDisplayName } from '@onekeyhq/shared/src/utils/perpsUtils';
 
 import { BalanceRow } from '../Components/BalanceRow';
 
@@ -143,10 +144,11 @@ function SpotBalanceList({
         pnlPercent = pnlBN.dividedBy(entryNtlBN).multipliedBy(100).toNumber();
       }
 
-      const needsSuffix = b.coin === 'USDC' && hasPerpsUsdc;
+      const displayCoin = getSpotTokenDisplayName(b.coin);
+      const needsSuffix = displayCoin === 'USDC' && hasPerpsUsdc;
 
       items.push({
-        coin: b.coin,
+        coin: displayCoin,
         type: 'spot',
         total: b.total,
         available: availableBN.toFixed(),

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/SpotBalanceList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/SpotBalanceList.tsx
@@ -63,10 +63,13 @@ function SpotBalanceList({
   const [spotUniverses, setSpotUniverses] = useState<
     { name: string; baseName: string; quoteName: string }[]
   >([]);
+  const [tokenContractMap, setTokenContractMap] = useState<
+    Record<string, string>
+  >({});
   useEffect(() => {
     void backgroundApiProxy.serviceHyperliquid
       .getSpotMeta()
-      .then(({ universes }) => {
+      .then(({ universes, tokens }) => {
         setSpotUniverses(
           universes.map((u) => ({
             name: u.name,
@@ -74,6 +77,13 @@ function SpotBalanceList({
             quoteName: u.quoteName,
           })),
         );
+        const contractMap: Record<string, string> = {};
+        for (const t of tokens ?? []) {
+          if (t.evmContract?.address) {
+            contractMap[t.name] = t.evmContract.address;
+          }
+        }
+        setTokenContractMap(contractMap);
       });
   }, []);
 
@@ -143,6 +153,7 @@ function SpotBalanceList({
         usdcValue: usdcValueBN.toFixed(2),
         pnl,
         pnlPercent,
+        contract: tokenContractMap[b.coin],
         needsSuffix,
         usdcValueNum: usdcValueBN.toNumber(),
       });
@@ -168,7 +179,7 @@ function SpotBalanceList({
       if (valueDiff !== 0) return valueDiff;
       return new BigNumber(b.total).comparedTo(new BigNumber(a.total));
     });
-  }, [balances, accountSummary, tokenPriceLookup]);
+  }, [balances, accountSummary, tokenPriceLookup, tokenContractMap]);
 
   // Filter out zero-balance tokens
   const filteredBalances = useMemo(

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/SpotBalanceList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/SpotBalanceList.tsx
@@ -5,7 +5,6 @@ import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
 import type { IDebugRenderTrackerProps } from '@onekeyhq/components';
-import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
   usePerpsActiveAccountAtom,
@@ -14,14 +13,17 @@ import {
   useSpotBalancesAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import type { ISpotUniverse } from '@onekeyhq/shared/types/hyperliquid';
 import { getSpotTokenDisplayName } from '@onekeyhq/shared/src/utils/perpsUtils';
 
+import { useSpotMetaMaps } from '../../../hooks/useSpotMetaMaps';
 import { BalanceRow } from '../Components/BalanceRow';
 
 import { CommonTableListView, type IColumnConfig } from './CommonTableListView';
 
 export interface IBalanceDisplayItem {
   coin: string;
+  rawCoin: string;
   type: 'spot' | 'perps';
   total: string;
   available: string;
@@ -30,6 +32,8 @@ export interface IBalanceDisplayItem {
   pnlPercent?: number;
   contract?: string;
   usdcValueNum: number;
+  spotUniverse?: ISpotUniverse;
+  isAssetClickable?: boolean;
   // True when the same coin appears in both spot and perps (e.g. USDC)
   needsSuffix: boolean;
 }
@@ -53,40 +57,13 @@ function SpotBalanceList({
   const [currentUser] = usePerpsActiveAccountAtom();
   const [priceMap] = useSpotAssetCtxsMapAtom();
   const actions = useHyperliquidActions();
+  const { spotUniverses, universeByBaseName, tokenContractMap } =
+    useSpotMetaMaps();
   const [currentListPage, setCurrentListPage] = useState(1);
 
   useEffect(() => {
     setCurrentListPage(1);
   }, [currentUser?.accountAddress]);
-
-  // Build baseName → markPx lookup
-  // priceMap is keyed by pair name (@107, PURR/USDC), but balances use token names (HYPE, PURR)
-  const [spotUniverses, setSpotUniverses] = useState<
-    { name: string; baseName: string; quoteName: string }[]
-  >([]);
-  const [tokenContractMap, setTokenContractMap] = useState<
-    Record<string, string>
-  >({});
-  useEffect(() => {
-    void backgroundApiProxy.serviceHyperliquid
-      .getSpotMeta()
-      .then(({ universes, tokens }) => {
-        setSpotUniverses(
-          universes.map((u) => ({
-            name: u.name,
-            baseName: u.baseName,
-            quoteName: u.quoteName,
-          })),
-        );
-        const contractMap: Record<string, string> = {};
-        for (const t of tokens ?? []) {
-          if (t.evmContract?.address) {
-            contractMap[t.name] = t.evmContract.address;
-          }
-        }
-        setTokenContractMap(contractMap);
-      });
-  }, []);
 
   const tokenPriceLookup = useMemo(() => {
     const lookup: Record<string, string> = {};
@@ -146,9 +123,12 @@ function SpotBalanceList({
 
       const displayCoin = getSpotTokenDisplayName(b.coin);
       const needsSuffix = displayCoin === 'USDC' && hasPerpsUsdc;
+      const spotUniverse = universeByBaseName[b.coin];
+      const isAssetClickable = b.coin !== 'USDC' && !!spotUniverse;
 
       items.push({
         coin: displayCoin,
+        rawCoin: b.coin,
         type: 'spot',
         total: b.total,
         available: availableBN.toFixed(),
@@ -156,6 +136,8 @@ function SpotBalanceList({
         pnl,
         pnlPercent,
         contract: tokenContractMap[b.coin],
+        spotUniverse,
+        isAssetClickable,
         needsSuffix,
         usdcValueNum: usdcValueBN.toNumber(),
       });
@@ -166,10 +148,12 @@ function SpotBalanceList({
       if (perpsUsdcBN.isGreaterThan(0)) {
         items.push({
           coin: 'USDC',
+          rawCoin: 'USDC',
           type: 'perps',
           total: perpsUsdcBN.toFixed(),
           available: accountSummary.withdrawable || '0',
           usdcValue: perpsUsdcBN.toFixed(2),
+          isAssetClickable: false,
           needsSuffix: spotCoinNames.has('USDC'),
           usdcValueNum: perpsUsdcBN.toNumber(),
         });
@@ -181,7 +165,13 @@ function SpotBalanceList({
       if (valueDiff !== 0) return valueDiff;
       return new BigNumber(b.total).comparedTo(new BigNumber(a.total));
     });
-  }, [balances, accountSummary, tokenPriceLookup, tokenContractMap]);
+  }, [
+    balances,
+    accountSummary,
+    tokenPriceLookup,
+    tokenContractMap,
+    universeByBaseName,
+  ]);
 
   // Filter out zero-balance tokens
   const filteredBalances = useMemo(
@@ -254,9 +244,19 @@ function SpotBalanceList({
         isMobile={isMobile}
         columnConfigs={columnsConfig}
         index={index}
+        onChangeAsset={
+          item.isAssetClickable
+            ? () => {
+                void actions.current.changeActiveSpotAsset({
+                  coin: item.rawCoin,
+                  spotUniverse: item.spotUniverse,
+                });
+              }
+            : undefined
+        }
       />
     ),
-    [isMobile, columnsConfig],
+    [actions, isMobile, columnsConfig],
   );
 
   return (

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpOrderInfoPanel.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpOrderInfoPanel.tsx
@@ -28,7 +28,7 @@ const tabNameToTranslationKey: Record<string, string> = {
   'Open Orders': ETranslations.perp_open_orders_title,
   'Trades History': ETranslations.perp_trades_history_title,
   'Account': ETranslations.perp_account_history,
-  'Balances': 'Balances',
+  'Balances': 'Balances', // TODO: add i18n key (ETranslations)
 };
 
 function TabBarItem({
@@ -107,7 +107,12 @@ function PerpOrderInfoPanel() {
         <Tabs.TabBar
           {...props}
           renderItem={({ name, isFocused, onPress }) => (
-            <TabBarItem key={name} name={name} isFocused={isFocused} onPress={onPress} />
+            <TabBarItem
+              key={name}
+              name={name}
+              isFocused={isFocused}
+              onPress={onPress}
+            />
           )}
           containerStyle={{
             borderRadius: 0,

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpOrderInfoPanel.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpOrderInfoPanel.tsx
@@ -21,12 +21,14 @@ import { PerpAccountList } from './List/PerpAccountList';
 import { PerpOpenOrdersList } from './List/PerpOpenOrdersList';
 import { PerpPositionsList } from './List/PerpPositionsList';
 import { PerpTradesHistoryList } from './List/PerpTradesHistoryList';
+import { SpotBalanceList } from './List/SpotBalanceList';
 
 const tabNameToTranslationKey: Record<string, string> = {
   'Positions': ETranslations.perp_position_title,
   'Open Orders': ETranslations.perp_open_orders_title,
   'Trades History': ETranslations.perp_trades_history_title,
   'Account': ETranslations.perp_account_history,
+  'Balances': 'Balances',
 };
 
 function TabBarItem({
@@ -124,6 +126,9 @@ function PerpOrderInfoPanel() {
       </Tabs.Tab>
       <Tabs.Tab name="Trades History">
         <PerpTradesHistoryList useTabsList />
+      </Tabs.Tab>
+      <Tabs.Tab name="Balances">
+        <SpotBalanceList />
       </Tabs.Tab>
       <Tabs.Tab name="Account">
         <PerpAccountList useTabsList />

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpOrderInfoPanel.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpOrderInfoPanel.tsx
@@ -96,7 +96,7 @@ function PerpOrderInfoPanel() {
     <Tabs.Container
       ref={tabsRef as any}
       headerHeight={80}
-      initialTabName="Positions"
+      initialTabName="Balances"
       disableScroll={!platformEnv.isNative}
       onTabChange={async (tab) => {
         if (tab.tabName === 'Account') {
@@ -118,6 +118,9 @@ function PerpOrderInfoPanel() {
         />
       )}
     >
+      <Tabs.Tab name="Balances">
+        <SpotBalanceList />
+      </Tabs.Tab>
       <Tabs.Tab name="Positions">
         <PerpPositionsList handleViewTpslOrders={handleViewTpslOrders} />
       </Tabs.Tab>
@@ -126,9 +129,6 @@ function PerpOrderInfoPanel() {
       </Tabs.Tab>
       <Tabs.Tab name="Trades History">
         <PerpTradesHistoryList useTabsList />
-      </Tabs.Tab>
-      <Tabs.Tab name="Balances">
-        <SpotBalanceList />
       </Tabs.Tab>
       <Tabs.Tab name="Account">
         <PerpAccountList useTabsList />

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpOrderInfoPanel.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpOrderInfoPanel.tsx
@@ -107,7 +107,7 @@ function PerpOrderInfoPanel() {
         <Tabs.TabBar
           {...props}
           renderItem={({ name, isFocused, onPress }) => (
-            <TabBarItem name={name} isFocused={isFocused} onPress={onPress} />
+            <TabBarItem key={name} name={name} isFocused={isFocused} onPress={onPress} />
           )}
           containerStyle={{
             borderRadius: 0,

--- a/packages/kit/src/views/Perp/components/PerpCandles.tsx
+++ b/packages/kit/src/views/Perp/components/PerpCandles.tsx
@@ -1,8 +1,8 @@
 import { DebugRenderTracker, Stack, usePageWidth } from '@onekeyhq/components';
 import { TradingViewPerpsV2 } from '@onekeyhq/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2';
+import { useActiveTradeInstrumentAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
   usePerpsActiveAccountAtom,
-  usePerpsActiveAssetAtom,
   usePerpsCandlesWebviewReloadHookAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -12,18 +12,18 @@ export function PerpCandles({
 }: {
   onTouchScroll?: (deltaY: number) => void;
 }) {
-  const [currentToken] = usePerpsActiveAssetAtom();
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const [currentAccount] = usePerpsActiveAccountAtom();
   const [{ reloadHook }] = usePerpsCandlesWebviewReloadHookAtom();
   const width = usePageWidth();
 
   const content = (
     <Stack w="100%" h="100%" flex={1} pr={6}>
-      {reloadHook > 0 ? (
+      {reloadHook > 0 && activeTradeInstrument.coin ? (
         <TradingViewPerpsV2
           webviewKey={reloadHook.toString()}
           userAddress={currentAccount?.accountAddress}
-          symbol={currentToken.coin}
+          symbol={activeTradeInstrument.coin}
           w={platformEnv.isNative ? width : undefined}
           onTouchScroll={onTouchScroll}
         />

--- a/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
+++ b/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
@@ -14,13 +14,14 @@ import {
   useMedia,
 } from '@onekeyhq/components';
 import {
+  useActiveTradeInstrumentAtom,
+  useConnectionStateAtom,
   useHyperliquidActions,
   useOrderBookTickOptionsAtom,
   useTradingFormAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import type { ITradingFormData } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
-  usePerpsActiveAssetAtom,
   usePerpsActiveAssetCtxAtom,
   usePerpsShouldShowEnableTradingButtonAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -28,7 +29,6 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { useFundingCountdown } from '../hooks/useFundingCountdown';
 import { useL2Book } from '../hooks/usePerpMarketData';
-import { usePerpSession } from '../hooks/usePerpSession';
 
 import {
   type IOrderBookSelection,
@@ -44,9 +44,18 @@ import type { IOrderBookVariant } from './OrderBook/types';
 function MobileHeader() {
   const intl = useIntl();
   const countdown = useFundingCountdown();
-  const { isReady, hasError } = usePerpSession();
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
+  const [connectionState] = useConnectionStateAtom();
   const [assetCtx] = usePerpsActiveAssetCtxAtom();
+  const hasError = connectionState.reconnectCount > 3;
+  const isReady = connectionState.isConnected && !hasError;
+  const isSpot = activeTradeInstrument.mode === 'spot';
 
+  if (isSpot) {
+    return null;
+  }
+
+  // After the isSpot early return above, we know this is perps-only
   const { fundingRate, markPrice } = assetCtx?.ctx || {
     fundingRate: '0',
     markPrice: '0',
@@ -318,14 +327,14 @@ export function PerpOrderBook({
 }) {
   const { gtMd } = useMedia();
   const actionsRef = useHyperliquidActions();
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const [formData] = useTradingFormAtom();
   const [orderBookTickOptions] = useOrderBookTickOptionsAtom();
-  const [perpsSelectedSymbol] = usePerpsActiveAssetAtom();
   const [shouldShowEnableTradingButton] =
     usePerpsShouldShowEnableTradingButtonAtom();
 
   const l2SubscriptionOptions = useMemo(() => {
-    const coin = perpsSelectedSymbol?.coin;
+    const coin = activeTradeInstrument.coin;
     if (!coin) {
       return { nSigFigs: null, mantissa: undefined };
     }
@@ -334,7 +343,7 @@ export function PerpOrderBook({
     const mantissa =
       stored?.mantissa === undefined ? undefined : stored.mantissa;
     return { nSigFigs, mantissa };
-  }, [orderBookTickOptions, perpsSelectedSymbol?.coin]);
+  }, [activeTradeInstrument.coin, orderBookTickOptions]);
 
   const { l2Book, hasOrderBook } = useL2Book({
     nSigFigs: l2SubscriptionOptions.nSigFigs,

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -15,13 +15,14 @@ import type { IPerpsActiveOrderBookOptionsAtom } from '@onekeyhq/kit-bg/src/stat
 import {
   perpsActiveAssetAtom,
   perpsActiveOrderBookOptionsAtom,
+  tradingModeAtom,
   usePerpsAccountLoadingInfoAtom,
   usePerpsActiveAccountAtom,
   usePerpsActiveAccountRefreshHookAtom,
-  usePerpsActiveAssetAtom,
   usePerpsActiveOrderBookOptionsAtom,
   usePerpsWebSocketConnectedAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms/perps';
+import { spotActiveAssetAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/spot';
 import { PERPS_NETWORK_ID } from '@onekeyhq/shared/src/consts/perp';
 import { COINTYPE_ETH } from '@onekeyhq/shared/src/engine/engineConsts';
 import type { IAppEventBusPayload } from '@onekeyhq/shared/src/eventBus/appEventBus';
@@ -55,21 +56,28 @@ import useListenTabFocusState from '../../../hooks/useListenTabFocusState';
 import { usePromiseResult } from '../../../hooks/usePromiseResult';
 import { useRouteIsFocused } from '../../../hooks/useRouteIsFocused';
 import { useActiveAccount } from '../../../states/jotai/contexts/accountSelector';
-import { useHyperliquidActions } from '../../../states/jotai/contexts/hyperliquid';
+import {
+  useActiveTradeInstrumentAtom,
+  useHyperliquidActions,
+  useTradeRouteViewStateAtom,
+} from '../../../states/jotai/contexts/hyperliquid';
 import {
   useOrderBookTickOptionsAtom,
   useSubscriptionActiveAtom,
 } from '../../../states/jotai/contexts/hyperliquid/atoms';
 import { usePerpsSharePrompt } from '../hooks/usePerpsSharePrompt';
+import { planTradeSubscriptions } from '../utils/subscriptionPlanner';
 
 import { usePerpTokenUrlSync } from './usePerpTokenUrlSync';
 
 function useSyncContextOrderBookOptionsToGlobal() {
-  const [activeAsset] = usePerpsActiveAssetAtom();
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const [orderBookTickOptions] = useOrderBookTickOptionsAtom();
 
   const orderBookTickOptionsRef = useRef(orderBookTickOptions);
   orderBookTickOptionsRef.current = orderBookTickOptions;
+  const activeTradeInstrumentRef = useRef(activeTradeInstrument);
+  activeTradeInstrumentRef.current = activeTradeInstrument;
 
   const isFocusedRef = useRef(false);
 
@@ -81,10 +89,10 @@ function useSyncContextOrderBookOptionsToGlobal() {
         return;
       }
       const prev = await perpsActiveOrderBookOptionsAtom.get();
-      const _activeAsset = await perpsActiveAssetAtom.get();
+      const _activeInstrument = activeTradeInstrumentRef.current;
 
       const l2SubscriptionOptions = (() => {
-        const coin = _activeAsset?.coin;
+        const coin = _activeInstrument?.coin;
         if (!coin) {
           return { nSigFigs: null, mantissa: null };
         }
@@ -96,8 +104,8 @@ function useSyncContextOrderBookOptionsToGlobal() {
       })();
 
       const next: IPerpsActiveOrderBookOptionsAtom = {
-        coin: _activeAsset?.coin,
-        assetId: _activeAsset?.assetId,
+        coin: _activeInstrument?.coin,
+        assetId: _activeInstrument?.assetId,
         ...l2SubscriptionOptions,
       };
       if (isEqual(prev, next)) {
@@ -112,9 +120,14 @@ function useSyncContextOrderBookOptionsToGlobal() {
 
   useEffect(() => {
     noop(orderBookTickOptions);
-    noop(activeAsset?.coin);
+    noop(activeTradeInstrument?.coin);
     void updateGlobalOrderBookOptions(orderBookTickOptions);
-  }, [orderBookTickOptions, activeAsset?.coin, updateGlobalOrderBookOptions]);
+  }, [
+    orderBookTickOptions,
+    activeTradeInstrument?.coin,
+    activeTradeInstrument?.assetId,
+    updateGlobalOrderBookOptions,
+  ]);
 
   useListenTabFocusState(
     ETabRoutes.Perp,
@@ -126,6 +139,29 @@ function useSyncContextOrderBookOptionsToGlobal() {
       }
     },
   );
+}
+
+function useTradeRouteViewStateSync() {
+  const actions = useHyperliquidActions();
+
+  useListenTabFocusState(
+    ETabRoutes.Perp,
+    (isFocus: boolean, isHiddenByModal: boolean) => {
+      actions.current.setTradeRouteViewState({
+        routeFocused: isFocus && !isHiddenByModal,
+      });
+    },
+  );
+
+  useEffect(() => {
+    const actionsRef = actions.current;
+    return () => {
+      actionsRef.setTradeRouteViewState({
+        routeFocused: false,
+        tokenSelectorOpen: false,
+      });
+    };
+  }, [actions]);
 }
 
 function useHyperliquidEventBusListener() {
@@ -433,8 +469,9 @@ function useHyperliquidAccountSelect() {
 function WebSocketSubscriptionUpdate() {
   const [loadingInfo] = usePerpsAccountLoadingInfoAtom();
   const [activePerpsAccount] = usePerpsActiveAccountAtom();
-  const [activeAsset] = usePerpsActiveAssetAtom();
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const [activeOrderBookOptions] = usePerpsActiveOrderBookOptionsAtom();
+  const [tradeRouteViewState] = useTradeRouteViewStateAtom();
   const actions = useHyperliquidActions();
   const [isWebSocketConnected] = usePerpsWebSocketConnectedAtom();
 
@@ -453,32 +490,48 @@ function WebSocketSubscriptionUpdate() {
       isLoading,
       actions,
       address: activePerpsAccount?.accountAddress,
-      coin: activeAsset?.coin,
+      coin: activeTradeInstrument?.coin,
+      tradingMode: activeTradeInstrument.mode,
       mantissa: activeOrderBookOptions?.mantissa,
       nSigFigs: activeOrderBookOptions?.nSigFigs,
       orderBookCoin: activeOrderBookOptions?.coin,
+      routeFocused: tradeRouteViewState.routeFocused,
+      tokenSelectorOpen: tradeRouteViewState.tokenSelectorOpen,
+      tokenSelectorTab: tradeRouteViewState.tokenSelectorTab,
+      infoPanelTab: tradeRouteViewState.infoPanelTab,
     });
     noop(activePerpsAccount?.accountAddress);
-    noop(activeAsset?.coin);
+    noop(activeTradeInstrument?.coin);
     noop(activeOrderBookOptions?.coin);
     noop(activeOrderBookOptions?.mantissa);
     noop(activeOrderBookOptions?.nSigFigs);
+    noop(activeTradeInstrument.mode);
+    noop(tradeRouteViewState.routeFocused);
+    noop(tradeRouteViewState.tokenSelectorOpen);
+    noop(tradeRouteViewState.tokenSelectorTab);
+    noop(tradeRouteViewState.infoPanelTab);
 
-    if (isWebSocketConnected === true && !isLoading) {
-      if (
-        activeAsset?.coin &&
-        activeOrderBookOptions?.coin === activeAsset?.coin
-      ) {
-        console.log('updateSubscriptions______PerpsGlobalEffects');
-        void actions.current.updateSubscriptions();
-      } else {
-        // update orderbook options to match the active asset
-        // Toast.error({
-        //   title: 'Error',
-        //   message:
-        //     'Orderbook options do not match the active asset coin, please change the asset',
-        // });
-      }
+    const plan = planTradeSubscriptions({
+      activeInstrument: activeTradeInstrument,
+      hasAccount: !!activePerpsAccount?.accountAddress,
+      orderBookOptions: activeOrderBookOptions,
+      viewState: tradeRouteViewState,
+    });
+
+    void backgroundApiProxy.serviceHyperliquidSubscription.setRouteSubscriptionState(
+      {
+        enableLedgerUpdates: plan.enableLedgerUpdates,
+        spotAssetCtxsEnabled: plan.spotAssetCtxsEnabled,
+        spotEnabled: plan.spotEnabled,
+      },
+    );
+
+    if (
+      isWebSocketConnected === true &&
+      !isLoading &&
+      plan.shouldSyncSubscriptions
+    ) {
+      void actions.current.updateSubscriptions();
     }
   }, [
     checkDeps,
@@ -486,10 +539,9 @@ function WebSocketSubscriptionUpdate() {
     isLoading,
     actions,
     activePerpsAccount?.accountAddress,
-    activeAsset?.coin,
-    activeOrderBookOptions?.mantissa,
-    activeOrderBookOptions?.nSigFigs,
-    activeOrderBookOptions?.coin,
+    activeTradeInstrument,
+    activeOrderBookOptions,
+    tradeRouteViewState,
   ]);
   return null;
 }
@@ -502,11 +554,28 @@ function useHyperliquidSymbolSelect() {
     if (isFocus && !initDoneRef.current) {
       initDoneRef.current = true;
       void (async () => {
-        await backgroundApiProxy.serviceHyperliquid.refreshTradingMeta();
-        const currentToken = await perpsActiveAssetAtom.get();
-        await actions.current.changeActiveAsset({
-          coin: currentToken.coin,
+        await Promise.all([
+          backgroundApiProxy.serviceHyperliquid.refreshTradingMeta(),
+          // Spot meta failure must not block perps initialization
+          backgroundApiProxy.serviceHyperliquid.refreshSpotMeta().catch((e) => {
+            console.error('refreshSpotMeta failed (non-blocking):', e);
+          }),
+        ]);
+        const currentMode = await tradingModeAtom.get();
+        const currentPerpToken = await perpsActiveAssetAtom.get();
+        const currentSpotToken = await spotActiveAssetAtom.get();
+        const nextMode = currentMode === 'spot' ? 'spot' : 'perp';
+        const nextCoin =
+          nextMode === 'spot' ? currentSpotToken?.coin : currentPerpToken?.coin;
+        if (!nextCoin) {
+          return;
+        }
+        await actions.current.switchTradeInstrument({
+          mode: nextMode,
+          coin: nextCoin,
           force: true,
+          spotUniverse:
+            nextMode === 'spot' ? currentSpotToken?.universe : undefined,
         });
       })();
     }
@@ -637,6 +706,7 @@ function PerpsGlobalEffectsView() {
   useHyperliquidSymbolSelect();
   useHyperliquidScreenLockHandler();
   useSyncContextOrderBookOptionsToGlobal();
+  useTradeRouteViewStateSync();
   usePerpsSharePrompt();
 
   return (

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -484,38 +484,50 @@ function WebSocketSubscriptionUpdate() {
   const isLoadingRef = useRef(isLoading);
   isLoadingRef.current = isLoading;
 
+  // Extract primitive values from objects to avoid re-running effect on
+  // every new object reference when the actual values haven't changed
+  const instrumentCoin = activeTradeInstrument?.coin;
+  const instrumentMode = activeTradeInstrument.mode;
+  const instrumentAssetId = activeTradeInstrument?.assetId;
+  const orderBookCoin = activeOrderBookOptions?.coin;
+  const orderBookMantissa = activeOrderBookOptions?.mantissa;
+  const orderBookNSigFigs = activeOrderBookOptions?.nSigFigs;
+  const routeFocused = tradeRouteViewState.routeFocused;
+  const tokenSelectorOpen = tradeRouteViewState.tokenSelectorOpen;
+  const tokenSelectorTab = tradeRouteViewState.tokenSelectorTab;
+  const infoPanelTab = tradeRouteViewState.infoPanelTab;
+  const accountAddress = activePerpsAccount?.accountAddress;
+
+  // Keep refs for objects needed inside the effect body (not as triggers)
+  const activeTradeInstrumentRef = useRef(activeTradeInstrument);
+  activeTradeInstrumentRef.current = activeTradeInstrument;
+  const activeOrderBookOptionsRef = useRef(activeOrderBookOptions);
+  activeOrderBookOptionsRef.current = activeOrderBookOptions;
+  const tradeRouteViewStateRef = useRef(tradeRouteViewState);
+  tradeRouteViewStateRef.current = tradeRouteViewState;
+
   useEffect(() => {
     checkDeps({
       isWebSocketConnected,
       isLoading,
       actions,
-      address: activePerpsAccount?.accountAddress,
-      coin: activeTradeInstrument?.coin,
-      tradingMode: activeTradeInstrument.mode,
-      mantissa: activeOrderBookOptions?.mantissa,
-      nSigFigs: activeOrderBookOptions?.nSigFigs,
-      orderBookCoin: activeOrderBookOptions?.coin,
-      routeFocused: tradeRouteViewState.routeFocused,
-      tokenSelectorOpen: tradeRouteViewState.tokenSelectorOpen,
-      tokenSelectorTab: tradeRouteViewState.tokenSelectorTab,
-      infoPanelTab: tradeRouteViewState.infoPanelTab,
+      address: accountAddress,
+      coin: instrumentCoin,
+      tradingMode: instrumentMode,
+      mantissa: orderBookMantissa,
+      nSigFigs: orderBookNSigFigs,
+      orderBookCoin,
+      routeFocused,
+      tokenSelectorOpen,
+      tokenSelectorTab,
+      infoPanelTab,
     });
-    noop(activePerpsAccount?.accountAddress);
-    noop(activeTradeInstrument?.coin);
-    noop(activeOrderBookOptions?.coin);
-    noop(activeOrderBookOptions?.mantissa);
-    noop(activeOrderBookOptions?.nSigFigs);
-    noop(activeTradeInstrument.mode);
-    noop(tradeRouteViewState.routeFocused);
-    noop(tradeRouteViewState.tokenSelectorOpen);
-    noop(tradeRouteViewState.tokenSelectorTab);
-    noop(tradeRouteViewState.infoPanelTab);
 
     const plan = planTradeSubscriptions({
-      activeInstrument: activeTradeInstrument,
-      hasAccount: !!activePerpsAccount?.accountAddress,
-      orderBookOptions: activeOrderBookOptions,
-      viewState: tradeRouteViewState,
+      activeInstrument: activeTradeInstrumentRef.current,
+      hasAccount: !!accountAddress,
+      orderBookOptions: activeOrderBookOptionsRef.current,
+      viewState: tradeRouteViewStateRef.current,
     });
 
     void backgroundApiProxy.serviceHyperliquidSubscription.setRouteSubscriptionState(
@@ -538,10 +550,17 @@ function WebSocketSubscriptionUpdate() {
     isWebSocketConnected,
     isLoading,
     actions,
-    activePerpsAccount?.accountAddress,
-    activeTradeInstrument,
-    activeOrderBookOptions,
-    tradeRouteViewState,
+    accountAddress,
+    instrumentCoin,
+    instrumentMode,
+    instrumentAssetId,
+    orderBookCoin,
+    orderBookMantissa,
+    orderBookNSigFigs,
+    routeFocused,
+    tokenSelectorOpen,
+    tokenSelectorTab,
+    infoPanelTab,
   ]);
   return null;
 }

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -374,10 +374,6 @@ function useHyperliquidAccountSelect() {
     }
     noop(activeAccountRefreshHook);
     noop(activeAccount.account?.address);
-    console.log(
-      'selectPerpsAccount______555_address',
-      activeAccount.account?.address,
-    );
     await actions.current.changeActivePerpsAccount({
       indexedAccountId: activeAccount?.indexedAccount?.id || null,
       accountId: activeAccount?.account?.id || null,
@@ -738,12 +734,7 @@ function PerpsGlobalEffectsView() {
   );
 }
 
-const PerpsGlobalEffectsMemo = memo(() => {
-  if (process.env.NODE_ENV !== 'production') {
-    console.log('PerpsGlobalEffectsMemo___mouted');
-  }
-  return <PerpsGlobalEffectsView />;
-});
+const PerpsGlobalEffectsMemo = memo(() => <PerpsGlobalEffectsView />);
 PerpsGlobalEffectsMemo.displayName = 'PerpsGlobalEffectsMemo';
 
 export function PerpsGlobalEffects() {

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -167,11 +167,9 @@ function useTradeRouteViewStateSync() {
 function useHyperliquidEventBusListener() {
   const actions = useHyperliquidActions();
 
-  // Throttle ALL_DEXS_ASSET_CTXS writes to 1s (leading + trailing).
-  // This fires every ~500ms and forces all visible token-selector rows to
-  // re-render via usePerpsAssetCtx → usePerpsAllAssetCtxsAtom. Throttling
-  // halves the ongoing rate; startTransition ensures these background updates
-  // yield to user interactions (e.g. opening the token selector).
+  // Throttle ALL_DEXS_ASSET_CTXS to 1s (leading + trailing) — fires every
+  // ~500ms and causes token-selector row re-renders; startTransition yields
+  // to user interactions.
   const assetCtxsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const assetCtxsDirtyRef = useRef<IWsAllDexsAssetCtxs | null>(null);
 
@@ -211,13 +209,11 @@ function useHyperliquidEventBusListener() {
           case ESubscriptionType.ALL_DEXS_ASSET_CTXS: {
             assetCtxsDirtyRef.current = data as IWsAllDexsAssetCtxs;
             if (!assetCtxsTimerRef.current) {
-              // Leading edge: flush immediately as a low-priority transition
               const pending = assetCtxsDirtyRef.current;
               assetCtxsDirtyRef.current = null;
               startTransition(() => {
                 void actions.current.updateAllDexsAssetCtxs(pending);
               });
-              // Trailing edge: one more flush after 1s if new data arrived
               assetCtxsTimerRef.current = setTimeout(() => {
                 assetCtxsTimerRef.current = null;
                 if (assetCtxsDirtyRef.current) {
@@ -509,8 +505,7 @@ function WebSocketSubscriptionUpdate() {
   const isLoadingRef = useRef(isLoading);
   isLoadingRef.current = isLoading;
 
-  // Extract primitive values from objects to avoid re-running effect on
-  // every new object reference when the actual values haven't changed
+  // Primitives as deps — avoids re-running on same-value object changes
   const instrumentCoin = activeTradeInstrument?.coin;
   const instrumentMode = activeTradeInstrument.mode;
   const instrumentAssetId = activeTradeInstrument?.assetId;
@@ -523,7 +518,7 @@ function WebSocketSubscriptionUpdate() {
   const infoPanelTab = tradeRouteViewState.infoPanelTab;
   const accountAddress = activePerpsAccount?.accountAddress;
 
-  // Keep refs for objects needed inside the effect body (not as triggers)
+  // Refs for reading inside effect body without triggering it
   const activeTradeInstrumentRef = useRef(activeTradeInstrument);
   activeTradeInstrumentRef.current = activeTradeInstrument;
   const activeOrderBookOptionsRef = useRef(activeOrderBookOptions);
@@ -663,11 +658,6 @@ function AutoPauseSubscriptions() {
   const pauseSubscriptionsTimerRef = useRef<
     ReturnType<typeof setTimeout> | undefined
   >(undefined);
-
-  // const isFocusedRoute = useRouteIsFocused();
-  // useEffect(() => {
-  //   //
-  // }, [isFocusedRoute]);
 
   const onFocusHandler = useCallback(
     async ({

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useRef } from 'react';
+import { memo, startTransition, useCallback, useEffect, useRef } from 'react';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { isEqual, noop } from 'lodash';
@@ -167,6 +167,14 @@ function useTradeRouteViewStateSync() {
 function useHyperliquidEventBusListener() {
   const actions = useHyperliquidActions();
 
+  // Throttle ALL_DEXS_ASSET_CTXS writes to 1s (leading + trailing).
+  // This fires every ~500ms and forces all visible token-selector rows to
+  // re-render via usePerpsAssetCtx → usePerpsAllAssetCtxsAtom. Throttling
+  // halves the ongoing rate; startTransition ensures these background updates
+  // yield to user interactions (e.g. opening the token selector).
+  const assetCtxsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const assetCtxsDirtyRef = useRef<IWsAllDexsAssetCtxs | null>(null);
+
   useEffect(() => {
     const handleDataUpdate = (payload: unknown) => {
       const eventPayload = payload as {
@@ -201,9 +209,26 @@ function useHyperliquidEventBusListener() {
           }
 
           case ESubscriptionType.ALL_DEXS_ASSET_CTXS: {
-            void actions.current.updateAllDexsAssetCtxs(
-              data as IWsAllDexsAssetCtxs,
-            );
+            assetCtxsDirtyRef.current = data as IWsAllDexsAssetCtxs;
+            if (!assetCtxsTimerRef.current) {
+              // Leading edge: flush immediately as a low-priority transition
+              const pending = assetCtxsDirtyRef.current;
+              assetCtxsDirtyRef.current = null;
+              startTransition(() => {
+                void actions.current.updateAllDexsAssetCtxs(pending);
+              });
+              // Trailing edge: one more flush after 1s if new data arrived
+              assetCtxsTimerRef.current = setTimeout(() => {
+                assetCtxsTimerRef.current = null;
+                if (assetCtxsDirtyRef.current) {
+                  const trailing = assetCtxsDirtyRef.current;
+                  assetCtxsDirtyRef.current = null;
+                  startTransition(() => {
+                    void actions.current.updateAllDexsAssetCtxs(trailing);
+                  });
+                }
+              }, 1000);
+            }
             break;
           }
 
@@ -276,6 +301,10 @@ function useHyperliquidEventBusListener() {
     );
 
     return () => {
+      if (assetCtxsTimerRef.current) {
+        clearTimeout(assetCtxsTimerRef.current);
+        assetCtxsTimerRef.current = null;
+      }
       appEventBus.off(
         EAppEventBusNames.HyperliquidDataUpdate,
         handleDataUpdate,

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -4,7 +4,6 @@ import { memo, startTransition, useCallback, useEffect, useRef } from 'react';
 import { isEqual, noop } from 'lodash';
 
 import { useUpdateEffect } from '@onekeyhq/components';
-import { DelayedRender } from '@onekeyhq/components/src/hocs/DelayedRender';
 import {
   useAccountIsAutoCreatingAtom,
   useAppIsLockedAtom,
@@ -745,9 +744,7 @@ function PerpsGlobalEffectsView() {
 
   return (
     <>
-      <DelayedRender delay={600}>
-        <WebSocketSubscriptionUpdate />
-      </DelayedRender>
+      <WebSocketSubscriptionUpdate />
       <AutoPauseSubscriptions />
     </>
   );

--- a/packages/kit/src/views/Perp/components/TickerBar/MobilePerpMarketHeader.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/MobilePerpMarketHeader.tsx
@@ -14,11 +14,15 @@ import {
   YStack,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { usePerpsActiveAssetCtxAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { useConnectionStateAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import {
+  usePerpsActiveAssetCtxAtom,
+  useSpotActiveAssetCtxAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 
-import { usePerpSession } from '../../hooks';
+import { useActiveTradeDisplay } from '../../hooks/useActiveTradeDisplay';
 
 function StatRow({
   label,
@@ -43,9 +47,15 @@ function StatRow({
 
 function MobilePerpMarketHeader() {
   const intl = useIntl();
-  const { isReady, hasError } = usePerpSession();
+  const { mode } = useActiveTradeDisplay();
+  const [connectionState] = useConnectionStateAtom();
   const [assetCtx] = usePerpsActiveAssetCtxAtom();
+  const [spotAssetCtx] = useSpotActiveAssetCtxAtom();
   const [builderFeeRate, setBuilderFeeRate] = useState<number | undefined>();
+  const hasError = connectionState.reconnectCount > 3;
+  const isReady = connectionState.isConnected && !hasError;
+  const isSpot = mode === 'spot';
+  const currentCtx = isSpot ? spotAssetCtx?.ctx : assetCtx?.ctx;
 
   useEffect(() => {
     void backgroundApiProxy.simpleDb.perp
@@ -55,21 +65,18 @@ function MobilePerpMarketHeader() {
       });
   }, []);
 
-  const {
-    midPrice,
-    markPrice,
-    fundingRate,
-    openInterest,
-    volume24h,
-    change24hPercent,
-  } = assetCtx?.ctx || {
-    midPrice: '0',
-    markPrice: '0',
-    fundingRate: '0',
-    openInterest: '0',
-    volume24h: '0',
-    change24hPercent: 0,
-  };
+  // Common fields exist on both IPerpsFormattedAssetCtx and ISpotFormattedAssetCtx
+  const midPrice = currentCtx?.midPrice ?? '0';
+  const markPrice = currentCtx?.markPrice ?? '0';
+  const volume24h = currentCtx?.volume24h ?? '0';
+  const change24hPercent = currentCtx?.change24hPercent ?? 0;
+  // Perp-only fields
+  const perpCtx = assetCtx?.ctx;
+  const fundingRate = perpCtx?.fundingRate ?? '0';
+  const openInterest = perpCtx?.openInterest ?? '0';
+  // Spot-only fields
+  const spotCtx = spotAssetCtx?.ctx;
+  const circulatingSupply = spotCtx?.circulatingSupply ?? '0';
 
   const midPriceNumber = useMemo(() => parseFloat(midPrice), [midPrice]);
   const fundingRateNumber = useMemo(
@@ -109,6 +116,17 @@ function MobilePerpMarketHeader() {
   }, [volume24h]);
 
   const openInterestDisplay = useMemo(() => {
+    if (isSpot) {
+      const marketCap = (Number(circulatingSupply || 0) * Number(markPrice || 0)).toString();
+      const formatted = numberFormat(marketCap, {
+        formatter: 'marketCap',
+      });
+      if (typeof formatted !== 'string' || formatted.length === 0) {
+        return '--';
+      }
+      return `$${formatted}`;
+    }
+
     if (
       openInterest === undefined ||
       openInterest === null ||
@@ -127,7 +145,7 @@ function MobilePerpMarketHeader() {
       return '--';
     }
     return `$${formatted}`;
-  }, [markPrice, openInterest]);
+  }, [circulatingSupply, isSpot, markPrice, openInterest]);
 
   return (
     <YStack bg="$bgApp" px="$5" pt="$3" gap="$2">
@@ -224,7 +242,9 @@ function MobilePerpMarketHeader() {
 
           <StatRow
             label={intl.formatMessage({
-              id: ETranslations.perp_token_bar_open_Interest,
+              id: isSpot
+                ? ETranslations.global_market_cap
+                : ETranslations.perp_token_bar_open_Interest,
             })}
             skeletonWidth={120}
             showSkeleton={showSkeleton}
@@ -239,24 +259,26 @@ function MobilePerpMarketHeader() {
             </SizableText>
           </StatRow>
 
-          <StatRow
-            label={intl.formatMessage({
-              id: ETranslations.perp_position_funding,
-            })}
-            skeletonWidth={140}
-            showSkeleton={showSkeleton}
-          >
-            <SizableText
-              size="$bodySmMedium"
-              flex={1}
-              textAlign="right"
-              color={fundingColor}
+          {isSpot ? null : (
+            <StatRow
+              label={intl.formatMessage({
+                id: ETranslations.perp_position_funding,
+              })}
+              skeletonWidth={140}
+              showSkeleton={showSkeleton}
             >
-              {fundingDisplay}
-            </SizableText>
-          </StatRow>
+              <SizableText
+                size="$bodySmMedium"
+                flex={1}
+                textAlign="right"
+                color={fundingColor}
+              >
+                {fundingDisplay}
+              </SizableText>
+            </StatRow>
+          )}
 
-          {builderFeeRate === 0 ? (
+          {!isSpot && builderFeeRate === 0 ? (
             <XStack alignItems="center" justifyContent="space-between" gap="$1">
               <Popover
                 title={intl.formatMessage({

--- a/packages/kit/src/views/Perp/components/TickerBar/MobilePerpMarketHeader.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/MobilePerpMarketHeader.tsx
@@ -6,12 +6,14 @@ import { useIntl } from 'react-intl';
 import {
   DashText,
   Icon,
+  IconButton,
   NumberSizeableText,
   Popover,
   SizableText,
   Skeleton,
   XStack,
   YStack,
+  useClipboard,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { useConnectionStateAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
@@ -19,9 +21,11 @@ import {
   usePerpsActiveAssetCtxAtom,
   useSpotActiveAssetCtxAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { useSpotActiveAssetAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/spot';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 
+import { useSpotMetaMaps } from '../../hooks/useSpotMetaMaps';
 import { useActiveTradeDisplay } from '../../hooks/useActiveTradeDisplay';
 
 function StatRow({
@@ -47,10 +51,13 @@ function StatRow({
 
 function MobilePerpMarketHeader() {
   const intl = useIntl();
+  const { copyText } = useClipboard();
   const { mode } = useActiveTradeDisplay();
   const [connectionState] = useConnectionStateAtom();
   const [assetCtx] = usePerpsActiveAssetCtxAtom();
   const [spotAssetCtx] = useSpotActiveAssetCtxAtom();
+  const [spotAsset] = useSpotActiveAssetAtom();
+  const { tokenContractMap } = useSpotMetaMaps();
   const [builderFeeRate, setBuilderFeeRate] = useState<number | undefined>();
   const hasError = connectionState.reconnectCount > 3;
   const isReady = connectionState.isConnected && !hasError;
@@ -117,7 +124,9 @@ function MobilePerpMarketHeader() {
 
   const openInterestDisplay = useMemo(() => {
     if (isSpot) {
-      const marketCap = (Number(circulatingSupply || 0) * Number(markPrice || 0)).toString();
+      const marketCap = (
+        Number(circulatingSupply || 0) * Number(markPrice || 0)
+      ).toString();
       const formatted = numberFormat(marketCap, {
         formatter: 'marketCap',
       });
@@ -146,6 +155,13 @@ function MobilePerpMarketHeader() {
     }
     return `$${formatted}`;
   }, [circulatingSupply, isSpot, markPrice, openInterest]);
+
+  const spotContract =
+    tokenContractMap[spotAsset?.universe?.baseName ?? ''] ||
+    tokenContractMap[spotAsset?.coin ?? ''];
+  const spotContractDisplay = spotContract
+    ? `${spotContract.slice(0, 6)}...${spotContract.slice(-4)}`
+    : '--';
 
   return (
     <YStack bg="$bgApp" px="$5" pt="$3" gap="$2">
@@ -258,6 +274,42 @@ function MobilePerpMarketHeader() {
               {openInterestDisplay}
             </SizableText>
           </StatRow>
+
+          {isSpot ? (
+            <StatRow
+              label={intl.formatMessage({
+                id: ETranslations.global_contract,
+              })}
+              skeletonWidth={120}
+              showSkeleton={showSkeleton}
+            >
+              <XStack
+                flex={1}
+                justifyContent="flex-end"
+                alignItems="center"
+                gap="$1"
+              >
+                <SizableText
+                  size="$bodySmMedium"
+                  color="$text"
+                  fontFamily="$monoRegular"
+                >
+                  {spotContractDisplay}
+                </SizableText>
+                {spotContract ? (
+                  <IconButton
+                    variant="tertiary"
+                    size="small"
+                    icon="Copy3Outline"
+                    iconSize="$3"
+                    onPress={() => {
+                      copyText(spotContract);
+                    }}
+                  />
+                ) : null}
+              </XStack>
+            </StatRow>
+          ) : null}
 
           {isSpot ? null : (
             <StatRow

--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 
 import { isString } from 'lodash';
 import { useIntl } from 'react-intl';
@@ -7,6 +7,7 @@ import {
   DashText,
   DebugRenderTracker,
   Divider,
+  IconButton,
   NumberSizeableText,
   ScrollView,
   SizableText,
@@ -14,6 +15,7 @@ import {
   Tooltip,
   XStack,
   YStack,
+  useClipboard,
   useMedia,
 } from '@onekeyhq/components';
 import {
@@ -21,7 +23,10 @@ import {
   usePerpsActiveAssetCtxAtom,
   useTradingModeAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import { useSpotActiveAssetCtxAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/spot';
+import {
+  useSpotActiveAssetAtom,
+  useSpotActiveAssetCtxAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms/spot';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
   NUMBER_FORMATTER,
@@ -30,6 +35,7 @@ import {
 import { PERP_LAYOUT_CONFIG } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 
 import { useFundingCountdown, usePerpSession } from '../../hooks';
+import { useSpotMetaMaps } from '../../hooks/useSpotMetaMaps';
 import { PerpTokenSelector } from '../TokenSelector/PerpTokenSelector';
 import { FavoriteButton } from '../TokenSelector/PerpTokenSelectorRow';
 
@@ -333,6 +339,111 @@ function TickerBarOpenInterest() {
       }
       isLoading={isLoading}
     />
+  );
+}
+
+const TickerBarMarketCapView = memo(
+  ({
+    formattedMarketCap,
+    isLoading,
+  }: {
+    formattedMarketCap: string;
+    isLoading: boolean;
+  }) => {
+    const intl = useIntl();
+    return (
+      <DebugRenderTracker name="TickerBarMarketCap">
+        <YStack>
+          <SizableText size="$bodySm" color="$textSubdued">
+            {intl.formatMessage({
+              id: ETranslations.global_market_cap,
+            })}
+          </SizableText>
+          <SkeletonContainer isLoading={isLoading} width={80} height={16}>
+            <SizableText size="$headingXs">${formattedMarketCap}</SizableText>
+          </SkeletonContainer>
+        </YStack>
+      </DebugRenderTracker>
+    );
+  },
+);
+TickerBarMarketCapView.displayName = 'TickerBarMarketCapView';
+
+function TickerBarMarketCap() {
+  const [spotAssetCtx] = useSpotActiveAssetCtxAtom();
+  const { circulatingSupply = '0', markPrice = '0' } = spotAssetCtx?.ctx || {};
+  const formattedMarketCap = formatDisplayNumber(
+    NUMBER_FORMATTER.marketCap(
+      (Number(circulatingSupply) * Number(markPrice)).toString(),
+    ),
+  );
+  const isLoading = useTickerBarIsLoading();
+
+  return (
+    <TickerBarMarketCapView
+      formattedMarketCap={
+        isString(formattedMarketCap) ? formattedMarketCap : '--'
+      }
+      isLoading={isLoading}
+    />
+  );
+}
+
+const TickerBarSpotContractView = memo(
+  ({ contract, isLoading }: { contract?: string; isLoading: boolean }) => {
+    const intl = useIntl();
+    const { copyText } = useClipboard();
+    const shortenedContract = contract
+      ? `${contract.slice(0, 6)}...${contract.slice(-4)}`
+      : '--';
+
+    return (
+      <DebugRenderTracker name="TickerBarSpotContract">
+        <YStack>
+          <SizableText size="$bodySm" color="$textSubdued">
+            {intl.formatMessage({
+              id: ETranslations.global_contract,
+            })}
+          </SizableText>
+          <SkeletonContainer isLoading={isLoading} width={120} height={16}>
+            <XStack gap="$1" alignItems="center">
+              <SizableText
+                size="$headingXs"
+                fontFamily="$monoRegular"
+                color="$text"
+              >
+                {shortenedContract}
+              </SizableText>
+              {contract ? (
+                <IconButton
+                  size="small"
+                  variant="tertiary"
+                  icon="Copy3Outline"
+                  iconProps={{ size: '$3', color: '$iconSubdued' }}
+                  onPress={() => {
+                    copyText(contract);
+                  }}
+                />
+              ) : null}
+            </XStack>
+          </SkeletonContainer>
+        </YStack>
+      </DebugRenderTracker>
+    );
+  },
+);
+TickerBarSpotContractView.displayName = 'TickerBarSpotContractView';
+
+function TickerBarSpotContract() {
+  const [spotAsset] = useSpotActiveAssetAtom();
+  const { tokenContractMap } = useSpotMetaMaps();
+  const isLoading = useTickerBarIsLoading();
+  const contract =
+    tokenContractMap[spotAsset?.universe?.baseName ?? ''] ||
+    tokenContractMap[spotAsset?.coin ?? ''];
+
+  return (
+    <TickerBarSpotContractView contract={contract} isLoading={isLoading} />
   );
 }
 
@@ -662,6 +773,7 @@ function PerpTickerBarDesktop() {
   const [activeAsset] = usePerpsActiveAssetAtom();
   const [tradingMode] = useTradingModeAtom();
   const isSpot = tradingMode === 'spot';
+  const marketDataGap = useMemo(() => (isSpot ? '$6' : '$8'), [isSpot]);
   const content = (
     <XStack
       bg="$bgApp"
@@ -677,7 +789,11 @@ function PerpTickerBarDesktop() {
     >
       <XStack gap="$4" alignItems="center">
         <XStack gap="$2" alignItems="center">
-          <FavoriteButton coin={activeAsset.coin} iconSize="$4" isSpot={isSpot} />
+          <FavoriteButton
+            coin={activeAsset.coin}
+            iconSize="$4"
+            isSpot={isSpot}
+          />
           <PerpTokenSelector />
         </XStack>
 
@@ -693,14 +809,15 @@ function PerpTickerBarDesktop() {
         horizontal
         flex={1}
         contentContainerStyle={{
-          gap: '$8',
+          gap: marketDataGap,
           alignItems: 'center',
           justifyContent: 'flex-start',
         }}
       >
         {isSpot ? null : <TickerBarOraclePrice />}
         <TickerBar24hVolume />
-        {isSpot ? null : <TickerBarOpenInterest />}
+        {isSpot ? <TickerBarMarketCap /> : <TickerBarOpenInterest />}
+        {isSpot ? <TickerBarSpotContract /> : null}
         {isSpot ? null : <TickerBarFundingRate />}
       </ScrollView>
     </XStack>

--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
@@ -88,8 +88,13 @@ const TickerBarMarkPriceView = memo(
 TickerBarMarkPriceView.displayName = 'TickerBarMarkPriceView';
 
 function TickerBarMarkPrice() {
+  const [tradingMode] = useTradingModeAtom();
   const [assetCtx] = usePerpsActiveAssetCtxAtom();
-  const formattedMarkPrice = assetCtx?.ctx?.markPrice || '';
+  const [spotAssetCtx] = useSpotActiveAssetCtxAtom();
+  const formattedMarkPrice =
+    tradingMode === 'spot'
+      ? spotAssetCtx?.ctx?.markPrice || ''
+      : assetCtx?.ctx?.markPrice || '';
   const isLoading = useTickerBarIsLoading();
   return (
     <TickerBarMarkPriceView
@@ -135,8 +140,13 @@ TickerBarChange24hPercentView.displayName = 'TickerBarChange24hPercentView';
 
 export function TickerBarChange24hPercent() {
   const { gtMd } = useMedia();
+  const [tradingMode] = useTradingModeAtom();
   const [assetCtx] = usePerpsActiveAssetCtxAtom();
-  const change24hPercent = assetCtx?.ctx?.change24hPercent || 0;
+  const [spotAssetCtx] = useSpotActiveAssetCtxAtom();
+  const change24hPercent =
+    tradingMode === 'spot'
+      ? spotAssetCtx?.ctx?.change24hPercent || 0
+      : assetCtx?.ctx?.change24hPercent || 0;
   const isLoading = useTickerBarIsLoading();
 
   return (
@@ -234,8 +244,13 @@ const TickerBar24hVolumeView = memo(
 TickerBar24hVolumeView.displayName = 'TickerBar24hVolumeView';
 
 function TickerBar24hVolume() {
+  const [tradingMode] = useTradingModeAtom();
   const [assetCtx] = usePerpsActiveAssetCtxAtom();
-  const volume24h = assetCtx?.ctx?.volume24h || '0';
+  const [spotAssetCtx] = useSpotActiveAssetCtxAtom();
+  const volume24h =
+    tradingMode === 'spot'
+      ? spotAssetCtx?.ctx?.volume24h || '0'
+      : assetCtx?.ctx?.volume24h || '0';
   const formattedVolume24h = formatDisplayNumber(
     NUMBER_FORMATTER.marketCap(volume24h.toString()),
   );
@@ -670,23 +685,21 @@ function PerpTickerBarDesktop() {
       </XStack>
 
       {/* Right: Market Data -- hide perps-only items for spot */}
-      {isSpot ? null : (
-        <ScrollView
-          cursor="default"
-          horizontal
-          flex={1}
-          contentContainerStyle={{
-            gap: '$8',
-            alignItems: 'center',
-            justifyContent: 'flex-start',
-          }}
-        >
-          <TickerBarOraclePrice />
-          <TickerBar24hVolume />
-          <TickerBarOpenInterest />
-          <TickerBarFundingRate />
-        </ScrollView>
-      )}
+      <ScrollView
+        cursor="default"
+        horizontal
+        flex={1}
+        contentContainerStyle={{
+          gap: '$8',
+          alignItems: 'center',
+          justifyContent: 'flex-start',
+        }}
+      >
+        {isSpot ? null : <TickerBarOraclePrice />}
+        <TickerBar24hVolume />
+        {isSpot ? null : <TickerBarOpenInterest />}
+        {isSpot ? null : <TickerBarFundingRate />}
+      </ScrollView>
     </XStack>
   );
   return (

--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
@@ -19,7 +19,9 @@ import {
 import {
   usePerpsActiveAssetAtom,
   usePerpsActiveAssetCtxAtom,
+  useTradingModeAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { useSpotActiveAssetCtxAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/spot';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
   NUMBER_FORMATTER,
@@ -33,7 +35,14 @@ import { FavoriteButton } from '../TokenSelector/PerpTokenSelectorRow';
 
 function useTickerBarIsLoading() {
   const { isReady, hasError } = usePerpSession();
+  const [tradingMode] = useTradingModeAtom();
   const [assetCtx] = usePerpsActiveAssetCtxAtom();
+  const [spotAssetCtx] = useSpotActiveAssetCtxAtom();
+  const isSpot = tradingMode === 'spot';
+  if (isSpot) {
+    // Spot: loaded when spotAssetCtx is available
+    return !isReady || hasError || !spotAssetCtx?.ctx;
+  }
   const { markPrice } = assetCtx?.ctx || {
     markPrice: '0',
   };
@@ -633,6 +642,8 @@ function TickerBarFundingRate() {
 
 function PerpTickerBarDesktop() {
   const [activeAsset] = usePerpsActiveAssetAtom();
+  const [tradingMode] = useTradingModeAtom();
+  const isSpot = tradingMode === 'spot';
   const content = (
     <XStack
       bg="$bgApp"
@@ -648,7 +659,7 @@ function PerpTickerBarDesktop() {
     >
       <XStack gap="$4" alignItems="center">
         <XStack gap="$2" alignItems="center">
-          <FavoriteButton coin={activeAsset.coin} iconSize="$4" />
+          <FavoriteButton coin={activeAsset.coin} iconSize="$4" isSpot={isSpot} />
           <PerpTokenSelector />
         </XStack>
 
@@ -658,22 +669,24 @@ function PerpTickerBarDesktop() {
         </XStack>
       </XStack>
 
-      {/* Right: Market Data */}
-      <ScrollView
-        cursor="default"
-        horizontal
-        flex={1}
-        contentContainerStyle={{
-          gap: '$8',
-          alignItems: 'center',
-          justifyContent: 'flex-start',
-        }}
-      >
-        <TickerBarOraclePrice />
-        <TickerBar24hVolume />
-        <TickerBarOpenInterest />
-        <TickerBarFundingRate />
-      </ScrollView>
+      {/* Right: Market Data -- hide perps-only items for spot */}
+      {isSpot ? null : (
+        <ScrollView
+          cursor="default"
+          horizontal
+          flex={1}
+          contentContainerStyle={{
+            gap: '$8',
+            alignItems: 'center',
+            justifyContent: 'flex-start',
+          }}
+        >
+          <TickerBarOraclePrice />
+          <TickerBar24hVolume />
+          <TickerBarOpenInterest />
+          <TickerBarFundingRate />
+        </ScrollView>
+      )}
     </XStack>
   );
   return (

--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
@@ -40,8 +40,11 @@ function useTickerBarIsLoading() {
   const [spotAssetCtx] = useSpotActiveAssetCtxAtom();
   const isSpot = tradingMode === 'spot';
   if (isSpot) {
-    // Spot: loaded when spotAssetCtx is available
-    return !isReady || hasError || !spotAssetCtx?.ctx;
+    // Spot: only loading if spot ctx hasn't arrived yet.
+    // Don't gate on isReady (perps WS connection state) — spot data
+    // flows through the same WS but isReady can be temporarily false
+    // during mode transitions while the spot subscription is active.
+    return !spotAssetCtx?.ctx;
   }
   const { markPrice } = assetCtx?.ctx || {
     markPrice: '0',

--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
@@ -250,10 +250,10 @@ function TickerBar24hVolume() {
   const [tradingMode] = useTradingModeAtom();
   const [assetCtx] = usePerpsActiveAssetCtxAtom();
   const [spotAssetCtx] = useSpotActiveAssetCtxAtom();
-  const volume24h =
-    tradingMode === 'spot'
-      ? spotAssetCtx?.ctx?.volume24h || '0'
-      : assetCtx?.ctx?.volume24h || '0';
+  const isSpot = tradingMode === 'spot';
+  const volume24h = isSpot
+    ? spotAssetCtx?.ctx?.volume24h || '0'
+    : assetCtx?.ctx?.volume24h || '0';
   const formattedVolume24h = formatDisplayNumber(
     NUMBER_FORMATTER.marketCap(volume24h.toString()),
   );
@@ -687,7 +687,7 @@ function PerpTickerBarDesktop() {
         </XStack>
       </XStack>
 
-      {/* Right: Market Data -- hide perps-only items for spot */}
+      {/* Right: Market Data */}
       <ScrollView
         cursor="default"
         horizontal

--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarMobile.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarMobile.tsx
@@ -17,6 +17,7 @@ import { usePerpsTokenSearchAliasesAtom } from '@onekeyhq/kit/src/states/jotai/c
 import {
   usePerpsActiveAccountStatusAtom,
   usePerpsActiveAssetAtom,
+  useTradingModeAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
@@ -51,6 +52,8 @@ function PerpCandleChartButtonMobile() {
 
 function PerpBadgesRow() {
   const intl = useIntl();
+  const [tradingMode] = useTradingModeAtom();
+  const isSpot = tradingMode === 'spot';
   const [builderFeeRate, setBuilderFeeRate] = useState<number | undefined>();
   const [asset] = usePerpsActiveAssetAtom();
   const [tokenSearchAliases] = usePerpsTokenSearchAliasesAtom();
@@ -101,9 +104,11 @@ function PerpBadgesRow() {
     <XStack alignItems="center" gap="$1.5">
       <Badge radius="$1" bg="$bgSubdued" px="$1" py={0}>
         <SizableText color="$textSubdued" fontSize={10}>
-          {intl.formatMessage({
-            id: ETranslations.perp_label_perp,
-          })}
+          {isSpot
+            ? 'Spot'
+            : intl.formatMessage({
+                id: ETranslations.perp_label_perp,
+              })}
         </SizableText>
       </Badge>
       {subtitle ? (
@@ -141,7 +146,7 @@ function PerpBadgesRow() {
           }
         />
       ) : null}
-      {builderFeeRate === 0 ? (
+      {!isSpot && builderFeeRate === 0 ? (
         <Badge radius="$1" bg="$bgSuccess" px="$0.5" py={0}>
           <SizableText color="$textSuccess" fontSize={10}>
             {intl.formatMessage({
@@ -156,6 +161,8 @@ function PerpBadgesRow() {
 
 export function PerpTickerBarMobile() {
   const [perpsAccountStatus] = usePerpsActiveAccountStatusAtom();
+  const [tradingMode] = useTradingModeAtom();
+  const isSpot = tradingMode === 'spot';
 
   const content = (
     <XStack

--- a/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
@@ -32,6 +32,7 @@ import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/h
 import {
   usePerpsAllAssetCtxsAtom,
   usePerpsAllAssetsFilteredAtom,
+  usePerpsTokenSearchAliasesAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
 import {
   usePerpTokenSelectorConfigPersistAtom,
@@ -44,6 +45,7 @@ import {
   SPOT_MIN_VOLUME_STRICT,
   formatSpotPairDisplayName,
   getSpotTokenDisplayName,
+  getTokenSubtitle,
   isSpotInstrument,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type {
@@ -182,6 +184,7 @@ function MobileTokenSelectorModal({
 
   const [{ assetsByDex }] = usePerpsAllAssetsFilteredAtom();
   const [{ assetCtxsByDex }] = usePerpsAllAssetCtxsAtom();
+  const [tokenSearchAliases] = usePerpsTokenSearchAliasesAtom();
   const { favoriteItems, isReady: isFavoritesReady } = usePerpsFavorites();
   const [selectorConfig, setSelectorConfig] =
     usePerpTokenSelectorConfigPersistAtom();
@@ -340,13 +343,18 @@ function MobileTokenSelectorModal({
       },
     );
 
+    const mapEntry = (entry: (typeof combinedEntries)[0]): ITokenSelectorListItem => ({
+      dexIndex: entry.dexIndex,
+      index: entry.index,
+      assetId: entry.assetId,
+      tokenName: entry.asset.name,
+      tokenMaxLeverage: entry.asset.maxLeverage,
+      tokenSubtitle: getTokenSubtitle(entry.asset.name, tokenSearchAliases),
+    });
+
     const sortField = selectorConfig?.field ?? '';
     if (!sortField) {
-      return combinedEntries.map((entry) => ({
-        dexIndex: entry.dexIndex,
-        index: entry.index,
-        assetId: entry.assetId,
-      }));
+      return combinedEntries.map(mapEntry);
     }
     return combinedEntries
       .toSorted((a, b) =>
@@ -355,12 +363,8 @@ function MobileTokenSelectorModal({
           { asset: b.asset, sortValues: b.sortValues },
         ),
       )
-      .map((entry) => ({
-        dexIndex: entry.dexIndex,
-        index: entry.index,
-        assetId: entry.assetId,
-      }));
-  }, [assetsByDex, computeSortValues, sortCompare, selectorConfig?.field]);
+      .map(mapEntry);
+  }, [assetsByDex, computeSortValues, sortCompare, selectorConfig?.field, tokenSearchAliases]);
 
   // Layer 1b: spot sort — isolated from perp. Reruns only when spot data or
   // sort config changes. spotPriceMap WS updates never touch the perp list.
@@ -660,7 +664,6 @@ function MobileTokenSelectorModal({
         <YStack flex={1} mt="$2">
           {isListReady ? (
             <ListView
-              key={`${activeTab}-${selectorConfig?.field ?? ''}-${selectorConfig?.direction ?? ''}`}
               useFlashList
               ref={listRef}
               keyExtractor={keyExtractor}

--- a/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
@@ -5,6 +5,7 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useState,
 } from 'react';
 
 import { useIntl } from 'react-intl';
@@ -15,14 +16,17 @@ import {
   ListView,
   Page,
   SizableText,
+  Spinner,
   Stack,
   XStack,
   YStack,
+  usePageMounted,
 } from '@onekeyhq/components';
 import {
   ScrollableFilterBar,
   useScrollableFilterBar,
 } from '@onekeyhq/kit/src/components/ScrollableFilterBar';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
@@ -32,14 +36,22 @@ import {
 import {
   usePerpTokenSelectorConfigPersistAtom,
   usePerpTokenSelectorTabsAtom,
+  useSpotAssetCtxsMapAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import {
+  SPOT_MIN_VOLUME_STRICT,
+  formatSpotPairDisplayName,
+  getSpotTokenDisplayName,
+  isSpotInstrument,
+} from '@onekeyhq/shared/src/utils/perpsUtils';
 import type {
   IPerpTokenSelectorConfig,
   IPerpTokenSortField,
   IPerpsAssetCtx,
   IPerpsUniverse,
+  ISpotUniverse,
 } from '@onekeyhq/shared/types/hyperliquid';
 import {
   DEFAULT_PERP_TOKEN_ACTIVE_TAB,
@@ -60,7 +72,7 @@ import { PerpsProviderMirror } from '../../PerpsProviderMirror';
 import { FavoritesEmptyState } from './FavoritesEmptyState';
 import { PerpTokenSelectorRow } from './PerpTokenSelectorRow';
 
-import type { ITokenSelectorListItem } from './PerpTokenSelector';
+import { SPOT_DEX_INDEX, type ITokenSelectorListItem } from './PerpTokenSelector';
 import type { LayoutChangeEvent } from 'react-native';
 
 const TabItem = memo(
@@ -113,19 +125,59 @@ function MobileTokenSelectorModal({
   const actions = useHyperliquidActions();
   const { searchQuery, setSearchQuery } = usePerpTokenSelector();
 
+  // Spot data — try cache first, fallback to refresh if empty
+  const [spotPriceMap] = useSpotAssetCtxsMapAtom();
+  const [spotUniverses, setSpotUniverses] = useState<ISpotUniverse[]>([]);
+  const [spotLoading, setSpotLoading] = useState(true);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      let { universes } =
+        await backgroundApiProxy.serviceHyperliquid.getSpotMeta();
+      if (!universes?.length) {
+        await backgroundApiProxy.serviceHyperliquid.refreshSpotMeta();
+        const res =
+          await backgroundApiProxy.serviceHyperliquid.getSpotMeta();
+        universes = res.universes;
+      }
+      if (!cancelled) {
+        setSpotUniverses(universes ?? []);
+        setSpotLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const handleSelectToken = useCallback(
     async (symbol: string) => {
+      const isSpotToken = isSpotInstrument(symbol);
       try {
         onLoadingChange(true);
         navigation.popStack();
-        await actions.current.changeActiveAsset({ coin: symbol });
+        if (isSpotToken) {
+          const universe = spotUniverses.find((u) => u.name === symbol);
+          // universe may be undefined if spotMeta hasn't loaded yet;
+          // switchTradeInstrument has a built-in fallback that fetches spotMeta.
+          await actions.current.switchTradeInstrument({
+            mode: 'spot',
+            coin: symbol,
+            spotUniverse: universe,
+          });
+        } else {
+          await actions.current.switchTradeInstrument({
+            mode: 'perp',
+            coin: symbol,
+          });
+        }
       } catch (error) {
         console.error('Failed to switch token:', error);
       } finally {
         onLoadingChange(false);
       }
     },
-    [onLoadingChange, navigation, actions],
+    [onLoadingChange, navigation, actions, spotUniverses],
   );
 
   const [{ assetsByDex }] = usePerpsAllAssetsFilteredAtom();
@@ -138,22 +190,24 @@ function MobileTokenSelectorModal({
   const activeTab = selectorConfig?.activeTab ?? DEFAULT_PERP_TOKEN_ACTIVE_TAB;
   const listRef = useRef<IListViewRef<ITokenSelectorListItem> | null>(null);
 
-  // Freeze sort order; only refresh on sort/tab change or first data arrival.
+  // Mount FlashList only after the navigation transition animation completes.
+  // transitionEnd fires via navigation listener, so this is exact — no guesswork.
+  const [isListReady, setIsListReady] = useState(false);
+  usePageMounted(() => setIsListReady(true));
+
+  // Freeze sort order; only refresh on sort config change or first data arrival.
+  // Does NOT track activeTab — tab switches should not refresh the snapshot.
   const ctxSnapshotRef = useRef(assetCtxsByDex);
   const lastSortRef = useRef<{
     field?: string;
     direction?: string;
-    activeTab?: string;
   } | null>(null);
   useEffect(() => {
     const field = selectorConfig?.field;
     const direction = selectorConfig?.direction;
-    const currentTab = selectorConfig?.activeTab;
     const last = lastSortRef.current;
     const sortChanged =
-      last?.field !== field ||
-      last?.direction !== direction ||
-      last?.activeTab !== currentTab;
+      last?.field !== field || last?.direction !== direction;
     // Also refresh when snapshot is empty (first WS data arrival after mount)
     const snapshotEmpty = !ctxSnapshotRef.current?.some(
       (arr) => arr?.length > 0,
@@ -161,14 +215,9 @@ function MobileTokenSelectorModal({
     if (!sortChanged && !snapshotEmpty) {
       return;
     }
-    lastSortRef.current = { field, direction, activeTab: currentTab };
+    lastSortRef.current = { field, direction };
     ctxSnapshotRef.current = assetCtxsByDex;
-  }, [
-    selectorConfig?.direction,
-    selectorConfig?.field,
-    selectorConfig?.activeTab,
-    assetCtxsByDex,
-  ]);
+  }, [selectorConfig?.direction, selectorConfig?.field, assetCtxsByDex]);
 
   // Container-level mark instead of per-row
   useEffect(() => {
@@ -183,6 +232,7 @@ function MobileTokenSelectorModal({
     () => ({
       favorites: intl.formatMessage({ id: ETranslations.perp_tab_favs }),
       all: intl.formatMessage({ id: ETranslations.perps_token_selector_perps }),
+      spot: 'Spot',
     }),
     [intl],
   );
@@ -269,9 +319,10 @@ function MobileTokenSelectorModal({
     [selectorConfig?.direction, selectorConfig?.field],
   );
 
-  const mockedListData = useMemo(() => {
+  // Layer 1: sort — only reruns when sort config or underlying assets change.
+  // Does NOT depend on activeTab, so tab switches never retrigger the sort.
+  const perpSortedList = useMemo(() => {
     const assetsByDexTyped: IPerpsUniverse[][] = assetsByDex || [];
-    // Use frozen snapshot to prevent FlashList recycling issues from real-time WS updates
     const assetCtxsByDexTyped: IPerpsAssetCtx[][] =
       ctxSnapshotRef.current || [];
 
@@ -284,72 +335,144 @@ function MobileTokenSelectorModal({
               ? asset.assetId - XYZ_ASSET_ID_OFFSET
               : asset.assetId;
           const sortValues = computeSortValues(ctxs?.[normalizedAssetId]);
-          return {
-            dexIndex,
-            index,
-            assetId: asset.assetId,
-            asset,
-            sortValues,
-          };
+          return { dexIndex, index, assetId: asset.assetId, asset, sortValues };
         });
       },
     );
 
     const sortField = selectorConfig?.field ?? '';
-    let result: { dexIndex: number; index: number; assetId: number }[];
     if (!sortField) {
-      result = combinedEntries.map((entry) => ({
+      return combinedEntries.map((entry) => ({
         dexIndex: entry.dexIndex,
         index: entry.index,
         assetId: entry.assetId,
       }));
-    } else {
-      const sorted = combinedEntries.toSorted((a, b) =>
+    }
+    return combinedEntries
+      .toSorted((a, b) =>
         sortCompare(
           { asset: a.asset, sortValues: a.sortValues },
           { asset: b.asset, sortValues: b.sortValues },
         ),
-      );
-      result = sorted.map((entry) => ({
+      )
+      .map((entry) => ({
         dexIndex: entry.dexIndex,
         index: entry.index,
         assetId: entry.assetId,
       }));
+  }, [assetsByDex, computeSortValues, sortCompare, selectorConfig?.field]);
+
+  // Layer 1b: spot sort — isolated from perp. Reruns only when spot data or
+  // sort config changes. spotPriceMap WS updates never touch the perp list.
+  const spotSortedList = useMemo((): ITokenSelectorListItem[] => {
+    const sortField = selectorConfig?.field ?? '';
+    const sortDirection = selectorConfig?.direction ?? 'desc';
+
+    const entries = spotUniverses
+      .map((u, index) => {
+        const ctx = spotPriceMap[u.name];
+        const markPrice = Number(ctx?.markPx || 0);
+        const prevDayPx = Number(ctx?.prevDayPx || 0);
+        const change24hPercent =
+          prevDayPx > 0 ? ((markPrice - prevDayPx) / prevDayPx) * 100 : 0;
+        const volume24h = Number(ctx?.dayNtlVlm || 0);
+        const circulatingSupply = Number(ctx?.circulatingSupply || 0);
+        const marketCap = circulatingSupply * markPrice;
+        return {
+          item: {
+            dexIndex: SPOT_DEX_INDEX,
+            index,
+            assetId: u.assetId,
+            spotUniverse: u,
+          } as ITokenSelectorListItem,
+          name: u.baseName,
+          markPrice,
+          change24hPercent,
+          volume24h,
+          marketCap,
+        };
+      })
+      .filter((e) => e.volume24h >= SPOT_MIN_VOLUME_STRICT);
+
+    if (sortField) {
+      entries.sort((a, b) => {
+        let cmp = 0;
+        switch (sortField) {
+          case 'name':
+            cmp = a.name.localeCompare(b.name, undefined, {
+              sensitivity: 'base',
+            });
+            break;
+          case 'markPrice':
+            cmp = a.markPrice - b.markPrice;
+            break;
+          case 'change24hPercent':
+            cmp = a.change24hPercent - b.change24hPercent;
+            break;
+          case 'volume24h':
+            cmp = a.volume24h - b.volume24h;
+            break;
+          case 'openInterest':
+            cmp = a.marketCap - b.marketCap;
+            break;
+          default:
+            break;
+        }
+        return sortDirection === 'asc' ? cmp : -cmp;
+      });
+    }
+
+    return entries.map((e) => e.item);
+  }, [spotUniverses, spotPriceMap, selectorConfig?.field, selectorConfig?.direction]);
+
+  // Layer 2: filter — cheap O(n) filter; never runs sort.
+  // Tab switches and favorites changes only reach here, not the sort layer.
+  const mockedListData = useMemo(() => {
+    if (activeTab === 'spot') {
+      if (!searchQuery) return spotSortedList;
+      const q = searchQuery.toLowerCase();
+      return spotSortedList.filter((item) => {
+        const u = item.spotUniverse;
+        if (!u) return false;
+        const displayBase = getSpotTokenDisplayName(u.baseName);
+        const pairDisplay = formatSpotPairDisplayName(u.baseName, u.quoteName);
+        return (
+          u.baseName.toLowerCase().includes(q) ||
+          displayBase.toLowerCase().includes(q) ||
+          pairDisplay.toLowerCase().includes(q)
+        );
+      });
     }
 
     if (activeTab === 'favorites') {
       const favoriteAssetIds = new Set(
         favoriteItems.map((f: IFavoriteItem) => `${f.dexIndex}-${f.assetId}`),
       );
-      return result.filter((item) =>
+      return perpSortedList.filter((item) =>
         favoriteAssetIds.has(`${item.dexIndex}-${item.assetId}`),
       );
     }
 
-    // Check if activeTab is a dynamic tab
     const dynamicTab = dynamicTabs.find((t) => t.tabId === activeTab);
     if (dynamicTab) {
       const tokenSet = new Set(dynamicTab.tokens);
-      const matchingIds = new Set(
-        combinedEntries
-          .filter((entry) => tokenSet.has(entry.asset.name))
-          .map((entry) => `${entry.dexIndex}-${entry.assetId}`),
+      const matchingIds = new Set<string>();
+      (assetsByDex as IPerpsUniverse[][] || []).forEach(
+        (assets, dexIndex) => {
+          assets?.forEach((asset) => {
+            if (tokenSet.has(asset.name)) {
+              matchingIds.add(`${dexIndex}-${asset.assetId}`);
+            }
+          });
+        },
       );
-      return result.filter((item) =>
+      return perpSortedList.filter((item) =>
         matchingIds.has(`${item.dexIndex}-${item.assetId}`),
       );
     }
 
-    return result;
-  }, [
-    activeTab,
-    assetsByDex,
-    computeSortValues,
-    dynamicTabs,
-    favoriteItems,
-    sortCompare,
-    selectorConfig?.field,
-  ]);
+    return perpSortedList;
+  }, [activeTab, assetsByDex, dynamicTabs, favoriteItems, perpSortedList, spotSortedList, searchQuery]);
 
   // Show all server-configured dynamic tabs regardless of search results.
   // Filtering by search-filtered assetsByDex would hide tabs during search.
@@ -423,7 +546,7 @@ function MobileTokenSelectorModal({
   return (
     <Page>
       <Page.Header
-        title={intl.formatMessage({ id: ETranslations.perps_search_perps })}
+        title={intl.formatMessage({ id: ETranslations.global_search_asset })}
         headerSearchBarOptions={{
           placeholder: intl.formatMessage({
             id: ETranslations.global_search,
@@ -446,7 +569,7 @@ function MobileTokenSelectorModal({
           itemPr="$3"
           contentContainerStyle={{ px: '$4', pb: '$2.5' }}
         >
-          {(['favorites', 'all'] as const).map((tabKey) => (
+          {(['favorites', 'all', 'spot'] as const).map((tabKey) => (
             <TabItem
               key={tabKey}
               id={tabKey}
@@ -535,40 +658,46 @@ function MobileTokenSelectorModal({
       </XStack>
       <Page.Body>
         <YStack flex={1} mt="$2">
-          <ListView
-            key={`${activeTab}-${selectorConfig?.field ?? ''}-${selectorConfig?.direction ?? ''}`}
-            useFlashList
-            ref={listRef}
-            keyExtractor={keyExtractor}
-            estimatedItemSize={44}
-            windowSize={3}
-            initialNumToRender={15}
-            decelerationRate="normal"
-            showsVerticalScrollIndicator
-            nestedScrollEnabled={platformEnv.isNativeAndroid}
-            contentContainerStyle={{
-              paddingBottom: 10,
-            }}
-            data={mockedListData}
-            renderItem={renderItem}
-            ListEmptyComponent={
-              activeTab === 'favorites' && !searchQuery && isFavoritesReady ? (
-                <FavoritesEmptyState isMobile />
-              ) : (
-                <XStack p="$5" justifyContent="center">
-                  <SizableText size="$bodySm" color="$textSubdued">
-                    {searchQuery
-                      ? intl.formatMessage({
-                          id: ETranslations.perp_token_selector_empty,
-                        })
-                      : intl.formatMessage({
-                          id: ETranslations.dexmarket_details_nodata,
-                        })}
-                  </SizableText>
-                </XStack>
-              )
-            }
-          />
+          {isListReady ? (
+            <ListView
+              key={`${activeTab}-${selectorConfig?.field ?? ''}-${selectorConfig?.direction ?? ''}`}
+              useFlashList
+              ref={listRef}
+              keyExtractor={keyExtractor}
+              estimatedItemSize={44}
+              windowSize={3}
+              initialNumToRender={5}
+              decelerationRate="normal"
+              showsVerticalScrollIndicator
+              nestedScrollEnabled={platformEnv.isNativeAndroid}
+              contentContainerStyle={{
+                paddingBottom: 10,
+              }}
+              data={mockedListData}
+              renderItem={renderItem}
+              ListEmptyComponent={
+                activeTab === 'spot' && spotLoading ? (
+                  <YStack p="$5" alignItems="center">
+                    <Spinner size="small" />
+                  </YStack>
+                ) : activeTab === 'favorites' && !searchQuery && isFavoritesReady ? (
+                  <FavoritesEmptyState isMobile />
+                ) : (
+                  <XStack p="$5" justifyContent="center">
+                    <SizableText size="$bodySm" color="$textSubdued">
+                      {searchQuery
+                        ? intl.formatMessage({
+                            id: ETranslations.perp_token_selector_empty,
+                          })
+                        : intl.formatMessage({
+                            id: ETranslations.dexmarket_details_nodata,
+                          })}
+                    </SizableText>
+                  </XStack>
+                )
+              }
+            />
+          ) : null}
         </YStack>
       </Page.Body>
     </Page>

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -35,6 +35,7 @@ import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/h
 import {
   usePerpsAllAssetCtxsAtom,
   usePerpsAllAssetsFilteredAtom,
+  usePerpsTokenSearchAliasesAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
 import type { IPerpDynamicTab } from '@onekeyhq/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp';
 import {
@@ -52,6 +53,7 @@ import {
   formatSpotPairDisplayName,
   getHyperliquidTokenImageUrl,
   getSpotTokenDisplayName,
+  getTokenSubtitle,
   isSpotInstrument,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type {
@@ -84,6 +86,10 @@ export type ITokenSelectorListItem = {
   dexIndex: number;
   index: number;
   assetId?: number;
+  // Perp-specific: pre-computed static token data so rows don't subscribe to universe atom
+  tokenName?: string;
+  tokenMaxLeverage?: number;
+  tokenSubtitle?: string;
   // Spot-specific: carries display name for rendering since spot uses @N identifiers
   spotUniverse?: ISpotUniverse;
 };
@@ -212,6 +218,7 @@ function BasePerpTokenSelectorContent({
 
   const [{ assetsByDex }] = usePerpsAllAssetsFilteredAtom();
   const [{ assetCtxsByDex }] = usePerpsAllAssetCtxsAtom();
+  const [tokenSearchAliases] = usePerpsTokenSearchAliasesAtom();
   const [selectorConfig, setSelectorConfig] =
     usePerpTokenSelectorConfigPersistAtom();
   const [dynamicTabsRaw] = usePerpTokenSelectorTabsAtom();
@@ -439,13 +446,18 @@ function BasePerpTokenSelectorContent({
       },
     );
 
+    const mapEntry = (entry: (typeof combinedEntries)[0]): ITokenSelectorListItem => ({
+      dexIndex: entry.dexIndex,
+      index: entry.index,
+      assetId: entry.assetId,
+      tokenName: entry.asset.name,
+      tokenMaxLeverage: entry.asset.maxLeverage,
+      tokenSubtitle: getTokenSubtitle(entry.asset.name, tokenSearchAliases),
+    });
+
     const sortField = selectorConfig?.field ?? '';
     if (!sortField) {
-      return combinedEntries.map((entry) => ({
-        dexIndex: entry.dexIndex,
-        index: entry.index,
-        assetId: entry.assetId,
-      }));
+      return combinedEntries.map(mapEntry);
     }
     return combinedEntries
       .toSorted((a, b) =>
@@ -454,12 +466,8 @@ function BasePerpTokenSelectorContent({
           { asset: b.asset, sortValues: b.sortValues },
         ),
       )
-      .map((entry) => ({
-        dexIndex: entry.dexIndex,
-        index: entry.index,
-        assetId: entry.assetId,
-      }));
-  }, [assetsByDex, computeSortValues, sortCompare, selectorConfig?.field]);
+      .map(mapEntry);
+  }, [assetsByDex, computeSortValues, sortCompare, selectorConfig?.field, tokenSearchAliases]);
 
   // Layer 1b: spot sort — isolated from perp. Reruns only when spot data or
   // sort config changes. spotPriceMap WS updates never touch the perp list.
@@ -706,7 +714,6 @@ function BasePerpTokenSelectorContent({
               <FavoritesEmptyState />
             ) : (
               <ListView
-                key={activeTab}
                 useFlashList
                 ref={listRef}
                 keyExtractor={keyExtractor}

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -40,20 +40,24 @@ import type { IPerpDynamicTab } from '@onekeyhq/kit-bg/src/services/ServiceWebvi
 import {
   usePerpTokenSelectorConfigPersistAtom,
   usePerpTokenSelectorTabsAtom,
-  usePerpsActiveAssetAtom,
   usePerpsActiveAssetCtxAtom,
+  useSpotAssetCtxsMapAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { useSpotActiveAssetCtxAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/spot';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
 import {
+  SPOT_MIN_VOLUME_STRICT,
+  formatSpotPairDisplayName,
   getHyperliquidTokenImageUrl,
+  getSpotTokenDisplayName,
   isSpotInstrument,
-  parseDexCoin,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type {
   IPerpsAssetCtx,
   IPerpsUniverse,
+  ISpotUniverse,
 } from '@onekeyhq/shared/types/hyperliquid';
 import {
   DEFAULT_PERP_TOKEN_ACTIVE_TAB,
@@ -68,15 +72,20 @@ import {
   usePerpTokenSelector,
   usePerpsFavorites,
 } from '../../hooks';
+import { useActiveTradeDisplay } from '../../hooks/useActiveTradeDisplay';
 
 import { FavoritesEmptyState } from './FavoritesEmptyState';
 import { PerpTokenSelectorRow } from './PerpTokenSelectorRow';
 import { SortableHeaderCell } from './SortableHeaderCell';
 
+export const SPOT_DEX_INDEX = -1;
+
 export type ITokenSelectorListItem = {
   dexIndex: number;
   index: number;
   assetId?: number;
+  // Spot-specific: carries display name for rendering since spot uses @N identifiers
+  spotUniverse?: ISpotUniverse;
 };
 
 const TabItem = memo(
@@ -114,7 +123,7 @@ const TabItem = memo(
 );
 TabItem.displayName = 'TabItem';
 
-function TokenListHeader() {
+function TokenListHeader({ isSpot }: { isSpot?: boolean }) {
   const intl = useIntl();
   return (
     <XStack
@@ -144,27 +153,47 @@ function TokenListHeader() {
         })}
         width={150}
       />
-      <SortableHeaderCell
-        field="fundingRate"
-        label={intl.formatMessage({
-          id: ETranslations.perp_position_funding,
-        })}
-        width={110}
-      />
-      <SortableHeaderCell
-        field="volume24h"
-        label={intl.formatMessage({
-          id: ETranslations.perp_token_selector_volume,
-        })}
-        width={110}
-      />
-      <SortableHeaderCell
-        field="openInterest"
-        label={intl.formatMessage({
-          id: ETranslations.perp_token_bar_open_Interest,
-        })}
-        width={120}
-      />
+      {isSpot ? null : (
+        <>
+          <SortableHeaderCell
+            field="fundingRate"
+            label={intl.formatMessage({
+              id: ETranslations.perp_position_funding,
+            })}
+            width={110}
+          />
+          <SortableHeaderCell
+            field="volume24h"
+            label={intl.formatMessage({
+              id: ETranslations.perp_token_selector_volume,
+            })}
+            width={110}
+          />
+          <SortableHeaderCell
+            field="openInterest"
+            label={intl.formatMessage({
+              id: ETranslations.perp_token_bar_open_Interest,
+            })}
+            width={120}
+          />
+        </>
+      )}
+      {isSpot ? (
+        <>
+          <SortableHeaderCell
+            field="volume24h"
+            label={intl.formatMessage({
+              id: ETranslations.perp_token_selector_volume,
+            })}
+            width={130}
+          />
+          <SortableHeaderCell
+            field="openInterest"
+            label="Market Cap"
+            width={200}
+          />
+        </>
+      ) : null}
     </XStack>
   );
 }
@@ -195,9 +224,21 @@ function BasePerpTokenSelectorContent({
     () => ({
       favorites: intl.formatMessage({ id: ETranslations.perp_tab_favs }),
       all: intl.formatMessage({ id: ETranslations.perps_token_selector_perps }),
+      spot: 'Spot',
     }),
     [intl],
   );
+
+  // Spot data
+  const [spotPriceMap] = useSpotAssetCtxsMapAtom();
+  const [spotUniverses, setSpotUniverses] = useState<ISpotUniverse[]>([]);
+  useEffect(() => {
+    void backgroundApiProxy.serviceHyperliquid
+      .getSpotMeta()
+      .then(({ universes }) => {
+        setSpotUniverses(universes);
+      });
+  }, []);
   const activeTab = selectorConfig?.activeTab ?? DEFAULT_PERP_TOKEN_ACTIVE_TAB;
   const listRef = useRef<IListViewRef<ITokenSelectorListItem> | null>(null);
 
@@ -214,8 +255,11 @@ function BasePerpTokenSelectorContent({
             }) as any,
         );
       });
+      actions.current.setTradeRouteViewState({
+        tokenSelectorTab: tab,
+      });
     },
-    [setSelectorConfig],
+    [actions, setSelectorConfig],
   );
 
   const handleSelectToken = useCallback(
@@ -223,18 +267,30 @@ function BasePerpTokenSelectorContent({
       const isSpotToken = isSpotInstrument(symbol);
       try {
         onLoadingChange(true);
+        if (isSpotToken) {
+          const universe = spotUniverses.find((u) => u.name === symbol);
+          if (!universe) {
+            return;
+          }
+          await actions.current.switchTradeInstrument({
+            mode: 'spot',
+            coin: symbol,
+            spotUniverse: universe,
+          });
+        } else {
+          await actions.current.switchTradeInstrument({
+            mode: 'perp',
+            coin: symbol,
+          });
+        }
         void closePopover?.();
-        await actions.current.switchTradeInstrument({
-          mode: isSpotToken ? 'spot' : 'perp',
-          coin: symbol,
-        });
       } catch (error) {
         console.error('Failed to switch token:', error);
       } finally {
         onLoadingChange(false);
       }
     },
-    [closePopover, actions, onLoadingChange],
+    [closePopover, actions, onLoadingChange, spotUniverses],
   );
 
   const { favoriteItems, isReady: isFavoritesReady } = usePerpsFavorites();
@@ -271,6 +327,12 @@ function BasePerpTokenSelectorContent({
       actions.current.markAllAssetCtxsNotRequired();
     };
   }, [actions]);
+
+  useEffect(() => {
+    actions.current.setTradeRouteViewState({
+      tokenSelectorTab: activeTab,
+    });
+  }, [actions, activeTab]);
 
   const computeSortValues = useCallback(
     (assetCtx: IPerpsAssetCtx | undefined) => {
@@ -343,6 +405,89 @@ function BasePerpTokenSelectorContent({
   );
 
   const activeTabData = useMemo(() => {
+    // Spot tab: render from spot universe data
+    if (activeTab === 'spot') {
+      let filtered = spotUniverses;
+      const sortField = selectorConfig?.field ?? '';
+      const sortDirection = selectorConfig?.direction ?? 'desc';
+
+      // Apply search filter — match raw name, display name, and formatted display name
+      if (searchQuery) {
+        const q = searchQuery.toLowerCase();
+        filtered = filtered.filter((u) => {
+          const displayBase = getSpotTokenDisplayName(u.baseName);
+          const pairDisplay = formatSpotPairDisplayName(
+            u.baseName,
+            u.quoteName,
+          );
+          return (
+            u.baseName.toLowerCase().includes(q) ||
+            displayBase.toLowerCase().includes(q) ||
+            pairDisplay.toLowerCase().includes(q)
+          );
+        });
+      }
+
+      const entries = filtered
+        .map((u, index) => {
+          // Use pair name (@107 or PURR/USDC) as key
+          const ctx = spotPriceMap[u.name];
+          const markPrice = Number(ctx?.markPx || 0);
+          const prevDayPx = Number(ctx?.prevDayPx || 0);
+          const change24hPercent =
+            prevDayPx > 0 ? ((markPrice - prevDayPx) / prevDayPx) * 100 : 0;
+          const volume24h = Number(ctx?.dayNtlVlm || 0);
+          const circulatingSupply = Number(ctx?.circulatingSupply || 0);
+          const marketCap = circulatingSupply * markPrice;
+          return {
+            item: {
+              dexIndex: SPOT_DEX_INDEX,
+              index,
+              assetId: u.assetId,
+              spotUniverse: u,
+            } as ITokenSelectorListItem,
+            name: u.baseName,
+            markPrice,
+            change24hPercent,
+            volume24h,
+            marketCap,
+          };
+        })
+        .filter((e) => e.volume24h >= SPOT_MIN_VOLUME_STRICT);
+
+      if (sortField) {
+        entries.sort((a, b) => {
+          let cmp = 0;
+          switch (sortField) {
+            case 'name':
+              cmp = a.name.localeCompare(b.name, undefined, {
+                sensitivity: 'base',
+              });
+              break;
+            case 'markPrice':
+              cmp = a.markPrice - b.markPrice;
+              break;
+            case 'change24hPercent':
+              cmp = a.change24hPercent - b.change24hPercent;
+              break;
+            case 'volume24h':
+              cmp = a.volume24h - b.volume24h;
+              break;
+            case 'openInterest':
+              // Reuse openInterest field for marketCap sort in spot tab
+              cmp = a.marketCap - b.marketCap;
+              break;
+            default:
+              break;
+          }
+          return sortDirection === 'asc' ? cmp : -cmp;
+        });
+      }
+
+      return entries.map((e) => e.item);
+    }
+
+    // Perps tabs: existing logic
     const assetsByDexTyped: IPerpsUniverse[][] = assetsByDex || [];
     const assetCtxsByDexTyped: IPerpsAssetCtx[][] =
       ctxSnapshotRef.current || [];
@@ -419,7 +564,11 @@ function BasePerpTokenSelectorContent({
     favoriteItems,
     sortCompare,
     selectorConfig?.field,
+    selectorConfig?.direction,
     activeTab,
+    spotPriceMap,
+    searchQuery,
+    spotUniverses,
   ]);
 
   // Always show all dynamic tabs — filtering them by search would hide tabs mid-search.
@@ -515,6 +664,12 @@ function BasePerpTokenSelectorContent({
             isFocused={activeTab === 'all'}
             onPress={setActiveTab}
           />
+          <TabItem
+            id="spot"
+            name={tabNames.spot}
+            isFocused={activeTab === 'spot'}
+            onPress={setActiveTab}
+          />
           {visibleDynamicTabs.map((tab: IPerpDynamicTab) => (
             <TabItem
               key={tab.tabId}
@@ -526,7 +681,9 @@ function BasePerpTokenSelectorContent({
           ))}
         </XStack>
         <YStack>
-          {!showFavoritesEmpty ? <TokenListHeader /> : null}
+          {!showFavoritesEmpty ? (
+            <TokenListHeader isSpot={activeTab === 'spot'} />
+          ) : null}
           <YStack height={350}>
             {showFavoritesEmpty ? (
               <FavoritesEmptyState />
@@ -575,10 +732,9 @@ const PerpTokenSelectorContentMemo = memo(PerpTokenSelectorContent);
 
 function BasePerpTokenSelector() {
   const intl = useIntl();
+  const actions = useHyperliquidActions();
   const [isOpen, setIsOpen] = useState(false);
-  const [currentToken] = usePerpsActiveAssetAtom();
-  const { coin } = currentToken;
-  const parsedActive = useMemo(() => parseDexCoin(coin), [coin]);
+  const { displayName, baseName, mode } = useActiveTradeDisplay();
   const [isLoading, setIsLoading] = useState(false);
   const [builderFeeRate, setBuilderFeeRate] = useState<number | undefined>();
 
@@ -589,6 +745,11 @@ function BasePerpTokenSelector() {
         setBuilderFeeRate(fee);
       });
   }, []);
+  useEffect(() => {
+    actions.current.setTradeRouteViewState({
+      tokenSelectorOpen: isOpen,
+    });
+  }, [actions, isOpen]);
   const content = useMemo(
     () => (
       <Popover
@@ -597,7 +758,9 @@ function BasePerpTokenSelector() {
           width: 800,
         }}
         open={isOpen}
-        onOpenChange={setIsOpen}
+        onOpenChange={(open) => {
+          setIsOpen(open);
+        }}
         placement="bottom-start"
         renderTrigger={
           <Badge
@@ -617,15 +780,13 @@ function BasePerpTokenSelector() {
             <Token
               size="md"
               borderRadius="$full"
-              tokenImageUri={getHyperliquidTokenImageUrl(
-                parsedActive.displayName,
-              )}
+              tokenImageUri={getHyperliquidTokenImageUrl(baseName)}
               fallbackIcon="CryptoCoinOutline"
             />
 
             {/* Token Name */}
             <SizableText size="$heading2xl">
-              {parsedActive.displayName}USDC
+              {mode === 'spot' ? displayName : `${displayName}USDC`}
             </SizableText>
             {builderFeeRate === 0 ? (
               <Tooltip
@@ -658,7 +819,7 @@ function BasePerpTokenSelector() {
         )}
       />
     ),
-    [isOpen, isLoading, parsedActive.displayName, builderFeeRate, intl],
+    [isOpen, isLoading, displayName, baseName, mode, builderFeeRate, intl],
   );
   return (
     <DebugRenderTracker name="PerpTokenSelector">{content}</DebugRenderTracker>
@@ -670,54 +831,55 @@ export const PerpTokenSelector = memo(BasePerpTokenSelector);
 const BasePerpTokenSelectorMobileView = memo(
   ({
     onPressTokenSelector,
-    coin,
+    displayLabel,
     change24hPercent,
   }: {
     onPressTokenSelector: () => void;
-    coin: string;
+    displayLabel: string;
     change24hPercent: number;
-  }) => {
-    const parsedCoin = useMemo(() => parseDexCoin(coin), [coin]);
-    const displayCoin = parsedCoin.displayName || coin;
-
-    return (
-      <DebugRenderTracker name="BasePerpTokenSelectorMobileView">
-        <XStack
-          gap="$1"
-          bg="$bgApp"
-          justifyContent="center"
-          alignItems="center"
-          onPress={onPressTokenSelector}
-          hitSlop={NATIVE_HIT_SLOP}
+  }) => (
+    <DebugRenderTracker name="BasePerpTokenSelectorMobileView">
+      <XStack
+        gap="$1"
+        bg="$bgApp"
+        justifyContent="center"
+        alignItems="center"
+        onPress={onPressTokenSelector}
+        hitSlop={NATIVE_HIT_SLOP}
+      >
+        <SizableText size="$headingLg">{displayLabel}</SizableText>
+        <NumberSizeableText
+          style={{ fontSize: 10 }}
+          fontFamily="$monoRegular"
+          fontVariant={['tabular-nums']}
+          alignSelf="center"
+          color={change24hPercent >= 0 ? '$green11' : '$red11'}
+          formatter="priceChange"
+          formatterOptions={{
+            showPlusMinusSigns: true,
+          }}
         >
-          <SizableText size="$headingLg">{displayCoin}USDC</SizableText>
-          <NumberSizeableText
-            style={{ fontSize: 10 }}
-            fontFamily="$monoRegular"
-            fontVariant={['tabular-nums']}
-            alignSelf="center"
-            color={change24hPercent >= 0 ? '$green11' : '$red11'}
-            formatter="priceChange"
-            formatterOptions={{
-              showPlusMinusSigns: true,
-            }}
-          >
-            {change24hPercent}
-          </NumberSizeableText>
-          <Icon name="ChevronTriangleDownSmallSolid" size="$5" />
-        </XStack>
-      </DebugRenderTracker>
-    );
-  },
+          {change24hPercent}
+        </NumberSizeableText>
+        <Icon name="ChevronTriangleDownSmallSolid" size="$5" />
+      </XStack>
+    </DebugRenderTracker>
+  ),
 );
 BasePerpTokenSelectorMobileView.displayName = 'BasePerpTokenSelectorMobileView';
 function BasePerpTokenSelectorMobile() {
   const navigation = useAppNavigation();
+  const { displayName, mode } = useActiveTradeDisplay();
 
-  const [asset] = usePerpsActiveAssetAtom();
   const [assetCtx] = usePerpsActiveAssetCtxAtom();
-  const coin = asset?.coin || '';
-  const change24hPercent = assetCtx?.ctx?.change24hPercent || 0;
+  const [spotAssetCtx] = useSpotActiveAssetCtxAtom();
+  const change24hPercent =
+    mode === 'spot'
+      ? spotAssetCtx?.ctx?.change24hPercent || 0
+      : assetCtx?.ctx?.change24hPercent || 0;
+
+  const displayLabel = mode === 'spot' ? displayName : `${displayName}USDC`;
+
   const onPressTokenSelector = useCallback(() => {
     navigation.pushModal(EModalRoutes.PerpModal, {
       screen: EModalPerpRoutes.MobileTokenSelector,
@@ -727,7 +889,7 @@ function BasePerpTokenSelectorMobile() {
   return (
     <BasePerpTokenSelectorMobileView
       onPressTokenSelector={onPressTokenSelector}
-      coin={coin}
+      displayLabel={displayLabel}
       change24hPercent={change24hPercent}
     />
   );

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -48,6 +48,7 @@ import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
 import {
   getHyperliquidTokenImageUrl,
+  isSpotInstrument,
   parseDexCoin,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type {
@@ -219,10 +220,12 @@ function BasePerpTokenSelectorContent({
 
   const handleSelectToken = useCallback(
     async (symbol: string) => {
+      const isSpotToken = isSpotInstrument(symbol);
       try {
         onLoadingChange(true);
         void closePopover?.();
-        await actions.current.changeActiveAsset({
+        await actions.current.switchTradeInstrument({
+          mode: isSpotToken ? 'spot' : 'perp',
           coin: symbol,
         });
       } catch (error) {

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -229,15 +229,29 @@ function BasePerpTokenSelectorContent({
     [intl],
   );
 
-  // Spot data
+  // Spot data — try cache first, fallback to refresh if empty
   const [spotPriceMap] = useSpotAssetCtxsMapAtom();
   const [spotUniverses, setSpotUniverses] = useState<ISpotUniverse[]>([]);
+  const [spotLoading, setSpotLoading] = useState(true);
   useEffect(() => {
-    void backgroundApiProxy.serviceHyperliquid
-      .getSpotMeta()
-      .then(({ universes }) => {
-        setSpotUniverses(universes);
-      });
+    let cancelled = false;
+    void (async () => {
+      let { universes } =
+        await backgroundApiProxy.serviceHyperliquid.getSpotMeta();
+      if (!universes?.length) {
+        await backgroundApiProxy.serviceHyperliquid.refreshSpotMeta();
+        const res =
+          await backgroundApiProxy.serviceHyperliquid.getSpotMeta();
+        universes = res.universes;
+      }
+      if (!cancelled) {
+        setSpotUniverses(universes ?? []);
+        setSpotLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
   const activeTab = selectorConfig?.activeTab ?? DEFAULT_PERP_TOKEN_ACTIVE_TAB;
   const listRef = useRef<IListViewRef<ITokenSelectorListItem> | null>(null);
@@ -404,90 +418,9 @@ function BasePerpTokenSelectorContent({
     [selectorConfig?.direction, selectorConfig?.field],
   );
 
-  const activeTabData = useMemo(() => {
-    // Spot tab: render from spot universe data
-    if (activeTab === 'spot') {
-      let filtered = spotUniverses;
-      const sortField = selectorConfig?.field ?? '';
-      const sortDirection = selectorConfig?.direction ?? 'desc';
-
-      // Apply search filter — match raw name, display name, and formatted display name
-      if (searchQuery) {
-        const q = searchQuery.toLowerCase();
-        filtered = filtered.filter((u) => {
-          const displayBase = getSpotTokenDisplayName(u.baseName);
-          const pairDisplay = formatSpotPairDisplayName(
-            u.baseName,
-            u.quoteName,
-          );
-          return (
-            u.baseName.toLowerCase().includes(q) ||
-            displayBase.toLowerCase().includes(q) ||
-            pairDisplay.toLowerCase().includes(q)
-          );
-        });
-      }
-
-      const entries = filtered
-        .map((u, index) => {
-          // Use pair name (@107 or PURR/USDC) as key
-          const ctx = spotPriceMap[u.name];
-          const markPrice = Number(ctx?.markPx || 0);
-          const prevDayPx = Number(ctx?.prevDayPx || 0);
-          const change24hPercent =
-            prevDayPx > 0 ? ((markPrice - prevDayPx) / prevDayPx) * 100 : 0;
-          const volume24h = Number(ctx?.dayNtlVlm || 0);
-          const circulatingSupply = Number(ctx?.circulatingSupply || 0);
-          const marketCap = circulatingSupply * markPrice;
-          return {
-            item: {
-              dexIndex: SPOT_DEX_INDEX,
-              index,
-              assetId: u.assetId,
-              spotUniverse: u,
-            } as ITokenSelectorListItem,
-            name: u.baseName,
-            markPrice,
-            change24hPercent,
-            volume24h,
-            marketCap,
-          };
-        })
-        .filter((e) => e.volume24h >= SPOT_MIN_VOLUME_STRICT);
-
-      if (sortField) {
-        entries.sort((a, b) => {
-          let cmp = 0;
-          switch (sortField) {
-            case 'name':
-              cmp = a.name.localeCompare(b.name, undefined, {
-                sensitivity: 'base',
-              });
-              break;
-            case 'markPrice':
-              cmp = a.markPrice - b.markPrice;
-              break;
-            case 'change24hPercent':
-              cmp = a.change24hPercent - b.change24hPercent;
-              break;
-            case 'volume24h':
-              cmp = a.volume24h - b.volume24h;
-              break;
-            case 'openInterest':
-              // Reuse openInterest field for marketCap sort in spot tab
-              cmp = a.marketCap - b.marketCap;
-              break;
-            default:
-              break;
-          }
-          return sortDirection === 'asc' ? cmp : -cmp;
-        });
-      }
-
-      return entries.map((e) => e.item);
-    }
-
-    // Perps tabs: existing logic
+  // Layer 1a: perp sort — only reruns when sort config or perp assets change.
+  // Never reruns on tab switch, spot WS updates, search, or favorites changes.
+  const perpSortedList = useMemo((): ITokenSelectorListItem[] => {
     const assetsByDexTyped: IPerpsUniverse[][] = assetsByDex || [];
     const assetCtxsByDexTyped: IPerpsAssetCtx[][] =
       ctxSnapshotRef.current || [];
@@ -501,44 +434,123 @@ function BasePerpTokenSelectorContent({
               ? asset.assetId - XYZ_ASSET_ID_OFFSET
               : asset.assetId;
           const sortValues = computeSortValues(ctxs?.[normalizedAssetId]);
-          return {
-            dexIndex,
-            index,
-            asset,
-            assetId: asset.assetId,
-            sortValues,
-          };
+          return { dexIndex, index, asset, assetId: asset.assetId, sortValues };
         });
       },
     );
 
     const sortField = selectorConfig?.field ?? '';
-    let result: ITokenSelectorListItem[];
     if (!sortField) {
-      result = combinedEntries.map((entry) => ({
+      return combinedEntries.map((entry) => ({
         dexIndex: entry.dexIndex,
         index: entry.index,
         assetId: entry.assetId,
       }));
-    } else {
-      const sorted = combinedEntries.toSorted((a, b) =>
+    }
+    return combinedEntries
+      .toSorted((a, b) =>
         sortCompare(
           { asset: a.asset, sortValues: a.sortValues },
           { asset: b.asset, sortValues: b.sortValues },
         ),
-      );
-      result = sorted.map((entry) => ({
+      )
+      .map((entry) => ({
         dexIndex: entry.dexIndex,
         index: entry.index,
         assetId: entry.assetId,
       }));
+  }, [assetsByDex, computeSortValues, sortCompare, selectorConfig?.field]);
+
+  // Layer 1b: spot sort — isolated from perp. Reruns only when spot data or
+  // sort config changes. spotPriceMap WS updates never touch the perp list.
+  const spotSortedList = useMemo((): ITokenSelectorListItem[] => {
+    const sortField = selectorConfig?.field ?? '';
+    const sortDirection = selectorConfig?.direction ?? 'desc';
+
+    const entries = spotUniverses
+      .map((u, index) => {
+        const ctx = spotPriceMap[u.name];
+        const markPrice = Number(ctx?.markPx || 0);
+        const prevDayPx = Number(ctx?.prevDayPx || 0);
+        const change24hPercent =
+          prevDayPx > 0 ? ((markPrice - prevDayPx) / prevDayPx) * 100 : 0;
+        const volume24h = Number(ctx?.dayNtlVlm || 0);
+        const circulatingSupply = Number(ctx?.circulatingSupply || 0);
+        const marketCap = circulatingSupply * markPrice;
+        return {
+          item: {
+            dexIndex: SPOT_DEX_INDEX,
+            index,
+            assetId: u.assetId,
+            spotUniverse: u,
+          } as ITokenSelectorListItem,
+          name: u.baseName,
+          markPrice,
+          change24hPercent,
+          volume24h,
+          marketCap,
+        };
+      })
+      .filter((e) => e.volume24h >= SPOT_MIN_VOLUME_STRICT);
+
+    if (sortField) {
+      entries.sort((a, b) => {
+        let cmp = 0;
+        switch (sortField) {
+          case 'name':
+            cmp = a.name.localeCompare(b.name, undefined, {
+              sensitivity: 'base',
+            });
+            break;
+          case 'markPrice':
+            cmp = a.markPrice - b.markPrice;
+            break;
+          case 'change24hPercent':
+            cmp = a.change24hPercent - b.change24hPercent;
+            break;
+          case 'volume24h':
+            cmp = a.volume24h - b.volume24h;
+            break;
+          case 'openInterest':
+            // Reuse openInterest field for marketCap sort in spot tab
+            cmp = a.marketCap - b.marketCap;
+            break;
+          default:
+            break;
+        }
+        return sortDirection === 'asc' ? cmp : -cmp;
+      });
+    }
+
+    return entries.map((e) => e.item);
+  }, [spotUniverses, spotPriceMap, selectorConfig?.field, selectorConfig?.direction]);
+
+  // Layer 2: filter — cheap O(n); no sort computation.
+  // Tab switches, search, and favorites changes only reach here.
+  // perpSortedList reference is stable unless sort config changes, so ListView
+  // bails out of re-rendering rows when spot WS updates trigger a component render.
+  const activeTabData = useMemo(() => {
+    if (activeTab === 'spot') {
+      if (!searchQuery) return spotSortedList;
+      const q = searchQuery.toLowerCase();
+      return spotSortedList.filter((item) => {
+        const u = item.spotUniverse;
+        if (!u) return false;
+        const displayBase = getSpotTokenDisplayName(u.baseName);
+        const pairDisplay = formatSpotPairDisplayName(u.baseName, u.quoteName);
+        return (
+          u.baseName.toLowerCase().includes(q) ||
+          displayBase.toLowerCase().includes(q) ||
+          pairDisplay.toLowerCase().includes(q)
+        );
+      });
     }
 
     if (activeTab === 'favorites') {
       const favoriteAssetIds = new Set(
         favoriteItems.map((f: IFavoriteItem) => `${f.dexIndex}-${f.assetId}`),
       );
-      return result.filter((item) =>
+      return perpSortedList.filter((item) =>
         favoriteAssetIds.has(`${item.dexIndex}-${item.assetId}`),
       );
     }
@@ -546,29 +558,30 @@ function BasePerpTokenSelectorContent({
     const dynamicTab = dynamicTabs.find((t) => t.tabId === activeTab);
     if (dynamicTab) {
       const tokenSet = new Set(dynamicTab.tokens);
-      const matchingIds = new Set(
-        combinedEntries
-          .filter((entry) => tokenSet.has(entry.asset.name))
-          .map((entry) => `${entry.dexIndex}-${entry.assetId}`),
+      const matchingIds = new Set<string>();
+      (assetsByDex as IPerpsUniverse[][] || []).forEach(
+        (assets, dexIndex) => {
+          assets?.forEach((asset) => {
+            if (tokenSet.has(asset.name)) {
+              matchingIds.add(`${dexIndex}-${asset.assetId}`);
+            }
+          });
+        },
       );
-      return result.filter((item) =>
+      return perpSortedList.filter((item) =>
         matchingIds.has(`${item.dexIndex}-${item.assetId}`),
       );
     }
 
-    return result;
+    return perpSortedList;
   }, [
+    activeTab,
     assetsByDex,
-    computeSortValues,
     dynamicTabs,
     favoriteItems,
-    sortCompare,
-    selectorConfig?.field,
-    selectorConfig?.direction,
-    activeTab,
-    spotPriceMap,
+    perpSortedList,
+    spotSortedList,
     searchQuery,
-    spotUniverses,
   ]);
 
   // Always show all dynamic tabs — filtering them by search would hide tabs mid-search.
@@ -609,7 +622,11 @@ function BasePerpTokenSelectorContent({
 
   const listEmptyComponent = useMemo(
     () =>
-      showFavoritesEmpty ? (
+      activeTab === 'spot' && spotLoading ? (
+        <YStack p="$4" alignItems="center">
+          <Spinner size="small" />
+        </YStack>
+      ) : showFavoritesEmpty ? (
         <FavoritesEmptyState />
       ) : (
         <XStack p="$4" justifyContent="center">
@@ -624,7 +641,7 @@ function BasePerpTokenSelectorContent({
           </SizableText>
         </XStack>
       ),
-    [showFavoritesEmpty, searchQuery, intl],
+    [activeTab, spotLoading, showFavoritesEmpty, searchQuery, intl],
   );
 
   const content = (
@@ -695,7 +712,7 @@ function BasePerpTokenSelectorContent({
                 keyExtractor={keyExtractor}
                 estimatedItemSize={40}
                 windowSize={3}
-                initialNumToRender={10}
+                initialNumToRender={5}
                 data={activeTabData}
                 renderItem={renderItem}
                 ListEmptyComponent={listEmptyComponent}

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
@@ -25,19 +25,27 @@ import {
   usePerpsAllAssetsFilteredAtom,
   usePerpsTokenSearchAliasesAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
-import { usePerpTokenFavoritesPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import { useSpotTokenFavoritesPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/spot';
+import {
+  usePerpTokenFavoritesPersistAtom,
+  useSpotAssetCtxsMapAtom,
+  useSpotTokenFavoritesPersistAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import {
   NUMBER_FORMATTER,
   formatDisplayNumber,
 } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
+  formatSpotPairDisplayName,
   getHyperliquidTokenImageUrl,
+  getSpotTokenDisplayName,
   getTokenSubtitle,
   parseDexCoin,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
-import type { IPerpsUniverse } from '@onekeyhq/shared/types/hyperliquid';
+import type {
+  IPerpsUniverse,
+  ISpotUniverse,
+} from '@onekeyhq/shared/types/hyperliquid';
 
 import { usePerpsAssetCtx } from '../../hooks/usePerpsAssetCtx';
 
@@ -45,6 +53,7 @@ interface IPerpTokenSelectorRowProps {
   mockedToken: {
     index: number;
     dexIndex: number;
+    spotUniverse?: ISpotUniverse;
   };
   onPress: (name: string) => void;
   isOnModal?: boolean;
@@ -52,6 +61,7 @@ interface IPerpTokenSelectorRowProps {
 }
 
 interface ITokenSelectorRowContextValue {
+  isSpot?: boolean;
   token: {
     name: string;
     displayName: string;
@@ -65,11 +75,11 @@ interface ITokenSelectorRowContextValue {
     change24h: string;
     change24hPercent: number;
     fundingRate: string;
+    marketCap?: string;
     volume24h: string;
     openInterest: string;
   };
   isLoading: boolean;
-  isSpot?: boolean;
   onPress: () => void;
 }
 
@@ -119,28 +129,25 @@ export const FavoriteButton = memo(
       : perpFavs.favorites.includes(coin);
 
     const handleToggle = useCallback(() => {
+      const toggleFavorites = (prev: string[]) => {
+        const removing = prev.includes(coin);
+        return removing ? prev.filter((f) => f !== coin) : [...prev, coin];
+      };
       if (isSpot) {
-        setSpotFavs((prev) => {
-          const alreadyFavorite = prev.favorites.includes(coin);
-          return {
-            ...prev,
-            favorites: alreadyFavorite
-              ? prev.favorites.filter((f) => f !== coin)
-              : [...prev.favorites, coin],
-          };
-        });
+        setSpotFavs((prev) => ({
+          ...prev,
+          favorites: toggleFavorites(prev.favorites),
+        }));
       } else {
         setPerpFavs((prev) => {
-          const alreadyFavorite = prev.favorites.includes(coin);
+          const removing = prev.favorites.includes(coin);
           void backgroundApiProxy.serviceMarketV2.syncToMarketWatchList({
             coin,
-            action: alreadyFavorite ? 'remove' : 'add',
+            action: removing ? 'remove' : 'add',
           });
           return {
             ...prev,
-            favorites: alreadyFavorite
-              ? prev.favorites.filter((f) => f !== coin)
-              : [...prev.favorites, coin],
+            favorites: toggleFavorites(prev.favorites),
           };
         });
       }
@@ -236,7 +243,7 @@ const TokenInfoCellDesktop = memo(() => {
           alignItems="center"
           minWidth={0}
         >
-          <FavoriteButton coin={token.name} />
+          <FavoriteButton coin={token.name} isSpot={isSpot} />
           <XStack
             gap="$1.5"
             alignItems="center"
@@ -287,7 +294,14 @@ const TokenInfoCellDesktop = memo(() => {
         </XStack>
       </DebugRenderTracker>
     ),
-    [token.displayName, token.subtitle, token.maxLeverage, token.name, gtLg, isSpot],
+    [
+      token.displayName,
+      token.subtitle,
+      token.maxLeverage,
+      token.name,
+      gtLg,
+      isSpot,
+    ],
   );
   return content;
 });
@@ -422,6 +436,26 @@ const TokenVolumeCellDesktop = memo(() => {
 
 TokenVolumeCellDesktop.displayName = 'TokenVolumeCellDesktop';
 
+const TokenMarketCapCellDesktop = memo(() => {
+  const { assetCtx, isLoading } = useTokenSelectorRowContext();
+
+  const content = useMemo(
+    () => (
+      <XStack width={200} justifyContent="flex-start">
+        <SkeletonContainer isLoading={isLoading} width="80%" height={16}>
+          <SizableText size="$bodySm" color="$text">
+            {assetCtx.marketCap ?? '--'}
+          </SizableText>
+        </SkeletonContainer>
+      </XStack>
+    ),
+    [assetCtx.marketCap, isLoading],
+  );
+  return content;
+});
+
+TokenMarketCapCellDesktop.displayName = 'TokenMarketCapCellDesktop';
+
 const TokenOpenInterestCellDesktop = memo(() => {
   const { assetCtx, isLoading } = useTokenSelectorRowContext();
 
@@ -461,7 +495,7 @@ const TokenOpenInterestCellDesktop = memo(() => {
 TokenOpenInterestCellDesktop.displayName = 'TokenOpenInterestCellDesktop';
 
 const TokenSelectorRowDesktop = memo(() => {
-  const { onPress } = useTokenSelectorRowContext();
+  const { onPress, isSpot } = useTokenSelectorRowContext();
 
   const content = useMemo(
     () => (
@@ -483,13 +517,23 @@ const TokenSelectorRowDesktop = memo(() => {
           <TokenInfoCellDesktop />
           <TokenPriceCellDesktop />
           <Token24hChangeCellDesktop />
-          <TokenFundingCellDesktop />
-          <TokenVolumeCellDesktop />
-          <TokenOpenInterestCellDesktop />
+          {isSpot ? null : (
+            <>
+              <TokenFundingCellDesktop />
+              <TokenVolumeCellDesktop />
+              <TokenOpenInterestCellDesktop />
+            </>
+          )}
+          {isSpot ? (
+            <>
+              <TokenVolumeCellDesktop />
+              <TokenMarketCapCellDesktop />
+            </>
+          ) : null}
         </XStack>
       </DebugRenderTracker>
     ),
-    [onPress],
+    [onPress, isSpot],
   );
   return content;
 });
@@ -508,7 +552,7 @@ const TokenImageMobile = memo(() => {
         offsetY={10}
       >
         <XStack gap="$2" alignItems="center">
-          <FavoriteButton coin={token.name} isMobile />
+          <FavoriteButton coin={token.name} isMobile isSpot={isSpot} />
           <Token
             size="lg"
             borderRadius="$full"
@@ -528,7 +572,7 @@ const TokenImageMobile = memo(() => {
 TokenImageMobile.displayName = 'TokenImageMobile';
 
 const TokenNameMobile = memo(() => {
-  const { token } = useTokenSelectorRowContext();
+  const { token, isSpot } = useTokenSelectorRowContext();
 
   const content = useMemo(
     () => (
@@ -542,22 +586,24 @@ const TokenNameMobile = memo(() => {
             <SizableText size="$bodyMdMedium">{token.displayName}</SizableText>
 
             <XStack gap="$1">
-              <XStack
-                borderRadius="$1"
-                bg="$bgStrong"
-                justifyContent="center"
-                alignItems="center"
-                px="$1.5"
-              >
-                <SizableText
-                  fontSize={10}
-                  alignSelf="center"
-                  color="$textSubdued"
-                  lineHeight={16}
+              {!isSpot && token.maxLeverage > 0 ? (
+                <XStack
+                  borderRadius="$1"
+                  bg="$bgStrong"
+                  justifyContent="center"
+                  alignItems="center"
+                  px="$1.5"
                 >
-                  {token.maxLeverage}x
-                </SizableText>
-              </XStack>
+                  <SizableText
+                    fontSize={10}
+                    alignSelf="center"
+                    color="$textSubdued"
+                    lineHeight={16}
+                  >
+                    {token.maxLeverage}x
+                  </SizableText>
+                </XStack>
+              ) : null}
               {token.subtitle ? (
                 <SubtitleBadge
                   subtitle={token.subtitle}
@@ -569,7 +615,7 @@ const TokenNameMobile = memo(() => {
         </YStack>
       </DebugRenderTracker>
     ),
-    [token.displayName, token.subtitle, token.maxLeverage],
+    [token.displayName, token.subtitle, token.maxLeverage, isSpot],
   );
   return content;
 });
@@ -717,7 +763,79 @@ const TokenSelectorRowMobile = memo(() => {
 
 TokenSelectorRowMobile.displayName = 'TokenSelectorRowMobile';
 
-const PerpTokenSelectorRow = memo(
+const SpotTokenSelectorRowInner = memo(
+  ({
+    spotUniverse,
+    onPress,
+    isOnModal,
+  }: {
+    spotUniverse: ISpotUniverse;
+    onPress: (name: string) => void;
+    isOnModal?: boolean;
+  }) => {
+    const [spotPriceMap] = useSpotAssetCtxsMapAtom();
+    // Use pair name (@107 or PURR/USDC) as key — matches universe.name
+    const ctx = spotPriceMap[spotUniverse.name];
+    const markPx = ctx?.markPx || '0';
+    const prevDayPx = Number(ctx?.prevDayPx || 0);
+    const markPxNum = Number(markPx);
+    const change24hPercent =
+      prevDayPx > 0 ? ((markPxNum - prevDayPx) / prevDayPx) * 100 : 0;
+    const change24h = prevDayPx > 0 ? (markPxNum - prevDayPx).toFixed(6) : '0';
+
+    const handlePress = useMemo(
+      () => () => onPress(spotUniverse.name),
+      [onPress, spotUniverse.name],
+    );
+
+    const contextValue: ITokenSelectorRowContextValue = useMemo(
+      () => ({
+        isSpot: true,
+        token: {
+          name: getSpotTokenDisplayName(spotUniverse.baseName),
+          displayName: formatSpotPairDisplayName(
+            spotUniverse.baseName,
+            spotUniverse.quoteName,
+          ),
+          maxLeverage: 0,
+          assetId: spotUniverse.assetId,
+        },
+        assetCtx: {
+          markPrice: markPx,
+          change24h,
+          change24hPercent,
+          fundingRate: '0',
+          volume24h: ctx?.dayNtlVlm || '0',
+          openInterest: '0',
+          marketCap:
+            ctx?.circulatingSupply && markPxNum > 0
+              ? `${Math.round(Number(ctx.circulatingSupply) * markPxNum).toLocaleString('en-US')} ${spotUniverse.quoteName}`
+              : undefined,
+        },
+        isLoading: !ctx,
+        onPress: handlePress,
+      }),
+      [
+        spotUniverse,
+        markPx,
+        markPxNum,
+        change24h,
+        change24hPercent,
+        ctx,
+        handlePress,
+      ],
+    );
+
+    return (
+      <TokenSelectorRowProvider value={contextValue}>
+        {isOnModal ? <TokenSelectorRowMobile /> : <TokenSelectorRowDesktop />}
+      </TokenSelectorRowProvider>
+    );
+  },
+);
+SpotTokenSelectorRowInner.displayName = 'SpotTokenSelectorRowInner';
+
+const PerpTokenSelectorRowPerps = memo(
   ({
     mockedToken,
     onPress,
@@ -796,7 +914,37 @@ const PerpTokenSelectorRow = memo(
     );
   },
 );
+PerpTokenSelectorRowPerps.displayName = 'PerpTokenSelectorRowPerps';
 
+const PerpTokenSelectorRow = memo(
+  ({
+    mockedToken,
+    onPress,
+    isOnModal,
+    skipMarkRequired,
+  }: IPerpTokenSelectorRowProps) => {
+    // Spot path: render from spotUniverse data
+    if (mockedToken.spotUniverse) {
+      return (
+        <SpotTokenSelectorRowInner
+          spotUniverse={mockedToken.spotUniverse}
+          onPress={onPress}
+          isOnModal={isOnModal}
+        />
+      );
+    }
+
+    // Perps path: existing logic
+    return (
+      <PerpTokenSelectorRowPerps
+        mockedToken={mockedToken}
+        onPress={onPress}
+        isOnModal={isOnModal}
+        skipMarkRequired={skipMarkRequired}
+      />
+    );
+  },
+);
 PerpTokenSelectorRow.displayName = 'PerpTokenSelectorRow';
 
 export { PerpTokenSelectorRow };

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
@@ -26,6 +26,7 @@ import {
   usePerpsTokenSearchAliasesAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
 import { usePerpTokenFavoritesPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { useSpotTokenFavoritesPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/spot';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import {
   NUMBER_FORMATTER,
@@ -68,6 +69,7 @@ interface ITokenSelectorRowContextValue {
     openInterest: string;
   };
   isLoading: boolean;
+  isSpot?: boolean;
   onPress: () => void;
 }
 
@@ -103,29 +105,46 @@ export const FavoriteButton = memo(
     coin,
     isMobile,
     iconSize,
+    isSpot,
   }: {
     coin: string;
     isMobile?: boolean;
     iconSize?: string;
+    isSpot?: boolean;
   }) => {
-    const [favorites, setFavorites] = usePerpTokenFavoritesPersistAtom();
-    const isFavorite = favorites.favorites.includes(coin);
+    const [perpFavs, setPerpFavs] = usePerpTokenFavoritesPersistAtom();
+    const [spotFavs, setSpotFavs] = useSpotTokenFavoritesPersistAtom();
+    const isFavorite = isSpot
+      ? spotFavs.favorites.includes(coin)
+      : perpFavs.favorites.includes(coin);
 
     const handleToggle = useCallback(() => {
-      setFavorites((prev) => {
-        const alreadyFavorite = prev.favorites.includes(coin);
-        void backgroundApiProxy.serviceMarketV2.syncToMarketWatchList({
-          coin,
-          action: alreadyFavorite ? 'remove' : 'add',
+      if (isSpot) {
+        setSpotFavs((prev) => {
+          const alreadyFavorite = prev.favorites.includes(coin);
+          return {
+            ...prev,
+            favorites: alreadyFavorite
+              ? prev.favorites.filter((f) => f !== coin)
+              : [...prev.favorites, coin],
+          };
         });
-        return {
-          ...prev,
-          favorites: alreadyFavorite
-            ? prev.favorites.filter((f) => f !== coin)
-            : [...prev.favorites, coin],
-        };
-      });
-    }, [coin, setFavorites]);
+      } else {
+        setPerpFavs((prev) => {
+          const alreadyFavorite = prev.favorites.includes(coin);
+          void backgroundApiProxy.serviceMarketV2.syncToMarketWatchList({
+            coin,
+            action: alreadyFavorite ? 'remove' : 'add',
+          });
+          return {
+            ...prev,
+            favorites: alreadyFavorite
+              ? prev.favorites.filter((f) => f !== coin)
+              : [...prev.favorites, coin],
+          };
+        });
+      }
+    }, [coin, isSpot, setPerpFavs, setSpotFavs]);
 
     return (
       <IconButton
@@ -200,7 +219,7 @@ SubtitleBadge.displayName = 'SubtitleBadge';
 
 // Desktop cell components
 const TokenInfoCellDesktop = memo(() => {
-  const { token } = useTokenSelectorRowContext();
+  const { token, isSpot } = useTokenSelectorRowContext();
   const { gtLg } = useMedia();
 
   const content = useMemo(
@@ -229,29 +248,33 @@ const TokenInfoCellDesktop = memo(() => {
             <Token
               size="xs"
               borderRadius="$full"
-              tokenImageUri={getHyperliquidTokenImageUrl(token.displayName)}
+              tokenImageUri={getHyperliquidTokenImageUrl(
+                isSpot ? token.name : token.displayName,
+              )}
               fallbackIcon="CryptoCoinOutline"
             />
             <SizableText size="$bodySmMedium" numberOfLines={1} flexShrink={1}>
               {token.displayName}
             </SizableText>
             <XStack gap="$1" minWidth={0}>
-              <XStack
-                borderRadius="$1"
-                bg="$bgStrong"
-                justifyContent="center"
-                alignItems="center"
-                px="$1.5"
-              >
-                <SizableText
-                  fontSize={10}
-                  alignSelf="center"
-                  color="$textSubdued"
-                  lineHeight={16}
+              {!isSpot && token.maxLeverage > 0 ? (
+                <XStack
+                  borderRadius="$1"
+                  bg="$bgStrong"
+                  justifyContent="center"
+                  alignItems="center"
+                  px="$1.5"
                 >
-                  {token.maxLeverage}x
-                </SizableText>
-              </XStack>
+                  <SizableText
+                    fontSize={10}
+                    alignSelf="center"
+                    color="$textSubdued"
+                    lineHeight={16}
+                  >
+                    {token.maxLeverage}x
+                  </SizableText>
+                </XStack>
+              ) : null}
               {token.subtitle && gtLg ? (
                 <SubtitleBadge
                   subtitle={token.subtitle}
@@ -264,7 +287,7 @@ const TokenInfoCellDesktop = memo(() => {
         </XStack>
       </DebugRenderTracker>
     ),
-    [token.displayName, token.subtitle, token.maxLeverage, token.name, gtLg],
+    [token.displayName, token.subtitle, token.maxLeverage, token.name, gtLg, isSpot],
   );
   return content;
 });
@@ -475,7 +498,7 @@ TokenSelectorRowDesktop.displayName = 'TokenSelectorRowDesktop';
 
 // Mobile cell components
 const TokenImageMobile = memo(() => {
-  const { token } = useTokenSelectorRowContext();
+  const { token, isSpot } = useTokenSelectorRowContext();
 
   const content = useMemo(
     () => (
@@ -489,13 +512,15 @@ const TokenImageMobile = memo(() => {
           <Token
             size="lg"
             borderRadius="$full"
-            tokenImageUri={getHyperliquidTokenImageUrl(token.displayName)}
+            tokenImageUri={getHyperliquidTokenImageUrl(
+              isSpot ? token.name : token.displayName,
+            )}
             fallbackIcon="CryptoCoinOutline"
           />
         </XStack>
       </DebugRenderTracker>
     ),
-    [token.displayName, token.name],
+    [token.displayName, token.name, isSpot],
   );
   return content;
 });

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
@@ -22,10 +22,6 @@ import {
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import {
-  usePerpsAllAssetsFilteredAtom,
-  usePerpsTokenSearchAliasesAtom,
-} from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
-import {
   usePerpTokenFavoritesPersistAtom,
   useSpotAssetCtxsMapAtom,
   useSpotTokenFavoritesPersistAtom,
@@ -39,13 +35,9 @@ import {
   formatSpotPairDisplayName,
   getHyperliquidTokenImageUrl,
   getSpotTokenDisplayName,
-  getTokenSubtitle,
   parseDexCoin,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
-import type {
-  IPerpsUniverse,
-  ISpotUniverse,
-} from '@onekeyhq/shared/types/hyperliquid';
+import type { ISpotUniverse } from '@onekeyhq/shared/types/hyperliquid';
 
 import { usePerpsAssetCtx } from '../../hooks/usePerpsAssetCtx';
 
@@ -53,6 +45,10 @@ interface IPerpTokenSelectorRowProps {
   mockedToken: {
     index: number;
     dexIndex: number;
+    assetId?: number;
+    tokenName?: string;
+    tokenMaxLeverage?: number;
+    tokenSubtitle?: string;
     spotUniverse?: ISpotUniverse;
   };
   onPress: (name: string) => void;
@@ -842,14 +838,11 @@ const PerpTokenSelectorRowPerps = memo(
     isOnModal,
     skipMarkRequired,
   }: IPerpTokenSelectorRowProps) => {
-    const [filteredAssets] = usePerpsAllAssetsFilteredAtom();
-    const [tokenSearchAliases] = usePerpsTokenSearchAliasesAtom();
-    const tokensByDex = filteredAssets.assetsByDex || [];
-    const assets: IPerpsUniverse[] = tokensByDex[mockedToken.dexIndex] || [];
-    const token: IPerpsUniverse | undefined = assets[mockedToken.index];
-    const tokenName = token?.name ?? '';
-    const tokenAssetId = token?.assetId ?? -1;
-    const tokenMaxLeverage = token?.maxLeverage ?? 0;
+    // Static token data is pre-computed in the parent list and passed via mockedToken.
+    // This avoids subscribing to usePerpsAllAssetsFilteredAtom (150+ subscriptions).
+    const tokenName = mockedToken.tokenName ?? '';
+    const tokenAssetId = mockedToken.assetId ?? -1;
+    const tokenMaxLeverage = mockedToken.tokenMaxLeverage ?? 0;
 
     const { assetCtx, isLoading } = usePerpsAssetCtx({
       assetId: tokenAssetId,
@@ -864,10 +857,7 @@ const PerpTokenSelectorRowPerps = memo(
     );
 
     const parsed = useMemo(() => parseDexCoin(tokenName), [tokenName]);
-    const subtitle = useMemo(
-      () => getTokenSubtitle(tokenName, tokenSearchAliases),
-      [tokenName, tokenSearchAliases],
-    );
+    const subtitle = mockedToken.tokenSubtitle;
 
     const contextValue: ITokenSelectorRowContextValue = useMemo(
       () => ({
@@ -903,7 +893,7 @@ const PerpTokenSelectorRowPerps = memo(
       ],
     );
 
-    if (!token || token.isDelisted || !assetCtx) {
+    if (!tokenName || !assetCtx) {
       return null;
     }
 

--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -17,7 +17,10 @@ import {
 } from '@onekeyhq/components';
 import { useDebounce } from '@onekeyhq/kit/src/hooks/useDebounce';
 import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
-import { useTradingFormAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import {
+  useActiveTradeInstrumentAtom,
+  useTradingFormAtom,
+} from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
   usePerpsAccountLoadingInfoAtom,
   usePerpsActiveAccountStatusAtom,
@@ -71,14 +74,17 @@ function SideButtonInternal({
   const [tradingMode] = useTradingModeAtom();
   const isSpot = tradingMode === 'spot';
   const [activeAsset] = usePerpsActiveAssetAtom();
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
 
   const { handleConfirm } = useOrderConfirm();
   const { midPriceBN } = useTradingPrice();
 
-  const szDecimals = useMemo(
-    () => activeAsset?.universe?.szDecimals ?? 2,
-    [activeAsset?.universe?.szDecimals],
-  );
+  const szDecimals = useMemo(() => {
+    if (isSpot && activeTradeInstrument.mode === 'spot') {
+      return activeTradeInstrument.universe?.baseSzDecimals ?? 2;
+    }
+    return activeAsset?.universe?.szDecimals ?? 2;
+  }, [isSpot, activeTradeInstrument, activeAsset?.universe?.szDecimals]);
 
   const calculations = useTradingCalculationsForSide(side);
   const {
@@ -143,14 +149,21 @@ function SideButtonInternal({
     const sizeValue = computedSizeForSide
       .decimalPlaces(szDecimals, BigNumber.ROUND_DOWN)
       .toFixed(szDecimals);
-    const symbol = activeAsset?.coin || '';
-    const displayName = symbol ? parseDexCoin(symbol).displayName : '';
+    const displayName = (() => {
+      if (isSpot && activeTradeInstrument.mode === 'spot') {
+        return activeTradeInstrument.universe?.displayName ?? '';
+      }
+      const symbol = activeAsset?.coin || '';
+      return symbol ? parseDexCoin(symbol).displayName : '';
+    })();
     return `${sizeValue} ${displayName}`;
   }, [
     orderValue,
     tradingPreferences.sizeInputUnit,
     computedSizeForSide,
     szDecimals,
+    isSpot,
+    activeTradeInstrument,
     activeAsset?.coin,
   ]);
 
@@ -310,9 +323,14 @@ function SideButtonInternal({
             .dividedBy(effectivePriceBN)
             .decimalPlaces(szDecimals, BigNumber.ROUND_UP);
           if (tradingPreferences.sizeInputUnit === 'token') {
-            const coinSymbol = activeAsset?.coin
-              ? parseDexCoin(activeAsset.coin).displayName
-              : '';
+            const coinSymbol = (() => {
+              if (isSpot && activeTradeInstrument.mode === 'spot') {
+                return activeTradeInstrument.universe?.displayName ?? '';
+              }
+              return activeAsset?.coin
+                ? parseDexCoin(activeAsset.coin).displayName
+                : '';
+            })();
             minAmount = `${minSize.toFixed(szDecimals)} ${coinSymbol}`;
           } else if (tradingPreferences.sizeInputUnit === 'margin') {
             const leverageBN = new BigNumber(leverage || 1);

--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -25,6 +25,7 @@ import {
   usePerpsCommonConfigPersistAtom,
   usePerpsCustomSettingsAtom,
   usePerpsTradingPreferencesAtom,
+  useTradingModeAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { parseDexCoin } from '@onekeyhq/shared/src/utils/perpsUtils';
@@ -67,6 +68,8 @@ function SideButtonInternal({
   const [perpsCustomSettings] = usePerpsCustomSettingsAtom();
   const [formData] = useTradingFormAtom();
   const [tradingPreferences] = usePerpsTradingPreferencesAtom();
+  const [tradingMode] = useTradingModeAtom();
+  const isSpot = tradingMode === 'spot';
   const [activeAsset] = usePerpsActiveAssetAtom();
 
   const { handleConfirm } = useOrderConfirm();
@@ -168,12 +171,16 @@ function SideButtonInternal({
       return intl.formatMessage({
         id: ETranslations.perp_trading_button_no_enough_margin,
       });
+    if (isSpot) {
+      return side === 'long' ? 'Buy' : 'Sell';
+    }
     return side === 'long'
       ? intl.formatMessage({ id: ETranslations.perp_trade_long })
       : intl.formatMessage({ id: ETranslations.perp_trade_short });
   }, [
     priceError,
     isNoEnoughMargin,
+    isSpot,
     side,
     intl,
     perpConfigCommon?.ipDisablePerp,
@@ -460,6 +467,7 @@ function SideButtonInternal({
   if (isMobile) {
     return (
       <YStack gap="$2" flex={1}>
+        {isSpot ? null : (
         <YStack gap="$1.5">
           {/* <XStack justifyContent="space-between">
           <SizableText size="$bodySm" color="$textSubdued">
@@ -544,6 +552,7 @@ function SideButtonInternal({
             {renderLiquidationPrice()}
           </XStack>
         </YStack>
+        )}
 
         <Button
           size="medium"

--- a/packages/kit/src/views/Perp/components/TradingPanel/inputs/PriceInput.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/inputs/PriceInput.tsx
@@ -3,7 +3,10 @@ import { memo, useCallback, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { validatePriceInput } from '@onekeyhq/shared/src/utils/perpsUtils';
+import {
+  validatePriceInput,
+  validateSpotPriceInput,
+} from '@onekeyhq/shared/src/utils/perpsUtils';
 
 import { TradingFormInput } from './TradingFormInput';
 
@@ -19,6 +22,7 @@ interface IPriceInputProps {
   placeholder?: string;
   ifOnDialog?: boolean;
   isMobile?: boolean;
+  isSpot?: boolean;
 }
 
 export const PriceInput = memo(
@@ -33,6 +37,7 @@ export const PriceInput = memo(
     placeholder,
     ifOnDialog = false,
     isMobile = false,
+    isSpot = false,
   }: IPriceInputProps) => {
     const intl = useIntl();
     const handleInputChange = useCallback(
@@ -46,9 +51,11 @@ export const PriceInput = memo(
     const validator = useCallback(
       (text: string) => {
         const processedText = text.replace(/。/g, '.');
-        return validatePriceInput(processedText, szDecimals);
+        return isSpot
+          ? validateSpotPriceInput(processedText, szDecimals)
+          : validatePriceInput(processedText, szDecimals);
       },
-      [szDecimals],
+      [isSpot, szDecimals],
     );
 
     const actions = useMemo(

--- a/packages/kit/src/views/Perp/components/TradingPanel/inputs/PriceInput.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/inputs/PriceInput.tsx
@@ -5,7 +5,6 @@ import { useIntl } from 'react-intl';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
   validatePriceInput,
-  validateSpotPriceInput,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 
 import { TradingFormInput } from './TradingFormInput';
@@ -51,9 +50,7 @@ export const PriceInput = memo(
     const validator = useCallback(
       (text: string) => {
         const processedText = text.replace(/。/g, '.');
-        return isSpot
-          ? validateSpotPriceInput(processedText, szDecimals)
-          : validatePriceInput(processedText, szDecimals);
+        return validatePriceInput(processedText, szDecimals);
       },
       [isSpot, szDecimals],
     );

--- a/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
@@ -132,13 +132,6 @@ export const SizeInput = memo(
         const marginBN = new BigNumber(marginValue);
         if (!marginBN.isFinite()) return '';
         const tokenValue = marginBN.multipliedBy(leverageBN).dividedBy(priceBN);
-        console.log('calcTokenFromMargin__debug', {
-          margin: marginValue,
-          leverage: leverageBN.toFixed(),
-          price: priceBN.toFixed(),
-          result: tokenValue.toFixed(),
-          szDecimals,
-        });
         return formatWithPrecision(tokenValue, szDecimals, true);
       },
       [hasValidPrice, priceBN, leverageBN, szDecimals],

--- a/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
@@ -132,6 +132,13 @@ export const SizeInput = memo(
         const marginBN = new BigNumber(marginValue);
         if (!marginBN.isFinite()) return '';
         const tokenValue = marginBN.multipliedBy(leverageBN).dividedBy(priceBN);
+        console.log('calcTokenFromMargin__debug', {
+          margin: marginValue,
+          leverage: leverageBN.toFixed(),
+          price: priceBN.toFixed(),
+          result: tokenValue.toFixed(),
+          szDecimals,
+        });
         return formatWithPrecision(tokenValue, szDecimals, true);
       },
       [hasValidPrice, priceBN, leverageBN, szDecimals],

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
@@ -65,9 +65,10 @@ function OrderConfirmContent({
   const effectiveSide = overrideSide || formData.side;
   const { computedSizeForSide, orderValue } =
     useTradingCalculationsForSide(effectiveSide);
-  const szDecimals = isSpot
-    ? (activeInstrument.universe as any)?.baseSzDecimals ?? 2
-    : (activeInstrument.universe as any)?.szDecimals ?? 2;
+  const szDecimals =
+    activeInstrument.mode === 'spot'
+      ? activeInstrument.universe?.baseSzDecimals ?? 2
+      : activeInstrument.universe?.szDecimals ?? 2;
   const actionColor = getTradingSideTextColor(effectiveSide);
 
   const [onekeyFee, setOnekeyFee] = useState<number | undefined>(undefined);
@@ -154,9 +155,12 @@ function OrderConfirmContent({
     const sizeString = computedSizeForSide.toFixed(szDecimals);
     if (activeInstrument?.coin) {
       // Spot coins use @N format, resolve to display name (e.g. HYPE)
-      const coinDisplay = isSpot && activeInstrument.mode === 'spot'
-        ? getSpotTokenDisplayName((activeInstrument.universe as any)?.baseName || activeInstrument.coin)
-        : parseDexCoin(activeInstrument.coin).displayName;
+      const coinDisplay =
+        activeInstrument.mode === 'spot'
+          ? getSpotTokenDisplayName(
+              activeInstrument.universe?.baseName ?? activeInstrument.coin,
+            )
+          : parseDexCoin(activeInstrument.coin).displayName;
       return `${sizeString} ${coinDisplay}`;
     }
     return sizeString;

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
@@ -321,6 +321,23 @@ function OrderConfirmContent({
           <SizableText size="$bodyMdMedium">{sizeDisplay}</SizableText>
         </XStack>
 
+        {/* Order Value */}
+        {orderValue.isFinite() && orderValue.gt(0) ? (
+          <XStack justifyContent="space-between" alignItems="center">
+            <SizableText size="$bodyMd" color="$textSubdued">
+              {intl.formatMessage({
+                id: ETranslations.perp_trade_order_value,
+              })}
+            </SizableText>
+            <SizableText size="$bodyMdMedium">
+              {numberFormat(orderValue.toFixed(2), {
+                formatter: 'value',
+                formatterOptions: { currency: '$' },
+              })}
+            </SizableText>
+          </XStack>
+        ) : null}
+
         {/* Price (standard orders only — trigger orders show trigger/execution price above) */}
         {!isTriggerMode ? (
           <XStack justifyContent="space-between" alignItems="center">
@@ -333,7 +350,7 @@ function OrderConfirmContent({
           </XStack>
         ) : null}
 
-        {/* Liquidation Price — perps only */}
+        {/* Liquidation Price */}
         {isSpot ? null : (
           <XStack justifyContent="space-between" alignItems="center">
             <SizableText size="$bodyMd" color="$textSubdued">

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
@@ -13,15 +13,19 @@ import {
   YStack,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { useTradingFormAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
-  usePerpsActiveAssetAtom,
-  usePerpsCustomSettingsAtom,
-} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+  useActiveTradeInstrumentAtom,
+  useTradingFormAtom,
+} from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import { usePerpsCustomSettingsAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
-import { inferTpsl, parseDexCoin } from '@onekeyhq/shared/src/utils/perpsUtils';
+import {
+  getSpotTokenDisplayName,
+  inferTpsl,
+  parseDexCoin,
+} from '@onekeyhq/shared/src/utils/perpsUtils';
 import { ETriggerOrderType } from '@onekeyhq/shared/types/hyperliquid/types';
 
 import { useOrderConfirm, useTradingCalculationsForSide } from '../../../hooks';
@@ -56,11 +60,14 @@ function OrderConfirmContent({
   const [perpsCustomSettings, setPerpsCustomSettings] =
     usePerpsCustomSettingsAtom();
   const [formData] = useTradingFormAtom();
-  const [selectedSymbol] = usePerpsActiveAssetAtom();
+  const [activeInstrument] = useActiveTradeInstrumentAtom();
+  const isSpot = activeInstrument.mode === 'spot';
   const effectiveSide = overrideSide || formData.side;
   const { computedSizeForSide, orderValue } =
     useTradingCalculationsForSide(effectiveSide);
-  const szDecimals = selectedSymbol?.universe?.szDecimals ?? 2;
+  const szDecimals = isSpot
+    ? (activeInstrument.universe as any)?.baseSzDecimals ?? 2
+    : (activeInstrument.universe as any)?.szDecimals ?? 2;
   const actionColor = getTradingSideTextColor(effectiveSide);
 
   const [onekeyFee, setOnekeyFee] = useState<number | undefined>(undefined);
@@ -129,23 +136,31 @@ function OrderConfirmContent({
     });
   }, [isTriggerMode, formData.triggerPrice, midPriceBN, effectiveSide, intl]);
 
-  const actionText =
-    effectiveSide === 'long'
-      ? intl.formatMessage({
-          id: ETranslations.perp_trade_long,
-        })
-      : intl.formatMessage({
-          id: ETranslations.perp_trade_short,
-        });
+  const actionText = isSpot
+    ? intl.formatMessage({
+        id:
+          effectiveSide === 'long'
+            ? ETranslations.global_buy
+            : ETranslations.global_sell,
+      })
+    : intl.formatMessage({
+        id:
+          effectiveSide === 'long'
+            ? ETranslations.perp_trade_long
+            : ETranslations.perp_trade_short,
+      });
 
   const sizeDisplay = useMemo(() => {
     const sizeString = computedSizeForSide.toFixed(szDecimals);
-    if (selectedSymbol?.coin) {
-      const parsed = parseDexCoin(selectedSymbol.coin);
-      return `${sizeString} ${parsed.displayName}`;
+    if (activeInstrument?.coin) {
+      // Spot coins use @N format, resolve to display name (e.g. HYPE)
+      const coinDisplay = isSpot && activeInstrument.mode === 'spot'
+        ? getSpotTokenDisplayName((activeInstrument.universe as any)?.baseName || activeInstrument.coin)
+        : parseDexCoin(activeInstrument.coin).displayName;
+      return `${sizeString} ${coinDisplay}`;
     }
     return sizeString;
-  }, [computedSizeForSide, szDecimals, selectedSymbol?.coin]);
+  }, [computedSizeForSide, szDecimals, activeInstrument?.coin]);
 
   const priceDisplay = useMemo(() => {
     if (formData.type === 'market' || !formData.price) {
@@ -314,20 +329,22 @@ function OrderConfirmContent({
           </XStack>
         ) : null}
 
-        {/* Liquidation Price */}
-        <XStack justifyContent="space-between" alignItems="center">
-          <SizableText size="$bodyMd" color="$textSubdued">
-            {appLocale.intl.formatMessage({
-              id: ETranslations.perp_position_liq_price,
-            })}
-          </SizableText>
-          <SizableText size="$bodyMd">
-            <LiquidationPriceDisplay
-              textSize="$bodyMdMedium"
-              side={effectiveSide}
-            />
-          </SizableText>
-        </XStack>
+        {/* Liquidation Price — perps only */}
+        {isSpot ? null : (
+          <XStack justifyContent="space-between" alignItems="center">
+            <SizableText size="$bodyMd" color="$textSubdued">
+              {appLocale.intl.formatMessage({
+                id: ETranslations.perp_position_liq_price,
+              })}
+            </SizableText>
+            <SizableText size="$bodyMd">
+              <LiquidationPriceDisplay
+                textSize="$bodyMdMedium"
+                side={effectiveSide}
+              />
+            </SizableText>
+          </XStack>
+        )}
 
         {/* OneKey Fee */}
         {onekeyFee === 0 ? (

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -1194,7 +1194,7 @@ function PerpTradingForm({
         sliderPercent={tradingComputed.sizePercent}
         onRequestManualMode={switchToManual}
         isMobile={isMobile}
-        leverage={formData.leverage ?? 1}
+        leverage={isSpot ? 1 : formData.leverage ?? 1}
       />
 
       <YStack px="$1" {...(isMobile && { pt: '$2', pb: '$2', mt: '$0' })}>

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -36,6 +36,7 @@ import {
   usePerpsActiveAssetDataAtom,
   usePerpsCustomSettingsAtom,
   usePerpsShouldShowEnableTradingButtonAtom,
+  useTradingModeAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
@@ -112,6 +113,8 @@ function PerpTradingForm({
   isMobile = false,
 }: IPerpTradingFormProps) {
   const [perpsAccountLoading] = usePerpsAccountLoadingInfoAtom();
+  const [tradingMode] = useTradingModeAtom();
+  const isSpot = tradingMode === 'spot';
 
   const [formData] = useTradingFormAtom();
   const [, setTradingFormEnv] = useTradingFormEnvAtom();
@@ -412,29 +415,35 @@ function PerpTradingForm({
     [intl],
   );
   const mobileOrderTypeOptions = useMemo(
-    () => [
-      {
-        label: intl.formatMessage({ id: ETranslations.perp_trade_market }),
-        value: 'market' as string,
-      },
-      {
-        label: intl.formatMessage({ id: ETranslations.perp_trade_limit }),
-        value: 'limit' as string,
-      },
-      {
-        label: intl.formatMessage({
-          id: ETranslations.perp_order_trigger_market,
-        }),
-        value: ETriggerOrderType.TRIGGER_MARKET as string,
-      },
-      {
-        label: intl.formatMessage({
-          id: ETranslations.perp_order_trigger_limit,
-        }),
-        value: ETriggerOrderType.TRIGGER_LIMIT as string,
-      },
-    ],
-    [intl],
+    () => {
+      const base = [
+        {
+          label: intl.formatMessage({ id: ETranslations.perp_trade_market }),
+          value: 'market' as string,
+        },
+        {
+          label: intl.formatMessage({ id: ETranslations.perp_trade_limit }),
+          value: 'limit' as string,
+        },
+      ];
+      if (isSpot) return base;
+      return [
+        ...base,
+        {
+          label: intl.formatMessage({
+            id: ETranslations.perp_order_trigger_market,
+          }),
+          value: ETriggerOrderType.TRIGGER_MARKET as string,
+        },
+        {
+          label: intl.formatMessage({
+            id: ETranslations.perp_order_trigger_limit,
+          }),
+          value: ETriggerOrderType.TRIGGER_LIMIT as string,
+        },
+      ];
+    },
+    [intl, isSpot],
   );
 
   const applyPrimaryOrderType = useCallback(
@@ -781,12 +790,14 @@ function PerpTradingForm({
     <YStack gap={isMobile ? '$2.5' : '$4'} pt={isMobile ? '$0' : '$2.5'}>
       {isMobile ? (
         <>
-          <XStack alignItems="center" flex={1} gap="$2.5">
-            <YStack flex={1}>
-              <MarginModeSelector disabled={isSubmitting} isMobile={isMobile} />
-            </YStack>
-            <LeverageAdjustModal isMobile={isMobile} />
-          </XStack>
+          {isSpot ? null : (
+            <XStack alignItems="center" flex={1} gap="$2.5">
+              <YStack flex={1}>
+                <MarginModeSelector disabled={isSubmitting} isMobile={isMobile} />
+              </YStack>
+              <LeverageAdjustModal isMobile={isMobile} />
+            </XStack>
+          )}
 
           <XStack alignItems="center" flex={1} gap="$2.5">
             <YStack flex={1}>
@@ -842,15 +853,17 @@ function PerpTradingForm({
       ) : (
         <>
           <YStack gap="$2">
-            <XStack alignItems="center" flex={1} gap="$3">
-              <YStack flex={1}>
-                <MarginModeSelector
-                  disabled={isSubmitting}
-                  isMobile={isMobile}
-                />
-              </YStack>
-              <LeverageAdjustModal isMobile={isMobile} />
-            </XStack>
+            {isSpot ? null : (
+              <XStack alignItems="center" flex={1} gap="$3">
+                <YStack flex={1}>
+                  <MarginModeSelector
+                    disabled={isSubmitting}
+                    isMobile={isMobile}
+                  />
+                </YStack>
+                <LeverageAdjustModal isMobile={isMobile} />
+              </XStack>
+            )}
 
             <XStack
               h={38}
@@ -894,7 +907,7 @@ function PerpTradingForm({
                   </XStack>
                 );
               })}
-              <Select
+              {isSpot ? null : <Select
                 items={triggerTypeOptions}
                 title="Trigger"
                 value={triggerOrderType}
@@ -949,7 +962,7 @@ function PerpTradingForm({
                     ) : null}
                   </XStack>
                 )}
-              />
+              />}
             </XStack>
           </YStack>
         </>
@@ -1033,7 +1046,7 @@ function PerpTradingForm({
         />
       </YStack>
 
-      {renderBottomSection()}
+      {isSpot ? null : renderBottomSection()}
     </YStack>
   );
 }

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -19,6 +19,7 @@ import {
 } from '@onekeyhq/components';
 import type { ICheckedState } from '@onekeyhq/components';
 import {
+  useActiveTradeInstrumentAtom,
   useHyperliquidActions,
   usePerpsActivePositionAtom,
   useTradingFormAtom,
@@ -36,11 +37,16 @@ import {
   usePerpsActiveAssetDataAtom,
   usePerpsCustomSettingsAtom,
   usePerpsShouldShowEnableTradingButtonAtom,
-  useTradingModeAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  useSpotActiveAssetAtom,
+  useSpotActiveAssetCtxAtom,
+  useSpotBalancesAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms/spot';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
   formatPriceToSignificantDigits,
+  formatSpotPriceToValid,
   getTriggerEffectivePrice,
   parseDexCoin,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
@@ -48,6 +54,7 @@ import { EPerpsSizeInputMode } from '@onekeyhq/shared/types/hyperliquid';
 import { ETriggerOrderType } from '@onekeyhq/shared/types/hyperliquid/types';
 
 import { useShowDepositWithdrawModal } from '../../../hooks/useShowDepositWithdrawModal';
+import { useActiveTradeDisplay } from '../../../hooks/useActiveTradeDisplay';
 import { useTradingPrice } from '../../../hooks/useTradingPrice';
 import {
   type ITradeSide,
@@ -113,16 +120,19 @@ function PerpTradingForm({
   isMobile = false,
 }: IPerpTradingFormProps) {
   const [perpsAccountLoading] = usePerpsAccountLoadingInfoAtom();
-  const [tradingMode] = useTradingModeAtom();
-  const isSpot = tradingMode === 'spot';
 
   const [formData] = useTradingFormAtom();
   const [, setTradingFormEnv] = useTradingFormEnvAtom();
   const [tradingComputed] = useTradingFormComputedAtom();
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const intl = useIntl();
   const actions = useHyperliquidActions();
   const [activeAsset] = usePerpsActiveAssetAtom();
   const [activeAssetCtx] = usePerpsActiveAssetCtxAtom();
+  const [spotActiveAsset] = useSpotActiveAssetAtom();
+  const [spotActiveAssetCtx] = useSpotActiveAssetCtxAtom();
+  const [{ balances: spotBalances }] = useSpotBalancesAtom();
+  const { baseName: activeBaseName } = useActiveTradeDisplay();
   const { midPrice, midPriceBN } = useTradingPrice();
   const [{ activePositions: perpsPositions }] = usePerpsActivePositionAtom();
   const [perpsSelectedSymbol] = usePerpsActiveAssetAtom();
@@ -132,12 +142,95 @@ function PerpTradingForm({
     [perpsSelectedSymbol.coin],
   );
   const [activeAssetData] = usePerpsActiveAssetDataAtom();
-  const { universe } = perpsSelectedSymbol;
   const [shouldShowEnableTradingButton] =
     usePerpsShouldShowEnableTradingButtonAtom();
 
   const [perpsCustomSettings, setPerpsCustomSettings] =
     usePerpsCustomSettingsAtom();
+
+  const isSpot = activeTradeInstrument.mode === 'spot';
+  const spotUniverse = isSpot ? spotActiveAsset?.universe : undefined;
+  const sizeSzDecimals = isSpot
+    ? (spotUniverse?.baseSzDecimals ?? 2)
+    : (activeAsset?.universe?.szDecimals ?? 2);
+  const selectedTradeAsset = useMemo(
+    () =>
+      isSpot
+        ? ({
+            coin: spotActiveAsset?.coin ?? activeTradeInstrument.coin,
+            assetId: spotActiveAsset?.assetId,
+            universe: {
+              ...(spotUniverse ?? {}),
+              szDecimals: sizeSzDecimals,
+            },
+          } as typeof activeAsset)
+        : activeAsset,
+    [
+      activeAsset,
+      activeTradeInstrument.coin,
+      isSpot,
+      sizeSzDecimals,
+      spotActiveAsset?.assetId,
+      spotActiveAsset?.coin,
+      spotUniverse,
+    ],
+  );
+  const selectedTradeAssetCtx = isSpot
+    ? (spotActiveAssetCtx as typeof activeAssetCtx)
+    : activeAssetCtx;
+
+  const spotAvailableBaseBN = useMemo(() => {
+    if (!spotUniverse?.baseName) {
+      return new BigNumber(0);
+    }
+    const balance = spotBalances.find(
+      (item) => item.coin === spotUniverse.baseName,
+    );
+    if (!balance) {
+      return new BigNumber(0);
+    }
+    return BigNumber.max(
+      new BigNumber(balance.total).minus(balance.hold ?? 0),
+      0,
+    );
+  }, [spotBalances, spotUniverse?.baseName]);
+
+  const spotAvailableQuoteBN = useMemo(() => {
+    if (!spotUniverse?.quoteName) {
+      return new BigNumber(0);
+    }
+    const balance = spotBalances.find(
+      (item) => item.coin === spotUniverse.quoteName,
+    );
+    if (!balance) {
+      return new BigNumber(0);
+    }
+    return BigNumber.max(
+      new BigNumber(balance.total).minus(balance.hold ?? 0),
+      0,
+    );
+  }, [spotBalances, spotUniverse?.quoteName]);
+
+  const spotMaxTradeSzs = useMemo(() => {
+    if (!isSpot) {
+      return undefined;
+    }
+    const buyMax = midPriceBN.gt(0)
+      ? spotAvailableQuoteBN.dividedBy(midPriceBN)
+      : new BigNumber(0);
+    return [
+      buyMax.decimalPlaces(sizeSzDecimals, BigNumber.ROUND_FLOOR).toFixed(),
+      spotAvailableBaseBN
+        .decimalPlaces(sizeSzDecimals, BigNumber.ROUND_FLOOR)
+        .toFixed(),
+    ] as [string, string];
+  }, [
+    isSpot,
+    midPriceBN,
+    sizeSzDecimals,
+    spotAvailableBaseBN,
+    spotAvailableQuoteBN,
+  ]);
 
   // Derive primaryOrderType from formData.orderMode
   const primaryOrderType: IPrimaryOrderType =
@@ -168,26 +261,52 @@ function PerpTradingForm({
 
     if (prevType !== 'limit' && currentType === 'limit' && midPrice) {
       updateForm({
-        price: formatPriceToSignificantDigits(midPrice),
+        price: isSpot
+          ? formatSpotPriceToValid(midPrice, sizeSzDecimals)
+          : formatPriceToSignificantDigits(midPrice),
       });
     }
 
     prevTypeRef.current = currentType;
-  }, [formData.type, formData.price, midPrice, updateForm]);
+  }, [
+    formData.type,
+    formData.price,
+    isSpot,
+    midPrice,
+    sizeSzDecimals,
+    updateForm,
+  ]);
 
   useEffect(() => {
-    const rawAvailable = activeAssetData?.availableToTrade;
-    const maxAvailable = rawAvailable
-      ? Math.max(Number(rawAvailable[0] ?? 0), Number(rawAvailable[1] ?? 0))
-      : 0;
-    const nextEnv = {
-      markPrice: midPrice,
-      availableToTrade: [maxAvailable, maxAvailable],
-      maxTradeSzs: activeAssetData?.maxTradeSzs,
-      leverageValue: activeAssetData?.leverage?.value,
-      fallbackLeverage: activeAsset?.universe?.maxLeverage,
-      szDecimals: activeAsset?.universe?.szDecimals,
-    };
+    const nextEnv = isSpot
+      ? {
+          markPrice: midPrice,
+          availableToTrade: [
+            spotAvailableQuoteBN.toFixed(),
+            spotAvailableBaseBN.toFixed(),
+          ],
+          maxTradeSzs: spotMaxTradeSzs,
+          leverageValue: 1,
+          fallbackLeverage: 1,
+          szDecimals: sizeSzDecimals,
+        }
+      : (() => {
+          const rawAvailable = activeAssetData?.availableToTrade;
+          const maxAvailable = rawAvailable
+            ? Math.max(
+                Number(rawAvailable[0] ?? 0),
+                Number(rawAvailable[1] ?? 0),
+              )
+            : 0;
+          return {
+            markPrice: midPrice,
+            availableToTrade: [maxAvailable, maxAvailable],
+            maxTradeSzs: activeAssetData?.maxTradeSzs,
+            leverageValue: activeAssetData?.leverage?.value,
+            fallbackLeverage: activeAsset?.universe?.maxLeverage,
+            szDecimals: activeAsset?.universe?.szDecimals,
+          };
+        })();
     setTradingFormEnv((prev) => {
       const prevAvailable = prev.availableToTrade ?? [];
       const nextAvailable = nextEnv.availableToTrade ?? [];
@@ -214,6 +333,11 @@ function PerpTradingForm({
     }
   }, [
     midPrice,
+    isSpot,
+    sizeSzDecimals,
+    spotAvailableBaseBN,
+    spotAvailableQuoteBN,
+    spotMaxTradeSzs,
     activeAssetData?.availableToTrade,
     activeAssetData?.maxTradeSzs,
     activeAssetData?.leverage?.value,
@@ -223,6 +347,20 @@ function PerpTradingForm({
     formData.leverage,
     updateForm,
   ]);
+
+  useEffect(() => {
+    if (!isSpot || formData.orderMode !== 'trigger') {
+      return;
+    }
+    updateForm({
+      ...TRIGGER_MODE_TPSL_RESET,
+      bboPriceMode: null,
+      orderMode: 'standard',
+      type: 'market',
+      triggerPrice: '',
+      executionPrice: '',
+    });
+  }, [formData.orderMode, isSpot, updateForm]);
 
   // Reference Price: Get the effective trading price (limit price, market price, or trigger effective price)
   const [, referencePriceString] = useMemo(() => {
@@ -244,10 +382,9 @@ function PerpTradingForm({
     }
     return [
       price,
-      formatPriceToSignificantDigits(
-        price,
-        activeAsset?.universe?.szDecimals ?? 2,
-      ),
+      isSpot
+        ? formatSpotPriceToValid(price.toFixed(), sizeSzDecimals)
+        : formatPriceToSignificantDigits(price, sizeSzDecimals),
     ];
   }, [
     formData.type,
@@ -256,8 +393,9 @@ function PerpTradingForm({
     formData.triggerOrderType,
     formData.triggerPrice,
     formData.executionPrice,
+    isSpot,
     midPriceBN,
-    activeAsset?.universe?.szDecimals,
+    sizeSzDecimals,
   ]);
 
   const [selectedSymbolPositionValue, selectedSymbolPositionSide] =
@@ -273,15 +411,31 @@ function PerpTradingForm({
     }, [perpsPositions, perpsSelectedSymbol.coin]);
 
   const availableToTrade = useMemo(() => {
+    if (isSpot) {
+      const availableValue =
+        formData.side === 'long'
+          ? spotAvailableQuoteBN
+          : spotAvailableBaseBN.multipliedBy(
+              midPriceBN.isFinite() && midPriceBN.gt(0) ? midPriceBN : 0,
+            );
+      return availableValue.toFixed(2, BigNumber.ROUND_DOWN);
+    }
     const available = activeAssetData?.availableToTrade;
     if (!available) return '0';
     const longValue = Number(available[0] ?? 0);
     const shortValue = Number(available[1] ?? 0);
-    return new BigNumber(Math.min(longValue, shortValue)).toFixed(
+    return new BigNumber(Math.max(longValue, shortValue)).toFixed(
       2,
       BigNumber.ROUND_DOWN,
     );
-  }, [activeAssetData?.availableToTrade]);
+  }, [
+    activeAssetData?.availableToTrade,
+    formData.side,
+    isSpot,
+    midPriceBN,
+    spotAvailableBaseBN,
+    spotAvailableQuoteBN,
+  ]);
 
   const switchToManual = useCallback(() => {
     if (tradingComputed.sizeInputMode === EPerpsSizeInputMode.SLIDER) {
@@ -414,37 +568,34 @@ function PerpTradingForm({
     ],
     [intl],
   );
-  const mobileOrderTypeOptions = useMemo(
-    () => {
-      const base = [
-        {
-          label: intl.formatMessage({ id: ETranslations.perp_trade_market }),
-          value: 'market' as string,
-        },
-        {
-          label: intl.formatMessage({ id: ETranslations.perp_trade_limit }),
-          value: 'limit' as string,
-        },
-      ];
-      if (isSpot) return base;
-      return [
-        ...base,
-        {
-          label: intl.formatMessage({
-            id: ETranslations.perp_order_trigger_market,
-          }),
-          value: ETriggerOrderType.TRIGGER_MARKET as string,
-        },
-        {
-          label: intl.formatMessage({
-            id: ETranslations.perp_order_trigger_limit,
-          }),
-          value: ETriggerOrderType.TRIGGER_LIMIT as string,
-        },
-      ];
-    },
-    [intl, isSpot],
-  );
+  const mobileOrderTypeOptions = useMemo(() => {
+    const base = [
+      {
+        label: intl.formatMessage({ id: ETranslations.perp_trade_market }),
+        value: 'market' as string,
+      },
+      {
+        label: intl.formatMessage({ id: ETranslations.perp_trade_limit }),
+        value: 'limit' as string,
+      },
+    ];
+    if (isSpot) return base;
+    return [
+      ...base,
+      {
+        label: intl.formatMessage({
+          id: ETranslations.perp_order_trigger_market,
+        }),
+        value: ETriggerOrderType.TRIGGER_MARKET as string,
+      },
+      {
+        label: intl.formatMessage({
+          id: ETranslations.perp_order_trigger_limit,
+        }),
+        value: ETriggerOrderType.TRIGGER_LIMIT as string,
+      },
+    ];
+  }, [intl, isSpot]);
 
   const applyPrimaryOrderType = useCallback(
     (nextType: IPrimaryOrderType) => {
@@ -515,7 +666,8 @@ function PerpTradingForm({
             })}
             value={triggerPrice}
             onChange={(value) => updateForm({ triggerPrice: value })}
-            szDecimals={universe?.szDecimals ?? 2}
+            szDecimals={sizeSzDecimals}
+            isSpot={isSpot}
             isMobile={isMobile}
             disabled={isSubmitting}
           />
@@ -524,7 +676,9 @@ function PerpTradingForm({
               onUseMidPrice={() => {
                 if (midPrice) {
                   updateForm({
-                    executionPrice: formatPriceToSignificantDigits(midPrice),
+                    executionPrice: isSpot
+                      ? formatSpotPriceToValid(midPrice, sizeSzDecimals)
+                      : formatPriceToSignificantDigits(midPrice),
                   });
                 }
               }}
@@ -533,7 +687,8 @@ function PerpTradingForm({
               })}
               value={formData.executionPrice ?? ''}
               onChange={(value) => updateForm({ executionPrice: value })}
-              szDecimals={universe?.szDecimals ?? 2}
+              szDecimals={sizeSzDecimals}
+              isSpot={isSpot}
               isMobile={isMobile}
               disabled={isSubmitting}
             />
@@ -559,7 +714,9 @@ function PerpTradingForm({
                 onUseMidPrice={() => {
                   if (midPrice) {
                     updateForm({
-                      price: formatPriceToSignificantDigits(midPrice),
+                      price: isSpot
+                        ? formatSpotPriceToValid(midPrice, sizeSzDecimals)
+                        : formatPriceToSignificantDigits(midPrice),
                     });
                   }
                 }}
@@ -571,7 +728,8 @@ function PerpTradingForm({
                       })
                 }
                 onChange={(value) => updateForm({ price: value })}
-                szDecimals={universe?.szDecimals ?? 2}
+                szDecimals={sizeSzDecimals}
+                isSpot={isSpot}
                 isMobile={isMobile}
                 disabled={formData.type === 'market'}
               />
@@ -643,6 +801,7 @@ function PerpTradingForm({
     : ETranslations.perp_trade_sl_price;
 
   const renderBottomSection = () => {
+    if (isSpot) return null;
     if (shouldShowEnableTradingButton && isMobile) {
       return null;
     }
@@ -749,7 +908,7 @@ function PerpTradingForm({
               value={formData.tpValue || ''}
               inputType={formData.tpType || 'price'}
               referencePrice={referencePriceString}
-              szDecimals={activeAsset?.universe?.szDecimals ?? 2}
+              szDecimals={sizeSzDecimals}
               onChange={handleTpValueChange}
               onTypeChange={handleTpTypeChange}
               disabled={isSubmitting}
@@ -763,7 +922,7 @@ function PerpTradingForm({
               value={formData.slValue || ''}
               inputType={formData.slType || 'price'}
               referencePrice={referencePriceString}
-              szDecimals={activeAsset?.universe?.szDecimals ?? 2}
+              szDecimals={sizeSzDecimals}
               onChange={handleSlValueChange}
               onTypeChange={handleSlTypeChange}
               disabled={isSubmitting}
@@ -793,7 +952,10 @@ function PerpTradingForm({
           {isSpot ? null : (
             <XStack alignItems="center" flex={1} gap="$2.5">
               <YStack flex={1}>
-                <MarginModeSelector disabled={isSubmitting} isMobile={isMobile} />
+                <MarginModeSelector
+                  disabled={isSubmitting}
+                  isMobile={isMobile}
+                />
               </YStack>
               <LeverageAdjustModal isMobile={isMobile} />
             </XStack>
@@ -907,62 +1069,64 @@ function PerpTradingForm({
                   </XStack>
                 );
               })}
-              {isSpot ? null : <Select
-                items={triggerTypeOptions}
-                title="Trigger"
-                value={triggerOrderType}
-                onOpenChange={setTriggerMenuOpen}
-                onChange={handleTriggerOrderTypeChange}
-                disabled={isSubmitting}
-                placement="bottom-start"
-                floatingPanelProps={{ width: 180 }}
-                renderTrigger={({ onPress, disabled: disabledTrigger }) => (
-                  <XStack
-                    h={38}
-                    alignItems="center"
-                    position="relative"
-                    gap="$1"
-                    cursor="pointer"
-                    onPress={(e) => {
-                      if (disabledTrigger) return;
-                      if (!isTriggerMode) {
-                        // First click: activate trigger mode with persisted type
-                        applyPrimaryOrderType('trigger');
-                      } else {
-                        // Already in trigger mode: open dropdown to switch type
-                        onPress?.(e);
-                      }
-                    }}
-                  >
-                    <SizableText
-                      size="$bodyMdMedium"
-                      color={isTriggerMode ? '$text' : '$textSubdued'}
+              {isSpot ? null : (
+                <Select
+                  items={triggerTypeOptions}
+                  title="Trigger"
+                  value={triggerOrderType}
+                  onOpenChange={setTriggerMenuOpen}
+                  onChange={handleTriggerOrderTypeChange}
+                  disabled={isSubmitting}
+                  placement="bottom-start"
+                  floatingPanelProps={{ width: 180 }}
+                  renderTrigger={({ onPress, disabled: disabledTrigger }) => (
+                    <XStack
+                      h={38}
+                      alignItems="center"
+                      position="relative"
+                      gap="$1"
+                      cursor="pointer"
+                      onPress={(e) => {
+                        if (disabledTrigger) return;
+                        if (!isTriggerMode) {
+                          // First click: activate trigger mode with persisted type
+                          applyPrimaryOrderType('trigger');
+                        } else {
+                          // Already in trigger mode: open dropdown to switch type
+                          onPress?.(e);
+                        }
+                      }}
                     >
-                      {triggerTabLabel}
-                    </SizableText>
-                    <Icon
-                      name={
-                        triggerMenuOpen
-                          ? 'ChevronTopSmallOutline'
-                          : 'ChevronDownSmallOutline'
-                      }
-                      color={isTriggerMode ? '$icon' : '$iconSubdued'}
-                      size="$4"
-                    />
-                    {isTriggerMode ? (
-                      <YStack
-                        position="absolute"
-                        bottom={0}
-                        left={0}
-                        right={0}
-                        h="$0.5"
-                        bg="$text"
-                        borderRadius={1}
+                      <SizableText
+                        size="$bodyMdMedium"
+                        color={isTriggerMode ? '$text' : '$textSubdued'}
+                      >
+                        {triggerTabLabel}
+                      </SizableText>
+                      <Icon
+                        name={
+                          triggerMenuOpen
+                            ? 'ChevronTopSmallOutline'
+                            : 'ChevronDownSmallOutline'
+                        }
+                        color={isTriggerMode ? '$icon' : '$iconSubdued'}
+                        size="$4"
                       />
-                    ) : null}
-                  </XStack>
-                )}
-              />}
+                      {isTriggerMode ? (
+                        <YStack
+                          position="absolute"
+                          bottom={0}
+                          left={0}
+                          right={0}
+                          h="$0.5"
+                          bg="$text"
+                          borderRadius={1}
+                        />
+                      ) : null}
+                    </XStack>
+                  )}
+                />
+              )}
             </XStack>
           </YStack>
         </>
@@ -993,7 +1157,7 @@ function PerpTradingForm({
           </XStack>
         </XStack>
 
-        {isMobile ? null : (
+        {isMobile || isSpot ? null : (
           <XStack justifyContent="space-between">
             <SizableText size="$bodySm" color="$textSubdued">
               {intl.formatMessage({
@@ -1021,9 +1185,9 @@ function PerpTradingForm({
       <SizeInput
         referencePrice={referencePriceString}
         side={formData.side}
-        activeAsset={activeAsset}
-        activeAssetCtx={activeAssetCtx}
-        symbol={perpsSelectedDisplayName}
+        activeAsset={selectedTradeAsset}
+        activeAssetCtx={selectedTradeAssetCtx}
+        symbol={activeBaseName || perpsSelectedDisplayName}
         value={formData.size}
         onChange={handleManualSizeChange}
         sizeInputMode={tradingComputed.sizeInputMode}
@@ -1046,7 +1210,7 @@ function PerpTradingForm({
         />
       </YStack>
 
-      {isSpot ? null : renderBottomSection()}
+      {renderBottomSection()}
     </YStack>
   );
 }

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -1194,6 +1194,8 @@ function PerpTradingForm({
         sliderPercent={tradingComputed.sizePercent}
         onRequestManualMode={switchToManual}
         isMobile={isMobile}
+        // Spot has no leverage concept — bypass formData.leverage (perps state)
+        // to avoid stale perps leverage affecting spot size calculations.
         leverage={isSpot ? 1 : formData.leverage ?? 1}
       />
 

--- a/packages/kit/src/views/Perp/components/usePerpTokenUrlSync.ts
+++ b/packages/kit/src/views/Perp/components/usePerpTokenUrlSync.ts
@@ -3,17 +3,19 @@ import { useEffect, useMemo, useRef } from 'react';
 import { useIsFocused } from '@react-navigation/native';
 
 import { useDebouncedCallback } from '@onekeyhq/kit/src/hooks/useDebounce';
-import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
-  usePerpsActiveAssetAtom,
-  usePerpsActiveAssetCtxAtom,
-} from '@onekeyhq/kit-bg/src/states/jotai/atoms/perps';
+  useActiveTradeInstrumentAtom,
+  useHyperliquidActions,
+} from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import { usePerpsActiveAssetCtxAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/perps';
+import { useSpotActiveAssetCtxAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/spot';
 import { PERPS_ROUTE_PATH } from '@onekeyhq/shared/src/consts/perp';
-import { parseDexCoin } from '@onekeyhq/shared/src/utils/perpsUtils';
 import {
   DEX_PREFIXES,
   DEX_SEPARATOR,
 } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+
+import { useActiveTradeDisplay } from '../hooks/useActiveTradeDisplay';
 
 function findDexPrefix(token: string): string | null {
   const lowerToken = token.toLowerCase();
@@ -48,22 +50,37 @@ function decodeCoinFromUrl(urlToken: string): string {
   return urlToken.toUpperCase();
 }
 
-function getTokenFromUrl(): string | null {
+function getInstrumentFromUrl(): {
+  coin: string;
+  mode: 'perp' | 'spot';
+} | null {
   try {
     const searchParams = new URLSearchParams(globalThis.location.search);
     const urlToken = searchParams.get('token')?.trim();
     if (!urlToken) return null;
+    const mode = searchParams.get('mode') === 'spot' ? 'spot' : 'perp';
 
-    return decodeCoinFromUrl(urlToken);
+    return {
+      coin: decodeCoinFromUrl(urlToken),
+      mode,
+    };
   } catch {
     return null;
   }
 }
 
-function updateUrlWithoutNavigation(token: string): void {
+function updateUrlWithoutNavigation(params: {
+  coin: string;
+  mode: 'perp' | 'spot';
+}): void {
   try {
-    const encoded = encodeCoinForUrl(token);
-    const newUrl = `${PERPS_ROUTE_PATH}?token=${encoded}`;
+    const encoded = encodeCoinForUrl(params.coin);
+    const searchParams = new URLSearchParams();
+    if (params.mode === 'spot') {
+      searchParams.set('mode', 'spot');
+    }
+    searchParams.set('token', encoded);
+    const newUrl = `${PERPS_ROUTE_PATH}?${searchParams.toString()}`;
     setTimeout(() => {
       try {
         globalThis.history.replaceState(null, '', newUrl);
@@ -85,22 +102,26 @@ function isValidPrice(price: string): boolean {
 export function usePerpTokenUrlSync(): void {
   const isFocused = useIsFocused();
   const actions = useHyperliquidActions();
-  const [activeAsset] = usePerpsActiveAssetAtom();
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
+  const { displayName } = useActiveTradeDisplay();
   const [activeAssetCtx] = usePerpsActiveAssetCtxAtom();
+  const [activeSpotAssetCtx] = useSpotActiveAssetCtxAtom();
   const isInitializedRef = useRef(false);
-  const lastSyncedTokenRef = useRef('');
   const originalTitleRef = useRef<string>('');
 
-  const symbolDisplay = useMemo(() => {
-    if (!activeAsset?.coin) return '';
-    const { displayName, dexLabel } = parseDexCoin(activeAsset.coin);
-    return dexLabel ? `${displayName} (${dexLabel})` : displayName;
-  }, [activeAsset?.coin]);
+  const symbolDisplay = useMemo(() => displayName || '', [displayName]);
 
   const markPrice = useMemo(() => {
-    const price = activeAssetCtx?.ctx?.markPrice || '';
+    const price =
+      activeTradeInstrument.mode === 'spot'
+        ? activeSpotAssetCtx?.ctx?.markPrice || ''
+        : activeAssetCtx?.ctx?.markPrice || '';
     return isValidPrice(price) ? price : '';
-  }, [activeAssetCtx?.ctx?.markPrice]);
+  }, [
+    activeAssetCtx?.ctx?.markPrice,
+    activeSpotAssetCtx?.ctx?.markPrice,
+    activeTradeInstrument.mode,
+  ]);
 
   const updateTitle = (price: string) => {
     try {
@@ -122,10 +143,9 @@ export function usePerpTokenUrlSync(): void {
     originalTitleRef.current = globalThis.document.title;
 
     void (async () => {
-      const urlToken = getTokenFromUrl();
-      if (urlToken) {
-        lastSyncedTokenRef.current = urlToken;
-        await actions.current.changeActiveAsset({ coin: urlToken });
+      const urlInstrument = getInstrumentFromUrl();
+      if (urlInstrument) {
+        await actions.current.switchTradeInstrument(urlInstrument);
       }
       isInitializedRef.current = true;
     })();
@@ -139,12 +159,14 @@ export function usePerpTokenUrlSync(): void {
   useEffect(() => {
     if (!isInitializedRef.current || !isFocused) return;
 
-    const currentToken = activeAsset?.coin?.trim();
+    const currentToken = activeTradeInstrument?.coin?.trim();
     if (!currentToken) return;
 
-    lastSyncedTokenRef.current = currentToken;
-    updateUrlWithoutNavigation(currentToken);
-  }, [activeAsset?.coin, isFocused]);
+    updateUrlWithoutNavigation({
+      coin: currentToken,
+      mode: activeTradeInstrument.mode,
+    });
+  }, [activeTradeInstrument, isFocused]);
 
   useEffect(() => {
     if (!isInitializedRef.current || !isFocused) return;

--- a/packages/kit/src/views/Perp/hooks/useActiveTradeDisplay.ts
+++ b/packages/kit/src/views/Perp/hooks/useActiveTradeDisplay.ts
@@ -3,6 +3,7 @@ import { useActiveTradeInstrumentAtom } from '@onekeyhq/kit/src/states/jotai/con
 import {
   formatSpotPairDisplayName,
   getSpotTokenDisplayName,
+  parseDexCoin,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 
 export function useActiveTradeDisplay() {
@@ -20,11 +21,14 @@ export function useActiveTradeDisplay() {
     };
   }
 
+  const coin = tradeInstrument.coin || perpsAsset.coin;
+  const parsed = parseDexCoin(coin);
+
   return {
     mode: 'perp' as const,
-    coin: tradeInstrument.coin || perpsAsset.coin,
-    displayName: tradeInstrument.coin || perpsAsset.coin,
-    baseName: tradeInstrument.coin || perpsAsset.coin,
+    coin,
+    displayName: parsed.displayName,
+    baseName: parsed.displayName,
     assetId: tradeInstrument.assetId ?? perpsAsset.assetId,
   };
 }

--- a/packages/kit/src/views/Perp/hooks/useActiveTradeDisplay.ts
+++ b/packages/kit/src/views/Perp/hooks/useActiveTradeDisplay.ts
@@ -1,0 +1,30 @@
+import { usePerpsActiveAssetAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { useActiveTradeInstrumentAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import {
+  formatSpotPairDisplayName,
+  getSpotTokenDisplayName,
+} from '@onekeyhq/shared/src/utils/perpsUtils';
+
+export function useActiveTradeDisplay() {
+  const [tradeInstrument] = useActiveTradeInstrumentAtom();
+  const [perpsAsset] = usePerpsActiveAssetAtom();
+
+  if (tradeInstrument.mode === 'spot' && tradeInstrument?.universe) {
+    const u = tradeInstrument.universe;
+    return {
+      mode: 'spot' as const,
+      coin: tradeInstrument.coin,
+      displayName: formatSpotPairDisplayName(u.baseName, u.quoteName),
+      baseName: getSpotTokenDisplayName(u.baseName),
+      assetId: tradeInstrument.assetId,
+    };
+  }
+
+  return {
+    mode: 'perp' as const,
+    coin: tradeInstrument.coin || perpsAsset.coin,
+    displayName: tradeInstrument.coin || perpsAsset.coin,
+    baseName: tradeInstrument.coin || perpsAsset.coin,
+    assetId: tradeInstrument.assetId ?? perpsAsset.assetId,
+  };
+}

--- a/packages/kit/src/views/Perp/hooks/useLiquidationPrice.ts
+++ b/packages/kit/src/views/Perp/hooks/useLiquidationPrice.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { BigNumber } from 'bignumber.js';
 
 import {
+  useActiveTradeInstrumentAtom,
   usePerpsActivePositionAtom,
   useTradingFormAtom,
   useTradingFormComputedAtom,
@@ -26,6 +27,7 @@ export function useLiquidationPrice(
 ): BigNumber | null {
   const [formData] = useTradingFormAtom();
   const [tradingComputed] = useTradingFormComputedAtom();
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const [activeAsset] = usePerpsActiveAssetAtom();
   const [activeAssetCtx] = usePerpsActiveAssetCtxAtom();
   const [activeAssetData] = usePerpsActiveAssetDataAtom();
@@ -60,6 +62,9 @@ export function useLiquidationPrice(
   }, [perpsPositions, coin]);
 
   const liquidationPrice: BigNumber | null = useMemo(() => {
+    if (activeTradeInstrument.mode === 'spot') {
+      return null;
+    }
     if (!leverage || !activeAssetData?.leverage.type) return null;
 
     const isTriggerMode = formData.orderMode === 'trigger';
@@ -146,6 +151,7 @@ export function useLiquidationPrice(
     });
     return _liquidationPrice?.gt(0) ? _liquidationPrice : null;
   }, [
+    activeTradeInstrument.mode,
     activeAsset?.universe?.maxLeverage,
     activeAssetCtx?.ctx?.markPrice,
     activeAssetData?.leverage.type,

--- a/packages/kit/src/views/Perp/hooks/useOrderConfirm.ts
+++ b/packages/kit/src/views/Perp/hooks/useOrderConfirm.ts
@@ -4,11 +4,11 @@ import { BigNumber } from 'bignumber.js';
 
 import { Toast } from '@onekeyhq/components';
 import {
+  useActiveTradeInstrumentAtom,
   useHyperliquidActions,
   useTradingFormAtom,
   useTradingLoadingAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
-import { usePerpsActiveAssetAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { formatPriceToSignificantDigits } from '@onekeyhq/shared/src/utils/perpsUtils';
 import { ETriggerOrderType } from '@onekeyhq/shared/types/hyperliquid/types';
 
@@ -29,7 +29,7 @@ export function useOrderConfirm(
   options?: IUseOrderConfirmOptions,
 ): IUseOrderConfirmReturn {
   const [formData] = useTradingFormAtom();
-  const [activeAsset] = usePerpsActiveAssetAtom();
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const hyperliquidActions = useHyperliquidActions();
   const [isSubmitting] = useTradingLoadingAtom();
   const { midPrice, midPriceBN } = useTradingPrice();
@@ -39,7 +39,7 @@ export function useOrderConfirm(
 
   const handleConfirm = useCallback(
     async (overrideSide?: 'long' | 'short') => {
-      if (activeAsset?.assetId === undefined) {
+      if (activeTradeInstrument?.assetId === undefined) {
         Toast.error({
           title: 'Order Failed',
           message: 'Token information not available',
@@ -52,6 +52,17 @@ export function useOrderConfirm(
         : { ...formData };
 
       const side = formDataSnapshot.side;
+
+      if (
+        activeTradeInstrument.mode === 'spot' &&
+        formDataSnapshot.orderMode === 'trigger'
+      ) {
+        Toast.error({
+          title: 'Order Failed',
+          message: 'Trigger orders are not supported in spot mode',
+        });
+        return;
+      }
 
       // Trigger mode: validate, snapshot, and submit (no TP/SL, no standard price validation)
       if (formDataSnapshot.orderMode === 'trigger') {
@@ -94,7 +105,7 @@ export function useOrderConfirm(
         hyperliquidActions.current.resetTradingForm();
         try {
           await hyperliquidActions.current.submitOrder({
-            assetId: activeAsset.assetId,
+            assetId: activeTradeInstrument.assetId,
             formData: formDataSnapshot,
             price: '0', // not used for trigger orders
           });
@@ -203,7 +214,7 @@ export function useOrderConfirm(
 
       try {
         await hyperliquidActions.current.submitOrder({
-          assetId: activeAsset.assetId,
+          assetId: activeTradeInstrument.assetId,
           formData: effectiveFormData,
           price:
             effectiveFormData.type === 'market'
@@ -219,7 +230,7 @@ export function useOrderConfirm(
     [
       midPrice,
       midPriceBN,
-      activeAsset.assetId,
+      activeTradeInstrument,
       formData,
       hyperliquidActions,
       options,

--- a/packages/kit/src/views/Perp/hooks/usePerpActiveTabValidation.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpActiveTabValidation.ts
@@ -3,7 +3,7 @@ import { useEffect, useMemo } from 'react';
 import type { IPerpDynamicTab } from '@onekeyhq/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp';
 import type { IPerpsUniverse } from '@onekeyhq/shared/types/hyperliquid';
 
-const FIXED_TAB_IDS = ['favorites', 'all'] as const;
+const FIXED_TAB_IDS = ['favorites', 'all', 'spot'] as const;
 
 /**
  * Validates the active tab and resets to 'all' if the currently selected

--- a/packages/kit/src/views/Perp/hooks/usePerpOrderInfoPanel.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpOrderInfoPanel.ts
@@ -54,11 +54,12 @@ export function usePerpTradesHistory() {
 
   useEffect(() => {
     noop(refreshHook);
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       if (isFocusedRef.current) {
         void backgroundApiProxy.serviceHyperliquidSubscription.refreshSubscriptionForUserFills();
       }
     }, 300);
+    return () => clearTimeout(timer);
   }, [refreshHook]);
 
   // Spot and perps fills both come from the same USER_FILLS WS subscription

--- a/packages/kit/src/views/Perp/hooks/usePerpOrderInfoPanel.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpOrderInfoPanel.ts
@@ -2,10 +2,12 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { noop } from 'lodash';
 
+import { useActiveTradeInstrumentAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
   usePerpsActiveAccountAtom,
   usePerpsTradesHistoryDataAtom,
   usePerpsTradesHistoryRefreshHookAtom,
+  useSpotTradesHistoryDataAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { PERPS_HISTORY_FILLS_URL } from '@onekeyhq/shared/src/consts/perp';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
@@ -16,8 +18,10 @@ import backgroundApiProxy from '../../../background/instance/backgroundApiProxy'
 import useListenTabFocusState from '../../../hooks/useListenTabFocusState';
 
 export function usePerpTradesHistory() {
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const [currentAccount] = usePerpsActiveAccountAtom();
-  const [tradesData] = usePerpsTradesHistoryDataAtom();
+  const [perpsTradesData] = usePerpsTradesHistoryDataAtom();
+  const [spotTradesData] = useSpotTradesHistoryDataAtom();
   const [{ refreshHook }] = usePerpsTradesHistoryRefreshHookAtom();
 
   const [currentListPage, setCurrentListPage] = useState(1);
@@ -59,6 +63,8 @@ export function usePerpTradesHistory() {
     }, 300);
   }, [refreshHook]);
 
+  const tradesData =
+    activeTradeInstrument.mode === 'spot' ? spotTradesData : perpsTradesData;
   const fills: IFill[] = tradesData?.fills ?? [];
   const isLoaded: boolean = tradesData?.isLoaded ?? false;
   const hasAccountAddress = Boolean(currentAccount?.accountAddress);
@@ -67,6 +73,7 @@ export function usePerpTradesHistory() {
     trades: fills,
     currentListPage,
     setCurrentListPage,
+    mode: activeTradeInstrument.mode,
     // If current account has no Perp address (unsupported or not created yet),
     // show empty state instead of skeleton loading.
     isLoading: hasAccountAddress ? !isLoaded : false,

--- a/packages/kit/src/views/Perp/hooks/usePerpOrderInfoPanel.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpOrderInfoPanel.ts
@@ -7,7 +7,6 @@ import {
   usePerpsActiveAccountAtom,
   usePerpsTradesHistoryDataAtom,
   usePerpsTradesHistoryRefreshHookAtom,
-  useSpotTradesHistoryDataAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { PERPS_HISTORY_FILLS_URL } from '@onekeyhq/shared/src/consts/perp';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
@@ -21,7 +20,6 @@ export function usePerpTradesHistory() {
   const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const [currentAccount] = usePerpsActiveAccountAtom();
   const [perpsTradesData] = usePerpsTradesHistoryDataAtom();
-  const [spotTradesData] = useSpotTradesHistoryDataAtom();
   const [{ refreshHook }] = usePerpsTradesHistoryRefreshHookAtom();
 
   const [currentListPage, setCurrentListPage] = useState(1);
@@ -63,8 +61,8 @@ export function usePerpTradesHistory() {
     }, 300);
   }, [refreshHook]);
 
-  const tradesData =
-    activeTradeInstrument.mode === 'spot' ? spotTradesData : perpsTradesData;
+  // Spot and perps fills both come from the same USER_FILLS WS subscription
+  const tradesData = perpsTradesData;
   const fills: IFill[] = tradesData?.fills ?? [];
   const isLoaded: boolean = tradesData?.isLoaded ?? false;
   const hasAccountAddress = Boolean(currentAccount?.accountAddress);

--- a/packages/kit/src/views/Perp/hooks/usePerpsAssetCtx.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpsAssetCtx.ts
@@ -1,17 +1,14 @@
 import { useEffect, useMemo } from 'react';
 
 import perpsUtils from '@onekeyhq/shared/src/utils/perpsUtils';
-import type {
-  IPerpsAssetCtx,
-  IPerpsFormattedAssetCtx,
-} from '@onekeyhq/shared/types/hyperliquid';
+import type { IPerpsFormattedAssetCtx } from '@onekeyhq/shared/types/hyperliquid';
 import {
   XYZ_ASSET_ID_LENGTH,
   XYZ_ASSET_ID_OFFSET,
 } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 
 import { useHyperliquidActions } from '../../../states/jotai/contexts/hyperliquid';
-import { usePerpsAllAssetCtxsAtom } from '../../../states/jotai/contexts/hyperliquid/atoms';
+import { usePerpsCtxByCoin } from '../../../states/jotai/contexts/hyperliquid/atoms';
 
 function detectDexByAssetId(assetId: number) {
   const str = `${assetId}`;
@@ -50,26 +47,20 @@ export function usePerpsAssetCtx({
   assetCtx: IPerpsFormattedAssetCtx;
   isLoading: boolean;
 } {
-  const [{ assetCtxsByDex }] = usePerpsAllAssetCtxsAtom();
-  const { dexIndex: resolvedDexIndex, ctxIndex } = useMemo(
+  const { dexIndex: resolvedDexIndex } = useMemo(
     () => normalizeCtxIndex(assetId, dexIndex),
     [assetId, dexIndex],
   );
-  const allAssetCtxs = useMemo(
-    () => assetCtxsByDex[resolvedDexIndex] || [],
-    [assetCtxsByDex, resolvedDexIndex],
-  );
-  const ctxAtIndex: IPerpsAssetCtx | null =
-    ctxIndex >= 0 && ctxIndex < allAssetCtxs.length
-      ? allAssetCtxs[ctxIndex]
-      : null;
-  const ctxSafe = ctxAtIndex ?? null;
+  // Per-asset subscription: only re-renders when this asset's fields actually change.
+  // selectAtom in getOrCreateCtxByCoinAtom returns the previous reference when
+  // field values are equal, so Jotai skips notification and this hook is not called.
+  const ctxSafe = usePerpsCtxByCoin(resolvedDexIndex, assetId);
   const actions = useHyperliquidActions();
   const assetCtx: IPerpsFormattedAssetCtx = useMemo<IPerpsFormattedAssetCtx>(
     () => perpsUtils.formatAssetCtx(ctxSafe) || undefined,
     [ctxSafe],
   );
-  const isLoading = useMemo(() => allAssetCtxs.length <= 0, [allAssetCtxs]);
+  const isLoading = useMemo(() => ctxSafe === null, [ctxSafe]);
   useEffect(() => {
     if (skipMarkRequired) return;
     actions.current.markAllAssetCtxsRequired();

--- a/packages/kit/src/views/Perp/hooks/usePerpsFavorites.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpsFavorites.ts
@@ -1,28 +1,65 @@
 import { useMemo } from 'react';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { usePerpTokenFavoritesPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import { parseDexCoin } from '@onekeyhq/shared/src/utils/perpsUtils';
+import { useActiveTradeInstrumentAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import {
+  usePerpTokenFavoritesPersistAtom,
+  useSpotTokenFavoritesPersistAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  formatSpotPairDisplayName,
+  parseDexCoin,
+} from '@onekeyhq/shared/src/utils/perpsUtils';
+import type {
+  IPerpsUniverse,
+  ISpotUniverse,
+} from '@onekeyhq/shared/types/hyperliquid';
 
 import { usePromiseResult } from '../../../hooks/usePromiseResult';
 
 export type IFavoriteItem = {
+  mode: 'perp' | 'spot';
   coinName: string;
   displayName: string;
+  imageTokenName: string;
   assetId: number;
   dexIndex: number;
 };
 
-export function usePerpsFavorites(): {
+export function usePerpsFavorites(options?: {
+  mode?: 'current' | 'perp' | 'spot';
+}): {
   favoriteItems: IFavoriteItem[];
   isReady: boolean;
 } {
-  const [favorites] = usePerpTokenFavoritesPersistAtom();
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
+  const [perpFavorites] = usePerpTokenFavoritesPersistAtom();
+  const [spotFavorites] = useSpotTokenFavoritesPersistAtom();
+  const favoritesMode =
+    options?.mode === 'current'
+      ? activeTradeInstrument.mode
+      : (options?.mode ?? 'perp');
+  const favorites =
+    favoritesMode === 'spot'
+      ? spotFavorites.favorites
+      : perpFavorites.favorites;
 
   // Fetch the full universe independently — must not read from the
   // search-filtered atom, otherwise favorites disappear during search.
   const { result: universe } = usePromiseResult(
-    async () => {
+    async (): Promise<IPerpsUniverse[][] | ISpotUniverse[]> => {
+      if (favoritesMode === 'spot') {
+        let { universes } = await backgroundApiProxy.serviceHyperliquid.getSpotMeta();
+
+        if (!universes?.length) {
+          await backgroundApiProxy.serviceHyperliquid.refreshSpotMeta();
+          const res = await backgroundApiProxy.serviceHyperliquid.getSpotMeta();
+          universes = res.universes;
+        }
+
+        return universes ?? [];
+      }
+
       let { universesByDex } =
         await backgroundApiProxy.serviceHyperliquid.getTradingUniverse();
 
@@ -40,34 +77,59 @@ export function usePerpsFavorites(): {
 
       return universesByDex ?? [];
     },
-    [],
+    [favoritesMode],
     { checkIsFocused: false },
   );
 
   const favoriteItems = useMemo(() => {
-    if (!universe?.length || !favorites.favorites.length) return [];
+    if (!universe?.length || !favorites.length) return [];
 
     const items: IFavoriteItem[] = [];
 
-    favorites.favorites.forEach((favCoin) => {
-      // Find in universe
-      for (let dexIndex = 0; dexIndex < universe.length; dexIndex += 1) {
-        const assets = universe[dexIndex] || [];
-        const asset = assets.find((a) => a.name === favCoin);
+    if (favoritesMode === 'spot') {
+      const spotUniverses = universe as ISpotUniverse[];
+      favorites.forEach((favCoin) => {
+        const asset = spotUniverses.find((item) => item.name === favCoin);
         if (asset) {
-          const parsed = parseDexCoin(asset.name);
           items.push({
+            mode: 'spot',
             coinName: asset.name,
-            displayName: parsed.displayName,
+            displayName:
+              asset.displayName ||
+              formatSpotPairDisplayName(asset.baseName, asset.quoteName),
+            imageTokenName: asset.baseName,
             assetId: asset.assetId,
-            dexIndex,
+            dexIndex: -1,
           });
-          break;
         }
+      });
+      return items;
+    }
+
+    const perpsUniverses = universe as IPerpsUniverse[][];
+    favorites.forEach((favCoin) => {
+      for (let dexIndex = 0; dexIndex < perpsUniverses.length; dexIndex += 1) {
+        const assets = perpsUniverses[dexIndex] || [];
+        const asset = assets.find((item) => item.name === favCoin);
+        if (!asset) {
+          continue;
+        }
+
+        const parsed = parseDexCoin(asset.name);
+        items.push({
+          mode: 'perp',
+          coinName: asset.name,
+          displayName: parsed.displayName,
+          imageTokenName: parsed.displayName,
+          assetId: asset.assetId,
+          dexIndex,
+        });
+        break;
       }
     });
+
     return items;
-  }, [universe, favorites.favorites]);
+  }, [favorites, favoritesMode, universe]);
 
   return { favoriteItems, isReady: universe !== undefined };
 }

--- a/packages/kit/src/views/Perp/hooks/usePopularTickers.ts
+++ b/packages/kit/src/views/Perp/hooks/usePopularTickers.ts
@@ -46,18 +46,25 @@ export function usePopularTickers(): IPopularTickerItem[] {
 
   // Fetch the full universe independently — must not read from the
   // search-filtered atom, otherwise popular tickers disappear during search.
-  const { result: universe } = usePromiseResult(
-    async (): Promise<IPerpsUniverse[][] | ISpotUniverse[]> => {
+  // Tag result with mode so we never use stale data from a previous mode
+  // (usePromiseResult keeps the old result until the new promise resolves).
+  const { result: taggedUniverse } = usePromiseResult(
+    async (): Promise<
+      | { mode: 'spot'; data: ISpotUniverse[] }
+      | { mode: 'perp'; data: IPerpsUniverse[][] }
+    > => {
       if (mode === 'spot') {
-        let { universes } = await backgroundApiProxy.serviceHyperliquid.getSpotMeta();
+        let { universes } =
+          await backgroundApiProxy.serviceHyperliquid.getSpotMeta();
 
         if (!universes?.length) {
           await backgroundApiProxy.serviceHyperliquid.refreshSpotMeta();
-          const res = await backgroundApiProxy.serviceHyperliquid.getSpotMeta();
+          const res =
+            await backgroundApiProxy.serviceHyperliquid.getSpotMeta();
           universes = res.universes;
         }
 
-        return universes ?? [];
+        return { mode: 'spot', data: universes ?? [] };
       }
 
       let { universesByDex } =
@@ -74,15 +81,18 @@ export function usePopularTickers(): IPopularTickerItem[] {
         universesByDex = res.universesByDex;
       }
 
-      return universesByDex ?? [];
+      return { mode: 'perp', data: universesByDex ?? [] };
     },
     [mode],
     { checkIsFocused: false },
   );
 
   return useMemo(() => {
-    if (mode === 'spot') {
-      const spotUniverses = universe as ISpotUniverse[] | undefined;
+    // Skip if data is from a stale mode (async promise not yet resolved for current mode)
+    if (!taggedUniverse || taggedUniverse.mode !== mode) return [];
+
+    if (mode === 'spot' && taggedUniverse.mode === 'spot') {
+      const spotUniverses = taggedUniverse.data;
       if (!spotUniverses?.length) {
         return [];
       }
@@ -117,14 +127,8 @@ export function usePopularTickers(): IPopularTickerItem[] {
 
     const { assetCtxsByDex } = allAssetCtxs;
 
-    if (!assetCtxsByDex.length || !universe?.length) return [];
-
-    // After the mode === 'spot' early return above, universe is IPerpsUniverse[][].
-    // Guard: during mode transition, universe may still hold stale spot data
-    // (flat ISpotUniverse[]) while mode has already switched to 'perp'.
-    if (!Array.isArray(universe[0])) return [];
-
-    const perpUniverse = universe as IPerpsUniverse[][];
+    const perpUniverse = taggedUniverse.data;
+    if (!assetCtxsByDex.length || !perpUniverse?.length) return [];
     const scored: IPopularTickerItem[] = [];
 
     for (let dexIndex = 0; dexIndex < perpUniverse.length; dexIndex += 1) {
@@ -164,5 +168,5 @@ export function usePopularTickers(): IPopularTickerItem[] {
 
     scored.sort((a, b) => b.hotScore - a.hotScore);
     return scored.slice(0, POPULAR_TICKER_COUNT);
-  }, [allAssetCtxs, mode, spotPriceMap, universe]);
+  }, [allAssetCtxs, mode, spotPriceMap, taggedUniverse]);
 }

--- a/packages/kit/src/views/Perp/hooks/usePopularTickers.ts
+++ b/packages/kit/src/views/Perp/hooks/usePopularTickers.ts
@@ -119,13 +119,18 @@ export function usePopularTickers(): IPopularTickerItem[] {
 
     if (!assetCtxsByDex.length || !universe?.length) return [];
 
-    // After the mode === 'spot' early return above, universe is IPerpsUniverse[][]
+    // After the mode === 'spot' early return above, universe is IPerpsUniverse[][].
+    // Guard: during mode transition, universe may still hold stale spot data
+    // (flat ISpotUniverse[]) while mode has already switched to 'perp'.
+    if (!Array.isArray(universe[0])) return [];
+
     const perpUniverse = universe as IPerpsUniverse[][];
     const scored: IPopularTickerItem[] = [];
 
     for (let dexIndex = 0; dexIndex < perpUniverse.length; dexIndex += 1) {
       const assets = perpUniverse[dexIndex] ?? [];
       const ctxs = assetCtxsByDex[dexIndex] ?? [];
+      if (!Array.isArray(assets)) continue;
 
       for (const asset of assets) {
         // XYZ DEX assets have offset IDs; array is indexed from 0

--- a/packages/kit/src/views/Perp/hooks/usePopularTickers.ts
+++ b/packages/kit/src/views/Perp/hooks/usePopularTickers.ts
@@ -44,10 +44,9 @@ export function usePopularTickers(): IPopularTickerItem[] {
   const [spotPriceMap] = useSpotAssetCtxsMapAtom();
   const mode = activeTradeInstrument.mode;
 
-  // Fetch the full universe independently — must not read from the
-  // search-filtered atom, otherwise popular tickers disappear during search.
-  // Tag result with mode so we never use stale data from a previous mode
-  // (usePromiseResult keeps the old result until the new promise resolves).
+  // Must not read from search-filtered atom — popular tickers would disappear
+  // during search. Tagged with mode because usePromiseResult keeps the old
+  // result until the new promise resolves.
   const { result: taggedUniverse } = usePromiseResult(
     async (): Promise<
       | { mode: 'spot'; data: ISpotUniverse[] }
@@ -88,7 +87,6 @@ export function usePopularTickers(): IPopularTickerItem[] {
   );
 
   return useMemo(() => {
-    // Skip if data is from a stale mode (async promise not yet resolved for current mode)
     if (!taggedUniverse || taggedUniverse.mode !== mode) return [];
 
     if (mode === 'spot' && taggedUniverse.mode === 'spot') {

--- a/packages/kit/src/views/Perp/hooks/usePopularTickers.ts
+++ b/packages/kit/src/views/Perp/hooks/usePopularTickers.ts
@@ -3,8 +3,17 @@ import { useMemo } from 'react';
 import BigNumber from 'bignumber.js';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { useActiveTradeInstrumentAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import { usePerpsAllAssetCtxsAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
-import { parseDexCoin } from '@onekeyhq/shared/src/utils/perpsUtils';
+import { useSpotAssetCtxsMapAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  formatSpotPairDisplayName,
+  parseDexCoin,
+} from '@onekeyhq/shared/src/utils/perpsUtils';
+import type {
+  IPerpsUniverse,
+  ISpotUniverse,
+} from '@onekeyhq/shared/types/hyperliquid';
 import { XYZ_ASSET_ID_OFFSET } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 
 import { usePromiseResult } from '../../../hooks/usePromiseResult';
@@ -12,8 +21,10 @@ import { usePromiseResult } from '../../../hooks/usePromiseResult';
 const POPULAR_TICKER_COUNT = 10;
 
 export interface IPopularTickerItem {
+  mode: 'perp' | 'spot';
   coinName: string;
   displayName: string;
+  imageTokenName: string;
   assetId: number;
   dexIndex: number;
   hotScore: number;
@@ -28,12 +39,27 @@ export interface IPopularTickerItem {
  * disappearing when the user types in the token search bar.
  */
 export function usePopularTickers(): IPopularTickerItem[] {
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const [allAssetCtxs] = usePerpsAllAssetCtxsAtom();
+  const [spotPriceMap] = useSpotAssetCtxsMapAtom();
+  const mode = activeTradeInstrument.mode;
 
   // Fetch the full universe independently — must not read from the
   // search-filtered atom, otherwise popular tickers disappear during search.
   const { result: universe } = usePromiseResult(
-    async () => {
+    async (): Promise<IPerpsUniverse[][] | ISpotUniverse[]> => {
+      if (mode === 'spot') {
+        let { universes } = await backgroundApiProxy.serviceHyperliquid.getSpotMeta();
+
+        if (!universes?.length) {
+          await backgroundApiProxy.serviceHyperliquid.refreshSpotMeta();
+          const res = await backgroundApiProxy.serviceHyperliquid.getSpotMeta();
+          universes = res.universes;
+        }
+
+        return universes ?? [];
+      }
+
       let { universesByDex } =
         await backgroundApiProxy.serviceHyperliquid.getTradingUniverse();
 
@@ -50,19 +76,55 @@ export function usePopularTickers(): IPopularTickerItem[] {
 
       return universesByDex ?? [];
     },
-    [],
+    [mode],
     { checkIsFocused: false },
   );
 
   return useMemo(() => {
+    if (mode === 'spot') {
+      const spotUniverses = universe as ISpotUniverse[] | undefined;
+      if (!spotUniverses?.length) {
+        return [];
+      }
+
+      const scored = spotUniverses
+        .map((asset) => {
+          const ctx = spotPriceMap[asset.name];
+          const volume24h = new BigNumber(ctx?.dayNtlVlm ?? '0');
+          const markPrice = new BigNumber(ctx?.markPx ?? '0');
+          const circulatingSupply = new BigNumber(ctx?.circulatingSupply ?? '0');
+          const hotScore = volume24h.toNumber();
+          const marketCap = circulatingSupply.multipliedBy(markPrice).toNumber();
+
+          return {
+            mode: 'spot' as const,
+            coinName: asset.name,
+            displayName:
+              asset.displayName ||
+              formatSpotPairDisplayName(asset.baseName, asset.quoteName),
+            imageTokenName: asset.baseName,
+            assetId: asset.assetId,
+            dexIndex: -1,
+            hotScore: Number.isFinite(hotScore) ? hotScore : 0,
+            marketCap,
+          };
+        })
+        .filter((item) => item.hotScore > 0 || item.marketCap > 0);
+
+      scored.sort((a, b) => b.hotScore - a.hotScore || b.marketCap - a.marketCap);
+      return scored.slice(0, POPULAR_TICKER_COUNT).map(({ marketCap, ...item }) => item);
+    }
+
     const { assetCtxsByDex } = allAssetCtxs;
 
     if (!assetCtxsByDex.length || !universe?.length) return [];
 
+    // After the mode === 'spot' early return above, universe is IPerpsUniverse[][]
+    const perpUniverse = universe as IPerpsUniverse[][];
     const scored: IPopularTickerItem[] = [];
 
-    for (let dexIndex = 0; dexIndex < universe.length; dexIndex += 1) {
-      const assets = universe[dexIndex] ?? [];
+    for (let dexIndex = 0; dexIndex < perpUniverse.length; dexIndex += 1) {
+      const assets = perpUniverse[dexIndex] ?? [];
       const ctxs = assetCtxsByDex[dexIndex] ?? [];
 
       for (const asset of assets) {
@@ -81,8 +143,10 @@ export function usePopularTickers(): IPopularTickerItem[] {
             if (Number.isFinite(hotScore) && hotScore > 0) {
               const parsed = parseDexCoin(asset.name);
               scored.push({
+                mode: 'perp',
                 coinName: asset.name,
                 displayName: parsed.displayName,
+                imageTokenName: parsed.displayName,
                 assetId: asset.assetId,
                 dexIndex,
                 hotScore,
@@ -95,5 +159,5 @@ export function usePopularTickers(): IPopularTickerItem[] {
 
     scored.sort((a, b) => b.hotScore - a.hotScore);
     return scored.slice(0, POPULAR_TICKER_COUNT);
-  }, [allAssetCtxs, universe]);
+  }, [allAssetCtxs, mode, spotPriceMap, universe]);
 }

--- a/packages/kit/src/views/Perp/hooks/useSpotMetaMaps.ts
+++ b/packages/kit/src/views/Perp/hooks/useSpotMetaMaps.ts
@@ -1,0 +1,52 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import type { ISpotUniverse } from '@onekeyhq/shared/types/hyperliquid';
+import { getSpotTokenDisplayName } from '@onekeyhq/shared/src/utils/perpsUtils';
+
+export function useSpotMetaMaps() {
+  const [spotUniverses, setSpotUniverses] = useState<ISpotUniverse[]>([]);
+  const [tokenContractMap, setTokenContractMap] = useState<
+    Record<string, string>
+  >({});
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    void backgroundApiProxy.serviceHyperliquid.getSpotMeta().then((meta) => {
+      if (isCancelled) {
+        return;
+      }
+
+      setSpotUniverses(meta.universes ?? []);
+
+      const contractMap: Record<string, string> = {};
+      for (const token of meta.tokens ?? []) {
+        if (token.evmContract?.address) {
+          contractMap[token.name] = token.evmContract.address;
+          contractMap[getSpotTokenDisplayName(token.name)] =
+            token.evmContract.address;
+        }
+      }
+      setTokenContractMap(contractMap);
+    });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, []);
+
+  const universeByBaseName = useMemo(
+    () =>
+      Object.fromEntries(
+        spotUniverses.map((universe) => [universe.baseName, universe]),
+      ) as Record<string, ISpotUniverse>,
+    [spotUniverses],
+  );
+
+  return {
+    spotUniverses,
+    universeByBaseName,
+    tokenContractMap,
+  };
+}

--- a/packages/kit/src/views/Perp/hooks/useTradingCalculationsForSide.ts
+++ b/packages/kit/src/views/Perp/hooks/useTradingCalculationsForSide.ts
@@ -2,34 +2,114 @@ import { useMemo } from 'react';
 
 import { BigNumber } from 'bignumber.js';
 
-import { useTradingFormAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import {
+  useActiveTradeInstrumentAtom,
+  useTradingFormAtom,
+} from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
   usePerpsActiveAssetAtom,
   usePerpsActiveAssetDataAtom,
+  useSpotBalancesAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
   computeMaxTradeSize,
   resolveTradingSizeBN,
+  sanitizeManualSize,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import { EPerpsSizeInputMode } from '@onekeyhq/shared/types/hyperliquid/types';
 
 import { useLiquidationPrice } from './useLiquidationPrice';
 import { useOrderPrice } from './useOrderPrice';
+import { useTradingPrice } from './useTradingPrice';
 
 export function useTradingCalculationsForSide(side: 'long' | 'short') {
   const [formData] = useTradingFormAtom();
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const [activeAsset] = usePerpsActiveAssetAtom();
   const [activeAssetData] = usePerpsActiveAssetDataAtom();
+  const [{ balances: spotBalances }] = useSpotBalancesAtom();
 
   const { price: effectivePriceBN, error: priceError } = useOrderPrice(side);
+  const { midPriceBN } = useTradingPrice();
   const liquidationPrice = useLiquidationPrice(side);
+  const isSpot = activeTradeInstrument.mode === 'spot';
+  const spotUniverse =
+    activeTradeInstrument.mode === 'spot'
+      ? activeTradeInstrument.universe
+      : undefined;
+  const spotSzDecimals = spotUniverse?.baseSzDecimals ?? 2;
+
+  const spotAvailableBaseBN = useMemo(() => {
+    if (!spotUniverse?.baseName) {
+      return new BigNumber(0);
+    }
+    const balance = spotBalances.find(
+      (item) => item.coin === spotUniverse.baseName,
+    );
+    if (!balance) {
+      return new BigNumber(0);
+    }
+    return BigNumber.max(
+      new BigNumber(balance.total).minus(balance.hold ?? 0),
+      0,
+    );
+  }, [spotBalances, spotUniverse?.baseName]);
+
+  const spotAvailableQuoteBN = useMemo(() => {
+    if (!spotUniverse?.quoteName) {
+      return new BigNumber(0);
+    }
+    const balance = spotBalances.find(
+      (item) => item.coin === spotUniverse.quoteName,
+    );
+    if (!balance) {
+      return new BigNumber(0);
+    }
+    return BigNumber.max(
+      new BigNumber(balance.total).minus(balance.hold ?? 0),
+      0,
+    );
+  }, [spotBalances, spotUniverse?.quoteName]);
 
   const leverage = useMemo(
-    () => activeAssetData?.leverage?.value || 1,
-    [activeAssetData?.leverage?.value],
+    () => (isSpot ? 1 : activeAssetData?.leverage?.value || 1),
+    [isSpot, activeAssetData?.leverage?.value],
   );
 
+  const effectiveSpotPriceBN = useMemo(() => {
+    if (effectivePriceBN.isFinite() && effectivePriceBN.gt(0)) {
+      return effectivePriceBN;
+    }
+    return midPriceBN.isFinite() && midPriceBN.gt(0)
+      ? midPriceBN
+      : new BigNumber(0);
+  }, [effectivePriceBN, midPriceBN]);
+
+  const spotMaxTradeSzs = useMemo(() => {
+    if (!isSpot) {
+      return undefined;
+    }
+    const buyMax = effectiveSpotPriceBN.gt(0)
+      ? spotAvailableQuoteBN.dividedBy(effectiveSpotPriceBN)
+      : new BigNumber(0);
+    return [
+      buyMax.decimalPlaces(spotSzDecimals, BigNumber.ROUND_FLOOR).toFixed(),
+      spotAvailableBaseBN
+        .decimalPlaces(spotSzDecimals, BigNumber.ROUND_FLOOR)
+        .toFixed(),
+    ] as [string, string];
+  }, [
+    isSpot,
+    effectiveSpotPriceBN,
+    spotAvailableQuoteBN,
+    spotAvailableBaseBN,
+    spotSzDecimals,
+  ]);
+
   const effectiveMaxTradeSzs = useMemo(() => {
+    if (isSpot) {
+      return spotMaxTradeSzs;
+    }
     if (formData.orderMode !== 'trigger') {
       return activeAssetData?.maxTradeSzs;
     }
@@ -75,7 +155,9 @@ export function useTradingCalculationsForSide(side: 'long' | 'short') {
     activeAssetData?.markPx,
     activeAsset?.universe?.maxLeverage,
     effectivePriceBN,
+    isSpot,
     side,
+    spotMaxTradeSzs,
   ]);
 
   const maxTradeSzBN = useMemo(() => {
@@ -84,11 +166,23 @@ export function useTradingCalculationsForSide(side: 'long' | 'short') {
   }, [effectiveMaxTradeSzs, side]);
 
   const markPxBN = useMemo(() => {
-    const markPx = activeAssetData?.markPx;
+    const markPx = isSpot
+      ? effectiveSpotPriceBN.toFixed()
+      : activeAssetData?.markPx;
     return new BigNumber(markPx ?? 0);
-  }, [activeAssetData?.markPx]);
+  }, [activeAssetData?.markPx, effectiveSpotPriceBN, isSpot]);
 
   const availableMarginBN = useMemo(() => {
+    if (isSpot) {
+      if (side === 'long') {
+        return spotAvailableQuoteBN;
+      }
+      if (!markPxBN.gt(0)) {
+        return new BigNumber(0);
+      }
+      return spotAvailableBaseBN.multipliedBy(markPxBN);
+    }
+
     if (formData.orderMode === 'trigger') {
       const availableIdx = side === 'long' ? 0 : 1;
       return new BigNumber(
@@ -103,10 +197,13 @@ export function useTradingCalculationsForSide(side: 'long' | 'short') {
   }, [
     formData.orderMode,
     activeAssetData?.availableToTrade,
+    isSpot,
     side,
     maxTradeSzBN,
     markPxBN,
     leverage,
+    spotAvailableBaseBN,
+    spotAvailableQuoteBN,
   ]);
 
   const availableToTrade = useMemo(
@@ -117,27 +214,31 @@ export function useTradingCalculationsForSide(side: 'long' | 'short') {
     [availableMarginBN],
   );
 
-  const maxPositionSizeBN = useMemo(
-    () =>
-      computeMaxTradeSize({
-        side,
-        price: effectivePriceBN.isFinite() ? effectivePriceBN.toFixed() : '',
-        markPrice: activeAssetData?.markPx,
-        maxTradeSzs: effectiveMaxTradeSzs,
-        leverageValue: activeAssetData?.leverage?.value,
-        fallbackLeverage: activeAsset?.universe?.maxLeverage,
-        szDecimals: activeAsset?.universe?.szDecimals,
-      }),
-    [
+  const maxPositionSizeBN = useMemo(() => {
+    if (isSpot) {
+      return maxTradeSzBN.decimalPlaces(spotSzDecimals, BigNumber.ROUND_FLOOR);
+    }
+    return computeMaxTradeSize({
       side,
-      effectivePriceBN,
-      activeAssetData?.markPx,
-      effectiveMaxTradeSzs,
-      activeAssetData?.leverage?.value,
-      activeAsset?.universe?.maxLeverage,
-      activeAsset?.universe?.szDecimals,
-    ],
-  );
+      price: effectivePriceBN.isFinite() ? effectivePriceBN.toFixed() : '',
+      markPrice: activeAssetData?.markPx,
+      maxTradeSzs: effectiveMaxTradeSzs,
+      leverageValue: activeAssetData?.leverage?.value,
+      fallbackLeverage: activeAsset?.universe?.maxLeverage,
+      szDecimals: activeAsset?.universe?.szDecimals,
+    });
+  }, [
+    side,
+    effectivePriceBN,
+    activeAssetData?.markPx,
+    effectiveMaxTradeSzs,
+    activeAssetData?.leverage?.value,
+    activeAsset?.universe?.maxLeverage,
+    activeAsset?.universe?.szDecimals,
+    isSpot,
+    maxTradeSzBN,
+    spotSzDecimals,
+  ]);
 
   const maxPositionSize = useMemo(
     () => maxPositionSizeBN.toNumber(),
@@ -145,6 +246,24 @@ export function useTradingCalculationsForSide(side: 'long' | 'short') {
   );
 
   const computedSizeForSide = useMemo(() => {
+    if (isSpot) {
+      if (
+        (formData.sizeInputMode ?? EPerpsSizeInputMode.MANUAL) ===
+        EPerpsSizeInputMode.SLIDER
+      ) {
+        const sliderPercent = Number.isFinite(formData.sizePercent)
+          ? Math.max(0, Math.min(100, formData.sizePercent ?? 0))
+          : 0;
+        return maxPositionSizeBN
+          .multipliedBy(sliderPercent)
+          .dividedBy(100)
+          .decimalPlaces(spotSzDecimals, BigNumber.ROUND_FLOOR);
+      }
+      const manualBN = new BigNumber(sanitizeManualSize(formData.size));
+      return manualBN.isFinite() && manualBN.gte(0)
+        ? manualBN.decimalPlaces(spotSzDecimals, BigNumber.ROUND_FLOOR)
+        : new BigNumber(0);
+    }
     return resolveTradingSizeBN({
       sizeInputMode: formData.sizeInputMode ?? EPerpsSizeInputMode.MANUAL,
       manualSize: formData.size,
@@ -168,6 +287,9 @@ export function useTradingCalculationsForSide(side: 'long' | 'short') {
     activeAssetData?.leverage?.value,
     activeAsset?.universe?.maxLeverage,
     activeAsset?.universe?.szDecimals,
+    isSpot,
+    maxPositionSizeBN,
+    spotSzDecimals,
   ]);
 
   const orderValue = useMemo(
@@ -181,6 +303,31 @@ export function useTradingCalculationsForSide(side: 'long' | 'short') {
   );
 
   const isNoEnoughMargin = useMemo(() => {
+    if (isSpot) {
+      const isSlider =
+        (formData.sizeInputMode ?? EPerpsSizeInputMode.MANUAL) ===
+        EPerpsSizeInputMode.SLIDER;
+      if (
+        isSlider &&
+        (formData.sizePercent ?? 0) > 0 &&
+        computedSizeForSide.lte(0)
+      ) {
+        return true;
+      }
+      if (
+        !computedSizeForSide.isFinite() ||
+        computedSizeForSide.lte(0) ||
+        !effectivePriceBN.isFinite() ||
+        effectivePriceBN.lte(0)
+      ) {
+        return false;
+      }
+      if (side === 'long') {
+        return orderValue.isFinite() && orderValue.gt(spotAvailableQuoteBN);
+      }
+      return computedSizeForSide.gt(spotAvailableBaseBN);
+    }
+
     // Trigger orders do not lock margin at placement time (HL checks margin
     // only when the trigger fires). Reduce-only triggers need no margin at all.
     if (formData.orderMode === 'trigger') {
@@ -227,6 +374,11 @@ export function useTradingCalculationsForSide(side: 'long' | 'short') {
     formData.orderMode,
     formData.sizeInputMode,
     formData.sizePercent,
+    isSpot,
+    orderValue,
+    side,
+    spotAvailableBaseBN,
+    spotAvailableQuoteBN,
   ]);
 
   return {

--- a/packages/kit/src/views/Perp/hooks/useTradingPrice.ts
+++ b/packages/kit/src/views/Perp/hooks/useTradingPrice.ts
@@ -2,11 +2,12 @@ import { useMemo } from 'react';
 
 import { BigNumber } from 'bignumber.js';
 
-import { usePerpsAllMidsAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
-  usePerpsActiveAssetAtom,
-  usePerpsActiveAssetCtxAtom,
-} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+  useActiveTradeInstrumentAtom,
+  usePerpsAllMidsAtom,
+} from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import { usePerpsActiveAssetCtxAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { useSpotActiveAssetCtxAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/spot';
 
 export interface IUseTradingPriceReturn {
   midPrice: string | undefined;
@@ -16,11 +17,12 @@ export interface IUseTradingPriceReturn {
 
 export function useTradingPrice(): IUseTradingPriceReturn {
   const [allMids] = usePerpsAllMidsAtom();
-  const [activeAsset] = usePerpsActiveAssetAtom();
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const [activeAssetCtx] = usePerpsActiveAssetCtxAtom();
+  const [activeSpotAssetCtx] = useSpotActiveAssetCtxAtom();
 
   const result = useMemo<IUseTradingPriceReturn>(() => {
-    const coin = activeAsset?.coin;
+    const coin = activeTradeInstrument?.coin;
     if (!coin) {
       return {
         midPrice: undefined,
@@ -29,9 +31,12 @@ export function useTradingPrice(): IUseTradingPriceReturn {
       };
     }
 
-    // Priority 1: Use activeAssetCtx.ctx.midPrice (higher update frequency for active token)
-    // Priority 2: Fallback to allMids (lower frequency but covers all tokens)
-    const midPrice = activeAssetCtx?.ctx?.midPrice || allMids?.mids?.[coin];
+    const midPrice =
+      activeTradeInstrument.mode === 'spot'
+        ? activeSpotAssetCtx?.ctx?.midPrice ||
+          activeSpotAssetCtx?.ctx?.markPrice ||
+          allMids?.mids?.[coin]
+        : activeAssetCtx?.ctx?.midPrice || allMids?.mids?.[coin];
 
     if (!midPrice) {
       return {
@@ -49,7 +54,13 @@ export function useTradingPrice(): IUseTradingPriceReturn {
       midPriceBN,
       isValid,
     };
-  }, [activeAssetCtx?.ctx?.midPrice, allMids?.mids, activeAsset?.coin]);
+  }, [
+    activeAssetCtx?.ctx?.midPrice,
+    activeSpotAssetCtx?.ctx?.markPrice,
+    activeSpotAssetCtx?.ctx?.midPrice,
+    allMids?.mids,
+    activeTradeInstrument,
+  ]);
 
   return result;
 }

--- a/packages/kit/src/views/Perp/layouts/PerpMobileLayout.tsx
+++ b/packages/kit/src/views/Perp/layouts/PerpMobileLayout.tsx
@@ -25,6 +25,7 @@ import {
 } from '../../../states/jotai/contexts/hyperliquid/atoms';
 import { PerpOpenOrdersList } from '../components/OrderInfoPanel/List/PerpOpenOrdersList';
 import { PerpPositionsList } from '../components/OrderInfoPanel/List/PerpPositionsList';
+import { SpotBalanceList } from '../components/OrderInfoPanel/List/SpotBalanceList';
 import { PerpMobileNetworkAlert } from '../components/PerpMobileNetworkAlert';
 import { PerpOrderBook } from '../components/PerpOrderBook';
 import { PerpTips } from '../components/PerpTips';
@@ -34,6 +35,7 @@ import { PerpTradingPanel } from '../components/TradingPanel/PerpTradingPanel';
 export enum ETabName {
   Positions = 'Positions',
   OpenOrders = 'OpenOrders',
+  Balances = 'Balances',
   SwapProOpenOrders = 'SwapProOpenOrders',
   SwapOrderHistory = 'SwapOrderHistory',
 }
@@ -42,11 +44,13 @@ const tabNameToTranslationKey: Record<
   ETabName,
   | ETranslations.perp_position_title
   | ETranslations.perp_open_orders_title
+  | ETranslations.global_balance
   | ETranslations.Limit_open_order
   | ETranslations.Limit_order_history
 > = {
   [ETabName.Positions]: ETranslations.perp_position_title,
   [ETabName.OpenOrders]: ETranslations.perp_open_orders_title,
+  [ETabName.Balances]: ETranslations.global_balance,
   [ETabName.SwapProOpenOrders]: ETranslations.Limit_open_order,
   [ETabName.SwapOrderHistory]: ETranslations.Limit_order_history,
 };
@@ -180,6 +184,11 @@ export function PerpMobileLayout() {
             onPress={setActiveTab}
             tabCount={openOrdersTabCount}
           />
+          <TabBarItem
+            name={ETabName.Balances}
+            isFocused={activeTab === ETabName.Balances}
+            onPress={setActiveTab}
+          />
         </XStack>
         <IconButton
           variant="tertiary"
@@ -206,6 +215,12 @@ export function PerpMobileLayout() {
           flex={1}
         >
           <PerpOpenOrdersList isMobile useTabsList={false} disableListScroll />
+        </YStack>
+        <YStack
+          display={activeTab === ETabName.Balances ? 'flex' : 'none'}
+          flex={1}
+        >
+          <SpotBalanceList isMobile useTabsList={false} disableListScroll />
         </YStack>
       </YStack>
     </ScrollView>

--- a/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
+++ b/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
@@ -14,7 +14,7 @@ import {
   isNativeTablet,
   useIsSplitView,
 } from '@onekeyhq/components';
-import { usePerpsActiveAssetAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { useActiveTradeInstrumentAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -23,15 +23,13 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
-import {
-  getHyperliquidTokenImageUrl,
-  parseDexCoin,
-} from '@onekeyhq/shared/src/utils/perpsUtils';
+import { getHyperliquidTokenImageUrl } from '@onekeyhq/shared/src/utils/perpsUtils';
 
 import { Token } from '../../../components/Token';
 import useAppNavigation from '../../../hooks/useAppNavigation';
 import { useMobileTabTouchScrollBridge } from '../../../hooks/useMobileTabTouchScrollBridge';
 import { useThemeVariant } from '../../../hooks/useThemeVariant';
+import { useActiveTradeDisplay } from '../hooks/useActiveTradeDisplay';
 import { PerpCandles } from '../components/PerpCandles';
 import PerpMarketFooter from '../components/PerpMarketFooter';
 import { PerpOrderBook } from '../components/PerpOrderBook';
@@ -55,8 +53,8 @@ function MobilePerpCandlesTouchBridge() {
 
 function MobilePerpMarket() {
   const intl = useIntl();
-  const [currentToken] = usePerpsActiveAssetAtom();
-  const { coin } = currentToken;
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
+  const { baseName, displayName, mode } = useActiveTradeDisplay();
   const themeVariant = useThemeVariant();
   const navigation = useAppNavigation();
 
@@ -71,9 +69,12 @@ function MobilePerpMarket() {
   }, [navigation]);
 
   const renderHeaderTitle = useCallback(() => {
-    const parsedCoin = coin ? parseDexCoin(coin) : null;
-    const displayCoin = parsedCoin?.displayName || coin || '';
-    const pairLabel = displayCoin ? `${displayCoin}USDC` : '--';
+    const pairLabel =
+      mode === 'spot'
+        ? displayName || '--'
+        : displayName
+          ? `${displayName}USDC`
+          : '--';
     return (
       <XStack alignItems="center" gap="$2">
         <NavBackButton
@@ -94,23 +95,33 @@ function MobilePerpMarket() {
             borderRadius="$full"
             bg={themeVariant === 'light' ? undefined : '$bgInverse'}
             tokenImageUri={
-              displayCoin ? getHyperliquidTokenImageUrl(displayCoin) : undefined
+              baseName ? getHyperliquidTokenImageUrl(baseName) : undefined
             }
             fallbackIcon="CryptoCoinOutline"
           />
           <SizableText size="$headingLg">{pairLabel}</SizableText>
           <Badge radius="$1" bg="$bgSubdued" px="$1" py={0}>
             <SizableText color="$textSubdued" fontSize={11}>
-              {intl.formatMessage({
-                id: ETranslations.perp_label_perp,
-              })}
+              {mode === 'spot'
+                ? 'Spot'
+                : intl.formatMessage({
+                    id: ETranslations.perp_label_perp,
+                  })}
             </SizableText>
           </Badge>
           <Icon name="ChevronDownSmallOutline" size="$4" color="$iconSubdued" />
         </XStack>
       </XStack>
     );
-  }, [coin, themeVariant, onPressTokenSelector, onPageGoBack, intl]);
+  }, [
+    baseName,
+    displayName,
+    mode,
+    onPageGoBack,
+    onPressTokenSelector,
+    themeVariant,
+    intl,
+  ]);
 
   const isTablet = isNativeTablet();
   const isLandscape = useIsSplitView();
@@ -126,8 +137,14 @@ function MobilePerpMarket() {
   }, [isLandscape, isTablet]);
 
   const renderHeaderRight = useCallback(
-    () => <FavoriteButton coin={coin} iconSize="$5" />,
-    [coin],
+    () => (
+      <FavoriteButton
+        coin={activeTradeInstrument.coin}
+        iconSize="$5"
+        isSpot={mode === 'spot'}
+      />
+    ),
+    [activeTradeInstrument.coin, mode],
   );
 
   const pageHeader = useMemo(

--- a/packages/kit/src/views/Perp/utils/subscriptionPlanner.ts
+++ b/packages/kit/src/views/Perp/utils/subscriptionPlanner.ts
@@ -1,0 +1,47 @@
+import type { IPerpsActiveOrderBookOptionsAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/perps';
+import type {
+  IActiveTradeInstrument,
+  ITradeRouteViewState,
+} from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+
+export interface ITradeSubscriptionPlan {
+  enableLedgerUpdates: boolean;
+  shouldSyncSubscriptions: boolean;
+  spotAssetCtxsEnabled: boolean;
+  spotEnabled: boolean;
+}
+
+export function planTradeSubscriptions(params: {
+  activeInstrument: IActiveTradeInstrument;
+  hasAccount: boolean;
+  orderBookOptions?: IPerpsActiveOrderBookOptionsAtom;
+  viewState: ITradeRouteViewState;
+}): ITradeSubscriptionPlan {
+  const { activeInstrument, hasAccount, orderBookOptions, viewState } = params;
+  const instrumentCoin = activeInstrument?.coin ?? '';
+  const isSpot = activeInstrument?.mode === 'spot';
+
+  const spotEnabled =
+    hasAccount && (isSpot || viewState.infoPanelTab === 'Balances');
+  const spotAssetCtxsEnabled =
+    isSpot || (viewState.tokenSelectorOpen && viewState.tokenSelectorTab === 'spot');
+  const enableLedgerUpdates =
+    hasAccount && viewState.infoPanelTab === 'Account';
+
+  let shouldSyncSubscriptions = false;
+  if (viewState.routeFocused) {
+    if (isSpot) {
+      shouldSyncSubscriptions = Boolean(instrumentCoin);
+    } else {
+      shouldSyncSubscriptions =
+        Boolean(instrumentCoin) && orderBookOptions?.coin === instrumentCoin;
+    }
+  }
+
+  return {
+    enableLedgerUpdates,
+    shouldSyncSubscriptions,
+    spotAssetCtxsEnabled,
+    spotEnabled,
+  };
+}

--- a/packages/shared/src/logger/scopes/perp/scenes/hyperliquid.ts
+++ b/packages/shared/src/logger/scopes/perp/scenes/hyperliquid.ts
@@ -261,6 +261,7 @@ export class HyperLiquidScene extends BaseScene {
 
 export type IHyperLiquidOrderAction =
   | 'placeOrder'
+  | 'placeSpotOrder'
   | 'orderOpen'
   | 'orderTrigger'
   | 'ordersClose'

--- a/packages/shared/src/utils/perpsUtils.ts
+++ b/packages/shared/src/utils/perpsUtils.ts
@@ -1647,6 +1647,13 @@ export {
   getTriggerEffectivePrice,
   getValidSpotPriceDecimals,
   formatSpotPriceToValid,
+  formatSpotAssetCtx,
+  isSpotInstrument,
+  getSpotTokenDisplayName,
+  formatSpotPairDisplayName,
+  filterSpotTokensStrict,
+  SPOT_TOKEN_DISPLAY_MAP,
+  SPOT_MIN_VOLUME_STRICT,
 };
 export default {
   formatAssetCtx,

--- a/packages/shared/src/utils/perpsUtils.ts
+++ b/packages/shared/src/utils/perpsUtils.ts
@@ -9,6 +9,7 @@ import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import type {
   EPerpsSizeInputMode,
   IPerpsFormattedAssetCtx,
+  ISpotFormattedAssetCtx,
 } from '@onekeyhq/shared/types/hyperliquid';
 import {
   MAX_DECIMALS_PERP,
@@ -18,6 +19,7 @@ import {
 import type {
   IPerpsAssetCtx,
   IPerpsUniverse,
+  ISpotAssetCtx,
   IWsActiveAssetCtx,
 } from '@onekeyhq/shared/types/hyperliquid/sdk';
 import { ETriggerOrderType } from '@onekeyhq/shared/types/hyperliquid/types';
@@ -1448,6 +1450,102 @@ export function formatChartUsdPrice(price: number): string {
   return `${sign}$${abs.toFixed(2)}`;
 }
 
+// ── Spot Asset Context Formatter ──
+
+function formatSpotAssetCtx(
+  spotCtx: ISpotAssetCtx | null,
+): ISpotFormattedAssetCtx {
+  const midPrice = spotCtx?.midPx || '0';
+  const markPrice = spotCtx?.markPx || '0';
+  const prevDayPrice = spotCtx?.prevDayPx || '0';
+  const priceDecimals = getValidPriceDecimals(markPrice);
+
+  const markPriceBN = new BigNumber(markPrice);
+  const prevDayPriceBN = new BigNumber(prevDayPrice);
+  const change24hBN = markPriceBN.minus(prevDayPriceBN);
+
+  const change24h = change24hBN.toFixed(priceDecimals);
+  const change24hPercent = prevDayPriceBN.isZero()
+    ? 0
+    : change24hBN.dividedBy(prevDayPriceBN).multipliedBy(100).toNumber();
+
+  return {
+    midPrice,
+    markPrice,
+    prevDayPrice,
+    volume24h: spotCtx?.dayNtlVlm || '0',
+    change24h,
+    change24hPercent,
+    circulatingSupply: spotCtx?.circulatingSupply || '0',
+    totalSupply: spotCtx?.totalSupply || '0',
+    dayBaseVlm: spotCtx?.dayBaseVlm || '0',
+  };
+}
+
+// ── Spot Token Utils ──
+
+const SPOT_TOKEN_DISPLAY_MAP: Record<string, string> = {
+  UBTC: 'BTC',
+  UETH: 'ETH',
+  USOL: 'SOL',
+  UFART: 'FARTCOIN',
+  UBONK: 'BONK',
+  UPUMP: 'PUMP',
+  UENA: 'ENA',
+  UXPL: 'XPL',
+  UZEC: 'ZEC',
+  UMON: 'MON',
+  UUUSPX: 'SPX',
+  UDOGE: 'DOGE',
+  UMOG: 'MOG',
+  UWLD: 'WLD',
+  UMEGA: 'MEGA',
+  UVIRT: 'VIRTUAL',
+  USPYX: 'SPYX',
+  UDZ: 'DZ',
+  LINK0: 'LINK',
+  AAVE0: 'AAVE',
+  AVAX0: 'AVAX',
+  BNB0: 'BNB',
+  CFX0: 'CFX',
+  PEPE0: 'PEPE',
+  TRX0: 'TRX',
+  USDT0: 'USDT',
+  XAUT0: 'XAUT',
+  HPENGU: 'PENGU',
+  HPEPE: 'PEPE',
+  FXRP: 'XRP',
+  XMR1: 'XMR',
+  HBNB: 'BNB',
+  HSEI: 'SEI',
+};
+
+function getSpotTokenDisplayName(rawName: string): string {
+  return SPOT_TOKEN_DISPLAY_MAP[rawName] ?? rawName;
+}
+
+function formatSpotPairDisplayName(
+  baseName: string,
+  quoteName: string,
+): string {
+  return `${getSpotTokenDisplayName(baseName)}/${quoteName}`;
+}
+
+function isSpotInstrument(coin?: string | null): boolean {
+  if (!coin) return false;
+  return coin.startsWith('@') || coin.includes('/');
+}
+
+const SPOT_MIN_VOLUME_STRICT = 10;
+
+function filterSpotTokensStrict(
+  tokens: Array<{ dayNtlVlm: number; midPx: boolean }>,
+): Array<{ dayNtlVlm: number; midPx: boolean }> {
+  return tokens.filter(
+    (t) => t.dayNtlVlm >= SPOT_MIN_VOLUME_STRICT && t.midPx,
+  );
+}
+
 export {
   formatAssetCtx,
   formatLargeNumber,
@@ -1520,4 +1618,11 @@ export default {
   formatPerpsCompactUsd,
   getPerpsValueColor,
   formatChartUsdPrice,
+  formatSpotAssetCtx,
+  isSpotInstrument,
+  getSpotTokenDisplayName,
+  formatSpotPairDisplayName,
+  filterSpotTokensStrict,
+  SPOT_TOKEN_DISPLAY_MAP,
+  SPOT_MIN_VOLUME_STRICT,
 };

--- a/packages/shared/src/utils/perpsUtils.ts
+++ b/packages/shared/src/utils/perpsUtils.ts
@@ -13,6 +13,7 @@ import type {
 } from '@onekeyhq/shared/types/hyperliquid';
 import {
   MAX_DECIMALS_PERP,
+  MAX_DECIMALS_SPOT,
   MAX_PRICE_INTEGER_DIGITS,
   MAX_SIGNIFICANT_FIGURES,
 } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
@@ -515,6 +516,72 @@ function validatePriceInput(input: string, szDecimals = 2): boolean {
  * @param szDecimals - Optional asset's szDecimals for precision limiting
  * @returns Formatted price string suitable for display
  */
+/**
+ * Get valid decimal places for a spot price
+ *
+ * HyperLiquid spot prices follow: maxDecimals = MAX_DECIMALS_SPOT - szDecimals
+ * with up to MAX_SIGNIFICANT_FIGURES significant figures.
+ */
+function getValidSpotPriceDecimals(
+  marketPrice: string | number,
+  szDecimals: number,
+): number {
+  const price = new BigNumber(marketPrice);
+
+  if (!price.isFinite() || price.isLessThanOrEqualTo(0)) {
+    return 2;
+  }
+
+  const maxDecimals = MAX_DECIMALS_SPOT - szDecimals;
+
+  if (price.isInteger()) {
+    return 0;
+  }
+
+  const priceStr = price.toFixed();
+  const decimalIndex = priceStr.indexOf('.');
+
+  if (decimalIndex === -1) {
+    return 0;
+  }
+
+  const actualDecimals = priceStr.length - decimalIndex - 1;
+  const significantFigures = _countSignificantFigures(price);
+
+  let maxAllowedDecimals = Math.min(actualDecimals, maxDecimals);
+
+  if (significantFigures > MAX_SIGNIFICANT_FIGURES) {
+    const integerPart = price.integerValue(BigNumber.ROUND_DOWN);
+    const integerDigits = integerPart.isZero()
+      ? 0
+      : integerPart.toFixed().length;
+    maxAllowedDecimals = Math.min(
+      maxAllowedDecimals,
+      Math.max(0, MAX_SIGNIFICANT_FIGURES - integerDigits),
+    );
+  }
+
+  return maxAllowedDecimals;
+}
+
+/**
+ * Format a spot price to a valid string according to HyperLiquid rules
+ */
+function formatSpotPriceToValid(
+  marketPrice: string | number,
+  szDecimals: number,
+): string {
+  const price = new BigNumber(marketPrice);
+
+  if (!price.isFinite() || price.isLessThanOrEqualTo(0)) {
+    return '0';
+  }
+
+  const validDecimals = getValidSpotPriceDecimals(marketPrice, szDecimals);
+
+  return price.toFixed(validDecimals).replace(/\.?0+$/, '');
+}
+
 function formatPriceToSignificantDigits(
   price: number | string | BigNumber | undefined,
   szDecimals?: number,
@@ -1578,6 +1645,8 @@ export {
   mapTriggerOrderType,
   inferTpsl,
   getTriggerEffectivePrice,
+  getValidSpotPriceDecimals,
+  formatSpotPriceToValid,
 };
 export default {
   formatAssetCtx,
@@ -1625,4 +1694,6 @@ export default {
   filterSpotTokensStrict,
   SPOT_TOKEN_DISPLAY_MAP,
   SPOT_MIN_VOLUME_STRICT,
+  getValidSpotPriceDecimals,
+  formatSpotPriceToValid,
 };

--- a/packages/shared/src/utils/perpsUtils.ts
+++ b/packages/shared/src/utils/perpsUtils.ts
@@ -579,7 +579,13 @@ function formatSpotPriceToValid(
 
   const validDecimals = getValidSpotPriceDecimals(marketPrice, szDecimals);
 
-  return price.toFixed(validDecimals).replace(/\.?0+$/, '');
+  // Strip trailing zeros ONLY after the decimal point (e.g. "60.100" → "60.1").
+  // Do NOT strip trailing zeros from integers (e.g. "60000" must stay "60000").
+  const fixed = price.toFixed(validDecimals);
+  if (fixed.includes('.')) {
+    return fixed.replace(/0+$/, '').replace(/\.$/, '');
+  }
+  return fixed;
 }
 
 function formatPriceToSignificantDigits(

--- a/packages/shared/types/hyperliquid/perp.constants.ts
+++ b/packages/shared/types/hyperliquid/perp.constants.ts
@@ -1,6 +1,7 @@
 import type { IHex } from './sdk';
 
 export const MAX_DECIMALS_PERP = 6;
+export const MAX_DECIMALS_SPOT = 8;
 export const MAX_SIGNIFICANT_FIGURES = 5;
 export const MAX_PRICE_INTEGER_DIGITS = 12;
 

--- a/packages/shared/types/hyperliquid/perp.constants.ts
+++ b/packages/shared/types/hyperliquid/perp.constants.ts
@@ -40,6 +40,9 @@ export const XYZ_DEX_PREFIX = `${DEX_PREFIXES[0]}${DEX_SEPARATOR}`;
 export const XYZ_ASSET_ID_OFFSET = 110_000;
 export const XYZ_ASSET_ID_LENGTH = `${XYZ_ASSET_ID_OFFSET}`.length;
 
+// Hyperliquid spot assetId = SPOT_ASSET_ID_OFFSET + spotUniverse.index
+export const SPOT_ASSET_ID_OFFSET = 10_000;
+
 // Token Selector default values
 export const DEFAULT_PERP_TOKEN_SORT_FIELD = 'volume24h';
 export const DEFAULT_PERP_TOKEN_SORT_DIRECTION = 'desc';

--- a/packages/shared/types/hyperliquid/perp.constants.ts
+++ b/packages/shared/types/hyperliquid/perp.constants.ts
@@ -43,6 +43,10 @@ export const XYZ_ASSET_ID_LENGTH = `${XYZ_ASSET_ID_OFFSET}`.length;
 // Hyperliquid spot assetId = SPOT_ASSET_ID_OFFSET + spotUniverse.index
 export const SPOT_ASSET_ID_OFFSET = 10_000;
 
+// Quantize Date.now() to this window so near-simultaneous callers
+// produce identical memoizee cache keys (e.g. loadTradesHistory).
+export const CACHE_TIME_QUANTIZE_MS = 10_000;
+
 // Token Selector default values
 export const DEFAULT_PERP_TOKEN_SORT_FIELD = 'volume24h';
 export const DEFAULT_PERP_TOKEN_SORT_DIRECTION = 'desc';

--- a/packages/shared/types/hyperliquid/sdk.ts
+++ b/packages/shared/types/hyperliquid/sdk.ts
@@ -15,10 +15,15 @@ export type IWsAllDexsClearinghouseState = HL.AllDexsClearinghouseStateWsEvent;
 export type IWsAllDexsAssetCtxs = HL.AllDexsAssetCtxsWsEvent;
 export type IWsBbo = HL.BboWsEvent;
 
-// Spot state types
+// Spot WebSocket event types
 export type IWsSpotState = HL.SpotStateWsEvent;
+export type IWsSpotAssetCtxs = HL.SpotAssetCtxsWsEvent;
+export type IWsActiveSpotAssetCtx = HL.ActiveSpotAssetCtxWsEvent;
 export type ISpotBalance = IWsSpotState['spotState']['balances'][number];
 export type IEventSpotStateParameters = HL.SpotStateWsParameters;
+export type IEventSpotAssetCtxsParameters = Record<string, never>;
+export type IEventActiveSpotAssetCtxParameters =
+  HL.ActiveSpotAssetCtxWsParameters;
 
 // Abstraction query types
 export type IUserAbstractionResponse = HL.UserAbstractionResponse;
@@ -56,6 +61,22 @@ export type IPerpsActiveAssetData = Omit<IActiveAssetData, 'user'> & {
   assetId: number | undefined;
 };
 export type IAllPerpMetasResponse = HL.AllPerpMetasResponse;
+
+// Spot info types
+export type ISpotMetaResponse = HL.SpotMetaResponse;
+export type ISpotMetaAndAssetCtxsResponse = HL.SpotMetaAndAssetCtxsResponse;
+export type ISpotClearinghouseStateResponse = HL.SpotClearinghouseStateResponse;
+export type ISpotToken = ISpotMetaResponse['tokens'][number];
+export type ISpotUniverseRaw = ISpotMetaResponse['universe'][number];
+export type ISpotUniverse = ISpotUniverseRaw & {
+  assetId: number;
+  baseName: string;
+  quoteName: string;
+  displayName: string;
+  baseSzDecimals: number;
+};
+export type ISpotAssetCtx = IWsSpotAssetCtxs[number];
+
 export type IMarginTable = HL.MarginTableResponse;
 export type IMarginTableMap = Partial<Record<number, IMarginTable>>;
 
@@ -147,6 +168,8 @@ export type IPerpsSubscriptionParams = {
   [ESubscriptionType.ALL_DEXS_ASSET_CTXS]: IEventAllDexsAssetCtxsParameters;
   [ESubscriptionType.TWAP_STATES]: IEventTwapStatesParameters;
   [ESubscriptionType.SPOT_STATE]: IEventSpotStateParameters;
+  [ESubscriptionType.SPOT_ASSET_CTXS]: IEventSpotAssetCtxsParameters;
+  [ESubscriptionType.ACTIVE_SPOT_ASSET_CTX]: IEventActiveSpotAssetCtxParameters;
 };
 
 export type IWebSocketTransportOptions = HL.WebSocketTransportOptions;

--- a/packages/shared/types/hyperliquid/types.ts
+++ b/packages/shared/types/hyperliquid/types.ts
@@ -177,7 +177,8 @@ export interface ITriggerOrderParams {
 }
 
 export interface ISpotOrderParams {
-  assetId: number; // 10000 + spotIndex
+  // Spot assetId = SPOT_ASSET_ID_OFFSET + spotUniverse.index
+  assetId: number;
   isBuy: boolean;
   sz: string;
   limitPx: string;

--- a/packages/shared/types/hyperliquid/types.ts
+++ b/packages/shared/types/hyperliquid/types.ts
@@ -1,6 +1,6 @@
 import type { IPerpServerBannerConfig } from '@onekeyhq/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp';
 
-import type { IHex, IWithdraw3Request } from './sdk';
+import type { IFill, IHex, IWithdraw3Request } from './sdk';
 import type { EHyperLiquidAgentName } from '../../src/consts/perp';
 
 export enum EPerpsSubscriptionCategory {
@@ -24,6 +24,8 @@ export enum ESubscriptionType {
   TWAP_STATES = 'twapStates',
   BBO = 'bbo',
   SPOT_STATE = 'spotState',
+  SPOT_ASSET_CTXS = 'spotAssetCtxs',
+  ACTIVE_SPOT_ASSET_CTX = 'activeSpotAssetCtx',
   // TRADES = 'trades',
   // USER_EVENTS = 'userEvents',
   // USER_NOTIFICATIONS = 'userNotifications',
@@ -174,6 +176,17 @@ export interface ITriggerOrderParams {
   slippage?: number;
 }
 
+export interface ISpotOrderParams {
+  assetId: number; // 10000 + spotIndex
+  isBuy: boolean;
+  sz: string;
+  limitPx: string;
+  orderType: 'limit' | 'market';
+  tif?: 'Gtc' | 'Ioc';
+  slippage?: number;
+  szDecimals?: number;
+}
+
 export interface IL2BookOptions {
   nSigFigs?: 2 | 3 | 4 | 5 | null;
   mantissa?: 2 | 5 | null;
@@ -276,4 +289,39 @@ export enum EHyperLiquidAbstractionMode {
   PORTFOLIO_MARGIN = 'portfolioMargin',
   DEX_ABSTRACTION = 'dexAbstraction',
   DEFAULT = 'default',
+}
+
+// ── Shared Types ──
+
+export interface ITradesHistoryData {
+  fills: IFill[];
+  isLoaded: boolean;
+  latestTime: number;
+  accountAddress: string | undefined;
+}
+
+// ── Spot Types ──
+
+export type ISpotFormattedAssetCtx = {
+  midPrice: string;
+  markPrice: string;
+  prevDayPrice: string;
+  volume24h: string;
+  change24h: string;
+  change24hPercent: number;
+  circulatingSupply: string;
+  totalSupply: string;
+  dayBaseVlm: string;
+};
+
+export type ISpotTokenSortField =
+  | 'name'
+  | 'markPrice'
+  | 'change24hPercent'
+  | 'volume24h';
+
+export interface ISpotTokenSelectorConfig {
+  field: ISpotTokenSortField;
+  direction: IPerpTokenSortDirection;
+  activeTab: 'all' | 'favorites' | string;
 }


### PR DESCRIPTION
## Summary
- Make spot balances actionable by wiring spot metadata into the balances list and allowing direct asset switching from the Balance panel.
- Add spot market metadata to the ticker/header, including market cap and contract address with copy support.
- Align the desktop balance asset label weight with the existing positions visual treatment.

## Intent & Context
These changes were made to improve the spot trading experience inside the perps/spot hybrid screen. The goal was to make the Balance panel more useful as an entry point into spot assets, and to expose the same kind of market metadata traders expect to see when switching symbols.

## Root Cause
Spot metadata was being fetched ad hoc in multiple places, and the Balance panel rows did not have enough mapped metadata to support direct navigation or contract display. As a result, balances were passive rows, and spot ticker/header surfaces were missing contract-level context.

## Design Decisions
A dedicated `useSpotMetaMaps` hook was introduced to centralize spot universe and contract-address lookups instead of duplicating local mapping logic in each component.
The Balance list now keeps both the raw spot token name and the resolved universe metadata so clicking a balance row can switch the active spot asset without extra async lookups at click time.
For spot ticker surfaces, market cap is shown instead of open interest, because open interest is not the right metric for spot markets.

## Changes Detail
- Update the spot balance list to derive raw token metadata, contract addresses, and clickability from shared spot meta maps.
- Update balance row rendering so clickable spot assets use the expected emphasis and route to the selected spot market.
- Add reusable spot meta mapping logic through `useSpotMetaMaps`.
- Add contract address display and copy actions to both the mobile header and desktop ticker bar.
- Add spot market cap to the desktop ticker bar.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile / Desktop / Web
- **Risk Areas**: Spot asset switching from the Balance panel, spot meta loading timing, spot ticker/header rendering

## Test plan
- [ ] Open the spot Balance panel and verify clickable spot assets switch to the correct selected market.
- [ ] Confirm `USDC` remains non-clickable when it should not navigate.
- [ ] Verify the desktop spot ticker shows Market Cap and Contract instead of perps-only metrics.
- [ ] Verify the mobile spot header shows the contract address and copy action.
- [ ] Confirm the desktop balance asset label weight matches the positions style.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
