### PR TITLE
fix: format desktop menu accelerator per platform (OK-54571)

### DIFF
--- a/packages/components/src/layouts/Navigation/Tab/TabBar/Menu.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/Menu.tsx
@@ -8,7 +8,6 @@ import type {
   IMenu,
   IMenuItem,
 } from '@onekeyhq/kit-bg/src/desktopApis/DesktopApiSystem';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 const MENU_ICON_STYLE = {
   width: 16,
@@ -33,21 +32,8 @@ const MENU_TRIGGER_BASE_STYLE = {
   fontSize: '13px',
 } as const;
 
-const MAC_MODIFIER_SYMBOLS: Record<string, string> = {
-  CommandOrControl: '⌘',
-  CmdOrCtrl: '⌘',
-  Command: '⌘',
-  Cmd: '⌘',
-  Control: '⌃',
-  Ctrl: '⌃',
-  Shift: '⇧',
-  Alt: '⌥',
-  Option: '⌥',
-  Super: '⌘',
-  Meta: '⌘',
-};
-
-const WIN_MODIFIER_NAMES: Record<string, string> = {
+// MenuHamburger only renders on Windows/Linux — macOS uses the native menu bar.
+const MODIFIER_NAMES: Record<string, string> = {
   CommandOrControl: 'Ctrl',
   CmdOrCtrl: 'Ctrl',
   Control: 'Ctrl',
@@ -61,13 +47,11 @@ const WIN_MODIFIER_NAMES: Record<string, string> = {
   Option: 'Alt',
 };
 
-const formatAccelerator = (accelerator: string): string => {
-  const tokens = accelerator.split('+');
-  if (platformEnv.isDesktopMac) {
-    return tokens.map((t) => MAC_MODIFIER_SYMBOLS[t] ?? t).join('');
-  }
-  return tokens.map((t) => WIN_MODIFIER_NAMES[t] ?? t).join('+');
-};
+const formatAccelerator = (accelerator: string): string =>
+  accelerator
+    .split('+')
+    .map((t) => MODIFIER_NAMES[t] ?? t)
+    .join('+');
 
 function MenuItemComponent({
   item,

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/Menu.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/Menu.tsx
@@ -8,6 +8,7 @@ import type {
   IMenu,
   IMenuItem,
 } from '@onekeyhq/kit-bg/src/desktopApis/DesktopApiSystem';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 const MENU_ICON_STYLE = {
   width: 16,
@@ -31,6 +32,42 @@ const MENU_TRIGGER_BASE_STYLE = {
   width: 'auto',
   fontSize: '13px',
 } as const;
+
+const MAC_MODIFIER_SYMBOLS: Record<string, string> = {
+  CommandOrControl: '⌘',
+  CmdOrCtrl: '⌘',
+  Command: '⌘',
+  Cmd: '⌘',
+  Control: '⌃',
+  Ctrl: '⌃',
+  Shift: '⇧',
+  Alt: '⌥',
+  Option: '⌥',
+  Super: '⌘',
+  Meta: '⌘',
+};
+
+const WIN_MODIFIER_NAMES: Record<string, string> = {
+  CommandOrControl: 'Ctrl',
+  CmdOrCtrl: 'Ctrl',
+  Control: 'Ctrl',
+  Ctrl: 'Ctrl',
+  Command: 'Win',
+  Cmd: 'Win',
+  Super: 'Win',
+  Meta: 'Win',
+  Shift: 'Shift',
+  Alt: 'Alt',
+  Option: 'Alt',
+};
+
+const formatAccelerator = (accelerator: string): string => {
+  const tokens = accelerator.split('+');
+  if (platformEnv.isDesktopMac) {
+    return tokens.map((t) => MAC_MODIFIER_SYMBOLS[t] ?? t).join('');
+  }
+  return tokens.map((t) => WIN_MODIFIER_NAMES[t] ?? t).join('+');
+};
 
 function MenuItemComponent({
   item,
@@ -112,11 +149,7 @@ function MenuItemComponent({
       <span className="desktop-menu-item-label">{item.label}</span>
       {item.accelerator ? (
         <span className="desktop-menu-item-accelerator">
-          {item.accelerator
-            .replace('CmdOrCtrl', '⌘')
-            .replace('Shift', '⇧')
-            .replace('Alt', '⌥')
-            .replace('+', '')}
+          {formatAccelerator(item.accelerator)}
         </span>
       ) : null}
       {hasSubmenu ? (


### PR DESCRIPTION
## Summary
- Windows/Linux 端自定义 React 菜单的快捷键文案显示为 `CommandOrControlZ` / `ControlY` 等，可读性差。
- 根因：`packages/components/src/layouts/Navigation/Tab/TabBar/Menu.tsx` 只 `replace('CmdOrCtrl', '⌘')` + 去掉一个 `+`，无法处理 role 默认的 `CommandOrControl` / `Control` token。
- 修复：新增 `formatAccelerator()`，按 `+` 切 token 映射 `CommandOrControl`/`CmdOrCtrl`/`Control`/`Ctrl` → `Ctrl`，`Alt`/`Option` → `Alt`，`Shift` 保留，重新以 `+` 连接。
- macOS 使用 native 菜单栏（`DesktopLeftSideBar` 上 `platformEnv.isDesktopMac` 分支不渲染 `MenuHamburger`），所以只处理 Win/Linux 路径。

## Test plan
- [ ] Windows 中文环境验证 Edit 菜单显示 `Ctrl+Z` / `Ctrl+Y` / `Ctrl+X` / `Ctrl+C` / `Ctrl+V` / `Ctrl+A`
- [ ] Windows 验证 OneKey 菜单 `Ctrl+,` / `Ctrl+Shift+L` / `Ctrl+Q` 及 View 菜单 `Ctrl+0` / `Ctrl+Shift+]` / `Ctrl+Shift+[` 显示正常
- [ ] Linux 回归同上
- [ ] 验证快捷键功能本身（Ctrl+Z 撤销等）不受影响
- [ ] macOS 回归 native Edit 菜单不受影响（本 PR 不触及 native menu 渲染路径）