### PR TITLE
fix: do not drop logger events whose method body returns undefined

### DIFF
--- a/packages/shared/src/logger/base/decorators.test.ts
+++ b/packages/shared/src/logger/base/decorators.test.ts
@@ -1,5 +1,5 @@
 import { BaseScene } from './baseScene';
-import { LogToConsole, LogToLocal } from './decorators';
+import { LogToConsole, LogToLocal, LogToServer } from './decorators';
 
 import type { IMethodDecoratorMetadata } from '../types';
 
@@ -32,6 +32,13 @@ class NestedCallTestScene extends BaseScene {
   methodB() {
     return ['fromB'];
   }
+
+  @LogToServer()
+  @LogToLocal()
+  emptyBodyEvent() {}
+
+  @LogToLocal()
+  singleDecoratorEmpty() {}
 }
 
 describe('logger decorators', () => {
@@ -49,6 +56,32 @@ describe('logger decorators', () => {
       {
         methodName: 'methodA',
         args: ['fromA'],
+        metadataList: [{ level: 'info', type: 'local' }],
+      },
+    ]);
+  });
+
+  it('emits payload-less events whose method body has no return statement', () => {
+    // Regression guard for #10959: empty-body methods such as `appStart()` were
+    // being silently dropped because the decorator treated `result === undefined`
+    // as a skip signal even when wrapping the user's actual method.
+    const scene = new NestedCallTestScene();
+
+    scene.emptyBodyEvent();
+    scene.singleDecoratorEmpty();
+
+    expect(scene.emissions).toEqual([
+      {
+        methodName: 'emptyBodyEvent',
+        args: [undefined],
+        metadataList: [
+          { level: 'info', type: 'local' },
+          { level: 'info', type: 'server' },
+        ],
+      },
+      {
+        methodName: 'singleDecoratorEmpty',
+        args: [undefined],
         metadataList: [{ level: 'info', type: 'local' }],
       },
     ]);

--- a/packages/shared/src/logger/base/decorators.ts
+++ b/packages/shared/src/logger/base/decorators.ts
@@ -37,7 +37,9 @@ function createDecorator(decoratorArgs: IMethodDecoratorMetadata) {
         metadataStack.push(callContext);
       }
 
-      if (!originalMethod[LOGGER_DECORATOR_WRAPPER]) {
+      const wrapsAnotherDecorator = !!originalMethod[LOGGER_DECORATOR_WRAPPER];
+
+      if (!wrapsAnotherDecorator) {
         callContext.isCollectingDecorators = false;
       }
 
@@ -53,8 +55,11 @@ function createDecorator(decoratorArgs: IMethodDecoratorMetadata) {
       try {
         let result = originalMethod.apply(this, args);
 
-        // Inner decorator error → propagate skip to outer
-        if (result === undefined) {
+        // Inner decorator's catch path returns undefined to signal skip — propagate
+        // only when wrapping another decorator. The innermost wrapper sees the user
+        // method's real return; an undefined there is the "no payload, just log the
+        // event" case (e.g. `appStart() {}`) and must still be emitted.
+        if (result === undefined && wrapsAnotherDecorator) {
           cleanupContext();
           return undefined;
         }


### PR DESCRIPTION
## Summary

- Hotfix for 6.2.0 — restores 11 silently-dropped server/local analytics events (incl. `appStart`).
- Limits the decorator's `result === undefined` skip propagation to outer wrappers only; the innermost wrapper now lets payload-less methods (e.g. `appStart() {}`) emit normally.
- Adds a regression test covering both stacked and single-decorator empty-body methods.

## Background

#10959 introduced an early `if (result === undefined) return undefined` in `createDecorator` to propagate the inner-decorator catch-path skip signal to the outer decorator. The check conflates two cases:

1. **Inner wrapper's catch path returned undefined** — legitimate skip signal.
2. **The user method has no return statement** — `apply()` returns undefined, but the event must still be logged.

For methods like `@LogToServer @LogToLocal appStart() {}`, both wrappers see `undefined` and exit before calling `_emitLog`. Pre-#10959 behavior wrapped this to `[undefined]`, and `handleServerLog`'s reducer treated `[undefined]` as `trackEvent(name, {})`.

## Affected events (6.2.0)

| File | Method | Decorators |
|---|---|---|
| `app/scenes/page.ts` | `appStart` | LogToServer + LogToLocal |
| `app/scenes/page.ts` | `navigationToggle` | LogToServer + LogToLocal |
| `app/scenes/component.ts` | `confirmedInUpdateDialog` | LogToServer + LogToLocal |
| `app/scenes/component.ts` | `closedInUpdateDialog` | LogToServer + LogToLocal |
| `account/scenes/wallet.ts` | `deleteWallet` | LogToServer + LogToLocal |
| `account/scenes/wallet.ts` | `enterManageToken` | LogToServer + LogToLocal |
| `account/scenes/wallet.ts` | `walletManualRefresh` | LogToServer + LogToLocal |
| `account/scenes/wallet.ts` | `openSidePanel` | LogToServer + LogToLocal |
| `account/scenes/wallet.ts` | `openExpandView` | LogToServer + LogToLocal |
| `account/scenes/wallet.ts` | `walletPullToRefresh` | LogToServer + LogToLocal |
| `scanQrCode/scenes/readQrCode.ts` | `releaseCamera` | LogToLocal only |

## Fix

Use the existing `LOGGER_DECORATOR_WRAPPER` flag to distinguish outer (wrapping another decorator) vs innermost (wrapping the user's actual method) wrappers. Only propagate the `undefined` skip signal at the outer level.

```ts
const wrapsAnotherDecorator = !!originalMethod[LOGGER_DECORATOR_WRAPPER];
...
if (result === undefined && wrapsAnotherDecorator) {
  cleanupContext();
  return undefined;
}
```

The catch path (still returning `undefined`) continues to short-circuit outer wrappers as before.

## Test plan

- [x] `yarn jest packages/shared/src/logger/base/decorators.test.ts` — 2 / 2 pass (existing nested-call test + new regression test for empty-body methods)
- [x] `yarn tsc --noEmit packages/shared/tsconfig.json` — clean
- [x] Manual: trigger `appStart` on a 6.2.0 build, confirm it appears in analytics
- [x] Manual: trigger `deleteWallet`, confirm event reported
- [x] Manual: confirm previously-working events (with payload) still report — e.g. `pageView`, `tabBarClick`

## Notes

- Same bug exists on `x`. A separate PR will follow to land the same fix on `x` (or this can be cherry-picked after merge).