### PR TITLE
fix(perps): mobile detach breaks WS lifecycle(OK-53208, OK-53244)

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -107,9 +107,23 @@ export default class ServiceHyperliquid extends ServiceBase {
 
   public maxBuilderFee: number = FALLBACK_MAX_BUILDER_FEE;
 
+  // OK-53208: survives Perp tab detach/remount; component refs reset on
+  // unmount and would otherwise repeat refreshTradingMeta + changeActiveAsset
+  // on every modal push.
+  private _initialSymbolSelectClaimed = false;
+
   constructor({ backgroundApi }: { backgroundApi: any }) {
     super({ backgroundApi });
     void this.init();
+  }
+
+  @backgroundMethod()
+  async tryClaimInitialSymbolSelect(): Promise<boolean> {
+    if (this._initialSymbolSelectClaimed) {
+      return false;
+    }
+    this._initialSymbolSelectClaimed = true;
+    return true;
   }
 
   private get exchangeService(): ServiceHyperliquidExchange {

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -585,7 +585,11 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     ...args
   ) => {
     const socket = event.target as WebSocket | undefined;
-    void perpsWebSocketReadyStateAtom.set({ readyState: socket?.readyState });
+    // OK-53208: SDK transport wrapper reports readyState=undefined in the
+    // open event, which keeps perpsWebSocketConnectedAtom false forever.
+    void perpsWebSocketReadyStateAtom.set({
+      readyState: socket?.readyState ?? WebSocket.OPEN,
+    });
     console.log('hyperliquidWebSocket__event__open', {
       readyState: socket?.readyState,
       args,

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -252,9 +252,11 @@ function useHyperliquidEventBusListener() {
   }, [actions]);
 }
 
+// OK-53208: perps atoms/WS must survive unmount — mobile modal push
+// detaches this tab and re-mount has no recovery. Resets on account
+// switch / logout are owned by clearActiveAccountData / ServiceApp.resetApp.
 function useHyperliquidSession() {
   const [subscriptionActive] = useSubscriptionActiveAtom();
-  const actions = useHyperliquidActions();
 
   const [currentAccount] = usePerpsActiveAccountAtom();
   useListenTabFocusState(
@@ -267,13 +269,6 @@ function useHyperliquidSession() {
       }
     },
   );
-
-  useEffect(() => {
-    const actionsRef = actions.current;
-    return () => {
-      void actionsRef.clearAllData();
-    };
-  }, [actions]);
 
   return {
     userAddress: currentAccount?.accountAddress,
@@ -496,20 +491,22 @@ function WebSocketSubscriptionUpdate() {
 
 function useHyperliquidSymbolSelect() {
   const actions = useHyperliquidActions();
-  const initDoneRef = useRef(false);
 
   useListenTabFocusState(ETabRoutes.Perp, (isFocus: boolean) => {
-    if (isFocus && !initDoneRef.current) {
-      initDoneRef.current = true;
-      void (async () => {
-        await backgroundApiProxy.serviceHyperliquid.refreshTradingMeta();
-        const currentToken = await perpsActiveAssetAtom.get();
-        await actions.current.changeActiveAsset({
-          coin: currentToken.coin,
-          force: true,
-        });
-      })();
-    }
+    if (!isFocus) return;
+    void (async () => {
+      // OK-53208: latch lives in ServiceHyperliquid (singleton) so that
+      // Perp tab detach/remount does not re-trigger this init.
+      const claimed =
+        await backgroundApiProxy.serviceHyperliquid.tryClaimInitialSymbolSelect();
+      if (!claimed) return;
+      await backgroundApiProxy.serviceHyperliquid.refreshTradingMeta();
+      const currentToken = await perpsActiveAssetAtom.get();
+      await actions.current.changeActiveAsset({
+        coin: currentToken.coin,
+        force: true,
+      });
+    })();
   });
 }
 
@@ -674,10 +671,13 @@ function AutoPauseSubscriptions() {
 
   useEffect(() => {
     return () => {
+      // OK-53208: unmount ≠ user left Perp. Mobile modal push detaches this
+      // tab; a 300ms pauseSubscriptions timer scheduled here would survive
+      // in the event loop, fire after remount, and kill WS data flow.
+      // Real tab-focus-loss owns the pause timer via useListenTabFocusState.
       clearTimeout(pauseSubscriptionsTimerRef.current);
-      void onFocusHandler({ isFocus: false, pauseDelay: 300 });
     };
-  }, [onFocusHandler]);
+  }, []);
 
   return null;
 }


### PR DESCRIPTION
## Summary
- Stop wiping the Perp WS/subscription atoms when `PerpsGlobalEffects` unmounts, so mobile modal-push detach no longer blanks the screen.
- Normalize `socket.readyState` on the Hyperliquid SDK `open` event (it reports `undefined`) so `isWebSocketConnected` computes correctly.
- Remove the 300ms `pauseSubscriptions` timer scheduled from `AutoPauseSubscriptions` cleanup; the timer survived unmount and killed a healthy WS after remount.
- Move the initial symbol-select latch from a component `useRef` into the `ServiceHyperliquid` singleton so it is not re-run on every detach/remount cycle.

## Intent & Context
Two QA-reported bugs on the 6.2.0 cycle:
- **OK-53208 (Highest, iOS)** — switching symbol on mobile wiped all Perp data ("整个 Perp 像 WebSocket 都断了"). Web/desktop not affected.
- **OK-53244 (High)** — after switching coin, changing the order book tick precision would sometimes leave the book data unchanged.

Both surfaced only on mobile. After 6.1.0 (released 2026-03-20) the tree already contained the code paths involved, but the combination of latent pieces plus the `react-native-bottom-tabs` migration (PR #9893, 2026-01-28) changed the native screen detach semantics enough to expose the bugs in QA this cycle.

## Root Cause
Mobile uses `navigation.pushModal(..., MobileTokenSelector)`; under `react-native-bottom-tabs` + `freezeOnBlur: true`, the Perp tab screen gets detached, which unmounts `<PerpsGlobalEffects />`. That unmount triggered three independent problems that stacked:

1. `useHyperliquidSession` cleanup called `actionsRef.clearAllData()`, wiping `perpsAllMidsAtom`, `perpsAllAssetCtxsAtom`, `l2BookAtom`, `subscriptionActiveAtom`, `connectionStateAtom`, etc. After remount, `WebSocketSubscriptionUpdate` gates on `isWebSocketConnected === true` and refused to resubscribe, permanently deadlocking the data flow.
2. The Hyperliquid SDK's `WebSocketTransport` wrapper does not surface `socket.readyState` inside the `open` event (reports `undefined`). `perpsWebSocketConnectedAtom` is computed as `readyState === WebSocket.OPEN`, so it stayed `false` forever even when the socket was actually open — the guard from (1) never re-opened.
3. `AutoPauseSubscriptions` cleanup called `onFocusHandler({ isFocus: false, pauseDelay: 300 })`, which scheduled a `setTimeout(pauseSubscriptions, 300)` on a ref that was about to be garbage-collected. The timer survived in the event loop, fired ~300ms later, and executed `pauseSubscriptions()` → `_cleanupAllSubscriptions()` + `subscriptionsHandlerDisabled = true`, silently killing WS processing after the component had already been remounted.

For OK-53244: `buildRequiredSubscriptionsMap` force-syncs coin while preserving the previous coin's `nSigFigs/mantissa`; combined with (1)+(2)+(3), after a coin switch any subsequent tick change looked like a no-op because the guarded update path was already dead.

All three problems manifest only when the Perp tab is actually unmounted — hence mobile-only.

Diagnosis was done by instrumenting targeted `console.warn` logs across mount/unmount, focus handler, WS open/close, and subscription build, reading the iOS simulator system log via `xcrun simctl spawn booted log stream`, and running two independent Codex reviews to cross-validate. Runtime trace captured `🔴 useHyperliquidSession UNMOUNT → clearAllData()` right on coin switch, and `🟢 BG socket OPEN { raw: undefined, reported: 1 }` confirming the SDK quirk after the fallback.

## Design Decisions
- **Do not reintroduce `clearAllData` in a different hook**. Verified via repo-wide search that there is no remaining live caller after this change. Real reset is owned by `clearActiveAccountData` (account switch) and `ServiceApp.resetApp()` (logout), which are not affected by unmount.
- **Fall back to `WebSocket.OPEN` instead of forking/patching `@nktkas/hyperliquid`**. `??` only replaces `null/undefined`, so it cannot mask a genuine `CONNECTING/CLOSING/CLOSED` state. Patching upstream is heavier than a localized boundary fix; upstream report is still reasonable but not required to ship.
- **Move the symbol-select latch to the singleton service** rather than a global atom. It is lifecycle state, not app state, and the service class already survives detach/remount. The `tryClaimInitialSymbolSelect()` method is atomic (synchronous check-then-set, no `await` between them).
- **Keep the `clearTimeout` in `AutoPauseSubscriptions` cleanup** as a defensive clear of any pending timer the component itself created; just stop creating a new one. Real `pauseSubscriptions` is still triggered by genuine tab focus loss via `useListenTabFocusState`, which is the correct semantic for "user left Perps."

## Changes Detail
- `packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx`
  - `useHyperliquidSession`: removed the unmount effect that called `clearAllData()`; the accompanying comment explains the detach semantics for future readers.
  - `AutoPauseSubscriptions` cleanup: keep `clearTimeout`, drop the `onFocusHandler({ isFocus: false, pauseDelay: 300 })` call that scheduled a cross-mount timer.
  - `useHyperliquidSymbolSelect`: call `backgroundApiProxy.serviceHyperliquid.tryClaimInitialSymbolSelect()` instead of a component-local `initDoneRef`.
- `packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts`: added private `_initialSymbolSelectClaimed` and `@backgroundMethod() tryClaimInitialSymbolSelect()` as a one-time latch.
- `packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts`: `socketOpenHandler` writes `readyState ?? WebSocket.OPEN`.

## Risk Assessment
- **Risk Level**: Low–Medium.
- **Affected Platforms**: Mobile (iOS/Android). Web/desktop paths unchanged (their token selector is a popover; `PerpsGlobalEffects` never unmounted there).
- **Risk Areas**:
  - Handler now stays enabled when the component unmounts without a corresponding focus-loss event. Background processing keeps running — which is what we want during a modal push. If `useListenTabFocusState(isFocus=false)` ever fails to fire before a detach, the 5m30s pause would not be scheduled; flagged for a follow-up audit.
  - `_initialSymbolSelectClaimed` has no reset hook. Logout/reset goes through `ServiceApp.resetApp()` which rebuilds the singleton, so this is fine today; if we add account-level reinit later we will need an explicit reset entry point.
  - Codex independent review: APPROVE, hidden-risk score 3/5 (two remaining design gaps noted above, both to be filed as follow-ups).

## Test plan
- [ ] iOS: enter Perp tab → switch symbol via the mobile token selector → top ticker, order book, K-line and history all keep updating in real time.
- [ ] iOS: after switching symbol, wait 15–30 seconds without touching anything → prices keep ticking (confirms no phantom pause timer).
- [ ] iOS: switch coin, then change the order book tick precision → book data refreshes to the new precision.
- [ ] iOS: navigate out of Perp tab and back several times → no repeated `refreshTradingMeta` / `changeActiveAsset(force)` flash.
- [ ] Web / Desktop: regression smoke-test Perp flows — token switch (popover), tick precision change, tab switch — unchanged behaviour.
- [ ] Long-running sanity: leave Perp tab open for >10 minutes → data keeps streaming and no duplicate subscriptions accumulate.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
