### PR TITLE
fix: stabilize perps mobile charts and favorites OK-54167 OK-54852 OK-54856 OK-54857

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -30,6 +30,18 @@ import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 import cacheUtils from '@onekeyhq/shared/src/utils/cacheUtils';
 import perfUtils from '@onekeyhq/shared/src/utils/debug/perfUtils';
 import { hyperLiquidErrorResolver } from '@onekeyhq/shared/src/utils/hyperLiquidErrorResolver';
+import type {
+  IResolvedTokenSelectorFavoriteAction,
+  ITokenSelectorFavoriteAction,
+  ITokenSelectorFavoriteMode,
+} from '@onekeyhq/shared/src/utils/perpsTokenSelectorFavorites';
+import {
+  dedupeTokenSelectorFavoriteCoins,
+  isSameFavoritesOrderSequence,
+  isSameStringArray,
+  reconcileTokenSelectorFavoritesOrder,
+  updateTokenSelectorFavoriteCoins,
+} from '@onekeyhq/shared/src/utils/perpsTokenSelectorFavorites';
 import perpsUtils, {
   parseDexCoin,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
@@ -74,6 +86,7 @@ import type { IHyperLiquidSignatureRSV } from '@onekeyhq/shared/types/hyperliqui
 
 import localDb from '../../dbs/local/localDb';
 import {
+  perpTokenFavoritesPersistAtom,
   perpTokenSelectorTabsAtom,
   perpsAbstractionModeAtom,
   perpsAccountLoadingInfoAtom,
@@ -88,6 +101,7 @@ import {
   perpsCustomSettingsAtom,
   perpsDepositNetworksAtom,
   perpsDepositTokensAtom,
+  perpsFavoritesOrderPersistAtom,
   perpsLastUsedLeverageAtom,
   perpsSpotBalancesAtom,
   perpsTradesHistoryDataAtom,
@@ -97,6 +111,7 @@ import {
   spotBalancesAtom,
   spotExternalMarketCapsAtom,
   spotPairDisplayMapAtom,
+  spotTokenFavoritesPersistAtom,
 } from '../../states/jotai/atoms';
 import ServiceBase from '../ServiceBase';
 
@@ -154,9 +169,121 @@ export default class ServiceHyperliquid extends ServiceBase {
 
   private activeAssetChangeRequestId = 0;
 
+  private tokenSelectorFavoriteUpdateQueue = Promise.resolve();
+
   @backgroundMethod()
   async cancelPendingActiveAssetChange(): Promise<void> {
     this.activeAssetChangeRequestId += 1;
+  }
+
+  private async updateTokenSelectorFavoriteInBg({
+    mode,
+    coin,
+    action,
+  }: {
+    mode: ITokenSelectorFavoriteMode;
+    coin: string;
+    action: ITokenSelectorFavoriteAction;
+  }) {
+    let result: {
+      favorites: string[];
+      action: IResolvedTokenSelectorFavoriteAction;
+    };
+    if (mode === 'perp' && action === 'remove') {
+      await this.backgroundApi.serviceMarketV2.syncToMarketWatchList({
+        coin,
+        action,
+      });
+    }
+    const [currentPerpFavorites, currentSpotFavorites] = await Promise.all([
+      perpTokenFavoritesPersistAtom.get(),
+      spotTokenFavoritesPersistAtom.get(),
+    ]);
+    let nextPerpFavorites = dedupeTokenSelectorFavoriteCoins(
+      currentPerpFavorites.favorites,
+    );
+    let nextSpotFavorites = dedupeTokenSelectorFavoriteCoins(
+      currentSpotFavorites.favorites,
+    );
+    if (mode === 'spot') {
+      result = updateTokenSelectorFavoriteCoins({
+        favorites: currentSpotFavorites.favorites,
+        coin,
+        action,
+      });
+      nextSpotFavorites = result.favorites;
+      if (
+        !isSameStringArray(result.favorites, currentSpotFavorites.favorites)
+      ) {
+        await spotTokenFavoritesPersistAtom.set({
+          ...currentSpotFavorites,
+          favorites: result.favorites,
+        });
+      }
+    } else {
+      result = updateTokenSelectorFavoriteCoins({
+        favorites: currentPerpFavorites.favorites,
+        coin,
+        action,
+      });
+      nextPerpFavorites = result.favorites;
+      if (
+        !isSameStringArray(result.favorites, currentPerpFavorites.favorites)
+      ) {
+        await perpTokenFavoritesPersistAtom.set({
+          ...currentPerpFavorites,
+          favorites: result.favorites,
+        });
+      }
+    }
+
+    const currentOrder = await perpsFavoritesOrderPersistAtom.get();
+    const nextSequence = reconcileTokenSelectorFavoritesOrder({
+      sequence: currentOrder.sequence,
+      perpFavorites: nextPerpFavorites,
+      spotFavorites: nextSpotFavorites,
+    });
+    if (!isSameFavoritesOrderSequence(nextSequence, currentOrder.sequence)) {
+      await perpsFavoritesOrderPersistAtom.set({
+        sequence: nextSequence,
+      });
+    }
+
+    const watchListAction = action === 'toggle' ? result.action : action;
+    if (mode === 'perp' && watchListAction !== 'none' && action !== 'remove') {
+      await this.backgroundApi.serviceMarketV2.syncToMarketWatchList({
+        coin,
+        action: watchListAction,
+      });
+    }
+
+    return result;
+  }
+
+  @backgroundMethod()
+  async updateTokenSelectorFavorite({
+    mode,
+    coin,
+    action = 'toggle',
+  }: {
+    mode: ITokenSelectorFavoriteMode;
+    coin: string;
+    action?: ITokenSelectorFavoriteAction;
+  }) {
+    const task = this.tokenSelectorFavoriteUpdateQueue
+      .catch(() => undefined)
+      .then(() =>
+        this.updateTokenSelectorFavoriteInBg({
+          mode,
+          coin,
+          action,
+        }),
+      );
+    this.tokenSelectorFavoriteUpdateQueue = task.then(
+      () => undefined,
+      () => undefined,
+    );
+    return task;
   }
 
   // Avoids async atom reads in the hot path — written to atom on a throttled schedule

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -161,11 +161,15 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
   private static readonly POST_OPEN_DATA_CHECK_MAX_RETRIES = 3;
 
+  private static readonly SUBSCRIPTION_UPDATE_OPEN_WAIT_MS = 3000;
+
   private _criticalSubscriptionHealthCheckTimer: ReturnType<
     typeof setTimeout
   > | null = null;
 
   private _resumeRecoveryPromise: Promise<void> | null = null;
+
+  private _subscriptionUpdateRecoveryPromise: Promise<void> | null = null;
 
   allSubSpecsMap: Record<string, ISubscriptionSpec<ESubscriptionType>> = {};
 
@@ -346,7 +350,15 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
   @backgroundMethod()
   async updateSubscriptions(): Promise<void> {
-    if (await this._reconnectClosedOrClosingSocket()) {
+    if (this.subscriptionsHandlerDisabled) {
+      return;
+    }
+    const client = await this.getWebSocketClient();
+    if (client?.transport?.socket?.readyState !== WebSocket.OPEN) {
+      await this._recoverNotOpenSocketBeforeSubscriptionUpdate({
+        client,
+        reason: 'update_subscriptions_not_open',
+      });
       return;
     }
     // Skip debounce on first subscription to speed up initial load
@@ -878,6 +890,87 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     );
     this._emitConnectionStatus();
     await this.getWebSocketClient();
+  }
+
+  private async _recoverNotOpenSocketBeforeSubscriptionUpdate(params: {
+    client: IHyperliquidWsClient;
+    reason: string;
+  }): Promise<void> {
+    if (this._subscriptionUpdateRecoveryPromise) {
+      await this._subscriptionUpdateRecoveryPromise;
+      return;
+    }
+
+    this._subscriptionUpdateRecoveryPromise = (async () => {
+      const readyState = params.client.transport?.socket?.readyState;
+      if (readyState === WebSocket.CLOSED || readyState === WebSocket.CLOSING) {
+        await this._forceReconnectTransport();
+        return;
+      }
+
+      const isOpen = await this._waitForOpenSocket({
+        client: params.client,
+        timeoutMs:
+          ServiceHyperliquidSubscription.SUBSCRIPTION_UPDATE_OPEN_WAIT_MS,
+      });
+      if (isOpen) {
+        this._watchSubscriptionAtoms();
+        await this._reconcileOpenSocketSubscriptionsOnResume({
+          reason: params.reason,
+        });
+        await perpsNetworkStatusAtom.set(
+          (prev): IPerpsNetworkStatus => ({
+            ...prev,
+            connected: true,
+          }),
+        );
+        this._currentState.isConnected = true;
+        this._startPingLoop();
+        this._startPostOpenDataCheck();
+        return;
+      }
+
+      if (
+        params.client === this._client &&
+        (platformEnv.isNative || platformEnv.isNativeBackgroundThread)
+      ) {
+        // Native main/BG restart can leave the first sync request racing a
+        // stuck CONNECTING transport; recreating it lets socketOpenHandler own
+        // the eventual subscription rebuild.
+        console.log(
+          `updateSubscriptions__force_reconnect_not_open__${params.reason}`,
+        );
+        await this._forceReconnectTransport();
+      }
+    })().finally(() => {
+      this._subscriptionUpdateRecoveryPromise = null;
+    });
+
+    await this._subscriptionUpdateRecoveryPromise;
+  }
+
+  private async _waitForOpenSocket(params: {
+    client: IHyperliquidWsClient;
+    timeoutMs: number;
+  }): Promise<boolean> {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < params.timeoutMs) {
+      if (params.client !== this._client) {
+        return false;
+      }
+      const readyState = params.client.transport?.socket?.readyState;
+      if (readyState === WebSocket.OPEN) {
+        return true;
+      }
+      if (readyState === WebSocket.CLOSED || readyState === WebSocket.CLOSING) {
+        return false;
+      }
+      await timerUtils.wait(100);
+    }
+    return (
+      params.client === this._client &&
+      params.client.transport?.socket?.readyState === WebSocket.OPEN
+    );
   }
 
   private _startPostOpenDataCheck(): void {

--- a/packages/kit-bg/src/services/ServiceMarketV2.ts
+++ b/packages/kit-bg/src/services/ServiceMarketV2.ts
@@ -10,6 +10,7 @@ import {
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { memoizee } from '@onekeyhq/shared/src/utils/cacheUtils';
+import { dedupeTokenSelectorFavoriteCoins } from '@onekeyhq/shared/src/utils/perpsTokenSelectorFavorites';
 import sortUtils from '@onekeyhq/shared/src/utils/sortUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { EServiceEndpointEnum } from '@onekeyhq/shared/types/endpoint';
@@ -920,17 +921,23 @@ class ServiceMarketV2 extends ServiceBase {
   }) {
     try {
       const current = await perpTokenFavoritesPersistAtom.get();
-      const hasCoin = current.favorites.includes(coin);
+      const favorites = dedupeTokenSelectorFavoriteCoins(current.favorites);
+      const hasCoin = favorites.includes(coin);
 
       if (action === 'add' && !hasCoin) {
         await perpTokenFavoritesPersistAtom.set({
           ...current,
-          favorites: [...current.favorites, coin],
+          favorites: [...favorites, coin],
         });
       } else if (action === 'remove' && hasCoin) {
         await perpTokenFavoritesPersistAtom.set({
           ...current,
-          favorites: current.favorites.filter((f) => f !== coin),
+          favorites: favorites.filter((f) => f !== coin),
+        });
+      } else if (favorites.length !== current.favorites.length) {
+        await perpTokenFavoritesPersistAtom.set({
+          ...current,
+          favorites,
         });
       }
     } catch (error) {
@@ -985,7 +992,10 @@ class ServiceMarketV2 extends ServiceBase {
           .filter((item) => !!item.perpsCoin)
           .map((item) => item.perpsCoin ?? ''),
       );
-      const perpsCoins = new Set(perpsFavorites.favorites);
+      const dedupedPerpsFavorites = dedupeTokenSelectorFavoriteCoins(
+        perpsFavorites.favorites,
+      );
+      const perpsCoins = new Set(dedupedPerpsFavorites);
 
       // Market has but Perps doesn't
       const missingInPerps = [...marketPerpsCoins].filter(
@@ -996,6 +1006,16 @@ class ServiceMarketV2 extends ServiceBase {
         (c) => !marketPerpsCoins.has(c),
       );
 
+      if (
+        dedupedPerpsFavorites.length !== perpsFavorites.favorites.length &&
+        missingInPerps.length === 0
+      ) {
+        await perpTokenFavoritesPersistAtom.set({
+          ...perpsFavorites,
+          favorites: dedupedPerpsFavorites,
+        });
+      }
+
       if (missingInPerps.length === 0 && missingInMarket.length === 0) {
         return;
       }
@@ -1003,12 +1023,18 @@ class ServiceMarketV2 extends ServiceBase {
       // Sync missing items to Perps atom
       if (missingInPerps.length > 0) {
         const current = await perpTokenFavoritesPersistAtom.get();
-        const existingSet = new Set(current.favorites);
+        const favorites = dedupeTokenSelectorFavoriteCoins(current.favorites);
+        const existingSet = new Set(favorites);
         const toAdd = missingInPerps.filter((c) => !existingSet.has(c));
         if (toAdd.length > 0) {
           await perpTokenFavoritesPersistAtom.set({
             ...current,
-            favorites: [...current.favorites, ...toAdd],
+            favorites: [...favorites, ...toAdd],
+          });
+        } else if (favorites.length !== current.favorites.length) {
+          await perpTokenFavoritesPersistAtom.set({
+            ...current,
+            favorites,
           });
         }
       }

--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
@@ -177,6 +177,59 @@ const WebViewMemoized = memo(
 
 WebViewMemoized.displayName = 'WebViewMemoized';
 
+const hideTradingViewBuiltInLoadingScript = `
+  ;(function() {
+    var styleText = [
+      '#loading-indicator',
+      '.loading-indicator',
+      '.tv-spinner',
+      '.spinner.tv-spinner'
+    ].join(',') + '{display:none!important;visibility:hidden!important;opacity:0!important;}';
+
+    function applyStyle(doc) {
+      try {
+        if (!doc || !doc.documentElement) {
+          return;
+        }
+        if (!doc.getElementById('onekey-hide-tradingview-loading')) {
+          var style = doc.createElement('style');
+          style.id = 'onekey-hide-tradingview-loading';
+          style.textContent = styleText;
+          doc.documentElement.appendChild(style);
+        }
+      } catch (error) {
+        // noop
+      }
+    }
+
+    function applyToFrames() {
+      applyStyle(document);
+      try {
+        var frames = document.querySelectorAll('iframe');
+        for (var i = 0; i < frames.length; i += 1) {
+          var frame = frames[i];
+          applyStyle(frame.contentDocument);
+        }
+      } catch (error) {
+        // noop
+      }
+    }
+
+    applyToFrames();
+    var observer = new MutationObserver(applyToFrames);
+    observer.observe(document.documentElement, {
+      childList: true,
+      subtree: true
+    });
+    var intervalId = setInterval(applyToFrames, 100);
+    setTimeout(function() {
+      clearInterval(intervalId);
+      observer.disconnect();
+    }, 5000);
+  })();
+  true;
+`;
+
 export function TradingViewPerpsV2(
   props: ITradingViewPerpsV2Props & WebViewProps,
 ) {
@@ -205,6 +258,7 @@ export function TradingViewPerpsV2(
     }`;
   }, [reloadOnSymbolChange, symbol, theme, webviewKey]);
   const [isChartLinesReady, setIsChartLinesReady] = useState(false);
+  const [isChartContentReady, setIsChartContentReady] = useState(false);
 
   // Track webviewKey changes and reset isChartLinesReady when it changes
   const prevWebviewKeyRef = useRef(_webviewKey);
@@ -212,6 +266,7 @@ export function TradingViewPerpsV2(
     if (prevWebviewKeyRef.current !== _webviewKey) {
       // WebView will reload due to key change, reset ready state
       setIsChartLinesReady(false);
+      setIsChartContentReady(false);
       prevWebviewKeyRef.current = _webviewKey;
     }
   }, [_webviewKey]);
@@ -288,7 +343,12 @@ export function TradingViewPerpsV2(
 
   // Callback when TradingView iframe signals chart lines are ready
   const onChartLinesReady = useCallback(() => {
+    setIsChartContentReady(true);
     setIsChartLinesReady(true);
+  }, []);
+
+  const onChartReady = useCallback(() => {
+    setIsChartContentReady(true);
   }, []);
 
   const onOrderCancel = useCallback(
@@ -378,6 +438,7 @@ export function TradingViewPerpsV2(
     symbol,
     userAddress,
     webRef,
+    onChartReady,
     onChartLinesReady,
     onOrderCancel,
     onOrderDraftCreate,
@@ -408,7 +469,7 @@ export function TradingViewPerpsV2(
     (event: WebViewNavigation) => handleNavigation(event),
     [handleNavigation],
   );
-  const showSymbolReloadMask = reloadOnSymbolChange && !isChartLinesReady;
+  const showSymbolReloadMask = reloadOnSymbolChange && !isChartContentReady;
 
   return (
     <Stack position="relative" flex={1} {...stackStyle}>
@@ -419,6 +480,11 @@ export function TradingViewPerpsV2(
         onWebViewRef={onWebViewRef}
         onLoadEnd={onLoadEnd}
         onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
+        nativeInjectedJavaScriptBeforeContentLoaded={
+          platformEnv.isNativeAndroid
+            ? hideTradingViewBuiltInLoadingScript
+            : undefined
+        }
         allowsBackForwardNavigationGestures={false}
         displayProgressBar={false}
         pullToRefreshEnabled={false}
@@ -438,7 +504,7 @@ export function TradingViewPerpsV2(
           right={0}
           bottom={0}
           zIndex={2}
-          bg="background-default"
+          bg="$bgApp"
           alignItems="center"
           justifyContent="center"
           pointerEvents="none"

--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
@@ -62,6 +62,7 @@ const useSymbolSync = ({
   displayCoin,
   isChartReady,
   enabled,
+  syncOnReady = enabled,
 }: {
   webRef: React.RefObject<IWebViewRef | null>;
   symbol: string;
@@ -69,13 +70,14 @@ const useSymbolSync = ({
   displayCoin: string | undefined;
   isChartReady: boolean;
   enabled: boolean;
+  syncOnReady?: boolean;
 }) => {
   const prevParamsRef = useRef({
     displayCoin,
     displayPair,
     symbol,
   });
-  const hasSyncedReadyChartRef = useRef(false);
+  const readySyncKeyRef = useRef<string | null>(null);
 
   const sendSymbolChange = useCallback(
     ({ force }: { force: boolean }) => {
@@ -122,23 +124,32 @@ const useSymbolSync = ({
 
   // Re-sync symbol when chart becomes ready to catch messages lost during iframe load
   useEffect(() => {
-    if (!enabled) {
-      hasSyncedReadyChartRef.current = false;
+    if (!syncOnReady) {
+      readySyncKeyRef.current = null;
       return;
     }
 
     if (!isChartReady) {
-      hasSyncedReadyChartRef.current = false;
+      readySyncKeyRef.current = null;
       return;
     }
 
-    if (hasSyncedReadyChartRef.current || !webRef.current) {
+    const readySyncKey = `${symbol}:${displayPair ?? ''}:${displayCoin ?? ''}`;
+    if (readySyncKeyRef.current === readySyncKey || !webRef.current) {
       return;
     }
 
     sendSymbolChange({ force: false });
-    hasSyncedReadyChartRef.current = true;
-  }, [enabled, isChartReady, sendSymbolChange, webRef]);
+    readySyncKeyRef.current = readySyncKey;
+  }, [
+    displayCoin,
+    displayPair,
+    isChartReady,
+    sendSymbolChange,
+    symbol,
+    syncOnReady,
+    webRef,
+  ]);
 };
 
 // WebView Memoized component to prevent unnecessary re-renders
@@ -303,6 +314,8 @@ export function TradingViewPerpsV2(
   const { finalUrl: staticTradingViewUrl } = useTradingViewUrl({
     additionalParams,
   });
+  const isSpotDisplayNameSyncRequired =
+    reloadOnSymbolChange && (!!displayPair || !!displayCoin);
 
   // Optimization: Dynamic symbol parameter sync mechanism
   useSymbolSync({
@@ -310,8 +323,11 @@ export function TradingViewPerpsV2(
     symbol,
     displayPair,
     displayCoin,
-    isChartReady: isChartLinesReady,
+    isChartReady: reloadOnSymbolChange
+      ? isChartContentReady
+      : isChartLinesReady,
     enabled: !reloadOnSymbolChange,
+    syncOnReady: !reloadOnSymbolChange || isSpotDisplayNameSyncRequired,
   });
 
   const pendingRecoverRef = useRef(false);

--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/constants/messageTypes.ts
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/constants/messageTypes.ts
@@ -13,6 +13,7 @@ export const MESSAGE_TYPES = {
 
 // Iframe -> App message methods
 export const PERPS_TV_MESSAGE_METHODS = {
+  CHART_READY: 'tradingview_chartReady',
   READY: 'tradingview_perpsReady',
   LINE_DRAG_COMMIT: 'tradingview_lineDragCommit',
   ORDER_CANCEL: 'tradingview_perpsOrderCancel',

--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/messageHandlers/usePerpsTradingViewMessageHandler.ts
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/messageHandlers/usePerpsTradingViewMessageHandler.ts
@@ -37,6 +37,7 @@ import type { IWebViewRef } from '../../../WebView/types';
 import type {
   IGetMarksRequest,
   IGetMarksResponse,
+  ITVChartReadyPayload,
   ITVLineReadyPayload,
   ITVOrderCancelPayload,
   ITVOrderDraftCreatePayload,
@@ -50,6 +51,7 @@ export function usePerpsTradingViewMessageHandler({
   symbol,
   userAddress,
   webRef,
+  onChartReady,
   onChartLinesReady,
   onOrderCancel,
   onOrderDraftCreate,
@@ -59,6 +61,7 @@ export function usePerpsTradingViewMessageHandler({
   symbol: string;
   userAddress?: IHex | null;
   webRef: React.RefObject<IWebViewRef | null>;
+  onChartReady?: (payload: ITVChartReadyPayload) => void;
   onChartLinesReady?: (payload: ITVLineReadyPayload) => void;
   onOrderCancel?: (payload: ITVOrderCancelPayload) => void;
   onOrderDraftCreate?: (payload: ITVOrderDraftCreatePayload) => void;
@@ -355,7 +358,10 @@ export function usePerpsTradingViewMessageHandler({
             messageData.data as { symbol: string; requestId: string },
           );
           break;
-        case 'tradingview_perpsReady':
+        case PERPS_TV_MESSAGE_METHODS.CHART_READY:
+          onChartReady?.(messageData.data as ITVChartReadyPayload);
+          break;
+        case PERPS_TV_MESSAGE_METHODS.READY:
           // Chart lines iframe is ready to receive data
           onChartLinesReady?.(messageData.data as ITVLineReadyPayload);
           break;
@@ -394,6 +400,7 @@ export function usePerpsTradingViewMessageHandler({
     [
       handleGetMarks,
       handleGetHyperliquidPriceScale,
+      onChartReady,
       onChartLinesReady,
       onOrderCancel,
       onOrderDraftCreate,

--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/types.ts
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/types.ts
@@ -109,6 +109,11 @@ export interface ITVLineEditResultPayload {
 }
 
 // Iframe -> App messages
+export interface ITVChartReadyPayload {
+  symbol?: string;
+  containerId?: string;
+}
+
 export interface ITVLineReadyPayload {
   capabilities?: string[];
 }

--- a/packages/kit/src/views/Perp/components/FavoritesBar/FavoritesBar.web.tsx
+++ b/packages/kit/src/views/Perp/components/FavoritesBar/FavoritesBar.web.tsx
@@ -21,6 +21,7 @@ import {
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 
 import { usePerpsFavorites } from '../../hooks/usePerpsFavorites';
+import { dedupeTokenSelectorFavoritesOrder } from '../../utils/tokenSelectorFavorites';
 
 import { FavoriteTokenItem } from './FavoriteTokenItem';
 
@@ -173,7 +174,9 @@ function FavoritesBar() {
     }
     const ordered: typeof merged = [];
     const seen = new Set<string>();
-    for (const entry of favoritesOrder.sequence) {
+    for (const entry of dedupeTokenSelectorFavoritesOrder(
+      favoritesOrder.sequence,
+    )) {
       const key = `${entry.mode}:${entry.coinName}`;
       const item = lookup.get(key);
       if (item) {
@@ -199,8 +202,8 @@ function FavoritesBar() {
       const allKeys = new Set<string>();
       for (const it of perpItems) allKeys.add(`${it.mode}:${it.coinName}`);
       for (const it of spotItems) allKeys.add(`${it.mode}:${it.coinName}`);
-      const filtered = prev.sequence.filter((e) =>
-        allKeys.has(`${e.mode}:${e.coinName}`),
+      const filtered = dedupeTokenSelectorFavoritesOrder(prev.sequence).filter(
+        (e) => allKeys.has(`${e.mode}:${e.coinName}`),
       );
       const seqKeys = new Set(filtered.map((e) => `${e.mode}:${e.coinName}`));
       const additions: IPerpsFavoritesOrderEntry[] = [];
@@ -251,7 +254,7 @@ function FavoritesBar() {
       if (!sourceItem || !destItem) return;
 
       setFavoritesOrder((prev) => {
-        const next = [...prev.sequence];
+        const next = dedupeTokenSelectorFavoritesOrder(prev.sequence);
         const sourceIdx = next.findIndex(
           (e) =>
             e.mode === sourceItem.mode && e.coinName === sourceItem.coinName,

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -75,6 +75,8 @@ const shouldTreatPerpAsFocusedOnMount = !!(
   platformEnv.isExtensionUiStandaloneWindow
 );
 
+let lastRecoveredPerpsLocaleVariant: string | undefined;
+
 function resolvePerpRouteFocused(isFocus: boolean) {
   return shouldTreatPerpAsFocusedOnMount || isFocus;
 }
@@ -570,11 +572,7 @@ function WebSocketSubscriptionUpdate() {
       },
     );
 
-    if (
-      isWebSocketConnected === true &&
-      !isLoading &&
-      plan.shouldSyncSubscriptions
-    ) {
+    if (!isLoading && plan.shouldSyncSubscriptions) {
       void actions.current.updateSubscriptions();
     }
   }, [
@@ -697,19 +695,32 @@ function useHyperliquidScreenLockHandler() {
 function useHyperliquidLocaleChangeRecovery() {
   const localeVariant = useLocaleVariant();
   const actions = useHyperliquidActions();
-  const isFocusedRef = useRef(false);
+  const isRouteFocused = useRouteIsFocused();
+  const isFocusedRef = useRef(resolvePerpRouteFocused(isRouteFocused));
   const pendingRecoveryRef = useRef(false);
+  const recoveryPromiseRef = useRef<Promise<void> | null>(null);
+  const localeVariantRef = useRef(localeVariant);
+  localeVariantRef.current = localeVariant;
 
   const recoverSubscriptions = useCallback(async () => {
-    await backgroundApiProxy.serviceHyperliquidSubscription.enableSubscriptionsHandler();
-    await backgroundApiProxy.serviceHyperliquidSubscription.resumeSubscriptions(
-      {
-        forceRebuild: true,
-        forceReconnect: platformEnv.isNativeIOS,
-      },
-    );
-    await actions.current.updateSubscriptions();
-    await backgroundApiProxy.serviceHyperliquidSubscription.forceReloadCandlesWebview();
+    if (recoveryPromiseRef.current) {
+      await recoveryPromiseRef.current;
+      return;
+    }
+    recoveryPromiseRef.current = (async () => {
+      await backgroundApiProxy.serviceHyperliquidSubscription.enableSubscriptionsHandler();
+      await backgroundApiProxy.serviceHyperliquidSubscription.resumeSubscriptions(
+        {
+          forceRebuild: true,
+        },
+      );
+      await actions.current.updateSubscriptions();
+      await backgroundApiProxy.serviceHyperliquidSubscription.forceReloadCandlesWebview();
+      lastRecoveredPerpsLocaleVariant = localeVariantRef.current;
+    })().finally(() => {
+      recoveryPromiseRef.current = null;
+    });
+    await recoveryPromiseRef.current;
   }, [actions]);
 
   useListenTabFocusState(
@@ -724,7 +735,15 @@ function useHyperliquidLocaleChangeRecovery() {
     },
   );
 
-  useUpdateEffect(() => {
+  useEffect(() => {
+    const currentLocaleVariant = localeVariantRef.current;
+    if (lastRecoveredPerpsLocaleVariant === undefined) {
+      lastRecoveredPerpsLocaleVariant = currentLocaleVariant;
+      return;
+    }
+    if (lastRecoveredPerpsLocaleVariant === currentLocaleVariant) {
+      return;
+    }
     if (!isFocusedRef.current) {
       pendingRecoveryRef.current = true;
       return;

--- a/packages/kit/src/views/Perp/components/TokenSelector/FavoritesEmptyState.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/FavoritesEmptyState.tsx
@@ -13,7 +13,6 @@ import {
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import { usePerpsAllAssetsFilteredAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
-import { usePerpTokenFavoritesPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { getHyperliquidTokenImageUrl } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type { IPerpsUniverse } from '@onekeyhq/shared/types/hyperliquid';
@@ -34,7 +33,6 @@ const QUICK_ADD_TOKENS: IQuickAddToken[] = [
 ];
 
 export function FavoritesEmptyState({ isMobile }: { isMobile?: boolean }) {
-  const [favorites, setFavorites] = usePerpTokenFavoritesPersistAtom();
   const [{ assetsByDex }] = usePerpsAllAssetsFilteredAtom();
   const [selectedTokens, setSelectedTokens] = useState<Set<string>>(
     new Set(QUICK_ADD_TOKENS.map((token) => token.coinName)),
@@ -61,7 +59,7 @@ export function FavoritesEmptyState({ isMobile }: { isMobile?: boolean }) {
     selectedTokens.forEach((coinName) => {
       for (const assets of assetsByDexTyped) {
         const foundAsset = assets.find((a) => a.name === coinName);
-        if (foundAsset && !favorites.favorites.includes(foundAsset.name)) {
+        if (foundAsset) {
           tokensToAdd.push(foundAsset.name);
           break;
         }
@@ -69,22 +67,17 @@ export function FavoritesEmptyState({ isMobile }: { isMobile?: boolean }) {
     });
 
     if (tokensToAdd.length > 0) {
-      setFavorites((prev) => ({
-        ...prev,
-        favorites: [...prev.favorites, ...tokensToAdd],
-      }));
-
       for (const coin of tokensToAdd) {
-        void backgroundApiProxy.serviceMarketV2.syncToMarketWatchList({
+        void backgroundApiProxy.serviceHyperliquid.updateTokenSelectorFavorite({
+          mode: 'perp',
           coin,
           action: 'add',
         });
       }
 
-      // Clear selection after adding to favorites
       setSelectedTokens(new Set());
     }
-  }, [selectedTokens, assetsByDex, favorites.favorites, setFavorites]);
+  }, [selectedTokens, assetsByDex]);
 
   return (
     <YStack flex={1} gap="$3" alignItems="center">

--- a/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
@@ -77,7 +77,12 @@ import {
 } from '../../hooks';
 import { PerpsAccountSelectorProviderMirror } from '../../PerpsAccountSelectorProviderMirror';
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
-import { getTokenSelectorFavoriteItems } from '../../utils/tokenSelectorFavorites';
+import {
+  getTokenSelectorFavoriteItems,
+  getTokenSelectorFavoriteSortEntry,
+  getTokenSelectorListItemKey,
+  sortTokenSelectorFavoriteItems,
+} from '../../utils/tokenSelectorFavorites';
 import {
   markTokenSelectorPerfMeasure,
   startTokenSelectorPerfMeasure,
@@ -742,6 +747,22 @@ function MobileTokenSelectorModal({
         perpItems: perpSortedList,
         spotItems: spotFavoriteSortedList,
       });
+      if (sortField) {
+        result = sortTokenSelectorFavoriteItems({
+          items: result,
+          sortField,
+          sortDirection,
+          getSortEntry: (item, order) =>
+            getTokenSelectorFavoriteSortEntry({
+              item,
+              order,
+              spotPriceSnapshot,
+              spotMarketCaps,
+              perpAssetCtxsByDex: ctxSnapshotRef.current,
+              computePerpSortValues: computeSortValues,
+            }),
+        });
+      }
     } else if (isPerpTokenSelectorPerpsTab(displayActiveTab)) {
       result = perpSortedList;
     } else {
@@ -788,10 +809,13 @@ function MobileTokenSelectorModal({
     categoryTabs,
     favoritesOrder.sequence,
     favoriteItems,
+    computeSortValues,
     perpSortedList,
     selectorConfig?.direction,
     selectorConfig?.field,
     spotFavoriteSortedList,
+    spotMarketCaps,
+    spotPriceSnapshot,
     spotSortedList,
     searchQuery,
   ]);
@@ -805,10 +829,7 @@ function MobileTokenSelectorModal({
   });
 
   const keyExtractor = useCallback(
-    (item: { dexIndex: number; assetId?: number; index: number }) => {
-      const assetId = item.assetId ?? item.index;
-      return `${item.dexIndex}-${assetId}`;
-    },
+    (item: ITokenSelectorListItem) => getTokenSelectorListItemKey(item),
     [],
   );
 

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -83,7 +83,12 @@ import {
   usePerpsFavorites,
 } from '../../hooks';
 import { useActiveTradeDisplay } from '../../hooks/useActiveTradeDisplay';
-import { getTokenSelectorFavoriteItems } from '../../utils/tokenSelectorFavorites';
+import {
+  getTokenSelectorFavoriteItems,
+  getTokenSelectorFavoriteSortEntry,
+  getTokenSelectorListItemKey,
+  sortTokenSelectorFavoriteItems,
+} from '../../utils/tokenSelectorFavorites';
 import {
   markTokenSelectorPerfMeasure,
   startTokenSelectorPerfMeasure,
@@ -903,6 +908,22 @@ function BasePerpTokenSelectorContent({
         perpItems: perpSortedList,
         spotItems: spotFavoriteSortedList,
       });
+      if (sortField) {
+        result = sortTokenSelectorFavoriteItems({
+          items: result,
+          sortField,
+          sortDirection,
+          getSortEntry: (item, order) =>
+            getTokenSelectorFavoriteSortEntry({
+              item,
+              order,
+              spotPriceSnapshot,
+              spotMarketCaps,
+              perpAssetCtxsByDex: ctxSnapshotRef.current,
+              computePerpSortValues: computeSortValues,
+            }),
+        });
+      }
     } else if (isPerpTokenSelectorPerpsTab(displayActiveTab)) {
       result = perpSortedList;
     } else {
@@ -947,10 +968,13 @@ function BasePerpTokenSelectorContent({
     displayPrimaryTab,
     assetsByDex,
     categoryTabs,
+    computeSortValues,
     favoritesOrder.sequence,
     favoriteItems,
     perpSortedList,
     spotFavoriteSortedList,
+    spotMarketCaps,
+    spotPriceSnapshot,
     spotSortedList,
     searchQuery,
     selectorConfig?.direction,
@@ -966,10 +990,7 @@ function BasePerpTokenSelectorContent({
   });
 
   const keyExtractor = useCallback(
-    (item: { dexIndex: number; index: number; assetId?: number }) => {
-      const assetId = item.assetId ?? item.index;
-      return `${item.dexIndex}-${assetId}`;
-    },
+    (item: ITokenSelectorListItem) => getTokenSelectorListItemKey(item),
     [],
   );
   const desktopListLayout = useMemo((): 'perp' | 'spot' | 'mixed' => {

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
@@ -41,6 +41,10 @@ import {
   formatLocalizedNumberString,
 } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
+  reconcileTokenSelectorFavoritesOrder,
+  updateTokenSelectorFavoriteCoins,
+} from '@onekeyhq/shared/src/utils/perpsTokenSelectorFavorites';
+import {
   formatSpotPairDisplayName,
   formatSpotPriceToValid,
   formatWithPrecision,
@@ -228,56 +232,54 @@ export const FavoriteButton = memo(
       : perpFavs.favorites.includes(coin);
 
     const handleToggle = useCallback(() => {
-      const mode: 'perp' | 'spot' = isSpot ? 'spot' : 'perp';
-      const toggleFavorites = (prev: string[]) => {
-        const removing = prev.includes(coin);
-        return removing ? prev.filter((f) => f !== coin) : [...prev, coin];
-      };
-      const wasFavorited = isSpot
-        ? spotFavs.favorites.includes(coin)
-        : perpFavs.favorites.includes(coin);
+      const mode = isSpot ? 'spot' : 'perp';
+      const action = isFavorite ? 'remove' : 'add';
+      const updateFavorites = (favorites: string[]) =>
+        updateTokenSelectorFavoriteCoins({
+          favorites,
+          coin,
+          action,
+        }).favorites;
+
       if (isSpot) {
         setSpotFavs((prev) => ({
           ...prev,
-          favorites: toggleFavorites(prev.favorites),
+          favorites: updateFavorites(prev.favorites),
         }));
       } else {
-        setPerpFavs((prev) => {
-          const removing = prev.favorites.includes(coin);
-          void backgroundApiProxy.serviceMarketV2.syncToMarketWatchList({
-            coin,
-            action: removing ? 'remove' : 'add',
-          });
-          return {
-            ...prev,
-            favorites: toggleFavorites(prev.favorites),
-          };
-        });
+        setPerpFavs((prev) => ({
+          ...prev,
+          favorites: updateFavorites(prev.favorites),
+        }));
       }
-      // FavoritesBar's passive sync would eventually backfill, but writing
-      // directly here avoids a one-frame flicker on add/remove.
-      setFavoritesOrder((prev) => {
-        if (wasFavorited) {
-          return {
-            sequence: prev.sequence.filter(
-              (e) => !(e.mode === mode && e.coinName === coin),
-            ),
-          };
-        }
-        if (prev.sequence.some((e) => e.mode === mode && e.coinName === coin)) {
-          return prev;
-        }
-        return {
-          sequence: [...prev.sequence, { mode, coinName: coin }],
-        };
+
+      const nextPerpFavorites = isSpot
+        ? perpFavs.favorites
+        : updateFavorites(perpFavs.favorites);
+      const nextSpotFavorites = isSpot
+        ? updateFavorites(spotFavs.favorites)
+        : spotFavs.favorites;
+      setFavoritesOrder((prev) => ({
+        sequence: reconcileTokenSelectorFavoritesOrder({
+          sequence: prev.sequence,
+          perpFavorites: nextPerpFavorites,
+          spotFavorites: nextSpotFavorites,
+        }),
+      }));
+
+      void backgroundApiProxy.serviceHyperliquid.updateTokenSelectorFavorite({
+        mode,
+        coin,
+        action,
       });
     }, [
       coin,
+      isFavorite,
       isSpot,
+      perpFavs.favorites,
+      setFavoritesOrder,
       setPerpFavs,
       setSpotFavs,
-      setFavoritesOrder,
-      perpFavs.favorites,
       spotFavs.favorites,
     ]);
 

--- a/packages/kit/src/views/Perp/hooks/usePerpsFavorites.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpsFavorites.ts
@@ -16,6 +16,7 @@ import type {
 } from '@onekeyhq/shared/types/hyperliquid';
 
 import { usePromiseResult } from '../../../hooks/usePromiseResult';
+import { dedupeTokenSelectorFavoriteCoins } from '../utils/tokenSelectorFavorites';
 
 export type IFavoriteItem = {
   mode: 'perp' | 'spot';
@@ -43,6 +44,10 @@ export function usePerpsFavorites(options?: {
     favoritesMode === 'spot'
       ? spotFavorites.favorites
       : perpFavorites.favorites;
+  const uniqueFavorites = useMemo(
+    () => dedupeTokenSelectorFavoriteCoins(favorites),
+    [favorites],
+  );
 
   // Fetch the full universe independently — must not read from the
   // search-filtered atom, otherwise favorites disappear during search.
@@ -88,7 +93,7 @@ export function usePerpsFavorites(options?: {
   );
 
   const favoriteItems = useMemo(() => {
-    if (!favorites.length || !taggedUniverse) {
+    if (!uniqueFavorites.length || !taggedUniverse) {
       return [];
     }
 
@@ -99,7 +104,7 @@ export function usePerpsFavorites(options?: {
       if (!spotUniverses.length) {
         return [];
       }
-      favorites.forEach((favCoin) => {
+      uniqueFavorites.forEach((favCoin) => {
         const asset = spotUniverses.find((item) => item.name === favCoin);
         if (asset) {
           items.push({
@@ -124,7 +129,7 @@ export function usePerpsFavorites(options?: {
     if (!perpsUniverses.length) {
       return [];
     }
-    favorites.forEach((favCoin) => {
+    uniqueFavorites.forEach((favCoin) => {
       for (let dexIndex = 0; dexIndex < perpsUniverses.length; dexIndex += 1) {
         const assets = perpsUniverses[dexIndex];
         const asset = Array.isArray(assets)
@@ -146,7 +151,7 @@ export function usePerpsFavorites(options?: {
     });
 
     return items;
-  }, [favorites, taggedUniverse]);
+  }, [uniqueFavorites, taggedUniverse]);
 
   return { favoriteItems, isReady: taggedUniverse !== undefined };
 }

--- a/packages/kit/src/views/Perp/utils/subscriptionPlanner.test.ts
+++ b/packages/kit/src/views/Perp/utils/subscriptionPlanner.test.ts
@@ -86,6 +86,33 @@ describe('planTradeSubscriptions', () => {
     expect(plan.shouldSyncSubscriptions).toBe(true);
   });
 
+  it('syncs a focused perp market before order book options arrive', () => {
+    const plan = planTradeSubscriptions({
+      activeInstrument: baseInstrument,
+      hasAccount: true,
+      viewState: {
+        ...baseViewState,
+        routeFocused: true,
+      },
+    });
+
+    expect(plan.shouldSyncSubscriptions).toBe(true);
+  });
+
+  it('syncs a focused perp market while order book options lag behind the active coin', () => {
+    const plan = planTradeSubscriptions({
+      activeInstrument: baseInstrument,
+      hasAccount: true,
+      orderBookOptions: { coin: 'ETH', assetId: 1 },
+      viewState: {
+        ...baseViewState,
+        routeFocused: true,
+      },
+    });
+
+    expect(plan.shouldSyncSubscriptions).toBe(true);
+  });
+
   it('does not sync subscriptions for a hidden perps-only selector tab', () => {
     const plan = planTradeSubscriptions({
       activeInstrument: baseInstrument,

--- a/packages/kit/src/views/Perp/utils/subscriptionPlanner.ts
+++ b/packages/kit/src/views/Perp/utils/subscriptionPlanner.ts
@@ -22,7 +22,7 @@ export function planTradeSubscriptions(params: {
   orderBookOptions?: IPerpsActiveOrderBookOptionsAtom;
   viewState: ITradeRouteViewState;
 }): ITradeSubscriptionPlan {
-  const { activeInstrument, hasAccount, orderBookOptions, viewState } = params;
+  const { activeInstrument, hasAccount, viewState } = params;
   const instrumentCoin = activeInstrument?.coin ?? '';
   const isSpot = activeInstrument?.mode === 'spot';
   const isSpotSelectorOpen =
@@ -52,8 +52,7 @@ export function planTradeSubscriptions(params: {
         shouldSyncSelectorSubscriptions || Boolean(instrumentCoin);
     } else {
       shouldSyncSubscriptions =
-        shouldSyncSelectorSubscriptions ||
-        (Boolean(instrumentCoin) && orderBookOptions?.coin === instrumentCoin);
+        shouldSyncSelectorSubscriptions || Boolean(instrumentCoin);
     }
   }
 

--- a/packages/kit/src/views/Perp/utils/tokenSelectorFavorites.test.ts
+++ b/packages/kit/src/views/Perp/utils/tokenSelectorFavorites.test.ts
@@ -1,4 +1,12 @@
-import { getTokenSelectorFavoriteItems } from './tokenSelectorFavorites';
+import {
+  dedupeTokenSelectorFavoriteCoins,
+  dedupeTokenSelectorFavoritesOrder,
+  getTokenSelectorFavoriteItems,
+  reconcileTokenSelectorFavoritesOrder,
+  sortTokenSelectorFavoriteItems,
+  toggleTokenSelectorFavoriteCoin,
+  updateTokenSelectorFavoriteCoins,
+} from './tokenSelectorFavorites';
 
 describe('tokenSelectorFavorites', () => {
   it('keeps spot favorites in the favorites selector list', () => {
@@ -44,5 +52,140 @@ describe('tokenSelectorFavorites', () => {
         spotItems: [{ dexIndex: -1, assetId: 0, tokenName: 'BTC' }],
       }),
     ).toEqual([{ dexIndex: 0, assetId: 0, tokenName: 'BTC' }]);
+  });
+
+  it('ignores duplicate favorites order entries', () => {
+    expect(
+      getTokenSelectorFavoriteItems({
+        favoriteItems: [
+          { mode: 'spot', coinName: '@234', dexIndex: -1, assetId: 10_234 },
+        ],
+        favoritesOrder: [
+          { mode: 'spot', coinName: '@234' },
+          { mode: 'spot', coinName: '@234' },
+        ],
+        perpItems: [],
+        spotItems: [{ dexIndex: -1, assetId: 10_234, tokenName: '@234' }],
+      }),
+    ).toEqual([{ dexIndex: -1, assetId: 10_234, tokenName: '@234' }]);
+  });
+
+  it('ignores duplicate favorite membership entries', () => {
+    expect(
+      getTokenSelectorFavoriteItems({
+        favoriteItems: [
+          { mode: 'spot', coinName: '@234', dexIndex: -1, assetId: 10_234 },
+          { mode: 'spot', coinName: '@234', dexIndex: -1, assetId: 10_234 },
+        ],
+        favoritesOrder: [],
+        perpItems: [],
+        spotItems: [{ dexIndex: -1, assetId: 10_234, tokenName: '@234' }],
+      }),
+    ).toEqual([{ dexIndex: -1, assetId: 10_234, tokenName: '@234' }]);
+  });
+
+  it('sorts mixed spot and perp favorites globally', () => {
+    const items = [
+      { dexIndex: 0, assetId: 1, tokenName: 'SOL' },
+      { dexIndex: -1, assetId: 10_234, tokenName: 'BTC/USDH' },
+      { dexIndex: 0, assetId: 2, tokenName: 'HYPE' },
+      { dexIndex: -1, assetId: 10_142, tokenName: 'ZEC/USDC' },
+    ];
+    const changeByTokenName: Record<string, number> = {
+      SOL: -1.21,
+      'BTC/USDH': 0.46,
+      HYPE: 6.2,
+      'ZEC/USDC': 0.4,
+    };
+
+    expect(
+      sortTokenSelectorFavoriteItems({
+        items,
+        sortField: 'change24hPercent',
+        sortDirection: 'desc',
+        getSortEntry: (item, order) => ({
+          item,
+          order,
+          name: item.tokenName,
+          change24hPercent: changeByTokenName[item.tokenName],
+        }),
+      }).map((item) => item.tokenName),
+    ).toEqual(['HYPE', 'BTC/USDH', 'ZEC/USDC', 'SOL']);
+  });
+
+  it('dedupes favorite coin lists while preserving order', () => {
+    expect(dedupeTokenSelectorFavoriteCoins(['BTC', 'ETH', 'BTC'])).toEqual([
+      'BTC',
+      'ETH',
+    ]);
+  });
+
+  it('dedupes favorite order entries by mode and coin', () => {
+    expect(
+      dedupeTokenSelectorFavoritesOrder([
+        { mode: 'perp', coinName: 'BTC' },
+        { mode: 'perp', coinName: 'BTC' },
+        { mode: 'spot', coinName: 'BTC' },
+      ]),
+    ).toEqual([
+      { mode: 'perp', coinName: 'BTC' },
+      { mode: 'spot', coinName: 'BTC' },
+    ]);
+  });
+
+  it('removes all duplicate copies when toggling off a favorite', () => {
+    expect(
+      toggleTokenSelectorFavoriteCoin({
+        favorites: ['BTC', 'ETH', 'BTC'],
+        coin: 'BTC',
+      }),
+    ).toEqual({
+      favorites: ['ETH'],
+      action: 'remove',
+    });
+  });
+
+  it('normalizes existing duplicates when toggling on a favorite', () => {
+    expect(
+      toggleTokenSelectorFavoriteCoin({
+        favorites: ['ETH', 'ETH'],
+        coin: 'BTC',
+      }),
+    ).toEqual({
+      favorites: ['ETH', 'BTC'],
+      action: 'add',
+    });
+  });
+
+  it('removes all duplicate copies with an explicit remove action', () => {
+    expect(
+      updateTokenSelectorFavoriteCoins({
+        favorites: ['HYPE', 'xyz:SILVER', 'xyz:SILVER'],
+        coin: 'xyz:SILVER',
+        action: 'remove',
+      }),
+    ).toEqual({
+      favorites: ['HYPE'],
+      action: 'remove',
+    });
+  });
+
+  it('reconciles mixed favorite order from current membership', () => {
+    expect(
+      reconcileTokenSelectorFavoritesOrder({
+        sequence: [
+          { mode: 'perp', coinName: 'xyz:SILVER' },
+          { mode: 'spot', coinName: '@230' },
+          { mode: 'perp', coinName: 'stale' },
+          { mode: 'spot', coinName: '@230' },
+        ],
+        perpFavorites: ['HYPE'],
+        spotFavorites: ['@230', '@156'],
+      }),
+    ).toEqual([
+      { mode: 'spot', coinName: '@230' },
+      { mode: 'perp', coinName: 'HYPE' },
+      { mode: 'spot', coinName: '@156' },
+    ]);
   });
 });

--- a/packages/kit/src/views/Perp/utils/tokenSelectorFavorites.ts
+++ b/packages/kit/src/views/Perp/utils/tokenSelectorFavorites.ts
@@ -1,3 +1,24 @@
+import type { ITokenSelectorFavoriteOrderEntry } from '@onekeyhq/shared/src/utils/perpsTokenSelectorFavorites';
+import {
+  dedupeTokenSelectorFavoriteCoins,
+  dedupeTokenSelectorFavoritesOrder,
+  getTokenSelectorFavoriteOrderKey,
+  reconcileTokenSelectorFavoritesOrder,
+  toggleTokenSelectorFavoriteCoin,
+  updateTokenSelectorFavoriteCoins,
+} from '@onekeyhq/shared/src/utils/perpsTokenSelectorFavorites';
+import {
+  compareSpotMarketCapValues,
+  getSpotMarketCapValue,
+} from '@onekeyhq/shared/src/utils/perpsUtils';
+import type {
+  IPerpTokenSortDirection,
+  IPerpTokenSortField,
+  IPerpsAssetCtx,
+  ISpotUniverse,
+} from '@onekeyhq/shared/types/hyperliquid';
+import { XYZ_ASSET_ID_OFFSET } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+
 type ITokenSelectorFavoriteItem = {
   mode: 'perp' | 'spot';
   coinName: string;
@@ -5,18 +26,62 @@ type ITokenSelectorFavoriteItem = {
   assetId: number;
 };
 
-type ITokenSelectorFavoriteOrderEntry = {
-  mode: 'perp' | 'spot';
-  coinName: string;
-};
-
 type ITokenSelectorListItemLike = {
   dexIndex: number;
   assetId?: number;
 };
 
+type ITokenSelectorSortableListItemLike = ITokenSelectorListItemLike & {
+  index: number;
+  tokenName?: string;
+  spotUniverse?: Pick<ISpotUniverse, 'name' | 'baseName'>;
+};
+
+type ITokenSelectorFavoriteSortEntry<T extends ITokenSelectorListItemLike> = {
+  item: T;
+  order: number;
+  name?: string;
+  markPrice?: number;
+  change24hPercent?: number;
+  fundingRate?: number;
+  volume24h?: number;
+  openInterestValue?: number;
+  marketCap?: number;
+};
+
+type ITokenSelectorPerpSortValues = {
+  markPrice: number;
+  fundingRate: number;
+  volume24h: number;
+  openInterestValue: number;
+  change24hPercent: number;
+};
+
+type ITokenSelectorSpotCtx = {
+  markPx?: string;
+  markPrice?: string;
+  prevDayPx?: string;
+  dayNtlVlm?: string | number;
+  totalSupply?: string;
+  circulatingSupply?: string;
+};
+
 function getTokenSelectorFavoriteKey(item: ITokenSelectorListItemLike): string {
   return `${item.dexIndex}-${item.assetId ?? ''}`;
+}
+
+function dedupeTokenSelectorFavoriteItems(
+  favoriteItems: ITokenSelectorFavoriteItem[],
+): ITokenSelectorFavoriteItem[] {
+  const seen = new Set<string>();
+  return favoriteItems.filter((item) => {
+    const key = getTokenSelectorFavoriteOrderKey(item);
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
 }
 
 function getTokenSelectorFavoriteItems<T extends ITokenSelectorListItemLike>({
@@ -30,6 +95,8 @@ function getTokenSelectorFavoriteItems<T extends ITokenSelectorListItemLike>({
   perpItems: T[];
   spotItems: T[];
 }): T[] {
+  const uniqueFavoriteItems = dedupeTokenSelectorFavoriteItems(favoriteItems);
+
   const perpItemsByKey = new Map(
     perpItems.map((item) => [getTokenSelectorFavoriteKey(item), item]),
   );
@@ -38,21 +105,24 @@ function getTokenSelectorFavoriteItems<T extends ITokenSelectorListItemLike>({
   );
   const favoriteRowsByOrderKey = new Map<string, T>();
 
-  for (const favorite of favoriteItems) {
+  for (const favorite of uniqueFavoriteItems) {
     const itemKey = getTokenSelectorFavoriteKey(favorite);
     const row =
       favorite.mode === 'spot'
         ? spotItemsByKey.get(itemKey)
         : perpItemsByKey.get(itemKey);
     if (row) {
-      favoriteRowsByOrderKey.set(`${favorite.mode}:${favorite.coinName}`, row);
+      favoriteRowsByOrderKey.set(
+        getTokenSelectorFavoriteOrderKey(favorite),
+        row,
+      );
     }
   }
 
   const ordered: T[] = [];
   const seenOrderKeys = new Set<string>();
-  for (const entry of favoritesOrder) {
-    const orderKey = `${entry.mode}:${entry.coinName}`;
+  for (const entry of dedupeTokenSelectorFavoritesOrder(favoritesOrder)) {
+    const orderKey = getTokenSelectorFavoriteOrderKey(entry);
     const row = favoriteRowsByOrderKey.get(orderKey);
     if (row) {
       ordered.push(row);
@@ -60,8 +130,8 @@ function getTokenSelectorFavoriteItems<T extends ITokenSelectorListItemLike>({
     }
   }
 
-  for (const favorite of favoriteItems) {
-    const orderKey = `${favorite.mode}:${favorite.coinName}`;
+  for (const favorite of uniqueFavoriteItems) {
+    const orderKey = getTokenSelectorFavoriteOrderKey(favorite);
     if (!seenOrderKeys.has(orderKey)) {
       const row = favoriteRowsByOrderKey.get(orderKey);
       if (row) {
@@ -74,4 +144,165 @@ function getTokenSelectorFavoriteItems<T extends ITokenSelectorListItemLike>({
   return ordered;
 }
 
-export { getTokenSelectorFavoriteItems };
+function getTokenSelectorListItemKey(item: ITokenSelectorSortableListItemLike) {
+  if (item.spotUniverse) {
+    return `spot-${item.spotUniverse.name}`;
+  }
+  const assetId = item.assetId ?? item.index;
+  return `perp-${item.dexIndex}-${assetId}-${item.tokenName ?? ''}`;
+}
+
+function getTokenSelectorFavoriteSortEntry<
+  T extends ITokenSelectorSortableListItemLike,
+>({
+  item,
+  order,
+  spotPriceSnapshot,
+  spotMarketCaps,
+  perpAssetCtxsByDex,
+  computePerpSortValues,
+}: {
+  item: T;
+  order: number;
+  spotPriceSnapshot: Record<string, ITokenSelectorSpotCtx | undefined>;
+  spotMarketCaps: Record<string, string>;
+  perpAssetCtxsByDex: IPerpsAssetCtx[][] | undefined;
+  computePerpSortValues: (
+    assetCtx: IPerpsAssetCtx | undefined,
+  ) => ITokenSelectorPerpSortValues;
+}): ITokenSelectorFavoriteSortEntry<T> {
+  if (item.spotUniverse) {
+    const ctx = spotPriceSnapshot[item.spotUniverse.name];
+    const markPrice = Number(ctx?.markPx || ctx?.markPrice || 0);
+    const prevDayPx = Number(ctx?.prevDayPx || 0);
+    const change24hPercent =
+      prevDayPx > 0 ? ((markPrice - prevDayPx) / prevDayPx) * 100 : 0;
+    const volume24h = Number(ctx?.dayNtlVlm || 0);
+    const marketCapValue = getSpotMarketCapValue(
+      ctx,
+      item.spotUniverse.baseName,
+      spotMarketCaps,
+    );
+    const marketCap = marketCapValue ? Number(marketCapValue) : undefined;
+    return {
+      item,
+      order,
+      name: item.spotUniverse.baseName,
+      markPrice,
+      change24hPercent,
+      volume24h,
+      openInterestValue: marketCap,
+      marketCap,
+    };
+  }
+
+  const itemAssetId = item.assetId ?? item.index;
+  const normalizedAssetId =
+    item.dexIndex === 1 ? itemAssetId - XYZ_ASSET_ID_OFFSET : itemAssetId;
+  const sortValues = computePerpSortValues(
+    perpAssetCtxsByDex?.[item.dexIndex]?.[normalizedAssetId],
+  );
+  return {
+    item,
+    order,
+    name: item.tokenName,
+    markPrice: sortValues.markPrice,
+    change24hPercent: sortValues.change24hPercent,
+    fundingRate: sortValues.fundingRate,
+    volume24h: sortValues.volume24h,
+    openInterestValue: sortValues.openInterestValue,
+  };
+}
+
+function sortTokenSelectorFavoriteItems<T extends ITokenSelectorListItemLike>({
+  items,
+  sortField,
+  sortDirection,
+  getSortEntry,
+}: {
+  items: T[];
+  sortField?: IPerpTokenSortField | '';
+  sortDirection: IPerpTokenSortDirection;
+  getSortEntry: (item: T, order: number) => ITokenSelectorFavoriteSortEntry<T>;
+}): T[] {
+  if (!sortField) {
+    return items;
+  }
+
+  return items
+    .map((item, order) => getSortEntry(item, order))
+    .toSorted((a, b) => {
+      let compareResult = 0;
+      switch (sortField) {
+        case 'name':
+          compareResult = (a.name ?? '').localeCompare(
+            b.name ?? '',
+            undefined,
+            {
+              sensitivity: 'base',
+            },
+          );
+          compareResult =
+            sortDirection === 'asc' ? compareResult : -compareResult;
+          break;
+        case 'markPrice':
+          compareResult = compareSpotMarketCapValues(
+            a.markPrice,
+            b.markPrice,
+            sortDirection,
+          );
+          break;
+        case 'change24hPercent':
+          compareResult = compareSpotMarketCapValues(
+            a.change24hPercent,
+            b.change24hPercent,
+            sortDirection,
+          );
+          break;
+        case 'fundingRate':
+          compareResult = compareSpotMarketCapValues(
+            a.fundingRate,
+            b.fundingRate,
+            sortDirection,
+          );
+          break;
+        case 'volume24h':
+          compareResult = compareSpotMarketCapValues(
+            a.volume24h,
+            b.volume24h,
+            sortDirection,
+          );
+          break;
+        case 'openInterest':
+          compareResult = compareSpotMarketCapValues(
+            a.openInterestValue,
+            b.openInterestValue,
+            sortDirection,
+          );
+          break;
+        case 'marketCap':
+          compareResult = compareSpotMarketCapValues(
+            a.marketCap,
+            b.marketCap,
+            sortDirection,
+          );
+          break;
+        default:
+          break;
+      }
+      return compareResult || a.order - b.order;
+    })
+    .map((entry) => entry.item);
+}
+
+export {
+  dedupeTokenSelectorFavoriteCoins,
+  dedupeTokenSelectorFavoritesOrder,
+  getTokenSelectorFavoriteSortEntry,
+  getTokenSelectorFavoriteItems,
+  getTokenSelectorListItemKey,
+  reconcileTokenSelectorFavoritesOrder,
+  sortTokenSelectorFavoriteItems,
+  toggleTokenSelectorFavoriteCoin,
+  updateTokenSelectorFavoriteCoins,
+};

--- a/packages/shared/src/utils/perpsTokenSelectorFavorites.ts
+++ b/packages/shared/src/utils/perpsTokenSelectorFavorites.ts
@@ -1,0 +1,147 @@
+export type ITokenSelectorFavoriteMode = 'perp' | 'spot';
+export type ITokenSelectorFavoriteAction = 'add' | 'remove' | 'toggle';
+export type IResolvedTokenSelectorFavoriteAction = 'add' | 'remove' | 'none';
+
+export type ITokenSelectorFavoriteOrderEntry = {
+  mode: ITokenSelectorFavoriteMode;
+  coinName: string;
+};
+
+function getTokenSelectorFavoriteOrderKey(
+  entry: ITokenSelectorFavoriteOrderEntry,
+): string {
+  return `${entry.mode}:${entry.coinName}`;
+}
+
+function dedupeTokenSelectorFavoriteCoins(favorites: string[]) {
+  return [...new Set(favorites)];
+}
+
+function dedupeTokenSelectorFavoritesOrder(
+  sequence: ITokenSelectorFavoriteOrderEntry[],
+) {
+  const seen = new Set<string>();
+  return sequence.filter((entry) => {
+    const key = getTokenSelectorFavoriteOrderKey(entry);
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function updateTokenSelectorFavoriteCoins({
+  favorites,
+  coin,
+  action,
+}: {
+  favorites: string[];
+  coin: string;
+  action: ITokenSelectorFavoriteAction;
+}): {
+  favorites: string[];
+  action: IResolvedTokenSelectorFavoriteAction;
+} {
+  const uniqueFavorites = dedupeTokenSelectorFavoriteCoins(favorites);
+  const hasCoin = uniqueFavorites.includes(coin);
+  if (action === 'remove' || (action === 'toggle' && hasCoin)) {
+    return {
+      favorites: uniqueFavorites.filter((favorite) => favorite !== coin),
+      action: hasCoin ? 'remove' : 'none',
+    };
+  }
+  if (action === 'add' || (action === 'toggle' && !hasCoin)) {
+    return {
+      favorites: hasCoin ? uniqueFavorites : [...uniqueFavorites, coin],
+      action: hasCoin ? 'none' : 'add',
+    };
+  }
+  return {
+    favorites: uniqueFavorites,
+    action: 'none',
+  };
+}
+
+function toggleTokenSelectorFavoriteCoin({
+  favorites,
+  coin,
+}: {
+  favorites: string[];
+  coin: string;
+}): {
+  favorites: string[];
+  action: 'add' | 'remove';
+} {
+  const result = updateTokenSelectorFavoriteCoins({
+    favorites,
+    coin,
+    action: 'toggle',
+  });
+  return {
+    favorites: result.favorites,
+    action: result.action === 'remove' ? 'remove' : 'add',
+  };
+}
+
+function isSameStringArray(a: string[], b: string[]) {
+  return a.length === b.length && a.every((item, index) => item === b[index]);
+}
+
+function isSameFavoritesOrderSequence(
+  a: ITokenSelectorFavoriteOrderEntry[],
+  b: ITokenSelectorFavoriteOrderEntry[],
+) {
+  return (
+    a.length === b.length &&
+    a.every(
+      (item, index) =>
+        item.mode === b[index]?.mode && item.coinName === b[index]?.coinName,
+    )
+  );
+}
+
+function reconcileTokenSelectorFavoritesOrder({
+  sequence,
+  perpFavorites,
+  spotFavorites,
+}: {
+  sequence: ITokenSelectorFavoriteOrderEntry[];
+  perpFavorites: string[];
+  spotFavorites: string[];
+}) {
+  const entries: ITokenSelectorFavoriteOrderEntry[] = [
+    ...perpFavorites.map((coinName) => ({
+      mode: 'perp' as const,
+      coinName,
+    })),
+    ...spotFavorites.map((coinName) => ({
+      mode: 'spot' as const,
+      coinName,
+    })),
+  ];
+  const validKeys = new Set(
+    entries.map((entry) => getTokenSelectorFavoriteOrderKey(entry)),
+  );
+  const filtered = dedupeTokenSelectorFavoritesOrder(sequence).filter((entry) =>
+    validKeys.has(getTokenSelectorFavoriteOrderKey(entry)),
+  );
+  const orderedKeys = new Set(
+    filtered.map((entry) => getTokenSelectorFavoriteOrderKey(entry)),
+  );
+  const missing = entries.filter(
+    (entry) => !orderedKeys.has(getTokenSelectorFavoriteOrderKey(entry)),
+  );
+  return [...filtered, ...missing];
+}
+
+export {
+  dedupeTokenSelectorFavoriteCoins,
+  dedupeTokenSelectorFavoritesOrder,
+  getTokenSelectorFavoriteOrderKey,
+  isSameFavoritesOrderSequence,
+  isSameStringArray,
+  reconcileTokenSelectorFavoritesOrder,
+  toggleTokenSelectorFavoriteCoin,
+  updateTokenSelectorFavoriteCoins,
+};


### PR DESCRIPTION
## Summary
- Fixed Perps iOS locale WebSocket recovery and avoided duplicate chart loading masks.
- Stabilized mobile Perps favorites removal, ordering, dedupe, and mixed spot/perp sorting.
- Synced spot display labels to TradingView after native reload-mode charts become ready.

## Intent & Context
This PR batches the current Perps mobile bug-fix work so QA can verify the Android and iOS flows together. The reported issues covered iOS TradingView recovery, duplicate loading states, Android spot chart labels showing numeric raw symbols, and mobile favorites rows disappearing or reappearing after unfavorite actions.

## Root Cause
- iOS locale-specific TradingView subscriptions could miss recovery handling and leave chart data stale.
- Chart and page loading states could both show during Perps chart initialization.
- Android reload-mode TradingView charts could initialize with the raw Hyperliquid spot symbol before receiving displayPair/displayCoin labels.
- Favorite state was mirrored across TokenSelector atoms and Market watchlist storage; duplicate entries plus background-only updates could make explicit removes look like no-ops and allow stale watchlist sync to revive removed rows.

## Design Decisions
- Keep raw TradingView symbols as datafeed keys and send display labels only through the SYMBOL_CHANGE bridge.
- Keep TokenSelector favorite add/remove operations idempotent in both UI and background layers.
- Add shared favorite/order helpers in `shared` so `kit-bg` can reuse the logic without violating import hierarchy.
- Preserve stable favorite ordering when no sort is active, but apply global mixed sorting when the favorites tab has an active sort field.

## Changes Detail
- `TradingViewPerpsV2`: re-syncs SYMBOL_CHANGE after chart content ready for reload-mode spot labels.
- `ServiceHyperliquid` / `ServiceMarketV2`: serializes and reconciles favorite membership, order, and Market watchlist sync.
- `TokenSelector` mobile/desktop components: uses stable unique keys, deduped favorite data, and global mixed favorites sorting.
- `usePerpsFavorites` and favorite utilities/tests: dedupe legacy duplicate favorites and lock removal/order behavior with unit tests.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile, Web
- **Risk Areas**: TradingView native bridge timing; Perps favorite state reconciliation across UI/background/Market storage.

## Test plan
- [x] yarn jest packages/kit/src/views/Perp/utils/tokenSelectorFavorites.test.ts --runInBand
- [x] yarn lint:staged
- [x] yarn tsc:staged
- [x] Android manual verification for duplicate loading and spot chart display labels
- [ ] iOS manual verification on simulator/device
