### PR TITLE
fix(discovery): decouple browser search trending suggestions from review control(OK-54766, OK-54767)

### DIFF
--- a/packages/kit/src/views/Discovery/hooks/useSearchModalData.test.tsx
+++ b/packages/kit/src/views/Discovery/hooks/useSearchModalData.test.tsx
@@ -120,27 +120,32 @@ describe('useSearchModalData', () => {
     ]);
   });
 
-  it('does not fetch or show trending suggestions when review control is disabled', async () => {
-    const { result } = renderHook(() => useSearchModalData('uni'));
+  it('keeps trending suggestions but skips remote dapp search when review control is disabled', async () => {
+    const { result } = renderHook(() => useSearchModalData('uniswap'));
 
     await waitFor(() => {
       expect(serviceDiscoveryMock.getBookmarkData).toHaveBeenCalled();
       expect(serviceDiscoveryMock.getHistoryData).toHaveBeenCalled();
+      expect(
+        serviceDiscoveryMock.fetchDiscoveryHomePageData,
+      ).toHaveBeenCalled();
+      expect(result.current.searchList).toEqual([
+        expect.objectContaining({
+          type: 'dapp',
+          source: 'trending',
+          url: 'https://app.uniswap.org',
+        }),
+        expect.objectContaining({
+          type: 'search-action',
+        }),
+      ]);
     });
 
-    expect(
-      serviceDiscoveryMock.fetchDiscoveryHomePageData,
-    ).not.toHaveBeenCalled();
     expect(serviceDiscoveryMock.searchDApp).not.toHaveBeenCalled();
     expect(serviceDiscoveryMock.getHistoryData).toHaveBeenCalledWith({
       generateIcon: false,
       sliceCount: 200,
     });
-    expect(result.current.searchList).toEqual([
-      expect.objectContaining({
-        type: 'search-action',
-      }),
-    ]);
   });
 
   it('keeps enough local candidates for chrome-like re-ranking before returning search results', async () => {

--- a/packages/kit/src/views/Discovery/hooks/useSearchModalData.ts
+++ b/packages/kit/src/views/Discovery/hooks/useSearchModalData.ts
@@ -95,14 +95,11 @@ export function useSearchModalData(searchValue: string) {
 
   const { result: trendingData, run: refreshTrendingData } = usePromiseResult(
     async (): Promise<IDApp[]> => {
-      if (!showSearchResult) {
-        return [];
-      }
       return (
         (await serviceDiscovery.fetchDiscoveryHomePageData())?.trending ?? []
       );
     },
-    [serviceDiscovery, showSearchResult],
+    [serviceDiscovery],
     {
       initResult: [],
     },
@@ -148,7 +145,6 @@ export function useSearchModalData(searchValue: string) {
     return buildDiscoverySearchListFromFactors({
       searchValue,
       searchActionTitle,
-      showSearchResult,
       searchResult,
       rankingHistoryData,
       localSearchData,
@@ -160,7 +156,6 @@ export function useSearchModalData(searchValue: string) {
     searchActionTitle,
     searchResult,
     searchValue,
-    showSearchResult,
     trendingData,
   ]);
 

--- a/packages/kit/src/views/Discovery/utils/searchDebugSnapshot.ts
+++ b/packages/kit/src/views/Discovery/utils/searchDebugSnapshot.ts
@@ -189,7 +189,6 @@ export interface IDiscoverySearchDebugSnapshot {
 interface IBuildDiscoverySearchListParams {
   searchValue: string;
   searchActionTitle: string;
-  showSearchResult: boolean;
   searchResult?: IDApp[];
   rankingHistoryData?: IBrowserHistory[];
   localSearchData: IDiscoverySearchLocalData;
@@ -198,6 +197,7 @@ interface IBuildDiscoverySearchListParams {
 
 interface IBuildDiscoverySearchDebugSnapshotParams extends IBuildDiscoverySearchListParams {
   source: IDiscoverySearchDebugSnapshot['source'];
+  showSearchResult: boolean;
   shouldSkipRemoteSearch: boolean;
   localData: IDiscoverySearchLocalData | null;
 }
@@ -357,7 +357,6 @@ function buildSearchListDebugItem(
 export function buildDiscoverySearchListFromFactors({
   searchValue,
   searchActionTitle,
-  showSearchResult,
   searchResult,
   rankingHistoryData,
   localSearchData,
@@ -370,12 +369,10 @@ export function buildDiscoverySearchListFromFactors({
     };
   }
 
-  const trendingSearchData = showSearchResult
-    ? searchTrendingDappsByKeyword({
-        keyword: searchValue,
-        trendingData,
-      })
-    : [];
+  const trendingSearchData = searchTrendingDappsByKeyword({
+    keyword: searchValue,
+    trendingData,
+  });
   const searchResultWithExactUrl = prependSearchValueExactUrlResult({
     searchValue,
     searchResult,
@@ -425,7 +422,6 @@ export function buildDiscoverySearchDebugSnapshot({
     buildDiscoverySearchListFromFactors({
       searchValue,
       searchActionTitle,
-      showSearchResult,
       searchResult: searchResultWithExactUrl,
       rankingHistoryData,
       localSearchData,
@@ -533,11 +529,9 @@ export async function collectDiscoverySearchDebugSnapshot({
     sliceCount: DISCOVERY_RANKING_HISTORY_LIMIT,
   });
 
-  const trendingDataPromise = showSearchResult
-    ? serviceDiscovery
-        .fetchDiscoveryHomePageData()
-        .then((data) => data?.trending ?? [])
-    : Promise.resolve([]);
+  const trendingDataPromise = serviceDiscovery
+    .fetchDiscoveryHomePageData()
+    .then((data) => data?.trending ?? []);
 
   const remoteSearchResultPromise =
     showSearchResult && !shouldSkipRemoteSearch


### PR DESCRIPTION
## Summary
- Browser search trending suggestions no longer depend on the review-control flag.
- Trending DApp data is now always fetched and matched by keyword; only the open-ended remote `searchDApp` call stays gated by review control.
- Updated the `useSearchModalData` test to assert trending suggestions still appear while remote DApp search is skipped when review control is off.

## Intent & Context
QA reported two browser-search bugs that only reproduce on production Apple App Store builds:
- **OK-54766** – Browser search suggestions fail in the production environment.
- **OK-54767** – Domain/keyword search shows no option to open the matching third-party website.

Both are symptoms of the same root cause. `useReviewControl()` returns `false` only on Apple App Store / Mac App Store builds when the persisted `reviewControl` setting is falsy; internal/dev, Android, web and extension builds always return `true`, which is why the bugs surfaced only in production.

## Root Cause
`useSearchModalData` fed `showSearchResult` (= `useReviewControl()`) into the trending pipeline, which gated trending suggestions in three places:
1. `useSearchModalData.ts` – the `trendingData` `usePromiseResult` short-circuited to `[]` when `showSearchResult` was false.
2. `searchDebugSnapshot.ts` / `buildDiscoverySearchListFromFactors` – `trendingSearchData` was computed only when `showSearchResult` was true.
3. `searchDebugSnapshot.ts` / `collectDiscoverySearchDebugSnapshot` – the trending fetch resolved to `[]` when `showSearchResult` was false.

As a result, on production iOS / MAS builds with `reviewControl` falsy, the search modal surfaced no trending matches: no autocomplete suggestions (OK-54766) and no trending-DApp item to open the matching third-party site (OK-54767) — only the bare "search for X" action remained.

Trending data comes from `fetchDiscoveryHomePageData()`, a curated server-side trending list, so it does not need review gating. The only content that must stay hidden during App Store review is the open-ended remote DApp search (`serviceDiscovery.searchDApp`).

## Design Decisions
- Removed `showSearchResult` from the trending pipeline only; kept it on the remote `searchDApp` call in `useSearchModalData` (`if (!showSearchResult || shouldSkipRemoteSearch) return []`). This restores trending suggestions while preserving App Store review behaviour for the open-ended search.
- Dropped `showSearchResult` from `IBuildDiscoverySearchListParams` (the list builder no longer needs it) but kept it on `IBuildDiscoverySearchDebugSnapshotParams`, so the debug snapshot still records the flag for diagnostics.

## Changes Detail
- `useSearchModalData.ts` – `trendingData` is always fetched; removed `showSearchResult` from its `usePromiseResult` deps and from the `searchList` builder call + memo deps.
- `searchDebugSnapshot.ts` – removed `showSearchResult` from `IBuildDiscoverySearchListParams` and `buildDiscoverySearchListFromFactors`; `trendingSearchData` is always computed; `collectDiscoverySearchDebugSnapshot` always fetches trending data; `showSearchResult` retained on the debug-snapshot params type.
- `useSearchModalData.test.tsx` – rewrote the review-control test to assert trending suggestions are kept while remote `searchDApp` is skipped when review control is disabled.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile (iOS App Store) and Desktop (Mac App Store). Android / web / extension / non-MAS desktop already had `useReviewControl()` returning `true`, so behaviour there is unchanged.
- **Risk Areas**: The only behavioural change is that trending suggestions now appear on production Apple builds when `reviewControl` is off. Review-sensitive open-ended DApp search stays gated, so App Store review behaviour is unaffected.

## Test plan
- [x] `yarn jest useSearchModalData.test.tsx` — 10/10 pass
- [x] `yarn tsc:staged` — no type errors
- [x] `yarn lint:staged` — 0 warnings / 0 errors
- [ ] On a production iOS build with `reviewControl` off, open browser search, type a trending DApp keyword (e.g. `uniswap`), and confirm the trending suggestion to open the third-party site appears.
- [ ] Confirm open-ended remote DApp search results stay hidden while `reviewControl` is off.
