### PR TITLE
feat: backport Bitrefill payment intent checkout to v6.2.0 bundle (OK-46521)

### DIFF
--- a/development/spellCheckerSkipWords.txt
+++ b/development/spellCheckerSkipWords.txt
@@ -13,6 +13,9 @@ _j_msgid
 oxlintrc
 0x1fffffffffffff
 skillshare
+bitrefill
+Bitrefill
+BITREFILL
 worktree
 googleusercontent
 0xf7ad23226db5c1c00ca0ca1468fd49c8f8bbc1489bc1c382de5adc557a69c229

--- a/packages/kit-bg/src/services/ServiceScanQRCode/handlePaymentUri.test.ts
+++ b/packages/kit-bg/src/services/ServiceScanQRCode/handlePaymentUri.test.ts
@@ -1,0 +1,69 @@
+// yarn jest packages/kit-bg/src/services/ServiceScanQRCode/handlePaymentUri.test.ts
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+
+import ServiceScanQRCode from '.';
+
+import { OneKeyError } from '@onekeyhq/shared/src/errors';
+import { EQRCodeHandlerType } from '@onekeyhq/shared/types/qrCode';
+
+jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
+  backgroundClass: () => (target: any) => target,
+  backgroundMethod: () => (_t: any, _k: string, desc: any) => desc,
+  backgroundMethodForDev: () => (_t: any, _k: string, desc: any) => desc,
+}));
+
+jest.mock('@onekeyhq/shared/src/logger/logger', () => ({
+  defaultLogger: {
+    scanQrCode: {
+      parseQrCode: {
+        parsedQrCode: jest.fn(),
+      },
+    },
+  },
+}));
+
+const mockBackgroundApi = {} as any;
+
+describe('ServiceScanQRCode.handlePaymentUri', () => {
+  let service: ServiceScanQRCode;
+
+  beforeEach(() => {
+    service = new ServiceScanQRCode({ backgroundApi: mockBackgroundApi });
+  });
+
+  it('parses a valid ethereum: URI into structured data', async () => {
+    const result = await service.handlePaymentUri({
+      uri: 'ethereum:0x3dD3DfaAdA4d6765Ae19b8964E2BAC0139eeCb40@1?value=1e17',
+    });
+    expect(result.type).toBe(EQRCodeHandlerType.ETHEREUM);
+    expect(result.data).toMatchObject({
+      address: '0x3dD3DfaAdA4d6765Ae19b8964E2BAC0139eeCb40',
+    });
+  });
+
+  it('throws OneKeyError for bitcoin: URI (not supported in minimal integration)', async () => {
+    await expect(
+      service.handlePaymentUri({
+        uri: 'bitcoin:bc1q...?amount=0.001',
+      }),
+    ).rejects.toThrow(OneKeyError);
+  });
+
+  it('throws OneKeyError for non-URI string', async () => {
+    await expect(
+      service.handlePaymentUri({ uri: 'not a uri' }),
+    ).rejects.toThrow(OneKeyError);
+  });
+
+  it('throws OneKeyError for empty URI', async () => {
+    await expect(service.handlePaymentUri({ uri: '' })).rejects.toThrow(
+      OneKeyError,
+    );
+  });
+
+  it('throws OneKeyError for malformed ethereum: URI (no address)', async () => {
+    await expect(
+      service.handlePaymentUri({ uri: 'ethereum:?value=1e17' }),
+    ).rejects.toThrow(OneKeyError);
+  });
+});

--- a/packages/kit-bg/src/services/ServiceScanQRCode/index.ts
+++ b/packages/kit-bg/src/services/ServiceScanQRCode/index.ts
@@ -3,6 +3,11 @@ import {
   backgroundClass,
   backgroundMethod,
 } from '@onekeyhq/shared/src/background/backgroundDecorators';
+import { OneKeyError } from '@onekeyhq/shared/src/errors';
+import {
+  EQRCodeHandlerNames,
+  EQRCodeHandlerType,
+} from '@onekeyhq/shared/types/qrCode';
 
 import ServiceBase from '../ServiceBase';
 
@@ -28,6 +33,31 @@ class ServiceScanQRCode extends ServiceBase {
   @backgroundMethod()
   public async resetAnimationData() {
     resetAnimationQrcodeScan();
+  }
+
+  /**
+   * Parse a payment URI (e.g. from a third-party widget like Bitrefill) and
+   * return structured data. The UI layer is responsible for opening the send
+   * modal with this data. Only ethereum: URIs are supported in the current
+   * minimal integration — callers should catch OneKeyError and surface a
+   * user-facing message for unsupported schemes.
+   */
+  @backgroundMethod()
+  public async handlePaymentUri({ uri }: { uri: string }) {
+    if (!uri || typeof uri !== 'string') {
+      throw new OneKeyError('Unsupported payment URI');
+    }
+
+    const result = await parseQRCode(uri, {
+      handlers: [EQRCodeHandlerNames.ethereum],
+      backgroundApi: this.backgroundApi,
+    });
+
+    if (result.type !== EQRCodeHandlerType.ETHEREUM) {
+      throw new OneKeyError('Unsupported payment URI');
+    }
+
+    return result;
   }
 }
 

--- a/packages/kit/src/views/Discovery/components/WebContent/WebContent.desktop.tsx
+++ b/packages/kit/src/views/Discovery/components/WebContent/WebContent.desktop.tsx
@@ -13,16 +13,25 @@ import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import uriUtils from '@onekeyhq/shared/src/utils/uriUtils';
 import { EValidateUrlEnum } from '@onekeyhq/shared/types/dappConnection';
 
+import {
+  BITREFILL_BRIDGE_SCRIPT,
+  isBitrefillEmbedUrl,
+} from '../../utils/bitrefillUtils';
 import { webviewRefs } from '../../utils/explorerUtils';
 import BlockAccessView from '../BlockAccessView';
 
 import type { IWebTab } from '../../types';
+import type { IJsBridgeReceiveHandler } from '@onekeyfe/cross-inpage-provider-types';
 import type { DidStartNavigationEvent, PageTitleUpdatedEvent } from 'electron';
 import type { WebViewProps } from 'react-native-webview';
 
-type IWebContentProps = IWebTab & WebViewProps;
+type IWebContentProps = IWebTab &
+  WebViewProps & {
+    isCurrent?: boolean;
+    customReceiveHandler?: IJsBridgeReceiveHandler;
+  };
 
-function WebContent({ id, url }: IWebContentProps) {
+function WebContent({ id, url, customReceiveHandler }: IWebContentProps) {
   const navigation = useAppNavigation();
   const urlRef = useRef<string>('');
   const phishingUrlRef = useRef<string>('');
@@ -112,13 +121,42 @@ function WebContent({ id, url }: IWebContentProps) {
     },
     [getWebTabById, id, setWebTabData],
   );
+  // Keep a ref to the latest url so onDomReady can read it without depending
+  // on `url`. Making `url` a dep of onDomReady invalidates the `webview`
+  // useMemo below, forces React to replace the <WebView> element, and lets
+  // Electron rebuild the webview instance — which wipes in-flight DApp
+  // state (e.g. the Bitrefill checkout page would redirect back to
+  // payment-method mid-flow).
+  const latestUrlRef = useRef(url);
+  useEffect(() => {
+    latestUrlRef.current = url;
+  }, [url]);
+
   const onDomReady = useCallback(() => {
     const ref = webviewRefs[id];
     if (ref) {
       // @ts-expect-error
       ref.__domReady = true;
     }
+    // Inject the Bitrefill bridge on every dom-ready so raw window.postMessage
+    // events from embed.bitrefill.com are re-emitted as $private JSBridge
+    // requests reaching useDiscoveryMessageHandler.
+    const currentUrl = latestUrlRef.current;
+    if (isBitrefillEmbedUrl(currentUrl)) {
+      const webviewEl = ref?.innerRef as IElectronWebView | undefined;
+      try {
+        const result = webviewEl?.executeJavaScript?.(BITREFILL_BRIDGE_SCRIPT);
+        if (result && typeof (result as Promise<unknown>).then === 'function') {
+          (result as Promise<unknown>).catch(() => {
+            // best-effort injection
+          });
+        }
+      } catch {
+        // best-effort injection
+      }
+    }
   }, [id]);
+
   const webview = useMemo(
     () => {
       const isValidate = validateWebviewSrc({ url, isTopFrame: true });
@@ -129,6 +167,7 @@ function WebContent({ id, url }: IWebContentProps) {
         <WebView
           id={id}
           src={url}
+          customReceiveHandler={customReceiveHandler}
           onWebViewRef={(ref) => {
             if (ref && ref.innerRef) {
               if (!webviewRefs[id]) {
@@ -159,6 +198,7 @@ function WebContent({ id, url }: IWebContentProps) {
       onDidStartLoading,
       onDidStartNavigation,
       onDomReady,
+      customReceiveHandler,
       // onPageTitleUpdated,
       // onPageFaviconUpdated,
     ],

--- a/packages/kit/src/views/Discovery/components/WebContent/WebContent.native.tsx
+++ b/packages/kit/src/views/Discovery/components/WebContent/WebContent.native.tsx
@@ -17,11 +17,16 @@ import { useSettingsFiatPaySiteWhitelistPersistAtom } from '@onekeyhq/kit-bg/src
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EValidateUrlEnum } from '@onekeyhq/shared/types/dappConnection';
 
+import {
+  BITREFILL_BRIDGE_SCRIPT,
+  isBitrefillEmbedUrl,
+} from '../../utils/bitrefillUtils';
 import { webviewRefs } from '../../utils/explorerUtils';
 import { showTabBar } from '../../utils/tabBarUtils';
 import BlockAccessView from '../BlockAccessView';
 
 import type { IWebTab } from '../../types';
+import type { IJsBridgeReceiveHandler } from '@onekeyfe/cross-inpage-provider-types';
 import type {
   WebView as ReactNativeWebview,
   WebViewMessageEvent,
@@ -38,6 +43,7 @@ type IWebContentProps = IWebTab &
     isCurrent: boolean;
     setBackEnabled: Dispatch<SetStateAction<boolean>>;
     setForwardEnabled: Dispatch<SetStateAction<boolean>>;
+    customReceiveHandler?: IJsBridgeReceiveHandler;
   };
 
 function WebContent({
@@ -50,6 +56,7 @@ function WebContent({
   setForwardEnabled,
   onScroll,
   siteMode,
+  customReceiveHandler,
 }: IWebContentProps) {
   const lastNavEventSnapshot = useRef('');
   const showHome = url === homeTab.url;
@@ -85,6 +92,17 @@ function WebContent({
       return;
     }
     changeNavigationInfo({ ...nativeEvent });
+    // Inject Bitrefill bridge for raw postMessage → JSBridge forwarding.
+    if (isBitrefillEmbedUrl(nativeEvent.url)) {
+      const webview = webviewRefs[id]?.innerRef as
+        | ReactNativeWebview
+        | undefined;
+      try {
+        webview?.injectJavaScript?.(BITREFILL_BRIDGE_SCRIPT);
+      } catch {
+        // best-effort injection
+      }
+    }
   };
 
   const onNavigationStateChange = useCallback(
@@ -164,6 +182,7 @@ function WebContent({
         pullToRefreshEnabled={!platformEnv.isNativeAndroid}
         src={url}
         mediaPermissionWhitelist={fiatPaySiteWhitelist}
+        customReceiveHandler={customReceiveHandler}
         onWebViewRef={(ref) => {
           if (ref && ref.innerRef) {
             if (!webviewRefs[id]) {
@@ -212,6 +231,7 @@ function WebContent({
       showHome,
       siteMode,
       url,
+      customReceiveHandler,
     ],
   );
 

--- a/packages/kit/src/views/Discovery/components/WebContent/WebContent.tsx
+++ b/packages/kit/src/views/Discovery/components/WebContent/WebContent.tsx
@@ -8,6 +8,7 @@ import { useBrowserTabActions } from '@onekeyhq/kit/src/states/jotai/contexts/di
 import { webviewRefs } from '../../utils/explorerUtils';
 
 import type { IWebTab } from '../../types';
+import type { IJsBridgeReceiveHandler } from '@onekeyfe/cross-inpage-provider-types';
 import type { WebViewMessageEvent, WebViewProps } from 'react-native-webview';
 
 type IWebContentProps = IWebTab &
@@ -15,9 +16,10 @@ type IWebContentProps = IWebTab &
     isCurrent: boolean;
     setBackEnabled?: Dispatch<SetStateAction<boolean>>;
     setForwardEnabled?: Dispatch<SetStateAction<boolean>>;
+    customReceiveHandler?: IJsBridgeReceiveHandler;
   };
 
-function WebContent({ id, url }: IWebContentProps) {
+function WebContent({ id, url, customReceiveHandler }: IWebContentProps) {
   const { setWebTabData } = useBrowserTabActions().current;
 
   const handleMessage = useCallback(
@@ -32,6 +34,7 @@ function WebContent({ id, url }: IWebContentProps) {
       <WebView
         id={id}
         src={url}
+        customReceiveHandler={customReceiveHandler}
         onMessage={handleMessage}
         onWebViewRef={(ref) => {
           if (ref && ref.innerRef) {
@@ -48,7 +51,7 @@ function WebContent({ id, url }: IWebContentProps) {
       />
     ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [id],
+    [id, customReceiveHandler],
   );
 
   return webview;

--- a/packages/kit/src/views/Discovery/hooks/useDiscoveryMessageHandler.ts
+++ b/packages/kit/src/views/Discovery/hooks/useDiscoveryMessageHandler.ts
@@ -1,0 +1,326 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import {
+  IInjectedProviderNames,
+  type IJsBridgeMessagePayload,
+} from '@onekeyfe/cross-inpage-provider-types';
+
+import { Toast } from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { parseOnChainAmount } from '@onekeyhq/kit/src/views/ScanQrCode/hooks/useParseQRCode';
+import type { IChainValue } from '@onekeyhq/kit-bg/src/services/ServiceScanQRCode/utils/parseQRCode/type';
+import { OneKeyError } from '@onekeyhq/shared/src/errors';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import type { IBitrefillFailStep } from '@onekeyhq/shared/src/logger/scopes/discovery/scenes/bitrefill';
+
+import {
+  isBitrefillOrigin,
+  parseBitrefillPaymentIntent,
+} from '../utils/bitrefillHandler';
+import {
+  BITREFILL_BRIDGE_METHOD,
+  BITREFILL_EMBED_ORIGIN,
+} from '../utils/bitrefillUtils';
+
+const BITREFILL_DAPP_SCOPE = IInjectedProviderNames.ethereum;
+
+// EIP-1193 user-rejected-request code. Also what web3Errors.provider
+// .userRejectedRequest() emits when a dApp connection modal is closed.
+const USER_REJECTED_CODE = 4001;
+
+function isUserRejectedError(error: unknown): boolean {
+  const code = (error as { code?: number } | null | undefined)?.code;
+  return code === USER_REJECTED_CODE;
+}
+
+class BitrefillStepError extends OneKeyError {
+  step: IBitrefillFailStep;
+
+  constructor(step: IBitrefillFailStep, message: string) {
+    super(message);
+    this.step = step;
+  }
+}
+
+/**
+ * Hook to handle Discovery WebView messages.
+ * Filters for Bitrefill payment_intent events, ensures a DApp wallet connection
+ * exists (prompting if needed), switches to the target network if required,
+ * builds the on-chain transaction from the paymentUri, then opens the DApp
+ * signature-and-send modal so the user just confirms the pre-built tx.
+ *
+ * Trust boundary: we trust postMessages coming from `embed.bitrefill.com`
+ * and rely on the user's final confirmation in the sign-and-send modal
+ * (recipient / amount / network) as the last safety net.
+ *
+ * This mirrors eth_sendTransaction semantics — Bitrefill already defines all
+ * payment parameters (recipient, token, amount) so we skip the Send form.
+ */
+export function useDiscoveryMessageHandler() {
+  const isMountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      isMountedRef.current = false;
+    },
+    [],
+  );
+
+  const customReceiveHandler = useCallback(
+    async (payload: IJsBridgeMessagePayload) => {
+      if (!isBitrefillOrigin(payload.origin)) return;
+
+      // Bitrefill raw window.postMessage does not flow through JSBridge. The
+      // webview page is injected with a bridge script (see BITREFILL_BRIDGE_SCRIPT)
+      // that re-emits each postMessage as $private/wallet_bitrefillEvent, which
+      // arrives here as a JSBridge REQUEST. Unwrap params[0] to get the original
+      // Bitrefill event payload.
+      const data = payload.data as
+        | { method?: string; params?: unknown[] }
+        | undefined;
+      if (data?.method !== BITREFILL_BRIDGE_METHOD) return;
+
+      const rawEvent = Array.isArray(data.params) ? data.params[0] : null;
+      const message = parseBitrefillPaymentIntent(rawEvent);
+      if (!message) {
+        // Non-payment_intent Bitrefill events (invoice_created/update/complete) — ignore silently
+        return;
+      }
+
+      const dappRequest: IJsBridgeMessagePayload = {
+        origin: BITREFILL_EMBED_ORIGIN,
+        scope: BITREFILL_DAPP_SCOPE,
+      };
+
+      try {
+        // 1. Parse paymentUri → recipient / tokenAddress / amount / network
+        let chainValue: IChainValue;
+        let result: Awaited<
+          ReturnType<
+            typeof backgroundApiProxy.serviceScanQRCode.handlePaymentUri
+          >
+        >;
+        try {
+          result = await backgroundApiProxy.serviceScanQRCode.handlePaymentUri({
+            uri: message.paymentUri,
+          });
+          chainValue = result.data as IChainValue;
+        } catch (e) {
+          throw new BitrefillStepError(
+            'handlePaymentUri',
+            (e as Error)?.message ?? 'handlePaymentUri failed',
+          );
+        }
+        const targetNetwork = chainValue.network;
+        if (!targetNetwork) {
+          throw new BitrefillStepError(
+            'handlePaymentUri',
+            'paymentUri missing network context',
+          );
+        }
+
+        defaultLogger.discovery.bitrefill.paymentIntentReceived({
+          networkId: targetNetwork.id,
+          tokenAddress: chainValue.tokenAddress,
+        });
+
+        // 2. Ensure connected account — prompt user if not yet connected.
+        //    If multiple accounts are already connected for this origin, we
+        //    force a clean reconnect so the user explicitly picks the one
+        //    that should pay. Multiple-account fallthrough would otherwise
+        //    silently default to accountsInfo[0].
+        let accountsInfo =
+          await backgroundApiProxy.serviceDApp.dAppGetConnectedAccountsInfo(
+            dappRequest,
+          );
+        if (accountsInfo && accountsInfo.length > 1) {
+          defaultLogger.discovery.bitrefill.walletReconnectTriggered({
+            reason: 'multiAccount',
+            connectedCount: accountsInfo.length,
+          });
+          try {
+            await backgroundApiProxy.serviceDApp.disconnectWebsite({
+              origin: BITREFILL_EMBED_ORIGIN,
+              storageType: 'injectedProvider',
+              beforeConnect: true,
+              entry: 'Browser',
+            });
+          } catch (e) {
+            throw new BitrefillStepError(
+              'connectWallet',
+              (e as Error)?.message ?? 'disconnect before reconnect failed',
+            );
+          }
+          if (!isMountedRef.current) return;
+          accountsInfo = null;
+        }
+        if (!accountsInfo || accountsInfo.length === 0) {
+          try {
+            await backgroundApiProxy.serviceDApp.openConnectionModal(
+              dappRequest,
+            );
+          } catch (err) {
+            if (isUserRejectedError(err)) {
+              // User closed the connection modal on purpose — stay silent,
+              // they can retry from Bitrefill's Pay button when ready.
+              defaultLogger.discovery.bitrefill.userRejectedConnect();
+              return;
+            }
+            throw new BitrefillStepError(
+              'connectWallet',
+              (err as Error)?.message ?? 'openConnectionModal failed',
+            );
+          }
+          if (!isMountedRef.current) return;
+          accountsInfo =
+            await backgroundApiProxy.serviceDApp.dAppGetConnectedAccountsInfo(
+              dappRequest,
+            );
+          if (!accountsInfo || accountsInfo.length === 0) {
+            throw new BitrefillStepError(
+              'connectWallet',
+              'no account after connection',
+            );
+          }
+        }
+
+        // 3. Switch network if mismatch
+        const currentNetworkId = accountsInfo[0]?.accountInfo?.networkId;
+        if (currentNetworkId !== targetNetwork.id) {
+          try {
+            await backgroundApiProxy.serviceDApp.switchConnectedNetwork({
+              origin: BITREFILL_EMBED_ORIGIN,
+              scope: BITREFILL_DAPP_SCOPE,
+              oldNetworkId: currentNetworkId,
+              newNetworkId: targetNetwork.id,
+            });
+          } catch (e) {
+            throw new BitrefillStepError(
+              'switchNetwork',
+              (e as Error)?.message ?? 'switchConnectedNetwork failed',
+            );
+          }
+          if (!isMountedRef.current) return;
+          accountsInfo =
+            await backgroundApiProxy.serviceDApp.dAppGetConnectedAccountsInfo(
+              dappRequest,
+            );
+          if (!accountsInfo || accountsInfo.length === 0) {
+            throw new BitrefillStepError(
+              'switchNetwork',
+              'no account after network switch',
+            );
+          }
+        }
+
+        // 4. Resolve final connection state
+        const finalAccountId = accountsInfo[0]?.accountInfo?.accountId;
+        const finalNetworkId = accountsInfo[0]?.accountInfo?.networkId;
+        const senderAddress =
+          accountsInfo[0]?.account?.addressDetail?.normalizedAddress;
+        if (!finalAccountId || !finalNetworkId || !senderAddress) {
+          throw new BitrefillStepError(
+            'resolveAccount',
+            'invalid connected account info',
+          );
+        }
+
+        if (!isMountedRef.current) return;
+
+        // 5. Resolve token (native or ERC-20) — use vault-registered metadata so
+        //    decimals/isNative are trustworthy even if Bitrefill sends unknown tokens
+        let selectedToken = null;
+        try {
+          if (chainValue.tokenAddress) {
+            selectedToken = await backgroundApiProxy.serviceToken.getToken({
+              networkId: finalNetworkId,
+              accountId: finalAccountId,
+              tokenIdOnNetwork: chainValue.tokenAddress,
+            });
+          }
+          if (!selectedToken) {
+            selectedToken =
+              await backgroundApiProxy.serviceToken.getNativeToken({
+                networkId: finalNetworkId,
+                accountId: finalAccountId,
+              });
+          }
+        } catch (e) {
+          throw new BitrefillStepError(
+            'resolveToken',
+            (e as Error)?.message ?? 'resolveToken failed',
+          );
+        }
+        if (!selectedToken) {
+          throw new BitrefillStepError(
+            'resolveToken',
+            'could not resolve token for payment',
+          );
+        }
+
+        if (!isMountedRef.current) return;
+
+        // 6. Build encodedTx through the EVM vault — handles ERC-20 ABI encoding
+        //    and native value conversion with BigNumber precision (no float math)
+        let unsignedTx: Awaited<
+          ReturnType<typeof backgroundApiProxy.serviceSend.buildUnsignedTx>
+        >;
+        try {
+          const amount = await parseOnChainAmount(result, selectedToken);
+          unsignedTx = await backgroundApiProxy.serviceSend.buildUnsignedTx({
+            networkId: finalNetworkId,
+            accountId: finalAccountId,
+            transfersInfo: [
+              {
+                from: senderAddress,
+                to: chainValue.address,
+                amount,
+                tokenInfo: selectedToken,
+              },
+            ],
+          });
+        } catch (e) {
+          throw new BitrefillStepError(
+            'buildUnsignedTx',
+            (e as Error)?.message ?? 'buildUnsignedTx failed',
+          );
+        }
+
+        if (!isMountedRef.current) return;
+
+        // 7. Open signature-and-send modal (same path as eth_sendTransaction)
+        try {
+          await backgroundApiProxy.serviceDApp.openSignAndSendTransactionModal({
+            request: dappRequest,
+            encodedTx: unsignedTx.encodedTx,
+            accountId: finalAccountId,
+            networkId: finalNetworkId,
+            transfersInfo: unsignedTx.transfersInfo,
+          });
+        } catch (e) {
+          if (isUserRejectedError(e)) {
+            // User rejected the tx — nothing to surface.
+            return;
+          }
+          throw new BitrefillStepError(
+            'openSignModal',
+            (e as Error)?.message ?? 'openSignAndSendTransactionModal failed',
+          );
+        }
+      } catch (error) {
+        const step: IBitrefillFailStep =
+          error instanceof BitrefillStepError ? error.step : 'unknown';
+        defaultLogger.discovery.bitrefill.paymentIntentFailed({
+          step,
+          message: (error as Error)?.message ?? String(error),
+        });
+        Toast.error({
+          title: ETranslations.browser_unable_to_pay,
+        });
+      }
+    },
+    [],
+  );
+
+  return { customReceiveHandler };
+}

--- a/packages/kit/src/views/Discovery/pages/Browser/DesktopBrowserContent.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/DesktopBrowserContent.tsx
@@ -20,6 +20,7 @@ import {
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import WebContent from '../../components/WebContent/WebContent';
+import { useDiscoveryMessageHandler } from '../../hooks/useDiscoveryMessageHandler';
 import { useWebTabDataById } from '../../hooks/useWebTabs';
 import { webviewRefs } from '../../utils/explorerUtils';
 import DashboardContent from '../Dashboard/DashboardContent';
@@ -304,11 +305,18 @@ function BasicDesktopBrowserContent({
     };
   }, [id]);
 
+  const { customReceiveHandler } = useDiscoveryMessageHandler();
+
   return (
     <Freeze key={id} freeze={!isActive}>
       {platformEnv.isDesktop ? <Find id={id} /> : null}
       {tab?.url ? (
-        <WebContent id={id} url={tab.url} isCurrent={isActive} />
+        <WebContent
+          id={id}
+          url={tab.url}
+          isCurrent={isActive}
+          customReceiveHandler={customReceiveHandler}
+        />
       ) : (
         <DashboardContent />
       )}

--- a/packages/kit/src/views/Discovery/pages/Browser/MobileBrowserContent.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/MobileBrowserContent.tsx
@@ -8,6 +8,7 @@ import type { IWebViewOnScrollEvent } from '@onekeyhq/kit/src/components/WebView
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import WebContent from '../../components/WebContent/WebContent';
+import { useDiscoveryMessageHandler } from '../../hooks/useDiscoveryMessageHandler';
 import { useActiveTabId, useWebTabDataById } from '../../hooks/useWebTabs';
 import { captureViewRefs } from '../../utils/explorerUtils';
 
@@ -27,6 +28,8 @@ function MobileBrowserContent({
     () => activeTabId === tab?.id,
     [tab?.id, activeTabId],
   );
+
+  const { customReceiveHandler } = useDiscoveryMessageHandler();
 
   const initCaptureViewRef = useCallback(
     ($ref: any) => {
@@ -58,6 +61,7 @@ function MobileBrowserContent({
                 setBackEnabled={setBackEnabled}
                 setForwardEnabled={setForwardEnabled}
                 onScroll={onScroll}
+                customReceiveHandler={customReceiveHandler}
               />
             </Stack>
           </ViewShot>
@@ -65,7 +69,7 @@ function MobileBrowserContent({
       </>
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tab?.id, tab?.url, tab?.siteMode, isActive]);
+  }, [tab?.id, tab?.url, tab?.siteMode, isActive, customReceiveHandler]);
   return <>{content}</>;
 }
 

--- a/packages/kit/src/views/Discovery/utils/bitrefillHandler.test.ts
+++ b/packages/kit/src/views/Discovery/utils/bitrefillHandler.test.ts
@@ -1,0 +1,99 @@
+import {
+  isBitrefillOrigin,
+  parseBitrefillPaymentIntent,
+} from './bitrefillHandler';
+
+describe('bitrefillHandler', () => {
+  describe('isBitrefillOrigin', () => {
+    it('accepts exact https://embed.bitrefill.com', () => {
+      expect(isBitrefillOrigin('https://embed.bitrefill.com')).toBe(true);
+    });
+
+    it('rejects http scheme', () => {
+      expect(isBitrefillOrigin('http://embed.bitrefill.com')).toBe(false);
+    });
+
+    it('rejects other bitrefill subdomains (exact match only)', () => {
+      expect(isBitrefillOrigin('https://www.bitrefill.com')).toBe(false);
+      expect(isBitrefillOrigin('https://api.bitrefill.com')).toBe(false);
+    });
+
+    it('rejects spoofed origins', () => {
+      expect(isBitrefillOrigin('https://evil-bitrefill.com')).toBe(false);
+      expect(isBitrefillOrigin('https://embed.bitrefill.com.evil.com')).toBe(
+        false,
+      );
+    });
+
+    it('rejects undefined and empty', () => {
+      expect(isBitrefillOrigin(undefined)).toBe(false);
+      expect(isBitrefillOrigin('')).toBe(false);
+    });
+  });
+
+  describe('parseBitrefillPaymentIntent', () => {
+    it('parses valid JSON string payload', () => {
+      const raw = JSON.stringify({
+        event: 'payment_intent',
+        paymentUri: 'ethereum:0x123@1?value=1e17',
+      });
+      expect(parseBitrefillPaymentIntent(raw)).toEqual({
+        event: 'payment_intent',
+        paymentUri: 'ethereum:0x123@1?value=1e17',
+      });
+    });
+
+    it('parses valid object payload', () => {
+      const raw = {
+        event: 'payment_intent',
+        paymentUri: 'ethereum:0xabc@137?value=1e6',
+      };
+      expect(parseBitrefillPaymentIntent(raw)).toEqual({
+        event: 'payment_intent',
+        paymentUri: 'ethereum:0xabc@137?value=1e6',
+      });
+    });
+
+    it('returns null for invoice_created event (ignored)', () => {
+      const raw = {
+        event: 'invoice_created',
+        invoiceId: 'x',
+        paymentUri: 'ethereum:0x123@1?value=1e17',
+      };
+      expect(parseBitrefillPaymentIntent(raw)).toBeNull();
+    });
+
+    it('returns null when paymentUri is missing', () => {
+      expect(
+        parseBitrefillPaymentIntent({ event: 'payment_intent' }),
+      ).toBeNull();
+    });
+
+    it('returns null when paymentUri is empty string', () => {
+      expect(
+        parseBitrefillPaymentIntent({
+          event: 'payment_intent',
+          paymentUri: '',
+        }),
+      ).toBeNull();
+    });
+
+    it('returns null when paymentUri is not a string', () => {
+      expect(
+        parseBitrefillPaymentIntent({
+          event: 'payment_intent',
+          paymentUri: 123,
+        }),
+      ).toBeNull();
+    });
+
+    it('returns null for malformed JSON string', () => {
+      expect(parseBitrefillPaymentIntent('{not json')).toBeNull();
+    });
+
+    it('returns null for null and undefined input', () => {
+      expect(parseBitrefillPaymentIntent(null)).toBeNull();
+      expect(parseBitrefillPaymentIntent(undefined)).toBeNull();
+    });
+  });
+});

--- a/packages/kit/src/views/Discovery/utils/bitrefillHandler.ts
+++ b/packages/kit/src/views/Discovery/utils/bitrefillHandler.ts
@@ -1,0 +1,44 @@
+import { BITREFILL_EMBED_ORIGIN } from './bitrefillUtils';
+
+export interface IBitrefillPaymentIntent {
+  event: 'payment_intent';
+  paymentUri: string;
+}
+
+/**
+ * Accept only the exact embed origin. Subdomain matching is intentionally
+ * disabled — Bitrefill only uses embed.bitrefill.com for the iframe widget.
+ */
+export function isBitrefillOrigin(origin: string | undefined): boolean {
+  return origin === BITREFILL_EMBED_ORIGIN;
+}
+
+/**
+ * Parse a raw postMessage payload into a Bitrefill payment_intent event.
+ * Returns null if the payload is not a valid payment_intent with a non-empty
+ * paymentUri string. Other Bitrefill events (invoice_created/update/complete)
+ * are intentionally ignored in the minimal integration.
+ */
+export function parseBitrefillPaymentIntent(
+  raw: unknown,
+): IBitrefillPaymentIntent | null {
+  let data: unknown = raw;
+  if (typeof raw === 'string') {
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+  if (!data || typeof data !== 'object') {
+    return null;
+  }
+  const obj = data as Record<string, unknown>;
+  if (obj.event !== 'payment_intent') {
+    return null;
+  }
+  if (typeof obj.paymentUri !== 'string' || obj.paymentUri.length === 0) {
+    return null;
+  }
+  return { event: 'payment_intent', paymentUri: obj.paymentUri };
+}

--- a/packages/kit/src/views/Discovery/utils/bitrefillUtils.test.ts
+++ b/packages/kit/src/views/Discovery/utils/bitrefillUtils.test.ts
@@ -1,0 +1,62 @@
+import {
+  BITREFILL_EMBED_ORIGIN,
+  BITREFILL_REF_CODE,
+  getBitrefillEmbedUrl,
+} from './bitrefillUtils';
+
+describe('bitrefillUtils', () => {
+  describe('constants', () => {
+    it('exposes embed origin as https://embed.bitrefill.com', () => {
+      expect(BITREFILL_EMBED_ORIGIN).toBe('https://embed.bitrefill.com');
+    });
+
+    it('exposes referral code bronekey01', () => {
+      expect(BITREFILL_REF_CODE).toBe('bronekey01');
+    });
+  });
+
+  describe('getBitrefillEmbedUrl', () => {
+    const url = getBitrefillEmbedUrl();
+    const parsed = new URL(url);
+
+    it('uses embed origin as base', () => {
+      expect(parsed.origin).toBe(BITREFILL_EMBED_ORIGIN);
+    });
+
+    it('includes ref=bronekey01', () => {
+      expect(parsed.searchParams.get('ref')).toBe('bronekey01');
+    });
+
+    it('includes utm_source=onekey', () => {
+      expect(parsed.searchParams.get('utm_source')).toBe('onekey');
+    });
+
+    it('includes EVM-only paymentMethods', () => {
+      const methods =
+        parsed.searchParams.get('paymentMethods')?.split(',') ?? [];
+      expect(methods).toEqual(
+        expect.arrayContaining([
+          'ethereum',
+          'eth_base',
+          'usdc_erc20',
+          'usdc_polygon',
+          'usdc_arbitrum',
+          'usdc_base',
+          'usdt_erc20',
+          'usdt_polygon',
+          'usdt_arbitrum',
+          'usdt_bsc',
+        ]),
+      );
+    });
+
+    it('does not include non-EVM payment methods', () => {
+      const methods =
+        parsed.searchParams.get('paymentMethods')?.split(',') ?? [];
+      expect(methods).not.toContain('bitcoin');
+      expect(methods).not.toContain('lightning');
+      expect(methods).not.toContain('usdt_trc20');
+      expect(methods).not.toContain('usdc_solana');
+    });
+  });
+});

--- a/packages/kit/src/views/Discovery/utils/bitrefillUtils.ts
+++ b/packages/kit/src/views/Discovery/utils/bitrefillUtils.ts
@@ -1,0 +1,76 @@
+export const BITREFILL_EMBED_ORIGIN = 'https://embed.bitrefill.com';
+export const BITREFILL_REF_CODE = 'bronekey01';
+
+// EVM-only payment method identifiers accepted by Bitrefill's embed widget.
+// These identifiers are Bitrefill's own naming (not OneKey's) — see the
+// paymentMethods enum in Bitrefill's embed docs. Non-EVM methods (bitcoin,
+// lightning, usdc_solana, usdt_trc20, etc.) are intentionally excluded
+// because OneKey currently only has a native parser for ethereum: URIs.
+// Not every EVM pair is listed (e.g. usdt_base, usdc_bsc) because Bitrefill
+// does not support them as of 2026-04-15; add as they become available.
+const EVM_PAYMENT_METHODS = [
+  'ethereum',
+  'eth_base',
+  'usdc_erc20',
+  'usdc_polygon',
+  'usdc_arbitrum',
+  'usdc_base',
+  'usdt_erc20',
+  'usdt_polygon',
+  'usdt_arbitrum',
+  'usdt_bsc',
+];
+
+export function getBitrefillEmbedUrl(): string {
+  const params = new URLSearchParams({
+    ref: BITREFILL_REF_CODE,
+    utm_source: 'onekey',
+    paymentMethods: EVM_PAYMENT_METHODS.join(','),
+  });
+  return `${BITREFILL_EMBED_ORIGIN}/?${params.toString()}`;
+}
+
+/**
+ * Bitrefill embed widget communicates with its host via raw window.postMessage,
+ * which does not flow through OneKey's JSBridge. We inject a small listener
+ * inside the webview page that forwards these raw postMessages as $private
+ * JSBridge REQUESTs, so they reach our customReceiveHandler on the host side.
+ */
+export const BITREFILL_BRIDGE_METHOD = 'wallet_bitrefillEvent';
+
+export const BITREFILL_BRIDGE_SCRIPT = `
+(function() {
+  try {
+    if (window.__onekeyBitrefillBridgeInstalled) return;
+    window.__onekeyBitrefillBridgeInstalled = true;
+
+    window.addEventListener('message', function(e) {
+      try {
+        if (e.origin !== '${BITREFILL_EMBED_ORIGIN}') return;
+        var data = e.data;
+        // Bitrefill may post JSON-stringified payloads.
+        if (typeof data === 'string') {
+          try { data = JSON.parse(data); } catch (_parseErr) { return; }
+        }
+        if (!data || typeof data !== 'object') return;
+        var api = window.$onekey && window.$onekey.$private;
+        if (!api || typeof api.request !== 'function') return;
+        api.request({
+          method: '${BITREFILL_BRIDGE_METHOD}',
+          params: [data],
+        }).catch(function(){});
+      } catch (_e) {}
+    });
+  } catch (_e) {}
+})();
+true;
+`;
+
+export function isBitrefillEmbedUrl(url: string | undefined | null): boolean {
+  if (!url) return false;
+  try {
+    return new URL(url).origin === BITREFILL_EMBED_ORIGIN;
+  } catch {
+    return false;
+  }
+}

--- a/packages/shared/src/logger/scopes/discovery/index.ts
+++ b/packages/shared/src/logger/scopes/discovery/index.ts
@@ -1,6 +1,7 @@
 import { BaseScope } from '../../base/baseScope';
 import { EScopeName } from '../../types';
 
+import { BitrefillScene } from './scenes/bitrefill';
 import { BrowserScene } from './scenes/browser';
 import { DappScene } from './scenes/dapp';
 import { TranslationScene } from './scenes/translation';
@@ -13,4 +14,6 @@ export class DiscoveryScope extends BaseScope {
   dapp = this.createScene('dapp', DappScene);
 
   translation = this.createScene('translation', TranslationScene);
+
+  bitrefill = this.createScene('bitrefill', BitrefillScene);
 }

--- a/packages/shared/src/logger/scopes/discovery/scenes/bitrefill.ts
+++ b/packages/shared/src/logger/scopes/discovery/scenes/bitrefill.ts
@@ -1,0 +1,43 @@
+import { BaseScene } from '../../../base/baseScene';
+import { LogToLocal } from '../../../base/decorators';
+
+export type IBitrefillFailStep =
+  | 'handlePaymentUri'
+  | 'connectWallet'
+  | 'switchNetwork'
+  | 'resolveAccount'
+  | 'resolveToken'
+  | 'buildUnsignedTx'
+  | 'openSignModal'
+  | 'unknown';
+
+export class BitrefillScene extends BaseScene {
+  @LogToLocal({ level: 'info' })
+  public paymentIntentReceived(params: {
+    networkId?: string;
+    tokenAddress?: string;
+  }) {
+    return params;
+  }
+
+  @LogToLocal()
+  public paymentIntentFailed(params: {
+    step: IBitrefillFailStep;
+    message: string;
+  }) {
+    return params;
+  }
+
+  @LogToLocal({ level: 'info' })
+  public walletReconnectTriggered(params: {
+    reason: 'multiAccount';
+    connectedCount: number;
+  }) {
+    return params;
+  }
+
+  @LogToLocal({ level: 'info' })
+  public userRejectedConnect() {
+    return {};
+  }
+}


### PR DESCRIPTION
## Summary
- Cherry-picks the squash-merged commit of #11245 onto `release/v6.2.0` for the v6.2.0 bundle hot-update.
- Single commit (`b9e647e2d3`), 15 files changed, +836 / −6, no conflicts.

## Intent & Context
PR #11245 (Bitrefill payment-intent checkout flow) landed on `x` after the v6.2.0 release branch had already cut. To ship Bitrefill in the v6.2.0 bundle, the same change needs to live on `release/v6.2.0`. This PR is purely a backport — no source changes versus the merged squash commit.

## Design Decisions
- **Cherry-pick the squash commit, not the individual feature-branch commits.** The original `feat/bitrefill` had 29 commits including merges, debug pings, and lint fixups. The squash on `x` (`021c200e4d`) is the intended atomic unit and keeps `release/v6.2.0` history clean.
- **Single commit on the bundle branch** so the bundle release diff is reviewable as one logical change.

## Changes Detail
Identical to #11245. New files:
- `packages/kit/src/views/Discovery/utils/bitrefillUtils.ts` (+ test) — embed URL builder, origin/payload validators
- `packages/kit/src/views/Discovery/utils/bitrefillHandler.ts` (+ test) — pure origin/message validators
- `packages/kit/src/views/Discovery/hooks/useDiscoveryMessageHandler.ts` — payment-intent → connect → switch → buildUnsignedTx → sign-and-send pipeline
- `packages/kit-bg/src/services/ServiceScanQRCode/handlePaymentUri.test.ts` and integration in `ServiceScanQRCode/index.ts` — ERC-681 `ethereum:` URI parsing
- `packages/shared/src/logger/scopes/discovery/scenes/bitrefill.ts` — Bitrefill logger scope

Modified: `WebContent` (desktop / native / web), `BrowserContent` (desktop / mobile), discovery logger index, `spellCheckerSkipWords.txt`.

## Risk Assessment
- **Risk Level**: Low (pure backport, code already reviewed and merged on `x`)
- **Affected Platforms**: Desktop, Mobile (iOS/Android), Web — Bitrefill embed runs in `WebContent` on all three
- **Risk Areas**:
  - `WebContent.desktop.tsx` `onDomReady` deps were stabilized in the original PR to fix Electron webview re-creation; verify Discovery tab doesn't regress on bundle build.
  - `release/v6.2.0` may have small drifts vs `x` in Discovery / Scan / logger files — cherry-pick was clean but runtime behavior should still be exercised.

## Test plan
- [x] `yarn tsc:staged` (full project) — exit 0
- [x] `oxlint --type-aware --deny-warnings` on all 14 changed `.ts/.tsx` — 0 warnings, 0 errors
- [x] `jest` on the 3 new test files — 25/25 passed
- [ ] Manual: open Bitrefill embed in Discovery → buy gift card → confirm payment-intent flow opens connect modal → switch network → sign-and-send modal opens with correct amount/recipient (Desktop)
- [ ] Manual: same flow on iOS / Android via mobile WebView bridge
- [ ] Manual: cancel at connect modal and at sign modal — no toast (silent return on EIP-1193 4001)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
