### PR TITLE
fix: inline category selector styling in PopularTrading (OK-54295)

### DIFF
--- a/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
@@ -1075,6 +1075,8 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
             categories={homeCategories}
             selectedCategoryId={selectedCategoryId}
             onSelectCategory={setSelectedCategoryId}
+            showBorder={false}
+            showHorizontalPadding={false}
           />
         </YStack>
         {listContent}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/CategorySelector/CategorySelector.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/CategorySelector/CategorySelector.tsx
@@ -17,6 +17,8 @@ interface ICategorySelectorProps {
   selectedCategoryId: string;
   onSelectCategory: (id: string) => void;
   triggerOnPressDown?: boolean;
+  showBorder?: boolean;
+  showHorizontalPadding?: boolean;
 }
 
 function CategorySelectorImpl({
@@ -24,6 +26,8 @@ function CategorySelectorImpl({
   selectedCategoryId,
   onSelectCategory,
   triggerOnPressDown = false,
+  showBorder = true,
+  showHorizontalPadding = true,
 }: ICategorySelectorProps) {
   const { md } = useMedia();
   const shouldUseScrollableBar = md || platformEnv.isNative;
@@ -81,10 +85,15 @@ function CategorySelectorImpl({
 
   return (
     <XStack
-      p="$1"
+      py="$1"
+      px={showHorizontalPadding ? '$1' : undefined}
       gap="$0.5"
-      borderWidth={1}
-      borderColor="$borderSubdued"
+      {...(showBorder
+        ? {
+            borderWidth: 1,
+            borderColor: '$borderSubdued',
+          }
+        : undefined)}
       borderRadius="$3"
       mt="$3"
       mb="$2"


### PR DESCRIPTION
## Summary
- Add optional `showBorder` and `showHorizontalPadding` props to `CategorySelector` (both default to `true`, preserving existing visual style).
- In Home `PopularTrading`, render the embedded `CategorySelector` with `showBorder={false}` and `showHorizontalPadding={false}` so it sits flush inside the section that already provides its own page padding.

## Intent & Context
The Market `CategorySelector` is also embedded into Home `PopularTrading`. In that inline context, the wrapping `YStack` already applies page padding (`px="$pagePadding"` on the `tableLayout` branch), so the selector's default border + inner horizontal padding produced redundant chrome and visual noise on desktop/web. We need the same component to keep its standalone styling on the Market page while being visually integrated when nested inside `PopularTrading`.

## Design Decisions
- Expose two narrowly-scoped boolean props on `CategorySelector` rather than introducing a `variant`/style preset — only two style toggles are needed today and both have well-defined defaults.
- Defaults stay `true` so all other call sites (Market) keep current behavior with no change.
- Apply `borderWidth`/`borderColor` via spread of an inline object, keeping the JSX terse and ensuring the props are fully omitted (not set to `undefined`) when the border is hidden.
- Switched the wrapper from `p="$1"` to `py="$1"` + conditional `px` so vertical padding remains for both modes, and only horizontal padding is gated by the new flag.

## Changes Detail
- `packages/kit/src/views/Market/MarketHomeV2/components/CategorySelector/CategorySelector.tsx`: add `showBorder` / `showHorizontalPadding` optional props (default `true`); split horizontal/vertical padding; conditionally apply `borderWidth` + `borderColor`.
- `packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx`: pass `showBorder={false}` and `showHorizontalPadding={false}` to the inline `CategorySelector` inside the `PopularTrading` view.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Web (and any non-`md`, non-native renderer that hits the `XStack` branch of `CategorySelectorImpl`).
- **Risk Areas**: Defaults are preserved for existing callers (Market). Mobile / native paths render via `ScrollableFilterBar` and are not touched. The Home embedding is the only call site explicitly opting into the new flags.

## Test plan
- [ ] Desktop / Web Home tab: `PopularTrading` category selector renders without an outer border and without internal horizontal padding, sitting flush with surrounding section padding.
- [ ] Desktop / Web Market page: `CategorySelector` still renders with its existing border and inner horizontal padding (default props).
- [ ] Mobile / native: Home and Market category bars still scroll horizontally via `ScrollableFilterBar` — no visual regression.
- [ ] Switching categories in both Home and Market still updates the selected state correctly.