### PR TITLE
fix: sync tray balance refresh state

### DIFF
--- a/packages/kit-bg/src/services/ServiceDeFi.getAccountTotalDeFiNetWorth.test.ts
+++ b/packages/kit-bg/src/services/ServiceDeFi.getAccountTotalDeFiNetWorth.test.ts
@@ -219,7 +219,7 @@ describe('getAccountTotalDeFiNetWorth', () => {
       networkId: 'onekeyall--0',
       targetCurrency: 'usd',
       enabledNetworkIds: ['evm--1', 'btc--0'],
-    } as any);
+    });
 
     expect(result).toEqual({ netWorth: '800', hasCache: true });
   });

--- a/packages/kit-bg/src/services/ServiceDeFi.getAccountTotalDeFiNetWorth.test.ts
+++ b/packages/kit-bg/src/services/ServiceDeFi.getAccountTotalDeFiNetWorth.test.ts
@@ -192,6 +192,38 @@ describe('getAccountTotalDeFiNetWorth', () => {
     expect(result).toEqual({ netWorth: '1000', hasCache: true });
   });
 
+  test('All-Networks: filters DeFi net worth to enabled networks when provided', async () => {
+    const svc = makeService({
+      getAllNetworkAccounts: jest.fn().mockResolvedValue({
+        accountsInfo: [
+          { apiAddress: '0xabc', accountXpub: undefined, networkId: 'evm--1' },
+          { apiAddress: '0xabc', accountXpub: undefined, networkId: 'evm--56' },
+          { apiAddress: '0xdef', accountXpub: undefined, networkId: 'btc--0' },
+        ],
+      }),
+      getRawData: jest.fn().mockResolvedValue({
+        overview: {
+          '0xabc|': {
+            'evm--1': { netWorth: 500, currency: 'usd' },
+            'evm--56': { netWorth: 200, currency: 'usd' },
+          },
+          '0xdef|': {
+            'btc--0': { netWorth: 300, currency: 'usd' },
+          },
+        },
+      }),
+    });
+
+    const result = await svc.getAccountTotalDeFiNetWorth({
+      accountId: 'hd-1--0',
+      networkId: 'onekeyall--0',
+      targetCurrency: 'usd',
+      enabledNetworkIds: ['evm--1', 'btc--0'],
+    } as any);
+
+    expect(result).toEqual({ netWorth: '800', hasCache: true });
+  });
+
   test('missing target currency → falls back to USD', async () => {
     const svc = makeService({
       getAccountsDeFiOverview: jest.fn().mockResolvedValue([

--- a/packages/kit-bg/src/services/ServiceDeFi.ts
+++ b/packages/kit-bg/src/services/ServiceDeFi.ts
@@ -448,8 +448,12 @@ class ServiceDeFi extends ServiceBase {
     accountId: string;
     networkId: string;
     targetCurrency: string;
+    enabledNetworkIds?: string[];
   }): Promise<{ netWorth: string; hasCache: boolean }> {
-    const { accountId, networkId, targetCurrency } = params;
+    const { accountId, networkId, targetCurrency, enabledNetworkIds } = params;
+    const enabledNetworkIdSet = enabledNetworkIds?.length
+      ? new Set(enabledNetworkIds)
+      : undefined;
 
     const indexedAccountId = accountUtils.isOthersAccount({ accountId })
       ? undefined
@@ -470,8 +474,12 @@ class ServiceDeFi extends ServiceBase {
     let hasCache = false;
     for (const entry of entries) {
       if (entry?.overview) {
-        for (const overview of Object.values(entry.overview)) {
-          if (overview) {
+        for (const [entryNetworkId, overview] of Object.entries(
+          entry.overview,
+        )) {
+          const shouldIncludeNetwork =
+            !enabledNetworkIdSet || enabledNetworkIdSet.has(entryNetworkId);
+          if (overview && shouldIncludeNetwork) {
             hasCache = true;
             const sourceInfo =
               currencyMap[overview.currency] ?? currencyMap.usd;

--- a/packages/kit/src/hooks/trayDataProviderUtils.test.ts
+++ b/packages/kit/src/hooks/trayDataProviderUtils.test.ts
@@ -1,0 +1,62 @@
+import { EAppEventBusNames } from '@onekeyhq/shared/src/eventBus/appEventBus';
+
+import {
+  TRAY_DATA_REFRESH_EVENT_NAMES,
+  getTrayTokenValueInTargetCurrency,
+} from './trayDataProviderUtils';
+
+describe('trayDataProviderUtils', () => {
+  test('refresh events include watchlist sorting and enabled network changes', () => {
+    expect(TRAY_DATA_REFRESH_EVENT_NAMES).toEqual(
+      expect.arrayContaining([
+        EAppEventBusNames.AccountDataUpdate,
+        EAppEventBusNames.MarketWatchListV2Changed,
+        EAppEventBusNames.EnabledNetworksChanged,
+      ]),
+    );
+  });
+
+  test('getTrayTokenValueInTargetCurrency only includes enabled compatible networks', () => {
+    const result = getTrayTokenValueInTargetCurrency({
+      tokensValue: {
+        'hd-1--0_default_evm--1': '100',
+        'hd-1--0_default_evm--56': '200',
+        'hd-1--0_default_btc--0': '300',
+      },
+      usdToTargetFactor: '7.2',
+      walletId: 'hd-1',
+      enabledNetworksCompatibleWithWalletId: [{ id: 'evm--1' }],
+      networkInfoMap: {
+        'evm--1': {
+          deriveType: 'default',
+          mergeDeriveAssetsEnabled: false,
+        },
+        'evm--56': {
+          deriveType: 'default',
+          mergeDeriveAssetsEnabled: false,
+        },
+        'btc--0': {
+          deriveType: 'default',
+          mergeDeriveAssetsEnabled: true,
+        },
+      },
+    });
+
+    expect(result).toBe('720');
+  });
+
+  test('getTrayTokenValueInTargetCurrency falls back to all networks until enabled scope is loaded', () => {
+    const result = getTrayTokenValueInTargetCurrency({
+      tokensValue: {
+        'hd-1--0_default_evm--1': '100',
+        'hd-1--0_default_evm--56': '200',
+      },
+      usdToTargetFactor: '1',
+      walletId: 'hd-1',
+      enabledNetworksCompatibleWithWalletId: [],
+      networkInfoMap: {},
+    });
+
+    expect(result).toBe('300');
+  });
+});

--- a/packages/kit/src/hooks/trayDataProviderUtils.ts
+++ b/packages/kit/src/hooks/trayDataProviderUtils.ts
@@ -1,0 +1,56 @@
+import BigNumber from 'bignumber.js';
+
+import { EAppEventBusNames } from '@onekeyhq/shared/src/eventBus/appEventBus';
+import { calculateAccountTotalValue } from '@onekeyhq/shared/src/utils/tokenUtils';
+
+type ITrayNetworkInfoMap = Record<
+  string,
+  {
+    deriveType: string;
+    mergeDeriveAssetsEnabled: boolean;
+  }
+>;
+
+export const TRAY_DATA_REFRESH_EVENT_NAMES = [
+  EAppEventBusNames.HistoryTxStatusChanged,
+  EAppEventBusNames.RefreshHistoryList,
+  EAppEventBusNames.AccountDataUpdate,
+  EAppEventBusNames.MarketWatchListV2Changed,
+  EAppEventBusNames.EnabledNetworksChanged,
+] as const;
+
+export function getTrayTokenValueInTargetCurrency({
+  tokensValue,
+  usdToTargetFactor,
+  walletId,
+  enabledNetworksCompatibleWithWalletId,
+  networkInfoMap,
+}: {
+  tokensValue: string | Record<string, string> | undefined;
+  usdToTargetFactor: BigNumber.Value;
+  walletId?: string;
+  enabledNetworksCompatibleWithWalletId?: Array<{ id: string }>;
+  networkInfoMap?: ITrayNetworkInfoMap;
+}) {
+  const hasEnabledNetworkScope =
+    !!walletId &&
+    !!enabledNetworksCompatibleWithWalletId?.length &&
+    !!networkInfoMap &&
+    Object.keys(networkInfoMap).length > 0;
+
+  const tokensUsd = calculateAccountTotalValue({
+    tokensValue,
+    deFiNetWorth: 0,
+    ...(hasEnabledNetworkScope
+      ? {
+          walletId,
+          enabledNetworksCompatibleWithWalletId,
+          networkInfoMap,
+        }
+      : undefined),
+  });
+
+  return new BigNumber(tokensUsd ?? '0')
+    .times(new BigNumber(usdToTargetFactor || 1))
+    .toFixed();
+}

--- a/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
+++ b/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
@@ -23,7 +23,9 @@ import {
   type ITrayWatchlistItem,
   TRAY_IPC,
 } from '@onekeyhq/shared/src/types/desktop/tray';
-import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
+import networkUtils, {
+  isEnabledNetworksInAllNetworks,
+} from '@onekeyhq/shared/src/utils/networkUtils';
 import {
   getHyperliquidTokenImageUrl,
   getTokenSubtitle,
@@ -39,6 +41,11 @@ import { EDecodedTxStatus } from '@onekeyhq/shared/types/tx';
 import backgroundApiProxy from '../background/instance/backgroundApiProxy';
 import { useActiveAccount } from '../states/jotai/contexts/accountSelector';
 
+import {
+  TRAY_DATA_REFRESH_EVENT_NAMES,
+  getTrayTokenValueInTargetCurrency,
+} from './trayDataProviderUtils';
+
 const USD_CURRENCY_ID = 'usd';
 const USD_CURRENCY_SYMBOL = '$';
 
@@ -48,12 +55,100 @@ function getNetworkLogoUri(networkId?: string): string {
   return network?.logoURI || '';
 }
 
+type ITrayEnabledNetworkScope = {
+  enabledNetworkIds: string[];
+  enabledNetworksCompatibleWithWalletId: Array<{ id: string }>;
+  networkInfoMap: Record<
+    string,
+    {
+      deriveType: string;
+      mergeDeriveAssetsEnabled: boolean;
+    }
+  >;
+};
+
+async function getTrayEnabledNetworkScope({
+  walletId,
+  accountId,
+}: {
+  walletId: string;
+  accountId?: string;
+}): Promise<ITrayEnabledNetworkScope> {
+  const [{ enabledNetworks, disabledNetworks }, { networks }] =
+    await Promise.all([
+      backgroundApiProxy.serviceAllNetwork.getAllNetworksState(),
+      backgroundApiProxy.serviceNetwork.getAllNetworks({
+        excludeTestNetwork: true,
+        excludeAllNetworkItem: true,
+      }),
+    ]);
+
+  const enabledNetworkIds = networks
+    .filter((network) =>
+      isEnabledNetworksInAllNetworks({
+        networkId: network.id,
+        enabledNetworks,
+        disabledNetworks,
+        isTestnet: !!network.isTestnet,
+      }),
+    )
+    .map((network) => network.id);
+
+  if (enabledNetworkIds.length === 0) {
+    return {
+      enabledNetworkIds: [],
+      enabledNetworksCompatibleWithWalletId: [],
+      networkInfoMap: {},
+    };
+  }
+
+  const compatibleNetworks =
+    await backgroundApiProxy.serviceNetwork.getChainSelectorNetworksCompatibleWithAccountId(
+      {
+        accountId,
+        walletId,
+        networkIds: enabledNetworkIds,
+      },
+    );
+
+  const enabledNetworksCompatibleWithWalletId =
+    compatibleNetworks.mainnetItems ?? [];
+
+  const networkInfoEntries = await Promise.all(
+    enabledNetworksCompatibleWithWalletId.map(async (network) => {
+      const [deriveType, vaultSettings] = await Promise.all([
+        backgroundApiProxy.serviceNetwork.getGlobalDeriveTypeOfNetwork({
+          networkId: network.id,
+        }),
+        backgroundApiProxy.serviceNetwork.getVaultSettings({
+          networkId: network.id,
+        }),
+      ]);
+      return [
+        network.id,
+        {
+          deriveType,
+          mergeDeriveAssetsEnabled: !!vaultSettings.mergeDeriveAssetsEnabled,
+        },
+      ] as const;
+    }),
+  );
+
+  return {
+    enabledNetworkIds: enabledNetworksCompatibleWithWalletId.map(
+      (network) => network.id,
+    ),
+    enabledNetworksCompatibleWithWalletId,
+    networkInfoMap: Object.fromEntries(networkInfoEntries),
+  };
+}
+
 export function useTrayDataProvider() {
   const [activeAccountValue] = useActiveAccountValueAtom();
   const [appIsLocked] = useAppIsLockedAtom();
   const [{ enableMenuBarTray }] = useSettingsPersistAtom();
   const {
-    activeAccount: { wallet, accountName },
+    activeAccount: { wallet, accountName, account },
   } = useActiveAccount({ num: 0 });
   // Guard every effect on this predicate so flipping the setting tears
   // down IPC/event subscriptions and re-subscribes without remounting.
@@ -64,6 +159,8 @@ export function useTrayDataProvider() {
   appIsLockedRef.current = appIsLocked;
   const walletRef = useRef(wallet);
   walletRef.current = wallet;
+  const accountRef = useRef(account);
+  accountRef.current = account;
   const accountNameRef = useRef<string>('');
   accountNameRef.current = accountName || '';
   // Seed with the current accountId so the first mount isn't mis-detected as
@@ -170,16 +267,29 @@ export function useTrayDataProvider() {
         try {
           // `value` is either a string (others account) or Record<key, string> (own).
           const val = accountValue.value;
-          let tokensUsd = new BigNumber(0);
-          if (typeof val === 'string') {
-            tokensUsd = new BigNumber(val || '0');
-          } else if (val && typeof val === 'object') {
-            tokensUsd = Object.values(val).reduce(
-              (sum, v) => sum.plus(new BigNumber(v || '0')),
-              new BigNumber(0),
-            );
+          let enabledNetworkScope: ITrayEnabledNetworkScope | undefined;
+          if (val && typeof val === 'object' && currentWallet.id) {
+            try {
+              enabledNetworkScope = await getTrayEnabledNetworkScope({
+                walletId: currentWallet.id,
+                accountId: accountRef.current?.id,
+              });
+            } catch (e) {
+              defaultLogger.app.error.log(
+                `[TrayDataProvider] enabled networks fetch error: ${
+                  (e as Error)?.message || String(e)
+                }`,
+              );
+            }
           }
-          const tokensInTarget = tokensUsd.times(usdToTargetFactor).toFixed();
+          const tokensInTarget = getTrayTokenValueInTargetCurrency({
+            tokensValue: val,
+            usdToTargetFactor,
+            walletId: currentWallet.id,
+            enabledNetworksCompatibleWithWalletId:
+              enabledNetworkScope?.enabledNetworksCompatibleWithWalletId,
+            networkInfoMap: enabledNetworkScope?.networkInfoMap,
+          });
 
           // DeFi via simpleDb.deFi cache only — no network call.
           let deFiNetWorth = '0';
@@ -189,6 +299,7 @@ export function useTrayDataProvider() {
                 accountId: accountValue.accountId,
                 networkId: getNetworkIdsMap().onekeyall,
                 targetCurrency: displayCurrency,
+                enabledNetworkIds: enabledNetworkScope?.enabledNetworkIds,
               });
             deFiNetWorth = deFiResp.netWorth;
           } catch (e) {
@@ -676,9 +787,9 @@ export function useTrayDataProvider() {
       debouncedRefresh();
     };
 
-    appEventBus.on(EAppEventBusNames.HistoryTxStatusChanged, debouncedRefresh);
-    appEventBus.on(EAppEventBusNames.RefreshHistoryList, debouncedRefresh);
-    appEventBus.on(EAppEventBusNames.AccountDataUpdate, debouncedRefresh);
+    TRAY_DATA_REFRESH_EVENT_NAMES.forEach((eventName) => {
+      appEventBus.on(eventName, debouncedRefresh);
+    });
     appEventBus.on(
       EAppEventBusNames.ClearLocalHistoryPendingTxs,
       handlePendingTxsCleared,
@@ -686,12 +797,9 @@ export function useTrayDataProvider() {
 
     return () => {
       if (debounceTimer) clearTimeout(debounceTimer);
-      appEventBus.off(
-        EAppEventBusNames.HistoryTxStatusChanged,
-        debouncedRefresh,
-      );
-      appEventBus.off(EAppEventBusNames.RefreshHistoryList, debouncedRefresh);
-      appEventBus.off(EAppEventBusNames.AccountDataUpdate, debouncedRefresh);
+      TRAY_DATA_REFRESH_EVENT_NAMES.forEach((eventName) => {
+        appEventBus.off(eventName, debouncedRefresh);
+      });
       appEventBus.off(
         EAppEventBusNames.ClearLocalHistoryPendingTxs,
         handlePendingTxsCleared,

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -338,6 +338,7 @@ function HomeOverviewContainer() {
             accountId: accountValueId,
             value: accountWorth.worth,
             currency: settings.currencyInfo.id,
+            updateAll: accountWorth.updateAll,
           },
         );
       }


### PR DESCRIPTION
## Summary
- Preserve the `updateAll` flag when Home overview writes account worth into `activeAccountValueAtom`.
- Align desktop tray token and DeFi totals with the enabled All Networks scope instead of summing every cached network.
- Refresh tray data when watchlist sorting or enabled networks change.

## Intent & Context
The bug report showed the desktop tray balance and the Home header balance diverging for the same account. The Home header renders from freshly loaded account worth plus the current DeFi overview. The tray reads from cached active account value and local DeFi cache, so it also needs the same full-refresh and enabled-network semantics as Home.

A follow-up investigation found another mismatch in the network selector: the selector's "found assets" total intentionally excludes networks below the `$1` display threshold, while the Home header displays the full account total. That confirmed the tray fix should preserve Home's account-total semantics and only scope the tray by the user's enabled networks, not by the network selector display threshold.

## Root Cause
There were two balance consistency gaps:

1. When Home overview refreshed All Networks balances, `accountWorth.updateAll` indicated that the new worth payload should replace cached account values. The write to `activeAccountValueAtom` omitted this flag, so the atom update path could treat the payload like a partial update and merge it with stale network values.
2. The tray summed cached token and DeFi values without applying the current enabled-network scope. Hidden or disabled networks could therefore remain included in the tray total even when Home and the All Networks UI were scoped to enabled networks.

## Design Decisions
The fix keeps the existing account-value data flow and passes `accountWorth.updateAll` through the existing `activeAccountValueAtom.set` call. For tray totals, it reuses the existing `calculateAccountTotalValue` wallet-scoped path, building an enabled-compatible network scope from the same All Networks state and chain-selector compatibility APIs used elsewhere. DeFi local-cache totals now accept an optional enabled-network filter so token and DeFi portions use the same scope.

Tray refresh events were centralized into a small utility to avoid diverging event subscription and cleanup lists, and to add enabled-network and watchlist changes explicitly.

## Changes Detail
- `packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx`: include `updateAll` when persisting Home overview account worth to `activeAccountValueAtom`.
- `packages/kit/src/hooks/useTrayDataProvider.desktop.ts`: compute tray token and DeFi balances using enabled compatible networks; refresh tray data on enabled-network and watchlist changes.
- `packages/kit/src/hooks/trayDataProviderUtils.ts`: add shared tray balance/event helpers.
- `packages/kit/src/hooks/trayDataProviderUtils.test.ts`: cover enabled-network token filtering and tray refresh events.
- `packages/kit-bg/src/services/ServiceDeFi.ts`: allow local DeFi net-worth totals to be filtered by enabled network IDs.
- `packages/kit-bg/src/services/ServiceDeFi.getAccountTotalDeFiNetWorth.test.ts`: cover enabled-network filtering for All Networks DeFi totals.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop primary; shared Home account-value and DeFi cache helper paths are touched.
- **Risk Areas**: Tray balance calculation now depends on enabled-network metadata loading. The helper intentionally falls back to all cached token values until the enabled scope is available to avoid showing zero during metadata failures.

## Test plan
- [x] Ran `yarn jest --runTestsByPath packages/kit/src/hooks/trayDataProviderUtils.test.ts packages/kit-bg/src/services/ServiceDeFi.getAccountTotalDeFiNetWorth.test.ts`.
- [x] Ran `yarn lint:staged`.
- [x] Ran `yarn tsc:staged`.
- [x] Verified in the running desktop app that `activeAccountValueAtom`, Home header, and tray data align after a full All Networks balance refresh.