### PR TITLE
fix(discovery): preserve browser store during active mirrors (OK-54651)

### DIFF
--- a/packages/kit/src/states/jotai/utils/useJotaiContextRootStore.tsx
+++ b/packages/kit/src/states/jotai/utils/useJotaiContextRootStore.tsx
@@ -1,8 +1,15 @@
 import { useEffect, useRef } from 'react';
 
+import {
+  EJotaiContextStoreNames,
+  getJotaiContextTrackerMap,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { IJotaiContextStoreData } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 
-import { jotaiContextStore } from './jotaiContextStore';
+import {
+  buildJotaiContextStoreId,
+  jotaiContextStore,
+} from './jotaiContextStore';
 
 export function useJotaiContextRootStore(data: IJotaiContextStoreData) {
   const store = jotaiContextStore.getOrCreateStore(data);
@@ -13,7 +20,15 @@ export function useJotaiContextRootStore(data: IJotaiContextStoreData) {
     // console.log('JotaiContextRootStore mount', dataRef.current);
     return () => {
       // console.log('JotaiContextRootStore unmount', dataRef.current);
-      jotaiContextStore.removeStore(dataRef.current);
+      const currentData = dataRef.current;
+      if (currentData.storeName === EJotaiContextStoreNames.discoveryBrowser) {
+        const storeId = buildJotaiContextStoreId(currentData);
+        const mirrorCount = getJotaiContextTrackerMap()[storeId]?.count ?? 0;
+        if (mirrorCount > 0) {
+          return;
+        }
+      }
+      jotaiContextStore.removeStore(currentData);
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- Backport of #11702 to `release/v6.3.0` hotfix.
- Preserve the discovery browser jotai store while mirror trackers are still active, so MobileTabListModal does not lose its tab list when the root store unmounts.

## Root Cause
On mobile, opening the browser tab list modal sometimes showed `0` tabs / empty list because the discovery browser jotai store was being removed by `useJotaiContextRootStore`'s unmount cleanup, even when a mirror (e.g. `MobileTabListModal`) was still mounted and reading from it.

## Fix
In the unmount cleanup of `useJotaiContextRootStore`:
- For `discoveryBrowser` stores, check the mirror tracker count.
- If `mirrorCount > 0`, skip `removeStore` so active mirrors keep their store reference.
- Otherwise, fall through to the original `removeStore(currentData)` behavior.

This mirrors the final fix that landed in PR #11702 on the `x` branch.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile (primarily)
- **Risk Areas**: Behavior change is gated to `EJotaiContextStoreNames.discoveryBrowser` and only triggers when there are active mirrors; default path is unchanged.

## Test plan
- [ ] Open the browser, create tabs, open the mobile tab list — count matches actual tab count.
- [ ] Open a tab via bookmark, then open the tab list — tabs render correctly.
- [ ] With no persisted tabs, the modal opens cleanly with no errors.
- [ ] Regression: closing/reopening browser context no longer leaks discovery stores in the long run (mirror count returns to 0).

Refs: #11702