### PR TITLE
fix: resolve token filter and receive selector issues (OK-54791, OK-54803)

### DIFF
--- a/packages/kit/src/hooks/useAllNetwork.ts
+++ b/packages/kit/src/hooks/useAllNetwork.ts
@@ -321,6 +321,7 @@ function useAllNetworkRequests<T>(params: {
     pollingNonce?: number;
     alwaysSetState?: boolean;
     skipAccountsCache?: boolean;
+    ignoreDisabled?: boolean;
   };
   const {
     accountId: currentAccountId,
@@ -361,6 +362,7 @@ function useAllNetworkRequests<T>(params: {
   // into the method body, so we relay it through this ref and consume it
   // inside the runner.
   const skipAccountsCacheRef = useRef(false);
+  const ignoreDisabledRef = useRef(false);
 
   useEffect(() => {
     const onEnabledNetworksChanged = () => {
@@ -438,8 +440,11 @@ function useAllNetworkRequests<T>(params: {
 
   const { run, result } = usePromiseResult(
     async () => {
+      const ignoreDisabledForThisRun = ignoreDisabledRef.current;
+      ignoreDisabledRef.current = false;
+      const effectiveDisabled = disabled && !ignoreDisabledForThisRun;
       const shouldDebounceWait =
-        !disabled &&
+        !effectiveDisabled &&
         !isFetching.current &&
         !!currentAccountId &&
         !!currentNetworkId &&
@@ -462,7 +467,7 @@ function useAllNetworkRequests<T>(params: {
 
       const requestsUUID = generateUUID();
 
-      if (disabled) return;
+      if (effectiveDisabled) return;
       if (isFetching.current) {
         rerunAfterCurrentRef.current = true;
         return;
@@ -854,11 +859,17 @@ function useAllNetworkRequests<T>(params: {
           skipAccountsCache:
             !!rerunConfigRef.current?.skipAccountsCache ||
             !!config?.skipAccountsCache,
+          ignoreDisabled:
+            !!rerunConfigRef.current?.ignoreDisabled ||
+            !!config?.ignoreDisabled,
         };
         return;
       }
       if (config?.skipAccountsCache) {
         skipAccountsCacheRef.current = true;
+      }
+      if (config?.ignoreDisabled) {
+        ignoreDisabledRef.current = true;
       }
       await run(config);
     },

--- a/packages/kit/src/hooks/useReceiveToken.ts
+++ b/packages/kit/src/hooks/useReceiveToken.ts
@@ -172,6 +172,7 @@ function useReceiveToken({
           tokens,
           tokenListState,
           searchAll: true,
+          showDeFiTokenSwitch: true,
           closeAfterSelect: false,
           footerTipText: intl.formatMessage({
             id: ETranslations.receive_token_list_footer_text,

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -249,6 +249,7 @@ function TokenListBlock({
   const refreshWalletTokenListRef = useRef<
     ((options?: { forceWalletTokenMode?: boolean }) => void) | undefined
   >(undefined);
+  const forceWalletTokenModeRef = useRef(false);
   const syncTokenFilterToOverview = true;
 
   const accountTokensValue = useMemo(() => {
@@ -417,8 +418,10 @@ function TokenListBlock({
         });
         tokenListRefreshEventStarted = false;
       };
-      const requestTokenSelectorFilterMode =
-        latestTokenSelectorFilterModeRef.current;
+      const forceWalletTokenMode = forceWalletTokenModeRef.current;
+      const requestTokenSelectorFilterMode = forceWalletTokenMode
+        ? 'wallet-token'
+        : latestTokenSelectorFilterModeRef.current;
       try {
         if (requestTokenSelectorFilterMode !== 'wallet-token') {
           return;
@@ -527,8 +530,9 @@ function TokenListBlock({
           });
 
           if (
+            !forceWalletTokenMode &&
             latestTokenSelectorFilterModeRef.current !==
-            requestTokenSelectorFilterMode
+              requestTokenSelectorFilterMode
           ) {
             return;
           }
@@ -564,8 +568,9 @@ function TokenListBlock({
             .plus(r.smallBalanceTokens.fiatValue ?? '0');
 
           if (
+            !forceWalletTokenMode &&
             latestTokenSelectorFilterModeRef.current !==
-            requestTokenSelectorFilterMode
+              requestTokenSelectorFilterMode
           ) {
             return;
           }
@@ -635,17 +640,17 @@ function TokenListBlock({
               tokens: mergedTokens,
             });
           }
-
-          perfTokenListView.markEnd(
-            'tokenListRefreshing_tokenListContainerRefreshList',
-          );
-          updateTokenListState({
-            initialized: true,
-            isRefreshing: false,
-          });
-
-          endTokenListRefreshEvent();
         }
+
+        perfTokenListView.markEnd(
+          'tokenListRefreshing_tokenListContainerRefreshList',
+        );
+        updateTokenListState({
+          initialized: true,
+          isRefreshing: false,
+        });
+
+        endTokenListRefreshEvent();
       } catch (e) {
         endTokenListRefreshEvent();
         if (e instanceof CanceledError) {
@@ -654,6 +659,9 @@ function TokenListBlock({
           throw e;
         }
       } finally {
+        if (forceWalletTokenMode) {
+          forceWalletTokenModeRef.current = false;
+        }
         endTokenListRefreshEvent();
         setIsHeaderRefreshing(false);
       }
@@ -791,6 +799,7 @@ function TokenListBlock({
     setScopedLpTokenListMap({});
     // Persisted DeFi-token mode can mount before tab focus settles; make the
     // initial clear and initial fetch atomic so loading always resolves.
+    refreshWalletTokenListRef.current?.({ forceWalletTokenMode: true });
     void runLpTokenList({ alwaysSetState: true });
   }, [
     account?.id,
@@ -851,7 +860,12 @@ function TokenListBlock({
       allNetworkDataInit?: boolean;
       isSingleRequest?: boolean;
     }) => {
-      if (latestTokenSelectorFilterModeRef.current !== 'wallet-token') {
+      const forceWalletTokenMode = forceWalletTokenModeRef.current;
+      const requestTokenSelectorFilterMode = forceWalletTokenMode
+        ? 'wallet-token'
+        : latestTokenSelectorFilterModeRef.current;
+
+      if (requestTokenSelectorFilterMode !== 'wallet-token') {
         isAllNetworkManualRefresh.current = false;
         return undefined;
       }
@@ -878,12 +892,14 @@ function TokenListBlock({
       );
       const r: IAllNetworkTokenListResp = {
         ...response,
-        tokenSelectorFilterMode,
+        tokenSelectorFilterMode: requestTokenSelectorFilterMode,
         syncTokenFilterToOverview,
       };
 
       if (
-        latestTokenSelectorFilterModeRef.current !== tokenSelectorFilterMode
+        !forceWalletTokenMode &&
+        latestTokenSelectorFilterModeRef.current !==
+          requestTokenSelectorFilterMode
       ) {
         isAllNetworkManualRefresh.current = false;
         return r;
@@ -911,7 +927,9 @@ function TokenListBlock({
       ]);
 
       if (
-        latestTokenSelectorFilterModeRef.current !== tokenSelectorFilterMode
+        !forceWalletTokenMode &&
+        latestTokenSelectorFilterModeRef.current !==
+          requestTokenSelectorFilterMode
       ) {
         isAllNetworkManualRefresh.current = false;
         return r;
@@ -1146,7 +1164,6 @@ function TokenListBlock({
       updateAccountWorth,
       updateAllNetworkData,
       updateTokenListState,
-      tokenSelectorFilterMode,
       syncTokenFilterToOverview,
       walletTokenFilterParams,
     ],
@@ -1215,6 +1232,7 @@ function TokenListBlock({
       accountId?: string;
       networkId?: string;
     }) => {
+      forceWalletTokenModeRef.current = false;
       appEventBus.emit(EAppEventBusNames.TabListStateUpdate, {
         isRefreshing: false,
         type: EHomeTab.TOKENS,
@@ -1235,7 +1253,10 @@ function TokenListBlock({
       networkId?: string;
       hasCache: boolean;
     }) => {
-      if (latestTokenSelectorFilterModeRef.current !== 'wallet-token') {
+      if (
+        !forceWalletTokenModeRef.current &&
+        latestTokenSelectorFilterModeRef.current !== 'wallet-token'
+      ) {
         return;
       }
       if (!syncTokenFilterToOverview) {
@@ -1282,7 +1303,10 @@ function TokenListBlock({
       localTokensRawData.current = l ?? undefined;
       aggregateTokenRawData.current = a ?? undefined;
 
-      if (latestTokenSelectorFilterModeRef.current !== 'wallet-token') {
+      if (
+        !forceWalletTokenModeRef.current &&
+        latestTokenSelectorFilterModeRef.current !== 'wallet-token'
+      ) {
         return;
       }
 
@@ -1320,7 +1344,10 @@ function TokenListBlock({
       xpub?: string;
       accountAddress: string;
     }) => {
-      if (latestTokenSelectorFilterModeRef.current !== 'wallet-token') {
+      if (
+        !forceWalletTokenModeRef.current &&
+        latestTokenSelectorFilterModeRef.current !== 'wallet-token'
+      ) {
         return null;
       }
 
@@ -1389,6 +1416,7 @@ function TokenListBlock({
       networkId: string;
     }) => {
       if (
+        !forceWalletTokenModeRef.current &&
         latestTokenSelectorFilterModeRef.current !== tokenSelectorFilterMode
       ) {
         return;
@@ -1649,10 +1677,6 @@ function TokenListBlock({
   });
 
   const updateAllNetworksTokenList = useCallback(async () => {
-    if (tokenSelectorFilterMode !== 'wallet-token') {
-      return;
-    }
-
     const tokenList: {
       tokens: IAccountToken[];
       keys: string;
@@ -1708,7 +1732,7 @@ function TokenListBlock({
           result.tokenSelectorFilterMode !== resultTokenSelectorFilterMode,
       );
       if (
-        resultTokenSelectorFilterMode !== tokenSelectorFilterMode ||
+        resultTokenSelectorFilterMode !== 'wallet-token' ||
         hasMixedTokenSelectorFilterResult
       ) {
         return;
@@ -1815,13 +1839,6 @@ function TokenListBlock({
             .plus(r.tokens.fiatValue ?? '0')
             .plus(r.smallBalanceTokens.fiatValue ?? '0');
         }
-      }
-
-      if (
-        latestTokenSelectorFilterModeRef.current !==
-        resultTokenSelectorFilterMode
-      ) {
-        return;
       }
 
       if (shouldSyncTokenFilterToOverview) {
@@ -1964,7 +1981,6 @@ function TokenListBlock({
     mergeDeriveAddressData,
     allNetworksResult,
     network?.id,
-    tokenSelectorFilterMode,
     refreshAllTokenList,
     refreshAllTokenListMap,
     refreshAggregateTokensListMap,
@@ -2440,6 +2456,7 @@ function TokenListBlock({
   useEffect(() => {
     if (isHeaderRefreshing) {
       if (showLpTokensOnly) {
+        refreshWalletTokenListRef.current?.({ forceWalletTokenMode: true });
         void runLpTokenList({ alwaysSetState: true });
         return;
       }
@@ -2482,6 +2499,7 @@ function TokenListBlock({
 
   const handleRefreshAllNetworkData = useCallback(() => {
     if (showLpTokensOnly) {
+      refreshWalletTokenListRef.current?.({ forceWalletTokenMode: true });
       void runLpTokenList({ alwaysSetState: true });
       return;
     }
@@ -2494,12 +2512,16 @@ function TokenListBlock({
   }, [runAllNetworksRequests, runLpTokenList, showLpTokensOnly]);
 
   refreshWalletTokenListRef.current = (options) => {
+    if (options?.forceWalletTokenMode) {
+      forceWalletTokenModeRef.current = true;
+    }
     if (network?.isAllNetworks) {
       if (options?.forceWalletTokenMode) {
         isAllNetworkManualRefresh.current = true;
         void runAllNetworksRequests({
           alwaysSetState: true,
           skipAccountsCache: true,
+          ignoreDisabled: true,
         });
         return;
       }
@@ -2518,6 +2540,7 @@ function TokenListBlock({
     lastVisibilityRefreshAtRef.current = now;
 
     if (showLpTokensOnly) {
+      refreshWalletTokenListRef.current?.({ forceWalletTokenMode: true });
       void runLpTokenList({ alwaysSetState: true });
       return;
     }

--- a/packages/kit/src/views/Receive/pages/ReceiveSelector.tsx
+++ b/packages/kit/src/views/Receive/pages/ReceiveSelector.tsx
@@ -198,6 +198,7 @@ function ReceiveSelectorContent() {
         accountId,
         indexedAccountId,
         closeAfterSelect: false,
+        showDeFiTokenSwitch: true,
         aggregateTokenSelectorScreen:
           EModalReceiveRoutes.ReceiveSelectAggregateToken,
         exchangeFilter: {
@@ -289,6 +290,7 @@ function ReceiveSelectorContent() {
           accountId,
           indexedAccountId,
           closeAfterSelect: false,
+          showDeFiTokenSwitch: true,
           aggregateTokenSelectorScreen:
             EModalReceiveRoutes.ReceiveSelectAggregateToken,
           onSelect: async (selectedToken: IToken) => {

--- a/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
@@ -570,9 +570,7 @@ const SwapTokenSelectPage = ({
     return popularTokens;
   }, [currentSelectNetwork?.networkId, swapTypeSwitch]);
   const shouldShowPopularTokens =
-    !showLpTokensOnly &&
-    currentNetworkPopularTokens.length > 0 &&
-    !requestedSearchKeyword;
+    currentNetworkPopularTokens.length > 0 && !requestedSearchKeyword;
   return (
     <Page lazyLoad={!platformEnv.isNativeIOS} safeAreaEnabled={false}>
       <Page.Header


### PR DESCRIPTION
## Summary
- Keep Swap token selector popular tokens visible when LP/DeFi-token mode is enabled and no search keyword is present.
- Bootstrap wallet-token worth and token-list state when the Wallet home DeFi-token switch is persisted on at startup.
- Allow forced All Networks wallet-token refreshes to bypass the DeFi display-mode disabled guard.
- Add the DeFi tokens switch to Receive token selectors for OK-54803.

## Issues
- Fixes OK-54791
- Fixes OK-54803

## Intent & Context
The user reported two related token-filter regressions: OK-54791 in the Swap token selector, and a Wallet home startup issue where refreshing with the DeFi tokens switch already enabled left the top amount hidden and the token list stuck loading. PR #11629 had addressed part of the DeFi scoped-list startup path, but the runtime symptom still reproduced on iOS when the persisted switch state was on.

The follow-up OK-54803 asks the Wallet Receive token list to expose the same DeFi tokens switch so users can choose DeFi-marked tokens from Receive flows instead of only seeing the wallet-token list.

## Root Cause
The Wallet home DeFi-token switch controls which token list is displayed, but the top wallet amount and TokenListView loading state still depend on the normal wallet-token initialization path. When `homeShowLpTokensOnly` was persisted as true, the wallet-token path returned early because the current token-selector mode was `lp-dapp-token`, so `accountWorth`, `accountOverviewState`, and `tokenListState` could remain uninitialized until the user toggled the switch off and on again.

For All Networks, the explicit refresh path also stayed blocked by `disabled: showLpTokensOnly`, so a force refresh did not actually execute while DeFi display mode was active.

Receive token selectors already shared the generic TokenSelector implementation, but the Receive routes did not pass `showDeFiTokenSwitch`, so the existing DeFi-token filter UI and scoped fetch path stayed hidden in Receive flows.

## Design Decisions
- Treat DeFi-token mode as a display filter, not as permission to skip wallet-token overview bootstrap.
- Keep the scoped DeFi list as the rendered list while running wallet-token refresh in the background for overview/global readiness.
- Add a one-shot `ignoreDisabled` escape hatch to `useAllNetworkRequests` instead of permanently disabling the DeFi-mode guard.
- Mark single-network wallet-token refresh complete even when `allTokens` is absent so TokenListView can leave skeleton state after the fetch resolves.
- Reuse TokenSelector's existing `showDeFiTokenSwitch` route parameter for Receive instead of adding a separate Receive-only filter state.

## Changes Detail
- `TokenListBlock.tsx`: force wallet-token bootstrap during persisted DeFi mode startup, header refresh, visibility refresh, and manual refresh while keeping the scoped DeFi list active.
- `useAllNetwork.ts`: support a one-shot `ignoreDisabled` runner option for forced All Networks refresh.
- `SwapTokenSelectModal.tsx`: allow popular tokens to render in LP/DeFi-token mode when there is no search keyword.
- `useReceiveToken.ts`: enable the existing DeFi tokens switch for Wallet Receive token selection.
- `ReceiveSelector.tsx`: enable the same switch for ReceiveSelector exchange token selection paths.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile, Desktop, Web wallet/token-selector surfaces
- **Risk Areas**: Wallet home refresh timing, All Networks token-list state, scoped DeFi list vs global wallet-token state separation, Receive token-selector header/filter behavior

## Test plan
- [x] `npx eslint packages/kit/src/hooks/useAllNetwork.ts packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx`
- [x] `npx eslint packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx`
- [x] `npx eslint packages/kit/src/hooks/useReceiveToken.ts packages/kit/src/views/Receive/pages/ReceiveSelector.tsx`
- [x] `git diff --check`
- [x] `yarn tsc:only --pretty false`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] iOS Simulator iPhone 16e: set `homeShowLpTokensOnly=true`, reload from Metro, verify top amount displays and DeFi token list leaves skeleton and renders tokens.