### PR TITLE
docs(readme): fix grammar in security bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Run these commands from the root directory:
 
 ## 🔰 Security
 
-- Please read the [Bug Bounty Rules](docs/BUG_RULES.md), we have detailed the exact plan in this article.
+- Please read the [Bug Bounty Rules](docs/BUG_RULES.md) for the full details of our disclosure program.
 - Report suspected vulnerabilities privately to **dev@onekey.so** or via [BugRap](https://bugrap.io/bounties/OneKey).
 - Please do **NOT** create publicly viewable issues for suspected security vulnerabilities.
 - As an open source project, although we are not yet profitable, we try to give some rewards to white hat hackers who disclose vulnerabilities to us in a timely manner.


### PR DESCRIPTION
## Summary

The first bullet of the Security section in `README.md` had a comma splice and awkward phrasing:

> - Please read the [Bug Bounty Rules](docs/BUG_RULES.md), we have detailed the exact plan in this article.

Rewritten into a single, natural sentence while preserving the link target and anchor text:

> - Please read the [Bug Bounty Rules](docs/BUG_RULES.md) for the full details of our disclosure program.

## Scope

- One-line change in `README.md` only.
- No code, other docs, or translation files touched.
- Surrounding Security bullets intentionally left alone.

## Test plan

- [x] `git diff --stat` shows `1 file changed, 1 insertion(+), 1 deletion(-)`.
- [x] Rendered Markdown still shows the `Bug Bounty Rules` link pointing at `docs/BUG_RULES.md`.

Self-review: skipped as trivial (single-line README prose fix, no logic).
