### PR TITLE
feat: SWR cache for account selector sidebar + bg-side invalidation(OK-54908)

### DIFF
--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -101,6 +101,11 @@ import hexUtils from '@onekeyhq/shared/src/utils/hexUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { EMnemonicType } from '@onekeyhq/shared/src/utils/secret';
 import stringUtils from '@onekeyhq/shared/src/utils/stringUtils';
+import {
+  prefixOf,
+  swrCacheNamespaces,
+  swrCacheUtils,
+} from '@onekeyhq/shared/src/utils/swrCacheUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { EHardwareTransportType } from '@onekeyhq/shared/types';
 import type { IServerNetwork } from '@onekeyhq/shared/types';
@@ -223,23 +228,48 @@ class ServiceAccount extends ServiceBase {
   constructor({ backgroundApi }: { backgroundApi: any }) {
     super({ backgroundApi });
 
+    // SWR cache invalidation. Mutation events have no payload, so we drop
+    // every entry in the affected namespace by prefix. Subsequent UI
+    // mounts read an empty MMKV slot and the fetcher repopulates with
+    // fresh data — avoids painting deleted wallets / stale section data
+    // when the mutation happened while the consumer wasn't mounted.
+    const dropWalletListSwr = () =>
+      swrCacheUtils.removeByPrefix(prefixOf(swrCacheNamespaces.walletListSideBar));
+    const dropAccountSelectorListSwr = () =>
+      swrCacheUtils.removeByPrefix(
+        prefixOf(swrCacheNamespaces.accountSelectorList),
+      );
+
     appEventBus.on(EAppEventBusNames.WalletUpdate, () => {
       void this.clearAccountCache();
+      dropWalletListSwr();
+      dropAccountSelectorListSwr();
     });
     appEventBus.on(EAppEventBusNames.AccountRemove, () => {
       void this.clearAccountCache();
+      // sidebar also depends on accounts via ignoreEmptySingletonWalletAccounts
+      dropWalletListSwr();
+      dropAccountSelectorListSwr();
     });
     appEventBus.on(EAppEventBusNames.AccountUpdate, () => {
       void this.clearAccountCache();
+      dropWalletListSwr();
+      dropAccountSelectorListSwr();
     });
     appEventBus.on(EAppEventBusNames.RenameDBAccounts, () => {
       void this.clearAccountCache();
+      // sidebar doesn't show account names, only the right-panel sectionData does
+      dropAccountSelectorListSwr();
     });
     appEventBus.on(EAppEventBusNames.WalletRename, () => {
       void this.clearAccountCache();
+      dropWalletListSwr();
+      dropAccountSelectorListSwr();
     });
     appEventBus.on(EAppEventBusNames.AddDBAccountsToWallet, () => {
       void this.clearAccountCache();
+      dropWalletListSwr();
+      dropAccountSelectorListSwr();
     });
     // Drop derived-address / xpub memoizee caches on critical memory
     // pressure. These caches are the cheapest to rebuild (one BIP32

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -234,7 +234,9 @@ class ServiceAccount extends ServiceBase {
     // fresh data — avoids painting deleted wallets / stale section data
     // when the mutation happened while the consumer wasn't mounted.
     const dropWalletListSwr = () =>
-      swrCacheUtils.removeByPrefix(prefixOf(swrCacheNamespaces.walletListSideBar));
+      swrCacheUtils.removeByPrefix(
+        prefixOf(swrCacheNamespaces.walletListSideBar),
+      );
     const dropAccountSelectorListSwr = () =>
       swrCacheUtils.removeByPrefix(
         prefixOf(swrCacheNamespaces.accountSelectorList),

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -229,10 +229,17 @@ class ServiceAccount extends ServiceBase {
     super({ backgroundApi });
 
     // SWR cache invalidation. Mutation events have no payload, so we drop
-    // every entry in the affected namespace by prefix. Subsequent UI
-    // mounts read an empty MMKV slot and the fetcher repopulates with
-    // fresh data — avoids painting deleted wallets / stale section data
-    // when the mutation happened while the consumer wasn't mounted.
+    // every entry in the affected namespace by prefix. Subsequent UI mounts
+    // read an empty MMKV slot and the fetcher repopulates with fresh data —
+    // avoids painting deleted wallets / stale section data when the mutation
+    // happened while the consumer wasn't mounted.
+    //
+    // flushNow forces the cleared snapshot into MMKV synchronously instead
+    // of waiting on scheduleFlush's 2s debounce. Mutations are low-frequency
+    // and the extra write is worth it: a force-kill (task-manager swipe,
+    // watchdog) between the bg drop and AppState's background flush would
+    // otherwise leave deleted wallets in the MMKV blob and resurrect them
+    // on the next cold open.
     const dropWalletListSwr = () =>
       swrCacheUtils.removeByPrefix(
         prefixOf(swrCacheNamespaces.walletListSideBar),
@@ -246,32 +253,50 @@ class ServiceAccount extends ServiceBase {
       void this.clearAccountCache();
       dropWalletListSwr();
       dropAccountSelectorListSwr();
+      swrCacheUtils.flushNow();
     });
     appEventBus.on(EAppEventBusNames.AccountRemove, () => {
       void this.clearAccountCache();
       // sidebar also depends on accounts via ignoreEmptySingletonWalletAccounts
       dropWalletListSwr();
       dropAccountSelectorListSwr();
+      swrCacheUtils.flushNow();
     });
     appEventBus.on(EAppEventBusNames.AccountUpdate, () => {
       void this.clearAccountCache();
       dropWalletListSwr();
       dropAccountSelectorListSwr();
+      swrCacheUtils.flushNow();
     });
     appEventBus.on(EAppEventBusNames.RenameDBAccounts, () => {
       void this.clearAccountCache();
       // sidebar doesn't show account names, only the right-panel sectionData does
       dropAccountSelectorListSwr();
+      swrCacheUtils.flushNow();
     });
     appEventBus.on(EAppEventBusNames.WalletRename, () => {
       void this.clearAccountCache();
       dropWalletListSwr();
       dropAccountSelectorListSwr();
+      swrCacheUtils.flushNow();
     });
     appEventBus.on(EAppEventBusNames.AddDBAccountsToWallet, () => {
       void this.clearAccountCache();
       dropWalletListSwr();
       dropAccountSelectorListSwr();
+      swrCacheUtils.flushNow();
+    });
+    // Defensive WalletClear handler. ServiceE2E.clearWalletsAndAccounts
+    // currently calls swrCacheUtils.clearAll() before emitting this event,
+    // so the drop here is redundant for the existing emitter — but it makes
+    // the contract explicit, so future emitters (logout flow, alternative
+    // reset paths) inherit the invalidation without having to remember the
+    // call-site dance.
+    appEventBus.on(EAppEventBusNames.WalletClear, () => {
+      void this.clearAccountCache();
+      dropWalletListSwr();
+      dropAccountSelectorListSwr();
+      swrCacheUtils.flushNow();
     });
     // Drop derived-address / xpub memoizee caches on critical memory
     // pressure. These caches are the cheapest to rebuild (one BIP32

--- a/packages/kit-bg/src/services/ServiceE2E.ts
+++ b/packages/kit-bg/src/services/ServiceE2E.ts
@@ -12,6 +12,7 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import { swrCacheUtils } from '@onekeyhq/shared/src/utils/swrCacheUtils';
 
 import localDb from '../dbs/local/localDb';
 import { ELocalDBStoreNames } from '../dbs/local/localDBStoreNames';
@@ -62,6 +63,15 @@ class ServiceE2E extends ServiceBase {
     await localDb.resetContext();
 
     await this.backgroundApi.simpleDb.accountSelector.clearRawData();
+
+    // Wipe the cold-start SWR cache here so consumers (sidebar wallet list,
+    // accountSelectorList, allNetworksCompatible, etc.) don't paint deleted
+    // wallets from MMKV on the next cold open. ServiceApp.resetApp clears
+    // the entire coldStartCacheStorage; this path is narrower (wallets
+    // only), so we just drop SWR entries. flushNow persists the empty
+    // snapshot immediately — clearAll alone debounces the MMKV write 2s.
+    swrCacheUtils.clearAll();
+    swrCacheUtils.flushNow();
 
     appEventBus.emit(EAppEventBusNames.WalletClear, undefined);
   }

--- a/packages/kit-bg/src/services/ServiceE2E.ts
+++ b/packages/kit-bg/src/services/ServiceE2E.ts
@@ -64,12 +64,15 @@ class ServiceE2E extends ServiceBase {
 
     await this.backgroundApi.simpleDb.accountSelector.clearRawData();
 
-    // Wipe the cold-start SWR cache here so consumers (sidebar wallet list,
-    // accountSelectorList, allNetworksCompatible, etc.) don't paint deleted
-    // wallets from MMKV on the next cold open. ServiceApp.resetApp clears
-    // the entire coldStartCacheStorage; this path is narrower (wallets
-    // only), so we just drop SWR entries. flushNow persists the empty
-    // snapshot immediately — clearAll alone debounces the MMKV write 2s.
+    // Wipe every SWR namespace (walletList, accountSelectorList,
+    // allNetCompat, netContent, unsMeta, recentNets, defiEnabled, etc.).
+    // This dev wipe means to reset all wallet state, so the broad clear
+    // is intentional — keeping non-account namespaces around would leave
+    // them referencing IDs that no longer exist in localDb.
+    // ServiceApp.resetApp clears the entire coldStartCacheStorage (jotai
+    // snapshot included); this path is narrower (SWR only). flushNow
+    // persists the empty snapshot immediately — clearAll alone debounces
+    // the MMKV write 2s, which could lose the wipe on a fast kill.
     swrCacheUtils.clearAll();
     swrCacheUtils.flushNow();
 

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/AccountSelectorWalletListSideBar.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/AccountSelectorWalletListSideBar.tsx
@@ -36,6 +36,7 @@ import {
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import { swrKeys } from '@onekeyhq/shared/src/utils/swrCacheUtils';
 
 import { useAccountSelectorRoute } from '../../../router/useAccountSelectorRoute';
 import { AccountManagerTestIDs } from '../../../testIDs';
@@ -128,6 +129,18 @@ export function AccountSelectorWalletListSideBar({
     accountSelectorStatus?.passphraseProtectionChangedAt ?? 0
   }`;
 
+  // Sidebar SWR cache. Invalidation strategy:
+  //   - Wallet/Account CRUD all funnel through WalletUpdate / AccountUpdate
+  //     (see ServiceAccount emits) — listeners below call reloadWallets,
+  //     which runs the fetcher and overwrites this slot via usePromiseResult.
+  //   - HardwareFeaturesUpdate / passphrase toggle flow through
+  //     reloadWalletsHook -> useEffect refetch -> same overwrite path.
+  //   - ServiceApp.resetApp wipes coldStartCacheStorage globally.
+  //   - ServiceE2E.clearWalletsAndAccounts emits WalletClear only, so we
+  //     add an explicit WalletClear listener below; otherwise the dev wipe
+  //     would leave a stale wallet list painted from MMKV.
+  const walletsSwrKey = swrKeys.walletListSideBar({ hideNonBackedUpWallet });
+
   const {
     result: walletsResult,
     setResult,
@@ -193,6 +206,7 @@ export function AccountSelectorWalletListSideBar({
     [serviceAccount, hideNonBackedUpWallet, reloadWalletsHook],
     {
       checkIsFocused: false,
+      swrKey: walletsSwrKey,
     },
   );
 
@@ -271,9 +285,14 @@ export function AccountSelectorWalletListSideBar({
     };
     appEventBus.on(EAppEventBusNames.WalletUpdate, fn);
     appEventBus.on(EAppEventBusNames.AccountUpdate, fn);
+    // ServiceE2E.clearWalletsAndAccounts emits only WalletClear (no
+    // WalletUpdate / coldStartCacheStorage.clearAll), so without this
+    // the SWR slot would keep painting deleted wallets after a dev wipe.
+    appEventBus.on(EAppEventBusNames.WalletClear, fn);
     return () => {
       appEventBus.off(EAppEventBusNames.WalletUpdate, fn);
       appEventBus.off(EAppEventBusNames.AccountUpdate, fn);
+      appEventBus.off(EAppEventBusNames.WalletClear, fn);
     };
   }, [reloadWallets]);
 

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/AccountSelectorWalletListSideBar.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/AccountSelectorWalletListSideBar.tsx
@@ -129,16 +129,15 @@ export function AccountSelectorWalletListSideBar({
     accountSelectorStatus?.passphraseProtectionChangedAt ?? 0
   }`;
 
-  // Sidebar SWR cache. Invalidation strategy:
-  //   - Wallet/Account CRUD all funnel through WalletUpdate / AccountUpdate
+  // Sidebar SWR cache. Invalidation is handled outside this component:
+  //   - Wallet/Account CRUD funnels through WalletUpdate / AccountUpdate
   //     (see ServiceAccount emits) — listeners below call reloadWallets,
   //     which runs the fetcher and overwrites this slot via usePromiseResult.
   //   - HardwareFeaturesUpdate / passphrase toggle flow through
   //     reloadWalletsHook -> useEffect refetch -> same overwrite path.
-  //   - ServiceApp.resetApp wipes coldStartCacheStorage globally.
-  //   - ServiceE2E.clearWalletsAndAccounts emits WalletClear only, so we
-  //     add an explicit WalletClear listener below; otherwise the dev wipe
-  //     would leave a stale wallet list painted from MMKV.
+  //   - Bulk wipes (ServiceApp.resetApp, ServiceE2E.clearWalletsAndAccounts)
+  //     clear the cold-start cache in the bg service before emitting the
+  //     wipe event, so this hook reads an empty MMKV on next mount.
   const walletsSwrKey = swrKeys.walletListSideBar({ hideNonBackedUpWallet });
 
   const {
@@ -285,14 +284,9 @@ export function AccountSelectorWalletListSideBar({
     };
     appEventBus.on(EAppEventBusNames.WalletUpdate, fn);
     appEventBus.on(EAppEventBusNames.AccountUpdate, fn);
-    // ServiceE2E.clearWalletsAndAccounts emits only WalletClear (no
-    // WalletUpdate / coldStartCacheStorage.clearAll), so without this
-    // the SWR slot would keep painting deleted wallets after a dev wipe.
-    appEventBus.on(EAppEventBusNames.WalletClear, fn);
     return () => {
       appEventBus.off(EAppEventBusNames.WalletUpdate, fn);
       appEventBus.off(EAppEventBusNames.AccountUpdate, fn);
-      appEventBus.off(EAppEventBusNames.WalletClear, fn);
     };
   }, [reloadWallets]);
 

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/index.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/index.tsx
@@ -27,7 +27,6 @@ export function AccountSelectorStack({
 
   return (
     <Page lazyLoad safeAreaEnabled={false}>
-      <Page.Header headerShown={false} />
       <Page.Body>
         <XStack flex={1}>
           {/* <AccountSelectorWalletListSideBarPerfTest num={num} /> */}

--- a/packages/kit/src/views/AccountManagerStacks/router/index.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/router/index.tsx
@@ -38,6 +38,9 @@ export const AccountManagerStacks: IModalFlowNavigatorConfig<
   {
     name: EAccountManagerStacksRoutes.AccountSelectorStack,
     component: AccountSelectorStackPage,
+    options: {
+      headerShown: false,
+    },
   },
   {
     name: EAccountManagerStacksRoutes.ExportPrivateKeysPage,

--- a/packages/shared/src/utils/swrCacheUtils.ts
+++ b/packages/shared/src/utils/swrCacheUtils.ts
@@ -203,7 +203,8 @@ export const swrKeys = {
   }: {
     walletId: string;
     accountId?: string;
-  }) => [NS.unifiedNetworkSelectorMeta, 'v1', walletId, accountId ?? ''].join(':'),
+  }) =>
+    [NS.unifiedNetworkSelectorMeta, 'v1', walletId, accountId ?? ''].join(':'),
   // NetworkContent (the "Network" tab inside UnifiedNetworkSelector) bundles
   // sorted chainSelectorNetworks + account balances + DeFi overview into one
   // result object. Balances/DeFi are included despite being volatile because

--- a/packages/shared/src/utils/swrCacheUtils.ts
+++ b/packages/shared/src/utils/swrCacheUtils.ts
@@ -234,6 +234,18 @@ export const swrKeys = {
       accountId ?? '',
     ].join(':'),
   defiEnabled: (networkId: string) => `defiEnabled:${networkId}`,
+  // Account selector left sidebar wallet list. One slot per
+  // `hideNonBackedUpWallet` variant — every selector instance (main /
+  // send-target / dapp-connect) shares the same wallets data, so we
+  // intentionally keep this single-slot. Other inputs (HardwareFeaturesUpdate
+  // ts, passphraseProtectionChangedAt) only drive a re-fetch and must stay
+  // out of the key, otherwise prevSwrKey reset (see usePromiseResult.ts)
+  // would blank the sidebar on every device/passphrase event.
+  walletListSideBar: ({
+    hideNonBackedUpWallet,
+  }: {
+    hideNonBackedUpWallet?: boolean;
+  }) => ['walletList', 'v1', hideNonBackedUpWallet ? '1' : '0'].join(':'),
   // Account selector accounts list: caches the section data that drives the
   // wallet/account picker modal so subsequent opens render the previous
   // structure synchronously instead of flashing the empty state. Account

--- a/packages/shared/src/utils/swrCacheUtils.ts
+++ b/packages/shared/src/utils/swrCacheUtils.ts
@@ -116,6 +116,25 @@ function remove(key: string): void {
   }
 }
 
+// Drops every entry whose key starts with `prefix`. Used by bg services
+// to invalidate a whole namespace (e.g. all walletList:* slots) on a
+// mutation whose payload doesn't identify which specific slot is dirty.
+function removeByPrefix(prefix: string): void {
+  if (!prefix) return;
+  const store = loadStore();
+  let touched = false;
+  for (const key of Object.keys(store)) {
+    if (key.startsWith(prefix)) {
+      delete store[key];
+      touched = true;
+    }
+  }
+  if (touched) {
+    _dirty = true;
+    scheduleFlush();
+  }
+}
+
 function clearAll(): void {
   _cache = {};
   _dirty = true;
@@ -130,6 +149,22 @@ function flushNow(): void {
   }
   flush();
 }
+
+// --- Centralized SWR key namespaces ---
+// Leading segment of every key produced by the matching swrKeys.X(...).
+// Pair with `swrCacheUtils.removeByPrefix(prefixOf(namespace))` to
+// invalidate a whole namespace at once.
+const NS = {
+  allNetworksCompatible: 'allNetCompat',
+  unifiedNetworkSelectorMeta: 'unsMeta',
+  networkContentData: 'netContent',
+  recentNetworks: 'recentNets',
+  walletListSideBar: 'walletList',
+  accountSelectorList: 'accSelList',
+} as const;
+export type ISwrCacheNamespace = (typeof NS)[keyof typeof NS];
+export const swrCacheNamespaces = NS;
+export const prefixOf = (namespace: ISwrCacheNamespace) => `${namespace}:`;
 
 // --- Centralized SWR key builders ---
 export const swrKeys = {
@@ -149,7 +184,7 @@ export const swrKeys = {
     enabledNetworkIdsKey?: string;
   }) =>
     [
-      'allNetCompat',
+      NS.allNetworksCompatible,
       'v1',
       walletId,
       networkId ?? '',
@@ -168,7 +203,7 @@ export const swrKeys = {
   }: {
     walletId: string;
     accountId?: string;
-  }) => ['unsMeta', 'v1', walletId, accountId ?? ''].join(':'),
+  }) => [NS.unifiedNetworkSelectorMeta, 'v1', walletId, accountId ?? ''].join(':'),
   // NetworkContent (the "Network" tab inside UnifiedNetworkSelector) bundles
   // sorted chainSelectorNetworks + account balances + DeFi overview into one
   // result object. Balances/DeFi are included despite being volatile because
@@ -194,7 +229,7 @@ export const swrKeys = {
     // the post-revalidate layout for accounts whose pinned segment is
     // stable across sessions. Old v2 (empty-freq) entries are orphaned.
     [
-      'netContent',
+      NS.networkContentData,
       'v3',
       walletId ?? '',
       accountId ?? '',
@@ -226,7 +261,7 @@ export const swrKeys = {
     accountId?: string;
   }) =>
     [
-      'recentNets',
+      NS.recentNetworks,
       'v2',
       scope,
       showAllNetwork ? '1' : '0',
@@ -245,7 +280,8 @@ export const swrKeys = {
     hideNonBackedUpWallet,
   }: {
     hideNonBackedUpWallet?: boolean;
-  }) => ['walletList', 'v1', hideNonBackedUpWallet ? '1' : '0'].join(':'),
+  }) =>
+    [NS.walletListSideBar, 'v1', hideNonBackedUpWallet ? '1' : '0'].join(':'),
   // Account selector accounts list: caches the section data that drives the
   // wallet/account picker modal so subsequent opens render the previous
   // structure synchronously instead of flashing the empty state. Account
@@ -265,7 +301,7 @@ export const swrKeys = {
     keepAllOtherAccounts?: boolean;
   }) =>
     [
-      'accSelList',
+      NS.accountSelectorList,
       'v1',
       focusedWallet,
       deriveType,
@@ -279,6 +315,7 @@ export const swrCacheUtils = {
   get,
   getWithTimestamp,
   set,
+  removeByPrefix,
   remove,
   isFresh,
   clearAll,


### PR DESCRIPTION
## Summary

- Wire SWR cache into the **left wallet sidebar** of the account selector (right-side accounts list was already cached; the sidebar wasn't, so on cold open the sidebar painted blank for a few hundred ms while `getWallets()` + per-bot-wallet metadata round-tripped through the bg bridge).
- Move cache invalidation to the **bg service** instead of UI event listeners — `ServiceAccount` now drops the affected SWR namespaces in its existing `WalletUpdate / AccountUpdate / AccountRemove / WalletRename / RenameDBAccounts / AddDBAccountsToWallet` listeners.
- `ServiceE2E.clearWalletsAndAccounts` (dev-only wallet wipe) explicitly calls `swrCacheUtils.clearAll() + flushNow()` so the empty snapshot lands in MMKV before app kill.

## Key changes

- `packages/shared/src/utils/swrCacheUtils.ts`
  - Add `removeByPrefix(prefix)` for namespace-wide invalidation (mutation events have no payload, so we can't pinpoint a single slot).
  - Extract `NS` constants + `swrCacheNamespaces` + `prefixOf()` so each key family's leading segment is single-sourced; existing key builders now reference these.
  - Add `swrKeys.walletListSideBar({ hideNonBackedUpWallet })` — single-slot key. Other inputs (HardwareFeaturesUpdate ts, passphraseProtectionChangedAt) deliberately stay out of the key to avoid `prevSwrKey` reset flashing the sidebar on every device/passphrase event.
- `packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts`
  - Inside the existing event-listener block in the constructor, also drop `walletListSideBar` + `accountSelectorList` SWR entries. `RenameDBAccounts` only drops `accountSelectorList` (sidebar doesn't display account names).
- `packages/kit-bg/src/services/ServiceE2E.ts`
  - After the localDb / accountSelector simpleDb wipe, call `swrCacheUtils.clearAll() + flushNow()` so a kill-and-relaunch after the dev wipe doesn't read stale wallets from MMKV.
- `packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/AccountSelectorWalletListSideBar.tsx`
  - Pass `swrKey: walletsSwrKey` to `usePromiseResult`; documented the invalidation flow so future readers don't relitigate the design.

## CRUD invalidation coverage

| Mutation | Emitted event | Namespaces dropped (bg) | Refetched (UI) |
|---|---|---|---|
| Create / remove HD/HW/QR wallet | `WalletUpdate` | walletList, accountSelectorList | ✓ |
| Bot wallet metadata change | `WalletUpdate` (debounced 600ms) | walletList, accountSelectorList | ✓ |
| Wallet rename / avatar | `WalletUpdate` (+ `WalletRename`) | walletList, accountSelectorList | ✓ |
| Add / remove account | `AccountUpdate` (+ `AccountRemove`) | walletList, accountSelectorList | ✓ |
| Account rename | `RenameDBAccounts` | accountSelectorList | sidebar not affected |
| HardwareFeaturesUpdate / passphrase toggle | (in-component deps) | n/a | ✓ via deps |
| `ServiceApp.resetApp` | (direct) | `coldStartCacheStorage.clearAll()` | – |
| `ServiceE2E.clearWalletsAndAccounts` (dev) | `WalletClear` | `swrCacheUtils.clearAll()` + `flushNow()` | – |

## Trade-offs

- After a wallet/account mutation, the next cold open paints empty briefly instead of stale (because the cache was cleared). For removals this is the **safer** outcome — no chance of clicking a deleted wallet. For renames/adds you trade a smaller "appears late" flicker for the same safety property.
- UI listeners on `WalletUpdate / AccountUpdate` still refetch and write the fresh result back into SWR via `usePromiseResult`, so when the UI is mounted the cache self-heals in a single round-trip.

## Test plan

- [ ] iOS cold open of account selector — sidebar renders the previous wallet list synchronously (no blank), then revalidates.
- [ ] Android cold open — same.
- [ ] Hardware features update (plug/unplug) → sidebar refreshes without empty flash.
- [ ] Passphrase toggle → sidebar refreshes without empty flash.
- [ ] Create wallet → sidebar shows new wallet immediately; cold open after kill confirms new wallet present.
- [ ] Rename wallet → sidebar shows new name; cold open after kill confirms new name (not old cached name).
- [ ] Delete wallet → sidebar removes wallet; kill app immediately after delete → cold open shows wallet gone (not stale).
- [ ] Add / remove account inside a wallet → right-panel sectionData refreshes; cold open reflects change.
- [ ] Rename account → right-panel reflects new name on cold open.
- [ ] Dev wipe (`clearWalletsAndAccounts`) → kill app immediately → cold open shows empty selector (no ghosts).