### PR TITLE
fix(swap): revalidate shared preview quote tip thresholds (OK-53328)

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
+++ b/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
@@ -47,6 +47,7 @@ import PreSwapInfoGroup from '../../components/PreSwapInfoGroup';
 import PreSwapStep from '../../components/PreSwapStep';
 import { PreSwapTipInfo } from '../../components/PreSwapTipInfo';
 import PreSwapTokenItem from '../../components/PreSwapTokenItem';
+import { resolveQuoteShowTip } from '../../utils/quoteShowTipUtils';
 
 interface IPreSwapDialogContentProps {
   onConfirm: () => void;
@@ -114,13 +115,31 @@ const PreSwapDialogContent = ({
     IQuoteTip | undefined
   >(undefined);
 
+  const validatedQuoteShowTip = useMemo(
+    () =>
+      resolveQuoteShowTip({
+        quoteShowTip: quoteResult?.quoteShowTip,
+        fromToken: preSwapData?.fromToken,
+        toToken: preSwapData?.toToken,
+        fromAmount,
+        toAmount,
+      }),
+    [
+      fromAmount,
+      preSwapData?.fromToken,
+      preSwapData?.toToken,
+      quoteResult?.quoteShowTip,
+      toAmount,
+    ],
+  );
+
   const handleConfirmPress = useCallback(() => {
-    if (quoteResult?.quoteShowTip) {
-      setShowPreSwapTipInfo(quoteResult?.quoteShowTip);
+    if (validatedQuoteShowTip) {
+      setShowPreSwapTipInfo(validatedQuoteShowTip);
     } else {
       onConfirm();
     }
-  }, [onConfirm, quoteResult?.quoteShowTip]);
+  }, [onConfirm, validatedQuoteShowTip]);
 
   const tipOnConfirm = useCallback(() => {
     onConfirm();

--- a/packages/kit/src/views/Swap/utils/quoteShowTipUtils.ts
+++ b/packages/kit/src/views/Swap/utils/quoteShowTipUtils.ts
@@ -22,7 +22,7 @@ function getTokenFiatValue({
   const priceBN = toValidBigNumber(token?.price);
   const amountBN = toValidBigNumber(amount);
 
-  if (!priceBN || !priceBN.gt(0) || !amountBN || amountBN.lt(0)) {
+  if (!priceBN || !priceBN.gt(0) || !amountBN || !amountBN.gt(0)) {
     return undefined;
   }
 

--- a/packages/kit/src/views/Swap/utils/quoteShowTipUtils.ts
+++ b/packages/kit/src/views/Swap/utils/quoteShowTipUtils.ts
@@ -4,7 +4,6 @@ import { EQuoteShowTipType } from '@onekeyhq/shared/types/swap/types';
 import type { IQuoteTip, ISwapToken } from '@onekeyhq/shared/types/swap/types';
 
 const QUOTE_SHOW_TIP_PRICE_IMPACT_THRESHOLD = 30;
-const QUOTE_SHOW_TIP_PRICE_IMPACT_TOLERANCE = 5;
 
 function toValidBigNumber(value?: string | number) {
   const valueBN = new BigNumber(value ?? '');
@@ -109,16 +108,5 @@ export function resolveQuoteShowTip({
     return undefined;
   }
 
-  const quotePriceImpactBN = toValidBigNumber(quoteShowTip.priceImpact);
-
-  if (!quotePriceImpactBN) {
-    return quoteShowTip;
-  }
-
-  return actualPriceImpactBN
-    .minus(quotePriceImpactBN)
-    .abs()
-    .lte(QUOTE_SHOW_TIP_PRICE_IMPACT_TOLERANCE)
-    ? quoteShowTip
-    : undefined;
+  return quoteShowTip;
 }

--- a/packages/kit/src/views/Swap/utils/quoteShowTipUtils.ts
+++ b/packages/kit/src/views/Swap/utils/quoteShowTipUtils.ts
@@ -1,0 +1,124 @@
+import BigNumber from 'bignumber.js';
+
+import { EQuoteShowTipType } from '@onekeyhq/shared/types/swap/types';
+import type { IQuoteTip, ISwapToken } from '@onekeyhq/shared/types/swap/types';
+
+const QUOTE_SHOW_TIP_PRICE_IMPACT_THRESHOLD = 30;
+const QUOTE_SHOW_TIP_PRICE_IMPACT_TOLERANCE = 5;
+
+function toValidBigNumber(value?: string | number) {
+  const valueBN = new BigNumber(value ?? '');
+
+  return valueBN.isNaN() ? undefined : valueBN;
+}
+
+function getTokenFiatValue({
+  token,
+  amount,
+}: {
+  token?: ISwapToken;
+  amount?: string;
+}) {
+  const priceBN = toValidBigNumber(token?.price);
+  const amountBN = toValidBigNumber(amount);
+
+  if (!priceBN || !priceBN.gt(0) || !amountBN || amountBN.lt(0)) {
+    return undefined;
+  }
+
+  return amountBN.multipliedBy(priceBN);
+}
+
+function getActualPriceImpact({
+  fromToken,
+  toToken,
+  fromAmount,
+  toAmount,
+}: {
+  fromToken?: ISwapToken;
+  toToken?: ISwapToken;
+  fromAmount?: string;
+  toAmount?: string;
+}) {
+  const fromFiatValueBN = getTokenFiatValue({
+    token: fromToken,
+    amount: fromAmount,
+  });
+  const toFiatValueBN = getTokenFiatValue({
+    token: toToken,
+    amount: toAmount,
+  });
+
+  if (!fromFiatValueBN || !fromFiatValueBN.gt(0) || !toFiatValueBN) {
+    return undefined;
+  }
+
+  const priceImpactBN = fromFiatValueBN
+    .minus(toFiatValueBN)
+    .dividedBy(fromFiatValueBN)
+    .multipliedBy(100);
+
+  return priceImpactBN.isNaN() ? undefined : priceImpactBN;
+}
+
+export function resolveQuoteShowTip({
+  quoteShowTip,
+  fromToken,
+  toToken,
+  fromAmount,
+  toAmount,
+}: {
+  quoteShowTip?: IQuoteTip;
+  fromToken?: ISwapToken;
+  toToken?: ISwapToken;
+  fromAmount?: string;
+  toAmount?: string;
+}) {
+  if (!quoteShowTip?.type) {
+    return quoteShowTip;
+  }
+
+  if (quoteShowTip.type === EQuoteShowTipType.TRADE_UNKNOWN) {
+    return getTokenFiatValue({
+      token: toToken,
+      amount: toAmount,
+    })
+      ? undefined
+      : quoteShowTip;
+  }
+
+  if (quoteShowTip.type !== EQuoteShowTipType.PRICE_IMPACT) {
+    return quoteShowTip;
+  }
+
+  const actualPriceImpactBN = getActualPriceImpact({
+    fromToken,
+    toToken,
+    fromAmount,
+    toAmount,
+  });
+
+  if (!actualPriceImpactBN) {
+    return quoteShowTip;
+  }
+
+  if (
+    !actualPriceImpactBN.gt(QUOTE_SHOW_TIP_PRICE_IMPACT_THRESHOLD) ||
+    actualPriceImpactBN.isNegative()
+  ) {
+    return undefined;
+  }
+
+  const quotePriceImpactBN = toValidBigNumber(quoteShowTip.priceImpact);
+
+  if (!quotePriceImpactBN) {
+    return quoteShowTip;
+  }
+
+  return actualPriceImpactBN
+    .minus(quotePriceImpactBN)
+    .abs()
+    .lte(QUOTE_SHOW_TIP_PRICE_IMPACT_TOLERANCE)
+    ? quoteShowTip
+    : undefined;
+}

--- a/packages/kit/src/views/Swap/utils/quoteShowTipUtils.ts
+++ b/packages/kit/src/views/Swap/utils/quoteShowTipUtils.ts
@@ -3,7 +3,7 @@ import BigNumber from 'bignumber.js';
 import { EQuoteShowTipType } from '@onekeyhq/shared/types/swap/types';
 import type { IQuoteTip, ISwapToken } from '@onekeyhq/shared/types/swap/types';
 
-const QUOTE_SHOW_TIP_PRICE_IMPACT_THRESHOLD = 30;
+const QUOTE_SHOW_TIP_DEFAULT_PRICE_IMPACT_LOSS_THRESHOLD = 30;
 
 function toValidBigNumber(value?: string | number) {
   const valueBN = new BigNumber(value ?? '');
@@ -90,6 +90,14 @@ export function resolveQuoteShowTip({
     return quoteShowTip;
   }
 
+  const quotePriceImpactLossThresholdBN = toValidBigNumber(
+    quoteShowTip.priceImpactLoss,
+  );
+  const priceImpactLossThresholdBN =
+    quotePriceImpactLossThresholdBN &&
+    !quotePriceImpactLossThresholdBN.isNegative()
+      ? quotePriceImpactLossThresholdBN
+      : new BigNumber(QUOTE_SHOW_TIP_DEFAULT_PRICE_IMPACT_LOSS_THRESHOLD);
   const actualPriceImpactBN = getActualPriceImpact({
     fromToken,
     toToken,
@@ -101,10 +109,7 @@ export function resolveQuoteShowTip({
     return quoteShowTip;
   }
 
-  if (
-    !actualPriceImpactBN.gt(QUOTE_SHOW_TIP_PRICE_IMPACT_THRESHOLD) ||
-    actualPriceImpactBN.isNegative()
-  ) {
+  if (!actualPriceImpactBN.gt(priceImpactLossThresholdBN)) {
     return undefined;
   }
 

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -367,6 +367,13 @@ export interface IQuoteTip {
   link?: string;
   showCheckbox?: boolean;
   checkboxLabel?: string;
+  priceImpact?: number;
+  type?: EQuoteShowTipType;
+}
+
+export enum EQuoteShowTipType {
+  PRICE_IMPACT = 'priceImpact',
+  TRADE_UNKNOWN = 'tradeUnknown',
 }
 
 export interface IFetchLimitMarketPrice {

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -368,6 +368,7 @@ export interface IQuoteTip {
   showCheckbox?: boolean;
   checkboxLabel?: string;
   priceImpact?: number;
+  priceImpactLoss?: number;
   type?: EQuoteShowTipType;
 }
 


### PR DESCRIPTION
## Summary
- add shared `quoteShowTip` typing for `tradeUnknown`, `priceImpact`, and `priceImpactLoss`
- revalidate preview warnings in the shared Market and Swap review entry before showing the tip UI
- suppress stale warnings only when local pricing disproves them, and keep `priceImpact` tips only when local loss still exceeds the backend threshold

## Issues
- OK-53328

## Intent & Context
Market swap review now reuses the same preview flow as Swap, but the two entry points do not always hydrate token prices at the same time. After the swap service started returning richer `quoteShowTip` payloads, the frontend still needed a second pass in the shared preview so it would not show warnings that local price data had already disproved, while still preserving real large-loss prompts.

## Root Cause
The shared preview dialog consumed `quoteResult.quoteShowTip` directly with no client-side revalidation. That was fragile once Market began entering the shared review flow with a different price source than Swap. It could leave stale warnings visible even when local pricing was already available, and it also treated a zero receive amount as if the preview had enough local information to suppress `tradeUnknown`.

## Design Decisions
A small validator lives in one shared Swap utility instead of branching Market and Swap review UIs. This keeps one decision point for the shared preview path.
For `tradeUnknown`, the tip is only hidden after the preview can calculate a positive receive-side fiat value locally.
For `priceImpact`, the preview recalculates the local loss from token prices and compares it only against the backend-provided `priceImpactLoss` threshold. If local loss cannot be calculated, the server tip is preserved. If the threshold is missing or invalid during rollout, the frontend falls back to `30`.

## Changes Detail
- `packages/shared/types/swap/types.ts`: extend `IQuoteTip` with `priceImpactLoss` and typed `quoteShowTip` variants
- `packages/kit/src/views/Swap/utils/quoteShowTipUtils.ts`: add the shared quote tip revalidation logic, including positive receive-value checks and threshold-based price impact validation
- `packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx`: gate preview tip display through the shared validator before rendering the warning card

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Desktop / Web / Extension
- **Risk Areas**: shared Market and Swap preview warning behavior; local token price availability differences across quote timing; rollout compatibility while `priceImpactLoss` propagates

## Test plan
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Swap/utils/quoteShowTipUtils.ts packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx packages/shared/types/swap/types.ts`
- [x] `git diff --check`
- [ ] Manually verify Market preview hides `tradeUnknown` only after a positive receive-side fiat value is available
- [ ] Manually verify `priceImpact` tips stay visible when local loss is above `priceImpactLoss`, and hide when local loss falls to or below the threshold

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
