### PR TITLE
perf(defi): force-refresh positions at +40s/+80s after local tx confirms (OK-53474)

### DIFF
--- a/packages/kit-bg/src/services/ServiceDeFi.ts
+++ b/packages/kit-bg/src/services/ServiceDeFi.ts
@@ -352,9 +352,17 @@ class ServiceDeFi extends ServiceBase {
   }) {
     const { accountId, indexedAccountId, networkId } = params;
     try {
-      const [settings, currencyMap] = await Promise.all([
+      const [settings, currencyMap, accountAddress, xpub] = await Promise.all([
         settingsPersistAtom.get(),
         this.backgroundApi.serviceSetting.getCurrencyMap(),
+        this.backgroundApi.serviceAccount.getAccountAddressForApi({
+          accountId,
+          networkId,
+        }),
+        this.backgroundApi.serviceAccount.getAccountXpub({
+          accountId,
+          networkId,
+        }),
       ]);
       const sourceCurrencyInfo = currencyMap[settings.currencyInfo.id];
       const targetCurrencyInfo = currencyMap.usd;
@@ -362,16 +370,58 @@ class ServiceDeFi extends ServiceBase {
       const resp = await this.fetchAccountDeFiPositions({
         accountId,
         networkId,
+        accountAddress,
+        xpub,
         excludeLowValueProtocols: true,
         sourceCurrencyInfo,
         targetCurrencyInfo,
-        saveToLocal: true,
+        // Do NOT use saveToLocal here. The shared `_localDeFiOverviewCache`
+        // is keyed only by networkId and the debounced flush writes against
+        // the last `accountAddress/xpub` it sees, so concurrent background
+        // refreshes for different accounts on the same network — or a
+        // background refresh racing with a foreground UI fetch — would
+        // overwrite each other's per-account local overview. Write this
+        // single account's overview directly below instead.
+        saveToLocal: false,
         isForceRefresh: true,
         // Do not share the abort pool: a UI-initiated
         // abortFetchAccountDeFiPositions() must not cancel the scheduled
         // force refresh, which is what delivers the post-tx freshness.
         abortable: false,
       });
+
+      if (accountAddress || xpub) {
+        await this.updateAccountsLocalDeFiOverview({
+          accountAddress,
+          xpub,
+          overview: {
+            [networkId]: {
+              totalValue: this._fixCurrencyValue({
+                sourceCurrencyInfo,
+                targetCurrencyInfo,
+                value: resp.overview.totalValue,
+              }).toNumber(),
+              totalDebt: this._fixCurrencyValue({
+                sourceCurrencyInfo,
+                targetCurrencyInfo,
+                value: resp.overview.totalDebt,
+              }).toNumber(),
+              totalReward: this._fixCurrencyValue({
+                sourceCurrencyInfo,
+                targetCurrencyInfo,
+                value: resp.overview.totalReward,
+              }).toNumber(),
+              netWorth: this._fixCurrencyValue({
+                sourceCurrencyInfo,
+                targetCurrencyInfo,
+                value: resp.overview.netWorth,
+              }).toNumber(),
+              currency: targetCurrencyInfo?.id ?? '',
+            },
+          },
+          merge: true,
+        });
+      }
 
       appEventBus.emit(EAppEventBusNames.DeFiPositionRefreshed, {
         accountId,

--- a/packages/kit-bg/src/services/ServiceDeFi.ts
+++ b/packages/kit-bg/src/services/ServiceDeFi.ts
@@ -2,11 +2,16 @@ import BigNumber from 'bignumber.js';
 import { debounce, isEmpty, isUndefined } from 'lodash';
 
 import type { ICurrencyItem } from '@onekeyhq/kit/src/views/Setting/pages/Currency';
+import { settingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
   backgroundClass,
   backgroundMethod,
 } from '@onekeyhq/shared/src/background/backgroundDecorators';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
+import {
+  EAppEventBusNames,
+  appEventBus,
+} from '@onekeyhq/shared/src/eventBus/appEventBus';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import defiUtils from '@onekeyhq/shared/src/utils/defiUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
@@ -15,6 +20,7 @@ import type {
   IFetchAccountDeFiPositionsResp,
 } from '@onekeyhq/shared/types/defi';
 import { EServiceEndpointEnum } from '@onekeyhq/shared/types/endpoint';
+import { EDecodedTxStatus } from '@onekeyhq/shared/types/tx';
 
 import ServiceBase from './ServiceBase';
 
@@ -31,9 +37,23 @@ class ServiceDeFi extends ServiceBase {
 
   constructor({ backgroundApi }: { backgroundApi: any }) {
     super({ backgroundApi });
+
+    appEventBus.on(EAppEventBusNames.LocalPendingTxConfirmed, (payload) => {
+      void this.onLocalTxConfirmedForDeFi(payload);
+    });
   }
 
   _fetchAccountDeFiPositionsControllers: AbortController[] = [];
+
+  // Offsets (ms) from a local tx being confirmed at which we force-refresh
+  // the DeFi portfolio for that chain. Covers indexer lag after the tx lands.
+  private readonly _FORCE_REFRESH_OFFSETS_MS = [40_000, 80_000] as const;
+
+  // Per (accountId + networkId) pending timers; newer txs reset the schedule.
+  private _deFiForceRefreshTimers = new Map<
+    string,
+    { timers: ReturnType<typeof setTimeout>[]; scheduledAt: number }
+  >();
 
   _localDeFiOverviewCache: Record<
     string,
@@ -264,6 +284,108 @@ class ServiceDeFi extends ServiceBase {
         allNetworksNetworkId === currentNetworkId
       ),
     };
+  }
+
+  private _buildDeFiForceRefreshKey(accountId: string, networkId: string) {
+    return `${accountId}__${networkId}`;
+  }
+
+  private _cancelDeFiForceRefresh(key: string) {
+    const entry = this._deFiForceRefreshTimers.get(key);
+    if (!entry) return;
+    entry.timers.forEach((t) => clearTimeout(t));
+    this._deFiForceRefreshTimers.delete(key);
+  }
+
+  @backgroundMethod()
+  public async isNetworkDeFiEnabled(networkId: string): Promise<boolean> {
+    if (!networkId) return false;
+    const enabledMap = await this.getDeFiEnabledNetworksMap();
+    return !!enabledMap[networkId];
+  }
+
+  @backgroundMethod()
+  public async onLocalTxConfirmedForDeFi(payload: {
+    accountId: string;
+    networkId: string;
+    status: EDecodedTxStatus;
+    txid?: string;
+    accountAddress?: string;
+    xpub?: string;
+  }) {
+    const { accountId, networkId, status } = payload;
+
+    if (!accountId || !networkId) return;
+
+    // Failed txs do not move positions, so no force refresh needed.
+    if (status !== EDecodedTxStatus.Confirmed) return;
+
+    // Skip chains that do not support DeFi at all.
+    if (!(await this.isNetworkDeFiEnabled(networkId))) return;
+
+    const key = this._buildDeFiForceRefreshKey(accountId, networkId);
+
+    // Coalesce multiple confirmed txs: reset the schedule to the latest one.
+    this._cancelDeFiForceRefresh(key);
+
+    const timers = this._FORCE_REFRESH_OFFSETS_MS.map((offset) =>
+      setTimeout(() => {
+        void this._runDeFiForceRefresh({ accountId, networkId });
+      }, offset),
+    );
+
+    this._deFiForceRefreshTimers.set(key, {
+      timers,
+      scheduledAt: Date.now(),
+    });
+  }
+
+  private async _runDeFiForceRefresh(params: {
+    accountId: string;
+    networkId: string;
+  }) {
+    const { accountId, networkId } = params;
+    try {
+      const [settings, currencyMap] = await Promise.all([
+        settingsPersistAtom.get(),
+        this.backgroundApi.serviceSetting.getCurrencyMap(),
+      ]);
+      const sourceCurrencyInfo = currencyMap[settings.currencyInfo.id];
+      const targetCurrencyInfo = currencyMap.usd;
+
+      const resp = await this.fetchAccountDeFiPositions({
+        accountId,
+        networkId,
+        excludeLowValueProtocols: true,
+        sourceCurrencyInfo,
+        targetCurrencyInfo,
+        saveToLocal: true,
+        isForceRefresh: true,
+      });
+
+      appEventBus.emit(EAppEventBusNames.DeFiPositionRefreshed, {
+        accountId,
+        networkId,
+        overview: {
+          totalValue: resp.overview.totalValue ?? 0,
+          totalDebt: resp.overview.totalDebt ?? 0,
+          totalReward: resp.overview.totalReward ?? 0,
+          netWorth: resp.overview.netWorth ?? 0,
+          chains: resp.overview.chains ?? [],
+          protocolCount: resp.overview.protocolCount ?? 0,
+          positionCount: resp.overview.positionCount ?? 0,
+        },
+        protocols: resp.protocols,
+        protocolMap: resp.protocolMap,
+      });
+    } catch (e) {
+      // Swallow: do not let a failed force-refresh poison the timer table.
+      console.error(
+        '[ServiceDeFi] force refresh failed',
+        { accountId, networkId },
+        e,
+      );
+    }
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceDeFi.ts
+++ b/packages/kit-bg/src/services/ServiceDeFi.ts
@@ -8,6 +8,7 @@ import {
   backgroundMethod,
 } from '@onekeyhq/shared/src/background/backgroundDecorators';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
+import type { IAppEventBusPayload } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -47,12 +48,11 @@ class ServiceDeFi extends ServiceBase {
 
   // Offsets (ms) from a local tx being confirmed at which we force-refresh
   // the DeFi portfolio for that chain. Covers indexer lag after the tx lands.
-  private readonly _FORCE_REFRESH_OFFSETS_MS = [40_000, 80_000] as const;
+  private readonly _deFiForceRefreshOffsetsMs = [40_000, 80_000] as const;
 
-  // Per (accountId + networkId) pending timers; newer txs reset the schedule.
   private _deFiForceRefreshTimers = new Map<
     string,
-    { timers: ReturnType<typeof setTimeout>[]; scheduledAt: number }
+    ReturnType<typeof setTimeout>[]
   >();
 
   _localDeFiOverviewCache: Record<
@@ -134,6 +134,7 @@ class ServiceDeFi extends ServiceBase {
       targetCurrencyInfo,
       saveToLocal,
       isForceRefresh,
+      abortable = true,
     } = params;
 
     const isUrlAccount = accountUtils.isUrlAccountFn({ accountId });
@@ -155,7 +156,9 @@ class ServiceDeFi extends ServiceBase {
     const client = await this.getClient(EServiceEndpointEnum.Wallet);
 
     const controller = new AbortController();
-    this._fetchAccountDeFiPositionsControllers.push(controller);
+    if (abortable) {
+      this._fetchAccountDeFiPositionsControllers.push(controller);
+    }
 
     let accountAddress = params.accountAddress;
     let xpub = params.xpub;
@@ -291,9 +294,9 @@ class ServiceDeFi extends ServiceBase {
   }
 
   private _cancelDeFiForceRefresh(key: string) {
-    const entry = this._deFiForceRefreshTimers.get(key);
-    if (!entry) return;
-    entry.timers.forEach((t) => clearTimeout(t));
+    const timers = this._deFiForceRefreshTimers.get(key);
+    if (!timers) return;
+    timers.forEach((t) => clearTimeout(t));
     this._deFiForceRefreshTimers.delete(key);
   }
 
@@ -305,15 +308,10 @@ class ServiceDeFi extends ServiceBase {
   }
 
   @backgroundMethod()
-  public async onLocalTxConfirmedForDeFi(payload: {
-    accountId: string;
-    networkId: string;
-    status: EDecodedTxStatus;
-    txid?: string;
-    accountAddress?: string;
-    xpub?: string;
-  }) {
-    const { accountId, networkId, status } = payload;
+  public async onLocalTxConfirmedForDeFi(
+    payload: IAppEventBusPayload[EAppEventBusNames.LocalPendingTxConfirmed],
+  ) {
+    const { accountId, indexedAccountId, networkId, status } = payload;
 
     if (!accountId || !networkId) return;
 
@@ -328,23 +326,31 @@ class ServiceDeFi extends ServiceBase {
     // Coalesce multiple confirmed txs: reset the schedule to the latest one.
     this._cancelDeFiForceRefresh(key);
 
-    const timers = this._FORCE_REFRESH_OFFSETS_MS.map((offset) =>
+    const maxOffset = Math.max(...this._deFiForceRefreshOffsetsMs);
+    const timers = this._deFiForceRefreshOffsetsMs.map((offset) =>
       setTimeout(() => {
-        void this._runDeFiForceRefresh({ accountId, networkId });
+        void this._runDeFiForceRefresh({
+          accountId,
+          indexedAccountId,
+          networkId,
+        });
+        // After the last scheduled offset fires, drop the Map entry so it
+        // does not linger once every timer has run.
+        if (offset === maxOffset) {
+          this._deFiForceRefreshTimers.delete(key);
+        }
       }, offset),
     );
 
-    this._deFiForceRefreshTimers.set(key, {
-      timers,
-      scheduledAt: Date.now(),
-    });
+    this._deFiForceRefreshTimers.set(key, timers);
   }
 
   private async _runDeFiForceRefresh(params: {
     accountId: string;
+    indexedAccountId?: string;
     networkId: string;
   }) {
-    const { accountId, networkId } = params;
+    const { accountId, indexedAccountId, networkId } = params;
     try {
       const [settings, currencyMap] = await Promise.all([
         settingsPersistAtom.get(),
@@ -361,25 +367,22 @@ class ServiceDeFi extends ServiceBase {
         targetCurrencyInfo,
         saveToLocal: true,
         isForceRefresh: true,
+        // Do not share the abort pool: a UI-initiated
+        // abortFetchAccountDeFiPositions() must not cancel the scheduled
+        // force refresh, which is what delivers the post-tx freshness.
+        abortable: false,
       });
 
       appEventBus.emit(EAppEventBusNames.DeFiPositionRefreshed, {
         accountId,
+        indexedAccountId,
         networkId,
-        overview: {
-          totalValue: resp.overview.totalValue ?? 0,
-          totalDebt: resp.overview.totalDebt ?? 0,
-          totalReward: resp.overview.totalReward ?? 0,
-          netWorth: resp.overview.netWorth ?? 0,
-          chains: resp.overview.chains ?? [],
-          protocolCount: resp.overview.protocolCount ?? 0,
-          positionCount: resp.overview.positionCount ?? 0,
-        },
+        overview: resp.overview,
         protocols: resp.protocols,
         protocolMap: resp.protocolMap,
       });
     } catch (e) {
-      // Swallow: do not let a failed force-refresh poison the timer table.
+      // Swallow so a failed force-refresh does not block future schedules.
       console.error(
         '[ServiceDeFi] force refresh failed',
         { accountId, networkId },

--- a/packages/kit-bg/src/services/ServiceHistory.ts
+++ b/packages/kit-bg/src/services/ServiceHistory.ts
@@ -228,17 +228,22 @@ class ServiceHistory extends ServiceBase {
 
     // Notify subscribers (e.g. DeFi scheduler) that locally-pending txs
     // submitted by this app have just transitioned to confirmed/failed.
+    // Resolve indexedAccountId so UI subscribers in All Networks mode (where
+    // the active account.id may not share a walletId with the tx's per-
+    // network accountId) can do a reliable equality match.
     for (const tx of confirmedTxs) {
-      try {
-        appEventBus.emit(EAppEventBusNames.LocalPendingTxConfirmed, {
-          accountId: tx.decodedTx.accountId,
-          networkId: tx.decodedTx.networkId,
-          txid: tx.decodedTx.txid,
-          status: tx.decodedTx.status,
+      const txAccountId = tx.decodedTx.accountId;
+      const txDBAccount =
+        await this.backgroundApi.serviceAccount.getDBAccountSafe({
+          accountId: txAccountId,
         });
-      } catch {
-        // swallow per-tx emit failures to avoid affecting history pipeline
-      }
+      appEventBus.emit(EAppEventBusNames.LocalPendingTxConfirmed, {
+        accountId: txAccountId,
+        indexedAccountId: txDBAccount?.indexedAccountId,
+        networkId: tx.decodedTx.networkId,
+        txid: tx.decodedTx.txid,
+        status: tx.decodedTx.status,
+      });
     }
 
     // 3. Get the locally confirmed transactions

--- a/packages/kit-bg/src/services/ServiceHistory.ts
+++ b/packages/kit-bg/src/services/ServiceHistory.ts
@@ -226,6 +226,21 @@ class ServiceHistory extends ServiceBase {
       }
     }
 
+    // Notify subscribers (e.g. DeFi scheduler) that locally-pending txs
+    // submitted by this app have just transitioned to confirmed/failed.
+    for (const tx of confirmedTxs) {
+      try {
+        appEventBus.emit(EAppEventBusNames.LocalPendingTxConfirmed, {
+          accountId: tx.decodedTx.accountId,
+          networkId: tx.decodedTx.networkId,
+          txid: tx.decodedTx.txid,
+          status: tx.decodedTx.status,
+        });
+      } catch {
+        // swallow per-tx emit failures to avoid affecting history pipeline
+      }
+    }
+
     // 3. Get the locally confirmed transactions
     if (isAllNetworks) {
       const allNetworksParams = accounts.map((account) => ({

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
@@ -44,7 +44,6 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import defiUtils from '@onekeyhq/shared/src/utils/defiUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { EHomeTab } from '@onekeyhq/shared/types';
@@ -844,20 +843,18 @@ function DeFiListBlock({
       if (!account?.id || !network?.id) return;
 
       // Prefer indexedAccountId equality (robust for All Networks mode);
-      // fall back to walletId match for accounts without an indexed id
-      // (e.g. imported / watching-only).
+      // fall back to a strict accountId match for accounts without an
+      // indexed id (imported / watching-only / external). A walletId-only
+      // compare is unsafe for those types because they all share a single
+      // wallet bucket (`imported`, `watching`, `external`) — distinct
+      // accounts inside the same bucket would otherwise leak each other's
+      // refreshed positions into the current view.
       const currentIndexedId = account.indexedAccountId;
       const payloadIndexedId = payload.indexedAccountId;
       if (currentIndexedId && payloadIndexedId) {
         if (currentIndexedId !== payloadIndexedId) return;
-      } else {
-        const { walletId: payloadWalletId } = accountUtils.parseAccountId({
-          accountId: payload.accountId,
-        });
-        const { walletId: currentWalletId } = accountUtils.parseAccountId({
-          accountId: account.id,
-        });
-        if (!payloadWalletId || payloadWalletId !== currentWalletId) return;
+      } else if (payload.accountId !== account.id) {
+        return;
       }
 
       if (!network.isAllNetworks) {

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
@@ -25,6 +25,7 @@ import {
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import {
   useDeFiListActions,
+  useDeFiListProtocolMapAtom,
   useDeFiListProtocolsAtom,
   useDeFiListStateAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/deFiList';
@@ -42,6 +43,7 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import defiUtils from '@onekeyhq/shared/src/utils/defiUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { EHomeTab } from '@onekeyhq/shared/types';
@@ -87,6 +89,7 @@ function DeFiListBlock({
   const [overview] = useAccountDeFiOverviewAtom();
   const [{ isRefreshing, initialized }] = useDeFiListStateAtom();
   const [{ protocols }] = useDeFiListProtocolsAtom();
+  const [{ protocolMap }] = useDeFiListProtocolMapAtom();
 
   const deFiRawDataRef = useRef<IDeFiDBStruct | undefined>(undefined);
   const initializedRef = useRef(initialized);
@@ -827,6 +830,124 @@ function DeFiListBlock({
       appEventBus.off(EAppEventBusNames.NetworkDeriveTypeChanged, onRefresh);
     };
   }, [isFocused, network?.isAllNetworks, handleRefreshAllNetworkData, run]);
+
+  useEffect(() => {
+    const onDeFiPositionRefreshed = (payload: {
+      accountId: string;
+      networkId: string;
+      overview: {
+        totalValue: number;
+        totalDebt: number;
+        totalReward: number;
+        netWorth: number;
+        chains: string[];
+        protocolCount: number;
+        positionCount: number;
+      };
+      protocols: IDeFiProtocol[];
+      protocolMap: Record<string, IProtocolSummary>;
+    }) => {
+      if (refreshCacheOnly) return;
+      if (!account?.id || !network?.id) return;
+
+      // Gate events to the currently viewed wallet. Single-network mode
+      // additionally matches exact accountId + networkId below.
+      const { walletId: payloadWalletId } = accountUtils.parseAccountId({
+        accountId: payload.accountId,
+      });
+      const { walletId: currentWalletId } = accountUtils.parseAccountId({
+        accountId: account.id,
+      });
+      if (!payloadWalletId || payloadWalletId !== currentWalletId) return;
+
+      if (!network.isAllNetworks) {
+        if (
+          payload.accountId !== account.id ||
+          payload.networkId !== network.id
+        ) {
+          return;
+        }
+        updateAccountDeFiOverview({
+          currency: settings.currencyInfo.id,
+          accountId: account.id,
+          networkId: network.id,
+          overview: {
+            totalValue: payload.overview.totalValue,
+            totalDebt: payload.overview.totalDebt,
+            totalReward: payload.overview.totalReward,
+            netWorth: payload.overview.netWorth,
+          },
+          isReady: true,
+        });
+        updateDeFiListProtocols({ protocols: payload.protocols });
+        updateDeFiListProtocolMap({ protocolMap: payload.protocolMap });
+        updateDeFiListState({ initialized: true, isRefreshing: false });
+        return;
+      }
+
+      // All Networks: drop this network's old entries and splice in the
+      // refreshed ones. Aggregated overview is recomputed from the merged
+      // protocolMap so the header total stays in sync.
+      const prefix = `${payload.networkId}-`;
+      const nextProtocols = protocols
+        .filter((p) => p.networkId !== payload.networkId)
+        .concat(payload.protocols);
+
+      const nextProtocolMap: Record<string, IProtocolSummary> = {};
+      for (const [k, v] of Object.entries(protocolMap)) {
+        if (!k.startsWith(prefix)) nextProtocolMap[k] = v;
+      }
+      Object.assign(nextProtocolMap, payload.protocolMap);
+
+      let totalValue = 0;
+      let totalDebt = 0;
+      let totalReward = 0;
+      let netWorth = 0;
+      for (const s of Object.values(nextProtocolMap)) {
+        totalValue = new BigNumber(totalValue)
+          .plus(s.totalValue ?? 0)
+          .toNumber();
+        totalDebt = new BigNumber(totalDebt).plus(s.totalDebt ?? 0).toNumber();
+        totalReward = new BigNumber(totalReward)
+          .plus(s.totalReward ?? 0)
+          .toNumber();
+        netWorth = new BigNumber(netWorth).plus(s.netWorth ?? 0).toNumber();
+      }
+
+      updateDeFiListProtocols({ protocols: nextProtocols });
+      updateDeFiListProtocolMap({ protocolMap: nextProtocolMap });
+      updateAccountDeFiOverview({
+        currency: settings.currencyInfo.id,
+        accountId: account.id,
+        networkId: network.id,
+        overview: { totalValue, totalDebt, totalReward, netWorth },
+        isReady: true,
+      });
+    };
+
+    appEventBus.on(
+      EAppEventBusNames.DeFiPositionRefreshed,
+      onDeFiPositionRefreshed,
+    );
+    return () => {
+      appEventBus.off(
+        EAppEventBusNames.DeFiPositionRefreshed,
+        onDeFiPositionRefreshed,
+      );
+    };
+  }, [
+    account?.id,
+    network?.id,
+    network?.isAllNetworks,
+    protocols,
+    protocolMap,
+    refreshCacheOnly,
+    settings.currencyInfo.id,
+    updateAccountDeFiOverview,
+    updateDeFiListProtocols,
+    updateDeFiListProtocolMap,
+    updateDeFiListState,
+  ]);
 
   useEffect(() => {
     if (allNetworksResult) {

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
@@ -38,6 +38,7 @@ import {
   POLLING_DEBOUNCE_INTERVAL,
   POLLING_INTERVAL_FOR_DEFI,
 } from '@onekeyhq/shared/src/consts/walletConsts';
+import type { IAppEventBusPayload } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -96,6 +97,10 @@ function DeFiListBlock({
   const isRefreshingRef = useRef(isRefreshing);
   initializedRef.current = initialized;
   isRefreshingRef.current = isRefreshing;
+  const protocolsRef = useRef(protocols);
+  const protocolMapRef = useRef(protocolMap);
+  protocolsRef.current = protocols;
+  protocolMapRef.current = protocolMap;
   const pendingRefreshRef = useRef(false);
 
   const [overflowState, setOverflowState] = useState<{
@@ -832,33 +837,28 @@ function DeFiListBlock({
   }, [isFocused, network?.isAllNetworks, handleRefreshAllNetworkData, run]);
 
   useEffect(() => {
-    const onDeFiPositionRefreshed = (payload: {
-      accountId: string;
-      networkId: string;
-      overview: {
-        totalValue: number;
-        totalDebt: number;
-        totalReward: number;
-        netWorth: number;
-        chains: string[];
-        protocolCount: number;
-        positionCount: number;
-      };
-      protocols: IDeFiProtocol[];
-      protocolMap: Record<string, IProtocolSummary>;
-    }) => {
+    const onDeFiPositionRefreshed = (
+      payload: IAppEventBusPayload[EAppEventBusNames.DeFiPositionRefreshed],
+    ) => {
       if (refreshCacheOnly) return;
       if (!account?.id || !network?.id) return;
 
-      // Gate events to the currently viewed wallet. Single-network mode
-      // additionally matches exact accountId + networkId below.
-      const { walletId: payloadWalletId } = accountUtils.parseAccountId({
-        accountId: payload.accountId,
-      });
-      const { walletId: currentWalletId } = accountUtils.parseAccountId({
-        accountId: account.id,
-      });
-      if (!payloadWalletId || payloadWalletId !== currentWalletId) return;
+      // Prefer indexedAccountId equality (robust for All Networks mode);
+      // fall back to walletId match for accounts without an indexed id
+      // (e.g. imported / watching-only).
+      const currentIndexedId = account.indexedAccountId;
+      const payloadIndexedId = payload.indexedAccountId;
+      if (currentIndexedId && payloadIndexedId) {
+        if (currentIndexedId !== payloadIndexedId) return;
+      } else {
+        const { walletId: payloadWalletId } = accountUtils.parseAccountId({
+          accountId: payload.accountId,
+        });
+        const { walletId: currentWalletId } = accountUtils.parseAccountId({
+          accountId: account.id,
+        });
+        if (!payloadWalletId || payloadWalletId !== currentWalletId) return;
+      }
 
       if (!network.isAllNetworks) {
         if (
@@ -889,29 +889,25 @@ function DeFiListBlock({
       // refreshed ones. Aggregated overview is recomputed from the merged
       // protocolMap so the header total stays in sync.
       const prefix = `${payload.networkId}-`;
-      const nextProtocols = protocols
+      const nextProtocols = protocolsRef.current
         .filter((p) => p.networkId !== payload.networkId)
         .concat(payload.protocols);
 
       const nextProtocolMap: Record<string, IProtocolSummary> = {};
-      for (const [k, v] of Object.entries(protocolMap)) {
+      for (const [k, v] of Object.entries(protocolMapRef.current)) {
         if (!k.startsWith(prefix)) nextProtocolMap[k] = v;
       }
       Object.assign(nextProtocolMap, payload.protocolMap);
 
-      let totalValue = 0;
-      let totalDebt = 0;
-      let totalReward = 0;
-      let netWorth = 0;
+      let totalValueBN = new BigNumber(0);
+      let totalDebtBN = new BigNumber(0);
+      let totalRewardBN = new BigNumber(0);
+      let netWorthBN = new BigNumber(0);
       for (const s of Object.values(nextProtocolMap)) {
-        totalValue = new BigNumber(totalValue)
-          .plus(s.totalValue ?? 0)
-          .toNumber();
-        totalDebt = new BigNumber(totalDebt).plus(s.totalDebt ?? 0).toNumber();
-        totalReward = new BigNumber(totalReward)
-          .plus(s.totalReward ?? 0)
-          .toNumber();
-        netWorth = new BigNumber(netWorth).plus(s.netWorth ?? 0).toNumber();
+        totalValueBN = totalValueBN.plus(s.totalValue ?? 0);
+        totalDebtBN = totalDebtBN.plus(s.totalDebt ?? 0);
+        totalRewardBN = totalRewardBN.plus(s.totalReward ?? 0);
+        netWorthBN = netWorthBN.plus(s.netWorth ?? 0);
       }
 
       updateDeFiListProtocols({ protocols: nextProtocols });
@@ -920,7 +916,12 @@ function DeFiListBlock({
         currency: settings.currencyInfo.id,
         accountId: account.id,
         networkId: network.id,
-        overview: { totalValue, totalDebt, totalReward, netWorth },
+        overview: {
+          totalValue: totalValueBN.toNumber(),
+          totalDebt: totalDebtBN.toNumber(),
+          totalReward: totalRewardBN.toNumber(),
+          netWorth: netWorthBN.toNumber(),
+        },
         isReady: true,
       });
     };
@@ -937,10 +938,9 @@ function DeFiListBlock({
     };
   }, [
     account?.id,
+    account?.indexedAccountId,
     network?.id,
     network?.isAllNetworks,
-    protocols,
-    protocolMap,
     refreshCacheOnly,
     settings.currencyInfo.id,
     updateAccountDeFiOverview,

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -26,6 +26,7 @@ import platformEnv from '../platformEnv';
 import { EAppEventBusNames } from './appEventBusNames';
 
 import type { EAccountSelectorSceneName, EHomeTab } from '../../types';
+import type { IDeFiProtocol, IProtocolSummary } from '../../types/defi';
 import type { IFeeSelectorItem } from '../../types/fee';
 import type { ESubscriptionType } from '../../types/hyperliquid/types';
 import type {
@@ -44,6 +45,7 @@ import type {
   ISwapTokenBase,
 } from '../../types/swap/types';
 import type { IAccountToken, ITokenFiat } from '../../types/token';
+import type { EDecodedTxStatus } from '../../types/tx';
 import type { EHomeWalletTab } from '../../types/wallet';
 import type { IOneKeyError } from '../errors/types/errorTypes';
 import type { EModalRoutes, ETabRoutes } from '../routes';
@@ -234,6 +236,29 @@ export interface IAppEventBusPayload {
   [EAppEventBusNames.CloseHardwareUiStateDialogManually]: undefined;
   [EAppEventBusNames.HardCloseHardwareUiStateDialog]: undefined;
   [EAppEventBusNames.HistoryTxStatusChanged]: undefined;
+  [EAppEventBusNames.LocalPendingTxConfirmed]: {
+    accountId: string;
+    networkId: string;
+    txid: string;
+    status: EDecodedTxStatus;
+    accountAddress?: string;
+    xpub?: string;
+  };
+  [EAppEventBusNames.DeFiPositionRefreshed]: {
+    accountId: string;
+    networkId: string;
+    overview: {
+      totalValue: number;
+      totalDebt: number;
+      totalReward: number;
+      netWorth: number;
+      chains: string[];
+      protocolCount: number;
+      positionCount: number;
+    };
+    protocols: IDeFiProtocol[];
+    protocolMap: Record<string, IProtocolSummary>;
+  };
   [EAppEventBusNames.EstimateTxFeeRetry]: undefined;
   [EAppEventBusNames.TokenListUpdate]: {
     tokens: IAccountToken[];

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -26,7 +26,11 @@ import platformEnv from '../platformEnv';
 import { EAppEventBusNames } from './appEventBusNames';
 
 import type { EAccountSelectorSceneName, EHomeTab } from '../../types';
-import type { IDeFiProtocol, IProtocolSummary } from '../../types/defi';
+import type {
+  IDeFiProtocol,
+  IFetchAccountDeFiPositionsResp,
+  IProtocolSummary,
+} from '../../types/defi';
 import type { IFeeSelectorItem } from '../../types/fee';
 import type { ESubscriptionType } from '../../types/hyperliquid/types';
 import type {
@@ -238,24 +242,16 @@ export interface IAppEventBusPayload {
   [EAppEventBusNames.HistoryTxStatusChanged]: undefined;
   [EAppEventBusNames.LocalPendingTxConfirmed]: {
     accountId: string;
+    indexedAccountId?: string;
     networkId: string;
     txid: string;
     status: EDecodedTxStatus;
-    accountAddress?: string;
-    xpub?: string;
   };
   [EAppEventBusNames.DeFiPositionRefreshed]: {
     accountId: string;
+    indexedAccountId?: string;
     networkId: string;
-    overview: {
-      totalValue: number;
-      totalDebt: number;
-      totalReward: number;
-      netWorth: number;
-      chains: string[];
-      protocolCount: number;
-      positionCount: number;
-    };
+    overview: IFetchAccountDeFiPositionsResp['data']['totals'];
     protocols: IDeFiProtocol[];
     protocolMap: Record<string, IProtocolSummary>;
   };

--- a/packages/shared/src/eventBus/appEventBusNames.ts
+++ b/packages/shared/src/eventBus/appEventBusNames.ts
@@ -55,6 +55,8 @@ export enum EAppEventBusNames {
   CloseHardwareUiStateDialogManually = 'CloseHardwareUiStateDialogManually',
   HardCloseHardwareUiStateDialog = 'CloseHardwareUiStateDialog',
   HistoryTxStatusChanged = 'HistoryTxStatusChanged',
+  LocalPendingTxConfirmed = 'LocalPendingTxConfirmed',
+  DeFiPositionRefreshed = 'DeFiPositionRefreshed',
   EstimateTxFeeRetry = 'estimateTxFeeRetry',
   TokenListUpdate = 'TokenListUpdate',
   TabListStateUpdate = 'TabListStateUpdate',

--- a/packages/shared/types/defi.ts
+++ b/packages/shared/types/defi.ts
@@ -14,6 +14,10 @@ export type IFetchAccountDeFiPositionsParams = {
   sourceCurrencyInfo?: ICurrencyItem;
   targetCurrencyInfo?: ICurrencyItem;
   isForceRefresh?: boolean;
+  // When false, the request is NOT registered with the shared abort pool and
+  // will not be cancelled by abortFetchAccountDeFiPositions(). Use for
+  // background schedulers whose fetches should survive UI-initiated aborts.
+  abortable?: boolean;
 };
 
 export enum EDeFiAssetType {


### PR DESCRIPTION
## Summary
- Schedule two force refreshes of the DeFi portfolio for the affected chain at +40s and +80s after a locally-submitted tx transitions pending → confirmed, so Wallet Home DeFi Tab reflects post-tx positions without waiting for the 60s poll.
- Only triggers on DeFi-enabled chains and `EDecodedTxStatus.Confirmed`; multiple txs on the same `(accountId, networkId)` coalesce to the latest schedule.
- Works in both single-network and All Networks modes; background scheduler so the fresh result lands in simpleDb even if the user has already navigated away.

## Intent & Context
Product reported that after users perform DeFi operations (stake / unstake / claim / swap) from inside the OneKey app, the Wallet Home DeFi Tab's Position data stays stale until the next 60s natural polling tick. We need a way to surface post-tx freshness quickly without aggressively shortening the poll interval.

The PM's proposal was to force refresh at +40s and +80s — empirical offsets that cover the common range of DeFi indexer lag across supported protocols (Aave, Lido, Compound, etc.) while strictly bounding the extra server load (at most two additional requests per DeFi tx per chain, coalesced across multiple rapid txs).

## Root Cause (for the stale-data problem)
The existing DeFi polling path in `DeFiListBlock` uses `usePromiseResult` with `pollingInterval: POLLING_INTERVAL_FOR_DEFI` (60s) and debounce 1s. Outside of this cadence, there is no reactive path from tx confirmation → DeFi refresh. The existing `AccountDataUpdate` event fires on pull-to-refresh but not on confirmation.

## Design Decisions
- **Event plumbing**: `ServiceHistory.fetchAccountHistory`'s pending→confirmed detection loop now emits `LocalPendingTxConfirmed` per tx. This loop only iterates locally-pending txs (those persisted by `saveSendConfirmHistoryTxs`), so it naturally filters for "tx submitted via this app" without an explicit origin check.
- **Indexed-account resolution at emit time**: The payload carries `indexedAccountId` resolved via `serviceAccount.getDBAccountSafe`, so All Networks mode subscribers can match reliably rather than parsing a walletId out of the raw accountId.
- **Background scheduling in ServiceDeFi**: The 40s/80s timers live in `ServiceDeFi`, not in `DeFiListBlock`. This means the force refresh writes to simpleDb regardless of whether the DeFi Tab is currently mounted — the user sees fresh data the next time they open the tab.
- **Coalescing key**: `(accountId, networkId)`. New txs reset the schedule to the latest confirmation time. Prevents timer stacking when users chain multiple operations.
- **"DeFi-enabled chain" filter**: Uses `getDeFiEnabledNetworksMap()` (the chain-level capability flag) rather than "has current positions > 0". This covers the first-stake case where the user has no positions on that chain until after the tx.
- **Abort pool separation**: Added `IFetchAccountDeFiPositionsParams.abortable` (default `true`, backward-compatible). The scheduler's force refresh passes `abortable: false` so a UI-initiated `abortFetchAccountDeFiPositions()` on account/tab switch does not cancel the scheduled refresh, which is what delivers the post-tx freshness.
- **All Networks partial merge**: Instead of triggering a full all-networks re-run, the subscriber splices the refreshed network's protocols into the current list and re-aggregates the overview totals from `protocolMap`, keeping the header number consistent.

## Changes Detail
- `packages/shared/src/eventBus/appEventBusNames.ts` — adds `LocalPendingTxConfirmed` and `DeFiPositionRefreshed` enum entries.
- `packages/shared/src/eventBus/appEventBus.ts` — payload types for both events; overview uses `IFetchAccountDeFiPositionsResp['data']['totals']` to stay in sync with the server contract.
- `packages/shared/types/defi.ts` — adds `abortable?: boolean` to `IFetchAccountDeFiPositionsParams`.
- `packages/kit-bg/src/services/ServiceHistory.ts` — emits `LocalPendingTxConfirmed` per confirmed tx with resolved `indexedAccountId`.
- `packages/kit-bg/src/services/ServiceDeFi.ts` — subscribes to `LocalPendingTxConfirmed` in the constructor; schedules timers per `(accountId, networkId)` with coalescing and post-fire Map cleanup; `_runDeFiForceRefresh` calls `fetchAccountDeFiPositions({isForceRefresh: true, saveToLocal: true, abortable: false})` and emits `DeFiPositionRefreshed`.
- `packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx` — subscribes to `DeFiPositionRefreshed`; single-network mode writes atoms from payload; All Networks mode splices the refreshed network's protocols/protocolMap in place and re-aggregates overview via BigNumber. Subscription deps stabilized via refs so it does not rebuild on every atom update.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension / Mobile / Desktop / Web (all Home Wallet DeFi Tab consumers)
- **Risk Areas**:
  - **Mobile background timers** — `setTimeout` accuracy degrades when iOS/Android backgrounds the app. Acceptable for this feature; if the user locks the phone mid-window, they will see fresh data on next resume via simpleDb + the natural polling cycle. Listed as P2 follow-up in planning doc.
  - **ServiceDeFi lazy instantiation** — the constructor-level subscription only activates after the service is first accessed. In practice, `DeFiListBlock` triggers this within the first render of Home. Edge case: if a tx confirms before ServiceDeFi is ever touched (deeplink flows), the event is missed; 60s natural polling still corrects.
  - **Extra server load** — bounded to 2 extra `/wallet/v1/portfolio/positions?isForceRefresh=true` calls per DeFi tx per chain, coalesced across rapid txs.
  - **Non-DeFi txs still emit** `LocalPendingTxConfirmed` — scheduler filters via `isNetworkDeFiEnabled`; extra events, no wasted network calls.

## Test plan
- [ ] Stake a small amount on Ethereum → verify `isForceRefresh=true` requests hit `/wallet/v1/portfolio/positions` at ~40s and ~80s post-confirm; new position appears in the DeFi Tab within 80s
- [ ] Unstake / claim rewards → same as above
- [ ] Send two stake txs within 30s → verify only one pair of timers fires (i.e. the first pair is cancelled; add temporary log to `_deFiForceRefreshTimers.size` if needed)
- [ ] All Networks mode: stake Ethereum → only the single-chain request flies (no fan-out to 20 enabled networks); header total updates, other chains' positions remain untouched
- [ ] Send DeFi tx → switch away from DeFi Tab immediately → return after 90s → see updated positions (simpleDb write path)
- [ ] Failed tx (insufficient gas) → no force-refresh request fires
- [ ] Non-DeFi chain tx → no force-refresh request fires
- [ ] Rapid account switch during the 40-80s window → verify scheduler's in-flight request is NOT cancelled by the UI's `abortFetchAccountDeFiPositions` (the new `abortable: false` protection)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
