### PR TITLE
fix(core): pin ethereumjs-util to 7.1.5 for correct personal_sign behavior

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,6 +53,7 @@
     "ecpair": "^2.1.0",
     "elliptic": "^6.6.0",
     "eth-sig-util": "^3.0.1",
+    "ethereumjs-util": "7.1.5",
     "js-conflux-sdk": "^2.1.12",
     "jsrsasign": "^10.8.6",
     "near-api-js": "^2.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9498,6 +9498,7 @@ __metadata:
     ecpair: "npm:^2.1.0"
     elliptic: "npm:^6.6.0"
     eth-sig-util: "npm:^3.0.1"
+    ethereumjs-util: "npm:7.1.5"
     folderslint: "npm:1.2.0"
     js-conflux-sdk: "npm:^2.1.12"
     jsrsasign: "npm:^10.8.6"
@@ -28534,7 +28535,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethereumjs-util@npm:*":
+"ethereumjs-util@npm:*, ethereumjs-util@npm:7.1.5":
   version: 7.1.5
   resolution: "ethereumjs-util@npm:7.1.5"
   dependencies:


### PR DESCRIPTION
## Summary
- Pin `ethereumjs-util` to version `7.1.5` in `@onekeyhq/core` package to fix referral code binding signature verification failure

## Intent & Context
User reported "Invalid signature" error when binding referral codes via HD wallet. The issue only appeared on local builds after v6.1.0, while production App worked correctly. Investigation revealed a dependency hoisting issue causing incorrect signature generation.

## Root Cause
PR #10996 (`f45b62fdc3` - "add OneKey CLI") introduced a new package that changed yarn's dependency hoisting strategy:
- **Before**: Root `node_modules/ethereumjs-util` was `7.1.5`
- **After**: Root `node_modules/ethereumjs-util` became `5.1.0` (from `@starcoin/starcoin`)

The behavioral difference between versions:
- `ethereumjs-util@7.1.5`: `toBuffer()` throws error for hex strings without `0x` prefix
- `ethereumjs-util@5.1.0`: `toBuffer()` silently treats them as UTF-8 strings

The `autoFixPersonalSignMessage()` function relies on `toBuffer()` throwing an error to detect raw hex and add the `0x` prefix. When `toBuffer()` doesn't throw, the raw hex string gets signed as plain text instead of decoded bytes, causing signature verification to fail on the server.

## Design Decisions
- **Chosen approach**: Add explicit `ethereumjs-util@7.1.5` dependency to `@onekeyhq/core` package
- **Rationale**: This pins the version for core's imports without affecting other packages that may need different versions (e.g., `@starcoin/starcoin` uses `5.1.0`)
- **Alternative considered**: Global resolution in root `package.json` - rejected because it would force all packages to use the same version

## Changes Detail
- `packages/core/package.json`: Added `"ethereumjs-util": "7.1.5"` to dependencies
- `yarn.lock`: Updated to reflect the new dependency

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: All (Extension / Mobile / Desktop / Web)
- **Risk Areas**: HD wallet personal_sign operations; minimal risk as this restores previous working behavior

## Test plan
- [ ] Verify `node_modules/ethereumjs-util` version is `7.1.5` after `yarn install`
- [ ] Test referral code binding flow with HD wallet - should succeed without "Invalid signature" error
- [ ] Verify other signing operations still work correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
