### PR TITLE
fix: add earn fixed income liquidity (OK-53658)

### DIFF
--- a/packages/kit/src/views/Earn/components/AvailableAssetsTabViewList.tsx
+++ b/packages/kit/src/views/Earn/components/AvailableAssetsTabViewList.tsx
@@ -35,10 +35,13 @@ import { EModalRoutes, EModalStakingRoutes } from '@onekeyhq/shared/src/routes';
 import type { IEarnAvailableAsset } from '@onekeyhq/shared/types/earn';
 import { EAvailableAssetsTypeEnum } from '@onekeyhq/shared/types/earn';
 
-import { EarnNavigation } from '../earnUtils';
+import { EarnNavigation, parseFormattedLiquidityValue } from '../earnUtils';
 
 import { AprText } from './AprText';
 import { buildEarnAvailableAssetCategoryTabs } from './earnCategoryTabs';
+import { EarnMobileSortControl } from './EarnMobileSortControl';
+
+import type { IEarnSortDirection } from './EarnMobileSortControl';
 
 export function AvailableAssetsTabViewList() {
   const [{ availableAssetsByType = {}, refreshTrigger = 0 }] = useEarnAtom();
@@ -47,6 +50,9 @@ export function AvailableAssetsTabViewList() {
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
   const [searchText, setSearchText] = useState('');
   const [searchLoading, setSearchLoading] = useState(false);
+  const [sortKey, setSortKey] = useState('yield');
+  const [sortDirection, setSortDirection] =
+    useState<IEarnSortDirection>('desc');
   const media = useMedia();
   const navigation = useAppNavigation();
   const { activeAccount } = useActiveAccount({ num: 0 });
@@ -63,11 +69,60 @@ export function AvailableAssetsTabViewList() {
     return tabData.map((item) => item.title);
   }, [tabData]);
   const focusedTab = useSharedValue(TabNames[0]);
+  const selectedTabType = tabData[selectedTabIndex]?.type;
+  const isFixedRateTab = selectedTabType === EAvailableAssetsTypeEnum.FixedRate;
+  const showMobileSortControl =
+    isFixedRateTab && (platformEnv.isNative || !media.gtMd);
+  const previousTabTypeRef = useRef<EAvailableAssetsTypeEnum | undefined>(
+    selectedTabType,
+  );
+
+  const handleSortChange = useCallback(
+    (key: string, direction: IEarnSortDirection) => {
+      setSortKey(key);
+      setSortDirection(direction);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const previousTabType = previousTabTypeRef.current;
+    const switchedFromFixedRate =
+      previousTabType === EAvailableAssetsTypeEnum.FixedRate &&
+      selectedTabType !== EAvailableAssetsTypeEnum.FixedRate;
+
+    if (switchedFromFixedRate) {
+      setSortKey('yield');
+      setSortDirection('desc');
+    }
+
+    previousTabTypeRef.current = selectedTabType;
+  }, [selectedTabType]);
+
+  const mobileSortOptions = useMemo(
+    () =>
+      isFixedRateTab
+        ? [
+            {
+              label: intl.formatMessage({ id: ETranslations.defi_apr_apy }),
+              value: 'yield',
+            },
+            {
+              label: intl.formatMessage({
+                id: ETranslations.dexmarket_details_liquidity_change_total,
+              }),
+              value: 'liquidity',
+            },
+          ]
+        : [],
+    [intl, isFixedRateTab],
+  );
 
   // Get filtered assets based on selected tab and search text
   const assets = useMemo(() => {
-    const currentTabType = tabData[selectedTabIndex]?.type;
-    const source = availableAssetsByType[currentTabType] || [];
+    const source = selectedTabType
+      ? availableAssetsByType[selectedTabType] || []
+      : [];
     if (!searchText) return source;
     const query = searchText.toLowerCase();
     return source.filter(
@@ -75,7 +130,7 @@ export function AvailableAssetsTabViewList() {
         a.symbol.toLowerCase().includes(query) ||
         a.name.toLowerCase().includes(query),
     );
-  }, [availableAssetsByType, selectedTabIndex, tabData, searchText]);
+  }, [availableAssetsByType, selectedTabType, searchText]);
 
   // Use ref to track component mount status to prevent state updates after unmount
   const isMountedRef = useRef(true);
@@ -121,15 +176,14 @@ export function AvailableAssetsTabViewList() {
   // Load data for the selected tab
   usePromiseResult(
     async () => {
-      const currentTabType = tabData[selectedTabIndex]?.type;
-      if (currentTabType) {
-        const result = await fetchAssetsData(currentTabType);
+      if (selectedTabType) {
+        const result = await fetchAssetsData(selectedTabType);
         return result || [];
       }
       return [];
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [selectedTabIndex, tabData, refreshTrigger, fetchAssetsData],
+    [selectedTabType, refreshTrigger, fetchAssetsData],
     {
       watchLoading: true,
       undefinedResultIfError: false, // Return empty array instead of undefined on error
@@ -148,8 +202,8 @@ export function AvailableAssetsTabViewList() {
     [focusedTab, tabData],
   );
 
-  const columns: ITableColumn<IEarnAvailableAsset>[] = useMemo(
-    () => [
+  const columns: ITableColumn<IEarnAvailableAsset>[] = useMemo(() => {
+    const baseColumns: ITableColumn<IEarnAvailableAsset>[] = [
       {
         key: 'asset',
         label: intl.formatMessage({ id: ETranslations.global_asset }),
@@ -195,22 +249,45 @@ export function AvailableAssetsTabViewList() {
           />
         ),
       },
-      {
-        key: 'yield',
-        label: intl.formatMessage({ id: ETranslations.defi_apr_apy }),
+    ];
+
+    if (isFixedRateTab) {
+      baseColumns.push({
+        key: 'liquidity',
+        label: intl.formatMessage({
+          id: ETranslations.dexmarket_details_liquidity_change_total,
+        }),
         flex: 1,
         align: 'flex-end',
+        hideInMobile: true,
         sortable: true,
-        comparator: (a, b) => {
-          const aprA = parseFloat(a.aprWithoutFee || a.apr || '0');
-          const aprB = parseFloat(b.aprWithoutFee || b.apr || '0');
-          return aprA - aprB;
-        },
-        render: (asset) => <AprText asset={asset} hideSuffix />,
+        comparator: (a, b) =>
+          parseFormattedLiquidityValue(a.liquidity) -
+          parseFormattedLiquidityValue(b.liquidity),
+        render: (asset) => (
+          <SizableText size="$bodyLgMedium">
+            {asset.liquidity || '-'}
+          </SizableText>
+        ),
+      });
+    }
+
+    baseColumns.push({
+      key: 'yield',
+      label: intl.formatMessage({ id: ETranslations.defi_apr_apy }),
+      flex: 1,
+      align: 'flex-end',
+      sortable: true,
+      comparator: (a, b) => {
+        const aprA = parseFloat(a.aprWithoutFee || a.apr || '0');
+        const aprB = parseFloat(b.aprWithoutFee || b.apr || '0');
+        return aprA - aprB;
       },
-    ],
-    [intl],
-  );
+      render: (asset) => <AprText asset={asset} hideSuffix />,
+    });
+
+    return baseColumns;
+  }, [intl, isFixedRateTab]);
 
   // Navigate to asset detail or protocol list, reused by both table and search dialog
   const navigateToAsset = useCallback(
@@ -284,10 +361,9 @@ export function AvailableAssetsTabViewList() {
   // Handle row press in the main table
   const handleRowPress = useCallback(
     (asset: IEarnAvailableAsset) => {
-      const currentTabType = tabData[selectedTabIndex]?.type;
-      return navigateToAsset(asset, currentTabType);
+      return navigateToAsset(asset, selectedTabType);
     },
-    [navigateToAsset, tabData, selectedTabIndex],
+    [navigateToAsset, selectedTabType],
   );
 
   // Mobile custom renderer
@@ -321,13 +397,21 @@ export function AvailableAssetsTabViewList() {
           }
         />
         <XStack flex={1} ai="center" jc="flex-end">
-          <XStack flexShrink={0} jc="flex-end">
+          <YStack flexShrink={0} ai="flex-end">
             <AprText asset={asset} />
-          </XStack>
+            {isFixedRateTab && asset.liquidity ? (
+              <SizableText size="$bodySm" color="$textSubdued">
+                {intl.formatMessage({
+                  id: ETranslations.dexmarket_details_liquidity_change_total,
+                })}
+                : {asset.liquidity}
+              </SizableText>
+            ) : null}
+          </YStack>
         </XStack>
       </ListItem>
     ),
-    [handleRowPress],
+    [handleRowPress, intl, isFixedRateTab],
   );
 
   // Memoize keyExtractor for TableList
@@ -513,14 +597,24 @@ export function AvailableAssetsTabViewList() {
         ) : null}
       </XStack>
 
+      {showMobileSortControl ? (
+        <EarnMobileSortControl
+          sortKey={sortKey}
+          sortDirection={sortDirection}
+          options={mobileSortOptions}
+          onSortChange={handleSortChange}
+        />
+      ) : null}
+
       <TableList<IEarnAvailableAsset>
         key={`assets-tab-${selectedTabIndex}`}
         data={assets ?? []}
         columns={columns}
         keyExtractor={keyExtractor}
         withHeader={platformEnv.isNative ? false : media.gtMd}
-        defaultSortKey="yield"
-        defaultSortDirection="desc"
+        sortKey={sortKey}
+        sortDirection={sortDirection}
+        onSortChange={handleSortChange}
         onPressRow={onPressRow}
         mobileRenderItem={mobileRenderItem}
         enableDrillIn

--- a/packages/kit/src/views/Earn/components/EarnMobileSortControl.tsx
+++ b/packages/kit/src/views/Earn/components/EarnMobileSortControl.tsx
@@ -1,0 +1,66 @@
+import { useCallback } from 'react';
+
+import { IconButton, SegmentControl, XStack } from '@onekeyhq/components';
+
+export type IEarnSortDirection = 'asc' | 'desc';
+
+export type IEarnSortOption = {
+  label: string;
+  value: string;
+};
+
+type IEarnMobileSortControlProps = {
+  sortKey: string;
+  sortDirection: IEarnSortDirection;
+  options: IEarnSortOption[];
+  onSortChange: (key: string, direction: IEarnSortDirection) => void;
+};
+
+export function EarnMobileSortControl({
+  sortKey,
+  sortDirection,
+  options,
+  onSortChange,
+}: IEarnMobileSortControlProps) {
+  const handleSortKeyChange = useCallback(
+    (value: string | number) => {
+      const nextSortKey = String(value);
+      onSortChange(
+        nextSortKey,
+        nextSortKey === sortKey ? sortDirection : 'desc',
+      );
+    },
+    [onSortChange, sortDirection, sortKey],
+  );
+
+  const handleSortDirectionChange = useCallback(() => {
+    onSortChange(sortKey, sortDirection === 'desc' ? 'asc' : 'desc');
+  }, [onSortChange, sortDirection, sortKey]);
+
+  if (!options.length) {
+    return null;
+  }
+
+  return (
+    <XStack px="$pagePadding" ai="center" gap="$2">
+      <SegmentControl
+        flex={1}
+        fullWidth
+        value={sortKey}
+        options={options}
+        onChange={handleSortKeyChange}
+        segmentControlItemStyleProps={{ px: '$2' }}
+      />
+      <IconButton
+        variant="tertiary"
+        icon={
+          sortDirection === 'desc'
+            ? 'ChevronDownSmallOutline'
+            : 'ChevronTopSmallOutline'
+        }
+        iconSize="$5"
+        onPress={handleSortDirectionChange}
+      />
+    </XStack>
+  );
+}

--- a/packages/kit/src/views/Earn/earnUtils.ts
+++ b/packages/kit/src/views/Earn/earnUtils.ts
@@ -99,6 +99,34 @@ export const EarnNetworkUtils = {
   },
 };
 
+const liquidityUnitMultiplierMap: Record<string, number> = {
+  k: 10 ** 3,
+  m: 10 ** 6,
+  b: 10 ** 9,
+  t: 10 ** 12,
+};
+
+export function parseFormattedLiquidityValue(value?: string): number {
+  if (!value) {
+    return 0;
+  }
+
+  const match = value.replace(/,/g, '').match(/(-?\d+(?:\.\d+)?)([kmbt])?/i);
+  if (!match) {
+    return 0;
+  }
+
+  const parsedValue = Number(match[1]);
+  if (!Number.isFinite(parsedValue)) {
+    return 0;
+  }
+
+  const unit = match[2]?.toLowerCase();
+  const multiplier = unit ? (liquidityUnitMultiplierMap[unit] ?? 1) : 1;
+
+  return parsedValue * multiplier;
+}
+
 export async function safePushToEarnRoute(
   navigation: IAppNavigation,
   route: ETabEarnRoutes,

--- a/packages/kit/src/views/Earn/pages/EarnProtocols/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnProtocols/index.tsx
@@ -42,9 +42,11 @@ import type { IStakeProtocolListItem } from '@onekeyhq/shared/types/staking';
 import { DiscoveryBrowserProviderMirror } from '../../../Discovery/components/DiscoveryBrowserProviderMirror';
 import { EarnText } from '../../../Staking/components/ProtocolDetails/EarnText';
 import { AprText } from '../../components/AprText';
+import { EarnMobileSortControl } from '../../components/EarnMobileSortControl';
 import { EarnPageContainer } from '../../components/EarnPageContainer';
-import { EarnNavigation } from '../../earnUtils';
+import { EarnNavigation, parseFormattedLiquidityValue } from '../../earnUtils';
 
+import type { IEarnSortDirection } from '../../components/EarnMobileSortControl';
 import type { RouteProp } from '@react-navigation/core';
 
 type IRouteProps = RouteProp<ITabEarnParamList, ETabEarnRoutes.EarnProtocols>;
@@ -123,12 +125,65 @@ function BasicEarnProtocols({ route }: { route: IRouteProps }) {
   const [protocolData, setProtocolData] = useState<IStakeProtocolListItem[]>(
     [],
   );
-  const [selectedCategory, setSelectedCategory] = useState<EProtocolCategory>(
-    (defaultCategoryParam as EProtocolCategory) || EProtocolCategory.SimpleEarn,
+  const initialCategory =
+    (defaultCategoryParam as EProtocolCategory) || EProtocolCategory.SimpleEarn;
+  const [selectedCategory, setSelectedCategory] =
+    useState<EProtocolCategory>(initialCategory);
+  const isInitialFixedRateCategory =
+    initialCategory === EProtocolCategory.FixedRate;
+  const [sortKey, setSortKey] = useState(
+    isInitialFixedRateCategory ? 'protocol' : 'yield',
+  );
+  const [sortDirection, setSortDirection] = useState<IEarnSortDirection>(
+    isInitialFixedRateCategory ? 'asc' : 'desc',
   );
   const [isLoading, setIsLoading] = useState(true);
   const accountId = activeAccount.account?.id;
   const accountNetworkId = filterNetworkId ?? activeAccount.network?.id;
+  const isFixedRateCategory = selectedCategory === EProtocolCategory.FixedRate;
+  const showMobileSortControl = isFixedRateCategory && !isDesktopLayout;
+
+  const handleSortChange = useCallback(
+    (key: string, direction: IEarnSortDirection) => {
+      setSortKey(key);
+      setSortDirection(direction);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (selectedCategory === EProtocolCategory.FixedRate) {
+      setSortKey('protocol');
+      setSortDirection('asc');
+      return;
+    }
+
+    setSortKey('yield');
+    setSortDirection('desc');
+  }, [selectedCategory]);
+
+  const mobileSortOptions = useMemo(
+    () =>
+      isFixedRateCategory
+        ? [
+            {
+              label: intl.formatMessage({
+                id: ETranslations.defi_protocol_maturity,
+              }),
+              value: 'protocol',
+            },
+            {
+              label: intl.formatMessage({ id: ETranslations.defi_apr_apy }),
+              value: 'yield',
+            },
+            {
+              label: intl.formatMessage({ id: ETranslations.global_liquidity }),
+              value: 'liquidity',
+            },
+          ]
+        : [],
+    [intl, isFixedRateCategory],
+  );
 
   const fetchProtocolData = useCallback(async () => {
     if (!activeAccount.ready) {
@@ -248,24 +303,26 @@ function BasicEarnProtocols({ route }: { route: IRouteProps }) {
   );
 
   const protocolDisplayData = useMemo(() => {
-    const isFixedRate = selectedCategory === EProtocolCategory.FixedRate;
     return protocolData.filter((item) => {
       const category = getProtocolCategory(item);
-      return isFixedRate
+      return isFixedRateCategory
         ? category === EProtocolCategory.FixedRate
         : category === EProtocolCategory.SimpleEarn;
     });
-  }, [protocolData, selectedCategory]);
+  }, [isFixedRateCategory, protocolData]);
 
   const columns: ITableColumn<IStakeProtocolListItem>[] = useMemo(() => {
-    const isFixedRateCategory =
-      selectedCategory === EProtocolCategory.FixedRate;
-
     const getMaturityDisplay = (item: IStakeProtocolListItem) => {
       const providerName = normalizeToEarnProvider(item.provider.name);
       const maturityTitle =
         item.provider.maturity || item.provider.vaultName || providerName;
-      const detailText = item.provider.description || providerName;
+      const baseDetailText = item.provider.description || providerName;
+      const detailText =
+        isFixedRateCategory && !isDesktopLayout && item.provider.liquidity
+          ? `${baseDetailText} · ${intl.formatMessage({
+              id: ETranslations.global_liquidity,
+            })}: ${item.provider.liquidity}`
+          : baseDetailText;
 
       return {
         detailText,
@@ -383,6 +440,31 @@ function BasicEarnProtocols({ route }: { route: IRouteProps }) {
           </SizableText>
         ),
       },
+      ...(isFixedRateCategory
+        ? [
+            {
+              key: 'liquidity',
+              label: intl.formatMessage({
+                id: ETranslations.global_liquidity,
+              }),
+              flex: 2,
+              hideInMobile: true,
+              align: 'flex-end' as const,
+              sortable: true,
+              comparator: (
+                a: IStakeProtocolListItem,
+                b: IStakeProtocolListItem,
+              ) =>
+                parseFormattedLiquidityValue(a.provider.liquidity) -
+                parseFormattedLiquidityValue(b.provider.liquidity),
+              render: (item: IStakeProtocolListItem) => (
+                <SizableText size="$bodyLgMedium">
+                  {item.provider.liquidity || '-'}
+                </SizableText>
+              ),
+            },
+          ]
+        : []),
       {
         key: 'yield',
         label: intl.formatMessage({ id: ETranslations.defi_apr_apy }),
@@ -416,7 +498,7 @@ function BasicEarnProtocols({ route }: { route: IRouteProps }) {
         },
       },
     ];
-  }, [intl, isDesktopLayout, selectedCategory]);
+  }, [intl, isDesktopLayout, isFixedRateCategory]);
 
   const shouldShowCategoryTabs =
     protocolCategoryCounts.simpleEarnCount > 0 &&
@@ -579,18 +661,22 @@ function BasicEarnProtocols({ route }: { route: IRouteProps }) {
     return (
       <YStack>
         {categoryTabs}
+        {showMobileSortControl ? (
+          <EarnMobileSortControl
+            sortKey={sortKey}
+            sortDirection={sortDirection}
+            options={mobileSortOptions}
+            onSortChange={handleSortChange}
+          />
+        ) : null}
         <TableList<IStakeProtocolListItem>
           key={selectedCategory}
           data={protocolDisplayData}
           columns={columns}
-          defaultSortKey={
-            selectedCategory === EProtocolCategory.FixedRate
-              ? 'protocol'
-              : 'yield'
-          }
-          defaultSortDirection={
-            selectedCategory === EProtocolCategory.FixedRate ? 'asc' : 'desc'
-          }
+          sortKey={sortKey}
+          sortDirection={sortDirection}
+          onSortChange={handleSortChange}
+          withHeader={showMobileSortControl ? false : undefined}
           onPressRow={handleProtocolPress}
           enableDrillIn={isDesktopLayout}
           isLoading={isLoading}
@@ -602,6 +688,11 @@ function BasicEarnProtocols({ route }: { route: IRouteProps }) {
     protocolData,
     protocolDisplayData,
     categoryTabs,
+    showMobileSortControl,
+    sortKey,
+    sortDirection,
+    mobileSortOptions,
+    handleSortChange,
     columns,
     selectedCategory,
     handleProtocolPress,

--- a/packages/shared/types/earn.ts
+++ b/packages/shared/types/earn.ts
@@ -163,6 +163,7 @@ export interface IEarnAvailableAsset {
   minAprInfo?: IEarnAvailableAssetAprRangeInfo;
   maxAprInfo?: IEarnAvailableAssetAprRangeInfo;
   bgColor?: string;
+  liquidity?: string;
   icon?: {
     icon: IKeyOfIcons | string;
     color?: ColorTokens;


### PR DESCRIPTION
## Summary
- show backend-provided Total liquidity on the Earn Fixed Income asset list
- add liquidity sorting alongside APY sorting, including mobile sort controls
- show per-pool liquidity on the fixed-rate pool selection page with liquidity/APY sorting

## Verification
- yarn lint:staged
- yarn tsc:staged
- sub-agent review: product/spec, UI/sorting, and TypeScript/lint passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
