### PR TITLE
fix: resolve verified Perps issues (OK-53743 OK-54112 OK-54151 OK-54164 OK-54167 OK-54168 OK-54244)

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -132,6 +132,12 @@ type ILoadTradesHistoryOptions = {
   force?: boolean;
 };
 
+function filterSupportedTradeHistoryFills(fills: IFill[]): IFill[] {
+  return fills.filter(
+    (fill) => !perpsUtils.isPredictionMarketInstrument(fill.coin),
+  );
+}
+
 @backgroundClass()
 export default class ServiceHyperliquid extends ServiceBase {
   public builderAddress: IHex = FALLBACK_BUILDER_ADDRESS;
@@ -626,9 +632,10 @@ export default class ServiceHyperliquid extends ServiceBase {
       reversed: true,
     };
 
-    const fills = options.force
+    const fillsRaw = options.force
       ? await this.getUserFillsByTime(params)
       : await this._getUserFillsByTimeMemo(params);
+    const fills = filterSupportedTradeHistoryFills(fillsRaw);
 
     const activeAccount = await perpsActiveAccountAtom.get();
     if (
@@ -692,7 +699,10 @@ export default class ServiceHyperliquid extends ServiceBase {
       return;
     }
 
-    const fills = this._sortAndDedupeFills([...newFills, ...current.fills]);
+    const fills = this._sortAndDedupeFills([
+      ...filterSupportedTradeHistoryFills(newFills),
+      ...current.fills,
+    ]);
 
     await perpsTradesHistoryDataAtom.set({
       ...current,

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -144,6 +144,13 @@ export default class ServiceHyperliquid extends ServiceBase {
 
   public maxBuilderFee: number = FALLBACK_MAX_BUILDER_FEE;
 
+  private activeAssetChangeRequestId = 0;
+
+  @backgroundMethod()
+  async cancelPendingActiveAssetChange(): Promise<void> {
+    this.activeAssetChangeRequestId += 1;
+  }
+
   // Avoids async atom reads in the hot path — written to atom on a throttled schedule
   private _spotPriceCache: Record<string, ISpotAssetCtxEntry> = {};
 
@@ -1520,6 +1527,7 @@ export default class ServiceHyperliquid extends ServiceBase {
     universeItems: IPerpsUniverse[];
     selectedUniverse: IPerpsUniverse | undefined;
   }> {
+    const requestId = (this.activeAssetChangeRequestId += 1);
     const oldActiveAsset = await perpsActiveAssetAtom.get();
     const oldCoin = oldActiveAsset?.coin;
     const newCoin = params.coin;
@@ -1541,6 +1549,13 @@ export default class ServiceHyperliquid extends ServiceBase {
 
     const selectedUniverse: IPerpsUniverse | undefined =
       dexUniverses?.find((item) => item.name === newCoin) || dexUniverses?.[0];
+    if (requestId !== this.activeAssetChangeRequestId) {
+      return {
+        universeItems: dexUniverses || [],
+        selectedUniverse: oldActiveAsset?.universe,
+      };
+    }
+
     const assetId =
       selectedUniverse?.assetId ??
       dexUniverses?.findIndex(
@@ -1548,6 +1563,13 @@ export default class ServiceHyperliquid extends ServiceBase {
       ) ??
       -1;
     const selectedMargin = dexMarginTables?.[selectedUniverse?.marginTableId];
+    if (requestId !== this.activeAssetChangeRequestId) {
+      return {
+        universeItems: dexUniverses || [],
+        selectedUniverse: oldActiveAsset?.universe,
+      };
+    }
+
     await perpsActiveAssetAtom.set({
       coin: selectedUniverse?.name || newCoin || '',
       assetId,

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.test.ts
@@ -3,20 +3,28 @@ import { ESubscriptionType } from '@onekeyhq/shared/types/hyperliquid/types';
 import { calculateRequiredSubscriptions } from './SubscriptionConfig';
 
 describe('calculateRequiredSubscriptions', () => {
-  it('subscribes openOrders to the main dex response channel', () => {
+  it('subscribes openOrders to all supported perp dex response channels', () => {
     const specs = calculateRequiredSubscriptions({
       currentUser: '0x0000000000000000000000000000000000000001',
       currentSymbol: 'ETH',
       isConnected: true,
     });
 
-    const openOrdersSpec = specs.find(
+    const openOrdersSpecs = specs.filter(
       (spec) => spec.type === ESubscriptionType.OPEN_ORDERS,
     );
 
-    expect(openOrdersSpec?.params).toMatchObject({
-      user: '0x0000000000000000000000000000000000000001',
-      dex: '',
-    });
+    expect(openOrdersSpecs.map((spec) => spec.params)).toEqual(
+      expect.arrayContaining([
+        {
+          user: '0x0000000000000000000000000000000000000001',
+          dex: '',
+        },
+        {
+          user: '0x0000000000000000000000000000000000000001',
+          dex: 'xyz',
+        },
+      ]),
+    );
   });
 });

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
@@ -1,5 +1,6 @@
 import { PERPS_EMPTY_ADDRESS } from '@onekeyhq/shared/src/consts/perp';
 import stringUtils from '@onekeyhq/shared/src/utils/stringUtils';
+import { DEX_PREFIXES } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import type {
   IEventAllDexsClearinghouseStateParameters,
   IEventL2BookParameters,
@@ -247,16 +248,19 @@ export function calculateRequiredSubscriptions(
       }),
     );
 
-    const openOrdersParams: IEventOpenOrdersParameters = {
-      user: state.currentUser,
-      dex: '',
-    };
-    specs.push(
-      buildSubscriptionSpec({
-        type: ESubscriptionType.OPEN_ORDERS,
-        params: openOrdersParams,
-      }),
-    );
+    const openOrdersDexes = ['', ...DEX_PREFIXES];
+    openOrdersDexes.forEach((dex) => {
+      const openOrdersParams: IEventOpenOrdersParameters = {
+        user: state.currentUser as IHex,
+        dex,
+      };
+      specs.push(
+        buildSubscriptionSpec({
+          type: ESubscriptionType.OPEN_ORDERS,
+          params: openOrdersParams,
+        }),
+      );
+    });
     specs.push(
       buildSubscriptionSpec({
         type: ESubscriptionType.WEB_DATA3,

--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
@@ -67,42 +67,61 @@ const useSymbolSync = ({
   displayCoin: string | undefined;
   isChartReady: boolean;
 }) => {
-  const prevSymbolRef = useRef<string>(symbol);
+  const prevParamsRef = useRef({
+    displayCoin,
+    displayPair,
+    symbol,
+  });
+  const hasSyncedReadyChartRef = useRef(false);
 
-  useEffect(() => {
-    const prevSymbol = prevSymbolRef.current;
-    const hasSymbolChanged = prevSymbol !== symbol;
-
-    if (hasSymbolChanged && webRef.current) {
-      // Sync symbol changes via message communication instead of WebView reload
-      webRef.current.sendMessageViaInjectedScript({
+  const sendSymbolChange = useCallback(
+    ({ force }: { force: boolean }) => {
+      webRef.current?.sendMessageViaInjectedScript({
         type: 'SYMBOL_CHANGE',
         payload: {
           symbol,
           displayPair,
           displayCoin,
-          force: true,
+          force,
         },
       });
+    },
+    [displayCoin, displayPair, symbol, webRef],
+  );
 
-      prevSymbolRef.current = symbol;
+  useEffect(() => {
+    const prevParams = prevParamsRef.current;
+    const hasSymbolChanged = prevParams.symbol !== symbol;
+    const hasDisplayParamsChanged =
+      prevParams.displayPair !== displayPair ||
+      prevParams.displayCoin !== displayCoin;
+
+    if ((hasSymbolChanged || hasDisplayParamsChanged) && webRef.current) {
+      // Sync symbol changes via message communication instead of WebView reload
+      sendSymbolChange({ force: hasSymbolChanged });
+
+      prevParamsRef.current = {
+        displayCoin,
+        displayPair,
+        symbol,
+      };
     }
-  }, [symbol, displayPair, displayCoin, webRef]);
+  }, [displayCoin, displayPair, sendSymbolChange, symbol, webRef]);
 
   // Re-sync symbol when chart becomes ready to catch messages lost during iframe load
   useEffect(() => {
-    if (isChartReady && webRef.current) {
-      webRef.current.sendMessageViaInjectedScript({
-        type: 'SYMBOL_CHANGE',
-        payload: {
-          symbol,
-          displayPair,
-          displayCoin,
-          force: false,
-        },
-      });
+    if (!isChartReady) {
+      hasSyncedReadyChartRef.current = false;
+      return;
     }
-  }, [isChartReady, symbol, displayPair, displayCoin, webRef]);
+
+    if (hasSyncedReadyChartRef.current || !webRef.current) {
+      return;
+    }
+
+    sendSymbolChange({ force: false });
+    hasSyncedReadyChartRef.current = true;
+  }, [isChartReady, sendSymbolChange, webRef]);
 };
 
 // WebView Memoized component to prevent unnecessary re-renders

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -94,6 +94,7 @@ type IChStateLite = {
 type IChPositionLite = HL.IPerpsAssetPosition;
 
 const MAX_LEDGER_UPDATES = 200;
+const ANDROID_ACTIVE_INSTRUMENT_SWITCH_SETTLE_MS = 120;
 
 function getLedgerUpdateKey(update: HL.IUserNonFundingLedgerUpdate): string {
   return (
@@ -175,6 +176,26 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
   private openOrdersByDexCache = new Map<string, HL.IPerpsFrontendOrder[]>();
 
   private openOrdersCacheAccountAddress: string | undefined;
+
+  private activeInstrumentChangeRequestId = 0;
+
+  private beginActiveInstrumentChange(): number {
+    this.activeInstrumentChangeRequestId += 1;
+    return this.activeInstrumentChangeRequestId;
+  }
+
+  private isLatestActiveInstrumentChange(requestId: number): boolean {
+    return requestId === this.activeInstrumentChangeRequestId;
+  }
+
+  private async waitForActiveInstrumentChangeSettle(
+    requestId: number,
+  ): Promise<boolean> {
+    if (platformEnv.isNativeAndroid) {
+      await timerUtils.wait(ANDROID_ACTIVE_INSTRUMENT_SWITCH_SETTLE_MS);
+    }
+    return this.isLatestActiveInstrumentChange(requestId);
+  }
 
   private async findChartOrder(
     get: (atom: ReturnType<typeof perpsActiveOpenOrdersAtom>) => {
@@ -854,7 +875,17 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
   );
 
   changeActiveAsset = contextAtomMethod(
-    async (get, set, { coin, force }: { coin: string; force?: boolean }) => {
+    async (
+      get,
+      set,
+      {
+        coin,
+        force,
+        requestId: existingRequestId,
+      }: { coin: string; force?: boolean; requestId?: number },
+    ) => {
+      const requestId = existingRequestId ?? this.beginActiveInstrumentChange();
+      await backgroundApiProxy.serviceHyperliquid.cancelPendingActiveAssetChange();
       const activeAsset = await perpsActiveAssetAtom.get();
       if (activeAsset?.coin === coin && !force) {
         // Mirror changeActiveSpotAsset: short-circuit ONLY when the current
@@ -863,24 +894,39 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
         const currentMode = await tradingModeAtom.get();
         if (currentMode === 'perp') {
           const next = await this._buildActiveTradeInstrument('perp');
+          if (!this.isLatestActiveInstrumentChange(requestId)) {
+            return false;
+          }
           const prev = get(activeTradeInstrumentAtom());
           if (
             !ContextJotaiActionsHyperliquid._isTradeInstrumentEqual(prev, next)
           ) {
             set(activeTradeInstrumentAtom(), next);
           }
-          return;
+          return true;
         }
       }
 
       const form = get(tradingFormAtom());
       const shouldUpdateLimitPrice = form.type === 'limit';
 
+      if (!(await this.waitForActiveInstrumentChangeSettle(requestId))) {
+        return false;
+      }
       await this.clearActiveAssetData.call(set);
+      if (!this.isLatestActiveInstrumentChange(requestId)) {
+        return false;
+      }
       await tradingModeAtom.set('perp');
+      if (!this.isLatestActiveInstrumentChange(requestId)) {
+        return false;
+      }
       await backgroundApiProxy.serviceHyperliquid.changeActiveAsset({
         coin,
       });
+      if (!this.isLatestActiveInstrumentChange(requestId)) {
+        return false;
+      }
 
       const nextFormUpdates: Partial<ITradingFormData> = {
         triggerPrice: '',
@@ -899,11 +945,13 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
             : '';
       }
 
+      const nextInstrument = await this._buildActiveTradeInstrument('perp');
+      if (!this.isLatestActiveInstrumentChange(requestId)) {
+        return false;
+      }
       this.updateTradingForm.call(set, nextFormUpdates);
-      set(
-        activeTradeInstrumentAtom(),
-        await this._buildActiveTradeInstrument('perp'),
-      );
+      set(activeTradeInstrumentAtom(), nextInstrument);
+      return true;
     },
   );
 
@@ -914,28 +962,47 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       {
         coin,
         spotUniverse,
-      }: { coin: string; spotUniverse: ISpotUniverse | undefined },
+        requestId: existingRequestId,
+      }: {
+        coin: string;
+        spotUniverse: ISpotUniverse | undefined;
+        requestId?: number;
+      },
     ) => {
+      const requestId = existingRequestId ?? this.beginActiveInstrumentChange();
+      await backgroundApiProxy.serviceHyperliquid.cancelPendingActiveAssetChange();
       const currentSpotAsset = await spotActiveAssetAtom.get();
       if (currentSpotAsset?.coin === coin) {
         const currentMode = await tradingModeAtom.get();
         if (currentMode === 'spot') {
           const next = await this._buildActiveTradeInstrument('spot');
+          if (!this.isLatestActiveInstrumentChange(requestId)) {
+            return false;
+          }
           const prev = get(activeTradeInstrumentAtom());
           if (
             !ContextJotaiActionsHyperliquid._isTradeInstrumentEqual(prev, next)
           ) {
             set(activeTradeInstrumentAtom(), next);
           }
-          return;
+          return true;
         }
       }
 
+      if (!(await this.waitForActiveInstrumentChangeSettle(requestId))) {
+        return false;
+      }
       await this.clearActiveAssetData.call(set);
+      if (!this.isLatestActiveInstrumentChange(requestId)) {
+        return false;
+      }
       await tradingModeAtom.set('spot');
 
       // Seed ticker bar from cached data to avoid skeleton flash
       const ctxsMap = await spotAssetCtxsMapAtom.get();
+      if (!this.isLatestActiveInstrumentChange(requestId)) {
+        return false;
+      }
       const cached = ctxsMap[coin];
       if (cached) {
         await spotActiveAssetCtxAtom.set({
@@ -956,14 +1023,20 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       } else {
         await spotActiveAssetCtxAtom.set(undefined);
       }
+      if (!this.isLatestActiveInstrumentChange(requestId)) {
+        return false;
+      }
 
       await spotActiveAssetAtom.set({
         coin,
         assetId: spotUniverse?.assetId,
         universe: spotUniverse,
       });
+      if (!this.isLatestActiveInstrumentChange(requestId)) {
+        return false;
+      }
 
-      this.updateTradingForm.call(set, {
+      const nextFormUpdates: Partial<ITradingFormData> = {
         size: '',
         price: '',
         orderMode: 'standard',
@@ -974,19 +1047,28 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
         sizePercent: 0,
         triggerPrice: '',
         executionPrice: '',
-      });
+      };
       // Spot doesn't have margin mode -- force to usd if currently set to margin
       const currentPrefs = await perpsTradingPreferencesAtom.get();
+      if (!this.isLatestActiveInstrumentChange(requestId)) {
+        return false;
+      }
       if (currentPrefs.sizeInputUnit === 'margin') {
         await perpsTradingPreferencesAtom.set({
           ...currentPrefs,
           sizeInputUnit: 'usd',
         });
+        if (!this.isLatestActiveInstrumentChange(requestId)) {
+          return false;
+        }
       }
-      set(
-        activeTradeInstrumentAtom(),
-        await this._buildActiveTradeInstrument('spot'),
-      );
+      const nextInstrument = await this._buildActiveTradeInstrument('spot');
+      if (!this.isLatestActiveInstrumentChange(requestId)) {
+        return false;
+      }
+      this.updateTradingForm.call(set, nextFormUpdates);
+      set(activeTradeInstrumentAtom(), nextInstrument);
+      return true;
     },
   );
 
@@ -1001,23 +1083,28 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
         spotUniverse?: ISpotUniverse;
       },
     ) => {
+      const requestId = this.beginActiveInstrumentChange();
       if (params.mode === 'spot') {
         let spotUniverse = params.spotUniverse;
         if (!spotUniverse) {
           const { universes } =
             await backgroundApiProxy.serviceHyperliquid.getSpotMeta();
+          if (!this.isLatestActiveInstrumentChange(requestId)) {
+            return false;
+          }
           spotUniverse = universes.find((item) => item.name === params.coin);
         }
-        await this.changeActiveSpotAsset.call(set, {
+        return this.changeActiveSpotAsset.call(set, {
           coin: params.coin,
           spotUniverse,
+          requestId,
         });
-        return;
       }
 
-      await this.changeActiveAsset.call(set, {
+      return this.changeActiveAsset.call(set, {
         coin: params.coin,
         force: params.force,
+        requestId,
       });
     },
   );

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -172,6 +172,10 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
 
   private canceledOrderIds = new Set<number>();
 
+  private openOrdersByDexCache = new Map<string, HL.IPerpsFrontendOrder[]>();
+
+  private openOrdersCacheAccountAddress: string | undefined;
+
   private async findChartOrder(
     get: (atom: ReturnType<typeof perpsActiveOpenOrdersAtom>) => {
       openOrders: HL.IPerpsFrontendOrder[];
@@ -237,6 +241,18 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     });
 
     return grouped;
+  }
+
+  private resetOpenOrdersByDexCache() {
+    this.openOrdersByDexCache.clear();
+    this.openOrdersCacheAccountAddress = undefined;
+  }
+
+  private ensureOpenOrdersCacheAccount(accountAddress: string | undefined) {
+    if (this.openOrdersCacheAccountAddress !== accountAddress) {
+      this.openOrdersByDexCache.clear();
+      this.openOrdersCacheAccountAddress = accountAddress;
+    }
   }
 
   updateAllMids = contextAtomMethod((_, set, data: HL.IWsAllMids) => {
@@ -385,6 +401,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       if (
         activeOpenOrders?.accountAddress?.toLowerCase() !== activeAccountAddress
       ) {
+        this.resetOpenOrdersByDexCache();
         set(perpsActiveOpenOrdersAtom(), {
           accountAddress: activeAccountAddress,
           openOrders: [],
@@ -470,6 +487,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       const activeAccountAddress = activeAccount?.accountAddress?.toLowerCase();
       const dataUser = data?.user?.toLowerCase();
       if (!activeAccountAddress || activeAccountAddress !== dataUser) {
+        this.resetOpenOrdersByDexCache();
         const activeOpenOrders = get(perpsActiveOpenOrdersAtom());
         if (
           activeOpenOrders?.accountAddress?.toLowerCase() !==
@@ -490,12 +508,18 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
 
       const prevOpenOrdersState = get(perpsActiveOpenOrdersAtom());
       const allOrders = data?.orders || [];
-      const perpOrders = allOrders.filter(
+      this.ensureOpenOrdersCacheAccount(activeAccountAddress);
+      this.openOrdersByDexCache.set(data?.dex ?? '', allOrders);
+      const mergedOrders = Array.from(
+        this.openOrdersByDexCache.values(),
+      ).flat();
+
+      const perpOrders = mergedOrders.filter(
         (order) =>
           !isSpotInstrument(order.coin) &&
           !this.canceledOrderIds.has(order.oid),
       );
-      const spotOrders = allOrders.filter(
+      const spotOrders = mergedOrders.filter(
         (order) =>
           isSpotInstrument(order.coin) && !this.canceledOrderIds.has(order.oid),
       );
@@ -1150,6 +1174,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       openOrders: [],
       openOrdersByCoin: {},
     });
+    this.resetOpenOrdersByDexCache();
     perpsOpenOrdersByCoinAtomCache.clear();
     this.canceledOrderIds.clear();
     set(perpsLedgerUpdatesAtom(), {

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
@@ -72,10 +72,11 @@ const TradesHistoryRow = memo(
       return (
         fill.closedPnl &&
         !new BigNumber(fill.closedPnl).isZero() &&
+        !isSpotInstrument(fill.coin) &&
         !fill.liquidation &&
         onShare
       );
-    }, [fill.closedPnl, fill.liquidation, onShare]);
+    }, [fill.closedPnl, fill.coin, fill.liquidation, onShare]);
     const actions = useHyperliquidActions();
     const intl = useIntl();
     const [spotDisplayMap] = useSpotPairDisplayMapAtom();

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTradesHistoryList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTradesHistoryList.tsx
@@ -119,6 +119,9 @@ function PerpTradesHistoryList({
 
   const handleShare = useCallback(
     async (fill: IFill) => {
+      if (isSpotInstrument(fill.coin)) {
+        return;
+      }
       const closedPnlBN = new BigNumber(fill.closedPnl).minus(
         new BigNumber(fill.fee),
       );

--- a/packages/kit/src/views/Perp/components/PerpCandles.tsx
+++ b/packages/kit/src/views/Perp/components/PerpCandles.tsx
@@ -7,7 +7,6 @@ import {
   usePerpsActiveAccountAtom,
   usePerpsCandlesWebviewReloadHookAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   formatSpotPairDisplayName,
   getSpotTokenDisplayName,
@@ -21,8 +20,7 @@ export function PerpCandles({
   const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const [currentAccount] = usePerpsActiveAccountAtom();
   const [{ reloadHook }] = usePerpsCandlesWebviewReloadHookAtom();
-  const enablePerpsTradingUi =
-    !platformEnv.isNative && !platformEnv.isWebMobile;
+  const enablePerpsTradingUi = false;
 
   const { displayPair, displayCoin } = useMemo(() => {
     if (

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -70,6 +70,15 @@ import { planTradeSubscriptions } from '../utils/subscriptionPlanner';
 
 import { usePerpTokenUrlSync } from './usePerpTokenUrlSync';
 
+const shouldTreatPerpAsFocusedOnMount = !!(
+  platformEnv.isExtensionUiExpandTab ||
+  platformEnv.isExtensionUiStandaloneWindow
+);
+
+function resolvePerpRouteFocused(isFocus: boolean) {
+  return shouldTreatPerpAsFocusedOnMount || isFocus;
+}
+
 function useSyncContextOrderBookOptionsToGlobal() {
   const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const [orderBookTickOptions] = useOrderBookTickOptionsAtom();
@@ -79,7 +88,7 @@ function useSyncContextOrderBookOptionsToGlobal() {
   const activeTradeInstrumentRef = useRef(activeTradeInstrument);
   activeTradeInstrumentRef.current = activeTradeInstrument;
 
-  const isFocusedRef = useRef(false);
+  const isFocusedRef = useRef(shouldTreatPerpAsFocusedOnMount);
 
   const updateGlobalOrderBookOptions = useCallback(
     async (
@@ -132,9 +141,10 @@ function useSyncContextOrderBookOptionsToGlobal() {
   useListenTabFocusState(
     ETabRoutes.Perp,
     (isFocus: boolean, _isHiddenByModal: boolean) => {
+      const nextFocused = resolvePerpRouteFocused(isFocus);
       const isFocusedPrev = isFocusedRef.current;
-      isFocusedRef.current = isFocus;
-      if (isFocus !== isFocusedPrev) {
+      isFocusedRef.current = nextFocused;
+      if (nextFocused !== isFocusedPrev) {
         void updateGlobalOrderBookOptions(orderBookTickOptionsRef.current);
       }
     },
@@ -148,13 +158,18 @@ function useTradeRouteViewStateSync() {
     ETabRoutes.Perp,
     (isFocus: boolean, isHiddenByModal: boolean) => {
       actions.current.setTradeRouteViewState({
-        routeFocused: isFocus && !isHiddenByModal,
+        routeFocused: resolvePerpRouteFocused(isFocus) && !isHiddenByModal,
       });
     },
   );
 
   useEffect(() => {
     const actionsRef = actions.current;
+    if (shouldTreatPerpAsFocusedOnMount) {
+      actionsRef.setTradeRouteViewState({
+        routeFocused: true,
+      });
+    }
     return () => {
       actionsRef.setTradeRouteViewState({
         routeFocused: false,
@@ -323,7 +338,7 @@ function useHyperliquidSession() {
   useListenTabFocusState(
     ETabRoutes.Perp,
     (isFocus: boolean, isHiddenByModal: boolean) => {
-      if (isFocus && !isHiddenByModal) {
+      if (resolvePerpRouteFocused(isFocus) && !isHiddenByModal) {
         // Handle tab focus
       } else {
         // Handle tab unfocus
@@ -385,7 +400,7 @@ function useHyperliquidAccountSelect() {
 
   const [{ refreshHook: activeAccountRefreshHook }] =
     usePerpsActiveAccountRefreshHookAtom();
-  const hasBeenFocusedRef = useRef(false);
+  const hasBeenFocusedRef = useRef(shouldTreatPerpAsFocusedOnMount);
   const pendingSelectRef = useRef(false);
 
   const selectPerpsAccount = useCallback(async () => {
@@ -416,7 +431,7 @@ function useHyperliquidAccountSelect() {
   selectPerpsAccountRef.current = selectPerpsAccount;
 
   useListenTabFocusState(ETabRoutes.Perp, (isFocus: boolean) => {
-    if (isFocus && !hasBeenFocusedRef.current) {
+    if (resolvePerpRouteFocused(isFocus) && !hasBeenFocusedRef.current) {
       hasBeenFocusedRef.current = true;
       if (pendingSelectRef.current) {
         pendingSelectRef.current = false;
@@ -587,7 +602,7 @@ function useHyperliquidSymbolSelect() {
   const actions = useHyperliquidActions();
 
   useListenTabFocusState(ETabRoutes.Perp, (isFocus: boolean) => {
-    if (!isFocus) return;
+    if (!resolvePerpRouteFocused(isFocus)) return;
     void (async () => {
       // OK-53208: latch lives in ServiceHyperliquid (singleton) so that
       // Perp tab detach/remount does not re-trigger this init.
@@ -670,7 +685,8 @@ function useHyperliquidLocaleChangeRecovery() {
   useListenTabFocusState(
     ETabRoutes.Perp,
     (isFocus: boolean, isHiddenByModal: boolean) => {
-      isFocusedRef.current = isFocus && !isHiddenByModal;
+      isFocusedRef.current =
+        resolvePerpRouteFocused(isFocus) && !isHiddenByModal;
       if (isFocusedRef.current && pendingRecoveryRef.current) {
         pendingRecoveryRef.current = false;
         void recoverSubscriptions();
@@ -730,11 +746,12 @@ function AutoPauseSubscriptions() {
     [],
   );
 
-  const isFocusedRef = useRef(false);
+  const isFocusedRef = useRef(shouldTreatPerpAsFocusedOnMount);
   useListenTabFocusState(ETabRoutes.Perp, (isFocus: boolean) => {
+    const nextFocused = resolvePerpRouteFocused(isFocus);
     const isFocusPrev = isFocusedRef.current;
-    isFocusedRef.current = isFocus;
-    if (isFocusPrev !== isFocus) {
+    isFocusedRef.current = nextFocused;
+    if (isFocusPrev !== nextFocused) {
       void onFocusHandler({ isFocus: isFocusedRef.current });
     }
   });

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -52,6 +52,7 @@ import { ESubscriptionType } from '@onekeyhq/shared/types/hyperliquid/types';
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import { useHandleAppStateActive } from '../../../hooks/useHandleAppStateActive';
 import useListenTabFocusState from '../../../hooks/useListenTabFocusState';
+import { useLocaleVariant } from '../../../hooks/useLocaleVariant';
 import { usePromiseResult } from '../../../hooks/usePromiseResult';
 import { useRouteIsFocused } from '../../../hooks/useRouteIsFocused';
 import { useActiveAccount } from '../../../states/jotai/contexts/accountSelector';
@@ -653,6 +654,39 @@ function useHyperliquidScreenLockHandler() {
   }, [unLock, checkPerpsAccountStatus]);
 }
 
+function useHyperliquidLocaleChangeRecovery() {
+  const localeVariant = useLocaleVariant();
+  const actions = useHyperliquidActions();
+  const isFocusedRef = useRef(false);
+  const pendingRecoveryRef = useRef(false);
+
+  const recoverSubscriptions = useCallback(async () => {
+    await backgroundApiProxy.serviceHyperliquidSubscription.enableSubscriptionsHandler();
+    await backgroundApiProxy.serviceHyperliquidSubscription.resumeSubscriptions();
+    await actions.current.updateSubscriptions();
+    await backgroundApiProxy.serviceHyperliquidSubscription.forceReloadCandlesWebview();
+  }, [actions]);
+
+  useListenTabFocusState(
+    ETabRoutes.Perp,
+    (isFocus: boolean, isHiddenByModal: boolean) => {
+      isFocusedRef.current = isFocus && !isHiddenByModal;
+      if (isFocusedRef.current && pendingRecoveryRef.current) {
+        pendingRecoveryRef.current = false;
+        void recoverSubscriptions();
+      }
+    },
+  );
+
+  useUpdateEffect(() => {
+    if (!isFocusedRef.current) {
+      pendingRecoveryRef.current = true;
+      return;
+    }
+    void recoverSubscriptions();
+  }, [localeVariant, recoverSubscriptions]);
+}
+
 function AutoPauseSubscriptions() {
   const pauseSubscriptionsTimerRef = useRef<
     ReturnType<typeof setTimeout> | undefined
@@ -785,6 +819,7 @@ function PerpsGlobalEffectsView() {
   useHyperliquidSymbolSelect();
   useHyperliquidInstrumentSwitchRequest();
   useHyperliquidScreenLockHandler();
+  useHyperliquidLocaleChangeRecovery();
   useSyncContextOrderBookOptionsToGlobal();
   useTradeRouteViewStateSync();
   usePerpsSharePrompt();

--- a/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
@@ -37,6 +37,7 @@ import {
   usePerpsTokenSearchAliasesAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
 import {
+  type ISpotAssetCtxsMap,
   usePerpTokenSelectorConfigPersistAtom,
   usePerpTokenSelectorTabsAtom,
   useSpotAssetCtxsMapAtom,
@@ -89,6 +90,7 @@ import {
   isPerpTokenSelectorFavoritesTab,
   isPerpTokenSelectorPerpsTab,
   isPerpTokenSelectorSpotTab,
+  shouldRefreshPerpTokenSelectorSortSnapshot,
 } from '../../utils/tokenSelectorTabs';
 
 import { FavoritesEmptyState } from './FavoritesEmptyState';
@@ -197,7 +199,7 @@ function MobileTokenSelectorModal({
 
   // Spot data — try cache first, fallback to refresh if empty
   const [spotPriceMap] = useSpotAssetCtxsMapAtom();
-  const spotPriceMapRef = useRef(spotPriceMap);
+  const spotPriceMapRef = useRef<ISpotAssetCtxsMap>(spotPriceMap);
   spotPriceMapRef.current = spotPriceMap;
   const [spotUniverses, setSpotUniverses] = useState<ISpotUniverse[]>([]);
   const [spotLoading, setSpotLoading] = useState(true);
@@ -352,17 +354,22 @@ function MobileTokenSelectorModal({
     const field = selectorConfig?.field;
     const direction = selectorConfig?.direction;
     const last = lastSortRef.current;
-    const sortChanged = last?.field !== field || last?.direction !== direction;
     // Also refresh when snapshot is empty (first WS data arrival after mount)
     const snapshotEmpty = !ctxSnapshotRef.current?.some(
       (arr) => arr?.length > 0,
     );
-    if (!sortChanged && !snapshotEmpty) {
+    const shouldRefresh = shouldRefreshPerpTokenSelectorSortSnapshot({
+      lastSort: last,
+      field,
+      direction,
+      snapshotEmpty,
+    });
+    if (!shouldRefresh) {
       return;
     }
     lastSortRef.current = { field, direction };
     ctxSnapshotRef.current = assetCtxsByDex;
-    if (sortChanged) {
+    if (last?.field !== field || last?.direction !== direction) {
       scrollListToTop();
     }
   }, [
@@ -370,6 +377,35 @@ function MobileTokenSelectorModal({
     selectorConfig?.field,
     assetCtxsByDex,
     scrollListToTop,
+  ]);
+
+  const [spotPriceSnapshot, setSpotPriceSnapshot] = useState<ISpotAssetCtxsMap>(
+    {},
+  );
+  const spotLastSortRef = useRef<{
+    field?: string;
+    direction?: IPerpTokenSelectorConfig['direction'];
+  } | null>(null);
+  useEffect(() => {
+    const field = selectorConfig?.field;
+    const direction = selectorConfig?.direction;
+    const snapshotEmpty = Object.keys(spotPriceSnapshot).length === 0;
+    const shouldRefresh = shouldRefreshPerpTokenSelectorSortSnapshot({
+      lastSort: spotLastSortRef.current,
+      field,
+      direction,
+      snapshotEmpty,
+    });
+    if (!shouldRefresh) {
+      return;
+    }
+    spotLastSortRef.current = { field, direction };
+    setSpotPriceSnapshot(spotPriceMapRef.current);
+  }, [
+    selectorConfig?.direction,
+    selectorConfig?.field,
+    spotPriceMap,
+    spotPriceSnapshot,
   ]);
 
   // Container-level mark instead of per-row
@@ -549,15 +585,16 @@ function MobileTokenSelectorModal({
     tokenSearchAliases,
   ]);
 
-  // Layer 1b: spot sort — isolated from perp. Reruns only when spot data or
-  // sort config changes. spotPriceMap WS updates never touch the perp list.
+  // Layer 1b: spot sort — isolated from perp. Sorts against a frozen snapshot
+  // so live WS updates refresh row values without reshuffling the list.
   const spotSortedList = useMemo((): ITokenSelectorListItem[] => {
     const perfStartTime = startTokenSelectorPerfMeasure();
     const sortField = selectorConfig?.field ?? '';
     const sortDirection = selectorConfig?.direction ?? 'desc';
+    const snapshot = spotPriceSnapshot;
 
     const mappedEntries = spotUniverses.map((u, index) => {
-      const ctx = spotPriceMap[u.name];
+      const ctx = snapshot[u.name];
       const markPrice = Number(ctx?.markPx || 0);
       const prevDayPx = Number(ctx?.prevDayPx || 0);
       const change24hPercent =
@@ -641,7 +678,7 @@ function MobileTokenSelectorModal({
     return result;
   }, [
     spotUniverses,
-    spotPriceMap,
+    spotPriceSnapshot,
     spotMarketCaps,
     tokenSearchAliases,
     selectorConfig?.field,

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -638,11 +638,12 @@ function PerpTradingForm({
   const handleSpotAvailableTradePress = useCallback(() => {
     if (!spotAvailableTradeUniverse) return;
     void (async () => {
-      await actions.current.switchTradeInstrument({
+      const switched = await actions.current.switchTradeInstrument({
         mode: 'spot',
         coin: spotAvailableTradeUniverse.name,
         spotUniverse: spotAvailableTradeUniverse,
       });
+      if (!switched) return;
       actions.current.updateTradingForm({
         side: 'long',
         size: '',

--- a/packages/kit/src/views/Perp/utils/tokenSelectorTabs.test.ts
+++ b/packages/kit/src/views/Perp/utils/tokenSelectorTabs.test.ts
@@ -236,4 +236,30 @@ describe('tokenSelectorTabs', () => {
       }),
     ).toBe(true);
   });
+
+  it('keeps all-tab instruments visible when sorting unsupported mixed columns', () => {
+    const items = [
+      { id: 'perp-btc', type: 'perp', fundingRate: 0.01 },
+      { id: 'spot-eth', type: 'spot', marketCap: 300 },
+      { id: 'spot-sol', type: 'spot', marketCap: 100 },
+      { id: 'perp-doge', type: 'perp', fundingRate: 0.02 },
+    ];
+
+    expect(
+      sortPerpTokenSelectorItemsBySortValue({
+        items,
+        getValue: (item) =>
+          item.type === 'spot' ? undefined : item.fundingRate,
+        direction: 'desc',
+      }).map((item) => item.id),
+    ).toEqual(['perp-doge', 'perp-btc', 'spot-eth', 'spot-sol']);
+
+    expect(
+      sortPerpTokenSelectorItemsBySortValue({
+        items,
+        getValue: (item) => (item.type === 'perp' ? undefined : item.marketCap),
+        direction: 'desc',
+      }).map((item) => item.id),
+    ).toEqual(['spot-eth', 'spot-sol', 'perp-btc', 'perp-doge']);
+  });
 });

--- a/packages/kit/src/views/Perp/utils/tokenSelectorTabs.test.ts
+++ b/packages/kit/src/views/Perp/utils/tokenSelectorTabs.test.ts
@@ -10,6 +10,7 @@ import {
   isPerpTokenSelectorPerpsTab,
   isPerpTokenSelectorPrimaryTab,
   isPerpTokenSelectorSpotTab,
+  shouldRefreshPerpTokenSelectorSortSnapshot,
   sortPerpTokenSelectorItemsBySortValue,
 } from './tokenSelectorTabs';
 
@@ -206,5 +207,33 @@ describe('tokenSelectorTabs', () => {
       }).map((item) => item.id),
     ).toEqual(['spot-btc', 'spot-eth', 'perp-btc']);
     expect(getValue).toHaveBeenCalledTimes(items.length);
+  });
+  it('only refreshes sort snapshots on sort changes or first data arrival', () => {
+    expect(
+      shouldRefreshPerpTokenSelectorSortSnapshot({
+        lastSort: { field: 'change24hPercent', direction: 'desc' },
+        field: 'change24hPercent',
+        direction: 'desc',
+        snapshotEmpty: false,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldRefreshPerpTokenSelectorSortSnapshot({
+        lastSort: { field: 'change24hPercent', direction: 'desc' },
+        field: 'change24hPercent',
+        direction: 'asc',
+        snapshotEmpty: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldRefreshPerpTokenSelectorSortSnapshot({
+        lastSort: { field: 'change24hPercent', direction: 'desc' },
+        field: 'change24hPercent',
+        direction: 'desc',
+        snapshotEmpty: true,
+      }),
+    ).toBe(true);
   });
 });

--- a/packages/kit/src/views/Perp/utils/tokenSelectorTabs.ts
+++ b/packages/kit/src/views/Perp/utils/tokenSelectorTabs.ts
@@ -4,6 +4,10 @@ import type { IPerpTokenSortDirection } from '@onekeyhq/shared/types/hyperliquid
 type IFixedTabNames = Record<'favorites' | 'all' | 'perps' | 'spot', string>;
 type ITokenSelectorSortValue = string | number | null | undefined;
 type IPerpTokenSelectorPrimaryTabId = 'favorites' | 'perps' | 'spot';
+type IPerpTokenSelectorSortSnapshotKey = {
+  field?: string;
+  direction?: string;
+};
 
 const PRIMARY_TAB_IDS = ['favorites', 'perps', 'spot'] as const;
 const FIXED_TAB_IDS = ['favorites', 'all', 'perps', 'spot'] as const;
@@ -196,6 +200,24 @@ function sortPerpTokenSelectorItemsBySortValue<T>({
     .map(({ item }) => item);
 }
 
+function shouldRefreshPerpTokenSelectorSortSnapshot({
+  lastSort,
+  field,
+  direction,
+  snapshotEmpty,
+}: {
+  lastSort: IPerpTokenSelectorSortSnapshotKey | null;
+  field?: string;
+  direction?: string;
+  snapshotEmpty: boolean;
+}) {
+  return (
+    lastSort?.field !== field ||
+    lastSort?.direction !== direction ||
+    snapshotEmpty
+  );
+}
+
 export {
   buildPrimaryTabs,
   buildPerpTokenSelectorCategoryTabs,
@@ -208,6 +230,7 @@ export {
   isPerpTokenSelectorPerpsTab,
   isPerpTokenSelectorPrimaryTab,
   isPerpTokenSelectorSpotTab,
+  shouldRefreshPerpTokenSelectorSortSnapshot,
   sortPerpTokenSelectorItemsBySortValue,
 };
 

--- a/packages/shared/src/utils/perpsUtils.test.ts
+++ b/packages/shared/src/utils/perpsUtils.test.ts
@@ -23,6 +23,7 @@ import {
   getSpotMarketCapValue,
   getSpotTokenDisplayName,
   getValidPriceDecimals,
+  isPredictionMarketInstrument,
 } from './perpsUtils';
 
 describe('getValidPriceDecimals - HyperLiquid Perp Rules', () => {
@@ -129,6 +130,15 @@ describe('spot token display helpers', () => {
         isSpot: false,
       }),
     ).toBe('NVDA');
+  });
+});
+
+describe('isPredictionMarketInstrument', () => {
+  test('recognizes Hyperliquid HIP-4 prediction market aliases', () => {
+    expect(isPredictionMarketInstrument('#12')).toBe(true);
+    expect(isPredictionMarketInstrument('BTC')).toBe(false);
+    expect(isPredictionMarketInstrument('@107')).toBe(false);
+    expect(isPredictionMarketInstrument(undefined)).toBe(false);
   });
 });
 

--- a/packages/shared/src/utils/perpsUtils.ts
+++ b/packages/shared/src/utils/perpsUtils.ts
@@ -1947,6 +1947,11 @@ function isSpotInstrument(coin?: string | null): boolean {
   return coin.startsWith('@') || coin.includes('/');
 }
 
+function isPredictionMarketInstrument(coin?: string | null): boolean {
+  if (!coin) return false;
+  return coin.startsWith('#');
+}
+
 const SPOT_MIN_VOLUME_STRICT = 10;
 const SPOT_SELECTOR_MIN_VOLUME = 1000;
 
@@ -1996,6 +2001,7 @@ export {
   formatSpotAssetCtx,
   formatSpotPriceEntry,
   isSpotInstrument,
+  isPredictionMarketInstrument,
   getSpotTokenDisplayName,
   formatSpotPairDisplayName,
   getOrderBookSizeDisplaySymbol,
@@ -2052,6 +2058,7 @@ export default {
   formatSpotAssetCtx,
   formatSpotPriceEntry,
   isSpotInstrument,
+  isPredictionMarketInstrument,
   getSpotTokenDisplayName,
   formatSpotPairDisplayName,
   getOrderBookSizeDisplaySymbol,


### PR DESCRIPTION
## Summary
- Fixed a batch of user-verified Perps defects around subscriptions, chart refresh behavior, token switching, token selector sorting, and unsupported history actions.
- Kept the branch rebased on the latest `x` with only the verified commits in the PR history.
- Disabled chart order entry across platforms as part of the verified Perps chart behavior changes.

## Intent & Context
This PR contains the verified Perps Jira batch from the `fix/perps-doing-issues` branch. The batch was handled issue-by-issue, with user verification before pushing each accepted fix. Rejected or skipped local drafts were kept out of the remote PR branch.

Related issues: OK-53743, OK-54112, OK-54151, OK-54164, OK-54167, OK-54168, OK-54244.

## Root Cause
Several independent Perps edge cases were addressed:
- OK-54151: HIP3 open-order subscriptions were not included in the market order display path.
- OK-54244: Chart symbol synchronization and token switching could trigger unnecessary chart churn.
- OK-53743: Extension refresh in expanded or standalone Perps views could lose reliable Perps route focus, leaving the chart iframe unmounted.
- OK-54167: Locale changes could interrupt HyperLiquid subscription recovery on iOS.
- OK-54164: Rapid token switches could leave transient Perps state unsettled and show loading.
- OK-54112: Unsupported prediction-market and spot close history actions were still exposed.
- OK-54168: Mixed selector sorting needed stable handling for unsupported column values.

## Design Decisions
- Preserve each user-verified fix as a separate commit so the batch remains auditable.
- Keep extension refresh recovery scoped to extension expanded or standalone Perps windows.
- Snapshot token selector sort inputs when the sort changes so live WS updates refresh row values without constantly reshuffling lists.
- Keep unsupported mixed-column values visible at the bottom instead of dropping rows.
- Disable TradingView chart order entry across all platforms to match the verified product decision.

## Changes Detail
- Updated HyperLiquid subscription config and recovery behavior for HIP3 orders, locale changes, and rapid token switching.
- Adjusted TradingView/Perps chart integration to reduce duplicate symbol sync and keep extension refresh focused on Perps.
- Hardened Perps token selector sorting helpers and tests for mixed supported/unsupported values.
- Hid unsupported history share/action paths for prediction markets and spot close flows.
- Added focused unit coverage for subscription config, Perps utilities, and selector sorting behavior.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension, Mobile, Desktop, Web
- **Risk Areas**: Perps subscription lifecycle, TradingView chart mounting/synchronization, token selector sorting behavior, and cross-platform chart order-entry behavior.

## Test plan
- [x] User-verified the accepted Jira fixes in the batch before pushing them to the remote branch.
- [x] Rebased `fix/perps-doing-issues` onto latest `origin/x`.
- [x] Ran `npx oxlint packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx packages/kit/src/views/Perp/utils/tokenSelectorTabs.ts packages/kit/src/views/Perp/utils/tokenSelectorTabs.test.ts`.
- [x] Ran `yarn jest packages/kit/src/views/Perp/utils/tokenSelectorTabs.test.ts --runInBand`.