### PR TITLE
fix(mobile): disable page gestures while TradingView indicators dialog is open(OK-54870)

### DIFF
--- a/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.native.tsx
+++ b/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.native.tsx
@@ -20,6 +20,7 @@ const REFRESH_THRESHOLD = 80;
 
 export function HeaderScrollGestureWrapper({
   children,
+  disabled = false,
   onRefresh,
   disableMomentum = false,
   panActiveOffsetY = [-10, 10],
@@ -96,6 +97,7 @@ export function HeaderScrollGestureWrapper({
     };
 
     let verticalPanGesture = Gesture.Pan()
+      .enabled(!disabled)
       .activeOffsetY(panActiveOffsetY)
       .failOffsetX(panFailOffsetX);
 
@@ -162,6 +164,7 @@ export function HeaderScrollGestureWrapper({
     }
 
     let horizontalPanGesture = Gesture.Pan()
+      .enabled(!disabled)
       .activeOffsetX([-10, 10])
       .failOffsetY([-10, 10]);
 
@@ -223,6 +226,7 @@ export function HeaderScrollGestureWrapper({
     simultaneousWithNativeGesture,
     cancelChildTouches,
     onGestureActiveChange,
+    disabled,
     containerWidth,
     measuredWidth,
     isGestureEnabled,

--- a/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.tsx
+++ b/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.tsx
@@ -1,6 +1,7 @@
 import type { PropsWithChildren } from 'react';
 
 export interface IHeaderScrollGestureWrapperProps {
+  disabled?: boolean;
   onRefresh?: () => void;
   disableMomentum?: boolean;
   panActiveOffsetY?: [number, number];

--- a/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
@@ -59,6 +59,7 @@ interface IBaseTradingViewV2Props {
   dataSource?: 'websocket' | 'polling';
   accountAddress?: string;
   onTouchScroll?: (deltaY: number) => void;
+  onIndicatorsDialogOpenChange?: (isOpen: boolean) => void;
 }
 
 export type ITradingViewV2Props = IBaseTradingViewV2Props & IStackStyle;
@@ -84,6 +85,7 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     dataSource,
     accountAddress,
     onTouchScroll,
+    onIndicatorsDialogOpenChange,
     ...stackStyle
   } = props;
 
@@ -98,6 +100,7 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     marksTimeRange,
     currentKLineResolution,
     onTouchScroll,
+    onIndicatorsDialogOpenChange,
   });
 
   const { isHyperLiquidSource, symbol: hyperLiquidSymbol } =

--- a/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
@@ -32,7 +32,10 @@ import type { IMarksTimeRange } from './messageHandlers';
 import type { ICustomReceiveHandlerData } from './types';
 import type { IWebViewRef } from '../../WebView/types';
 import type { WebViewProps } from 'react-native-webview';
-import type { WebViewNavigation } from 'react-native-webview/lib/WebViewTypes';
+import type {
+  WebViewNavigation,
+  WebViewNavigationEvent,
+} from 'react-native-webview/lib/WebViewTypes';
 
 const MOCK_EMPTY_KLINE_BADGE_POSITION_STYLES = [
   { right: '$2', bottom: '$2' },
@@ -86,6 +89,7 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     accountAddress,
     onTouchScroll,
     onIndicatorsDialogOpenChange,
+    onLoadStart,
     ...stackStyle
   } = props;
 
@@ -257,6 +261,34 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     [handleNavigation],
   );
 
+  const resetIndicatorsDialogOpen = useCallback(() => {
+    onIndicatorsDialogOpenChange?.(false);
+  }, [onIndicatorsDialogOpenChange]);
+
+  const handleLoadStart = useCallback(
+    (event: WebViewNavigationEvent) => {
+      resetIndicatorsDialogOpen();
+      onLoadStart?.(event);
+    },
+    [onLoadStart, resetIndicatorsDialogOpen],
+  );
+
+  const handleWebViewRef = useCallback(
+    (ref: IWebViewRef | null) => {
+      if (!ref) {
+        resetIndicatorsDialogOpen();
+      }
+      webRef.current = ref;
+    },
+    [resetIndicatorsDialogOpen, webRef],
+  );
+
+  useEffect(() => {
+    return () => {
+      resetIndicatorsDialogOpen();
+    };
+  }, [resetIndicatorsDialogOpen]);
+
   const handleMockEmptyKLineBadgePress = useCallback(() => {
     setMockEmptyKLineBadgePositionIndex(
       (positionIndex) =>
@@ -271,10 +303,9 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
         customReceiveHandler={async (data) => {
           await customReceiveHandler(data as ICustomReceiveHandlerData);
         }}
-        onWebViewRef={(ref) => {
-          webRef.current = ref;
-        }}
+        onWebViewRef={handleWebViewRef}
         allowsBackForwardNavigationGestures={false}
+        onLoadStart={handleLoadStart}
         onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
         displayProgressBar={false}
         pullToRefreshEnabled={false}
@@ -289,10 +320,11 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     ),
     [
       customReceiveHandler,
+      handleLoadStart,
+      handleWebViewRef,
       onShouldStartLoadWithRequest,
       theme,
       tradingViewUrlWithParams,
-      webRef,
     ],
   );
 

--- a/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/useTradingViewMessageHandler.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/useTradingViewMessageHandler.ts
@@ -15,7 +15,11 @@ import { handleLayoutUpdate } from './layoutUpdateHandler';
 
 import type { IMarksTimeRange, IMessageHandlerContext } from './types';
 import type { IWebViewRef } from '../../../WebView/types';
-import type { ICustomReceiveHandlerData } from '../types';
+import type {
+  ICustomReceiveHandlerData,
+  ITradingViewIndicatorsDialogData,
+  ITradingViewTouchScrollData,
+} from '../types';
 
 const DEFAULT_HYPERLIQUID_PRICE_SCALE = 100;
 
@@ -29,6 +33,7 @@ interface IUseTradingViewMessageHandlerParams {
   marksTimeRange?: React.MutableRefObject<IMarksTimeRange | null>;
   currentKLineResolution?: React.MutableRefObject<string>;
   onTouchScroll?: (deltaY: number) => void;
+  onIndicatorsDialogOpenChange?: (isOpen: boolean) => void;
 }
 
 async function handleGetHyperliquidPriceScale({
@@ -203,6 +208,21 @@ async function handleGetMarks({
   }
 }
 
+function getIndicatorsDialogOpenState(
+  dialogData: ITradingViewIndicatorsDialogData | undefined,
+): boolean | undefined {
+  if (typeof dialogData?.isOpen === 'boolean') {
+    return dialogData.isOpen;
+  }
+  if (dialogData?.action === 'open') {
+    return true;
+  }
+  if (dialogData?.action === 'close') {
+    return false;
+  }
+  return undefined;
+}
+
 export function useTradingViewMessageHandler({
   tokenAddress = '',
   networkId = '',
@@ -213,6 +233,7 @@ export function useTradingViewMessageHandler({
   marksTimeRange,
   currentKLineResolution,
   onTouchScroll,
+  onIndicatorsDialogOpenChange,
 }: IUseTradingViewMessageHandlerParams) {
   const customReceiveHandler = useCallback(
     async ({ data }: ICustomReceiveHandlerData) => {
@@ -297,10 +318,24 @@ export function useTradingViewMessageHandler({
         data.scope === '$private' &&
         data.method === 'tradingview_touchScroll'
       ) {
-        const touchData = data.data as { deltaY?: number } | undefined;
+        const touchData = data.data as ITradingViewTouchScrollData | undefined;
         const deltaY = Number(touchData?.deltaY ?? 0);
         if (Number.isFinite(deltaY) && deltaY !== 0) {
           onTouchScroll?.(deltaY);
+        }
+      }
+
+      if (
+        data.scope === '$private' &&
+        data.method === 'tradingview_indicatorsDialog'
+      ) {
+        const dialogData = data.data as
+          | ITradingViewIndicatorsDialogData
+          | undefined;
+        const isOpen = getIndicatorsDialogOpenState(dialogData);
+
+        if (typeof isOpen === 'boolean') {
+          onIndicatorsDialogOpenChange?.(isOpen);
         }
       }
     },
@@ -314,6 +349,7 @@ export function useTradingViewMessageHandler({
       marksTimeRange,
       currentKLineResolution,
       onTouchScroll,
+      onIndicatorsDialogOpenChange,
     ],
   );
 

--- a/packages/kit/src/components/TradingView/TradingViewV2/types.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/types.ts
@@ -10,8 +10,22 @@ export interface ITradingViewLayoutData {
   layout: string; // JSON string format of layout data
 }
 
+export interface ITradingViewTouchScrollData {
+  deltaY?: number;
+}
+
+export interface ITradingViewIndicatorsDialogData {
+  action?: 'open' | 'close';
+  isOpen?: boolean;
+  timestamp?: number;
+}
+
 // Union type to support different data structures
-type ITradingViewData = ITradingViewHistoryData | ITradingViewLayoutData;
+type ITradingViewData =
+  | ITradingViewHistoryData
+  | ITradingViewLayoutData
+  | ITradingViewTouchScrollData
+  | ITradingViewIndicatorsDialogData;
 
 interface ITradingViewMessage {
   scope: string;

--- a/packages/kit/src/views/Market/MarketDetailV2/components/MarketTradingView/MarketTradingView.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/MarketTradingView/MarketTradingView.tsx
@@ -15,6 +15,7 @@ interface IMarketTradingViewProps {
   dataSource: 'websocket' | 'polling';
   pageWidth?: number;
   onTouchScroll?: (deltaY: number) => void;
+  onIndicatorsDialogOpenChange?: (isOpen: boolean) => void;
 }
 
 export const MarketTradingView = memo(
@@ -26,6 +27,7 @@ export const MarketTradingView = memo(
     dataSource,
     pageWidth,
     onTouchScroll,
+    onIndicatorsDialogOpenChange,
   }: IMarketTradingViewProps) => {
     const { accountAddress } = useNetworkAccountAddress(networkId);
 
@@ -40,6 +42,7 @@ export const MarketTradingView = memo(
         accountAddress={accountAddress}
         w={pageWidth}
         onTouchScroll={onTouchScroll}
+        onIndicatorsDialogOpenChange={onIndicatorsDialogOpenChange}
       />
     );
   },

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -54,14 +54,40 @@ function MobileTradingViewTouchBridge({
   tokenSymbol,
   dataSource,
   pageWidth,
+  onIndicatorsDialogOpenChange,
 }: {
   tokenAddress: string;
   networkId: string;
   tokenSymbol: string;
   dataSource: 'websocket' | 'polling';
   pageWidth?: number;
+  onIndicatorsDialogOpenChange: (isOpen: boolean) => void;
 }) {
+  const indicatorsDialogOpenRef = useRef(false);
   const handleTouchScroll = useMobileTabTouchScrollBridge();
+  const handleTouchScrollWhenEnabled = useCallback(
+    (deltaY: number) => {
+      if (indicatorsDialogOpenRef.current) {
+        return;
+      }
+      handleTouchScroll(deltaY);
+    },
+    [handleTouchScroll],
+  );
+  const handleIndicatorsDialogOpenChange = useCallback(
+    (isOpen: boolean) => {
+      indicatorsDialogOpenRef.current = isOpen;
+      onIndicatorsDialogOpenChange(isOpen);
+    },
+    [onIndicatorsDialogOpenChange],
+  );
+
+  useEffect(() => {
+    return () => {
+      indicatorsDialogOpenRef.current = false;
+      onIndicatorsDialogOpenChange(false);
+    };
+  }, [onIndicatorsDialogOpenChange]);
 
   return (
     <MarketTradingView
@@ -70,7 +96,8 @@ function MobileTradingViewTouchBridge({
       tokenSymbol={tokenSymbol}
       dataSource={dataSource}
       pageWidth={pageWidth}
-      onTouchScroll={handleTouchScroll}
+      onTouchScroll={handleTouchScrollWhenEnabled}
+      onIndicatorsDialogOpenChange={handleIndicatorsDialogOpenChange}
     />
   );
 }
@@ -135,6 +162,10 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
 
   const scrollViewRef = useRef<IScrollViewRef>(null);
   const focusedTab = useSharedValue(tabNames[0]);
+  const [
+    isTradingViewIndicatorsDialogOpen,
+    setIsTradingViewIndicatorsDialogOpen,
+  ] = useState(false);
   const secondTabTouchStartRef = useRef<{
     pageX: number;
     pageY: number;
@@ -179,6 +210,14 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
 
     return () => clearTimeout(alignTimer);
   }, [effectivePageWidth, focusedTab, tabNames]);
+
+  useEffect(() => {
+    setIsTradingViewIndicatorsDialogOpen(false);
+  }, [networkId, tokenAddress, tokenSymbol]);
+
+  const handleIndicatorsDialogOpenChange = useCallback((isOpen: boolean) => {
+    setIsTradingViewIndicatorsDialogOpen(isOpen);
+  }, []);
 
   const handleHeaderHorizontalSwipe = useCallback(
     (direction: 'left' | 'right') => {
@@ -260,6 +299,7 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
         </HeaderScrollGestureWrapper>
         <Stack position="relative">
           <HeaderScrollGestureWrapper
+            disabled={isTradingViewIndicatorsDialogOpen}
             panActiveOffsetY={[-4, 4]}
             panFailOffsetX={chartAreaPanFailOffsetX}
             excludeRightEdgeRatio={chartAreaExcludeRightEdgeRatio}
@@ -278,6 +318,7 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
                 if (platformEnv.isNativeAndroid || platformEnv.isNativeIOS) {
                   return (
                     <MobileTradingViewTouchBridge
+                      key={`${networkId}:${tokenAddress}:${tokenSymbol}`}
                       tokenAddress={tokenAddress}
                       networkId={networkId}
                       tokenSymbol={tokenSymbol}
@@ -285,6 +326,9 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
                         websocketConfig?.kline ? 'websocket' : 'polling'
                       }
                       pageWidth={effectivePageWidth}
+                      onIndicatorsDialogOpenChange={
+                        handleIndicatorsDialogOpenChange
+                      }
                     />
                   );
                 }
@@ -320,6 +364,8 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
   }, [
     effectivePageWidth,
     handleHeaderHorizontalSwipe,
+    handleIndicatorsDialogOpenChange,
+    isTradingViewIndicatorsDialogOpen,
     networkId,
     tokenAddress,
     tokenSymbol,


### PR DESCRIPTION
## Summary
- Add a `tradingview_indicatorsDialog` message channel so the TradingView WebView can tell the host page when its indicators dialog opens/closes.
- While that dialog is open on mobile Market Detail, disable the chart-area `HeaderScrollGestureWrapper` pan gesture and stop forwarding `touchScroll` deltas to the tab bridge, so vertical drags scroll the dialog's list instead of the host page.
- Reset the dialog-open state and remount the touch bridge when the chart symbol changes (and on bridge unmount), so a stale "open" state cannot leak across tokens.

## Intent & Context
Reported in OK-54870: on the mobile Market Detail chart, opening the TradingView indicators list dialog made the list impossible to scroll — dragging inside the dialog scrolled/swiped the whole host page instead. Reproduced on Samsung Galaxy S23 Ultra and iPhone 16 Pro.

The TradingView chart is rendered in a WebView nested inside the host page's gesture stack (`HeaderScrollGestureWrapper` + the mobile tab touch-scroll bridge). When a dialog opens *inside* the WebView, the host page's native pan gestures still win gesture arbitration and consume the vertical drag, so the dialog's own scroll view never receives it.

## Root Cause
The host page has no awareness of UI state inside the TradingView WebView. The chart-area `HeaderScrollGestureWrapper` always keeps its vertical/horizontal `Gesture.Pan()` enabled, and `MobileTradingViewTouchBridge` always forwards `touchScroll` deltas to the tab bridge. When the indicators dialog is open, these host-side interception paths capture the touch that should scroll the dialog list.

## Design Decisions
- **WebView-driven signal**: the chart emits a `tradingview_indicatorsDialog` message (`$private` scope) on open/close; the host reacts. This keeps dialog visibility as the chart's source of truth instead of the host guessing.
- **Tolerant payload parsing**: `getIndicatorsDialogOpenState` accepts either an explicit `isOpen` boolean or an `action: 'open' | 'close'` string, staying compatible with whichever shape the chart bundle sends. Unknown payloads return `undefined` and are ignored rather than forcing a state.
- **Two independent guards**: the new `disabled` prop on `HeaderScrollGestureWrapper` handles the native gesture layer; suppressing `onTouchScroll` in `MobileTradingViewTouchBridge` handles the touch-scroll bridge. Both are separate interception paths, so both must be gated.
- **Ref + state split**: `MobileTradingViewTouchBridge` keeps an `indicatorsDialogOpenRef` for the synchronous `onTouchScroll` guard (no re-render needed), while `MobileLayout` keeps React state to drive the `disabled` prop.
- **Stale-state safety**: switching token (`networkId`/`tokenAddress`/`tokenSymbol`) resets the open state and remounts the bridge via a React `key`; the bridge also resets the state on unmount — so a dialog left "open" cannot leak across symbols.

## Changes Detail
- `components/.../Tabs/HeaderScrollGestureWrapper.tsx` — add optional `disabled` prop to the shared interface.
- `components/.../Tabs/HeaderScrollGestureWrapper.native.tsx` — apply `.enabled(!disabled)` to both vertical and horizontal pan gestures; add `disabled` to the gesture `useMemo` deps.
- `TradingViewV2/types.ts` — add `ITradingViewTouchScrollData` and `ITradingViewIndicatorsDialogData` types and include them in the `ITradingViewData` union.
- `TradingViewV2/messageHandlers/useTradingViewMessageHandler.ts` — handle the `tradingview_indicatorsDialog` message via `getIndicatorsDialogOpenState`; type the existing `tradingview_touchScroll` payload.
- `TradingViewV2/TradingViewV2.tsx` & `MarketTradingView/MarketTradingView.tsx` — thread the new `onIndicatorsDialogOpenChange` callback through.
- `MarketDetailV2/layouts/MobileLayout.tsx` — track `isTradingViewIndicatorsDialogOpen`, pass `disabled` to the chart-area `HeaderScrollGestureWrapper`, gate `onTouchScroll`, and add reset/remount safety on symbol change.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile (iOS + Android)
- **Risk Areas**: Gesture arbitration in the chart area. The `disabled` prop only toggles `Gesture.Pan().enabled()`; the desktop/web `.tsx` path gets only an additive optional prop with no behavior change. The new message handler is additive and ignores unrecognized payloads. The key thing to verify is that normal page scroll / tab swipe still work when the dialog is closed.

## Test plan
- [ ] Mobile Market Detail: open the TradingView indicators dialog, confirm the indicator list scrolls smoothly and the host page no longer moves.
- [ ] Close the dialog, confirm page vertical scroll and header tab swipe work as before.
- [ ] Switch token while the indicators dialog is open, confirm the new chart is interactive and page gestures are restored.
- [ ] Verify on both Samsung Galaxy S23 Ultra and iPhone 16 Pro (devices from the report).
- [ ] Desktop / Web Market Detail chart: confirm no behavior change.
