### PR TITLE
chore(skill): add Jira field update step to 1k-create-pr workflow

### DIFF
--- a/.skillshare/skills/1k-create-pr/SKILL.md
+++ b/.skillshare/skills/1k-create-pr/SKILL.md
@@ -21,6 +21,7 @@ Automates the complete PR creation workflow for OneKey app-monorepo changes.
 | 7 | Extract context | Analyze conversation for intent, decisions, risks |
 | 8 | Create PR | `gh pr create --base <base> --title "..." --body "..."` |
 | 9 | Enable auto-merge | `gh pr merge <number> --auto --squash` |
+| 10 | Update Jira issue | Update `1k-github-branch` and `1k-github-pr-url` fields |
 
 ## Workflow
 
@@ -173,7 +174,43 @@ gh pr update-branch <PR_NUMBER>
 gh pr merge <PR_NUMBER> --auto --squash
 ```
 
-### 10. Return PR URL
+### 10. Update Jira Issue (if OK-{number} exists)
+
+If a Jira issue ID (`OK-{number}`) was found in the conversation or commit message, update the Jira issue with PR and branch information.
+
+**Prerequisites:**
+1. Check if Atlassian MCP tools are available using `ToolSearch`:
+   ```
+   ToolSearch({ query: "select:mcp__plugin_atlassian_atlassian__editJiraIssue" })
+   ```
+2. If the tool is not available (MCP disconnected), skip this step and notify the user to update Jira manually.
+
+**Jira Custom Field IDs:**
+- `customfield_10241` = `1k-github-branch` (branch name)
+- `customfield_10242` = `1k-github-pr-url` (PR URL)
+
+**Using Atlassian MCP tool:**
+
+```
+mcp__plugin_atlassian_atlassian__editJiraIssue({
+  cloudId: "onekeyhq.atlassian.net",
+  issueIdOrKey: "OK-{number}",
+  fields: {
+    "customfield_10241": "<branch-name>",
+    "customfield_10242": "<pr-url>"
+  }
+})
+```
+
+**Example:**
+```
+fields: {
+  "customfield_10241": "fix/ios-browser-tab-switcher-safe-area",
+  "customfield_10242": "https://github.com/OneKeyHQ/app-monorepo/pull/11219"
+}
+```
+
+### 11. Return PR URL
 
 Display PR URL to user and open in browser:
 ```bash


### PR DESCRIPTION
## Summary
- Add step 10 to update Jira issue custom fields after PR creation
- Document Jira custom field IDs for `1k-github-branch` and `1k-github-pr-url`
- Add MCP availability check before attempting Jira update

## Intent & Context
When creating PRs linked to Jira issues (OK-{number}), we want to automatically populate the `1k-github-branch` and `1k-github-pr-url` custom fields in Jira. This improves traceability between GitHub PRs and Jira issues.

## Changes Detail
- `.skillshare/skills/1k-create-pr/SKILL.md`:
  - Added step 10 in Quick Reference table
  - Added detailed instructions for checking MCP availability
  - Documented Jira custom field IDs:
    - `customfield_10241` = `1k-github-branch`
    - `customfield_10242` = `1k-github-pr-url`
  - Added example MCP tool call
  - Renumbered "Return PR URL" to step 11

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: None (documentation only)
- **Risk Areas**: None

## Test plan
- [ ] Verify skill file renders correctly
- [ ] Test workflow with a real Jira-linked PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
