### PR TITLE
refactor(send): restyle zero-gas-warning dialog menu to match ReceiveSelector

### DIFF
--- a/packages/kit/src/components/OptionCard/index.tsx
+++ b/packages/kit/src/components/OptionCard/index.tsx
@@ -1,0 +1,92 @@
+import { StyleSheet } from 'react-native';
+
+import { Icon, XStack, YStack } from '@onekeyhq/components';
+import type { IKeyOfIcons } from '@onekeyhq/components';
+
+import { ListItem } from '../ListItem';
+
+import type { IListItemProps } from '../ListItem';
+
+export type IOptionCardProps = {
+  icon: IKeyOfIcons;
+  title: string;
+  subtitle: IListItemProps['subtitle'];
+} & IListItemProps;
+
+export function OptionCard({
+  icon,
+  title,
+  subtitle,
+  ...props
+}: IOptionCardProps) {
+  return (
+    <ListItem
+      mx="$0"
+      p="$3.5"
+      drillIn
+      gap="$3"
+      userSelect="none"
+      bg="$neutral2"
+      borderRadius="$3"
+      hoverStyle={{ bg: '$neutral3' }}
+      pressStyle={{ bg: '$neutral4' }}
+      $platform-native={{
+        borderWidth: StyleSheet.hairlineWidth,
+        borderColor: '$neutral3',
+      }}
+      $platform-web={{
+        outlineWidth: 1,
+        outlineColor: '$neutral3',
+        outlineStyle: 'solid',
+      }}
+      {...props}
+    >
+      <YStack bg="$neutral3" p="$2" borderRadius="$full">
+        <Icon name={icon} color="$iconActive" />
+      </YStack>
+      <ListItem.Text gap="$1" flex={1} primary={title} secondary={subtitle} />
+    </ListItem>
+  );
+}
+
+const PAYMENT_ICONS: Array<{
+  name: IKeyOfIcons;
+  px: string;
+}> = [
+  { name: 'ApplePayIllus', px: '$1.5' },
+  { name: 'GooglePayIllus', px: '$1.5' },
+  { name: 'VisaIllus', px: '$0.5' },
+];
+
+export function PaymentMethodBadges() {
+  return (
+    <XStack mt="$1" gap="$1">
+      {PAYMENT_ICONS.map(({ name, px }) => (
+        <YStack
+          key={name}
+          h="$5"
+          px={px}
+          borderRadius="$2"
+          borderCurve="continuous"
+          justifyContent="center"
+          alignItems="center"
+          bg="$neutral3"
+        >
+          <Icon name={name} h="$3" w="$8" color="$icon" />
+        </YStack>
+      ))}
+      <XStack
+        alignItems="center"
+        px="$1"
+        gap="$0.5"
+        bg="$neutral3"
+        borderRadius="$2"
+        borderCurve="continuous"
+      >
+        <YStack borderRadius="$full" w={3} h={3} bg="$iconSubdued" />
+        <YStack borderRadius="$full" w={3} h={3} bg="$iconSubdued" />
+        <YStack borderRadius="$full" w={3} h={3} bg="$iconSubdued" />
+      </XStack>
+    </XStack>
+  );
+}

--- a/packages/kit/src/views/Home/components/WalletActions/index.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/index.tsx
@@ -165,7 +165,7 @@ function WalletActionSend({
                   }}
                 >
                   <YStack bg="$neutral3" p="$2" borderRadius="$full">
-                    <Icon name="QrCodeOutline" color="$iconActive" />
+                    <Icon name="ArrowBottomOutline" color="$iconActive" />
                   </YStack>
                   <ListItem.Text
                     gap="$1"
@@ -313,6 +313,7 @@ function WalletActionSend({
                 <Button
                   variant="tertiary"
                   size="large"
+                  mt="$1.5"
                   mx="$0"
                   py="$2"
                   onPress={() => {

--- a/packages/kit/src/views/Home/components/WalletActions/index.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/index.tsx
@@ -1,14 +1,14 @@
 import { useCallback } from 'react';
 
 import { useIntl } from 'react-intl';
+import { StyleSheet } from 'react-native';
 
 import type { IPageNavigationProp, IXStackProps } from '@onekeyhq/components';
 import {
   Button,
   Dialog,
   Icon,
-  SizableText,
-  Stack,
+  ListItem,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -141,92 +141,181 @@ function WalletActionSend({
               { symbol },
             ),
             renderContent: (
-              <YStack gap="$4">
-                <XStack gap="$2.5">
-                  <Stack
+              <YStack gap="$2.5">
+                <ListItem
+                  mx="$0"
+                  p="$3.5"
+                  drillIn
+                  gap="$3"
+                  userSelect="none"
+                  bg="$neutral2"
+                  borderRadius="$3"
+                  hoverStyle={{ bg: '$neutral3' }}
+                  pressStyle={{ bg: '$neutral4' }}
+                  $platform-native={{
+                    borderWidth: StyleSheet.hairlineWidth,
+                    borderColor: '$neutral3',
+                  }}
+                  $platform-web={{
+                    outlineWidth: 1,
+                    outlineColor: '$neutral3',
+                    outlineStyle: 'solid',
+                  }}
+                  onPress={() => {
+                    logZeroGas('receive');
+                    void dialogRef.close();
+                    safeResolve(false);
+                    navigation.pushModal(EModalRoutes.ReceiveModal, {
+                      screen: EModalReceiveRoutes.ReceiveSelector,
+                    });
+                  }}
+                >
+                  <YStack bg="$neutral3" p="$2" borderRadius="$full">
+                    <Icon name="QrCodeOutline" color="$iconActive" />
+                  </YStack>
+                  <ListItem.Text
+                    gap="$1"
                     flex={1}
-                    flexBasis={0}
-                    alignItems="center"
-                    justifyContent="center"
-                    bg="$bgStrong"
-                    borderRadius="$4"
-                    pt="$4"
-                    pb="$3"
-                    px="$1"
-                    hoverStyle={{ bg: '$bgStrongHover' }}
-                    pressStyle={{ bg: '$bgStrongActive' }}
-                    onPress={() => {
-                      logZeroGas('receive');
+                    primary={intl.formatMessage({
+                      id: ETranslations.global_receive,
+                    })}
+                    secondary={intl.formatMessage({
+                      id: ETranslations.receive_from_another_wallet_desc,
+                    })}
+                  />
+                </ListItem>
+                {isBuySupported ? (
+                  <ListItem
+                    mx="$0"
+                    p="$3.5"
+                    drillIn
+                    gap="$3"
+                    userSelect="none"
+                    bg="$neutral2"
+                    borderRadius="$3"
+                    hoverStyle={{ bg: '$neutral3' }}
+                    pressStyle={{ bg: '$neutral4' }}
+                    $platform-native={{
+                      borderWidth: StyleSheet.hairlineWidth,
+                      borderColor: '$neutral3',
+                    }}
+                    $platform-web={{
+                      outlineWidth: 1,
+                      outlineColor: '$neutral3',
+                      outlineStyle: 'solid',
+                    }}
+                    onPress={async () => {
+                      logZeroGas('buy');
                       void dialogRef.close();
                       safeResolve(false);
-                      navigation.pushModal(EModalRoutes.ReceiveModal, {
-                        screen: EModalReceiveRoutes.ReceiveSelector,
-                      });
+                      try {
+                        const { url } =
+                          await backgroundApiProxy.serviceFiatCrypto.generateWidgetUrl(
+                            {
+                              networkId: network.id,
+                              tokenAddress: '',
+                              accountId: account?.id ?? '',
+                              type: 'buy',
+                            },
+                          );
+                        if (url) {
+                          openFiatCryptoUrl(url);
+                        }
+                      } catch {
+                        navigation.pushModal(EModalRoutes.FiatCryptoModal, {
+                          screen: EModalFiatCryptoRoutes.BuyModal,
+                          params: {
+                            networkId: network.id,
+                            accountId: account?.id ?? '',
+                            tokens: allTokens.tokens,
+                            map,
+                          },
+                        });
+                      }
                     }}
                   >
-                    <Icon name="ArrowBottomOutline" size="$6" color="$icon" />
-                    <SizableText size="$bodyMdMedium">
-                      {intl.formatMessage({
-                        id: ETranslations.global_receive,
-                      })}
-                    </SizableText>
-                  </Stack>
-                  {isBuySupported ? (
-                    <Stack
+                    <YStack bg="$neutral3" p="$2" borderRadius="$full">
+                      <Icon name="CurrencyDollarOutline" color="$iconActive" />
+                    </YStack>
+                    <ListItem.Text
+                      gap="$1"
                       flex={1}
-                      flexBasis={0}
-                      alignItems="center"
-                      justifyContent="center"
-                      bg="$bgStrong"
-                      borderRadius="$4"
-                      pt="$4"
-                      pb="$3"
-                      px="$1"
-                      hoverStyle={{ bg: '$bgStrongHover' }}
-                      pressStyle={{ bg: '$bgStrongActive' }}
-                      onPress={async () => {
-                        logZeroGas('buy');
-                        void dialogRef.close();
-                        safeResolve(false);
-                        try {
-                          const { url } =
-                            await backgroundApiProxy.serviceFiatCrypto.generateWidgetUrl(
-                              {
-                                networkId: network.id,
-                                tokenAddress: '',
-                                accountId: account?.id ?? '',
-                                type: 'buy',
-                              },
-                            );
-                          if (url) {
-                            openFiatCryptoUrl(url);
-                          }
-                        } catch {
-                          navigation.pushModal(EModalRoutes.FiatCryptoModal, {
-                            screen: EModalFiatCryptoRoutes.BuyModal,
-                            params: {
-                              networkId: network.id,
-                              accountId: account?.id ?? '',
-                              tokens: allTokens.tokens,
-                              map,
-                            },
-                          });
-                        }
-                      }}
-                    >
-                      <Icon
-                        name="CurrencyDollarOutline"
-                        size="$6"
-                        color="$icon"
-                      />
-                      <SizableText size="$bodyMdMedium">
-                        {intl.formatMessage({
-                          id: ETranslations.global_buy,
-                        })}
-                      </SizableText>
-                    </Stack>
-                  ) : null}
-                </XStack>
+                      primary={intl.formatMessage({
+                        id: ETranslations.global_buy,
+                      })}
+                      secondary={
+                        <XStack mt="$1" gap="$1">
+                          <YStack
+                            h="$5"
+                            px="$1.5"
+                            borderRadius="$2"
+                            borderCurve="continuous"
+                            justifyContent="center"
+                            alignItems="center"
+                            bg="$neutral3"
+                          >
+                            <Icon
+                              name="ApplePayIllus"
+                              h="$3"
+                              w="$8"
+                              color="$icon"
+                            />
+                          </YStack>
+                          <YStack
+                            h="$5"
+                            px="$1.5"
+                            borderRadius="$2"
+                            borderCurve="continuous"
+                            justifyContent="center"
+                            alignItems="center"
+                            bg="$neutral3"
+                          >
+                            <Icon
+                              name="GooglePayIllus"
+                              h="$3"
+                              w="$8"
+                              color="$icon"
+                            />
+                          </YStack>
+                          <YStack
+                            h="$5"
+                            px="$0.5"
+                            borderRadius="$2"
+                            borderCurve="continuous"
+                            justifyContent="center"
+                            alignItems="center"
+                            bg="$neutral3"
+                          >
+                            <Icon
+                              name="VisaIllus"
+                              h="$3"
+                              w="$8"
+                              color="$icon"
+                            />
+                          </YStack>
+                          <XStack
+                            alignItems="center"
+                            px="$1"
+                            gap="$0.5"
+                            bg="$neutral3"
+                            borderRadius="$2"
+                            borderCurve="continuous"
+                          >
+                            {Array.from({ length: 3 }).map((_, index) => (
+                              <YStack
+                                key={index}
+                                borderRadius="$full"
+                                w={3}
+                                h={3}
+                                bg="$iconSubdued"
+                              />
+                            ))}
+                          </XStack>
+                        </XStack>
+                      }
+                    />
+                  </ListItem>
+                ) : null}
                 <Button
                   variant="tertiary"
                   size="large"
@@ -234,8 +323,6 @@ function WalletActionSend({
                   py="$2"
                   onPress={() => {
                     logZeroGas('continue');
-                    // Dialog.close may fire onClose synchronously, so resolve
-                    // first — otherwise onClose's safeResolve(false) wins.
                     safeResolve(true);
                     void dialogRef.close();
                   }}

--- a/packages/kit/src/views/Home/components/WalletActions/index.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/index.tsx
@@ -4,15 +4,9 @@ import { useIntl } from 'react-intl';
 import { StyleSheet } from 'react-native';
 
 import type { IPageNavigationProp, IXStackProps } from '@onekeyhq/components';
-import {
-  Button,
-  Dialog,
-  Icon,
-  ListItem,
-  XStack,
-  YStack,
-} from '@onekeyhq/components';
+import { Button, Dialog, Icon, XStack, YStack } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { ReviewControl } from '@onekeyhq/kit/src/components/ReviewControl';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
@@ -163,8 +157,8 @@ function WalletActionSend({
                   }}
                   onPress={() => {
                     logZeroGas('receive');
-                    void dialogRef.close();
                     safeResolve(false);
+                    void dialogRef.close();
                     navigation.pushModal(EModalRoutes.ReceiveModal, {
                       screen: EModalReceiveRoutes.ReceiveSelector,
                     });
@@ -206,8 +200,8 @@ function WalletActionSend({
                     }}
                     onPress={async () => {
                       logZeroGas('buy');
-                      void dialogRef.close();
                       safeResolve(false);
+                      void dialogRef.close();
                       try {
                         const { url } =
                           await backgroundApiProxy.serviceFiatCrypto.generateWidgetUrl(

--- a/packages/kit/src/views/Home/components/WalletActions/index.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/index.tsx
@@ -137,7 +137,7 @@ function WalletActionSend({
               { symbol },
             ),
             renderContent: (
-              <YStack gap="$2.5">
+              <YStack gap="$5">
                 <OptionCard
                   icon="ArrowBottomOutline"
                   title={intl.formatMessage({
@@ -196,7 +196,6 @@ function WalletActionSend({
                 <Button
                   variant="tertiary"
                   size="large"
-                  mt="$1.5"
                   mx="$0"
                   py="$2"
                   onPress={() => {

--- a/packages/kit/src/views/Home/components/WalletActions/index.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/index.tsx
@@ -1,12 +1,14 @@
 import { useCallback } from 'react';
 
 import { useIntl } from 'react-intl';
-import { StyleSheet } from 'react-native';
 
 import type { IPageNavigationProp, IXStackProps } from '@onekeyhq/components';
-import { Button, Dialog, Icon, XStack, YStack } from '@onekeyhq/components';
+import { Button, Dialog, YStack } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
+import {
+  OptionCard,
+  PaymentMethodBadges,
+} from '@onekeyhq/kit/src/components/OptionCard';
 import { ReviewControl } from '@onekeyhq/kit/src/components/ReviewControl';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
@@ -136,25 +138,14 @@ function WalletActionSend({
             ),
             renderContent: (
               <YStack gap="$2.5">
-                <ListItem
-                  mx="$0"
-                  p="$3.5"
-                  drillIn
-                  gap="$3"
-                  userSelect="none"
-                  bg="$neutral2"
-                  borderRadius="$3"
-                  hoverStyle={{ bg: '$neutral3' }}
-                  pressStyle={{ bg: '$neutral4' }}
-                  $platform-native={{
-                    borderWidth: StyleSheet.hairlineWidth,
-                    borderColor: '$neutral3',
-                  }}
-                  $platform-web={{
-                    outlineWidth: 1,
-                    outlineColor: '$neutral3',
-                    outlineStyle: 'solid',
-                  }}
+                <OptionCard
+                  icon="ArrowBottomOutline"
+                  title={intl.formatMessage({
+                    id: ETranslations.global_receive,
+                  })}
+                  subtitle={intl.formatMessage({
+                    id: ETranslations.receive_from_another_wallet_desc,
+                  })}
                   onPress={() => {
                     logZeroGas('receive');
                     safeResolve(false);
@@ -163,41 +154,14 @@ function WalletActionSend({
                       screen: EModalReceiveRoutes.ReceiveSelector,
                     });
                   }}
-                >
-                  <YStack bg="$neutral3" p="$2" borderRadius="$full">
-                    <Icon name="ArrowBottomOutline" color="$iconActive" />
-                  </YStack>
-                  <ListItem.Text
-                    gap="$1"
-                    flex={1}
-                    primary={intl.formatMessage({
-                      id: ETranslations.global_receive,
-                    })}
-                    secondary={intl.formatMessage({
-                      id: ETranslations.receive_from_another_wallet_desc,
-                    })}
-                  />
-                </ListItem>
+                />
                 {isBuySupported ? (
-                  <ListItem
-                    mx="$0"
-                    p="$3.5"
-                    drillIn
-                    gap="$3"
-                    userSelect="none"
-                    bg="$neutral2"
-                    borderRadius="$3"
-                    hoverStyle={{ bg: '$neutral3' }}
-                    pressStyle={{ bg: '$neutral4' }}
-                    $platform-native={{
-                      borderWidth: StyleSheet.hairlineWidth,
-                      borderColor: '$neutral3',
-                    }}
-                    $platform-web={{
-                      outlineWidth: 1,
-                      outlineColor: '$neutral3',
-                      outlineStyle: 'solid',
-                    }}
+                  <OptionCard
+                    icon="CurrencyDollarOutline"
+                    title={intl.formatMessage({
+                      id: ETranslations.global_buy,
+                    })}
+                    subtitle={<PaymentMethodBadges />}
                     onPress={async () => {
                       logZeroGas('buy');
                       safeResolve(false);
@@ -227,88 +191,7 @@ function WalletActionSend({
                         });
                       }
                     }}
-                  >
-                    <YStack bg="$neutral3" p="$2" borderRadius="$full">
-                      <Icon name="CurrencyDollarOutline" color="$iconActive" />
-                    </YStack>
-                    <ListItem.Text
-                      gap="$1"
-                      flex={1}
-                      primary={intl.formatMessage({
-                        id: ETranslations.global_buy,
-                      })}
-                      secondary={
-                        <XStack mt="$1" gap="$1">
-                          <YStack
-                            h="$5"
-                            px="$1.5"
-                            borderRadius="$2"
-                            borderCurve="continuous"
-                            justifyContent="center"
-                            alignItems="center"
-                            bg="$neutral3"
-                          >
-                            <Icon
-                              name="ApplePayIllus"
-                              h="$3"
-                              w="$8"
-                              color="$icon"
-                            />
-                          </YStack>
-                          <YStack
-                            h="$5"
-                            px="$1.5"
-                            borderRadius="$2"
-                            borderCurve="continuous"
-                            justifyContent="center"
-                            alignItems="center"
-                            bg="$neutral3"
-                          >
-                            <Icon
-                              name="GooglePayIllus"
-                              h="$3"
-                              w="$8"
-                              color="$icon"
-                            />
-                          </YStack>
-                          <YStack
-                            h="$5"
-                            px="$0.5"
-                            borderRadius="$2"
-                            borderCurve="continuous"
-                            justifyContent="center"
-                            alignItems="center"
-                            bg="$neutral3"
-                          >
-                            <Icon
-                              name="VisaIllus"
-                              h="$3"
-                              w="$8"
-                              color="$icon"
-                            />
-                          </YStack>
-                          <XStack
-                            alignItems="center"
-                            px="$1"
-                            gap="$0.5"
-                            bg="$neutral3"
-                            borderRadius="$2"
-                            borderCurve="continuous"
-                          >
-                            {Array.from({ length: 3 }).map((_, index) => (
-                              <YStack
-                                key={index}
-                                borderRadius="$full"
-                                w={3}
-                                h={3}
-                                bg="$iconSubdued"
-                              />
-                            ))}
-                          </XStack>
-                        </XStack>
-                      }
-                    />
-                  </ListItem>
+                  />
                 ) : null}
                 <Button
                   variant="tertiary"


### PR DESCRIPTION
## Summary

Restyle the "Insufficient ETH for network fees" dialog's Receive/Buy buttons to match the ReceiveSelector page style — card-style ListItems with icon, title, subtitle, and drillIn arrow.

### Before
Simple icon+text card buttons in a horizontal row.

### After
Vertical ListItem cards matching ReceiveSelector:
- **Receive**: ArrowBottomOutline icon + "Receive using your wallet address" subtitle
- **Buy**: CurrencyDollarOutline icon + Apple Pay / Google Pay / Visa badges

### Shared components extracted
- `OptionCard` — reusable ListItem card with icon circle, title, subtitle, platform borders
- `PaymentMethodBadges` — Apple Pay / Google Pay / Visa + dots icons (was copy-pasted in 3 places)

## Files

| File | Changes |
|---|---|
| `components/OptionCard/index.tsx` | New shared component |
| `Home/components/WalletActions/index.tsx` | Use OptionCard, remove inline ListItem duplication |

## Test plan

- [ ] No ETH account → click Send → dialog shows with styled Receive/Buy cards
- [ ] Click Receive → navigates to ReceiveSelector
- [ ] Click Buy → opens fiat crypto flow
- [ ] Click Continue → proceeds to send flow
- [ ] Click X / backdrop → dialog dismisses, send flow aborted
- [ ] Buy hidden when network not supported for fiat purchase

<img width="1024" height="953" alt="image" src="https://github.com/user-attachments/assets/44c07b44-57b4-4dcd-9764-1e5d6037146f" />
