### PR TITLE
perf(send): batch account loading in RecipientQuickSelect to reduce IPC calls

### DIFF
--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -4816,6 +4816,11 @@ class ServiceAccount extends ServiceBase {
     }
 
     const settled = await Promise.allSettled(tasks);
+    for (const r of settled) {
+      if (r.status === 'rejected') {
+        console.error('resolveWallet failed:', r.reason);
+      }
+    }
     const groups = settled
       .filter(
         (

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -4682,8 +4682,7 @@ class ServiceAccount extends ServiceBase {
   }
 
   // Batch-fetch every wallet's accounts for a single network in ONE
-  // background call.  This replaces the N per-indexedAccount IPC
-  // round-trips that RecipientQuickSelect used to make from the UI.
+  // background call, replacing N per-indexedAccount IPC round-trips.
   @backgroundMethod()
   async getWalletAccountGroupsForNetwork({
     networkId,
@@ -4707,8 +4706,7 @@ class ServiceAccount extends ServiceBase {
   }> {
     const vault = await vaultFactory.getChainOnlyVault({ networkId });
     const vaultSettings = await vault.getVaultSettings();
-    const mergeDeriveAssetsEnabled =
-      !!vaultSettings.mergeDeriveAssetsEnabled;
+    const mergeDeriveAssetsEnabled = !!vaultSettings.mergeDeriveAssetsEnabled;
 
     const { wallets } = await this.getWallets({
       ignoreEmptySingletonWalletAccounts: true,
@@ -4717,32 +4715,33 @@ class ServiceAccount extends ServiceBase {
       includingAccounts: true,
     });
 
-    // Pre-fetch all DB accounts once — avoids N individual DB reads.
     const { accounts: allDbAccounts } = await localDb.getAllAccounts();
 
     const resolveWallet = async (
       wallet: IDBWallet,
       walletName: string,
-    ) => {
+    ): Promise<{
+      walletId: string;
+      walletName: string;
+      isHardwareWallet: boolean;
+      accounts: Array<{
+        account: INetworkAccount;
+        deriveInfo?: IAccountDeriveInfo;
+        deriveType?: string;
+      }>;
+      wallet: IDBWallet;
+    } | null> => {
       const shouldSkip =
         accountUtils.isWatchingWallet({ walletId: wallet.id }) ||
         accountUtils.isExternalWallet({ walletId: wallet.id }) ||
-        wallet.deprecated ||
-        wallet.isMocked ||
+        accountUtils.isWalletDeprecatedOrMocked(wallet) ||
         (keylessWalletsOnly &&
           !accountUtils.isKeylessWallet({ walletId: wallet.id }));
       if (shouldSkip) return null;
 
       const { dbIndexedAccounts, dbAccounts } = wallet;
-      let accounts: Array<{
-        account: INetworkAccount;
-        deriveInfo?: IAccountDeriveInfo;
-        deriveType?: string;
-      }> = [];
 
       if (dbIndexedAccounts?.length) {
-        // HD / Hardware / QR wallets — reuse existing method with
-        // pre-fetched DB accounts to skip per-account DB reads.
         const perIndexed = await Promise.all(
           dbIndexedAccounts.map(async (indexedAccount) => {
             try {
@@ -4762,7 +4761,7 @@ class ServiceAccount extends ServiceBase {
             }
           }),
         );
-        accounts = perIndexed
+        const accounts = perIndexed
           .flat()
           .filter((a) => a.account)
           .map((a) => ({
@@ -4770,46 +4769,62 @@ class ServiceAccount extends ServiceBase {
             deriveInfo: a.deriveInfo,
             deriveType: a.deriveType,
           }));
-      } else if (dbAccounts?.length) {
-        const networkImpl = networkId.split('--')[0];
-        accounts = dbAccounts
+        if (accounts.length === 0) return null;
+        return {
+          walletId: wallet.id,
+          walletName,
+          isHardwareWallet: accountUtils.isHwWallet({
+            walletId: wallet.id,
+          }),
+          accounts,
+          wallet,
+        };
+      }
+
+      if (dbAccounts?.length) {
+        const networkImpl = networkUtils.getNetworkImpl({ networkId });
+        const accounts = dbAccounts
           .filter((acc) => acc.impl === networkImpl)
           .map((acc) => ({
             account: acc as unknown as INetworkAccount,
           }));
+        if (accounts.length === 0) return null;
+        return {
+          walletId: wallet.id,
+          walletName,
+          isHardwareWallet: accountUtils.isHwWallet({
+            walletId: wallet.id,
+          }),
+          accounts,
+          wallet,
+        };
       }
 
-      if (accounts.length === 0) return null;
-
-      return {
-        walletId: wallet.id,
-        walletName,
-        isHardwareWallet: accountUtils.isHwWallet({
-          walletId: wallet.id,
-        }),
-        accounts,
-        wallet,
-      };
+      return null;
     };
 
-    const tasks: Array<Promise<ReturnType<typeof resolveWallet>>> = [];
+    const tasks: Array<Promise<Awaited<ReturnType<typeof resolveWallet>>>> = [];
     for (const wallet of wallets) {
       tasks.push(resolveWallet(wallet, wallet.name));
       for (const hidden of wallet.hiddenWallets ?? []) {
-        if (hidden.deprecated || hidden.isMocked) {
+        if (accountUtils.isWalletDeprecatedOrMocked(hidden)) {
           // eslint-disable-next-line no-continue
           continue;
         }
-        tasks.push(
-          resolveWallet(hidden, `${wallet.name} - ${hidden.name}`),
-        );
+        tasks.push(resolveWallet(hidden, `${wallet.name} - ${hidden.name}`));
       }
     }
 
-    const settled = await Promise.all(tasks);
-    const groups = settled.filter(
-      (g): g is NonNullable<typeof g> => !!g,
-    );
+    const settled = await Promise.allSettled(tasks);
+    const groups = settled
+      .filter(
+        (
+          r,
+        ): r is PromiseFulfilledResult<
+          NonNullable<Awaited<ReturnType<typeof resolveWallet>>>
+        > => r.status === 'fulfilled' && !!r.value,
+      )
+      .map((r) => r.value);
 
     return { groups, mergeDeriveAssetsEnabled };
   }

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -4740,6 +4740,11 @@ class ServiceAccount extends ServiceBase {
       if (shouldSkip) return null;
 
       const { dbIndexedAccounts, dbAccounts } = wallet;
+      let accounts: Array<{
+        account: INetworkAccount;
+        deriveInfo?: IAccountDeriveInfo;
+        deriveType?: string;
+      }> = [];
 
       if (dbIndexedAccounts?.length) {
         const perIndexed = await Promise.all(
@@ -4761,7 +4766,7 @@ class ServiceAccount extends ServiceBase {
             }
           }),
         );
-        const accounts = perIndexed
+        accounts = perIndexed
           .flat()
           .filter((a) => a.account)
           .map((a) => ({
@@ -4769,38 +4774,23 @@ class ServiceAccount extends ServiceBase {
             deriveInfo: a.deriveInfo,
             deriveType: a.deriveType,
           }));
-        if (accounts.length === 0) return null;
-        return {
-          walletId: wallet.id,
-          walletName,
-          isHardwareWallet: accountUtils.isHwWallet({
-            walletId: wallet.id,
-          }),
-          accounts,
-          wallet,
-        };
-      }
-
-      if (dbAccounts?.length) {
+      } else if (dbAccounts?.length) {
         const networkImpl = networkUtils.getNetworkImpl({ networkId });
-        const accounts = dbAccounts
+        accounts = dbAccounts
           .filter((acc) => acc.impl === networkImpl)
           .map((acc) => ({
             account: acc as unknown as INetworkAccount,
           }));
-        if (accounts.length === 0) return null;
-        return {
-          walletId: wallet.id,
-          walletName,
-          isHardwareWallet: accountUtils.isHwWallet({
-            walletId: wallet.id,
-          }),
-          accounts,
-          wallet,
-        };
       }
 
-      return null;
+      if (accounts.length === 0) return null;
+      return {
+        walletId: wallet.id,
+        walletName,
+        isHardwareWallet: accountUtils.isHwWallet({ walletId: wallet.id }),
+        accounts,
+        wallet,
+      };
     };
 
     const tasks: Array<Promise<Awaited<ReturnType<typeof resolveWallet>>>> = [];

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -4681,6 +4681,139 @@ class ServiceAccount extends ServiceBase {
     return { networkAccounts, network };
   }
 
+  // Batch-fetch every wallet's accounts for a single network in ONE
+  // background call.  This replaces the N per-indexedAccount IPC
+  // round-trips that RecipientQuickSelect used to make from the UI.
+  @backgroundMethod()
+  async getWalletAccountGroupsForNetwork({
+    networkId,
+    keylessWalletsOnly,
+  }: {
+    networkId: string;
+    keylessWalletsOnly?: boolean;
+  }): Promise<{
+    groups: Array<{
+      walletId: string;
+      walletName: string;
+      isHardwareWallet: boolean;
+      accounts: Array<{
+        account: INetworkAccount;
+        deriveInfo?: IAccountDeriveInfo;
+        deriveType?: string;
+      }>;
+      wallet: IDBWallet;
+    }>;
+    mergeDeriveAssetsEnabled: boolean;
+  }> {
+    const vault = await vaultFactory.getChainOnlyVault({ networkId });
+    const vaultSettings = await vault.getVaultSettings();
+    const mergeDeriveAssetsEnabled =
+      !!vaultSettings.mergeDeriveAssetsEnabled;
+
+    const { wallets } = await this.getWallets({
+      ignoreEmptySingletonWalletAccounts: true,
+      ignoreNonBackedUpWallets: true,
+      nestedHiddenWallets: true,
+      includingAccounts: true,
+    });
+
+    // Pre-fetch all DB accounts once — avoids N individual DB reads.
+    const { accounts: allDbAccounts } = await localDb.getAllAccounts();
+
+    const resolveWallet = async (
+      wallet: IDBWallet,
+      walletName: string,
+    ) => {
+      const shouldSkip =
+        accountUtils.isWatchingWallet({ walletId: wallet.id }) ||
+        accountUtils.isExternalWallet({ walletId: wallet.id }) ||
+        wallet.deprecated ||
+        wallet.isMocked ||
+        (keylessWalletsOnly &&
+          !accountUtils.isKeylessWallet({ walletId: wallet.id }));
+      if (shouldSkip) return null;
+
+      const { dbIndexedAccounts, dbAccounts } = wallet;
+      let accounts: Array<{
+        account: INetworkAccount;
+        deriveInfo?: IAccountDeriveInfo;
+        deriveType?: string;
+      }> = [];
+
+      if (dbIndexedAccounts?.length) {
+        // HD / Hardware / QR wallets — reuse existing method with
+        // pre-fetched DB accounts to skip per-account DB reads.
+        const perIndexed = await Promise.all(
+          dbIndexedAccounts.map(async (indexedAccount) => {
+            try {
+              const resp =
+                await this.getNetworkAccountsInSameIndexedAccountIdWithDeriveTypes(
+                  {
+                    allDbAccounts,
+                    skipDbQueryIfNotFoundFromAllDbAccounts: true,
+                    networkId,
+                    indexedAccountId: indexedAccount.id,
+                    excludeEmptyAccount: true,
+                  },
+                );
+              return resp.networkAccounts;
+            } catch {
+              return [];
+            }
+          }),
+        );
+        accounts = perIndexed
+          .flat()
+          .filter((a) => a.account)
+          .map((a) => ({
+            account: a.account as INetworkAccount,
+            deriveInfo: a.deriveInfo,
+            deriveType: a.deriveType,
+          }));
+      } else if (dbAccounts?.length) {
+        const networkImpl = networkId.split('--')[0];
+        accounts = dbAccounts
+          .filter((acc) => acc.impl === networkImpl)
+          .map((acc) => ({
+            account: acc as unknown as INetworkAccount,
+          }));
+      }
+
+      if (accounts.length === 0) return null;
+
+      return {
+        walletId: wallet.id,
+        walletName,
+        isHardwareWallet: accountUtils.isHwWallet({
+          walletId: wallet.id,
+        }),
+        accounts,
+        wallet,
+      };
+    };
+
+    const tasks: Array<Promise<ReturnType<typeof resolveWallet>>> = [];
+    for (const wallet of wallets) {
+      tasks.push(resolveWallet(wallet, wallet.name));
+      for (const hidden of wallet.hiddenWallets ?? []) {
+        if (hidden.deprecated || hidden.isMocked) {
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+        tasks.push(
+          resolveWallet(hidden, `${wallet.name} - ${hidden.name}`),
+        );
+      }
+    }
+
+    const settled = await Promise.all(tasks);
+    const groups = settled.filter(
+      (g): g is NonNullable<typeof g> => !!g,
+    );
+
+    return { groups, mergeDeriveAssetsEnabled };
+  }
+
   // For chains with `mergeDeriveAssetsEnabled` (BTC / LTC), a single user-
   // facing "account" owns multiple xpubs (one per derive type: Legacy /
   // Nested SegWit / Native SegWit / Taproot). The backend APIs that accept a

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -966,27 +966,45 @@ export default function RecipientQuickSelect({
   // Dedup auto-switch analytics to avoid multiple events per search
   const lastAutoSwitchRef = useRef<string | undefined>(undefined);
 
-  // Callbacks for each tab's match status and count
+  // Callbacks for each tab's match status and count.
+  // Return prev when unchanged to avoid unnecessary re-renders that
+  // cascade to the parent and cause close-button hover flicker.
   const handleRecentMatchStatus = useCallback(
     (hasMatches: boolean, matchCount: number) => {
-      setTabMatchStatus((prev) => ({ ...prev, recent: hasMatches }));
-      setTabMatchCounts((prev) => ({ ...prev, recent: matchCount }));
+      setTabMatchStatus((prev) =>
+        prev.recent === hasMatches ? prev : { ...prev, recent: hasMatches },
+      );
+      setTabMatchCounts((prev) =>
+        prev.recent === matchCount ? prev : { ...prev, recent: matchCount },
+      );
     },
     [],
   );
 
   const handleAccountMatchStatus = useCallback(
     (hasMatches: boolean, matchCount: number) => {
-      setTabMatchStatus((prev) => ({ ...prev, account: hasMatches }));
-      setTabMatchCounts((prev) => ({ ...prev, account: matchCount }));
+      setTabMatchStatus((prev) =>
+        prev.account === hasMatches ? prev : { ...prev, account: hasMatches },
+      );
+      setTabMatchCounts((prev) =>
+        prev.account === matchCount ? prev : { ...prev, account: matchCount },
+      );
     },
     [],
   );
 
   const handleAddressBookMatchStatus = useCallback(
     (hasMatches: boolean, matchCount: number) => {
-      setTabMatchStatus((prev) => ({ ...prev, addressBook: hasMatches }));
-      setTabMatchCounts((prev) => ({ ...prev, addressBook: matchCount }));
+      setTabMatchStatus((prev) =>
+        prev.addressBook === hasMatches
+          ? prev
+          : { ...prev, addressBook: hasMatches },
+      );
+      setTabMatchCounts((prev) =>
+        prev.addressBook === matchCount
+          ? prev
+          : { ...prev, addressBook: matchCount },
+      );
     },
     [],
   );
@@ -1047,12 +1065,16 @@ export default function RecipientQuickSelect({
     }));
   }, [intl, isSearchMode, trimmedSearchKey, tabMatchCounts, visibleTabKeys]);
 
-  // Report match status to parent. Only consider tabs that are actually visible
-  // (Lightning hides account/addressBook; callers can pass hideTabs).
+  // Report match status to parent. Only fire when value actually changes
+  // to avoid unnecessary parent re-renders (close-button hover flicker).
+  const lastMatchStatusRef = useRef<boolean | undefined>(undefined);
   useEffect(() => {
     const visibleStatuses = visibleTabKeys.map((tab) => tabMatchStatus[tab]);
     const anyTabHasMatches = visibleStatuses.some((status) => status === true);
-    onMatchStatusChange?.(anyTabHasMatches);
+    if (lastMatchStatusRef.current !== anyTabHasMatches) {
+      lastMatchStatusRef.current = anyTabHasMatches;
+      onMatchStatusChange?.(anyTabHasMatches);
+    }
 
     const allReported = visibleStatuses.every((status) => status !== null);
     if (

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -1,6 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { flatten, map } from 'lodash';
 import { useIntl } from 'react-intl';
 import Animated, { FadeIn } from 'react-native-reanimated';
 
@@ -39,7 +38,6 @@ import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalAddressBookRoutes } from '@onekeyhq/shared/src/routes/addressBook';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
-import { promiseAllSettledEnhanced } from '@onekeyhq/shared/src/utils/promiseUtils';
 import type { INetworkAccount } from '@onekeyhq/shared/types/account';
 import { EInputAddressChangeType } from '@onekeyhq/shared/types/address';
 
@@ -230,9 +228,6 @@ type IWalletGroup = {
   wallet: IDBWallet;
 };
 
-const NETWORK_ACCOUNTS_FETCH_CONCURRENCY = 4;
-const WALLET_GROUP_FETCH_CONCURRENCY = 6;
-
 // Collect every address an account should be searchable by. For BTC with
 // fresh-address mode (OK-52953) the currently-shown address is one of
 // many rotating entries stored in `IDBUtxoAccount.addresses` (relPath →
@@ -278,62 +273,8 @@ function findMatchedAccountAddress(
   );
 }
 
-// Get wallet accounts on the specified network (with derive type info)
-async function getWalletNetworkAccounts(
-  wallet: IDBWallet,
-  networkId: string,
-): Promise<IAccountWithDeriveInfo[]> {
-  const { dbIndexedAccounts, dbAccounts } = wallet;
-
-  // HD / Hardware wallets use dbIndexedAccounts
-  if (dbIndexedAccounts?.length) {
-    const accountRequestTaskFactories = dbIndexedAccounts.map(
-      (indexedAccount) => async () => {
-        const resp =
-          await backgroundApiProxy.serviceAccount.getNetworkAccountsInSameIndexedAccountIdWithDeriveTypes(
-            {
-              networkId,
-              indexedAccountId: indexedAccount.id,
-              excludeEmptyAccount: true,
-            },
-          );
-        return resp.networkAccounts;
-      },
-    );
-
-    const results = await promiseAllSettledEnhanced(
-      accountRequestTaskFactories,
-      {
-        continueOnError: true,
-        concurrency: NETWORK_ACCOUNTS_FETCH_CONCURRENCY,
-      },
-    );
-    return flatten(
-      map(results, (item) =>
-        (item ?? [])
-          .filter((acc) => acc.account)
-          .map((acc) => ({
-            account: acc.account as INetworkAccount,
-            deriveInfo: acc.deriveInfo,
-            deriveType: acc.deriveType,
-          })),
-      ),
-    );
-  }
-
-  // Imported / Private-key wallets use dbAccounts directly
-  if (dbAccounts?.length) {
-    const networkImpl = networkId.split('--')[0];
-    return dbAccounts
-      .filter((acc) => acc.impl === networkImpl)
-      .map((acc) => ({
-        account: acc as unknown as INetworkAccount,
-        deriveInfo: undefined,
-      }));
-  }
-
-  return [];
-}
+// Removed: getWalletNetworkAccounts — logic moved to
+// ServiceAccount.getWalletAccountGroupsForNetwork (single IPC call).
 
 function AccountRecipients({
   networkId,
@@ -348,7 +289,7 @@ function AccountRecipients({
 }: IAccountRecipientsProps) {
   const intl = useIntl();
 
-  // Get all wallets and their accounts (reuses BulkCopyAddresses logic)
+  // Single IPC call — all wallet/account aggregation happens in background.
   const { result: walletGroups = [], isLoading: isLoadingAccounts } =
     usePromiseResult<IWalletGroup[]>(
       async () => {
@@ -356,100 +297,28 @@ function AccountRecipients({
           return [];
         }
 
-        const vaultSettings =
-          await backgroundApiProxy.serviceNetwork.getVaultSettings({
-            networkId,
-          });
-        const showAllDeriveTypes = !!vaultSettings?.mergeDeriveAssetsEnabled;
-
-        // Fetch wallets, filter non-backed-up, include accounts
-        const { wallets } = await backgroundApiProxy.serviceAccount.getWallets({
-          ignoreEmptySingletonWalletAccounts: true,
-          ignoreNonBackedUpWallets: true,
-          nestedHiddenWallets: true,
-          includingAccounts: true,
-        });
-
-        const walletGroupTaskFactories: Array<
-          () => Promise<IWalletGroup | null>
-        > = [];
-
-        const createWalletGroupTaskFactory =
-          (wallet: IDBWallet, walletName: string) =>
-          async (): Promise<IWalletGroup | null> => {
-            let accounts = await getWalletNetworkAccounts(wallet, networkId);
-            // For chains with multiple derive types (BTC/LTC), keep all
-            // accounts so users can switch derive type via header menu.
-            // For other chains, filter by sender's derive type to avoid
-            // showing duplicates (e.g. bip44 + ledger-live on EVM).
-            if (!showAllDeriveTypes) {
-              const targetDeriveType =
-                senderDeriveType ?? accounts[0]?.deriveType;
-              if (targetDeriveType) {
-                const filtered = accounts.filter(
-                  (a) => !a.deriveType || a.deriveType === targetDeriveType,
-                );
-                if (filtered.length > 0) {
-                  accounts = filtered;
-                }
-              }
-            }
-            if (accounts.length === 0) {
-              return null;
-            }
-            return {
-              walletId: wallet.id,
-              walletName,
-              isHardwareWallet: accountUtils.isHwWallet({
-                walletId: wallet.id,
-              }),
-              accounts,
-              wallet,
-            };
-          };
-
-        for (const wallet of wallets) {
-          // Skip watch-only, external, deprecated, and deleted (mocked) wallets
-          // Keep HD, Hardware, Imported, QR wallets
-          const shouldSkip =
-            accountUtils.isWatchingWallet({ walletId: wallet.id }) ||
-            accountUtils.isExternalWallet({ walletId: wallet.id }) ||
-            wallet.deprecated ||
-            wallet.isMocked ||
-            (keylessWalletsOnly &&
-              !accountUtils.isKeylessWallet({ walletId: wallet.id }));
-
-          if (shouldSkip) {
-            // eslint-disable-next-line no-continue
-            continue;
-          }
-
-          walletGroupTaskFactories.push(
-            createWalletGroupTaskFactory(wallet, wallet.name),
+        const { groups, mergeDeriveAssetsEnabled } =
+          await backgroundApiProxy.serviceAccount.getWalletAccountGroupsForNetwork(
+            { networkId, keylessWalletsOnly },
           );
 
-          for (const hiddenWallet of wallet.hiddenWallets ?? []) {
-            if (hiddenWallet.deprecated || hiddenWallet.isMocked) {
-              // eslint-disable-next-line no-continue
-              continue;
-            }
-            walletGroupTaskFactories.push(
-              createWalletGroupTaskFactory(
-                hiddenWallet,
-                `${wallet.name} - ${hiddenWallet.name}`,
-              ),
-            );
-          }
+        // senderDeriveType filtering stays on UI side (cheap, no IPC)
+        if (!mergeDeriveAssetsEnabled) {
+          return groups
+            .map((group) => {
+              const targetDeriveType =
+                senderDeriveType ?? group.accounts[0]?.deriveType;
+              if (!targetDeriveType) return group;
+              const filtered = group.accounts.filter(
+                (a) => !a.deriveType || a.deriveType === targetDeriveType,
+              );
+              return filtered.length > 0
+                ? { ...group, accounts: filtered }
+                : group;
+            })
+            .filter((g) => g.accounts.length > 0);
         }
-
-        const groups = await promiseAllSettledEnhanced(
-          walletGroupTaskFactories,
-          {
-            continueOnError: true,
-            concurrency: WALLET_GROUP_FETCH_CONCURRENCY,
-          },
-        );
-        return groups.filter((group): group is IWalletGroup => !!group);
+        return groups;
       },
       [networkId, senderDeriveType, keylessWalletsOnly],
       { initResult: [], watchLoading: true, undefinedResultIfError: true },

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -855,7 +855,7 @@ function AddressBookRecipients({
   );
 }
 
-export default function RecipientQuickSelect({
+function RecipientQuickSelect({
   accountId,
   networkId,
   searchKey,
@@ -1204,3 +1204,5 @@ export default function RecipientQuickSelect({
     </Animated.View>
   );
 }
+
+export default memo(RecipientQuickSelect);

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -273,9 +273,6 @@ function findMatchedAccountAddress(
   );
 }
 
-// Removed: getWalletNetworkAccounts — logic moved to
-// ServiceAccount.getWalletAccountGroupsForNetwork (single IPC call).
-
 function AccountRecipients({
   networkId,
   senderDeriveType,

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -1065,18 +1065,22 @@ function RecipientQuickSelect({
     }));
   }, [intl, isSearchMode, trimmedSearchKey, tabMatchCounts, visibleTabKeys]);
 
-  // Report match status to parent. Only fire when value actually changes
-  // to avoid unnecessary parent re-renders (close-button hover flicker).
+  // Report match status to parent. Wait until every visible tab has
+  // reported (status !== null) before the first notification — avoids
+  // firing once with a partial false then again with the real value,
+  // which causes 2 parent re-renders and close-button hover flicker.
   const lastMatchStatusRef = useRef<boolean | undefined>(undefined);
   useEffect(() => {
     const visibleStatuses = visibleTabKeys.map((tab) => tabMatchStatus[tab]);
+    const allReported = visibleStatuses.every((status) => status !== null);
+    if (!allReported) return;
+
     const anyTabHasMatches = visibleStatuses.some((status) => status === true);
     if (lastMatchStatusRef.current !== anyTabHasMatches) {
       lastMatchStatusRef.current = anyTabHasMatches;
       onMatchStatusChange?.(anyTabHasMatches);
     }
 
-    const allReported = visibleStatuses.every((status) => status !== null);
     if (
       isSearchMode &&
       trimmedSearchKey &&

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -1,4 +1,12 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  memo,
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { useIntl } from 'react-intl';
 import Animated, { FadeIn } from 'react-native-reanimated';
@@ -287,7 +295,8 @@ function AccountRecipients({
   const intl = useIntl();
 
   // Single IPC call — all wallet/account aggregation happens in background.
-  const { result: walletGroups = [], isLoading: isLoadingAccounts } =
+  // useDeferredValue lets React yield to events (close button) mid-render.
+  const { result: walletGroupsRaw = [], isLoading: isLoadingAccounts } =
     usePromiseResult<IWalletGroup[]>(
       async () => {
         if (!networkId) {
@@ -320,6 +329,7 @@ function AccountRecipients({
       [networkId, senderDeriveType, keylessWalletsOnly],
       { initResult: [], watchLoading: true, undefinedResultIfError: true },
     );
+  const walletGroups = useDeferredValue(walletGroupsRaw);
 
   const debouncedSearchKey = useDebounce(searchKey, 300);
   const trimmedSearchKey = normalizeSearchKey(debouncedSearchKey);

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -569,9 +569,13 @@ function AccountRecipients({
     }));
   }, []);
 
-  // Show skeleton on initial load or while loading (when isLoadingAccounts is undefined or true)
+  // Show skeleton while loading OR while useDeferredValue is still stale
+  // (isLoadingAccounts settles before the deferred walletGroups updates,
+  // which would briefly show an empty list without this guard).
+  const isDeferredStale = walletGroupsRaw !== walletGroups;
   const isInitialLoading =
-    isLoadingAccounts !== false && walletGroups.length === 0;
+    (isLoadingAccounts !== false || isDeferredStale) &&
+    walletGroups.length === 0;
   if (isInitialLoading) {
     return <QuickSelectListSkeleton />;
   }
@@ -949,6 +953,11 @@ function RecipientQuickSelect({
   const trimmedSearchKey = normalizeSearchKey(debouncedSearchKey);
   const isDebouncing = isSearchMode && searchKey !== debouncedSearchKey;
 
+  // Tracks the last value sent to parent via onMatchStatusChange.
+  // Declared here (before prevSearchKeyRef check) so the reset below
+  // can clear it when searchKey changes.
+  const lastMatchStatusRef = useRef<boolean | undefined>(undefined);
+
   // When the raw searchKey changes, reset tabMatchStatus to null so that
   // the noResult check waits for children to re-report with the new key.
   // This prevents a race where parent's debounce settles before children's,
@@ -958,6 +967,7 @@ function RecipientQuickSelect({
     prevSearchKeyRef.current = searchKey;
     setTabMatchStatus({ recent: null, account: null, addressBook: null });
     setTabMatchCounts({ recent: 0, account: 0, addressBook: 0 });
+    lastMatchStatusRef.current = undefined;
   }
 
   // Track the search key at the time of last manual tab switch
@@ -1069,7 +1079,6 @@ function RecipientQuickSelect({
   // reported (status !== null) before the first notification — avoids
   // firing once with a partial false then again with the real value,
   // which causes 2 parent re-renders and close-button hover flicker.
-  const lastMatchStatusRef = useRef<boolean | undefined>(undefined);
   useEffect(() => {
     const visibleStatuses = visibleTabKeys.map((tab) => tabMatchStatus[tab]);
     const allReported = visibleStatuses.every((status) => status !== null);

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -138,6 +138,7 @@ type IAccountRecipientsProps = {
   senderDeriveType?: string;
   lastUsedDeriveType?: string;
   searchKey?: string;
+  debouncedSearchKey?: string;
   isSearchMode?: boolean;
   keylessWalletsOnly?: boolean;
   onInputTypeChange?: (type: EInputAddressChangeType) => void;
@@ -286,6 +287,7 @@ function AccountRecipients({
   senderDeriveType,
   lastUsedDeriveType: lastUsedDeriveTypeProp,
   searchKey,
+  debouncedSearchKey: debouncedSearchKeyProp,
   isSearchMode,
   keylessWalletsOnly,
   onInputTypeChange,
@@ -331,11 +333,10 @@ function AccountRecipients({
     );
   const walletGroups = useDeferredValue(walletGroupsRaw);
 
-  const debouncedSearchKey = useDebounce(searchKey, 300);
+  const debouncedSearchKey = debouncedSearchKeyProp ?? '';
   const trimmedSearchKey = normalizeSearchKey(debouncedSearchKey);
   const isSearchActive = !!(isSearchMode && trimmedSearchKey);
   const searchValue = trimmedSearchKey;
-  // Detect debounce gap: searchKey changed but debounce hasn't settled yet
   const isDebouncing = isSearchMode && searchKey !== debouncedSearchKey;
 
   // Filter accounts (name matches first, then address matches)
@@ -715,6 +716,7 @@ function AccountRecipients({
 type IAddressBookRecipientsProps = {
   networkId: string;
   searchKey?: string;
+  debouncedSearchKey?: string;
   isSearchMode?: boolean;
   onInputTypeChange?: (type: EInputAddressChangeType) => void;
   onSelect?: (params: {
@@ -728,6 +730,7 @@ type IAddressBookRecipientsProps = {
 function AddressBookRecipients({
   networkId,
   searchKey,
+  debouncedSearchKey: debouncedSearchKeyProp,
   isSearchMode,
   onInputTypeChange,
   onSelect,
@@ -735,11 +738,10 @@ function AddressBookRecipients({
 }: IAddressBookRecipientsProps) {
   const intl = useIntl();
   const navigation = useAppNavigation();
-  const debouncedSearchKey = useDebounce(searchKey, 300);
+  const debouncedSearchKey = debouncedSearchKeyProp ?? '';
   const trimmedSearchKey = normalizeSearchKey(debouncedSearchKey);
   const searchValue = trimmedSearchKey;
   const isSearchActive = !!(isSearchMode && trimmedSearchKey);
-  // Detect debounce gap: searchKey changed but debounce hasn't settled yet
   const isDebouncing = isSearchMode && searchKey !== debouncedSearchKey;
   const [{ updateTimestamp }] = useAddressBookPersistAtom();
 
@@ -1180,6 +1182,7 @@ function RecipientQuickSelect({
                 senderDeriveType={senderDeriveType}
                 lastUsedDeriveType={lastUsedDeriveType}
                 searchKey={searchKey}
+                debouncedSearchKey={debouncedSearchKey}
                 isSearchMode={isSearchMode}
                 keylessWalletsOnly={keylessWalletsOnly}
                 onInputTypeChange={onInputTypeChange}
@@ -1199,6 +1202,7 @@ function RecipientQuickSelect({
               <AddressBookRecipients
                 networkId={networkId}
                 searchKey={searchKey}
+                debouncedSearchKey={debouncedSearchKey}
                 isSearchMode={isSearchMode}
                 onInputTypeChange={onInputTypeChange}
                 onSelect={(params) =>

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -573,7 +573,8 @@ function AccountRecipients({
   // Show skeleton while loading OR while useDeferredValue is still stale
   // (isLoadingAccounts settles before the deferred walletGroups updates,
   // which would briefly show an empty list without this guard).
-  const isDeferredStale = walletGroupsRaw !== walletGroups;
+  const isDeferredStale =
+    walletGroupsRaw !== walletGroups && walletGroupsRaw.length > 0;
   const isInitialLoading =
     (isLoadingAccounts !== false || isDeferredStale) &&
     walletGroups.length === 0;


### PR DESCRIPTION
## Summary

Performance optimizations for `RecipientQuickSelect` in the Send/Swap address selection flow.

### IPC batch loading
Replace ~17 individual IPC calls with a single `getWalletAccountGroupsForNetwork()` background method. Pre-fetches all DB accounts once via `localDb.getAllAccounts()` to avoid N individual DB reads. Uses `Promise.allSettled` for error isolation.

### Render optimization
- `useDeferredValue(walletGroupsRaw)` — lets React yield to events (close button) mid-render
- `isDeferredStale` guard — keeps skeleton visible while deferred value settles; guarded with `walletGroupsRaw.length > 0` to prevent infinite skeleton on empty wallets
- `React.memo(RecipientQuickSelect)` — prevents re-renders from parent state changes (form validation etc.)

### Re-render suppression
- Match-status callbacks return `prev` reference when values unchanged — prevents cascading re-renders to parent page
- Parent notification deferred until all tabs have reported (`allReported` gate) — eliminates partial false→true notification that caused 2 parent re-renders
- `lastMatchStatusRef` reset on searchKey change for defensive correctness

### Debounce unification
AccountRecipients and AddressBookRecipients each had their own `useDebounce(searchKey, 300)`. Now the parent debounces once and passes the settled value down, eliminating timer drift between tabs.

## Files

| File | Changes |
|---|---|
| `ServiceAccount.ts` | New `getWalletAccountGroupsForNetwork()` batch method |
| `RecipientQuickSelect.tsx` | Single batch call, useDeferredValue, memo, match-status guards, unified debounce |

## Test plan

- [ ] Send page opens and account list loads correctly
- [ ] Account list shows all wallets and accounts correctly
- [ ] BTC/LTC: all derive types shown, derive type selector works
- [ ] EVM: only sender's derive type accounts shown (no duplicates)
- [ ] Hidden wallets shown with correct naming
- [ ] Search by account name and address works
- [ ] Search count labels (e.g. "Accounts (3)") appear after debounce settles
- [ ] Tab auto-switch works when current tab has no search matches
- [ ] Fast typing: no count flicker or intermediate states
- [ ] Empty wallet state: shows empty view (not infinite skeleton)
- [ ] Swap edit-address modal shows correct accounts

Closes #11270