### PR TITLE
fix: improve borrow market and redeem flow

### DIFF
--- a/packages/kit/src/views/Borrow/BorrowProvider.tsx
+++ b/packages/kit/src/views/Borrow/BorrowProvider.tsx
@@ -48,7 +48,9 @@ const defaultAsyncData = <T,>(data: T): IAsyncData<T> => ({
 type IBorrowContextValue = {
   // Market (sync data)
   market: IBorrowMarketItem | null;
+  markets: IBorrowMarketItem[];
   setMarket: React.Dispatch<React.SetStateAction<IBorrowMarketItem | null>>;
+  setMarkets: React.Dispatch<React.SetStateAction<IBorrowMarketItem[]>>;
 
   // Async data requests - unified format
   earnAccount: IAsyncData<IBorrowEarnAccount>;
@@ -80,12 +82,18 @@ const defaultSwapConfig: ISwapConfig = {
 
 const BorrowContext = createContext<IBorrowContextValue | null>(null);
 
+export const buildBorrowMarketKey = (market?: IBorrowMarketItem | null) =>
+  market
+    ? `${market.provider}-${market.networkId}-${market.marketAddress}`
+    : '';
+
 export const BorrowProvider = ({
   children,
 }: PropsWithChildren<{
   value?: IBorrowContextValue;
 }>) => {
   const [market, setMarket] = useState<IBorrowMarketItem | null>(null);
+  const [markets, setMarkets] = useState<IBorrowMarketItem[]>([]);
   const [earnAccount, setEarnAccount] = useState<
     IAsyncData<IBorrowEarnAccount>
   >(defaultAsyncData(null));
@@ -130,7 +138,9 @@ export const BorrowProvider = ({
   const contextValue = useMemo(
     () => ({
       market,
+      markets,
       setMarket,
+      setMarkets,
       earnAccount,
       setEarnAccount,
       reserves,
@@ -145,6 +155,7 @@ export const BorrowProvider = ({
     }),
     [
       market,
+      markets,
       earnAccount,
       reserves,
       borrowDataStatus,

--- a/packages/kit/src/views/Borrow/components/BorrowDataGate.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowDataGate.tsx
@@ -15,7 +15,7 @@ import type { IBorrowReserveItem } from '@onekeyhq/shared/types/staking';
 
 import { useEarnAccount } from '../../Staking/hooks/useEarnAccount';
 import { EBorrowDataStatus } from '../borrowDataStatus';
-import { useBorrowContext } from '../BorrowProvider';
+import { buildBorrowMarketKey, useBorrowContext } from '../BorrowProvider';
 import { useBorrowMarkets } from '../hooks/useBorrowMarkets';
 import { useBorrowReserves } from '../hooks/useBorrowReserves';
 
@@ -40,21 +40,46 @@ export const BorrowDataGate = ({
     isLoading: marketsLoading,
     refetchMarkets,
   } = useBorrowMarkets({ isActive: isViewActive });
-  const market = useMemo(() => markets?.[0], [markets]);
+  const availableMarkets = useMemo(() => markets ?? [], [markets]);
   const borrowNetworkIds = useMemo(() => {
-    const ids = (markets ?? []).map((item) => item.networkId);
+    const ids = availableMarkets.map((item) => item.networkId);
     return [
       ...new Set(
         ids.filter((networkId): networkId is string => Boolean(networkId)),
       ),
     ];
-  }, [markets]);
+  }, [availableMarkets]);
   useEffect(() => {
     onBorrowNetworksChange?.(borrowNetworkIds);
   }, [borrowNetworkIds, onBorrowNetworksChange, isViewActive]);
 
-  const { setMarket, setReserves, setEarnAccount, setBorrowDataStatus } =
-    useBorrowContext();
+  const {
+    market,
+    setMarkets,
+    setMarket,
+    setReserves,
+    setEarnAccount,
+    setBorrowDataStatus,
+  } = useBorrowContext();
+
+  useEffect(() => {
+    setMarkets(availableMarkets);
+  }, [availableMarkets, setMarkets]);
+
+  useEffect(() => {
+    setMarket((currentMarket) => {
+      if (!availableMarkets.length) {
+        return currentMarket ? null : currentMarket;
+      }
+
+      const currentMarketKey = buildBorrowMarketKey(currentMarket);
+      const refreshedCurrentMarket = availableMarkets.find(
+        (item) => buildBorrowMarketKey(item) === currentMarketKey,
+      );
+
+      return refreshedCurrentMarket ?? availableMarkets[0];
+    });
+  }, [availableMarkets, setMarket]);
 
   const { activeAccount } = useActiveAccount({ num: 0 });
   const {
@@ -128,9 +153,11 @@ export const BorrowDataGate = ({
   const fetchKey = useMemo(
     () =>
       !isEmpty(market)
-        ? `${marketProvider}-${marketAddress}-${accountId ?? 'public'}`
+        ? `${marketProvider}-${marketNetworkId}-${marketAddress}-${
+            accountId ?? 'public'
+          }`
         : null,
-    [market, marketProvider, marketAddress, accountId],
+    [market, marketProvider, marketNetworkId, marketAddress, accountId],
   );
 
   // Invalidate before usePromiseResult reruns for the new key; a later effect
@@ -261,10 +288,6 @@ export const BorrowDataGate = ({
     }
     wasActiveRef.current = isViewActive;
   }, [isViewActive, refetchMarkets, refreshReserves]);
-
-  useEffect(() => {
-    setMarket(market ?? null);
-  }, [market, setMarket]);
 
   useEffect(() => {
     setBorrowDataStatus(dataStatus);

--- a/packages/kit/src/views/Borrow/components/Markets.tsx
+++ b/packages/kit/src/views/Borrow/components/Markets.tsx
@@ -1,32 +1,121 @@
-import { XStack, YStack } from '@onekeyhq/components';
+import { useCallback, useMemo } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import {
+  type ISelectRenderTriggerProps,
+  Icon,
+  Select,
+  SizableText,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import { Token } from '@onekeyhq/kit/src/components/Token';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import type { IBorrowMarketItem } from '@onekeyhq/shared/types/staking';
 
-import { EarnText } from '../../Staking/components/ProtocolDetails/EarnText';
-import { useBorrowContext } from '../BorrowProvider';
+import { buildBorrowMarketKey, useBorrowContext } from '../BorrowProvider';
+import { BorrowTestIDs } from '../testIDs';
 
-export const Markets = () => {
-  const { market } = useBorrowContext();
-
+function MarketTrigger({
+  market,
+  showChevron,
+  onPress,
+}: {
+  market: IBorrowMarketItem | null;
+  showChevron?: boolean;
+  onPress?: ISelectRenderTriggerProps['onPress'];
+}) {
   return (
-    <XStack mb="$4" h="$14" ai="center" gap="$3">
+    <XStack
+      mb="$4"
+      h="$14"
+      ai="center"
+      gap="$3"
+      maxWidth="100%"
+      cursor={showChevron ? 'pointer' : undefined}
+      onPress={onPress}
+    >
       <Token
         isNFT
         source={market?.logoURI}
         networkImageUri={market?.network.logoURI}
         size="md"
       />
-      <YStack>
-        <EarnText
-          text={{ text: market?.network.name ?? '' }}
-          size="$bodySm"
-          color="$textSubdued"
-        />
-        <EarnText
-          text={{ text: market?.name ?? '' }}
-          size="$bodyLgMedium"
-          color="$textText"
-        />
+      <YStack flex={1} minWidth={0}>
+        <SizableText size="$bodySm" color="$textSubdued" numberOfLines={1}>
+          {market?.network.name ?? ''}
+        </SizableText>
+        <SizableText size="$bodyLgMedium" color="$text" numberOfLines={1}>
+          {market?.name ?? ''}
+        </SizableText>
       </YStack>
+      {showChevron ? (
+        <Icon
+          flexShrink={0}
+          name="ChevronDownSmallOutline"
+          size="$5"
+          color="$iconSubdued"
+        />
+      ) : null}
     </XStack>
+  );
+}
+
+export const Markets = () => {
+  const intl = useIntl();
+  const { market, markets, setMarket } = useBorrowContext();
+  const selectedMarket = market ?? markets[0] ?? null;
+  const selectedMarketKey = selectedMarket
+    ? buildBorrowMarketKey(selectedMarket)
+    : undefined;
+  const marketItems = useMemo(
+    () =>
+      markets.map((item) => ({
+        label: item.name,
+        value: buildBorrowMarketKey(item),
+        description: item.network.name,
+        leading: (
+          <Token
+            isNFT
+            source={item.logoURI}
+            networkImageUri={item.network.logoURI}
+            size="sm"
+          />
+        ),
+      })),
+    [markets],
+  );
+
+  const handleMarketChange = useCallback(
+    (value: string | number | boolean | undefined) => {
+      if (typeof value !== 'string') {
+        return;
+      }
+      const nextMarket = markets.find(
+        (item) => buildBorrowMarketKey(item) === value,
+      );
+      if (nextMarket) {
+        setMarket(nextMarket);
+      }
+    },
+    [markets, setMarket],
+  );
+
+  if (markets.length <= 1) {
+    return <MarketTrigger market={selectedMarket} />;
+  }
+
+  return (
+    <Select
+      testID={BorrowTestIDs.marketSelect}
+      title={intl.formatMessage({ id: ETranslations.global_market })}
+      items={marketItems}
+      value={selectedMarketKey}
+      onChange={handleMarketChange}
+      renderTrigger={({ onPress }) => (
+        <MarketTrigger market={selectedMarket} showChevron onPress={onPress} />
+      )}
+    />
   );
 };

--- a/packages/kit/src/views/Borrow/hooks/useBorrowMarkets.ts
+++ b/packages/kit/src/views/Borrow/hooks/useBorrowMarkets.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import type { IBorrowMarketItem } from '@onekeyhq/shared/types/staking';
@@ -22,7 +22,7 @@ export const useBorrowMarkets = ({
   const {
     result: markets,
     isLoading = true,
-    run: refetchMarkets,
+    run: runFetchMarkets,
   } = usePromiseResult(
     async () => {
       const cached = marketsRef.current ?? defaultMarkets;
@@ -56,6 +56,11 @@ export const useBorrowMarkets = ({
       marketsRef.current = markets;
     }
   }, [markets]);
+
+  const refetchMarkets = useCallback(async () => {
+    lastUpdatedAtRef.current = null;
+    await runFetchMarkets({ alwaysSetState: true });
+  }, [runFetchMarkets]);
 
   return { markets, isLoading, refetchMarkets };
 };

--- a/packages/kit/src/views/Borrow/pages/BorrowManagePosition/index.tsx
+++ b/packages/kit/src/views/Borrow/pages/BorrowManagePosition/index.tsx
@@ -27,6 +27,8 @@ const BorrowManagePosition = () => {
   >();
 
   const {
+    accountId: routeAccountId,
+    indexedAccountId: routeIndexedAccountId,
     networkId,
     symbol,
     provider,
@@ -39,9 +41,14 @@ const BorrowManagePosition = () => {
   const intl = useIntl();
   const appNavigation = useAppNavigation();
   const { gtMd } = useMedia();
-  const { earnAccount } = useEarnAccount({ networkId });
-  const accountId = earnAccount?.account?.id || '';
-  const indexedAccountId = earnAccount?.account?.indexedAccountId;
+  const { earnAccount } = useEarnAccount({
+    networkId,
+    accountId: routeAccountId,
+    indexedAccountId: routeIndexedAccountId,
+  });
+  const accountId = earnAccount?.account?.id || routeAccountId || '';
+  const indexedAccountId =
+    earnAccount?.account?.indexedAccountId ?? routeIndexedAccountId;
   const defaultTab = useMemo(() => {
     if (type === 'withdraw' || type === 'repay') {
       return 'withdraw';

--- a/packages/kit/src/views/Borrow/testIDs.ts
+++ b/packages/kit/src/views/Borrow/testIDs.ts
@@ -1,5 +1,6 @@
 export const BorrowTestIDs = {
   // --- Home Page ---
+  marketSelect: 'borrow-market-select',
   segmentControl: 'borrow-segment-control',
 
   // --- Overview ---

--- a/packages/kit/src/views/Staking/pages/ManagePosition/components/ManagePositionContent.tsx
+++ b/packages/kit/src/views/Staking/pages/ManagePosition/components/ManagePositionContent.tsx
@@ -185,8 +185,13 @@ export function ManagePositionContent({
   // Check if Bitcoin Only firmware is trying to access non-BTC network
   const { result: accountNetworkNotSupported } = usePromiseResult(
     async () => {
+      const checkAccountId =
+        accountId?.length > 0 ? accountId : (indexedAccountId ?? '');
+      if (!checkAccountId) {
+        return undefined;
+      }
       return backgroundApiProxy.serviceAccount.checkAccountNetworkNotSupported({
-        accountId: accountId?.length > 0 ? accountId : (indexedAccountId ?? ''),
+        accountId: checkAccountId,
         activeNetworkId: networkId,
       });
     },
@@ -462,7 +467,7 @@ export function ManagePositionContent({
   }
 
   // USDe special rendering
-  if (symbol.toLowerCase() === 'usde') {
+  if (!isBorrowType && symbol.toLowerCase() === 'usde') {
     // Show warning if needed (no address or BTC-only firmware)
     if (warningElement) {
       return <YStack px="$5">{warningElement}</YStack>;
@@ -494,7 +499,7 @@ export function ManagePositionContent({
   }
 
   // ADA special rendering (Stakefish provider)
-  if (symbol.toLowerCase() === 'ada') {
+  if (!isBorrowType && symbol.toLowerCase() === 'ada') {
     return (
       <AdaManageContent
         managePageData={managePageData}


### PR DESCRIPTION
## Summary
- Add desktop borrow market switching and preserve the selected market across refreshes.
- Fix Borrow manage-position account resolution so route params are not lost on modal open.
- Route Borrow USDe/ADA actions through the generic Borrow manage flow instead of staking-only special pages.

## Intent & Context
The desktop Borrow page exposed multiple markets from `/earn/v1/borrow/markets` but only displayed the first market and had no switcher. During verification, Aave USDe redeem also failed when opening the Borrow manage modal.

## Root Cause
- `BorrowDataGate` always selected `markets?.[0]`, and `Markets` was display-only.
- `BorrowManagePosition` ignored `accountId/indexedAccountId` from route params and waited for async account resolution, so the first render could call `checkAccountNetworkNotSupported` without an account.
- `ManagePositionContent` treated any `USDe` symbol as staking-specific USDe content; Aave Borrow USDe manage-page data has no `holdings`, causing a blank modal.

## Design Decisions
- Keep market state in `BorrowProvider` and key markets by `provider/networkId/marketAddress` to avoid resetting selection on refresh.
- Use route account params as synchronous fallback while still resolving the full earn account.
- Gate USDe/ADA staking-only rendering with `!isBorrowType` so Borrow assets reuse the existing generic Borrow manage UI.
- Avoid changing server contracts or guessing protocol capabilities.

## Changes Detail
- `BorrowProvider`: stores market list and exposes stable market key builder.
- `BorrowDataGate`: preserves selected market, refreshes markets without TTL on explicit refetch, and includes networkId in fetch key.
- `Markets`: adds a selectable desktop market trigger.
- `BorrowManagePosition`: passes route account params through account resolution.
- `ManagePositionContent`: skips account-network check when no account is available and avoids staking-only USDe/ADA pages for Borrow.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop, Web, Mobile Borrow UI
- **Risk Areas**: Borrow market switching and shared staking/borrow manage-position rendering.

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] Desktop: borrow market dropdown shows Kamino, Aave Ethereum, and Aave Base.
- [x] Desktop: Aave USDe redeem opens the generic Borrow redeem form without `checkAccountNetworkNotSupported`.