### PR TITLE
fix: chunk batch token details requests into groups of 50 for bulk send

### DIFF
--- a/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/BulkSendAmountsInput.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/BulkSendAmountsInput.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import BigNumber from 'bignumber.js';
-import { isEmpty } from 'lodash';
+import { chunk, isEmpty } from 'lodash';
 import pLimit from 'p-limit';
 import { useIntl } from 'react-intl';
 import { Keyboard } from 'react-native';
@@ -1420,17 +1420,25 @@ function BulkSendAmountsInputContent({
           sendersWithAccountId.find((sender) => sender.accountId)?.accountId ??
           accountId ??
           '';
-        const resp =
-          await backgroundApiProxy.serviceToken.fetchTokensDetailsBatch({
-            accountId: batchAccountId,
-            networkId,
-            contractList: [tokenInfo.address],
-            queries: Array.from(senderGroups.values()).map((group) => ({
-              accountAddress: group.queryAddress,
-            })),
-          });
 
-        resp.forEach((item) => {
+        const BATCH_CHUNK_SIZE = 50;
+        const allGroups = Array.from(senderGroups.values());
+        const groupChunks = chunk(allGroups, BATCH_CHUNK_SIZE);
+
+        const chunkResults = await Promise.all(
+          groupChunks.map((groupChunk) =>
+            backgroundApiProxy.serviceToken.fetchTokensDetailsBatch({
+              accountId: batchAccountId,
+              networkId,
+              contractList: [tokenInfo.address],
+              queries: groupChunk.map((group) => ({
+                accountAddress: group.queryAddress,
+              })),
+            }),
+          ),
+        );
+
+        chunkResults.flat().forEach((item) => {
           const addressKey = buildSenderBalanceAddressKey(item.accountAddress);
           if (!senderGroups.has(addressKey)) {
             return;


### PR DESCRIPTION
## Summary
- Split the `fetchTokensDetailsBatch` API call into chunks of 50 unique addresses with concurrent execution
- Prevents potential timeout or payload-size issues when bulk sending with hundreds of unique sender addresses

## Intent & Context
When using the bulk send feature in ManyToMany/ManyToOne mode with a large number of unique sender addresses, the batch token details API is called with all addresses in a single request. This can cause timeout or server-side payload limits when the address count is large (e.g., 200+ unique senders). The fix chunks the deduplicated addresses into groups of 50 and sends them concurrently via `Promise.all`, then flattens the results back into the existing processing pipeline.

## Design Decisions
- **Chunk size of 50**: Balances between minimizing request count and staying within reasonable API payload limits
- **`Promise.all` for concurrency**: All chunks are independent and can be fetched in parallel — no need for sequential processing or rate limiting since the server-side batch endpoint already handles the load per request
- **`chunkResults.flat()`**: Simple flattening merges all response arrays before feeding into the existing per-item parsing loop, requiring zero changes to downstream logic

## Changes Detail
- `BulkSendAmountsInput.tsx`: Import `chunk` from lodash; replace single `fetchTokensDetailsBatch` call with chunked concurrent requests; flatten results before existing response parsing

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: The chunking logic only affects the request dispatch — response parsing and balance mapping remain unchanged

## Test plan
- [ ] Bulk send ManyToMany mode with < 50 unique senders — should send 1 batch request (no behavioral change)
- [ ] Bulk send ManyToMany mode with 120 unique senders — should send 3 concurrent requests (50+50+20)
- [ ] Bulk send with 500 identical sender addresses — should still send only 1 request (deduplication unaffected)
- [ ] Verify sender balances display correctly on the amounts input page
- [ ] Verify custom network fallback path (legacy per-sender fetch) is unaffected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
