### PR TITLE
perf(send): lazy-mount non-active recipient quick-select tabs on web

### DIFF
--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -981,8 +981,9 @@ function RecipientQuickSelect({
   // builds the active tab. Three heavy lists (Recent + Account + AddressBook)
   // each fire their own IPC fan-out and N×blockies avatar work on mount —
   // doing all three simultaneously during the page-in transition caused
-  // visible jank on web/desktop/ext. After the transition settles, fill in
-  // the other tabs so match counts and auto-switch (OK-52952) still work.
+  // visible frame drops on web/desktop/ext. After the transition settles,
+  // fill in the other tabs so match counts and auto-switch (OK-52952)
+  // still work.
   useEffect(() => {
     const timer = setTimeout(() => {
       setVisitedTabs((prev) => {

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -10,7 +10,6 @@ import {
 } from 'react';
 
 import { useIntl } from 'react-intl';
-import Animated, { FadeIn } from 'react-native-reanimated';
 
 import {
   ActionList,
@@ -978,23 +977,27 @@ function RecipientQuickSelect({
     );
   }, [activeTab]);
 
-  // Pre-mount every visible tab (kept hidden via display:none until active)
-  // so each can fetch its data and report its match count without requiring
-  // the user to click in first. Without this, the addressBook tab label
-  // never showed its (N) count when a BTC chain landed on Accounts by
-  // default, and auto-switch couldn't jump to a non-mounted tab (OK-52952).
+  // Defer pre-mounting non-active tabs by ~300ms so the first paint only
+  // builds the active tab. Three heavy lists (Recent + Account + AddressBook)
+  // each fire their own IPC fan-out and N×blockies avatar work on mount —
+  // doing all three simultaneously during the page-in transition caused
+  // visible jank on web/desktop/ext. After the transition settles, fill in
+  // the other tabs so match counts and auto-switch (OK-52952) still work.
   useEffect(() => {
-    setVisitedTabs((prev) => {
-      const next = { ...prev };
-      let changed = false;
-      for (const tab of visibleTabKeys) {
-        if (!next[tab]) {
-          next[tab] = true;
-          changed = true;
+    const timer = setTimeout(() => {
+      setVisitedTabs((prev) => {
+        const next = { ...prev };
+        let changed = false;
+        for (const tab of visibleTabKeys) {
+          if (!next[tab]) {
+            next[tab] = true;
+            changed = true;
+          }
         }
-      }
-      return changed ? next : prev;
-    });
+        return changed ? next : prev;
+      });
+    }, 300);
+    return () => clearTimeout(timer);
   }, [visibleTabKeys]);
 
   // Use debounced search key for auto-switch logic
@@ -1184,93 +1187,91 @@ function RecipientQuickSelect({
   }
 
   return (
-    <Animated.View entering={FadeIn.duration(200)}>
-      <YStack mt="$3" gap="$3">
-        <SegmentControl
-          fullWidth
-          value={activeTab}
-          options={tabOptions}
-          onChange={(value) => {
-            // Record the current search key to prevent auto-switch until user types again
-            lastManualSwitchSearchKeyRef.current = trimmedSearchKey;
-            const toTab = value as IRecipientQuickSelectTab;
-            defaultLogger.transaction.send.quickSelectTabSwitch({
-              network: networkId,
-              fromTab: activeTab,
-              toTab,
-              isAutoSwitch: false,
-            });
-            setActiveTab(toTab);
-          }}
-        />
-        <Stack mx={-20} pb="$3">
-          {/* Render active tab, or visited tabs (hidden with display:none to avoid unmount crashes) */}
-          {!isRecentHidden && (activeTab === 'recent' || visitedTabs.recent) ? (
-            <Stack display={activeTab === 'recent' ? 'flex' : 'none'}>
-              <RecentRecipients
-                compact
-                accountId={accountId}
-                networkId={networkId}
-                searchKey={searchKey}
-                isSearchMode={isSearchMode}
-                onSelect={(params) => {
-                  // Reset input type to Manual to prevent auto-navigation from Recent tab
-                  onInputTypeChange?.(EInputAddressChangeType.Manual);
-                  onSelect?.({
-                    ...params,
-                    quickSelectTab: 'recent',
-                    ...getSearchContext(),
-                  });
-                }}
-                onMatchStatusChange={handleRecentMatchStatus}
-                onLastUsedDeriveTypeChange={setLastUsedDeriveType}
-              />
-            </Stack>
-          ) : null}
-          {activeTab === 'account' || visitedTabs.account ? (
-            <Stack display={activeTab === 'account' ? 'flex' : 'none'}>
-              <AccountRecipients
-                networkId={networkId}
-                senderDeriveType={senderDeriveType}
-                lastUsedDeriveType={lastUsedDeriveType}
-                searchKey={searchKey}
-                debouncedSearchKey={debouncedSearchKey}
-                isSearchMode={isSearchMode}
-                keylessWalletsOnly={keylessWalletsOnly}
-                onInputTypeChange={onInputTypeChange}
-                onSelect={({ address }) =>
-                  onSelect?.({
-                    address,
-                    quickSelectTab: 'account',
-                    ...getSearchContext(),
-                  })
-                }
-                onMatchStatusChange={handleAccountMatchStatus}
-              />
-            </Stack>
-          ) : null}
-          {activeTab === 'addressBook' || visitedTabs.addressBook ? (
-            <Stack display={activeTab === 'addressBook' ? 'flex' : 'none'}>
-              <AddressBookRecipients
-                networkId={networkId}
-                searchKey={searchKey}
-                debouncedSearchKey={debouncedSearchKey}
-                isSearchMode={isSearchMode}
-                onInputTypeChange={onInputTypeChange}
-                onSelect={(params) =>
-                  onSelect?.({
-                    ...params,
-                    quickSelectTab: 'addressBook',
-                    ...getSearchContext(),
-                  })
-                }
-                onMatchStatusChange={handleAddressBookMatchStatus}
-              />
-            </Stack>
-          ) : null}
-        </Stack>
-      </YStack>
-    </Animated.View>
+    <YStack mt="$3" gap="$3">
+      <SegmentControl
+        fullWidth
+        value={activeTab}
+        options={tabOptions}
+        onChange={(value) => {
+          // Record the current search key to prevent auto-switch until user types again
+          lastManualSwitchSearchKeyRef.current = trimmedSearchKey;
+          const toTab = value as IRecipientQuickSelectTab;
+          defaultLogger.transaction.send.quickSelectTabSwitch({
+            network: networkId,
+            fromTab: activeTab,
+            toTab,
+            isAutoSwitch: false,
+          });
+          setActiveTab(toTab);
+        }}
+      />
+      <Stack mx={-20} pb="$3">
+        {/* Render active tab, or visited tabs (hidden with display:none to avoid unmount crashes) */}
+        {!isRecentHidden && (activeTab === 'recent' || visitedTabs.recent) ? (
+          <Stack display={activeTab === 'recent' ? 'flex' : 'none'}>
+            <RecentRecipients
+              compact
+              accountId={accountId}
+              networkId={networkId}
+              searchKey={searchKey}
+              isSearchMode={isSearchMode}
+              onSelect={(params) => {
+                // Reset input type to Manual to prevent auto-navigation from Recent tab
+                onInputTypeChange?.(EInputAddressChangeType.Manual);
+                onSelect?.({
+                  ...params,
+                  quickSelectTab: 'recent',
+                  ...getSearchContext(),
+                });
+              }}
+              onMatchStatusChange={handleRecentMatchStatus}
+              onLastUsedDeriveTypeChange={setLastUsedDeriveType}
+            />
+          </Stack>
+        ) : null}
+        {activeTab === 'account' || visitedTabs.account ? (
+          <Stack display={activeTab === 'account' ? 'flex' : 'none'}>
+            <AccountRecipients
+              networkId={networkId}
+              senderDeriveType={senderDeriveType}
+              lastUsedDeriveType={lastUsedDeriveType}
+              searchKey={searchKey}
+              debouncedSearchKey={debouncedSearchKey}
+              isSearchMode={isSearchMode}
+              keylessWalletsOnly={keylessWalletsOnly}
+              onInputTypeChange={onInputTypeChange}
+              onSelect={({ address }) =>
+                onSelect?.({
+                  address,
+                  quickSelectTab: 'account',
+                  ...getSearchContext(),
+                })
+              }
+              onMatchStatusChange={handleAccountMatchStatus}
+            />
+          </Stack>
+        ) : null}
+        {activeTab === 'addressBook' || visitedTabs.addressBook ? (
+          <Stack display={activeTab === 'addressBook' ? 'flex' : 'none'}>
+            <AddressBookRecipients
+              networkId={networkId}
+              searchKey={searchKey}
+              debouncedSearchKey={debouncedSearchKey}
+              isSearchMode={isSearchMode}
+              onInputTypeChange={onInputTypeChange}
+              onSelect={(params) =>
+                onSelect?.({
+                  ...params,
+                  quickSelectTab: 'addressBook',
+                  ...getSearchContext(),
+                })
+              }
+              onMatchStatusChange={handleAddressBookMatchStatus}
+            />
+          </Stack>
+        ) : null}
+      </Stack>
+    </YStack>
   );
 }
 


### PR DESCRIPTION
## Summary
- Web/desktop/ext only: entering the Send Data Input page used to stall visibly during the Select crypto → Select Address transition.
- Root cause: `RecipientQuickSelect` seeded every visible tab as `visited` on mount, so **Recent / Account / AddressBook** all mounted simultaneously (still in DOM under `display:none`). Each tab fan-outs its own IPC round-trip and renders per-row `AccountAvatar` blockies hashes. The outer `Animated.View entering={FadeIn.duration(200)}` then forced reanimated-web to repaint the whole subtree for 200ms. Native stays smooth because FlashList virtualization + UI-thread animation offload those costs.
- Fix: only the `activeTab` renders on first paint; other visible tabs hydrate 300 ms later via `setTimeout`, preserving tab-label match counts and auto-switch (OK-52952). The `FadeIn` wrapper is dropped entirely.

## Test plan
- [ ] Desktop: Send flow, Select crypto → Select Address — transition is smooth, no visible frame drops.
- [ ] Web & extension: same flow, same check.
- [ ] iOS / Android: no regression; tab switching behavior unchanged.
- [ ] Search in the Recipient input — typing populates `(N)` counts on Account / AddressBook tabs within ~300 ms; auto-switch still jumps to a tab that has matches when the active one has none.
- [ ] Lightning network: only Recent tab visible, no extra mounts.
- [ ] BTC multi-derive: default tab still Accounts, derive-type selector in group header works after 300ms hydration.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
