### PR TITLE
OK-54179: dismiss Perps token selector popover on tray-triggered navigation

### DIFF
--- a/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
+++ b/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
@@ -1035,10 +1035,8 @@ export function useTrayDataProvider() {
       const nav = rootNavigationRef.current;
       if (!nav) return;
 
-      // RN Navigation modals render in DOM flow without their own stacking
-      // context, while tamagui Popover/Sheet portal to body at high zIndex —
-      // so a tray-triggered route would otherwise render behind any open
-      // overlay. Notify listeners (e.g. Perp token selector) to dismiss.
+      // Tamagui Popover/Sheet portal to body at high zIndex and would
+      // obscure any tray-triggered RN modal. Ask open overlays to dismiss.
       appEventBus.emit(EAppEventBusNames.TrayActionWillNavigate, undefined);
 
       if (action?.type === 'open-page') {

--- a/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
+++ b/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
@@ -1035,6 +1035,12 @@ export function useTrayDataProvider() {
       const nav = rootNavigationRef.current;
       if (!nav) return;
 
+      // RN Navigation modals render in DOM flow without their own stacking
+      // context, while tamagui Popover/Sheet portal to body at high zIndex —
+      // so a tray-triggered route would otherwise render behind any open
+      // overlay. Notify listeners (e.g. Perp token selector) to dismiss.
+      appEventBus.emit(EAppEventBusNames.TrayActionWillNavigate, undefined);
+
       if (action?.type === 'open-page') {
         if (action.route === TRAY_ROUTE_HOME) {
           resetAboveMainRoute();

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -48,6 +48,8 @@ import {
   useSpotExternalMarketCapsAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { useSpotActiveAssetCtxAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/spot';
+import { appEventBus } from '@onekeyhq/shared/src/eventBus/appEventBus';
+import { EAppEventBusNames } from '@onekeyhq/shared/src/eventBus/appEventBusNames';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
@@ -1159,6 +1161,19 @@ function BasePerpTokenSelector() {
       tokenSelectorOpen: isOpen,
     });
   }, [actions, isOpen]);
+  useEffect(() => {
+    const handleTrayNavigate = () => setIsOpen(false);
+    appEventBus.on(
+      EAppEventBusNames.TrayActionWillNavigate,
+      handleTrayNavigate,
+    );
+    return () => {
+      appEventBus.off(
+        EAppEventBusNames.TrayActionWillNavigate,
+        handleTrayNavigate,
+      );
+    };
+  }, []);
   const triggerLabel = mode === 'spot' ? displayName : `${displayName}USDC`;
   const content = useMemo(
     () => (

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -519,6 +519,7 @@ export interface IAppEventBusPayload {
     params: any;
   };
   [EAppEventBusNames.HomePageReady]: undefined;
+  [EAppEventBusNames.TrayActionWillNavigate]: undefined;
 }
 
 /**

--- a/packages/shared/src/eventBus/appEventBusNames.ts
+++ b/packages/shared/src/eventBus/appEventBusNames.ts
@@ -150,4 +150,5 @@ export enum EAppEventBusNames {
   ShowRookieShare = 'ShowRookieShare',
   CreateNewBrowserTab = 'CreateNewBrowserTab',
   NavigateModalFromBackgroundThread = 'NavigateModalFromBackgroundThread',
+  TrayActionWillNavigate = 'TrayActionWillNavigate',
 }


### PR DESCRIPTION
## Summary
- Tray-triggered navigation (e.g. clicking "待确认的交易" in the macOS tray menu) now dismisses any open Perps token selector popover before navigating, so the resulting modal renders on top instead of being hidden behind it.
- New `appEventBus` event `TrayActionWillNavigate` is emitted from `handleTrayNavigation` and consumed by the Perps token selector.

## Intent & Context
Reported flow on Desktop:
1. Open Perps page → click ticker to open the Token Select popover.
2. Click "待确认的交易" in the macOS tray menu.
3. Expected: pending-tx history detail modal appears on top.
4. Actual: it renders behind the still-open Perps popover.

## Root Cause
The two surfaces use different rendering systems on Desktop:
- The Perps token selector is a tamagui `Popover`, portaled to `document.body` at `zIndex: 150_000` (`SHEET_POPOVER_Z_INDEX`).
- The tray "transaction-detail" action calls `nav.navigate(ERootRoutes.Modal, ...)`, which renders a React Navigation `transparentModal` card inline in the React Native Web root view — **with no zIndex / stacking context**.

So the modal is correctly mounted in the DOM tree but visually obscured by the body-level popover overlay. Raising the modal's zIndex would not help because it has no stacking context to begin with — this is an architectural mismatch, not a numeric layering bug.

## Design Decisions
Three options were considered:
- **A. Local fix via event bus (chosen).** Tray emits `TrayActionWillNavigate` before `nav.navigate`; the Perps token selector subscribes and closes itself. Two files for the bus wiring, one subscription. Scoped, low risk.
- **B. Make `Popover` / `Sheet` primitives globally subscribe to a `dismissOverlays` event.** Prevents recurrence app-wide but requires deciding opt-in semantics (form selects, persistent panels should NOT auto-dismiss) and auditing existing usage. Out of scope here.
- **C. Re-host RN Navigation modals inside a portal at `zIndex >= SHEET_POPOVER_Z_INDEX`.** True structural fix but high blast radius — would reorder modal layering app-wide.

A was chosen because: only Perps Popover is currently affected, the diff is small and obvious, and it does not constrain how B might later be done.

Mobile is unaffected — its Perps token selector uses `navigation.pushModal`, which lives in the same RN Navigation stack as the tray's history-detail target, so layering already works there.

## Changes Detail
- `packages/shared/src/eventBus/appEventBusNames.ts` — add `TrayActionWillNavigate` enum entry.
- `packages/shared/src/eventBus/appEventBus.ts` — add `undefined` payload type.
- `packages/kit/src/hooks/useTrayDataProvider.desktop.ts` — emit `TrayActionWillNavigate` at the top of `handleTrayNavigation`, before any `nav.navigate` branch. Applies to `open-page`, `transaction-detail`, `view-all-transactions`, and `market-detail-v2`.
- `packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx` — `BasePerpTokenSelector` subscribes to the event and calls `setIsOpen(false)`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop (the bug is desktop-only by construction)
- **Risk Areas**: Subscription lifecycle in `BasePerpTokenSelector`. The subscribe/unsubscribe pair uses an empty dependency array and a stable handler, so there is no leak risk. `appEventBus.emit` already runs on every other tray nav action without observed regressions.

## Test plan
- [ ] Open Perps → open Token Select popover → click "待确认的交易" in tray → popover closes, history-detail modal appears on top.
- [ ] Open Perps → open Token Select popover → click any other tray menu item (Home, Market, View All Transactions, market-detail-v2) → popover closes and the target view loads correctly.
- [ ] Open Perps Token Select popover, ignore the tray, interact with the popover normally → no behavior change.
- [ ] Click tray "待确认的交易" with no Perps popover open → no regressions; history-detail opens as before.
- [ ] Ext / Web / Mobile builds remain unaffected (file is `.desktop.ts`).