### PR TITLE
fix: hide wallet badge for deleted/deprecated wallets (OK-53449)

### DIFF
--- a/packages/kit-bg/src/dbs/local/LocalDbBase.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.ts
@@ -4067,7 +4067,10 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
               account = await this.getAccount({ accountId });
             }
             if (wallet && account) {
-              if (this.isTempWalletRemoved({ wallet })) {
+              if (
+                this.isTempWalletRemoved({ wallet }) ||
+                accountUtils.isWalletDeprecatedOrMocked(wallet)
+              ) {
                 // eslint-disable-next-line no-continue
                 continue;
               }


### PR DESCRIPTION
## Summary
Deleted (deprecated) wallet accounts were still showing wallet name badges (e.g., `MyWallet / Account #1`) in the address input field when their address was entered in the send flow.

**Root cause**: `getAccountNameFromAddress` in `LocalDbBase` looks up wallet/account records from DB but didn't check whether the wallet is deprecated or mocked. Deleted wallets remain in the DB with `deprecated: true` but should not surface in UI.

**Fix**: Added `accountUtils.isWalletDeprecatedOrMocked(wallet)` check alongside the existing `isTempWalletRemoved` guard, so deprecated/mocked wallets are excluded from badge results.

## Test plan
- [ ] Delete a wallet → enter its address in Send → verify NO wallet name badge shown
- [ ] Active wallet → enter its address → verify badge still shows correctly
- [ ] Mocked wallet (HW standard without real account) → enter address → verify no badge
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
