### PR TITLE
fix: show loading state on NFT send Next button while building tx (OK-54587)

### DIFF
--- a/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
@@ -1320,7 +1320,7 @@ function SendDataInputContainer() {
               // Only disable for data-step field errors or in-flight validation.
               // handleNavigateToAmountInput still calls form.trigger() as a final
               // guard before navigating.
-              disabled: isNextDisabled || isSubmitting,
+              disabled: isNextDisabled,
             }}
           />
         </Page.Footer>

--- a/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
@@ -160,6 +160,10 @@ function SendDataInputContainer() {
     useState<IRecipientQuickSelectTab>('recent');
   const [hasQuickSelectMatches, setHasQuickSelectMatches] = useState(false);
   const [scannedAmount, setScannedAmount] = useState('');
+  // Skip-amount paths (ERC-721, fixed Lightning invoice) build the unsigned
+  // tx inside this handler, which can take seconds on mobile — the Next
+  // button needs a visible loading state during that wait.
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const pushAmountInput = useCallback(
     (params: ISendAmountInputParams) => {
@@ -373,6 +377,7 @@ function SendDataInputContainer() {
   const handleNavigateToAmountInput = useCallback(async () => {
     if (isNavigatingRef.current) return;
     isNavigatingRef.current = true;
+    setIsSubmitting(true);
     try {
       // Use already-watched toResolved instead of re-getting from form
       if (!toResolved) return;
@@ -572,6 +577,7 @@ function SendDataInputContainer() {
       console.error('Navigate to amount input failed:', e);
     } finally {
       isNavigatingRef.current = false;
+      setIsSubmitting(false);
     }
   }, [
     account,
@@ -1307,14 +1313,14 @@ function SendDataInputContainer() {
               id: ETranslations.global_next,
             })}
             confirmButtonProps={{
-              loading: false,
+              loading: isSubmitting,
               // Don't use form.formState.isValid here — the async address
               // validation (AddressInput queryAddress) can leave isValid stale.
               // toResolved && !toPending already gates address validity.
               // Only disable for data-step field errors or in-flight validation.
               // handleNavigateToAmountInput still calls form.trigger() as a final
               // guard before navigating.
-              disabled: isNextDisabled,
+              disabled: isNextDisabled || isSubmitting,
             }}
           />
         </Page.Footer>


### PR DESCRIPTION
## Summary
- Show a spinner on the Next button on the Send data-input page while the unsigned tx is being built, so the skip-amount path (ERC-721 NFT send, fixed Lightning invoice) no longer feels unresponsive on mobile.
- Wire the existing \`isNavigatingRef\` re-entry guard to a new \`isSubmitting\` React state and drive \`confirmButtonProps.loading\` from it, mirroring \`SendAmountInputContainer\`'s pattern.
- Keep the button visually \"loading\" rather than \"disabled\" during build — the Button component already blocks taps while loading, so adding \`disabled\` on top would gray it out and hide the spinner.

## Intent & Context
On mobile, tapping Next when sending an ERC-721 NFT (or a fixed-amount Lightning invoice) would freeze for several seconds with no feedback while \`handleNavigateToAmountInput\` synchronously built the unsigned transaction. These flows skip the amount-input page entirely, so the construction work that normally happens on the next screen runs here. Users repeatedly tapped Next, suspecting the app had hung.

## Root Cause
\`handleNavigateToAmountInput\` performs heavy work inline (unsigned-tx build for skip-amount paths) but the Next button was hard-coded to \`loading: false\`. The only re-entry protection was an internal \`isNavigatingRef\`, which prevented duplicate work but produced no visible state change.

## Design Decisions
- **Mirror \`SendAmountInputContainer\`**: it already uses an \`isSubmitting\` state for the same UX. Reusing the pattern keeps the two send entry points consistent.
- **Drive only \`loading\` from \`isSubmitting\`, not \`disabled\`**: when both are true, the disabled styling wins visually and the spinner is barely visible — defeating the purpose of the change. The Button component blocks taps while \`loading=true\`, and the existing \`isNavigatingRef\` is the authoritative re-entry guard, so \`disabled\` can stay reserved for genuine validation failures (\`isNextDisabled\`).
- **Reset in \`finally\`**: pairs with the existing \`isNavigatingRef = false\` reset so the spinner always clears, even on thrown errors or early returns.

## Changes Detail
- \`packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx\`
  - Add \`isSubmitting\` state; set it true on entry to \`handleNavigateToAmountInput\` and clear it in \`finally\`.
  - \`confirmButtonProps.loading\`: \`false\` → \`isSubmitting\`.
  - \`confirmButtonProps.disabled\`: unchanged from prior behavior — stays \`isNextDisabled\` only.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile (primary), Desktop / Web (cosmetic — they also benefit from the spinner)
- **Risk Areas**: Send data-input → amount-input transition for skip-amount tokens (ERC-721, Lightning fixed-invoice). Non-skip-amount paths (regular token send) navigate quickly and won't visibly flash the spinner.

## Test plan
- [ ] On mobile, initiate an ERC-721 NFT send and tap Next — the button should show a spinner until the confirm page opens.
- [ ] Repeat with a fixed-amount Lightning invoice — same spinner behavior, no double-navigation if you tap rapidly.
- [ ] Regular ERC-20 / native token send still navigates to the amount-input page normally with no regression.
- [ ] If address validation fails (\`isNextDisabled\`), the button is still disabled (greyed) as before.
- [ ] If the unsigned-tx build throws, the spinner clears and the button becomes tappable again.