### PR TITLE
fix(swap): enable progressive quote selection (OK-52655)

### DIFF
--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -616,9 +616,16 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
               (dataJson as ISwapQuoteEventInfo).totalQuoteCount ||
               (dataJson as ISwapQuoteEventInfo).totalQuoteCount === 0
             ) {
-              const { totalQuoteCount } = dataJson as ISwapQuoteEventInfo;
+              const { eventId, totalQuoteCount } =
+                dataJson as ISwapQuoteEventInfo;
+              const currentQuoteEventTotalCount = get(
+                swapQuoteEventTotalCountAtom(),
+              );
+              if (currentQuoteEventTotalCount.eventId !== eventId) {
+                set(swapQuoteListAtom(), []);
+              }
               set(swapQuoteEventTotalCountAtom(), {
-                eventId: (dataJson as ISwapQuoteEventInfo).eventId,
+                eventId,
                 count: totalQuoteCount,
               });
               if (totalQuoteCount === 0) {
@@ -627,7 +634,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
                     info: { provider: '', providerName: '' },
                     fromTokenInfo: event.tokenPairs.fromToken,
                     toTokenInfo: event.tokenPairs.toToken,
-                    eventId: (dataJson as ISwapQuoteEventInfo).eventId,
+                    eventId,
                   },
                 ]);
               }
@@ -670,18 +677,6 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
                   if (newUpdateQuoteRes) {
                     return newUpdateQuoteRes;
                   }
-                  // OK-49700: 如果旧报价的 fromAmount 与当前询价的 fromTokenAmount 相同，
-                  // 则更新旧报价的 eventId 为当前的 eventId，这样它就不会被 eventId 过滤掉，
-                  // 实现再次询价时保留旧报价、只更新部分渠道商报价的效果
-                  if (
-                    oldQuoteRes.fromAmount === event.params.fromTokenAmount &&
-                    quoteEventTotalCount.eventId
-                  ) {
-                    return {
-                      ...oldQuoteRes,
-                      eventId: quoteEventTotalCount.eventId,
-                    };
-                  }
                   return oldQuoteRes;
                 });
                 const newAddQuoteRes = quoteResultsUpdateSlippage.filter(
@@ -721,6 +716,12 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
           break;
         }
         case 'done': {
+          const quoteResultList = get(swapQuoteListAtom());
+          const quoteEventTotalCount = get(swapQuoteEventTotalCountAtom());
+          set(swapQuoteEventTotalCountAtom(), {
+            eventId: quoteEventTotalCount.eventId,
+            count: quoteResultList.length,
+          });
           set(swapQuoteActionLockAtom(), (v) => ({ ...v, actionLock: false }));
           if (platformEnv.isExtension) {
             set(swapQuoteFetchingAtom(), false);
@@ -729,6 +730,12 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
           break;
         }
         case 'error': {
+          const quoteResultList = get(swapQuoteListAtom());
+          const quoteEventTotalCount = get(swapQuoteEventTotalCountAtom());
+          set(swapQuoteEventTotalCountAtom(), {
+            eventId: quoteEventTotalCount.eventId,
+            count: quoteResultList.length,
+          });
           if (platformEnv.isExtension) {
             set(swapQuoteFetchingAtom(), false);
           }
@@ -736,6 +743,12 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
           break;
         }
         case 'close': {
+          const quoteResultList = get(swapQuoteListAtom());
+          const quoteEventTotalCount = get(swapQuoteEventTotalCountAtom());
+          set(swapQuoteEventTotalCountAtom(), {
+            eventId: quoteEventTotalCount.eventId,
+            count: quoteResultList.length,
+          });
           set(swapQuoteFetchingAtom(), false);
           set(swapQuoteActionLockAtom(), (v) => ({ ...v, actionLock: false }));
           break;
@@ -890,6 +903,8 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       if (!unResetCount) {
         set(swapQuoteIntervalCountAtom(), 0);
       }
+      set(swapQuoteListAtom(), []);
+      set(swapQuoteEventTotalCountAtom(), { count: 0 });
       set(swapBuildTxFetchingAtom(), false);
       set(swapShouldRefreshQuoteAtom(), false);
       const fromTokenAmountNumber = Number(fromTokenAmount.value);
@@ -1165,8 +1180,6 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       const swapSupportAllNetworks = get(swapNetworksIncludeAllNetworkAtom());
       const quoteResult = get(swapQuoteCurrentSelectAtom());
       const tokenMetadata = get(swapTokenMetadataAtom());
-      const quoteResultList = get(swapQuoteListAtom());
-      const quoteEventTotalCount = get(swapQuoteEventTotalCountAtom());
       const fromTokenAmount = get(swapFromTokenAmountAtom());
       let alertsRes: ISwapAlertState[] = [];
       const quoteEventError = get(swapQuoteEventErrorAtom());
@@ -1203,12 +1216,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         return;
       }
 
-      if (
-        !networks.length ||
-        !swapFromAddressInfo.accountInfo?.ready ||
-        (quoteEventTotalCount.count > 0 &&
-          quoteResultList.length < quoteEventTotalCount.count)
-      ) {
+      if (!networks.length || !swapFromAddressInfo.accountInfo?.ready) {
         if (quoteEventError) {
           set(swapAlertsAtom(), {
             states: alertsRes,

--- a/packages/kit/src/states/jotai/contexts/swap/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/atoms.ts
@@ -244,9 +244,14 @@ export const {
   atom: swapQuoteCurrentSelectAtom,
   use: useSwapQuoteCurrentSelectAtom,
 } = contextAtomComputed((get) => {
-  const list = get(swapSortedQuoteListAtom());
+  const list = get(swapQuoteListAtom());
+  const fromTokenAmount = get(swapFromTokenAmountAtom());
   const manualSelectQuoteProviders = get(swapManualSelectQuoteProvidersAtom());
-  return selectBestQuote(list, {
+  const recommendedList = sortSwapQuotes(list, {
+    sort: ESwapProviderSort.RECOMMENDED,
+    fromTokenAmount: fromTokenAmount.value,
+  });
+  return selectBestQuote(recommendedList, {
     manualSelect: manualSelectQuoteProviders ?? undefined,
   });
 });

--- a/packages/kit/src/views/Swap/hooks/useSwapState.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapState.ts
@@ -217,6 +217,12 @@ export function useSwapActionState() {
     () => quoteIntervalCount > swapQuoteIntervalMaxCount || shouldRefreshQuote,
     [quoteIntervalCount, shouldRefreshQuote],
   );
+  const hasActionableQuote = useMemo(
+    () => new BigNumber(quoteCurrentSelect?.toAmount ?? 0).gt(0),
+    [quoteCurrentSelect?.toAmount],
+  );
+  const isWaitingActionableQuote =
+    quoteLoading || (quoteEventFetching && !hasActionableQuote);
 
   const hasError = alerts.states.some(
     (item) => item.alertLevel === ESwapAlertLevel.ERROR,
@@ -273,15 +279,14 @@ export function useSwapActionState() {
     ) {
       infoRes.disable = true;
     }
-    if (
-      new BigNumber(toTokenAmount.value ?? 0).isZero() ||
-      new BigNumber(toTokenAmount.value ?? 0).isNaN()
-    ) {
+    const quoteToAmountBN = new BigNumber(
+      quoteCurrentSelect?.toAmount ?? toTokenAmount.value ?? 0,
+    );
+    if (quoteToAmountBN.isZero() || quoteToAmountBN.isNaN()) {
       infoRes.disable = true;
     }
     if (
-      quoteLoading ||
-      quoteEventFetching ||
+      isWaitingActionableQuote ||
       swapApprovingMatchLoading ||
       buildTxFetching
     ) {
@@ -378,8 +383,7 @@ export function useSwapActionState() {
     swapTypeSwitchValue,
     isRefreshQuote,
     toTokenAmount.value,
-    quoteLoading,
-    quoteEventFetching,
+    isWaitingActionableQuote,
     swapApprovingMatchLoading,
     buildTxFetching,
     selectedFromTokenBalance,
@@ -395,8 +399,7 @@ export function useSwapActionState() {
     noConnectWallet: actionInfo.noConnectWallet,
     disabled:
       actionInfo.disable ||
-      quoteLoading ||
-      quoteEventFetching ||
+      isWaitingActionableQuote ||
       swapApprovingMatchLoading,
     approveUnLimit: swapQuoteApproveAllowanceUnLimit,
     isApprove: !!quoteCurrentSelect?.allowanceResult,
@@ -406,8 +409,7 @@ export function useSwapActionState() {
     isWrapped: !!quoteCurrentSelect?.isWrapped,
     isRefreshQuote:
       (isRefreshQuote || quoteResultNoMatchDebounce) &&
-      !quoteLoading &&
-      !quoteEventFetching,
+      !isWaitingActionableQuote,
   };
   return stepState;
 }

--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -130,6 +130,12 @@ const SwapActionsState = ({
   }
   const themeVariant = useThemeVariant();
   const quoting = useSwapQuoteEventFetching();
+  const hasActionableQuote = useMemo(
+    () => new BigNumber(currentQuoteRes?.toAmount ?? 0).gt(0),
+    [currentQuoteRes?.toAmount],
+  );
+  const isWaitingActionableQuote =
+    quoteLoading || (quoting && !hasActionableQuote);
   const [desktopActionWidth, setDesktopActionWidth] = useState<number>();
 
   const isModalPage = useIsOverlayPage();
@@ -728,8 +734,8 @@ const SwapActionsState = ({
       new BigNumber(currentQuoteRes?.fee?.costSavings || 0).gt(0);
 
     if (hasCostSavings) {
-      const isLoadingQuote = quoting || quoteLoading;
-      const shouldShow = hasEverShownCostSavingsRef.current || !isLoadingQuote;
+      const shouldShow =
+        hasEverShownCostSavingsRef.current || !isWaitingActionableQuote;
 
       if (shouldShow) {
         if (!hasEverShownCostSavingsRef.current) {
@@ -770,8 +776,7 @@ const SwapActionsState = ({
   }, [
     currentQuoteRes?.fee?.costSavings,
     settingsPersistAtom.currencyInfo.symbol,
-    quoting,
-    quoteLoading,
+    isWaitingActionableQuote,
     intl,
   ]);
 
@@ -809,7 +814,7 @@ const SwapActionsState = ({
 
   const actionButtonChildren = useMemo(
     () =>
-      quoting || quoteLoading ? (
+      isWaitingActionableQuote ? (
         <LottieView
           source={
             themeVariant === 'light'
@@ -826,7 +831,7 @@ const SwapActionsState = ({
       ) : (
         swapActionState.label
       ),
-    [quoteLoading, quoting, swapActionState.label, themeVariant],
+    [isWaitingActionableQuote, swapActionState.label, themeVariant],
   );
 
   const actionRowComponent = useMemo(

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -594,7 +594,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
         focusSwapPro && swapProTradeType === ESwapProTradeType.MARKET
           ? swapProInputAmount
           : fromTokenAmount.value,
-      toTokenAmount: swapToAmount.value,
+      toTokenAmount: currentQuoteRes.toAmount ?? swapToAmount.value,
       quoteResult: currentQuoteRes,
       swapType: swapTypeFinal,
       shouldFallback:

--- a/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
@@ -162,6 +162,9 @@ const SwapQuoteResult = ({
   );
 
   const quoting = useSwapQuoteEventFetching();
+  const hasActionableQuote = new BigNumber(quoteResult?.toAmount ?? 0).gt(0);
+  const isWaitingActionableQuote =
+    swapQuoteLoading || (quoting && !hasActionableQuote);
 
   const { limitOrderExpiryStepMap, limitOrderPartiallyFillStepMap } =
     useSwapLimitConfigMaps();
@@ -197,7 +200,7 @@ const SwapQuoteResult = ({
     );
   }
   if (swapTypeSwitch === ESwapTabSwitchType.LIMIT) {
-    if (quoting || swapQuoteLoading) {
+    if (isWaitingActionableQuote) {
       return (
         <XStack alignItems="center">
           <XStack gap="$2">
@@ -283,7 +286,7 @@ const SwapQuoteResult = ({
             {({ open }: { open: boolean }) => (
               <SwapQuoteResultRate
                 rate={quoteResult?.instantRate}
-                quoting={quoting}
+                quoting={isWaitingActionableQuote}
                 fromToken={fromToken}
                 toToken={toToken}
                 isBest={quoteResult?.isBest}

--- a/packages/shared/src/utils/swapQuoteSortUtils.ts
+++ b/packages/shared/src/utils/swapQuoteSortUtils.ts
@@ -238,6 +238,15 @@ export function selectBestQuote(
 
   const manual = options?.manualSelect;
   if (manual) {
+    const hasDifferentEvent =
+      !!manual.eventId &&
+      sortedQuotes.some(
+        (item) => !!item.eventId && item.eventId !== manual.eventId,
+      );
+    if (hasDifferentEvent) {
+      return sortedQuotes[0];
+    }
+
     const matched = sortedQuotes.find(
       (item) =>
         item.info.provider === manual.info.provider &&

--- a/packages/shared/src/utils/swapQuoteSortUtils.ts
+++ b/packages/shared/src/utils/swapQuoteSortUtils.ts
@@ -238,12 +238,12 @@ export function selectBestQuote(
 
   const manual = options?.manualSelect;
   if (manual) {
-    const hasDifferentEvent =
-      !!manual.eventId &&
-      sortedQuotes.some(
-        (item) => !!item.eventId && item.eventId !== manual.eventId,
-      );
-    if (hasDifferentEvent) {
+    const hasEventQuotes = sortedQuotes.some((item) => !!item.eventId);
+    const isManualFromCurrentEvent =
+      !hasEventQuotes ||
+      (!!manual.eventId &&
+        sortedQuotes.some((item) => item.eventId === manual.eventId));
+    if (!isManualFromCurrentEvent) {
       return sortedQuotes[0];
     }
 


### PR DESCRIPTION
## Summary
- rebuild OK-52655 from a clean release/v6.2.0 branch with a narrower quote data flow
- clear stale quote results when a new quote event starts, so current selection only comes from the active event
- allow the Swap CTA/loading UI to unblock once the selected current quote has a positive toAmount instead of waiting for every provider
- use the selected quote toAmount for review data to keep CTA and review/buildTx aligned

## Verification
- npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/states/jotai/contexts/swap/actions.ts packages/kit/src/views/Swap/hooks/useSwapState.ts packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
- yarn tsc:staged