### PR TITLE
fix: send flow and signature confirm regressions (OK-53537, OK-53449, OK-53370)

### DIFF
--- a/packages/kit-bg/src/services/ServiceFreshAddress.ts
+++ b/packages/kit-bg/src/services/ServiceFreshAddress.ts
@@ -32,6 +32,20 @@ import type { IAccountDeriveTypes } from '../vaults/types';
 
 @backgroundClass()
 class ServiceFreshAddress extends ServiceBase {
+  constructor({ backgroundApi }: { backgroundApi: any }) {
+    super({ backgroundApi });
+
+    appEventBus.on(EAppEventBusNames.WalletRemove, () => {
+      this.getAccountNameFromFreshAddressMemo.clear();
+    });
+    appEventBus.on(EAppEventBusNames.AccountRemove, () => {
+      this.getAccountNameFromFreshAddressMemo.clear();
+    });
+    appEventBus.on(EAppEventBusNames.WalletUpdate, () => {
+      this.getAccountNameFromFreshAddressMemo.clear();
+    });
+  }
+
   private getLocalPendingTxsForFreshAddress = memoizee(
     async ({ networkId }: { networkId: string }) => {
       const localPendingTxs =
@@ -455,6 +469,71 @@ class ServiceFreshAddress extends ServiceBase {
     });
   }
 
+  private async resolveFreshAddressOwner({
+    accountId,
+  }: {
+    accountId: string;
+  }): Promise<
+    | {
+        accountId: string;
+        accountName: string;
+        walletName: string;
+      }
+    | undefined
+  > {
+    if (!accountId) {
+      return undefined;
+    }
+
+    const walletId = accountUtils.getWalletIdFromAccountId({ accountId });
+    if (!walletId) {
+      return undefined;
+    }
+
+    const wallet = await this.backgroundApi.serviceAccount.getWalletSafe({
+      walletId,
+    });
+    if (!wallet || accountUtils.isWalletDeprecatedOrMocked(wallet)) {
+      return undefined;
+    }
+
+    const isTempWalletRemoved =
+      await this.backgroundApi.serviceAccount.isTempWalletRemoved({
+        wallet,
+      });
+    if (isTempWalletRemoved) {
+      return undefined;
+    }
+
+    const indexedAccount =
+      await this.backgroundApi.serviceAccount.getIndexedAccountSafe({
+        id: accountId,
+      });
+    if (indexedAccount) {
+      return {
+        accountId: indexedAccount.id,
+        accountName: indexedAccount.name,
+        walletName: wallet.name,
+      };
+    }
+
+    const dbAccount = await this.backgroundApi.serviceAccount.getDBAccountSafe({
+      accountId,
+    });
+    if (
+      !dbAccount ||
+      accountUtils.isUrlAccountFn({ accountId: dbAccount.id })
+    ) {
+      return undefined;
+    }
+
+    return {
+      accountId: dbAccount.id,
+      accountName: dbAccount.name,
+      walletName: wallet.name,
+    };
+  }
+
   getAccountNameFromFreshAddressMemo = memoizee(
     async ({ address, networkId }: { address: string; networkId: string }) => {
       if (!networkUtils.isBTCNetwork(networkId)) {
@@ -477,19 +556,13 @@ class ServiceFreshAddress extends ServiceBase {
         await this.backgroundApi.simpleDb.btcFreshAddressMeta.getRecordByKey(
           key,
         );
-      if (
-        metadata &&
-        metadata.lastUsedAccountName &&
-        metadata.lastUsedAccountId &&
-        metadata.lastUsedWalletName
-      ) {
-        return [
-          {
-            accountName: metadata.lastUsedAccountName,
-            accountId: metadata.lastUsedAccountId,
-            walletName: metadata.lastUsedWalletName,
-          },
-        ];
+      if (metadata && metadata.lastUsedAccountId) {
+        const owner = await this.resolveFreshAddressOwner({
+          accountId: metadata.lastUsedAccountId,
+        });
+        if (owner) {
+          return [owner];
+        }
       }
       return [];
     },
@@ -500,6 +573,7 @@ class ServiceFreshAddress extends ServiceBase {
       maxAge: timerUtils.getTimeDurationMs({ seconds: 10 }),
     },
   );
+
   // Return all searchable fresh addresses for a list of BTC accounts.
   // Consolidates derive-type-aware xpub key selection and fresh address
   // extraction that was previously inlined in RecipientQuickSelect UI.

--- a/packages/kit-bg/src/services/ServiceSignatureConfirm.ts
+++ b/packages/kit-bg/src/services/ServiceSignatureConfirm.ts
@@ -40,6 +40,40 @@ import ServiceBase from './ServiceBase';
 
 import type { IBuildDecodedTxParams } from '../vaults/types';
 
+function mergeAddressComponentTags(
+  results: IParseTransactionResp[],
+): IParseTransactionResp {
+  const base = results[0];
+
+  if (!base.display?.components?.length) {
+    return base;
+  }
+
+  base.display.components.forEach((component, index) => {
+    if (component.type !== EParseTxComponentType.Address) {
+      return;
+    }
+
+    const addressComponents = results
+      .map((result) => result.display?.components?.[index])
+      .filter(
+        (candidate): candidate is typeof component =>
+          candidate?.type === EParseTxComponentType.Address,
+      );
+
+    const preferredTags =
+      addressComponents.find((candidate) =>
+        candidate.tags?.some((tag) => tag.key === 'transferred'),
+      )?.tags ?? addressComponents[0]?.tags;
+
+    if (preferredTags) {
+      component.tags = preferredTags;
+    }
+  });
+
+  return base;
+}
+
 @backgroundClass()
 class ServiceSignatureConfirm extends ServiceBase {
   constructor({ backgroundApi }: { backgroundApi: any }) {
@@ -340,7 +374,7 @@ class ServiceSignatureConfirm extends ServiceBase {
     }
     // Use the first result as base, merge riskLevel across xpubs
     // (take the highest risk seen from any derive path).
-    const base = validResults[0];
+    const base = mergeAddressComponentTags(validResults);
     if (base.parsedTx?.to) {
       const maxRiskLevel = Math.max(
         ...validResults.map((r) => r.parsedTx?.to?.riskLevel ?? 0),

--- a/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
@@ -60,7 +60,6 @@ import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import { EInputAddressChangeType } from '@onekeyhq/shared/types/address';
 import type { IAccountNFT } from '@onekeyhq/shared/types/nft';
-import { ENFTType } from '@onekeyhq/shared/types/nft';
 import { EQRCodeHandlerType } from '@onekeyhq/shared/types/qrCode';
 import type { IToken, ITokenFiat } from '@onekeyhq/shared/types/token';
 
@@ -74,6 +73,7 @@ import { SendConfirmProviderMirror } from '../../components/SendConfirmProvider/
 import RecipientQuickSelect from './RecipientQuickSelect';
 import {
   normalizeOptionalRecipientText,
+  shouldSkipAmountInputForNFT,
   shouldSkipResolvedRecipientUpdate,
 } from './recipientSelectionUtils';
 import { useWebDappRecipientOptions } from './useWebDappRecipientOptions';
@@ -490,9 +490,10 @@ function SendDataInputContainer() {
       // page — skip straight to confirm with a fixed quantity of 1 (OK-53248).
       const nftItem = nfts?.[0];
       if (
-        isNFT &&
-        nftItem &&
-        nftItem.collectionType !== ENFTType.ERC1155 &&
+        shouldSkipAmountInputForNFT({
+          isNFT,
+          nft: nftItem,
+        }) &&
         account
       ) {
         const transfersInfo: ITransferInfo[] = [
@@ -939,6 +940,56 @@ function SendDataInputContainer() {
 
         const effectiveNote =
           selectedNote || (isNoteOnlyChain ? selectedMemo?.trim() : undefined);
+        const recipientMemo = displayMemoForm
+          ? selectedMemo?.trim() || undefined
+          : undefined;
+        const recipientPaymentId = form.getValues('paymentId') || undefined;
+        const recipientNote = effectiveNote || undefined;
+        const nftItem = nfts?.[0];
+
+        if (
+          shouldSkipAmountInputForNFT({
+            isNFT,
+            nft: nftItem,
+          }) &&
+          account
+        ) {
+          const transfersInfo: ITransferInfo[] = [
+            {
+              from: account.address,
+              to: resolvedAddress,
+              amount: '1',
+              nftInfo: {
+                nftId: nftItem.itemId,
+                nftAddress: nftItem.collectionAddress,
+                nftType: nftItem.collectionType,
+              },
+              memo: recipientMemo,
+              paymentId: recipientPaymentId,
+              note: recipientNote,
+            },
+          ];
+          await signatureConfirm.navigationToTxConfirm({
+            transfersInfo,
+            sameModal: true,
+            onSuccess,
+            onFail,
+            onCancel,
+            transferPayload: {
+              amountToSend: '1',
+              isMaxSend: false,
+              isNFT: true,
+              originalRecipient: resolvedAddress,
+              isToContract: queryResult.isContract ?? false,
+              memo: recipientMemo,
+              paymentId: recipientPaymentId,
+              note: recipientNote,
+            },
+            isInternalTransfer: true,
+          });
+          return;
+        }
+
         pushAmountInput({
           networkId: currentAccount.networkId,
           accountId: currentAccount.accountId,
@@ -947,11 +998,9 @@ function SendDataInputContainer() {
           nfts,
           recipientAddress: resolvedAddress,
           recipientIsContract: queryResult.isContract ?? false,
-          recipientMemo: displayMemoForm
-            ? selectedMemo?.trim() || undefined
-            : undefined,
-          recipientPaymentId: form.getValues('paymentId') || undefined,
-          recipientNote: effectiveNote || undefined,
+          recipientMemo,
+          recipientPaymentId,
+          recipientNote,
           amount: scannedAmount || sendAmount || undefined,
           isAllNetworks,
           onSuccess,
@@ -972,6 +1021,7 @@ function SendDataInputContainer() {
     [
       currentAccount.accountId,
       currentAccount.networkId,
+      account,
       displayMemoForm,
       isNoteOnlyChain,
       fillRecipientFromQuickSelect,
@@ -984,6 +1034,7 @@ function SendDataInputContainer() {
       onFail,
       onSuccess,
       pushAmountInput,
+      signatureConfirm,
       scannedAmount,
       sendAmount,
       tokenInfo,

--- a/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
@@ -490,6 +490,7 @@ function SendDataInputContainer() {
       // page — skip straight to confirm with a fixed quantity of 1 (OK-53248).
       const nftItem = nfts?.[0];
       if (
+        nftItem &&
         shouldSkipAmountInputForNFT({
           isNFT,
           nft: nftItem,
@@ -948,6 +949,7 @@ function SendDataInputContainer() {
         const nftItem = nfts?.[0];
 
         if (
+          nftItem &&
           shouldSkipAmountInputForNFT({
             isNFT,
             nft: nftItem,

--- a/packages/kit/src/views/Send/pages/SendDataInput/recipientSelectionUtils.test.ts
+++ b/packages/kit/src/views/Send/pages/SendDataInput/recipientSelectionUtils.test.ts
@@ -1,10 +1,10 @@
+import { ENFTType } from '@onekeyhq/shared/types/nft';
 import {
   normalizeOptionalRecipientText,
   shouldSkipAmountInputForNFT,
   shouldSkipResolvedRecipientUpdate,
 } from './recipientSelectionUtils';
 
-import { ENFTType } from '@onekeyhq/shared/types/nft';
 
 describe('recipientSelectionUtils', () => {
   it('normalizes optional memo/note values to avoid stale form values', () => {

--- a/packages/kit/src/views/Send/pages/SendDataInput/recipientSelectionUtils.test.ts
+++ b/packages/kit/src/views/Send/pages/SendDataInput/recipientSelectionUtils.test.ts
@@ -1,7 +1,10 @@
 import {
   normalizeOptionalRecipientText,
+  shouldSkipAmountInputForNFT,
   shouldSkipResolvedRecipientUpdate,
 } from './recipientSelectionUtils';
+
+import { ENFTType } from '@onekeyhq/shared/types/nft';
 
 describe('recipientSelectionUtils', () => {
   it('normalizes optional memo/note values to avoid stale form values', () => {
@@ -51,6 +54,29 @@ describe('recipientSelectionUtils', () => {
       shouldSkipResolvedRecipientUpdate({
         currentTo: { raw: '0xabc' },
         selectedAddress: '0xabc',
+      }),
+    ).toBe(false);
+  });
+
+  it('skips amount input for ERC721 but not ERC1155', () => {
+    expect(
+      shouldSkipAmountInputForNFT({
+        isNFT: true,
+        nft: { collectionType: ENFTType.ERC721 },
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldSkipAmountInputForNFT({
+        isNFT: true,
+        nft: { collectionType: ENFTType.ERC1155 },
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldSkipAmountInputForNFT({
+        isNFT: false,
+        nft: { collectionType: ENFTType.ERC721 },
       }),
     ).toBe(false);
   });

--- a/packages/kit/src/views/Send/pages/SendDataInput/recipientSelectionUtils.test.ts
+++ b/packages/kit/src/views/Send/pages/SendDataInput/recipientSelectionUtils.test.ts
@@ -1,10 +1,10 @@
 import { ENFTType } from '@onekeyhq/shared/types/nft';
+
 import {
   normalizeOptionalRecipientText,
   shouldSkipAmountInputForNFT,
   shouldSkipResolvedRecipientUpdate,
 } from './recipientSelectionUtils';
-
 
 describe('recipientSelectionUtils', () => {
   it('normalizes optional memo/note values to avoid stale form values', () => {

--- a/packages/kit/src/views/Send/pages/SendDataInput/recipientSelectionUtils.ts
+++ b/packages/kit/src/views/Send/pages/SendDataInput/recipientSelectionUtils.ts
@@ -1,4 +1,6 @@
 import type { IAddressInputValue } from '@onekeyhq/kit/src/components/AddressInput';
+import type { IAccountNFT } from '@onekeyhq/shared/types/nft';
+import { ENFTType } from '@onekeyhq/shared/types/nft';
 
 export function normalizeOptionalRecipientText(value?: string) {
   return value ?? '';
@@ -32,4 +34,14 @@ export function shouldSkipResolvedRecipientUpdate({
     selected.length > 0 &&
     (selected === currentRaw || selected === currentResolved)
   );
+}
+
+export function shouldSkipAmountInputForNFT({
+  isNFT,
+  nft,
+}: {
+  isNFT: boolean;
+  nft?: Pick<IAccountNFT, 'collectionType'>;
+}) {
+  return !!(isNFT && nft && nft.collectionType !== ENFTType.ERC1155);
 }

--- a/packages/shared/types/signatureConfirm.ts
+++ b/packages/shared/types/signatureConfirm.ts
@@ -66,6 +66,7 @@ export interface IDisplayComponentAddress {
   label: string;
   address: string;
   tags: {
+    key?: string;
     value: string;
     displayType: IBadgeType;
     icon?: IKeyOfIcons;


### PR DESCRIPTION
## Summary
- Skip amount input step for ERC721 recipient quick-select path so single NFTs go straight to confirm (OK-53537).
- Invalidate cached BTC fresh-address account name labels after wallet/account removal or update so deleted wallets stop showing a stale badge (OK-53449).
- Preserve the `transferred` address tag when merging parsed-tx results across xpubs in signature confirm, so multi-derive BTC addresses that have been transacted with no longer display as "first transfer" (OK-53370).

## Intent & Context
These are three independent regressions bundled together for the v6.2.0 release cut.

1. **OK-53537 — ERC721 quick-select amount input**: OK-53248 previously introduced a shortcut that routes ERC721 sends directly to the signature-confirm screen with a fixed quantity of 1 (skipping the amount input step), but only in the standard recipient-entry flow. The newer recipient quick-select flow (`RecipientQuickSelect`) did not apply this shortcut, so users picking an NFT recipient via the account-contacts quick-select still landed on the amount-input page on the first click.
2. **OK-53449 — Deleted-wallet badge lingers**: `ServiceFreshAddress.getAccountNameFromFreshAddress` is memoized to resolve the display name of the owning account/wallet for a BTC fresh address. When the user deleted a wallet or account, the cache retained the previous owner info, so the "own wallet" badge on the send page kept pointing at wallets that no longer existed.
3. **OK-53370 — "First transfer" shown for already-transacted address**: In multi-derive (multi-xpub) mode, sending to an address that had been transferred to before still showed the "first transfer" label instead of "transferred". When signature confirm parses a transaction across multiple xpubs, it merges results and returns the first as the base. If the `transferred` address tag only appeared in a non-first result, it was dropped during merge.

## Root Cause
- **OK-53537**: The ERC721-skip condition was inlined (`isNFT && nftItem && nftItem.collectionType !== ENFTType.ERC1155`) only in the primary `handleOnConfirm` path, not in the quick-select `handleOnRecipientConfirm` path.
- **OK-53449**: The memoized `getAccountNameFromFreshAddressMemo` never listened for wallet/account mutation events, so its cache outlived the entities it described.
- **OK-53370**: `ServiceSignatureConfirm.parseTransaction` selected `validResults[0]` as the merge base without looking at address-component tags from the other results. The `tags` array had no stable key, so there was no way to identify the semantically meaningful `transferred` tag for preservation.

## Design Decisions
- **OK-53537**: Extracted `shouldSkipAmountInputForNFT({ isNFT, nft })` into `recipientSelectionUtils.ts` and reused it in both code paths. Applying it to the quick-select path required also wiring `memo` / `paymentId` / `note` into the transfer info and `transferPayload`, and adding `signatureConfirm` + `account` to the callback deps — matching the existing `handleOnConfirm` shape. Added unit tests for the ERC721 vs ERC1155 vs non-NFT cases.
- **OK-53449**: Clear the memoize cache in the `ServiceFreshAddress` constructor on `WalletRemove` / `AccountRemove` / `WalletUpdate` events. The service is a singleton, so constructor-time subscription is the right lifetime. `resolveFreshAddressOwner` was extracted so owner resolution is auditable and testable.
- **OK-53370**: Added an optional `key` discriminator to `IDisplayComponentAddress.tags` and introduced `mergeAddressComponentTags` that, for each address component, prefers the tag set containing a `transferred` tag, falling back to the first non-empty tags. This keeps the fix targeted without changing the broader merge semantics (risk-level merge logic remains untouched).

## Changes Detail
- `packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx` — Apply `shouldSkipAmountInputForNFT` guard in the quick-select confirm path; build `transfersInfo` / `transferPayload` with memo/paymentId/note; add `account` and `signatureConfirm` to deps. Null-check `nftItem` before calling the helper.
- `packages/kit/src/views/Send/pages/SendDataInput/recipientSelectionUtils.ts` — Add `shouldSkipAmountInputForNFT` helper.
- `packages/kit/src/views/Send/pages/SendDataInput/recipientSelectionUtils.test.ts` — Unit tests covering ERC721 (skip), ERC1155 (no skip), and non-NFT (no skip).
- `packages/kit-bg/src/services/ServiceFreshAddress.ts` — Subscribe to `WalletRemove` / `AccountRemove` / `WalletUpdate` to clear the fresh-address name cache; extract `resolveFreshAddressOwner` helper.
- `packages/kit-bg/src/services/ServiceSignatureConfirm.ts` — Add `mergeAddressComponentTags` and use it when picking the merge base.
- `packages/shared/types/signatureConfirm.ts` — Add optional `key?: string` on address-component tags.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: All (Desktop / Mobile / Web / Extension) — changes are in shared kit/kit-bg code.
- **Risk Areas**:
  - Send flow changes touch the quick-select confirm path; need to verify both ERC721 (skips amount) and ERC1155 (still shows amount input) end-to-end on an EVM chain.
  - `ServiceFreshAddress` now reacts to wallet/account events — verify the cache clears at the right moments without causing redundant resolver calls.
  - Signature-confirm merge change affects display only but runs on every multi-xpub parse; verify UTXO chains (BTC and friends) still render the destination tag correctly.

## Test plan
- [ ] OK-53537: Send a BSC/EVM NFT to an account contact via the quick-select list; confirm it skips the amount page and lands on signature confirm with quantity 1 on the first click.
- [ ] ERC1155 quick-select: pick an ERC1155 recipient via quick-select, confirm the amount input page still appears.
- [ ] Memo/paymentId/note are preserved on the ERC721 quick-select path where the chain surfaces them.
- [ ] Non-NFT quick-select sends still route through the amount input page.
- [ ] OK-53449: Remove a wallet that owned a BTC fresh address, then open the send page using that address — verify the "own wallet" badge no longer shows the deleted wallet.
- [ ] OK-53370: In multi-derive BTC mode, send to an address that has been transacted with previously — verify the destination shows "transferred" rather than "first transfer", even when only a non-first xpub result contains the tag.
- [ ] `yarn test` passes (new recipientSelectionUtils tests).
- [ ] `yarn lint:staged` and `yarn tsc:staged` pass on touched files.