### PR TITLE
chore: sync release/v6.2.0 to x

### DIFF
--- a/packages/kit-bg/src/services/ServiceHistory.ts
+++ b/packages/kit-bg/src/services/ServiceHistory.ts
@@ -1242,6 +1242,71 @@ class ServiceHistory extends ServiceBase {
   }
 
   @backgroundMethod()
+  public async clearLocalHistoryPendingTxByTxId(params: {
+    accountId?: string;
+    networkId: string;
+    txid?: string;
+    accountAddress?: string;
+  }) {
+    const { accountId, networkId, txid } = params;
+    if (!networkId || !txid) {
+      return false;
+    }
+
+    let accountAddress = params.accountAddress;
+    let xpub: string | undefined;
+    if (accountId) {
+      try {
+        [accountAddress, xpub] = await Promise.all([
+          this.backgroundApi.serviceAccount.getAccountAddressForApi({
+            accountId,
+            networkId,
+          }),
+          this.backgroundApi.serviceAccount.getAccountXpub({
+            accountId,
+            networkId,
+          }),
+        ]);
+      } catch (_e) {
+        // fall back to the caller-provided account address
+      }
+    }
+
+    if (!accountAddress && !xpub) {
+      return false;
+    }
+
+    const localHistoryPendingTxs = await this.getAccountLocalHistoryPendingTxs({
+      networkId,
+      accountAddress: accountAddress ?? '',
+      xpub,
+    });
+    const shouldIgnoreTxIdCase = networkUtils.isEvmNetwork({ networkId });
+    const txidForCompare = shouldIgnoreTxIdCase ? txid.toLowerCase() : txid;
+    const pendingTxsToClear = localHistoryPendingTxs.filter((tx) => {
+      const pendingTxId = tx.decodedTx.txid;
+      return (
+        (shouldIgnoreTxIdCase ? pendingTxId?.toLowerCase() : pendingTxId) ===
+        txidForCompare
+      );
+    });
+    if (!pendingTxsToClear.length) {
+      return false;
+    }
+
+    await simpleDb.localHistory.batchUpdateLocalHistoryTxs([
+      {
+        networkId,
+        accountAddress: accountAddress ?? '',
+        xpub,
+        confirmedTxs: pendingTxsToClear,
+      },
+    ]);
+    appEventBus.emit(EAppEventBusNames.HistoryTxStatusChanged, undefined);
+    return true;
+  }
+
+  @backgroundMethod()
   public async clearLocalHistory() {
     return this.backgroundApi.simpleDb.localHistory.clearLocalHistory();
   }

--- a/packages/kit-bg/src/services/ServiceSetting.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.ts
@@ -75,6 +75,7 @@ import ServiceBase from './ServiceBase';
 import type { ISimpleDBAppStatus } from '../dbs/simple/entity/SimpleDbEntityAppStatus';
 import type ProviderApiPrivate from '../providers/ProviderApiPrivate';
 import type { IDesktopBluetoothAtom } from '../states/jotai/atoms';
+import type { INewBrowserTabPosition } from '../states/jotai/atoms/settings';
 
 export type IAccountDerivationConfigItem = {
   num: number;
@@ -728,6 +729,15 @@ class ServiceSetting extends ServiceBase {
     const { enableMenuBarTray } = await settingsPersistAtom.get();
     // Fall back to true to match settingsAtomInitialValue for upgrades.
     return enableMenuBarTray ?? true;
+  }
+
+  @backgroundMethod()
+  public async setNewBrowserTabPosition(value: INewBrowserTabPosition) {
+    await settingsPersistAtom.set((prev) =>
+      prev.newBrowserTabPosition === value
+        ? prev
+        : { ...prev, newBrowserTabPosition: value },
+    );
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -90,7 +90,6 @@ import type {
 import {
   EProtocolOfExchange,
   ESwapApproveTransactionStatus,
-  ESwapCrossChainStatus,
   ESwapDirectionType,
   ESwapFetchCancelCause,
   ESwapLimitOrderStatus,
@@ -108,6 +107,10 @@ import { vaultFactory } from '../vaults/factory';
 
 import ServiceBase from './ServiceBase';
 import { buildSpeedSwapTxParams } from './utils/buildSpeedSwapTxParams';
+import {
+  shouldEmitSwapHistoryBalanceUpdate,
+  shouldUpdateSwapHistoryAfterTxState,
+} from './utils/swapHistoryStatusUtils';
 
 import type { IAllNetworkAccountInfo } from './ServiceAllNetwork/ServiceAllNetwork';
 
@@ -1387,18 +1390,48 @@ export default class ServiceSwap extends ServiceBase {
     return histories.toSorted((a, b) => b.date.created - a.date.created);
   }
 
+  private isSwapHistoryPendingStatus(history: ISwapTxHistory) {
+    return (
+      history.status === ESwapTxHistoryStatus.PENDING ||
+      history.status === ESwapTxHistoryStatus.CANCELING
+    );
+  }
+
   @backgroundMethod()
   async syncSwapHistoryPendingList() {
     const histories = await this.fetchSwapHistoryListFromSimple();
-    const pendingHistories = histories.filter(
-      (history) =>
-        history.status === ESwapTxHistoryStatus.PENDING ||
-        history.status === ESwapTxHistoryStatus.CANCELING,
+    const pendingHistories = histories.filter((history) =>
+      this.isSwapHistoryPendingStatus(history),
     );
     await inAppNotificationAtom.set((pre) => ({
       ...pre,
       swapHistoryPendingList: filterSwapHistoryPendingList(pendingHistories),
     }));
+  }
+
+  @backgroundMethod()
+  async refreshSwapHistoryPendingStatusOnce() {
+    const histories = await this.fetchSwapHistoryListFromSimple();
+    const pendingHistories = histories.filter((history) =>
+      this.isSwapHistoryPendingStatus(history),
+    );
+    await inAppNotificationAtom.set((pre) => ({
+      ...pre,
+      swapHistoryPendingList: filterSwapHistoryPendingList(pendingHistories),
+    }));
+
+    if (!pendingHistories.length) {
+      return;
+    }
+
+    await Promise.all(
+      pendingHistories.map((swapTxHistory) =>
+        this.swapHistoryStatusRunFetch(swapTxHistory, {
+          shouldScheduleNextFetch: false,
+          shouldShowToast: false,
+        }),
+      ),
+    );
   }
 
   @backgroundMethod()
@@ -1485,8 +1518,12 @@ export default class ServiceSwap extends ServiceBase {
   }
 
   @backgroundMethod()
-  async updateSwapHistoryItem(item: ISwapTxHistory) {
+  async updateSwapHistoryItem(
+    item: ISwapTxHistory,
+    options?: { shouldShowToast?: boolean },
+  ) {
     const { swapHistoryPendingList } = await inAppNotificationAtom.get();
+    const shouldShowToast = options?.shouldShowToast ?? true;
     const filteredList = filterSwapHistoryPendingList(swapHistoryPendingList);
     const matchFn = (i: ISwapTxHistory) =>
       item.txInfo.useOrderId
@@ -1526,7 +1563,7 @@ export default class ServiceSwap extends ServiceBase {
           swapHistoryPendingList: newPendingList,
         };
       });
-      if (item.status !== ESwapTxHistoryStatus.PENDING) {
+      if (shouldShowToast && item.status !== ESwapTxHistoryStatus.PENDING) {
         let fromAmountFinal = item.baseInfo.fromAmount;
         if (item.swapInfo.otherFeeInfos?.length) {
           item.swapInfo.otherFeeInfos.forEach((extraFeeInfo) => {
@@ -1634,8 +1671,36 @@ export default class ServiceSwap extends ServiceBase {
     }
   }
 
-  async swapHistoryStatusRunFetch(swapTxHistory: ISwapTxHistory) {
+  private async clearLocalPendingTxForTerminalSwap(
+    swapTxHistory: ISwapTxHistory,
+  ) {
+    const txId = swapTxHistory.txInfo.txId;
+    if (!txId) {
+      return;
+    }
+
+    try {
+      await this.backgroundApi.serviceHistory.clearLocalHistoryPendingTxByTxId({
+        accountId: swapTxHistory.accountInfo.sender.accountId,
+        networkId: swapTxHistory.baseInfo.fromToken.networkId,
+        txid: txId,
+        accountAddress: swapTxHistory.txInfo.sender,
+      });
+    } catch (error) {
+      console.error('Clear swap local pending tx error', error);
+    }
+  }
+
+  async swapHistoryStatusRunFetch(
+    swapTxHistory: ISwapTxHistory,
+    options?: {
+      shouldScheduleNextFetch?: boolean;
+      shouldShowToast?: boolean;
+    },
+  ) {
     let enableInterval = true;
+    const shouldScheduleNextFetch = options?.shouldScheduleNextFetch ?? true;
+    const shouldShowToast = options?.shouldShowToast ?? true;
     let currentSwapTxHistory = cloneDeep(swapTxHistory);
     try {
       const txStatusRes = await this.fetchTxState({
@@ -1652,13 +1717,19 @@ export default class ServiceSwap extends ServiceBase {
         orderId: currentSwapTxHistory.swapInfo.orderId,
       });
       if (
-        txStatusRes?.state !== ESwapTxHistoryStatus.PENDING ||
-        txStatusRes.crossChainStatus !== currentSwapTxHistory.crossChainStatus
+        shouldUpdateSwapHistoryAfterTxState({
+          swapTxHistory: currentSwapTxHistory,
+          txStatusRes,
+        })
       ) {
+        const rawStatus = txStatusRes.state;
+        const previousStateDetail = currentSwapTxHistory.stateDetail;
         currentSwapTxHistory = {
           ...currentSwapTxHistory,
-          status: txStatusRes.state,
+          status: rawStatus,
           extraStatus: txStatusRes.extraStatus,
+          stateDetail:
+            txStatusRes.stateDetail ?? currentSwapTxHistory.stateDetail,
           swapInfo: {
             ...currentSwapTxHistory.swapInfo,
             surplus:
@@ -1690,22 +1761,27 @@ export default class ServiceSwap extends ServiceBase {
               : currentSwapTxHistory.baseInfo.toAmount,
           },
         };
-        await this.updateSwapHistoryItem(currentSwapTxHistory);
+        await this.updateSwapHistoryItem(currentSwapTxHistory, {
+          shouldShowToast,
+        });
+        const finalStatus = currentSwapTxHistory.status;
         if (
-          currentSwapTxHistory.crossChainStatus ===
-            ESwapCrossChainStatus.FROM_SUCCESS ||
-          currentSwapTxHistory.crossChainStatus ===
-            ESwapCrossChainStatus.TO_SUCCESS ||
-          currentSwapTxHistory.crossChainStatus ===
-            ESwapCrossChainStatus.REFUNDED ||
-          (!currentSwapTxHistory.crossChainStatus &&
-            (txStatusRes?.state === ESwapTxHistoryStatus.SUCCESS ||
-              txStatusRes?.state === ESwapTxHistoryStatus.PARTIALLY_FILLED))
+          finalStatus === ESwapTxHistoryStatus.FAILED ||
+          finalStatus === ESwapTxHistoryStatus.CANCELED
+        ) {
+          await this.clearLocalPendingTxForTerminalSwap(currentSwapTxHistory);
+        }
+        if (
+          shouldEmitSwapHistoryBalanceUpdate({
+            swapTxHistory: currentSwapTxHistory,
+            txStatusRes,
+            previousStateDetail,
+          })
         ) {
           appEventBus.emit(EAppEventBusNames.SwapTxHistoryStatusUpdate, {
             fromToken: currentSwapTxHistory.baseInfo.fromToken,
             toToken: currentSwapTxHistory.baseInfo.toToken,
-            status: txStatusRes.state,
+            status: rawStatus,
             crossChainStatus: txStatusRes.crossChainStatus,
           });
           appEventBus.emit(EAppEventBusNames.SwapSpeedBalanceUpdate, {
@@ -1713,7 +1789,7 @@ export default class ServiceSwap extends ServiceBase {
             orderToToken: currentSwapTxHistory.baseInfo.toToken,
           });
         }
-        if (txStatusRes?.state !== ESwapTxHistoryStatus.PENDING) {
+        if (finalStatus !== ESwapTxHistoryStatus.PENDING) {
           enableInterval = false;
           const deleteHistoryId = currentSwapTxHistory.txInfo.useOrderId
             ? (currentSwapTxHistory.txInfo.orderId ?? '')
@@ -1730,6 +1806,7 @@ export default class ServiceSwap extends ServiceBase {
         : (currentSwapTxHistory.txInfo.txId ?? '');
       if (
         enableInterval &&
+        shouldScheduleNextFetch &&
         this.historyCurrentStateIntervalIds.includes(keyId)
       ) {
         this.historyStateIntervalCountMap[keyId] =
@@ -1754,11 +1831,7 @@ export default class ServiceSwap extends ServiceBase {
     const { swapHistoryPendingList } = await inAppNotificationAtom.get();
     const statusPendingList = filterSwapHistoryPendingList(
       swapHistoryPendingList,
-    ).filter(
-      (item) =>
-        item.status === ESwapTxHistoryStatus.PENDING ||
-        item.status === ESwapTxHistoryStatus.CANCELING,
-    );
+    ).filter((item) => this.isSwapHistoryPendingStatus(item));
     const newHistoryStatePendingList = statusPendingList.filter(
       (item) =>
         !this.historyCurrentStateIntervalIds.includes(

--- a/packages/kit-bg/src/services/utils/swapHistoryStatusUtils.ts
+++ b/packages/kit-bg/src/services/utils/swapHistoryStatusUtils.ts
@@ -1,0 +1,100 @@
+import type {
+  IFetchSwapTxHistoryStatusResponse,
+  ISwapTxHistory,
+} from '@onekeyhq/shared/types/swap/types';
+import {
+  ESwapCrossChainStatus,
+  ESwapTxHistoryStatus,
+} from '@onekeyhq/shared/types/swap/types';
+
+const HOUDINI_SWAP_PROVIDER = 'SwapHoudi';
+
+const HOUDINI_SOURCE_TOKEN_SENT_STATE_DETAIL = 'CONFIRMING';
+const HOUDINI_REFUNDED_STATE_DETAIL = 'REFUNDED';
+
+const BALANCE_REFRESH_CROSS_CHAIN_STATUSES = new Set<ESwapCrossChainStatus>([
+  ESwapCrossChainStatus.FROM_SUCCESS,
+  ESwapCrossChainStatus.TO_SUCCESS,
+  ESwapCrossChainStatus.REFUNDED,
+]);
+
+function isHoudiniSwapProvider(provider?: string) {
+  return provider === HOUDINI_SWAP_PROVIDER;
+}
+
+function isHoudiniSourceTokenSentStateDetail(stateDetail?: string) {
+  return stateDetail === HOUDINI_SOURCE_TOKEN_SENT_STATE_DETAIL;
+}
+
+function isHoudiniRefundedStateDetail(stateDetail?: string) {
+  return stateDetail === HOUDINI_REFUNDED_STATE_DETAIL;
+}
+
+function shouldTrackHoudiniStateDetailChange({
+  swapTxHistory,
+  txStatusRes,
+}: {
+  swapTxHistory: ISwapTxHistory;
+  txStatusRes: IFetchSwapTxHistoryStatusResponse;
+}) {
+  return (
+    isHoudiniSwapProvider(swapTxHistory.swapInfo.provider.provider) &&
+    Boolean(txStatusRes.stateDetail) &&
+    txStatusRes.stateDetail !== swapTxHistory.stateDetail
+  );
+}
+
+export function shouldUpdateSwapHistoryAfterTxState({
+  swapTxHistory,
+  txStatusRes,
+}: {
+  swapTxHistory: ISwapTxHistory;
+  txStatusRes: IFetchSwapTxHistoryStatusResponse;
+}) {
+  return (
+    txStatusRes.state !== ESwapTxHistoryStatus.PENDING ||
+    txStatusRes.crossChainStatus !== swapTxHistory.crossChainStatus ||
+    shouldTrackHoudiniStateDetailChange({ swapTxHistory, txStatusRes })
+  );
+}
+
+export function shouldEmitSwapHistoryBalanceUpdate({
+  swapTxHistory,
+  txStatusRes,
+  previousStateDetail,
+}: {
+  swapTxHistory: ISwapTxHistory;
+  txStatusRes: IFetchSwapTxHistoryStatusResponse;
+  previousStateDetail?: string;
+}) {
+  const finalStateWithoutCrossChainStatus =
+    !swapTxHistory.crossChainStatus &&
+    (txStatusRes.state === ESwapTxHistoryStatus.SUCCESS ||
+      txStatusRes.state === ESwapTxHistoryStatus.PARTIALLY_FILLED);
+
+  const crossChainStatusShouldRefresh = swapTxHistory.crossChainStatus
+    ? BALANCE_REFRESH_CROSS_CHAIN_STATUSES.has(swapTxHistory.crossChainStatus)
+    : false;
+
+  if (crossChainStatusShouldRefresh || finalStateWithoutCrossChainStatus) {
+    return true;
+  }
+
+  if (!isHoudiniSwapProvider(swapTxHistory.swapInfo.provider.provider)) {
+    return false;
+  }
+
+  const nextStateDetail = txStatusRes.stateDetail;
+  if (!nextStateDetail || previousStateDetail === nextStateDetail) {
+    return false;
+  }
+
+  const sourceTokenSentJustDetected =
+    !isHoudiniSourceTokenSentStateDetail(previousStateDetail) &&
+    isHoudiniSourceTokenSentStateDetail(nextStateDetail);
+  const refundJustDetected =
+    !isHoudiniRefundedStateDetail(previousStateDetail) &&
+    isHoudiniRefundedStateDetail(nextStateDetail);
+
+  return sourceTokenSentJustDetected || refundJustDetected;
+}

--- a/packages/kit-bg/src/states/jotai/atoms/settings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/settings.ts
@@ -12,6 +12,8 @@ import { globalAtom } from '../utils';
 
 export type IEndpointType = 'prod' | 'test';
 
+export type INewBrowserTabPosition = 'top' | 'bottom';
+
 // don't use deviceUtils.getDefaultHardwareTransportType(), it will cause resource export order conflict
 function getDefaultHardwareTransportType(): EHardwareTransportType {
   if (platformEnv.isNative) {
@@ -69,6 +71,7 @@ export type ISettingsPersistAtom = {
   enableDesktopBluetooth?: boolean;
   enableBTCFreshAddress?: boolean;
   enableMenuBarTray?: boolean;
+  newBrowserTabPosition?: INewBrowserTabPosition;
 };
 
 export const settingsAtomInitialValue: ISettingsPersistAtom = {
@@ -106,6 +109,7 @@ export const settingsAtomInitialValue: ISettingsPersistAtom = {
   enableDesktopBluetooth: true,
   enableBTCFreshAddress: true,
   enableMenuBarTray: true,
+  newBrowserTabPosition: 'bottom',
 };
 export const { target: settingsPersistAtom, use: useSettingsPersistAtom } =
   globalAtom<ISettingsPersistAtom>({

--- a/packages/kit/src/states/jotai/contexts/discovery/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/discovery/actions.ts
@@ -25,6 +25,8 @@ import {
   processWebSiteUrl,
   webviewRefs,
 } from '@onekeyhq/kit/src/views/Discovery/utils/explorerUtils';
+import { settingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { jotaiDefaultStore } from '@onekeyhq/kit-bg/src/states/jotai/utils/jotaiDefaultStore';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import {
   EAppEventBusNames,
@@ -65,7 +67,38 @@ function loggerForEmptyData(tabs: IWebTab[], fnName: string) {
   }
 }
 
+// Gap between timestamps when placing a tab above the current unpinned min.
+// Must exceed the drag-reorder midpoint precision: `onDragEnd` inserts
+// `Math.round((a + b) / 2)`, so a 1ms gap collapses to the neighbor and
+// produces duplicate timestamps that destabilize sort order.
+const TOP_POSITION_TIMESTAMP_GAP = 1000;
+
+// Lowest timestamp among unpinned tabs; callers subtract a gap to sort above them.
+function getMinUnpinnedTimestamp(tabs: IWebTab[], excludeId?: string) {
+  return tabs
+    .filter(
+      (t) => !t.isPinned && t.timestamp && (!excludeId || t.id !== excludeId),
+    )
+    .reduce(
+      (min, t) => Math.min(min, t.timestamp ?? min),
+      Number.MAX_SAFE_INTEGER,
+    );
+}
+
+function isNewTabPositionTop() {
+  return (
+    platformEnv.isDesktop &&
+    jotaiDefaultStore.get(settingsPersistAtom.atom()).newBrowserTabPosition ===
+      'top'
+  );
+}
+
 export const homeResettingFlags: Record<string, number> = {};
+
+// Tracks last navigation time per tab id for the 500ms redirect-loop
+// debounce in `onNavigation`. Decoupled from `tab.timestamp` because the
+// latter also drives sidebar sort order (`top` mode freezes it on creation).
+export const lastNavigationFlags: Record<string, number> = {};
 
 function buildWebTabData(tabs: IWebTab[]) {
   const map: Record<string, IWebTab> = {};
@@ -229,7 +262,15 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
     if (!payload.id || payload.id === homeTab.id) {
       payload.id = generateUUID();
     }
-    payload.timestamp = Date.now();
+    if (isNewTabPositionTop()) {
+      const minTs = getMinUnpinnedTimestamp(tabs);
+      payload.timestamp =
+        minTs < Number.MAX_SAFE_INTEGER
+          ? minTs - TOP_POSITION_TIMESTAMP_GAP
+          : Date.now();
+    } else {
+      payload.timestamp = Date.now();
+    }
     this.buildWebTabs.call(set, { data: [...tabs, payload as IWebTab] });
     this.setCurrentWebTab.call(set, payload.id ?? '');
     const endTime = performance.now();
@@ -275,9 +316,18 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
           // @ts-expect-error
           tabToModify[key] = value;
           if (key === 'url') {
-            tabToModify.timestamp = Date.now();
+            // Navigation normally bumps timestamp to Date.now(), which
+            // re-sorts the tab to the bottom. Skip when the user chose
+            // 'top' so the tab stays where it was created. Record the
+            // navigation time separately for the onNavigation debounce.
+            if (!isNewTabPositionTop()) {
+              tabToModify.timestamp = Date.now();
+            }
+            if (payload.id) {
+              lastNavigationFlags[payload.id] = Date.now();
+            }
             if (value === 'about:blank' && payload.id) {
-              homeResettingFlags[payload.id] = tabToModify.timestamp;
+              homeResettingFlags[payload.id] = Date.now();
             }
           }
         }
@@ -467,14 +517,9 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
       // When unpinning, place the tab at the top of the unpinned list
       if (!payload.pinned) {
         const allTabs = get(webTabsAtom())?.tabs ?? [];
-        const minUnpinnedTimestamp = allTabs
-          .filter((t) => !t.isPinned && t.id !== payload.id && t.timestamp)
-          .reduce(
-            (min, t) => Math.min(min, t.timestamp ?? min),
-            Number.MAX_SAFE_INTEGER,
-          );
-        if (minUnpinnedTimestamp < Number.MAX_SAFE_INTEGER) {
-          timestamp = minUnpinnedTimestamp - 1;
+        const minTs = getMinUnpinnedTimestamp(allTabs, payload.id);
+        if (minTs < Number.MAX_SAFE_INTEGER) {
+          timestamp = minTs - TOP_POSITION_TIMESTAMP_GAP;
         }
       }
       this.setWebTabData.call(set, {
@@ -980,7 +1025,8 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
       }
 
       if (isValidNewUrl) {
-        if (tab.timestamp && now - tab.timestamp < 500) {
+        const lastNav = lastNavigationFlags[tab.id];
+        if (lastNav && now - lastNav < 500) {
           // ignore url change if it's too fast to avoid back & forth loop
           return;
         }

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -86,7 +86,10 @@ import {
   swapProTradeTypeAtom,
   swapProUseSelectBuyTokenAtom,
   swapQuoteActionLockAtom,
+  swapQuoteCurrentEventProviderKeysAtom,
+  swapQuoteCurrentEventReceivedCountAtom,
   swapQuoteCurrentSelectAtom,
+  swapQuoteEventCompletedAtom,
   swapQuoteEventErrorAtom,
   swapQuoteEventTotalCountAtom,
   swapQuoteFetchingAtom,
@@ -107,6 +110,11 @@ import {
   swapTokenMetadataAtom,
   swapTypeSwitchAtom,
 } from './atoms';
+import {
+  buildSwapQuoteProviderKey,
+  getSwapQuoteProgressState,
+  isSwapQuoteEventFetching,
+} from './quoteProgress';
 
 class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
   private quoteInterval: ReturnType<typeof setTimeout> | undefined;
@@ -189,6 +197,26 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
 
   cleanManualSelectQuoteProviders = contextAtomMethod((get, set) => {
     set(swapManualSelectQuoteProvidersAtom(), undefined);
+  });
+
+  reconcileManualSelectQuoteProviders = contextAtomMethod((get, set) => {
+    const selectionIntent = get(swapManualSelectQuoteProvidersAtom());
+    if (selectionIntent?.type !== 'manual-provider') {
+      return;
+    }
+
+    const currentEventProviderKeys = get(
+      swapQuoteCurrentEventProviderKeysAtom(),
+    );
+    const quoteEventTotalCount = get(swapQuoteEventTotalCountAtom());
+    if (
+      quoteEventTotalCount.count === 0 ||
+      !currentEventProviderKeys.includes(
+        buildSwapQuoteProviderKey(selectionIntent),
+      )
+    ) {
+      set(swapManualSelectQuoteProvidersAtom(), undefined);
+    }
   });
 
   catchSwapTokensMap = contextAtomMethod(
@@ -516,9 +544,18 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
               }
             : {}),
         });
+        const currentEventProviderKeys = res.map((quote) =>
+          buildSwapQuoteProviderKey(quote),
+        );
         if (!loadingDelayEnable) {
           set(swapQuoteFetchingAtom(), false);
           set(swapQuoteListAtom(), res);
+          set(
+            swapQuoteCurrentEventProviderKeysAtom(),
+            currentEventProviderKeys,
+          );
+          set(swapQuoteCurrentEventReceivedCountAtom(), res.length);
+          set(swapQuoteEventCompletedAtom(), true);
           set(swapQuoteEventTotalCountAtom(), {
             count: res.length,
           });
@@ -527,6 +564,12 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
           setTimeout(() => {
             set(swapSilenceQuoteLoading(), false);
             set(swapQuoteListAtom(), res);
+            set(
+              swapQuoteCurrentEventProviderKeysAtom(),
+              currentEventProviderKeys,
+            );
+            set(swapQuoteCurrentEventReceivedCountAtom(), res.length);
+            set(swapQuoteEventCompletedAtom(), true);
             set(swapQuoteEventTotalCountAtom(), {
               count: res.length,
             });
@@ -566,15 +609,25 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
             const errorData = dataJson as ISwapQuoteEventError;
             if (errorData?.errorMessage) {
               set(swapQuoteListAtom(), []);
+              set(swapQuoteCurrentEventProviderKeysAtom(), []);
+              set(swapQuoteCurrentEventReceivedCountAtom(), 0);
+              set(swapQuoteEventCompletedAtom(), true);
               set(swapQuoteEventTotalCountAtom(), { count: 0 });
               set(swapQuoteFetchingAtom(), false);
               set(swapQuoteEventErrorAtom(), errorData.errorMessage);
+              this.reconcileManualSelectQuoteProviders.call(set);
+              set(swapQuoteActionLockAtom(), (v) => ({
+                ...v,
+                actionLock: false,
+              }));
+              this.closeQuoteEvent();
               break;
             }
             const autoSlippageData = dataJson as ISwapQuoteEventAutoSlippage;
             if (autoSlippageData?.autoSuggestedSlippage) {
               const {
                 autoSuggestedSlippage,
+                eventId,
                 fromNetworkId,
                 fromTokenAddress,
                 toNetworkId,
@@ -597,6 +650,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
                       contractAddress: toTokenAddress,
                     },
                   }) &&
+                  quotRes.eventId === eventId &&
                   !quotRes.autoSuggestedSlippage
                 ) {
                   return {
@@ -611,12 +665,16 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
                 value: autoSuggestedSlippage,
                 from: `${fromNetworkId}-${fromTokenAddress}`,
                 to: `${toNetworkId}-${toTokenAddress}`,
+                eventId,
               });
             } else if (
               (dataJson as ISwapQuoteEventInfo).totalQuoteCount ||
               (dataJson as ISwapQuoteEventInfo).totalQuoteCount === 0
             ) {
               const { totalQuoteCount } = dataJson as ISwapQuoteEventInfo;
+              set(swapQuoteCurrentEventProviderKeysAtom(), []);
+              set(swapQuoteCurrentEventReceivedCountAtom(), 0);
+              set(swapQuoteEventCompletedAtom(), false);
               set(swapQuoteEventTotalCountAtom(), {
                 eventId: (dataJson as ISwapQuoteEventInfo).eventId,
                 count: totalQuoteCount,
@@ -648,6 +706,8 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
                         swapAutoSlippageSuggestedValue?.from &&
                       `${quote.toTokenInfo.networkId}-${quote.toTokenInfo.contractAddress}` ===
                         swapAutoSlippageSuggestedValue?.to &&
+                      quote.eventId ===
+                        swapAutoSlippageSuggestedValue?.eventId &&
                       swapAutoSlippageSuggestedValue.value &&
                       !quote.autoSuggestedSlippage
                     ) {
@@ -714,6 +774,20 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
                       quoteEventTotalCount.eventId === q.eventId,
                   );
                 set(swapQuoteListAtom(), [...newQuoteList]);
+                set(swapQuoteCurrentEventProviderKeysAtom(), (keys) => [
+                  ...new Set([
+                    ...keys,
+                    ...quoteResultData.data.map((quote) =>
+                      buildSwapQuoteProviderKey(quote),
+                    ),
+                  ]),
+                ]);
+                set(swapQuoteCurrentEventReceivedCountAtom(), (count) =>
+                  Math.min(
+                    quoteEventTotalCount.count,
+                    count + quoteResultData.data.length,
+                  ),
+                );
               }
               set(swapQuoteFetchingAtom(), false);
             }
@@ -721,6 +795,8 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
           break;
         }
         case 'done': {
+          this.reconcileManualSelectQuoteProviders.call(set);
+          set(swapQuoteEventCompletedAtom(), true);
           set(swapQuoteActionLockAtom(), (v) => ({ ...v, actionLock: false }));
           if (platformEnv.isExtension) {
             set(swapQuoteFetchingAtom(), false);
@@ -729,13 +805,15 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
           break;
         }
         case 'error': {
-          if (platformEnv.isExtension) {
-            set(swapQuoteFetchingAtom(), false);
-          }
+          this.reconcileManualSelectQuoteProviders.call(set);
+          set(swapQuoteEventCompletedAtom(), true);
+          set(swapQuoteFetchingAtom(), false);
+          set(swapQuoteActionLockAtom(), (v) => ({ ...v, actionLock: false }));
           this.closeQuoteEvent();
           break;
         }
         case 'close': {
+          set(swapQuoteEventCompletedAtom(), true);
           set(swapQuoteFetchingAtom(), false);
           set(swapQuoteActionLockAtom(), (v) => ({ ...v, actionLock: false }));
           break;
@@ -780,6 +858,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       await backgroundApiProxy.serviceSwap.closeApproving();
       set(swapQuoteEventErrorAtom(), '');
       set(swapQuoteFetchingAtom(), true);
+      set(swapQuoteEventCompletedAtom(), false);
       const limitUserMarketPrice = get(swapLimitPriceUseRateAtom());
       await backgroundApiProxy.serviceSwap.fetchQuotesEvents({
         fromToken,
@@ -812,6 +891,9 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
     const fromTokenAmount = get(swapFromTokenAmountAtom());
     const toTokenAmount = get(swapToTokenAmountAtom());
     set(swapQuoteFetchingAtom(), false);
+    set(swapQuoteCurrentEventProviderKeysAtom(), []);
+    set(swapQuoteCurrentEventReceivedCountAtom(), 0);
+    set(swapQuoteEventCompletedAtom(), false);
     set(swapQuoteEventTotalCountAtom(), {
       count: 0,
     });
@@ -890,6 +972,10 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       if (!unResetCount) {
         set(swapQuoteIntervalCountAtom(), 0);
       }
+      set(swapQuoteCurrentEventProviderKeysAtom(), []);
+      set(swapQuoteCurrentEventReceivedCountAtom(), 0);
+      set(swapQuoteEventCompletedAtom(), false);
+      set(swapQuoteEventTotalCountAtom(), { count: 0 });
       set(swapBuildTxFetchingAtom(), false);
       set(swapShouldRefreshQuoteAtom(), false);
       const fromTokenAmountNumber = Number(fromTokenAmount.value);
@@ -1165,8 +1251,23 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       const swapSupportAllNetworks = get(swapNetworksIncludeAllNetworkAtom());
       const quoteResult = get(swapQuoteCurrentSelectAtom());
       const tokenMetadata = get(swapTokenMetadataAtom());
-      const quoteResultList = get(swapQuoteListAtom());
+      const quoteLoading =
+        get(swapQuoteFetchingAtom()) || get(swapSilenceQuoteLoading());
       const quoteEventTotalCount = get(swapQuoteEventTotalCountAtom());
+      const quoteEventCompleted = get(swapQuoteEventCompletedAtom());
+      const currentEventReceivedCount = get(
+        swapQuoteCurrentEventReceivedCountAtom(),
+      );
+      const quoteEventFetching = isSwapQuoteEventFetching({
+        quoteEventTotalCount,
+        currentEventReceivedCount,
+        quoteEventCompleted,
+      });
+      const { isWaitingActionableQuote } = getSwapQuoteProgressState({
+        quoteLoading,
+        quoteEventFetching,
+        quoteCurrentSelect: quoteResult,
+      });
       const fromTokenAmount = get(swapFromTokenAmountAtom());
       let alertsRes: ISwapAlertState[] = [];
       const quoteEventError = get(swapQuoteEventErrorAtom());
@@ -1206,8 +1307,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       if (
         !networks.length ||
         !swapFromAddressInfo.accountInfo?.ready ||
-        (quoteEventTotalCount.count > 0 &&
-          quoteResultList.length < quoteEventTotalCount.count)
+        isWaitingActionableQuote
       ) {
         if (quoteEventError) {
           set(swapAlertsAtom(), {
@@ -1995,6 +2095,9 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       }
       // OK-49718: Clear quote list when switching type to prevent showing stale data
       set(swapQuoteListAtom(), []);
+      set(swapQuoteCurrentEventProviderKeysAtom(), []);
+      set(swapQuoteCurrentEventReceivedCountAtom(), 0);
+      set(swapQuoteEventCompletedAtom(), false);
       set(swapQuoteEventTotalCountAtom(), { count: 0 });
       set(swapTypeSwitchAtom(), type);
       if (platformEnv.isNative && type === ESwapTabSwitchType.LIMIT) {

--- a/packages/kit/src/states/jotai/contexts/swap/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/atoms.ts
@@ -4,10 +4,7 @@ import { ESwapDirection } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/co
 import type { IToken } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/components/SwapPanel/types';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { dangerAllNetworkRepresent } from '@onekeyhq/shared/src/config/presetNetworks';
-import {
-  selectBestQuote,
-  sortSwapQuotes,
-} from '@onekeyhq/shared/src/utils/swapQuoteSortUtils';
+import { sortSwapQuotes } from '@onekeyhq/shared/src/utils/swapQuoteSortUtils';
 import {
   checkWrappedTokenPair,
   equalTokenNoCaseSensitive,
@@ -48,6 +45,12 @@ import {
 } from '@onekeyhq/shared/types/swap/types';
 
 import { createJotaiContext } from '../../utils/createJotaiContext';
+
+import {
+  type ISwapQuoteSelectionIntent,
+  buildSwapQuoteProviderKey,
+  selectSwapCurrentQuote,
+} from './quoteProgress';
 
 import type { IAccountSelectorActiveAccountInfo } from '../accountSelector';
 
@@ -186,7 +189,7 @@ export const {
 export const {
   atom: swapManualSelectQuoteProvidersAtom,
   use: useSwapManualSelectQuoteProvidersAtom,
-} = contextAtom<IFetchQuoteResult | undefined>(undefined);
+} = contextAtom<ISwapQuoteSelectionIntent | undefined>(undefined);
 
 export const { atom: swapQuoteListAtom, use: useSwapQuoteListAtom } =
   contextAtom<IFetchQuoteResult[]>([]);
@@ -223,15 +226,45 @@ export const {
 });
 
 export const {
+  atom: swapQuoteEventCompletedAtom,
+  use: useSwapQuoteEventCompletedAtom,
+} = contextAtom<boolean>(false);
+
+export const {
+  atom: swapQuoteCurrentEventProviderKeysAtom,
+  use: useSwapQuoteCurrentEventProviderKeysAtom,
+} = contextAtom<string[]>([]);
+
+export const {
+  atom: swapQuoteCurrentEventReceivedCountAtom,
+  use: useSwapQuoteCurrentEventReceivedCountAtom,
+} = contextAtom<number>(0);
+
+export const {
   atom: swapShouldRefreshQuoteAtom,
   use: useSwapShouldRefreshQuoteAtom,
 } = contextAtom<boolean>(false);
 
 export const {
+  atom: swapQuoteCurrentEventListAtom,
+  use: useSwapQuoteCurrentEventListAtom,
+} = contextAtomComputed<IFetchQuoteResult[]>((get) => {
+  const list = get(swapQuoteListAtom());
+  const quoteEventTotalCount = get(swapQuoteEventTotalCountAtom());
+  const currentEventProviderKeys = get(swapQuoteCurrentEventProviderKeysAtom());
+  const currentEventProviderKeySet = new Set(currentEventProviderKeys);
+  return quoteEventTotalCount.count > 0
+    ? list.filter((quote) =>
+        currentEventProviderKeySet.has(buildSwapQuoteProviderKey(quote)),
+      )
+    : list;
+});
+
+export const {
   atom: swapSortedQuoteListAtom,
   use: useSwapSortedQuoteListAtom,
 } = contextAtomComputed<IFetchQuoteResult[]>((get) => {
-  const list = get(swapQuoteListAtom());
+  const list = get(swapQuoteCurrentEventListAtom());
   const fromTokenAmount = get(swapFromTokenAmountAtom());
   const sortType = get(swapProviderSortAtom());
   return sortSwapQuotes(list, {
@@ -244,10 +277,20 @@ export const {
   atom: swapQuoteCurrentSelectAtom,
   use: useSwapQuoteCurrentSelectAtom,
 } = contextAtomComputed((get) => {
-  const list = get(swapSortedQuoteListAtom());
-  const manualSelectQuoteProviders = get(swapManualSelectQuoteProvidersAtom());
-  return selectBestQuote(list, {
-    manualSelect: manualSelectQuoteProviders ?? undefined,
+  const list = get(swapQuoteCurrentEventListAtom());
+  const fromTokenAmount = get(swapFromTokenAmountAtom());
+  const selectionIntent = get(swapManualSelectQuoteProvidersAtom());
+  const quoteEventTotalCount = get(swapQuoteEventTotalCountAtom());
+  const currentEventProviderKeys = get(swapQuoteCurrentEventProviderKeysAtom());
+  const recommendedSortedList = sortSwapQuotes(list, {
+    sort: ESwapProviderSort.RECOMMENDED,
+    fromTokenAmount: fromTokenAmount.value,
+  });
+  return selectSwapCurrentQuote({
+    currentEventSortedQuotes: recommendedSortedList,
+    selectionIntent: selectionIntent ?? undefined,
+    quoteEventTotalCount,
+    currentEventProviderKeys,
   });
 });
 

--- a/packages/kit/src/states/jotai/contexts/swap/quoteProgress.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/quoteProgress.ts
@@ -1,0 +1,148 @@
+import BigNumber from 'bignumber.js';
+
+import { selectBestQuote } from '@onekeyhq/shared/src/utils/swapQuoteSortUtils';
+import type { IFetchQuoteResult } from '@onekeyhq/shared/types/swap/types';
+
+type ISwapActionableQuote = Pick<IFetchQuoteResult, 'toAmount'>;
+type ISwapQuoteProviderIdentity = Pick<
+  IFetchQuoteResult['info'],
+  'provider' | 'providerName'
+>;
+export type ISwapQuoteSelectionIntent = {
+  type: 'manual-provider';
+  info: ISwapQuoteProviderIdentity;
+};
+
+type ISwapQuoteProgressInput = {
+  quoteLoading: boolean;
+  quoteEventFetching: boolean;
+  quoteCurrentSelect?: ISwapActionableQuote;
+};
+
+type ISwapQuoteProgressState = {
+  quoteLoading: boolean;
+  quoteEventFetching: boolean;
+  hasActionableQuote: boolean;
+  isWaitingActionableQuote: boolean;
+};
+
+type ISwapQuoteEventFetchingInput = {
+  quoteEventTotalCount: {
+    count: number;
+  };
+  currentEventReceivedCount: number;
+  quoteEventCompleted: boolean;
+};
+
+type ISwapCurrentQuoteInput = {
+  currentEventSortedQuotes: IFetchQuoteResult[];
+  selectionIntent?: ISwapQuoteSelectionIntent;
+  quoteEventTotalCount: {
+    count: number;
+    eventId?: string;
+  };
+  currentEventProviderKeys: string[];
+};
+
+export function buildSwapQuoteProviderKey(quote: {
+  info: ISwapQuoteProviderIdentity;
+}) {
+  return `${quote.info.provider}-${quote.info.providerName}`;
+}
+
+export function buildSwapManualProviderSelectionIntent(
+  quote: { info: ISwapQuoteProviderIdentity } | undefined,
+): ISwapQuoteSelectionIntent | undefined {
+  if (!quote) {
+    return undefined;
+  }
+
+  return {
+    type: 'manual-provider',
+    info: {
+      provider: quote.info.provider,
+      providerName: quote.info.providerName,
+    },
+  };
+}
+
+export function hasSwapCurrentEventProvider(
+  quote: { info: ISwapQuoteProviderIdentity } | undefined,
+  currentEventProviderKeys: string[],
+) {
+  if (!quote) {
+    return false;
+  }
+
+  return currentEventProviderKeys.includes(buildSwapQuoteProviderKey(quote));
+}
+
+export function isSwapQuoteEventFetching({
+  quoteEventTotalCount,
+  currentEventReceivedCount,
+  quoteEventCompleted,
+}: ISwapQuoteEventFetchingInput) {
+  return (
+    quoteEventTotalCount.count > 0 &&
+    !quoteEventCompleted &&
+    currentEventReceivedCount < quoteEventTotalCount.count
+  );
+}
+
+export function selectSwapCurrentQuote({
+  currentEventSortedQuotes,
+  selectionIntent,
+  quoteEventTotalCount,
+  currentEventProviderKeys,
+}: ISwapCurrentQuoteInput) {
+  if (selectionIntent?.type === 'manual-provider') {
+    const manualQuote = currentEventSortedQuotes.find(
+      (quote) =>
+        buildSwapQuoteProviderKey(quote) ===
+        buildSwapQuoteProviderKey(selectionIntent),
+    );
+
+    if (manualQuote) {
+      if (isSwapQuoteActionable(manualQuote)) {
+        return manualQuote;
+      }
+
+      return (
+        selectBestQuote(
+          currentEventSortedQuotes.filter(isSwapQuoteActionable),
+        ) ?? manualQuote
+      );
+    }
+
+    if (
+      quoteEventTotalCount.count > 0 &&
+      !hasSwapCurrentEventProvider(selectionIntent, currentEventProviderKeys)
+    ) {
+      return undefined;
+    }
+  }
+
+  return selectBestQuote(currentEventSortedQuotes);
+}
+
+export function isSwapQuoteActionable(
+  quoteCurrentSelect?: ISwapActionableQuote,
+) {
+  return new BigNumber(quoteCurrentSelect?.toAmount ?? 0).gt(0);
+}
+
+export function getSwapQuoteProgressState({
+  quoteLoading,
+  quoteEventFetching,
+  quoteCurrentSelect,
+}: ISwapQuoteProgressInput): ISwapQuoteProgressState {
+  const hasActionableQuote = isSwapQuoteActionable(quoteCurrentSelect);
+
+  return {
+    quoteLoading,
+    quoteEventFetching,
+    hasActionableQuote,
+    isWaitingActionableQuote:
+      quoteLoading || (quoteEventFetching && !hasActionableQuote),
+  };
+}

--- a/packages/kit/src/views/AssetDetails/pages/HistoryDetails/HistoryDetails.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/HistoryDetails/HistoryDetails.tsx
@@ -17,7 +17,6 @@ import {
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { AddressInfo } from '@onekeyhq/kit/src/components/AddressInfo';
-import { Currency } from '@onekeyhq/kit/src/components/Currency';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import NumberSizeableTextWrapper from '@onekeyhq/kit/src/components/NumberSizeableTextWrapper';
 import { Token } from '@onekeyhq/kit/src/components/Token';
@@ -392,13 +391,7 @@ function HistoryDetails() {
           });
       }
 
-      const swapHistoryInfo =
-        await backgroundApiProxy.serviceSwap.getSwapHistoryByTxId({
-          txId: txid,
-        });
-
       return {
-        swapHistoryInfo,
         txDetails: r?.data,
         decodedOnChainTx,
         addressMap: r?.addressMap,
@@ -428,8 +421,7 @@ function HistoryDetails() {
     },
   );
 
-  const { txDetails, decodedOnChainTx, addressMap, swapHistoryInfo } =
-    result || {};
+  const { txDetails, decodedOnChainTx, addressMap } = result || {};
   const historyTx = historyTxParam ?? decodedOnChainTx;
 
   useEffect(() => {
@@ -1183,28 +1175,6 @@ function HistoryDetails() {
               compact
             />
 
-            {swapHistoryInfo?.swapInfo?.oneKeyFeeExtraInfo?.oneKeyFeeUsd ? (
-              <InfoItem
-                label={intl.formatMessage({
-                  id: ETranslations.provider_ios_popover_onekey_fee,
-                })}
-                renderContent={
-                  <Currency
-                    formatter="value"
-                    size="$bodyMd"
-                    color="$textSubdued"
-                    sourceCurrency="usd"
-                  >
-                    {
-                      swapHistoryInfo?.swapInfo?.oneKeyFeeExtraInfo
-                        ?.oneKeyFeeUsd
-                    }
-                  </Currency>
-                }
-                compact
-              />
-            ) : null}
-
             <InfoItem
               label={intl.formatMessage({
                 id: ETranslations.global_network,
@@ -1286,7 +1256,6 @@ function HistoryDetails() {
     vaultSettings?.isUtxo,
     vaultSettings?.hideTxUtxoListWhenPending,
     renderFeeInfo,
-    swapHistoryInfo?.swapInfo?.oneKeyFeeExtraInfo?.oneKeyFeeUsd,
     network?.name,
     network?.id,
     historyTx?.decodedTx.status,

--- a/packages/kit/src/views/Discovery/pages/DesktopCustomTabBar/index.tsx
+++ b/packages/kit/src/views/Discovery/pages/DesktopCustomTabBar/index.tsx
@@ -3,6 +3,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import {
+  ActionList,
   Divider,
   Icon,
   SizableText,
@@ -11,8 +12,12 @@ import {
   XStack,
   useShortcuts,
 } from '@onekeyhq/components';
-import type { ISortableListViewRef } from '@onekeyhq/components';
+import type {
+  IActionListSection,
+  ISortableListViewRef,
+} from '@onekeyhq/components';
 import type { IPageNavigationProp } from '@onekeyhq/components/src/layouts/Navigation';
+import { useBrowserSubmenu } from '@onekeyhq/components/src/layouts/Navigation/Tab/TabBar/BrowserSubmenuColumn/BrowserSubmenuContext';
 import { DesktopTabItem } from '@onekeyhq/components/src/layouts/Navigation/Tab/TabBar/DesktopTabItem';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
@@ -24,6 +29,8 @@ import {
 } from '@onekeyhq/kit/src/states/jotai/contexts/discovery';
 import { HandleRebuildBrowserData } from '@onekeyhq/kit/src/views/Discovery/components/HandleData/HandleRebuildBrowserTabData';
 import type { IWebTab } from '@onekeyhq/kit/src/views/Discovery/types';
+import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import type { INewBrowserTabPosition } from '@onekeyhq/kit-bg/src/states/jotai/atoms/settings';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -73,6 +80,70 @@ function DesktopCustomTabBar({ isExpanded }: { isExpanded?: boolean }) {
   const { addOrUpdateBrowserBookmark, removeBrowserBookmark } =
     useBrowserBookmarkAction().current;
 
+  const { reportPopoverOpen } = useBrowserSubmenu();
+  // Guard against unbalanced onOpenChange calls from the ActionList.
+  // Without this, a duplicate open / missing close would leak the popover
+  // count in BrowserSubmenuColumn and the sidebar would never collapse again.
+  const newTabMenuOpenRef = useRef(false);
+  const handleNewTabMenuOpenChange = useCallback(
+    (isOpen: boolean) => {
+      if (isOpen && !newTabMenuOpenRef.current) {
+        newTabMenuOpenRef.current = true;
+        reportPopoverOpen(true);
+      } else if (!isOpen && newTabMenuOpenRef.current) {
+        newTabMenuOpenRef.current = false;
+        reportPopoverOpen(false);
+      }
+    },
+    [reportPopoverOpen],
+  );
+  useEffect(
+    () => () => {
+      if (newTabMenuOpenRef.current) {
+        newTabMenuOpenRef.current = false;
+        reportPopoverOpen(false);
+      }
+    },
+    [reportPopoverOpen],
+  );
+  const [{ newBrowserTabPosition }] = useSettingsPersistAtom();
+  const currentTabPosition = newBrowserTabPosition ?? 'bottom';
+  const newTabPositionSections = useMemo<IActionListSection[]>(() => {
+    const options = [
+      {
+        value: 'top' as INewBrowserTabPosition,
+        labelId: 'global_top' as ETranslations,
+        icon: 'ArrowTopOutline' as const,
+      },
+      {
+        value: 'bottom' as INewBrowserTabPosition,
+        labelId: 'global_bottom' as ETranslations,
+        icon: 'ArrowBottomOutline' as const,
+      },
+    ];
+    return [
+      {
+        title: intl.formatMessage({
+          id: 'settings_browser_new_tab_position' as ETranslations,
+        }),
+        items: options.map(({ value, labelId, icon }) => ({
+          label: intl.formatMessage({ id: labelId }),
+          icon,
+          extra:
+            currentTabPosition === value ? (
+              <Icon name="CheckRadioSolid" color="$iconActive" size="$5" />
+            ) : null,
+          onPress: () => {
+            void backgroundApiProxy.serviceSetting.setNewBrowserTabPosition(
+              value,
+            );
+          },
+          testID: `browser-sidebar-new-tab-position-${value}`,
+        })),
+      },
+    ];
+  }, [currentTabPosition, intl]);
+
   const { pinnedTabs, unpinnedTabs } = useMemo(() => {
     const allTabs = tabs ?? [];
     return {
@@ -86,10 +157,22 @@ function DesktopCustomTabBar({ isExpanded }: { isExpanded?: boolean }) {
   useEffect(() => {
     if (previousTabsLength && tabs?.length > previousTabsLength) {
       if (unpinnedTabs.length > 0) {
-        scrollViewRef.current?.scrollToEnd({ animated: true });
+        if (currentTabPosition === 'top') {
+          scrollViewRef.current?.scrollToOffset({
+            offset: 0,
+            animated: true,
+          });
+        } else {
+          scrollViewRef.current?.scrollToEnd({ animated: true });
+        }
       }
     }
-  }, [previousTabsLength, tabs?.length, unpinnedTabs.length]);
+  }, [
+    previousTabsLength,
+    tabs?.length,
+    unpinnedTabs.length,
+    currentTabPosition,
+  ]);
 
   const handlePinnedPress = useCallback(
     (id: string, pinned: boolean) => {
@@ -441,6 +524,29 @@ function DesktopCustomTabBar({ isExpanded }: { isExpanded?: boolean }) {
         onDragEnd={onDragEnd}
         contentContainerStyle={{ pb: '$2' }}
       />
+      {!isCollapsed ? (
+        <XStack flexShrink={0} justifyContent="flex-end" px="$2" pb="$3">
+          <ActionList
+            title=""
+            placement="top-end"
+            sections={newTabPositionSections}
+            onOpenChange={handleNewTabMenuOpenChange}
+            renderTrigger={
+              <Stack
+                p="$1"
+                borderRadius="$2"
+                hoverStyle={{ bg: '$bgHover' }}
+                pressStyle={{ bg: '$bgActive' }}
+                cursor="default"
+                testID="browser-sidebar-more"
+                onPress={() => {}}
+              >
+                <Icon name="SettingsOutline" size="$5" color="$iconSubdued" />
+              </Stack>
+            }
+          />
+        </XStack>
+      ) : null}
     </Stack>
   );
 }

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -18,6 +18,7 @@ import { useSignatureConfirm } from '@onekeyhq/kit/src/hooks/useSignatureConfirm
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import { useSelectedDeriveTypeAtom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2/atoms';
 import { type ISwapReviewStepTexts } from '@onekeyhq/kit/src/views/Swap/utils/buildSwapReviewState';
+import { checkSwapLatestBalanceSufficient } from '@onekeyhq/kit/src/views/Swap/utils/swapBalanceUtils';
 import type {
   ISwapReviewAdapter,
   ISwapReviewApproveBroadcastResult,
@@ -125,6 +126,26 @@ type IMarketReviewExecutionSnapshot = {
   swapInfo: ISwapTxInfo;
   buildRes?: IFetchBuildTxResponse;
 };
+
+type ICheckSwapLatestBalanceSufficient = (params: {
+  token: ISwapToken;
+  amount: string;
+  accountAddress?: string;
+  accountId?: string;
+}) => Promise<
+  | {
+      isSufficient: true;
+    }
+  | {
+      isSufficient: false;
+      balance: string;
+      requiredAmount: string;
+      tokenSymbol: string;
+    }
+>;
+
+const checkLatestBalanceSufficient =
+  checkSwapLatestBalanceSufficient as ICheckSwapLatestBalanceSufficient;
 
 export function buildMarketReviewTokens({
   tradeType,
@@ -713,6 +734,38 @@ export function useSpeedSwapActions(props: {
     [intl, marketDeriveInfoRes.result?.addressEncoding, slippage],
   );
 
+  const assertLatestFromTokenBalanceSufficient = useCallback(
+    async ({
+      token,
+      amount,
+      accountAddress,
+      accountId,
+    }: {
+      token: ISwapToken;
+      amount: string;
+      accountAddress?: string;
+      accountId?: string;
+    }) => {
+      const checkResult = await checkLatestBalanceSufficient({
+        token,
+        amount,
+        accountAddress,
+        accountId,
+      });
+      if (!checkResult.isSufficient) {
+        throw new OneKeyLocalError(
+          intl.formatMessage(
+            {
+              id: ETranslations.swap_page_toast_insufficient_balance_title,
+            },
+            { token: checkResult.tokenSymbol },
+          ),
+        );
+      }
+    },
+    [intl],
+  );
+
   const buildSpeedSwapTxData = useCallback(
     async ({
       fromAmount,
@@ -733,6 +786,13 @@ export function useSpeedSwapActions(props: {
           'Market swap review requires account and amount.',
         );
       }
+
+      await assertLatestFromTokenBalanceSufficient({
+        token: fromTokenFinal,
+        amount,
+        accountAddress: userAddress,
+        accountId: netAccountRes.result.id,
+      });
 
       setSpeedSwapBuildTxLoading(true);
       try {
@@ -871,6 +931,7 @@ export function useSpeedSwapActions(props: {
       slippage,
       toToken,
       buildMarketExecutionFromBuildRes,
+      assertLatestFromTokenBalanceSufficient,
     ],
   );
 
@@ -1820,6 +1881,13 @@ export function useSpeedSwapActions(props: {
       const snapshot = requireReviewExecutionSnapshot('swap');
 
       try {
+        await assertLatestFromTokenBalanceSufficient({
+          token: snapshot.swapInfo.sender.token,
+          amount: snapshot.swapInfo.sender.amount,
+          accountAddress: snapshot.accountAddress,
+          accountId: snapshot.accountId,
+        });
+
         if (snapshot.shouldFallback) {
           setSpeedSwapBuildTxLoading(true);
 
@@ -1892,6 +1960,7 @@ export function useSpeedSwapActions(props: {
     },
     [
       buildMarketApproveUnsignedTxArr,
+      assertLatestFromTokenBalanceSufficient,
       cancelSpeedSwapBuildTx,
       handleMarketSwapBuildTxSuccess,
       isUserCancelledError,
@@ -1971,6 +2040,14 @@ export function useSpeedSwapActions(props: {
       try {
         const signingQuoteResult = await refreshMarketSigningQuoteResult({
           snapshot,
+        });
+        const signingFromAmount =
+          signingQuoteResult.fromAmount ?? snapshot.swapInfo.sender.amount;
+        await assertLatestFromTokenBalanceSufficient({
+          token: snapshot.swapInfo.sender.token,
+          amount: signingFromAmount,
+          accountAddress: snapshot.accountAddress,
+          accountId: snapshot.accountId,
         });
         const signedQuoteResult = await signMarketReviewQuoteResult({
           quoteResult: signingQuoteResult,
@@ -2095,6 +2172,7 @@ export function useSpeedSwapActions(props: {
     [
       antiMEV,
       buildMarketExecutionFromBuildRes,
+      assertLatestFromTokenBalanceSufficient,
       cancelSpeedSwapBuildTx,
       handleMarketSignedOrderSuccess,
       isUserCancelledError,

--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -88,6 +88,34 @@ interface IAmountFormValues {
   txMessage: string;
 }
 
+// Floor a fiat-derived token amount to the precision the chain can actually
+// send. Lightning amounts are in sats (smallest unit, 0 decimals) — fractional
+// sats cause OK-53396. Other chains floor to `tokenDetails.info.decimals` so
+// the value stays representable. Keeping this in one place ensures the value
+// shown in the input, the value used by validation, and the value submitted
+// to the vault stay strictly equal.
+function floorFiatDerivedTokenAmount({
+  amount,
+  isLightningNetwork,
+  decimals,
+}: {
+  amount: BigNumber;
+  isLightningNetwork: boolean;
+  decimals: number | undefined;
+}): BigNumber {
+  if (isLightningNetwork) {
+    return amount.integerValue(BigNumber.ROUND_FLOOR);
+  }
+  if (
+    typeof decimals === 'number' &&
+    Number.isInteger(decimals) &&
+    decimals >= 0
+  ) {
+    return amount.decimalPlaces(decimals, BigNumber.ROUND_FLOOR);
+  }
+  return amount;
+}
+
 function SendAmountInputContainer() {
   const intl = useIntl();
   const _media = useMedia();
@@ -341,17 +369,15 @@ function SendAmountInputContainer() {
         return { originalAmount: '0', linkedAmount: '0' };
       }
       // fiat / pricePerSat = sats. Convert to BTC if lnUnit is BTC.
-      let originalAmt = amountBN.dividedBy(price);
-      if (isLightningNetwork) {
-        // Sats are the smallest Lightning unit (0 decimals) — floor the
-        // fiat→sats result so the display never shows fractional sats,
-        // which would cause a send error (OK-53396).
-        originalAmt = originalAmt.integerValue(BigNumber.ROUND_FLOOR);
-        if (lnUnit === ELightningUnit.BTC) {
-          originalAmt = new BigNumber(
-            chainValueUtils.convertSatsToBtc(originalAmt.toFixed()),
-          );
-        }
+      let originalAmt = floorFiatDerivedTokenAmount({
+        amount: amountBN.dividedBy(price),
+        isLightningNetwork,
+        decimals: tokenDetails?.info.decimals,
+      });
+      if (isLightningNetwork && lnUnit === ELightningUnit.BTC) {
+        originalAmt = new BigNumber(
+          chainValueUtils.convertSatsToBtc(originalAmt.toFixed()),
+        );
       }
       return {
         originalAmount: originalAmt.toFixed(),
@@ -364,7 +390,14 @@ function SendAmountInputContainer() {
       originalAmount: amountBN.toFixed(),
       linkedAmount: linkedAmountValue.toFixed(),
     };
-  }, [amount, isLightningNetwork, isUseFiat, lnUnit, tokenDetails?.price]);
+  }, [
+    amount,
+    isLightningNetwork,
+    isUseFiat,
+    lnUnit,
+    tokenDetails?.info.decimals,
+    tokenDetails?.price,
+  ]);
 
   const handleToggleFiatMode = useCallback(() => {
     // When currently in fiat mode (isUseFiat=true), switching to token mode -> use originalAmount
@@ -480,9 +513,17 @@ function SendAmountInputContainer() {
       }
 
       const priceBN = new BigNumber(tokenDetails?.price ?? 0);
+      // Mirror the flooring applied in `linkedAmount` so the value validated
+      // here matches the value submitted to the vault. Without this, fiat
+      // mode could pass min/balance checks against the raw fiat/price result
+      // while the user actually sends a smaller, floored value.
       const tokenAmountBN =
         isUseFiat && priceBN.isGreaterThan(0)
-          ? amountBN.dividedBy(priceBN)
+          ? floorFiatDerivedTokenAmount({
+              amount: amountBN.dividedBy(priceBN),
+              isLightningNetwork,
+              decimals: tokenDetails?.info.decimals,
+            })
           : amountBN;
 
       // For Lightning, normalize amount to sats for validation
@@ -552,6 +593,21 @@ function SendAmountInputContainer() {
         );
       }
 
+      // A positive fiat input that floors to 0 token (sub-sat on Lightning,
+      // or sub-decimal on other chains) would otherwise slip past the min
+      // check above (which excludes isZero) and the native-only zero guard
+      // below, letting the user submit a 0-amount transfer.
+      if (
+        isUseFiat &&
+        priceBN.isGreaterThan(0) &&
+        tokenAmountBN.isZero() &&
+        !amountBN.isZero()
+      ) {
+        return intl.formatMessage({
+          id: ETranslations.send_amount_too_small,
+        });
+      }
+
       // Zero native token transfer prevention
       if (
         !isNFT &&
@@ -591,6 +647,7 @@ function SendAmountInputContainer() {
       isLightningNetwork,
       lnUnit,
       tokenDetails?.balanceParsed,
+      tokenDetails?.info.decimals,
       tokenDetails?.info.isNative,
       tokenDetails?.price,
       tokenMinAmount,

--- a/packages/kit/src/views/Setting/pages/Tab/exportLogs/index.native.ts
+++ b/packages/kit/src/views/Setting/pages/Tab/exportLogs/index.native.ts
@@ -13,7 +13,6 @@ import {
   type ILogUploadResponse,
 } from '@onekeyhq/shared/src/logger/types';
 import utils from '@onekeyhq/shared/src/logger/utils';
-import { BundleUpdate } from '@onekeyhq/shared/src/modules3rdParty/auto-update';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { getRequestHeaders } from '@onekeyhq/shared/src/request/Interceptor';
 import { waitAsync } from '@onekeyhq/shared/src/utils/promiseUtils';
@@ -108,7 +107,13 @@ export const collectLogDigest = async (
   }
   const stat = await RNFS.stat(normalizedPath);
   const sizeBytes = Number(stat.size ?? 0);
-  const sha256 = await BundleUpdate.getSha256FromFilePath(normalizedPath);
+  // Keep prior "empty string on failure" semantics for ILogDigest consumers.
+  let sha256 = '';
+  try {
+    sha256 = await RNFS.hash(normalizedPath, 'sha256');
+  } catch {
+    sha256 = '';
+  }
   return {
     sizeBytes,
     sha256,

--- a/packages/kit/src/views/Swap/components/SwapProviderListPanel.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProviderListPanel.tsx
@@ -22,13 +22,20 @@ import {
   useSwapFromTokenAmountAtom,
   useSwapManualSelectQuoteProvidersAtom,
   useSwapProviderSortAtom,
+  useSwapQuoteCurrentEventProviderKeysAtom,
+  useSwapQuoteCurrentEventReceivedCountAtom,
   useSwapQuoteCurrentSelectAtom,
   useSwapQuoteEventTotalCountAtom,
   useSwapSelectFromTokenAtom,
   useSwapSelectToTokenAtom,
   useSwapSortedQuoteListAtom,
+  useSwapToTokenAmountAtom,
   useSwapTypeSwitchAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
+import {
+  buildSwapManualProviderSelectionIntent,
+  buildSwapQuoteProviderKey,
+} from '@onekeyhq/kit/src/states/jotai/contexts/swap/quoteProgress';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
@@ -128,31 +135,55 @@ const SwapProviderListPanel = ({
   const intl = useIntl();
   const [swapSortedList] = useSwapSortedQuoteListAtom();
   const [fromTokenAmount] = useSwapFromTokenAmountAtom();
+  const [toTokenAmount] = useSwapToTokenAmountAtom();
   const [fromToken] = useSwapSelectFromTokenAtom();
   const [toToken] = useSwapSelectToTokenAtom();
-  const [, setSwapManualSelect] = useSwapManualSelectQuoteProvidersAtom();
+  const [manualSelectQuoteProvider, setSwapManualSelect] =
+    useSwapManualSelectQuoteProvidersAtom();
   const [providerSort, setProviderSort] = useSwapProviderSortAtom();
   const [settingsPersist] = useSettingsPersistAtom();
   const [currentSelectQuote] = useSwapQuoteCurrentSelectAtom();
+  const selectedProviderInfo =
+    currentSelectQuote?.info ?? manualSelectQuoteProvider?.info;
   const quoteLoading = useSwapQuoteLoading();
   const quoteEventFetching = useSwapQuoteEventFetching();
   const [swapTypeSwitch] = useSwapTypeSwitchAtom();
   const [quoteEventTotalCount] = useSwapQuoteEventTotalCountAtom();
+  const [currentEventReceivedCount] =
+    useSwapQuoteCurrentEventReceivedCountAtom();
+  const [currentEventProviderKeys] = useSwapQuoteCurrentEventProviderKeysAtom();
+  const currentEventProviderKeySet = useMemo(
+    () => new Set(currentEventProviderKeys),
+    [currentEventProviderKeys],
+  );
+  const quoteListForDisplay = useMemo(
+    () =>
+      quoteEventTotalCount.count > 0
+        ? swapSortedList.filter((item) =>
+            currentEventProviderKeySet.has(buildSwapQuoteProviderKey(item)),
+          )
+        : swapSortedList,
+    [currentEventProviderKeySet, quoteEventTotalCount.count, swapSortedList],
+  );
 
   // Cache the previous list to show during refresh (prevents flash to empty)
   const cachedListRef = useRef<IFetchQuoteResult[]>([]);
   // Track if this is first load vs refresh
   const hadPreviousQuotesRef = useRef(false);
-  // Track token changes to reset cache
-  const prevTokenKeyRef = useRef('');
-  const currentTokenKey = `${fromToken?.contractAddress ?? ''}-${
+  // Track quote context changes to reset cache
+  const quoteInputAmount =
+    fromTokenAmount.isInput || !toTokenAmount.isInput
+      ? fromTokenAmount.value
+      : toTokenAmount.value;
+  const prevQuoteContextKeyRef = useRef('');
+  const currentQuoteContextKey = `${swapTypeSwitch}-${
+    fromToken?.networkId ?? ''
+  }-${fromToken?.contractAddress ?? ''}-${toToken?.networkId ?? ''}-${
     toToken?.contractAddress ?? ''
-  }`;
+  }-${quoteInputAmount}`;
   // Track if we're in a refresh cycle (list was cleared but we had data)
   const isRefreshingRef = useRef(false);
-  // Track swap type switch changes to reset cache (OK-49718)
-  const prevSwapTypeSwitchRef = useRef(swapTypeSwitch);
-  // Track quote event id changes to reset cache when new quote starts (OK-49718)
+  // Track quote event id changes to detect new quote cycles (OK-49718)
   const prevQuoteEventIdRef = useRef(quoteEventTotalCount.eventId);
   // Track if waiting for new quote to prevent flash to empty state (OK-49718)
   const isWaitingForNewQuoteRef = useRef(false);
@@ -164,42 +195,34 @@ const SwapProviderListPanel = ({
   // Track previous loading state for detecting when loading completes
   const prevIsLoadingRef = useRef(false);
 
-  // Reset cache when tokens change
-  if (prevTokenKeyRef.current !== currentTokenKey) {
-    prevTokenKeyRef.current = currentTokenKey;
+  // Reset cache when tokens, swap type, or the user-entered amount changes.
+  if (prevQuoteContextKeyRef.current !== currentQuoteContextKey) {
+    prevQuoteContextKeyRef.current = currentQuoteContextKey;
     cachedListRef.current = [];
     hadPreviousQuotesRef.current = false;
     isRefreshingRef.current = false;
     isWaitingForNewQuoteRef.current = true;
   }
 
-  // Reset cache when swap type switch changes (Swap/Limit/Bridge) (OK-49718)
-  if (prevSwapTypeSwitchRef.current !== swapTypeSwitch) {
-    prevSwapTypeSwitchRef.current = swapTypeSwitch;
-    cachedListRef.current = [];
-    hadPreviousQuotesRef.current = false;
-    isRefreshingRef.current = false;
-    isWaitingForNewQuoteRef.current = true;
-  }
-
-  // Reset cache when a new quote event starts (different eventId means new quote request) (OK-49718)
-  // Also reset when quote is cleared (eventId becomes undefined or count becomes 0)
-  if (
-    prevQuoteEventIdRef.current !== quoteEventTotalCount.eventId ||
-    (quoteEventTotalCount.count === 0 && prevQuoteEventIdRef.current)
-  ) {
+  // A new event for the same quote context is usually an auto-refresh; keep the
+  // previous list until the new event returns its first provider.
+  if (prevQuoteEventIdRef.current !== quoteEventTotalCount.eventId) {
     prevQuoteEventIdRef.current = quoteEventTotalCount.eventId;
-    cachedListRef.current = [];
-    hadPreviousQuotesRef.current = false;
-    isRefreshingRef.current = false;
     isWaitingForNewQuoteRef.current = true;
   }
 
   const isLoading = quoteLoading || quoteEventFetching;
 
+  if (!isLoading && quoteEventTotalCount.count === 0) {
+    cachedListRef.current = [];
+    hadPreviousQuotesRef.current = false;
+    isRefreshingRef.current = false;
+    isWaitingForNewQuoteRef.current = false;
+  }
+
   // Detect refresh: list becomes empty while we had previous data
   if (
-    swapSortedList.length === 0 &&
+    quoteListForDisplay.length === 0 &&
     hadPreviousQuotesRef.current &&
     cachedListRef.current.length > 0
   ) {
@@ -210,8 +233,8 @@ const SwapProviderListPanel = ({
   const wasWaitingForNewQuote = isWaitingForNewQuoteRef.current;
 
   // Update cache when we have new data
-  if (swapSortedList.length > 0) {
-    cachedListRef.current = swapSortedList;
+  if (quoteListForDisplay.length > 0) {
+    cachedListRef.current = quoteListForDisplay;
     hadPreviousQuotesRef.current = true;
     isRefreshingRef.current = false;
     isWaitingForNewQuoteRef.current = false;
@@ -221,10 +244,10 @@ const SwapProviderListPanel = ({
   // Show cached data when: loading with empty list but had previous data, OR during refresh
   const displayList =
     (isLoading || isRefreshingRef.current) &&
-    swapSortedList.length === 0 &&
+    quoteListForDisplay.length === 0 &&
     cachedListRef.current.length > 0
       ? cachedListRef.current
-      : swapSortedList;
+      : quoteListForDisplay;
 
   // Track previous provider keys to determine which items are new
   const prevProviderKeysRef = useRef<Set<string>>(new Set());
@@ -315,13 +338,13 @@ const SwapProviderListPanel = ({
     if (
       wasLoading &&
       !isLoading &&
-      currentSelectQuote &&
+      selectedProviderInfo &&
       availableList.length > 0
     ) {
       const selectedIndex = availableList.findIndex(
         (item) =>
-          item.info.provider === currentSelectQuote.info.provider &&
-          item.info.providerName === currentSelectQuote.info.providerName,
+          item.info.provider === selectedProviderInfo.provider &&
+          item.info.providerName === selectedProviderInfo.providerName,
       );
 
       if (selectedIndex > 0 && scrollViewRef.current) {
@@ -334,17 +357,17 @@ const SwapProviderListPanel = ({
         }, 100);
       }
     }
-  }, [isLoading, currentSelectQuote, availableList]);
+  }, [isLoading, selectedProviderInfo, availableList]);
 
   const onSelectQuote = useCallback(
     (item: IFetchQuoteResult) => {
-      setSwapManualSelect(item);
+      setSwapManualSelect(buildSwapManualProviderSelectionIntent(item));
       defaultLogger.swap.providerChange.providerChange({
-        changeFrom: currentSelectQuote?.info.provider ?? '-',
+        changeFrom: selectedProviderInfo?.provider ?? '-',
         changeTo: item.info.provider,
       });
     },
-    [setSwapManualSelect, currentSelectQuote?.info.provider],
+    [setSwapManualSelect, selectedProviderInfo?.provider],
   );
 
   const renderItem = useCallback(
@@ -382,8 +405,8 @@ const SwapProviderListPanel = ({
                 : undefined
             }
             selected={Boolean(
-              item.info.provider === currentSelectQuote?.info.provider &&
-              item.info.providerName === currentSelectQuote?.info.providerName,
+              item.info.provider === selectedProviderInfo?.provider &&
+              item.info.providerName === selectedProviderInfo?.providerName,
             )}
             fromTokenAmount={fromTokenAmount.value}
             fromToken={fromToken}
@@ -396,11 +419,11 @@ const SwapProviderListPanel = ({
       );
     },
     [
-      currentSelectQuote?.info.provider,
-      currentSelectQuote?.info.providerName,
       fromToken,
       fromTokenAmount,
       onSelectQuote,
+      selectedProviderInfo?.provider,
+      selectedProviderInfo?.providerName,
       settingsPersist.currencyInfo.symbol,
       toToken,
     ],
@@ -666,7 +689,7 @@ const SwapProviderListPanel = ({
   // Number of skeleton placeholders for providers not yet received
   const remainingSkeletonCount =
     hasReceivedTotal && quoteEventFetching
-      ? Math.max(0, quoteEventTotalCount.count - displayList.length)
+      ? Math.max(0, quoteEventTotalCount.count - currentEventReceivedCount)
       : 0;
 
   const contentArea = (

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -120,6 +120,7 @@ import {
   useSwapToTokenAmountAtom,
   useSwapTypeSwitchAtom,
 } from '../../../states/jotai/contexts/swap';
+import { checkSwapLatestBalanceSufficient } from '../utils/swapBalanceUtils';
 
 import { useSwapAddressInfo } from './useSwapAccount';
 import { useSwapBuildTxInfo, useSwapProAccount } from './useSwapPro';
@@ -471,6 +472,39 @@ export function useSwapBuildTx() {
       return checkRes;
     },
     [fromToken, intl, selectQuote?.fromAmount, fromUserAddress, fromAccountId],
+  );
+
+  const checkLatestFromTokenBalance = useCallback(
+    async (token: ISwapToken, amount: string) => {
+      const checkResult = await checkSwapLatestBalanceSufficient({
+        token,
+        amount,
+        accountAddress: fromUserAddress,
+        accountId: fromAccountId,
+      });
+      if (!checkResult.isSufficient) {
+        Toast.error({
+          title: intl.formatMessage(
+            {
+              id: ETranslations.swap_page_toast_insufficient_balance_title,
+            },
+            { token: checkResult.tokenSymbol },
+          ),
+          message: intl.formatMessage(
+            {
+              id: ETranslations.swap_page_toast_insufficient_balance_content,
+            },
+            {
+              token: checkResult.tokenSymbol,
+              number: numberFormat(checkResult.requiredAmount, formatter),
+            },
+          ),
+        });
+        return false;
+      }
+      return true;
+    },
+    [fromAccountId, fromUserAddress, intl],
   );
 
   const cancelLimitOrder = useCallback(
@@ -1739,6 +1773,13 @@ export function useSwapBuildTx() {
         fromAccountNetworkId &&
         fromAccountId
       ) {
+        const checkLatestBalanceRes = await checkLatestFromTokenBalance(
+          data.fromTokenInfo,
+          data.fromAmount,
+        );
+        if (!checkLatestBalanceRes) {
+          throw new OneKeyError('checkLatestFromTokenBalance failed');
+        }
         if (swapStepsRef.current.preSwapData.swapBuildResultData) {
           return swapStepsRef.current.preSwapData.swapBuildResultData;
         }
@@ -2053,6 +2094,7 @@ export function useSwapBuildTx() {
       fromAccountNetworkId,
       fromAccountId,
       setSwapSteps,
+      checkLatestFromTokenBalance,
       checkOtherFee,
       swapFromAddressInfo.accountInfo?.wallet?.type,
       swapFromAddressInfo.accountInfo?.deriveInfo?.addressEncoding,
@@ -2221,6 +2263,13 @@ export function useSwapBuildTx() {
       ) {
         const selectQuoteRes = cloneDeep(data);
         if (selectQuoteRes.swapShouldSignedData && fromAccountId) {
+          const checkLatestBalanceRes = await checkLatestFromTokenBalance(
+            selectQuoteRes.fromTokenInfo,
+            data.fromAmount,
+          );
+          if (!checkLatestBalanceRes) {
+            throw new OneKeyError('checkLatestFromTokenBalance failed');
+          }
           const {
             unSignedInfo,
             unSignedMessage,
@@ -2404,6 +2453,7 @@ export function useSwapBuildTx() {
     },
     [
       buildTxNew,
+      checkLatestFromTokenBalance,
       slippageItem,
       fromAccountId,
       fromUserAddress,

--- a/packages/kit/src/views/Swap/hooks/useSwapQuote.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapQuote.ts
@@ -48,6 +48,7 @@ import {
   useSwapToTokenAmountAtom,
   useSwapTypeSwitchAtom,
 } from '../../../states/jotai/contexts/swap';
+import { buildSwapManualProviderSelectionIntent } from '../../../states/jotai/contexts/swap/quoteProgress';
 import { truncateDecimalPlaces } from '../utils/utils';
 
 import { useSwapAddressInfo } from './useSwapAccount';
@@ -576,26 +577,14 @@ export function useSwapQuote() {
       if (swapShouldRefreshRef.current) {
         return;
       }
-      setSwapManualSelectQuoteProviders({
-        protocol: data.approvedSwapInfo.protocol,
-        quoteId: data.approvedSwapInfo?.quoteId,
-        info: {
-          provider: data.approvedSwapInfo.provider,
-          providerName: data.approvedSwapInfo.providerName,
-        },
-        fromTokenInfo: {
-          networkId: data.approvedSwapInfo.fromToken.networkId,
-          contractAddress: data.approvedSwapInfo.fromToken.contractAddress,
-          symbol: data.approvedSwapInfo.fromToken.symbol,
-          decimals: data.approvedSwapInfo.fromToken.decimals,
-        },
-        toTokenInfo: {
-          networkId: data.approvedSwapInfo.toToken.networkId,
-          contractAddress: data.approvedSwapInfo.toToken.contractAddress,
-          symbol: data.approvedSwapInfo.toToken.symbol,
-          decimals: data.approvedSwapInfo.toToken.decimals,
-        },
-      });
+      setSwapManualSelectQuoteProviders(
+        buildSwapManualProviderSelectionIntent({
+          info: {
+            provider: data.approvedSwapInfo.provider,
+            providerName: data.approvedSwapInfo.providerName,
+          },
+        }),
+      );
       const { approvedSwapInfo, enableFilled } = data;
       const {
         fromToken: fromTokenInfo,

--- a/packages/kit/src/views/Swap/hooks/useSwapState.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapState.ts
@@ -40,11 +40,12 @@ import {
   useSwapLimitPriceUseRateAtom,
   useSwapProTradeTypeAtom,
   useSwapQuoteApproveAllowanceUnLimitAtom,
+  useSwapQuoteCurrentEventReceivedCountAtom,
   useSwapQuoteCurrentSelectAtom,
+  useSwapQuoteEventCompletedAtom,
   useSwapQuoteEventTotalCountAtom,
   useSwapQuoteFetchingAtom,
   useSwapQuoteIntervalCountAtom,
-  useSwapQuoteListAtom,
   useSwapSelectFromTokenAtom,
   useSwapSelectToTokenAtom,
   useSwapSelectedFromTokenBalanceAtom,
@@ -54,6 +55,10 @@ import {
   useSwapToTokenAmountAtom,
   useSwapTypeSwitchAtom,
 } from '../../../states/jotai/contexts/swap';
+import {
+  getSwapQuoteProgressState,
+  isSwapQuoteEventFetching,
+} from '../../../states/jotai/contexts/swap/quoteProgress';
 import { buildSwapBatchTransferType } from '../utils/buildSwapReviewState';
 
 import { useSwapAddressInfo } from './useSwapAccount';
@@ -129,18 +134,31 @@ export function useSwapQuoteLoading() {
 
 export function useSwapQuoteEventFetching() {
   const [quoteEventTotalCount] = useSwapQuoteEventTotalCountAtom();
-  const [quoteResult] = useSwapQuoteListAtom();
+  const [quoteEventCompleted] = useSwapQuoteEventCompletedAtom();
+  const [currentEventReceivedCount] =
+    useSwapQuoteCurrentEventReceivedCountAtom();
 
-  if (quoteEventTotalCount.count > 0) {
-    if (
-      quoteResult?.every((q) => q.eventId === quoteEventTotalCount.eventId) &&
-      quoteResult.length === quoteEventTotalCount.count
-    ) {
-      return false;
-    }
-    return true;
-  }
-  return false;
+  return isSwapQuoteEventFetching({
+    quoteEventTotalCount,
+    currentEventReceivedCount,
+    quoteEventCompleted,
+  });
+}
+
+export function useSwapQuoteProgressState() {
+  const quoteLoading = useSwapQuoteLoading();
+  const quoteEventFetching = useSwapQuoteEventFetching();
+  const [quoteCurrentSelect] = useSwapQuoteCurrentSelectAtom();
+
+  return useMemo(
+    () =>
+      getSwapQuoteProgressState({
+        quoteLoading,
+        quoteEventFetching,
+        quoteCurrentSelect,
+      }),
+    [quoteCurrentSelect, quoteEventFetching, quoteLoading],
+  );
 }
 
 export function useSwapBatchTransferType(
@@ -164,8 +182,8 @@ export function useSwapBatchTransferType(
 
 export function useSwapActionState() {
   const intl = useIntl();
-  const quoteLoading = useSwapQuoteLoading();
-  const quoteEventFetching = useSwapQuoteEventFetching();
+  const { quoteLoading, quoteEventFetching, isWaitingActionableQuote } =
+    useSwapQuoteProgressState();
   const [quoteCurrentSelect] = useSwapQuoteCurrentSelectAtom();
   const [buildTxFetching] = useSwapBuildTxFetchingAtom();
   const [fromTokenAmount] = useSwapFromTokenAmountAtom();
@@ -173,6 +191,9 @@ export function useSwapActionState() {
   const [toToken] = useSwapSelectToTokenAtom();
   const [toTokenAmount] = useSwapToTokenAmountAtom();
   const [shouldRefreshQuote] = useSwapShouldRefreshQuoteAtom();
+  const [{ swapSlippagePercentageMode }] = useSettingsAtom();
+  const [quoteEventTotalCount] = useSwapQuoteEventTotalCountAtom();
+  const [quoteEventCompleted] = useSwapQuoteEventCompletedAtom();
   const [swapQuoteApproveAllowanceUnLimit] =
     useSwapQuoteApproveAllowanceUnLimitAtom();
   useSwapWarningCheck();
@@ -244,6 +265,23 @@ export function useSwapActionState() {
     ],
   );
   const quoteResultNoMatchDebounce = useDebounce(quoteResultNoMatch, 10);
+  const isWaitingAutoSlippage = useMemo(
+    () =>
+      swapSlippagePercentageMode === ESwapSlippageSegmentKey.AUTO &&
+      quoteEventTotalCount.count > 0 &&
+      !quoteEventCompleted &&
+      quoteCurrentSelect?.protocol === EProtocolOfExchange.SWAP &&
+      !quoteCurrentSelect.unSupportSlippage &&
+      isNil(quoteCurrentSelect.autoSuggestedSlippage),
+    [
+      quoteCurrentSelect?.autoSuggestedSlippage,
+      quoteCurrentSelect?.protocol,
+      quoteCurrentSelect?.unSupportSlippage,
+      quoteEventCompleted,
+      quoteEventTotalCount.count,
+      swapSlippagePercentageMode,
+    ],
+  );
   const actionInfo = useMemo(() => {
     const infoRes = {
       disable: !(!hasError && !!quoteCurrentSelect),
@@ -280,8 +318,8 @@ export function useSwapActionState() {
       infoRes.disable = true;
     }
     if (
-      quoteLoading ||
-      quoteEventFetching ||
+      isWaitingActionableQuote ||
+      isWaitingAutoSlippage ||
       swapApprovingMatchLoading ||
       buildTxFetching
     ) {
@@ -378,8 +416,8 @@ export function useSwapActionState() {
     swapTypeSwitchValue,
     isRefreshQuote,
     toTokenAmount.value,
-    quoteLoading,
-    quoteEventFetching,
+    isWaitingActionableQuote,
+    isWaitingAutoSlippage,
     swapApprovingMatchLoading,
     buildTxFetching,
     selectedFromTokenBalance,
@@ -395,8 +433,8 @@ export function useSwapActionState() {
     noConnectWallet: actionInfo.noConnectWallet,
     disabled:
       actionInfo.disable ||
-      quoteLoading ||
-      quoteEventFetching ||
+      isWaitingActionableQuote ||
+      isWaitingAutoSlippage ||
       swapApprovingMatchLoading,
     approveUnLimit: swapQuoteApproveAllowanceUnLimit,
     isApprove: !!quoteCurrentSelect?.allowanceResult,
@@ -408,6 +446,7 @@ export function useSwapActionState() {
       (isRefreshQuote || quoteResultNoMatchDebounce) &&
       !quoteLoading &&
       !quoteEventFetching,
+    isWaitingAutoSlippage,
   };
   return stepState;
 }

--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -69,8 +69,7 @@ import {
 } from '../../hooks/useSwapIncognitoRecipientInput';
 import {
   useSwapActionState,
-  useSwapQuoteEventFetching,
-  useSwapQuoteLoading,
+  useSwapQuoteProgressState,
   useSwapSlippagePercentageModeInfo,
 } from '../../hooks/useSwapState';
 import { buildSwapIncognitoSettingsUpdate } from '../../utils/incognitoSettings';
@@ -121,7 +120,8 @@ const SwapActionsState = ({
     setSettings,
   ] = useSettingsAtom();
   const [settingsPersistAtom] = useSettingsPersistAtom();
-  const quoteLoading = useSwapQuoteLoading();
+  const { quoteLoading, quoteEventFetching, isWaitingActionableQuote } =
+    useSwapQuoteProgressState();
   const swapRecipientAddressInfo = useSwapRecipientAddressInfo(
     swapEnableRecipientAddress,
   );
@@ -129,7 +129,6 @@ const SwapActionsState = ({
     swapSlippageRef.current = slippageItem;
   }
   const themeVariant = useThemeVariant();
-  const quoting = useSwapQuoteEventFetching();
   const [desktopActionWidth, setDesktopActionWidth] = useState<number>();
 
   const isModalPage = useIsOverlayPage();
@@ -728,7 +727,7 @@ const SwapActionsState = ({
       new BigNumber(currentQuoteRes?.fee?.costSavings || 0).gt(0);
 
     if (hasCostSavings) {
-      const isLoadingQuote = quoting || quoteLoading;
+      const isLoadingQuote = quoteEventFetching || quoteLoading;
       const shouldShow = hasEverShownCostSavingsRef.current || !isLoadingQuote;
 
       if (shouldShow) {
@@ -770,7 +769,7 @@ const SwapActionsState = ({
   }, [
     currentQuoteRes?.fee?.costSavings,
     settingsPersistAtom.currencyInfo.symbol,
-    quoting,
+    quoteEventFetching,
     quoteLoading,
     intl,
   ]);
@@ -809,7 +808,7 @@ const SwapActionsState = ({
 
   const actionButtonChildren = useMemo(
     () =>
-      quoting || quoteLoading ? (
+      isWaitingActionableQuote || swapActionState.isWaitingAutoSlippage ? (
         <LottieView
           source={
             themeVariant === 'light'
@@ -826,7 +825,12 @@ const SwapActionsState = ({
       ) : (
         swapActionState.label
       ),
-    [quoteLoading, quoting, swapActionState.label, themeVariant],
+    [
+      isWaitingActionableQuote,
+      swapActionState.isWaitingAutoSlippage,
+      swapActionState.label,
+      themeVariant,
+    ],
   );
 
   const actionRowComponent = useMemo(

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -248,8 +248,8 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
   }
 
   const quoteResultRef = useRef<IFetchQuoteResult | undefined>(undefined);
-  if (quoteResultRef.current !== currentQuoteRes) {
-    quoteResultRef.current = currentQuoteRes;
+  if (quoteResultRef.current !== swapStepData.quoteResult) {
+    quoteResultRef.current = swapStepData.quoteResult;
   }
 
   const preSwapDataRef = useRef<ISwapPreSwapData | undefined>(undefined);
@@ -516,6 +516,9 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     if (isWrapped) {
       return false;
     }
+    if (quoteEventFetching) {
+      return false;
+    }
     if (currentQuoteRes && !currentQuoteRes?.allowanceResult) {
       return true;
     }
@@ -525,7 +528,12 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
         fromSelectToken?.networkId ?? '',
       )
     );
-  }, [currentQuoteRes, fromSelectToken?.networkId, isWrapped]);
+  }, [
+    currentQuoteRes,
+    fromSelectToken?.networkId,
+    isWrapped,
+    quoteEventFetching,
+  ]);
 
   const reviewStepTexts = useMemo(
     () => ({

--- a/packages/kit/src/views/Swap/pages/components/SwapProActionButton.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProActionButton.tsx
@@ -34,7 +34,7 @@ import {
   useSwapProInputToken,
   useSwapProToToken,
 } from '../../hooks/useSwapPro';
-import { useSwapQuoteLoading } from '../../hooks/useSwapState';
+import { useSwapQuoteProgressState } from '../../hooks/useSwapState';
 
 const MAX_BUTTON_CHARS = 25;
 
@@ -157,7 +157,7 @@ const SwapProActionButton = ({
   const [swapQuoteResult] = useSwapQuoteCurrentSelectAtom();
   const [swapProQuoteResult] = useSwapSpeedQuoteResultAtom();
   const swapProAccount = useSwapProAccount();
-  const quoteLoading = useSwapQuoteLoading();
+  const { isWaitingActionableQuote } = useSwapQuoteProgressState();
   const currencyInfo = useCurrency();
   const [quoteFetching] = useSwapSpeedQuoteFetchingAtom();
   const [swapProInputAmount] = useSwapProInputAmountAtom();
@@ -351,8 +351,8 @@ const SwapProActionButton = ({
     if (swapProTradeType === ESwapProTradeType.MARKET) {
       return quoteFetching;
     }
-    return quoteLoading;
-  }, [swapProTradeType, quoteLoading, quoteFetching]);
+    return isWaitingActionableQuote;
+  }, [swapProTradeType, isWaitingActionableQuote, quoteFetching]);
   const actionButtonDisabled = useMemo(() => {
     let originalDisabled =
       !hasEnoughBalance ||

--- a/packages/kit/src/views/Swap/pages/components/SwapQuoteInput.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapQuoteInput.tsx
@@ -17,10 +17,7 @@ import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
 
 import { useSwapFromAccountNetworkSync } from '../../hooks/useSwapAccount';
 import { useSwapLimitPriceCheck } from '../../hooks/useSwapPro';
-import {
-  useSwapQuoteEventFetching,
-  useSwapQuoteLoading,
-} from '../../hooks/useSwapState';
+import { useSwapQuoteProgressState } from '../../hooks/useSwapState';
 
 import SwapInputContainer from './SwapInputContainer';
 
@@ -39,8 +36,7 @@ const SwapQuoteInput = ({
 }: ISwapQuoteInputProps) => {
   const [fromInputAmount, setFromInputAmount] = useSwapFromTokenAmountAtom();
   const [toInputAmount, setToInputAmount] = useSwapToTokenAmountAtom();
-  const swapQuoteLoading = useSwapQuoteLoading();
-  const quoteEventFetching = useSwapQuoteEventFetching();
+  const { isWaitingActionableQuote } = useSwapQuoteProgressState();
   const [fromToken] = useSwapSelectFromTokenAtom();
   const [toToken] = useSwapSelectToTokenAtom();
   const [swapTokenDetailLoading] = useSwapSelectTokenDetailFetchingAtom();
@@ -65,7 +61,7 @@ const SwapQuoteInput = ({
       <SwapInputContainer
         token={fromToken}
         direction={ESwapDirectionType.FROM}
-        inputLoading={swapQuoteLoading || quoteEventFetching}
+        inputLoading={isWaitingActionableQuote}
         selectTokenLoading={selectLoading}
         onAmountChange={(value) => {
           if (validateAmountInput(value, fromToken?.decimals)) {
@@ -111,7 +107,7 @@ const SwapQuoteInput = ({
       </Stack>
       <SwapInputContainer
         token={toToken}
-        inputLoading={swapQuoteLoading || quoteEventFetching}
+        inputLoading={isWaitingActionableQuote}
         selectTokenLoading={selectLoading}
         direction={ESwapDirectionType.TO}
         onAmountChange={(value) => {

--- a/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
@@ -48,8 +48,8 @@ import SwapQuoteResultRate from '../../components/SwapQuoteResultRate';
 import { useSwapLimitConfigMaps } from '../../hooks/useSwapGlobal';
 import { useSwapSlippageActions } from '../../hooks/useSwapSlippageActions';
 import {
-  useSwapQuoteEventFetching,
   useSwapQuoteLoading,
+  useSwapQuoteProgressState,
 } from '../../hooks/useSwapState';
 
 import SwapApproveAllowanceSelectContainer from './SwapApproveAllowanceSelectContainer';
@@ -85,6 +85,7 @@ const SwapQuoteResult = ({
   const [swapLimitPartiallyFill, setSwapLimitPartiallyFill] =
     useSwapLimitPartiallyFillAtom();
   const swapQuoteLoading = useSwapQuoteLoading();
+  const { isWaitingActionableQuote } = useSwapQuoteProgressState();
   const [swapTypeSwitch] = useSwapTypeSwitchAtom();
   const intl = useIntl();
   const { onSlippageHandleClick, slippageItem } = useSwapSlippageActions();
@@ -161,7 +162,7 @@ const SwapQuoteResult = ({
     [calculateTaxItem],
   );
 
-  const quoting = useSwapQuoteEventFetching();
+  const quoting = isWaitingActionableQuote;
 
   const { limitOrderExpiryStepMap, limitOrderPartiallyFillStepMap } =
     useSwapLimitConfigMaps();
@@ -197,7 +198,7 @@ const SwapQuoteResult = ({
     );
   }
   if (swapTypeSwitch === ESwapTabSwitchType.LIMIT) {
-    if (quoting || swapQuoteLoading) {
+    if (isWaitingActionableQuote) {
       return (
         <XStack alignItems="center">
           <XStack gap="$2">

--- a/packages/kit/src/views/Swap/pages/modal/SwapHistoryListModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapHistoryListModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useRoute } from '@react-navigation/core';
 import BigNumber from 'bignumber.js';
@@ -66,6 +66,11 @@ const SwapHistoryListModal = ({
   );
   const [{ swapHistoryPendingList, swapLimitOrders }] =
     useInAppNotificationAtom();
+
+  useEffect(() => {
+    void backgroundApiProxy.serviceSwap.refreshSwapHistoryPendingStatusOnce();
+  }, []);
+
   const { result: swapTxHistoryList } = usePromiseResult(
     async () => {
       const histories =

--- a/packages/kit/src/views/Swap/pages/modal/SwapProviderSelectModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapProviderSelectModal.tsx
@@ -22,11 +22,17 @@ import {
   useSwapFromTokenAmountAtom,
   useSwapManualSelectQuoteProvidersAtom,
   useSwapProviderSortAtom,
+  useSwapQuoteCurrentEventProviderKeysAtom,
   useSwapQuoteCurrentSelectAtom,
+  useSwapQuoteEventTotalCountAtom,
   useSwapSelectFromTokenAtom,
   useSwapSelectToTokenAtom,
   useSwapSortedQuoteListAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
+import {
+  buildSwapManualProviderSelectionIntent,
+  buildSwapQuoteProviderKey,
+} from '@onekeyhq/kit/src/states/jotai/contexts/swap/quoteProgress';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
@@ -70,10 +76,28 @@ const SwapProviderSelectModal = () => {
   const [fromTokenAmount] = useSwapFromTokenAmountAtom();
   const [fromToken] = useSwapSelectFromTokenAtom();
   const [toToken] = useSwapSelectToTokenAtom();
-  const [, setSwapManualSelect] = useSwapManualSelectQuoteProvidersAtom();
+  const [manualSelectQuoteProvider, setSwapManualSelect] =
+    useSwapManualSelectQuoteProvidersAtom();
   const [providerSort, setProviderSort] = useSwapProviderSortAtom();
   const [settingsPersist] = useSettingsPersistAtom();
   const [currentSelectQuote] = useSwapQuoteCurrentSelectAtom();
+  const selectedProviderInfo =
+    currentSelectQuote?.info ?? manualSelectQuoteProvider?.info;
+  const [quoteEventTotalCount] = useSwapQuoteEventTotalCountAtom();
+  const [currentEventProviderKeys] = useSwapQuoteCurrentEventProviderKeysAtom();
+  const currentEventProviderKeySet = useMemo(
+    () => new Set(currentEventProviderKeys),
+    [currentEventProviderKeys],
+  );
+  const quoteListForDisplay = useMemo(
+    () =>
+      quoteEventTotalCount.count > 0
+        ? swapSortedList.filter((item) =>
+            currentEventProviderKeySet.has(buildSwapQuoteProviderKey(item)),
+          )
+        : swapSortedList,
+    [currentEventProviderKeySet, quoteEventTotalCount.count, swapSortedList],
+  );
 
   const onSelectSortChange = useCallback(
     (value: ESwapProviderSort) => {
@@ -108,10 +132,10 @@ const SwapProviderSelectModal = () => {
     [intl],
   );
   const sectionData = useMemo(() => {
-    const availableList = swapSortedList.filter(
+    const availableList = quoteListForDisplay.filter(
       (item) => item.toAmount && !item.limit?.min && !item.limit?.max,
     );
-    const unavailableList = swapSortedList.filter(
+    const unavailableList = quoteListForDisplay.filter(
       (item) => !item.toAmount || item.limit?.min || item.limit?.max,
     );
     return [
@@ -136,17 +160,17 @@ const SwapProviderSelectModal = () => {
           ]
         : []),
     ];
-  }, [intl, swapSortedList]);
+  }, [intl, quoteListForDisplay]);
   const onSelectQuote = useCallback(
     (item: IFetchQuoteResult) => {
-      setSwapManualSelect(item);
+      setSwapManualSelect(buildSwapManualProviderSelectionIntent(item));
       defaultLogger.swap.providerChange.providerChange({
-        changeFrom: currentSelectQuote?.info.provider ?? '-',
+        changeFrom: selectedProviderInfo?.provider ?? '-',
         changeTo: item.info.provider,
       });
       navigation.pop();
     },
-    [navigation, setSwapManualSelect, currentSelectQuote?.info.provider],
+    [navigation, setSwapManualSelect, selectedProviderInfo?.provider],
   );
   const renderItem = useCallback(
     ({ item }: { item: IFetchQuoteResult; index: number }) => {
@@ -176,8 +200,8 @@ const SwapProviderSelectModal = () => {
               : undefined
           }
           selected={Boolean(
-            item.info.provider === currentSelectQuote?.info.provider &&
-            item.info.providerName === currentSelectQuote?.info.providerName,
+            item.info.provider === selectedProviderInfo?.provider &&
+            item.info.providerName === selectedProviderInfo?.providerName,
           )}
           fromTokenAmount={fromTokenAmount.value}
           fromToken={fromToken}
@@ -189,11 +213,11 @@ const SwapProviderSelectModal = () => {
       );
     },
     [
-      currentSelectQuote?.info.provider,
-      currentSelectQuote?.info.providerName,
       fromToken,
       fromTokenAmount,
       onSelectQuote,
+      selectedProviderInfo?.provider,
+      selectedProviderInfo?.providerName,
       settingsPersist.currencyInfo.symbol,
       toToken,
     ],

--- a/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
@@ -22,6 +22,7 @@ import {
   useSwapQuoteCurrentSelectAtom,
   useSwapToAnotherAccountAddressAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
+import { buildSwapManualProviderSelectionIntent } from '@onekeyhq/kit/src/states/jotai/contexts/swap/quoteProgress';
 import { useSettingsAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
@@ -128,7 +129,9 @@ const SwapToAnotherAddressPage = () => {
         networkId,
         accountInfo: activeAccount,
       }));
-      setSwapManualSelectQuote(selectedQuote);
+      setSwapManualSelectQuote(
+        buildSwapManualProviderSelectionIntent(selectedQuote),
+      );
       navigation.pop();
     },
     [

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
@@ -1,0 +1,68 @@
+import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
+
+import { checkSwapLatestBalanceSufficient } from './swapBalanceUtils';
+
+type IFetchSwapTokenDetailsParams = {
+  networkId: string;
+  contractAddress: string;
+  accountAddress?: string;
+  accountId?: string;
+  currency?: string;
+};
+
+const mockFetchSwapTokenDetails: jest.MockedFunction<
+  (params: IFetchSwapTokenDetailsParams) => Promise<{ balanceParsed: string }[]>
+> = jest.fn();
+
+jest.mock('../../../background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {
+    serviceSwap: {
+      fetchSwapTokenDetails: (params: IFetchSwapTokenDetailsParams) =>
+        mockFetchSwapTokenDetails(params),
+    },
+  },
+}));
+
+const ethToken = {
+  networkId: 'evm--1',
+  contractAddress: '',
+  symbol: 'ETH',
+} as ISwapToken;
+
+describe('checkSwapLatestBalanceSufficient', () => {
+  beforeEach(() => {
+    mockFetchSwapTokenDetails.mockReset();
+  });
+
+  it('returns insufficient when the latest token balance is lower than amount', async () => {
+    mockFetchSwapTokenDetails.mockResolvedValue([{ balanceParsed: '0.08' }]);
+
+    await expect(
+      checkSwapLatestBalanceSufficient({
+        token: ethToken,
+        amount: '0.1',
+        accountId: 'account-id',
+        accountAddress: '0xabc',
+      }),
+    ).resolves.toEqual({
+      isSufficient: false,
+      balance: '0.08',
+      requiredAmount: '0.1',
+      tokenSymbol: 'ETH',
+    });
+  });
+
+  it('does not block when balance cannot be fetched', async () => {
+    mockFetchSwapTokenDetails.mockResolvedValue([]);
+
+    await expect(
+      checkSwapLatestBalanceSufficient({
+        token: ethToken,
+        amount: '0.1',
+        accountId: 'account-id',
+        accountAddress: '0xabc',
+      }),
+    ).resolves.toEqual({ isSufficient: true });
+  });
+});

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
@@ -1,0 +1,73 @@
+import BigNumber from 'bignumber.js';
+
+import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
+
+import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
+
+type ISwapLatestBalanceCheckParams = {
+  token: ISwapToken;
+  amount: string;
+  accountId?: string;
+  accountAddress?: string;
+};
+
+export type ISwapLatestBalanceCheckResult =
+  | {
+      isSufficient: true;
+    }
+  | {
+      isSufficient: false;
+      balance: string;
+      requiredAmount: string;
+      tokenSymbol: string;
+    };
+
+export async function checkSwapLatestBalanceSufficient({
+  token,
+  amount,
+  accountId,
+  accountAddress,
+}: ISwapLatestBalanceCheckParams): Promise<ISwapLatestBalanceCheckResult> {
+  const amountBN = new BigNumber(amount || 0);
+  if (
+    !token?.networkId ||
+    !accountAddress ||
+    amountBN.isNaN() ||
+    !amountBN.isFinite() ||
+    amountBN.lte(0)
+  ) {
+    return { isSufficient: true };
+  }
+
+  try {
+    const tokenBalanceInfo =
+      await backgroundApiProxy.serviceSwap.fetchSwapTokenDetails({
+        networkId: token.networkId,
+        contractAddress: token.contractAddress ?? '',
+        accountAddress,
+        accountId,
+        currency: 'usd',
+      });
+    if (!tokenBalanceInfo?.length) {
+      return { isSufficient: true };
+    }
+
+    const balanceBN = new BigNumber(tokenBalanceInfo[0].balanceParsed ?? 0);
+    if (balanceBN.isNaN() || !balanceBN.isFinite()) {
+      return { isSufficient: true };
+    }
+
+    if (amountBN.gt(balanceBN)) {
+      return {
+        isSufficient: false,
+        balance: balanceBN.toFixed(),
+        requiredAmount: amountBN.toFixed(),
+        tokenSymbol: token.symbol,
+      };
+    }
+  } catch (error) {
+    console.error('checkSwapLatestBalanceSufficient error', error);
+  }
+
+  return { isSufficient: true };
+}

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -234,6 +234,7 @@ export interface ISwapAutoSlippageSuggestedValue {
   value: number;
   from: string;
   to: string;
+  eventId: string;
 }
 
 // quote
@@ -681,6 +682,7 @@ export interface ISwapState {
   noConnectWallet?: boolean;
   approveUnLimit?: boolean;
   isRefreshQuote?: boolean;
+  isWaitingAutoSlippage?: boolean;
 }
 
 export interface ISwapApproveAllowanceResponse {
@@ -932,6 +934,7 @@ export interface IFetchSwapTxHistoryStatusResponse {
   state: ESwapTxHistoryStatus;
   extraStatus?: ESwapExtraStatus;
   crossChainStatus?: ESwapCrossChainStatus;
+  stateDetail?: string;
   crossChainReceiveTxHash?: string;
   gasFee?: string;
   gasFeeFiatValue?: string;
@@ -955,6 +958,7 @@ export interface ISwapTxHistory {
   status: ESwapTxHistoryStatus;
   extraStatus?: ESwapExtraStatus;
   crossChainStatus?: ESwapCrossChainStatus;
+  stateDetail?: string;
   swapOrderHash?: ISwapOrderHash;
   ctx?: any;
   currency?: string;


### PR DESCRIPTION
Sync bundle release changes from `release/v6.2.0` back to `x`.

## What's included (squashed from release/v6.2.0)

- #11305 feat(perp): simplify positions empty state (OK-53506)
- #11307 fix: sync swap history badge count with limit orders (OK-53226 OK-53243 OK-53291 OK-53430 OK-53500)
- #11300 / #11301 fix: pass origin to parse transaction request (OK-53490)
- #11317 fix: send flow and signature confirm regressions (OK-53537 OK-53449 OK-53370)
- #11310 feat(browser): add sidebar preference to place new tab at top (OK-53560)
- #11316 fix(logs): use RNFS.hash to compute log bundle sha256 (OK-53527)
- #11368 fix: normalize fiat send amount precision (OK-53784)
- #11338 fix: refresh Houdini swap balance on state detail updates (OK-53652)
- #11312 fix(swap): unblock swap on first actionable quote (OK-52655)
- #11352 fix: prevent stale swap balance orders (OK-53762 OK-53841)

## Excluded (release-branch only)

- `RELEASES.json` — release-branch tracking file with SHAs that don't exist on `x`.
- `BUILD_NUMBER` line in `.env.version` — bundle-build-only state; `x` is on `VERSION=6.3.0` without a build number.

## Conflict resolution

23 files conflicted; all resolved as additive merges (both sides' changes kept):

- 3 source files (`ServiceSetting.ts`, `settings.ts` atom, `SwapHistoryListModal.tsx`) — release additions placed alongside existing `x` additions.
- 19 auto-generated locale files + `translations.ts` enum — `x` already contained every release-only key (auto-gen out-of-band), and 17 zh-CN/HK/TW value mismatches were resolved in favor of `x` (Perps→合約 localization, 網絡↔網路 regional normalization, and a release-side spacing typo on `perp.trade_long`).

## Test plan

- [ ] CI green (lint, type check, tests)
- [ ] Spot-check Chinese translations on the affected keys
- [ ] Smoke-test swap history pending refresh, browser sidebar new-tab toggle
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
