### PR TITLE
refactor(app): default restartApp to All mode for safer reload

### DIFF
--- a/packages/kit-bg/src/services/ServiceApp.ts
+++ b/packages/kit-bg/src/services/ServiceApp.ts
@@ -64,7 +64,7 @@ class ServiceApp extends ServiceBase {
     // chrome.runtime.reload, location.reload, BackgroundThread.restart for
     // native) lives inside `appRestart` so this method stays uniform.
     await appRestart({
-      mode: opts.mode ?? EAppRestartMode.UI,
+      mode: opts.mode ?? EAppRestartMode.All,
       reason: opts.reason ?? 'serviceApp.restartApp',
     });
   }

--- a/packages/kit/src/views/Setting/hooks/useLanguageSelector.ts
+++ b/packages/kit/src/views/Setting/hooks/useLanguageSelector.ts
@@ -32,11 +32,10 @@ export function useLanguageSelector() {
 
   const onChange = useCallback(async (text: string) => {
     await changeLanguage(text);
-    // mode=UI restarts only the main JS runtime — bg stays hot, and the
-    // SharedRPC quiesce step in BackgroundThread.restart closes the iOS
-    // dangling-jsi::Function race that used to crash on this path.
+    // mode=All restarts main + bg in lockstep so no half-quiesced state
+    // can leak across the reload boundary.
     await backgroundApiProxy.serviceApp.restartApp({
-      mode: EAppRestartMode.UI,
+      mode: EAppRestartMode.All,
       reason: `setting.language.${text}`,
     });
   }, []);


### PR DESCRIPTION
## Summary
- Switch the default `restartApp` mode from `UI` to `All` in `ServiceApp.restartApp`.
- Update `useLanguageSelector` to explicitly request `All` on language switch (and refresh the stale comment that still described the `UI` path).

## Why
The previous default `UI` mode kept the bg JS runtime hot across the reload, which works but leaves the door open to cross-runtime references surviving a partial reload. Restarting both runtimes in lockstep removes that whole class of races at the cost of a heavier reload (bg connections re-init, sockets reconnect).

## Trade-offs
- Heavier UX: bg host tear-down + reinit on every restart (~+1–2s perceived).
- All currently hot bg state (sockets, JPush, wallet subscriptions, TradingView WS, etc.) reconnects.
- `BackgroundThread.restart('all')` is the path already used by `resetData` and OTA, so the code path is well-exercised — this just extends it to the default restart and language-switch paths.

## Test plan
- [ ] iOS: switch language in Settings → app fully reloads, lands on the same page with new locale, no crash.
- [ ] Android: same as iOS.
- [ ] Desktop / Web / Extension: confirm `appRestart` platform routing still reloads correctly (they don't use BackgroundThread, only mode is forwarded).
- [ ] After language switch, confirm bg-driven features come back up: notifications, wallet sync, Hyperliquid/TradingView WS, JPush registration.
- [ ] Confirm `resetData` flow still works (it explicitly requests `All`, so behavior is unchanged for it).