### PR TITLE
fix(home): stabilize history list & overview spinner on network switch(OK-54950)

### DIFF
--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -19,6 +19,7 @@ import { XStack, YStack } from '../../primitives';
 
 import { TabsContext, TabsScrollContext } from './context';
 import { TabBar } from './TabBar';
+import { useConvertAnimatedToValue } from './useFocusedTab';
 
 import type { LayoutChangeEvent } from 'react-native';
 import type {
@@ -36,6 +37,11 @@ const childDivStyle = {
   scrollSnapAlign: 'center',
 } as const;
 
+const parseCssSize = (value: string | undefined) => {
+  const size = Number.parseFloat(value ?? '');
+  return Number.isFinite(size) ? size : 0;
+};
+
 export function ContainerChild({
   children,
   listContainerRef,
@@ -48,23 +54,35 @@ export function ContainerChild({
   containerWidth: number | string | undefined;
   focusedTab: SharedValue<string>;
   tabNames: (string | null)[];
+  updateListContainerHeight: () => void;
 }) {
+  const focusedTabValue = useConvertAnimatedToValue(focusedTab, '');
+
+  const syncFocusedTabVisibility = useCallback(
+    (tabName: string) => {
+      const focusedIndex = tabNames.findIndex((name) => name === tabName);
+      if (focusedIndex < 0 || !listContainerRef.current) return;
+      listContainerRef.current.childNodes.forEach((element, index) => {
+        if (!element) return;
+        (element as HTMLElement).style.setProperty(
+          'content-visibility',
+          focusedIndex === index ? 'visible' : 'hidden',
+        );
+      });
+    },
+    [listContainerRef, tabNames],
+  );
+
   useAnimatedReaction(
     () => focusedTab.value,
     (tabName) => {
-      const focusedIndex = tabNames.findIndex((name) => name === tabName);
-      if (focusedIndex > -1 && listContainerRef.current) {
-        listContainerRef.current.childNodes.forEach((element, index) => {
-          if (element) {
-            (
-              (element as HTMLDivElement).style as unknown as {
-                contentVisibility: 'hidden' | 'visible';
-              }
-            ).contentVisibility = focusedIndex === index ? 'visible' : 'hidden';
-          }
-        });
-      }
+      syncFocusedTabVisibility(tabName);
     },
+  );
+
+  useEffect(
+    () => syncFocusedTabVisibility(focusedTabValue ?? ''),
+    [focusedTabValue, syncFocusedTabVisibility],
   );
   return (
     <TabsScrollContext.Provider value={props}>
@@ -75,8 +93,15 @@ export function ContainerChild({
         style={scrollSnapStyle}
       >
         {Children.map(children, (child, index) => {
+          const key =
+            isValidElement(child) &&
+            child.props !== null &&
+            typeof child.props === 'object' &&
+            'name' in child.props
+              ? (child.props as { name: string }).name
+              : index;
           return (
-            <div style={childDivStyle} key={index}>
+            <div style={childDivStyle} key={key}>
               {child}
             </div>
           );
@@ -150,10 +175,31 @@ export function Container({
       return 0;
     }
 
+    const style = globalThis.getComputedStyle(htmlElement);
+    const verticalSpacing =
+      parseCssSize(style.marginTop) +
+      parseCssSize(style.marginBottom) +
+      parseCssSize(style.paddingTop) +
+      parseCssSize(style.paddingBottom);
+    const virtualizedInnerElement = htmlElement.querySelector(
+      [
+        '.ReactVirtualized__Grid__innerScrollContainer',
+        '.ReactVirtualized__Collection__innerScrollContainer',
+      ].join(','),
+    ) as HTMLElement | null;
+    const virtualizedHeight = virtualizedInnerElement
+      ? Math.max(
+          virtualizedInnerElement.scrollHeight || 0,
+          virtualizedInnerElement.clientHeight || 0,
+          virtualizedInnerElement.getBoundingClientRect().height || 0,
+        ) + verticalSpacing
+      : 0;
+
     return Math.max(
       htmlElement.scrollHeight || 0,
       htmlElement.clientHeight || 0,
       htmlElement.getBoundingClientRect().height || 0,
+      virtualizedHeight,
     );
   }, []);
 
@@ -163,7 +209,9 @@ export function Container({
     return Children.map(children, (child) => {
       if (
         isValidElement(child) &&
-        'name' in (child.props as { name: string })
+        child.props !== null &&
+        typeof child.props === 'object' &&
+        'name' in child.props
       ) {
         return (child.props as { name: string }).name;
       }
@@ -174,6 +222,9 @@ export function Container({
   const focusedTab = useSharedValue<string>(
     initialTabName || tabNames[0] || '',
   );
+  useEffect(() => {
+    sharedTabNames.value = tabNames;
+  }, [sharedTabNames, tabNames]);
   const scrollTabElementDict = useMemo(() => {
     return tabNames.reduce(
       (acc, name) => {
@@ -282,6 +333,26 @@ export function Container({
       }
     };
   }, [updateListContainerHeight]);
+
+  useLayoutEffect(() => {
+    const index = tabNames.findIndex((name) => name === focusedTab.value);
+    if (index < 0) {
+      const firstTabName = tabNames[0];
+      if (firstTabName) {
+        focusedTab.set(firstTabName);
+      }
+      return;
+    }
+
+    updateListContainerHeight();
+    const width = scrollElement?.clientWidth || 0;
+    if (width) {
+      listContainerRef.current?.scrollTo({
+        left: width * index,
+        behavior: 'instant',
+      });
+    }
+  }, [focusedTab, scrollElement, tabNames, updateListContainerHeight]);
 
   useLayoutEffect(() => {
     const callback = debounce(() => {
@@ -455,6 +526,7 @@ export function Container({
                     listContainerRef={listContainerRef as any}
                     focusedTab={focusedTab}
                     tabNames={tabNames}
+                    updateListContainerHeight={updateListContainerHeight}
                   >
                     {children}
                   </ContainerChild>

--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -20,6 +20,7 @@ import { XStack, YStack } from '../../primitives';
 import { TabsContext, TabsScrollContext } from './context';
 import { TabBar } from './TabBar';
 import { useConvertAnimatedToValue } from './useFocusedTab';
+import { parseCssSize } from './utils';
 
 import type { LayoutChangeEvent } from 'react-native';
 import type {
@@ -36,11 +37,6 @@ const childDivStyle = {
   flexShrink: 0,
   scrollSnapAlign: 'center',
 } as const;
-
-const parseCssSize = (value: string | undefined) => {
-  const size = Number.parseFloat(value ?? '');
-  return Number.isFinite(size) ? size : 0;
-};
 
 export function ContainerChild({
   children,
@@ -181,12 +177,12 @@ export function Container({
       parseCssSize(style.marginBottom) +
       parseCssSize(style.paddingTop) +
       parseCssSize(style.paddingBottom);
-    const virtualizedInnerElement = htmlElement.querySelector(
+    const virtualizedInnerElement = htmlElement.querySelector<HTMLElement>(
       [
         '.ReactVirtualized__Grid__innerScrollContainer',
         '.ReactVirtualized__Collection__innerScrollContainer',
       ].join(','),
-    ) as HTMLElement | null;
+    );
     const virtualizedHeight = virtualizedInnerElement
       ? Math.max(
           virtualizedInnerElement.scrollHeight || 0,

--- a/packages/components/src/composite/Tabs/List.tsx
+++ b/packages/components/src/composite/Tabs/List.tsx
@@ -12,6 +12,7 @@ import {
   useImperativeHandle,
   useMemo,
   useRef,
+  useState,
 } from 'react';
 
 import { View } from 'react-native';
@@ -78,6 +79,11 @@ const renderElement = (Element: ReactNode | ComponentType<any>) => {
   return <Component />;
 };
 
+const parseCssSize = (value: string | undefined) => {
+  const size = Number.parseFloat(value ?? '');
+  return Number.isFinite(size) ? size : 0;
+};
+
 export function List<Item>({
   ref: parentRef,
   renderItem,
@@ -116,6 +122,7 @@ export function List<Item>({
     isScrolling,
     onChildScroll,
     scrollTop,
+    updateListContainerHeight,
   } = useTabsScrollContext();
 
   const width = useMemo(() => {
@@ -127,6 +134,7 @@ export function List<Item>({
   const focusedTabValue = useConvertAnimatedToValue(focusedTab, '');
 
   const ref = useRef<Element>(null);
+  const [contentHeight, setContentHeight] = useState<number | undefined>();
 
   const scrollTabElementsRef = useTabsContext().scrollTabElementsRef;
 
@@ -383,7 +391,87 @@ export function List<Item>({
     [cache],
   );
 
+  const estimateContentHeight = useCallback(() => {
+    if (!listData.length) {
+      return 0;
+    }
+
+    if (numColumns > 1) {
+      const clientWidth = width / numColumns || 0;
+      const clientHeight = clientWidth + 60;
+      return Math.ceil(listData.length / numColumns) * clientHeight;
+    }
+
+    return listData.reduce((total, _item, index) => {
+      const rowHeight = Number(cache.rowHeight({ index }) ?? 60);
+      return total + (Number.isFinite(rowHeight) ? rowHeight : 60);
+    }, 0);
+  }, [cache, listData, numColumns, width]);
+
+  const updateMeasuredContentHeight = useCallback(() => {
+    if (!listData.length) {
+      setContentHeight(undefined);
+      updateListContainerHeight?.();
+      return;
+    }
+
+    const htmlElement = ref.current as HTMLElement | null;
+    const style =
+      htmlElement && typeof globalThis.getComputedStyle === 'function'
+        ? globalThis.getComputedStyle(htmlElement)
+        : undefined;
+    const verticalSpacing = style
+      ? parseCssSize(style.marginTop) +
+        parseCssSize(style.marginBottom) +
+        parseCssSize(style.paddingTop) +
+        parseCssSize(style.paddingBottom)
+      : 0;
+    const virtualizedInnerElement = htmlElement?.querySelector(
+      [
+        '.ReactVirtualized__Grid__innerScrollContainer',
+        '.ReactVirtualized__Collection__innerScrollContainer',
+      ].join(','),
+    ) as HTMLElement | null;
+    const virtualizedHeight = virtualizedInnerElement
+      ? Math.max(
+          virtualizedInnerElement.scrollHeight || 0,
+          virtualizedInnerElement.clientHeight || 0,
+          virtualizedInnerElement.getBoundingClientRect().height || 0,
+        )
+      : 0;
+    const nextHeight =
+      Math.max(virtualizedHeight, estimateContentHeight()) + verticalSpacing;
+
+    setContentHeight((previousHeight) =>
+      Math.abs((previousHeight ?? 0) - nextHeight) > 1
+        ? nextHeight
+        : previousHeight,
+    );
+    updateListContainerHeight?.();
+  }, [estimateContentHeight, listData.length, updateListContainerHeight]);
+
+  const scheduleListContainerHeightUpdate = useCallback(() => {
+    let timerShort: ReturnType<typeof setTimeout> | undefined;
+    let timerLong: ReturnType<typeof setTimeout> | undefined;
+    const frame = requestAnimationFrame(() => {
+      updateMeasuredContentHeight();
+      timerShort = setTimeout(updateMeasuredContentHeight, 100);
+      timerLong = setTimeout(updateMeasuredContentHeight, 350);
+    });
+
+    return () => {
+      cancelAnimationFrame(frame);
+      if (timerShort) {
+        clearTimeout(timerShort);
+      }
+      if (timerLong) {
+        clearTimeout(timerLong);
+      }
+    };
+  }, [updateMeasuredContentHeight]);
+
   useEffect(() => {
+    let cleanup: (() => void) | undefined;
     if (keyExtractor) {
       // With keyExtractor, the cache is stable (not recreated on data changes).
       // Only recompute row positions for new rows without clearing measured heights.
@@ -396,11 +484,14 @@ export function List<Item>({
           (listRef.current as any)?.recomputeRowHeights();
         }
       }
-      return;
+      cleanup = scheduleListContainerHeightUpdate();
+      return cleanup;
     }
     if (data?.length || sections?.length || numColumns || width || extraData) {
       recompute({ numColumns, width });
+      cleanup = scheduleListContainerHeightUpdate();
     }
+    return cleanup;
   }, [
     data?.length,
     sections?.length,
@@ -409,6 +500,16 @@ export function List<Item>({
     extraData,
     recompute,
     keyExtractor,
+    scheduleListContainerHeightUpdate,
+  ]);
+
+  useEffect(() => {
+    return scheduleListContainerHeightUpdate();
+  }, [
+    extraData,
+    isVisible,
+    listData.length,
+    scheduleListContainerHeightUpdate,
   ]);
 
   // Recompute row heights when tab becomes visible to fix stale
@@ -460,9 +561,23 @@ export function List<Item>({
     );
   }, [HeaderElement, ListEmptyComponent, FooterElement]);
 
+  // Imperative `recomputeLayout` runs outside React's effect lifecycle, so the
+  // rAF + setTimeout chain it spawns can outlive the component. We hold the
+  // latest cleanup in a ref and clear it on unmount (and before scheduling a
+  // new one) to avoid `setContentHeight` firing on an unmounted instance.
+  const pendingScheduleCleanupRef = useRef<(() => void) | undefined>(undefined);
+  useEffect(() => {
+    return () => {
+      pendingScheduleCleanupRef.current?.();
+      pendingScheduleCleanupRef.current = undefined;
+    };
+  }, []);
+
   useImperativeHandle(parentRef as any, () => ({
     recomputeLayout: () => {
       recompute({ numColumns, width });
+      pendingScheduleCleanupRef.current?.();
+      pendingScheduleCleanupRef.current = scheduleListContainerHeightUpdate();
     },
   }));
 
@@ -518,6 +633,17 @@ export function List<Item>({
     cache,
   ]);
 
+  const baseContentContainerStyle = contentContainerStyle as unknown as
+    | CSSProperties
+    | undefined;
+  const resolvedContentContainerStyle = useMemo<CSSProperties | undefined>(
+    () =>
+      contentHeight
+        ? { ...baseContentContainerStyle, minHeight: contentHeight }
+        : baseContentContainerStyle,
+    [baseContentContainerStyle, contentHeight],
+  );
+
   if (numColumns > 1) {
     return (
       <AutoSizer disableHeight>
@@ -525,7 +651,7 @@ export function List<Item>({
           return (
             <div
               ref={ref as React.RefObject<HTMLDivElement>}
-              style={contentContainerStyle as any}
+              style={resolvedContentContainerStyle as any}
               onMouseEnter={onMouseEnter}
               onMouseLeave={onMouseLeave}
             >
@@ -551,7 +677,7 @@ export function List<Item>({
         return (
           <div
             ref={ref as React.RefObject<HTMLDivElement>}
-            style={contentContainerStyle as any}
+            style={resolvedContentContainerStyle as any}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
           >

--- a/packages/components/src/composite/Tabs/List.tsx
+++ b/packages/components/src/composite/Tabs/List.tsx
@@ -27,6 +27,7 @@ import {
 import { useTabsContext, useTabsScrollContext } from './context';
 import { useTabNameContext } from './TabNameContext';
 import { useConvertAnimatedToValue } from './useFocusedTab';
+import { parseCssSize } from './utils';
 
 import type { ISectionListProps } from '../../layouts';
 import type { FlashListProps } from '@shopify/flash-list';
@@ -77,11 +78,6 @@ const renderElement = (Element: ReactNode | ComponentType<any>) => {
   }
   const Component = Element as ComponentType<any>;
   return <Component />;
-};
-
-const parseCssSize = (value: string | undefined) => {
-  const size = Number.parseFloat(value ?? '');
-  return Number.isFinite(size) ? size : 0;
 };
 
 export function List<Item>({
@@ -573,13 +569,17 @@ export function List<Item>({
     };
   }, []);
 
-  useImperativeHandle(parentRef as any, () => ({
-    recomputeLayout: () => {
-      recompute({ numColumns, width });
-      pendingScheduleCleanupRef.current?.();
-      pendingScheduleCleanupRef.current = scheduleListContainerHeightUpdate();
-    },
-  }));
+  useImperativeHandle(
+    parentRef as any,
+    () => ({
+      recomputeLayout: () => {
+        recompute({ numColumns, width });
+        pendingScheduleCleanupRef.current?.();
+        pendingScheduleCleanupRef.current = scheduleListContainerHeightUpdate();
+      },
+    }),
+    [numColumns, recompute, scheduleListContainerHeightUpdate, width],
+  );
 
   const handleScroll = useCallback(
     (params: {

--- a/packages/components/src/composite/Tabs/context.ts
+++ b/packages/components/src/composite/Tabs/context.ts
@@ -26,7 +26,9 @@ export const TabsContainerContext = createContext<ITabsContainerContext>({
   width: 0,
 });
 
-export type ITabsScrollContext = Omit<WindowScrollerChildProps, 'children'>;
+export type ITabsScrollContext = Omit<WindowScrollerChildProps, 'children'> & {
+  updateListContainerHeight?: () => void;
+};
 
 export const TabsScrollContext = createContext<ITabsScrollContext>({
   height: 0,

--- a/packages/components/src/composite/Tabs/utils.ts
+++ b/packages/components/src/composite/Tabs/utils.ts
@@ -5,3 +5,8 @@ export const startViewTransition = (fn: () => void) => {
     fn();
   }
 };
+
+export const parseCssSize = (value: string | undefined) => {
+  const size = Number.parseFloat(value ?? '');
+  return Number.isFinite(size) ? size : 0;
+};

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -2401,13 +2401,6 @@ function TokenListBlock({
           initialized: true,
           isRefreshing: false,
         });
-
-        appEventBus.emit(EAppEventBusNames.TabListStateUpdate, {
-          isRefreshing: true,
-          type: EHomeTab.TOKENS,
-          accountId,
-          networkId,
-        });
       }
     };
 

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -56,6 +56,21 @@ import { HomeTestIDs } from '../testIDs';
 // balance is shown as a placeholder to avoid a skeleton flash.
 const BALANCE_REUSE_GRACE_MS = 180;
 
+const HOME_OVERVIEW_REFRESH_TABS = [
+  EHomeTab.TOKENS,
+  EHomeTab.NFT,
+  EHomeTab.HISTORY,
+  EHomeTab.DEFI,
+] as const;
+
+type IHomeOverviewRefreshTab = (typeof HOME_OVERVIEW_REFRESH_TABS)[number];
+
+function isHomeOverviewRefreshTab(
+  type: EHomeTab,
+): type is IHomeOverviewRefreshTab {
+  return HOME_OVERVIEW_REFRESH_TABS.includes(type as IHomeOverviewRefreshTab);
+}
+
 function HomeOverviewContainer() {
   const num = 0;
   const { activeAccount } = useActiveAccount({ num });
@@ -80,7 +95,9 @@ function HomeOverviewContainer() {
   const [isRefreshingDeFiList, setIsRefreshingDeFiList] = useState(false);
   const [isRefreshingHistoryList, setIsRefreshingHistoryList] = useState(false);
 
-  const listRefreshKey = useRef('');
+  const listRefreshKeys = useRef<
+    Partial<Record<IHomeOverviewRefreshTab, string>>
+  >({});
 
   const [accountWorth] = useAccountWorthAtom();
   const [accountDeFiOverview] = useAccountDeFiOverviewAtom();
@@ -220,6 +237,51 @@ function HomeOverviewContainer() {
   ]);
 
   useEffect(() => {
+    const refreshStateSetters: Record<
+      IHomeOverviewRefreshTab,
+      (isRefreshing: boolean) => void
+    > = {
+      [EHomeTab.TOKENS]: setIsRefreshingTokenList,
+      [EHomeTab.NFT]: setIsRefreshingNftList,
+      [EHomeTab.HISTORY]: setIsRefreshingHistoryList,
+      [EHomeTab.DEFI]: setIsRefreshingDeFiList,
+    };
+
+    const syncWorthRefreshingState = () => {
+      setIsRefreshingWorth(
+        HOME_OVERVIEW_REFRESH_TABS.some((refreshType) =>
+          Boolean(listRefreshKeys.current[refreshType]),
+        ),
+      );
+    };
+
+    const updateRefreshState = ({
+      refreshType,
+      isRefreshing,
+      key,
+    }: {
+      refreshType: IHomeOverviewRefreshTab;
+      isRefreshing: boolean;
+      key: string;
+    }) => {
+      if (isRefreshing) {
+        listRefreshKeys.current[refreshType] = key;
+        refreshStateSetters[refreshType](true);
+        return true;
+      }
+
+      if (
+        listRefreshKeys.current[refreshType] &&
+        listRefreshKeys.current[refreshType] !== key
+      ) {
+        return false;
+      }
+
+      delete listRefreshKeys.current[refreshType];
+      refreshStateSetters[refreshType](false);
+      return true;
+    };
+
     const fn = ({
       isRefreshing,
       type,
@@ -232,35 +294,27 @@ function HomeOverviewContainer() {
       networkId: string;
     }) => {
       const key = `${accountId}-${networkId}`;
-      if (
-        !isRefreshing &&
-        listRefreshKey.current &&
-        listRefreshKey.current !== key
-      ) {
-        return;
-      }
-
-      listRefreshKey.current = key;
+      let didUpdateState = false;
 
       if (type === EHomeTab.ALL) {
-        setIsRefreshingTokenList(isRefreshing);
-        setIsRefreshingNftList(isRefreshing);
-        setIsRefreshingHistoryList(isRefreshing);
-        setIsRefreshingWorth(isRefreshing);
-        setIsRefreshingDeFiList(isRefreshing);
+        HOME_OVERVIEW_REFRESH_TABS.forEach((refreshType) => {
+          didUpdateState =
+            updateRefreshState({ refreshType, isRefreshing, key }) ||
+            didUpdateState;
+        });
+      } else if (isHomeOverviewRefreshTab(type)) {
+        didUpdateState = updateRefreshState({
+          refreshType: type,
+          isRefreshing,
+          key,
+        });
+      }
+
+      if (!didUpdateState) {
         return;
       }
 
-      if (type === EHomeTab.TOKENS) {
-        setIsRefreshingTokenList(isRefreshing);
-      } else if (type === EHomeTab.NFT) {
-        setIsRefreshingNftList(isRefreshing);
-      } else if (type === EHomeTab.HISTORY) {
-        setIsRefreshingHistoryList(isRefreshing);
-      } else if (type === EHomeTab.DEFI) {
-        setIsRefreshingDeFiList(isRefreshing);
-      }
-      setIsRefreshingWorth(isRefreshing);
+      syncWorthRefreshingState();
       if (isRefreshing) {
         perfMark(`Home:refresh:start:${type}`, {
           refreshType: type,
@@ -279,6 +333,15 @@ function HomeOverviewContainer() {
       appEventBus.off(EAppEventBusNames.TabListStateUpdate, fn);
     };
   }, []);
+
+  useEffect(() => {
+    listRefreshKeys.current = {};
+    setIsRefreshingWorth(false);
+    setIsRefreshingTokenList(false);
+    setIsRefreshingNftList(false);
+    setIsRefreshingHistoryList(false);
+    setIsRefreshingDeFiList(false);
+  }, [account?.id, account?.indexedAccountId, network?.id, wallet?.id]);
 
   useEffect(() => {
     const updateAccountValue = async () => {

--- a/packages/kit/src/views/Home/pages/TxHistoryContainer.tsx
+++ b/packages/kit/src/views/Home/pages/TxHistoryContainer.tsx
@@ -170,6 +170,10 @@ function TxHistoryListContainer(
   );
 
   const isManualRefresh = useRef(false);
+  // Identifies the most recently dispatched fetch. Older fetches that complete
+  // after a newer one started must NOT write their stale result into local
+  // state — they would clobber the new account/network's data.
+  const fetchDispatchKeyRef = useRef('');
   const { run } = usePromiseResult(
     async () => {
       if (!network) return;
@@ -180,12 +184,12 @@ function TxHistoryListContainer(
         accountId = indexedAccount?.id ?? '';
       } else if (!account) return;
 
-      appEventBus.emit(EAppEventBusNames.TabListStateUpdate, {
-        isRefreshing: true,
-        type: EHomeTab.HISTORY,
-        accountId,
-        networkId: network.id,
-      });
+      const refreshNetworkId = network.id;
+      const refreshAccountId = accountId;
+      const dispatchKey = `${refreshAccountId}-${refreshNetworkId}`;
+      fetchDispatchKeyRef.current = dispatchKey;
+      const isCurrentDispatch = () =>
+        fetchDispatchKeyRef.current === dispatchKey;
 
       let r: {
         allAccounts: IAllNetworkAccountInfo[];
@@ -204,96 +208,122 @@ function TxHistoryListContainer(
         hasMoreOnChainHistory: false,
       };
 
-      if (mergeDeriveAddressData) {
-        let hasMoreOnChainHistory = false;
-        const { networkAccounts } =
-          await backgroundApiProxy.serviceAccount.getNetworkAccountsInSameIndexedAccountIdWithDeriveTypes(
-            {
-              networkId: network.id,
-              indexedAccountId: indexedAccount?.id ?? '',
-              excludeEmptyAccount: true,
-            },
+      let emittedTrue = false;
+      try {
+        appEventBus.emit(EAppEventBusNames.TabListStateUpdate, {
+          isRefreshing: true,
+          type: EHomeTab.HISTORY,
+          accountId: refreshAccountId,
+          networkId: refreshNetworkId,
+        });
+        emittedTrue = true;
+
+        if (mergeDeriveAddressData) {
+          let hasMoreOnChainHistory = false;
+          const { networkAccounts } =
+            await backgroundApiProxy.serviceAccount.getNetworkAccountsInSameIndexedAccountIdWithDeriveTypes(
+              {
+                networkId: network.id,
+                indexedAccountId: indexedAccount?.id ?? '',
+                excludeEmptyAccount: true,
+              },
+            );
+          const resp = await Promise.all(
+            networkAccounts.map((networkAccount) =>
+              backgroundApiProxy.serviceHistory.fetchAccountHistory({
+                accountId: networkAccount.account?.id ?? '',
+                networkId: network.id,
+                isManualRefresh: isManualRefresh.current,
+                filterScam: settings.isFilterScamHistoryEnabled,
+                filterLowValue: settings.isFilterLowValueHistoryEnabled,
+                sourceCurrency: settings.currencyInfo.id,
+                currencyMap,
+                limit,
+              }),
+            ),
           );
-        const resp = await Promise.all(
-          networkAccounts.map((networkAccount) =>
-            backgroundApiProxy.serviceHistory.fetchAccountHistory({
-              accountId: networkAccount.account?.id ?? '',
-              networkId: network.id,
-              isManualRefresh: isManualRefresh.current,
-              filterScam: settings.isFilterScamHistoryEnabled,
-              filterLowValue: settings.isFilterLowValueHistoryEnabled,
-              sourceCurrency: settings.currencyInfo.id,
-              currencyMap,
-              limit,
-            }),
-          ),
-        );
 
-        resp.forEach((item) => {
-          r.txs = [...r.txs, ...item.txs];
-          r.allAccounts = [...r.allAccounts, ...item.allAccounts];
-          r.accountsWithChangedTxs = [
-            ...r.accountsWithChangedTxs,
-            ...item.accountsWithChangedTxs,
-          ];
-          r.addressMap = { ...r.addressMap, ...item.addressMap };
-          if (item.hasMoreOnChainHistory) {
-            hasMoreOnChainHistory = true;
-          }
+          resp.forEach((item) => {
+            r.txs = [...r.txs, ...item.txs];
+            r.allAccounts = [...r.allAccounts, ...item.allAccounts];
+            r.accountsWithChangedTxs = [
+              ...r.accountsWithChangedTxs,
+              ...item.accountsWithChangedTxs,
+            ];
+            r.addressMap = { ...r.addressMap, ...item.addressMap };
+            if (item.hasMoreOnChainHistory) {
+              hasMoreOnChainHistory = true;
+            }
+          });
+
+          r.txs = r.txs
+            .toSorted(
+              (b, a) =>
+                (a.decodedTx.updatedAt ?? a.decodedTx.createdAt ?? 0) -
+                (b.decodedTx.updatedAt ?? b.decodedTx.createdAt ?? 0),
+            )
+            .slice(0, HISTORY_PAGE_SIZE);
+          setHasMoreOnChainHistory(hasMoreOnChainHistory);
+          updateAddressesInfo({
+            data: r.addressMap ?? {},
+          });
+        } else {
+          r = await backgroundApiProxy.serviceHistory.fetchAccountHistory({
+            accountId,
+            networkId: network.id,
+            isManualRefresh: isManualRefresh.current,
+            filterScam: settings.isFilterScamHistoryEnabled,
+            filterLowValue: settings.isFilterLowValueHistoryEnabled,
+            excludeTestNetwork: true,
+            sourceCurrency: settings.currencyInfo.id,
+            currencyMap,
+            limit,
+          });
+          setHasMoreOnChainHistory(!!r.hasMoreOnChainHistory);
+          updateAddressesInfo({
+            data: r.addressMap ?? {},
+          });
+        }
+
+        // Skip every state write past this point if a newer fetch already
+        // took over — otherwise this stale body would clobber the new
+        // account/network's data and leave the UI on stale or empty state.
+        if (!isCurrentDispatch()) {
+          return;
+        }
+
+        updateAllNetworksState({
+          visibleCount: uniqBy(r.allAccounts, 'networkId').length,
         });
 
-        r.txs = r.txs
-          .toSorted(
-            (b, a) =>
-              (a.decodedTx.updatedAt ?? a.decodedTx.createdAt ?? 0) -
-              (b.decodedTx.updatedAt ?? b.decodedTx.createdAt ?? 0),
-          )
-          .slice(0, HISTORY_PAGE_SIZE);
-        setHasMoreOnChainHistory(hasMoreOnChainHistory);
-        updateAddressesInfo({
-          data: r.addressMap ?? {},
+        setHistoryState({
+          initialized: true,
+          isRefreshing: false,
         });
-      } else {
-        r = await backgroundApiProxy.serviceHistory.fetchAccountHistory({
-          accountId,
-          networkId: network.id,
-          isManualRefresh: isManualRefresh.current,
-          filterScam: settings.isFilterScamHistoryEnabled,
-          filterLowValue: settings.isFilterLowValueHistoryEnabled,
-          excludeTestNetwork: true,
-          sourceCurrency: settings.currencyInfo.id,
-          currencyMap,
-          limit,
-        });
-        setHasMoreOnChainHistory(!!r.hasMoreOnChainHistory);
-        updateAddressesInfo({
-          data: r.addressMap ?? {},
-        });
+        updateHistoryData(r.txs);
+
+        if (r.accountsWithChangedTxs.length > 0) {
+          appEventBus.emit(EAppEventBusNames.RefreshTokenList, {
+            accounts: r.accountsWithChangedTxs,
+          });
+        }
+        isManualRefresh.current = false;
+      } finally {
+        // Always clear the overview spinner that we lit up — emit-false has
+        // to mirror emit-true regardless of error / abort / dispatch
+        // supersession, or the home header spinner gets stuck.
+        if (emittedTrue) {
+          appEventBus.emit(EAppEventBusNames.TabListStateUpdate, {
+            isRefreshing: false,
+            type: EHomeTab.HISTORY,
+            accountId: refreshAccountId,
+            networkId: refreshNetworkId,
+          });
+        }
+        if (isCurrentDispatch()) {
+          setIsHeaderRefreshing(false);
+        }
       }
-
-      updateAllNetworksState({
-        visibleCount: uniqBy(r.allAccounts, 'networkId').length,
-      });
-
-      setHistoryState({
-        initialized: true,
-        isRefreshing: false,
-      });
-      setIsHeaderRefreshing(false);
-      updateHistoryData(r.txs);
-
-      appEventBus.emit(EAppEventBusNames.TabListStateUpdate, {
-        isRefreshing: false,
-        type: EHomeTab.HISTORY,
-        accountId,
-        networkId: network.id,
-      });
-      if (r.accountsWithChangedTxs.length > 0) {
-        appEventBus.emit(EAppEventBusNames.RefreshTokenList, {
-          accounts: r.accountsWithChangedTxs,
-        });
-      }
-      isManualRefresh.current = false;
     },
     [
       network,
@@ -319,11 +349,19 @@ function TxHistoryListContainer(
     },
   );
 
+  // Track the last identity we ran initHistoryState for, so dep-only changes
+  // (settings/currency map/limit) don't re-run identity-bound side-effects
+  // like clearing historyData. When body's first-page fetch lands a moment
+  // later, an unrelated useEffect re-fire would otherwise wipe the new
+  // account's data right back to []. We only re-init when the identity tuple
+  // genuinely changes.
+  const lastInitIdentityRef = useRef<string>('');
   useEffect(() => {
     const initHistoryState = async (
       accountId: string,
       networkId: string,
       indexedAccountId: string | undefined,
+      capturedIdentity: string,
     ) => {
       let accountHistoryTxs: IAccountHistoryTx[] = [];
 
@@ -370,6 +408,14 @@ function TxHistoryListContainer(
           });
       }
 
+      // The local-history reads above are async; a faster identity switch can
+      // arrive while we're awaiting and bump `lastInitIdentityRef`. If that
+      // happened, this stale result must not be written into the new identity's
+      // state (same rationale as the dispatch-key guard in `run()`).
+      if (lastInitIdentityRef.current !== capturedIdentity) {
+        return;
+      }
+
       if (!isEmpty(accountHistoryTxs)) {
         updateHistoryData(accountHistoryTxs);
         setHistoryState({
@@ -377,6 +423,11 @@ function TxHistoryListContainer(
           isRefreshing: false,
         });
       } else {
+        // No local cache for the new account/network — drop any rows still
+        // hanging around from the previous account so the user sees a clean
+        // skeleton (driven by initialized=false) instead of stale data while
+        // the first-page fetch is in flight.
+        setHistoryData([]);
         setHistoryState({
           initialized: false,
           isRefreshing: true,
@@ -387,10 +438,24 @@ function TxHistoryListContainer(
       refreshAllNetworksHistory.current = false;
     };
     if ((account?.id || mergeDeriveAddressData) && network?.id && wallet?.id) {
+      const identity = [
+        account?.id ?? '',
+        indexedAccount?.id ?? '',
+        network.id,
+        wallet.id,
+        mergeDeriveAddressData ? '1' : '0',
+      ].join('|');
+      if (lastInitIdentityRef.current === identity) {
+        // Same account/network/wallet — let the body refresh; no need to
+        // re-clear local state.
+        return;
+      }
+      lastInitIdentityRef.current = identity;
       void initHistoryState(
         account?.id ?? '',
         network.id,
         indexedAccount?.id ?? '',
+        identity,
       );
     }
   }, [
@@ -406,6 +471,20 @@ function TxHistoryListContainer(
     settings.currencyInfo.id,
     currencyMap,
     limit,
+  ]);
+
+  // Invalidate the dispatch key whenever the source identity changes so any
+  // in-flight `run()` from the previous identity fails its
+  // `isCurrentDispatch()` check on response, before the new `run()` even gets
+  // a chance to overwrite the key.
+  useEffect(() => {
+    fetchDispatchKeyRef.current = '';
+  }, [
+    account?.id,
+    indexedAccount?.id,
+    mergeDeriveAddressData,
+    network?.id,
+    wallet?.id,
   ]);
 
   useEffect(() => {

--- a/packages/kit/src/views/Home/pages/TxHistoryContainer.tsx
+++ b/packages/kit/src/views/Home/pages/TxHistoryContainer.tsx
@@ -170,6 +170,28 @@ function TxHistoryListContainer(
   );
 
   const isManualRefresh = useRef(false);
+
+  // Stable string capturing the source identity tuple. Both the init effect
+  // (short-circuit guard) and the dep-change effect (counter bump) consume
+  // this so they cannot drift apart on what counts as an identity change.
+  const identityKey = useMemo(
+    () =>
+      [
+        account?.id ?? '',
+        indexedAccount?.id ?? '',
+        network?.id ?? '',
+        wallet?.id ?? '',
+        mergeDeriveAddressData ? '1' : '0',
+      ].join('|'),
+    [
+      account?.id,
+      indexedAccount?.id,
+      mergeDeriveAddressData,
+      network?.id,
+      wallet?.id,
+    ],
+  );
+
   // Monotonic request id. Bumped on identity dep changes (via the effect
   // below) AND at the start of every `run()` body — so old in-flight fetches
   // are invalidated *before* the next debounced runner even starts, and
@@ -220,10 +242,8 @@ function TxHistoryListContainer(
         };
         let aggregatedHasMoreOnChainHistory = false;
 
-        // Set the flag BEFORE the synchronous emit call: if any subscriber
-        // throws inside its handler, the emit may have already broadcast the
-        // `true` to earlier subscribers, and the finally block must still
-        // mirror with `false` to release them.
+        // Set BEFORE emit so a throwing handler can't strand earlier
+        // subscribers that already received the `true` event.
         emittedTrue = true;
         appEventBus.emit(EAppEventBusNames.TabListStateUpdate, {
           isRefreshing: true,
@@ -292,11 +312,7 @@ function TxHistoryListContainer(
         }
 
         // Skip every state write past this point if a newer fetch already
-        // took over — otherwise this stale body would clobber the new
-        // account/network's data and leave the UI on stale or empty state.
-        // This guard must precede shared-state writes (has-more flag,
-        // address-badge metadata, history rows, allNetworks visible count),
-        // not just the local history setter.
+        // took over — a stale body would clobber the new identity's data.
         if (!isCurrentRequest()) {
           return;
         }
@@ -326,10 +342,7 @@ function TxHistoryListContainer(
         // / supersession, otherwise the next polling tick would be wrongly
         // marked as a manual refresh (forcing an on-chain fetch).
         isManualRefresh.current = false;
-        // emit-false must mirror emit-true. HomeOverviewContainer's per-tab
-        // keyed state filters stale `false` events by accountId/networkId
-        // already, so a superseded run's emit-false won't clobber the new
-        // run's spinner state.
+        // emit-false must mirror emit-true so subscribers are released.
         if (emittedTrue) {
           appEventBus.emit(EAppEventBusNames.TabListStateUpdate, {
             isRefreshing: false,
@@ -338,12 +351,7 @@ function TxHistoryListContainer(
             networkId: refreshNetworkId,
           });
         }
-        // Only the freshest run owns the header refresh indicator. If an
-        // older superseded run finishes first, hiding the indicator while
-        // the newer fetch is still in flight would mislead the user.
-        // Early-return runs (no network / no account) still bumped the
-        // counter at function entry, so they pass `isCurrentRequest()` and
-        // correctly release the spinner.
+        // Only the freshest run owns the header refresh indicator.
         if (isCurrentRequest()) {
           setIsHeaderRefreshing(false);
         }
@@ -373,20 +381,23 @@ function TxHistoryListContainer(
     },
   );
 
-  // Track the last identity we ran initHistoryState for, so dep-only changes
-  // (settings/currency map/limit) don't re-run identity-bound side-effects
-  // like clearing historyData. When body's first-page fetch lands a moment
-  // later, an unrelated useEffect re-fire would otherwise wipe the new
-  // account's data right back to []. We only re-init when the identity tuple
-  // genuinely changes.
-  const lastInitIdentityRef = useRef<string>('');
+  // Identity of the last in-flight `initHistoryState`. `null` means no init
+  // is owned by the current identity (initial mount or identity went
+  // invalid). Async reads compare their captured identity against this ref
+  // to bail out if a faster identity switch already took ownership.
+  const lastInitIdentityRef = useRef<string | null>(null);
   useEffect(() => {
-    const initHistoryState = async (
-      accountId: string,
-      networkId: string,
-      indexedAccountId: string | undefined,
-      capturedIdentity: string,
-    ) => {
+    const initHistoryState = async ({
+      accountId,
+      networkId,
+      indexedAccountId,
+      capturedIdentity,
+    }: {
+      accountId: string;
+      networkId: string;
+      indexedAccountId?: string;
+      capturedIdentity: string;
+    }) => {
       let accountHistoryTxs: IAccountHistoryTx[] = [];
 
       if (mergeDeriveAddressData) {
@@ -432,10 +443,8 @@ function TxHistoryListContainer(
           });
       }
 
-      // The local-history reads above are async; a faster identity switch can
-      // arrive while we're awaiting and bump `lastInitIdentityRef`. If that
-      // happened, this stale result must not be written into the new identity's
-      // state (same rationale as the monotonic request id guard in `run()`).
+      // Bail out if a faster identity switch already took ownership while we
+      // were awaiting — same rationale as the monotonic guard in `run()`.
       if (lastInitIdentityRef.current !== capturedIdentity) {
         return;
       }
@@ -447,11 +456,12 @@ function TxHistoryListContainer(
           isRefreshing: false,
         });
       } else {
-        // No local cache for the new account/network — drop any rows still
-        // hanging around from the previous account so the user sees a clean
-        // skeleton (driven by initialized=false) instead of stale data while
-        // the first-page fetch is in flight.
-        setHistoryData([]);
+        // No local cache for the new identity — drop any rows still hanging
+        // around from the previous account so the user sees a clean skeleton
+        // (driven by initialized=false) instead of stale data while the
+        // first-page fetch is in flight. Same-reference short-circuit avoids
+        // a redundant re-render when state is already empty.
+        setHistoryData((prev) => (prev.length === 0 ? prev : []));
         setHistoryState({
           initialized: false,
           isRefreshing: true,
@@ -462,31 +472,24 @@ function TxHistoryListContainer(
       refreshAllNetworksHistory.current = false;
     };
     if ((account?.id || mergeDeriveAddressData) && network?.id && wallet?.id) {
-      const identity = [
-        account?.id ?? '',
-        indexedAccount?.id ?? '',
-        network.id,
-        wallet.id,
-        mergeDeriveAddressData ? '1' : '0',
-      ].join('|');
-      if (lastInitIdentityRef.current === identity) {
-        // Same account/network/wallet — let the body refresh; no need to
-        // re-clear local state.
+      if (lastInitIdentityRef.current === identityKey) {
+        // Same identity — let the body refresh; no need to re-clear local
+        // state.
         return;
       }
-      lastInitIdentityRef.current = identity;
-      void initHistoryState(
-        account?.id ?? '',
-        network.id,
-        indexedAccount?.id ?? '',
-        identity,
-      );
+      lastInitIdentityRef.current = identityKey;
+      void initHistoryState({
+        accountId: account?.id ?? '',
+        networkId: network.id,
+        indexedAccountId: indexedAccount?.id ?? '',
+        capturedIdentity: identityKey,
+      });
     } else {
       // Identity went invalid (account/network/wallet became null during a
-      // transition). Invalidate the ref so any currently-awaiting
-      // `initHistoryState` from the previous valid identity bails out
-      // before writing stale local-cache rows into the new identity's state.
-      lastInitIdentityRef.current = '';
+      // transition). Release ownership so any awaiting `initHistoryState`
+      // from the previous valid identity bails out instead of writing stale
+      // rows into the new identity's state.
+      lastInitIdentityRef.current = null;
     }
   }, [
     account?.id,
@@ -501,23 +504,16 @@ function TxHistoryListContainer(
     settings.currencyInfo.id,
     currencyMap,
     limit,
+    identityKey,
   ]);
 
-  // Invalidate any in-flight `run()` AS SOON AS the source identity changes,
-  // without waiting for the next debounced runner to actually start. Without
-  // this, an old run that resolves during the ~1s debounce window (between
-  // user input change and the next runner firing) would still see its
-  // captured `requestId` as current and write stale data into the new
-  // identity's state. The runner-body bump alone cannot cover this window.
+  // Invalidate in-flight `run()` synchronously on identity change, so an
+  // old run resolving during the ~1s `usePromiseResult` debounce window
+  // can't write into the new identity's state before the next runner even
+  // starts. The runner-body bump alone cannot cover this window.
   useEffect(() => {
     fetchRequestIdRef.current += 1;
-  }, [
-    account?.id,
-    indexedAccount?.id,
-    mergeDeriveAddressData,
-    network?.id,
-    wallet?.id,
-  ]);
+  }, [identityKey]);
 
   useEffect(() => {
     if (isHeaderRefreshing) {

--- a/packages/kit/src/views/Home/pages/TxHistoryContainer.tsx
+++ b/packages/kit/src/views/Home/pages/TxHistoryContainer.tsx
@@ -386,17 +386,24 @@ function TxHistoryListContainer(
   // invalid). Async reads compare their captured identity against this ref
   // to bail out if a faster identity switch already took ownership.
   const lastInitIdentityRef = useRef<string | null>(null);
+  // Monotonic request id bumped on every `initHistoryState` launch. Combined
+  // with `lastInitIdentityRef`, this lets a same-identity dep change (e.g.
+  // filter/currency/limit) re-read the local cache while preventing an older
+  // slow fetch from clobbering newer results after they resolve out of order.
+  const initRequestIdRef = useRef(0);
   useEffect(() => {
     const initHistoryState = async ({
       accountId,
       networkId,
       indexedAccountId,
       capturedIdentity,
+      requestId,
     }: {
       accountId: string;
       networkId: string;
       indexedAccountId?: string;
       capturedIdentity: string;
+      requestId: number;
     }) => {
       let accountHistoryTxs: IAccountHistoryTx[] = [];
 
@@ -443,9 +450,15 @@ function TxHistoryListContainer(
           });
       }
 
-      // Bail out if a faster identity switch already took ownership while we
-      // were awaiting — same rationale as the monotonic guard in `run()`.
-      if (lastInitIdentityRef.current !== capturedIdentity) {
+      // Bail out if either:
+      //   (a) a faster identity switch took ownership during the await, OR
+      //   (b) a newer same-identity effect run (e.g. filter/currency/limit
+      //       change) superseded this one — without (b), an older slow fetch
+      //       could clobber newer filter results after both resolve.
+      if (
+        lastInitIdentityRef.current !== capturedIdentity ||
+        initRequestIdRef.current !== requestId
+      ) {
         return;
       }
 
@@ -456,8 +469,9 @@ function TxHistoryListContainer(
           isRefreshing: false,
         });
       } else {
-        // No local cache for the new identity — drop any rows still hanging
-        // around from the previous account so the user sees a clean skeleton
+        // No local cache for the current identity/filter combo — drop any
+        // rows still hanging around (from the previous account, or from a
+        // prior filter/currency setting) so the user sees a clean skeleton
         // (driven by initialized=false) instead of stale data while the
         // first-page fetch is in flight. Same-reference short-circuit avoids
         // a redundant re-render when state is already empty.
@@ -472,17 +486,19 @@ function TxHistoryListContainer(
       refreshAllNetworksHistory.current = false;
     };
     if ((account?.id || mergeDeriveAddressData) && network?.id && wallet?.id) {
-      if (lastInitIdentityRef.current === identityKey) {
-        // Same identity — let the body refresh; no need to re-clear local
-        // state.
-        return;
-      }
+      // Always re-run on every dep change (filter/currency/limit included) so
+      // the local cache view stays in sync with the latest filter inputs.
+      // Concurrent runs are disambiguated by `initRequestIdRef`; old-identity
+      // writes are still blocked by the `capturedIdentity` check above.
       lastInitIdentityRef.current = identityKey;
+      initRequestIdRef.current += 1;
+      const requestId = initRequestIdRef.current;
       void initHistoryState({
         accountId: account?.id ?? '',
         networkId: network.id,
         indexedAccountId: indexedAccount?.id ?? '',
         capturedIdentity: identityKey,
+        requestId,
       });
     } else {
       // Identity went invalid (account/network/wallet became null during a

--- a/packages/kit/src/views/Home/pages/TxHistoryContainer.tsx
+++ b/packages/kit/src/views/Home/pages/TxHistoryContainer.tsx
@@ -170,56 +170,69 @@ function TxHistoryListContainer(
   );
 
   const isManualRefresh = useRef(false);
-  // Identifies the most recently dispatched fetch. Older fetches that complete
-  // after a newer one started must NOT write their stale result into local
-  // state — they would clobber the new account/network's data.
-  const fetchDispatchKeyRef = useRef('');
+  // Monotonic request id. Bumped on identity dep changes (via the effect
+  // below) AND at the start of every `run()` body — so old in-flight fetches
+  // are invalidated *before* the next debounced runner even starts, and
+  // early-return runs (no network / no account) still produce a fresh id
+  // that older runs can compare against.
+  const fetchRequestIdRef = useRef(0);
   const { run } = usePromiseResult(
     async () => {
-      if (!network) return;
-
-      let accountId = account?.id ?? '';
-
-      if (mergeDeriveAddressData) {
-        accountId = indexedAccount?.id ?? '';
-      } else if (!account) return;
-
-      const refreshNetworkId = network.id;
-      const refreshAccountId = accountId;
-      const dispatchKey = `${refreshAccountId}-${refreshNetworkId}`;
-      fetchDispatchKeyRef.current = dispatchKey;
-      const isCurrentDispatch = () =>
-        fetchDispatchKeyRef.current === dispatchKey;
-
-      let r: {
-        allAccounts: IAllNetworkAccountInfo[];
-        txs: IAccountHistoryTx[];
-        accountsWithChangedTxs: {
-          accountId: string;
-          networkId: string;
-        }[];
-        addressMap?: Record<string, IAddressBadge>;
-        hasMoreOnChainHistory?: boolean;
-      } = {
-        allAccounts: [],
-        txs: [],
-        accountsWithChangedTxs: [],
-        addressMap: {},
-        hasMoreOnChainHistory: false,
-      };
+      // Bump UNCONDITIONALLY, before any early return, so an older in-flight
+      // run cannot survive across an identity change just because the new
+      // run happened to early-return (no account/network). The captured
+      // `requestId` is used everywhere below to gate state writes.
+      fetchRequestIdRef.current += 1;
+      const requestId = fetchRequestIdRef.current;
+      const isCurrentRequest = () => fetchRequestIdRef.current === requestId;
 
       let emittedTrue = false;
+      let refreshAccountId = '';
+      let refreshNetworkId = '';
+
       try {
+        if (!network) return;
+
+        let accountId = account?.id ?? '';
+
+        if (mergeDeriveAddressData) {
+          accountId = indexedAccount?.id ?? '';
+        } else if (!account) return;
+
+        refreshNetworkId = network.id;
+        refreshAccountId = accountId;
+
+        let r: {
+          allAccounts: IAllNetworkAccountInfo[];
+          txs: IAccountHistoryTx[];
+          accountsWithChangedTxs: {
+            accountId: string;
+            networkId: string;
+          }[];
+          addressMap?: Record<string, IAddressBadge>;
+          hasMoreOnChainHistory?: boolean;
+        } = {
+          allAccounts: [],
+          txs: [],
+          accountsWithChangedTxs: [],
+          addressMap: {},
+          hasMoreOnChainHistory: false,
+        };
+        let aggregatedHasMoreOnChainHistory = false;
+
+        // Set the flag BEFORE the synchronous emit call: if any subscriber
+        // throws inside its handler, the emit may have already broadcast the
+        // `true` to earlier subscribers, and the finally block must still
+        // mirror with `false` to release them.
+        emittedTrue = true;
         appEventBus.emit(EAppEventBusNames.TabListStateUpdate, {
           isRefreshing: true,
           type: EHomeTab.HISTORY,
           accountId: refreshAccountId,
           networkId: refreshNetworkId,
         });
-        emittedTrue = true;
 
         if (mergeDeriveAddressData) {
-          let hasMoreOnChainHistory = false;
           const { networkAccounts } =
             await backgroundApiProxy.serviceAccount.getNetworkAccountsInSameIndexedAccountIdWithDeriveTypes(
               {
@@ -252,7 +265,7 @@ function TxHistoryListContainer(
             ];
             r.addressMap = { ...r.addressMap, ...item.addressMap };
             if (item.hasMoreOnChainHistory) {
-              hasMoreOnChainHistory = true;
+              aggregatedHasMoreOnChainHistory = true;
             }
           });
 
@@ -263,10 +276,6 @@ function TxHistoryListContainer(
                 (b.decodedTx.updatedAt ?? b.decodedTx.createdAt ?? 0),
             )
             .slice(0, HISTORY_PAGE_SIZE);
-          setHasMoreOnChainHistory(hasMoreOnChainHistory);
-          updateAddressesInfo({
-            data: r.addressMap ?? {},
-          });
         } else {
           r = await backgroundApiProxy.serviceHistory.fetchAccountHistory({
             accountId,
@@ -279,18 +288,23 @@ function TxHistoryListContainer(
             currencyMap,
             limit,
           });
-          setHasMoreOnChainHistory(!!r.hasMoreOnChainHistory);
-          updateAddressesInfo({
-            data: r.addressMap ?? {},
-          });
+          aggregatedHasMoreOnChainHistory = !!r.hasMoreOnChainHistory;
         }
 
         // Skip every state write past this point if a newer fetch already
         // took over — otherwise this stale body would clobber the new
         // account/network's data and leave the UI on stale or empty state.
-        if (!isCurrentDispatch()) {
+        // This guard must precede shared-state writes (has-more flag,
+        // address-badge metadata, history rows, allNetworks visible count),
+        // not just the local history setter.
+        if (!isCurrentRequest()) {
           return;
         }
+
+        setHasMoreOnChainHistory(aggregatedHasMoreOnChainHistory);
+        updateAddressesInfo({
+          data: r.addressMap ?? {},
+        });
 
         updateAllNetworksState({
           visibleCount: uniqBy(r.allAccounts, 'networkId').length,
@@ -307,11 +321,15 @@ function TxHistoryListContainer(
             accounts: r.accountsWithChangedTxs,
           });
         }
-        isManualRefresh.current = false;
       } finally {
-        // Always clear the overview spinner that we lit up — emit-false has
-        // to mirror emit-true regardless of error / abort / dispatch
-        // supersession, or the home header spinner gets stuck.
+        // Always release the request-level latch regardless of error / abort
+        // / supersession, otherwise the next polling tick would be wrongly
+        // marked as a manual refresh (forcing an on-chain fetch).
+        isManualRefresh.current = false;
+        // emit-false must mirror emit-true. HomeOverviewContainer's per-tab
+        // keyed state filters stale `false` events by accountId/networkId
+        // already, so a superseded run's emit-false won't clobber the new
+        // run's spinner state.
         if (emittedTrue) {
           appEventBus.emit(EAppEventBusNames.TabListStateUpdate, {
             isRefreshing: false,
@@ -320,7 +338,13 @@ function TxHistoryListContainer(
             networkId: refreshNetworkId,
           });
         }
-        if (isCurrentDispatch()) {
+        // Only the freshest run owns the header refresh indicator. If an
+        // older superseded run finishes first, hiding the indicator while
+        // the newer fetch is still in flight would mislead the user.
+        // Early-return runs (no network / no account) still bumped the
+        // counter at function entry, so they pass `isCurrentRequest()` and
+        // correctly release the spinner.
+        if (isCurrentRequest()) {
           setIsHeaderRefreshing(false);
         }
       }
@@ -411,7 +435,7 @@ function TxHistoryListContainer(
       // The local-history reads above are async; a faster identity switch can
       // arrive while we're awaiting and bump `lastInitIdentityRef`. If that
       // happened, this stale result must not be written into the new identity's
-      // state (same rationale as the dispatch-key guard in `run()`).
+      // state (same rationale as the monotonic request id guard in `run()`).
       if (lastInitIdentityRef.current !== capturedIdentity) {
         return;
       }
@@ -457,6 +481,12 @@ function TxHistoryListContainer(
         indexedAccount?.id ?? '',
         identity,
       );
+    } else {
+      // Identity went invalid (account/network/wallet became null during a
+      // transition). Invalidate the ref so any currently-awaiting
+      // `initHistoryState` from the previous valid identity bails out
+      // before writing stale local-cache rows into the new identity's state.
+      lastInitIdentityRef.current = '';
     }
   }, [
     account?.id,
@@ -473,12 +503,14 @@ function TxHistoryListContainer(
     limit,
   ]);
 
-  // Invalidate the dispatch key whenever the source identity changes so any
-  // in-flight `run()` from the previous identity fails its
-  // `isCurrentDispatch()` check on response, before the new `run()` even gets
-  // a chance to overwrite the key.
+  // Invalidate any in-flight `run()` AS SOON AS the source identity changes,
+  // without waiting for the next debounced runner to actually start. Without
+  // this, an old run that resolves during the ~1s debounce window (between
+  // user input change and the next runner firing) would still see its
+  // captured `requestId` as current and write stale data into the new
+  // identity's state. The runner-body bump alone cannot cover this window.
   useEffect(() => {
-    fetchDispatchKeyRef.current = '';
+    fetchRequestIdRef.current += 1;
   }, [
     account?.id,
     indexedAccount?.id,


### PR DESCRIPTION
## Summary
- Fix a race in the wallet Home **History** tab where switching networks (e.g. BTC → ETH) could clobber the new network's history with a stale empty result and leave the header spinner stuck.
- Track refresh state per Tabs sub-tab in `HomeOverviewContainer` so a TOKENS true-emit cannot block the HISTORY false-emit after a network switch.
- Re-measure virtualized tab inner-container height and re-sync tab visibility on remount, so the new tab paints with the correct height instead of showing blank.
- Light refactor of the history identity tracking so the init-effect short-circuit and the dep-change counter share one source of truth.

## Intent & Context
Reported on Jira **OK-54950**: on the wallet Home History tab, switching networks (most reliably BTC → ETH) could leave the list blank with a stuck "refreshing" spinner in the overview header. Root cause was a stale in-flight fetch from the previous network landing after the identity changed, writing an empty result into the new network's state — and a separate per-tab refresh-state bug that prevented the header spinner from being cleared.

## Root Cause
1. `TxHistoryContainer.run()` was guarded by an account/network dispatch key, but the guard didn't cover:
   - The `usePromiseResult` debounce window (~1s) — a fetch started under the old identity could resolve after the identity flipped.
   - Early-return paths (null account/network) that did not bump the dispatch key, so a superseded in-flight fetch could still write state.
   - Setters outside the `isCurrentRequest` guard (e.g. `setHasMoreOnChainHistory`, `updateAddressesInfo`, `updateAllNetworksState`, the local-cache write after an `await`) — these leaked partial state from the stale identity.
2. `HomeOverviewContainer` tracked a single `isRefreshing` flag across tabs, so a TOKENS `isRefreshing:true` emit could mask the HISTORY `isRefreshing:false` emit on network switch and leave the spinner stuck.
3. `TokenListBlock` fired a bogus `isRefreshing:true` immediately after a successful local-cache load, which the overview interpreted as "still loading".
4. The `composite/Tabs` Container/List did not re-measure the virtualized inner container on remount, so after a sub-tab unmount/remount the new tab could paint with zero height (visible blank area).

## Design Decisions
- **Monotonic request id over dispatch key**: replaced the `account+network` dispatch key with a `fetchRequestIdRef` bumped at `run()` entry *before* any early return AND on identity dep change. This closes the debounce-window and early-return races at the same time, and is cheap to compare.
- **Single try/finally with `isCurrentRequest`-scoped writes**: every shared-state write now lives inside the guard; the `finally` always releases `isManualRefresh` and the header-spinner emit, but the spinner emit is itself restricted to the freshest run so a superseded fetch cannot prematurely dismiss it.
- **Invalidate `lastInitIdentityRef` mid-flight**: when identity goes null between awaits, mark the init owner as null so the awaited local-cache read can't write into a later identity.
- **Per-tab refresh state in `HomeOverviewContainer`**: store `isRefreshing` keyed by sub-tab so HISTORY and TOKENS can't fight over the header spinner.
- **Identity-key memo (refactor commit)**: extracted a single `identityKey` so the init-effect short-circuit and the dep-change counter share one source of truth instead of two hand-aligned dep arrays. Reduces drift risk on future edits.

Alternatives considered:
- Cancelling the in-flight fetch via `AbortController` — rejected: the underlying service call doesn't propagate abort to the backend layer cleanly, so the cheaper "ignore by request id" approach was used instead.
- Resetting `HomeOverviewContainer` refresh state to a single flag on tab-switch — rejected: it would mask, not fix, the underlying cross-tab interference and would regress the legitimate case where both tabs are refreshing concurrently on a fresh mount.

## Changes Detail
- `packages/kit/src/views/Home/pages/TxHistoryContainer.tsx` — request-id-based stale-fetch guard, single try/finally, `lastInitIdentityRef` invalidation, `identityKey` memo refactor, `setHistoryData([])` same-ref short-circuit.
- `packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx` — per-tab `isRefreshing` tracking so HISTORY/TOKENS no longer clobber the header spinner state.
- `packages/kit/src/components/TokenListBlock/TokenListBlock.tsx` — remove the spurious `isRefreshing:true` emit fired right after a local-cache load.
- `packages/components/src/composite/Tabs/{Container,List,context,utils}.tsx` — re-measure virtualized inner-container height on remount; extract `parseCssSize` into `utils`; add deps array to `useImperativeHandle`; replace an unnecessary type assertion with `querySelector<HTMLElement>`.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension / Mobile / Desktop / Web (Home tab + any caller of `composite/Tabs`)
- **Risk Areas**:
  - `TxHistoryContainer` was substantially restructured (+~200 LOC after the request-id rewrite). Regression surface is "history list correctness on network/account switch" and "header spinner lifecycle".
  - `composite/Tabs` Container/List changes affect every consumer of the shared Tabs component, not just Home. Re-measurement on remount could behave differently on platforms with non-default scroll containers.
  - `HomeOverviewContainer` per-tab refresh state changes the contract slightly for tabs that emit `isRefreshing` — verified TOKENS + HISTORY paths; other tabs use the same hook so should be unaffected.

## Test plan
- [ ] Wallet home → switch BTC → ETH repeatedly; verify the History list renders the new network's data (not blank) and the header spinner clears within ~1s.
- [ ] Wallet home → switch ETH → BTC → ETH rapidly within the debounce window; verify no stale empty list and no stuck spinner.
- [ ] Account switch (HW + software) with the History tab focused; verify list refreshes correctly.
- [ ] Switch to History on a fresh mount (cold start, wallet home) — local cache should render immediately, no flicker of `isRefreshing:true` from the token block.
- [ ] Repeatedly tab Tokens ↔ History; the header spinner should reflect only the active tab's loading state.
- [ ] Any other screen using `composite/Tabs` (Discovery / Earn / Market sub-tabs) — verify tab heights are correct after mount/remount, no blank panels.
- [ ] iOS + Android + Web + Extension + Desktop smoke pass on the Home tab.