### PR TITLE
fix: add earn analytics order tracking (OK-54953)

### DIFF
--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityEarnOrders.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityEarnOrders.ts
@@ -1,14 +1,8 @@
 import { backgroundMethod } from '@onekeyhq/shared/src/background/backgroundDecorators';
-import type { EEarnLabels, IStakeTag } from '@onekeyhq/shared/types/staking';
+import type { IEarnOrderTrackingInfo } from '@onekeyhq/shared/types/staking';
 import type { EDecodedTxStatus } from '@onekeyhq/shared/types/tx';
 
 import { SimpleDbEntityBase } from '../base/SimpleDbEntityBase';
-
-export interface IEarnOrderTrackingInfo {
-  stakingLabel?: EEarnLabels;
-  stakingProtocol?: string;
-  stakingTags?: IStakeTag[];
-}
 
 export interface IEarnOrderItem {
   orderId: string;

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityEarnOrders.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityEarnOrders.ts
@@ -1,7 +1,14 @@
 import { backgroundMethod } from '@onekeyhq/shared/src/background/backgroundDecorators';
+import type { EEarnLabels, IStakeTag } from '@onekeyhq/shared/types/staking';
 import type { EDecodedTxStatus } from '@onekeyhq/shared/types/tx';
 
 import { SimpleDbEntityBase } from '../base/SimpleDbEntityBase';
+
+export interface IEarnOrderTrackingInfo {
+  stakingLabel?: EEarnLabels;
+  stakingProtocol?: string;
+  stakingTags?: IStakeTag[];
+}
 
 export interface IEarnOrderItem {
   orderId: string;
@@ -11,6 +18,9 @@ export interface IEarnOrderItem {
   status: EDecodedTxStatus;
   updatedAt: number;
   createdAt: number;
+  stakingLabel?: IEarnOrderTrackingInfo['stakingLabel'];
+  stakingProtocol?: IEarnOrderTrackingInfo['stakingProtocol'];
+  stakingTags?: IEarnOrderTrackingInfo['stakingTags'];
 }
 
 export interface IEarnOrderDBStructure {
@@ -21,7 +31,8 @@ export interface IEarnOrderDBStructure {
 export type IAddEarnOrderParams = Omit<
   IEarnOrderItem,
   'updatedAt' | 'createdAt' | 'previousTxIds'
->;
+> &
+  IEarnOrderTrackingInfo;
 
 export class SimpleDbEntityEarnOrders extends SimpleDbEntityBase<IEarnOrderDBStructure> {
   entityName = 'earnOrders';

--- a/packages/kit-bg/src/services/ServiceStaking.ts
+++ b/packages/kit-bg/src/services/ServiceStaking.ts
@@ -2009,6 +2009,9 @@ class ServiceStaking extends ServiceBase {
           defaultLogger.staking.order.updateOrderStatus({
             txId: tx.txId,
             status: tx.status,
+            stakingLabel: order.stakingLabel,
+            stakingProtocol: order.stakingProtocol,
+            stakingTags: order.stakingTags,
           });
         }
       } catch (_e) {
@@ -2051,10 +2054,16 @@ class ServiceStaking extends ServiceBase {
     newTxId?: string;
     status: EDecodedTxStatus;
   }) {
-    defaultLogger.staking.order.updateOrderStatusByTxId(params);
-    await this.backgroundApi.simpleDb.earnOrders.updateOrderStatusByTxId(
-      params,
-    );
+    const result =
+      await this.backgroundApi.simpleDb.earnOrders.updateOrderStatusByTxId(
+        params,
+      );
+    defaultLogger.staking.order.updateOrderStatusByTxId({
+      ...params,
+      stakingLabel: result.order?.stakingLabel,
+      stakingProtocol: result.order?.stakingProtocol,
+      stakingTags: result.order?.stakingTags,
+    });
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceStaking.ts
+++ b/packages/kit-bg/src/services/ServiceStaking.ts
@@ -1967,7 +1967,12 @@ class ServiceStaking extends ServiceBase {
 
   @backgroundMethod()
   async addEarnOrder(order: IAddEarnOrderParams) {
-    defaultLogger.staking.order.addOrder(order);
+    defaultLogger.staking.order.addOrder({
+      status: order.status,
+      stakingLabel: order.stakingLabel,
+      stakingProtocol: order.stakingProtocol,
+      stakingTags: order.stakingTags,
+    });
     await simpleDb.earnOrders.addOrder(order);
     try {
       await this.updateEarnOrderStatusToServer({
@@ -1976,7 +1981,6 @@ class ServiceStaking extends ServiceBase {
     } catch (_e) {
       // ignore error, continue
       defaultLogger.staking.order.updateOrderStatusError({
-        txId: order.txId,
         status: order.status,
       });
     }
@@ -2007,7 +2011,6 @@ class ServiceStaking extends ServiceBase {
             status: tx.status,
           });
           defaultLogger.staking.order.updateOrderStatus({
-            txId: tx.txId,
             status: tx.status,
             stakingLabel: order.stakingLabel,
             stakingProtocol: order.stakingProtocol,
@@ -2017,7 +2020,6 @@ class ServiceStaking extends ServiceBase {
       } catch (_e) {
         // ignore error, continue loop
         defaultLogger.staking.order.updateOrderStatusError({
-          txId: tx.txId,
           status: tx.status,
         });
       }
@@ -2058,11 +2060,14 @@ class ServiceStaking extends ServiceBase {
       await this.backgroundApi.simpleDb.earnOrders.updateOrderStatusByTxId(
         params,
       );
+    if (!result.success || !result.order) {
+      return;
+    }
     defaultLogger.staking.order.updateOrderStatusByTxId({
-      ...params,
-      stakingLabel: result.order?.stakingLabel,
-      stakingProtocol: result.order?.stakingProtocol,
-      stakingTags: result.order?.stakingTags,
+      status: params.status,
+      stakingLabel: result.order.stakingLabel,
+      stakingProtocol: result.order.stakingProtocol,
+      stakingTags: result.order.stakingTags,
     });
   }
 

--- a/packages/kit/src/views/Borrow/hooks/useUniversalBorrowHooks.ts
+++ b/packages/kit/src/views/Borrow/hooks/useUniversalBorrowHooks.ts
@@ -84,6 +84,12 @@ const buildBorrowTrackingStakingInfo = ({
   });
 };
 
+const getEarnOrderTrackingInfo = (stakingInfo?: IStakingInfo) => ({
+  stakingLabel: stakingInfo?.label,
+  stakingProtocol: stakingInfo?.protocol,
+  stakingTags: stakingInfo?.tags,
+});
+
 type ITxConfirmResult =
   | {
       status: 'success';
@@ -115,11 +121,13 @@ const syncBorrowOrder = async ({
   networkId,
   txId,
   status,
+  stakingInfo,
 }: {
   orderId?: string;
   networkId: string;
   txId?: string;
   status: EDecodedTxStatus;
+  stakingInfo?: IStakingInfo;
 }) => {
   if (!orderId || !txId) {
     return;
@@ -130,6 +138,7 @@ const syncBorrowOrder = async ({
     networkId,
     txId,
     status,
+    ...getEarnOrderTrackingInfo(stakingInfo),
   });
 };
 
@@ -137,11 +146,13 @@ const handleBorrowSuccess = async ({
   data,
   orderId,
   networkId,
+  stakingInfo,
   onSuccess,
 }: {
   data: ISendTxOnSuccessData[];
   orderId?: string;
   networkId: string;
+  stakingInfo?: IStakingInfo;
   onSuccess?: IModalSendParamList['SendConfirm']['onSuccess'];
 }) => {
   const latestTxId =
@@ -153,6 +164,7 @@ const handleBorrowSuccess = async ({
       networkId,
       txId: latestTxId,
       status: data[data.length - 1]?.decodedTx.status,
+      ...getEarnOrderTrackingInfo(stakingInfo),
     });
   }
   onSuccess?.(data);
@@ -223,6 +235,7 @@ export function useUniversalBorrowSupply({
             data,
             orderId: resp.orderId,
             networkId,
+            stakingInfo: stakingInfoWithOrderId,
             onSuccess,
           });
         },
@@ -280,6 +293,7 @@ export function useUniversalBorrowWithdraw({
             data,
             orderId: resp.orderId,
             networkId,
+            stakingInfo: stakingInfoWithOrderId,
             onSuccess,
           });
         },
@@ -335,6 +349,7 @@ export function useUniversalBorrowBorrow({
             data,
             orderId: resp.orderId,
             networkId,
+            stakingInfo: stakingInfoWithOrderId,
             onSuccess,
           });
         },
@@ -392,6 +407,7 @@ export function useUniversalBorrowRepay({
             data,
             orderId: resp.orderId,
             networkId,
+            stakingInfo: stakingInfoWithOrderId,
             onSuccess,
           });
         },
@@ -525,6 +541,7 @@ export function useUniversalBorrowRepayWithCollateral({
             status:
               setupConfirmResult.data[setupConfirmResult.data.length - 1]
                 ?.decodedTx.status ?? EDecodedTxStatus.Pending,
+            stakingInfo: setupTrackingStakingInfo,
           });
 
           setupLutFinalizationResult =
@@ -620,6 +637,7 @@ export function useUniversalBorrowRepayWithCollateral({
           data: repayConfirmResult.data,
           orderId: resp.orderId,
           networkId,
+          stakingInfo: stakingInfoWithOrderId,
           onSuccess,
         });
         return true;
@@ -692,6 +710,7 @@ export function useUniversalBorrowClaim({
             data,
             orderId: resp.orderId,
             networkId,
+            stakingInfo: stakingInfoWithOrderId,
             onSuccess,
           });
         },

--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -85,6 +85,8 @@ function BasicEarnHome({
   const { faqList, isFaqLoading, refetchFAQ } = useFAQListInfo();
   const [isEarnTabFocused, setIsEarnTabFocused] = useState(false);
   const wasFocusedRef = useRef(false);
+  const wasHiddenByModalRef = useRef(false);
+  const shouldLogEnterEarnRef = useRef(false);
   const portfolioData = useEarnPortfolio({ isActive: isEarnTabFocused });
   const { refresh: refreshEarnDataRaw, isLoading: portfolioLoading } =
     portfolioData;
@@ -250,6 +252,8 @@ function BasicEarnHome({
   const isBorrowMode = defaultMode === 'borrow';
   const earnModeSwitchTypeRef = useRef<IEarnModeSwitchType>('default');
   const hasLoggedEarnModeSwitchRef = useRef(false);
+  const defaultModeRef = useRef(defaultMode);
+  defaultModeRef.current = defaultMode;
 
   const earnBorrowScrollPosition = useSharedValue(
     defaultMode === 'borrow' ? 1 : 0,
@@ -273,10 +277,12 @@ function BasicEarnHome({
       ? earnModeSwitchTypeRef.current
       : 'default';
 
-    hasLoggedEarnModeSwitchRef.current = true;
-    if (defaultMode === 'earn') {
+    const shouldLogEnterEarn = shouldLogEnterEarnRef.current;
+    shouldLogEnterEarnRef.current = false;
+    if (shouldLogEnterEarn && defaultMode === 'earn') {
       defaultLogger.staking.page.enterEarn();
     }
+    hasLoggedEarnModeSwitchRef.current = true;
     defaultLogger.staking.page.earnModeSwitch({
       mode: defaultMode,
       switchType,
@@ -314,7 +320,14 @@ function BasicEarnHome({
   const handleListenTabFocusState = useCallback(
     (isFocus: boolean, isHideByModal: boolean) => {
       const actualFocus = isFocus && !isHideByModal;
+      const wasFocused = wasFocusedRef.current;
+      const wasHiddenByModal = wasHiddenByModalRef.current;
+      wasHiddenByModalRef.current = isFocus && isHideByModal;
       wasFocusedRef.current = actualFocus;
+      // Closing a modal restores focus, but is not a fresh Earn entry.
+      if (actualFocus && !wasFocused && !wasHiddenByModal) {
+        shouldLogEnterEarnRef.current = true;
+      }
       setIsEarnTabFocused(actualFocus);
       if (!actualFocus) return;
 
@@ -343,9 +356,6 @@ function BasicEarnHome({
   );
 
   useListenTabFocusState(earnFocusTabRoutes, handleListenTabFocusState);
-
-  const defaultModeRef = useRef(defaultMode);
-  defaultModeRef.current = defaultMode;
 
   const handleHeaderHorizontalSwipe = useCallback(
     (direction: 'left' | 'right') => {

--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -274,6 +274,9 @@ function BasicEarnHome({
       : 'default';
 
     hasLoggedEarnModeSwitchRef.current = true;
+    if (defaultMode === 'earn') {
+      defaultLogger.staking.page.enterEarn();
+    }
     defaultLogger.staking.page.earnModeSwitch({
       mode: defaultMode,
       switchType,

--- a/packages/kit/src/views/Staking/hooks/useUniversalHooks.ts
+++ b/packages/kit/src/views/Staking/hooks/useUniversalHooks.ts
@@ -39,6 +39,12 @@ const createStakeInfoWithOrderId = ({
   orderId,
 });
 
+const getEarnOrderTrackingInfo = (stakingInfo?: IStakingInfo) => ({
+  stakingLabel: stakingInfo?.label,
+  stakingProtocol: stakingInfo?.protocol,
+  stakingTags: stakingInfo?.tags,
+});
+
 type ITxConfirmResult =
   | {
       status: 'success';
@@ -115,6 +121,7 @@ const handleStakeSuccess = async ({
       networkId,
       txId: data[0].signedTx.txid,
       status: data[0].decodedTx.status,
+      ...getEarnOrderTrackingInfo(stakeInfo),
     });
   }
   onSuccess?.(data);

--- a/packages/shared/src/logger/scopes/staking/scenes/order.ts
+++ b/packages/shared/src/logger/scopes/staking/scenes/order.ts
@@ -2,19 +2,30 @@ import type { IAddEarnOrderParams } from '@onekeyhq/kit-bg/src/dbs/simple/entity
 import type { EDecodedTxStatus } from '@onekeyhq/shared/types/tx';
 
 import { BaseScene } from '../../../base/baseScene';
-import { LogToLocal } from '../../../base/decorators';
+import { LogToLocal, LogToServer } from '../../../base/decorators';
 
 export class OrderScene extends BaseScene {
+  @LogToServer()
   @LogToLocal()
   public addOrder(order: IAddEarnOrderParams) {
     return order;
   }
 
+  @LogToServer()
   @LogToLocal()
-  public updateOrderStatus(params: { txId: string; status: EDecodedTxStatus }) {
+  public updateOrderStatus(
+    params: Pick<
+      IAddEarnOrderParams,
+      'stakingLabel' | 'stakingProtocol' | 'stakingTags'
+    > & {
+      txId: string;
+      status: EDecodedTxStatus;
+    },
+  ) {
     return params;
   }
 
+  @LogToServer()
   @LogToLocal()
   public updateOrderStatusError(params: {
     txId: string;
@@ -23,12 +34,18 @@ export class OrderScene extends BaseScene {
     return params;
   }
 
+  @LogToServer()
   @LogToLocal()
-  public updateOrderStatusByTxId(params: {
-    currentTxId: string;
-    newTxId?: string;
-    status: EDecodedTxStatus;
-  }) {
+  public updateOrderStatusByTxId(
+    params: Pick<
+      IAddEarnOrderParams,
+      'stakingLabel' | 'stakingProtocol' | 'stakingTags'
+    > & {
+      currentTxId: string;
+      newTxId?: string;
+      status: EDecodedTxStatus;
+    },
+  ) {
     return params;
   }
 }

--- a/packages/shared/src/logger/scopes/staking/scenes/order.ts
+++ b/packages/shared/src/logger/scopes/staking/scenes/order.ts
@@ -1,51 +1,35 @@
-import type { IAddEarnOrderParams } from '@onekeyhq/kit-bg/src/dbs/simple/entity/SimpleDbEntityEarnOrders';
+import type { IEarnOrderTrackingInfo } from '@onekeyhq/shared/types/staking';
 import type { EDecodedTxStatus } from '@onekeyhq/shared/types/tx';
 
 import { BaseScene } from '../../../base/baseScene';
 import { LogToLocal, LogToServer } from '../../../base/decorators';
 
+type IEarnOrderServerLogParams = IEarnOrderTrackingInfo & {
+  status: EDecodedTxStatus;
+};
+
 export class OrderScene extends BaseScene {
   @LogToServer()
   @LogToLocal()
-  public addOrder(order: IAddEarnOrderParams) {
-    return order;
-  }
-
-  @LogToServer()
-  @LogToLocal()
-  public updateOrderStatus(
-    params: Pick<
-      IAddEarnOrderParams,
-      'stakingLabel' | 'stakingProtocol' | 'stakingTags'
-    > & {
-      txId: string;
-      status: EDecodedTxStatus;
-    },
-  ) {
+  public addOrder(params: IEarnOrderServerLogParams) {
     return params;
   }
 
   @LogToServer()
   @LogToLocal()
-  public updateOrderStatusError(params: {
-    txId: string;
-    status: EDecodedTxStatus;
-  }) {
+  public updateOrderStatus(params: IEarnOrderServerLogParams) {
     return params;
   }
 
   @LogToServer()
   @LogToLocal()
-  public updateOrderStatusByTxId(
-    params: Pick<
-      IAddEarnOrderParams,
-      'stakingLabel' | 'stakingProtocol' | 'stakingTags'
-    > & {
-      currentTxId: string;
-      newTxId?: string;
-      status: EDecodedTxStatus;
-    },
-  ) {
+  public updateOrderStatusError(params: { status: EDecodedTxStatus }) {
+    return params;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  public updateOrderStatusByTxId(params: IEarnOrderServerLogParams) {
     return params;
   }
 }

--- a/packages/shared/types/staking.ts
+++ b/packages/shared/types/staking.ts
@@ -78,6 +78,12 @@ export enum EEarnLabels {
   Buy = 'Buy',
 }
 
+export interface IEarnOrderTrackingInfo {
+  stakingLabel?: EEarnLabels;
+  stakingProtocol?: string;
+  stakingTags?: IStakeTag[];
+}
+
 export type IStakingInfo = {
   protocol: string;
   protocolLogoURI?: string;


### PR DESCRIPTION
## Summary
- Send Earn order add/status logger events to server analytics.
- Attach non-address staking metadata (`stakingLabel`, `stakingProtocol`, `stakingTags`) to Earn order records for Stake/Borrow/Supply/Repay/Withdraw lifecycle analysis.
- Fire `enterEarn` when the Earn mode is actually focused, covering the previously unbound page-entry event.

## Intent & Context
OK-54953 / Earn 订单生命周期埋点补齐。Earn has multi-protocol, multi-asset, and multi-operation order flows; server analytics need the order lifecycle events to trace an Earn operation from signed order creation through pending/success/failure.

## Changes Detail
- Add optional staking tracking metadata to local Earn order records.
- Decorate Earn order logger methods with `LogToServer` while preserving local logs.
- Carry protocol/label/tags from staking and borrow success paths into `addEarnOrder`.
- Include stored staking metadata when updating order status by txId.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile / Desktop / Web / Extension
- **Risk Areas**: Analytics payload shape and order lifecycle logging only; transaction build/sign/send behavior is unchanged.

## Test plan
- [x] `git diff --check origin/release/v6.3.0...HEAD`
- [x] `yarn jest --runTestsByPath packages/kit/src/views/Borrow/hooks/useUniversalBorrowHooks.test.tsx --runInBand`
- [ ] Runtime: perform an Earn operation in test environment and verify `$analytics.trackEvent` plus `/utility/v1/track/event` payload includes `orderId`, `txId`, `stakingLabel`, `stakingProtocol`, and `stakingTags`.

## Notes
- This branch intentionally contains only `fix: add earn analytics order tracking` and excludes the iPad/split-view changes from the earlier grouped PR.