### PR TITLE
fix(send): fan out parse-transaction per xpub for BTC merge-derive (OK-53370)

### DIFF
--- a/packages/kit-bg/src/services/ServiceSignatureConfirm.ts
+++ b/packages/kit-bg/src/services/ServiceSignatureConfirm.ts
@@ -269,15 +269,9 @@ class ServiceSignatureConfirm extends ServiceBase {
         encodedTx,
       });
 
-    // For BTC/LTC merge-derive accounts, one user-facing account spans
-    // multiple xpubs (Taproot / Native SegWit / ...). Pass all of them so
-    // the server can check interaction history across all derive types,
-    // not just the one the user happens to be sending from right now.
-    // Mirrors the fan-out in ServiceAccountProfile.checkAccountBadges.
-    // Fan out all derive-type xpubs for comprehensive interaction check.
-    // The server's parse-transaction API only accepts a single xpub per
-    // call, so we call it once per derive type and merge the results
-    // (same pattern as ServiceAccountProfile.fetchBadgesDeduped).
+    // For BTC/LTC merge-derive accounts, the server's parse-transaction
+    // API only accepts a single xpub per call. Call once per derive type
+    // and merge interaction results (same as fetchBadgesDeduped).
     let xpubs: string[] = [];
     try {
       const xpubEntries =
@@ -330,15 +324,21 @@ class ServiceSignatureConfirm extends ServiceBase {
     }
 
     // Multiple xpubs: call once per xpub, merge interaction results.
-    const results = await Promise.all(
-      xpubs.map((xpub) => callParseTransaction(xpub).catch(() => null)),
+    const settled = await Promise.allSettled(
+      xpubs.map((xpub) => callParseTransaction(xpub)),
     );
-    const validResults = results.filter((r): r is IParseTransactionResp => !!r);
+    const validResults = settled
+      .filter(
+        (r): r is PromiseFulfilledResult<IParseTransactionResp> =>
+          r.status === 'fulfilled',
+      )
+      .map((r) => r.value);
     if (validResults.length === 0) {
-      return callParseTransaction(xpubs[0]);
+      // All xpub-scoped calls failed; retry without xpub so the server
+      // still parses the tx from encodedTx alone.
+      return callParseTransaction(undefined);
     }
-    // Use the first result as base, but if any xpub shows interaction,
-    // mark as interacted (same merge logic as badges).
+    // Use the first result as base, merge interaction + risk across xpubs.
     const base = validResults[0];
     if (base.parsedTx?.to) {
       const anyInteracted = validResults.some(
@@ -346,6 +346,12 @@ class ServiceSignatureConfirm extends ServiceBase {
       );
       if (anyInteracted) {
         base.parsedTx.to.interacted = true;
+      }
+      const maxRiskLevel = Math.max(
+        ...validResults.map((r) => r.parsedTx?.to?.riskLevel ?? 0),
+      );
+      if (maxRiskLevel > (base.parsedTx.to.riskLevel ?? 0)) {
+        base.parsedTx.to.riskLevel = maxRiskLevel;
       }
     }
     return base;

--- a/packages/kit-bg/src/services/ServiceSignatureConfirm.ts
+++ b/packages/kit-bg/src/services/ServiceSignatureConfirm.ts
@@ -274,19 +274,11 @@ class ServiceSignatureConfirm extends ServiceBase {
     // the server can check interaction history across all derive types,
     // not just the one the user happens to be sending from right now.
     // Mirrors the fan-out in ServiceAccountProfile.checkAccountBadges.
-    let xpubs: string[] = [];
-    // The sending account's own xpub — directly from the known accountId.
-    let currentAccountXpub: string | undefined;
-    try {
-      currentAccountXpub =
-        (await this.backgroundApi.serviceAccount.getAccountXpub({
-          accountId,
-          networkId,
-        })) || undefined;
-    } catch {
-      // non-fatal
-    }
     // Fan out all derive-type xpubs for comprehensive interaction check.
+    // The server's parse-transaction API only accepts a single xpub per
+    // call, so we call it once per derive type and merge the results
+    // (same pattern as ServiceAccountProfile.fetchBadgesDeduped).
+    let xpubs: string[] = [];
     try {
       const xpubEntries =
         await this.backgroundApi.serviceAccount.safeGetAccountXpubsForAllDeriveTypes(
@@ -296,30 +288,67 @@ class ServiceSignatureConfirm extends ServiceBase {
     } catch {
       // non-fatal
     }
-    if (xpubs.length === 0 && currentAccountXpub) {
-      xpubs = [currentAccountXpub];
+    if (xpubs.length === 0) {
+      try {
+        const singleXpub =
+          (await this.backgroundApi.serviceAccount.getAccountXpub({
+            accountId,
+            networkId,
+          })) || undefined;
+        if (singleXpub) {
+          xpubs = [singleXpub];
+        }
+      } catch {
+        // non-fatal
+      }
     }
 
     const client = await this.backgroundApi.serviceGas.getClient(
       EServiceEndpointEnum.Wallet,
     );
-    const resp = await client.post<{ data: IParseTransactionResp }>(
-      '/wallet/v1/account/parse-transaction',
-      {
-        networkId,
-        accountAddress,
-        encodedTx: encodedTxToParse,
-        xpub: currentAccountXpub ?? xpubs[0],
-        xpubs,
-      },
-      {
-        headers:
-          await this.backgroundApi.serviceAccountProfile._getWalletTypeHeader({
-            accountId,
-          }),
-      },
+    const walletTypeHeaders =
+      await this.backgroundApi.serviceAccountProfile._getWalletTypeHeader({
+        accountId,
+      });
+
+    const callParseTransaction = async (xpub?: string) => {
+      const resp = await client.post<{ data: IParseTransactionResp }>(
+        '/wallet/v1/account/parse-transaction',
+        {
+          networkId,
+          accountAddress,
+          encodedTx: encodedTxToParse,
+          xpub,
+        },
+        { headers: walletTypeHeaders },
+      );
+      return resp.data.data;
+    };
+
+    if (xpubs.length <= 1) {
+      return callParseTransaction(xpubs[0]);
+    }
+
+    // Multiple xpubs: call once per xpub, merge interaction results.
+    const results = await Promise.all(
+      xpubs.map((xpub) => callParseTransaction(xpub).catch(() => null)),
     );
-    return resp.data.data;
+    const validResults = results.filter((r): r is IParseTransactionResp => !!r);
+    if (validResults.length === 0) {
+      return callParseTransaction(xpubs[0]);
+    }
+    // Use the first result as base, but if any xpub shows interaction,
+    // mark as interacted (same merge logic as badges).
+    const base = validResults[0];
+    if (base.parsedTx?.to) {
+      const anyInteracted = validResults.some(
+        (r) => r.parsedTx?.to?.interacted === true,
+      );
+      if (anyInteracted) {
+        base.parsedTx.to.interacted = true;
+      }
+    }
+    return base;
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceSignatureConfirm.ts
+++ b/packages/kit-bg/src/services/ServiceSignatureConfirm.ts
@@ -338,15 +338,10 @@ class ServiceSignatureConfirm extends ServiceBase {
       // still parses the tx from encodedTx alone.
       return callParseTransaction(undefined);
     }
-    // Use the first result as base, merge interaction + risk across xpubs.
+    // Use the first result as base, merge riskLevel across xpubs
+    // (take the highest risk seen from any derive path).
     const base = validResults[0];
     if (base.parsedTx?.to) {
-      const anyInteracted = validResults.some(
-        (r) => r.parsedTx?.to?.interacted === true,
-      );
-      if (anyInteracted) {
-        base.parsedTx.to.interacted = true;
-      }
       const maxRiskLevel = Math.max(
         ...validResults.map((r) => r.parsedTx?.to?.riskLevel ?? 0),
       );


### PR DESCRIPTION
## Summary

Follow-up to PR #11263. The server's `parse-transaction` API only accepts a single `xpub` per call — the `xpubs` array parameter was silently ignored.

### Before
Passed `xpubs` array in one call → server ignored it → interaction badge only checked against the first xpub.

### After
Call `parse-transaction` once per derive-type xpub, merge results — if any xpub shows prior interaction, mark address as `interacted: true`. Same fan-out pattern as the badges API in `ServiceAccountProfile.fetchBadgesDeduped`.

## Files

| File | Changes |
|---|---|
| `ServiceSignatureConfirm.ts` | Fan out parse-transaction per xpub, merge interaction results |

## Test plan

- [ ] BTC merge-derive: send from Taproot to address X, then switch to Native SegWit and send to X → confirm page shows "Transferred" (not "First Transfer")
- [ ] Non-BTC chains: single xpub, behavior unchanged
- [ ] Network tab: 4 parse-transaction calls for BTC (one per derive type)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
