### PR TITLE
feat: rename referral invite event and add binding completed tracking(OK-53279)

### DIFF
--- a/packages/kit/src/views/ReferFriends/hooks/useWalletBoundReferralCode/useWalletBoundReferralCode.tsx
+++ b/packages/kit/src/views/ReferFriends/hooks/useWalletBoundReferralCode/useWalletBoundReferralCode.tsx
@@ -18,6 +18,7 @@ import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { EOneKeyErrorClassNames } from '@onekeyhq/shared/src/errors/types/errorTypes';
 import errorToastUtils from '@onekeyhq/shared/src/errors/utils/errorToastUtils';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { EMnemonicType } from '@onekeyhq/shared/src/utils/secret';
 import {
@@ -249,6 +250,11 @@ export function useWalletBoundReferralCode({
           });
           // Clear cached invite code after successful binding
           await backgroundApiProxy.serviceReferralCode.setCachedInviteCode('');
+          defaultLogger.referral.page.referralBindingCompleted({
+            referralCode,
+            address: walletInfo.address,
+            networkId: walletInfo.networkId,
+          });
           Toast.success({
             title: intl.formatMessage({
               id: ETranslations.global_success,

--- a/packages/kit/src/views/ReferFriends/pages/InvitedByFriend/components/InvitedByFriendActions.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/InvitedByFriend/components/InvitedByFriendActions.tsx
@@ -97,7 +97,7 @@ function WebWalletOptions({
   const intl = useIntl();
 
   const handleOpenDesktop = useCallback(() => {
-    defaultLogger.referral.page.acceptReferralInvitation({
+    defaultLogger.referral.page.clickAcceptInviteButton({
       referralCode,
       acceptMethod: 'web_no_extension',
     });
@@ -109,7 +109,7 @@ function WebWalletOptions({
   }, [referralCode, page]);
 
   const handleGetExtension = useCallback(() => {
-    defaultLogger.referral.page.acceptReferralInvitation({
+    defaultLogger.referral.page.clickAcceptInviteButton({
       referralCode,
       acceptMethod: 'web_no_extension',
     });
@@ -212,6 +212,11 @@ function InvitedByFriendActions({
       );
 
       await backgroundApiProxy.serviceReferralCode.setCachedInviteCode('');
+      defaultLogger.referral.page.referralBindingCompleted({
+        referralCode,
+        address,
+        networkId,
+      });
       success = true;
     } catch (error) {
       // EIP-1193: code 4001 = user rejected — silently ignore
@@ -247,7 +252,7 @@ function InvitedByFriendActions({
     if (platformEnv.isWeb) {
       // Extension installed → bind directly
       if (getOneKeyExtensionProvider()) {
-        defaultLogger.referral.page.acceptReferralInvitation({
+        defaultLogger.referral.page.clickAcceptInviteButton({
           referralCode,
           acceptMethod: 'web_extension',
         });
@@ -259,7 +264,7 @@ function InvitedByFriendActions({
       return;
     }
 
-    defaultLogger.referral.page.acceptReferralInvitation({
+    defaultLogger.referral.page.clickAcceptInviteButton({
       referralCode,
       acceptMethod: 'local_app',
     });

--- a/packages/shared/src/logger/scopes/referral/scenes/page.ts
+++ b/packages/shared/src/logger/scopes/referral/scenes/page.ts
@@ -95,9 +95,19 @@ export class PageScene extends BaseScene {
 
   @LogToServer()
   @LogToLocal({ level: 'info' })
-  public acceptReferralInvitation(params: {
+  public clickAcceptInviteButton(params: {
     referralCode: string;
     acceptMethod: 'local_app' | 'web_extension' | 'web_no_extension';
+  }) {
+    return params;
+  }
+
+  @LogToServer()
+  @LogToLocal({ level: 'info' })
+  public referralBindingCompleted(params: {
+    referralCode: string;
+    address: string;
+    networkId: string;
   }) {
     return params;
   }


### PR DESCRIPTION
## Summary
- Rename `acceptReferralInvitation` event to `clickAcceptInviteButton` to clarify it represents a button click, not a successful binding
- Add new `referralBindingCompleted` event that fires only after the bind API succeeds, carrying `referralCode`, `address`, and `networkId`
- This enables Growth to build a complete funnel: page enter → button click (may repeat) → binding success (once)

## Jira
OK-53279

## Test plan
- [ ] Verify `clickAcceptInviteButton` fires on button click (web extension, web no extension, local app)
- [ ] Verify `referralBindingCompleted` fires only once after successful bind via web extension flow
- [ ] Verify `referralBindingCompleted` fires only once after successful bind via app flow
- [ ] Verify no event fires on bind failure or user cancellation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
