### PR TITLE
chore: sync release/v6.2.0 (#4) to x

### DIFF
--- a/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts
+++ b/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts
@@ -1221,6 +1221,36 @@ class ServiceHardware extends ServiceBase {
   }
 
   @backgroundMethod()
+  async checkDeviceReachableForFirmwareUpdate(params: { connectId: string }) {
+    const dbDevice = await localDb.getDeviceByQuery({
+      connectId: params.connectId,
+    });
+    if (!dbDevice) {
+      // Onboarding / bootloader-mode flows hit this with a freshly-discovered
+      // device that has no local DB record yet — skip pre-flight and let the
+      // update modal proceed.
+      return;
+    }
+    const compatibleConnectId = await this.getCompatibleConnectId({
+      connectId: params.connectId,
+      featuresDeviceId: dbDevice.deviceId,
+      hardwareCallContext: EHardwareCallContext.UPDATE_FIRMWARE,
+    });
+    return this.backgroundApi.serviceHardwareUI.withHardwareProcessing(
+      () =>
+        this.getFeaturesWithoutCache({
+          connectId: compatibleConnectId,
+          params: { retryCount: 1 },
+        }),
+      {
+        deviceParams: {
+          dbDevice,
+        },
+      },
+    );
+  }
+
+  @backgroundMethod()
   async getPassphraseState({
     connectId,
     forceInputPassphrase,

--- a/packages/kit/src/provider/Container/HardwareUiStateContainer/HardwareUiStateContainer.tsx
+++ b/packages/kit/src/provider/Container/HardwareUiStateContainer/HardwareUiStateContainer.tsx
@@ -781,7 +781,7 @@ function HardwareUiStateContainerCmpControlled() {
 
         hardwareErrorDialogInstanceRef.current = Dialog.show({
           title: intl.formatMessage({
-            id: ETranslations.communication_timeout,
+            id: ETranslations.device_not_connected,
           }),
           description: intl.formatMessage({
             id: ETranslations.troubleshooting_show_helper_cta_label,

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -33,6 +33,7 @@ import type {
   IFetchTokensParams,
   ISwapAlertActionData,
   ISwapAlertState,
+  ISwapLimitPriceInfo,
   ISwapNetwork,
   ISwapQuoteEvent,
   ISwapQuoteEventAutoSlippage,
@@ -118,12 +119,42 @@ import {
   isSwapQuoteEventFetching,
 } from './quoteProgress';
 
+function getSelectedPairLimitPriceRate({
+  protocol,
+  limitPriceUseRate,
+  fromToken,
+  toToken,
+}: {
+  protocol: ESwapTabSwitchType;
+  limitPriceUseRate: ISwapLimitPriceInfo;
+  fromToken?: ISwapToken;
+  toToken?: ISwapToken;
+}) {
+  if (protocol !== ESwapTabSwitchType.LIMIT || !limitPriceUseRate.rate) {
+    return undefined;
+  }
+
+  const isSelectedPair =
+    equalTokenNoCaseSensitive({
+      token1: limitPriceUseRate.fromToken,
+      token2: fromToken,
+    }) &&
+    equalTokenNoCaseSensitive({
+      token1: limitPriceUseRate.toToken,
+      token2: toToken,
+    });
+
+  return isSelectedPair ? limitPriceUseRate.rate : undefined;
+}
+
 class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
   private quoteInterval: ReturnType<typeof setTimeout> | undefined;
 
   private limitOrderMarketPriceInterval:
     | ReturnType<typeof setTimeout>
     | undefined;
+
+  private limitOrderMarketPriceRequestId = 0;
 
   /**
    * Execute promises in batches with concurrency control to prevent overwhelming the system
@@ -524,6 +555,12 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         const limitPartiallyFillable = limitPartiallyFillableObj.value;
         const expirationTime = get(swapLimitExpirationTimeAtom());
         const limitUserMarketPrice = get(swapLimitPriceUseRateAtom());
+        const userMarketPriceRate = getSelectedPairLimitPriceRate({
+          protocol,
+          limitPriceUseRate: limitUserMarketPrice,
+          fromToken,
+          toToken,
+        });
         const res = await backgroundApiProxy.serviceSwap.fetchQuotes({
           fromToken,
           toToken,
@@ -538,7 +575,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
           incognito: incognitoEnabled,
           accountId,
           protocol,
-          userMarketPriceRate: limitUserMarketPrice.rate,
+          userMarketPriceRate,
           ...(protocol === ESwapTabSwitchType.LIMIT
             ? {
                 expirationTime: Number(expirationTime.value),
@@ -862,6 +899,12 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       set(swapQuoteFetchingAtom(), true);
       set(swapQuoteEventCompletedAtom(), false);
       const limitUserMarketPrice = get(swapLimitPriceUseRateAtom());
+      const userMarketPriceRate = getSelectedPairLimitPriceRate({
+        protocol,
+        limitPriceUseRate: limitUserMarketPrice,
+        fromToken,
+        toToken,
+      });
       await backgroundApiProxy.serviceSwap.fetchQuotesEvents({
         fromToken,
         toToken,
@@ -876,7 +919,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         protocol,
         receivingAddress,
         incognito: incognitoEnabled,
-        userMarketPriceRate: limitUserMarketPrice.rate,
+        userMarketPriceRate,
         ...(protocol === ESwapTabSwitchType.LIMIT
           ? {
               expirationTime: Number(expirationTime.value),
@@ -1148,6 +1191,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
   });
 
   cleanLimitOrderMarketPriceInterval = () => {
+    this.limitOrderMarketPriceRequestId += 1;
     if (this.limitOrderMarketPriceInterval) {
       clearInterval(this.limitOrderMarketPriceInterval);
       this.limitOrderMarketPriceInterval = undefined;
@@ -2285,7 +2329,13 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
   );
 
   limitMarketPriceRun = contextAtomMethod(
-    async (get, set, fromToken?: ISwapToken, toToken?: ISwapToken) => {
+    async (
+      get,
+      set,
+      fromToken?: ISwapToken,
+      toToken?: ISwapToken,
+      requestId?: number,
+    ) => {
       try {
         if (fromToken && toToken) {
           const { fromTokenPrice, toTokenPrice } =
@@ -2293,6 +2343,9 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
               fromToken,
               toToken,
             });
+          if (requestId !== this.limitOrderMarketPriceRequestId) {
+            return;
+          }
           const fromTokenPriceInfo = {
             tokenInfo: fromToken,
             price: fromTokenPrice || (fromToken.price ?? ''),
@@ -2310,6 +2363,9 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       } catch (error) {
         console.error(error);
       }
+      if (requestId !== this.limitOrderMarketPriceRequestId) {
+        return;
+      }
       this.limitOrderMarketPriceInterval = setTimeout(() => {
         void this.limitOrderMarketPriceIntervalAction.call(
           set,
@@ -2322,6 +2378,8 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
 
   limitOrderMarketPriceIntervalAction = contextAtomMethod(
     async (get, set, fromToken?: ISwapToken, toToken?: ISwapToken) => {
+      this.limitOrderMarketPriceRequestId += 1;
+      const requestId = this.limitOrderMarketPriceRequestId;
       if (this.limitOrderMarketPriceInterval) {
         clearInterval(this.limitOrderMarketPriceInterval);
       }
@@ -2334,7 +2392,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         set(limitOrderMarketPriceAtom(), {});
         return;
       }
-      await this.limitMarketPriceRun.call(set, fromToken, toToken);
+      await this.limitMarketPriceRun.call(set, fromToken, toToken, requestId);
     },
   );
 

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/FirmwareUpdateGallery.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/FirmwareUpdateGallery.tsx
@@ -61,7 +61,7 @@ function ForceOpenHomeDeviceUpdateFirmwareModal() {
   return (
     <Button
       onPress={async () => {
-        actions.openChangeLogModal({ connectId });
+        await actions.openChangeLogModal({ connectId });
       }}
     >
       NormalModeUpdate

--- a/packages/kit/src/views/DeviceManagement/pages/DeviceDetailsModal/DeviceUpdateAlert.tsx
+++ b/packages/kit/src/views/DeviceManagement/pages/DeviceDetailsModal/DeviceUpdateAlert.tsx
@@ -27,7 +27,7 @@ export function DeviceUpdateAlert({ type }: { type?: 'top' | 'bottom' }) {
 
   const actions = useFirmwareUpdateActions();
   const openChangeLogModalCallback = useCallback(() => {
-    actions.openChangeLogModal({ connectId: deviceConnectId });
+    void actions.openChangeLogModal({ connectId: deviceConnectId });
   }, [actions, deviceConnectId]);
 
   const detectResult = useMemo(() => {

--- a/packages/kit/src/views/DeviceManagement/pages/DeviceDetailsModal/index.tsx
+++ b/packages/kit/src/views/DeviceManagement/pages/DeviceDetailsModal/index.tsx
@@ -100,7 +100,7 @@ function DeviceDetailsModalV2Cmp({ walletId }: { walletId: string }) {
     ) => {
       const walletWithDevice = await localActions.getWalletWithDevice();
       if (!walletWithDevice) return;
-      actions.openChangeLogModal({
+      await actions.openChangeLogModal({
         connectId: walletWithDevice.device?.connectId,
         firmwareType,
         baseReleaseInfo,

--- a/packages/kit/src/views/FirmwareUpdate/components/HomeFirmwareUpdateReminder.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/components/HomeFirmwareUpdateReminder.tsx
@@ -14,7 +14,6 @@ import {
 } from '@onekeyhq/components';
 import { useFirmwareUpdatesDetectStatusPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import deviceUtils from '@onekeyhq/shared/src/utils/deviceUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
@@ -22,7 +21,7 @@ import { AccountSelectorProviderMirror } from '../../../components/AccountSelect
 import useAppNavigation from '../../../hooks/useAppNavigation';
 import { usePromiseResult } from '../../../hooks/usePromiseResult';
 import { useActiveAccount } from '../../../states/jotai/contexts/accountSelector';
-import { useFirmwareUpdateActions } from '../hooks/useFirmwareUpdateActions';
+import { useDeviceManagerNavigation } from '../../DeviceManagement/hooks/useDeviceManagerNavigation';
 
 import { BootloaderModeUpdateReminder } from './BootloaderModeUpdateReminder';
 import { HomeFirmwareUpdateDetect } from './HomeFirmwareUpdateDetect';
@@ -83,7 +82,7 @@ function HomeFirmwareUpdateReminderCmp() {
   const intl = useIntl();
   const { activeAccount } = useActiveAccount({ num: 0 });
   const connectId = activeAccount.device?.connectId;
-  const actions = useFirmwareUpdateActions();
+  const { pushToDeviceList } = useDeviceManagerNavigation();
   const { closePopover } = usePopoverContext();
   const { closeTooltip } = useTooltipContext();
   const [detectStatus] = useFirmwareUpdatesDetectStatusPersistAtom();
@@ -111,28 +110,9 @@ function HomeFirmwareUpdateReminderCmp() {
 
   const updateButton = useMemo(() => {
     if (result?.shouldUpdate) {
-      let message = 'New firmware is available';
-      if (result?.detectResult?.toVersion) {
-        const firmwareTypeLabel =
-          deviceUtils.getFirmwareTypeLabelByFirmwareType({
-            firmwareType: result?.detectResult?.toFirmwareType,
-            displayFormat: 'withSpace',
-          });
-        const version = `${firmwareTypeLabel}${result?.detectResult?.toVersion}`;
-        message = intl.formatMessage(
-          { id: ETranslations.update_firmware_version_available },
-          {
-            version,
-          },
-        );
-      } else if (result?.detectResult?.toVersionBle) {
-        message = intl.formatMessage(
-          { id: ETranslations.update_bluetooth_version_available },
-          {
-            version: result?.detectResult?.toVersionBle,
-          },
-        );
-      }
+      const message = intl.formatMessage({
+        id: ETranslations.update_firmware_available,
+      });
       return (
         <FirmwareUpdateReminderAlert
           containerProps={{
@@ -147,7 +127,7 @@ function HomeFirmwareUpdateReminderCmp() {
           onPress={async () => {
             await closePopover?.();
             await closeTooltip?.();
-            actions.openChangeLogModal({ connectId });
+            pushToDeviceList();
           }}
         />
       );
@@ -155,14 +135,10 @@ function HomeFirmwareUpdateReminderCmp() {
     return null;
   }, [
     result?.shouldUpdate,
-    result?.detectResult?.toVersion,
-    result?.detectResult?.toVersionBle,
-    result?.detectResult?.toFirmwareType,
     intl,
     closePopover,
     closeTooltip,
-    actions,
-    connectId,
+    pushToDeviceList,
   ]);
 
   if (!updateButton) {

--- a/packages/kit/src/views/FirmwareUpdate/hooks/useFirmwareUpdateActions.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/hooks/useFirmwareUpdateActions.tsx
@@ -76,7 +76,7 @@ export function useFirmwareUpdateActions() {
   appGlobals.$$appEventBus.emit('ShowFirmwareUpdateForce',{ connectId: '3383' })
   */
   const openChangeLogModal = useCallback(
-    ({
+    async ({
       connectId,
       firmwareType,
       baseReleaseInfo,
@@ -98,6 +98,16 @@ export function useFirmwareUpdateActions() {
           window.close();
         }
         return;
+      }
+
+      if (connectId) {
+        try {
+          await backgroundApiProxy.serviceHardware.checkDeviceReachableForFirmwareUpdate(
+            { connectId },
+          );
+        } catch {
+          return;
+        }
       }
 
       if (rootNavigationRef.current) {
@@ -167,7 +177,7 @@ export function useFirmwareUpdateActions() {
         // Only open modal if USB preparation succeeded (finalConnectId is defined)
         // If undefined, it means USB is not available and a dialog was already shown
         if (finalConnectId !== undefined) {
-          openChangeLogModal({ connectId: finalConnectId });
+          await openChangeLogModal({ connectId: finalConnectId });
         }
       };
 
@@ -224,7 +234,7 @@ export function useFirmwareUpdateActions() {
         }),
         dismissOnOverlayPress: false,
         onConfirm: async () => {
-          openChangeLogModal({ connectId });
+          await openChangeLogModal({ connectId });
         },
         onConfirmText: intl.formatMessage({
           id: ETranslations.update_update_now,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useMarketSwapReviewActions.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useMarketSwapReviewActions.test.tsx
@@ -187,6 +187,9 @@ describe('useMarketSwapReviewActions', () => {
                 status: ESwapStepStatus.READY,
               },
             ],
+            preSwapData: {
+              stepBeforeActionsError: true,
+            },
           }),
         ),
       },
@@ -214,6 +217,9 @@ describe('useMarketSwapReviewActions', () => {
     expect(result.current.swapSteps.preSwapData.stepBeforeActionsLoading).toBe(
       false,
     );
+    expect(
+      result.current.swapSteps.preSwapData.stepBeforeActionsError,
+    ).toBeUndefined();
   });
 
   it('starts a send step through the market speed swap adapter', async () => {
@@ -508,6 +514,9 @@ describe('useMarketSwapReviewActions', () => {
 
     expect(result.current.swapSteps.preSwapData.stepBeforeActionsLoading).toBe(
       false,
+    );
+    expect(result.current.swapSteps.preSwapData.stepBeforeActionsError).toBe(
+      true,
     );
     expect(result.current.swapSteps.preSwapData.netWorkFee).toBeUndefined();
   });

--- a/packages/kit/src/views/Onboardingv2/pages/CheckAndUpdate.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/CheckAndUpdate.tsx
@@ -192,7 +192,7 @@ function CheckAndUpdatePage({
     }
 
     // Original transport is stored in singleton, will be restored in useFocusEffect
-    actions.openChangeLogModal({
+    await actions.openChangeLogModal({
       connectId: usbPrepareResult.connectId,
     });
   }, [actions, currentDevice, prepareUSBConnect]);

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -83,6 +83,7 @@ import type {
   IFetchLimitOrderRes,
   IFetchQuoteResult,
   IOneInchOrderStruct,
+  IQuoteResultFeeOtherFeeInfo,
   ISwapGasInfo,
   ISwapPreSwapData,
   ISwapStep,
@@ -122,7 +123,10 @@ import {
   useSwapToTokenAmountAtom,
   useSwapTypeSwitchAtom,
 } from '../../../states/jotai/contexts/swap';
-import { checkSwapLatestBalanceSufficient } from '../utils/swapBalanceUtils';
+import {
+  checkSwapLatestBalanceSufficient,
+  getSwapRequiredNativeBalanceAmount,
+} from '../utils/swapBalanceUtils';
 
 import { useSwapAddressInfo } from './useSwapAccount';
 import { useSwapBuildTxInfo, useSwapProAccount } from './useSwapPro';
@@ -507,6 +511,63 @@ export function useSwapBuildTx() {
     [fromAccountId, fromUserAddress, showLatestBalanceInsufficientToast],
   );
 
+  const checkLatestNativeTokenBalance = useCallback(
+    async ({
+      gasInfos,
+      networkId,
+      token,
+      amount,
+      otherFeeInfos,
+    }: {
+      gasInfos?: { gasInfo?: ISwapGasInfo }[];
+      networkId?: string;
+      token?: ISwapToken;
+      amount?: string;
+      otherFeeInfos?: IQuoteResultFeeOtherFeeInfo[];
+    }) => {
+      const nativeBalanceRequirement = getSwapRequiredNativeBalanceAmount({
+        gasInfos,
+        networkId,
+        fromToken: token,
+        fromAmount: amount,
+        otherFeeInfos,
+      });
+
+      if (!nativeBalanceRequirement) {
+        return true;
+      }
+
+      const checkResult = await checkSwapLatestBalanceSufficient({
+        token: nativeBalanceRequirement.token,
+        amount: nativeBalanceRequirement.amount,
+        accountAddress: fromUserAddress,
+        accountId: fromAccountId,
+      });
+      if (!checkResult.isSufficient) {
+        Toast.error({
+          title: intl.formatMessage(
+            {
+              id: ETranslations.swap_page_toast_insufficient_balance_title,
+            },
+            { token: checkResult.tokenSymbol },
+          ),
+          message: intl.formatMessage(
+            {
+              id: ETranslations.swap_page_toast_insufficient_balance_content,
+            },
+            {
+              token: checkResult.tokenSymbol,
+              number: numberFormat(checkResult.requiredAmount, formatter),
+            },
+          ),
+        });
+        return false;
+      }
+      return true;
+    },
+    [fromAccountId, fromUserAddress, intl],
+  );
+
   const cancelLimitOrder = useCallback(
     async (item: IFetchLimitOrderRes, source: ESwapCancelLimitOrderSource) => {
       if (item.cancelInfo) {
@@ -692,6 +753,17 @@ export function useSwapBuildTx() {
         feeInfo: gasInfo as IFeeInfoUnit,
         nativeTokenPrice: gasInfo.common?.nativeTokenPrice ?? 0,
       });
+      const checkLatestNativeBalanceRes = await checkLatestNativeTokenBalance({
+        gasInfos: [{ gasInfo }],
+        networkId,
+        token: unsignedTxItem.swapInfo?.sender.token,
+        amount: unsignedTxItem.swapInfo?.sender.amount,
+        otherFeeInfos:
+          unsignedTxItem.swapInfo?.swapBuildResData.result?.fee?.otherFeeInfos,
+      });
+      if (!checkLatestNativeBalanceRes) {
+        throw new OneKeyError('checkLatestNativeTokenBalance failed');
+      }
       await backgroundApiProxy.serviceTransaction.verifyTransaction({
         networkId,
         accountId,
@@ -735,7 +807,7 @@ export function useSwapBuildTx() {
       });
       return res;
     },
-    [intl, setSwapSteps],
+    [checkLatestNativeTokenBalance, intl, setSwapSteps],
   );
 
   const swapEstimateFeeEvent = useCallback(
@@ -1799,12 +1871,12 @@ export function useSwapBuildTx() {
         if (!checkLatestBalanceRes) {
           throw new OneKeyError('checkLatestFromTokenBalance failed');
         }
-        if (swapStepsRef.current.preSwapData.swapBuildResultData) {
-          return swapStepsRef.current.preSwapData.swapBuildResultData;
-        }
         const checkRes = await checkOtherFee(data);
         if (!checkRes) {
           throw new OneKeyError('checkOtherFee failed');
+        }
+        if (swapStepsRef.current.preSwapData.swapBuildResultData) {
+          return swapStepsRef.current.preSwapData.swapBuildResultData;
         }
         let buildSwapRes: IFetchBuildTxResponse | undefined;
         try {
@@ -2935,6 +3007,19 @@ export function useSwapBuildTx() {
             throw e;
           }
         }
+        const checkLatestNativeBalanceRes = await checkLatestNativeTokenBalance(
+          {
+            gasInfos: gasFeeInfos,
+            networkId,
+            token: swapInfo?.sender.token,
+            amount: swapInfo?.sender.amount,
+            otherFeeInfos:
+              swapInfo?.swapBuildResData.result?.fee?.otherFeeInfos,
+          },
+        );
+        if (!checkLatestNativeBalanceRes) {
+          throw new OneKeyError('checkLatestNativeTokenBalance failed');
+        }
         const gasFeeFiatValues = await Promise.all(
           gasFeeInfos.map(async (item) => {
             const { gasInfo } = item;
@@ -2971,6 +3056,7 @@ export function useSwapBuildTx() {
             estimateNetworkFeeLoading: false,
           },
         }));
+        throw _e;
       }
     },
     [
@@ -2980,6 +3066,7 @@ export function useSwapBuildTx() {
       swapEstimateFeeEvent,
       fromAccountId,
       fromUserAddress,
+      checkLatestNativeTokenBalance,
     ],
   );
 
@@ -3005,6 +3092,7 @@ export function useSwapBuildTx() {
           preSwapData: {
             ...prev.preSwapData,
             stepBeforeActionsLoading: true,
+            stepBeforeActionsError: undefined,
           },
         }));
         try {
@@ -3031,14 +3119,17 @@ export function useSwapBuildTx() {
             preSwapData: {
               ...prev.preSwapData,
               stepBeforeActionsLoading: false,
+              stepBeforeActionsError: undefined,
             },
           }));
-        } catch (_e) {
+        } catch {
           setSwapSteps((prev) => ({
             ...prev,
             preSwapData: {
               ...prev.preSwapData,
               stepBeforeActionsLoading: false,
+              stepBeforeActionsError: true,
+              netWorkFee: undefined,
             },
           }));
         }

--- a/packages/kit/src/views/Swap/hooks/useSwapLimitRate.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapLimitRate.ts
@@ -74,6 +74,71 @@ export const useSwapLimitRate = () => {
     swapProTradeType,
     swapTypeSwitchValue,
   ]);
+  const isLimitPriceUseRateForSelectedPair = useMemo(() => {
+    if (!limitPriceUseRate.fromToken || !limitPriceUseRate.toToken) {
+      return false;
+    }
+    return (
+      equalTokenNoCaseSensitive({
+        token1: limitPriceUseRate.fromToken,
+        token2: fromSelectToken,
+      }) &&
+      equalTokenNoCaseSensitive({
+        token1: limitPriceUseRate.toToken,
+        token2: toSelectToken,
+      })
+    );
+  }, [
+    fromSelectToken,
+    limitPriceUseRate.fromToken,
+    limitPriceUseRate.toToken,
+    toSelectToken,
+  ]);
+  const hasLimitPriceUseRate = useMemo(
+    () =>
+      Boolean(
+        limitPriceUseRate.fromToken ||
+        limitPriceUseRate.toToken ||
+        limitPriceUseRate.rate ||
+        limitPriceUseRate.reverseRate ||
+        limitPriceUseRate.inputRate,
+      ),
+    [
+      limitPriceUseRate.fromToken,
+      limitPriceUseRate.inputRate,
+      limitPriceUseRate.rate,
+      limitPriceUseRate.reverseRate,
+      limitPriceUseRate.toToken,
+    ],
+  );
+  const canUseLimitPriceMarketPrice = useMemo(() => {
+    const rateBN = new BigNumber(limitPriceMarketPrice.rate ?? 0);
+    if (
+      rateBN.isNaN() ||
+      !rateBN.isFinite() ||
+      rateBN.lte(0) ||
+      !limitPriceMarketPrice.fromToken ||
+      !limitPriceMarketPrice.toToken
+    ) {
+      return false;
+    }
+    return (
+      equalTokenNoCaseSensitive({
+        token1: limitPriceMarketPrice.fromToken,
+        token2: fromSelectToken,
+      }) &&
+      equalTokenNoCaseSensitive({
+        token1: limitPriceMarketPrice.toToken,
+        token2: toSelectToken,
+      })
+    );
+  }, [
+    fromSelectToken,
+    limitPriceMarketPrice.fromToken,
+    limitPriceMarketPrice.rate,
+    limitPriceMarketPrice.toToken,
+    toSelectToken,
+  ]);
   const fromSelectTokenRef = useRef<ISwapToken | undefined>(fromSelectToken);
   const toSelectTokenRef = useRef<ISwapToken | undefined>(toSelectToken);
   if (fromSelectTokenRef.current !== fromSelectToken) {
@@ -196,6 +261,9 @@ export const useSwapLimitRate = () => {
 
   const onSetMarketPrice = useCallback(
     (percentage: number) => {
+      if (!canUseLimitPriceMarketPrice) {
+        return;
+      }
       const percentageBN = new BigNumber(1 + percentage / 100);
       const rateBN = new BigNumber(
         limitPriceMarketPrice.rate ?? '0',
@@ -220,7 +288,12 @@ export const useSwapLimitRate = () => {
           : formatRate.toFixed(),
       }));
     },
-    [setLimitPriceUseRate, limitPriceMarketPrice, limitPriceSetReverse],
+    [
+      canUseLimitPriceMarketPrice,
+      setLimitPriceUseRate,
+      limitPriceMarketPrice,
+      limitPriceSetReverse,
+    ],
   );
 
   const onChangeReverse = useCallback(
@@ -272,19 +345,20 @@ export const useSwapLimitRate = () => {
   ]);
 
   useEffect(() => {
-    if (
-      !limitPriceMarketPrice.rate ||
-      checkWrappedTokenPair({
-        fromToken: fromSelectToken,
-        toToken: toSelectToken,
-      })
-    ) {
+    const isWrappedTokenPair = checkWrappedTokenPair({
+      fromToken: fromSelectToken,
+      toToken: toSelectToken,
+    });
+    const shouldClearStaleLimitPrice =
+      hasLimitPriceUseRate && !isLimitPriceUseRateForSelectedPair;
+    if (isWrappedTokenPair || shouldClearStaleLimitPrice) {
       setLimitPriceUseRate({});
       setLimitPriceSetReverse(false);
     }
   }, [
     fromSelectToken,
-    limitPriceMarketPrice.rate,
+    hasLimitPriceUseRate,
+    isLimitPriceUseRateForSelectedPair,
     setLimitPriceSetReverse,
     setLimitPriceUseRate,
     toSelectToken,
@@ -312,6 +386,7 @@ export const useSwapLimitRate = () => {
     onSetMarketPrice,
     onChangeReverse,
     limitPriceSetReverse,
+    canUseLimitPriceMarketPrice,
     limitPriceUseRate,
     limitPriceMarketPrice,
     fromTokenInfo: fromSelectToken,

--- a/packages/kit/src/views/Swap/hooks/useSwapReviewActions.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapReviewActions.ts
@@ -104,6 +104,9 @@ function useReviewStepStateActions() {
         preSwapData: {
           ...prev.preSwapData,
           stepBeforeActionsLoading: loading,
+          stepBeforeActionsError: loading
+            ? undefined
+            : prev.preSwapData.stepBeforeActionsError,
         },
       }));
     },
@@ -202,6 +205,7 @@ export function useSwapReviewActions({
             preSwapData: {
               ...reviewState.preSwapData,
               stepBeforeActionsLoading: false,
+              stepBeforeActionsError: undefined,
             },
           },
           {
@@ -214,6 +218,7 @@ export function useSwapReviewActions({
           preSwapData: {
             ...prev.preSwapData,
             stepBeforeActionsLoading: false,
+            stepBeforeActionsError: true,
             netWorkFee: undefined,
           },
         }));

--- a/packages/kit/src/views/Swap/pages/components/LimitInfoContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/LimitInfoContainer.tsx
@@ -40,6 +40,7 @@ const LimitInfoContainer = () => {
     limitPriceSetReverse,
     onChangeReverse,
     limitPriceEqualMarketPrice,
+    canUseLimitPriceMarketPrice,
   } = useSwapLimitRate();
   const intl = useIntl();
   const checkEqualMarketPrice = useCallback(
@@ -147,13 +148,26 @@ const LimitInfoContainer = () => {
                   ? '$borderActive'
                   : '$borderSubdued'
               }
-              onPress={() => onSetMarketPrice(percentage)}
-              hoverStyle={{
-                bg: '$bgStrongHover',
-              }}
-              pressStyle={{
-                bg: '$bgStrongActive',
-              }}
+              opacity={canUseLimitPriceMarketPrice ? 1 : 0.5}
+              onPress={
+                canUseLimitPriceMarketPrice
+                  ? () => onSetMarketPrice(percentage)
+                  : undefined
+              }
+              hoverStyle={
+                canUseLimitPriceMarketPrice
+                  ? {
+                      bg: '$bgStrongHover',
+                    }
+                  : undefined
+              }
+              pressStyle={
+                canUseLimitPriceMarketPrice
+                  ? {
+                      bg: '$bgStrongActive',
+                    }
+                  : undefined
+              }
             >
               {percentage === 0
                 ? intl.formatMessage({ id: ETranslations.Limit_market })

--- a/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
+++ b/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { isEqual } from 'lodash';
 import { useIntl } from 'react-intl';
@@ -57,12 +64,12 @@ interface IPreSwapDialogContentProps {
     data?: IFetchQuoteResult,
     currentFromToken?: ISwapToken,
     currentToToken?: ISwapToken,
-  ) => void;
+  ) => void | Promise<void>;
   preSwapStepsStart: (swapStepsValues?: {
     steps: ISwapStep[];
     preSwapData: ISwapPreSwapData;
     quoteResult?: IFetchQuoteResult;
-  }) => void;
+  }) => void | Promise<void>;
 }
 
 const PreSwapDialogContent = ({
@@ -132,19 +139,40 @@ const PreSwapDialogContent = ({
       toAmount,
     ],
   );
+  const isPrimaryButtonDisabled = useMemo(
+    () =>
+      Boolean(
+        preSwapData?.estimateNetworkFeeLoading ||
+        preSwapData?.swapBuildLoading ||
+        preSwapData?.stepBeforeActionsLoading ||
+        preSwapData?.stepBeforeActionsError,
+      ),
+    [
+      preSwapData?.estimateNetworkFeeLoading,
+      preSwapData?.stepBeforeActionsError,
+      preSwapData?.stepBeforeActionsLoading,
+      preSwapData?.swapBuildLoading,
+    ],
+  );
 
   const handleConfirmPress = useCallback(() => {
+    if (isPrimaryButtonDisabled) {
+      return;
+    }
     if (validatedQuoteShowTip) {
       setShowPreSwapTipInfo(validatedQuoteShowTip);
     } else {
       onConfirm();
     }
-  }, [onConfirm, validatedQuoteShowTip]);
+  }, [isPrimaryButtonDisabled, onConfirm, validatedQuoteShowTip]);
 
   const tipOnConfirm = useCallback(() => {
+    if (isPrimaryButtonDisabled) {
+      return;
+    }
     onConfirm();
     setShowPreSwapTipInfo(undefined);
-  }, [onConfirm]);
+  }, [isPrimaryButtonDisabled, onConfirm]);
   const tipOnCancel = useCallback(() => {
     setShowPreSwapTipInfo(undefined);
   }, []);
@@ -206,7 +234,7 @@ const PreSwapDialogContent = ({
     swapSteps,
   ]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (
       swapStepsRef.current.preSwapData.supportNetworkFeeLevel &&
       swapStepsRef.current.preSwapData.supportPreBuild
@@ -461,11 +489,7 @@ const PreSwapDialogContent = ({
                     variant="primary"
                     onPress={handleConfirmPress}
                     size="medium"
-                    disabled={
-                      swapSteps.preSwapData.estimateNetworkFeeLoading ||
-                      swapSteps.preSwapData.swapBuildLoading ||
-                      swapSteps.preSwapData.stepBeforeActionsLoading
-                    }
+                    disabled={isPrimaryButtonDisabled}
                   >
                     {actionBtnTest}
                   </Button>

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
@@ -1,6 +1,9 @@
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 
-import { checkSwapLatestBalanceSufficient } from './swapBalanceUtils';
+import {
+  checkSwapLatestBalanceSufficient,
+  getSwapRequiredNativeBalanceAmount,
+} from './swapBalanceUtils';
 
 type IFetchSwapTokenDetailsParams = {
   networkId: string;
@@ -28,7 +31,29 @@ const ethToken = {
   networkId: 'evm--1',
   contractAddress: '',
   symbol: 'ETH',
+  decimals: 18,
+  isNative: true,
 } as ISwapToken;
+
+const usdcToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  symbol: 'USDC',
+  decimals: 6,
+} as ISwapToken;
+
+const evmGasInfo = {
+  common: {
+    feeDecimals: 9,
+    feeSymbol: 'Gwei',
+    nativeDecimals: 18,
+    nativeSymbol: 'ETH',
+  },
+  gas: {
+    gasLimit: '21000',
+    gasPrice: '1',
+  },
+};
 
 describe('checkSwapLatestBalanceSufficient', () => {
   beforeEach(() => {
@@ -64,5 +89,78 @@ describe('checkSwapLatestBalanceSufficient', () => {
         accountAddress: '0xabc',
       }),
     ).resolves.toEqual({ isSufficient: true });
+  });
+});
+
+describe('getSwapRequiredNativeBalanceAmount', () => {
+  it('returns the required native gas amount for non-native swaps', () => {
+    expect(
+      getSwapRequiredNativeBalanceAmount({
+        gasInfos: [{ gasInfo: evmGasInfo }],
+        networkId: 'evm--1',
+        fromToken: usdcToken,
+        fromAmount: '12',
+      }),
+    ).toEqual({
+      token: {
+        networkId: 'evm--1',
+        contractAddress: '',
+        isNative: true,
+        symbol: 'ETH',
+        decimals: 18,
+      },
+      amount: '0.000021',
+    });
+  });
+
+  it('adds the sending amount when the from token is native', () => {
+    expect(
+      getSwapRequiredNativeBalanceAmount({
+        gasInfos: [{ gasInfo: evmGasInfo }],
+        networkId: 'evm--1',
+        fromToken: ethToken,
+        fromAmount: '0.1',
+      }),
+    ).toEqual({
+      token: ethToken,
+      amount: '0.100021',
+    });
+  });
+
+  it('adds native other fees to the same native balance requirement', () => {
+    expect(
+      getSwapRequiredNativeBalanceAmount({
+        gasInfos: [{ gasInfo: evmGasInfo }],
+        networkId: 'evm--1',
+        fromToken: ethToken,
+        fromAmount: '0.1',
+        otherFeeInfos: [
+          {
+            token: {
+              networkId: 'evm--1',
+              contractAddress: '',
+              symbol: 'ETH',
+              price: '3000',
+              decimals: 18,
+              isNative: true,
+            },
+            amount: '0.02',
+          },
+          {
+            token: {
+              networkId: 'evm--1',
+              contractAddress: usdcToken.contractAddress,
+              symbol: 'USDC',
+              price: '1',
+              decimals: 6,
+            },
+            amount: '5',
+          },
+        ],
+      }),
+    ).toEqual({
+      token: ethToken,
+      amount: '0.120021',
+    });
   });
 });

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
@@ -1,6 +1,12 @@
 import BigNumber from 'bignumber.js';
 
-import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
+import { calculateFeeForSend } from '@onekeyhq/shared/src/utils/feeUtils';
+import type { IFeeInfoUnit } from '@onekeyhq/shared/types/fee';
+import type {
+  IQuoteResultFeeOtherFeeInfo,
+  ISwapGasInfo,
+  ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 
@@ -21,6 +27,130 @@ export type ISwapLatestBalanceCheckResult =
       requiredAmount: string;
       tokenSymbol: string;
     };
+
+type ISwapGasInfoEntry = {
+  gasInfo?: ISwapGasInfo;
+};
+
+type ISwapNativeBalanceRequirementParams = {
+  gasInfos?: ISwapGasInfoEntry[];
+  networkId?: string;
+  fromToken?: ISwapToken;
+  fromAmount?: string;
+  otherFeeInfos?: IQuoteResultFeeOtherFeeInfo[];
+};
+
+export type ISwapNativeBalanceRequirement = {
+  token: ISwapToken;
+  amount: string;
+};
+
+function buildNativeTokenFromGasInfo({
+  gasInfo,
+  networkId,
+  fromToken,
+}: {
+  gasInfo: ISwapGasInfo;
+  networkId?: string;
+  fromToken?: ISwapToken;
+}) {
+  if (!gasInfo.common || !networkId) {
+    return undefined;
+  }
+
+  if (fromToken?.isNative && fromToken.networkId === networkId) {
+    return fromToken;
+  }
+
+  return {
+    networkId,
+    contractAddress: '',
+    isNative: true,
+    symbol: gasInfo.common.nativeSymbol,
+    decimals: gasInfo.common.nativeDecimals,
+  } as ISwapToken;
+}
+
+export function getSwapRequiredNativeBalanceAmount({
+  gasInfos,
+  networkId,
+  fromToken,
+  fromAmount,
+  otherFeeInfos,
+}: ISwapNativeBalanceRequirementParams):
+  | ISwapNativeBalanceRequirement
+  | undefined {
+  if (!gasInfos?.length || !networkId) {
+    return undefined;
+  }
+
+  let nativeToken: ISwapToken | undefined;
+  const networkFeeAmount = gasInfos.reduce((acc, item) => {
+    if (!item.gasInfo?.common) {
+      return acc;
+    }
+
+    nativeToken =
+      nativeToken ??
+      buildNativeTokenFromGasInfo({
+        gasInfo: item.gasInfo,
+        networkId,
+        fromToken,
+      });
+
+    const { totalNative } = calculateFeeForSend({
+      feeInfo: item.gasInfo as IFeeInfoUnit,
+      nativeTokenPrice: item.gasInfo.common.nativeTokenPrice ?? 0,
+    });
+    const totalNativeBN = new BigNumber(totalNative);
+
+    if (totalNativeBN.isNaN() || !totalNativeBN.isFinite()) {
+      return acc;
+    }
+
+    return acc.plus(totalNativeBN);
+  }, new BigNumber(0));
+
+  if (!nativeToken) {
+    return undefined;
+  }
+
+  const fromAmountBN = new BigNumber(fromAmount ?? 0);
+  const shouldAddFromAmount =
+    fromToken?.isNative &&
+    fromToken.networkId === nativeToken.networkId &&
+    !fromAmountBN.isNaN() &&
+    fromAmountBN.isFinite() &&
+    fromAmountBN.gt(0);
+  const otherNativeFeeAmount = (otherFeeInfos ?? []).reduce((acc, item) => {
+    if (
+      !item.token?.isNative ||
+      item.token.networkId !== nativeToken?.networkId
+    ) {
+      return acc;
+    }
+
+    const amountBN = new BigNumber(item.amount ?? 0);
+    if (amountBN.isNaN() || !amountBN.isFinite() || amountBN.lte(0)) {
+      return acc;
+    }
+
+    return acc.plus(amountBN);
+  }, new BigNumber(0));
+
+  const requiredAmount = shouldAddFromAmount
+    ? networkFeeAmount.plus(fromAmountBN).plus(otherNativeFeeAmount)
+    : networkFeeAmount.plus(otherNativeFeeAmount);
+
+  if (requiredAmount.lte(0)) {
+    return undefined;
+  }
+
+  return {
+    token: nativeToken,
+    amount: requiredAmount.toFixed(),
+  };
+}
 
 export async function checkSwapLatestBalanceSufficient({
   token,

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -507,6 +507,7 @@ export interface ISwapPreSwapData {
   swapBuildLoading?: boolean;
   estimateNetworkFeeLoading?: boolean;
   stepBeforeActionsLoading?: boolean;
+  stepBeforeActionsError?: boolean;
   providerInfo?: IFetchQuoteInfo;
   isHWAndExBatchTransfer?: boolean;
   slippage?: number;


### PR DESCRIPTION
## Summary

Sync bundle release #4 changes from `release/v6.2.0` to `x`.

## Commits synced (2)

- `130e7fc11c` — fix(firmware-update): banner targets device list, friendly prompt when device disconnected (OK-53914) (#11397)
- `88016926d4` — fix: improve swap gas and limit price checks (OK-53915 OK-53459) (#11439)

## Skipped (1)

- `91f23d6fec` — fix(perps): patch rews dispatchEvent on RN to prevent SIGABRT (#11442) — **already on x as #11443 (`ef6d860464`) with a strictly more comprehensive patch (180 lines vs 130 lines, includes graceful CloseEvent → Event fallback path)**.

## Notes

- Release #3 was already synced via #11449 (`bf2c9c78e1`).
- Cherry-picks applied cleanly — no conflicts on the two synced commits.
- Conflict on `#11442` was resolved by skipping the entire commit since x already contains an equivalent fix for the same Sentry issue (REACT-NATIVE-4AX).