### PR TITLE
fix(perps): keep market data visible after iOS locale reload(OK-54167)

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -27,6 +27,7 @@ import {
   HYPERLIQUID_REFRESH_DATA_FLOW_THRESHOLD_MS,
 } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import type {
+  IBook,
   IHex,
   IHyperliquidEventTarget,
   IPerpsActiveAssetDataRaw,
@@ -68,6 +69,10 @@ import { spotActiveAssetAtom } from '../../states/jotai/atoms/spot';
 import ServiceBase from '../ServiceBase';
 
 import hyperLiquidCache from './hyperLiquidCache';
+import {
+  type ILatestPerpsMarketDataSnapshot,
+  filterFreshPerpsMarketDataSnapshot,
+} from './utils/latestMarketDataSnapshot';
 import {
   SUBSCRIPTION_TYPE_INFO,
   calculateRequiredSubscriptionsMap,
@@ -176,6 +181,8 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   pendingSubSpecsMap: Record<string, ISubscriptionSpec<ESubscriptionType>> = {};
 
   private _activeSubscriptions = new Map<string, IActiveSubscription>();
+
+  private _latestMarketDataSnapshot: ILatestPerpsMarketDataSnapshot = {};
 
   // Cross-runtime atom sync can lag behind a reopened socket, leaving current
   // market subscriptions absent while the socket still looks healthy.
@@ -429,6 +436,40 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         sub.isActive = true;
       }
     }
+  }
+
+  private _cacheMarketDataSnapshot(
+    subscriptionType: ESubscriptionType,
+    data: unknown,
+    updatedAt: number,
+  ): void {
+    if (subscriptionType === ESubscriptionType.ALL_DEXS_ASSET_CTXS) {
+      this._latestMarketDataSnapshot.allDexsAssetCtxs = {
+        data: data as IWsAllDexsAssetCtxs,
+        updatedAt,
+      };
+      return;
+    }
+
+    if (subscriptionType === ESubscriptionType.L2_BOOK) {
+      this._latestMarketDataSnapshot.l2Book = {
+        data: data as IBook,
+        updatedAt,
+      };
+    }
+  }
+
+  @backgroundMethod()
+  async getLatestMarketDataSnapshot(params?: {
+    coin?: string;
+    maxAgeMs?: number;
+  }): Promise<ILatestPerpsMarketDataSnapshot> {
+    return filterFreshPerpsMarketDataSnapshot({
+      snapshot: this._latestMarketDataSnapshot,
+      coin: params?.coin,
+      maxAgeMs: params?.maxAgeMs ?? HYPERLIQUID_NETWORK_INACTIVE_TIMEOUT_MS,
+      now: Date.now(),
+    });
   }
 
   private _getStaleCriticalOpenSubscriptionTypes(
@@ -1609,6 +1650,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
       const messageTimestamp = Date.now();
       this._markSubscriptionActivity(subscriptionType, messageTimestamp);
+      this._cacheMarketDataSnapshot(subscriptionType, data, messageTimestamp);
 
       if (subscriptionType === ESubscriptionType.ALL_MIDS) {
         // Cache allMids in background for spot balance USD calculation

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/latestMarketDataSnapshot.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/latestMarketDataSnapshot.test.ts
@@ -1,0 +1,62 @@
+import type {
+  IBook,
+  IWsAllDexsAssetCtxs,
+} from '@onekeyhq/shared/types/hyperliquid/sdk';
+
+import { filterFreshPerpsMarketDataSnapshot } from './latestMarketDataSnapshot';
+
+describe('filterFreshPerpsMarketDataSnapshot', () => {
+  const allDexsAssetCtxs = {
+    ctxs: [['', []]],
+  } as unknown as IWsAllDexsAssetCtxs;
+
+  const btcBook = {
+    coin: 'BTC',
+    levels: [[], []],
+    time: 1,
+  } as unknown as IBook;
+
+  it('returns fresh global asset ctxs and matching L2 book', () => {
+    const snapshot = filterFreshPerpsMarketDataSnapshot({
+      snapshot: {
+        allDexsAssetCtxs: { data: allDexsAssetCtxs, updatedAt: 1000 },
+        l2Book: { data: btcBook, updatedAt: 1100 },
+      },
+      coin: 'BTC',
+      maxAgeMs: 1000,
+      now: 1500,
+    });
+
+    expect(snapshot.allDexsAssetCtxs?.data).toBe(allDexsAssetCtxs);
+    expect(snapshot.l2Book?.data).toBe(btcBook);
+  });
+
+  it('does not replay a book for a different active coin', () => {
+    const snapshot = filterFreshPerpsMarketDataSnapshot({
+      snapshot: {
+        allDexsAssetCtxs: { data: allDexsAssetCtxs, updatedAt: 1000 },
+        l2Book: { data: btcBook, updatedAt: 1100 },
+      },
+      coin: 'ETH',
+      maxAgeMs: 1000,
+      now: 1500,
+    });
+
+    expect(snapshot.allDexsAssetCtxs?.data).toBe(allDexsAssetCtxs);
+    expect(snapshot.l2Book).toBeUndefined();
+  });
+
+  it('drops stale market snapshots', () => {
+    const snapshot = filterFreshPerpsMarketDataSnapshot({
+      snapshot: {
+        allDexsAssetCtxs: { data: allDexsAssetCtxs, updatedAt: 1000 },
+        l2Book: { data: btcBook, updatedAt: 1000 },
+      },
+      coin: 'BTC',
+      maxAgeMs: 1000,
+      now: 2001,
+    });
+
+    expect(snapshot).toEqual({});
+  });
+});

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/latestMarketDataSnapshot.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/latestMarketDataSnapshot.ts
@@ -1,0 +1,48 @@
+import type {
+  IBook,
+  IWsAllDexsAssetCtxs,
+} from '@onekeyhq/shared/types/hyperliquid/sdk';
+
+export interface ILatestPerpsMarketDataPayload<T> {
+  data: T;
+  updatedAt: number;
+}
+
+export interface ILatestPerpsMarketDataSnapshot {
+  allDexsAssetCtxs?: ILatestPerpsMarketDataPayload<IWsAllDexsAssetCtxs>;
+  l2Book?: ILatestPerpsMarketDataPayload<IBook>;
+}
+
+export function filterFreshPerpsMarketDataSnapshot({
+  snapshot,
+  coin,
+  maxAgeMs,
+  now,
+}: {
+  snapshot: ILatestPerpsMarketDataSnapshot;
+  coin?: string;
+  maxAgeMs: number;
+  now: number;
+}): ILatestPerpsMarketDataSnapshot {
+  const isFresh = (updatedAt: number) => now - updatedAt <= maxAgeMs;
+  const next: ILatestPerpsMarketDataSnapshot = {};
+
+  if (
+    snapshot.allDexsAssetCtxs &&
+    isFresh(snapshot.allDexsAssetCtxs.updatedAt)
+  ) {
+    next.allDexsAssetCtxs = snapshot.allDexsAssetCtxs;
+  }
+
+  const requestedCoin = coin?.trim();
+  if (
+    requestedCoin &&
+    snapshot.l2Book &&
+    snapshot.l2Book.data.coin === requestedCoin &&
+    isFresh(snapshot.l2Book.updatedAt)
+  ) {
+    next.l2Book = snapshot.l2Book;
+  }
+
+  return next;
+}

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -330,6 +330,59 @@ function useHyperliquidEventBusListener() {
   }, [actions]);
 }
 
+function useHyperliquidMarketDataSnapshotReplay() {
+  const actions = useHyperliquidActions();
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
+  const [tradeRouteViewState] = useTradeRouteViewStateAtom();
+  const localeVariant = useLocaleVariant();
+
+  const instrumentCoin = activeTradeInstrument.coin;
+  const instrumentMode = activeTradeInstrument.mode;
+  const routeFocused = tradeRouteViewState.routeFocused;
+  const tokenSelectorOpen = tradeRouteViewState.tokenSelectorOpen;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      const snapshot =
+        await backgroundApiProxy.serviceHyperliquidSubscription.getLatestMarketDataSnapshot(
+          {
+            coin: instrumentCoin,
+          },
+        );
+      if (cancelled) {
+        return;
+      }
+
+      const allDexsAssetCtxs = snapshot.allDexsAssetCtxs?.data;
+      if (allDexsAssetCtxs) {
+        // Replays the latest BG snapshot after iOS locale reloads where the
+        // one-shot event can fire before this UI context has mounted.
+        startTransition(() => {
+          void actions.current.updateAllDexsAssetCtxs(allDexsAssetCtxs);
+        });
+      }
+
+      const l2Book = snapshot.l2Book?.data;
+      if (l2Book) {
+        void actions.current.updateL2Book(l2Book);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    actions,
+    instrumentCoin,
+    instrumentMode,
+    localeVariant,
+    routeFocused,
+    tokenSelectorOpen,
+  ]);
+}
+
 // OK-53208: perps atoms/WS must survive unmount — mobile modal push
 // detaches this tab and re-mount has no recovery. Resets on account
 // switch / logout are owned by clearActiveAccountData / ServiceApp.resetApp.
@@ -879,6 +932,7 @@ function useHyperliquidInstrumentSwitchRequest() {
 
 function PerpsGlobalEffectsView() {
   useHyperliquidEventBusListener();
+  useHyperliquidMarketDataSnapshotReplay();
   useHyperliquidSession();
   useHyperliquidAccountSelect();
   usePerpTokenUrlSync();


### PR DESCRIPTION
## Summary
- Cache the latest Perps market snapshots in the background subscription service.
- Replay fresh `ALL_DEXS_ASSET_CTXS` and matching-coin `L2_BOOK` snapshots when the Perps UI remounts, refocuses, or observes a locale variant change.
- Add focused tests for freshness and coin-guarded snapshot replay.

## Intent & Context
This PR is for OK-54167 bundle validation with the new skip-GPG shell build. The latest iOS device testing showed that after switching language, spot data and `ACTIVE_ASSET_CTX` could recover while the Perps token selector and orderbook remained empty or recovered slowly. That makes the issue look less like a dead WebSocket transport and more like the Perps UI context missing one-shot market data events after the iOS locale reload.

## Root Cause
The Perps UI market data path is split:

- Spot and active asset data can be written through background/global atoms and may survive or recover independently.
- Token selector prices depend on `ALL_DEXS_ASSET_CTXS -> perpsAllAssetCtxsAtom`.
- Orderbook depends on `L2_BOOK -> l2BookAtom` with active coin matching.

Those last two are delivered to the foreground context via `appEventBus`. When iOS locale switching reloads the UI while the background runtime remains alive, the background service can receive the initial payload before the Perps UI listener is mounted. The event is then lost, leaving the UI context empty until the next payload or a later subscription recovery.

## Design Decisions
- Cache only the latest critical market payloads needed for the observed blank states.
- Replay only fresh snapshots, using the existing network inactivity timeout as the default freshness window.
- Replay `L2_BOOK` only when the cached book coin matches the current active coin, preventing stale or wrong-coin orderbook rendering.
- Avoid adding more WebSocket reconnect logic because device evidence shows other subscription paths can remain healthy.

## Changes Detail
- `ServiceHyperliquidSubscription.ts`: stores latest `ALL_DEXS_ASSET_CTXS` and `L2_BOOK` payloads and exposes `getLatestMarketDataSnapshot()`.
- `latestMarketDataSnapshot.ts`: filters cached snapshots by freshness and active coin.
- `latestMarketDataSnapshot.test.ts`: covers fresh replay, wrong-coin rejection, and stale snapshot dropping.
- `PerpsGlobalEffects.tsx`: replays fresh background snapshots into the Perps UI context after mount/focus/locale changes.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile iOS primarily; shared Perps UI path can run on other platforms
- **Risk Areas**: Replaying market data into UI context. Risk is reduced by freshness filtering and L2 coin matching.

## Test plan
- [x] `yarn jest packages/kit-bg/src/services/ServiceHyperLiquid/utils/latestMarketDataSnapshot.test.ts packages/kit/src/views/Perp/utils/subscriptionPlanner.test.ts --runInBand`
- [x] `npx oxlint packages/kit-bg/src/services/ServiceHyperLiquid/utils/latestMarketDataSnapshot.ts packages/kit-bg/src/services/ServiceHyperLiquid/utils/latestMarketDataSnapshot.test.ts packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [ ] iOS skip-GPG shell + QA Bundle remote validation for language switch recovery

## Merge State
This PR is intentionally opened as a draft for QA Bundle validation and should not be merged until device verification passes.
