### PR TITLE
refactor: debounce dev settings search and skip empty sections

### DIFF
--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/DevSettingsSearchContext.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/DevSettingsSearchContext.tsx
@@ -5,13 +5,21 @@ const DevSettingsSearchContext = createContext('');
 
 export const DevSettingsSearchProvider = DevSettingsSearchContext.Provider;
 
+export function matchesDevSearchQuery(
+  query: string,
+  ...searchableTexts: (string | undefined | null)[]
+): boolean {
+  const normalizedQuery = query.toLowerCase().trim();
+  if (!normalizedQuery) return true;
+  const combined = searchableTexts.filter(Boolean).join(' ').toLowerCase();
+  return combined.includes(normalizedQuery);
+}
+
 export function useMatchesDevSearch(
   ...searchableTexts: (string | undefined | null)[]
 ): boolean {
   const query = useContext(DevSettingsSearchContext);
-  if (!query) return true;
-  const combined = searchableTexts.filter(Boolean).join(' ').toLowerCase();
-  return combined.includes(query);
+  return matchesDevSearchQuery(query, ...searchableTexts);
 }
 
 export function SearchFilterItem({

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
@@ -1,5 +1,11 @@
-import { useCallback, useMemo, useState } from 'react';
-import type { ComponentProps } from 'react';
+import {
+  Children,
+  isValidElement,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 
 import { random } from 'lodash';
 import { useIntl } from 'react-intl';
@@ -34,6 +40,7 @@ import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/Acco
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { Section } from '@onekeyhq/kit/src/components/Section';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { useDebounce } from '@onekeyhq/kit/src/hooks/useDebounce';
 import { useSignatureConfirm } from '@onekeyhq/kit/src/hooks/useSignatureConfirm';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import { WebEmbedDevConfig } from '@onekeyhq/kit/src/views/Developer/pages/Gallery/Components/stories/WebEmbed';
@@ -95,6 +102,7 @@ import { DeviceToken } from './DeviceToken';
 import {
   DevSettingsSearchProvider,
   SearchFilterItem,
+  matchesDevSearchQuery,
 } from './DevSettingsSearchContext';
 import { DiscoverySearchDebugTool } from './DiscoverySearchDebugTool';
 import { HapticsPanel } from './HapticsPanel';
@@ -227,6 +235,51 @@ const DevSettingsAccordionTrigger = ({
   </Accordion.Trigger>
 );
 
+function getSearchableString(value: unknown) {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function hasMatchingDevSettingsSearchItem(node: ReactNode, query: string) {
+  if (!query) return true;
+
+  let hasMatch = false;
+
+  Children.forEach(node, (child) => {
+    if (hasMatch || !isValidElement(child)) {
+      return;
+    }
+
+    const props = child.props as {
+      children?: ReactNode;
+      keywords?: string;
+      searchKeywords?: string;
+      subtitle?: unknown;
+      title?: unknown;
+    };
+
+    if (child.type === SearchFilterItem) {
+      hasMatch = matchesDevSearchQuery(query, props.keywords);
+      return;
+    }
+
+    if (child.type === SectionPressItem || child.type === SectionFieldItem) {
+      hasMatch = matchesDevSearchQuery(
+        query,
+        getSearchableString(props.title),
+        getSearchableString(props.subtitle),
+        props.searchKeywords,
+      );
+      return;
+    }
+
+    if (props.children) {
+      hasMatch = hasMatchingDevSettingsSearchItem(props.children, query);
+    }
+  });
+
+  return hasMatch;
+}
+
 const BaseDevSettingsSection = () => {
   const [settings] = useSettingsPersistAtom();
   const [devSettings] = useDevSettingsPersistAtom();
@@ -329,6 +382,10 @@ const BaseDevSettingsSection = () => {
   const PINNED_STORAGE_KEY = 'onekey_dev_settings_pinned_sections';
 
   const [searchText, setSearchText] = useState('');
+  const debouncedSearchText = useDebounce(searchText, 300);
+  const normalizedSearchText = (searchText.trim() ? debouncedSearchText : '')
+    .toLowerCase()
+    .trim();
   const [pinnedSections, setPinnedSections] = useState<string[]>(() => {
     try {
       const raw = appStorage.syncStorage.getString(PINNED_STORAGE_KEY as any);
@@ -426,9 +483,6 @@ const BaseDevSettingsSection = () => {
   );
 
   const visibleSectionKeys = useMemo(() => {
-    // Show all sections — individual items are filtered by SearchFilterItem.
-    // This avoids the problem where item keywords missing from section-level
-    // keywords would make those items unreachable via search.
     const keys = sectionMeta.map((s) => s.key);
     // Sort: pinned first
     const pinSet = new Set(pinnedSections);
@@ -458,16 +512,18 @@ const BaseDevSettingsSection = () => {
           leftIconName="SearchOutline"
         />
       </Stack>
-      {searchText.trim() ? (
-        <BundleCommitSearch searchText={searchText} />
+      {normalizedSearchText ? (
+        <BundleCommitSearch searchText={debouncedSearchText} />
       ) : null}
       <Accordion
         width="100%"
         type="multiple"
         defaultValue={
-          searchText ? visibleSectionKeys : visibleSectionKeys.slice(0, 1)
+          normalizedSearchText
+            ? visibleSectionKeys
+            : visibleSectionKeys.slice(0, 1)
         }
-        key={`${searchText.trim() ? 'searching' : 'idle'}-${visibleSectionKeys.join(',')}`}
+        key={`${normalizedSearchText ? 'searching' : 'idle'}-${visibleSectionKeys.join(',')}`}
       >
         {visibleSectionKeys.map((sectionKey) => {
           const isPinned = pinnedSections.includes(sectionKey);
@@ -475,14 +531,19 @@ const BaseDevSettingsSection = () => {
             pinned: isPinned,
             onTogglePin: () => togglePin(sectionKey),
           };
-          const wrapWithSearch = (node: React.ReactNode) => (
-            <DevSettingsSearchProvider
-              key={sectionKey}
-              value={searchText.toLowerCase().trim()}
-            >
-              {node}
-            </DevSettingsSearchProvider>
-          );
+          const wrapWithSearch = (node: React.ReactNode) =>
+            normalizedSearchText &&
+            !hasMatchingDevSettingsSearchItem(
+              node,
+              normalizedSearchText,
+            ) ? null : (
+              <DevSettingsSearchProvider
+                key={sectionKey}
+                value={normalizedSearchText}
+              >
+                {node}
+              </DevSettingsSearchProvider>
+            );
           switch (sectionKey) {
             case 'basic':
               return wrapWithSearch(


### PR DESCRIPTION
## Summary
- Add a 300ms debounce on the Dev Settings search query so heavy filter re-renders no longer fire on every keystroke
- Extract `matchesDevSearchQuery()` so the same matcher can be used both inside the `useMatchesDevSearch` hook and during section-level React tree traversal
- Hide an entire section block (header + accordion body) when none of its descendant items match, instead of rendering an empty accordion entry

## Intent & Context
The Dev Settings panel ships a search input that filters items across many sections. Two UX issues motivated this work:

1. Per-keystroke filtering caused visible jank because the panel re-renders many heavy items.
2. When a query matched items inside only one section, every other section still rendered as an empty accordion header, cluttering the result list and forcing the user to scan past empty entries.

## Root Cause
- `setSearchText` drove the filter pipeline directly, so the entire accordion re-evaluated on every keystroke without any throttling.
- Each section was rendered unconditionally; per-item filtering happened only inside `SearchFilterItem` via the `useMatchesDevSearch` context. A section whose descendants all filtered out still showed its header.

## Design Decisions
- Keep `searchText` as the controlled value for the input (typing stays responsive) and feed only the debounced value into the heavy filter pipeline (`debouncedSearchText` + `normalizedSearchText`).
- Extract `matchesDevSearchQuery` as a pure helper. The original hook now thinly wraps it, and the new tree-walking helper can reuse the same matching rules without violating the rules of hooks.
- Walk each section's children with `React.Children.forEach` + `isValidElement` and short-circuit on the first match. The matcher recognizes `SearchFilterItem` (`keywords`) and `SectionPressItem` / `SectionFieldItem` (`title`, `subtitle`, `searchKeywords`); for any other element it recurses into `props.children`.
- Reuse the same `normalizedSearchText` for: the `BundleCommitSearch` guard, the accordion `defaultValue` (open all when searching, only the first when idle), the accordion `key` cache-buster, and the `DevSettingsSearchProvider` value, so all branches stay in lockstep.

## Changes Detail
- `DevSettingsSearchContext.tsx`: Exported new `matchesDevSearchQuery(query, ...texts)` helper. `useMatchesDevSearch` now delegates to it.
- `DevSettingsSection/index.tsx`:
  - Added `useDebounce` for the search input (300ms) and a `normalizedSearchText` derived from the debounced value.
  - Added `hasMatchingDevSettingsSearchItem` that walks a section's React subtree to determine whether to render the section at all.
  - `wrapWithSearch` now returns `null` for sections with no matches instead of an empty `DevSettingsSearchProvider`.
  - Removed the stale "show all sections" comment in `visibleSectionKeys` since the comment no longer matches the behavior.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: All (Dev Settings panel is built only in dev/internal builds)
- **Risk Areas**:
  - Section visibility now depends on `hasMatchingDevSettingsSearchItem` recognizing the item element types. If a section uses a custom item component that doesn't render through `SearchFilterItem` / `SectionPressItem` / `SectionFieldItem`, matches inside it will not be detected and the section will be hidden during search. Acceptable for internal tooling.
  - The 300ms debounce introduces a brief mismatch window between the input value and the filter result; clearing the input still feels instant because the input value drives the empty-state branch.

## Test plan
- [ ] Open Dev Settings, type a query slowly — verify input stays responsive and the filtered results settle after ~300ms idle
- [ ] Type a query that matches items in only one section — verify other section headers are hidden, not rendered as empty entries
- [ ] Clear the search box — verify all section headers come back and only the first section is expanded by default
- [ ] Type a query that matches a `SectionPressItem` `title`/`subtitle` only (no `keywords`) — verify the parent section stays visible
- [ ] Type a query that matches no items — verify all sections collapse away and only the bundle commit search panel remains (if applicable)