### PR TITLE
fix(mobile): close browser instead of switching to adjacent tab on tab close (OK-54855)

### DIFF
--- a/packages/kit/src/states/jotai/contexts/discovery/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/discovery/actions.test.tsx
@@ -230,16 +230,70 @@ describe('useBrowserTabActions', () => {
     });
   });
 
-  it('selects a replacement tab after closing the current tab', () => {
+  it('selects a replacement tab after closing the current tab outside native', () => {
+    Object.assign(platformEnv, {
+      isDesktop: true,
+      isNative: false,
+      isNativeAndroid: false,
+      isNativeIOS: false,
+    });
+    jest.useFakeTimers();
+    try {
+      const { result } = renderHook(
+        () => {
+          const actions = useBrowserTabActions().current;
+          const [activeTabId] = useActiveTabIdAtom();
+          const [webTabs] = useWebTabsAtom();
+
+          return {
+            actions,
+            activeTabId,
+            tabs: webTabs.tabs,
+          };
+        },
+        {
+          wrapper: createWrapper(),
+        },
+      );
+
+      act(() => {
+        result.current.actions.setCurrentWebTab('tab-2');
+      });
+
+      act(() => {
+        result.current.actions.closeWebTab({
+          tabId: 'tab-2',
+          entry: 'Menu',
+        });
+      });
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+
+      expect(result.current.activeTabId).toBe('tab-1');
+      expect(result.current.tabs).toEqual([
+        expect.objectContaining({
+          id: 'tab-1',
+          isActive: true,
+        }),
+      ]);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('closes the browser instead of revealing an adjacent tab on native', () => {
     const { result } = renderHook(
       () => {
         const actions = useBrowserTabActions().current;
         const [activeTabId] = useActiveTabIdAtom();
+        const [displayHomePage] = useDisplayHomePageAtom();
         const [webTabs] = useWebTabsAtom();
 
         return {
           actions,
           activeTabId,
+          displayHomePage,
           tabs: webTabs.tabs,
         };
       },
@@ -259,11 +313,12 @@ describe('useBrowserTabActions', () => {
       });
     });
 
-    expect(result.current.activeTabId).toBe('tab-1');
+    expect(result.current.activeTabId).toBe('');
+    expect(result.current.displayHomePage).toBe(true);
     expect(result.current.tabs).toEqual([
       expect.objectContaining({
         id: 'tab-1',
-        isActive: true,
+        isActive: false,
       }),
     ]);
   });

--- a/packages/kit/src/states/jotai/contexts/discovery/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/discovery/actions.test.tsx
@@ -146,12 +146,20 @@ const tabsFixture: IWebTab[] = [
   },
 ];
 
-function createWrapper() {
-  const tabs = tabsFixture.map((tab) => ({ ...tab }));
+function createWrapper({
+  tabs: tabsValue = tabsFixture,
+  activeTabId = 'tab-1',
+  displayHomePage = true,
+}: {
+  tabs?: IWebTab[];
+  activeTabId?: string;
+  displayHomePage?: boolean;
+} = {}) {
+  const tabs = tabsValue.map((tab) => ({ ...tab }));
   const store = createStore();
   store.set(browserDataReadyAtom(), true);
-  store.set(activeTabIdAtom(), 'tab-1');
-  store.set(displayHomePageAtom(), true);
+  store.set(activeTabIdAtom(), activeTabId);
+  store.set(displayHomePageAtom(), displayHomePage);
   store.set(webTabsAtom(), {
     keys: tabs.map((tab) => tab.id),
     tabs,
@@ -318,6 +326,79 @@ describe('useBrowserTabActions', () => {
     expect(result.current.tabs).toEqual([
       expect.objectContaining({
         id: 'tab-1',
+        isActive: false,
+      }),
+    ]);
+  });
+
+  it('keeps native browser closed when closing an inactive tab without an active tab', () => {
+    const { result } = renderHook(
+      () => {
+        const actions = useBrowserTabActions().current;
+        const [activeTabId] = useActiveTabIdAtom();
+        const [displayHomePage] = useDisplayHomePageAtom();
+        const [webTabs] = useWebTabsAtom();
+
+        return {
+          actions,
+          activeTabId,
+          displayHomePage,
+          tabs: webTabs.tabs,
+        };
+      },
+      {
+        wrapper: createWrapper({
+          tabs: [
+            {
+              id: 'tab-1',
+              url: 'https://previous.example',
+              title: 'Previous',
+              isActive: false,
+              timestamp: 1,
+            },
+            {
+              id: 'tab-2',
+              url: 'https://current.example',
+              title: 'Current',
+              isActive: true,
+              timestamp: 2,
+            },
+            {
+              id: 'tab-3',
+              url: 'https://next.example',
+              title: 'Next',
+              isActive: false,
+              timestamp: 3,
+            },
+          ],
+          activeTabId: 'tab-2',
+          displayHomePage: false,
+        }),
+      },
+    );
+
+    act(() => {
+      result.current.actions.closeWebTab({
+        tabId: 'tab-2',
+        entry: 'Menu',
+      });
+    });
+
+    expect(result.current.activeTabId).toBe('');
+    expect(result.current.displayHomePage).toBe(true);
+
+    act(() => {
+      result.current.actions.closeWebTab({
+        tabId: 'tab-1',
+        entry: 'Menu',
+      });
+    });
+
+    expect(result.current.activeTabId).toBe('');
+    expect(result.current.displayHomePage).toBe(true);
+    expect(result.current.tabs).toEqual([
+      expect.objectContaining({
+        id: 'tab-3',
         isActive: false,
       }),
     ]);

--- a/packages/kit/src/states/jotai/contexts/discovery/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/discovery/actions.ts
@@ -411,6 +411,9 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
       const targetIndex = tabs.findIndex((t) => t.id === tabId);
       if (targetIndex !== -1) {
         const closedTab = tabs[targetIndex];
+        const activeTabId = get(activeTabIdAtom());
+        const isClosingCurrentTab =
+          closedTab.isActive || activeTabId === closedTab.id;
         tabs.splice(targetIndex, 1);
 
         // Add to browser history when tab is closed
@@ -423,6 +426,11 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
         }
 
         const activateAdjacentTab = () => {
+          if (platformEnv.isNative && isClosingCurrentTab) {
+            this.setCurrentWebTab.call(set, null);
+            return;
+          }
+
           let newActiveTabIndex = targetIndex - 1;
 
           if (newActiveTabIndex < 0 && tabs.length > 0) {

--- a/packages/kit/src/states/jotai/contexts/discovery/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/discovery/actions.ts
@@ -426,9 +426,11 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
         }
 
         const activateAdjacentTab = () => {
-          if (platformEnv.isNative && isClosingCurrentTab) {
-            this.setCurrentWebTab.call(set, null);
-            return;
+          if (platformEnv.isNative) {
+            if (isClosingCurrentTab || !activeTabId) {
+              this.setCurrentWebTab.call(set, null);
+              return;
+            }
           }
 
           let newActiveTabIndex = targetIndex - 1;

--- a/packages/kit/src/views/Discovery/components/MobileBrowser/useMobileBrowserBottomBarData.ts
+++ b/packages/kit/src/views/Discovery/components/MobileBrowser/useMobileBrowserBottomBarData.ts
@@ -23,7 +23,6 @@ import { usePageTranslation } from '../../hooks/usePageTranslation';
 import {
   useDisplayHomePageFlag,
   useWebTabDataById,
-  useWebTabs,
 } from '../../hooks/useWebTabs';
 import { webviewRefs } from '../../utils/explorerUtils';
 import { showTabBar } from '../../utils/tabBarUtils';
@@ -49,7 +48,6 @@ export function useMobileBrowserBottomBarData({
   const { bottom } = useSafeAreaInsets();
 
   const { tab } = useWebTabDataById(id);
-  const { tabs } = useWebTabs();
 
   const origin = tab?.url ? new URL(tab.url).origin : null;
   const { result: hasConnectedAccount, run: refreshConnectState } =
@@ -69,7 +67,7 @@ export function useMobileBrowserBottomBarData({
     }, [origin]);
 
   const { displayHomePage } = useDisplayHomePageFlag();
-  const { setPinnedTab, setCurrentWebTab, closeWebTab, setSiteMode } =
+  const { setPinnedTab, closeWebTab, setSiteMode, setDisplayHomePage } =
     useBrowserTabActions().current;
 
   const {
@@ -124,14 +122,10 @@ export function useMobileBrowserBottomBarData({
   );
 
   const handleCloseTab = useCallback(() => {
-    const isLastTab = tabs.length <= 1;
     closeWebTab({ tabId: id, entry: 'Menu' });
-    if (isLastTab) {
-      setCurrentWebTab(null);
-    }
-
+    setDisplayHomePage(true);
     showTabBar();
-  }, [closeWebTab, id, setCurrentWebTab, tabs.length]);
+  }, [closeWebTab, id, setDisplayHomePage]);
 
   const onShare = useCallback(() => {
     handleShareUrl(tab?.displayUrl ?? tab?.url ?? '');

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -292,10 +292,12 @@ function MobileBrowser() {
 
   const closeCurrentWebTab = useCallback(async () => {
     showTabBar();
-    return activeTabId
-      ? closeWebTab({ tabId: activeTabId, entry: 'Menu' })
-      : Promise.resolve();
-  }, [activeTabId, closeWebTab]);
+    if (activeTabId) {
+      closeWebTab({ tabId: activeTabId, entry: 'Menu' });
+      setDisplayHomePage(true);
+    }
+    return Promise.resolve();
+  }, [activeTabId, closeWebTab, setDisplayHomePage]);
 
   useEffect(() => {
     const listener = async (event: {

--- a/packages/kit/src/views/Discovery/pages/MobileTabListModal/index.tsx
+++ b/packages/kit/src/views/Discovery/pages/MobileTabListModal/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 import { StyleSheet } from 'react-native';
@@ -131,15 +131,6 @@ function MobileTabListModal() {
     setDisplayHomePage,
   } = useBrowserTabActions().current;
 
-  const triggerCloseTab = useRef(false);
-  useEffect(() => {
-    if (triggerCloseTab.current && !tabs.length) {
-      setDisplayHomePage(true);
-      navigation.pop();
-    }
-    triggerCloseTab.current = false;
-  }, [tabs, setDisplayHomePage, navigation]);
-
   const initialScrollIndex = useMemo(() => {
     const index = data.findIndex((t) => t.id === activeTabId);
 
@@ -218,10 +209,32 @@ function MobileTabListModal() {
   );
   const handleCloseTab = useCallback(
     (id: string) => {
-      triggerCloseTab.current = true;
+      const isClosingActiveTab = id === activeTabId;
+      const targetIndex = tabs.findIndex((tab) => tab.id === id);
+      const remainingTabs = tabs.filter((tab) => tab.id !== id);
+      const nextActiveTab =
+        targetIndex > 0 ? remainingTabs[targetIndex - 1] : remainingTabs[0];
       void closeWebTab({ tabId: id, entry: 'Menu' });
+
+      if (!isClosingActiveTab) {
+        return;
+      }
+
+      if (nextActiveTab) {
+        setCurrentWebTab(nextActiveTab.id);
+      } else {
+        setDisplayHomePage(true);
+        navigation.pop();
+      }
     },
-    [closeWebTab],
+    [
+      activeTabId,
+      closeWebTab,
+      navigation,
+      setCurrentWebTab,
+      setDisplayHomePage,
+      tabs,
+    ],
   );
 
   const handleAddNewTab = useCallback(() => {
@@ -447,8 +460,11 @@ function MobileTabListModal() {
           closeAllDisabled={data.length <= 0}
           onAddTab={handleAddNewTab}
           onCloseAll={() => {
-            triggerCloseTab.current = true;
             void closeAllWebTabs({ navigation });
+            if (pinnedData.length === 0) {
+              setDisplayHomePage(true);
+              navigation.pop();
+            }
           }}
           onDone={() => {
             navigation.pop();

--- a/packages/kit/src/views/Discovery/pages/MobileTabListModal/index.tsx
+++ b/packages/kit/src/views/Discovery/pages/MobileTabListModal/index.tsx
@@ -210,32 +210,15 @@ function MobileTabListModal() {
   const handleCloseTab = useCallback(
     (id: string) => {
       const isClosingActiveTab = id === activeTabId;
-      const targetIndex = tabs.findIndex((tab) => tab.id === id);
-      const remainingTabs = tabs.filter((tab) => tab.id !== id);
-      const nextActiveTab =
-        targetIndex > 0 ? remainingTabs[targetIndex - 1] : remainingTabs[0];
+      const hasRemainingTabs = tabs.some((tab) => tab.id !== id);
       void closeWebTab({ tabId: id, entry: 'Menu' });
 
-      if (!nextActiveTab) {
+      if (isClosingActiveTab || !hasRemainingTabs) {
         setDisplayHomePage(true);
         navigation.pop();
-        return;
       }
-
-      if (!isClosingActiveTab) {
-        return;
-      }
-
-      setCurrentWebTab(nextActiveTab.id);
     },
-    [
-      activeTabId,
-      closeWebTab,
-      navigation,
-      setCurrentWebTab,
-      setDisplayHomePage,
-      tabs,
-    ],
+    [activeTabId, closeWebTab, navigation, setDisplayHomePage, tabs],
   );
 
   const handleAddNewTab = useCallback(() => {

--- a/packages/kit/src/views/Discovery/pages/MobileTabListModal/index.tsx
+++ b/packages/kit/src/views/Discovery/pages/MobileTabListModal/index.tsx
@@ -216,16 +216,17 @@ function MobileTabListModal() {
         targetIndex > 0 ? remainingTabs[targetIndex - 1] : remainingTabs[0];
       void closeWebTab({ tabId: id, entry: 'Menu' });
 
+      if (!nextActiveTab) {
+        setDisplayHomePage(true);
+        navigation.pop();
+        return;
+      }
+
       if (!isClosingActiveTab) {
         return;
       }
 
-      if (nextActiveTab) {
-        setCurrentWebTab(nextActiveTab.id);
-      } else {
-        setDisplayHomePage(true);
-        navigation.pop();
-      }
+      setCurrentWebTab(nextActiveTab.id);
     },
     [
       activeTabId,


### PR DESCRIPTION
## Summary
- On native (iOS/Android), closing the current browser tab now closes the browser back to the home page instead of silently switching to an adjacent tab.
- Unified tab-close behavior across the mobile bottom bar, native browser hardware/UI back actions, and the tab list modal.
- Replaced the `useEffect` watching `tabs.length` in the tab list modal with synchronous decisions at the close call site.

## Intent & Context
Previously, closing the active tab on mobile would auto-activate a neighboring tab, which surprised users who expected "close tab" to dismiss the browser view itself. The behavior also differed slightly between entry points (bottom bar vs. tab list modal vs. close-current shortcut), and the modal relied on a `useEffect` reacting to `tabs.length` changes, which introduced race-like timing and an extra ref (`triggerCloseTab`) to track intent across renders.

## Root Cause
- `closeWebTab` in `ContextJotaiActionsDiscovery` always called `activateAdjacentTab` after removing a tab, regardless of platform. On native this conflicted with the product expectation of "close tab = exit browser".
- The mobile tab list modal used a `useRef` + `useEffect(tabs.length)` pattern to decide whether to pop the navigator and show the home page, which made the intent implicit and timing-dependent.

## Design Decisions
- Branch the close behavior in `actions.ts` on `platformEnv.isNative`: when the currently active tab is being closed on native, clear `currentWebTab` instead of activating an adjacent one. Non-native (desktop/web/extension) keeps the existing adjacent-tab behavior to preserve multi-tab UX there.
- Move the "show home page / pop modal" decisions to be synchronous at the call sites (`useMobileBrowserBottomBarData`, `Browser.native`, `MobileTabListModal`) so intent is local and explicit, removing the `useEffect`/`useRef` indirection.
- Keep the `closeAllWebTabs` flow consistent by also calling `setDisplayHomePage(true)` and popping the modal when no pinned tabs remain.

## Changes Detail
- `packages/kit/src/states/jotai/contexts/discovery/actions.ts`: capture whether the closed tab is the active one, then short-circuit `activateAdjacentTab` on native by clearing `currentWebTab`.
- `packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx`: after `closeCurrentWebTab`, explicitly `setDisplayHomePage(true)` to return to the home page.
- `packages/kit/src/views/Discovery/components/MobileBrowser/useMobileBrowserBottomBarData.ts`: drop the `isLastTab`/`tabs` dependency; always set the home page flag after a close from the bottom bar.
- `packages/kit/src/views/Discovery/pages/MobileTabListModal/index.tsx`: remove the `triggerCloseTab` ref + `useEffect`; decide synchronously in `handleCloseTab` and `onCloseAll` whether to pop the modal and display the home page.
- `packages/kit/src/states/jotai/contexts/discovery/actions.test.tsx`: split the existing test into a non-native case (adjacent-tab activation) and a native case (browser closes, home page shown).

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile (iOS, Android); desktop/web/extension behavior preserved.
- **Risk Areas**:
  - `closeWebTab` is shared across all browser entry points; the native branch must not regress desktop/extension behavior — guarded via `platformEnv.isNative`.
  - Tab list modal close-all flow now pops navigation synchronously based on `pinnedData.length`; verify that pinned tabs still behave correctly.

## Test plan
- [ ] iOS: open multiple tabs, close the active tab from the bottom bar → browser returns to the home page (does not jump to an adjacent tab).
- [ ] iOS: open the tab list modal, tap the close icon on the active tab → modal closes and home page is shown.
- [ ] iOS: tab list modal "Close all" with no pinned tabs → modal pops and home page is shown.
- [ ] Android: repeat the three flows above.
- [ ] Desktop/Web/Extension: closing a tab still activates an adjacent tab (no regression).
- [ ] Unit tests `actions.test.tsx` for both native and non-native close paths pass.