### PR TITLE
fix: hide prime badge on Prime menu entry

### DIFF
--- a/packages/kit/src/components/MoreActionButton/index.tsx
+++ b/packages/kit/src/components/MoreActionButton/index.tsx
@@ -380,6 +380,7 @@ interface IMoreActionContentGridItemProps {
   badges?: number;
   lottieSrc?: any;
   isPrimeFeature?: boolean;
+  hidePrimeBadge?: boolean;
 }
 
 function MoreActionContentGridItem({
@@ -393,6 +394,7 @@ function MoreActionContentGridItem({
   badges = 0,
   lottieSrc,
   isPrimeFeature,
+  hidePrimeBadge,
 }: IMoreActionContentGridItemProps) {
   const { closePopover } = usePopoverContext();
   const { isPrimeAvailable } = usePrimeAvailable();
@@ -484,7 +486,7 @@ function MoreActionContentGridItem({
           </Stack>
         ) : null}
         {/* Only show Prime badge for non-Prime users */}
-        {isPrimeFeature && !isPrimeUser ? (
+        {isPrimeFeature && !hidePrimeBadge && !isPrimeUser ? (
           <Stack
             position="absolute"
             right={-10}
@@ -957,6 +959,7 @@ function MoreActionGeneralGrid() {
             onPress: handlePrime,
             trackID: 'wallet-prime',
             isPrimeFeature: true,
+            hidePrimeBadge: true,
           }
         : undefined,
       !platformEnv.isWebDappMode


### PR DESCRIPTION
## Summary
- Hide the Prime upsell badge on the Prime entry inside the More menu.
- Keep the same badge behavior for other Prime-gated actions.

## Intent & Context
The Prime entry already uses a Prime icon, so showing another Prime badge on top of it looked like a subscription status marker for non-subscribed users.

## Root Cause
`MoreActionContentGridItem` rendered the overlay badge for every item marked `isPrimeFeature`, including the Prime entry itself.

## Design Decisions
Added an item-level `hidePrimeBadge` flag instead of changing `isPrimeFeature`, so Prime availability gating and other paid-feature indicators stay unchanged.

## Changes Detail
- `packages/kit/src/components/MoreActionButton/index.tsx`: add `hidePrimeBadge` and enable it only on the Prime menu entry.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: More menu display only.

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
