### PR TITLE
fix(perps): recover candles and stabilize status badge

### DIFF
--- a/packages/components/src/content/NetworkStatusBadge/index.tsx
+++ b/packages/components/src/content/NetworkStatusBadge/index.tsx
@@ -87,6 +87,7 @@ export function NetworkStatusBadge({
       <Badge.Text size="$bodySmMedium">{badgeLabel}</Badge.Text>
       {monoLabel ? (
         <Badge.Text
+          flex={1}
           size="$bodySmMedium"
           fontFamily="$monoRegular"
           fontVariant={fontVariant}

--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
@@ -12,13 +12,10 @@ import {
   withToast,
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/utils';
 import { usePerpsCandlesWebviewMountedAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import {
-  EAppEventBusNames,
-  appEventBus,
-} from '@onekeyhq/shared/src/eventBus/appEventBus';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IHex } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
+import { useNetworkRestore } from '../../../hooks/useNetworkRestore';
 import { useThemeVariant } from '../../../hooks/useThemeVariant';
 import WebView from '../../WebView';
 import { useNavigationHandler, useTradingViewUrl } from '../hooks';
@@ -261,6 +258,7 @@ export function TradingViewPerpsV2(
   const webRef = useRef<IWebViewRef | null>(null);
   const theme = useThemeVariant();
   const actions = useHyperliquidActions();
+  const { restoreNonce } = useNetworkRestore();
 
   const [{ szDecimals }] = useTradingFormEnvAtom();
   const _webviewKey = useMemo(() => {
@@ -270,12 +268,15 @@ export function TradingViewPerpsV2(
   }, [reloadOnSymbolChange, symbol, theme, webviewKey]);
   const [isChartLinesReady, setIsChartLinesReady] = useState(false);
   const [isChartContentReady, setIsChartContentReady] = useState(false);
+  const hasPerpsReadyRef = useRef(false);
+  const lastHandledRestoreNonceRef = useRef(0);
 
-  // Track webviewKey changes and reset isChartLinesReady when it changes
   const prevWebviewKeyRef = useRef(_webviewKey);
   useEffect(() => {
     if (prevWebviewKeyRef.current !== _webviewKey) {
-      // WebView will reload due to key change, reset ready state
+      // A new WebView instance must prove perpsReady before app-side recovery
+      // can stay hands-off.
+      hasPerpsReadyRef.current = false;
       setIsChartLinesReady(false);
       setIsChartContentReady(false);
       prevWebviewKeyRef.current = _webviewKey;
@@ -330,35 +331,25 @@ export function TradingViewPerpsV2(
     syncOnReady: !reloadOnSymbolChange || isSpotDisplayNameSyncRequired,
   });
 
-  const pendingRecoverRef = useRef(false);
-
   useEffect(() => {
-    const handler = () => {
-      if (isChartLinesReady && webRef.current) {
-        webRef.current.sendMessageViaInjectedScript({
-          type: 'FORCE_RECOVER_WS',
-        });
-      } else {
-        pendingRecoverRef.current = true;
-      }
-    };
-    appEventBus.on(EAppEventBusNames.PerpsWebSocketRecovered, handler);
-    return () => {
-      appEventBus.off(EAppEventBusNames.PerpsWebSocketRecovered, handler);
-    };
-  }, [isChartLinesReady, webRef]);
-
-  useEffect(() => {
-    if (isChartLinesReady && pendingRecoverRef.current) {
-      pendingRecoverRef.current = false;
-      webRef.current?.sendMessageViaInjectedScript({
-        type: 'FORCE_RECOVER_WS',
-      });
+    if (restoreNonce <= 0) {
+      return;
     }
-  }, [isChartLinesReady, webRef]);
+    if (lastHandledRestoreNonceRef.current === restoreNonce) {
+      return;
+    }
 
-  // Callback when TradingView iframe signals chart lines are ready
+    lastHandledRestoreNonceRef.current = restoreNonce;
+
+    if (!hasPerpsReadyRef.current) {
+      setIsChartLinesReady(false);
+      setIsChartContentReady(false);
+      webRef.current?.reload();
+    }
+  }, [restoreNonce]);
+
   const onChartLinesReady = useCallback(() => {
+    hasPerpsReadyRef.current = true;
     setIsChartContentReady(true);
     setIsChartLinesReady(true);
   }, []);

--- a/packages/kit/src/hooks/useNetworkRestore.native.ts
+++ b/packages/kit/src/hooks/useNetworkRestore.native.ts
@@ -1,0 +1,32 @@
+import { useCallback, useEffect } from 'react';
+
+import NetInfo, { type NetInfoState } from '@react-native-community/netinfo';
+
+import {
+  type INetworkRestoreState,
+  useNetworkRestoreState,
+} from './useNetworkRestoreState';
+
+const getInternetReachableFromNativeState = (state: NetInfoState) =>
+  state.isInternetReachable ?? state.isConnected ?? null;
+
+export function useNetworkRestore(): INetworkRestoreState {
+  const { networkState, updateInternetReachable } =
+    useNetworkRestoreState(null);
+
+  const updateFromNativeState = useCallback(
+    (state: NetInfoState) => {
+      updateInternetReachable(getInternetReachableFromNativeState(state));
+    },
+    [updateInternetReachable],
+  );
+
+  useEffect(() => {
+    void NetInfo.fetch()
+      .then(updateFromNativeState)
+      .catch(() => undefined);
+    return NetInfo.addEventListener(updateFromNativeState);
+  }, [updateFromNativeState]);
+
+  return networkState;
+}

--- a/packages/kit/src/hooks/useNetworkRestore.ts
+++ b/packages/kit/src/hooks/useNetworkRestore.ts
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+
+import {
+  type INetworkRestoreState,
+  useNetworkRestoreState,
+} from './useNetworkRestoreState';
+
+const getBrowserInternetReachable = () => {
+  if (typeof globalThis.navigator === 'undefined') {
+    return null;
+  }
+
+  return globalThis.navigator.onLine;
+};
+
+export function useNetworkRestore(): INetworkRestoreState {
+  const { networkState, updateInternetReachable } = useNetworkRestoreState(
+    getBrowserInternetReachable(),
+  );
+
+  useEffect(() => {
+    updateInternetReachable(getBrowserInternetReachable());
+
+    if (
+      typeof globalThis.addEventListener !== 'function' ||
+      typeof globalThis.removeEventListener !== 'function'
+    ) {
+      return undefined;
+    }
+
+    const handleOnline = () => {
+      updateInternetReachable(true);
+    };
+    const handleOffline = () => {
+      updateInternetReachable(false);
+    };
+
+    globalThis.addEventListener('online', handleOnline);
+    globalThis.addEventListener('offline', handleOffline);
+
+    return () => {
+      globalThis.removeEventListener('online', handleOnline);
+      globalThis.removeEventListener('offline', handleOffline);
+    };
+  }, [updateInternetReachable]);
+
+  return networkState;
+}

--- a/packages/kit/src/hooks/useNetworkRestoreState.ts
+++ b/packages/kit/src/hooks/useNetworkRestoreState.ts
@@ -1,0 +1,60 @@
+import { useCallback, useRef, useState } from 'react';
+
+export type INetworkRestoreState = {
+  isInternetReachable: boolean | null;
+  restoreNonce: number;
+};
+
+export function useNetworkRestoreState(
+  initialInternetReachable: boolean | null,
+) {
+  const offlineSinceLastReachableRef = useRef(
+    initialInternetReachable === false,
+  );
+  const [networkState, setNetworkState] = useState<INetworkRestoreState>(
+    () => ({
+      isInternetReachable: initialInternetReachable,
+      restoreNonce: 0,
+    }),
+  );
+
+  const updateInternetReachable = useCallback(
+    (nextInternetReachable: boolean | null) => {
+      let shouldIncrementRestoreNonce = false;
+
+      if (nextInternetReachable === false) {
+        offlineSinceLastReachableRef.current = true;
+      } else if (
+        nextInternetReachable === true &&
+        offlineSinceLastReachableRef.current
+      ) {
+        offlineSinceLastReachableRef.current = false;
+        shouldIncrementRestoreNonce = true;
+      }
+
+      setNetworkState((prevState) => {
+        const nextRestoreNonce = shouldIncrementRestoreNonce
+          ? prevState.restoreNonce + 1
+          : prevState.restoreNonce;
+
+        if (
+          prevState.isInternetReachable === nextInternetReachable &&
+          prevState.restoreNonce === nextRestoreNonce
+        ) {
+          return prevState;
+        }
+
+        return {
+          isInternetReachable: nextInternetReachable,
+          restoreNonce: nextRestoreNonce,
+        };
+      });
+    },
+    [],
+  );
+
+  return {
+    networkState,
+    updateInternetReachable,
+  };
+}

--- a/packages/kit/src/views/Perp/components/PerpContentFooter.tsx
+++ b/packages/kit/src/views/Perp/components/PerpContentFooter.tsx
@@ -22,7 +22,13 @@ function PerpNetworkStatus() {
     return undefined;
   }, [connected, pingMs]);
 
-  return <NetworkStatusBadge connected={connected} monoLabel={monoLabel} />;
+  return (
+    <NetworkStatusBadge
+      connected={connected}
+      monoLabel={monoLabel}
+      minWidth={135}
+    />
+  );
 }
 
 export function PerpContentFooter() {

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -53,6 +53,7 @@ import backgroundApiProxy from '../../../background/instance/backgroundApiProxy'
 import { useHandleAppStateActive } from '../../../hooks/useHandleAppStateActive';
 import useListenTabFocusState from '../../../hooks/useListenTabFocusState';
 import { useLocaleVariant } from '../../../hooks/useLocaleVariant';
+import { useNetworkRestore } from '../../../hooks/useNetworkRestore';
 import { usePromiseResult } from '../../../hooks/usePromiseResult';
 import { useRouteIsFocused } from '../../../hooks/useRouteIsFocused';
 import { useActiveAccount } from '../../../states/jotai/contexts/accountSelector';
@@ -79,6 +80,34 @@ let lastRecoveredPerpsLocaleVariant: string | undefined;
 
 function resolvePerpRouteFocused(isFocus: boolean) {
   return shouldTreatPerpAsFocusedOnMount || isFocus;
+}
+
+async function buildActiveInstrumentSwitchParamsFromGlobal(options?: {
+  force?: boolean;
+}) {
+  const currentMode = (await tradingModeAtom.get()) ?? 'perp';
+  if (currentMode === 'spot') {
+    const spotAsset = await spotActiveAssetAtom.get();
+    if (!spotAsset?.coin) {
+      return undefined;
+    }
+    return {
+      mode: 'spot' as const,
+      coin: spotAsset.coin,
+      spotUniverse: spotAsset.universe,
+      force: options?.force,
+    };
+  }
+
+  const perpAsset = await perpsActiveAssetAtom.get();
+  if (!perpAsset?.coin) {
+    return undefined;
+  }
+  return {
+    mode: 'perp' as const,
+    coin: perpAsset.coin,
+    force: options?.force,
+  };
 }
 
 function useSyncContextOrderBookOptionsToGlobal() {
@@ -617,30 +646,29 @@ function useHyperliquidSymbolSelect() {
         return;
       }
       if (claimed) {
-        await Promise.all([
-          backgroundApiProxy.serviceHyperliquid.refreshTradingMeta(),
-          // Spot meta failure must not block perps initialization
-          backgroundApiProxy.serviceHyperliquid.refreshSpotMeta().catch((e) => {
-            console.error('refreshSpotMeta failed (non-blocking):', e);
-          }),
-        ]);
+        try {
+          await Promise.all([
+            backgroundApiProxy.serviceHyperliquid.refreshTradingMeta(),
+            // Spot meta failure must not block perps initialization.
+            backgroundApiProxy.serviceHyperliquid
+              .refreshSpotMeta()
+              .catch((e) => {
+                console.error('refreshSpotMeta failed (non-blocking):', e);
+              }),
+          ]);
+        } catch (error) {
+          // Offline entry should still hydrate UI context from persisted BG
+          // atoms.
+          console.error('refreshTradingMeta failed before symbol sync:', error);
+        }
       }
-      const currentMode = await tradingModeAtom.get();
-      const currentPerpToken = await perpsActiveAssetAtom.get();
-      const currentSpotToken = await spotActiveAssetAtom.get();
-      const nextMode = currentMode === 'spot' ? 'spot' : 'perp';
-      const nextCoin =
-        nextMode === 'spot' ? currentSpotToken?.coin : currentPerpToken?.coin;
-      if (!nextCoin) {
+      const switchParams = await buildActiveInstrumentSwitchParamsFromGlobal({
+        force: true,
+      });
+      if (!switchParams) {
         return;
       }
-      await actions.current.switchTradeInstrument({
-        mode: nextMode,
-        coin: nextCoin,
-        force: true,
-        spotUniverse:
-          nextMode === 'spot' ? currentSpotToken?.universe : undefined,
-      });
+      await actions.current.switchTradeInstrument(switchParams);
     } finally {
       isInitializingRef.current = false;
     }
@@ -849,6 +877,81 @@ function AutoPauseSubscriptions() {
   return null;
 }
 
+function useHyperliquidNetworkReachabilityRecovery() {
+  const { isInternetReachable } = useNetworkRestore();
+  const actions = useHyperliquidActions();
+  const isRouteFocused = useRouteIsFocused();
+  const isFocused = resolvePerpRouteFocused(isRouteFocused);
+  const isFocusedRef = useRef(isFocused);
+  const wasOfflineRef = useRef(isInternetReachable === false);
+  const recoveryPromiseRef = useRef<Promise<void> | null>(null);
+
+  isFocusedRef.current = isFocused;
+
+  const recoverSubscriptions = useCallback(async () => {
+    if (recoveryPromiseRef.current) {
+      await recoveryPromiseRef.current;
+      return;
+    }
+
+    recoveryPromiseRef.current = (async () => {
+      const switchParams = await buildActiveInstrumentSwitchParamsFromGlobal();
+      await Promise.all([
+        (async () => {
+          await backgroundApiProxy.serviceHyperliquidSubscription.enableSubscriptionsHandler();
+          // Network restoration can leave server-side streams missing while the
+          // socket still looks open.
+          await backgroundApiProxy.serviceHyperliquidSubscription.resumeSubscriptions(
+            {
+              forceReconnect: true,
+            },
+          );
+        })(),
+        switchParams
+          ? actions.current.switchTradeInstrument(switchParams)
+          : Promise.resolve(false),
+      ]);
+      await actions.current.updateSubscriptions();
+    })()
+      .catch((error) => {
+        console.error('perps network reachability recovery failed:', error);
+      })
+      .finally(() => {
+        recoveryPromiseRef.current = null;
+      });
+    await recoveryPromiseRef.current;
+  }, [actions]);
+
+  const handleReachabilityChange = useCallback(
+    (nextReachable: boolean | null) => {
+      if (nextReachable === null) {
+        return;
+      }
+      if (nextReachable === false) {
+        if (isFocusedRef.current) {
+          wasOfflineRef.current = true;
+        }
+        return;
+      }
+      if (isFocusedRef.current && wasOfflineRef.current) {
+        wasOfflineRef.current = false;
+        void recoverSubscriptions();
+      }
+    },
+    [recoverSubscriptions],
+  );
+
+  useEffect(() => {
+    handleReachabilityChange(isInternetReachable);
+  }, [handleReachabilityChange, isInternetReachable]);
+
+  useEffect(() => {
+    if (isFocused) {
+      handleReachabilityChange(isInternetReachable);
+    }
+  }, [handleReachabilityChange, isFocused, isInternetReachable]);
+}
+
 // Bridge for context-less callers (tray, notifications): the bg
 // `changeActiveAsset` alone leaves this context's
 // activeTradeInstrumentAtom / tradingModeAtom stale, so the UI keeps
@@ -886,6 +989,7 @@ function PerpsGlobalEffectsView() {
   useHyperliquidInstrumentSwitchRequest();
   useHyperliquidScreenLockHandler();
   useHyperliquidLocaleChangeRecovery();
+  useHyperliquidNetworkReachabilityRecovery();
   useSyncContextOrderBookOptionsToGlobal();
   useTradeRouteViewStateSync();
   usePerpsSharePrompt();

--- a/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
@@ -116,6 +116,17 @@ function hasSpotVolumeData(
   );
 }
 
+// Android FlashList can preserve the pre-sort anchor, which defeats the
+// selector's explicit scroll-to-top contract.
+const androidSortScrollBehaviorProps: Record<string, unknown> =
+  platformEnv.isNativeAndroid
+    ? {
+        maintainVisibleContentPosition: {
+          disabled: true,
+        },
+      }
+    : {};
+
 const PrimaryTabItem = memo(
   ({
     id,
@@ -1051,6 +1062,7 @@ function MobileTokenSelectorModal({
               decelerationRate="normal"
               showsVerticalScrollIndicator
               nestedScrollEnabled={platformEnv.isNativeAndroid}
+              {...androidSortScrollBehaviorProps}
               contentContainerStyle={{
                 paddingBottom: 10,
               }}


### PR DESCRIPTION
## Summary
- OK-54733: recover Perps TradingView candles after offline entry by reloading the WebView only when the chart never reached `perpsReady`; ready charts keep their iframe and let WS recovery handle reconnects.
- OK-54733: speed up Perps ticker/orderbook recovery on native network restore by driving subscription recovery from native/web reachability instead of waiting for slower health checks.
- OK-54964: stabilize the Perps footer network status badge width while latency text changes.
- OK-54946: fix Android TokenSelector sorting so the list returns to the top without remounting the whole FlashList.

## Intent & Context
Perps had separate recovery regressions after network changes: candles could stay blank when the page was entered offline, while ticker/orderbook recovery should remain fast after reconnect. The fix keeps chart reload scoped to the iframe-not-ready case, and keeps subscription recovery independent of candles reload. A small Android-only FlashList adjustment also fixes the reopened selector sorting issue.

## Root Cause
- Offline-entry candles: the TradingView page can fail before it sends readiness messages, so later WS recovery messages cannot reach a ready chart. App-side recovery must reload that WebView once network reachability returns.
- Ready chart reconnect: if the chart already reached `perpsReady`, the embedded TradingView/WS path can self-recover; forcing a WebView reload would unnecessarily lose chart state.
- Android selector sorting: FlashList v2 keeps visible content position by default, which can preserve the pre-sort anchor and override the selector's explicit scroll-to-top behavior.

## Design Decisions
- Introduce a small `useNetworkRestore` hook with native NetInfo and browser `online/offline` implementations so Perps recovery can share one reachability signal without native imports on web/desktop.
- Keep candles recovery local to `TradingViewPerpsV2`: reload only when a network restore happens before `perpsReady`; otherwise leave the iframe intact.
- Keep subscription recovery in `PerpsGlobalEffects` so ticker/orderbook recovery remains independent from candles reload.
- Disable Android FlashList `maintainVisibleContentPosition` only for the mobile TokenSelector instead of reintroducing sort-key remounts or timeout-based scrolling.
- Keep OK-54964 as a layout-only change; final badge min width is 135px.

## Changes Detail
- `packages/kit/src/hooks/useNetworkRestore*.ts`: shared restore nonce / reachability hook for native and non-native platforms.
- `TradingViewPerpsV2.tsx`: reload the candles WebView on network restore only if the chart never reported ready.
- `PerpsGlobalEffects.tsx`: recover Hyperliquid subscriptions on reachability restore while preserving existing focus guards.
- `PerpContentFooter.tsx` and `NetworkStatusBadge`: stabilize footer badge layout during ping updates.
- `MoblieTokenSelector.tsx`: Android-only FlashList anchor behavior fix for sort-to-top.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Web / Desktop
- **Risk Areas**: network-recovery timing, TradingView WebView reload gating, Android FlashList behavior.
- **Known trade-off**: repeated network flapping during an in-flight recovery is treated as a low-frequency edge case; current implementation prioritizes a minimal, reviewable recovery path.

## Test plan
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings` on changed files
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] Android Redmi manual: OK-54946 selector sort returns to top after scrolling
- [x] Web manual: offline-entry candles recover after network returns
- [ ] Native QA: enter Perps candles while offline, restore network, verify candles load automatically
- [ ] Native QA: enter Perps online, disconnect/reconnect, verify ticker/orderbook recover quickly and ready candles do not visibly reload
- [ ] Desktop/Web QA: verify footer badge width is stable for online latency and offline states
