### PR TITLE
fix(market): remove sharesPerToken field from stock info (OK-53084)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/hooks/useStockSecurityStats.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/hooks/useStockSecurityStats.ts
@@ -184,18 +184,6 @@ export function useStockSecurityStats(stock: IMarketStockInfo | undefined) {
         }),
         value: stock.underlyingAssetName ?? STAT_FALLBACK_VALUE,
       },
-      {
-        key: 'sharesPerToken',
-        label: intl.formatMessage({
-          id: ETranslations.dexmarket_stock_shares_per_token,
-        }),
-        tooltip: intl.formatMessage({
-          id: ETranslations.dexmarket_stock_shares_per_token_desc,
-        }),
-        value: stock.sharesPerToken
-          ? `${stock.sharesPerToken} ${stock.underlyingAssetTicker ?? ''}`.trim()
-          : STAT_FALLBACK_VALUE,
-      },
     ];
   }, [intl, stock]);
 

--- a/packages/shared/types/marketV2.ts
+++ b/packages/shared/types/marketV2.ts
@@ -151,7 +151,6 @@ export interface IMarketStockInfo {
   sharesOutstanding?: string;
   underlyingAssetTicker?: string;
   underlyingAssetName?: string;
-  sharesPerToken?: number;
 }
 
 export interface IMarketTokenListItem {


### PR DESCRIPTION
## Summary
- Remove `sharesPerToken` field from `IMarketStockInfo` type definition
- Remove "Shares per Token" row from stock security stats UI display

## Intent & Context
FMP API does not return the shares per token ratio. The field was hardcoded to 1, which caused user confusion as it didn't reflect actual data. Decision was made to remove the field entirely until the API provides real data.

## Changes Detail
- `packages/shared/types/marketV2.ts`: Removed `sharesPerToken?: number` from interface
- `packages/kit/src/views/Market/MarketDetailV2/hooks/useStockSecurityStats.ts`: Removed the stat row that displayed shares per token

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: None - simple removal of unused field and UI element

## Test plan
- [ ] Verify stock detail page loads without errors
- [ ] Confirm "Shares per Token" row is no longer displayed in stock security stats
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
