### PR TITLE
fix: prevent stale swap balance orders(OK-53762 OK-53841)

### DIFF
--- a/packages/kit-bg/src/services/ServiceHistory.ts
+++ b/packages/kit-bg/src/services/ServiceHistory.ts
@@ -1242,6 +1242,66 @@ class ServiceHistory extends ServiceBase {
   }
 
   @backgroundMethod()
+  public async clearLocalHistoryPendingTxByTxId(params: {
+    accountId?: string;
+    networkId: string;
+    txid?: string;
+    accountAddress?: string;
+  }) {
+    const { accountId, networkId, txid } = params;
+    if (!networkId || !txid) {
+      return false;
+    }
+
+    let accountAddress = params.accountAddress;
+    let xpub: string | undefined;
+    if (accountId) {
+      try {
+        [accountAddress, xpub] = await Promise.all([
+          this.backgroundApi.serviceAccount.getAccountAddressForApi({
+            accountId,
+            networkId,
+          }),
+          this.backgroundApi.serviceAccount.getAccountXpub({
+            accountId,
+            networkId,
+          }),
+        ]);
+      } catch (_e) {
+        // fall back to the caller-provided account address
+      }
+    }
+
+    if (!accountAddress && !xpub) {
+      return false;
+    }
+
+    const localHistoryPendingTxs = await this.getAccountLocalHistoryPendingTxs({
+      networkId,
+      accountAddress: accountAddress ?? '',
+      xpub,
+    });
+    const txidLower = txid.toLowerCase();
+    const pendingTxsToClear = localHistoryPendingTxs.filter(
+      (tx) => tx.decodedTx.txid?.toLowerCase() === txidLower,
+    );
+    if (!pendingTxsToClear.length) {
+      return false;
+    }
+
+    await simpleDb.localHistory.batchUpdateLocalHistoryTxs([
+      {
+        networkId,
+        accountAddress,
+        xpub,
+        confirmedTxs: pendingTxsToClear,
+      },
+    ]);
+    appEventBus.emit(EAppEventBusNames.HistoryTxStatusChanged, undefined);
+    return true;
+  }
+
+  @backgroundMethod()
   public async clearLocalHistory() {
     return this.backgroundApi.simpleDb.localHistory.clearLocalHistory();
   }

--- a/packages/kit-bg/src/services/ServiceHistory.ts
+++ b/packages/kit-bg/src/services/ServiceHistory.ts
@@ -1281,10 +1281,15 @@ class ServiceHistory extends ServiceBase {
       accountAddress: accountAddress ?? '',
       xpub,
     });
-    const txidLower = txid.toLowerCase();
-    const pendingTxsToClear = localHistoryPendingTxs.filter(
-      (tx) => tx.decodedTx.txid?.toLowerCase() === txidLower,
-    );
+    const shouldIgnoreTxIdCase = networkUtils.isEvmNetwork({ networkId });
+    const txidForCompare = shouldIgnoreTxIdCase ? txid.toLowerCase() : txid;
+    const pendingTxsToClear = localHistoryPendingTxs.filter((tx) => {
+      const pendingTxId = tx.decodedTx.txid;
+      return (
+        (shouldIgnoreTxIdCase ? pendingTxId?.toLowerCase() : pendingTxId) ===
+        txidForCompare
+      );
+    });
     if (!pendingTxsToClear.length) {
       return false;
     }

--- a/packages/kit-bg/src/services/ServiceHistory.ts
+++ b/packages/kit-bg/src/services/ServiceHistory.ts
@@ -1292,7 +1292,7 @@ class ServiceHistory extends ServiceBase {
     await simpleDb.localHistory.batchUpdateLocalHistoryTxs([
       {
         networkId,
-        accountAddress,
+        accountAddress: accountAddress ?? '',
         xpub,
         confirmedTxs: pendingTxsToClear,
       },

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -1717,9 +1717,10 @@ export default class ServiceSwap extends ServiceBase {
         txStatusRes?.state !== ESwapTxHistoryStatus.PENDING ||
         txStatusRes.crossChainStatus !== currentSwapTxHistory.crossChainStatus
       ) {
+        const rawStatus = txStatusRes.state;
         currentSwapTxHistory = {
           ...currentSwapTxHistory,
-          status: txStatusRes.state,
+          status: rawStatus,
           extraStatus: txStatusRes.extraStatus,
           swapInfo: {
             ...currentSwapTxHistory.swapInfo,
@@ -1770,13 +1771,13 @@ export default class ServiceSwap extends ServiceBase {
           currentSwapTxHistory.crossChainStatus ===
             ESwapCrossChainStatus.REFUNDED ||
           (!currentSwapTxHistory.crossChainStatus &&
-            (finalStatus === ESwapTxHistoryStatus.SUCCESS ||
-              finalStatus === ESwapTxHistoryStatus.PARTIALLY_FILLED))
+            (rawStatus === ESwapTxHistoryStatus.SUCCESS ||
+              rawStatus === ESwapTxHistoryStatus.PARTIALLY_FILLED))
         ) {
           appEventBus.emit(EAppEventBusNames.SwapTxHistoryStatusUpdate, {
             fromToken: currentSwapTxHistory.baseInfo.fromToken,
             toToken: currentSwapTxHistory.baseInfo.toToken,
-            status: finalStatus,
+            status: rawStatus,
             crossChainStatus: txStatusRes.crossChainStatus,
           });
           appEventBus.emit(EAppEventBusNames.SwapSpeedBalanceUpdate, {

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -1634,6 +1634,26 @@ export default class ServiceSwap extends ServiceBase {
     }
   }
 
+  private async clearLocalPendingTxForTerminalSwap(
+    swapTxHistory: ISwapTxHistory,
+  ) {
+    const txId = swapTxHistory.txInfo.txId;
+    if (!txId) {
+      return;
+    }
+
+    try {
+      await this.backgroundApi.serviceHistory.clearLocalHistoryPendingTxByTxId({
+        accountId: swapTxHistory.accountInfo.sender.accountId,
+        networkId: swapTxHistory.baseInfo.fromToken.networkId,
+        txid: txId,
+        accountAddress: swapTxHistory.txInfo.sender,
+      });
+    } catch (error) {
+      console.error('Clear swap local pending tx error', error);
+    }
+  }
+
   async swapHistoryStatusRunFetch(swapTxHistory: ISwapTxHistory) {
     let enableInterval = true;
     let currentSwapTxHistory = cloneDeep(swapTxHistory);
@@ -1691,6 +1711,12 @@ export default class ServiceSwap extends ServiceBase {
           },
         };
         await this.updateSwapHistoryItem(currentSwapTxHistory);
+        if (
+          txStatusRes?.state === ESwapTxHistoryStatus.FAILED ||
+          txStatusRes?.state === ESwapTxHistoryStatus.CANCELED
+        ) {
+          await this.clearLocalPendingTxForTerminalSwap(currentSwapTxHistory);
+        }
         if (
           currentSwapTxHistory.crossChainStatus ===
             ESwapCrossChainStatus.FROM_SUCCESS ||

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -1755,9 +1755,10 @@ export default class ServiceSwap extends ServiceBase {
         await this.updateSwapHistoryItem(currentSwapTxHistory, {
           shouldShowToast,
         });
+        const finalStatus = currentSwapTxHistory.status;
         if (
-          txStatusRes?.state === ESwapTxHistoryStatus.FAILED ||
-          txStatusRes?.state === ESwapTxHistoryStatus.CANCELED
+          finalStatus === ESwapTxHistoryStatus.FAILED ||
+          finalStatus === ESwapTxHistoryStatus.CANCELED
         ) {
           await this.clearLocalPendingTxForTerminalSwap(currentSwapTxHistory);
         }
@@ -1769,13 +1770,13 @@ export default class ServiceSwap extends ServiceBase {
           currentSwapTxHistory.crossChainStatus ===
             ESwapCrossChainStatus.REFUNDED ||
           (!currentSwapTxHistory.crossChainStatus &&
-            (txStatusRes?.state === ESwapTxHistoryStatus.SUCCESS ||
-              txStatusRes?.state === ESwapTxHistoryStatus.PARTIALLY_FILLED))
+            (finalStatus === ESwapTxHistoryStatus.SUCCESS ||
+              finalStatus === ESwapTxHistoryStatus.PARTIALLY_FILLED))
         ) {
           appEventBus.emit(EAppEventBusNames.SwapTxHistoryStatusUpdate, {
             fromToken: currentSwapTxHistory.baseInfo.fromToken,
             toToken: currentSwapTxHistory.baseInfo.toToken,
-            status: txStatusRes.state,
+            status: finalStatus,
             crossChainStatus: txStatusRes.crossChainStatus,
           });
           appEventBus.emit(EAppEventBusNames.SwapSpeedBalanceUpdate, {
@@ -1783,7 +1784,7 @@ export default class ServiceSwap extends ServiceBase {
             orderToToken: currentSwapTxHistory.baseInfo.toToken,
           });
         }
-        if (txStatusRes?.state !== ESwapTxHistoryStatus.PENDING) {
+        if (finalStatus !== ESwapTxHistoryStatus.PENDING) {
           enableInterval = false;
           const deleteHistoryId = currentSwapTxHistory.txInfo.useOrderId
             ? (currentSwapTxHistory.txInfo.orderId ?? '')

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -1387,18 +1387,48 @@ export default class ServiceSwap extends ServiceBase {
     return histories.toSorted((a, b) => b.date.created - a.date.created);
   }
 
+  private isSwapHistoryPendingStatus(history: ISwapTxHistory) {
+    return (
+      history.status === ESwapTxHistoryStatus.PENDING ||
+      history.status === ESwapTxHistoryStatus.CANCELING
+    );
+  }
+
   @backgroundMethod()
   async syncSwapHistoryPendingList() {
     const histories = await this.fetchSwapHistoryListFromSimple();
-    const pendingHistories = histories.filter(
-      (history) =>
-        history.status === ESwapTxHistoryStatus.PENDING ||
-        history.status === ESwapTxHistoryStatus.CANCELING,
+    const pendingHistories = histories.filter((history) =>
+      this.isSwapHistoryPendingStatus(history),
     );
     await inAppNotificationAtom.set((pre) => ({
       ...pre,
       swapHistoryPendingList: filterSwapHistoryPendingList(pendingHistories),
     }));
+  }
+
+  @backgroundMethod()
+  async refreshSwapHistoryPendingStatusOnce() {
+    const histories = await this.fetchSwapHistoryListFromSimple();
+    const pendingHistories = histories.filter((history) =>
+      this.isSwapHistoryPendingStatus(history),
+    );
+    await inAppNotificationAtom.set((pre) => ({
+      ...pre,
+      swapHistoryPendingList: filterSwapHistoryPendingList(pendingHistories),
+    }));
+
+    if (!pendingHistories.length) {
+      return;
+    }
+
+    await Promise.all(
+      pendingHistories.map((swapTxHistory) =>
+        this.swapHistoryStatusRunFetch(swapTxHistory, {
+          shouldScheduleNextFetch: false,
+          shouldShowToast: false,
+        }),
+      ),
+    );
   }
 
   @backgroundMethod()
@@ -1485,8 +1515,12 @@ export default class ServiceSwap extends ServiceBase {
   }
 
   @backgroundMethod()
-  async updateSwapHistoryItem(item: ISwapTxHistory) {
+  async updateSwapHistoryItem(
+    item: ISwapTxHistory,
+    options?: { shouldShowToast?: boolean },
+  ) {
     const { swapHistoryPendingList } = await inAppNotificationAtom.get();
+    const shouldShowToast = options?.shouldShowToast ?? true;
     const filteredList = filterSwapHistoryPendingList(swapHistoryPendingList);
     const matchFn = (i: ISwapTxHistory) =>
       item.txInfo.useOrderId
@@ -1526,7 +1560,7 @@ export default class ServiceSwap extends ServiceBase {
           swapHistoryPendingList: newPendingList,
         };
       });
-      if (item.status !== ESwapTxHistoryStatus.PENDING) {
+      if (shouldShowToast && item.status !== ESwapTxHistoryStatus.PENDING) {
         let fromAmountFinal = item.baseInfo.fromAmount;
         if (item.swapInfo.otherFeeInfos?.length) {
           item.swapInfo.otherFeeInfos.forEach((extraFeeInfo) => {
@@ -1654,8 +1688,16 @@ export default class ServiceSwap extends ServiceBase {
     }
   }
 
-  async swapHistoryStatusRunFetch(swapTxHistory: ISwapTxHistory) {
+  async swapHistoryStatusRunFetch(
+    swapTxHistory: ISwapTxHistory,
+    options?: {
+      shouldScheduleNextFetch?: boolean;
+      shouldShowToast?: boolean;
+    },
+  ) {
     let enableInterval = true;
+    const shouldScheduleNextFetch = options?.shouldScheduleNextFetch ?? true;
+    const shouldShowToast = options?.shouldShowToast ?? true;
     let currentSwapTxHistory = cloneDeep(swapTxHistory);
     try {
       const txStatusRes = await this.fetchTxState({
@@ -1710,7 +1752,9 @@ export default class ServiceSwap extends ServiceBase {
               : currentSwapTxHistory.baseInfo.toAmount,
           },
         };
-        await this.updateSwapHistoryItem(currentSwapTxHistory);
+        await this.updateSwapHistoryItem(currentSwapTxHistory, {
+          shouldShowToast,
+        });
         if (
           txStatusRes?.state === ESwapTxHistoryStatus.FAILED ||
           txStatusRes?.state === ESwapTxHistoryStatus.CANCELED
@@ -1756,6 +1800,7 @@ export default class ServiceSwap extends ServiceBase {
         : (currentSwapTxHistory.txInfo.txId ?? '');
       if (
         enableInterval &&
+        shouldScheduleNextFetch &&
         this.historyCurrentStateIntervalIds.includes(keyId)
       ) {
         this.historyStateIntervalCountMap[keyId] =
@@ -1780,11 +1825,7 @@ export default class ServiceSwap extends ServiceBase {
     const { swapHistoryPendingList } = await inAppNotificationAtom.get();
     const statusPendingList = filterSwapHistoryPendingList(
       swapHistoryPendingList,
-    ).filter(
-      (item) =>
-        item.status === ESwapTxHistoryStatus.PENDING ||
-        item.status === ESwapTxHistoryStatus.CANCELING,
-    );
+    ).filter((item) => this.isSwapHistoryPendingStatus(item));
     const newHistoryStatePendingList = statusPendingList.filter(
       (item) =>
         !this.historyCurrentStateIntervalIds.includes(

--- a/packages/kit/src/views/AssetDetails/pages/HistoryDetails/HistoryDetails.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/HistoryDetails/HistoryDetails.tsx
@@ -17,7 +17,6 @@ import {
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { AddressInfo } from '@onekeyhq/kit/src/components/AddressInfo';
-import { Currency } from '@onekeyhq/kit/src/components/Currency';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import NumberSizeableTextWrapper from '@onekeyhq/kit/src/components/NumberSizeableTextWrapper';
 import { Token } from '@onekeyhq/kit/src/components/Token';
@@ -392,13 +391,7 @@ function HistoryDetails() {
           });
       }
 
-      const swapHistoryInfo =
-        await backgroundApiProxy.serviceSwap.getSwapHistoryByTxId({
-          txId: txid,
-        });
-
       return {
-        swapHistoryInfo,
         txDetails: r?.data,
         decodedOnChainTx,
         addressMap: r?.addressMap,
@@ -428,8 +421,7 @@ function HistoryDetails() {
     },
   );
 
-  const { txDetails, decodedOnChainTx, addressMap, swapHistoryInfo } =
-    result || {};
+  const { txDetails, decodedOnChainTx, addressMap } = result || {};
   const historyTx = historyTxParam ?? decodedOnChainTx;
 
   useEffect(() => {
@@ -1183,28 +1175,6 @@ function HistoryDetails() {
               compact
             />
 
-            {swapHistoryInfo?.swapInfo?.oneKeyFeeExtraInfo?.oneKeyFeeUsd ? (
-              <InfoItem
-                label={intl.formatMessage({
-                  id: ETranslations.provider_ios_popover_onekey_fee,
-                })}
-                renderContent={
-                  <Currency
-                    formatter="value"
-                    size="$bodyMd"
-                    color="$textSubdued"
-                    sourceCurrency="usd"
-                  >
-                    {
-                      swapHistoryInfo?.swapInfo?.oneKeyFeeExtraInfo
-                        ?.oneKeyFeeUsd
-                    }
-                  </Currency>
-                }
-                compact
-              />
-            ) : null}
-
             <InfoItem
               label={intl.formatMessage({
                 id: ETranslations.global_network,
@@ -1286,7 +1256,6 @@ function HistoryDetails() {
     vaultSettings?.isUtxo,
     vaultSettings?.hideTxUtxoListWhenPending,
     renderFeeInfo,
-    swapHistoryInfo?.swapInfo?.oneKeyFeeExtraInfo?.oneKeyFeeUsd,
     network?.name,
     network?.id,
     historyTx?.decodedTx.status,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -2041,19 +2041,20 @@ export function useSpeedSwapActions(props: {
         const signingQuoteResult = await refreshMarketSigningQuoteResult({
           snapshot,
         });
+        const signingFromAmount =
+          signingQuoteResult.fromAmount ?? snapshot.swapInfo.sender.amount;
+        await assertLatestFromTokenBalanceSufficient({
+          token: snapshot.swapInfo.sender.token,
+          amount: signingFromAmount,
+          accountAddress: snapshot.accountAddress,
+          accountId: snapshot.accountId,
+        });
         const signedQuoteResult = await signMarketReviewQuoteResult({
           quoteResult: signingQuoteResult,
           accountId: snapshot.accountId,
           networkId: snapshot.networkId,
           accountAddress: snapshot.accountAddress,
           receivingAddress: snapshot.swapInfo.receivingAddress,
-        });
-        await assertLatestFromTokenBalanceSufficient({
-          token: snapshot.swapInfo.sender.token,
-          amount:
-            signedQuoteResult.fromAmount ?? snapshot.swapInfo.sender.amount,
-          accountAddress: snapshot.accountAddress,
-          accountId: snapshot.accountId,
         });
         const buildRes =
           await backgroundApiProxy.serviceSwap.fetchBuildSpeedSwapTx({

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -18,6 +18,7 @@ import { useSignatureConfirm } from '@onekeyhq/kit/src/hooks/useSignatureConfirm
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import { useSelectedDeriveTypeAtom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2/atoms';
 import { type ISwapReviewStepTexts } from '@onekeyhq/kit/src/views/Swap/utils/buildSwapReviewState';
+import { checkSwapLatestBalanceSufficient } from '@onekeyhq/kit/src/views/Swap/utils/swapBalanceUtils';
 import type {
   ISwapReviewAdapter,
   ISwapReviewApproveBroadcastResult,
@@ -125,6 +126,26 @@ type IMarketReviewExecutionSnapshot = {
   swapInfo: ISwapTxInfo;
   buildRes?: IFetchBuildTxResponse;
 };
+
+type ICheckSwapLatestBalanceSufficient = (params: {
+  token: ISwapToken;
+  amount: string;
+  accountAddress?: string;
+  accountId?: string;
+}) => Promise<
+  | {
+      isSufficient: true;
+    }
+  | {
+      isSufficient: false;
+      balance: string;
+      requiredAmount: string;
+      tokenSymbol: string;
+    }
+>;
+
+const checkLatestBalanceSufficient =
+  checkSwapLatestBalanceSufficient as ICheckSwapLatestBalanceSufficient;
 
 export function buildMarketReviewTokens({
   tradeType,
@@ -713,6 +734,38 @@ export function useSpeedSwapActions(props: {
     [intl, marketDeriveInfoRes.result?.addressEncoding, slippage],
   );
 
+  const assertLatestFromTokenBalanceSufficient = useCallback(
+    async ({
+      token,
+      amount,
+      accountAddress,
+      accountId,
+    }: {
+      token: ISwapToken;
+      amount: string;
+      accountAddress?: string;
+      accountId?: string;
+    }) => {
+      const checkResult = await checkLatestBalanceSufficient({
+        token,
+        amount,
+        accountAddress,
+        accountId,
+      });
+      if (!checkResult.isSufficient) {
+        throw new OneKeyLocalError(
+          intl.formatMessage(
+            {
+              id: ETranslations.swap_page_toast_insufficient_balance_title,
+            },
+            { token: checkResult.tokenSymbol },
+          ),
+        );
+      }
+    },
+    [intl],
+  );
+
   const buildSpeedSwapTxData = useCallback(
     async ({
       fromAmount,
@@ -733,6 +786,13 @@ export function useSpeedSwapActions(props: {
           'Market swap review requires account and amount.',
         );
       }
+
+      await assertLatestFromTokenBalanceSufficient({
+        token: fromTokenFinal,
+        amount,
+        accountAddress: userAddress,
+        accountId: netAccountRes.result.id,
+      });
 
       setSpeedSwapBuildTxLoading(true);
       try {
@@ -871,6 +931,7 @@ export function useSpeedSwapActions(props: {
       slippage,
       toToken,
       buildMarketExecutionFromBuildRes,
+      assertLatestFromTokenBalanceSufficient,
     ],
   );
 
@@ -1820,6 +1881,13 @@ export function useSpeedSwapActions(props: {
       const snapshot = requireReviewExecutionSnapshot('swap');
 
       try {
+        await assertLatestFromTokenBalanceSufficient({
+          token: snapshot.swapInfo.sender.token,
+          amount: snapshot.swapInfo.sender.amount,
+          accountAddress: snapshot.accountAddress,
+          accountId: snapshot.accountId,
+        });
+
         if (snapshot.shouldFallback) {
           setSpeedSwapBuildTxLoading(true);
 
@@ -1892,6 +1960,7 @@ export function useSpeedSwapActions(props: {
     },
     [
       buildMarketApproveUnsignedTxArr,
+      assertLatestFromTokenBalanceSufficient,
       cancelSpeedSwapBuildTx,
       handleMarketSwapBuildTxSuccess,
       isUserCancelledError,
@@ -1978,6 +2047,13 @@ export function useSpeedSwapActions(props: {
           networkId: snapshot.networkId,
           accountAddress: snapshot.accountAddress,
           receivingAddress: snapshot.swapInfo.receivingAddress,
+        });
+        await assertLatestFromTokenBalanceSufficient({
+          token: snapshot.swapInfo.sender.token,
+          amount:
+            signedQuoteResult.fromAmount ?? snapshot.swapInfo.sender.amount,
+          accountAddress: snapshot.accountAddress,
+          accountId: snapshot.accountId,
         });
         const buildRes =
           await backgroundApiProxy.serviceSwap.fetchBuildSpeedSwapTx({
@@ -2095,6 +2171,7 @@ export function useSpeedSwapActions(props: {
     [
       antiMEV,
       buildMarketExecutionFromBuildRes,
+      assertLatestFromTokenBalanceSufficient,
       cancelSpeedSwapBuildTx,
       handleMarketSignedOrderSuccess,
       isUserCancelledError,

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -120,6 +120,7 @@ import {
   useSwapToTokenAmountAtom,
   useSwapTypeSwitchAtom,
 } from '../../../states/jotai/contexts/swap';
+import { checkSwapLatestBalanceSufficient } from '../utils/swapBalanceUtils';
 
 import { useSwapAddressInfo } from './useSwapAccount';
 import { useSwapBuildTxInfo, useSwapProAccount } from './useSwapPro';
@@ -469,6 +470,39 @@ export function useSwapBuildTx() {
       return checkRes;
     },
     [fromToken, intl, selectQuote?.fromAmount, fromUserAddress, fromAccountId],
+  );
+
+  const checkLatestFromTokenBalance = useCallback(
+    async (token: ISwapToken, amount: string) => {
+      const checkResult = await checkSwapLatestBalanceSufficient({
+        token,
+        amount,
+        accountAddress: fromUserAddress,
+        accountId: fromAccountId,
+      });
+      if (!checkResult.isSufficient) {
+        Toast.error({
+          title: intl.formatMessage(
+            {
+              id: ETranslations.swap_page_toast_insufficient_balance_title,
+            },
+            { token: checkResult.tokenSymbol },
+          ),
+          message: intl.formatMessage(
+            {
+              id: ETranslations.swap_page_toast_insufficient_balance_content,
+            },
+            {
+              token: checkResult.tokenSymbol,
+              number: numberFormat(checkResult.requiredAmount, formatter),
+            },
+          ),
+        });
+        return false;
+      }
+      return true;
+    },
+    [fromAccountId, fromUserAddress, intl],
   );
 
   const cancelLimitOrder = useCallback(
@@ -1734,6 +1768,13 @@ export function useSwapBuildTx() {
         fromAccountNetworkId &&
         fromAccountId
       ) {
+        const checkLatestBalanceRes = await checkLatestFromTokenBalance(
+          data.fromTokenInfo,
+          data.fromAmount,
+        );
+        if (!checkLatestBalanceRes) {
+          throw new OneKeyError('checkLatestFromTokenBalance failed');
+        }
         if (swapStepsRef.current.preSwapData.swapBuildResultData) {
           return swapStepsRef.current.preSwapData.swapBuildResultData;
         }
@@ -2048,6 +2089,7 @@ export function useSwapBuildTx() {
       fromAccountNetworkId,
       fromAccountId,
       setSwapSteps,
+      checkLatestFromTokenBalance,
       checkOtherFee,
       swapFromAddressInfo.accountInfo?.wallet?.type,
       swapFromAddressInfo.accountInfo?.deriveInfo?.addressEncoding,

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -2258,6 +2258,13 @@ export function useSwapBuildTx() {
       ) {
         const selectQuoteRes = cloneDeep(data);
         if (selectQuoteRes.swapShouldSignedData && fromAccountId) {
+          const checkLatestBalanceRes = await checkLatestFromTokenBalance(
+            selectQuoteRes.fromTokenInfo,
+            data.fromAmount,
+          );
+          if (!checkLatestBalanceRes) {
+            throw new OneKeyError('checkLatestFromTokenBalance failed');
+          }
           const {
             unSignedInfo,
             unSignedMessage,
@@ -2440,6 +2447,7 @@ export function useSwapBuildTx() {
     },
     [
       buildTxNew,
+      checkLatestFromTokenBalance,
       slippageItem,
       fromAccountId,
       fromUserAddress,

--- a/packages/kit/src/views/Swap/pages/modal/SwapHistoryListModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapHistoryListModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useRoute } from '@react-navigation/core';
 import BigNumber from 'bignumber.js';
@@ -66,6 +66,11 @@ const SwapHistoryListModal = ({
   );
   const [{ swapHistoryPendingList, swapLimitOrders }] =
     useInAppNotificationAtom();
+
+  useEffect(() => {
+    void backgroundApiProxy.serviceSwap.refreshSwapHistoryPendingStatusOnce();
+  }, []);
+
   const { result: swapTxHistoryList } = usePromiseResult(
     async () => {
       const histories =

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
@@ -1,0 +1,68 @@
+import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
+
+import { checkSwapLatestBalanceSufficient } from './swapBalanceUtils';
+
+type IFetchSwapTokenDetailsParams = {
+  networkId: string;
+  contractAddress: string;
+  accountAddress?: string;
+  accountId?: string;
+  currency?: string;
+};
+
+const mockFetchSwapTokenDetails: jest.MockedFunction<
+  (params: IFetchSwapTokenDetailsParams) => Promise<{ balanceParsed: string }[]>
+> = jest.fn();
+
+jest.mock('../../../background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {
+    serviceSwap: {
+      fetchSwapTokenDetails: (params: IFetchSwapTokenDetailsParams) =>
+        mockFetchSwapTokenDetails(params),
+    },
+  },
+}));
+
+const ethToken = {
+  networkId: 'evm--1',
+  contractAddress: '',
+  symbol: 'ETH',
+} as ISwapToken;
+
+describe('checkSwapLatestBalanceSufficient', () => {
+  beforeEach(() => {
+    mockFetchSwapTokenDetails.mockReset();
+  });
+
+  it('returns insufficient when the latest token balance is lower than amount', async () => {
+    mockFetchSwapTokenDetails.mockResolvedValue([{ balanceParsed: '0.08' }]);
+
+    await expect(
+      checkSwapLatestBalanceSufficient({
+        token: ethToken,
+        amount: '0.1',
+        accountId: 'account-id',
+        accountAddress: '0xabc',
+      }),
+    ).resolves.toEqual({
+      isSufficient: false,
+      balance: '0.08',
+      requiredAmount: '0.1',
+      tokenSymbol: 'ETH',
+    });
+  });
+
+  it('does not block when balance cannot be fetched', async () => {
+    mockFetchSwapTokenDetails.mockResolvedValue([]);
+
+    await expect(
+      checkSwapLatestBalanceSufficient({
+        token: ethToken,
+        amount: '0.1',
+        accountId: 'account-id',
+        accountAddress: '0xabc',
+      }),
+    ).resolves.toEqual({ isSufficient: true });
+  });
+});

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
@@ -1,0 +1,73 @@
+import BigNumber from 'bignumber.js';
+
+import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
+
+import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
+
+type ISwapLatestBalanceCheckParams = {
+  token: ISwapToken;
+  amount: string;
+  accountId?: string;
+  accountAddress?: string;
+};
+
+export type ISwapLatestBalanceCheckResult =
+  | {
+      isSufficient: true;
+    }
+  | {
+      isSufficient: false;
+      balance: string;
+      requiredAmount: string;
+      tokenSymbol: string;
+    };
+
+export async function checkSwapLatestBalanceSufficient({
+  token,
+  amount,
+  accountId,
+  accountAddress,
+}: ISwapLatestBalanceCheckParams): Promise<ISwapLatestBalanceCheckResult> {
+  const amountBN = new BigNumber(amount || 0);
+  if (
+    !token?.networkId ||
+    !accountAddress ||
+    amountBN.isNaN() ||
+    !amountBN.isFinite() ||
+    amountBN.lte(0)
+  ) {
+    return { isSufficient: true };
+  }
+
+  try {
+    const tokenBalanceInfo =
+      await backgroundApiProxy.serviceSwap.fetchSwapTokenDetails({
+        networkId: token.networkId,
+        contractAddress: token.contractAddress ?? '',
+        accountAddress,
+        accountId,
+        currency: 'usd',
+      });
+    if (!tokenBalanceInfo?.length) {
+      return { isSufficient: true };
+    }
+
+    const balanceBN = new BigNumber(tokenBalanceInfo[0].balanceParsed ?? 0);
+    if (balanceBN.isNaN() || !balanceBN.isFinite()) {
+      return { isSufficient: true };
+    }
+
+    if (amountBN.gt(balanceBN)) {
+      return {
+        isSufficient: false,
+        balance: balanceBN.toFixed(),
+        requiredAmount: amountBN.toFixed(),
+        tokenSymbol: token.symbol,
+      };
+    }
+  } catch (error) {
+    console.error('checkSwapLatestBalanceSufficient error', error);
+  }
+
+  return { isSufficient: true };
+}


### PR DESCRIPTION
## Summary
- Check the latest source-token balance before building Swap transactions, instead of trusting potentially stale UI balance state.
- Apply the same latest-balance guard to Market/Trade speed swap build and send flows.
- When Swap marks an order as failed or canceled, clear only the matching local pending wallet tx by txid to avoid nonce blocking later orders.
- Add focused unit coverage for the latest-balance helper.

## Root Cause
- For centralized providers such as Changelly, build-tx may be entered with a stale source-token balance if the wallet asset state has not refreshed. That allowed a 0.1 ETH order to be built while the address had about 0.08 ETH.
- When the Swap order later failed before going on-chain, wallet local history could still keep the tx as pending. The next transaction then waited behind that local pending nonce.

## Design
- The balance guard fetches current token details through `serviceSwap.fetchSwapTokenDetails` immediately before build/send. If the latest balance cannot be fetched, it does not block the existing flow.
- Pending cleanup is exact-match only: same sender account/network/address scope and same txid. It does not clear unrelated pending transactions.

## Test Plan
- `yarn jest --runTestsByPath packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts --runInBand`
- `yarn lint:staged`
- `yarn tsc:staged`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
