### PR TITLE
fix: resolve Aptos swap native balance check (OK-54685)

### DIFF
--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -428,49 +428,42 @@ export function useSwapBuildTx() {
       if (otherFeeInfo?.length) {
         await Promise.all(
           otherFeeInfo.map(async (item) => {
-            const tokenBalanceInfo =
-              await backgroundApiProxy.serviceSwap.fetchSwapTokenDetails({
-                networkId: item.token?.networkId,
-                contractAddress: item.token?.contractAddress,
-                accountAddress: fromUserAddress,
-                accountId: fromAccountId,
+            const shouldAddFromAmount = equalTokenNoCaseSensitive({
+              token1: item.token,
+              token2: fromToken,
+            });
+            const tokenAmountBN = new BigNumber(item.amount ?? 0);
+            const fromTokenAmountBN = new BigNumber(
+              selectQuote?.fromAmount ?? 0,
+            );
+            const finalTokenAmount = shouldAddFromAmount
+              ? tokenAmountBN.plus(fromTokenAmountBN).toFixed()
+              : tokenAmountBN.toFixed();
+            const checkResult = await checkSwapLatestBalanceSufficient({
+              token: item.token,
+              amount: finalTokenAmount,
+              accountAddress: fromUserAddress,
+              accountId: fromAccountId,
+            });
+            if (!checkResult.isSufficient) {
+              Toast.error({
+                title: intl.formatMessage(
+                  {
+                    id: ETranslations.swap_page_toast_insufficient_balance_title,
+                  },
+                  { token: checkResult.tokenSymbol },
+                ),
+                message: intl.formatMessage(
+                  {
+                    id: ETranslations.swap_page_toast_insufficient_balance_content,
+                  },
+                  {
+                    token: checkResult.tokenSymbol,
+                    number: numberFormat(tokenAmountBN.toFixed(), formatter),
+                  },
+                ),
               });
-            if (tokenBalanceInfo?.length) {
-              const tokenBalanceBN = new BigNumber(
-                tokenBalanceInfo[0].balanceParsed ?? 0,
-              );
-              const shouldAddFromAmount = equalTokenNoCaseSensitive({
-                token1: item.token,
-                token2: fromToken,
-              });
-
-              const tokenAmountBN = new BigNumber(item.amount ?? 0);
-              const fromTokenAmountBN = new BigNumber(
-                selectQuote?.fromAmount ?? 0,
-              );
-              const finalTokenAmount = shouldAddFromAmount
-                ? tokenAmountBN.plus(fromTokenAmountBN).toFixed()
-                : tokenAmountBN.toFixed();
-              if (tokenBalanceBN.lt(finalTokenAmount)) {
-                Toast.error({
-                  title: intl.formatMessage(
-                    {
-                      id: ETranslations.swap_page_toast_insufficient_balance_title,
-                    },
-                    { token: item.token.symbol },
-                  ),
-                  message: intl.formatMessage(
-                    {
-                      id: ETranslations.swap_page_toast_insufficient_balance_content,
-                    },
-                    {
-                      token: item.token.symbol,
-                      number: numberFormat(tokenAmountBN.toFixed(), formatter),
-                    },
-                  ),
-                });
-                checkRes = false;
-              }
+              checkRes = false;
             }
           }),
         );

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
@@ -13,13 +13,24 @@ type IFetchSwapTokenDetailsParams = {
   currency?: string;
 };
 
+type IGetNativeTokenAddressParams = {
+  networkId: string;
+};
+
 const mockFetchSwapTokenDetails: jest.MockedFunction<
   (params: IFetchSwapTokenDetailsParams) => Promise<{ balanceParsed: string }[]>
+> = jest.fn();
+const mockGetNativeTokenAddress: jest.MockedFunction<
+  (params: IGetNativeTokenAddressParams) => Promise<string>
 > = jest.fn();
 
 jest.mock('../../../background/instance/backgroundApiProxy', () => ({
   __esModule: true,
   default: {
+    serviceToken: {
+      getNativeTokenAddress: (params: IGetNativeTokenAddressParams) =>
+        mockGetNativeTokenAddress(params),
+    },
     serviceSwap: {
       fetchSwapTokenDetails: (params: IFetchSwapTokenDetailsParams) =>
         mockFetchSwapTokenDetails(params),
@@ -55,9 +66,20 @@ const evmGasInfo = {
   },
 };
 
+const aptosNativeAddress = '0x1::aptos_coin::AptosCoin';
+
+const aptosToken = {
+  networkId: 'aptos--1',
+  contractAddress: '',
+  symbol: 'APT',
+  decimals: 8,
+  isNative: true,
+} as ISwapToken;
+
 describe('checkSwapLatestBalanceSufficient', () => {
   beforeEach(() => {
     mockFetchSwapTokenDetails.mockReset();
+    mockGetNativeTokenAddress.mockReset();
   });
 
   it('returns insufficient when the latest token balance is lower than amount', async () => {
@@ -89,6 +111,30 @@ describe('checkSwapLatestBalanceSufficient', () => {
         accountAddress: '0xabc',
       }),
     ).resolves.toEqual({ isSufficient: true });
+  });
+
+  it('uses canonical native token address when native token address is empty', async () => {
+    mockGetNativeTokenAddress.mockResolvedValue(aptosNativeAddress);
+    mockFetchSwapTokenDetails.mockResolvedValue([{ balanceParsed: '6.6044' }]);
+
+    await expect(
+      checkSwapLatestBalanceSufficient({
+        token: aptosToken,
+        amount: '0.0225',
+        accountId: 'account-id',
+        accountAddress: '0xabc',
+      }),
+    ).resolves.toEqual({ isSufficient: true });
+    expect(mockGetNativeTokenAddress).toHaveBeenCalledWith({
+      networkId: 'aptos--1',
+    });
+    expect(mockFetchSwapTokenDetails).toHaveBeenCalledWith({
+      networkId: 'aptos--1',
+      contractAddress: aptosNativeAddress,
+      accountAddress: '0xabc',
+      accountId: 'account-id',
+      currency: 'usd',
+    });
   });
 });
 

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
@@ -28,6 +28,22 @@ export type ISwapLatestBalanceCheckResult =
       tokenSymbol: string;
     };
 
+async function getSwapTokenBalanceContractAddress(token: ISwapToken) {
+  if (!token.isNative || token.contractAddress) {
+    return token.contractAddress ?? '';
+  }
+
+  try {
+    return (
+      (await backgroundApiProxy.serviceToken.getNativeTokenAddress({
+        networkId: token.networkId,
+      })) ?? ''
+    );
+  } catch {
+    return token.contractAddress ?? '';
+  }
+}
+
 type ISwapGasInfoEntry = {
   gasInfo?: ISwapGasInfo;
 };
@@ -176,10 +192,11 @@ export async function checkSwapLatestBalanceSufficient({
   }
 
   try {
+    const contractAddress = await getSwapTokenBalanceContractAddress(token);
     const tokenBalanceInfo =
       await backgroundApiProxy.serviceSwap.fetchSwapTokenDetails({
         networkId: token.networkId,
-        contractAddress: token.contractAddress ?? '',
+        contractAddress,
         accountAddress,
         accountId,
         currency: 'usd',


### PR DESCRIPTION
## Summary
- Resolve canonical native token address before running latest swap balance checks
- Reuse the latest balance helper for swap other-fee balance checks
- Add Aptos native-token regression coverage for empty native contract address

## Issues
- Fixes OK-54685

## Test Plan
- yarn jest packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts --runInBand
- npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts packages/kit/src/views/Swap/utils/swapBalanceUtils.ts packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
- yarn lint:staged
- yarn tsc:staged
- git diff --check

## Notes
- Runtime app validation was not run; this fix is covered by static trace and focused unit test.