### PR TITLE
fix(swap): use swap direction token network for recipient picker (OK-53211)

### DIFF
--- a/packages/kit/src/views/Swap/hooks/useSwapAccount.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapAccount.ts
@@ -339,10 +339,11 @@ export function useSwapAddressInfo(type: ESwapDirectionType) {
         address: isAllNetwork
           ? accountForAllNet?.addressDetail?.address
           : activeAccount.account?.address,
-        networkId:
-          isAllNetwork && tokenNetworkId
-            ? tokenNetworkId
-            : activeAccount.network?.id,
+        // Always prefer the swap direction's token network. Falling back to
+        // activeAccount.network leaks the wrong chain (e.g. EVM) into the
+        // recipient picker when the TO-side account selector mirror has not
+        // yet caught up to a non-EVM target like Aptos / Solana / Cosmos.
+        networkId: tokenNetworkId || activeAccount.network?.id,
         activeAccount: {
           ...activeAccount,
           ...(activeAccount.account

--- a/packages/kit/src/views/Swap/hooks/useSwapAccount.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapAccount.ts
@@ -339,10 +339,8 @@ export function useSwapAddressInfo(type: ESwapDirectionType) {
         address: isAllNetwork
           ? accountForAllNet?.addressDetail?.address
           : activeAccount.account?.address,
-        // Always prefer the swap direction's token network. Falling back to
-        // activeAccount.network leaks the wrong chain (e.g. EVM) into the
-        // recipient picker when the TO-side account selector mirror has not
-        // yet caught up to a non-EVM target like Aptos / Solana / Cosmos.
+        // The TO-side account selector mirror lags the toToken on first open,
+        // so trust the token's network rather than the (possibly stale) slot.
         networkId: tokenNetworkId || activeAccount.network?.id,
         activeAccount: {
           ...activeAccount,


### PR DESCRIPTION
## Summary

Fixes [OK-53211](https://onekeyhq.atlassian.net/browse/OK-53211) — on a cross-chain swap from an EVM network into a non-EVM target (Aptos in the original report, but the bug is generic), the first time the user opens **Swap → Send to another address**, the recipient picker shows EVM addresses instead of addresses on the swap target network. Confirming one of those EVM entries fills in an address that the swap can never deliver to.

## Root cause

`useSwapAddressInfo(TO)` in `packages/kit/src/views/Swap/hooks/useSwapAccount.ts` returned the wrong `networkId`:

\`\`\`ts
networkId:
  isAllNetwork && tokenNetworkId
    ? tokenNetworkId
    : activeAccount.network?.id,
\`\`\`

The hook only used the swap-direction token's network when the account selector was in **all-network** mode. In every other case it returned `activeAccount.network?.id` — the account selector slot's currently materialized network.

`SwapToAnotherAddressModal` mounts inside a fresh `AccountSelectorProviderMirror` (scene `swap`, `enabledNum={[0, 1]}`). The TO slot (num: 1) is supposed to be kept in sync with `toToken.networkId` by `useSwapFromAccountNetworkSync`, but that sync hook:
- Only runs on the swap main page (it's debounced 100 ms and gated on tab focus / modal focus)
- Lives in the parent provider, not the modal's mirror
- So on first open, the modal's mirror reflects whatever the slot was when the modal mounted, which on a fresh EVM → Aptos cross-chain swap can still be EVM

The page then forwards the bogus \`networkId\` into both \`<AddressInputField networkId={networkId}>\` and \`<RecipientQuickSelect networkId={networkId}>\`, so all the addresses in the picker are filtered to the wrong chain.

## Fix

\`\`\`ts
networkId: tokenNetworkId || activeAccount.network?.id,
\`\`\`

Always derive `networkId` from the direction-specific token (`tokenNetworkId` is already computed at line 210-219 from `currentSelectNetwork?.networkId ?? toToken?.networkId` for `TO`, symmetric for `FROM`). `activeAccount.network?.id` is kept only as a defensive fallback when no token is selected yet.

## Why this isn't Aptos-specific

The same race triggers for **any** non-EVM swap target whenever the TO account selector mirror has not yet been re-synced — Solana, Cosmos, TRON, TON, Aptos, Sui, Move, BTC, etc. The single-line fix to the hook covers all of them in one place rather than patching each chain.

The FROM direction was incidentally correct in practice because `useSwapFromAccountNetworkSync` keeps slot 0 ≡ `fromToken.networkId` aggressively; the new code still produces the same value there, so this is not a behavior change for FROM.

## Test plan

- [ ] Cross-chain swap **EVM → Aptos**: open "send to another address". Account selector and address book picker show **Aptos** addresses, not EVM
- [ ] Cross-chain swap **EVM → Solana**: same expectation, Solana addresses only
- [ ] Cross-chain swap **EVM → Cosmos / TON / Sui / TRON**: same expectation
- [ ] Same-chain swap (e.g. ETH → USDC on Ethereum): unchanged behavior, EVM addresses
- [ ] All-network mode source account: unchanged behavior, the existing `isAllNetwork` path is preserved by the fallback
- [ ] Quote fetching, slippage, tx build: regression-check that nothing on the main swap page is affected (the FROM side was already correct due to the existing sync hook, and TO callers like `useSwapBuiltTx` / `useSwapQuote` also benefit from the more deterministic value)

[OK-53211]: https://onekeyhq.atlassian.net/browse/OK-53211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
