### PR TITLE
fix: keep market banner badge within card(OK-54778)

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerItem.tsx
@@ -19,6 +19,7 @@ import {
 
 type IMarketBannerItemProps = {
   item: IMarketBannerItem;
+  isSmallScreen?: boolean;
   onPress?: (item: IMarketBannerItem) => void;
 };
 
@@ -84,7 +85,11 @@ function BannerTokenGroupComponent({ tokenLogos }: { tokenLogos?: string[] }) {
 
 const BannerTokenGroup = memo(BannerTokenGroupComponent);
 
-function MarketBannerItemComponent({ item, onPress }: IMarketBannerItemProps) {
+function MarketBannerItemComponent({
+  item,
+  isSmallScreen,
+  onPress,
+}: IMarketBannerItemProps) {
   const { title, description, backgroundColor, tokenLogos } = item;
   const isPerps = item.type === EMarketBannerType.Perps;
   const bgColor = convertThemeToken(backgroundColor, '$bgSubdued');
@@ -129,16 +134,28 @@ function MarketBannerItemComponent({ item, onPress }: IMarketBannerItemProps) {
         alignItems: 'center',
       }}
     >
-      <YStack gap="$0.5" flex={1} $gtMd={{ flex: 1 }}>
-        <XStack alignItems="center" gap="$1">
+      <YStack
+        gap="$0.5"
+        flex={1}
+        minWidth={0}
+        width="100%"
+        $gtMd={{ flex: 1, width: 'auto' }}
+      >
+        <XStack alignItems="flex-start" gap="$1" minWidth={0} maxWidth="100%">
           <SizableText
             size="$headingSm"
-            numberOfLines={isPerps ? 1 : 2}
+            numberOfLines={isPerps && !isSmallScreen ? 1 : 2}
             flexShrink={1}
+            minWidth={0}
+            ellipsizeMode="tail"
           >
             {title}
           </SizableText>
-          {isPerps ? <LeverageBadge leverage={10} /> : null}
+          {isPerps ? (
+            <Stack flexShrink={0}>
+              <LeverageBadge leverage={10} />
+            </Stack>
+          ) : null}
         </XStack>
         {description ? (
           <SizableText size="$bodyMdMedium" color={descriptionColor}>

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerList.tsx
@@ -82,6 +82,7 @@ function MarketBannerListComponent() {
     <MarketBannerItem
       key={item._id}
       item={item}
+      isSmallScreen={isSmallScreen}
       onPress={toMarketBannerDetail}
     />
   ));


### PR DESCRIPTION
## Summary
- Constrain the Market top banner title row so long Perps banner names cannot push the 10x badge outside the card.
- Keep small-screen Perps banner titles within two lines while preserving the existing one-line Perps title behavior on wider layouts.

## Intent & Context
OK-54778 reported an iOS Market top banner overflow when long names such as hyphenated banner titles are shown next to the Perps 10x badge.

## Root Cause
The Perps banner title and badge shared one horizontal row without enough width constraints, so a long title could expand the row and move the badge beyond the fixed mobile card width.

## Design Decisions
The fix stays local to Market banner cards instead of changing the shared LeverageBadge component. It avoids web-only word-break behavior and uses flex constraints that work across React Native and web.

## Changes Detail
- MarketBannerItem: adds min-width/width constraints to the title area, top-aligns the badge, prevents badge shrink, and uses two lines only on small screens.
- MarketBannerList: passes the existing small-screen state into each banner item.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile, Desktop, Web
- **Risk Areas**: Market banner card title wrapping and Perps badge alignment.

## Test plan
- [x] Run oxlint on Market banner files.
- [x] Run yarn tsc:staged.
- [ ] Verify the iOS Market top banner with a long Perps title such as Quantum-Safe.
- [ ] Verify wide layouts still show Perps banner titles in one line.