### PR TITLE
fix: clear prime user info when logged out

### DIFF
--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
@@ -430,6 +430,7 @@ class ServicePrime extends ServiceBase {
         reason:
           'ServicePrime.apiFetchPrimeUserInfo: auth token cleared during request, discarding response',
       });
+      await this.setPrimePersistAtomNotLoggedIn();
       const localUserInfo = await primePersistAtom.get();
       return {
         userInfo: localUserInfo,

--- a/packages/kit-bg/src/states/jotai/atomNames.ts
+++ b/packages/kit-bg/src/states/jotai/atomNames.ts
@@ -134,9 +134,12 @@ export enum EAtomNames {
 }
 export type IAtomNameKeys = keyof typeof EAtomNames;
 export const atomsConfig: Partial<
-  Record<IAtomNameKeys, { deepCompare?: boolean }>
+  Record<IAtomNameKeys, { deepCompare?: boolean; mergeInitialValue?: boolean }>
 > = {
   [EAtomNames.notificationsAtom]: {
     deepCompare: true,
+  },
+  [EAtomNames.primePersistAtom]: {
+    mergeInitialValue: false,
   },
 };

--- a/packages/kit-bg/src/states/jotai/jotaiStorage.ts
+++ b/packages/kit-bg/src/states/jotai/jotaiStorage.ts
@@ -414,7 +414,11 @@ export function atomWithStorage<Value>(
         return storage.removeItem(key);
       }
 
-      const newValue = merge({}, initialValue, nextValue);
+      const shouldMergeInitialValue =
+        atomsConfig?.[storageName]?.mergeInitialValue ?? true;
+      const newValue = shouldMergeInitialValue
+        ? merge({}, initialValue, nextValue)
+        : nextValue;
 
       const shouldDeepCompare =
         atomsConfig?.[storageName]?.deepCompare ?? false;
@@ -475,7 +479,14 @@ export function atomWithStorage<Value>(
             return initialValue;
           }
 
-          const newValue = merge({}, initialValue, nextValue) as Value;
+          const shouldMergeInitialValue =
+            atomsConfig?.[storageName as any as IAtomNameKeys]
+              ?.mergeInitialValue ?? true;
+          const newValue = (
+            shouldMergeInitialValue
+              ? merge({}, initialValue, nextValue)
+              : nextValue
+          ) as Value;
 
           const shouldDeepCompare =
             atomsConfig?.[storageName as any as IAtomNameKeys]?.deepCompare ??


### PR DESCRIPTION
## Summary
- Prevent `primePersistAtom` writes from merging with a stale hydrated initial value.
- Clear Prime persisted state when a Prime user info refresh detects that the auth token was removed while the request was in flight.
- Ensure logged-out or non-Prime server responses can actually clear stale email and Prime subscription state.

## Intent & Context
The Prime dashboard could still show a masked OneKey ID email and Prime benefits after logout. The user provided app logs from `OneKeyLogs-20260515T083929189Z.zip` showing that `setPrimePersistAtomNotLoggedIn` was called repeatedly, but the post-clear atom still contained the old `onekeyUserId` and `isPrime=true`.

## Root Cause
`primePersistAtom` is a persisted global atom. On native, its atom initial value can be hydrated from cached MMKV state. The storage setter then merged every write with that hydrated `initialValue` via `merge({}, initialValue, nextValue)`. Because lodash merge does not overwrite existing values with `undefined`, clearing Prime fields with the default logged-out object could leave stale `onekeyUserId`, `displayEmail`, and `primeSubscription` from the hydrated cache. The logs also showed server `isPrime=false` responses still resulting in `after update, atom isPrime=true`, which matches the same merge behavior.

## Design Decisions
Prime user state writes already return a full `IPrimeUserInfo` object, so `primePersistAtom` should replace with the caller-provided value instead of merging against hydrated initial state. This keeps the default merge behavior for other persisted atoms while making Prime auth state clearable. The existing no-token flow remains the same: clear the atom, then read the local user info. The in-flight logout branch now follows the same order.

## Changes Detail
- `packages/kit-bg/src/states/jotai/atomNames.ts`: added `mergeInitialValue` atom config and disabled it for `primePersistAtom`.
- `packages/kit-bg/src/states/jotai/jotaiStorage.ts`: respected `mergeInitialValue`; default remains merge-on-write for existing atoms.
- `packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx`: when `authTokenAfterFetch` is missing, clear Prime persisted state before returning local user info.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Desktop / Web / Extension
- **Risk Areas**: Prime auth state persistence and logout state propagation. The Jotai storage behavior change is gated to `primePersistAtom`; other persisted atoms keep existing merge behavior.

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `yarn jest packages/kit-bg/src/states/jotai/jotaiStorage.test.ts`
- [ ] Log in to OneKey Prime, open Prime dashboard, then log out and verify the email row and Prime benefits no longer remain visible.
- [ ] Verify a server `isPrime=false` response clears the Prime badge/benefits instead of preserving the previous active subscription.