### PR TITLE
fix: align swap quote tip validation (OK-53328)

### DIFF
--- a/packages/kit/src/views/Swap/utils/quoteShowTipUtils.ts
+++ b/packages/kit/src/views/Swap/utils/quoteShowTipUtils.ts
@@ -78,12 +78,16 @@ export function resolveQuoteShowTip({
   }
 
   if (quoteShowTip.type === EQuoteShowTipType.TRADE_UNKNOWN) {
-    return getTokenFiatValue({
+    const fromFiatValueBN = getTokenFiatValue({
+      token: fromToken,
+      amount: fromAmount,
+    });
+    const toFiatValueBN = getTokenFiatValue({
       token: toToken,
       amount: toAmount,
-    })
-      ? undefined
-      : quoteShowTip;
+    });
+
+    return fromFiatValueBN && toFiatValueBN ? undefined : quoteShowTip;
   }
 
   if (quoteShowTip.type !== EQuoteShowTipType.PRICE_IMPACT) {


### PR DESCRIPTION
## Summary
- align `tradeUnknown` preview revalidation with the server-side `quoteShowTip` semantics
- only suppress the unknown token value warning when both sell and receive fiat values are available locally
- keep the existing local `priceImpact` threshold revalidation unchanged

## Intent & Context
During swap preview, selling a token with local fiat value `0` could still skip the warning modal when the receive token had a valid fiat value. The backend `quoteShowTip` branch treats unknown value as a bilateral check: if either sell or receive fiat value is unavailable, it returns `tradeUnknown`.

This PR aligns the client-side guard with that server behavior so the preview dialog no longer clears the warning tip in the sell-value-unknown case.

## Root Cause
`resolveQuoteShowTip()` revalidated `tradeUnknown` using only the receive-side fiat value. When the receive token had a price but the sell token did not, the client cleared the server-provided `tradeUnknown` tip and allowed confirmation to continue without showing the warning modal.

This regression was introduced when shared preview quote tip revalidation was added in `d9d205e63df`.

## Design Decisions
- Keep the fix local to the client-side quote tip revalidation utility instead of changing dialog rendering.
- Preserve the server tip whenever either side cannot produce a positive fiat value locally.
- Leave the `priceImpact` path unchanged, including local threshold-based filtering with `priceImpactLoss`.
- Do not include a new unit test in this PR because the user explicitly asked to remove the test case before submission.

## Changes Detail
- Update `packages/kit/src/views/Swap/utils/quoteShowTipUtils.ts` so `tradeUnknown` is only suppressed when both sell and receive fiat values are available.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile / Desktop / Web / Extension
- **Risk Areas**: Swap preview dialog tip gating for shared Kit clients

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [ ] Manually verify a quote where the sell token fiat value is `0` and the receive token fiat value is available still shows the warning modal.
- [ ] Manually verify quotes with both fiat values available still follow the existing `priceImpact` behavior.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
