### PR TITLE
chore(debug): add biology auth visibility logs for diagnosis

### DIFF
--- a/packages/kit-bg/src/services/ServicePassword/index.ts
+++ b/packages/kit-bg/src/services/ServicePassword/index.ts
@@ -386,6 +386,12 @@ export default class ServicePassword extends ServiceBase {
     enable: boolean,
     skipAuth?: boolean,
   ): Promise<void> {
+    // TODO(biologyAuth-debug): temporary log to diagnose biometric disappearing
+    defaultLogger.setting.page.biologyAuthDebug('setBiologyAuthEnable', {
+      enable,
+      skipAuth: !!skipAuth,
+      stack: new Error('trace').stack?.split('\n').slice(1, 6).join(' | '),
+    });
     if (enable && !skipAuth) {
       const authRes = await biologyAuth.biologyAuthenticate();
       if (!authRes.success) {

--- a/packages/kit/src/components/Password/components/PasswordVerify.tsx
+++ b/packages/kit/src/components/Password/components/PasswordVerify.tsx
@@ -27,6 +27,7 @@ import {
 import { usePasswordPersistManualLockStateAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import biologyAuth from '@onekeyhq/shared/src/biologyAuth';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { checkBiometricAuthChanged } from '@onekeyhq/shared/src/modules3rdParty/check-biometric-auth-changed';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
@@ -185,11 +186,22 @@ function PasswordVerify({
 
   const checkAuthChanged = useCallback(async () => {
     const isSupport = await biologyAuth.isSupportBiologyAuth();
+    // TODO(biologyAuth-debug): temporary log to diagnose iOS biometric disappearing
+    defaultLogger.setting.page.biologyAuthDebug('checkAuthChanged:start', {
+      platform: platformEnv.symbol,
+      isSupport,
+    });
     if (!isSupport) {
       return false;
     }
     try {
       const changed = await checkBiometricAuthChanged();
+      // TODO(biologyAuth-debug): temporary log — `changed: true` silently turns off
+      // isBiologyAuthSwitchOn, hiding the biometric button on lock screen.
+      defaultLogger.setting.page.biologyAuthDebug('checkAuthChanged:result', {
+        platform: platformEnv.symbol,
+        changed,
+      });
       if (changed) {
         await backgroundApiProxy.servicePassword.setBiologyAuthEnable(false);
         setTimeout(() => {

--- a/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
+++ b/packages/kit/src/components/Password/container/PasswordVerifyContainer.tsx
@@ -54,7 +54,8 @@ const PasswordVerifyContainer = ({
   pageMode,
 }: IPasswordVerifyProps) => {
   const intl = useIntl();
-  const [{ authType, isEnable }] = usePasswordBiologyAuthInfoAtom();
+  const [{ authType, isEnable, isSupport: biologyAuthIsSupport }] =
+    usePasswordBiologyAuthInfoAtom();
   const { verifiedPasswordWebAuth, checkWebAuth } = useWebAuthActions();
   const [{ webAuthCredentialId }] = usePasswordPersistAtom();
   const [{ isBiologyAuthSwitchOn }] = useSettingsPersistAtom();
@@ -164,6 +165,38 @@ const PasswordVerifyContainer = ({
       hasCachedPassword,
     ],
   );
+
+  // TODO(biologyAuth-debug): temporary log to diagnose biology auth visibility
+  useEffect(() => {
+    defaultLogger.setting.page.biologyAuthDebug('PasswordVerifyContainer', {
+      platform: platformEnv.symbol,
+      isLock,
+      pageMode: !!pageMode,
+      isExtLockAndNoCachePassword,
+      isBiologyAuthSwitchOn,
+      verifyPeriodBiologyEnable,
+      biologyAuthIsSupport,
+      biologyAuthIsEnable: isEnable,
+      authType,
+      hasSecurePassword,
+      hasCachedPassword,
+      hasWebAuthCredentialId: !!webAuthCredentialId,
+      isBiologyAuthEnable,
+    });
+  }, [
+    isLock,
+    pageMode,
+    isExtLockAndNoCachePassword,
+    isBiologyAuthSwitchOn,
+    verifyPeriodBiologyEnable,
+    biologyAuthIsSupport,
+    isEnable,
+    authType,
+    hasSecurePassword,
+    hasCachedPassword,
+    webAuthCredentialId,
+    isBiologyAuthEnable,
+  ]);
 
   const resetPasswordErrorAttempts = useCallback(() => {
     if (isLock && enablePasswordErrorProtection) {

--- a/packages/kit/src/views/Setting/pages/Tab/CustomElement.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/CustomElement.tsx
@@ -208,10 +208,31 @@ export function ThemeListItem(props: ICustomElementProps) {
 
 function SuspenseBiologyAuthListItem(props: ICustomElementProps) {
   const [{ isPasswordSet }] = usePasswordPersistAtom();
-  const [{ isSupport: biologyAuthIsSupport }] =
+  const [{ isSupport: biologyAuthIsSupport, authType, isEnable }] =
     usePasswordBiologyAuthInfoAtom();
   const [{ isSupport: webAuthIsSupport }] = usePasswordWebAuthInfoAtom();
-  return isPasswordSet && (biologyAuthIsSupport || webAuthIsSupport) ? (
+  const shouldRender =
+    isPasswordSet && (biologyAuthIsSupport || webAuthIsSupport);
+  // TODO(biologyAuth-debug): temporary log to diagnose biology auth visibility in Settings
+  useEffect(() => {
+    defaultLogger.setting.page.biologyAuthDebug('SuspenseBiologyAuthListItem', {
+      platform: platformEnv.symbol,
+      isPasswordSet,
+      biologyAuthIsSupport,
+      biologyAuthIsEnable: isEnable,
+      authType,
+      webAuthIsSupport,
+      shouldRender,
+    });
+  }, [
+    isPasswordSet,
+    biologyAuthIsSupport,
+    isEnable,
+    authType,
+    webAuthIsSupport,
+    shouldRender,
+  ]);
+  return shouldRender ? (
     <TabSettingsListItem {...props}>
       <UniversalContainerWithSuspense />
     </TabSettingsListItem>

--- a/packages/shared/src/logger/scopes/setting/scenes/page.ts
+++ b/packages/shared/src/logger/scopes/setting/scenes/page.ts
@@ -169,4 +169,10 @@ export class PageScene extends BaseScene {
   public settingsEnableBTCFreshAddress({ enabled }: { enabled: boolean }) {
     return { enabled };
   }
+
+  // TODO(biologyAuth-debug): temporary log to diagnose biology auth visibility
+  @LogToLocal({ level: 'info' })
+  public biologyAuthDebug(tag: string, state: Record<string, unknown>) {
+    return { tag, ...state };
+  }
 }


### PR DESCRIPTION
## Summary
- Temporary local-only logs to diagnose reports that the biometric/passkey button disappears after startup (Windows Hello on desktop, Face ID/Touch ID on iOS).
- Instruments 4 sites via a new `defaultLogger.setting.page.biologyAuthDebug(tag, state)` scene (`@LogToLocal` only, no server upload).
- All call sites tagged with `TODO(biologyAuth-debug)` for easy removal once the root cause is pinned.

## What gets logged
| Tag | Location | Purpose |
|---|---|---|
| `PasswordVerifyContainer` | lock screen | all inputs to `isBiologyAuthEnable` (`isBiologyAuthSwitchOn`, `verifyPeriodBiologyEnable`, `biologyAuthIsSupport`, `biologyAuthIsEnable`, `authType`, `hasSecurePassword`, `hasCachedPassword`, `webAuthCredentialId`, result) |
| `SuspenseBiologyAuthListItem` | Settings → Security row | `isPasswordSet`, `biologyAuthIsSupport`, `biologyAuthIsEnable`, `authType`, `webAuthIsSupport`, `shouldRender` |
| `checkAuthChanged:start` / `:result` | iOS/macOS only | detects when the system biometric changes silently flip `isBiologyAuthSwitchOn` off |
| `setBiologyAuthEnable` | background service | captures every caller of the toggle with a short stack trace |

## How to use
```bash
grep "biologyAuthDebug" app-latest.log
```
Compare the snapshot before/after the user's triggering action (e.g. modifying auto-lock duration, backgrounding/foregrounding the app) — whichever field flips from `false` → `true` (or vice versa) is the root cause.

## Test plan
- [ ] Build desktop dev → open, confirm `PasswordVerifyContainer` log appears on lock screen
- [ ] Visit Settings → Security on desktop, confirm `SuspenseBiologyAuthListItem` log
- [ ] Build iOS dev → background/foreground the app, confirm `checkAuthChanged:start/:result` logs
- [ ] Toggle Windows Hello / Face ID switch, confirm `setBiologyAuthEnable` log includes stack
- [ ] Verify no `@LogToServer` leakage (logs only land in local log file)
- [ ] Revert/remove once root cause is identified (grep `TODO(biologyAuth-debug)`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
