### PR TITLE
fix(send): include orphan HW hidden wallets in recipient account tab (OK-53423)

### DIFF
--- a/packages/kit-bg/src/dbs/local/LocalDbBase.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.ts
@@ -889,17 +889,24 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
     const refilledWalletsCache: {
       [walletId: string]: IDBWallet;
     } = {};
+    const nestedHiddenIds = new Set<string>();
     wallets = await Promise.all(
       wallets.map(async (w) => {
+        const ownHidden = w.associatedDevice
+          ? (hiddenWalletsMap[w.associatedDevice] || []).filter((hw) =>
+              hw.id.startsWith(w.id),
+            )
+          : undefined;
+        if (ownHidden) {
+          for (const hw of ownHidden) {
+            nestedHiddenIds.add(hw.id);
+          }
+        }
         const newWallet: IDBWallet = await this.refillWalletInfo({
           refilledWalletsCache,
           allDevices,
           wallet: w,
-          hiddenWallets: w.associatedDevice
-            ? (hiddenWalletsMap[w.associatedDevice] || []).filter((hw) =>
-                hw.id.startsWith(w.id),
-              )
-            : undefined,
+          hiddenWallets: ownHidden,
         });
         if (includingAccounts) {
           await Promise.all([
@@ -913,6 +920,31 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
         return newWallet;
       }),
     );
+
+    // Promote orphan hidden wallets whose parent standard wallet doesn't
+    // exist (e.g., user only created a passphrase wallet on a HW device).
+    for (const deviceHiddenWallets of Object.values(hiddenWalletsMap)) {
+      if (!deviceHiddenWallets) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      for (const hw of deviceHiddenWallets) {
+        if (nestedHiddenIds.has(hw.id)) {
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+        const newWallet: IDBWallet = await this.refillWalletInfo({
+          refilledWalletsCache,
+          allDevices,
+          wallet: hw,
+        });
+        if (includingAccounts) {
+          await fillDbAccounts(newWallet);
+        }
+        wallets.push(newWallet);
+      }
+    }
+
     wallets = wallets.toSorted(this.walletSortFn);
 
     return {

--- a/packages/kit-bg/src/dbs/local/LocalDbBase.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.ts
@@ -4067,6 +4067,10 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
               account = await this.getAccount({ accountId });
             }
             if (wallet && account) {
+              if (this.isTempWalletRemoved({ wallet })) {
+                // eslint-disable-next-line no-continue
+                continue;
+              }
               const order = getOrderByWalletType(wallet.type);
               if (
                 !accountUtils.isUrlAccountFn({


### PR DESCRIPTION
## Summary
Two fixes for HW hidden (passphrase) wallets in the send flow:

### 1. Orphan hidden wallets missing from Account tab
HW hidden wallets created without a standard parent wallet were missing from the send recipient quick-select "Account" tab, bulk copy addresses, and notification wallet name resolution.

**Root cause**: `LocalDbBase.getWallets({ nestedHiddenWallets: true })` removes hidden wallets from the flat list and nests them under their parent standard wallet via `hw.id.startsWith(parentWallet.id)`. But if no standard wallet exists for that device (HW flow doesn't auto-create a mocked parent like QR flow does), the hidden wallets are silently dropped.

**Fix**: After nesting hidden wallets under parents, promote any orphan hidden wallets back to top-level wallets. Fixes all consumers at once.

### 2. Temp wallet badge leaking after disconnect
When a user chose "don't remember" for a passphrase wallet and disconnected, inputting that wallet's address in the send flow still showed the wallet name badge (e.g., `slip39-QR / Account #1`).

**Root cause**: `getAccountNameFromAddress` queries the DB directly without checking `isTempWalletRemoved` status.

**Fix**: Added `isTempWalletRemoved` check before returning wallet/account name results.

**Not affected**: Account selector uses a different code path (`ServiceAccountSelector`).

## Test plan
- [ ] Connect HW device → create only a hidden (passphrase) wallet, skip standard wallet → open Send → verify hidden wallet accounts appear in "Account" tab
- [ ] Same scenario → verify hidden wallet appears in Bulk Copy Addresses
- [ ] Create standard + hidden wallet → verify both show correctly (no duplicates)
- [ ] Disconnect HW with "don't remember" passphrase wallet → verify it does NOT appear in Account tab
- [ ] Disconnect HW with "don't remember" → input that wallet's address → verify NO wallet name badge shown
- [ ] Disconnect HW with "remember" passphrase wallet → verify it still appears in Account tab and badge