### PR TITLE
fix: avoid iOS onboarding pop detaching tabs OK-54167

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -184,11 +184,26 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
   private _latestMarketDataSnapshot: ILatestPerpsMarketDataSnapshot = {};
 
+  private _loggedFirstDataSubscriptionTypes = new Set<ESubscriptionType>();
+
   // Cross-runtime atom sync can lag behind a reopened socket, leaving current
   // market subscriptions absent while the socket still looks healthy.
   private _subscriptionAtomsUnsubs: Array<() => void> = [];
 
   private _subscriptionLifecycleVersion = 0;
+
+  private _summarizeRequiredSubscriptions(
+    requiredSubSpecsMap?: Record<string, ISubscriptionSpec<ESubscriptionType>>,
+  ) {
+    const specs = Object.values(requiredSubSpecsMap || {});
+    return {
+      requiredCount: specs.length,
+      hasAllDexsAssetCtxs: specs.some(
+        (spec) => spec.type === ESubscriptionType.ALL_DEXS_ASSET_CTXS,
+      ),
+      hasL2Book: specs.some((spec) => spec.type === ESubscriptionType.L2_BOOK),
+    };
+  }
 
   private _watchSubscriptionAtoms(): void {
     if (!platformEnv.isExtension && !platformEnv.isNativeBackgroundThread) {
@@ -300,12 +315,47 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
   private async _updateSubscriptionsCore() {
     if (this.subscriptionsHandlerDisabled) {
+      defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+        source: 'bg',
+        event: 'update_core_skip_disabled',
+        disabled: this.subscriptionsHandlerDisabled,
+        disabledCount: this.subscriptionsHandlerDisabledCount,
+        hasInitialSubscription: this._hasInitialSubscription,
+        lifecycleVersion: this._subscriptionLifecycleVersion,
+      });
       return;
     }
     const requiredSubInfo = await this.buildRequiredSubscriptionsMap();
     if (!requiredSubInfo) {
+      defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+        source: 'bg',
+        event: 'update_core_skip_no_required_info',
+        disabled: this.subscriptionsHandlerDisabled,
+        disabledCount: this.subscriptionsHandlerDisabledCount,
+        hasInitialSubscription: this._hasInitialSubscription,
+        lifecycleVersion: this._subscriptionLifecycleVersion,
+      });
       return;
     }
+    defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+      source: 'bg',
+      event: 'update_core_required',
+      ...this._summarizeRequiredSubscriptions(
+        requiredSubInfo.requiredSubSpecsMap,
+      ),
+      disabled: this.subscriptionsHandlerDisabled,
+      disabledCount: this.subscriptionsHandlerDisabledCount,
+      hasInitialSubscription: this._hasInitialSubscription,
+      lifecycleVersion: this._subscriptionLifecycleVersion,
+      currentSymbolSet: !!requiredSubInfo.params.currentSymbol,
+      currentSpotSymbolSet: !!requiredSubInfo.params.currentSpotSymbol,
+      currentUserSet: !!requiredSubInfo.params.currentUser,
+      hasL2BookOptions: !!requiredSubInfo.params.l2BookOptions,
+      tradingMode: requiredSubInfo.params.tradingMode,
+      spotEnabled: requiredSubInfo.params.spotEnabled,
+      spotAssetCtxsEnabled: requiredSubInfo.params.spotAssetCtxsEnabled,
+      enableLedgerUpdates: requiredSubInfo.params.enableLedgerUpdates,
+    });
 
     const staleCriticalTypes = this._getStaleCriticalOpenSubscriptionTypes(
       requiredSubInfo.requiredSubSpecsMap,
@@ -358,6 +408,14 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   @backgroundMethod()
   async updateSubscriptions(): Promise<void> {
     if (this.subscriptionsHandlerDisabled) {
+      defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+        source: 'bg',
+        event: 'update_skip_disabled',
+        disabled: this.subscriptionsHandlerDisabled,
+        disabledCount: this.subscriptionsHandlerDisabledCount,
+        hasInitialSubscription: this._hasInitialSubscription,
+        lifecycleVersion: this._subscriptionLifecycleVersion,
+      });
       return;
     }
     const client = await this.getWebSocketClient();
@@ -457,6 +515,31 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         updatedAt,
       };
     }
+  }
+
+  private _logFirstCriticalSubscriptionData(
+    subscriptionType: ESubscriptionType,
+  ): void {
+    if (
+      subscriptionType !== ESubscriptionType.ALL_DEXS_ASSET_CTXS &&
+      subscriptionType !== ESubscriptionType.L2_BOOK
+    ) {
+      return;
+    }
+    if (this._loggedFirstDataSubscriptionTypes.has(subscriptionType)) {
+      return;
+    }
+    this._loggedFirstDataSubscriptionTypes.add(subscriptionType);
+    defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+      source: 'bg',
+      event: 'critical_subscription_first_data',
+      subscriptionType,
+      isFirstData: true,
+      disabled: this.subscriptionsHandlerDisabled,
+      disabledCount: this.subscriptionsHandlerDisabledCount,
+      lifecycleVersion: this._subscriptionLifecycleVersion,
+      activeCount: this._activeSubscriptions.size,
+    });
   }
 
   @backgroundMethod()
@@ -643,6 +726,18 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
     this._resumeRecoveryPromise = (async () => {
       const requiredSubInfo = await this.buildRequiredSubscriptionsMap();
+      defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+        source: 'bg',
+        event: 'reconcile_open_socket',
+        reason: params?.reason,
+        ...this._summarizeRequiredSubscriptions(
+          requiredSubInfo?.requiredSubSpecsMap,
+        ),
+        disabled: this.subscriptionsHandlerDisabled,
+        disabledCount: this.subscriptionsHandlerDisabledCount,
+        hasInitialSubscription: this._hasInitialSubscription,
+        lifecycleVersion: this._subscriptionLifecycleVersion,
+      });
       if (
         this._shouldRebuildOpenSocketSubscriptionsOnResume({
           ...params,
@@ -763,6 +858,24 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   }): Promise<void> {
     await this.enableSubscriptionsHandler();
     this._postOpenDataCheckRetries = 0;
+    let reason = 'resume';
+    if (params?.forceRebuild) {
+      reason = 'force_rebuild';
+    } else if (params?.forceReconnect) {
+      reason = 'force_reconnect';
+    }
+    defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+      source: 'bg',
+      event: 'resume_subscriptions',
+      reason,
+      readyState: this._client?.transport?.socket?.readyState ?? null,
+      socketOpen:
+        this._client?.transport?.socket?.readyState === WebSocket.OPEN,
+      disabled: this.subscriptionsHandlerDisabled,
+      disabledCount: this.subscriptionsHandlerDisabledCount,
+      hasInitialSubscription: this._hasInitialSubscription,
+      lifecycleVersion: this._subscriptionLifecycleVersion,
+    });
     console.log('updateSubscriptions__by__resumeSubscriptions');
 
     if (params?.forceReconnect) {
@@ -812,11 +925,29 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   async disableSubscriptionsHandler(): Promise<void> {
     this.subscriptionsHandlerDisabled = true;
     this.subscriptionsHandlerDisabledCount += 1;
+    defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+      source: 'bg',
+      event: 'disable_subscriptions_handler',
+      disabled: this.subscriptionsHandlerDisabled,
+      disabledCount: this.subscriptionsHandlerDisabledCount,
+      hasInitialSubscription: this._hasInitialSubscription,
+      lifecycleVersion: this._subscriptionLifecycleVersion,
+      activeCount: this._activeSubscriptions.size,
+    });
   }
 
   @backgroundMethod()
   async enableSubscriptionsHandler(): Promise<void> {
     this.subscriptionsHandlerDisabled = false;
+    defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+      source: 'bg',
+      event: 'enable_subscriptions_handler',
+      disabled: this.subscriptionsHandlerDisabled,
+      disabledCount: this.subscriptionsHandlerDisabledCount,
+      hasInitialSubscription: this._hasInitialSubscription,
+      lifecycleVersion: this._subscriptionLifecycleVersion,
+      activeCount: this._activeSubscriptions.size,
+    });
     if (this.hasNewUserFills) {
       this.hasNewUserFills = false;
       void perpsTradesHistoryRefreshHookAtom.set({
@@ -837,6 +968,16 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     spotAssetCtxsEnabled: boolean;
     spotEnabled: boolean;
   }): Promise<void> {
+    defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+      source: 'bg',
+      event: 'set_route_subscription_state',
+      enableLedgerUpdates: params.enableLedgerUpdates,
+      spotAssetCtxsEnabled: params.spotAssetCtxsEnabled,
+      spotEnabled: params.spotEnabled,
+      disabled: this.subscriptionsHandlerDisabled,
+      disabledCount: this.subscriptionsHandlerDisabledCount,
+      lifecycleVersion: this._subscriptionLifecycleVersion,
+    });
     // enableLedgerUpdates is a one-way toggle (set true by enableLedgerUpdatesSubscription
     // when user visits Account tab). Never reset to false — planTradeSubscriptions cannot
     // reliably compute this since infoPanelTab is not synced to real tab state.
@@ -953,6 +1094,17 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         client: params.client,
         timeoutMs:
           ServiceHyperliquidSubscription.SUBSCRIPTION_UPDATE_OPEN_WAIT_MS,
+      });
+      defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+        source: 'bg',
+        event: 'recover_not_open_socket',
+        reason: params.reason,
+        readyState: params.client.transport?.socket?.readyState ?? null,
+        socketOpen: isOpen,
+        disabled: this.subscriptionsHandlerDisabled,
+        disabledCount: this.subscriptionsHandlerDisabledCount,
+        hasInitialSubscription: this._hasInitialSubscription,
+        lifecycleVersion: this._subscriptionLifecycleVersion,
       });
       if (isOpen) {
         this._watchSubscriptionAtoms();
@@ -1154,6 +1306,17 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
       await timerUtils.wait(600); // wait network status atom update
       const currentClient = this._client;
+      defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+        source: 'bg',
+        event: 'socket_open_after_wait',
+        readyState: currentClient?.transport?.socket?.readyState ?? null,
+        socketOpen:
+          currentClient?.transport?.socket?.readyState === WebSocket.OPEN,
+        disabled: this.subscriptionsHandlerDisabled,
+        disabledCount: this.subscriptionsHandlerDisabledCount,
+        hasInitialSubscription: this._hasInitialSubscription,
+        lifecycleVersion: this._subscriptionLifecycleVersion,
+      });
       if (
         !currentClient ||
         currentClient !== openClient ||
@@ -1459,6 +1622,24 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         toCreateSubscriptions.push(spec);
       }
     });
+    const pendingSpecs = Object.values(this.pendingSubSpecsMap);
+    defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+      source: 'bg',
+      event: 'execute_subscription_changes',
+      pendingCount: pendingSpecs.length,
+      activeCount: this._activeSubscriptions.size,
+      toCreateCount: toCreateSubscriptions.length,
+      hasAllDexsAssetCtxs: pendingSpecs.some(
+        (spec) => spec.type === ESubscriptionType.ALL_DEXS_ASSET_CTXS,
+      ),
+      hasL2Book: pendingSpecs.some(
+        (spec) => spec.type === ESubscriptionType.L2_BOOK,
+      ),
+      disabled: this.subscriptionsHandlerDisabled,
+      disabledCount: this.subscriptionsHandlerDisabledCount,
+      hasInitialSubscription: this._hasInitialSubscription,
+      lifecycleVersion: this._subscriptionLifecycleVersion,
+    });
 
     this.destroyUnusedSubscriptions();
 
@@ -1492,6 +1673,21 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     }
 
     try {
+      if (
+        spec.type === ESubscriptionType.ALL_DEXS_ASSET_CTXS ||
+        spec.type === ESubscriptionType.L2_BOOK
+      ) {
+        defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+          source: 'bg',
+          event: 'create_critical_subscription_start',
+          subscriptionType: spec.type,
+          activeCount: this._activeSubscriptions.size,
+          disabled: this.subscriptionsHandlerDisabled,
+          disabledCount: this.subscriptionsHandlerDisabledCount,
+          hasInitialSubscription: this._hasInitialSubscription,
+          lifecycleVersion: this._subscriptionLifecycleVersion,
+        });
+      }
       const _sdkSubscription = await this._createSubscriptionDirect(spec);
       this._activeSubscriptions.set(spec.key, {
         key: spec.key,
@@ -1501,6 +1697,21 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         lastActivity: Date.now(),
         isActive: true,
       });
+      if (
+        spec.type === ESubscriptionType.ALL_DEXS_ASSET_CTXS ||
+        spec.type === ESubscriptionType.L2_BOOK
+      ) {
+        defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+          source: 'bg',
+          event: 'create_critical_subscription_done',
+          subscriptionType: spec.type,
+          activeCount: this._activeSubscriptions.size,
+          disabled: this.subscriptionsHandlerDisabled,
+          disabledCount: this.subscriptionsHandlerDisabledCount,
+          hasInitialSubscription: this._hasInitialSubscription,
+          lifecycleVersion: this._subscriptionLifecycleVersion,
+        });
+      }
     } catch (error) {
       console.error(
         `[ServiceHyperliquidSubscription.createSubscription] Failed to create subscription ${spec.type}:`,
@@ -1651,6 +1862,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       const messageTimestamp = Date.now();
       this._markSubscriptionActivity(subscriptionType, messageTimestamp);
       this._cacheMarketDataSnapshot(subscriptionType, data, messageTimestamp);
+      this._logFirstCriticalSubscriptionData(subscriptionType);
 
       if (subscriptionType === ESubscriptionType.ALL_MIDS) {
         // Cache allMids in background for spot balance USD calculation

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -27,6 +27,7 @@ import {
   HYPERLIQUID_REFRESH_DATA_FLOW_THRESHOLD_MS,
 } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import type {
+  IBook,
   IHex,
   IHyperliquidEventTarget,
   IPerpsActiveAssetDataRaw,
@@ -68,6 +69,10 @@ import { spotActiveAssetAtom } from '../../states/jotai/atoms/spot';
 import ServiceBase from '../ServiceBase';
 
 import hyperLiquidCache from './hyperLiquidCache';
+import {
+  type ILatestPerpsMarketDataSnapshot,
+  filterFreshPerpsMarketDataSnapshot,
+} from './utils/latestMarketDataSnapshot';
 import {
   SUBSCRIPTION_TYPE_INFO,
   calculateRequiredSubscriptionsMap,
@@ -176,6 +181,8 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   pendingSubSpecsMap: Record<string, ISubscriptionSpec<ESubscriptionType>> = {};
 
   private _activeSubscriptions = new Map<string, IActiveSubscription>();
+
+  private _latestMarketDataSnapshot: ILatestPerpsMarketDataSnapshot = {};
 
   // Cross-runtime atom sync can lag behind a reopened socket, leaving current
   // market subscriptions absent while the socket still looks healthy.
@@ -429,6 +436,40 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         sub.isActive = true;
       }
     }
+  }
+
+  private _cacheMarketDataSnapshot(
+    subscriptionType: ESubscriptionType,
+    data: unknown,
+    updatedAt: number,
+  ): void {
+    if (subscriptionType === ESubscriptionType.ALL_DEXS_ASSET_CTXS) {
+      this._latestMarketDataSnapshot.allDexsAssetCtxs = {
+        data: data as IWsAllDexsAssetCtxs,
+        updatedAt,
+      };
+      return;
+    }
+
+    if (subscriptionType === ESubscriptionType.L2_BOOK) {
+      this._latestMarketDataSnapshot.l2Book = {
+        data: data as IBook,
+        updatedAt,
+      };
+    }
+  }
+
+  @backgroundMethod()
+  async getLatestMarketDataSnapshot(params?: {
+    coin?: string;
+    maxAgeMs?: number;
+  }): Promise<ILatestPerpsMarketDataSnapshot> {
+    return filterFreshPerpsMarketDataSnapshot({
+      snapshot: this._latestMarketDataSnapshot,
+      coin: params?.coin,
+      maxAgeMs: params?.maxAgeMs ?? HYPERLIQUID_NETWORK_INACTIVE_TIMEOUT_MS,
+      now: Date.now(),
+    });
   }
 
   private _getStaleCriticalOpenSubscriptionTypes(
@@ -1609,6 +1650,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
       const messageTimestamp = Date.now();
       this._markSubscriptionActivity(subscriptionType, messageTimestamp);
+      this._cacheMarketDataSnapshot(subscriptionType, data, messageTimestamp);
 
       if (subscriptionType === ESubscriptionType.ALL_MIDS) {
         // Cache allMids in background for spot balance USD calculation

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/latestMarketDataSnapshot.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/latestMarketDataSnapshot.test.ts
@@ -1,0 +1,62 @@
+import type {
+  IBook,
+  IWsAllDexsAssetCtxs,
+} from '@onekeyhq/shared/types/hyperliquid/sdk';
+
+import { filterFreshPerpsMarketDataSnapshot } from './latestMarketDataSnapshot';
+
+describe('filterFreshPerpsMarketDataSnapshot', () => {
+  const allDexsAssetCtxs = {
+    ctxs: [['', []]],
+  } as unknown as IWsAllDexsAssetCtxs;
+
+  const btcBook = {
+    coin: 'BTC',
+    levels: [[], []],
+    time: 1,
+  } as unknown as IBook;
+
+  it('returns fresh global asset ctxs and matching L2 book', () => {
+    const snapshot = filterFreshPerpsMarketDataSnapshot({
+      snapshot: {
+        allDexsAssetCtxs: { data: allDexsAssetCtxs, updatedAt: 1000 },
+        l2Book: { data: btcBook, updatedAt: 1100 },
+      },
+      coin: 'BTC',
+      maxAgeMs: 1000,
+      now: 1500,
+    });
+
+    expect(snapshot.allDexsAssetCtxs?.data).toBe(allDexsAssetCtxs);
+    expect(snapshot.l2Book?.data).toBe(btcBook);
+  });
+
+  it('does not replay a book for a different active coin', () => {
+    const snapshot = filterFreshPerpsMarketDataSnapshot({
+      snapshot: {
+        allDexsAssetCtxs: { data: allDexsAssetCtxs, updatedAt: 1000 },
+        l2Book: { data: btcBook, updatedAt: 1100 },
+      },
+      coin: 'ETH',
+      maxAgeMs: 1000,
+      now: 1500,
+    });
+
+    expect(snapshot.allDexsAssetCtxs?.data).toBe(allDexsAssetCtxs);
+    expect(snapshot.l2Book).toBeUndefined();
+  });
+
+  it('drops stale market snapshots', () => {
+    const snapshot = filterFreshPerpsMarketDataSnapshot({
+      snapshot: {
+        allDexsAssetCtxs: { data: allDexsAssetCtxs, updatedAt: 1000 },
+        l2Book: { data: btcBook, updatedAt: 1000 },
+      },
+      coin: 'BTC',
+      maxAgeMs: 1000,
+      now: 2001,
+    });
+
+    expect(snapshot).toEqual({});
+  });
+});

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/latestMarketDataSnapshot.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/latestMarketDataSnapshot.ts
@@ -1,0 +1,48 @@
+import type {
+  IBook,
+  IWsAllDexsAssetCtxs,
+} from '@onekeyhq/shared/types/hyperliquid/sdk';
+
+export interface ILatestPerpsMarketDataPayload<T> {
+  data: T;
+  updatedAt: number;
+}
+
+export interface ILatestPerpsMarketDataSnapshot {
+  allDexsAssetCtxs?: ILatestPerpsMarketDataPayload<IWsAllDexsAssetCtxs>;
+  l2Book?: ILatestPerpsMarketDataPayload<IBook>;
+}
+
+export function filterFreshPerpsMarketDataSnapshot({
+  snapshot,
+  coin,
+  maxAgeMs,
+  now,
+}: {
+  snapshot: ILatestPerpsMarketDataSnapshot;
+  coin?: string;
+  maxAgeMs: number;
+  now: number;
+}): ILatestPerpsMarketDataSnapshot {
+  const isFresh = (updatedAt: number) => now - updatedAt <= maxAgeMs;
+  const next: ILatestPerpsMarketDataSnapshot = {};
+
+  if (
+    snapshot.allDexsAssetCtxs &&
+    isFresh(snapshot.allDexsAssetCtxs.updatedAt)
+  ) {
+    next.allDexsAssetCtxs = snapshot.allDexsAssetCtxs;
+  }
+
+  const requestedCoin = coin?.trim();
+  if (
+    requestedCoin &&
+    snapshot.l2Book &&
+    snapshot.l2Book.data.coin === requestedCoin &&
+    isFresh(snapshot.l2Book.updatedAt)
+  ) {
+    next.l2Book = snapshot.l2Book;
+  }
+
+  return next;
+}

--- a/packages/kit/src/views/Onboardingv2/components/Layout.tsx
+++ b/packages/kit/src/views/Onboardingv2/components/Layout.tsx
@@ -21,6 +21,7 @@ import {
   SizableText,
   XStack,
   YStack,
+  resetOnboardingModal,
   useMedia,
   useSafeAreaInsets,
 } from '@onekeyhq/components';
@@ -76,6 +77,11 @@ export const LayoutHeaderBack = memo(({ exit }: { exit?: boolean }) => {
   const handleBack = useCallback(() => {
     if (exit) {
       defaultLogger.account.wallet.onboardingExit();
+      // iOS can leave Main's RNSScreenStack detached when the root
+      // Onboarding route is popped during cold-start reattach. Drop the
+      // onboarding root atomically so tab screens keep a valid window.
+      resetOnboardingModal();
+      return;
     }
     navigation.pop();
   }, [navigation, exit]);

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -3,7 +3,7 @@ import { memo, startTransition, useCallback, useEffect, useRef } from 'react';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { isEqual, noop } from 'lodash';
 
-import { useUpdateEffect } from '@onekeyhq/components';
+import { useOnRouterChange, useUpdateEffect } from '@onekeyhq/components';
 import {
   useAccountIsAutoCreatingAtom,
   useAppIsLockedAtom,
@@ -29,8 +29,9 @@ import {
   EAppEventBusNames,
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import { ETabRoutes } from '@onekeyhq/shared/src/routes';
+import { ERootRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { useDebugHooksDepsChangedChecker } from '@onekeyhq/shared/src/utils/debug/debugUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import type {
@@ -79,6 +80,60 @@ let lastRecoveredPerpsLocaleVariant: string | undefined;
 
 function resolvePerpRouteFocused(isFocus: boolean) {
   return shouldTreatPerpAsFocusedOnMount || isFocus;
+}
+
+function usePerpsNavigationDiagnostics() {
+  const lastRouterSnapshotRef = useRef<string>('');
+
+  useEffect(() => {
+    defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+      source: 'ui',
+      event: 'perps_global_effects_mount',
+      shouldTreatFocusedOnMount: shouldTreatPerpAsFocusedOnMount,
+    });
+    return () => {
+      defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+        source: 'ui',
+        event: 'perps_global_effects_unmount',
+      });
+    };
+  }, []);
+
+  useOnRouterChange((state) => {
+    const rootState = state?.routes.find(
+      ({ name }) => name === ERootRoutes.Main,
+    )?.state;
+    const currentTabName = rootState?.routeNames
+      ? (rootState?.routeNames?.[rootState?.index || 0] as ETabRoutes)
+      : (rootState?.routes[0]?.name as ETabRoutes | undefined);
+    const hasOnboardingRoute = !!state?.routes.some(
+      ({ name }) => name === ERootRoutes.Onboarding,
+    );
+    const hasOverlayRoute = !!state?.routes.some(({ name }) =>
+      [
+        ERootRoutes.Modal,
+        ERootRoutes.iOSFullScreen,
+        ERootRoutes.FullScreenPush,
+      ].includes(name as ERootRoutes),
+    );
+    const snapshot = [
+      currentTabName ?? '',
+      hasOnboardingRoute ? 'onboarding' : '',
+      hasOverlayRoute ? 'overlay' : '',
+    ].join('|');
+    if (lastRouterSnapshotRef.current === snapshot) {
+      return;
+    }
+    lastRouterSnapshotRef.current = snapshot;
+    defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+      source: 'ui',
+      event: 'router_state',
+      currentTabName,
+      routeFocused: currentTabName === ETabRoutes.Perp,
+      hasOnboardingRoute,
+      hasOverlayRoute,
+    });
+  });
 }
 
 function useSyncContextOrderBookOptionsToGlobal() {
@@ -616,6 +671,26 @@ function WebSocketSubscriptionUpdate() {
       orderBookOptions: activeOrderBookOptionsRef.current,
       viewState: tradeRouteViewStateRef.current,
     });
+    defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+      source: 'ui',
+      event: 'subscription_plan',
+      hasAccount: !!accountAddress,
+      hasInstrumentCoin: !!instrumentCoin,
+      instrumentMode,
+      hasOrderBookCoin: !!orderBookCoin,
+      hasOrderBookOptions: !!activeOrderBookOptionsRef.current,
+      routeFocused,
+      tokenSelectorOpen,
+      tokenSelectorTab,
+      infoPanelTab,
+      favoritesBarSpotActive,
+      isLoading,
+      isWebSocketConnected,
+      shouldSyncSubscriptions: plan.shouldSyncSubscriptions,
+      spotEnabled: plan.spotEnabled,
+      spotAssetCtxsEnabled: plan.spotAssetCtxsEnabled,
+      enableLedgerUpdates: plan.enableLedgerUpdates,
+    });
 
     void backgroundApiProxy.serviceHyperliquidSubscription.setRouteSubscriptionState(
       {
@@ -666,17 +741,39 @@ function useHyperliquidSymbolSelect() {
       // Perp tab detach/remount does not re-trigger this init.
       const claimed =
         await backgroundApiProxy.serviceHyperliquid.tryClaimInitialSymbolSelect();
+      defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+        source: 'ui',
+        event: 'initial_symbol_claim',
+        claimed,
+        hasInstrumentCoin: !!activeTradeInstrumentRef.current?.coin,
+        instrumentMode: activeTradeInstrumentRef.current?.mode,
+      });
       if (!claimed && activeTradeInstrumentRef.current?.coin) {
         return;
       }
       if (claimed) {
-        await Promise.all([
-          backgroundApiProxy.serviceHyperliquid.refreshTradingMeta(),
-          // Spot meta failure must not block perps initialization
-          backgroundApiProxy.serviceHyperliquid.refreshSpotMeta().catch((e) => {
-            console.error('refreshSpotMeta failed (non-blocking):', e);
-          }),
-        ]);
+        let metaRefreshOk = true;
+        try {
+          await Promise.all([
+            backgroundApiProxy.serviceHyperliquid.refreshTradingMeta(),
+            // Spot meta failure must not block perps initialization
+            backgroundApiProxy.serviceHyperliquid
+              .refreshSpotMeta()
+              .catch((e) => {
+                console.error('refreshSpotMeta failed (non-blocking):', e);
+              }),
+          ]);
+        } catch (e) {
+          metaRefreshOk = false;
+          throw e;
+        } finally {
+          defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+            source: 'ui',
+            event: 'initial_symbol_meta_refresh',
+            claimed,
+            metaRefreshOk,
+          });
+        }
       }
       const currentMode = await tradingModeAtom.get();
       const currentPerpToken = await perpsActiveAssetAtom.get();
@@ -684,6 +781,13 @@ function useHyperliquidSymbolSelect() {
       const nextMode = currentMode === 'spot' ? 'spot' : 'perp';
       const nextCoin =
         nextMode === 'spot' ? currentSpotToken?.coin : currentPerpToken?.coin;
+      defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+        source: 'ui',
+        event: 'initial_symbol_next_coin',
+        claimed,
+        nextCoinSet: !!nextCoin,
+        instrumentMode: nextMode,
+      });
       if (!nextCoin) {
         return;
       }
@@ -813,6 +917,10 @@ function AutoPauseSubscriptions() {
   // Dedup: visibilitychange + window.focus can fire back-to-back
   const lastFocusStateRef = useRef<boolean | null>(null);
 
+  const [isLocked] = useAppIsLockedAtom();
+  const isLockedRef = useRef(isLocked);
+  isLockedRef.current = isLocked;
+
   const onFocusHandler = useCallback(
     async ({
       isFocus,
@@ -824,7 +932,15 @@ function AutoPauseSubscriptions() {
       if (lastFocusStateRef.current === isFocus && pauseDelay === undefined) {
         return;
       }
+      const previousFocusState = lastFocusStateRef.current;
       lastFocusStateRef.current = isFocus;
+      defaultLogger.perp.hyperliquid.subscriptionDiagnostic({
+        source: 'ui',
+        event: 'auto_pause_focus',
+        isFocus,
+        lastFocusState: previousFocusState,
+        isLocked: isLockedRef.current,
+      });
 
       if (isFocus) {
         clearTimeout(pauseSubscriptionsTimerRef.current);
@@ -879,8 +995,6 @@ function AutoPauseSubscriptions() {
   // native the OS itself suspends JS in the background and resume is
   // handled by useHandleAppStateActive.
 
-  const [isLocked] = useAppIsLockedAtom();
-
   useEffect(() => {
     if (isLocked) {
       void onFocusHandler({ isFocus: false });
@@ -931,6 +1045,7 @@ function useHyperliquidInstrumentSwitchRequest() {
 }
 
 function PerpsGlobalEffectsView() {
+  usePerpsNavigationDiagnostics();
   useHyperliquidEventBusListener();
   useHyperliquidMarketDataSnapshotReplay();
   useHyperliquidSession();

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -330,6 +330,59 @@ function useHyperliquidEventBusListener() {
   }, [actions]);
 }
 
+function useHyperliquidMarketDataSnapshotReplay() {
+  const actions = useHyperliquidActions();
+  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
+  const [tradeRouteViewState] = useTradeRouteViewStateAtom();
+  const localeVariant = useLocaleVariant();
+
+  const instrumentCoin = activeTradeInstrument.coin;
+  const instrumentMode = activeTradeInstrument.mode;
+  const routeFocused = tradeRouteViewState.routeFocused;
+  const tokenSelectorOpen = tradeRouteViewState.tokenSelectorOpen;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      const snapshot =
+        await backgroundApiProxy.serviceHyperliquidSubscription.getLatestMarketDataSnapshot(
+          {
+            coin: instrumentCoin,
+          },
+        );
+      if (cancelled) {
+        return;
+      }
+
+      const allDexsAssetCtxs = snapshot.allDexsAssetCtxs?.data;
+      if (allDexsAssetCtxs) {
+        // Replays the latest BG snapshot after iOS locale reloads where the
+        // one-shot event can fire before this UI context has mounted.
+        startTransition(() => {
+          void actions.current.updateAllDexsAssetCtxs(allDexsAssetCtxs);
+        });
+      }
+
+      const l2Book = snapshot.l2Book?.data;
+      if (l2Book) {
+        void actions.current.updateL2Book(l2Book);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    actions,
+    instrumentCoin,
+    instrumentMode,
+    localeVariant,
+    routeFocused,
+    tokenSelectorOpen,
+  ]);
+}
+
 // OK-53208: perps atoms/WS must survive unmount — mobile modal push
 // detaches this tab and re-mount has no recovery. Resets on account
 // switch / logout are owned by clearActiveAccountData / ServiceApp.resetApp.
@@ -879,6 +932,7 @@ function useHyperliquidInstrumentSwitchRequest() {
 
 function PerpsGlobalEffectsView() {
   useHyperliquidEventBusListener();
+  useHyperliquidMarketDataSnapshotReplay();
   useHyperliquidSession();
   useHyperliquidAccountSelect();
   usePerpTokenUrlSync();

--- a/packages/shared/src/logger/scopes/perp/scenes/hyperliquid.ts
+++ b/packages/shared/src/logger/scopes/perp/scenes/hyperliquid.ts
@@ -56,6 +56,59 @@ export interface IHyperLiquidOrderRequestPayload {
   } | null;
 }
 
+export type IHyperLiquidSubscriptionDiagnosticParams = {
+  source: 'ui' | 'bg';
+  event: string;
+  reason?: string;
+  caller?: string;
+  readyState?: number | null;
+  socketOpen?: boolean;
+  routeFocused?: boolean;
+  isFocus?: boolean;
+  isHiddenByModal?: boolean;
+  hasOnboardingRoute?: boolean;
+  hasOverlayRoute?: boolean;
+  currentTabName?: string;
+  isLocked?: boolean;
+  lastFocusState?: boolean | null;
+  shouldTreatFocusedOnMount?: boolean;
+  hasAccount?: boolean;
+  hasInstrumentCoin?: boolean;
+  instrumentMode?: string;
+  hasOrderBookCoin?: boolean;
+  hasOrderBookOptions?: boolean;
+  tokenSelectorOpen?: boolean;
+  tokenSelectorTab?: string;
+  infoPanelTab?: string;
+  favoritesBarSpotActive?: boolean;
+  isLoading?: boolean;
+  isWebSocketConnected?: boolean;
+  shouldSyncSubscriptions?: boolean;
+  spotEnabled?: boolean;
+  spotAssetCtxsEnabled?: boolean;
+  enableLedgerUpdates?: boolean;
+  disabled?: boolean;
+  disabledCount?: number;
+  hasInitialSubscription?: boolean;
+  lifecycleVersion?: number;
+  pendingCount?: number;
+  activeCount?: number;
+  toCreateCount?: number;
+  requiredCount?: number;
+  hasAllDexsAssetCtxs?: boolean;
+  hasL2Book?: boolean;
+  hasL2BookOptions?: boolean;
+  currentSymbolSet?: boolean;
+  currentSpotSymbolSet?: boolean;
+  currentUserSet?: boolean;
+  tradingMode?: string;
+  subscriptionType?: string;
+  isFirstData?: boolean;
+  claimed?: boolean;
+  nextCoinSet?: boolean;
+  metaRefreshOk?: boolean;
+};
+
 export class HyperLiquidScene extends BaseScene {
   @LogToServer()
   public setReferrer(
@@ -320,6 +373,14 @@ export class HyperLiquidScene extends BaseScene {
    */
   @LogToLocal({ level: 'error' })
   public subscriptionInnerClientDisposeError(params: { error: unknown }) {
+    return params;
+  }
+
+  // Local-only breadcrumbs for OK-54167 QA bundles; keep them out of analytics.
+  @LogToLocal({ level: 'info' })
+  public subscriptionDiagnostic(
+    params: IHyperLiquidSubscriptionDiagnosticParams,
+  ) {
     return params;
   }
 }


### PR DESCRIPTION
## Summary
- Supersedes the closed v3 recovery test PR with a v4 QA-bundle diagnostics branch for OK-54167.
- Keeps the existing v3 Perps recovery/replay test code in the branch, then adds local-only lifecycle breadcrumbs around UI bootstrap, route focus, BG subscription gating, critical subscription creation, and first data delivery.
- Adds no Mixpanel/server analytics for the new diagnostics; `subscriptionDiagnostic` is decorated with `@LogToLocal({ level: 'info' })` only.

## Intent & Context
OK-54167 is still reproducible on iOS after language switching: Perps orderbook and token selector market data may stay empty, while some other subscriptions can remain alive. Recent manual testing showed timing sensitivity around the post-restart Onboarding route: entering Perps before the Onboarding screen appears can behave differently from entering after it appears.

The goal of this PR is not to ship another blind recovery fix. It creates a QA Bundle that can produce enough local logs to distinguish whether the failure is caused by UI focus/bootstrap state, BG `subscriptionsHandlerDisabled` gating, missing/duplicate critical subscription creation, or data arriving but not being consumed by UI state.

## Root Cause
Root cause is not confirmed yet. Current leading hypotheses are:
- Auto-pause focus handling may disable the BG subscriptions handler during mount and lose the later enable/resume ordering.
- Socket open recovery and explicit subscription update paths may race during initial bootstrap.
- Onboarding as a root route may affect Perps focus/route state differently from normal modal overlays after the language-triggered restart.

## Design Decisions
- Use OneKey's existing logger pipeline instead of ad-hoc console output so logs are written into the same local app log files we can pull with `devicectl`.
- Add one dedicated `subscriptionDiagnostic` logger method and keep it local-only with `@LogToLocal`; do not add `@LogToServer` and do not call analytics/Mixpanel directly.
- Log only booleans, counts, enum-like state, lifecycle version, readyState, and subscription type. Do not log wallet addresses, payloads, orderbook data, prices, or coin values.
- Keep diagnostics low-frequency: route-state dedupe, first critical data delivery only once per critical subscription type, and lifecycle events rather than every WS message.

## Changes Detail
- `packages/shared/src/logger/scopes/perp/scenes/hyperliquid.ts`: adds typed local-only subscription diagnostics for OK-54167 QA bundle logs.
- `packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx`: logs Perps mount/unmount, router focus state, initial symbol selection checkpoints, subscription planner output, and auto-pause focus transitions.
- `packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts`: logs BG disabled gating, required subscription summaries, resume/reconcile/recover paths, critical subscription create start/done, and first critical data arrival.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile, mainly iOS QA Bundle verification for Perps
- **Risk Areas**: Additional local log volume during Perps bootstrap and subscription lifecycle. The diagnostics intentionally avoid payloads and server analytics, but should be removed or gated after root cause is confirmed.

## Test plan
- [x] `yarn jest packages/kit-bg/src/services/ServiceHyperLiquid/utils/latestMarketDataSnapshot.test.ts packages/kit/src/views/Perp/utils/subscriptionPlanner.test.ts --runInBand`
- [x] `npx oxlint packages/shared/src/logger/scopes/perp/scenes/hyperliquid.ts packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [ ] QA Bundle path A: switch language, enter Perps immediately, then pull `Library/Caches/logs/app-latest.log`.
- [ ] QA Bundle path B: switch language, wait for Onboarding to appear, enter Perps, wait about 60 seconds, then pull `Library/Caches/logs/app-latest.log`.
