### PR TITLE
fix: sync swap history badge count with limit orders (OK-53226 OK-53243 OK-53291 OK-53430 OK-53500)

### DIFF
--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -963,30 +963,18 @@ export default class ServiceSwap extends ServiceBase {
       kind,
       walletType,
     };
-    try {
-      const client = await this.getClient(EServiceEndpointEnum.Swap);
-      const { data } = await client.post<IFetchResponse<IFetchBuildTxResponse>>(
-        '/swap/v1/build-tx',
-        params,
-        {
-          headers:
-            await this.backgroundApi.serviceAccountProfile._getWalletTypeHeader(
-              {
-                accountId,
-              },
-            ),
-        },
-      );
-      return data?.data;
-    } catch (e) {
-      const error = e as { code: number; message: string; requestId: string };
-      void this.backgroundApi.serviceApp.showToast({
-        method: 'error',
-        title: error?.message,
-        message: error?.requestId,
-      });
-      throw e;
-    }
+    const client = await this.getClient(EServiceEndpointEnum.Swap);
+    const { data } = await client.post<IFetchResponse<IFetchBuildTxResponse>>(
+      '/swap/v1/build-tx',
+      params,
+      {
+        headers:
+          await this.backgroundApi.serviceAccountProfile._getWalletTypeHeader({
+            accountId,
+          }),
+      },
+    );
+    return data?.data;
   }
 
   @backgroundMethod()

--- a/packages/kit/src/views/Earn/components/Overview.tsx
+++ b/packages/kit/src/views/Earn/components/Overview.tsx
@@ -250,10 +250,10 @@ const OverviewComponent = ({
   );
 
   const handleHistoryPress = useCallback(async () => {
-    if (!evmAccount || !account?.id) return;
+    if (!evmAccount) return;
     const currentEarnAccount =
       await backgroundApiProxy.serviceStaking.getEarnAccount({
-        accountId: account.id,
+        accountId: account?.id || '',
         indexedAccountId: indexedAccount?.id || '',
         networkId: evmNetworkId,
         btcOnlyTaproot: true,

--- a/packages/kit/src/views/Staking/components/ApyChartBase.tsx
+++ b/packages/kit/src/views/Staking/components/ApyChartBase.tsx
@@ -48,6 +48,7 @@ const ApyChartBaseComponent = ({
 }: IApyChartBaseProps) => {
   const intl = useIntl();
   const chartHeight = 200;
+  const POPUP_WIDTH = 160;
   const [hoverData, setHoverData] = useState<{
     time: number;
     apy: number;
@@ -86,19 +87,18 @@ const ApyChartBaseComponent = ({
   const popoverPosition = useMemo(() => {
     if (!hoverData || !containerWidth) return null;
 
-    const POPOVER_WIDTH = 144;
     const OFFSET = 10;
     const EDGE_PADDING = 16;
     const isLeftHalf = hoverData.x < containerWidth / 2;
 
-    const translateXValue = isLeftHalf ? 0 : -POPOVER_WIDTH;
+    const translateXValue = isLeftHalf ? 0 : -POPUP_WIDTH;
     const desiredLeft = isLeftHalf
       ? hoverData.x + OFFSET
       : hoverData.x - OFFSET;
     const minLeft = EDGE_PADDING;
     const maxLeft = Math.max(
       minLeft,
-      containerWidth - POPOVER_WIDTH - EDGE_PADDING,
+      containerWidth - POPUP_WIDTH - EDGE_PADDING,
     );
     const actualLeft = desiredLeft + translateXValue;
     const clampedActualLeft = Math.min(Math.max(actualLeft, minLeft), maxLeft);
@@ -108,7 +108,7 @@ const ApyChartBaseComponent = ({
       translateXValue,
       top: Math.max(10, hoverData.y - 70),
     };
-  }, [hoverData, containerWidth]);
+  }, [hoverData, containerWidth, POPUP_WIDTH]);
 
   const formatPopoverDate = useCallback(
     (timestamp: number) => {
@@ -202,20 +202,24 @@ const ApyChartBaseComponent = ({
               shadowRadius={8}
               zIndex={9999}
               pointerEvents="none"
-              minWidth={144}
+              width={POPUP_WIDTH}
+              overflow="hidden"
             >
               <YStack gap="$1.5" width="100%">
                 <SizableText
                   size="$bodySm"
                   color="$textSubdued"
+                  numberOfLines={1}
                   whiteSpace="nowrap"
                 >
                   {formatPopoverDate(hoverData.time)}
                 </SizableText>
-                <XStack jc="space-between" ai="center" width="100%">
+                <XStack jc="space-between" ai="center" width="100%" gap="$2">
                   <SizableText
                     size="$bodySm"
                     color="$textSubdued"
+                    numberOfLines={1}
+                    flexShrink={1}
                     whiteSpace="nowrap"
                   >
                     {tooltipLabel}

--- a/packages/kit/src/views/Swap/pages/components/LimitOrderOpenItem.tsx
+++ b/packages/kit/src/views/Swap/pages/components/LimitOrderOpenItem.tsx
@@ -30,7 +30,9 @@ const LimitOrderOpenItem = ({
   const openLimitOrder = useMemo(
     () =>
       swapLimitOrders.filter(
-        (order) => order.status === ESwapLimitOrderStatus.OPEN,
+        (order) =>
+          order.status === ESwapLimitOrderStatus.OPEN ||
+          order.status === ESwapLimitOrderStatus.PRESIGNATURE_PENDING,
       ),
     [swapLimitOrders],
   );

--- a/packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx
@@ -57,6 +57,7 @@ import {
 import type { ISwapSlippageSegmentItem } from '@onekeyhq/shared/types/swap/types';
 import {
   EProtocolOfExchange,
+  ESwapLimitOrderStatus,
   ESwapProTradeType,
   ESwapSlippageCustomStatus,
   ESwapSlippageSegmentKey,
@@ -459,7 +460,8 @@ const SwapHeaderRightActionContainer = ({
 }) => {
   const navigation =
     useAppNavigation<IPageNavigationProp<IModalSwapParamList>>();
-  const [{ swapHistoryPendingList }] = useInAppNotificationAtom();
+  const [{ swapHistoryPendingList, swapLimitOrders }] =
+    useInAppNotificationAtom();
   const intl = useIntl();
   const { slippageItem } = useSwapSlippagePercentageModeInfo();
   const [swapTypeSwitch] = useSwapTypeSwitchAtom();
@@ -473,6 +475,17 @@ const SwapHeaderRightActionContainer = ({
       ),
     [swapHistoryPendingList],
   );
+  const limitOpenStatusList = useMemo(
+    () =>
+      swapLimitOrders.filter(
+        (i) =>
+          i.status === ESwapLimitOrderStatus.OPEN ||
+          i.status === ESwapLimitOrderStatus.PRESIGNATURE_PENDING,
+      ),
+    [swapLimitOrders],
+  );
+  const historyBadgeCount =
+    swapPendingStatusList.length + limitOpenStatusList.length;
   const slippageTitle = useMemo(() => {
     if (slippageItem.key === ESwapSlippageSegmentKey.CUSTOM) {
       return (
@@ -567,7 +580,7 @@ const SwapHeaderRightActionContainer = ({
         />
       )}
 
-      {swapPendingStatusList.length > 0 ? (
+      {historyBadgeCount > 0 ? (
         <Stack
           m="$0.5"
           w="$5"
@@ -593,7 +606,7 @@ const SwapHeaderRightActionContainer = ({
           onPress={onOpenHistoryListModal}
         >
           <SizableText color="$text" size="$bodySm">
-            {`${swapPendingStatusList.length}`}
+            {`${historyBadgeCount}`}
           </SizableText>
         </Stack>
       ) : (

--- a/packages/kit/src/views/Swap/pages/modal/SwapHistoryListModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapHistoryListModal.tsx
@@ -14,8 +14,8 @@ import {
   Icon,
   Page,
   Popover,
-  Select,
   SizableText,
+  Stack,
   XStack,
   YStack,
   useMedia,
@@ -24,7 +24,10 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import { LazyHeaderTitle } from '@onekeyhq/kit/src/components/LazyHeaderTitle';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import type { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import { useInAppNotificationAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  filterSwapHistoryPendingList,
+  useInAppNotificationAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import type {
@@ -35,6 +38,7 @@ import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   EProtocolOfExchange,
   ESwapCleanHistorySource,
+  ESwapLimitOrderStatus,
   ESwapTxHistoryStatus,
 } from '@onekeyhq/shared/types/swap/types';
 
@@ -60,7 +64,8 @@ const SwapHistoryListModal = ({
   const [historyType, setHistoryType] = useState<EProtocolOfExchange>(
     type ?? EProtocolOfExchange.SWAP,
   );
-  const [{ swapHistoryPendingList }] = useInAppNotificationAtom();
+  const [{ swapHistoryPendingList, swapLimitOrders }] =
+    useInAppNotificationAtom();
   const { result: swapTxHistoryList } = usePromiseResult(
     async () => {
       const histories =
@@ -109,6 +114,154 @@ const SwapHistoryListModal = ({
       formatterOptions: { currency: '$' },
     });
   }, [swapTxHistoryList]);
+
+  const marketPendingHistoryCount = useMemo(
+    () =>
+      filterSwapHistoryPendingList(swapHistoryPendingList).filter(
+        (item) =>
+          item.status === ESwapTxHistoryStatus.PENDING ||
+          item.status === ESwapTxHistoryStatus.CANCELING,
+      ).length,
+    [swapHistoryPendingList],
+  );
+
+  const limitPendingHistoryCount = useMemo(
+    () =>
+      swapLimitOrders.filter(
+        (item) =>
+          item.status === ESwapLimitOrderStatus.OPEN ||
+          item.status === ESwapLimitOrderStatus.PRESIGNATURE_PENDING,
+      ).length,
+    [swapLimitOrders],
+  );
+
+  const showHistoryInfoDot =
+    marketPendingHistoryCount + limitPendingHistoryCount > 0;
+
+  const historyTypeTitle = useMemo(
+    () =>
+      historyType === EProtocolOfExchange.LIMIT
+        ? intl.formatMessage({
+            id: ETranslations.swap_page_limit_dialog_title,
+          })
+        : intl.formatMessage({
+            id: ETranslations.perp_trade_market,
+          }),
+    [historyType, intl],
+  );
+
+  const renderHistoryTypeBadge = useCallback((count: number) => {
+    if (count <= 0) {
+      return null;
+    }
+
+    return (
+      <Stack
+        minWidth="$5"
+        h="$5"
+        px="$1.5"
+        borderRadius="$full"
+        borderWidth={1}
+        borderColor="$borderSubdued"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <SizableText size="$bodyMd" color="$textSubdued">
+          {count}
+        </SizableText>
+      </Stack>
+    );
+  }, []);
+
+  const handleSelectSwapHistoryType = useCallback(() => {
+    setHistoryType(EProtocolOfExchange.SWAP);
+  }, []);
+
+  const handleSelectLimitHistoryType = useCallback(() => {
+    setHistoryType(EProtocolOfExchange.LIMIT);
+  }, []);
+
+  const renderSwapHistoryTypeLabel = useCallback(
+    () => (
+      <XStack alignItems="center" gap="$2" flex={1}>
+        <SizableText size="$bodyMd" $gtMd={{ size: '$bodyLg' }}>
+          {intl.formatMessage({
+            id: ETranslations.perp_trade_market,
+          })}
+        </SizableText>
+        {renderHistoryTypeBadge(marketPendingHistoryCount)}
+      </XStack>
+    ),
+    [intl, marketPendingHistoryCount, renderHistoryTypeBadge],
+  );
+
+  const renderLimitHistoryTypeLabel = useCallback(
+    () => (
+      <XStack alignItems="center" gap="$2" flex={1}>
+        <SizableText size="$bodyMd" $gtMd={{ size: '$bodyLg' }}>
+          {intl.formatMessage({
+            id: ETranslations.swap_page_limit_dialog_title,
+          })}
+        </SizableText>
+        {renderHistoryTypeBadge(limitPendingHistoryCount)}
+      </XStack>
+    ),
+    [intl, limitPendingHistoryCount, renderHistoryTypeBadge],
+  );
+
+  const historyTypeItems = useMemo(
+    () => [
+      {
+        label: intl.formatMessage({
+          id: ETranslations.perp_trade_market,
+        }),
+        renderLabel: renderSwapHistoryTypeLabel,
+        extra:
+          historyType === EProtocolOfExchange.SWAP ? (
+            <Icon name="CheckLargeOutline" size="$4" color="$iconActive" />
+          ) : undefined,
+        onPress: handleSelectSwapHistoryType,
+      },
+      {
+        label: intl.formatMessage({
+          id: ETranslations.swap_page_limit_dialog_title,
+        }),
+        renderLabel: renderLimitHistoryTypeLabel,
+        extra:
+          historyType === EProtocolOfExchange.LIMIT ? (
+            <Icon name="CheckLargeOutline" size="$4" color="$iconActive" />
+          ) : undefined,
+        onPress: handleSelectLimitHistoryType,
+      },
+    ],
+    [
+      handleSelectLimitHistoryType,
+      handleSelectSwapHistoryType,
+      historyType,
+      intl,
+      renderLimitHistoryTypeLabel,
+      renderSwapHistoryTypeLabel,
+    ],
+  );
+
+  const historyTypeTrigger = useMemo(
+    () => (
+      <XStack alignItems="center" gap="$1" cursor="pointer">
+        <SizableText size="$headingLg">{historyTypeTitle}</SizableText>
+        {showHistoryInfoDot ? (
+          <Stack
+            w="$2"
+            h="$2"
+            borderRadius="$full"
+            backgroundColor="$textInfo"
+            pointerEvents="none"
+          />
+        ) : null}
+        <Icon name="ChevronDownSmallSolid" size="$5" />
+      </XStack>
+    ),
+    [historyTypeTitle, showHistoryInfoDot],
+  );
 
   const onDeleteHistory = useCallback(() => {
     // dialog
@@ -335,48 +488,18 @@ const SwapHistoryListModal = ({
     ],
   );
 
-  const headerSelectType = useMemo(() => {
-    const title =
-      historyType === EProtocolOfExchange.LIMIT
-        ? intl.formatMessage({
-            id: ETranslations.swap_page_limit_dialog_title,
-          })
-        : intl.formatMessage({
-            id: ETranslations.perp_trade_market,
-          });
-    const renderHeaderTitle = () => (
+  const headerSelectType = useCallback(
+    () => (
       <LazyHeaderTitle>
-        <Select
-          title={title}
-          items={[
-            {
-              label: intl.formatMessage({
-                id: ETranslations.perp_trade_market,
-              }),
-              value: EProtocolOfExchange.SWAP,
-            },
-            {
-              label: intl.formatMessage({
-                id: ETranslations.swap_page_limit_dialog_title,
-              }),
-              value: EProtocolOfExchange.LIMIT,
-            },
-          ]}
-          onChange={(value) => {
-            setHistoryType(value as EProtocolOfExchange);
-          }}
-          value={historyType}
-          renderTrigger={(props) => (
-            <XStack {...props} alignItems="center" gap="$1" cursor="pointer">
-              <SizableText size="$headingLg">{title}</SizableText>
-              <Icon name="ChevronDownSmallSolid" size="$5" />
-            </XStack>
-          )}
+        <ActionList
+          title={historyTypeTitle}
+          items={historyTypeItems}
+          renderTrigger={historyTypeTrigger}
         />
       </LazyHeaderTitle>
-    );
-    return renderHeaderTitle;
-  }, [historyType, intl]);
+    ),
+    [historyTypeItems, historyTypeTitle, historyTypeTrigger],
+  );
 
   const savingsBanner = useMemo(() => {
     if (

--- a/packages/kit/src/views/Swap/pages/modal/SwapHistoryListModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapHistoryListModal.tsx
@@ -156,20 +156,20 @@ const SwapHistoryListModal = ({
     }
 
     return (
-      <Stack
+      <Badge
+        badgeType="default"
+        badgeSize="sm"
         minWidth="$5"
         h="$5"
-        px="$1.5"
+        px="$0"
+        bg="$transparent"
         borderRadius="$full"
         borderWidth={1}
         borderColor="$borderSubdued"
-        alignItems="center"
         justifyContent="center"
       >
-        <SizableText size="$bodyMd" color="$textSubdued">
-          {count}
-        </SizableText>
-      </Stack>
+        <Badge.Text>{count}</Badge.Text>
+      </Badge>
     );
   }, []);
 


### PR DESCRIPTION
## Summary
- Sync the Swap page header history badge with open limit orders so the count matches the unified history navigation under Swap / Bridge / Limit.
- Tighten the Borrow reserve APY chart tooltip layout on iOS so the hover card no longer stretches across the chart and long labels stay readable.
- Fix Earn Home referral reward history so it still opens when the current network has no created address but the wallet has an indexed account that can resolve the EVM earn account.
- Remove the extra manual toast in `ServiceSwap.fetchBuildTx` so swap build-tx failures surface through a single shared error toast.
- Add pending/open status hints to the Swap history type selector so users can see when Market or Limit history has content behind the dropdown before opening it.
- Align the selector count badge with the system `Badge` layout so the number is centered inside the circle.

## Issues
- OK-53226
- OK-53243
- OK-53291
- OK-53430
- OK-53500

## Root Cause
### OK-53226
The Swap page header badge only counted local pending Swap/Bridge history from `swapHistoryPendingList`. Limit orders come from a different source, `swapLimitOrders`, so the badge could show `1` while the Limit page itself showed multiple open orders. The green limit entry also only counted `OPEN`, while the Limit list treats `PRESIGNATURE_PENDING` as open.

### OK-53243
`ApyChartBase` positioned the tooltip using a fixed 144px width assumption, but the Borrow APY tooltip container only had `minWidth`. On iOS the inner `width="100%"` rows could expand the popover far beyond the positioning math, so the hover card stretched across the chart.

### OK-53291
The Earn Home `Overview` rebate history action returned early when `activeAccount.account.id` was missing. In the reported scenario, the current network had no created address, but `indexedAccountId` was still available and `serviceStaking.getEarnAccount()` could resolve the EVM earn account from it. The extra `account?.id` guard caused the history action to do nothing.

### OK-53430
`ServiceSwap.fetchBuildTx()` had two toast paths for the same failure:
1. a local `catch` block calling `serviceApp.showToast(...)`
2. the `@toastIfError()` decorator, which feeds the shared auto-toast flow

When build-tx failed, both toasts rendered.

### OK-53500
The Swap history type selector only exposed text labels, so users had no inline cue that Market history still had pending swap records or that Limit history still had open orders. The state already existed in `swapHistoryPendingList` and `swapLimitOrders`, but the selector UI did not surface it. After adding the badge, the count was visually off-center because it used a hand-rolled stack instead of the system badge text layout.

## Design Decisions
- For `OK-53226`, keep the fix local to Swap UI counters: aggregate `swapHistoryPendingList` with open limit orders in the header badge, and align the green limit entry with the same open-order definition used by the limit list (`OPEN + PRESIGNATURE_PENDING`).
- For `OK-53243`, keep the fix inside shared `ApyChartBase` because Borrow reserve details are the only current caller and the positioning math should stay consistent with the rendered width. Use a slightly wider fixed popup width plus single-line truncation instead of fully dynamic width, so the tooltip stays aligned near chart edges.
- For `OK-53291`, keep the fix in `Overview.tsx` and allow `getEarnAccount()` to fall back to `indexedAccountId` instead of broadening lower-level account semantics.
- For `OK-53430`, remove only the local manual toast and keep `@toastIfError()` so the shared support toast UI remains unchanged.
- For `OK-53500`, keep the status hint local to the history selector entry point: show the blue dot only when either side has pending/open content, show per-option count badges only when the count is greater than zero, reuse the same pending/open definitions that already drive the existing Swap history counters, and render the count with the system `Badge` component so alignment matches existing UI.

## Changes Detail
- `packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx`
  - add open limit order count into the right-top history badge total
  - keep the existing navigation target unchanged
- `packages/kit/src/views/Swap/pages/components/LimitOrderOpenItem.tsx`
  - treat `PRESIGNATURE_PENDING` as an open limit order so the green limit entry matches the limit list behavior
- `packages/kit/src/views/Staking/components/ApyChartBase.tsx`
  - align tooltip width with the popover positioning math
  - widen the popup slightly to 160px
  - add truncation/flex-shrink guards so long labels do not blow out the layout
- `packages/kit/src/views/Earn/components/Overview.tsx`
  - remove the unnecessary `account?.id` early-return guard from referral reward history navigation
  - pass `account?.id || ''` so `indexedAccountId` can still resolve the EVM earn account
- `packages/kit-bg/src/services/ServiceSwap.ts`
  - remove the local duplicate error toast in `fetchBuildTx()`
  - keep shared auto-toast behavior unchanged
- `packages/kit/src/views/Swap/pages/modal/SwapHistoryListModal.tsx`
  - add a blue status dot to the history type selector trigger when either Market or Limit has pending/open content
  - add per-option count badges to the selector menu and hide them when the count is zero
  - switch the count badge to the system `Badge` layout so the number is centered in the circle

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile / Desktop / Extension / Web
- **Risk Areas**:
  - Swap header history badge count and limit open-order entry copy/count
  - Borrow reserve details APY tooltip layout
  - Earn referral reward history navigation on Home
  - Swap build-tx error presentation only
  - Swap history selector status hint rendering

## Test plan
- [x] Run `npx eslint packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx packages/kit/src/views/Swap/pages/components/LimitOrderOpenItem.tsx --ext .tsx --cache`
- [x] Verify with 1 pending Swap/Bridge item and 2 open Limit orders that the right-top badge shows `3`
- [x] Verify the green limit entry count matches the open Limit list count
- [x] Run `npx eslint packages/kit/src/views/Staking/components/ApyChartBase.tsx --ext .tsx --cache`
- [x] Verify Borrow reserve APY tooltip layout in iOS simulator by pressing and dragging across the chart
- [x] Run `yarn eslint packages/kit/src/views/Earn/components/Overview.tsx`
- [x] Verify Earn Home referral reward history opens even when the current network has no created address
- [x] Run `npx eslint packages/kit-bg/src/services/ServiceSwap.ts --ext .ts --cache`
- [x] Trigger a swap build-tx failure and verify only one toast is shown
- [x] Verify the remaining toast still shows `Contact Us` and `Copy`
- [x] Run `./node_modules/.bin/eslint packages/kit/src/views/Swap/pages/modal/SwapHistoryListModal.tsx --ext .tsx`
- [x] Verify the selector trigger shows the blue dot only when Market or Limit has pending/open content
- [x] Verify Market / Limit badges are hidden when the count is `0`
- [x] Verify the count badge text is visually centered inside the circle on mobile

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
