### PR TITLE
fix(discovery): translate settings UX and Prime gate (OK-53020)

### DIFF
--- a/packages/kit/src/views/Discovery/components/HeaderLeftToolBar/HeaderLeftToolBarInput.tsx
+++ b/packages/kit/src/views/Discovery/components/HeaderLeftToolBar/HeaderLeftToolBarInput.tsx
@@ -58,6 +58,13 @@ function HeaderLeftToolBarInput({
 }: IHeaderLeftToolBarInputProps) {
   const intl = useIntl();
   const [translateIsOpen, setTranslateIsOpen] = useState(false);
+  const [translateShowSettings, setTranslateShowSettings] = useState(false);
+  const handleTranslateOpenChange = useCallback((isOpen: boolean) => {
+    if (!isOpen) {
+      setTranslateShowSettings(false);
+    }
+    setTranslateIsOpen(isOpen);
+  }, []);
   const [dappInfoIsOpen, setDappInfoIsOpen] = useState(false);
   const [searchValue, setSearchValue] = useState('');
   const [internalValue, setInternalValue] = useState('');
@@ -243,7 +250,7 @@ function HeaderLeftToolBarInput({
             id: ETranslations.browser_translate_settings_title,
           })}
           open={translateIsOpen}
-          onOpenChange={setTranslateIsOpen}
+          onOpenChange={handleTranslateOpenChange}
           renderTrigger={<Stack />}
           renderContent={({ closePopover }) => (
             <TranslatePopoverContent
@@ -251,6 +258,8 @@ function HeaderLeftToolBarInput({
               onTranslate={onTranslate ?? (() => {})}
               onTestAITranslateError={onTestAITranslateError}
               closePopover={closePopover}
+              showSettings={translateShowSettings}
+              onShowSettingsChange={setTranslateShowSettings}
             />
           )}
         />

--- a/packages/kit/src/views/Discovery/hooks/usePageTranslation.tsx
+++ b/packages/kit/src/views/Discovery/hooks/usePageTranslation.tsx
@@ -3,22 +3,30 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import {
+  Badge,
   Button,
   IconButton,
   Popover,
   SegmentControl,
   Select,
   SizableText,
+  Stack,
   Toast,
   XStack,
   YStack,
 } from '@onekeyhq/components';
+import { useOneKeyAuth } from '@onekeyhq/kit/src/components/OneKeyAuth/useOneKeyAuth';
 import { useWebViewTranslate } from '@onekeyhq/kit/src/components/WebView/useWebViewTranslate';
+import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
 import { useTranslateSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
 import { ETranslations, LOCALES_OPTION } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import { EModalRoutes } from '@onekeyhq/shared/src/routes';
+import { EPrimeFeatures, EPrimePages } from '@onekeyhq/shared/src/routes/prime';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
 import { ETranslateDisplayMode, ETranslateEngine } from '../types';
 
@@ -133,7 +141,15 @@ function TranslateSettings({
             if (v === 'auto') {
               updateSetting('targetLanguage', 'auto');
             } else {
-              updateSetting('targetLanguage', intl.locale);
+              const hasLocaleOption = customLanguageOptions.some(
+                (o) => o.value === intl.locale,
+              );
+              updateSetting(
+                'targetLanguage',
+                hasLocaleOption
+                  ? intl.locale
+                  : (customLanguageOptions[0]?.value ?? intl.locale),
+              );
             }
           }}
         />
@@ -214,20 +230,45 @@ export function TranslatePopoverContent({
   onTranslate,
   onTestAITranslateError,
   closePopover,
+  showSettings,
+  onShowSettingsChange,
 }: {
   isTranslated: boolean;
   onTranslate: () => void;
   onTestAITranslateError?: (testFlag: string) => void;
   closePopover: () => void;
+  showSettings: boolean;
+  onShowSettingsChange: (show: boolean) => void;
 }) {
   const intl = useIntl();
-  const [showSettings, setShowSettings] = useState(false);
+  const { user } = useOneKeyAuth();
+  const navigation = useAppNavigation();
+  const isPrimeUser = useMemo(
+    () => !!(user?.primeSubscription?.isActive && user?.onekeyUserId),
+    [user?.primeSubscription?.isActive, user?.onekeyUserId],
+  );
+  const themeVariant = useThemeVariant();
   const targetLanguageLabel = useTargetLanguageLabel();
 
-  const handleAction = useCallback(() => {
+  const handleAction = useCallback(async () => {
+    if (!isTranslated && !isPrimeUser) {
+      closePopover();
+      await timerUtils.wait(150);
+      defaultLogger.prime.subscription.primeEntryClick({
+        featureName: EPrimeFeatures.DAppTranslate,
+        entryPoint: 'browserTranslate',
+      });
+      navigation.pushFullModal(EModalRoutes.PrimeModal, {
+        screen: EPrimePages.PrimeDashboard,
+        params: {
+          fromFeature: EPrimeFeatures.DAppTranslate,
+        },
+      });
+      return;
+    }
     onTranslate();
     closePopover();
-  }, [onTranslate, closePopover]);
+  }, [onTranslate, closePopover, isTranslated, isPrimeUser, navigation]);
 
   const handleTestAITranslateError = useCallback(
     (testFlag: string) => {
@@ -250,7 +291,7 @@ export function TranslatePopoverContent({
           size="small"
           icon="ChevronLeftOutline"
           alignSelf="flex-start"
-          onPress={() => setShowSettings(false)}
+          onPress={() => onShowSettingsChange(false)}
         >
           {intl.formatMessage({
             id: ETranslations.wallet_bulk_send_btn_back,
@@ -277,16 +318,36 @@ export function TranslatePopoverContent({
           icon="SettingsOutline"
           variant="tertiary"
           size="small"
-          onPress={() => setShowSettings(true)}
+          onPress={() => onShowSettingsChange(true)}
         />
       </XStack>
-      <Button variant="primary" size="medium" onPress={handleAction}>
-        {intl.formatMessage({
-          id: isTranslated
-            ? ETranslations.browser_restore_original
-            : ETranslations.browser_translate_start,
-        })}
-      </Button>
+      <Stack overflow="visible">
+        <Button variant="primary" size="medium" onPress={handleAction}>
+          {intl.formatMessage({
+            id: isTranslated
+              ? ETranslations.browser_restore_original
+              : ETranslations.browser_translate_start,
+          })}
+        </Button>
+        {!isTranslated && !isPrimeUser ? (
+          <Stack position="absolute" right={-4} top={-8}>
+            <Badge
+              badgeSize="sm"
+              badgeType="default"
+              bg={themeVariant === 'light' ? '#F1F1F1' : '#3A3A3A'}
+              borderRadius="$full"
+              borderWidth="$px"
+              borderColor="$bgApp"
+            >
+              <Badge.Text size="$bodySmMedium">
+                {intl.formatMessage({
+                  id: ETranslations.prime_status_prime,
+                })}
+              </Badge.Text>
+            </Badge>
+          </Stack>
+        ) : null}
+      </Stack>
     </YStack>
   );
 }
@@ -307,6 +368,18 @@ export function TranslatePopoverTrigger({
   onOpenChange?: (open: boolean) => void;
 }) {
   const intl = useIntl();
+  const [showSettings, setShowSettings] = useState(false);
+
+  const handleOpenChange = useCallback(
+    (isOpen: boolean) => {
+      if (!isOpen) {
+        setShowSettings(false);
+      }
+      onOpenChange?.(isOpen);
+    },
+    [onOpenChange],
+  );
+
   return (
     <Popover
       title={intl.formatMessage({
@@ -314,7 +387,7 @@ export function TranslatePopoverTrigger({
       })}
       placement={placement}
       open={open}
-      onOpenChange={onOpenChange}
+      onOpenChange={handleOpenChange}
       renderTrigger={
         <IconButton
           variant="tertiary"
@@ -329,6 +402,8 @@ export function TranslatePopoverTrigger({
           onTranslate={onTranslate}
           onTestAITranslateError={onTestAITranslateError}
           closePopover={closePopover}
+          showSettings={showSettings}
+          onShowSettingsChange={setShowSettings}
         />
       )}
     />

--- a/packages/shared/src/logger/scopes/prime/scenes/subscription.ts
+++ b/packages/shared/src/logger/scopes/prime/scenes/subscription.ts
@@ -20,7 +20,8 @@ export class PrimeSubscriptionScene extends BaseScene {
       | 'moreActions'
       | 'approvalPopup'
       | 'primePage'
-      | 'walletEdit';
+      | 'walletEdit'
+      | 'browserTranslate';
   }) {
     return {
       featureName,


### PR DESCRIPTION
## Summary
- Fix translate settings page auto-navigating back on any setting change by lifting `showSettings` state above Popover
- Fix custom language Select showing no default when `intl.locale` (e.g. `en-US`) is filtered from options
- Add Prime membership gate: non-Prime users are redirected to Prime upgrade page on translate action
- Add Prime badge indicator on translate button for non-Prime users
- Add `primeEntryClick` analytics tracking with `browserTranslate` entry point

## Test plan
- [ ] Open browser translate popover, enter settings, change engine/language/display mode — verify settings view persists (no auto-back)
- [ ] Switch target language to "Manual Selection" — verify first language is selected by default
- [ ] As non-Prime user, tap "Start Translation" — verify Prime upgrade modal appears after popover closes
- [ ] As non-Prime user, verify Prime badge is visible on translate button
- [ ] As Prime user, tap "Start Translation" — verify translation executes normally
- [ ] Tap "Restore Original" as non-Prime user — verify it works without Prime gate
- [ ] Test on desktop, iOS, and Android
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
