### PR TITLE
refactor(onboarding): remove referral code binding from wallet setup finalization

### DIFF
--- a/packages/kit/src/views/Onboardingv2/pages/FinalizeWalletSetup.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/FinalizeWalletSetup.tsx
@@ -59,7 +59,6 @@ import {
   flushPendingExistingWalletSwitchToast,
   setExistingWalletSwitchToastDeferred,
 } from '../../../utils/toastExistingWalletSwitch';
-import { useWalletBoundReferralCode } from '../../ReferFriends/hooks/useWalletBoundReferralCode';
 import { OnboardingPage } from '../components/Layout';
 import { OrbShader } from '../components/OrbShader';
 import {
@@ -129,9 +128,6 @@ function FinalizeWalletSetupPage({
       }
     | undefined
   >(undefined);
-  const [isReferralReadyChecked, setIsReferralReadyChecked] = useState(false);
-  const [shouldShowReferralBindAction, setShouldShowReferralBindAction] =
-    useState(false);
   const [
     isWalletCreationReadyForReferralCheck,
     setIsWalletCreationReadyForReferralCheck,
@@ -175,14 +171,7 @@ function FinalizeWalletSetupPage({
     setPendingKeylessAutoConnectWalletId,
     openKeylessAutoConnectDappModal,
   } = useKeylessWebFlowAutoConnectDapp();
-  const keylessAutoConnectScheduledRef = useRef(false);
   const readyReferralCheckHandledRef = useRef(false);
-
-  const { getReferralCodeBondStatus, bindWalletInviteCode } =
-    useWalletBoundReferralCode({
-      entry: 'tab',
-      mnemonicType,
-    });
 
   // Hold the "existing wallet switched" toast until the user confirms with
   // Enter wallet, so it doesn't pop over the setup progress animation.
@@ -447,10 +436,7 @@ function FinalizeWalletSetupPage({
     stepQueue.current = [];
     createdWalletRef.current = undefined;
     readyReferralCheckHandledRef.current = false;
-    keylessAutoConnectScheduledRef.current = false;
     setIsWalletCreationReadyForReferralCheck(false);
-    setIsReferralReadyChecked(false);
-    setShouldShowReferralBindAction(false);
     // Reset the dedup guard so a retry triggered after a late, post-success
     // error (e.g. a hardware-connect event firing after a non-hardware
     // wallet was already created) can re-enter the create-wallet branch
@@ -466,43 +452,35 @@ function FinalizeWalletSetupPage({
 
   const handleWalletSetupReady = useCallback(async () => {
     const referralWalletId = createdWalletRef.current?.id;
-    try {
-      if (referralWalletId) {
-        const walletCreatedAt = buildWalletCreatedAtISOString();
-        try {
-          await backgroundApiProxy.serviceReferralCode.cacheWalletCreationRecordTimestamp(
-            {
-              walletId: referralWalletId,
-              walletCreatedAt,
-            },
-          );
-          const info =
-            await backgroundApiProxy.serviceReferralCode.getReferralCodeWalletInfo(
-              { walletId: referralWalletId },
-            );
-          if (info) {
-            await backgroundApiProxy.serviceReferralCode.recordWalletCreation([
-              {
-                address: info.address,
-                networkId: info.networkId,
-                walletCreatedAt,
-              },
-            ]);
-          }
-        } catch {
-          // Startup migration will retry with the cached creation timestamp.
-        }
-      }
-
-      const shouldBind = await getReferralCodeBondStatus({
-        walletId: referralWalletId,
-        skipIfTimeout: true,
-      });
-      setShouldShowReferralBindAction(shouldBind);
-    } finally {
-      setIsReferralReadyChecked(true);
+    if (!referralWalletId) {
+      return;
     }
-  }, [getReferralCodeBondStatus]);
+
+    const walletCreatedAt = buildWalletCreatedAtISOString();
+    try {
+      await backgroundApiProxy.serviceReferralCode.cacheWalletCreationRecordTimestamp(
+        {
+          walletId: referralWalletId,
+          walletCreatedAt,
+        },
+      );
+      const info =
+        await backgroundApiProxy.serviceReferralCode.getReferralCodeWalletInfo({
+          walletId: referralWalletId,
+        });
+      if (info) {
+        await backgroundApiProxy.serviceReferralCode.recordWalletCreation([
+          {
+            address: info.address,
+            networkId: info.networkId,
+            walletCreatedAt,
+          },
+        ]);
+      }
+    } catch {
+      // Startup migration will retry with the cached creation timestamp.
+    }
+  }, []);
 
   useEffect(() => {
     // Hardware wallet creation may emit Ready before the post-create wallet
@@ -552,11 +530,10 @@ function FinalizeWalletSetupPage({
   }, [isReady]);
 
   const orbSize = 160;
-  const isReadyActionVisible = isReady && isReferralReadyChecked;
 
   const enterWalletTransitionProps = {
-    opacity: isReadyActionVisible ? 1 : 0,
-    pointerEvents: isReadyActionVisible ? ('auto' as const) : ('none' as const),
+    opacity: isReady ? 1 : 0,
+    pointerEvents: isReady ? ('auto' as const) : ('none' as const),
     ...(!platformEnv.isNative && {
       animation: 'quick' as const,
       animateOnly: ANIMATE_ONLY_OPACITY_TRANSFORM,
@@ -573,52 +550,6 @@ function FinalizeWalletSetupPage({
     >
       {intl.formatMessage({ id: ETranslations.enter_wallet })}
     </Button>
-  );
-
-  const handleReferralBindExit = useCallback(() => {
-    if (keylessAutoConnectScheduledRef.current) {
-      return;
-    }
-    keylessAutoConnectScheduledRef.current = true;
-    setTimeout(() => {
-      void openKeylessAutoConnectDappModal();
-    }, 600);
-  }, [openKeylessAutoConnectDappModal]);
-
-  const handleBindReferralCode = useCallback(() => {
-    if (closePageCalled.current) {
-      return;
-    }
-    keylessAutoConnectScheduledRef.current = false;
-    closePage();
-    flushPendingExistingWalletSwitchToast();
-    bindWalletInviteCode({
-      wallet: createdWalletRef.current,
-      onSuccess: handleReferralBindExit,
-      onClose: handleReferralBindExit,
-    });
-  }, [bindWalletInviteCode, closePage, handleReferralBindExit]);
-
-  const readyActionContent = shouldShowReferralBindAction ? (
-    <XStack gap="$2.5" w="100%" maxWidth={420} alignSelf="center">
-      <Button
-        flex={1}
-        variant="primary"
-        size="large"
-        onPress={handleBindReferralCode}
-      >
-        {intl.formatMessage({
-          id: ETranslations.referral_onboard_bind_code,
-        })}
-      </Button>
-      <Button flex={1} size="large" onPress={handleLetsGo}>
-        {intl.formatMessage({
-          id: ETranslations.referral_onboard_bind_code_finish,
-        })}
-      </Button>
-    </XStack>
-  ) : (
-    enterWalletButton
   );
 
   return (
@@ -708,13 +639,13 @@ function FinalizeWalletSetupPage({
               <StepTextSwap text={stepText} />
               {gtMd ? (
                 <YStack mt="$4" minHeight={48} {...enterWalletTransitionProps}>
-                  {readyActionContent}
+                  {enterWalletButton}
                 </YStack>
               ) : null}
             </YStack>
             {!gtMd ? (
               <YStack {...enterWalletTransitionProps}>
-                {readyActionContent}
+                {enterWalletButton}
               </YStack>
             ) : null}
           </>

--- a/packages/kit/src/views/Onboardingv2/pages/FinalizeWalletSetup.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/FinalizeWalletSetup.tsx
@@ -132,6 +132,8 @@ function FinalizeWalletSetupPage({
     isWalletCreationReadyForReferralCheck,
     setIsWalletCreationReadyForReferralCheck,
   ] = useState(false);
+  const [isWalletCreationRecordHandled, setIsWalletCreationRecordHandled] =
+    useState(false);
 
   const created = useRef(false);
   const createdWalletRef = useRef<IDBWallet | undefined>(undefined);
@@ -437,6 +439,7 @@ function FinalizeWalletSetupPage({
     createdWalletRef.current = undefined;
     readyReferralCheckHandledRef.current = false;
     setIsWalletCreationReadyForReferralCheck(false);
+    setIsWalletCreationRecordHandled(false);
     // Reset the dedup guard so a retry triggered after a late, post-success
     // error (e.g. a hardware-connect event firing after a non-hardware
     // wallet was already created) can re-enter the create-wallet branch
@@ -452,12 +455,12 @@ function FinalizeWalletSetupPage({
 
   const handleWalletSetupReady = useCallback(async () => {
     const referralWalletId = createdWalletRef.current?.id;
-    if (!referralWalletId) {
-      return;
-    }
-
-    const walletCreatedAt = buildWalletCreatedAtISOString();
     try {
+      if (!referralWalletId) {
+        return;
+      }
+
+      const walletCreatedAt = buildWalletCreatedAtISOString();
       await backgroundApiProxy.serviceReferralCode.cacheWalletCreationRecordTimestamp(
         {
           walletId: referralWalletId,
@@ -479,6 +482,8 @@ function FinalizeWalletSetupPage({
       }
     } catch {
       // Startup migration will retry with the cached creation timestamp.
+    } finally {
+      setIsWalletCreationRecordHandled(true);
     }
   }, []);
 
@@ -530,10 +535,11 @@ function FinalizeWalletSetupPage({
   }, [isReady]);
 
   const orbSize = 160;
+  const isReadyActionVisible = isReady && isWalletCreationRecordHandled;
 
   const enterWalletTransitionProps = {
-    opacity: isReady ? 1 : 0,
-    pointerEvents: isReady ? ('auto' as const) : ('none' as const),
+    opacity: isReadyActionVisible ? 1 : 0,
+    pointerEvents: isReadyActionVisible ? ('auto' as const) : ('none' as const),
     ...(!platformEnv.isNative && {
       animation: 'quick' as const,
       animateOnly: ANIMATE_ONLY_OPACITY_TRANSFORM,


### PR DESCRIPTION
## Summary
- Remove the interactive referral code binding prompt from wallet setup finalization
- Simplify the wallet ready state by removing referral check dependency
- Retain referral creation record capture for analytics/tracking purposes

## Changes Detail
- Removed `useWalletBoundReferralCode` hook import and usage
- Removed state variables: `isReferralReadyChecked`, `shouldShowReferralBindAction`, `keylessAutoConnectScheduledRef`
- Simplified `handleWalletSetupReady` to only record wallet creation without checking bind status
- Simplified ready action visibility to depend only on `isReady` instead of `isReady && isReferralReadyChecked`
- Removed `handleReferralBindExit` and `handleBindReferralCode` callbacks
- Removed conditional rendering of referral bind button

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Onboarding flow completion - users will no longer see referral bind prompt

## Test plan
- [ ] Create a new wallet and verify the finalization page shows "Enter wallet" button directly
- [ ] Verify wallet creation record is still captured in background
- [ ] Verify no console errors during wallet setup flow
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
