### PR TITLE
feat(redemption): restore paidAt / txHash / rejectReason on BTC reward detail

### DIFF
--- a/packages/kit/src/views/Redemption/pages/BtcReward/BtcRewardDetail.tsx
+++ b/packages/kit/src/views/Redemption/pages/BtcReward/BtcRewardDetail.tsx
@@ -13,6 +13,8 @@ import {
   YStack,
   useClipboard,
 } from '@onekeyhq/components';
+import { openTransactionDetailsUrl } from '@onekeyhq/kit/src/utils/explorerUtils';
+import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IBtcRewardHistoryItem } from '@onekeyhq/shared/src/referralCode/type';
 import { EBtcRewardStatus } from '@onekeyhq/shared/src/referralCode/type';
@@ -64,8 +66,26 @@ function BtcRewardDetailPage() {
     copyText(item.walletAddress);
   }, [item.walletAddress, copyText]);
 
+  const handleCopyTxHash = useCallback(() => {
+    copyText(item.txHash);
+  }, [item.txHash, copyText]);
+
+  const handleViewOnBaseScan = useCallback(() => {
+    void openTransactionDetailsUrl({
+      networkId: getNetworkIdsMap().base,
+      txid: item.txHash,
+    });
+  }, [item.txHash]);
+
   const statusConfig =
     statusConfigs[item.status] ?? statusConfigs[EBtcRewardStatus.Wait];
+  const isPaid = item.status === EBtcRewardStatus.Paid;
+  // OAS marks these fields required, but the server uses empty string when
+  // the field is not applicable to the current status — guard before render.
+  const rejectReason =
+    item.status === EBtcRewardStatus.Rejected && item.rejectReason
+      ? item.rejectReason
+      : null;
 
   return (
     <Page scrollEnabled>
@@ -87,11 +107,11 @@ function BtcRewardDetailPage() {
             </SizableText>
             <SizableText
               size="$bodyMd"
-              color="$textSubdued"
+              color={rejectReason ? '$textCritical' : '$textSubdued'}
               textAlign="center"
               pt="$1"
             >
-              {statusConfig.description}
+              {rejectReason ?? statusConfig.description}
             </SizableText>
           </YStack>
 
@@ -146,6 +166,15 @@ function BtcRewardDetailPage() {
               />
             ) : null}
 
+            {isPaid && item.paidAt ? (
+              <DetailRow
+                label={intl.formatMessage({
+                  id: ETranslations.referral_distributed,
+                })}
+                value={formatDate(item.paidAt)}
+              />
+            ) : null}
+
             <Divider />
             <XStack justifyContent="space-between" alignItems="center" gap="$2">
               <SizableText size="$bodyMd" color="$textSubdued">
@@ -170,6 +199,43 @@ function BtcRewardDetailPage() {
                 />
               </XStack>
             </XStack>
+
+            {isPaid && item.txHash ? (
+              <XStack
+                justifyContent="space-between"
+                alignItems="center"
+                gap="$2"
+              >
+                <SizableText size="$bodyMd" color="$textSubdued">
+                  {intl.formatMessage({
+                    id: ETranslations.global_transaction_id,
+                  })}
+                </SizableText>
+                <XStack gap="$1" alignItems="center" flexShrink={1}>
+                  <SizableText size="$bodyMdMedium" numberOfLines={1}>
+                    {accountUtils.shortenAddress({ address: item.txHash })}
+                  </SizableText>
+                  <IconButton
+                    variant="tertiary"
+                    size="small"
+                    icon="Copy3Outline"
+                    onPress={handleCopyTxHash}
+                    title={intl.formatMessage({
+                      id: ETranslations.redemption_btc_detail_copy_tx_hash,
+                    })}
+                  />
+                  <IconButton
+                    variant="tertiary"
+                    size="small"
+                    icon="OpenOutline"
+                    onPress={handleViewOnBaseScan}
+                    title={intl.formatMessage({
+                      id: ETranslations.global_view_in_blockchain_explorer,
+                    })}
+                  />
+                </XStack>
+              </XStack>
+            ) : null}
           </YStack>
         </YStack>
       </Page.Body>

--- a/packages/kit/src/views/Redemption/pages/BtcReward/BtcRewardDetail.tsx
+++ b/packages/kit/src/views/Redemption/pages/BtcReward/BtcRewardDetail.tsx
@@ -51,6 +51,51 @@ function DetailRow({ label, value }: { label: string; value: string }) {
   );
 }
 
+function HashRow({
+  label,
+  value,
+  onCopy,
+  copyTitle,
+  onOpenExplorer,
+  openExplorerTitle,
+}: {
+  label: string;
+  value: string;
+  onCopy: () => void;
+  copyTitle: string;
+  onOpenExplorer?: () => void;
+  openExplorerTitle?: string;
+}) {
+  return (
+    <XStack justifyContent="space-between" alignItems="center" gap="$2">
+      <SizableText size="$bodyMd" color="$textSubdued">
+        {label}
+      </SizableText>
+      <XStack gap="$1" alignItems="center" flexShrink={1}>
+        <SizableText size="$bodyMdMedium" numberOfLines={1}>
+          {accountUtils.shortenAddress({ address: value })}
+        </SizableText>
+        <IconButton
+          variant="tertiary"
+          size="small"
+          icon="Copy3Outline"
+          onPress={onCopy}
+          title={copyTitle}
+        />
+        {onOpenExplorer ? (
+          <IconButton
+            variant="tertiary"
+            size="small"
+            icon="OpenOutline"
+            onPress={onOpenExplorer}
+            title={openExplorerTitle}
+          />
+        ) : null}
+      </XStack>
+    </XStack>
+  );
+}
+
 function BtcRewardDetailPage() {
   const intl = useIntl();
   const route = useRoute<IRouteParams>();
@@ -176,65 +221,32 @@ function BtcRewardDetailPage() {
             ) : null}
 
             <Divider />
-            <XStack justifyContent="space-between" alignItems="center" gap="$2">
-              <SizableText size="$bodyMd" color="$textSubdued">
-                {intl.formatMessage({
-                  id: ETranslations.referral_reward_received_address,
-                })}
-              </SizableText>
-              <XStack gap="$1" alignItems="center" flexShrink={1}>
-                <SizableText size="$bodyMdMedium" numberOfLines={1}>
-                  {accountUtils.shortenAddress({
-                    address: item.walletAddress,
-                  })}
-                </SizableText>
-                <IconButton
-                  variant="tertiary"
-                  size="small"
-                  icon="Copy3Outline"
-                  onPress={handleCopyAddress}
-                  title={intl.formatMessage({
-                    id: ETranslations.global_copy_address,
-                  })}
-                />
-              </XStack>
-            </XStack>
+            <HashRow
+              label={intl.formatMessage({
+                id: ETranslations.referral_reward_received_address,
+              })}
+              value={item.walletAddress}
+              onCopy={handleCopyAddress}
+              copyTitle={intl.formatMessage({
+                id: ETranslations.global_copy_address,
+              })}
+            />
 
             {isPaid && item.txHash ? (
-              <XStack
-                justifyContent="space-between"
-                alignItems="center"
-                gap="$2"
-              >
-                <SizableText size="$bodyMd" color="$textSubdued">
-                  {intl.formatMessage({
-                    id: ETranslations.global_transaction_id,
-                  })}
-                </SizableText>
-                <XStack gap="$1" alignItems="center" flexShrink={1}>
-                  <SizableText size="$bodyMdMedium" numberOfLines={1}>
-                    {accountUtils.shortenAddress({ address: item.txHash })}
-                  </SizableText>
-                  <IconButton
-                    variant="tertiary"
-                    size="small"
-                    icon="Copy3Outline"
-                    onPress={handleCopyTxHash}
-                    title={intl.formatMessage({
-                      id: ETranslations.redemption_btc_detail_copy_tx_hash,
-                    })}
-                  />
-                  <IconButton
-                    variant="tertiary"
-                    size="small"
-                    icon="OpenOutline"
-                    onPress={handleViewOnBaseScan}
-                    title={intl.formatMessage({
-                      id: ETranslations.global_view_in_blockchain_explorer,
-                    })}
-                  />
-                </XStack>
-              </XStack>
+              <HashRow
+                label={intl.formatMessage({
+                  id: ETranslations.global_transaction_id,
+                })}
+                value={item.txHash}
+                onCopy={handleCopyTxHash}
+                copyTitle={intl.formatMessage({
+                  id: ETranslations.redemption_btc_detail_copy_tx_hash,
+                })}
+                onOpenExplorer={handleViewOnBaseScan}
+                openExplorerTitle={intl.formatMessage({
+                  id: ETranslations.global_view_in_blockchain_explorer,
+                })}
+              />
             ) : null}
           </YStack>
         </YStack>

--- a/packages/shared/src/referralCode/type.ts
+++ b/packages/shared/src/referralCode/type.ts
@@ -778,6 +778,12 @@ export interface IBtcRewardHistoryItem {
   status: EBtcRewardStatus;
   submittedAt: string;
   payoutEligibleAt: string;
+  // Status-conditional fields. OAS marks them required but the value is an
+  // empty string when not applicable (paidAt/txHash empty unless paid;
+  // rejectReason empty unless rejected).
+  paidAt: string;
+  txHash: string;
+  rejectReason: string;
 }
 
 export interface IBtcRewardHistoryResponse {


### PR DESCRIPTION
## Summary

Server re-added the three status-conditional fields to the `btc-reward/history` OAS schema (`paidAt`, `txHash`, `rejectReason`). Pull them back into the client type and restore the corresponding rows on the BTC reward detail page so users can see:

- the payout time when `status=paid`
- the on-chain tx hash + Base explorer link when `status=paid`
- the reject reason in red text when `status=rejected`

## Context

The previous PR (#11414) dropped these three fields because the OAS at the time did not include them. Server has since updated the OAS to mark all three as required strings. The server returns an empty string for fields that don't apply to the current status (e.g. `txHash=""` for a `wait` record), so the rendering guards on a non-empty string in addition to status.

## Test plan

- [ ] Detail page on a `paid` record shows the payout time row and the tx hash row with copy + Base explorer buttons
- [ ] Detail page on a `rejected` record shows the reject reason in red text in place of the default status description
- [ ] Detail page on a `wait` / `pendingPayout` / `payoutInProgress` record shows neither the payout time nor the tx hash row
- [ ] Tx hash copy button copies the full hash; explorer button opens BaseScan for the same hash
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
