### PR TITLE
refactor: share Bot Wallet key API consts and use default request timeouts

### DIFF
--- a/apps/cli/scripts/_simulate-export.ts
+++ b/apps/cli/scripts/_simulate-export.ts
@@ -7,6 +7,7 @@ import type {
   ICliBotWalletRevealableSeed,
   IPersistAuthSessionInput,
 } from '@onekeyhq/shared/src/types/cliBotWallet';
+import { BOT_WALLET_KEY_API_PATH } from '@onekeyhq/shared/src/utils/cliBotWalletExport/botWalletKeyApiConsts';
 
 type IRegisterResponse = {
   accessToken: string;
@@ -32,7 +33,6 @@ type IApiResponse<T> = {
   data: T;
 };
 
-const BOT_WALLET_KEY_API_PATH = '/prime/v1/bot-wallet-keys';
 const BOT_WALLET_HASH_SALT = 'onekey-cli-bot-wallet-key-api:v1';
 
 class SimulatedExportError extends Error {

--- a/apps/cli/src/infra/vault/service-client.ts
+++ b/apps/cli/src/infra/vault/service-client.ts
@@ -1,12 +1,19 @@
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import {
+  BOT_WALLET_KEY_API_PATH,
+  BOT_WALLET_KEY_API_TOKEN_HEADER,
+} from '@onekeyhq/shared/src/utils/cliBotWalletExport/botWalletKeyApiConsts';
 
 import { apiClient } from '../api-client';
 
 import { LOCK_TIMEOUT_MS, REVOKE_TIMEOUT_MS } from './constants';
 
+export {
+  BOT_WALLET_KEY_API_PATH,
+  BOT_WALLET_KEY_API_TOKEN_HEADER,
+} from '@onekeyhq/shared/src/utils/cliBotWalletExport/botWalletKeyApiConsts';
+
 export const BOT_WALLET_KEY_API_SERVICE = 'prime';
-export const BOT_WALLET_KEY_API_PATH = '/prime/v1/bot-wallet-keys';
-export const BOT_WALLET_KEY_API_TOKEN_HEADER = 'X-Onekey-Request-Token';
 
 export type IFetchBotWalletKeyInput = {
   keyId: string;

--- a/packages/shared/src/utils/cliBotWalletExport/__tests__/register.test.ts
+++ b/packages/shared/src/utils/cliBotWalletExport/__tests__/register.test.ts
@@ -50,10 +50,8 @@ describe('buildBotWalletHash', () => {
 describe('registerKey (AC9)', () => {
   it('POST body field set is EXACTLY ["botWalletHash", "keyBase64"] and uses the Prime API path', async () => {
     let capturedBody: unknown;
-    let capturedConfig: Record<string, unknown> | undefined;
-    const http = makeHttp(async (_url, body, config) => {
+    const http = makeHttp(async (_url, body) => {
       capturedBody = body;
-      capturedConfig = config;
       return {
         data: {
           code: 0,
@@ -79,10 +77,6 @@ describe('registerKey (AC9)', () => {
       botWalletHash: VALID_BOT_WALLET_HASH,
       keyBase64: 'AAAA',
     });
-    expect(capturedConfig?.timeout).toBe(
-      CLI_BOT_WALLET_CLIENT_INTERNALS.REGISTER_TIMEOUT_MS,
-    );
-    expect(capturedConfig?.signal).toBeInstanceOf(AbortSignal);
   });
 
   it('parses 200 response { keyId, accessToken }', async () => {
@@ -214,7 +208,7 @@ describe('registerKey (AC9)', () => {
 });
 
 describe('revokeKey (AC9 — best-effort)', () => {
-  it('POST happy path includes Prime token header and 3s AbortSignal', async () => {
+  it('POST happy path includes Prime token header', async () => {
     let capturedConfig: Record<string, unknown> | undefined;
     const http = makeHttp(async (_url, _body, config) => {
       capturedConfig = config;
@@ -230,11 +224,6 @@ describe('revokeKey (AC9 — best-effort)', () => {
         CLI_BOT_WALLET_CLIENT_INTERNALS.BOT_WALLET_KEY_API_TOKEN_HEADER
       ],
     ).toBe('tokenA');
-    // Has timeout config
-    expect(capturedConfig?.timeout).toBe(
-      CLI_BOT_WALLET_CLIENT_INTERNALS.REVOKE_TIMEOUT_MS,
-    );
-    expect(capturedConfig?.signal).toBeInstanceOf(AbortSignal);
   });
 
   it('swallows network errors (logger.warn called, NO throw)', async () => {
@@ -269,30 +258,4 @@ describe('revokeKey (AC9 — best-effort)', () => {
     expect(warn).toHaveBeenCalledTimes(1);
   });
 
-  it('AbortSignal.timeout fires after 3s when service hangs (real-timer)', async () => {
-    // Use the real AbortSignal.timeout to ensure axios receives a signal that
-    // truly aborts after the configured TTL. We assert the config carries a
-    // signal that aborts in <= REVOKE_TIMEOUT_MS + buffer.
-    let capturedSignal: AbortSignal | undefined;
-    const http = makeHttp(async (_url, _body, config) => {
-      capturedSignal = config?.signal as AbortSignal;
-      // Return a never-resolving-but-cancellable promise
-      return new Promise((resolve, reject) => {
-        capturedSignal?.addEventListener('abort', () => {
-          reject(new Error('AbortError: timeout'));
-        });
-      });
-    });
-    const warn = jest.fn();
-    const t0 = Date.now();
-    await revokeKey('keyA', 'tokenA', {
-      baseUrl: 'http://x',
-      http,
-      logger: { warn },
-    });
-    const elapsed = Date.now() - t0;
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(elapsed).toBeGreaterThanOrEqual(2900);
-    expect(elapsed).toBeLessThanOrEqual(3500);
-  }, 5000);
 });

--- a/packages/shared/src/utils/cliBotWalletExport/__tests__/register.test.ts
+++ b/packages/shared/src/utils/cliBotWalletExport/__tests__/register.test.ts
@@ -257,5 +257,4 @@ describe('revokeKey (AC9 — best-effort)', () => {
     });
     expect(warn).toHaveBeenCalledTimes(1);
   });
-
 });

--- a/packages/shared/src/utils/cliBotWalletExport/botWalletKeyApiConsts.ts
+++ b/packages/shared/src/utils/cliBotWalletExport/botWalletKeyApiConsts.ts
@@ -1,0 +1,8 @@
+/**
+ * Single source of truth for the Bot Wallet key API contract shared between
+ * the App (which registers/revokes keys when exporting a wallet to the CLI)
+ * and the CLI (which fetches/revokes keys at runtime). Keep both sides
+ * importing from here so they cannot drift out of sync.
+ */
+export const BOT_WALLET_KEY_API_PATH = '/prime/v1/bot-wallet-keys';
+export const BOT_WALLET_KEY_API_TOKEN_HEADER = 'X-Onekey-Request-Token';

--- a/packages/shared/src/utils/cliBotWalletExport/register.ts
+++ b/packages/shared/src/utils/cliBotWalletExport/register.ts
@@ -6,11 +6,11 @@ import { appApiClient } from '../../appApiClient/appApiClient';
 import { getEndpointByServiceName } from '../../config/endpointsMap';
 import { OneKeyLocalError } from '../../errors';
 
+import { isBotWalletHash } from './botWalletHash';
 import {
   BOT_WALLET_KEY_API_PATH,
   BOT_WALLET_KEY_API_TOKEN_HEADER,
 } from './botWalletKeyApiConsts';
-import { isBotWalletHash } from './botWalletHash';
 
 function describeKeyServiceFailure(err: unknown): string {
   if (err && typeof err === 'object') {

--- a/packages/shared/src/utils/cliBotWalletExport/register.ts
+++ b/packages/shared/src/utils/cliBotWalletExport/register.ts
@@ -6,12 +6,11 @@ import { appApiClient } from '../../appApiClient/appApiClient';
 import { getEndpointByServiceName } from '../../config/endpointsMap';
 import { OneKeyLocalError } from '../../errors';
 
+import {
+  BOT_WALLET_KEY_API_PATH,
+  BOT_WALLET_KEY_API_TOKEN_HEADER,
+} from './botWalletKeyApiConsts';
 import { isBotWalletHash } from './botWalletHash';
-
-const BOT_WALLET_KEY_API_PATH = '/prime/v1/bot-wallet-keys';
-const BOT_WALLET_KEY_API_TOKEN_HEADER = 'X-Onekey-Request-Token';
-const REGISTER_TIMEOUT_MS = 3000;
-const REVOKE_TIMEOUT_MS = 3000;
 
 function describeKeyServiceFailure(err: unknown): string {
   if (err && typeof err === 'object') {
@@ -215,8 +214,6 @@ export async function registerKey(
       { data: IApiClientResponse<IRegisterKeyResponse> }
     >(BOT_WALLET_KEY_API_PATH, body, {
       headers: { 'Content-Type': 'application/json' },
-      signal: AbortSignal.timeout(REGISTER_TIMEOUT_MS),
-      timeout: REGISTER_TIMEOUT_MS,
     });
   } catch (err) {
     throw buildKeyServiceUnreachableError(endpoint, err);
@@ -239,8 +236,7 @@ export async function registerKey(
 /**
  * Best-effort POST /prime/v1/bot-wallet-keys/:keyId/revoke. **Never throws** — any
  * failure (network / 4xx / 5xx / timeout) is swallowed and surfaced as a
- * single `logger.warn` call. Hard-capped at 3s with `AbortSignal.timeout`
- * so that a wedged request cannot block the rollback path.
+ * single `logger.warn` call.
  */
 export async function revokeKey(
   keyId: string,
@@ -255,8 +251,6 @@ export async function revokeKey(
       undefined,
       {
         headers: { [BOT_WALLET_KEY_API_TOKEN_HEADER]: accessToken },
-        signal: AbortSignal.timeout(REVOKE_TIMEOUT_MS),
-        timeout: REVOKE_TIMEOUT_MS,
       },
     );
   } catch (e) {
@@ -271,6 +265,4 @@ export async function revokeKey(
 export const CLI_BOT_WALLET_CLIENT_INTERNALS = {
   BOT_WALLET_KEY_API_PATH,
   BOT_WALLET_KEY_API_TOKEN_HEADER,
-  REGISTER_TIMEOUT_MS,
-  REVOKE_TIMEOUT_MS,
 } as const;


### PR DESCRIPTION
## Summary

- Extract `BOT_WALLET_KEY_API_PATH` and `BOT_WALLET_KEY_API_TOKEN_HEADER` into a single shared module (`packages/shared/src/utils/cliBotWalletExport/botWalletKeyApiConsts.ts`) so the App-side register/revoke flow (`packages/shared/.../register.ts`) and the CLI-side service client (`apps/cli/src/infra/vault/service-client.ts`) cannot drift apart. The CLI re-exports them so existing downstream imports (`SignerSoftwareBase`, etc.) keep working unchanged.
- Drop the local 3s `AbortSignal.timeout`/`timeout` config from `registerKey` and `revokeKey`; let the API client use its default timeouts.
- `_simulate-export.ts` now imports the shared `BOT_WALLET_KEY_API_PATH` instead of redefining its own copy.

## Test plan

- [x] `yarn jest packages/shared/src/utils/cliBotWalletExport/__tests__/register.test.ts` — 14/14 passing
- [ ] `yarn workspace @onekeyhq/cli jest src/infra/vault/__tests__/service-client.test.ts` — needs `yarn install` first in this fresh worktree; passed locally on a sibling worktree where install was up to date
- [ ] CI lint + tsc