### PR TITLE
docs(readme): document corepack bootstrap and yarn version pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,14 @@ app-monorepo/
 
 ## 🚀 Getting Onboard
 
-> **Prerequisites:** Node.js >= 22, Yarn 4.x (bundled via Corepack), [Git LFS](https://git-lfs.github.com/)
+> **Prerequisites:** Node.js >= 22, Yarn 4.x (the exact version is pinned via the `packageManager` field in `package.json` and provisioned by Corepack), [Git LFS](https://git-lfs.github.com/)
 
 ```bash
 git clone https://github.com/OneKeyHQ/app-monorepo.git
 cd app-monorepo
+corepack enable    # bootstraps the Yarn version pinned in package.json
 yarn
-yarn app:web    # starts dev server at http://localhost:3000
+yarn app:web      # starts dev server at http://localhost:3000
 ```
 
 <details>


### PR DESCRIPTION
## Summary

Closes GITBOT-SMOKE-005.

A first-time contributor previously had no clear path from a clean machine to a working `yarn` install. The README mentioned `Yarn 4.x (bundled via Corepack)` but never showed the actual `corepack enable` step, and didn't make it explicit that the exact Yarn version is pinned by `package.json`'s `packageManager` field (currently `yarn@4.12.0`).

## Changes

- `README.md` — Getting Onboard section:
  - Clarified the prerequisites note so it's clear the exact Yarn version is pinned in `package.json` and provisioned by Corepack.
  - Added `corepack enable` to the bootstrap snippet so newcomers get the right Yarn version on the first run.

Net diff: **+3 / -2** lines, well within the < 15 lines added budget. No code or build-config changes — markdown only.

`engines.node` (`>=22`) is already documented on the same prerequisites line, so no additional duplication was introduced and no new `CONTRIBUTING.md` was created (matches the repo's existing single-README style).

## Test plan

- [x] `git status` clean after commit.
- [x] Diff scoped to `README.md` only.
- [x] Bootstrap snippet runs in order: `corepack enable` → `yarn` → `yarn app:web`.