### PR TITLE
fix: truncate long market liquidity pool pair names

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/TokenLiquidityPools.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/TokenLiquidityPools.tsx
@@ -36,6 +36,8 @@ import type {
 
 import { useTokenDetail } from '../../hooks/useTokenDetail';
 
+import { formatDisplayPairName } from './utils';
+
 type IFieldPath = string | readonly string[];
 
 type IFeeFieldCandidate = {
@@ -458,7 +460,7 @@ function formatFeeRate(item: IMarketTokenTopLiquidityItem) {
 function getPairName(item: IMarketTokenTopLiquidityItem) {
   const pairName = getText(item, PAIR_NAME_CANDIDATES);
   if (pairName) {
-    return pairName;
+    return formatDisplayPairName(pairName);
   }
 
   const baseSymbol = getText(item, BASE_SYMBOL_CANDIDATES);

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/utils.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/utils.test.ts
@@ -1,0 +1,13 @@
+import { formatDisplayPairName } from './utils';
+
+describe('formatDisplayPairName', () => {
+  it('keeps pair names with three or fewer slash segments unchanged', () => {
+    expect(formatDisplayPairName('Aquifer')).toBe('Aquifer');
+    expect(formatDisplayPairName('A/B/C')).toBe('A/B/C');
+  });
+
+  it('keeps the first three slash segments and appends ellipsis', () => {
+    expect(formatDisplayPairName('A/B/C/D')).toBe('A/B/C...');
+    expect(formatDisplayPairName('A/B/C/D/E')).toBe('A/B/C...');
+  });
+});

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/utils.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/utils.ts
@@ -1,0 +1,12 @@
+const MAX_DISPLAY_PAIR_NAME_SEGMENTS = 3;
+
+export function formatDisplayPairName(pairName: string) {
+  const pairNameSegments = pairName.split('/');
+  const displayPairName = pairNameSegments
+    .slice(0, MAX_DISPLAY_PAIR_NAME_SEGMENTS)
+    .join('/');
+
+  return pairNameSegments.length > MAX_DISPLAY_PAIR_NAME_SEGMENTS
+    ? `${displayPairName}...`
+    : displayPairName;
+}


### PR DESCRIPTION
## Summary
- Truncate long pair names with more than 3 slash-separated segments to `A/B/C...` in the Market detail liquidity pools list.
- Extract the formatting logic into a `formatDisplayPairName` utility with unit tests.

## Intent & Context
Some liquidity pools (e.g. multi-hop or basket pools) return pair names containing many slash-separated tokens. When rendered as-is they overflow the column and break the table layout in the Market detail page. The fix bounds the display length so layouts stay stable while still telling the user the name was truncated.

## Design Decisions
- Cap at 3 segments (`A/B/C...`) — keeps enough context to identify the pool while preventing overflow on smaller widths.
- Apply the truncation only to the API-provided `pairName`. The fallback path that composes a name from `baseSymbol`/`quoteSymbol` keeps its original behavior, since those names are always 2 segments by construction.
- Pulled the helper into a sibling `utils.ts` module rather than inlining it, so it can be unit-tested without rendering the React tree.

## Changes Detail
- `TokenLiquidityPools.tsx`: route the resolved `pairName` through `formatDisplayPairName` before returning it from `getPairName`.
- `utils.ts`: new `formatDisplayPairName` helper that splits on `/`, keeps the first 3 segments, and appends an ellipsis when truncated.
- `utils.test.ts`: covers pass-through (≤3 segments) and truncation (>3 segments) cases.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Web / Mobile / Extension (all platforms render the Market detail page)
- **Risk Areas**: Display string only — no behavior, no data, no navigation. Worst case is a visually truncated label.

## Test plan
- [ ] Open Market detail for a token whose top liquidity pool has a `pairName` with >3 slash segments and confirm it renders as `A/B/C...`.
- [ ] Verify pools with 1–3 segments still render the original name unchanged.
- [ ] Confirm pools without an API-provided `pairName` still fall back to the `base/quote` composition.
- [ ] `yarn jest packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/utils.test.ts` passes.