### PR TITLE
chore(skills): add explicit update-branch step to 1k-create-pr skill

### DIFF
--- a/.skillshare/skills/1k-create-pr/SKILL.md
+++ b/.skillshare/skills/1k-create-pr/SKILL.md
@@ -20,8 +20,9 @@ Automates the complete PR creation workflow for OneKey app-monorepo changes.
 | 6 | Push to remote | `git push -u origin <branch-name>` |
 | 7 | Extract context | Analyze conversation for intent, decisions, risks |
 | 8 | Create PR | `gh pr create --base <base> --title "..." --body "..."` |
-| 9 | Enable auto-merge | `gh pr merge <number> --auto --squash` |
-| 10 | Update Jira issue | Update `1k-github-branch` and `1k-github-pr-url` fields |
+| 9 | Update branch | `gh pr update-branch <number>` |
+| 10 | Enable auto-merge | `gh pr merge <number> --auto --squash` |
+| 11 | Update Jira issue | Update `1k-github-branch` and `1k-github-pr-url` fields |
 
 ## Workflow
 
@@ -167,14 +168,23 @@ The PR body MUST use this template. Omit sections that don't apply (don't write 
 - [ ] <Testing steps to verify the changes>
 ```
 
-### 9. Enable Auto-Merge
+### 9. Update Branch
+
+Sync the PR branch with the latest base branch to ensure CI runs on the merged state:
 
 ```bash
 gh pr update-branch <PR_NUMBER>
+```
+
+This is equivalent to clicking "Update branch" button on GitHub PR page.
+
+### 10. Enable Auto-Merge
+
+```bash
 gh pr merge <PR_NUMBER> --auto --squash
 ```
 
-### 10. Update Jira Issue (if OK-{number} exists)
+### 11. Update Jira Issue (if OK-{number} exists)
 
 If a Jira issue ID (`OK-{number}`) was found in the conversation or commit message, update the Jira issue with PR and branch information.
 
@@ -210,7 +220,7 @@ fields: {
 }
 ```
 
-### 11. Return PR URL
+### 12. Return PR URL
 
 Display PR URL to user and open in browser:
 ```bash


### PR DESCRIPTION
## Summary
- Add explicit "Update Branch" as a separate step (step 9) in the 1k-create-pr skill workflow
- Makes it clear that `gh pr update-branch` should be called after creating PR and before enabling auto-merge

## Intent & Context
User requested to add an explicit step to click "Update branch" after creating a PR. Previously, the `gh pr update-branch` command was bundled together with auto-merge in step 9. This change separates them into distinct steps for clarity and ensures the branch is synced with the base branch before auto-merge is enabled.

## Changes Detail
- **Quick Reference table**: Added step 9 "Update branch", renumbered steps 10-11
- **Workflow section**: Split step 9 into two sections with explanatory text
- Step 9 now explicitly handles branch update with `gh pr update-branch`
- Step 10 handles auto-merge with `gh pr merge --auto --squash`
- Renumbered subsequent steps (Jira update -> 11, Return URL -> 12)

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: N/A (documentation only)
- **Risk Areas**: None - this is a skill documentation update

## Test plan
- [ ] Verify skill renders correctly when invoked via `/1k-create-pr`
- [ ] Verify the workflow follows the updated step order
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
