### PR TITLE
fix(send): account names and avatar alignment with account selector (OK-53451, OK-53450)

### DIFF
--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -4743,6 +4743,7 @@ class ServiceAccount extends ServiceBase {
       isHardwareWallet: boolean;
       accounts: Array<{
         account: INetworkAccount;
+        indexedAccount?: IDBIndexedAccount;
         deriveInfo?: IAccountDeriveInfo;
         deriveType?: string;
       }>;
@@ -4759,6 +4760,7 @@ class ServiceAccount extends ServiceBase {
       const { dbIndexedAccounts, dbAccounts } = wallet;
       let accounts: Array<{
         account: INetworkAccount;
+        indexedAccount?: IDBIndexedAccount;
         deriveInfo?: IAccountDeriveInfo;
         deriveType?: string;
       }> = [];

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -4697,6 +4697,7 @@ class ServiceAccount extends ServiceBase {
       isHardwareWallet: boolean;
       accounts: Array<{
         account: INetworkAccount;
+        indexedAccount?: IDBIndexedAccount;
         deriveInfo?: IAccountDeriveInfo;
         deriveType?: string;
       }>;
@@ -4785,11 +4786,17 @@ class ServiceAccount extends ServiceBase {
         accounts = perIndexed
           .flat()
           .filter((a) => a.account)
-          .map((a) => ({
-            account: a.account as INetworkAccount,
-            deriveInfo: a.deriveInfo,
-            deriveType: a.deriveType,
-          }));
+          .map((a) => {
+            const acc = a.account as INetworkAccount;
+            return {
+              account: acc,
+              indexedAccount: acc.indexedAccountId
+                ? indexedAccountMap.get(acc.indexedAccountId)
+                : undefined,
+              deriveInfo: a.deriveInfo,
+              deriveType: a.deriveType,
+            };
+          });
       } else if (dbAccounts?.length) {
         const networkImpl = networkUtils.getNetworkImpl({ networkId });
         accounts = dbAccounts

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -4715,7 +4715,23 @@ class ServiceAccount extends ServiceBase {
       includingAccounts: true,
     });
 
-    const { accounts: allDbAccounts } = await localDb.getAllAccounts();
+    const [{ accounts: allDbAccounts }, { indexedAccounts }] =
+      await Promise.all([
+        localDb.getAllAccounts(),
+        localDb.getAllIndexedAccounts(),
+      ]);
+    // Patch account names from indexedAccount (same as refillAccountInfo)
+    // so pre-fetched accounts show the user's custom name, not the
+    // vault-generated default like "APT #1".
+    const indexedAccountMap = new Map(indexedAccounts.map((ia) => [ia.id, ia]));
+    for (const acc of allDbAccounts) {
+      if (acc.indexedAccountId) {
+        const ia = indexedAccountMap.get(acc.indexedAccountId);
+        if (ia) {
+          acc.name = ia.name;
+        }
+      }
+    }
 
     const resolveWallet = async (
       wallet: IDBWallet,

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -18,6 +18,7 @@ import {
   Button,
   DashText,
   Empty,
+  Icon,
   MatchSizeableText,
   Popover,
   SegmentControl,
@@ -30,6 +31,7 @@ import {
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { AccountAvatar } from '@onekeyhq/kit/src/components/AccountAvatar';
 import { addressTypeTooltipMap } from '@onekeyhq/kit/src/components/AddressTypeSelector/AddressTypeSelectorItem';
+import { WalletAvatar } from '@onekeyhq/kit/src/components/WalletAvatar';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useDebounce } from '@onekeyhq/kit/src/hooks/useDebounce';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
@@ -551,6 +553,7 @@ function AccountRecipients({
         type: 'header';
         title: string;
         walletId: string;
+        wallet?: IDBWallet;
         hasMultipleDeriveTypes: boolean;
         deriveTypeOptions: {
           label: string;
@@ -579,6 +582,7 @@ function AccountRecipients({
             type: 'header',
             title: section.title,
             walletId: section.walletId,
+            wallet: section.wallet,
             hasMultipleDeriveTypes: section.hasMultipleDeriveTypes,
             deriveTypeOptions: section.deriveTypeOptions,
             activeDeriveType: section.activeDeriveType,
@@ -656,21 +660,39 @@ function AccountRecipients({
               pt="$4"
               pb="$2"
               alignItems="center"
-              gap="$4"
+              gap="$2"
             >
               <Button
                 size="small"
                 variant="tertiary"
                 flexShrink={1}
-                textEllipsis
+                childrenAsText={false}
                 onPress={() => toggleCollapse(item.walletId)}
-                iconAfter={
-                  isCollapsed
-                    ? 'ChevronRightSmallOutline'
-                    : 'ChevronDownSmallOutline'
-                }
               >
-                {item.title}
+                <XStack alignItems="center" gap="$1.5">
+                  {item.wallet ? (
+                    <WalletAvatar wallet={item.wallet} size="$5" />
+                  ) : null}
+                  <XStack alignItems="center" flexShrink={1}>
+                    <SizableText
+                      size="$bodySmMedium"
+                      numberOfLines={1}
+                      flexShrink={1}
+                    >
+                      {item.title}
+                    </SizableText>
+                    <Icon
+                      name={
+                        isCollapsed
+                          ? 'ChevronRightSmallOutline'
+                          : 'ChevronDownSmallOutline'
+                      }
+                      size="$5"
+                      color="$iconSubdued"
+                      flexShrink={0}
+                    />
+                  </XStack>
+                </XStack>
               </Button>
               {item.hasMultipleDeriveTypes ? (
                 <ActionList
@@ -699,10 +721,19 @@ function AccountRecipients({
                     <Button
                       size="small"
                       variant="tertiary"
-                      iconAfter="ChevronDownSmallSolid"
                       flexShrink={0}
+                      childrenAsText={false}
                     >
-                      {activeLabel ?? ''}
+                      <XStack alignItems="center">
+                        <SizableText size="$bodySmMedium" numberOfLines={1}>
+                          {activeLabel ?? ''}
+                        </SizableText>
+                        <Icon
+                          name="ChevronDownSmallSolid"
+                          size="$5"
+                          color="$iconSubdued"
+                        />
+                      </XStack>
                     </Button>
                   }
                 />
@@ -716,7 +747,6 @@ function AccountRecipients({
           return null;
         }
 
-        // Render account item
         if (!item.account) {
           return null;
         }
@@ -746,10 +776,6 @@ function AccountRecipients({
               displayAddress: itemAddress,
               walletId,
               wallet,
-              // Align with AccountSelector: when indexedAccount exists,
-              // omit address so AccountAvatar uses idHash as blockies seed
-              // (same as AccountSelector). For imported accounts without
-              // indexedAccount, pass address fallback to avoid X mark.
               customRenderAvatar: () => (
                 <AccountAvatar
                   size="default"

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -35,6 +35,7 @@ import { useDebounce } from '@onekeyhq/kit/src/hooks/useDebounce';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import type { IAddressNetworkItem } from '@onekeyhq/kit/src/views/AddressBook/type';
 import type {
+  IDBIndexedAccount,
   IDBUtxoAccount,
   IDBWallet,
 } from '@onekeyhq/kit-bg/src/dbs/local/types';
@@ -224,6 +225,7 @@ QuickSelectListItem.displayName = 'QuickSelectListItem';
 // Account with derive type info
 type IAccountWithDeriveInfo = {
   account: INetworkAccount;
+  indexedAccount?: IDBIndexedAccount;
   deriveInfo?: IAccountDeriveInfo;
   deriveType?: string;
   // The actual historical address that matched the current search (OK-53313).
@@ -560,6 +562,7 @@ function AccountRecipients({
     | {
         type: 'account';
         account: INetworkAccount;
+        indexedAccount?: IDBIndexedAccount;
         matchedAddress?: string;
         walletId: string;
         walletName: string;
@@ -586,6 +589,7 @@ function AccountRecipients({
           items.push({
             type: 'account',
             account: item.account,
+            indexedAccount: item.indexedAccount,
             matchedAddress: item.matchedAddress,
             walletId: section.walletId,
             walletName: section.title,
@@ -716,19 +720,20 @@ function AccountRecipients({
         if (!item.account) {
           return null;
         }
-        const { account, matchedAddress, walletId, wallet } = item;
+        const {
+          account,
+          indexedAccount: itemIndexedAccount,
+          matchedAddress,
+          walletId,
+          wallet,
+        } = item;
         const currentAddress =
           account.addressDetail?.displayAddress ??
           account.address ??
           account.addressDetail?.address ??
           '';
-        // Prefer the matched historical address (OK-53313) so the user sees
-        // exactly what they typed instead of the current rotating fresh
-        // address.
         const itemAddress = matchedAddress ?? currentAddress;
         const itemKey = `${account.id ?? 'no-id'}-${itemAddress}`;
-
-        // Wallet name is already shown in the section header, only show account name
         const displayName = account.name ?? '';
 
         return (
@@ -741,9 +746,10 @@ function AccountRecipients({
               displayAddress: itemAddress,
               walletId,
               wallet,
-              // Align with AccountSelector: pass account + wallet + networkId
-              // so avatar renders consistent blockies + wallet badge + network badge.
-              // address fallback for imported accounts with empty account.address.
+              // Align with AccountSelector avatar rendering:
+              // indexedAccount for stable blockies seed (idHash),
+              // address fallback for imported accounts,
+              // networkId for network badge.
               customRenderAvatar: () => (
                 <AccountAvatar
                   size="default"
@@ -752,6 +758,7 @@ function AccountRecipients({
                     account.addressDetail?.displayAddress ||
                     account.id
                   }
+                  indexedAccount={itemIndexedAccount}
                   account={account}
                   wallet={wallet}
                   networkId={networkId}

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -746,17 +746,19 @@ function AccountRecipients({
               displayAddress: itemAddress,
               walletId,
               wallet,
-              // Align with AccountSelector avatar rendering:
-              // indexedAccount for stable blockies seed (idHash),
-              // address fallback for imported accounts,
-              // networkId for network badge.
+              // Align with AccountSelector: when indexedAccount exists,
+              // omit address so AccountAvatar uses idHash as blockies seed
+              // (same as AccountSelector). For imported accounts without
+              // indexedAccount, pass address fallback to avoid X mark.
               customRenderAvatar: () => (
                 <AccountAvatar
                   size="default"
                   address={
-                    account.address ||
-                    account.addressDetail?.displayAddress ||
-                    account.id
+                    itemIndexedAccount
+                      ? undefined
+                      : account.address ||
+                        account.addressDetail?.displayAddress ||
+                        account.id
                   }
                   indexedAccount={itemIndexedAccount}
                   account={account}

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -762,7 +762,6 @@ function AccountRecipients({
                   }
                   indexedAccount={itemIndexedAccount}
                   account={account}
-                  wallet={wallet}
                   networkId={networkId}
                 />
               ),

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -741,14 +741,20 @@ function AccountRecipients({
               displayAddress: itemAddress,
               walletId,
               wallet,
-              // Stable avatar: use account object directly so AccountAvatar
-              // renders the wallet-type icon + consistent blockies seed,
-              // independent of BTC fresh address rotation.
+              // Align with AccountSelector: pass account + wallet + networkId
+              // so avatar renders consistent blockies + wallet badge + network badge.
+              // address fallback for imported accounts with empty account.address.
               customRenderAvatar: () => (
                 <AccountAvatar
                   size="default"
+                  address={
+                    account.address ||
+                    account.addressDetail?.displayAddress ||
+                    account.id
+                  }
                   account={account}
                   wallet={wallet}
+                  networkId={networkId}
                 />
               ),
             }}


### PR DESCRIPTION
## Summary

Align the Accounts tab in RecipientQuickSelect with the Account Selector — names, avatars, wallet headers, and derive type buttons.

### OK-53451 — Account names show vault default instead of custom name

`getWalletAccountGroupsForNetwork` pre-fetches accounts via `getAllAccounts()` which returns raw DB records without `refillAccountInfo`. Account names showed vault defaults ("APT #1") instead of the user's custom name ("ran").

**Fix**: Pre-fetch `indexedAccounts` and patch each account's `name` from `indexedAccount.name`.

### OK-53450 — Imported DOT account avatar shows X mark

`customRenderAvatar` passed `<AccountAvatar account={account} />` without `address` prop. For DOT variant accounts with empty `account.address`, this rendered the X icon.

**Fix**: Pass `address` fallback chain (`account.address → displayAddress → account.id`). Omit `address` when `indexedAccount` exists so blockies uses `idHash` (matching AccountSelector).

### Avatar alignment with AccountSelector

- Pass `indexedAccount` for consistent blockies seed (`idHash`)
- Pass `networkId` for network badge
- Remove `wallet` prop (AccountSelector doesn't show wallet badge on avatar)

### Wallet group header

- Add `WalletAvatar` before wallet name in the collapsible header
- Text + chevron in inner `XStack` without gap (matching home page spacing)
- Derive type button: same tight text+chevron pattern
- Both buttons use `childrenAsText={false}` for RN compatibility

## Files

| File | Changes |
|---|---|
| `ServiceAccount.ts` | Patch names + return indexedAccount from batch method |
| `RecipientQuickSelect.tsx` | Avatar alignment, wallet header, derive type button |

## Test plan

- [ ] Rename account → Send → Accounts tab shows custom name
- [ ] DOT imported private key → blockies avatar (not X mark)
- [ ] Same account shows same blockies in AccountSelector and Accounts tab
- [ ] Avatar has network badge, no wallet badge
- [ ] Wallet header shows wallet icon + name + tight chevron
- [ ] Derive type button shows tight text + chevron
- [ ] BTC: wallet headers with derive type selector work correctly
- [ ] Mobile: no rendering errors (childrenAsText=false)