### PR TITLE
fix(mobile): keep main↔bg transport alive on per-call timeout

### DIFF
--- a/apps/mobile/src/backgroundThread/setupMainThreadBackgroundRunner.ts
+++ b/apps/mobile/src/backgroundThread/setupMainThreadBackgroundRunner.ts
@@ -53,10 +53,13 @@ const transportLog = (msg: string) => {
 const OBSERVER_RETRY_MS = 50;
 const MAX_OBSERVER_RETRY_COUNT = 600;
 const READY_TIMEOUT_MS = 10_000;
-const REQUEST_TIMEOUT_MS = 30_000;
+// Long enough to cover HW + passphrase batch derivation (dozens of BLE
+// round-trips, ~1.5 min in practice) plus headroom. A per-call timeout only
+// rejects that single call — it no longer tears down the transport.
+const REQUEST_TIMEOUT_MS = 10 * 60_000; // 10 minutes
 // bridge-calls may wait for user interaction (e.g. DApp connect modal),
 // so they need a much longer timeout and should NOT break the transport.
-const BRIDGE_CALL_TIMEOUT_MS = 5 * 60_000; // 5 minutes
+const BRIDGE_CALL_TIMEOUT_MS = 10 * 60_000; // 10 minutes
 const MAX_REMOTE_CALL_SLOT_COUNT = 512;
 
 type IQueuedCall = {
@@ -626,22 +629,20 @@ function dispatchRemoteRequest(
         return;
       }
       transportLog(`dispatchRemoteRequest TIMEOUT: callId=${callId}`);
-      if (isBridgeCall) {
-        // bridge-call timeouts mean user didn't interact in time,
-        // NOT that the background thread is dead — don't break transport.
-        const pending = pendingRemoteCalls.get(callId);
-        pendingRemoteCalls.delete(callId);
-        if (pending) {
-          clearTimeout(pending.timer);
-          pending.reject(
-            createTransportError(
-              `Bridge call timeout (${timeoutMs / 1000}s). request=${getRequestDebugLabel(request)}`,
-            ),
-          );
-        }
-      } else {
-        switchToRemoteBroken(
-          `Background request timeout. request=${getRequestDebugLabel(request)}`,
+      // A single slow call (e.g. batch account derivation that legitimately
+      // runs past REQUEST_TIMEOUT_MS) must NOT tear down the whole main↔bg
+      // transport. Reject only this pending call; keep transport alive so
+      // subsequent RPCs still reach the background runtime.
+      const pending = pendingRemoteCalls.get(callId);
+      pendingRemoteCalls.delete(callId);
+      if (pending) {
+        clearTimeout(pending.timer);
+        pending.reject(
+          createTransportError(
+            isBridgeCall
+              ? `Bridge call timeout (${timeoutMs / 1000}s). request=${getRequestDebugLabel(request)}`
+              : `Background request timeout (${timeoutMs / 1000}s). request=${getRequestDebugLabel(request)}`,
+          ),
         );
       }
     }, timeoutMs);


### PR DESCRIPTION
## Summary
- A single slow `service-call` (e.g. HW + passphrase batch account derivation, which can legitimately take 90s+ due to dozens of sequential BLE round-trips) tripped the 30s `REQUEST_TIMEOUT_MS` and called `switchToRemoteBroken(...)`, marking the whole main↔bg transport dead.
- Recovery via `handleRuntimeSignal` never fired in practice (verified in a user log: 1164 heartbeat-triggered `handleRuntimeSignal` calls post-timeout, 0 transitions back to `ready`), so every subsequent RPC — including `serviceOnboarding.isOnboardingDone()` triggered by tapping **Create Wallet** — was rejected synchronously, leaving the UI unresponsive.
- Fix: per-call timeouts now only reject that specific pending call (matching the existing `bridge-call` branch); transport stays alive. Also raises `REQUEST_TIMEOUT_MS` 30s → 10min and `BRIDGE_CALL_TIMEOUT_MS` 5min → 10min so legitimately long HW flows don't trip the timeout at all.

## Root cause chain (from the reported log)
1. `11:55:27` — main dispatched `serviceBatchCreateAccount.addDefaultNetworkAccounts` (HW + passphrase, ~30 derivation paths across BTC/EVM/TRON/SOL/Cosmos×11/DOT×8/Aptos/ADA/…).
2. `11:55:57` — main's 30s timeout fired → `switchToRemoteBroken(...)` → transport = `remote-broken`.
3. `11:58:01` — bg finished the same call (`elapsedMs=91911`, ~92s — normal for HW + passphrase). Main logged `handleResponse: callId=288 no pending call`.
4. `11:58:01`–`11:59:34` — 1164 heartbeat signals, 0 recoveries.
5. `11:59:10` — user taps **创建钱包** → `isOnboardingDone()` rejected immediately by `callRemoteRequest` → `onPress` handler's `void toOnBoardingPage()` swallows the rejection → UI does nothing.

## Test plan
- [ ] On Android + HW wallet with passphrase, trigger a flow that runs `addDefaultNetworkAccounts` across many networks; confirm it completes without timing out.
- [ ] After a simulated/real long RPC (>30s), tap **Create Wallet** from the account selector empty state and confirm it navigates normally (no more silent no-op).
- [ ] Verify normal SW wallet creation flow still works (quick calls complete as before).
- [ ] Regression: confirm DApp connect / bridge-call flows still behave (now sharing the 10min timeout).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
