### PR TITLE
fix: refresh market watchlist on page focus(OK-54859)

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/MarketHomeV2.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/MarketHomeV2.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Page, useMedia } from '@onekeyhq/components';
 import type { ITabContainerRef } from '@onekeyhq/components';
+import { useRouteIsFocused } from '@onekeyhq/kit/src/hooks/useRouteIsFocused';
 import {
   EJotaiContextStoreNames,
   useMarketSelectedTabAtom,
@@ -15,7 +16,10 @@ import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import { AccountSelectorProviderMirror } from '../../../components/AccountSelector';
 import { LazyPageContainer } from '../../../components/LazyPageContainer';
 import { TabPageHeader } from '../../../components/TabPageHeader';
-import { useSelectedNetworkIdAtom } from '../../../states/jotai/contexts/marketV2';
+import {
+  useSelectedNetworkIdAtom,
+  useWatchListV2Actions,
+} from '../../../states/jotai/contexts/marketV2';
 import { useMarketBasicConfig } from '../hooks';
 import { useMarketHomePageEnterAnalytics } from '../hooks/useMarketEnterAnalytics';
 import { MarketWatchListProviderMirrorV2 } from '../MarketWatchListProviderMirrorV2';
@@ -27,6 +31,16 @@ import { MobileLayout } from './layouts/MobileLayout';
 
 import type { ITimeRangeSelectorValue } from './components/TimeRangeSelector';
 import type { ILiquidityFilter, IMarketCategoryItem } from './types';
+
+function useRefreshWatchListV2OnFocus(isFocused: boolean) {
+  const actions = useWatchListV2Actions();
+
+  useEffect(() => {
+    if (isFocused) {
+      void actions.current.refreshWatchListV2();
+    }
+  }, [actions, isFocused]);
+}
 
 const useMarketHomeLayoutProps = () => {
   const { md } = useMedia();
@@ -166,6 +180,8 @@ const useMarketHomeLayoutProps = () => {
 
 function BaseMarketHomeLayout() {
   const { md, layoutProps } = useMarketHomeLayoutProps();
+  const isFocused = useRouteIsFocused();
+  useRefreshWatchListV2OnFocus(isFocused);
 
   return (
     <LazyPageContainer>
@@ -223,6 +239,7 @@ function BaseMarketHomeWithProvider({
   nestedPager?: boolean;
 }) {
   const { layoutProps } = useMarketHomeLayoutProps();
+  useRefreshWatchListV2OnFocus(isFocused);
   // In nested outer pagers (Discovery: Market/Earn/Browser), keep Market mounted
   // and let Freeze control inactive-page performance. Unmounting here causes
   // visible flashes when the outer pager finishes settling.


### PR DESCRIPTION
## Summary
- Add a `useRefreshWatchListV2OnFocus` hook that refreshes the Market V2 watchlist whenever the Market page gains focus.
- Wire it into both Market entry points: `BaseMarketHomeLayout` (standalone Market tab) and `BaseMarketHomeWithProvider` (Discovery nested pager).

## Intent & Context
Bug report OK-54859: on mobile, after a user favorites a token on the wallet home page during their first session, switching to the Market module still shows the recommended/trending list — the favorited token is missing and the watchlist looks empty/stale.

## Root Cause
The Market V2 watchlist atom (`marketWatchListV2Atom`) is populated when the Market page first mounts and is not re-synced afterwards. Favoriting a token from another screen (e.g. the wallet home page) persists the change through `serviceMarketV2`, but the Market page never re-reads it. Because the Market page stays mounted (Freeze-controlled in nested pagers), a remount-based refresh never fires either, so the in-memory list stays stale.

## Design Decisions
- Trigger the refresh on route focus (`useRouteIsFocused`) instead of on mount, so it works even when the page stays mounted in the background.
- Extract the logic into a single `useRefreshWatchListV2OnFocus` hook and apply it at both Market entry points, since the standalone tab and the Discovery-nested pager render through different components.
- `BaseMarketHomeWithProvider` already receives an `isFocused` prop from its parent pager, so it reuses that signal; `BaseMarketHomeLayout` derives focus locally via `useRouteIsFocused()`.
- `refreshWatchListV2` re-fetches from `serviceMarketV2.getMarketWatchListV2()` and flushes the atom, so calling it on focus brings the list back in sync with the persisted source of truth.

## Changes Detail
- `packages/kit/src/views/Market/MarketHomeV2/MarketHomeV2.tsx`
  - New `useRefreshWatchListV2OnFocus(isFocused)` hook — calls `actions.current.refreshWatchListV2()` when `isFocused` is true.
  - `BaseMarketHomeLayout`: obtains focus state via `useRouteIsFocused()` and invokes the hook.
  - `BaseMarketHomeWithProvider`: invokes the hook with its existing `isFocused` prop.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile (primary), Desktop, Web — all platforms rendering Market V2.
- **Risk Areas**: The refresh fires on every focus gain and issues a network request via `serviceMarketV2`. This is bounded by how often the user navigates to Market; no change to mount/unmount or rendering behavior.

## Test plan
- [ ] Fresh app launch: favorite a token on the wallet home page, switch to Market — the favorited token appears in the watchlist.
- [ ] Favorite / unfavorite a token from another screen, return to Market — the watchlist reflects the change.
- [ ] Discovery nested pager (Market / Earn / Browser): switching back to the Market page refreshes the watchlist.
- [ ] Cold open Market directly — watchlist still loads correctly with no regression.
