### PR TITLE
fix: add perps analytics events

### DIFF
--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPerp.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPerp.ts
@@ -51,6 +51,7 @@ export interface ISimpleDbPerpData {
   configVersion?: string;
   tradingviewDisplayPriceScale?: Record<string, number>; // decimal places for price display in tradingview chart
   hyperliquidTermsAccepted?: boolean;
+  perpOrderOpenFlags?: Record<string, boolean>; // user address -> whether orderOpen has succeeded
   hyperliquidErrorLocales?: IHyperLiquidErrorLocaleItem[];
   dexAbstractionEnabledUsers?: Record<string, boolean>; // user address -> HIP-3 DEX abstraction enabled status
   abstractionModeUsers?: Record<string, string>; // user address -> EHyperLiquidAbstractionMode
@@ -87,6 +88,33 @@ export class SimpleDbEntityPerp extends SimpleDbEntityBase<ISimpleDbPerpData> {
       (prevConfig): ISimpleDbPerpData => ({
         ...prevConfig,
         hyperliquidTermsAccepted: termsAccepted,
+      }),
+    );
+  }
+
+  @backgroundMethod()
+  async isFirstPerpOrderOpen(userAddress: string): Promise<boolean> {
+    const key = userAddress.toLowerCase();
+    if (!key) {
+      return true;
+    }
+    const config = await this.getPerpData();
+    return !config.perpOrderOpenFlags?.[key];
+  }
+
+  @backgroundMethod()
+  async markPerpOrderOpen(userAddress: string) {
+    const key = userAddress.toLowerCase();
+    if (!key) {
+      return;
+    }
+    await this.setPerpData(
+      (prevConfig): ISimpleDbPerpData => ({
+        ...prevConfig,
+        perpOrderOpenFlags: {
+          ...prevConfig?.perpOrderOpenFlags,
+          [key]: true,
+        },
       }),
     );
   }

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
@@ -174,11 +174,16 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
     if (options.action !== 'orderOpen') {
       return undefined;
     }
-    const key = this._getOrderOpenFirstTimeKey(context);
-    if (!key) {
-      return true;
+    try {
+      const key = this._getOrderOpenFirstTimeKey(context);
+      if (!key) {
+        return true;
+      }
+      return await this.backgroundApi.simpleDb.perp.isFirstPerpOrderOpen(key);
+    } catch (error) {
+      console.error(error);
+      return undefined;
     }
-    return this.backgroundApi.simpleDb.perp.isFirstPerpOrderOpen(key);
   }
 
   private async _markOrderOpenSucceeded(

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
@@ -87,6 +87,11 @@ interface IOrderLogOptions {
   extra?: Record<string, unknown>;
 }
 
+interface IOrderLogContext {
+  accountAddress: string | null;
+  exchangeAccountAddress: string | null;
+}
+
 // TV lowercases everything; HL universe keys perps as `BTC`, spot as `@N`,
 // and sub-DEX as `xyz:<TICKER>` (lowercase prefix, uppercase ticker).
 function normalizePerpsCoin(coin: string): string {
@@ -152,6 +157,47 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
       accountAddress: activeAccount?.accountAddress ?? null,
       exchangeAccountAddress: this._account,
     };
+  }
+
+  private _getOrderOpenFirstTimeKey(context: IOrderLogContext) {
+    return (
+      context.accountAddress ??
+      context.exchangeAccountAddress ??
+      ''
+    ).toLowerCase();
+  }
+
+  private async _resolveOrderOpenIsFirstTime(
+    options: IOrderLogOptions,
+    context: IOrderLogContext,
+  ) {
+    if (options.action !== 'orderOpen') {
+      return undefined;
+    }
+    const key = this._getOrderOpenFirstTimeKey(context);
+    if (!key) {
+      return true;
+    }
+    return this.backgroundApi.simpleDb.perp.isFirstPerpOrderOpen(key);
+  }
+
+  private async _markOrderOpenSucceeded(
+    options: IOrderLogOptions,
+    context: IOrderLogContext,
+    isFirstTime: boolean | undefined,
+  ) {
+    if (options.action !== 'orderOpen' || !isFirstTime) {
+      return;
+    }
+    const key = this._getOrderOpenFirstTimeKey(context);
+    if (!key) {
+      return;
+    }
+    try {
+      await this.backgroundApi.simpleDb.perp.markPerpOrderOpen(key);
+    } catch (error) {
+      console.error(error);
+    }
   }
 
   private _composeOrderLogExtra(options: IOrderLogOptions) {
@@ -558,6 +604,12 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
     };
     const context = await this._buildLogContext();
     const extra = this._composeOrderLogExtra(options);
+    const isFirstTime = await this._resolveOrderOpenIsFirstTime(
+      options,
+      context,
+    );
+    const firstTimePayload =
+      typeof isFirstTime === 'boolean' ? { isFirstTime } : {};
     try {
       const response = await convertHyperLiquidResponse(() =>
         client.order({
@@ -571,6 +623,7 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
         action: options.action,
         payload: {
           ...context,
+          ...firstTimePayload,
           request: requestPayload,
           response,
           extra,
@@ -580,6 +633,7 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
       void this.backgroundApi.serviceRookieGuide.recordTaskCompleted(
         ERookieTaskType.PERPS,
       );
+      await this._markOrderOpenSucceeded(options, context, isFirstTime);
       return response;
     } catch (error) {
       dispatchHyperLiquidOrderLog({
@@ -587,6 +641,7 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
         action: options.action,
         payload: {
           ...context,
+          ...firstTimePayload,
           request: requestPayload,
           response: extractHyperLiquidErrorResponse<
             IOrderResponse | IApiErrorResponse

--- a/packages/kit/src/views/Perp/components/HyperliquidTerms.tsx
+++ b/packages/kit/src/views/Perp/components/HyperliquidTerms.tsx
@@ -81,11 +81,11 @@ function CustomCheckbox({
 
 export function HyperliquidTermsContent({
   onConfirm,
-  onClose,
+  onOpenLegalLink,
   renderDelay = 0,
 }: {
   onConfirm: () => void;
-  onClose?: () => void;
+  onOpenLegalLink?: () => void;
   renderDelay?: number;
 }) {
   const intl = useIntl();
@@ -217,7 +217,7 @@ export function HyperliquidTermsContent({
                       color="$textInteractive"
                       onPress={() => {
                         if (platformEnv.isDesktop || platformEnv.isNative) {
-                          onClose?.();
+                          onOpenLegalLink?.();
                           openUrlInDiscovery({ url: TERMS_OF_SERVICE_URL });
                         } else {
                           openUrlExternal(TERMS_OF_SERVICE_URL);
@@ -252,7 +252,7 @@ export function HyperliquidTermsContent({
                       color="$textInteractive"
                       onPress={() => {
                         if (platformEnv.isDesktop || platformEnv.isNative) {
-                          onClose?.();
+                          onOpenLegalLink?.();
                           openUrlInDiscovery({ url: PRIVACY_POLICY_URL });
                         } else {
                           openUrlExternal(PRIVACY_POLICY_URL);
@@ -286,6 +286,7 @@ export async function showHyperliquidTermsDialog(): Promise<boolean> {
     let hasResolved = false;
     let didTrackAgree = false;
     let didTrackReject = false;
+    let didOpenLegalLink = false;
     const trackTermsAgree = () => {
       if (!didTrackAgree) {
         didTrackAgree = true;
@@ -293,7 +294,12 @@ export async function showHyperliquidTermsDialog(): Promise<boolean> {
       }
     };
     const trackTermsReject = () => {
-      if (!didConfirm && !didTrackAgree && !didTrackReject) {
+      if (
+        !didConfirm &&
+        !didTrackAgree &&
+        !didTrackReject &&
+        !didOpenLegalLink
+      ) {
         didTrackReject = true;
         defaultLogger.perp.hyperliquid.perpTermsReject();
       }
@@ -322,12 +328,10 @@ export async function showHyperliquidTermsDialog(): Promise<boolean> {
               safeResolve(didConfirm);
             }
           }}
-          onClose={() => {
+          onOpenLegalLink={() => {
+            didOpenLegalLink = true;
             void dialog.close();
-            if (!didConfirm) {
-              trackTermsReject();
-              safeResolve(false);
-            }
+            safeResolve(false);
           }}
         />
       ),

--- a/packages/kit/src/views/Perp/components/HyperliquidTerms.tsx
+++ b/packages/kit/src/views/Perp/components/HyperliquidTerms.tsx
@@ -17,6 +17,7 @@ import {
 } from '@onekeyhq/components';
 import { DelayedRender } from '@onekeyhq/components/src/hocs/DelayedRender';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   openUrlExternal,
@@ -283,6 +284,20 @@ export async function showHyperliquidTermsDialog(): Promise<boolean> {
   return new Promise((resolve) => {
     let didConfirm = false;
     let hasResolved = false;
+    let didTrackAgree = false;
+    let didTrackReject = false;
+    const trackTermsAgree = () => {
+      if (!didTrackAgree) {
+        didTrackAgree = true;
+        defaultLogger.perp.hyperliquid.perpTermsAgree();
+      }
+    };
+    const trackTermsReject = () => {
+      if (!didConfirm && !didTrackAgree && !didTrackReject) {
+        didTrackReject = true;
+        defaultLogger.perp.hyperliquid.perpTermsReject();
+      }
+    };
     const safeResolve = (value: boolean) => {
       if (!hasResolved) {
         hasResolved = true;
@@ -295,6 +310,7 @@ export async function showHyperliquidTermsDialog(): Promise<boolean> {
         <HyperliquidTermsContent
           renderDelay={300}
           onConfirm={async () => {
+            trackTermsAgree();
             try {
               await backgroundApiProxy.simpleDb.perp.setHyperliquidTermsAccepted(
                 true,
@@ -309,6 +325,7 @@ export async function showHyperliquidTermsDialog(): Promise<boolean> {
           onClose={() => {
             void dialog.close();
             if (!didConfirm) {
+              trackTermsReject();
               safeResolve(false);
             }
           }}
@@ -328,6 +345,7 @@ export async function showHyperliquidTermsDialog(): Promise<boolean> {
       showConfirmButton: false,
       onClose: () => {
         if (!didConfirm) {
+          trackTermsReject();
           safeResolve(false);
         }
       },

--- a/packages/kit/src/views/Setting/pages/Tab/config.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/config.tsx
@@ -453,12 +453,12 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
               [
                 {
                   icon: 'GasOutline',
-                  // TODO: i18n — replace with ETranslations keys once product
-                  // adds the translation entries (settings_use_gas_account_by_default
-                  // / settings_use_gas_account_by_default_description).
-                  title: 'Use Gas Account by default',
-                  subtitle:
-                    'Pay eligible network fees from your Gas Account when available. Otherwise, use your wallet balance.',
+                  title: intl.formatMessage({
+                    id: ETranslations.settings_prefer_gas_account__title,
+                  }),
+                  subtitle: intl.formatMessage({
+                    id: ETranslations.settings_prefer_gas_account__desc,
+                  }),
                   renderElement: <UseGasAccountByDefaultListItem />,
                 },
               ],

--- a/packages/shared/src/locale/enum/translations.ts
+++ b/packages/shared/src/locale/enum/translations.ts
@@ -4101,6 +4101,8 @@ export enum ETranslations {
   settings_browser_new_tab_position_desc = 'settings_browser_new_tab_position_desc',
   settings_menu_bar_tray = 'settings_menu_bar_tray',
   settings_menu_bar_tray_desc = 'settings_menu_bar_tray_desc',
+  settings_prefer_gas_account__desc = 'settings_prefer_gas_account__desc',
+  settings_prefer_gas_account__title = 'settings_prefer_gas_account__title',
   settings_protection_allowlist_content = 'settings_protection.allowlist_content',
   settings_protection_allowlist_title = 'settings_protection.allowlist_title',
   setup_choose_option_create_new_wallet = 'setup_choose_option_create_new_wallet',

--- a/packages/shared/src/locale/json/bn.json
+++ b/packages/shared/src/locale/json/bn.json
@@ -3792,7 +3792,7 @@
   "referral_perps.undistributed": "অবণ্টিত",
   "referral_perps.undistributed_reward": "অবণ্টিত পুরস্কার",
   "referral_perps.volume": "আয়তন",
-  "referral_promo_title": "OneKey রেফারেল প্রোগ্রামে যোগ দিন",
+  "referral_promo_title": "রেফারাল কোড আছে? নিচে লিখুন",
   "remember_your_pin": "আপনার PIN প্রবেশ করুন",
   "remember_your_pin_desc": "এটি একটি পিন স্মরণকারী পরীক্ষা। আপনার পিন আপনার কীলেস ওয়ালেট পুনরুদ্ধার করতে প্রয়োজন—দয়া করে এটি নিরাপদে রাখুন।",
   "remove_account_desc": "এই অ্যাকাউন্টটি মুছে ফেলা হবে।",

--- a/packages/shared/src/locale/json/de.json
+++ b/packages/shared/src/locale/json/de.json
@@ -3792,7 +3792,7 @@
   "referral_perps.undistributed": "Nicht ausgeschüttet",
   "referral_perps.undistributed_reward": "Nicht ausgeschüttete Belohnung",
   "referral_perps.volume": "Volumen",
-  "referral_promo_title": "Tritt dem OneKey-Empfehlungsprogramm bei",
+  "referral_promo_title": "Hast du einen Empfehlungscode? Unten eingeben",
   "remember_your_pin": "Geben Sie Ihre PIN ein",
   "remember_your_pin_desc": "Dies ist eine PIN-Erinnerungsüberprüfung. Ihre PIN ist erforderlich, um Ihre schlüssellose Brieftasche wiederherzustellen – bitte bewahren Sie sie sicher auf.",
   "remove_account_desc": "Dieses Konto wird entfernt.",

--- a/packages/shared/src/locale/json/en_US.json
+++ b/packages/shared/src/locale/json/en_US.json
@@ -3792,7 +3792,7 @@
   "referral_perps.undistributed": "Undistributed",
   "referral_perps.undistributed_reward": "Undistributed reward",
   "referral_perps.volume": "Volume",
-  "referral_promo_title": "Join the OneKey Referral Program",
+  "referral_promo_title": "Got a referral code? Enter it below",
   "remember_your_pin": "Enter your PIN",
   "remember_your_pin_desc": "This is a PIN reminder check. Your PIN is required to restore your keyless wallet—please keep it safe.",
   "remove_account_desc": "This account will be removed.",

--- a/packages/shared/src/locale/json/es.json
+++ b/packages/shared/src/locale/json/es.json
@@ -3792,7 +3792,7 @@
   "referral_perps.undistributed": "No distribuido",
   "referral_perps.undistributed_reward": "Recompensa no distribuida",
   "referral_perps.volume": "Volumen",
-  "referral_promo_title": "Únete al Programa de Referidos de OneKey",
+  "referral_promo_title": "¿Tienes un código de referido? Introdúcelo abajo",
   "remember_your_pin": "Ingrese su PIN",
   "remember_your_pin_desc": "Este es un recordatorio de PIN. Se requiere su PIN para restaurar su billetera sin llave; por favor, manténgalo a salvo.",
   "remove_account_desc": "Esta cuenta será eliminada.",

--- a/packages/shared/src/locale/json/fr_FR.json
+++ b/packages/shared/src/locale/json/fr_FR.json
@@ -3792,7 +3792,7 @@
   "referral_perps.undistributed": "Non distribué",
   "referral_perps.undistributed_reward": "Récompense non distribuée",
   "referral_perps.volume": "Volume",
-  "referral_promo_title": "Rejoignez le programme de parrainage OneKey",
+  "referral_promo_title": "Vous avez un code de parrainage ? Saisissez-le ci-dessous",
   "remember_your_pin": "Entrez votre code PIN",
   "remember_your_pin_desc": "Ceci est un rappel de code PIN. Votre code PIN est requis pour restaurer votre portefeuille sans clé - veuillez le garder en sécurité.",
   "remove_account_desc": "Ce compte sera supprimé.",

--- a/packages/shared/src/locale/json/hi_IN.json
+++ b/packages/shared/src/locale/json/hi_IN.json
@@ -3792,7 +3792,7 @@
   "referral_perps.undistributed": "अवितरित",
   "referral_perps.undistributed_reward": "अवितरित इनाम",
   "referral_perps.volume": "मात्रा",
-  "referral_promo_title": "OneKey रेफ़रल प्रोग्राम से जुड़ें",
+  "referral_promo_title": "रेफ़रल कोड है? नीचे दर्ज करें",
   "remember_your_pin": "आपका पिन दर्ज करें",
   "remember_your_pin_desc": "यह एक पिन रिमाइंडर चेक है। आपकी पिन आपके कीलेस वॉलेट को पुनर्स्थापित करने के लिए आवश्यक है—कृपया इसे सुरक्षित रखें।",
   "remove_account_desc": "यह खाता हटा दिया जाएगा।",

--- a/packages/shared/src/locale/json/id.json
+++ b/packages/shared/src/locale/json/id.json
@@ -3792,7 +3792,7 @@
   "referral_perps.undistributed": "Belum didistribusikan",
   "referral_perps.undistributed_reward": "Hadiah yang belum didistribusikan",
   "referral_perps.volume": "Volume",
-  "referral_promo_title": "Bergabung dengan Program Rujukan OneKey",
+  "referral_promo_title": "Punya kode rujukan? Masukkan di bawah",
   "remember_your_pin": "Masukkan PIN Anda",
   "remember_your_pin_desc": "Ini adalah pemeriksaan pengingat PIN. PIN Anda diperlukan untuk memulihkan dompet tanpa kunci Anda—harap simpan dengan aman.",
   "remove_account_desc": "Akun ini akan dihapus.",

--- a/packages/shared/src/locale/json/it_IT.json
+++ b/packages/shared/src/locale/json/it_IT.json
@@ -3792,7 +3792,7 @@
   "referral_perps.undistributed": "Non distribuito",
   "referral_perps.undistributed_reward": "Ricompensa non distribuita",
   "referral_perps.volume": "Volume",
-  "referral_promo_title": "Partecipa al programma di referral OneKey",
+  "referral_promo_title": "Hai un codice referral? Inseriscilo qui sotto",
   "remember_your_pin": "Inserisci il tuo PIN",
   "remember_your_pin_desc": "Questo è un promemoria per il PIN. Il tuo PIN è necessario per ripristinare il tuo portafoglio senza chiave—per favore conservalo al sicuro.",
   "remove_account_desc": "Questo account verrà rimosso.",

--- a/packages/shared/src/locale/json/ja_JP.json
+++ b/packages/shared/src/locale/json/ja_JP.json
@@ -3792,7 +3792,7 @@
   "referral_perps.undistributed": "未分配",
   "referral_perps.undistributed_reward": "未分配報酬",
   "referral_perps.volume": "取引量",
-  "referral_promo_title": "OneKey リファラルプログラムに参加する",
+  "referral_promo_title": "紹介コードをお持ちですか？下に入力してください",
   "remember_your_pin": "あなたのPINを入力してください",
   "remember_your_pin_desc": "これはPINリマインダーの確認です。あなたのPINはキーレスウォレットを復元するために必要です—安全に保管してください。",
   "remove_account_desc": "このアカウントは削除されます。",

--- a/packages/shared/src/locale/json/ko_KR.json
+++ b/packages/shared/src/locale/json/ko_KR.json
@@ -3792,7 +3792,7 @@
   "referral_perps.undistributed": "분배되지 않음",
   "referral_perps.undistributed_reward": "분배되지 않은 보상",
   "referral_perps.volume": "거래량",
-  "referral_promo_title": "OneKey 추천 프로그램에 참여하세요",
+  "referral_promo_title": "추천 코드가 있으신가요? 아래에 입력하세요",
   "remember_your_pin": "PIN을 입력하세요",
   "remember_your_pin_desc": "이것은 PIN 알림 확인입니다. 키 없는 지갑을 복원하려면 PIN이 필요합니다. 안전하게 보관해 주세요.",
   "remove_account_desc": "이 계정은 삭제될 것입니다.",

--- a/packages/shared/src/locale/json/pt.json
+++ b/packages/shared/src/locale/json/pt.json
@@ -3792,7 +3792,7 @@
   "referral_perps.undistributed": "Não distribuído",
   "referral_perps.undistributed_reward": "Recompensa não distribuída",
   "referral_perps.volume": "Volume",
-  "referral_promo_title": "Participe do Programa de Indicação OneKey",
+  "referral_promo_title": "Tem um código de indicação? Insira abaixo",
   "remember_your_pin": "Introduza o seu PIN",
   "remember_your_pin_desc": "Isto é um aviso de lembrete do PIN. O seu PIN é necessário para restaurar a sua carteira sem chave—por favor, mantenha-o seguro.",
   "remove_account_desc": "Esta conta será removida.",

--- a/packages/shared/src/locale/json/pt_BR.json
+++ b/packages/shared/src/locale/json/pt_BR.json
@@ -3792,7 +3792,7 @@
   "referral_perps.undistributed": "Não distribuído",
   "referral_perps.undistributed_reward": "Recompensa não distribuída",
   "referral_perps.volume": "Volume",
-  "referral_promo_title": "Participe do Programa de Indicação OneKey",
+  "referral_promo_title": "Tem um código de indicação? Insira abaixo",
   "remember_your_pin": "Digite seu PIN",
   "remember_your_pin_desc": "Este é um lembrete do PIN. Seu PIN é necessário para restaurar sua carteira sem chave—por favor, mantenha-o seguro.",
   "remove_account_desc": "Esta conta será removida.",

--- a/packages/shared/src/locale/json/ru.json
+++ b/packages/shared/src/locale/json/ru.json
@@ -3792,7 +3792,7 @@
   "referral_perps.undistributed": "Нераспределено",
   "referral_perps.undistributed_reward": "Нераспределенная награда",
   "referral_perps.volume": "Объем",
-  "referral_promo_title": "Присоединяйтесь к реферальной программе OneKey",
+  "referral_promo_title": "Есть реферальный код? Введите ниже",
   "remember_your_pin": "Введите ваш PIN",
   "remember_your_pin_desc": "Это проверка напоминания PIN-кода. Ваш PIN-код необходим для восстановления вашего безключевого кошелька — пожалуйста, храните его в безопасности.",
   "remove_account_desc": "Этот аккаунт будет удален.",

--- a/packages/shared/src/locale/json/th_TH.json
+++ b/packages/shared/src/locale/json/th_TH.json
@@ -3792,7 +3792,7 @@
   "referral_perps.undistributed": "ยังไม่ได้แจกจ่าย",
   "referral_perps.undistributed_reward": "รางวัลที่ยังไม่ได้แจกจ่าย",
   "referral_perps.volume": "ปริมาณ",
-  "referral_promo_title": "เข้าร่วมโปรแกรมแนะนำเพื่อน OneKey",
+  "referral_promo_title": "มีรหัสแนะนำหรือไม่? กรอกด้านล่าง",
   "remember_your_pin": "กรุณาใส่ PIN ของคุณ",
   "remember_your_pin_desc": "นี่คือการตรวจสอบการเตือน PIN ของคุณ PIN ของคุณจำเป็นต้องใช้ในการกู้คืนกระเป๋าเงินแบบไม่ใช้กุญแจของคุณ—โปรดเก็บให้ปลอดภัย",
   "remove_account_desc": "บัญชีนี้จะถูกลบออก",

--- a/packages/shared/src/locale/json/uk_UA.json
+++ b/packages/shared/src/locale/json/uk_UA.json
@@ -3792,7 +3792,7 @@
   "referral_perps.undistributed": "Нерозподілено",
   "referral_perps.undistributed_reward": "Нерозподілена винагорода",
   "referral_perps.volume": "Обсяг",
-  "referral_promo_title": "Приєднуйтесь до реферальної програми OneKey",
+  "referral_promo_title": "Маєте реферальний код? Введіть нижче",
   "remember_your_pin": "Введіть свій PIN",
   "remember_your_pin_desc": "Це перевірка нагадування PIN. Ваш PIN необхідний для відновлення вашого безключового гаманця — будь ласка, зберігайте його в безпеці.",
   "remove_account_desc": "Цей обліковий запис буде видалено.",

--- a/packages/shared/src/locale/json/vi.json
+++ b/packages/shared/src/locale/json/vi.json
@@ -3792,7 +3792,7 @@
   "referral_perps.undistributed": "Chưa phân phối",
   "referral_perps.undistributed_reward": "Phần thưởng chưa phân phối",
   "referral_perps.volume": "Khối lượng",
-  "referral_promo_title": "Tham gia Chương trình Giới thiệu OneKey",
+  "referral_promo_title": "Có mã giới thiệu? Nhập bên dưới",
   "remember_your_pin": "Nhập mã PIN của bạn",
   "remember_your_pin_desc": "Đây là một kiểm tra nhắc nhở PIN. PIN của bạn là cần thiết để khôi phục ví không khóa của bạn—xin vui lòng giữ nó an toàn.",
   "remove_account_desc": "Tài khoản này sẽ bị xóa.",

--- a/packages/shared/src/locale/json/zh_CN.json
+++ b/packages/shared/src/locale/json/zh_CN.json
@@ -3792,7 +3792,7 @@
   "referral_perps.undistributed": "待发放",
   "referral_perps.undistributed_reward": "未发放奖励",
   "referral_perps.volume": "交易量",
-  "referral_promo_title": "加入 OneKey 推荐计划",
+  "referral_promo_title": "有邀请码吗？在此填写",
   "remember_your_pin": "输入您的 PIN",
   "remember_your_pin_desc": "这是一次 PIN 记忆校验。PIN 用于恢复无私钥钱包，请妥善保管并牢记。",
   "remove_account_desc": "此账户将被删除。",

--- a/packages/shared/src/locale/json/zh_HK.json
+++ b/packages/shared/src/locale/json/zh_HK.json
@@ -3792,7 +3792,7 @@
   "referral_perps.undistributed": "待發放",
   "referral_perps.undistributed_reward": "尚未發放獎勵",
   "referral_perps.volume": "交易量",
-  "referral_promo_title": "加入 OneKey 推薦計劃",
+  "referral_promo_title": "有邀請碼嗎？在此填寫",
   "remember_your_pin": "輸入您的 PIN",
   "remember_your_pin_desc": "這是一次 PIN 記憶校驗。 PIN 用於恢復無私鑰錢包，請妥善保管並牢記。",
   "remove_account_desc": "此帳戶將被刪除。",

--- a/packages/shared/src/locale/json/zh_TW.json
+++ b/packages/shared/src/locale/json/zh_TW.json
@@ -3792,7 +3792,7 @@
   "referral_perps.undistributed": "待發放",
   "referral_perps.undistributed_reward": "尚未發放獎勵",
   "referral_perps.volume": "交易量",
-  "referral_promo_title": "加入 OneKey 推薦計畫",
+  "referral_promo_title": "有邀請碼嗎？在此填寫",
   "remember_your_pin": "輸入您的 PIN",
   "remember_your_pin_desc": "這是一次 PIN 記憶校驗。 PIN 用於恢復無私鑰錢包，請妥善保管並牢記。",
   "remove_account_desc": "此帳戶將被移除。",

--- a/packages/shared/src/logger/scopes/perp/scenes/hyperliquid.ts
+++ b/packages/shared/src/logger/scopes/perp/scenes/hyperliquid.ts
@@ -34,6 +34,7 @@ export interface IHyperLiquidLogParams<
   response?: TResponse;
   error?: Record<string, unknown>;
   extra?: Record<string, unknown>;
+  isFirstTime?: boolean;
 }
 
 function stripSensitiveFields<TRequest, TResponse>(
@@ -133,6 +134,16 @@ export class HyperLiquidScene extends BaseScene {
     >,
   ) {
     return stripSensitiveFields(params);
+  }
+
+  @LogToServer()
+  public perpTermsAgree() {
+    return {};
+  }
+
+  @LogToServer()
+  public perpTermsReject() {
+    return {};
   }
 
   @LogToServer()


### PR DESCRIPTION
## Summary
- Add server-side Perps analytics events for Hyperliquid terms agree and reject actions.
- Add an `isFirstTime` flag to the existing `orderOpen` analytics payload.
- Persist successful first Perps open-order state locally with `simpleDb.perp`.

## Intent & Context
The Perps new-user funnel currently cannot split loss between the Hyperliquid terms step and the deposit step, and Mixpanel cannot directly distinguish first-time Perps opens from repeat trading. The requested scope was to add items 1, 2, and 3 from the analytics gap list, skip item 4 (`perpOrderFinalStatus`), and confirm item 5 (`PerpDepositFinal`) is not defined on the frontend.

## Root Cause
The Perps Hyperliquid terms dialog had no `LogToServer` events for explicit agreement or rejection. The existing `orderOpen` event also had no persistent first-time marker, so first-time trade analysis required offline data joins.

## Design Decisions
- Reused the existing `defaultLogger.perp.hyperliquid` scene to keep events in the Perps Hyperliquid analytics scope.
- Used `@LogToServer()` methods rather than direct analytics calls, matching the logger architecture.
- Kept `isFirstTime` as a top-level `orderOpen` payload field so it is directly filterable in Mixpanel.
- Marked a user as non-first-time only after a successful `orderOpen`; failed attempts still report the current first-time state but do not consume it.
- Did not add `perpOrderFinalStatus` because it was explicitly excluded from this request.
- Did not modify `PerpDepositFinal`; no frontend event definition was found, so pending-event noise should be handled in the backend emitter.

## Changes Detail
- `packages/shared/src/logger/scopes/perp/scenes/hyperliquid.ts`: adds `perpTermsAgree`, `perpTermsReject`, and allows `isFirstTime` in Hyperliquid log params.
- `packages/kit/src/views/Perp/components/HyperliquidTerms.tsx`: logs agree/reject actions from the terms dialog with local de-duplication.
- `packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPerp.ts`: stores successful Perps open-order flags keyed by user address.
- `packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts`: resolves and sends `isFirstTime` for `orderOpen`, then persists the successful first-open marker.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Analytics payload shape and local first-time state persistence. The trading request flow is unchanged, and the marker write happens only after the order response is logged.

## Test plan
- [x] `yarn lint:staged`
- [x] `git diff --cached --check`
- [ ] `yarn tsc:staged` currently fails on existing hardware SDK and ledger/ton type errors outside this change set.
- [ ] Open the Hyperliquid terms dialog and verify `perpTermsAgree` fires once when clicking agree.
- [ ] Close the Hyperliquid terms dialog and verify `perpTermsReject` fires once.
- [ ] Submit a first Perps open order and verify `orderOpen.isFirstTime === true`; submit a later successful open order and verify `false`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
