### PR TITLE
fix: respect review fee selection (OK-54486)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewDialog.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewDialog.tsx
@@ -15,7 +15,7 @@ type IMarketSwapReviewDialogProps = {
   reviewState: ISwapReviewState;
   defaultNetworkFeeLevel?: ESwapNetworkFeeLevel;
   defaultCustomPriorityFee?: ICustomPriorityFeeOverride;
-  customNetworkFeeOptionLabel?: string;
+  showCustomNetworkFeeOption?: boolean;
 };
 
 export function MarketSwapReviewDialog({
@@ -24,7 +24,7 @@ export function MarketSwapReviewDialog({
   reviewState,
   defaultNetworkFeeLevel,
   defaultCustomPriorityFee,
-  customNetworkFeeOptionLabel,
+  showCustomNetworkFeeOption,
 }: IMarketSwapReviewDialogProps) {
   return (
     <SwapReviewDialog
@@ -33,7 +33,7 @@ export function MarketSwapReviewDialog({
       reviewState={reviewState}
       defaultNetworkFeeLevel={defaultNetworkFeeLevel}
       defaultCustomPriorityFee={defaultCustomPriorityFee}
-      customNetworkFeeOptionLabel={customNetworkFeeOptionLabel}
+      showCustomNetworkFeeOption={showCustomNetworkFeeOption}
       storeName={EJotaiContextStoreNames.marketSwapReview}
       disableGlobalApproveSync
       approveTransactionSource={ESwapReviewApproveTransactionSource.SpeedSwap}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
@@ -28,7 +28,7 @@ import { useTokenDetail } from '../../hooks/useTokenDetail';
 
 import {
   EMarketPresetTradeSide,
-  getMarketPresetReviewNetworkFeeOptionLabel,
+  shouldShowMarketPresetReviewNetworkFeeOption,
 } from './hooks/marketPresetSettings';
 import { useMarketPresetSettings } from './hooks/useMarketPresetSettings';
 import { useSpeedSwapActions } from './hooks/useSpeedSwapActions';
@@ -493,8 +493,8 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
       const requestId = reviewDialogRequestIdRef.current + 1;
       reviewDialogRequestIdRef.current = requestId;
       setIsReviewOpening(true);
-      const reviewNetworkFeeOptionLabel =
-        getMarketPresetReviewNetworkFeeOptionLabel(marketPresetSettings);
+      const showCustomNetworkFeeOption =
+        shouldShowMarketPresetReviewNetworkFeeOption(marketPresetSettings);
 
       try {
         const nextReviewState = await prepareMarketSwapReview({
@@ -531,7 +531,7 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
               adapter={reviewAdapter}
               defaultNetworkFeeLevel={effectiveNetworkFeeLevel}
               defaultCustomPriorityFee={effectiveCustomPriorityFee}
-              customNetworkFeeOptionLabel={reviewNetworkFeeOptionLabel}
+              showCustomNetworkFeeOption={showCustomNetworkFeeOption}
               reviewState={nextReviewState}
               onDone={() => void dialog?.close()}
             />

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.test.ts
@@ -19,6 +19,7 @@ import {
   getMarketPresetSlippageValue,
   isMarketPresetConfirmDisabled,
   resolveMarketPresetDirectionSettings,
+  shouldShowMarketPresetReviewNetworkFeeOption,
 } from './marketPresetSettings';
 
 describe('marketPresetSettings', () => {
@@ -276,5 +277,26 @@ describe('marketPresetSettings', () => {
         hasInvalidDirtySettings: true,
       }),
     ).toBe(true);
+  });
+
+  it('uses a custom review fee option for selected manual presets only', () => {
+    expect(
+      shouldShowMarketPresetReviewNetworkFeeOption({
+        enabled: true,
+        selectedPresetKey: EMarketPresetKey.P1,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowMarketPresetReviewNetworkFeeOption({
+        enabled: true,
+        selectedPresetKey: EMarketPresetKey.AUTO,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowMarketPresetReviewNetworkFeeOption({
+        enabled: false,
+        selectedPresetKey: EMarketPresetKey.P2,
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.ts
@@ -441,29 +441,14 @@ export function getMarketPresetCustomizedMap(
   );
 }
 
-export function getMarketPresetReviewNetworkFeeOptionLabel({
+export function shouldShowMarketPresetReviewNetworkFeeOption({
   enabled,
-  presetCustomizedMap,
-  presets,
-  selectedPreset,
   selectedPresetKey,
 }: {
   enabled: boolean;
-  presetCustomizedMap: Partial<Record<EMarketPresetKey, boolean>>;
-  presets: IMarketPresetItem[];
-  selectedPreset?: IMarketPresetItem;
   selectedPresetKey: EMarketPresetKey;
 }) {
-  if (!enabled || selectedPresetKey === EMarketPresetKey.AUTO) {
-    return undefined;
-  }
-
-  const selectedPresetItem =
-    selectedPreset ??
-    presets.find((preset) => preset.key === selectedPresetKey);
-  const label = selectedPresetItem?.label ?? selectedPresetKey.toUpperCase();
-
-  return `${label}${presetCustomizedMap[selectedPresetKey] ? '*' : ''}`;
+  return enabled && selectedPresetKey !== EMarketPresetKey.AUTO;
 }
 
 export function getMarketPresetSlippageValue({

--- a/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
+++ b/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
@@ -77,7 +77,7 @@ interface IPreSwapDialogContentProps {
   }) => void | Promise<void>;
   defaultNetworkFeeLevel?: ESwapNetworkFeeLevel;
   defaultCustomPriorityFee?: ICustomPriorityFeeOverride;
-  customNetworkFeeOptionLabel?: string;
+  showCustomNetworkFeeOption?: boolean;
 }
 
 const PreSwapDialogContent = ({
@@ -88,43 +88,42 @@ const PreSwapDialogContent = ({
   preSwapStepsStart,
   defaultNetworkFeeLevel,
   defaultCustomPriorityFee,
-  customNetworkFeeOptionLabel,
+  showCustomNetworkFeeOption,
 }: IPreSwapDialogContentProps) => {
   const intl = useIntl();
   const [swapSteps, setSwapSteps] = useSwapStepsAtom();
   const [swapStepNetFeeLevel, setSwapStepNetFeeLevel] =
     useSwapStepNetFeeLevelAtom();
-  const effectiveCustomPriorityFee =
-    defaultCustomPriorityFee ?? swapStepNetFeeLevel.customPriorityFee;
-  const effectiveNetworkFeeLevel =
-    defaultNetworkFeeLevel ?? swapStepNetFeeLevel.networkFeeLevel;
   const customNetworkFeeOption = useMemo(() => {
-    const label =
-      customNetworkFeeOptionLabel ??
-      (effectiveCustomPriorityFee
-        ? intl.formatMessage({ id: ETranslations.transaction_custom })
-        : undefined);
+    const optionNetworkFeeLevel = showCustomNetworkFeeOption
+      ? (defaultNetworkFeeLevel ?? swapStepNetFeeLevel.networkFeeLevel)
+      : swapStepNetFeeLevel.networkFeeLevel;
+    const optionCustomPriorityFee = showCustomNetworkFeeOption
+      ? defaultCustomPriorityFee
+      : swapStepNetFeeLevel.customPriorityFee;
 
-    if (!label) {
+    if (!showCustomNetworkFeeOption && !optionCustomPriorityFee) {
       return undefined;
     }
 
     return {
-      label,
-      networkFeeLevel: effectiveNetworkFeeLevel,
-      customPriorityFee: effectiveCustomPriorityFee,
+      label: intl.formatMessage({ id: ETranslations.transaction_custom }),
+      networkFeeLevel: optionNetworkFeeLevel,
+      customPriorityFee: optionCustomPriorityFee,
     };
   }, [
-    customNetworkFeeOptionLabel,
-    effectiveCustomPriorityFee,
-    effectiveNetworkFeeLevel,
+    defaultCustomPriorityFee,
+    defaultNetworkFeeLevel,
     intl,
+    showCustomNetworkFeeOption,
+    swapStepNetFeeLevel.customPriorityFee,
+    swapStepNetFeeLevel.networkFeeLevel,
   ]);
   const [networkFeeSelectValue, setNetworkFeeSelectValue] =
     useState<ISwapReviewNetworkFeeSelectValue>(
       customNetworkFeeOption
         ? SWAP_REVIEW_CUSTOM_NETWORK_FEE_VALUE
-        : effectiveNetworkFeeLevel,
+        : swapStepNetFeeLevel.networkFeeLevel,
     );
   const customNetworkFeeOptionRef = useRef(customNetworkFeeOption);
   const customNetworkFeeOptionKey = useMemo(() => {

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -100,7 +100,7 @@ import {
 
 import {
   EMarketPresetTradeSide,
-  getMarketPresetReviewNetworkFeeOptionLabel,
+  shouldShowMarketPresetReviewNetworkFeeOption,
 } from '../../../Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings';
 import { useMarketPresetSettings } from '../../../Market/MarketDetailV2/components/SwapPanel/hooks/useMarketPresetSettings';
 import { ESwapDirection } from '../../../Market/MarketDetailV2/components/SwapPanel/hooks/useTradeType';
@@ -289,7 +289,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     networkId: swapProMarketPresetTokenContext?.networkId,
     tradeSide: swapProMarketPresetTradeSide,
   });
-  const swapProReviewMarketPresetNetworkFeeOptionLabel = useMemo(() => {
+  const showSwapProReviewCustomNetworkFeeOption = useMemo(() => {
     if (
       !focusSwapPro ||
       swapProTradeType !== ESwapProTradeType.MARKET ||
@@ -298,16 +298,16 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
       return undefined;
     }
 
-    return getMarketPresetReviewNetworkFeeOptionLabel(
+    return shouldShowMarketPresetReviewNetworkFeeOption(
       swapProMarketPresetSettings,
     );
   }, [focusSwapPro, swapProMarketPresetSettings, swapProTradeType]);
   const swapProReviewDefaultNetworkFeeLevel =
-    swapProReviewMarketPresetNetworkFeeOptionLabel
+    showSwapProReviewCustomNetworkFeeOption
       ? swapProMarketPresetSettings.selectedNetworkFeeLevel
       : undefined;
   const swapProReviewDefaultCustomPriorityFee =
-    swapProReviewMarketPresetNetworkFeeOptionLabel
+    showSwapProReviewCustomNetworkFeeOption
       ? swapProMarketPresetSettings.selectedPriorityFeeOverride
       : undefined;
 
@@ -946,8 +946,8 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
                       defaultCustomPriorityFee={
                         swapProReviewDefaultCustomPriorityFee
                       }
-                      customNetworkFeeOptionLabel={
-                        swapProReviewMarketPresetNetworkFeeOptionLabel
+                      showCustomNetworkFeeOption={
+                        showSwapProReviewCustomNetworkFeeOption
                       }
                       onConfirm={handleConfirm}
                       onDone={onPreSwapClose}
@@ -988,8 +988,8 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
                       defaultCustomPriorityFee={
                         swapProReviewDefaultCustomPriorityFee
                       }
-                      customNetworkFeeOptionLabel={
-                        swapProReviewMarketPresetNetworkFeeOptionLabel
+                      showCustomNetworkFeeOption={
+                        showSwapProReviewCustomNetworkFeeOption
                       }
                       onDone={onPreSwapClose}
                       onConfirm={handleConfirm}
@@ -1018,7 +1018,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     preSwapStepsStart,
     swapProReviewDefaultCustomPriorityFee,
     swapProReviewDefaultNetworkFeeLevel,
-    swapProReviewMarketPresetNetworkFeeOptionLabel,
+    showSwapProReviewCustomNetworkFeeOption,
     handleConfirm,
     InTabDialog,
   ]);

--- a/packages/kit/src/views/Swap/pages/components/SwapReviewDialog.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapReviewDialog.tsx
@@ -25,7 +25,7 @@ type ISwapReviewDialogProps = {
   storeName: EJotaiContextStoreNames;
   defaultNetworkFeeLevel?: ESwapNetworkFeeLevel;
   defaultCustomPriorityFee?: ICustomPriorityFeeOverride;
-  customNetworkFeeOptionLabel?: string;
+  showCustomNetworkFeeOption?: boolean;
   disableGlobalApproveSync?: boolean;
   approveTransactionSource?: ESwapReviewApproveTransactionSource;
   accountSelectorConfig?: {
@@ -43,7 +43,7 @@ function SwapReviewDialogContent({
   disableGlobalApproveSync,
   defaultCustomPriorityFee,
   defaultNetworkFeeLevel,
-  customNetworkFeeOptionLabel,
+  showCustomNetworkFeeOption,
   onDone,
 }: {
   adapter: ISwapReviewAdapter;
@@ -51,7 +51,7 @@ function SwapReviewDialogContent({
   disableGlobalApproveSync?: boolean;
   defaultNetworkFeeLevel?: ESwapNetworkFeeLevel;
   defaultCustomPriorityFee?: ICustomPriorityFeeOverride;
-  customNetworkFeeOptionLabel?: string;
+  showCustomNetworkFeeOption?: boolean;
   onDone: () => void;
 }) {
   const { onConfirm, preSwapBeforeStepActions, preSwapStepsStart } =
@@ -69,7 +69,7 @@ function SwapReviewDialogContent({
       preSwapStepsStart={preSwapStepsStart}
       defaultNetworkFeeLevel={defaultNetworkFeeLevel}
       defaultCustomPriorityFee={defaultCustomPriorityFee}
-      customNetworkFeeOptionLabel={customNetworkFeeOptionLabel}
+      showCustomNetworkFeeOption={showCustomNetworkFeeOption}
     />
   );
 }
@@ -81,7 +81,7 @@ export function SwapReviewDialog({
   storeName,
   defaultNetworkFeeLevel,
   defaultCustomPriorityFee,
-  customNetworkFeeOptionLabel,
+  showCustomNetworkFeeOption,
   disableGlobalApproveSync,
   approveTransactionSource = ESwapReviewApproveTransactionSource.None,
   accountSelectorConfig = {
@@ -117,7 +117,7 @@ export function SwapReviewDialog({
             disableGlobalApproveSync={disableGlobalApproveSync}
             defaultNetworkFeeLevel={defaultNetworkFeeLevel}
             defaultCustomPriorityFee={defaultCustomPriorityFee}
-            customNetworkFeeOptionLabel={customNetworkFeeOptionLabel}
+            showCustomNetworkFeeOption={showCustomNetworkFeeOption}
             onDone={onDone}
           />
         </SwapReviewInitializer>


### PR DESCRIPTION
## Summary
- Use the generic Custom i18n label for Market preset fee overrides in the review dialog.
- Keep the preset fee as the review Custom option payload instead of forcing it over later fee-tier selections.
- Preserve Normal/Slow/Fast review selections so fee re-estimation and submit-time fee params use the selected tier.

## Issues
- Fixes OK-54486

## Intent & Context
OK-54486 covers the case where a user sets a very high fee on a Market preset, opens Review, switches the review fee selector back to Normal, and still sees the high preset fee. The previous combined PR was closed so this PR only handles OK-54486.

## Root Cause
`PreSwapDialogContent` treated `defaultCustomPriorityFee` from the Market preset as the effective fee even after the user selected Normal/Slow/Fast in the review dialog. That kept the P2/P3 custom fee in the re-estimation path and submit-time fee params.

## Design Decisions
- The outer Market preset selection remains intact; opening Review from P1/P2/P3 still starts with a Custom fee option populated from the preset.
- Inside Review, Normal/Slow/Fast are now independent controlled selections that clear `customPriorityFee` from `swapStepNetFeeLevel`.
- The review dropdown no longer displays P1/P2/P3 labels; custom preset fees are represented as `transaction.custom`.

## Changes Detail
- Replaced the Market preset review label helper with a boolean helper that only decides whether a Custom fee option should be shown.
- Threaded `showCustomNetworkFeeOption` through Market and Swap review wrappers.
- Updated `PreSwapDialogContent` so the preset fee is only used by the Custom option, while selected standard tiers use the atom state.
- Added helper coverage for manual preset vs Auto/disabled behavior.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop / Mobile / Web / Extension
- **Risk Areas**: Swap review fee selection and Market preset review entry points.

## Test plan
- [x] `git diff --check`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewDialog.tsx packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.test.ts packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.ts packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx packages/kit/src/views/Swap/pages/components/SwapReviewDialog.tsx`
- [x] `yarn jest --runTestsByPath packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.test.ts packages/kit/src/views/Swap/pages/components/SwapReviewDialog.test.tsx`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
