### PR TITLE
fix(market): scroll network selector to selected network on open(OK-53324)

### DIFF
--- a/packages/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorListView.tsx
+++ b/packages/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorListView.tsx
@@ -1,4 +1,11 @@
-import { type FC, useCallback, useMemo, useState } from 'react';
+import {
+  type FC,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
@@ -9,7 +16,9 @@ import {
   SearchBar,
   Stack,
   useSafeAreaInsets,
+  useSafelyScrollIntoIndex,
 } from '@onekeyhq/components';
+import type { IListViewRef } from '@onekeyhq/components';
 import { Currency } from '@onekeyhq/kit/src/components/Currency';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { NetworkAvatarBase } from '@onekeyhq/kit/src/components/NetworkAvatar';
@@ -18,8 +27,7 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { useFuseSearch } from '../../hooks/useFuseSearch';
-
-import type { IServerNetworkMatch } from '../../types';
+import { CELL_HEIGHT, type IServerNetworkMatch } from '../../types';
 
 const ListEmptyComponent = () => {
   const intl = useIntl();
@@ -36,6 +44,7 @@ const ListEmptyComponent = () => {
 type IChainSelectorListViewProps = {
   networks: IServerNetworkMatch[];
   networkId?: string;
+  isOpen?: boolean;
   onPressItem?: (network: IServerNetworkMatch) => void;
   accountNetworkValues?: Record<string, string>;
   accountNetworkValueCurrency?: string;
@@ -46,15 +55,50 @@ const ChainSelectorListViewContent = ({
   networks,
   onPressItem,
   networkId,
+  selectedIndex,
+  shouldAutoScrollToSelected,
   accountNetworkValues,
   accountNetworkValueCurrency,
   hideLowValueNetworkValue,
-}: IChainSelectorListViewProps) => {
+}: IChainSelectorListViewProps & {
+  selectedIndex: number;
+  shouldAutoScrollToSelected: boolean;
+}) => {
   const { bottom } = useSafeAreaInsets();
   const intl = useIntl();
+  const listViewRef = useRef<IListViewRef<IServerNetworkMatch>>(null);
+  const { scrollIntoIndex, onLayout } = useSafelyScrollIntoIndex(listViewRef);
+
+  useEffect(() => {
+    if (!shouldAutoScrollToSelected || selectedIndex <= 0) {
+      return;
+    }
+
+    if (platformEnv.isNative) {
+      scrollIntoIndex({
+        index: selectedIndex,
+        animated: false,
+        viewPosition: 0.3,
+      });
+      return;
+    }
+
+    const timerId = setTimeout(() => {
+      listViewRef.current?.scrollToOffset?.({
+        offset: Math.max((selectedIndex - 2) * CELL_HEIGHT, 0),
+        animated: false,
+      });
+    }, 80);
+
+    return () => clearTimeout(timerId);
+  }, [scrollIntoIndex, selectedIndex, shouldAutoScrollToSelected]);
 
   return (
     <ListView
+      flex={1}
+      minHeight={0}
+      ref={listViewRef}
+      onLayout={onLayout}
       ListEmptyComponent={ListEmptyComponent}
       ListFooterComponent={<Stack h={bottom || '$2'} />}
       estimatedItemSize={48}
@@ -125,6 +169,7 @@ const ChainSelectorListViewContent = ({
 export const ChainSelectorListView: FC<IChainSelectorListViewProps> = ({
   networks,
   networkId,
+  isOpen,
   onPressItem,
   accountNetworkValues,
   accountNetworkValueCurrency,
@@ -144,23 +189,37 @@ export const ChainSelectorListView: FC<IChainSelectorListViewProps> = ({
     }
     return networkFuseSearch(text);
   }, [networkFuseSearch, text, networks]);
+
+  const shouldAutoScrollToSelected = !text && (isOpen ?? true);
+  const selectedIndex = useMemo(() => {
+    if (!shouldAutoScrollToSelected || !networkId) {
+      return -1;
+    }
+
+    return data.findIndex((network) => network.id === networkId);
+  }, [data, networkId, shouldAutoScrollToSelected]);
+
   return (
-    <Stack flex={1}>
-      <Stack px="$5" pb="$2">
+    <Stack flex={1} minHeight={0}>
+      <Stack px="$5" pb="$2" flexShrink={0}>
         <SearchBar
           placeholder={intl.formatMessage({ id: ETranslations.global_search })}
           value={text}
           onChangeText={onChangeText}
         />
       </Stack>
-      <ChainSelectorListViewContent
-        networkId={networkId}
-        networks={data}
-        onPressItem={onPressItem}
-        accountNetworkValues={accountNetworkValues}
-        accountNetworkValueCurrency={accountNetworkValueCurrency}
-        hideLowValueNetworkValue={hideLowValueNetworkValue}
-      />
+      <Stack flex={1} minHeight={0}>
+        <ChainSelectorListViewContent
+          networkId={networkId}
+          networks={data}
+          selectedIndex={selectedIndex}
+          shouldAutoScrollToSelected={shouldAutoScrollToSelected}
+          onPressItem={onPressItem}
+          accountNetworkValues={accountNetworkValues}
+          accountNetworkValueCurrency={accountNetworkValueCurrency}
+          hideLowValueNetworkValue={hideLowValueNetworkValue}
+        />
+      </Stack>
     </Stack>
   );
 };

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenListNetworkSelector/MoreButton.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenListNetworkSelector/MoreButton.tsx
@@ -1,5 +1,5 @@
 import type { FC, ReactNode } from 'react';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -8,7 +8,10 @@ import type { IButtonProps, IPopoverProps } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IServerNetwork } from '@onekeyhq/shared/types';
 
-import { NetworksSearchPanel } from './NetworksSearchPanel';
+import {
+  NETWORKS_SEARCH_PANEL_MAX_HEIGHT,
+  NetworksSearchPanel,
+} from './NetworksSearchPanel';
 
 import type { INetworksSearchPanelProps } from './NetworksSearchPanel';
 
@@ -32,14 +35,34 @@ const MoreButton: FC<IMoreButtonProps> = ({
   const intl = useIntl();
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleNetworkSelect = (network: IServerNetwork) => {
-    onNetworkSelect?.(network);
-    setIsOpen(false);
-  };
+  const handleNetworkSelect = useCallback(
+    (network: IServerNetwork) => {
+      onNetworkSelect?.(network);
+      setIsOpen(false);
+    },
+    [onNetworkSelect],
+  );
 
   const handleToggle = () => {
     setIsOpen(!isOpen);
   };
+
+  const renderContent = useCallback(
+    ({
+      isOpen: isContentOpen,
+    }: {
+      isOpen?: boolean;
+      closePopover: () => void;
+    }) => (
+      <NetworksSearchPanel
+        isOpen={isContentOpen}
+        networks={networks}
+        networkId={selectedNetworkId}
+        onNetworkSelect={handleNetworkSelect}
+      />
+    ),
+    [handleNetworkSelect, networks, selectedNetworkId],
+  );
 
   const renderTrigger = () => {
     if (customTrigger) {
@@ -72,15 +95,9 @@ const MoreButton: FC<IMoreButtonProps> = ({
       placement={placement}
       floatingPanelProps={{
         maxWidth: 384,
-        maxHeight: 420,
+        maxHeight: NETWORKS_SEARCH_PANEL_MAX_HEIGHT,
       }}
-      renderContent={
-        <NetworksSearchPanel
-          networks={networks}
-          networkId={selectedNetworkId}
-          onNetworkSelect={handleNetworkSelect}
-        />
-      }
+      renderContent={renderContent}
       renderTrigger={renderTrigger()}
     />
   );

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenListNetworkSelector/NetworksSearchPanel.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenListNetworkSelector/NetworksSearchPanel.tsx
@@ -3,8 +3,15 @@ import type { ComponentProps, FC } from 'react';
 
 import { Stack } from '@onekeyhq/components';
 import { ChainSelectorListView } from '@onekeyhq/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorListView';
-import type { IServerNetworkMatch } from '@onekeyhq/kit/src/views/ChainSelector/types';
+import {
+  CELL_HEIGHT,
+  type IServerNetworkMatch,
+} from '@onekeyhq/kit/src/views/ChainSelector/types';
 import type { IServerNetwork } from '@onekeyhq/shared/types';
+
+export const NETWORKS_SEARCH_PANEL_MAX_HEIGHT = 420;
+
+const NETWORKS_SEARCH_PANEL_BASE_HEIGHT = 92;
 
 export interface INetworksSearchPanelProps extends Omit<
   ComponentProps<typeof ChainSelectorListView>,
@@ -17,6 +24,7 @@ export interface INetworksSearchPanelProps extends Omit<
 export const NetworksSearchPanel: FC<INetworksSearchPanelProps> = ({
   networks: networksProp,
   networkId,
+  isOpen,
   onNetworkSelect,
 }) => {
   const networksForListView = useMemo(() => {
@@ -25,6 +33,16 @@ export const NetworksSearchPanel: FC<INetworksSearchPanelProps> = ({
       (network): network is IServerNetwork => network !== null,
     ) as IServerNetworkMatch[];
   }, [networksProp]);
+
+  const panelHeight = useMemo(
+    () =>
+      Math.min(
+        NETWORKS_SEARCH_PANEL_MAX_HEIGHT,
+        NETWORKS_SEARCH_PANEL_BASE_HEIGHT +
+          networksForListView.length * CELL_HEIGHT,
+      ),
+    [networksForListView.length],
+  );
 
   const handleNetworkPress = (network: IServerNetworkMatch) => {
     // Find the original ISwapNetwork to pass back
@@ -38,8 +56,9 @@ export const NetworksSearchPanel: FC<INetworksSearchPanelProps> = ({
   };
 
   return (
-    <Stack pt="$4">
+    <Stack pt="$3" h={panelHeight} minHeight={0}>
       <ChainSelectorListView
+        isOpen={isOpen}
         networkId={networkId}
         networks={networksForListView}
         onPressItem={handleNetworkPress}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MobileNetworkDropdown/MobileNetworkDropdown.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MobileNetworkDropdown/MobileNetworkDropdown.tsx
@@ -7,75 +7,21 @@ import {
   Image,
   Popover,
   SizableText,
-  Stack,
   XStack,
 } from '@onekeyhq/components';
-import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
-import { NetworkAvatarBase } from '@onekeyhq/kit/src/components/NetworkAvatar';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import type { IServerNetwork } from '@onekeyhq/shared/types';
 
 import { useMarketNetworks } from '../../../hooks/useMarketNetworks';
+import {
+  NETWORKS_SEARCH_PANEL_MAX_HEIGHT,
+  NetworksSearchPanel,
+} from '../MarketTokenListNetworkSelector/NetworksSearchPanel';
 
 interface IMobileNetworkDropdownProps {
   selectedNetworkId?: string;
   onNetworkIdChange?: (id: string) => void;
-}
-
-function NetworkDropdownContent({
-  networks,
-  selectedNetworkId,
-  onSelect,
-  closePopover,
-}: {
-  networks: IServerNetwork[];
-  selectedNetworkId?: string;
-  onSelect: (network: IServerNetwork) => void;
-  closePopover: () => void;
-}) {
-  const intl = useIntl();
-
-  return (
-    <Stack pt="$4">
-      {networks.map((item) => {
-        const { isAllNetworks } = item;
-        return (
-          <ListItem
-            key={item.id}
-            h={48}
-            renderAvatar={
-              <NetworkAvatarBase
-                logoURI={item.logoURI}
-                isCustomNetwork={item.isCustomNetwork}
-                networkName={item.name}
-                isAllNetworks={isAllNetworks}
-                allNetworksIconProps={{
-                  color: '$iconActive',
-                }}
-                size="$8"
-              />
-            }
-            title={
-              isAllNetworks
-                ? intl.formatMessage({
-                    id: ETranslations.global_all_networks,
-                  })
-                : item.name
-            }
-            onPress={() => {
-              onSelect(item);
-              closePopover();
-            }}
-          >
-            {selectedNetworkId === item.id ? (
-              <ListItem.CheckMark key="checkmark" />
-            ) : null}
-          </ListItem>
-        );
-      })}
-    </Stack>
-  );
 }
 
 function MobileNetworkDropdownImpl({
@@ -126,12 +72,21 @@ function MobileNetworkDropdownImpl({
   );
 
   const RenderContent = useCallback(
-    ({ closePopover }: { isOpen?: boolean; closePopover: () => void }) => (
-      <NetworkDropdownContent
+    ({
+      isOpen,
+      closePopover,
+    }: {
+      isOpen?: boolean;
+      closePopover: () => void;
+    }) => (
+      <NetworksSearchPanel
+        isOpen={isOpen}
         networks={marketNetworks}
-        selectedNetworkId={selectedNetworkId}
-        onSelect={handleNetworkSelect}
-        closePopover={closePopover}
+        networkId={selectedNetworkId}
+        onNetworkSelect={(network) => {
+          handleNetworkSelect(network);
+          closePopover();
+        }}
       />
     ),
     [marketNetworks, selectedNetworkId, handleNetworkSelect],
@@ -143,10 +98,11 @@ function MobileNetworkDropdownImpl({
       placement="bottom-start"
       floatingPanelProps={{
         maxWidth: 384,
+        maxHeight: NETWORKS_SEARCH_PANEL_MAX_HEIGHT,
       }}
       sheetProps={{
-        snapPoints: [60],
-        snapPointsMode: 'percent',
+        dismissOnSnapToBottom: false,
+        disableDrag: true,
       }}
       renderTrigger={renderTrigger}
       renderContent={RenderContent}


### PR DESCRIPTION
## Summary
- Auto-scroll the Market network selector to the currently selected network when the popover/sheet opens, on all platforms.
- Unify the mobile network dropdown to reuse `NetworksSearchPanel` instead of a separate list implementation.
- Give the search panel a dynamic height based on the number of networks, capped at the existing max.

## Intent & Context
Jira OK-53324 (High / Bug):
> Market - 进入网络选择器，需要定位到选中的网络
>
> Repro:
> 1. Open the network selector and pick a network lower down the list.
> 2. Close it, then reopen the selector.
> 3. The previously selected network is not visible — the list stays at the top.
>
> Expected: on every platform, opening the selector should scroll to the selected network.

## Root Cause
`ChainSelectorListView` rendered the `ListView` without any scroll-to-selection logic, so on reopen it always showed the first page. On mobile, `MobileNetworkDropdown` used its own `NetworkDropdownContent` (a plain mapped `Stack`) rather than `ChainSelectorListView`, so even a fix localized to that component would miss mobile.

## Design Decisions
- **`isOpen` prop drives the scroll** — pass the Popover open state down from `MoreButton`/`MobileNetworkDropdown` → `NetworksSearchPanel` → `ChainSelectorListView`. The scroll effect only runs when the panel is actually open and there is no active search text, so typing to filter doesn't yank the list around.
- **Platform-specific scroll method** — native uses `useSafelyScrollIntoIndex` with `viewPosition: 0.3` to center the selected row slightly above middle; web uses a `setTimeout(80ms)` + `scrollToOffset` fallback because `scrollIntoIndex` is unreliable on web virtualized lists. Offset = `(selectedIndex - 2) * CELL_HEIGHT` so the selected row has two rows of headroom.
- **Unify mobile with `NetworksSearchPanel`** — rather than duplicating the scroll logic in `MobileNetworkDropdown`, delete its inline `NetworkDropdownContent` and reuse `NetworksSearchPanel`. This is the only way both dropdowns can share the same behavior going forward, and it removes ~55 lines of drift.
- **Dynamic panel height** — `NETWORKS_SEARCH_PANEL_BASE_HEIGHT (92) + networks.length * CELL_HEIGHT`, clamped to `NETWORKS_SEARCH_PANEL_MAX_HEIGHT (420)`. Fixes the short-list case where the panel reserved 420px even with only a few networks, and lets virtualized scroll compute offsets correctly.
- **Mobile sheet props** — switched from `snapPoints: [60]` percent sheet to `disableDrag: true` + `dismissOnSnapToBottom: false` so the sheet body matches the computed panel height and the scroll offset isn't fighting the sheet's own drag gesture during the initial scroll.

## Changes Detail
- `ChainSelector/components/PureChainSelector/ChainSelectorListView.tsx`
  - Add `isOpen` prop; derive `shouldAutoScrollToSelected = !text && (isOpen ?? true)`.
  - Compute `selectedIndex` from `data` + `networkId`; skip when searching.
  - New `useEffect` that calls `scrollIntoIndex` (native) or `scrollToOffset` (web) with the platform-specific behavior described above.
  - Wrap `ListView` in `flex={1} minHeight={0}` and set the outer `Stack` to `flex={1} minHeight={0}` so the list can shrink inside a fixed-height Popover panel.
- `Market/.../MarketTokenListNetworkSelector/NetworksSearchPanel.tsx`
  - Export `NETWORKS_SEARCH_PANEL_MAX_HEIGHT = 420` and add `NETWORKS_SEARCH_PANEL_BASE_HEIGHT = 92`.
  - Forward `isOpen` to `ChainSelectorListView`.
  - Compute `panelHeight` from network count and apply it to the wrapping `Stack`.
- `Market/.../MarketTokenListNetworkSelector/MoreButton.tsx`
  - Switch `renderContent` to a function so the Popover can pass `isOpen` into `NetworksSearchPanel`.
  - Memoize `handleNetworkSelect` and `renderContent` with `useCallback`.
  - Use the exported `NETWORKS_SEARCH_PANEL_MAX_HEIGHT` constant for `floatingPanelProps.maxHeight`.
- `Market/.../MobileNetworkDropdown/MobileNetworkDropdown.tsx`
  - Delete the inline `NetworkDropdownContent` component.
  - `RenderContent` now renders `NetworksSearchPanel` and forwards `isOpen` plus `closePopover`-on-select.
  - Replace `snapPoints: [60]` percent sheet with `disableDrag: true` + `dismissOnSnapToBottom: false`; set `maxHeight: NETWORKS_SEARCH_PANEL_MAX_HEIGHT` on the floating panel so desktop and mobile share the same ceiling.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension / Desktop / Web / Mobile (all Market entry points that open the network selector)
- **Risk Areas**:
  - Scroll behavior differs across Popover (web/ext/desktop) and BottomSheet (mobile). The effect runs on every `selectedIndex`/`shouldAutoScrollToSelected` change, so re-renders during initial mount must not trigger a second scroll — guarded by `!text && isOpen`.
  - Mobile dropdown UX changed (`disableDrag` + no percent snap point). Needs manual verification that the sheet still closes from the backdrop/trigger and doesn't visually clip.
  - The height formula assumes `CELL_HEIGHT = 48` matches the actual row height. If `ListItem` is themed differently in the future, the panel may over/under-size.

## Test plan
- [ ] iOS: open Market → tap network selector → pick a network far down the list → close → reopen → selected network is visible and highlighted.
- [ ] Android: same as above.
- [ ] Desktop: open Market → click \"More\" network button → pick a network far down → close → reopen → selected network is in view.
- [ ] Web/Extension: same flow as desktop.
- [ ] Search: type in the search bar while the panel is open → list does NOT auto-scroll; clearing search restores scroll-to-selected only on next open.
- [ ] Short list (few networks): panel height shrinks to fit content, no large empty area.
- [ ] Long list (many networks): panel caps at 420px and scrolls normally.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
