### PR TITLE
feat(prime): merge profile editor into OneKey ID page (OK-53678)

### DIFF
--- a/packages/kit/src/components/MoreActionButton/index.tsx
+++ b/packages/kit/src/components/MoreActionButton/index.tsx
@@ -88,7 +88,6 @@ import useScanQrCode from '../../views/ScanQrCode/hooks/useScanQrCode';
 import { OneKeyIdAvatar } from '../../views/Setting/pages/OneKeyId';
 import { ESettingsTabNames } from '../../views/Setting/pages/Tab/config';
 import { AccountSelectorProviderMirror } from '../AccountSelector';
-import { useEditPrimeProfileDialog } from '../RenameDialog';
 import { UpdateReminder } from '../UpdateReminder';
 import {
   isShowAppUpdateUIWhenUpdating,
@@ -551,16 +550,6 @@ function MoreActionOneKeyId() {
   }, [isLoggedIn, user?.displayEmail, intl]);
 
   const navigation = useAppNavigation();
-  const showEditPrimeProfileDialog = useEditPrimeProfileDialog();
-
-  const handleAvatarPress = useCallback(
-    async (e: GestureResponderEvent) => {
-      e.stopPropagation();
-      await closePopover?.();
-      await showEditPrimeProfileDialog();
-    },
-    [closePopover, showEditPrimeProfileDialog],
-  );
 
   const handleNavigateToOneKeyId = useCallback(async () => {
     await closePopover?.();
@@ -667,9 +656,7 @@ function MoreActionOneKeyId() {
       }}
     >
       <XStack alignItems="center" gap="$3" flex={1}>
-        <Stack onPress={handleAvatarPress}>
-          <OneKeyIdAvatar size="$14" />
-        </Stack>
+        <OneKeyIdAvatar size="$14" />
 
         <YStack flex={1} gap="$1">
           <XStack

--- a/packages/kit/src/views/Prime/pages/OneKeyId/index.tsx
+++ b/packages/kit/src/views/Prime/pages/OneKeyId/index.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useRef } from 'react';
 
 import { useIntl } from 'react-intl';
+import { StyleSheet } from 'react-native';
 
 import {
   Badge,
   Icon,
-  LinearGradient,
   Page,
   SizableText,
   Stack,
@@ -19,8 +19,10 @@ import {
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { useOneKeyAuth } from '@onekeyhq/kit/src/components/OneKeyAuth/useOneKeyAuth';
+import { useEditPrimeProfileDialog } from '@onekeyhq/kit/src/components/RenameDialog';
 import { useReferFriends } from '@onekeyhq/kit/src/hooks/useReferFriends';
 import { useRouteIsFocused } from '@onekeyhq/kit/src/hooks/useRouteIsFocused';
+import { OneKeyIdAvatar } from '@onekeyhq/kit/src/views/Setting/pages/OneKeyId';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -36,7 +38,8 @@ function OneKeyIdPage() {
   const intl = useIntl();
   const { toInviteRewardPage } = useReferFriends();
   const { isPrimeAvailable } = usePrimeAvailable();
-  const { isLoggedIn, logout } = useOneKeyAuth();
+  const { isLoggedIn, logout, user } = useOneKeyAuth();
+  const showEditPrimeProfileDialog = useEditPrimeProfileDialog();
   const logoutRef = useRef<() => Promise<void>>(logout);
   const isFocused = useRouteIsFocused();
   const isExplicitLogoutRef = useRef(false);
@@ -102,25 +105,40 @@ function OneKeyIdPage() {
       <Page.Header title="OneKey ID" />
       <Page.Body>
         <YStack>
-          <YStack p="$5" ai="center" jc="center">
-            <LinearGradient
-              bg="$bgInverse"
-              borderRadius="$3"
-              colors={['rgba(255, 255, 255, 0.2)', 'rgba(255, 255, 255, 0)']}
-              width={56}
-              height={56}
-              jc="center"
+          {isLoggedIn && user ? (
+            <YStack
+              p="$5"
               ai="center"
+              jc="center"
+              onPress={showEditPrimeProfileDialog}
+              hoverStyle={{ bg: '$bgHover' }}
+              pressStyle={{ bg: '$bgActive' }}
+              borderRadius="$3"
+              userSelect="none"
             >
-              <Icon size="$8" name="PeopleSolid" color="$iconInverse" />
-            </LinearGradient>
-            <SizableText pt="$5" pb="$2" size="$heading2xl">
-              OneKey ID
-            </SizableText>
-            <SizableText color="$textSubdued" size="$bodyLg">
-              {intl.formatMessage({ id: ETranslations.id_desc })}
-            </SizableText>
-          </YStack>
+              <Stack position="relative">
+                <OneKeyIdAvatar size="$20" />
+                <XStack
+                  bg="$bg"
+                  w={30}
+                  h={30}
+                  jc="center"
+                  ai="center"
+                  borderRadius="$full"
+                  position="absolute"
+                  borderWidth={StyleSheet.hairlineWidth}
+                  borderColor="$bgApp"
+                  right={0}
+                  bottom={0}
+                >
+                  <Icon name="EditOutline" size="$4" color="$icon" />
+                </XStack>
+              </Stack>
+              <SizableText pt="$5" pb="$2" size="$heading2xl" numberOfLines={1}>
+                {user.nickname ?? 'OneKey ID'}
+              </SizableText>
+            </YStack>
+          ) : null}
           <Stack p="$5">
             <PrimeUserInfo
               onBeforeLogout={handleBeforeLogout}


### PR DESCRIPTION
## Summary

Jira: [OK-53678](https://onekeyhq.atlassian.net/browse/OK-53678)

Users reported that the avatar-edit affordance in the MoreActionButton popover is undiscoverable — tapping the avatar opens a Dialog to edit avatar/nickname, while tapping the rest of the identity row navigates to the OneKey ID page. This PR collapses those two targets into a single nav target and surfaces the avatar/nickname editor inside the OneKey ID page itself.

- **MoreActionButton (`packages/kit/src/components/MoreActionButton/index.tsx`)**: remove the avatar's inner `onPress` that opened `useEditPrimeProfileDialog`. The whole identity row now routes to the OneKey ID page on tap, matching the logged-out branch.
- **OneKey ID page (`packages/kit/src/views/Prime/pages/OneKeyId/index.tsx`)**: replace the decorative `LinearGradient + PeopleSolid` header (redundant with the `Page.Header title="OneKey ID"`) with a tappable user-profile header that renders the user's avatar (+ edit-icon badge) and nickname. Tapping the header opens the existing `useEditPrimeProfileDialog`, which is already wired to `servicePrime.updatePrimeUserProfile`. `PrimeUserInfo` (email + Prime badge + logout menu) and the list items are untouched.

No backend changes — reuses the existing Dialog and service.

## Test plan

- [ ] Log in to OneKey ID on web/desktop; open the MoreActionButton popover
- [ ] Tap the avatar in the popover → navigates to OneKey ID page (no more Dialog)
- [ ] Tap elsewhere in the row → same nav
- [ ] Tap the Prime badge (if Prime active) → still shows the device-limit Dialog
- [ ] On the OneKey ID page, user's avatar + nickname render at the top with an edit-icon badge
- [ ] Tap the header → avatar/nickname Dialog opens, pick a new avatar and nickname, submit → Toast confirms, header reflects the new values
- [ ] Log out then log back in → header re-renders correctly
- [ ] `yarn lint:staged` and `yarn tsc:staged` pass on both files

Self-review: fixed 1 finding (nickname fallback uses `??` to match the `MoreActionButton` precedent and dropped the redundant optional chain inside the `isLoggedIn && user` guard); skipped pre-existing dead branch in the Prime `ListItem` per CLAUDE.md scope rules.

[OK-53678]: https://onekeyhq.atlassian.net/browse/OK-53678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ