### PR TITLE
fix(swap): align edit-address dialog placeholder with send flow

### DIFF
--- a/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
@@ -164,6 +164,9 @@ const SwapToAnotherAddressPage = () => {
             name="address"
             networkId={networkId}
             actionsLayout="recipient"
+            placeholder={intl.formatMessage({
+              id: ETranslations.search_or_paste_address__desc,
+            })}
             enableAddressBook
             enableWalletName
             enableAddressInteractionStatus


### PR DESCRIPTION
## Summary
- The recipient input in the Swap "Edit Address" dialog was using `AddressInputField`'s default placeholder (`send_to_placeholder`), which differed from the Send flow
- Pass `placeholder={ETranslations.search_or_paste_address__desc}` explicitly (same key as the Send flow) so the copy reads "Search or paste address"
- Swap does not run on Lightning networks, so no Lightning-specific branch is needed (unlike Send)

## Test plan
- [ ] Open Swap → tap "To another address" → the recipient input placeholder should read "Search or paste address"
- [ ] Compare against the Send page recipient input — placeholders should match
- [ ] Switch across chains (EVM / Solana / TRON) — placeholder should stay consistent

<img width="1105" height="906" alt="Screenshot 2026-04-24 at 16 28 14" src="https://github.com/user-attachments/assets/40a86a6b-18e4-408f-a0d3-835cd298fd10" />

