### PR TITLE
fix: warn when market review token value is unknown (OK-53328)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.test.ts
@@ -4,6 +4,7 @@ import type {
 } from '@onekeyhq/shared/types/swap/types';
 
 import {
+  attachMarketUnknownTokenValueTip,
   buildDefaultMarketSpeedCheckState,
   buildMarketReviewShouldFallback,
   mergeMarketBuildResultWithQuote,
@@ -150,6 +151,62 @@ describe('marketSwapBuildUtils', () => {
     expect(merged.result.gasLimit).toBe(45_678);
     expect(merged.result.minToAmount).toBe('950');
     expect(merged.result.routesData).toHaveLength(1);
+  });
+
+  it('preserves quote tips from the selected quote fallback data', () => {
+    const quoteShowTip = {
+      title: 'Unknown Token Value',
+      detail: 'Unable to obtain token value',
+      showCancelButton: true,
+    };
+
+    const merged = mergeMarketBuildResultWithQuote({
+      buildRes: createBuildRes(),
+      quoteResult: createQuoteResult({
+        quoteShowTip,
+      }),
+    });
+
+    expect(merged.result.quoteShowTip).toEqual(quoteShowTip);
+  });
+
+  it('attaches the unknown token value warning when the receive token price is unavailable', () => {
+    const quoteShowTip = {
+      title: 'Unknown Token Value',
+      detail: 'Unable to obtain token value',
+      showCancelButton: true,
+    };
+
+    const nextQuoteResult = attachMarketUnknownTokenValueTip({
+      quoteResult: createQuoteResult(),
+      toTokenPrice: '0',
+      quoteTip: quoteShowTip,
+    });
+
+    expect(nextQuoteResult.quoteShowTip).toEqual(quoteShowTip);
+  });
+
+  it('does not override an existing quote tip when the receive token price is unavailable', () => {
+    const existingQuoteTip = {
+      title: '40% value drop',
+      detail: 'High price impact may cause your asset loss.',
+      showCancelButton: true,
+    };
+    const unknownTokenValueTip = {
+      title: 'Unknown Token Value',
+      detail: 'Unable to obtain token value',
+      showCancelButton: true,
+    };
+
+    const nextQuoteResult = attachMarketUnknownTokenValueTip({
+      quoteResult: createQuoteResult({
+        quoteShowTip: existingQuoteTip,
+      }),
+      toTokenPrice: '0',
+      quoteTip: unknownTokenValueTip,
+    });
+
+    expect(nextQuoteResult.quoteShowTip).toEqual(existingQuoteTip);
   });
 
   it('does not overwrite build result fields that are already present', () => {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.test.ts
@@ -186,6 +186,42 @@ describe('marketSwapBuildUtils', () => {
     expect(nextQuoteResult.quoteShowTip).toEqual(quoteShowTip);
   });
 
+  it('attaches the unknown token value warning when the review receive fiat value resolves to zero', () => {
+    const quoteShowTip = {
+      title: 'Unknown Token Value',
+      detail: 'Unable to obtain token value',
+      showCancelButton: true,
+    };
+
+    const nextQuoteResult = attachMarketUnknownTokenValueTip({
+      quoteResult: createQuoteResult({
+        toAmount: '0.0000',
+      }),
+      toTokenPrice: '1',
+      quoteTip: quoteShowTip,
+    });
+
+    expect(nextQuoteResult.quoteShowTip).toEqual(quoteShowTip);
+  });
+
+  it('does not attach the unknown token value warning when the review receive fiat value is still positive', () => {
+    const quoteShowTip = {
+      title: 'Unknown Token Value',
+      detail: 'Unable to obtain token value',
+      showCancelButton: true,
+    };
+
+    const nextQuoteResult = attachMarketUnknownTokenValueTip({
+      quoteResult: createQuoteResult({
+        toAmount: '0.0001',
+      }),
+      toTokenPrice: '1',
+      quoteTip: quoteShowTip,
+    });
+
+    expect(nextQuoteResult.quoteShowTip).toBeUndefined();
+  });
+
   it('does not override an existing quote tip when the receive token price is unavailable', () => {
     const existingQuoteTip = {
       title: '40% value drop',

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.ts
@@ -3,6 +3,7 @@ import BigNumber from 'bignumber.js';
 import type {
   IFetchBuildTxResponse,
   IFetchQuoteResult,
+  IQuoteTip,
 } from '@onekeyhq/shared/types/swap/types';
 import { SwapBuildShouldFallBackNetworkIds } from '@onekeyhq/shared/types/swap/types';
 
@@ -65,6 +66,36 @@ export function pickMarketQuoteResultByProvider({
   );
 }
 
+export function attachMarketUnknownTokenValueTip({
+  quoteResult,
+  toTokenPrice,
+  quoteTip,
+}: {
+  quoteResult: IFetchQuoteResult;
+  toTokenPrice?: string;
+  quoteTip?: IQuoteTip;
+}) {
+  if (quoteResult.quoteShowTip || !quoteTip) {
+    return quoteResult;
+  }
+
+  const toAmountBN = new BigNumber(quoteResult.toAmount ?? 0);
+  const toTokenPriceBN = new BigNumber(toTokenPrice ?? 0);
+
+  if (toAmountBN.isNaN() || !toAmountBN.gt(0)) {
+    return quoteResult;
+  }
+
+  if (!toTokenPriceBN.isNaN() && toTokenPriceBN.gt(0)) {
+    return quoteResult;
+  }
+
+  return {
+    ...quoteResult,
+    quoteShowTip: quoteTip,
+  };
+}
+
 export function mergeMarketBuildResultWithQuote({
   buildRes,
   quoteResult,
@@ -99,6 +130,10 @@ export function mergeMarketBuildResultWithQuote({
 
   if (!nextBuildRes.result?.minToAmount && quoteResult?.minToAmount) {
     nextBuildRes.result.minToAmount = quoteResult.minToAmount;
+  }
+
+  if (!nextBuildRes.result?.quoteShowTip && quoteResult?.quoteShowTip) {
+    nextBuildRes.result.quoteShowTip = quoteResult.quoteShowTip;
   }
 
   return nextBuildRes;

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.ts
@@ -82,11 +82,15 @@ export function attachMarketUnknownTokenValueTip({
   const toAmountBN = new BigNumber(quoteResult.toAmount ?? 0);
   const toTokenPriceBN = new BigNumber(toTokenPrice ?? 0);
 
-  if (toAmountBN.isNaN() || !toAmountBN.gt(0)) {
+  if (toAmountBN.isNaN()) {
     return quoteResult;
   }
 
-  if (!toTokenPriceBN.isNaN() && toTokenPriceBN.gt(0)) {
+  const receiveFiatValueBN = toAmountBN.multipliedBy(
+    toTokenPriceBN.isNaN() ? 0 : toTokenPriceBN,
+  );
+
+  if (!receiveFiatValueBN.isNaN() && receiveFiatValueBN.gt(0)) {
     return quoteResult;
   }
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.ts
@@ -1,5 +1,6 @@
 import BigNumber from 'bignumber.js';
 
+import { attachUnknownTokenValueTip } from '@onekeyhq/kit/src/views/Swap/utils/unknownTokenValueTip';
 import type {
   IFetchBuildTxResponse,
   IFetchQuoteResult,
@@ -75,29 +76,11 @@ export function attachMarketUnknownTokenValueTip({
   toTokenPrice?: string;
   quoteTip?: IQuoteTip;
 }) {
-  if (quoteResult.quoteShowTip || !quoteTip) {
-    return quoteResult;
-  }
-
-  const toAmountBN = new BigNumber(quoteResult.toAmount ?? 0);
-  const toTokenPriceBN = new BigNumber(toTokenPrice ?? 0);
-
-  if (toAmountBN.isNaN()) {
-    return quoteResult;
-  }
-
-  const receiveFiatValueBN = toAmountBN.multipliedBy(
-    toTokenPriceBN.isNaN() ? 0 : toTokenPriceBN,
-  );
-
-  if (!receiveFiatValueBN.isNaN() && receiveFiatValueBN.gt(0)) {
-    return quoteResult;
-  }
-
-  return {
-    ...quoteResult,
-    quoteShowTip: quoteTip,
-  };
+  return attachUnknownTokenValueTip({
+    quoteResult,
+    toTokenPrice,
+    quoteTip,
+  });
 }
 
 export function mergeMarketBuildResultWithQuote({

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
@@ -967,15 +967,33 @@ describe('useSpeedSwapActions', () => {
     expect(mockFetchSwapTokenDetails).not.toHaveBeenCalled();
   });
 
-  it('adds the unknown token value tip to the prepared market review when the receive fiat value is zero', async () => {
+  it('adds the unknown token value tip from quote semantics even when the review display token still has a price', async () => {
     mockFetchSwapTokenDetails.mockResolvedValue([]);
+    mockFetchBuildSpeedSwapTx.mockResolvedValue({
+      result: {
+        protocol: EProtocolOfExchange.SWAP,
+        info: {
+          provider: 'onekey',
+          providerName: 'OneKey',
+        },
+        fromTokenInfo: usdcToken,
+        toTokenInfo: {
+          ...btcToken,
+          price: '0',
+        },
+        fromAmount: '100',
+        toAmount: '2',
+        gasLimit: 21_000,
+        routesData: [{ subRoutes: [[{}]] }],
+      },
+    } as IFetchBuildTxResponse);
 
     const { result } = renderHook(() =>
       useSpeedSwapActions(
         createHookProps({
           marketToken: {
             ...btcToken,
-            price: '0',
+            price: '100000',
           },
           tradeToken: {
             ...usdcToken,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
@@ -8,9 +8,11 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import type {
+  IFetchBuildTxResponse,
   ISwapToken,
   ISwapTokenBase,
 } from '@onekeyhq/shared/types/swap/types';
+import { EProtocolOfExchange } from '@onekeyhq/shared/types/swap/types';
 
 import {
   buildMarketReviewTokens,
@@ -28,6 +30,55 @@ type IFetchSwapTokenDetailsParams = {
 
 type IFetchSwapNativeTokenConfigParams = {
   networkId: string;
+};
+
+type IFetchBuildSpeedSwapTxParams = {
+  fromToken: ISwapToken;
+  toToken: ISwapToken;
+  fromTokenAmount: string;
+  provider: string;
+  userAddress: string;
+  receivingAddress: string;
+  slippagePercentage: number;
+  accountId?: string;
+};
+
+type IResolveMarketReviewAllowanceStateParams = {
+  amount: string;
+  currentState: {
+    allowanceTarget?: string;
+    shouldApprove?: boolean;
+    shouldResetApprove?: boolean;
+  };
+  isWrapped?: boolean;
+  spenderAddress?: string;
+  token?: ISwapTokenBase;
+  walletAddress?: string;
+};
+
+type IResolveMarketReviewAllowanceStateResult = {
+  shouldApprove: boolean;
+  shouldResetApprove: boolean;
+  allowanceTarget?: string;
+};
+
+type IBuildMarketExecutionPayloadParams = {
+  accountId: string;
+  buildRes: IFetchBuildTxResponse;
+  currentFromToken: ISwapToken;
+  currentToToken: ISwapToken;
+  fromAmount: string;
+  receivingAddress: string;
+  slippage: number;
+  userAddress: string;
+};
+
+type IEstimateMarketDirectGasInfosResult = {
+  preparedUnsignedTx: {
+    encodedTx: undefined;
+  };
+  gasInfos: unknown[];
+  gasFeeFiatValue: string;
 };
 
 type IUsePaymentTokenPriceResult = {
@@ -50,12 +101,55 @@ const mockFetchSwapNativeTokenConfig: jest.MockedFunction<
     params: IFetchSwapNativeTokenConfigParams,
   ) => Promise<{ networkId: string; reserveGas: string }>
 > = jest.fn();
+const mockFetchBuildSpeedSwapTx: jest.MockedFunction<
+  (
+    params: IFetchBuildSpeedSwapTxParams,
+  ) => Promise<IFetchBuildTxResponse | undefined>
+> = jest.fn();
 const mockSetInAppNotificationAtom = jest.fn();
 const mockNavigationToTxConfirm = jest.fn();
 const mockNetAccountRun = jest.fn();
 const mockMarketDeriveInfoRun = jest.fn();
 const mockUsePaymentTokenPrice: jest.MockedFunction<IUsePaymentTokenPriceMock> =
   jest.fn();
+const mockResolveMarketReviewAllowanceState: jest.MockedFunction<
+  (
+    params: IResolveMarketReviewAllowanceStateParams,
+  ) => Promise<IResolveMarketReviewAllowanceStateResult>
+> = jest.fn();
+const mockBuildMarketExecutionPayload: jest.MockedFunction<
+  (params: IBuildMarketExecutionPayloadParams) => Promise<{
+    encodedTx: undefined;
+    transferInfo: undefined;
+    swapInfo: {
+      protocol: EProtocolOfExchange;
+      sender: {
+        amount: string;
+        token: ISwapToken;
+        accountInfo: {
+          accountId: string;
+          networkId: string;
+        };
+      };
+      receiver: {
+        amount: string;
+        token: ISwapToken;
+        accountInfo: {
+          accountId: string;
+          networkId: string;
+        };
+      };
+      accountAddress: string;
+      receivingAddress: string;
+      swapBuildResData: IFetchBuildTxResponse;
+    };
+    skipSendTransAction: boolean;
+    orderId?: string;
+  }>
+> = jest.fn();
+const mockEstimateMarketDirectGasInfos: jest.MockedFunction<
+  (_params: unknown) => Promise<IEstimateMarketDirectGasInfosResult>
+> = jest.fn();
 
 let mockUsePromiseResultCallCount = 0;
 let mockPaymentTokenPriceCache: Record<string, BigNumber> = {};
@@ -95,6 +189,8 @@ jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
         mockFetchSwapTokenDetails(params),
       fetchSwapNativeTokenConfig: (params: IFetchSwapNativeTokenConfigParams) =>
         mockFetchSwapNativeTokenConfig(params),
+      fetchBuildSpeedSwapTx: (params: IFetchBuildSpeedSwapTxParams) =>
+        mockFetchBuildSpeedSwapTx(params),
     },
   },
 }));
@@ -171,6 +267,24 @@ jest.mock('./usePaymentTokenPrice', () => ({
     networkId?: string,
   ): IUsePaymentTokenPriceResult =>
     mockUsePaymentTokenPrice(paymentToken, networkId),
+}));
+
+jest.mock('./marketReviewAllowance', () => ({
+  resolveMarketReviewAllowanceState: (
+    params: IResolveMarketReviewAllowanceStateParams,
+  ) => mockResolveMarketReviewAllowanceState(params),
+}));
+
+jest.mock('./marketBuildExecutionUtils', () => ({
+  buildMarketExecutionPayload: (params: IBuildMarketExecutionPayloadParams) =>
+    mockBuildMarketExecutionPayload(params),
+}));
+
+jest.mock('./marketDirectSendTx', () => ({
+  estimateMarketApproveGasInfos: jest.fn(),
+  estimateMarketDirectGasInfos: (params: unknown) =>
+    mockEstimateMarketDirectGasInfos(params),
+  sendMarketDirectUnsignedTxs: jest.fn(),
 }));
 
 function createDeferred<T>() {
@@ -275,11 +389,15 @@ describe('useSpeedSwapActions', () => {
   beforeEach(() => {
     mockFetchSwapTokenDetails.mockReset();
     mockFetchSwapNativeTokenConfig.mockReset();
+    mockFetchBuildSpeedSwapTx.mockReset();
     mockSetInAppNotificationAtom.mockReset();
     mockNavigationToTxConfirm.mockReset();
     mockNetAccountRun.mockReset();
     mockMarketDeriveInfoRun.mockReset();
     mockUsePaymentTokenPrice.mockReset();
+    mockResolveMarketReviewAllowanceState.mockReset();
+    mockBuildMarketExecutionPayload.mockReset();
+    mockEstimateMarketDirectGasInfos.mockReset();
     mockUsePromiseResultCallCount = 0;
     mockPaymentTokenPriceCache = {};
     mockInAppNotificationAtomState = {};
@@ -308,6 +426,87 @@ describe('useSpeedSwapActions', () => {
     mockFetchSwapNativeTokenConfig.mockResolvedValue({
       networkId: 'evm--1',
       reserveGas: '0.01',
+    });
+    mockFetchBuildSpeedSwapTx.mockResolvedValue({
+      result: {
+        protocol: EProtocolOfExchange.SWAP,
+        info: {
+          provider: 'onekey',
+          providerName: 'OneKey',
+        },
+        fromTokenInfo: usdcToken,
+        toTokenInfo: btcToken,
+        fromAmount: '100',
+        toAmount: '2',
+        gasLimit: 21_000,
+        routesData: [{ subRoutes: [[{}]] }],
+      },
+    } as IFetchBuildTxResponse);
+    mockResolveMarketReviewAllowanceState.mockResolvedValue({
+      shouldApprove: false,
+      shouldResetApprove: false,
+      allowanceTarget: '0xspender',
+    });
+    mockBuildMarketExecutionPayload.mockImplementation(
+      async ({
+        accountId,
+        buildRes,
+        currentFromToken,
+        currentToToken,
+        fromAmount,
+        receivingAddress,
+        slippage,
+        userAddress,
+      }: {
+        accountId: string;
+        buildRes: IFetchBuildTxResponse;
+        currentFromToken: ISwapToken;
+        currentToToken: ISwapToken;
+        fromAmount: string;
+        receivingAddress: string;
+        slippage: number;
+        userAddress: string;
+      }) => ({
+        encodedTx: undefined,
+        transferInfo: undefined,
+        swapInfo: {
+          protocol: buildRes.result.protocol ?? EProtocolOfExchange.SWAP,
+          sender: {
+            amount: buildRes.result.fromAmount ?? fromAmount,
+            token: currentFromToken,
+            accountInfo: {
+              accountId,
+              networkId: currentFromToken.networkId,
+            },
+          },
+          receiver: {
+            amount: buildRes.result.toAmount ?? '0',
+            token: currentToToken,
+            accountInfo: {
+              accountId,
+              networkId: currentToToken.networkId,
+            },
+          },
+          accountAddress: userAddress,
+          receivingAddress,
+          swapBuildResData: {
+            ...buildRes,
+            result: {
+              ...buildRes.result,
+              slippage: buildRes.result.slippage ?? slippage,
+            },
+          },
+        },
+        skipSendTransAction: false,
+        orderId: buildRes.orderId,
+      }),
+    );
+    mockEstimateMarketDirectGasInfos.mockResolvedValue({
+      preparedUnsignedTx: {
+        encodedTx: undefined,
+      },
+      gasInfos: [],
+      gasFeeFiatValue: '0',
     });
     mockNetAccountPromiseResult = {
       result: {
@@ -766,6 +965,41 @@ describe('useSpeedSwapActions', () => {
     });
 
     expect(mockFetchSwapTokenDetails).not.toHaveBeenCalled();
+  });
+
+  it('adds the unknown token value tip to the prepared market review when the receive fiat value is zero', async () => {
+    mockFetchSwapTokenDetails.mockResolvedValue([]);
+
+    const { result } = renderHook(() =>
+      useSpeedSwapActions(
+        createHookProps({
+          marketToken: {
+            ...btcToken,
+            price: '0',
+          },
+          tradeToken: {
+            ...usdcToken,
+            price: '1',
+          },
+        }),
+      ),
+    );
+
+    let reviewState:
+      | Awaited<ReturnType<typeof result.current.prepareMarketSwapReview>>
+      | undefined;
+
+    await act(async () => {
+      reviewState = await result.current.prepareMarketSwapReview({
+        fromAmount: '100',
+      });
+    });
+
+    expect(reviewState?.quoteResult?.quoteShowTip).toEqual({
+      title: 'trade.unknown_token_value',
+      detail: 'trade.unable_to_obtain_token_value',
+      showCancelButton: true,
+    });
   });
 });
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -90,6 +90,7 @@ import {
   shouldSkipMarketSignedPrebuild,
 } from './marketReviewExecutionUtils';
 import {
+  attachMarketUnknownTokenValueTip,
   buildDefaultMarketSpeedCheckState,
   buildMarketReviewShouldFallback,
   mergeMarketBuildResultWithQuote,
@@ -1241,6 +1242,19 @@ export function useSpeedSwapActions(props: {
           amount,
         }),
       );
+      const reviewQuoteResult = attachMarketUnknownTokenValueTip({
+        quoteResult: normalizedQuoteResult,
+        toTokenPrice: reviewToToken.price,
+        quoteTip: {
+          title: intl.formatMessage({
+            id: ETranslations.trade_unknown_token_value,
+          }),
+          detail: intl.formatMessage({
+            id: ETranslations.trade_unable_to_obtain_token_value,
+          }),
+          showCancelButton: true,
+        },
+      });
       const shouldFallback = buildMarketReviewShouldFallback({
         networkId: reviewFromToken.networkId,
         isCustomRpcUnavailable,
@@ -1251,7 +1265,7 @@ export function useSpeedSwapActions(props: {
         accountId: netAccountRes.result?.id ?? '',
         networkId: reviewFromToken.networkId,
         shouldFallback,
-        quoteResult: normalizedQuoteResult,
+        quoteResult: reviewQuoteResult,
         buildUnsignedParams: {
           networkId: reviewFromToken.networkId,
           accountId: netAccountRes.result?.id ?? '',
@@ -1280,6 +1294,7 @@ export function useSpeedSwapActions(props: {
       fromTokenAmountDebounced,
       isCustomRpcUnavailable,
       isWrapped,
+      intl,
       netAccountRes.result?.id,
       netAccountRes.result?.addressDetail.address,
       shouldApprove,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -1040,16 +1040,31 @@ export function useSpeedSwapActions(props: {
       snapshot: IMarketReviewExecutionSnapshot,
       networkFeeLevel: ESwapNetworkFeeLevel = ESwapNetworkFeeLevel.MEDIUM,
     ) => {
+      const reviewQuoteResult = attachMarketUnknownTokenValueTip({
+        quoteResult: snapshot.quoteResult,
+        toTokenPrice: snapshot.swapInfo.receiver.token.price,
+        quoteTip: {
+          title: intl.formatMessage({
+            id: ETranslations.trade_unknown_token_value,
+          }),
+          detail: intl.formatMessage({
+            id: ETranslations.trade_unable_to_obtain_token_value,
+          }),
+          showCancelButton: true,
+        },
+      });
+      snapshot.quoteResult = reviewQuoteResult;
+
       const nextReviewState = buildMarketReviewState({
         accountId: snapshot.accountId,
         networkId: snapshot.networkId,
         fromToken: snapshot.swapInfo.sender.token,
         toToken: snapshot.swapInfo.receiver.token,
         fromTokenAmount:
-          snapshot.quoteResult.fromAmount ?? snapshot.swapInfo.sender.amount,
+          reviewQuoteResult.fromAmount ?? snapshot.swapInfo.sender.amount,
         toTokenAmount:
-          snapshot.quoteResult.toAmount ?? snapshot.swapInfo.receiver.amount,
-        quoteResult: snapshot.quoteResult,
+          reviewQuoteResult.toAmount ?? snapshot.swapInfo.receiver.amount,
+        quoteResult: reviewQuoteResult,
         shouldFallback: snapshot.shouldFallback,
         slippage,
         texts: buildReviewStepTexts(snapshot.quoteResult.info.providerName),
@@ -1060,13 +1075,13 @@ export function useSpeedSwapActions(props: {
         const approveUnsignedTxArr = await buildMarketApproveUnsignedTxArr({
           approveInfos: buildMarketApproveInfos({
             fromUserAddress: snapshot.accountAddress,
-            quoteResult: snapshot.quoteResult,
+            quoteResult: reviewQuoteResult,
           }),
           accountId: snapshot.accountId,
           networkId: snapshot.networkId,
         });
         if (
-          snapshot.quoteResult.swapShouldSignedData &&
+          reviewQuoteResult.swapShouldSignedData &&
           approveUnsignedTxArr?.length
         ) {
           const feeState = await estimateMarketApproveGasInfos({
@@ -1083,7 +1098,7 @@ export function useSpeedSwapActions(props: {
           };
         } else if (
           shouldSkipMarketSignedPrebuild({
-            quoteResult: snapshot.quoteResult,
+            quoteResult: reviewQuoteResult,
             approveUnsignedTxCount: approveUnsignedTxArr?.length,
           })
         ) {
@@ -1128,10 +1143,10 @@ export function useSpeedSwapActions(props: {
           },
           netWorkFee,
         },
-        quoteResult: snapshot.quoteResult,
+        quoteResult: reviewQuoteResult,
       };
     },
-    [buildMarketApproveUnsignedTxArr, buildReviewStepTexts, slippage],
+    [buildMarketApproveUnsignedTxArr, buildReviewStepTexts, intl, slippage],
   );
 
   const prepareMarketSwapReview = useCallback<
@@ -1242,19 +1257,6 @@ export function useSpeedSwapActions(props: {
           amount,
         }),
       );
-      const reviewQuoteResult = attachMarketUnknownTokenValueTip({
-        quoteResult: normalizedQuoteResult,
-        toTokenPrice: reviewToToken.price,
-        quoteTip: {
-          title: intl.formatMessage({
-            id: ETranslations.trade_unknown_token_value,
-          }),
-          detail: intl.formatMessage({
-            id: ETranslations.trade_unable_to_obtain_token_value,
-          }),
-          showCancelButton: true,
-        },
-      });
       const shouldFallback = buildMarketReviewShouldFallback({
         networkId: reviewFromToken.networkId,
         isCustomRpcUnavailable,
@@ -1265,7 +1267,7 @@ export function useSpeedSwapActions(props: {
         accountId: netAccountRes.result?.id ?? '',
         networkId: reviewFromToken.networkId,
         shouldFallback,
-        quoteResult: reviewQuoteResult,
+        quoteResult: normalizedQuoteResult,
         buildUnsignedParams: {
           networkId: reviewFromToken.networkId,
           accountId: netAccountRes.result?.id ?? '',
@@ -1294,7 +1296,6 @@ export function useSpeedSwapActions(props: {
       fromTokenAmountDebounced,
       isCustomRpcUnavailable,
       isWrapped,
-      intl,
       netAccountRes.result?.id,
       netAccountRes.result?.addressDetail.address,
       shouldApprove,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -1042,7 +1042,7 @@ export function useSpeedSwapActions(props: {
     ) => {
       const reviewQuoteResult = attachMarketUnknownTokenValueTip({
         quoteResult: snapshot.quoteResult,
-        toTokenPrice: snapshot.swapInfo.receiver.token.price,
+        toTokenPrice: snapshot.quoteResult.toTokenInfo.price,
         quoteTip: {
           title: intl.formatMessage({
             id: ETranslations.trade_unknown_token_value,

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -113,6 +113,7 @@ import {
   useSwapSlippagePercentageModeInfo,
 } from '../../hooks/useSwapState';
 import { buildSwapReviewState } from '../../utils/buildSwapReviewState';
+import { attachUnknownTokenValueTip } from '../../utils/unknownTokenValueTip';
 import { SwapProviderMirror } from '../SwapProviderMirror';
 
 import PreSwapDialogContent from './PreSwapDialogContent';
@@ -579,11 +580,29 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     }),
     [currentQuoteRes?.info.providerName, fromSelectToken?.symbol, intl],
   );
+  const unknownTokenValueTip = useMemo(
+    () => ({
+      title: intl.formatMessage({
+        id: ETranslations.trade_unknown_token_value,
+      }),
+      detail: intl.formatMessage({
+        id: ETranslations.trade_unable_to_obtain_token_value,
+      }),
+      showCancelButton: true,
+    }),
+    [intl],
+  );
 
   const parseQuoteResultToSteps = useCallback(() => {
     if (!currentQuoteRes) {
       return;
     }
+
+    const reviewQuoteResult = attachUnknownTokenValueTip({
+      quoteResult: currentQuoteRes,
+      toTokenPrice: toSelectToken?.price,
+      quoteTip: unknownTokenValueTip,
+    });
 
     const nextReviewState = buildSwapReviewState({
       accountId: swapFromAddressInfo.accountInfo?.account?.id,
@@ -596,7 +615,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
           ? swapProInputAmount
           : fromTokenAmount.value,
       toTokenAmount: swapToAmount.value,
-      quoteResult: currentQuoteRes,
+      quoteResult: reviewQuoteResult,
       swapType: swapTypeFinal,
       shouldFallback:
         SwapBuildShouldFallBackNetworkIds.includes(
@@ -617,6 +636,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     setSwapSteps,
     fromSelectToken,
     toSelectToken,
+    unknownTokenValueTip,
     focusSwapPro,
     swapProTradeType,
     swapProInputAmount,

--- a/packages/kit/src/views/Swap/utils/unknownTokenValueTip.test.ts
+++ b/packages/kit/src/views/Swap/utils/unknownTokenValueTip.test.ts
@@ -1,0 +1,91 @@
+import type { IFetchQuoteResult } from '@onekeyhq/shared/types/swap/types';
+
+import { attachUnknownTokenValueTip } from './unknownTokenValueTip';
+
+function createQuoteResult(
+  overrides: Partial<IFetchQuoteResult> = {},
+): IFetchQuoteResult {
+  return {
+    info: {
+      provider: 'provider-a',
+      providerName: 'Provider A',
+    },
+    fromTokenInfo: {
+      networkId: 'evm--1',
+      contractAddress: '0xfrom',
+      symbol: 'ETH',
+      decimals: 18,
+      isNative: true,
+    },
+    toTokenInfo: {
+      networkId: 'evm--1',
+      contractAddress: '0xto',
+      symbol: 'USDC',
+      decimals: 6,
+      isNative: false,
+    },
+    fromAmount: '1',
+    toAmount: '1000',
+    ...overrides,
+  };
+}
+
+describe('attachUnknownTokenValueTip', () => {
+  const quoteTip = {
+    title: 'Unknown Token Value',
+    detail: 'Unable to obtain token value',
+    showCancelButton: true,
+  };
+
+  it('attaches the warning when the receive token price is unavailable', () => {
+    const nextQuoteResult = attachUnknownTokenValueTip({
+      quoteResult: createQuoteResult(),
+      toTokenPrice: '0',
+      quoteTip,
+    });
+
+    expect(nextQuoteResult.quoteShowTip).toEqual(quoteTip);
+  });
+
+  it('attaches the warning when the receive fiat value resolves to zero', () => {
+    const nextQuoteResult = attachUnknownTokenValueTip({
+      quoteResult: createQuoteResult({
+        toAmount: '0.0000',
+      }),
+      toTokenPrice: '1',
+      quoteTip,
+    });
+
+    expect(nextQuoteResult.quoteShowTip).toEqual(quoteTip);
+  });
+
+  it('does not attach the warning when the receive fiat value is positive', () => {
+    const nextQuoteResult = attachUnknownTokenValueTip({
+      quoteResult: createQuoteResult({
+        toAmount: '0.0001',
+      }),
+      toTokenPrice: '1',
+      quoteTip,
+    });
+
+    expect(nextQuoteResult.quoteShowTip).toBeUndefined();
+  });
+
+  it('does not override an existing quote tip', () => {
+    const existingQuoteTip = {
+      title: '40% value drop',
+      detail: 'High price impact may cause your asset loss.',
+      showCancelButton: true,
+    };
+
+    const nextQuoteResult = attachUnknownTokenValueTip({
+      quoteResult: createQuoteResult({
+        quoteShowTip: existingQuoteTip,
+      }),
+      toTokenPrice: '0',
+      quoteTip,
+    });
+
+    expect(nextQuoteResult.quoteShowTip).toEqual(existingQuoteTip);
+  });
+});

--- a/packages/kit/src/views/Swap/utils/unknownTokenValueTip.ts
+++ b/packages/kit/src/views/Swap/utils/unknownTokenValueTip.ts
@@ -1,0 +1,40 @@
+import BigNumber from 'bignumber.js';
+
+import type {
+  IFetchQuoteResult,
+  IQuoteTip,
+} from '@onekeyhq/shared/types/swap/types';
+
+export function attachUnknownTokenValueTip({
+  quoteResult,
+  toTokenPrice,
+  quoteTip,
+}: {
+  quoteResult: IFetchQuoteResult;
+  toTokenPrice?: string;
+  quoteTip?: IQuoteTip;
+}) {
+  if (quoteResult.quoteShowTip || !quoteTip) {
+    return quoteResult;
+  }
+
+  const toAmountBN = new BigNumber(quoteResult.toAmount ?? 0);
+  const toTokenPriceBN = new BigNumber(toTokenPrice ?? 0);
+
+  if (toAmountBN.isNaN()) {
+    return quoteResult;
+  }
+
+  const receiveFiatValueBN = toAmountBN.multipliedBy(
+    toTokenPriceBN.isNaN() ? 0 : toTokenPriceBN,
+  );
+
+  if (!receiveFiatValueBN.isNaN() && receiveFiatValueBN.gt(0)) {
+    return quoteResult;
+  }
+
+  return {
+    ...quoteResult,
+    quoteShowTip: quoteTip,
+  };
+}


### PR DESCRIPTION
## Summary
- warn Market review orders when the receive token fiat value is unavailable
- preserve quote fallback `quoteShowTip` data instead of dropping existing warnings
- add focused tests for the unknown-token-value warning path

## Issues
- OK-53328

## Intent & Context
Jira OK-53328 and the linked Slack discussion showed a Market Trade review dialog that displayed `$0.00` for newly listed meme tokens whose fiat value was unavailable. In that state the review could proceed without the existing Value Drop warning flow, which made the risk easy to miss.

## Root Cause
The shared review token item falls back to `$0.00` when `token.price` is missing. On the Market review path, we were not attaching a warning tip when the receive token fiat price was unavailable, and the Market quote fallback merge also failed to carry over an upstream `quoteShowTip` when one existed.

## Design Decisions
The fix stays in the Market review construction layer instead of patching the shared dialog UI. This keeps the existing PreSwap tip UI, analytics, and confirmation flow unchanged while only filling the missing Market-specific warning case. The implementation also preserves any existing server-provided `quoteShowTip` so regular Value Drop warnings continue to win over the unknown-value fallback.

## Changes Detail
- add a Market utility to attach an unknown-token-value warning only when the receive amount is non-zero, the receive token price is unavailable, and no warning tip already exists
- preserve `quoteShowTip` when Market build results are hydrated from quote fallback data
- inject the existing `trade.unknown_token_value` and `trade.unable_to_obtain_token_value` copy into the Market review quote before opening the dialog
- cover fallback tip preservation and unknown-token-value warning behavior with focused unit tests

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile / Desktop / Web / Extension
- **Risk Areas**: Market review warning gating and quote fallback hydration

## Test plan
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.ts packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.test.ts`
- [x] `yarn jest --runInBand --roots packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks --modulePathIgnorePatterns '<rootDir>/apps/desktop/app' --testPathPattern marketSwapBuildUtils.test.ts`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
