### PR TITLE
fix: handle disabled bot wallet actions(OK-53641)

### DIFF
--- a/packages/components/src/actions/ActionList/index.tsx
+++ b/packages/components/src/actions/ActionList/index.tsx
@@ -52,6 +52,7 @@ export interface IActionListItemProps {
   onPress?: (close: () => void) => void | Promise<boolean | void>;
   onClose?: () => void;
   disabled?: boolean;
+  allowPressWhenDisabled?: boolean;
   extraInteractiveWhenDisabled?: boolean;
   testID?: string;
   trackID?: string;
@@ -114,6 +115,7 @@ export function ActionListItem(
     onPress,
     destructive,
     disabled,
+    allowPressWhenDisabled,
     extraInteractiveWhenDisabled,
     onClose,
     testID,
@@ -123,6 +125,14 @@ export function ActionListItem(
   const isActionDisabled = Boolean(disabled);
   const shouldKeepExtraInteractive = Boolean(
     isActionDisabled && extraInteractiveWhenDisabled,
+  );
+  const shouldAllowPressWhenDisabled = Boolean(
+    isActionDisabled && allowPressWhenDisabled,
+  );
+  const shouldSetAriaDisabled = Boolean(
+    isActionDisabled &&
+    !shouldAllowPressWhenDisabled &&
+    !shouldKeepExtraInteractive,
   );
 
   const handlePress = useCallback(
@@ -148,6 +158,7 @@ export function ActionListItem(
 
   const { onPress: sharedOnPress } = useSharedPress({
     ...props,
+    disabled: isActionDisabled && !shouldAllowPressWhenDisabled,
     onPress: handlePress,
   });
 
@@ -162,10 +173,18 @@ export function ActionListItem(
       $md={ACTION_LIST_ITEM_MD}
       borderCurve="continuous"
       opacity={disabled ? 0.5 : 1}
-      disabled={shouldKeepExtraInteractive ? false : disabled}
-      aria-disabled={disabled}
+      disabled={
+        shouldKeepExtraInteractive || shouldAllowPressWhenDisabled
+          ? false
+          : disabled
+      }
+      aria-disabled={shouldSetAriaDisabled}
       {...(!disabled && ACTION_LIST_ENABLED_STYLE)}
-      onPress={isLoading || isActionDisabled ? undefined : sharedOnPress}
+      onPress={
+        isLoading || (isActionDisabled && !allowPressWhenDisabled)
+          ? undefined
+          : sharedOnPress
+      }
       testID={testID}
     >
       <XStack jc="space-between" flex={1} alignItems="center">

--- a/packages/components/src/actions/IconButton/index.tsx
+++ b/packages/components/src/actions/IconButton/index.tsx
@@ -24,6 +24,7 @@ export interface IIconButtonProps extends Omit<
   icon: IKeyOfIcons;
   iconSize?: IIconProps['size'];
   iconProps?: IIconProps;
+  allowPressWhenDisabled?: boolean;
   title?: ITooltipProps['renderContent'];
   // Allow triggering via the Enter or Space key.
   hotKey?: boolean;
@@ -57,6 +58,7 @@ export function IconButton(props: IIconButtonProps) {
     title,
     icon,
     iconProps,
+    allowPressWhenDisabled = false,
     size,
     variant = 'secondary',
     hotKey = false,
@@ -65,10 +67,12 @@ export function IconButton(props: IIconButtonProps) {
     ...rest
   } = props;
 
+  const visualDisabled = !!disabled;
+  const effectiveDisabled = visualDisabled && !allowPressWhenDisabled;
   const { p, negativeMargin } = getSizeStyles(size);
 
   const { sharedFrameStyles, iconColor } = getSharedButtonStyles({
-    disabled,
+    disabled: visualDisabled,
     loading,
     variant,
   });
@@ -84,8 +88,8 @@ export function IconButton(props: IIconButtonProps) {
       <ButtonFrame
         p={p}
         borderRadius="$full"
-        disabled={!!disabled || !!loading}
-        aria-disabled={!!disabled || !!loading}
+        disabled={effectiveDisabled || !!loading}
+        aria-disabled={effectiveDisabled || !!loading}
         // @ts-expect-error
         onKeyDown={hotKey ? undefined : onKeyDown}
         hitSlop={size === 'small' ? NATIVE_HIT_SLOP : undefined}
@@ -116,7 +120,7 @@ export function IconButton(props: IIconButtonProps) {
       </ButtonFrame>
     ),
     [
-      disabled,
+      effectiveDisabled,
       hotKey,
       icon,
       iconColor,

--- a/packages/components/src/actions/SegmentControl/index.tsx
+++ b/packages/components/src/actions/SegmentControl/index.tsx
@@ -24,6 +24,7 @@ export interface ISegmentControlProps extends IXStackProps {
     label: string | ReactElement;
     value: string | number;
     testID?: string;
+    disabled?: boolean;
   }[];
   onChange: (value: string | number) => void;
   segmentControlItemStyleProps?: GetProps<typeof YStack>;
@@ -131,13 +132,14 @@ function SegmentControlFrame({
       h={32}
       {...rest}
     >
-      {options.map(({ label, value: v, testID }, index) => (
+      {options.map(({ label, value: v, testID, disabled }, index) => (
         <SegmentControlItem
           testID={testID}
           key={index}
           label={label}
           value={v}
           active={value === v}
+          disabled={disabled}
           onChange={handleChange}
           activeBackgroundColor={activeBackgroundColor}
           activeTextColor={activeTextColor}

--- a/packages/kit/src/components/AccountSelector/AccountSelectorActiveAccount.tsx
+++ b/packages/kit/src/components/AccountSelector/AccountSelectorActiveAccount.tsx
@@ -51,6 +51,30 @@ const AllNetworkAccountSelector = ({
     useAllNetworkCopyAddressHandler({
       activeAccount,
     });
+  const { isBotWallet, isBotWalletDeactivated } = useBotWalletDeactivatedStatus(
+    {
+      walletId: activeAccount?.wallet?.id,
+    },
+  );
+  const isCopyDisabled = shouldBlockBotWalletCopyAddress({
+    isBotWallet,
+    isBotWalletDeactivated,
+  });
+  const handleCopyAddress = useCallback(async () => {
+    if (isCopyDisabled) {
+      showBotWalletDisabledToast('copyAddress');
+      return;
+    }
+
+    if (
+      await backgroundApiProxy.serviceAccount.checkIsWalletNotBackedUp({
+        walletId: activeAccount?.wallet?.id ?? '',
+      })
+    ) {
+      return;
+    }
+    await handleAllNetworkCopyAddress(true);
+  }, [activeAccount?.wallet?.id, handleAllNetworkCopyAddress, isCopyDisabled]);
 
   if (!isAllNetworkEnabled) {
     return null;
@@ -70,11 +94,12 @@ const AllNetworkAccountSelector = ({
           m="$-1"
           borderRadius="$2"
           hoverStyle={{
-            bg: '$bgHover',
+            bg: isCopyDisabled ? '$transparent' : '$bgHover',
           }}
           pressStyle={{
-            bg: '$bgActive',
+            bg: isCopyDisabled ? '$transparent' : '$bgActive',
           }}
+          opacity={isCopyDisabled ? 0.5 : 1}
           focusVisibleStyle={{
             outlineColor: '$focusRing',
             outlineWidth: 2,
@@ -87,16 +112,7 @@ const AllNetworkAccountSelector = ({
             top: 8,
           }}
           userSelect="none"
-          onPress={async () => {
-            if (
-              await backgroundApiProxy.serviceAccount.checkIsWalletNotBackedUp({
-                walletId: activeAccount?.wallet?.id ?? '',
-              })
-            ) {
-              return;
-            }
-            await handleAllNetworkCopyAddress(true);
-          }}
+          onPress={handleCopyAddress}
         >
           <Icon size="$5" name="Copy3Outline" color="$iconSubdued" />
         </XStack>
@@ -197,6 +213,13 @@ export function AccountSelectorActiveAccountHome({
     isBotWallet,
     isBotWalletDeactivated,
   });
+  const handleAllNetworkCopyAddressOnPress = useCallback(async () => {
+    if (isCopyDisabled) {
+      showBotWalletDisabledToast('copyAddress');
+      return;
+    }
+    await handleAllNetworkCopyAddress();
+  }, [handleAllNetworkCopyAddress, isCopyDisabled]);
 
   const logActiveAccount = useCallback(() => {
     console.log({
@@ -310,7 +333,7 @@ export function AccountSelectorActiveAccountHome({
   useShortcutsOnRouteFocused(
     EShortcutEvents.CopyAddressOrUrl,
     account?.address === ALL_NETWORK_ACCOUNT_MOCK_ADDRESS
-      ? handleAllNetworkCopyAddress
+      ? handleAllNetworkCopyAddressOnPress
       : handleAddressOnPress,
   );
 

--- a/packages/kit/src/components/AccountSelector/AccountSelectorActiveAccount.tsx
+++ b/packages/kit/src/components/AccountSelector/AccountSelectorActiveAccount.tsx
@@ -52,16 +52,6 @@ const AllNetworkAccountSelector = ({
       activeAccount,
     });
 
-  const { isBotWallet, isBotWalletDeactivated } = useBotWalletDeactivatedStatus(
-    {
-      walletId: activeAccount?.wallet?.id,
-    },
-  );
-  const isCopyDisabled = shouldBlockBotWalletCopyAddress({
-    isBotWallet,
-    isBotWalletDeactivated,
-  });
-
   if (!isAllNetworkEnabled) {
     return null;
   }
@@ -97,12 +87,7 @@ const AllNetworkAccountSelector = ({
             top: 8,
           }}
           userSelect="none"
-          opacity={isCopyDisabled ? 0.5 : 1}
           onPress={async () => {
-            if (isCopyDisabled) {
-              showBotWalletDisabledToast('copyAddress');
-              return;
-            }
             if (
               await backgroundApiProxy.serviceAccount.checkIsWalletNotBackedUp({
                 walletId: activeAccount?.wallet?.id ?? '',
@@ -147,9 +132,11 @@ const AllNetworkAccountSelector = ({
 function CopyButton({
   onPress,
   visible,
+  disabled,
 }: {
   onPress: IIconButtonProps['onPress'];
   visible: boolean;
+  disabled?: boolean;
 }) {
   const intl = useIntl();
   return visible ? (
@@ -161,6 +148,8 @@ function CopyButton({
       icon="Copy3Outline"
       size="small"
       variant="tertiary"
+      disabled={disabled}
+      allowPressWhenDisabled={disabled}
       onPress={onPress}
     />
   ) : null;
@@ -356,10 +345,10 @@ export function AccountSelectorActiveAccountHome({
               mx="$-2"
               borderRadius="$2"
               hoverStyle={{
-                bg: '$bgHover',
+                bg: isCopyDisabled ? '$transparent' : '$bgHover',
               }}
               pressStyle={{
-                bg: '$bgActive',
+                bg: isCopyDisabled ? '$transparent' : '$bgActive',
               }}
               focusable
               focusVisibleStyle={{
@@ -394,7 +383,11 @@ export function AccountSelectorActiveAccountHome({
     }
 
     return (
-      <CopyButton onPress={handleAddressOnPress} visible={showCopyButton} />
+      <CopyButton
+        onPress={handleAddressOnPress}
+        visible={showCopyButton}
+        disabled={isCopyDisabled}
+      />
     );
   }
 

--- a/packages/kit/src/components/AddressInput/plugins/selector.tsx
+++ b/packages/kit/src/components/AddressInput/plugins/selector.tsx
@@ -99,6 +99,7 @@ const AccountSelectorAddressBookPlugin: FC<ISelectorPluginProps> = ({
   const intl = useIntl();
   const accountSelectorNum = num ?? 0;
   const accountSelectorOpen = useRef<boolean>(false);
+  const selectionSequence = useRef<number>(0);
   const showAddressBook = useAddressBookPick();
   const actions = useAccountSelectorActions();
   const { hideNonBackedUpWallet } = useContext(AddressInputContext);
@@ -115,7 +116,16 @@ const AccountSelectorAddressBookPlugin: FC<ISelectorPluginProps> = ({
         return;
       }
 
+      // Guard against stale async callbacks: if a newer selection starts while
+      // onActiveAccountChange is awaiting, bail out so the old address is not
+      // written back into the input.
+      selectionSequence.current += 1;
+      const currentSequence = selectionSequence.current;
+
       const shouldContinue = await onActiveAccountChange?.(activeAccount);
+      if (currentSequence !== selectionSequence.current) {
+        return;
+      }
       if (shouldContinue === false) {
         accountSelectorOpen.current = false;
         return;

--- a/packages/kit/src/components/AddressInput/plugins/selector.tsx
+++ b/packages/kit/src/components/AddressInput/plugins/selector.tsx
@@ -110,12 +110,16 @@ const AccountSelectorAddressBookPlugin: FC<ISelectorPluginProps> = ({
     });
 
   const handleActiveAccountSelected = useCallback(
-    (activeAccount: IAccountSelectorActiveAccountInfo | undefined) => {
+    async (activeAccount: IAccountSelectorActiveAccountInfo | undefined) => {
       if (!activeAccount?.account?.address || !accountSelectorOpen.current) {
         return;
       }
 
-      onActiveAccountChange?.(activeAccount);
+      const shouldContinue = await onActiveAccountChange?.(activeAccount);
+      if (shouldContinue === false) {
+        accountSelectorOpen.current = false;
+        return;
+      }
       onChange?.({
         text: activeAccount.account.address,
         inputType: EInputAddressChangeType.AccountSelector,
@@ -126,7 +130,7 @@ const AccountSelectorAddressBookPlugin: FC<ISelectorPluginProps> = ({
   );
 
   useEffect(() => {
-    handleActiveAccountSelected(activeAccountFromSelector);
+    void handleActiveAccountSelected(activeAccountFromSelector);
   }, [activeAccountFromSelector, handleActiveAccountSelected]);
 
   useEffect(() => {
@@ -152,7 +156,7 @@ const AccountSelectorAddressBookPlugin: FC<ISelectorPluginProps> = ({
         payload.othersWalletAccountId === activeAccountFromSelector.account?.id;
 
       if (isSameIndexedAccount || isSameOthersWalletAccount) {
-        handleActiveAccountSelected(activeAccountFromSelector);
+        void handleActiveAccountSelected(activeAccountFromSelector);
       }
     };
 

--- a/packages/kit/src/components/AddressInput/types.ts
+++ b/packages/kit/src/components/AddressInput/types.ts
@@ -12,7 +12,7 @@ export type IAddressPluginProps = {
   }) => void;
   onActiveAccountChange?: (
     activeAccount: IAccountSelectorActiveAccountInfo,
-  ) => void;
+  ) => void | boolean | Promise<void | boolean>;
   onExtraDataChange?: ({
     memo,
     note,

--- a/packages/kit/src/views/AccountManagerStacks/components/AccountEdit/AccountCopyButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/AccountEdit/AccountCopyButton.tsx
@@ -62,14 +62,13 @@ export function AccountCopyButton({
       walletId: wallet?.id,
     },
   );
+  const isCopyBlocked = shouldBlockBotWalletCopyAddress({
+    isBotWallet,
+    isBotWalletDeactivated,
+  });
 
   const handleCopyAddress = useCallback(async () => {
-    if (
-      shouldBlockBotWalletCopyAddress({
-        isBotWallet,
-        isBotWalletDeactivated,
-      })
-    ) {
+    if (isCopyBlocked) {
       showBotWalletDisabledToast('copyAddress');
       return;
     }
@@ -153,8 +152,7 @@ export function AccountCopyButton({
     indexedAccount?.id,
     copyAddressWithDeriveType,
     activeAccount?.deriveInfoItems,
-    isBotWallet,
-    isBotWalletDeactivated,
+    isCopyBlocked,
   ]);
 
   return (
@@ -164,6 +162,8 @@ export function AccountCopyButton({
       label={intl.formatMessage({ id: ETranslations.global_copy_address })}
       onClose={() => {}}
       onPress={handleCopyAddress}
+      disabled={isCopyBlocked}
+      allowPressWhenDisabled={isCopyBlocked}
     />
   );
 }

--- a/packages/kit/src/views/AccountManagerStacks/components/AccountEdit/AccountExportPrivateKeyButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/AccountEdit/AccountExportPrivateKeyButton.tsx
@@ -56,12 +56,11 @@ export function AccountExportPrivateKeyButton({
       testID={testID}
       icon={icon}
       label={label}
-      onClose={onClose}
+      onClose={() => {}}
+      disabled={isExportBlocked}
+      allowPressWhenDisabled={isExportBlocked}
       onPress={async () => {
         if (isExportBlocked) {
-          // Stay clickable so users get feedback instead of a silent
-          // dead-click. Keep the visual cue minimal — `disabled` would
-          // also suppress onPress in ActionList.Item.
           showBotWalletDisabledToast('export');
           return;
         }
@@ -91,6 +90,7 @@ export function AccountExportPrivateKeyButton({
           });
           return;
         }
+        onClose?.();
         navigation.pushModal(EModalRoutes.AccountManagerStacks, {
           screen: EAccountManagerStacksRoutes.ExportPrivateKeysPage,
           params: {

--- a/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/BulkCopyAddressesButton.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/components/WalletEdit/BulkCopyAddressesButton.tsx
@@ -43,6 +43,8 @@ export function BulkCopyAddressesButton({
       label={intl.formatMessage({
         id: ETranslations.global_bulk_copy_addresses,
       })}
+      disabled={isBulkCopyBlocked}
+      allowPressWhenDisabled={isBulkCopyBlocked}
       onPress={async (close) => {
         if (isBulkCopyBlocked) {
           // Keep the entry interactive so users get feedback instead of a

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
@@ -82,6 +82,7 @@ type ITokenDetailsAddressBlockProps = {
   address: string;
   onPress: () => void;
   testID?: string;
+  disabled?: boolean;
 };
 
 const TokenDetailsAddressBlock = memo(
@@ -91,6 +92,7 @@ const TokenDetailsAddressBlock = memo(
     address,
     onPress,
     testID,
+    disabled,
   }: ITokenDetailsAddressBlockProps) => {
     if (!shouldShow) {
       return null;
@@ -103,6 +105,7 @@ const TokenDetailsAddressBlock = memo(
           testID={testID}
           userSelect="none"
           onPress={onPress}
+          opacity={disabled ? 0.5 : 1}
           px="$5"
           py="$3"
           gap="$1"
@@ -602,6 +605,7 @@ function TokenDetailsHeader(props: IProps) {
           address={addressBlockValue}
           onPress={handleCopyAddressPress}
           testID={AssetDetailsTestIDs.copyAddressBtn}
+          disabled={isBotWalletCopyBlocked}
         />
         {/* History */}
         <Divider mb="$3" />

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/LineNumberedTextArea.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/LineNumberedTextArea.tsx
@@ -72,7 +72,7 @@ export type ILineNumberedTextAreaProps = {
   };
   onActiveAccountChange?: (
     activeAccount: IAccountSelectorActiveAccountInfo,
-  ) => void;
+  ) => void | boolean | Promise<void | boolean>;
   networkId?: string;
   accountId?: string;
   onInputTypeChange?: (type: EInputAddressChangeType) => void;

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/ReceiverAddressesInput.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/ReceiverAddressesInput.tsx
@@ -206,7 +206,19 @@ function useReceiverSelectorAccountItems() {
   >({});
 
   const handleActiveAccountChange = useCallback(
-    (activeAccount: IAccountSelectorActiveAccountInfo) => {
+    async (activeAccount: IAccountSelectorActiveAccountInfo) => {
+      const walletId = activeAccount.wallet?.id;
+      if (
+        accountUtils.isBotWallet({ walletId }) &&
+        walletId &&
+        (await backgroundApiProxy.serviceAccount.isBotWalletDeactivated({
+          walletId,
+        }))
+      ) {
+        showBotWalletDisabledToast('beReceiver');
+        return false;
+      }
+
       const selectorAccountItem =
         buildReceiverSelectorAccountItem(activeAccount);
       if (selectorAccountItem) {
@@ -215,6 +227,7 @@ function useReceiverSelectorAccountItems() {
         ] = selectorAccountItem;
         void backgroundApiProxy.serviceAccount.clearAccountNameFromAddressCache();
       }
+      return true;
     },
     [],
   );
@@ -458,6 +471,7 @@ function ManyToManyReceiverInput({ maxLines }: { maxLines?: number }) {
     selectedAccountId,
     selectorAccountItemsRef,
     onErrorsChange: setReceiverValidationErrors,
+    rejectDeactivatedBotWalletReceiver: true,
   });
 
   const validate = useCallback(
@@ -594,6 +608,7 @@ function OneToManyReceiverInput({ maxLines }: { maxLines?: number }) {
     onDuplicateAddressCountChange: setDuplicateAddressCount,
     selectorAccountItemsRef,
     onErrorsChange: setReceiverValidationErrors,
+    rejectDeactivatedBotWalletReceiver: true,
   });
 
   const validate = useCallback(

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/useMultiLineAddressValidation.ts
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/components/AddressesInput/useMultiLineAddressValidation.ts
@@ -55,6 +55,7 @@ type IUseMultiLineAddressValidationParams = {
     Record<string, IBulkSendSelectorAccountItem>
   >;
   onErrorsChange?: (errors: ILineError[]) => void;
+  rejectDeactivatedBotWalletReceiver?: boolean;
 };
 
 function useMultiLineAddressValidation(
@@ -78,6 +79,7 @@ function useMultiLineAddressValidation(
     connectedDeviceIds,
     selectorAccountItemsRef,
     onErrorsChange,
+    rejectDeactivatedBotWalletReceiver = false,
   } = params;
 
   const intl = useIntl();
@@ -578,7 +580,11 @@ function useMultiLineAddressValidation(
         // account. The helper resolves owners through the regular address
         // index and falls back to fresh-address resolution for BTC, matching
         // the allowlist resolver below.
-        if (validAddresses.length > 0 && selectedNetworkId) {
+        if (
+          rejectDeactivatedBotWalletReceiver &&
+          validAddresses.length > 0 &&
+          selectedNetworkId
+        ) {
           const botWalletResults = await Promise.all(
             validAddresses.map(({ index, address }) =>
               limit(async () => {
@@ -777,6 +783,7 @@ function useMultiLineAddressValidation(
       requireAmounts,
       checkDuplicates,
       checkAllowlist,
+      rejectDeactivatedBotWalletReceiver,
       resolveAccountId,
       resolveAccountIdForAddress,
       duplicateWarningMode,

--- a/packages/kit/src/views/FiatCrypto/pages/Buy/index.tsx
+++ b/packages/kit/src/views/FiatCrypto/pages/Buy/index.tsx
@@ -1,5 +1,5 @@
 import type { RefObject } from 'react';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useRoute } from '@react-navigation/core';
 import { useIntl } from 'react-intl';
@@ -8,6 +8,8 @@ import { Page, SegmentControl, Stack } from '@onekeyhq/components';
 import { PagerView } from '@onekeyhq/components/src/composite/Carousel/pager';
 import { HeaderIconButton } from '@onekeyhq/components/src/layouts/Navigation/Header';
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
+import { useBotWalletDeactivatedStatus } from '@onekeyhq/kit/src/hooks/useBotWalletDeactivatedStatus';
+import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
 import {
   BUY_GUIDE_URL,
   SELL_GUIDE_URL,
@@ -18,6 +20,7 @@ import type {
   EModalFiatCryptoRoutes,
   IModalFiatCryptoParamList,
 } from '@onekeyhq/shared/src/routes';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import {
   openUrlExternal,
   openUrlInDiscovery,
@@ -54,30 +57,70 @@ const BuyPage = () => {
     defaultTab,
   } = route.params;
   const intl = useIntl();
+  const walletId = useMemo(
+    () =>
+      accountUtils.getWalletIdFromAccountId({
+        accountId: accountId ?? '',
+      }),
+    [accountId],
+  );
+  const { isBotWallet, isBotWalletDeactivated } = useBotWalletDeactivatedStatus(
+    {
+      walletId,
+    },
+  );
+  const isBuyBlockedByBotWallet = isBotWallet && isBotWalletDeactivated;
 
-  const initialTab: ITabType = defaultTab ?? 'buy';
+  const requestedInitialTab: ITabType = defaultTab ?? 'buy';
+  const initialTab: ITabType =
+    requestedInitialTab === 'buy' && isBuyBlockedByBotWallet
+      ? 'sell'
+      : requestedInitialTab;
   const [activeTab, setActiveTab] = useState<ITabType>(initialTab);
 
   const pagerRef = useRef<NativePagerView>(null);
   const activeTabRef = useRef(activeTab);
   activeTabRef.current = activeTab;
 
-  const handleTabChange = useCallback((value: string | number) => {
-    const tab = value as ITabType;
+  const switchToTab = useCallback((tab: ITabType) => {
     setActiveTab(tab);
     if (platformEnv.isNative) {
       pagerRef.current?.setPage(TAB_TO_INDEX[tab]);
     }
   }, []);
 
+  useEffect(() => {
+    if (!isBuyBlockedByBotWallet || activeTabRef.current !== 'buy') {
+      return;
+    }
+    switchToTab('sell');
+  }, [isBuyBlockedByBotWallet, switchToTab]);
+
+  const handleTabChange = useCallback(
+    (value: string | number) => {
+      const tab = value as ITabType;
+      if (tab === 'buy' && isBuyBlockedByBotWallet) {
+        showBotWalletDisabledToast('addMoney');
+        return;
+      }
+      switchToTab(tab);
+    },
+    [isBuyBlockedByBotWallet, switchToTab],
+  );
+
   const handlePageSelected = useCallback(
     (e: { nativeEvent: { position: number } }) => {
       const newTab = INDEX_TO_TAB[e.nativeEvent.position];
+      if (newTab === 'buy' && isBuyBlockedByBotWallet) {
+        showBotWalletDisabledToast('addMoney');
+        switchToTab('sell');
+        return;
+      }
       if (newTab && newTab !== activeTabRef.current) {
         setActiveTab(newTab);
       }
     },
-    [],
+    [isBuyBlockedByBotWallet, switchToTab],
   );
 
   const segmentOptions = useMemo(
@@ -85,13 +128,14 @@ const BuyPage = () => {
       {
         label: intl.formatMessage({ id: ETranslations.global_buy }),
         value: 'buy' as const,
+        disabled: isBuyBlockedByBotWallet,
       },
       {
         label: intl.formatMessage({ id: ETranslations.global_cash_out }),
         value: 'sell' as const,
       },
     ],
-    [intl],
+    [intl, isBuyBlockedByBotWallet],
   );
 
   const headerRight = useCallback(

--- a/packages/kit/src/views/FiatCrypto/pages/Buy/index.tsx
+++ b/packages/kit/src/views/FiatCrypto/pages/Buy/index.tsx
@@ -1,15 +1,15 @@
 import type { RefObject } from 'react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { useRoute } from '@react-navigation/core';
 import { useIntl } from 'react-intl';
 
-import { Page, SegmentControl, Stack } from '@onekeyhq/components';
+import { Empty, Page, SegmentControl, Stack } from '@onekeyhq/components';
 import { PagerView } from '@onekeyhq/components/src/composite/Carousel/pager';
 import { HeaderIconButton } from '@onekeyhq/components/src/layouts/Navigation/Header';
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import { useBotWalletDeactivatedStatus } from '@onekeyhq/kit/src/hooks/useBotWalletDeactivatedStatus';
-import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
+import { getBotWalletDisabledMessage } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
 import {
   BUY_GUIDE_URL,
   SELL_GUIDE_URL,
@@ -44,6 +44,17 @@ const TAB_GUIDE_URLS: Record<ITabType, string> = {
   sell: SELL_GUIDE_URL,
 };
 
+function BotWalletBuyBlockedPlaceholder() {
+  return (
+    <Stack flex={1} justifyContent="center" px="$5">
+      <Empty
+        illustration="WalletAdd"
+        title={getBotWalletDisabledMessage('addMoney')}
+      />
+    </Stack>
+  );
+}
+
 const BuyPage = () => {
   const route =
     useRoute<
@@ -71,11 +82,7 @@ const BuyPage = () => {
   );
   const isBuyBlockedByBotWallet = isBotWallet && isBotWalletDeactivated;
 
-  const requestedInitialTab: ITabType = defaultTab ?? 'buy';
-  const initialTab: ITabType =
-    requestedInitialTab === 'buy' && isBuyBlockedByBotWallet
-      ? 'sell'
-      : requestedInitialTab;
+  const initialTab: ITabType = defaultTab ?? 'buy';
   const [activeTab, setActiveTab] = useState<ITabType>(initialTab);
 
   const pagerRef = useRef<NativePagerView>(null);
@@ -89,38 +96,22 @@ const BuyPage = () => {
     }
   }, []);
 
-  useEffect(() => {
-    if (!isBuyBlockedByBotWallet || activeTabRef.current !== 'buy') {
-      return;
-    }
-    switchToTab('sell');
-  }, [isBuyBlockedByBotWallet, switchToTab]);
-
   const handleTabChange = useCallback(
     (value: string | number) => {
       const tab = value as ITabType;
-      if (tab === 'buy' && isBuyBlockedByBotWallet) {
-        showBotWalletDisabledToast('addMoney');
-        return;
-      }
       switchToTab(tab);
     },
-    [isBuyBlockedByBotWallet, switchToTab],
+    [switchToTab],
   );
 
   const handlePageSelected = useCallback(
     (e: { nativeEvent: { position: number } }) => {
       const newTab = INDEX_TO_TAB[e.nativeEvent.position];
-      if (newTab === 'buy' && isBuyBlockedByBotWallet) {
-        showBotWalletDisabledToast('addMoney');
-        switchToTab('sell');
-        return;
-      }
       if (newTab && newTab !== activeTabRef.current) {
         setActiveTab(newTab);
       }
     },
-    [isBuyBlockedByBotWallet, switchToTab],
+    [],
   );
 
   const segmentOptions = useMemo(
@@ -128,14 +119,13 @@ const BuyPage = () => {
       {
         label: intl.formatMessage({ id: ETranslations.global_buy }),
         value: 'buy' as const,
-        disabled: isBuyBlockedByBotWallet,
       },
       {
         label: intl.formatMessage({ id: ETranslations.global_cash_out }),
         value: 'sell' as const,
       },
     ],
-    [intl, isBuyBlockedByBotWallet],
+    [intl],
   );
 
   const headerRight = useCallback(
@@ -166,6 +156,23 @@ const BuyPage = () => {
     ),
     [activeTab, handleTabChange, segmentOptions],
   );
+
+  const buyContent = isBuyBlockedByBotWallet ? (
+    <BotWalletBuyBlockedPlaceholder />
+  ) : (
+    <SellOrBuyContent type="buy" networkId={networkId} accountId={accountId} />
+  );
+
+  const activeTabContent =
+    activeTab === 'buy' ? (
+      buyContent
+    ) : (
+      <SellOrBuyContent
+        type="sell"
+        networkId={networkId}
+        accountId={accountId}
+      />
+    );
 
   return (
     <AccountSelectorProviderMirror
@@ -198,13 +205,7 @@ const BuyPage = () => {
                   keyboardDismissMode="on-drag"
                   pageWidth="100%"
                 >
-                  <Stack flex={1}>
-                    <SellOrBuyContent
-                      type="buy"
-                      networkId={networkId}
-                      accountId={accountId}
-                    />
-                  </Stack>
+                  <Stack flex={1}>{buyContent}</Stack>
                   <Stack flex={1}>
                     <SellOrBuyContent
                       type="sell"
@@ -214,11 +215,7 @@ const BuyPage = () => {
                   </Stack>
                 </PagerView>
               ) : (
-                <SellOrBuyContent
-                  type={activeTab}
-                  networkId={networkId}
-                  accountId={accountId}
-                />
+                activeTabContent
               )}
             </Page.Body>
           </Page>

--- a/packages/kit/src/views/Home/components/ReceiveInfo/ReceiveInfo.tsx
+++ b/packages/kit/src/views/Home/components/ReceiveInfo/ReceiveInfo.tsx
@@ -7,6 +7,7 @@ import type { IYStackProps } from '@onekeyhq/components';
 import { Button, Icon, XStack, YStack } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { useBotWalletDeactivatedStatus } from '@onekeyhq/kit/src/hooks/useBotWalletDeactivatedStatus';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
 import {
@@ -14,6 +15,7 @@ import {
   useWalletStatusAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/accountOverview';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
+import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -44,6 +46,12 @@ function ReceiveInfo({
   const {
     activeAccount: { wallet },
   } = useActiveAccount({ num: 0 });
+  const { isBotWallet, isBotWalletDeactivated } = useBotWalletDeactivatedStatus(
+    {
+      walletId: wallet?.id,
+    },
+  );
+  const isAddMoneyBlockedByBotWallet = isBotWallet && isBotWalletDeactivated;
 
   const { run: refreshShouldShowReceiveInfo } = usePromiseResult(async () => {
     let shouldShowReceiveInfo = false;
@@ -69,10 +77,14 @@ function ReceiveInfo({
   }, [wallet?.id, wallet?.xfp, updateWalletStatus]);
 
   const handleAddMoney = useCallback(async () => {
+    if (isAddMoneyBlockedByBotWallet) {
+      showBotWalletDisabledToast('addMoney');
+      return;
+    }
     navigation.pushModal(EModalRoutes.ReceiveModal, {
       screen: EModalReceiveRoutes.ReceiveSelector,
     });
-  }, [navigation]);
+  }, [isAddMoneyBlockedByBotWallet, navigation]);
 
   const handleClose = useCallback(async () => {
     if (!closable) return;
@@ -240,6 +252,7 @@ function ReceiveInfo({
             size="large"
             variant="primary"
             onPress={handleAddMoney}
+            opacity={isAddMoneyBlockedByBotWallet ? 0.4 : undefined}
             minWidth={120}
           >
             {intl.formatMessage({ id: ETranslations.global_add_money })}

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionBuy.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionBuy.tsx
@@ -12,10 +12,7 @@ import { useUserWalletProfile } from '@onekeyhq/kit/src/hooks/useUserWalletProfi
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import { useAllTokenListMapAtom } from '@onekeyhq/kit/src/states/jotai/contexts/tokenList';
 import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
-import {
-  useFiatCrypto,
-  useSupportNetworkId,
-} from '@onekeyhq/kit/src/views/FiatCrypto/hooks';
+import { useFiatCrypto } from '@onekeyhq/kit/src/views/FiatCrypto/hooks';
 import { WALLET_TYPE_WATCHING } from '@onekeyhq/shared/src/consts/dbConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
@@ -45,12 +42,20 @@ export function WalletActionBuy({
   const {
     activeAccount: { network, account, wallet, vaultSettings, indexedAccount },
   } = useActiveAccount({ num: 0 });
-  const { isSupported: isBuySupported, handleFiatCrypto } = useFiatCrypto({
+  const { isSupported: isBuySupported, handleFiatCrypto: handleBuyFiatCrypto } =
+    useFiatCrypto({
+      networkId: network?.id ?? '',
+      accountId: account?.id ?? '',
+      fiatCryptoType: 'buy',
+    });
+  const {
+    isSupported: isSellSupported,
+    handleFiatCrypto: handleSellFiatCrypto,
+  } = useFiatCrypto({
     networkId: network?.id ?? '',
     accountId: account?.id ?? '',
-    fiatCryptoType: 'buy',
+    fiatCryptoType: 'sell',
   });
-  const { result: isSellSupported } = useSupportNetworkId('sell', network?.id);
 
   const intl = useIntl();
 
@@ -72,7 +77,10 @@ export function WalletActionBuy({
   );
   const isAddMoneyBlockedByBotWallet = isBotWallet && isBotWalletDeactivated;
 
-  const isBuyDisabled = useMemo(() => {
+  const shouldOpenSellForBotWallet =
+    isAddMoneyBlockedByBotWallet && isSellSupported;
+
+  const isBuyAndSellDisabled = useMemo(() => {
     if (wallet?.type === WALLET_TYPE_WATCHING && !platformEnv.isDev) {
       return true;
     }
@@ -81,7 +89,7 @@ export function WalletActionBuy({
       return true;
     }
 
-    if (isAddMoneyBlockedByBotWallet) {
+    if (isAddMoneyBlockedByBotWallet && !isSellSupported) {
       return true;
     }
 
@@ -95,11 +103,11 @@ export function WalletActionBuy({
 
   const { isSoftwareWalletOnlyUser } = useUserWalletProfile();
   const handleBuyToken = useCallback(async () => {
-    if (isAddMoneyBlockedByBotWallet) {
+    if (isAddMoneyBlockedByBotWallet && !shouldOpenSellForBotWallet) {
       showBotWalletDisabledToast('addMoney');
       return;
     }
-    if (isBuyDisabled) return;
+    if (isBuyAndSellDisabled) return;
 
     if (
       await backgroundApiProxy.serviceAccount.checkIsWalletNotBackedUp({
@@ -116,12 +124,18 @@ export function WalletActionBuy({
       isSoftwareWalletOnlyUser,
     });
 
-    handleFiatCrypto({ sameModal });
+    if (shouldOpenSellForBotWallet) {
+      handleSellFiatCrypto({ sameModal });
+    } else {
+      handleBuyFiatCrypto({ sameModal });
+    }
     onClose();
   }, [
     isAddMoneyBlockedByBotWallet,
-    isBuyDisabled,
-    handleFiatCrypto,
+    shouldOpenSellForBotWallet,
+    isBuyAndSellDisabled,
+    handleBuyFiatCrypto,
+    handleSellFiatCrypto,
     network,
     wallet,
     isSoftwareWalletOnlyUser,
@@ -136,7 +150,8 @@ export function WalletActionBuy({
     !accountUtils.isOthersWallet({ walletId: wallet?.id ?? '' }) &&
     vaultSettings?.mergeDeriveAssetsEnabled &&
     nativeToken &&
-    !isBuyDisabled
+    !isBuyAndSellDisabled &&
+    !shouldOpenSellForBotWallet
   ) {
     return (
       <AddressTypeSelector
@@ -150,7 +165,7 @@ export function WalletActionBuy({
         renderSelectorTrigger={
           renderTrigger ? (
             renderTrigger({
-              disabled: isBuyDisabled,
+              disabled: isBuyAndSellDisabled,
               onPress: () => {},
             })
           ) : (
@@ -158,7 +173,7 @@ export function WalletActionBuy({
               trackID="wallet-buy"
               icon="CurrencyDollarOutline"
               label={intl.formatMessage({ id: ETranslations.buy_and_sell })}
-              disabled={isBuyDisabled}
+              disabled={isBuyAndSellDisabled}
               onClose={() => {}}
               onPress={() => {}}
             />
@@ -197,7 +212,7 @@ export function WalletActionBuy({
 
   if (renderTrigger) {
     return renderTrigger({
-      disabled: isBuyDisabled,
+      disabled: isBuyAndSellDisabled,
       onPress: handleBuyToken,
     });
   }
@@ -209,10 +224,10 @@ export function WalletActionBuy({
       label={intl.formatMessage({ id: ETranslations.buy_and_sell })}
       onClose={() => {}}
       onPress={handleBuyToken}
-      // Stay tappable for the deactivated-bot-wallet path so handleBuyToken
-      // can surface the disabled-bot-wallet toast (ActionList.Item suppresses
-      // onPress when `disabled` is true).
-      disabled={Boolean(isBuyDisabled && !isAddMoneyBlockedByBotWallet)}
+      disabled={isBuyAndSellDisabled}
+      allowPressWhenDisabled={
+        isAddMoneyBlockedByBotWallet && !shouldOpenSellForBotWallet
+      }
     />
   );
 }

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionBuyMain.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionBuyMain.tsx
@@ -7,10 +7,7 @@ import { useBotWalletDeactivatedStatus } from '@onekeyhq/kit/src/hooks/useBotWal
 import { useUserWalletProfile } from '@onekeyhq/kit/src/hooks/useUserWalletProfile';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
-import {
-  useFiatCrypto,
-  useSupportNetworkId,
-} from '@onekeyhq/kit/src/views/FiatCrypto/hooks';
+import { useFiatCrypto } from '@onekeyhq/kit/src/views/FiatCrypto/hooks';
 import { WALLET_TYPE_WATCHING } from '@onekeyhq/shared/src/consts/dbConsts';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -30,12 +27,20 @@ function WalletActionBuyMain({
   const {
     activeAccount: { network, wallet, account },
   } = useActiveAccount({ num: 0 });
-  const { isSupported: isBuySupported, handleFiatCrypto } = useFiatCrypto({
+  const { isSupported: isBuySupported, handleFiatCrypto: handleBuyFiatCrypto } =
+    useFiatCrypto({
+      networkId: network?.id ?? '',
+      accountId: account?.id ?? '',
+      fiatCryptoType: 'buy',
+    });
+  const {
+    isSupported: isSellSupported,
+    handleFiatCrypto: handleSellFiatCrypto,
+  } = useFiatCrypto({
     networkId: network?.id ?? '',
     accountId: account?.id ?? '',
-    fiatCryptoType: 'buy',
+    fiatCryptoType: 'sell',
   });
-  const { result: isSellSupported } = useSupportNetworkId('sell', network?.id);
 
   const { isBotWallet, isBotWalletDeactivated } = useBotWalletDeactivatedStatus(
     {
@@ -44,7 +49,10 @@ function WalletActionBuyMain({
   );
   const isAddMoneyBlockedByBotWallet = isBotWallet && isBotWalletDeactivated;
 
-  const isBuyDisabled = useMemo(() => {
+  const shouldOpenSellForBotWallet =
+    !customization?.onPress && isAddMoneyBlockedByBotWallet && isSellSupported;
+
+  const isBuyAndSellDisabled = useMemo(() => {
     if (wallet?.type === WALLET_TYPE_WATCHING && !platformEnv.isDev) {
       return true;
     }
@@ -53,7 +61,7 @@ function WalletActionBuyMain({
       return true;
     }
 
-    if (isAddMoneyBlockedByBotWallet) {
+    if (isAddMoneyBlockedByBotWallet && !isSellSupported) {
       return true;
     }
 
@@ -68,11 +76,11 @@ function WalletActionBuyMain({
   const { isSoftwareWalletOnlyUser } = useUserWalletProfile();
 
   const handleBuyToken = useCallback(async () => {
-    if (isAddMoneyBlockedByBotWallet) {
+    if (isAddMoneyBlockedByBotWallet && !shouldOpenSellForBotWallet) {
       showBotWalletDisabledToast('addMoney');
       return;
     }
-    if (isBuyDisabled) return;
+    if (isBuyAndSellDisabled) return;
 
     if (
       await backgroundApiProxy.serviceAccount.checkIsWalletNotBackedUp({
@@ -91,13 +99,17 @@ function WalletActionBuyMain({
 
     if (customization?.onPress) {
       void customization.onPress();
+    } else if (shouldOpenSellForBotWallet) {
+      handleSellFiatCrypto({});
     } else {
-      handleFiatCrypto({});
+      handleBuyFiatCrypto({});
     }
   }, [
     isAddMoneyBlockedByBotWallet,
-    isBuyDisabled,
-    handleFiatCrypto,
+    shouldOpenSellForBotWallet,
+    isBuyAndSellDisabled,
+    handleBuyFiatCrypto,
+    handleSellFiatCrypto,
     network,
     wallet,
     isSoftwareWalletOnlyUser,
@@ -113,10 +125,10 @@ function WalletActionBuyMain({
           : undefined
       }
       icon={customization?.icon}
-      disabled={customization?.disabled ?? isBuyDisabled}
-      // Keep the deactivated-bot-wallet branch tappable so users get a
-      // toast instead of a silent dead-click.
-      allowPressWhenDisabled={isAddMoneyBlockedByBotWallet}
+      disabled={customization?.disabled ?? isBuyAndSellDisabled}
+      allowPressWhenDisabled={
+        isAddMoneyBlockedByBotWallet && !shouldOpenSellForBotWallet
+      }
       trackID="wallet-buy"
       testID={HomeTestIDs.buyButton}
     />

--- a/packages/kit/src/views/Home/components/WalletActions/WalletActionCopy.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/WalletActionCopy.tsx
@@ -50,14 +50,13 @@ export function WalletActionCopy({ onClose }: { onClose: () => void }) {
       walletId: wallet?.id,
     },
   );
+  const isCopyBlocked = shouldBlockBotWalletCopyAddress({
+    isBotWallet,
+    isBotWalletDeactivated,
+  });
 
   const handleCopyAddress = useCallback(async () => {
-    if (
-      shouldBlockBotWalletCopyAddress({
-        isBotWallet,
-        isBotWalletDeactivated,
-      })
-    ) {
+    if (isCopyBlocked) {
       showBotWalletDisabledToast('copyAddress');
       return;
     }
@@ -149,8 +148,7 @@ export function WalletActionCopy({ onClose }: { onClose: () => void }) {
     indexedAccount?.id,
     copyAddressWithDeriveType,
     deriveInfoItems,
-    isBotWallet,
-    isBotWalletDeactivated,
+    isCopyBlocked,
   ]);
 
   return (
@@ -160,6 +158,8 @@ export function WalletActionCopy({ onClose }: { onClose: () => void }) {
       label={intl.formatMessage({ id: ETranslations.global_copy_address })}
       onClose={() => {}}
       onPress={handleCopyAddress}
+      disabled={isCopyBlocked}
+      allowPressWhenDisabled={isCopyBlocked}
     />
   );
 }

--- a/packages/kit/src/views/Home/components/WalletActions/index.tsx
+++ b/packages/kit/src/views/Home/components/WalletActions/index.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import { useIntl } from 'react-intl';
 
 import type { IPageNavigationProp, IXStackProps } from '@onekeyhq/components';
-import { Button, Dialog, Toast, YStack } from '@onekeyhq/components';
+import { Button, Dialog, YStack } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import {
   OptionCard,
@@ -20,6 +20,7 @@ import {
   useAllTokenListMapAtom,
   useTokenListStateAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/tokenList';
+import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
 import { shouldBlockBotWalletReceive } from '@onekeyhq/kit/src/utils/botWalletStatusUtils';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
@@ -159,13 +160,10 @@ function WalletActionSend({
                   subtitle={intl.formatMessage({
                     id: ETranslations.receive_from_another_wallet_desc,
                   })}
-                  disabled={isBotWalletReceiveBlocked}
                   opacity={isBotWalletReceiveBlocked ? 0.5 : 1}
                   onPress={() => {
                     if (isBotWalletReceiveBlocked) {
-                      Toast.error({
-                        title: '该钱包已停用，无法接收资产',
-                      });
+                      showBotWalletDisabledToast('receive');
                       return;
                     }
                     logZeroGas('receive');
@@ -183,7 +181,12 @@ function WalletActionSend({
                       id: ETranslations.global_buy,
                     })}
                     subtitle={<PaymentMethodBadges />}
+                    opacity={isBotWalletReceiveBlocked ? 0.5 : 1}
                     onPress={async () => {
+                      if (isBotWalletReceiveBlocked) {
+                        showBotWalletDisabledToast('addMoney');
+                        return;
+                      }
                       logZeroGas('buy');
                       safeResolve(false);
                       void dialogRef.close();

--- a/packages/kit/src/views/WalletAddress/pages/WalletAddress/index.tsx
+++ b/packages/kit/src/views/WalletAddress/pages/WalletAddress/index.tsx
@@ -144,12 +144,9 @@ function SingleWalletAddressListItem({ network }: { network: IServerNetwork }) {
       walletId,
     },
   );
-  // The modal itself and create-address (`+`) rows stay available for
-  // deactivated Bot Wallets. Only copying an existing address is blocked.
   const isBotWalletAddressBlocked =
     isBotWallet &&
     isBotWalletDeactivated &&
-    Boolean(account) &&
     actionType !== EWalletAddressActionType.ViewInExplorer;
 
   const subtitle = useMemo(() => {
@@ -198,7 +195,7 @@ function SingleWalletAddressListItem({ network }: { network: IServerNetwork }) {
     }
 
     if (isBotWalletAddressBlocked) {
-      showBotWalletDisabledToast('copyAddress');
+      showBotWalletDisabledToast(account ? 'copyAddress' : 'receive');
       return;
     }
 
@@ -315,7 +312,8 @@ function SingleWalletAddressListItem({ network }: { network: IServerNetwork }) {
             primary={
               <XStack alignItems="center" gap="$2">
                 <SizableText size="$bodyLgMedium">{network.name}</SizableText>
-                {networkUtils
+                {!isBotWalletAddressBlocked &&
+                networkUtils
                   .getDefaultDeriveTypeVisibleNetworks()
                   .includes(network.id) ? (
                   <AddressTypeSelector

--- a/packages/kit/src/views/WalletAddress/pages/WalletAddress/index.tsx
+++ b/packages/kit/src/views/WalletAddress/pages/WalletAddress/index.tsx
@@ -144,12 +144,12 @@ function SingleWalletAddressListItem({ network }: { network: IServerNetwork }) {
       walletId,
     },
   );
-  // Block both copy and "create / + " actions for deactivated bot wallets:
-  // they shouldn't be able to add new addresses or expose existing ones.
-  // Reading-only actions (e.g. ViewInExplorer) stay enabled.
+  // The modal itself and create-address (`+`) rows stay available for
+  // deactivated Bot Wallets. Only copying an existing address is blocked.
   const isBotWalletAddressBlocked =
     isBotWallet &&
     isBotWalletDeactivated &&
+    Boolean(account) &&
     actionType !== EWalletAddressActionType.ViewInExplorer;
 
   const subtitle = useMemo(() => {
@@ -198,10 +198,7 @@ function SingleWalletAddressListItem({ network }: { network: IServerNetwork }) {
     }
 
     if (isBotWalletAddressBlocked) {
-      // Both copy and add-address paths route through this onPress; surface
-      // a single toast here rather than gating the row visually so users
-      // get explicit feedback instead of a silent dead-click.
-      showBotWalletDisabledToast(account ? 'copyAddress' : 'receive');
+      showBotWalletDisabledToast('copyAddress');
       return;
     }
 


### PR DESCRIPTION
## Summary
- Normalize deactivated Bot Wallet disabled-action behavior so blocked actions use disabled styling while still showing the required toast.
- Keep outbound flows available: bulk-send sender inputs and FiatCrypto Sell remain usable, while receive/buy/copy/export inbound or sensitive actions are blocked.
- Cover account selector, account address modal, home actions, Add money entry, token address copy, and bulk-send receiver validation.

## Intent & Context
OK-53641 tracks inconsistent handling for deactivated Bot Wallets. Disabled wallet funds should only be allowed to move out, not in. The requested behavior was: blocked actions must look disabled but still toast, account-selector copy/export actions should not close the popover, bulk send should only reject deactivated Bot Wallets as receivers, Add money should be shown but intercepted, and the Account address modal should still open while copy remains blocked.

## Root Cause
Several UI paths used native disabled states, which prevented click handlers from firing and therefore suppressed the required toast. Other paths only handled one flow variant, such as one-to-many bulk send receivers, or applied the deactivated wallet guard too broadly, such as disabling the whole Buy & Sell entry even though Sell is an outbound flow.

## Design Decisions
- Added opt-in clickable disabled styling to shared action primitives so blocked actions can keep disabled visuals and still show feedback.
- Centralized deactivated Bot Wallet toast messages and reused them across account, home, wallet address, token detail, and bulk-send surfaces.
- Made bulk-send receiver account selection veto insertion when the selected address belongs to a deactivated Bot Wallet, while leaving sender inputs unchanged.
- Split FiatCrypto Buy and Sell handling so deactivated Bot Wallets open Sell from Buy & Sell, while the Buy tab stays visually disabled and toasts if selected.

## Changes Detail
- `ActionList`, `IconButton`, and `SegmentControl`: support disabled-looking but clickable controls for toast-driven blocked states.
- Account selector and account menu actions: block copy address/export key actions with toast while keeping popovers open where required.
- Wallet address modal and token details: allow modal access/create-address flows, but block copy/receive operations for deactivated Bot Wallets.
- Home wallet actions: block receive/Add money/buy-only inflows while allowing Sell through Buy & Sell.
- Bulk send address inputs: reject deactivated Bot Wallets only as receiving addresses across one-to-many, many-to-many, and many-to-one flows.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Web, Desktop, Extension, Mobile
- **Risk Areas**: Shared action primitive disabled semantics, FiatCrypto tab behavior, and bulk-send account-selection insertion paths.

## Test plan
- [x] `yarn tsc:staged`
- [x] `git diff --check`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings` on changed TypeScript files
- [x] Chrome verification: Home Buy & Sell opens Sell for a deactivated Bot Wallet; Buy tab has disabled styling, shows `该钱包已停用，无法充值`, and remains on Sell.
- [x] Chrome verification: Add money entry shows `该钱包已停用，无法充值` and does not open the FiatCrypto page.
- [x] Chrome verification: account selector copy/export private key/export public key use disabled styling, show toast, and keep the popover open.
- [x] Chrome verification: Account address modal opens; create-address entry remains allowed; address copy remains blocked with toast.
- [x] Chrome verification: bulk send one-to-many, many-to-many, and many-to-one allow the deactivated Bot Wallet as sender and reject it as receiver without filling the receiver input.
