### PR TITLE
refactor(tray): remove renderer-side pending-tx recheck self-loop(OK-54981)

### DIFF
--- a/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
+++ b/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
@@ -80,11 +80,6 @@ import {
 
 const TRAY_ROUTE_HOME = '/main/tab-home';
 const TRAY_ROUTE_MARKET = '/main/tab-market';
-// Pending-tx tail recheck. Fires only when pending txs still exist after a
-// gather, regardless of panel visibility. Kept long because panel-open
-// updates are already covered by the main-process 30s poll, and panel-closed
-// data isn't visible to the user — so server-side cost dominates freshness.
-const TRAY_PENDING_TX_RECHECK_INTERVAL_MS = 120_000;
 
 async function refreshTrayPendingTxStatuses(
   txs: IAccountHistoryTx[],
@@ -472,15 +467,8 @@ export function useTrayDataProvider() {
   // Renderer-side inflight guard for non-poll paths (account change, refresh).
   const inFlightRef = useRef(false);
   const trailingRefreshRef = useRef(false);
-  const hasPendingTxRef = useRef(false);
   // Cached resolved watchlist for the account-switch optimistic placeholder (OK-54088).
   const lastWatchlistRef = useRef<ITrayWatchlistItem[]>([]);
-  const pendingRecheckTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
-  const isTrayActiveRef = useRef(isTrayActive);
-  isTrayActiveRef.current = isTrayActive;
-
   const handleTrayDataRequestInner = useCallback(async () => {
     // Tray window can't reach backgroundApiProxy (DESKTOP_API_CALL is gated
     // to the main window), so we push locale inline with every payload.
@@ -881,7 +869,6 @@ export function useTrayDataProvider() {
         return;
       }
 
-      hasPendingTxRef.current = (trayData.pendingTxs?.length ?? 0) > 0;
       globalThis.desktopApi?.sendTrayData(trayData);
     } catch {
       // Prefer locked placeholder over error if user locked during the
@@ -914,25 +901,6 @@ export function useTrayDataProvider() {
     }
   }, []);
 
-  const clearPendingRecheck = useCallback(() => {
-    if (pendingRecheckTimerRef.current) {
-      clearTimeout(pendingRecheckTimerRef.current);
-      pendingRecheckTimerRef.current = null;
-    }
-  }, []);
-
-  // Resets on every refresh so external events near a tick don't cause back-to-back gathers.
-  const schedulePendingRecheck = useCallback(() => {
-    if (!isTrayActiveRef.current) return;
-    if (pendingRecheckTimerRef.current) {
-      clearTimeout(pendingRecheckTimerRef.current);
-    }
-    pendingRecheckTimerRef.current = setTimeout(() => {
-      pendingRecheckTimerRef.current = null;
-      void handleTrayDataRequestRef.current?.();
-    }, TRAY_PENDING_TX_RECHECK_INTERVAL_MS);
-  }, []);
-
   const handleTrayDataRequest = useCallback(async () => {
     if (inFlightRef.current) {
       trailingRefreshRef.current = true;
@@ -943,21 +911,16 @@ export function useTrayDataProvider() {
       await handleTrayDataRequestInner();
     } finally {
       inFlightRef.current = false;
-      const willTrailingRefresh = trailingRefreshRef.current;
-      if (willTrailingRefresh) {
+      if (trailingRefreshRef.current) {
         trailingRefreshRef.current = false;
         // Microtask so the call stack unwinds and main-process
         // `guardedRequest` can release on TRAY_DATA_RESPONSE first.
         queueMicrotask(() => {
           void handleTrayDataRequestRef.current?.();
         });
-      } else if (hasPendingTxRef.current) {
-        schedulePendingRecheck();
-      } else {
-        clearPendingRecheck();
       }
     }
-  }, [handleTrayDataRequestInner, schedulePendingRecheck, clearPendingRecheck]);
+  }, [handleTrayDataRequestInner]);
 
   const handleOpenTransactionDetail = useCallback(
     async (action: ITrayAction) => {
@@ -1236,14 +1199,4 @@ export function useTrayDataProvider() {
       );
     };
   }, [isTrayActive]);
-
-  useEffect(() => {
-    if (!isTrayActive) {
-      clearPendingRecheck();
-      hasPendingTxRef.current = false;
-    }
-    return () => {
-      clearPendingRecheck();
-    };
-  }, [isTrayActive, clearPendingRecheck]);
 }


### PR DESCRIPTION
## Summary
- Removes the renderer-side `schedulePendingRecheck` self-loop from `useTrayDataProvider.desktop.ts`.
- Net deletion: 1 file changed, +2/-49 (drops ~47 lines of state + scheduling code).
- Tray pending-tx state is now refreshed exclusively by (a) main-process 30s poll while the panel is visible, and (b) event-bus driven refresh (`HistoryTxStatusChanged`, `LocalPendingTxConfirmed`, etc., 1.5s debounce) — both panel-open and panel-closed.

## Intent & Context
Follow-up to #11698 (which throttled the same loop from 12s to 120s as a pre-release hot-fix). After that PR shipped we re-audited the menu-bar tray refresh pipeline and concluded the renderer self-loop should be removed entirely, not just throttled:

1. **It triggered the full `handleTrayDataRequestInner` every tick**, not just a pending-status check. Each tick re-ran `getMarketWatchListV2`, `fetchMarketTokenListBatch`, `fetchMarketPerpsTokenList`, `getTokenSearchAliases`, and one `fetchAccountHistory` per pending `(accountId, networkId)`. With multiple pending chains this fanned out aggressively against backend services even while the panel was closed.
2. **The tray icon has no badge / dynamic title / image swap** (`TrayManager.ts:121` only sets a static tooltip). Data refreshed while the panel is closed is never observable to the user.
3. **Panel-open freshness is already covered by the main-process 30s poll** (`TrayManager.ts:67`), which is gated by `onTrayWindowVisibilityChange` and runs the same `handleTrayDataRequestInner`. The 120s renderer self-loop was effectively a no-op while the panel was open because every 30s the main process triggered a gather that reset the renderer's timer before it could fire.

The renderer self-loop was dead-or-redundant in both states. Removing it yields the same data freshness with strictly less code and strictly fewer backend requests while the panel is closed.

## Design Decisions

Considered three approaches, picked the simplest:

1. **Add `TRAY_VISIBILITY` IPC** so the renderer can clear its timer when the panel hides. Rejected — adds IPC surface, preload allowlist entry, renderer subscription. The simpler removal achieves the same effect.
2. **Throttle further** (e.g. 120s → 600s). Rejected — still has the architectural confusion of two independent scheduling sources, and panel-closed cost is still non-zero even though no user can see the data.
3. **Net deletion of the renderer self-loop.** Chosen. The main-process poll is panel-gated; the event bus is event-driven. Together they cover all cases without any renderer-side periodic timer.

Confirmed with the user that the tray icon will not gain a pending-count badge or dynamic title in the foreseeable product roadmap. If that ever changes, a dedicated lightweight `recheckPendingOnly` path should be added then (separate from the full `handleTrayDataRequestInner`), rather than re-introducing this loop.

## Changes Detail

Single file: `packages/kit/src/hooks/useTrayDataProvider.desktop.ts`

Removed:
- `TRAY_PENDING_TX_RECHECK_INTERVAL_MS` constant + its comment (5 lines)
- `hasPendingTxRef`, `pendingRecheckTimerRef`, and `isTrayActiveRef` (all only consumed by the deleted scheduler)
- `hasPendingTxRef.current = (trayData.pendingTxs?.length ?? 0) > 0` assignment inside `handleTrayDataRequestInner`
- `clearPendingRecheck` and `schedulePendingRecheck` `useCallback`s
- The `else if (hasPendingTxRef.current) { schedulePendingRecheck(); } else { clearPendingRecheck(); }` branch in `handleTrayDataRequest`'s `finally` block — trailing-refresh logic (the serialization guard for back-to-back triggers) is preserved
- The `useEffect` that cleared the recheck timer on `!isTrayActive` and on unmount

Preserved (all other refresh paths):
- Main-process 30s poll via `TRAY_IPC.DATA_REQUEST` listener (panel-visible only)
- Account switch (immediate + 300ms debounced)
- `appIsLocked` toggle
- Locale change
- Event bus: `TRAY_DATA_REFRESH_EVENT_NAMES` + `ClearLocalHistoryPendingTxs` (1.5s debounce)
- `handleTrayDataRequest`'s `inFlightRef` / `trailingRefreshRef` serialization

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop (macOS only — `platformEnv.isDesktopMac` gates `isTrayActive`)
- **Risk Areas**:
  - **Panel-open pending-tx detection latency**: previously a 30s + 12s/120s mix (effective ~30s due to main-process poll dominance), now strictly 30s worst-case from the main-process poll, plus immediate updates on event-bus pushes (`LocalPendingTxConfirmed` typically arrives within 1.5s of the home-page poll confirming a tx). User-visible change should be imperceptible.
  - **Panel-closed pending-tx detection**: now relies exclusively on event-bus pushes. If the main window is also idle and no other module emits, the cached `pendingTxs` may be stale by the time the panel reopens — but `TRAY_READY` + `onTrayWindowVisibilityChange → startPolling` both trigger an immediate gather on open, so the user sees fresh data within ~1s of opening.
  - **No API contracts changed, no IPC surface changed, no security boundary touched.**
  - Existing `trayDataProviderUtils.test.ts` unit tests still pass (16/16).

## Test plan
- [ ] macOS: with menu-bar tray enabled and a pending tx, leave panel closed for 5+ minutes, confirm tx externally, reopen panel — verify pending row clears within ~1s of opening (immediate gather on visibility change).
- [ ] macOS: with panel open and a pending tx, verify pending row clears within ~30s of on-chain confirmation (main-process 30s poll).
- [ ] macOS: with panel open and a pending tx, trigger a `LocalPendingTxConfirmed` from elsewhere (e.g. confirm via main-window home-page polling) — verify tray cache updates within ~1.5s (event bus debounce).
- [ ] macOS: account switch, lock/unlock, locale change all still trigger an immediate tray refresh.
- [ ] macOS: rapid event-bus bursts don't cause back-to-back gathers (serialized by `inFlightRef` / `trailingRefreshRef`).
- [ ] macOS: toggle menu-bar tray setting off/on multiple times — no timer leaks (verified by absence of dangling `setTimeout` references after removal).