### PR TITLE
fix: simplify native max balance toast (OK-54559)

### DIFF
--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -544,6 +544,20 @@ export function useSwapBuildTx() {
         accountId: fromAccountId,
       });
       if (!checkResult.isSufficient) {
+        const reserveAmountMessage = nativeBalanceRequirement.includesFromAmount
+          ? undefined
+          : intl.formatMessage(
+              {
+                id: ETranslations.swap_page_toast_insufficient_balance_content,
+              },
+              {
+                token: checkResult.tokenSymbol,
+                number: numberFormat(
+                  nativeBalanceRequirement.reserveAmount,
+                  formatter,
+                ),
+              },
+            );
         Toast.error({
           title: intl.formatMessage(
             {
@@ -551,15 +565,7 @@ export function useSwapBuildTx() {
             },
             { token: checkResult.tokenSymbol },
           ),
-          message: intl.formatMessage(
-            {
-              id: ETranslations.swap_page_toast_insufficient_balance_content,
-            },
-            {
-              token: checkResult.tokenSymbol,
-              number: numberFormat(checkResult.requiredAmount, formatter),
-            },
-          ),
+          message: reserveAmountMessage,
         });
         return false;
       }

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -544,20 +544,6 @@ export function useSwapBuildTx() {
         accountId: fromAccountId,
       });
       if (!checkResult.isSufficient) {
-        const reserveAmountMessage = nativeBalanceRequirement.includesFromAmount
-          ? undefined
-          : intl.formatMessage(
-              {
-                id: ETranslations.swap_page_toast_insufficient_balance_content,
-              },
-              {
-                token: checkResult.tokenSymbol,
-                number: numberFormat(
-                  nativeBalanceRequirement.reserveAmount,
-                  formatter,
-                ),
-              },
-            );
         Toast.error({
           title: intl.formatMessage(
             {
@@ -565,7 +551,15 @@ export function useSwapBuildTx() {
             },
             { token: checkResult.tokenSymbol },
           ),
-          message: reserveAmountMessage,
+          message: intl.formatMessage(
+            {
+              id: ETranslations.swap_page_toast_insufficient_balance_content,
+            },
+            {
+              token: checkResult.tokenSymbol,
+              number: numberFormat(checkResult.requiredAmount, formatter),
+            },
+          ),
         });
         return false;
       }

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
@@ -110,6 +110,8 @@ describe('getSwapRequiredNativeBalanceAmount', () => {
         decimals: 18,
       },
       amount: '0.000021',
+      reserveAmount: '0.000021',
+      includesFromAmount: false,
     });
   });
 
@@ -124,6 +126,8 @@ describe('getSwapRequiredNativeBalanceAmount', () => {
     ).toEqual({
       token: ethToken,
       amount: '0.100021',
+      reserveAmount: '0.000021',
+      includesFromAmount: true,
     });
   });
 
@@ -161,6 +165,8 @@ describe('getSwapRequiredNativeBalanceAmount', () => {
     ).toEqual({
       token: ethToken,
       amount: '0.120021',
+      reserveAmount: '0.020021',
+      includesFromAmount: true,
     });
   });
 });

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
@@ -110,8 +110,6 @@ describe('getSwapRequiredNativeBalanceAmount', () => {
         decimals: 18,
       },
       amount: '0.000021',
-      reserveAmount: '0.000021',
-      includesFromAmount: false,
     });
   });
 
@@ -126,8 +124,6 @@ describe('getSwapRequiredNativeBalanceAmount', () => {
     ).toEqual({
       token: ethToken,
       amount: '0.100021',
-      reserveAmount: '0.000021',
-      includesFromAmount: true,
     });
   });
 
@@ -165,8 +161,6 @@ describe('getSwapRequiredNativeBalanceAmount', () => {
     ).toEqual({
       token: ethToken,
       amount: '0.120021',
-      reserveAmount: '0.020021',
-      includesFromAmount: true,
     });
   });
 });

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
@@ -43,6 +43,8 @@ type ISwapNativeBalanceRequirementParams = {
 export type ISwapNativeBalanceRequirement = {
   token: ISwapToken;
   amount: string;
+  reserveAmount: string;
+  includesFromAmount: boolean;
 };
 
 function buildNativeTokenFromGasInfo({
@@ -116,12 +118,13 @@ export function getSwapRequiredNativeBalanceAmount({
   }
 
   const fromAmountBN = new BigNumber(fromAmount ?? 0);
-  const shouldAddFromAmount =
+  const shouldAddFromAmount = Boolean(
     fromToken?.isNative &&
     fromToken.networkId === nativeToken.networkId &&
     !fromAmountBN.isNaN() &&
     fromAmountBN.isFinite() &&
-    fromAmountBN.gt(0);
+    fromAmountBN.gt(0),
+  );
   const otherNativeFeeAmount = (otherFeeInfos ?? []).reduce((acc, item) => {
     if (
       !item.token?.isNative ||
@@ -138,9 +141,10 @@ export function getSwapRequiredNativeBalanceAmount({
     return acc.plus(amountBN);
   }, new BigNumber(0));
 
+  const reserveAmount = networkFeeAmount.plus(otherNativeFeeAmount);
   const requiredAmount = shouldAddFromAmount
-    ? networkFeeAmount.plus(fromAmountBN).plus(otherNativeFeeAmount)
-    : networkFeeAmount.plus(otherNativeFeeAmount);
+    ? reserveAmount.plus(fromAmountBN)
+    : reserveAmount;
 
   if (requiredAmount.lte(0)) {
     return undefined;
@@ -149,6 +153,8 @@ export function getSwapRequiredNativeBalanceAmount({
   return {
     token: nativeToken,
     amount: requiredAmount.toFixed(),
+    reserveAmount: reserveAmount.toFixed(),
+    includesFromAmount: shouldAddFromAmount,
   };
 }
 

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
@@ -43,8 +43,6 @@ type ISwapNativeBalanceRequirementParams = {
 export type ISwapNativeBalanceRequirement = {
   token: ISwapToken;
   amount: string;
-  reserveAmount: string;
-  includesFromAmount: boolean;
 };
 
 function buildNativeTokenFromGasInfo({
@@ -118,13 +116,12 @@ export function getSwapRequiredNativeBalanceAmount({
   }
 
   const fromAmountBN = new BigNumber(fromAmount ?? 0);
-  const shouldAddFromAmount = Boolean(
+  const shouldAddFromAmount =
     fromToken?.isNative &&
     fromToken.networkId === nativeToken.networkId &&
     !fromAmountBN.isNaN() &&
     fromAmountBN.isFinite() &&
-    fromAmountBN.gt(0),
-  );
+    fromAmountBN.gt(0);
   const otherNativeFeeAmount = (otherFeeInfos ?? []).reduce((acc, item) => {
     if (
       !item.token?.isNative ||
@@ -141,10 +138,9 @@ export function getSwapRequiredNativeBalanceAmount({
     return acc.plus(amountBN);
   }, new BigNumber(0));
 
-  const reserveAmount = networkFeeAmount.plus(otherNativeFeeAmount);
   const requiredAmount = shouldAddFromAmount
-    ? reserveAmount.plus(fromAmountBN)
-    : reserveAmount;
+    ? networkFeeAmount.plus(fromAmountBN).plus(otherNativeFeeAmount)
+    : networkFeeAmount.plus(otherNativeFeeAmount);
 
   if (requiredAmount.lte(0)) {
     return undefined;
@@ -153,8 +149,6 @@ export function getSwapRequiredNativeBalanceAmount({
   return {
     token: nativeToken,
     amount: requiredAmount.toFixed(),
-    reserveAmount: reserveAmount.toFixed(),
-    includesFromAmount: shouldAddFromAmount,
   };
 }
 


### PR DESCRIPTION
## Summary
- Separate native balance requirement into total required amount and reserve-only amount.
- Suppress the reserve amount toast detail when the swap from-token itself is native.
- Keep reserve amount details for non-native swaps that still need native gas.

## Issues
- Fixes OK-54559

## Intent & Context
OK-54559 reports that for networks without reserved gas config, such as SUI, tapping Max on a native-token swap can show an abnormal insufficient-balance error that includes the current account balance / amount detail. The expected behavior is to only tell the user that the native balance is insufficient.

## Root Cause
The final native-balance check reused one required amount for both validation and user-facing toast detail. For native-token swaps, that required amount is `fromAmount + gas + other native fees`. When the user taps Max and there is no reserved gas config, `fromAmount` is close to the account balance, so the toast detail displays a misleading large amount instead of just the insufficient-balance title.

## Design Decisions
- Keep the validation strict: native-token swaps still check `fromAmount + gas + other native fees` before signing/sending.
- Split display semantics from validation semantics by returning `reserveAmount` and `includesFromAmount` from `getSwapRequiredNativeBalanceAmount`.
- Only hide the reserve detail when `fromAmount` is included, because showing the full send amount as a "reserved for network fee" value is misleading.

## Changes Detail
- `packages/kit/src/views/Swap/utils/swapBalanceUtils.ts`: exposes reserve-only amount and whether the validation amount includes the sell amount.
- `packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts`: avoids showing the reserve amount detail for native from-token insufficient-balance cases.
- `packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts`: covers the native and non-native requirement split.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile / Desktop / Web / Extension
- **Risk Areas**: Swap final balance-check toast copy only; transaction validation amount is unchanged.

## Test plan
- [x] `yarn jest packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts --runInBand`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Swap/utils/swapBalanceUtils.ts packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `git diff --check`
