### PR TITLE
fix: preserve tiny limit prices (OK-54655)

### DIFF
--- a/packages/kit/src/states/jotai/contexts/swap/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/atoms.ts
@@ -5,6 +5,7 @@ import type { IToken } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/compo
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { dangerAllNetworkRepresent } from '@onekeyhq/shared/src/config/presetNetworks';
 import type { ICustomPriorityFeeOverride } from '@onekeyhq/shared/src/utils/marketPresetFeeUtils';
+import { getSwapLimitPriceRateDecimals } from '@onekeyhq/shared/src/utils/swapLimitPriceUtils';
 import { sortSwapQuotes } from '@onekeyhq/shared/src/utils/swapQuoteSortUtils';
 import {
   checkWrappedTokenPair,
@@ -683,18 +684,14 @@ export const {
     const rate = fromPriceBN
       .div(toPriceBN)
       .decimalPlaces(
-        Number(
-          toTokenPriceInfo.tokenInfo.decimals ?? LIMIT_PRICE_DEFAULT_DECIMALS,
-        ),
+        getSwapLimitPriceRateDecimals(toTokenPriceInfo.tokenInfo.decimals),
         BigNumber.ROUND_HALF_UP,
       )
       .toFixed();
     const reverseRate = toPriceBN
       .div(fromPriceBN)
       .decimalPlaces(
-        Number(
-          fromTokenPriceInfo.tokenInfo.decimals ?? LIMIT_PRICE_DEFAULT_DECIMALS,
-        ),
+        getSwapLimitPriceRateDecimals(fromTokenPriceInfo.tokenInfo.decimals),
         BigNumber.ROUND_HALF_UP,
       )
       .toFixed();

--- a/packages/kit/src/views/Swap/hooks/useSwapLimitRate.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapLimitRate.ts
@@ -15,6 +15,7 @@ import {
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
 import { validateAmountInput } from '@onekeyhq/kit/src/utils/validateAmountInput';
 import { useInAppNotificationAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { getSwapLimitPriceRateDecimals } from '@onekeyhq/shared/src/utils/swapLimitPriceUtils';
 import {
   checkWrappedTokenPair,
   equalTokenNoCaseSensitive,
@@ -152,8 +153,12 @@ export const useSwapLimitRate = () => {
       const isValidate = validateAmountInput(
         text,
         limitPriceSetReverse
-          ? limitPriceMarketPrice.fromToken?.decimals
-          : limitPriceMarketPrice.toToken?.decimals,
+          ? getSwapLimitPriceRateDecimals(
+              limitPriceMarketPrice.fromToken?.decimals,
+            )
+          : getSwapLimitPriceRateDecimals(
+              limitPriceMarketPrice.toToken?.decimals,
+            ),
       );
       if (isValidate) {
         const inputRate = new BigNumber(text);
@@ -174,13 +179,17 @@ export const useSwapLimitRate = () => {
             : new BigNumber(1).div(inputBN);
           const newReverseRateValue = newReverseRate
             .decimalPlaces(
-              Number(limitPriceMarketPrice.fromToken?.decimals ?? 0),
+              getSwapLimitPriceRateDecimals(
+                limitPriceMarketPrice.fromToken?.decimals,
+              ),
               BigNumber.ROUND_HALF_UP,
             )
             .toFixed();
           const newRateValue = newRate
             .decimalPlaces(
-              Number(limitPriceMarketPrice.toToken?.decimals ?? 0),
+              getSwapLimitPriceRateDecimals(
+                limitPriceMarketPrice.toToken?.decimals,
+              ),
               BigNumber.ROUND_HALF_UP,
             )
             .toFixed();
@@ -240,7 +249,7 @@ export const useSwapLimitRate = () => {
       const useRateBN = new BigNumber(limitPriceUseRate.rate ?? '0');
       const rateBN = priceMarketBN.multipliedBy(percentageBN);
       const formatRate = rateBN.decimalPlaces(
-        Number(limitPriceMarketPrice.toToken?.decimals ?? 0),
+        getSwapLimitPriceRateDecimals(limitPriceMarketPrice.toToken?.decimals),
         BigNumber.ROUND_HALF_UP,
       );
       const limitPriceEqualMarket = useRateBN.eq(formatRate);
@@ -272,11 +281,13 @@ export const useSwapLimitRate = () => {
         ? new BigNumber(0)
         : new BigNumber(1).div(rateBN);
       const formatRate = rateBN.decimalPlaces(
-        Number(limitPriceMarketPrice.toToken?.decimals ?? 0),
+        getSwapLimitPriceRateDecimals(limitPriceMarketPrice.toToken?.decimals),
         BigNumber.ROUND_HALF_UP,
       );
       const formatReverseRate = reverseRateBN.decimalPlaces(
-        Number(limitPriceMarketPrice.fromToken?.decimals ?? 0),
+        getSwapLimitPriceRateDecimals(
+          limitPriceMarketPrice.fromToken?.decimals,
+        ),
         BigNumber.ROUND_HALF_UP,
       );
       setLimitPriceUseRate((v) => ({

--- a/packages/kit/src/views/Swap/pages/components/SwapProLimitPriceValue.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProLimitPriceValue.tsx
@@ -8,6 +8,10 @@ import {
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
 import { ESwapDirection } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useTradeType';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  formatSwapLimitTokenPriceInputValue,
+  getSwapLimitPriceRateDecimals,
+} from '@onekeyhq/shared/src/utils/swapLimitPriceUtils';
 
 import SwapProLimitPriceInput from '../../components/SwapProLimitPriceInput';
 import { useSwapLimitRate } from '../../hooks/useSwapLimitRate';
@@ -71,7 +75,7 @@ const SwapProLimitPriceValue = ({
         return '';
       }
       const toTokenPrice = fromTokenPriceBN.dividedBy(limitRateBN);
-      return toTokenPrice.decimalPlaces(6, BigNumber.ROUND_HALF_UP).toFixed();
+      return formatSwapLimitTokenPriceInputValue(toTokenPrice);
     }
     // SELL: show fromToken price
     // limit price = fromToken price / toToken price
@@ -83,7 +87,7 @@ const SwapProLimitPriceValue = ({
       return '';
     }
     const fromTokenPrice = toTokenPriceBN.multipliedBy(limitRateBN);
-    return fromTokenPrice.decimalPlaces(6, BigNumber.ROUND_HALF_UP).toFixed();
+    return formatSwapLimitTokenPriceInputValue(fromTokenPrice);
   }, [
     swapLimitPriceUseRate.rate,
     swapProDirection,
@@ -115,9 +119,7 @@ const SwapProLimitPriceValue = ({
         return '';
       }
       const toTokenMarketPrice = fromTokenPriceBN.dividedBy(marketRateBN);
-      return toTokenMarketPrice
-        .decimalPlaces(6, BigNumber.ROUND_HALF_UP)
-        .toFixed();
+      return formatSwapLimitTokenPriceInputValue(toTokenMarketPrice);
     }
     // SELL: show fromToken market price
     // market limit price = fromToken price / toToken price
@@ -129,9 +131,7 @@ const SwapProLimitPriceValue = ({
       return '';
     }
     const fromTokenMarketPrice = toTokenPriceBN.multipliedBy(marketRateBN);
-    return fromTokenMarketPrice
-      .decimalPlaces(6, BigNumber.ROUND_HALF_UP)
-      .toFixed();
+    return formatSwapLimitTokenPriceInputValue(fromTokenMarketPrice);
   }, [
     limitPriceMarketPrice.rate,
     swapProDirection,
@@ -223,7 +223,9 @@ const SwapProLimitPriceValue = ({
           return;
         }
         const newLimitRate = fromTokenPriceBN.dividedBy(tokenPriceBN);
-        const decimals = Number(limitPriceMarketPrice.toToken?.decimals ?? 8);
+        const decimals = getSwapLimitPriceRateDecimals(
+          limitPriceMarketPrice.toToken?.decimals,
+        );
         const formattedRate = newLimitRate
           .decimalPlaces(decimals, BigNumber.ROUND_HALF_UP)
           .toFixed();
@@ -240,7 +242,9 @@ const SwapProLimitPriceValue = ({
         return;
       }
       const newLimitRate = tokenPriceBN.dividedBy(toTokenPriceBN);
-      const decimals = Number(limitPriceMarketPrice.toToken?.decimals ?? 8);
+      const decimals = getSwapLimitPriceRateDecimals(
+        limitPriceMarketPrice.toToken?.decimals,
+      );
       const formattedRate = newLimitRate
         .decimalPlaces(decimals, BigNumber.ROUND_HALF_UP)
         .toFixed();
@@ -294,7 +298,9 @@ const SwapProLimitPriceValue = ({
         return;
       }
       const newLimitRate = fromTokenPriceBN.dividedBy(tokenPriceBN);
-      const decimals = Number(limitPriceMarketPrice.toToken?.decimals ?? 8);
+      const decimals = getSwapLimitPriceRateDecimals(
+        limitPriceMarketPrice.toToken?.decimals,
+      );
       const formattedRate = newLimitRate
         .decimalPlaces(decimals, BigNumber.ROUND_HALF_UP)
         .toFixed();
@@ -313,7 +319,9 @@ const SwapProLimitPriceValue = ({
       return;
     }
     const newLimitRate = tokenPriceBN.dividedBy(toTokenPriceBN);
-    const decimals = Number(limitPriceMarketPrice.toToken?.decimals ?? 8);
+    const decimals = getSwapLimitPriceRateDecimals(
+      limitPriceMarketPrice.toToken?.decimals,
+    );
     const formattedRate = newLimitRate
       .decimalPlaces(decimals, BigNumber.ROUND_HALF_UP)
       .toFixed();
@@ -375,7 +383,9 @@ const SwapProLimitPriceValue = ({
           return;
         }
         const newLimitRate = fromTokenPriceBN.dividedBy(newTokenPrice);
-        const decimals = Number(limitPriceMarketPrice.toToken?.decimals ?? 8);
+        const decimals = getSwapLimitPriceRateDecimals(
+          limitPriceMarketPrice.toToken?.decimals,
+        );
         const formattedRate = newLimitRate
           .decimalPlaces(decimals, BigNumber.ROUND_HALF_UP)
           .toFixed();
@@ -391,7 +401,9 @@ const SwapProLimitPriceValue = ({
         return;
       }
       const newLimitRate = newTokenPrice.dividedBy(toTokenPriceBN);
-      const decimals = Number(limitPriceMarketPrice.toToken?.decimals ?? 8);
+      const decimals = getSwapLimitPriceRateDecimals(
+        limitPriceMarketPrice.toToken?.decimals,
+      );
       const formattedRate = newLimitRate
         .decimalPlaces(decimals, BigNumber.ROUND_HALF_UP)
         .toFixed();

--- a/packages/shared/src/utils/swapLimitPriceUtils.test.ts
+++ b/packages/shared/src/utils/swapLimitPriceUtils.test.ts
@@ -1,0 +1,29 @@
+import {
+  formatSwapLimitTokenPriceInputValue,
+  getSwapLimitPriceRateDecimals,
+} from './swapLimitPriceUtils';
+
+describe('swapLimitPriceUtils', () => {
+  test('keeps enough rate precision for stablecoin quote pairs', () => {
+    expect(getSwapLimitPriceRateDecimals(6)).toBe(18);
+    expect(getSwapLimitPriceRateDecimals(24)).toBe(24);
+    expect(getSwapLimitPriceRateDecimals()).toBe(18);
+  });
+
+  test('formats tiny token prices without rounding them to zero', () => {
+    expect(formatSwapLimitTokenPriceInputValue('0.0000000214562')).toBe(
+      '0.00000002146',
+    );
+    expect(formatSwapLimitTokenPriceInputValue('0.0000000002146')).toBe(
+      '0.0000000002146',
+    );
+  });
+
+  test('uses plain input-safe strings for normal prices', () => {
+    expect(formatSwapLimitTokenPriceInputValue('1.230000')).toBe('1.23');
+    expect(formatSwapLimitTokenPriceInputValue('1234.56789123')).toBe(
+      '1234.567891',
+    );
+    expect(formatSwapLimitTokenPriceInputValue('0')).toBe('');
+  });
+});

--- a/packages/shared/src/utils/swapLimitPriceUtils.ts
+++ b/packages/shared/src/utils/swapLimitPriceUtils.ts
@@ -1,0 +1,39 @@
+import BigNumber from 'bignumber.js';
+
+import {
+  LIMIT_PRICE_DEFAULT_DECIMALS,
+  LIMIT_PRICE_RATE_DECIMALS,
+} from '../../types/swap/types';
+
+const LIMIT_PRICE_INPUT_SIGNIFICANT_DECIMALS = 4;
+const LIMIT_PRICE_INPUT_DEFAULT_DECIMALS = 6;
+
+export function getSwapLimitPriceRateDecimals(tokenDecimals?: number) {
+  const decimals = Number(tokenDecimals ?? LIMIT_PRICE_DEFAULT_DECIMALS);
+  return Math.max(
+    Number.isFinite(decimals) ? decimals : LIMIT_PRICE_DEFAULT_DECIMALS,
+    LIMIT_PRICE_RATE_DECIMALS,
+  );
+}
+
+function countLeadingZeroDecimals(value: BigNumber) {
+  const [, decimalPart = ''] = value.abs().toFixed().split('.');
+  const firstNonZeroIndex = decimalPart.search(/[1-9]/);
+  return firstNonZeroIndex < 0 ? 0 : firstNonZeroIndex;
+}
+
+export function formatSwapLimitTokenPriceInputValue(value?: BigNumber.Value) {
+  const valueBN = new BigNumber(value ?? '');
+  if (!valueBN.isFinite() || valueBN.lte(0)) {
+    return '';
+  }
+
+  const decimalPlaces = valueBN.abs().gte(1)
+    ? LIMIT_PRICE_INPUT_DEFAULT_DECIMALS
+    : countLeadingZeroDecimals(valueBN) +
+      LIMIT_PRICE_INPUT_SIGNIFICANT_DECIMALS;
+
+  return valueBN
+    .decimalPlaces(decimalPlaces, BigNumber.ROUND_HALF_UP)
+    .toFixed();
+}

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -1026,6 +1026,7 @@ export interface ISwapTxHistory {
 // limit order
 
 export const LIMIT_PRICE_DEFAULT_DECIMALS = 6;
+export const LIMIT_PRICE_RATE_DECIMALS = 18;
 
 export interface ISwapCowSwapOrderFee {
   fullFeeAmount?: string;


### PR DESCRIPTION
## Summary
- Preserve enough Limit order rate precision for tiny-price tokens.
- Format Swap Pro Limit Price input values with dynamic precision instead of fixed 6 decimals.
- Add focused utility tests for tiny price display and rate precision.

## Issues
- Fixes OK-54655

## Note
- This PR intentionally fixes OK-54655 only. OK-54649 remains pending.

## Intent & Context
OK-54655 reports that a tiny-price token in Swap Pro mode shows `Limit Price` as `0` after switching to Limit. The expected behavior is to prefill the token's current market price, not zero.

## Root Cause
Limit market price and user-selected rates were rounded using token decimal precision. For 6-decimal stablecoin quote pairs, tiny market rates could be rounded down to `0`. The Limit Price display also forced token prices to 6 decimals, so valid tiny USD prices were displayed as `0`.

## Design Decisions
- Kept rate calculations as plain numeric strings and raised minimum Limit rate precision to 18 decimals.
- Kept display input values free of currency symbols/subscript formatting because the value is fed into an editable numeric input.
- Centralized the precision and display rules in `swapLimitPriceUtils` so initialization, manual edits, and market-price presets use the same boundary.

## Changes Detail
- `swapLimitPriceUtils`: adds shared helpers for Limit rate precision and tiny price input formatting.
- Swap Jotai atoms and `useSwapLimitRate`: use the shared precision helper for market rate, reverse rate, validation, and preset calculations.
- `SwapProLimitPriceValue`: formats tiny token prices without rounding them to zero.
- Added focused tests for stablecoin quote precision and tiny token price formatting.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Desktop / Web / Extension
- **Risk Areas**: Limit order rate calculation and editable price input formatting.

## Test plan
- [x] `yarn jest packages/shared/src/utils/swapLimitPriceUtils.test.ts --runInBand`
- [x] `yarn lint:staged`
- [x] `git diff --cached --check`
- [ ] `yarn tsc:staged` (blocked by existing unrelated `BackgroundThread.restart` type error in `packages/shared/src/modules3rdParty/appRestart/index.native.ts`)
