### PR TITLE
fix: recover iOS Perps subscriptions after locale change OK-54167

### DIFF
--- a/.env.version
+++ b/.env.version
@@ -2,4 +2,6 @@
 
 VERSION=6.3.0
 
+BUILD_NUMBER=2026051425
+
 # Will auto add BUILD_NUMBER and BUNDLE_VERSION variable at CI job. Must give an empty line at end of this file.

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -161,36 +161,37 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
   private static readonly POST_OPEN_DATA_CHECK_MAX_RETRIES = 3;
 
+  private _resumeRecoveryPromise: Promise<void> | null = null;
+
   allSubSpecsMap: Record<string, ISubscriptionSpec<ESubscriptionType>> = {};
 
   pendingSubSpecsMap: Record<string, ISubscriptionSpec<ESubscriptionType>> = {};
 
   private _activeSubscriptions = new Map<string, IActiveSubscription>();
 
-  // OK-53014: Extension-only defensive watcher.
+  // OK-53014 / OK-54167: cross-runtime defensive watcher.
   //
-  // Context: On browser extension cold start (e.g. create wallet in popup
-  // then expand to large-screen tab), UI-to-background atom sync is an async
-  // IPC round-trip.  socketOpenHandler() calls updateSubscriptions() before
+  // Context: On browser extension cold start and native background-thread
+  // resumes, UI-to-background atom sync is an async round-trip.
+  // socketOpenHandler() can call updateSubscriptions() before
   // perpsActiveAccountAtom / perpsActiveAssetAtom / perpsActiveOrderBookOptionsAtom
   // have arrived from the freshly-mounted UI, so calculateRequiredSubscriptions()
-  // silently skips all user-/symbol-gated subscriptions and the user sees
-  // everything except the K-line iframe stuck in loading.
+  // silently skips user-/symbol-gated subscriptions and the user sees Perps
+  // market data stuck in loading.
   //
   // Fix: subscribe to the three atoms that gate subscription creation and
   // re-run updateSubscriptions() whenever any of them changes while the
   // socket is OPEN.  updateSubscriptions() is debounced(300ms) + idempotent
   // via diff, so redundant fires are coalesced.
   //
-  // Scope: extension only — other platforms run UI and background in the
-  // same JS process where atom writes are effectively synchronous, so the
-  // IPC race does not apply.
+  // Scope: cross-runtime environments only — same-JS-runtime platforms do not
+  // need the extra atom subscriptions.
   private _subscriptionAtomsUnsubs: Array<() => void> = [];
 
   private _subscriptionLifecycleVersion = 0;
 
   private _watchSubscriptionAtoms(): void {
-    if (!platformEnv.isExtension) {
+    if (!platformEnv.isExtension && !platformEnv.isNativeBackgroundThread) {
       return;
     }
     this._unwatchSubscriptionAtoms();
@@ -304,6 +305,23 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       return;
     }
 
+    const staleCriticalTypes = this._getStaleCriticalOpenSubscriptionTypes(
+      requiredSubInfo.requiredSubSpecsMap,
+    );
+    if (staleCriticalTypes.length > 0) {
+      console.log(
+        `updateSubscriptions__rebuild_stale_critical__${staleCriticalTypes.join(
+          ',',
+        )}`,
+      );
+      this._subscriptionLifecycleVersion += 1;
+      this._updateSubscriptionsDebounced.cancel();
+      this._clearPostOpenDataCheck();
+      this._hasInitialSubscription = false;
+      await this._cleanupAllSubscriptions();
+      await timerUtils.wait(50);
+    }
+
     this.allSubSpecsMap = {
       ...this.allSubSpecsMap,
       ...requiredSubInfo.requiredSubSpecsMap,
@@ -335,6 +353,9 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
   @backgroundMethod()
   async updateSubscriptions(): Promise<void> {
+    if (await this._reconnectClosedOrClosingSocket()) {
+      return;
+    }
     // Skip debounce on first subscription to speed up initial load
     if (!this._hasInitialSubscription) {
       this._hasInitialSubscription = true;
@@ -384,16 +405,175 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
   lastRefreshAllPerpsDataAt: number | null = null;
 
+  private _hasRecentDataFlow(): boolean {
+    return (
+      this._lastMessageAt !== null &&
+      this._lastMessageAt !== undefined &&
+      Date.now() - this._lastMessageAt <
+        HYPERLIQUID_REFRESH_DATA_FLOW_THRESHOLD_MS
+    );
+  }
+
+  private _markSubscriptionActivity(
+    subscriptionType: ESubscriptionType,
+    messageTimestamp: number,
+  ): void {
+    for (const sub of this._activeSubscriptions.values()) {
+      if (sub.type === subscriptionType) {
+        sub.lastActivity = messageTimestamp;
+        sub.isActive = true;
+      }
+    }
+  }
+
+  private _getStaleCriticalOpenSubscriptionTypes(
+    requiredSubSpecsMap?: Record<string, ISubscriptionSpec<ESubscriptionType>>,
+  ): ESubscriptionType[] {
+    if (!platformEnv.isNative && !platformEnv.isNativeBackgroundThread) {
+      return [];
+    }
+
+    const criticalTypes = new Set<ESubscriptionType>([
+      ESubscriptionType.ALL_DEXS_ASSET_CTXS,
+      ESubscriptionType.L2_BOOK,
+    ]);
+    const now = Date.now();
+    const staleTypes = new Set<ESubscriptionType>();
+
+    for (const sub of this._activeSubscriptions.values()) {
+      const isCurrentRequired =
+        !requiredSubSpecsMap || Boolean(requiredSubSpecsMap[sub.key]);
+      const isPastGracePeriod =
+        now - sub.createdAt >= HYPERLIQUID_REFRESH_DATA_FLOW_THRESHOLD_MS;
+      const isStale =
+        now - sub.lastActivity > HYPERLIQUID_REFRESH_DATA_FLOW_THRESHOLD_MS;
+      if (
+        criticalTypes.has(sub.type) &&
+        isCurrentRequired &&
+        isPastGracePeriod &&
+        isStale
+      ) {
+        staleTypes.add(sub.type);
+      }
+    }
+
+    return Array.from(staleTypes);
+  }
+
+  private _getMissingCriticalOpenSubscriptionTypes(
+    requiredSubSpecsMap?: Record<string, ISubscriptionSpec<ESubscriptionType>>,
+  ): ESubscriptionType[] {
+    if (!requiredSubSpecsMap) {
+      return [];
+    }
+
+    const criticalTypes = new Set<ESubscriptionType>([
+      ESubscriptionType.ALL_DEXS_ASSET_CTXS,
+      ESubscriptionType.L2_BOOK,
+    ]);
+    const missingTypes = new Set<ESubscriptionType>();
+    for (const spec of Object.values(requiredSubSpecsMap)) {
+      if (
+        criticalTypes.has(spec.type) &&
+        !this._activeSubscriptions.has(spec.key)
+      ) {
+        missingTypes.add(spec.type);
+      }
+    }
+    return Array.from(missingTypes);
+  }
+
+  private _hasHealthyOpenSocketDataFlow(
+    requiredSubSpecsMap?: Record<string, ISubscriptionSpec<ESubscriptionType>>,
+  ): boolean {
+    return (
+      this._hasRecentDataFlow() &&
+      this._getStaleCriticalOpenSubscriptionTypes(requiredSubSpecsMap)
+        .length === 0 &&
+      this._getMissingCriticalOpenSubscriptionTypes(requiredSubSpecsMap)
+        .length === 0
+    );
+  }
+
+  private _shouldRebuildOpenSocketSubscriptionsOnResume(params?: {
+    forceRebuild?: boolean;
+    requiredSubSpecsMap?: Record<string, ISubscriptionSpec<ESubscriptionType>>;
+  }): boolean {
+    if (params?.forceRebuild) {
+      return this._activeSubscriptions.size > 0;
+    }
+
+    if (!platformEnv.isNative && !platformEnv.isNativeBackgroundThread) {
+      return false;
+    }
+
+    return (
+      this._activeSubscriptions.size > 0 &&
+      (!this._hasRecentDataFlow() ||
+        this._getStaleCriticalOpenSubscriptionTypes(params?.requiredSubSpecsMap)
+          .length > 0)
+    );
+  }
+
+  private async _reconcileOpenSocketSubscriptionsOnResume(params?: {
+    forceRebuild?: boolean;
+    reason?: string;
+  }): Promise<void> {
+    if (this._resumeRecoveryPromise) {
+      await this._resumeRecoveryPromise;
+      return;
+    }
+
+    this._resumeRecoveryPromise = (async () => {
+      const requiredSubInfo = await this.buildRequiredSubscriptionsMap();
+      if (
+        this._shouldRebuildOpenSocketSubscriptionsOnResume({
+          ...params,
+          requiredSubSpecsMap: requiredSubInfo?.requiredSubSpecsMap,
+        })
+      ) {
+        const reason = params?.reason ?? 'resumeSubscriptions';
+        console.log(`resumeSubscriptions__rebuild_open_socket__${reason}`);
+        this._subscriptionLifecycleVersion += 1;
+        this._updateSubscriptionsDebounced.cancel();
+        this._clearPostOpenDataCheck();
+        this._hasInitialSubscription = false;
+        await this._cleanupAllSubscriptions();
+        await timerUtils.wait(50);
+      }
+      await this.updateSubscriptions();
+    })().finally(() => {
+      this._resumeRecoveryPromise = null;
+    });
+
+    await this._resumeRecoveryPromise;
+  }
+
+  private _isSocketClosedOrClosing(): boolean {
+    const readyState = this._client?.transport?.socket?.readyState;
+    return readyState === WebSocket.CLOSED || readyState === WebSocket.CLOSING;
+  }
+
+  private async _reconnectClosedOrClosingSocket(): Promise<boolean> {
+    if (!this._isSocketClosedOrClosing()) {
+      return false;
+    }
+    console.log('updateSubscriptions__force_reconnect_closed_socket');
+    await this._forceReconnectTransport();
+    return true;
+  }
+
   @backgroundMethod()
   async refreshAllPerpsData(): Promise<boolean> {
     const client = await this.getWebSocketClient();
     const isSocketOpen =
       client?.transport?.socket?.readyState === WebSocket.OPEN;
-    const isDataFlowing =
-      this._lastMessageAt !== null &&
-      this._lastMessageAt !== undefined &&
-      Date.now() - this._lastMessageAt <
-        HYPERLIQUID_REFRESH_DATA_FLOW_THRESHOLD_MS;
+    const requiredSubInfo = isSocketOpen
+      ? await this.buildRequiredSubscriptionsMap()
+      : undefined;
+    const isDataFlowing = this._hasHealthyOpenSocketDataFlow(
+      requiredSubInfo?.requiredSubSpecsMap,
+    );
 
     void this.backgroundApi.serviceHyperliquid.updatePerpsConfigByServerSilently(
       {
@@ -459,7 +639,9 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   }
 
   @backgroundMethod()
-  async resumeSubscriptions(): Promise<void> {
+  async resumeSubscriptions(params?: {
+    forceRebuild?: boolean;
+  }): Promise<void> {
     await this.enableSubscriptionsHandler();
     this._postOpenDataCheckRetries = 0;
     console.log('updateSubscriptions__by__resumeSubscriptions');
@@ -473,7 +655,12 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       // it down.  The socket is still OPEN here, so socketOpenHandler will
       // not fire again to reinstall it for us.
       this._watchSubscriptionAtoms();
-      await this.updateSubscriptions();
+      await this._reconcileOpenSocketSubscriptionsOnResume({
+        forceRebuild: params?.forceRebuild,
+        reason: params?.forceRebuild
+          ? 'force_rebuild'
+          : 'native_resume_stale_data',
+      });
     }
   }
 
@@ -547,8 +734,18 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
   @backgroundMethod()
   async connect(): Promise<void> {
-    await this.getWebSocketClient();
-    this._currentState.isConnected = true;
+    const client = await this.getWebSocketClient();
+    if (await this._reconnectClosedOrClosingSocket()) {
+      return;
+    }
+    const readyState = client.transport?.socket?.readyState;
+    if (readyState === WebSocket.OPEN) {
+      this._currentState.isConnected = true;
+      this._watchSubscriptionAtoms();
+      await this._reconcileOpenSocketSubscriptionsOnResume({
+        reason: 'connect_open_socket',
+      });
+    }
   }
 
   @backgroundMethod()
@@ -760,10 +957,10 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       // captured and re-triggers a reconcile.
       this._watchSubscriptionAtoms();
 
-      if (!wasConnected) {
-        // resubscribe when reconnecting
-        await this.updateSubscriptions();
-      }
+      // The transport can reopen while networkStatusAtom still says connected.
+      // Reconcile every open event so native resumes and locale changes cannot
+      // leave the singleton socket without the current market subscriptions.
+      await this.updateSubscriptions();
 
       // Mark connected after handling potential resubscribe.
       await perpsNetworkStatusAtom.set(
@@ -1242,6 +1439,9 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         return;
       }
 
+      const messageTimestamp = Date.now();
+      this._markSubscriptionActivity(subscriptionType, messageTimestamp);
+
       if (subscriptionType === ESubscriptionType.ALL_MIDS) {
         // Cache allMids in background for spot balance USD calculation
         hyperLiquidCache.allMids = data as IWsAllMids;
@@ -1395,8 +1595,6 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       } else {
         this._emitHyperliquidDataUpdate(subscriptionType, data);
       }
-
-      const messageTimestamp = Date.now();
 
       // Restart ping loop if not running (e.g. after transport auto-reconnect
       // where socketOpenHandler doesn't fire on the new internal socket)

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -570,11 +570,7 @@ function WebSocketSubscriptionUpdate() {
       },
     );
 
-    if (
-      isWebSocketConnected === true &&
-      !isLoading &&
-      plan.shouldSyncSubscriptions
-    ) {
+    if (!isLoading && plan.shouldSyncSubscriptions) {
       void actions.current.updateSubscriptions();
     }
   }, [
@@ -677,7 +673,11 @@ function useHyperliquidLocaleChangeRecovery() {
 
   const recoverSubscriptions = useCallback(async () => {
     await backgroundApiProxy.serviceHyperliquidSubscription.enableSubscriptionsHandler();
-    await backgroundApiProxy.serviceHyperliquidSubscription.resumeSubscriptions();
+    await backgroundApiProxy.serviceHyperliquidSubscription.resumeSubscriptions(
+      {
+        forceRebuild: true,
+      },
+    );
     await actions.current.updateSubscriptions();
     await backgroundApiProxy.serviceHyperliquidSubscription.forceReloadCandlesWebview();
   }, [actions]);

--- a/packages/kit/src/views/Perp/utils/subscriptionPlanner.test.ts
+++ b/packages/kit/src/views/Perp/utils/subscriptionPlanner.test.ts
@@ -86,7 +86,7 @@ describe('planTradeSubscriptions', () => {
     expect(plan.shouldSyncSubscriptions).toBe(true);
   });
 
-  it('does not sync subscriptions for a hidden perps-only selector tab', () => {
+  it('syncs market ctxs for a hidden perps-only selector tab', () => {
     const plan = planTradeSubscriptions({
       activeInstrument: baseInstrument,
       hasAccount: true,
@@ -99,6 +99,34 @@ describe('planTradeSubscriptions', () => {
     });
 
     expect(plan.spotAssetCtxsEnabled).toBe(false);
-    expect(plan.shouldSyncSubscriptions).toBe(false);
+    expect(plan.shouldSyncSubscriptions).toBe(true);
+  });
+
+  it('syncs focused perp market subscriptions before order book options are ready', () => {
+    const plan = planTradeSubscriptions({
+      activeInstrument: baseInstrument,
+      hasAccount: true,
+      orderBookOptions: undefined,
+      viewState: {
+        ...baseViewState,
+        routeFocused: true,
+      },
+    });
+
+    expect(plan.shouldSyncSubscriptions).toBe(true);
+  });
+
+  it('keeps focused perp market subscriptions alive when order book options lag behind', () => {
+    const plan = planTradeSubscriptions({
+      activeInstrument: baseInstrument,
+      hasAccount: true,
+      orderBookOptions: { coin: 'ETH', assetId: 1 },
+      viewState: {
+        ...baseViewState,
+        routeFocused: true,
+      },
+    });
+
+    expect(plan.shouldSyncSubscriptions).toBe(true);
   });
 });

--- a/packages/kit/src/views/Perp/utils/subscriptionPlanner.ts
+++ b/packages/kit/src/views/Perp/utils/subscriptionPlanner.ts
@@ -6,6 +6,7 @@ import type { IPerpsActiveOrderBookOptionsAtom } from '@onekeyhq/kit-bg/src/stat
 
 import {
   isPerpTokenSelectorAllTab,
+  isPerpTokenSelectorPerpsTab,
   isPerpTokenSelectorSpotTab,
 } from './tokenSelectorTabs';
 
@@ -22,7 +23,7 @@ export function planTradeSubscriptions(params: {
   orderBookOptions?: IPerpsActiveOrderBookOptionsAtom;
   viewState: ITradeRouteViewState;
 }): ITradeSubscriptionPlan {
-  const { activeInstrument, hasAccount, orderBookOptions, viewState } = params;
+  const { activeInstrument, hasAccount, viewState } = params;
   const instrumentCoin = activeInstrument?.coin ?? '';
   const isSpot = activeInstrument?.mode === 'spot';
   const isSpotSelectorOpen =
@@ -31,8 +32,11 @@ export function planTradeSubscriptions(params: {
   const isAllSelectorOpen =
     viewState.tokenSelectorOpen &&
     isPerpTokenSelectorAllTab(viewState.tokenSelectorTab);
+  const isPerpsSelectorOpen =
+    viewState.tokenSelectorOpen &&
+    isPerpTokenSelectorPerpsTab(viewState.tokenSelectorTab);
   const shouldSyncSelectorSubscriptions =
-    isSpotSelectorOpen || isAllSelectorOpen;
+    isSpotSelectorOpen || isAllSelectorOpen || isPerpsSelectorOpen;
 
   // Always subscribe to SPOT_STATE when account exists — total account value
   // (perps + spot) depends on spotTotalUsd from this subscription.
@@ -52,8 +56,7 @@ export function planTradeSubscriptions(params: {
         shouldSyncSelectorSubscriptions || Boolean(instrumentCoin);
     } else {
       shouldSyncSubscriptions =
-        shouldSyncSelectorSubscriptions ||
-        (Boolean(instrumentCoin) && orderBookOptions?.coin === instrumentCoin);
+        shouldSyncSelectorSubscriptions || Boolean(instrumentCoin);
     }
   }
 


### PR DESCRIPTION
## Summary
- cherry-pick the Perps subscription recovery fix for OK-54167 onto the 6.3 line (`x`)
- set `.env.version` BUILD_NUMBER to `2026051425` so the QA Bundle matches the installed 6.3 TestFlight shell (`6.3.0@2026051425`)

## Validation
- yarn jest packages/kit/src/views/Perp/utils/subscriptionPlanner.test.ts --runInBand
- yarn lint:staged
- yarn tsc:staged

## QA Bundle Note
This PR is for QA Bundle validation only. The BUILD_NUMBER commit can be dropped before final product merge if the fix is validated.