### PR TITLE
fix(send): recent recipients API/local split + BTC badge merge fixes (OK-53278, OK-53284)

### DIFF
--- a/packages/kit-bg/src/services/ServiceAccountProfile.ts
+++ b/packages/kit-bg/src/services/ServiceAccountProfile.ts
@@ -80,12 +80,15 @@ function emptyAccountBadgeResult(): IAccountBadgeResult {
 //     so we never demote a positive interaction on one path with a
 //     negative on another
 //   - `addressLabel` / `similarAddress` take the first non-empty response
-//   - badges are concatenated and deduped by (type, label)
+//   - badges come only from responses whose own `interacted` matches the
+//     merged status, so xpub-scoped "First transfer" / "Transferred" badges
+//     cannot coexist in the final array (OK-53278). Address-scoped static
+//     labels (OKX / Scam / CEX / ...) are present in every response, so they
+//     still surface through the matching subset.
 function mergeAccountBadgeResults(
   responses: IAccountBadgeResult[],
 ): IAccountBadgeResult {
   const merged = emptyAccountBadgeResult();
-  const seenBadgeKeys = new Set<string>();
 
   for (const r of responses) {
     merged.isScam = merged.isScam || r.isScam;
@@ -107,12 +110,17 @@ function mergeAccountBadgeResults(
     if (!merged.similarAddress && r.similarAddress) {
       merged.similarAddress = r.similarAddress;
     }
+  }
 
-    for (const badge of r.badges) {
-      const key = `${badge.type ?? ''}:${badge.label ?? ''}`;
-      if (!seenBadgeKeys.has(key)) {
-        seenBadgeKeys.add(key);
-        merged.badges.push(badge);
+  const seenBadgeKeys = new Set<string>();
+  for (const r of responses) {
+    if (r.interacted === merged.interacted) {
+      for (const badge of r.badges) {
+        const key = `${badge.type ?? ''}:${badge.label ?? ''}`;
+        if (!seenBadgeKeys.has(key)) {
+          seenBadgeKeys.add(key);
+          merged.badges.push(badge);
+        }
       }
     }
   }

--- a/packages/kit-bg/src/services/ServiceAccountProfile.ts
+++ b/packages/kit-bg/src/services/ServiceAccountProfile.ts
@@ -344,17 +344,12 @@ class ServiceAccountProfile extends ServiceBase {
       });
       fromAddress = acc.address;
     }
-    // For BTC network with fresh address enabled, skip interaction check
-    let checkInteraction: boolean | undefined;
-    if (networkUtils.isBTCNetwork(networkId)) {
-      const enableBTCFreshAddress =
-        await this.backgroundApi.serviceSetting.getEnableBTCFreshAddress();
-      if (enableBTCFreshAddress) {
-        checkInteraction = false;
-      }
-    }
 
     // BTC/LTC merge-derive: fan out /badges per xpub and merge (OK-52897).
+    // The server-side interaction check is now xpub-based, so BTC fresh
+    // address no longer needs the client to disable checkInteraction —
+    // any xpub that actually sent to `toAddress` will report INTERACTED
+    // regardless of which "fresh" fromAddress is active.
     const xpubEntries = accountId
       ? await serviceAccount.safeGetAccountXpubsForAllDeriveTypes({
           accountId,
@@ -374,7 +369,6 @@ class ServiceAccountProfile extends ServiceBase {
               networkId,
               fromAddress,
               toAddress,
-              checkInteraction,
               xpub: entry.xpub,
             }),
         ),
@@ -389,7 +383,6 @@ class ServiceAccountProfile extends ServiceBase {
         networkId,
         fromAddress,
         toAddress,
-        checkInteraction,
         xpub: xpubEntries[0]?.xpub,
       });
     }

--- a/packages/kit/src/views/Send/pages/SendDataInput/useRecentRecipientsData.ts
+++ b/packages/kit/src/views/Send/pages/SendDataInput/useRecentRecipientsData.ts
@@ -453,129 +453,57 @@ export function useRecentRecipientsData({
     setRecentRecipients([]);
     setLastUsedDeriveType(undefined);
 
-    const isEvmNetwork = networkUtils.isEvmNetwork({ networkId });
-
-    // Phase 1: API + local store in parallel. Local store is always loaded
-    // so fresh sends (OK-52728) and non-indexer EVM chains aren't masked.
-    const fetchApiRecipients = async () => {
-      if (!accountId)
-        return {
-          extraMap: null,
-          addresses: [] as string[],
-          apiDeriveType: undefined as string | undefined,
-        };
-      try {
-        const apiNetworkId = isEvmNetwork ? 'evm--1' : networkId;
-        const {
-          supported,
-          data: apiRecipients,
-          lastUsedDeriveType: apiDeriveType,
-        } = await backgroundApiProxy.serviceHistory.fetchTransferRecipients({
-          accountId,
-          networkId: apiNetworkId,
-          limit: MAX_RECIPIENTS,
-        });
-        if (supported && apiRecipients.length > 0) {
-          return {
-            extraMap: await buildExtraMapFromApiRecipients(apiRecipients),
-            addresses: apiRecipients.map((r) => r.address),
-            apiDeriveType,
-          };
-        }
-      } catch {
-        // Fall through to local strategies.
-      }
-      return {
-        extraMap: null,
-        addresses: [] as string[],
-        apiDeriveType: undefined as string | undefined,
-      };
-    };
-
-    let apiEnriched: IEnrichedRecentRecipient[] | null = null;
-    const [
-      { extraMap: apiExtraMap, addresses: apiAddresses, apiDeriveType },
-      { addresses: storedAddresses, extraMap: storedExtraMap },
-    ] = await Promise.all([
-      fetchApiRecipients(),
-      accountId
-        ? loadStoredRecipients({ networkId, accountId })
-        : { addresses: [] as string[], extraMap: null },
-    ]);
-
-    if (isStale()) return;
-
-    if (apiDeriveType) {
-      setLastUsedDeriveType(apiDeriveType);
-    }
-
-    if (apiAddresses.length > 0) {
-      // Merge before enrichment so each unique address hits queryAddress
-      // only once (OK-52897 — badge calls are expensive).
-      const apiAddressSet = new Set(apiAddresses.map((a) => a.toLowerCase()));
-      const localOnlyAddresses = storedAddresses.filter(
-        (a) => !apiAddressSet.has(a.toLowerCase()),
-      );
-
-      const combinedAddresses = [...apiAddresses, ...localOnlyAddresses];
-      const combinedExtraMap = new Map<string, IRecipientExtraInfo>(
-        apiExtraMap ?? [],
-      );
-      if (storedExtraMap) {
-        for (const [key, value] of storedExtraMap) {
-          if (!combinedExtraMap.has(key)) {
-            combinedExtraMap.set(key, value);
-          } else if (value.memo) {
-            const existing = combinedExtraMap.get(key)!;
-            if (!existing.memo) {
-              existing.memo = value.memo;
-            }
-          }
-        }
-      }
-
-      try {
-        const enriched = await enrichAddresses(
-          combinedAddresses,
-          combinedExtraMap,
-          networkId,
-        );
-        if (isStale()) return;
-
-        // Freshness overlay: on re-send the local updatedAt is newer than
-        // the indexer's — bump the entry up and swap the network badge so
-        // the new timestamp doesn't pair with the API's stale network.
-        apiEnriched = enriched
-          .map((r) => {
-            const lower = r.input?.toLowerCase();
-            const local = lower ? storedExtraMap?.get(lower) : undefined;
-            if (local?.time && local.time > (r.lastTransferTime ?? 0)) {
-              return {
-                ...r,
-                lastTransferTime: local.time,
-                lastTransferNetworkName:
-                  local.networkName ?? r.lastTransferNetworkName,
-                recipientMemo: local.memo ?? r.recipientMemo,
-              };
-            }
-            return r;
-          })
-          .toSorted(
-            (a, b) => (b.lastTransferTime ?? 0) - (a.lastTransferTime ?? 0),
-          )
-          .slice(0, MAX_RECIPIENTS);
-      } catch {
-        // ignore enrichment errors — fall through to local strategies
-      }
-    }
-
-    if (apiEnriched) {
-      setRecentRecipients(apiEnriched);
+    if (!accountId) {
       setIsLoadingRecent(false);
       return;
     }
 
-    // Phase 2: API not supported or empty — show stored recipients instantly.
+    const isEvmNetwork = networkUtils.isEvmNetwork({ networkId });
+
+    // Phase 1: try the indexer API. When the API is supported, it is the
+    // single source of truth — we do not fall back to local storage or
+    // chain history to avoid mixing sources (OK-53284). If the API is
+    // not supported for this chain (or the call fails), drop to the
+    // local fallback below.
+    const apiNetworkId = isEvmNetwork ? 'evm--1' : networkId;
+    try {
+      const {
+        supported,
+        data: apiRecipients,
+        lastUsedDeriveType: apiDeriveType,
+      } = await backgroundApiProxy.serviceHistory.fetchTransferRecipients({
+        accountId,
+        networkId: apiNetworkId,
+        limit: MAX_RECIPIENTS,
+      });
+      if (isStale()) return;
+
+      if (supported) {
+        if (apiDeriveType) setLastUsedDeriveType(apiDeriveType);
+
+        const apiExtraMap = await buildExtraMapFromApiRecipients(apiRecipients);
+        if (isStale()) return;
+
+        const enriched = await enrichAddresses(
+          apiRecipients.map((r) => r.address),
+          apiExtraMap,
+          networkId,
+        );
+        if (isStale()) return;
+
+        setRecentRecipients(enriched);
+        setIsLoadingRecent(false);
+        return;
+      }
+    } catch {
+      // API call failed — fall through to local fallback.
+    }
+
+    // Phase 2: indexer API not supported — show stored recipients.
+    const { addresses: storedAddresses, extraMap: storedExtraMap } =
+      await loadStoredRecipients({ networkId, accountId });
+    if (isStale()) return;
+
     if (storedAddresses.length > 0) {
       try {
         const enriched = await enrichAddresses(
@@ -593,13 +521,7 @@ export function useRecentRecipientsData({
       }
     }
 
-    // Phase 3: Load from chain history and merge new entries.
-    if (!accountId) {
-      setIsLoadingRecent(false);
-      setIsLoadingMore(false);
-      return;
-    }
-
+    // Phase 3: merge in anything new from local chain history.
     try {
       let historyAddresses: string[] = [];
       let historyExtraMap: Map<string, IRecipientExtraInfo> | null = null;


### PR DESCRIPTION
## Summary

Three fixes for the Recent tab and address-input badges.

## Jira

- https://onekeyhq.atlassian.net/browse/OK-53278
- https://onekeyhq.atlassian.net/browse/OK-53284

## Changes

**1. Recent list: indexer API is the only source when supported (OK-53284)**

Previously the client fetched `/transfer-recipient` and the local store in parallel and merged them. Stale local entries could leak into a clean indexer response.

Now:
- `supported: true` → use API data only, no mixing
- `supported: false` (or call fails) → fall back to local store + chain history

Server contract: return `supported: false` when the chain isn't indexed. `supported: true` with an empty list means "no recents for this account" and the client honors it.

**2. Drop contradictory interaction badges on BTC merge-derive (OK-53278)**

BTC fans out `/badges` per xpub. "First transfer" and "Transferred" are xpub-scoped, so the old merge kept both in the final array, and the UI showed them side by side.

Now badges are only taken from responses whose `interacted` matches the merged state. Static labels (Scam / CEX / OKX / …) still surface because every response returns them.

**3. Remove the BTC fresh-address `checkInteraction=false` gate (OK-53278)**

Leftover from the pre-xpub era. With fresh address on, the client forced `checkInteraction=false`, so the server skipped the interaction lookup and every xpub came back `unknown` — no "Transferred" even for addresses in Recent.

Backend confirmed `/badges` is xpub-indexed now, so the gate is obsolete and removed. `ServiceSend` keeps its own gate since it only reads `isContract / isScam`.

## Test plan

- [ ] SOL / non-EVM account: Recent only shows that network's addresses
- [ ] Supported chain with data: API results, no local mix
- [ ] Unsupported chain: local store + chain history fallback
- [ ] BTC recipient sent from one derive path: only "Transferred" badge, no "First transfer"
- [ ] BTC brand-new recipient: "First transfer" badge
- [ ] BTC fresh address enabled, pick from Recent: "Transferred" badge shows
- [ ] Send pre-check (scam / contract warning) still fires