### PR TITLE
chore: bump electron 39.8.7 -> 39.8.9

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -61,7 +61,7 @@
     "@types/node-fetch": "^2.6.1",
     "concurrently": "9.2.1",
     "cross-env": "7.0.3",
-    "electron": "39.8.7",
+    "electron": "39.8.9",
     "electron-builder": "26.4.0",
     "esbuild": "0.27.2",
     "folderslint": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -420,7 +420,7 @@
     "@metamask/eth-sig-util": "5.1.0",
     "@polkadot/api": "14.3.1",
     "@polkadot/util": "13.2.3",
-    "electron": "39.8.7",
+    "electron": "39.8.9",
     "@walletconnect/core": "2.21.9",
     "@walletconnect/utils": "2.21.9",
     "@walletconnect/types": "2.21.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9735,7 +9735,7 @@ __metadata:
     adm-zip: "npm:^0.5.10"
     concurrently: "npm:9.2.1"
     cross-env: "npm:7.0.3"
-    electron: "npm:39.8.7"
+    electron: "npm:39.8.9"
     electron-builder: "npm:26.4.0"
     electron-check-biometric-auth-changed: "npm:1.0.0"
     electron-context-menu: "npm:^3.5.0"
@@ -27151,16 +27151,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:39.8.7":
-  version: 39.8.7
-  resolution: "electron@npm:39.8.7"
+"electron@npm:39.8.9":
+  version: 39.8.9
+  resolution: "electron@npm:39.8.9"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^22.7.7"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/775996a65d016baa372d85e3d755a26fbd5243ee04bfe87dc8cda2e1a836c3a3afe8585aabffa3205e7a5ed4c16dc6ece56d4c506dc13ed2aaa6ce93b02324ce
+  checksum: 10/7e6902177a34486595a3db7fd07cdc8b5a705e76fc8520527c15d72d09f0ce205765da02080ee77b5ebdc02d4dde365f80f100a4dc592cc05b75dc351abc8beb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bumps Electron from 39.8.7 to 39.8.9 in `apps/desktop/package.json` and root `package.json` resolutions.
- Regenerates `yarn.lock` for the new version.

## Test plan
- [ ] `yarn install` succeeds
- [ ] `yarn app:desktop` boots without regressions
- [ ] Desktop build pipeline passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
