### PR TITLE
fix: use dexmarket i18n keys for market liquidity pools(OK-54210)(OK-54189)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/TokenLiquidityPools.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/TokenLiquidityPools.tsx
@@ -280,19 +280,16 @@ function useLiquidityPoolLabels(): ILiquidityPoolLabels {
   const intl = useIntl();
 
   return useMemo(() => {
-    const pool = intl.formatMessage({
-      id: ETranslations.wallet_defi_position_module_liquidity_pool,
-    });
-    const address = intl.formatMessage({ id: ETranslations.global_address });
-
     return {
-      pool,
+      pool: intl.formatMessage({ id: ETranslations.dexmarket_pool }),
       tokenAmount: intl.formatMessage({
-        id: ETranslations.wallet_defi_portfolio_column_amount,
+        id: ETranslations.dexmarket_token_amount,
       }),
-      feeRate: intl.formatMessage({ id: ETranslations.fee_fee_rate }),
-      poolAddress: `${pool} ${address}`,
-      creator: intl.formatMessage({ id: ETranslations.nft_owner_program }),
+      feeRate: intl.formatMessage({ id: ETranslations.dexmarket_tax_rate }),
+      poolAddress: intl.formatMessage({
+        id: ETranslations.dexmarket_pool_address,
+      }),
+      creator: intl.formatMessage({ id: ETranslations.dexmarket_creator }),
     };
   }, [intl]);
 }
@@ -757,7 +754,7 @@ function TokenLiquidityPoolsDesktopHeader() {
         {labels.pool}
       </SizableText>
       <SizableText {...DESKTOP_HEADER_TEXT_PROPS} {...styles.liquidity}>
-        {intl.formatMessage({ id: ETranslations.global_liquidity })}
+        {intl.formatMessage({ id: ETranslations.dexmarket_liquidity })}
       </SizableText>
       <SizableText {...DESKTOP_HEADER_TEXT_PROPS} {...styles.tokenAmount}>
         {labels.tokenAmount}
@@ -789,7 +786,7 @@ function TokenLiquidityPoolsMobileHeader() {
         textAlign="right"
         {...MOBILE_COLUMN_STYLE.liquidity}
       >
-        {intl.formatMessage({ id: ETranslations.global_liquidity })}
+        {intl.formatMessage({ id: ETranslations.dexmarket_liquidity })}
       </SizableText>
       <SizableText
         {...MOBILE_HEADER_TEXT_PROPS}
@@ -948,9 +945,7 @@ function PoolDetailsContent({ item }: { item: IDisplayPool }) {
             {intl.formatMessage({ id: ETranslations.dexmarket_select_token })}
           </SizableText>
           <SizableText size="$bodyMdMedium" color="$textSubdued">
-            {intl.formatMessage({
-              id: ETranslations.wallet_defi_portfolio_column_amount,
-            })}
+            {labels.tokenAmount}
           </SizableText>
         </XStack>
         <DetailTokenRows tokens={item.tokenAmounts} />
@@ -984,7 +979,7 @@ function MobilePoolRow({ item }: { item: IDisplayPool }) {
 
   const handlePress = useCallback(() => {
     Dialog.show({
-      title: intl.formatMessage({ id: ETranslations.market_pool_details }),
+      title: intl.formatMessage({ id: ETranslations.dexmarket_pool_details }),
       renderContent: <PoolDetailsContent item={item} />,
       showFooter: false,
     });
@@ -1177,7 +1172,7 @@ export function TokenLiquidityPools({
       {showTitle ? (
         <SizableText size="$headingXs" color="$text" px="$5" pb="$3">
           {intl.formatMessage({
-            id: ETranslations.wallet_defi_position_module_liquidity_pool,
+            id: ETranslations.dexmarket_pool,
           })}
         </SizableText>
       ) : null}

--- a/packages/kit/src/views/Market/components/MarketDetailPools.tsx
+++ b/packages/kit/src/views/Market/components/MarketDetailPools.tsx
@@ -280,7 +280,7 @@ export function MarketDetailPools({
         inPageDialog.show({
           showFooter: false,
           title: intl.formatMessage({
-            id: ETranslations.market_pool_details,
+            id: ETranslations.dexmarket_pool_details,
           }),
           renderContent: isCEXSelected ? (
             <PairDetailDialog item={item as IMarketDetailTicker} />


### PR DESCRIPTION
## Summary
- Replace generic/legacy translation keys with dedicated `dexmarket_*` keys across the Market liquidity pool UI (header, mobile/desktop rows, pool detail dialog).
- Use a single `dexmarket_pool_address` key instead of concatenating `${pool} ${address}`, which previously rendered an extra space between the two words.

## Intent & Context
Two related Market i18n cleanups requested by design/PM:
- **OK-54210** Market - 流动性文案补充: design supplied a set of new keys (`dexmarket::pool`, `dexmarket::token_amount`, `dexmarket::tax_rate`, `dexmarket::creator`, `dexmarket::pool_details`, plus `dexmarket::pool_address` / `dexmarket::liquidity`) that should be used in the Market liquidity pools view instead of borrowed strings from `wallet_defi_*`, `global_*`, `nft_*`, and `fee_*` namespaces.
- **OK-54189** Market - 流动性池地址 i18n 多了空格: the Pool Address label was assembled at runtime as `${pool} ${address}`, leaving a stray space (and not localizing well in non-English locales). Switching to the dedicated `dexmarket_pool_address` key removes the manual concatenation and the extra space.

## Root Cause
- The pool detail UI was reusing translation keys from unrelated modules (DeFi portfolio, NFT, global) because Market-specific copies had not been wired up yet.
- `poolAddress` was hand-built by joining two independently-translated tokens with a literal space — language-specific (CJK has no space), and produced the visible double-spacing/extra-space bug reported in OK-54189.

## Design Decisions
- Keep changes minimal: only swap the `id` passed to `intl.formatMessage` (and inline one missing `labels.tokenAmount` for consistency). No layout / component refactors.
- Drop the now-unused local `pool` and `address` intermediates inside `useLiquidityPoolLabels` since `poolAddress` no longer needs to compose them.
- Reuse the same dedicated `dexmarket_pool_details` key in `MarketDetailPools.tsx` so the dialog title matches the V2 detail view.

## Changes Detail
- `packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/TokenLiquidityPools.tsx`
  - `useLiquidityPoolLabels`: `pool`, `tokenAmount`, `feeRate`, `poolAddress`, `creator` now resolved via `dexmarket_*` keys; remove manual `${pool} ${address}` composition.
  - Desktop/Mobile headers: `global_liquidity` → `dexmarket_liquidity`.
  - `PoolDetailsContent`: amount column now uses `labels.tokenAmount` (i.e. `dexmarket_token_amount`) for consistency with the table.
  - `MobilePoolRow` dialog title: `market_pool_details` → `dexmarket_pool_details`.
  - Section header (`showTitle`): `wallet_defi_position_module_liquidity_pool` → `dexmarket_pool`.
- `packages/kit/src/views/Market/components/MarketDetailPools.tsx`
  - In-page dialog title for pool details: `market_pool_details` → `dexmarket_pool_details`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Mobile / Web / Extension (Market detail view, all platforms)
- **Risk Areas**: Pure translation-key swap inside `intl.formatMessage(...)` calls; assumes the `dexmarket_*` keys exist in the auto-generated `ETranslations` enum (TypeScript would fail otherwise — `tsc:staged` passed locally).

## Test plan
- [ ] Open Market detail page for a token that has liquidity pools; confirm the section title shows "Pool" (en) / corresponding localized strings.
- [ ] Desktop & Mobile: verify the table headers show Pool / Liquidity / Token Amount / Tax Rate / Pool Address / Creator with no extra spaces.
- [ ] Mobile: tap a pool row — dialog title reads "Pool Details", and the amount column header reads "Token Amount".
- [ ] V1 `MarketDetailPools` dialog: title reads "Pool Details".
- [ ] Switch app language to zh-CN and verify the same strings render correctly with no double-spacing in "Pool Address".
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/11493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->