### PR TITLE
feat(referral): add tooltip for not applicable referral code binding status

### DIFF
--- a/packages/components/src/actions/ActionList/index.tsx
+++ b/packages/components/src/actions/ActionList/index.tsx
@@ -52,6 +52,7 @@ export interface IActionListItemProps {
   onPress?: (close: () => void) => void | Promise<boolean | void>;
   onClose?: () => void;
   disabled?: boolean;
+  extraInteractiveWhenDisabled?: boolean;
   testID?: string;
   trackID?: string;
   shortcutKeys?: string[] | EShortcutEvents;
@@ -113,11 +114,16 @@ export function ActionListItem(
     onPress,
     destructive,
     disabled,
+    extraInteractiveWhenDisabled,
     onClose,
     testID,
     shortcutKeys,
     isLoading,
   } = props;
+  const isActionDisabled = Boolean(disabled);
+  const shouldKeepExtraInteractive = Boolean(
+    isActionDisabled && extraInteractiveWhenDisabled,
+  );
 
   const handlePress = useCallback(
     async (event: GestureResponderEvent) => {
@@ -156,10 +162,10 @@ export function ActionListItem(
       $md={ACTION_LIST_ITEM_MD}
       borderCurve="continuous"
       opacity={disabled ? 0.5 : 1}
-      disabled={disabled}
+      disabled={shouldKeepExtraInteractive ? false : disabled}
       aria-disabled={disabled}
       {...(!disabled && ACTION_LIST_ENABLED_STYLE)}
-      onPress={isLoading ? undefined : sharedOnPress}
+      onPress={isLoading || isActionDisabled ? undefined : sharedOnPress}
       testID={testID}
     >
       <XStack jc="space-between" flex={1} alignItems="center">

--- a/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletBoundReferralCodeButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletBoundReferralCodeButton.tsx
@@ -2,7 +2,16 @@ import { useCallback, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { ActionList, Badge } from '@onekeyhq/components';
+import {
+  ActionList,
+  Badge,
+  Icon,
+  Popover,
+  SizableText,
+  Tooltip,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
@@ -13,8 +22,39 @@ import {
 } from '@onekeyhq/kit/src/views/ReferFriends/hooks/useWalletBoundReferralCode/referralBindStatusUtils';
 import type { IDBWallet } from '@onekeyhq/kit-bg/src/dbs/local/types';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
+
+function NotApplicableTooltip({ description }: { description: string }) {
+  const renderTrigger = (
+    <Icon name="InfoCircleOutline" color="$iconSubdued" size="$4" />
+  );
+
+  if (platformEnv.isNative) {
+    return (
+      <Popover
+        title=""
+        showHeader={false}
+        placement="top-end"
+        renderTrigger={renderTrigger}
+        renderContent={
+          <YStack p="$5">
+            <SizableText size="$bodyLg">{description}</SizableText>
+          </YStack>
+        }
+      />
+    );
+  }
+
+  return (
+    <Tooltip
+      placement="top-end"
+      renderTrigger={renderTrigger}
+      renderContent={description}
+    />
+  );
+}
 
 function WalletBoundReferralCodeButtonView({
   wallet,
@@ -89,6 +129,9 @@ function WalletBoundReferralCodeButtonView({
 
   const shouldBoundReferralCode = referralCodeButtonState?.shouldBound;
   const isNotBindable = referralCodeButtonState?.isNotBindable;
+  const notApplicableDesc = intl.formatMessage({
+    id: ETranslations.referral_not_applicable_desc,
+  });
 
   const handlePress = useCallback(async () => {
     if (isLoading) {
@@ -143,21 +186,30 @@ function WalletBoundReferralCodeButtonView({
       })}
       extra={
         shouldBoundReferralCode ? undefined : (
-          <Badge badgeSize="sm" badgeType={isNotBindable ? 'default' : 'info'}>
-            <Badge.Text size="$bodySmMedium">
-              {intl.formatMessage({
-                id: isNotBindable
-                  ? ETranslations.referral_not_applicable
-                  : ETranslations.referral_wallet_bind_code_finish,
-              })}
-            </Badge.Text>
-          </Badge>
+          <XStack ai="center" gap="$1" flexShrink={0}>
+            <Badge
+              badgeSize="sm"
+              badgeType={isNotBindable ? 'default' : 'info'}
+            >
+              <Badge.Text size="$bodySmMedium">
+                {intl.formatMessage({
+                  id: isNotBindable
+                    ? ETranslations.referral_not_applicable
+                    : ETranslations.referral_wallet_bind_code_finish,
+                })}
+              </Badge.Text>
+            </Badge>
+            {isNotBindable ? (
+              <NotApplicableTooltip description={notApplicableDesc} />
+            ) : null}
+          </XStack>
         )
       }
       onPress={handlePress}
       isLoading={isLoading}
       onClose={onClose}
       disabled={Boolean(!shouldBoundReferralCode)}
+      extraInteractiveWhenDisabled={Boolean(isNotBindable)}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Add `extraInteractiveWhenDisabled` prop to ActionList component to allow tooltip interaction on disabled items
- Add info tooltip/popover to explain why a wallet is "Not Applicable" for referral code binding
- Use Popover on native platforms (iOS/Android) and Tooltip on desktop/web for platform-appropriate UX

## Intent & Context
Users seeing "Not Applicable" status for referral code binding had no way to understand why their wallet couldn't be bound. This change adds an informational tooltip that explains the reason when users tap/hover the info icon.

## Design Decisions
- **New ActionList prop**: Added `extraInteractiveWhenDisabled` instead of modifying disabled behavior globally, keeping the change opt-in and backward compatible
- **Platform-specific tooltip**: Native platforms use Popover (better touch UX), desktop/web use Tooltip (better mouse UX)
- **Icon placement**: Info icon placed after the badge for visual consistency

## Changes Detail
- `packages/components/src/actions/ActionList/index.tsx`: Added `extraInteractiveWhenDisabled` prop that keeps the item touchable for secondary interactions while preventing the main action
- `packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletBoundReferralCodeButton.tsx`: Added `NotApplicableTooltip` component with platform detection and integrated it with the existing referral code button

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: ActionList behavior change is opt-in only, minimal regression risk

## Test plan
- [ ] Verify "Not Applicable" wallet shows info icon next to badge
- [ ] Tap/click info icon shows tooltip with explanation text
- [ ] On mobile: Popover appears with description
- [ ] On desktop/web: Tooltip appears on hover
- [ ] Disabled item still prevents main action (bind referral code)
- [ ] Other ActionList items unaffected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
