### PR TITLE
fix: refine DeFi portfolio interactions (OK-53112)

### DIFF
--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
@@ -67,6 +67,7 @@ const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
 
 const MAX_PROTOCOLS_ON_SMALL_SCREEN = 6;
 const MAX_PROTOCOLS_ON_LARGE_SCREEN = OVERVIEW_TOP_N;
+const PROTOCOL_LIST_TOGGLE_PRESS_LOCK_MS = 600;
 
 export type IDeFiListBlockProps = {
   refreshCacheOnly?: boolean;
@@ -991,6 +992,50 @@ function DeFiListBlock({
     return sorted;
   }, [protocols, protocolMap, isOverflow, isSliced, tableLayout]);
 
+  const protocolListLockUntilRef = useRef(0);
+  const protocolListUnlockTimerRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
+  const [isProtocolListInteractionLocked, setIsProtocolListInteractionLocked] =
+    useState(false);
+
+  const isProtocolListLocked = useCallback(
+    () => protocolListLockUntilRef.current > Date.now(),
+    [],
+  );
+  const lockProtocolListInteractions = useCallback(() => {
+    protocolListLockUntilRef.current =
+      Date.now() + PROTOCOL_LIST_TOGGLE_PRESS_LOCK_MS;
+    setIsProtocolListInteractionLocked(true);
+
+    if (protocolListUnlockTimerRef.current) {
+      clearTimeout(protocolListUnlockTimerRef.current);
+    }
+    protocolListUnlockTimerRef.current = setTimeout(() => {
+      protocolListUnlockTimerRef.current = null;
+      setIsProtocolListInteractionLocked(false);
+    }, PROTOCOL_LIST_TOGGLE_PRESS_LOCK_MS);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (protocolListUnlockTimerRef.current) {
+        clearTimeout(protocolListUnlockTimerRef.current);
+      }
+    };
+  }, []);
+
+  const handleToggleSliced = useCallback(() => {
+    if (isProtocolListLocked()) return;
+    lockProtocolListInteractions();
+    setIsSliced(!isSliced);
+  }, [
+    isSliced,
+    isProtocolListLocked,
+    lockProtocolListInteractions,
+    setIsSliced,
+  ]);
+
   const renderSubTitle = useCallback(() => {
     if (!initialized && isRefreshing) {
       return <Skeleton.HeadingXl />;
@@ -1020,7 +1065,11 @@ function DeFiListBlock({
   const renderContent = useCallback(() => {
     return (
       <>
-        <YStack gap={tableLayout ? '$5' : '$0'} flex={1}>
+        <YStack
+          gap={tableLayout ? '$5' : '$0'}
+          flex={1}
+          pointerEvents={isProtocolListInteractionLocked ? 'none' : undefined}
+        >
           {filteredProtocols.map((protocol, index) => {
             const protocolKey = defiUtils.buildProtocolMapKey({
               protocol: protocol.protocol,
@@ -1049,7 +1098,8 @@ function DeFiListBlock({
             <Button
               size="small"
               variant="secondary"
-              onPress={() => setIsSliced(!isSliced)}
+              disabled={isProtocolListInteractionLocked}
+              onPress={handleToggleSliced}
               $md={
                 {
                   flexGrow: 1,
@@ -1074,7 +1124,8 @@ function DeFiListBlock({
     intl,
     isOverflow,
     isSliced,
-    setIsSliced,
+    isProtocolListInteractionLocked,
+    handleToggleSliced,
     registerProtocol,
   ]);
 

--- a/packages/kit/src/views/Home/components/DeFiListBlock/Protocol.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/Protocol.tsx
@@ -202,76 +202,84 @@ const ProtocolDesktopLayout = memo(
                   borderTopWidth={StyleSheet.hairlineWidth}
                   borderColor="$borderSubdued"
                 >
-                  {positions.map((position, index) => (
-                    <YStack key={position.positionKey} py="$3">
-                      <XStack
-                        alignItems="center"
-                        gap="$2"
-                        px="$5"
-                        minHeight={40}
+                  {positions.map((position, index) => {
+                    const isLastPosition = index === positions.length - 1;
+                    return (
+                      <YStack
+                        key={position.positionKey}
+                        pb={isLastPosition ? '$3' : '$0'}
                       >
-                        <Badge bg={position.categoryConfig.bg} badgeSize="lg">
-                          <Badge.Text color={position.categoryConfig.text}>
-                            {position.categoryLabel}
-                          </Badge.Text>
-                        </Badge>
-                        {position.poolName ? (
-                          <Popover
-                            hoverable
-                            placement="top"
-                            title={positionNamePopoverTitle}
-                            renderTrigger={
-                              <SizableText
-                                size="$headingSm"
-                                color="$textSubdued"
-                                numberOfLines={1}
-                                flex={1}
-                                minWidth={0}
-                              >
-                                {position.poolName}
-                              </SizableText>
-                            }
-                            renderContent={
-                              <Stack px="$4" py="$2">
-                                <SizableText size="$bodyLgMedium">
-                                  {position.poolFullName || position.poolName}
-                                </SizableText>
-                              </Stack>
-                            }
-                          />
-                        ) : (
-                          <Stack flex={1} />
-                        )}
-                        <NumberSizeableTextWrapper
-                          hideValue
-                          size="$headingMd"
-                          formatter="value"
-                          formatterOptions={{ currency: currencySymbol }}
-                          textAlign="right"
-                          numberOfLines={1}
-                          maxWidth="45%"
+                        <XStack
+                          alignItems="center"
+                          gap="$2"
+                          px="$5"
+                          minHeight={40}
                         >
-                          {position.value}
-                        </NumberSizeableTextWrapper>
-                      </XStack>
-                      <YStack gap="$2" px="$5">
-                        {position.sections.map((section) => (
-                          <ProtocolPositionSection
-                            key={section.key}
-                            itemKeyPrefix={position.positionKey}
-                            section={section}
-                            currencySymbol={currencySymbol}
-                            priceUnavailableLabel={priceUnavailableLabel}
-                          />
-                        ))}
+                          <Badge bg={position.categoryConfig.bg} badgeSize="lg">
+                            <Badge.Text color={position.categoryConfig.text}>
+                              {position.categoryLabel}
+                            </Badge.Text>
+                          </Badge>
+                          {position.poolName ? (
+                            <Stack flex={1} minWidth={0}>
+                              <Popover
+                                hoverable
+                                placement="top"
+                                title={positionNamePopoverTitle}
+                                renderTrigger={
+                                  <SizableText
+                                    size="$headingSm"
+                                    color="$textSubdued"
+                                    numberOfLines={1}
+                                    minWidth={0}
+                                  >
+                                    {position.poolName}
+                                  </SizableText>
+                                }
+                                renderContent={
+                                  <Stack px="$4" py="$2">
+                                    <SizableText size="$bodyLgMedium">
+                                      {position.poolFullName ||
+                                        position.poolName}
+                                    </SizableText>
+                                  </Stack>
+                                }
+                              />
+                            </Stack>
+                          ) : (
+                            <Stack flex={1} />
+                          )}
+                          <NumberSizeableTextWrapper
+                            hideValue
+                            size="$headingMd"
+                            formatter="value"
+                            formatterOptions={{ currency: currencySymbol }}
+                            textAlign="right"
+                            numberOfLines={1}
+                            maxWidth="45%"
+                          >
+                            {position.value}
+                          </NumberSizeableTextWrapper>
+                        </XStack>
+                        <YStack gap="$2" px="$5">
+                          {position.sections.map((section) => (
+                            <ProtocolPositionSection
+                              key={section.key}
+                              itemKeyPrefix={position.positionKey}
+                              section={section}
+                              currencySymbol={currencySymbol}
+                              priceUnavailableLabel={priceUnavailableLabel}
+                            />
+                          ))}
+                        </YStack>
+                        {index !== positions.length - 1 ? (
+                          <Stack px="$5">
+                            <Divider />
+                          </Stack>
+                        ) : null}
                       </YStack>
-                      {index !== positions.length - 1 ? (
-                        <Stack px="$5" py="$3">
-                          <Divider />
-                        </Stack>
-                      ) : null}
-                    </YStack>
-                  ))}
+                    );
+                  })}
                 </YStack>
               </Accordion.Content>
             </Accordion.Item>

--- a/packages/kit/src/views/Home/pages/DeFiContainer.tsx
+++ b/packages/kit/src/views/Home/pages/DeFiContainer.tsx
@@ -504,8 +504,8 @@ function DeFiContainer() {
   if (tableLayout) {
     return (
       <>
-        <XStack gap="$6">
-          <YStack flex={1} gap="$8" pt="$3" pb="$8">
+        <XStack gap="$6" pt="$3">
+          <YStack flex={1} gap="$8" pb="$8">
             {shouldShowOverview ? (
               <YStack gap="$6" px="$pagePadding" userSelect="none">
                 <DeFiPortfolioCard
@@ -546,7 +546,6 @@ function DeFiContainer() {
                     node as unknown as HTMLElement | null;
                 }}
                 width={PORTFOLIO_CONTAINER_RIGHT_SIDE_FIXED_WIDTH}
-                pt={isSidebarPinned ? '$0' : '$3'}
                 {...(isSidebarPinned
                   ? {
                       position: 'fixed' as any,

--- a/packages/kit/src/views/Home/pages/PortfolioContainer.tsx
+++ b/packages/kit/src/views/Home/pages/PortfolioContainer.tsx
@@ -1,4 +1,11 @@
-import { useMemo } from 'react';
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import {
   Stack,
@@ -9,28 +16,177 @@ import {
 } from '@onekeyhq/components';
 import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import { EHomeWalletTab } from '@onekeyhq/shared/types/wallet';
 
 import { useActiveAccount } from '../../../states/jotai/contexts/accountSelector';
 import { ProviderJotaiContextDeFiList } from '../../../states/jotai/contexts/deFiList';
 import { ProviderJotaiContextHistoryList } from '../../../states/jotai/contexts/historyList';
 import useActiveTabDAppInfo from '../../DAppConnection/hooks/useActiveTabDAppInfo';
 import { EarnProviderMirror } from '../../Earn/EarnProviderMirror';
-import { DeFiListBlock } from '../components/DeFiListBlock';
+import { DeFiListBlock, DeFiStickyPortal } from '../components/DeFiListBlock';
 import { EarnListView } from '../components/EarnListView';
+import { HomeStickyHeaderContext } from '../components/HomeStickyHeaderContext';
 import { HomeTokenListProviderMirrorWrapper } from '../components/HomeTokenListProvider';
 import { PopularTrading } from '../components/PopularTrading';
 import { PullToRefresh, onHomePageRefresh } from '../components/PullToRefresh';
-import { RecentHistory } from '../components/RecentHistory';
+import { RecentHistory, RecentHistoryTitle } from '../components/RecentHistory';
 import { SupportHub } from '../components/SupportHub';
 import { TokenListBlock } from '../components/TokenListBlock';
 import { Upgrade } from '../components/Upgrade';
-import { PORTFOLIO_CONTAINER_RIGHT_SIDE_FIXED_WIDTH } from '../types';
+import {
+  PORTFOLIO_CONTAINER_RIGHT_SIDE_FIXED_WIDTH,
+  STICKY_TOP_OFFSET,
+} from '../types';
+
+import {
+  findScrollableAncestorFromLocalNode,
+  getStickySidebarMaxHeight,
+} from './defiDesktopStickyDom';
+
+const SIDEBAR_STICKY_UNPIN_GAP = 8;
 
 function PortfolioContainer() {
   const media = useMedia();
 
   const tableLayout = media.gtMd;
   const showRecentHistory = media.gtXl;
+  const stickyHeaderCtx = useContext(HomeStickyHeaderContext);
+  const tabBarRightPortalTarget =
+    stickyHeaderCtx?.tabBarRightPortalTarget ?? null;
+  const isTabFocused =
+    stickyHeaderCtx?.activeTabId === EHomeWalletTab.Portfolio;
+
+  const sidebarRef = useRef<HTMLElement | null>(null);
+  const sidebarContentRef = useRef<HTMLElement | null>(null);
+  const [isSidebarPinned, setIsSidebarPinned] = useState(false);
+  const [sidebarShellHeight, setSidebarShellHeight] = useState(0);
+  const [sidebarFixedLeft, setSidebarFixedLeft] = useState(0);
+  const [sidebarStickyTop, setSidebarStickyTop] = useState(STICKY_TOP_OFFSET);
+  const [stickyLine, setStickyLine] = useState(STICKY_TOP_OFFSET);
+
+  useEffect(() => {
+    if (platformEnv.isNative || !tableLayout || !showRecentHistory) {
+      setIsSidebarPinned(false);
+      return;
+    }
+
+    let raf = 0;
+    let attachedScroller: HTMLElement | null = null;
+    const scrollOpts: AddEventListenerOptions = {
+      capture: true,
+      passive: true,
+    };
+
+    const resolveOriginNode = () => {
+      const sidebarNode = sidebarRef.current;
+      return sidebarNode?.isConnected ? sidebarNode : null;
+    };
+
+    let check = () => {};
+    let syncScrollerSubscription = () => {};
+    const schedule = () => {
+      syncScrollerSubscription();
+      if (raf) cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(check);
+    };
+
+    syncScrollerSubscription = () => {
+      const originNode = resolveOriginNode();
+      const nextScroller = originNode
+        ? findScrollableAncestorFromLocalNode(originNode)
+        : null;
+
+      if (attachedScroller === nextScroller) {
+        return;
+      }
+
+      if (attachedScroller) {
+        attachedScroller.removeEventListener('scroll', schedule, scrollOpts);
+      }
+
+      attachedScroller = nextScroller;
+
+      if (attachedScroller) {
+        attachedScroller.addEventListener('scroll', schedule, scrollOpts);
+      }
+    };
+
+    check = () => {
+      syncScrollerSubscription();
+
+      const stickyHostRect =
+        stickyHeaderCtx?.stickyHost?.getBoundingClientRect() ?? null;
+      const nextSidebarStickyTop =
+        stickyHostRect && stickyHostRect.bottom > 0
+          ? stickyHostRect.bottom
+          : STICKY_TOP_OFFSET;
+      setSidebarStickyTop((prev) =>
+        prev === nextSidebarStickyTop ? prev : nextSidebarStickyTop,
+      );
+      setStickyLine((prev) =>
+        prev === nextSidebarStickyTop ? prev : nextSidebarStickyTop,
+      );
+
+      const sidebarAnchor = sidebarRef.current;
+      if (!isTabFocused || !sidebarAnchor?.isConnected) {
+        setIsSidebarPinned(false);
+        return;
+      }
+
+      const sidebarRect = sidebarAnchor.getBoundingClientRect();
+      const measuredContentHeight =
+        sidebarContentRef.current?.getBoundingClientRect().height ??
+        sidebarRect.height;
+      const measuredHeight = Math.max(
+        sidebarRect.height,
+        measuredContentHeight,
+      );
+      setSidebarShellHeight((prev) =>
+        prev === measuredHeight ? prev : measuredHeight,
+      );
+      setSidebarFixedLeft((prev) =>
+        prev === sidebarRect.left ? prev : sidebarRect.left,
+      );
+
+      setIsSidebarPinned((prev) => {
+        const nextIsSidebarPinned = prev
+          ? sidebarRect.top <= nextSidebarStickyTop + SIDEBAR_STICKY_UNPIN_GAP
+          : sidebarRect.top <= nextSidebarStickyTop;
+        return prev === nextIsSidebarPinned ? prev : nextIsSidebarPinned;
+      });
+    };
+
+    syncScrollerSubscription();
+    globalThis.addEventListener('resize', schedule);
+    schedule();
+
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+      if (attachedScroller) {
+        attachedScroller.removeEventListener('scroll', schedule, scrollOpts);
+      }
+      globalThis.removeEventListener('resize', schedule);
+    };
+  }, [
+    isTabFocused,
+    stickyHeaderCtx?.stickyHost,
+    tableLayout,
+    showRecentHistory,
+  ]);
+
+  const registerSidebarRef = useCallback((node: unknown) => {
+    sidebarRef.current = node as HTMLElement | null;
+  }, []);
+
+  const registerSidebarContentRef = useCallback((node: unknown) => {
+    sidebarContentRef.current = node as HTMLElement | null;
+  }, []);
+
+  const stickySidebarMaxHeight = getStickySidebarMaxHeight({
+    viewportHeight: globalThis.window?.innerHeight ?? 0,
+    stickyLine,
+    bottomGap: 16,
+  });
 
   const { result: extensionActiveTabDAppInfo } = useActiveTabDAppInfo();
   const addPaddingOnListFooter = useMemo(
@@ -44,32 +200,59 @@ function PortfolioContainer() {
   // All-Networks loading state while the page is "unfocused" (modal open),
   // which causes the token list to be stuck in a loading state.
   return (
-    <Stack flexDirection={tableLayout ? 'row' : 'column'} pt="$3" gap="$6">
-      <YStack
-        flex={1}
-        gap={tableLayout ? '$10' : '$6'}
-        pb={tableLayout ? '$8' : '$4'}
-      >
-        <TokenListBlock
-          showRecentHistory={tableLayout ? showRecentHistory : undefined}
-          tableLayout={tableLayout || undefined}
-        />
-        <DeFiListBlock refreshCacheOnly />
-        <PopularTrading tableLayout={tableLayout || undefined} />
-        <EarnListView />
-        <Upgrade />
-        <SupportHub />
-      </YStack>
-      {tableLayout && showRecentHistory ? (
+    <>
+      <Stack flexDirection={tableLayout ? 'row' : 'column'} pt="$3" gap="$6">
         <YStack
-          width={PORTFOLIO_CONTAINER_RIGHT_SIDE_FIXED_WIDTH}
-          flexShrink={0}
+          flex={1}
+          gap={tableLayout ? '$10' : '$6'}
+          pb={tableLayout ? '$8' : '$4'}
         >
-          <RecentHistory />
+          <TokenListBlock
+            showRecentHistory={tableLayout ? showRecentHistory : undefined}
+            tableLayout={tableLayout || undefined}
+          />
+          <DeFiListBlock refreshCacheOnly />
+          <PopularTrading tableLayout={tableLayout || undefined} />
+          <EarnListView />
+          <Upgrade />
+          <SupportHub />
         </YStack>
+        {tableLayout && showRecentHistory ? (
+          <YStack
+            ref={registerSidebarRef as any}
+            width={PORTFOLIO_CONTAINER_RIGHT_SIDE_FIXED_WIDTH}
+            flexShrink={0}
+            height={isSidebarPinned ? sidebarShellHeight : undefined}
+          >
+            <YStack
+              ref={registerSidebarContentRef as any}
+              width={PORTFOLIO_CONTAINER_RIGHT_SIDE_FIXED_WIDTH}
+              {...(isSidebarPinned
+                ? {
+                    position: 'fixed' as any,
+                    top: sidebarStickyTop,
+                    left: sidebarFixedLeft,
+                    maxHeight: stickySidebarMaxHeight,
+                    overflow: 'scroll' as any,
+                    zIndex: 1,
+                  }
+                : null)}
+            >
+              <RecentHistory hideTitle={isSidebarPinned} />
+            </YStack>
+          </YStack>
+        ) : null}
+        {addPaddingOnListFooter ? <Stack h="$16" /> : null}
+      </Stack>
+      {tabBarRightPortalTarget &&
+      showRecentHistory &&
+      isTabFocused &&
+      isSidebarPinned ? (
+        <DeFiStickyPortal target={tabBarRightPortalTarget}>
+          <RecentHistoryTitle />
+        </DeFiStickyPortal>
       ) : null}
-      {addPaddingOnListFooter ? <Stack h="$16" /> : null}
-    </Stack>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- Align DeFi desktop Recent Activity sticky layout with the Spot portfolio page.
- Tighten DeFi protocol position spacing to match the Figma layout.
- Move each position value to the right side of the position header.

## Issues
- OK-53112

## Intent & Context
This follows the Slack/Figma feedback for the DeFi portfolio UI after PR #11299 landed on `x`. The visible issues were DeFi Recent Activity drift, misplaced position value text, missing click-lock protection on Show More/Less, and overly loose protocol position spacing.

## Root Cause
The DeFi page had its own sticky sidebar spacing path instead of matching the Spot portfolio container structure. The protocol position header also placed `flex` on the Popover trigger text rather than the direct row child, so the value stayed near the pool title instead of being pushed right. Position containers still had first-item and divider vertical padding that contradicted the tighter Figma layout.

## Changes Detail
- `DeFiContainer.tsx`: aligns desktop row top spacing with the Spot layout so the right sidebar uses the same coordinate model.
- `PortfolioContainer.tsx`: adds matching desktop Recent Activity sticky behavior and title portal handling.
- `Protocol.tsx`: moves the position value to the right side and removes extra position padding except the last bottom padding.
- `DeFiListBlock.tsx`: adds a short lock around Show More/Less to avoid duplicate click-through interactions.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop / Web
- **Risk Areas**: Desktop home page sticky behavior and DeFi protocol card layout. Native layout is not intended to change.

## Test plan
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Home/pages/DeFiContainer.tsx packages/kit/src/views/Home/pages/PortfolioContainer.tsx`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Home/components/DeFiListBlock/Protocol.tsx`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `yarn jest packages/kit/src/views/Home/components/DeFiListBlock/hooks/useDeFiOverviewTopN.test.ts packages/kit/src/views/Home/components/DeFiListBlock/DeFiPortfolioStats.test.ts packages/kit/src/views/Home/pages/__tests__/defiDesktopStickyDom.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
