### PR TITLE
feat: customizable browser home modules with editor and new sections

### DIFF
--- a/packages/kit-bg/src/states/jotai/atoms/settings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/settings.ts
@@ -14,6 +14,24 @@ export type IEndpointType = 'prod' | 'test';
 
 export type INewBrowserTabPosition = 'top' | 'bottom';
 
+export type IBrowserHomeModuleId =
+  | 'openTabs'
+  | 'bookmarks'
+  | 'trending'
+  | 'recentlyClosed';
+
+export type IBrowserHomeModuleConfig = {
+  id: IBrowserHomeModuleId;
+  visible: boolean;
+};
+
+export const DEFAULT_BROWSER_HOME_MODULES: IBrowserHomeModuleConfig[] = [
+  { id: 'openTabs', visible: true },
+  { id: 'bookmarks', visible: true },
+  { id: 'trending', visible: true },
+  { id: 'recentlyClosed', visible: true },
+];
+
 // don't use deviceUtils.getDefaultHardwareTransportType(), it will cause resource export order conflict
 function getDefaultHardwareTransportType(): EHardwareTransportType {
   if (platformEnv.isNative) {
@@ -72,6 +90,7 @@ export type ISettingsPersistAtom = {
   enableBTCFreshAddress?: boolean;
   enableMenuBarTray?: boolean;
   newBrowserTabPosition?: INewBrowserTabPosition;
+  browserHomeModules?: IBrowserHomeModuleConfig[];
   // Pay eligible network fees from Gas Account (sponsored gas) when available;
   // turning this off makes ServiceGas.estimateFee force gasAccountEnabled=false
   // for every caller (Send / Swap / Perps / Earn / dApp ...).
@@ -114,6 +133,7 @@ export const settingsAtomInitialValue: ISettingsPersistAtom = {
   enableBTCFreshAddress: true,
   enableMenuBarTray: true,
   newBrowserTabPosition: 'bottom',
+  browserHomeModules: DEFAULT_BROWSER_HOME_MODULES,
   useGasAccountByDefault: true,
 };
 export const { target: settingsPersistAtom, use: useSettingsPersistAtom } =

--- a/packages/kit/src/views/Discovery/components/DiscoveryItemCard.tsx
+++ b/packages/kit/src/views/Discovery/components/DiscoveryItemCard.tsx
@@ -24,6 +24,15 @@ export interface IDiscoveryItemCardProps {
   dApp?: IDApp;
   isAd?: boolean;
   isLoading?: boolean;
+  logoSize?: '$14' | '$16';
+  logoIconSize?: '$12' | '$14';
+  logoBorderRadius?: '$3' | '$4';
+  logoFullWidth?: boolean;
+  contentPy?: '$1' | '$2';
+  contentGap?: '$2' | '$3';
+  titlePx?: '$0' | '$2';
+  titleMx?: '$-2.5' | '$-3';
+  maxTitleWordLength?: number;
   handleOpenWebSite: ({ dApp, webSite }: IMatchDAppItemType) => void;
 }
 
@@ -34,15 +43,27 @@ export function DiscoveryItemCard({
   dApp,
   isAd,
   isLoading,
+  logoSize = '$14',
+  logoIconSize = '$12',
+  logoBorderRadius = '$3',
+  logoFullWidth = false,
+  contentPy = '$2',
+  contentGap = '$3',
+  titlePx = '$2',
+  titleMx,
+  maxTitleWordLength,
   handleOpenWebSite,
 }: IDiscoveryItemCardProps) {
   const { md } = useMedia();
   const maxWordLength = useMemo(() => {
+    if (maxTitleWordLength) {
+      return maxTitleWordLength;
+    }
     if (platformEnv.isNative) {
       return 9;
     }
     return md ? 9 : 16;
-  }, [md]);
+  }, [maxTitleWordLength, md]);
   const displayTitle = useMemo(() => {
     const words = title.split(' ');
     if (words[0].length > maxWordLength) {
@@ -64,13 +85,23 @@ export function DiscoveryItemCard({
   if (isLoading) {
     return (
       <Stack
-        py="$2"
-        gap="$3"
+        width="100%"
+        py={contentPy}
+        gap={contentGap}
         justifyContent="center"
         alignItems="center"
         userSelect="none"
       >
-        <Skeleton width="$14" height="$14" borderRadius="$4" />
+        <Stack
+          width={logoFullWidth ? '100%' : logoSize}
+          {...(logoFullWidth ? { aspectRatio: 1 } : { height: logoSize })}
+        >
+          <Skeleton
+            width="100%"
+            height="100%"
+            borderRadius={logoBorderRadius}
+          />
+        </Stack>
         <Skeleton
           width="$18"
           $gtMd={{
@@ -86,19 +117,24 @@ export function DiscoveryItemCard({
   // Use TouchableOpacity to fix iOS bug where setTimeout cannot be triggered
   // through components other than Button or TouchableOpacity after hidden views are restored.
   return (
-    <TouchableOpacity onPress={handlePress} activeOpacity={1}>
+    <TouchableOpacity
+      onPress={handlePress}
+      activeOpacity={1}
+      style={{ width: '100%' }}
+    >
       <Stack
-        py="$2"
-        gap="$3"
+        width="100%"
+        py={contentPy}
+        gap={contentGap}
         justifyContent="center"
         alignItems="center"
         userSelect="none"
       >
         <Stack
-          width="$14"
-          height="$14"
+          width={logoFullWidth ? '100%' : logoSize}
+          {...(logoFullWidth ? { aspectRatio: 1 } : { height: logoSize })}
           position="relative"
-          borderRadius="$3"
+          borderRadius={logoBorderRadius}
           borderCurve="continuous"
           overflow="hidden"
         >
@@ -108,16 +144,20 @@ export function DiscoveryItemCard({
             source={{ uri: logo }}
             fallback={
               <Image.Fallback>
-                <Icon size="$12" color="$iconSubdued" name="GlobusOutline" />
+                <Icon
+                  size={logoIconSize}
+                  color="$iconSubdued"
+                  name="GlobusOutline"
+                />
               </Image.Fallback>
             }
           />
-          <InnerStroke borderRadius="$3" />
+          <InnerStroke borderRadius={logoBorderRadius} />
           {isAd ? <AdCornerBadge badgeSize="sm" /> : null}
         </Stack>
         <SizableText
-          px="$2"
-          w="100%"
+          px={titlePx}
+          {...(titleMx ? { alignSelf: 'stretch', mx: titleMx } : { w: '100%' })}
           size="$bodySmMedium"
           textAlign="center"
           numberOfLines={2}

--- a/packages/kit/src/views/Discovery/pages/Dashboard/BookmarksSection.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/BookmarksSection.tsx
@@ -104,7 +104,7 @@ export function BookmarksSection() {
 
   return (
     <Stack minHeight="$40">
-      <DashboardSectionHeader>
+      <DashboardSectionHeader px="$pagePadding">
         <DashboardSectionHeader.Heading selected>
           {intl.formatMessage({ id: ETranslations.explore_bookmarks })}
         </DashboardSectionHeader.Heading>

--- a/packages/kit/src/views/Discovery/pages/Dashboard/BookmarksSectionItem.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/BookmarksSectionItem.tsx
@@ -25,6 +25,15 @@ export function BookmarksSectionItem({
       url={url}
       dApp={dApp}
       handleOpenWebSite={handleOpenWebSite}
+      logoSize="$16"
+      logoIconSize="$14"
+      logoBorderRadius="$4"
+      logoFullWidth
+      contentPy="$1"
+      contentGap="$2"
+      titlePx="$0"
+      titleMx="$-2.5"
+      maxTitleWordLength={16}
     />
   );
 }

--- a/packages/kit/src/views/Discovery/pages/Dashboard/BookmarksSectionItems.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/BookmarksSectionItems.tsx
@@ -29,7 +29,15 @@ export function BookmarksSectionItems({
   }, [media.gtXl, media.gt2Md, media.gtSm]);
 
   return (
-    <YStack py="$2" flexDirection="row" flexWrap="wrap" {...restProps}>
+    <YStack
+      px="$pagePadding"
+      mx="$-3"
+      py="$2"
+      flexDirection="row"
+      flexWrap="wrap"
+      rowGap="$4"
+      {...restProps}
+    >
       {dataSource.slice(0, numberOfItems).map(({ logo, title, url }) => (
         <YStack
           key={title + url}
@@ -37,6 +45,7 @@ export function BookmarksSectionItems({
           $gtSm={{ width: '20%' }}
           $gt2Md={{ width: '16.6%' }}
           $gtXl={{ width: '14.2%' }}
+          px="$3"
         >
           <BookmarksSectionItem
             logo={logo}

--- a/packages/kit/src/views/Discovery/pages/Dashboard/BrowserHomeModulesEditButton.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/BrowserHomeModulesEditButton.tsx
@@ -1,0 +1,174 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import type {
+  IDialogInstance,
+  IDragEndParamsWithItem,
+} from '@onekeyhq/components';
+import {
+  Button,
+  Dialog,
+  ESwitchSize,
+  SortableListView,
+  Stack,
+  Switch,
+} from '@onekeyhq/components';
+import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
+import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import type { IBrowserHomeModuleConfig } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import {
+  getBrowserHomeModuleLabel,
+  normalizeBrowserHomeModules,
+} from './browserHomeModuleUtils';
+
+const CELL_HEIGHT = 56;
+const EDIT_DIALOG_CONTENT_PADDING_BOTTOM = 16;
+const EDIT_DIALOG_HEIGHT = CELL_HEIGHT * 4 + EDIT_DIALOG_CONTENT_PADDING_BOTTOM;
+
+const getBrowserHomeModuleItemLayout = (_: unknown, index: number) => ({
+  length: CELL_HEIGHT,
+  offset: index * CELL_HEIGHT,
+  index,
+});
+
+function BrowserHomeModulesEditDialogContent() {
+  const intl = useIntl();
+  const [{ browserHomeModules }, setSettingsPersist] = useSettingsPersistAtom();
+
+  const modules = useMemo(
+    () => normalizeBrowserHomeModules(browserHomeModules),
+    [browserHomeModules],
+  );
+
+  const persistModules = useCallback(
+    (nextModules: IBrowserHomeModuleConfig[]) => {
+      setSettingsPersist((settings) => ({
+        ...settings,
+        browserHomeModules: normalizeBrowserHomeModules(nextModules),
+      }));
+    },
+    [setSettingsPersist],
+  );
+
+  const handleToggle = useCallback(
+    (target: IBrowserHomeModuleConfig, visible: boolean) => {
+      persistModules(
+        modules.map((module) =>
+          module.id === target.id ? { ...module, visible } : module,
+        ),
+      );
+    },
+    [modules, persistModules],
+  );
+
+  const handleDragEnd = useCallback(
+    (params: IDragEndParamsWithItem<IBrowserHomeModuleConfig>) => {
+      persistModules(params.data);
+    },
+    [persistModules],
+  );
+
+  return (
+    <Stack h={EDIT_DIALOG_HEIGHT}>
+      <SortableListView
+        data={modules}
+        enabled
+        keyExtractor={(item) => item.id}
+        getItemLayout={getBrowserHomeModuleItemLayout}
+        contentContainerStyle={{
+          paddingBottom: EDIT_DIALOG_CONTENT_PADDING_BOTTOM,
+        }}
+        onDragEnd={handleDragEnd}
+        renderItem={({ item, drag, dragProps, isActive }) => (
+          <ListItem
+            h={CELL_HEIGHT}
+            minHeight={0}
+            px="$0"
+            mx="$0"
+            py="$0"
+            gap="$2"
+            borderRadius="$0"
+            opacity={isActive ? 0.8 : 1}
+          >
+            <ListItem.Text
+              primary={getBrowserHomeModuleLabel(intl, item.id)}
+              primaryTextProps={{
+                numberOfLines: 1,
+              }}
+              flex={1}
+            />
+            <Stack
+              width="$16"
+              height={CELL_HEIGHT}
+              alignItems="center"
+              justifyContent="center"
+              flexShrink={0}
+            >
+              <Switch
+                size={ESwitchSize.small}
+                value={item.visible}
+                onChange={(visible) => {
+                  handleToggle(item, visible);
+                }}
+              />
+            </Stack>
+            <ListItem.IconButton
+              key="drag"
+              cursor="move"
+              icon="DragOutline"
+              onPressIn={drag}
+              dataSet={dragProps}
+            />
+          </ListItem>
+        )}
+      />
+    </Stack>
+  );
+}
+
+export function BrowserHomeModulesEditButton() {
+  const intl = useIntl();
+  const dialogRef = useRef<IDialogInstance | null>(null);
+
+  const handlePress = useCallback(() => {
+    if (dialogRef.current?.isExist()) {
+      return;
+    }
+
+    dialogRef.current = Dialog.show({
+      title: intl.formatMessage({
+        id: ETranslations.global_edit,
+      }),
+      renderContent: <BrowserHomeModulesEditDialogContent />,
+      estimatedContentHeight: EDIT_DIALOG_HEIGHT,
+      disableDrag: true,
+      showFooter: false,
+    });
+  }, [intl]);
+
+  useEffect(
+    () => () => {
+      if (dialogRef.current?.isExist()) {
+        void dialogRef.current.close();
+      }
+      dialogRef.current = null;
+    },
+    [],
+  );
+
+  if (!platformEnv.isNative) {
+    return null;
+  }
+
+  return (
+    <Stack px="$pagePadding" width="100%" mt="$6" alignItems="center">
+      <Button size="small" variant="secondary" onPress={handlePress}>
+        {intl.formatMessage({ id: ETranslations.global_edit })}
+      </Button>
+    </Stack>
+  );
+}

--- a/packages/kit/src/views/Discovery/pages/Dashboard/DashboardContent.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/DashboardContent.tsx
@@ -3,12 +3,19 @@ import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import pRetry from 'p-retry';
 import { View } from 'react-native';
 
-import { Page, RefreshControl, ScrollView, Stack } from '@onekeyhq/components';
+import {
+  Empty,
+  Page,
+  RefreshControl,
+  ScrollView,
+  Stack,
+} from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ReviewControl } from '@onekeyhq/kit/src/components/ReviewControl';
 import useListenTabFocusState from '@onekeyhq/kit/src/hooks/useListenTabFocusState';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useRouteIsFocused as useIsFocused } from '@onekeyhq/kit/src/hooks/useRouteIsFocused';
+import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 
@@ -17,7 +24,11 @@ import { useDisplayHomePageFlag } from '../../hooks/useWebTabs';
 
 import { DashboardBanner } from './Banner';
 import { BookmarksSection } from './BookmarksSection';
+import { BrowserHomeModulesEditButton } from './BrowserHomeModulesEditButton';
+import { normalizeBrowserHomeModules } from './browserHomeModuleUtils';
 import { DiveInContent } from './DiveInContent';
+import { OpenBrowserTabsSection } from './OpenBrowserTabsSection';
+import { RecentlyClosedTabsSection } from './RecentlyClosedTabsSection';
 import { TrendingSection } from './TrendingSection';
 import { Welcome } from './Welcome';
 
@@ -102,11 +113,32 @@ function DashboardContent({
     }
   }, [displayHomePage, refreshBookmarks]);
 
-  // Check if both bookmarks and trending have no data
-  const hasBookmarks = bookmarksData && bookmarksData.length > 0;
-  const hasTrending =
-    homePageData?.trending && homePageData.trending.length > 0;
-  const showDiveInDescription = !hasBookmarks && !hasTrending;
+  const hasBookmarks = Boolean(bookmarksData?.length);
+  const hasTrending = Boolean(homePageData?.trending?.length);
+  const [{ browserHomeModules }] = useSettingsPersistAtom();
+  const visibleBrowserHomeModules = useMemo(
+    () =>
+      normalizeBrowserHomeModules(browserHomeModules).filter(
+        (module) => module.visible,
+      ),
+    [browserHomeModules],
+  );
+  const visibleDiveInModules = useMemo(
+    () =>
+      visibleBrowserHomeModules.filter(
+        (module) => module.id === 'bookmarks' || module.id === 'trending',
+      ),
+    [visibleBrowserHomeModules],
+  );
+  const hasVisibleDiveInModuleContent = visibleDiveInModules.some((module) =>
+    module.id === 'bookmarks' ? hasBookmarks : hasTrending,
+  );
+  const shouldShowDiveInDescription =
+    !isLoading &&
+    visibleDiveInModules.length > 0 &&
+    !hasVisibleDiveInModuleContent;
+  const shouldShowNoVisibleModulesEmpty =
+    visibleBrowserHomeModules.length === 0;
 
   const content = useMemo(
     () => (
@@ -132,26 +164,43 @@ function DashboardContent({
         />
 
         <Stack alignItems="center">
-          {!isLoading && showDiveInDescription ? (
-            <DiveInContent onReload={refresh} />
-          ) : (
-            <>
-              {hasBookmarks ? (
-                <Stack px="$pagePadding" width="100%">
-                  <BookmarksSection key="BookmarksSection" />
-                </Stack>
-              ) : null}
+          {visibleBrowserHomeModules.map((module) => {
+            switch (module.id) {
+              case 'openTabs':
+                return <OpenBrowserTabsSection key={module.id} />;
+              case 'bookmarks':
+                return hasBookmarks ? (
+                  <Stack key={module.id} width="100%" mt="$3">
+                    <BookmarksSection />
+                  </Stack>
+                ) : null;
+              case 'trending':
+                return shouldShowDiveInDescription ? null : (
+                  <Stack key={module.id} width="100%" mt="$3">
+                    <ReviewControl>
+                      <TrendingSection
+                        data={homePageData?.trending || []}
+                        isLoading={!!isLoading}
+                      />
+                    </ReviewControl>
+                  </Stack>
+                );
+              case 'recentlyClosed':
+                return <RecentlyClosedTabsSection key={module.id} />;
+              default:
+                return null;
+            }
+          })}
 
-              <Stack px="$pagePadding" width="100%" mt="$4">
-                <ReviewControl>
-                  <TrendingSection
-                    data={homePageData?.trending || []}
-                    isLoading={!!isLoading}
-                  />
-                </ReviewControl>
-              </Stack>
-            </>
-          )}
+          {shouldShowNoVisibleModulesEmpty ? (
+            <Empty illustration="TwoBlocks" width="100%" py="$8" />
+          ) : null}
+
+          {shouldShowDiveInDescription ? (
+            <DiveInContent onReload={refresh} />
+          ) : null}
+
+          <BrowserHomeModulesEditButton />
         </Stack>
       </>
     ),
@@ -159,9 +208,11 @@ function DashboardContent({
       hasActiveBanners,
       homePageData,
       isLoading,
-      showDiveInDescription,
+      shouldShowNoVisibleModulesEmpty,
+      shouldShowDiveInDescription,
       refresh,
       hasBookmarks,
+      visibleBrowserHomeModules,
     ],
   );
 
@@ -169,6 +220,7 @@ function DashboardContent({
     return (
       <ScrollView
         height="100%"
+        contentContainerStyle={{ pb: '$28' }}
         onScroll={isFocused ? (onScroll as any) : undefined}
         scrollEventThrottle={16}
         refreshControl={
@@ -181,7 +233,7 @@ function DashboardContent({
   }
 
   return (
-    <ScrollView>
+    <ScrollView contentContainerStyle={{ pb: '$16' }}>
       <Page.Container padded={false}>{content}</Page.Container>
     </ScrollView>
   );

--- a/packages/kit/src/views/Discovery/pages/Dashboard/OpenBrowserTabsSection.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/OpenBrowserTabsSection.tsx
@@ -1,0 +1,149 @@
+import { useCallback, useMemo } from 'react';
+
+import { useIntl } from 'react-intl';
+import { TouchableOpacity } from 'react-native';
+
+import {
+  Icon,
+  Image,
+  InnerStroke,
+  SizableText,
+  Stack,
+  XStack,
+} from '@onekeyhq/components';
+import { useBrowserTabActions } from '@onekeyhq/kit/src/states/jotai/contexts/discovery';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import { useWebTabs } from '../../hooks/useWebTabs';
+
+import { DashboardSectionHeader } from './DashboardSectionHeader';
+
+import type { IWebTab } from '../../types';
+
+const OPEN_BROWSER_TAB_LIMIT = 4;
+
+function getTabTitle(tab: IWebTab) {
+  return tab.customTitle || tab.title || tab.displayUrl || tab.url;
+}
+
+function getTabDomain(tab: IWebTab) {
+  const url = tab.displayUrl || tab.url;
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return url.replace(/^https?:\/\//, '').split(/[/?#]/)[0] || url;
+  }
+}
+
+function isValidOpenBrowserTab(tab: IWebTab) {
+  return tab.type !== 'home' && tab.url && tab.url !== 'about:blank';
+}
+
+function OpenBrowserTabItem({
+  tab,
+  onPress,
+}: {
+  tab: IWebTab;
+  onPress: (tabId: string) => void;
+}) {
+  const handlePress = useCallback(() => {
+    onPress(tab.id);
+  }, [onPress, tab.id]);
+
+  return (
+    <TouchableOpacity
+      onPress={handlePress}
+      activeOpacity={1}
+      style={{ width: '100%' }}
+    >
+      <Stack
+        width="100%"
+        height="$14"
+        p="$2"
+        borderRadius="$3"
+        bg="$bgSubdued"
+        borderCurve="continuous"
+        justifyContent="center"
+        userSelect="none"
+      >
+        <XStack alignItems="center" gap="$2.5">
+          <Stack
+            width="$9"
+            height="$9"
+            position="relative"
+            borderRadius="$2"
+            borderCurve="continuous"
+            overflow="hidden"
+            flexShrink={0}
+          >
+            <Image
+              width="100%"
+              height="100%"
+              source={{ uri: tab.favicon }}
+              fallback={
+                <Image.Fallback>
+                  <Icon size="$7" color="$iconSubdued" name="GlobusOutline" />
+                </Image.Fallback>
+              }
+            />
+            <InnerStroke borderRadius="$2" />
+          </Stack>
+          <Stack flex={1} minWidth={0}>
+            <SizableText size="$bodyMdMedium" numberOfLines={1}>
+              {getTabTitle(tab)}
+            </SizableText>
+            <SizableText size="$bodySm" color="$textSubdued" numberOfLines={1}>
+              {getTabDomain(tab)}
+            </SizableText>
+          </Stack>
+        </XStack>
+      </Stack>
+    </TouchableOpacity>
+  );
+}
+
+function OpenBrowserTabsSectionContent() {
+  const intl = useIntl();
+  const { tabs } = useWebTabs();
+  const { setCurrentWebTab } = useBrowserTabActions().current;
+
+  const openTabs = useMemo(
+    () =>
+      tabs
+        .filter(isValidOpenBrowserTab)
+        .toSorted((a, b) => (b.timestamp ?? 0) - (a.timestamp ?? 0))
+        .slice(0, OPEN_BROWSER_TAB_LIMIT),
+    [tabs],
+  );
+
+  if (openTabs.length === 0) {
+    return null;
+  }
+
+  return (
+    <Stack px="$pagePadding" width="100%" mt="$3" minHeight="$28">
+      <DashboardSectionHeader>
+        <DashboardSectionHeader.Heading selected>
+          {intl.formatMessage({ id: ETranslations.global_current })}
+        </DashboardSectionHeader.Heading>
+      </DashboardSectionHeader>
+
+      <XStack flexWrap="wrap" mx="$-1" py="$1">
+        {openTabs.map((tab) => (
+          <Stack key={tab.id} width="50%" p="$1">
+            <OpenBrowserTabItem tab={tab} onPress={setCurrentWebTab} />
+          </Stack>
+        ))}
+      </XStack>
+    </Stack>
+  );
+}
+
+export function OpenBrowserTabsSection() {
+  if (!platformEnv.isNative) {
+    return null;
+  }
+
+  return <OpenBrowserTabsSectionContent />;
+}

--- a/packages/kit/src/views/Discovery/pages/Dashboard/RecentlyClosedTabsSection.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/RecentlyClosedTabsSection.tsx
@@ -1,0 +1,118 @@
+import { useCallback, useEffect } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import { Stack } from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import useListenTabFocusState from '@onekeyhq/kit/src/hooks/useListenTabFocusState';
+import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { EEnterMethod } from '@onekeyhq/shared/src/logger/scopes/discovery/scenes/dapp';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import {
+  EDiscoveryModalRoutes,
+  EModalRoutes,
+  ETabRoutes,
+} from '@onekeyhq/shared/src/routes';
+
+import { useWebSiteHandler } from '../../hooks/useWebSiteHandler';
+import { useDisplayHomePageFlag } from '../../hooks/useWebTabs';
+import { HistoryListItem } from '../HistoryListModal/HistoryListItem';
+
+import { DashboardSectionHeader } from './DashboardSectionHeader';
+
+import type { IBrowserHistory } from '../../types';
+
+const RECENTLY_CLOSED_TAB_LIMIT = 5;
+
+function RecentlyClosedTabsSectionContent() {
+  const intl = useIntl();
+  const navigation = useAppNavigation();
+  const handleWebSite = useWebSiteHandler();
+  const { displayHomePage } = useDisplayHomePageFlag();
+
+  const { result: historyData = [], run: refreshHistory } = usePromiseResult(
+    async () =>
+      backgroundApiProxy.serviceDiscovery.fetchHistoryData(
+        1,
+        RECENTLY_CLOSED_TAB_LIMIT,
+      ),
+    [],
+    {
+      watchLoading: true,
+      checkIsFocused: false,
+    },
+  );
+
+  useListenTabFocusState(ETabRoutes.Discovery, (isFocus) => {
+    if (isFocus) {
+      setTimeout(() => {
+        void refreshHistory();
+      });
+    }
+  });
+
+  useEffect(() => {
+    if (displayHomePage && platformEnv.isNative) {
+      void refreshHistory();
+    }
+  }, [displayHomePage, refreshHistory]);
+
+  const handlePress = useCallback(
+    (item: IBrowserHistory) => {
+      handleWebSite({
+        webSite: {
+          url: item.url,
+          title: item.title,
+          logo: item.logo,
+          sortIndex: undefined,
+        },
+        enterMethod: EEnterMethod.history,
+      });
+    },
+    [handleWebSite],
+  );
+
+  const handleSeeAllPress = useCallback(() => {
+    navigation.pushModal(EModalRoutes.DiscoveryModal, {
+      screen: EDiscoveryModalRoutes.HistoryListModal,
+    });
+  }, [navigation]);
+
+  if (historyData.length === 0) {
+    return null;
+  }
+
+  return (
+    <Stack width="100%" mt="$3">
+      <DashboardSectionHeader px="$pagePadding">
+        <DashboardSectionHeader.Heading selected>
+          {intl.formatMessage({ id: ETranslations.browser_recently_closed })}
+        </DashboardSectionHeader.Heading>
+        <DashboardSectionHeader.Button onPress={handleSeeAllPress}>
+          {intl.formatMessage({ id: ETranslations.explore_see_all })}
+        </DashboardSectionHeader.Button>
+      </DashboardSectionHeader>
+
+      <Stack py="$1">
+        {historyData.slice(0, RECENTLY_CLOSED_TAB_LIMIT).map((item) => (
+          <HistoryListItem
+            key={item.id}
+            item={item}
+            testIDPrefix="browser-home-recently-closed"
+            onPress={handlePress}
+          />
+        ))}
+      </Stack>
+    </Stack>
+  );
+}
+
+export function RecentlyClosedTabsSection() {
+  if (!platformEnv.isNative) {
+    return null;
+  }
+
+  return <RecentlyClosedTabsSectionContent />;
+}

--- a/packages/kit/src/views/Discovery/pages/Dashboard/TrendingSection.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/TrendingSection.tsx
@@ -40,7 +40,7 @@ export function TrendingSection({
 
   return (
     <Stack minHeight="$40">
-      <DashboardSectionHeader>
+      <DashboardSectionHeader px="$pagePadding">
         <DashboardSectionHeader.Heading selected>
           {intl.formatMessage({
             id: ETranslations.market_trending,

--- a/packages/kit/src/views/Discovery/pages/Dashboard/TrendingSectionItem.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/TrendingSectionItem.tsx
@@ -28,6 +28,15 @@ export function TrendingSectionItem({
       isAd={dApp.isAd}
       handleOpenWebSite={handleOpenWebSite}
       isLoading={isLoading}
+      logoSize="$16"
+      logoIconSize="$14"
+      logoBorderRadius="$4"
+      logoFullWidth
+      contentPy="$1"
+      contentGap="$2"
+      titlePx="$0"
+      titleMx="$-2.5"
+      maxTitleWordLength={16}
     />
   );
 }

--- a/packages/kit/src/views/Discovery/pages/Dashboard/TrendingSectionItems.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/TrendingSectionItems.tsx
@@ -53,6 +53,8 @@ export function TrendingSectionItems({
 
   return (
     <YStack
+      px="$pagePadding"
+      mx="$-3"
       flexDirection="row"
       flexWrap="wrap"
       rowGap="$4"
@@ -66,6 +68,7 @@ export function TrendingSectionItems({
           $gtSm={{ width: '20%' }}
           $gt2Md={{ width: '16.6%' }}
           $gtXl={{ width: '10%' }}
+          px="$3"
         >
           <TrendingSectionItem
             logo={dApp.logo}

--- a/packages/kit/src/views/Discovery/pages/Dashboard/browserHomeModuleUtils.ts
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/browserHomeModuleUtils.ts
@@ -1,0 +1,75 @@
+import {
+  DEFAULT_BROWSER_HOME_MODULES,
+  type IBrowserHomeModuleConfig,
+  type IBrowserHomeModuleId,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+
+import type { IntlShape } from 'react-intl';
+
+const DEFAULT_BROWSER_HOME_MODULE_IDS = new Set<IBrowserHomeModuleId>(
+  DEFAULT_BROWSER_HOME_MODULES.map((module) => module.id),
+);
+
+type ILegacyBrowserHomeModuleConfig = {
+  id: IBrowserHomeModuleId | 'recents';
+  visible: boolean;
+};
+
+function normalizeBrowserHomeModuleId(
+  moduleId: ILegacyBrowserHomeModuleConfig['id'],
+) {
+  if (moduleId === 'recents') {
+    return 'openTabs';
+  }
+  if (DEFAULT_BROWSER_HOME_MODULE_IDS.has(moduleId)) {
+    return moduleId;
+  }
+  return undefined;
+}
+
+export function normalizeBrowserHomeModules(
+  modules?: ILegacyBrowserHomeModuleConfig[],
+): IBrowserHomeModuleConfig[] {
+  const usedIds = new Set<IBrowserHomeModuleId>();
+  const normalized: IBrowserHomeModuleConfig[] = [];
+
+  modules?.forEach((module) => {
+    const normalizedId = normalizeBrowserHomeModuleId(module.id);
+    if (!normalizedId || usedIds.has(normalizedId)) {
+      return;
+    }
+
+    normalized.push({
+      id: normalizedId,
+      visible: module.visible !== false,
+    });
+    usedIds.add(normalizedId);
+  });
+
+  DEFAULT_BROWSER_HOME_MODULES.forEach((module) => {
+    if (!usedIds.has(module.id)) {
+      normalized.push({ ...module });
+    }
+  });
+
+  return normalized;
+}
+
+export function getBrowserHomeModuleLabel(
+  intl: IntlShape,
+  moduleId: IBrowserHomeModuleId,
+) {
+  switch (moduleId) {
+    case 'openTabs':
+      return intl.formatMessage({ id: ETranslations.global_current });
+    case 'bookmarks':
+      return intl.formatMessage({ id: ETranslations.explore_bookmarks });
+    case 'trending':
+      return intl.formatMessage({ id: ETranslations.market_trending });
+    case 'recentlyClosed':
+      return intl.formatMessage({ id: ETranslations.browser_recently_closed });
+    default:
+      return '';
+  }
+}

--- a/packages/kit/src/views/Discovery/pages/HistoryListModal/HistoryListItem.tsx
+++ b/packages/kit/src/views/Discovery/pages/HistoryListModal/HistoryListItem.tsx
@@ -1,0 +1,56 @@
+import { useCallback } from 'react';
+
+import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
+
+import { DiscoveryIcon } from '../../components/DiscoveryIcon';
+
+import type { IBrowserHistory } from '../../types';
+
+type IHistoryListItemProps = {
+  item: IBrowserHistory;
+  isEditing?: boolean;
+  testIDPrefix?: string;
+  onPress?: (item: IBrowserHistory) => void;
+  onDelete?: (item: IBrowserHistory) => void;
+};
+
+export function HistoryListItem({
+  item,
+  isEditing,
+  testIDPrefix = 'search-modal',
+  onPress,
+  onDelete,
+}: IHistoryListItemProps) {
+  const handlePress = useCallback(() => {
+    onPress?.(item);
+  }, [item, onPress]);
+
+  const handleDelete = useCallback(() => {
+    onDelete?.(item);
+  }, [item, onDelete]);
+
+  return (
+    <ListItem
+      key={item.id}
+      renderAvatar={<DiscoveryIcon uri={item.logo} size="$10" />}
+      title={item.title}
+      titleProps={{
+        numberOfLines: 1,
+      }}
+      subtitle={item.url}
+      subtitleProps={{
+        numberOfLines: 1,
+      }}
+      testID={`${testIDPrefix}-${item.url.toLowerCase()}`}
+      {...(!isEditing && onPress
+        ? {
+            onPress: handlePress,
+          }
+        : undefined)}
+    >
+      {isEditing && onDelete ? (
+        <ListItem.IconButton icon="DeleteOutline" onPress={handleDelete} />
+      ) : null}
+    </ListItem>
+  );
+}

--- a/packages/kit/src/views/Discovery/pages/HistoryListModal/index.tsx
+++ b/packages/kit/src/views/Discovery/pages/HistoryListModal/index.tsx
@@ -16,7 +16,6 @@ import {
   XStack,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useBrowserHistoryAction } from '@onekeyhq/kit/src/states/jotai/contexts/discovery';
@@ -24,9 +23,10 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { EEnterMethod } from '@onekeyhq/shared/src/logger/scopes/discovery/scenes/dapp';
 import { formatRelativeDate } from '@onekeyhq/shared/src/utils/dateUtils';
 
-import { DiscoveryIcon } from '../../components/DiscoveryIcon';
 import { useWebSiteHandler } from '../../hooks/useWebSiteHandler';
 import { withBrowserProvider } from '../Browser/WithBrowserProvider';
+
+import { HistoryListItem } from './HistoryListItem';
 
 import type { IBrowserHistory } from '../../types';
 
@@ -101,6 +101,37 @@ function HistoryListModal() {
       void run();
     }, 200);
   }, [run, removeAllBrowserHistory]);
+
+  const handleHistoryPress = useCallback(
+    (item: IBrowserHistory) => {
+      handleWebSite({
+        webSite: {
+          url: item.url,
+          title: item.title,
+          logo: item.logo,
+          sortIndex: undefined,
+        },
+        enterMethod: EEnterMethod.history,
+      });
+    },
+    [handleWebSite],
+  );
+
+  const handleDeleteHistory = useCallback(
+    (item: IBrowserHistory) => {
+      void removeBrowserHistory(item.id);
+      removeHistoryFlagRef.current = true;
+      setTimeout(() => {
+        void run();
+      }, 200);
+      Toast.success({
+        title: intl.formatMessage({
+          id: ETranslations.explore_removed_success,
+        }),
+      });
+    },
+    [intl, removeBrowserHistory, run],
+  );
 
   useEffect(() => {
     if (removeHistoryFlagRef.current && dataSource?.length === 0) {
@@ -192,50 +223,12 @@ function HistoryListModal() {
           )}
           keyExtractor={keyExtractor}
           renderItem={({ item }: { item: IBrowserHistory }) => (
-            <ListItem
-              key={item.id}
-              renderAvatar={<DiscoveryIcon uri={item.logo} size="$10" />}
-              title={item.title}
-              titleProps={{
-                numberOfLines: 1,
-              }}
-              subtitle={item.url}
-              subtitleProps={{
-                numberOfLines: 1,
-              }}
-              testID={`search-modal-${item.url.toLowerCase()}`}
-              {...(!isEditing && {
-                onPress: () => {
-                  handleWebSite({
-                    webSite: {
-                      url: item.url,
-                      title: item.title,
-                      logo: item.logo,
-                      sortIndex: undefined,
-                    },
-                    enterMethod: EEnterMethod.history,
-                  });
-                },
-              })}
-            >
-              {isEditing ? (
-                <ListItem.IconButton
-                  icon="DeleteOutline"
-                  onPress={() => {
-                    void removeBrowserHistory(item.id);
-                    removeHistoryFlagRef.current = true;
-                    setTimeout(() => {
-                      void run();
-                    }, 200);
-                    Toast.success({
-                      title: intl.formatMessage({
-                        id: ETranslations.explore_removed_success,
-                      }),
-                    });
-                  }}
-                />
-              ) : null}
-            </ListItem>
+            <HistoryListItem
+              item={item}
+              isEditing={isEditing}
+              onPress={handleHistoryPress}
+              onDelete={handleDeleteHistory}
+            />
           )}
           onEndReached={debouncedOnEndReached}
           onEndReachedThreshold={0.2}


### PR DESCRIPTION
## Summary
- Introduce a customizable browser home (Discovery dashboard) where users can toggle visibility and reorder four modules: Open Tabs, Bookmarks, Trending, Recently Closed.
- Add two new native-only sections (`OpenBrowserTabsSection`, `RecentlyClosedTabsSection`) and an editor dialog (`BrowserHomeModulesEditButton`) using a sortable list with switches.
- Persist user preferences in `settingsPersistAtom.browserHomeModules` with normalization for legacy values and missing modules.
- Refactor `HistoryListItem` into a reusable component and tune `DiscoveryItemCard` styling props so Bookmarks/Trending tiles share a larger square logo layout.

https://github.com/user-attachments/assets/a53dbdb0-4248-4aaf-87db-99ae84d0134e


## Intent & Context
Native users wanted more control over what appears on the browser home page and a quick way to jump back to currently-open and recently-closed tabs. The existing dashboard hard-coded the order and combination of Bookmarks + Trending; there was no way to hide either, no surface for in-progress browsing, and recently-closed history was only reachable through the modal.

## Design Decisions
- **Mobile-only surface**: Both new sections and the edit button are gated by `platformEnv.isNative`. The desktop/web Discovery pages keep their existing layout, avoiding regressions on platforms where the dashboard composition differs.
- **Module config in `settingsPersistAtom`**: Persisting the ordered list of `{ id, visible }` keeps state consistent across app reloads and lives next to other browser preferences (e.g. `newBrowserTabPosition`). A `DEFAULT_BROWSER_HOME_MODULES` constant defines the initial order.
- **`normalizeBrowserHomeModules` migration helper**: Tolerates legacy ids (maps `recents` → `openTabs`), drops unknown ids, dedupes, and appends any missing default modules so older installs and future additions keep working without explicit migrations.
- **Reusable `HistoryListItem`**: The `HistoryListModal` row markup was duplicated when adding the Recently Closed section, so it was extracted with `testIDPrefix`, optional `onPress`/`onDelete`, and `isEditing` props instead of duplicating UI.
- **`DiscoveryItemCard` style props**: Rather than forking the card, added optional `logoSize`, `logoFullWidth`, `contentPy/Gap`, `titlePx/Mx`, and `maxTitleWordLength` props so Bookmarks and Trending can opt into the new larger-tile look while existing call sites keep their previous defaults.
- **Empty/loading composition**: When all modules are hidden, render a neutral `Empty` illustration; when the visible Dive-In modules (Bookmarks/Trending) have no data, fall back to `DiveInContent`. This keeps the home from feeling empty while still respecting user choices.

## Changes Detail
- `packages/kit-bg/src/states/jotai/atoms/settings.ts` — Add `IBrowserHomeModuleId`, `IBrowserHomeModuleConfig`, `DEFAULT_BROWSER_HOME_MODULES`, and the `browserHomeModules` field on the persisted settings atom.
- `packages/kit/src/views/Discovery/pages/Dashboard/browserHomeModuleUtils.ts` — Normalize/migrate persisted module lists and provide localized labels for the editor.
- `packages/kit/src/views/Discovery/pages/Dashboard/BrowserHomeModulesEditButton.tsx` — Native-only `Edit` button that opens a `Dialog` with a `SortableListView` of modules; each row has a label, a visibility `Switch`, and a drag handle. State changes write through `useSettingsPersistAtom`.
- `packages/kit/src/views/Discovery/pages/Dashboard/OpenBrowserTabsSection.tsx` — Renders up to 4 currently-open browser tabs (excluding `home`/blank) as a 2-column grid that resumes the tab on press via `useBrowserTabActions`.
- `packages/kit/src/views/Discovery/pages/Dashboard/RecentlyClosedTabsSection.tsx` — Fetches the latest 5 history entries on focus and reuses `HistoryListItem`; provides a "See all" entry into `HistoryListModal`.
- `packages/kit/src/views/Discovery/pages/Dashboard/DashboardContent.tsx` — Drives the layout from `visibleBrowserHomeModules`, switches each module by id, computes Dive-In/empty states, and mounts the edit button.
- `packages/kit/src/views/Discovery/pages/Dashboard/Bookmarks*` and `Trending*` — Pass new `DiscoveryItemCard` style props (square 16-unit logos, tighter padding) and add `px="$pagePadding"` headers/grid offsets so the layout matches the new sections.
- `packages/kit/src/views/Discovery/components/DiscoveryItemCard.tsx` — Add the optional style/length props described above; defaults preserve existing call sites.
- `packages/kit/src/views/Discovery/pages/HistoryListModal/HistoryListItem.tsx` — New shared row component used by both the modal and the Recently Closed section.
- `packages/kit/src/views/Discovery/pages/HistoryListModal/index.tsx` — Switch the modal to use the shared `HistoryListItem` and lift inline handlers into stable callbacks.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile (iOS/Android)
- **Risk Areas**:
  - Persisted settings shape change in `settingsPersistAtom` — relies on `normalizeBrowserHomeModules` to upgrade existing state on launch.
  - `DashboardContent` rendering path was rewritten; need to verify Dive-In description, empty state, and per-module skeletons match the previous behavior when modules hide/reorder.
  - `DiscoveryItemCard` accepts new style props with defaults; non-Discovery call sites (if any) should be unaffected, but worth confirming via the existing dashboard.
  - `HistoryListItem` extraction must keep test IDs stable for existing automation (`search-modal-...`).

## Test plan
- [ ] iOS: open Discovery tab, confirm Open Tabs / Bookmarks / Trending / Recently Closed sections render in order with the new larger logos.
- [ ] iOS: tap Edit, toggle each module off/on and drag-reorder; confirm state persists across app reload.
- [ ] iOS: hide all modules — verify the empty illustration shows and edit button still works.
- [ ] iOS: hide Bookmarks and Trending, leave others — verify Dive-In description does not appear.
- [ ] iOS: tap an Open Tabs tile — should activate that web tab.
- [ ] iOS: tap a Recently Closed entry — should open the URL via the standard handler; tap "See all" — opens the History modal.
- [ ] iOS: in History modal, swipe/edit/delete still works and test IDs (`search-modal-<url>`) remain unchanged.
- [ ] Android: spot-check the same flows.
- [ ] Desktop / Web: confirm the dashboard remains visually unchanged (no edit button, no new sections).
- [ ] Fresh install vs. upgrade: launch with no persisted `browserHomeModules` and with a legacy `recents` id — both should land on the default ordering.