### PR TITLE
fix: harden DApp browser localhost handling and search result rendering

### DIFF
--- a/packages/kit-bg/src/services/ServiceScanQRCode/utils/parseQRCode/type.ts
+++ b/packages/kit-bg/src/services/ServiceScanQRCode/utils/parseQRCode/type.ts
@@ -8,6 +8,9 @@ import type {
   EQRCodeHandlerType,
 } from '@onekeyhq/shared/types/qrCode';
 import type { ITokenData } from '@onekeyhq/shared/types/token';
+import type { IUrlValue } from '@onekeyhq/shared/types/uri';
+
+export type { IUrlValue } from '@onekeyhq/shared/types/uri';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type
 export interface IBaseValue {}
@@ -86,16 +89,6 @@ export interface IAnimationValue extends IBaseValue {
   fullUr?: IAirGapUrJson;
   progress: number;
 }
-export interface IUrlValue extends IBaseValue {
-  url: string;
-  hostname: string;
-  origin: string;
-  pathname: string;
-  urlSchema: string;
-  urlPathList: string[];
-  urlParamList: { [key: string]: string };
-}
-
 export type IQRCodeHandlerResult<T extends IBaseValue> = {
   type: EQRCodeHandlerType;
   data: T;

--- a/packages/kit-bg/src/services/ServiceUniversalSearch.ts
+++ b/packages/kit-bg/src/services/ServiceUniversalSearch.ts
@@ -26,6 +26,7 @@ import {
   getMergedDeriveTokenData,
   sortTokensByFiatValue,
 } from '@onekeyhq/shared/src/utils/tokenUtils';
+import uriUtils from '@onekeyhq/shared/src/utils/uriUtils';
 import type { IServerNetwork } from '@onekeyhq/shared/types';
 import type { INetworkAccount } from '@onekeyhq/shared/types/account';
 import type { IAddressValidation } from '@onekeyhq/shared/types/address';
@@ -1166,7 +1167,7 @@ class ServiceUniversalSearch extends ServiceBase {
           name: `${appLocale.intl.formatMessage({
             id: ETranslations.explore_search_placeholder,
           })} "${input}"`,
-          url: '',
+          url: uriUtils.buildGoogleSearchUrl(input),
           logo: GOOGLE_LOGO_URL,
           description: '',
           networkIds: [],

--- a/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
@@ -90,6 +90,8 @@ export interface IDevSettings {
   // When true, buildCustomUA() returns null, all call sites fall back to
   // the runtime default UA.
   disableCustomUA?: boolean;
+  // Allow Discovery browser to load local development URLs.
+  allowLocalhostUrlInDAppBrowser?: boolean;
 }
 
 export type IDevSettingsKeys = keyof IDevSettings;
@@ -125,6 +127,7 @@ export const {
         selectedTab: ETabRoutes.Home,
       },
       useLocalTradingViewUrl: false,
+      allowLocalhostUrlInDAppBrowser: false,
       // Linux Desktop use Bridge，avoiding WebUSB permission problem
       usbCommunicationMode: platformEnv.isDesktopLinux ? 'bridge' : 'webusb',
       disableIpTableInProd: false, // IP Table enabled by default

--- a/packages/kit/src/states/jotai/contexts/discovery/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/discovery/actions.test.tsx
@@ -6,8 +6,10 @@ import { act, renderHook } from '@testing-library/react';
 import { createStore } from 'jotai';
 
 import type { IWebTab } from '@onekeyhq/kit/src/views/Discovery/types';
+import { jotaiDefaultStore } from '@onekeyhq/kit-bg/src/states/jotai/utils/jotaiDefaultStore';
+import { EValidateUrlEnum } from '@onekeyhq/shared/types/dappConnection';
 
-import { useBrowserTabActions } from './actions';
+import { useBrowserAction, useBrowserTabActions } from './actions';
 import {
   ProviderJotaiContextDiscovery,
   activeTabIdAtom,
@@ -49,6 +51,9 @@ jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
           mockSetBrowserHistoryRawData(payload);
         },
       },
+      browserBookmarks: {
+        getRawData: jest.fn(async () => ({ data: [] })),
+      },
       browserClosedTabs: {
         setRawData: (payload: unknown) => {
           mockSetBrowserClosedTabsRawData(payload);
@@ -63,6 +68,9 @@ jest.mock('@onekeyhq/kit/src/routes/config/deeplink', () => ({
 }));
 
 jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms', () => ({
+  devSettingsPersistAtom: {
+    atom: jest.fn(),
+  },
   settingsPersistAtom: {
     atom: jest.fn(),
   },
@@ -119,6 +127,7 @@ function createWrapper() {
 describe('useBrowserTabActions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (jotaiDefaultStore.get as jest.Mock).mockReturnValue({});
   });
 
   it('persists active tab flags when switching to an existing tab', () => {
@@ -208,5 +217,66 @@ describe('useBrowserTabActions', () => {
         isActive: true,
       }),
     ]);
+  });
+
+  it('allows localhost webview URLs only when the developer setting is enabled', () => {
+    const { result } = renderHook(() => useBrowserAction().current, {
+      wrapper: createWrapper(),
+    });
+
+    expect(
+      result.current.validateWebviewSrc({
+        url: 'http://localhost:3000',
+        isTopFrame: true,
+      }),
+    ).toBe(EValidateUrlEnum.NotSupportProtocol);
+
+    (jotaiDefaultStore.get as jest.Mock).mockReturnValue({
+      enabled: true,
+      settings: {
+        allowLocalhostUrlInDAppBrowser: true,
+      },
+    });
+
+    expect(
+      result.current.validateWebviewSrc({
+        url: 'http://localhost:3000',
+        isTopFrame: true,
+      }),
+    ).toBe(EValidateUrlEnum.Valid);
+  });
+
+  it('keeps blocked localhost gotoSite in the browser so the block page is shown', async () => {
+    const { result } = renderHook(
+      () => {
+        const actions = useBrowserAction().current;
+        const [webTabs] = useWebTabsAtom();
+
+        return {
+          actions,
+          tabs: webTabs.tabs,
+        };
+      },
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    let opened: boolean | void = undefined;
+    await act(async () => {
+      opened = await result.current.actions.gotoSite({
+        id: 'tab-1',
+        url: 'http://localhost:3000',
+        title: 'http://localhost:3000',
+      });
+    });
+
+    expect(opened).toBe(true);
+    expect(
+      result.current.tabs.some((tab) => tab.url === 'http://localhost:3000'),
+    ).toBe(true);
+    expect(
+      result.current.tabs.some((tab) => tab.url.includes('google.com/search')),
+    ).toBe(false);
   });
 });

--- a/packages/kit/src/states/jotai/contexts/discovery/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/discovery/actions.ts
@@ -24,7 +24,10 @@ import {
   injectToResumeWebsocket,
   webviewRefs,
 } from '@onekeyhq/kit/src/views/Discovery/utils/explorerUtils';
-import { settingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  devSettingsPersistAtom,
+  settingsPersistAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { jotaiDefaultStore } from '@onekeyhq/kit-bg/src/states/jotai/utils/jotaiDefaultStore';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import {
@@ -92,6 +95,14 @@ function isNewTabPositionTop() {
     platformEnv.isDesktop &&
     jotaiDefaultStore.get(settingsPersistAtom.atom()).newBrowserTabPosition ===
       'top'
+  );
+}
+
+function isLocalhostUrlAllowedInDAppBrowser() {
+  const devSettings = jotaiDefaultStore.get(devSettingsPersistAtom.atom());
+  return Boolean(
+    devSettings?.enabled &&
+    devSettings.settings?.allowLocalhostUrlInDAppBrowser,
   );
 }
 
@@ -798,7 +809,14 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
     ) => {
       const tab = this.getWebTabById.call(set, id ?? '');
       if (url) {
-        const validatedUrl = uriUtils.validateUrl(url);
+        const allowLocalhostUrl = isLocalhostUrlAllowedInDAppBrowser();
+        const shouldBlockLocalhostUrl =
+          !allowLocalhostUrl && uriUtils.isLocalhostUrl(url);
+        const validatedUrl = shouldBlockLocalhostUrl
+          ? uriUtils.ensureHttpPrefix(url)
+          : uriUtils.validateUrl(url, {
+              allowLocalhostUrl,
+            });
         if (!validatedUrl) {
           return;
         }
@@ -1029,6 +1047,9 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
         const { action } = uriUtils.parseDappRedirect(
           url,
           Array.from(cache.keys()),
+          {
+            allowLocalhostUrl: isLocalhostUrlAllowedInDAppBrowser(),
+          },
         );
         if (action === uriUtils.EDAppOpenActionEnum.DENY) {
           defaultLogger.discovery.browser.logRejectUrl(url);
@@ -1168,7 +1189,10 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
       const { action } = uriUtils.parseDappRedirect(
         url,
         Array.from(cache.keys()),
-        { isTopFrame },
+        {
+          isTopFrame,
+          allowLocalhostUrl: isLocalhostUrlAllowedInDAppBrowser(),
+        },
       );
       if (action === uriUtils.EDAppOpenActionEnum.DENY) {
         defaultLogger.discovery.browser.logRejectUrl(url);

--- a/packages/kit/src/views/Discovery/components/SearchResultContent.tsx
+++ b/packages/kit/src/views/Discovery/components/SearchResultContent.tsx
@@ -12,7 +12,6 @@ import { StyleSheet } from 'react-native';
 import {
   Icon,
   Image,
-  RichSizeableText,
   SizableText,
   Skeleton,
   Stack,
@@ -20,12 +19,15 @@ import {
 } from '@onekeyhq/components';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { EEnterMethod } from '@onekeyhq/shared/src/logger/scopes/discovery/scenes/dapp';
 import {
   EDiscoveryModalRoutes,
   EModalRoutes,
+  EModalSettingRoutes,
 } from '@onekeyhq/shared/src/routes';
+import uriUtils from '@onekeyhq/shared/src/utils/uriUtils';
 
 import { useWebSiteHandler } from '../hooks/useWebSiteHandler';
 import { DappSearchModalSectionHeader } from '../pages/SearchModal/DappSearchModalSectionHeader';
@@ -60,6 +62,71 @@ interface ISearchResultContentProps {
   innerRef?: React.RefObject<ISearchResultContentRef>;
 }
 
+const HTML_ANCHOR_TAG_REGEXP = /<\/?a(?:\s[^>]*)?>/giu;
+
+function escapeRegExp(value: string) {
+  return value.replace(/[[\]()+?*^$.|\\{}]/g, '\\$&');
+}
+
+function stripSearchResultTitleMarkup(title: string) {
+  return title.replace(HTML_ANCHOR_TAG_REGEXP, '');
+}
+
+function getSearchResultTitleParts({
+  title,
+  keyword,
+}: {
+  title: string;
+  keyword?: string;
+}) {
+  const normalizedTitle = stripSearchResultTitleMarkup(title);
+  const normalizedKeyword = keyword?.trim();
+  if (!normalizedKeyword) {
+    return [{ text: normalizedTitle, highlighted: false }];
+  }
+
+  const keywordRegExp = new RegExp(
+    `(${escapeRegExp(normalizedKeyword)})`,
+    'ig',
+  );
+  return normalizedTitle
+    .split(keywordRegExp)
+    .filter(Boolean)
+    .map((text) => ({
+      text,
+      highlighted: text.toLowerCase() === normalizedKeyword.toLowerCase(),
+    }));
+}
+
+function DappSearchResultTitle({
+  item,
+}: {
+  item: Extract<IDiscoverySearchListItem, { type: 'dapp' }>;
+}) {
+  const titleParts = getSearchResultTitleParts({
+    title: item.title,
+    keyword: item.keyword,
+  });
+
+  return (
+    <SizableText numberOfLines={1} size="$bodyLgMedium" flex={1}>
+      {titleParts.map((part, index) =>
+        part.highlighted ? (
+          <SizableText
+            key={`${part.text}-${index}`}
+            size="$bodyLgMedium"
+            color="$textInfo"
+          >
+            {part.text}
+          </SizableText>
+        ) : (
+          part.text
+        ),
+      )}
+    </SizableText>
+  );
+}
+
 export function SearchResultContent({
   searchValue,
   localData,
@@ -77,6 +144,7 @@ export function SearchResultContent({
   const intl = useIntl();
   const navigation = useAppNavigation();
   const handleWebSite = useWebSiteHandler();
+  const [devSettings] = useDevSettingsPersistAtom();
 
   // State for keeping track of which section is active
   const [selectedSection, setSelectedSection] = useState<
@@ -101,6 +169,19 @@ export function SearchResultContent({
   const historyCount = displayHistoryList
     ? localData?.historyData?.length || 0
     : 0;
+  const showLocalhostDevSettingHint =
+    devSettings.enabled &&
+    !devSettings.settings?.allowLocalhostUrlInDAppBrowser &&
+    uriUtils.isLocalhostUrl(searchValue);
+
+  const handleOpenLocalhostDevSetting = useCallback(() => {
+    navigation.pushModal(EModalRoutes.SettingModal, {
+      screen: EModalSettingRoutes.SettingListSubModal,
+      params: {
+        name: 'Dev',
+      },
+    });
+  }, [navigation]);
 
   // Helper functions to calculate adjusted indices
   const getAdjustedBookmarkIndex = useCallback(() => {
@@ -244,14 +325,15 @@ export function SearchResultContent({
       }
 
       if (item.type === 'search-action') {
+        const searchUrl = uriUtils.buildGoogleSearchUrl(searchValue);
         onItemClick?.({
-          url: searchValue,
+          url: searchUrl,
           title: searchValue,
           logo: undefined,
         });
         handleWebSite({
           webSite: {
-            url: searchValue,
+            url: searchUrl,
             title: searchValue,
             logo: undefined,
             sortIndex: undefined,
@@ -402,24 +484,7 @@ export function SearchResultContent({
           }}
           {...(item.type === 'dapp'
             ? {
-                renderItemText: () => (
-                  <RichSizeableText
-                    linkList={{ a: { url: undefined, cursor: 'auto' } }}
-                    numberOfLines={1}
-                    size="$bodyLgMedium"
-                    flex={1}
-                  >
-                    {item.keyword
-                      ? item.title.replace(
-                          new RegExp(
-                            item.keyword.replace(/[[\]()+?*^$.|\\{}]/g, '\\$&'),
-                            'ig',
-                          ),
-                          (match) => `<a>${match}</a>`,
-                        )
-                      : item.title}
-                  </RichSizeableText>
-                ),
+                renderItemText: () => <DappSearchResultTitle item={item} />,
                 subtitleProps: {
                   numberOfLines: 1,
                 },
@@ -448,6 +513,19 @@ export function SearchResultContent({
 
   return (
     <>
+      {showLocalhostDevSettingHint ? (
+        <ListItem
+          icon="CodeOutline"
+          title="Local URLs are blocked by default"
+          subtitle='Enable "Allow local URLs in DApp Browser" in Developer settings'
+          subtitleProps={{
+            numberOfLines: 2,
+          }}
+          drillIn
+          onPress={handleOpenLocalhostDevSetting}
+          testID="discovery-localhost-dev-setting-hint"
+        />
+      ) : null}
       {displaySearchList ? (
         <Stack ref={searchListRef}>{renderList(searchList)}</Stack>
       ) : null}

--- a/packages/kit/src/views/Discovery/components/WebContent/WebContent.desktop.tsx
+++ b/packages/kit/src/views/Discovery/components/WebContent/WebContent.desktop.tsx
@@ -34,23 +34,40 @@ type IWebContentProps = IWebTab &
     customReceiveHandler?: IJsBridgeReceiveHandler;
   };
 
+function shouldBlockAccess(validateState: EValidateUrlEnum | undefined) {
+  return (
+    Boolean(validateState) &&
+    validateState !== EValidateUrlEnum.Valid &&
+    validateState !== EValidateUrlEnum.ValidDeeplink
+  );
+}
+
 function WebContent({ id, url, customReceiveHandler }: IWebContentProps) {
   const navigation = useAppNavigation();
   const urlRef = useRef<string>('');
   const phishingUrlRef = useRef<string>('');
-  const [showBlockAccessView, setShowBlockAccessView] = useState(false);
-  const [urlValidateState, setUrlValidateState] = useState<EValidateUrlEnum>();
+  const [navigationBlockAccessView, setNavigationBlockAccessView] =
+    useState(false);
+  const [navigationUrlValidateState, setNavigationUrlValidateState] =
+    useState<EValidateUrlEnum>();
   const { setWebTabData, closeWebTab, setCurrentWebTab, getWebTabById } =
     useBrowserTabActions().current;
   const { onNavigation, validateWebviewSrc } = useBrowserAction().current;
+  const currentUrlValidateState = useMemo(
+    () => validateWebviewSrc({ url, isTopFrame: true }),
+    [url, validateWebviewSrc],
+  );
+  const shouldBlockCurrentUrl = shouldBlockAccess(currentUrlValidateState);
+  const showBlockAccessView =
+    shouldBlockCurrentUrl || navigationBlockAccessView;
+  const urlValidateState = shouldBlockCurrentUrl
+    ? currentUrlValidateState
+    : navigationUrlValidateState;
+
   useEffect(() => {
-    const validateState = validateWebviewSrc({ url, isTopFrame: true });
-    setUrlValidateState(validateState);
-    setShowBlockAccessView(
-      validateState !== EValidateUrlEnum.Valid &&
-        validateState !== EValidateUrlEnum.ValidDeeplink,
-    );
-  }, [url, validateWebviewSrc]);
+    setNavigationBlockAccessView(false);
+    setNavigationUrlValidateState(undefined);
+  }, [url]);
 
   const getNavStatusInfo = useCallback(() => {
     const ref = webviewRefs[id];
@@ -75,6 +92,8 @@ function WebContent({ id, url, customReceiveHandler }: IWebContentProps) {
   const onDidStartNavigation = useCallback(
     ({ url: willNavigationUrl, isMainFrame }: DidStartNavigationEvent) => {
       if (isMainFrame) {
+        setNavigationBlockAccessView(false);
+        setNavigationUrlValidateState(undefined);
         notifyTabNavigation(id);
         onNavigation({
           id,
@@ -84,7 +103,8 @@ function WebContent({ id, url, customReceiveHandler }: IWebContentProps) {
           ...getNavStatusInfo(),
           handlePhishingUrl: (illegalUrl) => {
             console.log('=====>>>>: handlePhishingUrl', illegalUrl);
-            setShowBlockAccessView(true);
+            setNavigationBlockAccessView(true);
+            setNavigationUrlValidateState(EValidateUrlEnum.NotSupportProtocol);
             phishingUrlRef.current = illegalUrl;
           },
         });
@@ -163,8 +183,7 @@ function WebContent({ id, url, customReceiveHandler }: IWebContentProps) {
 
   const webview = useMemo(
     () => {
-      const isValidate = validateWebviewSrc({ url, isTopFrame: true });
-      if (!isValidate) {
+      if (shouldBlockCurrentUrl) {
         return null;
       }
       return (
@@ -202,6 +221,7 @@ function WebContent({ id, url, customReceiveHandler }: IWebContentProps) {
       onDidStartLoading,
       onDidStartNavigation,
       onDomReady,
+      shouldBlockCurrentUrl,
       customReceiveHandler,
       // onPageTitleUpdated,
       // onPageFaviconUpdated,

--- a/packages/kit/src/views/Discovery/utils/searchDebugSnapshot.ts
+++ b/packages/kit/src/views/Discovery/utils/searchDebugSnapshot.ts
@@ -326,7 +326,7 @@ export function buildDiscoverySearchListFromFactors({
       type: 'search-action',
       key: SEARCH_ITEM_ID,
       title: searchActionTitle,
-      url: '',
+      url: uriUtils.buildGoogleSearchUrl(searchValue),
       logo: GOOGLE_LOGO_URL,
     },
   ];

--- a/packages/kit/src/views/Discovery/utils/searchResultRanking.test.ts
+++ b/packages/kit/src/views/Discovery/utils/searchResultRanking.test.ts
@@ -1,6 +1,7 @@
 import type { IDApp } from '@onekeyhq/shared/types/discovery';
 
 import {
+  isWebUrlLikeSearchKeyword,
   mergeSearchResultsWithLocalData,
   rankSearchResultsChromeLike,
   searchTrendingDappsByKeyword,
@@ -1553,5 +1554,17 @@ describe('searchResultRanking', () => {
         'app.uniswap.org/swap?inputCurrency=ETH&outputCurrency=USDC&chain=ethereum',
       ),
     ).toBe(false);
+  });
+
+  it('detects URL-like search keywords without parsing invalid input', () => {
+    expect(isWebUrlLikeSearchKeyword('https://app.uniswap.org/swap')).toBe(
+      true,
+    );
+    expect(isWebUrlLikeSearchKeyword('app.uniswap.org/swap')).toBe(true);
+    expect(isWebUrlLikeSearchKeyword('http://localhost:3000')).toBe(true);
+    expect(isWebUrlLikeSearchKeyword('localhost:3000')).toBe(true);
+    expect(isWebUrlLikeSearchKeyword('http://')).toBe(false);
+    expect(isWebUrlLikeSearchKeyword('https:// app.uniswap.org')).toBe(false);
+    expect(isWebUrlLikeSearchKeyword('search query')).toBe(false);
   });
 });

--- a/packages/kit/src/views/Discovery/utils/searchResultRanking.ts
+++ b/packages/kit/src/views/Discovery/utils/searchResultRanking.ts
@@ -16,6 +16,7 @@ const DAPP_PROMOTION_PREFIX_COVERAGE_DIRECT = 0.8;
 const DAPP_PROMOTION_LIGHT_SUPPORT_MIN_QUERY_LENGTH = 5;
 const DAPP_PROMOTION_PREFIX_COVERAGE_WITH_LIGHT_SUPPORT = 0.5;
 const DAPP_PROMOTION_PREFIX_COVERAGE_WITH_SUPPORT = 0.6;
+const WEB_URL_WITH_PROTOCOL_REGEXP = /^https?:\/\/[^\s/?#]+(?:[/?#]|$)/iu;
 
 export const DISCOVERY_RANKING_HISTORY_LIMIT = 200;
 export const DISCOVERY_LOCAL_SEARCH_CANDIDATE_LIMIT = 200;
@@ -1109,14 +1110,17 @@ export function shouldSkipRemoteSearchByKeyword(keyword: string) {
 
 export function isWebUrlLikeSearchKeyword(keyword: string) {
   const normalizedKeyword = keyword.trim();
-  const normalizedUrl = uriUtils.safeParseURL(
-    uriUtils.ensureHttpsPrefix(normalizedKeyword),
-  );
+  if (!normalizedKeyword) {
+    return false;
+  }
 
-  return Boolean(
-    normalizedUrl &&
-    normalizedUrl.hostname &&
-    ['http:', 'https:'].includes(normalizedUrl.protocol),
+  if (/^https?:\/\//iu.test(normalizedKeyword)) {
+    return WEB_URL_WITH_PROTOCOL_REGEXP.test(normalizedKeyword);
+  }
+
+  return (
+    uriUtils.isUrlWithoutProtocol(normalizedKeyword) ||
+    uriUtils.isLocalhostUrl(normalizedKeyword)
   );
 }
 

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
@@ -1484,6 +1484,14 @@ const BaseDevSettingsSection = () => {
                       >
                         <Switch size={ESwitchSize.small} />
                       </SectionFieldItem>
+                      <SectionFieldItem
+                        icon="BrowserOutline"
+                        name="allowLocalhostUrlInDAppBrowser"
+                        title="Allow local URLs in DApp Browser"
+                        subtitle="Allow http://localhost and http://127.0.0.1"
+                      >
+                        <Switch size={ESwitchSize.small} />
+                      </SectionFieldItem>
                     </Accordion.Content>
                   </Accordion.HeightAnimator>
                 </Accordion.Item>,

--- a/packages/shared/src/utils/uriUtils.test.ts
+++ b/packages/shared/src/utils/uriUtils.test.ts
@@ -1,8 +1,11 @@
 import platformEnv from '../platformEnv';
 
 import uriUtils, {
+  buildGoogleSearchUrl,
   containsPunycode,
+  ensureHttpPrefix,
   ensureHttpsPrefix,
+  isLocalhostUrl,
   isUrlWithoutProtocol,
   parseUrl,
   validateUrl,
@@ -112,6 +115,83 @@ describe('validateUrl', () => {
       );
     });
   });
+
+  test('allows HTTP localhost only when explicitly enabled', () => {
+    const testCases = [
+      {
+        input: 'http://localhost:3000/path?query=value',
+        expected: 'http://localhost:3000/path?query=value',
+      },
+      { input: 'http://127.0.0.1:5173/', expected: 'http://127.0.0.1:5173/' },
+      { input: 'localhost', expected: 'http://localhost' },
+      { input: 'localhost:3000', expected: 'http://localhost:3000' },
+      { input: '127.0.0.1:5173', expected: 'http://127.0.0.1:5173' },
+      { input: '[::1]:5173', expected: 'http://[::1]:5173' },
+    ];
+    testCases.forEach(({ input, expected }) => {
+      expect(validateUrl(input)).not.toBe(expected);
+      expect(validateUrl(input, { allowLocalhostUrl: true })).toBe(expected);
+    });
+  });
+});
+
+describe('parseDappRedirect', () => {
+  test('allows localhost redirects only when explicitly enabled', () => {
+    const localUrls = [
+      'http://localhost:3000',
+      'http://127.0.0.1:5173',
+      'http://[::1]:5173',
+    ];
+    localUrls.forEach((url) => {
+      expect(uriUtils.parseDappRedirect(url, []).action).toBe(
+        uriUtils.EDAppOpenActionEnum.DENY,
+      );
+      expect(
+        uriUtils.parseDappRedirect(url, [], {
+          allowLocalhostUrl: true,
+        }).action,
+      ).toBe(uriUtils.EDAppOpenActionEnum.ALLOW);
+    });
+  });
+
+  test('does not bypass protocol checks for localhost redirects', () => {
+    ['ftp://localhost', 'file://127.0.0.1'].forEach((url) => {
+      expect(
+        uriUtils.parseDappRedirect(url, [], {
+          allowLocalhostUrl: true,
+        }).action,
+      ).toBe(uriUtils.EDAppOpenActionEnum.DENY);
+    });
+  });
+});
+
+describe('isLocalhostUrl', () => {
+  test('matches localhost and 127.0.0.1 inputs with or without protocol', () => {
+    [
+      'localhost',
+      'localhost:3000',
+      'http://localhost:3000/path',
+      '127.0.0.1',
+      '127.0.0.1:5173',
+      'http://127.0.0.1:5173/',
+      '[::1]:5173',
+      'http://[::1]:5173/',
+    ].forEach((url) => {
+      expect(isLocalhostUrl(url)).toBe(true);
+    });
+  });
+
+  test('rejects non-localhost hostnames', () => {
+    [
+      'localhost.com',
+      'example.com',
+      'http://example.com/localhost',
+      'search query',
+      'http://',
+    ].forEach((url) => {
+      expect(isLocalhostUrl(url)).toBe(false);
+    });
+  });
 });
 
 describe('isUrlWithoutProtocol', () => {
@@ -197,6 +277,33 @@ describe('ensureHttpsPrefix', () => {
 
   test('returns empty string for empty input', () => {
     expect(ensureHttpsPrefix('')).toBe('');
+  });
+});
+
+describe('ensureHttpPrefix', () => {
+  test('returns URL unchanged if it already has a protocol', () => {
+    expect(ensureHttpPrefix('http://localhost:3000')).toBe(
+      'http://localhost:3000',
+    );
+    expect(ensureHttpPrefix('https://example.com')).toBe('https://example.com');
+    expect(ensureHttpPrefix('onekey-wallet:account/list')).toBe(
+      'onekey-wallet:account/list',
+    );
+    expect(ensureHttpPrefix('mailto:test@example.com')).toBe(
+      'mailto:test@example.com',
+    );
+  });
+
+  test('adds http:// prefix to URL-like text without protocol', () => {
+    expect(ensureHttpPrefix('localhost:3000')).toBe('http://localhost:3000');
+  });
+});
+
+describe('buildGoogleSearchUrl', () => {
+  test('builds an explicit Google search URL for localhost keywords', () => {
+    expect(buildGoogleSearchUrl('http://localhost:3000')).toBe(
+      'https://www.google.com/search?q=http%3A%2F%2Flocalhost%3A3000',
+    );
   });
 });
 

--- a/packages/shared/src/utils/uriUtils.ts
+++ b/packages/shared/src/utils/uriUtils.ts
@@ -1,7 +1,7 @@
 import { toASCII, toUnicode } from 'punycode/';
 import validator from 'validator';
 
-import type { IUrlValue } from '@onekeyhq/kit-bg/src/services/ServiceScanQRCode/utils/parseQRCode/type';
+import type { IUrlValue } from '@onekeyhq/shared/types/uri';
 
 import { ONEKEY_APP_DEEP_LINK_NAME } from '../consts/deeplinkConsts';
 import {
@@ -23,6 +23,56 @@ const DOMAIN_REGEXP =
 const URL_WITHOUT_PROTOCOL_REGEXP =
   /^(?:www\.)?[a-zA-Z0-9-]+(?:\.[a-zA-Z]{2,})+(?:\/[^\s]*)?$/;
 
+const LOCALHOST_URL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
+const URL_SCHEME_REGEXP = /^[a-zA-Z][a-zA-Z0-9+.-]*:/u;
+const URL_PROTOCOL_PREFIX_REGEXP = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//u;
+
+type ILocalhostUrlOptions = {
+  allowLocalhostUrl?: boolean;
+};
+
+function isLocalhostParsedUrl(parsedUrl: URL | null) {
+  const hostname = parsedUrl?.hostname.replace(/^\[|\]$/gu, '').toLowerCase();
+  return Boolean(hostname && LOCALHOST_URL_HOSTNAMES.has(hostname));
+}
+
+function getHostnameFromUrlLikeText(text: string): string {
+  const protocolMatch = text.match(URL_PROTOCOL_PREFIX_REGEXP);
+  const hostAndPath = protocolMatch
+    ? text.slice(protocolMatch[0].length)
+    : text;
+  const hostWithPortAndAuth = hostAndPath.split(/[/?#]/u)[0] ?? '';
+  const hostWithPort = hostWithPortAndAuth.split('@').pop() ?? '';
+
+  if (hostWithPort.startsWith('[')) {
+    const closingBracketIndex = hostWithPort.indexOf(']');
+    return closingBracketIndex > 0
+      ? hostWithPort.slice(1, closingBracketIndex).toLowerCase()
+      : '';
+  }
+
+  return hostWithPort.split(':')[0].toLowerCase();
+}
+
+export function isLocalhostUrl(url: string): boolean {
+  const text = url.trim();
+  if (!text) return false;
+
+  return LOCALHOST_URL_HOSTNAMES.has(getHostnameFromUrlLikeText(text));
+}
+
+function normalizeHttpLocalhostUrl(url: string): string | null {
+  const text = url.trim();
+  if (!isLocalhostUrl(text)) return null;
+
+  const normalizedUrl = ensureHttpPrefix(text);
+  const parsedUrl = safeParseURL(normalizedUrl);
+  if (parsedUrl?.protocol === 'http:' && isLocalhostParsedUrl(parsedUrl)) {
+    return normalizedUrl;
+  }
+  return null;
+}
+
 export function isUrlWithoutProtocol(text: string): boolean {
   return URL_WITHOUT_PROTOCOL_REGEXP.test(text);
 }
@@ -38,6 +88,21 @@ export function ensureHttpsPrefix(url: string): string {
     return `https://${url}`;
   }
   return url;
+}
+
+export function ensureHttpPrefix(url: string): string {
+  if (!url) return url;
+  if (isLocalhostUrl(url) && !URL_PROTOCOL_PREFIX_REGEXP.test(url)) {
+    return `http://${url}`;
+  }
+  if (URL_SCHEME_REGEXP.test(url)) {
+    return url;
+  }
+  return `http://${url}`;
+}
+
+export function buildGoogleSearchUrl(keyword: string): string {
+  return `https://www.google.com/search?q=${encodeURIComponent(keyword)}`;
 }
 
 function getHostNameFromUrl({ url }: { url: string }): string {
@@ -102,7 +167,7 @@ enum EDAppOpenActionEnum {
 function parseDappRedirect(
   url: string,
   allowedUrls: string[],
-  options?: { isTopFrame?: boolean },
+  options?: ILocalhostUrlOptions & { isTopFrame?: boolean },
 ): { action: EDAppOpenActionEnum } {
   // allow iframe ad
   const isTopFrame = options?.isTopFrame ?? true;
@@ -119,13 +184,12 @@ function parseDappRedirect(
   }
 
   const parsedUrl = safeParseURL(url);
-  if (process.env.NODE_ENV !== 'production') {
-    if (
-      parsedUrl?.hostname &&
-      ['localhost', '127.0.0.1'].includes(parsedUrl?.hostname)
-    ) {
-      return { action: EDAppOpenActionEnum.ALLOW };
-    }
+  if (
+    options?.allowLocalhostUrl &&
+    parsedUrl?.protocol === 'http:' &&
+    isLocalhostParsedUrl(parsedUrl)
+  ) {
+    return { action: EDAppOpenActionEnum.ALLOW };
   }
   if (
     !parsedUrl ||
@@ -237,19 +301,14 @@ export function isValidDeepLink(url: string) {
   );
 }
 
-export const validateUrl = (url: string): string => {
-  // In development mode, allow HTTP localhost URLs
-  if (process.env.NODE_ENV !== 'production') {
-    try {
-      const parsedUrl = new URL(url);
-      if (
-        parsedUrl.protocol === 'http:' &&
-        ['localhost', '127.0.0.1'].includes(parsedUrl.hostname)
-      ) {
-        return url;
-      }
-    } catch {
-      // Continue with normal validation
+export const validateUrl = (
+  url: string,
+  options?: ILocalhostUrlOptions,
+): string => {
+  if (options?.allowLocalhostUrl) {
+    const localhostUrl = normalizeHttpLocalhostUrl(url);
+    if (localhostUrl) {
+      return localhostUrl;
     }
   }
 
@@ -285,7 +344,7 @@ export const validateUrl = (url: string): string => {
   }
 
   // If still not valid, return Google search URL
-  return `https://www.google.com/search?q=${encodeURIComponent(url)}`;
+  return buildGoogleSearchUrl(url);
 };
 
 export const containsPunycode = (url: string) => {
@@ -399,8 +458,11 @@ export default {
   buildDeepLinkUrl,
   safeGetWalletConnectOrigin,
   parseUrl,
+  isLocalhostUrl,
   safeParseURL,
   appendUtmSourceToUrl,
   isUrlWithoutProtocol,
   ensureHttpsPrefix,
+  ensureHttpPrefix,
+  buildGoogleSearchUrl,
 };

--- a/packages/shared/types/uri.ts
+++ b/packages/shared/types/uri.ts
@@ -1,0 +1,9 @@
+export interface IUrlValue {
+  url: string;
+  hostname: string;
+  origin: string;
+  pathname: string;
+  urlSchema: string;
+  urlPathList: string[];
+  urlParamList: { [key: string]: string };
+}


### PR DESCRIPTION
## Summary
- Replace `process.env.NODE_ENV` localhost gating with a runtime `allowLocalhostUrlInDAppBrowser` dev setting and a Discovery search hint that links to it.
- Rebuild DApp search title highlighting in plain JSX (`DappSearchResultTitle`) instead of injecting `<a>` markup into `RichSizeableText`.
- Promote `IUrlValue` to `@onekeyhq/shared/types/uri` so `shared/uriUtils` no longer reaches into `kit-bg`, fixing the import-hierarchy violation.
<img width="981" height="809" alt="image" src="https://github.com/user-attachments/assets/37daaced-c369-4857-aeeb-0f19c259300d" />


## Intent & Context
This branch follows up on a Codex review that flagged three concrete issues in the Discovery / shared URL stack: (1) localhost URLs were silently allowed only in dev builds via `process.env.NODE_ENV`, which is brittle for QA on production-like builds; (2) search result titles built HTML with a regex and rendered through `RichSizeableText`, an injection risk if titles or keywords ever contained markup; (3) `shared/uriUtils.ts` imported `IUrlValue` from `kit-bg`, violating the strict import hierarchy declared in `CLAUDE.md`.

## Root Cause
- Localhost gate keyed off `process.env.NODE_ENV` instead of a user-controllable setting, and `validateUrl` / `parseDappRedirect` duplicated the localhost detection inline.
- `RichSizeableText` rendering interpreted regex-built `<a>` tags as HTML, which is fragile for arbitrary `item.title` / `item.keyword` content.
- `IUrlValue` lived in `kit-bg/src/services/ServiceScanQRCode/...`, but `shared/uriUtils.ts` already depended on the type, creating a `shared → kit-bg` cycle.

## Design Decisions
- Introduced `isLocalhostUrl`, `ensureHttpPrefix`, `normalizeHttpLocalhostUrl`, and a shared `ILocalhostUrlOptions` so callers explicitly opt in via `allowLocalhostUrl`. The Discovery action layer reads `devSettingsPersistAtom` once per call to keep the toggle authoritative across web tab open / dapp redirect / popup paths.
- Added a `SearchResultContent` hint row that deep-links into the Dev settings tab so users do not have to know where the toggle lives.
- Replaced `RichSizeableText` markup with a plain `SizableText` parts list; kept the regex-escape helper but now operates on already-normalized text after stripping any existing `<a>` tags so legacy data still renders cleanly.
- Moved `IUrlValue` into `@onekeyhq/shared/types/uri` and re-exported it from the original `parseQRCode/type.ts` to avoid breaking external imports.
- `search-action` items now carry an actual Google search URL (`buildGoogleSearchUrl`) so `handleWebSite` opens a real tab instead of an empty string.

## Changes Detail
- `packages/shared/src/utils/uriUtils.ts` — added localhost helpers, `ensureHttpPrefix`, `buildGoogleSearchUrl`; `validateUrl` / `parseDappRedirect` accept `allowLocalhostUrl`.
- `packages/shared/types/uri.ts` (new) — canonical `IUrlValue` location.
- `packages/kit-bg/src/services/ServiceScanQRCode/utils/parseQRCode/type.ts` — re-export `IUrlValue` from shared.
- `packages/kit-bg/src/states/jotai/atoms/devSettings.ts` — new `allowLocalhostUrlInDAppBrowser` flag.
- `packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx` — UI switch for the new flag.
- `packages/kit/src/states/jotai/contexts/discovery/actions.ts` — read dev flag and pass `allowLocalhostUrl` into URL pipeline.
- `packages/kit/src/views/Discovery/components/SearchResultContent.tsx` — `DappSearchResultTitle`, localhost hint row, real search URL.
- `packages/kit/src/views/Discovery/utils/searchResultRanking.ts` + `searchDebugSnapshot.ts` — recognise localhost / protocol-prefixed URLs as URL-like keywords; emit real search URLs.
- `packages/kit-bg/src/services/ServiceUniversalSearch.ts` — search-action item now carries a Google URL.
- Tests updated: `uriUtils.test.ts`, `searchResultRanking.test.ts`, `actions.test.tsx`.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop / Mobile / Web / Extension (Discovery browser is shared)
- **Risk Areas**: DApp redirect / web tab open path (anything routed through `validateUrl` / `parseDappRedirect`); search result rendering (highlight logic, keyword regex); the new dev setting must default to `false` in production so prior gating is preserved when the toggle is off.

## Test plan
- [ ] With dev setting OFF, opening `http://localhost:3000` from the DApp browser is blocked and the search hint row is shown linking to Dev settings.
- [ ] With dev setting ON, `localhost`, `127.0.0.1`, and `[::1]` HTTP URLs open normally; HTTPS / non-localhost behavior is unchanged.
- [ ] Searching a keyword in Discovery highlights it inside the dapp title without rendering any leftover `<a>` markup; titles that already contain `<a>` from server data render as plain text.
- [ ] The "Search Google for ..." action opens an actual Google results tab (URL contains `google.com/search?q=`).
- [ ] `yarn lint:staged` and `yarn tsc:staged` pass.
- [ ] Existing tests under `searchResultRanking.test.ts`, `actions.test.tsx`, and `uriUtils.test.ts` pass locally.