### PR TITLE
fix(onboarding-v2): keyboard handling on import phrase page (OK-54637 OK-54645 OK-54647)

### DIFF
--- a/packages/kit/src/views/Onboardingv2/components/Layout.tsx
+++ b/packages/kit/src/views/Onboardingv2/components/Layout.tsx
@@ -14,8 +14,9 @@ import {
   Divider,
   Icon,
   IconButton,
+  KEYBOARD_AWARE_SCROLL_BOTTOM_OFFSET,
+  Keyboard,
   Page,
-  ScrollView,
   Select,
   SizableText,
   XStack,
@@ -189,6 +190,11 @@ export interface IOnboardingPageProps extends IPageProps {
   alignTop?: boolean;
   narrow?: boolean;
   backgroundLayer?: React.ReactNode;
+  /**
+   * Extra offset above the keyboard. Increase when a Page.Footer is rendered
+   * so the focused input clears the footer area, not just the keyboard.
+   */
+  keyboardBottomOffset?: number;
   children: React.ReactNode;
 }
 
@@ -202,6 +208,7 @@ export function OnboardingPage({
   alignTop = false,
   narrow = false,
   backgroundLayer,
+  keyboardBottomOffset = KEYBOARD_AWARE_SCROLL_BOTTOM_OFFSET,
   children,
   ...pageProps
 }: IOnboardingPageProps) {
@@ -265,9 +272,14 @@ export function OnboardingPage({
         {showLanguageSelector ? <LayoutHeaderLanguageSelector /> : null}
       </LayoutHeader>
       {scrollable ? (
-        <ScrollView flex={1} contentContainerStyle={{ flexGrow: 1 }}>
+        <Keyboard.AwareScrollView
+          style={{ flex: 1 }}
+          contentContainerStyle={{ flexGrow: 1 }}
+          keyboardShouldPersistTaps="handled"
+          bottomOffset={keyboardBottomOffset}
+        >
           {contentArea}
-        </ScrollView>
+        </Keyboard.AwareScrollView>
       ) : (
         contentArea
       )}

--- a/packages/kit/src/views/Onboardingv2/pages/CreateOrImportWallet.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/CreateOrImportWallet.tsx
@@ -364,8 +364,10 @@ function CreateOrImportWallet() {
             {intl.formatMessage({ id: ETranslations.more_options })}
           </SizableText>
           <YStack
+            pb="$5"
             $gtMd={{
               mx: '$-5',
+              pb: '$5',
             }}
           >
             {secondaryOptions.map(renderSecondaryItem)}

--- a/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
@@ -2,27 +2,23 @@ import type { ReactNode, RefObject } from 'react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { useRoute } from '@react-navigation/core';
-import { noop } from 'lodash';
 import { useIntl } from 'react-intl';
 import { StyleSheet } from 'react-native';
-import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 
 import type { IInputRef, ITextAreaInputProps } from '@onekeyhq/components';
 import {
   Button,
   HeightTransition,
   Icon,
+  KEYBOARD_AWARE_SCROLL_BOTTOM_OFFSET,
+  Page,
   Portal,
   SegmentControl,
   SizableText,
-  Stack,
   TextAreaInput,
   XStack,
   YStack,
-  useKeyboardEvent,
   useMedia,
-  useReanimatedKeyboardAnimation,
-  useSafeAreaInsets,
 } from '@onekeyhq/components';
 import type { IKeyOfIcons } from '@onekeyhq/components/src/primitives';
 import { ANIMATE_ONLY_OPACITY } from '@onekeyhq/components/src/utils/animationConstants';
@@ -300,28 +296,6 @@ export default function ImportPhraseOrPrivateKey() {
     }
   };
 
-  const { height } = useReanimatedKeyboardAnimation();
-  const { bottom: safeAreaBottom } = useSafeAreaInsets();
-  const [isKeyboardVisible, setIsKeyboardVisible] = useState(
-    selected === EOnboardingV2ImportPhraseOrPrivateKeyTab.Phrase,
-  );
-  useKeyboardEvent({
-    keyboardWillShow: () => setIsKeyboardVisible(true),
-    keyboardWillHide: () => setIsKeyboardVisible(false),
-  });
-
-  // The root layout adds pb: safeAreaBottom + 10 which creates a gap below
-  // the footer when keyboard is up. Compensate by translating down half that
-  // distance so the footer content is vertically centered.
-  const rootBottomPadding = safeAreaBottom + 10;
-  const footerAnimatedStyle = useAnimatedStyle(() => ({
-    transform: [
-      {
-        translateY: height.value < 0 ? height.value + rootBottomPadding / 2 : 0,
-      },
-    ],
-  }));
-
   const renderHardwarePhrasesWarningTag = useCallback(
     (chunks: ReactNode[]) => (
       <SizableText
@@ -346,7 +320,11 @@ export default function ImportPhraseOrPrivateKey() {
   );
 
   return (
-    <OnboardingPage testID={OnboardingTestIDs.importPhrasePage} scrollable>
+    <OnboardingPage
+      testID={OnboardingTestIDs.importPhrasePage}
+      scrollable
+      keyboardBottomOffset={KEYBOARD_AWARE_SCROLL_BOTTOM_OFFSET + 80}
+    >
       <YStack $gtMd={{ flexDirection: 'row' }}>
         <YStack gap="$8" $gtMd={{ flex: 1, gap: '$12' }}>
           <OnboardingHeading>
@@ -354,7 +332,7 @@ export default function ImportPhraseOrPrivateKey() {
               id: ETranslations.global_import_wallet,
             })}
           </OnboardingHeading>
-          <YStack gap="$5">
+          <YStack gap="$5" pb="$5">
             <SegmentControl
               value={selected}
               fullWidth
@@ -463,73 +441,22 @@ export default function ImportPhraseOrPrivateKey() {
         ) : null}
       </YStack>
       {!gtMd ? (
-        <XStack
-          mt="auto"
-          minHeight="$6"
-          justifyContent="center"
-          alignItems="center"
-        >
-          {platformEnv.isNative ? (
-            <YStack>
-              <Animated.View style={footerAnimatedStyle}>
-                <YStack>
-                  {isKeyboardVisible ? (
-                    <Stack
-                      mx="$-5"
-                      borderTopWidth={StyleSheet.hairlineWidth}
-                      borderColor="$borderSubdued"
-                    />
-                  ) : null}
-                  <XStack
-                    bg="$bgApp"
-                    alignItems="center"
-                    justifyContent="center"
-                    pt="$3"
-                    pb={500}
-                    mb={-500}
-                  >
-                    <YStack w="100%" gap="$3">
-                      <HeightTransition>
-                        <XStack onPress={noop}>
-                          <Portal.Container
-                            name={Portal.Constant.SUGGESTION_LIST}
-                          />
-                        </XStack>
-                      </HeightTransition>
-                      <Button
-                        testID={OnboardingTestIDs.importPhraseConfirmBtn}
-                        size="large"
-                        variant="primary"
-                        onPress={handleConfirm}
-                        loading={isConfirming}
-                        w="100%"
-                      >
-                        {intl.formatMessage({
-                          id: ETranslations.global_confirm,
-                        })}
-                      </Button>
-                    </YStack>
-                  </XStack>
-                </YStack>
-              </Animated.View>
-            </YStack>
-          ) : (
-            <YStack w="100%" pb="$5">
-              <Button
-                testID={OnboardingTestIDs.importPhraseConfirmBtn}
-                size="large"
-                variant="primary"
-                onPress={handleConfirm}
-                loading={isConfirming}
-                w="100%"
-              >
-                {intl.formatMessage({
-                  id: ETranslations.global_confirm,
-                })}
-              </Button>
-            </YStack>
-          )}
-        </XStack>
+        <Page.Footer>
+          <Page.FooterActions
+            onConfirmText={intl.formatMessage({
+              id: ETranslations.global_confirm,
+            })}
+            confirmButtonProps={{
+              testID: OnboardingTestIDs.importPhraseConfirmBtn,
+              onPress: handleConfirm,
+              loading: isConfirming,
+            }}
+          >
+            <HeightTransition>
+              <Portal.Container name={Portal.Constant.SUGGESTION_LIST} />
+            </HeightTransition>
+          </Page.FooterActions>
+        </Page.Footer>
       ) : null}
     </OnboardingPage>
   );

--- a/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ImportPhraseOrPrivateKey.tsx
@@ -19,6 +19,7 @@ import {
   XStack,
   YStack,
   useMedia,
+  useSafeAreaInsets,
 } from '@onekeyhq/components';
 import type { IKeyOfIcons } from '@onekeyhq/components/src/primitives';
 import { ANIMATE_ONLY_OPACITY } from '@onekeyhq/components/src/utils/animationConstants';
@@ -248,6 +249,7 @@ export default function ImportPhraseOrPrivateKey() {
   const [isConfirming, setIsConfirming] = useState(false);
   const intl = useIntl();
   const [privateKey, setPrivateKey] = useState('');
+  const { bottom: safeAreaBottom } = useSafeAreaInsets();
 
   const sidebarFaqs =
     selected === EOnboardingV2ImportPhraseOrPrivateKeyTab.Phrase
@@ -443,6 +445,7 @@ export default function ImportPhraseOrPrivateKey() {
       {!gtMd ? (
         <Page.Footer>
           <Page.FooterActions
+            pb={safeAreaBottom ? safeAreaBottom + 8 : 20}
             onConfirmText={intl.formatMessage({
               id: ETranslations.global_confirm,
             })}


### PR DESCRIPTION
## Summary

Fixes three keyboard-related issues on the Onboardingv2 recovery-phrase import page on iOS.

- **OK-54637 — suggestion taps did nothing.** The page sat inside a `ScrollView` whose default `keyboardShouldPersistTaps='never'` dismissed the keyboard and swallowed the press before the suggestion button received it. Setting it to `'handled'` lets the press through.
- **OK-54645 — lower inputs were hidden by the keyboard.** Replaced the plain `ScrollView` in `OnboardingPage` with `Keyboard.AwareScrollView` from `react-native-keyboard-controller`, matching how v1 `<Page scrollEnabled>` already works internally. Added a `keyboardBottomOffset` prop so pages that render a `Page.Footer` (Confirm + suggestion bar) can reserve enough clearance above the keyboard; the import page passes `KEYBOARD_AWARE_SCROLL_BOTTOM_OFFSET + 80`.
- **OK-54647 — footer was floating too high above the keyboard.** The mobile footer used a manual `Animated.View translateY` worklet to push itself above the keyboard. Combined with `Keyboard.AwareScrollView`'s auto-scroll, the footer was translated twice. Refactored the footer to `Page.Footer` + `Page.FooterActions`, which renders outside the scroll container and uses the built-in `paddingBottom` keyboard animation — same pattern as v1 `ImportRecoveryPhrase`. Removes the local `useReanimatedKeyboardAnimation` / `useSafeAreaInsets` / `useKeyboardEvent` hooks and the `pb={500}/mb={-500}` background-extension trick.

Also includes a small unrelated spacing tweak on `CreateOrImportWallet` (bottom padding on the secondary options group).

## Test plan

- [ ] iOS: focus input #1, suggestions appear above Confirm, tapping a suggestion fills the input and keyboard stays up
- [ ] iOS: focus input #11/#12, the focused input is scrolled into view above the keyboard and above the Page.Footer
- [ ] iOS: with the suggestion bar visible, the focused input is not occluded by the footer
- [ ] iOS: Confirm button stays just above the keyboard at all times; no large gap when the keyboard is up
- [ ] Android: same scenarios behave reasonably (no regression vs current behaviour)
- [ ] Web / desktop: gtMd layout still renders the inline Confirm button; no footer regressions
- [ ] Private key tab: paste / scan / eye-toggle still work; Confirm navigates to SelectPrivateKeyNetwork