### PR TITLE
fix(discovery): use unified browser search bar placeholder (OK-54653)

### DIFF
--- a/packages/kit/src/views/Discovery/components/CustomHeaderTitle/index.tsx
+++ b/packages/kit/src/views/Discovery/components/CustomHeaderTitle/index.tsx
@@ -4,7 +4,6 @@ import { useIntl } from 'react-intl';
 
 import { Icon, Popover, SizableText, XStack } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { useUrlRiskConfig } from '../../hooks/useUrlRiskConfig';
 import { useActiveTabId, useWebTabDataById } from '../../hooks/useWebTabs';
@@ -90,9 +89,7 @@ function CustomHeaderTitle({ handleSearchBarPress }: ICustomHeaderTitleProps) {
         {displayUrl
           ? hiddenHttpsUrl
           : intl.formatMessage({
-              id: platformEnv.isWebDappMode
-                ? ETranslations.global_search
-                : ETranslations.global_search_everything,
+              id: ETranslations.browser_search_dapp_or_enter_url,
             })}
       </SizableText>
     </XStack>


### PR DESCRIPTION
## Summary
- Replace the conditional browser search bar placeholder (`global_search` / `global_search_everything`) with the unified `browser_search_dapp_or_enter_url` text.
- Remove the now-unused `platformEnv.isWebDappMode` branch and `platformEnv` import in `CustomHeaderTitle`.

## Intent & Context
The browser search bar previously showed a generic placeholder — either "Search" (web dApp mode) or "Search everything" — which did not clearly communicate what the field accepts. This change uses a dedicated, browser-specific placeholder ("Search dApp or enter URL") so the input affordance is consistent and self-explanatory across all platforms.

## Design Decisions
- Use a single translation key (`browser.search_dapp_or_enter_url`) instead of branching on `platformEnv.isWebDappMode`. The web dApp vs. native distinction no longer changes the intended placeholder, so the conditional was dropped along with its `platformEnv` import.

## Changes Detail
- `packages/kit/src/views/Discovery/components/CustomHeaderTitle/index.tsx`: switch the placeholder `formatMessage` id to `ETranslations.browser_search_dapp_or_enter_url`; drop the `platformEnv` import.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Display-only text change in the Discovery browser header; no behavioral impact.

## Test plan
- [ ] Open the Discovery / browser tab and confirm the search bar placeholder reads "Search dApp or enter URL".
- [ ] Verify the placeholder is consistent in web dApp mode and native app builds.