### PR TITLE
fix(send): low-priority UI bundle (OK-53311, OK-53312, OK-53313, OK-53314, OK-53315, OK-53212)

### DIFF
--- a/packages/components/src/actions/ActionList/index.tsx
+++ b/packages/components/src/actions/ActionList/index.tsx
@@ -44,6 +44,7 @@ export interface IActionListItemProps {
   icon?: IKeyOfIcons;
   iconProps?: IIconProps;
   label: string;
+  renderLabel?: () => ReactNode;
   extra?: ReactNode;
   description?: string;
   descriptionNumberOfLines?: number;
@@ -105,6 +106,7 @@ export function ActionListItem(
     icon,
     iconProps,
     label,
+    renderLabel,
     extra,
     description,
     descriptionNumberOfLines,
@@ -173,17 +175,21 @@ export function ActionListItem(
         ) : null}
         <YStack gap="$0.5" flex={1}>
           <XStack>
-            <SizableText
-              flex={1}
-              textAlign="left"
-              size="$bodyMd"
-              width="100%"
-              flexShrink={1}
-              $md={ACTION_LIST_TEXT_MD}
-              color={destructive ? '$textCritical' : '$text'}
-            >
-              {label}
-            </SizableText>
+            {renderLabel ? (
+              renderLabel()
+            ) : (
+              <SizableText
+                flex={1}
+                textAlign="left"
+                size="$bodyMd"
+                width="100%"
+                flexShrink={1}
+                $md={ACTION_LIST_TEXT_MD}
+                color={destructive ? '$textCritical' : '$text'}
+              >
+                {label}
+              </SizableText>
+            )}
 
             {platformEnv.isDesktop && keys?.length ? (
               <Shortcut>

--- a/packages/components/src/forms/Form/index.tsx
+++ b/packages/components/src/forms/Form/index.tsx
@@ -108,6 +108,12 @@ const getChildProps = (
     onChange?: (value: unknown) => void;
     onChangeText?: (value: unknown) => void;
   };
+  // Spread only the keys we want to forward from the RHF field. `field.disabled`
+  // is always present and defaults to `undefined`, which would otherwise clobber
+  // an explicit `disabled={...}` prop the caller set on the child via
+  // cloneElement. onChange is replaced below by a composed handler.
+  const { name, value, onBlur, ref } = field;
+  const baseProps = { name, value, onBlur, ref, error, hasError };
   switch (child.type) {
     case Input:
     case TextAreaInput:
@@ -116,9 +122,8 @@ const getChildProps = (
         ? composeEventHandlers(onChangeText, field.onChange)
         : field.onChange;
       return {
-        ...field,
-        error,
-        hasError,
+        ...baseProps,
+        onChange: field.onChange,
         onChangeText: handleChange,
       };
     }
@@ -127,9 +132,7 @@ const getChildProps = (
         ? composeEventHandlers(onChange, field.onChange)
         : field.onChange;
       return {
-        ...field,
-        error,
-        hasError,
+        ...baseProps,
         onChange: handleChange,
       };
     }

--- a/packages/components/src/forms/Form/index.tsx
+++ b/packages/components/src/forms/Form/index.tsx
@@ -111,9 +111,18 @@ const getChildProps = (
   // Spread only the keys we want to forward from the RHF field. `field.disabled`
   // is always present and defaults to `undefined`, which would otherwise clobber
   // an explicit `disabled={...}` prop the caller set on the child via
-  // cloneElement. onChange is replaced below by a composed handler.
-  const { name, value, onBlur, ref } = field;
-  const baseProps = { name, value, onBlur, ref, error, hasError };
+  // cloneElement. Forward it only when RHF actually set it (e.g. `<Form.Field
+  // disabled>`). onChange is replaced below by a composed handler.
+  const { name, value, onBlur, ref, disabled } = field;
+  const baseProps = {
+    name,
+    value,
+    onBlur,
+    ref,
+    error,
+    hasError,
+    ...(disabled != null && { disabled }),
+  };
   switch (child.type) {
     case Input:
     case TextAreaInput:

--- a/packages/components/src/forms/Form/index.tsx
+++ b/packages/components/src/forms/Form/index.tsx
@@ -108,20 +108,19 @@ const getChildProps = (
     onChange?: (value: unknown) => void;
     onChangeText?: (value: unknown) => void;
   };
-  // Spread only the keys we want to forward from the RHF field. `field.disabled`
-  // is always present and defaults to `undefined`, which would otherwise clobber
-  // an explicit `disabled={...}` prop the caller set on the child via
-  // cloneElement. Forward it only when RHF actually set it (e.g. `<Form.Field
-  // disabled>`). onChange is replaced below by a composed handler.
-  const { name, value, onBlur, ref, disabled } = field;
+  // Strip `disabled` from the field spread so it doesn't clobber an explicit
+  // `disabled={...}` prop the caller set on the child via cloneElement.
+  // RHF always includes `disabled` on the field object (defaults to
+  // `undefined`), which would override the caller's value. Re-add it only
+  // when RHF actually set it (e.g. `<Controller disabled>`).
+  // `onChange` is also stripped — each branch below composes its own handler.
+  const { disabled: fieldDisabled, onChange: _onChange, ...restField } = field;
   const baseProps = {
-    name,
-    value,
-    onBlur,
-    ref,
+    ...restField,
     error,
     hasError,
-    ...(disabled != null && { disabled }),
+    ...(fieldDisabled !== null &&
+      fieldDisabled !== undefined && { disabled: fieldDisabled }),
   };
   switch (child.type) {
     case Input:

--- a/packages/components/src/forms/Form/index.tsx
+++ b/packages/components/src/forms/Form/index.tsx
@@ -166,6 +166,11 @@ export type IFieldProps = Omit<GetProps<typeof Controller>, 'render'> &
       | 'flex'
       | 'inline-flex';
     description?: string | ReactNode;
+    /**
+     * Helper text rendered in the error message slot, in textSubdued color.
+     * Takes precedence over the error message when both are present.
+     */
+    hint?: string;
     horizontal?: boolean;
     optional?: boolean;
     labelAddon?: string | ReactElement | ReactNode;
@@ -180,6 +185,7 @@ function Field({
   display,
   errorMessageAlign,
   description,
+  hint,
   rules,
   children,
   horizontal = false,
@@ -252,7 +258,7 @@ function Field({
           )}
         </Stack>
         <HeightTransition>
-          {error?.message ? (
+          {hint || error?.message ? (
             <SizableText
               pt="$1.5"
               animation="quick"
@@ -261,9 +267,19 @@ function Field({
               exitStyle={errorAnimationStyle}
               textAlign={errorMessageAlign}
             >
-              {renderErrorMessage ? (
-                renderErrorMessage({ error })
-              ) : (
+              {hint ? (
+                <SizableText
+                  color="$textSubdued"
+                  size="$bodyMd"
+                  textAlign={errorMessageAlign}
+                >
+                  {hint}
+                </SizableText>
+              ) : null}
+              {!hint && renderErrorMessage
+                ? renderErrorMessage({ error })
+                : null}
+              {!hint && !renderErrorMessage ? (
                 <SizableText
                   color="$textCritical"
                   size="$bodyMd"
@@ -273,7 +289,7 @@ function Field({
                 >
                   {error?.message}
                 </SizableText>
-              )}
+              ) : null}
             </SizableText>
           ) : null}
         </HeightTransition>
@@ -286,6 +302,7 @@ function Field({
       display,
       error,
       errorMessageAlign,
+      hint,
       horizontal,
       intl,
       label,

--- a/packages/kit/src/components/AddressTypeSelector/AddressTypeSelectorItem.tsx
+++ b/packages/kit/src/components/AddressTypeSelector/AddressTypeSelectorItem.tsx
@@ -29,15 +29,16 @@ import {
   useAddressTypeSelectorStableContext,
 } from './AddressTypeSelectorContext';
 
-const addressTypeTooltipMap: Partial<Record<EAddressEncodings, ETranslations>> =
-  {
-    [EAddressEncodings.P2TR]: ETranslations.address_type_tooltip_taproot__desc,
-    [EAddressEncodings.P2WPKH]:
-      ETranslations.address_type_tooltip_native_segwit__desc,
-    [EAddressEncodings.P2SH_P2WPKH]:
-      ETranslations.address_type_tooltip_nested_segwit__desc,
-    [EAddressEncodings.P2PKH]: ETranslations.address_type_tooltip_legacy__desc,
-  };
+export const addressTypeTooltipMap: Partial<
+  Record<EAddressEncodings, ETranslations>
+> = {
+  [EAddressEncodings.P2TR]: ETranslations.address_type_tooltip_taproot__desc,
+  [EAddressEncodings.P2WPKH]:
+    ETranslations.address_type_tooltip_native_segwit__desc,
+  [EAddressEncodings.P2SH_P2WPKH]:
+    ETranslations.address_type_tooltip_nested_segwit__desc,
+  [EAddressEncodings.P2PKH]: ETranslations.address_type_tooltip_legacy__desc,
+};
 
 type IProps = {
   data: {

--- a/packages/kit/src/components/ChainSelectorInput/index.tsx
+++ b/packages/kit/src/components/ChainSelectorInput/index.tsx
@@ -73,8 +73,10 @@ export const ChainSelectorInput: FC<IChainSelectorInputProps> = ({
 
   const openChainSelector = useConfigurableChainSelector();
 
+  const isReadOnly = disabled || editable === false;
+
   const onPress = useCallback(() => {
-    if (disabled) {
+    if (isReadOnly) {
       return;
     }
     openChainSelector({
@@ -84,7 +86,7 @@ export const ChainSelectorInput: FC<IChainSelectorInputProps> = ({
       onSelect: (network) => onChange?.(network.id),
     });
   }, [
-    disabled,
+    isReadOnly,
     openChainSelector,
     title,
     selectorNetworks,
@@ -109,7 +111,12 @@ export const ChainSelectorInput: FC<IChainSelectorInputProps> = ({
       borderRadius="$3"
       borderWidth={1}
       borderCurve="continuous"
-      borderColor="$borderStrong"
+      borderColor={sharedStyles.borderColor}
+      backgroundColor={sharedStyles.backgroundColor}
+      // ChainSelectorInput is a button-like selector, not a text field, so
+      // override sharedStyles.cursor (which would default to 'text' for the
+      // Input use case) with selector semantics.
+      cursor={isReadOnly ? 'default' : 'pointer'}
       px="$3"
       py="$2.5"
       $gtMd={{
@@ -117,7 +124,7 @@ export const ChainSelectorInput: FC<IChainSelectorInputProps> = ({
         py: '$2',
       }}
       testID="network-selector-input"
-      {...(!disabled && {
+      {...(!isReadOnly && {
         hoverStyle: {
           bg: '$bgHover',
         },
@@ -133,10 +140,11 @@ export const ChainSelectorInput: FC<IChainSelectorInputProps> = ({
         px={sharedStyles.px}
         flex={1}
         size={size === 'small' ? '$bodyMd' : '$bodyLg'}
+        color={sharedStyles.color}
       >
         {current?.name ?? ''}
       </SizableText>
-      {!disabled ? (
+      {!isReadOnly ? (
         <Icon name="ChevronDownSmallOutline" mr="$-0.5" color="$iconSubdued" />
       ) : null}
     </Stack>

--- a/packages/kit/src/views/AddressBook/components/CreateOrEditContent.tsx
+++ b/packages/kit/src/views/AddressBook/components/CreateOrEditContent.tsx
@@ -277,7 +277,7 @@ export function CreateOrEditContent({
           >
             <ChainSelectorInput
               networkIds={addressBookEnabledNetworkIds}
-              disabled={lockRoutingFields}
+              editable={!lockRoutingFields}
             />
           </Form.Field>
           <Form.Field

--- a/packages/kit/src/views/DAppConnection/components/DAppRequestLayout/DAppSiteMark.tsx
+++ b/packages/kit/src/views/DAppConnection/components/DAppRequestLayout/DAppSiteMark.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 
 import type { IIconProps } from '@onekeyhq/components';
 import { Icon, Image, SizableText, XStack } from '@onekeyhq/components';
@@ -9,7 +9,7 @@ import {
   type IHostSecurity,
 } from '@onekeyhq/shared/types/discovery';
 
-function DAppSiteMark({
+function DAppSiteMarkInner({
   origin,
   urlSecurityInfo,
   favicon,
@@ -103,5 +103,7 @@ function DAppSiteMark({
     </XStack>
   );
 }
+
+const DAppSiteMark = memo(DAppSiteMarkInner);
 
 export { DAppSiteMark };

--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -164,6 +164,7 @@ function SendAmountInputContainer() {
 
   const amount = form.watch('amount');
   const nftAmount = form.watch('nftAmount');
+  const hasAmountError = !!form.formState.errors.amount;
   const txMessage = form.watch('txMessage');
 
   const { serviceToken, serviceNFT } = backgroundApiProxy;
@@ -420,6 +421,42 @@ function SendAmountInputContainer() {
     }
     return new BigNumber(1).shiftedBy(-decimals).toFixed();
   }, [tokenDetails?.info.decimals]);
+
+  const minAmountHint = useMemo(() => {
+    if (!tokenSymbol || tokenMinAmount === undefined) return undefined;
+    const isNative = tokenDetails?.info.isNative;
+    // Only show the hint when the chain enforces a meaningful chain-level
+    // minimum. Without that, displaying the token-precision floor (e.g.
+    // 1e-18 for an 18-decimal ERC20) is noise.
+    const chainMinRaw = isNative
+      ? (vaultSettings?.nativeMinTransferAmount ??
+        vaultSettings?.minTransferAmount)
+      : vaultSettings?.minTransferAmount;
+    if (!chainMinRaw || new BigNumber(chainMinRaw).isLessThanOrEqualTo(0)) {
+      return undefined;
+    }
+    // Mirror the validator's effectiveMin = max(tokenPrecisionMin, chainMin)
+    // so the hint matches the value the validator actually rejects against.
+    const effectiveMin = BigNumber.max(tokenMinAmount, chainMinRaw).toFixed();
+    // Lightning BTC unit displays the min converted from sats.
+    const displayMinAmount =
+      isLightningNetwork && lnUnit === ELightningUnit.BTC
+        ? chainValueUtils.convertSatsToBtc(effectiveMin)
+        : effectiveMin;
+    return intl.formatMessage(
+      { id: ETranslations.send_error_minimum_amount },
+      { amount: displayMinAmount, token: tokenSymbol },
+    );
+  }, [
+    intl,
+    isLightningNetwork,
+    lnUnit,
+    tokenDetails?.info.isNative,
+    tokenMinAmount,
+    tokenSymbol,
+    vaultSettings?.minTransferAmount,
+    vaultSettings?.nativeMinTransferAmount,
+  ]);
 
   const handleValidateTokenAmount = useCallback(
     async (value: string): Promise<string | undefined> => {
@@ -1285,12 +1322,17 @@ function SendAmountInputContainer() {
     walletId,
   ]);
 
+  const isAmountZeroOrEmpty = !amount || new BigNumber(amount).isZero();
+  const amountHint =
+    isAmountZeroOrEmpty || !hasAmountError ? minAmountHint : undefined;
+
   const renderAmountInput = useMemo(
     () => (
       <>
         <Form.Field
           name="amount"
           errorMessageAlign="center"
+          hint={amountHint}
           rules={{
             required: true,
             validate: handleValidateTokenAmount,
@@ -1341,6 +1383,7 @@ function SendAmountInputContainer() {
       </>
     ),
     [
+      amountHint,
       currencySymbol,
       handleAmountInputChange,
       handleToggleFiatMode,

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -8,14 +8,19 @@ import {
   ActionList,
   Badge,
   Button,
+  DashText,
   Empty,
   MatchSizeableText,
+  Popover,
   SegmentControl,
+  SizableText,
   Stack,
+  Tooltip,
   XStack,
   YStack,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { addressTypeTooltipMap } from '@onekeyhq/kit/src/components/AddressTypeSelector/AddressTypeSelectorItem';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useDebounce } from '@onekeyhq/kit/src/hooks/useDebounce';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
@@ -29,6 +34,7 @@ import type { IAccountDeriveInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 import { IMPL_EVM } from '@onekeyhq/shared/src/engine/engineConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalAddressBookRoutes } from '@onekeyhq/shared/src/routes/addressBook';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
@@ -51,6 +57,52 @@ import {
   normalizeSearchKey,
   prioritizeNameThenAddressMatches,
 } from './searchMatchUtils';
+
+function DeriveTypeLabelWithTooltip({
+  label,
+  description,
+}: {
+  label: string;
+  description: string;
+}) {
+  const trigger = (
+    <DashText
+      size="$bodyMd"
+      $md={{ size: '$bodyLg' }}
+      dashColor="$textDisabled"
+      dashThickness={0.5}
+      cursor="help"
+    >
+      {label}
+    </DashText>
+  );
+  if (platformEnv.isNative) {
+    return (
+      <YStack alignSelf="flex-start">
+        <Popover
+          title=""
+          showHeader={false}
+          placement="top"
+          renderTrigger={trigger}
+          renderContent={
+            <YStack p="$5">
+              <SizableText size="$bodyMd">{description}</SizableText>
+            </YStack>
+          }
+        />
+      </YStack>
+    );
+  }
+  return (
+    <YStack alignSelf="flex-start">
+      <Tooltip
+        placement="top"
+        renderTrigger={trigger}
+        renderContent={description}
+      />
+    </YStack>
+  );
+}
 
 type IRecipientQuickSelectProps = {
   accountId?: string;
@@ -455,10 +507,13 @@ function AccountRecipients({
     return filteredWalletGroups.map((group) => {
       const allAccounts = group?.accounts ?? [];
 
-      // Collect unique derive types for this wallet group
+      // Collect unique derive types for this wallet group. For BTC
+      // merge-derive chains we also surface the per-type explanation
+      // (Taproot / Native SegWit / ...) as a description so users know
+      // what each option means without guessing (OK-53312).
       const deriveTypeMap = new Map<
         string,
-        { label: string; deriveType: string }
+        { label: string; description?: string; deriveType: string }
       >();
       for (const item of allAccounts) {
         const dt = item.deriveType;
@@ -466,7 +521,13 @@ function AccountRecipients({
           const label = item.deriveInfo?.labelKey
             ? intl.formatMessage({ id: item.deriveInfo.labelKey })
             : (item.deriveInfo?.label ?? dt);
-          deriveTypeMap.set(dt, { label, deriveType: dt });
+          const tooltipKey = item.deriveInfo?.addressEncoding
+            ? addressTypeTooltipMap[item.deriveInfo.addressEncoding]
+            : undefined;
+          const description = tooltipKey
+            ? intl.formatMessage({ id: tooltipKey })
+            : undefined;
+          deriveTypeMap.set(dt, { label, description, deriveType: dt });
         }
       }
       const deriveTypeOptions = Array.from(deriveTypeMap.values());
@@ -532,7 +593,11 @@ function AccountRecipients({
         title: string;
         walletId: string;
         hasMultipleDeriveTypes: boolean;
-        deriveTypeOptions: { label: string; deriveType: string }[];
+        deriveTypeOptions: {
+          label: string;
+          description?: string;
+          deriveType: string;
+        }[];
         activeDeriveType?: string;
       }
     | {
@@ -646,6 +711,15 @@ function AccountRecipients({
                   })}
                   items={item.deriveTypeOptions.map((option) => ({
                     label: option.label,
+                    renderLabel: option.description
+                      ? // eslint-disable-next-line react/no-unstable-nested-components
+                        () => (
+                          <DeriveTypeLabelWithTooltip
+                            label={option.label}
+                            description={option.description ?? ''}
+                          />
+                        )
+                      : undefined,
                     onPress: () => {
                       setWalletDeriveType((prev) => ({
                         ...prev,

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -215,6 +215,10 @@ type IAccountWithDeriveInfo = {
   account: INetworkAccount;
   deriveInfo?: IAccountDeriveInfo;
   deriveType?: string;
+  // The actual historical address that matched the current search (OK-53313).
+  // When set, the row displays this address instead of the account's current
+  // rotating address so the user sees the value they actually typed.
+  matchedAddress?: string;
 };
 
 // Wallet account group type
@@ -247,7 +251,31 @@ function collectAccountSearchAddresses(
     ...(utxo.addresses ? Object.values(utxo.addresses) : []),
     ...(utxo.customAddresses ? Object.values(utxo.customAddresses) : []),
   ].filter((a): a is string => !!a);
-  return Array.from(new Set(candidates.map((a) => a.toLowerCase())));
+  // Preserve original case so the matched value can be shown back to the
+  // user (OK-53313) instead of the current rotating receive address.
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const addr of candidates) {
+    const key = addr.toLowerCase();
+    if (!seen.has(key)) {
+      seen.add(key);
+      unique.push(addr);
+    }
+  }
+  return unique;
+}
+
+// Find the actual address on `account` that matches `searchValue`
+// (already lowercased). Returns the original-case string so callers can
+// display it back to the user.
+function findMatchedAccountAddress(
+  account: INetworkAccount | undefined,
+  searchValue: string,
+): string | undefined {
+  if (!searchValue) return undefined;
+  return collectAccountSearchAddresses(account).find((addr) =>
+    addr.toLowerCase().includes(searchValue),
+  );
 }
 
 // Get wallet accounts on the specified network (with derive type info)
@@ -459,13 +487,26 @@ function AccountRecipients({
             isNameMatch: (item) =>
               (item.account?.name ?? '').toLowerCase().includes(searchValue),
             isAddressMatch: (item) =>
-              collectAccountSearchAddresses(item.account).some((addr) =>
-                addr.includes(searchValue),
-              ),
+              !!findMatchedAccountAddress(item.account, searchValue),
           });
 
         if (sortedAccounts.length > 0) {
-          const updatedGroup = { ...group, accounts: sortedAccounts };
+          // Attach the matched address so the row can display the value the
+          // user actually searched for instead of the current fresh address
+          // (OK-53313). Name matches keep matchedAddress undefined so the
+          // default display path still wins.
+          const decoratedAccounts = sortedAccounts.map((item) => {
+            const isNameHit = (item.account?.name ?? '')
+              .toLowerCase()
+              .includes(searchValue);
+            if (isNameHit) return item;
+            const matchedAddress = findMatchedAccountAddress(
+              item.account,
+              searchValue,
+            );
+            return matchedAddress ? { ...item, matchedAddress } : item;
+          });
+          const updatedGroup = { ...group, accounts: decoratedAccounts };
           if (nameMatched.length > 0) {
             nameMatchedGroups.push(updatedGroup);
           } else {
@@ -484,6 +525,7 @@ function AccountRecipients({
       const account = item?.account;
       if (!account) return;
       const address =
+        item.matchedAddress ??
         account.addressDetail?.displayAddress ??
         account.address ??
         account.addressDetail?.address ??
@@ -603,6 +645,7 @@ function AccountRecipients({
     | {
         type: 'account';
         account: INetworkAccount;
+        matchedAddress?: string;
         walletId: string;
         walletName: string;
         wallet?: IDBWallet;
@@ -628,6 +671,7 @@ function AccountRecipients({
           items.push({
             type: 'account',
             account: item.account,
+            matchedAddress: item.matchedAddress,
             walletId: section.walletId,
             walletName: section.title,
             wallet: section.wallet,
@@ -752,12 +796,16 @@ function AccountRecipients({
         if (!item.account) {
           return null;
         }
-        const { account, walletId, wallet } = item;
-        const itemAddress =
+        const { account, matchedAddress, walletId, wallet } = item;
+        const currentAddress =
           account.addressDetail?.displayAddress ??
           account.address ??
           account.addressDetail?.address ??
           '';
+        // Prefer the matched historical address (OK-53313) so the user sees
+        // exactly what they typed instead of the current rotating fresh
+        // address.
+        const itemAddress = matchedAddress ?? currentAddress;
         const itemKey = `${account.id ?? 'no-id'}-${itemAddress}`;
 
         // Wallet name is already shown in the section header, only show account name
@@ -776,7 +824,7 @@ function AccountRecipients({
               walletId,
               wallet,
             }}
-            onPress={() => handleSelectAccount({ account })}
+            onPress={() => handleSelectAccount({ account, matchedAddress })}
           />
         );
       })}

--- a/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
@@ -76,7 +76,9 @@ import {
   normalizeOptionalRecipientText,
   shouldSkipResolvedRecipientUpdate,
 } from './recipientSelectionUtils';
+import { useWebDappRecipientOptions } from './useWebDappRecipientOptions';
 
+import type { IRecipientQuickSelectTab } from './recipientQuickSelectTabUtils';
 import type { RouteProp } from '@react-navigation/core';
 
 interface IFormValues {
@@ -149,9 +151,11 @@ function SendDataInputContainer() {
     networkId,
   });
 
-  const [quickSelectActiveTab, setQuickSelectActiveTab] = useState<
-    'recent' | 'account' | 'addressBook'
-  >('recent');
+  const { hiddenTabs: recipientHiddenTabs, keylessWalletsOnly } =
+    useWebDappRecipientOptions();
+
+  const [quickSelectActiveTab, setQuickSelectActiveTab] =
+    useState<IRecipientQuickSelectTab>('recent');
   const [hasQuickSelectMatches, setHasQuickSelectMatches] = useState(false);
   const [scannedAmount, setScannedAmount] = useState('');
 
@@ -1219,6 +1223,8 @@ function SendDataInputContainer() {
               onInputTypeChange={handleAddressInputChangeType}
               onMatchStatusChange={setHasQuickSelectMatches}
               onSelect={handleQuickSelectRecipient}
+              hideTabs={recipientHiddenTabs}
+              keylessWalletsOnly={keylessWalletsOnly}
             />
           </Form>
         </AccountSelectorProviderMirror>

--- a/packages/kit/src/views/Send/pages/SendDataInput/useWebDappRecipientOptions.ts
+++ b/packages/kit/src/views/Send/pages/SendDataInput/useWebDappRecipientOptions.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+
+import type { IRecipientQuickSelectTab } from './recipientQuickSelectTabUtils';
+
+export function useWebDappRecipientOptions({
+  baseHiddenTabs,
+}: { baseHiddenTabs?: IRecipientQuickSelectTab[] } = {}) {
+  const { result: hasKeylessWallet = true } = usePromiseResult(async () => {
+    if (!platformEnv.isWebDappMode) return true;
+    const { wallets } = await backgroundApiProxy.serviceAccount.getWallets({
+      ignoreNonBackedUpWallets: true,
+      nestedHiddenWallets: true,
+    });
+    return wallets.some((w) =>
+      accountUtils.isKeylessWallet({ walletId: w.id }),
+    );
+  }, []);
+
+  const hiddenTabs = useMemo<IRecipientQuickSelectTab[]>(() => {
+    const base = baseHiddenTabs ?? [];
+    if (!platformEnv.isWebDappMode) return base;
+    return hasKeylessWallet
+      ? [...base, 'addressBook']
+      : [...base, 'addressBook', 'account'];
+  }, [baseHiddenTabs, hasKeylessWallet]);
+
+  return {
+    hiddenTabs,
+    keylessWalletsOnly: platformEnv.isWebDappMode,
+  };
+}

--- a/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { useRoute } from '@react-navigation/core';
 import { useIntl } from 'react-intl';
@@ -12,13 +12,11 @@ import {
   XStack,
   useForm,
 } from '@onekeyhq/components';
-import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import type { IAddressInputValue } from '@onekeyhq/kit/src/components/AddressInput';
 import { AddressInputField } from '@onekeyhq/kit/src/components/AddressInput';
 import { renderAddressSecurityHeaderRightButton } from '@onekeyhq/kit/src/components/AddressInput/AddressSecurityHeaderRightButton';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
-import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import {
   useSwapManualSelectQuoteProvidersAtom,
   useSwapQuoteCurrentSelectAtom,
@@ -27,17 +25,16 @@ import {
 import { useSettingsAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type {
   EModalSwapRoutes,
   IModalSwapParamList,
 } from '@onekeyhq/shared/src/routes/swap';
-import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
 
 import RecipientQuickSelect from '../../../Send/pages/SendDataInput/RecipientQuickSelect';
 import { shouldSkipResolvedRecipientUpdate } from '../../../Send/pages/SendDataInput/recipientSelectionUtils';
+import { useWebDappRecipientOptions } from '../../../Send/pages/SendDataInput/useWebDappRecipientOptions';
 import { useSwapAddressInfo } from '../../hooks/useSwapAccount';
 import { SwapProviderMirror } from '../SwapProviderMirror';
 
@@ -65,26 +62,9 @@ const SwapToAnotherAddressPage = () => {
   const [, setSwapManualSelectQuote] = useSwapManualSelectQuoteProvidersAtom();
   const intl = useIntl();
 
-  // OK-52685: on web dapp mode, only keyless wallet accounts are valid swap
-  // recipients — hide the address book tab, and the whole account tab too
-  // when the user has no keyless wallet at all.
-  const { result: hasKeylessWallet = true } = usePromiseResult(async () => {
-    if (!platformEnv.isWebDappMode) return true;
-    const { wallets } = await backgroundApiProxy.serviceAccount.getWallets({
-      ignoreNonBackedUpWallets: true,
-      nestedHiddenWallets: true,
-    });
-    return wallets.some((w) =>
-      accountUtils.isKeylessWallet({ walletId: w.id }),
-    );
-  }, []);
-
-  const hiddenTabs = useMemo<IRecipientQuickSelectTab[]>(() => {
-    if (!platformEnv.isWebDappMode) return BASE_HIDDEN_TABS;
-    return hasKeylessWallet
-      ? [...BASE_HIDDEN_TABS, 'addressBook']
-      : [...BASE_HIDDEN_TABS, 'addressBook', 'account'];
-  }, [hasKeylessWallet]);
+  const { hiddenTabs, keylessWalletsOnly } = useWebDappRecipientOptions({
+    baseHiddenTabs: BASE_HIDDEN_TABS,
+  });
   const form = useForm({
     defaultValues: {
       address: {
@@ -207,7 +187,7 @@ const SwapToAnotherAddressPage = () => {
             searchKey={toAddressRaw}
             isSearchMode={!!toAddressRaw?.trim()}
             hideTabs={hiddenTabs}
-            keylessWalletsOnly={platformEnv.isWebDappMode}
+            keylessWalletsOnly={keylessWalletsOnly}
             onMatchStatusChange={setHasQuickSelectMatches}
             onSelect={handleQuickSelectRecipient}
           />


### PR DESCRIPTION
## Summary

Bundles six independent low-priority UI fixes in the send flow and adjacent shared components.

| Ticket | Area | Change |
|---|---|---|
| [OK-53311](https://onekeyhq.atlassian.net/browse/OK-53311) | Send / shared Form | Show min transfer amount as a hint in the same slot as the validation error (mirrors textCritical → textSubdued). Adds `hint` prop to shared `Form.Field` |
| [OK-53312](https://onekeyhq.atlassian.net/browse/OK-53312) | Send recipient quick select | BTC derive-type switch dropdown items now use a dashed-underline label (`DashText`) with tap-to-reveal Tooltip / Popover, matching the Swap "Select address type" pattern. Adds optional `renderLabel` to shared `ActionList` items |
| [OK-53313](https://onekeyhq.atlassian.net/browse/OK-53313) | Send recipient quick select | When an account is matched by a historical (non-current-fresh) BTC address, display and select that matched address instead of the rotating fresh address |
| [OK-53314](https://onekeyhq.atlassian.net/browse/OK-53314) | Lightning send | Memoize `DAppSiteMark` so the dapp favicon doesn't re-mount on every keystroke in the LNURL amount input |
| [OK-53315](https://onekeyhq.atlassian.net/browse/OK-53315) | Send recipient quick select | In web dapp mode, hide the address book tab and only surface keyless-wallet accounts (mirrors Swap's OK-52685). Extracted into shared `useWebDappRecipientOptions` hook used by both Send and Swap |
| [OK-53212](https://onekeyhq.atlassian.net/browse/OK-53212) | Address book edit | Network field in edit mode is now visually + functionally read-only. Root-cause was Form.Field clobbering the caller's explicit `disabled` prop with `field.disabled: undefined` from react-hook-form's spread; switched to explicit prop forwarding and used `editable={false}` semantics on the `ChainSelectorInput` for visual consistency with sibling fields |

## Test plan

- [ ] **OK-53311** — open Send → ADA → recipient → amount input. Hint "Minimum amount 1 ADA" visible at empty / `0` amount in textSubdued; once a value below 1 is entered the validation error replaces it in the same slot in textCritical
- [ ] **OK-53312** — Send → BTC → recipient. In the account section, tap the derive-type Switch (Taproot etc.). Each option's label has a dashed underline; tapping the label reveals a Tooltip (desktop) / Popover (native) with the description; tapping the row outside the label still selects normally
- [ ] **OK-53313** — Enable BTC fresh address mode. Make a historical send. Re-enter Send and search by the historical (now non-current) address — the matching account row should display the historical address, not the new rotating one. Tapping fills the historical address into the input
- [ ] **OK-53314** — Mobile, Lightning Network LNURL pay flow → type / clear amount repeatedly. The dapp icon in the modal header is steady, no per-keystroke flicker
- [ ] **OK-53315** — Web dapp mode (hosted instance) → Send. Address book tab is gone. Account tab only shows keyless wallet accounts (or also gone if no keyless wallet exists). Verify Swap's existing behavior is unchanged
- [ ] **OK-53212** — Address book → edit an existing entry. Network field shows the saved chain in the disabled visual state (greyed background, no chevron, not pressable). Confirm name field is still editable. Adding a new entry still allows free network selection

[OK-53311]: https://onekeyhq.atlassian.net/browse/OK-53311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-53312]: https://onekeyhq.atlassian.net/browse/OK-53312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-53313]: https://onekeyhq.atlassian.net/browse/OK-53313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-53314]: https://onekeyhq.atlassian.net/browse/OK-53314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-53315]: https://onekeyhq.atlassian.net/browse/OK-53315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ