### PR TITLE
fix: add earn analytics order tracking (OK-54953)

### DIFF
--- a/packages/components/src/composite/Tabs/hooks.tsx
+++ b/packages/components/src/composite/Tabs/hooks.tsx
@@ -12,6 +12,7 @@ import { useMedia } from '@onekeyhq/components/src/hooks/useStyle';
 import {
   isDualScreenDevice,
   useDualScreenWidth,
+  useIsSplitViewLayoutDisabled,
 } from '@onekeyhq/shared/src/modules/DualScreenInfo';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
@@ -89,17 +90,19 @@ const useNativeTabContainerWidth = isDualScreenDevice()
   : () => {
       const isTablet = isNativeTablet();
       const isLandscape = useIsSplitView();
+      const isSplitViewLayoutDisabled = useIsSplitViewLayoutDisabled();
       const { width } = useWindowDimensions();
       const isIpadModalPage = useIsIpadModalPage();
       const ipadModalPageWidth = useIPadModalPageWidth();
       if (isIpadModalPage) {
         return ipadModalPageWidth || 640;
       }
-      if (isTablet && isLandscape) {
+      if (isTablet && isLandscape && !isSplitViewLayoutDisabled) {
         // In landscape split view, use half of the screen width
         return width / 2;
       }
-      // In portrait or non-tablet, use full screen width
+      // In portrait, non-tablet, or when the user opted out of split view,
+      // use full screen width.
       return width;
     };
 

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityEarnOrders.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityEarnOrders.ts
@@ -1,7 +1,14 @@
 import { backgroundMethod } from '@onekeyhq/shared/src/background/backgroundDecorators';
+import type { EEarnLabels, IStakeTag } from '@onekeyhq/shared/types/staking';
 import type { EDecodedTxStatus } from '@onekeyhq/shared/types/tx';
 
 import { SimpleDbEntityBase } from '../base/SimpleDbEntityBase';
+
+export interface IEarnOrderTrackingInfo {
+  stakingLabel?: EEarnLabels;
+  stakingProtocol?: string;
+  stakingTags?: IStakeTag[];
+}
 
 export interface IEarnOrderItem {
   orderId: string;
@@ -11,6 +18,9 @@ export interface IEarnOrderItem {
   status: EDecodedTxStatus;
   updatedAt: number;
   createdAt: number;
+  stakingLabel?: IEarnOrderTrackingInfo['stakingLabel'];
+  stakingProtocol?: IEarnOrderTrackingInfo['stakingProtocol'];
+  stakingTags?: IEarnOrderTrackingInfo['stakingTags'];
 }
 
 export interface IEarnOrderDBStructure {
@@ -21,7 +31,8 @@ export interface IEarnOrderDBStructure {
 export type IAddEarnOrderParams = Omit<
   IEarnOrderItem,
   'updatedAt' | 'createdAt' | 'previousTxIds'
->;
+> &
+  IEarnOrderTrackingInfo;
 
 export class SimpleDbEntityEarnOrders extends SimpleDbEntityBase<IEarnOrderDBStructure> {
   entityName = 'earnOrders';

--- a/packages/kit-bg/src/services/ServiceStaking.ts
+++ b/packages/kit-bg/src/services/ServiceStaking.ts
@@ -2009,6 +2009,9 @@ class ServiceStaking extends ServiceBase {
           defaultLogger.staking.order.updateOrderStatus({
             txId: tx.txId,
             status: tx.status,
+            stakingLabel: order.stakingLabel,
+            stakingProtocol: order.stakingProtocol,
+            stakingTags: order.stakingTags,
           });
         }
       } catch (_e) {
@@ -2051,10 +2054,16 @@ class ServiceStaking extends ServiceBase {
     newTxId?: string;
     status: EDecodedTxStatus;
   }) {
-    defaultLogger.staking.order.updateOrderStatusByTxId(params);
-    await this.backgroundApi.simpleDb.earnOrders.updateOrderStatusByTxId(
-      params,
-    );
+    const result =
+      await this.backgroundApi.simpleDb.earnOrders.updateOrderStatusByTxId(
+        params,
+      );
+    defaultLogger.staking.order.updateOrderStatusByTxId({
+      ...params,
+      stakingLabel: result.order?.stakingLabel,
+      stakingProtocol: result.order?.stakingProtocol,
+      stakingTags: result.order?.stakingTags,
+    });
   }
 
   @backgroundMethod()

--- a/packages/kit/src/hooks/useTabContainerWidth.ts
+++ b/packages/kit/src/hooks/useTabContainerWidth.ts
@@ -1,0 +1,60 @@
+import { useMemo } from 'react';
+
+import { useWindowDimensions } from 'react-native';
+
+import {
+  useIPadModalPageWidth,
+  useIsIpadModalPage,
+  useIsSplitView,
+  useMedia,
+} from '@onekeyhq/components';
+import {
+  DESKTOP_MODE_UI_PAGE_BORDER_WIDTH,
+  DESKTOP_MODE_UI_PAGE_MARGIN,
+  MIN_SIDEBAR_WIDTH,
+} from '@onekeyhq/components/src/utils/sidebar';
+import {
+  isDualScreenDevice,
+  useDualScreenWidth,
+} from '@onekeyhq/shared/src/modules/DualScreenInfo';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import { useShouldUseSplitView } from './useShouldUseSplitView';
+
+const useNativeTabContainerWidth = isDualScreenDevice()
+  ? () => {
+      const dualScreenWidth = useDualScreenWidth();
+      return dualScreenWidth;
+    }
+  : () => {
+      const isLandscape = useIsSplitView();
+      const shouldUseSplitView = useShouldUseSplitView();
+      const { width } = useWindowDimensions();
+      const isIpadModalPage = useIsIpadModalPage();
+      const ipadModalPageWidth = useIPadModalPageWidth();
+      if (isIpadModalPage) {
+        return ipadModalPageWidth || 640;
+      }
+      // shouldUseSplitView already implies isNativeTablet() && enableSplitView.
+      // Only halve the width when the split layout is actually rendering.
+      if (shouldUseSplitView && isLandscape) {
+        return width / 2;
+      }
+      return width;
+    };
+
+export const useTabContainerWidth = platformEnv.isNative
+  ? useNativeTabContainerWidth
+  : () => {
+      const { md } = useMedia();
+      return useMemo(() => {
+        if (platformEnv.isWebDappMode || md) {
+          return `calc(100vw)`;
+        }
+        return `calc(100vw - ${
+          MIN_SIDEBAR_WIDTH +
+          DESKTOP_MODE_UI_PAGE_MARGIN +
+          DESKTOP_MODE_UI_PAGE_BORDER_WIDTH * 2
+        }px)`;
+      }, [md]);
+    };

--- a/packages/kit/src/provider/Container/index.tsx
+++ b/packages/kit/src/provider/Container/index.tsx
@@ -1,18 +1,12 @@
 import { useEffect } from 'react';
 
-import * as ScreenOrientation from 'expo-screen-orientation';
 import { RootSiblingParent } from 'react-native-root-siblings';
 
-import {
-  ESplitViewType,
-  SplitViewContext,
-  isNativeTablet,
-} from '@onekeyhq/components';
+import { ESplitViewType, SplitViewContext } from '@onekeyhq/components';
 import appGlobals from '@onekeyhq/shared/src/appGlobals';
 import LazyLoad from '@onekeyhq/shared/src/lazyLoad';
 import { setSplitViewLayoutDisabled } from '@onekeyhq/shared/src/modules/DualScreenInfo';
 import { debugLandingLog } from '@onekeyhq/shared/src/performance/init';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { WalletBackupPreCheckContainer } from '../../components/WalletBackup';
 import useAppNavigation from '../../hooks/useAppNavigation';
@@ -113,24 +107,6 @@ export function Container() {
   // split-view setting — leaving Wallet/Home content stuck on the left half.
   useEffect(() => {
     setSplitViewLayoutDisabled(!shouldUseSplitView);
-  }, [shouldUseSplitView]);
-
-  // iPad allows all orientations via Info.plist (UISupportedInterfaceOrientations~ipad).
-  // When the user opts out of the split-view layout, the single-pane UI is only
-  // designed for portrait — so lock the device to portrait. Android already
-  // forces portrait at the AndroidManifest level, so this only matters on iPad.
-  // Toggling enableSplitView restarts the app, so this effect only needs to run
-  // once per boot.
-  useEffect(() => {
-    if (!platformEnv.isNativeIOS) return;
-    if (!isNativeTablet()) return;
-    if (shouldUseSplitView) {
-      ScreenOrientation.unlockAsync().catch(() => {});
-    } else {
-      ScreenOrientation.lockAsync(
-        ScreenOrientation.OrientationLock.PORTRAIT,
-      ).catch(() => {});
-    }
   }, [shouldUseSplitView]);
 
   if (shouldUseSplitView) {

--- a/packages/kit/src/views/Borrow/hooks/useUniversalBorrowHooks.ts
+++ b/packages/kit/src/views/Borrow/hooks/useUniversalBorrowHooks.ts
@@ -84,6 +84,12 @@ const buildBorrowTrackingStakingInfo = ({
   });
 };
 
+const getEarnOrderTrackingInfo = (stakingInfo?: IStakingInfo) => ({
+  stakingLabel: stakingInfo?.label,
+  stakingProtocol: stakingInfo?.protocol,
+  stakingTags: stakingInfo?.tags,
+});
+
 type ITxConfirmResult =
   | {
       status: 'success';
@@ -115,11 +121,13 @@ const syncBorrowOrder = async ({
   networkId,
   txId,
   status,
+  stakingInfo,
 }: {
   orderId?: string;
   networkId: string;
   txId?: string;
   status: EDecodedTxStatus;
+  stakingInfo?: IStakingInfo;
 }) => {
   if (!orderId || !txId) {
     return;
@@ -130,6 +138,7 @@ const syncBorrowOrder = async ({
     networkId,
     txId,
     status,
+    ...getEarnOrderTrackingInfo(stakingInfo),
   });
 };
 
@@ -137,11 +146,13 @@ const handleBorrowSuccess = async ({
   data,
   orderId,
   networkId,
+  stakingInfo,
   onSuccess,
 }: {
   data: ISendTxOnSuccessData[];
   orderId?: string;
   networkId: string;
+  stakingInfo?: IStakingInfo;
   onSuccess?: IModalSendParamList['SendConfirm']['onSuccess'];
 }) => {
   const latestTxId =
@@ -153,6 +164,7 @@ const handleBorrowSuccess = async ({
       networkId,
       txId: latestTxId,
       status: data[data.length - 1]?.decodedTx.status,
+      ...getEarnOrderTrackingInfo(stakingInfo),
     });
   }
   onSuccess?.(data);
@@ -223,6 +235,7 @@ export function useUniversalBorrowSupply({
             data,
             orderId: resp.orderId,
             networkId,
+            stakingInfo: stakingInfoWithOrderId,
             onSuccess,
           });
         },
@@ -280,6 +293,7 @@ export function useUniversalBorrowWithdraw({
             data,
             orderId: resp.orderId,
             networkId,
+            stakingInfo: stakingInfoWithOrderId,
             onSuccess,
           });
         },
@@ -335,6 +349,7 @@ export function useUniversalBorrowBorrow({
             data,
             orderId: resp.orderId,
             networkId,
+            stakingInfo: stakingInfoWithOrderId,
             onSuccess,
           });
         },
@@ -392,6 +407,7 @@ export function useUniversalBorrowRepay({
             data,
             orderId: resp.orderId,
             networkId,
+            stakingInfo: stakingInfoWithOrderId,
             onSuccess,
           });
         },
@@ -525,6 +541,7 @@ export function useUniversalBorrowRepayWithCollateral({
             status:
               setupConfirmResult.data[setupConfirmResult.data.length - 1]
                 ?.decodedTx.status ?? EDecodedTxStatus.Pending,
+            stakingInfo: setupTrackingStakingInfo,
           });
 
           setupLutFinalizationResult =
@@ -620,6 +637,7 @@ export function useUniversalBorrowRepayWithCollateral({
           data: repayConfirmResult.data,
           orderId: resp.orderId,
           networkId,
+          stakingInfo: stakingInfoWithOrderId,
           onSuccess,
         });
         return true;
@@ -692,6 +710,7 @@ export function useUniversalBorrowClaim({
             data,
             orderId: resp.orderId,
             networkId,
+            stakingInfo: stakingInfoWithOrderId,
             onSuccess,
           });
         },

--- a/packages/kit/src/views/Borrow/pages/ReserveDetails/components/ReserveDetailsTabs.tsx
+++ b/packages/kit/src/views/Borrow/pages/ReserveDetails/components/ReserveDetailsTabs.tsx
@@ -6,12 +6,8 @@ import type {
   ITabContainerProps,
   ITabContainerRef,
 } from '@onekeyhq/components';
-import {
-  Tabs,
-  XStack,
-  YStack,
-  useTabContainerWidth,
-} from '@onekeyhq/components';
+import { Tabs, XStack, YStack } from '@onekeyhq/components';
+import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IBorrowReserveDetail } from '@onekeyhq/shared/types/staking';

--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -274,6 +274,9 @@ function BasicEarnHome({
       : 'default';
 
     hasLoggedEarnModeSwitchRef.current = true;
+    if (defaultMode === 'earn') {
+      defaultLogger.staking.page.enterEarn();
+    }
     defaultLogger.staking.page.earnModeSwitch({
       mode: defaultMode,
       switchType,

--- a/packages/kit/src/views/Earn/components/EarnMainTabs.tsx
+++ b/packages/kit/src/views/Earn/components/EarnMainTabs.tsx
@@ -15,7 +15,6 @@ import {
   YStack,
   rootNavigationRef,
   useScrollContentTabBarOffset,
-  useTabContainerWidth,
   useTheme,
 } from '@onekeyhq/components';
 import {
@@ -28,6 +27,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ListItem } from '../../../components/ListItem';
 import { useIsFirstFocused } from '../../../hooks/useIsFirstFocused';
 import { useRouteIsFocused } from '../../../hooks/useRouteIsFocused';
+import { useTabContainerWidth } from '../../../hooks/useTabContainerWidth';
 import { useEarnHideSmallAssets } from '../hooks/useEarnHideSmallAssets';
 
 import { FAQContent } from './FAQContent';

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -18,10 +18,10 @@ import {
   YStack,
   useFocusedTab,
   useScrollContentTabBarOffset,
-  useTabContainerWidth,
 } from '@onekeyhq/components';
 import type { ITabBarItemProps } from '@onekeyhq/components/src/composite/Tabs/TabBar';
 import { TabBarItem } from '@onekeyhq/components/src/composite/Tabs/TabBar';
+import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import { getNetworksSupportBulkRevokeApproval } from '@onekeyhq/shared/src/config/presetNetworks';
 import {
   WALLET_TYPE_HD,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/layout/MobileInformationTabs.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/layout/MobileInformationTabs.tsx
@@ -2,12 +2,8 @@ import { useCallback, useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import {
-  HeaderScrollGestureWrapper,
-  Tabs,
-  YStack,
-  useTabContainerWidth,
-} from '@onekeyhq/components';
+import { HeaderScrollGestureWrapper, Tabs, YStack } from '@onekeyhq/components';
+import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import { isHoldersTabSupported } from '@onekeyhq/shared/src/consts/marketConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
@@ -10,15 +10,10 @@ import {
 } from 'react';
 import type { RefObject } from 'react';
 
-import {
-  IconButton,
-  Tabs,
-  XStack,
-  YStack,
-  useTabContainerWidth,
-} from '@onekeyhq/components';
+import { IconButton, Tabs, XStack, YStack } from '@onekeyhq/components';
 import type { ITabContainerRef } from '@onekeyhq/components';
 import { useTabBarHeight } from '@onekeyhq/components/src/layouts/Page/hooks';
+import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import { useMarketWatchListV2Atom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
@@ -10,15 +10,10 @@ import {
 } from 'react';
 import type { RefObject } from 'react';
 
-import {
-  IconButton,
-  Tabs,
-  XStack,
-  YStack,
-  useTabContainerWidth,
-} from '@onekeyhq/components';
+import { IconButton, Tabs, XStack, YStack } from '@onekeyhq/components';
 import type { ITabContainerRef } from '@onekeyhq/components';
 import { useTabBarHeight } from '@onekeyhq/components/src/layouts/Page/hooks';
+import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import { useMarketWatchListV2Atom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 

--- a/packages/kit/src/views/Market/components/TokenDetailTabs.tsx
+++ b/packages/kit/src/views/Market/components/TokenDetailTabs.tsx
@@ -11,9 +11,9 @@ import {
   useIsOverlayPage,
   useMedia,
   useSplitSubView,
-  useTabContainerWidth,
 } from '@onekeyhq/components';
 import type { IDeferredPromise } from '@onekeyhq/components';
+import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IMarketTokenDetail } from '@onekeyhq/shared/types/market';

--- a/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSyncDebug.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSyncDebug.tsx
@@ -16,11 +16,11 @@ import {
   XStack,
   YStack,
   useClipboard,
-  useTabContainerWidth,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { useOneKeyAuth } from '@onekeyhq/kit/src/components/OneKeyAuth/useOneKeyAuth';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import type { IDBCloudSyncItem } from '@onekeyhq/kit-bg/src/dbs/local/types';
 import {
   useDevSettingsPersistAtom,

--- a/packages/kit/src/views/Staking/hooks/useUniversalHooks.ts
+++ b/packages/kit/src/views/Staking/hooks/useUniversalHooks.ts
@@ -39,6 +39,12 @@ const createStakeInfoWithOrderId = ({
   orderId,
 });
 
+const getEarnOrderTrackingInfo = (stakingInfo?: IStakingInfo) => ({
+  stakingLabel: stakingInfo?.label,
+  stakingProtocol: stakingInfo?.protocol,
+  stakingTags: stakingInfo?.tags,
+});
+
 type ITxConfirmResult =
   | {
       status: 'success';
@@ -115,6 +121,7 @@ const handleStakeSuccess = async ({
       networkId,
       txId: data[0].signedTx.txid,
       status: data[0].decodedTx.status,
+      ...getEarnOrderTrackingInfo(stakeInfo),
     });
   }
   onSuccess?.(data);

--- a/packages/shared/src/logger/scopes/staking/scenes/order.ts
+++ b/packages/shared/src/logger/scopes/staking/scenes/order.ts
@@ -2,19 +2,30 @@ import type { IAddEarnOrderParams } from '@onekeyhq/kit-bg/src/dbs/simple/entity
 import type { EDecodedTxStatus } from '@onekeyhq/shared/types/tx';
 
 import { BaseScene } from '../../../base/baseScene';
-import { LogToLocal } from '../../../base/decorators';
+import { LogToLocal, LogToServer } from '../../../base/decorators';
 
 export class OrderScene extends BaseScene {
+  @LogToServer()
   @LogToLocal()
   public addOrder(order: IAddEarnOrderParams) {
     return order;
   }
 
+  @LogToServer()
   @LogToLocal()
-  public updateOrderStatus(params: { txId: string; status: EDecodedTxStatus }) {
+  public updateOrderStatus(
+    params: Pick<
+      IAddEarnOrderParams,
+      'stakingLabel' | 'stakingProtocol' | 'stakingTags'
+    > & {
+      txId: string;
+      status: EDecodedTxStatus;
+    },
+  ) {
     return params;
   }
 
+  @LogToServer()
   @LogToLocal()
   public updateOrderStatusError(params: {
     txId: string;
@@ -23,12 +34,18 @@ export class OrderScene extends BaseScene {
     return params;
   }
 
+  @LogToServer()
   @LogToLocal()
-  public updateOrderStatusByTxId(params: {
-    currentTxId: string;
-    newTxId?: string;
-    status: EDecodedTxStatus;
-  }) {
+  public updateOrderStatusByTxId(
+    params: Pick<
+      IAddEarnOrderParams,
+      'stakingLabel' | 'stakingProtocol' | 'stakingTags'
+    > & {
+      currentTxId: string;
+      newTxId?: string;
+      status: EDecodedTxStatus;
+    },
+  ) {
     return params;
   }
 }

--- a/packages/shared/src/modules/DualScreenInfo/index.android.ts
+++ b/packages/shared/src/modules/DualScreenInfo/index.android.ts
@@ -93,3 +93,15 @@ export const useDualScreenWidth = () => {
   }, []);
   return width;
 };
+
+export const useIsSplitViewLayoutDisabled = () => {
+  const [disabled, setDisabled] = useState(splitViewLayoutDisabled);
+  useEffect(() => {
+    const update = () => setDisabled(splitViewLayoutDisabled);
+    splitViewLayoutListeners.add(update);
+    return () => {
+      splitViewLayoutListeners.delete(update);
+    };
+  }, []);
+  return disabled;
+};

--- a/packages/shared/src/modules/DualScreenInfo/index.ts
+++ b/packages/shared/src/modules/DualScreenInfo/index.ts
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import { Dimensions } from 'react-native';
 
 export const isDualScreenDevice = () => {
@@ -20,6 +22,26 @@ export const useDualScreenWidth = () => {
   return Dimensions.get('window').width;
 };
 
-export function setSplitViewLayoutDisabled(_disabled: boolean) {
-  // no-op outside Android dual-screen devices
+// Mirror the Android implementation: kit calls `setSplitViewLayoutDisabled`
+// from <Container> at startup so non-dual-screen platforms (iPad) can also gate
+// split-view-only width math behind the `enableSplitView` setting.
+let splitViewLayoutDisabled = false;
+const splitViewLayoutListeners = new Set<() => void>();
+
+export function setSplitViewLayoutDisabled(disabled: boolean) {
+  if (splitViewLayoutDisabled === disabled) return;
+  splitViewLayoutDisabled = disabled;
+  splitViewLayoutListeners.forEach((fn) => fn());
 }
+
+export const useIsSplitViewLayoutDisabled = () => {
+  const [disabled, setDisabled] = useState(splitViewLayoutDisabled);
+  useEffect(() => {
+    const update = () => setDisabled(splitViewLayoutDisabled);
+    splitViewLayoutListeners.add(update);
+    return () => {
+      splitViewLayoutListeners.delete(update);
+    };
+  }, []);
+  return disabled;
+};


### PR DESCRIPTION
## Summary
- Send Earn order add/status logger events to server analytics.
- Attach non-address staking metadata (`stakingLabel`, `stakingProtocol`, `stakingTags`) to Earn order records so Stake/Borrow/Supply/Repay/Withdraw can be split from completion/status logs.
- Fire `enterEarn` when the Earn mode is actually focused, covering the previously unbound page-entry event.

## Issue
- https://onekeyhq.atlassian.net/browse/OK-54953

## Test Plan
- `git diff --cached --check`
- `yarn lint:staged`
- `yarn tsc:staged`
- `yarn jest --runTestsByPath packages/kit/src/views/Borrow/hooks/useUniversalBorrowHooks.test.tsx --runInBand`
- Desktop runtime: entered DeFi/Earn in local OneKey Electron and captured `enterEarn`, `earnModeSwitch`, `addOrder`, and `updateOrderStatus` through `$analytics.trackEvent`.
- iOS simulator runtime: entered native Earn on iPhone 16e / iOS 26.0 and captured `enterEarn`, `earnModeSwitch`, `addOrder`, and `updateOrderStatus` through the iOS JS runtime.

## Notes
- Analytics-only client change; no transaction execution behavior changed.
- Runtime validation did not execute a real Stake/Borrow transaction; it verified the UI entry path and logger/decorator/analytics channel.
- This does not solve backend Kamino user-level aggregation. Borrow weekly/new-user analysis should still come from backend EarnOrders/EarnSnapshots or a server-side distinct-user field.
