### PR TITLE
fix(swap): skip stale token address on network switch (OK-53281)

### DIFF
--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -296,16 +296,17 @@ export default class ServiceSwap extends ServiceBase {
     if (!isAllNetworkFetchAccountTokens) {
       await this.cancelFetchTokenList();
     }
+    const targetNetworkId = networkId ?? getNetworkIdsMap().onekeyall;
     const params: IFetchTokenListParams = {
       protocol:
         protocol === ESwapTabSwitchType.LIMIT
           ? EProtocolOfExchange.LIMIT
           : EProtocolOfExchange.SWAP,
-      networkId: networkId ?? getNetworkIdsMap().onekeyall,
+      networkId: targetNetworkId,
       keywords,
       limit,
       accountAddress: !networkUtils.isAllNetwork({
-        networkId: networkId ?? getNetworkIdsMap().onekeyall,
+        networkId: targetNetworkId,
       })
         ? accountAddress
         : undefined,
@@ -324,12 +325,17 @@ export default class ServiceSwap extends ServiceBase {
             accountId,
             networkId,
           });
-        if (accountAddressForAccountId === accountAddress) {
+        if (equalsIgnoreCase(accountAddressForAccountId, accountAddress)) {
           params.accountXpub =
             await this.backgroundApi.serviceAccount.getAccountXpub({
               accountId,
               networkId,
             });
+        } else {
+          // Drop stale addresses during network-switch races. The token list
+          // endpoint treats accountAddress as optional and should not receive
+          // another network's address.
+          params.accountAddress = undefined;
         }
       } catch (e) {
         console.error(e);

--- a/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.ts
@@ -1,3 +1,4 @@
+import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
 
 type IShouldUseSwapCustomRecipientAddressParams = {
@@ -16,6 +17,13 @@ type IShouldShowSwapRecipientAddressInfoParams = {
   selectedRecipientNetworkId?: string;
   toAddressNetworkId?: string;
   toTokenNetworkId?: string;
+};
+
+type IShouldUseSwapAddressForTokenFetchParams = {
+  address?: string;
+  activeNetworkId?: string;
+  resolvedAddressNetworkId?: string;
+  targetNetworkId?: string;
 };
 
 export function shouldUseSwapCustomRecipientAddress({
@@ -63,5 +71,25 @@ export function shouldShowSwapRecipientAddressInfo({
 
   return (
     selectedRecipientNetworkId === (toTokenNetworkId ?? toAddressNetworkId)
+  );
+}
+
+export function shouldUseSwapAddressForTokenFetch({
+  address,
+  activeNetworkId,
+  resolvedAddressNetworkId,
+  targetNetworkId,
+}: IShouldUseSwapAddressForTokenFetchParams) {
+  if (!address || !resolvedAddressNetworkId || !targetNetworkId) {
+    return false;
+  }
+
+  if (networkUtils.isAllNetwork({ networkId: activeNetworkId })) {
+    return resolvedAddressNetworkId === targetNetworkId;
+  }
+
+  return (
+    activeNetworkId === targetNetworkId &&
+    resolvedAddressNetworkId === targetNetworkId
   );
 }

--- a/packages/kit/src/views/Swap/hooks/useSwapTokens.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapTokens.ts
@@ -37,6 +37,7 @@ import {
 } from '../../../states/jotai/contexts/swap';
 
 import { useSwapAddressInfo } from './useSwapAccount';
+import { shouldUseSwapAddressForTokenFetch } from './useSwapAccount.utils';
 
 export function useSwapTokenList(
   selectTokenModalType: ESwapDirectionType,
@@ -81,17 +82,19 @@ export function useSwapTokenList(
   ]);
 
   const tokenFetchParams = useMemo(() => {
+    const targetNetworkId = currentSelectNetwork?.networkId ?? currentNetworkId;
     const findNetInfo = swapSupportAllAccountsRef.current.find(
-      (net) =>
-        net.networkId === currentNetworkId ||
-        net.networkId === currentSelectNetwork?.networkId,
+      (net) => net.networkId === targetNetworkId,
     );
-    if (
-      swapAddressInfo.networkId === currentNetworkId ||
-      swapAddressInfo.networkId === currentSelectNetwork?.networkId
-    ) {
+    const shouldUseCurrentAccountAddress = shouldUseSwapAddressForTokenFetch({
+      address: swapAddressInfo?.address,
+      activeNetworkId: swapAddressInfo?.activeAccount?.network?.id,
+      resolvedAddressNetworkId: swapAddressInfo.networkId,
+      targetNetworkId,
+    });
+    if (shouldUseCurrentAccountAddress) {
       return {
-        networkId: currentSelectNetwork?.networkId ?? currentNetworkId,
+        networkId: targetNetworkId,
         keywords,
         accountAddress: swapAddressInfo?.address,
         accountNetworkId: swapAddressInfo?.networkId,
@@ -99,7 +102,7 @@ export function useSwapTokenList(
       };
     }
     return {
-      networkId: currentSelectNetwork?.networkId ?? currentNetworkId,
+      networkId: targetNetworkId,
       keywords,
       accountAddress: findNetInfo?.apiAddress,
       accountNetworkId: findNetInfo?.networkId,
@@ -109,6 +112,7 @@ export function useSwapTokenList(
     currentNetworkId,
     swapAddressInfo.networkId,
     swapAddressInfo?.address,
+    swapAddressInfo?.activeAccount?.network?.id,
     swapAddressInfo?.accountInfo?.account?.id,
     keywords,
     currentSelectNetwork?.networkId,


### PR DESCRIPTION
## Issues
- OK-53281
- OK-53211

## Summary
- stop sending a stale `accountAddress` to `/swap/v1/tokens` while the swap network has already switched but the active account address is still catching up
- keep the supported-account fallback path for token list loading instead of forcing the stale current-account address
- add a service-side guard so mismatched `accountId + networkId + accountAddress` combinations drop the optional address hint instead of forwarding the wrong one

## Intent & Context
The user reported that after switching swap networks, the token list request could send the previous network's address to `/swap/v1/tokens`, which caused the backend request to fail. The backend treats `accountAddress` as optional, and production behavior already works without it in this scenario.

This change is intentionally scoped to the token-list request path. It does not roll back the recent `OK-53211` recipient-picker fix that made the picker trust the swap direction token network.

## Root Cause
`OK-53211` updated `useSwapAddressInfo()` to prefer the swap direction's token network so the TO-side recipient picker would not stay on a stale EVM slot when the target chain was non-EVM.

That change is correct for recipient selection, but it exposed a race in token list fetching: during a network switch, `networkId` can move to the new target chain before the active account address has switched with it. `useSwapTokens()` previously treated those values as if they were always synchronized, so it forwarded a new `networkId` together with an old `accountAddress` to `/swap/v1/tokens`.

## Design Decisions
- keep the `OK-53211` network-resolution behavior in `useSwapAddressInfo()` unchanged so the recipient picker continues to follow the token network
- gate `accountAddress` usage in `useSwapTokens()` so the current account address is only forwarded when it is actually aligned with the target network
- preserve the existing supported-account fallback path for network-specific token fetching
- add a service-level defensive check in `fetchSwapTokens()` so future callers cannot accidentally forward another network's address through this optional parameter

## Changes Detail
- `packages/kit/src/views/Swap/hooks/useSwapTokens.ts`: derive a single target network and only use the current account address when the active account and resolved address network are both aligned with that target
- `packages/kit/src/views/Swap/hooks/useSwapAccount.utils.ts`: add a small helper to keep the address-forwarding condition readable and shared in one place
- `packages/kit-bg/src/services/ServiceSwap.ts`: if `getAccountAddressForApi({ accountId, networkId })` does not match the provided address, clear `params.accountAddress` instead of forwarding the stale optional hint

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: swap token list refresh during network switching, all-network account fallback for supported swap networks

## Test plan
- [x] Run `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/views/Swap/hooks/useSwapAccount.utils.ts packages/kit/src/views/Swap/hooks/useSwapTokens.ts packages/kit-bg/src/services/ServiceSwap.ts`
- [x] Review the `OK-53211` recipient-picker path and confirm this PR does not change `useSwapAddressInfo()` network resolution
- [ ] Manually verify a cross-chain flow from an EVM source network to a non-EVM target network still opens the recipient picker on the target network
- [ ] Manually verify rapid swap network switching no longer sends the previous network's address to `/swap/v1/tokens`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
