### PR TITLE
fix: resolve menu bar display issues(OK-53624, OK-53667)

### DIFF
--- a/apps/desktop/app/tray/trayWindow.ts
+++ b/apps/desktop/app/tray/trayWindow.ts
@@ -19,6 +19,19 @@ export function onTrayWindowVisibilityChange(
   visibilityCallback = cb;
 }
 
+function hideTrayWindow(): void {
+  if (!trayWindow || trayWindow.isDestroyed()) return;
+  if (blurHideTimer) {
+    clearTimeout(blurHideTimer);
+    blurHideTimer = null;
+  }
+  if (!trayWindow.isVisible()) return;
+
+  trayWindow.setAlwaysOnTop(true, 'pop-up-menu');
+  trayWindow.hide();
+  visibilityCallback?.(false);
+}
+
 function calculateWindowPosition(
   tray: Tray,
   windowWidth: number,
@@ -121,16 +134,14 @@ export function createTrayWindow(
     blurHideTimer = setTimeout(() => {
       blurHideTimer = null;
       if (trayWindow && !trayWindow.isDestroyed() && !trayWindow.isFocused()) {
-        trayWindow.hide();
-        visibilityCallback?.(false);
+        hideTrayWindow();
       }
     }, 100);
   });
 
   trayWindow.webContents.on('before-input-event', (event, input) => {
     if (input.key === 'Escape' && input.type === 'keyDown') {
-      trayWindow?.hide();
-      visibilityCallback?.(false);
+      hideTrayWindow();
     }
   });
 
@@ -141,13 +152,14 @@ export function showTrayWindow(tray: Tray): void {
   if (!trayWindow || trayWindow.isDestroyed()) return;
 
   if (trayWindow.isVisible()) {
-    trayWindow.hide();
-    visibilityCallback?.(false);
+    hideTrayWindow();
     return;
   }
 
   const { x, y } = calculateWindowPosition(tray, WINDOW_WIDTH, WINDOW_HEIGHT);
   trayWindow.setPosition(x, y);
+  trayWindow.setAlwaysOnTop(true, 'pop-up-menu');
+  trayWindow.moveTop();
   trayWindow.show();
   visibilityCallback?.(true);
 }

--- a/packages/kit/src/views/Tray/components/PortfolioOverview.tsx
+++ b/packages/kit/src/views/Tray/components/PortfolioOverview.tsx
@@ -48,7 +48,12 @@ export function PortfolioOverview({
       cursor="pointer"
       hoverStyle={{ backgroundColor: '$bgHover' }}
     >
-      <Stack flexDirection="row" alignItems="center" marginBottom="$1">
+      <Stack
+        flexDirection="row"
+        alignItems="center"
+        marginBottom="$1"
+        minWidth={0}
+      >
         {(() => {
           if (avatarSource) {
             return (
@@ -58,24 +63,39 @@ export function PortfolioOverview({
                 height={20}
                 borderRadius={4}
                 marginRight="$1.5"
+                flexShrink={0}
               />
             );
           }
           if (wallet.emoji) {
             return (
-              <SizableText fontSize="$bodyMd" marginRight="$1.5">
+              <SizableText fontSize="$bodyMd" marginRight="$1.5" flexShrink={0}>
                 {wallet.emoji}
               </SizableText>
             );
           }
           return null;
         })()}
-        <SizableText fontSize="$bodySm" color="$textSubdued">
+        <SizableText
+          fontSize="$bodySm"
+          color="$textSubdued"
+          numberOfLines={1}
+          ellipsizeMode="tail"
+          flexShrink={1}
+          minWidth={0}
+        >
           {wallet.name}
         </SizableText>
       </Stack>
       {account.name ? (
-        <SizableText fontSize="$bodySm" color="$textSubdued" marginBottom="$1">
+        <SizableText
+          fontSize="$bodySm"
+          color="$textSubdued"
+          marginBottom="$1"
+          numberOfLines={1}
+          ellipsizeMode="tail"
+          minWidth={0}
+        >
           {account.name}
         </SizableText>
       ) : null}


### PR DESCRIPTION
## Summary
- Add single-line ellipsis constraints for tray wallet and account names.
- Keep the desktop tray popover at popup-menu z-order while showing and hiding.

## Intent & Context
This PR fixes the two remaining menu-bar Jira issues from the current batch: OK-53624 reports that long wallet and account names need to be truncated in the menu-bar tray header, and OK-53667 reports that the tray popover briefly appears underneath the main app window during the close animation.

## Root Cause
For OK-53624, the tray header text lived in a flex row without width constraints on the text or non-shrinking constraints on the avatar/emoji, so long names could expand instead of truncating. For OK-53667, the tray window used direct hide calls from multiple paths and did not explicitly preserve popup-menu z-order immediately before hide, which made the macOS window level transition visible during close.

## Design Decisions
The text truncation fix stays local to the tray overview component and uses existing Tamagui text props rather than introducing a new shared component. The window close fix centralizes hide behavior in a helper so blur, Escape, and tray-icon toggle paths all preserve the same z-order behavior before hiding.

## Changes Detail
- `packages/kit/src/views/Tray/components/PortfolioOverview.tsx`: constrain the wallet row, keep avatar/emoji from shrinking, and apply single-line tail ellipsis to wallet and account names.
- `apps/desktop/app/tray/trayWindow.ts`: add a shared hide helper, clear pending blur timers before hiding, and set popup-menu z-order plus `moveTop()` when showing the tray window.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop
- **Risk Areas**: macOS tray window z-order behavior and tray header layout sizing.

## Test plan
- [x] `yarn tsc:only`
- [x] `yarn lint:only`
- [x] `yarn lint --fix`
- [x] Launch desktop renderer and Electron, open the menu-bar tray from the status item, verify the tray header renders, then close the tray and verify the tray polling stops.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
