### PR TITLE
OK-54670: support SUI multi-recipient transfer parsing

### DIFF
--- a/packages/kit-bg/src/vaults/impls/sui/Vault.ts
+++ b/packages/kit-bg/src/vaults/impls/sui/Vault.ts
@@ -40,6 +40,7 @@ import {
   EDecodedTxStatus,
   type IDecodedTx,
   type IDecodedTxAction,
+  type IDecodedTxTransferInfo,
 } from '@onekeyhq/shared/types/tx';
 
 import { VaultBase } from '../../base/VaultBase';
@@ -74,6 +75,11 @@ import type {
   SuiTransactionBlockResponse,
   SuiTransactionBlockResponseOptions,
 } from '@mysten/sui/client';
+
+function getTransferActionAddress(addresses: string[]) {
+  const uniqueAddresses = Array.from(new Set(addresses.filter(Boolean)));
+  return uniqueAddresses.length === 1 ? uniqueAddresses[0] : '';
+}
 
 export default class Vault extends VaultBase {
   override coreApi = coreChainApi.sui.hd;
@@ -227,12 +233,10 @@ export default class Vault extends VaultBase {
         }
 
         if (transfers.length > 0) {
-          const action = await this.buildTxTransferAssetAction({
-            from: transfers[0].from,
-            to: transfers[0].to,
-            transfers: (
-              await Promise.all(
-                transfers.map(async (transfer) => {
+          const parsedTransfers = (
+            await Promise.all(
+              transfers.map(
+                async (transfer): Promise<IDecodedTxTransferInfo | null> => {
                   const token = await this.backgroundApi.serviceToken.getToken({
                     networkId: this.networkId,
                     accountId: this.accountId,
@@ -245,7 +249,7 @@ export default class Vault extends VaultBase {
                   ) {
                     return null;
                   }
-                  return {
+                  const parsedTransfer: IDecodedTxTransferInfo = {
                     from: transfer.from,
                     to: transfer.to,
                     amount: new BigNumber(transfer.amount)
@@ -255,13 +259,30 @@ export default class Vault extends VaultBase {
                     symbol: token?.symbol ?? '',
                     name: token?.name ?? '',
                     tokenIdOnNetwork: token?.address ?? '',
-                    isNative: token?.isNative,
                   };
-                }),
-              )
-            ).filter(Boolean),
-          });
-          actions.push(action);
+                  if (token.isNative !== undefined) {
+                    parsedTransfer.isNative = token.isNative;
+                  }
+                  return parsedTransfer;
+                },
+              ),
+            )
+          ).filter(
+            (transfer): transfer is IDecodedTxTransferInfo => transfer !== null,
+          );
+
+          if (parsedTransfers.length > 0) {
+            const action = await this.buildTxTransferAssetAction({
+              from: getTransferActionAddress(
+                parsedTransfers.map((transfer) => transfer.from),
+              ),
+              to: getTransferActionAddress(
+                parsedTransfers.map((transfer) => transfer.to),
+              ),
+              transfers: parsedTransfers,
+            });
+            actions.push(action);
+          }
         }
       }
     } else if (transactionType === ESuiTransactionType.ContractInteraction) {

--- a/packages/shared/src/utils/txActionUtils.test.ts
+++ b/packages/shared/src/utils/txActionUtils.test.ts
@@ -1,0 +1,114 @@
+import {
+  EParseTxComponentType,
+  type IDisplayComponentAddress,
+  type IDisplayComponentInternalAssets,
+} from '../../types/signatureConfirm';
+import {
+  EDecodedTxActionType,
+  EDecodedTxStatus,
+  type IDecodedTx,
+  type IDecodedTxTransferInfo,
+} from '../../types/tx';
+import { appLocale } from '../locale/appLocale';
+import { ETranslations } from '../locale/enum/translations';
+
+import { convertDecodedTxActionsToSignatureConfirmTxDisplayComponents } from './txActionUtils';
+
+const defaultLocal = appLocale.intl.locale;
+const defaultMessages = appLocale.intl.messages;
+
+function buildTransfer(to: string): IDecodedTxTransferInfo {
+  return {
+    from: '0xsender',
+    to,
+    amount: '0.001',
+    icon: '',
+    name: 'Sui',
+    symbol: 'SUI',
+    tokenIdOnNetwork: '0x2::sui::SUI',
+    isNative: true,
+  };
+}
+
+function buildDecodedTx(transfers: IDecodedTxTransferInfo[]): IDecodedTx {
+  return {
+    txid: '',
+    owner: '0xsender',
+    signer: '0xsender',
+    nonce: 0,
+    actions: [
+      {
+        type: EDecodedTxActionType.ASSET_TRANSFER,
+        assetTransfer: {
+          from: '0xsender',
+          to: '',
+          sends: transfers,
+          receives: [],
+        },
+      },
+    ],
+    status: EDecodedTxStatus.Pending,
+    networkId: 'sui--mainnet',
+    accountId: 'account-id',
+    extraInfo: null,
+  };
+}
+
+describe('txActionUtils', () => {
+  beforeEach(() => {
+    appLocale.setLocale('en-US', {
+      [ETranslations.global_asset]: 'Asset',
+      [ETranslations.global_to]: 'To',
+    } as Parameters<typeof appLocale.setLocale>[1]);
+  });
+
+  afterEach(() => {
+    appLocale.setLocale(defaultLocal, defaultMessages);
+  });
+
+  it('renders each outgoing recipient as an address component', () => {
+    const components =
+      convertDecodedTxActionsToSignatureConfirmTxDisplayComponents({
+        decodedTx: buildDecodedTx([
+          buildTransfer('0xrecipient1'),
+          buildTransfer('0xrecipient2'),
+        ]),
+        unsignedTx: {} as never,
+      });
+
+    const assetComponents = components.filter(
+      (component): component is IDisplayComponentInternalAssets =>
+        component.type === EParseTxComponentType.InternalAssets,
+    );
+    const addressComponents = components.filter(
+      (component): component is IDisplayComponentAddress =>
+        component.type === EParseTxComponentType.Address,
+    );
+
+    expect(assetComponents).toHaveLength(2);
+    expect(addressComponents.map((component) => component.address)).toEqual([
+      '0xrecipient1',
+      '0xrecipient2',
+    ]);
+  });
+
+  it('deduplicates repeated outgoing recipients', () => {
+    const components =
+      convertDecodedTxActionsToSignatureConfirmTxDisplayComponents({
+        decodedTx: buildDecodedTx([
+          buildTransfer('0xrecipient1'),
+          buildTransfer('0xrecipient1'),
+        ]),
+        unsignedTx: {} as never,
+      });
+
+    const addressComponents = components.filter(
+      (component): component is IDisplayComponentAddress =>
+        component.type === EParseTxComponentType.Address,
+    );
+
+    expect(addressComponents.map((component) => component.address)).toEqual([
+      '0xrecipient1',
+    ]);
+  });
+});

--- a/packages/shared/src/utils/txActionUtils.ts
+++ b/packages/shared/src/utils/txActionUtils.ts
@@ -308,6 +308,10 @@ export function convertNetworkToSignatureConfirmNetwork({
   };
 }
 
+function getUniqueAddresses(addresses: string[]) {
+  return Array.from(new Set(addresses.filter(Boolean)));
+}
+
 function convertAssetTransferActionToSignatureConfirmComponent({
   action,
   unsignedTx,
@@ -389,15 +393,23 @@ function convertAssetTransferActionToSignatureConfirmComponent({
     components.push(receiveAddressComponent);
   }
 
-  if (action.to) {
-    let showInteractWithContract = false;
+  let showInteractWithContract = false;
 
-    if (isInternalSwap) {
-      showInteractWithContract = true;
-    } else if (isInternalStake) {
-      showInteractWithContract = !isUTXO;
-    }
+  if (isInternalSwap) {
+    showInteractWithContract = true;
+  } else if (isInternalStake) {
+    showInteractWithContract = !isUTXO;
+  }
 
+  const toAddresses = showInteractWithContract
+    ? getUniqueAddresses(action.to ? [action.to] : [])
+    : getUniqueAddresses(action.sends.map((send) => send.to));
+
+  const addressComponents = toAddresses.length
+    ? toAddresses
+    : getUniqueAddresses(action.to ? [action.to] : []);
+
+  addressComponents.forEach((address) => {
     const toAddressComponent: IDisplayComponentAddress = {
       type: EParseTxComponentType.Address,
       label: showInteractWithContract
@@ -407,14 +419,14 @@ function convertAssetTransferActionToSignatureConfirmComponent({
         : appLocale.intl.formatMessage({
             id: ETranslations.global_to,
           }),
-      address: action.to,
+      address,
       tags: [],
       isNavigable: showInteractWithContract,
       highlight: !showInteractWithContract,
     };
 
     components.push(toAddressComponent);
-  }
+  });
 
   return components;
 }


### PR DESCRIPTION
## Summary
- Preserve every parsed SUI transfer output in the decoded asset transfer action instead of collapsing the top-level recipient to the first transfer.
- Render outgoing transfer recipients from `sends[].to` using the existing signature-confirm Address display component.
- Add focused coverage for multi-recipient and duplicate-recipient transfer display conversion.

## Intent & Context
The Slack thread investigation showed that SUI programmable transaction blocks can contain multiple `TransferObjects` commands, but the current SUI Vault parsing only populated the decoded action with `to: transfers[0].to`. That made confirmation data lose recipient detail for transactions with more than one output. The desired direction was to avoid UI component changes and reuse the existing confirmation rendering pipeline by fixing the Vault/action data shape.

## Root Cause
SUI transfer parsing treated the asset-transfer action as having a single top-level recipient. For PTBs with multiple transfer outputs, `transfers[0].to` became the only address exposed to the generic signature-confirm conversion path, so additional recipients were not rendered even though the dry-run response contained them.

## Design Decisions
- Model SUI like the existing BTC Vault pattern: keep one `ASSET_TRANSFER` action, but preserve per-output recipient data in the transfer list.
- Only populate top-level `from`/`to` when all parsed transfers share a single unique address; multi-recipient transactions leave the top-level recipient empty and rely on `sends[].to` as the authoritative list.
- Keep UI components unchanged. The shared conversion layer now emits multiple existing Address display components from outgoing `sends` data, with deduplication for repeated recipients.
- Preserve internal swap/staking contract-address behavior by continuing to prefer the existing top-level contract address in those flows.

## Changes Detail
- `packages/kit-bg/src/vaults/impls/sui/Vault.ts`: builds typed parsed transfer entries from SUI dry-run balance changes and derives top-level action addresses only when unique.
- `packages/shared/src/utils/txActionUtils.ts`: converts outgoing transfer sends into one or more signature-confirm Address components while keeping existing labels, highlighting, and contract interaction behavior.
- `packages/shared/src/utils/txActionUtils.test.ts`: covers rendering multiple outgoing recipients and deduplicating repeated outgoing recipient addresses.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Signature confirmation display for asset-transfer actions is shared across chains, so the change is scoped to outgoing `sends` address extraction and preserves existing contract-interaction fallbacks.

## Test plan
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --fix --deny-warnings packages/kit-bg/src/vaults/impls/sui/Vault.ts packages/shared/src/utils/txActionUtils.ts packages/shared/src/utils/txActionUtils.test.ts`
- [x] `yarn lint:staged`
- [x] `yarn jest packages/shared/src/utils/txActionUtils.test.ts --runInBand`
- [ ] `yarn tsc:staged` currently fails on unrelated existing CLI/hardware/perf-stats dependency/type errors outside this change.