### PR TITLE
fix: prevent "no wallet" flash in account selector during hydration

### DIFF
--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/EmptyView.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/EmptyView.tsx
@@ -76,7 +76,13 @@ export function EmptyNoWalletView() {
   );
 }
 
-export function EmptyView() {
+export function EmptyView({ hasResolved }: { hasResolved: boolean }) {
   const [isLoading] = useAccountSelectorAccountsListIsLoadingAtom();
-  return isLoading ? <LoadingSkeletonView /> : <EmptyNoWalletView />;
+  // hasResolved=false covers the gap before the first fetch lands AND the
+  // brief window where storage is still hydrating, so we don't flash
+  // EmptyNoWalletView for users who actually have wallets.
+  if (isLoading || !hasResolved) {
+    return <LoadingSkeletonView />;
+  }
+  return <EmptyNoWalletView />;
 }

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/index.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/index.tsx
@@ -22,6 +22,7 @@ import { useEnabledNetworksCompatibleWithWalletIdInAllNetworks } from '@onekeyhq
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import {
   useAccountSelectorActions,
+  useAccountSelectorStorageReadyAtom,
   useSelectedAccount,
 } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import qrHiddenCreateGuideDialog from '@onekeyhq/kit/src/views/Onboarding/pages/ConnectHardwareWallet/qrHiddenCreateGuideDialog';
@@ -46,6 +47,7 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import { swrKeys } from '@onekeyhq/shared/src/utils/swrCacheUtils';
 
 import { HiddenWalletRememberSwitch } from '../../../components/WalletEdit/HiddenWalletRememberSwitch';
 import { useAccountSelectorRoute } from '../../../router/useAccountSelectorRoute';
@@ -123,6 +125,24 @@ function WalletDetailsView({ num }: IWalletDetailsProps) {
   const selectedNetworkId = selectedAccount?.networkId;
   const [searchText, setSearchText] = useState('');
   const { createQrWallet } = useCreateQrWallet();
+  const [storageReady] = useAccountSelectorStorageReadyAtom();
+
+  const accountsListSwrKey = useMemo(() => {
+    if (!selectedAccount?.focusedWallet || !usedDeriveType) return undefined;
+    return swrKeys.accountSelectorList({
+      focusedWallet: selectedAccount.focusedWallet,
+      deriveType: usedDeriveType,
+      linkedNetworkId,
+      selectedNetworkId,
+      keepAllOtherAccounts,
+    });
+  }, [
+    selectedAccount?.focusedWallet,
+    usedDeriveType,
+    linkedNetworkId,
+    selectedNetworkId,
+    keepAllOtherAccounts,
+  ]);
 
   defaultLogger.accountSelector.perf.renderAccountsList({
     selectedAccount,
@@ -181,12 +201,25 @@ function WalletDetailsView({ num }: IWalletDetailsProps) {
       // debounced: 100,
       checkIsFocused: false,
       watchLoading: false,
+      swrKey: accountsListSwrKey,
       onIsLoadingChange(loading) {
         // setIsLoading(loading);
         void accountSelectorAccountsListIsLoadingAtom.set(loading);
       },
     },
   );
+
+  // Drives EmptyView's skeleton-vs-no-wallet decision. We're "resolved" when
+  // either: (a) we already have a result (real fetch or SWR cache hit), or
+  // (b) storage finished hydrating and confirmed there's no focused wallet
+  // — i.e. the user truly has none. The early-return path inside the
+  // usePromiseResult method also resolves to undefined, so without (b) the
+  // genuine "no wallets" case would render an infinite skeleton.
+  const hasResolved = useMemo(() => {
+    if (listDataResult !== undefined) return true;
+    if (storageReady && !selectedAccount?.focusedWallet) return true;
+    return false;
+  }, [listDataResult, storageReady, selectedAccount?.focusedWallet]);
 
   const sectionDataOriginal = useMemo(
     () => listDataResult?.sectionData || [],
@@ -593,7 +626,7 @@ function WalletDetailsView({ num }: IWalletDetailsProps) {
               (item as IDBIndexedAccount | IDBAccount).id
             }`
           }
-          ListEmptyComponent={<EmptyView />}
+          ListEmptyComponent={<EmptyView hasResolved={hasResolved} />}
           contentContainerStyle={{ pb: '$3' }}
           extraData={[
             selectedAccount.indexedAccountId,
@@ -705,6 +738,7 @@ function WalletDetailsView({ num }: IWalletDetailsProps) {
     handleLayoutForContainer,
     handleLayoutForHeader,
     handleLayoutForSectionList,
+    hasResolved,
     hideAddress,
     initialScrollIndex,
     intl,

--- a/packages/shared/src/utils/swrCacheUtils.ts
+++ b/packages/shared/src/utils/swrCacheUtils.ts
@@ -234,6 +234,33 @@ export const swrKeys = {
       accountId ?? '',
     ].join(':'),
   defiEnabled: (networkId: string) => `defiEnabled:${networkId}`,
+  // Account selector accounts list: caches the section data that drives the
+  // wallet/account picker modal so subsequent opens render the previous
+  // structure synchronously instead of flashing the empty state. Account
+  // values are loaded separately (see useAccountSelectorValuesLoader) and
+  // intentionally NOT in this cache.
+  accountSelectorList: ({
+    focusedWallet,
+    deriveType,
+    linkedNetworkId,
+    selectedNetworkId,
+    keepAllOtherAccounts,
+  }: {
+    focusedWallet: string;
+    deriveType: string;
+    linkedNetworkId?: string;
+    selectedNetworkId?: string;
+    keepAllOtherAccounts?: boolean;
+  }) =>
+    [
+      'accSelList',
+      'v1',
+      focusedWallet,
+      deriveType,
+      linkedNetworkId ?? '',
+      selectedNetworkId ?? '',
+      keepAllOtherAccounts ? '1' : '0',
+    ].join(':'),
 };
 
 export const swrCacheUtils = {


### PR DESCRIPTION
## Summary

Account selector modal briefly renders the "沒有錢包 / Create Wallet" empty state on first cold-launch open and flashes empty section data on every subsequent open before the real fetch lands.

Root cause:
1. `EmptyView` only checked `accountSelectorAccountsListIsLoadingAtom` (defaults to `false`), so before any fetch fires it falls through to `EmptyNoWalletView`.
2. `usePromiseResult` early-returns `Promise.resolve(undefined)` while `selectedAccount.focusedWallet` / `usedDeriveType` are still hydrating — that path never sets loading to `true`, so the empty CTA shows first.
3. Every open re-mounts `WalletDetailsView` with no cached result, so even returning users see one-frame empty state until the async fetch resolves.

Fix:
- `EmptyView` now takes a `hasResolved` prop. It renders the loading skeleton while loading OR until results are resolved.
- `WalletDetailsView` derives `hasResolved` from either a defined `listDataResult` (real fetch / SWR cache hit) **or** `accountSelectorStorageReadyAtom === true && !focusedWallet` (genuine "no wallets" terminal state). This avoids both the hydration flash AND infinite skeleton for users who really have no wallets.
- Wire a new `swrKeys.accountSelectorList(...)` SWR key into the `usePromiseResult` call. MMKV-backed cache lets subsequent opens paint last-known section data synchronously on first frame; the real fetch still runs in the background to revalidate.

Trade-off: same-wallet account add/remove may briefly show the prior account structure (~50–200 ms) on the next open until revalidation completes. Account values stay fresh because they load through `useAccountSelectorValuesLoader`, which is intentionally outside this cache.

## Test plan

- [ ] Cold start app on iOS/Android with at least one wallet — open account selector immediately, no "沒有錢包" flash.
- [ ] Open / close / reopen the account selector several times — no empty-state flash on subsequent opens.
- [ ] Brand-new install with zero wallets — "沒有錢包" + "Create Wallet" still shows correctly (no infinite skeleton).
- [ ] Switch wallet → reopen selector — the new wallet's accounts render immediately if previously cached, then revalidate.
- [ ] Add / remove an account → reopen selector — UI converges to fresh state within a frame after revalidation.
- [ ] Verify on iPad / web / desktop that no platform regresses (storage-ready signal works on all platforms).