### PR TITLE
fix(market): hide extended stats columns for compact spot categories(OK-53080)

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/DesktopLayout.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/DesktopLayout.tsx
@@ -11,6 +11,10 @@ import { MarketPerpsTokenList } from '../components/MarketPerpsList';
 import { MarketNormalTokenList } from '../components/MarketTokenList/MarketNormalTokenList';
 import { MarketWatchlistTokenList } from '../components/MarketTokenList/MarketWatchlistTokenList';
 import { TimeRangeDropdown } from '../components/TimeRangeDropdown';
+import {
+  COMPACT_SPOT_HIDDEN_DESKTOP_COLUMNS,
+  shouldHideSpotExtendedStats,
+} from '../utils';
 
 import { DesktopStickyHeaderContext } from './DesktopStickyHeaderContext';
 import { useMarketTabsLogic } from './hooks';
@@ -163,6 +167,14 @@ export function DesktopLayout({
     return { paddingBottom: 0 };
   }, []);
 
+  const hiddenSpotDesktopColumns = useMemo(
+    () =>
+      shouldHideSpotExtendedStats(filterBarProps.selectedCategory)
+        ? COMPACT_SPOT_HIDDEN_DESKTOP_COLUMNS
+        : undefined,
+    [filterBarProps.selectedCategory],
+  );
+
   const stickyHeaderCtx = useMemo(
     () => ({ portalTarget, activeTabName }),
     [portalTarget, activeTabName],
@@ -200,6 +212,7 @@ export function DesktopLayout({
                 tabName={spotTabName}
                 listContainerProps={listContainerProps}
                 toolbar={<MarketFilterBar {...filterBarProps} />}
+                hiddenDesktopColumns={hiddenSpotDesktopColumns}
               />
             </YStack>
           </Tabs.Tab>

--- a/packages/kit/src/views/Market/MarketHomeV2/utils.test.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/utils.test.ts
@@ -1,5 +1,7 @@
 import {
+  COMPACT_SPOT_HIDDEN_DESKTOP_COLUMNS,
   parseValueToNumber,
+  shouldHideSpotExtendedStats,
   validateLiquidityInput,
   validateMaximumMinLiquidity,
 } from './utils';
@@ -321,5 +323,38 @@ describe('Maximum Minimum Liquidity Validation Tests', () => {
       const result = validateMaximumMinLiquidity(input);
       expect(result).toBe(should);
     });
+  });
+});
+
+describe('Spot Category Extended Stats Visibility Tests', () => {
+  test('keep extended stats for trending', () => {
+    expect(shouldHideSpotExtendedStats('trending')).toBe(false);
+  });
+
+  test('keep extended stats for x mentioned', () => {
+    expect(shouldHideSpotExtendedStats('x_mentioned')).toBe(false);
+  });
+
+  test('hide extended stats for AI and other thematic categories', () => {
+    expect(shouldHideSpotExtendedStats('ai')).toBe(true);
+    expect(shouldHideSpotExtendedStats('stock')).toBe(true);
+    expect(shouldHideSpotExtendedStats('metal')).toBe(true);
+  });
+
+  test('default category keeps extended stats visible', () => {
+    expect(shouldHideSpotExtendedStats()).toBe(false);
+  });
+
+  test('empty string category keeps extended stats visible', () => {
+    expect(shouldHideSpotExtendedStats('')).toBe(false);
+  });
+
+  test('compact spot columns match watchlist-oriented desktop fields', () => {
+    expect(COMPACT_SPOT_HIDDEN_DESKTOP_COLUMNS).toEqual([
+      'transactions',
+      'uniqueTraders',
+      'holders',
+      'tokenAge',
+    ]);
   });
 });

--- a/packages/kit/src/views/Market/MarketHomeV2/utils.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/utils.ts
@@ -2,6 +2,15 @@
 
 import BigNumber from 'bignumber.js';
 
+const SPOT_CATEGORIES_WITH_FULL_STATS = new Set(['trending', 'x_mentioned']);
+
+export const COMPACT_SPOT_HIDDEN_DESKTOP_COLUMNS = [
+  'transactions',
+  'uniqueTraders',
+  'holders',
+  'tokenAge',
+] as const;
+
 /**
  * Validate liquidity input to only allow numbers and k/m/b/t/K/M/B/T characters
  * Unit letters can only appear at the end and only one unit is allowed
@@ -111,4 +120,16 @@ export const validateMaximumMinLiquidity = (value: string): boolean => {
   const maximumMinValue = 1_000_000_000_000; // 1 trillion
 
   return numValue <= maximumMinValue;
+};
+
+/**
+ * Spot categories backed by per-token OKX detail APIs only expose a compact
+ * metric set, so desktop list pages should hide the extended stats columns to
+ * match watchlist behavior.
+ */
+export const shouldHideSpotExtendedStats = (
+  selectedCategory?: string,
+): boolean => {
+  const normalizedCategory = selectedCategory || 'trending';
+  return !SPOT_CATEGORIES_WITH_FULL_STATS.has(normalizedCategory);
 };


### PR DESCRIPTION
## Summary
- Hide extended stats columns (transactions, uniqueTraders, holders, tokenAge) on desktop market layout for spot categories with limited OKX API data
- Categories `trending` and `x_mentioned` retain full stats; other thematic categories (ai, stock, metal, etc.) show compact view
- Added unit tests for the new `shouldHideSpotExtendedStats` utility function

## Intent & Context
Spot categories backed by per-token OKX detail APIs only expose a compact metric set. The desktop list pages now conditionally hide extended stats columns to match watchlist behavior and avoid displaying empty/unavailable data.

## Design Decisions
- Used a `Set` for O(1) lookup of categories with full stats (`trending`, `x_mentioned`)
- Exported `COMPACT_SPOT_HIDDEN_DESKTOP_COLUMNS` as a constant array with `as const` for type safety
- Used `useMemo` with `selectedCategory` dependency to avoid unnecessary re-renders

## Changes Detail
- **utils.ts**: Added `shouldHideSpotExtendedStats()` function and `COMPACT_SPOT_HIDDEN_DESKTOP_COLUMNS` constant
- **utils.test.ts**: Added comprehensive test coverage for the new utility
- **DesktopLayout.tsx**: Integrated column hiding logic using memoized `hiddenSpotDesktopColumns`

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop
- **Risk Areas**: Only affects desktop market view column visibility; no data logic changes

## Test plan
- [ ] Open Market page on desktop
- [ ] Select `trending` category - verify all columns visible
- [ ] Select `x_mentioned` category - verify all columns visible  
- [ ] Select `ai` or other thematic category - verify extended stats columns are hidden
- [ ] Verify unit tests pass: `yarn test utils.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
