### PR TITLE
feat(account-value): migrate accountValue storage to address-keyed OK-45036 OK-39276 OK-52258

### DIFF
--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
@@ -40,7 +40,7 @@ export interface IAccountValueDb {
   _migrationVersion?: number;
 }
 
-const CURRENT_MIGRATION_VERSION = 2;
+const CURRENT_MIGRATION_VERSION = 3;
 
 export interface IAccountValueSingleItem {
   networkId: string;
@@ -210,11 +210,16 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
   //     Record<networkId, worth>, but it is actually Record<${networkAccountId}_${networkId}, worth>
   //     produced by `buildAccountValueKey`. This dropped all HD/HW worth and
   //     wrote compound-keyed entries for Others.
-  //   v2 (current): parses each inner key with `parseAccountValueKey` and
-  //     resolves the address via the embedded networkAccountId, working
-  //     uniformly for Others and HD/HW.
+  //   v2 (buggy): parses each inner key correctly with `parseAccountValueKey`,
+  //     but used the raw `account.xpub` when building the addressKey, while
+  //     the BTC vault's `getAccountXpub` returns `xpubSegwit || xpub` — so
+  //     nested-segwit (P2SH-P2WPKH) entries were written to a different key
+  //     than v2 itself wrote, leaving that derive type's worth orphaned.
+  //   v3 (current): uses `xpubSegwit || xpub` when resolving the addressKey,
+  //     matching the write path. Re-runs against `_legacy_*` so v1 / v2
+  //     users recover correctly.
   //
-  // When `_legacy_all` / `_legacy_data` are present (set by v1), we re-run
+  // When `_legacy_all` / `_legacy_data` are present (set by v1+), we re-run
   // against them so users who already migrated can recover.
   async migrateFromAccountIdToAddressKey({
     serviceAccount,
@@ -294,7 +299,12 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
           accountResolveCache.set(accountId, null);
           return null;
         }
-        const xpub = (account as { xpub?: string }).xpub;
+        // Match the BTC vault's `getAccountXpub` precedence (`xpubSegwit ||
+        // xpub`) so nested-segwit derive types land at the same addressKey
+        // their post-migration writes use; otherwise migrated worth would be
+        // unreadable for that derive type.
+        const utxoAcc = account as { xpub?: string; xpubSegwit?: string };
+        const xpub = utxoAcc.xpubSegwit || utxoAcc.xpub;
         if (!account.address && !xpub) {
           accountResolveCache.set(accountId, null);
           return null;
@@ -320,10 +330,14 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
             accountId: oldKey,
           });
           if (account && account.createAtNetwork) {
+            const utxoAcc = account as {
+              xpub?: string;
+              xpubSegwit?: string;
+            };
             const addressKey = accountUtils.buildAccountLocalAssetsKey({
               networkId: account.createAtNetwork,
               accountAddress: account.address,
-              xpub: (account as { xpub?: string }).xpub,
+              xpub: utxoAcc.xpubSegwit || utxoAcc.xpub,
             });
             byAddress[addressKey] = { value: entry.value, currency: 'usd' };
           } else {

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
@@ -1,3 +1,8 @@
+import {
+  EAppEventBusNames,
+  appEventBus,
+} from '@onekeyhq/shared/src/eventBus/appEventBus';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 
 import { SimpleDbEntityBase } from '../base/SimpleDbEntityBase';
@@ -161,10 +166,15 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
   async updateAllNetworkAccountValue({
     items,
     currency,
-    updateAll,
   }: {
     items: IAccountValueAllWriteItem[];
     currency: 'usd';
+    // `updateAll` is accepted by upstream callers but intentionally ignored
+    // here: address-keyed entries are shared across every wallet that
+    // resolves to the same on-chain identifier, so a destructive "replace
+    // the whole network set" write would erase another wallet's per-network
+    // values. All writes now merge by networkId; callers that need to drop
+    // stale networks should issue an explicit clear instead.
     updateAll?: boolean;
   }) {
     // Group write items by addressKey so a single setRawData call handles
@@ -184,11 +194,6 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
     const isNoop = Object.entries(grouped).every(([key, valueMap]) => {
       const prev = existingMap[key];
       if (!prev || prev.currency !== currency) return false;
-      if (updateAll) {
-        const prevKeys = Object.keys(prev.value);
-        const nextKeys = Object.keys(valueMap);
-        if (prevKeys.length !== nextKeys.length) return false;
-      }
       return Object.entries(valueMap).every(
         ([nId, v]) => prev.value[nId] === v,
       );
@@ -204,14 +209,10 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
         ...existing,
       };
       for (const [key, valueMap] of Object.entries(grouped)) {
-        if (updateAll) {
-          next[key] = { value: valueMap, currency };
-        } else {
-          next[key] = {
-            value: { ...existing[key]?.value, ...valueMap },
-            currency,
-          };
-        }
+        next[key] = {
+          value: { ...existing[key]?.value, ...valueMap },
+          currency,
+        };
       }
       return {
         ...base,
@@ -269,6 +270,11 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
     const byAddress: Record<string, IAccountValueEntry> = {};
     const allByAddress: Record<string, IAllNetworkAccountValueEntry> = {};
 
+    // Track transient resolve failures so we can hold back the migration
+    // version bump and retry on a later launch instead of permanently
+    // dropping a legacy entry.
+    let hadResolveError = false;
+
     // Cache DB-account lookups; the same networkAccountId can appear under
     // many networkIds in legacy `all`.
     const accountResolveCache = new Map<
@@ -293,6 +299,11 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
         accountResolveCache.set(accountId, resolved);
         return resolved;
       } catch {
+        hadResolveError = true;
+        defaultLogger.app.bootstrap.initDeferredStepFailed(
+          `accountValue.migrate.resolveAccount[${accountId}]`,
+          0,
+        );
         accountResolveCache.set(accountId, null);
         return null;
       }
@@ -318,6 +329,11 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
             byAddress[addressKey] = { value: entry.value, currency: 'usd' };
           }
         } catch {
+          hadResolveError = true;
+          defaultLogger.app.bootstrap.initDeferredStepFailed(
+            `accountValue.migrate.legacyData[${oldKey}]`,
+            0,
+          );
           // Skip records that fail to resolve; legacy snapshot stays preserved
           // in `_legacy_data` so a later version can retry.
         }
@@ -354,16 +370,48 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
       }
     }
 
-    await this.setRawData((current) => ({
-      ...(current ?? emptyData()),
-      byAddress,
-      allByAddress,
-      // Preserve legacy snapshot once, even on re-run, so a future migration
-      // version can re-derive without losing data.
-      _legacy_data: current?._legacy_data ?? legacyData,
-      _legacy_all: current?._legacy_all ?? legacyAll,
-      _migratedAt: Date.now(),
-      _migrationVersion: CURRENT_MIGRATION_VERSION,
-    }));
+    await this.setRawData((current) => {
+      // Merge so that any writes that landed during the migration window —
+      // and any post-migration writes preserved across a version-bump
+      // re-run — survive. `current` wins over the legacy-derived snapshot;
+      // legacy values only fill keys that don't already exist.
+      const mergedByAddress: Record<string, IAccountValueEntry> = {
+        ...byAddress,
+        ...current?.byAddress,
+      };
+      const mergedAllByAddress: Record<string, IAllNetworkAccountValueEntry> = {
+        ...current?.allByAddress,
+      };
+      for (const [key, legacyEntry] of Object.entries(allByAddress)) {
+        const cur = mergedAllByAddress[key];
+        mergedAllByAddress[key] = cur
+          ? {
+              value: { ...legacyEntry.value, ...cur.value },
+              currency: cur.currency,
+            }
+          : legacyEntry;
+      }
+
+      return {
+        ...(current ?? emptyData()),
+        byAddress: mergedByAddress,
+        allByAddress: mergedAllByAddress,
+        // Preserve legacy snapshot once, even on re-run, so a future
+        // migration version can re-derive without losing data.
+        _legacy_data: current?._legacy_data ?? legacyData,
+        _legacy_all: current?._legacy_all ?? legacyAll,
+        _migratedAt: Date.now(),
+        // Hold the version back when any legacy entry failed to resolve so
+        // a later launch retries; otherwise a single transient DB error
+        // would permanently strip that account's cached worth.
+        _migrationVersion: hadResolveError
+          ? (current?._migrationVersion ?? 0)
+          : CURRENT_MIGRATION_VERSION,
+      };
+    });
+
+    // Nudge consumers that already read the empty buckets during the
+    // pre-migration window to re-fetch and pick up the freshly-merged data.
+    appEventBus.emit(EAppEventBusNames.AccountValueUpdate, undefined);
   }
 }

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
@@ -166,15 +166,19 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
   async updateAllNetworkAccountValue({
     items,
     currency,
+    updateAll,
   }: {
     items: IAccountValueAllWriteItem[];
     currency: 'usd';
-    // `updateAll` is accepted by upstream callers but intentionally ignored
-    // here: address-keyed entries are shared across every wallet that
-    // resolves to the same on-chain identifier, so a destructive "replace
-    // the whole network set" write would erase another wallet's per-network
-    // values. All writes now merge by networkId; callers that need to drop
-    // stale networks should issue an explicit clear instead.
+    // When `updateAll === true` the caller has completed a full token
+    // snapshot for the covered address keys, so the per-network map for
+    // each touched address is replaced — networkIds that no longer appear
+    // (network removed/disabled, refresh produced no value) are dropped to
+    // avoid stale entries leaking into ChainSelector / AccountSelector /
+    // UniversalSearch. Address keys NOT covered by this refresh are left
+    // untouched so a sibling wallet's data for an unrelated address is
+    // preserved. When `updateAll === false` writes are partial and merge
+    // by networkId.
     updateAll?: boolean;
   }) {
     // Group write items by addressKey so a single setRawData call handles
@@ -194,6 +198,14 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
     const isNoop = Object.entries(grouped).every(([key, valueMap]) => {
       const prev = existingMap[key];
       if (!prev || prev.currency !== currency) return false;
+      if (updateAll) {
+        // Replace mode: the existing map must match the incoming snapshot
+        // exactly, otherwise we still need to write to drop stale networkIds.
+        const prevKeys = Object.keys(prev.value);
+        const nextKeys = Object.keys(valueMap);
+        if (prevKeys.length !== nextKeys.length) return false;
+        return nextKeys.every((nId) => prev.value[nId] === valueMap[nId]);
+      }
       return Object.entries(valueMap).every(
         ([nId, v]) => prev.value[nId] === v,
       );
@@ -210,7 +222,9 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
       };
       for (const [key, valueMap] of Object.entries(grouped)) {
         next[key] = {
-          value: { ...existing[key]?.value, ...valueMap },
+          value: updateAll
+            ? valueMap
+            : { ...existing[key]?.value, ...valueMap },
           currency,
         };
       }

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
@@ -34,7 +34,13 @@ export interface IAccountValueDb {
     { value: Record<string, string>; currency: string }
   >;
   _migratedAt?: number;
+  // Migration version. Bumped when the migration logic itself is corrected so we
+  // can re-run against the preserved `_legacy_*` snapshot for users that already
+  // completed a buggy earlier version.
+  _migrationVersion?: number;
 }
+
+const CURRENT_MIGRATION_VERSION = 2;
 
 export interface IAccountValueSingleItem {
   networkId: string;
@@ -197,8 +203,19 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
 
   // One-shot migration from the legacy `data` / `all` shape (keyed by accountId)
   // to the new address-keyed shape. Safe to invoke on every startup — idempotent
-  // via `_migratedAt`. Legacy fields are kept for one or two releases so a
-  // rollback PR can read them directly.
+  // via `_migrationVersion`.
+  //
+  // Versioning:
+  //   v1 (buggy): mis-read the inner `value` map of legacy `all` as
+  //     Record<networkId, worth>, but it is actually Record<${networkAccountId}_${networkId}, worth>
+  //     produced by `buildAccountValueKey`. This dropped all HD/HW worth and
+  //     wrote compound-keyed entries for Others.
+  //   v2 (current): parses each inner key with `parseAccountValueKey` and
+  //     resolves the address via the embedded networkAccountId, working
+  //     uniformly for Others and HD/HW.
+  //
+  // When `_legacy_all` / `_legacy_data` are present (set by v1), we re-run
+  // against them so users who already migrated can recover.
   async migrateFromAccountIdToAddressKey({
     serviceAccount,
   }: {
@@ -216,31 +233,80 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
       | undefined;
 
     if (!raw) {
+      console.log(
+        '[accountValue migration] skip: no rawData (fresh install or storage empty)',
+      );
       return;
     }
-    if (raw._migratedAt) {
+    if ((raw._migrationVersion ?? 0) >= CURRENT_MIGRATION_VERSION) {
+      console.log('[accountValue migration] skip: already at current version', {
+        migrationVersion: raw._migrationVersion,
+        migratedAt: raw._migratedAt,
+        migratedAtISO: raw._migratedAt
+          ? new Date(raw._migratedAt).toISOString()
+          : undefined,
+        byAddress: Object.keys(raw.byAddress ?? {}).length,
+        allByAddress: Object.keys(raw.allByAddress ?? {}).length,
+      });
       return;
     }
-    const legacyData = raw.data ?? {};
-    const legacyAll = raw.all ?? {};
+
+    // Source the legacy snapshot. For v0 (never migrated) it lives under
+    // `data` / `all`. For v1 (buggy migration already ran) the originals were
+    // preserved into `_legacy_data` / `_legacy_all`.
+    const previousVersion = raw._migrationVersion ?? (raw._migratedAt ? 1 : 0);
+    const legacyData = raw.data ?? raw._legacy_data ?? {};
+    const legacyAll = raw.all ?? raw._legacy_all ?? {};
     if (
       Object.keys(legacyData).length === 0 &&
       Object.keys(legacyAll).length === 0
     ) {
-      // Nothing to migrate, but still stamp _migratedAt so we don't keep
-      // hitting this branch every cold start.
       await this.setRawData((current) => ({
         ...(current ?? emptyData()),
         byAddress: current?.byAddress ?? {},
         allByAddress: current?.allByAddress ?? {},
         _migratedAt: Date.now(),
+        _migrationVersion: CURRENT_MIGRATION_VERSION,
       }));
+      console.log(
+        '[accountValue migration] skip: no legacy data, stamped current version',
+        { previousVersion },
+      );
       return;
     }
 
     const byAddress: Record<string, IAccountValueEntry> = {};
     const allByAddress: Record<string, IAllNetworkAccountValueEntry> = {};
     const failures: string[] = [];
+
+    // Cache DB-account lookups; the same networkAccountId can appear under
+    // many networkIds in legacy `all`.
+    const accountResolveCache = new Map<
+      string,
+      { accountAddress?: string; xpub?: string } | null
+    >();
+    const resolveByAccountId = async (accountId: string) => {
+      const cached = accountResolveCache.get(accountId);
+      if (cached !== undefined) return cached;
+      try {
+        const account = await serviceAccount.getDBAccount({ accountId });
+        if (!account) {
+          accountResolveCache.set(accountId, null);
+          return null;
+        }
+        const xpub = (account as { xpub?: string }).xpub;
+        if (!account.address && !xpub) {
+          accountResolveCache.set(accountId, null);
+          return null;
+        }
+        const resolved = { accountAddress: account.address, xpub };
+        accountResolveCache.set(accountId, resolved);
+        return resolved;
+      } catch {
+        accountResolveCache.set(accountId, null);
+        return null;
+      }
+    };
 
     // Legacy `data` was only ever populated by Others accounts at their
     // createAtNetwork. Skip anything that doesn't fit that shape.
@@ -269,75 +335,56 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
       }
     }
 
+    // Legacy `all` inner map keys are `${networkAccountId}_${networkId}` from
+    // `buildAccountValueKey` (see pre-migration HomeOverviewContainer and
+    // TokenSelector write paths). Resolve each inner accountId to its
+    // address/xpub and emit one address-keyed entry per (address, networkId).
     for (const [oldKey, entry] of Object.entries(legacyAll)) {
-      if (entry?.currency !== 'usd') {
-        // skip: unknown currency leaves no safe migration path
-      } else if (accountUtils.isOthersAccount({ accountId: oldKey })) {
-        try {
-          const account = await serviceAccount.getDBAccount({
-            accountId: oldKey,
+      if (entry?.currency === 'usd') {
+        for (const [compoundKey, worth] of Object.entries(entry.value)) {
+          const parsed = accountUtils.parseAccountValueKey({
+            key: compoundKey,
           });
-          const xpub = account
-            ? (account as { xpub?: string }).xpub
-            : undefined;
-          if (account && (account.address || xpub)) {
-            const addressKey = accountUtils.buildAccountLocalAssetsKey({
-              accountAddress: account.address,
-              xpub,
-            });
-            allByAddress[addressKey] = {
-              value: {
-                ...allByAddress[addressKey]?.value,
-                ...entry.value,
-              },
-              currency: 'usd',
-            };
+          if (!parsed.accountId || !parsed.networkId) {
+            failures.push(`${oldKey}#${compoundKey}`);
           } else {
-            failures.push(oldKey);
-          }
-        } catch {
-          failures.push(oldKey);
-        }
-      } else {
-        for (const [networkId, v] of Object.entries(entry.value)) {
-          try {
-            const result =
-              await serviceAccount.getNetworkAccountsInSameIndexedAccountId({
-                indexedAccountId: oldKey,
-                networkIds: [networkId],
-              });
-            const networkAccount = result?.[0]?.account;
-            if (networkAccount) {
+            const resolved = await resolveByAccountId(parsed.accountId);
+            if (!resolved) {
+              failures.push(`${oldKey}#${compoundKey}`);
+            } else {
               const addressKey = accountUtils.buildAccountLocalAssetsKey({
-                accountAddress: networkAccount.address,
-                xpub: (networkAccount as { xpub?: string }).xpub,
+                accountAddress: resolved.accountAddress,
+                xpub: resolved.xpub,
               });
+              const existing = allByAddress[addressKey];
               allByAddress[addressKey] = {
                 value: {
-                  ...allByAddress[addressKey]?.value,
-                  [networkId]: v,
+                  ...(existing?.value ?? {}),
+                  [parsed.networkId]: worth,
                 },
                 currency: 'usd',
               };
-            } else {
-              failures.push(`${oldKey}/${networkId}`);
             }
-          } catch {
-            failures.push(`${oldKey}/${networkId}`);
           }
         }
       }
     }
 
-    await this.setRawData(() => ({
+    await this.setRawData((current) => ({
+      ...(current ?? emptyData()),
       byAddress,
       allByAddress,
-      _legacy_data: legacyData,
-      _legacy_all: legacyAll,
+      // Preserve legacy snapshot once, even on re-run, so a future v3 can
+      // re-derive without losing data.
+      _legacy_data: current?._legacy_data ?? legacyData,
+      _legacy_all: current?._legacy_all ?? legacyAll,
       _migratedAt: Date.now(),
+      _migrationVersion: CURRENT_MIGRATION_VERSION,
     }));
 
     console.log('[accountValue migration]', {
+      previousVersion,
+      migrationVersion: CURRENT_MIGRATION_VERSION,
       legacyData: Object.keys(legacyData).length,
       legacyAll: Object.keys(legacyAll).length,
       byAddress: Object.keys(byAddress).length,

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
@@ -45,7 +45,7 @@ export interface IAccountValueDb {
   _migrationVersion?: number;
 }
 
-const CURRENT_MIGRATION_VERSION = 3;
+const CURRENT_MIGRATION_VERSION = 1;
 
 export interface IAccountValueSingleItem {
   networkId: string;

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
@@ -1,20 +1,58 @@
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+
 import { SimpleDbEntityBase } from '../base/SimpleDbEntityBase';
 
+import type ServiceAccount from '../../../services/ServiceAccount/ServiceAccount';
+
+// Stored value entry for a single (networkId, addressOrXpub) pair.
+export interface IAccountValueEntry {
+  value: string;
+  currency: 'usd';
+}
+
+// Stored value entry for All Networks aggregate, keyed only by addressOrXpub.
+// Inner value is keyed by networkId so a single address shared across multiple
+// EVM-compatible networks can hold per-network worth in one entry.
+export interface IAllNetworkAccountValueEntry {
+  value: Record<string, string>; // <networkId, value>
+  currency: 'usd';
+}
+
 export interface IAccountValueDb {
-  data: Record<
-    string,
-    {
-      value: string;
-      currency: string;
-    }
-  >; // <accountId, value>
-  all: Record<
-    string,
-    {
-      value: Record<string, string>; // <networkId, value>
-      currency: string; // Currency for all networks is always USD
-    }
-  >;
+  // Single-network worth, key = buildAccountLocalAssetsKey({networkId, accountAddress, xpub}).
+  byAddress: Record<string, IAccountValueEntry>;
+
+  // All Networks aggregate worth, key = buildAccountLocalAssetsKey({accountAddress, xpub}) (no networkId).
+  // Inner value records per-network worth so callers can iterate or sum.
+  allByAddress: Record<string, IAllNetworkAccountValueEntry>;
+
+  // Legacy fields preserved during the one-shot address-key migration so a rollback
+  // PR can keep reading old data. Cleaned up in a later release.
+  _legacy_data?: Record<string, { value: string; currency: string }>;
+  _legacy_all?: Record<string, { value: Record<string, string>; currency: string }>;
+  _migratedAt?: number;
+}
+
+export interface IAccountValueSingleItem {
+  networkId: string;
+  accountAddress?: string;
+  xpub?: string;
+}
+
+export interface IAccountValueAllItem {
+  accountAddress?: string;
+  xpub?: string;
+}
+
+export interface IAccountValueAllWriteItem {
+  accountAddress?: string;
+  xpub?: string;
+  networkId: string;
+  value: string;
+}
+
+function emptyData(): IAccountValueDb {
+  return { byAddress: {}, allByAddress: {} };
 }
 
 export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValueDb> {
@@ -22,82 +60,281 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
 
   override enableCache = false;
 
-  async getAccountsValue({ accounts }: { accounts: { accountId: string }[] }) {
-    const rawData = await this.getRawData();
-    const data = rawData?.data;
+  private buildSingleKey({
+    networkId,
+    accountAddress,
+    xpub,
+  }: IAccountValueSingleItem): string | null {
+    if (!accountAddress && !xpub) {
+      return null;
+    }
+    return accountUtils.buildAccountLocalAssetsKey({
+      networkId,
+      accountAddress,
+      xpub,
+    });
+  }
 
-    return accounts.map(({ accountId }) => ({
-      accountId,
-      value: data?.[accountId]?.value,
-      currency: data?.[accountId]?.currency,
-    }));
+  private buildAllKey({
+    accountAddress,
+    xpub,
+  }: IAccountValueAllItem): string | null {
+    if (!accountAddress && !xpub) {
+      return null;
+    }
+    return accountUtils.buildAccountLocalAssetsKey({
+      accountAddress,
+      xpub,
+    });
+  }
+
+  async getAccountsValue({ items }: { items: IAccountValueSingleItem[] }) {
+    const raw = await this.getRawData();
+    return items.map((it) => {
+      const key = this.buildSingleKey(it);
+      const entry = key ? raw?.byAddress?.[key] : undefined;
+      return {
+        value: entry?.value,
+        currency: entry?.currency,
+      };
+    });
   }
 
   async updateAccountValue({
-    accountId,
+    networkId,
+    accountAddress,
+    xpub,
     value,
     currency,
   }: {
-    accountId: string;
+    networkId: string;
+    accountAddress?: string;
+    xpub?: string;
     value: string;
-    currency: string;
+    currency: 'usd';
   }) {
+    const key = this.buildSingleKey({ networkId, accountAddress, xpub });
+    if (!key) {
+      return;
+    }
     await this.setRawData((rawData) => {
-      const data = { ...rawData?.data };
-      if (data[accountId]) {
-        data[accountId].value = value;
-        data[accountId].currency = currency;
-      } else {
-        data[accountId] = { value, currency };
-      }
-      return { data, all: { ...rawData?.all } };
+      const base = rawData ?? emptyData();
+      return {
+        ...base,
+        byAddress: {
+          ...(base.byAddress ?? {}),
+          [key]: { value, currency },
+        },
+        allByAddress: base.allByAddress ?? {},
+      };
+    });
+  }
+
+  async getAllNetworkAccountsValue({
+    items,
+  }: {
+    items: IAccountValueAllItem[];
+  }) {
+    const raw = await this.getRawData();
+    return items.map((it) => {
+      const key = this.buildAllKey(it);
+      const entry = key ? raw?.allByAddress?.[key] : undefined;
+      return {
+        value: entry?.value,
+        currency: entry?.currency,
+      };
     });
   }
 
   async updateAllNetworkAccountValue({
-    accountId,
-    value,
+    items,
     currency,
     updateAll,
   }: {
-    accountId: string;
-    value: Record<string, string>;
-    currency: string;
+    items: IAccountValueAllWriteItem[];
+    currency: 'usd';
     updateAll?: boolean;
   }) {
-    if (updateAll) {
-      await this.setRawData((rawData) => {
-        const all = { ...rawData?.all };
-        all[accountId] = { value, currency };
-        return { all, data: { ...rawData?.data } };
-      });
-    } else {
-      await this.setRawData((rawData) => {
-        const all = { ...rawData?.all };
-        all[accountId] = {
-          value: {
-            ...all[accountId]?.value,
-            ...value,
-          },
-          currency,
-        };
-        return { all, data: { ...rawData?.data } };
-      });
+    // Group write items by addressKey so a single setRawData call handles
+    // multi-network entries that share the same address.
+    const grouped: Record<string, Record<string, string>> = {};
+    for (const it of items) {
+      const key = this.buildAllKey(it);
+      if (!key) continue;
+      grouped[key] = { ...(grouped[key] ?? {}), [it.networkId]: it.value };
     }
+    if (Object.keys(grouped).length === 0) {
+      return;
+    }
+
+    await this.setRawData((rawData) => {
+      const base = rawData ?? emptyData();
+      const existing = base.allByAddress ?? {};
+      const next: Record<string, IAllNetworkAccountValueEntry> = {
+        ...existing,
+      };
+      for (const [key, valueMap] of Object.entries(grouped)) {
+        if (updateAll) {
+          next[key] = { value: valueMap, currency };
+        } else {
+          next[key] = {
+            value: { ...(existing[key]?.value ?? {}), ...valueMap },
+            currency,
+          };
+        }
+      }
+      return {
+        ...base,
+        byAddress: base.byAddress ?? {},
+        allByAddress: next,
+      };
+    });
   }
 
-  async getAllNetworkAccountsValue({
-    accounts,
+  // One-shot migration from the legacy `data` / `all` shape (keyed by accountId)
+  // to the new address-keyed shape. Safe to invoke on every startup — idempotent
+  // via `_migratedAt`. Legacy fields are kept for one or two releases so a
+  // rollback PR can read them directly.
+  async migrateFromAccountIdToAddressKey({
+    serviceAccount,
   }: {
-    accounts: { accountId: string }[];
+    serviceAccount: ServiceAccount;
   }) {
-    const rawData = await this.getRawData();
-    const all = rawData?.all;
+    const raw = (await this.getRawData()) as
+      | (IAccountValueDb & {
+          data?: Record<string, { value: string; currency: string }>;
+          all?: Record<
+            string,
+            { value: Record<string, string>; currency: string }
+          >;
+        })
+      | null
+      | undefined;
 
-    return accounts.map(({ accountId }) => ({
-      accountId,
-      value: all?.[accountId]?.value,
-      currency: all?.[accountId]?.currency,
+    if (!raw) {
+      return;
+    }
+    if (raw._migratedAt) {
+      return;
+    }
+    const legacyData = raw.data ?? {};
+    const legacyAll = raw.all ?? {};
+    if (
+      Object.keys(legacyData).length === 0 &&
+      Object.keys(legacyAll).length === 0
+    ) {
+      // Nothing to migrate, but still stamp _migratedAt so we don't keep
+      // hitting this branch every cold start.
+      await this.setRawData((current) => ({
+        ...(current ?? emptyData()),
+        byAddress: current?.byAddress ?? {},
+        allByAddress: current?.allByAddress ?? {},
+        _migratedAt: Date.now(),
+      }));
+      return;
+    }
+
+    const byAddress: Record<string, IAccountValueEntry> = {};
+    const allByAddress: Record<string, IAllNetworkAccountValueEntry> = {};
+    const failures: string[] = [];
+
+    // Legacy `data` was only ever populated by Others accounts at their
+    // createAtNetwork. Skip anything that doesn't fit that shape.
+    for (const [oldKey, entry] of Object.entries(legacyData)) {
+      if (entry?.currency !== 'usd') continue;
+      if (!accountUtils.isOthersAccount({ accountId: oldKey })) continue;
+      try {
+        const account = await serviceAccount.getDBAccount({ accountId: oldKey });
+        if (!account) {
+          failures.push(oldKey);
+          continue;
+        }
+        const networkId = account.createAtNetwork;
+        if (!networkId) {
+          failures.push(oldKey);
+          continue;
+        }
+        const addressKey = accountUtils.buildAccountLocalAssetsKey({
+          networkId,
+          accountAddress: account.address,
+          xpub: (account as { xpub?: string }).xpub,
+        });
+        byAddress[addressKey] = { value: entry.value, currency: 'usd' };
+      } catch {
+        failures.push(oldKey);
+      }
+    }
+
+    for (const [oldKey, entry] of Object.entries(legacyAll)) {
+      if (entry?.currency !== 'usd') continue;
+      try {
+        if (accountUtils.isOthersAccount({ accountId: oldKey })) {
+          const account = await serviceAccount.getDBAccount({
+            accountId: oldKey,
+          });
+          if (!account || (!account.address && !(account as { xpub?: string }).xpub)) {
+            failures.push(oldKey);
+            continue;
+          }
+          const addressKey = accountUtils.buildAccountLocalAssetsKey({
+            accountAddress: account.address,
+            xpub: (account as { xpub?: string }).xpub,
+          });
+          allByAddress[addressKey] = {
+            value: {
+              ...(allByAddress[addressKey]?.value ?? {}),
+              ...entry.value,
+            },
+            currency: 'usd',
+          };
+        } else {
+          for (const [networkId, v] of Object.entries(entry.value)) {
+            try {
+              const result =
+                await serviceAccount.getNetworkAccountsInSameIndexedAccountId({
+                  indexedAccountId: oldKey,
+                  networkIds: [networkId],
+                });
+              const networkAccount = result?.[0]?.account;
+              if (!networkAccount) {
+                failures.push(`${oldKey}/${networkId}`);
+                continue;
+              }
+              const addressKey = accountUtils.buildAccountLocalAssetsKey({
+                accountAddress: networkAccount.address,
+                xpub: (networkAccount as { xpub?: string }).xpub,
+              });
+              allByAddress[addressKey] = {
+                value: {
+                  ...(allByAddress[addressKey]?.value ?? {}),
+                  [networkId]: v,
+                },
+                currency: 'usd',
+              };
+            } catch {
+              failures.push(`${oldKey}/${networkId}`);
+            }
+          }
+        }
+      } catch {
+        failures.push(oldKey);
+      }
+    }
+
+    await this.setRawData(() => ({
+      byAddress,
+      allByAddress,
+      _legacy_data: legacyData,
+      _legacy_all: legacyAll,
+      _migratedAt: Date.now(),
     }));
+
+    console.log('[accountValue migration]', {
+      legacyData: Object.keys(legacyData).length,
+      legacyAll: Object.keys(legacyAll).length,
+      byAddress: Object.keys(byAddress).length,
+      allByAddress: Object.keys(allByAddress).length,
+      failures: failures.length,
+    });
   }
 }

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
@@ -126,6 +126,10 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
     if (!key) {
       return;
     }
+    const existing = (await this.getRawData())?.byAddress?.[key];
+    if (existing?.value === value && existing?.currency === currency) {
+      return;
+    }
     await this.setRawData((rawData) => {
       const base = rawData ?? emptyData();
       return {
@@ -134,7 +138,6 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
           ...base.byAddress,
           [key]: { value, currency },
         },
-        allByAddress: base.allByAddress ?? {},
       };
     });
   }
@@ -177,9 +180,26 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
       return;
     }
 
+    const existingMap = (await this.getRawData())?.allByAddress ?? {};
+    const isNoop = Object.entries(grouped).every(([key, valueMap]) => {
+      const prev = existingMap[key];
+      if (!prev || prev.currency !== currency) return false;
+      if (updateAll) {
+        const prevKeys = Object.keys(prev.value);
+        const nextKeys = Object.keys(valueMap);
+        if (prevKeys.length !== nextKeys.length) return false;
+      }
+      return Object.entries(valueMap).every(
+        ([nId, v]) => prev.value[nId] === v,
+      );
+    });
+    if (isNoop) {
+      return;
+    }
+
     await this.setRawData((rawData) => {
       const base = rawData ?? emptyData();
-      const existing = base.allByAddress ?? {};
+      const existing = base.allByAddress;
       const next: Record<string, IAllNetworkAccountValueEntry> = {
         ...existing,
       };
@@ -195,32 +215,15 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
       }
       return {
         ...base,
-        byAddress: base.byAddress ?? {},
         allByAddress: next,
       };
     });
   }
 
-  // One-shot migration from the legacy `data` / `all` shape (keyed by accountId)
-  // to the new address-keyed shape. Safe to invoke on every startup — idempotent
-  // via `_migrationVersion`.
-  //
-  // Versioning:
-  //   v1 (buggy): mis-read the inner `value` map of legacy `all` as
-  //     Record<networkId, worth>, but it is actually Record<${networkAccountId}_${networkId}, worth>
-  //     produced by `buildAccountValueKey`. This dropped all HD/HW worth and
-  //     wrote compound-keyed entries for Others.
-  //   v2 (buggy): parses each inner key correctly with `parseAccountValueKey`,
-  //     but used the raw `account.xpub` when building the addressKey, while
-  //     the BTC vault's `getAccountXpub` returns `xpubSegwit || xpub` — so
-  //     nested-segwit (P2SH-P2WPKH) entries were written to a different key
-  //     than v2 itself wrote, leaving that derive type's worth orphaned.
-  //   v3 (current): uses `xpubSegwit || xpub` when resolving the addressKey,
-  //     matching the write path. Re-runs against `_legacy_*` so v1 / v2
-  //     users recover correctly.
-  //
-  // When `_legacy_all` / `_legacy_data` are present (set by v1+), we re-run
-  // against them so users who already migrated can recover.
+  // One-shot migration from the legacy accountId-keyed `data` / `all` shape
+  // to the address-keyed shape. Idempotent via `_migrationVersion`; bump
+  // `CURRENT_MIGRATION_VERSION` to re-run against the preserved `_legacy_*`
+  // snapshot when the migration logic itself changes.
   async migrateFromAccountIdToAddressKey({
     serviceAccount,
   }: {
@@ -238,28 +241,15 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
       | undefined;
 
     if (!raw) {
-      console.log(
-        '[accountValue migration] skip: no rawData (fresh install or storage empty)',
-      );
       return;
     }
     if ((raw._migrationVersion ?? 0) >= CURRENT_MIGRATION_VERSION) {
-      console.log('[accountValue migration] skip: already at current version', {
-        migrationVersion: raw._migrationVersion,
-        migratedAt: raw._migratedAt,
-        migratedAtISO: raw._migratedAt
-          ? new Date(raw._migratedAt).toISOString()
-          : undefined,
-        byAddress: Object.keys(raw.byAddress ?? {}).length,
-        allByAddress: Object.keys(raw.allByAddress ?? {}).length,
-      });
       return;
     }
 
-    // Source the legacy snapshot. For v0 (never migrated) it lives under
-    // `data` / `all`. For v1 (buggy migration already ran) the originals were
-    // preserved into `_legacy_data` / `_legacy_all`.
-    const previousVersion = raw._migrationVersion ?? (raw._migratedAt ? 1 : 0);
+    // For v0 (never migrated) the snapshot lives under `data` / `all`; for
+    // earlier buggy migration versions the originals were preserved into
+    // `_legacy_*` so we can re-run.
     const legacyData = raw.data ?? raw._legacy_data ?? {};
     const legacyAll = raw.all ?? raw._legacy_all ?? {};
     if (
@@ -273,16 +263,11 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
         _migratedAt: Date.now(),
         _migrationVersion: CURRENT_MIGRATION_VERSION,
       }));
-      console.log(
-        '[accountValue migration] skip: no legacy data, stamped current version',
-        { previousVersion },
-      );
       return;
     }
 
     const byAddress: Record<string, IAccountValueEntry> = {};
     const allByAddress: Record<string, IAllNetworkAccountValueEntry> = {};
-    const failures: string[] = [];
 
     // Cache DB-account lookups; the same networkAccountId can appear under
     // many networkIds in legacy `all`.
@@ -299,12 +284,7 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
           accountResolveCache.set(accountId, null);
           return null;
         }
-        // Match the BTC vault's `getAccountXpub` precedence (`xpubSegwit ||
-        // xpub`) so nested-segwit derive types land at the same addressKey
-        // their post-migration writes use; otherwise migrated worth would be
-        // unreadable for that derive type.
-        const utxoAcc = account as { xpub?: string; xpubSegwit?: string };
-        const xpub = utxoAcc.xpubSegwit || utxoAcc.xpub;
+        const xpub = accountUtils.pickXpubFromDBAccount(account);
         if (!account.address && !xpub) {
           accountResolveCache.set(accountId, null);
           return null;
@@ -329,43 +309,33 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
           const account = await serviceAccount.getDBAccount({
             accountId: oldKey,
           });
-          if (account && account.createAtNetwork) {
-            const utxoAcc = account as {
-              xpub?: string;
-              xpubSegwit?: string;
-            };
+          if (account?.createAtNetwork) {
             const addressKey = accountUtils.buildAccountLocalAssetsKey({
               networkId: account.createAtNetwork,
               accountAddress: account.address,
-              xpub: utxoAcc.xpubSegwit || utxoAcc.xpub,
+              xpub: accountUtils.pickXpubFromDBAccount(account),
             });
             byAddress[addressKey] = { value: entry.value, currency: 'usd' };
-          } else {
-            failures.push(oldKey);
           }
         } catch {
-          failures.push(oldKey);
+          // Skip records that fail to resolve; legacy snapshot stays preserved
+          // in `_legacy_data` so a later version can retry.
         }
       }
     }
 
     // Legacy `all` inner map keys are `${networkAccountId}_${networkId}` from
-    // `buildAccountValueKey` (see pre-migration HomeOverviewContainer and
-    // TokenSelector write paths). Resolve each inner accountId to its
-    // address/xpub and emit one address-keyed entry per (address, networkId).
-    for (const [oldKey, entry] of Object.entries(legacyAll)) {
+    // `buildAccountValueKey`. Resolve each inner accountId to its address/xpub
+    // and emit one address-keyed entry per (address, networkId).
+    for (const [, entry] of Object.entries(legacyAll)) {
       if (entry?.currency === 'usd') {
         for (const [compoundKey, worth] of Object.entries(entry.value)) {
           const parsed = accountUtils.parseAccountValueKey({
             key: compoundKey,
           });
-          if (!parsed.accountId || !parsed.networkId) {
-            failures.push(`${oldKey}#${compoundKey}`);
-          } else {
+          if (parsed.accountId && parsed.networkId) {
             const resolved = await resolveByAccountId(parsed.accountId);
-            if (!resolved) {
-              failures.push(`${oldKey}#${compoundKey}`);
-            } else {
+            if (resolved) {
               const addressKey = accountUtils.buildAccountLocalAssetsKey({
                 accountAddress: resolved.accountAddress,
                 xpub: resolved.xpub,
@@ -388,22 +358,12 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
       ...(current ?? emptyData()),
       byAddress,
       allByAddress,
-      // Preserve legacy snapshot once, even on re-run, so a future v3 can
-      // re-derive without losing data.
+      // Preserve legacy snapshot once, even on re-run, so a future migration
+      // version can re-derive without losing data.
       _legacy_data: current?._legacy_data ?? legacyData,
       _legacy_all: current?._legacy_all ?? legacyAll,
       _migratedAt: Date.now(),
       _migrationVersion: CURRENT_MIGRATION_VERSION,
     }));
-
-    console.log('[accountValue migration]', {
-      previousVersion,
-      migrationVersion: CURRENT_MIGRATION_VERSION,
-      legacyData: Object.keys(legacyData).length,
-      legacyAll: Object.keys(legacyAll).length,
-      byAddress: Object.keys(byAddress).length,
-      allByAddress: Object.keys(allByAddress).length,
-      failures: failures.length,
-    });
   }
 }

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
@@ -29,7 +29,10 @@ export interface IAccountValueDb {
   // Legacy fields preserved during the one-shot address-key migration so a rollback
   // PR can keep reading old data. Cleaned up in a later release.
   _legacy_data?: Record<string, { value: string; currency: string }>;
-  _legacy_all?: Record<string, { value: Record<string, string>; currency: string }>;
+  _legacy_all?: Record<
+    string,
+    { value: Record<string, string>; currency: string }
+  >;
   _migratedAt?: number;
 }
 
@@ -122,7 +125,7 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
       return {
         ...base,
         byAddress: {
-          ...(base.byAddress ?? {}),
+          ...base.byAddress,
           [key]: { value, currency },
         },
         allByAddress: base.allByAddress ?? {},
@@ -160,8 +163,9 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
     const grouped: Record<string, Record<string, string>> = {};
     for (const it of items) {
       const key = this.buildAllKey(it);
-      if (!key) continue;
-      grouped[key] = { ...(grouped[key] ?? {}), [it.networkId]: it.value };
+      if (key) {
+        grouped[key] = { ...grouped[key], [it.networkId]: it.value };
+      }
     }
     if (Object.keys(grouped).length === 0) {
       return;
@@ -178,7 +182,7 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
           next[key] = { value: valueMap, currency };
         } else {
           next[key] = {
-            value: { ...(existing[key]?.value ?? {}), ...valueMap },
+            value: { ...existing[key]?.value, ...valueMap },
             currency,
           };
         }
@@ -241,83 +245,87 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
     // Legacy `data` was only ever populated by Others accounts at their
     // createAtNetwork. Skip anything that doesn't fit that shape.
     for (const [oldKey, entry] of Object.entries(legacyData)) {
-      if (entry?.currency !== 'usd') continue;
-      if (!accountUtils.isOthersAccount({ accountId: oldKey })) continue;
-      try {
-        const account = await serviceAccount.getDBAccount({ accountId: oldKey });
-        if (!account) {
+      if (
+        entry?.currency === 'usd' &&
+        accountUtils.isOthersAccount({ accountId: oldKey })
+      ) {
+        try {
+          const account = await serviceAccount.getDBAccount({
+            accountId: oldKey,
+          });
+          if (account && account.createAtNetwork) {
+            const addressKey = accountUtils.buildAccountLocalAssetsKey({
+              networkId: account.createAtNetwork,
+              accountAddress: account.address,
+              xpub: (account as { xpub?: string }).xpub,
+            });
+            byAddress[addressKey] = { value: entry.value, currency: 'usd' };
+          } else {
+            failures.push(oldKey);
+          }
+        } catch {
           failures.push(oldKey);
-          continue;
         }
-        const networkId = account.createAtNetwork;
-        if (!networkId) {
-          failures.push(oldKey);
-          continue;
-        }
-        const addressKey = accountUtils.buildAccountLocalAssetsKey({
-          networkId,
-          accountAddress: account.address,
-          xpub: (account as { xpub?: string }).xpub,
-        });
-        byAddress[addressKey] = { value: entry.value, currency: 'usd' };
-      } catch {
-        failures.push(oldKey);
       }
     }
 
     for (const [oldKey, entry] of Object.entries(legacyAll)) {
-      if (entry?.currency !== 'usd') continue;
-      try {
-        if (accountUtils.isOthersAccount({ accountId: oldKey })) {
+      if (entry?.currency !== 'usd') {
+        // skip: unknown currency leaves no safe migration path
+      } else if (accountUtils.isOthersAccount({ accountId: oldKey })) {
+        try {
           const account = await serviceAccount.getDBAccount({
             accountId: oldKey,
           });
-          if (!account || (!account.address && !(account as { xpub?: string }).xpub)) {
+          const xpub = account
+            ? (account as { xpub?: string }).xpub
+            : undefined;
+          if (account && (account.address || xpub)) {
+            const addressKey = accountUtils.buildAccountLocalAssetsKey({
+              accountAddress: account.address,
+              xpub,
+            });
+            allByAddress[addressKey] = {
+              value: {
+                ...allByAddress[addressKey]?.value,
+                ...entry.value,
+              },
+              currency: 'usd',
+            };
+          } else {
             failures.push(oldKey);
-            continue;
           }
-          const addressKey = accountUtils.buildAccountLocalAssetsKey({
-            accountAddress: account.address,
-            xpub: (account as { xpub?: string }).xpub,
-          });
-          allByAddress[addressKey] = {
-            value: {
-              ...(allByAddress[addressKey]?.value ?? {}),
-              ...entry.value,
-            },
-            currency: 'usd',
-          };
-        } else {
-          for (const [networkId, v] of Object.entries(entry.value)) {
-            try {
-              const result =
-                await serviceAccount.getNetworkAccountsInSameIndexedAccountId({
-                  indexedAccountId: oldKey,
-                  networkIds: [networkId],
-                });
-              const networkAccount = result?.[0]?.account;
-              if (!networkAccount) {
-                failures.push(`${oldKey}/${networkId}`);
-                continue;
-              }
+        } catch {
+          failures.push(oldKey);
+        }
+      } else {
+        for (const [networkId, v] of Object.entries(entry.value)) {
+          try {
+            const result =
+              await serviceAccount.getNetworkAccountsInSameIndexedAccountId({
+                indexedAccountId: oldKey,
+                networkIds: [networkId],
+              });
+            const networkAccount = result?.[0]?.account;
+            if (networkAccount) {
               const addressKey = accountUtils.buildAccountLocalAssetsKey({
                 accountAddress: networkAccount.address,
                 xpub: (networkAccount as { xpub?: string }).xpub,
               });
               allByAddress[addressKey] = {
                 value: {
-                  ...(allByAddress[addressKey]?.value ?? {}),
+                  ...allByAddress[addressKey]?.value,
                   [networkId]: v,
                 },
                 currency: 'usd',
               };
-            } catch {
+            } else {
               failures.push(`${oldKey}/${networkId}`);
             }
+          } catch {
+            failures.push(`${oldKey}/${networkId}`);
           }
         }
-      } catch {
-        failures.push(oldKey);
       }
     }
 

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts
@@ -343,7 +343,7 @@ export class SimpleDbEntityAccountValue extends SimpleDbEntityBase<IAccountValue
               const existing = allByAddress[addressKey];
               allByAddress[addressKey] = {
                 value: {
-                  ...(existing?.value ?? {}),
+                  ...existing?.value,
                   [parsed.networkId]: worth,
                 },
                 currency: 'usd',

--- a/packages/kit-bg/src/services/ServiceAccountProfile.ts
+++ b/packages/kit-bg/src/services/ServiceAccountProfile.ts
@@ -1044,19 +1044,21 @@ class ServiceAccountProfile extends ServiceBase {
       const parsed = accountUtils.parseAccountValueKey({
         key: accountValueKey,
       });
-      if (!parsed.accountId || !parsed.networkId) continue;
-      const resolved = await this.resolveAddressKey({
-        accountId: parsed.accountId,
-        networkId: parsed.networkId,
-      });
-      atomValueByNetworkId[parsed.networkId] = usdValue;
-      if (!resolved) continue;
-      writeItems.push({
-        accountAddress: resolved.accountAddress,
-        xpub: resolved.xpub,
-        networkId: parsed.networkId,
-        value: usdValue,
-      });
+      if (parsed.accountId && parsed.networkId) {
+        const resolved = await this.resolveAddressKey({
+          accountId: parsed.accountId,
+          networkId: parsed.networkId,
+        });
+        atomValueByNetworkId[parsed.networkId] = usdValue;
+        if (resolved) {
+          writeItems.push({
+            accountAddress: resolved.accountAddress,
+            xpub: resolved.xpub,
+            networkId: parsed.networkId,
+            value: usdValue,
+          });
+        }
+      }
     }
 
     if (updateAll) {
@@ -1072,7 +1074,7 @@ class ServiceAccountProfile extends ServiceBase {
         typeof current.value === 'object' &&
         current.value !== null
           ? {
-              ...(current.value as Record<string, string>),
+              ...current.value,
               ...atomValueByNetworkId,
             }
           : atomValueByNetworkId;
@@ -1155,14 +1157,16 @@ class ServiceAccountProfile extends ServiceBase {
       const seen = new Set<string>();
       for (const acc of dbAccounts ?? []) {
         const xpub = (acc as IDBUtxoAccount).xpub;
-        if (!acc.address && !xpub) continue;
-        const ak = accountUtils.buildAccountLocalAssetsKey({
-          accountAddress: acc.address,
-          xpub,
-        });
-        if (seen.has(ak)) continue;
-        seen.add(ak);
-        items.push({ accountAddress: acc.address, xpub });
+        if (acc.address || xpub) {
+          const ak = accountUtils.buildAccountLocalAssetsKey({
+            accountAddress: acc.address,
+            xpub,
+          });
+          if (!seen.has(ak)) {
+            seen.add(ak);
+            items.push({ accountAddress: acc.address, xpub });
+          }
+        }
       }
 
       if (items.length === 0) {

--- a/packages/kit-bg/src/services/ServiceAccountProfile.ts
+++ b/packages/kit-bg/src/services/ServiceAccountProfile.ts
@@ -46,7 +46,7 @@ import { vaultFactory } from '../vaults/factory';
 
 import ServiceBase from './ServiceBase';
 
-import type { IDBUtxoAccount } from '../dbs/local/types';
+import type { IDBAccount, IDBUtxoAccount } from '../dbs/local/types';
 import type BTCVault from '../vaults/impls/btc/Vault';
 
 // Shape of `/wallet/v1/account/badges` response after local mapping.
@@ -61,6 +61,24 @@ type IAccountBadgeResult = {
   badges: IAddressBadge[];
   similarAddress?: string;
 };
+
+// Address-keyed storage hashes by xpub (or address). On the write path, the
+// BTC vault returns `xpubSegwit || xpub` from `getAccountXpub`, so nested-segwit
+// (P2SH-P2WPKH) entries land under `xpubSegwit`. Readers that look up DBAccounts
+// directly must use the same precedence; reading raw `.xpub` instead would miss
+// nested-segwit derive types and the chain selector / account selector would
+// show a total $X.XX below the live main view.
+function pickAccountXpubForAssetsKey(
+  account:
+    | IDBAccount
+    | { xpub?: string; xpubSegwit?: string }
+    | undefined
+    | null,
+): string | undefined {
+  if (!account) return undefined;
+  const a = account as { xpub?: string; xpubSegwit?: string };
+  return a.xpubSegwit || a.xpub;
+}
 
 function emptyAccountBadgeResult(): IAccountBadgeResult {
   return {
@@ -1157,7 +1175,7 @@ class ServiceAccountProfile extends ServiceBase {
       const items: { accountAddress?: string; xpub?: string }[] = [];
       const seen = new Set<string>();
       for (const acc of dbAccounts ?? []) {
-        const xpub = (acc as IDBUtxoAccount).xpub;
+        const xpub = pickAccountXpubForAssetsKey(acc);
         if (acc.address || xpub) {
           const ak = accountUtils.buildAccountLocalAssetsKey({
             accountAddress: acc.address,
@@ -1305,7 +1323,7 @@ class ServiceAccountProfile extends ServiceBase {
           await this.backgroundApi.serviceAccount.getDBAccountSafe({
             accountId,
           });
-        const xpub = account ? (account as IDBUtxoAccount).xpub : undefined;
+        const xpub = pickAccountXpubForAssetsKey(account);
         if (!account || (!account.address && !xpub)) {
           return empty;
         }
@@ -1338,7 +1356,7 @@ class ServiceAccountProfile extends ServiceBase {
         xpub?: string;
       }[] = [];
       for (const acc of dbAccounts ?? []) {
-        const xpub = (acc as IDBUtxoAccount).xpub;
+        const xpub = pickAccountXpubForAssetsKey(acc);
         if (acc.address || xpub) {
           items.push({
             dbAccountId: acc.id,

--- a/packages/kit-bg/src/services/ServiceAccountProfile.ts
+++ b/packages/kit-bg/src/services/ServiceAccountProfile.ts
@@ -957,124 +957,367 @@ class ServiceAccountProfile extends ServiceBase {
     return resp.data.data as T;
   }
 
+  // Resolve a (accountId, networkId) to its on-chain identifiers used as
+  // the SimpleDb key. Returns null when either lookup fails so callers can
+  // skip the write/read gracefully.
+  private async resolveAddressKey({
+    accountId,
+    networkId,
+  }: {
+    accountId: string;
+    networkId: string;
+  }): Promise<{ accountAddress?: string; xpub?: string } | null> {
+    try {
+      const [xpub, accountAddress] = await Promise.all([
+        this.backgroundApi.serviceAccount.getAccountXpub({
+          accountId,
+          networkId,
+        }),
+        this.backgroundApi.serviceAccount.getAccountAddressForApi({
+          accountId,
+          networkId,
+        }),
+      ]);
+      if (!xpub && !accountAddress) {
+        return null;
+      }
+      return { accountAddress, xpub };
+    } catch {
+      return null;
+    }
+  }
+
+  private async convertOneToUsd(value: string, currency: string) {
+    if (currency === 'usd') return value;
+    const currencyMap = (await currencyPersistAtom.get()).currencyMap;
+    const info = currencyMap[currency];
+    if (!info) {
+      throw new OneKeyLocalError('Currency not found');
+    }
+    return new BigNumber(value).div(new BigNumber(info.value)).toFixed();
+  }
+
+  private async convertMapToUsd(
+    value: Record<string, string>,
+    currency: string,
+  ): Promise<Record<string, string>> {
+    if (currency === 'usd') return value;
+    const currencyMap = (await currencyPersistAtom.get()).currencyMap;
+    const info = currencyMap[currency];
+    if (!info) {
+      throw new OneKeyLocalError('Currency not found');
+    }
+    return Object.entries(value).reduce<Record<string, string>>(
+      (acc, [k, v]) => {
+        acc[k] = new BigNumber(v).div(new BigNumber(info.value)).toFixed();
+        return acc;
+      },
+      {},
+    );
+  }
+
   @backgroundMethod()
   async updateAllNetworkAccountValue(params: {
     accountId: string;
+    // Record<accountValueKey, value> where accountValueKey = `${networkAccount.id}_${networkId}`,
+    // produced by accountUtils.buildAccountValueKey in UI layer.
     value: Record<string, string>;
     currency: string;
     updateAll?: boolean;
   }) {
-    const { currency, value, updateAll } = params;
+    const { currency, value, updateAll, accountId } = params;
 
-    const currencyMap = (await currencyPersistAtom.get()).currencyMap;
+    const usdValueMap = await this.convertMapToUsd(value, currency);
 
-    let usdValue: Record<string, string> = value;
+    // Parse each accountValueKey back to (networkAccountId, networkId), resolve
+    // the chain identifiers, and collect both the SimpleDb write items and a
+    // per-networkId atom snapshot.
+    const writeItems: {
+      accountAddress?: string;
+      xpub?: string;
+      networkId: string;
+      value: string;
+    }[] = [];
+    const atomValueByNetworkId: Record<string, string> = {};
 
-    if (currency !== 'usd') {
-      const currencyInfo = currencyMap[currency];
-
-      if (!currencyInfo) {
-        throw new OneKeyLocalError('Currency not found');
-      }
-      usdValue = Object.entries(value).reduce(
-        (acc, [n, v]) => {
-          acc[n] = new BigNumber(v)
-            .div(new BigNumber(currencyInfo.value))
-            .toFixed();
-          return acc;
-        },
-        {} as Record<string, string>,
-      );
-    }
-
-    const usdAccountValue = {
-      ...params,
-      value: usdValue,
-      currency: 'usd',
-    };
-
-    if (updateAll) {
-      await activeAccountValueAtom.set(usdAccountValue);
-    } else {
-      const accountsValue =
-        await simpleDb.accountValue.getAllNetworkAccountsValue({
-          accounts: [{ accountId: params.accountId }],
-        });
-      const currentAccountValue = accountsValue?.[0];
-      if (currentAccountValue?.accountId !== params.accountId) {
-        return;
-      }
-
-      await activeAccountValueAtom.set({
-        ...usdAccountValue,
-        value: {
-          ...currentAccountValue.value,
-          ...usdValue,
-        },
+    for (const [accountValueKey, usdValue] of Object.entries(usdValueMap)) {
+      const parsed = accountUtils.parseAccountValueKey({
+        key: accountValueKey,
+      });
+      if (!parsed.accountId || !parsed.networkId) continue;
+      const resolved = await this.resolveAddressKey({
+        accountId: parsed.accountId,
+        networkId: parsed.networkId,
+      });
+      atomValueByNetworkId[parsed.networkId] = usdValue;
+      if (!resolved) continue;
+      writeItems.push({
+        accountAddress: resolved.accountAddress,
+        xpub: resolved.xpub,
+        networkId: parsed.networkId,
+        value: usdValue,
       });
     }
 
-    await simpleDb.accountValue.updateAllNetworkAccountValue(usdAccountValue);
+    if (updateAll) {
+      await activeAccountValueAtom.set({
+        accountId,
+        value: atomValueByNetworkId,
+        currency: 'usd',
+      });
+    } else {
+      const current = await activeAccountValueAtom.get();
+      const mergedAtomValue =
+        current?.accountId === accountId &&
+        typeof current.value === 'object' &&
+        current.value !== null
+          ? {
+              ...(current.value as Record<string, string>),
+              ...atomValueByNetworkId,
+            }
+          : atomValueByNetworkId;
+      await activeAccountValueAtom.set({
+        accountId,
+        value: mergedAtomValue,
+        currency: 'usd',
+      });
+    }
+
+    await simpleDb.accountValue.updateAllNetworkAccountValue({
+      items: writeItems,
+      currency: 'usd',
+      updateAll,
+    });
 
     // Check DEPOSIT task for rookie guide (fire-and-forget)
     void this.backgroundApi.serviceRookieGuide.checkAndRecordDepositTask(
-      params.accountId,
+      accountId,
     );
   }
 
   @backgroundMethod()
   async getAllNetworkAccountsValue(params: {
-    accounts: { accountId: string }[];
+    accounts: {
+      accountId: string;
+      networkId?: string;
+      indexedAccountId?: string;
+      accountAddress?: string;
+      xpub?: string;
+    }[];
   }) {
-    const accountsValue =
-      await simpleDb.accountValue.getAllNetworkAccountsValue(params);
-    return accountsValue;
+    const items = await Promise.all(
+      params.accounts.map(async (a) => {
+        if (a.accountAddress || a.xpub) {
+          return { accountAddress: a.accountAddress, xpub: a.xpub };
+        }
+        if (a.networkId) {
+          const resolved = await this.resolveAddressKey({
+            accountId: a.accountId,
+            networkId: a.networkId,
+          });
+          if (resolved) {
+            return {
+              accountAddress: resolved.accountAddress,
+              xpub: resolved.xpub,
+            };
+          }
+        }
+        return {} as { accountAddress?: string; xpub?: string };
+      }),
+    );
+
+    const values = await simpleDb.accountValue.getAllNetworkAccountsValue({
+      items,
+    });
+
+    return params.accounts.map((a, i) => ({
+      accountId: a.accountId,
+      value: values[i]?.value,
+      currency: values[i]?.currency,
+    }));
+  }
+
+  // Aggregate "All Networks" worth for a single indexedAccount when the caller
+  // does not already know each network's address — used by global search where
+  // only indexedAccountId is available.
+  @backgroundMethod()
+  async getAllNetworkAccountsValueByIndexedAccount(params: {
+    indexedAccountId: string;
+  }) {
+    const { indexedAccountId } = params;
+    try {
+      const { accounts: dbAccounts } =
+        await this.backgroundApi.serviceAccount.getAccountsInSameIndexedAccountId(
+          { indexedAccountId },
+        );
+
+      const items: { accountAddress?: string; xpub?: string }[] = [];
+      const seen = new Set<string>();
+      for (const acc of dbAccounts ?? []) {
+        const xpub = (acc as IDBUtxoAccount).xpub;
+        if (!acc.address && !xpub) continue;
+        const ak = accountUtils.buildAccountLocalAssetsKey({
+          accountAddress: acc.address,
+          xpub,
+        });
+        if (seen.has(ak)) continue;
+        seen.add(ak);
+        items.push({ accountAddress: acc.address, xpub });
+      }
+
+      if (items.length === 0) {
+        return {
+          accountId: indexedAccountId,
+          value: undefined,
+          currency: undefined,
+        };
+      }
+
+      const entries = await simpleDb.accountValue.getAllNetworkAccountsValue({
+        items,
+      });
+
+      const mergedValue: Record<string, string> = {};
+      let currency: 'usd' | undefined;
+      for (const entry of entries) {
+        if (entry?.value) {
+          Object.assign(mergedValue, entry.value);
+          currency = entry.currency;
+        }
+      }
+
+      if (Object.keys(mergedValue).length === 0) {
+        return {
+          accountId: indexedAccountId,
+          value: undefined,
+          currency: undefined,
+        };
+      }
+
+      return {
+        accountId: indexedAccountId,
+        value: mergedValue,
+        currency,
+      };
+    } catch {
+      return {
+        accountId: indexedAccountId,
+        value: undefined,
+        currency: undefined,
+      };
+    }
   }
 
   @backgroundMethod()
-  async getAccountsValue(params: { accounts: { accountId: string }[] }) {
-    const accountsValue = await simpleDb.accountValue.getAccountsValue(params);
-    return accountsValue;
+  async getAccountsValue(params: {
+    accounts: {
+      accountId: string;
+      networkId: string;
+      accountAddress?: string;
+      xpub?: string;
+    }[];
+  }) {
+    const items = await Promise.all(
+      params.accounts.map(async (a) => {
+        if (a.accountAddress || a.xpub) {
+          return {
+            networkId: a.networkId,
+            accountAddress: a.accountAddress,
+            xpub: a.xpub,
+          };
+        }
+        const resolved = await this.resolveAddressKey({
+          accountId: a.accountId,
+          networkId: a.networkId,
+        });
+        if (resolved) {
+          return {
+            networkId: a.networkId,
+            accountAddress: resolved.accountAddress,
+            xpub: resolved.xpub,
+          };
+        }
+        return { networkId: a.networkId };
+      }),
+    );
+
+    const values = await simpleDb.accountValue.getAccountsValue({ items });
+
+    return params.accounts.map((a, i) => ({
+      accountId: a.accountId,
+      value: values[i]?.value,
+      currency: values[i]?.currency,
+    }));
   }
 
   @backgroundMethod()
   async updateAccountValue(params: {
+    // The logical account id used for the activeAccountValueAtom snapshot — it
+    // is indexedAccountId for HD/HW wallets and account.id for Others, matching
+    // the keying convention used by the account selector.
     accountId: string;
+    // The network-specific account id (always account.id of the active
+    // networkAccount), used to resolve the chain address/xpub for SimpleDb.
+    // Defaults to `accountId` (correct for Others accounts).
+    networkAccountId?: string;
+    networkId: string;
     value: string;
     currency: string;
     shouldUpdateActiveAccountValue?: boolean;
   }) {
     if (params.shouldUpdateActiveAccountValue) {
-      await activeAccountValueAtom.set(params);
+      await activeAccountValueAtom.set({
+        accountId: params.accountId,
+        value: params.value,
+        currency: params.currency,
+      });
     }
 
-    await simpleDb.accountValue.updateAccountValue(params);
+    const usdValue = await this.convertOneToUsd(params.value, params.currency);
+    const resolved = await this.resolveAddressKey({
+      accountId: params.networkAccountId ?? params.accountId,
+      networkId: params.networkId,
+    });
+    if (!resolved) return;
+
+    await simpleDb.accountValue.updateAccountValue({
+      networkId: params.networkId,
+      accountAddress: resolved.accountAddress,
+      xpub: resolved.xpub,
+      value: usdValue,
+      currency: 'usd',
+    });
   }
 
   @backgroundMethod()
   async updateAccountValueForSingleNetwork(params: {
     accountId: string;
+    networkAccountId?: string;
+    networkId: string;
     value: string;
     currency: string;
   }) {
-    const accountsValue = await simpleDb.accountValue.getAccountsValue({
-      accounts: [{ accountId: params.accountId }],
+    const resolved = await this.resolveAddressKey({
+      accountId: params.networkAccountId ?? params.accountId,
+      networkId: params.networkId,
     });
-    const currentAccountValue = accountsValue?.[0];
-    if (currentAccountValue?.accountId !== params.accountId) {
-      return;
-    }
+    if (!resolved) return;
+
+    const [existing] = await simpleDb.accountValue.getAccountsValue({
+      items: [
+        {
+          networkId: params.networkId,
+          accountAddress: resolved.accountAddress,
+          xpub: resolved.xpub,
+        },
+      ],
+    });
+
+    const usdValue = await this.convertOneToUsd(params.value, params.currency);
     if (
-      currentAccountValue?.currency &&
-      params.currency &&
-      currentAccountValue?.currency !== params.currency
-    ) {
-      return;
-    }
-    if (
-      currentAccountValue?.value &&
-      params.value &&
-      new BigNumber(params.value).lte(currentAccountValue.value)
+      existing?.value &&
+      usdValue &&
+      new BigNumber(usdValue).lte(existing.value)
     ) {
       return;
     }

--- a/packages/kit-bg/src/services/ServiceAccountProfile.ts
+++ b/packages/kit-bg/src/services/ServiceAccountProfile.ts
@@ -1029,16 +1029,18 @@ class ServiceAccountProfile extends ServiceBase {
 
     const usdValueMap = await this.convertMapToUsd(value, currency);
 
-    // Parse each accountValueKey back to (networkAccountId, networkId), resolve
-    // the chain identifiers, and collect both the SimpleDb write items and a
-    // per-networkId atom snapshot.
+    // Parse each accountValueKey back to (networkAccountId, networkId) only to
+    // resolve the chain identifiers for the SimpleDb write. The atom snapshot
+    // stays in the original compound-key shape `Record<${networkAccountId}_${networkId}, worth>`
+    // because `AccountValue.tsx` / `calculateAccountTotalValue` look it up via
+    // `buildAccountValueKey(accountId, networkId)` — replacing it with a
+    // per-networkId map would silently break the active-account row display.
     const writeItems: {
       accountAddress?: string;
       xpub?: string;
       networkId: string;
       value: string;
     }[] = [];
-    const atomValueByNetworkId: Record<string, string> = {};
 
     for (const [accountValueKey, usdValue] of Object.entries(usdValueMap)) {
       const parsed = accountUtils.parseAccountValueKey({
@@ -1049,7 +1051,6 @@ class ServiceAccountProfile extends ServiceBase {
           accountId: parsed.accountId,
           networkId: parsed.networkId,
         });
-        atomValueByNetworkId[parsed.networkId] = usdValue;
         if (resolved) {
           writeItems.push({
             accountAddress: resolved.accountAddress,
@@ -1064,7 +1065,7 @@ class ServiceAccountProfile extends ServiceBase {
     if (updateAll) {
       await activeAccountValueAtom.set({
         accountId,
-        value: atomValueByNetworkId,
+        value: usdValueMap,
         currency: 'usd',
       });
     } else {
@@ -1075,9 +1076,9 @@ class ServiceAccountProfile extends ServiceBase {
         current.value !== null
           ? {
               ...current.value,
-              ...atomValueByNetworkId,
+              ...usdValueMap,
             }
-          : atomValueByNetworkId;
+          : usdValueMap;
       await activeAccountValueAtom.set({
         accountId,
         value: mergedAtomValue,
@@ -1181,11 +1182,21 @@ class ServiceAccountProfile extends ServiceBase {
         items,
       });
 
+      // Sum (not overwrite) per networkId across entries. Multiple address-keyed
+      // entries under one indexed account commonly share a networkId — e.g. BTC
+      // native / nested / taproot all writing to `btc--0--0` from different
+      // xpubs — so the aggregate must add them, not pick whichever was iterated
+      // last.
       const mergedValue: Record<string, string> = {};
       let currency: 'usd' | undefined;
       for (const entry of entries) {
         if (entry?.value) {
-          Object.assign(mergedValue, entry.value);
+          for (const [nId, v] of Object.entries(entry.value)) {
+            const prev = mergedValue[nId];
+            mergedValue[nId] = prev
+              ? new BigNumber(prev).plus(v ?? '0').toFixed()
+              : v;
+          }
           currency = entry.currency;
         }
       }
@@ -1209,6 +1220,165 @@ class ServiceAccountProfile extends ServiceBase {
         value: undefined,
         currency: undefined,
       };
+    }
+  }
+
+  // Address-search result flow.
+  //
+  // Returns the worth at a specific (accountAddress, xpub) pair, shaped as
+  // `Record<${networkAccountId}_${networkId}, value>` using the caller-supplied
+  // `networkAccountId` as the compound-key prefix. The underlying SimpleDb
+  // entry is keyed only by (address, xpub), so multiple wallets that share a
+  // chain address read the same entry and see the same per-network worth —
+  // the per-wallet prefix only changes the emitted compound key, not the
+  // worth values themselves. Use this for global-search address rows where
+  // each row must show the worth at *that exact address*, not the whole
+  // indexed account.
+  @backgroundMethod()
+  async getAllNetworkAccountsValueByAddress(params: {
+    networkAccountId: string;
+    accountAddress?: string;
+    xpub?: string;
+  }) {
+    const { networkAccountId, accountAddress, xpub } = params;
+    const empty = {
+      accountId: networkAccountId,
+      value: undefined as Record<string, string> | undefined,
+      currency: undefined as 'usd' | undefined,
+    };
+    if (!accountAddress && !xpub) {
+      return empty;
+    }
+    try {
+      const [entry] = await simpleDb.accountValue.getAllNetworkAccountsValue({
+        items: [{ accountAddress, xpub }],
+      });
+      if (!entry?.value || Object.keys(entry.value).length === 0) {
+        return empty;
+      }
+      const value: Record<string, string> = {};
+      for (const [networkId, v] of Object.entries(entry.value)) {
+        const compoundKey = accountUtils.buildAccountValueKey({
+          accountId: networkAccountId,
+          networkId,
+        });
+        value[compoundKey] = v;
+      }
+      return { accountId: networkAccountId, value, currency: entry.currency };
+    } catch {
+      return empty;
+    }
+  }
+
+  // Chain selector / network selector flow.
+  //
+  // Returns the per-network worth for a logical account using the legacy
+  // compound-key shape `Record<${networkAccountId}_${networkId}, value>` so
+  // existing consumers — both `ServiceNetwork.sortChainSelectorNetworksByValue`
+  // and the inline parser in `ChainSelector.tsx` — keep working unchanged.
+  //
+  // Routes by accountId:
+  //   - Others account: looks up the single (address, xpub) entry. Emits
+  //     compound keys with the Others accountId as the prefix, matching the
+  //     pre-migration write shape from `HomeOverviewContainer`.
+  //   - Indexed (HD/HW): walks every DBAccount under the indexedAccountId,
+  //     loads its address-keyed entry, and emits one compound key per
+  //     (dbAccount.id, networkId). Multiple derive types under one indexed
+  //     account each produce their own compound keys — `sortChainSelectorNetworksByValue`
+  //     uses that to honor the global deriveType filter (or merge-derive-assets,
+  //     or Others) just like before.
+  @backgroundMethod()
+  async getAllNetworkAccountsValueByAccountId(params: { accountId: string }) {
+    const { accountId } = params;
+    const empty = {
+      accountId,
+      value: undefined as Record<string, string> | undefined,
+      currency: undefined as 'usd' | undefined,
+    };
+    if (!accountId) {
+      return empty;
+    }
+
+    try {
+      if (accountUtils.isOthersAccount({ accountId })) {
+        const account =
+          await this.backgroundApi.serviceAccount.getDBAccountSafe({
+            accountId,
+          });
+        const xpub = account ? (account as IDBUtxoAccount).xpub : undefined;
+        if (!account || (!account.address && !xpub)) {
+          return empty;
+        }
+        const [entry] = await simpleDb.accountValue.getAllNetworkAccountsValue({
+          items: [{ accountAddress: account.address, xpub }],
+        });
+        if (!entry?.value || Object.keys(entry.value).length === 0) {
+          return empty;
+        }
+        const value: Record<string, string> = {};
+        for (const [networkId, v] of Object.entries(entry.value)) {
+          const compoundKey = accountUtils.buildAccountValueKey({
+            accountId,
+            networkId,
+          });
+          value[compoundKey] = v;
+        }
+        return { accountId, value, currency: entry.currency };
+      }
+
+      // HD/HW indexed account path.
+      const { accounts: dbAccounts } =
+        await this.backgroundApi.serviceAccount.getAccountsInSameIndexedAccountId(
+          { indexedAccountId: accountId },
+        );
+
+      const items: {
+        dbAccountId: string;
+        accountAddress?: string;
+        xpub?: string;
+      }[] = [];
+      for (const acc of dbAccounts ?? []) {
+        const xpub = (acc as IDBUtxoAccount).xpub;
+        if (acc.address || xpub) {
+          items.push({
+            dbAccountId: acc.id,
+            accountAddress: acc.address,
+            xpub,
+          });
+        }
+      }
+      if (items.length === 0) {
+        return empty;
+      }
+
+      const entries = await simpleDb.accountValue.getAllNetworkAccountsValue({
+        items: items.map((i) => ({
+          accountAddress: i.accountAddress,
+          xpub: i.xpub,
+        })),
+      });
+
+      const value: Record<string, string> = {};
+      let currency: 'usd' | undefined;
+      entries.forEach((entry, idx) => {
+        if (!entry?.value) return;
+        const dbAccountId = items[idx].dbAccountId;
+        for (const [networkId, v] of Object.entries(entry.value)) {
+          const compoundKey = accountUtils.buildAccountValueKey({
+            accountId: dbAccountId,
+            networkId,
+          });
+          value[compoundKey] = v;
+        }
+        currency = entry.currency;
+      });
+
+      if (Object.keys(value).length === 0) {
+        return empty;
+      }
+      return { accountId, value, currency };
+    } catch {
+      return empty;
     }
   }
 

--- a/packages/kit-bg/src/services/ServiceAccountProfile.ts
+++ b/packages/kit-bg/src/services/ServiceAccountProfile.ts
@@ -1268,6 +1268,148 @@ class ServiceAccountProfile extends ServiceBase {
     }
   }
 
+  // Batched variant of `getAllNetworkAccountsValueByAccountId` for callers
+  // like the account selector that resolve worth for tens of accounts at a
+  // time. Folds the per-account `simpleDb.accountValue.getAllNetworkAccountsValue`
+  // call into a single read (the SimpleDb entity has caching disabled, so
+  // each per-account call previously paid a fresh storage deserialization).
+  @backgroundMethod()
+  async getAllNetworkAccountsValueByAccountIdBatch(params: {
+    accounts: {
+      accountId: string;
+      accountAddress?: string;
+      xpub?: string;
+    }[];
+  }): Promise<
+    Array<{
+      accountId: string;
+      value: Record<string, string> | undefined;
+      currency: 'usd' | undefined;
+    }>
+  > {
+    const { accounts } = params;
+    if (!accounts.length) return [];
+
+    type IResolved = {
+      ownerAccountId: string;
+      // Account id used as the compound-key prefix. For Others, this is the
+      // owner accountId; for HD, it is the per-derive dbAccount.id so the
+      // deriveType filter and merge-derive-assets paths keep working.
+      compoundKeyAccountId: string;
+      accountAddress?: string;
+      xpub?: string;
+    };
+    const resolved: IResolved[] = [];
+
+    await Promise.all(
+      accounts.map(async (a) => {
+        if (!a.accountId) return;
+        try {
+          if (accountUtils.isOthersAccount({ accountId: a.accountId })) {
+            // Others: reuse pre-resolved address/xpub if upstream supplied
+            // it, otherwise fetch the dbAccount once.
+            if (a.accountAddress || a.xpub) {
+              resolved.push({
+                ownerAccountId: a.accountId,
+                compoundKeyAccountId: a.accountId,
+                accountAddress: a.accountAddress,
+                xpub: a.xpub,
+              });
+              return;
+            }
+            const acc =
+              await this.backgroundApi.serviceAccount.getDBAccountSafe({
+                accountId: a.accountId,
+              });
+            const xpub = accountUtils.pickXpubFromDBAccount(acc);
+            if (acc && (acc.address || xpub)) {
+              resolved.push({
+                ownerAccountId: a.accountId,
+                compoundKeyAccountId: a.accountId,
+                accountAddress: acc.address,
+                xpub,
+              });
+            }
+            return;
+          }
+
+          // HD/HW indexed account: expand to all derives so ChainSelector
+          // can use per-derive compound keys.
+          const { accounts: dbAccountsList } =
+            await this.backgroundApi.serviceAccount.getAccountsInSameIndexedAccountId(
+              { indexedAccountId: a.accountId },
+            );
+          for (const dbAcc of dbAccountsList ?? []) {
+            const xpub = accountUtils.pickXpubFromDBAccount(dbAcc);
+            if (dbAcc.address || xpub) {
+              resolved.push({
+                ownerAccountId: a.accountId,
+                compoundKeyAccountId: dbAcc.id,
+                accountAddress: dbAcc.address,
+                xpub,
+              });
+            }
+          }
+        } catch {
+          // Skip this account; its slot in the result will fall back to
+          // the empty shape below.
+        }
+      }),
+    );
+
+    if (resolved.length === 0) {
+      return accounts.map((a) => ({
+        accountId: a.accountId,
+        value: undefined,
+        currency: undefined,
+      }));
+    }
+
+    // Single SimpleDb read for the whole batch.
+    const entries = await simpleDb.accountValue.getAllNetworkAccountsValue({
+      items: resolved.map((r) => ({
+        accountAddress: r.accountAddress,
+        xpub: r.xpub,
+      })),
+    });
+
+    const grouped = new Map<
+      string,
+      { value: Record<string, string>; currency?: 'usd' }
+    >();
+    resolved.forEach((r, i) => {
+      const entry = entries[i];
+      if (!entry?.value) return;
+      let agg = grouped.get(r.ownerAccountId);
+      if (!agg) {
+        agg = { value: {} };
+        grouped.set(r.ownerAccountId, agg);
+      }
+      for (const [nId, v] of Object.entries(entry.value)) {
+        const compoundKey = accountUtils.buildAccountValueKey({
+          accountId: r.compoundKeyAccountId,
+          networkId: nId,
+        });
+        agg.value[compoundKey] = v;
+      }
+      agg.currency = entry.currency;
+    });
+
+    return accounts.map((a) => {
+      const g = grouped.get(a.accountId);
+      const hasValue = g && Object.keys(g.value).length > 0;
+      return {
+        accountId: a.accountId,
+        value: hasValue ? g.value : undefined,
+        currency: g?.currency,
+      } as {
+        accountId: string;
+        value: Record<string, string> | undefined;
+        currency: 'usd' | undefined;
+      };
+    });
+  }
+
   // Returns per-network worth for a logical account in the compound-key shape
   // `Record<${networkAccountId}_${networkId}, value>` consumed by
   // `sortChainSelectorNetworksByValue` and `ChainSelector.tsx`. For HD/HW the

--- a/packages/kit-bg/src/services/ServiceAccountProfile.ts
+++ b/packages/kit-bg/src/services/ServiceAccountProfile.ts
@@ -46,12 +46,9 @@ import { vaultFactory } from '../vaults/factory';
 
 import ServiceBase from './ServiceBase';
 
-import type { IDBAccount, IDBUtxoAccount } from '../dbs/local/types';
+import type { IDBUtxoAccount } from '../dbs/local/types';
 import type BTCVault from '../vaults/impls/btc/Vault';
 
-// Shape of `/wallet/v1/account/badges` response after local mapping.
-// Declared at module level so the xpub fan-out merge helper can be a
-// pure function (easier to test, no class coupling).
 type IAccountBadgeResult = {
   isScam: boolean;
   isContract: boolean;
@@ -61,24 +58,6 @@ type IAccountBadgeResult = {
   badges: IAddressBadge[];
   similarAddress?: string;
 };
-
-// Address-keyed storage hashes by xpub (or address). On the write path, the
-// BTC vault returns `xpubSegwit || xpub` from `getAccountXpub`, so nested-segwit
-// (P2SH-P2WPKH) entries land under `xpubSegwit`. Readers that look up DBAccounts
-// directly must use the same precedence; reading raw `.xpub` instead would miss
-// nested-segwit derive types and the chain selector / account selector would
-// show a total $X.XX below the live main view.
-function pickAccountXpubForAssetsKey(
-  account:
-    | IDBAccount
-    | { xpub?: string; xpubSegwit?: string }
-    | undefined
-    | null,
-): string | undefined {
-  if (!account) return undefined;
-  const a = account as { xpub?: string; xpubSegwit?: string };
-  return a.xpubSegwit || a.xpub;
-}
 
 function emptyAccountBadgeResult(): IAccountBadgeResult {
   return {
@@ -1047,38 +1026,46 @@ class ServiceAccountProfile extends ServiceBase {
 
     const usdValueMap = await this.convertMapToUsd(value, currency);
 
-    // Parse each accountValueKey back to (networkAccountId, networkId) only to
-    // resolve the chain identifiers for the SimpleDb write. The atom snapshot
-    // stays in the original compound-key shape `Record<${networkAccountId}_${networkId}, worth>`
-    // because `AccountValue.tsx` / `calculateAccountTotalValue` look it up via
-    // `buildAccountValueKey(accountId, networkId)` — replacing it with a
-    // per-networkId map would silently break the active-account row display.
-    const writeItems: {
+    // Atom snapshot stays in the compound-key shape because consumers look
+    // entries up via `buildAccountValueKey(accountId, networkId)`.
+    type IWriteItem = {
       accountAddress?: string;
       xpub?: string;
       networkId: string;
       value: string;
-    }[] = [];
-
-    for (const [accountValueKey, usdValue] of Object.entries(usdValueMap)) {
-      const parsed = accountUtils.parseAccountValueKey({
-        key: accountValueKey,
-      });
-      if (parsed.accountId && parsed.networkId) {
-        const resolved = await this.resolveAddressKey({
-          accountId: parsed.accountId,
-          networkId: parsed.networkId,
-        });
-        if (resolved) {
-          writeItems.push({
-            accountAddress: resolved.accountAddress,
-            xpub: resolved.xpub,
+    };
+    const resolveCache = new Map<
+      string,
+      Promise<{ accountAddress?: string; xpub?: string } | null>
+    >();
+    const resolved = await Promise.all(
+      Object.entries(usdValueMap).map<Promise<IWriteItem | null>>(
+        async ([accountValueKey, usdValue]) => {
+          const parsed = accountUtils.parseAccountValueKey({
+            key: accountValueKey,
+          });
+          if (!parsed.accountId || !parsed.networkId) return null;
+          const cacheKey = `${parsed.accountId}:${parsed.networkId}`;
+          let pending = resolveCache.get(cacheKey);
+          if (!pending) {
+            pending = this.resolveAddressKey({
+              accountId: parsed.accountId,
+              networkId: parsed.networkId,
+            });
+            resolveCache.set(cacheKey, pending);
+          }
+          const r = await pending;
+          if (!r) return null;
+          return {
+            accountAddress: r.accountAddress,
+            xpub: r.xpub,
             networkId: parsed.networkId,
             value: usdValue,
-          });
-        }
-      }
-    }
+          };
+        },
+      ),
+    );
+    const writeItems = resolved.filter((x): x is IWriteItem => x !== null);
 
     if (updateAll) {
       await activeAccountValueAtom.set({
@@ -1159,8 +1146,7 @@ class ServiceAccountProfile extends ServiceBase {
   }
 
   // Aggregate "All Networks" worth for a single indexedAccount when the caller
-  // does not already know each network's address — used by global search where
-  // only indexedAccountId is available.
+  // doesn't already know each network's address.
   @backgroundMethod()
   async getAllNetworkAccountsValueByIndexedAccount(params: {
     indexedAccountId: string;
@@ -1175,7 +1161,7 @@ class ServiceAccountProfile extends ServiceBase {
       const items: { accountAddress?: string; xpub?: string }[] = [];
       const seen = new Set<string>();
       for (const acc of dbAccounts ?? []) {
-        const xpub = pickAccountXpubForAssetsKey(acc);
+        const xpub = accountUtils.pickXpubFromDBAccount(acc);
         if (acc.address || xpub) {
           const ak = accountUtils.buildAccountLocalAssetsKey({
             accountAddress: acc.address,
@@ -1241,17 +1227,11 @@ class ServiceAccountProfile extends ServiceBase {
     }
   }
 
-  // Address-search result flow.
-  //
-  // Returns the worth at a specific (accountAddress, xpub) pair, shaped as
-  // `Record<${networkAccountId}_${networkId}, value>` using the caller-supplied
-  // `networkAccountId` as the compound-key prefix. The underlying SimpleDb
-  // entry is keyed only by (address, xpub), so multiple wallets that share a
-  // chain address read the same entry and see the same per-network worth —
-  // the per-wallet prefix only changes the emitted compound key, not the
-  // worth values themselves. Use this for global-search address rows where
-  // each row must show the worth at *that exact address*, not the whole
-  // indexed account.
+  // Returns worth for a specific (accountAddress, xpub) pair, shaped as
+  // `Record<${networkAccountId}_${networkId}, value>` with the caller-supplied
+  // `networkAccountId` as the compound-key prefix. SimpleDb entries are keyed
+  // only by (address, xpub), so identical-address rows from different wallets
+  // read the same entry; the per-wallet prefix only re-labels the output key.
   @backgroundMethod()
   async getAllNetworkAccountsValueByAddress(params: {
     networkAccountId: string;
@@ -1288,23 +1268,11 @@ class ServiceAccountProfile extends ServiceBase {
     }
   }
 
-  // Chain selector / network selector flow.
-  //
-  // Returns the per-network worth for a logical account using the legacy
-  // compound-key shape `Record<${networkAccountId}_${networkId}, value>` so
-  // existing consumers — both `ServiceNetwork.sortChainSelectorNetworksByValue`
-  // and the inline parser in `ChainSelector.tsx` — keep working unchanged.
-  //
-  // Routes by accountId:
-  //   - Others account: looks up the single (address, xpub) entry. Emits
-  //     compound keys with the Others accountId as the prefix, matching the
-  //     pre-migration write shape from `HomeOverviewContainer`.
-  //   - Indexed (HD/HW): walks every DBAccount under the indexedAccountId,
-  //     loads its address-keyed entry, and emits one compound key per
-  //     (dbAccount.id, networkId). Multiple derive types under one indexed
-  //     account each produce their own compound keys — `sortChainSelectorNetworksByValue`
-  //     uses that to honor the global deriveType filter (or merge-derive-assets,
-  //     or Others) just like before.
+  // Returns per-network worth for a logical account in the compound-key shape
+  // `Record<${networkAccountId}_${networkId}, value>` consumed by
+  // `sortChainSelectorNetworksByValue` and `ChainSelector.tsx`. For HD/HW the
+  // compound prefix is the per-derive `dbAccount.id` so the deriveType filter
+  // and merge-derive-assets paths keep working.
   @backgroundMethod()
   async getAllNetworkAccountsValueByAccountId(params: { accountId: string }) {
     const { accountId } = params;
@@ -1323,7 +1291,7 @@ class ServiceAccountProfile extends ServiceBase {
           await this.backgroundApi.serviceAccount.getDBAccountSafe({
             accountId,
           });
-        const xpub = pickAccountXpubForAssetsKey(account);
+        const xpub = accountUtils.pickXpubFromDBAccount(account);
         if (!account || (!account.address && !xpub)) {
           return empty;
         }
@@ -1356,7 +1324,7 @@ class ServiceAccountProfile extends ServiceBase {
         xpub?: string;
       }[] = [];
       for (const acc of dbAccounts ?? []) {
-        const xpub = pickAccountXpubForAssetsKey(acc);
+        const xpub = accountUtils.pickXpubFromDBAccount(acc);
         if (acc.address || xpub) {
           items.push({
             dbAccountId: acc.id,
@@ -1444,14 +1412,12 @@ class ServiceAccountProfile extends ServiceBase {
 
   @backgroundMethod()
   async updateAccountValue(params: {
-    // The logical account id used for the activeAccountValueAtom snapshot — it
-    // is indexedAccountId for HD/HW wallets and account.id for Others, matching
-    // the keying convention used by the account selector.
+    // Logical account id for the activeAccountValueAtom — indexedAccountId for
+    // HD/HW, account.id for Others (matches the account selector's keying).
     accountId: string;
-    // The network-specific account id (always account.id of the active
-    // networkAccount), used to resolve the chain address/xpub for SimpleDb.
-    // Defaults to `accountId` (correct for Others accounts).
-    networkAccountId?: string;
+    // The active networkAccount's account.id; required because HD/HW callers
+    // pass indexedAccountId as `accountId` which can't resolve a chain address.
+    networkAccountId: string;
     networkId: string;
     value: string;
     currency: string;
@@ -1467,7 +1433,7 @@ class ServiceAccountProfile extends ServiceBase {
 
     const usdValue = await this.convertOneToUsd(params.value, params.currency);
     const resolved = await this.resolveAddressKey({
-      accountId: params.networkAccountId ?? params.accountId,
+      accountId: params.networkAccountId,
       networkId: params.networkId,
     });
     if (!resolved) return;
@@ -1484,13 +1450,13 @@ class ServiceAccountProfile extends ServiceBase {
   @backgroundMethod()
   async updateAccountValueForSingleNetwork(params: {
     accountId: string;
-    networkAccountId?: string;
+    networkAccountId: string;
     networkId: string;
     value: string;
     currency: string;
   }) {
     const resolved = await this.resolveAddressKey({
-      accountId: params.networkAccountId ?? params.accountId,
+      accountId: params.networkAccountId,
       networkId: params.networkId,
     });
     if (!resolved) return;

--- a/packages/kit-bg/src/services/ServiceAccountSelector.ts
+++ b/packages/kit-bg/src/services/ServiceAccountSelector.ts
@@ -988,14 +988,21 @@ class ServiceAccountSelector extends ServiceBase {
       });
     // Compound-key shape consumed by `calculateAccountTotalValue`; the
     // per-address `getAllNetworkAccountsValue` would yield Record<networkId,
-    // worth> and silently miss every compound-key lookup downstream.
-    const accountsValue = await Promise.all(
-      accounts.map((a) =>
-        this.backgroundApi.serviceAccountProfile.getAllNetworkAccountsValueByAccountId(
-          { accountId: a.accountId },
-        ),
-      ),
-    );
+    // worth> and silently miss every compound-key lookup downstream. The
+    // batched form folds N storage reads into one (the SimpleDb entity has
+    // caching disabled, so the per-account form paid a fresh
+    // deserialization per row — a 50-row selector batch turned into 50
+    // reads).
+    const accountsValue =
+      await this.backgroundApi.serviceAccountProfile.getAllNetworkAccountsValueByAccountIdBatch(
+        {
+          accounts: accounts.map((a) => ({
+            accountId: a.accountId,
+            accountAddress: a.accountAddress,
+            xpub: a.xpub,
+          })),
+        },
+      );
     return { accountsValue, accountsDeFiOverview };
   }
 }

--- a/packages/kit-bg/src/services/ServiceAccountSelector.ts
+++ b/packages/kit-bg/src/services/ServiceAccountSelector.ts
@@ -986,15 +986,9 @@ class ServiceAccountSelector extends ServiceBase {
       await this.backgroundApi.serviceDeFi.getAccountsLocalDeFiOverview({
         accounts,
       });
-    // Per-row aggregation. Each row's `accountId` is the indexedAccountId for
-    // HD/HW or the Others accountId — exactly what
-    // `getAllNetworkAccountsValueByAccountId` expects. The returned value is
-    // shaped as Record<${networkAccountId}_${networkId}, worth>, which is what
-    // `AccountValue.tsx` / `calculateAccountTotalValue` consume (branch 3 looks
-    // up a compound key, branch 4 filters compound keys by walletId+deriveType).
-    // Using the per-address `getAllNetworkAccountsValue` here would return
-    // Record<networkId, worth> instead, which silently fails every compound-key
-    // lookup downstream — so the selector would show only DeFi worth.
+    // Compound-key shape consumed by `calculateAccountTotalValue`; the
+    // per-address `getAllNetworkAccountsValue` would yield Record<networkId,
+    // worth> and silently miss every compound-key lookup downstream.
     const accountsValue = await Promise.all(
       accounts.map((a) =>
         this.backgroundApi.serviceAccountProfile.getAllNetworkAccountsValueByAccountId(

--- a/packages/kit-bg/src/services/ServiceAccountSelector.ts
+++ b/packages/kit-bg/src/services/ServiceAccountSelector.ts
@@ -986,12 +986,22 @@ class ServiceAccountSelector extends ServiceBase {
       await this.backgroundApi.serviceDeFi.getAccountsLocalDeFiOverview({
         accounts,
       });
-    const accountsValue =
-      await this.backgroundApi.serviceAccountProfile.getAllNetworkAccountsValue(
-        {
-          accounts,
-        },
-      );
+    // Per-row aggregation. Each row's `accountId` is the indexedAccountId for
+    // HD/HW or the Others accountId — exactly what
+    // `getAllNetworkAccountsValueByAccountId` expects. The returned value is
+    // shaped as Record<${networkAccountId}_${networkId}, worth>, which is what
+    // `AccountValue.tsx` / `calculateAccountTotalValue` consume (branch 3 looks
+    // up a compound key, branch 4 filters compound keys by walletId+deriveType).
+    // Using the per-address `getAllNetworkAccountsValue` here would return
+    // Record<networkId, worth> instead, which silently fails every compound-key
+    // lookup downstream — so the selector would show only DeFi worth.
+    const accountsValue = await Promise.all(
+      accounts.map((a) =>
+        this.backgroundApi.serviceAccountProfile.getAllNetworkAccountsValueByAccountId(
+          { accountId: a.accountId },
+        ),
+      ),
+    );
     return { accountsValue, accountsDeFiOverview };
   }
 }

--- a/packages/kit-bg/src/services/ServiceBootstrap.ts
+++ b/packages/kit-bg/src/services/ServiceBootstrap.ts
@@ -135,6 +135,11 @@ class ServiceBootstrap extends ServiceBase {
       timedDeferred('customTokens.migrateFromV1LegacyData', () =>
         this.backgroundApi.simpleDb.customTokens.migrateFromV1LegacyData(),
       ),
+      timedDeferred('accountValue.migrateToAddressKey', () =>
+        this.backgroundApi.simpleDb.accountValue.migrateFromAccountIdToAddressKey(
+          { serviceAccount: this.backgroundApi.serviceAccount },
+        ),
+      ),
       timedDeferred('serviceAccount.migrateHdWalletsBackedUpStatus', () =>
         this.backgroundApi.serviceAccount.migrateHdWalletsBackedUpStatus(),
       ),

--- a/packages/kit-bg/src/services/ServiceUniversalSearch.ts
+++ b/packages/kit-bg/src/services/ServiceUniversalSearch.ts
@@ -687,7 +687,9 @@ class ServiceUniversalSearch extends ServiceBase {
                     accountId: account.id,
                     networkId: networkId || '',
                     accountAddress: account.address,
-                    xpub: (account as { xpub?: string }).xpub,
+                    xpub:
+                      (account as { xpubSegwit?: string }).xpubSegwit ||
+                      (account as { xpub?: string }).xpub,
                   },
                 ],
               })
@@ -717,7 +719,9 @@ class ServiceUniversalSearch extends ServiceBase {
                 {
                   networkAccountId: account.id,
                   accountAddress: account.address,
-                  xpub: (account as { xpub?: string }).xpub,
+                  xpub:
+                    (account as { xpubSegwit?: string }).xpubSegwit ||
+                    (account as { xpub?: string }).xpub,
                 },
               );
           }
@@ -1035,7 +1039,9 @@ class ServiceUniversalSearch extends ServiceBase {
                   accountId: i.item.id,
                   networkId: i.item.createAtNetwork ?? network?.id ?? '',
                   accountAddress: account.address,
-                  xpub: (account as { xpub?: string }).xpub,
+                  xpub:
+                    (account as { xpubSegwit?: string }).xpubSegwit ||
+                    (account as { xpub?: string }).xpub,
                 },
               ],
             })

--- a/packages/kit-bg/src/services/ServiceUniversalSearch.ts
+++ b/packages/kit-bg/src/services/ServiceUniversalSearch.ts
@@ -687,9 +687,7 @@ class ServiceUniversalSearch extends ServiceBase {
                     accountId: account.id,
                     networkId: networkId || '',
                     accountAddress: account.address,
-                    xpub:
-                      (account as { xpubSegwit?: string }).xpubSegwit ||
-                      (account as { xpub?: string }).xpub,
+                    xpub: accountUtils.pickXpubFromDBAccount(account),
                   },
                 ],
               })
@@ -708,20 +706,14 @@ class ServiceUniversalSearch extends ServiceBase {
           )?.[0]?.account;
           if (account?.id) {
             // Scope the worth lookup to the matched (address, xpub) — not the
-            // whole indexedAccount — so wallets that share the same chain
-            // address (HW devices initialized from the same seed, etc.) all
-            // read the same SimpleDb entry and surface identical balances.
-            // Using `getAllNetworkAccountsValueByIndexedAccount` here would
-            // fold in unrelated chain addresses under the indexedAccount,
-            // causing identical-address rows to disagree.
+            // whole indexedAccount — so identical-address rows from different
+            // wallets read the same SimpleDb entry and agree.
             accountsValue =
               await this.backgroundApi.serviceAccountProfile.getAllNetworkAccountsValueByAddress(
                 {
                   networkAccountId: account.id,
                   accountAddress: account.address,
-                  xpub:
-                    (account as { xpubSegwit?: string }).xpubSegwit ||
-                    (account as { xpub?: string }).xpub,
+                  xpub: accountUtils.pickXpubFromDBAccount(account),
                 },
               );
           }
@@ -936,13 +928,9 @@ class ServiceUniversalSearch extends ServiceBase {
           const wallet = await serviceAccount.getWalletSafe({
             walletId: i.item.walletId,
           });
-          // Name search needs the legacy compound-key shape
-          // `Record<${networkAccountId}_${networkId}, worth>` so the
-          // `AccountValue` render path (branch 3 / branch 4 in
-          // `calculateAccountTotalValue`) can match the row's linkedAccountId.
-          // The per-networkId shape returned by the indexed-account aggregator
-          // silently fails those lookups and would leave the row showing only
-          // DeFi worth.
+          // Compound-key shape consumed by `calculateAccountTotalValue`; the
+          // per-networkId shape from the indexed-account aggregator would not
+          // match the row's linkedAccountId.
           const accountsValue =
             await serviceAccountProfile.getAllNetworkAccountsValueByAccountId({
               accountId: i.item.id,
@@ -1039,9 +1027,7 @@ class ServiceUniversalSearch extends ServiceBase {
                   accountId: i.item.id,
                   networkId: i.item.createAtNetwork ?? network?.id ?? '',
                   accountAddress: account.address,
-                  xpub:
-                    (account as { xpubSegwit?: string }).xpubSegwit ||
-                    (account as { xpub?: string }).xpub,
+                  xpub: accountUtils.pickXpubFromDBAccount(account),
                 },
               ],
             })

--- a/packages/kit-bg/src/services/ServiceUniversalSearch.ts
+++ b/packages/kit-bg/src/services/ServiceUniversalSearch.ts
@@ -705,11 +705,20 @@ class ServiceUniversalSearch extends ServiceBase {
             })
           )?.[0]?.account;
           if (account?.id) {
-            // Use the address-keyed aggregate so wallets sharing the same
-            // chain address can read each other's already-loaded worth.
+            // Scope the worth lookup to the matched (address, xpub) — not the
+            // whole indexedAccount — so wallets that share the same chain
+            // address (HW devices initialized from the same seed, etc.) all
+            // read the same SimpleDb entry and surface identical balances.
+            // Using `getAllNetworkAccountsValueByIndexedAccount` here would
+            // fold in unrelated chain addresses under the indexedAccount,
+            // causing identical-address rows to disagree.
             accountsValue =
-              await this.backgroundApi.serviceAccountProfile.getAllNetworkAccountsValueByIndexedAccount(
-                { indexedAccountId: indexedAccount.id },
+              await this.backgroundApi.serviceAccountProfile.getAllNetworkAccountsValueByAddress(
+                {
+                  networkAccountId: account.id,
+                  accountAddress: account.address,
+                  xpub: (account as { xpub?: string }).xpub,
+                },
               );
           }
         }
@@ -923,13 +932,17 @@ class ServiceUniversalSearch extends ServiceBase {
           const wallet = await serviceAccount.getWalletSafe({
             walletId: i.item.walletId,
           });
-          // Aggregate across all known chain addresses for this indexedAccount
-          // by querying the address-keyed store, so wallets that share an
-          // address with one another inherit each other's loaded worth.
+          // Name search needs the legacy compound-key shape
+          // `Record<${networkAccountId}_${networkId}, worth>` so the
+          // `AccountValue` render path (branch 3 / branch 4 in
+          // `calculateAccountTotalValue`) can match the row's linkedAccountId.
+          // The per-networkId shape returned by the indexed-account aggregator
+          // silently fails those lookups and would leave the row showing only
+          // DeFi worth.
           const accountsValue =
-            await serviceAccountProfile.getAllNetworkAccountsValueByIndexedAccount(
-              { indexedAccountId: i.item.id },
-            );
+            await serviceAccountProfile.getAllNetworkAccountsValueByAccountId({
+              accountId: i.item.id,
+            });
 
           let account: INetworkAccount | undefined;
           let addressInfo: IAddressValidation | undefined;

--- a/packages/kit-bg/src/services/ServiceUniversalSearch.ts
+++ b/packages/kit-bg/src/services/ServiceUniversalSearch.ts
@@ -624,8 +624,7 @@ class ServiceUniversalSearch extends ServiceBase {
     networkId?: string;
     searchedEncoding?: EAddressEncodings;
   }): Promise<IUniversalSearchResultItem[]> {
-    const { serviceNetwork, serviceAccount, serviceValidator } =
-      this.backgroundApi;
+    const { serviceNetwork, serviceAccount } = this.backgroundApi;
     const items: IUniversalSearchResultItem[] = [];
 
     // Get all accounts with this address
@@ -718,47 +717,42 @@ class ServiceUniversalSearch extends ServiceBase {
             (a) => a.address?.toLowerCase() === normalizedAddress,
           );
 
-          // For BTC and forks with `enableBTCFreshAddress` (default ON), the
-          // searched address can be a non-0/0 fresh receive address that
-          // ServiceAllNetwork registered against the indexedAccountId. But
-          // `dbAccount.address` is fixed to the derive type's 0/0 master, so
-          // the exact-address match above misses. Each BTC derive type owns a
-          // unique address encoding (P2PKH/P2SH_P2WPKH/P2WPKH/P2TR), so match
-          // by encoding before falling back to "first compatible" — otherwise
-          // a Taproot search row would resolve to e.g. the Nested SegWit
-          // dbAccount's xpub and show that derive type's balance instead.
-          if (!matchedDbAccount && networkId && searchedEncoding) {
-            const candidates = allDbAccounts.filter(
-              (a) =>
-                a.address &&
-                accountUtils.isAccountCompatibleWithNetwork({
-                  account: a,
-                  networkId,
-                }),
-            );
-            const candidateEncodings = await Promise.all(
-              candidates.map((a) =>
-                serviceValidator
-                  .localValidateAddress({ networkId, address: a.address })
-                  .then((r) => r.encoding)
-                  .catch(() => undefined),
-              ),
-            );
-            const idx = candidateEncodings.findIndex(
-              (e) => e === searchedEncoding,
-            );
-            if (idx >= 0) {
-              matchedDbAccount = candidates[idx];
-            }
-          }
-
           if (!matchedDbAccount) {
-            matchedDbAccount = allDbAccounts.find((a) =>
+            const compatibles = allDbAccounts.filter((a) =>
               accountUtils.isAccountCompatibleWithNetwork({
                 account: a,
                 networkId: networkId || '',
               }),
             );
+
+            // BTC fresh-address mode registers non-0/0 receive addresses
+            // against the indexedAccountId, but `dbAccount.address` stays at
+            // the derive type's 0/0 master — so the exact match above misses.
+            // Each derive type owns a unique encoding, so resolve via the
+            // dbAccount's `template` before the "first compatible" fallback,
+            // otherwise the row would show the wrong derive type's balance.
+            if (networkId && searchedEncoding) {
+              const deriveInfoMap =
+                await serviceNetwork.getDeriveInfoMapOfNetwork({ networkId });
+              const templateToEncoding = new Map<
+                string,
+                EAddressEncodings | undefined
+              >();
+              for (const info of Object.values(deriveInfoMap)) {
+                if (info?.template) {
+                  templateToEncoding.set(info.template, info.addressEncoding);
+                }
+              }
+              matchedDbAccount = compatibles.find(
+                (a) =>
+                  a.template &&
+                  templateToEncoding.get(a.template) === searchedEncoding,
+              );
+            }
+
+            if (!matchedDbAccount) {
+              matchedDbAccount = compatibles[0];
+            }
           }
 
           if (matchedDbAccount) {

--- a/packages/kit-bg/src/services/ServiceUniversalSearch.ts
+++ b/packages/kit-bg/src/services/ServiceUniversalSearch.ts
@@ -577,6 +577,7 @@ class ServiceUniversalSearch extends ServiceBase {
         const internalItems = await this.findInternalWalletAccounts({
           address: localValidateResult.displayAddress,
           networkId: validNetworkId,
+          searchedEncoding: localValidateResult.encoding,
         });
 
         if (internalItems.length > 0) {
@@ -617,11 +618,14 @@ class ServiceUniversalSearch extends ServiceBase {
   private async findInternalWalletAccounts({
     address,
     networkId,
+    searchedEncoding,
   }: {
     address: string;
     networkId?: string;
+    searchedEncoding?: EAddressEncodings;
   }): Promise<IUniversalSearchResultItem[]> {
-    const { serviceNetwork, serviceAccount } = this.backgroundApi;
+    const { serviceNetwork, serviceAccount, serviceValidator } =
+      this.backgroundApi;
     const items: IUniversalSearchResultItem[] = [];
 
     // Get all accounts with this address
@@ -713,6 +717,41 @@ class ServiceUniversalSearch extends ServiceBase {
           let matchedDbAccount = allDbAccounts.find(
             (a) => a.address?.toLowerCase() === normalizedAddress,
           );
+
+          // For BTC and forks with `enableBTCFreshAddress` (default ON), the
+          // searched address can be a non-0/0 fresh receive address that
+          // ServiceAllNetwork registered against the indexedAccountId. But
+          // `dbAccount.address` is fixed to the derive type's 0/0 master, so
+          // the exact-address match above misses. Each BTC derive type owns a
+          // unique address encoding (P2PKH/P2SH_P2WPKH/P2WPKH/P2TR), so match
+          // by encoding before falling back to "first compatible" — otherwise
+          // a Taproot search row would resolve to e.g. the Nested SegWit
+          // dbAccount's xpub and show that derive type's balance instead.
+          if (!matchedDbAccount && networkId && searchedEncoding) {
+            const candidates = allDbAccounts.filter(
+              (a) =>
+                a.address &&
+                accountUtils.isAccountCompatibleWithNetwork({
+                  account: a,
+                  networkId,
+                }),
+            );
+            const candidateEncodings = await Promise.all(
+              candidates.map((a) =>
+                serviceValidator
+                  .localValidateAddress({ networkId, address: a.address })
+                  .then((r) => r.encoding)
+                  .catch(() => undefined),
+              ),
+            );
+            const idx = candidateEncodings.findIndex(
+              (e) => e === searchedEncoding,
+            );
+            if (idx >= 0) {
+              matchedDbAccount = candidates[idx];
+            }
+          }
+
           if (!matchedDbAccount) {
             matchedDbAccount = allDbAccounts.find((a) =>
               accountUtils.isAccountCompatibleWithNetwork({

--- a/packages/kit-bg/src/services/ServiceUniversalSearch.ts
+++ b/packages/kit-bg/src/services/ServiceUniversalSearch.ts
@@ -698,12 +698,41 @@ class ServiceUniversalSearch extends ServiceBase {
             id: accountItem.accountId,
           });
 
-          account = (
-            await serviceAccount.getNetworkAccountsInSameIndexedAccountId({
+          // Locate the dbAccount that actually owns the searched address.
+          // `getNetworkAccountsInSameIndexedAccountId` picks the first
+          // network-compatible dbAccount, which for chains with multiple
+          // derive types under one indexed account (e.g. BTC
+          // legacy/nested-segwit/native-segwit/taproot) is not necessarily
+          // the one whose address matched the search — leading to a worth
+          // lookup against the wrong xpub.
+          const { accounts: allDbAccounts } =
+            await serviceAccount.getAccountsInSameIndexedAccountId({
               indexedAccountId: accountItem.accountId,
-              networkIds: [networkId || ''],
-            })
-          )?.[0]?.account;
+            });
+          const normalizedAddress = address.toLowerCase();
+          let matchedDbAccount = allDbAccounts.find(
+            (a) => a.address?.toLowerCase() === normalizedAddress,
+          );
+          if (!matchedDbAccount) {
+            matchedDbAccount = allDbAccounts.find((a) =>
+              accountUtils.isAccountCompatibleWithNetwork({
+                account: a,
+                networkId: networkId || '',
+              }),
+            );
+          }
+
+          if (matchedDbAccount) {
+            try {
+              account = await serviceAccount.getAccount({
+                accountId: matchedDbAccount.id,
+                networkId: networkId || '',
+              });
+            } catch {
+              // Fall through with no account — accountsValue stays undefined.
+            }
+          }
+
           if (account?.id) {
             // Scope the worth lookup to the matched (address, xpub) — not the
             // whole indexedAccount — so identical-address rows from different
@@ -712,8 +741,10 @@ class ServiceUniversalSearch extends ServiceBase {
               await this.backgroundApi.serviceAccountProfile.getAllNetworkAccountsValueByAddress(
                 {
                   networkAccountId: account.id,
-                  accountAddress: account.address,
-                  xpub: accountUtils.pickXpubFromDBAccount(account),
+                  accountAddress: matchedDbAccount?.address,
+                  xpub: matchedDbAccount
+                    ? accountUtils.pickXpubFromDBAccount(matchedDbAccount)
+                    : undefined,
                 },
               );
           }

--- a/packages/kit-bg/src/services/ServiceUniversalSearch.ts
+++ b/packages/kit-bg/src/services/ServiceUniversalSearch.ts
@@ -682,7 +682,14 @@ class ServiceUniversalSearch extends ServiceBase {
           if (account?.id) {
             accountsValue = (
               await this.backgroundApi.serviceAccountProfile.getAccountsValue({
-                accounts: [{ accountId: account?.id }],
+                accounts: [
+                  {
+                    accountId: account.id,
+                    networkId: networkId || '',
+                    accountAddress: account.address,
+                    xpub: (account as { xpub?: string }).xpub,
+                  },
+                ],
               })
             )?.[0];
           }
@@ -698,13 +705,12 @@ class ServiceUniversalSearch extends ServiceBase {
             })
           )?.[0]?.account;
           if (account?.id) {
-            accountsValue = (
-              await this.backgroundApi.serviceAccountProfile.getAllNetworkAccountsValue(
-                {
-                  accounts: [{ accountId: indexedAccount.id }],
-                },
-              )
-            )?.[0];
+            // Use the address-keyed aggregate so wallets sharing the same
+            // chain address can read each other's already-loaded worth.
+            accountsValue =
+              await this.backgroundApi.serviceAccountProfile.getAllNetworkAccountsValueByIndexedAccount(
+                { indexedAccountId: indexedAccount.id },
+              );
           }
         }
 
@@ -917,11 +923,13 @@ class ServiceUniversalSearch extends ServiceBase {
           const wallet = await serviceAccount.getWalletSafe({
             walletId: i.item.walletId,
           });
-          const accountsValue = (
-            await serviceAccountProfile.getAllNetworkAccountsValue({
-              accounts: [{ accountId: i.item.id }],
-            })
-          )?.[0];
+          // Aggregate across all known chain addresses for this indexedAccount
+          // by querying the address-keyed store, so wallets that share an
+          // address with one another inherit each other's loaded worth.
+          const accountsValue =
+            await serviceAccountProfile.getAllNetworkAccountsValueByIndexedAccount(
+              { indexedAccountId: i.item.id },
+            );
 
           let account: INetworkAccount | undefined;
           let addressInfo: IAddressValidation | undefined;
@@ -1009,7 +1017,14 @@ class ServiceUniversalSearch extends ServiceBase {
           }
           const accountsValue = (
             await serviceAccountProfile.getAccountsValue({
-              accounts: [{ accountId: i.item.id }],
+              accounts: [
+                {
+                  accountId: i.item.id,
+                  networkId: i.item.createAtNetwork ?? network?.id ?? '',
+                  accountAddress: account.address,
+                  xpub: (account as { xpub?: string }).xpub,
+                },
+              ],
             })
           )?.[0];
           const localValidateResult =

--- a/packages/kit/src/views/ChainSelector/components/UnifiedNetworkSelector/NetworkContent.tsx
+++ b/packages/kit/src/views/ChainSelector/components/UnifiedNetworkSelector/NetworkContent.tsx
@@ -82,9 +82,9 @@ export function NetworkContent({
     async () => {
       const [_accountsValue, _chainSelectorNetworks, _localDeFiOverview] =
         await Promise.all([
-          backgroundApiProxy.serviceAccountProfile.getAllNetworkAccountsValue({
-            accounts: [{ accountId: indexedAccountId ?? accountId ?? '' }],
-          }),
+          backgroundApiProxy.serviceAccountProfile.getAllNetworkAccountsValueByAccountId(
+            { accountId: indexedAccountId ?? accountId ?? '' },
+          ),
           backgroundApiProxy.serviceNetwork.getChainSelectorNetworksCompatibleWithAccountId(
             {
               accountId,
@@ -105,7 +105,7 @@ export function NetworkContent({
           }),
         ]);
 
-      if (_accountsValue[0] || _localDeFiOverview[0]) {
+      if (_accountsValue || _localDeFiOverview[0]) {
         const {
           chainSelectorNetworks: sortedChainSelectorNetworks,
           formattedAccountNetworkValues,
@@ -115,10 +115,10 @@ export function NetworkContent({
         } = await backgroundApiProxy.serviceNetwork.sortChainSelectorNetworksByValue(
           {
             walletId: accountUtils.getWalletIdFromAccountId({
-              accountId: _accountsValue[0]?.accountId ?? '',
+              accountId: _accountsValue?.accountId ?? '',
             }),
             chainSelectorNetworks: _chainSelectorNetworks,
-            accountNetworkValues: _accountsValue[0]?.value ?? {},
+            accountNetworkValues: _accountsValue?.value ?? {},
             localDeFiOverview: _localDeFiOverview[0]?.overview ?? {},
           },
         );
@@ -126,7 +126,7 @@ export function NetworkContent({
         return {
           chainSelectorNetworks: sortedChainSelectorNetworks,
           accountNetworkValues: formattedAccountNetworkValues,
-          accountNetworkValueCurrency: _accountsValue[0]?.currency,
+          accountNetworkValueCurrency: _accountsValue?.currency,
           accountDeFiOverview: _accountDeFiOverview,
           zeroValue,
         };

--- a/packages/kit/src/views/ChainSelector/components/UnifiedNetworkSelector/index.tsx
+++ b/packages/kit/src/views/ChainSelector/components/UnifiedNetworkSelector/index.tsx
@@ -295,9 +295,9 @@ function UnifiedNetworkSelector() {
     if (!accountId && !indexedAccountId) return;
 
     const [_accountsValue, _localDeFiOverview] = await Promise.all([
-      backgroundApiProxy.serviceAccountProfile.getAllNetworkAccountsValue({
-        accounts: [{ accountId: indexedAccountId ?? accountId ?? '' }],
-      }),
+      backgroundApiProxy.serviceAccountProfile.getAllNetworkAccountsValueByAccountId(
+        { accountId: indexedAccountId ?? accountId ?? '' },
+      ),
       backgroundApiProxy.serviceDeFi.getAccountsLocalDeFiOverview({
         accounts: [
           {
@@ -310,7 +310,7 @@ function UnifiedNetworkSelector() {
       }),
     ]);
 
-    if (_accountsValue[0] || _localDeFiOverview[0]) {
+    if (_accountsValue || _localDeFiOverview[0]) {
       const {
         formattedAccountNetworkValues,
         accountDeFiOverview: _accountDeFiOverview,
@@ -318,16 +318,16 @@ function UnifiedNetworkSelector() {
         await backgroundApiProxy.serviceNetwork.sortChainSelectorNetworksByValue(
           {
             walletId: accountUtils.getWalletIdFromAccountId({
-              accountId: _accountsValue[0]?.accountId ?? '',
+              accountId: _accountsValue?.accountId ?? '',
             }),
             chainSelectorNetworks: compatibleNetworks,
-            accountNetworkValues: _accountsValue[0]?.value ?? {},
+            accountNetworkValues: _accountsValue?.value ?? {},
             localDeFiOverview: _localDeFiOverview[0]?.overview ?? {},
           },
         );
 
       setAccountNetworkValues(formattedAccountNetworkValues ?? {});
-      setAccountNetworkValueCurrency(_accountsValue[0]?.currency);
+      setAccountNetworkValueCurrency(_accountsValue?.currency);
       setAccountDeFiOverview(_accountDeFiOverview ?? {});
     }
   }, [accountId, indexedAccountId, compatibleNetworks]);

--- a/packages/kit/src/views/ChainSelector/pages/AccountChainSelector.tsx
+++ b/packages/kit/src/views/ChainSelector/pages/AccountChainSelector.tsx
@@ -82,9 +82,9 @@ const EditableAccountChainSelector = ({
     async () => {
       const [_accountsValue, _chainSelectorNetworks, _localDeFiOverview] =
         await Promise.all([
-          backgroundApiProxy.serviceAccountProfile.getAllNetworkAccountsValue({
-            accounts: [{ accountId: indexedAccount?.id ?? account?.id ?? '' }],
-          }),
+          backgroundApiProxy.serviceAccountProfile.getAllNetworkAccountsValueByAccountId(
+            { accountId: indexedAccount?.id ?? account?.id ?? '' },
+          ),
           backgroundApiProxy.serviceNetwork.getChainSelectorNetworksCompatibleWithAccountId(
             {
               accountId: account?.id,
@@ -105,7 +105,7 @@ const EditableAccountChainSelector = ({
           }),
         ]);
 
-      if (_accountsValue[0] || _localDeFiOverview[0]) {
+      if (_accountsValue || _localDeFiOverview[0]) {
         const {
           chainSelectorNetworks: sortedChainSelectorNetworks,
           formattedAccountNetworkValues,
@@ -113,10 +113,10 @@ const EditableAccountChainSelector = ({
         } = await backgroundApiProxy.serviceNetwork.sortChainSelectorNetworksByValue(
           {
             walletId: accountUtils.getWalletIdFromAccountId({
-              accountId: _accountsValue[0].accountId,
+              accountId: _accountsValue?.accountId ?? '',
             }),
             chainSelectorNetworks: _chainSelectorNetworks,
-            accountNetworkValues: _accountsValue[0].value ?? {},
+            accountNetworkValues: _accountsValue?.value ?? {},
             localDeFiOverview: _localDeFiOverview[0]?.overview ?? {},
           },
         );
@@ -124,7 +124,7 @@ const EditableAccountChainSelector = ({
         return {
           chainSelectorNetworks: sortedChainSelectorNetworks,
           accountNetworkValues: formattedAccountNetworkValues,
-          accountNetworkValueCurrency: _accountsValue[0].currency,
+          accountNetworkValueCurrency: _accountsValue?.currency,
           accountDeFiOverview: _accountDeFiOverview,
         };
       }

--- a/packages/kit/src/views/ChainSelector/pages/ChainSelector.tsx
+++ b/packages/kit/src/views/ChainSelector/pages/ChainSelector.tsx
@@ -85,15 +85,13 @@ export default function ChainSelectorPage({
         }
         if (valueAccountId) {
           const accountsValue =
-            await backgroundApiProxy.serviceAccountProfile.getAllNetworkAccountsValue(
-              {
-                accounts: [{ accountId: valueAccountId }],
-              },
+            await backgroundApiProxy.serviceAccountProfile.getAllNetworkAccountsValueByAccountId(
+              { accountId: valueAccountId },
             );
           // Raw values use compound keys "accountId_networkId" (via buildAccountValueKey).
           // Multiple concrete accounts can map to the same network (for example BTC
           // address types under one indexed account), so aggregate by networkId here.
-          const rawValues = accountsValue[0]?.value ?? {};
+          const rawValues = accountsValue?.value ?? {};
           const formattedValues: Record<string, string> = {};
           const walletId = accountUtils.getWalletIdFromAccountId({
             accountId: valueAccountId,
@@ -115,7 +113,7 @@ export default function ChainSelectorPage({
             }
           }
           accountNetworkValues = formattedValues;
-          accountNetworkValueCurrency = accountsValue[0]?.currency;
+          accountNetworkValueCurrency = accountsValue?.currency;
 
           // Sort networks by value descending
           networks.sort((a, b) => {

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -307,29 +307,37 @@ function HomeOverviewContainer() {
           });
           appEventBus.emit(EAppEventBusNames.AccountValueUpdate, undefined);
         }
-        let accountValueId = '';
-        if (accountUtils.isOthersAccount({ accountId: account.id })) {
-          accountValueId = account.id;
+        const isOthers = accountUtils.isOthersAccount({
+          accountId: account.id,
+        });
+        // Logical account id for the active value atom & rookie guide: matches
+        // the keying convention used by the account selector (indexedAccountId
+        // for HD/HW, account.id for Others).
+        const accountValueId = isOthers
+          ? account.id
+          : (account.indexedAccountId as string);
 
-          if (network.isAllNetworks || account.createAtNetwork === network.id) {
+        if (isOthers) {
+          if (
+            account.createAtNetwork &&
+            (network.isAllNetworks ||
+              account.createAtNetwork === network.id)
+          ) {
             void backgroundApiProxy.serviceAccountProfile.updateAccountValue({
               accountId: accountValueId,
+              networkAccountId: account.id,
+              networkId: account.createAtNetwork,
               value: accountWorth.createAtNetworkWorth,
               currency: settings.currencyInfo.id,
               shouldUpdateActiveAccountValue: true,
             });
           }
-        } else {
-          accountValueId = account.indexedAccountId as string;
-        }
-
-        if (
-          !accountUtils.isOthersAccount({ accountId: account.id }) &&
-          !network.isAllNetworks
-        ) {
+        } else if (!network.isAllNetworks) {
           void backgroundApiProxy.serviceAccountProfile.updateAccountValueForSingleNetwork(
             {
               accountId: accountValueId,
+              networkAccountId: account.id,
+              networkId: network.id,
               value:
                 accountWorth.worth[
                   accountUtils.buildAccountValueKey({

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -320,8 +320,7 @@ function HomeOverviewContainer() {
         if (isOthers) {
           if (
             account.createAtNetwork &&
-            (network.isAllNetworks ||
-              account.createAtNetwork === network.id)
+            (network.isAllNetworks || account.createAtNetwork === network.id)
           ) {
             void backgroundApiProxy.serviceAccountProfile.updateAccountValue({
               accountId: accountValueId,

--- a/packages/shared/src/utils/accountUtils.ts
+++ b/packages/shared/src/utils/accountUtils.ts
@@ -700,6 +700,18 @@ function buildAccountLocalAssetsKey({
   return ((xpub || accountAddress) ?? '').toLowerCase();
 }
 
+// Mirrors the BTC vault's `getAccountXpub` precedence so address-keyed storage
+// reads/writes land at the same key. Nested-segwit (P2SH-P2WPKH) accounts hold
+// the spendable xpub in `xpubSegwit`; reading raw `.xpub` instead misses that
+// derive type's worth. Accepts any account-shaped object — callers pass
+// IDBAccount / INetworkAccount whose non-UTXO variants don't structurally
+// declare these fields.
+function pickXpubFromDBAccount(account: unknown): string | undefined {
+  if (!account || typeof account !== 'object') return undefined;
+  const a = account as { xpub?: string; xpubSegwit?: string };
+  return a.xpubSegwit || a.xpub;
+}
+
 function isAccountCompatibleWithNetwork({
   account,
   networkId,
@@ -1397,6 +1409,7 @@ export default {
   removePathLastSegment,
   buildHiddenWalletName,
   buildAccountLocalAssetsKey,
+  pickXpubFromDBAccount,
   buildTonMnemonicCredentialId,
   getAccountIdFromTonMnemonicCredentialId,
   buildHyperLiquidAgentCredentialId,


### PR DESCRIPTION
## Summary
- Re-key `SimpleDbEntityAccountValue` from `accountId` to `(networkId, address|xpub)` so wallets that share an on-chain address share already-loaded worth.
- Add address resolution in `ServiceAccountProfile` plus an aggregate helper for indexed accounts, and route `HomeOverviewContainer` + `ServiceUniversalSearch` through the new shape.
- Ship a one-shot migration via `ServiceBootstrap.fireAndForgetTasks`, keeping legacy buckets and a `_migratedAt` stamp for rollback.

## Intent & Context
The cached account-value store was keyed by `accountId`, which meant HD / imported / watching accounts that all resolve to the same on-chain address each maintained their own worth entry. In the account selector and global search this surfaced as redundant balance loads and inconsistent display — the second wallet would re-fetch a number the first wallet already had cached. The goal of this change is to make the cache reflect on-chain identity (network + address/xpub), not local account identity.

## Root Cause
`SimpleDbEntityAccountValue` historically stored per-`accountId` records. Any feature that needed "the worth of this address" had to go through an `accountId` it might not have (e.g. address-match results in global search, or sibling HD accounts pointing at the same chain address). The schema, not the consumers, was the wrong abstraction.

## Design Decisions
- **New buckets `byAddress` / `allByAddress`** keyed by `${networkId}--${address|xpub}`. Old `data` / `all` buckets are renamed to `_legacy_data` / `_legacy_all` and kept untouched so we can roll back without data loss.
- **Idempotent migration**: a `_migratedAt` stamp + one-shot task in `ServiceBootstrap.fireAndForgetTasks` guarantees a single pass per install, even across restarts.
- **Address resolution lives in `ServiceAccountProfile`** via a new `resolveAddressKey` helper that reuses existing `serviceAccount` helpers, so callers don't grow new dependencies on account internals.
- **Carry `networkAccountId` from `HomeOverviewContainer` writes** so HD wallets resolve to the correct chain address while `indexedAccountId` continues to drive the `activeAccountValueAtom` snapshot — UI behavior is unchanged.
- **`getAllNetworkAccountsValueByIndexedAccount`** added for name-search aggregation so the universal-search path doesn't re-implement the cross-network rollup.
- The `chore` follow-up commit inverts a few guards to satisfy `no-continue` lint without changing behavior.

## Changes Detail
- `packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountValue.ts` — new schema, address-key encoding, legacy-data preservation, migration logic.
- `packages/kit-bg/src/services/ServiceAccountProfile.ts` — rewritten read/write methods, new `resolveAddressKey` and `getAllNetworkAccountsValueByIndexedAccount` helpers.
- `packages/kit-bg/src/services/ServiceBootstrap.ts` — registers the one-shot migration in `fireAndForgetTasks`.
- `packages/kit-bg/src/services/ServiceUniversalSearch.ts` — address-match branch passes `accountAddress`/`xpub`; name-search routes through the aggregate helper.
- `packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx` — passes `networkAccountId` on writes, preserves `indexedAccountId` for the active atom.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension / Mobile / Desktop / Web (background service change — all platforms)
- **Risk Areas**:
  - Migration correctness on first launch (idempotency stamp + retained legacy buckets mitigate this).
  - Address resolution for HD accounts in `HomeOverviewContainer` — wrong `networkAccountId` would write to the wrong bucket.
  - Universal-search performance for indexed-account name matches now hits the aggregate helper.

## Test plan
- [ ] Fresh install: confirm `_migratedAt` is set and `byAddress` populates as accounts load.
- [ ] Upgrade install with existing `data`/`all`: confirm legacy buckets are preserved as `_legacy_*` and new buckets back-fill on first read; no double-migration on restart.
- [ ] Account selector with two wallets (e.g. HD + watching) on the same EVM address: second wallet shows the cached worth without a re-fetch.
- [ ] Global search by address: cached worth appears for matched address even when the wallet wasn't previously selected.
- [ ] Global search by indexed-account name: aggregate worth across networks matches the home overview.
- [ ] HD wallet on a chain whose address derivation requires `networkAccountId`: worth writes/reads to the correct address bucket.
