### PR TITLE
polish(discovery): tweak ad corner badge + add reusable InnerStroke

### DIFF
--- a/packages/components/src/content/AdCornerBadge/index.tsx
+++ b/packages/components/src/content/AdCornerBadge/index.tsx
@@ -1,6 +1,12 @@
+import { memo } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+
 import { SizableText, Stack } from '../../primitives';
 
-import type { ISizableTextProps, IStackProps } from '../../primitives';
+import type { IStackProps } from '../../primitives';
 
 type IAdCornerBadgeSize = 'sm' | 'lg';
 type IAdCornerBadgePlacement = 'top-left' | 'top-right';
@@ -8,33 +14,30 @@ type IAdCornerBadgePlacement = 'top-left' | 'top-right';
 const adCornerBadgeSizeMap: Record<
   IAdCornerBadgeSize,
   {
-    containerSize: number;
-    ribbonEdge: number;
-    ribbonHeight: number;
-    ribbonTop: number;
-    ribbonWidth: number;
-    textSize: ISizableTextProps['size'];
+    offset: number;
+    paddingX: number;
+    paddingY: number;
+    fontSize: number;
+    lineHeight: number;
   }
 > = {
   sm: {
-    containerSize: 36,
-    ribbonEdge: -24,
-    ribbonHeight: 15,
-    ribbonTop: 1,
-    ribbonWidth: 66,
-    textSize: '$bodyXsMedium',
+    offset: 3,
+    paddingX: 4,
+    paddingY: 1,
+    fontSize: 9,
+    lineHeight: 11,
   },
   lg: {
-    containerSize: 60,
-    ribbonEdge: -36,
-    ribbonHeight: 22,
-    ribbonTop: 5,
-    ribbonWidth: 112,
-    textSize: '$bodySmMedium',
+    offset: 6,
+    paddingX: 6,
+    paddingY: 2,
+    fontSize: 11,
+    lineHeight: 13,
   },
 };
 
-export function AdCornerBadge({
+export const AdCornerBadge = memo(function AdCornerBadge({
   badgeSize = 'sm',
   placement = 'top-right',
   ...rest
@@ -42,48 +45,38 @@ export function AdCornerBadge({
   badgeSize?: IAdCornerBadgeSize;
   placement?: IAdCornerBadgePlacement;
 } & IStackProps) {
+  const intl = useIntl();
+  const label = intl.formatMessage({ id: ETranslations.discovery_ad_label });
   const config = adCornerBadgeSizeMap[badgeSize];
   const isTopLeft = placement === 'top-left';
 
   return (
     <Stack
+      role="img"
+      aria-label={label}
       position="absolute"
-      top={0}
-      {...(isTopLeft ? { left: 0 } : { right: 0 })}
-      width={config.containerSize}
-      height={config.containerSize}
-      overflow="hidden"
+      top={config.offset}
+      left={isTopLeft ? config.offset : undefined}
+      right={isTopLeft ? undefined : config.offset}
+      paddingHorizontal={config.paddingX}
+      paddingVertical={config.paddingY}
+      borderRadius="$full"
+      bg="rgba(255, 255, 255, 0.65)"
       pointerEvents="none"
       zIndex={1}
       {...rest}
     >
-      <Stack
-        position="absolute"
-        top={config.ribbonTop}
-        {...(isTopLeft
-          ? { left: config.ribbonEdge }
-          : { right: config.ribbonEdge })}
-        width={config.ribbonWidth}
-        height={config.ribbonHeight}
-        rotate={isTopLeft ? '-45deg' : '45deg'}
-        alignItems="center"
-        justifyContent="center"
-        bg="rgba(255, 255, 255, 0.78)"
-        borderWidth={0.5}
-        borderColor="rgba(0, 0, 0, 0.06)"
+      <SizableText
+        allowFontScaling={false}
+        color="rgba(0, 0, 0, 0.65)"
+        fontWeight="500"
+        fontSize={config.fontSize}
+        lineHeight={config.lineHeight}
+        letterSpacing={0}
+        numberOfLines={1}
       >
-        <SizableText
-          allowFontScaling={false}
-          color="$textSubduedLight"
-          fontWeight="600"
-          letterSpacing={0}
-          lineHeight={config.ribbonHeight}
-          numberOfLines={1}
-          size={config.textSize}
-        >
-          AD
-        </SizableText>
-      </Stack>
+        {label}
+      </SizableText>
     </Stack>
   );
-}
+});

--- a/packages/components/src/content/InnerStroke/index.tsx
+++ b/packages/components/src/content/InnerStroke/index.tsx
@@ -1,0 +1,41 @@
+import { memo } from 'react';
+
+import { StyleSheet } from 'react-native';
+
+import { Stack } from '../../primitives';
+
+import type { IStackProps } from '../../primitives';
+
+/**
+ * Hairline inner stroke overlay for rounded elements.
+ *
+ * RN/CSS box-shadow inset paints under children, and outline-offset
+ * is clipped by overflow:hidden. A sibling layer rendered after the
+ * content is the only cross-platform way to draw a stroke above
+ * 100%-fill content inside a rounded clip.
+ *
+ * Place inside a parent with matching borderRadius + overflow:hidden.
+ */
+export const InnerStroke = memo(function InnerStroke({
+  borderRadius,
+  borderColor = 'rgba(0, 0, 0, 0.1)',
+  ...rest
+}: Omit<IStackProps, 'borderRadius'> & {
+  borderRadius: IStackProps['borderRadius'];
+}) {
+  return (
+    <Stack
+      position="absolute"
+      top={0}
+      left={0}
+      right={0}
+      bottom={0}
+      borderRadius={borderRadius}
+      borderCurve="continuous"
+      borderWidth={StyleSheet.hairlineWidth}
+      borderColor={borderColor}
+      pointerEvents="none"
+      {...rest}
+    />
+  );
+});

--- a/packages/components/src/content/index.ts
+++ b/packages/components/src/content/index.ts
@@ -1,5 +1,6 @@
 export * from './Badge';
 export * from './AdCornerBadge';
+export * from './InnerStroke';
 export * from './Breadcrumb';
 export * from './HeightTransition';
 export * from './LinearGradient';

--- a/packages/kit/src/views/Discovery/components/DiscoveryItemCard.tsx
+++ b/packages/kit/src/views/Discovery/components/DiscoveryItemCard.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useMemo } from 'react';
 
-import { StyleSheet, TouchableOpacity } from 'react-native';
+import { TouchableOpacity } from 'react-native';
 
 import {
   AdCornerBadge,
   Icon,
   Image,
+  InnerStroke,
   SizableText,
   Skeleton,
   Stack,
@@ -104,10 +105,6 @@ export function DiscoveryItemCard({
           <Image
             width="100%"
             height="100%"
-            borderRadius="$3"
-            borderCurve="continuous"
-            borderWidth={StyleSheet.hairlineWidth}
-            borderColor="$borderSubdued"
             source={{ uri: logo }}
             fallback={
               <Image.Fallback>
@@ -115,6 +112,7 @@ export function DiscoveryItemCard({
               </Image.Fallback>
             }
           />
+          <InnerStroke borderRadius="$3" />
           {isAd ? <AdCornerBadge badgeSize="sm" /> : null}
         </Stack>
         <SizableText

--- a/packages/shared/src/locale/enum/translations.ts
+++ b/packages/shared/src/locale/enum/translations.ts
@@ -816,6 +816,7 @@ export enum ETranslations {
   dexmarket_stock_underlying_asset_name = 'dexmarket_stock.underlying_asset_name',
   dexmarket_stock_underlying_asset_ticker = 'dexmarket_stock.underlying_asset_ticker',
   dexmarket_stock_volume_shares = 'dexmarket_stock.volume_shares',
+  discovery_ad_label = 'discovery.ad_label',
   do_not_exit_app_during_setup = 'do_not_exit_app_during_setup',
   dont_have_mobile_app_yet = 'dont_have_mobile_app_yet',
   downgrade_warning_checkbox_label = 'downgrade_warning_checkbox_label',

--- a/packages/shared/src/locale/json/bn.json
+++ b/packages/shared/src/locale/json/bn.json
@@ -811,6 +811,7 @@
   "dexmarket_stock.underlying_asset_name": "অন্তর্নিহিত সম্পদের নাম",
   "dexmarket_stock.underlying_asset_ticker": "অন্তর্নিহিত সম্পদের টিকার",
   "dexmarket_stock.volume_shares": "ভলিউম (শেয়ার)",
+  "discovery.ad_label": "AD",
   "do_not_exit_app_during_setup": "সেটআপের সময় অনুগ্রহ করে অ্যাপ থেকে বের হবেন না, নইলে তৈরি প্রক্রিয়া ব্যর্থ হবে",
   "dont_have_mobile_app_yet": "মোবাইল অ্যাপটি এখনো নেই?",
   "downgrade_warning_checkbox_label": "আমি OneKey v4 এ ডাউনগ্রেড করব না",

--- a/packages/shared/src/locale/json/de.json
+++ b/packages/shared/src/locale/json/de.json
@@ -811,6 +811,7 @@
   "dexmarket_stock.underlying_asset_name": "Name des Basiswerts",
   "dexmarket_stock.underlying_asset_ticker": "Basiswert-Ticker",
   "dexmarket_stock.volume_shares": "Volumen (Aktien)",
+  "discovery.ad_label": "AD",
   "do_not_exit_app_during_setup": "Bitte beenden Sie die App während der Einrichtung nicht, da sonst die Erstellung fehlschlägt",
   "dont_have_mobile_app_yet": "Haben Sie die mobile App noch nicht?",
   "downgrade_warning_checkbox_label": "Ich werde NICHT auf OneKey v4 herunterstufen",

--- a/packages/shared/src/locale/json/en_US.json
+++ b/packages/shared/src/locale/json/en_US.json
@@ -811,6 +811,7 @@
   "dexmarket_stock.underlying_asset_name": "Underlying Asset Name",
   "dexmarket_stock.underlying_asset_ticker": "Underlying Asset Ticker",
   "dexmarket_stock.volume_shares": "Volume (Shares)",
+  "discovery.ad_label": "AD",
   "do_not_exit_app_during_setup": "Please do not exit the app during setup, or the creation will fail",
   "dont_have_mobile_app_yet": "Don’t have the mobile App yet?",
   "downgrade_warning_checkbox_label": "I will NOT downgrade to OneKey v4",

--- a/packages/shared/src/locale/json/es.json
+++ b/packages/shared/src/locale/json/es.json
@@ -811,6 +811,7 @@
   "dexmarket_stock.underlying_asset_name": "Nombre del activo subyacente",
   "dexmarket_stock.underlying_asset_ticker": "Ticker del activo subyacente",
   "dexmarket_stock.volume_shares": "Volumen (Acciones)",
+  "discovery.ad_label": "AD",
   "do_not_exit_app_during_setup": "No salgas de la aplicación durante la configuración o la creación fallará",
   "dont_have_mobile_app_yet": "¿Aún no tienes la aplicación móvil?",
   "downgrade_warning_checkbox_label": "No voy a retroceder a OneKey v4",

--- a/packages/shared/src/locale/json/fr_FR.json
+++ b/packages/shared/src/locale/json/fr_FR.json
@@ -811,6 +811,7 @@
   "dexmarket_stock.underlying_asset_name": "Nom de l'actif sous-jacent",
   "dexmarket_stock.underlying_asset_ticker": "Symbole de l'actif sous-jacent",
   "dexmarket_stock.volume_shares": "Volume (Actions)",
+  "discovery.ad_label": "AD",
   "do_not_exit_app_during_setup": "Veuillez ne pas quitter l'application pendant la configuration, sinon la création échouera",
   "dont_have_mobile_app_yet": "Vous n'avez pas encore l'application mobile ?",
   "downgrade_warning_checkbox_label": "Je ne vais PAS rétrograder à OneKey v4",

--- a/packages/shared/src/locale/json/hi_IN.json
+++ b/packages/shared/src/locale/json/hi_IN.json
@@ -811,6 +811,7 @@
   "dexmarket_stock.underlying_asset_name": "अंडरलाइनिंग एसेट नाम",
   "dexmarket_stock.underlying_asset_ticker": "अंडरलाइनिंग एसेट टिकर",
   "dexmarket_stock.volume_shares": "वॉल्यूम (शेयर)",
+  "discovery.ad_label": "AD",
   "do_not_exit_app_during_setup": "कृपया सेटअप के दौरान ऐप से बाहर न निकलें, अन्यथा निर्माण विफल हो जाएगा",
   "dont_have_mobile_app_yet": "क्या आपके पास मोबाइल ऐप अभी तक नहीं है?",
   "downgrade_warning_checkbox_label": "मैं OneKey v4 के लिए अवनति नहीं करूंगा",

--- a/packages/shared/src/locale/json/id.json
+++ b/packages/shared/src/locale/json/id.json
@@ -811,6 +811,7 @@
   "dexmarket_stock.underlying_asset_name": "Nama Aset Dasar",
   "dexmarket_stock.underlying_asset_ticker": "Ticker Aset Dasar",
   "dexmarket_stock.volume_shares": "Volume (Saham)",
+  "discovery.ad_label": "AD",
   "do_not_exit_app_during_setup": "Jangan keluar dari aplikasi selama pengaturan, atau pembuatan akan gagal",
   "dont_have_mobile_app_yet": "Belum memiliki aplikasi seluler?",
   "downgrade_warning_checkbox_label": "Saya TIDAK akan menurunkan versi ke OneKey v4",

--- a/packages/shared/src/locale/json/it_IT.json
+++ b/packages/shared/src/locale/json/it_IT.json
@@ -811,6 +811,7 @@
   "dexmarket_stock.underlying_asset_name": "Nome dell'asset sottostante",
   "dexmarket_stock.underlying_asset_ticker": "Ticker dell'asset sottostante",
   "dexmarket_stock.volume_shares": "Volume (Azioni)",
+  "discovery.ad_label": "AD",
   "do_not_exit_app_during_setup": "Non uscire dall'app durante la configurazione, altrimenti la creazione non riuscirà",
   "dont_have_mobile_app_yet": "Non hai ancora l'app mobile?",
   "downgrade_warning_checkbox_label": "Non effettuerò il downgrade a OneKey v4",

--- a/packages/shared/src/locale/json/ja_JP.json
+++ b/packages/shared/src/locale/json/ja_JP.json
@@ -811,6 +811,7 @@
   "dexmarket_stock.underlying_asset_name": "基礎資産名",
   "dexmarket_stock.underlying_asset_ticker": "基礎資産ティッカー",
   "dexmarket_stock.volume_shares": "取引量（株式）",
+  "discovery.ad_label": "広告",
   "do_not_exit_app_during_setup": "セットアップ中はアプリを終了しないでください。終了すると作成に失敗します",
   "dont_have_mobile_app_yet": "まだモバイルアプリをお持ちでないですか？",
   "downgrade_warning_checkbox_label": "私はOneKey v4にダウングレードするつもりはありません",

--- a/packages/shared/src/locale/json/ko_KR.json
+++ b/packages/shared/src/locale/json/ko_KR.json
@@ -811,6 +811,7 @@
   "dexmarket_stock.underlying_asset_name": "기초 자산 이름",
   "dexmarket_stock.underlying_asset_ticker": "기초 자산 티커",
   "dexmarket_stock.volume_shares": "거래량 (주식)",
+  "discovery.ad_label": "광고",
   "do_not_exit_app_during_setup": "설정 중에는 앱을 종료하지 마세요. 그렇지 않으면 생성이 실패합니다.",
   "dont_have_mobile_app_yet": "아직 모바일 앱을 가지고 있지 않으신가요?",
   "downgrade_warning_checkbox_label": "나는 OneKey v4로 다운그레이드하지 않을 것입니다",

--- a/packages/shared/src/locale/json/pt.json
+++ b/packages/shared/src/locale/json/pt.json
@@ -811,6 +811,7 @@
   "dexmarket_stock.underlying_asset_name": "Nome do Ativo Subjacente",
   "dexmarket_stock.underlying_asset_ticker": "Ticker do Ativo Subjacente",
   "dexmarket_stock.volume_shares": "Volume (Ações)",
+  "discovery.ad_label": "AD",
   "do_not_exit_app_during_setup": "Por favor, não saia do aplicativo durante a configuração, ou a criação falhará",
   "dont_have_mobile_app_yet": "Ainda não tem o aplicativo móvel?",
   "downgrade_warning_checkbox_label": "Eu NÃO vou retroceder para o OneKey v4",

--- a/packages/shared/src/locale/json/pt_BR.json
+++ b/packages/shared/src/locale/json/pt_BR.json
@@ -811,6 +811,7 @@
   "dexmarket_stock.underlying_asset_name": "Nome do ativo subjacente",
   "dexmarket_stock.underlying_asset_ticker": "Código do ativo subjacente",
   "dexmarket_stock.volume_shares": "Volume (Ações)",
+  "discovery.ad_label": "AD",
   "do_not_exit_app_during_setup": "Não saia do aplicativo durante a configuração, ou a criação falhará",
   "dont_have_mobile_app_yet": "Ainda não tem o aplicativo móvel?",
   "downgrade_warning_checkbox_label": "Eu NÃO vou retroceder para o OneKey v4",

--- a/packages/shared/src/locale/json/ru.json
+++ b/packages/shared/src/locale/json/ru.json
@@ -811,6 +811,7 @@
   "dexmarket_stock.underlying_asset_name": "Название базового актива",
   "dexmarket_stock.underlying_asset_ticker": "Тикер базового актива",
   "dexmarket_stock.volume_shares": "Объем (акции)",
+  "discovery.ad_label": "AD",
   "do_not_exit_app_during_setup": "Пожалуйста, не выходите из приложения во время настройки, иначе создание не удастся",
   "dont_have_mobile_app_yet": "У вас еще нет мобильного приложения?",
   "downgrade_warning_checkbox_label": "Я НЕ собираюсь переходить на OneKey v4",

--- a/packages/shared/src/locale/json/th_TH.json
+++ b/packages/shared/src/locale/json/th_TH.json
@@ -811,6 +811,7 @@
   "dexmarket_stock.underlying_asset_name": "ชื่อสินทรัพย์พื้นฐาน",
   "dexmarket_stock.underlying_asset_ticker": "สัญลักษณ์สินทรัพย์พื้นฐาน",
   "dexmarket_stock.volume_shares": "ปริมาณ (หุ้น)",
+  "discovery.ad_label": "AD",
   "do_not_exit_app_during_setup": "โปรดอย่าออกจากแอประหว่างการตั้งค่า มิฉะนั้นการสร้างจะล้มเหลว",
   "dont_have_mobile_app_yet": "ยังไม่มีแอปมือถือหรือ?",
   "downgrade_warning_checkbox_label": "ฉันจะไม่ยอมลดรุ่นลงไปยัง OneKey v4",

--- a/packages/shared/src/locale/json/uk_UA.json
+++ b/packages/shared/src/locale/json/uk_UA.json
@@ -811,6 +811,7 @@
   "dexmarket_stock.underlying_asset_name": "Назва базового активу",
   "dexmarket_stock.underlying_asset_ticker": "Тікер базового активу",
   "dexmarket_stock.volume_shares": "Обсяг (акції)",
+  "discovery.ad_label": "AD",
   "do_not_exit_app_during_setup": "Будь ласка, не виходьте з програми під час налаштування, інакше створення не вдасться",
   "dont_have_mobile_app_yet": "Ще не маєте мобільного додатку?",
   "downgrade_warning_checkbox_label": "Я НЕ буду переходити на OneKey v4",

--- a/packages/shared/src/locale/json/vi.json
+++ b/packages/shared/src/locale/json/vi.json
@@ -811,6 +811,7 @@
   "dexmarket_stock.underlying_asset_name": "Tên tài sản cơ sở",
   "dexmarket_stock.underlying_asset_ticker": "Mã tài sản cơ sở",
   "dexmarket_stock.volume_shares": "Khối lượng (Cổ phần)",
+  "discovery.ad_label": "AD",
   "do_not_exit_app_during_setup": "Vui lòng không thoát khỏi ứng dụng trong quá trình thiết lập, nếu không quá trình tạo sẽ thất bại",
   "dont_have_mobile_app_yet": "Chưa có ứng dụng di động?",
   "downgrade_warning_checkbox_label": "Tôi KHÔNG chuyển xuống OneKey v4",

--- a/packages/shared/src/locale/json/zh_CN.json
+++ b/packages/shared/src/locale/json/zh_CN.json
@@ -811,6 +811,7 @@
   "dexmarket_stock.underlying_asset_name": "标的资产名称",
   "dexmarket_stock.underlying_asset_ticker": "标的资产代码",
   "dexmarket_stock.volume_shares": "交易量（股）",
+  "discovery.ad_label": "广告",
   "do_not_exit_app_during_setup": "设置过程中请勿退出应用，否则创建将失败",
   "dont_have_mobile_app_yet": "还没有移动端 App 吗？",
   "downgrade_warning_checkbox_label": "我不会降级到 OneKey v4",

--- a/packages/shared/src/locale/json/zh_HK.json
+++ b/packages/shared/src/locale/json/zh_HK.json
@@ -811,6 +811,7 @@
   "dexmarket_stock.underlying_asset_name": "標的資產名稱",
   "dexmarket_stock.underlying_asset_ticker": "標的資產代碼",
   "dexmarket_stock.volume_shares": "成交量（股）",
+  "discovery.ad_label": "廣告",
   "do_not_exit_app_during_setup": "設定期間請勿退出應用程式，否則建立將會失敗",
   "dont_have_mobile_app_yet": "還沒有移動端 App 嗎？",
   "downgrade_warning_checkbox_label": "我不會降級到 OneKey v4",

--- a/packages/shared/src/locale/json/zh_TW.json
+++ b/packages/shared/src/locale/json/zh_TW.json
@@ -811,6 +811,7 @@
   "dexmarket_stock.underlying_asset_name": "標的資產名稱",
   "dexmarket_stock.underlying_asset_ticker": "標的資產代碼",
   "dexmarket_stock.volume_shares": "成交量（股）",
+  "discovery.ad_label": "廣告",
   "do_not_exit_app_during_setup": "設定期間請勿退出應用程式，否則建立將會失敗",
   "dont_have_mobile_app_yet": "還沒有手機 App 嗎？",
   "downgrade_warning_checkbox_label": "我不會降級到 OneKey v4",


### PR DESCRIPTION
Follow-up polish on top of #11395.

## Summary
- Redesign **AdCornerBadge** from a rotated ribbon to an App Store–style pill chip; localize the label via a new \`discovery::ad_label\` key (19 locales) and expose it to assistive tech with \`role=\"img\"\` + \`aria-label\`. Add a \`placement\` prop and memoize the component for hot-path renders.
- Add a small reusable **InnerStroke** primitive. RN/CSS \`box-shadow inset\` paints under children and \`outline-offset\` is clipped by \`overflow: hidden\`, so 100%-fill content (e.g. dapp icons) covered any border on the image itself. \`InnerStroke\` is a sibling overlay rendered after the content with a hairline border, which is the only cross-platform way to draw the stroke above the fill inside a rounded clip.
- Use \`InnerStroke\` on the dapp icon in \`DiscoveryItemCard\` and drop the now-invisible inline border on \`<Image>\`.

## Test plan
- [ ] Trending / dapp grid: ad badge renders top-right on cards, hairline stroke visible on iOS, Android and Web
- [ ] Discovery banner: large ad badge renders top-left, no regression on non-ad slides
- [ ] Screen reader announces the localized "Ad" label on both placements
- [ ] Verify in zh-CN, ja-JP, and one RTL-ish locale that the chip width adapts and doesn't truncate
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
