### PR TITLE
fix: normalize fiat send amount precision (OK-53784)

### DIFF
--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -352,6 +352,18 @@ function SendAmountInputContainer() {
             chainValueUtils.convertSatsToBtc(originalAmt.toFixed()),
           );
         }
+      } else {
+        const decimals = tokenDetails?.info.decimals;
+        if (
+          typeof decimals === 'number' &&
+          Number.isInteger(decimals) &&
+          decimals >= 0
+        ) {
+          originalAmt = originalAmt.decimalPlaces(
+            decimals,
+            BigNumber.ROUND_FLOOR,
+          );
+        }
       }
       return {
         originalAmount: originalAmt.toFixed(),
@@ -364,7 +376,14 @@ function SendAmountInputContainer() {
       originalAmount: amountBN.toFixed(),
       linkedAmount: linkedAmountValue.toFixed(),
     };
-  }, [amount, isLightningNetwork, isUseFiat, lnUnit, tokenDetails?.price]);
+  }, [
+    amount,
+    isLightningNetwork,
+    isUseFiat,
+    lnUnit,
+    tokenDetails?.info.decimals,
+    tokenDetails?.price,
+  ]);
 
   const handleToggleFiatMode = useCallback(() => {
     // When currently in fiat mode (isUseFiat=true), switching to token mode -> use originalAmount

--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -515,8 +515,8 @@ function SendAmountInputContainer() {
       const priceBN = new BigNumber(tokenDetails?.price ?? 0);
       // Mirror the flooring applied in `linkedAmount` so the value validated
       // here matches the value submitted to the vault. Without this, fiat
-      // mode could pass min/balance checks against an unfloored amount while
-      // the user actually sends a smaller, floored value.
+      // mode could pass min/balance checks against the raw fiat/price result
+      // while the user actually sends a smaller, floored value.
       const tokenAmountBN =
         isUseFiat && priceBN.isGreaterThan(0)
           ? floorFiatDerivedTokenAmount({
@@ -591,6 +591,21 @@ function SendAmountInputContainer() {
           { id: ETranslations.send_error_minimum_amount },
           { amount: displayMinAmount, token: tokenSymbol },
         );
+      }
+
+      // A positive fiat input that floors to 0 token (sub-sat on Lightning,
+      // or sub-decimal on other chains) would otherwise slip past the min
+      // check above (which excludes isZero) and the native-only zero guard
+      // below, letting the user submit a 0-amount transfer.
+      if (
+        isUseFiat &&
+        priceBN.isGreaterThan(0) &&
+        tokenAmountBN.isZero() &&
+        !amountBN.isZero()
+      ) {
+        return intl.formatMessage({
+          id: ETranslations.send_amount_too_small,
+        });
       }
 
       // Zero native token transfer prevention

--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -88,6 +88,34 @@ interface IAmountFormValues {
   txMessage: string;
 }
 
+// Floor a fiat-derived token amount to the precision the chain can actually
+// send. Lightning amounts are in sats (smallest unit, 0 decimals) — fractional
+// sats cause OK-53396. Other chains floor to `tokenDetails.info.decimals` so
+// the value stays representable. Keeping this in one place ensures the value
+// shown in the input, the value used by validation, and the value submitted
+// to the vault stay strictly equal.
+function floorFiatDerivedTokenAmount({
+  amount,
+  isLightningNetwork,
+  decimals,
+}: {
+  amount: BigNumber;
+  isLightningNetwork: boolean;
+  decimals: number | undefined;
+}): BigNumber {
+  if (isLightningNetwork) {
+    return amount.integerValue(BigNumber.ROUND_FLOOR);
+  }
+  if (
+    typeof decimals === 'number' &&
+    Number.isInteger(decimals) &&
+    decimals >= 0
+  ) {
+    return amount.decimalPlaces(decimals, BigNumber.ROUND_FLOOR);
+  }
+  return amount;
+}
+
 function SendAmountInputContainer() {
   const intl = useIntl();
   const _media = useMedia();
@@ -341,29 +369,15 @@ function SendAmountInputContainer() {
         return { originalAmount: '0', linkedAmount: '0' };
       }
       // fiat / pricePerSat = sats. Convert to BTC if lnUnit is BTC.
-      let originalAmt = amountBN.dividedBy(price);
-      if (isLightningNetwork) {
-        // Sats are the smallest Lightning unit (0 decimals) — floor the
-        // fiat→sats result so the display never shows fractional sats,
-        // which would cause a send error (OK-53396).
-        originalAmt = originalAmt.integerValue(BigNumber.ROUND_FLOOR);
-        if (lnUnit === ELightningUnit.BTC) {
-          originalAmt = new BigNumber(
-            chainValueUtils.convertSatsToBtc(originalAmt.toFixed()),
-          );
-        }
-      } else {
-        const decimals = tokenDetails?.info.decimals;
-        if (
-          typeof decimals === 'number' &&
-          Number.isInteger(decimals) &&
-          decimals >= 0
-        ) {
-          originalAmt = originalAmt.decimalPlaces(
-            decimals,
-            BigNumber.ROUND_FLOOR,
-          );
-        }
+      let originalAmt = floorFiatDerivedTokenAmount({
+        amount: amountBN.dividedBy(price),
+        isLightningNetwork,
+        decimals: tokenDetails?.info.decimals,
+      });
+      if (isLightningNetwork && lnUnit === ELightningUnit.BTC) {
+        originalAmt = new BigNumber(
+          chainValueUtils.convertSatsToBtc(originalAmt.toFixed()),
+        );
       }
       return {
         originalAmount: originalAmt.toFixed(),
@@ -499,9 +513,17 @@ function SendAmountInputContainer() {
       }
 
       const priceBN = new BigNumber(tokenDetails?.price ?? 0);
+      // Mirror the flooring applied in `linkedAmount` so the value validated
+      // here matches the value submitted to the vault. Without this, fiat
+      // mode could pass min/balance checks against an unfloored amount while
+      // the user actually sends a smaller, floored value.
       const tokenAmountBN =
         isUseFiat && priceBN.isGreaterThan(0)
-          ? amountBN.dividedBy(priceBN)
+          ? floorFiatDerivedTokenAmount({
+              amount: amountBN.dividedBy(priceBN),
+              isLightningNetwork,
+              decimals: tokenDetails?.info.decimals,
+            })
           : amountBN;
 
       // For Lightning, normalize amount to sats for validation
@@ -610,6 +632,7 @@ function SendAmountInputContainer() {
       isLightningNetwork,
       lnUnit,
       tokenDetails?.balanceParsed,
+      tokenDetails?.info.decimals,
       tokenDetails?.info.isNative,
       tokenDetails?.price,
       tokenMinAmount,


### PR DESCRIPTION
## Summary
- Floor the fiat→token conversion in `linkedAmount` to the chain's native precision so the displayed and submitted amount is always representable.
- Apply the same flooring in `handleValidateTokenAmount` so validation operates on the exact value that gets submitted to the vault.
- Reject positive fiat inputs that floor to a zero token amount, preventing 0-amount transfers that would waste gas.

## Intent & Context
In fiat send mode the original token amount was computed as `fiat / price` and used both for display and for submission without rounding. For tokens whose `decimals` is smaller than the precision of the division result (e.g. `decimals=2` or `decimals=0` ERC-20s), the value passed to the vault carried more decimal places than the chain could represent, leading to confirm-screen / vault rejection or unexpected dust. Lightning already had a `ROUND_FLOOR` for sats; non-Lightning chains did not.

## Root Cause
`packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx` had three coupled issues in the fiat path:

1. `linkedAmount` did not floor `fiat / price` to `tokenDetails.info.decimals` for non-Lightning chains.
2. `handleValidateTokenAmount` computed `tokenAmountBN = amount / price` *unfloored*, while submit used the floored value from `linkedAmount.originalAmount`. Min/balance checks ran on a different value than what was actually sent.
3. After flooring, a positive fiat input small enough to floor to `0` (sub-sat on Lightning, sub-decimal on a 0-decimal ERC-20) slipped past the min-amount check (which excludes `isZero`) and the native-only zero guard, and the submit-disabled predicate only checks the raw fiat string. The user could send a real on-chain `0`-amount transfer and pay gas for nothing.

## Design Decisions
- **Extract a single helper `floorFiatDerivedTokenAmount`** at module scope rather than duplicating the floor logic in two places. Makes the contract — "this is the precision the chain can actually send" — explicit and prevents the two call sites from drifting again.
- **Lightning unit conversion stays at the call site**, not inside the helper. Validation needs the value in sats; display needs it in BTC when `lnUnit === BTC`. Both share the floor; only the call site decides whether to convert.
- **Conservative zero-amount guard** that only fires in fiat mode when the user provided a positive fiat input but the floored token result is `0`. We deliberately do not broaden the existing native-only zero guard to all tokens, since some chains/contracts have legitimate uses for 0-amount token transfers — the fiat case is the only one regressed by flooring.
- **`send_amount_too_small` reuses an existing translation key** (\"Transfer amount too small.\"), so no i18n churn.
- Cross-validated with Codex on both the validation/submit alignment and the zero-floor edge case.

## Changes Detail
`packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx`:
- Add module-scope `floorFiatDerivedTokenAmount({ amount, isLightningNetwork, decimals })` that returns the input floored to integer sats for Lightning, or to `decimals` places for other chains; returns the input unchanged when `decimals` is missing or invalid.
- `linkedAmount` useMemo: route the fiat→token result through the helper, then convert sats→BTC if `lnUnit === BTC`. Add `tokenDetails?.info.decimals` to the deps array.
- `handleValidateTokenAmount` useCallback: route `tokenAmountBN` through the same helper in fiat mode. Add `tokenDetails?.info.decimals` to the deps array. Insert a `send_amount_too_small` guard for the "positive fiat → 0 token" case.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: All (Send flow, every chain that uses fiat-mode input)
- **Risk Areas**:
  - Behavior change in the fiat send path on every non-Lightning chain. Token-mode input is untouched.
  - Three reviews (primary + Codex twice) confirm validation and submit now compute identical values across all four scenarios (Lightning sats / Lightning BTC / non-Lightning fiat / non-Lightning token).
  - The new "amount too small" check is gated on `isUseFiat && priceBN.isGreaterThan(0) && tokenAmountBN.isZero() && !amountBN.isZero()`, so it cannot fire in token mode and cannot affect the existing "user typed 0" path.

## Test plan
- [ ] Non-Lightning chain (e.g. ERC-20 with `decimals=6`) in fiat mode: enter a fiat amount that produces more than 6 decimal places. Confirm `originalAmount` shown in the input and the amount on the confirm screen are both floored to 6 decimals and identical.
- [ ] Same chain, enter a fiat amount large enough to be representable but small enough that `floor(fiat/price)` is `0` for a `decimals=0` token: expect "Transfer amount too small.", submit blocked.
- [ ] Lightning + fiat + SATS unit, enter sub-sat fiat: expect "Transfer amount too small.", no zero-sat submission.
- [ ] Lightning + fiat + BTC unit, regression check for OK-53396: enter normal fiat, confirm sats are floored and BTC display is consistent.
- [ ] Toggle fiat ↔ token several times with various amounts, confirm no precision drift.
- [ ] Fiat mode with `tokenDetails.price === 0`: existing behavior preserved (early return, no new error path).
- [ ] User types `"0"` in fiat mode for a non-native token: existing behavior preserved (no new error from the zero-floor guard).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
