### PR TITLE
refactor(onboarding-v2): eagerly import flow pages (OK-53837)

### DIFF
--- a/packages/kit/src/views/Onboardingv2/router/index.tsx
+++ b/packages/kit/src/views/Onboardingv2/router/index.tsx
@@ -1,188 +1,45 @@
 import type { IModalFlowNavigatorConfig } from '@onekeyhq/components';
-import { LazyLoadPage } from '@onekeyhq/kit/src/components/LazyLoadPage';
 import type { IOnboardingParamListV2 } from '@onekeyhq/shared/src/routes';
 import { EOnboardingPagesV2 } from '@onekeyhq/shared/src/routes';
 
-import { OnboardingPageFallback } from '../components/Layout';
-import { OnboardingLayoutFallback } from '../components/OnboardingLayout';
-
-// Keep the Suspense fallback aligned with the page shell so lazy-loaded pages
-// do not briefly flash the legacy onboarding frame during navigation.
-const pageFallback = <OnboardingPageFallback />;
-const legacyLayoutFallback = <OnboardingLayoutFallback />;
-
-const GetStarted = LazyLoadPage(
-  () => import('../pages/GetStarted'),
-  undefined,
-  false,
-  pageFallback,
-);
-const CreateNewWallet = LazyLoadPage(
-  () => import('../pages/CreateNewWallet'),
-  undefined,
-  false,
-  pageFallback,
-);
-const CreateOrImportWallet = LazyLoadPage(
-  () => import('../pages/CreateOrImportWallet'),
-  undefined,
-  false,
-  pageFallback,
-);
-const FinalizeWalletSetup = LazyLoadPage(
-  () => import('../pages/FinalizeWalletSetup'),
-  undefined,
-  false,
-  pageFallback,
-);
-const PickYourDevice = LazyLoadPage(
-  () => import('../pages/PickYourDevice'),
-  undefined,
-  false,
-  pageFallback,
-);
-const ImportPhraseOrPrivateKey = LazyLoadPage(
-  () => import('../pages/ImportPhraseOrPrivateKey'),
-  undefined,
-  false,
-  pageFallback,
-);
-const ImportWatchedAccount = LazyLoadPage(
-  () => import('../pages/ImportWatchedAccountV2'),
-  undefined,
-  false,
-  legacyLayoutFallback,
-);
-const BackupWalletReminder = LazyLoadPage(
-  () => import('../pages/BackupWalletReminder'),
-  undefined,
-  false,
-  pageFallback,
-);
-const ShowRecoveryPhrase = LazyLoadPage(
-  () => import('../pages/ShowRecoveryPhrase'),
-  undefined,
-  false,
-  legacyLayoutFallback,
-);
-const VerifyRecoveryPhrase = LazyLoadPage(
-  () => import('../pages/VerifyRecoveryPhrase'),
-  undefined,
-  false,
-  legacyLayoutFallback,
-);
-const SelectPrivateKeyNetwork = LazyLoadPage(
-  () => import('../pages/SelectPrivateKeyNetwork'),
-  undefined,
-  false,
-  pageFallback,
-);
-const ConnectYourDevice = LazyLoadPage(
-  () => import('../pages/ConnectYourDevice'),
-  undefined,
-  false,
-  pageFallback,
-);
-const ConnectQRCode = LazyLoadPage(
-  () => import('../pages/ConnectQRCode'),
-  undefined,
-  false,
-  pageFallback,
-);
-const CheckAndUpdate = LazyLoadPage(
-  () => import('../pages/CheckAndUpdate'),
-  undefined,
-  false,
-  pageFallback,
-);
-const ICloudBackup = LazyLoadPage(
-  () => import('../pages/ICloudBackup'),
-  undefined,
-  false,
-  pageFallback,
-);
-const ICloudBackupDetails = LazyLoadPage(
-  () => import('../pages/ICloudBackupDetails'),
-  undefined,
-  false,
-  pageFallback,
-);
-const ConnectWalletSelectNetworks = LazyLoadPage(
-  () => import('../pages/ConnectWalletSelectNetworks'),
-  undefined,
-  false,
-  legacyLayoutFallback,
-);
-const ConnectExternalWallet = LazyLoadPage(
-  () => import('../pages/ConnectExternalWallet'),
-  undefined,
-  false,
-  legacyLayoutFallback,
-);
-const ImportKeyTag = LazyLoadPage(
-  () => import('../pages/ImportKeyTag'),
-  undefined,
-  false,
-  legacyLayoutFallback,
-);
-const KeylessWalletRecovery = LazyLoadPage(
-  () => import('../pages/KeylessWalletRecovery'),
-  undefined,
-  false,
-  legacyLayoutFallback,
-);
-const KeylessWalletCreation = LazyLoadPage(
-  () => import('../pages/KeylessWalletCreation'),
-  undefined,
-  false,
-  legacyLayoutFallback,
-);
-const OneKeyIDLogin = LazyLoadPage(
-  () => import('../pages/OneKeyIDLoginPage'),
-  undefined,
-  false,
-  pageFallback,
-);
-const CreatePin = LazyLoadPage(
-  () => import('../pages/CreatePinPage'),
-  undefined,
-  false,
-  pageFallback,
-);
-const ConfirmPin = LazyLoadPage(
-  () => import('../pages/ConfirmPinPage'),
-  undefined,
-  false,
-  pageFallback,
-);
-const CreatePasscode = LazyLoadPage(
-  () => import('../pages/CreatePasscodePage'),
-  undefined,
-  false,
-  pageFallback,
-);
-const VerifyPin = LazyLoadPage(
-  () => import('../pages/VerifyPinPage'),
-  undefined,
-  false,
-  pageFallback,
-);
-const ResetPinGuidePage = LazyLoadPage(
-  () => import('../pages/ResetPinGuidePage'),
-  undefined,
-  false,
-  pageFallback,
-);
-const NewPinCreated = LazyLoadPage(
-  () => import('../pages/NewPinCreatedPage'),
-  undefined,
-  false,
-  pageFallback,
-);
+import BackupWalletReminder from '../pages/BackupWalletReminder';
+import CheckAndUpdate from '../pages/CheckAndUpdate';
+import ConfirmPin from '../pages/ConfirmPinPage';
+import ConnectExternalWallet from '../pages/ConnectExternalWallet';
+import ConnectQRCode from '../pages/ConnectQRCode';
+import ConnectWalletSelectNetworks from '../pages/ConnectWalletSelectNetworks';
+import ConnectYourDevice from '../pages/ConnectYourDevice';
+import CreateNewWallet from '../pages/CreateNewWallet';
+import CreateOrImportWallet from '../pages/CreateOrImportWallet';
+import CreatePasscode from '../pages/CreatePasscodePage';
+import CreatePin from '../pages/CreatePinPage';
+import FinalizeWalletSetup from '../pages/FinalizeWalletSetup';
+import GetStarted from '../pages/GetStarted';
+import ICloudBackup from '../pages/ICloudBackup';
+import ICloudBackupDetails from '../pages/ICloudBackupDetails';
+import ImportKeyTag from '../pages/ImportKeyTag';
+import ImportPhraseOrPrivateKey from '../pages/ImportPhraseOrPrivateKey';
+import ImportWatchedAccount from '../pages/ImportWatchedAccountV2';
+import KeylessWalletCreation from '../pages/KeylessWalletCreation';
+import KeylessWalletRecovery from '../pages/KeylessWalletRecovery';
+import NewPinCreated from '../pages/NewPinCreatedPage';
+import OneKeyIDLogin from '../pages/OneKeyIDLoginPage';
+import PickYourDevice from '../pages/PickYourDevice';
+import ResetPinGuidePage from '../pages/ResetPinGuidePage';
+import SelectPrivateKeyNetwork from '../pages/SelectPrivateKeyNetwork';
+import ShowRecoveryPhrase from '../pages/ShowRecoveryPhrase';
+import VerifyPin from '../pages/VerifyPinPage';
+import VerifyRecoveryPhrase from '../pages/VerifyRecoveryPhrase';
 
 const hiddenHeaderOptions = {
   headerShown: false,
 };
+
+// Pages are imported eagerly (not via React.lazy / LazyLoadPage) so every
+// navigation inside the onboarding flow renders without a Suspense fallback
+// flash. The 28 page modules join the chunk that loads when the onboarding
+// modal opens — the one-time cost is hidden by the modal's opening transition,
+// and every subsequent in-flow navigation is instant.
 export const OnboardingRouterV2: IModalFlowNavigatorConfig<
   EOnboardingPagesV2,
   IOnboardingParamListV2

--- a/packages/kit/src/views/Onboardingv2/router/index.tsx
+++ b/packages/kit/src/views/Onboardingv2/router/index.tsx
@@ -1,45 +1,188 @@
 import type { IModalFlowNavigatorConfig } from '@onekeyhq/components';
+import { LazyLoadPage } from '@onekeyhq/kit/src/components/LazyLoadPage';
 import type { IOnboardingParamListV2 } from '@onekeyhq/shared/src/routes';
 import { EOnboardingPagesV2 } from '@onekeyhq/shared/src/routes';
 
-import BackupWalletReminder from '../pages/BackupWalletReminder';
-import CheckAndUpdate from '../pages/CheckAndUpdate';
-import ConfirmPin from '../pages/ConfirmPinPage';
-import ConnectExternalWallet from '../pages/ConnectExternalWallet';
-import ConnectQRCode from '../pages/ConnectQRCode';
-import ConnectWalletSelectNetworks from '../pages/ConnectWalletSelectNetworks';
-import ConnectYourDevice from '../pages/ConnectYourDevice';
-import CreateNewWallet from '../pages/CreateNewWallet';
-import CreateOrImportWallet from '../pages/CreateOrImportWallet';
-import CreatePasscode from '../pages/CreatePasscodePage';
-import CreatePin from '../pages/CreatePinPage';
-import FinalizeWalletSetup from '../pages/FinalizeWalletSetup';
-import GetStarted from '../pages/GetStarted';
-import ICloudBackup from '../pages/ICloudBackup';
-import ICloudBackupDetails from '../pages/ICloudBackupDetails';
-import ImportKeyTag from '../pages/ImportKeyTag';
-import ImportPhraseOrPrivateKey from '../pages/ImportPhraseOrPrivateKey';
-import ImportWatchedAccount from '../pages/ImportWatchedAccountV2';
-import KeylessWalletCreation from '../pages/KeylessWalletCreation';
-import KeylessWalletRecovery from '../pages/KeylessWalletRecovery';
-import NewPinCreated from '../pages/NewPinCreatedPage';
-import OneKeyIDLogin from '../pages/OneKeyIDLoginPage';
-import PickYourDevice from '../pages/PickYourDevice';
-import ResetPinGuidePage from '../pages/ResetPinGuidePage';
-import SelectPrivateKeyNetwork from '../pages/SelectPrivateKeyNetwork';
-import ShowRecoveryPhrase from '../pages/ShowRecoveryPhrase';
-import VerifyPin from '../pages/VerifyPinPage';
-import VerifyRecoveryPhrase from '../pages/VerifyRecoveryPhrase';
+import { OnboardingPageFallback } from '../components/Layout';
+import { OnboardingLayoutFallback } from '../components/OnboardingLayout';
+
+// Keep the Suspense fallback aligned with the page shell so lazy-loaded pages
+// do not briefly flash the legacy onboarding frame during navigation.
+const pageFallback = <OnboardingPageFallback />;
+const legacyLayoutFallback = <OnboardingLayoutFallback />;
+
+const GetStarted = LazyLoadPage(
+  () => import('../pages/GetStarted'),
+  undefined,
+  false,
+  pageFallback,
+);
+const CreateNewWallet = LazyLoadPage(
+  () => import('../pages/CreateNewWallet'),
+  undefined,
+  false,
+  pageFallback,
+);
+const CreateOrImportWallet = LazyLoadPage(
+  () => import('../pages/CreateOrImportWallet'),
+  undefined,
+  false,
+  pageFallback,
+);
+const FinalizeWalletSetup = LazyLoadPage(
+  () => import('../pages/FinalizeWalletSetup'),
+  undefined,
+  false,
+  pageFallback,
+);
+const PickYourDevice = LazyLoadPage(
+  () => import('../pages/PickYourDevice'),
+  undefined,
+  false,
+  pageFallback,
+);
+const ImportPhraseOrPrivateKey = LazyLoadPage(
+  () => import('../pages/ImportPhraseOrPrivateKey'),
+  undefined,
+  false,
+  pageFallback,
+);
+const ImportWatchedAccount = LazyLoadPage(
+  () => import('../pages/ImportWatchedAccountV2'),
+  undefined,
+  false,
+  legacyLayoutFallback,
+);
+const BackupWalletReminder = LazyLoadPage(
+  () => import('../pages/BackupWalletReminder'),
+  undefined,
+  false,
+  pageFallback,
+);
+const ShowRecoveryPhrase = LazyLoadPage(
+  () => import('../pages/ShowRecoveryPhrase'),
+  undefined,
+  false,
+  legacyLayoutFallback,
+);
+const VerifyRecoveryPhrase = LazyLoadPage(
+  () => import('../pages/VerifyRecoveryPhrase'),
+  undefined,
+  false,
+  legacyLayoutFallback,
+);
+const SelectPrivateKeyNetwork = LazyLoadPage(
+  () => import('../pages/SelectPrivateKeyNetwork'),
+  undefined,
+  false,
+  pageFallback,
+);
+const ConnectYourDevice = LazyLoadPage(
+  () => import('../pages/ConnectYourDevice'),
+  undefined,
+  false,
+  pageFallback,
+);
+const ConnectQRCode = LazyLoadPage(
+  () => import('../pages/ConnectQRCode'),
+  undefined,
+  false,
+  pageFallback,
+);
+const CheckAndUpdate = LazyLoadPage(
+  () => import('../pages/CheckAndUpdate'),
+  undefined,
+  false,
+  pageFallback,
+);
+const ICloudBackup = LazyLoadPage(
+  () => import('../pages/ICloudBackup'),
+  undefined,
+  false,
+  pageFallback,
+);
+const ICloudBackupDetails = LazyLoadPage(
+  () => import('../pages/ICloudBackupDetails'),
+  undefined,
+  false,
+  pageFallback,
+);
+const ConnectWalletSelectNetworks = LazyLoadPage(
+  () => import('../pages/ConnectWalletSelectNetworks'),
+  undefined,
+  false,
+  legacyLayoutFallback,
+);
+const ConnectExternalWallet = LazyLoadPage(
+  () => import('../pages/ConnectExternalWallet'),
+  undefined,
+  false,
+  legacyLayoutFallback,
+);
+const ImportKeyTag = LazyLoadPage(
+  () => import('../pages/ImportKeyTag'),
+  undefined,
+  false,
+  legacyLayoutFallback,
+);
+const KeylessWalletRecovery = LazyLoadPage(
+  () => import('../pages/KeylessWalletRecovery'),
+  undefined,
+  false,
+  legacyLayoutFallback,
+);
+const KeylessWalletCreation = LazyLoadPage(
+  () => import('../pages/KeylessWalletCreation'),
+  undefined,
+  false,
+  legacyLayoutFallback,
+);
+const OneKeyIDLogin = LazyLoadPage(
+  () => import('../pages/OneKeyIDLoginPage'),
+  undefined,
+  false,
+  pageFallback,
+);
+const CreatePin = LazyLoadPage(
+  () => import('../pages/CreatePinPage'),
+  undefined,
+  false,
+  pageFallback,
+);
+const ConfirmPin = LazyLoadPage(
+  () => import('../pages/ConfirmPinPage'),
+  undefined,
+  false,
+  pageFallback,
+);
+const CreatePasscode = LazyLoadPage(
+  () => import('../pages/CreatePasscodePage'),
+  undefined,
+  false,
+  pageFallback,
+);
+const VerifyPin = LazyLoadPage(
+  () => import('../pages/VerifyPinPage'),
+  undefined,
+  false,
+  pageFallback,
+);
+const ResetPinGuidePage = LazyLoadPage(
+  () => import('../pages/ResetPinGuidePage'),
+  undefined,
+  false,
+  pageFallback,
+);
+const NewPinCreated = LazyLoadPage(
+  () => import('../pages/NewPinCreatedPage'),
+  undefined,
+  false,
+  pageFallback,
+);
 
 const hiddenHeaderOptions = {
   headerShown: false,
 };
-
-// Pages are imported eagerly (not via React.lazy / LazyLoadPage) so every
-// navigation inside the onboarding flow renders without a Suspense fallback
-// flash. The 28 page modules join the chunk that loads when the onboarding
-// modal opens — the one-time cost is hidden by the modal's opening transition,
-// and every subsequent in-flow navigation is instant.
 export const OnboardingRouterV2: IModalFlowNavigatorConfig<
   EOnboardingPagesV2,
   IOnboardingParamListV2

--- a/packages/kit/src/views/Onboardingv2/router/index.web.tsx
+++ b/packages/kit/src/views/Onboardingv2/router/index.web.tsx
@@ -1,0 +1,196 @@
+import type { IModalFlowNavigatorConfig } from '@onekeyhq/components';
+import type { IOnboardingParamListV2 } from '@onekeyhq/shared/src/routes';
+import { EOnboardingPagesV2 } from '@onekeyhq/shared/src/routes';
+
+import BackupWalletReminder from '../pages/BackupWalletReminder';
+import CheckAndUpdate from '../pages/CheckAndUpdate';
+import ConfirmPin from '../pages/ConfirmPinPage';
+import ConnectExternalWallet from '../pages/ConnectExternalWallet';
+import ConnectQRCode from '../pages/ConnectQRCode';
+import ConnectWalletSelectNetworks from '../pages/ConnectWalletSelectNetworks';
+import ConnectYourDevice from '../pages/ConnectYourDevice';
+import CreateNewWallet from '../pages/CreateNewWallet';
+import CreateOrImportWallet from '../pages/CreateOrImportWallet';
+import CreatePasscode from '../pages/CreatePasscodePage';
+import CreatePin from '../pages/CreatePinPage';
+import FinalizeWalletSetup from '../pages/FinalizeWalletSetup';
+import GetStarted from '../pages/GetStarted';
+import ICloudBackup from '../pages/ICloudBackup';
+import ICloudBackupDetails from '../pages/ICloudBackupDetails';
+import ImportKeyTag from '../pages/ImportKeyTag';
+import ImportPhraseOrPrivateKey from '../pages/ImportPhraseOrPrivateKey';
+import ImportWatchedAccount from '../pages/ImportWatchedAccountV2';
+import KeylessWalletCreation from '../pages/KeylessWalletCreation';
+import KeylessWalletRecovery from '../pages/KeylessWalletRecovery';
+import NewPinCreated from '../pages/NewPinCreatedPage';
+import OneKeyIDLogin from '../pages/OneKeyIDLoginPage';
+import PickYourDevice from '../pages/PickYourDevice';
+import ResetPinGuidePage from '../pages/ResetPinGuidePage';
+import SelectPrivateKeyNetwork from '../pages/SelectPrivateKeyNetwork';
+import ShowRecoveryPhrase from '../pages/ShowRecoveryPhrase';
+import VerifyPin from '../pages/VerifyPinPage';
+import VerifyRecoveryPhrase from '../pages/VerifyRecoveryPhrase';
+
+const hiddenHeaderOptions = {
+  headerShown: false,
+};
+
+// Web/Desktop/Extension override: pages are imported eagerly (not via
+// React.lazy / LazyLoadPage) so every navigation inside the onboarding flow
+// renders without a Suspense fallback flash — the visible problem on web
+// caused by the modal's enter animation amplifying React.lazy's microtask
+// boundary. The 28 page modules join the chunk that loads when the
+// onboarding modal opens; the one-time cost is hidden by the modal's
+// opening transition.
+//
+// Native (iOS / Android) uses the default lazy version in `./index.tsx` —
+// no enter animation to amplify the lazy boundary, and lazy keeps the
+// module count out of the cold-start startup graph (mobile budget check).
+export const OnboardingRouterV2: IModalFlowNavigatorConfig<
+  EOnboardingPagesV2,
+  IOnboardingParamListV2
+>[] = [
+  {
+    name: EOnboardingPagesV2.GetStarted,
+    component: GetStarted,
+    options: hiddenHeaderOptions,
+    rewrite: '/get-started',
+  },
+  {
+    name: EOnboardingPagesV2.CreateNewWallet,
+    component: CreateNewWallet,
+    options: hiddenHeaderOptions,
+    rewrite: '/create-new-wallet',
+  },
+  {
+    name: EOnboardingPagesV2.CreateOrImportWallet,
+    component: CreateOrImportWallet,
+    options: hiddenHeaderOptions,
+    rewrite: '/create-or-import-wallet',
+  },
+  {
+    name: EOnboardingPagesV2.FinalizeWalletSetup,
+    component: FinalizeWalletSetup,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.PickYourDevice,
+    component: PickYourDevice,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.ConnectYourDevice,
+    component: ConnectYourDevice,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.ConnectQRCode,
+    component: ConnectQRCode,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.CheckAndUpdate,
+    component: CheckAndUpdate,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.ImportPhraseOrPrivateKey,
+    component: ImportPhraseOrPrivateKey,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.ImportWatchedAccount,
+    component: ImportWatchedAccount,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.BackupWalletReminder,
+    component: BackupWalletReminder,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.ShowRecoveryPhrase,
+    component: ShowRecoveryPhrase,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.VerifyRecoveryPhrase,
+    component: VerifyRecoveryPhrase,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.SelectPrivateKeyNetwork,
+    component: SelectPrivateKeyNetwork,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.ICloudBackup,
+    component: ICloudBackup,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.ICloudBackupDetails,
+    component: ICloudBackupDetails,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.ConnectWalletSelectNetworks,
+    component: ConnectWalletSelectNetworks,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.ConnectExternalWallet,
+    component: ConnectExternalWallet,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.ImportKeyTag,
+    component: ImportKeyTag,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.KeylessWalletRecovery,
+    component: KeylessWalletRecovery,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.KeylessWalletCreation,
+    component: KeylessWalletCreation,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.OneKeyIDLogin,
+    component: OneKeyIDLogin,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.CreatePin,
+    component: CreatePin,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.ConfirmPin,
+    component: ConfirmPin,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.CreatePasscode,
+    component: CreatePasscode,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.VerifyPin,
+    component: VerifyPin,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.ResetPinGuide,
+    component: ResetPinGuidePage,
+    options: hiddenHeaderOptions,
+  },
+  {
+    name: EOnboardingPagesV2.NewPinCreated,
+    component: NewPinCreated,
+    options: hiddenHeaderOptions,
+  },
+];


### PR DESCRIPTION
## Summary

- Replace `LazyLoadPage(() => import('...'))` with static imports for all 28 v2 onboarding pages so in-flow navigation renders without a Suspense fallback flash.
- `React.lazy` + `Suspense` always shows a brief blank state on first visit (`Pending → Resolved` requires at least one re-render), even when chunks are already cached. Eager imports remove the lazy boundary entirely and the navigation lands instantly.

## Trade-off

- The 28 page modules now join the chunk that loads when the onboarding modal opens — a one-time ~100-300KB increase paid only when entering onboarding.
- The cost is hidden by the modal's own opening transition, and every in-flow navigation is then instant.
- `ModalNavigator` is itself lazy-gated, so this does **not** bloat the main app bundle for users who never open onboarding.

## Test plan

QA checklist tracked in [OK-53837](https://onekeyhq.atlassian.net/browse/OK-53837).

- [ ] Cold-start → Onboarding → GetStarted → all 3 entries (Create / Add existing / Connect hardware) on Desktop / iOS / Android / Web / Extension: no blank flash on navigation
- [ ] Full create-new-wallet flow (mnemonic + passcode) works end-to-end
- [ ] Full import-wallet flow (mnemonic + private key) works end-to-end
- [ ] Full hardware-wallet flow (verify + firmware check) works end-to-end on Desktop / iOS / Android
- [ ] Opening the onboarding modal itself is still snappy on each platform (no observable regression)

## Notes

- Only affects v2 onboarding (`packages/kit/src/views/Onboardingv2/`); v1 flow untouched.
- Bundling topology changed → Desktop / Web / Extension need a fresh build to verify locally.
- `yarn lint:staged` and `yarn tsc:staged` both clean.

[OK-53837]: https://onekeyhq.atlassian.net/browse/OK-53837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
