### PR TITLE
chore: sync release/v6.2.0 to x

### DIFF
--- a/packages/kit-bg/src/services/ServiceDeFi.ts
+++ b/packages/kit-bg/src/services/ServiceDeFi.ts
@@ -1,11 +1,17 @@
 import BigNumber from 'bignumber.js';
 import { debounce, isEmpty, isUndefined } from 'lodash';
 
+import { settingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
   backgroundClass,
   backgroundMethod,
 } from '@onekeyhq/shared/src/background/backgroundDecorators';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
+import type { IAppEventBusPayload } from '@onekeyhq/shared/src/eventBus/appEventBus';
+import {
+  EAppEventBusNames,
+  appEventBus,
+} from '@onekeyhq/shared/src/eventBus/appEventBus';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import defiUtils from '@onekeyhq/shared/src/utils/defiUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
@@ -15,6 +21,7 @@ import type {
   IFetchAccountDeFiPositionsResp,
 } from '@onekeyhq/shared/types/defi';
 import { EServiceEndpointEnum } from '@onekeyhq/shared/types/endpoint';
+import { EDecodedTxStatus } from '@onekeyhq/shared/types/tx';
 
 import { currencyPersistAtom } from '../states/jotai/atoms/currency';
 
@@ -33,9 +40,22 @@ class ServiceDeFi extends ServiceBase {
 
   constructor({ backgroundApi }: { backgroundApi: any }) {
     super({ backgroundApi });
+
+    appEventBus.on(EAppEventBusNames.LocalPendingTxConfirmed, (payload) => {
+      void this.onLocalTxConfirmedForDeFi(payload);
+    });
   }
 
   _fetchAccountDeFiPositionsControllers: AbortController[] = [];
+
+  // Offsets (ms) from a local tx being confirmed at which we force-refresh
+  // the DeFi portfolio for that chain. Covers indexer lag after the tx lands.
+  private readonly _deFiForceRefreshOffsetsMs = [40_000, 80_000] as const;
+
+  private _deFiForceRefreshTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>[]
+  >();
 
   _localDeFiOverviewCache: Record<
     string,
@@ -116,6 +136,7 @@ class ServiceDeFi extends ServiceBase {
       targetCurrencyInfo,
       saveToLocal,
       isForceRefresh,
+      abortable = true,
     } = params;
 
     const isUrlAccount = accountUtils.isUrlAccountFn({ accountId });
@@ -137,7 +158,9 @@ class ServiceDeFi extends ServiceBase {
     const client = await this.getClient(EServiceEndpointEnum.Wallet);
 
     const controller = new AbortController();
-    this._fetchAccountDeFiPositionsControllers.push(controller);
+    if (abortable) {
+      this._fetchAccountDeFiPositionsControllers.push(controller);
+    }
 
     let accountAddress = params.accountAddress;
     let xpub = params.xpub;
@@ -266,6 +289,158 @@ class ServiceDeFi extends ServiceBase {
         allNetworksNetworkId === currentNetworkId
       ),
     };
+  }
+
+  private _buildDeFiForceRefreshKey(accountId: string, networkId: string) {
+    return `${accountId}__${networkId}`;
+  }
+
+  private _cancelDeFiForceRefresh(key: string) {
+    const timers = this._deFiForceRefreshTimers.get(key);
+    if (!timers) return;
+    timers.forEach((t) => clearTimeout(t));
+    this._deFiForceRefreshTimers.delete(key);
+  }
+
+  @backgroundMethod()
+  public async isNetworkDeFiEnabled(networkId: string): Promise<boolean> {
+    if (!networkId) return false;
+    const enabledMap = await this.getDeFiEnabledNetworksMap();
+    return !!enabledMap[networkId];
+  }
+
+  @backgroundMethod()
+  public async onLocalTxConfirmedForDeFi(
+    payload: IAppEventBusPayload[EAppEventBusNames.LocalPendingTxConfirmed],
+  ) {
+    const { accountId, indexedAccountId, networkId, status } = payload;
+
+    if (!accountId || !networkId) return;
+
+    // Failed txs do not move positions, so no force refresh needed.
+    if (status !== EDecodedTxStatus.Confirmed) return;
+
+    // Skip chains that do not support DeFi at all.
+    if (!(await this.isNetworkDeFiEnabled(networkId))) return;
+
+    const key = this._buildDeFiForceRefreshKey(accountId, networkId);
+
+    // Coalesce multiple confirmed txs: reset the schedule to the latest one.
+    this._cancelDeFiForceRefresh(key);
+
+    const maxOffset = Math.max(...this._deFiForceRefreshOffsetsMs);
+    const timers = this._deFiForceRefreshOffsetsMs.map((offset) =>
+      setTimeout(() => {
+        void this._runDeFiForceRefresh({
+          accountId,
+          indexedAccountId,
+          networkId,
+        });
+        // After the last scheduled offset fires, drop the Map entry so it
+        // does not linger once every timer has run.
+        if (offset === maxOffset) {
+          this._deFiForceRefreshTimers.delete(key);
+        }
+      }, offset),
+    );
+
+    this._deFiForceRefreshTimers.set(key, timers);
+  }
+
+  private async _runDeFiForceRefresh(params: {
+    accountId: string;
+    indexedAccountId?: string;
+    networkId: string;
+  }) {
+    const { accountId, indexedAccountId, networkId } = params;
+    try {
+      const [settings, currencyMap, accountAddress, xpub] = await Promise.all([
+        settingsPersistAtom.get(),
+        this.backgroundApi.serviceSetting.getCurrencyMap(),
+        this.backgroundApi.serviceAccount.getAccountAddressForApi({
+          accountId,
+          networkId,
+        }),
+        this.backgroundApi.serviceAccount.getAccountXpub({
+          accountId,
+          networkId,
+        }),
+      ]);
+      const sourceCurrencyInfo = currencyMap[settings.currencyInfo.id];
+      const targetCurrencyInfo = currencyMap.usd;
+
+      const resp = await this.fetchAccountDeFiPositions({
+        accountId,
+        networkId,
+        accountAddress,
+        xpub,
+        excludeLowValueProtocols: true,
+        sourceCurrencyInfo,
+        targetCurrencyInfo,
+        // Do NOT use saveToLocal here. The shared `_localDeFiOverviewCache`
+        // is keyed only by networkId and the debounced flush writes against
+        // the last `accountAddress/xpub` it sees, so concurrent background
+        // refreshes for different accounts on the same network — or a
+        // background refresh racing with a foreground UI fetch — would
+        // overwrite each other's per-account local overview. Write this
+        // single account's overview directly below instead.
+        saveToLocal: false,
+        isForceRefresh: true,
+        // Do not share the abort pool: a UI-initiated
+        // abortFetchAccountDeFiPositions() must not cancel the scheduled
+        // force refresh, which is what delivers the post-tx freshness.
+        abortable: false,
+      });
+
+      if (accountAddress || xpub) {
+        await this.updateAccountsLocalDeFiOverview({
+          accountAddress,
+          xpub,
+          overview: {
+            [networkId]: {
+              totalValue: this._fixCurrencyValue({
+                sourceCurrencyInfo,
+                targetCurrencyInfo,
+                value: resp.overview.totalValue,
+              }).toNumber(),
+              totalDebt: this._fixCurrencyValue({
+                sourceCurrencyInfo,
+                targetCurrencyInfo,
+                value: resp.overview.totalDebt,
+              }).toNumber(),
+              totalReward: this._fixCurrencyValue({
+                sourceCurrencyInfo,
+                targetCurrencyInfo,
+                value: resp.overview.totalReward,
+              }).toNumber(),
+              netWorth: this._fixCurrencyValue({
+                sourceCurrencyInfo,
+                targetCurrencyInfo,
+                value: resp.overview.netWorth,
+              }).toNumber(),
+              currency: targetCurrencyInfo?.id ?? '',
+            },
+          },
+          merge: true,
+        });
+      }
+
+      appEventBus.emit(EAppEventBusNames.DeFiPositionRefreshed, {
+        accountId,
+        indexedAccountId,
+        networkId,
+        overview: resp.overview,
+        protocols: resp.protocols,
+        protocolMap: resp.protocolMap,
+      });
+    } catch (e) {
+      // Swallow so a failed force-refresh does not block future schedules.
+      console.error(
+        '[ServiceDeFi] force refresh failed',
+        { accountId, networkId },
+        e,
+      );
+    }
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceHistory.ts
+++ b/packages/kit-bg/src/services/ServiceHistory.ts
@@ -226,6 +226,26 @@ class ServiceHistory extends ServiceBase {
       }
     }
 
+    // Notify subscribers (e.g. DeFi scheduler) that locally-pending txs
+    // submitted by this app have just transitioned to confirmed/failed.
+    // Resolve indexedAccountId so UI subscribers in All Networks mode (where
+    // the active account.id may not share a walletId with the tx's per-
+    // network accountId) can do a reliable equality match.
+    for (const tx of confirmedTxs) {
+      const txAccountId = tx.decodedTx.accountId;
+      const txDBAccount =
+        await this.backgroundApi.serviceAccount.getDBAccountSafe({
+          accountId: txAccountId,
+        });
+      appEventBus.emit(EAppEventBusNames.LocalPendingTxConfirmed, {
+        accountId: txAccountId,
+        indexedAccountId: txDBAccount?.indexedAccountId,
+        networkId: tx.decodedTx.networkId,
+        txid: tx.decodedTx.txid,
+        status: tx.decodedTx.status,
+      });
+    }
+
     // 3. Get the locally confirmed transactions
     if (isAllNetworks) {
       const allNetworksParams = accounts.map((account) => ({

--- a/packages/kit/src/components/UpdateReminder/hooks.tsx
+++ b/packages/kit/src/components/UpdateReminder/hooks.tsx
@@ -1030,10 +1030,12 @@ export const useAppUpdateInfo = (isFullModal = false, autoCheck = true) => {
       toUpdatePreviewPage,
       onViewReleaseInfo,
       checkForUpdates,
+      downloadPackage,
     };
   }, [
     appUpdateInfo,
     checkForUpdates,
+    downloadPackage,
     onUpdateAction,
     onViewReleaseInfo,
     toUpdatePreviewPage,

--- a/packages/kit/src/hooks/useAllNetwork.ts
+++ b/packages/kit/src/hooks/useAllNetwork.ts
@@ -107,12 +107,14 @@ function getAllNetworkAccountsBaseCached({
   networkId,
   networksEnabledOnly,
   excludeTestNetwork,
+  skipCache,
 }: {
   walletId: string;
   accountId: string;
   networkId: string;
   networksEnabledOnly: boolean;
   excludeTestNetwork: boolean;
+  skipCache?: boolean;
 }): {
   cacheKey: IAllNetworkAccountsBaseCacheKey;
   reused: boolean;
@@ -130,6 +132,7 @@ function getAllNetworkAccountsBaseCached({
   sweepAllNetworkAccountsBaseCache(now);
   const cached = allNetworkAccountsBaseCache.get(cacheKey);
   if (
+    !skipCache &&
     cached &&
     now - cached.createdAt < ALL_NETWORK_ACCOUNTS_BASE_CACHE_TTL_MS
   ) {
@@ -317,6 +320,7 @@ function useAllNetworkRequests<T>(params: {
     triggerByDeps?: boolean;
     pollingNonce?: number;
     alwaysSetState?: boolean;
+    skipAccountsCache?: boolean;
   };
   const {
     accountId: currentAccountId,
@@ -352,6 +356,11 @@ function useAllNetworkRequests<T>(params: {
   const runWithQueueRef = useRef<
     ((config?: IAllNetworkRequestsRunConfig) => Promise<void>) | undefined
   >(undefined);
+  // Single-shot signal that the next run should bypass the all-network
+  // accounts base cache. usePromiseResult does not forward the runner config
+  // into the method body, so we relay it through this ref and consume it
+  // inside the runner.
+  const skipAccountsCacheRef = useRef(false);
 
   useEffect(() => {
     const onEnabledNetworksChanged = () => {
@@ -375,6 +384,41 @@ function useAllNetworkRequests<T>(params: {
       );
     };
   }, [isAllNetworks]);
+
+  // Hardware wallets create default network accounts in series after connect
+  // (BTC -> EVM -> TRON -> SOL). The 15s account-list cache can otherwise
+  // capture a half-formed snapshot that contains only the first impl, which
+  // makes Spot show only BTC and DeFi filter to an empty network set.
+  // Invalidate this wallet's entries on every batch so the next run picks up
+  // the latest DB account set. allNetworkDataInit stays as-is to avoid
+  // clearAllNetworkData wiping the visible list between batches.
+  useEffect(() => {
+    if (!isAllNetworks) return;
+    if (!currentWalletId) return;
+    const walletIdAtSubscribe = currentWalletId;
+    const onAddDBAccounts = (payload?: { walletId: string }) => {
+      if (!payload?.walletId) return;
+      if (payload.walletId !== walletIdAtSubscribe) return;
+      const prefix = `${walletIdAtSubscribe}::`;
+      for (const key of Array.from(allNetworkAccountsBaseCache.keys())) {
+        if (key.startsWith(prefix)) {
+          allNetworkAccountsBaseCache.delete(key);
+        }
+      }
+      // alwaysSetState forces the runner past usePromiseResult's focus
+      // check, otherwise the refresh is dropped when the consuming tab
+      // (e.g. DeFi) is mounted but not the active tab during the HW connect
+      // batch — the cache would be cleared but no fetch would actually run.
+      void runWithQueueRef.current?.({
+        skipAccountsCache: true,
+        alwaysSetState: true,
+      });
+    };
+    appEventBus.on(EAppEventBusNames.AddDBAccountsToWallet, onAddDBAccounts);
+    return () => {
+      appEventBus.off(EAppEventBusNames.AddDBAccountsToWallet, onAddDBAccounts);
+    };
+  }, [isAllNetworks, currentWalletId]);
 
   useEffect(() => {
     if (currentAccountId && currentNetworkId && currentWalletId) {
@@ -428,6 +472,9 @@ function useAllNetworkRequests<T>(params: {
       runCountRef.current += 1;
       isFetching.current = true;
 
+      let onStartedError: unknown;
+      let onStartedTask: Promise<void> | undefined;
+
       try {
         if (!allNetworkDataInit.current) {
           clearAllNetworkData();
@@ -441,8 +488,6 @@ function useAllNetworkRequests<T>(params: {
           allNetworkDataInit: !!allNetworkDataInit.current,
         });
 
-        let onStartedError: unknown;
-        let onStartedTask: Promise<void> | undefined;
         if (onStarted) {
           onStartedTask = onStarted({
             accountId: currentAccountId,
@@ -464,12 +509,16 @@ function useAllNetworkRequests<T>(params: {
           accountId: currentAccountId,
         });
 
+        const skipAccountsCacheForThisRun = skipAccountsCacheRef.current;
+        skipAccountsCacheRef.current = false;
+
         const { promise: accountsTask } = getAllNetworkAccountsBaseCached({
           walletId: currentWalletId,
           accountId: currentAccountId,
           networkId: currentNetworkId,
           excludeTestNetwork: true,
           networksEnabledOnly,
+          skipCache: skipAccountsCacheForThisRun,
         });
 
         const deFiEnabledNetworksMapTask = isDeFiRequests
@@ -729,14 +778,33 @@ function useAllNetworkRequests<T>(params: {
         if (accountsInfo.length && accountsInfo.length > 0) {
           allNetworkDataInit.current = true;
         }
-        await onFinished?.({
-          accountId: currentAccountId,
-          networkId: currentNetworkId,
-        });
 
         return resp;
       } finally {
         isFetching.current = false;
+        // Wait for onStarted to settle before firing onFinished, so
+        // the started/finished events for this run land in monotonic
+        // order (true -> false). Without this, an early throw above
+        // can fire onFinished while onStarted is still in flight,
+        // letting a stale "isRefreshing: true" arrive after "false".
+        if (onStartedTask) {
+          try {
+            await onStartedTask;
+          } catch (e) {
+            console.error(e);
+          }
+        }
+        // Fire onFinished from finally so the "isRefreshing: false" signal
+        // (consumed by DeFi tab's runAfterTokensDone) is always emitted —
+        // even when the work above threw before reaching the prior call site.
+        try {
+          await onFinished?.({
+            accountId: currentAccountId,
+            networkId: currentNetworkId,
+          });
+        } catch (e) {
+          console.error(e);
+        }
         if (rerunAfterCurrentRef.current) {
           rerunAfterCurrentRef.current = false;
           const rerunConfig = rerunConfigRef.current;
@@ -783,8 +851,14 @@ function useAllNetworkRequests<T>(params: {
           alwaysSetState:
             !!rerunConfigRef.current?.alwaysSetState ||
             !!config?.alwaysSetState,
+          skipAccountsCache:
+            !!rerunConfigRef.current?.skipAccountsCache ||
+            !!config?.skipAccountsCache,
         };
         return;
+      }
+      if (config?.skipAccountsCache) {
+        skipAccountsCacheRef.current = true;
       }
       await run(config);
     },

--- a/packages/kit/src/provider/Bootstrap.tsx
+++ b/packages/kit/src/provider/Bootstrap.tsx
@@ -27,6 +27,7 @@ import {
 import {
   EAppUpdateStatus,
   EUpdateFileType,
+  EUpdateStrategy,
   getUpdateFileType,
 } from '@onekeyhq/shared/src/appUpdate';
 import {
@@ -71,7 +72,10 @@ import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import backgroundApiProxy from '../background/instance/backgroundApiProxy';
 import { AccountSelectorProviderMirror } from '../components/AccountSelector';
-import { useAppUpdateInfo } from '../components/UpdateReminder/hooks';
+import {
+  isAutoUpdateStrategy,
+  useAppUpdateInfo,
+} from '../components/UpdateReminder/hooks';
 import useAppNavigation from '../hooks/useAppNavigation';
 import { useOnLock } from '../hooks/useOnLock';
 import { useRunAfterTokensDone } from '../hooks/useRunAfterTokensDone';
@@ -97,10 +101,8 @@ const useDesktopEvents = platformEnv.isDesktop
       const useOnLockRef = useRef(onLock);
       useOnLockRef.current = onLock;
 
-      const { checkForUpdates, onUpdateAction } = useAppUpdateInfoCallback(
-        false,
-        false,
-      );
+      const { checkForUpdates, downloadPackage, onUpdateAction } =
+        useAppUpdateInfoCallback(false, false);
       const isCheckingUpdate = useRef(false);
 
       const onCheckUpdate = useCallback(async () => {
@@ -110,7 +112,26 @@ const useDesktopEvents = platformEnv.isDesktop
         }
         isCheckingUpdate.current = true;
         const { isNeedUpdate, response } = await checkForUpdates();
-        if (isNeedUpdate || response === undefined) {
+        // OTA (silent/seamless) updates download/install transparently in
+        // the background. The desktop menu "Check for updates" must not open
+        // the download/verify UI for these strategies — that breaks the
+        // silent/seamless contract. Instead, kick off the background
+        // download silently (the auto useEffect only runs once at startup,
+        // so mid-session OTA discovery would otherwise stall) and show the
+        // "up to date" dialog as user feedback. The auto useEffect still
+        // drives any user-visible install dialog when status === ready.
+        const isOtaStrategy =
+          response &&
+          isAutoUpdateStrategy(
+            response.updateStrategy ?? EUpdateStrategy.manual,
+          );
+        if (isNeedUpdate && isOtaStrategy) {
+          // serviceAppUpdate.downloadPackage() inside this hook gates on
+          // DOWNLOAD_ENTRY_STATUSES, so calling it while already in-flight
+          // is a safe no-op. Fire-and-forget — we don't await the download.
+          void downloadPackage?.();
+        }
+        if ((isNeedUpdate && !isOtaStrategy) || response === undefined) {
           onUpdateAction();
           isCheckingUpdate.current = false;
         } else {
@@ -131,7 +152,7 @@ const useDesktopEvents = platformEnv.isDesktop
             }),
           });
         }
-      }, [checkForUpdates, intl, onUpdateAction]);
+      }, [checkForUpdates, downloadPackage, intl, onUpdateAction]);
 
       const onCheckUpdateRef = useRef(onCheckUpdate);
       onCheckUpdateRef.current = onCheckUpdate;

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
@@ -702,7 +702,10 @@ function DeFiListBlock({
   });
 
   const handleRefreshAllNetworkData = useCallback(() => {
-    void runAllNetworkRequests({ alwaysSetState: true });
+    void runAllNetworkRequests({
+      alwaysSetState: true,
+      skipAccountsCache: true,
+    });
   }, [runAllNetworkRequests]);
 
   useEffect(() => {

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
@@ -42,6 +42,7 @@ import {
   POLLING_DEBOUNCE_INTERVAL,
   POLLING_INTERVAL_FOR_DEFI,
 } from '@onekeyhq/shared/src/consts/walletConsts';
+import type { IAppEventBusPayload } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -157,6 +158,10 @@ function DeFiListBlock({
   const isRefreshingRef = useRef(isRefreshing);
   initializedRef.current = initialized;
   isRefreshingRef.current = isRefreshing;
+  const protocolsRef = useRef(protocols);
+  const protocolMapRef = useRef(protocolMap);
+  protocolsRef.current = protocols;
+  protocolMapRef.current = protocolMap;
   const pendingRefreshRef = useRef(false);
 
   const [isSliced, setIsSliced] = useDeFiListSlicedAtom();
@@ -882,6 +887,117 @@ function DeFiListBlock({
       appEventBus.off(EAppEventBusNames.NetworkDeriveTypeChanged, onRefresh);
     };
   }, [isFocused, network?.isAllNetworks, handleRefreshAllNetworkData, run]);
+
+  useEffect(() => {
+    const onDeFiPositionRefreshed = (
+      payload: IAppEventBusPayload[EAppEventBusNames.DeFiPositionRefreshed],
+    ) => {
+      if (refreshCacheOnly) return;
+      if (!account?.id || !network?.id) return;
+
+      // Prefer indexedAccountId equality (robust for All Networks mode);
+      // fall back to a strict accountId match for accounts without an
+      // indexed id (imported / watching-only / external). A walletId-only
+      // compare is unsafe for those types because they all share a single
+      // wallet bucket (`imported`, `watching`, `external`) — distinct
+      // accounts inside the same bucket would otherwise leak each other's
+      // refreshed positions into the current view.
+      const currentIndexedId = account.indexedAccountId;
+      const payloadIndexedId = payload.indexedAccountId;
+      if (currentIndexedId && payloadIndexedId) {
+        if (currentIndexedId !== payloadIndexedId) return;
+      } else if (payload.accountId !== account.id) {
+        return;
+      }
+
+      if (!network.isAllNetworks) {
+        if (
+          payload.accountId !== account.id ||
+          payload.networkId !== network.id
+        ) {
+          return;
+        }
+        updateAccountDeFiOverview({
+          currency: settings.currencyInfo.id,
+          accountId: account.id,
+          networkId: network.id,
+          overview: {
+            totalValue: payload.overview.totalValue,
+            totalDebt: payload.overview.totalDebt,
+            totalReward: payload.overview.totalReward,
+            netWorth: payload.overview.netWorth,
+          },
+          isReady: true,
+        });
+        updateDeFiListProtocols({ protocols: payload.protocols });
+        updateDeFiListProtocolMap({ protocolMap: payload.protocolMap });
+        updateDeFiListState({ initialized: true, isRefreshing: false });
+        return;
+      }
+
+      // All Networks: drop this network's old entries and splice in the
+      // refreshed ones. Aggregated overview is recomputed from the merged
+      // protocolMap so the header total stays in sync.
+      const prefix = `${payload.networkId}-`;
+      const nextProtocols = protocolsRef.current
+        .filter((p) => p.networkId !== payload.networkId)
+        .concat(payload.protocols);
+
+      const nextProtocolMap: Record<string, IProtocolSummary> = {};
+      for (const [k, v] of Object.entries(protocolMapRef.current)) {
+        if (!k.startsWith(prefix)) nextProtocolMap[k] = v;
+      }
+      Object.assign(nextProtocolMap, payload.protocolMap);
+
+      let totalValueBN = new BigNumber(0);
+      let totalDebtBN = new BigNumber(0);
+      let totalRewardBN = new BigNumber(0);
+      let netWorthBN = new BigNumber(0);
+      for (const s of Object.values(nextProtocolMap)) {
+        totalValueBN = totalValueBN.plus(s.totalValue ?? 0);
+        totalDebtBN = totalDebtBN.plus(s.totalDebt ?? 0);
+        totalRewardBN = totalRewardBN.plus(s.totalReward ?? 0);
+        netWorthBN = netWorthBN.plus(s.netWorth ?? 0);
+      }
+
+      updateDeFiListProtocols({ protocols: nextProtocols });
+      updateDeFiListProtocolMap({ protocolMap: nextProtocolMap });
+      updateAccountDeFiOverview({
+        currency: settings.currencyInfo.id,
+        accountId: account.id,
+        networkId: network.id,
+        overview: {
+          totalValue: totalValueBN.toNumber(),
+          totalDebt: totalDebtBN.toNumber(),
+          totalReward: totalRewardBN.toNumber(),
+          netWorth: netWorthBN.toNumber(),
+        },
+        isReady: true,
+      });
+    };
+
+    appEventBus.on(
+      EAppEventBusNames.DeFiPositionRefreshed,
+      onDeFiPositionRefreshed,
+    );
+    return () => {
+      appEventBus.off(
+        EAppEventBusNames.DeFiPositionRefreshed,
+        onDeFiPositionRefreshed,
+      );
+    };
+  }, [
+    account?.id,
+    account?.indexedAccountId,
+    network?.id,
+    network?.isAllNetworks,
+    refreshCacheOnly,
+    settings.currencyInfo.id,
+    updateAccountDeFiOverview,
+    updateDeFiListProtocols,
+    updateDeFiListProtocolMap,
+    updateDeFiListState,
+  ]);
 
   useEffect(() => {
     if (allNetworksResult) {

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -2075,7 +2075,10 @@ function TokenListBlock({
 
   const handleRefreshAllNetworkData = useCallback(() => {
     isAllNetworkManualRefresh.current = true;
-    void runAllNetworksRequests({ alwaysSetState: true });
+    void runAllNetworksRequests({
+      alwaysSetState: true,
+      skipAccountsCache: true,
+    });
   }, [runAllNetworksRequests]);
 
   const lastVisibilityRefreshAtRef = useRef(0);

--- a/packages/kit/src/views/Swap/components/SwapServiceFeeOverview.tsx
+++ b/packages/kit/src/views/Swap/components/SwapServiceFeeOverview.tsx
@@ -1,6 +1,6 @@
 import { useIntl } from 'react-intl';
 
-import { Icon, Popover, SizableText, Stack } from '@onekeyhq/components';
+import { Icon, Popover, SizableText } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 export function SwapServiceFeeOverview(_props: {
@@ -22,18 +22,11 @@ export function SwapServiceFeeOverview(_props: {
         />
       }
       renderContent={
-        <Stack gap="$1" p="$4">
-          <SizableText size="$bodyMd" color="$textSubdued">
-            {intl.formatMessage({
-              id: ETranslations.provider_popover_onekey_fee_content_nofee,
-            })}
-          </SizableText>
-          <SizableText size="$bodyMd" color="$textSubdued">
-            {intl.formatMessage({
-              id: ETranslations.provider_ios_popover_onekey_fee_content_2,
-            })}
-          </SizableText>
-        </Stack>
+        <SizableText p="$4" size="$bodyMd" color="$textSubdued">
+          {intl.formatMessage({
+            id: ETranslations.provider_popover_onekey_fee_content_nofee,
+          })}
+        </SizableText>
       }
     />
   );

--- a/packages/kit/src/views/Swap/components/SwapServiceFeeOverview.tsx
+++ b/packages/kit/src/views/Swap/components/SwapServiceFeeOverview.tsx
@@ -1,23 +1,13 @@
-import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
 import { Icon, Popover, SizableText, Stack } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { swapServiceFeeDefault } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
 
-export function SwapServiceFeeOverview({
-  percentageFee,
-  percentOriginFee,
-}: {
+export function SwapServiceFeeOverview(_props: {
   percentageFee?: number;
   percentOriginFee?: number;
 }) {
   const intl = useIntl();
-  const displayFee =
-    typeof percentageFee === 'number' &&
-    new BigNumber(percentageFee).lt(percentOriginFee ?? swapServiceFeeDefault)
-      ? (percentOriginFee ?? swapServiceFeeDefault)
-      : (percentageFee ?? swapServiceFeeDefault);
   return (
     <Popover
       title={intl.formatMessage({
@@ -34,14 +24,9 @@ export function SwapServiceFeeOverview({
       renderContent={
         <Stack gap="$1" p="$4">
           <SizableText size="$bodyMd" color="$textSubdued">
-            {intl.formatMessage(
-              {
-                id: ETranslations.provider_popover_onekey_fee_content,
-              },
-              {
-                number: `${displayFee}%`,
-              },
-            )}
+            {intl.formatMessage({
+              id: ETranslations.provider_popover_onekey_fee_content_nofee,
+            })}
           </SizableText>
           <SizableText size="$bodyMd" color="$textSubdued">
             {intl.formatMessage({

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -25,6 +25,11 @@ import platformEnv, { ERuntimeRole } from '../platformEnv';
 import { EAppEventBusNames } from './appEventBusNames';
 
 import type { EAccountSelectorSceneName, EHomeTab } from '../../types';
+import type {
+  IDeFiProtocol,
+  IFetchAccountDeFiPositionsResp,
+  IProtocolSummary,
+} from '../../types/defi';
 import type { IFeeSelectorItem } from '../../types/fee';
 import type { ESubscriptionType } from '../../types/hyperliquid/types';
 import type {
@@ -43,6 +48,7 @@ import type {
   ISwapTokenBase,
 } from '../../types/swap/types';
 import type { IAccountToken, ITokenFiat } from '../../types/token';
+import type { EDecodedTxStatus } from '../../types/tx';
 import type { EHomeWalletTab } from '../../types/wallet';
 import type { IOneKeyError } from '../errors/types/errorTypes';
 import type { EModalRoutes, ETabRoutes } from '../routes';
@@ -235,6 +241,21 @@ export interface IAppEventBusPayload {
   [EAppEventBusNames.CloseHardwareUiStateDialogManually]: undefined;
   [EAppEventBusNames.HardCloseHardwareUiStateDialog]: undefined;
   [EAppEventBusNames.HistoryTxStatusChanged]: undefined;
+  [EAppEventBusNames.LocalPendingTxConfirmed]: {
+    accountId: string;
+    indexedAccountId?: string;
+    networkId: string;
+    txid: string;
+    status: EDecodedTxStatus;
+  };
+  [EAppEventBusNames.DeFiPositionRefreshed]: {
+    accountId: string;
+    indexedAccountId?: string;
+    networkId: string;
+    overview: IFetchAccountDeFiPositionsResp['data']['totals'];
+    protocols: IDeFiProtocol[];
+    protocolMap: Record<string, IProtocolSummary>;
+  };
   [EAppEventBusNames.EstimateTxFeeRetry]: undefined;
   [EAppEventBusNames.GasAccountSubmitRetryScheduled]: {
     attempt: number;

--- a/packages/shared/src/eventBus/appEventBusNames.ts
+++ b/packages/shared/src/eventBus/appEventBusNames.ts
@@ -55,6 +55,8 @@ export enum EAppEventBusNames {
   CloseHardwareUiStateDialogManually = 'CloseHardwareUiStateDialogManually',
   HardCloseHardwareUiStateDialog = 'CloseHardwareUiStateDialog',
   HistoryTxStatusChanged = 'HistoryTxStatusChanged',
+  LocalPendingTxConfirmed = 'LocalPendingTxConfirmed',
+  DeFiPositionRefreshed = 'DeFiPositionRefreshed',
   EstimateTxFeeRetry = 'estimateTxFeeRetry',
   GasAccountSubmitRetryScheduled = 'gasAccountSubmitRetryScheduled',
   GasAccountSubmitRetryCleared = 'gasAccountSubmitRetryCleared',

--- a/packages/shared/types/defi.ts
+++ b/packages/shared/types/defi.ts
@@ -14,6 +14,10 @@ export type IFetchAccountDeFiPositionsParams = {
   sourceCurrencyInfo?: ICurrencyItem;
   targetCurrencyInfo?: ICurrencyItem;
   isForceRefresh?: boolean;
+  // When false, the request is NOT registered with the shared abort pool and
+  // will not be cancelled by abortFetchAccountDeFiPositions(). Use for
+  // background schedulers whose fetches should survive UI-initiated aborts.
+  abortable?: boolean;
 };
 
 export enum EDeFiAssetType {


### PR DESCRIPTION
Sync bundle release commits from `release/v6.2.0` (post release #2) to `x`.

## Synced commits

- #11357 perf(defi): force-refresh positions at +40s/+80s after local tx confirms (OK-53474)
- #11383 fix(home): refresh all-net accounts on HW batch (OK-53863 OK-53864)
- #11402 fix: update provider fee content i18n
- #11412 fix(swap): remove duplicate gas fee paragraph in service fee tooltip
- #11390 fix(desktop): skip download UI for OTA updates from menu check

## Skipped

- #11320 fix(appUpdate): detect Google Play flavor via Nitro registry (backport #11303 to v6.2.0) — empty cherry-pick; `x` already contains the Nitro probe and has evolved further with a `react-native-device-utils.getAndroidChannel()` preferred path, so the backport adds nothing.

## Excluded from sync

- `RELEASES.json` (release-branch-only)
- `.env.version` BUILD_NUMBER bump
- `chore: release #1 / #2` tracking commits (already squashed into x via #11388)

## Conflict resolutions

- `packages/kit-bg/src/services/ServiceDeFi.ts` — drop legacy `@onekeyhq/kit/src/views/Setting/pages/Currency` import (kit-bg → kit hierarchy violation; `ICurrencyItem` already moved to `@onekeyhq/shared/types/currency` on x). Keep the new `settingsPersistAtom` import needed by the cherry-picked body.
- `packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx` — keep x's `useSettingsValuePersistAtom()` call (used by `hideValue` later in the file).
- `packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx` — keep x's visibility-refresh + `AddDBAccountsToWallet` subscription block (release commit's actual change lands below this section).
- `packages/kit/src/provider/Bootstrap.tsx` — merge imports: keep both `AccountSelectorProviderMirror` (x-only) and `{ isAutoUpdateStrategy, useAppUpdateInfo }` from `UpdateReminder/hooks` (release adds `isAutoUpdateStrategy`, used by the cherry-picked body).
- `packages/shared/src/androidNativeEnv.android.ts` + `development/spellCheckerSkipWords.txt` — keep x (already includes everything from #11320 and more).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->