### PR TITLE
fix(cli): serialize hardware SDK calls

### DIFF
--- a/apps/cli/src/__tests__/btc-signer-hardware.test.ts
+++ b/apps/cli/src/__tests__/btc-signer-hardware.test.ts
@@ -190,6 +190,45 @@ describe('btc hardware signer', () => {
     );
   });
 
+  it('serializes btc address and public key reads on the same device', async () => {
+    const order: string[] = [];
+    const device = makeDevice();
+    const { deps } = makeDeps({
+      sdk: {
+        btcGetAddress: jest.fn(async () => {
+          order.push('address-start');
+          await Promise.resolve();
+          order.push('address-end');
+          return makeSuccess({
+            address: 'tb1p-first',
+            path: "m/86'/1'/0'/0/0",
+          });
+        }),
+        btcGetPublicKey: jest.fn(async () => {
+          order.push('public-key-start');
+          return makeSuccess({
+            path: "m/86'/1'/0'/0/0",
+            node: {
+              public_key:
+                '03098891dd952dd6f6bde1489761d0befbfa31815e9c0e64058d12b83de852a18c',
+            },
+            root_fingerprint: 0xde_ad_be_ef,
+          });
+        }),
+      } as unknown as Partial<CoreApi>,
+    });
+    const signer = new SignerHardware({
+      impl: 'tbtc',
+      device,
+      passphraseMode: 'none',
+      deps,
+    });
+
+    await signer.getAddress('tbtc--0', { addressType: 'taproot' });
+
+    expect(order).toEqual(['address-start', 'address-end', 'public-key-start']);
+  });
+
   it('rejects getAddress without explicit addressType', async () => {
     const { deps, mocks } = makeDeps();
     const signer = new SignerHardware({

--- a/apps/cli/src/__tests__/hardware-sdk-queue.test.ts
+++ b/apps/cli/src/__tests__/hardware-sdk-queue.test.ts
@@ -1,6 +1,6 @@
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 
-import { createSerializedHardwareSDK } from '../commands/device/hardware-sdk';
+import { createQueuedHardwareSDK } from '../commands/device/hardware-sdk';
 
 function createDeferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -12,11 +12,11 @@ function createDeferred<T>() {
   return { promise, resolve, reject };
 }
 
-describe('createSerializedHardwareSDK', () => {
+describe('createQueuedHardwareSDK', () => {
   it('serializes SDK method calls in FIFO order', async () => {
     const firstCall = createDeferred<void>();
     const order: string[] = [];
-    const sdk = createSerializedHardwareSDK({
+    const sdk = createQueuedHardwareSDK({
       searchDevices: jest.fn(async () => {
         order.push('search-start');
         await firstCall.promise;
@@ -41,10 +41,10 @@ describe('createSerializedHardwareSDK', () => {
     expect(order).toEqual(['search-start', 'search-end', 'features-start']);
   });
 
-  it('does not queue SDK control methods', async () => {
+  it('does not queue SDK queue-bypass methods', async () => {
     const firstCall = createDeferred<void>();
     const order: string[] = [];
-    const sdk = createSerializedHardwareSDK({
+    const sdk = createQueuedHardwareSDK({
       searchDevices: jest.fn(async () => {
         order.push('search-start');
         await firstCall.promise;
@@ -71,7 +71,7 @@ describe('createSerializedHardwareSDK', () => {
 
   it('keeps processing queued calls after a SDK method rejects', async () => {
     const order: string[] = [];
-    const sdk = createSerializedHardwareSDK({
+    const sdk = createQueuedHardwareSDK({
       getFeatures: jest.fn(async () => {
         order.push('features-start');
         throw new OneKeyLocalError('device busy');
@@ -94,7 +94,7 @@ describe('createSerializedHardwareSDK', () => {
   it('uses the same queue for SOL hardware methods', async () => {
     const btcCall = createDeferred<void>();
     const order: string[] = [];
-    const sdk = createSerializedHardwareSDK({
+    const sdk = createQueuedHardwareSDK({
       btcGetAddress: jest.fn(async () => {
         order.push('btc-address-start');
         await btcCall.promise;

--- a/apps/cli/src/__tests__/hardware-sdk-queue.test.ts
+++ b/apps/cli/src/__tests__/hardware-sdk-queue.test.ts
@@ -1,0 +1,125 @@
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+
+import { createSerializedHardwareSDK } from '../commands/device/hardware-sdk';
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolveFn, rejectFn) => {
+    resolve = resolveFn;
+    reject = rejectFn;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('createSerializedHardwareSDK', () => {
+  it('serializes SDK method calls in FIFO order', async () => {
+    const firstCall = createDeferred<void>();
+    const order: string[] = [];
+    const sdk = createSerializedHardwareSDK({
+      searchDevices: jest.fn(async () => {
+        order.push('search-start');
+        await firstCall.promise;
+        order.push('search-end');
+        return { success: true as const, payload: [] };
+      }),
+      getFeatures: jest.fn(async (_connectId: string) => {
+        order.push('features-start');
+        return { success: true as const, payload: { unlocked: true } };
+      }),
+    });
+
+    const searchPromise = sdk.searchDevices();
+    const featuresPromise = sdk.getFeatures('connect-1');
+    await Promise.resolve();
+
+    expect(order).toEqual(['search-start']);
+
+    firstCall.resolve();
+    await Promise.all([searchPromise, featuresPromise]);
+
+    expect(order).toEqual(['search-start', 'search-end', 'features-start']);
+  });
+
+  it('does not queue SDK control methods', async () => {
+    const firstCall = createDeferred<void>();
+    const order: string[] = [];
+    const sdk = createSerializedHardwareSDK({
+      searchDevices: jest.fn(async () => {
+        order.push('search-start');
+        await firstCall.promise;
+        order.push('search-end');
+        return { success: true as const, payload: [] };
+      }),
+      uiResponse: jest.fn((_event: { type: string }) => {
+        order.push('ui-response');
+      }),
+    });
+
+    const searchPromise = sdk.searchDevices();
+    await Promise.resolve();
+
+    sdk.uiResponse({ type: 'receive-pin' });
+
+    expect(order).toEqual(['search-start', 'ui-response']);
+
+    firstCall.resolve();
+    await searchPromise;
+
+    expect(order).toEqual(['search-start', 'ui-response', 'search-end']);
+  });
+
+  it('keeps processing queued calls after a SDK method rejects', async () => {
+    const order: string[] = [];
+    const sdk = createSerializedHardwareSDK({
+      getFeatures: jest.fn(async () => {
+        order.push('features-start');
+        throw new OneKeyLocalError('device busy');
+      }),
+      searchDevices: jest.fn(async () => {
+        order.push('search-start');
+        return { success: true as const, payload: [] };
+      }),
+    });
+
+    const failingCall = sdk.getFeatures();
+    const nextCall = sdk.searchDevices();
+
+    await expect(failingCall).rejects.toThrow('device busy');
+    await expect(nextCall).resolves.toEqual({ success: true, payload: [] });
+
+    expect(order).toEqual(['features-start', 'search-start']);
+  });
+
+  it('uses the same queue for SOL hardware methods', async () => {
+    const btcCall = createDeferred<void>();
+    const order: string[] = [];
+    const sdk = createSerializedHardwareSDK({
+      btcGetAddress: jest.fn(async () => {
+        order.push('btc-address-start');
+        await btcCall.promise;
+        order.push('btc-address-end');
+        return { success: true as const, payload: { address: 'bc1q-test' } };
+      }),
+      solGetAddress: jest.fn(async () => {
+        order.push('sol-address-start');
+        return { success: true as const, payload: { address: 'sol-test' } };
+      }),
+    });
+
+    const btcPromise = sdk.btcGetAddress();
+    const solPromise = sdk.solGetAddress();
+    await Promise.resolve();
+
+    expect(order).toEqual(['btc-address-start']);
+
+    btcCall.resolve();
+    await Promise.all([btcPromise, solPromise]);
+
+    expect(order).toEqual([
+      'btc-address-start',
+      'btc-address-end',
+      'sol-address-start',
+    ]);
+  });
+});

--- a/apps/cli/src/commands/device/hardware-sdk.ts
+++ b/apps/cli/src/commands/device/hardware-sdk.ts
@@ -32,6 +32,78 @@ export const CoreSDKLoader = async (): Promise<
 // where two concurrent ensureSDKReady() calls could both enter the init block
 // before sdkInitialized is set.
 let sdkReadyPromise: Promise<CoreApi> | null = null;
+let sdkTaskQueue: Promise<void> = Promise.resolve();
+
+const SDK_CONTROL_METHODS = new Set<PropertyKey>([
+  'addListener',
+  'cancel',
+  'dispose',
+  'emit',
+  'eventNames',
+  'getMaxListeners',
+  'init',
+  'listenerCount',
+  'listeners',
+  'off',
+  'on',
+  'once',
+  'prependListener',
+  'prependOnceListener',
+  'rawListeners',
+  'removeListener',
+  'removeAllListeners',
+  'setMaxListeners',
+  'uiResponse',
+]);
+
+type HardwareMethod = (...args: unknown[]) => unknown;
+
+function enqueueSDKTask<T>(task: () => T | Promise<T>): Promise<T> {
+  const run = sdkTaskQueue.then(task, task);
+  sdkTaskQueue = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+/**
+ * CLI analogue of app-monorepo's hardware processing boundary.
+ *
+ * The Node USB transport and SDK UI/passphrase state are process-wide serial
+ * resources. Returning a serialized facade makes accidental concurrent SDK
+ * calls (for example Promise.all inside a signer) execute FIFO instead of
+ * interrupting the device with code 107. Control methods must bypass the
+ * queue so PIN/passphrase responses and cancel can reach the SDK immediately.
+ */
+export function createSerializedHardwareSDK<T extends object>(sdk: T): T {
+  const methodCache = new Map<PropertyKey, unknown>();
+
+  return new Proxy(sdk, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value !== 'function') {
+        return value;
+      }
+
+      const cached = methodCache.get(prop);
+      if (cached) {
+        return cached;
+      }
+
+      const method = (...args: unknown[]) => {
+        const hardwareMethod = value as HardwareMethod;
+        const call = (): unknown => Reflect.apply(hardwareMethod, target, args);
+        if (SDK_CONTROL_METHODS.has(prop)) {
+          return call();
+        }
+        return enqueueSDKTask(call);
+      };
+      methodCache.set(prop, method);
+      return method;
+    },
+  });
+}
 
 /**
  * Release the USB transport and dispose the SDK instance.
@@ -48,6 +120,7 @@ export async function disposeSDK(): Promise<void> {
     // ignore errors during cleanup
   } finally {
     sdkReadyPromise = null;
+    sdkTaskQueue = Promise.resolve();
   }
 }
 
@@ -186,7 +259,7 @@ async function initSDK(): Promise<CoreApi> {
     },
   );
 
-  return sdk;
+  return createSerializedHardwareSDK(sdk);
 }
 
 export async function ensureSDKReady(): Promise<CoreApi> {

--- a/apps/cli/src/commands/device/hardware-sdk.ts
+++ b/apps/cli/src/commands/device/hardware-sdk.ts
@@ -32,9 +32,9 @@ export const CoreSDKLoader = async (): Promise<
 // where two concurrent ensureSDKReady() calls could both enter the init block
 // before sdkInitialized is set.
 let sdkReadyPromise: Promise<CoreApi> | null = null;
-let sdkTaskQueue: Promise<void> = Promise.resolve();
+let hardwareSDKQueueTail: Promise<void> = Promise.resolve();
 
-const SDK_CONTROL_METHODS = new Set<PropertyKey>([
+const SDK_QUEUE_BYPASS_METHODS = new Set<PropertyKey>([
   'addListener',
   'cancel',
   'dispose',
@@ -58,25 +58,29 @@ const SDK_CONTROL_METHODS = new Set<PropertyKey>([
 
 type HardwareMethod = (...args: unknown[]) => unknown;
 
-function enqueueSDKTask<T>(task: () => T | Promise<T>): Promise<T> {
-  const run = sdkTaskQueue.then(task, task);
-  sdkTaskQueue = run.then(
+function enqueueHardwareSDKCall<T>(call: () => T | Promise<T>): Promise<T> {
+  const run = hardwareSDKQueueTail.then(call, call);
+  hardwareSDKQueueTail = run.then(
     () => undefined,
     () => undefined,
   );
   return run;
 }
 
+function resetHardwareSDKQueue() {
+  hardwareSDKQueueTail = Promise.resolve();
+}
+
 /**
  * CLI analogue of app-monorepo's hardware processing boundary.
  *
  * The Node USB transport and SDK UI/passphrase state are process-wide serial
- * resources. Returning a serialized facade makes accidental concurrent SDK
+ * resources. Returning a queued facade makes accidental concurrent SDK
  * calls (for example Promise.all inside a signer) execute FIFO instead of
- * interrupting the device with code 107. Control methods must bypass the
- * queue so PIN/passphrase responses and cancel can reach the SDK immediately.
+ * interrupting the device with code 107. Queue-bypass methods must stay
+ * immediate so PIN/passphrase responses and cancel can reach the SDK.
  */
-export function createSerializedHardwareSDK<T extends object>(sdk: T): T {
+export function createQueuedHardwareSDK<T extends object>(sdk: T): T {
   const methodCache = new Map<PropertyKey, unknown>();
 
   return new Proxy(sdk, {
@@ -94,10 +98,10 @@ export function createSerializedHardwareSDK<T extends object>(sdk: T): T {
       const method = (...args: unknown[]) => {
         const hardwareMethod = value as HardwareMethod;
         const call = (): unknown => Reflect.apply(hardwareMethod, target, args);
-        if (SDK_CONTROL_METHODS.has(prop)) {
+        if (SDK_QUEUE_BYPASS_METHODS.has(prop)) {
           return call();
         }
-        return enqueueSDKTask(call);
+        return enqueueHardwareSDKCall(call);
       };
       methodCache.set(prop, method);
       return method;
@@ -120,7 +124,7 @@ export async function disposeSDK(): Promise<void> {
     // ignore errors during cleanup
   } finally {
     sdkReadyPromise = null;
-    sdkTaskQueue = Promise.resolve();
+    resetHardwareSDKQueue();
   }
 }
 
@@ -259,7 +263,7 @@ async function initSDK(): Promise<CoreApi> {
     },
   );
 
-  return createSerializedHardwareSDK(sdk);
+  return createQueuedHardwareSDK(sdk);
 }
 
 export async function ensureSDKReady(): Promise<CoreApi> {

--- a/apps/cli/src/signer/impls/btc/SignerHardware.ts
+++ b/apps/cli/src/signer/impls/btc/SignerHardware.ts
@@ -144,20 +144,26 @@ export class SignerHardware extends SignerHardwareBase {
     const sdk = await this.getHardwareSDK();
     const commonParams = await this.getHwCommonParams();
 
-    const [addressResult, pubKeyResult] = await Promise.all([
-      sdk.btcGetAddress(this.device.connectId, this.device.deviceId, {
+    const addressResult = await sdk.btcGetAddress(
+      this.device.connectId,
+      this.device.deviceId,
+      {
         path: info.path,
         coin: this.getCoin(),
         showOnOneKey: false,
         ...commonParams,
-      }),
-      sdk.btcGetPublicKey(this.device.connectId, this.device.deviceId, {
+      },
+    );
+    const pubKeyResult = await sdk.btcGetPublicKey(
+      this.device.connectId,
+      this.device.deviceId,
+      {
         path: info.path,
         coin: this.getCoin(),
         showOnOneKey: false,
         ...commonParams,
-      }),
-    ]);
+      },
+    );
 
     const address = unwrapSDKResult<IBtcAddressPayload>(
       addressResult,


### PR DESCRIPTION
## Summary
- Serialize CLI hardware SDK calls behind a shared FIFO facade while letting SDK control methods bypass the queue.
- Make BTC hardware address derivation read address and public key sequentially instead of with `Promise.all`.
- Add regression coverage for generic queue behavior, BTC address/public-key ordering, and SOL hardware methods sharing the same queue.

## Intent & Context
Hardware login can succeed, but follow-up BTC address reads may fail with `Hardware getAddress failed: Device interrupted (code 107)`, especially for `wallet address --chain tbtc --address-type taproot`.

The fix follows the App-side hardware processing boundary pattern by centralizing serialization in the CLI hardware SDK accessor rather than adding isolated per-call guards. The branch is rebased on the latest `x`, which already contains CLI SOL support, so SOL hardware methods such as `solGetAddress` also go through the same serialized SDK facade.

## Root Cause
The CLI exposed the raw hardware SDK to commands and signers. That allowed multiple SDK calls to share the same Node USB transport and process-wide UI/passphrase state concurrently. BTC `getAddress()` triggered this directly by running `btcGetAddress` and `btcGetPublicKey` in `Promise.all`, which can interrupt the device.

## Design Decisions
- Put serialization in `apps/cli/src/commands/device/hardware-sdk.ts`, the shared SDK accessor, to match the App pattern where hardware interaction goes through a centralized processing boundary.
- Keep `uiResponse`, `cancel`, `dispose`, and event listener APIs out of the queue so PIN/passphrase replies and cancellation are not blocked behind long-running device calls.
- Keep BTC `getAddress()` explicitly sequential as a local correctness fix and easier-to-read call flow.
- Add a SOL-specific queue test without changing SOL signer code, because the production fix is intentionally SDK-boundary based and applies to every chain method.

## Changes Detail
- `hardware-sdk.ts`: adds `createSerializedHardwareSDK()` and wraps the singleton SDK instance.
- `SignerHardware.ts`: removes concurrent BTC address/public-key reads.
- `hardware-sdk-queue.test.ts`: covers FIFO ordering, control-method bypass, queue continuation after rejection, and SOL hardware method serialization.
- `btc-signer-hardware.test.ts`: covers BTC address/public-key sequencing.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: CLI hardware wallet flows
- **Risk Areas**: Hardware SDK timing and UI control methods; mitigated by bypassing control APIs and keeping the wrapper at the CLI SDK boundary.

## Test plan
- [x] `git diff --check origin/x...HEAD`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware apps/cli/src/commands/device/hardware-sdk.ts apps/cli/src/signer/impls/btc/SignerHardware.ts apps/cli/src/__tests__/btc-signer-hardware.test.ts apps/cli/src/__tests__/hardware-sdk-queue.test.ts apps/cli/src/__tests__/sol-signer-hardware.test.ts apps/cli/src/signer/impls/sol/SignerHardware.ts --deny-warnings`
- [x] `yarn workspace @onekeyfe/cli test:unit --runTestsByPath src/__tests__/hardware-sdk-queue.test.ts src/__tests__/btc-signer-hardware.test.ts src/__tests__/wallet-btc-address.test.ts src/__tests__/sol-signer-hardware.test.ts`
- [x] `yarn workspace @onekeyfe/cli build`
- [ ] `yarn workspace @onekeyfe/cli typecheck` currently fails on existing non-PR errors in `ServiceHardware/thirdPartyDeviceMapping.ts`, `shared/src/utils/avatarUtils.ts`, and `shared/src/utils/deviceUtils.ts`.