### PR TITLE
fix: resolve perps mobile spot followups(OK-53924 OK-53925 OK-53933 OK-53937 OK-53938 OK-53941)

### DIFF
--- a/packages/kit/src/views/Perp/components/HyperliquidTerms.tsx
+++ b/packages/kit/src/views/Perp/components/HyperliquidTerms.tsx
@@ -35,15 +35,17 @@ function CustomCheckbox({
   onChange,
   label,
   labelSize,
+  compact,
 }: {
   value: boolean;
   onChange: (value: boolean) => void;
   label: string;
   labelSize: '$bodyMd' | '$bodySm';
+  compact?: boolean;
 }) {
   return (
     <XStack
-      p="$4"
+      p={compact ? '$3' : '$4'}
       gap="$3"
       alignItems="center"
       onPress={() => onChange(!value)}
@@ -93,6 +95,7 @@ export function HyperliquidTermsContent({
   const { hyperliquidLogo } = usePerpsLogo();
 
   const { gtMd } = useMedia();
+  const isCompact = !gtMd;
 
   const confirmationSlideStyle: IYStackProps | undefined = platformEnv.isNative
     ? undefined
@@ -101,23 +104,30 @@ export function HyperliquidTermsContent({
       };
 
   return (
-    <Stack>
+    <Stack w="100%">
       <Stack
+        w="100%"
         minHeight={200}
         display="flex"
-        alignItems="center"
+        alignItems={isCompact ? 'stretch' : 'center'}
         justifyContent="center"
       >
         <DelayedRender delay={renderDelay}>
-          <Stack px="$2" py="$4" position="relative">
-            <YStack {...confirmationSlideStyle}>
+          <Stack
+            w="100%"
+            px={isCompact ? '$2' : '$2'}
+            py="$4"
+            position="relative"
+          >
+            <YStack w="100%" {...confirmationSlideStyle}>
               <Stack
                 testID="hyperliquid-intro-confirmation-slide"
+                w="100%"
                 alignItems="center"
                 justifyContent="center"
-                px="$2"
+                px={isCompact ? '$0' : '$2'}
               >
-                <YStack gap="$2">
+                <YStack w="100%" gap="$2">
                   <YStack
                     alignItems="center"
                     gap={gtMd ? '$2' : '$2'}
@@ -142,8 +152,9 @@ export function HyperliquidTermsContent({
                   </YStack>
 
                   <YStack
+                    w="100%"
                     maxWidth="100%"
-                    px="$3"
+                    px={isCompact ? '$1' : '$3'}
                     bg="$bgSubdued"
                     borderRadius="$3"
                   >
@@ -154,6 +165,7 @@ export function HyperliquidTermsContent({
                         id: ETranslations.perp_term_content_1,
                       })}
                       labelSize={gtMd ? '$bodyMd' : '$bodySm'}
+                      compact={isCompact}
                     />
                     <Divider borderColor="$borderSubdued" />
                     <CustomCheckbox
@@ -163,13 +175,15 @@ export function HyperliquidTermsContent({
                         id: ETranslations.perp_term_content_2,
                       })}
                       labelSize={gtMd ? '$bodyMd' : '$bodySm'}
+                      compact={isCompact}
                     />
                   </YStack>
                 </YStack>
               </Stack>
               <YStack
+                w="100%"
                 py="$8"
-                px={gtMd ? '$4' : '$2'}
+                px={gtMd ? '$4' : '$1'}
                 justifyContent="center"
                 pb={gtMd ? '$3' : '$1'}
                 gap="$1"
@@ -304,6 +318,12 @@ export async function showHyperliquidTermsDialog(): Promise<boolean> {
       disableDrag: true,
       dismissOnOverlayPress: false,
       showFooter: false,
+      contentContainerProps: platformEnv.isNative
+        ? {
+            px: '$3',
+            pb: '$3',
+          }
+        : undefined,
       showCancelButton: false,
       showConfirmButton: false,
       onClose: () => {

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/MobileOpenOrdersListHeader.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/MobileOpenOrdersListHeader.tsx
@@ -46,7 +46,7 @@ export function MobileOpenOrdersListHeader({
       {/* Left: Filter checkbox - same style as TP/SL checkbox in trading form */}
       <Checkbox
         label={intl.formatMessage({
-          id: ETranslations.perps_hide_other_symbols,
+          id: ETranslations.perps_hide_other_pairs,
         })}
         labelProps={{ fontSize: '$bodyXs' }}
         containerProps={{ p: '$0', alignItems: 'center' }}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/MobilePositionsListHeader.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/MobilePositionsListHeader.tsx
@@ -46,7 +46,7 @@ export function MobilePositionsListHeader({
       {/* Left: Filter checkbox - same style as TP/SL checkbox in trading form */}
       <Checkbox
         label={intl.formatMessage({
-          id: ETranslations.perps_hide_other_symbols,
+          id: ETranslations.perps_hide_other_pairs,
         })}
         labelProps={{ fontSize: '$bodyXs' }}
         containerProps={{ p: '$0', alignItems: 'center' }}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/SpotBalanceList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/SpotBalanceList.tsx
@@ -247,8 +247,9 @@ function SpotBalanceList({
       },
       {
         key: 'pnl',
-        // TODO: add i18n key — domain term consistent with Hyperliquid UI
-        title: 'PNL (ROE %)',
+        title: intl.formatMessage({
+          id: ETranslations.perp_position_pnl,
+        }),
         minWidth: 140,
         align: 'left',
         flex: 1,
@@ -355,7 +356,9 @@ function SpotBalanceList({
                 id: ETranslations.marketdex_unrealized_pnl,
               })}
             >
-              PnL
+              {intl.formatMessage({
+                id: ETranslations.perp_position_pnl_mobile,
+              })}
             </DashText>
           </XStack>
         </XStack>

--- a/packages/kit/src/views/Perp/components/PerpMarketFooter.android.tsx
+++ b/packages/kit/src/views/Perp/components/PerpMarketFooter.android.tsx
@@ -5,7 +5,7 @@ import { StyleSheet, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { runOnJS } from 'react-native-reanimated';
 
-import { Button, Page } from '@onekeyhq/components';
+import { Button, Page, SizableText } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import useAppNavigation from '../../../hooks/useAppNavigation';
@@ -15,6 +15,7 @@ import { GetTradingButtonStyleProps } from '../utils/styleUtils';
 
 const MARKET_FOOTER_BUTTON_WIDTH = '47%';
 const MARKET_FOOTER_BUTTON_HEIGHT = 36;
+const MARKET_FOOTER_BUTTON_TEXT_LINE_HEIGHT = 20;
 
 // On Android, the native bottom tab navigator (react-native-bottom-tabs)
 // intercepts touches in the tab bar area, preventing RN's built-in touch
@@ -88,14 +89,24 @@ function PerpMarketFooter() {
             width="100%"
             height={MARKET_FOOTER_BUTTON_HEIGHT}
             size="small"
+            py="$0"
             borderRadius="$full"
             bg={longButtonStyle.bg}
-            color={longButtonStyle.textColor}
             justifyContent="center"
             alignItems="center"
+            childrenAsText={false}
             testID="page-footer-cancel"
           >
-            {buyText}
+            <SizableText
+              size="$bodyMdMedium"
+              lineHeight={MARKET_FOOTER_BUTTON_TEXT_LINE_HEIGHT}
+              color={longButtonStyle.textColor}
+              numberOfLines={1}
+              ellipsizeMode="tail"
+              textAlign="center"
+            >
+              {buyText}
+            </SizableText>
           </Button>
         </View>
       </GestureDetector>
@@ -112,14 +123,24 @@ function PerpMarketFooter() {
             width="100%"
             height={MARKET_FOOTER_BUTTON_HEIGHT}
             size="small"
+            py="$0"
             borderRadius="$full"
             bg={shortButtonStyle.bg}
-            color={shortButtonStyle.textColor}
             justifyContent="center"
             alignItems="center"
+            childrenAsText={false}
             testID="page-footer-confirm"
           >
-            {sellText}
+            <SizableText
+              size="$bodyMdMedium"
+              lineHeight={MARKET_FOOTER_BUTTON_TEXT_LINE_HEIGHT}
+              color={shortButtonStyle.textColor}
+              numberOfLines={1}
+              ellipsizeMode="tail"
+              textAlign="center"
+            >
+              {sellText}
+            </SizableText>
           </Button>
         </View>
       </GestureDetector>
@@ -131,7 +152,7 @@ function PerpMarketFooter() {
     <Page.Footer
       px="$2"
       pt="$3"
-      pb="$8"
+      pb="$10"
       cancelButton={buyButton}
       confirmButton={sellButton}
       buttonContainerProps={{

--- a/packages/kit/src/views/Perp/components/PerpMarketFooter.tsx
+++ b/packages/kit/src/views/Perp/components/PerpMarketFooter.tsx
@@ -1,36 +1,21 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 
 import { useIntl } from 'react-intl';
-import { StyleSheet, View } from 'react-native';
 
-import {
-  Button,
-  Page,
-  SizableText,
-  useSafeAreaInsets,
-} from '@onekeyhq/components';
+import { Page, SizableText } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
-import useAppNavigation from '../../../hooks/useAppNavigation';
 import { useHyperliquidActions } from '../../../states/jotai/contexts/hyperliquid';
 import { useActiveTradeDisplay } from '../hooks/useActiveTradeDisplay';
 import { GetTradingButtonStyleProps } from '../utils/styleUtils';
 
-const MARKET_FOOTER_BUTTON_WIDTH = '47%';
 const MARKET_FOOTER_BUTTON_HEIGHT = 36;
-
-const styles = StyleSheet.create({
-  buttonContainer: {
-    width: MARKET_FOOTER_BUTTON_WIDTH,
-  },
-});
+const MARKET_FOOTER_BUTTON_TEXT_LINE_HEIGHT = 20;
 
 function PerpMarketFooter() {
   const intl = useIntl();
   const actionsRef = useHyperliquidActions();
   const { mode } = useActiveTradeDisplay();
-  const { bottom } = useSafeAreaInsets();
-  const navigation = useAppNavigation();
   const longButtonStyle = GetTradingButtonStyleProps('long');
   const shortButtonStyle = GetTradingButtonStyleProps('short');
 
@@ -47,86 +32,81 @@ function PerpMarketFooter() {
         : ETranslations.perp_trade_short,
   });
 
-  const handleCancel = useCallback(() => {
-    actionsRef.current.updateTradingForm({ side: 'long' });
-    navigation.pop();
-  }, [actionsRef, navigation]);
-
-  const handleConfirm = useCallback(() => {
-    actionsRef.current.updateTradingForm({ side: 'short' });
-    navigation.pop();
-  }, [actionsRef, navigation]);
-
-  const buyButton = useMemo(
-    () => (
-      <View style={styles.buttonContainer}>
-        <Button
-          width="100%"
-          height={MARKET_FOOTER_BUTTON_HEIGHT}
-          size="small"
-          borderRadius="$full"
-          bg={longButtonStyle.bg}
-          hoverStyle={longButtonStyle.hoverStyle}
-          pressStyle={longButtonStyle.pressStyle}
-          color={longButtonStyle.textColor}
-          justifyContent="center"
-          alignItems="center"
-          childrenAsText={false}
-          onPress={handleCancel}
-          testID="page-footer-cancel"
-        >
-          <SizableText
-            size="$bodyMdMedium"
-            lineHeight={18}
-            color={longButtonStyle.textColor}
-          >
-            {buyText}
-          </SizableText>
-        </Button>
-      </View>
-    ),
-    [buyText, handleCancel, longButtonStyle],
+  const handleCancel = useCallback(
+    (close: () => void) => {
+      actionsRef.current.updateTradingForm({ side: 'long' });
+      close();
+    },
+    [actionsRef],
   );
 
-  const sellButton = useMemo(
-    () => (
-      <View style={styles.buttonContainer}>
-        <Button
-          variant="primary"
-          width="100%"
-          height={MARKET_FOOTER_BUTTON_HEIGHT}
-          size="small"
-          borderRadius="$full"
-          bg={shortButtonStyle.bg}
-          hoverStyle={shortButtonStyle.hoverStyle}
-          pressStyle={shortButtonStyle.pressStyle}
-          color={shortButtonStyle.textColor}
-          justifyContent="center"
-          alignItems="center"
-          childrenAsText={false}
-          onPress={handleConfirm}
-          testID="page-footer-confirm"
-        >
-          <SizableText
-            size="$bodyMdMedium"
-            lineHeight={18}
-            color={shortButtonStyle.textColor}
-          >
-            {sellText}
-          </SizableText>
-        </Button>
-      </View>
-    ),
-    [handleConfirm, sellText, shortButtonStyle],
+  const handleConfirm = useCallback(
+    (close: () => void) => {
+      actionsRef.current.updateTradingForm({ side: 'short' });
+      close();
+    },
+    [actionsRef],
   );
 
   return (
     <Page.Footer
       px="$2"
       pt="$3"
-      pb={Math.max(bottom + 8, 32)}
-      cancelButton={buyButton}
-      confirmButton={sellButton}
+      pb="$10"
+      cancelButton={
+        <Page.CancelButton
+          flex={1}
+          height={MARKET_FOOTER_BUTTON_HEIGHT}
+          size="small"
+          py="$0"
+          borderRadius="$full"
+          bg={longButtonStyle.bg}
+          hoverStyle={longButtonStyle.hoverStyle}
+          pressStyle={longButtonStyle.pressStyle}
+          justifyContent="center"
+          alignItems="center"
+          childrenAsText={false}
+          onCancel={handleCancel}
+        >
+          <SizableText
+            size="$bodyMdMedium"
+            lineHeight={MARKET_FOOTER_BUTTON_TEXT_LINE_HEIGHT}
+            color={longButtonStyle.textColor}
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            textAlign="center"
+          >
+            {buyText}
+          </SizableText>
+        </Page.CancelButton>
+      }
+      confirmButton={
+        <Page.ConfirmButton
+          flex={1}
+          height={MARKET_FOOTER_BUTTON_HEIGHT}
+          size="small"
+          py="$0"
+          borderRadius="$full"
+          bg={shortButtonStyle.bg}
+          hoverStyle={shortButtonStyle.hoverStyle}
+          pressStyle={shortButtonStyle.pressStyle}
+          justifyContent="center"
+          alignItems="center"
+          childrenAsText={false}
+          onConfirm={handleConfirm}
+        >
+          <SizableText
+            size="$bodyMdMedium"
+            lineHeight={MARKET_FOOTER_BUTTON_TEXT_LINE_HEIGHT}
+            color={shortButtonStyle.textColor}
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            textAlign="center"
+          >
+            {sellText}
+          </SizableText>
+        </Page.ConfirmButton>
+      }
       buttonContainerProps={{
         width: '100%',
         justifyContent: 'center',

--- a/packages/kit/src/views/Perp/components/TickerBar/MobilePerpMarketHeader.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/MobilePerpMarketHeader.tsx
@@ -326,12 +326,7 @@ function MobilePerpMarketHeader() {
               id: ETranslations.perp_token_bar_24h_Volume,
             })}
           >
-            <SizableText
-              size="$bodySmMedium"
-              color="$text"
-              flex={1}
-              textAlign="right"
-            >
+            <SizableText size="$bodySmMedium" color="$text" textAlign="right">
               {volumeDisplay}
             </SizableText>
           </StatRow>
@@ -343,12 +338,7 @@ function MobilePerpMarketHeader() {
                 : ETranslations.perp_token_bar_open_Interest,
             })}
           >
-            <SizableText
-              size="$bodySmMedium"
-              color="$text"
-              flex={1}
-              textAlign="right"
-            >
+            <SizableText size="$bodySmMedium" color="$text" textAlign="right">
               {openInterestDisplay}
             </SizableText>
           </StatRow>
@@ -361,7 +351,6 @@ function MobilePerpMarketHeader() {
             >
               <SizableText
                 size="$bodySmMedium"
-                flex={1}
                 textAlign="right"
                 color={fundingColor}
               >
@@ -400,7 +389,6 @@ function MobilePerpMarketHeader() {
               />
               <SizableText
                 size="$bodySmMedium"
-                flex={1}
                 textAlign="right"
                 color="$green11"
               >

--- a/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
@@ -43,7 +43,7 @@ import {
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
-  SPOT_MIN_VOLUME_STRICT,
+  SPOT_SELECTOR_MIN_VOLUME,
   formatSpotPairDisplayName,
   getSpotTokenDisplayName,
   getTokenSubtitle,
@@ -411,7 +411,7 @@ function MobileTokenSelectorModal({
           marketCap,
         };
       })
-      .filter((e) => e.volume24h >= SPOT_MIN_VOLUME_STRICT);
+      .filter((e) => e.volume24h >= SPOT_SELECTOR_MIN_VOLUME);
 
     if (sortField) {
       entries.sort((a, b) => {

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -50,7 +50,7 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
 import {
-  SPOT_MIN_VOLUME_STRICT,
+  SPOT_SELECTOR_MIN_VOLUME,
   formatSpotPairDisplayName,
   getHyperliquidTokenImageUrl,
   getSpotTokenDisplayName,
@@ -138,6 +138,7 @@ function TokenListHeader({ isSpot }: { isSpot?: boolean }) {
   const intl = useIntl();
   return (
     <XStack
+      width="100%"
       px="$4"
       py="$3"
       borderBottomWidth="$px"
@@ -580,7 +581,7 @@ function BasePerpTokenSelectorContent({
           marketCap,
         };
       })
-      .filter((e) => e.volume24h >= SPOT_MIN_VOLUME_STRICT);
+      .filter((e) => e.volume24h >= SPOT_SELECTOR_MIN_VOLUME);
 
     if (sortField) {
       entries.sort((a, b) => {
@@ -800,12 +801,10 @@ function BasePerpTokenSelectorContent({
               <FavoritesEmptyState />
             ) : (
               <ListView
-                useFlashList
                 ref={listRef}
                 keyExtractor={keyExtractor}
-                estimatedItemSize={40}
                 windowSize={3}
-                initialNumToRender={5}
+                initialNumToRender={12}
                 data={activeTabData}
                 renderItem={renderItem}
                 ListEmptyComponent={listEmptyComponent}

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
@@ -97,7 +97,7 @@ const DESKTOP_SUBTITLE_MAX_WIDTH = 52;
 const MOBILE_SUBTITLE_MAX_WIDTH = 80;
 
 export const SPOT_TOKEN_SELECTOR_DESKTOP_COLUMN_LAYOUT = {
-  asset: { flex: 1.8, minWidth: 180 },
+  asset: { flex: 2.2, minWidth: 220 },
   price: { flex: 1.1, minWidth: 110 },
   change24h: { flex: 1.5, minWidth: 150 },
   volume: { flex: 1.1, minWidth: 110 },
@@ -671,9 +671,11 @@ const TokenSelectorRowDesktop = memo(() => {
           onPress={onPress}
           borderRadius="$0"
           justifyContent="flex-start"
+          width="100%"
           hoverStyle={{ bg: '$bgHover' }}
           px="$4"
           py="$3"
+          minHeight={48}
           flex={1}
           cursor="default"
         >

--- a/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
+++ b/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
@@ -39,7 +39,7 @@ import { PerpsAccountSelectorProviderMirror } from '../PerpsAccountSelectorProvi
 import { PerpsProviderMirror } from '../PerpsProviderMirror';
 
 const IOS_CHART_HEIGHT = 500;
-const IOS_CHART_BOTTOM_OVERLAP = 40;
+const IOS_CHART_BOTTOM_OVERLAP = 56;
 
 function useNativeGestureTouchScrollGuard({
   onTouchScroll,
@@ -257,8 +257,11 @@ function MobilePerpMarket() {
               renderTabBar={() => null}
             >
               <Tabs.Tab name="orderbook">
-                <Tabs.ScrollView showsVerticalScrollIndicator={false}>
-                  <YStack pt="$1.5">{orderBookContent}</YStack>
+                <Tabs.ScrollView
+                  showsVerticalScrollIndicator={false}
+                  contentContainerStyle={{ flexGrow: 0, minHeight: 0 }}
+                >
+                  <YStack>{orderBookContent}</YStack>
                 </Tabs.ScrollView>
               </Tabs.Tab>
             </Tabs.Container>

--- a/packages/shared/src/locale/enum/translations.ts
+++ b/packages/shared/src/locale/enum/translations.ts
@@ -3123,6 +3123,7 @@ export enum ETranslations {
   perps__fee_discount_activated__msg = 'perps__fee_discount_activated__msg',
   perps__snooze_remind_later__action = 'perps__snooze_remind_later__action',
   perps_footer_help_us_better = 'perps_footer.help_us_better',
+  perps_hide_other_pairs = 'perps_hide_other_pairs',
   perps_referral_campaign__desc = 'perps_referral_campaign__desc',
   perps_trigger_price_equal_current = 'perps_trigger_price_equal_current',
   pick_your_device = 'pick_your_device',

--- a/packages/shared/src/locale/json/bn.json
+++ b/packages/shared/src/locale/json/bn.json
@@ -3118,6 +3118,7 @@
   "perps__fee_discount_activated__msg": "ফি ছাড় সক্রিয় হয়েছে",
   "perps__snooze_remind_later__action": "এখন নয়, পরে মনে করিয়ে দিন",
   "perps_footer.help_us_better": "Perps Community",
+  "perps_hide_other_pairs": "অন্যান্য পেয়ার লুকান",
   "perps_referral_campaign__desc": "বন্ধুদের আমন্ত্রণ জানান, একসাথে 99U জিতুন। লিডারবোর্ডে উঠুন এবং গ্র্যান্ড প্রাইজের সুযোগ নিন!",
   "perps_trigger_price_equal_current": "ট্রিগার মূল্য বর্তমান মূল্য থেকে আলাদা হতে হবে",
   "pick_your_device": "আপনার ডিভাইস নির্বাচন করুন",

--- a/packages/shared/src/locale/json/de.json
+++ b/packages/shared/src/locale/json/de.json
@@ -3118,6 +3118,7 @@
   "perps__fee_discount_activated__msg": "Gebührenrabatt aktiviert",
   "perps__snooze_remind_later__action": "Nicht jetzt, später erinnern",
   "perps_footer.help_us_better": "Perps Community",
+  "perps_hide_other_pairs": "Andere Paare ausblenden",
   "perps_referral_campaign__desc": "Lade Freunde ein und gewinne gemeinsam 99U. Klettere die Rangliste hoch und sichere dir den Hauptpreis!",
   "perps_trigger_price_equal_current": "Auslösepreis muss sich vom aktuellen Preis unterscheiden",
   "pick_your_device": "Wähle dein Gerät aus",

--- a/packages/shared/src/locale/json/en_US.json
+++ b/packages/shared/src/locale/json/en_US.json
@@ -3118,6 +3118,7 @@
   "perps__fee_discount_activated__msg": "Fee discount activated",
   "perps__snooze_remind_later__action": "Not now, remind me later",
   "perps_footer.help_us_better": "Perps Community",
+  "perps_hide_other_pairs": "Hide other pairs",
   "perps_referral_campaign__desc": "Invite friends, win 99U together. Climb the leaderboard for a chance at the grand prize!",
   "perps_trigger_price_equal_current": "Trigger price must differ from current price",
   "pick_your_device": "Pick your device",

--- a/packages/shared/src/locale/json/es.json
+++ b/packages/shared/src/locale/json/es.json
@@ -3118,6 +3118,7 @@
   "perps__fee_discount_activated__msg": "Descuento de comisión activado",
   "perps__snooze_remind_later__action": "Ahora no, recuérdame más tarde",
   "perps_footer.help_us_better": "Perps Community",
+  "perps_hide_other_pairs": "Ocultar otros pares",
   "perps_referral_campaign__desc": "¡Invita a amigos, gana 99U juntos. Escala en la clasificación y opta al gran premio!",
   "perps_trigger_price_equal_current": "El precio de activación debe ser diferente al precio actual",
   "pick_your_device": "Elige tu dispositivo",

--- a/packages/shared/src/locale/json/fr_FR.json
+++ b/packages/shared/src/locale/json/fr_FR.json
@@ -3118,6 +3118,7 @@
   "perps__fee_discount_activated__msg": "Réduction des frais activée",
   "perps__snooze_remind_later__action": "Pas maintenant, me rappeler plus tard",
   "perps_footer.help_us_better": "Perps Community",
+  "perps_hide_other_pairs": "Masquer les autres paires",
   "perps_referral_campaign__desc": "Invite des amis, gagnez 99U ensemble. Montez dans le classement pour tenter de remporter le grand prix !",
   "perps_trigger_price_equal_current": "Le prix déclencheur doit être différent du prix actuel",
   "pick_your_device": "Choisissez votre appareil",

--- a/packages/shared/src/locale/json/hi_IN.json
+++ b/packages/shared/src/locale/json/hi_IN.json
@@ -3118,6 +3118,7 @@
   "perps__fee_discount_activated__msg": "शुल्क छूट सक्रिय हो गई",
   "perps__snooze_remind_later__action": "अभी नहीं, बाद में याद दिलाएं",
   "perps_footer.help_us_better": "हमें बेहतर बनाने में मदद करें",
+  "perps_hide_other_pairs": "अन्य पेयर छिपाएँ",
   "perps_referral_campaign__desc": "दोस्तों को आमंत्रित करें, मिलकर 99U जीतें। लीडरबोर्ड पर चढ़ें और ग्रैंड प्राइज़ का मौका पाएं!",
   "perps_trigger_price_equal_current": "ट्रिगर मूल्य वर्तमान मूल्य से अलग होना चाहिए",
   "pick_your_device": "अपना डिवाइस चुनें",

--- a/packages/shared/src/locale/json/id.json
+++ b/packages/shared/src/locale/json/id.json
@@ -3118,6 +3118,7 @@
   "perps__fee_discount_activated__msg": "Diskon biaya diaktifkan",
   "perps__snooze_remind_later__action": "Nanti saja, ingatkan lagi nanti",
   "perps_footer.help_us_better": "Perps Community",
+  "perps_hide_other_pairs": "Sembunyikan pasangan lain",
   "perps_referral_campaign__desc": "Undang teman, menangkan 99U bersama. Daki papan peringkat untuk kesempatan meraih hadiah utama!",
   "perps_trigger_price_equal_current": "Harga trigger harus berbeda dari harga saat ini",
   "pick_your_device": "Pilih perangkat Anda",

--- a/packages/shared/src/locale/json/it_IT.json
+++ b/packages/shared/src/locale/json/it_IT.json
@@ -3118,6 +3118,7 @@
   "perps__fee_discount_activated__msg": "Sconto commissioni attivato",
   "perps__snooze_remind_later__action": "Non ora, ricordamelo dopo",
   "perps_footer.help_us_better": "Perps Community",
+  "perps_hide_other_pairs": "Nascondi altre coppie",
   "perps_referral_campaign__desc": "Invita amici, vinci 99U insieme. Scala la classifica per avere una chance al premio principale!",
   "perps_trigger_price_equal_current": "Il prezzo trigger deve differire dal prezzo attuale",
   "pick_your_device": "Scegli il tuo dispositivo",

--- a/packages/shared/src/locale/json/ja_JP.json
+++ b/packages/shared/src/locale/json/ja_JP.json
@@ -3118,6 +3118,7 @@
   "perps__fee_discount_activated__msg": "手数料割引が有効になりました",
   "perps__snooze_remind_later__action": "今はいい、後でもう一度",
   "perps_footer.help_us_better": "改善にご協力ください",
+  "perps_hide_other_pairs": "他のペアを非表示",
   "perps_referral_campaign__desc": "友達を招待して、一緒に 99U を当てよう。ランキングを上げてグランドプライズを狙え！",
   "perps_trigger_price_equal_current": "トリガー価格は現在の価格と異なる必要があります",
   "pick_your_device": "デバイスを選択",

--- a/packages/shared/src/locale/json/ko_KR.json
+++ b/packages/shared/src/locale/json/ko_KR.json
@@ -3118,6 +3118,7 @@
   "perps__fee_discount_activated__msg": "수수료 할인이 적용되었습니다",
   "perps__snooze_remind_later__action": "지금은 괜찮아요, 나중에 다시 알려주세요",
   "perps_footer.help_us_better": "저희 서비스 개선에 도움을 주세요",
+  "perps_hide_other_pairs": "다른 페어 숨기기",
   "perps_referral_campaign__desc": "친구를 초대하고 함께 99U를 받아가세요. 리더보드를 올라 대상을 노려보세요!",
   "perps_trigger_price_equal_current": "트리거 가격은 현재 가격과 달라야 합니다",
   "pick_your_device": "기기를 선택하세요",

--- a/packages/shared/src/locale/json/pt.json
+++ b/packages/shared/src/locale/json/pt.json
@@ -3118,6 +3118,7 @@
   "perps__fee_discount_activated__msg": "Desconto de taxa ativado",
   "perps__snooze_remind_later__action": "Agora não, lembrar mais tarde",
   "perps_footer.help_us_better": "Perps Community",
+  "perps_hide_other_pairs": "Ocultar outros pares",
   "perps_referral_campaign__desc": "Convida amigos, ganhem 99U juntos. Sobe no ranking e concorre ao grande prémio!",
   "perps_trigger_price_equal_current": "O preço de gatilho deve ser diferente do preço atual",
   "pick_your_device": "Escolha o seu dispositivo",

--- a/packages/shared/src/locale/json/pt_BR.json
+++ b/packages/shared/src/locale/json/pt_BR.json
@@ -3118,6 +3118,7 @@
   "perps__fee_discount_activated__msg": "Desconto de taxa ativado",
   "perps__snooze_remind_later__action": "Agora não, me lembre depois",
   "perps_footer.help_us_better": "Perps Community",
+  "perps_hide_other_pairs": "Ocultar outros pares",
   "perps_referral_campaign__desc": "Convide amigos, ganhe 99U juntos. Suba no ranking e concorra ao grande prêmio!",
   "perps_trigger_price_equal_current": "O preço de gatilho deve ser diferente do preço atual",
   "pick_your_device": "Escolha seu dispositivo",

--- a/packages/shared/src/locale/json/ru.json
+++ b/packages/shared/src/locale/json/ru.json
@@ -3118,6 +3118,7 @@
   "perps__fee_discount_activated__msg": "Скидка на комиссию активирована",
   "perps__snooze_remind_later__action": "Не сейчас, напомнить позже",
   "perps_footer.help_us_better": "Perps Community",
+  "perps_hide_other_pairs": "Скрыть другие пары",
   "perps_referral_campaign__desc": "Приглашай друзей, выигрывайте 99U вместе. Поднимайтесь в рейтинге и борись за главный приз!",
   "perps_trigger_price_equal_current": "Цена триггера должна отличаться от текущей цены",
   "pick_your_device": "Выберите своё устройство",

--- a/packages/shared/src/locale/json/th_TH.json
+++ b/packages/shared/src/locale/json/th_TH.json
@@ -3118,6 +3118,7 @@
   "perps__fee_discount_activated__msg": "ส่วนลดค่าธรรมเนียมเปิดใช้งานแล้ว",
   "perps__snooze_remind_later__action": "ยังไม่ต้อง เตือนฉันทีหลัง",
   "perps_footer.help_us_better": "Perps Community",
+  "perps_hide_other_pairs": "ซ่อนคู่เทรดอื่น",
   "perps_referral_campaign__desc": "ชวนเพื่อน ลุ้น 99U ด้วยกัน ปีนอันดับลีดเดอร์บอร์ดเพื่อลุ้นรางวัลใหญ่!",
   "perps_trigger_price_equal_current": "ราคาทริกเกอร์ต้องแตกต่างจากราคาปัจจุบัน",
   "pick_your_device": "เลือกอุปกรณ์ของคุณ",

--- a/packages/shared/src/locale/json/uk_UA.json
+++ b/packages/shared/src/locale/json/uk_UA.json
@@ -3118,6 +3118,7 @@
   "perps__fee_discount_activated__msg": "Знижку на комісію активовано",
   "perps__snooze_remind_later__action": "Не зараз, нагадати пізніше",
   "perps_footer.help_us_better": "Perps Community",
+  "perps_hide_other_pairs": "Приховати інші пари",
   "perps_referral_campaign__desc": "Запрошуй друзів, вигравайте 99U разом. Підіймайся в рейтингу та змагайся за головний приз!",
   "perps_trigger_price_equal_current": "Ціна тригера має відрізнятися від поточної ціни",
   "pick_your_device": "Виберіть свій пристрій",

--- a/packages/shared/src/locale/json/vi.json
+++ b/packages/shared/src/locale/json/vi.json
@@ -3118,6 +3118,7 @@
   "perps__fee_discount_activated__msg": "Đã kích hoạt giảm phí",
   "perps__snooze_remind_later__action": "Không phải bây giờ, nhắc tôi sau",
   "perps_footer.help_us_better": "Perps Community",
+  "perps_hide_other_pairs": "Ẩn các cặp khác",
   "perps_referral_campaign__desc": "Mời bạn bè, cùng nhau giành 99U. Leo bảng xếp hạng để có cơ hội giành giải lớn!",
   "perps_trigger_price_equal_current": "Giá kích hoạt phải khác với giá hiện tại",
   "pick_your_device": "Chọn thiết bị của bạn",

--- a/packages/shared/src/locale/json/zh_CN.json
+++ b/packages/shared/src/locale/json/zh_CN.json
@@ -3118,6 +3118,7 @@
   "perps__fee_discount_activated__msg": "手续费优惠已生效",
   "perps__snooze_remind_later__action": "暂不需要，下次再提醒我",
   "perps_footer.help_us_better": "合约社区",
+  "perps_hide_other_pairs": "隐藏其他交易对",
   "perps_referral_campaign__desc": "邀请好友，一起抽奖 99U。更有天梯排名冲击大奖！",
   "perps_trigger_price_equal_current": "触发价不能等于当前价格",
   "pick_your_device": "选择您的设备",

--- a/packages/shared/src/locale/json/zh_HK.json
+++ b/packages/shared/src/locale/json/zh_HK.json
@@ -3118,6 +3118,7 @@
   "perps__fee_discount_activated__msg": "手續費優惠已生效",
   "perps__snooze_remind_later__action": "暫不需要，下次再提醒我",
   "perps_footer.help_us_better": "合約社区",
+  "perps_hide_other_pairs": "隱藏其他交易對",
   "perps_referral_campaign__desc": "邀請好友，一起抽獎 99U。更有天梯排名衝擊大獎！",
   "perps_trigger_price_equal_current": "觸發價不能等於當前價格",
   "pick_your_device": "選擇你的裝置",

--- a/packages/shared/src/locale/json/zh_TW.json
+++ b/packages/shared/src/locale/json/zh_TW.json
@@ -3118,6 +3118,7 @@
   "perps__fee_discount_activated__msg": "手續費優惠已生效",
   "perps__snooze_remind_later__action": "暫不需要，下次再提醒我",
   "perps_footer.help_us_better": "合約社区",
+  "perps_hide_other_pairs": "隱藏其他交易對",
   "perps_referral_campaign__desc": "邀請好友，一起抽獎 99U。更有天梯排名衝擊大獎！",
   "perps_trigger_price_equal_current": "觸發價不能等於當前價格",
   "pick_your_device": "選擇您的裝置",

--- a/packages/shared/src/utils/perpsUtils.ts
+++ b/packages/shared/src/utils/perpsUtils.ts
@@ -1668,6 +1668,7 @@ function isSpotInstrument(coin?: string | null): boolean {
 }
 
 const SPOT_MIN_VOLUME_STRICT = 10;
+const SPOT_SELECTOR_MIN_VOLUME = 1000;
 
 function filterSpotTokensStrict(
   tokens: Array<{ dayNtlVlm: number; midPx: boolean }>,
@@ -1718,6 +1719,7 @@ export {
   filterSpotTokensStrict,
   SPOT_TOKEN_DISPLAY_MAP,
   SPOT_MIN_VOLUME_STRICT,
+  SPOT_SELECTOR_MIN_VOLUME,
 };
 export default {
   formatAssetCtx,
@@ -1767,6 +1769,7 @@ export default {
   filterSpotTokensStrict,
   SPOT_TOKEN_DISPLAY_MAP,
   SPOT_MIN_VOLUME_STRICT,
+  SPOT_SELECTOR_MIN_VOLUME,
   getValidSpotPriceDecimals,
   formatSpotPriceToValid,
 };


### PR DESCRIPTION
## Summary
- Fixed Perps/Spot mobile follow-up issues covering i18n, selector filtering, token selector layout stability, mobile K-line header copy, mobile order book/footer spacing, and filter copy.
- Added the new `perps_hide_other_pairs` i18n key with full locale coverage and reused existing PnL translation keys where possible.
- Optimized the Hyperliquid terms sheet content width on mobile.

## Issues
- https://onekeyhq.atlassian.net/browse/OK-53924
- https://onekeyhq.atlassian.net/browse/OK-53925
- https://onekeyhq.atlassian.net/browse/OK-53933
- https://onekeyhq.atlassian.net/browse/OK-53937
- https://onekeyhq.atlassian.net/browse/OK-53938
- https://onekeyhq.atlassian.net/browse/OK-53941

## Intent & Context
These changes address the Perps mobile review items shown in the QA board:
- `OK-53924`: Spot holdings PnL labels were still using raw copy in some places.
- `OK-53925`: Spot token selector columns could visually jump due to unstable first-column width/rendering.
- `OK-53933`: Spot selector needed to filter out tokens with volume below 1k.
- `OK-53937`: Some copy on the mobile K-line page was missing due to squeezed layout.
- `OK-53938`: Mobile market/order book footer area had excess blank space and footer button text clipping.
- `OK-53941`: "Hide other symbols/contracts" copy was inaccurate for Spot pairs.

## Changes Detail
- Reused `perp_position_pnl` / `perp_position_pnl_mobile` for Spot holdings PnL labels.
- Added `perps_hide_other_pairs` and switched mobile positions/open orders filter copy to "Hide other pairs".
- Adjusted mobile token selector filtering and layout stability for Spot rows.
- Adjusted mobile market header stat layout so K-line page labels remain visible.
- Tuned mobile market order book/footer spacing and footer button text rendering.
- Tuned Hyperliquid terms sheet content width on mobile.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile primarily; generated i18n locale files affect all platforms.
- **Risk Areas**: Mobile Perps/Spot layout, generated locale updates, Hyperliquid terms sheet presentation.

## Test plan
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware ... --deny-warnings` for the changed Perps files.
- [x] `yarn lint:staged`
- [ ] `yarn tsc:staged` currently fails on existing unrelated CLI type errors in:
  - `apps/cli/src/commands/auth/hardware-login-command.ts`
  - `apps/cli/src/commands/device/hardware-sdk.ts`
  - `apps/cli/src/signer/base/SignerHardwareBase.ts`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
