### PR TITLE
fix(swap): remove duplicate gas fee paragraph in service fee tooltip

### DIFF
--- a/packages/kit/src/views/Swap/components/SwapServiceFeeOverview.tsx
+++ b/packages/kit/src/views/Swap/components/SwapServiceFeeOverview.tsx
@@ -1,6 +1,6 @@
 import { useIntl } from 'react-intl';
 
-import { Icon, Popover, SizableText, Stack } from '@onekeyhq/components';
+import { Icon, Popover, SizableText } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 export function SwapServiceFeeOverview(_props: {
@@ -22,18 +22,11 @@ export function SwapServiceFeeOverview(_props: {
         />
       }
       renderContent={
-        <Stack gap="$1" p="$4">
-          <SizableText size="$bodyMd" color="$textSubdued">
-            {intl.formatMessage({
-              id: ETranslations.provider_popover_onekey_fee_content_nofee,
-            })}
-          </SizableText>
-          <SizableText size="$bodyMd" color="$textSubdued">
-            {intl.formatMessage({
-              id: ETranslations.provider_ios_popover_onekey_fee_content_2,
-            })}
-          </SizableText>
-        </Stack>
+        <SizableText p="$4" size="$bodyMd" color="$textSubdued">
+          {intl.formatMessage({
+            id: ETranslations.provider_popover_onekey_fee_content_nofee,
+          })}
+        </SizableText>
       }
     />
   );


### PR DESCRIPTION
## Summary

Swap 渠道商 tooltip 中出现两段文案，第二段 (`provider.ios_popover.onekey_fee_content_2`) 是关于"滑点 / Gas 费用直接付给区块链网络"的补充说明。在 #11402 把第一段切换到 `provider.popover.onekey_fee_content_nofee` 后，新版第一段已经包含同样的语义，导致 tooltip 出现明显重复。

本 PR 只在前端层面移除冗余的第二段（不动任何 i18n 文件），并顺手把因此变成单子节点的 `<Stack>` 包装去掉，将内边距合并到 `<SizableText>` 上。

变更前 tooltip：
> 当前报价已包含 OneKey 服务费及可用优惠……**滑点和渠道商费用可能影响最终到账金额。Gas 费用直接支付给区块链网络，并非由 OneKey 收取。**
>
> **滑点和网络 Gas 费用可能影响最终到账金额，其中 Gas 费用直接支付给区块链网络，并非由 OneKey 收取。**

变更后 tooltip：
> 当前报价已包含 OneKey 服务费及可用优惠……滑点和渠道商费用可能影响最终到账金额。Gas 费用直接支付给区块链网络，并非由 OneKey 收取。

## Changes

- `packages/kit/src/views/Swap/components/SwapServiceFeeOverview.tsx`
  - 移除对 `ETranslations.provider_ios_popover_onekey_fee_content_2` 的引用
  - 单子节点 `<Stack>` 包装已无意义，改为直接渲染 `<SizableText>`

## Follow-ups (not in this PR)

- 翻译 key `provider.ios_popover.onekey_fee_content_2` 在前端已无引用，建议 i18n 维护者按既有流程清理
- `SwapServiceFeeOverview` 的 `_props` (percentageFee / percentOriginFee) 自 #11402 起未使用，5 个调用点仍在传值，可单独 PR 清理

## Test plan

- [ ] Swap 页打开渠道商旁边的服务费 tooltip，确认只剩一段文案，多语言（zh-CN / zh-HK / zh-TW / en-US 等）显示正常
- [ ] iOS / Android / Web / Desktop / Extension 渲染一致
- [ ] 确认改动未影响 `SwapProviderInfoItem` 整体布局
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
