### PR TITLE
fix: harden DeFi initial refresh (OK-54353)

### DIFF
--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
@@ -505,6 +505,13 @@ function DeFiListBlock({
       accountId?: string;
       networkId?: string;
     }) => {
+      if (!refreshCacheOnly && accountId && networkId) {
+        await backgroundApiProxy.serviceDeFi.updateCurrentAccount({
+          accountId,
+          networkId,
+        });
+      }
+
       deFiRawDataRef.current =
         (await backgroundApiProxy.simpleDb.deFi.getRawData()) ?? undefined;
 

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
@@ -72,6 +72,18 @@ const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
 const MAX_PROTOCOLS_ON_SMALL_SCREEN = 6;
 const PROTOCOL_LIST_TOGGLE_PRESS_LOCK_MS = 600;
 
+function buildSingleNetworkDeFiCacheKey({
+  accountId,
+  networkId,
+  accountAddress,
+}: {
+  accountId: string;
+  networkId: string;
+  accountAddress?: string;
+}) {
+  return `${accountId}:${networkId}:${accountAddress ?? ''}`;
+}
+
 function MobileProtocolDivider() {
   return (
     <YStack px="$5" pt="$1" pb="$2">
@@ -176,6 +188,10 @@ function DeFiListBlock({
   protocolsRef.current = protocols;
   protocolMapRef.current = protocolMap;
   const pendingRefreshRef = useRef(false);
+  const singleNetworkLocalCacheRef = useRef<{
+    cacheKey?: string;
+    hasCache: boolean;
+  }>({ hasCache: false });
 
   const [isSliced, setIsSliced] = useDeFiListSlicedAtom();
   const overviewCols = useMemo(
@@ -299,7 +315,14 @@ function DeFiListBlock({
       });
 
       try {
-        const shouldForceInitialRefresh = !initializedRef.current;
+        const cacheKey = buildSingleNetworkDeFiCacheKey({
+          accountId: account.id,
+          networkId: network.id,
+          accountAddress: account.address,
+        });
+        const shouldForceInitialRefresh =
+          singleNetworkLocalCacheRef.current.cacheKey !== cacheKey ||
+          !singleNetworkLocalCacheRef.current.hasCache;
         const resp =
           await backgroundApiProxy.serviceDeFi.fetchAccountDeFiPositions({
             accountId: account.id,
@@ -312,6 +335,9 @@ function DeFiListBlock({
             isForceRefresh:
               isForceRefreshRef.current || shouldForceInitialRefresh,
           });
+        if (singleNetworkLocalCacheRef.current.cacheKey === cacheKey) {
+          singleNetworkLocalCacheRef.current.hasCache = true;
+        }
         updateAccountDeFiOverview({
           currency: settings.currencyInfo.id,
           accountId: account.id,
@@ -780,6 +806,15 @@ function DeFiListBlock({
       accountId: string;
       networkId: string;
     }) => {
+      const cacheKey = buildSingleNetworkDeFiCacheKey({
+        accountId,
+        networkId,
+        accountAddress: account?.address,
+      });
+      singleNetworkLocalCacheRef.current = {
+        cacheKey,
+        hasCache: false,
+      };
       updateOverviewDeFiDataState({
         accountId,
         networkId,
@@ -808,6 +843,9 @@ function DeFiListBlock({
 
       if (localDeFiOverview) {
         const rawOverview = localDeFiOverview.overview[networkId];
+        if (singleNetworkLocalCacheRef.current.cacheKey === cacheKey) {
+          singleNetworkLocalCacheRef.current.hasCache = Boolean(rawOverview);
+        }
         if (rawOverview) {
           let convertedOverview = rawOverview;
           if (rawOverview.currency !== settings.currencyInfo.id) {

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
@@ -299,6 +299,7 @@ function DeFiListBlock({
       });
 
       try {
+        const shouldForceInitialRefresh = !initializedRef.current;
         const resp =
           await backgroundApiProxy.serviceDeFi.fetchAccountDeFiPositions({
             accountId: account.id,
@@ -308,7 +309,8 @@ function DeFiListBlock({
             sourceCurrencyInfo,
             targetCurrencyInfo,
             saveToLocal: true,
-            isForceRefresh: isForceRefreshRef.current,
+            isForceRefresh:
+              isForceRefreshRef.current || shouldForceInitialRefresh,
           });
         updateAccountDeFiOverview({
           currency: settings.currencyInfo.id,
@@ -404,6 +406,7 @@ function DeFiListBlock({
         return;
       }
 
+      const shouldForceInitialRefresh = !allNetworkDataInit;
       const r = await backgroundApiProxy.serviceDeFi.fetchAccountDeFiPositions({
         accountId,
         networkId,
@@ -414,7 +417,7 @@ function DeFiListBlock({
         excludeLowValueProtocols: true,
         sourceCurrencyInfo,
         targetCurrencyInfo,
-        isForceRefresh: isForceRefreshRef.current,
+        isForceRefresh: isForceRefreshRef.current || shouldForceInitialRefresh,
       });
 
       if (!allNetworkDataInit && r.isSameAllNetworksAccountData) {
@@ -890,9 +893,9 @@ function DeFiListBlock({
     };
 
     const onRefresh = () => {
+      isForceRefreshRef.current = true;
       if (isFocused) {
         pendingRefreshRef.current = false;
-        isForceRefreshRef.current = true;
         refresh();
       } else {
         pendingRefreshRef.current = true;


### PR DESCRIPTION
## Summary
- Ensure All Networks DeFi refresh syncs the current account/network context before cache and portfolio requests start.
- Force the first real DeFi fetch when the current account/network has no local DeFi cache, matching the manual refresh path that already loads the assets.
- Preserve the force-refresh flag for DeFi refresh events received while the DeFi tab is not focused.

## Issues
- Fixes OK-54353

## Intent & Context
Jira reported that Wallet > DeFi tab assets failed to load on the first refresh and only appeared after tapping refresh again. The reported account address was `0xbDfA4f4492dD7b7Cf211209C4791AF8d52BF5c50`.

## Root Cause
There are two first-load timing differences versus the successful manual refresh path:

1. The All Networks DeFi request path depends on `ServiceDeFi`'s current account/network guard. On first entry, `DeFiListBlock` updated that background context with a fire-and-forget call, while `useAllNetworkRequests` could immediately start cache and network requests. If `fetchAccountDeFiPositions()` ran before the background context reached `onekeyall`, it returned empty data.
2. On a cache miss or pending refresh while the DeFi tab was not focused, the first network request could run with `isForceRefresh=false`. A later manual refresh sets `isForceRefresh=true`, which is why the second refresh loads the assets.

## Design Decisions
- Await `serviceDeFi.updateCurrentAccount()` in the DeFi all-network request start hook before cache/network work begins.
- For All Networks, use `allNetworkDataInit` to detect local cache miss and force only the initial cache-miss fetch.
- For single-network DeFi, track local cache hit by `accountId/networkId/accountAddress` instead of using the provider-level `initialized` flag, so account/network switches cannot inherit a previous account's settled state.
- Set the force-refresh flag when DeFi receives account/derive/network update events, even if the tab is currently blurred, so the pending refresh keeps the same semantics after focus returns.
- Keep the fix scoped to DeFi. Token and NFT paths are unchanged.

## Changes Detail
- `packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx`: await current account/network synchronization during DeFi all-network startup.
- `packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx`: pass `isForceRefresh=true` on All Networks initial cache-miss fetches and blurred pending refreshes.
- `packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx`: pass `isForceRefresh=true` on single-network initial cache miss, keyed to the current account/network/address.

## Risk Assessment
- **Risk Level**: Low to Medium
- **Affected Platforms**: Mobile / Desktop / Web
- **Risk Areas**: DeFi refresh timing and first-load server fetch behavior. The force-refresh change is limited to initial cache-miss / pending refresh paths, not normal cached polling.

## Test plan
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx`
- [x] `yarn lint:staged`
- [x] `yarn jest packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.loading.test.ts`
- [x] `git diff --check`
- [ ] `yarn tsc:staged` currently fails on existing hardware adapter type drift unrelated to this PR (`@onekeyfe/hwk-adapter-core` missing exports / enum members in 6 files).