### PR TITLE
fix(discovery): add safe area bottom padding to browser tab switcher toolbar(OK-53268)

### DIFF
--- a/packages/kit/src/views/Discovery/pages/MobileTabListModal/index.tsx
+++ b/packages/kit/src/views/Discovery/pages/MobileTabListModal/index.tsx
@@ -13,6 +13,7 @@ import {
   Toast,
   XStack,
   useClipboard,
+  useSafeAreaInsets,
 } from '@onekeyhq/components';
 import type { IActionListItemProps } from '@onekeyhq/components';
 import type { IPageNavigationProp } from '@onekeyhq/components/src/layouts/Navigation';
@@ -57,9 +58,11 @@ function TabToolBar({
   onDone: () => void;
 }) {
   const intl = useIntl();
+  const { bottom } = useSafeAreaInsets();
   return (
     <Stack
-      py="$2"
+      pt="$2"
+      pb={bottom || '$2'}
       flexDirection="row"
       alignItems="center"
       borderTopWidth={StyleSheet.hairlineWidth}


### PR DESCRIPTION
## Summary
- Add safe area bottom padding to `TabToolBar` component in MobileTabListModal
- Import `useSafeAreaInsets` hook and apply bottom inset to toolbar padding

## Intent & Context
User reported that the bottom buttons ("Close All", "+", "Done") in the iOS Browser Tab Switcher modal are positioned too low and cannot be tapped. The issue was reported via Slack and tracked in Jira OK-53268.

## Root Cause
The `TabToolBar` component was using fixed `py="$2"` padding without considering iOS safe area insets. When `Page.Footer` has custom children, it doesn't automatically apply safe area padding - the child component must handle it manually.

This issue has existed since the original implementation (`e524f8c6a7 Feat/explore browser`) - the safe area was never handled for this specific toolbar.

## Design Decisions
- Used `useSafeAreaInsets` hook to get the bottom safe area value
- Changed `py="$2"` to `pt="$2"` (top padding) + `pb={bottom || '$2'}` (bottom padding)
- When device has safe area bottom, use it; otherwise fall back to default `$2` padding
- Minimal change approach - only added what's necessary to fix the issue

## Changes Detail
- `packages/kit/src/views/Discovery/pages/MobileTabListModal/index.tsx`:
  - Import `useSafeAreaInsets` from `@onekeyhq/components`
  - Add `const { bottom } = useSafeAreaInsets()` in `TabToolBar`
  - Replace `py="$2"` with `pt="$2"` and `pb={bottom || '$2'}`

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: iOS Mobile only
- **Risk Areas**: Only affects the browser tab switcher toolbar padding

## Test plan
- [ ] Open the app on iOS device
- [ ] Navigate to Browser module
- [ ] Open multiple browser tabs
- [ ] Open Tab Switcher (tap on tab count)
- [ ] Verify bottom buttons ("Close All", "+", "Done") are visible and tappable
- [ ] Test on devices with different safe area sizes (iPhone with notch vs without)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
