### PR TITLE
fix(send): use AccountAvatar with account object for stable blockies (OK-53400)

### DIFF
--- a/packages/kit/src/views/Send/pages/SendDataInput/QuickSelectListShared.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/QuickSelectListShared.tsx
@@ -47,6 +47,7 @@ type IQuickSelectListItemFrameProps = {
   address: string;
   walletId?: string;
   wallet?: IDBWallet;
+  customRenderAvatar?: () => ReactNode;
   onPress?: () => void;
   onLongPress?: () => void;
   onHoverIn?: () => void;
@@ -61,6 +62,7 @@ function QuickSelectListItemFrame({
   address,
   walletId,
   wallet,
+  customRenderAvatar,
   onPress,
   onLongPress,
   onHoverIn,
@@ -70,7 +72,7 @@ function QuickSelectListItemFrame({
   secondary,
   trailing,
 }: IQuickSelectListItemFrameProps) {
-  const renderAvatar = useCallback(
+  const defaultRenderAvatar = useCallback(
     () => (
       <MemoizedAccountAvatarWithWallet
         address={address}
@@ -80,6 +82,7 @@ function QuickSelectListItemFrame({
     ),
     [address, wallet, walletId],
   );
+  const renderAvatar = customRenderAvatar ?? defaultRenderAvatar;
 
   return (
     <ListItem

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import {
   memo,
   useCallback,
@@ -27,6 +28,7 @@ import {
   YStack,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { AccountAvatar } from '@onekeyhq/kit/src/components/AccountAvatar';
 import { addressTypeTooltipMap } from '@onekeyhq/kit/src/components/AddressTypeSelector/AddressTypeSelectorItem';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useDebounce } from '@onekeyhq/kit/src/hooks/useDebounce';
@@ -150,12 +152,13 @@ type IQuickItem = {
   id?: string;
   name: string;
   address: string;
-  displayAddress?: string; // Address shown in secondary text (may differ from avatar seed)
+  displayAddress?: string;
   memo?: string;
   note?: string;
   deriveLabel?: string;
   walletId?: string;
   wallet?: IDBWallet;
+  customRenderAvatar?: () => ReactNode;
 };
 
 const QuickSelectListItem = memo(
@@ -181,6 +184,7 @@ const QuickSelectListItem = memo(
         address={item.address}
         walletId={item.walletId}
         wallet={item.wallet}
+        customRenderAvatar={item.customRenderAvatar}
         onPress={onPress}
         testID={`recipient-item-${item.address}`}
         primary={
@@ -699,12 +703,20 @@ function AccountRecipients({
             item={{
               id: account.id ?? '',
               name: displayName,
-              // Use account.id as avatar seed when address is empty (e.g. Lightning)
               address: itemAddress || account.id || '',
-              // Only show address in secondary text when it's a real address
               displayAddress: itemAddress,
               walletId,
               wallet,
+              // Stable avatar: use account object directly so AccountAvatar
+              // renders the wallet-type icon + consistent blockies seed,
+              // independent of BTC fresh address rotation.
+              customRenderAvatar: () => (
+                <AccountAvatar
+                  size="default"
+                  account={account}
+                  wallet={wallet}
+                />
+              ),
             }}
             onPress={() => handleSelectAccount({ account, matchedAddress })}
           />


### PR DESCRIPTION
## Summary

BTC fresh address rotation caused the same account to show different blockies avatars each time the Send page opened.

### Fix

Add `customRenderAvatar` prop to `QuickSelectListItemFrame`. The Accounts tab passes `<AccountAvatar account={account} wallet={wallet} />` directly, which uses the stable account object for blockies generation instead of the rotating display address.

This keeps the `address` field semantically correct (always an address, never an account ID).

## Files

| File | Changes |
|---|---|
| `QuickSelectListShared.tsx` | Add optional `customRenderAvatar` prop |
| `RecipientQuickSelect.tsx` | Pass `AccountAvatar` with account object for Accounts tab items |

## Test plan

- [ ] BTC Send → Accounts tab → same account shows same blockies across multiple opens
- [ ] BTC Send → search old address → account found, blockies matches the non-search view
- [ ] EVM Send → Accounts tab → blockies unchanged
- [ ] Recent tab → blockies still uses recipient address (unchanged)
- [ ] AddressBook tab → blockies still uses address (unchanged)
- [ ] Lightning Send → accounts with no address still show avatar