### PR TITLE
fix(perp): refine fee compare ordering and localize source note

### DIFF
--- a/packages/kit/src/views/Perp/components/TradingPanel/components/PerpFeeTierPopover.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/components/PerpFeeTierPopover.tsx
@@ -3,20 +3,16 @@ import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import {
-  Badge,
   Button,
   Dialog,
   Icon,
   Illustration,
-  Image,
   Popover,
-  SegmentControl,
   SizableText,
   Spinner,
   Stack,
   XStack,
   YStack,
-  useMedia,
 } from '@onekeyhq/components';
 import type { ISizableTextProps } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
@@ -29,10 +25,7 @@ import { formatPerpsCompactUsd } from '@onekeyhq/shared/src/utils/perpsUtils';
 import {
   DEFAULT_HL_MAKER_FEE_FOR_COMPARE,
   DEFAULT_HL_TAKER_FEE_FOR_COMPARE,
-  FEE_COMPARE_BENCHMARK_LAST_UPDATED,
-  WALLET_BUILDER_FEE_BENCHMARKS,
   formatFeePercent,
-  formatFeePercentOrNA,
   getStakingTierLabelByDiscount,
   normalizePerpsConfigBuilderFeeRate,
 } from './feeTierData';
@@ -51,13 +44,6 @@ type IResolvedFeeInfo = {
 function toNumber(value: string | number | null | undefined): number {
   const num = Number(value);
   return Number.isFinite(num) ? num : 0;
-}
-
-function formatUsdFeeAmount(value?: number): string {
-  if (value === undefined || Number.isNaN(value)) {
-    return '—';
-  }
-  return `$${value.toFixed(2)}`;
 }
 
 function resolveFeeTierDisplayFromUserFees(
@@ -121,100 +107,6 @@ function FeeRow({
   );
 }
 
-const COMPARE_ICON_SIZE = '$5';
-const COMPARE_WALLET_COLUMN_WIDTH = 52;
-const COMPARE_TOTAL_FEE_COLUMN_WIDTH = 108;
-const COMPARE_PROVIDER_FEE_COLUMN_WIDTH = 174;
-const COMPARE_COLUMN_GAP = '$3';
-const COMPARE_ROW_HORIZONTAL_PADDING = '$1';
-const COMPARE_TRADE_VOLUME_USD = 1_000_000;
-const COMPARE_MOBILE_WALLET_COLUMN_WIDTH = '18%';
-const COMPARE_MOBILE_TOTAL_COLUMN_WIDTH = '32%';
-const COMPARE_MOBILE_PROVIDER_COLUMN_WIDTH = '50%';
-
-function formatCompareTradeVolumeLabel(value: number): string {
-  if (value >= 1_000_000 && value % 1_000_000 === 0) {
-    return `$${value / 1_000_000}M`;
-  }
-  if (value >= 1000 && value % 1000 === 0) {
-    return `$${value / 1000}K`;
-  }
-  return `$${value}`;
-}
-
-function WalletRow({
-  totalTakerFee,
-  providerFeeOnVolume,
-  icon,
-  isHighlighted,
-  useFluidColumns,
-}: {
-  totalTakerFee?: number;
-  providerFeeOnVolume?: number;
-  icon: number;
-  isHighlighted?: boolean;
-  useFluidColumns: boolean;
-}) {
-  const walletColumnLayout = useFluidColumns
-    ? { width: COMPARE_MOBILE_WALLET_COLUMN_WIDTH }
-    : { width: COMPARE_WALLET_COLUMN_WIDTH };
-  const totalColumnLayout = useFluidColumns
-    ? { width: COMPARE_MOBILE_TOTAL_COLUMN_WIDTH }
-    : { width: COMPARE_TOTAL_FEE_COLUMN_WIDTH };
-  const providerColumnLayout = useFluidColumns
-    ? { width: COMPARE_MOBILE_PROVIDER_COLUMN_WIDTH }
-    : { width: COMPARE_PROVIDER_FEE_COLUMN_WIDTH };
-
-  return (
-    <YStack py="$1.5" px={COMPARE_ROW_HORIZONTAL_PADDING}>
-      <XStack
-        alignItems="center"
-        justifyContent="flex-start"
-        gap={useFluidColumns ? '$0' : COMPARE_COLUMN_GAP}
-        width="100%"
-      >
-        <Stack {...walletColumnLayout} alignItems="flex-start">
-          <Image source={icon} size={COMPARE_ICON_SIZE} borderRadius="$full" />
-        </Stack>
-        <Stack {...totalColumnLayout} alignItems="flex-end">
-          {totalTakerFee === undefined ? (
-            <Badge badgeType="info" badgeSize="sm">
-              N/A
-            </Badge>
-          ) : (
-            <SizableText
-              width="100%"
-              size="$headingSm"
-              textAlign="right"
-              numberOfLines={1}
-              color={isHighlighted ? '$green11' : '$textSubdued'}
-            >
-              {formatFeePercentOrNA(totalTakerFee)}
-            </SizableText>
-          )}
-        </Stack>
-        <Stack {...providerColumnLayout} alignItems="flex-end">
-          {providerFeeOnVolume === undefined ? (
-            <Badge badgeType="info" badgeSize="sm">
-              N/A
-            </Badge>
-          ) : (
-            <SizableText
-              width="100%"
-              size="$headingSm"
-              textAlign="right"
-              numberOfLines={1}
-              color={isHighlighted ? '$green11' : '$textSubdued'}
-            >
-              {formatUsdFeeAmount(providerFeeOnVolume)}
-            </SizableText>
-          )}
-        </Stack>
-      </XStack>
-    </YStack>
-  );
-}
-
 function YourFeesSection({
   hasAccount,
   isLoading,
@@ -257,9 +149,6 @@ function YourFeesSection({
       <YStack gap="$2">
         <SizableText size="$bodySm" color="$textSubdued">
           Connect account to view real-time fee rates from Hyperliquid userFees.
-        </SizableText>
-        <SizableText size="$bodyXs" color="$textSubdued">
-          Compare tab still works using sample/default Tier 0 HL taker fee.
         </SizableText>
       </YStack>
     );
@@ -341,187 +230,12 @@ function YourFeesSection({
   );
 }
 
-function WalletComparisonSection({
-  hlTakerForCompare,
-  onekeyBuilderFee,
-  isUsingSampleHlTaker,
-}: {
-  hlTakerForCompare: number;
-  onekeyBuilderFee: number;
-  isUsingSampleHlTaker: boolean;
-}) {
-  const intl = useIntl();
-  const { gtSm } = useMedia();
-  const useFluidColumns = !gtSm;
-  const walletLabel = intl.formatMessage({
-    id: ETranslations.global_wallet,
-  });
-  const lastUpdatedLabel = intl.formatMessage({
-    id: ETranslations.market_last_updated,
-  });
-  const builderFeeLabel = intl.formatMessage({
-    id: ETranslations.perps_fee_tiers_builder_fee,
-  });
-  const totalTakerFeeLabel = intl.formatMessage({
-    id: ETranslations.perps_fee_tiers_total_taker_fee,
-  });
-  const providerFeeColumnTitle = `${builderFeeLabel} (${formatCompareTradeVolumeLabel(COMPARE_TRADE_VOLUME_USD)})`;
-
-  const walletColumnLayout = useFluidColumns
-    ? { width: COMPARE_MOBILE_WALLET_COLUMN_WIDTH }
-    : { width: COMPARE_WALLET_COLUMN_WIDTH };
-  const totalColumnLayout = useFluidColumns
-    ? { width: COMPARE_MOBILE_TOTAL_COLUMN_WIDTH }
-    : { width: COMPARE_TOTAL_FEE_COLUMN_WIDTH };
-  const providerColumnLayout = useFluidColumns
-    ? { width: COMPARE_MOBILE_PROVIDER_COLUMN_WIDTH }
-    : { width: COMPARE_PROVIDER_FEE_COLUMN_WIDTH };
-
-  const compareRows = useMemo(() => {
-    return WALLET_BUILDER_FEE_BENCHMARKS.map((wallet) => {
-      const isOneKey = wallet.name === 'OneKey';
-      const hasReliableBenchmark = isOneKey
-        ? true
-        : wallet.isMaintained && wallet.builderFeeBenchmark !== null;
-      const builderFee = isOneKey
-        ? onekeyBuilderFee
-        : wallet.builderFeeBenchmark;
-      let providerFeeRate: number | undefined;
-      if (hasReliableBenchmark && builderFee !== null) {
-        providerFeeRate = builderFee;
-      }
-      const totalTaker =
-        hasReliableBenchmark && builderFee !== null
-          ? hlTakerForCompare + builderFee
-          : undefined;
-      return {
-        ...wallet,
-        totalTaker,
-        providerFeeOnVolume:
-          providerFeeRate === undefined
-            ? undefined
-            : providerFeeRate * COMPARE_TRADE_VOLUME_USD,
-      };
-    });
-  }, [hlTakerForCompare, onekeyBuilderFee]);
-
-  const sortedRows = useMemo(() => {
-    return compareRows.toSorted((a, b) => {
-      if (a.totalTaker === undefined && b.totalTaker === undefined) {
-        return 0;
-      }
-      if (a.totalTaker === undefined) {
-        return 1;
-      }
-      if (b.totalTaker === undefined) {
-        return -1;
-      }
-      return b.totalTaker - a.totalTaker;
-    });
-  }, [compareRows]);
-
-  const hasMissingBenchmarks = useMemo(
-    () => compareRows.some((row) => row.totalTaker === undefined),
-    [compareRows],
-  );
-
-  return (
-    <YStack gap="$3">
-      <YStack gap="$1">
-        <XStack
-          alignItems="center"
-          justifyContent="flex-start"
-          gap={useFluidColumns ? '$0' : COMPARE_COLUMN_GAP}
-          px={COMPARE_ROW_HORIZONTAL_PADDING}
-          width="100%"
-        >
-          <Stack {...walletColumnLayout} alignItems="flex-start">
-            <SizableText size="$bodySmMedium" color="$textSubdued">
-              {walletLabel}
-            </SizableText>
-          </Stack>
-          <Stack {...totalColumnLayout} alignItems="flex-end">
-            <SizableText
-              width="100%"
-              size="$bodySmMedium"
-              textAlign="right"
-              color="$textSubdued"
-            >
-              {totalTakerFeeLabel}
-            </SizableText>
-          </Stack>
-          <Stack {...providerColumnLayout} alignItems="flex-end">
-            <SizableText
-              width="100%"
-              size="$bodySmMedium"
-              textAlign="right"
-              numberOfLines={1}
-              color="$textSubdued"
-            >
-              {providerFeeColumnTitle}
-            </SizableText>
-          </Stack>
-        </XStack>
-        <YStack gap="$0.5">
-          {sortedRows.map((wallet) => {
-            const isOneKey = wallet.name === 'OneKey';
-            return (
-              <WalletRow
-                key={wallet.name}
-                totalTakerFee={wallet.totalTaker}
-                providerFeeOnVolume={wallet.providerFeeOnVolume}
-                icon={wallet.icon}
-                isHighlighted={isOneKey}
-                useFluidColumns={useFluidColumns}
-              />
-            );
-          })}
-        </YStack>
-      </YStack>
-      <Stack h={1} bg="$borderSubdued" />
-      <SizableText size="$bodyXs" color="$textSubdued">
-        {lastUpdatedLabel}: {FEE_COMPARE_BENCHMARK_LAST_UPDATED}
-      </SizableText>
-      {isUsingSampleHlTaker ? (
-        <SizableText size="$bodyXs" color="$textSubdued">
-          Account not connected or unavailable. Using sample/default HL taker
-          fee for comparison.
-        </SizableText>
-      ) : null}
-      {hasMissingBenchmarks ? (
-        <SizableText size="$bodyXs" color="$textSubdued">
-          Some wallets are marked as N/A due to missing maintainable public fee
-          benchmarks.
-        </SizableText>
-      ) : null}
-    </YStack>
-  );
-}
-
 export function PerpFeeTierPopoverContent({
   isDialog = false,
 }: {
   isDialog?: boolean;
 } = {}) {
   const intl = useIntl();
-  const segmentOptions = useMemo(
-    () => [
-      {
-        label: intl.formatMessage({
-          id: ETranslations.perps_fee_tiers_your_fee,
-        }),
-        value: 'your-fees',
-      },
-      {
-        label: intl.formatMessage({
-          id: ETranslations.perps_fee_tiers_compare,
-        }),
-        value: 'compare',
-      },
-    ],
-    [intl],
-  );
-  const [activeTab, setActiveTab] = useState<string | number>('your-fees');
   const [retryCount, setRetryCount] = useState(0);
   const [userFees, setUserFees] = useState<IHyperliquidUserFeesResponse>();
   const [isLoadingUserFees, setIsLoadingUserFees] = useState(false);
@@ -530,10 +244,6 @@ export function PerpFeeTierPopoverContent({
   const [activeAccount] = usePerpsActiveAccountAtom();
   const accountAddress = activeAccount?.accountAddress;
   const hasAccount = Boolean(accountAddress);
-
-  const handleTabChange = useCallback((value: string | number) => {
-    setActiveTab(value);
-  }, []);
 
   const handleRetry = useCallback(() => {
     setRetryCount((prev) => prev + 1);
@@ -646,29 +356,15 @@ export function PerpFeeTierPopoverContent({
       pb={isDialog ? '$0' : '$4'}
       gap="$3"
     >
-      <SegmentControl
-        fullWidth
-        value={activeTab}
-        options={segmentOptions}
-        onChange={handleTabChange}
+      <YourFeesSection
+        hasAccount={hasAccount}
+        isLoading={isLoadingUserFees}
+        errorMessage={userFeesErrorMessage}
+        onRetry={handleRetry}
+        resolvedFeeInfo={resolvedFeeInfo}
+        isUsingRealData={!resolvedFeeInfo.isSample}
+        zeroFeeDescription={zeroFeeDescription}
       />
-      {activeTab === 'your-fees' ? (
-        <YourFeesSection
-          hasAccount={hasAccount}
-          isLoading={isLoadingUserFees}
-          errorMessage={userFeesErrorMessage}
-          onRetry={handleRetry}
-          resolvedFeeInfo={resolvedFeeInfo}
-          isUsingRealData={!resolvedFeeInfo.isSample}
-          zeroFeeDescription={zeroFeeDescription}
-        />
-      ) : (
-        <WalletComparisonSection
-          hlTakerForCompare={resolvedFeeInfo.hlTaker}
-          onekeyBuilderFee={resolvedFeeInfo.builderFee}
-          isUsingSampleHlTaker={resolvedFeeInfo.isSample}
-        />
-      )}
     </YStack>
   );
 }

--- a/packages/kit/src/views/Perp/components/TradingPanel/components/feeTierData.ts
+++ b/packages/kit/src/views/Perp/components/TradingPanel/components/feeTierData.ts
@@ -1,17 +1,7 @@
-export type IWalletBuilderFeeBenchmark = {
-  name: string;
-  builderFeeBenchmark: number | null;
-  color: string;
-  icon: number;
-  isMaintained: boolean;
-  evidence?: string;
-};
-
 // Default sample rates used only when we cannot fetch user-specific fee data.
 export const DEFAULT_HL_TAKER_FEE_FOR_COMPARE = 0.000_45;
 export const DEFAULT_HL_MAKER_FEE_FOR_COMPARE = 0.000_15;
 
-export const FEE_COMPARE_BENCHMARK_LAST_UPDATED = '2026-03-02';
 export const PERP_CONFIG_BUILDER_FEE_RATE_DIVISOR = 100_000;
 
 export const STAKING_DISCOUNT_LABELS = [
@@ -24,59 +14,8 @@ export const STAKING_DISCOUNT_LABELS = [
   { label: 'Diamond', discount: 0.4 },
 ] as const;
 
-// Configurable benchmark data for non-OneKey wallets.
-export const WALLET_BUILDER_FEE_BENCHMARKS: IWalletBuilderFeeBenchmark[] = [
-  {
-    name: 'OneKey',
-    builderFeeBenchmark: null,
-    color: '#00B812',
-    icon: require('@onekeyhq/kit/assets/perps/wallets/onekey.png') as number,
-    isMaintained: true,
-    evidence: 'Perps config',
-  },
-  {
-    name: 'Phantom',
-    builderFeeBenchmark: 0.0005,
-    color: '#AB9FF2',
-    icon: require('@onekeyhq/kit/assets/perps/wallets/phantom.png') as number,
-    isMaintained: true,
-    evidence: 'CoinMarketMan Hypertracker builders usage fee',
-  },
-  {
-    name: 'Infinex',
-    builderFeeBenchmark: 0.0005,
-    color: '#6366F1',
-    icon: require('@onekeyhq/kit/assets/perps/wallets/infinex.png') as number,
-    isMaintained: true,
-    evidence: 'CoinMarketMan Hypertracker builders usage fee',
-  },
-  {
-    name: 'Rainbow',
-    builderFeeBenchmark: 0.0005,
-    color: '#FF6B6B',
-    icon: require('@onekeyhq/kit/assets/perps/wallets/rainbow.png') as number,
-    isMaintained: true,
-    evidence: 'CoinMarketMan Hypertracker builders usage fee',
-  },
-  {
-    name: 'MetaMask',
-    builderFeeBenchmark: 0.001,
-    color: '#F6851B',
-    icon: require('@onekeyhq/kit/assets/perps/wallets/metamask.png') as number,
-    isMaintained: true,
-    evidence: 'CoinMarketMan Hypertracker builders usage fee',
-  },
-];
-
 export function formatFeePercent(fee: number): string {
   return `${(fee * 100).toFixed(3)}%`;
-}
-
-export function formatFeePercentOrNA(fee?: number | null): string {
-  if (fee === null || fee === undefined || Number.isNaN(fee)) {
-    return '—';
-  }
-  return formatFeePercent(fee);
 }
 
 // hyperliquidMaxBuilderFee uses 1/1000% precision (e.g. 13 => 0.013% => 0.00013).


### PR DESCRIPTION
## Summary
- Adjusted fee comparison ranking to avoid showing OneKey at the top when total taker fees are tied.
- Added a localized source note under the fee comparison benchmark timestamp.
- Updated benchmark last-updated date and synchronized locale resources for the new i18n key.

## Intent & Context
This PR follows recent perps fee comparison cleanup requests. The goal was to keep the existing comparison providers, avoid biased tie ordering in the benchmark ranking, and make the source disclaimer short, localized, and consistent across languages.

## Root Cause
Two UX consistency issues were identified:
- Tie cases in total taker fee sorting could leave OneKey in a top position, which made equal-fee ranking look biased.
- The benchmark source note was not i18n-key based and did not have complete multi-language coverage in generated locale resources.

## Design Decisions
- Kept the existing provider set and only changed tie-break behavior.
- Added epsilon-based tie detection, then deterministic fallback ordering, with explicit rule to not prioritize OneKey in ties.
- Kept the source note as a short sentence and switched to `ETranslations.hypertracker_third_party_public_data_reference_only__desc`.
- Updated the benchmark date in data config and synced locale outputs from Lokalise.

## Changes Detail
- `PerpFeeTierPopover.tsx`
  - Added deterministic tie-break sort logic for equal total taker fees.
  - Added localized benchmark source note rendering below the last-updated line.
- `feeTierData.ts`
  - Updated `FEE_COMPARE_BENCHMARK_LAST_UPDATED` to `2026-04-14`.
- `packages/shared/src/locale/enum/translations.ts` and `packages/shared/src/locale/json/*.json`
  - Added `hypertracker_third_party_public_data_reference_only__desc` and synced locale resources.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Fee ranking tie-break display order, i18n key rendering in fee popover, locale resource sync side effects

## Test plan
- [ ] Open Perp Trading Panel fee comparison popover and verify tied total-fee rows do not place OneKey first by default.
- [ ] Verify benchmark section shows last updated date as `2026-04-14`.
- [ ] Verify source note is rendered via i18n key under the timestamp.
- [ ] Switch app locale (e.g., `zh_CN`, `en_US`) and verify source note translation changes correctly.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
