### PR TITLE
feat(perp): simplify positions empty state(OK-53506)

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PerpPositionsEmptyState.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PerpPositionsEmptyState.tsx
@@ -7,6 +7,7 @@ import {
   SizableText,
   XStack,
   YStack,
+  useMedia,
 } from '@onekeyhq/components';
 import { usePerpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -54,6 +55,7 @@ function ActionButton({
 
 export function PerpPositionsEmptyState({ isMobile }: { isMobile?: boolean }) {
   const intl = useIntl();
+  const { gtMd } = useMedia();
   const { showDepositWithdrawModal } = useShowDepositWithdrawModal();
   const { showGuide } = useShowGuide();
   const [activeAccount] = usePerpsActiveAccountAtom();
@@ -61,6 +63,7 @@ export function PerpPositionsEmptyState({ isMobile }: { isMobile?: boolean }) {
   const buttonWidth = isMobile ? 136 : 132;
   const buttonHeight = isMobile ? 32 : 28;
   const hasAccountAddress = Boolean(activeAccount?.accountAddress);
+  const useGuidePopover = gtMd;
   const guideLabel = intl.formatMessage({
     id: ETranslations.perp_guide_title,
   });
@@ -71,7 +74,7 @@ export function PerpPositionsEmptyState({ isMobile }: { isMobile?: boolean }) {
       variant="secondary"
       icon="BookOpenOutline"
       label={guideLabel}
-      onPress={isMobile ? showGuide : undefined}
+      onPress={useGuidePopover ? undefined : showGuide}
     />
   );
 
@@ -130,12 +133,12 @@ export function PerpPositionsEmptyState({ isMobile }: { isMobile?: boolean }) {
             onPress={() => void showDepositWithdrawModal('deposit')}
             disabled={!hasAccountAddress}
           />
-          {isMobile ? (
-            guideButton
-          ) : (
+          {useGuidePopover ? (
             <YStack width={buttonWidth}>
               <PerpGuidePopover renderTrigger={guideButton} />
             </YStack>
+          ) : (
+            guideButton
           )}
         </XStack>
       </YStack>

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PerpPositionsEmptyState.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PerpPositionsEmptyState.tsx
@@ -91,23 +91,16 @@ export function PerpPositionsEmptyState({ isMobile }: { isMobile?: boolean }) {
       >
         <Illustration name="Orders" size={isMobile ? 88 : 100} mb={-24} />
 
-        <YStack gap="$1" alignItems="center">
-          <SizableText size={isMobile ? '$bodyMdMedium' : '$headingSm'}>
-            {intl.formatMessage({
-              id: ETranslations.perp_position_empty,
-            })}
-          </SizableText>
-          <SizableText
-            size={isMobile ? '$bodyXs' : '$bodySm'}
-            color="$textSubdued"
-            textAlign="center"
-            maxWidth={isMobile ? 280 : 360}
-          >
-            {intl.formatMessage({
-              id: ETranslations.perp_position_empty_desc,
-            })}
-          </SizableText>
-        </YStack>
+        <SizableText
+          size={isMobile ? '$bodyXs' : '$bodySm'}
+          color="$textSubdued"
+          textAlign="center"
+          maxWidth={isMobile ? 280 : 360}
+        >
+          {intl.formatMessage({
+            id: ETranslations.perp_position_empty_desc,
+          })}
+        </SizableText>
 
         <XStack
           gap="$2"

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PerpPositionsEmptyState.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PerpPositionsEmptyState.tsx
@@ -89,11 +89,7 @@ export function PerpPositionsEmptyState({ isMobile }: { isMobile?: boolean }) {
         gap="$3"
         alignItems="center"
       >
-        <Illustration
-          name="Orders"
-          size={isMobile ? 88 : 100}
-          mb={-24}
-        />
+        <Illustration name="Orders" size={isMobile ? 88 : 100} mb={-24} />
 
         <YStack gap="$1" alignItems="center">
           <SizableText size={isMobile ? '$bodyMdMedium' : '$headingSm'}>

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PerpPositionsEmptyState.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PerpPositionsEmptyState.tsx
@@ -12,8 +12,8 @@ import {
 import { usePerpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
-import { useShowGuide } from '../../../hooks/useShowGuide';
 import { useShowDepositWithdrawModal } from '../../../hooks/useShowDepositWithdrawModal';
+import { useShowGuide } from '../../../hooks/useShowGuide';
 import { PerpGuidePopover } from '../../Guide/PerpGuidePopover';
 
 function ActionButton({
@@ -21,7 +21,6 @@ function ActionButton({
   icon,
   width,
   height,
-  variant = 'secondary',
   onPress,
   disabled,
 }: {
@@ -29,7 +28,6 @@ function ActionButton({
   icon: 'DownloadOutline' | 'BookOpenOutline';
   width: number;
   height: number;
-  variant?: 'secondary';
   onPress?: () => void;
   disabled?: boolean;
 }) {
@@ -40,7 +38,7 @@ function ActionButton({
       size="small"
       h={height}
       px="$3"
-      variant={variant}
+      variant="secondary"
       onPress={onPress}
       disabled={disabled}
       childrenAsText={false}
@@ -71,7 +69,6 @@ export function PerpPositionsEmptyState({ isMobile }: { isMobile?: boolean }) {
     <ActionButton
       width={buttonWidth}
       height={buttonHeight}
-      variant="secondary"
       icon="BookOpenOutline"
       label={guideLabel}
       onPress={useGuidePopover ? undefined : showGuide}
@@ -95,7 +92,7 @@ export function PerpPositionsEmptyState({ isMobile }: { isMobile?: boolean }) {
         <Illustration
           name="Orders"
           size={isMobile ? 88 : 100}
-          mb={isMobile ? -24 : -24}
+          mb={-24}
         />
 
         <YStack gap="$1" alignItems="center">
@@ -121,7 +118,6 @@ export function PerpPositionsEmptyState({ isMobile }: { isMobile?: boolean }) {
           flexDirection="row"
           alignItems="center"
           justifyContent="center"
-          flexWrap={isMobile ? 'nowrap' : undefined}
         >
           <ActionButton
             width={buttonWidth}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PerpPositionsEmptyState.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PerpPositionsEmptyState.tsx
@@ -1,0 +1,144 @@
+import { useIntl } from 'react-intl';
+
+import {
+  Button,
+  Icon,
+  Illustration,
+  SizableText,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
+import { usePerpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+
+import { useShowGuide } from '../../../hooks/useShowGuide';
+import { useShowDepositWithdrawModal } from '../../../hooks/useShowDepositWithdrawModal';
+import { PerpGuidePopover } from '../../Guide/PerpGuidePopover';
+
+function ActionButton({
+  label,
+  icon,
+  width,
+  height,
+  variant = 'secondary',
+  onPress,
+  disabled,
+}: {
+  label: string;
+  icon: 'DownloadOutline' | 'BookOpenOutline';
+  width: number;
+  height: number;
+  variant?: 'secondary';
+  onPress?: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <Button
+      width={width}
+      borderRadius="$full"
+      size="small"
+      h={height}
+      px="$3"
+      variant={variant}
+      onPress={onPress}
+      disabled={disabled}
+      childrenAsText={false}
+    >
+      <XStack gap="$1.5" alignItems="center">
+        <Icon name={icon} size="$4" />
+        <SizableText size="$bodySmMedium">{label}</SizableText>
+      </XStack>
+    </Button>
+  );
+}
+
+export function PerpPositionsEmptyState({ isMobile }: { isMobile?: boolean }) {
+  const intl = useIntl();
+  const { showDepositWithdrawModal } = useShowDepositWithdrawModal();
+  const { showGuide } = useShowGuide();
+  const [activeAccount] = usePerpsActiveAccountAtom();
+
+  const buttonWidth = isMobile ? 136 : 132;
+  const buttonHeight = isMobile ? 32 : 28;
+  const hasAccountAddress = Boolean(activeAccount?.accountAddress);
+  const guideLabel = intl.formatMessage({
+    id: ETranslations.perp_guide_title,
+  });
+  const guideButton = (
+    <ActionButton
+      width={buttonWidth}
+      height={buttonHeight}
+      variant="secondary"
+      icon="BookOpenOutline"
+      label={guideLabel}
+      onPress={isMobile ? showGuide : undefined}
+    />
+  );
+
+  return (
+    <YStack
+      flex={1}
+      justifyContent="center"
+      alignItems="center"
+      px="$5"
+      py="$6"
+    >
+      <YStack
+        width="100%"
+        maxWidth={isMobile ? 320 : 420}
+        gap="$3"
+        alignItems="center"
+      >
+        <Illustration
+          name="Orders"
+          size={isMobile ? 88 : 100}
+          mb={isMobile ? -24 : -24}
+        />
+
+        <YStack gap="$1" alignItems="center">
+          <SizableText size={isMobile ? '$bodyMdMedium' : '$headingSm'}>
+            {intl.formatMessage({
+              id: ETranslations.perp_position_empty,
+            })}
+          </SizableText>
+          <SizableText
+            size={isMobile ? '$bodyXs' : '$bodySm'}
+            color="$textSubdued"
+            textAlign="center"
+            maxWidth={isMobile ? 280 : 360}
+          >
+            {intl.formatMessage({
+              id: ETranslations.perp_position_empty_desc,
+            })}
+          </SizableText>
+        </YStack>
+
+        <XStack
+          gap="$2"
+          flexDirection="row"
+          alignItems="center"
+          justifyContent="center"
+          flexWrap={isMobile ? 'nowrap' : undefined}
+        >
+          <ActionButton
+            width={buttonWidth}
+            icon="DownloadOutline"
+            height={buttonHeight}
+            label={intl.formatMessage({
+              id: ETranslations.perp_trade_deposit,
+            })}
+            onPress={() => void showDepositWithdrawModal('deposit')}
+            disabled={!hasAccountAddress}
+          />
+          {isMobile ? (
+            guideButton
+          ) : (
+            <YStack width={buttonWidth}>
+              <PerpGuidePopover renderTrigger={guideButton} />
+            </YStack>
+          )}
+        </XStack>
+      </YStack>
+    </YStack>
+  );
+}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
@@ -309,6 +309,7 @@ export interface ICommonTableListViewProps<T = unknown> {
   ) => ReactElement;
   emptyMessage?: string;
   emptySubMessage?: string;
+  ListEmptyComponent?: ReactElement | null;
   minTableWidth?: number;
   headerBgColor?: string;
   headerTextColor?: string;
@@ -343,6 +344,7 @@ export function CommonTableListView<T>({
   isMobile,
   emptyMessage = 'No data',
   emptySubMessage = 'Data will appear here',
+  ListEmptyComponent,
   minTableWidth: _minTableWidth,
   headerBgColor = '$bgSubtle',
   headerTextColor = '$textSubdued',
@@ -429,6 +431,40 @@ export function CommonTableListView<T>({
     }
   };
   const ListComponent = shouldUseTabsList ? Tabs.FlatList : ListView;
+  const defaultEmptyComponent = (
+    <YStack flex={1} alignItems="center" p="$6">
+      <SizableText size="$bodyMd" color="$textSubdued" textAlign="center">
+        {emptyMessage}
+      </SizableText>
+      <SizableText
+        size="$bodySm"
+        color="$textSubdued"
+        textAlign="center"
+        mt="$2"
+      >
+        {emptySubMessage}
+      </SizableText>
+    </YStack>
+  );
+  const emptyComponent = ListEmptyComponent ?? defaultEmptyComponent;
+  const desktopEmptyComponent = ListEmptyComponent ? (
+    emptyComponent
+  ) : (
+    <YStack flex={1} justifyContent="flex-start" alignItems="flex-start" p="$5">
+      <SizableText size="$bodyMd" color="$text" textAlign="center">
+        {emptyMessage}
+      </SizableText>
+      <SizableText
+        size="$bodySm"
+        color="$textSubdued"
+        textAlign="center"
+        mt="$2"
+      >
+        {emptySubMessage}
+      </SizableText>
+    </YStack>
+  );
+  const showDesktopEmptyState = !listLoading && paginatedData.length === 0;
 
   if (isMobile) {
     const ListContent = (
@@ -467,29 +503,10 @@ export function CommonTableListView<T>({
             return renderRow(item, index, 'full');
           }}
           ListEmptyComponent={
-            listLoading ? (
-              <TradesHistoryLoadingView />
-            ) : (
-              <YStack flex={1} alignItems="center" p="$6">
-                <SizableText
-                  size="$bodyMd"
-                  color="$textSubdued"
-                  textAlign="center"
-                >
-                  {emptyMessage}
-                </SizableText>
-                <SizableText
-                  size="$bodySm"
-                  color="$textSubdued"
-                  textAlign="center"
-                  mt="$2"
-                >
-                  {emptySubMessage}
-                </SizableText>
-              </YStack>
-            )
+            listLoading ? <TradesHistoryLoadingView /> : emptyComponent
           }
           contentContainerStyle={{
+            flexGrow: paginatedData.length === 0 ? 1 : undefined,
             paddingBottom: enablePagination && totalPages > 1 ? 0 : 16,
           }}
         />
@@ -570,7 +587,6 @@ export function CommonTableListView<T>({
       )}
     </XStack>
   );
-
   return (
     <YStack flex={1}>
       <YStack flex={1}>
@@ -620,30 +636,7 @@ export function CommonTableListView<T>({
                     <Spinner size="large" />
                   </YStack>
                 ) : null}
-                {!listLoading && paginatedData.length === 0 ? (
-                  <YStack
-                    flex={1}
-                    justifyContent="flex-start"
-                    alignItems="flex-start"
-                    p="$5"
-                  >
-                    <SizableText
-                      size="$bodyMd"
-                      color="$text"
-                      textAlign="center"
-                    >
-                      {emptyMessage}
-                    </SizableText>
-                    <SizableText
-                      size="$bodySm"
-                      color="$textSubdued"
-                      textAlign="center"
-                      mt="$2"
-                    >
-                      {emptySubMessage}
-                    </SizableText>
-                  </YStack>
-                ) : null}
+                {showDesktopEmptyState ? desktopEmptyComponent : null}
                 {!listLoading && paginatedData.length > 0
                   ? paginatedData.map((item, index) =>
                       renderRow(

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpPositionsList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpPositionsList.tsx
@@ -26,8 +26,8 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { showCloseAllPositionsDialog } from '../CloseAllPositionsModal';
 import { MobilePositionsListHeader } from '../Components/MobilePositionsListHeader';
 import { PerpPositionsEmptyState } from '../Components/PerpPositionsEmptyState';
-import { calcCellAlign, getColumnStyle } from '../utils';
 import { PositionRow } from '../Components/PositionsRow';
+import { calcCellAlign, getColumnStyle } from '../utils';
 
 import { CommonTableListView, type IColumnConfig } from './CommonTableListView';
 

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpPositionsList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpPositionsList.tsx
@@ -4,6 +4,13 @@ import { noop } from 'lodash';
 import { useIntl } from 'react-intl';
 
 import type { IDebugRenderTrackerProps } from '@onekeyhq/components';
+import {
+  ScrollView,
+  SizableText,
+  Tooltip,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
   usePerpsActivePositionAtom,
@@ -18,6 +25,8 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { showCloseAllPositionsDialog } from '../CloseAllPositionsModal';
 import { MobilePositionsListHeader } from '../Components/MobilePositionsListHeader';
+import { PerpPositionsEmptyState } from '../Components/PerpPositionsEmptyState';
+import { calcCellAlign, getColumnStyle } from '../utils';
 import { PositionRow } from '../Components/PositionsRow';
 
 import { CommonTableListView, type IColumnConfig } from './CommonTableListView';
@@ -144,7 +153,7 @@ function PerpPositionsList({
         minWidth: 80,
         align: 'right',
         flex: 1,
-        fixed: true,
+        fixed: positionsLength > 0,
         ...(positionsLength > 0 && {
           onPress: () => showCloseAllPositionsDialog(),
         }),
@@ -202,18 +211,96 @@ function PerpPositionsList({
     />
   );
   const actions = useHyperliquidActions();
+  const listViewDebugRenderTrackerProps = useMemo(
+    (): IDebugRenderTrackerProps => ({
+      name: 'PerpPositionsList',
+      position: 'top-left',
+    }),
+    [],
+  );
+
+  const renderDesktopHeaderCell = (column: IColumnConfig, index: number) => (
+    <XStack
+      key={`${column.key}-${index}`}
+      {...getColumnStyle(column)}
+      justifyContent={calcCellAlign(column.align) as any}
+      cursor="default"
+    >
+      {column.tooltip ? (
+        <Tooltip
+          placement="top"
+          renderTrigger={
+            <SizableText
+              size="$bodySmMedium"
+              borderBottomWidth="$px"
+              borderTopWidth={0}
+              borderLeftWidth={0}
+              borderRightWidth={0}
+              borderBottomColor="$border"
+              borderStyle="dashed"
+              cursor="help"
+              color="$textSubdued"
+              textAlign={column.align || 'left'}
+            >
+              {column.title}
+            </SizableText>
+          }
+          renderContent={column.tooltip}
+        />
+      ) : (
+        <SizableText
+          size="$bodySmMedium"
+          borderBottomWidth="$px"
+          borderBottomColor="transparent"
+          color="$textSubdued"
+          textAlign={column.align || 'left'}
+        >
+          {column.title}
+        </SizableText>
+      )}
+    </XStack>
+  );
+
+  if (!isMobile && mockedPositions.length === 0) {
+    return (
+      <YStack flex={1} width="100%">
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator
+          nestedScrollEnabled
+          contentContainerStyle={{
+            minWidth: totalMinWidth,
+            flexGrow: 1,
+          }}
+        >
+          <XStack
+            flex={1}
+            py="$2"
+            pl="$5"
+            pr="$3"
+            display="flex"
+            minWidth={totalMinWidth}
+            width="100%"
+            borderBottomWidth="$px"
+            borderBottomColor="$borderSubdued"
+            bg="$bgSubtle"
+          >
+            {columnsConfig.map(renderDesktopHeaderCell)}
+          </XStack>
+        </ScrollView>
+        <YStack flex={1} width="100%">
+          <PerpPositionsEmptyState />
+        </YStack>
+      </YStack>
+    );
+  }
+
   return (
     <CommonTableListView
       onPullToRefresh={async () => {
         await actions.current.refreshAllPerpsData();
       }}
-      listViewDebugRenderTrackerProps={useMemo(
-        (): IDebugRenderTrackerProps => ({
-          name: 'PerpPositionsList',
-          position: 'top-left',
-        }),
-        [],
-      )}
+      listViewDebugRenderTrackerProps={listViewDebugRenderTrackerProps}
       useTabsList={useTabsList}
       disableListScroll={disableListScroll}
       currentListPage={currentListPage}
@@ -224,6 +311,7 @@ function PerpPositionsList({
       data={mockedPositions}
       isMobile={isMobile}
       renderRow={renderPositionRow}
+      ListEmptyComponent={<PerpPositionsEmptyState isMobile={isMobile} />}
       emptyMessage={intl.formatMessage({
         id: ETranslations.perp_position_empty,
       })}


### PR DESCRIPTION
## Summary
- simplify the empty state in the Perps Positions tab and keep the actions focused on Deposit and Guide
- add a custom empty-state rendering path so the desktop layout keeps the table header visible while mobile stays compact
- restore the Guide action behavior on large-screen native layouts

## Intent & Context
The Positions empty state needed to be closer to the simpler Bitget-style treatment: less visual noise, smaller actions, and only the most useful entry points.
This PR targets the `release/v6.2.0` line for the Perps empty-state polish.

## Root Cause
For the follow-up fix, the empty-state Guide action was originally branched by the `isMobile` layout prop, while the actual guide presentation behavior is controlled by the media breakpoint. On large-screen native layouts this could render a visible Guide button without an active handler.

## Design Decisions
- keep the empty state specific to the Positions tab instead of changing all order info tables
- add a reusable `ListEmptyComponent` extension in the common table view, but keep a Positions-only desktop empty-state branch to preserve the header row layout
- use the same secondary button style for both Deposit and Guide, and keep the mobile actions side by side

## Changes Detail
- add a dedicated Positions empty-state component with the simplified illustration, copy, and CTA layout
- extend the common table list view to accept a custom empty-state component
- wire the new empty state into the Positions list and keep the desktop header visible when there are no positions
- fix the Guide action so large-screen native layouts open the guide correctly

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile / Desktop / Web
- **Risk Areas**: Perps Positions empty-state rendering and Guide entry behavior on large-screen native layouts

## Test plan
- [ ] Verify the Positions tab shows the simplified empty state when there are no positions
- [ ] Verify Deposit opens the existing deposit flow from the empty state on desktop, web, and mobile
- [ ] Verify Guide opens correctly on mobile, web desktop, and large-screen native layouts
- [ ] Verify the desktop empty state keeps the table header visible and does not affect the populated Positions list

## Jira
- https://onekeyhq.atlassian.net/browse/OK-53506

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
