### PR TITLE
fix: keep Prime gate above parent modal on iOS (OK-54003)

### DIFF
--- a/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/BulkCopyAddressesButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/BulkCopyAddressesButton.tsx
@@ -44,7 +44,7 @@ export function BulkCopyAddressesButton({
             featureName: EPrimeFeatures.BulkCopyAddresses,
             entryPoint: 'walletEdit',
           });
-          navigation?.pushFullModal(EModalRoutes.PrimeModal, {
+          navigation?.pushModal(EModalRoutes.PrimeModal, {
             screen: EPrimePages.PrimeDashboard,
             params: {
               fromFeature: EPrimeFeatures.BulkCopyAddresses,

--- a/packages/kit/src/views/ApprovalManagement/hooks/useBulkRevoke.tsx
+++ b/packages/kit/src/views/ApprovalManagement/hooks/useBulkRevoke.tsx
@@ -205,7 +205,7 @@ function useBulkRevoke() {
                       contractMap,
                     });
                   } else {
-                    navigation.pushFullModal(EModalRoutes.PrimeModal, {
+                    navigation.pushModal(EModalRoutes.PrimeModal, {
                       screen: EPrimePages.PrimeDashboard,
                       params: {
                         fromFeature: EPrimeFeatures.BulkRevoke,


### PR DESCRIPTION
## Summary

- iOS 上当父级是 `pushModal`（pageSheet）时，Prime 权限拦截弹窗用 `pushFullModal` 打开会被父级 Modal 覆盖。改为同栈 `pushModal`，让 Prime 拦截页自然叠在父级之上，保留返回路径。
- 影响两个入口：账户选择器 → 钱包编辑 → 批量复制；授权管理 → 批量取消授权 → 选"批量"方法。

Jira: [OK-54003](https://onekeyhq.atlassian.net/browse/OK-54003)

## Test plan

- [ ] iOS 非 Prime 账号：钱包编辑 → 批量复制 → Prime 拦截页出现在账户选择器之上，可见、可返回
- [ ] iOS 非 Prime 账号：首页 → 更多 → 授权 → 批量取消授权 → 选"批量" → Prime 拦截页出现在授权列表之上，返回保留勾选状态
- [ ] Prime 用户两个入口直接进入批量功能，行为不变
- [ ] Android / Web 回归

[OK-54003]: https://onekeyhq.atlassian.net/browse/OK-54003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ