### PR TITLE
fix: extend bot-wallet deactivated guardrails across send/receive paths

### DIFF
--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -4124,6 +4124,39 @@ class ServiceAccount extends ServiceBase {
     return metadata?.status === BOT_WALLET_STATUS_DEACTIVATED;
   }
 
+  // Batch variant of isBotWalletDeactivated to avoid N IPC round-trips when a
+  // caller needs the status for many wallets (recipient picker, bulk lists).
+  // Returns a map keyed by the input walletId; non-bot wallets are mapped to
+  // false without touching simpleDb.
+  @backgroundMethod()
+  async getBotWalletDeactivationStatusMap({
+    walletIds,
+  }: {
+    walletIds: string[];
+  }): Promise<Record<string, boolean>> {
+    const result: Record<string, boolean> = {};
+    if (!walletIds?.length) {
+      return result;
+    }
+    const uniqueIds = Array.from(new Set(walletIds));
+    const botWalletIds = uniqueIds.filter((id) =>
+      accountUtils.isBotWallet({ walletId: id }),
+    );
+    for (const id of uniqueIds) {
+      result[id] = false;
+    }
+    if (botWalletIds.length === 0) {
+      return result;
+    }
+    const metadataList = await Promise.all(
+      botWalletIds.map((id) => simpleDb.botWallet.getMetadata(id)),
+    );
+    botWalletIds.forEach((id, idx) => {
+      result[id] = metadataList[idx]?.status === BOT_WALLET_STATUS_DEACTIVATED;
+    });
+    return result;
+  }
+
   @backgroundMethod()
   async isTempWalletRemoved({
     wallet,

--- a/packages/kit/src/components/AccountSelector/AccountSelectorActiveAccount.tsx
+++ b/packages/kit/src/components/AccountSelector/AccountSelectorActiveAccount.tsx
@@ -11,7 +11,6 @@ import {
   IconButton,
   NATIVE_HIT_SLOP,
   SizableText,
-  Toast,
   Tooltip,
   XStack,
 } from '@onekeyhq/components';
@@ -33,6 +32,7 @@ import {
   useActiveAccount,
   useSelectedAccount,
 } from '../../states/jotai/contexts/accountSelector';
+import { showBotWalletDisabledToast } from '../../utils/botWalletDisabledToast';
 import { shouldBlockBotWalletCopyAddress } from '../../utils/botWalletStatusUtils';
 
 import { AccountSelectorCreateAddressButton } from './AccountSelectorCreateAddressButton';
@@ -98,12 +98,9 @@ const AllNetworkAccountSelector = ({
           }}
           userSelect="none"
           opacity={isCopyDisabled ? 0.5 : 1}
-          disabled={isCopyDisabled}
           onPress={async () => {
             if (isCopyDisabled) {
-              Toast.error({
-                title: '该钱包已停用，无法复制地址',
-              });
+              showBotWalletDisabledToast('copyAddress');
               return;
             }
             if (
@@ -233,9 +230,7 @@ export function AccountSelectorActiveAccountHome({
         isBotWalletDeactivated,
       })
     ) {
-      Toast.error({
-        title: '该钱包已停用，无法复制地址',
-      });
+      showBotWalletDisabledToast('copyAddress');
       return;
     }
 

--- a/packages/kit/src/hooks/useBotWalletDeactivatedStatus.ts
+++ b/packages/kit/src/hooks/useBotWalletDeactivatedStatus.ts
@@ -1,7 +1,11 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import {
+  EAppEventBusNames,
+  appEventBus,
+} from '@onekeyhq/shared/src/eventBus/appEventBus';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 
 export interface IBotWalletDeactivatedStatus {
@@ -19,7 +23,7 @@ export function useBotWalletDeactivatedStatus({
     [walletId],
   );
 
-  const { result } = usePromiseResult(
+  const { result, run } = usePromiseResult(
     async () => {
       if (!walletId || !isBotWallet) {
         return false;
@@ -33,6 +37,18 @@ export function useBotWalletDeactivatedStatus({
       checkIsFocused: false,
     },
   );
+
+  // Refresh when bot wallet metadata changes. ServiceAccount.deactivate /
+  // reactivateBotWallet emit WalletUpdate (debounced) via
+  // scheduleWalletUpdateForBotMetadata, so subscribing here keeps every
+  // dependent UI in sync without requiring a page refresh.
+  useEffect(() => {
+    if (!isBotWallet) return;
+    appEventBus.on(EAppEventBusNames.WalletUpdate, run);
+    return () => {
+      appEventBus.off(EAppEventBusNames.WalletUpdate, run);
+    };
+  }, [isBotWallet, run]);
 
   return {
     isBotWallet,

--- a/packages/kit/src/utils/botWalletDisabledToast.ts
+++ b/packages/kit/src/utils/botWalletDisabledToast.ts
@@ -1,0 +1,31 @@
+import { Toast } from '@onekeyhq/components';
+
+// Centralised messages for "deactivated bot wallet" UI feedback. Disabled
+// buttons should still respond to taps with a toast so users get feedback
+// instead of a silent dead-click.
+// TODO(i18n): replace hardcoded Chinese once locale entries are added.
+
+export type IBotWalletDisabledScene =
+  | 'copyAddress'
+  | 'receive'
+  | 'export'
+  | 'beReceiver'
+  | 'addMoney'
+  | 'bulkCopy'
+  | 'referral';
+
+const SCENE_TITLES: Record<IBotWalletDisabledScene, string> = {
+  copyAddress: '该钱包已停用，无法复制地址',
+  receive: '该钱包已停用，无法接收资产',
+  export: '该钱包已停用，无法导出密钥',
+  beReceiver: '该地址属于已停用的 Bot 钱包，无法作为接收地址',
+  addMoney: '该钱包已停用，无法充值',
+  bulkCopy: '该钱包已停用，无法批量复制地址',
+  referral: '该钱包已停用，无法绑定邀请码',
+};
+
+export function showBotWalletDisabledToast(scene: IBotWalletDisabledScene) {
+  Toast.error({
+    title: SCENE_TITLES[scene],
+  });
+}

--- a/packages/kit/src/utils/botWalletDisabledToast.ts
+++ b/packages/kit/src/utils/botWalletDisabledToast.ts
@@ -24,6 +24,10 @@ const SCENE_TITLES: Record<IBotWalletDisabledScene, string> = {
   referral: '该钱包已停用，无法绑定邀请码',
 };
 
+export function getBotWalletDisabledMessage(scene: IBotWalletDisabledScene) {
+  return SCENE_TITLES[scene];
+}
+
 export function showBotWalletDisabledToast(scene: IBotWalletDisabledScene) {
   Toast.error({
     title: SCENE_TITLES[scene],

--- a/packages/kit/src/utils/botWalletDisabledToast.ts
+++ b/packages/kit/src/utils/botWalletDisabledToast.ts
@@ -1,6 +1,6 @@
 import { Toast } from '@onekeyhq/components';
 
-// Centralised messages for "deactivated bot wallet" UI feedback. Disabled
+// Centralized messages for "deactivated bot wallet" UI feedback. Disabled
 // buttons should still respond to taps with a toast so users get feedback
 // instead of a silent dead-click.
 // TODO(i18n): replace hardcoded Chinese once locale entries are added.

--- a/packages/kit/src/views/AccountManagerStacks/components/AccountEdit/AccountCopyButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/AccountEdit/AccountCopyButton.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import { useIntl } from 'react-intl';
 
 import type { IPageNavigationProp } from '@onekeyhq/components';
-import { ActionList, Toast } from '@onekeyhq/components';
+import { ActionList } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { useAccountData } from '@onekeyhq/kit/src/hooks/useAccountData';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
@@ -11,6 +11,7 @@ import { useBotWalletDeactivatedStatus } from '@onekeyhq/kit/src/hooks/useBotWal
 import { useCopyAddressWithDeriveType } from '@onekeyhq/kit/src/hooks/useCopyAccountAddress';
 import { useUserWalletProfile } from '@onekeyhq/kit/src/hooks/useUserWalletProfile';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
+import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
 import { shouldBlockBotWalletCopyAddress } from '@onekeyhq/kit/src/utils/botWalletStatusUtils';
 import type {
   IDBAccount,
@@ -61,10 +62,6 @@ export function AccountCopyButton({
       walletId: wallet?.id,
     },
   );
-  const isCopyDisabled = shouldBlockBotWalletCopyAddress({
-    isBotWallet,
-    isBotWalletDeactivated,
-  });
 
   const handleCopyAddress = useCallback(async () => {
     if (
@@ -73,9 +70,7 @@ export function AccountCopyButton({
         isBotWalletDeactivated,
       })
     ) {
-      Toast.error({
-        title: '该钱包已停用，无法复制地址',
-      });
+      showBotWalletDisabledToast('copyAddress');
       return;
     }
     if (
@@ -169,7 +164,6 @@ export function AccountCopyButton({
       label={intl.formatMessage({ id: ETranslations.global_copy_address })}
       onClose={() => {}}
       onPress={handleCopyAddress}
-      disabled={isCopyDisabled}
     />
   );
 }

--- a/packages/kit/src/views/AccountManagerStacks/components/AccountEdit/AccountExportPrivateKeyButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/AccountEdit/AccountExportPrivateKeyButton.tsx
@@ -5,6 +5,7 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useBotWalletDeactivatedStatus } from '@onekeyhq/kit/src/hooks/useBotWalletDeactivatedStatus';
 import { navigateToBackupWalletReminderPage } from '@onekeyhq/kit/src/hooks/usePageNavigation';
+import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
 import { shouldHideBotWalletExport } from '@onekeyhq/kit/src/utils/botWalletStatusUtils';
 import type {
   IDBAccount,
@@ -45,14 +46,10 @@ export function AccountExportPrivateKeyButton({
       walletId: wallet?.id,
     },
   );
-  if (
-    shouldHideBotWalletExport({
-      isBotWallet,
-      isBotWalletDeactivated,
-    })
-  ) {
-    return null;
-  }
+  const isExportBlocked = shouldHideBotWalletExport({
+    isBotWallet,
+    isBotWalletDeactivated,
+  });
 
   return (
     <ActionList.Item
@@ -61,6 +58,13 @@ export function AccountExportPrivateKeyButton({
       label={label}
       onClose={onClose}
       onPress={async () => {
+        if (isExportBlocked) {
+          // Stay clickable so users get feedback instead of a silent
+          // dead-click. Keep the visual cue minimal — `disabled` would
+          // also suppress onPress in ActionList.Item.
+          showBotWalletDisabledToast('export');
+          return;
+        }
         if (
           await backgroundApiProxy.serviceAccount.checkIsWalletNotBackedUp({
             walletId: wallet?.id ?? '',

--- a/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/BulkCopyAddressesButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/BulkCopyAddressesButton.tsx
@@ -3,7 +3,9 @@ import { useIntl } from 'react-intl';
 import { ActionList, Badge, Dialog, Toast } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { useBotWalletDeactivatedStatus } from '@onekeyhq/kit/src/hooks/useBotWalletDeactivatedStatus';
 import { useAccountSelectorActions } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
+import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
 import type { IDBWallet } from '@onekeyhq/kit-bg/src/dbs/local/types';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
@@ -28,6 +30,12 @@ export function BulkCopyAddressesButton({
   const intl = useIntl();
   const navigation = useAppNavigation();
   const actions = useAccountSelectorActions();
+  const { isBotWallet, isBotWalletDeactivated } = useBotWalletDeactivatedStatus(
+    {
+      walletId: wallet?.id,
+    },
+  );
+  const isBulkCopyBlocked = isBotWallet && isBotWalletDeactivated;
 
   return (
     <ActionList.Item
@@ -36,6 +44,13 @@ export function BulkCopyAddressesButton({
         id: ETranslations.global_bulk_copy_addresses,
       })}
       onPress={async (close) => {
+        if (isBulkCopyBlocked) {
+          // Keep the entry interactive so users get feedback instead of a
+          // silent dead-click; close the action sheet after toasting.
+          showBotWalletDisabledToast('bulkCopy');
+          close?.();
+          return;
+        }
         close?.();
         // Close the Action first and wait 150ms before ejecting the Modal to avoid the problem of closing after ejecting
         await timerUtils.wait(150);

--- a/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletBoundReferralCodeButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletBoundReferralCodeButton.tsx
@@ -13,7 +13,9 @@ import {
   YStack,
 } from '@onekeyhq/components';
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
+import { useBotWalletDeactivatedStatus } from '@onekeyhq/kit/src/hooks/useBotWalletDeactivatedStatus';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
 import { useWalletBoundReferralCode } from '@onekeyhq/kit/src/views/ReferFriends/hooks/useWalletBoundReferralCode';
 import type { IReferralBindDisplayStatus } from '@onekeyhq/kit/src/views/ReferFriends/hooks/useWalletBoundReferralCode/referralBindStatusUtils';
 import type { IDBWallet } from '@onekeyhq/kit-bg/src/dbs/local/types';
@@ -87,6 +89,12 @@ function WalletBoundReferralCodeButtonView({
       !accountUtils.isHwHiddenWallet({
         wallet,
       }));
+  const { isBotWallet, isBotWalletDeactivated } = useBotWalletDeactivatedStatus(
+    {
+      walletId: wallet?.id,
+    },
+  );
+  const isReferralBlocked = isBotWallet && isBotWalletDeactivated;
 
   const {
     result: referralCodeButtonState,
@@ -124,6 +132,10 @@ function WalletBoundReferralCodeButtonView({
     if (isLoading) {
       return;
     }
+    if (isReferralBlocked) {
+      showBotWalletDisabledToast('referral');
+      return;
+    }
     if (!shouldBoundReferralCode) {
       return;
     }
@@ -148,6 +160,7 @@ function WalletBoundReferralCodeButtonView({
     }
   }, [
     isLoading,
+    isReferralBlocked,
     shouldBoundReferralCode,
     getReferralCodeBondStatus,
     wallet,
@@ -198,7 +211,10 @@ function WalletBoundReferralCodeButtonView({
       onPress={handlePress}
       isLoading={isLoading}
       onClose={onClose}
-      disabled={Boolean(!shouldBoundReferralCode)}
+      // For deactivated bot wallets we keep the item interactive so
+      // handlePress can surface the disabled-bot-wallet toast (ActionList.Item
+      // suppresses onPress when `disabled` is true).
+      disabled={Boolean(!shouldBoundReferralCode) && !isReferralBlocked}
       extraInteractiveWhenDisabled={Boolean(isNotBindable)}
     />
   );

--- a/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletBoundReferralCodeButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/WalletBoundReferralCodeButton.tsx
@@ -214,7 +214,7 @@ function WalletBoundReferralCodeButtonView({
       // For deactivated bot wallets we keep the item interactive so
       // handlePress can surface the disabled-bot-wallet toast (ActionList.Item
       // suppresses onPress when `disabled` is true).
-      disabled={Boolean(!shouldBoundReferralCode) && !isReferralBlocked}
+      disabled={Boolean(!shouldBoundReferralCode && !isReferralBlocked)}
       extraInteractiveWhenDisabled={Boolean(isNotBindable)}
     />
   );

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
@@ -13,7 +13,6 @@ import {
   SizableText,
   Skeleton,
   Stack,
-  Toast,
   XStack,
   YStack,
   useTabIsRefreshingFocused,
@@ -29,6 +28,7 @@ import { useDisplayAccountAddress } from '@onekeyhq/kit/src/hooks/useDisplayAcco
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useReceiveToken } from '@onekeyhq/kit/src/hooks/useReceiveToken';
 import { useUserWalletProfile } from '@onekeyhq/kit/src/hooks/useUserWalletProfile';
+import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
 import {
   shouldBlockBotWalletCopyAddress,
   shouldBlockBotWalletReceive,
@@ -442,6 +442,14 @@ function TokenDetailsHeader(props: IProps) {
   const addressBlockValue = useMemo(() => {
     const address = account?.address ?? '';
 
+    // For deactivated bot wallets the address must not be exposed in full —
+    // copying is blocked, and showing the full string would let users still
+    // grab the address via long-press / OS-level select. Mask it the same
+    // way the account selector shortens addresses.
+    if (isBotWalletCopyBlocked) {
+      return accountUtils.shortenAddress({ address });
+    }
+
     if (
       accountUtils.isHwWallet({ walletId }) ||
       accountUtils.isQrWallet({ walletId })
@@ -450,13 +458,11 @@ function TokenDetailsHeader(props: IProps) {
     }
 
     return address;
-  }, [account?.address, walletId]);
+  }, [account?.address, walletId, isBotWalletCopyBlocked]);
 
   const handleCopyAddressPress = useCallback(() => {
     if (isBotWalletCopyBlocked) {
-      Toast.error({
-        title: '该钱包已停用，无法复制地址',
-      });
+      showBotWalletDisabledToast('copyAddress');
       return;
     }
     void copyAccountAddress({
@@ -536,9 +542,7 @@ function TokenDetailsHeader(props: IProps) {
               allowPressWhenDisabled={isBotWalletReceiveBlocked}
               onPress={async () => {
                 if (isBotWalletReceiveBlocked) {
-                  Toast.error({
-                    title: '该钱包已停用，无法接收资产',
-                  });
+                  showBotWalletDisabledToast('receive');
                   return;
                 }
                 if (

--- a/packages/kit/src/views/BulkCopyAddresses/pages/BulkCopyAddresses.tsx
+++ b/packages/kit/src/views/BulkCopyAddresses/pages/BulkCopyAddresses.tsx
@@ -142,69 +142,69 @@ function BulkCopyAddresses({
 
   const { result: availableWallets, run: refreshAvailableWallets } =
     usePromiseResult(async () => {
-    const { wallets } = await backgroundApiProxy.serviceAccount.getWallets({
-      ignoreEmptySingletonWalletAccounts: true,
-      ignoreNonBackedUpWallets: true,
-      nestedHiddenWallets: true,
-      includingAccounts: true,
-    });
-
-    const availableWalletsTemp: (IDBWallet & {
-      parentWalletName?: string;
-    })[] = [];
-
-    const isWalletDeactivatedBotWallet = async (id: string) => {
-      if (!accountUtils.isBotWallet({ walletId: id })) {
-        return false;
-      }
-      return backgroundApiProxy.serviceAccount.isBotWalletDeactivated({
-        walletId: id,
+      const { wallets } = await backgroundApiProxy.serviceAccount.getWallets({
+        ignoreEmptySingletonWalletAccounts: true,
+        ignoreNonBackedUpWallets: true,
+        nestedHiddenWallets: true,
+        includingAccounts: true,
       });
-    };
 
-    // Reset the map alongside the list so a deactivated wallet that was
-    // previously selectable cannot stay reachable through walletsMap when its
-    // status flips.
-    walletsMap.current = {};
+      const availableWalletsTemp: (IDBWallet & {
+        parentWalletName?: string;
+      })[] = [];
 
-    for (const wallet of wallets) {
-      if (
-        !accountUtils.isQrWallet({ walletId: wallet.id }) &&
-        !accountUtils.isOthersWallet({ walletId: wallet.id }) &&
-        !wallet.deprecated
-      ) {
-        // eslint-disable-next-line no-await-in-loop
-        const isWalletDeactivated = await isWalletDeactivatedBotWallet(
-          wallet.id,
-        );
-        if (!wallet.isMocked && !isWalletDeactivated) {
-          availableWalletsTemp.push(wallet);
-          walletsMap.current[wallet.id] = wallet;
+      const isWalletDeactivatedBotWallet = async (id: string) => {
+        if (!accountUtils.isBotWallet({ walletId: id })) {
+          return false;
         }
-        if (wallet.hiddenWallets?.length) {
-          for (const hiddenWallet of wallet.hiddenWallets) {
-            if (!hiddenWallet.deprecated && !hiddenWallet.isMocked) {
-              // eslint-disable-next-line no-await-in-loop
-              const isHiddenWalletDeactivated =
-                await isWalletDeactivatedBotWallet(hiddenWallet.id);
-              if (!isHiddenWalletDeactivated) {
-                availableWalletsTemp.push({
-                  ...hiddenWallet,
-                  parentWalletName: wallet.name,
-                });
-                walletsMap.current[hiddenWallet.id] = {
-                  ...hiddenWallet,
-                  parentWalletName: wallet.name,
-                };
+        return backgroundApiProxy.serviceAccount.isBotWalletDeactivated({
+          walletId: id,
+        });
+      };
+
+      // Reset the map alongside the list so a deactivated wallet that was
+      // previously selectable cannot stay reachable through walletsMap when its
+      // status flips.
+      walletsMap.current = {};
+
+      for (const wallet of wallets) {
+        if (
+          !accountUtils.isQrWallet({ walletId: wallet.id }) &&
+          !accountUtils.isOthersWallet({ walletId: wallet.id }) &&
+          !wallet.deprecated
+        ) {
+          // eslint-disable-next-line no-await-in-loop
+          const isWalletDeactivated = await isWalletDeactivatedBotWallet(
+            wallet.id,
+          );
+          if (!wallet.isMocked && !isWalletDeactivated) {
+            availableWalletsTemp.push(wallet);
+            walletsMap.current[wallet.id] = wallet;
+          }
+          if (wallet.hiddenWallets?.length) {
+            for (const hiddenWallet of wallet.hiddenWallets) {
+              if (!hiddenWallet.deprecated && !hiddenWallet.isMocked) {
+                // eslint-disable-next-line no-await-in-loop
+                const isHiddenWalletDeactivated =
+                  await isWalletDeactivatedBotWallet(hiddenWallet.id);
+                if (!isHiddenWalletDeactivated) {
+                  availableWalletsTemp.push({
+                    ...hiddenWallet,
+                    parentWalletName: wallet.name,
+                  });
+                  walletsMap.current[hiddenWallet.id] = {
+                    ...hiddenWallet,
+                    parentWalletName: wallet.name,
+                  };
+                }
               }
             }
           }
         }
       }
-    }
 
-    return availableWalletsTemp;
-  }, []);
+      return availableWalletsTemp;
+    }, []);
 
   // Keep the available-wallet list reactive: bot wallet activate /
   // deactivate emits WalletUpdate (debounced) — without this the picker

--- a/packages/kit/src/views/BulkCopyAddresses/pages/BulkCopyAddresses.tsx
+++ b/packages/kit/src/views/BulkCopyAddresses/pages/BulkCopyAddresses.tsx
@@ -140,7 +140,8 @@ function BulkCopyAddresses({
 
   const isHwWallet = accountUtils.isHwWallet({ walletId: selectedWalletId });
 
-  const { result: availableWallets } = usePromiseResult(async () => {
+  const { result: availableWallets, run: refreshAvailableWallets } =
+    usePromiseResult(async () => {
     const { wallets } = await backgroundApiProxy.serviceAccount.getWallets({
       ignoreEmptySingletonWalletAccounts: true,
       ignoreNonBackedUpWallets: true,
@@ -204,6 +205,16 @@ function BulkCopyAddresses({
 
     return availableWalletsTemp;
   }, []);
+
+  // Keep the available-wallet list reactive: bot wallet activate /
+  // deactivate emits WalletUpdate (debounced) — without this the picker
+  // would still show the wallet until the user navigates away and back.
+  useEffect(() => {
+    appEventBus.on(EAppEventBusNames.WalletUpdate, refreshAvailableWallets);
+    return () => {
+      appEventBus.off(EAppEventBusNames.WalletUpdate, refreshAvailableWallets);
+    };
+  }, [refreshAvailableWallets]);
 
   // If the wallet that was passed in via route params (or previously selected)
   // is no longer available — e.g. it became a deactivated Bot Wallet and was

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/ReceiverAddressesInput.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/ReceiverAddressesInput.tsx
@@ -18,7 +18,10 @@ import { useAccountData } from '@onekeyhq/kit/src/hooks/useAccountData';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import type { IAccountSelectorActiveAccountInfo } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import { isAddressOwnedByDeactivatedBotWallet } from '@onekeyhq/kit/src/utils/botWalletAccountUtils';
-import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
+import {
+  getBotWalletDisabledMessage,
+  showBotWalletDisabledToast,
+} from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
 import { useDebouncedValidation } from '@onekeyhq/kit/src/views/BulkSend/hooks/useDebouncedValidation';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -294,7 +297,7 @@ function SingleLineReceiverInput() {
         if (isDeactivatedBotReceiver) {
           setReceiverValidationErrors([]);
           showBotWalletDisabledToast('beReceiver');
-          return '该 Bot 钱包已停用，无法作为接收地址';
+          return getBotWalletDisabledMessage('beReceiver');
         }
       }
 

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/ReceiverAddressesInput.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/ReceiverAddressesInput.tsx
@@ -18,6 +18,7 @@ import { useAccountData } from '@onekeyhq/kit/src/hooks/useAccountData';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import type { IAccountSelectorActiveAccountInfo } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import { isAddressOwnedByDeactivatedBotWallet } from '@onekeyhq/kit/src/utils/botWalletAccountUtils';
+import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
 import { useDebouncedValidation } from '@onekeyhq/kit/src/views/BulkSend/hooks/useDebouncedValidation';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -281,7 +282,9 @@ function SingleLineReceiverInput() {
 
       // Reject when the receiver address resolves to a deactivated Bot Wallet
       // account. The helper falls back to BTC fresh-address resolution to
-      // match the allowlist resolver below.
+      // match the allowlist resolver below. Surface a toast in addition to
+      // the inline error so users see the rejection prominently — the form
+      // continues to block submission via the inline error.
       if (selectedNetworkId) {
         const isDeactivatedBotReceiver =
           await isAddressOwnedByDeactivatedBotWallet({
@@ -290,6 +293,7 @@ function SingleLineReceiverInput() {
           });
         if (isDeactivatedBotReceiver) {
           setReceiverValidationErrors([]);
+          showBotWalletDisabledToast('beReceiver');
           return '该 Bot 钱包已停用，无法作为接收地址';
         }
       }

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/useMultiLineAddressValidation.ts
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/useMultiLineAddressValidation.ts
@@ -9,7 +9,10 @@ import { useIsEnableTransferAllowList } from '@onekeyhq/kit/src/components/Addre
 import { useAccountData } from '@onekeyhq/kit/src/hooks/useAccountData';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { isAddressOwnedByDeactivatedBotWallet } from '@onekeyhq/kit/src/utils/botWalletAccountUtils';
-import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
+import {
+  getBotWalletDisabledMessage,
+  showBotWalletDisabledToast,
+} from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
 import {
   getBulkSendMinTransferAmount,
   getBulkSendMinTransferDisplayAmount,
@@ -598,7 +601,7 @@ function useMultiLineAddressValidation(
               hasDeactivatedBotReceiver = true;
               lineErrors.push({
                 lineNumber: index + 1,
-                message: '该 Bot 钱包已停用，无法作为接收地址',
+                message: getBotWalletDisabledMessage('beReceiver'),
               });
             }
           }

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/useMultiLineAddressValidation.ts
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/useMultiLineAddressValidation.ts
@@ -9,6 +9,7 @@ import { useIsEnableTransferAllowList } from '@onekeyhq/kit/src/components/Addre
 import { useAccountData } from '@onekeyhq/kit/src/hooks/useAccountData';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { isAddressOwnedByDeactivatedBotWallet } from '@onekeyhq/kit/src/utils/botWalletAccountUtils';
+import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
 import {
   getBulkSendMinTransferAmount,
   getBulkSendMinTransferDisplayAmount,
@@ -591,13 +592,20 @@ function useMultiLineAddressValidation(
           if (isValidationStale()) {
             return true;
           }
+          let hasDeactivatedBotReceiver = false;
           for (const { index, isDeactivated } of botWalletResults) {
             if (isDeactivated) {
+              hasDeactivatedBotReceiver = true;
               lineErrors.push({
                 lineNumber: index + 1,
                 message: '该 Bot 钱包已停用，无法作为接收地址',
               });
             }
+          }
+          if (hasDeactivatedBotReceiver) {
+            // Show a single aggregated toast — pasting many lines should not
+            // spam one toast per row.
+            showBotWalletDisabledToast('beReceiver');
           }
         }
 

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionBuy.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionBuy.tsx
@@ -6,10 +6,12 @@ import { useIntl } from 'react-intl';
 import { ActionList } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import AddressTypeSelector from '@onekeyhq/kit/src/components/AddressTypeSelector/AddressTypeSelector';
+import { useBotWalletDeactivatedStatus } from '@onekeyhq/kit/src/hooks/useBotWalletDeactivatedStatus';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useUserWalletProfile } from '@onekeyhq/kit/src/hooks/useUserWalletProfile';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import { useAllTokenListMapAtom } from '@onekeyhq/kit/src/states/jotai/contexts/tokenList';
+import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
 import {
   useFiatCrypto,
   useSupportNetworkId,
@@ -63,6 +65,13 @@ export function WalletActionBuy({
     [network?.id, account?.id],
   );
 
+  const { isBotWallet, isBotWalletDeactivated } = useBotWalletDeactivatedStatus(
+    {
+      walletId: wallet?.id,
+    },
+  );
+  const isAddMoneyBlockedByBotWallet = isBotWallet && isBotWalletDeactivated;
+
   const isBuyDisabled = useMemo(() => {
     if (wallet?.type === WALLET_TYPE_WATCHING && !platformEnv.isDev) {
       return true;
@@ -72,11 +81,24 @@ export function WalletActionBuy({
       return true;
     }
 
+    if (isAddMoneyBlockedByBotWallet) {
+      return true;
+    }
+
     return false;
-  }, [isBuySupported, isSellSupported, wallet?.type]);
+  }, [
+    isBuySupported,
+    isSellSupported,
+    wallet?.type,
+    isAddMoneyBlockedByBotWallet,
+  ]);
 
   const { isSoftwareWalletOnlyUser } = useUserWalletProfile();
   const handleBuyToken = useCallback(async () => {
+    if (isAddMoneyBlockedByBotWallet) {
+      showBotWalletDisabledToast('addMoney');
+      return;
+    }
     if (isBuyDisabled) return;
 
     if (
@@ -97,6 +119,7 @@ export function WalletActionBuy({
     handleFiatCrypto({ sameModal });
     onClose();
   }, [
+    isAddMoneyBlockedByBotWallet,
     isBuyDisabled,
     handleFiatCrypto,
     network,
@@ -186,7 +209,10 @@ export function WalletActionBuy({
       label={intl.formatMessage({ id: ETranslations.buy_and_sell })}
       onClose={() => {}}
       onPress={handleBuyToken}
-      disabled={isBuyDisabled}
+      // Stay tappable for the deactivated-bot-wallet path so handleBuyToken
+      // can surface the disabled-bot-wallet toast (ActionList.Item suppresses
+      // onPress when `disabled` is true).
+      disabled={isBuyDisabled && !isAddMoneyBlockedByBotWallet}
     />
   );
 }

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionBuy.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionBuy.tsx
@@ -212,7 +212,7 @@ export function WalletActionBuy({
       // Stay tappable for the deactivated-bot-wallet path so handleBuyToken
       // can surface the disabled-bot-wallet toast (ActionList.Item suppresses
       // onPress when `disabled` is true).
-      disabled={isBuyDisabled && !isAddMoneyBlockedByBotWallet}
+      disabled={Boolean(isBuyDisabled && !isAddMoneyBlockedByBotWallet)}
     />
   );
 }

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionBuyMain.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionBuyMain.tsx
@@ -3,8 +3,10 @@ import { useCallback, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { useBotWalletDeactivatedStatus } from '@onekeyhq/kit/src/hooks/useBotWalletDeactivatedStatus';
 import { useUserWalletProfile } from '@onekeyhq/kit/src/hooks/useUserWalletProfile';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
+import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
 import {
   useFiatCrypto,
   useSupportNetworkId,
@@ -35,6 +37,13 @@ function WalletActionBuyMain({
   });
   const { result: isSellSupported } = useSupportNetworkId('sell', network?.id);
 
+  const { isBotWallet, isBotWalletDeactivated } = useBotWalletDeactivatedStatus(
+    {
+      walletId: wallet?.id,
+    },
+  );
+  const isAddMoneyBlockedByBotWallet = isBotWallet && isBotWalletDeactivated;
+
   const isBuyDisabled = useMemo(() => {
     if (wallet?.type === WALLET_TYPE_WATCHING && !platformEnv.isDev) {
       return true;
@@ -44,12 +53,25 @@ function WalletActionBuyMain({
       return true;
     }
 
+    if (isAddMoneyBlockedByBotWallet) {
+      return true;
+    }
+
     return false;
-  }, [isBuySupported, isSellSupported, wallet?.type]);
+  }, [
+    isBuySupported,
+    isSellSupported,
+    wallet?.type,
+    isAddMoneyBlockedByBotWallet,
+  ]);
 
   const { isSoftwareWalletOnlyUser } = useUserWalletProfile();
 
   const handleBuyToken = useCallback(async () => {
+    if (isAddMoneyBlockedByBotWallet) {
+      showBotWalletDisabledToast('addMoney');
+      return;
+    }
     if (isBuyDisabled) return;
 
     if (
@@ -73,6 +95,7 @@ function WalletActionBuyMain({
       handleFiatCrypto({});
     }
   }, [
+    isAddMoneyBlockedByBotWallet,
     isBuyDisabled,
     handleFiatCrypto,
     network,
@@ -91,6 +114,9 @@ function WalletActionBuyMain({
       }
       icon={customization?.icon}
       disabled={customization?.disabled ?? isBuyDisabled}
+      // Keep the deactivated-bot-wallet branch tappable so users get a
+      // toast instead of a silent dead-click.
+      allowPressWhenDisabled={isAddMoneyBlockedByBotWallet}
       trackID="wallet-buy"
       testID={HomeTestIDs.buyButton}
     />

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionCopy.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionCopy.tsx
@@ -3,13 +3,14 @@ import { useCallback } from 'react';
 import { useIntl } from 'react-intl';
 
 import type { IPageNavigationProp } from '@onekeyhq/components';
-import { ActionList, Toast } from '@onekeyhq/components';
+import { ActionList } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useBotWalletDeactivatedStatus } from '@onekeyhq/kit/src/hooks/useBotWalletDeactivatedStatus';
 import { useCopyAddressWithDeriveType } from '@onekeyhq/kit/src/hooks/useCopyAccountAddress';
 import { useUserWalletProfile } from '@onekeyhq/kit/src/hooks/useUserWalletProfile';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
+import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
 import { shouldBlockBotWalletCopyAddress } from '@onekeyhq/kit/src/utils/botWalletStatusUtils';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
@@ -49,10 +50,6 @@ export function WalletActionCopy({ onClose }: { onClose: () => void }) {
       walletId: wallet?.id,
     },
   );
-  const isCopyDisabled = shouldBlockBotWalletCopyAddress({
-    isBotWallet,
-    isBotWalletDeactivated,
-  });
 
   const handleCopyAddress = useCallback(async () => {
     if (
@@ -61,9 +58,7 @@ export function WalletActionCopy({ onClose }: { onClose: () => void }) {
         isBotWalletDeactivated,
       })
     ) {
-      Toast.error({
-        title: '该钱包已停用，无法复制地址',
-      });
+      showBotWalletDisabledToast('copyAddress');
       return;
     }
     if (
@@ -165,7 +160,6 @@ export function WalletActionCopy({ onClose }: { onClose: () => void }) {
       label={intl.formatMessage({ id: ETranslations.global_copy_address })}
       onClose={() => {}}
       onPress={handleCopyAddress}
-      disabled={isCopyDisabled}
     />
   );
 }

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionExport.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionExport.tsx
@@ -1,13 +1,12 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 
 import { ActionList, Dialog, useClipboard } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { useBotWalletDeactivatedStatus } from '@onekeyhq/kit/src/hooks/useBotWalletDeactivatedStatus';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import { shouldHideBotWalletExport } from '@onekeyhq/kit/src/utils/botWalletStatusUtils';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { ECoreApiExportedSecretKeyType } from '@onekeyhq/shared/src/types/coreEnums';
-import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 
 export function WalletActionExport({ onClose }: { onClose: () => void }) {
   const { activeAccount } = useActiveAccount({ num: 0 });
@@ -15,26 +14,11 @@ export function WalletActionExport({ onClose }: { onClose: () => void }) {
   const { copyText } = useClipboard();
 
   const { network, account, wallet } = activeAccount;
-  const isBotWallet = useMemo(
-    () => accountUtils.isBotWallet({ walletId: wallet?.id }),
-    [wallet?.id],
-  );
-  const { result: isBotWalletDeactivatedResult } = usePromiseResult(
-    async () => {
-      if (!wallet?.id || !isBotWallet) {
-        return false;
-      }
-
-      return backgroundApiProxy.serviceAccount.isBotWalletDeactivated({
-        walletId: wallet.id,
-      });
-    },
-    [wallet?.id, isBotWallet],
+  const { isBotWallet, isBotWalletDeactivated } = useBotWalletDeactivatedStatus(
     {
-      checkIsFocused: false,
+      walletId: wallet?.id,
     },
   );
-  const isBotWalletDeactivated = !!isBotWalletDeactivatedResult;
 
   const exportAccountCredentialKey = useCallback(
     async ({ keyType }: { keyType: ECoreApiExportedSecretKeyType }) => {

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionMore.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionMore.tsx
@@ -6,6 +6,7 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import { useReviewControl } from '@onekeyhq/kit/src/components/ReviewControl';
 import { getRewardCenterConfig } from '@onekeyhq/kit/src/components/RewardCenter';
+import { useBotWalletDeactivatedStatus } from '@onekeyhq/kit/src/hooks/useBotWalletDeactivatedStatus';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import {
   useAccountSelectorSceneInfo,
@@ -40,9 +41,6 @@ export function WalletActionMore() {
   const { activeAccount } = useActiveAccount({ num: 0 });
   const { sceneName, sceneUrl } = useAccountSelectorSceneInfo();
   const { account, network } = activeAccount;
-  const isBotWallet = accountUtils.isBotWallet({
-    walletId: activeAccount?.wallet?.id,
-  });
 
   const show = useReviewControl();
   const { config, getMoreActionGroups, getActionCustomization } =
@@ -63,22 +61,11 @@ export function WalletActionMore() {
   const displaySignAndVerify = usePromiseResult(async () => {
     return vaultSettings?.enabledInternalSignAndVerify;
   }, [vaultSettings]);
-  const { result: isBotWalletDeactivatedResult } = usePromiseResult(
-    async () => {
-      if (!activeAccount?.wallet?.id || !isBotWallet) {
-        return false;
-      }
-
-      return backgroundApiProxy.serviceAccount.isBotWalletDeactivated({
-        walletId: activeAccount.wallet.id,
-      });
-    },
-    [activeAccount?.wallet?.id, isBotWallet],
+  const { isBotWallet, isBotWalletDeactivated } = useBotWalletDeactivatedStatus(
     {
-      checkIsFocused: false,
+      walletId: activeAccount?.wallet?.id,
     },
   );
-  const isBotWalletDeactivated = !!isBotWalletDeactivatedResult;
 
   const isApprovalEnabled = useMemo(() => {
     const networksSupportApproval = getNetworksSupportBulkRevokeApproval();

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionReceive.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionReceive.tsx
@@ -3,9 +3,8 @@ import { useCallback, useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { Toast } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { useBotWalletDeactivatedStatus } from '@onekeyhq/kit/src/hooks/useBotWalletDeactivatedStatus';
 import { useReceiveToken } from '@onekeyhq/kit/src/hooks/useReceiveToken';
 import { useUserWalletProfile } from '@onekeyhq/kit/src/hooks/useUserWalletProfile';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
@@ -14,11 +13,11 @@ import {
   useAllTokenListMapAtom,
   useTokenListStateAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/tokenList';
+import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
 import { shouldBlockBotWalletReceive } from '@onekeyhq/kit/src/utils/botWalletStatusUtils';
 import { WALLET_TYPE_WATCHING } from '@onekeyhq/shared/src/consts/dbConsts';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import type { IWalletActionBaseParams } from '@onekeyhq/shared/src/logger/scopes/wallet/scenes/walletActions';
-import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 
 import { HomeTestIDs } from '../../testIDs';
 
@@ -58,26 +57,11 @@ function WalletActionReceive({
   const [allTokens] = useAllTokenListAtom();
   const [map] = useAllTokenListMapAtom();
   const [tokenListState] = useTokenListStateAtom();
-  const isBotWallet = useMemo(
-    () => accountUtils.isBotWallet({ walletId: wallet?.id }),
-    [wallet?.id],
-  );
-  const { result: isBotWalletDeactivatedResult } = usePromiseResult(
-    async () => {
-      if (!wallet?.id || !isBotWallet) {
-        return false;
-      }
-
-      return backgroundApiProxy.serviceAccount.isBotWalletDeactivated({
-        walletId: wallet.id,
-      });
-    },
-    [wallet?.id, isBotWallet],
+  const { isBotWallet, isBotWalletDeactivated } = useBotWalletDeactivatedStatus(
     {
-      checkIsFocused: false,
+      walletId: wallet?.id,
     },
   );
-  const isBotWalletDeactivated = !!isBotWalletDeactivatedResult;
 
   const isReceiveDisabled = useMemo(() => {
     if (wallet?.type === WALLET_TYPE_WATCHING) {
@@ -111,9 +95,7 @@ function WalletActionReceive({
         isBotWalletDeactivated,
       })
     ) {
-      Toast.error({
-        title: '该钱包已停用，无法接收资产',
-      });
+      showBotWalletDisabledToast('receive');
       return;
     }
 

--- a/packages/kit/src/views/ReferFriends/hooks/useWalletBoundReferralCode/useFetchWalletsWithBoundStatus.ts
+++ b/packages/kit/src/views/ReferFriends/hooks/useWalletBoundReferralCode/useFetchWalletsWithBoundStatus.ts
@@ -1,8 +1,12 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import type { IDBWallet } from '@onekeyhq/kit-bg/src/dbs/local/types';
+import {
+  EAppEventBusNames,
+  appEventBus,
+} from '@onekeyhq/shared/src/eventBus/appEventBus';
 import type { IBatchCheckWalletV2Item } from '@onekeyhq/shared/src/referralCode/type';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { normalizeTokenContractAddress } from '@onekeyhq/shared/src/utils/tokenUtils';
@@ -183,10 +187,23 @@ export function useFetchWalletsWithBoundStatus() {
     return walletsWithBoundStatus;
   }, [getReferralCodeWalletInfo]);
 
-  const { result: walletsWithStatus, isLoading } = usePromiseResult(
+  const {
+    result: walletsWithStatus,
+    isLoading,
+    run: refreshWalletsWithStatus,
+  } = usePromiseResult(fetchWalletsWithBoundStatus, [
     fetchWalletsWithBoundStatus,
-    [fetchWalletsWithBoundStatus],
-  );
+  ]);
+
+  // Bot wallet activate/deactivate emits WalletUpdate; refresh so the
+  // referral binding picker excludes/includes the wallet without requiring
+  // a navigation reload.
+  useEffect(() => {
+    appEventBus.on(EAppEventBusNames.WalletUpdate, refreshWalletsWithStatus);
+    return () => {
+      appEventBus.off(EAppEventBusNames.WalletUpdate, refreshWalletsWithStatus);
+    };
+  }, [refreshWalletsWithStatus]);
 
   return {
     walletsWithStatus,

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecentRecipients.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecentRecipients.tsx
@@ -380,6 +380,34 @@ function RecentRecipients(props: IRecentRecipientsProps) {
       { initResult: new Map(), undefinedResultIfError: true },
     );
 
+  // Pre-compute deactivated-bot-wallet status for every recent recipient so
+  // the per-tap check is a sync map lookup instead of an IPC round-trip.
+  // Recipients without a walletId are external addresses and can't belong
+  // to a bot wallet — they default to false.
+  const { result: deactivatedRecipientWalletIds = new Set<string>() } =
+    usePromiseResult<Set<string>>(
+      async () => {
+        if (recentWalletIds.length === 0) {
+          return new Set();
+        }
+        try {
+          const statusMap =
+            await backgroundApiProxy.serviceAccount.getBotWalletDeactivationStatusMap(
+              { walletIds: recentWalletIds },
+            );
+          return new Set(
+            Object.entries(statusMap)
+              .filter(([, isDeactivated]) => isDeactivated)
+              .map(([walletId]) => walletId),
+          );
+        } catch {
+          return new Set();
+        }
+      },
+      [recentWalletIds],
+      { initResult: new Set(), undefinedResultIfError: true },
+    );
+
   // Notify parent of match status and count.
   // Skip during debounce — parent resets tabMatchStatus to null on
   // searchKey change, so allReported stays false until we re-report.
@@ -425,7 +453,15 @@ function RecentRecipients(props: IRecentRecipientsProps) {
               // which has since been deactivated. Block selection so we
               // don't paste a dead address into the recipient input — show
               // a toast so the user understands why the row is rejected.
-              if (
+              // Fast path: recipients with a known walletId resolve via the
+              // precomputed set (no IPC). Recipients without a walletId
+              // (e.g. BTC fresh addresses) still need the async lookup.
+              if (recipient.walletId) {
+                if (deactivatedRecipientWalletIds.has(recipient.walletId)) {
+                  showBotWalletDisabledToast('beReceiver');
+                  return;
+                }
+              } else if (
                 await isAddressOwnedByDeactivatedBotWallet({
                   networkId,
                   address: canonicalAddress,
@@ -475,6 +511,7 @@ function RecentRecipients(props: IRecentRecipientsProps) {
     networkId,
     onSelect,
     recentWalletMap,
+    deactivatedRecipientWalletIds,
   ]);
 
   return (

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecentRecipients.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecentRecipients.tsx
@@ -18,6 +18,8 @@ import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useDebounce } from '@onekeyhq/kit/src/hooks/useDebounce';
 import useFormatDate from '@onekeyhq/kit/src/hooks/useFormatDate';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { isAddressOwnedByDeactivatedBotWallet } from '@onekeyhq/kit/src/utils/botWalletAccountUtils';
+import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
 import type { IDBWallet } from '@onekeyhq/kit-bg/src/dbs/local/types';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -418,7 +420,20 @@ function RecentRecipients(props: IRecentRecipientsProps) {
             intl={intl}
             networkId={networkId}
             formatRelativeTime={formatCompactTime}
-            onPress={() => {
+            onPress={async () => {
+              // Recents may include addresses that belong to a bot wallet
+              // which has since been deactivated. Block selection so we
+              // don't paste a dead address into the recipient input — show
+              // a toast so the user understands why the row is rejected.
+              if (
+                await isAddressOwnedByDeactivatedBotWallet({
+                  networkId,
+                  address: canonicalAddress,
+                })
+              ) {
+                showBotWalletDisabledToast('beReceiver');
+                return;
+              }
               onSelect?.({
                 address: canonicalAddress,
                 memo: recipient.recipientMemo,

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -36,10 +36,6 @@ import { useDebounce } from '@onekeyhq/kit/src/hooks/useDebounce';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import type { IAddressNetworkItem } from '@onekeyhq/kit/src/views/AddressBook/type';
 import { SendTestIDs } from '@onekeyhq/kit/src/views/Send/testIDs';
-import {
-  EAppEventBusNames,
-  appEventBus,
-} from '@onekeyhq/shared/src/eventBus/appEventBus';
 import type {
   IDBIndexedAccount,
   IDBUtxoAccount,
@@ -48,6 +44,10 @@ import type {
 import { useAddressBookPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/addressBooks';
 import type { IAccountDeriveInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 import { IMPL_EVM } from '@onekeyhq/shared/src/engine/engineConsts';
+import {
+  EAppEventBusNames,
+  appEventBus,
+} from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -330,30 +330,24 @@ function AccountRecipients({
 
       // Drop deactivated bot wallets from the recipient picker — sending
       // to them is blocked elsewhere, so don't even surface them as a
-      // selectable target.
-      const botGroups = groups.filter((g) =>
-        accountUtils.isBotWallet({ walletId: g.walletId }),
-      );
-      const deactivatedBotWalletIds = new Set<string>();
-      if (botGroups.length > 0) {
-        const flags = await Promise.all(
-          botGroups.map(async (g) => {
-            try {
-              return await backgroundApiProxy.serviceAccount.isBotWalletDeactivated(
-                { walletId: g.walletId },
-              );
-            } catch {
-              return false;
-            }
-          }),
-        );
-        botGroups.forEach((g, idx) => {
-          if (flags[idx]) deactivatedBotWalletIds.add(g.walletId);
-        });
+      // selectable target. Use the batch IPC to keep this O(1) round-trip
+      // instead of one call per bot wallet.
+      const botWalletIds = groups
+        .map((g) => g.walletId)
+        .filter((id) => accountUtils.isBotWallet({ walletId: id }));
+      let filteredGroups = groups;
+      if (botWalletIds.length > 0) {
+        let statusMap: Record<string, boolean> = {};
+        try {
+          statusMap =
+            await backgroundApiProxy.serviceAccount.getBotWalletDeactivationStatusMap(
+              { walletIds: botWalletIds },
+            );
+        } catch {
+          statusMap = {};
+        }
+        filteredGroups = groups.filter((g) => !statusMap[g.walletId]);
       }
-      const filteredGroups = groups.filter(
-        (g) => !deactivatedBotWalletIds.has(g.walletId),
-      );
 
       // senderDeriveType filtering stays on UI side (cheap, no IPC)
       if (!mergeDeriveAssetsEnabled) {

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -318,64 +318,64 @@ function AccountRecipients({
     isLoading: isLoadingAccounts,
     run: refreshWalletGroups,
   } = usePromiseResult<IWalletGroup[]>(
-      async () => {
-        if (!networkId) {
-          return [];
-        }
+    async () => {
+      if (!networkId) {
+        return [];
+      }
 
-        const { groups, mergeDeriveAssetsEnabled } =
-          await backgroundApiProxy.serviceAccount.getWalletAccountGroupsForNetwork(
-            { networkId, keylessWalletsOnly },
-          );
-
-        // Drop deactivated bot wallets from the recipient picker — sending
-        // to them is blocked elsewhere, so don't even surface them as a
-        // selectable target.
-        const botGroups = groups.filter((g) =>
-          accountUtils.isBotWallet({ walletId: g.walletId }),
-        );
-        const deactivatedBotWalletIds = new Set<string>();
-        if (botGroups.length > 0) {
-          const flags = await Promise.all(
-            botGroups.map(async (g) => {
-              try {
-                return await backgroundApiProxy.serviceAccount.isBotWalletDeactivated(
-                  { walletId: g.walletId },
-                );
-              } catch {
-                return false;
-              }
-            }),
-          );
-          botGroups.forEach((g, idx) => {
-            if (flags[idx]) deactivatedBotWalletIds.add(g.walletId);
-          });
-        }
-        const filteredGroups = groups.filter(
-          (g) => !deactivatedBotWalletIds.has(g.walletId),
+      const { groups, mergeDeriveAssetsEnabled } =
+        await backgroundApiProxy.serviceAccount.getWalletAccountGroupsForNetwork(
+          { networkId, keylessWalletsOnly },
         );
 
-        // senderDeriveType filtering stays on UI side (cheap, no IPC)
-        if (!mergeDeriveAssetsEnabled) {
-          return filteredGroups
-            .map((group) => {
-              const targetDeriveType =
-                senderDeriveType ?? group.accounts[0]?.deriveType;
-              if (!targetDeriveType) return group;
-              const filtered = group.accounts.filter(
-                (a) => !a.deriveType || a.deriveType === targetDeriveType,
+      // Drop deactivated bot wallets from the recipient picker — sending
+      // to them is blocked elsewhere, so don't even surface them as a
+      // selectable target.
+      const botGroups = groups.filter((g) =>
+        accountUtils.isBotWallet({ walletId: g.walletId }),
+      );
+      const deactivatedBotWalletIds = new Set<string>();
+      if (botGroups.length > 0) {
+        const flags = await Promise.all(
+          botGroups.map(async (g) => {
+            try {
+              return await backgroundApiProxy.serviceAccount.isBotWalletDeactivated(
+                { walletId: g.walletId },
               );
-              return filtered.length > 0
-                ? { ...group, accounts: filtered }
-                : group;
-            })
-            .filter((g) => g.accounts.length > 0);
-        }
-        return filteredGroups;
-      },
-      [networkId, senderDeriveType, keylessWalletsOnly],
-      { initResult: [], watchLoading: true, undefinedResultIfError: true },
-    );
+            } catch {
+              return false;
+            }
+          }),
+        );
+        botGroups.forEach((g, idx) => {
+          if (flags[idx]) deactivatedBotWalletIds.add(g.walletId);
+        });
+      }
+      const filteredGroups = groups.filter(
+        (g) => !deactivatedBotWalletIds.has(g.walletId),
+      );
+
+      // senderDeriveType filtering stays on UI side (cheap, no IPC)
+      if (!mergeDeriveAssetsEnabled) {
+        return filteredGroups
+          .map((group) => {
+            const targetDeriveType =
+              senderDeriveType ?? group.accounts[0]?.deriveType;
+            if (!targetDeriveType) return group;
+            const filtered = group.accounts.filter(
+              (a) => !a.deriveType || a.deriveType === targetDeriveType,
+            );
+            return filtered.length > 0
+              ? { ...group, accounts: filtered }
+              : group;
+          })
+          .filter((g) => g.accounts.length > 0);
+      }
+      return filteredGroups;
+    },
+    [networkId, senderDeriveType, keylessWalletsOnly],
+    { initResult: [], watchLoading: true, undefinedResultIfError: true },
+  );
   const walletGroups = useDeferredValue(walletGroupsRaw);
 
   // Bot wallet activate/deactivate emits WalletUpdate via

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -36,6 +36,10 @@ import { useDebounce } from '@onekeyhq/kit/src/hooks/useDebounce';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import type { IAddressNetworkItem } from '@onekeyhq/kit/src/views/AddressBook/type';
 import { SendTestIDs } from '@onekeyhq/kit/src/views/Send/testIDs';
+import {
+  EAppEventBusNames,
+  appEventBus,
+} from '@onekeyhq/shared/src/eventBus/appEventBus';
 import type {
   IDBIndexedAccount,
   IDBUtxoAccount,
@@ -309,8 +313,11 @@ function AccountRecipients({
 
   // Single IPC call — all wallet/account aggregation happens in background.
   // useDeferredValue lets React yield to events (close button) mid-render.
-  const { result: walletGroupsRaw = [], isLoading: isLoadingAccounts } =
-    usePromiseResult<IWalletGroup[]>(
+  const {
+    result: walletGroupsRaw = [],
+    isLoading: isLoadingAccounts,
+    run: refreshWalletGroups,
+  } = usePromiseResult<IWalletGroup[]>(
       async () => {
         if (!networkId) {
           return [];
@@ -321,9 +328,36 @@ function AccountRecipients({
             { networkId, keylessWalletsOnly },
           );
 
+        // Drop deactivated bot wallets from the recipient picker — sending
+        // to them is blocked elsewhere, so don't even surface them as a
+        // selectable target.
+        const botGroups = groups.filter((g) =>
+          accountUtils.isBotWallet({ walletId: g.walletId }),
+        );
+        const deactivatedBotWalletIds = new Set<string>();
+        if (botGroups.length > 0) {
+          const flags = await Promise.all(
+            botGroups.map(async (g) => {
+              try {
+                return await backgroundApiProxy.serviceAccount.isBotWalletDeactivated(
+                  { walletId: g.walletId },
+                );
+              } catch {
+                return false;
+              }
+            }),
+          );
+          botGroups.forEach((g, idx) => {
+            if (flags[idx]) deactivatedBotWalletIds.add(g.walletId);
+          });
+        }
+        const filteredGroups = groups.filter(
+          (g) => !deactivatedBotWalletIds.has(g.walletId),
+        );
+
         // senderDeriveType filtering stays on UI side (cheap, no IPC)
         if (!mergeDeriveAssetsEnabled) {
-          return groups
+          return filteredGroups
             .map((group) => {
               const targetDeriveType =
                 senderDeriveType ?? group.accounts[0]?.deriveType;
@@ -337,12 +371,22 @@ function AccountRecipients({
             })
             .filter((g) => g.accounts.length > 0);
         }
-        return groups;
+        return filteredGroups;
       },
       [networkId, senderDeriveType, keylessWalletsOnly],
       { initResult: [], watchLoading: true, undefinedResultIfError: true },
     );
   const walletGroups = useDeferredValue(walletGroupsRaw);
+
+  // Bot wallet activate/deactivate emits WalletUpdate via
+  // ServiceAccount.scheduleWalletUpdateForBotMetadata. Re-fetch the
+  // recipient list so the picker stays in sync without page refresh.
+  useEffect(() => {
+    appEventBus.on(EAppEventBusNames.WalletUpdate, refreshWalletGroups);
+    return () => {
+      appEventBus.off(EAppEventBusNames.WalletUpdate, refreshWalletGroups);
+    };
+  }, [refreshWalletGroups]);
 
   // BTC fresh address lookup — logic lives in ServiceFreshAddress.
   const { result: btcFreshAddressMap = {} } = usePromiseResult<

--- a/packages/kit/src/views/WalletAddress/pages/WalletAddress/index.tsx
+++ b/packages/kit/src/views/WalletAddress/pages/WalletAddress/index.tsx
@@ -35,8 +35,10 @@ import AddressTypeSelector from '@onekeyhq/kit/src/components/AddressTypeSelecto
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { NetworkAvatarBase } from '@onekeyhq/kit/src/components/NetworkAvatar';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { useBotWalletDeactivatedStatus } from '@onekeyhq/kit/src/hooks/useBotWalletDeactivatedStatus';
 import { useCopyAccountAddress } from '@onekeyhq/kit/src/hooks/useCopyAccountAddress';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
 import { openExplorerAddressUrl } from '@onekeyhq/kit/src/utils/explorerUtils';
 import { useFuseSearch } from '@onekeyhq/kit/src/views/ChainSelector/hooks/useFuseSearch';
 import type { IAllNetworksDBStruct } from '@onekeyhq/kit-bg/src/dbs/simple/entity/SimpleDbEntityAllNetworks';
@@ -137,6 +139,19 @@ function SingleWalletAddressListItem({ network }: { network: IServerNetwork }) {
     walletId: walletId ?? '',
   });
 
+  const { isBotWallet, isBotWalletDeactivated } = useBotWalletDeactivatedStatus(
+    {
+      walletId,
+    },
+  );
+  // Block both copy and "create / + " actions for deactivated bot wallets:
+  // they shouldn't be able to add new addresses or expose existing ones.
+  // Reading-only actions (e.g. ViewInExplorer) stay enabled.
+  const isBotWalletAddressBlocked =
+    isBotWallet &&
+    isBotWalletDeactivated &&
+    actionType !== EWalletAddressActionType.ViewInExplorer;
+
   const subtitle = useMemo(() => {
     if (account) {
       if (networkUtils.isLightningNetworkByNetworkId(network.id)) {
@@ -179,6 +194,14 @@ function SingleWalletAddressListItem({ network }: { network: IServerNetwork }) {
         networkId: network.id,
         address: othersWalletAddress,
       });
+      return;
+    }
+
+    if (isBotWalletAddressBlocked) {
+      // Both copy and add-address paths route through this onPress; surface
+      // a single toast here rather than gating the row visually so users
+      // get explicit feedback instead of a silent dead-click.
+      showBotWalletDisabledToast(account ? 'copyAddress' : 'receive');
       return;
     }
 
@@ -265,6 +288,7 @@ function SingleWalletAddressListItem({ network }: { network: IServerNetwork }) {
     copyAccountAddress,
     isOthersWallet,
     othersWalletAddress,
+    isBotWalletAddressBlocked,
   ]);
 
   const avatar = useMemo(
@@ -335,6 +359,7 @@ function SingleWalletAddressListItem({ network }: { network: IServerNetwork }) {
         renderAvatar={avatar}
         onPress={onPress}
         disabled={loading}
+        opacity={isBotWalletAddressBlocked ? 0.5 : 1}
       >
         {loading ? (
           <Stack p="$0.5">
@@ -357,6 +382,7 @@ function SingleWalletAddressListItem({ network }: { network: IServerNetwork }) {
       refreshLocalData,
       subtitle,
       walletId,
+      isBotWalletAddressBlocked,
     ],
   );
 }


### PR DESCRIPTION
Follow-up to OK-53641. Extends bot-wallet deactivated guardrails to the entries that were still missing or had silent dead-clicks.

## Summary

- **Reactive status hook**: `useBotWalletDeactivatedStatus` now subscribes to `EAppEventBusNames.WalletUpdate` so every consumer refreshes on activate/deactivate without a page reload. `ServiceAccount.scheduleWalletUpdateForBotMetadata` already emits this event after `deactivate`/`reactivateBotWallet`.
- **No silent dead-clicks**: Centralised the disabled-bot-wallet toast copy in `packages/kit/src/utils/botWalletDisabledToast.ts`. Replaced `disabled={…}` props that suppressed `onPress` with the toast-on-press pattern so users always get feedback (`ActionList.Item` and Tamagui `XStack` both suppress `onPress` when `disabled=true`).
- **Account selector menu**:
  - `AccountExportPrivateKeyButton.tsx` — export private/public key changed from hide to disable+toast.
  - `AccountCopyButton.tsx` — toast on tap when blocked (no longer dead-clicks).
  - `WalletBoundReferralCodeButton.tsx` — referral code entry disabled with toast for deactivated bot wallets.
  - `BulkCopyAddressesButton.tsx` — top-right bulk-copy entry disabled with toast.
- **Home wallet card**:
  - `AccountSelectorActiveAccount.tsx` — copy-address chip stays tappable to toast.
  - `WalletActionCopy/Receive/Buy/BuyMain.tsx` — Add money button now blocked for deactivated bot wallets; receive/copy use the centralised toast helper.
  - `WalletActionMore.tsx`, `WalletActionExport.tsx` — switched to the reactive `useBotWalletDeactivatedStatus` hook.
- **Token details**:
  - `TokenDetailsHeader.tsx` — My Address row shows a shortened (masked) address for deactivated bot wallets so the full string isn't exposed.
- **Account Address Modal** (`WalletAddress/pages/WalletAddress/index.tsx`) — copy and create-address rows surface a toast and fade out for deactivated bot wallets; ViewInExplorer stays enabled.
- **Send / Trade recipient picker** (`RecipientQuickSelect.tsx`, shared by Swap):
  - Accounts tab filters out deactivated bot wallets (background batch check).
  - Refreshes on `WalletUpdate`.
  - `RecentRecipients.tsx` — clicking a recent address owned by a deactivated bot wallet toasts and refuses to paste into the recipient input.
- **Bulk send recipient input** — single-line and multi-line validation now show the deactivated-bot toast in addition to the existing inline error; multi-line aggregates a single toast for pasted batches. Sender selection is left untouched.
- **Referral binding list** (`useFetchWalletsWithBoundStatus.ts`) — refreshes on `WalletUpdate` so deactivated bot wallets disappear from the picker without navigation.

## Test plan

- [ ] Toggle a Bot wallet from active → deactivated and back; verify every entry updates without a page refresh: account-selector copy / export private+public key / referral code / bulk copy, home Copy / Receive / Add money, More menu Copy / Buy / Export, token details Receive / My Address, Account Address modal copy/create rows.
- [ ] Tap each disabled entry and confirm a Chinese toast appears (no silent dead-clicks).
- [ ] Token details: confirm `My Address` row shows a shortened address (e.g. `0x1234…abcd`) while the wallet is deactivated.
- [ ] Send flow: open the recipient picker — deactivated bot wallets do not appear under Accounts; tapping a recent transfer to one of them toasts and does not paste.
- [ ] Trade (Swap → custom receive address): same Accounts filter applies via the shared `RecipientQuickSelect`.
- [ ] Bulk send: paste a deactivated bot wallet address into the recipient field — toast appears and inline error blocks submission. Sender field can still select an active bot wallet.
- [ ] Token details / home Receive: tapping the disabled Receive button toasts.
- [ ] Referral bind dialog: deactivated bot wallets do not appear; toggling activation updates the list while the dialog is open.

https://claude.ai/code/session_01YZVJnqcmVcMHRGjipsM32P

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZVJnqcmVcMHRGjipsM32P)_