### PR TITLE
fix: clear swap recipient input on network change (OK-53277)

### DIFF
--- a/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.test.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.test.ts
@@ -191,7 +191,51 @@ describe('useSwapIncognitoRecipientInput', () => {
     expect(result.current.inputText).toBe('');
   });
 
-  it('revalidates the current input when the validation scope changes', async () => {
+  it('clears the current input when the recipient network changes', async () => {
+    mockQueryAddressWithFallback.mockResolvedValueOnce({
+      input: '0xrecipient',
+      resolveAddress: '0xresolved-1',
+      validStatus: 'valid',
+    });
+
+    const { result, rerender } = renderUseSwapIncognitoRecipientInput({
+      visible: true,
+      clearRecipientAddressOnHide: false,
+      networkId: 'evm--1',
+      accountId: 'account-1',
+      address: undefined,
+      swapToAnotherAccountSwitchOn: false,
+    });
+
+    act(() => {
+      result.current.onInputChange('0xrecipient');
+    });
+
+    await flushDebounce();
+
+    await waitFor(() => {
+      expect(mockSettingsState.swapToAnotherAccountSwitchOn).toBe(true);
+      expect(mockSwapToAddressState.address).toBe('0xresolved-1');
+    });
+
+    rerender({
+      visible: true,
+      clearRecipientAddressOnHide: false,
+      networkId: 'aptos--1',
+      accountId: 'account-1',
+      address: undefined,
+      swapToAnotherAccountSwitchOn: false,
+    });
+
+    expect(result.current.inputText).toBe('');
+    expect(mockSettingsState.swapToAnotherAccountSwitchOn).toBe(false);
+    expect(mockSwapToAddressState.address).toBeUndefined();
+
+    await flushDebounce();
+    expect(mockQueryAddressWithFallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('revalidates the current input when only the validation account changes', async () => {
     mockQueryAddressWithFallback
       .mockResolvedValueOnce({
         input: '0xrecipient',
@@ -227,7 +271,7 @@ describe('useSwapIncognitoRecipientInput', () => {
     rerender({
       visible: true,
       clearRecipientAddressOnHide: false,
-      networkId: 'evm--10',
+      networkId: 'evm--1',
       accountId: 'account-2',
       address: undefined,
       swapToAnotherAccountSwitchOn: false,
@@ -245,7 +289,7 @@ describe('useSwapIncognitoRecipientInput', () => {
         expect.objectContaining({
           accountId: 'account-2',
           address: '0xrecipient',
-          networkId: 'evm--10',
+          networkId: 'evm--1',
         }),
       );
       expect(mockSettingsState.swapToAnotherAccountSwitchOn).toBe(true);

--- a/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts
@@ -258,6 +258,7 @@ export function useSwapIncognitoRecipientInput({
     }
 
     resetValidationState({
+      clearInput: prevScope.networkId !== nextScope.networkId,
       clearRecipientAddress: true,
     });
   }, [


### PR DESCRIPTION
## Summary
- clear the incognito recipient input when the recipient network changes
- keep account-only scope changes revalidating the existing input instead of broadening the behavior change
- update the swap recipient hook tests to cover the network-reset and account-revalidation transitions

## Issues
- OK-53277

## Intent & Context
The original request was to investigate `OK-53277`, where the Swap page kept the previous recipient text after switching networks. A reproducible case was entering an EVM recipient address and then switching the quote to Aptos, which immediately surfaced an address validation error. The expected behavior is to clear the recipient input on network switch, matching the previous Swap interaction.

## Root Cause
This is a newly introduced regression rather than a historical issue. The recipient input hook introduced in [1a167d3090946528f099e06ff6a70e18e33ef3e1](https://github.com/OneKeyHQ/app-monorepo/commit/1a167d3090946528f099e06ff6a70e18e33ef3e1) reset the synced recipient state when the validation scope changed, but intentionally kept the input text and revalidated it against the new network. That behavior is safe for account-only scope changes, but it is incorrect for cross-network switches because the old address text is no longer valid in the new network context.

## Design Decisions
- Only clear the input when `networkId` changes, because that is the case called out by the bug report and the lowest-risk fix.
- Preserve the existing revalidation behavior when only `accountId` changes, so we do not silently change another interaction path without product evidence.
- Keep the tests at the hook level because the value here is the state transition logic, not UI layout or presentation details.

## Changes Detail
- `packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts`: clear the local input state together with the synced recipient state when the recipient network changes.
- `packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.test.ts`: split the old scope-change test into a network-reset case and an account-only revalidation case.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Swap incognito recipient input state transitions during network switching

## Test plan
- [x] `yarn jest packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.test.ts --runInBand`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.test.ts --deny-warnings`
- [ ] Manually verify that switching from an EVM quote with a filled recipient to an Aptos quote clears the recipient input without leaving a validation error
