### PR TITLE
fix(bulk-send): fix iOS address input errors(OK-53340)

### DIFF
--- a/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/LineNumberedTextArea.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/LineNumberedTextArea.tsx
@@ -88,9 +88,13 @@ const LINE_NUMBER_WIDTH = 40;
 // SizableText (UILabel). This offset compensates so line numbers align with the text.
 // On Android, EditText with includeFontPadding=false has no such extra inset.
 const NATIVE_LINE_NUMBER_TOP_OFFSET = platformEnv.isNativeIOS ? 3 : 0;
+// Keep overlay positioned the same as UITextView; use native TextInput for
+// visible overlay content so baseline comes from the same text engine.
+const NATIVE_TEXT_OVERLAY_TOP_OFFSET = 0;
 // Allow 2 lines of text in singleLine mode for wrapped long addresses
 const SINGLE_LINE_HEIGHT = LINE_HEIGHT * 2 + PADDING_VERTICAL * 2;
 const WEB_WORD_BREAK_STYLE = { wordBreak: 'break-all' } as const;
+const NATIVE_TEXT_FONT_FAMILY = 'System';
 
 function LineNumberedTextArea({
   value = '',
@@ -123,6 +127,8 @@ function LineNumberedTextArea({
   const { getClipboard } = useClipboard();
   const theme = useTheme();
   const textColor = theme.text?.val;
+  const textCriticalColor = theme.textCritical?.val;
+  const textCautionColor = theme.textCaution?.val;
   const selectionColor = useSelectionColor();
   const placeholderColor = theme.textPlaceholder?.val;
   const [inputText, setInputText] = useState<string>(value);
@@ -186,10 +192,21 @@ function LineNumberedTextArea({
     return value.split('\n');
   }, [value]);
 
+  const visualErrors = useMemo(
+    () =>
+      errors.filter((item) => {
+        if (item.lineNumber <= 0) {
+          return true;
+        }
+        return Boolean(lines[item.lineNumber - 1]?.trim());
+      }),
+    [errors, lines],
+  );
+
   const { errorLineNumbers, warningLineNumbers } = useMemo(() => {
     const errorSet = new Set<number>();
     const warningSet = new Set<number>();
-    errors.forEach((item) => {
+    visualErrors.forEach((item) => {
       if (item.type === ELineAnnotationType.Warning) {
         warningSet.add(item.lineNumber);
       } else {
@@ -197,7 +214,7 @@ function LineNumberedTextArea({
       }
     });
     return { errorLineNumbers: errorSet, warningLineNumbers: warningSet };
-  }, [errors]);
+  }, [visualErrors]);
 
   // #1 iOS: scroll outer page ScrollView to keep this component visible above keyboard
   const { scrollViewRef: pageScrollViewRef, pageOffsetRef } = useScrollView();
@@ -306,6 +323,8 @@ function LineNumberedTextArea({
   const hasContent = lines.length > 0;
   // Show line numbers based on prop
   const showLineNumbers = showLineNumbersProp;
+  const shouldUseAnnotatedTextOverlay =
+    platformEnv.isNativeIOS && visualErrors.length > 0 && hasContent;
 
   // Auto-scroll to bottom when content height changes
   useEffect(() => {
@@ -371,9 +390,9 @@ function LineNumberedTextArea({
               fontSize: FONT_SIZE,
               lineHeight: LINE_HEIGHT,
               textAlignVertical: 'top',
-              fontFamily: 'System',
+              fontFamily: NATIVE_TEXT_FONT_FAMILY,
               includeFontPadding: false,
-              color: textColor,
+              color: shouldUseAnnotatedTextOverlay ? 'transparent' : textColor,
             }
           : {
               // Web: TextInput is overlaid on display layer
@@ -394,7 +413,7 @@ function LineNumberedTextArea({
               caretColor: textColor,
             },
       } as any),
-    [textColor, contentPaddingLeft],
+    [textColor, contentPaddingLeft, shouldUseAnnotatedTextOverlay],
   );
 
   return (
@@ -432,6 +451,12 @@ function LineNumberedTextArea({
                 {(hasContent ? lines : ['']).map((_, index) => {
                   const lineNumber = index + 1;
                   const lineHeight = lineHeights[index] || LINE_HEIGHT;
+                  let lineNumberColor: string = '$textDisabled';
+                  if (errorLineNumbers.has(lineNumber)) {
+                    lineNumberColor = '$textCritical';
+                  } else if (warningLineNumbers.has(lineNumber)) {
+                    lineNumberColor = '$textCaution';
+                  }
                   return (
                     <Stack
                       key={index}
@@ -442,7 +467,7 @@ function LineNumberedTextArea({
                       <SizableText
                         fontSize={FONT_SIZE}
                         lineHeight={LINE_HEIGHT}
-                        color="$textDisabled"
+                        color={lineNumberColor}
                         userSelect="none"
                         numberOfLines={1}
                         ellipsizeMode="tail"
@@ -467,10 +492,10 @@ function LineNumberedTextArea({
                 {...(platformEnv.isNative
                   ? {
                       position: 'absolute' as const,
-                      top: 0,
+                      top: NATIVE_TEXT_OVERLAY_TOP_OFFSET,
                       left: 0,
                       right: 0,
-                      opacity: 0,
+                      opacity: shouldUseAnnotatedTextOverlay ? 1 : 0,
                     }
                   : {})}
               >
@@ -478,10 +503,13 @@ function LineNumberedTextArea({
                   lines.map((line, index) => {
                     const lineNumber = index + 1;
                     let lineColor = '$text';
+                    let nativeLineColor = textColor;
                     if (errorLineNumbers.has(lineNumber)) {
                       lineColor = '$textCritical';
+                      nativeLineColor = textCriticalColor ?? textColor;
                     } else if (warningLineNumbers.has(lineNumber)) {
                       lineColor = '$textCaution';
+                      nativeLineColor = textCautionColor ?? textColor;
                     }
 
                     return (
@@ -491,28 +519,84 @@ function LineNumberedTextArea({
                           handleLineLayout(index, e)
                         }
                       >
-                        <SizableText
-                          fontSize={FONT_SIZE}
-                          lineHeight={LINE_HEIGHT}
-                          color={lineColor}
-                          textBreakStrategy="simple"
-                          style={
-                            platformEnv.isWeb ? WEB_WORD_BREAK_STYLE : undefined
-                          }
-                        >
-                          {line || ' '}
-                        </SizableText>
+                        {platformEnv.isNative ? (
+                          <RNTextInput
+                            value={line || ' '}
+                            editable={false}
+                            multiline
+                            scrollEnabled={false}
+                            caretHidden
+                            allowFontScaling={false}
+                            maxFontSizeMultiplier={1}
+                            underlineColorAndroid="transparent"
+                            style={{
+                              width: '100%',
+                              paddingTop: 0,
+                              paddingBottom: 0,
+                              paddingLeft: 0,
+                              paddingRight: 0,
+                              margin: 0,
+                              fontSize: FONT_SIZE,
+                              lineHeight: LINE_HEIGHT,
+                              fontFamily: NATIVE_TEXT_FONT_FAMILY,
+                              textAlignVertical: 'top',
+                              includeFontPadding: false,
+                              color: nativeLineColor,
+                              backgroundColor: 'transparent',
+                            }}
+                          />
+                        ) : (
+                          <SizableText
+                            fontSize={FONT_SIZE}
+                            lineHeight={LINE_HEIGHT}
+                            color={lineColor}
+                            textBreakStrategy="simple"
+                            style={WEB_WORD_BREAK_STYLE}
+                          >
+                            {line || ' '}
+                          </SizableText>
+                        )}
                       </Stack>
                     );
                   })
                 ) : (
-                  <SizableText
-                    fontSize={FONT_SIZE}
-                    lineHeight={LINE_HEIGHT}
-                    color="$textPlaceholder"
-                  >
-                    {placeholder}
-                  </SizableText>
+                  <>
+                    {platformEnv.isNative ? (
+                      <RNTextInput
+                        value={placeholder}
+                        editable={false}
+                        multiline
+                        scrollEnabled={false}
+                        caretHidden
+                        allowFontScaling={false}
+                        maxFontSizeMultiplier={1}
+                        underlineColorAndroid="transparent"
+                        style={{
+                          width: '100%',
+                          paddingTop: 0,
+                          paddingBottom: 0,
+                          paddingLeft: 0,
+                          paddingRight: 0,
+                          margin: 0,
+                          fontSize: FONT_SIZE,
+                          lineHeight: LINE_HEIGHT,
+                          fontFamily: NATIVE_TEXT_FONT_FAMILY,
+                          textAlignVertical: 'top',
+                          includeFontPadding: false,
+                          color: placeholderColor,
+                          backgroundColor: 'transparent',
+                        }}
+                      />
+                    ) : (
+                      <SizableText
+                        fontSize={FONT_SIZE}
+                        lineHeight={LINE_HEIGHT}
+                        color="$textPlaceholder"
+                      >
+                        {placeholder}
+                      </SizableText>
+                    )}
+                  </>
                 )}
               </YStack>
 
@@ -520,7 +604,11 @@ function LineNumberedTextArea({
               <RNTextInput
                 ref={inputRef}
                 value={value}
-                placeholder={platformEnv.isNative ? placeholder : undefined}
+                placeholder={
+                  platformEnv.isNative && !shouldUseAnnotatedTextOverlay
+                    ? placeholder
+                    : undefined
+                }
                 placeholderTextColor={placeholderColor}
                 allowFontScaling={false}
                 maxFontSizeMultiplier={1}

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/ReceiverAddressesInput.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/ReceiverAddressesInput.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-continue */
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { useWatch } from 'react-hook-form';
 import { useIntl } from 'react-intl';
@@ -164,28 +164,30 @@ function BulkSendReceiverAllowlistErrorMessage({ error }: IFieldErrorProps) {
   }, [error?.message, receiverValidationErrors]);
 
   return (
-    <YStack gap="$1">
-      {parsedMessages.map((item) =>
-        'lineNumber' in item ? (
-          <HyperlinkText
-            key={item.key}
-            color="$textCritical"
-            size="$bodyMd"
-            translationId={ETranslations.send_address_not_allowlist_error}
-            autoExecuteParsedAction={false}
-            onAction={(actionId) => {
-              if (actionId === 'to_add_address_page') {
-                void handleOpenAddressBook(item.lineNumber);
-              }
-            }}
-          />
-        ) : (
-          <SizableText key={item.key} color="$textCritical" size="$bodyMd">
-            {item.message}
-          </SizableText>
-        ),
-      )}
-    </YStack>
+    <>
+      {parsedMessages.map((item, index) => (
+        <Fragment key={item.key}>
+          {index > 0 ? '\n' : null}
+          {'lineNumber' in item ? (
+            <HyperlinkText
+              color="$textCritical"
+              size="$bodyMd"
+              translationId={ETranslations.send_address_not_allowlist_error}
+              autoExecuteParsedAction={false}
+              onAction={(actionId) => {
+                if (actionId === 'to_add_address_page') {
+                  void handleOpenAddressBook(item.lineNumber);
+                }
+              }}
+            />
+          ) : (
+            <SizableText color="$textCritical" size="$bodyMd">
+              {item.message}
+            </SizableText>
+          )}
+        </Fragment>
+      ))}
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- fix iOS bulk-send receiver input rendering so line-numbered text, caret, and error highlighting stay aligned in the address textarea
- only apply the native annotated overlay when real line-level validation errors exist, and keep empty trailing lines from being marked as visual errors
- render multiple allowlist error messages inline so per-line address book actions remain available without stacking layout issues

## Intent & Context
This change addresses Bulk Send receiver address input issues on iOS. The goal was to make address entry and validation feedback readable and correctly aligned when users paste or type multiple receiver lines, especially when validation annotations are present.

## Root Cause
The previous native textarea implementation mixed `UITextView` input rendering with `SizableText` overlay rendering, which uses a different native text engine. On iOS that caused baseline and inset mismatches between the editable input, displayed content, and line numbers. The receiver allowlist error renderer also stacked messages in a layout that did not fit the field error surface well for multiple line-level messages.

## Design Decisions
- Use native `TextInput` components for the visible annotated overlay on iOS so the overlay and editable input share the same text engine and baseline behavior.
- Limit the annotated overlay to cases with actual visible line errors, which avoids unnecessary transparent-input mode when there is no line-level annotation to display.
- Filter visual error markers for blank trailing lines so only lines with meaningful content get highlighted.
- Flatten allowlist error rendering into inline fragments so multiple actionable messages can render cleanly in the form error area.

## Changes Detail
- `LineNumberedTextArea.tsx`: adds native overlay text rendering for iOS, keeps line-number coloring in sync with error/warning states, and filters line annotations against non-empty lines.
- `ReceiverAddressesInput.tsx`: changes allowlist error rendering to support multiple inline actionable messages without the previous stacked wrapper.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile (iOS-focused code path; shared receiver error rendering also affects other platforms)
- **Risk Areas**: Bulk Send address input editing, line-height measurement, validation highlighting, allowlist error presentation

## Test plan
- [ ] On iOS, open Bulk Send receiver input and verify typed and pasted multiline addresses align with line numbers.
- [ ] Trigger receiver validation errors and warnings, then verify the highlighted text and line number colors match the correct lines.
- [ ] Add and remove trailing blank lines to confirm empty lines are not visually marked as invalid.
- [ ] Trigger multiple allowlist errors and verify each message renders correctly and the address-book action opens the expected entry flow.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
