### PR TITLE
feat: smooth perps order book transitions

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderBook/index.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/index.tsx
@@ -1,15 +1,18 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { colorTokens } from '@tamagui/themes';
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 import {
+  Animated,
+  Easing,
   Pressable,
   StyleSheet,
   Text,
   TouchableOpacity,
   View,
 } from 'react-native';
+import { useReducedMotion } from 'react-native-reanimated';
 
 import {
   DashText,
@@ -71,6 +74,8 @@ export function PerpBookText({ children, style, ...props }: TextProps) {
 export const rowHeight = 24;
 
 type IWebPointerStyle = ViewStyle & { cursor?: string };
+const ORDER_BOOK_DEPTH_WIDTH_TRANSITION_MS = 260;
+const ORDER_BOOK_SIDE_RATIO_TRANSITION_MS = 300;
 
 const getPressableHoverState = (state: PressableStateCallbackType): boolean => {
   if (!platformEnv.isNative) {
@@ -366,16 +371,79 @@ export type IOrderBookSelection = {
   index: number;
 };
 
+function normalizeDepthWidth(width: DimensionValue) {
+  let numericWidth = 0;
+
+  if (typeof width === 'number') {
+    numericWidth = width;
+  } else if (typeof width === 'string') {
+    numericWidth = Number.parseFloat(width);
+  }
+
+  if (!Number.isFinite(numericWidth)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(100, numericWidth));
+}
+
+function useAnimatedOrderBookPercentage({
+  duration,
+  value,
+}: {
+  duration: number;
+  value: number;
+}) {
+  const targetValue = Math.max(0, Math.min(100, value));
+  const reducedMotion = useReducedMotion();
+  const animatedValue = useRef(new Animated.Value(targetValue)).current;
+  const isFirstRenderRef = useRef(true);
+
+  useEffect(() => {
+    animatedValue.stopAnimation();
+
+    if (isFirstRenderRef.current || reducedMotion) {
+      isFirstRenderRef.current = false;
+      animatedValue.setValue(targetValue);
+      return;
+    }
+
+    Animated.timing(animatedValue, {
+      toValue: targetValue,
+      duration,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: false,
+    }).start();
+  }, [animatedValue, duration, reducedMotion, targetValue]);
+
+  return animatedValue;
+}
+
 function ColorBlock({ color, width, left, right, height }: IColorBlockProps) {
+  const targetWidth = useMemo(() => normalizeDepthWidth(width), [width]);
+  const widthAnim = useAnimatedOrderBookPercentage({
+    duration: ORDER_BOOK_DEPTH_WIDTH_TRANSITION_MS,
+    value: targetWidth,
+  });
+  const animatedWidth = useMemo(
+    () =>
+      widthAnim.interpolate({
+        inputRange: [0, 100],
+        outputRange: ['0%', '100%'],
+        extrapolate: 'clamp',
+      }),
+    [widthAnim],
+  );
+
   return (
-    <View
+    <Animated.View
       style={[
         styles.colorBlock,
         {
           height: height ?? rowHeight,
           right,
           left,
-          width,
+          width: animatedWidth,
           backgroundColor: color,
         },
       ]}
@@ -534,6 +602,14 @@ function OrderBookSideRatio({
       askPercentage: 100 - bid,
     };
   }, [bidDepth, totalDepth]);
+  const bidSegmentFlex = useAnimatedOrderBookPercentage({
+    duration: ORDER_BOOK_SIDE_RATIO_TRANSITION_MS,
+    value: Math.max(bidPercentage, 1),
+  });
+  const askSegmentFlex = useAnimatedOrderBookPercentage({
+    duration: ORDER_BOOK_SIDE_RATIO_TRANSITION_MS,
+    value: Math.max(askPercentage, 1),
+  });
   const isCompact = size === 'compact' || size === 'mobile';
   const isMobile = size === 'mobile';
 
@@ -564,22 +640,22 @@ function OrderBookSideRatio({
           isMobile ? styles.sideRatioTrackMobile : null,
         ]}
       >
-        <View
+        <Animated.View
           style={[
             styles.sideRatioSegment,
             styles.sideRatioSegmentStart,
             {
-              flex: Math.max(bidPercentage, 1),
+              flex: bidSegmentFlex,
               backgroundColor: sideRatioColors.long,
             },
           ]}
         />
-        <View
+        <Animated.View
           style={[
             styles.sideRatioSegment,
             styles.sideRatioSegmentEnd,
             {
-              flex: Math.max(askPercentage, 1),
+              flex: askSegmentFlex,
               backgroundColor: sideRatioColors.short,
             },
           ]}
@@ -1035,7 +1111,7 @@ export function OrderBook({
                   <OrderBookVerticalRow
                     item={itemData}
                     priceColor={textColor.red}
-                    sizeColor={textColor.textSubdued}
+                    sizeColor={textColor.text}
                     isHovered={getPressableHoverState(state)}
                   />
                 )}
@@ -1122,7 +1198,7 @@ export function OrderBook({
                 <OrderBookVerticalRow
                   item={itemData}
                   priceColor={textColor.green}
-                  sizeColor={textColor.textSubdued}
+                  sizeColor={textColor.text}
                   isHovered={getPressableHoverState(state)}
                 />
               )}


### PR DESCRIPTION
## Summary
- Smooth Perps order book depth bar width changes instead of jumping between updates.
- Smooth the B/S side ratio bar when bid/ask depth percentages change.
- Increase desktop vertical order book size/total text contrast.

## Intent & Context
The Perps order book depth blocks updated instantly as market data changed, which made the blocks feel like they were jumping between states. The requested behavior was to make the transition from state 1 to state 2 smoother, similar to trading UIs that keep the order book readable while data updates frequently.

## Design Decisions
- Animate only the depth bar width and B/S ratio values, leaving text, row height, sorting, and click targets unchanged.
- Use short layout animations with `Animated.Value` because the visual property being changed is width/flex.
- Respect reduced motion by directly setting values when reduced motion is enabled.
- Keep B/S ratio colors aligned with the existing trading button colors in light mode and current red/green tokens in dark mode.

## Changes Detail
- `packages/kit/src/views/Perp/components/OrderBook/index.tsx`
  - Added a shared percentage animation helper for order book visual bars.
  - Changed depth `ColorBlock` from a static `View` to an `Animated.View`.
  - Animated B/S ratio segment flex values.
  - Changed desktop vertical size/total text color from `textSubdued` to `text`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Web / Desktop / Mobile / iOS / Android
- **Risk Areas**: Width and flex animations use `useNativeDriver: false` because layout properties are animated. Durations are short, but order book update frequency should be checked on lower-end devices.

## Test plan
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/views/Perp/components/OrderBook/index.tsx --deny-warnings`
- [x] `git diff --check`
- [ ] Verify Perps order book depth bars transition smoothly on desktop.
- [ ] Verify Perps order book depth bars and B/S ratio transition smoothly on mobile/iOS.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
