### PR TITLE
build(cli): notarize macOS OneKey CLI standalone package

### DIFF
--- a/.github/workflows/cli-macos-standalone.yml
+++ b/.github/workflows/cli-macos-standalone.yml
@@ -157,7 +157,9 @@ jobs:
           fi
 
           BIN="apps/cli/build/macos-standalone/darwin-${CLI_MACOS_ARCH}/onekey"
+          TARBALL_DIR="apps/cli/build/macos-standalone/darwin-${CLI_MACOS_ARCH}/npm-tarball"
           ZIP="apps/cli/build/macos-standalone/darwin-${CLI_MACOS_ARCH}/onekey-cli-darwin-${CLI_MACOS_ARCH}.zip"
+          TARBALL=$(ls "$TARBALL_DIR"/*.tgz)
           xcrun notarytool submit "$ZIP" \
             --apple-id "$APPLEID" \
             --password "$APPLEIDPASS" \
@@ -166,15 +168,41 @@ jobs:
 
           codesign --verify --check-notarization --verbose=4 "$BIN"
 
-          GATEKEEPER_TEST_BIN="$RUNNER_TEMP/onekey-gatekeeper-test"
-          cp "$BIN" "$GATEKEEPER_TEST_BIN"
-          QUARANTINE_TS="$(printf '%x' "$(date +%s)")"
-          xattr -w com.apple.quarantine \
-            "0081;$QUARANTINE_TS;onekey-ci;https://github.com/OneKeyHQ/app-monorepo" \
-            "$GATEKEEPER_TEST_BIN"
-          xattr -p com.apple.quarantine "$GATEKEEPER_TEST_BIN"
-          codesign --verify --check-notarization --verbose=4 "$GATEKEEPER_TEST_BIN"
-          "$GATEKEEPER_TEST_BIN" --version
+          ARTIFACT_VERIFY_DIR="$RUNNER_TEMP/onekey-notarized-artifacts"
+          rm -rf "$ARTIFACT_VERIFY_DIR"
+          mkdir -p "$ARTIFACT_VERIFY_DIR/zip" "$ARTIFACT_VERIFY_DIR/tarball"
+          ditto -x -k "$ZIP" "$ARTIFACT_VERIFY_DIR/zip"
+          tar -xzf "$TARBALL" -C "$ARTIFACT_VERIFY_DIR/tarball"
+
+          ZIP_BIN=$(find "$ARTIFACT_VERIFY_DIR/zip" -type f -name onekey -print -quit)
+          TARBALL_BIN="$ARTIFACT_VERIFY_DIR/tarball/package/bin/onekey"
+          if [ -z "$ZIP_BIN" ] || [ ! -x "$ZIP_BIN" ]; then
+            echo "::error::Distribution zip does not contain an executable onekey binary."
+            exit 1
+          fi
+          if [ ! -x "$TARBALL_BIN" ]; then
+            echo "::error::NPM tarball does not contain an executable package/bin/onekey binary."
+            exit 1
+          fi
+
+          for PACKAGE_BIN in "$BIN" "$ZIP_BIN" "$TARBALL_BIN"; do
+            file "$PACKAGE_BIN"
+            codesign --verify --check-notarization --verbose=4 "$PACKAGE_BIN"
+          done
+
+          GATEKEEPER_INDEX=0
+          for PACKAGE_BIN in "$ZIP_BIN" "$TARBALL_BIN"; do
+            GATEKEEPER_TEST_BIN="$RUNNER_TEMP/onekey-gatekeeper-test-$GATEKEEPER_INDEX"
+            cp "$PACKAGE_BIN" "$GATEKEEPER_TEST_BIN"
+            QUARANTINE_TS="$(printf '%x' "$(date +%s)")"
+            xattr -w com.apple.quarantine \
+              "0081;$QUARANTINE_TS;onekey-ci;https://github.com/OneKeyHQ/app-monorepo" \
+              "$GATEKEEPER_TEST_BIN"
+            xattr -p com.apple.quarantine "$GATEKEEPER_TEST_BIN"
+            codesign --verify --check-notarization --verbose=4 "$GATEKEEPER_TEST_BIN"
+            "$GATEKEEPER_TEST_BIN" --version
+            GATEKEEPER_INDEX=$((GATEKEEPER_INDEX + 1))
+          done
 
       - name: Upload standalone package
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cli-macos-standalone.yml
+++ b/.github/workflows/cli-macos-standalone.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: next
+      notarize:
+        description: 'Submit the signed macOS CLI zip to Apple notarization'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -35,6 +40,7 @@ jobs:
       YARN_ENABLE_GLOBAL_CACHE: true
       CLI_MACOS_ARCH: ${{ matrix.arch }}
       CLI_MACOS_BUNDLE_ID: so.onekey.cli
+      CLI_MACOS_HARDENED_RUNTIME: true
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -66,10 +72,11 @@ jobs:
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
           PUBLISH_TO_NPM: ${{ inputs.publish_to_npm }}
+          NOTARIZE: ${{ inputs.notarize }}
         run: |
           if [ -z "$DESKTOP_KEYS_SECRET" ] || [ -z "$CSC_KEY_PASSWORD" ]; then
-            if [ "$PUBLISH_TO_NPM" = "true" ]; then
-              echo "::error::Developer ID signing secrets are required before publishing macOS standalone CLI packages."
+            if [ "$PUBLISH_TO_NPM" = "true" ] || [ "$NOTARIZE" = "true" ]; then
+              echo "::error::Developer ID signing secrets are required before publishing or notarizing macOS standalone CLI packages."
               exit 1
             fi
             echo "::warning::Developer ID signing secrets are missing; using ad-hoc signing for this artifact."
@@ -133,7 +140,40 @@ jobs:
           cp "$BIN" "$RUNNER_TEMP/onekey-standalone-test"
           HOME="$RUNNER_TEMP/onekey-cli-home" "$RUNNER_TEMP/onekey-standalone-test" auth status --json
           codesign --verify --verbose=2 "$BIN"
+          codesign -d --entitlements - "$BIN"
           ls "$TARBALL_DIR"/*.tgz
+
+      - name: Notarize standalone CLI
+        if: ${{ inputs.notarize }}
+        env:
+          APPLEID: ${{ secrets.APPLEID }}
+          APPLEIDPASS: ${{ secrets.APPLEIDPASS }}
+          ASC_PROVIDER: ${{ secrets.ASC_PROVIDER }}
+        run: |
+          set -euo pipefail
+          if [ -z "${APPLEID:-}" ] || [ -z "${APPLEIDPASS:-}" ] || [ -z "${ASC_PROVIDER:-}" ]; then
+            echo "::error::APPLEID, APPLEIDPASS, and ASC_PROVIDER are required to notarize macOS standalone CLI packages."
+            exit 1
+          fi
+
+          BIN="apps/cli/build/macos-standalone/darwin-${CLI_MACOS_ARCH}/onekey"
+          ZIP="apps/cli/build/macos-standalone/darwin-${CLI_MACOS_ARCH}/onekey-cli-darwin-${CLI_MACOS_ARCH}.zip"
+          xcrun notarytool submit "$ZIP" \
+            --apple-id "$APPLEID" \
+            --password "$APPLEIDPASS" \
+            --team-id "$ASC_PROVIDER" \
+            --wait
+
+          spctl --assess --type execute --verbose=4 "$BIN"
+
+          GATEKEEPER_TEST_BIN="$RUNNER_TEMP/onekey-gatekeeper-test"
+          cp "$BIN" "$GATEKEEPER_TEST_BIN"
+          QUARANTINE_TS="$(printf '%x' "$(date +%s)")"
+          xattr -w com.apple.quarantine \
+            "0081;$QUARANTINE_TS;onekey-ci;https://github.com/OneKeyHQ/app-monorepo" \
+            "$GATEKEEPER_TEST_BIN"
+          spctl --assess --type execute --verbose=4 "$GATEKEEPER_TEST_BIN"
+          "$GATEKEEPER_TEST_BIN" --version
 
       - name: Upload standalone package
         uses: actions/upload-artifact@v4
@@ -141,6 +181,7 @@ jobs:
           name: onekey-cli-macos-standalone-${{ matrix.arch }}-${{ github.sha }}
           path: |
             apps/cli/build/macos-standalone/darwin-${{ matrix.arch }}/onekey
+            apps/cli/build/macos-standalone/darwin-${{ matrix.arch }}/onekey-cli-darwin-${{ matrix.arch }}.zip
             apps/cli/build/macos-standalone/darwin-${{ matrix.arch }}/npm-tarball/*.tgz
 
       - name: Publish standalone package to npm

--- a/.github/workflows/cli-macos-standalone.yml
+++ b/.github/workflows/cli-macos-standalone.yml
@@ -164,7 +164,7 @@ jobs:
             --team-id "$ASC_PROVIDER" \
             --wait
 
-          spctl --assess --type execute --verbose=4 "$BIN"
+          codesign --verify --check-notarization --verbose=4 "$BIN"
 
           GATEKEEPER_TEST_BIN="$RUNNER_TEMP/onekey-gatekeeper-test"
           cp "$BIN" "$GATEKEEPER_TEST_BIN"
@@ -172,7 +172,8 @@ jobs:
           xattr -w com.apple.quarantine \
             "0081;$QUARANTINE_TS;onekey-ci;https://github.com/OneKeyHQ/app-monorepo" \
             "$GATEKEEPER_TEST_BIN"
-          spctl --assess --type execute --verbose=4 "$GATEKEEPER_TEST_BIN"
+          xattr -p com.apple.quarantine "$GATEKEEPER_TEST_BIN"
+          codesign --verify --check-notarization --verbose=4 "$GATEKEEPER_TEST_BIN"
           "$GATEKEEPER_TEST_BIN" --version
 
       - name: Upload standalone package

--- a/apps/cli/docs/macos-standalone.md
+++ b/apps/cli/docs/macos-standalone.md
@@ -127,11 +127,15 @@ workflow therefore submits the ZIP for notarization and verifies the resulting
 online ticket with:
 
 ```bash
-spctl --assess --type execute --verbose=4 path/to/onekey
+codesign --verify --check-notarization --verbose=4 path/to/onekey
 ```
 
-It also verifies a copied binary with `com.apple.quarantine` applied, which is
-the Gatekeeper path that direct downloads use.
+The workflow does not treat `spctl --assess --type execute` as the standalone
+binary pass/fail check because current macOS runners reject plain Mach-O tools
+with `the code is valid but does not seem to be an app`, even after Apple
+accepts the notarization submission. Instead, it verifies notarization with
+`codesign --check-notarization` and executes a copied binary after applying
+`com.apple.quarantine`, which is the Gatekeeper path that direct downloads use.
 
 ## CI Notarization Steps
 
@@ -175,7 +179,11 @@ The workflow does the following when `notarize` is enabled:
 5. Verify on CI and on a clean macOS machine or VM:
 
    ```bash
-   spctl --assess --type execute --verbose path/to/onekey
+   codesign --verify --check-notarization --verbose=4 path/to/onekey
+   QUARANTINE_TS="$(printf '%x' "$(date +%s)")"
+   xattr -w com.apple.quarantine \
+     "0081;$QUARANTINE_TS;onekey-ci;https://github.com/OneKeyHQ/app-monorepo" \
+     path/to/onekey
    path/to/onekey --version
    ```
 

--- a/apps/cli/docs/macos-standalone.md
+++ b/apps/cli/docs/macos-standalone.md
@@ -36,6 +36,7 @@ yarn workspace @onekeyfe/cli package:macos-standalone
 The script produces:
 
 - `apps/cli/build/macos-standalone/darwin-${arch}/onekey`
+- `apps/cli/build/macos-standalone/darwin-${arch}/onekey-cli-darwin-${arch}.zip`
 - `apps/cli/build/macos-standalone/darwin-${arch}/npm-tarball/*.tgz`
 
 The GitHub Actions workflow is:
@@ -45,10 +46,13 @@ The GitHub Actions workflow is:
 ```
 
 It builds separate `arm64` and `x64` packages. The current workflow reuses the
-desktop Developer ID certificate secrets:
+desktop Developer ID and notarization secrets:
 
 - `DESKTOP_KEYS_SECRET`
 - `CSC_KEY_PASSWORD`
+- `APPLEID`
+- `APPLEIDPASS`
+- `ASC_PROVIDER`
 
 The CLI package does not need the desktop provisioning profile. It does not use
 CloudKit, App Sandbox, or a Keychain access group.
@@ -95,12 +99,15 @@ only the binary to an arbitrary directory.
 
 Notarization is not required for npm-only distribution.
 
-For npm distribution, the important security property is the signed Mach-O
+The GitHub Actions workflow notarizes the standalone macOS CLI zip by default
+because workflow artifacts and direct downloads can receive the
+`com.apple.quarantine` attribute and be assessed by Gatekeeper. For npm
+distribution, the important security property is still the signed Mach-O
 executable identity used for Keychain access. Users install through npm and run
 the CLI from Terminal, so Gatekeeper quarantine checks are usually not the main
 distribution blocker.
 
-Notarization is recommended when distributing the same binary through channels
+Keep notarization enabled when distributing the same binary through channels
 outside npm, for example:
 
 - GitHub Releases
@@ -113,10 +120,22 @@ Gatekeeper can verify when the downloaded file is first opened or executed. It
 improves first-run trust and reduces quarantine/Gatekeeper friction. It is not
 what gives the CLI its Keychain access identity; code signing does that.
 
-## Future Notarization Steps
+The standalone CLI is a plain Mach-O executable, not a `.app` bundle. Apple
+creates notarization tickets for standalone binaries, but the ticket cannot be
+stapled directly to the binary. ZIP files also cannot be stapled directly. The
+workflow therefore submits the ZIP for notarization and verifies the resulting
+online ticket with:
 
-When we decide to distribute the macOS CLI outside npm, add a notarization phase
-to the standalone CLI workflow:
+```bash
+spctl --assess --type execute --verbose=4 path/to/onekey
+```
+
+It also verifies a copied binary with `com.apple.quarantine` applied, which is
+the Gatekeeper path that direct downloads use.
+
+## CI Notarization Steps
+
+The workflow does the following when `notarize` is enabled:
 
 1. Enable Hardened Runtime during signing:
 
@@ -124,20 +143,26 @@ to the standalone CLI workflow:
    CLI_MACOS_HARDENED_RUNTIME=true
    ```
 
-2. Decide how native addons are handled under Hardened Runtime. The CLI embeds
-   and extracts the `@napi-rs/keyring` native `.node` file, so either sign that
-   native file with the same Developer ID identity before embedding it, or add
-   the entitlement below if library validation must be disabled:
+2. Sign the `@napi-rs/keyring` native `.node` file copy before embedding it
+   into the SEA executable. The CLI executable uses these Hardened Runtime
+   entitlements:
 
    ```xml
+   <key>com.apple.security.cs.allow-jit</key>
+   <true/>
+   <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+   <true/>
    <key>com.apple.security.cs.disable-library-validation</key>
    <true/>
    ```
 
-3. Package the signed CLI into a notarizable container, usually ZIP or PKG.
+   The JIT entitlements keep the Node/V8 runtime functional. Library validation
+   is disabled because CLI flows may load native Node addons.
 
-4. Submit it with `notarytool` using the same Apple credentials already used by
-   desktop releases:
+3. Package the signed CLI into a notarizable ZIP.
+
+4. Submit the ZIP with `notarytool` using the same Apple credentials already
+   used by desktop releases:
 
    ```bash
    xcrun notarytool submit path/to/onekey-cli.zip \
@@ -147,17 +172,32 @@ to the standalone CLI workflow:
      --wait
    ```
 
-5. Staple the ticket when the artifact type supports stapling:
-
-   ```bash
-   xcrun stapler staple path/to/onekey-cli.zip
-   ```
-
-6. Verify on a clean macOS machine or VM:
+5. Verify on CI and on a clean macOS machine or VM:
 
    ```bash
    spctl --assess --type execute --verbose path/to/onekey
    path/to/onekey --version
    ```
 
-Keep notarization opt-in until a non-npm distribution channel requires it.
+For offline first-run support, distribute a `.pkg` or `.dmg` wrapper and staple
+that container. A plain standalone binary should be treated as an online-ticket
+notarized artifact.
+
+## Apple Account Setup
+
+No new App ID, provisioning profile, iCloud capability, App Sandbox setting, or
+Keychain access group is needed for the CLI. Keep the signing identifier as
+`so.onekey.cli`; it is only a code-signing identifier for this Mach-O binary.
+
+Required Apple-side material:
+
+- A valid `Developer ID Application` certificate in the OneKey Apple Developer
+  team. The existing desktop `DESKTOP_KEYS_SECRET` and `CSC_KEY_PASSWORD` can be
+  reused if that P12 contains `Developer ID Application: ...`.
+- An Apple ID that has access to that developer team and an app-specific
+  password stored as `APPLEIDPASS`.
+- The Apple Developer Team ID stored as `ASC_PROVIDER`, matching the desktop
+  notarization workflow.
+
+Only add a `Developer ID Installer` certificate if we later choose to ship a
+stapled `.pkg` installer.

--- a/apps/cli/entitlements.macos-standalone.plist
+++ b/apps/cli/entitlements.macos-standalone.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/apps/cli/scripts/package-macos-standalone.js
+++ b/apps/cli/scripts/package-macos-standalone.js
@@ -37,6 +37,16 @@ function run(command, args, options = {}) {
   });
 }
 
+function capture(command, args, options = {}) {
+  console.log(`$ ${[command, ...args].join(' ')}`);
+  return execFileSync(command, args, {
+    cwd: options.cwd || cliRoot,
+    env: options.env ? { ...process.env, ...options.env } : process.env,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+}
+
 function ensureDarwinHost() {
   if (process.platform !== 'darwin') {
     throw new PackageMacOSStandaloneError(
@@ -205,6 +215,127 @@ function removeSignature(filePath) {
   } catch {
     // Fresh Node binaries may not have a removable signature in local dev.
   }
+}
+
+function assertMachOArchitecture(filePath) {
+  const expectedArchitecture = arch === 'arm64' ? 'arm64' : 'x86_64';
+  const fileDescription = capture('file', [filePath], { cwd: repoRoot }).trim();
+  console.log(fileDescription);
+
+  if (!fileDescription.includes('Mach-O 64-bit executable')) {
+    throw new PackageMacOSStandaloneError(
+      `${filePath} is not a Mach-O 64-bit executable.`,
+    );
+  }
+
+  if (!fileDescription.includes(expectedArchitecture)) {
+    throw new PackageMacOSStandaloneError(
+      `${filePath} does not match expected architecture ${expectedArchitecture}.`,
+    );
+  }
+}
+
+function assertExecutableMode(filePath) {
+  if ((fs.statSync(filePath).mode & 0o111) === 0) {
+    throw new PackageMacOSStandaloneError(
+      `${filePath} is not marked as executable.`,
+    );
+  }
+}
+
+function assertNodeOptionsPatched(filePath) {
+  if (fs.readFileSync(filePath).includes(nodeOptionsEnvKey)) {
+    throw new PackageMacOSStandaloneError(
+      `${filePath} still contains NODE_OPTIONS references.`,
+    );
+  }
+}
+
+function verifyStandaloneExecutable(filePath, label) {
+  console.log('');
+  console.log(`Verifying ${label}: ${filePath}`);
+  if (!fs.existsSync(filePath)) {
+    throw new PackageMacOSStandaloneError(`Missing ${label}: ${filePath}`);
+  }
+
+  assertExecutableMode(filePath);
+  assertMachOArchitecture(filePath);
+  assertNodeOptionsPatched(filePath);
+  run('codesign', ['--verify', '--verbose=2', filePath], { cwd: repoRoot });
+  run(filePath, ['--version'], {
+    cwd: cliRoot,
+    env: {
+      HOME: path.join(path.dirname(filePath), '.onekey-cli-home'),
+    },
+  });
+}
+
+function findFirstExecutable(rootDir) {
+  const entries = fs.readdirSync(rootDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const entryPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      const found = findFirstExecutable(entryPath);
+      if (found) {
+        return found;
+      }
+    } else if (entry.isFile() && entry.name === 'onekey') {
+      return entryPath;
+    }
+  }
+
+  return '';
+}
+
+function getSingleTarballPath(tarballDir) {
+  const tarballs = fs
+    .readdirSync(tarballDir)
+    .filter((fileName) => fileName.endsWith('.tgz'));
+
+  if (tarballs.length !== 1) {
+    throw new PackageMacOSStandaloneError(
+      `Expected exactly one npm tarball in ${tarballDir}, found ${tarballs.length}.`,
+    );
+  }
+
+  return path.join(tarballDir, tarballs[0]);
+}
+
+function verifyPackagedArtifacts({
+  buildDir,
+  executablePath,
+  npmPackage,
+  zipPath,
+}) {
+  const verifyDir = path.join(buildDir, 'artifact-verify');
+  const zipExtractDir = path.join(verifyDir, 'zip');
+  const tarballExtractDir = path.join(verifyDir, 'tarball');
+  const tarballPath = getSingleTarballPath(npmPackage.tarballDir);
+
+  fs.rmSync(verifyDir, { recursive: true, force: true });
+  fs.mkdirSync(zipExtractDir, { recursive: true });
+  fs.mkdirSync(tarballExtractDir, { recursive: true });
+
+  verifyStandaloneExecutable(executablePath, 'raw standalone executable');
+
+  run('ditto', ['-x', '-k', zipPath, zipExtractDir], { cwd: repoRoot });
+  const zipExecutablePath = findFirstExecutable(zipExtractDir);
+  if (!zipExecutablePath) {
+    throw new PackageMacOSStandaloneError(
+      `Distribution zip does not contain an onekey executable: ${zipPath}`,
+    );
+  }
+  verifyStandaloneExecutable(zipExecutablePath, 'distribution zip executable');
+
+  run('tar', ['-xzf', tarballPath, '-C', tarballExtractDir], { cwd: repoRoot });
+  const tarballExecutablePath = path.join(
+    tarballExtractDir,
+    'package',
+    'bin',
+    'onekey',
+  );
+  verifyStandaloneExecutable(tarballExecutablePath, 'npm tarball executable');
 }
 
 function prepareSeaEntry(distCliPath, seaEntryPath) {
@@ -407,6 +538,7 @@ function main() {
   buildStandaloneBinary({ buildDir, executablePath });
   const npmPackage = buildNpmPackage({ buildDir, executablePath });
   const zipPath = buildDistributionZip({ buildDir, executablePath });
+  verifyPackagedArtifacts({ buildDir, executablePath, npmPackage, zipPath });
 
   console.log('');
   console.log(`Built: ${executablePath}`);

--- a/apps/cli/scripts/package-macos-standalone.js
+++ b/apps/cli/scripts/package-macos-standalone.js
@@ -13,6 +13,9 @@ class PackageMacOSStandaloneError extends Error {}
 const supportedArchitectures = new Set(['arm64', 'x64']);
 const arch = process.env.CLI_MACOS_ARCH || process.arch;
 const bundleId = process.env.CLI_MACOS_BUNDLE_ID || 'so.onekey.cli';
+const entitlementsPath =
+  process.env.CLI_MACOS_ENTITLEMENTS ||
+  path.join(cliRoot, 'entitlements.macos-standalone.plist');
 const signIdentity = process.env.CLI_MACOS_SIGN_IDENTITY || '-';
 const signingKeychain = process.env.CLI_MACOS_SIGNING_KEYCHAIN || '';
 const timestamp =
@@ -95,6 +98,23 @@ function resolveNativeKeyringBindingPath() {
   return nativePackageMain;
 }
 
+function prepareNativeKeyringBinding({ buildDir }) {
+  const nativeBindingPath = resolveNativeKeyringBindingPath();
+  const signedNativeBindingPath = path.join(buildDir, 'keyring-native.node');
+
+  fs.copyFileSync(nativeBindingPath, signedNativeBindingPath);
+  fs.chmodSync(signedNativeBindingPath, 0o755);
+  removeSignature(signedNativeBindingPath);
+  signFile(signedNativeBindingPath, {
+    identifier: `${bundleId}.keyring-native`,
+  });
+  run('codesign', ['--verify', '--verbose=2', signedNativeBindingPath], {
+    cwd: repoRoot,
+  });
+
+  return signedNativeBindingPath;
+}
+
 function supportsBuildSea() {
   try {
     const help = execFileSync(process.execPath, ['--help'], {
@@ -120,8 +140,11 @@ function ensureNodeSupportsSeaInjection() {
   }
 }
 
-function signFile(filePath) {
-  const args = ['--force', '--sign', signIdentity, '--identifier', bundleId];
+function signFile(
+  filePath,
+  { identifier = bundleId, entitlements = false } = {},
+) {
+  const args = ['--force', '--sign', signIdentity, '--identifier', identifier];
 
   if (signingKeychain) {
     args.push('--keychain', signingKeychain);
@@ -133,6 +156,9 @@ function signFile(filePath) {
   }
   if (hardenedRuntime) {
     args.push('--options', 'runtime');
+  }
+  if (entitlements) {
+    args.push('--entitlements', entitlementsPath);
   }
 
   args.push(filePath);
@@ -212,7 +238,7 @@ function buildStandaloneBinary({ buildDir, executablePath }) {
   const seaEntryPath = path.join(buildDir, 'sea-entry.cjs');
   const seaConfigPath = path.join(buildDir, 'sea-config.json');
   const seaBlobPath = path.join(buildDir, 'onekey-sea.blob');
-  const nativeKeyringBindingPath = resolveNativeKeyringBindingPath();
+  const nativeKeyringBindingPath = prepareNativeKeyringBinding({ buildDir });
 
   ensureNodeSupportsSeaInjection();
   prepareSeaEntry(distCliPath, seaEntryPath);
@@ -235,7 +261,7 @@ function buildStandaloneBinary({ buildDir, executablePath }) {
     });
     fs.chmodSync(executablePath, 0o755);
     disableNodeOptionsEnv(executablePath);
-    signFile(executablePath);
+    signFile(executablePath, { entitlements: hardenedRuntime });
     run('codesign', ['--verify', '--verbose=2', executablePath], {
       cwd: repoRoot,
     });
@@ -277,7 +303,7 @@ function buildStandaloneBinary({ buildDir, executablePath }) {
   );
 
   disableNodeOptionsEnv(executablePath);
-  signFile(executablePath);
+  signFile(executablePath, { entitlements: hardenedRuntime });
   run('codesign', ['--verify', '--verbose=2', executablePath], {
     cwd: repoRoot,
   });
@@ -349,6 +375,21 @@ function buildNpmPackage({ buildDir, executablePath }) {
   };
 }
 
+function buildDistributionZip({ buildDir, executablePath }) {
+  const zipPath = path.join(buildDir, `onekey-cli-darwin-${arch}.zip`);
+
+  fs.rmSync(zipPath, { force: true });
+  run(
+    'ditto',
+    ['-c', '-k', '--keepParent', path.basename(executablePath), zipPath],
+    {
+      cwd: path.dirname(executablePath),
+    },
+  );
+
+  return zipPath;
+}
+
 function main() {
   ensureDarwinHost();
 
@@ -365,9 +406,11 @@ function main() {
 
   buildStandaloneBinary({ buildDir, executablePath });
   const npmPackage = buildNpmPackage({ buildDir, executablePath });
+  const zipPath = buildDistributionZip({ buildDir, executablePath });
 
   console.log('');
   console.log(`Built: ${executablePath}`);
+  console.log(`Distribution zip: ${zipPath}`);
   console.log(`NPM package: ${npmPackage.packageName}`);
   console.log(`Tarball dir: ${npmPackage.tarballDir}`);
 }


### PR DESCRIPTION
## Summary
- Enable Developer ID Hardened Runtime signing and Apple notarization for the macOS standalone OneKey CLI workflow.
- Sign the embedded @napi-rs/keyring native binding before SEA embedding and add CLI-specific Hardened Runtime entitlements.
- Produce notarizable ZIP and npm tarball artifacts, then verify raw, ZIP-contained, and npm-tarball-contained binaries before upload.

## Intent & Context
The standalone macOS CLI now runs as the OneKey CLI identity for Keychain access, instead of being attributed to node or security. The remaining launch problem was Gatekeeper blocking binaries downloaded from GitHub artifacts, Slack, or browser-based channels. The goal is to make the CI-produced macOS CLI artifact acceptable to Gatekeeper without requiring extra Apple App ID, provisioning profile, CloudKit, sandbox, or keychain access group setup.

## Root Cause
The previous workflow only performed codesign --verify. That validates the code signature structure but does not prove Apple notarization has accepted the artifact or that a quarantined download can execute. The standalone CLI workflow did not submit the signed artifact to Apple notarization and did not run a quarantined first-run check against the packaged artifacts.

## Design Decisions
- Reuse the existing desktop Developer ID and notarization secrets: DESKTOP_KEYS_SECRET, CSC_KEY_PASSWORD, APPLEID, APPLEIDPASS, and ASC_PROVIDER.
- Keep the CLI as a plain Mach-O executable with signing identifier so.onekey.cli. No Apple App ID or provisioning profile is needed because this CLI does not use CloudKit, App Sandbox, app groups, or a Keychain access group.
- Enable Hardened Runtime for notarization and add CLI-specific entitlements for Node/V8 and native addon loading.
- Sign a copied @napi-rs/keyring native .node file before embedding it into the SEA executable so the extracted native binding is not left as an unsigned dependency under the standalone CLI flow.
- Make the packaging script fail if the raw executable, distribution ZIP, or npm tarball contains a missing, non-executable, wrong-architecture, unsigned, or NODE_OPTIONS-unpatched binary.
- Submit the ZIP to notarytool, then verify the online notarization ticket for raw, ZIP-contained, and npm-tarball-contained binaries before upload. A plain binary and ZIP cannot be stapled like an app, pkg, or dmg; a stapled pkg or dmg can be added later if offline first-run support is required.
- Avoid using spctl --assess --type execute as the pass/fail check for this plain Mach-O CLI, because current macOS runners can reject non-app binaries with the code is valid but does not seem to be an app.

## Changes Detail
- .github/workflows/cli-macos-standalone.yml: adds a default-on notarize input, enables CLI_MACOS_HARDENED_RUNTIME, submits the ZIP to notarytool, checks raw/ZIP/tarball binaries with codesign --check-notarization, and runs quarantined copies from the packaged artifacts before upload.
- apps/cli/scripts/package-macos-standalone.js: signs the keyring native binding copy, signs the final SEA binary with CLI entitlements when Hardened Runtime is enabled, emits a distribution ZIP, and self-verifies the raw executable plus ZIP/tarball contents.
- apps/cli/entitlements.macos-standalone.plist: adds the standalone CLI Hardened Runtime entitlements.
- apps/cli/docs/macos-standalone.md: documents the CI notarization flow, Apple account requirements, reusable secrets, and the limitation around stapling plain binaries and ZIP files.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: macOS CLI CI artifacts
- **Risk Areas**: Hardened Runtime can expose native addon or Node runtime entitlement gaps; Apple notarization can fail if existing secrets are missing, expired, or not Developer ID Application credentials; plain binary and ZIP artifacts rely on Apple online notarization tickets because they cannot be stapled directly.

## Test plan
- [x] yarn install --immutable
- [x] yarn lint --fix
- [x] node --check apps/cli/scripts/package-macos-standalone.js
- [x] plutil -lint apps/cli/entitlements.macos-standalone.plist
- [x] Ruby YAML parse for .github/workflows/cli-macos-standalone.yml
- [x] bash -n on modified workflow shell blocks
- [x] git diff --check
- [x] PR checks on current HEAD 343901b116a6747d29c8deaf06b95b636101a955 all pass: lint, unittest, Supply Chain, CodeQL, Socket, and Snyk
- [x] cli-macos-standalone workflow run 25486030611 on current HEAD 343901b116a6747d29c8deaf06b95b636101a955 passes for arm64 and x64 with notarize=true
- [x] CI confirms Package standalone CLI, Verify standalone CLI, Notarize standalone CLI, and Upload standalone package succeeded for both arm64 and x64
- [x] Packaging script self-verifies raw, distribution ZIP, and npm tarball binaries before notarization/upload
- [x] CI verifies raw, ZIP-contained, and npm-tarball-contained binaries with codesign --verify --check-notarization after Apple notarization
- [x] CI applies com.apple.quarantine to ZIP-contained and npm-tarball-contained binaries and executes ./onekey --version before artifact upload
