### PR TITLE
fix(mobile): BootRecovery false-positive + DownloadVerify resume self-heal(OK-54871)

### DIFF
--- a/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/BootRecoveryKeys.java
+++ b/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/BootRecoveryKeys.java
@@ -2,9 +2,37 @@ package so.onekey.app.wallet;
 
 final class BootRecoveryKeys {
     static final String PREFS_NAME = "onekey_recovery";
+    // Activity-stage counter: incremented in MainActivity.onCreate, reset on
+    // graceful onStop / RecoveryActivity / JS markBootSuccess. Also serves
+    // as a freshness signal for BOOT_FAIL_TIMESTAMPS — when 0, the timestamps
+    // list is considered stale (some reset path zeroed it, but the Nitro
+    // `markBootSuccess` in node_modules only writes this integer, so we
+    // piggy-back the "list invalidated" signal on integer == 0 rather than
+    // requiring every reset site to clear two keys).
+    //
+    // Application-stage crashes (SoLoader / NewArch / Expo / JPush register)
+    // are intentionally NOT tracked here — those are extremely rare in
+    // practice, and when they DO happen they are usually permanent
+    // (corrupted .so / ABI mismatch) rather than transient crash-loops that
+    // a "clear cache" recovery flow could repair. Counting them adds
+    // mental complexity (two-stage counters, two reset semantics) for
+    // negligible production value.
     static final String CONSECUTIVE_BOOT_FAIL_COUNT = "consecutive_boot_fail_count";
+    // Comma-separated MainActivity.onCreate timestamps used by
+    // BootRecoveryStore to compute a TIME-WINDOWED failure count. Without
+    // this, Activity recreations that are NOT consecutive-in-time (memory-
+    // pressure resurrection hours later, locale/fontScale config change
+    // bursts, appRestart-driven recreations racing with the 5s JS
+    // markBootSuccess timer) all ratchet `consecutive_boot_fail_count`
+    // toward recovery even though there was no actual crash loop.
+    static final String BOOT_FAIL_TIMESTAMPS = "boot_fail_timestamps";
     static final String BOOT_FAIL_APP_VERSION = "boot_fail_app_version";
     static final String RECOVERY_ACTION = "recovery_action";
+    static final int RECOVERY_THRESHOLD = 3;
+    // 10-minute sliding window. RN init crash-loops fire within seconds;
+    // any restarts spaced further apart than this are almost certainly not
+    // a crash loop.
+    static final long ACTIVITY_FAIL_WINDOW_MS = 10L * 60L * 1000L;
 
     private BootRecoveryKeys() {}
 }

--- a/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/BootRecoveryStore.java
+++ b/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/BootRecoveryStore.java
@@ -1,0 +1,112 @@
+package so.onekey.app.wallet;
+
+import android.content.SharedPreferences;
+
+import com.margelo.nitro.nativelogger.OneKeyLog;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Single source of truth for the Activity-stage boot-failure tracking
+ * used by BootRecovery. All SharedPreferences access for the time-windowed
+ * counter lives here so that MainActivity / MainApplication / RecoveryActivity
+ * never touch the raw keys directly — adding a new reset path is a single
+ * call here, not a hunt across files.
+ *
+ * Why integer + timestamp list instead of just timestamps:
+ *   The JS-side `markBootSuccess` is exposed via the @onekeyfe/react-native-
+ *   device-utils Nitro module (lives in node_modules) and only writes the
+ *   integer. Piggy-backing the "timestamps are stale" signal on `integer == 0`
+ *   keeps that external module unchanged while still giving every existing
+ *   reset path (Nitro markBootSuccess, MainActivity.onStop, RecoveryActivity,
+ *   version migration) the correct invalidation behaviour for free.
+ */
+final class BootRecoveryStore {
+
+    // Cap retained timestamps. We only need to distinguish "< RECOVERY_THRESHOLD"
+    // from ">= RECOVERY_THRESHOLD"; retaining slightly more provides graceful
+    // overflow if increments happen faster than expected.
+    private static final int MAX_RETAINED = 5;
+
+    private BootRecoveryStore() {}
+
+    /**
+     * Records a new MainActivity.onCreate attempt and returns the post-write
+     * windowed count. Caller uses the return value to decide whether to
+     * route this launch into RecoveryActivity.
+     */
+    static int recordBootAttempt(SharedPreferences prefs) {
+        long now = System.currentTimeMillis();
+        int oldInteger = prefs.getInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, 0);
+        // integer == 0 ⇒ a reset path zeroed us; discard stale timestamps.
+        List<Long> timestamps = (oldInteger > 0)
+            ? parseTimestamps(prefs.getString(BootRecoveryKeys.BOOT_FAIL_TIMESTAMPS, ""))
+            : new ArrayList<>();
+        dropOutsideWindow(timestamps, now);
+        timestamps.add(now);
+        while (timestamps.size() > MAX_RETAINED) {
+            timestamps.remove(0);
+        }
+        int newInteger = oldInteger + 1;
+        prefs.edit()
+            .putInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, newInteger)
+            .putString(BootRecoveryKeys.BOOT_FAIL_TIMESTAMPS, serializeTimestamps(timestamps))
+            .commit();
+        int windowedCount = timestamps.size();
+        OneKeyLog.info(
+            "BootRecovery",
+            "boot_fail_count(activity): " + oldInteger + " -> " + newInteger
+                + ", windowed=" + windowedCount
+        );
+        return windowedCount;
+    }
+
+    /**
+     * Reads the windowed failure count WITHOUT recording a new attempt.
+     * Returns 0 if the freshness signal says timestamps are stale.
+     */
+    static int readWindowedCount(SharedPreferences prefs) {
+        int integer = prefs.getInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, 0);
+        if (integer <= 0) return 0;
+        List<Long> timestamps = parseTimestamps(
+            prefs.getString(BootRecoveryKeys.BOOT_FAIL_TIMESTAMPS, "")
+        );
+        dropOutsideWindow(timestamps, System.currentTimeMillis());
+        return timestamps.size();
+    }
+
+    private static void dropOutsideWindow(List<Long> timestamps, long now) {
+        Iterator<Long> it = timestamps.iterator();
+        while (it.hasNext()) {
+            if (now - it.next() > BootRecoveryKeys.ACTIVITY_FAIL_WINDOW_MS) {
+                it.remove();
+            }
+        }
+    }
+
+    private static List<Long> parseTimestamps(String raw) {
+        List<Long> result = new ArrayList<>();
+        if (raw == null || raw.isEmpty()) return result;
+        for (String part : raw.split(",")) {
+            try {
+                long t = Long.parseLong(part.trim());
+                if (t > 0) result.add(t);
+            } catch (NumberFormatException ignored) {
+                // skip malformed token
+            }
+        }
+        return result;
+    }
+
+    private static String serializeTimestamps(List<Long> timestamps) {
+        if (timestamps.isEmpty()) return "";
+        StringBuilder sb = new StringBuilder(timestamps.size() * 14);
+        for (int i = 0; i < timestamps.size(); i++) {
+            if (i > 0) sb.append(',');
+            sb.append(timestamps.get(i));
+        }
+        return sb.toString();
+    }
+}

--- a/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/MainActivity.java
+++ b/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/MainActivity.java
@@ -38,31 +38,24 @@ public class MainActivity extends ReactActivity {
       "android.activity.on_create.start: +" + (tActivityStart - MainApplication.appLaunchMs) + "ms from launch"
     );
 
-    // Increment the boot-fail counter HERE (not in MainApplication.onCreate).
-    // System-initiated process launches — JPush wakeups, foreground-service
-    // callbacks, broadcast receivers, post-download relaunches — only run
-    // Application.onCreate; they never bring up MainActivity, so they must
-    // not bump the counter. Doing it here is the "user actually tried to
-    // open the app" signal. Reset path is unchanged: MainActivity.onStop on
-    // graceful background, RecoveryActivity after the user resolves recovery,
-    // and the JS-side 5s `markBootSuccess` timer in Bootstrap.tsx.
+    // Record this MainActivity.onCreate attempt and get the post-write
+    // time-windowed count back. The increment lives HERE (not in
+    // MainApplication.onCreate) so system-initiated process launches —
+    // JPush wakeups, foreground-service callbacks, broadcast receivers,
+    // post-download relaunches — that run Application.onCreate but never
+    // bring up the UI don't ratchet the counter.
     //
     // Placed before super.onCreate(null) so that crashes during ReactActivity
     // / Fabric / TurboModule init still accumulate toward recovery — the
-    // whole point of the counter is to catch RN init crash-loops.
-    {
-      SharedPreferences recoveryPrefs =
-        getSharedPreferences(BootRecoveryKeys.PREFS_NAME, MODE_PRIVATE);
-      int oldCount = recoveryPrefs.getInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, 0);
-      int newCount = oldCount + 1;
-      recoveryPrefs.edit()
-        .putInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, newCount)
-        .commit();
-      OneKeyLog.info(
-        "BootRecovery",
-        "boot_fail_count(activity): " + oldCount + " -> " + newCount
-      );
-    }
+    // whole point of this counter is to catch RN init crash-loops.
+    //
+    // Reset paths (all live outside this file): MainActivity.onStop on
+    // graceful background, RecoveryActivity after the user resolves
+    // recovery, JS-side 5s `markBootSuccess` timer in Bootstrap.tsx via
+    // the Nitro module.
+    int windowedFailures = BootRecoveryStore.recordBootAttempt(
+      getSharedPreferences(BootRecoveryKeys.PREFS_NAME, MODE_PRIVATE)
+    );
 
     // Install AndroidX SplashScreen before super.onCreate() to fix MIUI/HyperOS crashes
     // where system's replaceUmiTheme method fails with NullPointerException
@@ -103,7 +96,13 @@ public class MainActivity extends ReactActivity {
       "android.activity.super_on_create: " + (tAfterSuper - tBeforeSuper) + "ms (ReactActivity init)"
     );
 
-    if (MainApplication.shouldShowRecovery) {
+    // Re-evaluate recovery here using the post-increment windowed count.
+    // MainApplication only saw the pre-increment value (it doesn't increment),
+    // so when the third user-launch in the 10-minute window finally crosses
+    // the threshold, MainApplication.shouldShowRecovery is still false on
+    // this launch and we have to route to recovery ourselves.
+    if (MainApplication.shouldShowRecovery
+        || windowedFailures >= BootRecoveryKeys.RECOVERY_THRESHOLD) {
         startActivity(new Intent(this, RecoveryActivity.class));
         finish();
         return;
@@ -160,7 +159,7 @@ public class MainActivity extends ReactActivity {
     // is still offered if the user swipe-kills without resolving.
     SharedPreferences prefs = getSharedPreferences(BootRecoveryKeys.PREFS_NAME, MODE_PRIVATE);
     int count = prefs.getInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, 0);
-    if (count < 3) {
+    if (count < BootRecoveryKeys.RECOVERY_THRESHOLD) {
       prefs.edit()
           .putInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, 0)
           .commit();

--- a/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/MainActivity.java
+++ b/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/MainActivity.java
@@ -37,6 +37,33 @@ public class MainActivity extends ReactActivity {
       "StartupTiming",
       "android.activity.on_create.start: +" + (tActivityStart - MainApplication.appLaunchMs) + "ms from launch"
     );
+
+    // Increment the boot-fail counter HERE (not in MainApplication.onCreate).
+    // System-initiated process launches — JPush wakeups, foreground-service
+    // callbacks, broadcast receivers, post-download relaunches — only run
+    // Application.onCreate; they never bring up MainActivity, so they must
+    // not bump the counter. Doing it here is the "user actually tried to
+    // open the app" signal. Reset path is unchanged: MainActivity.onStop on
+    // graceful background, RecoveryActivity after the user resolves recovery,
+    // and the JS-side 5s `markBootSuccess` timer in Bootstrap.tsx.
+    //
+    // Placed before super.onCreate(null) so that crashes during ReactActivity
+    // / Fabric / TurboModule init still accumulate toward recovery — the
+    // whole point of the counter is to catch RN init crash-loops.
+    {
+      SharedPreferences recoveryPrefs =
+        getSharedPreferences(BootRecoveryKeys.PREFS_NAME, MODE_PRIVATE);
+      int oldCount = recoveryPrefs.getInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, 0);
+      int newCount = oldCount + 1;
+      recoveryPrefs.edit()
+        .putInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, newCount)
+        .commit();
+      OneKeyLog.info(
+        "BootRecovery",
+        "boot_fail_count(activity): " + oldCount + " -> " + newCount
+      );
+    }
+
     // Install AndroidX SplashScreen before super.onCreate() to fix MIUI/HyperOS crashes
     // where system's replaceUmiTheme method fails with NullPointerException
     // Added defensive error handling for OPPO and other vendor-specific crashes

--- a/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/MainApplication.java
+++ b/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/MainApplication.java
@@ -281,16 +281,23 @@ public class MainApplication extends Application implements ReactApplication {
     }
     prefs.edit().putString(BootRecoveryKeys.BOOT_FAIL_APP_VERSION, currentVersion).commit();
 
-    // Increment boot fail count; counter is reset in MainActivity.onStop()
-    // on graceful exit, so only consecutive crashes accumulate
-    int oldCount = prefs.getInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, 0);
-    int newCount = oldCount + 1;
-    prefs.edit().putInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, newCount).commit();
+    // Read (do NOT increment) the boot-fail counter here. The increment
+    // moved to MainActivity.onCreate so that system-initiated process
+    // launches — JPush wakeups, foreground-service callbacks, broadcast
+    // receivers, post-download relaunches — don't bump the counter when
+    // they never bring up the UI. Counter is reset by MainActivity.onStop
+    // on graceful background, and by RecoveryActivity after the user
+    // resolves recovery.
+    int currentCount = prefs.getInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, 0);
 
     // Harness tests create this marker file via globalSetup so the recovery
     // page never blocks React Native from starting during test runs.
     boolean isHarnessMode = new java.io.File(getFilesDir(), "harness_mode").exists();
-    shouldShowRecovery = !isHarnessMode && newCount >= 3;
+    // Predicts the post-increment value: MainActivity.onCreate will bump
+    // currentCount by 1 right after Application init. Keeping the literal
+    // `>= 3` here preserves the original "3 strikes" semantic — recovery
+    // triggers on the 3rd consecutive failed user-launch, not the 4th.
+    shouldShowRecovery = !isHarnessMode && (currentCount + 1) >= 3;
 
     long tBeforeSuper = System.currentTimeMillis();
     super.onCreate();
@@ -323,7 +330,7 @@ public class MainApplication extends Application implements ReactApplication {
       "android.app.new_arch_load: " + (tAfterNewArch - tAfterSoLoader) + "ms (+" + (tAfterNewArch - appLaunchMs) + "ms from launch)"
     );
 
-    OneKeyLog.info("BootRecovery", "boot_fail_count: " + oldCount + " -> " + newCount + ", shouldShowRecovery: " + shouldShowRecovery);
+    OneKeyLog.info("BootRecovery", "boot_fail_count(app.read): " + currentCount + ", shouldShowRecovery: " + shouldShowRecovery);
 
     if (shouldShowRecovery) {
         // Skip heavy initialization (React Native, Expo, JPush).

--- a/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/MainApplication.java
+++ b/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/MainApplication.java
@@ -273,31 +273,38 @@ public class MainApplication extends Application implements ReactApplication {
     // Recovery check
     SharedPreferences prefs = getSharedPreferences(BootRecoveryKeys.PREFS_NAME, MODE_PRIVATE);
 
-    // Version-aware counter reset
+    // Version-aware counter reset — clears the Activity-stage counter when
+    // the installed app version changes (an upgrade resets the crash-loop
+    // history because the failing code path may be gone). Timestamps don't
+    // need an explicit clear; the freshness signal (integer == 0) handles it.
     String currentVersion = BuildConfig.VERSION_NAME;
     String storedVersion = prefs.getString(BootRecoveryKeys.BOOT_FAIL_APP_VERSION, "");
     if (!storedVersion.isEmpty() && !storedVersion.equals(currentVersion)) {
-        prefs.edit().putInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, 0).commit();
+        prefs.edit()
+            .putInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, 0)
+            .commit();
     }
     prefs.edit().putString(BootRecoveryKeys.BOOT_FAIL_APP_VERSION, currentVersion).commit();
-
-    // Read (do NOT increment) the boot-fail counter here. The increment
-    // moved to MainActivity.onCreate so that system-initiated process
-    // launches — JPush wakeups, foreground-service callbacks, broadcast
-    // receivers, post-download relaunches — don't bump the counter when
-    // they never bring up the UI. Counter is reset by MainActivity.onStop
-    // on graceful background, and by RecoveryActivity after the user
-    // resolves recovery.
-    int currentCount = prefs.getInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, 0);
 
     // Harness tests create this marker file via globalSetup so the recovery
     // page never blocks React Native from starting during test runs.
     boolean isHarnessMode = new java.io.File(getFilesDir(), "harness_mode").exists();
-    // Predicts the post-increment value: MainActivity.onCreate will bump
-    // currentCount by 1 right after Application init. Keeping the literal
-    // `>= 3` here preserves the original "3 strikes" semantic — recovery
-    // triggers on the 3rd consecutive failed user-launch, not the 4th.
-    shouldShowRecovery = !isHarnessMode && (currentCount + 1) >= 3;
+
+    // Read-only here. MainApplication never increments — that's MainActivity's
+    // job (`recordBootAttempt`). System-initiated process launches (JPush
+    // wakeups, foreground-service callbacks, broadcast receivers, post-
+    // download relaunches) run Application.onCreate but NOT MainActivity,
+    // so the counter stays untouched and bg-launches don't count as failures.
+    //
+    // No +1 prediction either: predicting `(windowed + 1) >= threshold` would
+    // skip RN/JPush init on bg-launches when the previous user-launches were
+    // already approaching the threshold, silently dropping the wakeup. We
+    // take the small cost of running RN init on the strike that triggers
+    // recovery — MainActivity re-evaluates post-increment and launches
+    // RecoveryActivity itself.
+    int windowedFailures = BootRecoveryStore.readWindowedCount(prefs);
+    shouldShowRecovery = !isHarnessMode
+        && windowedFailures >= BootRecoveryKeys.RECOVERY_THRESHOLD;
 
     long tBeforeSuper = System.currentTimeMillis();
     super.onCreate();
@@ -330,7 +337,11 @@ public class MainApplication extends Application implements ReactApplication {
       "android.app.new_arch_load: " + (tAfterNewArch - tAfterSoLoader) + "ms (+" + (tAfterNewArch - appLaunchMs) + "ms from launch)"
     );
 
-    OneKeyLog.info("BootRecovery", "boot_fail_count(app.read): " + currentCount + ", shouldShowRecovery: " + shouldShowRecovery);
+    OneKeyLog.info(
+      "BootRecovery",
+      "boot_fail_count(activity.windowed): " + windowedFailures
+        + ", shouldShowRecovery: " + shouldShowRecovery
+    );
 
     if (shouldShowRecovery) {
         // Skip heavy initialization (React Native, Expo, JPush).

--- a/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/RecoveryActivity.java
+++ b/apps/mobile/android/app/src/main/java/so/onekey/app/wallet/RecoveryActivity.java
@@ -257,7 +257,9 @@ public class RecoveryActivity extends AppCompatActivity {
             // Clear app cache
             clearAppCache();
 
-            // Reset counter and set recovery action (single atomic write)
+            // Reset counter and set recovery action (single atomic write).
+            // Timestamps are invalidated implicitly via the freshness signal
+            // (integer == 0), so no explicit clear is needed.
             SharedPreferences prefs = getSharedPreferences(BootRecoveryKeys.PREFS_NAME, MODE_PRIVATE);
             prefs.edit()
                 .putInt(BootRecoveryKeys.CONSECUTIVE_BOOT_FAIL_COUNT, 0)

--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - AesCrypto (3.0.36):
+  - AesCrypto (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -37,7 +37,7 @@ PODS:
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
-  - AsyncStorage (3.0.36):
+  - AsyncStorage (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -65,7 +65,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - AutoSizeInput (3.0.36):
+  - AutoSizeInput (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -95,7 +95,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - BackgroundThread (3.0.36):
+  - BackgroundThread (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -157,7 +157,7 @@ PODS:
     - ExpoModulesCore
     - SPAlert (~> 4.2)
     - SPIndicator (~> 1.6)
-  - CloudFs (3.0.36):
+  - CloudFs (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -185,7 +185,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - CloudKitModule (3.0.36):
+  - CloudKitModule (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -219,7 +219,7 @@ PODS:
   - CocoaLumberjack/Core (3.9.0)
   - CocoaLumberjack/Swift (3.9.0):
     - CocoaLumberjack/Core
-  - DnsLookup (3.0.36):
+  - DnsLookup (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -439,7 +439,7 @@ PODS:
   - JPushRN (3.2.1):
     - React
   - JuiceboxSdk (0.3.2)
-  - KeychainModule (3.0.36):
+  - KeychainModule (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -516,7 +516,7 @@ PODS:
     - MMKVCore (~> 2.2.4)
   - MMKVCore (2.2.4)
   - MultiplatformBleAdapter (0.2.0)
-  - NetworkInfo (3.0.36):
+  - NetworkInfo (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -604,7 +604,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - Pbkdf2 (3.0.36):
+  - Pbkdf2 (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -632,7 +632,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - Ping (3.0.36):
+  - Ping (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -2576,7 +2576,7 @@ PODS:
     - Yoga
   - react-native-netinfo (11.4.1):
     - React-Core
-  - react-native-pager-view (3.0.36):
+  - react-native-pager-view (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -2778,7 +2778,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-tab-view (3.0.36):
+  - react-native-tab-view (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -2796,7 +2796,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-tab-view/common (= 3.0.36)
+    - react-native-tab-view/common (= 3.0.37)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -2807,7 +2807,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-tab-view/common (3.0.36):
+  - react-native-tab-view/common (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -3484,7 +3484,7 @@ PODS:
     - React-perflogger (= 0.81.5)
     - React-utils (= 0.81.5)
     - SocketRocket
-  - ReactNativeAppUpdate (3.0.36):
+  - ReactNativeAppUpdate (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -3515,7 +3515,7 @@ PODS:
     - ReactNativeNativeLogger
     - SocketRocket
     - Yoga
-  - ReactNativeBundleUpdate (3.0.36):
+  - ReactNativeBundleUpdate (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -3576,7 +3576,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ReactNativeCheckBiometricAuthChanged (3.0.36):
+  - ReactNativeCheckBiometricAuthChanged (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -3607,7 +3607,7 @@ PODS:
     - ReactNativeNativeLogger
     - SocketRocket
     - Yoga
-  - ReactNativeDeviceUtils (3.0.36):
+  - ReactNativeDeviceUtils (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -3666,7 +3666,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ReactNativeGetRandomValues (3.0.36):
+  - ReactNativeGetRandomValues (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -3697,7 +3697,7 @@ PODS:
     - ReactNativeNativeLogger
     - SocketRocket
     - Yoga
-  - ReactNativeLiteCard (3.0.36):
+  - ReactNativeLiteCard (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -3726,7 +3726,7 @@ PODS:
     - ReactNativeNativeLogger
     - SocketRocket
     - Yoga
-  - ReactNativeNativeLogger (3.0.36):
+  - ReactNativeNativeLogger (3.0.37):
     - boost
     - CocoaLumberjack/Swift (~> 3.8)
     - DoubleConversion
@@ -3759,7 +3759,7 @@ PODS:
     - Yoga
   - ReactNativePasskeys (0.3.3):
     - ExpoModulesCore
-  - ReactNativePerfMemory (3.0.36):
+  - ReactNativePerfMemory (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -3790,7 +3790,7 @@ PODS:
     - ReactNativeNativeLogger
     - SocketRocket
     - Yoga
-  - ReactNativePerfStats (3.0.36):
+  - ReactNativePerfStats (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -3821,7 +3821,7 @@ PODS:
     - ReactNativeNativeLogger
     - SocketRocket
     - Yoga
-  - ReactNativeSplashScreen (3.0.36):
+  - ReactNativeSplashScreen (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -4365,7 +4365,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ScrollGuard (3.0.36):
+  - ScrollGuard (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -4404,7 +4404,7 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
   - Sentry/HybridSDK (8.56.2)
-  - Skeleton (3.0.36):
+  - Skeleton (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -4468,7 +4468,7 @@ PODS:
   - SocketRocket (0.7.1)
   - SPAlert (4.2.0)
   - SPIndicator (1.6.4)
-  - SplitBundleLoader (3.0.36):
+  - SplitBundleLoader (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -4498,7 +4498,7 @@ PODS:
     - SocketRocket
     - Yoga
   - SSZipArchive (2.5.5)
-  - TcpSocket (3.0.36):
+  - TcpSocket (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -4528,7 +4528,7 @@ PODS:
     - Yoga
   - TOCropViewController (2.8.1)
   - Yoga (0.0.0)
-  - ZipArchive (3.0.36):
+  - ZipArchive (3.0.37):
     - boost
     - DoubleConversion
     - fast_float
@@ -5118,19 +5118,19 @@ CHECKOUT OPTIONS:
     :git: https://github.com/OneKeyHQ/app-modules.git
 
 SPEC CHECKSUMS:
-  AesCrypto: 1af04cb7c3272947d4e96e38aa23e1f02b88d520
+  AesCrypto: 67fc32fe6ccbd31dbccb0af462b26f7b6a8bbdd2
   AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
-  AsyncStorage: bdbbf309fb672d8dd9976a13e45254cc589e7d08
-  AutoSizeInput: 9926a0dd8e17ea219f14deca92a6543a5dab0fdf
-  BackgroundThread: 20b27ebe307f90dfb82745605e1bbb783e804837
+  AsyncStorage: 937339618b55d5df45f26f13d6463a499803cb3a
+  AutoSizeInput: f2139586efe28b666f8027f98e43daf18680ceb2
+  BackgroundThread: e03ffe5743dd12b2f9c08b3370cfc608f098fb9d
   BleUtils: 0fd18e5fd2732c89771dc79941c7320ac9c42015
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   Burnt: e3a3397e26172fca31a59bb27421475a58068836
-  CloudFs: 31d00ea4f153a464e87a2edc764c0ebf410e352c
-  CloudKitModule: cf4bca84208b893be32ba7554edfd675c641a048
+  CloudFs: 890edcde023d69a4915697a5037c866686258b85
+  CloudKitModule: 6758f134bfbeedc51da1f3e5eb5913778c45fa42
   CocoaLumberjack: 5644158777912b7de7469fa881f8a3f259c2512a
-  DnsLookup: eaeba555191a38ce00f6e47311221ec24f2938c7
+  DnsLookup: 6e65f413a7838fa10d21cfe4c920cbeff047f445
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   EMASCurl: 50940d5e8e695aa85d153514e184f897dc1ca2a7
   EXApplication: 296622817d459f46b6c5fe8691f4aac44d2b79e7
@@ -5178,18 +5178,18 @@ SPEC CHECKSUMS:
   JCoreRN: d985de509185b381c177fde4bb6bfc686089fdbd
   JPushRN: 807bc962b2f25860e5c0caa5fcb7b4910572b890
   JuiceboxSdk: b2222491ce92b263694c217ea202a54b66c5ec5f
-  KeychainModule: 3d44344f6854e6120131c7d09a5f0c11e7838990
+  KeychainModule: 83836349fb50cb6966c013c91622adc8214dfd84
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
   lottie-react-native: 86fa7488b1476563f41071244aa73d5b738faf19
   MMKV: 1a8e7dbce7f9cad02c52e1b1091d07bd843aefaf
   MMKVCore: f2dd4c9befea04277a55e84e7812f930537993df
   MultiplatformBleAdapter: b1fddd0d499b96b607e00f0faa8e60648343dc1d
-  NetworkInfo: fe686e3789a31c17a220ec07a3470064d4057648
+  NetworkInfo: 797a86072b272fec5b3346a1b06a8bfe208e42c7
   NitroMmkv: ce1df9b9f0e06dfbde2455d863047e0411fceb6e
   NitroModules: 11bba9d065af151eae51e38a6425e04c3b223ff3
-  Pbkdf2: fd565a184817751196cefdfc7c40618215c161bc
-  Ping: c3e48fea2c67d5d074d0eea92ca19789028e9baa
+  Pbkdf2: 71418bb05eba5243b3e7bdbe79abc8503cac49d6
+  Ping: 6c5e4d5e86d363277c7a0bbc581907cb8ee2ae20
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PurchasesHybridCommon: f1650b33e9a1dd04d5e8a40dfe757f39e63f935c
   RCT-Folly: b29feb752b08042c62badaef7d453f3bb5e6ae23
@@ -5232,11 +5232,11 @@ SPEC CHECKSUMS:
   react-native-document-picker: dc2d83366e47e89e7c51e8a41eab99c1d54e941c
   react-native-keyboard-controller: dbf568b5d029cdc5b26667a7c2323b160c25dc00
   react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
-  react-native-pager-view: 46fcdd5f587c4ef4a1236e97d3b00601e64c9f27
+  react-native-pager-view: d34ce4dc163d625776964ade5c8a5da87112eaaa
   react-native-safe-area-context: c00143b4823773bba23f2f19f85663ae89ceb460
   react-native-skia: fc73e9bdc46ebb420a98c9c2be29fee80f565e79
   react-native-slider: 663776e5683e257de8df8091abc2d93ff6ec67db
-  react-native-tab-view: f2f4f74ffd2c8eb10773a5001a64781a1ead7c96
+  react-native-tab-view: 10b92cbdca037cf7f132ba213abfb29ba25679d2
   react-native-video: 7b821291837d8ba7b9d7574bfeb0cd651e910141
   react-native-view-shot: 6c008e58f4720de58370848201c5d4a082c6d4ca
   react-native-webview: 4cbb7f05f2c50671a7dcff4012d3e85faad271e4
@@ -5271,19 +5271,19 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 1bcd3527ac0390a1c898c114f81ff954be35ed79
   ReactCodegen: 0c47bcad3576258ef1a91e2ec1fd43afae72e85f
   ReactCommon: 5f0e5c09a64a2717215dd84380e1a747810406f2
-  ReactNativeAppUpdate: 311136d0e4cd328e3d89574d374717e39a6a9ffe
-  ReactNativeBundleUpdate: 92eda8e1dfb761c60068ceef442cbc9481753d8a
+  ReactNativeAppUpdate: e0a9f87dee5be04d349b47ad63407b64f9e564a5
+  ReactNativeBundleUpdate: cf9965fbd2f06d5f54f074615ac4892dfb3079b6
   ReactNativeCameraKit: 84894fc476300e5d3b9f4e34f55ff75050ec5050
-  ReactNativeCheckBiometricAuthChanged: a1255ec2a28bf7952823aadd770bd0304a0b8ac8
-  ReactNativeDeviceUtils: 8058bd6a500cfebc8816b0320ffd3406f1c9919f
+  ReactNativeCheckBiometricAuthChanged: cba537781ec3b9e23031af59de44b124d7df3b01
+  ReactNativeDeviceUtils: 36be53c69fbe2be9b72914d7117b0c27e85c71d9
   ReactNativeFs: fa4d6c721fedd16abb5a7eb5c591303f147677b5
-  ReactNativeGetRandomValues: c7c91e9d01f6f1674e5d9913dd5a9740a49ddcde
-  ReactNativeLiteCard: 5618a1cee906955c276409a1865ecb6d48f5ea45
-  ReactNativeNativeLogger: 7f4a428bcba878d9c576539df58615e422cd53a0
+  ReactNativeGetRandomValues: d44dc14ac15f1a19978e04ac9b4ca828054c03c5
+  ReactNativeLiteCard: 0489a21ee4872bfe34b113271dde1f38a8ac384a
+  ReactNativeNativeLogger: e7768234414a1ca3b75e90df2b4c658782085908
   ReactNativePasskeys: 9e950e8cbf0e7d6aad9df4dcd21cee0efeb4e5cd
-  ReactNativePerfMemory: 6f720fb3d8fe6786fcdec746afd74af912b48834
-  ReactNativePerfStats: b736f3d4afded481862a1bf833b6f1cab7a7ebaa
-  ReactNativeSplashScreen: ab8b5cc5ee4eaecd4153b0ef6f99bfaf5139f7f3
+  ReactNativePerfMemory: d34ba9b2171d75c22af0e9298278f43c1889adce
+  ReactNativePerfStats: f5539d50fe82fcdb5bdadf6cfc7ced19fcfed8d8
+  ReactNativeSplashScreen: 1556f619e9077a7a6cea170f7d2c3ddf74d32f22
   RealmJS: 1c37c6bdfe060f4caa0f9175aa0eedb962622ee1
   RevenueCat: 7e1d0768fb287c9983173c9b28e39ccbeeb828a9
   RNGestureHandler: e37bdb684df1ac17c7e1d8f71a3311b2793c186b
@@ -5298,22 +5298,22 @@ SPEC CHECKSUMS:
   RNSentry: a20c5194cc6d7902683276f399a6eb5206fb9f05
   RNSVG: d260beec1775108e1bd065a0ed666ff2c5565158
   RNWorklets: 8068c8af4b241eb2c19221310729e4c440bee023
-  ScrollGuard: eb70b6fae677155259f77102bea3536636d55876
+  ScrollGuard: 4de2932bd258d5525d2800386b2f9fbf94d9b003
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   Sentry: b53951377b78e21a734f5dc8318e333dbfc682d7
-  Skeleton: b9f76e1e96258ecd41426366151fe458d0fb9f47
+  Skeleton: 59aa3e22e4348ff72062e6f15e059eb398c3f92c
   SniConnect: c92bce3bb3204c4cff031c0badb7aefaebee8f04
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SPAlert: 735da1f16a887e294719217572ce1f936d8c8782
   SPIndicator: 93e0a4fb23de51294ac48e874c0f081a5e293e4f
-  SplitBundleLoader: 12807b52fb6dc831ad667ffdc29a16f7ee9f5dc3
+  SplitBundleLoader: 33b617167ad9d456ba5e1e13434d72032e8dbfb9
   SSZipArchive: c69881e8ac5521f0e622291387add5f60f30f3c4
-  TcpSocket: 72c5d885352c7d04149f9e4f181cf1fde0961361
+  TcpSocket: 60875f126b9632c3e008672330382f388f827d40
   TOCropViewController: f7863f38e4c5f45a5db9b52c4a2cc759a61ab550
   Yoga: 728df40394d49f3f471688747cf558158b3a3bd1
-  ZipArchive: 8cb6634ebd3e6514eb53f4332689be518804d8de
+  ZipArchive: 31447105c574b16229debe2c7832b5b4ed6147d7
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 2430ff9e6b7aa2cc39982650e3ad77e67fc8093d

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -698,6 +698,33 @@ class ServiceAppUpdate extends ServiceBase {
     }));
   }
 
+  /**
+   * Self-heal hook for the failed → resuming race. Native progress events
+   * keep firing while status sits at downloadPackageFailed when the
+   * previous attempt rejected JS-side but native's transfer outlived the
+   * rejection, or the AppState 'active' resume path didn't propagate
+   * cleanly through serviceAppUpdate.downloadPackage. Flipping status
+   * back here lets the UI catch up with reality.
+   *
+   * No-op unless status is exactly downloadPackageFailed — never touches
+   * a healthy in-progress or post-download state. Idempotent against
+   * repeat calls because the second one reads status === downloadPackage
+   * and returns immediately.
+   */
+  @backgroundMethod()
+  async onDownloadProgressHeartbeat(): Promise<void> {
+    const { status } = await appUpdatePersistAtom.get();
+    if (status !== EAppUpdateStatus.downloadPackageFailed) return;
+    defaultLogger.app.appUpdate.log(
+      'onDownloadProgressHeartbeat: native still progressing while status=failed → healing to downloadPackage',
+    );
+    await appUpdatePersistAtom.set((prev) => ({
+      ...prev,
+      status: EAppUpdateStatus.downloadPackage,
+      errorText: undefined,
+    }));
+  }
+
   @backgroundMethod()
   updateErrorText(status: EAppUpdateStatus, errorText: string) {
     void appUpdatePersistAtom.set((prev) => ({

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -713,16 +713,38 @@ class ServiceAppUpdate extends ServiceBase {
    */
   @backgroundMethod()
   async onDownloadProgressHeartbeat(): Promise<void> {
-    const { status } = await appUpdatePersistAtom.get();
-    if (status !== EAppUpdateStatus.downloadPackageFailed) return;
+    // Functional set with a re-check inside the updater closes the
+    // get-then-set window: status may have already advanced to
+    // downloadASC / verifyASC / done by the time we set, and we must
+    // not regress those healthy states back to downloadPackage.
+    let healed = false;
+    await appUpdatePersistAtom.set((prev) => {
+      if (prev.status !== EAppUpdateStatus.downloadPackageFailed) return prev;
+      healed = true;
+      return {
+        ...prev,
+        status: EAppUpdateStatus.downloadPackage,
+        errorText: undefined,
+      };
+    });
+    if (!healed) return;
     defaultLogger.app.appUpdate.log(
       'onDownloadProgressHeartbeat: native still progressing while status=failed → healing to downloadPackage',
     );
-    await appUpdatePersistAtom.set((prev) => ({
-      ...prev,
-      status: EAppUpdateStatus.downloadPackage,
-      errorText: undefined,
-    }));
+    // Restart the 30-min watchdog so we never get stuck silently when
+    // native progress stalls or the JS download Promise is dead (e.g.,
+    // the previous JS instance was killed and the foreground download
+    // outlived it). Without this, percent could hit 100% but no further
+    // step transitions would ever fire.
+    clearTimeout(downloadTimeoutId);
+    downloadTimeoutId = setTimeout(
+      async () => {
+        await this.downloadPackageFailed({
+          message: ETranslations.update_download_timed_out_check_connection,
+        });
+      },
+      timerUtils.getTimeDurationMs({ minute: 30 }),
+    );
   }
 
   @backgroundMethod()

--- a/packages/kit/src/views/AppUpdate/pages/DownloadVerify.tsx
+++ b/packages/kit/src/views/AppUpdate/pages/DownloadVerify.tsx
@@ -139,6 +139,19 @@ function DownloadVerify({
 
   const percent = useDownloadProgress();
 
+  // Self-heal stale failure UI: native progress events imply the download
+  // is actually running. If the atom still says downloadPackageFailed
+  // (race in the AppState 'active' resume path or a previous JS
+  // rejection that outlived the native transfer), nudge bg to flip
+  // status back. percent is integer-bucketed so this fires ~once per
+  // 1% change — the bg method is cheap and a no-op outside the failed
+  // status.
+  useEffect(() => {
+    if (percent > 0 && data.status === EAppUpdateStatus.downloadPackageFailed) {
+      void backgroundApiProxy.serviceAppUpdate.onDownloadProgressHeartbeat();
+    }
+  }, [percent, data.status]);
+
   const renderDownloadError = useCallback(
     () => (
       <HyperlinkText

--- a/packages/shared/src/logger/scopes/app/index.ts
+++ b/packages/shared/src/logger/scopes/app/index.ts
@@ -3,6 +3,7 @@ import { EScopeName } from '../../types';
 
 import { AppUpdateScene } from './scenes/appUpdate';
 import { BackgroundScene } from './scenes/background';
+import { BootRecoveryScene } from './scenes/bootRecovery';
 import { BootstrapScene } from './scenes/bootstrap';
 import { ComponentScene } from './scenes/component';
 import { CustomUAScene } from './scenes/customUA';
@@ -42,6 +43,8 @@ export class AppScope extends BaseScope {
   router = this.createScene('router', RouterScene);
 
   appUpdate = this.createScene('appUpdate', AppUpdateScene);
+
+  bootRecovery = this.createScene('bootRecovery', BootRecoveryScene);
 
   jsBundleDev = this.createScene('jsBundleDev', JsBundleDevScene);
 

--- a/packages/shared/src/logger/scopes/app/scenes/bootRecovery.ts
+++ b/packages/shared/src/logger/scopes/app/scenes/bootRecovery.ts
@@ -1,0 +1,13 @@
+import { BaseScene } from '../../../base/baseScene';
+import { LogToLocal } from '../../../base/decorators';
+
+// Dedicated channel for BootRecovery health monitoring (markBootSuccess,
+// counter inspection, recovery decisions). Kept separate from `appUpdate`
+// so post-incident filtering for "why didn't markBootSuccess take effect?"
+// doesn't have to wade through OTA traffic.
+export class BootRecoveryScene extends BaseScene {
+  @LogToLocal({ level: 'info' })
+  public log(message: string) {
+    return message;
+  }
+}

--- a/packages/shared/src/modules3rdParty/appRestart/index.native.ts
+++ b/packages/shared/src/modules3rdParty/appRestart/index.native.ts
@@ -1,4 +1,5 @@
 import { BackgroundThread } from '@onekeyfe/react-native-background-thread';
+import { ReactNativeDeviceUtils } from '@onekeyfe/react-native-device-utils';
 
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import BootRecovery from '@onekeyhq/shared/src/modules/BootRecovery';
@@ -25,10 +26,29 @@ export const appRestart: IAppRestart = async (opts: IAppRestartOptions) => {
   // Reset the boot-fail counter ahead of the planned restart so the JS
   // reload is not misinterpreted as a crash-loop by BootRecovery. Best
   // effort — recovery must not block the restart.
+  //
+  // Past production logs on Xiaomi-class Android showed the post-restart
+  // MainApplication.onCreate reading a stale non-zero count even though
+  // this path was supposed to clear it. The previous silent catch hid
+  // which branch failed (call threw / call landed but write was lost /
+  // wasn't reached at all), so each branch is now logged explicitly and
+  // a read-back proves the SharedPreferences write actually hit disk.
   try {
     BootRecovery.markBootSuccess();
-  } catch {
-    /* ignore */
+    // Same Nitro module, separate sync-style getter. .commit() is
+    // documented synchronous, but if a race with Runtime.exit ever
+    // swallows the flush we want evidence, not guesswork.
+    const countAfter =
+      await ReactNativeDeviceUtils.getConsecutiveBootFailCount();
+    defaultLogger.app.appUpdate.log(
+      `appRestart: markBootSuccess ok, count_after=${countAfter}`,
+    );
+  } catch (err) {
+    defaultLogger.app.appUpdate.log(
+      `appRestart: markBootSuccess threw: ${
+        (err as Error)?.message ?? String(err)
+      }`,
+    );
   }
 
   await BackgroundThread.restart(opts.mode, opts.reason);

--- a/packages/shared/src/modules3rdParty/appRestart/index.native.ts
+++ b/packages/shared/src/modules3rdParty/appRestart/index.native.ts
@@ -40,11 +40,11 @@ export const appRestart: IAppRestart = async (opts: IAppRestartOptions) => {
     // swallows the flush we want evidence, not guesswork.
     const countAfter =
       await ReactNativeDeviceUtils.getConsecutiveBootFailCount();
-    defaultLogger.app.appUpdate.log(
+    defaultLogger.app.bootRecovery.log(
       `appRestart: markBootSuccess ok, count_after=${countAfter}`,
     );
   } catch (err) {
-    defaultLogger.app.appUpdate.log(
+    defaultLogger.app.bootRecovery.log(
       `appRestart: markBootSuccess threw: ${
         (err as Error)?.message ?? String(err)
       }`,


### PR DESCRIPTION
## Summary

Two independent Android app-update reliability fixes uncovered while debugging a Xiaomi log where the recovery page appeared after backgrounding during a long bundle download.

### 1. BootRecovery false positive on bg-launched process
- `MainApplication.onCreate` used to unconditionally `+1` the consecutive-boot-fail counter, so JPush wakeups, post-download relaunch callbacks, broadcast receivers, etc. all looked like failed boot attempts even when MainActivity never showed up.
- Counter +1 now happens in `MainActivity.onCreate` (the actual user-launch signal). `MainApplication` only reads it; `shouldShowRecovery` uses `(currentCount + 1) >= 3` to preserve the original 3-strikes semantic.
- `appRestart/index.native.ts`: silent catch around `BootRecovery.markBootSuccess()` is now logged with a read-back self-check so future regressions surface in production logs instead of staying invisible.

### 2. DownloadVerify shows failed UI while download is actually progressing
- When a previous download attempt rejects JS-side but native's transfer outlives the rejection (or the AppState 'active' resume path doesn't propagate cleanly through `serviceAppUpdate.downloadPackage`), the atom status sits at `downloadPackageFailed` while native progress events keep ticking. Users see red X + retry button + a growing percent badge — contradictory UI.
- New `ServiceAppUpdate.onDownloadProgressHeartbeat` background method: no-op unless status is exactly `downloadPackageFailed`, otherwise flips status back to `downloadPackage` and clears `errorText`. Idempotent.
- `DownloadVerify` adds a `useEffect` watching `(percent, data.status)` to call the heartbeat. Triggers ~once per 1% (percent is integer-bucketed) and only when the page is genuinely stuck on the failed state.

## Test plan
- [ ] **Xiaomi/MIUI** Android device: start a bundle download, background app for several minutes during download, foreground — recovery page must NOT appear.
- [ ] Same device: trigger a real `runDownloadWithRetry` exhaustion (e.g. airplane mode), confirm the failed UI shows correctly; restore connectivity and re-foreground — UI should self-heal back to the in-progress state once native progress events resume.
- [ ] DevSettings → `setConsecutiveBootFailCount(3)` → foreground: recovery page still triggers (normal path not broken).
- [ ] Active `serviceApp.restartApp({mode:'all'})` flows (language switch, currency switch): no recovery loop, `adb logcat -s OneKey.BootRecovery` shows `boot_fail_count(activity): 0 -> 1` after restart.
- [ ] Look for `onDownloadProgressHeartbeat: native still progressing while status=failed → healing` in app logs after a stuck-failure reproduction.