### PR TITLE
fix(address-input): collapse default layout to clear button on non-empty input (OK-53255)

### DIFF
--- a/packages/kit/src/components/AddressInput/index.tsx
+++ b/packages/kit/src/components/AddressInput/index.tsx
@@ -287,6 +287,13 @@ export const createValidateAddressRule =
     if (value.pending) {
       return;
     }
+    // Empty input is the pristine / cleared state — don't surface an
+    // "invalid address" message here. Callers must gate their submit
+    // button on `value.resolved` (or equivalent) since the form will
+    // now report isValid=true for empty input.
+    if (!value.raw?.trim()) {
+      return;
+    }
     if (!value.resolved) {
       return value.validateError?.message ?? defaultErrorMessage;
     }
@@ -651,7 +658,7 @@ export function AddressInput(props: IAddressInputProps) {
       ) : (
         <IconButton
           title={intl.formatMessage({ id: ETranslations.global_clear })}
-          variant="secondary"
+          variant="tertiary"
           icon="BroomOutline"
           disabled={disabled}
           onPress={disabled ? undefined : handleClear}
@@ -703,32 +710,34 @@ export function AddressInput(props: IAddressInputProps) {
                 </>
               );
             }
+            // Default layout: empty state shows the action cluster
+            // (clipboard / scan / account selector). Non-empty state collapses
+            // to the clear button alone — the selector is hidden so it
+            // doesn't float next to committed address content (OK-53255,
+            // matching the recipient layout used by the Send flow).
+            if (hasContent) {
+              return clearButton;
+            }
             return (
               <>
-                {hasContent ? (
-                  clearButton
-                ) : (
-                  <>
-                    {clipboard ? (
-                      <ClipboardPlugin
-                        display={actionDisplay}
-                        onChange={onChangeText}
-                        disabled={disabled}
-                        testID={testID ? `${testID}-clip` : undefined}
-                      />
-                    ) : null}
-                    {scan ? (
-                      <ScanPlugin
-                        display={actionDisplay}
-                        networkId={networkId}
-                        onScanResult={onScanResult}
-                        onChange={onChangeText}
-                        disabled={disabled}
-                        testID={testID ? `${testID}-scan` : undefined}
-                      />
-                    ) : null}
-                  </>
-                )}
+                {clipboard ? (
+                  <ClipboardPlugin
+                    display={actionDisplay}
+                    onChange={onChangeText}
+                    disabled={disabled}
+                    testID={testID ? `${testID}-clip` : undefined}
+                  />
+                ) : null}
+                {scan ? (
+                  <ScanPlugin
+                    display={actionDisplay}
+                    networkId={networkId}
+                    onScanResult={onScanResult}
+                    onChange={onChangeText}
+                    disabled={disabled}
+                    testID={testID ? `${testID}-scan` : undefined}
+                  />
+                ) : null}
                 {showSelector ? (
                   <SelectorPlugin
                     disabled={disabled}

--- a/packages/kit/src/views/Onboarding/pages/ImportWallet/hooks/useImportAddressForm.ts
+++ b/packages/kit/src/views/Onboarding/pages/ImportWallet/hooks/useImportAddressForm.ts
@@ -197,10 +197,20 @@ export function useImportAddressForm({
       return false;
     }
     if (method === EImportMethod.Address) {
-      return !addressValue.pending && form.formState.isValid;
+      return (
+        !addressValue.pending &&
+        !!addressValue.resolved &&
+        form.formState.isValid
+      );
     }
     return validateResult?.isValid ?? false;
-  }, [method, addressValue.pending, validateResult, form.formState]);
+  }, [
+    method,
+    addressValue.pending,
+    addressValue.resolved,
+    validateResult,
+    form.formState,
+  ]);
 
   const isKeyExportEnabled = useMemo(
     () =>

--- a/packages/kit/src/views/ReferFriends/pages/EditAddress/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/EditAddress/index.tsx
@@ -159,8 +159,10 @@ function BasicEditAddress() {
     if (errors.length) {
       return false;
     }
-    return !addressValue.pending && form.formState.isValid;
-  }, [addressValue.pending, form.formState]);
+    return (
+      !addressValue.pending && !!addressValue.resolved && form.formState.isValid
+    );
+  }, [addressValue.pending, addressValue.resolved, form.formState]);
 
   const { result: addressBookEnabledNetworkIds } = usePromiseResult(
     async () => {


### PR DESCRIPTION
## Summary

Referral → Edit Address: after the user typed an address, the contact/account selector icon stayed visible next to the clear button in a half-floating position. Clearing the input also surfaced an \"invalid address\" error message because the empty state was treated as a validation failure. Both regressions trace back to the default \`AddressInput\` layout.

## Jira

https://onekeyhq.atlassian.net/browse/OK-53255

## Changes

### \`packages/kit/src/components/AddressInput/index.tsx\`
- **Default layout non-empty state collapses to clear button.** Previously the layout rendered \`clearButton + selector\` side-by-side whenever the input had content. Now \`hasContent\` returns just the clear button; the action cluster (clipboard / scan / account selector) only appears when the input is empty. Matches what the recipient layout already does for the Send / Swap flows.
- **Clear button uses \`variant=\"tertiary\"\` in default layout** so the icon-only style lines up with the clipboard / scan / selector glyphs already rendered there.
- **\`createValidateAddressRule\` now treats empty input as the pristine/cleared state** and returns \`undefined\` instead of the default \"invalid address\" message. Callers must gate their submit button on \`value.resolved\` (which they already do, or are updated in this PR).

### \`packages/kit/src/views/ReferFriends/pages/EditAddress/index.tsx\`
- \`isEnable\` now additionally requires \`!!addressValue.resolved\`, so the Next button stays disabled when the field is empty even though the validation rule no longer reports an error.

### \`packages/kit/src/views/Onboarding/pages/ImportWallet/hooks/useImportAddressForm.ts\`
- Same \`!!addressValue.resolved\` guard for the Address import flow.

### Not touched

- Send / Swap flows use the recipient layout and already gate their Next button on \`toResolved\`, so nothing changes for them.
- AddressBook create/edit and the gallery demo don't pass \`contacts\`/\`accountSelector\` so \`showSelector\` was always false for them — their render output is bit-for-bit identical.
- BulkSend uses a different \`LineNumberedTextArea\` component.

## Test plan

- [ ] Referral → Edit Address, open with empty field: contact icon + paste + scan visible on the right, no error under the input
- [ ] Type a valid address: icons collapse to a single broom-style clear button (tertiary variant), no background, same visual weight as the empty-state icons
- [ ] Tap clear: returns to pristine empty state, no \"invalid address\" error, Next button disabled
- [ ] Type an invalid address: \"invalid address\" error shows, clear button still there, Next disabled
- [ ] Type a valid address that resolves: error clears, Next enabled
- [ ] Onboarding → Import Address: confirm Next button stays disabled on empty input and enables once a valid address is typed
- [ ] Send flow (both native and Swap): no visual change, Next behavior unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
