### PR TITLE
fix: harden security audit follow-ups

### DIFF
--- a/.github/actions/shared-env/action.yml
+++ b/.github/actions/shared-env/action.yml
@@ -62,7 +62,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout Source Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       with:
         lfs: true
         ref: ${{ inputs.checkout_ref || '' }}

--- a/packages/core/src/chains/btc/CoreChainSoftware.ts
+++ b/packages/core/src/chains/btc/CoreChainSoftware.ts
@@ -24,7 +24,6 @@ import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { checkIsDefined } from '@onekeyhq/shared/src/utils/assertUtils';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
-import numberUtils from '@onekeyhq/shared/src/utils/numberUtils';
 import type { IServerNetwork } from '@onekeyhq/shared/types';
 import type {
   IXprvtValidation,
@@ -318,9 +317,6 @@ export default class CoreChainSoftwareBtc extends CoreChainApiBase {
     // 4236794462
     const fingerprintBuf = ripemd160Buf.slice(0, 4);
     const fingerprintHex = bufferUtils.bytesToHex(fingerprintBuf);
-    // const fingerprintInt = fingerprintBuf.readUInt32BE(0);
-    const fingerprintInt = numberUtils.hexToDecimal(fingerprintHex);
-    const fingerprintHexCheck = numberUtils.numberToHex(fingerprintInt);
 
     const taprootChild = root.derivePath(BTC_FIRST_TAPROOT_PATH);
     const firstTaprootXpub = taprootChild.neutered().toBase58();
@@ -328,14 +324,6 @@ export default class CoreChainSoftwareBtc extends CoreChainApiBase {
     const fullXfp = accountUtils.buildFullXfp({
       xfp: fingerprintHex,
       firstTaprootXpub,
-    });
-
-    console.log('generateXfpFromMnemonic', {
-      fulXfp: fullXfp,
-      firstTaprootXpub,
-      fingerprintHex,
-      fingerprintInt,
-      fingerprintHexCheck,
     });
 
     if (!fullXfp) {
@@ -1081,11 +1069,6 @@ export default class CoreChainSoftwareBtc extends CoreChainApiBase {
       signers,
       payload,
     });
-
-    if (process.env.NODE_ENV !== 'production') {
-      const buildPsbtHex = psbt.toHex();
-      console.log('BTC buildPsbtHex:', buildPsbtHex);
-    }
 
     // eslint-disable-next-line no-plusplus
     for (let i = 0; i < encodedTx.inputs.length; ++i) {

--- a/packages/kit-bg/src/apis/BackgroundApiBase.ts
+++ b/packages/kit-bg/src/apis/BackgroundApiBase.ts
@@ -39,6 +39,7 @@ import { jotaiInit } from '../states/jotai/jotaiInit';
 
 import {
   isExtensionInternalCall,
+  isProviderApiPrivateAllowedKeylessOrigin,
   isProviderApiPrivateAllowedMethod,
   isProviderApiPrivateAllowedOrigin,
   isProviderApiPrivateKeylessMethod,
@@ -172,6 +173,9 @@ class BackgroundApiBase implements IBackgroundApiBridge {
   ): Promise<IJsonRpcResponse<any>> {
     const { scope, origin } = payload;
     const payloadData = payload?.data as IJsonRpcRequest;
+    const isKeylessPrivateMethod = isProviderApiPrivateKeylessMethod(
+      payloadData?.method,
+    );
     const provider: ProviderApiBase | null =
       this.providers[scope as IInjectedProviderNames];
     if (!provider) {
@@ -181,9 +185,10 @@ class BackgroundApiBase implements IBackgroundApiBridge {
     }
     if (
       scope === IInjectedProviderNames.$private &&
-      ((isProviderApiPrivateKeylessMethod(payloadData?.method) &&
-        !isProviderApiPrivateAllowedOrigin(origin)) ||
-        (!isProviderApiPrivateAllowedOrigin(origin) &&
+      ((isKeylessPrivateMethod &&
+        !isProviderApiPrivateAllowedKeylessOrigin(origin)) ||
+        (!isKeylessPrivateMethod &&
+          !isProviderApiPrivateAllowedOrigin(origin) &&
           !isProviderApiPrivateAllowedMethod(payloadData?.method)))
     ) {
       const error = new Error(

--- a/packages/kit-bg/src/apis/backgroundApiPermissions.ts
+++ b/packages/kit-bg/src/apis/backgroundApiPermissions.ts
@@ -96,6 +96,10 @@ export function isProviderApiPrivateKeylessMethod(method?: string) {
   return method && PROVIDER_API_PRIVATE_KEYLESS_METHOD.includes(method || '');
 }
 
+export function isProviderApiPrivateAllowedKeylessOrigin(origin?: string) {
+  return !!origin && KEYLESS_WEB_TAB_WHITE_LIST_ORIGIN.includes(origin);
+}
+
 export function isProviderApiPrivateAllowedOrigin(origin?: string) {
   const isDevLocalhostOrigin =
     platformEnv.isDev &&

--- a/packages/kit-bg/src/services/ServicePrimeTransfer/ServicePrimeTransfer.ts
+++ b/packages/kit-bg/src/services/ServicePrimeTransfer/ServicePrimeTransfer.ts
@@ -2480,11 +2480,6 @@ class ServicePrimeTransfer extends ServiceBase {
               accountId: addedAccounts?.[0]?.id,
               rs: tonRsEncrypted,
             });
-            // const tonMnemonic2 = await tonMnemonicFromEntropy(
-            //   tonMnemonicCredential,
-            //   password,
-            // );
-            // console.log('tonMnemonic2', tonMnemonic2);
           }
         } catch (e) {
           console.error('tonMnemonicCredential error', e);

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionExport.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionExport.tsx
@@ -38,7 +38,6 @@ export function WalletActionExport({ onClose }: { onClose: () => void }) {
 
   const exportAccountCredentialKey = useCallback(
     async ({ keyType }: { keyType: ECoreApiExportedSecretKeyType }) => {
-      console.log('ExportSecretKeys >>>> ', keyType);
       let r: string | undefined = '';
       if (
         keyType === ECoreApiExportedSecretKeyType.xpub ||
@@ -56,13 +55,6 @@ export function WalletActionExport({ onClose }: { onClose: () => void }) {
           keyType,
         });
       }
-      console.log('ExportSecretKeys >>>> ', r);
-      console.log(
-        'ExportSecretKeys >>>> ',
-        wallet?.type,
-        keyType,
-        account?.address,
-      );
       Dialog.show({
         title: 'Key',
         description: r,
@@ -73,14 +65,7 @@ export function WalletActionExport({ onClose }: { onClose: () => void }) {
       });
       onClose();
     },
-    [
-      wallet?.type,
-      account?.address,
-      account?.id,
-      network?.id,
-      copyText,
-      onClose,
-    ],
+    [account?.id, network?.id, copyText, onClose],
   );
 
   if (


### PR DESCRIPTION
## Summary
- tighten keyless private provider origin checks to use the exact keyless whitelist instead of the broad `.onekey.so` suffix match
- pin the shared GitHub Actions checkout step to the `actions/checkout` v4.1.1 commit SHA
- remove production `console.log` statements from wallet fingerprint / export related paths highlighted by the security audit

## Intent & Context
This PR addresses the concrete follow-up items identified in the security audit for `v6.1.0 -> x`.

The requested scope was to fix three audit findings only:
- the keyless origin guard was too broad
- the shared GitHub Action was still using an unpinned checkout action
- production logging could expose wallet fingerprint or export-flow information

The goal here is to reduce the exposed security surface without expanding the change set into unrelated refactors.

## Root Cause
The audit found three separate root causes:
- keyless private methods reused the generic `$private` origin guard, which allowed any `*.onekey.so` / `*.onekeytest.com` subdomain instead of the explicit keyless web allowlist
- `.github/actions/shared-env/action.yml` depended on `actions/checkout@v3`, which was a floating major tag instead of a fixed commit
- wallet fingerprint / export related code still contained direct `console.log` calls in production paths

## Design Decisions
- keyless methods now use a dedicated `isProviderApiPrivateAllowedKeylessOrigin()` check backed by `KEYLESS_WEB_TAB_WHITE_LIST_ORIGIN`; the broader `$private` origin behavior for non-keyless methods is intentionally unchanged to avoid widening the regression surface
- `actions/checkout` is pinned to the `v4.1.1` commit SHA after confirming that using v4 is acceptable for this repo's GitHub-hosted runners
- the flagged production logs were deleted instead of being moved to another logger, because the request was to remove them completely and the audit concern was unnecessary exposure rather than missing diagnostics
- no extra test file was added, per request, to keep the PR scoped to the requested fixes only

## Changes Detail
- `packages/kit-bg/src/apis/backgroundApiPermissions.ts`: add the dedicated keyless origin allowlist helper
- `packages/kit-bg/src/apis/BackgroundApiBase.ts`: route keyless private methods through the stricter keyless origin check while preserving existing behavior for other `$private` methods
- `.github/actions/shared-env/action.yml`: replace `actions/checkout@v3` with the pinned `v4.1.1` commit SHA
- `packages/core/src/chains/btc/CoreChainSoftware.ts`: remove production logs related to XFP / PSBT debug output and clean up now-unused variables/imports
- `packages/kit/src/views/Home/components/WalletActions/WalletActionExport.tsx`: remove export-flow `console.log` calls and trim hook dependencies accordingly
- `packages/kit-bg/src/services/ServicePrimeTransfer/ServicePrimeTransfer.ts`: remove the leftover sensitive debug comment block in the audited code path

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Desktop / Web / Extension / CI
- **Risk Areas**: keyless login flows that rely on `$private` provider calls, CI checkout bootstrap, and any workflows that previously depended on the removed debug output

## Test plan
- [x] Run `npx eslint` against the changed TypeScript files in this PR
- [x] Run `npx oxlint --tsconfig ./tsconfig.json --type-aware` against the changed TypeScript files in this PR
- [x] Attempt `yarn lint --fix` for full-repo verification
- [ ] Investigate the unrelated `.yalc` package version inconsistency that currently causes `yarn lint --fix` to fail in `_packageVersions`
- [ ] Manually verify keyless private method access from an allowlisted origin and a non-allowlisted `*.onekey.so` origin

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
