### PR TITLE
fix(swap): unblock swap on first actionable quote (OK-52655)

### DIFF
--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -86,7 +86,10 @@ import {
   swapProTradeTypeAtom,
   swapProUseSelectBuyTokenAtom,
   swapQuoteActionLockAtom,
+  swapQuoteCurrentEventProviderKeysAtom,
+  swapQuoteCurrentEventReceivedCountAtom,
   swapQuoteCurrentSelectAtom,
+  swapQuoteEventCompletedAtom,
   swapQuoteEventErrorAtom,
   swapQuoteEventTotalCountAtom,
   swapQuoteFetchingAtom,
@@ -107,6 +110,11 @@ import {
   swapTokenMetadataAtom,
   swapTypeSwitchAtom,
 } from './atoms';
+import {
+  buildSwapQuoteProviderKey,
+  getSwapQuoteProgressState,
+  isSwapQuoteEventFetching,
+} from './quoteProgress';
 
 class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
   private quoteInterval: ReturnType<typeof setTimeout> | undefined;
@@ -189,6 +197,26 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
 
   cleanManualSelectQuoteProviders = contextAtomMethod((get, set) => {
     set(swapManualSelectQuoteProvidersAtom(), undefined);
+  });
+
+  reconcileManualSelectQuoteProviders = contextAtomMethod((get, set) => {
+    const selectionIntent = get(swapManualSelectQuoteProvidersAtom());
+    if (selectionIntent?.type !== 'manual-provider') {
+      return;
+    }
+
+    const currentEventProviderKeys = get(
+      swapQuoteCurrentEventProviderKeysAtom(),
+    );
+    const quoteEventTotalCount = get(swapQuoteEventTotalCountAtom());
+    if (
+      quoteEventTotalCount.count === 0 ||
+      !currentEventProviderKeys.includes(
+        buildSwapQuoteProviderKey(selectionIntent),
+      )
+    ) {
+      set(swapManualSelectQuoteProvidersAtom(), undefined);
+    }
   });
 
   catchSwapTokensMap = contextAtomMethod(
@@ -516,9 +544,18 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
               }
             : {}),
         });
+        const currentEventProviderKeys = res.map((quote) =>
+          buildSwapQuoteProviderKey(quote),
+        );
         if (!loadingDelayEnable) {
           set(swapQuoteFetchingAtom(), false);
           set(swapQuoteListAtom(), res);
+          set(
+            swapQuoteCurrentEventProviderKeysAtom(),
+            currentEventProviderKeys,
+          );
+          set(swapQuoteCurrentEventReceivedCountAtom(), res.length);
+          set(swapQuoteEventCompletedAtom(), true);
           set(swapQuoteEventTotalCountAtom(), {
             count: res.length,
           });
@@ -527,6 +564,12 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
           setTimeout(() => {
             set(swapSilenceQuoteLoading(), false);
             set(swapQuoteListAtom(), res);
+            set(
+              swapQuoteCurrentEventProviderKeysAtom(),
+              currentEventProviderKeys,
+            );
+            set(swapQuoteCurrentEventReceivedCountAtom(), res.length);
+            set(swapQuoteEventCompletedAtom(), true);
             set(swapQuoteEventTotalCountAtom(), {
               count: res.length,
             });
@@ -566,15 +609,25 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
             const errorData = dataJson as ISwapQuoteEventError;
             if (errorData?.errorMessage) {
               set(swapQuoteListAtom(), []);
+              set(swapQuoteCurrentEventProviderKeysAtom(), []);
+              set(swapQuoteCurrentEventReceivedCountAtom(), 0);
+              set(swapQuoteEventCompletedAtom(), true);
               set(swapQuoteEventTotalCountAtom(), { count: 0 });
               set(swapQuoteFetchingAtom(), false);
               set(swapQuoteEventErrorAtom(), errorData.errorMessage);
+              this.reconcileManualSelectQuoteProviders.call(set);
+              set(swapQuoteActionLockAtom(), (v) => ({
+                ...v,
+                actionLock: false,
+              }));
+              this.closeQuoteEvent();
               break;
             }
             const autoSlippageData = dataJson as ISwapQuoteEventAutoSlippage;
             if (autoSlippageData?.autoSuggestedSlippage) {
               const {
                 autoSuggestedSlippage,
+                eventId,
                 fromNetworkId,
                 fromTokenAddress,
                 toNetworkId,
@@ -597,6 +650,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
                       contractAddress: toTokenAddress,
                     },
                   }) &&
+                  quotRes.eventId === eventId &&
                   !quotRes.autoSuggestedSlippage
                 ) {
                   return {
@@ -611,12 +665,16 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
                 value: autoSuggestedSlippage,
                 from: `${fromNetworkId}-${fromTokenAddress}`,
                 to: `${toNetworkId}-${toTokenAddress}`,
+                eventId,
               });
             } else if (
               (dataJson as ISwapQuoteEventInfo).totalQuoteCount ||
               (dataJson as ISwapQuoteEventInfo).totalQuoteCount === 0
             ) {
               const { totalQuoteCount } = dataJson as ISwapQuoteEventInfo;
+              set(swapQuoteCurrentEventProviderKeysAtom(), []);
+              set(swapQuoteCurrentEventReceivedCountAtom(), 0);
+              set(swapQuoteEventCompletedAtom(), false);
               set(swapQuoteEventTotalCountAtom(), {
                 eventId: (dataJson as ISwapQuoteEventInfo).eventId,
                 count: totalQuoteCount,
@@ -648,6 +706,8 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
                         swapAutoSlippageSuggestedValue?.from &&
                       `${quote.toTokenInfo.networkId}-${quote.toTokenInfo.contractAddress}` ===
                         swapAutoSlippageSuggestedValue?.to &&
+                      quote.eventId ===
+                        swapAutoSlippageSuggestedValue?.eventId &&
                       swapAutoSlippageSuggestedValue.value &&
                       !quote.autoSuggestedSlippage
                     ) {
@@ -714,6 +774,20 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
                       quoteEventTotalCount.eventId === q.eventId,
                   );
                 set(swapQuoteListAtom(), [...newQuoteList]);
+                set(swapQuoteCurrentEventProviderKeysAtom(), (keys) => [
+                  ...new Set([
+                    ...keys,
+                    ...quoteResultData.data.map((quote) =>
+                      buildSwapQuoteProviderKey(quote),
+                    ),
+                  ]),
+                ]);
+                set(swapQuoteCurrentEventReceivedCountAtom(), (count) =>
+                  Math.min(
+                    quoteEventTotalCount.count,
+                    count + quoteResultData.data.length,
+                  ),
+                );
               }
               set(swapQuoteFetchingAtom(), false);
             }
@@ -721,6 +795,8 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
           break;
         }
         case 'done': {
+          this.reconcileManualSelectQuoteProviders.call(set);
+          set(swapQuoteEventCompletedAtom(), true);
           set(swapQuoteActionLockAtom(), (v) => ({ ...v, actionLock: false }));
           if (platformEnv.isExtension) {
             set(swapQuoteFetchingAtom(), false);
@@ -729,13 +805,15 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
           break;
         }
         case 'error': {
-          if (platformEnv.isExtension) {
-            set(swapQuoteFetchingAtom(), false);
-          }
+          this.reconcileManualSelectQuoteProviders.call(set);
+          set(swapQuoteEventCompletedAtom(), true);
+          set(swapQuoteFetchingAtom(), false);
+          set(swapQuoteActionLockAtom(), (v) => ({ ...v, actionLock: false }));
           this.closeQuoteEvent();
           break;
         }
         case 'close': {
+          set(swapQuoteEventCompletedAtom(), true);
           set(swapQuoteFetchingAtom(), false);
           set(swapQuoteActionLockAtom(), (v) => ({ ...v, actionLock: false }));
           break;
@@ -780,6 +858,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       await backgroundApiProxy.serviceSwap.closeApproving();
       set(swapQuoteEventErrorAtom(), '');
       set(swapQuoteFetchingAtom(), true);
+      set(swapQuoteEventCompletedAtom(), false);
       const limitUserMarketPrice = get(swapLimitPriceUseRateAtom());
       await backgroundApiProxy.serviceSwap.fetchQuotesEvents({
         fromToken,
@@ -812,6 +891,9 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
     const fromTokenAmount = get(swapFromTokenAmountAtom());
     const toTokenAmount = get(swapToTokenAmountAtom());
     set(swapQuoteFetchingAtom(), false);
+    set(swapQuoteCurrentEventProviderKeysAtom(), []);
+    set(swapQuoteCurrentEventReceivedCountAtom(), 0);
+    set(swapQuoteEventCompletedAtom(), false);
     set(swapQuoteEventTotalCountAtom(), {
       count: 0,
     });
@@ -890,6 +972,10 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       if (!unResetCount) {
         set(swapQuoteIntervalCountAtom(), 0);
       }
+      set(swapQuoteCurrentEventProviderKeysAtom(), []);
+      set(swapQuoteCurrentEventReceivedCountAtom(), 0);
+      set(swapQuoteEventCompletedAtom(), false);
+      set(swapQuoteEventTotalCountAtom(), { count: 0 });
       set(swapBuildTxFetchingAtom(), false);
       set(swapShouldRefreshQuoteAtom(), false);
       const fromTokenAmountNumber = Number(fromTokenAmount.value);
@@ -1165,8 +1251,23 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       const swapSupportAllNetworks = get(swapNetworksIncludeAllNetworkAtom());
       const quoteResult = get(swapQuoteCurrentSelectAtom());
       const tokenMetadata = get(swapTokenMetadataAtom());
-      const quoteResultList = get(swapQuoteListAtom());
+      const quoteLoading =
+        get(swapQuoteFetchingAtom()) || get(swapSilenceQuoteLoading());
       const quoteEventTotalCount = get(swapQuoteEventTotalCountAtom());
+      const quoteEventCompleted = get(swapQuoteEventCompletedAtom());
+      const currentEventReceivedCount = get(
+        swapQuoteCurrentEventReceivedCountAtom(),
+      );
+      const quoteEventFetching = isSwapQuoteEventFetching({
+        quoteEventTotalCount,
+        currentEventReceivedCount,
+        quoteEventCompleted,
+      });
+      const { isWaitingActionableQuote } = getSwapQuoteProgressState({
+        quoteLoading,
+        quoteEventFetching,
+        quoteCurrentSelect: quoteResult,
+      });
       const fromTokenAmount = get(swapFromTokenAmountAtom());
       let alertsRes: ISwapAlertState[] = [];
       const quoteEventError = get(swapQuoteEventErrorAtom());
@@ -1206,8 +1307,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       if (
         !networks.length ||
         !swapFromAddressInfo.accountInfo?.ready ||
-        (quoteEventTotalCount.count > 0 &&
-          quoteResultList.length < quoteEventTotalCount.count)
+        isWaitingActionableQuote
       ) {
         if (quoteEventError) {
           set(swapAlertsAtom(), {
@@ -1995,6 +2095,9 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       }
       // OK-49718: Clear quote list when switching type to prevent showing stale data
       set(swapQuoteListAtom(), []);
+      set(swapQuoteCurrentEventProviderKeysAtom(), []);
+      set(swapQuoteCurrentEventReceivedCountAtom(), 0);
+      set(swapQuoteEventCompletedAtom(), false);
       set(swapQuoteEventTotalCountAtom(), { count: 0 });
       set(swapTypeSwitchAtom(), type);
       if (platformEnv.isNative && type === ESwapTabSwitchType.LIMIT) {

--- a/packages/kit/src/states/jotai/contexts/swap/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/atoms.ts
@@ -4,10 +4,7 @@ import { ESwapDirection } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/co
 import type { IToken } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/components/SwapPanel/types';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { dangerAllNetworkRepresent } from '@onekeyhq/shared/src/config/presetNetworks';
-import {
-  selectBestQuote,
-  sortSwapQuotes,
-} from '@onekeyhq/shared/src/utils/swapQuoteSortUtils';
+import { sortSwapQuotes } from '@onekeyhq/shared/src/utils/swapQuoteSortUtils';
 import {
   checkWrappedTokenPair,
   equalTokenNoCaseSensitive,
@@ -48,6 +45,12 @@ import {
 } from '@onekeyhq/shared/types/swap/types';
 
 import { createJotaiContext } from '../../utils/createJotaiContext';
+
+import {
+  type ISwapQuoteSelectionIntent,
+  buildSwapQuoteProviderKey,
+  selectSwapCurrentQuote,
+} from './quoteProgress';
 
 import type { IAccountSelectorActiveAccountInfo } from '../accountSelector';
 
@@ -186,7 +189,7 @@ export const {
 export const {
   atom: swapManualSelectQuoteProvidersAtom,
   use: useSwapManualSelectQuoteProvidersAtom,
-} = contextAtom<IFetchQuoteResult | undefined>(undefined);
+} = contextAtom<ISwapQuoteSelectionIntent | undefined>(undefined);
 
 export const { atom: swapQuoteListAtom, use: useSwapQuoteListAtom } =
   contextAtom<IFetchQuoteResult[]>([]);
@@ -223,15 +226,45 @@ export const {
 });
 
 export const {
+  atom: swapQuoteEventCompletedAtom,
+  use: useSwapQuoteEventCompletedAtom,
+} = contextAtom<boolean>(false);
+
+export const {
+  atom: swapQuoteCurrentEventProviderKeysAtom,
+  use: useSwapQuoteCurrentEventProviderKeysAtom,
+} = contextAtom<string[]>([]);
+
+export const {
+  atom: swapQuoteCurrentEventReceivedCountAtom,
+  use: useSwapQuoteCurrentEventReceivedCountAtom,
+} = contextAtom<number>(0);
+
+export const {
   atom: swapShouldRefreshQuoteAtom,
   use: useSwapShouldRefreshQuoteAtom,
 } = contextAtom<boolean>(false);
 
 export const {
+  atom: swapQuoteCurrentEventListAtom,
+  use: useSwapQuoteCurrentEventListAtom,
+} = contextAtomComputed<IFetchQuoteResult[]>((get) => {
+  const list = get(swapQuoteListAtom());
+  const quoteEventTotalCount = get(swapQuoteEventTotalCountAtom());
+  const currentEventProviderKeys = get(swapQuoteCurrentEventProviderKeysAtom());
+  const currentEventProviderKeySet = new Set(currentEventProviderKeys);
+  return quoteEventTotalCount.count > 0
+    ? list.filter((quote) =>
+        currentEventProviderKeySet.has(buildSwapQuoteProviderKey(quote)),
+      )
+    : list;
+});
+
+export const {
   atom: swapSortedQuoteListAtom,
   use: useSwapSortedQuoteListAtom,
 } = contextAtomComputed<IFetchQuoteResult[]>((get) => {
-  const list = get(swapQuoteListAtom());
+  const list = get(swapQuoteCurrentEventListAtom());
   const fromTokenAmount = get(swapFromTokenAmountAtom());
   const sortType = get(swapProviderSortAtom());
   return sortSwapQuotes(list, {
@@ -244,10 +277,20 @@ export const {
   atom: swapQuoteCurrentSelectAtom,
   use: useSwapQuoteCurrentSelectAtom,
 } = contextAtomComputed((get) => {
-  const list = get(swapSortedQuoteListAtom());
-  const manualSelectQuoteProviders = get(swapManualSelectQuoteProvidersAtom());
-  return selectBestQuote(list, {
-    manualSelect: manualSelectQuoteProviders ?? undefined,
+  const list = get(swapQuoteCurrentEventListAtom());
+  const fromTokenAmount = get(swapFromTokenAmountAtom());
+  const selectionIntent = get(swapManualSelectQuoteProvidersAtom());
+  const quoteEventTotalCount = get(swapQuoteEventTotalCountAtom());
+  const currentEventProviderKeys = get(swapQuoteCurrentEventProviderKeysAtom());
+  const recommendedSortedList = sortSwapQuotes(list, {
+    sort: ESwapProviderSort.RECOMMENDED,
+    fromTokenAmount: fromTokenAmount.value,
+  });
+  return selectSwapCurrentQuote({
+    currentEventSortedQuotes: recommendedSortedList,
+    selectionIntent: selectionIntent ?? undefined,
+    quoteEventTotalCount,
+    currentEventProviderKeys,
   });
 });
 

--- a/packages/kit/src/states/jotai/contexts/swap/quoteProgress.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/quoteProgress.ts
@@ -1,0 +1,148 @@
+import BigNumber from 'bignumber.js';
+
+import { selectBestQuote } from '@onekeyhq/shared/src/utils/swapQuoteSortUtils';
+import type { IFetchQuoteResult } from '@onekeyhq/shared/types/swap/types';
+
+type ISwapActionableQuote = Pick<IFetchQuoteResult, 'toAmount'>;
+type ISwapQuoteProviderIdentity = Pick<
+  IFetchQuoteResult['info'],
+  'provider' | 'providerName'
+>;
+export type ISwapQuoteSelectionIntent = {
+  type: 'manual-provider';
+  info: ISwapQuoteProviderIdentity;
+};
+
+type ISwapQuoteProgressInput = {
+  quoteLoading: boolean;
+  quoteEventFetching: boolean;
+  quoteCurrentSelect?: ISwapActionableQuote;
+};
+
+type ISwapQuoteProgressState = {
+  quoteLoading: boolean;
+  quoteEventFetching: boolean;
+  hasActionableQuote: boolean;
+  isWaitingActionableQuote: boolean;
+};
+
+type ISwapQuoteEventFetchingInput = {
+  quoteEventTotalCount: {
+    count: number;
+  };
+  currentEventReceivedCount: number;
+  quoteEventCompleted: boolean;
+};
+
+type ISwapCurrentQuoteInput = {
+  currentEventSortedQuotes: IFetchQuoteResult[];
+  selectionIntent?: ISwapQuoteSelectionIntent;
+  quoteEventTotalCount: {
+    count: number;
+    eventId?: string;
+  };
+  currentEventProviderKeys: string[];
+};
+
+export function buildSwapQuoteProviderKey(quote: {
+  info: ISwapQuoteProviderIdentity;
+}) {
+  return `${quote.info.provider}-${quote.info.providerName}`;
+}
+
+export function buildSwapManualProviderSelectionIntent(
+  quote: { info: ISwapQuoteProviderIdentity } | undefined,
+): ISwapQuoteSelectionIntent | undefined {
+  if (!quote) {
+    return undefined;
+  }
+
+  return {
+    type: 'manual-provider',
+    info: {
+      provider: quote.info.provider,
+      providerName: quote.info.providerName,
+    },
+  };
+}
+
+export function hasSwapCurrentEventProvider(
+  quote: { info: ISwapQuoteProviderIdentity } | undefined,
+  currentEventProviderKeys: string[],
+) {
+  if (!quote) {
+    return false;
+  }
+
+  return currentEventProviderKeys.includes(buildSwapQuoteProviderKey(quote));
+}
+
+export function isSwapQuoteEventFetching({
+  quoteEventTotalCount,
+  currentEventReceivedCount,
+  quoteEventCompleted,
+}: ISwapQuoteEventFetchingInput) {
+  return (
+    quoteEventTotalCount.count > 0 &&
+    !quoteEventCompleted &&
+    currentEventReceivedCount < quoteEventTotalCount.count
+  );
+}
+
+export function selectSwapCurrentQuote({
+  currentEventSortedQuotes,
+  selectionIntent,
+  quoteEventTotalCount,
+  currentEventProviderKeys,
+}: ISwapCurrentQuoteInput) {
+  if (selectionIntent?.type === 'manual-provider') {
+    const manualQuote = currentEventSortedQuotes.find(
+      (quote) =>
+        buildSwapQuoteProviderKey(quote) ===
+        buildSwapQuoteProviderKey(selectionIntent),
+    );
+
+    if (manualQuote) {
+      if (isSwapQuoteActionable(manualQuote)) {
+        return manualQuote;
+      }
+
+      return (
+        selectBestQuote(
+          currentEventSortedQuotes.filter(isSwapQuoteActionable),
+        ) ?? manualQuote
+      );
+    }
+
+    if (
+      quoteEventTotalCount.count > 0 &&
+      !hasSwapCurrentEventProvider(selectionIntent, currentEventProviderKeys)
+    ) {
+      return undefined;
+    }
+  }
+
+  return selectBestQuote(currentEventSortedQuotes);
+}
+
+export function isSwapQuoteActionable(
+  quoteCurrentSelect?: ISwapActionableQuote,
+) {
+  return new BigNumber(quoteCurrentSelect?.toAmount ?? 0).gt(0);
+}
+
+export function getSwapQuoteProgressState({
+  quoteLoading,
+  quoteEventFetching,
+  quoteCurrentSelect,
+}: ISwapQuoteProgressInput): ISwapQuoteProgressState {
+  const hasActionableQuote = isSwapQuoteActionable(quoteCurrentSelect);
+
+  return {
+    quoteLoading,
+    quoteEventFetching,
+    hasActionableQuote,
+    isWaitingActionableQuote:
+      quoteLoading || (quoteEventFetching && !hasActionableQuote),
+  };
+}

--- a/packages/kit/src/views/Swap/components/SwapProviderListPanel.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProviderListPanel.tsx
@@ -22,13 +22,20 @@ import {
   useSwapFromTokenAmountAtom,
   useSwapManualSelectQuoteProvidersAtom,
   useSwapProviderSortAtom,
+  useSwapQuoteCurrentEventProviderKeysAtom,
+  useSwapQuoteCurrentEventReceivedCountAtom,
   useSwapQuoteCurrentSelectAtom,
   useSwapQuoteEventTotalCountAtom,
   useSwapSelectFromTokenAtom,
   useSwapSelectToTokenAtom,
   useSwapSortedQuoteListAtom,
+  useSwapToTokenAmountAtom,
   useSwapTypeSwitchAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
+import {
+  buildSwapManualProviderSelectionIntent,
+  buildSwapQuoteProviderKey,
+} from '@onekeyhq/kit/src/states/jotai/contexts/swap/quoteProgress';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
@@ -128,31 +135,55 @@ const SwapProviderListPanel = ({
   const intl = useIntl();
   const [swapSortedList] = useSwapSortedQuoteListAtom();
   const [fromTokenAmount] = useSwapFromTokenAmountAtom();
+  const [toTokenAmount] = useSwapToTokenAmountAtom();
   const [fromToken] = useSwapSelectFromTokenAtom();
   const [toToken] = useSwapSelectToTokenAtom();
-  const [, setSwapManualSelect] = useSwapManualSelectQuoteProvidersAtom();
+  const [manualSelectQuoteProvider, setSwapManualSelect] =
+    useSwapManualSelectQuoteProvidersAtom();
   const [providerSort, setProviderSort] = useSwapProviderSortAtom();
   const [settingsPersist] = useSettingsPersistAtom();
   const [currentSelectQuote] = useSwapQuoteCurrentSelectAtom();
+  const selectedProviderInfo =
+    currentSelectQuote?.info ?? manualSelectQuoteProvider?.info;
   const quoteLoading = useSwapQuoteLoading();
   const quoteEventFetching = useSwapQuoteEventFetching();
   const [swapTypeSwitch] = useSwapTypeSwitchAtom();
   const [quoteEventTotalCount] = useSwapQuoteEventTotalCountAtom();
+  const [currentEventReceivedCount] =
+    useSwapQuoteCurrentEventReceivedCountAtom();
+  const [currentEventProviderKeys] = useSwapQuoteCurrentEventProviderKeysAtom();
+  const currentEventProviderKeySet = useMemo(
+    () => new Set(currentEventProviderKeys),
+    [currentEventProviderKeys],
+  );
+  const quoteListForDisplay = useMemo(
+    () =>
+      quoteEventTotalCount.count > 0
+        ? swapSortedList.filter((item) =>
+            currentEventProviderKeySet.has(buildSwapQuoteProviderKey(item)),
+          )
+        : swapSortedList,
+    [currentEventProviderKeySet, quoteEventTotalCount.count, swapSortedList],
+  );
 
   // Cache the previous list to show during refresh (prevents flash to empty)
   const cachedListRef = useRef<IFetchQuoteResult[]>([]);
   // Track if this is first load vs refresh
   const hadPreviousQuotesRef = useRef(false);
-  // Track token changes to reset cache
-  const prevTokenKeyRef = useRef('');
-  const currentTokenKey = `${fromToken?.contractAddress ?? ''}-${
+  // Track quote context changes to reset cache
+  const quoteInputAmount =
+    fromTokenAmount.isInput || !toTokenAmount.isInput
+      ? fromTokenAmount.value
+      : toTokenAmount.value;
+  const prevQuoteContextKeyRef = useRef('');
+  const currentQuoteContextKey = `${swapTypeSwitch}-${
+    fromToken?.networkId ?? ''
+  }-${fromToken?.contractAddress ?? ''}-${toToken?.networkId ?? ''}-${
     toToken?.contractAddress ?? ''
-  }`;
+  }-${quoteInputAmount}`;
   // Track if we're in a refresh cycle (list was cleared but we had data)
   const isRefreshingRef = useRef(false);
-  // Track swap type switch changes to reset cache (OK-49718)
-  const prevSwapTypeSwitchRef = useRef(swapTypeSwitch);
-  // Track quote event id changes to reset cache when new quote starts (OK-49718)
+  // Track quote event id changes to detect new quote cycles (OK-49718)
   const prevQuoteEventIdRef = useRef(quoteEventTotalCount.eventId);
   // Track if waiting for new quote to prevent flash to empty state (OK-49718)
   const isWaitingForNewQuoteRef = useRef(false);
@@ -164,42 +195,34 @@ const SwapProviderListPanel = ({
   // Track previous loading state for detecting when loading completes
   const prevIsLoadingRef = useRef(false);
 
-  // Reset cache when tokens change
-  if (prevTokenKeyRef.current !== currentTokenKey) {
-    prevTokenKeyRef.current = currentTokenKey;
+  // Reset cache when tokens, swap type, or the user-entered amount changes.
+  if (prevQuoteContextKeyRef.current !== currentQuoteContextKey) {
+    prevQuoteContextKeyRef.current = currentQuoteContextKey;
     cachedListRef.current = [];
     hadPreviousQuotesRef.current = false;
     isRefreshingRef.current = false;
     isWaitingForNewQuoteRef.current = true;
   }
 
-  // Reset cache when swap type switch changes (Swap/Limit/Bridge) (OK-49718)
-  if (prevSwapTypeSwitchRef.current !== swapTypeSwitch) {
-    prevSwapTypeSwitchRef.current = swapTypeSwitch;
-    cachedListRef.current = [];
-    hadPreviousQuotesRef.current = false;
-    isRefreshingRef.current = false;
-    isWaitingForNewQuoteRef.current = true;
-  }
-
-  // Reset cache when a new quote event starts (different eventId means new quote request) (OK-49718)
-  // Also reset when quote is cleared (eventId becomes undefined or count becomes 0)
-  if (
-    prevQuoteEventIdRef.current !== quoteEventTotalCount.eventId ||
-    (quoteEventTotalCount.count === 0 && prevQuoteEventIdRef.current)
-  ) {
+  // A new event for the same quote context is usually an auto-refresh; keep the
+  // previous list until the new event returns its first provider.
+  if (prevQuoteEventIdRef.current !== quoteEventTotalCount.eventId) {
     prevQuoteEventIdRef.current = quoteEventTotalCount.eventId;
-    cachedListRef.current = [];
-    hadPreviousQuotesRef.current = false;
-    isRefreshingRef.current = false;
     isWaitingForNewQuoteRef.current = true;
   }
 
   const isLoading = quoteLoading || quoteEventFetching;
 
+  if (!isLoading && quoteEventTotalCount.count === 0) {
+    cachedListRef.current = [];
+    hadPreviousQuotesRef.current = false;
+    isRefreshingRef.current = false;
+    isWaitingForNewQuoteRef.current = false;
+  }
+
   // Detect refresh: list becomes empty while we had previous data
   if (
-    swapSortedList.length === 0 &&
+    quoteListForDisplay.length === 0 &&
     hadPreviousQuotesRef.current &&
     cachedListRef.current.length > 0
   ) {
@@ -210,8 +233,8 @@ const SwapProviderListPanel = ({
   const wasWaitingForNewQuote = isWaitingForNewQuoteRef.current;
 
   // Update cache when we have new data
-  if (swapSortedList.length > 0) {
-    cachedListRef.current = swapSortedList;
+  if (quoteListForDisplay.length > 0) {
+    cachedListRef.current = quoteListForDisplay;
     hadPreviousQuotesRef.current = true;
     isRefreshingRef.current = false;
     isWaitingForNewQuoteRef.current = false;
@@ -221,10 +244,10 @@ const SwapProviderListPanel = ({
   // Show cached data when: loading with empty list but had previous data, OR during refresh
   const displayList =
     (isLoading || isRefreshingRef.current) &&
-    swapSortedList.length === 0 &&
+    quoteListForDisplay.length === 0 &&
     cachedListRef.current.length > 0
       ? cachedListRef.current
-      : swapSortedList;
+      : quoteListForDisplay;
 
   // Track previous provider keys to determine which items are new
   const prevProviderKeysRef = useRef<Set<string>>(new Set());
@@ -315,13 +338,13 @@ const SwapProviderListPanel = ({
     if (
       wasLoading &&
       !isLoading &&
-      currentSelectQuote &&
+      selectedProviderInfo &&
       availableList.length > 0
     ) {
       const selectedIndex = availableList.findIndex(
         (item) =>
-          item.info.provider === currentSelectQuote.info.provider &&
-          item.info.providerName === currentSelectQuote.info.providerName,
+          item.info.provider === selectedProviderInfo.provider &&
+          item.info.providerName === selectedProviderInfo.providerName,
       );
 
       if (selectedIndex > 0 && scrollViewRef.current) {
@@ -334,17 +357,17 @@ const SwapProviderListPanel = ({
         }, 100);
       }
     }
-  }, [isLoading, currentSelectQuote, availableList]);
+  }, [isLoading, selectedProviderInfo, availableList]);
 
   const onSelectQuote = useCallback(
     (item: IFetchQuoteResult) => {
-      setSwapManualSelect(item);
+      setSwapManualSelect(buildSwapManualProviderSelectionIntent(item));
       defaultLogger.swap.providerChange.providerChange({
-        changeFrom: currentSelectQuote?.info.provider ?? '-',
+        changeFrom: selectedProviderInfo?.provider ?? '-',
         changeTo: item.info.provider,
       });
     },
-    [setSwapManualSelect, currentSelectQuote?.info.provider],
+    [setSwapManualSelect, selectedProviderInfo?.provider],
   );
 
   const renderItem = useCallback(
@@ -382,8 +405,8 @@ const SwapProviderListPanel = ({
                 : undefined
             }
             selected={Boolean(
-              item.info.provider === currentSelectQuote?.info.provider &&
-              item.info.providerName === currentSelectQuote?.info.providerName,
+              item.info.provider === selectedProviderInfo?.provider &&
+              item.info.providerName === selectedProviderInfo?.providerName,
             )}
             fromTokenAmount={fromTokenAmount.value}
             fromToken={fromToken}
@@ -396,11 +419,11 @@ const SwapProviderListPanel = ({
       );
     },
     [
-      currentSelectQuote?.info.provider,
-      currentSelectQuote?.info.providerName,
       fromToken,
       fromTokenAmount,
       onSelectQuote,
+      selectedProviderInfo?.provider,
+      selectedProviderInfo?.providerName,
       settingsPersist.currencyInfo.symbol,
       toToken,
     ],
@@ -666,7 +689,7 @@ const SwapProviderListPanel = ({
   // Number of skeleton placeholders for providers not yet received
   const remainingSkeletonCount =
     hasReceivedTotal && quoteEventFetching
-      ? Math.max(0, quoteEventTotalCount.count - displayList.length)
+      ? Math.max(0, quoteEventTotalCount.count - currentEventReceivedCount)
       : 0;
 
   const contentArea = (

--- a/packages/kit/src/views/Swap/hooks/useSwapQuote.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapQuote.ts
@@ -48,6 +48,7 @@ import {
   useSwapToTokenAmountAtom,
   useSwapTypeSwitchAtom,
 } from '../../../states/jotai/contexts/swap';
+import { buildSwapManualProviderSelectionIntent } from '../../../states/jotai/contexts/swap/quoteProgress';
 import { truncateDecimalPlaces } from '../utils/utils';
 
 import { useSwapAddressInfo } from './useSwapAccount';
@@ -576,26 +577,14 @@ export function useSwapQuote() {
       if (swapShouldRefreshRef.current) {
         return;
       }
-      setSwapManualSelectQuoteProviders({
-        protocol: data.approvedSwapInfo.protocol,
-        quoteId: data.approvedSwapInfo?.quoteId,
-        info: {
-          provider: data.approvedSwapInfo.provider,
-          providerName: data.approvedSwapInfo.providerName,
-        },
-        fromTokenInfo: {
-          networkId: data.approvedSwapInfo.fromToken.networkId,
-          contractAddress: data.approvedSwapInfo.fromToken.contractAddress,
-          symbol: data.approvedSwapInfo.fromToken.symbol,
-          decimals: data.approvedSwapInfo.fromToken.decimals,
-        },
-        toTokenInfo: {
-          networkId: data.approvedSwapInfo.toToken.networkId,
-          contractAddress: data.approvedSwapInfo.toToken.contractAddress,
-          symbol: data.approvedSwapInfo.toToken.symbol,
-          decimals: data.approvedSwapInfo.toToken.decimals,
-        },
-      });
+      setSwapManualSelectQuoteProviders(
+        buildSwapManualProviderSelectionIntent({
+          info: {
+            provider: data.approvedSwapInfo.provider,
+            providerName: data.approvedSwapInfo.providerName,
+          },
+        }),
+      );
       const { approvedSwapInfo, enableFilled } = data;
       const {
         fromToken: fromTokenInfo,

--- a/packages/kit/src/views/Swap/hooks/useSwapState.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapState.ts
@@ -40,11 +40,12 @@ import {
   useSwapLimitPriceUseRateAtom,
   useSwapProTradeTypeAtom,
   useSwapQuoteApproveAllowanceUnLimitAtom,
+  useSwapQuoteCurrentEventReceivedCountAtom,
   useSwapQuoteCurrentSelectAtom,
+  useSwapQuoteEventCompletedAtom,
   useSwapQuoteEventTotalCountAtom,
   useSwapQuoteFetchingAtom,
   useSwapQuoteIntervalCountAtom,
-  useSwapQuoteListAtom,
   useSwapSelectFromTokenAtom,
   useSwapSelectToTokenAtom,
   useSwapSelectedFromTokenBalanceAtom,
@@ -54,6 +55,10 @@ import {
   useSwapToTokenAmountAtom,
   useSwapTypeSwitchAtom,
 } from '../../../states/jotai/contexts/swap';
+import {
+  getSwapQuoteProgressState,
+  isSwapQuoteEventFetching,
+} from '../../../states/jotai/contexts/swap/quoteProgress';
 import { buildSwapBatchTransferType } from '../utils/buildSwapReviewState';
 
 import { useSwapAddressInfo } from './useSwapAccount';
@@ -129,18 +134,31 @@ export function useSwapQuoteLoading() {
 
 export function useSwapQuoteEventFetching() {
   const [quoteEventTotalCount] = useSwapQuoteEventTotalCountAtom();
-  const [quoteResult] = useSwapQuoteListAtom();
+  const [quoteEventCompleted] = useSwapQuoteEventCompletedAtom();
+  const [currentEventReceivedCount] =
+    useSwapQuoteCurrentEventReceivedCountAtom();
 
-  if (quoteEventTotalCount.count > 0) {
-    if (
-      quoteResult?.every((q) => q.eventId === quoteEventTotalCount.eventId) &&
-      quoteResult.length === quoteEventTotalCount.count
-    ) {
-      return false;
-    }
-    return true;
-  }
-  return false;
+  return isSwapQuoteEventFetching({
+    quoteEventTotalCount,
+    currentEventReceivedCount,
+    quoteEventCompleted,
+  });
+}
+
+export function useSwapQuoteProgressState() {
+  const quoteLoading = useSwapQuoteLoading();
+  const quoteEventFetching = useSwapQuoteEventFetching();
+  const [quoteCurrentSelect] = useSwapQuoteCurrentSelectAtom();
+
+  return useMemo(
+    () =>
+      getSwapQuoteProgressState({
+        quoteLoading,
+        quoteEventFetching,
+        quoteCurrentSelect,
+      }),
+    [quoteCurrentSelect, quoteEventFetching, quoteLoading],
+  );
 }
 
 export function useSwapBatchTransferType(
@@ -164,8 +182,8 @@ export function useSwapBatchTransferType(
 
 export function useSwapActionState() {
   const intl = useIntl();
-  const quoteLoading = useSwapQuoteLoading();
-  const quoteEventFetching = useSwapQuoteEventFetching();
+  const { quoteLoading, quoteEventFetching, isWaitingActionableQuote } =
+    useSwapQuoteProgressState();
   const [quoteCurrentSelect] = useSwapQuoteCurrentSelectAtom();
   const [buildTxFetching] = useSwapBuildTxFetchingAtom();
   const [fromTokenAmount] = useSwapFromTokenAmountAtom();
@@ -173,6 +191,9 @@ export function useSwapActionState() {
   const [toToken] = useSwapSelectToTokenAtom();
   const [toTokenAmount] = useSwapToTokenAmountAtom();
   const [shouldRefreshQuote] = useSwapShouldRefreshQuoteAtom();
+  const [{ swapSlippagePercentageMode }] = useSettingsAtom();
+  const [quoteEventTotalCount] = useSwapQuoteEventTotalCountAtom();
+  const [quoteEventCompleted] = useSwapQuoteEventCompletedAtom();
   const [swapQuoteApproveAllowanceUnLimit] =
     useSwapQuoteApproveAllowanceUnLimitAtom();
   useSwapWarningCheck();
@@ -244,6 +265,23 @@ export function useSwapActionState() {
     ],
   );
   const quoteResultNoMatchDebounce = useDebounce(quoteResultNoMatch, 10);
+  const isWaitingAutoSlippage = useMemo(
+    () =>
+      swapSlippagePercentageMode === ESwapSlippageSegmentKey.AUTO &&
+      quoteEventTotalCount.count > 0 &&
+      !quoteEventCompleted &&
+      quoteCurrentSelect?.protocol === EProtocolOfExchange.SWAP &&
+      !quoteCurrentSelect.unSupportSlippage &&
+      isNil(quoteCurrentSelect.autoSuggestedSlippage),
+    [
+      quoteCurrentSelect?.autoSuggestedSlippage,
+      quoteCurrentSelect?.protocol,
+      quoteCurrentSelect?.unSupportSlippage,
+      quoteEventCompleted,
+      quoteEventTotalCount.count,
+      swapSlippagePercentageMode,
+    ],
+  );
   const actionInfo = useMemo(() => {
     const infoRes = {
       disable: !(!hasError && !!quoteCurrentSelect),
@@ -280,8 +318,8 @@ export function useSwapActionState() {
       infoRes.disable = true;
     }
     if (
-      quoteLoading ||
-      quoteEventFetching ||
+      isWaitingActionableQuote ||
+      isWaitingAutoSlippage ||
       swapApprovingMatchLoading ||
       buildTxFetching
     ) {
@@ -378,8 +416,8 @@ export function useSwapActionState() {
     swapTypeSwitchValue,
     isRefreshQuote,
     toTokenAmount.value,
-    quoteLoading,
-    quoteEventFetching,
+    isWaitingActionableQuote,
+    isWaitingAutoSlippage,
     swapApprovingMatchLoading,
     buildTxFetching,
     selectedFromTokenBalance,
@@ -395,8 +433,8 @@ export function useSwapActionState() {
     noConnectWallet: actionInfo.noConnectWallet,
     disabled:
       actionInfo.disable ||
-      quoteLoading ||
-      quoteEventFetching ||
+      isWaitingActionableQuote ||
+      isWaitingAutoSlippage ||
       swapApprovingMatchLoading,
     approveUnLimit: swapQuoteApproveAllowanceUnLimit,
     isApprove: !!quoteCurrentSelect?.allowanceResult,
@@ -408,6 +446,7 @@ export function useSwapActionState() {
       (isRefreshQuote || quoteResultNoMatchDebounce) &&
       !quoteLoading &&
       !quoteEventFetching,
+    isWaitingAutoSlippage,
   };
   return stepState;
 }

--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -69,8 +69,7 @@ import {
 } from '../../hooks/useSwapIncognitoRecipientInput';
 import {
   useSwapActionState,
-  useSwapQuoteEventFetching,
-  useSwapQuoteLoading,
+  useSwapQuoteProgressState,
   useSwapSlippagePercentageModeInfo,
 } from '../../hooks/useSwapState';
 import { buildSwapIncognitoSettingsUpdate } from '../../utils/incognitoSettings';
@@ -121,7 +120,8 @@ const SwapActionsState = ({
     setSettings,
   ] = useSettingsAtom();
   const [settingsPersistAtom] = useSettingsPersistAtom();
-  const quoteLoading = useSwapQuoteLoading();
+  const { quoteLoading, quoteEventFetching, isWaitingActionableQuote } =
+    useSwapQuoteProgressState();
   const swapRecipientAddressInfo = useSwapRecipientAddressInfo(
     swapEnableRecipientAddress,
   );
@@ -129,7 +129,6 @@ const SwapActionsState = ({
     swapSlippageRef.current = slippageItem;
   }
   const themeVariant = useThemeVariant();
-  const quoting = useSwapQuoteEventFetching();
   const [desktopActionWidth, setDesktopActionWidth] = useState<number>();
 
   const isModalPage = useIsOverlayPage();
@@ -728,7 +727,7 @@ const SwapActionsState = ({
       new BigNumber(currentQuoteRes?.fee?.costSavings || 0).gt(0);
 
     if (hasCostSavings) {
-      const isLoadingQuote = quoting || quoteLoading;
+      const isLoadingQuote = quoteEventFetching || quoteLoading;
       const shouldShow = hasEverShownCostSavingsRef.current || !isLoadingQuote;
 
       if (shouldShow) {
@@ -770,7 +769,7 @@ const SwapActionsState = ({
   }, [
     currentQuoteRes?.fee?.costSavings,
     settingsPersistAtom.currencyInfo.symbol,
-    quoting,
+    quoteEventFetching,
     quoteLoading,
     intl,
   ]);
@@ -809,7 +808,7 @@ const SwapActionsState = ({
 
   const actionButtonChildren = useMemo(
     () =>
-      quoting || quoteLoading ? (
+      isWaitingActionableQuote || swapActionState.isWaitingAutoSlippage ? (
         <LottieView
           source={
             themeVariant === 'light'
@@ -826,7 +825,12 @@ const SwapActionsState = ({
       ) : (
         swapActionState.label
       ),
-    [quoteLoading, quoting, swapActionState.label, themeVariant],
+    [
+      isWaitingActionableQuote,
+      swapActionState.isWaitingAutoSlippage,
+      swapActionState.label,
+      themeVariant,
+    ],
   );
 
   const actionRowComponent = useMemo(

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -248,8 +248,8 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
   }
 
   const quoteResultRef = useRef<IFetchQuoteResult | undefined>(undefined);
-  if (quoteResultRef.current !== currentQuoteRes) {
-    quoteResultRef.current = currentQuoteRes;
+  if (quoteResultRef.current !== swapStepData.quoteResult) {
+    quoteResultRef.current = swapStepData.quoteResult;
   }
 
   const preSwapDataRef = useRef<ISwapPreSwapData | undefined>(undefined);
@@ -516,6 +516,9 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     if (isWrapped) {
       return false;
     }
+    if (quoteEventFetching) {
+      return false;
+    }
     if (currentQuoteRes && !currentQuoteRes?.allowanceResult) {
       return true;
     }
@@ -525,7 +528,12 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
         fromSelectToken?.networkId ?? '',
       )
     );
-  }, [currentQuoteRes, fromSelectToken?.networkId, isWrapped]);
+  }, [
+    currentQuoteRes,
+    fromSelectToken?.networkId,
+    isWrapped,
+    quoteEventFetching,
+  ]);
 
   const reviewStepTexts = useMemo(
     () => ({

--- a/packages/kit/src/views/Swap/pages/components/SwapProActionButton.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProActionButton.tsx
@@ -34,7 +34,7 @@ import {
   useSwapProInputToken,
   useSwapProToToken,
 } from '../../hooks/useSwapPro';
-import { useSwapQuoteLoading } from '../../hooks/useSwapState';
+import { useSwapQuoteProgressState } from '../../hooks/useSwapState';
 
 const MAX_BUTTON_CHARS = 25;
 
@@ -157,7 +157,7 @@ const SwapProActionButton = ({
   const [swapQuoteResult] = useSwapQuoteCurrentSelectAtom();
   const [swapProQuoteResult] = useSwapSpeedQuoteResultAtom();
   const swapProAccount = useSwapProAccount();
-  const quoteLoading = useSwapQuoteLoading();
+  const { isWaitingActionableQuote } = useSwapQuoteProgressState();
   const currencyInfo = useCurrency();
   const [quoteFetching] = useSwapSpeedQuoteFetchingAtom();
   const [swapProInputAmount] = useSwapProInputAmountAtom();
@@ -351,8 +351,8 @@ const SwapProActionButton = ({
     if (swapProTradeType === ESwapProTradeType.MARKET) {
       return quoteFetching;
     }
-    return quoteLoading;
-  }, [swapProTradeType, quoteLoading, quoteFetching]);
+    return isWaitingActionableQuote;
+  }, [swapProTradeType, isWaitingActionableQuote, quoteFetching]);
   const actionButtonDisabled = useMemo(() => {
     let originalDisabled =
       !hasEnoughBalance ||

--- a/packages/kit/src/views/Swap/pages/components/SwapQuoteInput.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapQuoteInput.tsx
@@ -17,10 +17,7 @@ import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
 
 import { useSwapFromAccountNetworkSync } from '../../hooks/useSwapAccount';
 import { useSwapLimitPriceCheck } from '../../hooks/useSwapPro';
-import {
-  useSwapQuoteEventFetching,
-  useSwapQuoteLoading,
-} from '../../hooks/useSwapState';
+import { useSwapQuoteProgressState } from '../../hooks/useSwapState';
 
 import SwapInputContainer from './SwapInputContainer';
 
@@ -39,8 +36,7 @@ const SwapQuoteInput = ({
 }: ISwapQuoteInputProps) => {
   const [fromInputAmount, setFromInputAmount] = useSwapFromTokenAmountAtom();
   const [toInputAmount, setToInputAmount] = useSwapToTokenAmountAtom();
-  const swapQuoteLoading = useSwapQuoteLoading();
-  const quoteEventFetching = useSwapQuoteEventFetching();
+  const { isWaitingActionableQuote } = useSwapQuoteProgressState();
   const [fromToken] = useSwapSelectFromTokenAtom();
   const [toToken] = useSwapSelectToTokenAtom();
   const [swapTokenDetailLoading] = useSwapSelectTokenDetailFetchingAtom();
@@ -65,7 +61,7 @@ const SwapQuoteInput = ({
       <SwapInputContainer
         token={fromToken}
         direction={ESwapDirectionType.FROM}
-        inputLoading={swapQuoteLoading || quoteEventFetching}
+        inputLoading={isWaitingActionableQuote}
         selectTokenLoading={selectLoading}
         onAmountChange={(value) => {
           if (validateAmountInput(value, fromToken?.decimals)) {
@@ -111,7 +107,7 @@ const SwapQuoteInput = ({
       </Stack>
       <SwapInputContainer
         token={toToken}
-        inputLoading={swapQuoteLoading || quoteEventFetching}
+        inputLoading={isWaitingActionableQuote}
         selectTokenLoading={selectLoading}
         direction={ESwapDirectionType.TO}
         onAmountChange={(value) => {

--- a/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
@@ -48,8 +48,8 @@ import SwapQuoteResultRate from '../../components/SwapQuoteResultRate';
 import { useSwapLimitConfigMaps } from '../../hooks/useSwapGlobal';
 import { useSwapSlippageActions } from '../../hooks/useSwapSlippageActions';
 import {
-  useSwapQuoteEventFetching,
   useSwapQuoteLoading,
+  useSwapQuoteProgressState,
 } from '../../hooks/useSwapState';
 
 import SwapApproveAllowanceSelectContainer from './SwapApproveAllowanceSelectContainer';
@@ -85,6 +85,7 @@ const SwapQuoteResult = ({
   const [swapLimitPartiallyFill, setSwapLimitPartiallyFill] =
     useSwapLimitPartiallyFillAtom();
   const swapQuoteLoading = useSwapQuoteLoading();
+  const { isWaitingActionableQuote } = useSwapQuoteProgressState();
   const [swapTypeSwitch] = useSwapTypeSwitchAtom();
   const intl = useIntl();
   const { onSlippageHandleClick, slippageItem } = useSwapSlippageActions();
@@ -161,7 +162,7 @@ const SwapQuoteResult = ({
     [calculateTaxItem],
   );
 
-  const quoting = useSwapQuoteEventFetching();
+  const quoting = isWaitingActionableQuote;
 
   const { limitOrderExpiryStepMap, limitOrderPartiallyFillStepMap } =
     useSwapLimitConfigMaps();
@@ -197,7 +198,7 @@ const SwapQuoteResult = ({
     );
   }
   if (swapTypeSwitch === ESwapTabSwitchType.LIMIT) {
-    if (quoting || swapQuoteLoading) {
+    if (isWaitingActionableQuote) {
       return (
         <XStack alignItems="center">
           <XStack gap="$2">

--- a/packages/kit/src/views/Swap/pages/modal/SwapProviderSelectModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapProviderSelectModal.tsx
@@ -22,11 +22,17 @@ import {
   useSwapFromTokenAmountAtom,
   useSwapManualSelectQuoteProvidersAtom,
   useSwapProviderSortAtom,
+  useSwapQuoteCurrentEventProviderKeysAtom,
   useSwapQuoteCurrentSelectAtom,
+  useSwapQuoteEventTotalCountAtom,
   useSwapSelectFromTokenAtom,
   useSwapSelectToTokenAtom,
   useSwapSortedQuoteListAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
+import {
+  buildSwapManualProviderSelectionIntent,
+  buildSwapQuoteProviderKey,
+} from '@onekeyhq/kit/src/states/jotai/contexts/swap/quoteProgress';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
@@ -70,10 +76,28 @@ const SwapProviderSelectModal = () => {
   const [fromTokenAmount] = useSwapFromTokenAmountAtom();
   const [fromToken] = useSwapSelectFromTokenAtom();
   const [toToken] = useSwapSelectToTokenAtom();
-  const [, setSwapManualSelect] = useSwapManualSelectQuoteProvidersAtom();
+  const [manualSelectQuoteProvider, setSwapManualSelect] =
+    useSwapManualSelectQuoteProvidersAtom();
   const [providerSort, setProviderSort] = useSwapProviderSortAtom();
   const [settingsPersist] = useSettingsPersistAtom();
   const [currentSelectQuote] = useSwapQuoteCurrentSelectAtom();
+  const selectedProviderInfo =
+    currentSelectQuote?.info ?? manualSelectQuoteProvider?.info;
+  const [quoteEventTotalCount] = useSwapQuoteEventTotalCountAtom();
+  const [currentEventProviderKeys] = useSwapQuoteCurrentEventProviderKeysAtom();
+  const currentEventProviderKeySet = useMemo(
+    () => new Set(currentEventProviderKeys),
+    [currentEventProviderKeys],
+  );
+  const quoteListForDisplay = useMemo(
+    () =>
+      quoteEventTotalCount.count > 0
+        ? swapSortedList.filter((item) =>
+            currentEventProviderKeySet.has(buildSwapQuoteProviderKey(item)),
+          )
+        : swapSortedList,
+    [currentEventProviderKeySet, quoteEventTotalCount.count, swapSortedList],
+  );
 
   const onSelectSortChange = useCallback(
     (value: ESwapProviderSort) => {
@@ -108,10 +132,10 @@ const SwapProviderSelectModal = () => {
     [intl],
   );
   const sectionData = useMemo(() => {
-    const availableList = swapSortedList.filter(
+    const availableList = quoteListForDisplay.filter(
       (item) => item.toAmount && !item.limit?.min && !item.limit?.max,
     );
-    const unavailableList = swapSortedList.filter(
+    const unavailableList = quoteListForDisplay.filter(
       (item) => !item.toAmount || item.limit?.min || item.limit?.max,
     );
     return [
@@ -136,17 +160,17 @@ const SwapProviderSelectModal = () => {
           ]
         : []),
     ];
-  }, [intl, swapSortedList]);
+  }, [intl, quoteListForDisplay]);
   const onSelectQuote = useCallback(
     (item: IFetchQuoteResult) => {
-      setSwapManualSelect(item);
+      setSwapManualSelect(buildSwapManualProviderSelectionIntent(item));
       defaultLogger.swap.providerChange.providerChange({
-        changeFrom: currentSelectQuote?.info.provider ?? '-',
+        changeFrom: selectedProviderInfo?.provider ?? '-',
         changeTo: item.info.provider,
       });
       navigation.pop();
     },
-    [navigation, setSwapManualSelect, currentSelectQuote?.info.provider],
+    [navigation, setSwapManualSelect, selectedProviderInfo?.provider],
   );
   const renderItem = useCallback(
     ({ item }: { item: IFetchQuoteResult; index: number }) => {
@@ -176,8 +200,8 @@ const SwapProviderSelectModal = () => {
               : undefined
           }
           selected={Boolean(
-            item.info.provider === currentSelectQuote?.info.provider &&
-            item.info.providerName === currentSelectQuote?.info.providerName,
+            item.info.provider === selectedProviderInfo?.provider &&
+            item.info.providerName === selectedProviderInfo?.providerName,
           )}
           fromTokenAmount={fromTokenAmount.value}
           fromToken={fromToken}
@@ -189,11 +213,11 @@ const SwapProviderSelectModal = () => {
       );
     },
     [
-      currentSelectQuote?.info.provider,
-      currentSelectQuote?.info.providerName,
       fromToken,
       fromTokenAmount,
       onSelectQuote,
+      selectedProviderInfo?.provider,
+      selectedProviderInfo?.providerName,
       settingsPersist.currencyInfo.symbol,
       toToken,
     ],

--- a/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
@@ -22,6 +22,7 @@ import {
   useSwapQuoteCurrentSelectAtom,
   useSwapToAnotherAccountAddressAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
+import { buildSwapManualProviderSelectionIntent } from '@onekeyhq/kit/src/states/jotai/contexts/swap/quoteProgress';
 import { useSettingsAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
@@ -128,7 +129,9 @@ const SwapToAnotherAddressPage = () => {
         networkId,
         accountInfo: activeAccount,
       }));
-      setSwapManualSelectQuote(selectedQuote);
+      setSwapManualSelectQuote(
+        buildSwapManualProviderSelectionIntent(selectedQuote),
+      );
       navigation.pop();
     },
     [

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -234,6 +234,7 @@ export interface ISwapAutoSlippageSuggestedValue {
   value: number;
   from: string;
   to: string;
+  eventId: string;
 }
 
 // quote
@@ -681,6 +682,7 @@ export interface ISwapState {
   noConnectWallet?: boolean;
   approveUnLimit?: boolean;
   isRefreshQuote?: boolean;
+  isWaitingAutoSlippage?: boolean;
 }
 
 export interface ISwapApproveAllowanceResponse {


### PR DESCRIPTION
## Issues
- OK-52655

## Summary
- unblock the main Swap action as soon as the first actionable quote arrives during SSE streaming
- keep provider streaming semantics intact so later quotes can still update the current selection
- ignore stale carry-over quotes from the previous quote cycle while a new SSE event is still warming up
- require a positive `toAmount` before stopping the main action loading state

## Intent & Context
The goal of OK-52655 is to stop making users wait for every provider to finish before they can continue. The current experience shows provider quotes progressively, but the main Swap button stays blocked until the slowest channel returns, which makes the whole quote flow feel much slower than necessary.

## Root Cause
The action layer was using the same `quoteEventFetching` state for two different meanings: "more quotes are still streaming" and "the user still cannot act". That coupling caused the main button to remain disabled even after a valid actionable quote was already selected.

A second issue showed up during review: re-quote cycles can temporarily keep the previous event's quote in state before the current event has returned a fresh provider result. If that stale quote is treated as actionable, the button can unlock too early.

## Design Decisions
This PR keeps the existing streaming UI semantics, but splits out a smaller derived rule for the main action state. The provider list and quote result area can keep streaming, while the main action only waits for the first actionable quote.

To avoid stale re-quote unlocks, the current selected quote is now scoped to providers that have actually returned in the active SSE event. Manual provider selection behavior stays intact within the current event.

## Changes Detail
- `packages/kit/src/views/Swap/hooks/useSwapState.ts`
  - derive the main action disable/loading state from `useSwapQuoteProgressState()` instead of the raw full-stream completion state
- `packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx`
  - stop blocking the main action on full-stream completion while keeping cost-savings loading tied to streaming progress
- `packages/kit/src/states/jotai/contexts/swap/quoteProgress.ts`
  - centralize actionable-quote and current-event quote-selection rules
- `packages/kit/src/states/jotai/contexts/swap/atoms.ts`
  - select the current quote from providers that have responded in the active quote event
- `packages/kit/src/states/jotai/contexts/swap/actions.ts`
  - track and reset the active event provider set across new quote events, errors, resets, and re-quotes

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Desktop / Web
- **Risk Areas**:
  - Swap action enablement while quotes are still streaming
  - quote selection during re-quote cycles
  - native Limit / Pro surfaces that reuse `swapQuoteCurrentSelectAtom`
- **Not in Scope**:
  - native Pro Market speed-quote execution path (`useSwapSpeedQuoteResultAtom`) is not changed in this PR

## Test Plan
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/states/jotai/contexts/swap/actions.ts packages/kit/src/states/jotai/contexts/swap/atoms.ts packages/kit/src/states/jotai/contexts/swap/quoteProgress.ts packages/kit/src/views/Swap/hooks/useSwapState.ts packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx`
- [x] `yarn tsc:staged`
- [ ] Verify that the Swap button becomes clickable as soon as the first actionable quote arrives
- [ ] Verify that a later better quote can still replace the auto-selected provider before manual selection
- [ ] Verify that manual provider selection still locks the chosen provider for the current quote cycle
- [ ] Verify that a re-quote does not unlock the button from a stale quote before the current SSE event returns a fresh provider result
- [ ] Verify native mobile Limit / Pro mode still behaves correctly because it reuses `swapQuoteCurrentSelectAtom`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
