### PR TITLE
fix(market): replace long-press drag with dedicated drag handle button in watchlist edit dialog(OK-52948)

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/useOpenMarketWatchlistEditDialog.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/useOpenMarketWatchlistEditDialog.tsx
@@ -8,7 +8,6 @@ import type {
 } from '@onekeyhq/components';
 import {
   Dialog,
-  Icon,
   SortableListView,
   Toast,
   XStack,
@@ -100,7 +99,7 @@ function MarketWatchlistEditDialogContent({
         getItemLayout={getWatchlistItemLayout}
         onDragEnd={handleDragEnd}
         ListEmptyComponent={null}
-        renderItem={({ item, drag, isActive }) => (
+        renderItem={({ item, drag, dragProps, isActive }) => (
           <ListItem
             h={CELL_HEIGHT}
             minHeight={0}
@@ -109,12 +108,8 @@ function MarketWatchlistEditDialogContent({
             py="$0"
             gap="$2"
             borderRadius="$0"
-            onLongPress={drag}
             opacity={isActive ? 0.8 : 1}
           >
-            <XStack pr="$1" alignItems="center" justifyContent="center">
-              <Icon name="DragOutline" color="$iconSubdued" />
-            </XStack>
             <YStack flex={1} minWidth={0}>
               <TokenIdentityItem
                 tokenLogoURI={item.tokenImageUri}
@@ -131,7 +126,7 @@ function MarketWatchlistEditDialogContent({
                 perpsSubtitle={item.perpsSubtitle}
               />
             </YStack>
-            <XStack gap="$1">
+            <XStack gap="$6">
               <ListItem.IconButton
                 title={intl.formatMessage({
                   id: ETranslations.global_remove,
@@ -140,6 +135,13 @@ function MarketWatchlistEditDialogContent({
                 onPress={() => {
                   void handleRemove(item);
                 }}
+              />
+              <ListItem.IconButton
+                key="drag"
+                cursor="move"
+                icon="DragOutline"
+                onPressIn={drag}
+                dataSet={dragProps}
               />
             </XStack>
           </ListItem>


### PR DESCRIPTION
## Summary
- Replace long-press-to-drag with a dedicated drag handle `IconButton` in market watchlist edit dialog
- Add `dragProps` support for better accessibility and cross-platform drag behavior
- Adjust button spacing for improved layout

## Intent & Context
The watchlist edit dialog previously required long-pressing on a list row to initiate drag-and-drop reordering. This was unintuitive as users had no visual cue for drag functionality. The change adds an explicit drag handle button (`DragOutline` icon) on the right side of each row, making the drag interaction discoverable and easier to use.

## Root Cause
The previous long-press drag mechanism (`onLongPress={drag}` on the entire `ListItem`) lacked discoverability — users couldn't tell that rows were draggable. The standalone `DragOutline` icon on the left was purely decorative and didn't trigger drag.

## Design Decisions
- **Moved drag trigger from `onLongPress` to a dedicated `IconButton` with `onPressIn`**: Makes drag interaction immediate and discoverable via a visible handle
- **Used `dataSet={dragProps}`**: Ensures proper drag behavior across platforms (especially web) by passing necessary drag attributes
- **Removed standalone drag icon from left side**: The new drag handle button on the right replaces it, avoiding redundant UI
- **Increased gap from `$1` to `$6`**: Provides adequate spacing between delete and drag buttons to prevent accidental taps

## Changes Detail
- `useOpenMarketWatchlistEditDialog.tsx`: Restructured the `renderItem` layout — removed left-side decorative drag icon and `onLongPress` from `ListItem`, added right-side `ListItem.IconButton` drag handle with `onPressIn={drag}` and `dataSet={dragProps}`

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Drag-and-drop reordering behavior — verify that `onPressIn` + `dragProps` works correctly across all platforms

## Test plan
- [ ] Open market watchlist edit dialog
- [ ] Verify drag handle icon is visible on the right side of each row
- [ ] Drag a row using the drag handle and verify reordering works
- [ ] Verify delete button still works correctly
- [ ] Test on iOS, Android, and Web platforms
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
