### PR TITLE
fix: polish market preset dialog (OK-54578)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/MarketPresetSelector/MarketPresetSelector.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/MarketPresetSelector/MarketPresetSelector.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   Dialog,
   Divider,
+  Heading,
   Icon,
   Input,
   ScrollView,
@@ -76,8 +77,9 @@ type IDraftPresetSettings = Partial<
 >;
 
 const MARKET_PRESET_DIALOG_TOP_SAFE_GAP = 16;
-const MARKET_PRESET_DIALOG_CHROME_HEIGHT = 220;
+const MARKET_PRESET_DIALOG_CHROME_HEIGHT = 176;
 const MARKET_PRESET_DIALOG_MIN_CONTENT_HEIGHT = 120;
+const MARKET_PRESET_SLIPPAGE_INPUT_PROPS = { autoFocus: false } as const;
 const READONLY_PRIORITY_FEE_DISPLAY_TYPES = [
   EMarketPresetPriorityFeeType.AUTO,
   EMarketPresetPriorityFeeType.CUSTOM,
@@ -240,11 +242,11 @@ function MarketPresetDialogHeader({ networkId }: { networkId?: string }) {
     <Dialog.Header>
       <XStack alignItems="center" gap="$2" py="$px">
         <NetworkAvatar networkId={networkId} size="$6" />
-        <SizableText size="$headingSm">
+        <Heading size="$headingXl" py="$px">
           {intl.formatMessage({
             id: ETranslations.marketdex_edit_presets_title,
           })}
-        </SizableText>
+        </Heading>
       </XStack>
     </Dialog.Header>
   );
@@ -972,6 +974,7 @@ function MarketPresetSettingsDialog({
                             },
                           }));
                         }}
+                        props={MARKET_PRESET_SLIPPAGE_INPUT_PROPS}
                       />
                       <XStack>
                         {swapSlippageCustomDefaultList.map((item, index) => (


### PR DESCRIPTION
## Summary
- Prevent Market preset edit dialog from auto-focusing the custom slippage input on open.
- Use the HeadingXL title size for the Edit Preset dialog header.
- Increase the mobile dialog content budget while keeping the existing safe-area and keyboard constraints.

## Issues
- Fixes OK-54578

## Intent & Context
OK-54578 reports that mobile users entering Edit Preset are immediately focused into the slippage input, which opens the keyboard and prevents them from seeing the global settings first. The same report also calls out that the edit dialog content area feels too short and the Edit Preset title is smaller than the design spec.

## Root Cause
Market preset reused the shared SlippageInput, whose default behavior focuses the input whenever slippage is in Custom mode. The preset dialog also rendered its custom header title with headingSm instead of the standard HeadingXL treatment, and its mobile content max-height budget reserved more chrome height than the actual header/footer need.

## Design Decisions
- Keep the autofocus override local to Market preset so ordinary Swap slippage dialogs keep their existing behavior.
- Preserve the existing safe-area and keyboard-aware height guard from earlier mobile preset fixes, and only reduce the reserved chrome budget.
- Avoid touching Market preset persistence, preset switching, or transaction parameter flow.

## Changes Detail
- packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/MarketPresetSelector/MarketPresetSelector.tsx: disables initial slippage autofocus for the preset dialog, switches the custom title to HeadingXL, and raises the available mobile content height.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile, Desktop, Web
- **Risk Areas**: Mobile sheet height and keyboard behavior around the Edit Preset dialog.

## Test plan
- [x] git diff --cached --check
- [x] yarn lint:staged
- [x] yarn tsc:staged
- [x] yarn jest packages/kit/src/components/SlippageSettingDialog/SlippageInput.test.ts --runInBand
- [ ] Runtime mobile check: enter Market preset Edit Preset on iOS/Android and verify the keyboard does not open until the input is tapped.