### PR TITLE
fix(native): update bottom tab bar colors on OS theme switch

### DIFF
--- a/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.native.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.native.tsx
@@ -8,7 +8,6 @@ import {
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EEnterWay } from '@onekeyhq/shared/src/logger/scopes/dex';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes/tab';
 import { ESwapSource } from '@onekeyhq/shared/types/swap/types';
 
@@ -17,6 +16,7 @@ import {
   useIsSplitView,
   useSplitViewType,
   useTheme,
+  useThemeName,
 } from '../../../hooks';
 import { createNativeBottomTabNavigator } from '../BottomTabs';
 import { makeTabScreenOptions } from '../GlobalScreenOptions';
@@ -93,6 +93,9 @@ export function TabStackNavigator<RouteName extends string>({
 }: ITabNavigatorProps<RouteName>) {
   const intl = useIntl();
   const theme = useTheme();
+  // Subscribe to theme name so OS dark/light switch triggers re-render —
+  // `theme.*.val` reads are non-reactive on native.
+  useThemeName();
   const [tabBarHidden, setTabBarHidden] = useState(false);
 
   // Listen for HideTabBar events to show/hide the tab bar
@@ -195,10 +198,7 @@ export function TabStackNavigator<RouteName extends string>({
     }
   }, [tabBarHidden, splitViewType, isLandscape]);
   const tabBarStyle = useMemo(
-    () =>
-      platformEnv.isNativeAndroid
-        ? { backgroundColor: theme.bg.val }
-        : undefined,
+    () => ({ backgroundColor: theme.bg.val }),
     [theme.bg.val],
   );
 


### PR DESCRIPTION
## Summary

- The iOS/Android native bottom tab bar kept stale tint and background colors when the user switched the OS theme (dark ↔ light) while the app was running. Only the active tab's tint occasionally updated; inactive icons/labels and the bar background stayed on the previous theme, making them nearly invisible against the new background.
- Root cause: `TabStackNavigator.native.tsx` read theme tokens via tamagui's `theme.*.val`, which is a non-reactive read on native. When the OS theme flipped, the component did not re-render, so the new hex values never flowed as props to `@onekeyfe/react-native-tab-view`, and the native Swift-side `didSet` observers on `activeTintColor` / `inactiveTintColor` / `barTintColor` never triggered an appearance rebuild.
- Secondary: iOS passed `tabBarStyle={undefined}`, so the bar background relied on `UITabBarAppearance.configureWithDefaultBackground()`'s system dynamic color. In the embedded `UITabBarController` setup that doesn't re-resolve on trait changes, so the background stayed stuck.

## Fix

- Add `useThemeName()` in `TabStackNavigator` — it subscribes to theme name changes and forces a re-render on OS theme switch, so the already-computed `theme.iconActive.val` / `theme.iconSubdued.val` / `theme.bg.val` get re-read with fresh values and propagated to native props.
- Pass `tabBarStyle={{ backgroundColor: theme.bg.val }}` on all native platforms (no longer Android-only), so the background is driven by the app theme and flips correctly. This also triggers the Swift `barTintColor didSet → updateTabBarAppearance()` path that fully rebuilds `standardAppearance` / `scrollEdgeAppearance`.
- Drop the now-unused `platformEnv` import.

No native changes required — the existing Swift `didSet` observers already rebuild the full appearance; the bug was purely that JS wasn't pushing new values.

## Test plan

- [ ] iOS simulator: open the app in light mode, flip the system appearance to dark at runtime → bottom bar background, inactive icon, and inactive label should all update immediately to the dark palette.
- [ ] iOS simulator: flip from dark back to light → bar should return to the light palette.
- [ ] iOS: verify the active tab tint color also flips correctly.
- [ ] Android: regression check that the bar background continues to follow the theme (this was already working).
- [ ] Split-view / landscape on iPad: tab bar hide/show behavior unchanged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
