### PR TITLE
fix: market pool identity full pair name display and adaptive sizing(OK-54592)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/TokenLiquidityPools.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/TokenLiquidityPools.tsx
@@ -65,6 +65,8 @@ type IDisplayPool = {
   networkId: string;
 };
 
+type IPoolIdentityTextSize = '$bodyLg' | '$bodyMd' | '$bodySm';
+
 type ITokenLiquidityPoolsProps = {
   px?: string;
   pl?: string;
@@ -96,6 +98,8 @@ const MIN_DISPLAY_PERCENTAGE_TEXT = '< 0.01%';
 const TOKEN_AMOUNT_COMPACT_THRESHOLD = 1000;
 const POOL_DETAIL_TOKEN_LIST_SCROLL_THRESHOLD = 6;
 const POOL_DETAIL_TOKEN_LIST_MAX_HEIGHT = '$64';
+const POOL_DETAIL_PAIR_NAME_COMPACT_THRESHOLD = 10;
+const POOL_DETAIL_PAIR_NAME_MINI_THRESHOLD = 100;
 const POOL_NAME_TOOLTIP_TEXT_STYLE = {
   wordBreak: 'break-all',
   whiteSpace: 'normal',
@@ -618,30 +622,77 @@ function PoolIdentity({
 }: {
   item: IDisplayPool;
   logoSize?: SizeTokens;
-  textSize?: '$bodyLg' | '$bodyMd';
+  textSize?: IPoolIdentityTextSize;
   nameNumberOfLines?: number;
   truncateName?: boolean;
 }) {
   const { gtMd } = useMedia();
+  let displayPairName = item.fullPairName;
+  if (truncateName || item.fullPairName === FALLBACK_VALUE) {
+    displayPairName = item.pairName;
+  }
+
+  let displayTextSize: IPoolIdentityTextSize = textSize;
+  if (
+    !truncateName &&
+    displayPairName.length > POOL_DETAIL_PAIR_NAME_MINI_THRESHOLD
+  ) {
+    displayTextSize = '$bodySm';
+  } else if (
+    !truncateName &&
+    displayPairName.length > POOL_DETAIL_PAIR_NAME_COMPACT_THRESHOLD
+  ) {
+    displayTextSize = '$bodyMd';
+  }
+
+  let identityOverflow: 'hidden' | 'visible' = 'visible';
+  let pairNameNumberOfLines: number | undefined;
+  let pairNameEllipsizeMode: 'tail' | undefined;
+  let pairNameOverflow: 'hidden' | undefined;
+  if (truncateName) {
+    identityOverflow = 'hidden';
+    pairNameNumberOfLines = nameNumberOfLines;
+    pairNameEllipsizeMode = 'tail';
+    pairNameOverflow = 'hidden';
+  }
+
+  const shouldShowPairNameTooltip =
+    gtMd && truncateName && item.fullPairName !== FALLBACK_VALUE;
   const pairNameText = (
     <SizableText
-      size={textSize}
+      size={displayTextSize}
       color="$text"
       display="block"
       width="100%"
       maxWidth="100%"
-      {...(truncateName
-        ? {
-            numberOfLines: nameNumberOfLines,
-            ellipsizeMode: 'tail' as const,
-            overflow: 'hidden' as const,
-          }
-        : undefined)}
+      numberOfLines={pairNameNumberOfLines}
+      ellipsizeMode={pairNameEllipsizeMode}
+      overflow={pairNameOverflow}
       flexShrink={1}
     >
-      {item.pairName}
+      {displayPairName}
     </SizableText>
   );
+  let pairNameNode = pairNameText;
+  if (shouldShowPairNameTooltip) {
+    pairNameNode = (
+      <Tooltip
+        placement="top"
+        renderContent={
+          <SizableText
+            size="$bodySm"
+            color="$text"
+            display="block"
+            maxWidth="$72"
+            style={POOL_NAME_TOOLTIP_TEXT_STYLE}
+          >
+            {item.fullPairName}
+          </SizableText>
+        }
+        renderTrigger={pairNameText}
+      />
+    );
+  }
 
   return (
     <XStack
@@ -649,34 +700,11 @@ function PoolIdentity({
       gap="$3"
       width="100%"
       minWidth={0}
-      overflow={truncateName ? 'hidden' : 'visible'}
+      overflow={identityOverflow}
     >
       <PoolLogo uri={item.dexLogoUrl} size={logoSize} />
-      <YStack
-        flex={1}
-        minWidth={0}
-        maxWidth="100%"
-        overflow={truncateName ? 'hidden' : 'visible'}
-      >
-        {gtMd && truncateName && item.fullPairName !== FALLBACK_VALUE ? (
-          <Tooltip
-            placement="top"
-            renderContent={
-              <SizableText
-                size="$bodySm"
-                color="$text"
-                display="block"
-                maxWidth="$72"
-                style={POOL_NAME_TOOLTIP_TEXT_STYLE}
-              >
-                {item.fullPairName}
-              </SizableText>
-            }
-            renderTrigger={pairNameText}
-          />
-        ) : (
-          pairNameText
-        )}
+      <YStack flex={1} minWidth={0} maxWidth="100%" overflow={identityOverflow}>
+        {pairNameNode}
         <SizableText
           size="$bodyMd"
           color="$textSubdued"


### PR DESCRIPTION
## Summary
- Show `fullPairName` instead of the short `pairName` in pool identity rows when truncation is disabled, and add a tooltip exposing the full pair name in the truncated/`gtMd` mode.
- Adaptively scale pool pair-name text size (`$bodyLg` → `$bodyMd` → `$bodySm`) based on character length thresholds to keep long pair names readable without breaking layout.
- Refactor `PoolIdentity` rendering branches into explicit variables (`identityOverflow`, `pairNameNumberOfLines`, `pairNameEllipsizeMode`, `pairNameOverflow`, `pairNameNode`) for clearer conditional logic.

## Intent & Context
The Market Detail liquidity pool list rendered only the short `pairName` and a fixed text size, which truncated context for pools with long full pair names and made long names overflow or crowd the row. OK-54592 calls for surfacing the complete pair name where space allows and gracefully shrinking the font when the name is unusually long.

## Design Decisions
- Use length thresholds (`POOL_DETAIL_PAIR_NAME_COMPACT_THRESHOLD = 10`, `POOL_DETAIL_PAIR_NAME_MINI_THRESHOLD = 100`) so the same component can render comfortably for short names and degrade size for very long names without requiring a separate measurement pass.
- Keep the tooltip behind `gtMd && truncateName` so mobile/compact contexts (where tooltips behave poorly) keep using truncation only, while wider contexts get the full string on hover.
- Introduce a dedicated `IPoolIdentityTextSize` union (`$bodyLg | $bodyMd | $bodySm`) to keep the size prop strongly typed across the new size paths.

## Changes Detail
- `packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/TokenLiquidityPools.tsx`
  - New constants `POOL_DETAIL_PAIR_NAME_COMPACT_THRESHOLD`, `POOL_DETAIL_PAIR_NAME_MINI_THRESHOLD`.
  - `PoolIdentity` now derives `displayPairName`, `displayTextSize`, overflow/numberOfLines/ellipsizeMode flags, and `pairNameNode` (with optional Tooltip) before composing the row.
  - `truncateName` still falls back to `pairName`; non-truncated rendering now uses `fullPairName` when it isn't the fallback sentinel.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile / Desktop / Web / Extension (Market Detail liquidity pool list)
- **Risk Areas**: Layout regressions for rows where the full pair name is very long; tooltip behavior on `gtMd` breakpoints.

## Test plan
- [ ] Market Detail → Liquidity Pools: short pair names render at the default size with the full name visible.
- [ ] Pools with pair names > 10 chars render in `$bodyMd`; > 100 chars render in `$bodySm`.
- [ ] In compact contexts where `truncateName` is true, the pair name still truncates with ellipsis and shows the full name in the tooltip on `gtMd` (Desktop/Web).
- [ ] On mobile (no `gtMd`), no tooltip appears and truncation still works.
- [ ] `fullPairName === FALLBACK_VALUE` rows fall back to `pairName` cleanly.