### PR TITLE
fix(send): skip amount input page for ERC-721 NFTs (OK-53248)

### DIFF
--- a/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
@@ -60,6 +60,7 @@ import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import { EInputAddressChangeType } from '@onekeyhq/shared/types/address';
 import type { IAccountNFT } from '@onekeyhq/shared/types/nft';
+import { ENFTType } from '@onekeyhq/shared/types/nft';
 import { EQRCodeHandlerType } from '@onekeyhq/shared/types/qrCode';
 import type { IToken, ITokenFiat } from '@onekeyhq/shared/types/token';
 
@@ -475,6 +476,51 @@ function SendDataInputContainer() {
             isNFT: false,
             originalRecipient: toResolved,
             isToContract: false,
+          },
+          isInternalTransfer: true,
+        });
+        return;
+      }
+
+      // ERC-721 NFTs are 1-of-1 so there is nothing to enter on the amount
+      // page — skip straight to confirm with a fixed quantity of 1 (OK-53248).
+      const nftItem = nfts?.[0];
+      if (
+        isNFT &&
+        nftItem &&
+        nftItem.collectionType !== ENFTType.ERC1155 &&
+        account
+      ) {
+        const transfersInfo: ITransferInfo[] = [
+          {
+            from: account.address,
+            to: toResolved,
+            amount: '1',
+            nftInfo: {
+              nftId: nftItem.itemId,
+              nftAddress: nftItem.collectionAddress,
+              nftType: nftItem.collectionType,
+            },
+            memo: nextMemoValue || undefined,
+            paymentId: nextPaymentIdValue || undefined,
+            note: nextNoteValue || undefined,
+          },
+        ];
+        await signatureConfirm.navigationToTxConfirm({
+          transfersInfo,
+          sameModal: true,
+          onSuccess,
+          onFail,
+          onCancel,
+          transferPayload: {
+            amountToSend: '1',
+            isMaxSend: false,
+            isNFT: true,
+            originalRecipient: toResolved,
+            isToContract: !!toVal?.isContract,
+            memo: nextMemoValue || undefined,
+            paymentId: nextPaymentIdValue || undefined,
+            note: nextNoteValue || undefined,
           },
           isInternalTransfer: true,
         });


### PR DESCRIPTION
## Summary

ERC-721 NFTs are 1-of-1, so the \`SendAmountInput\` page had nothing for the user to enter — \`renderNFTAmountInput\` returned \`null\` for anything that wasn't ERC-1155, which left the page body empty and visually broken. Patrick's Jira comment explicitly said \"1155 and 721 should be differentiated\"; this PR implements that.

## Jira

https://onekeyhq.atlassian.net/browse/OK-53248

## Approach

Skip the amount page entirely for ERC-721. In \`SendDataInputContainer.handleNavigateToAmountInput\` we already short-circuit directly to \`signatureConfirm.navigationToTxConfirm\` for fixed-amount Lightning invoices. Reuse the same pattern for ERC-721 NFTs:

- Detect \`isNFT && nftItem && collectionType !== ENFTType.ERC1155\`
- Build \`transfersInfo\` with \`amount: '1'\` and the NFT identity (itemId + collectionAddress + collectionType)
- Carry over the memo / paymentId / note that were already collected on the data-input page
- Call \`signatureConfirm.navigationToTxConfirm\` with \`isNFT: true\` in the transfer payload
- \`return\` before the generic \`pushAmountInput\` call

ERC-1155 continues to go through \`SendAmountInput\` to enter a quantity. Non-NFT flows are untouched.

## Changes

- \`packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx\`
  - Import \`ENFTType\`
  - Add the ERC-721 short-circuit block after the Lightning fixed-amount block

No changes to the \`SendAmountInput\` page itself — it stays as-is for ERC-1155.

## Test plan

- [ ] Send an ERC-721 NFT: pick recipient → tap Next → lands directly on the signature-confirm page (no \`SendAmountInput\` screen)
- [ ] Send an ERC-1155 NFT: pick recipient → tap Next → still lands on the amount-input page to enter a quantity (unchanged)
- [ ] Memo / note / paymentId entered on the data-input page are preserved in the ERC-721 confirm payload
- [ ] Regular token send flow: unchanged (amount page still used)
- [ ] Lightning fixed-amount invoice: unchanged (still short-circuits via the existing block)
- [ ] LNURL / Lightning Address: unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
