### PR TITLE
fix: NFT send loading + hide swap service fee row (OK-54667 OK-54587)

### DIFF
--- a/packages/kit/src/components/TxAction/TxActionSwapInfo.tsx
+++ b/packages/kit/src/components/TxAction/TxActionSwapInfo.tsx
@@ -14,10 +14,7 @@ import {
   XStack,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import {
-  swapServiceFeeDefault,
-  swapSlippageDecimal,
-} from '@onekeyhq/shared/types/swap/SwapProvider.constants';
+import { swapSlippageDecimal } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
 import type { ISwapTxInfo } from '@onekeyhq/shared/types/swap/types';
 
 import { useAccountData } from '../../hooks/useAccountData';
@@ -25,7 +22,6 @@ import {
   InfoItem,
   InfoItemGroup,
 } from '../../views/AssetDetails/pages/HistoryDetails/components/TxDetailsInfoItem';
-import { SwapServiceFeeOverview } from '../../views/Swap/components/SwapServiceFeeOverview';
 import { NetworkAvatar } from '../NetworkAvatar';
 
 interface IProps {
@@ -46,7 +42,6 @@ function TxActionSwapInfo(props: IProps) {
     instantRate,
     slippage,
     unSupportSlippage,
-    fee,
   } = swapBuildResData.result;
 
   const { network: senderNetwork } = useAccountData({
@@ -98,41 +93,6 @@ function TxActionSwapInfo(props: IProps) {
     );
   }, [instantRate, receiver.token.symbol, sender.token.symbol]);
 
-  const serviceFee = useMemo(() => {
-    if (!fee || isNil(fee.percentageFee)) {
-      return null;
-    }
-
-    const originPercentageFee = fee.percentOriginFee ?? swapServiceFeeDefault;
-
-    if (new BigNumber(fee.percentageFee).gte(originPercentageFee)) {
-      return (
-        <XStack alignItems="center" gap="$1">
-          <SizableText {...textStyle}>{fee.percentageFee}%</SizableText>
-          <SwapServiceFeeOverview
-            percentageFee={fee.percentageFee}
-            percentOriginFee={fee.percentOriginFee}
-          />
-        </XStack>
-      );
-    }
-
-    return (
-      <XStack alignItems="center" gap="$1">
-        <SizableText color="$textSuccess" {...textStyle}>
-          {fee.percentageFee}%
-        </SizableText>
-        <SizableText textDecorationLine="line-through" {...textStyle}>
-          {originPercentageFee}%
-        </SizableText>
-        <SwapServiceFeeOverview
-          percentageFee={fee.percentageFee}
-          percentOriginFee={fee.percentOriginFee}
-        />
-      </XStack>
-    );
-  }, [fee]);
-
   const intl = useIntl();
 
   if (!swapInfo) {
@@ -180,15 +140,6 @@ function TxActionSwapInfo(props: IProps) {
             compactAll
           />
         )}
-        {serviceFee ? (
-          <InfoItem
-            label={intl.formatMessage({
-              id: ETranslations.swap_history_detail_service_fee,
-            })}
-            renderContent={serviceFee}
-            compactAll
-          />
-        ) : null}
         {sender.accountInfo.networkId !== receiver.accountInfo.networkId ? (
           <InfoItem
             compactAll

--- a/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
@@ -932,6 +932,7 @@ function SendDataInputContainer() {
     }) => {
       if (isNavigatingRef.current) return;
       isNavigatingRef.current = true;
+      setIsSubmitting(true);
       try {
         const queryResult =
           await backgroundApiProxy.serviceAccountProfile.queryAddress({
@@ -1045,6 +1046,7 @@ function SendDataInputContainer() {
         });
       } finally {
         isNavigatingRef.current = false;
+        setIsSubmitting(false);
       }
     },
     [
@@ -1309,7 +1311,7 @@ function SendDataInputContainer() {
           </Form>
         </AccountSelectorProviderMirror>
       </Page.Body>
-      {toResolved && !toPending ? (
+      {(toResolved && !toPending) || isSubmitting ? (
         <Page.Footer>
           <Page.FooterActions
             onConfirm={handleNavigateToAmountInput}

--- a/packages/kit/src/views/SignatureConfirm/components/SwapInfo/SwapInfo.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/SwapInfo/SwapInfo.tsx
@@ -15,13 +15,9 @@ import {
 } from '@onekeyhq/components';
 import { useAccountData } from '@onekeyhq/kit/src/hooks/useAccountData';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import {
-  swapServiceFeeDefault,
-  swapSlippageDecimal,
-} from '@onekeyhq/shared/types/swap/SwapProvider.constants';
+import { swapSlippageDecimal } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
 import type { ISwapTxInfo } from '@onekeyhq/shared/types/swap/types';
 
-import { SwapServiceFeeOverview } from '../../../Swap/components/SwapServiceFeeOverview';
 import { SignatureConfirmItem } from '../SignatureConfirmItem';
 
 interface IProps {
@@ -42,7 +38,6 @@ function SwapInfo(props: IProps) {
     instantRate,
     slippage,
     unSupportSlippage,
-    fee,
   } = swapBuildResData.result;
 
   const { network: senderNetwork } = useAccountData({
@@ -93,41 +88,6 @@ function SwapInfo(props: IProps) {
       </XStack>
     );
   }, [instantRate, receiver.token.symbol, sender.token.symbol]);
-
-  const serviceFee = useMemo(() => {
-    if (!fee || isNil(fee.percentageFee)) {
-      return null;
-    }
-
-    const originPercentageFee = fee.percentOriginFee ?? swapServiceFeeDefault;
-
-    if (new BigNumber(fee.percentageFee).gte(originPercentageFee)) {
-      return (
-        <XStack alignItems="center" gap="$1">
-          <SizableText {...textStyle}>{fee.percentageFee}%</SizableText>
-          <SwapServiceFeeOverview
-            percentageFee={fee.percentageFee}
-            percentOriginFee={fee.percentOriginFee}
-          />
-        </XStack>
-      );
-    }
-
-    return (
-      <XStack alignItems="center" gap="$1">
-        <SizableText color="$textSuccess" {...textStyle}>
-          {fee.percentageFee}%
-        </SizableText>
-        <SizableText textDecorationLine="line-through" {...textStyle}>
-          {originPercentageFee}%
-        </SizableText>
-        <SwapServiceFeeOverview
-          percentageFee={fee.percentageFee}
-          percentOriginFee={fee.percentOriginFee}
-        />
-      </XStack>
-    );
-  }, [fee]);
 
   const intl = useIntl();
 
@@ -180,17 +140,6 @@ function SwapInfo(props: IProps) {
             </SignatureConfirmItem.Value>
           </SignatureConfirmItem>
         )}
-
-        {serviceFee ? (
-          <SignatureConfirmItem compact p="$2.5">
-            <SignatureConfirmItem.Label>
-              {intl.formatMessage({
-                id: ETranslations.swap_history_detail_service_fee,
-              })}
-            </SignatureConfirmItem.Label>
-            {serviceFee}
-          </SignatureConfirmItem>
-        ) : null}
       </XStack>
       <Divider />
       <Stack>


### PR DESCRIPTION
## Summary
- NFT send: show Next button loading when picking a contact from the Account or Address Book quick-select tab (OK-54587).
- Swap transaction confirmation: remove the redundant service fee row from both the new SignatureConfirm flow and the legacy SendConfirm flow (OK-54667).

## Intent & Context
Two QA-reported issues bundled into one PR for the same release.

1. **OK-54587 (NFT send loading)** — Follow-up to commit `e34deb569b`. That fix wired `isSubmitting` to the Next button when the user clicked it, which worked for the *Recent* recipient tab. The user reported that selecting from the *Account* / *Address Book* tab still gave no feedback while the unsigned ERC-721 tx was being built (several seconds on mobile).

2. **OK-54667 (Hide swap service fee)** — User asked to remove the 服务费用 / Service Fee row from the swap transaction confirmation modal. Provided two screenshots showing the fee in different UI variants, indicating both render paths needed to be cleaned up.

## Root Cause
**OK-54587** — In `SendDataInputContainer.tsx`, the Page.Footer (which hosts the Next button + its `loading: isSubmitting` spinner) is conditionally rendered on `toResolved && !toPending`. When the user taps an entry in the account/address-book tab:

1. `fillRecipientFromQuickSelect` immediately sets `to.pending=true` and `to.resolved=undefined`.
2. The Footer condition becomes false → the entire footer + button is unmounted.
3. `navigateQuickSelectRecipientToAmount` then runs `queryAddress` + (for ERC-721) `navigationToTxConfirm` — which takes seconds — but never toggled `isSubmitting`, and the button it would have lit up no longer exists.

The *Recent* path works because no auto-skip happens: the AddressInput resolves the address, the Footer reappears, the user clicks Next manually, and `handleNavigateToAmountInput`'s existing `isSubmitting` toggle drives the spinner.

## Design Decisions
- **NFT send fix**: Toggle `setIsSubmitting(true/false)` around `navigateQuickSelectRecipientToAmount`'s async work and keep the Footer mounted when `isSubmitting` is true (`(toResolved && !toPending) || isSubmitting`). This mirrors the pattern the previous fix established for `handleNavigateToAmountInput`, so both quick-select paths now produce the same loading affordance. Considered passing `isSubmitting` through props to the AddressInput instead, but reusing the existing Footer-based pattern is more local and matches the user's expectation (they explicitly compared the two paths in their feedback).
- **Swap service fee removal**: First attempt only touched `TxActionSwapInfo.tsx` (legacy SendConfirm single-column layout). User confirmed the active modal renders via `SignatureConfirm/components/SwapInfo/SwapInfo.tsx` (two-column grid). Both files now drop the InfoItem / SignatureConfirmItem and their supporting `useMemo` / imports — the user explicitly chose to keep both edits to ensure UI consistency across the two flows. The `HistoryDetails.tsx` page has its own renderer with no service fee field, so historical records are unaffected.

## Changes Detail
- `packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx` — Set/clear `isSubmitting` inside `navigateQuickSelectRecipientToAmount`; relax the Page.Footer render guard to keep the loading button visible while submitting even before the address resolves.
- `packages/kit/src/components/TxAction/TxActionSwapInfo.tsx` — Drop the service fee InfoItem and remove the now-dead `serviceFee` useMemo, `fee` destructuring, and `swapServiceFeeDefault` / `SwapServiceFeeOverview` imports.
- `packages/kit/src/views/SignatureConfirm/components/SwapInfo/SwapInfo.tsx` — Same cleanup applied to the SignatureConfirm flow's SwapInfo component.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile (primary — ERC-721 build latency is most visible on iOS/Android), Desktop, Web, Extension (UI changes apply universally)
- **Risk Areas**:
  - The Footer's render condition is now broader (`|| isSubmitting`). Only `isSubmitting=true` paths that already exist trigger this, and the button's `disabled` logic is unchanged, so it should not accidentally appear during invalid form states.
  - Service fee removal is purely a display change — no business logic or fee calculation in the backend is touched. Fee data is still returned by the swap provider; we just don't render the row.

## Test plan
- [ ] NFT send (ERC-721, mobile): tap a recent recipient → click Next → button shows loading spinner during build-tx (regression check).
- [ ] NFT send (ERC-721, mobile): tap an Account-tab entry that skips the amount step → Next button appears with a loading spinner during build-tx, then navigates to confirm.
- [ ] NFT send (ERC-721, mobile): tap an Address-Book-tab entry → same loading behavior as above.
- [ ] NFT send: address validation failure path still falls back to filling the input (spinner clears).
- [ ] Swap (any provider, any chain) on mobile: confirm modal no longer shows 服务费用 / Service Fee row; provider / rate / slippage rows remain.
- [ ] Swap on desktop/web/extension: same UI verification.
- [ ] Swap history detail page: service fee was never shown here and remains unchanged.