### PR TITLE
fix(webembed): clip hidden WebView container to prevent ErrorView overflow(OK-53094)

### DIFF
--- a/packages/kit/src/components/WebViewWebEmbed/index.tsx
+++ b/packages/kit/src/components/WebViewWebEmbed/index.tsx
@@ -343,6 +343,7 @@ export function WebViewWebEmbed({
       width={debugViewSize.width}
       height={debugViewSize.height}
       borderWidth={debugViewSize.borderWidth}
+      overflow="hidden"
       top={top}
       left="5%"
       position="absolute"


### PR DESCRIPTION
## Summary

Add `overflow=\"hidden\"` to the outer container of the `WebViewWebEmbed` singleton so children with intrinsic sizes cannot leak onto the screen.

## Context

`WebViewWebEmbed` mounts a WKWebView at app root to run bundled JS (RevenueCat, auto-typing, etc.). In production its container is rendered at `width: 0, height: 0` but kept in the view tree so iOS keeps the WebView process alive.

`NativeWebView` always renders `<ErrorView>` when the native WebView reports an error or when the 60s load timeout fires. `ErrorView` → `Empty` → `Illustration` has a hard-coded 144x144 size. On iOS, with the 0x0 outer container having no `overflow: hidden`, the 144px `GlobeError` SVG draws outside the parent bounds, appearing on screen at `top: 15%, left: 5%` (the positioning of the WebEmbed singleton) on top of whatever page the user is on.

Repro path: lock the device > 60s after any action that triggers `LoadWebEmbedWebView` (e.g. opening Prime), then unlock — the 60s JS timer fires while backgrounded, `loadTimeoutError` becomes true, and on return the GlobeError appears at the top-left of the screen.

This was verified by temporarily forcing `ErrorView` to always render inside `NativeWebView`: the exact same GlobeError icon appeared at the expected screen position, confirming the overflow path.

## Fix

One-line change: set `overflow=\"hidden\"` on the outer `<View>` in `WebViewWebEmbed/index.tsx`. The WebView still runs JS normally (unchanged layout / sizing / mount behavior), any error-state UI inside stays clipped to the 0x0 container.

## Test plan

- [ ] iOS: trigger WebEmbed (e.g. open Prime page), lock device, wait >60s, unlock — no GlobeError icon on screen
- [ ] iOS: confirm Prime / RevenueCat flows still work (WebEmbed JS still executing)
- [ ] Android: same smoke test to confirm no regression
- [ ] Other WebViews (Discover browser, DApp signing, Market) unaffected — their ErrorView still shows within their own (non-zero) containers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
