### PR TITLE
fix: improve swap quote, fee and review rate handling (OK-53771 OK-53920 OK-53922 OK-53928 OK-53936)

### DIFF
--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -111,7 +111,9 @@ import {
   swapTypeSwitchAtom,
 } from './atoms';
 import {
+  SWAP_INCOGNITO_QUOTE_PROVIDER_COUNT_CAP,
   buildSwapQuoteProviderKey,
+  getSwapQuoteEventProgressTotalCount,
   getSwapQuoteProgressState,
   isSwapQuoteEventFetching,
 } from './quoteProgress';
@@ -1262,8 +1264,17 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       const currentEventReceivedCount = get(
         swapQuoteCurrentEventReceivedCountAtom(),
       );
-      const quoteEventFetching = isSwapQuoteEventFetching({
+      const { swapIncognitoMode } = await settingsAtom.get();
+      const swapTypeSwitch = get(swapTypeSwitchAtom());
+      const quoteEventProgressTotalCount = getSwapQuoteEventProgressTotalCount({
         quoteEventTotalCount,
+        maxQuoteCount:
+          swapIncognitoMode && swapTypeSwitch !== ESwapTabSwitchType.LIMIT
+            ? SWAP_INCOGNITO_QUOTE_PROVIDER_COUNT_CAP
+            : undefined,
+      });
+      const quoteEventFetching = isSwapQuoteEventFetching({
+        quoteEventTotalCount: quoteEventProgressTotalCount,
         currentEventReceivedCount,
         quoteEventCompleted,
       });

--- a/packages/kit/src/states/jotai/contexts/swap/quoteProgress.test.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/quoteProgress.test.ts
@@ -1,0 +1,33 @@
+import {
+  getSwapQuoteEventProgressTotalCount,
+  isSwapQuoteEventFetching,
+} from './quoteProgress';
+
+describe('swap quote progress', () => {
+  it('caps quote event total count for scoped provider flows', () => {
+    expect(
+      getSwapQuoteEventProgressTotalCount({
+        quoteEventTotalCount: { eventId: 'event-1', count: 6 },
+        maxQuoteCount: 2,
+      }),
+    ).toEqual({ eventId: 'event-1', count: 2 });
+  });
+
+  it('keeps quote event fetching active until the capped count is received', () => {
+    expect(
+      isSwapQuoteEventFetching({
+        quoteEventTotalCount: { count: 2 },
+        currentEventReceivedCount: 1,
+        quoteEventCompleted: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      isSwapQuoteEventFetching({
+        quoteEventTotalCount: { count: 2 },
+        currentEventReceivedCount: 2,
+        quoteEventCompleted: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/kit/src/states/jotai/contexts/swap/quoteProgress.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/quoteProgress.ts
@@ -34,6 +34,14 @@ type ISwapQuoteEventFetchingInput = {
   quoteEventCompleted: boolean;
 };
 
+type ISwapQuoteEventProgressTotalCountInput = {
+  quoteEventTotalCount: {
+    count: number;
+    eventId?: string;
+  };
+  maxQuoteCount?: number;
+};
+
 type ISwapCurrentQuoteInput = {
   currentEventSortedQuotes: IFetchQuoteResult[];
   selectionIntent?: ISwapQuoteSelectionIntent;
@@ -87,6 +95,22 @@ export function isSwapQuoteEventFetching({
     !quoteEventCompleted &&
     currentEventReceivedCount < quoteEventTotalCount.count
   );
+}
+
+export const SWAP_INCOGNITO_QUOTE_PROVIDER_COUNT_CAP = 2;
+
+export function getSwapQuoteEventProgressTotalCount({
+  quoteEventTotalCount,
+  maxQuoteCount,
+}: ISwapQuoteEventProgressTotalCountInput) {
+  if (!maxQuoteCount || maxQuoteCount <= 0) {
+    return quoteEventTotalCount;
+  }
+
+  return {
+    ...quoteEventTotalCount,
+    count: Math.min(quoteEventTotalCount.count, maxQuoteCount),
+  };
 }
 
 export function isSwapQuoteActionable(

--- a/packages/kit/src/views/Swap/components/PreSwapTokenItem.tsx
+++ b/packages/kit/src/views/Swap/components/PreSwapTokenItem.tsx
@@ -15,11 +15,17 @@ import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 
 import { Token } from '../../../components/Token';
 
+import {
+  type ISwapRateDifference,
+  SwapRateDifferenceText,
+} from './SwapRateDifferenceText';
+
 interface IPreSwapTokenItemProps {
   token?: ISwapToken;
   amount: string;
   loading?: boolean;
   isFloating?: boolean;
+  rateDifference?: ISwapRateDifference;
 }
 
 const PreSwapTokenItem = ({
@@ -27,6 +33,7 @@ const PreSwapTokenItem = ({
   amount,
   loading,
   isFloating,
+  rateDifference,
 }: IPreSwapTokenItemProps) => {
   const fiatValue = useMemo(() => {
     return token?.price && amount
@@ -72,17 +79,24 @@ const PreSwapTokenItem = ({
                 {amount}
               </NumberSizeableText>
             </XStack>
-            <NumberSizeableText
-              size="$bodyMd"
-              color="$textSubdued"
-              formatter="value"
-              formatterOptions={{
-                currency: settings.currencyInfo.symbol,
-              }}
-              numberOfLines={1}
-            >
-              {fiatValue}
-            </NumberSizeableText>
+            <XStack alignItems="center" gap="$1">
+              <NumberSizeableText
+                size="$bodyMd"
+                color="$textSubdued"
+                formatter="value"
+                formatterOptions={{
+                  currency: settings.currencyInfo.symbol,
+                }}
+                numberOfLines={1}
+              >
+                {fiatValue}
+              </NumberSizeableText>
+              <SwapRateDifferenceText
+                loading={loading}
+                rateDifference={rateDifference}
+                size="$bodyMd"
+              />
+            </XStack>
           </>
         )}
       </YStack>

--- a/packages/kit/src/views/Swap/components/SwapProviderListPanel.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProviderListPanel.tsx
@@ -33,14 +33,22 @@ import {
   useSwapTypeSwitchAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
 import {
+  SWAP_INCOGNITO_QUOTE_PROVIDER_COUNT_CAP,
   buildSwapManualProviderSelectionIntent,
   buildSwapQuoteProviderKey,
+  getSwapQuoteEventProgressTotalCount,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap/quoteProgress';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  useSettingsAtom,
+  useSettingsPersistAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { ESwapProviderSort } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
-import type { IFetchQuoteResult } from '@onekeyhq/shared/types/swap/types';
+import {
+  ESwapTabSwitchType,
+  type IFetchQuoteResult,
+} from '@onekeyhq/shared/types/swap/types';
 
 import {
   useSwapQuoteEventFetching,
@@ -142,6 +150,7 @@ const SwapProviderListPanel = ({
     useSwapManualSelectQuoteProvidersAtom();
   const [providerSort, setProviderSort] = useSwapProviderSortAtom();
   const [settingsPersist] = useSettingsPersistAtom();
+  const [{ swapIncognitoMode }] = useSettingsAtom();
   const [currentSelectQuote] = useSwapQuoteCurrentSelectAtom();
   const selectedProviderInfo =
     currentSelectQuote?.info ?? manualSelectQuoteProvider?.info;
@@ -683,13 +692,27 @@ const SwapProviderListPanel = ({
   }
 
   const hasQuotes = displayList.length > 0;
+  const quoteEventProgressTotalCount = useMemo(
+    () =>
+      getSwapQuoteEventProgressTotalCount({
+        quoteEventTotalCount,
+        maxQuoteCount:
+          swapIncognitoMode && swapTypeSwitch !== ESwapTabSwitchType.LIMIT
+            ? SWAP_INCOGNITO_QUOTE_PROVIDER_COUNT_CAP
+            : undefined,
+      }),
+    [quoteEventTotalCount, swapIncognitoMode, swapTypeSwitch],
+  );
 
   // Whether the SSE total event has been received
-  const hasReceivedTotal = quoteEventTotalCount.count > 0;
+  const hasReceivedTotal = quoteEventProgressTotalCount.count > 0;
   // Number of skeleton placeholders for providers not yet received
   const remainingSkeletonCount =
     hasReceivedTotal && quoteEventFetching
-      ? Math.max(0, quoteEventTotalCount.count - currentEventReceivedCount)
+      ? Math.max(
+          0,
+          quoteEventProgressTotalCount.count - currentEventReceivedCount,
+        )
       : 0;
 
   const contentArea = (

--- a/packages/kit/src/views/Swap/components/SwapRateDifferenceText.tsx
+++ b/packages/kit/src/views/Swap/components/SwapRateDifferenceText.tsx
@@ -1,0 +1,87 @@
+import { memo, useCallback } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import { Dialog, SizableText, XStack } from '@onekeyhq/components';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { ESwapRateDifferenceUnit } from '@onekeyhq/shared/types/swap/types';
+
+export type ISwapRateDifference = {
+  value: string;
+  unit: ESwapRateDifferenceUnit;
+};
+
+type ISwapRateDifferenceTextProps = {
+  loading?: boolean;
+  rateDifference?: ISwapRateDifference;
+  size?: '$bodySm' | '$bodyMd';
+};
+
+function BasicSwapRateDifferenceText({
+  loading,
+  rateDifference,
+  size = '$bodySm',
+}: ISwapRateDifferenceTextProps) {
+  const intl = useIntl();
+  const onRateDifferencePress = useCallback(() => {
+    Dialog.show({
+      title: intl.formatMessage({
+        id: ETranslations.swap_page_price_impact_title,
+      }),
+      description: intl.formatMessage({
+        id: ETranslations.swap_page_price_impact_content_1,
+      }),
+      renderContent: (
+        <SizableText size="$bodyLg" color="$textSubdued">
+          {intl.formatMessage({
+            id: ETranslations.swap_page_price_impact_content_2,
+          })}
+        </SizableText>
+      ),
+      showCancelButton: false,
+      onConfirmText: intl.formatMessage({
+        id: ETranslations.global_ok,
+      }),
+    });
+  }, [intl]);
+
+  if (!rateDifference) {
+    return null;
+  }
+
+  let color = '$textSubdued';
+  if (loading) {
+    color = '$textPlaceholder';
+  }
+  if (rateDifference.unit === ESwapRateDifferenceUnit.NEGATIVE) {
+    color = '$textCritical';
+  }
+  if (rateDifference.unit === ESwapRateDifferenceUnit.POSITIVE) {
+    color = '$textSuccess';
+  }
+
+  return (
+    <XStack alignItems="center">
+      <SizableText size={size} color={color}>
+        (
+      </SizableText>
+      <SizableText
+        size={size}
+        color={color}
+        cursor="pointer"
+        onPress={onRateDifferencePress}
+        {...(rateDifference.unit === ESwapRateDifferenceUnit.NEGATIVE && {
+          textDecorationLine: 'underline',
+          textDecorationStyle: 'dotted',
+        })}
+      >
+        {rateDifference.value}
+      </SizableText>
+      <SizableText size={size} color={color}>
+        )
+      </SizableText>
+    </XStack>
+  );
+}
+
+export const SwapRateDifferenceText = memo(BasicSwapRateDifferenceText);

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -474,6 +474,20 @@ export function useSwapBuildTx() {
     [fromToken, intl, selectQuote?.fromAmount, fromUserAddress, fromAccountId],
   );
 
+  const showLatestBalanceInsufficientToast = useCallback(
+    (tokenSymbol: string) => {
+      Toast.error({
+        title: intl.formatMessage(
+          {
+            id: ETranslations.swap_page_toast_insufficient_balance_title,
+          },
+          { token: tokenSymbol },
+        ),
+      });
+    },
+    [intl],
+  );
+
   const checkLatestFromTokenBalance = useCallback(
     async (token: ISwapToken, amount: string) => {
       const checkResult = await checkSwapLatestBalanceSufficient({
@@ -483,28 +497,12 @@ export function useSwapBuildTx() {
         accountId: fromAccountId,
       });
       if (!checkResult.isSufficient) {
-        Toast.error({
-          title: intl.formatMessage(
-            {
-              id: ETranslations.swap_page_toast_insufficient_balance_title,
-            },
-            { token: checkResult.tokenSymbol },
-          ),
-          message: intl.formatMessage(
-            {
-              id: ETranslations.swap_page_toast_insufficient_balance_content,
-            },
-            {
-              token: checkResult.tokenSymbol,
-              number: numberFormat(checkResult.requiredAmount, formatter),
-            },
-          ),
-        });
+        showLatestBalanceInsufficientToast(checkResult.tokenSymbol);
         return false;
       }
       return true;
     },
-    [fromAccountId, fromUserAddress, intl],
+    [fromAccountId, fromUserAddress, showLatestBalanceInsufficientToast],
   );
 
   const cancelLimitOrder = useCallback(

--- a/packages/kit/src/views/Swap/hooks/useSwapState.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapState.ts
@@ -56,6 +56,8 @@ import {
   useSwapTypeSwitchAtom,
 } from '../../../states/jotai/contexts/swap';
 import {
+  SWAP_INCOGNITO_QUOTE_PROVIDER_COUNT_CAP,
+  getSwapQuoteEventProgressTotalCount,
   getSwapQuoteProgressState,
   isSwapQuoteEventFetching,
 } from '../../../states/jotai/contexts/swap/quoteProgress';
@@ -137,9 +139,22 @@ export function useSwapQuoteEventFetching() {
   const [quoteEventCompleted] = useSwapQuoteEventCompletedAtom();
   const [currentEventReceivedCount] =
     useSwapQuoteCurrentEventReceivedCountAtom();
+  const [{ swapIncognitoMode }] = useSettingsAtom();
+  const [swapTypeSwitch] = useSwapTypeSwitchAtom();
+  const quoteEventProgressTotalCount = useMemo(
+    () =>
+      getSwapQuoteEventProgressTotalCount({
+        quoteEventTotalCount,
+        maxQuoteCount:
+          swapIncognitoMode && swapTypeSwitch !== ESwapTabSwitchType.LIMIT
+            ? SWAP_INCOGNITO_QUOTE_PROVIDER_COUNT_CAP
+            : undefined,
+      }),
+    [quoteEventTotalCount, swapIncognitoMode, swapTypeSwitch],
+  );
 
   return isSwapQuoteEventFetching({
-    quoteEventTotalCount,
+    quoteEventTotalCount: quoteEventProgressTotalCount,
     currentEventReceivedCount,
     quoteEventCompleted,
   });

--- a/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
+++ b/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
@@ -422,6 +422,7 @@ const PreSwapDialogContent = ({
               amount={toAmount}
               loading={preSwapData.swapBuildLoading}
               isFloating={quoteResult?.isFloating}
+              rateDifference={preSwapData.rateDifference}
             />
           </YStack>
 

--- a/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
@@ -1,7 +1,6 @@
-import { memo, useCallback, useMemo, useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 
 import BigNumber from 'bignumber.js';
-import { useIntl } from 'react-intl';
 import {
   InputAccessoryView,
   Keyboard,
@@ -11,8 +10,6 @@ import {
 
 import {
   Button,
-  Dialog,
-  SizableText,
   XStack,
   YStack,
   useIsKeyboardShown,
@@ -33,7 +30,6 @@ import {
   useInAppNotificationAtom,
   useSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { checkWrappedTokenPair } from '@onekeyhq/shared/src/utils/tokenUtils';
@@ -41,13 +37,13 @@ import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 import {
   ESwapDirectionType,
   ESwapQuoteKind,
-  ESwapRateDifferenceUnit,
   ESwapTabSwitchType,
   SwapAmountInputAccessoryViewID,
   SwapPercentageInputStageForNative,
 } from '@onekeyhq/shared/types/swap/types';
 
 import SwapPercentageStageBadge from '../../components/SwapPercentageStageBadge';
+import { SwapRateDifferenceText } from '../../components/SwapRateDifferenceText';
 import { useSwapAddressInfo } from '../../hooks/useSwapAccount';
 import { useSwapSelectedTokenInfo } from '../../hooks/useSwapTokens';
 
@@ -148,7 +144,6 @@ const SwapInputContainer = ({
   });
   const [settingsPersistAtom] = useSettingsPersistAtom();
   const [alerts] = useSwapAlertsAtom();
-  const intl = useIntl();
   const { address, accountInfo } = useSwapAddressInfo(direction);
   const [rateDifference] = useRateDifferenceAtom();
   const amountPrice = useMemo(() => {
@@ -198,74 +193,21 @@ const SwapInputContainer = ({
     fromTokenAmount,
     fromToken,
   ]);
-  const onRateDifferencePress = useCallback(() => {
-    Dialog.show({
-      title: intl.formatMessage({
-        id: ETranslations.swap_page_price_impact_title,
-      }),
-      description: intl.formatMessage({
-        id: ETranslations.swap_page_price_impact_content_1,
-      }),
-      renderContent: (
-        <SizableText size="$bodyLg" color="$textSubdued">
-          {intl.formatMessage({
-            id: ETranslations.swap_page_price_impact_content_2,
-          })}
-        </SizableText>
-      ),
-      showCancelButton: false,
-      onConfirmText: intl.formatMessage({
-        id: ETranslations.global_ok,
-      }),
-    });
-  }, [intl]);
   const valueMoreComponent = useMemo(() => {
     if (
       rateDifference &&
       direction === ESwapDirectionType.TO &&
       swapTypeSwitch !== ESwapTabSwitchType.LIMIT
     ) {
-      let color = '$textSubdued';
-      if (inputLoading) {
-        color = '$textPlaceholder';
-      }
-      if (rateDifference.unit === ESwapRateDifferenceUnit.NEGATIVE) {
-        color = '$textCritical';
-      }
-      if (rateDifference.unit === ESwapRateDifferenceUnit.POSITIVE) {
-        color = '$textSuccess';
-      }
       return (
-        <XStack alignItems="center">
-          <SizableText size="$bodySm" color={color}>
-            (
-          </SizableText>
-          <SizableText
-            size="$bodySm"
-            color={color}
-            cursor="pointer"
-            onPress={onRateDifferencePress}
-            {...(rateDifference.unit === ESwapRateDifferenceUnit.NEGATIVE && {
-              textDecorationLine: 'underline',
-              textDecorationStyle: 'dotted',
-            })}
-          >
-            {rateDifference.value}
-          </SizableText>
-          <SizableText size="$bodySm" color={color}>
-            )
-          </SizableText>
-        </XStack>
+        <SwapRateDifferenceText
+          loading={inputLoading}
+          rateDifference={rateDifference}
+        />
       );
     }
     return null;
-  }, [
-    direction,
-    inputLoading,
-    onRateDifferencePress,
-    rateDifference,
-    swapTypeSwitch,
-  ]);
+  }, [direction, inputLoading, rateDifference, swapTypeSwitch]);
 
   const [percentageInputStageShow, setPercentageInputStageShow] =
     useState(false);

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -25,6 +25,7 @@ import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useCustomRpcAvailability } from '@onekeyhq/kit/src/hooks/useCustomRpcAvailability';
 import { useTokenDetailActions } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
 import {
+  useRateDifferenceAtom,
   useSwapActions,
   useSwapAlertsAtom,
   useSwapBuildTxFetchingAtom,
@@ -140,6 +141,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
   const [quoteResult] = useSwapQuoteCurrentSelectAtom();
   const [alerts] = useSwapAlertsAtom();
   const [swapTypeSwitch] = useSwapTypeSwitchAtom();
+  const [rateDifference] = useRateDifferenceAtom();
   const [settingsPersistAtom] = useSettingsPersistAtom();
   const toAddressInfo = useSwapAddressInfo(ESwapDirectionType.TO);
   const swapFromAddressInfo = useSwapAddressInfo(ESwapDirectionType.FROM);
@@ -611,6 +613,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
         ) || isCustomRpcUnavailable,
       supportPreBuild,
       slippage: swapSlippageRef.current.value,
+      rateDifference,
       texts: reviewStepTexts,
     });
 
@@ -635,6 +638,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     settingsPersistAtom.swapBatchApproveAndSwap,
     supportPreBuild,
     isCustomRpcUnavailable,
+    rateDifference,
     reviewStepTexts,
   ]);
   const onActionHandler = useCallback(() => {

--- a/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
@@ -413,10 +413,68 @@ const SwapHistoryDetailModal = () => {
     ],
   );
 
+  const renderProtocolFee = useCallback(() => {
+    const protocolFee = txHistory?.swapInfo.protocolFee;
+    const protocolFeeBN = new BigNumber(protocolFee ?? 0);
+    const positiveOtherFeeInfos = txHistory?.swapInfo.otherFeeInfos?.filter(
+      (item) => {
+        const amountBN = new BigNumber(item.amount ?? 0);
+        return !amountBN.isNaN() && amountBN.gt(0);
+      },
+    );
+
+    if (positiveOtherFeeInfos?.length && protocolFeeBN.isZero()) {
+      return (
+        <Stack alignItems="flex-end" gap="$1">
+          {positiveOtherFeeInfos.map((item, index) => (
+            <SizableText
+              key={`${item.token.networkId}-${item.token.contractAddress}-${index}`}
+              size="$bodyMd"
+              color="$textSubdued"
+            >
+              <NumberSizeableText
+                size="$bodyMd"
+                color="$textSubdued"
+                formatter="balance"
+              >
+                {item.amount}
+              </NumberSizeableText>
+              {` ${item.token.symbol}`}
+            </SizableText>
+          ))}
+        </Stack>
+      );
+    }
+
+    if (isNil(protocolFee)) {
+      return null;
+    }
+
+    return (
+      <NumberSizeableText
+        size="$bodyMd"
+        color="$textSubdued"
+        formatter="value"
+        formatterOptions={{
+          currency:
+            txHistory?.currency ?? settingsPersistAtom.currencyInfo.symbol,
+        }}
+      >
+        {protocolFee.toString()}
+      </NumberSizeableText>
+    );
+  }, [
+    settingsPersistAtom.currencyInfo.symbol,
+    txHistory?.currency,
+    txHistory?.swapInfo.otherFeeInfos,
+    txHistory?.swapInfo.protocolFee,
+  ]);
+
   const renderSwapHistoryDetails = useCallback(() => {
     if (!txHistory) {
       return null;
     }
+    const protocolFeeContent = renderProtocolFee();
 
     return (
       <>
@@ -526,26 +584,13 @@ const SwapHistoryDetailModal = () => {
               })}
               renderContent={renderRate()}
             />
-            {!isNil(txHistory.swapInfo.protocolFee) ? (
+            {protocolFeeContent ? (
               <InfoItem
                 disabledCopy
                 label={intl.formatMessage({
                   id: ETranslations.swap_history_detail_protocol_fee,
                 })}
-                renderContent={
-                  <NumberSizeableText
-                    size="$bodyMd"
-                    color="$textSubdued"
-                    formatter="value"
-                    formatterOptions={{
-                      currency:
-                        txHistory.currency ??
-                        settingsPersistAtom.currencyInfo.symbol,
-                    }}
-                  >
-                    {txHistory.swapInfo.protocolFee.toString()}
-                  </NumberSizeableText>
-                }
+                renderContent={protocolFeeContent}
               />
             ) : null}
 
@@ -566,13 +611,13 @@ const SwapHistoryDetailModal = () => {
     intl,
     onViewInBrowser,
     renderNetworkFee,
+    renderProtocolFee,
     renderRate,
     renderSwapAssetsChange,
     renderSwapCrossChainStatus,
     renderSwapDate,
     renderSwapOrderStatus,
     renderSwapProvider,
-    settingsPersistAtom.currencyInfo.symbol,
     txHistory,
   ]);
 

--- a/packages/kit/src/views/Swap/utils/buildSwapReviewState.test.ts
+++ b/packages/kit/src/views/Swap/utils/buildSwapReviewState.test.ts
@@ -5,6 +5,7 @@ import type {
 import {
   EProtocolOfExchange,
   ESwapBatchTransferType,
+  ESwapRateDifferenceUnit,
   ESwapStepType,
   ESwapTabSwitchType,
 } from '@onekeyhq/shared/types/swap/types';
@@ -109,6 +110,10 @@ describe('buildSwapReviewState', () => {
       shouldFallback: false,
       supportPreBuild: true,
       slippage: 1,
+      rateDifference: {
+        value: '-12.34%',
+        unit: ESwapRateDifferenceUnit.NEGATIVE,
+      },
       texts,
     });
 
@@ -117,6 +122,10 @@ describe('buildSwapReviewState', () => {
     ]);
     expect(result.preSwapData.needFetchGas).toBe(false);
     expect(result.preSwapData.supportNetworkFeeLevel).toBe(true);
+    expect(result.preSwapData.rateDifference).toEqual({
+      value: '-12.34%',
+      unit: ESwapRateDifferenceUnit.NEGATIVE,
+    });
   });
 
   it('builds a wrap flow', () => {

--- a/packages/kit/src/views/Swap/utils/buildSwapReviewState.ts
+++ b/packages/kit/src/views/Swap/utils/buildSwapReviewState.ts
@@ -173,6 +173,7 @@ export type IBuildSwapReviewStateInput = {
   shouldFallback?: boolean;
   supportPreBuild: boolean;
   slippage?: number;
+  rateDifference?: ISwapPreSwapData['rateDifference'];
   texts: ISwapReviewStepTexts;
 };
 
@@ -189,6 +190,7 @@ export function buildSwapReviewState({
   shouldFallback,
   supportPreBuild,
   slippage,
+  rateDifference,
   texts,
 }: IBuildSwapReviewStateInput): {
   batchTransferType: ESwapBatchTransferType;
@@ -297,6 +299,10 @@ export function buildSwapReviewState({
       quoteResult?.unSupportSlippage
         ? undefined
         : slippage,
+    rateDifference:
+      quoteResult?.protocol === EProtocolOfExchange.LIMIT
+        ? undefined
+        : rateDifference,
     unSupportSlippage: quoteResult?.unSupportSlippage ?? false,
     isHWAndExBatchTransfer: shouldSignEveryTime,
     fee: quoteResult?.fee,

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -503,6 +503,10 @@ export interface ISwapPreSwapData {
   providerInfo?: IFetchQuoteInfo;
   isHWAndExBatchTransfer?: boolean;
   slippage?: number;
+  rateDifference?: {
+    value: string;
+    unit: ESwapRateDifferenceUnit;
+  };
   swapType?: ESwapTabSwitchType;
   unSupportSlippage?: boolean;
   swapBuildResultData?: {


### PR DESCRIPTION
## Summary
- Cap incognito swap quote progress to the two expected providers so loading and prebuild state settle correctly.
- Simplify the stale-balance retry toast to only show insufficient balance for the affected latest-balance check.
- Show RocketX provider fee from `otherFeeInfos` in swap history when fiat protocol fee is not returned.
- Show the homepage rate-difference percentage in the swap review dialog using the same color and risk-popover behavior.

## Issues
- Fixes OK-53771
- Fixes OK-53920
- Fixes OK-53922
- Fixes OK-53928
- Fixes OK-53936

## Intent & Context
These changes address Swap bug reports around review-dialog rate difference display, incognito quote progress, retry balance messaging, and provider fee display in history.

## Root Cause
- The review dialog did not carry the homepage `rateDifference` state into `preSwapData`, so users could not see the market-rate percentage delta while reviewing the order.
- Incognito quote flows can expose only two usable providers while the progress total count can still represent more providers, causing extra skeleton rows and delaying quote completion/prebuild readiness.
- The latest balance recheck reused the generic insufficient balance toast with a network-fee reserve message, which is misleading for the delayed balance refresh retry case.
- RocketX fee data can be returned through `otherFeeInfos` while `protocolFee` remains zero, so the history detail row had no token-fee fallback to render.

## Design Decisions
- Reuse a shared `SwapRateDifferenceText` component for both the homepage amount input and review dialog so color, underline, and price-impact popover behavior stay aligned.
- Keep the provider-count cap scoped to incognito non-Limit swap flows and reuse the same helper across quote progress consumers.
- Leave other fee validation toasts unchanged and only adjust the latest from-token balance recheck path.
- Preserve the existing fiat `protocolFee` rendering and only fall back to positive `otherFeeInfos` when `protocolFee` is zero.

## Changes Detail
- Added `SwapRateDifferenceText` and passed `rateDifference` through swap review state into the received-token row.
- Added `getSwapQuoteEventProgressTotalCount` and tests for capped quote progress semantics.
- Applied the incognito provider cap in quote fetching state, warning checks, and provider-list skeleton rendering.
- Extracted the latest-balance insufficient toast so it omits the second-line network-fee message.
- Added a provider-fee renderer in swap history detail for positive `otherFeeInfos` token amounts.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Swap review display, quote loading state, and swap history fee display. OK-53920 may still need backend follow-up if the build transaction API itself remains slow after the client no longer waits on the wrong quote total.

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `yarn tsc:only`
- [x] `yarn test packages/kit/src/views/Swap/utils/buildSwapReviewState.test.ts packages/kit/src/states/jotai/contexts/swap/quoteProgress.test.ts --runInBand`
- [x] `git diff --check`
