### PR TITLE
feat: support speed config preset fields

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.test.ts
@@ -39,6 +39,19 @@ function buildSpeedConfigWithMarketPresetConfig(
   return speedConfig;
 }
 
+function buildSpeedConfigWithPresetConfig(
+  preset: ISwapProSpeedConfig['preset'],
+): ISwapProSpeedConfig {
+  return {
+    slippage: 0.5,
+    spenderAddress: '',
+    defaultTokens: [],
+    defaultLimitTokens: [],
+    swapMevNetConfig: [],
+    preset,
+  };
+}
+
 describe('marketPresetSettings', () => {
   it('returns hardcoded dashboard presets from the Promise adapter', async () => {
     const config = await fetchMarketPresetConfig({
@@ -183,6 +196,109 @@ describe('marketPresetSettings', () => {
     expect(
       getMarketPresetPriorityFeeOverride(settings, config),
     ).toBeUndefined();
+  });
+
+  it('uses speed-config preset fields for enablement, priority fee, and range', async () => {
+    const config = await fetchMarketPresetConfig({
+      networkId: presetNetworksMap.base.id,
+      speedConfig: buildSpeedConfigWithPresetConfig({
+        isEnabled: true,
+        priorityFee: true,
+        min: 0,
+        max: 100,
+      }),
+    });
+
+    expect(config?.enabled).toBe(true);
+    expect(config?.priorityFee.editable).toBe(true);
+    expect(config?.priorityFee.customRange).toEqual({
+      min: '0',
+      max: '100',
+    });
+    expect(getMarketPresetPriorityFeeCustomPlaceholder(config)).toBe('0 ~ 100');
+  });
+
+  it('lets speed-config preset disable Market presets before local fallback', async () => {
+    const config = await fetchMarketPresetConfig({
+      networkId: presetNetworksMap.eth.id,
+      speedConfig: buildSpeedConfigWithPresetConfig({
+        isEnabled: false,
+        priorityFee: true,
+        min: 0,
+        max: 100,
+      }),
+    });
+
+    expect(config?.enabled).toBe(false);
+    expect(config?.priorityFee.editable).toBe(false);
+    expect(
+      getMarketPresetItem({
+        config,
+        presetKey: EMarketPresetKey.P1,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('uses speed-config preset priorityFee false as readonly priority fee', async () => {
+    const config = await fetchMarketPresetConfig({
+      networkId: presetNetworksMap.eth.id,
+      speedConfig: buildSpeedConfigWithPresetConfig({
+        isEnabled: true,
+        priorityFee: false,
+        min: 0,
+        max: 100,
+      }),
+    });
+
+    expect(config?.enabled).toBe(true);
+    expect(config?.priorityFee.editable).toBe(false);
+    expect(config?.priorityFee.supportedTypes).toEqual([
+      EMarketPresetPriorityFeeType.AUTO,
+    ]);
+
+    const settings = resolveMarketPresetDirectionSettings({
+      config,
+      presetKey: EMarketPresetKey.P1,
+      tradeSide: EMarketPresetTradeSide.BUY,
+      savedSettings: {
+        presets: {
+          [EMarketPresetKey.P1]: {
+            [EMarketPresetTradeSide.BUY]: {
+              slippage: {
+                key: ESwapSlippageSegmentKey.AUTO,
+              },
+              priorityFee: {
+                type: EMarketPresetPriorityFeeType.CUSTOM,
+                customValue: '1',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(settings.priorityFee.type).toBe(EMarketPresetPriorityFeeType.AUTO);
+  });
+
+  it('allows speed-config preset to enable fallback-disabled networks explicitly', async () => {
+    const config = await fetchMarketPresetConfig({
+      networkId: presetNetworksMap.sui.id,
+      speedConfig: buildSpeedConfigWithPresetConfig({
+        isEnabled: true,
+        priorityFee: false,
+        min: 0,
+        max: 100,
+      }),
+    });
+
+    expect(config?.enabled).toBe(true);
+    expect(config?.priorityFee.editable).toBe(false);
+    expect(
+      getMarketPresetItem({
+        config,
+        presetKey: EMarketPresetKey.P1,
+      })?.key,
+    ).toBe(EMarketPresetKey.P1);
   });
 
   it('uses configured priority fee range for placeholder, validation, and override', async () => {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.test.ts
@@ -39,19 +39,6 @@ function buildSpeedConfigWithMarketPresetConfig(
   return speedConfig;
 }
 
-function buildSpeedConfigWithPresetConfig(
-  preset: ISwapProSpeedConfig['preset'],
-): ISwapProSpeedConfig {
-  return {
-    slippage: 0.5,
-    spenderAddress: '',
-    defaultTokens: [],
-    defaultLimitTokens: [],
-    swapMevNetConfig: [],
-    preset,
-  };
-}
-
 describe('marketPresetSettings', () => {
   it('returns hardcoded dashboard presets from the Promise adapter', async () => {
     const config = await fetchMarketPresetConfig({
@@ -196,109 +183,6 @@ describe('marketPresetSettings', () => {
     expect(
       getMarketPresetPriorityFeeOverride(settings, config),
     ).toBeUndefined();
-  });
-
-  it('uses speed-config preset fields for enablement, priority fee, and range', async () => {
-    const config = await fetchMarketPresetConfig({
-      networkId: presetNetworksMap.base.id,
-      speedConfig: buildSpeedConfigWithPresetConfig({
-        isEnabled: true,
-        priorityFee: true,
-        min: 0,
-        max: 100,
-      }),
-    });
-
-    expect(config?.enabled).toBe(true);
-    expect(config?.priorityFee.editable).toBe(true);
-    expect(config?.priorityFee.customRange).toEqual({
-      min: '0',
-      max: '100',
-    });
-    expect(getMarketPresetPriorityFeeCustomPlaceholder(config)).toBe('0 ~ 100');
-  });
-
-  it('lets speed-config preset disable Market presets before local fallback', async () => {
-    const config = await fetchMarketPresetConfig({
-      networkId: presetNetworksMap.eth.id,
-      speedConfig: buildSpeedConfigWithPresetConfig({
-        isEnabled: false,
-        priorityFee: true,
-        min: 0,
-        max: 100,
-      }),
-    });
-
-    expect(config?.enabled).toBe(false);
-    expect(config?.priorityFee.editable).toBe(false);
-    expect(
-      getMarketPresetItem({
-        config,
-        presetKey: EMarketPresetKey.P1,
-      }),
-    ).toBeUndefined();
-  });
-
-  it('uses speed-config preset priorityFee false as readonly priority fee', async () => {
-    const config = await fetchMarketPresetConfig({
-      networkId: presetNetworksMap.eth.id,
-      speedConfig: buildSpeedConfigWithPresetConfig({
-        isEnabled: true,
-        priorityFee: false,
-        min: 0,
-        max: 100,
-      }),
-    });
-
-    expect(config?.enabled).toBe(true);
-    expect(config?.priorityFee.editable).toBe(false);
-    expect(config?.priorityFee.supportedTypes).toEqual([
-      EMarketPresetPriorityFeeType.AUTO,
-    ]);
-
-    const settings = resolveMarketPresetDirectionSettings({
-      config,
-      presetKey: EMarketPresetKey.P1,
-      tradeSide: EMarketPresetTradeSide.BUY,
-      savedSettings: {
-        presets: {
-          [EMarketPresetKey.P1]: {
-            [EMarketPresetTradeSide.BUY]: {
-              slippage: {
-                key: ESwapSlippageSegmentKey.AUTO,
-              },
-              priorityFee: {
-                type: EMarketPresetPriorityFeeType.CUSTOM,
-                customValue: '1',
-              },
-            },
-          },
-        },
-      },
-    });
-
-    expect(settings.priorityFee.type).toBe(EMarketPresetPriorityFeeType.AUTO);
-  });
-
-  it('allows speed-config preset to enable fallback-disabled networks explicitly', async () => {
-    const config = await fetchMarketPresetConfig({
-      networkId: presetNetworksMap.sui.id,
-      speedConfig: buildSpeedConfigWithPresetConfig({
-        isEnabled: true,
-        priorityFee: false,
-        min: 0,
-        max: 100,
-      }),
-    });
-
-    expect(config?.enabled).toBe(true);
-    expect(config?.priorityFee.editable).toBe(false);
-    expect(
-      getMarketPresetItem({
-        config,
-        presetKey: EMarketPresetKey.P1,
-      })?.key,
-    ).toBe(EMarketPresetKey.P1);
   });
 
   it('uses configured priority fee range for placeholder, validation, and override', async () => {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.ts
@@ -103,6 +103,7 @@ export type IMarketPresetConfig = {
 
 type IMarketPresetRemoteConfig = {
   enabled?: boolean;
+  priorityFeeEditable?: boolean;
   customPriorityFeeRange?: IMarketPresetCustomPriorityFeeRange;
 };
 
@@ -271,18 +272,24 @@ function buildPresetConfig({
 function getMarketPresetRemoteConfig(
   speedConfig?: ISwapProSpeedConfig,
 ): IMarketPresetRemoteConfig | undefined {
-  const nestedConfig = (speedConfig as IMarketPresetSpeedConfig | undefined)
+  const legacyConfig = (speedConfig as IMarketPresetSpeedConfig | undefined)
     ?.marketPresetConfig;
-  const enabled = nestedConfig?.enabled;
+  const presetConfig = speedConfig?.preset;
+  const enabled = presetConfig?.isEnabled ?? legacyConfig?.enabled;
+  const priorityFeeEditable =
+    presetConfig?.priorityFee ?? legacyConfig?.priorityFeeEditable;
   const customPriorityFeeMin =
-    nestedConfig?.customPriorityFeeRange?.min ??
-    nestedConfig?.customPriorityFeeMin;
+    presetConfig?.min ??
+    legacyConfig?.customPriorityFeeRange?.min ??
+    legacyConfig?.customPriorityFeeMin;
   const customPriorityFeeMax =
-    nestedConfig?.customPriorityFeeRange?.max ??
-    nestedConfig?.customPriorityFeeMax;
+    presetConfig?.max ??
+    legacyConfig?.customPriorityFeeRange?.max ??
+    legacyConfig?.customPriorityFeeMax;
 
   if (
     enabled === undefined &&
+    priorityFeeEditable === undefined &&
     customPriorityFeeMin === undefined &&
     customPriorityFeeMax === undefined
   ) {
@@ -291,6 +298,7 @@ function getMarketPresetRemoteConfig(
 
   return {
     enabled,
+    priorityFeeEditable,
     customPriorityFeeRange: {
       min: customPriorityFeeMin,
       max: customPriorityFeeMax,
@@ -306,6 +314,8 @@ function buildPresetConfigFromRemote({
   remoteConfig: IMarketPresetRemoteConfig;
 }): IMarketPresetConfig | undefined {
   const customRange = remoteConfig.customPriorityFeeRange;
+  const resolvePriorityFeeEditable = (editable: boolean) =>
+    remoteConfig.priorityFeeEditable ?? editable;
 
   if (
     remoteConfig.enabled === false ||
@@ -324,7 +334,8 @@ function buildPresetConfigFromRemote({
   if (MARKET_PRESET_PRIORITY_READONLY_NETWORK_IDS.has(networkId)) {
     return buildPresetConfig({
       networkId,
-      priorityFeeEditable: false,
+      priorityFeeEditable: resolvePriorityFeeEditable(false),
+      customUnit: networkId.startsWith('evm--') ? 'Gwei' : undefined,
       customRange,
     });
   }
@@ -336,7 +347,7 @@ function buildPresetConfigFromRemote({
   ) {
     return buildPresetConfig({
       networkId,
-      priorityFeeEditable: true,
+      priorityFeeEditable: resolvePriorityFeeEditable(true),
       customUnit: 'Gwei',
       customRange,
     });
@@ -345,7 +356,7 @@ function buildPresetConfigFromRemote({
   if (MARKET_PRESET_SOL_NETWORK_IDS.has(networkId)) {
     return buildPresetConfig({
       networkId,
-      priorityFeeEditable: true,
+      priorityFeeEditable: resolvePriorityFeeEditable(true),
       priorityFeeSupportedTypes: [
         EMarketPresetPriorityFeeType.MARKET,
         EMarketPresetPriorityFeeType.CUSTOM,

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -1066,12 +1066,20 @@ export interface IFetchLimitOrderRes {
   };
 }
 
+export type ISwapProPresetConfig = {
+  isEnabled?: boolean;
+  priorityFee?: boolean;
+  min?: string | number;
+  max?: string | number;
+};
+
 export interface ISwapProSpeedConfig {
   slippage: number;
   spenderAddress: string;
   defaultTokens: ISwapTokenBase[];
   defaultLimitTokens: ISwapTokenBase[];
   swapMevNetConfig: string[];
+  preset?: ISwapProPresetConfig;
 }
 export interface ISpeedSwapConfig {
   provider: string;


### PR DESCRIPTION
## Summary
- Add frontend typing for the new `swap/v1/speed-config` `preset` config block.
- Wire `preset.isEnabled`, `preset.priorityFee`, `preset.min`, and `preset.max` into the existing Market preset adapter.
- Keep backward compatibility with the previous `marketPresetConfig` shape and cover the new server-driven config paths with focused tests.

## Intent & Context
The speed-config API now returns a `preset` block for Market preset configuration. This PR connects those server-provided fields to the previously reserved Market preset entry so the server can control preset enablement, priority fee editability, and custom priority fee range.

## Design Decisions
- Treat `speedConfig.preset` as the preferred contract while preserving the older local `marketPresetConfig` bridge.
- Map `isEnabled` to Market preset enablement and keep explicit disablement ahead of local fallback.
- Map `priorityFee` to priority fee editability so the server can make priority fee readonly without disabling preset selection.
- Reuse existing range normalization so numeric `min` / `max` values and legacy string ranges share the same validation path.

## Changes Detail
- `packages/shared/types/swap/types.ts`: add `ISwapProPresetConfig` and expose `preset` on `ISwapProSpeedConfig`.
- `marketPresetSettings.ts`: parse new `preset` fields, keep legacy `marketPresetConfig`, and apply remote priority fee editability by network.
- `marketPresetSettings.test.ts`: cover new enable/disable, readonly priority fee, range mapping, and explicit fallback-disabled network enablement cases.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile / Desktop / Web / Extension
- **Risk Areas**: Market preset config parsing and priority fee option availability.

## Test plan
- [x] `yarn jest packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.test.ts --runInBand`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/shared/types/swap/types.ts packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.ts packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketPresetSettings.test.ts`
- [x] `git diff --check`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`