### PR TITLE
fix(perps): keep iOS locale market data store live OK-54167

### DIFF
--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -2322,7 +2322,7 @@ export function useHyperliquidActions() {
   const updateOpenOrders = actions.updateOpenOrders.use();
   const updateAllDexsAssetCtxs = actions.updateAllDexsAssetCtxs.use();
 
-  return useRef({
+  const currentActions = {
     updateAllAssetsFiltered,
     updateAllMids,
     markAllAssetCtxsRequired,
@@ -2374,5 +2374,14 @@ export function useHyperliquidActions() {
     getMidPrice,
     switchTradeInstrument,
     setTradeRouteViewState,
-  });
+  };
+
+  const actionsRef = useRef(currentActions);
+
+  // The Perps context store can be recreated during native restart/route
+  // recovery. Keep long-lived event handlers writing to the currently mounted
+  // store instead of the one captured on first render.
+  actionsRef.current = currentActions;
+
+  return actionsRef;
 }


### PR DESCRIPTION
## Summary
- Fix OK-54167 by keeping Hyperliquid actions bound to the currently mounted Perps context store.
- Clean Perps effect cleanup paths that could write through stale action refs.

## Intent & Context
This PR isolates the iOS Perps language-switch WS recovery fix. QA bundle validation confirmed that Perps market data, order book, and TokenSelector prices recover after switching language.

## Root Cause
After iOS language restart or route recovery, long-lived Perps event handlers could keep first-render Hyperliquid actions. Those actions still had stable function identities, but their setters could write into an old Jotai context store after the Perps provider remounted. As a result, WS data could arrive while the visible Perps screen stayed bound to stale state.

## Design Decisions
- Keep `useHyperliquidActions()` ref identity stable so existing listeners do not need to resubscribe.
- Refresh `actionsRef.current` on every render so long-lived callbacks always call the latest actions bound to the active store.
- Update effect cleanup paths to read live actions through stable callbacks instead of capturing stale `actions.current`.

## Changes Detail
- Hyperliquid actions now remain live across Perps store recreation.
- Perps global effects and selector cleanup paths use live callbacks for route/requirement teardown.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile, Desktop, Web
- **Risk Areas**: Perps route cleanup state, long-lived Hyperliquid event handlers.

## Test plan
- [x] QA bundle validation: iOS language switch, then enter Perps; order book, TokenSelector prices, and market data recover.
- [x] Previous targeted checks on the isolated change branch: `yarn lint:staged`, `yarn tsc:staged`
- [ ] Reviewer smoke test if needed
