### PR TITLE
fix(home): refresh all-net accounts on HW batch (OK-53863 OK-53864)

### DIFF
--- a/packages/kit/src/hooks/useAllNetwork.ts
+++ b/packages/kit/src/hooks/useAllNetwork.ts
@@ -395,9 +395,9 @@ function useAllNetworkRequests<T>(params: {
     if (!isAllNetworks) return;
     if (!currentWalletId) return;
     const walletIdAtSubscribe = currentWalletId;
-    const onAddDBAccounts = (params?: { walletId: string }) => {
-      if (!params?.walletId) return;
-      if (params.walletId !== walletIdAtSubscribe) return;
+    const onAddDBAccounts = (payload?: { walletId: string }) => {
+      if (!payload?.walletId) return;
+      if (payload.walletId !== walletIdAtSubscribe) return;
       const prefix = `${walletIdAtSubscribe}::`;
       for (const key of Array.from(allNetworkAccountsBaseCache.keys())) {
         if (key.startsWith(prefix)) {

--- a/packages/kit/src/hooks/useAllNetwork.ts
+++ b/packages/kit/src/hooks/useAllNetwork.ts
@@ -404,7 +404,14 @@ function useAllNetworkRequests<T>(params: {
           allNetworkAccountsBaseCache.delete(key);
         }
       }
-      void runWithQueueRef.current?.({ skipAccountsCache: true });
+      // alwaysSetState forces the runner past usePromiseResult's focus
+      // check, otherwise the refresh is dropped when the consuming tab
+      // (e.g. DeFi) is mounted but not the active tab during the HW connect
+      // batch — the cache would be cleared but no fetch would actually run.
+      void runWithQueueRef.current?.({
+        skipAccountsCache: true,
+        alwaysSetState: true,
+      });
     };
     appEventBus.on(EAppEventBusNames.AddDBAccountsToWallet, onAddDBAccounts);
     return () => {

--- a/packages/kit/src/hooks/useAllNetwork.ts
+++ b/packages/kit/src/hooks/useAllNetwork.ts
@@ -471,6 +471,9 @@ function useAllNetworkRequests<T>(params: {
       runCountRef.current += 1;
       isFetching.current = true;
 
+      let onStartedError: unknown;
+      let onStartedTask: Promise<void> | undefined;
+
       try {
         if (!allNetworkDataInit.current) {
           clearAllNetworkData();
@@ -484,8 +487,6 @@ function useAllNetworkRequests<T>(params: {
           allNetworkDataInit: !!allNetworkDataInit.current,
         });
 
-        let onStartedError: unknown;
-        let onStartedTask: Promise<void> | undefined;
         if (onStarted) {
           onStartedTask = onStarted({
             accountId: currentAccountId,
@@ -780,6 +781,18 @@ function useAllNetworkRequests<T>(params: {
         return resp;
       } finally {
         isFetching.current = false;
+        // Wait for onStarted to settle before firing onFinished, so
+        // the started/finished events for this run land in monotonic
+        // order (true -> false). Without this, an early throw above
+        // can fire onFinished while onStarted is still in flight,
+        // letting a stale "isRefreshing: true" arrive after "false".
+        if (onStartedTask) {
+          try {
+            await onStartedTask;
+          } catch (e) {
+            console.error(e);
+          }
+        }
         // Fire onFinished from finally so the "isRefreshing: false" signal
         // (consumed by DeFi tab's runAfterTokensDone) is always emitted —
         // even when the work above threw before reaching the prior call site.

--- a/packages/kit/src/hooks/useAllNetwork.ts
+++ b/packages/kit/src/hooks/useAllNetwork.ts
@@ -106,12 +106,14 @@ function getAllNetworkAccountsBaseCached({
   networkId,
   networksEnabledOnly,
   excludeTestNetwork,
+  skipCache,
 }: {
   walletId: string;
   accountId: string;
   networkId: string;
   networksEnabledOnly: boolean;
   excludeTestNetwork: boolean;
+  skipCache?: boolean;
 }): {
   cacheKey: IAllNetworkAccountsBaseCacheKey;
   reused: boolean;
@@ -129,6 +131,7 @@ function getAllNetworkAccountsBaseCached({
   sweepAllNetworkAccountsBaseCache(now);
   const cached = allNetworkAccountsBaseCache.get(cacheKey);
   if (
+    !skipCache &&
     cached &&
     now - cached.createdAt < ALL_NETWORK_ACCOUNTS_BASE_CACHE_TTL_MS
   ) {
@@ -316,6 +319,7 @@ function useAllNetworkRequests<T>(params: {
     triggerByDeps?: boolean;
     pollingNonce?: number;
     alwaysSetState?: boolean;
+    skipAccountsCache?: boolean;
   };
   const {
     accountId: currentAccountId,
@@ -351,6 +355,11 @@ function useAllNetworkRequests<T>(params: {
   const runWithQueueRef = useRef<
     ((config?: IAllNetworkRequestsRunConfig) => Promise<void>) | undefined
   >(undefined);
+  // Single-shot signal that the next run should bypass the all-network
+  // accounts base cache. usePromiseResult does not forward the runner config
+  // into the method body, so we relay it through this ref and consume it
+  // inside the runner.
+  const skipAccountsCacheRef = useRef(false);
 
   useEffect(() => {
     const onEnabledNetworksChanged = () => {
@@ -374,6 +383,34 @@ function useAllNetworkRequests<T>(params: {
       );
     };
   }, [isAllNetworks]);
+
+  // Hardware wallets create default network accounts in series after connect
+  // (BTC -> EVM -> TRON -> SOL). The 15s account-list cache can otherwise
+  // capture a half-formed snapshot that contains only the first impl, which
+  // makes Spot show only BTC and DeFi filter to an empty network set.
+  // Invalidate this wallet's entries on every batch so the next run picks up
+  // the latest DB account set. allNetworkDataInit stays as-is to avoid
+  // clearAllNetworkData wiping the visible list between batches.
+  useEffect(() => {
+    if (!isAllNetworks) return;
+    if (!currentWalletId) return;
+    const walletIdAtSubscribe = currentWalletId;
+    const onAddDBAccounts = (params?: { walletId: string }) => {
+      if (!params?.walletId) return;
+      if (params.walletId !== walletIdAtSubscribe) return;
+      const prefix = `${walletIdAtSubscribe}::`;
+      for (const key of Array.from(allNetworkAccountsBaseCache.keys())) {
+        if (key.startsWith(prefix)) {
+          allNetworkAccountsBaseCache.delete(key);
+        }
+      }
+      void runWithQueueRef.current?.({ skipAccountsCache: true });
+    };
+    appEventBus.on(EAppEventBusNames.AddDBAccountsToWallet, onAddDBAccounts);
+    return () => {
+      appEventBus.off(EAppEventBusNames.AddDBAccountsToWallet, onAddDBAccounts);
+    };
+  }, [isAllNetworks, currentWalletId]);
 
   useEffect(() => {
     if (currentAccountId && currentNetworkId && currentWalletId) {
@@ -463,12 +500,16 @@ function useAllNetworkRequests<T>(params: {
           accountId: currentAccountId,
         });
 
+        const skipAccountsCacheForThisRun = skipAccountsCacheRef.current;
+        skipAccountsCacheRef.current = false;
+
         const { promise: accountsTask } = getAllNetworkAccountsBaseCached({
           walletId: currentWalletId,
           accountId: currentAccountId,
           networkId: currentNetworkId,
           excludeTestNetwork: true,
           networksEnabledOnly,
+          skipCache: skipAccountsCacheForThisRun,
         });
 
         const deFiEnabledNetworksMapTask = isDeFiRequests
@@ -728,14 +769,21 @@ function useAllNetworkRequests<T>(params: {
         if (accountsInfo.length && accountsInfo.length > 0) {
           allNetworkDataInit.current = true;
         }
-        await onFinished?.({
-          accountId: currentAccountId,
-          networkId: currentNetworkId,
-        });
 
         return resp;
       } finally {
         isFetching.current = false;
+        // Fire onFinished from finally so the "isRefreshing: false" signal
+        // (consumed by DeFi tab's runAfterTokensDone) is always emitted —
+        // even when the work above threw before reaching the prior call site.
+        try {
+          await onFinished?.({
+            accountId: currentAccountId,
+            networkId: currentNetworkId,
+          });
+        } catch (e) {
+          console.error(e);
+        }
         if (rerunAfterCurrentRef.current) {
           rerunAfterCurrentRef.current = false;
           const rerunConfig = rerunConfigRef.current;
@@ -782,8 +830,14 @@ function useAllNetworkRequests<T>(params: {
           alwaysSetState:
             !!rerunConfigRef.current?.alwaysSetState ||
             !!config?.alwaysSetState,
+          skipAccountsCache:
+            !!rerunConfigRef.current?.skipAccountsCache ||
+            !!config?.skipAccountsCache,
         };
         return;
+      }
+      if (config?.skipAccountsCache) {
+        skipAccountsCacheRef.current = true;
       }
       await run(config);
     },

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
@@ -633,7 +633,10 @@ function DeFiListBlock({
   });
 
   const handleRefreshAllNetworkData = useCallback(() => {
-    void runAllNetworkRequests({ alwaysSetState: true });
+    void runAllNetworkRequests({
+      alwaysSetState: true,
+      skipAccountsCache: true,
+    });
   }, [runAllNetworkRequests]);
 
   useEffect(() => {

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -1917,18 +1917,6 @@ function TokenListBlock({
     });
   }, [runAllNetworksRequests]);
 
-  useEffect(() => {
-    const fn = () => {
-      if (network?.isAllNetworks) {
-        void runAllNetworksRequests({ alwaysSetState: true });
-      }
-    };
-    appEventBus.on(EAppEventBusNames.AddDBAccountsToWallet, fn);
-    return () => {
-      appEventBus.off(EAppEventBusNames.AddDBAccountsToWallet, fn);
-    };
-  }, [network?.isAllNetworks, runAllNetworksRequests]);
-
   const handleRefreshAllNetworkDataByAccounts = useCallback(
     async (accounts: { accountId: string; networkId: string }[]) => {
       for (const { accountId, networkId } of accounts) {

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -1911,7 +1911,10 @@ function TokenListBlock({
 
   const handleRefreshAllNetworkData = useCallback(() => {
     isAllNetworkManualRefresh.current = true;
-    void runAllNetworksRequests({ alwaysSetState: true });
+    void runAllNetworksRequests({
+      alwaysSetState: true,
+      skipAccountsCache: true,
+    });
   }, [runAllNetworksRequests]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Spot tab in **All Networks** mode loaded only BTC after a hardware-wallet connect; other enabled networks needed a manual refresh.
- DeFi tab in All Networks mode silently sat at the 30s `runAfterTokensDone` fallback — positions only appeared after a manual refresh.
- Both reduce to the same root cause: a 15s in-memory account-list cache captured a half-formed snapshot during HW default-account batch creation.

## Root Cause
After a HW wallet connects, `addDefaultNetworkAccounts → batchBuildAccounts` creates default accounts **in series** (BTC × 4 derive types → EVM → TRON → SOL), emitting `AddDBAccountsToWallet` between each batch. `useAllNetworkRequests` calls `getAllNetworkAccountsBaseCached` to enumerate accounts, and the cache:
- has a 15s TTL keyed only by `walletId / accountId / networkId / networksEnabledOnly / excludeTestNetwork`
- is invalidated **only** on `EnabledNetworksChanged`, not on `AddDBAccountsToWallet`

So the first all-network fetch — which typically lands while only the BTC batch has been written — populates the cache with a BTC-only `accountsInfo`. Spot fetches only BTC. DeFi filters that result through `deFiEnabledNetworksMap`, ends up with an empty network set, never calls `/wallet/v1/portfolio/positions`. The existing per-component `AddDBAccountsToWallet` listener in `TokenListBlock` re-runs, but the re-run still hits the stale cache.

## Fix
Invalidate this wallet's entries on every `AddDBAccountsToWallet`, then re-run with cache bypassed. This is wired at the `useAllNetworkRequests` layer so all consumers (Spot / DeFi / NFT) benefit without per-component duplication.

- `getAllNetworkAccountsBaseCached`: new `skipCache?: boolean` parameter — bypass the lookup but still write the fresh promise back, so concurrent readers see the new result.
- `IAllNetworkRequestsRunConfig`: new `skipAccountsCache?: boolean`. Relayed through `skipAccountsCacheRef` because `usePromiseResult` does not forward runner config into the method body.
- `useAllNetworkRequests`: subscribe to `AddDBAccountsToWallet`; on each batch, drop only this wallet's cache entries (`${walletId}::` prefix) and `runWithQueue({ skipAccountsCache: true, alwaysSetState: true })`. `alwaysSetState` is required so the refresh fires even when the consuming tab is mounted-but-not-active (DeFi while user is on Spot). `allNetworkDataInit` is intentionally **not** reset, so `clearAllNetworkData` does not flicker the visible list between batches.
- `runWithQueue`: OR-merge `skipAccountsCache` into the queued rerun config.
- `TokenListBlock` / `DeFiListBlock`: manual refresh now passes `skipAccountsCache: true` so it always re-derives the account list instead of waiting on the TTL.
- `useAllNetwork.ts` `onFinished`: moved into the runner's `finally` (try/catch guarded). The `TabListStateUpdate isRefreshing:false` signal — consumed by DeFi's `runAfterTokensDone` — is now always emitted, even when the work above threw before reaching the prior call site. DeFi no longer sits on the 30s fallback when the token fetch errors.

## Why per-event invalidation (not "HW first connect only")
`AddDBAccountsToWallet` fires for every account write — HW first connect, HD first creation, manual account add, batch fill — and they all need the same "just-added accounts visible immediately on home" guarantee. `runWithQueue`'s existing coalesce already collapses the HW-connect storm of ~7 emissions into ~2 actual fan-outs (first emit triggers a fetch, mid-batch emits hit `isFetching=true` and merge into a single trailing rerun), so a special-case path for HW first connect would add complexity without meaningful savings.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension / Mobile / Desktop / Web (all Home tab consumers in All Networks mode)
- **Risk Areas**:
  - `runWithQueue` rerun-config merge now carries the new `skipAccountsCache` flag — verified via OR-merge that newer manual-refresh intent is not lost when coalescing with a queued AddDB rerun
  - Moving `onFinished` to `finally` causes it to fire even on error paths inside the runner. `TokenListBlock` / `DeFiListBlock` `handleAllNetworkRequestsFinished` are pure event emits and idempotent. DeFi additionally clears `isForceRefreshRef.current = false`, which is only consumed by single-network mode (where `finally` already cleared it via the inner `try/finally`); All Networks mode does not consume `isForceRefreshRef`, so no regression
  - `skipAccountsCacheRef` is a single-shot ref; under concurrent deps-triggered re-run a manual-refresh request can lose its skip flag (worst case: falls back to TTL behavior, no data corruption). Documented as a follow-up
- **Out of scope (separate follow-ups)**:
  - DeFi force-refresh scheduler in MV3 extension SW (in-memory `setTimeout` lost on SW teardown)
  - `_runDeFiForceRefresh` `console.error` → `defaultLogger`

## Test plan
- [ ] Connect a fresh HW wallet → land on Wallet Home with All Networks selected → Spot tab shows BTC → EVM → TRON → SOL **progressively** without manual refresh; DeFi tab shows positions immediately after the All Networks fetch completes (no 30s fallback wait)
- [ ] Same flow but stay on Spot tab → switch to DeFi tab after HW batch finishes → DeFi already shows the correct All Networks data (the new `alwaysSetState` path)
- [ ] Manually add a single new account on Solana to an existing HW wallet → home Spot list updates within ~1s, no need to wait 15s TTL
- [ ] Manual refresh button on Spot / DeFi (header refresh) → forces a fresh account-list re-derive (network tab shows new fetch even within 15s of last fetch)
- [ ] Switch wallets / accounts repeatedly → no stuck loading state, no flicker between batches
- [ ] Single network mode (not All Networks): unchanged behavior
- [ ] Inject a throw in `TokenListBlock`'s `handleAllNetworkRequestsStarted` (e.g. mock `simpleDb.aggregateToken.getRawData()` to reject once) → Tokens tab still emits `TabListStateUpdate isRefreshing:false`, DeFi's `runAfterTokensDone` fires immediately rather than after 30s
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
