### PR TITLE
fix(perps): recover WS subscriptions on browser tab switch(OK-53250)

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -443,6 +443,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   // _destroySubscription completion deletes newly created tracking entries
   private async _forceReconnectTransport(): Promise<void> {
     this._clearPostOpenDataCheck();
+    this._clearNetworkTimeout();
     this._stopPingLoop();
     this._activeSubscriptions.clear();
     await this._closeClient();

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -129,6 +129,8 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
   private _lastMessageAt: number | null = null;
 
+  private _postOpenDataCheckTimer: ReturnType<typeof setTimeout> | null = null;
+
   allSubSpecsMap: Record<string, ISubscriptionSpec<ESubscriptionType>> = {};
 
   pendingSubSpecsMap: Record<string, ISubscriptionSpec<ESubscriptionType>> = {};
@@ -343,33 +345,22 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     await this.enableSubscriptionsHandler();
     console.log('updateSubscriptions__by__resumeSubscriptions');
 
-    // Reconnect if socket is CLOSED (iOS closes WebSocket when app is in background)
     const client = await this.getWebSocketClient();
     if (client?.transport?.socket?.readyState === WebSocket.CLOSED) {
-      console.log('resumeSubscriptions__reconnecting_closed_socket');
-      await this.disconnect();
-      await this.getWebSocketClient();
-    }
-
-    await this.updateSubscriptions();
-
-    const hookInfo = await perpsCandlesWebviewReloadHookAtom.get();
-    if (hookInfo.reloadHook <= -1) {
-      await perpsCandlesWebviewReloadHookAtom.set({
-        reloadHook: Date.now(),
-      });
+      console.log('resumeSubscriptions__force_reconnect_transport');
+      await this._forceReconnectTransport();
+    } else {
+      await this.updateSubscriptions();
     }
   }
 
   @backgroundMethod()
   async pauseSubscriptions(): Promise<void> {
     await this.disableSubscriptionsHandler();
+    this._clearPostOpenDataCheck();
     this._stopPingLoop();
     await this._cleanupAllSubscriptions();
-
-    await perpsCandlesWebviewReloadHookAtom.set({
-      reloadHook: -1 * Date.now(),
-    });
+    // No reloadHook change — iframe WS self-heals on resume
   }
 
   hasNewUserFills = false;
@@ -427,6 +418,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   async disconnect(): Promise<void> {
     await this._cleanupAllSubscriptions();
     this._clearNetworkTimeout();
+    this._clearPostOpenDataCheck();
     this._stopPingLoop();
     await this._closeClient();
     this._currentState.isConnected = false;
@@ -443,7 +435,47 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   @backgroundMethod()
   async cleanup(): Promise<void> {
     this._stopPingLoop();
+    this._clearPostOpenDataCheck();
     await this._cleanupAllSubscriptions();
+  }
+
+  // Skip per-subscription unsubscribe to avoid async race where stale
+  // _destroySubscription completion deletes newly created tracking entries
+  private async _forceReconnectTransport(): Promise<void> {
+    this._clearPostOpenDataCheck();
+    this._stopPingLoop();
+    this._activeSubscriptions.clear();
+    await this._closeClient();
+    this._client = null;
+    this._clientInitPromise = null;
+    this._currentState.isConnected = false;
+    await perpsNetworkStatusAtom.set(
+      (prev): IPerpsNetworkStatus => ({ ...prev, connected: false }),
+    );
+    this._emitConnectionStatus();
+    await this.getWebSocketClient();
+  }
+
+  private _startPostOpenDataCheck(): void {
+    this._clearPostOpenDataCheck();
+    const messageAtBefore = this._lastMessageAt;
+    this._postOpenDataCheckTimer = setTimeout(async () => {
+      this._postOpenDataCheckTimer = null;
+      if (
+        this._lastMessageAt === messageAtBefore &&
+        !this.subscriptionsHandlerDisabled
+      ) {
+        console.log('staleness_watchdog__force_reconnect_transport');
+        await this._forceReconnectTransport();
+      }
+    }, 5000);
+  }
+
+  private _clearPostOpenDataCheck(): void {
+    if (this._postOpenDataCheckTimer) {
+      clearTimeout(this._postOpenDataCheckTimer);
+      this._postOpenDataCheckTimer = null;
+    }
   }
 
   @backgroundMethod()
@@ -561,6 +593,13 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     );
     this._currentState.isConnected = true;
     this._startPingLoop();
+
+    // Skip initial connect — only notify iframe on reconnection
+    if (wasConnected === false && this._lastMessageAt !== null) {
+      appEventBus.emit(EAppEventBusNames.PerpsWebSocketRecovered, undefined);
+    }
+
+    this._startPostOpenDataCheck();
   };
 
   socketMessageHandler: (event: WebSocketEventMap['message']) => void = (

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -347,6 +347,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   @backgroundMethod()
   async resumeSubscriptions(): Promise<void> {
     await this.enableSubscriptionsHandler();
+    this._postOpenDataCheckRetries = 0;
     console.log('updateSubscriptions__by__resumeSubscriptions');
 
     const client = await this.getWebSocketClient();

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -131,6 +131,10 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
   private _postOpenDataCheckTimer: ReturnType<typeof setTimeout> | null = null;
 
+  private _postOpenDataCheckRetries = 0;
+
+  private static readonly POST_OPEN_DATA_CHECK_MAX_RETRIES = 3;
+
   allSubSpecsMap: Record<string, ISubscriptionSpec<ESubscriptionType>> = {};
 
   pendingSubSpecsMap: Record<string, ISubscriptionSpec<ESubscriptionType>> = {};
@@ -459,6 +463,13 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
   private _startPostOpenDataCheck(): void {
     this._clearPostOpenDataCheck();
+    if (
+      this._postOpenDataCheckRetries >=
+      ServiceHyperliquidSubscription.POST_OPEN_DATA_CHECK_MAX_RETRIES
+    ) {
+      // Stop retrying — rely on transport's built-in backoff
+      return;
+    }
     const messageAtBefore = this._lastMessageAt;
     this._postOpenDataCheckTimer = setTimeout(async () => {
       this._postOpenDataCheckTimer = null;
@@ -466,8 +477,13 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         this._lastMessageAt === messageAtBefore &&
         !this.subscriptionsHandlerDisabled
       ) {
-        console.log('staleness_watchdog__force_reconnect_transport');
+        this._postOpenDataCheckRetries += 1;
+        console.log(
+          `post_open_data_check__force_reconnect (${this._postOpenDataCheckRetries}/${ServiceHyperliquidSubscription.POST_OPEN_DATA_CHECK_MAX_RETRIES})`,
+        );
         await this._forceReconnectTransport();
+      } else {
+        this._postOpenDataCheckRetries = 0;
       }
     }, 5000);
   }
@@ -1205,6 +1221,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
   private _scheduleNetworkTimeout(messageTimestamp: number): void {
     this._lastMessageAt = messageTimestamp;
+    this._postOpenDataCheckRetries = 0;
 
     if (this._networkTimeoutTimer) {
       return;

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -552,6 +552,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       event,
     });
     this._activeSubscriptions.clear();
+    this._clearPostOpenDataCheck();
     this._stopPingLoop();
     void perpsNetworkStatusAtom.set((prev): IPerpsNetworkStatus => {
       return {

--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
@@ -8,6 +8,10 @@ import {
   useTradingFormEnvAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import { usePerpsCandlesWebviewMountedAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  EAppEventBusNames,
+  appEventBus,
+} from '@onekeyhq/shared/src/eventBus/appEventBus';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IHex } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
@@ -188,6 +192,33 @@ export function TradingViewPerpsV2(
     symbol,
     isChartReady: isChartLinesReady,
   });
+
+  const pendingRecoverRef = useRef(false);
+
+  useEffect(() => {
+    const handler = () => {
+      if (isChartLinesReady && webRef.current) {
+        webRef.current.sendMessageViaInjectedScript({
+          type: 'FORCE_RECOVER_WS',
+        });
+      } else {
+        pendingRecoverRef.current = true;
+      }
+    };
+    appEventBus.on(EAppEventBusNames.PerpsWebSocketRecovered, handler);
+    return () => {
+      appEventBus.off(EAppEventBusNames.PerpsWebSocketRecovered, handler);
+    };
+  }, [isChartLinesReady, webRef]);
+
+  useEffect(() => {
+    if (isChartLinesReady && pendingRecoverRef.current) {
+      pendingRecoverRef.current = false;
+      webRef.current?.sendMessageViaInjectedScript({
+        type: 'FORCE_RECOVER_WS',
+      });
+    }
+  }, [isChartLinesReady, webRef]);
 
   // Callback when TradingView iframe signals chart lines are ready
   const onChartLinesReady = useCallback(() => {

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -605,6 +605,9 @@ function AutoPauseSubscriptions() {
 
   const handleAppActiveFromBackground = useCallback(() => {
     if (isFocusedRef.current) {
+      // Native doesn't set lastFocusStateRef to false on background,
+      // so reset it here to prevent dedup guard from blocking resume
+      lastFocusStateRef.current = false;
       void onFocusHandler({ isFocus: true });
     }
   }, [onFocusHandler]);
@@ -621,6 +624,7 @@ function AutoPauseSubscriptions() {
     if (platformEnv.isDesktop) {
       return globalThis.desktopApi.onAppState(
         (state: 'active' | 'background' | 'blur') => {
+          if (!state) return; // fullscreen transitions send undefined
           const isActive = state === 'active';
           if (isActive && isFocusedRef.current) {
             void onFocusHandler({ isFocus: true });

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -556,6 +556,9 @@ function AutoPauseSubscriptions() {
   //   //
   // }, [isFocusedRoute]);
 
+  // Dedup: visibilitychange + window.focus can fire back-to-back
+  const lastFocusStateRef = useRef<boolean | null>(null);
+
   const onFocusHandler = useCallback(
     async ({
       isFocus,
@@ -564,10 +567,11 @@ function AutoPauseSubscriptions() {
       isFocus: boolean;
       pauseDelay?: number;
     }) => {
-      // console.log('AutoPauseSubscriptions___useListenTabFocusState', {
-      //   isFocus,
-      //   isHideByModal,
-      // });
+      if (lastFocusStateRef.current === isFocus && pauseDelay === undefined) {
+        return;
+      }
+      lastFocusStateRef.current = isFocus;
+
       if (isFocus) {
         clearTimeout(pauseSubscriptionsTimerRef.current);
         void backgroundApiProxy.serviceHyperliquidSubscription.enableSubscriptionsHandler();
@@ -608,6 +612,51 @@ function AutoPauseSubscriptions() {
   useHandleAppStateActive(
     platformEnv.isNative ? handleAppActiveFromBackground : undefined,
   );
+
+  // useListenTabFocusState only covers in-app route changes;
+  // browser tab switches need platform-level visibility events
+  useEffect(() => {
+    if (platformEnv.isNative) return undefined;
+
+    if (platformEnv.isDesktop) {
+      return globalThis.desktopApi.onAppState(
+        (state: 'active' | 'background' | 'blur') => {
+          const isActive = state === 'active';
+          if (isActive && isFocusedRef.current) {
+            void onFocusHandler({ isFocus: true });
+          } else if (!isActive) {
+            void onFocusHandler({ isFocus: false });
+          }
+        },
+      );
+    }
+
+    const handleVisibilityChange = () => {
+      const isVisible = document.visibilityState === 'visible';
+      if (isVisible && isFocusedRef.current) {
+        void onFocusHandler({ isFocus: true });
+      } else if (!isVisible) {
+        void onFocusHandler({ isFocus: false });
+      }
+    };
+    const handleWindowFocus = () => {
+      if (isFocusedRef.current) {
+        void onFocusHandler({ isFocus: true });
+      }
+    };
+    const handleWindowBlur = () => {
+      void onFocusHandler({ isFocus: false });
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('focus', handleWindowFocus);
+    window.addEventListener('blur', handleWindowBlur);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('focus', handleWindowFocus);
+      window.removeEventListener('blur', handleWindowBlur);
+    };
+  }, [onFocusHandler]);
 
   const [isLocked] = useAppIsLockedAtom();
 

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -390,6 +390,7 @@ export interface IAppEventBusPayload {
     subType: ESubscriptionType;
     data: unknown;
   };
+  [EAppEventBusNames.PerpsWebSocketRecovered]: undefined;
   [EAppEventBusNames.HyperliquidConnectionChange]: {
     type: 'connection';
     subType: 'datastream';

--- a/packages/shared/src/eventBus/appEventBusNames.ts
+++ b/packages/shared/src/eventBus/appEventBusNames.ts
@@ -123,6 +123,7 @@ export enum EAppEventBusNames {
   UpdateNotificationBadge = 'UpdateNotificationBadge',
   HyperliquidDataUpdate = 'HyperliquidDataUpdate',
   HyperliquidConnectionChange = 'HyperliquidConnectionChange',
+  PerpsWebSocketRecovered = 'PerpsWebSocketRecovered',
   BtcFreshAddressUpdated = 'BtcFreshAddressUpdated',
   BtcFreshAddressConnectDappRejected = 'BtcFreshAddressConnectDappRejected',
   ClientLogUploadProgress = 'ClientLogUploadProgress',


### PR DESCRIPTION
## Summary
- Add browser-level visibility listeners to `AutoPauseSubscriptions` for web (visibilitychange + blur/focus) and desktop (desktopApi.onAppState)
- Replace WebView reload with `FORCE_RECOVER_WS` postMessage to iframe — K-line chart recovers without losing zoom/indicators/drawings
- Add `_forceReconnectTransport()` to avoid async cleanup race in `_destroySubscription`
- Add post-open data check (5s after socket OPEN) to detect half-open connections
- Emit `PerpsWebSocketRecovered` event only on reconnection (not initial connect)

## Intent & Context
Users reported that when switching browser tabs on desktop web, the Perps K-line chart and TickerBar freeze and don't recover. Root cause: `AutoPauseSubscriptions` only monitored in-app route changes via `useListenTabFocusState`, which doesn't fire when the browser tab changes. `useHandleAppStateActive` was also gated behind `platformEnv.isNative`, skipping web/desktop entirely.

## Root Cause
The pause/resume lifecycle had no browser-level visibility hook on web/desktop. When a user switched browser tabs:
1. `useListenTabFocusState` didn't fire (route unchanged)
2. `useHandleAppStateActive` passed `undefined` (non-native)
3. Browser throttled/froze the background tab
4. No resume triggered on return → data stayed stale

## Design Decisions
- **Perps-local listener over global hook change**: Adding `visibilitychange` to the global `useHandleAppStateActive` would affect `StateActiveContainer` and `AppStateUpdater`. Scoped the listener to `AutoPauseSubscriptions` to avoid side effects.
- **Message-driven recovery over WebView reload**: `pauseSubscriptions` no longer sets `reloadHook` negative. The iframe's own WS self-heals via its `visibilitychange` handler + health check + `FORCE_RECOVER_WS` message. This preserves chart state (zoom, drawings, indicators).
- **`_forceReconnectTransport` over `disconnect()`**: `disconnect()` calls `_cleanupAllSubscriptions()` which does async per-subscription unsubscribe. Stale `_destroySubscription` completion can delete newly created tracking entries. The new method skips per-subscription cleanup and directly resets the transport.
- **Dedup guard on `onFocusHandler`**: `visibilitychange` and `window.focus` can fire back-to-back with the same value, causing double `resumeSubscriptions()`. A `lastFocusStateRef` prevents this.

## Changes Detail
- `appEventBusNames.ts` / `appEventBus.ts` — Register `PerpsWebSocketRecovered` event
- `ServiceHyperliquidSubscription.ts` — Add `_forceReconnectTransport()`, `_startPostOpenDataCheck()`, emit recovery event from `socketOpenHandler`
- `PerpsGlobalEffects.tsx` — Add visibility/blur/focus listener with dedup, scoped to web/desktop
- `TradingViewPerpsV2.tsx` — Listen to recovery event, forward `FORCE_RECOVER_WS` to iframe with pending/replay pattern

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Web, Desktop
- **Risk Areas**: Dedup correctness under rapid focus/blur cycling, `_forceReconnectTransport` interaction with existing reconnect paths

## Test plan
- [ ] Open Perps, switch browser tab for 30s, switch back — TickerBar + K-line resume immediately
- [ ] Switch away for 10+ minutes, switch back — everything recovers without WebView reload
- [ ] Multi-monitor: blur browser window (click another app), return — data resumes
- [ ] In-app tab switch (Perp → Home → Perp) — works as before (regression check)
- [ ] Cold start — no spurious FORCE_RECOVER_WS or double resume
- [ ] Lock screen → unlock — works as before
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
