### PR TITLE
fix: hide duplicate history when matching dapp exists in discovery search

### DIFF
--- a/packages/kit/src/views/Discovery/utils/searchResultRanking.test.ts
+++ b/packages/kit/src/views/Discovery/utils/searchResultRanking.test.ts
@@ -776,7 +776,7 @@ describe('searchResultRanking', () => {
     ]);
   });
 
-  it('keeps a same-url dapp behind local history when it is not promoted', () => {
+  it('hides same-url history when the dapp is not promoted', () => {
     const result = mergeSearchResultsWithLocalData({
       keyword: 'aav',
       searchResult: [
@@ -810,10 +810,6 @@ describe('searchResultRanking', () => {
         title: item.title,
       })),
     ).toEqual([
-      {
-        type: 'history',
-        title: 'Aave - Open Source Liquidity Protocol',
-      },
       {
         type: 'dapp',
         title: 'AAVE',
@@ -1211,6 +1207,57 @@ describe('searchResultRanking', () => {
       {
         type: 'bookmark',
         url: 'https://app.uniswap.org/swap',
+      },
+    ]);
+  });
+
+  it('hides exact history duplicates while keeping history weight on dapps', () => {
+    const result = mergeSearchResultsWithLocalData({
+      keyword: 'swap',
+      searchResult: [
+        createDApp({
+          dappId: 'alpha',
+          name: 'Swap Alpha',
+          url: 'https://alpha.example',
+        }),
+        createDApp({
+          dappId: 'bravo',
+          name: 'Swap Bravo',
+          url: 'https://bravo.example',
+        }),
+      ],
+      rankingHistoryData: [
+        createHistory({
+          id: 'history-bravo',
+          title: 'Swap Bravo',
+          url: 'https://bravo.example',
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+        }),
+      ],
+      bookmarkSearchData: [],
+      historySearchData: [
+        createHistory({
+          id: 'history-bravo',
+          title: 'Swap Bravo',
+          url: 'https://bravo.example',
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+        }),
+      ],
+    });
+
+    expect(
+      result.map((item) => ({
+        type: item.type,
+        url: item.url,
+      })),
+    ).toEqual([
+      {
+        type: 'dapp',
+        url: 'https://bravo.example',
+      },
+      {
+        type: 'dapp',
+        url: 'https://alpha.example',
       },
     ]);
   });

--- a/packages/kit/src/views/Discovery/utils/searchResultRanking.ts
+++ b/packages/kit/src/views/Discovery/utils/searchResultRanking.ts
@@ -1216,6 +1216,46 @@ function appendDappSearchResults({
   });
 }
 
+function collectVisibleDappUrlKeys({
+  groupedItems,
+  originDedupeKeySet,
+}: {
+  groupedItems: IDApp[][];
+  originDedupeKeySet: Set<string>;
+}) {
+  const visibleDappUrlKeySet = new Set<string>();
+  const simulatedOriginDedupeKeySet = new Set(originDedupeKeySet);
+
+  groupedItems.forEach((items) => {
+    items.forEach((item) => {
+      const keys = getOriginMatchKeys({
+        url: item.url,
+        origins: item.origins,
+      });
+      if (
+        hasMatchKeyOverlap({
+          keys,
+          dedupeKeySet: simulatedOriginDedupeKeySet,
+        })
+      ) {
+        return;
+      }
+
+      appendMatchKeys({
+        keys,
+        dedupeKeySet: simulatedOriginDedupeKeySet,
+      });
+
+      const urlKey = getExactUrlVisitKey(item.url);
+      if (urlKey) {
+        visibleDappUrlKeySet.add(urlKey);
+      }
+    });
+  });
+
+  return visibleDappUrlKeySet;
+}
+
 export function mergeSearchResultsWithLocalData({
   keyword,
   searchResult,
@@ -1314,9 +1354,18 @@ export function mergeSearchResultsWithLocalData({
     reserveLocalUrlKey: true,
   });
 
+  const deferredDappUrlKeySet = collectVisibleDappUrlKeys({
+    groupedItems: [otherTrendingResults, remainingRemoteResults],
+    originDedupeKeySet: dappOriginDedupeKeySet,
+  });
+
   rankedLocalItems.forEach((candidate) => {
     const urlKey = getExactUrlVisitKey(candidate.item.url);
-    if (urlKey && urlDedupeKeySet.has(urlKey)) {
+    if (
+      urlKey &&
+      (urlDedupeKeySet.has(urlKey) ||
+        (candidate.type === 'history' && deferredDappUrlKeySet.has(urlKey)))
+    ) {
       return;
     }
     if (urlKey) {


### PR DESCRIPTION
## Summary
- In Discovery search, hide a local history entry when a remote dapp result with the same exact URL will be rendered, even if the dapp is not promoted ahead of the history block.
- Add `collectVisibleDappUrlKeys` to pre-compute which dapp URLs will survive origin-dedupe, and use that set to skip exact-URL history duplicates while preserving history-driven dapp ranking weight.

## Intent & Context
The previous behavior kept a history row visible whenever the matching dapp ranked behind it (the dapp was "not promoted"). That produced a redundant pair: a history row and a dapp row pointing at the exact same URL, just in different positions. Users see the same site twice in one short search list.

## Root Cause
`mergeSearchResultsWithLocalData` deduped local items against the *already-emitted* dedupe set. Trending/remaining dapp results are appended **after** local items, so their URLs are not yet in `urlDedupeKeySet` when local history is filtered — local history wins, and the duplicate dapp lands later in the list.

## Design Decisions
- **Pre-compute, don't reorder**: Simulating the origin-dedupe pass for the deferred dapp groups (`otherTrendingResults`, `remainingRemoteResults`) produces the set of URLs that will actually be visible. This avoids changing the dapp ordering logic or the history weighting on dapps (history boost still applies).
- **Only history is suppressed**: The new check is gated on `candidate.type === 'history'` so bookmarks and other local types are unaffected.
- **Simulate, don't mutate**: `collectVisibleDappUrlKeys` clones `originDedupeKeySet` so the simulation does not leak state into the real dedupe pipeline.

## Changes Detail
- `searchResultRanking.ts`: Added `collectVisibleDappUrlKeys`; before iterating `rankedLocalItems`, build `deferredDappUrlKeySet` and skip history rows whose URL is in it.
- `searchResultRanking.test.ts`:
  - Renamed/updated the existing "not promoted" case to assert the history row is now hidden.
  - Added a new case asserting that when an exact-URL history matches a dapp, the history is hidden but the dapp keeps its history-driven ranking boost (Bravo ranks above Alpha).

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: All (shared Discovery search ranking)
- **Risk Areas**: Result list composition for the Discovery search dropdown. The change only suppresses an item type already covered by tests; it does not affect dapp ordering, bookmark visibility, or trending-only flows.

## Test plan
- [ ] `yarn jest packages/kit/src/views/Discovery/utils/searchResultRanking.test.ts`
- [ ] Manual: open Discovery search, type a keyword that matches a recently visited dapp (e.g. `aav`). Confirm only one row appears for the matching URL.
- [ ] Manual: keyword where multiple dapps share related history — confirm the dapp with history still ranks above the dapp without history.