### PR TITLE
fix(market): use ScrollableFilterBar and platformEnv.isNative for category selectors (OK-52023)

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/CategoryFilterItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/CategoryFilterItem.tsx
@@ -80,22 +80,25 @@ export function CategoryFilterItemWithLayout({
   name,
   isSelected,
   icon,
-  onPress,
+  onLayout,
+  ...rest
 }: {
   id: string;
   name: string;
   isSelected: boolean;
   icon?: string;
-  onPress: () => void;
-}) {
+} & IXStackProps) {
   const { handleItemLayout } = useScrollableFilterBar();
   return (
     <CategoryFilterItem
       name={name}
       isSelected={isSelected}
       icon={icon}
-      onPress={onPress}
-      onLayout={(event) => handleItemLayout(id, event)}
+      {...rest}
+      onLayout={(event) => {
+        handleItemLayout(id, event);
+        onLayout?.(event);
+      }}
     />
   );
 }

--- a/packages/kit/src/views/Market/MarketHomeV2/components/CategorySelector/CategorySelector.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/CategorySelector/CategorySelector.tsx
@@ -1,9 +1,14 @@
 import { memo, useCallback } from 'react';
 import type { KeyboardEvent } from 'react';
 
-import { ScrollView, XStack, useMedia } from '@onekeyhq/components';
+import { XStack, useMedia } from '@onekeyhq/components';
+import { ScrollableFilterBar } from '@onekeyhq/kit/src/components/ScrollableFilterBar';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
-import { CategoryFilterItem } from '../CategoryFilterItem';
+import {
+  CategoryFilterItem,
+  CategoryFilterItemWithLayout,
+} from '../CategoryFilterItem';
 
 import type { IMarketCategoryItem } from '../../types';
 
@@ -21,6 +26,7 @@ function CategorySelectorImpl({
   triggerOnPressDown = false,
 }: ICategorySelectorProps) {
   const { md } = useMedia();
+  const shouldUseScrollableBar = md || platformEnv.isNative;
   const getCategoryInteractionProps = useCallback(
     (categoryId: string) => {
       const handleSelect = () => {
@@ -47,27 +53,27 @@ function CategorySelectorImpl({
     [onSelectCategory, triggerOnPressDown],
   );
 
-  if (md) {
+  if (shouldUseScrollableBar) {
     return (
-      <ScrollView
-        horizontal
-        showsHorizontalScrollIndicator={false}
+      <ScrollableFilterBar
+        selectedItemId={selectedCategoryId}
+        itemGap="$1"
         contentContainerStyle={{
-          gap: 4,
           paddingHorizontal: 20,
           paddingVertical: 8,
         }}
       >
         {categories.map((item) => (
-          <CategoryFilterItem
+          <CategoryFilterItemWithLayout
             key={item.id}
+            id={item.id}
             name={item.name}
             icon={item.icon}
             isSelected={item.id === selectedCategoryId}
             {...getCategoryInteractionProps(item.id)}
           />
         ))}
-      </ScrollView>
+      </ScrollableFilterBar>
     );
   }
 

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/MarketPerpsCategorySelector.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/MarketPerpsCategorySelector.tsx
@@ -7,6 +7,7 @@ import {
   useMedia,
 } from '@onekeyhq/components';
 import { ScrollableFilterBar } from '@onekeyhq/kit/src/components/ScrollableFilterBar';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { useNetworkFilterScroll } from '../../hooks/useNetworkFilterScroll';
 import {
@@ -128,8 +129,9 @@ function MarketPerpsCategorySelectorImpl(
   props: IMarketPerpsCategorySelectorProps,
 ) {
   const { md } = useMedia();
+  const shouldUseMobileSelector = md || platformEnv.isNative;
 
-  if (md) {
+  if (shouldUseMobileSelector) {
     return <MarketPerpsCategorySelectorMobile {...props} />;
   }
 

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketWatchlistCategorySelector.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketWatchlistCategorySelector.tsx
@@ -10,6 +10,7 @@ import {
 } from '@onekeyhq/components';
 import { ScrollableFilterBar } from '@onekeyhq/kit/src/components/ScrollableFilterBar';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { useNetworkFilterScroll } from '../../hooks/useNetworkFilterScroll';
 import {
@@ -150,8 +151,9 @@ function MarketWatchlistCategorySelectorImpl(
   props: IMarketWatchlistCategorySelectorProps,
 ) {
   const { md } = useMedia();
+  const shouldUseMobileSelector = md || platformEnv.isNative;
 
-  if (md) {
+  if (shouldUseMobileSelector) {
     return <MarketWatchlistCategorySelectorMobile {...props} />;
   }
 


### PR DESCRIPTION
## Summary
- Replace raw `ScrollView` with `ScrollableFilterBar` in `CategorySelector` for mobile/native layout, enabling auto-scroll-to-selected-item behavior
- Add `platformEnv.isNative` check alongside `useMedia().md` breakpoint in all market category selectors to ensure native platforms always use mobile-optimized layout
- Refactor `CategoryFilterItemWithLayout` to accept rest props via `IXStackProps` spread and properly chain `onLayout` callbacks

## Intent & Context
The `useMedia().md` responsive breakpoint alone does not reliably identify native platforms (iOS/Android), causing category selectors in the Market tab to incorrectly render the desktop layout on native devices. This fix ensures native platforms always use the mobile `ScrollableFilterBar` variant regardless of screen size breakpoint.

## Root Cause
The category selectors relied solely on `useMedia().md` to decide between mobile and desktop layouts. On native platforms, this breakpoint may not match, resulting in the desktop-style selector being shown instead of the scrollable mobile-optimized one.

## Changes Detail
- **CategoryFilterItem.tsx**: Refactored `CategoryFilterItemWithLayout` to use `...rest` spread with `IXStackProps` instead of explicit `onPress` prop; properly chains `onLayout` callbacks
- **CategorySelector.tsx**: Replaced `ScrollView` with `ScrollableFilterBar`; added `platformEnv.isNative` guard; uses `CategoryFilterItemWithLayout` in scrollable mode
- **MarketPerpsCategorySelector.tsx**: Added `platformEnv.isNative` to mobile selector condition
- **MarketWatchlistCategorySelector.tsx**: Added `platformEnv.isNative` to mobile selector condition

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile (iOS, Android), Web
- **Risk Areas**: Category filter rendering on native; desktop layout is unchanged

## Test plan
- [ ] Verify market category tabs render as scrollable pills on iOS
- [ ] Verify market category tabs render as scrollable pills on Android
- [ ] Verify perps category selector uses mobile layout on native
- [ ] Verify watchlist filter (All/Spot/Perps) uses mobile layout on native
- [ ] Verify desktop/web layout remains unchanged (bordered pill group)
- [ ] Verify auto-scroll-to-selected category works on mobile
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
