### PR TITLE
fix(desktop): mirror header no-drag regions to body so clicks land (OK-50357)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -13,7 +13,7 @@
     "install-app-deps": "electron-builder install-app-deps",
     "dev": "npx concurrently \"yarn build:main:dev\" \"yarn dev:renderer\" \"cross-env LAUNCH_ELECTRON=true node scripts/dev.js\"",
     "dev:rspack": "npx concurrently \"yarn build:main:dev\" \"yarn dev:renderer:rspack\" \"cross-env LAUNCH_ELECTRON=true node scripts/dev.js\"",
-    "dev:main": "electron --inspect=5858 app/dist/app.js",
+    "dev:main": "electron --inspect=5858 --remote-debugging-port=9222 --remote-debugging-address=127.0.0.1 app/dist/app.js",
     "dev:renderer": "TRANSFORM_REGENERATOR_DISABLED=true BROWSER=none WEB_PORT=3001 webpack serve",
     "dev:renderer:rspack": "TRANSFORM_REGENERATOR_DISABLED=true BROWSER=none WEB_PORT=3001 rspack serve",
     "build:main:dev": "rimraf ./app/dist && cross-env node scripts/build.js",

--- a/packages/components/src/layouts/DesktopDragZoneBox/index.desktop.tsx
+++ b/packages/components/src/layouts/DesktopDragZoneBox/index.desktop.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react';
+
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { Stack } from '../../primitives';
@@ -8,6 +10,181 @@ const dragZoneStyle = {
   userSelect: 'none',
   cursor: 'default',
 } as const;
+
+// Selectors for descendants that should remain clickable inside an
+// app-region:drag container. Chromium's region calculator unreliably honours
+// such descendants once they live deep inside Tamagui-generated trees (see
+// electron/electron#41695, #27149, #20926), so for every match we mirror a
+// fresh fixed-position no-drag ghost element at body level. Ghosts are
+// pointer-events:none so real clicks still reach the underlying control.
+const NO_DRAG_SELECTOR = [
+  '.app-region-no-drag',
+  'input',
+  'textarea',
+  'select',
+  'button',
+  '[role="button"]',
+  'a[href]',
+  '[contenteditable]',
+  '[class*="is_GroupFrame"]',
+].join(',');
+
+const GHOST_ATTR = 'data-onekey-drag-mask-ghost';
+
+function useDragMaskMirror(
+  rootRef: React.MutableRefObject<HTMLElement | null>,
+  enabled: boolean,
+) {
+  useEffect(() => {
+    if (
+      !enabled ||
+      // SSR guard: this hook never runs server-side, but be defensive in
+      // case the bundle is imported from a non-DOM context.
+      // eslint-disable-next-line unicorn/prefer-global-this
+      typeof window === 'undefined'
+    ) {
+      return undefined;
+    }
+    const root = rootRef.current;
+    if (!root) {
+      return undefined;
+    }
+
+    const ghosts = new Map<Element, HTMLDivElement>();
+    let rafId = 0;
+    let scheduled = false;
+
+    const applyRect = (el: Element, ghost: HTMLDivElement) => {
+      const r = (el as HTMLElement).getBoundingClientRect();
+      if (r.width === 0 || r.height === 0) {
+        // hidden / collapsed → contribute nothing to the mask
+        ghost.style.width = '0px';
+        ghost.style.height = '0px';
+        return;
+      }
+      ghost.style.left = `${r.left}px`;
+      ghost.style.top = `${r.top}px`;
+      ghost.style.width = `${r.width}px`;
+      ghost.style.height = `${r.height}px`;
+    };
+
+    const ensureGhost = (el: Element) => {
+      let ghost = ghosts.get(el);
+      if (!ghost) {
+        ghost = document.createElement('div');
+        ghost.className = 'app-region-no-drag';
+        ghost.setAttribute(GHOST_ATTR, '');
+        ghost.style.cssText =
+          'position:fixed;pointer-events:none;z-index:2147483647;left:0;top:0;width:0;height:0;';
+        document.body.appendChild(ghost);
+        ghosts.set(el, ghost);
+      }
+      applyRect(el, ghost);
+    };
+
+    const clearGhosts = () => {
+      ghosts.forEach((ghost) => ghost.remove());
+      ghosts.clear();
+    };
+
+    // react-navigation on web marks inactive tab containers with
+    // `aria-hidden="true"` (often paired with `z-index: -1` to push them
+    // behind the active screen). The hidden container still has layout, so
+    // width/height/visibility/display alone do not detect it. Walk up the
+    // ancestor chain and treat any of those signals as "this root lives in
+    // a stale background tab" — skip the entire sync and clear ghosts.
+    const isRootShown = () => {
+      let cur: Element | null = root;
+      while (cur && cur !== document.body) {
+        const cs = globalThis.getComputedStyle(cur);
+        if (
+          cs.display === 'none' ||
+          cs.visibility === 'hidden' ||
+          cs.visibility === 'collapse'
+        ) {
+          return false;
+        }
+        if (cur.getAttribute('aria-hidden') === 'true') {
+          return false;
+        }
+        cur = cur.parentElement;
+      }
+      return true;
+    };
+
+    const sync = () => {
+      scheduled = false;
+      if (!document.body.isConnected) return;
+      if (!isRootShown()) {
+        clearGhosts();
+        return;
+      }
+      const rootRect = root.getBoundingClientRect();
+      if (rootRect.width === 0 || rootRect.height === 0) {
+        clearGhosts();
+        return;
+      }
+      const matches = root.querySelectorAll(NO_DRAG_SELECTOR);
+      const seen = new Set<Element>();
+      matches.forEach((el) => {
+        const rect = (el as HTMLElement).getBoundingClientRect();
+        if (rect.width === 0 || rect.height === 0) return;
+        seen.add(el);
+        ensureGhost(el);
+      });
+      // Drop ghosts whose source vanished or was removed from the subtree.
+      ghosts.forEach((ghost, el) => {
+        if (!seen.has(el)) {
+          ghost.remove();
+          ghosts.delete(el);
+        }
+      });
+    };
+
+    const schedule = () => {
+      if (scheduled) return;
+      scheduled = true;
+      rafId = globalThis.requestAnimationFrame(sync);
+    };
+
+    // Initial pass — handles the common case where children are already in
+    // the tree at mount time. The follow-up observers cover later mutations.
+    sync();
+
+    const subtreeObserver = new MutationObserver(schedule);
+    subtreeObserver.observe(root, { childList: true, subtree: true });
+
+    // react-navigation toggles aria-hidden on ancestor tab containers when
+    // the user switches tabs. Those mutations live OUTSIDE this root subtree
+    // so the subtree observer above won't see them. Watch document-wide for
+    // aria-hidden attribute flips so each instance can re-evaluate whether
+    // it still belongs to the active tab and clear its ghosts when not.
+    const ancestorObserver = new MutationObserver(schedule);
+    ancestorObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['aria-hidden'],
+      subtree: true,
+    });
+
+    const resizeObserver = new ResizeObserver(schedule);
+    resizeObserver.observe(root);
+
+    globalThis.addEventListener('resize', schedule);
+    // Use capture so inner scroll containers also trigger a resync.
+    globalThis.addEventListener('scroll', schedule, true);
+
+    return () => {
+      subtreeObserver.disconnect();
+      ancestorObserver.disconnect();
+      resizeObserver.disconnect();
+      globalThis.removeEventListener('resize', schedule);
+      globalThis.removeEventListener('scroll', schedule, true);
+      if (rafId) globalThis.cancelAnimationFrame(rafId);
+      ghosts.forEach((ghost) => ghost.remove());
+      ghosts.clear();
+    };
+  }, [enabled, rootRef]);
+}
 
 function BaseDesktopDragZoneBox({
   children,
@@ -26,16 +203,22 @@ function DesktopDragZoneBoxMac({
   disabled,
   ...rest
 }: IDesktopDragZoneBoxProps) {
-  return disabled ? (
-    <Stack key="true" {...rest}>
-      {children}
-    </Stack>
-  ) : (
+  const rootRef = useRef<HTMLElement | null>(null);
+  useDragMaskMirror(rootRef, !disabled);
+
+  // Toggle className/style instead of swapping keys so Chromium can
+  // incrementally update its non-client drag mask without tearing down the
+  // subtree mid-drag. The mirror hook above creates body-level no-drag
+  // ghosts to compensate for Chromium's unreliable in-tree mask calculation.
+  // Tamagui's Stack types its ref as TamaguiElement which on web resolves to
+  // the underlying HTMLDivElement; cast through `any` to bridge the gap.
+  return (
     <Stack
-      key="false"
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ref={rootRef as any}
       {...rest}
-      className="app-region-drag"
-      style={dragZoneStyle}
+      className={disabled ? undefined : 'app-region-drag'}
+      style={disabled ? style : dragZoneStyle}
     >
       {children}
     </Stack>

--- a/packages/components/src/layouts/Navigation/Header/HeaderIconButton.tsx
+++ b/packages/components/src/layouts/Navigation/Header/HeaderIconButton.tsx
@@ -14,6 +14,7 @@ function HeaderIconButton(props: IIconButtonProps) {
       tooltipProps={headerTooltipProps}
       variant="tertiary"
       focusVisibleStyle={undefined}
+      className="app-region-no-drag"
       {...props}
     />
   );

--- a/packages/components/src/layouts/Navigation/Header/HeaderNotificationButton.tsx
+++ b/packages/components/src/layouts/Navigation/Header/HeaderNotificationButton.tsx
@@ -26,7 +26,12 @@ function HeaderNotificationButton({
   testID = 'headerNotificationButton',
 }: IHeaderNotificationButtonProps) {
   return (
-    <Stack testID={testID} onPress={onPress} position="relative">
+    <Stack
+      testID={testID}
+      onPress={onPress}
+      position="relative"
+      className="app-region-no-drag"
+    >
       <HeaderIconButton
         size={size}
         icon="BellOutline"

--- a/packages/components/src/layouts/Navigation/Header/HeaderView.tsx
+++ b/packages/components/src/layouts/Navigation/Header/HeaderView.tsx
@@ -1,16 +1,14 @@
 import type { ReactNode } from 'react';
-import { memo, useCallback, useMemo, useState } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import * as React from 'react';
 
 import { Header } from '@react-navigation/elements';
-import { useFocusEffect } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useMedia } from '@onekeyhq/components/src/hooks/useStyle';
 import { useTheme } from '@onekeyhq/components/src/shared/tamagui';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
-import { useIsOverlayPage } from '../../../hocs';
 import { useIsDesktopModeUIInTabPages } from '../../../hooks';
 import { Stack, XStack } from '../../../primitives';
 import { WINDOWS_OVERLAY_BUTTONS_WIDTH } from '../../../utils/sidebar';
@@ -20,7 +18,6 @@ import HeaderBackButton from './HeaderBackButton';
 import HeaderSearchBar from './HeaderSearchBar';
 
 import type { IOnekeyStackHeaderProps } from './HeaderScreenOptions';
-import type { IDesktopDragZoneBoxProps } from '../../DesktopDragZoneBox';
 import type { IStackHeaderProps } from '../ScreenProps';
 import type {
   HeaderBackButtonProps,
@@ -57,28 +54,14 @@ function getHeaderTitle(
       : fallback;
 }
 
-const DesktopDragZoneBoxView = platformEnv.isDesktopWithCustomTitleBar
-  ? ({ disabled, children }: IDesktopDragZoneBoxProps) => {
-      const isModalPage = useIsOverlayPage();
-
-      const [isFocus, setIsFocus] = useState(false);
-
-      const handlePageEffect = useCallback(() => {
-        setIsFocus(true);
-        return () => {
-          setIsFocus(false);
-        };
-      }, []);
-
-      useFocusEffect(handlePageEffect);
-
-      return (
-        <DesktopDragZoneBox disabled={disabled || !isFocus || isModalPage}>
-          {children}
-        </DesktopDragZoneBox>
-      );
-    }
-  : DesktopDragZoneBox;
+// Keep the drag region attached to the rendered header at all times. The
+// previous version toggled it via useFocusEffect/useIsOverlayPage, which left
+// a one-frame gap during route/modal transitions where the title bar was no
+// longer draggable — that was the source of the "header sometimes can't be
+// dragged" reports on macOS and Windows. Stacked overlays sit above this
+// header, so their clicks never reach the drag region anyway; the
+// `isModelScreen` prop already disables drag for genuine modal screens.
+const DesktopDragZoneBoxView = DesktopDragZoneBox;
 
 const useHeaderHeight = platformEnv.isNativeIOS
   ? () => 52
@@ -223,10 +206,14 @@ function HeaderView({
 
   const headerRightView = useCallback(
     ({ tintColor }: { tintColor?: string }) => {
-      if (typeof headerRight === 'function') {
-        return headerRight({ tintColor, canGoBack });
+      const node =
+        typeof headerRight === 'function'
+          ? headerRight({ tintColor, canGoBack })
+          : (headerRight as React.ReactNode);
+      if (!node) {
+        return node ?? null;
       }
-      return headerRight as React.ReactNode;
+      return <XStack className="app-region-no-drag">{node}</XStack>;
     },
     [headerRight, canGoBack],
   );

--- a/packages/shared/src/web/index.css
+++ b/packages/shared/src/web/index.css
@@ -237,7 +237,12 @@ textarea {
   max-width: calc(100vw - 32px);
 }
 
-.app-region-no-drag {
+.app-region-no-drag,
+.app-region-drag button,
+.app-region-drag input,
+.app-region-drag textarea,
+.app-region-drag a,
+.app-region-drag [role='button'] {
   -webkit-app-region: no-drag;
 }
 .app-region-drag {


### PR DESCRIPTION
## Background

Empty whitespace in the desktop title bar was sometimes un-draggable while interactive controls (search bar, gift / notification / OneKey ID buttons) were sometimes un-clickable, with the symptom flipping unpredictably between sessions and after route transitions on macOS and Windows.

CDP-driven debugging traced this to a known cluster of Electron / Chromium issues — blink's drag-region collector misses `app-region: no-drag` rects buried inside heavily nested trees, and Electron's downstream `supports_app_region` plumbing only re-runs unreliably. Relevant prior art:

- [electron/electron#41695](https://github.com/electron/electron/issues/41695) — `no-drag` ignored when nested under `drag`
- [electron/electron#27149](https://github.com/electron/electron/issues/27149) — `no-drag` ignored intermittently, hover lost
- [electron/electron#20926](https://github.com/electron/electron/issues/20926) — drag region stops working after BrowserView changes
- [electron/electron#43371](https://github.com/electron/electron/issues/43371) — `app-region: drag` has no effect
- [Chromium embedder-dev: Breaking changes to draggable app-regions](https://groups.google.com/a/chromium.org/g/embedder-dev/c/dNNWXw3Ab08)

Live CDP experiments confirmed: every interactive element has the correct computed `app-region: no-drag`, but Chromium's drag mask cache silently drops them. Adding a fresh fixed-position element with `app-region: no-drag` immediately at the click coordinates makes the click work — i.e. the rect needs to be a body-level node that Chromium does pick up reliably.

## What this PR does

### 1. Body-level ghost mirror in `DesktopDragZoneBox`

`DesktopDragZoneBox` now scans its subtree for any descendant that should remain clickable (`.app-region-no-drag`, native form controls, `[role=\"button\"]`, Tamagui `is_GroupFrame`, etc.) and renders a body-level fixed-position no-drag \"ghost\" `<div>` at each one's bounding rect. Ghosts are `pointer-events: none` so real clicks fall through to the underlying control; their only job is to be a stable body-level rect Chromium will reliably include in the OS drag mask.

The mirror is driven by three observers so it stays accurate across React re-renders, layout changes, scrolls and tab transitions:
- `MutationObserver(root, { childList, subtree })` — header content additions / removals
- `ResizeObserver(root)` — header layout changes
- `MutationObserver(document.documentElement, { attributes, attributeFilter: ['aria-hidden'] })` — react-navigation marks inactive tab containers with `aria-hidden=\"true\"`; this is what tells stale background headers to clear their ghosts when the user switches tabs
- `window` `resize` and capturing `scroll` listeners

A pre-flight `isRootShown()` check walks up the ancestor chain for `display:none`, `visibility:hidden` and `aria-hidden=\"true\"` so DesktopDragZoneBox instances in stale background tab stacks never contribute ghosts to the active layer.

All Observer callbacks coalesce through `requestAnimationFrame` to avoid thrashing on bursty mutations.

### 2. React-tree tidy-up so the static state is also correct

These changes are not strictly required once the mirror is in place, but they make the tree read correctly in isolation and remove other footguns:

- `HeaderView` no longer toggles the drag region via `useFocusEffect` / `useIsOverlayPage`. The toggle left a one-frame gap where the title bar was momentarily non-draggable during route or modal transitions. The `disabled={isModelScreen}` prop still disables drag for genuine modal screens.
- `DesktopDragZoneBoxMac` swaps `className` / `style` in place instead of swapping React keys, so Chromium incrementally updates the non-client mask without unmounting the subtree mid-drag.
- `headerRightView` now wraps its content in `<XStack className=\"app-region-no-drag\">` the same way `headerLeftView` already does, so `BaseDesktopTabPageHeader`'s direct injections (Gift / HeaderNotificationIconButton / etc.) inherit no-drag even when they bypass `HeaderRight.tsx`.
- `HeaderIconButton` and `HeaderNotificationButton` carry the `app-region-no-drag` className on the click target itself, so individual controls remain clickable even if a parent wrapper is missed.
- A global CSS fallback marks interactive descendants (button/input/textarea/a/[role=button]) of `.app-region-drag` as no-drag, removing the need for every control in the header to remember the class.

### 3. Dev convenience

`dev:main` gains `--remote-debugging-port=9222 --remote-debugging-address=127.0.0.1` (localhost only, dev script only) so future drag-region investigations can attach a CDP client without rebuilding.

## Test plan

Manual on macOS (primary affected platform):

- [ ] Wallet tab: search bar focusable, gift / notification clickable, empty whitespace between them drags the window
- [ ] Tab through Wallet → Market → Trade → Perp → DeFi → Browser → Wallet; each tab's header is fully clickable AND draggable in whitespace
- [ ] Switch back to Wallet from any tab — old buttons from that tab do NOT leave behind no-drag holes in Wallet's drag area
- [ ] Open a Modal (e.g. settings, send) and close it — header drag still works immediately
- [ ] Window resize — interactive rects stay clickable, no drift
- [ ] DevTools open — drag still works (known to be flakier upstream but should not regress)

Manual on Windows:

- [ ] Same scenarios as macOS; `titleBarOverlay` system buttons (min/max/close) still functional
- [ ] All tab transitions preserve clickability and draggability

Automated:

- [x] `yarn lint:staged` clean
- [x] `yarn tsc:staged` clean

## Notes for reviewers

- The mirror creates O(N) body-level `<div>` ghosts where N is the number of no-drag descendants on the active page (~6 on Wallet, ~10 on Perp in practice). These are `pointer-events: none` and contribute zero work to layout / paint beyond their existence; they are not visible to the user.
- The `isRootShown` ancestor walk happens once per coalesced sync and is bounded by the body. Negligible cost.
- The selector covers Tamagui's `is_GroupFrame` explicitly because Tamagui's Input wraps its `<input>` in a frame that intercepts pointer events; without it the SearchBar would only be no-drag at the inner input rect (~266×28) instead of the full group (~320×32), which we observed leave the icon area un-clickable.
- `apps/desktop/app/app.ts` is intentionally untouched in this PR. The `acceptFirstMouse: true` switch (improves first-click-after-defocus on macOS) ships separately.