### PR TITLE
fix(address-type-selector): close popover for HW createAddress so PIN/Passphrase dialog is visible (OK-54928)

### DIFF
--- a/packages/kit/src/components/AddressTypeSelector/AddressTypeSelector.tsx
+++ b/packages/kit/src/components/AddressTypeSelector/AddressTypeSelector.tsx
@@ -192,6 +192,13 @@ function AddressTypeSelectorContent(
           const walletId = accountUtils.getWalletIdFromAccountId({
             accountId: indexedAccountId,
           });
+          // Hardware wallets open the Enter PIN / Passphrase dialog during
+          // createAddress. Close this popover first so its Tamagui default
+          // z-index (150_000) does not hide those dialogs (z-index 100_000).
+          // Software wallets keep the popover open to show inline loading.
+          if (accountUtils.isHwWallet({ walletId })) {
+            closePopover();
+          }
           const createAddressResult = await createAddress({
             selectAfterCreate: false,
             num: 0,


### PR DESCRIPTION
## Summary
- When creating a new derivation address for a **hardware wallet** via `AddressTypeSelector`, close the popover before `createAddress` runs so the device PIN / Passphrase dialog can render on top.
- **Software wallets** still keep the popover open to display the inline loading indicator (no behavior change for them).

## Intent & Context
Selecting a derivation type for a hardware wallet (e.g. BTC Taproot / Native SegWit) and tapping an unfilled address slot in `AddressTypeSelector` calls `createAddress`, which prompts the hardware wallet flow (Enter PIN / Passphrase). The popover that hosts the type list uses Tamagui's default popover z-index (`150_000`), while those device dialogs render at z-index `100_000`. The popover therefore covered the dialog and the user could not enter their PIN — the flow appeared frozen.

## Root Cause
Z-index ordering between the Tamagui popover (`150_000`) and the hardware wallet PIN / Passphrase dialog (`100_000`). The popover was kept open during `createAddress` for both wallet kinds, which is fine for software wallets (inline loading) but blocks the device prompts for hardware wallets.

## Design Decisions
- **Branch on wallet kind** with `accountUtils.isHwWallet({ walletId })` instead of unconditionally closing the popover. Software wallets benefit from the popover staying open during `createAddress` to show inline loading state — we did not want to regress that UX.
- **Close before await** so the dialog's overlay is no longer in the tree by the time the firmware prompt mounts. Avoids touching shared z-index constants, which would have wider implications across the app.

## Changes Detail
- `packages/kit/src/components/AddressTypeSelector/AddressTypeSelector.tsx`: inside the empty-slot tap handler, after resolving `walletId` from `indexedAccountId`, call `closePopover()` early when the wallet is a hardware wallet, then proceed to `createAddress` as before.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Mobile / Web / Extension (the popover + HW flow exists on all platforms)
- **Risk Areas**: Only the hardware-wallet branch of one empty-slot tap handler in `AddressTypeSelector`. Software wallet behavior is unchanged.

## Test plan
- [ ] Hardware wallet: in token detail / receive flow, open `AddressTypeSelector`, tap an empty derivation slot — confirm popover closes and PIN / Passphrase dialog is visible and interactive.
- [ ] Hardware wallet with passphrase enabled: same flow — confirm passphrase prompt is visible.
- [ ] Software wallet (HD / imported): tap an empty derivation slot — confirm popover stays open and inline loading state shows as before, then address is created and selected.
- [ ] Cancel HW PIN prompt mid-flow — confirm no orphan UI state and the type list can be reopened cleanly.