### PR TITLE
fix(home): resolve Tron action label i18n fallback (OK-53783)

### DIFF
--- a/packages/kit/src/components/RewardCenter/index.ts
+++ b/packages/kit/src/components/RewardCenter/index.ts
@@ -1,13 +1,13 @@
 import type { IDialogShowProps, IKeyOfIcons } from '@onekeyhq/components';
 import { IMPL_TRON } from '@onekeyhq/shared/src/engine/engineConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 
 import { showTronRewardCenter } from './TronRewardCenter';
 
 export type IRewardCenterConfig = {
-  title: string;
+  title?: string;
+  titleId?: ETranslations;
   icon: IKeyOfIcons;
   handler: (
     props: IDialogShowProps & {
@@ -18,9 +18,7 @@ export type IRewardCenterConfig = {
 };
 
 const rewardCenterDefaultConfig: IRewardCenterConfig = {
-  title: appLocale.intl.formatMessage({
-    id: ETranslations.wallet_subsidy_redeem_title,
-  }),
+  titleId: ETranslations.wallet_subsidy_redeem_title,
   icon: 'GiftOutline',
   handler: () => {},
 };

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionRewardCenter.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionRewardCenter.tsx
@@ -1,9 +1,12 @@
 import { useCallback } from 'react';
 
+import { useIntl } from 'react-intl';
+
 import { ActionList } from '@onekeyhq/components';
 import type { IRewardCenterConfig } from '@onekeyhq/kit/src/components/RewardCenter';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
   EModalRewardCenterRoutes,
   EModalRoutes,
@@ -16,6 +19,7 @@ export function WalletActionRewardCenter({
   rewardCenterConfig: IRewardCenterConfig;
   onClose: () => void;
 }) {
+  const intl = useIntl();
   const { activeAccount } = useActiveAccount({ num: 0 });
 
   const { network, account, wallet } = activeAccount;
@@ -47,7 +51,14 @@ export function WalletActionRewardCenter({
     <ActionList.Item
       trackID="wallet-reward-center"
       icon={rewardCenterConfig?.icon}
-      label={rewardCenterConfig?.title}
+      label={
+        rewardCenterConfig?.title ??
+        intl.formatMessage({
+          id:
+            rewardCenterConfig?.titleId ??
+            ETranslations.wallet_subsidy_redeem_title,
+        })
+      }
       onClose={() => {}}
       onPress={handleRewardCenter}
     />

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionStaking.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionStaking.tsx
@@ -1,9 +1,11 @@
 import { useCallback } from 'react';
 
 import { noop } from 'lodash';
+import { useIntl } from 'react-intl';
 
 import { useUserWalletProfile } from '@onekeyhq/kit/src/hooks/useUserWalletProfile';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 
 import { RawActions } from './RawActions';
@@ -17,6 +19,7 @@ function WalletActionStaking({
   customization?: IActionCustomization;
   showButtonStyle?: boolean;
 }) {
+  const intl = useIntl();
   const { activeAccount } = useActiveAccount({ num: 0 });
 
   const { network, wallet } = activeAccount;
@@ -40,7 +43,12 @@ function WalletActionStaking({
   return (
     <RawActions.Staking
       onPress={handleStaking}
-      label={customization?.label}
+      label={
+        customization?.label ??
+        intl.formatMessage({
+          id: customization?.labelId ?? ETranslations.wallet_tron_trx_staking,
+        })
+      }
       icon={customization?.icon}
       showButtonStyle={showButtonStyle}
       disabled={customization?.disabled}

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionVote.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionVote.tsx
@@ -43,7 +43,9 @@ export function WalletActionVote({
       label={
         customization?.label ??
         intl.formatMessage({
-          id: ETranslations.wallet_tron_votes_management,
+          id:
+            customization?.labelId ??
+            ETranslations.wallet_tron_votes_management,
         })
       }
       onClose={() => {}}

--- a/packages/kit/src/views/Home/components/WalletActions/networkConfigs.ts
+++ b/packages/kit/src/views/Home/components/WalletActions/networkConfigs.ts
@@ -4,7 +4,6 @@ import {
 } from '@onekeyhq/core/src/chains/tron/constants';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   openUrlExternal,
@@ -98,9 +97,7 @@ export const detailedNetworkConfigs: Record<
     ],
     actionCustomization: {
       staking: {
-        label: appLocale.intl.formatMessage({
-          id: ETranslations.wallet_tron_trx_staking,
-        }),
+        labelId: ETranslations.wallet_tron_trx_staking,
         onPress: () => {
           if (platformEnv.isDesktop || platformEnv.isNative) {
             setTimeout(() => {
@@ -114,9 +111,7 @@ export const detailedNetworkConfigs: Record<
         },
       },
       vote: {
-        label: appLocale.intl.formatMessage({
-          id: ETranslations.wallet_tron_votes_management,
-        }),
+        labelId: ETranslations.wallet_tron_votes_management,
         onPress: () => {
           if (platformEnv.isDesktop || platformEnv.isNative) {
             setTimeout(() => {

--- a/packages/kit/src/views/Home/components/WalletActions/types.ts
+++ b/packages/kit/src/views/Home/components/WalletActions/types.ts
@@ -1,3 +1,5 @@
+import type { ETranslations } from '@onekeyhq/shared/src/locale';
+
 export type IWalletActionType =
   | 'send'
   | 'receive'
@@ -21,6 +23,7 @@ export type IMoreActionGroupType = 'trading' | 'tools' | 'developer' | 'others';
 
 export interface IActionCustomization {
   label?: string;
+  labelId?: ETranslations;
   icon?: any;
   disabled?: boolean;
   onPress?: () => void | Promise<void>;


### PR DESCRIPTION
## Jira
https://onekeyhq.atlassian.net/browse/OK-53783

## Summary
- Fix Tron wallet home actions showing i18n keys before locale messages are ready
- Resolve labels for TRX staking, votes management, and free resource action at render time

## Verification
- lint:staged passed
- pre-commit tsc passed

## Release
- JS Bundle hot update candidate
- QA bundle verification pending
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->