### PR TITLE
feat: onboarding v2 analytics tracking gaps (OK-54200)

### DIFF
--- a/packages/kit/src/views/Onboardingv2/components/Layout.tsx
+++ b/packages/kit/src/views/Onboardingv2/components/Layout.tsx
@@ -26,6 +26,7 @@ import {
 import { ANIMATE_ONLY_OPACITY_TRANSFORM } from '@onekeyhq/components/src/utils/animationConstants';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { useLanguageSelectorWithoutAuto } from '../../Setting/hooks/useLanguageSelector';
@@ -71,8 +72,11 @@ export const LayoutHeaderBack = memo(({ exit }: { exit?: boolean }) => {
   const icon = exit ? 'CrossedLargeOutline' : 'ArrowLeftOutline';
 
   const handleBack = useCallback(() => {
+    if (exit) {
+      defaultLogger.account.wallet.onboardingExit();
+    }
     navigation.pop();
-  }, [navigation]);
+  }, [navigation, exit]);
 
   if (gtMd && !exit) {
     return (

--- a/packages/kit/src/views/Onboardingv2/hooks/useDeviceConnect.tsx
+++ b/packages/kit/src/views/Onboardingv2/hooks/useDeviceConnect.tsx
@@ -499,6 +499,9 @@ export function useDeviceConnect({
             onBeforeUpdate: prepareUSBForUpdate,
           });
           console.log('Device is in bootloader mode', device);
+          // Bootloader mode hands off to the firmware-update flow, so the throw
+          // below is not a connection failure — suppress the catch-block tracking.
+          connectionFailureTracked = true;
           throw new OneKeyLocalError('Device is in bootloader mode');
         };
 
@@ -688,12 +691,16 @@ export function useDeviceConnect({
         void backgroundApiProxy.serviceHardwareUI.cleanHardwareUiState();
         console.error('handleDeviceConnect error:', error);
         if (!connectionFailureTracked) {
-          void trackHardwareWalletConnection({
+          // Fire-and-forget; an analytics rejection must not mask the original error
+          // in the catch, so we cannot await here.
+          trackHardwareWalletConnection({
             status: 'failure',
             isSoftwareWalletOnlyUser,
             deviceType: device.deviceType,
             hardwareTransportType: forceTransportType || hardwareTransportType,
-          });
+          }).catch((e) =>
+            console.error('trackHardwareWalletConnection failed:', e),
+          );
         }
         throw error;
       }

--- a/packages/kit/src/views/Onboardingv2/hooks/useDeviceConnect.tsx
+++ b/packages/kit/src/views/Onboardingv2/hooks/useDeviceConnect.tsx
@@ -453,6 +453,8 @@ export function useDeviceConnect({
         );
       }
 
+      let connectionFailureTracked = false;
+      let forceTransportType: EHardwareTransportType | undefined;
       try {
         void backgroundApiProxy.serviceHardwareUI.showCheckingDeviceDialog({
           connectId: device.connectId ?? '',
@@ -518,7 +520,6 @@ export function useDeviceConnect({
         }
 
         // Set global transport type based on selected channel before connecting
-        let forceTransportType: EHardwareTransportType | undefined;
         if (tabValue === EConnectDeviceChannel.bluetooth) {
           forceTransportType = EHardwareTransportType.DesktopWebBle;
         } else {
@@ -542,6 +543,7 @@ export function useDeviceConnect({
             features,
             hardwareTransportType: forceTransportType || hardwareTransportType,
           });
+          connectionFailureTracked = true;
           throw new OneKeyHardwareError(
             'connect device failed, no features returned',
           );
@@ -574,6 +576,7 @@ export function useDeviceConnect({
             features,
             hardwareTransportType: forceTransportType || hardwareTransportType,
           });
+          connectionFailureTracked = true;
           Toast.error({
             title: 'Device is in backup mode',
           });
@@ -684,6 +687,14 @@ export function useDeviceConnect({
         // Clear force transport type on device connection error
         void backgroundApiProxy.serviceHardwareUI.cleanHardwareUiState();
         console.error('handleDeviceConnect error:', error);
+        if (!connectionFailureTracked) {
+          void trackHardwareWalletConnection({
+            status: 'failure',
+            isSoftwareWalletOnlyUser,
+            deviceType: device.deviceType,
+            hardwareTransportType: forceTransportType || hardwareTransportType,
+          });
+        }
         throw error;
       }
     },

--- a/packages/kit/src/views/Onboardingv2/pages/CreateOrImportWallet.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/CreateOrImportWallet.tsx
@@ -149,7 +149,12 @@ function CreateOrImportWallet() {
         isFromOnboardingV2: true,
       },
     });
-  }, [navigation]);
+    defaultLogger.account.wallet.addWalletStarted({
+      addMethod: 'ImportWallet',
+      details: { importType: 'address' },
+      isSoftwareWalletOnlyUser,
+    });
+  }, [navigation, isSoftwareWalletOnlyUser]);
 
   const options: IImportOption[] = useMemo(() => {
     const isGoogleLoading =

--- a/packages/kit/src/views/Onboardingv2/pages/OneKeyIDLoginPage.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/OneKeyIDLoginPage.tsx
@@ -160,6 +160,16 @@ function OneKeyIDLoginPage() {
       }
       // Close the same-tick re-entry window before React state updates commit.
       loggingInProviderRef.current = provider;
+      const reportOAuthFailure = () => {
+        if (!isVerifyMode) {
+          defaultLogger.account.wallet.walletAdded({
+            status: 'failure',
+            addMethod: 'CreateKeylessWallet',
+            isSoftwareWalletOnlyUser: true,
+            details: { provider },
+          });
+        }
+      };
       try {
         setLoggingInProvider(provider);
         const result = await signInWithSocialLogin(provider);
@@ -175,17 +185,11 @@ function OneKeyIDLoginPage() {
             });
             setIsResetMode(false);
           } else {
-            // Track wallet creation started after OAuth login succeeds
             if (!isVerifyMode) {
               defaultLogger.account.wallet.addWalletStarted({
                 addMethod: 'CreateKeylessWallet',
                 isSoftwareWalletOnlyUser: true,
-                details: {
-                  provider:
-                    provider === EOAuthSocialLoginProvider.Google
-                      ? 'google'
-                      : 'apple',
-                },
+                details: { provider },
               });
             }
             await checkKeylessWalletCreatedOnServer({
@@ -194,7 +198,12 @@ function OneKeyIDLoginPage() {
               mode,
             });
           }
+        } else {
+          reportOAuthFailure();
         }
+      } catch (error) {
+        reportOAuthFailure();
+        throw error;
       } finally {
         loggingInProviderRef.current = null;
         setLoggingInProvider(null);

--- a/packages/kit/src/views/Onboardingv2/pages/OneKeyIDLoginPage.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/OneKeyIDLoginPage.tsx
@@ -16,6 +16,7 @@ import {
 } from '@onekeyhq/components';
 import { ANIMATE_ONLY_OPACITY_TRANSFORM } from '@onekeyhq/components/src/utils/animationConstants';
 import { EOAuthSocialLoginProvider } from '@onekeyhq/shared/src/consts/authConsts';
+import { OAuthLoginCancelError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale/enum/translations';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -172,6 +173,16 @@ function OneKeyIDLoginPage() {
       };
       try {
         setLoggingInProvider(provider);
+        // Pair every wallet-creation OAuth attempt with a start event so failure
+        // events have a matching denominator. Reset/verify flows reuse OAuth for
+        // identity only and don't create a wallet.
+        if (!isVerifyMode && !isResetMode) {
+          defaultLogger.account.wallet.addWalletStarted({
+            addMethod: 'CreateKeylessWallet',
+            isSoftwareWalletOnlyUser: true,
+            details: { provider },
+          });
+        }
         const result = await signInWithSocialLogin(provider);
         if (result?.session?.accessToken) {
           if (isResetMode) {
@@ -185,13 +196,6 @@ function OneKeyIDLoginPage() {
             });
             setIsResetMode(false);
           } else {
-            if (!isVerifyMode) {
-              defaultLogger.account.wallet.addWalletStarted({
-                addMethod: 'CreateKeylessWallet',
-                isSoftwareWalletOnlyUser: true,
-                details: { provider },
-              });
-            }
             await checkKeylessWalletCreatedOnServer({
               token: result.session.accessToken,
               refreshToken: result.session.refreshToken,
@@ -202,7 +206,10 @@ function OneKeyIDLoginPage() {
           reportOAuthFailure();
         }
       } catch (error) {
-        reportOAuthFailure();
+        // User cancellation is normal behavior, not a failure metric.
+        if (!(error instanceof OAuthLoginCancelError)) {
+          reportOAuthFailure();
+        }
         throw error;
       } finally {
         loggingInProviderRef.current = null;


### PR DESCRIPTION
## Summary

- Fill 4 missing analytics tracking points in onboarding v2: GetStarted X exit, Watch only address entry, Keyless OAuth failure/cancel, hardware connect handshake failure
- Fix `forceTransportType` field missing in the hardware connect catch block (was losing communication channel info — Bluetooth / USB / WebUSB)
- Tracking-only + data accuracy fix; no user-visible UI / copy / flow changes

## Test plan

Regression-style — verify the tracking code didn't accidentally break the user flows it touches. Analytics event delivery itself is verified by the data team in Mixpanel.

- [ ] Enter GetStarted, tap the X close button — onboarding closes cleanly, no white screen
- [ ] CreateOrImportWallet → Watch only address — routes to address input (V1 modal); a valid address creates a watch-only wallet
- [ ] CreateNewWallet → tap Google / Apple, cancel in the OAuth dialog — return to the previous page, buttons recover from loading state, OAuth can be re-initiated
- [ ] ConnectYourDevice → tap a scanned device and trigger a handshake failure (decline BLE pairing prompt / lock device by wrong PIN / unplug during pairing) — error toast surfaces, onboarding does not crash

See [OK-54200](https://onekeyhq.atlassian.net/browse/OK-54200) for full context.

[OK-54200]: https://onekeyhq.atlassian.net/browse/OK-54200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ