### PR TITLE
fix: hide allowlist icon on web dapp mode (OK-53448)

### DIFF
--- a/packages/kit/src/components/AddressInput/AddressSecurityHeaderRightButton.tsx
+++ b/packages/kit/src/components/AddressInput/AddressSecurityHeaderRightButton.tsx
@@ -14,6 +14,7 @@ import {
 } from '@onekeyhq/components';
 import type { IHyperlinkTextProps } from '@onekeyhq/kit/src/components/HyperlinkText';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { HyperlinkText } from '../HyperlinkText';
 
@@ -107,6 +108,6 @@ function AddressSecurityHeaderRightButton() {
   );
 }
 
-export const renderAddressSecurityHeaderRightButton = () => (
-  <AddressSecurityHeaderRightButton />
-);
+export const renderAddressSecurityHeaderRightButton = platformEnv.isWebDappMode
+  ? undefined
+  : () => <AddressSecurityHeaderRightButton />;


### PR DESCRIPTION
## Summary
Hide the transfer allowlist shield icon from the page header on web dapp mode. The allowlist feature is not accessible in web settings (already hidden via `platformEnv.isWebDappMode` guard in settings config), so the icon entry point in Send / Swap / ReferFriends should also be hidden.

**Fix**: Guard `renderAddressSecurityHeaderRightButton` export with `platformEnv.isWebDappMode` — returns `undefined` on web, which all 3 callers already handle (headerRight accepts undefined).

## Test plan
- [ ] Web dapp mode → Send flow → verify no shield icon in header
- [ ] Web dapp mode → Swap → edit recipient → verify no shield icon in header
- [ ] Desktop/Mobile → Send flow → verify shield icon still visible
- [ ] Desktop/Mobile → Swap edit recipient → verify shield icon still visible
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
