### PR TITLE
feat: add dev tool to mock empty TradingView K-Line data

### DIFF
--- a/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
@@ -13,6 +13,16 @@ export interface IApiEndpointConfig {
   enabled: boolean;
 }
 
+export type ITradingViewKLineMockEmptyInterval =
+  | '1m'
+  | '5m'
+  | '15m'
+  | '30m'
+  | '1H'
+  | '4H'
+  | '1D'
+  | '1W';
+
 // Test account for dev login testing
 export interface ITestAccount {
   id: string;
@@ -67,6 +77,8 @@ export interface IDevSettings {
   // use local trading view URL for development
   useLocalTradingViewUrl?: boolean;
   showPerpsRenderStats?: boolean;
+  mockTradingViewKLineEmptyEnabled?: boolean;
+  mockTradingViewKLineEmptyIntervals?: ITradingViewKLineMockEmptyInterval[];
 
   usbCommunicationMode?: 'webusb' | 'bridge';
 
@@ -127,6 +139,8 @@ export const {
         selectedTab: ETabRoutes.Home,
       },
       useLocalTradingViewUrl: false,
+      mockTradingViewKLineEmptyEnabled: false,
+      mockTradingViewKLineEmptyIntervals: ['1m'],
       allowLocalhostUrlInDAppBrowser: false,
       // Linux Desktop use Bridge，avoiding WebUSB permission problem
       usbCommunicationMode: platformEnv.isDesktopLinux ? 'bridge' : 'webusb',

--- a/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
@@ -1,7 +1,9 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { Stack } from '@onekeyhq/components';
+import { SizableText, Stack } from '@onekeyhq/components';
 import type { IStackStyle } from '@onekeyhq/components';
+import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
+import type { ITradingViewKLineMockEmptyInterval } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -31,6 +33,22 @@ import type { IWebViewRef } from '../../WebView/types';
 import type { WebViewProps } from 'react-native-webview';
 import type { WebViewNavigation } from 'react-native-webview/lib/WebViewTypes';
 
+const MOCK_EMPTY_KLINE_BADGE_POSITION_STYLES = [
+  { right: '$2', bottom: '$2' },
+  { left: '$2', bottom: '$2' },
+  { left: '$2', top: '$2' },
+  { right: '$2', top: '$2' },
+] as const;
+
+function formatMockEmptyKLineIntervals(
+  intervals: ITradingViewKLineMockEmptyInterval[] | undefined,
+) {
+  if (!intervals?.length) {
+    return '未选择周期';
+  }
+  return intervals.join('/');
+}
+
 interface IBaseTradingViewV2Props {
   symbol: string;
   tokenAddress?: string;
@@ -49,6 +67,11 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
   const marksTimeRange = useRef<IMarksTimeRange | null>(null);
   const theme = useThemeVariant();
   const isVisible = useRouteIsFocused();
+  const [devSettings] = useDevSettingsPersistAtom();
+  const [
+    mockEmptyKLineBadgePositionIndex,
+    setMockEmptyKLineBadgePositionIndex,
+  ] = useState(0);
 
   const {
     tokenAddress = '',
@@ -80,6 +103,16 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
   const chartSymbol = useHyperLiquid ? (hyperLiquidSymbol ?? symbol) : symbol;
   const effectiveDataSource =
     dataSource === 'websocket' && !tokenAddress ? 'polling' : dataSource;
+  const mockEmptyKLineEnabled =
+    devSettings.enabled &&
+    devSettings.settings?.mockTradingViewKLineEmptyEnabled;
+  const mockEmptyKLineBadgeText = useMemo(
+    () =>
+      `Mock 空K线 ${formatMockEmptyKLineIntervals(
+        devSettings.settings?.mockTradingViewKLineEmptyIntervals,
+      )}`,
+    [devSettings.settings?.mockTradingViewKLineEmptyIntervals],
+  );
 
   const additionalParams = useMemo(() => {
     return {
@@ -97,13 +130,16 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     additionalParams,
   });
 
-  // Disable OneKey data hooks when using HyperLiquid source
+  // OneKey realtime hooks only apply to app-served market candles.
   useAutoKLineUpdate({
     tokenAddress,
     networkId,
     webRef,
     enabled:
-      isVisible && effectiveDataSource !== 'websocket' && !isHyperLiquidSource,
+      isVisible &&
+      effectiveDataSource !== 'websocket' &&
+      !isHyperLiquidSource &&
+      !mockEmptyKLineEnabled,
   });
 
   useAutoTokenDetailUpdate({
@@ -118,7 +154,10 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     networkId,
     webRef,
     enabled:
-      isVisible && effectiveDataSource === 'websocket' && !isHyperLiquidSource,
+      isVisible &&
+      effectiveDataSource === 'websocket' &&
+      !isHyperLiquidSource &&
+      !mockEmptyKLineEnabled,
     chartType: '1m',
   });
 
@@ -202,6 +241,13 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     [handleNavigation],
   );
 
+  const handleMockEmptyKLineBadgePress = useCallback(() => {
+    setMockEmptyKLineBadgePositionIndex(
+      (positionIndex) =>
+        (positionIndex + 1) % MOCK_EMPTY_KLINE_BADGE_POSITION_STYLES.length,
+    );
+  }, []);
+
   const webView = useMemo(
     () => (
       <WebView
@@ -237,6 +283,27 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
   return (
     <Stack position="relative" flex={1} {...stackStyle}>
       {webView}
+
+      {mockEmptyKLineEnabled ? (
+        <Stack
+          position="absolute"
+          zIndex={2}
+          px="$2"
+          py="$1"
+          borderRadius="$1"
+          bg="#D92D20"
+          cursor="pointer"
+          maxWidth={220}
+          onPress={handleMockEmptyKLineBadgePress}
+          {...MOCK_EMPTY_KLINE_BADGE_POSITION_STYLES[
+            mockEmptyKLineBadgePositionIndex
+          ]}
+        >
+          <SizableText size="$bodyXsMedium" color="white" numberOfLines={2}>
+            {mockEmptyKLineBadgeText}
+          </SizableText>
+        </Stack>
+      ) : null}
 
       {platformEnv.isNativeIOS ? (
         <Stack

--- a/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
@@ -23,6 +23,7 @@ import {
   useTradingViewV2WebSocket,
 } from './hooks';
 import {
+  DEFAULT_TRADING_VIEW_KLINE_RESOLUTION,
   fetchAndSendAccountMarks,
   useTradingViewMessageHandler,
 } from './messageHandlers';
@@ -65,6 +66,7 @@ export type ITradingViewV2Props = IBaseTradingViewV2Props & IStackStyle;
 export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
   const webRef = useRef<IWebViewRef | null>(null);
   const marksTimeRange = useRef<IMarksTimeRange | null>(null);
+  const currentKLineResolution = useRef(DEFAULT_TRADING_VIEW_KLINE_RESOLUTION);
   const theme = useThemeVariant();
   const isVisible = useRouteIsFocused();
   const [devSettings] = useDevSettingsPersistAtom();
@@ -94,6 +96,7 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     accountAddress,
     tokenSymbol: symbol,
     marksTimeRange,
+    currentKLineResolution,
     onTouchScroll,
   });
 
@@ -106,12 +109,12 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
   const mockEmptyKLineEnabled =
     devSettings.enabled &&
     devSettings.settings?.mockTradingViewKLineEmptyEnabled;
+  const mockEmptyKLineIntervals =
+    devSettings.settings?.mockTradingViewKLineEmptyIntervals;
   const mockEmptyKLineBadgeText = useMemo(
     () =>
-      `Mock 空K线 ${formatMockEmptyKLineIntervals(
-        devSettings.settings?.mockTradingViewKLineEmptyIntervals,
-      )}`,
-    [devSettings.settings?.mockTradingViewKLineEmptyIntervals],
+      `Mock 空K线 ${formatMockEmptyKLineIntervals(mockEmptyKLineIntervals)}`,
+    [mockEmptyKLineIntervals],
   );
 
   const additionalParams = useMemo(() => {
@@ -181,6 +184,7 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
         from: timeRange.min,
         to: timeRange.max,
         symbol: chartSymbol,
+        resolution: currentKLineResolution.current,
         webRef,
       });
     };
@@ -234,7 +238,16 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
         handleSwapSuccess,
       );
     };
-  }, [isVisible, accountAddress, tokenAddress, networkId, chartSymbol, webRef]);
+  }, [
+    isVisible,
+    accountAddress,
+    tokenAddress,
+    networkId,
+    chartSymbol,
+    mockEmptyKLineEnabled,
+    mockEmptyKLineIntervals,
+    webRef,
+  ]);
 
   const onShouldStartLoadWithRequest = useCallback(
     (event: WebViewNavigation) => handleNavigation(event),

--- a/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/analyticsHandler/intervalHandler.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/analyticsHandler/intervalHandler.ts
@@ -4,6 +4,7 @@ import type { IMessageHandlerParams } from '../types';
 
 export async function handleAnalyticsInterval({
   data,
+  context,
 }: IMessageHandlerParams): Promise<void> {
   // Safely extract analytics interval data with proper type checking
   const messageData = data.data;
@@ -16,6 +17,9 @@ export async function handleAnalyticsInterval({
     // Extract interval property safely
     const safeData = messageData as unknown as Record<string, unknown>;
     const interval = safeData.TVIntervalSelect as string;
+    if (context.currentKLineResolution) {
+      context.currentKLineResolution.current = interval;
+    }
 
     try {
       // Log to DEX analytics system

--- a/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/index.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/index.ts
@@ -6,6 +6,7 @@ export {
   handleAnalyticsStudyCreated,
 } from './analyticsHandler';
 export {
+  DEFAULT_TRADING_VIEW_KLINE_RESOLUTION,
   fetchAndSendAccountMarks,
   handleKLineDataRequest,
 } from './klineDataHandler';

--- a/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/klineDataHandler.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/klineDataHandler.ts
@@ -1,11 +1,15 @@
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import type { ITradingViewKLineMockEmptyInterval } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import {
   formatBalance,
   formatDisplayNumber,
 } from '@onekeyhq/shared/src/utils/numberUtils';
-import type { IMarketAccountTokenTransaction } from '@onekeyhq/shared/types/marketV2';
+import type {
+  IMarketAccountTokenTransaction,
+  IMarketTokenKLineResponse,
+} from '@onekeyhq/shared/types/marketV2';
 
 import { MESSAGE_TYPES } from '../../TradingViewPerpsV2/constants/messageTypes';
 import { fetchTradingViewV2DataWithSlicing } from '../hooks';
@@ -13,6 +17,69 @@ import { fetchTradingViewV2DataWithSlicing } from '../hooks';
 import type { IMessageHandlerContext, IMessageHandlerParams } from './types';
 
 const MAX_MARKS_COUNT = 60;
+
+function normalizeTradingViewKLineInterval(
+  interval: string,
+): ITradingViewKLineMockEmptyInterval | string {
+  switch (interval) {
+    case '1':
+    case '1m':
+      return '1m';
+    case '5':
+    case '5m':
+      return '5m';
+    case '15':
+    case '15m':
+      return '15m';
+    case '30':
+    case '30m':
+      return '30m';
+    case '60':
+    case '1h':
+    case '1H':
+      return '1H';
+    case '240':
+    case '4h':
+    case '4H':
+      return '4H';
+    case '1d':
+    case '1D':
+      return '1D';
+    case '1w':
+    case '1W':
+      return '1W';
+    default:
+      return interval;
+  }
+}
+
+async function shouldMockEmptyKLineData(resolution: string) {
+  const devSettings =
+    await backgroundApiProxy.serviceDevSetting.getDevSetting();
+
+  if (
+    !devSettings.enabled ||
+    !devSettings.settings?.mockTradingViewKLineEmptyEnabled
+  ) {
+    return false;
+  }
+
+  const selectedInterval =
+    devSettings.settings.mockTradingViewKLineEmptyIntervals ?? [];
+
+  return selectedInterval.some(
+    (interval) =>
+      normalizeTradingViewKLineInterval(resolution) ===
+      normalizeTradingViewKLineInterval(interval),
+  );
+}
+
+function buildEmptyKLineData(): IMarketTokenKLineResponse {
+  return {
+    points: [],
+    total: 0,
+  };
+}
 
 function formatAmount(amount: string) {
   const result = formatDisplayNumber(formatBalance(amount));
@@ -177,13 +244,16 @@ export async function handleKLineDataRequest({
 
     // Use combined function to get sliced data
     try {
-      const kLineData = await fetchTradingViewV2DataWithSlicing({
-        tokenAddress,
-        networkId,
-        interval: resolution,
-        timeFrom: from,
-        timeTo: to,
-      });
+      const shouldMockEmpty = await shouldMockEmptyKLineData(resolution);
+      const kLineData = shouldMockEmpty
+        ? buildEmptyKLineData()
+        : await fetchTradingViewV2DataWithSlicing({
+            tokenAddress,
+            networkId,
+            interval: resolution,
+            timeFrom: from,
+            timeTo: to,
+          });
 
       if (webRef.current && kLineData) {
         webRef.current.sendMessageViaInjectedScript({
@@ -196,7 +266,7 @@ export async function handleKLineDataRequest({
         });
       }
 
-      if (accountAddress && tokenAddress && networkId) {
+      if (!shouldMockEmpty && accountAddress && tokenAddress && networkId) {
         void fetchAndSendAccountMarks({
           accountAddress,
           tokenAddress,

--- a/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/klineDataHandler.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/klineDataHandler.ts
@@ -17,8 +17,9 @@ import { fetchTradingViewV2DataWithSlicing } from '../hooks';
 import type { IMessageHandlerContext, IMessageHandlerParams } from './types';
 
 const MAX_MARKS_COUNT = 60;
+export const DEFAULT_TRADING_VIEW_KLINE_RESOLUTION = '1m';
 
-function normalizeTradingViewKLineInterval(
+export function normalizeTradingViewKLineInterval(
   interval: string,
 ): ITradingViewKLineMockEmptyInterval | string {
   switch (interval) {
@@ -53,7 +54,11 @@ function normalizeTradingViewKLineInterval(
   }
 }
 
-async function shouldMockEmptyKLineData(resolution: string) {
+export async function shouldMockEmptyKLineData(resolution?: string) {
+  if (!resolution) {
+    return false;
+  }
+
   const devSettings =
     await backgroundApiProxy.serviceDevSetting.getDevSetting();
 
@@ -165,6 +170,7 @@ export async function fetchAndSendAccountMarks({
   from,
   to,
   symbol,
+  resolution,
   webRef,
 }: {
   accountAddress?: string;
@@ -173,8 +179,18 @@ export async function fetchAndSendAccountMarks({
   from: number;
   to: number;
   symbol?: string;
+  resolution?: string;
   webRef: IMessageHandlerContext['webRef'];
 }) {
+  if (await shouldMockEmptyKLineData(resolution)) {
+    sendClearAccountMarks({
+      tokenAddress,
+      symbol,
+      webRef,
+    });
+    return;
+  }
+
   if (!accountAddress) {
     return;
   }
@@ -200,6 +216,31 @@ export async function fetchAndSendAccountMarks({
   } catch (error) {
     console.error('Failed to fetch account token transactions:', error);
   }
+}
+
+export function sendClearAccountMarks({
+  tokenAddress,
+  symbol,
+  webRef,
+}: {
+  tokenAddress: string;
+  symbol?: string;
+  webRef: IMessageHandlerContext['webRef'];
+}) {
+  const marksSymbol = symbol || tokenAddress;
+
+  if (!webRef.current || !marksSymbol) {
+    return;
+  }
+
+  webRef.current.sendMessageViaInjectedScript({
+    type: MESSAGE_TYPES.MARKS_UPDATE,
+    payload: {
+      marks: [],
+      symbol: marksSymbol,
+      operation: 'clear',
+    },
+  });
 }
 
 export async function handleKLineDataRequest({
@@ -230,6 +271,9 @@ export async function handleKLineDataRequest({
     const resolution = safeData.resolution as string;
     const from = safeData.from as number;
     const to = safeData.to as number;
+    if (context.currentKLineResolution) {
+      context.currentKLineResolution.current = resolution;
+    }
 
     // Track the time range that user has browsed
     if (marksTimeRange) {
@@ -266,6 +310,14 @@ export async function handleKLineDataRequest({
         });
       }
 
+      if (shouldMockEmpty) {
+        sendClearAccountMarks({
+          tokenAddress,
+          symbol: (safeData.symbol as string) || tokenAddress,
+          webRef,
+        });
+      }
+
       if (!shouldMockEmpty && accountAddress && tokenAddress && networkId) {
         void fetchAndSendAccountMarks({
           accountAddress,
@@ -274,6 +326,7 @@ export async function handleKLineDataRequest({
           from,
           to,
           symbol: (safeData.symbol as string) || tokenAddress,
+          resolution,
           webRef,
         });
       }

--- a/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/types.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/types.ts
@@ -26,6 +26,7 @@ export interface IMessageHandlerContext {
   accountAddress?: string;
   tokenSymbol?: string;
   marksTimeRange?: React.MutableRefObject<IMarksTimeRange | null>;
+  currentKLineResolution?: React.MutableRefObject<string>;
 }
 
 export interface IMessageHandlerParams {

--- a/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/useTradingViewMessageHandler.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/useTradingViewMessageHandler.ts
@@ -8,6 +8,8 @@ import { handleAnalyticsEvent } from './analyticsHandler';
 import {
   fetchAccountTransactionMarks,
   handleKLineDataRequest,
+  sendClearAccountMarks,
+  shouldMockEmptyKLineData,
 } from './klineDataHandler';
 import { handleLayoutUpdate } from './layoutUpdateHandler';
 
@@ -25,6 +27,7 @@ interface IUseTradingViewMessageHandlerParams {
   accountAddress?: string;
   tokenSymbol?: string;
   marksTimeRange?: React.MutableRefObject<IMarksTimeRange | null>;
+  currentKLineResolution?: React.MutableRefObject<string>;
   onTouchScroll?: (deltaY: number) => void;
 }
 
@@ -123,21 +126,41 @@ async function handleGetMarks({
   accountAddress,
   tokenAddress,
   networkId,
+  resolution,
   webRef,
 }: {
   request: {
     requestId?: string;
     from?: number;
     to?: number;
+    symbol?: string;
+    resolution?: string;
   };
   accountAddress?: string;
   tokenAddress: string;
   networkId: string;
+  resolution?: string;
   webRef: React.RefObject<IWebViewRef | null>;
 }) {
   const requestId = request.requestId;
 
   if (!requestId) {
+    return;
+  }
+
+  if (await shouldMockEmptyKLineData(resolution)) {
+    webRef.current?.sendMessageViaInjectedScript({
+      type: 'MARKS_RESPONSE',
+      payload: {
+        marks: [],
+        requestId,
+      },
+    });
+    sendClearAccountMarks({
+      tokenAddress,
+      symbol: request.symbol,
+      webRef,
+    });
     return;
   }
 
@@ -188,6 +211,7 @@ export function useTradingViewMessageHandler({
   accountAddress,
   tokenSymbol,
   marksTimeRange,
+  currentKLineResolution,
   onTouchScroll,
 }: IUseTradingViewMessageHandlerParams) {
   const customReceiveHandler = useCallback(
@@ -209,6 +233,7 @@ export function useTradingViewMessageHandler({
         accountAddress,
         tokenSymbol,
         marksTimeRange,
+        currentKLineResolution,
       };
 
       // Handle TradingView private API requests
@@ -248,15 +273,22 @@ export function useTradingViewMessageHandler({
       }
 
       if (data.scope === '$private' && data.method === 'tradingview_getMarks') {
+        const marksRequest = data.data as {
+          requestId?: string;
+          from?: number;
+          to?: number;
+          symbol?: string;
+          resolution?: string;
+        };
+        const resolution =
+          marksRequest.resolution || currentKLineResolution?.current;
+
         await handleGetMarks({
-          request: data.data as {
-            requestId?: string;
-            from?: number;
-            to?: number;
-          },
+          request: marksRequest,
           accountAddress,
           tokenAddress,
           networkId,
+          resolution,
           webRef,
         });
       }
@@ -280,6 +312,7 @@ export function useTradingViewMessageHandler({
       accountAddress,
       tokenSymbol,
       marksTimeRange,
+      currentKLineResolution,
       onTouchScroll,
     ],
   );

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
@@ -13,6 +13,7 @@ import { Dimensions, I18nManager } from 'react-native';
 
 import {
   Accordion,
+  Checkbox,
   Dialog,
   ESwitchSize,
   Icon,
@@ -30,6 +31,7 @@ import {
   useClipboard,
   useInPageDialog,
 } from '@onekeyhq/components';
+import type { ICheckedState } from '@onekeyhq/components';
 import type { IDialogButtonProps } from '@onekeyhq/components/src/composite/Dialog/type';
 import {
   ANIMATE_ONLY_OPACITY,
@@ -46,6 +48,7 @@ import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accoun
 import { WebEmbedDevConfig } from '@onekeyhq/kit/src/views/Developer/pages/Gallery/Components/stories/WebEmbed';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
+import type { ITradingViewKLineMockEmptyInterval } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
 import appDeviceInfo from '@onekeyhq/shared/src/appDeviceInfo/appDeviceInfo';
 import type { IBackgroundMethodWithDevOnlyPassword } from '@onekeyhq/shared/src/background/backgroundDecorators';
 import { isCorrectDevOnlyPassword } from '@onekeyhq/shared/src/background/backgroundDecorators';
@@ -284,6 +287,149 @@ function hasMatchingDevSettingsSearchItem(node: ReactNode, query: string) {
   return hasMatch;
 }
 
+const TRADING_VIEW_KLINE_EMPTY_MOCK_INTERVAL_ITEMS: {
+  label: string;
+  value: ITradingViewKLineMockEmptyInterval;
+}[] = [
+  { label: '1 minute', value: '1m' },
+  { label: '5 minutes', value: '5m' },
+  { label: '15 minutes', value: '15m' },
+  { label: '30 minutes', value: '30m' },
+  { label: '1 hour', value: '1H' },
+  { label: '4 hours', value: '4H' },
+  { label: '1 day', value: '1D' },
+  { label: '1 week', value: '1W' },
+];
+
+function getTradingViewKLineMockIntervalsText(
+  intervals: ITradingViewKLineMockEmptyInterval[],
+) {
+  if (!intervals.length) {
+    return '未选择周期';
+  }
+
+  const labelMap = new Map(
+    TRADING_VIEW_KLINE_EMPTY_MOCK_INTERVAL_ITEMS.map((item) => [
+      item.value,
+      item.label,
+    ]),
+  );
+
+  return intervals
+    .map((interval) => labelMap.get(interval) ?? interval)
+    .join(', ');
+}
+
+function TradingViewKLineEmptyMockIntervalsDialogContent({
+  initialEnabled,
+  initialValue,
+  onConfirm,
+}: {
+  initialEnabled: boolean;
+  initialValue: ITradingViewKLineMockEmptyInterval[];
+  onConfirm: (params: {
+    enabled: boolean;
+    intervals: ITradingViewKLineMockEmptyInterval[];
+  }) => Promise<void>;
+}) {
+  const [enabled, setEnabled] = useState(initialEnabled);
+  const [selectedIntervals, setSelectedIntervals] =
+    useState<ITradingViewKLineMockEmptyInterval[]>(initialValue);
+  const allIntervals = useMemo(
+    () =>
+      TRADING_VIEW_KLINE_EMPTY_MOCK_INTERVAL_ITEMS.map((item) => item.value),
+    [],
+  );
+  const allSelected = selectedIntervals.length === allIntervals.length;
+
+  const handleEnabledChange = useCallback(
+    (checked: boolean) => {
+      setEnabled(checked);
+
+      if (checked && !selectedIntervals.length) {
+        setSelectedIntervals(['1m']);
+      }
+    },
+    [selectedIntervals.length],
+  );
+
+  const handleSelectAllChange = useCallback(
+    (checked: ICheckedState) => {
+      setSelectedIntervals(checked === true ? allIntervals : []);
+    },
+    [allIntervals],
+  );
+
+  const handleIntervalChange = useCallback(
+    (interval: ITradingViewKLineMockEmptyInterval, checked: ICheckedState) => {
+      setSelectedIntervals((prev) => {
+        if (checked === true) {
+          return prev.includes(interval) ? prev : [...prev, interval];
+        }
+
+        return prev.filter((item) => item !== interval);
+      });
+    },
+    [],
+  );
+
+  const handleConfirm = useCallback(
+    () =>
+      onConfirm({
+        enabled,
+        intervals: selectedIntervals,
+      }),
+    [enabled, onConfirm, selectedIntervals],
+  );
+
+  return (
+    <YStack gap="$3">
+      <XStack alignItems="center" justifyContent="space-between" gap="$4">
+        <YStack flex={1}>
+          <SizableText size="$bodyMdMedium">启用 Mock</SizableText>
+          <SizableText size="$bodySm" color="$textSubdued">
+            开启后，命中的 K 线 history 请求会返回空数据
+          </SizableText>
+        </YStack>
+        <Switch
+          size={ESwitchSize.small}
+          value={enabled}
+          onChange={handleEnabledChange}
+        />
+      </XStack>
+      {enabled ? (
+        <>
+          <Checkbox
+            label="All intervals"
+            value={allSelected}
+            onChange={handleSelectAllChange}
+          />
+          <YStack gap="$2">
+            {TRADING_VIEW_KLINE_EMPTY_MOCK_INTERVAL_ITEMS.map((item) => (
+              <Checkbox
+                key={item.value}
+                label={item.label}
+                value={selectedIntervals.includes(item.value)}
+                onChange={(checked) => {
+                  handleIntervalChange(item.value, checked);
+                }}
+              />
+            ))}
+          </YStack>
+        </>
+      ) : null}
+      <Dialog.Footer
+        showConfirmButton
+        showCancelButton
+        onConfirm={handleConfirm}
+        confirmButtonProps={{
+          disabled: enabled && selectedIntervals.length === 0,
+        }}
+      />
+    </YStack>
+  );
+}
+
 const BaseDevSettingsSection = () => {
   const [settings] = useSettingsPersistAtom();
   const [devSettings] = useDevSettingsPersistAtom();
@@ -293,6 +439,22 @@ const BaseDevSettingsSection = () => {
   const localTradingViewUrlSubtitle = platformEnv.isNativeAndroid
     ? 'http://10.0.2.2:5173/'
     : 'http://localhost:5173/';
+  const mockTradingViewKLineEmptyEnabled =
+    devSettings.settings?.mockTradingViewKLineEmptyEnabled ?? false;
+  const rawMockTradingViewKLineEmptyIntervals =
+    devSettings.settings?.mockTradingViewKLineEmptyIntervals;
+  const mockTradingViewKLineEmptyIntervals = useMemo(
+    () => rawMockTradingViewKLineEmptyIntervals ?? [],
+    [rawMockTradingViewKLineEmptyIntervals],
+  );
+  const mockTradingViewKLineEmptyIntervalsText = useMemo(
+    () =>
+      getTradingViewKLineMockIntervalsText(mockTradingViewKLineEmptyIntervals),
+    [mockTradingViewKLineEmptyIntervals],
+  );
+  const mockTradingViewKLineEmptySubtitle = mockTradingViewKLineEmptyEnabled
+    ? mockTradingViewKLineEmptyIntervalsText
+    : '已关闭';
 
   const handleDevModeOnChange = useCallback(() => {
     Dialog.show({
@@ -314,6 +476,29 @@ const BaseDevSettingsSection = () => {
       },
     });
   }, []);
+
+  const handleOpenMockTradingViewKLineEmptyIntervalsDialog = useCallback(() => {
+    Dialog.show({
+      title: 'Mock 空 K 线周期',
+      description: '选择一个或多个周期，命中后 history 请求会返回空数据。',
+      renderContent: (
+        <TradingViewKLineEmptyMockIntervalsDialogContent
+          initialEnabled={mockTradingViewKLineEmptyEnabled}
+          initialValue={mockTradingViewKLineEmptyIntervals}
+          onConfirm={async ({ enabled, intervals }) => {
+            await backgroundApiProxy.serviceDevSetting.updateDevSetting(
+              'mockTradingViewKLineEmptyEnabled',
+              enabled,
+            );
+            await backgroundApiProxy.serviceDevSetting.updateDevSetting(
+              'mockTradingViewKLineEmptyIntervals',
+              intervals,
+            );
+          }}
+        />
+      ),
+    });
+  }, [mockTradingViewKLineEmptyEnabled, mockTradingViewKLineEmptyIntervals]);
 
   const forceIntoRTL = useCallback(() => {
     I18nManager.forceRTL(!I18nManager.isRTL);
@@ -1549,6 +1734,14 @@ const BaseDevSettingsSection = () => {
                       >
                         <Switch size={ESwitchSize.small} />
                       </SectionFieldItem>
+                      <SectionPressItem
+                        icon="TradeOutline"
+                        title="Mock TradingView 空 K 线"
+                        subtitle={mockTradingViewKLineEmptySubtitle}
+                        onPress={
+                          handleOpenMockTradingViewKLineEmptyIntervalsDialog
+                        }
+                      />
                       <SectionFieldItem
                         icon="BrowserOutline"
                         name="allowLocalhostUrlInDAppBrowser"


### PR DESCRIPTION
## Summary
- New developer-only toggle in Dev Settings to force TradingView K-Line history requests to return empty data, scoped to selected intervals (1m / 5m / 15m / 30m / 1H / 4H / 1D / 1W).
- While the mock is active, OneKey realtime/polling K-Line update hooks are suspended so the chart stays empty instead of being repopulated.
- A red badge is overlaid on the chart while mocking is on; tapping it cycles the badge through the four corners so it never sits on top of UI a QA tester needs to inspect.

## Intent & Context
We needed a fast way to verify how the TradingView chart behaves when a token has no K-Line data for a given resolution (empty state, blank candles, error fallbacks, etc.). Reproducing this in production data is unreliable because real tokens nearly always have *some* candles, and switching backends just to test empty responses is heavy. Adding a dev-only switch lets engineering and QA validate the empty-state UI in seconds on any token.

## Design Decisions
- **Per-interval selection** instead of a global on/off — most empty-data bugs are interval-specific (e.g., a new token has 1m candles but no 1W), so the toggle accepts a list of resolutions.
- **Mock at the message-handler layer** (`klineDataHandler`) rather than inside the data-fetch hooks. This guarantees both the in-flight history response and any subsequent re-requests by the TradingView iframe return the same empty payload, regardless of whether the chart uses websocket or polling.
- **Disable realtime hooks when mocking** so newly arrived candles don't sneak back into the chart and silently invalidate the test. The mock is treated as a stateful "no data" mode, not just a one-shot filter.
- **Tappable badge with rotating corners** rather than a static label. During testing it became clear the badge can sit on top of the price scale, MA labels, or the WS-status badge depending on token; letting the user cycle positions keeps the indicator visible without obscuring whatever the tester is inspecting.
- **Interval normalization** in the handler (`normalizeTradingViewKLineInterval`) — TradingView sends resolutions as `1`, `60`, `240`, `1D`, etc., while the dev UI stores `1m`, `1H`, `4H`, `1D`. A single canonical form prevents accidental mismatches across the two value spaces.
- **Default to `['1m']`** when the user flips the toggle on without any interval selected, so it's never possible to "enable" mocking and silently mock nothing.

## Changes Detail
- `packages/kit-bg/src/states/jotai/atoms/devSettings.ts` — adds the `ITradingViewKLineMockEmptyInterval` type, two new persisted fields (`mockTradingViewKLineEmptyEnabled`, `mockTradingViewKLineEmptyIntervals`), and their defaults.
- `packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx` — new `TradingViewKLineEmptyMockIntervalsDialogContent` dialog with switch + select-all + per-interval checkboxes, plus a `SectionPressItem` entry that summarizes the current state.
- `packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/klineDataHandler.ts` — `shouldMockEmptyKLineData` reads dev settings and matches the requested resolution; when active, returns an empty `IMarketTokenKLineResponse` and skips `fetchAndSendAccountMarks` so we don't backfill marks on top of the empty chart.
- `packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx` — gates `useAutoKLineUpdate` and `useTokenWebSocketSubscription` on the mock flag, and renders the rotating red overlay badge that lists the currently mocked intervals.

## Risk Assessment
- **Risk Level**: Low — feature is gated behind \`devSettings.enabled\`, so it is unreachable in production builds.
- **Affected Platforms**: Desktop / Mobile / Web / Extension (any platform that renders TradingView V2).
- **Risk Areas**: The realtime-hook gating is the most behavior-changing piece; if \`mockTradingViewKLineEmptyEnabled\` were ever true in a production build, the chart would not auto-update. The dev-settings guard makes this impossible outside dev mode, but the conditional should be the focus of review.

## Test plan
- [ ] Enable dev mode, open Dev Settings → "Mock TradingView 空 K 线", toggle on with default `1m` selected, open any token chart at 1m, confirm the candles are empty and the red badge appears.
- [ ] Switch the chart resolution to 5m / 15m / 1H etc. and confirm normal data loads for non-selected intervals.
- [ ] Select multiple intervals (e.g. 1m + 1H + 1D), confirm all selected intervals return empty and others load normally.
- [ ] Tap the red badge multiple times; verify it cycles through bottom-right → bottom-left → top-left → top-right → bottom-right.
- [ ] Toggle the dev switch off; verify the badge disappears and realtime updates resume on the chart.
- [ ] Verify dev mode disabled (\`devSettings.enabled = false\`): the mock has no effect even if the persisted fields are true.