### PR TITLE
docs(defi): clarify sectioned table comments(OK-54066)

### DIFF
--- a/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolCategoryGroup.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolCategoryGroup.tsx
@@ -9,9 +9,9 @@ import {
 import { ProtocolSectionedPositionTable } from './ProtocolSectionedPositionTable';
 import { ProtocolUnifiedTable } from './ProtocolUnifiedTable';
 
-// Unified groups keep the position name in the first table column. Sectioned
-// groups replace that first column with Supplied/Borrowed/Rewards
-// sections, so each position gets its pool name beside the type badge instead.
+// Unified groups use the first column for the pool name. Sectioned groups
+// reserve that column for Supplied/Borrowed/Rewards, so the pool name lives
+// beside the type badge instead.
 
 type IProtocolCategoryGroupProps = {
   group: ILocalizedProtocolCategoryGroup;

--- a/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolSectionedPositionTable.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolSectionedPositionTable.tsx
@@ -15,25 +15,12 @@ import {
   USD_FLEX_WITHOUT_REWARDS,
 } from './ProtocolUnifiedTable';
 
-// Sectioned positions keep Supplied / Borrowed / Rewards as labelled
-// segments so the user can tell what they own vs owe vs earned. Used
-// for lending and for non-lending positions whose payload carries debts
-// (leveraged farming etc.) — the unified table has no Borrowed column,
-// so debt-bearing positions are routed here by buildProtocolCategoryGroups.
+// Sectioned positions preserve Supplied/Borrowed/Rewards as explicit segments.
+// This is used for lending and debt-bearing non-lending positions because the
+// unified table has no Borrowed column.
 //
-// No per-position header: upstream poolName values are almost always
-// redundant with the protocol name (card header) or the category Badge
-// directly above this block, so a header line just stacks the same info
-// twice. Sibling positions in a sectioned group are separated by the
-// parent YStack's gap.
-//
-// The Supplied section's leftmost header is overridden to "Positions" so
-// it parallels ProtocolUnifiedTable's first column — "Supplied" reads as
-// jargon next to plain language like "Borrowed" / "Rewards", and the
-// asset rows below already convey the supplied semantic via the section
-// being grouped with Borrowed / Rewards in the same block. Borrowed and
-// Rewards section titles stay as-is because they are the terms users
-// actually scan for.
+// The Supplied segment uses "Positions" in the first header cell to align with
+// the unified table; Borrowed and Rewards keep their semantic labels.
 
 const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
 


### PR DESCRIPTION
## Summary
- Clarify why sectioned DeFi groups place the pool name beside the type badge.
- Shorten the sectioned table comments so they match the current product behavior.

## Intent & Context
Follow-up to #11546 after it was merged. The product rule is that unified groups use the first table column for pool names, while sectioned groups reserve that column for Supplied/Borrowed/Rewards and show the pool name beside the type badge.

## Design Decisions
Keep this as a comment-only follow-up so the merged DeFi portfolio behavior remains unchanged. The comments are intentionally brief and in English to match repository standards.

## Changes Detail
- `ProtocolCategoryGroup.tsx`: documents the pool-name placement rule for unified vs sectioned groups.
- `ProtocolSectionedPositionTable.tsx`: removes the misleading per-position-header note and keeps only the sectioned table semantics.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Web
- **Risk Areas**: Comment-only change; no runtime behavior changes.

## Test plan
- [x] `git diff --check onekey/x...HEAD`
