### PR TITLE
chore(discovery): hide AI translate test buttons before release

### DIFF
--- a/packages/kit/src/views/Discovery/hooks/usePageTranslation.tsx
+++ b/packages/kit/src/views/Discovery/hooks/usePageTranslation.tsx
@@ -20,7 +20,7 @@ import { useWebViewTranslate } from '@onekeyhq/kit/src/components/WebView/useWeb
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
 import { useTranslateSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
+// import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
 import { ETranslations, LOCALES_OPTION } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -33,13 +33,13 @@ import { ETranslateDisplayMode, ETranslateEngine } from '../types';
 import { useActiveTabId, useWebTabDataById } from './useWebTabs';
 
 function TranslateSettings({
-  onTestAITranslateError,
+  onTestAITranslateError: _onTestAITranslateError,
 }: {
   onTestAITranslateError?: (testFlag: string) => void;
 }) {
   const intl = useIntl();
   const [settings, setSettings] = useTranslateSettingsPersistAtom();
-  const [devSettings] = useDevSettingsPersistAtom();
+  // const [devSettings] = useDevSettingsPersistAtom();
 
   const updateSetting = useCallback(
     <K extends keyof typeof settings>(key: K, value: (typeof settings)[K]) => {
@@ -179,7 +179,7 @@ function TranslateSettings({
           }
         />
       </YStack>
-      {devSettings.enabled && onTestAITranslateError ? (
+      {/* {devSettings.enabled && onTestAITranslateError ? (
         <YStack gap="$2">
           <SizableText size="$headingSm" color="$textSubdued">
             {intl.formatMessage({
@@ -205,7 +205,7 @@ function TranslateSettings({
             </Button>
           </XStack>
         </YStack>
-      ) : null}
+      ) : null} */}
     </YStack>
   );
 }


### PR DESCRIPTION
## Summary

- Comment out the AI translate debug buttons (`90104 Rate limit` / `90105 Service error`) in the browser translate settings popover.
- These buttons were gated by `devSettings.enabled`, so they were already hidden from fresh installs, but users who had previously enabled dev mode on older builds would still see them after upgrading to 6.2.0 (the first version to ship the DApp AI translate feature).
- Keeps the underlying `onTestAITranslateError` plumbing intact so we can restore the buttons later (or migrate them to the Dev mode tab).

## Test plan

- [ ] Open the DApp browser in dev mode, tap the translate icon → settings. The "测试 / 90104 / 90105" section should no longer appear.
- [ ] Verify normal AI / standard translate flows still work.
- [ ] `yarn lint:staged` and `yarn tsc:staged` pass on the modified file.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
