### PR TITLE
fix(prime-transfer): auto-disconnect on missing peer after pairing (OK-51681)

### DIFF
--- a/packages/kit/src/views/Prime/pages/PagePrimeTransfer/components/PrimeTransferDirection.tsx
+++ b/packages/kit/src/views/Prime/pages/PagePrimeTransfer/components/PrimeTransferDirection.tsx
@@ -293,8 +293,10 @@ export function PrimeTransferDirection({
     if (!roomId) return;
     if (peerPresenceCheckedRoomId.current === roomId) return;
 
+    let cancelled = false;
     const timer = setTimeout(() => {
       void (async () => {
+        if (cancelled) return;
         if (peerPresenceCheckedRoomId.current === roomId) return;
         peerPresenceCheckedRoomId.current = roomId;
         try {
@@ -302,6 +304,10 @@ export function PrimeTransferDirection({
             await backgroundApiProxy.servicePrimeTransfer.getRoomUsers({
               roomId,
             });
+          // Bail out if the room/status changed while the request was in
+          // flight — otherwise a stale `users.length < 2` from the previous
+          // pairing session could force-exit a new valid session.
+          if (cancelled) return;
           if (users.length < 2) {
             appEventBus.emit(EAppEventBusNames.PrimeTransferForceExit, {
               title: intl.formatMessage({
@@ -316,7 +322,10 @@ export function PrimeTransferDirection({
       })();
     }, 3000);
 
-    return () => clearTimeout(timer);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
   }, [primeTransferAtom.status, primeTransferAtom.pairedRoomId, intl]);
 
   // Bot wallet export: auto-fix direction so current device is always the sender

--- a/packages/kit/src/views/Prime/pages/PagePrimeTransfer/components/PrimeTransferDirection.tsx
+++ b/packages/kit/src/views/Prime/pages/PagePrimeTransfer/components/PrimeTransferDirection.tsx
@@ -281,6 +281,44 @@ export function PrimeTransferDirection({
     primeTransferAtom.pairedRoomId,
   ]);
 
+  // OK-51681: After entering the transfer-data page, confirm the peer is still
+  // in the room. The `user-left` socket event can race with the paired-status
+  // transition when the peer cancels mid-pairing, leaving this side stuck on
+  // the paired screen with no real peer. The delay gives the server room state
+  // a chance to settle before we act on it.
+  const peerPresenceCheckedRoomId = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    if (primeTransferAtom.status !== EPrimeTransferStatus.paired) return;
+    const roomId = primeTransferAtom.pairedRoomId;
+    if (!roomId) return;
+    if (peerPresenceCheckedRoomId.current === roomId) return;
+
+    const timer = setTimeout(() => {
+      void (async () => {
+        if (peerPresenceCheckedRoomId.current === roomId) return;
+        peerPresenceCheckedRoomId.current = roomId;
+        try {
+          const users =
+            await backgroundApiProxy.servicePrimeTransfer.getRoomUsers({
+              roomId,
+            });
+          if (users.length < 2) {
+            appEventBus.emit(EAppEventBusNames.PrimeTransferForceExit, {
+              title: intl.formatMessage({
+                id: ETranslations.global_connet_error_try_again,
+              }),
+              description: platformEnv.isDev ? 'PeerMissingAfterPaired' : '',
+            });
+          }
+        } catch (error) {
+          console.error('[PeerPresenceCheck] failed:', error);
+        }
+      })();
+    }, 2000);
+
+    return () => clearTimeout(timer);
+  }, [primeTransferAtom.status, primeTransferAtom.pairedRoomId, intl]);
+
   // Bot wallet export: auto-fix direction so current device is always the sender
   const botDirectionFixDone = useRef(false);
   const fixBotDirection = useCallback(async () => {

--- a/packages/kit/src/views/Prime/pages/PagePrimeTransfer/components/PrimeTransferDirection.tsx
+++ b/packages/kit/src/views/Prime/pages/PagePrimeTransfer/components/PrimeTransferDirection.tsx
@@ -314,7 +314,7 @@ export function PrimeTransferDirection({
           console.error('[PeerPresenceCheck] failed:', error);
         }
       })();
-    }, 2000);
+    }, 3000);
 
     return () => clearTimeout(timer);
   }, [primeTransferAtom.status, primeTransferAtom.pairedRoomId, intl]);


### PR DESCRIPTION
## Summary

- Closes [OK-51681](https://onekeyhq.atlassian.net/browse/OK-51681).
- When the peer (B side) cancels the transfer mid-pairing, the `user-left` socket event can race with the paired-status transition on the A side, leaving the transfer-data page stuck in `paired` state with an empty peer.
- Add a one-shot delayed presence check (2s) after entering the paired screen: re-fetch the room user list and force-exit with `global.connet_error_try_again` if the peer is missing. Guarded by `pairedRoomId` so it only runs once per pairing session.

## Test plan

- [ ] A side creates link/QR; B side enters the pairing code and then immediately exits the loading dialog → expect A side to show "Connection error, please try again" and return to the home screen within ~2s.
- [ ] Normal flow (both sides stay connected) is unaffected — direction page loads, both devices are visible, transfer proceeds as before.
- [ ] Pair → cancel mid-transfer (existing `PrimeTransferCancel` path) → back to paired → no duplicate force-exit fires (ref-guarded by `pairedRoomId`).
- [ ] Bot-wallet export path (`fixTransferDirectionForKeylessWallet`) still works.

[OK-51681]: https://onekeyhq.atlassian.net/browse/OK-51681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ