### PR TITLE
fix: show full pair name in market liquidity pool tooltip(OK-54462)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/TokenLiquidityPools.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/TokenLiquidityPools.tsx
@@ -54,6 +54,7 @@ type IDisplayPoolToken = {
 type IDisplayPool = {
   key: string;
   pairName: string;
+  fullPairName: string;
   dexName: string;
   dexLogoUrl?: string;
   liquidity: string;
@@ -457,10 +458,10 @@ function formatFeeRate(item: IMarketTokenTopLiquidityItem) {
   return FALLBACK_VALUE;
 }
 
-function getPairName(item: IMarketTokenTopLiquidityItem) {
+function getFullPairName(item: IMarketTokenTopLiquidityItem) {
   const pairName = getText(item, PAIR_NAME_CANDIDATES);
   if (pairName) {
-    return formatDisplayPairName(pairName);
+    return pairName;
   }
 
   const baseSymbol = getText(item, BASE_SYMBOL_CANDIDATES);
@@ -561,9 +562,14 @@ function toDisplayPool(
   const poolAddress = getValidAddress(item, POOL_ADDRESS_CANDIDATES);
   const creatorAddress = getValidAddress(item, CREATOR_ADDRESS_CANDIDATES);
   const networkId = item.networkId || fallbackNetworkId;
+  const fullPairName = getFullPairName(item);
   return {
     key: poolAddress ?? `${networkId}:${index}`,
-    pairName: getPairName(item),
+    pairName:
+      fullPairName === FALLBACK_VALUE
+        ? FALLBACK_VALUE
+        : formatDisplayPairName(fullPairName),
+    fullPairName,
     dexName: getText(item, DEX_NAME_CANDIDATES) ?? FALLBACK_VALUE,
     dexLogoUrl: getText(item, DEX_LOGO_CANDIDATES),
     liquidity: formatLiquidity(item),
@@ -652,7 +658,7 @@ function PoolIdentity({
         maxWidth="100%"
         overflow={truncateName ? 'hidden' : 'visible'}
       >
-        {gtMd && truncateName && item.pairName !== FALLBACK_VALUE ? (
+        {gtMd && truncateName && item.fullPairName !== FALLBACK_VALUE ? (
           <Tooltip
             placement="top"
             renderContent={
@@ -663,7 +669,7 @@ function PoolIdentity({
                 maxWidth="$72"
                 style={POOL_NAME_TOOLTIP_TEXT_STYLE}
               >
-                {item.pairName}
+                {item.fullPairName}
               </SizableText>
             }
             renderTrigger={pairNameText}


### PR DESCRIPTION
## Summary
- Tooltip on truncated liquidity pool pair names now shows the full pair name instead of the truncated/formatted display name
- Introduces a separate `fullPairName` field on the display pool so the visible row stays formatted while the tooltip surfaces complete content

## Intent & Context
[OK-54462] Bug: On the Market token detail page (例如 ZEC), the liquidity pool list truncates long pair names. Hovering over the truncated name showed the *same* truncated text in the tooltip — so users could never see the complete pool name. The tooltip is supposed to reveal what was elided, similar to OKX.

## Root Cause
`getPairName()` returned the *formatted* (truncated) pair name via `formatDisplayPairName()`. Both the inline cell and the hover tooltip read from the same `item.pairName`, so the tooltip just repeated the truncated text instead of revealing the full name.

## Design Decisions
- Renamed `getPairName()` → `getFullPairName()` so the helper now returns the raw, untruncated pair name, keeping the formatting concern at the call site.
- Added a new `fullPairName` field to `IDisplayPool`, while keeping `pairName` as the formatted/visible value. The display row keeps using `pairName` (compact), and the tooltip uses `fullPairName` (complete). This avoids any visible regression in the inline cell.
- Preserved `FALLBACK_VALUE` semantics: when no pair name is available, both fields fall back together and the tooltip is suppressed (existing `!== FALLBACK_VALUE` guard now keys off `fullPairName`).

## Changes Detail
- `packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/TokenLiquidityPools.tsx`
  - `IDisplayPool` gains `fullPairName: string`.
  - `getFullPairName()` returns the raw pair name (no truncation/formatting).
  - `toDisplayPool()` computes `fullPairName` once and derives the formatted `pairName` from it.
  - `PoolIdentity` tooltip trigger and content read from `fullPairName`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Web (tooltip is gated on `gtMd`, mobile unaffected)
- **Risk Areas**: Limited to the Market token detail liquidity pool list rendering. Behavior change is scoped to the tooltip content; the visible cell text and fallback handling are unchanged.

## Test plan
- [ ] Open Market detail for a token whose pool pair name is long (e.g. ZEC) on Desktop/Web at `gtMd` width
- [ ] Verify the inline cell still displays the truncated/formatted pair name
- [ ] Hover the truncated pair name and verify the tooltip shows the **full** untruncated pair name
- [ ] Verify pools without a pair name still render the fallback and do not show a tooltip
- [ ] Sanity-check other token detail pages to ensure no regression in the pool list layout

[OK-54462]: https://onekeyhq.atlassian.net/browse/OK-54462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ