### PR TITLE
[codex] Use WebUSB for Linux Snap raw USB

### DIFF
--- a/packages/kit-bg/src/desktopApis/DesktopApiSystem.ts
+++ b/packages/kit-bg/src/desktopApis/DesktopApiSystem.ts
@@ -1,3 +1,4 @@
+import { execFile } from 'child_process';
 import os from 'os';
 import path from 'path';
 
@@ -16,7 +17,11 @@ import {
 } from '@onekeyhq/desktop/app/libs/utils';
 import { restartBridge } from '@onekeyhq/desktop/app/process';
 import { memoizee } from '@onekeyhq/shared/src/utils/cacheUtils';
-import type { IMediaType, IPrefType } from '@onekeyhq/shared/types/desktop';
+import type {
+  IMediaType,
+  IPrefType,
+  ISnapRawUsbConnectionStatus,
+} from '@onekeyhq/shared/types/desktop';
 
 import type { IDesktopApi } from './instance/IDesktopApi';
 
@@ -281,6 +286,48 @@ class DesktopApiSystem {
   async reloadBridgeProcess(): Promise<boolean> {
     await restartBridge();
     return true;
+  }
+
+  async checkSnapRawUsbConnection(): Promise<ISnapRawUsbConnectionStatus> {
+    const snapName = process.env.SNAP_NAME || 'onekey-wallet';
+    const command = `sudo snap connect ${snapName}:raw-usb`;
+
+    if (process.platform !== 'linux' || !process.env.SNAP) {
+      return {
+        isSnap: false,
+        connected: true,
+        command,
+      };
+    }
+
+    return new Promise<ISnapRawUsbConnectionStatus>((resolve) => {
+      execFile(
+        'snapctl',
+        ['is-connected', 'raw-usb'],
+        { timeout: 5000 },
+        (error, stdout, stderr) => {
+          if (!error) {
+            resolve({
+              isSnap: true,
+              connected: true,
+              command,
+            });
+            return;
+          }
+
+          const message = [error.message, stderr, stdout]
+            .filter(Boolean)
+            .join('\n')
+            .trim();
+          resolve({
+            isSnap: true,
+            connected: false,
+            command,
+            error: message || undefined,
+          });
+        },
+      );
+    });
   }
 
   async getAppName(): Promise<string> {

--- a/packages/kit-bg/src/services/ServiceSetting.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.ts
@@ -650,19 +650,18 @@ class ServiceSetting extends ServiceBase {
   public async setHardwareTransportType(
     hardwareTransportType: EHardwareTransportType,
   ) {
+    const nextHardwareTransportType =
+      deviceUtils.normalizeHardwareTransportType(hardwareTransportType);
     await settingsPersistAtom.set((prev) => ({
       ...prev,
-      hardwareTransportType,
+      hardwareTransportType: nextHardwareTransportType,
     }));
   }
 
   @backgroundMethod()
   public async getHardwareTransportType(): Promise<EHardwareTransportType> {
     const { hardwareTransportType } = await settingsPersistAtom.get();
-    if (hardwareTransportType) {
-      return hardwareTransportType;
-    }
-    return deviceUtils.getDefaultHardwareTransportType();
+    return deviceUtils.normalizeHardwareTransportType(hardwareTransportType);
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
@@ -125,8 +125,7 @@ export const {
         selectedTab: ETabRoutes.Home,
       },
       useLocalTradingViewUrl: false,
-      // Linux Desktop use Bridge，avoiding WebUSB permission problem
-      usbCommunicationMode: platformEnv.isDesktopLinux ? 'bridge' : 'webusb',
+      usbCommunicationMode: 'webusb',
       disableIpTableInProd: false, // IP Table enabled by default
       forceIpTableStrict: false, // Strict mode: disabled by default
     },

--- a/packages/kit-bg/src/states/jotai/atoms/settings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/settings.ts
@@ -19,9 +19,8 @@ function getDefaultHardwareTransportType(): EHardwareTransportType {
   if (platformEnv.isNative) {
     return EHardwareTransportType.BLE;
   }
-  // Linux 桌面端优先使用 Bridge（WebUSB 受 udev 等限制）
   if (platformEnv.isDesktopLinux) {
-    return EHardwareTransportType.Bridge;
+    return EHardwareTransportType.WEBUSB;
   }
   if (platformEnv.isSupportWebUSB) {
     return EHardwareTransportType.WEBUSB;

--- a/packages/kit/src/hooks/useEnsureSnapRawUsbConnection.tsx
+++ b/packages/kit/src/hooks/useEnsureSnapRawUsbConnection.tsx
@@ -1,0 +1,67 @@
+import { useCallback } from 'react';
+
+import { Dialog, SizableText, Stack, useClipboard } from '@onekeyhq/components';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+const DEFAULT_SNAP_RAW_USB_CONNECT_COMMAND =
+  'sudo snap connect onekey-wallet:raw-usb';
+
+export function useEnsureSnapRawUsbConnection() {
+  const { copyText } = useClipboard();
+
+  const showRawUsbPermissionDialog = useCallback(
+    (command = DEFAULT_SNAP_RAW_USB_CONNECT_COMMAND) => {
+      Dialog.show({
+        icon: 'UsbOutline',
+        title: 'USB permission required',
+        description: (
+          <Stack gap="$3">
+            <SizableText size="$bodyMd" color="$textSubdued">
+              OneKey Wallet needs raw USB permission before WebUSB can access
+              your hardware wallet. Run this command in Terminal, then try
+              again.
+            </SizableText>
+            <Stack
+              px="$3"
+              py="$2.5"
+              borderRadius="$2"
+              bg="$bgSubdued"
+              borderWidth="$px"
+              borderColor="$borderSubdued"
+            >
+              <SizableText size="$bodyMd" fontFamily="$monoRegular" selectable>
+                {command}
+              </SizableText>
+            </Stack>
+          </Stack>
+        ),
+        onCancelText: 'Got it',
+        onConfirmText: 'Copy command',
+        onConfirm: () => {
+          copyText(command);
+        },
+      });
+    },
+    [copyText],
+  );
+
+  return useCallback(async () => {
+    if (!platformEnv.isDesktopLinuxSnap) {
+      return true;
+    }
+
+    try {
+      const status =
+        await globalThis.desktopApiProxy?.system?.checkSnapRawUsbConnection?.();
+      if (!status?.isSnap || status.connected) {
+        return true;
+      }
+      showRawUsbPermissionDialog(status.command);
+      return false;
+    } catch (error) {
+      console.error('checkSnapRawUsbConnection failed:', error);
+      showRawUsbPermissionDialog();
+      return false;
+    }
+  }, [showRawUsbPermissionDialog]);
+}

--- a/packages/kit/src/views/Onboarding/pages/ConnectHardwareWallet/ConnectYourDevice.tsx
+++ b/packages/kit/src/views/Onboarding/pages/ConnectHardwareWallet/ConnectYourDevice.tsx
@@ -44,6 +44,7 @@ import { MultipleClickStack } from '@onekeyhq/kit/src/components/MultipleClickSt
 import type { ITutorialsListItem } from '@onekeyhq/kit/src/components/TutorialsList';
 import { TutorialsList } from '@onekeyhq/kit/src/components/TutorialsList';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { useEnsureSnapRawUsbConnection } from '@onekeyhq/kit/src/hooks/useEnsureSnapRawUsbConnection';
 import { useHelpLink } from '@onekeyhq/kit/src/hooks/useHelpLink';
 import { usePromptWebDeviceAccess } from '@onekeyhq/kit/src/hooks/usePromptWebDeviceAccess';
 import { useRouteIsFocused as useIsFocused } from '@onekeyhq/kit/src/hooks/useRouteIsFocused';
@@ -143,6 +144,7 @@ async function getForceTransportType(
     case EConnectDeviceChannel.usbOrBle: {
       // For usbOrBle, constrain based on platform
       if (platformEnv.isNative) return EHardwareTransportType.BLE;
+      if (platformEnv.isDesktopLinux) return EHardwareTransportType.WEBUSB;
       if (platformEnv.isDesktop) {
         const dev = await backgroundApiProxy.serviceDevSetting.getDevSetting();
         const usbCommunicationMode = dev?.settings?.usbCommunicationMode;
@@ -714,6 +716,11 @@ function ConnectByUSBOrBLE({
   const intl = useIntl();
   const isFocused = useIsFocused();
   const [{ hardwareTransportType }] = useSettingsPersistAtom();
+  const effectiveHardwareTransportType = useMemo(
+    () => deviceUtils.normalizeHardwareTransportType(hardwareTransportType),
+    [hardwareTransportType],
+  );
+  const ensureSnapRawUsbConnection = useEnsureSnapRawUsbConnection();
 
   // Use the shared device connection logic
   const deviceConnection = useDeviceConnection({
@@ -738,9 +745,21 @@ function ConnectByUSBOrBLE({
   }, []);
 
   const listingDevice = useCallback(async () => {
+    if (
+      effectiveHardwareTransportType === EHardwareTransportType.WEBUSB &&
+      !(await ensureSnapRawUsbConnection())
+    ) {
+      setConnectStatus(EConnectionStatus.init);
+      return;
+    }
     setConnectStatus(EConnectionStatus.listing);
     await scanDevice();
-  }, [scanDevice, setConnectStatus]);
+  }, [
+    effectiveHardwareTransportType,
+    ensureSnapRawUsbConnection,
+    scanDevice,
+    setConnectStatus,
+  ]);
 
   useEffect(() => {
     if (isFocused) {
@@ -796,6 +815,10 @@ function ConnectByUSBOrBLE({
   const onConnectWebDevice = useCallback(async () => {
     setIsChecking(true);
     try {
+      if (!(await ensureSnapRawUsbConnection())) {
+        return;
+      }
+
       // Set global transport type before device access
       const targetTransportType = await getForceTransportType(tabValue);
       if (targetTransportType) {
@@ -820,12 +843,18 @@ function ConnectByUSBOrBLE({
     } finally {
       setIsChecking(false);
     }
-  }, [onDeviceConnect, promptWebUsbDeviceAccess, tabValue, setIsChecking]);
+  }, [
+    ensureSnapRawUsbConnection,
+    onDeviceConnect,
+    promptWebUsbDeviceAccess,
+    tabValue,
+    setIsChecking,
+  ]);
 
   useEffect(() => {
     if (
       platformEnv.isNative ||
-      (hardwareTransportType === EHardwareTransportType.WEBUSB &&
+      (effectiveHardwareTransportType === EHardwareTransportType.WEBUSB &&
         !platformEnv.isDesktop)
     ) {
       return;
@@ -833,7 +862,7 @@ function ConnectByUSBOrBLE({
     void (async () => {
       void listingDevice();
     })();
-  }, [listingDevice, hardwareTransportType, tabValue]);
+  }, [listingDevice, effectiveHardwareTransportType, tabValue]);
 
   useEffect(
     () =>
@@ -859,7 +888,7 @@ function ConnectByUSBOrBLE({
           <Heading size="$headingMd" textAlign="center">
             {intl.formatMessage({
               id:
-                hardwareTransportType === EHardwareTransportType.WEBUSB
+                effectiveHardwareTransportType === EHardwareTransportType.WEBUSB
                   ? ETranslations.device_connect_via_usb
                   : ETranslations.onboarding_bluetooth_prepare_to_connect,
             })}
@@ -874,7 +903,7 @@ function ConnectByUSBOrBLE({
           >
             {intl.formatMessage({
               id:
-                hardwareTransportType === EHardwareTransportType.WEBUSB
+                effectiveHardwareTransportType === EHardwareTransportType.WEBUSB
                   ? ETranslations.device_select_device_popup
                   : ETranslations.onboarding_bluetooth_prepare_to_connect_help_text,
             })}
@@ -885,7 +914,7 @@ function ConnectByUSBOrBLE({
             variant="primary"
             loading={isCheckingDeviceLoading}
             onPress={
-              hardwareTransportType === EHardwareTransportType.WEBUSB
+              effectiveHardwareTransportType === EHardwareTransportType.WEBUSB
                 ? onConnectWebDevice
                 : startBLEConnection
             }

--- a/packages/kit/src/views/Onboardingv2/hooks/usePrepareUSBConnectForFirmwareUpdate.tsx
+++ b/packages/kit/src/views/Onboardingv2/hooks/usePrepareUSBConnectForFirmwareUpdate.tsx
@@ -4,6 +4,7 @@ import { isNil } from 'lodash';
 import { useIntl } from 'react-intl';
 
 import { Dialog } from '@onekeyhq/components';
+import { useEnsureSnapRawUsbConnection } from '@onekeyhq/kit/src/hooks/useEnsureSnapRawUsbConnection';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import deviceUtils from '@onekeyhq/shared/src/utils/deviceUtils';
@@ -27,6 +28,7 @@ let globalOriginalTransport: EHardwareTransportType | undefined;
 
 export function usePrepareUSBConnectForFirmwareUpdate() {
   const intl = useIntl();
+  const ensureSnapRawUsbConnection = useEnsureSnapRawUsbConnection();
   const prepareUSBConnect = useCallback(
     async ({
       device,
@@ -35,6 +37,10 @@ export function usePrepareUSBConnectForFirmwareUpdate() {
       device: SearchDevice;
       features: IOneKeyDeviceFeatures | undefined;
     }): Promise<IUSBConnectPrepareResult | null> => {
+      if (!(await ensureSnapRawUsbConnection())) {
+        return null;
+      }
+
       // Step 1: Check if USB device is available
       const isUSBDeviceAvailable =
         await backgroundApiProxy.serviceHardware.detectUSBDeviceAvailability();
@@ -98,7 +104,7 @@ export function usePrepareUSBConnectForFirmwareUpdate() {
         needsRestore: globalOriginalTransport !== undefined,
       };
     },
-    [intl],
+    [ensureSnapRawUsbConnection, intl],
   );
 
   /**

--- a/packages/kit/src/views/Onboardingv2/pages/ConnectYourDevice.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ConnectYourDevice.tsx
@@ -30,6 +30,7 @@ import {
   useThemeName,
 } from '@onekeyhq/components';
 import { ANIMATE_ONLY_OPACITY_TRANSFORM } from '@onekeyhq/components/src/utils/animationConstants';
+import { useEnsureSnapRawUsbConnection } from '@onekeyhq/kit/src/hooks/useEnsureSnapRawUsbConnection';
 import { usePromptWebDeviceAccess } from '@onekeyhq/kit/src/hooks/usePromptWebDeviceAccess';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
@@ -728,6 +729,11 @@ function USBOrBLEConnectionIndicator({
   const navigation = useAppNavigation();
   const isFocused = useIsFocused();
   const [{ hardwareTransportType }] = useSettingsPersistAtom();
+  const effectiveHardwareTransportType = useMemo(
+    () => deviceUtils.normalizeHardwareTransportType(hardwareTransportType),
+    [hardwareTransportType],
+  );
+  const ensureSnapRawUsbConnection = useEnsureSnapRawUsbConnection();
 
   // Use the shared device connection logic
   const deviceConnection = useDeviceConnection({
@@ -747,8 +753,8 @@ function USBOrBLEConnectionIndicator({
   } = deviceConnection;
 
   const isBLE = useMemo(() => {
-    return hardwareTransportType === EHardwareTransportType.BLE;
-  }, [hardwareTransportType]);
+    return effectiveHardwareTransportType === EHardwareTransportType.BLE;
+  }, [effectiveHardwareTransportType]);
 
   // USB/BLE specific logic only
   const checkBLEState = useCallback(async () => {
@@ -757,9 +763,21 @@ function USBOrBLEConnectionIndicator({
   }, []);
 
   const listingDevice = useCallback(async () => {
+    if (
+      effectiveHardwareTransportType === EHardwareTransportType.WEBUSB &&
+      !(await ensureSnapRawUsbConnection())
+    ) {
+      setConnectStatus(EConnectionStatus.init);
+      return;
+    }
     setConnectStatus(EConnectionStatus.listing);
     await scanDevice();
-  }, [scanDevice, setConnectStatus]);
+  }, [
+    effectiveHardwareTransportType,
+    ensureSnapRawUsbConnection,
+    scanDevice,
+    setConnectStatus,
+  ]);
 
   useEffect(() => {
     if (isFocused) {
@@ -815,6 +833,10 @@ function USBOrBLEConnectionIndicator({
   const onConnectWebDevice = useCallback(async () => {
     setIsChecking(true);
     try {
+      if (!(await ensureSnapRawUsbConnection())) {
+        return;
+      }
+
       // Set global transport type before device access
       const targetTransportType = await getForceTransportType(tabValue);
       if (targetTransportType) {
@@ -839,12 +861,20 @@ function USBOrBLEConnectionIndicator({
     } catch (error) {
       console.error('onConnectWebDevice error:', error);
       setIsChecking(false);
+    } finally {
+      setIsChecking(false);
     }
-  }, [setIsChecking, tabValue, promptWebUsbDeviceAccess, navigation]);
+  }, [
+    ensureSnapRawUsbConnection,
+    setIsChecking,
+    tabValue,
+    promptWebUsbDeviceAccess,
+    navigation,
+  ]);
 
   useEffect(() => {
     if (
-      hardwareTransportType === EHardwareTransportType.WEBUSB &&
+      effectiveHardwareTransportType === EHardwareTransportType.WEBUSB &&
       !platformEnv.isDesktop
     ) {
       return;
@@ -860,7 +890,7 @@ function USBOrBLEConnectionIndicator({
     return () => clearTimeout(timeoutId);
   }, [
     listingDevice,
-    hardwareTransportType,
+    effectiveHardwareTransportType,
     tabValue,
     startBLEConnection,
     vendor,

--- a/packages/kit/src/views/Onboardingv2/pages/ConnectionFlowLedger.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ConnectionFlowLedger.tsx
@@ -14,6 +14,7 @@ import {
   XStack,
   YStack,
 } from '@onekeyhq/components';
+import { useEnsureSnapRawUsbConnection } from '@onekeyhq/kit/src/hooks/useEnsureSnapRawUsbConnection';
 import { usePromptWebDeviceAccess } from '@onekeyhq/kit/src/hooks/usePromptWebDeviceAccess';
 import { ThirdPartyDevicePermissionDenied } from '@onekeyhq/shared/src/errors/errors/thirdPartyHardwareErrors';
 import { convertDeviceError } from '@onekeyhq/shared/src/errors/utils/deviceErrorUtils';
@@ -77,6 +78,7 @@ export default function LedgerConnectionFlow() {
   const isFocused = useIsFocused();
   const themeVariant = useThemeVariant();
   const { promptHidDeviceAccess } = usePromptWebDeviceAccess();
+  const ensureSnapRawUsbConnection = useEnsureSnapRawUsbConnection();
 
   const vendor = EHardwareVendor.ledger;
   const tabValue = EConnectDeviceChannel.usbOrBle;
@@ -219,9 +221,13 @@ export default function LedgerConnectionFlow() {
 
   // --- Listing mode ---
   const listingDevice = useCallback(async () => {
+    if (!(await ensureSnapRawUsbConnection())) {
+      setConnectStatus(EConnectionStatus.init);
+      return;
+    }
     setConnectStatus(EConnectionStatus.listing);
     await scanDevice();
-  }, [scanDevice]);
+  }, [ensureSnapRawUsbConnection, scanDevice]);
 
   // --- Start connection ---
   // Extension: HID permission popup first, then listing

--- a/packages/kit/src/views/Onboardingv2/utils.tsx
+++ b/packages/kit/src/views/Onboardingv2/utils.tsx
@@ -49,6 +49,7 @@ export async function getForceTransportType(
     case EConnectDeviceChannel.usbOrBle: {
       // For usbOrBle, constrain based on platform
       if (platformEnv.isNative) return EHardwareTransportType.BLE;
+      if (platformEnv.isDesktopLinux) return EHardwareTransportType.WEBUSB;
       if (platformEnv.isDesktop) {
         const dev = await backgroundApiProxy.serviceDevSetting.getDevSetting();
         const usbCommunicationMode = dev?.settings?.usbCommunicationMode;
@@ -71,6 +72,7 @@ export async function getForceTransportType(
 
 export async function getDesktopForceUSBTransportType(): Promise<EHardwareTransportType | null> {
   if (platformEnv.isDesktop) {
+    if (platformEnv.isDesktopLinux) return EHardwareTransportType.WEBUSB;
     const dev = await backgroundApiProxy.serviceDevSetting.getDevSetting();
     const usbCommunicationMode = dev?.settings?.usbCommunicationMode;
     if (usbCommunicationMode === 'bridge') return EHardwareTransportType.Bridge;
@@ -86,6 +88,8 @@ export const getDeviceLabel = (
   return deviceTypeItems
     .map((deviceType) => {
       switch (deviceType) {
+        case EDeviceType.Pro2:
+          return 'OneKey Pro 2';
         case EDeviceType.Pro:
           return 'OneKey Pro';
         case EDeviceType.Classic:

--- a/packages/kit/src/views/Setting/pages/Tab/CustomElement.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/CustomElement.tsx
@@ -76,6 +76,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IModalSettingParamList } from '@onekeyhq/shared/src/routes';
 import { EModalSettingRoutes, ERootRoutes } from '@onekeyhq/shared/src/routes';
 import { EOnboardingV2OneKeyIDLoginMode } from '@onekeyhq/shared/src/routes/onboardingv2';
+import deviceUtils from '@onekeyhq/shared/src/utils/deviceUtils';
 import openUrlUtils, {
   openUrlExternal,
 } from '@onekeyhq/shared/src/utils/openUrlUtils';
@@ -317,6 +318,8 @@ export function ResetAppListItem(props: ICustomElementProps) {
 export function HardwareTransportTypeListItem(props: ICustomElementProps) {
   const [{ hardwareTransportType }] = useSettingsPersistAtom();
   const [devPersist] = useDevSettingsPersistAtom();
+  const normalizedHardwareTransportType =
+    deviceUtils.normalizeHardwareTransportType(hardwareTransportType);
 
   const transportOptions = useMemo(() => {
     if (platformEnv.isNative) {
@@ -330,7 +333,7 @@ export function HardwareTransportTypeListItem(props: ICustomElementProps) {
     if (platformEnv.isDesktop) {
       const usb = devPersist?.settings?.usbCommunicationMode;
       const desktopTransportList: ISelectItem[] = [];
-      if (usb === 'bridge') {
+      if (usb === 'bridge' && !platformEnv.isDesktopLinux) {
         desktopTransportList.push({
           label: 'Bridge',
           value: EHardwareTransportType.Bridge,
@@ -388,7 +391,7 @@ export function HardwareTransportTypeListItem(props: ICustomElementProps) {
       offset={{ mainAxis: -4, crossAxis: -10 }}
       title={props?.title || ''}
       items={transportOptions}
-      value={hardwareTransportType}
+      value={normalizedHardwareTransportType}
       onChange={onChange}
       placement="bottom-end"
       renderTrigger={({ label }) => (

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
@@ -658,7 +658,9 @@ const BaseDevSettingsSection = () => {
                               title="USB 通信方式"
                               items={[
                                 { label: 'WebUSB', value: 'webusb' },
-                                { label: 'Bridge', value: 'bridge' },
+                                ...(platformEnv.isDesktopLinux
+                                  ? []
+                                  : [{ label: 'Bridge', value: 'bridge' }]),
                               ]}
                               placement="bottom-end"
                             />

--- a/packages/shared/src/platformEnv.ts
+++ b/packages/shared/src/platformEnv.ts
@@ -440,8 +440,7 @@ const isRuntimeChrome = checkIsRuntimeChrome();
 const isRuntimeEdge = checkIsRuntimeEdge();
 const isRuntimeBrave = checkIsRuntimeBrave();
 const isRuntimeMacOSBrowser = isDesktopMac || checkIsRuntimeMacOSBrowser();
-// Desktop (Electron) supports WebUSB through Chromium, except Linux which uses Bridge due to udev permission issues
-const isSupportWebUSB = isExtension || isWeb || (isDesktop && !isDesktopLinux);
+const isSupportWebUSB = isExtension || isWeb || isDesktop;
 
 const isSupportDesktopBle = isDesktopMac || isDesktopWin;
 

--- a/packages/shared/src/utils/deviceUtils.ts
+++ b/packages/shared/src/utils/deviceUtils.ts
@@ -341,6 +341,7 @@ async function buildDeviceLabel({
     [EDeviceType.Mini]: 'OneKey Mini',
     [EDeviceType.Touch]: 'OneKey Touch',
     [EDeviceType.Pro]: 'OneKey Pro',
+    [EDeviceType.Pro2]: 'OneKey Pro 2',
     [EDeviceType.Unknown]: '',
   };
   const deviceType = await getDeviceTypeFromFeatures({
@@ -614,14 +615,25 @@ function getDefaultHardwareTransportType(): EHardwareTransportType {
   if (platformEnv.isNative) {
     return EHardwareTransportType.BLE;
   }
-  // Because of uDev rules, using http bridge in linux desktop
   if (platformEnv.isDesktopLinux) {
-    return EHardwareTransportType.Bridge;
+    return EHardwareTransportType.WEBUSB;
   }
   if (platformEnv.isSupportWebUSB) {
     return EHardwareTransportType.WEBUSB;
   }
   return EHardwareTransportType.Bridge;
+}
+
+function normalizeHardwareTransportType(
+  hardwareTransportType?: EHardwareTransportType,
+): EHardwareTransportType {
+  if (
+    platformEnv.isDesktopLinux &&
+    hardwareTransportType === EHardwareTransportType.Bridge
+  ) {
+    return EHardwareTransportType.WEBUSB;
+  }
+  return hardwareTransportType ?? getDefaultHardwareTransportType();
 }
 
 function getFirmwareTypeByCachedFeatures({
@@ -806,6 +818,7 @@ export default {
   getRawDeviceId,
   getDeviceConnectId,
   getDefaultHardwareTransportType,
+  normalizeHardwareTransportType,
   isBtcOnlyFirmware,
   getFirmwareTypeByCachedFeatures,
   getFirmwareType,

--- a/packages/shared/types/desktop.ts
+++ b/packages/shared/types/desktop.ts
@@ -17,6 +17,13 @@ export type IDesktopAppState = 'active' | 'background' | 'blur';
 
 export type IDesktopEventUnSubscribe = () => void;
 
+export type ISnapRawUsbConnectionStatus = {
+  isSnap: boolean;
+  connected: boolean;
+  command: string;
+  error?: string;
+};
+
 // Type for the legacy desktopApi exposed via contextBridge in preload.ts
 export type INobleBleApi = {
   enumerate: () => Promise<{ id: string; name: string }[]>;


### PR DESCRIPTION
## Summary
- default Linux desktop hardware transport to WebUSB and normalize any persisted Bridge value back to WebUSB
- add a desktop system API that checks `snapctl is-connected raw-usb` inside Snap builds
- show a blocking WebUSB permission dialog with `sudo snap connect onekey-wallet:raw-usb` before USB scan/access when the Snap raw-usb plug is disconnected
- keep Linux developer transport choices aligned with WebUSB and add Pro2 display labels in the touched onboarding/device paths

## Verification
- `git diff --check`
- `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings <changed files>`
- `yarn lint:staged`
- `yarn workspace @onekeyhq/desktop build:main:dev`

## Notes
- `yarn tsc:only` is currently blocked on existing base-branch type/dependency issues, including missing `expect-type`, missing third-party hardware exports, missing Skia types, and related hardware adapter type mismatches.