### PR TITLE
fix: mobile browser close tab action list animation timing(OK-54692)

### DIFF
--- a/packages/kit/src/views/Discovery/components/MobileBrowser/MobileBrowserBottomBar.android.tsx
+++ b/packages/kit/src/views/Discovery/components/MobileBrowser/MobileBrowserBottomBar.android.tsx
@@ -23,7 +23,10 @@ import { ESiteMode } from '../../types';
 
 import RefreshButton from './RefreshButton';
 import TabCountButton from './TabCountButton';
-import { useMobileBrowserBottomBarData } from './useMobileBrowserBottomBarData';
+import {
+  ACTION_LIST_CLOSE_ANIMATION_DELAY_MS,
+  useMobileBrowserBottomBarData,
+} from './useMobileBrowserBottomBarData';
 
 import type { IMobileBrowserBottomBarProps } from './useMobileBrowserBottomBarData';
 
@@ -90,6 +93,15 @@ function MobileBrowserBottomBar({
       });
     })();
   }, [takeScreenshot, navigation, displayHomePage]);
+
+  const handleCloseTabFromActionList = useCallback(
+    async (close: () => void) => {
+      close();
+      await timerUtils.wait(ACTION_LIST_CLOSE_ANIMATION_DELAY_MS);
+      handleCloseTab();
+    },
+    [handleCloseTab],
+  );
 
   // Options button: use ActionList.show() programmatically
   const handleShowOptions = useCallback(() => {
@@ -200,7 +212,7 @@ function MobileBrowserBottomBar({
                   : ETranslations.explore_close_tab,
               }),
               icon: 'CrossedLargeOutline',
-              onPress: handleCloseTab,
+              onPress: handleCloseTabFromActionList,
               testID: DiscoveryTestIDs.tabActionClose,
             },
             ...(onGoBackHomePage
@@ -234,7 +246,7 @@ function MobileBrowserBottomBar({
     onShare,
     hasConnectedAccount,
     handleDisconnect,
-    handleCloseTab,
+    handleCloseTabFromActionList,
     onGoBackHomePage,
   ]);
 

--- a/packages/kit/src/views/Discovery/components/MobileBrowser/MobileBrowserBottomOptions.tsx
+++ b/packages/kit/src/views/Discovery/components/MobileBrowser/MobileBrowserBottomOptions.tsx
@@ -6,9 +6,12 @@ import type { IActionListItemProps } from '@onekeyhq/components';
 import { ActionList } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
 import { DiscoveryTestIDs } from '../../testIDs';
 import { ESiteMode, type IMobileBottomOptionsProps } from '../../types';
+
+import { ACTION_LIST_CLOSE_ANIMATION_DELAY_MS } from './useMobileBrowserBottomBarData';
 
 function MobileBrowserBottomOptions({
   children,
@@ -126,7 +129,11 @@ function MobileBrowserBottomOptions({
                 : ETranslations.explore_close_tab,
             }),
             icon: 'CrossedLargeOutline',
-            onPress: onCloseTab,
+            onPress: async (close: () => void) => {
+              close();
+              await timerUtils.wait(ACTION_LIST_CLOSE_ANIMATION_DELAY_MS);
+              onCloseTab();
+            },
             testID: DiscoveryTestIDs.tabActionClose,
           },
           onGoBackHomePage

--- a/packages/kit/src/views/Discovery/components/MobileBrowser/useMobileBrowserBottomBarData.ts
+++ b/packages/kit/src/views/Discovery/components/MobileBrowser/useMobileBrowserBottomBarData.ts
@@ -23,12 +23,15 @@ import { usePageTranslation } from '../../hooks/usePageTranslation';
 import {
   useDisplayHomePageFlag,
   useWebTabDataById,
+  useWebTabs,
 } from '../../hooks/useWebTabs';
 import { webviewRefs } from '../../utils/explorerUtils';
 import { showTabBar } from '../../utils/tabBarUtils';
 
 import type { ESiteMode } from '../../types';
 import type WebView from 'react-native-webview';
+
+export const ACTION_LIST_CLOSE_ANIMATION_DELAY_MS = 350;
 
 export interface IMobileBrowserBottomBarProps extends IStackProps {
   id: string;
@@ -46,6 +49,7 @@ export function useMobileBrowserBottomBarData({
   const { bottom } = useSafeAreaInsets();
 
   const { tab } = useWebTabDataById(id);
+  const { tabs } = useWebTabs();
 
   const origin = tab?.url ? new URL(tab.url).origin : null;
   const { result: hasConnectedAccount, run: refreshConnectState } =
@@ -119,16 +123,15 @@ export function useMobileBrowserBottomBarData({
     [setPinnedTab, id, intl],
   );
 
-  const handleCloseTab = useCallback(async () => {
-    // a workaround to fix this issue
-    //  that remove page includes Popover from screen before closing popover
-    setTimeout(() => {
-      closeWebTab({ tabId: id, entry: 'Menu' });
+  const handleCloseTab = useCallback(() => {
+    const isLastTab = tabs.length <= 1;
+    closeWebTab({ tabId: id, entry: 'Menu' });
+    if (isLastTab) {
       setCurrentWebTab(null);
-    });
+    }
 
     showTabBar();
-  }, [closeWebTab, setCurrentWebTab, id]);
+  }, [closeWebTab, id, setCurrentWebTab, tabs.length]);
 
   const onShare = useCallback(() => {
     handleShareUrl(tab?.displayUrl ?? tab?.url ?? '');


### PR DESCRIPTION
## Summary
- Fix mobile browser tab close timing so the ActionList close animation finishes before the tab is removed
- Only reset `currentWebTab` to `null` when closing the last remaining tab (avoid blanking active tab on multi-tab close)
- Replace `setTimeout` workaround with explicit animation delay constant `ACTION_LIST_CLOSE_ANIMATION_DELAY_MS`

## Intent & Context
When closing a tab from the bottom ActionList menu in the mobile browser, the previous implementation removed the tab/WebView from the screen before the ActionList popover animation finished, causing visual glitches. Additionally, `setCurrentWebTab(null)` was unconditionally called, which incorrectly cleared the active tab even when other tabs still existed.

## Root Cause
1. The ActionList `onPress` handler triggered `closeWebTab` immediately, racing with the ActionList close animation.
2. `setCurrentWebTab(null)` was called regardless of how many tabs remained, so closing a non-last tab still cleared the active selection.
3. The original `setTimeout(...)` workaround was opaque — no explicit delay matched to the popover animation duration.

## Design Decisions
- Introduce a shared constant `ACTION_LIST_CLOSE_ANIMATION_DELAY_MS = 350` exported from `useMobileBrowserBottomBarData` so both `MobileBrowserBottomBar.android.tsx` and `MobileBrowserBottomOptions.tsx` use the same delay value.
- Use `timerUtils.wait(...)` after invoking ActionList's `close()` callback, then trigger tab close — this serializes the animation and the state update cleanly.
- Guard `setCurrentWebTab(null)` behind `tabs.length <= 1` to preserve active tab when other tabs remain.

## Changes Detail
- `useMobileBrowserBottomBarData.ts`: Export `ACTION_LIST_CLOSE_ANIMATION_DELAY_MS`; rewrite `handleCloseTab` to drop the `setTimeout` workaround and only null out current tab when it's the last one; subscribe to `useWebTabs` for tab count.
- `MobileBrowserBottomBar.android.tsx`: Wrap `handleCloseTab` in `handleCloseTabFromActionList` that awaits the animation delay before closing the tab.
- `MobileBrowserBottomOptions.tsx`: Apply the same `close() → wait → onCloseTab()` pattern to keep iOS/cross-platform behavior aligned with Android.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile (iOS + Android)
- **Risk Areas**: Tab lifecycle and current-tab selection logic in the mobile browser bottom bar.

## Test plan
- [ ] Open multiple tabs in mobile browser; close a non-last tab via ActionList → ActionList animation completes smoothly and the active tab is preserved
- [ ] Close the last remaining tab via ActionList → falls back to home page (currentWebTab cleared)
- [ ] Verify on both Android (`MobileBrowserBottomBar.android.tsx`) and iOS (`MobileBrowserBottomOptions.tsx`)
- [ ] No visual glitch (popover content disappearing before animation finishes)