### PR TITLE
fix(app-update): correct "View full changelog" routing and smooth carousel height (OK-54757)

### DIFF
--- a/packages/kit/src/views/AppUpdate/components/FeaturedCarousel/useHeightSpring.ts
+++ b/packages/kit/src/views/AppUpdate/components/FeaturedCarousel/useHeightSpring.ts
@@ -23,12 +23,14 @@ interface IUseHeightSpringParams {
  * area below the media.
  *
  * Snap vs spring policy:
- *   - On the same slide we already settled on, target changes are measurement
- *     updates from the dialog scale-in / webfont swap — snap, otherwise the
- *     height visibly climbs after open.
- *   - When the rounded slide index changes (tap-jump that sets progress to a
- *     new integer, or a swipe that crosses a midpoint), spring smoothly to the
- *     new target.
+ *   - Settled on a slide AND no spring in flight: target changes are
+ *     post-settlement measurement updates (dialog scale-in, webfont swap,
+ *     deferred remeasure) — snap, otherwise the height visibly climbs after
+ *     open.
+ *   - Rounded slide index changed, or a spring is mid-flight: spring smoothly
+ *     to the new target. Without the in-flight guard, a slide's onLayout (or
+ *     its deferred remeasures) firing during the transition would re-enter
+ *     the snap branch and short-circuit the spring.
  *
  * IMPORTANT: prepare must return a primitive number — useAnimatedReaction does
  * reference equality on the return value, so an object literal would fire the
@@ -40,6 +42,9 @@ export function useHeightSpring({
 }: IUseHeightSpringParams) {
   const heightSpring = useSharedValue(ESTIMATED_FALLBACK_HEIGHT);
   const lastSnappedRounded = useSharedValue(0);
+  // Cleared only on natural spring completion; cancelled springs keep this
+  // true so a chained re-target stays in spring mode end to end.
+  const isSpringing = useSharedValue(false);
 
   useAnimatedReaction(
     () =>
@@ -53,7 +58,11 @@ export function useHeightSpring({
       const isStable =
         Math.abs(progress.value - rounded) < PROGRESS_SNAP_TOLERANCE;
 
-      if (isStable && lastSnappedRounded.value === rounded) {
+      if (
+        isStable &&
+        lastSnappedRounded.value === rounded &&
+        !isSpringing.value
+      ) {
         if (heightSpring.value !== target) heightSpring.value = target;
         return;
       }
@@ -61,9 +70,14 @@ export function useHeightSpring({
       if (isStable) lastSnappedRounded.value = rounded;
 
       if (prev !== null && Math.abs(target - prev) < 1) return;
+      isSpringing.value = true;
       heightSpring.value = withDelay(
         HEIGHT_SPRING_DELAY_MS,
-        withSpring(target, HEIGHT_SPRING_CONFIG),
+        withSpring(target, HEIGHT_SPRING_CONFIG, (finished) => {
+          'worklet';
+
+          if (finished) isSpringing.value = false;
+        }),
       );
     },
   );

--- a/packages/kit/src/views/AppUpdate/components/FeaturedFooter.tsx
+++ b/packages/kit/src/views/AppUpdate/components/FeaturedFooter.tsx
@@ -10,9 +10,12 @@ import {
   useMedia,
   useSafeAreaInsets,
 } from '@onekeyhq/components';
+import { appUpdatePersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { jotaiDefaultStore } from '@onekeyhq/kit-bg/src/states/jotai/utils/jotaiDefaultStore';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { EAppUpdateRoutes, EModalRoutes } from '@onekeyhq/shared/src/routes';
 
+import { isForceUpdateStrategy } from '../../../components/AppUpdate/updateStrategy';
 import useAppNavigation from '../../../hooks/useAppNavigation';
 import { AppUpdateTestIDs } from '../testIDs';
 
@@ -22,6 +25,7 @@ interface IFeaturedFooterProps {
   ctaText: string;
   onCtaPress: () => void;
   showFullChangelog?: boolean;
+  isPreInstall: boolean;
   closeDialog: () => Promise<void>;
   onLayout?: (event: LayoutChangeEvent) => void;
 }
@@ -30,6 +34,7 @@ function FeaturedFooter({
   ctaText,
   onCtaPress,
   showFullChangelog = true,
+  isPreInstall,
   closeDialog,
   onLayout,
 }: IFeaturedFooterProps) {
@@ -43,10 +48,24 @@ function FeaturedFooter({
 
   const handleViewChangelog = useCallback(async () => {
     await closeDialog();
+    if (isPreInstall) {
+      // WhatsNew hard-codes its title to APP_VERSION (currently installed);
+      // pre-install featured changelog targets a future version, so route to
+      // UpdatePreview which renders the target version end-to-end.
+      const info = jotaiDefaultStore.get(appUpdatePersistAtom.atom());
+      navigation.pushModal(EModalRoutes.AppUpdateModal, {
+        screen: EAppUpdateRoutes.UpdatePreview,
+        params: {
+          latestVersion: info.latestVersion,
+          isForceUpdate: isForceUpdateStrategy(info.updateStrategy),
+        },
+      });
+      return;
+    }
     navigation.pushModal(EModalRoutes.AppUpdateModal, {
       screen: EAppUpdateRoutes.WhatsNew,
     });
-  }, [navigation, closeDialog]);
+  }, [navigation, closeDialog, isPreInstall]);
 
   if (md) {
     return (

--- a/packages/kit/src/views/AppUpdate/dialogs/showFeaturedChangelogDialog.tsx
+++ b/packages/kit/src/views/AppUpdate/dialogs/showFeaturedChangelogDialog.tsx
@@ -233,6 +233,7 @@ function FeaturedChangelogContent({
         ctaText={ctaText}
         onCtaPress={() => void onCtaPress()}
         showFullChangelog={!isLocked}
+        isPreInstall={isPreInstall}
         closeDialog={closeDialog}
         onLayout={(e) => setFooterHeight(e.nativeEvent.layout.height)}
       />

--- a/packages/kit/src/views/Onboardingv2/pages/BackupWalletReminder.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/BackupWalletReminder.tsx
@@ -308,7 +308,7 @@ export default function BackupWalletReminder() {
 
         <OnboardingSidebar
           gap="$4"
-          $md={{ mt: 'auto' }}
+          $md={{ mt: 'auto', pb: '$5' }}
           $gtMd={{ justifyContent: 'center', alignItems: 'center' }}
         >
           <AnimatePresence initial={false} exitBeforeEnter>


### PR DESCRIPTION
## Summary

Two unrelated fixes shipped together.

### Featured changelog dialog (OK-54757)

- **"View full changelog" routed to the wrong page in pre-install context.** The footer button always pushed `EAppUpdateRoutes.WhatsNew`, which hard-codes its title to `APP_VERSION` (currently installed). For pre-install featured changelogs (which target a future version, e.g. `9906.15.1`), users saw a title for their currently installed version instead of the upcoming one. Fix routes to `EAppUpdateRoutes.UpdatePreview` (which renders the target version end-to-end via `displayAppUpdateVersion(updateInfo)`) when `isPreInstall` is true; keeps `WhatsNew` for post-install. `isPreInstall` is threaded through `showFeaturedChangelogDialog` → `FeaturedFooter`. Atom is read imperatively (`jotaiDefaultStore.get(appUpdatePersistAtom.atom())`) inside the click handler to avoid subscribing the footer to unrelated atom field changes (download `status`, `lastUpdateDialogShownAt`, etc.).

- **Carousel height "snapped" instead of animating on desktop.** When switching between feature slides on desktop, the dialog height frequently jumped to the new size instead of springing. Root cause in `useHeightSpring.ts`: `lastSnappedRounded` was set immediately when a spring was scheduled (not when it completed), so any deferred remeasure firing during the transition — `FeaturedSlide.tsx` runs `onLayout` ~1–2 frames after mount, plus `setTimeout(100/300)` remeasures and `document.fonts.ready` — re-entered the snap branch and short-circuited the in-flight spring. Fix adds an `isSpringing` shared value that gates the snap branch; it is cleared only on the spring's natural completion (callback `finished === true`), so an interrupted-and-retargeted spring stays in spring mode end to end.

### Onboarding v2 — backup reminder

- Adds bottom padding to the backup wallet reminder sidebar on mobile so it doesn't sit flush against the safe-area bottom inset.

## Test plan

- [ ] Pre-install featured changelog dialog: tap "View full changelog" → page title shows the target version (e.g. `9906.15.1`), not the installed version
- [ ] Post-install featured changelog dialog: tap "View full changelog" → page title still shows the installed app version (existing behavior)
- [ ] Desktop featured changelog: tap any pagination indicator to jump between features → dialog height springs smoothly to the new slide's height (no snap)
- [ ] Desktop featured changelog: swipe between adjacent features → dialog height tracks smoothly
- [ ] Initial dialog open: dialog height still snaps cleanly into place after webfont swap / scale-in (no visible "climbing" after open)
- [ ] Mobile onboarding backup reminder: sidebar has bottom padding above the safe-area inset