### PR TITLE
fix: handle backend placeholder values in market token activity (OK-54177)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenActivityOverview/utils/formatTokenActivityData.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenActivityOverview/utils/formatTokenActivityData.test.ts
@@ -1,0 +1,62 @@
+import type { IMarketTokenDetail } from '@onekeyhq/shared/types/marketV2';
+
+import { formatTokenActivityData } from './formatTokenActivityData';
+
+function buildTokenDetail(
+  overrides: Partial<IMarketTokenDetail> = {},
+): IMarketTokenDetail {
+  return {
+    address: 'EQAvlWFDxGF2lXm67y4yzC17wYKD9A0guwPkMs1gOsM__NOT',
+    decimals: 9,
+    logoUrl: '',
+    name: 'Notcoin',
+    symbol: 'NOT',
+    ...overrides,
+  };
+}
+
+describe('formatTokenActivityData', () => {
+  it('treats backend placeholder values as missing data', () => {
+    const volume1h = '1662.14437643546';
+
+    expect(
+      formatTokenActivityData(
+        buildTokenDetail({
+          buy1hCount: '24',
+          sell1hCount: '17',
+          vBuy1h: '-',
+          vSell1h: '-',
+          volume1h,
+        }),
+        '1h',
+      ),
+    ).toEqual({
+      buys: 24,
+      sells: 17,
+      buyVolume: undefined,
+      sellVolume: undefined,
+      totalVolume: Number(volume1h),
+    });
+  });
+
+  it('falls back to buy and sell volume sum when total volume is unavailable', () => {
+    expect(
+      formatTokenActivityData(
+        buildTokenDetail({
+          buy24hCount: '-',
+          sell24hCount: '856',
+          vBuy24h: '120',
+          vSell24h: '80',
+          volume24h: '-',
+        }),
+        '24h',
+      ),
+    ).toEqual({
+      buys: undefined,
+      sells: 856,
+      buyVolume: 120,
+      sellVolume: 80,
+      totalVolume: 200,
+    });
+  });
+});

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenActivityOverview/utils/formatTokenActivityData.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenActivityOverview/utils/formatTokenActivityData.ts
@@ -7,7 +7,14 @@ function toNumberOrUndefined(
   if (value === undefined || value === null) {
     return undefined;
   }
-  return Number(value);
+
+  const normalizedValue = typeof value === 'string' ? value.trim() : value;
+  if (normalizedValue === '') {
+    return undefined;
+  }
+
+  const numericValue = Number(normalizedValue);
+  return Number.isFinite(numericValue) ? numericValue : undefined;
 }
 
 export function formatTokenActivityData(


### PR DESCRIPTION
## Summary
- Treat backend placeholder values like `"-"`, empty strings, and whitespace as missing data inside `toNumberOrUndefined`
- Guard against `NaN` propagation by using `Number.isFinite` before returning numeric values
- Add unit tests for placeholder handling and the buy/sell volume fallback sum

## Intent & Context
Reported in OK-54177: on the Ton-network NOT token (`EQAvlWFDxGF2lXm67y4yzC17wYKD9A0guwPkMs1gOsM__NOT`), the Market Detail v2 "Activity Overview" buy/sell volume bar failed to render because backend fields such as `vBuy1h` / `vSell1h` are returned as the string `"-"`. The previous client code passed `"-"` straight into `Number(...)`, producing `NaN` instead of `undefined`, which leaked into UI calculations and prevented the default empty-state bar from being drawn. PM / QA confirmed the client should treat these placeholders as "data missing" so the UI can fall back to the default visualization (see Jira comments dated 2026-05-11).

## Root Cause
`toNumberOrUndefined()` only short-circuited on `null` / `undefined`. For string inputs (including `"-"` and whitespace), `Number(value)` was returned directly. `Number("-")` is `NaN`, which then flowed downstream into `totalVolume = buyVolume + sellVolume` and disabled the proportional bar.

## Design Decisions
- Normalize string inputs with `trim()` before evaluating, so backend values with stray whitespace also collapse to "missing".
- Return `undefined` for both empty strings and non-finite numeric conversions, keeping the helper's contract — "field is missing" → `undefined` — consistent with the existing `null` / `undefined` branch. This lets the renderer keep its existing `??` fallback for `totalVolume` and the default empty-state bar; no UI / renderer changes are required.
- Added a dedicated unit test instead of changing the renderer, because the renderer already handles `undefined` correctly and the regression was purely in this helper.

## Changes Detail
- `packages/kit/src/views/Market/MarketDetailV2/components/TokenActivityOverview/utils/formatTokenActivityData.ts`: harden `toNumberOrUndefined` with trim + empty-string + `Number.isFinite` guards.
- `packages/kit/src/views/Market/MarketDetailV2/components/TokenActivityOverview/utils/formatTokenActivityData.test.ts`: new test file covering (1) `"-"` placeholders mapping to `undefined` while real numeric counts / volumes pass through, and (2) the buy / sell volume sum fallback when the time-range `volume` field itself is `"-"`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: All (helper is platform-agnostic; consumed by Market Detail v2 UI shared across desktop / mobile / web / extension)
- **Risk Areas**: Behavior change is strictly more conservative — values that previously became `NaN` now become `undefined`, which the renderer already handles. No change for legitimate numeric inputs.

## Test plan
- [ ] Open Market Detail v2 for the Ton NOT token (`EQAvlWFDxGF2lXm67y4yzC17wYKD9A0guwPkMs1gOsM__NOT`) and verify the buy / sell activity bar renders the empty-state visualization instead of breaking when 1h / 4h / 8h fields return `"-"`.
- [ ] Confirm tokens with normal numeric activity still show real buy / sell ratios across 1h / 4h / 8h / 24h ranges.
- [ ] `yarn jest packages/kit/src/views/Market/MarketDetailV2/components/TokenActivityOverview/utils/formatTokenActivityData.test.ts` passes.