### PR TITLE
fix(home): hide risk approval banner for watch-only accounts (OK-53476)

### DIFF
--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -21,7 +21,10 @@ import {
 import type { ITabBarItemProps } from '@onekeyhq/components/src/composite/Tabs/TabBar';
 import { TabBarItem } from '@onekeyhq/components/src/composite/Tabs/TabBar';
 import { getNetworksSupportBulkRevokeApproval } from '@onekeyhq/shared/src/config/presetNetworks';
-import { WALLET_TYPE_HD } from '@onekeyhq/shared/src/consts/dbConsts';
+import {
+  WALLET_TYPE_HD,
+  WALLET_TYPE_WATCHING,
+} from '@onekeyhq/shared/src/consts/dbConsts';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -247,6 +250,10 @@ export function HomePageView({
   }, [wallet]);
 
   const isBulkRevokeApprovalEnabled = useMemo(() => {
+    if (wallet?.type === WALLET_TYPE_WATCHING) {
+      return false;
+    }
+
     if (network?.isAllNetworks) {
       if (
         accountUtils.isOthersAccount({
@@ -262,6 +269,7 @@ export function HomePageView({
 
     return networksSupportBulkRevokeApproval[network?.id ?? ''] ?? false;
   }, [
+    wallet?.type,
     network?.isAllNetworks,
     network?.id,
     account?.id,


### PR DESCRIPTION
## Summary

Watch-only accounts cannot sign transactions, so they have no way to revoke approvals — yet the wallet home still shows the "N risky approvals" banner, and only blocks the user once they try to revoke on the approval list page. That's one wasted navigation.

This PR short-circuits `isBulkRevokeApprovalEnabled` in `HomePageView` on the watching wallet type, which both hides `RiskApprovalAlert` and skips the unnecessary `fetchAccountApprovals` request. Behavior now matches how `ApprovalList` already handles watch-only wallets.

Jira: [OK-53476](https://onekeyhq.atlassian.net/browse/OK-53476)

## Test plan

- [ ] Open the home page with a Watch account — confirm the risk approval banner does not appear and no `fetchAccountApprovals` request is sent
- [ ] Open the home page with HD / Imported / Hardware accounts — confirm banner and request behavior are unchanged

[OK-53476]: https://onekeyhq.atlassian.net/browse/OK-53476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ