### PR TITLE
fix(perps): patch rews dispatchEvent on RN to prevent SIGABRT

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment */
 /* spell-checker: disable */
+// cspell:ignore rews
 import { SubscriptionClient, WebSocketTransport } from '@nktkas/hyperliquid';
 import { cloneDeep, debounce, isEmpty } from 'lodash';
 
@@ -12,6 +13,7 @@ import {
   EAppEventBusNames,
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
@@ -650,50 +652,62 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     event,
     ...args
   ) => {
-    const socket = event.target as WebSocket | undefined;
-    // OK-53208: SDK transport wrapper reports readyState=undefined in the
-    // open event, which keeps perpsWebSocketConnectedAtom false forever.
-    void perpsWebSocketReadyStateAtom.set({
-      readyState: socket?.readyState ?? WebSocket.OPEN,
-    });
-    console.log('hyperliquidWebSocket__event__open', {
-      readyState: socket?.readyState,
-      args,
-      event,
-    });
+    // OneKey: defensive try/catch around the entire async handler body.
+    // This handler is registered as a WebSocket "open" event listener but its
+    // body is async. Any rejection here would become an unhandled promise
+    // rejection. While RN routes those to reportError (soft) rather than
+    // reportFatalError (fatal), some downstream paths can re-throw on the
+    // event loop and turn into a RuntimeScheduler task error → SIGABRT.
+    // Catch-all here keeps the WS lifecycle robust regardless of which atom
+    // write or update fails.
+    try {
+      const socket = event.target as WebSocket | undefined;
+      // OK-53208: SDK transport wrapper reports readyState=undefined in the
+      // open event, which keeps perpsWebSocketConnectedAtom false forever.
+      void perpsWebSocketReadyStateAtom.set({
+        readyState: socket?.readyState ?? WebSocket.OPEN,
+      });
+      console.log('hyperliquidWebSocket__event__open', {
+        readyState: socket?.readyState,
+        args,
+        event,
+      });
 
-    const prevNetworkStatus = await perpsNetworkStatusAtom.get();
-    const wasConnected = prevNetworkStatus?.connected;
+      const prevNetworkStatus = await perpsNetworkStatusAtom.get();
+      const wasConnected = prevNetworkStatus?.connected;
 
-    await timerUtils.wait(600); // wait network status atom update
+      await timerUtils.wait(600); // wait network status atom update
 
-    // OK-53014: Install atom watcher BEFORE initial updateSubscriptions so
-    // that any atom change arriving in the gap between these two calls is
-    // captured and re-triggers a reconcile.
-    this._watchSubscriptionAtoms();
+      // OK-53014: Install atom watcher BEFORE initial updateSubscriptions so
+      // that any atom change arriving in the gap between these two calls is
+      // captured and re-triggers a reconcile.
+      this._watchSubscriptionAtoms();
 
-    if (!wasConnected) {
-      console.log('updateSubscriptions__by__socketOpen');
-      // resubscribe when reconnecting
-      await this.updateSubscriptions();
+      if (!wasConnected) {
+        console.log('updateSubscriptions__by__socketOpen');
+        // resubscribe when reconnecting
+        await this.updateSubscriptions();
+      }
+
+      // Mark connected after handling potential resubscribe.
+      await perpsNetworkStatusAtom.set(
+        (prev): IPerpsNetworkStatus => ({
+          ...prev,
+          connected: true,
+        }),
+      );
+      this._currentState.isConnected = true;
+      this._startPingLoop();
+
+      // Skip initial connect — only notify iframe on reconnection
+      if (wasConnected === false && this._lastMessageAt !== null) {
+        appEventBus.emit(EAppEventBusNames.PerpsWebSocketRecovered, undefined);
+      }
+
+      this._startPostOpenDataCheck();
+    } catch (error) {
+      defaultLogger.perp.hyperliquid.subscriptionSocketOpenError({ error });
     }
-
-    // Mark connected after handling potential resubscribe.
-    await perpsNetworkStatusAtom.set(
-      (prev): IPerpsNetworkStatus => ({
-        ...prev,
-        connected: true,
-      }),
-    );
-    this._currentState.isConnected = true;
-    this._startPingLoop();
-
-    // Skip initial connect — only notify iframe on reconnection
-    if (wasConnected === false && this._lastMessageAt !== null) {
-      appEventBus.emit(EAppEventBusNames.PerpsWebSocketRecovered, undefined);
-    }
-
-    this._startPostOpenDataCheck();
   };
 
   socketMessageHandler: (event: WebSocketEventMap['message']) => void = (
@@ -766,7 +780,22 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       const registerSubscriptionHandler = (type: ESubscriptionType) => {
         if (!this.subscriptionHandlerByType[type]) {
           const handleData = (data: unknown) => {
-            void this._handleSubscriptionData(type, data as CustomEvent);
+            // OneKey: defensive try/catch on the WS message hot path.
+            // Hyperliquid streams up to ~10 L2 book updates per second; any
+            // synchronous throw inside _handleSubscriptionData (e.g. from a
+            // jotai atom setter or a downstream service call) would propagate
+            // through SDK's HyperliquidEventTarget.dispatchEvent and surface
+            // as a fatal RuntimeScheduler task error → SIGABRT. The void on
+            // the inner promise covers async rejections, but a sync throw
+            // before the first await can still escape — this catch handles it.
+            try {
+              void this._handleSubscriptionData(type, data as CustomEvent);
+            } catch (error) {
+              defaultLogger.perp.hyperliquid.subscriptionHandlerError({
+                type,
+                error,
+              });
+            }
           };
           this.subscriptionHandlerByType[type] = handleData;
         }
@@ -847,6 +876,25 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         subscribe,
         unsubscribe,
         dispose: async () => {
+          // OneKey: dispose order matters for orphan-timer cleanup. We must
+          // close the underlying socket BEFORE removing OUR listeners — the
+          // close() triggers rews's internal `cleanup` listener (registered
+          // with { once: true } on close/error/open) which calls clearTimeout
+          // on its connection-timeout timer. If we removed listeners first,
+          // any in-flight close event might be dropped before rews can clean
+          // up its 5s setTimeout, leaving an orphan timer that could fire
+          // after dispose and re-trigger the dispatchEvent path (now caught
+          // defensively by the rews patch, but harmless cleanup is preferred).
+          defaultLogger.perp.hyperliquid.subscriptionTransportDispose({
+            clientId,
+          });
+          try {
+            // Close socket first so rews's internal close listener fires and
+            // clears its connection-timeout setTimeout.
+            transport.socket.close();
+          } catch (error) {
+            console.error('dispose__transport.socket.close__error', error);
+          }
           try {
             removeAllSocketEventListeners();
           } catch (error) {
@@ -863,18 +911,19 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
               error,
             );
           }
-          try {
-            transport.socket.close();
-          } catch (error) {
-            console.error('dispose__transport.socket.close__error', error);
-          }
           const disposer = (
             innerClient as unknown as {
               [Symbol.asyncDispose]?: () => Promise<void>;
             }
           )[Symbol.asyncDispose];
           if (disposer) {
-            await disposer();
+            try {
+              await disposer();
+            } catch (error) {
+              defaultLogger.perp.hyperliquid.subscriptionInnerClientDisposeError(
+                { error },
+              );
+            }
           }
         },
       };

--- a/packages/shared/src/logger/scopes/perp/scenes/hyperliquid.ts
+++ b/packages/shared/src/logger/scopes/perp/scenes/hyperliquid.ts
@@ -1,3 +1,4 @@
+// cspell:ignore rews
 import type {
   IApiErrorResponse,
   IApiRequestError,
@@ -255,6 +256,48 @@ export class HyperLiquidScene extends BaseScene {
     passed: boolean;
     reason?: string;
   }) {
+    return params;
+  }
+
+  // ============ WebSocket Subscription Lifecycle Logs ============
+
+  /**
+   * Defensive log for the socket "open" handler async body.
+   * Emitted when the open handler's body throws/rejects — caught to prevent
+   * unhandled rejection from escalating into a fatal RuntimeScheduler error.
+   */
+  @LogToLocal({ level: 'error' })
+  public subscriptionSocketOpenError(params: { error: unknown }) {
+    return params;
+  }
+
+  /**
+   * Defensive log for the WS subscription message hot path.
+   * Emitted when _handleSubscriptionData throws synchronously inside the
+   * SDK's HyperliquidEventTarget dispatch. Hyperliquid streams up to ~10
+   * L2 book updates per second; any uncaught throw here would propagate
+   * via dispatchEvent → fatal RuntimeScheduler task → SIGABRT.
+   */
+  @LogToLocal({ level: 'error' })
+  public subscriptionHandlerError(params: { type: string; error: unknown }) {
+    return params;
+  }
+
+  /**
+   * Trace log for socket transport dispose — fires when ServiceHyperliquid
+   * tears down the rews ReconnectingWebSocket. Useful to correlate orphan
+   * timer cleanup with rapid Perp/Discovery tab switching scenarios.
+   */
+  @LogToLocal({ level: 'info' })
+  public subscriptionTransportDispose(params: { clientId: string }) {
+    return params;
+  }
+
+  /**
+   * Defensive log for inner SDK SubscriptionClient dispose errors.
+   */
+  @LogToLocal({ level: 'error' })
+  public subscriptionInnerClientDisposeError(params: { error: unknown }) {
     return params;
   }
 }

--- a/patches/@nktkas+rews+2.0.2.patch
+++ b/patches/@nktkas+rews+2.0.2.patch
@@ -1,0 +1,130 @@
+diff --git a/node_modules/@nktkas/rews/esm/mod.js b/node_modules/@nktkas/rews/esm/mod.js
+--- a/node_modules/@nktkas/rews/esm/mod.js
++++ b/node_modules/@nktkas/rews/esm/mod.js
+@@ -168,11 +168,19 @@
+             }, { signal });
+             this._socket.addEventListener("close", (e) => {
+                 ac.abort();
+-                this.dispatchEvent(new CloseEvent("close", {
+-                    code: e.code,
+-                    reason: e.reason,
+-                    wasClean: e.wasClean,
+-                }));
++                // OneKey: defensive try/catch — on React Native, the global CloseEvent
++                // polyfill constructs events from globalThis.Event which is NOT the
++                // same class as RN's internal Event used by EventTarget.dispatchEvent
++                // for instanceof checks. A throw here would escape into RN's
++                // RuntimeScheduler and be reported as a fatal error → SIGABRT.
++                try {
++                    this.dispatchEvent(new CloseEvent("close", {
++                        code: e.code,
++                        reason: e.reason,
++                        wasClean: e.wasClean,
++                    }));
++                }
++                catch (_err) { /* no-op: socket lifecycle is already complete via ac.abort() */ }
+                 resolve();
+             }, { signal });
+         });
+@@ -330,7 +338,16 @@
+         //       removing all listeners before native events fire.
+         if (wasConnecting) {
+             // 1006 = Abnormal Closure (RFC 6455) — no close frame was received
+-            this._socket.dispatchEvent(new CloseEvent("close", { code: 1006, reason: "", wasClean: false }));
++            // OneKey: defensive try/catch — see explanation in the "close" listener above.
++            // The dispatched event is constructed via globalThis.CloseEvent polyfill (which
++            // uses globalThis.Event), but the underlying RN WebSocket extends RN's internal
++            // EventTarget whose dispatchEvent does instanceof against RN's internal Event
++            // class. Class identity mismatch would throw "parameter 1 is not of type 'Event'"
++            // and propagate as a fatal error via RuntimeScheduler → SIGABRT.
++            try {
++                this._socket.dispatchEvent(new CloseEvent("close", { code: 1006, reason: "", wasClean: false }));
++            }
++            catch (_err) { /* no-op: native close() above will eventually fire close event in RN */ }
+         }
+     }
+     /**
+@@ -374,7 +391,17 @@
+         //       because the internal close listener calls ac.abort(),
+         //       removing all listeners before native events fire.
+         if (wasConnecting) {
+-            socket.dispatchEvent(new CloseEvent("close", { code: 3008, reason: "Timeout", wasClean: false }));
++            // OneKey: defensive try/catch — same root cause as the dispatchEvent calls
++            // above. This setTimeout fires after `timeout` ms (5s by default) when the
++            // underlying socket is still CONNECTING. On React Native, the throw from
++            // dispatchEvent would propagate out of this setTimeout callback into RN's
++            // RuntimeScheduler which hardcodes timer task errors as fatal → SIGABRT.
++            // Sentry issue REACT-NATIVE-4AX (357 events on so.onekey.wallet@6.2.0) is
++            // exactly this path firing during slow Hyperliquid WebSocket connects.
++            try {
++                socket.dispatchEvent(new CloseEvent("close", { code: 3008, reason: "Timeout", wasClean: false }));
++            }
++            catch (_err) { /* no-op: socket.close(3008) above already initiates teardown */ }
+         }
+     }, timeout);
+     const cleanup = () => clearTimeout(timer);
+diff --git a/node_modules/@nktkas/rews/script/mod.js b/node_modules/@nktkas/rews/script/mod.js
+--- a/node_modules/@nktkas/rews/script/mod.js
++++ b/node_modules/@nktkas/rews/script/mod.js
+@@ -172,11 +172,19 @@
+             }, { signal });
+             this._socket.addEventListener("close", (e) => {
+                 ac.abort();
+-                this.dispatchEvent(new CloseEvent("close", {
+-                    code: e.code,
+-                    reason: e.reason,
+-                    wasClean: e.wasClean,
+-                }));
++                // OneKey: defensive try/catch — on React Native, the global CloseEvent
++                // polyfill constructs events from globalThis.Event which is NOT the
++                // same class as RN's internal Event used by EventTarget.dispatchEvent
++                // for instanceof checks. A throw here would escape into RN's
++                // RuntimeScheduler and be reported as a fatal error → SIGABRT.
++                try {
++                    this.dispatchEvent(new CloseEvent("close", {
++                        code: e.code,
++                        reason: e.reason,
++                        wasClean: e.wasClean,
++                    }));
++                }
++                catch (_err) { /* no-op: socket lifecycle is already complete via ac.abort() */ }
+                 resolve();
+             }, { signal });
+         });
+@@ -334,7 +342,16 @@
+         //       removing all listeners before native events fire.
+         if (wasConnecting) {
+             // 1006 = Abnormal Closure (RFC 6455) — no close frame was received
+-            this._socket.dispatchEvent(new CloseEvent("close", { code: 1006, reason: "", wasClean: false }));
++            // OneKey: defensive try/catch — see explanation in the "close" listener above.
++            // The dispatched event is constructed via globalThis.CloseEvent polyfill (which
++            // uses globalThis.Event), but the underlying RN WebSocket extends RN's internal
++            // EventTarget whose dispatchEvent does instanceof against RN's internal Event
++            // class. Class identity mismatch would throw "parameter 1 is not of type 'Event'"
++            // and propagate as a fatal error via RuntimeScheduler → SIGABRT.
++            try {
++                this._socket.dispatchEvent(new CloseEvent("close", { code: 1006, reason: "", wasClean: false }));
++            }
++            catch (_err) { /* no-op: native close() above will eventually fire close event in RN */ }
+         }
+     }
+     /**
+@@ -379,7 +396,17 @@
+         //       because the internal close listener calls ac.abort(),
+         //       removing all listeners before native events fire.
+         if (wasConnecting) {
+-            socket.dispatchEvent(new CloseEvent("close", { code: 3008, reason: "Timeout", wasClean: false }));
++            // OneKey: defensive try/catch — same root cause as the dispatchEvent calls
++            // above. This setTimeout fires after `timeout` ms (5s by default) when the
++            // underlying socket is still CONNECTING. On React Native, the throw from
++            // dispatchEvent would propagate out of this setTimeout callback into RN's
++            // RuntimeScheduler which hardcodes timer task errors as fatal → SIGABRT.
++            // Sentry issue REACT-NATIVE-4AX (357 events on so.onekey.wallet@6.2.0) is
++            // exactly this path firing during slow Hyperliquid WebSocket connects.
++            try {
++                socket.dispatchEvent(new CloseEvent("close", { code: 3008, reason: "Timeout", wasClean: false }));
++            }
++            catch (_err) { /* no-op: socket.close(3008) above already initiates teardown */ }
+         }
+     }, timeout);
+     const cleanup = () => clearTimeout(timer);


### PR DESCRIPTION
## Summary

Fix native crash on iOS where Hyperliquid Perps WebSocket connection timeout triggers SIGABRT after slow connect (>5s) or rapid Discovery↔Perp tab switching.

**Sentry**: [REACT-NATIVE-4AX](https://onekey-bb.sentry.io/issues/114664082/) — 357 events / 182 users on `so.onekey.wallet@6.2.0+2026041735`. Source-maps confirmed all top events converge to `RN EventTarget.js:193 instanceof Event check` ← `@nktkas/rews/mod.js:374 dispatchEvent(new CloseEvent(...))` ← `setTimeout` connection-timeout callback.

## Root Cause

1. `@nktkas/rews@2.0.2` does `socket.dispatchEvent(new CloseEvent(...))` in 3 places, including a 5-second connection-timeout `setTimeout` callback.
2. `globalThis.CloseEvent` is OneKey's polyfill (`packages/shared/src/polyfills/polyfillsPlatform.js`) which constructs events from `globalThis.Event` = `event-target-polyfill`'s class.
3. RN 0.81's internal `EventTarget.dispatchEvent` (used by RN's `WebSocket` superclass) imports its own `Event` from `react-native/src/private/webapis/dom/events/Event.js` and does `instanceof Event` against THAT class — never exposed to global.
4. **Class identity mismatch** ⇒ throws `TypeError: Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'`.
5. The throw escapes the `setTimeout` callback into RN's `RuntimeScheduler_Modern.cpp:382`, which hardcodes timer task errors as fatal via `handleTaskErrorDefault → handleJSError(..., isFatal=true)` → `RCTFatal()` → SIGABRT.

## Changes

### `patches/@nktkas+rews+2.0.2.patch` (treat root cause)

Defensive `try/catch` around all 3 `socket.dispatchEvent(new CloseEvent(...))` call sites in both `esm/mod.js` and `script/mod.js` (6 total). Comments explain the RN polyfill class identity issue.

### `ServiceHyperliquidSubscription.ts` (defense-in-depth)

- `socketOpenHandler` async body wrapped in `try/catch` so async rejections cannot escalate via RuntimeScheduler.
- `_handleSubscriptionData` call site wrapped to keep the WS message hot path crash-safe.
- `dispose()` reordered: close the underlying socket BEFORE removing OUR listeners, so rews's internal `cleanup` listener (registered with `{ once: true }`) can fire and `clearTimeout` its 5s connection-timeout timer, eliminating the orphan-timer scenario.

### `HyperLiquidScene` logger

4 new `@LogToLocal` methods for visibility into the defensive paths:
- `subscriptionSocketOpenError`
- `subscriptionHandlerError`
- `subscriptionTransportDispose`
- `subscriptionInnerClientDisposeError`

## Test plan

- [ ] `npx tsgo -p ./tsconfig.json --noEmit` (✅ verified locally — exit 0)
- [ ] `yarn lint:staged` (✅ verified locally — 0 warnings 0 errors)
- [ ] `npx patch-package` apply succeeds for `@nktkas/rews@2.0.2` (✅ verified locally)
- [ ] Repro on iOS dev build: temporarily set `connectionTimeout: 100` in `ServiceHyperliquidSubscription.ts`, enter Perp tab — should NOT crash anymore (was: ~100% crash within 100ms).
- [ ] Repro on iOS dev build with Network Link Conditioner "Very Bad Network" — enter/leave Perp tab rapidly — should NOT crash.
- [ ] Sentry REACT-NATIVE-4AX event count stops growing after rollout.
- [ ] Hyperliquid Perp page renders price/orderbook normally on stable network.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->