### PR TITLE
fix: support Aptos batch transfer fallback parsing

### DIFF
--- a/packages/kit-bg/src/services/ServiceHardware/thirdPartyDeviceMapping.ts
+++ b/packages/kit-bg/src/services/ServiceHardware/thirdPartyDeviceMapping.ts
@@ -51,6 +51,6 @@ export function mapThirdPartyDeviceToSearchDevice({
     commType: 'bridge',
     // Pass-through: persisted into IDBDeviceSettings.vendorModel/vendorModelName.
     vendorModel: device.model,
-    vendorModelName: device.modelName,
+    vendorModelName: (device as DeviceInfo & { modelName?: string }).modelName,
   } as SearchDevice;
 }

--- a/packages/kit-bg/src/vaults/impls/aptos/Vault.ts
+++ b/packages/kit-bg/src/vaults/impls/aptos/Vault.ts
@@ -1,6 +1,7 @@
 /* oxlint-disable @cspell/spellchecker, @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import {
+  AccountAddress,
   AptosConfig,
   Aptos as AptosRpcClient,
   Deserializer,
@@ -64,6 +65,7 @@ import {
   EDecodedTxStatus,
   type IDecodedTx,
   type IDecodedTxAction,
+  type IDecodedTxTransferInfo,
 } from '@onekeyhq/shared/types/tx';
 
 import { VaultBase } from '../../base/VaultBase';
@@ -75,6 +77,7 @@ import { KeyringImported } from './KeyringImported';
 import { KeyringWatching } from './KeyringWatching';
 import { AptosClient } from './sdkAptos/AptosClient';
 import {
+  APTOS_NATIVE_BATCH_TRANSFER_FUNC_LEGACY,
   APTOS_NATIVE_COIN,
   APTOS_NATIVE_TRANSFER_FUNC,
   APTOS_NATIVE_TRANSFER_FUNC_LEGACY,
@@ -105,6 +108,61 @@ import type {
   AnyRawTransaction,
   PendingTransactionResponse,
 } from '@aptos-labs/ts-sdk';
+
+function getTransferActionAddress(addresses: string[]) {
+  const uniqueAddresses = Array.from(new Set(addresses.filter(Boolean)));
+  return uniqueAddresses.length === 1 ? uniqueAddresses[0] : '';
+}
+
+function deserializeU64Arg(arg: { bcsToBytes: () => Uint8Array }) {
+  return U64.deserialize(new Deserializer(arg.bcsToBytes())).value.toString();
+}
+
+function deserializeAddressVectorArg(arg: { bcsToBytes: () => Uint8Array }) {
+  return new Deserializer(arg.bcsToBytes())
+    .deserializeVector(AccountAddress)
+    .map((address) => address.toString());
+}
+
+function deserializeU64VectorArg(arg: { bcsToBytes: () => Uint8Array }) {
+  return new Deserializer(arg.bcsToBytes())
+    .deserializeVector(U64)
+    .map((amount) => amount.value.toString());
+}
+
+function parsePayloadAddressArray(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const addresses: string[] = [];
+  value.forEach((item) => {
+    if (typeof item === 'string') {
+      addresses.push(item);
+    } else if (item instanceof AccountAddress) {
+      addresses.push(item.toString());
+    }
+  });
+  return addresses.filter(Boolean);
+}
+
+function parsePayloadAmountArray(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const amounts: string[] = [];
+  value.forEach((item) => {
+    if (
+      typeof item === 'string' ||
+      typeof item === 'number' ||
+      typeof item === 'bigint'
+    ) {
+      amounts.push(item.toString());
+    } else if (item instanceof U64) {
+      amounts.push(item.value.toString());
+    }
+  });
+  return amounts;
+}
 
 export default class VaultAptos extends VaultBase {
   override coreApi = coreChainApi.aptos.hd;
@@ -248,14 +306,15 @@ export default class VaultAptos extends VaultBase {
       // non-SimpleTransaction
     }
 
+    let actionType = EDecodedTxActionType.UNKNOWN;
     if (!rawTx) {
       return {
+        actionType,
         actions: [],
         rawTxn: null,
       };
     }
 
-    let actionType = EDecodedTxActionType.UNKNOWN;
     const payload = rawTx.payload;
 
     const { sender } = rawTx;
@@ -288,11 +347,7 @@ export default class VaultAptos extends VaultBase {
           const [toArg, amountValueArg] = payload.entryFunction.args || [];
           const toAddress = toArg.bcsToHex().toString();
 
-          const amountValue = new BigNumber(
-            U64.deserialize(
-              new Deserializer(amountValueArg.bcsToBytes()),
-            ).value.toString(),
-          );
+          const amountValue = new BigNumber(deserializeU64Arg(amountValueArg));
           const coinType = coinTypeTypeArg.toString();
 
           const tokenInfo = await this.backgroundApi.serviceToken.getToken({
@@ -324,6 +379,23 @@ export default class VaultAptos extends VaultBase {
                 ],
               }),
             );
+          }
+        } else if (
+          moveFunctionName === APTOS_NATIVE_BATCH_TRANSFER_FUNC_LEGACY
+        ) {
+          actionType = EDecodedTxActionType.ASSET_TRANSFER;
+
+          const [coinTypeTypeArg] = payload.entryFunction.type_args || [];
+          const [toArg, amountValueArg] = payload.entryFunction.args || [];
+          const action = await this._buildBatchTransferCoinAction({
+            sender: senderAddress,
+            network,
+            coinType: coinTypeTypeArg?.toString() ?? APTOS_NATIVE_COIN,
+            toAddresses: deserializeAddressVectorArg(toArg),
+            amountValues: deserializeU64VectorArg(amountValueArg),
+          });
+          if (action) {
+            actions.push(action);
           }
         } else if (moveFunctionName === APTOS_TRANSFER_FUNGIBLE_FUNC) {
           actionType = EDecodedTxActionType.ASSET_TRANSFER;
@@ -450,6 +522,57 @@ export default class VaultAptos extends VaultBase {
     };
   }
 
+  private async _buildBatchTransferCoinAction(params: {
+    sender: string | undefined;
+    network: IServerNetwork;
+    coinType: string;
+    toAddresses: string[];
+    amountValues: string[];
+  }) {
+    const { sender, network, coinType, toAddresses, amountValues } = params;
+    if (
+      !sender ||
+      toAddresses.length === 0 ||
+      toAddresses.length !== amountValues.length
+    ) {
+      return null;
+    }
+
+    const tokenInfo = await this.backgroundApi.serviceToken.getToken({
+      networkId: network.id,
+      accountId: this.accountId,
+      tokenIdOnNetwork: coinType,
+    });
+    if (!tokenInfo) {
+      return null;
+    }
+
+    const parsedTransfers: IDecodedTxTransferInfo[] = toAddresses.map(
+      (to, index) => ({
+        from: sender,
+        to,
+        amount: new BigNumber(amountValues[index])
+          .shiftedBy(-tokenInfo.decimals)
+          .toFixed(),
+        icon: tokenInfo.logoURI ?? '',
+        name: tokenInfo.symbol,
+        symbol: tokenInfo.symbol,
+        tokenIdOnNetwork: coinType,
+        isNative: !coinType || coinType === APTOS_NATIVE_COIN,
+      }),
+    );
+
+    return this.buildTxTransferAssetAction({
+      from: getTransferActionAddress(
+        parsedTransfers.map((transfer) => transfer.from),
+      ),
+      to: getTransferActionAddress(
+        parsedTransfers.map((transfer) => transfer.to),
+      ),
+      transfers: parsedTransfers,
+    });
+  }
+
   override async buildDecodedTx(
     params: IBuildDecodedTxParams,
   ): Promise<IDecodedTx> {
@@ -537,6 +660,18 @@ export default class VaultAptos extends VaultBase {
             ],
           });
         }
+      } else if (fun === APTOS_NATIVE_BATCH_TRANSFER_FUNC_LEGACY) {
+        const { sender } = encodedTx;
+        const [coinType] = payload?.type_arguments || [];
+        const [toAddressesArg, amountValuesArg] = payload?.arguments || [];
+
+        action = await this._buildBatchTransferCoinAction({
+          sender,
+          network,
+          coinType: coinType ?? APTOS_NATIVE_COIN,
+          toAddresses: parsePayloadAddressArray(toAddressesArg),
+          amountValues: parsePayloadAmountArray(amountValuesArg),
+        });
       } else if (actionType === EDecodedTxActionType.ASSET_TRANSFER) {
         const { sender } = encodedTx;
         const [coinType] = payload?.type_arguments || [];

--- a/packages/kit-bg/src/vaults/impls/aptos/utils.ts
+++ b/packages/kit-bg/src/vaults/impls/aptos/utils.ts
@@ -58,6 +58,8 @@ export const APTOS_NATIVE_TRANSFER_FUNC = '0x1::aptos_account::transfer';
 // Transfer legacy coin & native coin, not register account
 export const APTOS_NATIVE_TRANSFER_FUNC_LEGACY =
   '0x1::aptos_account::transfer_coins';
+export const APTOS_NATIVE_BATCH_TRANSFER_FUNC_LEGACY =
+  '0x1::aptos_account::batch_transfer_coins';
 
 export const APTOS_TRANSFER_FUNGIBLE_FUNC =
   '0x1::primary_fungible_store::transfer';
@@ -101,6 +103,7 @@ export function getTransactionTypeByPayload({
       function_name === APTOS_NATIVE_TRANSFER_FUNC ||
       function_name === APTOS_TRANSFER_FUNC ||
       function_name === APTOS_NATIVE_TRANSFER_FUNC_LEGACY ||
+      function_name === APTOS_NATIVE_BATCH_TRANSFER_FUNC_LEGACY ||
       function_name === APTOS_TRANSFER_FUNGIBLE_FUNC
     ) {
       return EDecodedTxActionType.ASSET_TRANSFER;


### PR DESCRIPTION
## Summary
- Add local Aptos parsing support for `0x1::aptos_account::batch_transfer_coins` in both payload and BCS transaction paths.
- Preserve multiple Aptos recipients in `transfers` so the existing signature confirmation UI can render recipient details through the fallback display path.
- Fix a latest-`x` third-party hardware type mismatch that blocked local TypeScript/pre-commit checks.

## Intent & Context
Aptos server-side transaction simulation/parse support already exists. For multi-transaction flows, the parse-transaction API can return an empty parse result, which causes the app to fall back to client-side Vault parsing. The previous SUI/BTC discussion established that the UI should be reused instead of adding a new UI path, so Aptos needs the Vault fallback parser to preserve multiple transfer recipients when the server does not provide display data.

## Root Cause
The Aptos Vault only recognized single-recipient transfer entry functions locally. When `batch_transfer_coins` reached the local fallback parser, it was treated as an unknown/function-call style transaction rather than an asset transfer with multiple recipients.

## Design Decisions
- Keep the behavior in the Vault parsing layer and reuse the existing decoded transaction action/display conversion.
- Do not add Aptos RPC simulation or parse simulation events in this PR; simulation remains a product/server-layer behavior.
- Use the existing `buildTxTransferAssetAction` shape and set top-level `to` only when all parsed recipients collapse to one address. Multiple recipients remain in `transfers`.
- Decode both dApp payload arguments and BCS transaction arguments so fallback works for both encoded transaction shapes.

## Changes Detail
- `packages/kit-bg/src/vaults/impls/aptos/utils.ts`: marks `batch_transfer_coins` as an asset transfer function.
- `packages/kit-bg/src/vaults/impls/aptos/Vault.ts`: decodes `vector<address>` and `vector<u64>` recipients/amounts for Aptos batch coin transfers and builds a multi-transfer asset action.
- `packages/kit-bg/src/services/ServiceHardware/thirdPartyDeviceMapping.ts`: narrows optional `modelName` access to match the current `DeviceInfo` type and unblock TypeScript checks on latest `x`.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Aptos transaction confirmation fallback display for batch coin transfers; BCS argument decoding for Aptos dApp transactions.

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `yarn lint --fix` reached full TypeScript/Oxlint pass; repository package-version check still fails on local `.yalc` package version mismatches unrelated to this PR.
- [x] `npx eslint packages/kit-bg/src/vaults/impls/aptos/Vault.ts packages/kit-bg/src/vaults/impls/aptos/utils.ts`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit-bg/src/vaults/impls/aptos/Vault.ts packages/kit-bg/src/vaults/impls/aptos/utils.ts`
- [x] `git diff --check`