### PR TITLE
fix(perps): forward spot display labels to TradingView for chart top-bar and order popover (OK-53630)

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
@@ -39,6 +39,9 @@ import type { WebViewNavigation } from 'react-native-webview/lib/WebViewTypes';
 
 interface IBaseTradingViewPerpsV2Props {
   symbol: string;
+  // Spot-only normalized labels; perp omits and the TV side falls back to symbol.
+  displayPair?: string;
+  displayCoin?: string;
   userAddress: IHex | undefined | null;
   webviewKey?: string;
   onLoadEnd?: () => void;
@@ -53,10 +56,14 @@ export type ITradingViewPerpsV2Props = IBaseTradingViewPerpsV2Props &
 const useSymbolSync = ({
   webRef,
   symbol,
+  displayPair,
+  displayCoin,
   isChartReady,
 }: {
   webRef: React.RefObject<IWebViewRef | null>;
   symbol: string;
+  displayPair: string | undefined;
+  displayCoin: string | undefined;
   isChartReady: boolean;
 }) => {
   const prevSymbolRef = useRef<string>(symbol);
@@ -71,13 +78,15 @@ const useSymbolSync = ({
         type: 'SYMBOL_CHANGE',
         payload: {
           symbol,
+          displayPair,
+          displayCoin,
           force: true,
         },
       });
 
       prevSymbolRef.current = symbol;
     }
-  }, [symbol, webRef]);
+  }, [symbol, displayPair, displayCoin, webRef]);
 
   // Re-sync symbol when chart becomes ready to catch messages lost during iframe load
   useEffect(() => {
@@ -86,11 +95,13 @@ const useSymbolSync = ({
         type: 'SYMBOL_CHANGE',
         payload: {
           symbol,
+          displayPair,
+          displayCoin,
           force: false,
         },
       });
     }
-  }, [isChartReady, symbol, webRef]);
+  }, [isChartReady, symbol, displayPair, displayCoin, webRef]);
 };
 
 // WebView Memoized component to prevent unnecessary re-renders
@@ -134,6 +145,8 @@ export function TradingViewPerpsV2(
 ) {
   const {
     symbol,
+    displayPair,
+    displayCoin,
     userAddress,
     onLoadEnd,
     onTradeUpdate,
@@ -200,6 +213,8 @@ export function TradingViewPerpsV2(
   useSymbolSync({
     webRef,
     symbol,
+    displayPair,
+    displayCoin,
     isChartReady: isChartLinesReady,
   });
 

--- a/packages/kit/src/views/Perp/components/PerpCandles.tsx
+++ b/packages/kit/src/views/Perp/components/PerpCandles.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { DebugRenderTracker, Stack, usePageWidth } from '@onekeyhq/components';
 import { TradingViewPerpsV2 } from '@onekeyhq/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2';
 import { useActiveTradeInstrumentAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
@@ -6,6 +8,10 @@ import {
   usePerpsCandlesWebviewReloadHookAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import {
+  formatSpotPairDisplayName,
+  getSpotTokenDisplayName,
+} from '@onekeyhq/shared/src/utils/perpsUtils';
 
 export function PerpCandles({
   onTouchScroll,
@@ -17,6 +23,20 @@ export function PerpCandles({
   const [{ reloadHook }] = usePerpsCandlesWebviewReloadHookAtom();
   const width = usePageWidth();
 
+  const { displayPair, displayCoin } = useMemo(() => {
+    if (
+      activeTradeInstrument.mode !== 'spot' ||
+      !activeTradeInstrument.universe
+    ) {
+      return { displayPair: undefined, displayCoin: undefined };
+    }
+    const { baseName, quoteName } = activeTradeInstrument.universe;
+    return {
+      displayPair: formatSpotPairDisplayName(baseName, quoteName),
+      displayCoin: getSpotTokenDisplayName(baseName),
+    };
+  }, [activeTradeInstrument]);
+
   const content = (
     <Stack w="100%" h="100%" flex={1} pr={6}>
       {reloadHook > 0 && activeTradeInstrument.coin ? (
@@ -24,6 +44,8 @@ export function PerpCandles({
           webviewKey={reloadHook.toString()}
           userAddress={currentAccount?.accountAddress}
           symbol={activeTradeInstrument.coin}
+          displayPair={displayPair}
+          displayCoin={displayCoin}
           w={platformEnv.isNative ? width : undefined}
           onTouchScroll={onTouchScroll}
         />


### PR DESCRIPTION
## Summary
- Spot tokens (\`@149\`, \`UETH\`, \`PURR/USDC\`) were leaking raw HL identifiers into the embedded TradingView chart top-bar / description / order popover; this PR forwards normalized display labels so the chart matches the official Hyperliquid UI
- Adds \`displayPair\` (e.g. \`HYPE/USDC\`) and \`displayCoin\` (e.g. \`HYPE\`) to the existing \`SYMBOL_CHANGE\` postMessage payload

## Intent & Context
QA reported (OK-53630) that the K-line chart for spot pairs shows raw datafeed strings rather than the user-friendly labels visible everywhere else in the app. This is the host-side half of the fix — the receiving end lives in the TV submodule (separate PR, must merge together).

## Root Cause
\`TradingViewPerpsV2\` only sent \`{ symbol, force }\` to the iframe. The TV widget's \`resolveSymbol\` then used \`symbol\` directly as both the chart's display name and the canonical key for the price cache + WS subscription, so the raw HL coin id was the only thing the chart could ever paint.

## Design Decisions
- **Compute labels at the call site** (\`PerpCandles\`) where \`activeTradeInstrument.universe\` is already on hand — \`baseName\`/\`quoteName\` go through \`getSpotTokenDisplayName\` (UETH→ETH) and \`formatSpotPairDisplayName\` (\`\${base}/\${quote}\`).
- **Perp passes both fields as \`undefined\`** — the TV side falls back to the raw symbol, which already matches what users expect (\`BTC\`, \`ETH\`).
- **Defer URL update on spot until the universe is loaded** is handled in the existing \`useSymbolSync\` flow; this PR only adds the new payload fields and wires them through.

## Changes Detail
- \`packages/kit/src/views/Perp/components/PerpCandles.tsx\` — derive \`{ displayPair, displayCoin }\` from \`activeTradeInstrument.universe\` for spot mode (perp returns \`{}\`); pass to \`TradingViewPerpsV2\`.
- \`packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx\` — accept new props, include them in \`useSymbolSync\` payload (both the symbol-change and chart-ready re-sync messages).

## Cross-Repo Coordination
This change is **paired with the TV submodule PR**:
- TV: https://github.com/OneKeyHQ/tradingview-charting-library/pull/144

Both PRs must be merged together. The TV bundle redeploy lands the new \`SYMBOL_CHANGE\` payload handling, and this PR starts sending the labels. Order-of-merge is not strict (each side back-compat with the other), but releasing them together avoids any visible window where labels are sent but not consumed (or vice versa).

## Risk Assessment
- **Risk Level**: Low (host-side change is purely additive — extra fields on an existing message; missing handler on TV side just falls back to raw, no crash)
- **Affected Platforms**: Web / Desktop / Mobile (anywhere the embedded TV chart loads)
- **Risk Areas**: Spot universe missing during initial mount → \`displayPair\`/\`displayCoin\` are \`undefined\`, message still sent, TV falls back to raw — no breakage

## Test plan
- [ ] Open spot HYPE/USDC: chart top-bar shows \`HYPE/USDC\`, right-click order popover quantity unit shows \`HYPE\`
- [ ] Open spot UETH variant (display ETH): top-bar \`ETH/USDC\`, popover unit \`ETH\`
- [ ] Switch from spot → perp BTC: top-bar updates to \`BTC\`, popover unit \`BTC\` (no stale spot label)
- [ ] Switch perp → spot → perp multiple times: each switch lands the right labels
- [ ] Drag chart price line to submit a limit order: HL receives the raw coin (\`@149\` / \`BTC\`), order succeeds
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
