### PR TITLE
fix(v6.3.0): home banner placeholder + iPad split-view + HW popover

### DIFF
--- a/packages/components/src/composite/Tabs/hooks.tsx
+++ b/packages/components/src/composite/Tabs/hooks.tsx
@@ -12,6 +12,7 @@ import { useMedia } from '@onekeyhq/components/src/hooks/useStyle';
 import {
   isDualScreenDevice,
   useDualScreenWidth,
+  useIsSplitViewLayoutDisabled,
 } from '@onekeyhq/shared/src/modules/DualScreenInfo';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
@@ -89,17 +90,19 @@ const useNativeTabContainerWidth = isDualScreenDevice()
   : () => {
       const isTablet = isNativeTablet();
       const isLandscape = useIsSplitView();
+      const isSplitViewLayoutDisabled = useIsSplitViewLayoutDisabled();
       const { width } = useWindowDimensions();
       const isIpadModalPage = useIsIpadModalPage();
       const ipadModalPageWidth = useIPadModalPageWidth();
       if (isIpadModalPage) {
         return ipadModalPageWidth || 640;
       }
-      if (isTablet && isLandscape) {
+      if (isTablet && isLandscape && !isSplitViewLayoutDisabled) {
         // In landscape split view, use half of the screen width
         return width / 2;
       }
-      // In portrait or non-tablet, use full screen width
+      // In portrait, non-tablet, or when the user opted out of split view,
+      // use full screen width.
       return width;
     };
 

--- a/packages/kit/src/components/AddressTypeSelector/AddressTypeSelector.tsx
+++ b/packages/kit/src/components/AddressTypeSelector/AddressTypeSelector.tsx
@@ -192,6 +192,13 @@ function AddressTypeSelectorContent(
           const walletId = accountUtils.getWalletIdFromAccountId({
             accountId: indexedAccountId,
           });
+          // Hardware wallets open the Enter PIN / Passphrase dialog during
+          // createAddress. Close this popover first so its Tamagui default
+          // z-index (150_000) does not hide those dialogs (z-index 100_000).
+          // Software wallets keep the popover open to show inline loading.
+          if (accountUtils.isHwWallet({ walletId })) {
+            closePopover();
+          }
           const createAddressResult = await createAddress({
             selectAfterCreate: false,
             num: 0,

--- a/packages/kit/src/hooks/useTabContainerWidth.ts
+++ b/packages/kit/src/hooks/useTabContainerWidth.ts
@@ -1,0 +1,60 @@
+import { useMemo } from 'react';
+
+import { useWindowDimensions } from 'react-native';
+
+import {
+  useIPadModalPageWidth,
+  useIsIpadModalPage,
+  useIsSplitView,
+  useMedia,
+} from '@onekeyhq/components';
+import {
+  DESKTOP_MODE_UI_PAGE_BORDER_WIDTH,
+  DESKTOP_MODE_UI_PAGE_MARGIN,
+  MIN_SIDEBAR_WIDTH,
+} from '@onekeyhq/components/src/utils/sidebar';
+import {
+  isDualScreenDevice,
+  useDualScreenWidth,
+} from '@onekeyhq/shared/src/modules/DualScreenInfo';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import { useShouldUseSplitView } from './useShouldUseSplitView';
+
+const useNativeTabContainerWidth = isDualScreenDevice()
+  ? () => {
+      const dualScreenWidth = useDualScreenWidth();
+      return dualScreenWidth;
+    }
+  : () => {
+      const isLandscape = useIsSplitView();
+      const shouldUseSplitView = useShouldUseSplitView();
+      const { width } = useWindowDimensions();
+      const isIpadModalPage = useIsIpadModalPage();
+      const ipadModalPageWidth = useIPadModalPageWidth();
+      if (isIpadModalPage) {
+        return ipadModalPageWidth || 640;
+      }
+      // shouldUseSplitView already implies isNativeTablet() && enableSplitView.
+      // Only halve the width when the split layout is actually rendering.
+      if (shouldUseSplitView && isLandscape) {
+        return width / 2;
+      }
+      return width;
+    };
+
+export const useTabContainerWidth = platformEnv.isNative
+  ? useNativeTabContainerWidth
+  : () => {
+      const { md } = useMedia();
+      return useMemo(() => {
+        if (platformEnv.isWebDappMode || md) {
+          return `calc(100vw)`;
+        }
+        return `calc(100vw - ${
+          MIN_SIDEBAR_WIDTH +
+          DESKTOP_MODE_UI_PAGE_MARGIN +
+          DESKTOP_MODE_UI_PAGE_BORDER_WIDTH * 2
+        }px)`;
+      }, [md]);
+    };

--- a/packages/kit/src/provider/Container/index.tsx
+++ b/packages/kit/src/provider/Container/index.tsx
@@ -1,18 +1,12 @@
 import { useEffect } from 'react';
 
-import * as ScreenOrientation from 'expo-screen-orientation';
 import { RootSiblingParent } from 'react-native-root-siblings';
 
-import {
-  ESplitViewType,
-  SplitViewContext,
-  isNativeTablet,
-} from '@onekeyhq/components';
+import { ESplitViewType, SplitViewContext } from '@onekeyhq/components';
 import appGlobals from '@onekeyhq/shared/src/appGlobals';
 import LazyLoad from '@onekeyhq/shared/src/lazyLoad';
 import { setSplitViewLayoutDisabled } from '@onekeyhq/shared/src/modules/DualScreenInfo';
 import { debugLandingLog } from '@onekeyhq/shared/src/performance/init';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { WalletBackupPreCheckContainer } from '../../components/WalletBackup';
 import useAppNavigation from '../../hooks/useAppNavigation';
@@ -113,24 +107,6 @@ export function Container() {
   // split-view setting — leaving Wallet/Home content stuck on the left half.
   useEffect(() => {
     setSplitViewLayoutDisabled(!shouldUseSplitView);
-  }, [shouldUseSplitView]);
-
-  // iPad allows all orientations via Info.plist (UISupportedInterfaceOrientations~ipad).
-  // When the user opts out of the split-view layout, the single-pane UI is only
-  // designed for portrait — so lock the device to portrait. Android already
-  // forces portrait at the AndroidManifest level, so this only matters on iPad.
-  // Toggling enableSplitView restarts the app, so this effect only needs to run
-  // once per boot.
-  useEffect(() => {
-    if (!platformEnv.isNativeIOS) return;
-    if (!isNativeTablet()) return;
-    if (shouldUseSplitView) {
-      ScreenOrientation.unlockAsync().catch(() => {});
-    } else {
-      ScreenOrientation.lockAsync(
-        ScreenOrientation.OrientationLock.PORTRAIT,
-      ).catch(() => {});
-    }
   }, [shouldUseSplitView]);
 
   if (shouldUseSplitView) {

--- a/packages/kit/src/views/Borrow/pages/ReserveDetails/components/ReserveDetailsTabs.tsx
+++ b/packages/kit/src/views/Borrow/pages/ReserveDetails/components/ReserveDetailsTabs.tsx
@@ -6,12 +6,8 @@ import type {
   ITabContainerProps,
   ITabContainerRef,
 } from '@onekeyhq/components';
-import {
-  Tabs,
-  XStack,
-  YStack,
-  useTabContainerWidth,
-} from '@onekeyhq/components';
+import { Tabs, XStack, YStack } from '@onekeyhq/components';
+import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IBorrowReserveDetail } from '@onekeyhq/shared/types/staking';

--- a/packages/kit/src/views/Earn/components/EarnMainTabs.tsx
+++ b/packages/kit/src/views/Earn/components/EarnMainTabs.tsx
@@ -15,7 +15,6 @@ import {
   YStack,
   rootNavigationRef,
   useScrollContentTabBarOffset,
-  useTabContainerWidth,
   useTheme,
 } from '@onekeyhq/components';
 import {
@@ -28,6 +27,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ListItem } from '../../../components/ListItem';
 import { useIsFirstFocused } from '../../../hooks/useIsFirstFocused';
 import { useRouteIsFocused } from '../../../hooks/useRouteIsFocused';
+import { useTabContainerWidth } from '../../../hooks/useTabContainerWidth';
 import { useEarnHideSmallAssets } from '../hooks/useEarnHideSmallAssets';
 
 import { FAQContent } from './FAQContent';

--- a/packages/kit/src/views/Home/components/WalletBanner/WalletBanner.tsx
+++ b/packages/kit/src/views/Home/components/WalletBanner/WalletBanner.tsx
@@ -137,6 +137,7 @@ function BannerItem({
           right="$2"
           size="small"
           variant="tertiary"
+          hitSlop={{ top: 12, left: 12, right: 12, bottom: 12 }}
           onPress={(event: GestureResponderEvent) => {
             event.stopPropagation();
             onDismiss(item);
@@ -211,6 +212,7 @@ function NativeBannerScroller({
       Gesture.Pan()
         .activeOffsetX([-10, 10])
         .failOffsetY([-10, 10])
+        .cancelsTouchesInView(false)
         .onStart(() => {
           'worklet';
 

--- a/packages/kit/src/views/Home/pages/HomeHeaderContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeHeaderContainer.tsx
@@ -53,6 +53,11 @@ function BaseHomeHeaderContainer() {
   const shouldShowInitBlock =
     !isWalletNotBackedUp && (showReceiveInfo || showReferralCodeBlock);
 
+  let nativeMinHeight: number | undefined;
+  if (platformEnv.isNative && !isWalletNotBackedUp) {
+    nativeMinHeight = hasWalletBannerContent ? 312 : 182;
+  }
+
   const renderWalletInitBlock = useCallback(() => {
     if (isWalletNotBackedUp) {
       return null;
@@ -120,13 +125,7 @@ function BaseHomeHeaderContainer() {
       <YStack
         pb="$8"
         gap="$5"
-        minHeight={
-          platformEnv.isNative && !isWalletNotBackedUp
-            ? hasWalletBannerContent
-              ? 312
-              : 182
-            : undefined
-        }
+        minHeight={nativeMinHeight}
         $gtMd={{ gap: '$8' }}
         bg="$bgApp"
         pointerEvents="box-none"

--- a/packages/kit/src/views/Home/pages/HomeHeaderContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeHeaderContainer.tsx
@@ -9,6 +9,7 @@ import {
 import { WALLET_TYPE_HD } from '@onekeyhq/shared/src/consts/dbConsts';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
+import { useWalletTopBannersAtom } from '../../../states/jotai/contexts/accountOverview';
 import { useActiveAccount } from '../../../states/jotai/contexts/accountSelector';
 import { HomeTokenListProviderMirror } from '../components/HomeTokenListProvider/HomeTokenListProviderMirror';
 import ReferralCodeBlock from '../components/NotBakcedUp/ReferralCodeBlock';
@@ -22,7 +23,7 @@ import { HomeOverviewContainer } from './HomeOverviewContainer';
 
 function BaseHomeHeaderContainer() {
   const {
-    activeAccount: { wallet },
+    activeAccount: { wallet, account, network, vaultSettings },
   } = useActiveAccount({
     num: 0,
   });
@@ -31,6 +32,16 @@ function BaseHomeHeaderContainer() {
 
   const [showReceiveInfo, setShowReceiveInfo] = useState(false);
   const [showReferralCodeBlock, setShowReferralCodeBlock] = useState(false);
+
+  // Mirror WalletBanner's render condition so the placeholder height matches
+  // exactly what WalletBanner will display. WalletBanner returns null when
+  // `banners.length === 0 && !tronCard`; otherwise it renders the banner band
+  // (~130pt tall) and the header settles around 312pt total.
+  const [{ banners }] = useWalletTopBannersAtom();
+  const hasTronCard = Boolean(
+    vaultSettings?.hasResource && account?.id && network?.id,
+  );
+  const hasWalletBannerContent = banners.length > 0 || hasTronCard;
 
   const isWalletNotBackedUp = useMemo(() => {
     if (wallet && wallet.type === WALLET_TYPE_HD && !wallet.backuped) {
@@ -110,25 +121,15 @@ function BaseHomeHeaderContainer() {
         pb="$8"
         gap="$5"
         minHeight={
-          platformEnv.isNative && !isWalletNotBackedUp ? 312 : undefined
+          platformEnv.isNative && !isWalletNotBackedUp
+            ? hasWalletBannerContent
+              ? 312
+              : 182
+            : undefined
         }
         $gtMd={{ gap: '$8' }}
         bg="$bgApp"
         pointerEvents="box-none"
-        onLayout={(e) => {
-          try {
-            // eslint-disable-next-line @typescript-eslint/no-require-imports
-            const { NativeLogger: NL, LogLevel: LL } =
-              require('@onekeyhq/shared/src/modules3rdParty/react-native-file-logger') as typeof import('@onekeyhq/shared/src/modules3rdParty/react-native-file-logger');
-            const { height } = e.nativeEvent.layout;
-            NL.write(
-              LL.Info,
-              `[LayoutDiag] HeaderContainer: h=${height} rounded=${Math.round(height)} diff=${(height - 312).toFixed(2)}`,
-            );
-          } catch {
-            /* */
-          }
-        }}
       >
         <Stack
           testID={HomeTestIDs.headerContainer}

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -18,10 +18,10 @@ import {
   YStack,
   useFocusedTab,
   useScrollContentTabBarOffset,
-  useTabContainerWidth,
 } from '@onekeyhq/components';
 import type { ITabBarItemProps } from '@onekeyhq/components/src/composite/Tabs/TabBar';
 import { TabBarItem } from '@onekeyhq/components/src/composite/Tabs/TabBar';
+import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import { getNetworksSupportBulkRevokeApproval } from '@onekeyhq/shared/src/config/presetNetworks';
 import {
   WALLET_TYPE_HD,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/layout/MobileInformationTabs.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/layout/MobileInformationTabs.tsx
@@ -2,12 +2,8 @@ import { useCallback, useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import {
-  HeaderScrollGestureWrapper,
-  Tabs,
-  YStack,
-  useTabContainerWidth,
-} from '@onekeyhq/components';
+import { HeaderScrollGestureWrapper, Tabs, YStack } from '@onekeyhq/components';
+import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import { isHoldersTabSupported } from '@onekeyhq/shared/src/consts/marketConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
@@ -10,15 +10,10 @@ import {
 } from 'react';
 import type { RefObject } from 'react';
 
-import {
-  IconButton,
-  Tabs,
-  XStack,
-  YStack,
-  useTabContainerWidth,
-} from '@onekeyhq/components';
+import { IconButton, Tabs, XStack, YStack } from '@onekeyhq/components';
 import type { ITabContainerRef } from '@onekeyhq/components';
 import { useTabBarHeight } from '@onekeyhq/components/src/layouts/Page/hooks';
+import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import { useMarketWatchListV2Atom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
@@ -10,15 +10,10 @@ import {
 } from 'react';
 import type { RefObject } from 'react';
 
-import {
-  IconButton,
-  Tabs,
-  XStack,
-  YStack,
-  useTabContainerWidth,
-} from '@onekeyhq/components';
+import { IconButton, Tabs, XStack, YStack } from '@onekeyhq/components';
 import type { ITabContainerRef } from '@onekeyhq/components';
 import { useTabBarHeight } from '@onekeyhq/components/src/layouts/Page/hooks';
+import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import { useMarketWatchListV2Atom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 

--- a/packages/kit/src/views/Market/components/TokenDetailTabs.tsx
+++ b/packages/kit/src/views/Market/components/TokenDetailTabs.tsx
@@ -11,9 +11,9 @@ import {
   useIsOverlayPage,
   useMedia,
   useSplitSubView,
-  useTabContainerWidth,
 } from '@onekeyhq/components';
 import type { IDeferredPromise } from '@onekeyhq/components';
+import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IMarketTokenDetail } from '@onekeyhq/shared/types/market';

--- a/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSyncDebug.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeCloudSync/PagePrimeCloudSyncDebug.tsx
@@ -16,11 +16,11 @@ import {
   XStack,
   YStack,
   useClipboard,
-  useTabContainerWidth,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { useOneKeyAuth } from '@onekeyhq/kit/src/components/OneKeyAuth/useOneKeyAuth';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import type { IDBCloudSyncItem } from '@onekeyhq/kit-bg/src/dbs/local/types';
 import {
   useDevSettingsPersistAtom,

--- a/packages/shared/src/modules/DualScreenInfo/index.android.ts
+++ b/packages/shared/src/modules/DualScreenInfo/index.android.ts
@@ -93,3 +93,15 @@ export const useDualScreenWidth = () => {
   }, []);
   return width;
 };
+
+export const useIsSplitViewLayoutDisabled = () => {
+  const [disabled, setDisabled] = useState(splitViewLayoutDisabled);
+  useEffect(() => {
+    const update = () => setDisabled(splitViewLayoutDisabled);
+    splitViewLayoutListeners.add(update);
+    return () => {
+      splitViewLayoutListeners.delete(update);
+    };
+  }, []);
+  return disabled;
+};

--- a/packages/shared/src/modules/DualScreenInfo/index.ts
+++ b/packages/shared/src/modules/DualScreenInfo/index.ts
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import { Dimensions } from 'react-native';
 
 export const isDualScreenDevice = () => {
@@ -20,6 +22,26 @@ export const useDualScreenWidth = () => {
   return Dimensions.get('window').width;
 };
 
-export function setSplitViewLayoutDisabled(_disabled: boolean) {
-  // no-op outside Android dual-screen devices
+// Mirror the Android implementation: kit calls `setSplitViewLayoutDisabled`
+// from <Container> at startup so non-dual-screen platforms (iPad) can also gate
+// split-view-only width math behind the `enableSplitView` setting.
+let splitViewLayoutDisabled = false;
+const splitViewLayoutListeners = new Set<() => void>();
+
+export function setSplitViewLayoutDisabled(disabled: boolean) {
+  if (splitViewLayoutDisabled === disabled) return;
+  splitViewLayoutDisabled = disabled;
+  splitViewLayoutListeners.forEach((fn) => fn());
 }
+
+export const useIsSplitViewLayoutDisabled = () => {
+  const [disabled, setDisabled] = useState(splitViewLayoutDisabled);
+  useEffect(() => {
+    const update = () => setDisabled(splitViewLayoutDisabled);
+    splitViewLayoutListeners.add(update);
+    return () => {
+      splitViewLayoutListeners.delete(update);
+    };
+  }, []);
+  return disabled;
+};


### PR DESCRIPTION
Bundles three fixes destined for `release/v6.3.0`. The first two are backports of already-merged PRs (#11688, #11694); the third is the new home banner placeholder work this branch was originally opened for.

> **Note 2026-05-21**: the four bg-thread perf commits that were briefly on this branch have been moved to their own PR (#11740) for cleaner review and isolated rollout.

## 1. `fix(home)`: match banner placeholder height to predicted content
The 312px `minHeight` on the wallet home header was a cold-start placeholder to absorb async banner loading jitter. It oversized the container by ~130px, leaving a visible empty gap between the action buttons and the spot/history tabs whenever the user dismissed all banners or the API returned none.

- Mirror `WalletBanner`'s render condition (`banners.length === 0 && !tronCard`) by reading the same `walletTopBannersAtom` and `vaultSettings` the component itself reads.
- Apply `312` when content will render, `182` (measured natural height without the banner band) when it won't. The atom's `coldStartCache` keeps the prediction stable across launches.
- Drop the `LayoutDiag` `onLayout` logger that was instrumentation around the old 312 baseline.
- Follow-up `chore`: extract the nested ternary into a single `nativeMinHeight` variable for readability.
- Follow-up `fix(home)`: make the iOS banner close button reliably tappable (extended hit slop + gesture priority so the dismiss tap registers even near scroll edges).

## 2. `fix(tabs)`: fill full width on iPad when split view is disabled (backport of #11688)
When `enableSplitView` is off, iPad should render the home/wallet content full-width in both portrait and landscape. Previously the orientation lock forced portrait and the tab container always halved width in landscape.

- Move `useTabContainerWidth` to `packages/kit` so it can read `enableSplitView` via `useShouldUseSplitView`; halve width only when the split layout is actually rendering.
- Remove the iPad portrait orientation lock — the device can rotate freely regardless of the split-view setting.
- Keep the components-side `useTabContainerWidth` (used by Toast/`usePageWidth`) in sync via `setSplitViewLayoutDisabled`, now wired up on iOS too.

## 3. `fix(address-type-selector)`: close popover before HW `createAddress` (backport of #11694)
Hardware wallets open the Enter PIN / Passphrase dialog during `createAddress`. The Tamagui popover's default z-index (150_000) was hiding those dialogs (z-index 100_000). Close the popover first when the wallet is HW; software wallets keep it open to show inline loading.

## Test plan

### Home banner
- [ ] iOS native — no empty gap after dismissing all closeable banners.
- [ ] iOS native — 312 placeholder still applies on cold start when banners are cached.
- [ ] iOS native — **fresh install** first home view: observe whether a visible ~130px content shift happens when the first banner response arrives (acceptable per current design but should be measured).
- [ ] iOS native — switching to a wallet with **no banner cache history** — same observation.
- [ ] iOS native — TRON account: `tronCard`-only state keeps `minHeight` at 312.
- [ ] iOS native — Perps referral banner (non-closeable) keeps `minHeight` at 312.
- [ ] iOS native — banner close button tap is reliable near scroll edges.
- [ ] Android native — same checks.
- [ ] Web / Extension — unchanged (path returns `undefined`).
- [ ] Non-backed-up HD wallet — header still skips banner/`minHeight` path.

### iPad split view
- [ ] iPad with `enableSplitView` OFF — home tabs render full-width in both portrait and landscape.
- [ ] iPad with `enableSplitView` ON — landscape still halves width as before.
- [ ] iPad — device can rotate freely when split view is disabled.
- [ ] **iPad landscape single-pane regression sweep** (since the portrait lock is gone): Home, Discover, Swap, Earn, Market, Settings modal, HW pairing — verify no overflow / clipping / Fabric layout jitter on rotate.
- [ ] **Components↔kit `useTabContainerWidth` parity**: Toast positioning and full-screen page width remain correct under both split-view ON and OFF.

### HW popover
- [ ] Hardware wallet — PIN / Passphrase dialog is visible (not hidden behind popover) when creating an address from the address type selector.
- [ ] Software wallet — popover stays open with inline loading.
