### PR TITLE
fix(discovery): prevent desktop browser home page jitter when adding a new tab (OK-54658)

### DIFF
--- a/packages/kit/src/states/jotai/contexts/discovery/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/discovery/actions.test.tsx
@@ -26,6 +26,7 @@ import {
   useDisplayHomePageAtom,
   useWebTabsAtom,
   webTabsAtom,
+  webTabsMapAtom,
 } from './atoms';
 
 const mockSetBrowserTabsRawData = jest.fn();
@@ -164,6 +165,10 @@ function createWrapper({
     keys: tabs.map((tab) => tab.id),
     tabs,
   });
+  store.set(
+    webTabsMapAtom(),
+    Object.fromEntries(tabs.map((tab) => [tab.id, tab])),
+  );
 
   return function Wrapper({ children }: { children?: ReactNode }) {
     return (
@@ -236,6 +241,95 @@ describe('useBrowserTabActions', () => {
         }),
       ],
     });
+  });
+
+  it('keeps a desktop home tab in place when it opens its first page and still allows drag sorting', async () => {
+    Object.assign(platformEnv, {
+      isDesktop: true,
+      isNative: false,
+      isNativeAndroid: false,
+      isNativeIOS: false,
+    });
+
+    const { result } = renderHook(
+      () => {
+        const tabActions = useBrowserTabActions().current;
+        const browserActions = useBrowserAction().current;
+        const [webTabs] = useWebTabsAtom();
+
+        return {
+          browserActions,
+          tabActions,
+          tabs: webTabs.tabs,
+        };
+      },
+      {
+        wrapper: createWrapper({
+          tabs: [
+            {
+              id: 'tab-1',
+              url: 'https://previous.example',
+              title: 'Previous',
+              timestamp: 100,
+            },
+            {
+              id: 'home-tab',
+              url: '',
+              title: 'Start Tab',
+              timestamp: 200,
+              type: 'home',
+              isActive: true,
+            },
+            {
+              id: 'tab-2',
+              url: 'https://next.example',
+              title: 'Next',
+              timestamp: 300,
+            },
+          ],
+          activeTabId: 'home-tab',
+          displayHomePage: false,
+        }),
+      },
+    );
+
+    await act(async () => {
+      await result.current.browserActions.gotoSite({
+        id: 'home-tab',
+        url: 'https://bookmark.example',
+        title: 'Bookmark',
+      });
+    });
+
+    expect(result.current.tabs.map((tab) => tab.id)).toEqual([
+      'tab-1',
+      'home-tab',
+      'tab-2',
+    ]);
+    expect(result.current.tabs.find((tab) => tab.id === 'home-tab')).toEqual(
+      expect.objectContaining({
+        timestamp: 200,
+        type: 'normal',
+        url: 'https://bookmark.example',
+      }),
+    );
+
+    act(() => {
+      result.current.tabActions.setTabsByIds({
+        pinnedTabs: [],
+        unpinnedTabs: [
+          { id: 'tab-1', timestamp: 100 },
+          { id: 'tab-2', timestamp: 300 },
+          { id: 'home-tab', timestamp: 302 },
+        ],
+      });
+    });
+
+    expect(result.current.tabs.map((tab) => tab.id)).toEqual([
+      'tab-1',
+      'tab-2',
+      'home-tab',
+    ]);
   });
 
   it('selects a replacement tab after closing the current tab outside native', () => {

--- a/packages/kit/src/states/jotai/contexts/discovery/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/discovery/actions.ts
@@ -361,6 +361,48 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
     }
   });
 
+  openUrlInHomeTab = contextAtomMethod(
+    (
+      get,
+      set,
+      payload: {
+        id: string;
+        url: string;
+        title?: string;
+        favicon?: string;
+        isBookmark?: boolean;
+        siteMode?: ESiteMode;
+      },
+    ) => {
+      const { tabs } = get(webTabsAtom());
+      const tabIndex = tabs.findIndex((t) => t.id === payload.id);
+      if (tabIndex === -1) {
+        return;
+      }
+
+      const previousTab = tabs[tabIndex];
+      const nextTab: IWebTab = {
+        ...previousTab,
+        url: payload.url,
+        title: payload.title || previousTab.title,
+        favicon: payload.favicon ?? previousTab.favicon,
+        isBookmark: payload.isBookmark,
+        siteMode: payload.siteMode,
+        type: 'normal',
+        timestamp: previousTab.timestamp ?? Date.now(),
+      };
+
+      lastNavigationFlags[payload.id] = Date.now();
+
+      const nextTabs = [...tabs];
+      nextTabs[tabIndex] = nextTab;
+      this.buildWebTabs.call(set, {
+        data: nextTabs,
+        options: { forceUpdate: true },
+      });
+    },
+  );
+
   buildClosedTabData = contextAtomMethod((get, set, payload: IWebTab[]) => {
     const isReady = get(browserDataReadyAtom());
     if (!isReady) {
@@ -814,7 +856,6 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
         isInPlace,
       }: IGotoSiteFnParams,
     ) => {
-      const tab = this.getWebTabById.call(set, id ?? '');
       if (url) {
         const allowLocalhostUrl = isLocalhostUrlAllowedInDAppBrowser();
         const isLocalhost = uriUtils.isLocalhostUrl(url);
@@ -832,6 +873,7 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
           return openUrlInApp(validatedUrl);
         }
 
+        const tab = this.getWebTabById.call(set, id ?? '');
         const tabId = tab?.id;
 
         const thisTab = this.getWebTabById.call(set, tabId ?? '');
@@ -841,7 +883,8 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
             : (isNewWindow || !tabId || tabId === 'home') &&
               browserTypeHandler === 'MultiTabBrowser';
 
-        if (thisTab?.type === 'home') {
+        const shouldOpenInHomeTab = thisTab?.type === 'home';
+        if (shouldOpenInHomeTab) {
           isNewTab = false;
         }
 
@@ -858,6 +901,18 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
             siteMode,
             type: 'normal',
           });
+        } else if (shouldOpenInHomeTab && tabId) {
+          this.openUrlInHomeTab.call(set, {
+            id: tabId,
+            url: validatedUrl,
+            title,
+            favicon,
+            isBookmark,
+            siteMode,
+          });
+          if (!isInPlace) {
+            this.setCurrentWebTab.call(set, tabId);
+          }
         } else {
           this.setWebTabData.call(set, {
             id: tabId,

--- a/packages/kit/src/views/Discovery/pages/Browser/DesktopBrowserContent.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/DesktopBrowserContent.tsx
@@ -228,6 +228,8 @@ function BasicFind({ id }: { id: string }) {
 
 const Find = memo(BasicFind);
 
+const DESKTOP_HOME_PAGE_VISIBLE_DELAY_MS = 200;
+
 function BasicDesktopBrowserContent({
   id,
   activeTabId,
@@ -237,6 +239,8 @@ function BasicDesktopBrowserContent({
 }) {
   const { tab } = useWebTabDataById(id);
   const isActive = activeTabId === id;
+  const isHomeTab = !tab?.url;
+  const [homePageReady, setHomePageReady] = useState(!isHomeTab);
 
   // Memory Cleanup - Aggressively release all resources when tab is closed
   useEffect(() => {
@@ -306,6 +310,22 @@ function BasicDesktopBrowserContent({
     };
   }, [id]);
 
+  useEffect(() => {
+    if (!isHomeTab) {
+      setHomePageReady(true);
+      return undefined;
+    }
+
+    setHomePageReady(false);
+    const timer = setTimeout(() => {
+      setHomePageReady(true);
+    }, DESKTOP_HOME_PAGE_VISIBLE_DELAY_MS);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [isHomeTab]);
+
   const { customReceiveHandler } = useDiscoveryMessageHandler();
 
   return (
@@ -319,7 +339,9 @@ function BasicDesktopBrowserContent({
           customReceiveHandler={customReceiveHandler}
         />
       ) : (
-        <DashboardContent />
+        <Stack flex={1} opacity={homePageReady ? 1 : 0}>
+          <DashboardContent />
+        </Stack>
       )}
     </Freeze>
   );

--- a/packages/kit/src/views/Discovery/pages/Dashboard/Welcome/DefaultTitle.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/Welcome/DefaultTitle.tsx
@@ -1,46 +1,23 @@
 // Let's Dive in
-import { memo, useEffect } from 'react';
+import { memo } from 'react';
 
 import { useIntl } from 'react-intl';
-import Animated, {
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated';
 
 import { SizableText } from '@onekeyhq/components/src/primitives';
 import { ETranslations } from '@onekeyhq/shared/src/locale/enum/translations';
 
 const DefaultTitleComponent = () => {
   const intl = useIntl();
-  const opacity = useSharedValue(0);
-  const translateY = useSharedValue(-10);
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      opacity.value = withTiming(1, { duration: 300 });
-      translateY.value = withTiming(0, { duration: 400 });
-    }, 300);
-
-    return () => clearTimeout(timer);
-  }, [opacity, translateY]);
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    opacity: opacity.value,
-    transform: [{ translateY: translateY.value }],
-  }));
 
   return (
-    <Animated.View style={animatedStyle}>
-      <SizableText
-        color="$text"
-        size="$heading2xl"
-        fontWeight="bold"
-        textAlign="center"
-      >
-        {intl.formatMessage({ id: ETranslations.browser_dive_in })}
-      </SizableText>
-    </Animated.View>
+    <SizableText
+      color="$text"
+      size="$heading2xl"
+      fontWeight="bold"
+      textAlign="center"
+    >
+      {intl.formatMessage({ id: ETranslations.browser_dive_in })}
+    </SizableText>
   );
 };
 


### PR DESCRIPTION
## Summary
- Keep a desktop browser home tab in its existing position when it opens its first page, instead of letting it jump/reorder.
- Hide the dashboard (home page) content behind a short opacity gate so it does not flash a half–laid-out frame while a new tab is added.
- Remove the entrance animation from the "Let's Dive in" title, which contributed to the visible jitter.

## Intent & Context
Jira OK-54658: "Browser - 侧边栏添加新标签页时，背景页面跳动" — on desktop, when a new tab is added from the sidebar, the background home page visibly jitters/jumps. This PR removes the sources of that jitter.

## Root Cause
Two independent causes:
1. **Tab reorder** — When the active `home` tab navigated to its first real page, `gotoSite` routed through `setWebTabData`, which could move the tab out of its current position in the tab list.
2. **Visible re-layout / animation** — The dashboard re-rendered and laid out while still on screen, and the "Let's Dive in" title ran a delayed `translateY` + `opacity` entrance animation each time, so the background page appeared to jump.

## Design Decisions
- Added a dedicated `openUrlInHomeTab` action that updates the home tab **in place** at its current index and preserves its `timestamp`, so the tab does not reorder. Restored `setCurrentWebTab` for non-`isInPlace` navigation so focus still follows. Kept `setWebTabData` for all other (non-home) cases to avoid behavior changes.
- Gated `DashboardContent` behind a 200ms `opacity` transition (`homePageReady`) rather than mounting/unmounting, so the dashboard finishes layout off-screen and fades in cleanly. Non-home tabs skip the gate entirely.
- Dropped the reanimated entrance animation in `DefaultTitle` instead of tuning its timing — the title is now static, removing the jitter at its source and simplifying the component.

## Changes Detail
- `states/jotai/contexts/discovery/actions.ts` — New `openUrlInHomeTab` context action; `gotoSite` now routes home-tab navigation through it and calls `setCurrentWebTab` when not in place. Moved `getWebTabById` lookup after the open-in-app early return.
- `views/Discovery/pages/Browser/DesktopBrowserContent.tsx` — Added `homePageReady` state with a 200ms delay; wraps `DashboardContent` in an opacity `Stack`.
- `views/Discovery/pages/Dashboard/Welcome/DefaultTitle.tsx` — Removed reanimated entrance animation; renders a static `SizableText`.
- `states/jotai/contexts/discovery/actions.test.tsx` — New test: a desktop home tab stays in place when it opens its first page and is still drag-sortable afterward.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop
- **Risk Areas**: `gotoSite` home-tab branch — the new `openUrlInHomeTab` path replaces the previous `setWebTabData` call for home tabs; covered by the new unit test.

## Test plan
- [ ] On desktop, open the browser with a home/start tab and add a new tab from the sidebar — the background home page must not jitter.
- [ ] From a home tab, open a bookmark/site — the tab keeps its position in the tab bar and becomes active.
- [ ] Drag-sort tabs after a home tab has opened its first page — ordering still works.
- [ ] Non-home tabs and "open in new tab" behavior are unchanged.
