### PR TITLE
fix: guard hyperliquid referral checks

### DIFF
--- a/packages/kit/src/views/SignatureConfirm/hooks/useHyperliquidReferralPromotion.ts
+++ b/packages/kit/src/views/SignatureConfirm/hooks/useHyperliquidReferralPromotion.ts
@@ -54,9 +54,12 @@ export function useHyperliquidReferralPromotion({
     }
   }, [origin, unsignedMessage]);
 
+  const shouldCheckReferralPromotion =
+    Boolean(origin && accountId && userAddress) && isApproveAgentSign;
+
   // Check snooze state and set default checkbox state
   const { result: snoozeResult } = usePromiseResult(async () => {
-    if (!userAddress) {
+    if (!shouldCheckReferralPromotion) {
       return { snoozed: false };
     }
     const snoozedUntil =
@@ -64,7 +67,7 @@ export function useHyperliquidReferralPromotion({
         { userAddress },
       );
     return { snoozed: snoozedUntil > Date.now() };
-  }, [userAddress]);
+  }, [shouldCheckReferralPromotion, userAddress]);
 
   // Update checkbox state based on snooze preference
   useEffect(() => {
@@ -75,7 +78,7 @@ export function useHyperliquidReferralPromotion({
 
   const { result, isLoading } = usePromiseResult(
     async () => {
-      if (!origin || !accountId || !userAddress) {
+      if (!shouldCheckReferralPromotion) {
         return { shouldShow: false };
       }
 
@@ -88,7 +91,13 @@ export function useHyperliquidReferralPromotion({
         },
       );
     },
-    [origin, accountId, userAddress, isApproveAgentSign],
+    [
+      origin,
+      accountId,
+      userAddress,
+      isApproveAgentSign,
+      shouldCheckReferralPromotion,
+    ],
     { watchLoading: true },
   );
 


### PR DESCRIPTION
## Summary
- Guard Hyperliquid referral promotion checks behind a valid origin/account/user context and the Hyperliquid approveAgent typed-data shape.
- Prevent internal DeFi Permit2 signature confirmations from calling Hyperliquid referral snooze and eligibility checks.

## Intent & Context
The original issue was an Android crash in the DeFi subscribe flow when tapping the subscribe action. The local app log showed the flow entering Earn Permit2 approval signing, opening the internal MessageConfirm page, calling `serviceHyperliquidReferral.getReferralBannerSnoozedUntil`, then crashing shortly after background split segments were loaded.

This change keeps the referral promotion hook scoped to the Hyperliquid approveAgent signing flow. DeFi internal signatures do not have an origin and should not trigger Hyperliquid referral checks.

## Root Cause
`MessageConfirmActions` mounts `useHyperliquidReferralPromotion` for message confirmations. The referral eligibility call already required `origin`, `accountId`, and `userAddress`, but the snooze-state call only required `userAddress`. As a result, internal wallet signatures with no origin could still call `serviceHyperliquidReferral.getReferralBannerSnoozedUntil`, even though the signature was unrelated to Hyperliquid.

## Design Decisions
The fix is applied at the trigger layer by introducing one shared `shouldCheckReferralPromotion` condition. Both the snooze lookup and the promotion eligibility check now require the same valid Hyperliquid approveAgent context.

An alternative defensive change was considered: lazy-loading the Hyperliquid SDK inside `ServiceHyperliquidReferral`. That was not kept because it changes package loading and bundling behavior, while the root issue is that non-Hyperliquid signatures should not call the referral service at all.

## Changes Detail
- `packages/kit/src/views/SignatureConfirm/hooks/useHyperliquidReferralPromotion.ts`: adds `shouldCheckReferralPromotion` and uses it to skip both referral snooze and eligibility checks unless the message is a Hyperliquid approveAgent signature with complete context.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile
- **Risk Areas**: Hyperliquid referral promotion visibility on approveAgent signing, and internal message confirmation flows that should not show referral UI.

## Test plan
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --fix --deny-warnings packages/kit/src/views/SignatureConfirm/hooks/useHyperliquidReferralPromotion.ts`
- [x] `yarn lint:staged`
- [x] `git diff --check -- packages/kit/src/views/SignatureConfirm/hooks/useHyperliquidReferralPromotion.ts`
- [ ] `yarn tsc:staged` is currently blocked by existing unrelated errors in `packages/kit-bg/src/services/ServiceHardware/thirdPartyDeviceMapping.ts:54` and `packages/shared/src/modules3rdParty/appRestart/index.native.ts:34`.
- [ ] Verify the Android DeFi subscribe flow with a build from this branch.
