### PR TITLE
fix: keep Market detail sidebar visible on desktop (OK-54287 OK-54296)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/MarketDetailV2.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/MarketDetailV2.tsx
@@ -93,6 +93,7 @@ function MarketDetailV2(
   const { navigation } = props;
   const isLandscape = useIsSplitView();
   const isTablet = isNativeTablet();
+  const media = useMedia();
 
   useLayoutEffect(() => {
     if (!platformEnv.isNativeIOS) {
@@ -109,7 +110,10 @@ function MarketDetailV2(
 
   useFocusEffect(
     useCallback(() => {
-      if (platformEnv.isExtension || (isTablet && isLandscape)) {
+      const shouldHideTabBar =
+        platformEnv.isNative || (!platformEnv.isExtension && media.md);
+
+      if (!shouldHideTabBar || (isTablet && isLandscape)) {
         return;
       }
 
@@ -118,7 +122,7 @@ function MarketDetailV2(
       return () => {
         appEventBus.emit(EAppEventBusNames.HideTabBar, false);
       };
-    }, [isLandscape, isTablet]),
+    }, [isLandscape, isTablet, media.md]),
   );
 
   return (


### PR DESCRIPTION
## Summary
- Narrow the `HideTabBar` emission in Market detail to (a) native mobile or (b) non-extension web at the md breakpoint (≤767px).
- Restore sidebar/tab bar visibility on Desktop and on web ≥768px when entering a Market detail screen.

## Intent & Context
Two QA bugs report the same regression class on the Market detail page:
- **OK-54287** — "Market - 进入详情页后页面全屏，左边侧边栏消失": after navigating into a Market detail, the desktop layout went fullscreen and the left sidebar disappeared.
- **OK-54296** — "Market - tokendetails 页面导航栏消失": the token details page lost its navigation bar.

Both bugs share the same root cause: `HideTabBar` was being emitted on platforms/viewports where the host layout still expects the sidebar/tab bar to remain visible.

## Root Cause
The previous focus-effect early-return only suppressed `HideTabBar` on the browser extension or a tablet in landscape:

```ts
if (platformEnv.isExtension || (isTablet && isLandscape)) {
  return;
}
appEventBus.emit(EAppEventBusNames.HideTabBar, true);
```

That meant the event still fired on Desktop and on Web at *any* viewport — even though Desktop and wide-Web render a sidebar layout where hiding the tab bar collapsed the sidebar/navigation unexpectedly.

## Design Decisions
The new condition expresses *when hiding makes sense* (positive predicate) rather than enumerating exclusions:

```ts
const shouldHideTabBar =
  platformEnv.isNative || (!platformEnv.isExtension && media.md);

if (!shouldHideTabBar || (isTablet && isLandscape)) {
  return;
}
```

- `platformEnv.isNative` — mobile (iOS/Android) where the tab bar should yield screen real estate to the detail view.
- `!platformEnv.isExtension && media.md` — web/desktop at the md breakpoint (≤767px per `tamagui.config.ts`), where the layout falls back to a mobile-style tab bar; the extension keeps its existing chrome.
- Tablet-landscape stays as a hard exception (sidebar layout, identical to prior behavior).

`media.md` is added to the `useCallback` dependency array so the focus effect re-evaluates if the viewport crosses the breakpoint while the screen is mounted (e.g. window resize on web).

## Changes Detail
- `packages/kit/src/views/Market/MarketDetailV2/MarketDetailV2.tsx`
  - Consume `useMedia()` in `MarketDetailV2`.
  - Replace the early-return guard in the focus effect with a positive `shouldHideTabBar` predicate scoped to native + non-extension web-md only.
  - Add `media.md` to `useCallback` deps so the cleanup/emit pair refreshes on breakpoint changes.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Web (browser desktop & responsive), Desktop app, Native iOS/Android (no behavioral change on phones), Extension (no behavioral change).
- **Risk Areas**:
  - Web at md (≤767px): tab bar still hides on Market detail — same as before for that size class.
  - Tablet landscape: still skipped (unchanged).
  - Native mobile: unchanged — still hides on focus, restores on blur.
  - Effect re-runs when `media.md` flips during resize; the cleanup function still emits `HideTabBar(false)` so no stuck-hidden states.

## Test plan
- [ ] Desktop app: open Market → enter a token detail; sidebar stays visible; navigate back; sidebar still visible.
- [ ] Web ≥768px: same as desktop — sidebar / nav remains visible across detail navigation.
- [ ] Web ≤767px (responsive md): tab bar hides on detail; restores on back navigation; resizing across the breakpoint behaves correctly.
- [ ] Native iOS / Android: tab bar still hides on Market detail; restores on back.
- [ ] Tablet (iPad) landscape: tab bar / sidebar remains visible (regression-check on the existing exception).
- [ ] Browser extension: no change — tab bar remains visible on Market detail.