### PR TITLE
feat: refine BTC market detail layout and show 24h volume

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderRight.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderRight.tsx
@@ -158,6 +158,23 @@ export function TokenDetailHeaderRight({
         />
         <StatItem
           label={intl.formatMessage({
+            id: ETranslations.dexmarket_stock_24h_volume,
+          })}
+          value={
+            <NumberSizeableText
+              size="$headingXs"
+              color="$text"
+              formatter="marketCap"
+              formatterOptions={{
+                currency: '$',
+              }}
+            >
+              {btcMetadata.volume24h}
+            </NumberSizeableText>
+          }
+        />
+        <StatItem
+          label={intl.formatMessage({
             id: ETranslations.dexmarket_btc_circulating_supply,
           })}
           value={
@@ -165,24 +182,8 @@ export function TokenDetailHeaderRight({
               size="$headingXs"
               color="$text"
               formatter="marketCap"
-              formatterOptions={{ tokenSymbol: 'BTC' }}
             >
               {btcMetadata.circulatingSupply}
-            </NumberSizeableText>
-          }
-        />
-        <StatItem
-          label={intl.formatMessage({
-            id: ETranslations.dexmarket_btc_remaining_supply,
-          })}
-          value={
-            <NumberSizeableText
-              size="$headingXs"
-              color="$text"
-              formatter="marketCap"
-              formatterOptions={{ tokenSymbol: 'BTC' }}
-            >
-              {btcMetadata.remainingSupply}
             </NumberSizeableText>
           }
         />

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenOverview/TokenOverview.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenOverview/TokenOverview.tsx
@@ -14,8 +14,8 @@ import {
   MARKET_CAP_FORMATTER,
   USD_CURRENCY_FORMATTER,
   formatBlockHeightValue,
-  formatBtcSupplyValue,
   formatCurrencyStatValue,
+  formatMarketCapValue,
   formatStatValueWithFormatter,
 } from '../../utils/statValue';
 import { TokenSecurityAlertDialogContent } from '../TokenSecurityAlert/components';
@@ -131,31 +131,31 @@ export function TokenOverview() {
             />
             <StatCard
               label={intl.formatMessage({
-                id: ETranslations.dexmarket_btc_circulating_supply,
+                id: ETranslations.dexmarket_stock_24h_volume,
               })}
-              value={formatBtcSupplyValue(btcMetadata.circulatingSupply)}
+              value={formatCurrencyStatValue(btcMetadata.volume24h)}
             />
           </XStack>
           <XStack gap="$2">
+            <StatCard
+              label={intl.formatMessage({
+                id: ETranslations.dexmarket_btc_circulating_supply,
+              })}
+              value={formatMarketCapValue(btcMetadata.circulatingSupply)}
+            />
             <StatCard
               label={intl.formatMessage({
                 id: ETranslations.dexmarket_btc_remaining_supply,
               })}
-              value={formatBtcSupplyValue(btcMetadata.remainingSupply)}
-            />
-            <StatCard
-              label={intl.formatMessage({
-                id: ETranslations.dexmarket_btc_total_supply,
-              })}
-              value={formatBtcSupplyValue(btcMetadata.totalSupply)}
+              value={formatMarketCapValue(btcMetadata.remainingSupply)}
             />
           </XStack>
           <XStack gap="$2">
             <StatCard
               label={intl.formatMessage({
-                id: ETranslations.dexmarket_fdv_title,
+                id: ETranslations.dexmarket_btc_total_supply,
               })}
-              value={formatCurrencyStatValue(btcMetadata.fdv)}
+              value={formatMarketCapValue(btcMetadata.totalSupply)}
             />
             <StatCard
               label={intl.formatMessage({

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenSupplementaryInfo/TokenSupplementaryInfo.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenSupplementaryInfo/TokenSupplementaryInfo.tsx
@@ -18,8 +18,7 @@ import {
   MARKET_CAP_FORMATTER,
   USD_CURRENCY_FORMATTER,
   formatBlockHeightValue,
-  formatBtcSupplyValue,
-  formatCurrencyStatValue,
+  formatMarketCapValue,
   formatStatValueWithFormatter,
 } from '../../utils/statValue';
 
@@ -54,12 +53,14 @@ export function TokenSupplementaryInfo() {
           label: intl.formatMessage({
             id: ETranslations.dexmarket_btc_total_supply,
           }),
-          value: formatBtcSupplyValue(btcMetadata.totalSupply),
+          value: formatMarketCapValue(btcMetadata.totalSupply),
         },
         {
-          key: 'fdv',
-          label: intl.formatMessage({ id: ETranslations.dexmarket_fdv_title }),
-          value: formatCurrencyStatValue(btcMetadata.fdv),
+          key: 'remainingSupply',
+          label: intl.formatMessage({
+            id: ETranslations.dexmarket_btc_remaining_supply,
+          }),
+          value: formatMarketCapValue(btcMetadata.remainingSupply),
         },
         {
           key: 'blockHeight',

--- a/packages/kit/src/views/Market/MarketDetailV2/hooks/useBtcMetadata.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/hooks/useBtcMetadata.test.ts
@@ -53,6 +53,7 @@ const buildBtcMetadata = (
   remainingSupply: '977825',
   totalSupply: '21000000',
   fdv: '1545781500232',
+  volume24h: '40906812011',
   blockHeight: '947103',
   blockReward: '3.125',
   nextHalving: {
@@ -157,6 +158,7 @@ describe('useBtcMetadata', () => {
       remainingSupply: '977825',
       totalSupply: '21000000',
       fdv: '1545781500232',
+      volume24h: '40906812011',
       blockHeight: '947103',
       blockReward: '3.125',
       nextHalvingDisplay: '~2Y 41D',

--- a/packages/kit/src/views/Market/MarketDetailV2/hooks/useBtcMetadata.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/hooks/useBtcMetadata.ts
@@ -4,21 +4,18 @@ import { useIntl } from 'react-intl';
 
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import type { IBtcMetadata } from '@onekeyhq/shared/types/marketV2';
 
 import { formatNextHalving } from '../utils/formatNextHalving';
 
 import { useTokenDetail } from './useTokenDetail';
 
-export interface IUseBtcMetadataResult {
-  marketCap: string;
-  circulatingSupply: string;
-  remainingSupply: string;
-  totalSupply: string;
-  fdv: string;
-  blockHeight: string;
-  blockReward: string;
+export type IUseBtcMetadataResult = Omit<
+  IBtcMetadata,
+  'nextHalving' | 'updatedAt' | 'stale'
+> & {
   nextHalvingDisplay: string;
-}
+};
 
 export function useBtcMetadata(): IUseBtcMetadataResult | null {
   const intl = useIntl();
@@ -44,6 +41,7 @@ export function useBtcMetadata(): IUseBtcMetadataResult | null {
       remainingSupply: meta.remainingSupply,
       totalSupply: meta.totalSupply,
       fdv: meta.fdv,
+      volume24h: meta.volume24h,
       blockHeight: meta.blockHeight,
       blockReward: meta.blockReward,
       nextHalvingDisplay: formatNextHalving(

--- a/packages/kit/src/views/Market/MarketDetailV2/utils/statValue.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/utils/statValue.ts
@@ -107,11 +107,6 @@ export function formatBlockHeightValue(
   return Number.isFinite(n) ? n.toLocaleString('en-US') : fallback;
 }
 
-export function formatBtcSupplyValue(value?: string | number | null): string {
-  const formatted = formatMarketCapValue(value);
-  return formatted === STAT_FALLBACK_VALUE ? formatted : `${formatted} BTC`;
-}
-
 export function formatPercentValue(
   value?: string | number | null,
   fallback: string = STAT_FALLBACK_VALUE,

--- a/packages/shared/types/marketV2.ts
+++ b/packages/shared/types/marketV2.ts
@@ -10,6 +10,7 @@ export interface IBtcMetadata {
   remainingSupply: string;
   totalSupply: string;
   fdv: string;
+  volume24h: string;
   blockHeight: string;
   blockReward: string;
   nextHalving: IBtcMetadataNextHalving;


### PR DESCRIPTION
https://onekeyhq.atlassian.net/browse/OK-54059
## Summary

Refine the BTC token detail page in the Market module:

- **Top header** — Replace `剩余供应量` slot with `24h Volume` (data from `btcMetadata.volume24h`). New order: `市值` | `24h Volume` | `流通供应量`.
- **Right side panel (desktop)** — Remove `全流通价值 / FDV` row (redundant with market cap), and use that slot to display `剩余供应量` instead.
- **Mobile detail card grid** — Remove FDV card, replace with `24h Volume`; rearrange supply rows accordingly.
- **Remove `BTC` suffix** from `流通供应量 / 总供应量 / 剩余供应量` values.
- Drop unused `formatBtcSupplyValue` helper; refactor `IUseBtcMetadataResult` as `Omit<IBtcMetadata, ...>` derivation.

Translation keys are reused (no locale JSON edits): `dexmarket_stock_24h_volume`, `dexmarket_btc_circulating_supply / remaining_supply / total_supply`.

## Test plan

- [ ] Open BTC detail page on **Web / Desktop** — verify top header shows `市值 / 24h Volume / 流通供应量` (no BTC suffix), right panel shows `总供应量 / 剩余供应量 / 区块高度 / 区块奖励 / 距下次减半` (no FDV)
- [ ] Open BTC detail page on **iOS / Android** — verify 4×2 card grid: row1 `市值 / 24h Volume`, row2 `流通供应量 / 剩余供应量`, row3 `总供应量 / 区块高度`, row4 `区块奖励 / 距下次减半`
- [ ] Open a non-BTC token detail page — verify FDV is still shown (fallback branch unaffected)
- [ ] `yarn jest packages/kit/src/views/Market/MarketDetailV2/hooks/useBtcMetadata.test.ts` passes (7/7)
- [ ] `yarn lint:staged` passes (0 warnings, 0 errors)