### PR TITLE
fix: restrict bulk send max mode to tokens

### DIFF
--- a/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/BulkSendAmountsInput.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/BulkSendAmountsInput.tsx
@@ -114,7 +114,8 @@ function BaseBulkSendAmountsInput({ isInModal }: { isInModal?: boolean }) {
   } = useBulkSendAmountsInputContext();
 
   const isOneToMany = bulkSendMode === EBulkSendMode.OneToMany;
-  const shouldHideMaxMode = !isOneToMany && hasDuplicateSenders;
+  const shouldShowMaxMode =
+    !tokenInfo?.isNative && (isOneToMany || !hasDuplicateSenders);
 
   const intl = useIntl();
   const navigation = useAppNavigation();
@@ -418,17 +419,23 @@ function BaseBulkSendAmountsInput({ isInModal }: { isInModal?: boolean }) {
 
     try {
       // Resolve Max mode amounts from sender balances
-      const resolvedTransfersInfo = isMaxMode
-        ? effectiveTransfersInfo.map((transfer) => ({
-            ...transfer,
-            amount: senderBalances[transfer.from] ?? '0',
-          }))
-        : effectiveTransfersInfo;
+      const resolvedTransfersInfo =
+        !isOneToMany && !tokenInfo.isNative && isMaxMode
+          ? effectiveTransfersInfo.map((transfer) => ({
+              ...transfer,
+              amount: senderBalances[transfer.from] ?? '0',
+            }))
+          : effectiveTransfersInfo;
 
       // Recalculate totals for Max mode
       let finalTotalTokenAmount = effectiveTotalTokenAmount;
       let finalTotalFiatAmount = effectiveTotalFiatAmount;
-      if (isMaxMode && tokenDetails?.price) {
+      if (
+        !isOneToMany &&
+        !tokenInfo.isNative &&
+        isMaxMode &&
+        tokenDetails?.price
+      ) {
         const { totalTokenAmount: maxTotal, totalFiatAmount: maxFiat } =
           calculateTotalAmounts({
             transfersInfo: resolvedTransfersInfo,
@@ -463,7 +470,7 @@ function BaseBulkSendAmountsInput({ isInModal }: { isInModal?: boolean }) {
         transfersInfo: resolvedTransfersInfo,
         bulkSendMode,
         isInModal,
-        isMaxMode,
+        isMaxMode: !isOneToMany && !tokenInfo.isNative && isMaxMode,
         totalTokenAmount: finalTotalTokenAmount,
         totalFiatAmount: finalTotalFiatAmount,
       });
@@ -487,6 +494,7 @@ function BaseBulkSendAmountsInput({ isInModal }: { isInModal?: boolean }) {
     senderAccountIdMap,
     getEffectiveData,
     navigateToReviewOrInterval,
+    isOneToMany,
   ]);
 
   // Main submit dispatcher
@@ -624,16 +632,16 @@ function BaseBulkSendAmountsInput({ isInModal }: { isInModal?: boolean }) {
   ]);
 
   const handleMaxPress = useCallback(() => {
-    if (!tokenInfo) return;
+    if (!tokenInfo || tokenInfo.isNative) return;
     if (amountInputMode !== EAmountInputMode.Specified) return;
 
-    // Non-OneToMany: toggle Max mode (send full balance per sender)
+    // Non-OneToMany: toggle Max mode (send full token balance per sender)
     if (!isOneToMany) {
       setIsMaxMode(!isMaxMode);
       return;
     }
 
-    // OneToMany: calculate max amount per address from balance
+    // OneToMany token transfer: calculate max token amount per address from balance
     const balance = tokenDetails?.balanceParsed ?? '0';
     if (!balance || transfersInfo.length === 0) return;
     const maxAmountPerAddress = new BigNumber(balance)
@@ -769,7 +777,7 @@ function BaseBulkSendAmountsInput({ isInModal }: { isInModal?: boolean }) {
                 rangePreviewAmounts={previewState.rangePreviewAmounts}
                 onMaxPress={
                   amountInputMode === EAmountInputMode.Specified &&
-                  !shouldHideMaxMode
+                  shouldShowMaxMode
                     ? handleMaxPress
                     : undefined
                 }

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/BulkSendAmountsInput.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/BulkSendAmountsInput.tsx
@@ -114,8 +114,9 @@ function BaseBulkSendAmountsInput({ isInModal }: { isInModal?: boolean }) {
   } = useBulkSendAmountsInputContext();
 
   const isOneToMany = bulkSendMode === EBulkSendMode.OneToMany;
-  const shouldShowMaxMode =
-    !tokenInfo?.isNative && (isOneToMany || !hasDuplicateSenders);
+  const shouldShowMaxMode = isOneToMany
+    ? !tokenInfo?.isNative
+    : !hasDuplicateSenders;
 
   const intl = useIntl();
   const navigation = useAppNavigation();
@@ -420,7 +421,7 @@ function BaseBulkSendAmountsInput({ isInModal }: { isInModal?: boolean }) {
     try {
       // Resolve Max mode amounts from sender balances
       const resolvedTransfersInfo =
-        !isOneToMany && !tokenInfo.isNative && isMaxMode
+        !isOneToMany && isMaxMode
           ? effectiveTransfersInfo.map((transfer) => ({
               ...transfer,
               amount: senderBalances[transfer.from] ?? '0',
@@ -430,12 +431,7 @@ function BaseBulkSendAmountsInput({ isInModal }: { isInModal?: boolean }) {
       // Recalculate totals for Max mode
       let finalTotalTokenAmount = effectiveTotalTokenAmount;
       let finalTotalFiatAmount = effectiveTotalFiatAmount;
-      if (
-        !isOneToMany &&
-        !tokenInfo.isNative &&
-        isMaxMode &&
-        tokenDetails?.price
-      ) {
+      if (!isOneToMany && isMaxMode && tokenDetails?.price) {
         const { totalTokenAmount: maxTotal, totalFiatAmount: maxFiat } =
           calculateTotalAmounts({
             transfersInfo: resolvedTransfersInfo,
@@ -470,7 +466,7 @@ function BaseBulkSendAmountsInput({ isInModal }: { isInModal?: boolean }) {
         transfersInfo: resolvedTransfersInfo,
         bulkSendMode,
         isInModal,
-        isMaxMode: !isOneToMany && !tokenInfo.isNative && isMaxMode,
+        isMaxMode: !isOneToMany && isMaxMode,
         totalTokenAmount: finalTotalTokenAmount,
         totalFiatAmount: finalTotalFiatAmount,
       });
@@ -632,7 +628,7 @@ function BaseBulkSendAmountsInput({ isInModal }: { isInModal?: boolean }) {
   ]);
 
   const handleMaxPress = useCallback(() => {
-    if (!tokenInfo || tokenInfo.isNative) return;
+    if (!tokenInfo || (isOneToMany && tokenInfo.isNative)) return;
     if (amountInputMode !== EAmountInputMode.Specified) return;
 
     // Non-OneToMany: toggle Max mode (send full token balance per sender)
@@ -877,7 +873,7 @@ function BulkSendAmountsInputContent({
 
   // Dynamically compute whether there are duplicate sender addresses
   const hasDuplicateSenders = useMemo(() => {
-    if (bulkSendMode !== EBulkSendMode.ManyToMany) return false;
+    if (bulkSendMode === EBulkSendMode.OneToMany) return false;
     const senderAddresses = transfersInfo.map((t) => t.from);
     return new Set(senderAddresses).size !== senderAddresses.length;
   }, [bulkSendMode, transfersInfo]);

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/components/TableLayout.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/components/TableLayout.tsx
@@ -237,7 +237,8 @@ function AmountCard() {
   const { network } = useAccountData({ networkId });
 
   const isOneToMany = bulkSendMode === EBulkSendMode.OneToMany;
-  const shouldHideMaxMode = !isOneToMany && hasDuplicateSenders;
+  const shouldShowMaxMode =
+    !tokenInfo?.isNative && (isOneToMany || !hasDuplicateSenders);
   const balance = tokenDetails?.balanceParsed ?? '0';
   const minTransferDisplayAmount = useMemo(
     () =>
@@ -505,16 +506,16 @@ function AmountCard() {
 
   // Handle Max button press
   const handleMaxPress = useCallback(() => {
-    if (!tokenInfo) return;
+    if (!tokenInfo || tokenInfo.isNative) return;
     if (amountInputMode !== EAmountInputMode.Specified) return;
 
-    // Non-OneToMany: toggle Max mode (send full balance per sender)
+    // Non-OneToMany: toggle Max mode (send full token balance per sender)
     if (!isOneToMany) {
       setIsMaxMode(!isMaxMode);
       return;
     }
 
-    // OneToMany: calculate max amount per address from balance
+    // OneToMany token transfer: calculate max token amount per address from balance
     if (!balance || transfersInfo.length === 0) return;
     const maxAmountPerAddress = new BigNumber(balance)
       .dividedBy(transfersInfo.length)
@@ -833,8 +834,7 @@ function AmountCard() {
         ) : (
           <Stack />
         )}
-        {amountInputMode === EAmountInputMode.Specified &&
-        !shouldHideMaxMode ? (
+        {amountInputMode === EAmountInputMode.Specified && shouldShowMaxMode ? (
           <SizableText
             size="$bodySmMedium"
             color={isMaxMode ? '$textSuccess' : '$textInteractive'}

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/components/TableLayout.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/components/TableLayout.tsx
@@ -237,8 +237,9 @@ function AmountCard() {
   const { network } = useAccountData({ networkId });
 
   const isOneToMany = bulkSendMode === EBulkSendMode.OneToMany;
-  const shouldShowMaxMode =
-    !tokenInfo?.isNative && (isOneToMany || !hasDuplicateSenders);
+  const shouldShowMaxMode = isOneToMany
+    ? !tokenInfo?.isNative
+    : !hasDuplicateSenders;
   const balance = tokenDetails?.balanceParsed ?? '0';
   const minTransferDisplayAmount = useMemo(
     () =>
@@ -506,7 +507,7 @@ function AmountCard() {
 
   // Handle Max button press
   const handleMaxPress = useCallback(() => {
-    if (!tokenInfo || tokenInfo.isNative) return;
+    if (!tokenInfo || (isOneToMany && tokenInfo.isNative)) return;
     if (amountInputMode !== EAmountInputMode.Specified) return;
 
     // Non-OneToMany: toggle Max mode (send full token balance per sender)


### PR DESCRIPTION
## Summary
- Hide Bulk Send Max only for native-token one-to-many transfers.
- Keep Max available for many-to-one and many-to-many flows unless duplicate sender addresses make Max unsafe.
- Preserve Max-mode sender-balance resolution for non-one-to-many transfers, including native-token flows.

## Intent & Context
The Max button visibility needed more precise mode-specific behavior. It should not be globally hidden for native tokens; the native-token restriction only applies to one-to-many mode. Many-to-one and many-to-many still need Max, except when duplicate sender addresses would make full-balance calculation ambiguous.

## Root Cause
The previous PR logic tied Max visibility too broadly to `tokenInfo.isNative`, which hid Max in many-to-one and many-to-many native-token flows that still need it. Duplicate-sender protection also only covered many-to-many, while many-to-one can also receive duplicate sender rows from existing route params or data updates.

## Design Decisions
- Use a mode-specific `shouldShowMaxMode` rule: one-to-many requires a non-native token, while non-one-to-many requires no duplicate senders.
- Keep Max press handlers blocked only for the unsupported one-to-many native-token case.
- Keep non-one-to-many Max resolution and review payload behavior available for native tokens.
- Treat duplicate sender detection as relevant for all non-one-to-many modes.

## Changes Detail
- Updated the main Bulk Send amount input flow to apply mode-specific Max visibility and native-token guarding.
- Updated the table amount card to use the same visibility and handler rules.
- Restored non-one-to-many Max calculation/review behavior for native-token transfers.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Bulk Send Max-mode visibility and review payloads for many-to-one / many-to-many flows.

## Test plan
- [x] yarn lint:staged
- [x] yarn tsc:staged
- [ ] Verify one-to-many native-token Bulk Send does not show Max.
- [ ] Verify one-to-many token Bulk Send shows Max.
- [ ] Verify many-to-one and many-to-many Bulk Send show Max when sender addresses are unique.
- [ ] Verify many-to-one and many-to-many Bulk Send hide Max when duplicate sender addresses exist.
