### PR TITLE
fix: iOS Lottie render mode and background for ReferFriends(OK-50147)

### DIFF
--- a/packages/kit/src/views/ReferFriends/pages/InvitedByFriend/components/InvitedByFriendImage.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/InvitedByFriend/components/InvitedByFriendImage.tsx
@@ -24,11 +24,13 @@ export function InvitedByFriendImage() {
     !platformEnv.isNative && (gtSm || platformEnv.isExtensionUiPopup);
   const lottieSource =
     LOTTIE_SOURCE[themeVariant === 'dark' ? 'dark' : 'light'];
+  const renderMode =
+    platformEnv.isNativeIOS && themeVariant !== 'dark' ? 'HARDWARE' : undefined;
   const width = !platformEnv.isNative && gtSm ? DESKTOP_WIDTH : pageWidth;
   const height = isDesktop ? width * DESKTOP_ASPECT_RATIO : pageWidth;
 
   return (
-    <Stack w={width} h={height} alignSelf="center">
+    <Stack w={width} h={height} alignSelf="center" bg="$bgApp">
       <LottieView
         source={lottieSource}
         width={width}
@@ -36,6 +38,8 @@ export function InvitedByFriendImage() {
         autoPlay
         loop
         resizeMode="contain"
+        renderMode={renderMode}
+        backgroundColor="$bgApp"
       />
     </Stack>
   );

--- a/packages/kit/src/views/ReferFriends/pages/ReferAFriend/components/InviteCodeStepImage.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/ReferAFriend/components/InviteCodeStepImage.tsx
@@ -35,9 +35,13 @@ export function InviteCodeStepImage({ step }: IInviteCodeStepImageProps) {
   const width = gtSm ? DESKTOP_WIDTH : pageWidth;
   const height = isDesktop ? width * DESKTOP_ASPECT_RATIO : pageWidth;
   const shouldLoop = step === 2;
+  const renderMode =
+    platformEnv.isNativeIOS && step === 2 && themeVariant !== 'dark'
+      ? 'HARDWARE'
+      : 'AUTOMATIC';
 
   return (
-    <Stack w={width} h={height} alignSelf="center">
+    <Stack w={width} h={height} alignSelf="center" bg="$bgApp">
       <LottieView
         source={lottieSource}
         width={width}
@@ -45,7 +49,8 @@ export function InviteCodeStepImage({ step }: IInviteCodeStepImageProps) {
         autoPlay
         loop={shouldLoop}
         resizeMode="contain"
-        renderMode="AUTOMATIC"
+        renderMode={renderMode}
+        backgroundColor="$bgApp"
       />
     </Stack>
   );


### PR DESCRIPTION
## Summary
- Add `renderMode="HARDWARE"` for iOS native in light theme to fix Lottie animation rendering issues
- Add `bg="$bgApp"` and `backgroundColor="$bgApp"` to prevent transparency/background issues

## Intent & Context
Fix iOS-specific Lottie animation rendering problems in the ReferFriends feature. The Lottie animations were not rendering correctly on iOS in light theme mode.

## Root Cause
iOS Lottie animations in light theme mode require HARDWARE render mode for correct rendering. The default AUTOMATIC mode was causing display issues.

## Changes Detail
- `InvitedByFriendImage.tsx`: Added conditional HARDWARE renderMode for iOS native light theme, added background color
- `InviteCodeStepImage.tsx`: Added conditional HARDWARE renderMode for iOS native light theme (step 2 animation), added background color

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: iOS Native
- **Risk Areas**: Lottie animation rendering on iOS

## Test plan
- [ ] Test ReferFriends flow on iOS in light theme
- [ ] Test ReferFriends flow on iOS in dark theme
- [ ] Verify Lottie animations render correctly
- [ ] Test on Android to ensure no regression
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
