### PR TITLE
fix(address-book): lock routing fields (address/memo/note) in edit mode

### DIFF
--- a/packages/kit/src/views/AddressBook/components/CreateOrEditContent.tsx
+++ b/packages/kit/src/views/AddressBook/components/CreateOrEditContent.tsx
@@ -45,10 +45,12 @@ type ICreateOrEditContentProps = {
   title?: string;
   item: IAddressItem;
   isSubmitLoading?: boolean;
-  disabledAddressEdit?: boolean;
-  disabledMemoEdit?: boolean;
-  disabledNoteEdit?: boolean;
-  disabledNetworkEdit?: boolean;
+  // Lock every field that is part of the entry's routing identity (network,
+  // address, memo, note). `name` stays editable. Routing fields are immutable
+  // post-create because the cloud sync layer keys items by (networkImpl +
+  // address) and chains like XRP/Cosmos/Algorand treat memo/note as part of
+  // the destination.
+  lockRoutingFields?: boolean;
   onSubmit: (item: IAddressItem) => Promise<void>;
   onRemove?: (item: IAddressItem) => void;
   nameHistoryInfo?: {
@@ -83,10 +85,7 @@ export function CreateOrEditContent({
   onRemove,
   nameHistoryInfo,
   isSubmitLoading,
-  disabledAddressEdit,
-  disabledMemoEdit,
-  disabledNoteEdit,
-  disabledNetworkEdit,
+  lockRoutingFields,
 }: ICreateOrEditContentProps) {
   const intl = useIntl();
 
@@ -188,13 +187,13 @@ export function CreateOrEditContent({
           placeholder={intl.formatMessage({
             id: ETranslations.global_Note,
           })}
-          editable={!disabledNoteEdit}
+          editable={!lockRoutingFields}
         />
       </Form.Field>
     );
   }, [
-    disabledNoteEdit,
     intl,
+    lockRoutingFields,
     media.gtMd,
     vaultSettings?.noteMaxLength,
     vaultSettings?.withNote,
@@ -241,13 +240,13 @@ export function CreateOrEditContent({
           keyboardType={
             isNumericMemo && platformEnv.isNative ? 'number-pad' : undefined
           }
-          editable={!disabledMemoEdit}
+          editable={!lockRoutingFields}
         />
       </Form.Field>
     );
   }, [
-    disabledMemoEdit,
     intl,
+    lockRoutingFields,
     media.gtMd,
     validateMemoField,
     vaultSettings?.memoMaxLength,
@@ -278,7 +277,7 @@ export function CreateOrEditContent({
           >
             <ChainSelectorInput
               networkIds={addressBookEnabledNetworkIds}
-              disabled={disabledNetworkEdit}
+              disabled={lockRoutingFields}
             />
           </Form.Field>
           <Form.Field
@@ -380,7 +379,7 @@ export function CreateOrEditContent({
               placeholder={intl.formatMessage({
                 id: ETranslations.address_book_add_address_address,
               })}
-              editable={!disabledAddressEdit}
+              editable={!lockRoutingFields}
               autoError={false}
               testID="address-form-address"
               enableNameResolve

--- a/packages/kit/src/views/AddressBook/components/CreateOrEditContent.tsx
+++ b/packages/kit/src/views/AddressBook/components/CreateOrEditContent.tsx
@@ -47,6 +47,7 @@ type ICreateOrEditContentProps = {
   isSubmitLoading?: boolean;
   disabledAddressEdit?: boolean;
   disabledMemoEdit?: boolean;
+  disabledNoteEdit?: boolean;
   onSubmit: (item: IAddressItem) => Promise<void>;
   onRemove?: (item: IAddressItem) => void;
   nameHistoryInfo?: {
@@ -83,6 +84,7 @@ export function CreateOrEditContent({
   isSubmitLoading,
   disabledAddressEdit,
   disabledMemoEdit,
+  disabledNoteEdit,
 }: ICreateOrEditContentProps) {
   const intl = useIntl();
 
@@ -184,10 +186,17 @@ export function CreateOrEditContent({
           placeholder={intl.formatMessage({
             id: ETranslations.global_Note,
           })}
+          editable={!disabledNoteEdit}
         />
       </Form.Field>
     );
-  }, [intl, media.gtMd, vaultSettings?.noteMaxLength, vaultSettings?.withNote]);
+  }, [
+    disabledNoteEdit,
+    intl,
+    media.gtMd,
+    vaultSettings?.noteMaxLength,
+    vaultSettings?.withNote,
+  ]);
 
   const validateMemoField = useValidateMemoField({
     networkId,

--- a/packages/kit/src/views/AddressBook/components/CreateOrEditContent.tsx
+++ b/packages/kit/src/views/AddressBook/components/CreateOrEditContent.tsx
@@ -48,6 +48,7 @@ type ICreateOrEditContentProps = {
   disabledAddressEdit?: boolean;
   disabledMemoEdit?: boolean;
   disabledNoteEdit?: boolean;
+  disabledNetworkEdit?: boolean;
   onSubmit: (item: IAddressItem) => Promise<void>;
   onRemove?: (item: IAddressItem) => void;
   nameHistoryInfo?: {
@@ -85,6 +86,7 @@ export function CreateOrEditContent({
   disabledAddressEdit,
   disabledMemoEdit,
   disabledNoteEdit,
+  disabledNetworkEdit,
 }: ICreateOrEditContentProps) {
   const intl = useIntl();
 
@@ -274,7 +276,10 @@ export function CreateOrEditContent({
               ) : null
             }
           >
-            <ChainSelectorInput networkIds={addressBookEnabledNetworkIds} />
+            <ChainSelectorInput
+              networkIds={addressBookEnabledNetworkIds}
+              disabled={disabledNetworkEdit}
+            />
           </Form.Field>
           <Form.Field
             label={intl.formatMessage({

--- a/packages/kit/src/views/AddressBook/components/CreateOrEditContent.tsx
+++ b/packages/kit/src/views/AddressBook/components/CreateOrEditContent.tsx
@@ -46,6 +46,7 @@ type ICreateOrEditContentProps = {
   item: IAddressItem;
   isSubmitLoading?: boolean;
   disabledAddressEdit?: boolean;
+  disabledMemoEdit?: boolean;
   onSubmit: (item: IAddressItem) => Promise<void>;
   onRemove?: (item: IAddressItem) => void;
   nameHistoryInfo?: {
@@ -81,6 +82,7 @@ export function CreateOrEditContent({
   nameHistoryInfo,
   isSubmitLoading,
   disabledAddressEdit,
+  disabledMemoEdit,
 }: ICreateOrEditContentProps) {
   const intl = useIntl();
 
@@ -228,10 +230,12 @@ export function CreateOrEditContent({
           keyboardType={
             isNumericMemo && platformEnv.isNative ? 'number-pad' : undefined
           }
+          editable={!disabledMemoEdit}
         />
       </Form.Field>
     );
   }, [
+    disabledMemoEdit,
     intl,
     media.gtMd,
     validateMemoField,

--- a/packages/kit/src/views/AddressBook/pages/EditItem/index.tsx
+++ b/packages/kit/src/views/AddressBook/pages/EditItem/index.tsx
@@ -152,7 +152,7 @@ function EditItemPage() {
           ? ETranslations.address_book_add_address_title
           : ETranslations.address_book_edit_address_title,
       })}
-      disabledAddressEdit={false}
+      disabledAddressEdit={!isCreateMode}
       item={item}
       onSubmit={onSubmit}
       onRemove={isCreateMode ? undefined : onRemove}

--- a/packages/kit/src/views/AddressBook/pages/EditItem/index.tsx
+++ b/packages/kit/src/views/AddressBook/pages/EditItem/index.tsx
@@ -153,6 +153,7 @@ function EditItemPage() {
           : ETranslations.address_book_edit_address_title,
       })}
       disabledAddressEdit={!isCreateMode}
+      disabledMemoEdit={!isCreateMode}
       item={item}
       onSubmit={onSubmit}
       onRemove={isCreateMode ? undefined : onRemove}

--- a/packages/kit/src/views/AddressBook/pages/EditItem/index.tsx
+++ b/packages/kit/src/views/AddressBook/pages/EditItem/index.tsx
@@ -155,6 +155,7 @@ function EditItemPage() {
       disabledAddressEdit={!isCreateMode}
       disabledMemoEdit={!isCreateMode}
       disabledNoteEdit={!isCreateMode}
+      disabledNetworkEdit={!isCreateMode}
       item={item}
       onSubmit={onSubmit}
       onRemove={isCreateMode ? undefined : onRemove}

--- a/packages/kit/src/views/AddressBook/pages/EditItem/index.tsx
+++ b/packages/kit/src/views/AddressBook/pages/EditItem/index.tsx
@@ -152,10 +152,7 @@ function EditItemPage() {
           ? ETranslations.address_book_add_address_title
           : ETranslations.address_book_edit_address_title,
       })}
-      disabledAddressEdit={!isCreateMode}
-      disabledMemoEdit={!isCreateMode}
-      disabledNoteEdit={!isCreateMode}
-      disabledNetworkEdit={!isCreateMode}
+      lockRoutingFields={!isCreateMode}
       item={item}
       onSubmit={onSubmit}
       onRemove={isCreateMode ? undefined : onRemove}

--- a/packages/kit/src/views/AddressBook/pages/EditItem/index.tsx
+++ b/packages/kit/src/views/AddressBook/pages/EditItem/index.tsx
@@ -154,6 +154,7 @@ function EditItemPage() {
       })}
       disabledAddressEdit={!isCreateMode}
       disabledMemoEdit={!isCreateMode}
+      disabledNoteEdit={!isCreateMode}
       item={item}
       onSubmit={onSubmit}
       onRemove={isCreateMode ? undefined : onRemove}


### PR DESCRIPTION
## Summary

Lock three routing fields — **address / memo / note** — when editing an existing address book entry. All three remain editable in create mode.

## Jira

https://onekeyhq.atlassian.net/browse/OK-53212

## Why lock them

- **address**: Cloud sync keys entries by `(networkImpl + address)`, not by local uuid. Editing the address creates a duplicate record on other devices and can bypass the name uniqueness check. The lock existed originally and was accidentally relaxed in #10507 — this restores it.
- **memo**: On XRP / Cosmos / Stellar / TON / EOS / BNB Beacon, exchange deposit addresses are **shared across all users**, and the memo is the only field that routes funds to the right account. A wrong memo means lost funds.
- **note**: Algorand is the only chain in the repo with `withNote: true`. The note is written into on-chain transaction bytes and is used by Binance / Coinbase / KuCoin / OKX / Kraken as the destination tag for ALGO deposits.

memo and note don't have the sync-duplication bug — locking them is purely to prevent silent user error that loses funds.

## Behavior

| Mode   | name | address | memo | note |
|--------|------|---------|------|------|
| Create | ✅   | ✅      | ✅   | ✅   |
| Edit   | ✅   | 🔒      | 🔒   | 🔒   |

To "change" any locked field, the supported flow is delete + recreate.

## Test plan

- [ ] Create a new entry → address / memo / note are all editable
- [ ] Open an existing entry → address / memo / note are read-only; name still editable
- [ ] Rename an existing entry → no duplicate appears on a second logged-in device
- [ ] On an XRP / Cosmos / Stellar entry, memo is read-only in edit mode
- [ ] On an Algorand entry, note is read-only in edit mode