### PR TITLE
fix: disable pool detail dialog drag for long token lists (OK-55021)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/TokenLiquidityPools.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/TokenLiquidityPools.tsx
@@ -98,6 +98,7 @@ const ADDRESS_ACTION_ICON_SIZE = '$4';
 const DESKTOP_CONTENT_MIN_WIDTH = 960;
 const MIN_DISPLAY_PERCENTAGE_TEXT = '< 0.01%';
 const TOKEN_AMOUNT_COMPACT_THRESHOLD = 1000;
+const POOL_DETAIL_DIALOG_DISABLE_DRAG_TOKEN_THRESHOLD = 2;
 const POOL_DETAIL_TOKEN_LIST_SCROLL_THRESHOLD = 6;
 const POOL_DETAIL_TOKEN_LIST_MAX_HEIGHT = '$64';
 const POOL_DETAIL_PAIR_NAME_COMPACT_THRESHOLD = 10;
@@ -806,6 +807,8 @@ function TokenAmountLines({ tokens }: { tokens: IDisplayPoolToken[] }) {
       title: labels.tokenAmount,
       renderContent: <TokenAmountListDialogContent tokens={tokens} />,
       showFooter: false,
+      disableDrag:
+        tokens.length > POOL_DETAIL_DIALOG_DISABLE_DRAG_TOKEN_THRESHOLD,
     });
   }, [labels.tokenAmount, tokens]);
 
@@ -1185,6 +1188,9 @@ function MobilePoolRow({ item }: { item: IDisplayPool }) {
       title: intl.formatMessage({ id: ETranslations.dexmarket_pool_details }),
       renderContent: <PoolDetailsContent item={item} />,
       showFooter: false,
+      disableDrag:
+        item.tokenAmounts.length >
+        POOL_DETAIL_DIALOG_DISABLE_DRAG_TOKEN_THRESHOLD,
     });
   }, [intl, item]);
 


### PR DESCRIPTION
## Summary
- Hotfix cherry-pick of #11722 onto `release/v6.3.0` for bundle hot update.
- Adds `disableDrag` to the "Token Amount" and "Pool Details" dialogs in the Market Detail liquidity pools view when the pool token list exceeds 2 tokens.

## Intent & Context
Ship the OK-55021 fix to the v6.3.0 bundle hot-update channel so users on the released app version stop hitting the gesture conflict on long token lists.

On mobile, these dialogs render a vertical token list inside a draggable dialog. When the list is long enough to scroll, the dialog's drag-to-dismiss gesture competes with the inner list scroll gesture — the vertical drag gets intercepted by the dialog, making the token list hard to scroll. This change prevents that gesture conflict for multi-token pools.

## Root Cause
The dialog drag gesture and the inner scrollable token list both consume vertical pan gestures. For pools with more than 2 tokens the list is long enough that users need to scroll it, but the dialog drag handler intercepts the gesture first.

## Design Decisions
- Gate `disableDrag` behind a token-count threshold instead of always disabling it: short lists (1-2 tokens) don't scroll, so keeping drag-to-dismiss there preserves the convenient gesture.
- Threshold extracted as a named constant (`POOL_DETAIL_DIALOG_DISABLE_DRAG_TOKEN_THRESHOLD`) alongside the existing pool-detail layout thresholds for consistency.
- Applied to both dialog entry points that share the same token-list content: `TokenAmountLines` ("Token Amount") and `MobilePoolRow` ("Pool Details").
- Clean cherry-pick from `x` (commit 658ff572b5) onto `release/v6.3.0` — no conflicts, no behavioral divergence from the original merge.

## Changes Detail
- `packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/TokenLiquidityPools.tsx`
  - Add `POOL_DETAIL_DIALOG_DISABLE_DRAG_TOKEN_THRESHOLD = 2` constant.
  - `TokenAmountLines.handleShowAllTokenAmounts`: set `disableDrag` when `tokens.length > threshold`.
  - `MobilePoolRow.handlePress`: set `disableDrag` when `item.tokenAmounts.length > threshold`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile (bundle hot update)
- **Risk Areas**: Only changes the `disableDrag` prop of two dialogs; no data or layout logic touched. Worst case is a dialog that can/can't be dragged to dismiss. Already validated on `x` via #11722.

## Test plan
- [ ] Open a liquidity pool with more than 2 tokens; open both the "Token Amount" and "Pool Details" dialogs and confirm the token list scrolls smoothly and the dialog cannot be drag-dismissed.
- [ ] Open a pool with 1-2 tokens and confirm those dialogs can still be dragged to dismiss.
- [ ] Verify the hotfix bundle picks up the change on a device running v6.3.0.