### PR TITLE
fix(tray): throttle menu-bar pending-tx recheck from 12s to 2min

### DIFF
--- a/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
+++ b/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
@@ -80,8 +80,11 @@ import {
 
 const TRAY_ROUTE_HOME = '/main/tab-home';
 const TRAY_ROUTE_MARKET = '/main/tab-market';
-// Fires while pending txs exist even when panel is closed and home is unfocused.
-const TRAY_PENDING_TX_RECHECK_INTERVAL_MS = 12_000;
+// Pending-tx tail recheck. Fires only when pending txs still exist after a
+// gather, regardless of panel visibility. Kept long because panel-open
+// updates are already covered by the main-process 30s poll, and panel-closed
+// data isn't visible to the user — so server-side cost dominates freshness.
+const TRAY_PENDING_TX_RECHECK_INTERVAL_MS = 120_000;
 
 async function refreshTrayPendingTxStatuses(
   txs: IAccountHistoryTx[],


### PR DESCRIPTION
## Summary
- Raises `TRAY_PENDING_TX_RECHECK_INTERVAL_MS` from `12_000` to `120_000` in `useTrayDataProvider.desktop.ts`.
- Server-side load on `fetchAccountHistory` / `fetchMarketTokenListBatch` / `fetchMarketPerpsTokenList` from the menu-bar tray hook drops by ~10× while the panel is closed, and by ~3× while the panel is open (effective cadence becomes the main-process 30s poll).

## Intent & Context
While auditing the menu-bar tray pending-tx flow, we found that the renderer-side `schedulePendingRecheck` self-loop fires every 12s **even when the menu-bar panel is closed and the home tab is unfocused** (per the existing comment at line 83). Each fire triggers the full `handleTrayDataRequestInner`, not just a status refresh — so each tick re-runs `serviceMarketV2.getMarketWatchListV2`, `fetchMarketTokenListBatch`, `fetchMarketPerpsTokenList`, `serviceHyperliquid.getTokenSearchAliases`, plus one `serviceHistory.fetchAccountHistory({ isManualRefresh: true })` per pending `(accountId, networkId)`. With multiple pending chains this fans out aggressively against backend services.

The tray icon has no badge / dynamic title / image swap (`TrayManager.ts:121` only sets a static tooltip), so the data refreshed while the panel is closed is never observable to the user.

This is a minimal pre-release hot-fix to reduce server pressure before any deeper restructuring.

## Design Decisions
Considered three options:
1. **Add a `TRAY_VISIBILITY` IPC** so the renderer can pick 12s when the panel is open and 120s when closed. Rejected: too much surface area (new IPC channel, preload allowlist entry, renderer subscription) for a pre-release hot-fix.
2. **Stop the recheck entirely while the panel is hidden.** Cleaner but requires the IPC plumbing above and changes more behavior than necessary right now.
3. **Single constant bump from 12s → 120s.** Chosen. One-line change. Panel-open freshness is preserved by the existing main-process 30s poll (`TrayManager.ts:67`), which already runs a full `handleTrayDataRequestInner` (including `refreshTrayPendingTxStatuses`) every 30s while the panel is visible. Event-bus driven refresh (`TRAY_DATA_REFRESH_EVENT_NAMES`, 1.5s debounce) is untouched, so `LocalPendingTxConfirmed` / `HistoryTxStatusChanged` from other parts of the app still pushes updates into the tray cache immediately.

The deeper restructuring (separating pending-status refresh from full data gather, gating on panel visibility) is intentionally deferred — call it out in a follow-up.

## Changes Detail
- `packages/kit/src/hooks/useTrayDataProvider.desktop.ts`: `TRAY_PENDING_TX_RECHECK_INTERVAL_MS` 12_000 → 120_000, and updated the comment to explain the new contract (panel-open freshness comes from the main-process 30s poll; panel-closed data isn't user-visible).

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop (macOS only — `platformEnv.isDesktopMac` gates `isTrayActive`)
- **Risk Areas**:
  - Panel-open pending-tx detection latency: 12s → 30s worst case. Acceptable for tx confirmations that typically take tens of seconds to minutes.
  - Panel-closed pending-tx detection latency: 12s → 120s worst case. Data is not user-visible anyway; the cache only matters when the panel reopens, and `TRAY_READY` + `onTrayWindowVisibilityChange → startPolling` both trigger an immediate gather on open.
  - No API contracts changed, no IPC surface changed, no security boundary touched.

## Test plan
- [ ] macOS: enable menu-bar tray, send a pending tx, close the panel, confirm the tx on-chain externally. Within ~2min after confirmation, reopen the panel and verify pending list reflects the confirmed status (or earlier, if `LocalPendingTxConfirmed` fires from elsewhere first).
- [ ] macOS: with panel open and a pending tx, verify the pending row eventually clears within ~30s of on-chain confirmation (covered by the main-process 30s poll).
- [ ] macOS: with panel open, manually confirm an event-bus-driven refresh path still works (e.g. send a new tx from main window — `LocalPendingTxConfirmed` should debounce-refresh tray within ~1.5s).
- [ ] No-op smoke: panel-open price/balance refresh cadence (30s) is unchanged.