### PR TITLE
fix(swap): show only keyless wallet accounts in web recipient picker (OK-52685)

### DIFF
--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -60,6 +60,7 @@ type IRecipientQuickSelectProps = {
   isSearchMode?: boolean;
   activeTab?: IRecipientQuickSelectTab;
   hideTabs?: IRecipientQuickSelectTab[];
+  keylessWalletsOnly?: boolean;
   onActiveTabChange?: (tab: IRecipientQuickSelectTab) => void;
   onInputTypeChange?: (type: EInputAddressChangeType) => void;
   onSelect?: (params: {
@@ -80,6 +81,7 @@ type IAccountRecipientsProps = {
   lastUsedDeriveType?: string;
   searchKey?: string;
   isSearchMode?: boolean;
+  keylessWalletsOnly?: boolean;
   onInputTypeChange?: (type: EInputAddressChangeType) => void;
   onSelect?: (params: { address: string }) => void;
   onMatchStatusChange?: (hasMatches: boolean, matchCount: number) => void;
@@ -259,6 +261,7 @@ function AccountRecipients({
   lastUsedDeriveType: lastUsedDeriveTypeProp,
   searchKey,
   isSearchMode,
+  keylessWalletsOnly,
   onInputTypeChange,
   onSelect,
   onMatchStatusChange,
@@ -332,7 +335,9 @@ function AccountRecipients({
             accountUtils.isWatchingWallet({ walletId: wallet.id }) ||
             accountUtils.isExternalWallet({ walletId: wallet.id }) ||
             wallet.deprecated ||
-            wallet.isMocked;
+            wallet.isMocked ||
+            (keylessWalletsOnly &&
+              !accountUtils.isKeylessWallet({ walletId: wallet.id }));
 
           if (shouldSkip) {
             // eslint-disable-next-line no-continue
@@ -366,7 +371,7 @@ function AccountRecipients({
         );
         return groups.filter((group): group is IWalletGroup => !!group);
       },
-      [networkId, senderDeriveType],
+      [networkId, senderDeriveType, keylessWalletsOnly],
       { initResult: [], watchLoading: true, undefinedResultIfError: true },
     );
 
@@ -863,6 +868,7 @@ export default function RecipientQuickSelect({
   onInputTypeChange,
   onMatchStatusChange,
   hideTabs,
+  keylessWalletsOnly,
   senderDeriveType,
 }: IRecipientQuickSelectProps) {
   const intl = useIntl();
@@ -1142,6 +1148,7 @@ export default function RecipientQuickSelect({
                 lastUsedDeriveType={lastUsedDeriveType}
                 searchKey={searchKey}
                 isSearchMode={isSearchMode}
+                keylessWalletsOnly={keylessWalletsOnly}
                 onInputTypeChange={onInputTypeChange}
                 onSelect={({ address }) =>
                   onSelect?.({

--- a/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useRoute } from '@react-navigation/core';
 import { useIntl } from 'react-intl';
@@ -12,11 +12,13 @@ import {
   XStack,
   useForm,
 } from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import type { IAddressInputValue } from '@onekeyhq/kit/src/components/AddressInput';
 import { AddressInputField } from '@onekeyhq/kit/src/components/AddressInput';
 import { renderAddressSecurityHeaderRightButton } from '@onekeyhq/kit/src/components/AddressInput/AddressSecurityHeaderRightButton';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import {
   useSwapManualSelectQuoteProvidersAtom,
   useSwapQuoteCurrentSelectAtom,
@@ -25,10 +27,12 @@ import {
 import { useSettingsAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type {
   EModalSwapRoutes,
   IModalSwapParamList,
 } from '@onekeyhq/shared/src/routes/swap';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
 
@@ -41,7 +45,7 @@ import type { IRecipientQuickSelectTab } from '../../../Send/pages/SendDataInput
 import type { RouteProp } from '@react-navigation/core';
 import type { SubmitHandler } from 'react-hook-form';
 
-const SWAP_HIDDEN_TABS: IRecipientQuickSelectTab[] = ['recent'];
+const BASE_HIDDEN_TABS: IRecipientQuickSelectTab[] = ['recent'];
 
 interface IFormType {
   address: IAddressInputValue;
@@ -68,6 +72,27 @@ const SwapToAnotherAddressPage = () => {
   const [selectedQuote] = useSwapQuoteCurrentSelectAtom();
   const [, setSwapManualSelectQuote] = useSwapManualSelectQuoteProvidersAtom();
   const intl = useIntl();
+
+  // OK-52685: on web dapp mode, only keyless wallet accounts are valid swap
+  // recipients — hide the address book tab, and the whole account tab too
+  // when the user has no keyless wallet at all.
+  const { result: hasKeylessWallet = true } = usePromiseResult(async () => {
+    if (!platformEnv.isWebDappMode) return true;
+    const { wallets } = await backgroundApiProxy.serviceAccount.getWallets({
+      ignoreNonBackedUpWallets: true,
+      nestedHiddenWallets: true,
+    });
+    return wallets.some((w) =>
+      accountUtils.isKeylessWallet({ walletId: w.id }),
+    );
+  }, []);
+
+  const hiddenTabs = useMemo<IRecipientQuickSelectTab[]>(() => {
+    if (!platformEnv.isWebDappMode) return BASE_HIDDEN_TABS;
+    return hasKeylessWallet
+      ? [...BASE_HIDDEN_TABS, 'addressBook']
+      : [...BASE_HIDDEN_TABS, 'addressBook', 'account'];
+  }, [hasKeylessWallet]);
   const form = useForm({
     defaultValues: {
       address: {
@@ -198,7 +223,8 @@ const SwapToAnotherAddressPage = () => {
             senderDeriveType={activeAccount?.deriveType}
             searchKey={toAddressRaw}
             isSearchMode={!!toAddressRaw?.trim()}
-            hideTabs={SWAP_HIDDEN_TABS}
+            hideTabs={hiddenTabs}
+            keylessWalletsOnly={platformEnv.isWebDappMode}
             onMatchStatusChange={setHasQuickSelectMatches}
             onSelect={handleQuickSelectRecipient}
           />


### PR DESCRIPTION
## Summary

On web dapp mode, the swap **Send to another address** picker should only surface the user's own keyless wallet accounts. Address book entries and accounts from non-keyless wallet types should not appear, and the whole account tab should collapse when the user has no keyless wallet at all.

## Jira

https://onekeyhq.atlassian.net/browse/OK-52685

## Background

The ticket was labelled as fixed in #11065, but inspection shows that PR only changed an unrelated icon in \`SwapToAnotherAddressModal.tsx\` (that was the OK-52681 fix). No code touched the tab/account filtering, and \`SWAP_HIDDEN_TABS\` still only hid the recent tab. QA re-reported the regression on 2026-04-10 with a screenshot confirming the address book and non-keyless accounts were still visible on web.

## Changes

### \`RecipientQuickSelect.tsx\`
- New \`keylessWalletsOnly?: boolean\` prop on both \`RecipientQuickSelect\` and the internal \`AccountRecipients\` component
- Threads through as an extra skip condition in the wallet loop alongside the existing watch-only / external / deprecated / mocked filters
- Added to the \`usePromiseResult\` deps so the wallet list re-fetches when the flag flips

### \`SwapToAnotherAddressModal.tsx\`
- Pulls the wallet list once at modal open (web only) to determine whether any keyless wallet exists
- On web dapp mode, builds \`hiddenTabs\` dynamically:
  - Always hides address book
  - Hides the account tab too if no keyless wallet exists, so the user doesn't land on an empty selector
- Defaults \`hasKeylessWallet\` to \`true\` so the account tab stays visible on the first frame while the lookup resolves (avoids a visible flicker for the common case)
- Passes \`keylessWalletsOnly={platformEnv.isWebDappMode}\` to \`RecipientQuickSelect\`
- Non-web platforms go straight to the existing \`BASE_HIDDEN_TABS = ['recent']\` constant — zero behavior change

## Test plan

- [ ] **Web dapp mode**, user has keyless wallet + HD wallet: open swap → send to another address. Only the keyless wallet's accounts appear in the Accounts tab; address book tab is hidden
- [ ] **Web dapp mode**, user has only keyless wallet: same as above, only keyless accounts appear
- [ ] **Web dapp mode**, user has only non-keyless wallets (edge case): Accounts tab AND address book tab are both hidden; user types the address manually
- [ ] **Desktop**, **mobile**, **extension**: no change — address book, accounts, recent behave exactly as before
- [ ] Regular send flow recipient picker on web: unchanged, \`keylessWalletsOnly\` is only set from the swap modal
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
