### PR TITLE
fix: refine market preset labels (OK-54485)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewDialog.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewDialog.tsx
@@ -15,7 +15,7 @@ type IMarketSwapReviewDialogProps = {
   reviewState: ISwapReviewState;
   defaultNetworkFeeLevel?: ESwapNetworkFeeLevel;
   defaultCustomPriorityFee?: ICustomPriorityFeeOverride;
-  customNetworkFeeOptionLabel?: string;
+  showCustomNetworkFeeOption?: boolean;
 };
 
 export function MarketSwapReviewDialog({
@@ -24,7 +24,7 @@ export function MarketSwapReviewDialog({
   reviewState,
   defaultNetworkFeeLevel,
   defaultCustomPriorityFee,
-  customNetworkFeeOptionLabel,
+  showCustomNetworkFeeOption,
 }: IMarketSwapReviewDialogProps) {
   return (
     <SwapReviewDialog
@@ -33,7 +33,7 @@ export function MarketSwapReviewDialog({
       reviewState={reviewState}
       defaultNetworkFeeLevel={defaultNetworkFeeLevel}
       defaultCustomPriorityFee={defaultCustomPriorityFee}
-      customNetworkFeeOptionLabel={customNetworkFeeOptionLabel}
+      showCustomNetworkFeeOption={showCustomNetworkFeeOption}
       storeName={EJotaiContextStoreNames.marketSwapReview}
       disableGlobalApproveSync
       approveTransactionSource={ESwapReviewApproveTransactionSource.SpeedSwap}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
@@ -28,7 +28,7 @@ import { useTokenDetail } from '../../hooks/useTokenDetail';
 
 import {
   EMarketPresetTradeSide,
-  getMarketPresetReviewNetworkFeeOptionLabel,
+  shouldShowMarketPresetReviewNetworkFeeOption,
 } from './hooks/marketPresetSettings';
 import { useMarketPresetSettings } from './hooks/useMarketPresetSettings';
 import { useSpeedSwapActions } from './hooks/useSpeedSwapActions';
@@ -493,8 +493,8 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
       const requestId = reviewDialogRequestIdRef.current + 1;
       reviewDialogRequestIdRef.current = requestId;
       setIsReviewOpening(true);
-      const reviewNetworkFeeOptionLabel =
-        getMarketPresetReviewNetworkFeeOptionLabel(marketPresetSettings);
+      const showCustomNetworkFeeOption =
+        shouldShowMarketPresetReviewNetworkFeeOption(marketPresetSettings);
 
       try {
         const nextReviewState = await prepareMarketSwapReview({
@@ -531,7 +531,7 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
               adapter={reviewAdapter}
               defaultNetworkFeeLevel={effectiveNetworkFeeLevel}
               defaultCustomPriorityFee={effectiveCustomPriorityFee}
-              customNetworkFeeOptionLabel={reviewNetworkFeeOptionLabel}
+              showCustomNetworkFeeOption={showCustomNetworkFeeOption}
               reviewState={nextReviewState}
               onDone={() => void dialog?.close()}
             />

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/MarketPresetSelector/MarketPresetSelector.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/MarketPresetSelector/MarketPresetSelector.tsx
@@ -114,16 +114,6 @@ function getMarketPresetLabel({
   return label ?? presetKey.toUpperCase();
 }
 
-function getMarketPresetCustomizedLabel({
-  customized,
-  label,
-}: {
-  customized?: boolean;
-  label: string;
-}) {
-  return customized ? `${label}*` : label;
-}
-
 function getPriorityFeeLabel({
   intl,
   settings,
@@ -485,18 +475,15 @@ function MarketPresetSettingsDialog({
   const presetOptions = useMemo(
     () =>
       presetSettings.presets.map((preset) => ({
-        label: getMarketPresetCustomizedLabel({
-          customized: presetSettings.presetCustomizedMap[preset.key],
-          label: getMarketPresetLabel({
-            intl,
-            label: preset.label,
-            presetKey: preset.key,
-          }),
+        label: getMarketPresetLabel({
+          intl,
+          label: preset.label,
+          presetKey: preset.key,
         }),
         testID: `market-preset-dialog-tab-${preset.key}`,
         value: preset.key,
       })),
-    [intl, presetSettings.presetCustomizedMap, presetSettings.presets],
+    [intl, presetSettings.presets],
   );
 
   const sideOptions = useMemo(
@@ -1145,7 +1132,6 @@ export function MarketPresetSelector({
   const {
     enabled,
     presets,
-    presetCustomizedMap,
     selectedPreset,
     selectedDirectionSettings,
     selectedPresetKey,
@@ -1157,18 +1143,15 @@ export function MarketPresetSelector({
   const presetOptions = useMemo(
     () =>
       presets.map((preset) => ({
-        label: getMarketPresetCustomizedLabel({
-          customized: presetCustomizedMap[preset.key],
-          label: getMarketPresetLabel({
-            intl,
-            label: preset.label,
-            presetKey: preset.key,
-          }),
+        label: getMarketPresetLabel({
+          intl,
+          label: preset.label,
+          presetKey: preset.key,
         }),
         value: preset.key,
         testID: `market-preset-${preset.key}`,
       })),
-    [intl, presetCustomizedMap, presets],
+    [intl, presets],
   );
 
   const openPresetDialog = useCallback(() => {
@@ -1226,13 +1209,10 @@ export function MarketPresetSelector({
     selectedPreset ??
     presets.find((preset) => preset.key === selectedPresetKey);
   const selectedPresetLabel = selectedPresetItem
-    ? getMarketPresetCustomizedLabel({
-        customized: presetCustomizedMap[selectedPresetItem.key],
-        label: getMarketPresetLabel({
-          intl,
-          label: selectedPresetItem.label,
-          presetKey: selectedPresetItem.key,
-        }),
+    ? getMarketPresetLabel({
+        intl,
+        label: selectedPresetItem.label,
+        presetKey: selectedPresetItem.key,
       })
     : intl.formatMessage({ id: ETranslations.global_auto });
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.test.ts
@@ -19,6 +19,7 @@ import {
   getMarketPresetSlippageValue,
   isMarketPresetConfirmDisabled,
   resolveMarketPresetDirectionSettings,
+  shouldShowMarketPresetReviewNetworkFeeOption,
 } from './marketPresetSettings';
 
 describe('marketPresetSettings', () => {
@@ -276,5 +277,26 @@ describe('marketPresetSettings', () => {
         hasInvalidDirtySettings: true,
       }),
     ).toBe(true);
+  });
+
+  it('uses a custom review fee option for selected manual presets only', () => {
+    expect(
+      shouldShowMarketPresetReviewNetworkFeeOption({
+        enabled: true,
+        selectedPresetKey: EMarketPresetKey.P1,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowMarketPresetReviewNetworkFeeOption({
+        enabled: true,
+        selectedPresetKey: EMarketPresetKey.AUTO,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowMarketPresetReviewNetworkFeeOption({
+        enabled: false,
+        selectedPresetKey: EMarketPresetKey.P2,
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.ts
@@ -441,29 +441,14 @@ export function getMarketPresetCustomizedMap(
   );
 }
 
-export function getMarketPresetReviewNetworkFeeOptionLabel({
+export function shouldShowMarketPresetReviewNetworkFeeOption({
   enabled,
-  presetCustomizedMap,
-  presets,
-  selectedPreset,
   selectedPresetKey,
 }: {
   enabled: boolean;
-  presetCustomizedMap: Partial<Record<EMarketPresetKey, boolean>>;
-  presets: IMarketPresetItem[];
-  selectedPreset?: IMarketPresetItem;
   selectedPresetKey: EMarketPresetKey;
 }) {
-  if (!enabled || selectedPresetKey === EMarketPresetKey.AUTO) {
-    return undefined;
-  }
-
-  const selectedPresetItem =
-    selectedPreset ??
-    presets.find((preset) => preset.key === selectedPresetKey);
-  const label = selectedPresetItem?.label ?? selectedPresetKey.toUpperCase();
-
-  return `${label}${presetCustomizedMap[selectedPresetKey] ? '*' : ''}`;
+  return enabled && selectedPresetKey !== EMarketPresetKey.AUTO;
 }
 
 export function getMarketPresetSlippageValue({

--- a/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
+++ b/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
@@ -77,7 +77,7 @@ interface IPreSwapDialogContentProps {
   }) => void | Promise<void>;
   defaultNetworkFeeLevel?: ESwapNetworkFeeLevel;
   defaultCustomPriorityFee?: ICustomPriorityFeeOverride;
-  customNetworkFeeOptionLabel?: string;
+  showCustomNetworkFeeOption?: boolean;
 }
 
 const PreSwapDialogContent = ({
@@ -88,7 +88,7 @@ const PreSwapDialogContent = ({
   preSwapStepsStart,
   defaultNetworkFeeLevel,
   defaultCustomPriorityFee,
-  customNetworkFeeOptionLabel,
+  showCustomNetworkFeeOption,
 }: IPreSwapDialogContentProps) => {
   const intl = useIntl();
   const [swapSteps, setSwapSteps] = useSwapStepsAtom();
@@ -99,26 +99,20 @@ const PreSwapDialogContent = ({
   const effectiveNetworkFeeLevel =
     defaultNetworkFeeLevel ?? swapStepNetFeeLevel.networkFeeLevel;
   const customNetworkFeeOption = useMemo(() => {
-    const label =
-      customNetworkFeeOptionLabel ??
-      (effectiveCustomPriorityFee
-        ? intl.formatMessage({ id: ETranslations.transaction_custom })
-        : undefined);
-
-    if (!label) {
+    if (!showCustomNetworkFeeOption && !effectiveCustomPriorityFee) {
       return undefined;
     }
 
     return {
-      label,
+      label: intl.formatMessage({ id: ETranslations.transaction_custom }),
       networkFeeLevel: effectiveNetworkFeeLevel,
       customPriorityFee: effectiveCustomPriorityFee,
     };
   }, [
-    customNetworkFeeOptionLabel,
     effectiveCustomPriorityFee,
     effectiveNetworkFeeLevel,
     intl,
+    showCustomNetworkFeeOption,
   ]);
   const [networkFeeSelectValue, setNetworkFeeSelectValue] =
     useState<ISwapReviewNetworkFeeSelectValue>(

--- a/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
+++ b/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
@@ -94,31 +94,36 @@ const PreSwapDialogContent = ({
   const [swapSteps, setSwapSteps] = useSwapStepsAtom();
   const [swapStepNetFeeLevel, setSwapStepNetFeeLevel] =
     useSwapStepNetFeeLevelAtom();
-  const effectiveCustomPriorityFee =
-    defaultCustomPriorityFee ?? swapStepNetFeeLevel.customPriorityFee;
-  const effectiveNetworkFeeLevel =
-    defaultNetworkFeeLevel ?? swapStepNetFeeLevel.networkFeeLevel;
   const customNetworkFeeOption = useMemo(() => {
-    if (!showCustomNetworkFeeOption && !effectiveCustomPriorityFee) {
+    const optionNetworkFeeLevel = showCustomNetworkFeeOption
+      ? (defaultNetworkFeeLevel ?? swapStepNetFeeLevel.networkFeeLevel)
+      : swapStepNetFeeLevel.networkFeeLevel;
+    const optionCustomPriorityFee = showCustomNetworkFeeOption
+      ? defaultCustomPriorityFee
+      : swapStepNetFeeLevel.customPriorityFee;
+
+    if (!showCustomNetworkFeeOption && !optionCustomPriorityFee) {
       return undefined;
     }
 
     return {
       label: intl.formatMessage({ id: ETranslations.transaction_custom }),
-      networkFeeLevel: effectiveNetworkFeeLevel,
-      customPriorityFee: effectiveCustomPriorityFee,
+      networkFeeLevel: optionNetworkFeeLevel,
+      customPriorityFee: optionCustomPriorityFee,
     };
   }, [
-    effectiveCustomPriorityFee,
-    effectiveNetworkFeeLevel,
+    defaultCustomPriorityFee,
+    defaultNetworkFeeLevel,
     intl,
     showCustomNetworkFeeOption,
+    swapStepNetFeeLevel.customPriorityFee,
+    swapStepNetFeeLevel.networkFeeLevel,
   ]);
   const [networkFeeSelectValue, setNetworkFeeSelectValue] =
     useState<ISwapReviewNetworkFeeSelectValue>(
       customNetworkFeeOption
         ? SWAP_REVIEW_CUSTOM_NETWORK_FEE_VALUE
-        : effectiveNetworkFeeLevel,
+        : swapStepNetFeeLevel.networkFeeLevel,
     );
   const customNetworkFeeOptionRef = useRef(customNetworkFeeOption);
   const customNetworkFeeOptionKey = useMemo(() => {

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -100,7 +100,7 @@ import {
 
 import {
   EMarketPresetTradeSide,
-  getMarketPresetReviewNetworkFeeOptionLabel,
+  shouldShowMarketPresetReviewNetworkFeeOption,
 } from '../../../Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings';
 import { useMarketPresetSettings } from '../../../Market/MarketDetailV2/components/SwapPanel/hooks/useMarketPresetSettings';
 import { ESwapDirection } from '../../../Market/MarketDetailV2/components/SwapPanel/hooks/useTradeType';
@@ -289,7 +289,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     networkId: swapProMarketPresetTokenContext?.networkId,
     tradeSide: swapProMarketPresetTradeSide,
   });
-  const swapProReviewMarketPresetNetworkFeeOptionLabel = useMemo(() => {
+  const showSwapProReviewCustomNetworkFeeOption = useMemo(() => {
     if (
       !focusSwapPro ||
       swapProTradeType !== ESwapProTradeType.MARKET ||
@@ -298,16 +298,16 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
       return undefined;
     }
 
-    return getMarketPresetReviewNetworkFeeOptionLabel(
+    return shouldShowMarketPresetReviewNetworkFeeOption(
       swapProMarketPresetSettings,
     );
   }, [focusSwapPro, swapProMarketPresetSettings, swapProTradeType]);
   const swapProReviewDefaultNetworkFeeLevel =
-    swapProReviewMarketPresetNetworkFeeOptionLabel
+    showSwapProReviewCustomNetworkFeeOption
       ? swapProMarketPresetSettings.selectedNetworkFeeLevel
       : undefined;
   const swapProReviewDefaultCustomPriorityFee =
-    swapProReviewMarketPresetNetworkFeeOptionLabel
+    showSwapProReviewCustomNetworkFeeOption
       ? swapProMarketPresetSettings.selectedPriorityFeeOverride
       : undefined;
 
@@ -946,8 +946,8 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
                       defaultCustomPriorityFee={
                         swapProReviewDefaultCustomPriorityFee
                       }
-                      customNetworkFeeOptionLabel={
-                        swapProReviewMarketPresetNetworkFeeOptionLabel
+                      showCustomNetworkFeeOption={
+                        showSwapProReviewCustomNetworkFeeOption
                       }
                       onConfirm={handleConfirm}
                       onDone={onPreSwapClose}
@@ -988,8 +988,8 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
                       defaultCustomPriorityFee={
                         swapProReviewDefaultCustomPriorityFee
                       }
-                      customNetworkFeeOptionLabel={
-                        swapProReviewMarketPresetNetworkFeeOptionLabel
+                      showCustomNetworkFeeOption={
+                        showSwapProReviewCustomNetworkFeeOption
                       }
                       onDone={onPreSwapClose}
                       onConfirm={handleConfirm}
@@ -1018,7 +1018,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     preSwapStepsStart,
     swapProReviewDefaultCustomPriorityFee,
     swapProReviewDefaultNetworkFeeLevel,
-    swapProReviewMarketPresetNetworkFeeOptionLabel,
+    showSwapProReviewCustomNetworkFeeOption,
     handleConfirm,
     InTabDialog,
   ]);

--- a/packages/kit/src/views/Swap/pages/components/SwapReviewDialog.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapReviewDialog.tsx
@@ -25,7 +25,7 @@ type ISwapReviewDialogProps = {
   storeName: EJotaiContextStoreNames;
   defaultNetworkFeeLevel?: ESwapNetworkFeeLevel;
   defaultCustomPriorityFee?: ICustomPriorityFeeOverride;
-  customNetworkFeeOptionLabel?: string;
+  showCustomNetworkFeeOption?: boolean;
   disableGlobalApproveSync?: boolean;
   approveTransactionSource?: ESwapReviewApproveTransactionSource;
   accountSelectorConfig?: {
@@ -43,7 +43,7 @@ function SwapReviewDialogContent({
   disableGlobalApproveSync,
   defaultCustomPriorityFee,
   defaultNetworkFeeLevel,
-  customNetworkFeeOptionLabel,
+  showCustomNetworkFeeOption,
   onDone,
 }: {
   adapter: ISwapReviewAdapter;
@@ -51,7 +51,7 @@ function SwapReviewDialogContent({
   disableGlobalApproveSync?: boolean;
   defaultNetworkFeeLevel?: ESwapNetworkFeeLevel;
   defaultCustomPriorityFee?: ICustomPriorityFeeOverride;
-  customNetworkFeeOptionLabel?: string;
+  showCustomNetworkFeeOption?: boolean;
   onDone: () => void;
 }) {
   const { onConfirm, preSwapBeforeStepActions, preSwapStepsStart } =
@@ -69,7 +69,7 @@ function SwapReviewDialogContent({
       preSwapStepsStart={preSwapStepsStart}
       defaultNetworkFeeLevel={defaultNetworkFeeLevel}
       defaultCustomPriorityFee={defaultCustomPriorityFee}
-      customNetworkFeeOptionLabel={customNetworkFeeOptionLabel}
+      showCustomNetworkFeeOption={showCustomNetworkFeeOption}
     />
   );
 }
@@ -81,7 +81,7 @@ export function SwapReviewDialog({
   storeName,
   defaultNetworkFeeLevel,
   defaultCustomPriorityFee,
-  customNetworkFeeOptionLabel,
+  showCustomNetworkFeeOption,
   disableGlobalApproveSync,
   approveTransactionSource = ESwapReviewApproveTransactionSource.None,
   accountSelectorConfig = {
@@ -117,7 +117,7 @@ export function SwapReviewDialog({
             disableGlobalApproveSync={disableGlobalApproveSync}
             defaultNetworkFeeLevel={defaultNetworkFeeLevel}
             defaultCustomPriorityFee={defaultCustomPriorityFee}
-            customNetworkFeeOptionLabel={customNetworkFeeOptionLabel}
+            showCustomNetworkFeeOption={showCustomNetworkFeeOption}
             onDone={onDone}
           />
         </SwapReviewInitializer>


### PR DESCRIPTION
## Summary
- Remove the customized `*` suffix from Market preset labels after P1/P2/P3 settings are saved.
- Stop passing P1/P2/P3 as the swap review network-fee option label; selected manual presets now display the custom network-fee option through `transaction.custom` i18n.
- Fix review-dialog fee switching so choosing `Normal` / `Slow` / `Fast` clears the preset custom priority fee and re-estimates with the selected tier.

## Intent & Context
Fixes the two Market Preset QA issues:
- OK-54485: preset labels should not show a star after the preset has been configured.
- OK-54486: the transaction review dialog should not pass P1/P2/P3 as independent labels; it should use the custom i18n label.

Additional verified behavior: if a manual preset such as P2 has an extremely high custom priority fee, opening Review starts from that custom fee, but switching the Review dialog selector to `Normal` must stop using the P2 custom fee and re-estimate with Normal.

## Root Cause
Two preset concepts were coupled too tightly to UI and review state:
- `presetCustomizedMap` was used to append `*` to visible P1/P2/P3 labels.
- The review dialog treated the selected preset label as the custom network-fee option label.

A second issue appeared in the review fee selector: `PreSwapDialogContent` used `defaultCustomPriorityFee ?? swapStepNetFeeLevel.customPriorityFee`, so after the user changed the dialog selector from the preset custom option to `Normal`, the old preset custom fee could still win and keep the estimate extremely high.

## Design Decisions
- Keep `presetCustomizedMap` as internal state for preset settings, but stop using it to decorate visible labels.
- Replace the review label helper with `shouldShowMarketPresetReviewNetworkFeeOption`, so callers pass only whether a custom option is needed.
- Let `PreSwapDialogContent` resolve the visible label with `ETranslations.transaction_custom`.
- Treat preset custom fee as the custom option payload only; normal fee-tier selections now rely on the current `swapStepNetFeeLevel` state and do not fall back to preset defaults.

## Changes Detail
- `MarketPresetSelector.tsx`: render raw preset labels without the customized `*` suffix.
- `marketPresetSettings.ts`: replace label construction with a boolean review-option helper.
- `SwapPanelWrap.tsx`, `SwapMainLand.tsx`, `MarketSwapReviewDialog.tsx`, `SwapReviewDialog.tsx`: thread `showCustomNetworkFeeOption` instead of an externally supplied label.
- `PreSwapDialogContent.tsx`: keep the preset custom fee only on the custom option, and clear it from execution state when users select normal fee tiers.
- `marketPresetSettings.test.ts`: add focused coverage for manual preset vs Auto/custom-option visibility.

## Issues
- Fixes OK-54485
- OK-54486

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Desktop / Web / Extension
- **Risk Areas**: Market preset selector labels and Swap review network-fee option display / estimation.

## Test plan
- [x] `yarn jest --runTestsByPath packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.test.ts`
- [x] `yarn jest --runTestsByPath packages/kit/src/views/Swap/pages/components/SwapReviewDialog.test.tsx`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.ts packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.test.ts packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/MarketPresetSelector/MarketPresetSelector.tsx packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewDialog.tsx packages/kit/src/views/Swap/pages/components/SwapReviewDialog.tsx packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `git diff --check`
