### PR TITLE
feat: gate botwallet manager with dev setting

### DIFF
--- a/.skillshare/skills/1k-dev-commands/SKILL.md
+++ b/.skillshare/skills/1k-dev-commands/SKILL.md
@@ -9,17 +9,17 @@ allowed-tools: Bash, Read
 ## Application Development Commands
 
 **PLATFORM-SPECIFIC DEVELOPMENT**:
-- `yarn app:desktop` - Start desktop Electron app development
+- `yarn app:desktop:rspack` - Start desktop Electron app development
   - **Runtime**: 30-60 seconds to start
   - **Common issues**: Node version conflicts, missing native dependencies
   - **Troubleshooting**: Run `yarn clean && yarn reinstall` if startup fails
 
-- `yarn app:web` - Start web development server (port 3000)
+- `yarn app:web:rspack` - Start web development server (port 3000)
   - **Runtime**: 15-30 seconds to start
-  - **Common issues**: Port 3000 already in use, webpack compilation errors
+  - **Common issues**: Port 3000 already in use, rspack compilation errors
   - **Troubleshooting**: Kill existing processes on port 3000, check console for specific errors
 
-- `yarn app:ext` - Start browser extension development
+- `yarn app:ext:rspack` - Start browser extension development
   - **Runtime**: 20-40 seconds to start
   - **Common issues**: Manifest v3 validation errors, permission issues
   - **Troubleshooting**: Check extension manifest validity, verify content security policy

--- a/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
@@ -46,6 +46,8 @@ export interface IDevSettings {
   allowDeleteKeylessKey?: boolean;
   // show Keyless-related debug dialogs/logs in UI (dev only)
   enableKeylessDebugInfo?: boolean;
+  // enable BotWallet management entry for Keyless wallet
+  enableBotWalletFeature?: boolean;
 
   showPrimeTest?: boolean;
   usePrimeSandboxPayment?: boolean;
@@ -106,6 +108,7 @@ export const {
       strictSignatureAlert: false,
       enableAnalyticsRequest: false,
       enableKeylessDebugInfo: false,
+      enableBotWalletFeature: false,
       showPrimeTest: true,
       usePrimeSandboxPayment: platformEnv.isDev,
       showPerformanceMonitor: true,

--- a/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletEditButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletEditButton.tsx
@@ -124,9 +124,17 @@ function WalletEditButtonView({
     );
   }, [wallet, isPrimeAvailable]);
 
+  const isBotWalletFeatureEnabled = useMemo(
+    () =>
+      Boolean(
+        devSettings.enabled && devSettings.settings?.enableBotWalletFeature,
+      ),
+    [devSettings.enabled, devSettings.settings?.enableBotWalletFeature],
+  );
+
   const showBotWalletManagerButton = useMemo(
-    () => Boolean(isKeyless && wallet?.id),
-    [isKeyless, wallet?.id],
+    () => Boolean(isKeyless && wallet?.id && isBotWalletFeatureEnabled),
+    [isKeyless, wallet?.id, isBotWalletFeatureEnabled],
   );
 
   const navigation = useAppNavigation();

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
@@ -1598,6 +1598,15 @@ const BaseDevSettingsSection = () => {
                         <Switch size={ESwitchSize.small} />
                       </SectionFieldItem>
 
+                      <SectionFieldItem
+                        icon="WalletOutline"
+                        name="enableBotWalletFeature"
+                        title="启用 BotWallet 功能"
+                        subtitle="开启后，Keyless 钱包更多菜单显示 BotWallets 管理入口"
+                      >
+                        <Switch size={ESwitchSize.small} />
+                      </SectionFieldItem>
+
                       <SectionPressItem
                         icon="ServerOutline"
                         title="Add ServerNetwork Test Data"


### PR DESCRIPTION
## Summary
- add a dev settings toggle for exposing the BotWallet feature
- gate the Keyless wallet BotWallet manager entry behind that toggle
- update the skill docs to use the current rspack dev commands

## Intent & Context
These workspace changes make BotWallet management exposure opt-in during development instead of always surfacing it for eligible Keyless wallets. The user asked to commit the current work and open a PR for review.

## Root Cause
The BotWallet manager entry visibility only depended on `isKeyless` and `wallet.id`, so there was no dedicated dev flag to control when the feature should be shown.

## Design Decisions
- Added a persisted dev setting with a default value of `false` so the feature stays hidden unless explicitly enabled
- Wired the UI entry visibility to both the wallet eligibility check and the new dev setting to keep the rollout scoped
- Updated the dev command skill doc in the same PR so the documented local startup commands match the current rspack scripts

## Changes Detail
- added `enableBotWalletFeature` to the dev settings atom defaults and schema
- added a new switch in Dev Settings to enable the BotWallet feature for Keyless wallets
- updated the wallet edit more-menu logic to require the new dev setting before showing the BotWallet manager entry
- renamed the documented desktop, web, and extension development commands to their rspack variants

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile / Desktop / Web / Extension
- **Risk Areas**: Dev settings persistence, Keyless wallet more-menu visibility, internal developer workflow docs

## Test plan
- [x] Run `yarn lint:staged`
- [x] Run `yarn tsc:staged`
- [ ] Verify the BotWallet manager entry stays hidden for Keyless wallets when the new dev setting is off
- [ ] Verify enabling the new dev setting shows the BotWallet manager entry for eligible Keyless wallets

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
