### PR TITLE
chore(cli): bump alpha version to 0.1.0-alpha.5

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/cli",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "OneKey wallet CLI for developers and AI agents",
   "bin": {
     "onekey": "./bin/onekey"


### PR DESCRIPTION
## Summary
- Bump `@onekeyfe/cli` from `0.1.0-alpha.4` to `0.1.0-alpha.5`.
- Prepare the next prerelease package so the manual `publish-cli` workflow can publish the hardware wallet login and device command changes to NPM under the `next` dist-tag.

## Intent & Context
The current NPM `@onekeyfe/cli@next` package is `0.1.0-alpha.4`, published from commit `055bc4d5` before the hardware wallet login changes landed. The hardware work is now on `x`, so this PR only increments the CLI prerelease version to avoid an NPM version conflict when rerunning the publish workflow.

## Design Decisions
Keep the change limited to `apps/cli/package.json` because the Yarn workspace lock entry does not record the workspace package version. The existing publish workflow treats prerelease versions as `next`, so `0.1.0-alpha.5` is the minimal release bump.

## Changes Detail
- `apps/cli/package.json`: update `@onekeyfe/cli` version to `0.1.0-alpha.5`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: CLI
- **Risk Areas**: NPM publish metadata only; no runtime code changes.

## Test plan
- [x] `node -p "require('./apps/cli/package.json').version"`
- [x] `npm view @onekeyfe/cli@0.1.0-alpha.5 version --json` returns 404, confirming the version is available
- [x] `yarn workspace @onekeyfe/cli build`
- [x] `node apps/cli/dist/cli.js --version`
- [x] `npm pack --dry-run --json` from `apps/cli`
- [x] `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
