### PR TITLE
fix: prevent swap action text clipping (OK-54687)

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -825,7 +825,17 @@ const SwapActionsState = ({
           }}
         />
       ) : (
-        swapActionState.label
+        <SizableText
+          flex={platformEnv.isNativeAndroid ? 1 : undefined}
+          flexShrink={1}
+          minWidth={0}
+          maxWidth="100%"
+          size="$bodyLgMedium"
+          color="$textInverse"
+          textAlign="center"
+        >
+          {swapActionState.label}
+        </SizableText>
       ),
     [
       isWaitingActionableQuote,
@@ -860,6 +870,7 @@ const SwapActionsState = ({
             variant="primary"
             disabled={isActionDisabled}
             borderRadius="$full"
+            childrenAsText={false}
           >
             {actionButtonChildren}
           </Button>


### PR DESCRIPTION
## Issues
- Fixes OK-54687

## Summary
- Render the Swap action label with an explicit `SizableText` wrapper.
- Allow the label to shrink within the Android action button instead of being clipped.

## Intent & Context
Android devices with narrower logical widths could visually clip the disabled Swap action text for long token symbols. In the reproduced case, `jlUSDC 余额不足` rendered as `jlUSDC 余额不` even though the underlying button text was complete.

## Root Cause
`SwapActionsState` passed the dynamic action label as a plain string to the generic `Button`. The Button default text wrapper did not provide the shrink/min-width constraints needed for this long mixed Latin/CJK label on Android, so the text was clipped by the button bounds.

## Design Decisions
- Kept the fix local to the Swap action button instead of changing the shared Button component globally.
- Used `childrenAsText={false}` and an explicit `SizableText` so the Swap action label owns its shrink and centering behavior.

## Changes Detail
- `packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx`: wrap non-loading action labels with constrained `SizableText` and disable Button's default string wrapper.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile Android primarily; shared Swap action rendering on other platforms should remain visually equivalent.
- **Risk Areas**: Swap action button text layout for disabled/action states.

## Test plan
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx --deny-warnings`
- [x] `git diff --check`
- [x] Android emulator: Solana Swap, select `jlUSDC` as from token, input `1`, verify `jlUSDC 余额不足` is fully visible.
- [ ] `npx tsgo -p ./tsconfig.json --noEmit --tsBuildInfoFile "$(yarn config get cacheFolder)"/.app-mono-ts-cache --pretty` is currently blocked by unrelated existing type errors in `thirdPartyDeviceMapping.ts` and `appRestart/index.native.ts`.
