### PR TITLE
fix: align BTC market detail mobile fields with desktop

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationPanel/InformationPanel.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationPanel/InformationPanel.tsx
@@ -103,19 +103,19 @@ function HeaderStatRows({
         />
         <StatRow
           label={intl.formatMessage({
-            id: ETranslations.dexmarket_btc_circulating_supply,
+            id: ETranslations.dexmarket_stock_24h_volume,
           })}
           value={formatStatValueWithFormatter(
-            btcMetadata.circulatingSupply,
-            MARKET_CAP_FORMATTER,
+            btcMetadata.volume24h,
+            USD_CURRENCY_FORMATTER,
           )}
         />
         <StatRow
           label={intl.formatMessage({
-            id: ETranslations.dexmarket_btc_remaining_supply,
+            id: ETranslations.dexmarket_btc_circulating_supply,
           })}
           value={formatStatValueWithFormatter(
-            btcMetadata.remainingSupply,
+            btcMetadata.circulatingSupply,
             MARKET_CAP_FORMATTER,
           )}
         />


### PR DESCRIPTION
https://onekeyhq.atlassian.net/browse/OK-54212
## Summary

Align the BTC market detail page mobile header fields with the desktop layout.

Mobile previously showed: 市值 / 流通供应量 / 剩余供应量
Desktop shows: 市值 / 24小时交易量 / 流通供应量

Mobile is now updated to match desktop, replacing 剩余供应量 with 24小时交易量 and reordering accordingly. Follow-up to #11469 which introduced the desktop layout.

## Test plan

- [ ] iOS — open BTC detail; header shows 市值 / 24小时交易量 / 流通供应量 with `$` prefix and T/B/M/K units
- [ ] Android — same as above
- [ ] Desktop regression — header still renders the same three fields, no layout shift
- [ ] Non-BTC ERC-20 token mobile detail — still shows 市值 / 流动性 / 持有人
- [ ] Stock-token mobile detail — still shows 市值 / 24h volume / PE