### PR TITLE
fix: stabilize incognito recipient validation (OK-53352)

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -225,8 +225,8 @@ const SwapActionsState = ({
     clearRecipientAddressOnHide,
     networkId: toToken?.networkId ?? swapToAddressInfo.networkId,
     accountId:
-      swapToAddressInfo.activeAccount?.account?.id ??
-      swapToAddressInfo.accountInfo?.account?.id,
+      swapToAddressInfo.accountInfo?.account?.id ??
+      swapToAddressInfo.activeAccount?.account?.id,
     accountInfo:
       swapToAddressInfo.accountInfo ?? swapToAddressInfo.activeAccount,
     address: swapToAnotherAccountAddress.address,

--- a/packages/kit/src/views/Swap/pages/components/SwapIncognitoRecipientInput.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapIncognitoRecipientInput.tsx
@@ -261,6 +261,7 @@ export function SwapIncognitoRecipientInput({
             variant="tertiary"
             size="small"
             icon="PeopleCircleOutline"
+            loading={loading}
             onPress={onOpenRecipientAddress}
           />
         </XStack>


### PR DESCRIPTION
## Summary
- keep swap incognito recipient validation bound to the stable recipient account context
- block the recipient picker trigger while inline validation is still loading

## Issues
- OK-53352

## Intent & Context
The swap incognito recipient input could enter a validation loop after clearing and re-pasting the same address. The recipient picker trigger was also still clickable while the inline badge validation was pending, which left room for race conditions.

## Root Cause
The inline validator read `accountId` from `swapToAddressInfo.activeAccount` before `swapToAddressInfo.accountInfo`. After a successful resolve, that value could flip to another TO account context and trigger the incognito input scope reset, which cleared the synced recipient and restarted validation indefinitely.

## Design Decisions
- Keep the fix minimal by only changing the `accountId` priority in `SwapActionsState` instead of rewriting the incognito input state flow.
- Preserve the loading gate on the recipient picker button so the modal cannot be opened while inline validation is still resolving.

## Changes Detail
- prioritize `swapToAddressInfo.accountInfo.account.id` over `swapToAddressInfo.activeAccount.account.id` for incognito recipient validation
- pass `loading` to the recipient picker `IconButton` so the action is blocked during validation

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: swap incognito recipient validation context, recipient picker trigger timing

## Test plan
- [x] Reproduce paste -> clear -> paste the same recipient in swap incognito mode and confirm the badge resolves without looping
- [x] Verify the recipient picker button shows loading and cannot open while inline validation is pending
- [x] `yarn eslint packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx packages/kit/src/views/Swap/pages/components/SwapIncognitoRecipientInput.tsx` (run from the main repo worktree because the new worktree does not have a yarn install state file)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
