### PR TITLE
fix(keyboard): dismiss native (non-RN) keyboards to unblock Dialog on Send (OK-42598)

### DIFF
--- a/packages/shared/src/keyboard/index.native.ts
+++ b/packages/shared/src/keyboard/index.native.ts
@@ -1,14 +1,23 @@
-import { Keyboard } from 'react-native';
+import { KeyboardController } from 'react-native-keyboard-controller';
 
+// Do NOT use RN's `Keyboard.dismiss()` here — on both iOS and Android it is
+// implemented as `TextInputState.blurTextInput(currentlyFocusedInput())`,
+// which only blurs RN-managed TextInputs. Keyboards raised by native inputs
+// outside RN's tracking (e.g. UITextField inside @onekeyfe/react-native-
+// auto-size-input's Nitro HybridView used by Send amount input) are not
+// affected and remain on screen, so `Dialog.show` ends up rendering its
+// Sheet behind the still-visible system keyboard (OK-42598).
+//
+// `KeyboardController.dismiss()` from react-native-keyboard-controller is a
+// true global dismiss: on iOS it resigns `UIResponder.current`, on Android
+// it calls `InputMethodManager.hideSoftInputFromWindow` on the currently
+// focused input's window token. Both code paths dismiss any soft keyboard
+// regardless of whether RN tracks the input.
 export const dismissKeyboard = () => {
-  if (Keyboard.isVisible()) {
-    Keyboard.dismiss();
-  }
+  void KeyboardController.dismiss();
 };
 
 export const dismissKeyboardWithDelay = async (delayMs = 80) => {
-  if (Keyboard.isVisible()) {
-    Keyboard.dismiss();
-    await new Promise((resolve) => setTimeout(resolve, delayMs));
-  }
+  await KeyboardController.dismiss();
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
 };


### PR DESCRIPTION
## 现象 (OK-42598)

iOS 上当 Send 输入金额页（键盘展开）出现「队列中有太多待处理的交易」toast，点击 toast 上的「清除处理中的交易」按钮后，屏幕只出现 \$bgBackdrop 灰色蒙层，`Dialog` 本体完全不可见，清理流程也无法继续。

## 根因链路

1. `Dialog.show` 在挂 Sheet 之前调用 `Keyboard.dismissWithDelay` 尝试关键盘。
2. 该 helper 底层调用 RN 的 `Keyboard.dismiss()`。但 RN 的实现是：
   ```js
   // node_modules/react-native/Libraries/Utilities/dismissKeyboard.js
   TextInputState.blurTextInput(TextInputState.currentlyFocusedInput());
   ```
   只 blur **RN 自己追踪的 `TextInput`**，对其他来源的键盘完全无效。
3. Send 输入金额页用的是 `@onekeyfe/react-native-auto-size-input`（Nitro HybridView）。它内部是原生 `UITextField` / `EditText`，通过 `becomeFirstResponder()` 直接拉起系统键盘，不走 RN 的键盘追踪。因此 `Keyboard.dismiss()` 在这个场景下等于空操作。
4. iOS 系统键盘所在的 `UIRemoteKeyboardWindow` 的 `windowLevel` 高于 `FullWindowOverlay`，所以 Dialog 的 Sheet.Frame 虽然渲染在屏幕底部，但被仍然展开的系统键盘物理覆盖——用户只看到 Sheet.Overlay（灰蒙层）。
5. 原来的 `if (Keyboard.isVisible()) { ... }` guard 更让人误以为 dismiss 被正确调用——实际上 `isVisible()` 只反映 RN 追踪的那份可见性，Nitro 键盘下返回 false，直接被跳过。

## 修复

把 `packages/shared/src/keyboard/index.native.ts` 里 `dismissKeyboard` / `dismissKeyboardWithDelay` 的底层从 RN `Keyboard.dismiss()` 换成 **`react-native-keyboard-controller` 的 `KeyboardController.dismiss()`**，这是真正的全局 dismiss：

- iOS：\`UIResponder.current?.resignFirstResponder()\`
- Android：\`InputMethodManager.hideSoftInputFromWindow(view.windowToken, 0)\`

两端都和输入框来源无关，只要是 first responder / focused view 就能收掉。顺便去掉 `Keyboard.isVisible()` 的 guard——它只反映 RN 自己追踪的可见性，Nitro 键盘下会误判 false 导致 dismiss 被跳过。

影响面：所有复用 `dismissKeyboard` / `dismissKeyboardWithDelay` 的入口（Dialog / Popover / ActionList / Toast.show / Carousel / Select / OTPInput 等 30+ 处）都会从此可靠收起 Nitro UITextField 拉起的键盘。

## Test plan

- [ ] iOS: 进入 Send → 输入金额页（键盘展开）；构造 pending-queue too long 场景（或 Gallery `ErrorToast` 自测）→ 点 toast 的「清除处理中的交易」→ 键盘收起、Dialog 正常弹出、确认后流程正常。
- [ ] iOS: 验证 Popover / ActionList / Swap slippage Dialog 等其它从 Send 输入金额页触发的弹窗同样不再被键盘遮挡。
- [ ] Android: 回归 Setting 页 Clear pending transactions / 其它 Dialog.show 入口，确保 dismiss 正常、无副作用。
- [ ] 普通场景（无键盘）：任意页面的 Dialog.show / Toast.show / ActionList 点击，确认无回归。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
