### PR TITLE
fix: pass origin to parse transaction request(OK-53490)

### DIFF
--- a/packages/kit-bg/src/services/ServiceSignatureConfirm.ts
+++ b/packages/kit-bg/src/services/ServiceSignatureConfirm.ts
@@ -250,7 +250,7 @@ class ServiceSignatureConfirm extends ServiceBase {
 
   @backgroundMethod()
   async parseTransaction(params: IParseTransactionParams) {
-    const { accountId, networkId, encodedTx } = params;
+    const { accountId, networkId, encodedTx, origin } = params;
     const vault = await vaultFactory.getVault({
       networkId,
       accountId,
@@ -313,6 +313,7 @@ class ServiceSignatureConfirm extends ServiceBase {
           accountAddress,
           encodedTx: encodedTxToParse,
           xpub,
+          origin,
         },
         { headers: walletTypeHeaders },
       );


### PR DESCRIPTION
## Summary
- pass `origin` through `ServiceSignatureConfirm.parseTransaction()` to the wallet `parse-transaction` API request
- preserve the dapp/site context for both single-xpub and multi-xpub parse flows

## Intent & Context
This change fixes transaction parsing requests triggered from signature confirmation so backend risk analysis and display logic still receive the requesting dapp origin. The task is tracked under OK-53490.

## Root Cause
`buildDecodedTx()` already forwarded `sourceInfo.origin` into `ServiceSignatureConfirm.parseTransaction()`, but the service method dropped that field when building the `/wallet/v1/account/parse-transaction` request body. As a result, backend parsing lost the original dapp context.

## Design Decisions
Propagate `origin` at the service boundary instead of changing caller behavior, because the caller already had the right context. The fix is kept inside the existing request helper so both the normal single-xpub path and the per-xpub fallback path send the same payload shape.

## Changes Detail
`packages/kit-bg/src/services/ServiceSignatureConfirm.ts`: include `origin` when destructuring parse params and forward it in each wallet parse-transaction API request.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: transaction parsing payloads for signature confirmation requests

## Test plan
- [ ] Trigger a dapp signature-confirm transaction and verify the parse-transaction request payload includes the originating site URL
- [ ] Confirm parsed transaction display and risk checks still work for a normal single-account flow
- [ ] Confirm BTC/LTC merge-derive parsing still succeeds when the service fans out parse requests per xpub
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
