### PR TITLE
fix(ios): allow sentry upload failure and sync ServiceExtension build version

### DIFF
--- a/apps/mobile/ios/OneKeyWallet.xcodeproj/project.pbxproj
+++ b/apps/mobile/ios/OneKeyWallet.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/bin/sh ../../../node_modules/@sentry/react-native/scripts/sentry-xcode-debug-files.sh";
+			shellScript = "export SENTRY_ALLOW_FAILURE=true\n/bin/sh ../../../node_modules/@sentry/react-native/scripts/sentry-xcode-debug-files.sh";
 		};
 		3EDAD8685393FC102363B5F8 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -933,6 +933,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				VERSIONING_SYSTEM = "apple-generic";
 				CXX = "clang++";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = BVJ3FU5H2K;
@@ -983,6 +984,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
+				VERSIONING_SYSTEM = "apple-generic";
 				CXX = "clang++";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = BVJ3FU5H2K;


### PR DESCRIPTION
## Summary

- Add `SENTRY_ALLOW_FAILURE=true` to the "Upload Debug Symbols to Sentry" build phase so a transient Sentry API error no longer breaks the archive
- Add `VERSIONING_SYSTEM = "apple-generic"` to ServiceExtension Debug and Release targets so `agvtool` updates its `CURRENT_PROJECT_VERSION` alongside the main app, preventing `CFBundleVersion` mismatch on App Store submission

## Root Cause

EAS uses `agvtool new-version -all <buildNumber>` to bump the iOS build number. `agvtool` only updates targets that have `VERSIONING_SYSTEM = "apple-generic"` set. The main app already had it, but the ServiceExtension did not — so its `CFBundleVersion` stayed at `1` while the main app got e.g. `2026051107`, causing App Store Connect rejection.

## Test plan

- [ ] Trigger an EAS iOS build and verify the archive succeeds even when Sentry API is unavailable
- [ ] Confirm `CFBundleVersion` in `ServiceExtension/Info.plist` matches the main app after the build