### PR TITLE
fix: improve swap gas and limit price checks(OK-53915 OK-53459)

### DIFF
--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -33,6 +33,7 @@ import type {
   IFetchTokensParams,
   ISwapAlertActionData,
   ISwapAlertState,
+  ISwapLimitPriceInfo,
   ISwapNetwork,
   ISwapQuoteEvent,
   ISwapQuoteEventAutoSlippage,
@@ -115,6 +116,34 @@ import {
   getSwapQuoteProgressState,
   isSwapQuoteEventFetching,
 } from './quoteProgress';
+
+function getSelectedPairLimitPriceRate({
+  protocol,
+  limitPriceUseRate,
+  fromToken,
+  toToken,
+}: {
+  protocol: ESwapTabSwitchType;
+  limitPriceUseRate: ISwapLimitPriceInfo;
+  fromToken?: ISwapToken;
+  toToken?: ISwapToken;
+}) {
+  if (protocol !== ESwapTabSwitchType.LIMIT || !limitPriceUseRate.rate) {
+    return undefined;
+  }
+
+  const isSelectedPair =
+    equalTokenNoCaseSensitive({
+      token1: limitPriceUseRate.fromToken,
+      token2: fromToken,
+    }) &&
+    equalTokenNoCaseSensitive({
+      token1: limitPriceUseRate.toToken,
+      token2: toToken,
+    });
+
+  return isSelectedPair ? limitPriceUseRate.rate : undefined;
+}
 
 class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
   private quoteInterval: ReturnType<typeof setTimeout> | undefined;
@@ -524,6 +553,12 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         const limitPartiallyFillable = limitPartiallyFillableObj.value;
         const expirationTime = get(swapLimitExpirationTimeAtom());
         const limitUserMarketPrice = get(swapLimitPriceUseRateAtom());
+        const userMarketPriceRate = getSelectedPairLimitPriceRate({
+          protocol,
+          limitPriceUseRate: limitUserMarketPrice,
+          fromToken,
+          toToken,
+        });
         const res = await backgroundApiProxy.serviceSwap.fetchQuotes({
           fromToken,
           toToken,
@@ -538,7 +573,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
           incognito: incognitoEnabled,
           accountId,
           protocol,
-          userMarketPriceRate: limitUserMarketPrice.rate,
+          userMarketPriceRate,
           ...(protocol === ESwapTabSwitchType.LIMIT
             ? {
                 expirationTime: Number(expirationTime.value),
@@ -862,6 +897,12 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       set(swapQuoteFetchingAtom(), true);
       set(swapQuoteEventCompletedAtom(), false);
       const limitUserMarketPrice = get(swapLimitPriceUseRateAtom());
+      const userMarketPriceRate = getSelectedPairLimitPriceRate({
+        protocol,
+        limitPriceUseRate: limitUserMarketPrice,
+        fromToken,
+        toToken,
+      });
       await backgroundApiProxy.serviceSwap.fetchQuotesEvents({
         fromToken,
         toToken,
@@ -876,7 +917,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         protocol,
         receivingAddress,
         incognito: incognitoEnabled,
-        userMarketPriceRate: limitUserMarketPrice.rate,
+        userMarketPriceRate,
         ...(protocol === ESwapTabSwitchType.LIMIT
           ? {
               expirationTime: Number(expirationTime.value),

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -123,6 +123,8 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
     | ReturnType<typeof setTimeout>
     | undefined;
 
+  private limitOrderMarketPriceRequestId = 0;
+
   /**
    * Execute promises in batches with concurrency control to prevent overwhelming the system
    * This fixes iOS app hangs when fetching token lists for multiple networks simultaneously
@@ -1146,6 +1148,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
   });
 
   cleanLimitOrderMarketPriceInterval = () => {
+    this.limitOrderMarketPriceRequestId += 1;
     if (this.limitOrderMarketPriceInterval) {
       clearInterval(this.limitOrderMarketPriceInterval);
       this.limitOrderMarketPriceInterval = undefined;
@@ -2258,7 +2261,13 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
   );
 
   limitMarketPriceRun = contextAtomMethod(
-    async (get, set, fromToken?: ISwapToken, toToken?: ISwapToken) => {
+    async (
+      get,
+      set,
+      fromToken?: ISwapToken,
+      toToken?: ISwapToken,
+      requestId?: number,
+    ) => {
       try {
         if (fromToken && toToken) {
           const { fromTokenPrice, toTokenPrice } =
@@ -2266,6 +2275,9 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
               fromToken,
               toToken,
             });
+          if (requestId !== this.limitOrderMarketPriceRequestId) {
+            return;
+          }
           const fromTokenPriceInfo = {
             tokenInfo: fromToken,
             price: fromTokenPrice || (fromToken.price ?? ''),
@@ -2283,6 +2295,9 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       } catch (error) {
         console.error(error);
       }
+      if (requestId !== this.limitOrderMarketPriceRequestId) {
+        return;
+      }
       this.limitOrderMarketPriceInterval = setTimeout(() => {
         void this.limitOrderMarketPriceIntervalAction.call(
           set,
@@ -2295,6 +2310,8 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
 
   limitOrderMarketPriceIntervalAction = contextAtomMethod(
     async (get, set, fromToken?: ISwapToken, toToken?: ISwapToken) => {
+      this.limitOrderMarketPriceRequestId += 1;
+      const requestId = this.limitOrderMarketPriceRequestId;
       if (this.limitOrderMarketPriceInterval) {
         clearInterval(this.limitOrderMarketPriceInterval);
       }
@@ -2307,7 +2324,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         set(limitOrderMarketPriceAtom(), {});
         return;
       }
-      await this.limitMarketPriceRun.call(set, fromToken, toToken);
+      await this.limitMarketPriceRun.call(set, fromToken, toToken, requestId);
     },
   );
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useMarketSwapReviewActions.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useMarketSwapReviewActions.test.tsx
@@ -187,6 +187,9 @@ describe('useMarketSwapReviewActions', () => {
                 status: ESwapStepStatus.READY,
               },
             ],
+            preSwapData: {
+              stepBeforeActionsError: true,
+            },
           }),
         ),
       },
@@ -214,6 +217,9 @@ describe('useMarketSwapReviewActions', () => {
     expect(result.current.swapSteps.preSwapData.stepBeforeActionsLoading).toBe(
       false,
     );
+    expect(
+      result.current.swapSteps.preSwapData.stepBeforeActionsError,
+    ).toBeUndefined();
   });
 
   it('starts a send step through the market speed swap adapter', async () => {
@@ -508,6 +514,9 @@ describe('useMarketSwapReviewActions', () => {
 
     expect(result.current.swapSteps.preSwapData.stepBeforeActionsLoading).toBe(
       false,
+    );
+    expect(result.current.swapSteps.preSwapData.stepBeforeActionsError).toBe(
+      true,
     );
     expect(result.current.swapSteps.preSwapData.netWorkFee).toBeUndefined();
   });

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -80,6 +80,7 @@ import type {
   IFetchBuildTxResponse,
   IFetchLimitOrderRes,
   IFetchQuoteResult,
+  IQuoteResultFeeOtherFeeInfo,
   IOneInchOrderStruct,
   ISwapGasInfo,
   ISwapPreSwapData,
@@ -514,17 +515,20 @@ export function useSwapBuildTx() {
       networkId,
       token,
       amount,
+      otherFeeInfos,
     }: {
       gasInfos?: { gasInfo?: ISwapGasInfo }[];
       networkId?: string;
       token?: ISwapToken;
       amount?: string;
+      otherFeeInfos?: IQuoteResultFeeOtherFeeInfo[];
     }) => {
       const nativeBalanceRequirement = getSwapRequiredNativeBalanceAmount({
         gasInfos,
         networkId,
         fromToken: token,
         fromAmount: amount,
+        otherFeeInfos,
       });
 
       if (!nativeBalanceRequirement) {
@@ -751,6 +755,8 @@ export function useSwapBuildTx() {
         networkId,
         token: unsignedTxItem.swapInfo?.sender.token,
         amount: unsignedTxItem.swapInfo?.sender.amount,
+        otherFeeInfos:
+          unsignedTxItem.swapInfo?.swapBuildResData.result?.fee?.otherFeeInfos,
       });
       if (!checkLatestNativeBalanceRes) {
         throw new OneKeyError('checkLatestNativeTokenBalance failed');
@@ -2968,6 +2974,7 @@ export function useSwapBuildTx() {
             networkId,
             token: swapInfo?.sender.token,
             amount: swapInfo?.sender.amount,
+            otherFeeInfos: swapInfo?.swapBuildResData.result?.fee?.otherFeeInfos,
           },
         );
         if (!checkLatestNativeBalanceRes) {

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -120,7 +120,10 @@ import {
   useSwapToTokenAmountAtom,
   useSwapTypeSwitchAtom,
 } from '../../../states/jotai/contexts/swap';
-import { checkSwapLatestBalanceSufficient } from '../utils/swapBalanceUtils';
+import {
+  checkSwapLatestBalanceSufficient,
+  getSwapRequiredNativeBalanceAmount,
+} from '../utils/swapBalanceUtils';
 
 import { useSwapAddressInfo } from './useSwapAccount';
 import { useSwapBuildTxInfo, useSwapProAccount } from './useSwapPro';
@@ -505,6 +508,60 @@ export function useSwapBuildTx() {
     [fromAccountId, fromUserAddress, intl],
   );
 
+  const checkLatestNativeTokenBalance = useCallback(
+    async ({
+      gasInfos,
+      networkId,
+      token,
+      amount,
+    }: {
+      gasInfos?: { gasInfo?: ISwapGasInfo }[];
+      networkId?: string;
+      token?: ISwapToken;
+      amount?: string;
+    }) => {
+      const nativeBalanceRequirement = getSwapRequiredNativeBalanceAmount({
+        gasInfos,
+        networkId,
+        fromToken: token,
+        fromAmount: amount,
+      });
+
+      if (!nativeBalanceRequirement) {
+        return true;
+      }
+
+      const checkResult = await checkSwapLatestBalanceSufficient({
+        token: nativeBalanceRequirement.token,
+        amount: nativeBalanceRequirement.amount,
+        accountAddress: fromUserAddress,
+        accountId: fromAccountId,
+      });
+      if (!checkResult.isSufficient) {
+        Toast.error({
+          title: intl.formatMessage(
+            {
+              id: ETranslations.swap_page_toast_insufficient_balance_title,
+            },
+            { token: checkResult.tokenSymbol },
+          ),
+          message: intl.formatMessage(
+            {
+              id: ETranslations.swap_page_toast_insufficient_balance_content,
+            },
+            {
+              token: checkResult.tokenSymbol,
+              number: numberFormat(checkResult.requiredAmount, formatter),
+            },
+          ),
+        });
+        return false;
+      }
+      return true;
+    },
+    [fromAccountId, fromUserAddress, intl],
+  );
+
   const cancelLimitOrder = useCallback(
     async (item: IFetchLimitOrderRes, source: ESwapCancelLimitOrderSource) => {
       if (item.cancelInfo) {
@@ -689,6 +746,15 @@ export function useSwapBuildTx() {
         feeInfo: gasInfo as IFeeInfoUnit,
         nativeTokenPrice: gasInfo.common?.nativeTokenPrice ?? 0,
       });
+      const checkLatestNativeBalanceRes = await checkLatestNativeTokenBalance({
+        gasInfos: [{ gasInfo }],
+        networkId,
+        token: unsignedTxItem.swapInfo?.sender.token,
+        amount: unsignedTxItem.swapInfo?.sender.amount,
+      });
+      if (!checkLatestNativeBalanceRes) {
+        throw new OneKeyError('checkLatestNativeTokenBalance failed');
+      }
       await backgroundApiProxy.serviceTransaction.verifyTransaction({
         networkId,
         accountId,
@@ -732,7 +798,7 @@ export function useSwapBuildTx() {
       });
       return res;
     },
-    [intl, setSwapSteps],
+    [checkLatestNativeTokenBalance, intl, setSwapSteps],
   );
 
   const swapEstimateFeeEvent = useCallback(
@@ -1775,12 +1841,12 @@ export function useSwapBuildTx() {
         if (!checkLatestBalanceRes) {
           throw new OneKeyError('checkLatestFromTokenBalance failed');
         }
-        if (swapStepsRef.current.preSwapData.swapBuildResultData) {
-          return swapStepsRef.current.preSwapData.swapBuildResultData;
-        }
         const checkRes = await checkOtherFee(data);
         if (!checkRes) {
           throw new OneKeyError('checkOtherFee failed');
+        }
+        if (swapStepsRef.current.preSwapData.swapBuildResultData) {
+          return swapStepsRef.current.preSwapData.swapBuildResultData;
         }
         let buildSwapRes: IFetchBuildTxResponse | undefined;
         try {
@@ -2896,6 +2962,17 @@ export function useSwapBuildTx() {
             throw e;
           }
         }
+        const checkLatestNativeBalanceRes = await checkLatestNativeTokenBalance(
+          {
+            gasInfos: gasFeeInfos,
+            networkId,
+            token: swapInfo?.sender.token,
+            amount: swapInfo?.sender.amount,
+          },
+        );
+        if (!checkLatestNativeBalanceRes) {
+          throw new OneKeyError('checkLatestNativeTokenBalance failed');
+        }
         const gasFeeFiatValues = await Promise.all(
           gasFeeInfos.map(async (item) => {
             const { gasInfo } = item;
@@ -2932,6 +3009,10 @@ export function useSwapBuildTx() {
             estimateNetworkFeeLoading: false,
           },
         }));
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        if (_e?.message === 'checkLatestNativeTokenBalance failed') {
+          throw _e;
+        }
       }
     },
     [
@@ -2941,6 +3022,7 @@ export function useSwapBuildTx() {
       swapEstimateFeeEvent,
       fromAccountId,
       fromUserAddress,
+      checkLatestNativeTokenBalance,
     ],
   );
 

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -3090,6 +3090,7 @@ export function useSwapBuildTx() {
               ...prev.preSwapData,
               stepBeforeActionsLoading: false,
               stepBeforeActionsError: true,
+              netWorkFee: undefined,
             },
           }));
         }

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -80,8 +80,8 @@ import type {
   IFetchBuildTxResponse,
   IFetchLimitOrderRes,
   IFetchQuoteResult,
-  IQuoteResultFeeOtherFeeInfo,
   IOneInchOrderStruct,
+  IQuoteResultFeeOtherFeeInfo,
   ISwapGasInfo,
   ISwapPreSwapData,
   ISwapStep,
@@ -2974,7 +2974,8 @@ export function useSwapBuildTx() {
             networkId,
             token: swapInfo?.sender.token,
             amount: swapInfo?.sender.amount,
-            otherFeeInfos: swapInfo?.swapBuildResData.result?.fee?.otherFeeInfos,
+            otherFeeInfos:
+              swapInfo?.swapBuildResData.result?.fee?.otherFeeInfos,
           },
         );
         if (!checkLatestNativeBalanceRes) {
@@ -3016,10 +3017,7 @@ export function useSwapBuildTx() {
             estimateNetworkFeeLoading: false,
           },
         }));
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        if (_e?.message === 'checkLatestNativeTokenBalance failed') {
-          throw _e;
-        }
+        throw _e;
       }
     },
     [
@@ -3055,6 +3053,7 @@ export function useSwapBuildTx() {
           preSwapData: {
             ...prev.preSwapData,
             stepBeforeActionsLoading: true,
+            stepBeforeActionsError: undefined,
           },
         }));
         try {
@@ -3081,14 +3080,16 @@ export function useSwapBuildTx() {
             preSwapData: {
               ...prev.preSwapData,
               stepBeforeActionsLoading: false,
+              stepBeforeActionsError: undefined,
             },
           }));
-        } catch (_e) {
+        } catch {
           setSwapSteps((prev) => ({
             ...prev,
             preSwapData: {
               ...prev.preSwapData,
               stepBeforeActionsLoading: false,
+              stepBeforeActionsError: true,
             },
           }));
         }

--- a/packages/kit/src/views/Swap/hooks/useSwapLimitRate.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapLimitRate.ts
@@ -98,10 +98,10 @@ export const useSwapLimitRate = () => {
     () =>
       Boolean(
         limitPriceUseRate.fromToken ||
-          limitPriceUseRate.toToken ||
-          limitPriceUseRate.rate ||
-          limitPriceUseRate.reverseRate ||
-          limitPriceUseRate.inputRate,
+        limitPriceUseRate.toToken ||
+        limitPriceUseRate.rate ||
+        limitPriceUseRate.reverseRate ||
+        limitPriceUseRate.inputRate,
       ),
     [
       limitPriceUseRate.fromToken,

--- a/packages/kit/src/views/Swap/hooks/useSwapLimitRate.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapLimitRate.ts
@@ -94,6 +94,23 @@ export const useSwapLimitRate = () => {
     limitPriceUseRate.toToken,
     toSelectToken,
   ]);
+  const hasLimitPriceUseRate = useMemo(
+    () =>
+      Boolean(
+        limitPriceUseRate.fromToken ||
+          limitPriceUseRate.toToken ||
+          limitPriceUseRate.rate ||
+          limitPriceUseRate.reverseRate ||
+          limitPriceUseRate.inputRate,
+      ),
+    [
+      limitPriceUseRate.fromToken,
+      limitPriceUseRate.inputRate,
+      limitPriceUseRate.rate,
+      limitPriceUseRate.reverseRate,
+      limitPriceUseRate.toToken,
+    ],
+  );
   const canUseLimitPriceMarketPrice = useMemo(() => {
     const rateBN = new BigNumber(limitPriceMarketPrice.rate ?? 0);
     if (
@@ -333,15 +350,15 @@ export const useSwapLimitRate = () => {
       toToken: toSelectToken,
     });
     const shouldClearStaleLimitPrice =
-      !limitPriceMarketPrice.rate && !isLimitPriceUseRateForSelectedPair;
+      hasLimitPriceUseRate && !isLimitPriceUseRateForSelectedPair;
     if (isWrappedTokenPair || shouldClearStaleLimitPrice) {
       setLimitPriceUseRate({});
       setLimitPriceSetReverse(false);
     }
   }, [
     fromSelectToken,
+    hasLimitPriceUseRate,
     isLimitPriceUseRateForSelectedPair,
-    limitPriceMarketPrice.rate,
     setLimitPriceSetReverse,
     setLimitPriceUseRate,
     toSelectToken,

--- a/packages/kit/src/views/Swap/hooks/useSwapLimitRate.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapLimitRate.ts
@@ -74,6 +74,54 @@ export const useSwapLimitRate = () => {
     swapProTradeType,
     swapTypeSwitchValue,
   ]);
+  const isLimitPriceUseRateForSelectedPair = useMemo(() => {
+    if (!limitPriceUseRate.fromToken || !limitPriceUseRate.toToken) {
+      return false;
+    }
+    return (
+      equalTokenNoCaseSensitive({
+        token1: limitPriceUseRate.fromToken,
+        token2: fromSelectToken,
+      }) &&
+      equalTokenNoCaseSensitive({
+        token1: limitPriceUseRate.toToken,
+        token2: toSelectToken,
+      })
+    );
+  }, [
+    fromSelectToken,
+    limitPriceUseRate.fromToken,
+    limitPriceUseRate.toToken,
+    toSelectToken,
+  ]);
+  const canUseLimitPriceMarketPrice = useMemo(() => {
+    const rateBN = new BigNumber(limitPriceMarketPrice.rate ?? 0);
+    if (
+      rateBN.isNaN() ||
+      !rateBN.isFinite() ||
+      rateBN.lte(0) ||
+      !limitPriceMarketPrice.fromToken ||
+      !limitPriceMarketPrice.toToken
+    ) {
+      return false;
+    }
+    return (
+      equalTokenNoCaseSensitive({
+        token1: limitPriceMarketPrice.fromToken,
+        token2: fromSelectToken,
+      }) &&
+      equalTokenNoCaseSensitive({
+        token1: limitPriceMarketPrice.toToken,
+        token2: toSelectToken,
+      })
+    );
+  }, [
+    fromSelectToken,
+    limitPriceMarketPrice.fromToken,
+    limitPriceMarketPrice.rate,
+    limitPriceMarketPrice.toToken,
+    toSelectToken,
+  ]);
   const fromSelectTokenRef = useRef<ISwapToken | undefined>(fromSelectToken);
   const toSelectTokenRef = useRef<ISwapToken | undefined>(toSelectToken);
   if (fromSelectTokenRef.current !== fromSelectToken) {
@@ -196,6 +244,9 @@ export const useSwapLimitRate = () => {
 
   const onSetMarketPrice = useCallback(
     (percentage: number) => {
+      if (!canUseLimitPriceMarketPrice) {
+        return;
+      }
       const percentageBN = new BigNumber(1 + percentage / 100);
       const rateBN = new BigNumber(
         limitPriceMarketPrice.rate ?? '0',
@@ -220,7 +271,12 @@ export const useSwapLimitRate = () => {
           : formatRate.toFixed(),
       }));
     },
-    [setLimitPriceUseRate, limitPriceMarketPrice, limitPriceSetReverse],
+    [
+      canUseLimitPriceMarketPrice,
+      setLimitPriceUseRate,
+      limitPriceMarketPrice,
+      limitPriceSetReverse,
+    ],
   );
 
   const onChangeReverse = useCallback(
@@ -272,18 +328,19 @@ export const useSwapLimitRate = () => {
   ]);
 
   useEffect(() => {
-    if (
-      !limitPriceMarketPrice.rate ||
-      checkWrappedTokenPair({
-        fromToken: fromSelectToken,
-        toToken: toSelectToken,
-      })
-    ) {
+    const isWrappedTokenPair = checkWrappedTokenPair({
+      fromToken: fromSelectToken,
+      toToken: toSelectToken,
+    });
+    const shouldClearStaleLimitPrice =
+      !limitPriceMarketPrice.rate && !isLimitPriceUseRateForSelectedPair;
+    if (isWrappedTokenPair || shouldClearStaleLimitPrice) {
       setLimitPriceUseRate({});
       setLimitPriceSetReverse(false);
     }
   }, [
     fromSelectToken,
+    isLimitPriceUseRateForSelectedPair,
     limitPriceMarketPrice.rate,
     setLimitPriceSetReverse,
     setLimitPriceUseRate,
@@ -312,6 +369,7 @@ export const useSwapLimitRate = () => {
     onSetMarketPrice,
     onChangeReverse,
     limitPriceSetReverse,
+    canUseLimitPriceMarketPrice,
     limitPriceUseRate,
     limitPriceMarketPrice,
     fromTokenInfo: fromSelectToken,

--- a/packages/kit/src/views/Swap/hooks/useSwapReviewActions.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapReviewActions.ts
@@ -104,6 +104,9 @@ function useReviewStepStateActions() {
         preSwapData: {
           ...prev.preSwapData,
           stepBeforeActionsLoading: loading,
+          stepBeforeActionsError: loading
+            ? undefined
+            : prev.preSwapData.stepBeforeActionsError,
         },
       }));
     },
@@ -199,6 +202,7 @@ export function useSwapReviewActions({
             preSwapData: {
               ...reviewState.preSwapData,
               stepBeforeActionsLoading: false,
+              stepBeforeActionsError: undefined,
             },
           },
           {
@@ -211,6 +215,7 @@ export function useSwapReviewActions({
           preSwapData: {
             ...prev.preSwapData,
             stepBeforeActionsLoading: false,
+            stepBeforeActionsError: true,
             netWorkFee: undefined,
           },
         }));

--- a/packages/kit/src/views/Swap/pages/components/LimitInfoContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/LimitInfoContainer.tsx
@@ -40,6 +40,7 @@ const LimitInfoContainer = () => {
     limitPriceSetReverse,
     onChangeReverse,
     limitPriceEqualMarketPrice,
+    canUseLimitPriceMarketPrice,
   } = useSwapLimitRate();
   const intl = useIntl();
   const checkEqualMarketPrice = useCallback(
@@ -147,13 +148,26 @@ const LimitInfoContainer = () => {
                   ? '$borderActive'
                   : '$borderSubdued'
               }
-              onPress={() => onSetMarketPrice(percentage)}
-              hoverStyle={{
-                bg: '$bgStrongHover',
-              }}
-              pressStyle={{
-                bg: '$bgStrongActive',
-              }}
+              opacity={canUseLimitPriceMarketPrice ? 1 : 0.5}
+              onPress={
+                canUseLimitPriceMarketPrice
+                  ? () => onSetMarketPrice(percentage)
+                  : undefined
+              }
+              hoverStyle={
+                canUseLimitPriceMarketPrice
+                  ? {
+                      bg: '$bgStrongHover',
+                    }
+                  : undefined
+              }
+              pressStyle={
+                canUseLimitPriceMarketPrice
+                  ? {
+                      bg: '$bgStrongActive',
+                    }
+                  : undefined
+              }
             >
               {percentage === 0
                 ? intl.formatMessage({ id: ETranslations.Limit_market })

--- a/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
+++ b/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { isEqual } from 'lodash';
 import { useIntl } from 'react-intl';
@@ -57,12 +64,12 @@ interface IPreSwapDialogContentProps {
     data?: IFetchQuoteResult,
     currentFromToken?: ISwapToken,
     currentToToken?: ISwapToken,
-  ) => void;
+  ) => void | Promise<void>;
   preSwapStepsStart: (swapStepsValues?: {
     steps: ISwapStep[];
     preSwapData: ISwapPreSwapData;
     quoteResult?: IFetchQuoteResult;
-  }) => void;
+  }) => void | Promise<void>;
 }
 
 const PreSwapDialogContent = ({
@@ -227,7 +234,7 @@ const PreSwapDialogContent = ({
     swapSteps,
   ]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (
       swapStepsRef.current.preSwapData.supportNetworkFeeLevel &&
       swapStepsRef.current.preSwapData.supportPreBuild

--- a/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
+++ b/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
@@ -132,19 +132,40 @@ const PreSwapDialogContent = ({
       toAmount,
     ],
   );
+  const isPrimaryButtonDisabled = useMemo(
+    () =>
+      Boolean(
+        preSwapData?.estimateNetworkFeeLoading ||
+        preSwapData?.swapBuildLoading ||
+        preSwapData?.stepBeforeActionsLoading ||
+        preSwapData?.stepBeforeActionsError,
+      ),
+    [
+      preSwapData?.estimateNetworkFeeLoading,
+      preSwapData?.stepBeforeActionsError,
+      preSwapData?.stepBeforeActionsLoading,
+      preSwapData?.swapBuildLoading,
+    ],
+  );
 
   const handleConfirmPress = useCallback(() => {
+    if (isPrimaryButtonDisabled) {
+      return;
+    }
     if (validatedQuoteShowTip) {
       setShowPreSwapTipInfo(validatedQuoteShowTip);
     } else {
       onConfirm();
     }
-  }, [onConfirm, validatedQuoteShowTip]);
+  }, [isPrimaryButtonDisabled, onConfirm, validatedQuoteShowTip]);
 
   const tipOnConfirm = useCallback(() => {
+    if (isPrimaryButtonDisabled) {
+      return;
+    }
     onConfirm();
     setShowPreSwapTipInfo(undefined);
-  }, [onConfirm]);
+  }, [isPrimaryButtonDisabled, onConfirm]);
   const tipOnCancel = useCallback(() => {
     setShowPreSwapTipInfo(undefined);
   }, []);
@@ -456,11 +477,7 @@ const PreSwapDialogContent = ({
                     variant="primary"
                     onPress={handleConfirmPress}
                     size="medium"
-                    disabled={
-                      swapSteps.preSwapData.estimateNetworkFeeLoading ||
-                      swapSteps.preSwapData.swapBuildLoading ||
-                      swapSteps.preSwapData.stepBeforeActionsLoading
-                    }
+                    disabled={isPrimaryButtonDisabled}
                   >
                     {actionBtnTest}
                   </Button>

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
@@ -1,6 +1,9 @@
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 
-import { checkSwapLatestBalanceSufficient } from './swapBalanceUtils';
+import {
+  checkSwapLatestBalanceSufficient,
+  getSwapRequiredNativeBalanceAmount,
+} from './swapBalanceUtils';
 
 type IFetchSwapTokenDetailsParams = {
   networkId: string;
@@ -28,7 +31,29 @@ const ethToken = {
   networkId: 'evm--1',
   contractAddress: '',
   symbol: 'ETH',
+  decimals: 18,
+  isNative: true,
 } as ISwapToken;
+
+const usdcToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  symbol: 'USDC',
+  decimals: 6,
+} as ISwapToken;
+
+const evmGasInfo = {
+  common: {
+    feeDecimals: 9,
+    feeSymbol: 'Gwei',
+    nativeDecimals: 18,
+    nativeSymbol: 'ETH',
+  },
+  gas: {
+    gasLimit: '21000',
+    gasPrice: '1',
+  },
+};
 
 describe('checkSwapLatestBalanceSufficient', () => {
   beforeEach(() => {
@@ -64,5 +89,41 @@ describe('checkSwapLatestBalanceSufficient', () => {
         accountAddress: '0xabc',
       }),
     ).resolves.toEqual({ isSufficient: true });
+  });
+});
+
+describe('getSwapRequiredNativeBalanceAmount', () => {
+  it('returns the required native gas amount for non-native swaps', () => {
+    expect(
+      getSwapRequiredNativeBalanceAmount({
+        gasInfos: [{ gasInfo: evmGasInfo }],
+        networkId: 'evm--1',
+        fromToken: usdcToken,
+        fromAmount: '12',
+      }),
+    ).toEqual({
+      token: {
+        networkId: 'evm--1',
+        contractAddress: '',
+        isNative: true,
+        symbol: 'ETH',
+        decimals: 18,
+      },
+      amount: '0.000021',
+    });
+  });
+
+  it('adds the sending amount when the from token is native', () => {
+    expect(
+      getSwapRequiredNativeBalanceAmount({
+        gasInfos: [{ gasInfo: evmGasInfo }],
+        networkId: 'evm--1',
+        fromToken: ethToken,
+        fromAmount: '0.1',
+      }),
+    ).toEqual({
+      token: ethToken,
+      amount: '0.100021',
+    });
   });
 });

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
@@ -126,4 +126,41 @@ describe('getSwapRequiredNativeBalanceAmount', () => {
       amount: '0.100021',
     });
   });
+
+  it('adds native other fees to the same native balance requirement', () => {
+    expect(
+      getSwapRequiredNativeBalanceAmount({
+        gasInfos: [{ gasInfo: evmGasInfo }],
+        networkId: 'evm--1',
+        fromToken: ethToken,
+        fromAmount: '0.1',
+        otherFeeInfos: [
+          {
+            token: {
+              networkId: 'evm--1',
+              contractAddress: '',
+              symbol: 'ETH',
+              price: '3000',
+              decimals: 18,
+              isNative: true,
+            },
+            amount: '0.02',
+          },
+          {
+            token: {
+              networkId: 'evm--1',
+              contractAddress: usdcToken.contractAddress,
+              symbol: 'USDC',
+              price: '1',
+              decimals: 6,
+            },
+            amount: '5',
+          },
+        ],
+      }),
+    ).toEqual({
+      token: ethToken,
+      amount: '0.120021',
+    });
+  });
 });

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
@@ -3,6 +3,7 @@ import BigNumber from 'bignumber.js';
 import { calculateFeeForSend } from '@onekeyhq/shared/src/utils/feeUtils';
 import type { IFeeInfoUnit } from '@onekeyhq/shared/types/fee';
 import type {
+  IQuoteResultFeeOtherFeeInfo,
   ISwapGasInfo,
   ISwapToken,
 } from '@onekeyhq/shared/types/swap/types';
@@ -36,6 +37,7 @@ type ISwapNativeBalanceRequirementParams = {
   networkId?: string;
   fromToken?: ISwapToken;
   fromAmount?: string;
+  otherFeeInfos?: IQuoteResultFeeOtherFeeInfo[];
 };
 
 export type ISwapNativeBalanceRequirement = {
@@ -74,6 +76,7 @@ export function getSwapRequiredNativeBalanceAmount({
   networkId,
   fromToken,
   fromAmount,
+  otherFeeInfos,
 }: ISwapNativeBalanceRequirementParams):
   | ISwapNativeBalanceRequirement
   | undefined {
@@ -119,10 +122,25 @@ export function getSwapRequiredNativeBalanceAmount({
     !fromAmountBN.isNaN() &&
     fromAmountBN.isFinite() &&
     fromAmountBN.gt(0);
+  const otherNativeFeeAmount = (otherFeeInfos ?? []).reduce((acc, item) => {
+    if (
+      !item.token?.isNative ||
+      item.token.networkId !== nativeToken?.networkId
+    ) {
+      return acc;
+    }
+
+    const amountBN = new BigNumber(item.amount ?? 0);
+    if (amountBN.isNaN() || !amountBN.isFinite() || amountBN.lte(0)) {
+      return acc;
+    }
+
+    return acc.plus(amountBN);
+  }, new BigNumber(0));
 
   const requiredAmount = shouldAddFromAmount
-    ? networkFeeAmount.plus(fromAmountBN)
-    : networkFeeAmount;
+    ? networkFeeAmount.plus(fromAmountBN).plus(otherNativeFeeAmount)
+    : networkFeeAmount.plus(otherNativeFeeAmount);
 
   if (requiredAmount.lte(0)) {
     return undefined;

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
@@ -1,6 +1,11 @@
 import BigNumber from 'bignumber.js';
 
-import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
+import { calculateFeeForSend } from '@onekeyhq/shared/src/utils/feeUtils';
+import type { IFeeInfoUnit } from '@onekeyhq/shared/types/fee';
+import type {
+  ISwapGasInfo,
+  ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 
@@ -21,6 +26,113 @@ export type ISwapLatestBalanceCheckResult =
       requiredAmount: string;
       tokenSymbol: string;
     };
+
+type ISwapGasInfoEntry = {
+  gasInfo?: ISwapGasInfo;
+};
+
+type ISwapNativeBalanceRequirementParams = {
+  gasInfos?: ISwapGasInfoEntry[];
+  networkId?: string;
+  fromToken?: ISwapToken;
+  fromAmount?: string;
+};
+
+export type ISwapNativeBalanceRequirement = {
+  token: ISwapToken;
+  amount: string;
+};
+
+function buildNativeTokenFromGasInfo({
+  gasInfo,
+  networkId,
+  fromToken,
+}: {
+  gasInfo: ISwapGasInfo;
+  networkId?: string;
+  fromToken?: ISwapToken;
+}) {
+  if (!gasInfo.common || !networkId) {
+    return undefined;
+  }
+
+  if (fromToken?.isNative && fromToken.networkId === networkId) {
+    return fromToken;
+  }
+
+  return {
+    networkId,
+    contractAddress: '',
+    isNative: true,
+    symbol: gasInfo.common.nativeSymbol,
+    decimals: gasInfo.common.nativeDecimals,
+  } as ISwapToken;
+}
+
+export function getSwapRequiredNativeBalanceAmount({
+  gasInfos,
+  networkId,
+  fromToken,
+  fromAmount,
+}: ISwapNativeBalanceRequirementParams):
+  | ISwapNativeBalanceRequirement
+  | undefined {
+  if (!gasInfos?.length || !networkId) {
+    return undefined;
+  }
+
+  let nativeToken: ISwapToken | undefined;
+  const networkFeeAmount = gasInfos.reduce((acc, item) => {
+    if (!item.gasInfo?.common) {
+      return acc;
+    }
+
+    nativeToken =
+      nativeToken ??
+      buildNativeTokenFromGasInfo({
+        gasInfo: item.gasInfo,
+        networkId,
+        fromToken,
+      });
+
+    const { totalNative } = calculateFeeForSend({
+      feeInfo: item.gasInfo as IFeeInfoUnit,
+      nativeTokenPrice: item.gasInfo.common.nativeTokenPrice ?? 0,
+    });
+    const totalNativeBN = new BigNumber(totalNative);
+
+    if (totalNativeBN.isNaN() || !totalNativeBN.isFinite()) {
+      return acc;
+    }
+
+    return acc.plus(totalNativeBN);
+  }, new BigNumber(0));
+
+  if (!nativeToken) {
+    return undefined;
+  }
+
+  const fromAmountBN = new BigNumber(fromAmount ?? 0);
+  const shouldAddFromAmount =
+    fromToken?.isNative &&
+    fromToken.networkId === nativeToken.networkId &&
+    !fromAmountBN.isNaN() &&
+    fromAmountBN.isFinite() &&
+    fromAmountBN.gt(0);
+
+  const requiredAmount = shouldAddFromAmount
+    ? networkFeeAmount.plus(fromAmountBN)
+    : networkFeeAmount;
+
+  if (requiredAmount.lte(0)) {
+    return undefined;
+  }
+
+  return {
+    token: nativeToken,
+    amount: requiredAmount.toFixed(),
+  };
+}
 
 export async function checkSwapLatestBalanceSufficient({
   token,

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -500,6 +500,7 @@ export interface ISwapPreSwapData {
   swapBuildLoading?: boolean;
   estimateNetworkFeeLoading?: boolean;
   stepBeforeActionsLoading?: boolean;
+  stepBeforeActionsError?: boolean;
   providerInfo?: IFetchQuoteInfo;
   isHWAndExBatchTransfer?: boolean;
   slippage?: number;


### PR DESCRIPTION
## Summary
- Add latest native-token balance checks for Swap network fees before verify/sign/send, including native sell amount plus gas when the source token is native.
- Await the native balance check during network-fee estimation and avoid reusing aggregate approve+swap gas after approve has already spent gas.
- Prevent Limit market-price actions from writing `0` when the current pair price is stale or unavailable; stale market-price polling responses are ignored.

## Jira
- OK-53915: Swap gas is insufficient but transaction/order flow still proceeds.
- OK-53459: Limit price clears when ToToken is native, and Market price cannot refill.
- OK-53865 is already covered by ready-for-review PR #11437.

## Verification
- `yarn jest packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts --runInBand`
- `yarn lint:staged`
- `yarn tsc:staged`
- Cross-review completed with no blocking findings after fixes.

## Notes
- Exact network gas cannot be known before `fetchBuildTx`; this PR blocks during fee estimation when gas is known and again immediately before final sign/send.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
