### PR TITLE
feat(discovery): add intelligent search result ranking algorithm(OK-53425)

### DIFF
--- a/development/spellCheckerSkipWords.txt
+++ b/development/spellCheckerSkipWords.txt
@@ -1441,3 +1441,4 @@ ellipsize
 minimizable
 maximizable
 fullscreenable
+frecency

--- a/packages/kit-bg/src/services/ServiceDiscovery.test.ts
+++ b/packages/kit-bg/src/services/ServiceDiscovery.test.ts
@@ -1,0 +1,69 @@
+/* eslint-disable import/first */
+
+jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
+  backgroundClass: () => (target: unknown) => target,
+  backgroundMethod:
+    () =>
+    (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+  backgroundMethodForDev:
+    () =>
+    (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+}));
+
+jest.mock('react-native-webview-cleaner', () => ({
+  __esModule: true,
+  default: {
+    clearAll: jest.fn(),
+  },
+}));
+
+jest.mock('@onekeyhq/shared/src/utils/imageUtils', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+import ServiceDiscovery from './ServiceDiscovery';
+
+describe('ServiceDiscovery', () => {
+  it('drops stored bookmark logos when icons are disabled', async () => {
+    const buildWebsiteIconUrl = jest.fn();
+    const service = {
+      backgroundApi: {
+        simpleDb: {
+          browserBookmarks: {
+            getRawData: jest.fn().mockResolvedValue({
+              data: [
+                {
+                  title: 'OneKey',
+                  url: 'https://onekey.so',
+                  logo: 'data:image/png;base64,abc',
+                  sortIndex: 0,
+                },
+              ],
+            }),
+          },
+        },
+      },
+      buildWebsiteIconUrl,
+    } as unknown as ServiceDiscovery;
+
+    const result = await ServiceDiscovery.prototype.getBookmarkData.call(
+      service,
+      {
+        generateIcon: false,
+      },
+    );
+
+    expect(result).toEqual([
+      {
+        title: 'OneKey',
+        url: 'https://onekey.so',
+        logo: undefined,
+        sortIndex: 0,
+      },
+    ]);
+    expect(buildWebsiteIconUrl).not.toHaveBeenCalled();
+  });
+});

--- a/packages/kit-bg/src/services/ServiceDiscovery.ts
+++ b/packages/kit-bg/src/services/ServiceDiscovery.ts
@@ -266,13 +266,22 @@ class ServiceDiscovery extends ServiceBase {
       | {
           generateIcon?: boolean;
           sliceCount?: number;
+          keyword?: string;
         }
       | undefined,
   ): Promise<IBrowserBookmark[]> {
-    const { generateIcon, sliceCount } = options ?? {};
+    const { generateIcon, sliceCount, keyword } = options ?? {};
     const data =
       await this.backgroundApi.simpleDb.browserBookmarks.getRawData();
     let dataSource = data?.data ?? [];
+    if (keyword) {
+      const fuse = buildFuse(dataSource, { keys: ['title', 'url'] });
+      dataSource = fuse.search(keyword).map((i) => ({
+        ...i.item,
+        titleMatch: i.matches?.find((v) => v.key === 'title'),
+        urlMatch: i.matches?.find((v) => v.key === 'url'),
+      }));
+    }
     if (isNumber(sliceCount)) {
       dataSource = dataSource.slice(0, sliceCount);
     }
@@ -332,7 +341,7 @@ class ServiceDiscovery extends ServiceBase {
     let dataSource: IBrowserHistory[] = data?.data ?? [];
     if (keyword) {
       const fuse = buildFuse(dataSource, { keys: ['title', 'url'] });
-      dataSource = fuse.search(options?.keyword ?? 'uniswap').map((i) => ({
+      dataSource = fuse.search(keyword).map((i) => ({
         ...i.item,
         titleMatch: i.matches?.find((v) => v.key === 'title'),
         urlMatch: i.matches?.find((v) => v.key === 'url'),

--- a/packages/kit-bg/src/services/ServiceFreshAddress.ts
+++ b/packages/kit-bg/src/services/ServiceFreshAddress.ts
@@ -500,6 +500,7 @@ class ServiceFreshAddress extends ServiceBase {
       maxAge: timerUtils.getTimeDurationMs({ seconds: 10 }),
     },
   );
+
   // Return all searchable fresh addresses for a list of BTC accounts.
   // Consolidates derive-type-aware xpub key selection and fresh address
   // extraction that was previously inlined in RecipientQuickSelect UI.

--- a/packages/kit/src/views/Discovery/components/SearchResultContent.tsx
+++ b/packages/kit/src/views/Discovery/components/SearchResultContent.tsx
@@ -26,7 +26,6 @@ import {
   EDiscoveryModalRoutes,
   EModalRoutes,
 } from '@onekeyhq/shared/src/routes';
-import type { IDApp } from '@onekeyhq/shared/types/discovery';
 
 import { useWebSiteHandler } from '../hooks/useWebSiteHandler';
 import { DappSearchModalSectionHeader } from '../pages/SearchModal/DappSearchModalSectionHeader';
@@ -34,6 +33,7 @@ import { DappSearchModalSectionHeader } from '../pages/SearchModal/DappSearchMod
 import { DiscoveryIcon } from './DiscoveryIcon';
 
 import type { ILocalDataType } from '../hooks/useSearchModalData';
+import type { IDiscoverySearchListItem } from '../utils/searchResultRanking';
 
 const LoadingSkeleton = (
   <Image.Loading>
@@ -48,16 +48,14 @@ export interface ISearchResultContentRef {
 interface ISearchResultContentProps {
   searchValue: string;
   localData: ILocalDataType | null;
-  searchList: IDApp[];
+  searchList: IDiscoverySearchListItem[];
   displaySearchList: boolean;
   displayBookmarkList: boolean;
   displayHistoryList: boolean;
   SEARCH_ITEM_ID: string;
   useCurrentWindow?: boolean;
   tabId?: string;
-  onItemClick?: (
-    item: IDApp | { url: string; title: string; logo?: string },
-  ) => void;
+  onItemClick?: (item: { url: string; title: string; logo?: string }) => void;
   selectedIndex?: number;
   innerRef?: React.RefObject<ISearchResultContentRef>;
 }
@@ -195,42 +193,6 @@ export function SearchResultContent({
     historyCount,
   ]);
 
-  // Handlers for different types of items
-  const handleSearchItemClick = useCallback(
-    (item: IDApp) => {
-      onItemClick?.(item);
-
-      if (item.dappId === SEARCH_ITEM_ID) {
-        handleWebSite({
-          webSite: {
-            url: searchValue,
-            title: searchValue,
-            logo: undefined,
-            sortIndex: undefined,
-          },
-          useCurrentWindow,
-          tabId,
-          enterMethod: EEnterMethod.search,
-        });
-      } else {
-        handleWebSite({
-          dApp: item,
-          useCurrentWindow,
-          tabId,
-          enterMethod: EEnterMethod.search,
-        });
-      }
-    },
-    [
-      SEARCH_ITEM_ID,
-      handleWebSite,
-      onItemClick,
-      searchValue,
-      tabId,
-      useCurrentWindow,
-    ],
-  );
-
   const handleBookmarkItemClick = useCallback(
     (item: { url: string; title: string; logo?: string }) => {
       onItemClick?.(item);
@@ -269,12 +231,68 @@ export function SearchResultContent({
     [handleWebSite, onItemClick, tabId, useCurrentWindow],
   );
 
+  // Handlers for different types of items
+  const handleSearchItemClick = useCallback(
+    (item: IDiscoverySearchListItem) => {
+      if (item.type === 'bookmark') {
+        handleBookmarkItemClick(item.bookmark);
+        return;
+      }
+      if (item.type === 'history') {
+        handleHistoryItemClick(item.history);
+        return;
+      }
+
+      if (item.type === 'search-action') {
+        onItemClick?.({
+          url: searchValue,
+          title: searchValue,
+          logo: undefined,
+        });
+        handleWebSite({
+          webSite: {
+            url: searchValue,
+            title: searchValue,
+            logo: undefined,
+            sortIndex: undefined,
+          },
+          useCurrentWindow,
+          tabId,
+          enterMethod: EEnterMethod.search,
+        });
+        return;
+      }
+
+      onItemClick?.({
+        url: item.dapp.url,
+        title: item.dapp.name,
+        logo: item.dapp.logo,
+      });
+      handleWebSite({
+        dApp: item.dapp,
+        useCurrentWindow,
+        tabId,
+        enterMethod: EEnterMethod.search,
+      });
+    },
+    [
+      handleBookmarkItemClick,
+      handleHistoryItemClick,
+      handleWebSite,
+      onItemClick,
+      searchValue,
+      tabId,
+      useCurrentWindow,
+    ],
+  );
+
   const openSelectedItem = useCallback(() => {
     // Priority: Check if first item is exact URL match when no item is manually selected
     try {
       if (
         displaySearchList &&
         searchList.length > 0 &&
+        searchList[0].type === 'dapp' &&
         searchList[0].isExactUrl &&
         selectedIndex === -1
       ) {
@@ -320,13 +338,11 @@ export function SearchResultContent({
 
     if (searchValue) {
       handleSearchItemClick({
-        dappId: SEARCH_ITEM_ID,
-        name: searchValue,
-        logo: '',
-        description: '',
+        type: 'search-action',
+        key: SEARCH_ITEM_ID,
+        title: searchValue,
         url: searchValue,
-        networkIds: [],
-        tags: [],
+        logo: '',
       });
       return { type: 'search' };
     }
@@ -360,10 +376,10 @@ export function SearchResultContent({
   );
 
   const renderList = useCallback(
-    (list: IDApp[]) =>
+    (list: IDiscoverySearchListItem[]) =>
       list.map((item, index) => (
         <ListItem
-          key={index}
+          key={item.key}
           // @ts-expect-error
           ref={
             ((el: any) => {
@@ -371,7 +387,8 @@ export function SearchResultContent({
             }) as any
           }
           avatarProps={{
-            src: item.logo || item.originLogo,
+            src:
+              item.type === 'dapp' ? item.logo || item.originLogo : item.logo,
             loading: LoadingSkeleton,
             bg: '$bgStrong',
             fallbackProps: {
@@ -383,27 +400,44 @@ export function SearchResultContent({
             borderWidth: StyleSheet.hairlineWidth,
             borderColor: '$borderSubdued',
           }}
-          renderItemText={() => (
-            <RichSizeableText
-              linkList={{ a: { url: undefined, cursor: 'auto' } }}
-              numberOfLines={1}
-              size="$bodyLgMedium"
-              flex={1}
-            >
-              {item?.keyword
-                ? item.name.replace(
-                    new RegExp(
-                      item.keyword.replace(/[[\]()+?*^$.|\\{}]/g, '\\$&'),
-                      'ig',
-                    ),
-                    (match) => `<a>${match}</a>`,
-                  )
-                : item.name}
-            </RichSizeableText>
-          )}
-          subtitleProps={{
-            numberOfLines: 1,
-          }}
+          {...(item.type === 'dapp'
+            ? {
+                renderItemText: () => (
+                  <RichSizeableText
+                    linkList={{ a: { url: undefined, cursor: 'auto' } }}
+                    numberOfLines={1}
+                    size="$bodyLgMedium"
+                    flex={1}
+                  >
+                    {item.keyword
+                      ? item.title.replace(
+                          new RegExp(
+                            item.keyword.replace(/[[\]()+?*^$.|\\{}]/g, '\\$&'),
+                            'ig',
+                          ),
+                          (match) => `<a>${match}</a>`,
+                        )
+                      : item.title}
+                  </RichSizeableText>
+                ),
+                subtitleProps: {
+                  numberOfLines: 1,
+                },
+              }
+            : {
+                title: item.title,
+                titleMatch:
+                  item.type === 'search-action' ? undefined : item.titleMatch,
+                titleProps: {
+                  numberOfLines: 1,
+                },
+                subtitle: item.type === 'search-action' ? undefined : item.url,
+                subTitleMatch:
+                  item.type === 'search-action' ? undefined : item.urlMatch,
+                subtitleProps: {
+                  numberOfLines: 1,
+                },
+              })}
           bg={searchIndex(index) ? '$bgActive' : undefined}
           onPress={() => handleSearchItemClick(item)}
           testID={`dapp-search${index}`}

--- a/packages/kit/src/views/Discovery/hooks/useSearchModalData.test.tsx
+++ b/packages/kit/src/views/Discovery/hooks/useSearchModalData.test.tsx
@@ -198,4 +198,183 @@ describe('useSearchModalData', () => {
       sliceCount: DISCOVERY_LOCAL_SEARCH_CANDIDATE_LIMIT,
     });
   });
+
+  it('skips remote search for queries shorter than three characters when review control is enabled', async () => {
+    reviewControlMock.mockReturnValue(true);
+
+    const { result } = renderHook(() => useSearchModalData('un'));
+
+    await waitFor(() => {
+      expect(
+        serviceDiscoveryMock.fetchDiscoveryHomePageData,
+      ).toHaveBeenCalled();
+      // Short queries still keep locally matched trending results and the
+      // trailing search-action row; only remote DApp search is skipped.
+      expect(result.current.searchList).toHaveLength(2);
+    });
+
+    expect(serviceDiscoveryMock.searchDApp).not.toHaveBeenCalled();
+    expect(result.current.searchList).toEqual([
+      expect.objectContaining({
+        type: 'dapp',
+        source: 'trending',
+        url: 'https://app.uniswap.org',
+      }),
+      expect.objectContaining({
+        type: 'search-action',
+      }),
+    ]);
+  });
+
+  it('requests remote search for queries with length three when review control is enabled', async () => {
+    reviewControlMock.mockReturnValue(true);
+    serviceDiscoveryMock.getBookmarkData.mockImplementation(
+      async (options?: {
+        generateIcon?: boolean;
+        keyword?: string;
+        sliceCount?: number;
+      }) => {
+        if (options?.keyword === 'ast') {
+          return [
+            {
+              title: '74,419.1 | BTCUSDT | Trade | Aster',
+              url: 'https://www.asterdex.com/en/trade/pro/futures/BTCUSDT',
+              logo: '',
+              sortIndex: 0,
+            },
+          ];
+        }
+        return [];
+      },
+    );
+    serviceDiscoveryMock.fetchDiscoveryHomePageData.mockResolvedValue({
+      trending: [],
+    });
+    serviceDiscoveryMock.searchDApp.mockResolvedValue([
+      {
+        dappId: '93ba2378-b2c4-47c8-b05e-b80d8cfd4375',
+        name: 'Aster',
+        url: 'https://www.asterdex.com',
+        origins: ['defillama', 'tp'],
+        logo: '',
+        description: '',
+        networkIds: [],
+        tags: [],
+      },
+    ]);
+
+    const { result } = renderHook(() => useSearchModalData('ast'));
+
+    await waitFor(() => {
+      expect(serviceDiscoveryMock.searchDApp).toHaveBeenCalledWith('ast');
+      expect(result.current.searchList).toEqual([
+        expect.objectContaining({
+          type: 'bookmark',
+          title: '74,419.1 | BTCUSDT | Trade | Aster',
+        }),
+        expect.objectContaining({
+          type: 'dapp',
+          source: 'remote',
+          title: 'Aster',
+        }),
+        expect.objectContaining({
+          type: 'search-action',
+        }),
+      ]);
+    });
+  });
+
+  it('prioritizes near-complete dapp name prefixes ahead of local items', async () => {
+    reviewControlMock.mockReturnValue(true);
+    serviceDiscoveryMock.getBookmarkData.mockImplementation(
+      async (options?: {
+        generateIcon?: boolean;
+        keyword?: string;
+        sliceCount?: number;
+      }) => {
+        if (options?.keyword === 'aste') {
+          return [
+            {
+              title: '74,419.1 | BTCUSDT | Trade | Aster',
+              url: 'https://www.asterdex.com/en/trade/pro/futures/BTCUSDT',
+              logo: '',
+              sortIndex: 0,
+            },
+          ];
+        }
+        return [];
+      },
+    );
+    serviceDiscoveryMock.fetchDiscoveryHomePageData.mockResolvedValue({
+      trending: [],
+    });
+    serviceDiscoveryMock.searchDApp.mockResolvedValue([
+      {
+        dappId: '93ba2378-b2c4-47c8-b05e-b80d8cfd4375',
+        name: 'Aster',
+        url: 'https://www.asterdex.com',
+        origins: ['defillama', 'tp'],
+        logo: '',
+        description: '',
+        networkIds: [],
+        tags: [],
+      },
+    ]);
+
+    const { result } = renderHook(() => useSearchModalData('aste'));
+
+    await waitFor(() => {
+      expect(serviceDiscoveryMock.searchDApp).toHaveBeenCalledWith('aste');
+      expect(result.current.searchList).toEqual([
+        expect.objectContaining({
+          type: 'dapp',
+          source: 'remote',
+          title: 'Aster',
+        }),
+        expect.objectContaining({
+          type: 'bookmark',
+          title: '74,419.1 | BTCUSDT | Trade | Aster',
+        }),
+        expect.objectContaining({
+          type: 'search-action',
+        }),
+      ]);
+    });
+  });
+
+  it('requests remote search for queries longer than three characters when review control is enabled', async () => {
+    reviewControlMock.mockReturnValue(true);
+
+    const { result } = renderHook(() => useSearchModalData('uniswap'));
+
+    await waitFor(() => {
+      expect(
+        serviceDiscoveryMock.fetchDiscoveryHomePageData,
+      ).toHaveBeenCalled();
+      expect(serviceDiscoveryMock.searchDApp).toHaveBeenCalledWith('uniswap');
+    });
+
+    expect(result.current.searchList).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'search-action',
+        }),
+      ]),
+    );
+  });
+
+  it('returns an empty search list for empty query', async () => {
+    reviewControlMock.mockReturnValue(true);
+
+    const { result } = renderHook(() => useSearchModalData(''));
+
+    await waitFor(() => {
+      expect(serviceDiscoveryMock.getBookmarkData).toHaveBeenCalled();
+      expect(serviceDiscoveryMock.getHistoryData).toHaveBeenCalled();
+    });
+
+    expect(serviceDiscoveryMock.searchDApp).not.toHaveBeenCalled();
+    expect(result.current.searchList).toEqual([]);
+    expect(result.current.displaySearchList).toBe(false);
+  });
 });

--- a/packages/kit/src/views/Discovery/hooks/useSearchModalData.test.tsx
+++ b/packages/kit/src/views/Discovery/hooks/useSearchModalData.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/first */
+
+jest.mock('react-intl', () => ({
+  useIntl: () => ({
+    formatMessage: ({ id }: { id: string }) => id,
+  }),
+}));
+
+jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
+  __esModule: true,
+  default: {
+    isNative: false,
+    isDesktop: false,
+    isWeb: true,
+    isRuntimeBrowser: true,
+    isRuntimeChrome: false,
+  },
+}));
+
+jest.mock('@onekeyhq/kit/src/hooks/useRouteIsFocused', () => ({
+  useRouteIsFocused: () => true,
+}));
+
+jest.mock('@onekeyhq/components', () => {
+  const deferredPromiseModule = require('../../../../../components/src/hooks/useDeferredPromise');
+  const netInfoModule = require('../../../../../components/src/hooks/useNetInfo');
+
+  return {
+    __esModule: true,
+    getCurrentVisibilityState: () => true,
+    onVisibilityStateChange: () => () => {},
+    useDeferredPromise: deferredPromiseModule.useDeferredPromise,
+    useNetInfo: netInfoModule.useNetInfo,
+  };
+});
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => {
+  const serviceDiscovery = {
+    getBookmarkData: jest.fn(),
+    getHistoryData: jest.fn(),
+    fetchDiscoveryHomePageData: jest.fn(),
+    searchDApp: jest.fn(),
+  };
+
+  (globalThis as any).__useSearchModalDataMock = {
+    serviceDiscovery,
+  };
+
+  return {
+    __esModule: true,
+    default: {
+      serviceDiscovery,
+    },
+  };
+});
+
+jest.mock('../../../components/ReviewControl', () => ({
+  useReviewControl: jest.fn(),
+}));
+
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useReviewControl } from '../../../components/ReviewControl';
+import { DISCOVERY_LOCAL_SEARCH_CANDIDATE_LIMIT } from '../utils/searchResultRanking';
+
+import { useSearchModalData } from './useSearchModalData';
+
+const reviewControlMock = jest.mocked(useReviewControl);
+const serviceDiscoveryMock = (globalThis as any).__useSearchModalDataMock
+  .serviceDiscovery as {
+  getBookmarkData: jest.Mock;
+  getHistoryData: jest.Mock;
+  fetchDiscoveryHomePageData: jest.Mock;
+  searchDApp: jest.Mock;
+};
+
+describe('useSearchModalData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    reviewControlMock.mockReturnValue(false);
+    serviceDiscoveryMock.getBookmarkData.mockResolvedValue([]);
+    serviceDiscoveryMock.getHistoryData.mockResolvedValue([]);
+    serviceDiscoveryMock.fetchDiscoveryHomePageData.mockResolvedValue({
+      trending: [
+        {
+          dappId: 'uniswap',
+          name: 'Uniswap',
+          url: 'https://app.uniswap.org',
+          logo: '',
+          description: '',
+          networkIds: [],
+          tags: [],
+        },
+      ],
+    });
+    serviceDiscoveryMock.searchDApp.mockResolvedValue([
+      {
+        dappId: 'remote-uniswap',
+        name: 'Remote Uniswap',
+        url: 'https://app.uniswap.org',
+        logo: '',
+        description: '',
+        networkIds: [],
+        tags: [],
+      },
+    ]);
+  });
+
+  it('does not fetch or show trending suggestions when review control is disabled', async () => {
+    const { result } = renderHook(() => useSearchModalData('uni'));
+
+    await waitFor(() => {
+      expect(serviceDiscoveryMock.getBookmarkData).toHaveBeenCalled();
+      expect(serviceDiscoveryMock.getHistoryData).toHaveBeenCalled();
+    });
+
+    expect(
+      serviceDiscoveryMock.fetchDiscoveryHomePageData,
+    ).not.toHaveBeenCalled();
+    expect(serviceDiscoveryMock.searchDApp).not.toHaveBeenCalled();
+    expect(serviceDiscoveryMock.getHistoryData).toHaveBeenCalledWith({
+      generateIcon: false,
+      sliceCount: 200,
+    });
+    expect(result.current.searchList).toEqual([
+      expect.objectContaining({
+        type: 'search-action',
+      }),
+    ]);
+  });
+
+  it('keeps enough local candidates for chrome-like re-ranking before returning search results', async () => {
+    const strongBookmark = {
+      title: 'Portfolio',
+      url: 'https://app.uniswap.org/swap',
+      logo: '',
+      sortIndex: 6,
+    };
+    const weakBookmarks = Array.from({ length: 6 }, (_, index) => ({
+      title: `App unit tests ${index + 1}`,
+      url: `https://example.com/posts/${index + 1}`,
+      logo: '',
+      sortIndex: index,
+    }));
+
+    serviceDiscoveryMock.getBookmarkData.mockImplementation(
+      async (options?: {
+        generateIcon?: boolean;
+        keyword?: string;
+        sliceCount?: number;
+      }) => {
+        if (options?.keyword === 'app.uni') {
+          const items = [...weakBookmarks, strongBookmark];
+          return items.slice(0, options.sliceCount ?? items.length);
+        }
+        return [];
+      },
+    );
+    serviceDiscoveryMock.getHistoryData.mockImplementation(
+      async (options?: {
+        generateIcon?: boolean;
+        keyword?: string;
+        sliceCount?: number;
+      }) => {
+        if (options?.generateIcon === false) {
+          return [];
+        }
+        if (options?.keyword === 'app.uni') {
+          return [];
+        }
+        return [];
+      },
+    );
+
+    const { result } = renderHook(() => useSearchModalData('app.uni'));
+
+    await waitFor(() => {
+      expect(result.current.searchList[0]).toEqual(
+        expect.objectContaining({
+          type: 'bookmark',
+          url: strongBookmark.url,
+        }),
+      );
+    });
+
+    expect(serviceDiscoveryMock.getBookmarkData).toHaveBeenCalledWith({
+      generateIcon: true,
+      keyword: 'app.uni',
+      sliceCount: DISCOVERY_LOCAL_SEARCH_CANDIDATE_LIMIT,
+    });
+    expect(serviceDiscoveryMock.getHistoryData).toHaveBeenCalledWith({
+      generateIcon: true,
+      keyword: 'app.uni',
+      sliceCount: DISCOVERY_LOCAL_SEARCH_CANDIDATE_LIMIT,
+    });
+  });
+});

--- a/packages/kit/src/views/Discovery/hooks/useSearchModalData.test.tsx
+++ b/packages/kit/src/views/Discovery/hooks/useSearchModalData.test.tsx
@@ -342,6 +342,44 @@ describe('useSearchModalData', () => {
     });
   });
 
+  it('keeps remote search enabled for long url queries when review control is enabled', async () => {
+    reviewControlMock.mockReturnValue(true);
+    serviceDiscoveryMock.fetchDiscoveryHomePageData.mockResolvedValue({
+      trending: [],
+    });
+    serviceDiscoveryMock.searchDApp.mockResolvedValue([
+      {
+        dappId: 'remote-uniswap-exact',
+        name: 'Remote Uniswap Exact',
+        url: 'https://app.uniswap.org',
+        isExactUrl: true,
+        logo: '',
+        description: '',
+        networkIds: [],
+        tags: [],
+      },
+    ]);
+    const longUrl =
+      'https://app.uniswap.org/swap?inputCurrency=ETH&outputCurrency=USDC&chain=ethereum';
+
+    const { result } = renderHook(() => useSearchModalData(longUrl));
+
+    await waitFor(() => {
+      expect(serviceDiscoveryMock.searchDApp).toHaveBeenCalledWith(longUrl);
+      expect(result.current.searchList).toEqual([
+        expect.objectContaining({
+          type: 'dapp',
+          source: 'remote',
+          title: 'Remote Uniswap Exact',
+          isExactUrl: true,
+        }),
+        expect.objectContaining({
+          type: 'search-action',
+        }),
+      ]);
+    });
+  });
+
   it('requests remote search for queries longer than three characters when review control is enabled', async () => {
     reviewControlMock.mockReturnValue(true);
 

--- a/packages/kit/src/views/Discovery/hooks/useSearchModalData.ts
+++ b/packages/kit/src/views/Discovery/hooks/useSearchModalData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -9,92 +9,187 @@ import {
   SEARCH_ITEM_ID,
 } from '@onekeyhq/shared/src/consts/discovery';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import type { IFuseResultMatch } from '@onekeyhq/shared/src/modules3rdParty/fuse';
 import type { IDApp } from '@onekeyhq/shared/types/discovery';
 
 import { useReviewControl } from '../../../components/ReviewControl';
+import {
+  DISCOVERY_LOCAL_SEARCH_CANDIDATE_LIMIT,
+  DISCOVERY_RANKING_HISTORY_LIMIT,
+  type IDiscoverySearchListItem,
+  mergeSearchResultsWithLocalData,
+  searchTrendingDappsByKeyword,
+  shouldSkipRemoteSearchByKeyword,
+} from '../utils/searchResultRanking';
+
+import type { IBrowserBookmark, IBrowserHistory } from '../types';
 
 export interface ILocalDataType {
-  bookmarkData: Array<{
-    url: string;
-    title: string;
-    logo?: string;
-  }>;
-  historyData: Array<{
-    url: string;
-    title: string;
-    logo?: string;
-    titleMatch?: IFuseResultMatch;
-    urlMatch?: IFuseResultMatch;
-  }>;
+  bookmarkData: IBrowserBookmark[];
+  historyData: IBrowserHistory[];
 }
 
 export function useSearchModalData(searchValue: string) {
   const intl = useIntl();
   const { serviceDiscovery } = backgroundApiProxy;
-  const [searchList, setSearchList] = useState<IDApp[]>([]);
+  const showSearchResult = useReviewControl();
 
-  // Get bookmark and history data
-  const { result: localData, run: refreshLocalData } =
+  const { result: localData, run: refreshDisplayLocalData } =
     usePromiseResult<ILocalDataType | null>(async () => {
-      const bookmarkData = await serviceDiscovery.getBookmarkData({
-        generateIcon: true,
-        sliceCount: 6,
-      });
-      const historyData = await serviceDiscovery.getHistoryData({
-        generateIcon: true,
-        sliceCount: 6,
-        keyword: searchValue ?? undefined,
-      });
+      const [bookmarkData, historyData] = await Promise.all([
+        serviceDiscovery.getBookmarkData({
+          generateIcon: true,
+          sliceCount: 6,
+        }),
+        serviceDiscovery.getHistoryData({
+          generateIcon: true,
+          sliceCount: 6,
+        }),
+      ]);
       return {
         bookmarkData,
         historyData,
       };
-    }, [serviceDiscovery, searchValue]);
+    }, [serviceDiscovery]);
 
-  const showSearchResult = useReviewControl();
+  const { result: localSearchData, run: refreshLocalSearchData } =
+    usePromiseResult<ILocalDataType>(
+      async () => {
+        if (!searchValue) {
+          return {
+            bookmarkData: [],
+            historyData: [],
+          };
+        }
+        const [bookmarkData, historyData] = await Promise.all([
+          serviceDiscovery.getBookmarkData({
+            generateIcon: true,
+            keyword: searchValue,
+            sliceCount: DISCOVERY_LOCAL_SEARCH_CANDIDATE_LIMIT,
+          }),
+          serviceDiscovery.getHistoryData({
+            generateIcon: true,
+            keyword: searchValue,
+            sliceCount: DISCOVERY_LOCAL_SEARCH_CANDIDATE_LIMIT,
+          }),
+        ]);
+        return {
+          bookmarkData,
+          historyData,
+        };
+      },
+      [serviceDiscovery, searchValue],
+      {
+        initResult: {
+          bookmarkData: [],
+          historyData: [],
+        },
+      },
+    );
+
+  const { result: rankingHistoryData, run: refreshRankingHistoryData } =
+    usePromiseResult(
+      () =>
+        serviceDiscovery.getHistoryData({
+          generateIcon: false,
+          sliceCount: DISCOVERY_RANKING_HISTORY_LIMIT,
+        }),
+      [serviceDiscovery],
+    );
+
+  const { result: trendingData, run: refreshTrendingData } = usePromiseResult(
+    async (): Promise<IDApp[]> => {
+      if (!showSearchResult) {
+        return [];
+      }
+      return (
+        (await serviceDiscovery.fetchDiscoveryHomePageData())?.trending ?? []
+      );
+    },
+    [serviceDiscovery, showSearchResult],
+    {
+      initResult: [],
+    },
+  );
+
+  const refreshLocalData = useCallback(async () => {
+    await Promise.all([
+      refreshDisplayLocalData(),
+      refreshLocalSearchData(),
+      refreshRankingHistoryData(),
+      refreshTrendingData(),
+    ]);
+  }, [
+    refreshDisplayLocalData,
+    refreshLocalSearchData,
+    refreshRankingHistoryData,
+    refreshTrendingData,
+  ]);
+
+  const shouldSkipRemoteSearch = useMemo(
+    () => shouldSkipRemoteSearchByKeyword(searchValue),
+    [searchValue],
+  );
 
   // Search for DApps
   const { result: searchResult } = usePromiseResult(async () => {
-    if (!showSearchResult) {
-      return [] as IDApp[];
+    if (!showSearchResult || shouldSkipRemoteSearch) {
+      return [];
     }
     const res = await serviceDiscovery.searchDApp(searchValue);
     return res;
-  }, [searchValue, serviceDiscovery, showSearchResult]);
+  }, [searchValue, serviceDiscovery, showSearchResult, shouldSkipRemoteSearch]);
 
-  // Process search results
-  useEffect(() => {
-    void (async () => {
-      if (!searchValue) {
-        setSearchList([]);
-        return;
-      }
+  const trendingSearchData = useMemo(() => {
+    if (!showSearchResult) {
+      return [];
+    }
+    return searchTrendingDappsByKeyword({
+      keyword: searchValue,
+      trendingData,
+    });
+  }, [searchValue, showSearchResult, trendingData]);
 
-      const exactUrlResults =
-        searchResult?.filter((item) => item.isExactUrl) || [];
-      const otherResults =
-        searchResult?.filter((item) => !item.isExactUrl) || [];
-      setSearchList([
-        ...exactUrlResults,
-        ...otherResults,
-        {
-          dappId: SEARCH_ITEM_ID,
-          name: `${intl.formatMessage({
-            id: ETranslations.explore_search_placeholder,
-          })} "${searchValue}"`,
-          url: '',
-          logo: GOOGLE_LOGO_URL,
-        } as IDApp,
-      ]);
-    })();
-  }, [searchValue, searchResult, intl]);
+  const searchList = useMemo<IDiscoverySearchListItem[]>(() => {
+    if (!searchValue) {
+      return [];
+    }
+
+    return [
+      ...mergeSearchResultsWithLocalData({
+        keyword: searchValue,
+        searchResult,
+        rankingHistoryData,
+        bookmarkSearchData: localSearchData.bookmarkData,
+        historySearchData: localSearchData.historyData,
+        trendingSearchData,
+      }),
+      {
+        type: 'search-action',
+        key: SEARCH_ITEM_ID,
+        title: `${intl.formatMessage({
+          id: ETranslations.explore_search_placeholder,
+        })} "${searchValue}"`,
+        url: '',
+        logo: GOOGLE_LOGO_URL,
+      },
+    ];
+  }, [
+    searchValue,
+    searchResult,
+    rankingHistoryData,
+    localSearchData.bookmarkData,
+    localSearchData.historyData,
+    trendingSearchData,
+    intl,
+  ]);
 
   // Determine what to display
-  const displaySearchList = Array.isArray(searchList) && searchList.length > 0;
+  const displaySearchList =
+    Boolean(searchValue) && Array.isArray(searchList) && searchList.length > 0;
   const displayBookmarkList =
-    (localData?.bookmarkData ?? []).length > 0 && !displaySearchList;
-  const displayHistoryList = (localData?.historyData ?? []).length > 0;
+    !searchValue && (localData?.bookmarkData ?? []).length > 0;
+  const displayHistoryList =
+    !searchValue && (localData?.historyData ?? []).length > 0;
 
   // Calculate total items
   const totalItems = useMemo(() => {

--- a/packages/kit/src/views/Discovery/types.ts
+++ b/packages/kit/src/views/Discovery/types.ts
@@ -18,6 +18,8 @@ export interface IBrowserBookmark {
   url: string;
   logo: string | undefined;
   sortIndex: number | undefined;
+  titleMatch?: IFuseResultMatch;
+  urlMatch?: IFuseResultMatch;
 }
 
 export interface IBrowserRiskWhiteList {

--- a/packages/kit/src/views/Discovery/utils/searchResultRanking.test.ts
+++ b/packages/kit/src/views/Discovery/utils/searchResultRanking.test.ts
@@ -1,0 +1,522 @@
+import type { IDApp } from '@onekeyhq/shared/types/discovery';
+
+import {
+  mergeSearchResultsWithLocalData,
+  rankSearchResultsChromeLike,
+  searchTrendingDappsByKeyword,
+  shouldSkipRemoteSearchByKeyword,
+} from './searchResultRanking';
+
+import type { IBrowserBookmark, IBrowserHistory } from '../types';
+
+function createDApp({
+  dappId,
+  name,
+  url,
+  origins,
+  isExactUrl,
+}: {
+  dappId: string;
+  name?: string;
+  url: string;
+  origins?: string[];
+  isExactUrl?: boolean;
+}): IDApp {
+  return {
+    dappId,
+    name: name ?? dappId,
+    url,
+    origins,
+    isExactUrl,
+    logo: '',
+    description: '',
+    networkIds: [],
+    tags: [],
+  };
+}
+
+function createHistory({
+  id,
+  title,
+  url,
+  createdAt,
+}: {
+  id: string;
+  title?: string;
+  url: string;
+  createdAt: number;
+}): IBrowserHistory {
+  return {
+    id,
+    title: title ?? id,
+    url,
+    createdAt,
+  };
+}
+
+function createBookmark({
+  title,
+  url,
+}: {
+  title: string;
+  url: string;
+}): IBrowserBookmark {
+  return {
+    title,
+    url,
+    logo: '',
+    sortIndex: 0,
+  };
+}
+
+describe('searchResultRanking', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-04-20T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('uses frecency to move visited dapps ahead within the same topicality bucket', () => {
+    const result = rankSearchResultsChromeLike({
+      keyword: 'swap',
+      searchResult: [
+        createDApp({
+          dappId: 'alpha',
+          name: 'Alpha Swap',
+          url: 'https://alpha.example',
+        }),
+        createDApp({
+          dappId: 'beta',
+          name: 'Beta Swap',
+          url: 'https://beta.example',
+        }),
+      ],
+      rankingHistoryData: [
+        createHistory({
+          id: 'history-beta',
+          url: 'https://beta.example/trade',
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+        }),
+      ],
+    });
+
+    expect(result.map((item) => item.dappId)).toEqual(['beta', 'alpha']);
+  });
+
+  it('keeps stronger topicality ahead of weaker but more frequent matches', () => {
+    const result = rankSearchResultsChromeLike({
+      keyword: 'uni',
+      searchResult: [
+        createDApp({
+          dappId: 'strong',
+          name: 'Uniswap',
+          url: 'https://app.uniswap.org',
+        }),
+        createDApp({
+          dappId: 'weak',
+          name: 'Community Portal',
+          url: 'https://weak.example/universe',
+        }),
+      ],
+      rankingHistoryData: Array.from({ length: 10 }, (_, index) =>
+        createHistory({
+          id: `history-weak-${index}`,
+          url: `https://weak.example/page-${index}`,
+          createdAt: Date.now() - index * 60 * 60 * 1000,
+        }),
+      ),
+    });
+
+    expect(result.map((item) => item.dappId)).toEqual(['strong', 'weak']);
+  });
+
+  it('keeps original order when candidates share topicality and frecency', () => {
+    const result = rankSearchResultsChromeLike({
+      keyword: 'swap',
+      searchResult: [
+        createDApp({
+          dappId: 'first',
+          name: 'First Swap',
+          url: 'https://first.example',
+        }),
+        createDApp({
+          dappId: 'second',
+          name: 'Second Swap',
+          url: 'https://second.example',
+        }),
+      ],
+      rankingHistoryData: [],
+    });
+
+    expect(result.map((item) => item.dappId)).toEqual(['first', 'second']);
+  });
+
+  it('matches dapps through alternate origins', () => {
+    const result = rankSearchResultsChromeLike({
+      keyword: 'llama',
+      searchResult: [
+        createDApp({ dappId: 'paraswap', url: 'https://www.paraswap.io' }),
+        createDApp({
+          dappId: 'llama',
+          name: 'DefiLlama',
+          url: 'https://defillama.com',
+          origins: ['https://llama.fi'],
+        }),
+      ],
+      rankingHistoryData: [
+        createHistory({
+          id: 'history-llama',
+          url: 'https://llama.fi/protocols',
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+        }),
+      ],
+    });
+
+    expect(result.map((item) => item.dappId)).toEqual(['llama', 'paraswap']);
+  });
+
+  it('keeps exact url matches ahead of chrome-like ranked results', () => {
+    const result = rankSearchResultsChromeLike({
+      keyword: 'https://exact.example',
+      searchResult: [
+        createDApp({
+          dappId: 'visited',
+          name: 'Visited App',
+          url: 'https://visited.example',
+        }),
+        createDApp({
+          dappId: 'exact',
+          name: 'Exact App',
+          url: 'https://exact.example',
+          isExactUrl: true,
+        }),
+      ],
+      rankingHistoryData: [
+        createHistory({
+          id: 'history-visited',
+          url: 'https://visited.example/path',
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+        }),
+      ],
+    });
+
+    expect(result.map((item) => item.dappId)).toEqual(['exact', 'visited']);
+  });
+
+  it('ranks local host matches ahead of weaker title-only matches before merging remote results', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'app.uni',
+      searchResult: [
+        createDApp({
+          dappId: 'remote',
+          name: 'Remote App Uni',
+          url: 'https://remote.example',
+        }),
+      ],
+      rankingHistoryData: [
+        createHistory({
+          id: 'history-local',
+          url: 'https://example.com/posts/1',
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+        }),
+      ],
+      bookmarkSearchData: [
+        createBookmark({
+          title: 'Portfolio',
+          url: 'https://app.uniswap.org/swap',
+        }),
+      ],
+      historySearchData: [
+        createHistory({
+          id: 'history-title-match',
+          title: 'App unit tests',
+          url: 'https://example.com/posts/1',
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+        }),
+      ],
+    });
+
+    expect(
+      result.map((item) => ({
+        type: item.type,
+        url: item.url,
+      })),
+    ).toEqual([
+      {
+        type: 'bookmark',
+        url: 'https://app.uniswap.org/swap',
+      },
+      {
+        type: 'history',
+        url: 'https://example.com/posts/1',
+      },
+      {
+        type: 'dapp',
+        url: 'https://remote.example',
+      },
+    ]);
+  });
+
+  it('keeps exact url results ahead of local fused items', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'swap',
+      searchResult: [
+        createDApp({
+          dappId: 'exact',
+          name: 'Exact App',
+          url: 'https://exact.example',
+          isExactUrl: true,
+        }),
+        createDApp({
+          dappId: 'remote',
+          name: 'Remote Swap',
+          url: 'https://remote.example',
+        }),
+      ],
+      rankingHistoryData: [],
+      bookmarkSearchData: [
+        createBookmark({
+          title: 'Bookmark Swap',
+          url: 'https://bookmark.example',
+        }),
+      ],
+      historySearchData: [
+        createHistory({
+          id: 'history-1',
+          title: 'History Swap',
+          url: 'https://history.example/path',
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+        }),
+      ],
+    });
+
+    expect(
+      result.map((item) => ({
+        type: item.type,
+        url: item.url,
+      })),
+    ).toEqual([
+      {
+        type: 'dapp',
+        url: 'https://exact.example',
+      },
+      {
+        type: 'bookmark',
+        url: 'https://bookmark.example',
+      },
+      {
+        type: 'history',
+        url: 'https://history.example/path',
+      },
+      {
+        type: 'dapp',
+        url: 'https://remote.example',
+      },
+    ]);
+  });
+
+  it('applies source priority as bookmark then history then trending then remote', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'swap',
+      searchResult: [
+        createDApp({
+          dappId: 'remote',
+          name: 'Remote Swap',
+          url: 'https://remote.example',
+        }),
+      ],
+      rankingHistoryData: [],
+      bookmarkSearchData: [
+        createBookmark({
+          title: 'Bookmark Swap',
+          url: 'https://bookmark.example',
+        }),
+      ],
+      historySearchData: [
+        createHistory({
+          id: 'history-1',
+          title: 'History Swap',
+          url: 'https://history.example/path',
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+        }),
+      ],
+      trendingSearchData: [
+        createDApp({
+          dappId: 'trending',
+          name: 'Trending Swap',
+          url: 'https://trending.example',
+        }),
+      ],
+    });
+
+    expect(
+      result.map((item) => ({
+        type: item.type,
+        url: item.url,
+      })),
+    ).toEqual([
+      {
+        type: 'bookmark',
+        url: 'https://bookmark.example',
+      },
+      {
+        type: 'history',
+        url: 'https://history.example/path',
+      },
+      {
+        type: 'dapp',
+        url: 'https://trending.example',
+      },
+      {
+        type: 'dapp',
+        url: 'https://remote.example',
+      },
+    ]);
+  });
+
+  it('dedupes trending ahead of remote when they share the same origin', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'swap',
+      searchResult: [
+        createDApp({
+          dappId: 'remote',
+          name: 'Remote Swap',
+          url: 'https://app.uniswap.org',
+        }),
+      ],
+      rankingHistoryData: [],
+      bookmarkSearchData: [],
+      historySearchData: [],
+      trendingSearchData: [
+        createDApp({
+          dappId: 'trending',
+          name: 'Trending Swap',
+          url: 'https://app.uniswap.org/swap',
+        }),
+      ],
+    });
+
+    expect(
+      result.map((item) => ({
+        type: item.type,
+        url: item.url,
+      })),
+    ).toEqual([
+      {
+        type: 'dapp',
+        url: 'https://app.uniswap.org/swap',
+      },
+    ]);
+  });
+
+  it('keeps distinct local matches from the same origin', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'swap',
+      searchResult: [
+        createDApp({
+          dappId: 'remote',
+          name: 'Remote Swap',
+          url: 'https://app.uniswap.org',
+        }),
+      ],
+      rankingHistoryData: [],
+      bookmarkSearchData: [
+        createBookmark({
+          title: 'Swap',
+          url: 'https://app.uniswap.org/swap',
+        }),
+      ],
+      historySearchData: [
+        createHistory({
+          id: 'history-pool',
+          title: 'Pool Swap',
+          url: 'https://app.uniswap.org/pool',
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+        }),
+      ],
+      trendingSearchData: [
+        createDApp({
+          dappId: 'trending',
+          name: 'Trending Swap',
+          url: 'https://app.uniswap.org/explore',
+        }),
+      ],
+    });
+
+    expect(
+      result.map((item) => ({
+        type: item.type,
+        url: item.url,
+      })),
+    ).toEqual([
+      {
+        type: 'bookmark',
+        url: 'https://app.uniswap.org/swap',
+      },
+      {
+        type: 'history',
+        url: 'https://app.uniswap.org/pool',
+      },
+    ]);
+  });
+
+  it('dedupes identical local urls across bookmark and history', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'swap',
+      searchResult: [],
+      rankingHistoryData: [],
+      bookmarkSearchData: [
+        createBookmark({
+          title: 'Swap',
+          url: 'https://app.uniswap.org/swap',
+        }),
+      ],
+      historySearchData: [
+        createHistory({
+          id: 'history-swap',
+          title: 'Swap',
+          url: 'https://app.uniswap.org/swap',
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+        }),
+      ],
+    });
+
+    expect(
+      result.map((item) => ({
+        type: item.type,
+        url: item.url,
+      })),
+    ).toEqual([
+      {
+        type: 'bookmark',
+        url: 'https://app.uniswap.org/swap',
+      },
+    ]);
+  });
+
+  it('searches trending dapps locally by keyword', () => {
+    const result = searchTrendingDappsByKeyword({
+      keyword: 'uni',
+      trendingData: [
+        createDApp({ dappId: 'uniswap', url: 'https://app.uniswap.org' }),
+        createDApp({ dappId: 'aave', url: 'https://app.aave.com' }),
+      ],
+    });
+
+    expect(result.map((item) => item.dappId)).toEqual(['uniswap']);
+  });
+
+  it('skips remote search for queries with length up to three', () => {
+    expect(shouldSkipRemoteSearchByKeyword('a')).toBe(true);
+    expect(shouldSkipRemoteSearchByKeyword('ab')).toBe(true);
+    expect(shouldSkipRemoteSearchByKeyword(' Ab ')).toBe(true);
+    expect(shouldSkipRemoteSearchByKeyword('abc')).toBe(true);
+    expect(shouldSkipRemoteSearchByKeyword('abcd')).toBe(false);
+    expect(shouldSkipRemoteSearchByKeyword('a1')).toBe(true);
+    expect(shouldSkipRemoteSearchByKeyword('你我')).toBe(true);
+    expect(shouldSkipRemoteSearchByKeyword('okx')).toBe(true);
+    expect(shouldSkipRemoteSearchByKeyword('okxx')).toBe(false);
+  });
+});

--- a/packages/kit/src/views/Discovery/utils/searchResultRanking.test.ts
+++ b/packages/kit/src/views/Discovery/utils/searchResultRanking.test.ts
@@ -1025,7 +1025,308 @@ describe('searchResultRanking', () => {
     expect(result.map((item) => item.dappId)).toEqual(['uniswap']);
   });
 
-  it('skips remote search only for queries shorter than three characters', () => {
+  it('returns all local items without scoring when keyword is empty', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: '',
+      searchResult: [
+        createDApp({ dappId: 'dapp', url: 'https://example.com' }),
+      ],
+      rankingHistoryData: [],
+      bookmarkSearchData: [
+        createBookmark({ title: 'Bookmark', url: 'https://bookmark.example' }),
+      ],
+      historySearchData: [
+        createHistory({
+          id: 'history-1',
+          title: 'History',
+          url: 'https://history.example',
+          createdAt: Date.now(),
+        }),
+      ],
+    });
+
+    expect(result.map((item) => item.type)).toEqual([
+      'bookmark',
+      'history',
+      'dapp',
+    ]);
+  });
+
+  it('handles special regex characters in keyword without errors', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'test(.*)+?[]',
+      searchResult: [],
+      rankingHistoryData: [],
+      bookmarkSearchData: [
+        createBookmark({
+          title: 'Test (.*)+?[] Page',
+          url: 'https://example.com',
+        }),
+      ],
+      historySearchData: [],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('bookmark');
+  });
+
+  it('ranks recent visits ahead of older ones following time decay buckets', () => {
+    const now = Date.now();
+    const DAY = 24 * 60 * 60 * 1000;
+
+    const result = rankSearchResultsChromeLike({
+      keyword: 'swap',
+      searchResult: [
+        createDApp({
+          dappId: 'day-400',
+          name: 'Swap 400',
+          url: 'https://400.example',
+        }),
+        createDApp({
+          dappId: 'day-100',
+          name: 'Swap 100',
+          url: 'https://100.example',
+        }),
+        createDApp({
+          dappId: 'day-50',
+          name: 'Swap 50',
+          url: 'https://50.example',
+        }),
+        createDApp({
+          dappId: 'day-20',
+          name: 'Swap 20',
+          url: 'https://20.example',
+        }),
+        createDApp({
+          dappId: 'day-10',
+          name: 'Swap 10',
+          url: 'https://10.example',
+        }),
+        createDApp({
+          dappId: 'day-2',
+          name: 'Swap 2',
+          url: 'https://2.example',
+        }),
+      ],
+      rankingHistoryData: [
+        createHistory({
+          id: 'h-400',
+          url: 'https://400.example',
+          createdAt: now - 400 * DAY,
+        }),
+        createHistory({
+          id: 'h-100',
+          url: 'https://100.example',
+          createdAt: now - 100 * DAY,
+        }),
+        createHistory({
+          id: 'h-50',
+          url: 'https://50.example',
+          createdAt: now - 50 * DAY,
+        }),
+        createHistory({
+          id: 'h-20',
+          url: 'https://20.example',
+          createdAt: now - 20 * DAY,
+        }),
+        createHistory({
+          id: 'h-10',
+          url: 'https://10.example',
+          createdAt: now - 10 * DAY,
+        }),
+        createHistory({
+          id: 'h-2',
+          url: 'https://2.example',
+          createdAt: now - 2 * DAY,
+        }),
+      ],
+    });
+
+    expect(result.map((item) => item.dappId)).toEqual([
+      'day-2',
+      'day-10',
+      'day-20',
+      'day-50',
+      'day-100',
+      'day-400',
+    ]);
+  });
+
+  it('treats ccTLD domains as same site across subdomains', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'bbc',
+      searchResult: [
+        createDApp({
+          dappId: 'bbc-dapp',
+          name: 'BBC News',
+          url: 'https://www.bbc.co.uk',
+        }),
+      ],
+      rankingHistoryData: [],
+      bookmarkSearchData: [
+        createBookmark({
+          title: 'BBC Sport',
+          url: 'https://sport.bbc.co.uk/football',
+        }),
+        createBookmark({
+          title: 'BBC Weather',
+          url: 'https://weather.bbc.co.uk',
+        }),
+      ],
+      historySearchData: [],
+    });
+
+    expect(
+      result.map((item) => ({
+        type: item.type,
+        title: item.title,
+      })),
+    ).toEqual([
+      { type: 'dapp', title: 'BBC News' },
+      { type: 'bookmark', title: 'BBC Sport' },
+      { type: 'bookmark', title: 'BBC Weather' },
+    ]);
+  });
+
+  it('treats com.cn domains as same site with ccTLD logic', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'taobao',
+      searchResult: [
+        createDApp({
+          dappId: 'taobao-dapp',
+          name: 'Taobao',
+          url: 'https://www.taobao.com.cn',
+        }),
+      ],
+      rankingHistoryData: [],
+      bookmarkSearchData: [
+        createBookmark({
+          title: 'Taobao Mobile',
+          url: 'https://m.taobao.com.cn/page',
+        }),
+        createBookmark({
+          title: 'Taobao App',
+          url: 'https://app.taobao.com.cn',
+        }),
+      ],
+      historySearchData: [],
+    });
+
+    expect(
+      result.map((item) => ({
+        type: item.type,
+        title: item.title,
+      })),
+    ).toEqual([
+      { type: 'dapp', title: 'Taobao' },
+      { type: 'bookmark', title: 'Taobao Mobile' },
+      { type: 'bookmark', title: 'Taobao App' },
+    ]);
+  });
+
+  it('dedupes IP address URLs by origin like regular hostnames', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'local',
+      searchResult: [
+        createDApp({
+          dappId: 'local-dapp',
+          name: 'Local Server',
+          url: 'http://192.168.1.1:8080',
+        }),
+      ],
+      rankingHistoryData: [],
+      bookmarkSearchData: [
+        createBookmark({
+          title: 'Local Admin',
+          url: 'http://192.168.1.1:8080/admin',
+        }),
+      ],
+      historySearchData: [],
+    });
+
+    expect(
+      result.map((item) => ({
+        type: item.type,
+        title: item.title,
+      })),
+    ).toEqual([
+      { type: 'bookmark', title: 'Local Admin' },
+      { type: 'dapp', title: 'Local Server' },
+    ]);
+  });
+
+  it('treats visits at decay boundary days with expected scores', () => {
+    const now = Date.now();
+    const DAY = 24 * 60 * 60 * 1000;
+
+    const result = rankSearchResultsChromeLike({
+      keyword: 'swap',
+      searchResult: [
+        createDApp({
+          dappId: 'day-4',
+          name: 'Swap 4',
+          url: 'https://4.example',
+        }),
+        createDApp({
+          dappId: 'day-14',
+          name: 'Swap 14',
+          url: 'https://14.example',
+        }),
+        createDApp({
+          dappId: 'day-31',
+          name: 'Swap 31',
+          url: 'https://31.example',
+        }),
+        createDApp({
+          dappId: 'day-90',
+          name: 'Swap 90',
+          url: 'https://90.example',
+        }),
+        createDApp({
+          dappId: 'day-365',
+          name: 'Swap 365',
+          url: 'https://365.example',
+        }),
+      ],
+      rankingHistoryData: [
+        createHistory({
+          id: 'h-4',
+          url: 'https://4.example',
+          createdAt: now - 4 * DAY,
+        }),
+        createHistory({
+          id: 'h-14',
+          url: 'https://14.example',
+          createdAt: now - 14 * DAY,
+        }),
+        createHistory({
+          id: 'h-31',
+          url: 'https://31.example',
+          createdAt: now - 31 * DAY,
+        }),
+        createHistory({
+          id: 'h-90',
+          url: 'https://90.example',
+          createdAt: now - 90 * DAY,
+        }),
+        createHistory({
+          id: 'h-365',
+          url: 'https://365.example',
+          createdAt: now - 365 * DAY,
+        }),
+      ],
+    });
+
+    expect(result.map((item) => item.dappId)).toEqual([
+      'day-4',
+      'day-14',
+      'day-31',
+      'day-90',
+      'day-365',
+    ]);
+  });
+
+  it('skips remote search for short queries and overlong non-url queries', () => {
     expect(shouldSkipRemoteSearchByKeyword('a')).toBe(true);
     expect(shouldSkipRemoteSearchByKeyword('ab')).toBe(true);
     expect(shouldSkipRemoteSearchByKeyword(' Ab ')).toBe(true);
@@ -1035,5 +1336,21 @@ describe('searchResultRanking', () => {
     expect(shouldSkipRemoteSearchByKeyword('你我')).toBe(true);
     expect(shouldSkipRemoteSearchByKeyword('okx')).toBe(false);
     expect(shouldSkipRemoteSearchByKeyword('okxx')).toBe(false);
+    expect(shouldSkipRemoteSearchByKeyword('a'.repeat(64))).toBe(false);
+    expect(shouldSkipRemoteSearchByKeyword('a'.repeat(65))).toBe(true);
+    expect(shouldSkipRemoteSearchByKeyword(`  ${'a'.repeat(64)}  `)).toBe(
+      false,
+    );
+    expect(shouldSkipRemoteSearchByKeyword('a'.repeat(200))).toBe(true);
+    expect(
+      shouldSkipRemoteSearchByKeyword(
+        'https://app.uniswap.org/swap?inputCurrency=ETH&outputCurrency=USDC&chain=ethereum',
+      ),
+    ).toBe(false);
+    expect(
+      shouldSkipRemoteSearchByKeyword(
+        'app.uniswap.org/swap?inputCurrency=ETH&outputCurrency=USDC&chain=ethereum',
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/kit/src/views/Discovery/utils/searchResultRanking.test.ts
+++ b/packages/kit/src/views/Discovery/utils/searchResultRanking.test.ts
@@ -15,12 +15,16 @@ function createDApp({
   url,
   origins,
   isExactUrl,
+  keyword,
+  tags,
 }: {
   dappId: string;
   name?: string;
   url: string;
   origins?: string[];
   isExactUrl?: boolean;
+  keyword?: string;
+  tags?: IDApp['tags'];
 }): IDApp {
   return {
     dappId,
@@ -28,10 +32,11 @@ function createDApp({
     url,
     origins,
     isExactUrl,
+    keyword,
     logo: '',
     description: '',
     networkIds: [],
-    tags: [],
+    tags: tags ?? [],
   };
 }
 
@@ -68,6 +73,33 @@ function createBookmark({
     sortIndex: 0,
   };
 }
+
+const REAL_DISCOVERY_DAPPS = {
+  aave: createDApp({
+    dappId: 'f1346f86-ff4b-489c-9dc0-98362f8eab95',
+    name: 'AAVE',
+    url: 'https://app.aave.com/',
+    origins: ['okx', 'bitget', 'defillama', 'tp', 'dappradar'],
+  }),
+  uniswap: createDApp({
+    dappId: 'e7642615-0d2c-496a-9d9e-2042f1623447',
+    name: 'Uniswap',
+    url: 'https://uniswap.org',
+    origins: ['okx', 'bitget', 'defillama', 'tp', 'dappradar'],
+  }),
+  pendle: createDApp({
+    dappId: 'e193d6d2-c919-4e6e-8c31-2d7208706037',
+    name: 'Pendle',
+    url: 'https://pendle.finance/',
+    origins: ['okx', 'defillama', 'tp', 'dappradar'],
+  }),
+  aster: createDApp({
+    dappId: '93ba2378-b2c4-47c8-b05e-b80d8cfd4375',
+    name: 'Aster',
+    url: 'https://www.asterdex.com',
+    origins: ['defillama', 'tp'],
+  }),
+};
 
 describe('searchResultRanking', () => {
   beforeEach(() => {
@@ -130,6 +162,62 @@ describe('searchResultRanking', () => {
     });
 
     expect(result.map((item) => item.dappId)).toEqual(['strong', 'weak']);
+  });
+
+  it('uses dapp keyword matches in chrome-like ranking', () => {
+    const result = rankSearchResultsChromeLike({
+      keyword: 'dex',
+      searchResult: [
+        createDApp({
+          dappId: 'keyword-match',
+          name: 'Aggregator',
+          url: 'https://keyword.example',
+          keyword: 'dex',
+        }),
+        createDApp({
+          dappId: 'name-substring',
+          name: 'Indexer',
+          url: 'https://name.example',
+        }),
+      ],
+      rankingHistoryData: [],
+    });
+
+    expect(result.map((item) => item.dappId)).toEqual([
+      'keyword-match',
+      'name-substring',
+    ]);
+  });
+
+  it('uses dapp tag matches in chrome-like ranking', () => {
+    const result = rankSearchResultsChromeLike({
+      keyword: 'social',
+      searchResult: [
+        createDApp({
+          dappId: 'tag-match',
+          name: 'Community Hub',
+          url: 'https://tag.example',
+          tags: [
+            {
+              tagId: 'social',
+              name: 'social',
+              type: 'category',
+            },
+          ],
+        }),
+        createDApp({
+          dappId: 'name-substring',
+          name: 'Unsocialized',
+          url: 'https://name.example',
+        }),
+      ],
+      rankingHistoryData: [],
+    });
+
+    expect(result.map((item) => item.dappId)).toEqual([
+      'tag-match',
+      'name-substring',
+    ]);
   });
 
   it('keeps original order when candidates share topicality and frecency', () => {
@@ -205,6 +293,52 @@ describe('searchResultRanking', () => {
     expect(result.map((item) => item.dappId)).toEqual(['exact', 'visited']);
   });
 
+  it('normalizes protocol, www prefix, and trailing slash for exact url matching', () => {
+    const result = rankSearchResultsChromeLike({
+      keyword: 'app.uniswap.org/swap',
+      searchResult: [
+        createDApp({
+          dappId: 'normalized-exact',
+          url: 'https://www.app.uniswap.org/swap/',
+          isExactUrl: true,
+        }),
+        createDApp({
+          dappId: 'other',
+          url: 'https://app.uniswap.org/pool',
+        }),
+      ],
+      rankingHistoryData: [],
+    });
+
+    expect(result.map((item) => item.dappId)).toEqual([
+      'normalized-exact',
+      'other',
+    ]);
+  });
+
+  it('normalizes protocol and www prefix for host-level matching', () => {
+    const result = rankSearchResultsChromeLike({
+      keyword: 'app.uni',
+      searchResult: [
+        createDApp({
+          dappId: 'host-prefix',
+          url: 'https://www.app.uniswap.org/swap',
+        }),
+        createDApp({
+          dappId: 'weaker',
+          name: 'Application unit',
+          url: 'https://example.com/path',
+        }),
+      ],
+      rankingHistoryData: [],
+    });
+
+    expect(result.map((item) => item.dappId)).toEqual([
+      'host-prefix',
+      'weaker',
+    ]);
+  });
+
   it('ranks local host matches ahead of weaker title-only matches before merging remote results', () => {
     const result = mergeSearchResultsWithLocalData({
       keyword: 'app.uni',
@@ -257,6 +391,308 @@ describe('searchResultRanking', () => {
         url: 'https://remote.example',
       },
     ]);
+  });
+
+  it('prioritizes exact dapp name matches ahead while deduping same-url local items', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'pendle',
+      searchResult: [REAL_DISCOVERY_DAPPS.pendle],
+      rankingHistoryData: [],
+      bookmarkSearchData: [
+        createBookmark({
+          title: 'Pendle - Liberating Yield',
+          url: 'https://pendle.finance/',
+        }),
+      ],
+      historySearchData: [
+        createHistory({
+          id: 'pendle-history',
+          title: 'Pendle V2 - Fixed Yield & Yield Trading',
+          url: 'https://pendle.finance/pendle',
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+        }),
+      ],
+    });
+
+    expect(
+      result.map((item) => ({
+        type: item.type,
+        title: item.title,
+      })),
+    ).toEqual([
+      {
+        type: 'dapp',
+        title: 'Pendle',
+      },
+      {
+        type: 'history',
+        title: 'Pendle V2 - Fixed Yield & Yield Trading',
+      },
+    ]);
+  });
+
+  it('prioritizes dapps with multiple same-origin local matches for shorter queries', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'ast',
+      searchResult: [REAL_DISCOVERY_DAPPS.aster],
+      rankingHistoryData: [],
+      bookmarkSearchData: [
+        createBookmark({
+          title: '74,419.1 | BTCUSDT | Trade | Aster',
+          url: 'https://www.asterdex.com/en/trade/pro/futures/BTCUSDT',
+        }),
+      ],
+      historySearchData: [
+        createHistory({
+          id: 'aster-history',
+          title: 'Aster Spot',
+          url: 'https://www.asterdex.com/en/trade/spot/BTCUSDT',
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+        }),
+      ],
+    });
+
+    expect(
+      result.map((item) => ({
+        type: item.type,
+        title: item.title,
+      })),
+    ).toEqual([
+      {
+        type: 'dapp',
+        title: 'Aster',
+      },
+      {
+        type: 'bookmark',
+        title: '74,419.1 | BTCUSDT | Trade | Aster',
+      },
+      {
+        type: 'history',
+        title: 'Aster Spot',
+      },
+    ]);
+  });
+
+  it('prioritizes near-complete dapp name prefixes ahead of local items', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'aste',
+      searchResult: [REAL_DISCOVERY_DAPPS.aster],
+      rankingHistoryData: [],
+      bookmarkSearchData: [
+        createBookmark({
+          title: '74,419.1 | BTCUSDT | Trade | Aster',
+          url: 'https://www.asterdex.com/en/trade/pro/futures/BTCUSDT',
+        }),
+      ],
+      historySearchData: [],
+    });
+
+    expect(
+      result.map((item) => ({
+        type: item.type,
+        title: item.title,
+      })),
+    ).toEqual([
+      {
+        type: 'dapp',
+        title: 'Aster',
+      },
+      {
+        type: 'bookmark',
+        title: '74,419.1 | BTCUSDT | Trade | Aster',
+      },
+    ]);
+  });
+
+  it('keeps shorter dapp matches behind local items when same-origin support is weak', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'ast',
+      searchResult: [REAL_DISCOVERY_DAPPS.aster],
+      rankingHistoryData: [],
+      bookmarkSearchData: [
+        createBookmark({
+          title: 'Astrolabe Notes',
+          url: 'https://notes.example/ast',
+        }),
+      ],
+      historySearchData: [],
+    });
+
+    expect(
+      result.map((item) => ({
+        type: item.type,
+        title: item.title,
+      })),
+    ).toEqual([
+      {
+        type: 'bookmark',
+        title: 'Astrolabe Notes',
+      },
+      {
+        type: 'dapp',
+        title: 'Aster',
+      },
+    ]);
+  });
+
+  it('uses real discovery URLs to promote site-backed dapps ahead of weaker text matches', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'aav',
+      searchResult: [REAL_DISCOVERY_DAPPS.aave],
+      rankingHistoryData: [],
+      bookmarkSearchData: [
+        createBookmark({
+          title: 'Aave Markets',
+          url: 'https://app.aave.com/markets',
+        }),
+        createBookmark({
+          title: 'Aave Borrow',
+          url: 'https://app.aave.com/borrow',
+        }),
+      ],
+      historySearchData: [
+        createHistory({
+          id: 'history-weak-aav',
+          title: 'Available notes',
+          url: 'https://notes.example/available',
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+        }),
+      ],
+    });
+
+    expect(
+      result.map((item) => ({
+        type: item.type,
+        title: item.title,
+      })),
+    ).toEqual([
+      {
+        type: 'dapp',
+        title: 'AAVE',
+      },
+      {
+        type: 'bookmark',
+        title: 'Aave Markets',
+      },
+      {
+        type: 'bookmark',
+        title: 'Aave Borrow',
+      },
+      {
+        type: 'history',
+        title: 'Available notes',
+      },
+    ]);
+  });
+
+  it('prioritizes dapps with same-site local support across root and app subdomains', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'uni',
+      searchResult: [REAL_DISCOVERY_DAPPS.uniswap],
+      rankingHistoryData: [],
+      bookmarkSearchData: [
+        createBookmark({
+          title: 'Swap | Uniswap',
+          url: 'https://app.uniswap.org/swap',
+        }),
+      ],
+      historySearchData: [
+        createHistory({
+          id: 'uniswap-history',
+          title: 'Uniswap Pool',
+          url: 'https://app.uniswap.org/pool',
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+        }),
+      ],
+    });
+
+    expect(
+      result.map((item) => ({
+        type: item.type,
+        title: item.title,
+      })),
+    ).toEqual([
+      {
+        type: 'dapp',
+        title: 'Uniswap',
+      },
+      {
+        type: 'bookmark',
+        title: 'Swap | Uniswap',
+      },
+      {
+        type: 'history',
+        title: 'Uniswap Pool',
+      },
+    ]);
+  });
+
+  it('keeps a same-url dapp behind local history when it is not promoted', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'aav',
+      searchResult: [
+        REAL_DISCOVERY_DAPPS.aave,
+        createDApp({
+          dappId: 'aavegotchi',
+          name: 'Aavegotchi',
+          url: 'https://www.aavegotchi.com',
+        }),
+        createDApp({
+          dappId: 'aave-chan',
+          name: 'Aave-Chan',
+          url: 'https://www.aavechan.com',
+        }),
+      ],
+      rankingHistoryData: [],
+      bookmarkSearchData: [],
+      historySearchData: [
+        createHistory({
+          id: 'history-aave-home',
+          title: 'Aave - Open Source Liquidity Protocol',
+          url: 'https://app.aave.com',
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+        }),
+      ],
+    });
+
+    expect(
+      result.map((item) => ({
+        type: item.type,
+        title: item.title,
+      })),
+    ).toEqual([
+      {
+        type: 'history',
+        title: 'Aave - Open Source Liquidity Protocol',
+      },
+      {
+        type: 'dapp',
+        title: 'AAVE',
+      },
+      {
+        type: 'dapp',
+        title: 'Aavegotchi',
+      },
+      {
+        type: 'dapp',
+        title: 'Aave-Chan',
+      },
+    ]);
+  });
+
+  it('does not dedupe different dapps that only share metadata origins in real payloads', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'e',
+      searchResult: [REAL_DISCOVERY_DAPPS.aster, REAL_DISCOVERY_DAPPS.pendle],
+      rankingHistoryData: [],
+      bookmarkSearchData: [],
+      historySearchData: [],
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result.map((item) => item.title)).toEqual(
+      expect.arrayContaining(['Aster', 'Pendle']),
+    );
   });
 
   it('keeps exact url results ahead of local fused items', () => {
@@ -411,7 +847,7 @@ describe('searchResultRanking', () => {
     ]);
   });
 
-  it('keeps distinct local matches from the same origin', () => {
+  it('keeps distinct local matches and one same-origin dapp result', () => {
     const result = mergeSearchResultsWithLocalData({
       keyword: 'swap',
       searchResult: [
@@ -458,6 +894,87 @@ describe('searchResultRanking', () => {
       {
         type: 'history',
         url: 'https://app.uniswap.org/pool',
+      },
+      {
+        type: 'dapp',
+        url: 'https://app.uniswap.org/explore',
+      },
+    ]);
+  });
+
+  it('uses history item itself as a visit when no exact url history match exists', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'swap',
+      searchResult: [],
+      rankingHistoryData: [],
+      bookmarkSearchData: [],
+      historySearchData: [
+        createHistory({
+          id: 'history-older',
+          title: 'Swap Alpha',
+          url: 'https://alpha.example/trade',
+          createdAt: Date.now() - 30 * 24 * 60 * 60 * 1000,
+        }),
+        createHistory({
+          id: 'history-newer',
+          title: 'Swap Beta',
+          url: 'https://beta.example/trade',
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+        }),
+      ],
+    });
+
+    expect(
+      result.map((item) => ({
+        type: item.type,
+        key: item.key,
+      })),
+    ).toEqual([
+      {
+        type: 'history',
+        key: 'history:history-newer',
+      },
+      {
+        type: 'history',
+        key: 'history:history-older',
+      },
+    ]);
+  });
+
+  it('keeps bookmark ahead of history when local scores tie', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'swap',
+      searchResult: [],
+      rankingHistoryData: [],
+      bookmarkSearchData: [
+        createBookmark({
+          title: 'Swap Alpha',
+          url: 'https://alpha.example',
+        }),
+      ],
+      historySearchData: [
+        createHistory({
+          id: 'history-beta',
+          title: 'Swap Beta',
+          url: 'https://beta.example',
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+        }),
+      ],
+    });
+
+    expect(
+      result.map((item) => ({
+        type: item.type,
+        url: item.url,
+      })),
+    ).toEqual([
+      {
+        type: 'bookmark',
+        url: 'https://alpha.example',
+      },
+      {
+        type: 'history',
+        url: 'https://beta.example',
       },
     ]);
   });
@@ -508,15 +1025,15 @@ describe('searchResultRanking', () => {
     expect(result.map((item) => item.dappId)).toEqual(['uniswap']);
   });
 
-  it('skips remote search for queries with length up to three', () => {
+  it('skips remote search only for queries shorter than three characters', () => {
     expect(shouldSkipRemoteSearchByKeyword('a')).toBe(true);
     expect(shouldSkipRemoteSearchByKeyword('ab')).toBe(true);
     expect(shouldSkipRemoteSearchByKeyword(' Ab ')).toBe(true);
-    expect(shouldSkipRemoteSearchByKeyword('abc')).toBe(true);
+    expect(shouldSkipRemoteSearchByKeyword('abc')).toBe(false);
     expect(shouldSkipRemoteSearchByKeyword('abcd')).toBe(false);
     expect(shouldSkipRemoteSearchByKeyword('a1')).toBe(true);
     expect(shouldSkipRemoteSearchByKeyword('你我')).toBe(true);
-    expect(shouldSkipRemoteSearchByKeyword('okx')).toBe(true);
+    expect(shouldSkipRemoteSearchByKeyword('okx')).toBe(false);
     expect(shouldSkipRemoteSearchByKeyword('okxx')).toBe(false);
   });
 });

--- a/packages/kit/src/views/Discovery/utils/searchResultRanking.test.ts
+++ b/packages/kit/src/views/Discovery/utils/searchResultRanking.test.ts
@@ -339,6 +339,79 @@ describe('searchResultRanking', () => {
     ]);
   });
 
+  it('keeps stronger dapp name prefixes ahead of weaker host prefix matches', () => {
+    const result = rankSearchResultsChromeLike({
+      keyword: 'aav',
+      searchResult: [
+        REAL_DISCOVERY_DAPPS.aave,
+        createDApp({
+          dappId: 'aavegotchi',
+          name: 'Aavegotchi',
+          url: 'https://www.aavegotchi.com',
+        }),
+      ],
+      rankingHistoryData: [],
+    });
+
+    expect(result.map((item) => item.dappId)).toEqual([
+      REAL_DISCOVERY_DAPPS.aave.dappId,
+      'aavegotchi',
+    ]);
+  });
+
+  it('does not let local support move weaker remote dapps ahead of stronger remote relevance', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'aav',
+      searchResult: [
+        REAL_DISCOVERY_DAPPS.aave,
+        createDApp({
+          dappId: 'aavegotchi',
+          name: 'Aavegotchi',
+          url: 'https://www.aavegotchi.com',
+        }),
+      ],
+      rankingHistoryData: [],
+      bookmarkSearchData: [
+        createBookmark({
+          title: 'Aavegotchi Lending',
+          url: 'https://www.aavegotchi.com/lending',
+        }),
+      ],
+      historySearchData: [
+        createHistory({
+          id: 'history-aavegotchi',
+          title: 'Aavegotchi Wearables',
+          url: 'https://www.aavegotchi.com/wearables',
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+        }),
+      ],
+    });
+
+    expect(
+      result.map((item) => ({
+        type: item.type,
+        title: item.title,
+      })),
+    ).toEqual([
+      {
+        type: 'bookmark',
+        title: 'Aavegotchi Lending',
+      },
+      {
+        type: 'history',
+        title: 'Aavegotchi Wearables',
+      },
+      {
+        type: 'dapp',
+        title: 'AAVE',
+      },
+      {
+        type: 'dapp',
+        title: 'Aavegotchi',
+      },
+    ]);
+  });
+
   it('ranks local host matches ahead of weaker title-only matches before merging remote results', () => {
     const result = mergeSearchResultsWithLocalData({
       keyword: 'app.uni',
@@ -671,11 +744,64 @@ describe('searchResultRanking', () => {
       },
       {
         type: 'dapp',
-        title: 'Aavegotchi',
+        title: 'Aave-Chan',
       },
       {
         type: 'dapp',
-        title: 'Aave-Chan',
+        title: 'Aavegotchi',
+      },
+    ]);
+  });
+
+  it('keeps stronger remote relevance ahead of weaker locally supported matches', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'aav',
+      searchResult: [
+        REAL_DISCOVERY_DAPPS.aave,
+        createDApp({
+          dappId: 'weaker-local-support',
+          name: 'DeFi Club',
+          url: 'https://defi.example/aav',
+        }),
+      ],
+      rankingHistoryData: [],
+      bookmarkSearchData: [
+        createBookmark({
+          title: 'AAV Guide',
+          url: 'https://defi.example/aav-guide',
+        }),
+      ],
+      historySearchData: [
+        createHistory({
+          id: 'history-weaker-local-support',
+          title: 'AAV Tools',
+          url: 'https://defi.example/aav-tools',
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+        }),
+      ],
+    });
+
+    expect(
+      result.map((item) => ({
+        type: item.type,
+        title: item.title,
+      })),
+    ).toEqual([
+      {
+        type: 'bookmark',
+        title: 'AAV Guide',
+      },
+      {
+        type: 'history',
+        title: 'AAV Tools',
+      },
+      {
+        type: 'dapp',
+        title: 'AAVE',
+      },
+      {
+        type: 'dapp',
+        title: 'DeFi Club',
       },
     ]);
   });

--- a/packages/kit/src/views/Discovery/utils/searchResultRanking.ts
+++ b/packages/kit/src/views/Discovery/utils/searchResultRanking.ts
@@ -10,6 +10,7 @@ const MAX_RECENT_VISITS_PER_ITEM = 10;
 const MAX_FRECENCY_VISIT_SCORE = 6;
 const BOOKMARK_FRECENCY_BONUS = 0.2;
 const REMOTE_SEARCH_MIN_QUERY_LENGTH = 3;
+const REMOTE_SEARCH_MAX_QUERY_LENGTH = 64;
 const DAPP_PROMOTION_LOCAL_SUPPORT_MIN_COUNT = 2;
 const DAPP_PROMOTION_PREFIX_COVERAGE_DIRECT = 0.8;
 const DAPP_PROMOTION_PREFIX_COVERAGE_WITH_SUPPORT = 0.6;
@@ -891,9 +892,21 @@ export function searchTrendingDappsByKeyword({
 }
 
 export function shouldSkipRemoteSearchByKeyword(keyword: string) {
-  // Three characters already form a meaningful prefix for most English dapp
-  // names, so remote search starts at length 3 and only skips shorter input.
-  return keyword.trim().length < REMOTE_SEARCH_MIN_QUERY_LENGTH;
+  const trimmedLength = keyword.trim().length;
+  const normalizedKeyword = keyword.trim();
+  const normalizedUrl = uriUtils.safeParseURL(
+    uriUtils.ensureHttpsPrefix(normalizedKeyword),
+  );
+  const isLongUrlLikeQuery = Boolean(
+    normalizedUrl &&
+    normalizedUrl.hostname &&
+    ['http:', 'https:'].includes(normalizedUrl.protocol),
+  );
+
+  return (
+    trimmedLength < REMOTE_SEARCH_MIN_QUERY_LENGTH ||
+    (trimmedLength > REMOTE_SEARCH_MAX_QUERY_LENGTH && !isLongUrlLikeQuery)
+  );
 }
 
 function hasMatchKeyOverlap({
@@ -926,6 +939,36 @@ function sortDappsByLocalSupport({
   return items.toSorted(
     (a, b) => getLocalSupportCount(b) - getLocalSupportCount(a),
   );
+}
+
+function appendDappSearchResults({
+  items,
+  source,
+  keyword,
+  mergedItems,
+  originDedupeKeySet,
+  urlDedupeKeySet,
+  reserveLocalUrlKey = false,
+}: {
+  items: IDApp[];
+  source: 'remote' | 'trending';
+  keyword: string;
+  mergedItems: IDiscoverySearchListItem[];
+  originDedupeKeySet: Set<string>;
+  urlDedupeKeySet: Set<string>;
+  reserveLocalUrlKey?: boolean;
+}) {
+  items.forEach((item) => {
+    appendDappSearchResult({
+      item,
+      source,
+      keyword,
+      mergedItems,
+      originDedupeKeySet,
+      urlDedupeKeySet,
+      reserveLocalUrlKey,
+    });
+  });
 }
 
 function appendDappSearchResult({
@@ -1028,78 +1071,64 @@ export function mergeSearchResultsWithLocalData({
     getLocalSupportCount,
   });
 
-  const exactUrlResults = rankedRemoteResultsWithLocalSupport.filter(
-    (item) => item.isExactUrl,
-  );
-  const prioritizedTrendingResults =
-    rankedTrendingResultsWithLocalSupport.filter((item) =>
-      shouldPrioritizeDappAheadOfLocal({
-        dapp: item,
-        keyword,
-        localSupportCount: getLocalSupportCount(item),
-      }),
-    );
-  const otherRemoteResults = rankedRemoteResultsWithLocalSupport.filter(
-    (item) => !item.isExactUrl,
-  );
-  const prioritizedRemoteResults = otherRemoteResults.filter((item) =>
+  const shouldPrioritize = (dapp: IDApp) =>
     shouldPrioritizeDappAheadOfLocal({
-      dapp: item,
+      dapp,
       keyword,
-      localSupportCount: getLocalSupportCount(item),
-    }),
-  );
-  const otherTrendingResults = rankedTrendingResultsWithLocalSupport.filter(
-    (item) =>
-      !shouldPrioritizeDappAheadOfLocal({
-        dapp: item,
-        keyword,
-        localSupportCount: getLocalSupportCount(item),
-      }),
-  );
-  const remainingRemoteResults = otherRemoteResults.filter(
-    (item) =>
-      !shouldPrioritizeDappAheadOfLocal({
-        dapp: item,
-        keyword,
-        localSupportCount: getLocalSupportCount(item),
-      }),
-  );
-
-  exactUrlResults.forEach((item) => {
-    appendDappSearchResult({
-      item,
-      source: 'remote',
-      keyword,
-      mergedItems,
-      originDedupeKeySet: dappOriginDedupeKeySet,
-      urlDedupeKeySet,
-      reserveLocalUrlKey: true,
+      localSupportCount: getLocalSupportCount(dapp),
     });
+
+  const exactUrlResults: IDApp[] = [];
+  const prioritizedRemoteResults: IDApp[] = [];
+  const remainingRemoteResults: IDApp[] = [];
+  for (const item of rankedRemoteResultsWithLocalSupport) {
+    if (item.isExactUrl) {
+      exactUrlResults.push(item);
+    } else if (shouldPrioritize(item)) {
+      prioritizedRemoteResults.push(item);
+    } else {
+      remainingRemoteResults.push(item);
+    }
+  }
+
+  const prioritizedTrendingResults: IDApp[] = [];
+  const otherTrendingResults: IDApp[] = [];
+  for (const item of rankedTrendingResultsWithLocalSupport) {
+    if (shouldPrioritize(item)) {
+      prioritizedTrendingResults.push(item);
+    } else {
+      otherTrendingResults.push(item);
+    }
+  }
+
+  appendDappSearchResults({
+    items: exactUrlResults,
+    source: 'remote',
+    keyword,
+    mergedItems,
+    originDedupeKeySet: dappOriginDedupeKeySet,
+    urlDedupeKeySet,
+    reserveLocalUrlKey: true,
   });
 
-  prioritizedTrendingResults.forEach((item) => {
-    appendDappSearchResult({
-      item,
-      source: 'trending',
-      keyword,
-      mergedItems,
-      originDedupeKeySet: dappOriginDedupeKeySet,
-      urlDedupeKeySet,
-      reserveLocalUrlKey: true,
-    });
+  appendDappSearchResults({
+    items: prioritizedTrendingResults,
+    source: 'trending',
+    keyword,
+    mergedItems,
+    originDedupeKeySet: dappOriginDedupeKeySet,
+    urlDedupeKeySet,
+    reserveLocalUrlKey: true,
   });
 
-  prioritizedRemoteResults.forEach((item) => {
-    appendDappSearchResult({
-      item,
-      source: 'remote',
-      keyword,
-      mergedItems,
-      originDedupeKeySet: dappOriginDedupeKeySet,
-      urlDedupeKeySet,
-      reserveLocalUrlKey: true,
-    });
+  appendDappSearchResults({
+    items: prioritizedRemoteResults,
+    source: 'remote',
+    keyword,
+    mergedItems,
+    originDedupeKeySet: dappOriginDedupeKeySet,
+    urlDedupeKeySet,
+    reserveLocalUrlKey: true,
   });
 
   rankedLocalItems.forEach((candidate) => {
@@ -1139,26 +1168,22 @@ export function mergeSearchResultsWithLocalData({
     });
   });
 
-  otherTrendingResults.forEach((item) => {
-    appendDappSearchResult({
-      item,
-      source: 'trending',
-      keyword,
-      mergedItems,
-      originDedupeKeySet: dappOriginDedupeKeySet,
-      urlDedupeKeySet,
-    });
+  appendDappSearchResults({
+    items: otherTrendingResults,
+    source: 'trending',
+    keyword,
+    mergedItems,
+    originDedupeKeySet: dappOriginDedupeKeySet,
+    urlDedupeKeySet,
   });
 
-  remainingRemoteResults.forEach((item) => {
-    appendDappSearchResult({
-      item,
-      source: 'remote',
-      keyword,
-      mergedItems,
-      originDedupeKeySet: dappOriginDedupeKeySet,
-      urlDedupeKeySet,
-    });
+  appendDappSearchResults({
+    items: remainingRemoteResults,
+    source: 'remote',
+    keyword,
+    mergedItems,
+    originDedupeKeySet: dappOriginDedupeKeySet,
+    urlDedupeKeySet,
   });
 
   return mergedItems;

--- a/packages/kit/src/views/Discovery/utils/searchResultRanking.ts
+++ b/packages/kit/src/views/Discovery/utils/searchResultRanking.ts
@@ -69,6 +69,15 @@ type IHistoryVisitMaps = {
   urlVisitMap: Map<string, IBrowserHistory[]>;
 };
 
+type IDappRankedSearchEntry = {
+  item: IDApp;
+  index: number;
+  topicality: ITopicalityScore;
+  namePrefixCoverage: number;
+  visits: IBrowserHistory[];
+  finalScore: number;
+};
+
 type ILocalCandidate =
   | {
       type: 'bookmark';
@@ -361,7 +370,7 @@ function getUrlTopicalityScore({
   }
 
   if (normalizedHost.startsWith(query)) {
-    return makeTopicalityScore(5, 104);
+    return makeTopicalityScore(4, 94);
   }
 
   if (hasWordBoundaryMatch(normalizedHost, query)) {
@@ -735,6 +744,84 @@ function getLocalItemMatchedVisits({
   return visits;
 }
 
+function compareRankedDappSearchEntries(
+  a: IDappRankedSearchEntry,
+  b: IDappRankedSearchEntry,
+  options?: {
+    getLocalSupportCount?: (dapp: IDApp) => number;
+  },
+) {
+  if (Boolean(a.item.isExactUrl) !== Boolean(b.item.isExactUrl)) {
+    return (
+      Number(Boolean(b.item.isExactUrl)) - Number(Boolean(a.item.isExactUrl))
+    );
+  }
+  if (a.topicality.bucket !== b.topicality.bucket) {
+    return b.topicality.bucket - a.topicality.bucket;
+  }
+  if (a.finalScore !== b.finalScore) {
+    return b.finalScore - a.finalScore;
+  }
+  if (a.namePrefixCoverage !== b.namePrefixCoverage) {
+    return b.namePrefixCoverage - a.namePrefixCoverage;
+  }
+
+  const localSupportCountDiff =
+    (options?.getLocalSupportCount?.(b.item) ?? 0) -
+    (options?.getLocalSupportCount?.(a.item) ?? 0);
+  if (localSupportCountDiff !== 0) {
+    return localSupportCountDiff;
+  }
+
+  const latestVisitDiff =
+    getLatestVisitTimestamp(b.visits) - getLatestVisitTimestamp(a.visits);
+  if (latestVisitDiff !== 0) {
+    return latestVisitDiff;
+  }
+  return a.index - b.index;
+}
+
+function buildRankedDappSearchEntries({
+  keyword,
+  searchResult,
+  rankingHistoryData,
+}: {
+  keyword: string;
+  searchResult?: IDApp[];
+  rankingHistoryData?: IBrowserHistory[];
+}): IDappRankedSearchEntry[] {
+  const normalizedQuery = normalizeUrlLikeText(keyword);
+  const historyVisitMaps = buildHistoryVisitMaps(rankingHistoryData ?? []);
+  const now = Date.now();
+
+  return (searchResult ?? []).map((item, index) => {
+    const topicality = getDappTopicalityScore({
+      dapp: item,
+      query: normalizedQuery,
+    });
+    const visits = getDappMatchedVisits({
+      dapp: item,
+      originVisitMap: historyVisitMaps.originVisitMap,
+    });
+    const frecencyMultiplier = getFrecencyMultiplier({
+      visits,
+      now,
+    });
+
+    return {
+      item,
+      index,
+      topicality,
+      namePrefixCoverage: getDappNamePrefixCoverage({
+        dapp: item,
+        keyword,
+      }),
+      visits,
+      finalScore: topicality.score * frecencyMultiplier,
+    };
+  });
+}
+
 export function rankSearchResultsChromeLike({
   keyword,
   searchResult,
@@ -744,54 +831,12 @@ export function rankSearchResultsChromeLike({
   searchResult?: IDApp[];
   rankingHistoryData?: IBrowserHistory[];
 }) {
-  const normalizedQuery = normalizeUrlLikeText(keyword);
-  const historyVisitMaps = buildHistoryVisitMaps(rankingHistoryData ?? []);
-  const now = Date.now();
-
-  return (searchResult ?? [])
-    .map((item, index) => {
-      const topicality = getDappTopicalityScore({
-        dapp: item,
-        query: normalizedQuery,
-      });
-      const visits = getDappMatchedVisits({
-        dapp: item,
-        originVisitMap: historyVisitMaps.originVisitMap,
-      });
-      const frecencyMultiplier = getFrecencyMultiplier({
-        visits,
-        now,
-      });
-
-      return {
-        item,
-        index,
-        topicality,
-        visits,
-        frecencyMultiplier,
-        finalScore: topicality.score * frecencyMultiplier,
-      };
-    })
-    .toSorted((a, b) => {
-      if (Boolean(a.item.isExactUrl) !== Boolean(b.item.isExactUrl)) {
-        return (
-          Number(Boolean(b.item.isExactUrl)) -
-          Number(Boolean(a.item.isExactUrl))
-        );
-      }
-      if (a.topicality.bucket !== b.topicality.bucket) {
-        return b.topicality.bucket - a.topicality.bucket;
-      }
-      if (a.finalScore !== b.finalScore) {
-        return b.finalScore - a.finalScore;
-      }
-      const latestVisitDiff =
-        getLatestVisitTimestamp(b.visits) - getLatestVisitTimestamp(a.visits);
-      if (latestVisitDiff !== 0) {
-        return latestVisitDiff;
-      }
-      return a.index - b.index;
-    })
+  return buildRankedDappSearchEntries({
+    keyword,
+    searchResult,
+    rankingHistoryData,
+  })
+    .toSorted((a, b) => compareRankedDappSearchEntries(a, b))
     .map(({ item }) => item);
 }
 
@@ -929,18 +974,6 @@ function appendMatchKeys({
   keys.forEach((key) => dedupeKeySet.add(key));
 }
 
-function sortDappsByLocalSupport({
-  items,
-  getLocalSupportCount,
-}: {
-  items: IDApp[];
-  getLocalSupportCount: (dapp: IDApp) => number;
-}) {
-  return items.toSorted(
-    (a, b) => getLocalSupportCount(b) - getLocalSupportCount(a),
-  );
-}
-
 function appendDappSearchResults({
   items,
   source,
@@ -1032,12 +1065,12 @@ export function mergeSearchResultsWithLocalData({
   const dappOriginDedupeKeySet = new Set<string>();
   const urlDedupeKeySet = new Set<string>();
 
-  const rankedRemoteResults = rankSearchResultsChromeLike({
+  const rankedRemoteSearchEntries = buildRankedDappSearchEntries({
     keyword,
     searchResult,
     rankingHistoryData,
   });
-  const rankedTrendingResults = rankSearchResultsChromeLike({
+  const rankedTrendingSearchEntries = buildRankedDappSearchEntries({
     keyword,
     searchResult: trendingSearchData,
     rankingHistoryData,
@@ -1062,14 +1095,20 @@ export function mergeSearchResultsWithLocalData({
     localSupportCountCache.set(dapp.dappId, count);
     return count;
   };
-  const rankedTrendingResultsWithLocalSupport = sortDappsByLocalSupport({
-    items: rankedTrendingResults,
-    getLocalSupportCount,
-  });
-  const rankedRemoteResultsWithLocalSupport = sortDappsByLocalSupport({
-    items: rankedRemoteResults,
-    getLocalSupportCount,
-  });
+  const rankedTrendingResults = rankedTrendingSearchEntries
+    .toSorted((a, b) =>
+      compareRankedDappSearchEntries(a, b, {
+        getLocalSupportCount,
+      }),
+    )
+    .map(({ item }) => item);
+  const rankedRemoteResults = rankedRemoteSearchEntries
+    .toSorted((a, b) =>
+      compareRankedDappSearchEntries(a, b, {
+        getLocalSupportCount,
+      }),
+    )
+    .map(({ item }) => item);
 
   const shouldPrioritize = (dapp: IDApp) =>
     shouldPrioritizeDappAheadOfLocal({
@@ -1081,22 +1120,26 @@ export function mergeSearchResultsWithLocalData({
   const exactUrlResults: IDApp[] = [];
   const prioritizedRemoteResults: IDApp[] = [];
   const remainingRemoteResults: IDApp[] = [];
-  for (const item of rankedRemoteResultsWithLocalSupport) {
+  let hasStartedRemainingRemoteResults = false;
+  for (const item of rankedRemoteResults) {
     if (item.isExactUrl) {
       exactUrlResults.push(item);
-    } else if (shouldPrioritize(item)) {
+    } else if (!hasStartedRemainingRemoteResults && shouldPrioritize(item)) {
       prioritizedRemoteResults.push(item);
     } else {
+      hasStartedRemainingRemoteResults = true;
       remainingRemoteResults.push(item);
     }
   }
 
   const prioritizedTrendingResults: IDApp[] = [];
   const otherTrendingResults: IDApp[] = [];
-  for (const item of rankedTrendingResultsWithLocalSupport) {
-    if (shouldPrioritize(item)) {
+  let hasStartedOtherTrendingResults = false;
+  for (const item of rankedTrendingResults) {
+    if (!hasStartedOtherTrendingResults && shouldPrioritize(item)) {
       prioritizedTrendingResults.push(item);
     } else {
+      hasStartedOtherTrendingResults = true;
       otherTrendingResults.push(item);
     }
   }

--- a/packages/kit/src/views/Discovery/utils/searchResultRanking.ts
+++ b/packages/kit/src/views/Discovery/utils/searchResultRanking.ts
@@ -9,6 +9,10 @@ const DAY_IN_MS = 24 * 60 * 60 * 1000;
 const MAX_RECENT_VISITS_PER_ITEM = 10;
 const MAX_FRECENCY_VISIT_SCORE = 6;
 const BOOKMARK_FRECENCY_BONUS = 0.2;
+const REMOTE_SEARCH_MIN_QUERY_LENGTH = 3;
+const DAPP_PROMOTION_LOCAL_SUPPORT_MIN_COUNT = 2;
+const DAPP_PROMOTION_PREFIX_COVERAGE_DIRECT = 0.8;
+const DAPP_PROMOTION_PREFIX_COVERAGE_WITH_SUPPORT = 0.6;
 
 export const DISCOVERY_RANKING_HISTORY_LIMIT = 200;
 export const DISCOVERY_LOCAL_SEARCH_CANDIDATE_LIMIT = 200;
@@ -80,6 +84,14 @@ function normalizeText(text?: string) {
   return (text ?? '').trim().toLowerCase();
 }
 
+function isWebUrl(text?: string): text is string {
+  return /^https?:\/\//.test(normalizeText(text));
+}
+
+function getWebOrigins(origins?: string[]) {
+  return (origins ?? []).filter((origin) => isWebUrl(origin));
+}
+
 function normalizeUrlLikeText(text?: string) {
   return normalizeText(text)
     .replace(/^https?:\/\//, '')
@@ -110,10 +122,42 @@ function pickHigherTopicalityScore(
 }
 
 function getHostFromUrl(url?: string) {
-  if (!url) {
+  if (!isWebUrl(url)) {
     return '';
   }
   return normalizeUrlLikeText(uriUtils.getHostNameFromUrl({ url }));
+}
+
+function isIpHostname(hostname: string) {
+  return /^\d{1,3}(?:\.\d{1,3}){3}$/u.test(hostname) || hostname.includes(':');
+}
+
+function getHostnameSiteKey(hostname?: string) {
+  const normalizedHostname = normalizeText(hostname)
+    .replace(/^www\./, '')
+    .replace(/\.+$/u, '');
+
+  if (!normalizedHostname) {
+    return '';
+  }
+
+  if (isIpHostname(normalizedHostname)) {
+    return normalizedHostname;
+  }
+
+  const labels = normalizedHostname.split('.').filter(Boolean);
+  if (labels.length <= 2) {
+    return normalizedHostname;
+  }
+
+  const tld = labels[labels.length - 1];
+  const sld = labels[labels.length - 2];
+
+  if (tld.length === 2 && sld.length <= 3) {
+    return labels.slice(-3).join('.');
+  }
+
+  return labels.slice(-2).join('.');
 }
 
 function getOriginMatchKeys({
@@ -125,15 +169,118 @@ function getOriginMatchKeys({
 }) {
   return Array.from(
     new Set(
-      [url, ...(origins ?? [])]
+      [url, ...getWebOrigins(origins)]
         .filter((item): item is string => Boolean(item))
         .map((item) => uriUtils.getOriginFromUrl({ url: item }) || item),
     ),
   );
 }
 
+function getSiteMatchKeys({
+  url,
+  origins,
+}: {
+  url?: string;
+  origins?: string[];
+}) {
+  return Array.from(
+    new Set(
+      [url, ...getWebOrigins(origins)]
+        .filter((item): item is string => Boolean(item))
+        .map((item) => {
+          const parsedUrl = uriUtils.safeParseURL(item);
+          if (!parsedUrl || !['http:', 'https:'].includes(parsedUrl.protocol)) {
+            return '';
+          }
+
+          const siteKey = getHostnameSiteKey(parsedUrl.hostname);
+          return siteKey ? `${parsedUrl.protocol}//${siteKey}` : '';
+        })
+        .filter(Boolean),
+    ),
+  );
+}
+
 function getExactUrlVisitKey(url?: string) {
   return normalizeUrlLikeText(url);
+}
+
+function isExactDappNameMatch({
+  dapp,
+  keyword,
+}: {
+  dapp: Pick<IDApp, 'name'>;
+  keyword: string;
+}) {
+  const normalizedKeyword = normalizeText(keyword);
+  const normalizedName = normalizeText(dapp.name);
+
+  return Boolean(normalizedKeyword) && normalizedKeyword === normalizedName;
+}
+
+function getDappNamePrefixCoverage({
+  dapp,
+  keyword,
+}: {
+  dapp: Pick<IDApp, 'name'>;
+  keyword: string;
+}) {
+  const normalizedKeyword = normalizeText(keyword);
+  const normalizedName = normalizeText(dapp.name);
+
+  if (
+    !normalizedKeyword ||
+    !normalizedName ||
+    !normalizedName.startsWith(normalizedKeyword)
+  ) {
+    return 0;
+  }
+
+  return normalizedKeyword.length / normalizedName.length;
+}
+
+function getDappLocalSupportCount({
+  dapp,
+  rankedLocalItems,
+}: {
+  dapp: Pick<IDApp, 'url' | 'origins'>;
+  rankedLocalItems: ILocalCandidate[];
+}) {
+  const dappOriginKeySet = new Set(
+    getOriginMatchKeys({
+      url: dapp.url,
+      origins: dapp.origins,
+    }),
+  );
+  const dappSiteKeySet = new Set(
+    getSiteMatchKeys({
+      url: dapp.url,
+      origins: dapp.origins,
+    }),
+  );
+  const supportedUrlKeySet = new Set<string>();
+
+  rankedLocalItems.forEach((candidate) => {
+    const candidateOriginKeys = getOriginMatchKeys({ url: candidate.item.url });
+    const candidateSiteKeys = getSiteMatchKeys({ url: candidate.item.url });
+    const hasOriginSupport = candidateOriginKeys.some((key) =>
+      dappOriginKeySet.has(key),
+    );
+    const hasSiteSupport = candidateSiteKeys.some((key) =>
+      dappSiteKeySet.has(key),
+    );
+
+    if (!hasOriginSupport && !hasSiteSupport) {
+      return;
+    }
+
+    const urlKey = getExactUrlVisitKey(candidate.item.url);
+    if (urlKey) {
+      supportedUrlKeySet.add(urlKey);
+    }
+  });
+
+  return supportedUrlKeySet.size;
 }
 
 function hasWordBoundaryMatch(text: string, query: string) {
@@ -231,6 +378,59 @@ function getUrlTopicalityScore({
   return makeTopicalityScore(0, 0);
 }
 
+function getDappSiteTopicalityScore({
+  dapp,
+  query,
+}: {
+  dapp: Pick<IDApp, 'url' | 'origins'>;
+  query: string;
+}) {
+  let bestScore = getUrlTopicalityScore({ url: dapp.url, query });
+
+  getWebOrigins(dapp.origins).forEach((origin) => {
+    bestScore = pickHigherTopicalityScore(
+      bestScore,
+      getUrlTopicalityScore({ url: origin, query }),
+    );
+  });
+
+  return bestScore;
+}
+
+function shouldPrioritizeDappAheadOfLocal({
+  dapp,
+  keyword,
+  localSupportCount,
+}: {
+  dapp: Pick<IDApp, 'name' | 'url' | 'origins' | 'keyword' | 'tags'>;
+  keyword: string;
+  localSupportCount: number;
+}) {
+  if (isExactDappNameMatch({ dapp, keyword })) {
+    return true;
+  }
+
+  const namePrefixCoverage = getDappNamePrefixCoverage({ dapp, keyword });
+  if (namePrefixCoverage >= DAPP_PROMOTION_PREFIX_COVERAGE_DIRECT) {
+    return true;
+  }
+
+  if (localSupportCount < DAPP_PROMOTION_LOCAL_SUPPORT_MIN_COUNT) {
+    return false;
+  }
+
+  if (namePrefixCoverage >= DAPP_PROMOTION_PREFIX_COVERAGE_WITH_SUPPORT) {
+    return true;
+  }
+
+  return (
+    getDappSiteTopicalityScore({
+      dapp,
+      query: normalizeUrlLikeText(keyword),
+    }).bucket >= 4
+  );
+}
+
 function getLocalItemTopicalityScore({
   title,
   url,
@@ -269,7 +469,7 @@ function getDappTopicalityScore({
 }) {
   let bestScore = getUrlTopicalityScore({ url: dapp.url, query });
 
-  (dapp.origins ?? []).forEach((origin) => {
+  getWebOrigins(dapp.origins).forEach((origin) => {
     bestScore = pickHigherTopicalityScore(
       bestScore,
       getUrlTopicalityScore({ url: origin, query }),
@@ -691,7 +891,9 @@ export function searchTrendingDappsByKeyword({
 }
 
 export function shouldSkipRemoteSearchByKeyword(keyword: string) {
-  return keyword.trim().length <= 3;
+  // Three characters already form a meaningful prefix for most English dapp
+  // names, so remote search starts at length 3 and only skips shorter input.
+  return keyword.trim().length < REMOTE_SEARCH_MIN_QUERY_LENGTH;
 }
 
 function hasMatchKeyOverlap({
@@ -714,6 +916,60 @@ function appendMatchKeys({
   keys.forEach((key) => dedupeKeySet.add(key));
 }
 
+function sortDappsByLocalSupport({
+  items,
+  getLocalSupportCount,
+}: {
+  items: IDApp[];
+  getLocalSupportCount: (dapp: IDApp) => number;
+}) {
+  return items.toSorted(
+    (a, b) => getLocalSupportCount(b) - getLocalSupportCount(a),
+  );
+}
+
+function appendDappSearchResult({
+  item,
+  source,
+  keyword,
+  mergedItems,
+  originDedupeKeySet,
+  urlDedupeKeySet,
+  reserveLocalUrlKey = false,
+}: {
+  item: IDApp;
+  source: 'remote' | 'trending';
+  keyword: string;
+  mergedItems: IDiscoverySearchListItem[];
+  originDedupeKeySet: Set<string>;
+  urlDedupeKeySet: Set<string>;
+  reserveLocalUrlKey?: boolean;
+}) {
+  const urlKey = getExactUrlVisitKey(item.url);
+  const keys = getOriginMatchKeys({ url: item.url, origins: item.origins });
+  if (hasMatchKeyOverlap({ keys, dedupeKeySet: originDedupeKeySet })) {
+    return;
+  }
+
+  appendMatchKeys({ keys, dedupeKeySet: originDedupeKeySet });
+  if (reserveLocalUrlKey && urlKey) {
+    urlDedupeKeySet.add(urlKey);
+  }
+
+  mergedItems.push({
+    type: 'dapp',
+    source,
+    key: `${source === 'trending' ? 'trending' : 'dapp'}:${item.dappId}`,
+    title: item.name,
+    url: item.url,
+    logo: item.logo,
+    originLogo: item.originLogo,
+    isExactUrl: item.isExactUrl,
+    keyword: keyword || item.keyword,
+    dapp: item,
+  });
+}
+
 export function mergeSearchResultsWithLocalData({
   keyword,
   searchResult,
@@ -730,7 +986,7 @@ export function mergeSearchResultsWithLocalData({
   trendingSearchData?: IDApp[];
 }): IDiscoverySearchListItem[] {
   const mergedItems: IDiscoverySearchListItem[] = [];
-  const originDedupeKeySet = new Set<string>();
+  const dappOriginDedupeKeySet = new Set<string>();
   const urlDedupeKeySet = new Set<string>();
 
   const rankedRemoteResults = rankSearchResultsChromeLike({
@@ -749,33 +1005,100 @@ export function mergeSearchResultsWithLocalData({
     bookmarkSearchData,
     historySearchData,
   });
+  const localSupportCountCache = new Map<string, number>();
+  const getLocalSupportCount = (dapp: IDApp) => {
+    const cached = localSupportCountCache.get(dapp.dappId);
+    if (cached !== undefined) {
+      return cached;
+    }
 
-  const exactUrlResults = rankedRemoteResults.filter((item) => item.isExactUrl);
-  const otherRemoteResults = rankedRemoteResults.filter(
+    const count = getDappLocalSupportCount({
+      dapp,
+      rankedLocalItems,
+    });
+    localSupportCountCache.set(dapp.dappId, count);
+    return count;
+  };
+  const rankedTrendingResultsWithLocalSupport = sortDappsByLocalSupport({
+    items: rankedTrendingResults,
+    getLocalSupportCount,
+  });
+  const rankedRemoteResultsWithLocalSupport = sortDappsByLocalSupport({
+    items: rankedRemoteResults,
+    getLocalSupportCount,
+  });
+
+  const exactUrlResults = rankedRemoteResultsWithLocalSupport.filter(
+    (item) => item.isExactUrl,
+  );
+  const prioritizedTrendingResults =
+    rankedTrendingResultsWithLocalSupport.filter((item) =>
+      shouldPrioritizeDappAheadOfLocal({
+        dapp: item,
+        keyword,
+        localSupportCount: getLocalSupportCount(item),
+      }),
+    );
+  const otherRemoteResults = rankedRemoteResultsWithLocalSupport.filter(
     (item) => !item.isExactUrl,
+  );
+  const prioritizedRemoteResults = otherRemoteResults.filter((item) =>
+    shouldPrioritizeDappAheadOfLocal({
+      dapp: item,
+      keyword,
+      localSupportCount: getLocalSupportCount(item),
+    }),
+  );
+  const otherTrendingResults = rankedTrendingResultsWithLocalSupport.filter(
+    (item) =>
+      !shouldPrioritizeDappAheadOfLocal({
+        dapp: item,
+        keyword,
+        localSupportCount: getLocalSupportCount(item),
+      }),
+  );
+  const remainingRemoteResults = otherRemoteResults.filter(
+    (item) =>
+      !shouldPrioritizeDappAheadOfLocal({
+        dapp: item,
+        keyword,
+        localSupportCount: getLocalSupportCount(item),
+      }),
   );
 
   exactUrlResults.forEach((item) => {
-    const keys = getOriginMatchKeys({ url: item.url, origins: item.origins });
-    if (hasMatchKeyOverlap({ keys, dedupeKeySet: originDedupeKeySet })) {
-      return;
-    }
-    appendMatchKeys({ keys, dedupeKeySet: originDedupeKeySet });
-    const urlKey = getExactUrlVisitKey(item.url);
-    if (urlKey) {
-      urlDedupeKeySet.add(urlKey);
-    }
-    mergedItems.push({
-      type: 'dapp',
+    appendDappSearchResult({
+      item,
       source: 'remote',
-      key: `dapp:${item.dappId}`,
-      title: item.name,
-      url: item.url,
-      logo: item.logo,
-      originLogo: item.originLogo,
-      isExactUrl: item.isExactUrl,
-      keyword: keyword || item.keyword,
-      dapp: item,
+      keyword,
+      mergedItems,
+      originDedupeKeySet: dappOriginDedupeKeySet,
+      urlDedupeKeySet,
+      reserveLocalUrlKey: true,
+    });
+  });
+
+  prioritizedTrendingResults.forEach((item) => {
+    appendDappSearchResult({
+      item,
+      source: 'trending',
+      keyword,
+      mergedItems,
+      originDedupeKeySet: dappOriginDedupeKeySet,
+      urlDedupeKeySet,
+      reserveLocalUrlKey: true,
+    });
+  });
+
+  prioritizedRemoteResults.forEach((item) => {
+    appendDappSearchResult({
+      item,
+      source: 'remote',
+      keyword,
+      mergedItems,
+      originDedupeKeySet: dappOriginDedupeKeySet,
+      urlDedupeKeySet,
+      reserveLocalUrlKey: true,
     });
   });
 
@@ -787,10 +1110,6 @@ export function mergeSearchResultsWithLocalData({
     if (urlKey) {
       urlDedupeKeySet.add(urlKey);
     }
-    appendMatchKeys({
-      keys: getOriginMatchKeys({ url: candidate.item.url }),
-      dedupeKeySet: originDedupeKeySet,
-    });
 
     if (candidate.type === 'bookmark') {
       const item = candidate.item;
@@ -820,43 +1139,25 @@ export function mergeSearchResultsWithLocalData({
     });
   });
 
-  rankedTrendingResults.forEach((item) => {
-    const keys = getOriginMatchKeys({ url: item.url, origins: item.origins });
-    if (hasMatchKeyOverlap({ keys, dedupeKeySet: originDedupeKeySet })) {
-      return;
-    }
-    appendMatchKeys({ keys, dedupeKeySet: originDedupeKeySet });
-    mergedItems.push({
-      type: 'dapp',
+  otherTrendingResults.forEach((item) => {
+    appendDappSearchResult({
+      item,
       source: 'trending',
-      key: `trending:${item.dappId}`,
-      title: item.name,
-      url: item.url,
-      logo: item.logo,
-      originLogo: item.originLogo,
-      isExactUrl: item.isExactUrl,
-      keyword: keyword || item.keyword,
-      dapp: item,
+      keyword,
+      mergedItems,
+      originDedupeKeySet: dappOriginDedupeKeySet,
+      urlDedupeKeySet,
     });
   });
 
-  otherRemoteResults.forEach((item) => {
-    const keys = getOriginMatchKeys({ url: item.url, origins: item.origins });
-    if (hasMatchKeyOverlap({ keys, dedupeKeySet: originDedupeKeySet })) {
-      return;
-    }
-    appendMatchKeys({ keys, dedupeKeySet: originDedupeKeySet });
-    mergedItems.push({
-      type: 'dapp',
+  remainingRemoteResults.forEach((item) => {
+    appendDappSearchResult({
+      item,
       source: 'remote',
-      key: `dapp:${item.dappId}`,
-      title: item.name,
-      url: item.url,
-      logo: item.logo,
-      originLogo: item.originLogo,
-      isExactUrl: item.isExactUrl,
-      keyword: keyword || item.keyword,
-      dapp: item,
+      keyword,
+      mergedItems,
+      originDedupeKeySet: dappOriginDedupeKeySet,
+      urlDedupeKeySet,
     });
   });
 

--- a/packages/kit/src/views/Discovery/utils/searchResultRanking.ts
+++ b/packages/kit/src/views/Discovery/utils/searchResultRanking.ts
@@ -1,0 +1,864 @@
+import type { IFuseResultMatch } from '@onekeyhq/shared/src/modules3rdParty/fuse';
+import { buildFuse } from '@onekeyhq/shared/src/modules3rdParty/fuse';
+import uriUtils from '@onekeyhq/shared/src/utils/uriUtils';
+import type { IDApp } from '@onekeyhq/shared/types/discovery';
+
+import type { IBrowserBookmark, IBrowserHistory } from '../types';
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+const MAX_RECENT_VISITS_PER_ITEM = 10;
+const MAX_FRECENCY_VISIT_SCORE = 6;
+const BOOKMARK_FRECENCY_BONUS = 0.2;
+
+export const DISCOVERY_RANKING_HISTORY_LIMIT = 200;
+export const DISCOVERY_LOCAL_SEARCH_CANDIDATE_LIMIT = 200;
+
+export type IDiscoverySearchListItem =
+  | {
+      type: 'dapp';
+      source: 'remote' | 'trending';
+      key: string;
+      title: string;
+      url: string;
+      logo?: string;
+      originLogo?: string;
+      isExactUrl?: boolean;
+      keyword?: string;
+      dapp: IDApp;
+    }
+  | {
+      type: 'bookmark';
+      key: string;
+      title: string;
+      url: string;
+      logo?: string;
+      titleMatch?: IFuseResultMatch;
+      urlMatch?: IFuseResultMatch;
+      bookmark: IBrowserBookmark;
+    }
+  | {
+      type: 'history';
+      key: string;
+      title: string;
+      url: string;
+      logo?: string;
+      titleMatch?: IFuseResultMatch;
+      urlMatch?: IFuseResultMatch;
+      history: IBrowserHistory;
+    }
+  | {
+      type: 'search-action';
+      key: string;
+      title: string;
+      url: string;
+      logo?: string;
+    };
+
+type ITopicalityScore = {
+  bucket: number;
+  score: number;
+};
+
+type IHistoryVisitMaps = {
+  originVisitMap: Map<string, IBrowserHistory[]>;
+  urlVisitMap: Map<string, IBrowserHistory[]>;
+};
+
+type ILocalCandidate =
+  | {
+      type: 'bookmark';
+      item: IBrowserBookmark;
+      index: number;
+    }
+  | {
+      type: 'history';
+      item: IBrowserHistory;
+      index: number;
+    };
+
+function normalizeText(text?: string) {
+  return (text ?? '').trim().toLowerCase();
+}
+
+function normalizeUrlLikeText(text?: string) {
+  return normalizeText(text)
+    .replace(/^https?:\/\//, '')
+    .replace(/^www\./, '')
+    .replace(/\/$/, '');
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[[\]()+?*^$.|\\{}]/g, '\\$&');
+}
+
+function makeTopicalityScore(bucket: number, score: number): ITopicalityScore {
+  return { bucket, score };
+}
+
+function compareTopicalityScore(a: ITopicalityScore, b: ITopicalityScore) {
+  if (a.bucket !== b.bucket) {
+    return a.bucket - b.bucket;
+  }
+  return a.score - b.score;
+}
+
+function pickHigherTopicalityScore(
+  current: ITopicalityScore,
+  next: ITopicalityScore,
+) {
+  return compareTopicalityScore(next, current) > 0 ? next : current;
+}
+
+function getHostFromUrl(url?: string) {
+  if (!url) {
+    return '';
+  }
+  return normalizeUrlLikeText(uriUtils.getHostNameFromUrl({ url }));
+}
+
+function getOriginMatchKeys({
+  url,
+  origins,
+}: {
+  url?: string;
+  origins?: string[];
+}) {
+  return Array.from(
+    new Set(
+      [url, ...(origins ?? [])]
+        .filter((item): item is string => Boolean(item))
+        .map((item) => uriUtils.getOriginFromUrl({ url: item }) || item),
+    ),
+  );
+}
+
+function getExactUrlVisitKey(url?: string) {
+  return normalizeUrlLikeText(url);
+}
+
+function hasWordBoundaryMatch(text: string, query: string) {
+  if (!text || !query) {
+    return false;
+  }
+
+  const pattern = new RegExp(`(^|[^a-z0-9])${escapeRegExp(query)}`);
+  return pattern.test(text);
+}
+
+function getTextTopicalityScore({
+  text,
+  query,
+  exactBucket,
+  prefixBucket,
+  substringBucket,
+  exactScore,
+  prefixScore,
+  wordBoundaryScore,
+  substringScore,
+}: {
+  text?: string;
+  query: string;
+  exactBucket: number;
+  prefixBucket: number;
+  substringBucket: number;
+  exactScore: number;
+  prefixScore: number;
+  wordBoundaryScore: number;
+  substringScore: number;
+}) {
+  const normalizedText = normalizeText(text);
+  if (!normalizedText || !query) {
+    return makeTopicalityScore(0, 0);
+  }
+
+  if (normalizedText === query) {
+    return makeTopicalityScore(exactBucket, exactScore);
+  }
+
+  if (normalizedText.startsWith(query)) {
+    return makeTopicalityScore(prefixBucket, prefixScore);
+  }
+
+  if (hasWordBoundaryMatch(normalizedText, query)) {
+    return makeTopicalityScore(prefixBucket, wordBoundaryScore);
+  }
+
+  if (normalizedText.includes(query)) {
+    return makeTopicalityScore(substringBucket, substringScore);
+  }
+
+  return makeTopicalityScore(0, 0);
+}
+
+function getUrlTopicalityScore({
+  url,
+  query,
+}: {
+  url?: string;
+  query: string;
+}) {
+  const normalizedUrl = normalizeUrlLikeText(url);
+  const normalizedHost = getHostFromUrl(url);
+
+  if (!query || (!normalizedUrl && !normalizedHost)) {
+    return makeTopicalityScore(0, 0);
+  }
+
+  if (normalizedUrl === query) {
+    return makeTopicalityScore(6, 120);
+  }
+
+  if (normalizedHost === query) {
+    return makeTopicalityScore(5, 110);
+  }
+
+  if (normalizedHost.startsWith(query)) {
+    return makeTopicalityScore(5, 104);
+  }
+
+  if (hasWordBoundaryMatch(normalizedHost, query)) {
+    return makeTopicalityScore(4, 96);
+  }
+
+  if (normalizedUrl.startsWith(query)) {
+    return makeTopicalityScore(4, 92);
+  }
+
+  if (normalizedUrl.includes(query)) {
+    return makeTopicalityScore(3, 80);
+  }
+
+  return makeTopicalityScore(0, 0);
+}
+
+function getLocalItemTopicalityScore({
+  title,
+  url,
+  query,
+}: {
+  title: string;
+  url: string;
+  query: string;
+}) {
+  let bestScore = getUrlTopicalityScore({ url, query });
+
+  bestScore = pickHigherTopicalityScore(
+    bestScore,
+    getTextTopicalityScore({
+      text: title,
+      query,
+      exactBucket: 5,
+      prefixBucket: 4,
+      substringBucket: 2,
+      exactScore: 106,
+      prefixScore: 94,
+      wordBoundaryScore: 88,
+      substringScore: 64,
+    }),
+  );
+
+  return bestScore;
+}
+
+function getDappTopicalityScore({
+  dapp,
+  query,
+}: {
+  dapp: Pick<IDApp, 'name' | 'url' | 'origins' | 'keyword' | 'tags'>;
+  query: string;
+}) {
+  let bestScore = getUrlTopicalityScore({ url: dapp.url, query });
+
+  (dapp.origins ?? []).forEach((origin) => {
+    bestScore = pickHigherTopicalityScore(
+      bestScore,
+      getUrlTopicalityScore({ url: origin, query }),
+    );
+  });
+
+  bestScore = pickHigherTopicalityScore(
+    bestScore,
+    getTextTopicalityScore({
+      text: dapp.name,
+      query,
+      exactBucket: 5,
+      prefixBucket: 4,
+      substringBucket: 2,
+      exactScore: 108,
+      prefixScore: 98,
+      wordBoundaryScore: 90,
+      substringScore: 68,
+    }),
+  );
+
+  if (dapp.keyword) {
+    bestScore = pickHigherTopicalityScore(
+      bestScore,
+      getTextTopicalityScore({
+        text: dapp.keyword,
+        query,
+        exactBucket: 4,
+        prefixBucket: 3,
+        substringBucket: 2,
+        exactScore: 95,
+        prefixScore: 82,
+        wordBoundaryScore: 76,
+        substringScore: 60,
+      }),
+    );
+  }
+
+  (dapp.tags ?? []).forEach((tag) => {
+    bestScore = pickHigherTopicalityScore(
+      bestScore,
+      getTextTopicalityScore({
+        text: tag.name,
+        query,
+        exactBucket: 3,
+        prefixBucket: 2,
+        substringBucket: 2,
+        exactScore: 74,
+        prefixScore: 66,
+        wordBoundaryScore: 62,
+        substringScore: 56,
+      }),
+    );
+  });
+
+  return bestScore;
+}
+
+function buildVisitMap({
+  history,
+  keyBuilder,
+}: {
+  history: IBrowserHistory[];
+  keyBuilder: (item: IBrowserHistory) => string[];
+}) {
+  const visitMap = new Map<string, IBrowserHistory[]>();
+
+  history.forEach((item) => {
+    keyBuilder(item).forEach((key) => {
+      if (!key) {
+        return;
+      }
+      const visits = visitMap.get(key) ?? [];
+      visits.push(item);
+      visitMap.set(key, visits);
+    });
+  });
+
+  visitMap.forEach((visits, key) => {
+    visitMap.set(
+      key,
+      visits.toSorted((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0)),
+    );
+  });
+
+  return visitMap;
+}
+
+function buildHistoryVisitMaps(history: IBrowserHistory[]): IHistoryVisitMaps {
+  return {
+    originVisitMap: buildVisitMap({
+      history,
+      keyBuilder: (item) => getOriginMatchKeys({ url: item.url }),
+    }),
+    urlVisitMap: buildVisitMap({
+      history,
+      keyBuilder: (item) => [getExactUrlVisitKey(item.url)],
+    }),
+  };
+}
+
+function getLatestVisitTimestamp(visits: IBrowserHistory[]) {
+  return visits[0]?.createdAt ?? 0;
+}
+
+function interpolateScore({
+  value,
+  fromStart,
+  fromEnd,
+  scoreStart,
+  scoreEnd,
+}: {
+  value: number;
+  fromStart: number;
+  fromEnd: number;
+  scoreStart: number;
+  scoreEnd: number;
+}) {
+  if (fromEnd <= fromStart) {
+    return scoreEnd;
+  }
+
+  const progress = (value - fromStart) / (fromEnd - fromStart);
+  return scoreStart + progress * (scoreEnd - scoreStart);
+}
+
+function getRecencyBucketScore({
+  createdAt,
+  now,
+}: {
+  createdAt: number;
+  now: number;
+}) {
+  if (!Number.isFinite(createdAt) || createdAt <= 0) {
+    return 0.1;
+  }
+
+  const ageDays = Math.max(0, (now - createdAt) / DAY_IN_MS);
+
+  if (ageDays <= 4) {
+    return 1;
+  }
+  if (ageDays <= 14) {
+    return interpolateScore({
+      value: ageDays,
+      fromStart: 4,
+      fromEnd: 14,
+      scoreStart: 1,
+      scoreEnd: 0.7,
+    });
+  }
+  if (ageDays <= 31) {
+    return interpolateScore({
+      value: ageDays,
+      fromStart: 14,
+      fromEnd: 31,
+      scoreStart: 0.7,
+      scoreEnd: 0.5,
+    });
+  }
+  if (ageDays <= 90) {
+    return interpolateScore({
+      value: ageDays,
+      fromStart: 31,
+      fromEnd: 90,
+      scoreStart: 0.5,
+      scoreEnd: 0.3,
+    });
+  }
+  if (ageDays <= 365) {
+    return interpolateScore({
+      value: ageDays,
+      fromStart: 90,
+      fromEnd: 365,
+      scoreStart: 0.3,
+      scoreEnd: 0.1,
+    });
+  }
+
+  return 0.1;
+}
+
+function getVisitFrecencyScore({
+  visits,
+  now,
+}: {
+  visits: IBrowserHistory[];
+  now: number;
+}) {
+  return visits.slice(0, MAX_RECENT_VISITS_PER_ITEM).reduce(
+    (score, visit, index) =>
+      score +
+      getRecencyBucketScore({
+        createdAt: visit.createdAt,
+        now,
+      }) *
+        Math.max(0.65, 1 - index * 0.05),
+    0,
+  );
+}
+
+function getFrecencyMultiplier({
+  visits,
+  now,
+  bookmarkBonus = 0,
+}: {
+  visits: IBrowserHistory[];
+  now: number;
+  bookmarkBonus?: number;
+}) {
+  const visitScore = Math.min(
+    getVisitFrecencyScore({
+      visits,
+      now,
+    }),
+    MAX_FRECENCY_VISIT_SCORE,
+  );
+
+  return 1 + visitScore * 0.2 + bookmarkBonus;
+}
+
+function getDappMatchedVisits({
+  dapp,
+  originVisitMap,
+}: {
+  dapp: Pick<IDApp, 'url' | 'origins'>;
+  originVisitMap: Map<string, IBrowserHistory[]>;
+}) {
+  const dedupeSet = new Set<string>();
+  const visits: IBrowserHistory[] = [];
+
+  getOriginMatchKeys({
+    url: dapp.url,
+    origins: dapp.origins,
+  }).forEach((key) => {
+    (originVisitMap.get(key) ?? []).forEach((visit) => {
+      const visitKey = visit.id || `${visit.url}:${visit.createdAt}`;
+      if (dedupeSet.has(visitKey)) {
+        return;
+      }
+      dedupeSet.add(visitKey);
+      visits.push(visit);
+    });
+  });
+
+  return visits.toSorted((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
+}
+
+function getLocalItemMatchedVisits({
+  candidate,
+  urlVisitMap,
+}: {
+  candidate: ILocalCandidate;
+  urlVisitMap: Map<string, IBrowserHistory[]>;
+}) {
+  const visits = urlVisitMap.get(getExactUrlVisitKey(candidate.item.url)) ?? [];
+
+  if (candidate.type === 'history' && visits.length === 0) {
+    return [candidate.item];
+  }
+
+  return visits;
+}
+
+export function rankSearchResultsChromeLike({
+  keyword,
+  searchResult,
+  rankingHistoryData,
+}: {
+  keyword: string;
+  searchResult?: IDApp[];
+  rankingHistoryData?: IBrowserHistory[];
+}) {
+  const normalizedQuery = normalizeUrlLikeText(keyword);
+  const historyVisitMaps = buildHistoryVisitMaps(rankingHistoryData ?? []);
+  const now = Date.now();
+
+  return (searchResult ?? [])
+    .map((item, index) => {
+      const topicality = getDappTopicalityScore({
+        dapp: item,
+        query: normalizedQuery,
+      });
+      const visits = getDappMatchedVisits({
+        dapp: item,
+        originVisitMap: historyVisitMaps.originVisitMap,
+      });
+      const frecencyMultiplier = getFrecencyMultiplier({
+        visits,
+        now,
+      });
+
+      return {
+        item,
+        index,
+        topicality,
+        visits,
+        frecencyMultiplier,
+        finalScore: topicality.score * frecencyMultiplier,
+      };
+    })
+    .toSorted((a, b) => {
+      if (Boolean(a.item.isExactUrl) !== Boolean(b.item.isExactUrl)) {
+        return (
+          Number(Boolean(b.item.isExactUrl)) -
+          Number(Boolean(a.item.isExactUrl))
+        );
+      }
+      if (a.topicality.bucket !== b.topicality.bucket) {
+        return b.topicality.bucket - a.topicality.bucket;
+      }
+      if (a.finalScore !== b.finalScore) {
+        return b.finalScore - a.finalScore;
+      }
+      const latestVisitDiff =
+        getLatestVisitTimestamp(b.visits) - getLatestVisitTimestamp(a.visits);
+      if (latestVisitDiff !== 0) {
+        return latestVisitDiff;
+      }
+      return a.index - b.index;
+    })
+    .map(({ item }) => item);
+}
+
+function rankLocalSearchItems({
+  keyword,
+  rankingHistoryData,
+  bookmarkSearchData,
+  historySearchData,
+}: {
+  keyword: string;
+  rankingHistoryData?: IBrowserHistory[];
+  bookmarkSearchData?: IBrowserBookmark[];
+  historySearchData?: IBrowserHistory[];
+}) {
+  const normalizedQuery = normalizeUrlLikeText(keyword);
+  const historyVisitMaps = buildHistoryVisitMaps(rankingHistoryData ?? []);
+  const now = Date.now();
+  const candidates: ILocalCandidate[] = [
+    ...(bookmarkSearchData ?? []).map(
+      (item, index) =>
+        ({
+          type: 'bookmark',
+          item,
+          index,
+        }) as const,
+    ),
+    ...(historySearchData ?? []).map(
+      (item, index) =>
+        ({
+          type: 'history',
+          item,
+          index,
+        }) as const,
+    ),
+  ];
+
+  return candidates
+    .map((candidate) => {
+      const topicality = getLocalItemTopicalityScore({
+        title: candidate.item.title,
+        url: candidate.item.url,
+        query: normalizedQuery,
+      });
+      const visits = getLocalItemMatchedVisits({
+        candidate,
+        urlVisitMap: historyVisitMaps.urlVisitMap,
+      });
+      const frecencyMultiplier = getFrecencyMultiplier({
+        visits,
+        now,
+        bookmarkBonus:
+          candidate.type === 'bookmark' ? BOOKMARK_FRECENCY_BONUS : 0,
+      });
+
+      return {
+        candidate,
+        topicality,
+        visits,
+        finalScore: topicality.score * frecencyMultiplier,
+      };
+    })
+    .toSorted((a, b) => {
+      if (a.topicality.bucket !== b.topicality.bucket) {
+        return b.topicality.bucket - a.topicality.bucket;
+      }
+      if (a.finalScore !== b.finalScore) {
+        return b.finalScore - a.finalScore;
+      }
+      if (a.candidate.type !== b.candidate.type) {
+        return a.candidate.type === 'bookmark' ? -1 : 1;
+      }
+      const latestVisitDiff =
+        getLatestVisitTimestamp(b.visits) - getLatestVisitTimestamp(a.visits);
+      if (latestVisitDiff !== 0) {
+        return latestVisitDiff;
+      }
+      return a.candidate.index - b.candidate.index;
+    })
+    .map(({ candidate }) => candidate);
+}
+
+export function searchTrendingDappsByKeyword({
+  keyword,
+  trendingData,
+}: {
+  keyword: string;
+  trendingData?: IDApp[];
+}) {
+  if (!keyword) {
+    return [];
+  }
+
+  const fuse = buildFuse(trendingData ?? [], {
+    keys: ['name', 'url', 'origins', 'keyword', 'tags.name'],
+  });
+
+  return fuse.search(keyword).map((item) => item.item);
+}
+
+export function shouldSkipRemoteSearchByKeyword(keyword: string) {
+  return keyword.trim().length <= 3;
+}
+
+function hasMatchKeyOverlap({
+  keys,
+  dedupeKeySet,
+}: {
+  keys: string[];
+  dedupeKeySet: Set<string>;
+}) {
+  return keys.some((key) => dedupeKeySet.has(key));
+}
+
+function appendMatchKeys({
+  keys,
+  dedupeKeySet,
+}: {
+  keys: string[];
+  dedupeKeySet: Set<string>;
+}) {
+  keys.forEach((key) => dedupeKeySet.add(key));
+}
+
+export function mergeSearchResultsWithLocalData({
+  keyword,
+  searchResult,
+  rankingHistoryData,
+  bookmarkSearchData,
+  historySearchData,
+  trendingSearchData,
+}: {
+  keyword: string;
+  searchResult?: IDApp[];
+  rankingHistoryData?: IBrowserHistory[];
+  bookmarkSearchData?: IBrowserBookmark[];
+  historySearchData?: IBrowserHistory[];
+  trendingSearchData?: IDApp[];
+}): IDiscoverySearchListItem[] {
+  const mergedItems: IDiscoverySearchListItem[] = [];
+  const originDedupeKeySet = new Set<string>();
+  const urlDedupeKeySet = new Set<string>();
+
+  const rankedRemoteResults = rankSearchResultsChromeLike({
+    keyword,
+    searchResult,
+    rankingHistoryData,
+  });
+  const rankedTrendingResults = rankSearchResultsChromeLike({
+    keyword,
+    searchResult: trendingSearchData,
+    rankingHistoryData,
+  });
+  const rankedLocalItems = rankLocalSearchItems({
+    keyword,
+    rankingHistoryData,
+    bookmarkSearchData,
+    historySearchData,
+  });
+
+  const exactUrlResults = rankedRemoteResults.filter((item) => item.isExactUrl);
+  const otherRemoteResults = rankedRemoteResults.filter(
+    (item) => !item.isExactUrl,
+  );
+
+  exactUrlResults.forEach((item) => {
+    const keys = getOriginMatchKeys({ url: item.url, origins: item.origins });
+    if (hasMatchKeyOverlap({ keys, dedupeKeySet: originDedupeKeySet })) {
+      return;
+    }
+    appendMatchKeys({ keys, dedupeKeySet: originDedupeKeySet });
+    const urlKey = getExactUrlVisitKey(item.url);
+    if (urlKey) {
+      urlDedupeKeySet.add(urlKey);
+    }
+    mergedItems.push({
+      type: 'dapp',
+      source: 'remote',
+      key: `dapp:${item.dappId}`,
+      title: item.name,
+      url: item.url,
+      logo: item.logo,
+      originLogo: item.originLogo,
+      isExactUrl: item.isExactUrl,
+      keyword: keyword || item.keyword,
+      dapp: item,
+    });
+  });
+
+  rankedLocalItems.forEach((candidate) => {
+    const urlKey = getExactUrlVisitKey(candidate.item.url);
+    if (urlKey && urlDedupeKeySet.has(urlKey)) {
+      return;
+    }
+    if (urlKey) {
+      urlDedupeKeySet.add(urlKey);
+    }
+    appendMatchKeys({
+      keys: getOriginMatchKeys({ url: candidate.item.url }),
+      dedupeKeySet: originDedupeKeySet,
+    });
+
+    if (candidate.type === 'bookmark') {
+      const item = candidate.item;
+      mergedItems.push({
+        type: 'bookmark',
+        key: `bookmark:${item.url}:${candidate.index}`,
+        title: item.title,
+        url: item.url,
+        logo: item.logo,
+        titleMatch: item.titleMatch,
+        urlMatch: item.urlMatch,
+        bookmark: item,
+      });
+      return;
+    }
+
+    const item = candidate.item;
+    mergedItems.push({
+      type: 'history',
+      key: `history:${item.id}`,
+      title: item.title,
+      url: item.url,
+      logo: item.logo,
+      titleMatch: item.titleMatch,
+      urlMatch: item.urlMatch,
+      history: item,
+    });
+  });
+
+  rankedTrendingResults.forEach((item) => {
+    const keys = getOriginMatchKeys({ url: item.url, origins: item.origins });
+    if (hasMatchKeyOverlap({ keys, dedupeKeySet: originDedupeKeySet })) {
+      return;
+    }
+    appendMatchKeys({ keys, dedupeKeySet: originDedupeKeySet });
+    mergedItems.push({
+      type: 'dapp',
+      source: 'trending',
+      key: `trending:${item.dappId}`,
+      title: item.name,
+      url: item.url,
+      logo: item.logo,
+      originLogo: item.originLogo,
+      isExactUrl: item.isExactUrl,
+      keyword: keyword || item.keyword,
+      dapp: item,
+    });
+  });
+
+  otherRemoteResults.forEach((item) => {
+    const keys = getOriginMatchKeys({ url: item.url, origins: item.origins });
+    if (hasMatchKeyOverlap({ keys, dedupeKeySet: originDedupeKeySet })) {
+      return;
+    }
+    appendMatchKeys({ keys, dedupeKeySet: originDedupeKeySet });
+    mergedItems.push({
+      type: 'dapp',
+      source: 'remote',
+      key: `dapp:${item.dappId}`,
+      title: item.name,
+      url: item.url,
+      logo: item.logo,
+      originLogo: item.originLogo,
+      isExactUrl: item.isExactUrl,
+      keyword: keyword || item.keyword,
+      dapp: item,
+    });
+  });
+
+  return mergedItems;
+}


### PR DESCRIPTION
## Summary
- Implement multi-factor ranking algorithm for Discovery search results
- Add character-level fuzzy matching with position-aware scoring
- Include category bonuses (popular dApps, bookmarks, network tokens) and search history personalization
- Add comprehensive test coverage for ranking logic

## Intent & Context
Users reported that Discovery search results were not optimally ordered. The search would return results but popular/frequently-used dApps weren't prioritized, making it harder to find commonly accessed services.

## Design Decisions
- **Multi-factor scoring**: Combined topicality (text match quality), category bonuses, and frecency (recency + frequency) for holistic ranking
- **Bucket-based topicality**: Exact matches > prefix matches > contains > fuzzy matches, with fine-grained scoring within buckets
- **Position-aware matching**: Earlier matches in title/URL score higher than later matches
- **Token-based matching**: Multi-word queries scored by how many tokens match
- **Frecency scoring**: Recent visits weighted more heavily using Mozilla-style time decay buckets

## Changes Detail
- `searchResultRanking.ts`: Core ranking algorithm with topicality, frecency, and category scoring
- `useSearchModalData.ts`: Integrate ranking into search flow, fetch history for personalization
- `ServiceDiscovery.ts`: Add `fetchSearchHistoryForRanking` API for recent history
- `SearchResultContent.tsx`: Update to use new unified search item types
- Added 3 new test files with comprehensive coverage

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: All (Extension / Mobile / Desktop / Web)
- **Risk Areas**: Ranking algorithm changes affect search UX; tests mitigate regression risk

## Test plan
- [ ] Search for popular dApps (uniswap, opensea) and verify they appear at top
- [ ] Search partial terms and verify fuzzy matching works
- [ ] Bookmark a dApp, search for it, verify it ranks higher
- [ ] Visit a dApp multiple times, search for it, verify frecency boost
- [ ] Run `yarn test` to verify all ranking tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
