### PR TITLE
fix(swap): synthesize message from provider results when quote fails

### DIFF
--- a/packages/kit/src/views/Swap/hooks/useSwapQuote.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapQuote.ts
@@ -671,6 +671,19 @@ export function useSwapQuote() {
       } else if (providerQuoteResult?.some((item) => !item.toAmount)) {
         finalStatus = ESwapEventAPIStatus.PARTIAL_SUCCESS;
       }
+      let finalMessage = errorMessage;
+      if (!finalMessage && finalStatus !== ESwapEventAPIStatus.SUCCESS) {
+        if (!providerQuoteResult?.length) {
+          finalMessage = 'no provider result';
+        } else {
+          const failedProviders = providerQuoteResult.filter(
+            (p) => !p.toAmount,
+          );
+          finalMessage = failedProviders
+            .map((p) => `${p.providerName}: ${p.errorMessage ?? 'no quote'}`)
+            .join('; ');
+        }
+      }
       defaultLogger.swap.swapQuote.swapQuote({
         fromAddress: swapAddressInfo.address ?? '',
         toAddress: swapToAddressInfo.address ?? '',
@@ -689,7 +702,7 @@ export function useSwapQuote() {
         isSmartMode: settingsPersistAtomRef.current.swapBatchApproveAndSwap,
         status: finalStatus,
         providerQuoteResult,
-        message: errorMessage,
+        message: finalMessage,
       });
     },
     [swapAddressInfo.address, swapToAddressInfo.address],


### PR DESCRIPTION
## Summary

- `swapQuote` analytics events on Mixpanel report `message: undefined` for ~97% of non-success rows. Root cause: the post-quote `useEffect` and the partial-failure path in `swapQuoteMixEventAction` do not pass `errorMessage`, and the upload site forwards `errorMessage` verbatim.
- Per-provider `errorMessage` is already aggregated into `providerQuoteResult`. Derive a fallback message from failed providers when the caller did not supply one. Empty-result case falls back to `no provider result`.
- Expected impact: undefined ratio on failed `swapQuote` drops from ~97.5% to near zero, exposing actionable provider-level error reasons for the first time.

## Why this matters

Sample data window: W20, 2026-05-11 through 2026-05-17.

| `status` (filter `!= success`) | Events / week | `message` |
| --- | ---: | --- |
| `partial_success` | 35,484 | mostly `undefined` |
| `fail` | 7,054 | 894 = `no provider support`, ~200 = stringified EventSource error, **~5,960 = `undefined`** |
| `undefined` | 1,278 | — |

The ~41,000 `undefined` rows per week prevented any meaningful error-reason analysis on Swap; this PR addresses ~41k of the ~43k non-success events. The fix touches only the analytics call path, no runtime/quote behavior change.

## Out of scope (follow-ups)

- `useSwapQuote.ts:707` still passes `JSON.stringify(event.event)` for EventSource errors (~200 events / week). Separate PR to extract `event.event?.message` and surface `xhrState` / `xhrStatus` as structured fields.
- `status = undefined` ~1,278 events / week. Code analysis suggests this cannot be produced by current code paths; likely a logger/decorator dropout (cf. OK-54299) or older client versions. Re-evaluate after this PR ships.
- Schema-level improvement: replace single `message` string with a `failedProviders` structured field for richer Mixpanel breakdowns. Larger change, separate proposal.

## Test plan

- [ ] Manual: trigger a Swap quote with a deliberately invalid token pair so all providers fail; confirm `swapQuote` event in Mixpanel `Latest` view shows `message` with concatenated provider failure reasons (e.g. `LiFi: timeout; 1inch: no liquidity`), not `undefined`.
- [ ] Manual: trigger a Swap quote where at least one provider returns a quote and another fails; confirm `status = partial_success` and `message` lists only the failed providers.
- [ ] Manual: trigger the "no provider support" path (unsupported chain/token) and confirm message stays `no provider support` (caller still passes the literal).
- [ ] Manual: trigger an EventSource error path and confirm message remains the JSON-stringified error (unchanged in this PR).
- [ ] Smoke: regular successful Swap quote — confirm `status = success` and `message` stays `undefined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)