### PR TITLE
fix: stabilize Android network selector initial scroll (OK-54208)

### DIFF
--- a/packages/kit/src/views/ChainSelector/components/EditableChainSelector/ChainSelectorContent.tsx
+++ b/packages/kit/src/views/ChainSelector/components/EditableChainSelector/ChainSelectorContent.tsx
@@ -2,6 +2,7 @@ import type { Dispatch, SetStateAction } from 'react';
 import {
   useCallback,
   useContext,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -44,6 +45,12 @@ import type {
 // below for why we use spread-cast instead of naming the prop directly.
 const flashListOverrideProps = {
   overrideProps: { initialDrawBatchSize: 30 },
+};
+
+const androidFlashListScrollProps = {
+  maintainVisibleContentPosition: {
+    disabled: true,
+  },
 };
 
 const ListEmptyComponent = () => {
@@ -157,6 +164,7 @@ export const EditableChainSelectorContent = ({
   );
   const listRef = useRef<ISectionListRef<any> | null>(null);
   const hasRenderedSectionListRef = useRef(false);
+  const hasUserScrolledRef = useRef(false);
 
   useLayoutEffect(() => {
     setTempFrequentlyUsedItems(frequentlyUsedItems);
@@ -343,6 +351,52 @@ export const EditableChainSelectorContent = ({
     return idx + (initialScrollIndex.itemIndex ?? 0);
   }, [sections, initialScrollIndex]);
 
+  useEffect(() => {
+    if (!platformEnv.isNativeAndroid) {
+      return undefined;
+    }
+    if (
+      !shouldRenderList ||
+      searchText.trim() ||
+      initialScrollFlatIndex === undefined ||
+      hasUserScrolledRef.current
+    ) {
+      return undefined;
+    }
+
+    // FlashList v2 may re-anchor Android scroll position after async data
+    // replaces the initial list. Re-apply the selected-network position once
+    // the committed section data has settled, unless the user already scrolled.
+    const scrollToSelectedNetwork = () => {
+      if (hasUserScrolledRef.current) {
+        return;
+      }
+      listRef.current?.scrollToIndex?.({
+        index: initialScrollFlatIndex,
+        animated: false,
+      });
+    };
+    const timerIds = [
+      setTimeout(scrollToSelectedNetwork, 0),
+      setTimeout(scrollToSelectedNetwork, 120),
+    ];
+
+    return () => {
+      timerIds.forEach(clearTimeout);
+    };
+  }, [
+    initialScrollFlatIndex,
+    networkId,
+    searchText,
+    sections,
+    shouldRenderList,
+    zeroValue,
+  ]);
+
+  const handleScrollBeginDrag = useCallback(() => {
+    hasUserScrolledRef.current = true;
+  }, []);
+
   const context = useMemo<IEditableChainSelectorContext>(
     () => ({
       walletId: walletId ?? '',
@@ -471,8 +525,12 @@ export const EditableChainSelectorContent = ({
               // ISectionListProps (the web variant maps to FlatList),
               // so we funnel it through as any.
               {...(flashListOverrideProps as Record<string, unknown>)}
+              {...(platformEnv.isNativeAndroid
+                ? (androidFlashListScrollProps as Record<string, unknown>)
+                : {})}
               ListHeaderComponent={<ListHeaderComponent />}
               renderSectionHeader={renderSectionHeader}
+              onScrollBeginDrag={handleScrollBeginDrag}
               contentContainerStyle={{ paddingBottom: bottom || 8 }}
             />
           ) : null}

--- a/packages/kit/src/views/ChainSelector/components/EditableChainSelector/ChainSelectorContent.tsx
+++ b/packages/kit/src/views/ChainSelector/components/EditableChainSelector/ChainSelectorContent.tsx
@@ -2,7 +2,6 @@ import type { Dispatch, SetStateAction } from 'react';
 import {
   useCallback,
   useContext,
-  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -27,6 +26,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EAppSWRCacheScopes } from '@onekeyhq/shared/src/storage/syncStorageKeys';
 import type { IServerNetwork } from '@onekeyhq/shared/types';
 
+import { useAndroidFlashListInitialScrollFix } from '../../hooks/useAndroidFlashListInitialScrollFix';
 import { useFuseSearch } from '../../hooks/useFuseSearch';
 import ChainSelectorTooltip from '../ChainSelectorTooltip';
 import DottedLine from '../DottedLine';
@@ -45,12 +45,6 @@ import type {
 // below for why we use spread-cast instead of naming the prop directly.
 const flashListOverrideProps = {
   overrideProps: { initialDrawBatchSize: 30 },
-};
-
-const androidFlashListScrollProps = {
-  maintainVisibleContentPosition: {
-    disabled: true,
-  },
 };
 
 const ListEmptyComponent = () => {
@@ -164,7 +158,6 @@ export const EditableChainSelectorContent = ({
   );
   const listRef = useRef<ISectionListRef<any> | null>(null);
   const hasRenderedSectionListRef = useRef(false);
-  const hasUserScrolledRef = useRef(false);
 
   useLayoutEffect(() => {
     setTempFrequentlyUsedItems(frequentlyUsedItems);
@@ -351,51 +344,13 @@ export const EditableChainSelectorContent = ({
     return idx + (initialScrollIndex.itemIndex ?? 0);
   }, [sections, initialScrollIndex]);
 
-  useEffect(() => {
-    if (!platformEnv.isNativeAndroid) {
-      return undefined;
-    }
-    if (
-      !shouldRenderList ||
-      searchText.trim() ||
-      initialScrollFlatIndex === undefined ||
-      hasUserScrolledRef.current
-    ) {
-      return undefined;
-    }
-
-    // FlashList v2 may re-anchor Android scroll position after async data
-    // replaces the initial list. Re-apply the selected-network position once
-    // the committed section data has settled, unless the user already scrolled.
-    const scrollToSelectedNetwork = () => {
-      if (hasUserScrolledRef.current) {
-        return;
-      }
-      listRef.current?.scrollToIndex?.({
-        index: initialScrollFlatIndex,
-        animated: false,
-      });
-    };
-    const timerIds = [
-      setTimeout(scrollToSelectedNetwork, 0),
-      setTimeout(scrollToSelectedNetwork, 120),
-    ];
-
-    return () => {
-      timerIds.forEach(clearTimeout);
-    };
-  }, [
-    initialScrollFlatIndex,
-    networkId,
-    searchText,
-    sections,
-    shouldRenderList,
-    zeroValue,
-  ]);
-
-  const handleScrollBeginDrag = useCallback(() => {
-    hasUserScrolledRef.current = true;
-  }, []);
+  const { scrollProps: androidScrollProps, onScrollBeginDrag } =
+    useAndroidFlashListInitialScrollFix({
+      listRef,
+      initialIndex: initialScrollFlatIndex,
+      enabled: shouldRenderList && !searchText.trim(),
+      contentKey: sections,
+    });
 
   const context = useMemo<IEditableChainSelectorContext>(
     () => ({
@@ -525,12 +480,10 @@ export const EditableChainSelectorContent = ({
               // ISectionListProps (the web variant maps to FlatList),
               // so we funnel it through as any.
               {...(flashListOverrideProps as Record<string, unknown>)}
-              {...(platformEnv.isNativeAndroid
-                ? (androidFlashListScrollProps as Record<string, unknown>)
-                : {})}
+              {...androidScrollProps}
               ListHeaderComponent={<ListHeaderComponent />}
               renderSectionHeader={renderSectionHeader}
-              onScrollBeginDrag={handleScrollBeginDrag}
+              onScrollBeginDrag={onScrollBeginDrag}
               contentContainerStyle={{ paddingBottom: bottom || 8 }}
             />
           ) : null}

--- a/packages/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorSectionList.tsx
+++ b/packages/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorSectionList.tsx
@@ -40,6 +40,12 @@ import type {
   IServerNetworkMatch,
 } from '../../types';
 
+const androidFlashListScrollProps = {
+  maintainVisibleContentPosition: {
+    disabled: true,
+  },
+};
+
 const ListEmptyComponent = () => {
   const intl = useIntl();
   return (
@@ -59,6 +65,7 @@ type IChainSelectorSectionListContentProps = {
   recentNetworksEnabled?: boolean;
   networks: IServerNetworkMatch[];
   listRef: React.RefObject<ISortableSectionListRef<any>>;
+  onScrollBeginDrag?: () => void;
   accountNetworkValues?: Record<string, string>;
   accountNetworkValueCurrency?: string;
   hideLowValueNetworkValue?: boolean;
@@ -70,6 +77,7 @@ const ChainSelectorSectionListContent = ({
   networkId,
   initialScrollIndex,
   listRef,
+  onScrollBeginDrag,
   accountNetworkValues,
   accountNetworkValueCurrency,
   hideLowValueNetworkValue,
@@ -106,6 +114,10 @@ const ChainSelectorSectionListContent = ({
       keyExtractor={(item) => (item as IServerNetworkMatch).id}
       renderSectionHeader={renderSectionHeader}
       initialScrollIndex={initialScrollIndex}
+      {...(platformEnv.isNativeAndroid
+        ? (androidFlashListScrollProps as Record<string, unknown>)
+        : {})}
+      onScrollBeginDrag={onScrollBeginDrag}
       renderItem={({
         item,
         section,
@@ -233,6 +245,7 @@ export const ChainSelectorSectionList: FC<IChainSelectorSectionListProps> = ({
   const listRef = useRef<ISortableSectionListRef<any> | null>(null);
   const [isTyping, setIsTyping] = useState(false);
   const typingTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const hasUserScrolledRef = useRef(false);
 
   const onChangeText = useCallback((value: string) => {
     clearTimeout(typingTimerRef.current);
@@ -416,6 +429,10 @@ export const ChainSelectorSectionList: FC<IChainSelectorSectionListProps> = ({
     }
   }, [initialScrollIndex, layoutList]);
 
+  const handleScrollBeginDrag = useCallback(() => {
+    hasUserScrolledRef.current = true;
+  }, []);
+
   const renderSections = useCallback(
     () =>
       sections.length ? (
@@ -427,6 +444,7 @@ export const ChainSelectorSectionList: FC<IChainSelectorSectionListProps> = ({
           initialScrollIndex={initialScrollIndex?.initialScrollIndexNumber ?? 0}
           recentNetworksEnabled={recentNetworksEnabled}
           listRef={listRef as any}
+          onScrollBeginDrag={handleScrollBeginDrag}
           accountNetworkValues={accountNetworkValues}
           accountNetworkValueCurrency={accountNetworkValueCurrency}
           hideLowValueNetworkValue={hideLowValueNetworkValue}
@@ -444,6 +462,7 @@ export const ChainSelectorSectionList: FC<IChainSelectorSectionListProps> = ({
       accountNetworkValues,
       accountNetworkValueCurrency,
       hideLowValueNetworkValue,
+      handleScrollBeginDrag,
     ],
   );
 
@@ -460,6 +479,45 @@ export const ChainSelectorSectionList: FC<IChainSelectorSectionListProps> = ({
       ) : null,
     [],
   );
+
+  useEffect(() => {
+    if (!platformEnv.isNativeAndroid) {
+      return undefined;
+    }
+    if (
+      loading ||
+      text.trim() ||
+      sections.length === 0 ||
+      initialScrollIndex?.initialScrollIndexNumber === undefined ||
+      hasUserScrolledRef.current
+    ) {
+      return undefined;
+    }
+
+    const scrollToSelectedNetwork = () => {
+      if (hasUserScrolledRef.current) {
+        return;
+      }
+      listRef.current?.scrollToIndex?.({
+        index: initialScrollIndex.initialScrollIndexNumber,
+        animated: false,
+      });
+    };
+    const timerIds = [
+      setTimeout(scrollToSelectedNetwork, 0),
+      setTimeout(scrollToSelectedNetwork, 120),
+    ];
+
+    return () => {
+      timerIds.forEach(clearTimeout);
+    };
+  }, [
+    initialScrollIndex?.initialScrollIndexNumber,
+    loading,
+    networkId,
+    sections,
+    text,
+  ]);
 
   return (
     <Stack flex={1}>

--- a/packages/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorSectionList.tsx
+++ b/packages/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorSectionList.tsx
@@ -31,6 +31,7 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EAppSWRCacheScopes } from '@onekeyhq/shared/src/storage/syncStorageKeys';
 
+import { useAndroidFlashListInitialScrollFix } from '../../hooks/useAndroidFlashListInitialScrollFix';
 import { usePureChainSelectorSections } from '../../hooks/usePureChainSelectorSections';
 import { CELL_HEIGHT } from '../../types';
 import RecentNetworks from '../RecentNetworks';
@@ -39,12 +40,6 @@ import type {
   IPureChainSelectorSectionListItem,
   IServerNetworkMatch,
 } from '../../types';
-
-const androidFlashListScrollProps = {
-  maintainVisibleContentPosition: {
-    disabled: true,
-  },
-};
 
 const ListEmptyComponent = () => {
   const intl = useIntl();
@@ -66,6 +61,7 @@ type IChainSelectorSectionListContentProps = {
   networks: IServerNetworkMatch[];
   listRef: React.RefObject<ISortableSectionListRef<any>>;
   onScrollBeginDrag?: () => void;
+  androidScrollProps?: Record<string, unknown>;
   accountNetworkValues?: Record<string, string>;
   accountNetworkValueCurrency?: string;
   hideLowValueNetworkValue?: boolean;
@@ -78,6 +74,7 @@ const ChainSelectorSectionListContent = ({
   initialScrollIndex,
   listRef,
   onScrollBeginDrag,
+  androidScrollProps,
   accountNetworkValues,
   accountNetworkValueCurrency,
   hideLowValueNetworkValue,
@@ -114,9 +111,7 @@ const ChainSelectorSectionListContent = ({
       keyExtractor={(item) => (item as IServerNetworkMatch).id}
       renderSectionHeader={renderSectionHeader}
       initialScrollIndex={initialScrollIndex}
-      {...(platformEnv.isNativeAndroid
-        ? (androidFlashListScrollProps as Record<string, unknown>)
-        : {})}
+      {...androidScrollProps}
       onScrollBeginDrag={onScrollBeginDrag}
       renderItem={({
         item,
@@ -245,7 +240,6 @@ export const ChainSelectorSectionList: FC<IChainSelectorSectionListProps> = ({
   const listRef = useRef<ISortableSectionListRef<any> | null>(null);
   const [isTyping, setIsTyping] = useState(false);
   const typingTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const hasUserScrolledRef = useRef(false);
 
   const onChangeText = useCallback((value: string) => {
     clearTimeout(typingTimerRef.current);
@@ -429,9 +423,17 @@ export const ChainSelectorSectionList: FC<IChainSelectorSectionListProps> = ({
     }
   }, [initialScrollIndex, layoutList]);
 
-  const handleScrollBeginDrag = useCallback(() => {
-    hasUserScrolledRef.current = true;
-  }, []);
+  const loading = useMemo(() => {
+    return platformEnv.isNative ? isPending || isTyping : isPending;
+  }, [isPending, isTyping]);
+
+  const { scrollProps: androidScrollProps, onScrollBeginDrag } =
+    useAndroidFlashListInitialScrollFix({
+      listRef,
+      initialIndex: initialScrollIndex?.initialScrollIndexNumber,
+      enabled: !loading && !text.trim() && sections.length > 0,
+      contentKey: sections,
+    });
 
   const renderSections = useCallback(
     () =>
@@ -444,7 +446,8 @@ export const ChainSelectorSectionList: FC<IChainSelectorSectionListProps> = ({
           initialScrollIndex={initialScrollIndex?.initialScrollIndexNumber ?? 0}
           recentNetworksEnabled={recentNetworksEnabled}
           listRef={listRef as any}
-          onScrollBeginDrag={handleScrollBeginDrag}
+          onScrollBeginDrag={onScrollBeginDrag}
+          androidScrollProps={androidScrollProps}
           accountNetworkValues={accountNetworkValues}
           accountNetworkValueCurrency={accountNetworkValueCurrency}
           hideLowValueNetworkValue={hideLowValueNetworkValue}
@@ -462,13 +465,10 @@ export const ChainSelectorSectionList: FC<IChainSelectorSectionListProps> = ({
       accountNetworkValues,
       accountNetworkValueCurrency,
       hideLowValueNetworkValue,
-      handleScrollBeginDrag,
+      onScrollBeginDrag,
+      androidScrollProps,
     ],
   );
-
-  const loading = useMemo(() => {
-    return platformEnv.isNative ? isPending || isTyping : isPending;
-  }, [isPending, isTyping]);
 
   const loadingElement = useMemo(
     () =>
@@ -479,45 +479,6 @@ export const ChainSelectorSectionList: FC<IChainSelectorSectionListProps> = ({
       ) : null,
     [],
   );
-
-  useEffect(() => {
-    if (!platformEnv.isNativeAndroid) {
-      return undefined;
-    }
-    if (
-      loading ||
-      text.trim() ||
-      sections.length === 0 ||
-      initialScrollIndex?.initialScrollIndexNumber === undefined ||
-      hasUserScrolledRef.current
-    ) {
-      return undefined;
-    }
-
-    const scrollToSelectedNetwork = () => {
-      if (hasUserScrolledRef.current) {
-        return;
-      }
-      listRef.current?.scrollToIndex?.({
-        index: initialScrollIndex.initialScrollIndexNumber,
-        animated: false,
-      });
-    };
-    const timerIds = [
-      setTimeout(scrollToSelectedNetwork, 0),
-      setTimeout(scrollToSelectedNetwork, 120),
-    ];
-
-    return () => {
-      timerIds.forEach(clearTimeout);
-    };
-  }, [
-    initialScrollIndex?.initialScrollIndexNumber,
-    loading,
-    networkId,
-    sections,
-    text,
-  ]);
 
   return (
     <Stack flex={1}>

--- a/packages/kit/src/views/ChainSelector/hooks/useAndroidFlashListInitialScrollFix.ts
+++ b/packages/kit/src/views/ChainSelector/hooks/useAndroidFlashListInitialScrollFix.ts
@@ -1,13 +1,12 @@
 import { useCallback, useEffect, useRef } from 'react';
+import type { RefObject } from 'react';
 
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-
-import type { RefObject } from 'react';
 
 // FlashList v2 may re-anchor Android scroll position after async data
 // replaces the initial list. Re-apply the selected position once the
 // committed data has settled: the setTimeout(0) catches the post-commit
-// frame and the delayed timer covers FlashList's later internal reanchor.
+// frame and the delayed timer covers FlashList's later internal re-anchor.
 const ANDROID_RESTORE_DELAY_MS = 120;
 
 const androidScrollProps = {

--- a/packages/kit/src/views/ChainSelector/hooks/useAndroidFlashListInitialScrollFix.ts
+++ b/packages/kit/src/views/ChainSelector/hooks/useAndroidFlashListInitialScrollFix.ts
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import type { RefObject } from 'react';
+
+// FlashList v2 may re-anchor Android scroll position after async data
+// replaces the initial list. Re-apply the selected position once the
+// committed data has settled: the setTimeout(0) catches the post-commit
+// frame and the delayed timer covers FlashList's later internal reanchor.
+const ANDROID_RESTORE_DELAY_MS = 120;
+
+const androidScrollProps = {
+  maintainVisibleContentPosition: {
+    disabled: true,
+  },
+} as const;
+
+const emptyScrollProps: Record<string, unknown> = {};
+
+type IScrollableRef = {
+  scrollToIndex?: (params: { index: number; animated?: boolean }) => void;
+};
+
+export function useAndroidFlashListInitialScrollFix({
+  listRef,
+  initialIndex,
+  enabled,
+  contentKey,
+}: {
+  listRef: RefObject<IScrollableRef | null>;
+  initialIndex: number | undefined;
+  enabled: boolean;
+  // Reference whose change signals an async data swap that may have
+  // re-anchored the scroll position (typically the sections array).
+  contentKey?: unknown;
+}): {
+  scrollProps: Record<string, unknown>;
+  onScrollBeginDrag: () => void;
+} {
+  const hasUserScrolledRef = useRef(false);
+
+  useEffect(() => {
+    if (!platformEnv.isNativeAndroid) {
+      return undefined;
+    }
+    if (!enabled || initialIndex === undefined || hasUserScrolledRef.current) {
+      return undefined;
+    }
+    const scrollToTarget = () => {
+      if (hasUserScrolledRef.current) {
+        return;
+      }
+      listRef.current?.scrollToIndex?.({
+        index: initialIndex,
+        animated: false,
+      });
+    };
+    const timerIds = [
+      setTimeout(scrollToTarget, 0),
+      setTimeout(scrollToTarget, ANDROID_RESTORE_DELAY_MS),
+    ];
+    return () => {
+      timerIds.forEach(clearTimeout);
+    };
+  }, [enabled, initialIndex, contentKey, listRef]);
+
+  const onScrollBeginDrag = useCallback(() => {
+    hasUserScrolledRef.current = true;
+  }, []);
+
+  return {
+    scrollProps: platformEnv.isNativeAndroid
+      ? (androidScrollProps as Record<string, unknown>)
+      : emptyScrollProps,
+    onScrollBeginDrag,
+  };
+}


### PR DESCRIPTION
## Summary
- Fix Android FlashList re-anchoring the network/chain selector to the top after the initial sections data lands asynchronously, causing the user's selected network to be off-screen.
- Extract the stabilization logic into a shared `useAndroidFlashListInitialScrollFix` hook and apply it to both `EditableChainSelectorContent` and the pure `ChainSelectorSectionList`.

## Intent & Context
On Android, opening the network selector with a non-top selection (e.g. an item far down the list) would briefly land at the correct position and then jump back to the top once the async sections data finished loading. This is a FlashList v2 behavior on Android where `maintainVisibleContentPosition` re-anchors the viewport after the committed dataset replaces the initial one. iOS and web were not affected.

## Root Cause
FlashList v2 on Android re-anchors scroll position after the async data swap that replaces the initial empty/placeholder list. `initialScrollIndex` is honored on first mount, but the later re-anchor pass moves the viewport back to index 0, defeating the intended initial position.

## Design Decisions
- **Disable `maintainVisibleContentPosition` on Android only.** iOS/web rendering is unaffected, so the prop override is gated behind `platformEnv.isNativeAndroid`. Web ignores this prop entirely (it's a SectionList/FlatList there), but we still keep the override Android-only to avoid any cross-platform regressions.
- **Re-issue `scrollToIndex` after the data settles.** A `setTimeout(0)` catches the immediate post-commit frame and a second timer at 120ms covers FlashList's later internal re-anchor. Two-shot is intentional: a single immediate call loses to the later re-anchor, and a single delayed call leaves a visible flash.
- **Bail out once the user scrolls.** `onScrollBeginDrag` flips `hasUserScrolledRef` so the restore timers don't fight a deliberate user gesture if the sections data updates mid-scroll.
- **Extract into a shared hook.** The same fix was needed in two list components (`EditableChainSelectorContent` and `ChainSelectorSectionList`); duplicating the constant, ref, callback, and double-`setTimeout` effect across both was error-prone, so the second commit consolidates them into `useAndroidFlashListInitialScrollFix`.

## Changes Detail
- `packages/kit/src/views/ChainSelector/hooks/useAndroidFlashListInitialScrollFix.ts` — New hook. Returns Android-only `scrollProps` (disabling `maintainVisibleContentPosition`) and an `onScrollBeginDrag` handler; runs a two-shot `scrollToIndex` effect keyed off `contentKey` so each async data swap re-pins to `initialIndex` until the user scrolls.
- `packages/kit/src/views/ChainSelector/components/EditableChainSelector/ChainSelectorContent.tsx` — Wire the hook into the editable selector, computing the flat initial index from the section/item indices and gating on `shouldRenderList && !searchText.trim()` so search results don't get re-pinned.
- `packages/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorSectionList.tsx` — Wire the hook into the pure selector, threading `androidScrollProps` and `onScrollBeginDrag` to the inner list content; gated on `!loading && !text.trim() && sections.length > 0`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Android (no behavior change for iOS, Web, Desktop, Extension — the hook returns an empty scroll-props object and a no-op effect off-Android)
- **Risk Areas**: The two-shot timer in `useAndroidFlashListInitialScrollFix`. If `initialIndex` changes mid-effect, the cleanup clears pending timers and the new value re-runs the effect; `hasUserScrolledRef` prevents fighting a user gesture. Worth a manual check that searching/filtering during initial load doesn't cause an unwanted snap-back.

## Test plan
- [ ] Android: open network selector with a network selected that sits far down the list — selected item should remain visible (no top-snap) after async data loads.
- [ ] Android: open network selector, immediately drag-scroll before data finishes loading — list should respect the user drag rather than snapping back to the initial index.
- [ ] Android: type in the search box while the list is settling — search results should appear without the hook trying to re-pin to the original index.
- [ ] Android: open both the editable chain selector and the pure chain selector flows to confirm both code paths apply the fix.
- [ ] iOS / Web: confirm no regression — initial scroll position still respected, no extra jumps.