### PR TITLE
fix(swap): clear recipient input on modal open, disable confirm when empty (OK-53355, OK-53356)

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -343,11 +343,10 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     navigation.pushModal(EModalRoutes.SwapModal, {
       screen: EModalSwapRoutes.SwapToAnotherAddress,
       params: {
-        address: toAddressInfo.address,
         storeName,
       },
     });
-  }, [navigation, storeName, toAddressInfo.address]);
+  }, [navigation, storeName]);
 
   const refreshAction = useCallback(
     (manual?: boolean) => {

--- a/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { useRoute } from '@react-navigation/core';
 import { useIntl } from 'react-intl';
@@ -55,19 +55,11 @@ const SwapToAnotherAddressPage = () => {
   const navigation =
     useAppNavigation<IPageNavigationProp<IModalSwapParamList>>();
 
-  const route =
-    useRoute<
-      RouteProp<IModalSwapParamList, EModalSwapRoutes.SwapToAnotherAddress>
-    >();
-  const paramAddress = route.params?.address;
-  const {
-    accountInfo,
-    address: _address,
-    activeAccount,
-    networkId,
-  } = useSwapAddressInfo(ESwapDirectionType.TO);
+  const { accountInfo, activeAccount, networkId } = useSwapAddressInfo(
+    ESwapDirectionType.TO,
+  );
 
-  const [{ swapToAnotherAccountSwitchOn }, setSettings] = useSettingsAtom();
+  const [, setSettings] = useSettingsAtom();
   const [, setSwapToAddress] = useSwapToAnotherAccountAddressAtom();
   const [selectedQuote] = useSwapQuoteCurrentSelectAtom();
   const [, setSwapManualSelectQuote] = useSwapManualSelectQuoteProvidersAtom();
@@ -102,15 +94,6 @@ const SwapToAnotherAddressPage = () => {
     mode: 'onChange',
     reValidateMode: 'onBlur',
   });
-  // Only prefill when editing an existing custom address.
-  // When swapToAnotherAccountSwitchOn is true and paramAddress differs from
-  // the user's own address, the user previously set a custom address — prefill it.
-  useEffect(() => {
-    if (paramAddress && swapToAnotherAccountSwitchOn) {
-      form.setValue('address', { raw: paramAddress });
-    }
-  }, [paramAddress, swapToAnotherAccountSwitchOn, form]);
-
   const toAddressRaw = form.watch('address')?.raw ?? '';
   const [hasQuickSelectMatches, setHasQuickSelectMatches] = useState(false);
 
@@ -232,7 +215,7 @@ const SwapToAnotherAddressPage = () => {
       </Page.Body>
       <Page.Footer
         confirmButtonProps={{
-          disabled: !form.formState.isValid,
+          disabled: !form.formState.isValid || !toAddressRaw.trim(),
         }}
         onConfirm={() => form.handleSubmit(handleOnConfirm)()}
         onConfirmText={intl.formatMessage({

--- a/packages/shared/src/routes/swap.ts
+++ b/packages/shared/src/routes/swap.ts
@@ -63,7 +63,6 @@ export type IModalSwapParamList = {
     storeName: EJotaiContextStoreNames;
   };
   [EModalSwapRoutes.SwapToAnotherAddress]: {
-    address?: string;
     storeName: EJotaiContextStoreNames;
   };
   [EModalSwapRoutes.TokenRiskReminder]: {


### PR DESCRIPTION
## Summary
- Clear the address input field every time the "Edit Address" modal opens (custom recipient / privacy mode), so users always see the full account list instead of a filtered view
- Disable the "Confirm" button when the address input is empty, preventing submission without a valid address
- Remove the now-unused `address` route parameter from the modal navigation and type definition

## Test plan
- [ ] Open Swap → tap custom recipient → verify address input is empty, full account list visible, confirm button greyed out
- [ ] Select an account → confirm → reopen modal → verify input is still empty (no pre-fill)
- [ ] Open modal → close without action → verify previously set address is preserved
- [ ] Open modal → tap "Reset" → verify custom recipient is turned off
- [ ] Repeat above tests in privacy mode