### PR TITLE
fix(tabs): fill full width on iPad when split view is disabled

### DIFF
--- a/packages/components/src/composite/Tabs/hooks.tsx
+++ b/packages/components/src/composite/Tabs/hooks.tsx
@@ -12,6 +12,7 @@ import { useMedia } from '@onekeyhq/components/src/hooks/useStyle';
 import {
   isDualScreenDevice,
   useDualScreenWidth,
+  useIsSplitViewLayoutDisabled,
 } from '@onekeyhq/shared/src/modules/DualScreenInfo';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
@@ -89,17 +90,19 @@ const useNativeTabContainerWidth = isDualScreenDevice()
   : () => {
       const isTablet = isNativeTablet();
       const isLandscape = useIsSplitView();
+      const isSplitViewLayoutDisabled = useIsSplitViewLayoutDisabled();
       const { width } = useWindowDimensions();
       const isIpadModalPage = useIsIpadModalPage();
       const ipadModalPageWidth = useIPadModalPageWidth();
       if (isIpadModalPage) {
         return ipadModalPageWidth || 640;
       }
-      if (isTablet && isLandscape) {
+      if (isTablet && isLandscape && !isSplitViewLayoutDisabled) {
         // In landscape split view, use half of the screen width
         return width / 2;
       }
-      // In portrait or non-tablet, use full screen width
+      // In portrait, non-tablet, or when the user opted out of split view,
+      // use full screen width.
       return width;
     };
 

--- a/packages/kit/src/hooks/useTabContainerWidth.ts
+++ b/packages/kit/src/hooks/useTabContainerWidth.ts
@@ -1,0 +1,60 @@
+import { useMemo } from 'react';
+
+import { useWindowDimensions } from 'react-native';
+
+import {
+  useIPadModalPageWidth,
+  useIsIpadModalPage,
+  useIsSplitView,
+  useMedia,
+} from '@onekeyhq/components';
+import {
+  DESKTOP_MODE_UI_PAGE_BORDER_WIDTH,
+  DESKTOP_MODE_UI_PAGE_MARGIN,
+  MIN_SIDEBAR_WIDTH,
+} from '@onekeyhq/components/src/utils/sidebar';
+import {
+  isDualScreenDevice,
+  useDualScreenWidth,
+} from '@onekeyhq/shared/src/modules/DualScreenInfo';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import { useShouldUseSplitView } from './useShouldUseSplitView';
+
+const useNativeTabContainerWidth = isDualScreenDevice()
+  ? () => {
+      const dualScreenWidth = useDualScreenWidth();
+      return dualScreenWidth;
+    }
+  : () => {
+      const isLandscape = useIsSplitView();
+      const shouldUseSplitView = useShouldUseSplitView();
+      const { width } = useWindowDimensions();
+      const isIpadModalPage = useIsIpadModalPage();
+      const ipadModalPageWidth = useIPadModalPageWidth();
+      if (isIpadModalPage) {
+        return ipadModalPageWidth || 640;
+      }
+      // shouldUseSplitView already implies isNativeTablet() && enableSplitView.
+      // Only halve the width when the split layout is actually rendering.
+      if (shouldUseSplitView && isLandscape) {
+        return width / 2;
+      }
+      return width;
+    };
+
+export const useTabContainerWidth = platformEnv.isNative
+  ? useNativeTabContainerWidth
+  : () => {
+      const { md } = useMedia();
+      return useMemo(() => {
+        if (platformEnv.isWebDappMode || md) {
+          return `calc(100vw)`;
+        }
+        return `calc(100vw - ${
+          MIN_SIDEBAR_WIDTH +
+          DESKTOP_MODE_UI_PAGE_MARGIN +
+          DESKTOP_MODE_UI_PAGE_BORDER_WIDTH * 2
+        }px)`;
+      }, [md]);
+    };

--- a/packages/kit/src/provider/Container/index.tsx
+++ b/packages/kit/src/provider/Container/index.tsx
@@ -1,18 +1,12 @@
 import { useEffect } from 'react';
 
-import * as ScreenOrientation from 'expo-screen-orientation';
 import { RootSiblingParent } from 'react-native-root-siblings';
 
-import {
-  ESplitViewType,
-  SplitViewContext,
-  isNativeTablet,
-} from '@onekeyhq/components';
+import { ESplitViewType, SplitViewContext } from '@onekeyhq/components';
 import appGlobals from '@onekeyhq/shared/src/appGlobals';
 import LazyLoad from '@onekeyhq/shared/src/lazyLoad';
 import { setSplitViewLayoutDisabled } from '@onekeyhq/shared/src/modules/DualScreenInfo';
 import { debugLandingLog } from '@onekeyhq/shared/src/performance/init';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { WalletBackupPreCheckContainer } from '../../components/WalletBackup';
 import useAppNavigation from '../../hooks/useAppNavigation';
@@ -113,24 +107,6 @@ export function Container() {
   // split-view setting — leaving Wallet/Home content stuck on the left half.
   useEffect(() => {
     setSplitViewLayoutDisabled(!shouldUseSplitView);
-  }, [shouldUseSplitView]);
-
-  // iPad allows all orientations via Info.plist (UISupportedInterfaceOrientations~ipad).
-  // When the user opts out of the split-view layout, the single-pane UI is only
-  // designed for portrait — so lock the device to portrait. Android already
-  // forces portrait at the AndroidManifest level, so this only matters on iPad.
-  // Toggling enableSplitView restarts the app, so this effect only needs to run
-  // once per boot.
-  useEffect(() => {
-    if (!platformEnv.isNativeIOS) return;
-    if (!isNativeTablet()) return;
-    if (shouldUseSplitView) {
-      ScreenOrientation.unlockAsync().catch(() => {});
-    } else {
-      ScreenOrientation.lockAsync(
-        ScreenOrientation.OrientationLock.PORTRAIT,
-      ).catch(() => {});
-    }
   }, [shouldUseSplitView]);
 
   if (shouldUseSplitView) {

--- a/packages/kit/src/views/Borrow/pages/ReserveDetails/components/ReserveDetailsTabs.tsx
+++ b/packages/kit/src/views/Borrow/pages/ReserveDetails/components/ReserveDetailsTabs.tsx
@@ -6,12 +6,8 @@ import type {
   ITabContainerProps,
   ITabContainerRef,
 } from '@onekeyhq/components';
-import {
-  Tabs,
-  XStack,
-  YStack,
-  useTabContainerWidth,
-} from '@onekeyhq/components';
+import { Tabs, XStack, YStack } from '@onekeyhq/components';
+import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IBorrowReserveDetail } from '@onekeyhq/shared/types/staking';

--- a/packages/kit/src/views/Earn/components/EarnMainTabs.tsx
+++ b/packages/kit/src/views/Earn/components/EarnMainTabs.tsx
@@ -15,7 +15,6 @@ import {
   YStack,
   rootNavigationRef,
   useScrollContentTabBarOffset,
-  useTabContainerWidth,
   useTheme,
 } from '@onekeyhq/components';
 import {
@@ -28,6 +27,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ListItem } from '../../../components/ListItem';
 import { useIsFirstFocused } from '../../../hooks/useIsFirstFocused';
 import { useRouteIsFocused } from '../../../hooks/useRouteIsFocused';
+import { useTabContainerWidth } from '../../../hooks/useTabContainerWidth';
 import { useEarnHideSmallAssets } from '../hooks/useEarnHideSmallAssets';
 
 import { FAQContent } from './FAQContent';

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -18,10 +18,10 @@ import {
   YStack,
   useFocusedTab,
   useScrollContentTabBarOffset,
-  useTabContainerWidth,
 } from '@onekeyhq/components';
 import type { ITabBarItemProps } from '@onekeyhq/components/src/composite/Tabs/TabBar';
 import { TabBarItem } from '@onekeyhq/components/src/composite/Tabs/TabBar';
+import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import { getNetworksSupportBulkRevokeApproval } from '@onekeyhq/shared/src/config/presetNetworks';
 import {
   WALLET_TYPE_HD,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/layout/MobileInformationTabs.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/layout/MobileInformationTabs.tsx
@@ -2,12 +2,8 @@ import { useCallback, useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import {
-  HeaderScrollGestureWrapper,
-  Tabs,
-  YStack,
-  useTabContainerWidth,
-} from '@onekeyhq/components';
+import { HeaderScrollGestureWrapper, Tabs, YStack } from '@onekeyhq/components';
+import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import { isHoldersTabSupported } from '@onekeyhq/shared/src/consts/marketConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
@@ -10,15 +10,10 @@ import {
 } from 'react';
 import type { RefObject } from 'react';
 
-import {
-  IconButton,
-  Tabs,
-  XStack,
-  YStack,
-  useTabContainerWidth,
-} from '@onekeyhq/components';
+import { IconButton, Tabs, XStack, YStack } from '@onekeyhq/components';
 import type { ITabContainerRef } from '@onekeyhq/components';
 import { useTabBarHeight } from '@onekeyhq/components/src/layouts/Page/hooks';
+import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import { useMarketWatchListV2Atom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
@@ -10,15 +10,10 @@ import {
 } from 'react';
 import type { RefObject } from 'react';
 
-import {
-  IconButton,
-  Tabs,
-  XStack,
-  YStack,
-  useTabContainerWidth,
-} from '@onekeyhq/components';
+import { IconButton, Tabs, XStack, YStack } from '@onekeyhq/components';
 import type { ITabContainerRef } from '@onekeyhq/components';
 import { useTabBarHeight } from '@onekeyhq/components/src/layouts/Page/hooks';
+import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import { useMarketWatchListV2Atom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 

--- a/packages/kit/src/views/Market/components/TokenDetailTabs.tsx
+++ b/packages/kit/src/views/Market/components/TokenDetailTabs.tsx
@@ -11,9 +11,9 @@ import {
   useIsOverlayPage,
   useMedia,
   useSplitSubView,
-  useTabContainerWidth,
 } from '@onekeyhq/components';
 import type { IDeferredPromise } from '@onekeyhq/components';
+import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IMarketTokenDetail } from '@onekeyhq/shared/types/market';

--- a/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSyncDebug.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSyncDebug.tsx
@@ -16,11 +16,11 @@ import {
   XStack,
   YStack,
   useClipboard,
-  useTabContainerWidth,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { useOneKeyAuth } from '@onekeyhq/kit/src/components/OneKeyAuth/useOneKeyAuth';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import type { IDBCloudSyncItem } from '@onekeyhq/kit-bg/src/dbs/local/types';
 import {
   useDevSettingsPersistAtom,

--- a/packages/shared/src/modules/DualScreenInfo/index.android.ts
+++ b/packages/shared/src/modules/DualScreenInfo/index.android.ts
@@ -93,3 +93,15 @@ export const useDualScreenWidth = () => {
   }, []);
   return width;
 };
+
+export const useIsSplitViewLayoutDisabled = () => {
+  const [disabled, setDisabled] = useState(splitViewLayoutDisabled);
+  useEffect(() => {
+    const update = () => setDisabled(splitViewLayoutDisabled);
+    splitViewLayoutListeners.add(update);
+    return () => {
+      splitViewLayoutListeners.delete(update);
+    };
+  }, []);
+  return disabled;
+};

--- a/packages/shared/src/modules/DualScreenInfo/index.ts
+++ b/packages/shared/src/modules/DualScreenInfo/index.ts
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import { Dimensions } from 'react-native';
 
 export const isDualScreenDevice = () => {
@@ -20,6 +22,26 @@ export const useDualScreenWidth = () => {
   return Dimensions.get('window').width;
 };
 
-export function setSplitViewLayoutDisabled(_disabled: boolean) {
-  // no-op outside Android dual-screen devices
+// Mirror the Android implementation: kit calls `setSplitViewLayoutDisabled`
+// from <Container> at startup so non-dual-screen platforms (iPad) can also gate
+// split-view-only width math behind the `enableSplitView` setting.
+let splitViewLayoutDisabled = false;
+const splitViewLayoutListeners = new Set<() => void>();
+
+export function setSplitViewLayoutDisabled(disabled: boolean) {
+  if (splitViewLayoutDisabled === disabled) return;
+  splitViewLayoutDisabled = disabled;
+  splitViewLayoutListeners.forEach((fn) => fn());
 }
+
+export const useIsSplitViewLayoutDisabled = () => {
+  const [disabled, setDisabled] = useState(splitViewLayoutDisabled);
+  useEffect(() => {
+    const update = () => setDisabled(splitViewLayoutDisabled);
+    splitViewLayoutListeners.add(update);
+    return () => {
+      splitViewLayoutListeners.delete(update);
+    };
+  }, []);
+  return disabled;
+};


### PR DESCRIPTION
## Summary

- iPad now fills full width in both portrait and landscape when `enableSplitView` is off (was previously locked to portrait with content stuck on the left half in landscape).
- Move `useTabContainerWidth` to `packages/kit` so it can read `enableSplitView` directly via `useShouldUseSplitView`; only halve width when the split layout is actually rendering. `components` version stays (for Toast / `usePageWidth`) and reads via the existing `setSplitViewLayoutDisabled` sync flag, now also functional on iOS.
- Remove the iPad portrait orientation lock in `Container/index.tsx` so iPad can rotate freely regardless of the split view setting.

## Test plan

- [ ] iPad + `enableSplitView` off + portrait → home/wallet fills full width
- [ ] iPad + `enableSplitView` off + landscape → home/wallet fills full width
- [ ] iPad + `enableSplitView` on + portrait → home/wallet fills full width
- [ ] iPad + `enableSplitView` on + landscape → split view (left/right panes) still works as before
- [ ] iPhone (portrait only) → no regression
- [ ] Android dual-screen / foldable spanning → no regression (still respects `enableSplitView`)
- [ ] Toast width is correct under all of the above
- [ ] Other tab-based screens (Earn, Market detail, Borrow reserve detail, Prime cloud sync debug, Market Home V2) → no regression