### PR TITLE
fix(send): fix imported account avatar showing X mark (OK-53450)

### DIFF
--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -741,12 +741,18 @@ function AccountRecipients({
               displayAddress: itemAddress,
               walletId,
               wallet,
-              // Stable avatar: use account object directly so AccountAvatar
-              // renders the wallet-type icon + consistent blockies seed,
-              // independent of BTC fresh address rotation.
+              // Stable avatar: use account object so AccountAvatar renders
+              // the wallet-type icon + consistent blockies seed. Pass
+              // address fallback for imported accounts that may have an
+              // empty account.address (e.g. DOT variant accounts).
               customRenderAvatar: () => (
                 <AccountAvatar
                   size="default"
+                  address={
+                    account.address ||
+                    account.addressDetail?.displayAddress ||
+                    account.id
+                  }
                   account={account}
                   wallet={wallet}
                 />


### PR DESCRIPTION
## Summary

Imported DOT (Polkadot) private key accounts showed an X mark instead of blockies avatar in the Accounts tab.

### Root cause

`customRenderAvatar` (added in PR #11280) passed `<AccountAvatar account={account} />` without an `address` prop. For imported accounts using `IDBVariantAccount`, the `account.address` field can be empty, causing `AccountAvatar` to render `DefaultEmptyAccount` (CrossedSmallSolid icon).

### Fix

Pass explicit `address` prop with fallback chain: `account.address → addressDetail.displayAddress → account.id`. This ensures blockies always have a seed value.

## Test plan

- [ ] DOT imported private key account → Accounts tab shows blockies (not X mark)
- [ ] EVM imported account → avatar unchanged
- [ ] HD wallet accounts → avatar unchanged (still uses account object)
- [ ] Accounts with empty address (e.g. Lightning) → falls back to account.id