### PR TITLE
fix(market): allow stock name to display without ellipsis on mobile(OK-52417)

### DIFF
--- a/development/spellCheckerSkipWords.txt
+++ b/development/spellCheckerSkipWords.txt
@@ -1434,3 +1434,4 @@ Blockaid
 posthog
 Posthog
 autocapture
+ellipsize

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationPanel/InformationPanel.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationPanel/InformationPanel.tsx
@@ -137,6 +137,7 @@ export function InformationPanel() {
             stock={stock}
             showAllInTrigger
             hideCommunityInTrigger
+            noTruncateSubtitle={isStockToken}
           />
         </XStack>
       </YStack>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenOverview/StockTokenOverview.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenOverview/StockTokenOverview.tsx
@@ -19,9 +19,9 @@ export function StockTokenOverview() {
 
   return (
     <Stack gap="$2" px="$5" pt="$5" pb="$3">
-      <XStack alignItems="center" gap="$3" mb="$3">
+      <XStack alignItems="flex-start" gap="$3" mb="$3">
         <Token size="lg" tokenImageUri={tokenDetail.logoUrl} />
-        <Stack flex={1}>
+        <Stack flexShrink={1}>
           <SizableText size="$headingLg" color="$text" fontWeight="600">
             {tokenDetail.symbol}
           </SizableText>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenOverview/StockTokenOverview.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenOverview/StockTokenOverview.tsx
@@ -19,9 +19,9 @@ export function StockTokenOverview() {
 
   return (
     <Stack gap="$2" px="$5" pt="$5" pb="$3">
-      <XStack alignItems="flex-start" gap="$3" mb="$3">
+      <XStack alignItems="center" gap="$3" mb="$3">
         <Token size="lg" tokenImageUri={tokenDetail.logoUrl} />
-        <Stack flexShrink={1}>
+        <Stack flex={1}>
           <SizableText size="$headingLg" color="$text" fontWeight="600">
             {tokenDetail.symbol}
           </SizableText>

--- a/packages/kit/src/views/Market/components/PerpsBadges.tsx
+++ b/packages/kit/src/views/Market/components/PerpsBadges.tsx
@@ -30,53 +30,60 @@ const LeverageBadge = memo(({ leverage }: { leverage: number }) => (
 ));
 LeverageBadge.displayName = 'LeverageBadge';
 
-const SubtitleBadge = memo(({ subtitle }: { subtitle: string }) => {
-  const normalizedSubtitle = truncatePerpsSubtitle(subtitle);
-  const isTruncated = normalizedSubtitle !== subtitle;
+const SubtitleBadge = memo(
+  ({ subtitle, noTruncate }: { subtitle: string; noTruncate?: boolean }) => {
+    const normalizedSubtitle = truncatePerpsSubtitle(subtitle);
+    const isTruncated = normalizedSubtitle !== subtitle;
+    const displayText = noTruncate ? subtitle : normalizedSubtitle;
 
-  const badgeElement = useMemo(
-    () => (
-      <XStack
-        borderRadius="$1"
-        bg="$bgStrong"
-        justifyContent="center"
-        alignItems="center"
-        px="$1.5"
-        minWidth={0}
-        maxWidth="$24"
-        flexShrink={1}
-        overflow="hidden"
-      >
-        <SizableText
-          fontSize={10}
-          color="$textSubdued"
-          lineHeight={16}
-          numberOfLines={1}
-          ellipsizeMode="tail"
+    const badgeElement = useMemo(
+      () => (
+        <XStack
+          borderRadius="$1"
+          bg="$bgStrong"
+          justifyContent="center"
+          alignItems="center"
+          px="$1.5"
+          minWidth={0}
+          {...(!noTruncate && {
+            maxWidth: '$24',
+            overflow: 'hidden',
+          })}
+          flexShrink={1}
         >
-          {normalizedSubtitle}
-        </SizableText>
-      </XStack>
-    ),
-    [normalizedSubtitle],
-  );
+          <SizableText
+            fontSize={10}
+            color="$textSubdued"
+            lineHeight={16}
+            {...(!noTruncate && {
+              numberOfLines: 1,
+              ellipsizeMode: 'tail',
+            })}
+          >
+            {displayText}
+          </SizableText>
+        </XStack>
+      ),
+      [displayText, noTruncate],
+    );
 
-  if (platformEnv.isNative || !isTruncated) {
-    return badgeElement;
-  }
+    if (platformEnv.isNative || !isTruncated || noTruncate) {
+      return badgeElement;
+    }
 
-  return (
-    <Tooltip
-      renderTrigger={
-        <Stack minWidth={0} flexShrink={1}>
-          {badgeElement}
-        </Stack>
-      }
-      renderContent={subtitle}
-      placement="top"
-    />
-  );
-});
+    return (
+      <Tooltip
+        renderTrigger={
+          <Stack minWidth={0} flexShrink={1}>
+            {badgeElement}
+          </Stack>
+        }
+        renderContent={subtitle}
+        placement="top"
+      />
+    );
+  },
+);
 SubtitleBadge.displayName = 'SubtitleBadge';
 
 const StockIsOpenBadge = memo(({ stock }: { stock: IMarketStockInfo }) => {

--- a/packages/kit/src/views/Market/components/TokenTagsPopover.tsx
+++ b/packages/kit/src/views/Market/components/TokenTagsPopover.tsx
@@ -32,6 +32,8 @@ interface ITokenTagsPopoverProps {
   hideCommunityInTrigger?: boolean;
   /** Custom trigger element. Overrides default trigger rendering. */
   customTrigger?: ReactNode;
+  /** Disable truncation for subtitle badge. Defaults to false. */
+  noTruncateSubtitle?: boolean;
 }
 
 function TokenTagsPopover({
@@ -40,6 +42,7 @@ function TokenTagsPopover({
   showAllInTrigger = false,
   hideCommunityInTrigger = false,
   customTrigger,
+  noTruncateSubtitle = false,
 }: ITokenTagsPopoverProps) {
   const intl = useIntl();
 
@@ -82,7 +85,10 @@ function TokenTagsPopover({
         <Icon name="BadgeRecognizedSolid" size="$4" color="$iconSuccess" />
       ) : null}
       {showAllInTrigger && hasSubtitle ? (
-        <SubtitleBadge subtitle={stock.subtitle ?? ''} />
+        <SubtitleBadge
+          subtitle={stock.subtitle ?? ''}
+          noTruncate={noTruncateSubtitle}
+        />
       ) : null}
       {showAllInTrigger && hasStockStatus ? (
         <StockIsOpenBadge stock={stock} />


### PR DESCRIPTION
## Summary
- Fixed stock token name being truncated with ellipsis on mobile market detail page
- Changed XStack alignItems from `center` to `flex-start` for proper alignment when name wraps
- Changed Stack `flex={1}` to `flexShrink={1}` to allow text to wrap naturally

## Jira
https://onekeyhq.atlassian.net/browse/OK-52417

## Test plan
- [ ] Open market detail page for a stock token on mobile
- [ ] Verify the stock name displays fully without ellipsis
- [ ] Verify layout looks correct when name is long and wraps to multiple lines
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
