### PR TITLE
fix: restrict restore sync policy to transfer and icloud restore

### DIFF
--- a/packages/kit-bg/src/dbs/local/LocalDbBase.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.ts
@@ -4304,27 +4304,36 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
 
             // add imported account credential
             if (walletId === WALLET_TYPE_IMPORTED) {
-              if (addedIds.length !== 1) {
-                throw new OneKeyLocalError(
-                  'Only one can be imported at a time into a private key account.',
-                );
+              const shouldReuseExistingImportedCredential =
+                applyRestoreSyncPolicy &&
+                existsAccounts.length > 0 &&
+                addedIds.length === 0;
+
+              // Restore can keep an existing imported account record, so its
+              // credential row should be reused instead of being inserted again.
+              if (!shouldReuseExistingImportedCredential) {
+                if (addedIds.length !== 1) {
+                  throw new OneKeyLocalError(
+                    'Only one can be imported at a time into a private key account.',
+                  );
+                }
+                if (!importedCredential) {
+                  throw new OneKeyLocalError(
+                    'importedCredential is required for imported account',
+                  );
+                }
+                await this.txAddRecords({
+                  tx,
+                  name: ELocalDBStoreNames.Credential,
+                  records: [
+                    {
+                      id: addedIds[0],
+                      credential: importedCredential,
+                    },
+                  ],
+                  skipIfExists: true,
+                });
               }
-              if (!importedCredential) {
-                throw new OneKeyLocalError(
-                  'importedCredential is required for imported account',
-                );
-              }
-              await this.txAddRecords({
-                tx,
-                name: ELocalDBStoreNames.Credential,
-                records: [
-                  {
-                    id: addedIds[0],
-                    credential: importedCredential,
-                  },
-                ],
-                skipIfExists: true,
-              });
             }
 
             const isOverrideAccounts = removed > 0 && actualAdded === 0;

--- a/packages/kit-bg/src/dbs/local/LocalDbBase.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.ts
@@ -51,7 +51,10 @@ import {
   WALLET_TYPE_WATCHING,
 } from '@onekeyhq/shared/src/consts/dbConsts';
 import type { EHyperLiquidAgentName } from '@onekeyhq/shared/src/consts/perp';
-import { EPrimeCloudSyncDataType } from '@onekeyhq/shared/src/consts/primeConsts';
+import {
+  EPrimeCloudSyncDataType,
+  PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME,
+} from '@onekeyhq/shared/src/consts/primeConsts';
 import {
   COINTYPE_DNX,
   COINTYPE_ETH,
@@ -316,6 +319,19 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
 
   async timeNow(): Promise<number> {
     return this.backgroundApi.servicePrimeCloudSync.timeNow();
+  }
+
+  buildRestoreSyncItemDataTime(params: {
+    existingSyncItem: IDBCloudSyncItem | undefined;
+  }): number | undefined {
+    const existingDataTime = params.existingSyncItem?.dataTime;
+    if (
+      !existingDataTime ||
+      existingDataTime === PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME
+    ) {
+      return (existingDataTime || PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME) + 1;
+    }
+    return undefined;
   }
 
   // #region ---------------------------------------------- credential
@@ -1456,6 +1472,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
     indexes,
     names,
     skipIfExists,
+    applyRestoreSyncPolicy,
   }: {
     walletId: string;
     indexes: number[];
@@ -1463,6 +1480,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
       [index: number]: string;
     };
     skipIfExists: boolean;
+    applyRestoreSyncPolicy?: boolean;
   }) {
     return this.withTransaction(EIndexedDBBucketNames.account, async (tx) =>
       this.txAddIndexedAccount({
@@ -1471,6 +1489,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
         skipIfExists,
         indexes,
         names,
+        applyRestoreSyncPolicy,
       }),
     );
   }
@@ -1508,6 +1527,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
     names,
     skipIfExists,
     skipServerSyncFlow,
+    applyRestoreSyncPolicy,
   }: {
     tx: ILocalDBTransaction;
     walletId: string;
@@ -1517,6 +1537,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
     };
     skipIfExists: boolean;
     skipServerSyncFlow?: boolean;
+    applyRestoreSyncPolicy?: boolean;
   }) {
     if (
       !accountUtils.isHdWallet({ walletId }) &&
@@ -1602,6 +1623,10 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
 
     const syncManager =
       this.backgroundApi?.servicePrimeCloudSync.syncManagers.indexedAccount;
+    const shouldBackfillIndexedAccountSyncItemMap: Record<string, boolean> = {};
+    indexedAccountsToAdd.forEach((indexedAccount) => {
+      shouldBackfillIndexedAccountSyncItemMap[indexedAccount.id] = true;
+    });
 
     const buildSyncItemsStartTime = Date.now();
     const syncItemsInfo:
@@ -1630,6 +1655,8 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
           const name = existingItem?.syncPayload?.name;
           if (name) {
             indexedAccount.name = name;
+            existingItem.target.indexedAccount.name = name;
+            shouldBackfillIndexedAccountSyncItemMap[indexedAccount.id] = false;
           }
         });
       },
@@ -1641,6 +1668,16 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
           target.indexedAccount.name === accountDefaultName,
         );
       },
+      buildSyncItemDataTime: applyRestoreSyncPolicy
+        ? async ({ existingSyncItem, target }) => {
+            if (!shouldBackfillIndexedAccountSyncItemMap[target.targetId]) {
+              return undefined;
+            }
+            return this.buildRestoreSyncItemDataTime({
+              existingSyncItem,
+            });
+          }
+        : undefined,
     });
     const buildSyncItemsDuration = Date.now() - buildSyncItemsStartTime;
     if (buildSyncItemsDuration > 600) {
@@ -2100,6 +2137,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
       isKeylessWallet,
       keylessDetailsInfo,
       skipAddHDNextIndexedAccount,
+      applyRestoreSyncPolicy,
     } = params;
     const { overrideWalletId } = params;
     const shouldConsumeNextHD = !overrideWalletId;
@@ -2176,6 +2214,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
 
     const isUsingDefaultName = () =>
       currentWalletToCreate?.name === defaultWalletName;
+    let shouldBackfillWalletSyncItem = true;
 
     const syncManager =
       this.backgroundApi.servicePrimeCloudSync.syncManagers.wallet;
@@ -2199,8 +2238,9 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
           if (!currentWalletToCreate) {
             return;
           }
-          const syncPayload =
-            existingSyncItemsInfo[currentWalletToCreate?.id]?.syncPayload;
+          const existingSyncItemInfo =
+            existingSyncItemsInfo[currentWalletToCreate?.id];
+          const syncPayload = existingSyncItemInfo?.syncPayload;
 
           if (!syncPayload) {
             return;
@@ -2213,12 +2253,32 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
               defaultWalletName,
             avatar: syncPayload.avatar || currentAvatarInfo,
           });
+          shouldBackfillWalletSyncItem = false;
+          if (existingSyncItemInfo?.target?.wallet) {
+            existingSyncItemInfo.target.wallet.name =
+              syncPayload.name ||
+              existingSyncItemInfo.target.wallet.name ||
+              defaultWalletName;
+            existingSyncItemInfo.target.wallet.avatarInfo =
+              syncPayload.avatar ||
+              existingSyncItemInfo.target.wallet.avatarInfo;
+          }
         },
         useCreateGenesisTime: async ({ target }) => {
           // Avoid syncing the default name of the mnemonic wallet when creating a wallet on other devices that are not prime members
           const b: boolean = isUsingDefaultName();
           return b;
         },
+        buildSyncItemDataTime: applyRestoreSyncPolicy
+          ? async ({ existingSyncItem }) => {
+              if (!shouldBackfillWalletSyncItem) {
+                return undefined;
+              }
+              return this.buildRestoreSyncItemDataTime({
+                existingSyncItem,
+              });
+            }
+          : undefined,
       });
 
     await this.withTransaction(EIndexedDBBucketNames.account, async (tx) => {
@@ -3655,7 +3715,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
       }
     }
 
-    const walletName = params.name || wallet.name;
+    let walletName = params.name || wallet.name;
     let avatarInfo = wallet.avatarInfo;
     if (
       params.avatar &&
@@ -3666,9 +3726,46 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
     }
 
     const syncManagers = this.backgroundApi.servicePrimeCloudSync.syncManagers;
-    const syncItem = params.skipSaveLocalSyncItem
-      ? undefined
-      : await syncManagers.wallet.buildSyncItemByDBQuery({
+    let syncItem: IDBCloudSyncItem | undefined;
+    let shouldSkipWalletUpdate = false;
+    if (!params.skipSaveLocalSyncItem) {
+      if (params.applyRestoreSyncPolicy) {
+        let shouldUseSyncPayload = false;
+        const walletTarget = await syncManagers.wallet.buildSyncTargetByDBQuery(
+          {
+            dbRecord: {
+              ...wallet,
+              name: walletName,
+              avatarInfo,
+              avatar: avatarInfo ? JSON.stringify(avatarInfo) : wallet.avatar,
+            },
+          },
+        );
+        await syncManagers.wallet.buildExistingSyncItemsInfo({
+          tx: undefined,
+          targets: [walletTarget],
+          onExistingSyncItemsInfo: async (syncItemsInfo) => {
+            const existingSyncItemInfo = syncItemsInfo[walletId];
+            const syncPayload = existingSyncItemInfo?.syncPayload;
+            if (!syncPayload) {
+              return;
+            }
+            shouldUseSyncPayload = true;
+            if (syncPayload.name) {
+              walletName = syncPayload.name;
+              walletTarget.wallet.name = syncPayload.name;
+            }
+            if (syncPayload.avatar) {
+              avatarInfo = syncPayload.avatar;
+              walletTarget.wallet.avatarInfo = syncPayload.avatar;
+              walletTarget.wallet.avatar = JSON.stringify(syncPayload.avatar);
+            }
+          },
+        });
+        syncItem = undefined;
+        shouldSkipWalletUpdate = !shouldUseSyncPayload;
+      } else {
+        syncItem = await syncManagers.wallet.buildSyncItemByDBQuery({
           dbRecord: {
             ...wallet,
             name: walletName,
@@ -3680,6 +3777,12 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
           isDeleted: false,
           dataTime: await this.timeNow(),
         });
+      }
+    }
+
+    if (shouldSkipWalletUpdate) {
+      return wallet;
+    }
 
     await this.withTransaction(EIndexedDBBucketNames.account, async (tx) => {
       // add or update sync item
@@ -3959,6 +4062,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
     importedCredential,
     accountNameBuilder,
     skipEventEmit,
+    applyRestoreSyncPolicy,
   }: {
     allAccountsBelongToNetworkId?: string; // pass this only if all accounts belong to the same network
     walletId: string;
@@ -3967,6 +4071,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
     // accountNameBuilder for watching, imported, external account
     accountNameBuilder?: (data: { nextAccountId: number }) => string;
     skipEventEmit?: boolean;
+    applyRestoreSyncPolicy?: boolean;
   }): Promise<{ isOverrideAccounts: boolean; existsAccounts: IDBAccount[] }> {
     // eslint-disable-next-line no-param-reassign
     accounts = accounts.map((account) => {
@@ -4021,6 +4126,12 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
 
     const syncManager =
       this.backgroundApi.servicePrimeCloudSync.syncManagers.account;
+    const shouldBackfillAccountSyncItemMap: Record<string, boolean> = {};
+    accounts.forEach((account) => {
+      shouldBackfillAccountSyncItemMap[account.id] = !existsAccounts.some(
+        (item) => item.id === account.id,
+      );
+    });
 
     const existingSyncItemsInfoResult000025394378263443374653 =
       await (async () => {
@@ -4037,6 +4148,9 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
               const existingSyncItem = existingSyncItemsInfo[account.id];
               if (existingSyncItem?.syncPayload?.name) {
                 account.name = existingSyncItem.syncPayload.name;
+                existingSyncItem.target.account.name =
+                  existingSyncItem.syncPayload.name;
+                shouldBackfillAccountSyncItemMap[account.id] = false;
               }
             });
           },
@@ -4046,6 +4160,16 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
               accountDefaultName && target.account.name === accountDefaultName,
             );
           },
+          buildSyncItemDataTime: applyRestoreSyncPolicy
+            ? async ({ existingSyncItem, target }) => {
+                if (!shouldBackfillAccountSyncItemMap[target.targetId]) {
+                  return undefined;
+                }
+                return this.buildRestoreSyncItemDataTime({
+                  existingSyncItem,
+                });
+              }
+            : undefined,
         });
       })();
 
@@ -4098,7 +4222,11 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
             }
 
             let removed = 0;
-            if (existsAccounts && existsAccounts.length) {
+            if (
+              existsAccounts &&
+              existsAccounts.length &&
+              !applyRestoreSyncPolicy
+            ) {
               // TODO remove and re-add, may cause nextIds not correct,
               // TODO return actual removed count
               await this.txRemoveRecords({
@@ -4884,38 +5012,107 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
 
     const syncManagers = this.backgroundApi.servicePrimeCloudSync.syncManagers;
     let syncItem: IDBCloudSyncItem | undefined;
+    let accountName = params.name;
+    let shouldSkipAccountUpdate = false;
     if (!params.skipSaveLocalSyncItem) {
-      const now = await this.timeNow();
-      if (params.accountId) {
-        const account = await this.getAccountSafe({
-          accountId: params.accountId,
-        });
-        if (account) {
-          syncItem = await syncManagers.account.buildSyncItemByDBQuery({
-            syncCredential: await syncManagers.account.getSyncCredential(),
-            dbRecord: { ...account, name: params.name || account.name },
-            isDeleted: false,
-            dataTime: now,
+      if (params.applyRestoreSyncPolicy) {
+        if (params.accountId) {
+          let shouldUseSyncPayload = false;
+          const account = await this.getAccountSafe({
+            accountId: params.accountId,
           });
+          if (account) {
+            const target = await syncManagers.account.buildSyncTargetByDBQuery({
+              dbRecord: { ...account, name: params.name || account.name },
+            });
+            await syncManagers.account.buildExistingSyncItemsInfo({
+              tx: undefined,
+              targets: [target],
+              onExistingSyncItemsInfo: async (syncItemsInfo) => {
+                const existingSyncItemInfo =
+                  syncItemsInfo[params.accountId || ''];
+                const syncPayload = existingSyncItemInfo?.syncPayload;
+                if (syncPayload?.name) {
+                  shouldUseSyncPayload = true;
+                  accountName = syncPayload.name;
+                  target.account.name = syncPayload.name;
+                }
+              },
+            });
+            syncItem = undefined;
+            shouldSkipAccountUpdate = !shouldUseSyncPayload;
+          }
+        }
+        if (params.indexedAccountId) {
+          let shouldUseSyncPayload = false;
+          const indexedAccount = await this.getIndexedAccountSafe({
+            id: params.indexedAccountId,
+          });
+          if (indexedAccount) {
+            const target =
+              await syncManagers.indexedAccount.buildSyncTargetByDBQuery({
+                dbRecord: {
+                  ...indexedAccount,
+                  name: params.name || indexedAccount.name,
+                },
+              });
+            await syncManagers.indexedAccount.buildExistingSyncItemsInfo({
+              tx: undefined,
+              targets: [target],
+              onExistingSyncItemsInfo: async (syncItemsInfo) => {
+                const existingSyncItemInfo =
+                  syncItemsInfo[params.indexedAccountId || ''];
+                const syncPayload = existingSyncItemInfo?.syncPayload;
+                if (syncPayload?.name) {
+                  shouldUseSyncPayload = true;
+                  accountName = syncPayload.name;
+                  target.indexedAccount.name = syncPayload.name;
+                }
+              },
+            });
+            syncItem = undefined;
+            shouldSkipAccountUpdate = !shouldUseSyncPayload;
+          }
+        }
+      } else {
+        const now = await this.timeNow();
+        if (params.accountId) {
+          const account = await this.getAccountSafe({
+            accountId: params.accountId,
+          });
+          if (account) {
+            syncItem = await syncManagers.account.buildSyncItemByDBQuery({
+              syncCredential: await syncManagers.account.getSyncCredential(),
+              dbRecord: { ...account, name: params.name || account.name },
+              isDeleted: false,
+              dataTime: now,
+            });
+          }
+        }
+        if (params.indexedAccountId) {
+          const indexedAccount = await this.getIndexedAccountSafe({
+            id: params.indexedAccountId,
+          });
+          if (indexedAccount) {
+            syncItem = await syncManagers.indexedAccount.buildSyncItemByDBQuery(
+              {
+                syncCredential:
+                  await syncManagers.indexedAccount.getSyncCredential(),
+                dbRecord: {
+                  ...indexedAccount,
+                  name: params.name || indexedAccount.name,
+                },
+                isDeleted: false,
+                dataTime: now,
+              },
+            );
+          }
         }
       }
-      if (params.indexedAccountId) {
-        const indexedAccount = await this.getIndexedAccountSafe({
-          id: params.indexedAccountId,
-        });
-        if (indexedAccount) {
-          syncItem = await syncManagers.indexedAccount.buildSyncItemByDBQuery({
-            syncCredential:
-              await syncManagers.indexedAccount.getSyncCredential(),
-            dbRecord: {
-              ...indexedAccount,
-              name: params.name || indexedAccount.name,
-            },
-            isDeleted: false,
-            dataTime: now,
-          });
-        }
-      }
+    }
+
+    if (shouldSkipAccountUpdate) {
+      return;
     }
 
     await this.withTransaction(EIndexedDBBucketNames.account, async (tx) => {
@@ -4933,8 +5130,8 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
           name: ELocalDBStoreNames.IndexedAccount,
           ids: [params.indexedAccountId],
           updater: (r) => {
-            if (params.name) {
-              r.name = params.name || r.name;
+            if (accountName) {
+              r.name = accountName || r.name;
             }
             return r;
           },
@@ -4946,8 +5143,8 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
           name: ELocalDBStoreNames.Account,
           ids: [params.accountId],
           updater: (r) => {
-            if (params.name) {
-              r.name = params.name || r.name;
+            if (accountName) {
+              r.name = accountName || r.name;
             }
             return r;
           },

--- a/packages/kit-bg/src/dbs/local/types.ts
+++ b/packages/kit-bg/src/dbs/local/types.ts
@@ -191,6 +191,7 @@ export type IDBCreateHDWalletParams = {
   keylessDetailsInfo?: IKeylessWalletDetailsInfo;
   skipAddHDNextIndexedAccount?: boolean;
   overrideWalletId?: string;
+  applyRestoreSyncPolicy?: boolean;
 };
 export type IDBCreateKeylessWalletParams = {
   password: string;
@@ -232,6 +233,7 @@ export type IDBSetWalletNameAndAvatarParams = {
   shouldCheckDuplicate?: boolean;
   skipSaveLocalSyncItem?: boolean; // avoid infinite loop sync
   skipEmitEvent?: boolean;
+  applyRestoreSyncPolicy?: boolean;
 };
 export type IDBRemoveWalletParams = {
   walletId: string;
@@ -242,6 +244,7 @@ type IDBSetAccountNameParamsBase = {
   shouldCheckDuplicate?: boolean;
   skipEventEmit?: boolean;
   skipSaveLocalSyncItem?: boolean; // avoid infinite loop sync
+  applyRestoreSyncPolicy?: boolean;
 };
 export type IDBSetAccountNameParams = IDBSetAccountNameParamsBase & {
   accountId?: string;

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -942,6 +942,7 @@ class ServiceAccount extends ServiceBase {
     account,
     indexedAccountNames,
     skipEventEmit,
+    applyRestoreSyncPolicy,
   }: {
     walletId: string;
     networkId: string;
@@ -950,6 +951,7 @@ class ServiceAccount extends ServiceBase {
       [index: number]: string;
     };
     skipEventEmit?: boolean;
+    applyRestoreSyncPolicy?: boolean;
   }) {
     const {
       addressDetail: _addressDetail,
@@ -967,12 +969,14 @@ class ServiceAccount extends ServiceBase {
       indexes: [dbAccount.pathIndex],
       skipIfExists: true,
       names: indexedAccountNames,
+      applyRestoreSyncPolicy,
     });
     await localDb.addAccountsToWallet({
       allAccountsBelongToNetworkId: networkId,
       walletId,
       accounts: [dbAccount],
       skipEventEmit,
+      applyRestoreSyncPolicy,
     });
   }
 
@@ -1038,8 +1042,10 @@ class ServiceAccount extends ServiceBase {
     walletId: string;
     accounts: IDBAccount[];
     importedCredential?: string;
+    applyRestoreSyncPolicy?: boolean;
   }) {
-    const { walletId, accounts, importedCredential } = params;
+    const { walletId, accounts, importedCredential, applyRestoreSyncPolicy } =
+      params;
     const wallet = await this.getWalletSafe({ walletId });
     const shouldCreateIndexAccount =
       accountUtils.isHdWallet({ walletId }) ||
@@ -1076,8 +1082,24 @@ class ServiceAccount extends ServiceBase {
       walletId,
       accounts,
       importedCredential,
+      applyRestoreSyncPolicy,
     });
     if (shouldCreateIndexAccount) {
+      const indexedAccountNames = Object.fromEntries(
+        accounts
+          .filter(
+            (
+              account,
+            ): account is IDBAccount & {
+              indexedAccountId: string;
+              pathIndex: number;
+            } =>
+              !isNil(account.pathIndex) &&
+              !!account.indexedAccountId &&
+              !!account.name,
+          )
+          .map((account) => [account.pathIndex, account.name]),
+      );
       await this.addIndexedAccount({
         walletId,
         indexes: accounts.map((account) =>
@@ -1088,12 +1110,14 @@ class ServiceAccount extends ServiceBase {
             : 0,
         ),
         skipIfExists: true,
+        names: indexedAccountNames,
+        applyRestoreSyncPolicy,
       });
       for (const account of accounts) {
         const isAccountExists = existsAccounts.some(
           (existsAccount) => existsAccount.id === account.id,
         );
-        if (!isAccountExists) {
+        if (applyRestoreSyncPolicy || !isAccountExists) {
           if (wallet?.xfp && account.indexedAccountId) {
             await this.setUniversalIndexedAccountName({
               name: account.name,
@@ -1102,11 +1126,13 @@ class ServiceAccount extends ServiceBase {
                 indexedAccountId: account.indexedAccountId,
               }).index,
               walletXfp: wallet.xfp,
+              applyRestoreSyncPolicy,
             });
           } else {
             await this.setAccountName({
               name: account.name,
               indexedAccountId: account.indexedAccountId,
+              applyRestoreSyncPolicy,
             });
           }
         }
@@ -1611,6 +1637,7 @@ class ServiceAccount extends ServiceBase {
     shouldCheckDuplicateName,
     skipAddIfNotEqualToAddress,
     skipEventEmit,
+    applyRestoreSyncPolicy,
   }: {
     name?: string;
     fallbackName?: string;
@@ -1620,6 +1647,7 @@ class ServiceAccount extends ServiceBase {
     deriveType: IAccountDeriveTypes | undefined;
     skipAddIfNotEqualToAddress?: string;
     skipEventEmit?: boolean;
+    applyRestoreSyncPolicy?: boolean;
   }): Promise<{
     networkId: string;
     walletId: string;
@@ -1703,6 +1731,7 @@ class ServiceAccount extends ServiceBase {
         walletId,
         accounts,
         importedCredential: credentialEncrypt,
+        applyRestoreSyncPolicy,
         accountNameBuilder: ({ nextAccountId }) => {
           if (fallbackName) {
             return fallbackName;
@@ -1711,11 +1740,17 @@ class ServiceAccount extends ServiceBase {
         },
       });
 
-    void this.fixAccountName({
+    const fixAccountNamePromise = this.fixAccountName({
       account: existsAccounts?.[0],
       name,
       fallbackName,
+      applyRestoreSyncPolicy,
     });
+    if (applyRestoreSyncPolicy) {
+      await fixAccountNamePromise;
+    } else {
+      void fixAccountNamePromise;
+    }
 
     appEventBus.emit(EAppEventBusNames.AccountUpdate, undefined);
 
@@ -1837,19 +1872,22 @@ class ServiceAccount extends ServiceBase {
     account,
     name,
     fallbackName,
+    applyRestoreSyncPolicy,
   }: {
     account: IDBAccount | undefined;
     name?: string;
     fallbackName?: string;
+    applyRestoreSyncPolicy?: boolean;
   }) {
     if (!account) {
       return;
     }
     const newName = name || fallbackName;
-    if (newName && account.name !== newName) {
+    if (newName && (applyRestoreSyncPolicy || account.name !== newName)) {
       await this.setAccountName({
         accountId: account.id,
         name: newName,
+        applyRestoreSyncPolicy,
       });
     }
   }
@@ -1866,6 +1904,7 @@ class ServiceAccount extends ServiceBase {
     isUrlAccount,
     skipAddIfNotEqualToAddress,
     skipEventEmit,
+    applyRestoreSyncPolicy,
   }: {
     input: string;
     networkId: string;
@@ -1876,6 +1915,7 @@ class ServiceAccount extends ServiceBase {
     isUrlAccount?: boolean;
     skipAddIfNotEqualToAddress?: string;
     skipEventEmit?: boolean;
+    applyRestoreSyncPolicy?: boolean;
   }): Promise<{
     networkId: string;
     walletId: string;
@@ -2007,6 +2047,7 @@ class ServiceAccount extends ServiceBase {
         allAccountsBelongToNetworkId: networkId,
         walletId,
         accounts,
+        applyRestoreSyncPolicy,
         accountNameBuilder: ({ nextAccountId }) => {
           if (isUrlAccount) {
             return `Url Account ${Date.now()}`;
@@ -2018,11 +2059,17 @@ class ServiceAccount extends ServiceBase {
         },
       });
 
-    void this.fixAccountName({
+    const fixAccountNamePromise = this.fixAccountName({
       account: existsAccounts?.[0],
       name,
       fallbackName,
+      applyRestoreSyncPolicy,
     });
+    if (applyRestoreSyncPolicy) {
+      await fixAccountNamePromise;
+    } else {
+      void fixAccountNamePromise;
+    }
 
     appEventBus.emit(EAppEventBusNames.AccountUpdate, undefined);
 
@@ -2661,6 +2708,7 @@ class ServiceAccount extends ServiceBase {
     indexes,
     names,
     skipIfExists,
+    applyRestoreSyncPolicy,
   }: {
     walletId: string;
     indexes: number[];
@@ -2668,12 +2716,14 @@ class ServiceAccount extends ServiceBase {
       [index: number]: string;
     };
     skipIfExists: boolean;
+    applyRestoreSyncPolicy?: boolean;
   }) {
     return localDb.addIndexedAccount({
       walletId,
       indexes,
       names,
       skipIfExists,
+      applyRestoreSyncPolicy,
     });
   }
 
@@ -2720,17 +2770,57 @@ class ServiceAccount extends ServiceBase {
     if (!name) {
       return;
     }
-    if (oldName && name && oldName === name) {
+    if (!params.applyRestoreSyncPolicy && oldName && name && oldName === name) {
       return;
     }
 
     const r = await localDb.setAccountName(params);
-    if (!params.skipEventEmit) {
+
+    if (!params.applyRestoreSyncPolicy) {
+      if (!params.skipEventEmit) {
+        appEventBus.emit(EAppEventBusNames.AccountUpdate, undefined);
+      }
+
+      if (oldName && name && oldName !== name) {
+        const entityType: EChangeHistoryEntityType = accountId
+          ? EChangeHistoryEntityType.Account
+          : EChangeHistoryEntityType.IndexedAccount;
+
+        const entityId = accountId || indexedAccountId || '';
+        await simpleDb.changeHistory.addChangeHistory({
+          items: [
+            {
+              entityType,
+              entityId,
+              contentType: EChangeHistoryContentType.Name,
+              oldValue: oldName,
+              value: name,
+            },
+          ],
+        });
+      }
+
+      return r;
+    }
+
+    const latestName = accountId
+      ? (
+          await this.getDBAccountSafe({
+            accountId,
+          })
+        )?.name || ''
+      : (
+          await this.getIndexedAccountSafe({
+            id: indexedAccountId || '',
+          })
+        )?.name || '';
+    const isNameChanged = oldName && latestName && oldName !== latestName;
+
+    if (!params.skipEventEmit && isNameChanged) {
       appEventBus.emit(EAppEventBusNames.AccountUpdate, undefined);
     }
 
-    // Only proceed if the name is actually changing
-    if (oldName && name && oldName !== name) {
+    if (isNameChanged) {
       const entityType: EChangeHistoryEntityType = accountId
         ? EChangeHistoryEntityType.Account
         : EChangeHistoryEntityType.IndexedAccount;
@@ -2744,7 +2834,7 @@ class ServiceAccount extends ServiceBase {
             entityId,
             contentType: EChangeHistoryContentType.Name,
             oldValue: oldName,
-            value: name,
+            value: latestName,
           },
         ],
       });
@@ -3102,6 +3192,7 @@ class ServiceAccount extends ServiceBase {
     avatarInfo,
     keylessDetailsInfo,
     skipAddHDNextIndexedAccount,
+    applyRestoreSyncPolicy,
   }: {
     mnemonic: string;
     name?: string;
@@ -3110,6 +3201,7 @@ class ServiceAccount extends ServiceBase {
     avatarInfo?: IAvatarInfo;
     keylessDetailsInfo?: IKeylessWalletDetailsInfo;
     skipAddHDNextIndexedAccount?: boolean;
+    applyRestoreSyncPolicy?: boolean;
   }) {
     const { servicePassword } = this.backgroundApi;
     const { password } = await servicePassword.promptPasswordVerify({
@@ -3153,6 +3245,7 @@ class ServiceAccount extends ServiceBase {
       avatarInfo,
       keylessDetailsInfo,
       skipAddHDNextIndexedAccount,
+      applyRestoreSyncPolicy,
     });
   }
 
@@ -3201,6 +3294,7 @@ class ServiceAccount extends ServiceBase {
     isKeylessWallet,
     keylessDetailsInfo,
     skipAddHDNextIndexedAccount,
+    applyRestoreSyncPolicy,
   }: {
     rs: string;
     password: string;
@@ -3212,6 +3306,7 @@ class ServiceAccount extends ServiceBase {
     isKeylessWallet?: boolean;
     keylessDetailsInfo?: IKeylessWalletDetailsInfo;
     skipAddHDNextIndexedAccount?: boolean;
+    applyRestoreSyncPolicy?: boolean;
   }): Promise<{
     wallet: IDBWallet;
     indexedAccount?: IDBIndexedAccount;
@@ -3248,6 +3343,7 @@ class ServiceAccount extends ServiceBase {
           walletId: existsSameHashWallet.id,
           indexes: [0],
           skipIfExists: true,
+          applyRestoreSyncPolicy,
         });
         // localDb.buildCreateHDAndHWWalletResult({
         //   walletId: existsSameHashWallet.id,
@@ -3274,6 +3370,7 @@ class ServiceAccount extends ServiceBase {
       isKeylessWallet,
       keylessDetailsInfo,
       skipAddHDNextIndexedAccount,
+      applyRestoreSyncPolicy,
     });
 
     if (result.wallet?.keylessDetailsInfo?.keylessOwnerId) {
@@ -3800,26 +3897,32 @@ class ServiceAccount extends ServiceBase {
     const { walletId, name } = params;
 
     let oldName = '';
+    let oldAvatar = '';
     // Get the old name before updating
-    if (name) {
+    if (name || params.applyRestoreSyncPolicy) {
       const wallet = await this.getWalletSafe({
         walletId,
         withoutRefill: true,
       });
       oldName = wallet?.name || '';
+      oldAvatar = wallet?.avatar || '';
     }
 
     const result = await localDb.setWalletNameAndAvatar(params);
+    const isWalletMetadataChanged =
+      oldName !== result.name || oldAvatar !== (result.avatar || '');
 
-    if (!params.skipEmitEvent) {
+    if (
+      !params.skipEmitEvent &&
+      (!params.applyRestoreSyncPolicy || isWalletMetadataChanged)
+    ) {
       appEventBus.emit(EAppEventBusNames.WalletUpdate, undefined);
       appEventBus.emit(EAppEventBusNames.WalletRename, {
         walletId: params.walletId,
       });
     }
 
-    // Only proceed if the name is actually changing
-    if (name && oldName && oldName !== name) {
+    if (name && oldName && oldName !== result.name) {
       // Record the name change history
       await simpleDb.changeHistory.addChangeHistory({
         items: [
@@ -3828,7 +3931,7 @@ class ServiceAccount extends ServiceBase {
             entityId: walletId,
             contentType: EChangeHistoryContentType.Name,
             oldValue: oldName,
-            value: name,
+            value: result.name,
           },
         ],
       });
@@ -5732,12 +5835,14 @@ class ServiceAccount extends ServiceBase {
     privateKey,
     networkId,
     skipEventEmit,
+    applyRestoreSyncPolicy,
   }: {
     importedAccount: IPrimeTransferAccount;
     input: string;
     privateKey: string;
     networkId: string;
     skipEventEmit?: boolean;
+    applyRestoreSyncPolicy?: boolean;
   }) {
     const addedAccounts: IDBAccount[] = [];
     try {
@@ -5795,6 +5900,7 @@ class ServiceAccount extends ServiceBase {
               name: importedAccount.name,
               deriveType,
               skipAddIfNotEqualToAddress,
+              applyRestoreSyncPolicy,
             });
           addedAccounts.push(...(accounts || []));
         } catch (e) {
@@ -5812,11 +5918,13 @@ class ServiceAccount extends ServiceBase {
     input,
     networkId,
     skipEventEmit,
+    applyRestoreSyncPolicy,
   }: {
     watchingAccount: IPrimeTransferAccount;
     input: string;
     networkId: string;
     skipEventEmit?: boolean;
+    applyRestoreSyncPolicy?: boolean;
   }): Promise<{
     addedAccounts: IDBAccount[];
   }> {
@@ -5874,6 +5982,7 @@ class ServiceAccount extends ServiceBase {
             deriveType,
             isUrlAccount: false,
             skipAddIfNotEqualToAddress,
+            applyRestoreSyncPolicy,
           });
           addedAccounts.push(...(accounts || []));
         } catch (e) {

--- a/packages/kit-bg/src/services/ServiceBatchCreateAccount/ServiceBatchCreateAccount.ts
+++ b/packages/kit-bg/src/services/ServiceBatchCreateAccount/ServiceBatchCreateAccount.ts
@@ -82,6 +82,7 @@ export type IBatchBuildAccountsParams = IBatchBuildAccountsBaseParams & {
   hwRootFingerprintInfo?: {
     rootFingerprint: number | undefined;
   };
+  applyRestoreSyncPolicy?: boolean;
 };
 
 export type IBatchBuildAccountsNormalFlowParams =
@@ -102,6 +103,7 @@ type IAdvancedModeFlowParamsBase = {
   };
   saveToDb: boolean;
   progressTotalCount?: number;
+  applyRestoreSyncPolicy?: boolean;
 };
 export type IBatchBuildAccountsAdvancedFlowParams =
   IBatchBuildAccountsBaseParams & IAdvancedModeFlowParamsBase;
@@ -1222,6 +1224,7 @@ class ServiceBatchCreateAccount extends ServiceBase {
     errorMessage,
     indexedAccountNames,
     hwRootFingerprintInfo,
+    applyRestoreSyncPolicy,
   }: IBatchBuildAccountsParams): Promise<{
     accountsForCreate: IBatchCreateAccount[];
   }> {
@@ -1320,6 +1323,7 @@ class ServiceBatchCreateAccount extends ServiceBase {
             account: accountForCreate,
             indexedAccountNames,
             skipEventEmit: !shouldEmitEvent,
+            applyRestoreSyncPolicy,
           });
           if (this.progressInfo) {
             this.progressInfo.createdCount += 1;

--- a/packages/kit-bg/src/services/ServiceCloudBackup/index.ts
+++ b/packages/kit-bg/src/services/ServiceCloudBackup/index.ts
@@ -673,19 +673,25 @@ class ServiceCloudBackup extends ServiceBase {
           await serviceAccount.createHDWalletWithRs({
             rs: rsEncoded,
             password: localPassword,
+            name,
             avatarInfo: avatar,
             walletHash: walletHashAndXfp.hash,
             walletXfp: walletHashAndXfp.xfp,
             isWalletBackedUp: true,
+            skipAddHDNextIndexedAccount: true,
+            applyRestoreSyncPolicy: true,
           });
         await serviceAccount.restoreAccountsToWallet({
           walletId: wallet.id,
           accounts,
+          applyRestoreSyncPolicy: true,
         });
-        if (!isOverrideWallet) {
+        if (isOverrideWallet) {
           await serviceAccount.setWalletNameAndAvatar({
             walletId: wallet?.id,
             name,
+            avatar,
+            applyRestoreSyncPolicy: true,
           });
         }
       }
@@ -698,6 +704,7 @@ class ServiceCloudBackup extends ServiceBase {
         await serviceAccount.restoreAccountsToWallet({
           walletId: WALLET_TYPE_WATCHING,
           accounts: [account],
+          applyRestoreSyncPolicy: true,
         });
       }
 
@@ -719,6 +726,7 @@ class ServiceCloudBackup extends ServiceBase {
           walletId: WALLET_TYPE_IMPORTED,
           accounts: [account],
           importedCredential,
+          applyRestoreSyncPolicy: true,
         });
       }
 

--- a/packages/kit-bg/src/services/ServicePrimeCloudSync/CloudSyncFlowManager/CloudSyncFlowManagerBase.ts
+++ b/packages/kit-bg/src/services/ServicePrimeCloudSync/CloudSyncFlowManager/CloudSyncFlowManagerBase.ts
@@ -321,6 +321,7 @@ export abstract class CloudSyncFlowManagerBase<
     tx,
     targets,
     useCreateGenesisTime,
+    buildSyncItemDataTime,
     onExistingSyncItemsInfo,
   }: {
     tx: ILocalDBTransaction | undefined;
@@ -328,6 +329,10 @@ export abstract class CloudSyncFlowManagerBase<
     useCreateGenesisTime?: (params: {
       target: ICloudSyncTargetMap[T];
     }) => Promise<boolean>;
+    buildSyncItemDataTime?: (params: {
+      target: ICloudSyncTargetMap[T];
+      existingSyncItem: IDBCloudSyncItem | undefined;
+    }) => Promise<number | undefined>;
     onExistingSyncItemsInfo: (
       existingSyncItemsInfo: IExistingSyncItemsInfo<T>,
     ) => Promise<void>;
@@ -358,33 +363,148 @@ export abstract class CloudSyncFlowManagerBase<
       canSyncWithoutServer ||
       (await this.backgroundApi.servicePrimeCloudSync.isCloudSyncIsAvailable());
 
+    if (!buildSyncItemDataTime) {
+      for (const target of targets) {
+        let existingSyncItem: IDBCloudSyncItem | undefined;
+
+        if (shouldSync) {
+          if (tx) {
+            existingSyncItem = await this.txGetSyncItem({
+              tx,
+              shouldDecrypt: true,
+              target,
+              syncCredential,
+            });
+          } else {
+            existingSyncItem = await this.getSyncItem({
+              // tx,
+              shouldDecrypt: true,
+              target,
+              syncCredential,
+            });
+          }
+        }
+
+        if (
+          existingSyncItem?.rawDataJson &&
+          existingSyncItem?.rawDataJson.dataType === this.dataType &&
+          existingSyncItem?.rawDataJson.payload
+        ) {
+          const syncPayload = existingSyncItem?.rawDataJson.payload;
+
+          if (target.targetId) {
+            existingSyncItemsInfo[target.targetId] = {
+              syncPayload: syncPayload as any,
+              syncItem: existingSyncItem,
+              target,
+            };
+          }
+          existingSyncItems.push(existingSyncItem);
+        } else if (
+          canSyncWithoutServer &&
+          existingSyncItem &&
+          existingSyncItem.rawData
+        ) {
+          try {
+            const rawDataJson = JSON.parse(
+              existingSyncItem.rawData,
+            ) as ICloudSyncRawDataJson;
+            if (rawDataJson.payload) {
+              if (target.targetId) {
+                existingSyncItemsInfo[target.targetId] = {
+                  syncPayload: rawDataJson.payload as any,
+                  syncItem: existingSyncItem,
+                  target,
+                };
+              }
+              existingSyncItems.push(existingSyncItem);
+            }
+          } catch (error) {
+            console.error('parse rawData error', error);
+          }
+        } else {
+          const newSyncItem = await this.buildSyncItem({
+            syncCredential,
+            target,
+            // eslint-disable-next-line react-hooks/rules-of-hooks
+            // oxlint-disable-next-line eslint-plugin-react-hooks/rules-of-hooks
+            dataTime: await (async () => {
+              if (useCreateGenesisTime) {
+                if (await useCreateGenesisTime({ target })) {
+                  console.log(
+                    'useCreateGenesisTime PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME',
+                    PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME,
+                  );
+                  return PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME;
+                }
+              }
+              return this.timeNow();
+            })(),
+          });
+          if (newSyncItem) {
+            newSyncItems.push(newSyncItem);
+          }
+        }
+      }
+
+      await onExistingSyncItemsInfo(existingSyncItemsInfo);
+
+      return {
+        existingSyncItemsInfo,
+        existingSyncItems,
+        newSyncItems,
+      };
+    }
+
+    const targetSyncStateList: Array<{
+      target: ICloudSyncTargetMap[T];
+      existingSyncItem: IDBCloudSyncItem | undefined;
+    }> = [];
+
     for (const target of targets) {
       let existingSyncItem: IDBCloudSyncItem | undefined;
+      let decryptedSyncItem: IDBCloudSyncItem | undefined;
 
-      if (shouldSync) {
-        if (tx) {
-          existingSyncItem = await this.txGetSyncItem({
-            tx,
-            shouldDecrypt: true,
-            target,
+      if (tx) {
+        existingSyncItem = await this.txGetSyncItem({
+          tx,
+          shouldDecrypt: false,
+          target,
+          syncCredential,
+        });
+      } else {
+        existingSyncItem = await this.getSyncItem({
+          // tx,
+          shouldDecrypt: false,
+          target,
+          syncCredential,
+        });
+      }
+
+      if (
+        shouldSync &&
+        existingSyncItem &&
+        existingSyncItem.dataType === this.dataType
+      ) {
+        try {
+          const { dbItem } = await cloudSyncItemBuilder.decryptSyncItem({
+            item: {
+              ...existingSyncItem,
+            },
             syncCredential,
           });
-        } else {
-          existingSyncItem = await this.getSyncItem({
-            // tx,
-            shouldDecrypt: true,
-            target,
-            syncCredential,
-          });
+          decryptedSyncItem = dbItem;
+        } catch (error) {
+          errorUtils.autoPrintErrorIgnore(error);
         }
       }
 
       if (
-        existingSyncItem?.rawDataJson &&
-        existingSyncItem?.rawDataJson.dataType === this.dataType &&
-        existingSyncItem?.rawDataJson.payload
+        decryptedSyncItem?.rawDataJson &&
+        decryptedSyncItem?.rawDataJson.dataType === this.dataType &&
+        decryptedSyncItem?.rawDataJson.payload
       ) {
-        const syncPayload = existingSyncItem?.rawDataJson.payload;
+        const syncPayload = decryptedSyncItem.rawDataJson.payload;
 
         if (target.targetId) {
           existingSyncItemsInfo[target.targetId] = {
@@ -393,7 +513,6 @@ export abstract class CloudSyncFlowManagerBase<
             target,
           };
         }
-        existingSyncItems.push(existingSyncItem);
       } else if (
         canSyncWithoutServer &&
         existingSyncItem &&
@@ -411,37 +530,72 @@ export abstract class CloudSyncFlowManagerBase<
                 target,
               };
             }
-            existingSyncItems.push(existingSyncItem);
           }
         } catch (error) {
           console.error('parse rawData error', error);
         }
+      }
+
+      targetSyncStateList.push({
+        target,
+        existingSyncItem,
+      });
+    }
+
+    await onExistingSyncItemsInfo(existingSyncItemsInfo);
+
+    for (const { target, existingSyncItem } of targetSyncStateList) {
+      if (existingSyncItem) {
+        const updatedDataTime = await buildSyncItemDataTime({
+          target,
+          existingSyncItem,
+        });
+
+        if (updatedDataTime !== undefined) {
+          const updatedSyncItem = await this.buildSyncItem({
+            syncCredential,
+            target,
+            dataTime: updatedDataTime,
+          });
+          if (updatedSyncItem) {
+            newSyncItems.push(updatedSyncItem);
+          } else {
+            existingSyncItems.push(existingSyncItem);
+          }
+        } else {
+          existingSyncItems.push(existingSyncItem);
+        }
       } else {
+        const dataTime = await buildSyncItemDataTime({
+          target,
+          existingSyncItem: undefined,
+        });
+
         const newSyncItem = await this.buildSyncItem({
           syncCredential,
           target,
           // eslint-disable-next-line react-hooks/rules-of-hooks
           // oxlint-disable-next-line eslint-plugin-react-hooks/rules-of-hooks
-          dataTime: await (async () => {
-            if (useCreateGenesisTime) {
-              if (await useCreateGenesisTime({ target })) {
-                console.log(
-                  'useCreateGenesisTime PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME',
-                  PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME,
-                );
-                return PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME;
+          dataTime:
+            dataTime ??
+            (await (async () => {
+              if (useCreateGenesisTime) {
+                if (await useCreateGenesisTime({ target })) {
+                  console.log(
+                    'useCreateGenesisTime PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME',
+                    PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME,
+                  );
+                  return PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME;
+                }
               }
-            }
-            return this.timeNow();
-          })(),
+              return this.timeNow();
+            })()),
         });
         if (newSyncItem) {
           newSyncItems.push(newSyncItem);
         }
       }
     }
-
-    await onExistingSyncItemsInfo(existingSyncItemsInfo);
 
     return {
       existingSyncItemsInfo,

--- a/packages/kit-bg/src/services/ServicePrimeCloudSync/CloudSyncFlowManager/CloudSyncFlowManagerBase.ts
+++ b/packages/kit-bg/src/services/ServicePrimeCloudSync/CloudSyncFlowManager/CloudSyncFlowManagerBase.ts
@@ -320,7 +320,7 @@ export abstract class CloudSyncFlowManagerBase<
   async buildExistingSyncItemsInfo({
     tx,
     targets,
-    useCreateGenesisTime,
+    useCreateGenesisTime: shouldUseCreateGenesisTime,
     buildSyncItemDataTime,
     onExistingSyncItemsInfo,
   }: {
@@ -426,11 +426,9 @@ export abstract class CloudSyncFlowManagerBase<
           const newSyncItem = await this.buildSyncItem({
             syncCredential,
             target,
-            // eslint-disable-next-line react-hooks/rules-of-hooks
-            // oxlint-disable-next-line eslint-plugin-react-hooks/rules-of-hooks
             dataTime: await (async () => {
-              if (useCreateGenesisTime) {
-                if (await useCreateGenesisTime({ target })) {
+              if (shouldUseCreateGenesisTime) {
+                if (await shouldUseCreateGenesisTime({ target })) {
                   console.log(
                     'useCreateGenesisTime PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME',
                     PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME,
@@ -500,6 +498,7 @@ export abstract class CloudSyncFlowManagerBase<
       }
 
       if (
+        existingSyncItem &&
         decryptedSyncItem?.rawDataJson &&
         decryptedSyncItem?.rawDataJson.dataType === this.dataType &&
         decryptedSyncItem?.rawDataJson.payload
@@ -574,13 +573,11 @@ export abstract class CloudSyncFlowManagerBase<
         const newSyncItem = await this.buildSyncItem({
           syncCredential,
           target,
-          // eslint-disable-next-line react-hooks/rules-of-hooks
-          // oxlint-disable-next-line eslint-plugin-react-hooks/rules-of-hooks
           dataTime:
             dataTime ??
             (await (async () => {
-              if (useCreateGenesisTime) {
-                if (await useCreateGenesisTime({ target })) {
+              if (shouldUseCreateGenesisTime) {
+                if (await shouldUseCreateGenesisTime({ target })) {
                   console.log(
                     'useCreateGenesisTime PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME',
                     PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME,

--- a/packages/kit-bg/src/services/ServicePrimeTransfer/ServicePrimeTransfer.ts
+++ b/packages/kit-bg/src/services/ServicePrimeTransfer/ServicePrimeTransfer.ts
@@ -2248,15 +2248,26 @@ class ServicePrimeTransfer extends ServiceBase {
           throw new OneKeyLocalError('Mnemonic is required');
         }
         // serviceAccount.createAddressIfNotExists
-        const { wallet: newWalletData } = await serviceAccount.createHDWallet({
-          mnemonic: await servicePassword.encodeSensitiveText({
-            text: mnemonicFromRs,
-          }),
-          name: wallet.name,
-          avatarInfo: wallet.avatarInfo,
-          isWalletBackedUp: wallet.backuped,
-        });
+        const { wallet: newWalletData, isOverrideWallet } =
+          await serviceAccount.createHDWallet({
+            mnemonic: await servicePassword.encodeSensitiveText({
+              text: mnemonicFromRs,
+            }),
+            name: wallet.name,
+            avatarInfo: wallet.avatarInfo,
+            isWalletBackedUp: wallet.backuped,
+            skipAddHDNextIndexedAccount: true,
+            applyRestoreSyncPolicy: true,
+          });
         newWallet = newWalletData;
+        if (isOverrideWallet && newWallet?.id) {
+          await serviceAccount.setWalletNameAndAvatar({
+            walletId: newWallet.id,
+            name: wallet.name,
+            avatar: wallet.avatarInfo,
+            applyRestoreSyncPolicy: true,
+          });
+        }
       } catch (e) {
         console.error('startImport error', e);
         errorsInfo.push({
@@ -2329,6 +2340,7 @@ class ServicePrimeTransfer extends ServiceBase {
               saveToDb: true,
               showUIProgress: true, // emit EAppEventBusNames.BatchCreateAccount event
               autoHandleExitError: false,
+              applyRestoreSyncPolicy: true,
             };
             // params.customNetworks = [];
             // params.includingDefaultNetworks = true;
@@ -2363,6 +2375,7 @@ class ServicePrimeTransfer extends ServiceBase {
               indexedAccountId,
               name: indexedAccountNames[index],
               skipEventEmit: true,
+              applyRestoreSyncPolicy: true,
             });
           }
         } catch (e) {
@@ -2424,6 +2437,7 @@ class ServicePrimeTransfer extends ServiceBase {
           privateKey,
           networkId,
           skipEventEmit: true,
+          applyRestoreSyncPolicy: true,
         });
       if (addedAccounts?.length && addedAccounts?.[0]?.id) {
         try {
@@ -2520,6 +2534,7 @@ class ServicePrimeTransfer extends ServiceBase {
           input: watchingAccount.pub,
           networkId,
           skipEventEmit: true,
+          applyRestoreSyncPolicy: true,
         });
         addedAccounts = [...addedAccounts, ...(result?.addedAccounts || [])];
       }
@@ -2534,6 +2549,7 @@ class ServicePrimeTransfer extends ServiceBase {
           input: watchingAccountUtxo.xpub,
           networkId,
           skipEventEmit: true,
+          applyRestoreSyncPolicy: true,
         });
         addedAccounts = [...addedAccounts, ...(result?.addedAccounts || [])];
       }
@@ -2548,6 +2564,7 @@ class ServicePrimeTransfer extends ServiceBase {
           input: watchingAccountUtxo.xpubSegwit,
           networkId,
           skipEventEmit: true,
+          applyRestoreSyncPolicy: true,
         });
         addedAccounts = [...addedAccounts, ...(result?.addedAccounts || [])];
       }
@@ -2562,6 +2579,7 @@ class ServicePrimeTransfer extends ServiceBase {
           input: watchingAccount.address,
           networkId,
           skipEventEmit: true,
+          applyRestoreSyncPolicy: true,
         });
         addedAccounts = [...addedAccounts, ...(result?.addedAccounts || [])];
       }


### PR DESCRIPTION
## Summary
- limit `applyRestoreSyncPolicy` activation to Prime Transfer and iCloud backup restore flows
- preserve existing behavior for regular account import, watching account import, wallet rename, and batch account creation flows
- update restore-time sync item handling so metadata backfill only happens when the restore policy is explicitly enabled

## Intent & Context
The goal of this change is to keep the new restore sync reconciliation logic scoped to the recovery flows that actually need it. The user request was to review and ensure the updated behavior only triggers during Transfer and iCloud import restore, while every other flow keeps its existing logic unchanged.

## Root Cause
The restore-related sync policy needed to reuse server-side metadata when recovering wallets and accounts, but the supporting implementation lives in shared account and local DB layers. Without explicit gating, the same code paths could accidentally affect normal import, rename, or batch creation flows.

## Design Decisions
- Introduced an explicit `applyRestoreSyncPolicy` flag and threaded it through shared service and local DB entry points.
- Kept the default path unchanged by branching all new behavior behind the restore-policy flag.
- Applied the flag only from Prime Transfer and iCloud backup restore entry points.
- Preserved existing cloud sync manager behavior when the restore policy callback is not provided.

## Changes Detail
- Updated local DB wallet/account/indexed-account creation and rename logic to reuse sync payload metadata only when restore policy is enabled.
- Added restore-specific sync item timestamp backfill behavior to avoid changing normal sync semantics.
- Passed the restore policy through Transfer HD wallet restore, imported account restore, watching account restore, and iCloud backup restore flows.
- Kept event emission and change-history behavior aligned with actual metadata changes during restore.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: shared restore flow plumbing in `kit-bg`, sync item generation, wallet/account rename side effects during recovery

## Test plan
- [ ] Verify Prime Transfer restore keeps cloud metadata for duplicated HD wallets and restored accounts
- [ ] Verify iCloud backup restore keeps cloud metadata for duplicated wallets and restored accounts
- [ ] Verify regular imported account and watching account flows behave the same as before
- [ ] Verify normal batch HD account creation does not trigger restore-only sync behavior

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
