### PR TITLE
fix: present Bulk send Prime paywall as full-screen page

### DIFF
--- a/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/BulkCopyAddressesButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/BulkCopyAddressesButton.tsx
@@ -44,8 +44,7 @@ export function BulkCopyAddressesButton({
             featureName: EPrimeFeatures.BulkCopyAddresses,
             entryPoint: 'walletEdit',
           });
-          // FullModal can cause hierarchy issues
-          navigation?.pushModal(EModalRoutes.PrimeModal, {
+          navigation?.pushFullModal(EModalRoutes.PrimeModal, {
             screen: EPrimePages.PrimeDashboard,
             params: {
               fromFeature: EPrimeFeatures.BulkCopyAddresses,

--- a/packages/kit/src/views/ApprovalManagement/hooks/useBulkRevoke.tsx
+++ b/packages/kit/src/views/ApprovalManagement/hooks/useBulkRevoke.tsx
@@ -205,7 +205,7 @@ function useBulkRevoke() {
                       contractMap,
                     });
                   } else {
-                    navigation.pushModal(EModalRoutes.PrimeModal, {
+                    navigation.pushFullModal(EModalRoutes.PrimeModal, {
                       screen: EPrimePages.PrimeDashboard,
                       params: {
                         fromFeature: EPrimeFeatures.BulkRevoke,

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionBulkSend.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionBulkSend.tsx
@@ -36,7 +36,7 @@ export function WalletActionBulkSend({ onClose }: { onClose: () => void }) {
         featureName: EPrimeFeatures.BulkSend,
         entryPoint: 'moreActions',
       });
-      navigation.pushModal(EModalRoutes.PrimeModal, {
+      navigation.pushFullModal(EModalRoutes.PrimeModal, {
         screen: EPrimePages.PrimeDashboard,
         params: {
           fromFeature: EPrimeFeatures.BulkSend,


### PR DESCRIPTION
## Summary

When a non-Prime user taps **Bulk send** in the Wallet home **More** menu, the
`PrimeDashboard` paywall was opened with `navigation.pushModal(...)`. On wider
viewports (desktop / tablet) that presents the dashboard inside a narrow modal
panel, breaking its layout — `PrimeDashboard` is a full-screen Page (Lottie
banner, subscription plans, benefits list, footer) and does not fit a
constrained modal width.

This change switches the call to `pushFullModal`, matching every other Prime
paywall entry point in the app:

- `Home/components/Upgrade/Upgrade.tsx`
- `Prime/components/PrimeHeaderIconButton/PrimeHeaderIconButton.tsx`
- `components/MoreActionButton/index.tsx` (two call sites)
- `Discovery/hooks/usePageTranslation.tsx`

The route, screen, and `fromFeature: EPrimeFeatures.BulkSend` param are
unchanged — only the presentation method.

## Test plan

- [ ] Desktop/web: as a non-Prime user, open Wallet → More → **Bulk send** and
      confirm `PrimeDashboard` opens full-screen (banner + plans + benefits +
      footer all visible without horizontal cramping), matching the wallet
      header Prime icon entry.
- [ ] As a Prime user, **Bulk send** still opens the existing
      `showBulkSendModeDialog` flow unchanged.
- [ ] iOS / Android: cosmetic parity — both methods are full-screen on phones,
      no regression.

## Notes

The two sibling entries `BulkCopyAddressesButton.tsx` and
`useBulkRevoke.tsx` share the same bug (also `pushModal` to `PrimeDashboard`).
Left out of this PR to keep scope focused.