### PR TITLE
fix(perps): prevent stale persisted favorite snapshots(OK-54852)

### DIFF
--- a/packages/kit-bg/src/states/jotai/atomNames.test.ts
+++ b/packages/kit-bg/src/states/jotai/atomNames.test.ts
@@ -1,0 +1,27 @@
+import { EAtomNames, atomsConfig } from './atomNames';
+
+describe('atomsConfig', () => {
+  it('replaces Perps snapshot atoms instead of merging stale fields', () => {
+    expect(
+      atomsConfig[EAtomNames.perpsActiveAssetAtom]?.mergeInitialValue,
+    ).toBe(false);
+    expect(atomsConfig[EAtomNames.spotActiveAssetAtom]?.mergeInitialValue).toBe(
+      false,
+    );
+    expect(
+      atomsConfig[EAtomNames.perpsCommonConfigPersistAtom]?.mergeInitialValue,
+    ).toBe(false);
+    expect(
+      atomsConfig[EAtomNames.perpTokenFavoritesPersistAtom]?.mergeInitialValue,
+    ).toBe(false);
+    expect(
+      atomsConfig[EAtomNames.spotTokenFavoritesPersistAtom]?.mergeInitialValue,
+    ).toBe(false);
+    expect(
+      atomsConfig[EAtomNames.perpsFavoritesOrderPersistAtom]?.mergeInitialValue,
+    ).toBe(false);
+    expect(
+      atomsConfig[EAtomNames.perpsDepositOrderAtom]?.mergeInitialValue,
+    ).toBe(false);
+  });
+});

--- a/packages/kit-bg/src/states/jotai/atomNames.ts
+++ b/packages/kit-bg/src/states/jotai/atomNames.ts
@@ -142,4 +142,27 @@ export const atomsConfig: Partial<
   [EAtomNames.primePersistAtom]: {
     mergeInitialValue: false,
   },
+  // These Perps states are written as complete snapshots. Lodash merge keeps
+  // old array tails and ignores undefined, which can resurrect stale fields.
+  [EAtomNames.perpsActiveAssetAtom]: {
+    mergeInitialValue: false,
+  },
+  [EAtomNames.spotActiveAssetAtom]: {
+    mergeInitialValue: false,
+  },
+  [EAtomNames.perpsCommonConfigPersistAtom]: {
+    mergeInitialValue: false,
+  },
+  [EAtomNames.perpTokenFavoritesPersistAtom]: {
+    mergeInitialValue: false,
+  },
+  [EAtomNames.spotTokenFavoritesPersistAtom]: {
+    mergeInitialValue: false,
+  },
+  [EAtomNames.perpsFavoritesOrderPersistAtom]: {
+    mergeInitialValue: false,
+  },
+  [EAtomNames.perpsDepositOrderAtom]: {
+    mergeInitialValue: false,
+  },
 };


### PR DESCRIPTION
## Summary
- Disable initial-value merging for complete Perps persisted snapshot atoms.
- Add coverage to lock the Perps atom storage config.

## Intent & Context
OK-54852 reports unstable mobile Perps favorites behavior: removing several favorite rows can leave removed items visible, re-opened, duplicated, or impossible to remove. Earlier fixes focused on UI/BG favorite write ownership and Market watchlist reconciliation, but device validation showed the issue still reproduced.

## Root Cause
The root cause is storage-level stale snapshot merging. Native persisted object atoms can hydrate their initial value from MMKV. The default storage config then merges the hydrated initial value with the next written value. For snapshot atoms containing arrays, lodash merge can keep old array tail entries instead of replacing the array completely. That can restore removed Perps favorites or favorite-order rows from the stale persisted snapshot.

## Design Decisions
- Treat these Perps atoms as complete snapshots rather than partial patch objects.
- Set mergeInitialValue to false only for Perps snapshot atoms with arrays or nullable fields.
- Avoid broader favorite flow rewrites in this PR to keep the blast radius narrow.

## Changes Detail
- packages/kit-bg/src/states/jotai/atomNames.ts: disables initial-value merging for Perps active asset, config, favorites, favorite order, and deposit-order snapshot atoms.
- packages/kit-bg/src/states/jotai/atomNames.test.ts: verifies the protected atom names keep mergeInitialValue disabled.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile primarily; any platform using these persisted Perps atoms can benefit.
- **Risk Areas**: Existing callers must write complete values for these atoms instead of relying on partial object merge semantics.

## Test plan
- [x] yarn jest packages/kit-bg/src/states/jotai/atomNames.test.ts --runInBand
- [ ] QA bundle verification on mobile favorite add/remove/reopen flow