### PR TITLE
fix(send): add Max button to ERC-1155 NFT info card (OK-53398)

### DIFF
--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -1466,19 +1466,36 @@ function SendAmountInputContainer() {
           )}
         </Stack>
         <YStack flex={1}>
-          <SizableText size="$bodyMdMedium" numberOfLines={1}>
+          <SizableText size="$bodySm" color="$textSubdued">
             {nftName}
           </SizableText>
           {nft?.collectionType === ENFTType.ERC1155 ? (
-            <SizableText size="$bodySm" color="$textSubdued" mt="$0.5">
-              {intl.formatMessage({ id: ETranslations.global_available })}:{' '}
-              {nftDetails?.amount ?? 1}
-            </SizableText>
+            <XStack alignItems="center" mt="$0.5">
+              <SizableText size="$bodyLgMedium" color="$text">
+                {nftDetails?.amount ?? 1}
+              </SizableText>
+            </XStack>
           ) : null}
         </YStack>
+
+        {nft?.collectionType === ENFTType.ERC1155 ? (
+          <Button
+            variant="secondary"
+            size="small"
+            ml="$2"
+            onPress={() => {
+              form.setValue('nftAmount', nftDetails?.amount ?? '1', {
+                shouldValidate: true,
+              });
+            }}
+          >
+            {intl.formatMessage({ id: ETranslations.send_max })}
+          </Button>
+        ) : null}
       </XStack>
     );
   }, [
+    form,
     intl,
     isNFT,
     nft?.collectionName,


### PR DESCRIPTION
## Summary

[OK-53398](https://onekeyhq.atlassian.net/browse/OK-53398) — ERC-1155 NFT send page's info card missing Max button.

The Max button was added in PR #11253 but lost due to a force-push timing issue — GitHub merged the pre-Max-button commit.

## Changes

- Add Max button to `renderNFTInfoCard` (mirrors token balance card pattern)
- Click Max → `form.setValue('nftAmount', nftDetails?.amount, { shouldValidate: true })`
- Layout adjustment: NFT name in small subdued text, quantity in larger text

## Test plan

- [ ] ERC-1155 NFT send → info card shows NFT thumbnail + name + available count + **Max** button
- [ ] Click Max → input fills with available quantity
- [ ] Token send → balance card unchanged

[OK-53398]: https://onekeyhq.atlassian.net/browse/OK-53398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ