### PR TITLE
fix(ios+android): onboarding hardware dialog stacking & TextInput guards(OK-54522)

### DIFF
--- a/development/spellCheckerSkipWords.txt
+++ b/development/spellCheckerSkipWords.txt
@@ -1478,3 +1478,4 @@ psourceaddress
 neighbour
 KHTML
 Leons
+symbolicated

--- a/packages/components/src/forms/Input/index.tsx
+++ b/packages/components/src/forms/Input/index.tsx
@@ -123,7 +123,7 @@ export const useAutoScrollToTop = platformEnv.isNativeAndroid
   ? (ref: RefObject<TextInput | null>, waitMs = 250) => {
       useEffect(() => {
         setTimeout(() => {
-          ref.current?.setSelection(0, 0);
+          ref.current?.setSelection?.(0, 0);
         }, waitMs);
       }, [ref, waitMs]);
     }

--- a/packages/components/src/forms/TextArea/Input.tsx
+++ b/packages/components/src/forms/TextArea/Input.tsx
@@ -4,7 +4,7 @@ import { forwardRef, useImperativeHandle, useRef } from 'react';
 import { getFontSize } from '@onekeyhq/components/src/shared/tamagui';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
-import { Input, useAutoScrollToTop } from '../Input';
+import { Input } from '../Input';
 
 import { TextArea as TMTextArea } from './TamaguiTextArea';
 
@@ -62,7 +62,6 @@ function BaseTextArea(
     : allowSecureTextEye;
   const ref = useRef<TextInput>(null);
   useImperativeHandle(forwardedRef, () => ref.current as TextInput);
-  useAutoScrollToTop(ref);
   return (
     // testID is forwarded via the rest props the caller supplies.
     // oxlint-disable-next-line onekey/require-testid

--- a/packages/kit/src/views/Onboarding/pages/ConnectHardwareWallet/SelectAddWalletTypeDialog.tsx
+++ b/packages/kit/src/views/Onboarding/pages/ConnectHardwareWallet/SelectAddWalletTypeDialog.tsx
@@ -3,8 +3,11 @@ import { useCallback, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import { Dialog, YStack } from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
 export function SelectAddWalletTypeDialogContent({
   onAddStandardWalletPress,
@@ -81,6 +84,26 @@ export function useSelectAddWalletTypeDialog() {
   const showSelectAddWalletTypeDialog = useCallback(async (): Promise<
     'Standard' | 'Hidden' | undefined
   > => {
+    // iOS-only: dismiss the hardware-UI dialog before mounting this one.
+    // Both dialogs render into FULL_WINDOW_OVERLAY_PORTAL and share the same
+    // useOverlayZIndex stack. The hardware DialogContainer remounts on every
+    // atom action transition, so its Sheet.Overlay can end up above this
+    // dialog's Frame on iOS and intercept taps even though the wallet-type
+    // buttons appear visually on top. skipDeviceCancel:true keeps the BLE
+    // session alive; the hardware dialog naturally returns when the SDK
+    // emits its next UI event.
+    if (platformEnv.isNativeIOS) {
+      await backgroundApiProxy.serviceHardwareUI.closeHardwareUiStateDialog({
+        connectId: undefined,
+        skipDeviceCancel: true,
+        skipDelayClose: true,
+        reason: 'open SelectAddWalletTypeDialog',
+      });
+      // Let the hardware DialogContainer unmount and its useOverlayZIndex
+      // cleanup drop from the stack before we mount.
+      await timerUtils.wait(300);
+    }
+
     return new Promise((resolve) => {
       const onCloseFn = async () => {
         setIsLoading(false);


### PR DESCRIPTION
## Summary

Splits the non-patch fixes out of #11641 (which now contains only the `patches/fast-deep-equal+3.1.3.patch` work). Three independent stability fixes:

1. **iOS hardware-onboarding tap blocker** — when a passphrase-enabled OneKey device is locked and the user enters PIN to unlock, the "select Standard/Hidden wallet" dialog appears but its buttons can't be tapped. Root cause: the BLE "处理中" dialog (`HardwareUiStateContainer`) and `SelectAddWalletTypeDialog` both render into `FULL_WINDOW_OVERLAY_PORTAL` and share the same `useOverlayZIndex` stack. The hardware `DialogContainer` remounts on every atom action transition; on iOS its `Sheet.Overlay` ends up above the wallet-type dialog's Frame and intercepts taps. Android doesn't honor RN `zIndex` the same way and isn't affected.

   Fix: in `useSelectAddWalletTypeDialog`, on iOS only, call `serviceHardwareUI.closeHardwareUiStateDialog({ skipDeviceCancel: true, skipDelayClose: true })` and wait 300 ms before mounting. `skipDeviceCancel:true` keeps the BLE session alive; the hardware dialog reappears on the next SDK event (during `createHwWallet`).

2. **TextInput `setSelection` crash guard** — wrapped `TextInput` refs whose `setSelection` is undefined no-op instead of throwing. Drops the `useAutoScrollToTop` hook from `BaseTextArea` which was the only path reaching such a ref.

3. **`symbolicated` added to spell-check skip list** — supports Sentry release unification doc/commit messages.

## Changes

| File | What |
|---|---|
| `packages/kit/src/views/Onboarding/pages/ConnectHardwareWallet/SelectAddWalletTypeDialog.tsx` | iOS-only: dismiss hardware-UI dialog + 300 ms wait before `Dialog.show`. |
| `packages/components/src/forms/Input/index.tsx` | `ref.current?.setSelection?.(0, 0)` instead of unguarded call. |
| `packages/components/src/forms/TextArea/Input.tsx` | Drop `useAutoScrollToTop(ref)` from `BaseTextArea`. |
| `development/spellCheckerSkipWords.txt` | Add `symbolicated`. |

## Test plan

- [ ] iOS release build: passphrase + locked device + connect + enter PIN → "Select Standard/Hidden Wallet" dialog appears and both options are tappable.
- [ ] iOS release build: same flow but without passphrase / unlocked device → no regression, no extra delay perceived.
- [ ] Android release build: same flow works (and no new behavior introduced because the iOS guard is `platformEnv.isNativeIOS`-gated).
- [ ] Android release build: trigger TextArea/TextInput in DApp Permit / Sign-and-Verify flows → no `setSelection` crash, scroll behavior acceptable.
- [ ] `yarn tsc:staged` + `yarn lint:staged` pass.

## Refs

- Companion to #11641 (fast-deep-equal patch). Originally bundled there; split out for cleaner review.