### PR TITLE
chore: bump Node heap size for EAS mobile builds

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -10,7 +10,8 @@
         "ENABLE_NATIVE_BACKGROUND_THREAD": "true",
         "SPLIT_BUNDLE": "1",
         "SPLIT_BUNDLE_SEGMENTS": "true",
-        "UNION_BUILD": "true"
+        "UNION_BUILD": "true",
+        "NODE_OPTIONS": "--max-old-space-size=8192"
       },
       "android": {
         "image": "ubuntu-24.04-jdk-17-ndk-r27b",


### PR DESCRIPTION
## Summary
- Add `NODE_OPTIONS=--max-old-space-size=8192` to `base.env` in `apps/mobile/eas.json` so all extending profiles (production / production-store / qa-internal / simulator) inherit it.
- Fixes OOM during EAS mobile builds (Metro bundle / source map upload steps) on the default `medium` resource class (iOS 20 GB / Android 16 GB).

## Why 8 GB
- Default Node old-space cap (~4 GB) is too small for the bundler step on this monorepo.
- Leaves ample headroom for Gradle / Xcode / Metro on a `medium` machine. If still OOM, next steps are bumping to 12288 or upgrading `resourceClass` to `large`.

## Test plan
- [ ] Trigger an EAS Android build on this branch and confirm bundling step no longer OOMs.
- [ ] Trigger an EAS iOS build on this branch and confirm bundling step no longer OOMs.
- [ ] Confirm `eas.json` is still valid (EAS CLI accepts the build profile without schema errors).