### PR TITLE
fix: scope BTC reward history by instance only (OK-54480)

### DIFF
--- a/packages/kit/src/views/Redemption/pages/RedemptionHistory.tsx
+++ b/packages/kit/src/views/Redemption/pages/RedemptionHistory.tsx
@@ -4,13 +4,10 @@ import { useIntl } from 'react-intl';
 
 import { Badge, Empty, Page, Spinner, YStack } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { useOneKeyAuth } from '@onekeyhq/kit/src/components/OneKeyAuth/useOneKeyAuth';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
-import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
-import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EBtcRewardStatus } from '@onekeyhq/shared/src/referralCode/type';
@@ -20,15 +17,12 @@ import type {
 } from '@onekeyhq/shared/src/referralCode/type';
 import { EModalReferFriendsRoutes } from '@onekeyhq/shared/src/routes';
 import { formatDate } from '@onekeyhq/shared/src/utils/dateUtils';
-import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import {
   formatUsd,
   getBtcRewardStatusConfig,
   isBtcRewardSnapshotStatus,
 } from '../utils';
-
-const baseNetworkId = getNetworkIdsMap().base;
 
 type IUnifiedRecord =
   | {
@@ -114,32 +108,7 @@ function RedemptionHistoryContent() {
   const navigation = useAppNavigation();
   const statusConfigs = useMemo(() => getBtcRewardStatusConfig(intl), [intl]);
 
-  const { activeAccount } = useActiveAccount({ num: 0 });
   const { isLoggedIn } = useOneKeyAuth();
-
-  const indexedAccountId = activeAccount?.indexedAccount?.id;
-  const accountId = activeAccount?.account?.id;
-
-  const { result: walletAddress, isLoading: isWalletAddressLoading } =
-    usePromiseResult(
-      async () => {
-        if (!indexedAccountId && !accountId) return undefined;
-        try {
-          const networkAccount =
-            await backgroundApiProxy.serviceAccount.getNetworkAccount({
-              indexedAccountId,
-              accountId: indexedAccountId ? undefined : accountId,
-              networkId: baseNetworkId,
-              deriveType: 'default',
-            });
-          return networkAccount?.address;
-        } catch {
-          return undefined;
-        }
-      },
-      [indexedAccountId, accountId],
-      { watchLoading: true },
-    );
 
   const { result: legacyResult, isLoading: isLegacyLoading } = usePromiseResult(
     async () => {
@@ -153,16 +122,14 @@ function RedemptionHistoryContent() {
 
   const { result: btcItems, isLoading: isBtcLoading } = usePromiseResult(
     async () => {
-      if (!walletAddress) return [] as IBtcRewardHistoryItem[];
       const result =
         await backgroundApiProxy.serviceReferralCode.btcRewardHistory({
-          walletAddress,
           pageSize: 100,
         });
       if (!result.success) return [] as IBtcRewardHistoryItem[];
       return result.data.data;
     },
-    [walletAddress],
+    [],
     { watchLoading: true, initResult: [] as IBtcRewardHistoryItem[] },
   );
 
@@ -192,8 +159,7 @@ function RedemptionHistoryContent() {
     [navigation],
   );
 
-  const isLoading =
-    isWalletAddressLoading || isBtcLoading || (isLoggedIn && isLegacyLoading);
+  const isLoading = isBtcLoading || (isLoggedIn && isLegacyLoading);
 
   const renderContent = () => {
     if (isLoading) {
@@ -251,15 +217,5 @@ function RedemptionHistoryContent() {
 }
 
 export default function RedemptionHistory() {
-  return (
-    <AccountSelectorProviderMirror
-      config={{
-        sceneName: EAccountSelectorSceneName.home,
-        sceneUrl: '',
-      }}
-      enabledNum={[0]}
-    >
-      <RedemptionHistoryContent />
-    </AccountSelectorProviderMirror>
-  );
+  return <RedemptionHistoryContent />;
 }

--- a/packages/shared/src/referralCode/type.ts
+++ b/packages/shared/src/referralCode/type.ts
@@ -760,7 +760,6 @@ export interface IBtcRewardCommitData {
 }
 
 export interface IBtcRewardHistoryParams {
-  walletAddress: string;
   current?: number;
   pageSize?: number;
   status?: EBtcRewardStatus;


### PR DESCRIPTION
## Summary
- Drop `walletAddress` from BTC reward history query — backend now scopes purely by `X-Onekey-Instance-Id` header.
- Remove `useActiveAccount` / `AccountSelectorProviderMirror` dependency from the page (no longer needed).
- `IBtcRewardHistoryParams.walletAddress` removed from the shared type.

## Intent & Context
Bug OK-54480 reports: after switching accounts in the redemption history page, BTC reward records disappear; another client with the same wallet only sees the currently-selected account's records.

Root issue is twofold:
1. The page was passing the current account's Base address as `walletAddress`, so any account switch changed the query and the list emptied.
2. Even with the existing backend `OR { instanceId, walletAddress }` fallback (added in OK-54113), the wallet-address branch let any caller probe arbitrary addresses they happen to know — a privacy leak (`security: []` on this endpoint, no ownership proof on the param).

After discussion we accepted the boundary: **anonymous users only see records from the current device.** That's the natural scope for a non-authenticated, write-anywhere endpoint, and it cleanly resolves both the "switch account loses records" bug and the address-probe leak.

## Root Cause
`RedemptionHistory.tsx` derived `walletAddress` from the active account's Base derivation and passed it to `btcRewardHistory({ walletAddress, pageSize })`. The backend filter (`server-service-rebate/src/entity/btc-reward/service/btc-redemption.service.ts`) treats a present `walletAddress` as an OR clause against `instanceId`, but the per-address branch is what allowed the cross-account probe. By omitting `walletAddress` entirely the backend falls into its `else` branch — `filter.instanceId = instanceId` — which is what we want.

## Design Decisions
- **Considered scoping by `userId` (OneKeyId)**: cleanest cross-device story, but BTC reward endpoints are explicitly anonymous (`security: []`), and the schema currently stores no `userId` on records. Out of scope.
- **Considered backend-side `instanceId` cluster expansion via `walletAddress` lookup**: rejected — single-hop expansion is incomplete (cannot traverse the full bipartite graph), still leaves fresh accounts empty, and turns the existing per-address leak into a per-device-cluster leak. Real privacy regression.
- **Considered passing `walletAddress[]` of every derived account**: viable but adds 50–300ms first-load BIP32 derivation cost on HD wallets and still has the address-probe leak unless paired with ownership proofs. Defer until a concrete cross-device requirement appears.
- **Chose: drop `walletAddress` from the request entirely.** Smallest diff, no schema change, no privacy regression, immediately fixes the reported account-switch bug.

## Changes Detail
- `packages/shared/src/referralCode/type.ts` — remove `walletAddress` from `IBtcRewardHistoryParams`.
- `packages/kit/src/views/Redemption/pages/RedemptionHistory.tsx` — drop the address-derivation `usePromiseResult` block, the `useActiveAccount` hook, the `AccountSelectorProviderMirror` wrapper, the `baseNetworkId` constant and related imports; BTC reward call now only passes `{ pageSize: 100 }`; `isLoading` no longer waits on address derivation.
- `packages/kit-bg/src/services/ServiceReferralCode.ts` — no edit; signature inherits from the trimmed shared type automatically.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: All (Extension / Mobile / Desktop / Web — single shared page)
- **Risk Areas**:
  - Backend OAS may still mark `walletAddress` as required on `GET /rebate/v1/btc-reward/history`. Schema declares it `required: false`, but if the route validator rejects missing param the request will 400. Needs verification on staging before relying on the auto-merge.
  - Records committed before `instanceId` was stored on `btc_redemption_codes` (field is `required: false` in schema) will not surface for any client. Pre-existing data hole, not introduced by this PR.

## Test plan
- [ ] Open Settings → Redeem → History on a device that has redeemed BTC reward; confirm the records list is non-empty.
- [ ] Switch the active account from the account selector; the BTC reward rows should remain visible (this is the OK-54480 regression).
- [ ] Switch wallets entirely; same — rows persist as long as you stay on the same device/install.
- [ ] On a fresh install (different `instanceId`), import the same wallet; confirm the BTC reward list is empty (expected new boundary; legacy OneKeyId-scoped rows still appear if logged in).
- [ ] Network tab: verify the request to `/rebate/v1/btc-reward/history` no longer includes `walletAddress` in the query string and returns 200.
- [ ] Legacy redemption rows (GiftOutline icon) still load when OneKeyId is logged in and disappear when logged out — unchanged behavior.