### PR TITLE
fix(eventBus): restore ui→bg→ui round-trip on extension

### DIFF
--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -642,7 +642,16 @@ class AppEventBusClass extends CrossEventEmitter {
       return payloadCloned;
     };
 
-    if (isRemoteEventPayload) {
+    // Skip re-broadcasting remote-origin payloads only on native, where the
+    // main-thread ↔ bg-thread relay would otherwise echo. On extension, the
+    // bg→ui broadcast is the only way for a ui-emitted event to reach other
+    // UI listeners (shouldEmitToSelf is false for isExtensionUi), so we must
+    // let it through.
+    if (
+      isRemoteEventPayload &&
+      platformEnv.isNative &&
+      platformEnv.enableNativeBackgroundThread
+    ) {
       return;
     }
 


### PR DESCRIPTION
## Summary

- **Bug**: Creating a wallet in the Chrome extension got stuck on the "Creating your wallet" loading page. Backend account creation finished (e.g. `hd-5`, 7 accounts added), but the UI never advanced past `CreatingWallet` and never navigated to Main.
- **Root cause**: The `$$isRemoteEvent` early-return added in #10969 (native background thread runtime) makes the bg `emitToRemote` skip re-broadcasting payloads that carry the remote-origin flag. On extension, `shouldEmitToSelf` is `false` for `isExtensionUi`, so the bg→ui broadcast is the **only** way a ui-emitted event can reach UI listeners — the early-return silently killed all ui-emitted events (e.g. `FinalizeWalletSetupStep`).
- **Fix**: Scope the early-return to `isNative && enableNativeBackgroundThread`. That's the actual scenario the guard was designed for (preventing main-thread ↔ bg-thread echo in the new mobile native runtime); extension is unaffected by that echo concern because UI receives bg broadcasts via `emitToSelf` (not `emit`), so no re-broadcast loop is possible.

## Evidence

Console logs added during investigation showed:
- All 4 `appEventBus.emit(FinalizeWalletSetupStep, ...)` calls fire from `actions.tsx`
- UI listener is subscribed before the first emit
- UI listener is **never** invoked → step queue stuck at initial `[CreatingWallet]`, `processNextStep` loops on `nextStep: undefined`

## Scope of change

- `packages/shared/src/eventBus/appEventBus.ts`: scope early-return condition; added a comment explaining why.

No behavior change on native (EAS mobile builds with `ENABLE_NATIVE_BACKGROUND_THREAD=true`) — the existing echo guard still applies there.

## Test plan

- [ ] Ext (Chrome): `yarn app:ext`, reload the extension, create a new HD wallet → should advance through `CreatingWallet → GeneratingAccounts → EncryptingData → Ready`, then navigate to Main
- [ ] Ext: import mnemonic flow — same expected progression
- [ ] Desktop: `yarn app:desktop`, create a new HD wallet → no regression
- [ ] Web: `yarn app:web`, create a new HD wallet → no regression
- [ ] Mobile (EAS preview build with `ENABLE_NATIVE_BACKGROUND_THREAD=true`): create a new HD wallet → no regression, no duplicate events
- [ ] Verify other ui-emitted `appEventBus` events on ext still behave correctly (no duplicated handling)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
