### PR TITLE
feat(analytics): add hardware wallet vendor attribution

### DIFF
--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/hooks/useAddHiddenWallet.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/hooks/useAddHiddenWallet.tsx
@@ -218,13 +218,15 @@ export function useAddHiddenWallet() {
   );
 
   const createQrHiddenWallet = useCallback(
-    async ({ wallet: _wallet }: { wallet?: IDBWallet }) => {
+    async ({ wallet }: { wallet?: IDBWallet }) => {
+      const vendor = wallet?.associatedDeviceInfo?.vendor;
       try {
         defaultLogger.account.wallet.addWalletStarted({
           addMethod: 'ConnectHWWallet',
           details: {
             hardwareWalletType: 'Hidden',
             communication: 'QRCode',
+            vendor,
           },
           isSoftwareWalletOnlyUser: false,
         });
@@ -244,6 +246,7 @@ export function useAddHiddenWallet() {
             hardwareWalletType: 'Hidden',
             communication: 'QRCode',
             deviceType: EDeviceType.Pro,
+            vendor,
           },
           isSoftwareWalletOnlyUser: false,
         });
@@ -256,6 +259,7 @@ export function useAddHiddenWallet() {
             hardwareWalletType: 'Hidden',
             communication: 'QRCode',
             deviceType: EDeviceType.Pro,
+            vendor,
           },
           isSoftwareWalletOnlyUser: false,
         });

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/AccountSelectorWalletListSideBar.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/AccountSelectorWalletListSideBar.tsx
@@ -45,6 +45,7 @@ import { AccountSelectorCreateWalletButton } from './AccountSelectorCreateWallet
 import { WalletListItem } from './WalletListItem';
 import {
   buildGroupedAccountSelectorWallets,
+  computeHwVendorProfile,
   getWalletChildrenLength,
 } from './walletListUtils';
 
@@ -229,11 +230,15 @@ export function AccountSelectorWalletListSideBar({
         (wallet) => wallet.isKeyless,
       ).length;
       const appWalletCount = walletCount - hwWalletCount;
+      const { hwVendors, primaryHwVendor } = computeHwVendorProfile(wallets);
+
       analytics.updateUserProfile({
         walletCount,
         hwWalletCount,
         appWalletCount,
         keylessWalletCount,
+        hwVendors,
+        primaryHwVendor,
       });
     }
   }, [wallets]);

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/walletListUtils.test.ts
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/walletListUtils.test.ts
@@ -1,8 +1,10 @@
 import type { IDBWallet } from '@onekeyhq/kit-bg/src/dbs/local/types';
 import { BOT_WALLET_STATUS_DEACTIVATED } from '@onekeyhq/shared/src/consts/dbConsts';
+import { EHardwareVendor } from '@onekeyhq/shared/types/device';
 
 import {
   buildGroupedAccountSelectorWallets,
+  computeHwVendorProfile,
   getWalletChildrenLength,
 } from './walletListUtils';
 
@@ -141,5 +143,108 @@ describe('walletListUtils', () => {
         ],
       }),
     ).toBe(3);
+  });
+});
+
+function createHwWallet({
+  id,
+  vendor,
+}: {
+  id: string;
+  vendor?: EHardwareVendor;
+}): IDBWallet {
+  return {
+    id,
+    name: id,
+    type: 'hw',
+    backuped: true,
+    accounts: [],
+    nextIds: {},
+    walletNo: 1,
+    associatedDeviceInfo: vendor ? ({ vendor } as any) : undefined,
+  } as IDBWallet;
+}
+
+describe('computeHwVendorProfile', () => {
+  it('returns empty profile when there are no hardware wallets', () => {
+    expect(
+      computeHwVendorProfile([
+        { id: 'hd-1', name: 'HD', type: 'hd' } as IDBWallet,
+      ]),
+    ).toEqual({ hwVendors: [], primaryHwVendor: undefined });
+  });
+
+  it('ignores non-hw wallets when aggregating vendors', () => {
+    // hd + keyless + imported wallets must not appear in vendor stats
+    const result = computeHwVendorProfile([
+      { id: 'hd-1', type: 'hd' } as IDBWallet,
+      { id: 'imported-1', type: 'imported' } as IDBWallet,
+      createHwWallet({ id: 'hw-1', vendor: EHardwareVendor.onekey }),
+    ]);
+    expect(result).toEqual({
+      hwVendors: ['onekey'],
+      primaryHwVendor: 'onekey',
+    });
+  });
+
+  it('falls back to onekey for hw wallets with no vendor on device record', () => {
+    // Legacy hw wallets created before vendor was persisted should still be
+    // counted as OneKey, otherwise existing OneKey users would show up as
+    // having zero hw vendors on a fresh app launch.
+    expect(
+      computeHwVendorProfile([createHwWallet({ id: 'hw-legacy' })]),
+    ).toEqual({
+      hwVendors: ['onekey'],
+      primaryHwVendor: 'onekey',
+    });
+  });
+
+  it('reports ledger when a single Ledger wallet is present', () => {
+    expect(
+      computeHwVendorProfile([
+        createHwWallet({ id: 'hw-ledger', vendor: EHardwareVendor.ledger }),
+      ]),
+    ).toEqual({
+      hwVendors: ['ledger'],
+      primaryHwVendor: 'ledger',
+    });
+  });
+
+  it('returns sorted unique vendor list and picks majority as primary', () => {
+    // Two OneKey wallets vs one Ledger — primary should be OneKey.
+    // hwVendors is sorted lexically so consumers get stable ordering.
+    const result = computeHwVendorProfile([
+      createHwWallet({ id: 'hw-1', vendor: EHardwareVendor.onekey }),
+      createHwWallet({ id: 'hw-2', vendor: EHardwareVendor.onekey }),
+      createHwWallet({ id: 'hw-3', vendor: EHardwareVendor.ledger }),
+    ]);
+    expect(result.hwVendors).toEqual(['ledger', 'onekey']);
+    expect(result.primaryHwVendor).toBe('onekey');
+  });
+
+  it('breaks vendor-count ties deterministically by lexical order', () => {
+    // 1 OneKey + 1 Ledger — both have count=1.
+    // The reducer scans sorted vendor keys ['ledger', 'onekey'] and only
+    // replaces the leader on strict-greater, so the first key ('ledger') wins.
+    // Document this so consumers don't depend on a different tiebreak.
+    const result = computeHwVendorProfile([
+      createHwWallet({ id: 'hw-1', vendor: EHardwareVendor.onekey }),
+      createHwWallet({ id: 'hw-2', vendor: EHardwareVendor.ledger }),
+    ]);
+    expect(result.hwVendors).toEqual(['ledger', 'onekey']);
+    expect(result.primaryHwVendor).toBe('ledger');
+  });
+
+  it('handles mixed legacy (no vendor) + Ledger as onekey + ledger', () => {
+    // Realistic 6.3.0 upgrade scenario: existing OneKey user (legacy device
+    // record without vendor field) adds a Ledger wallet. Profile must show
+    // both vendors and pick majority.
+    const result = computeHwVendorProfile([
+      createHwWallet({ id: 'hw-onekey-legacy' }),
+      createHwWallet({ id: 'hw-onekey-legacy-2' }),
+      createHwWallet({ id: 'hw-ledger', vendor: EHardwareVendor.ledger }),
+    ]);
+    expect(result.hwVendors).toEqual(['ledger', 'onekey']);
+    expect(result.primaryHwVendor).toBe('onekey');
   });
 });

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/walletListUtils.ts
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/walletListUtils.ts
@@ -2,8 +2,10 @@ import type { IDBWallet } from '@onekeyhq/kit-bg/src/dbs/local/types';
 import {
   BOT_WALLET_STATUS_ACTIVE,
   BOT_WALLET_STATUS_DEACTIVATED,
+  WALLET_TYPE_HW,
 } from '@onekeyhq/shared/src/consts/dbConsts';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import { EHardwareVendor } from '@onekeyhq/shared/types/device';
 
 import type { IAccountSelectorWalletInfo } from '../../../type';
 
@@ -120,4 +122,34 @@ export function buildGroupedAccountSelectorWallets(
   });
 
   return [...topLevelWallets, ...orphanBotWallets];
+}
+
+// Aggregate hardware-wallet vendor info for analytics user profile.
+// Legacy hw wallets without `associatedDeviceInfo.vendor` are counted as
+// 'onekey' (vendor is a runtime field; older device records may not have it
+// populated until next connect). Returns sorted unique vendor list and the
+// vendor with the most wallets (deterministic tiebreak via lexical sort).
+type IHwVendorProfileWallet = Pick<IDBWallet, 'type' | 'associatedDeviceInfo'>;
+
+export function computeHwVendorProfile(
+  wallets: readonly IHwVendorProfileWallet[],
+): {
+  hwVendors: string[];
+  primaryHwVendor: string | undefined;
+} {
+  const hwWallets = wallets.filter((w) => w.type === WALLET_TYPE_HW);
+  if (hwWallets.length === 0) {
+    return { hwVendors: [], primaryHwVendor: undefined };
+  }
+  const counts = hwWallets.reduce<Record<string, number>>((acc, wallet) => {
+    const vendor =
+      wallet.associatedDeviceInfo?.vendor ?? EHardwareVendor.onekey;
+    acc[vendor] = (acc[vendor] ?? 0) + 1;
+    return acc;
+  }, {});
+  const hwVendors = Object.keys(counts).toSorted();
+  const primaryHwVendor = hwVendors.reduce((leader, v) =>
+    counts[v] > counts[leader] ? v : leader,
+  );
+  return { hwVendors, primaryHwVendor };
 }

--- a/packages/kit/src/views/Onboardingv2/hooks/useDeviceConnect.tsx
+++ b/packages/kit/src/views/Onboardingv2/hooks/useDeviceConnect.tsx
@@ -122,16 +122,8 @@ async function createLedgerHwWallet({
       features: params.features,
       hardwareTransportType,
       isSoftwareWalletOnlyUser,
-      vendor,
     });
   } catch (error) {
-    await trackHardwareWalletConnection({
-      status: 'failure',
-      deviceType: device.deviceType,
-      hardwareTransportType,
-      isSoftwareWalletOnlyUser,
-      vendor,
-    });
     errorToastUtils.toastIfError(error);
     navigation.pop();
     throw error;
@@ -436,17 +428,6 @@ export function useDeviceConnect({
       const deviceVendor = (device as SearchDevice & { vendor?: string })
         ?.vendor;
       if (deviceVendor === EHardwareVendor.ledger) {
-        defaultLogger.account.wallet.addWalletStarted({
-          addMethod: 'ConnectHWWallet',
-          details: {
-            hardwareWalletType: 'Standard',
-            communication: getHardwareCommunicationTypeString(
-              hardwareTransportType,
-            ),
-            vendor: EHardwareVendor.ledger,
-          },
-          isSoftwareWalletOnlyUser,
-        });
         return verifyLedgerDevice(device);
       }
 

--- a/packages/kit/src/views/Onboardingv2/hooks/useDeviceConnect.tsx
+++ b/packages/kit/src/views/Onboardingv2/hooks/useDeviceConnect.tsx
@@ -122,8 +122,16 @@ async function createLedgerHwWallet({
       features: params.features,
       hardwareTransportType,
       isSoftwareWalletOnlyUser,
+      vendor,
     });
   } catch (error) {
+    await trackHardwareWalletConnection({
+      status: 'failure',
+      deviceType: device.deviceType,
+      hardwareTransportType,
+      isSoftwareWalletOnlyUser,
+      vendor,
+    });
     errorToastUtils.toastIfError(error);
     navigation.pop();
     throw error;
@@ -428,6 +436,17 @@ export function useDeviceConnect({
       const deviceVendor = (device as SearchDevice & { vendor?: string })
         ?.vendor;
       if (deviceVendor === EHardwareVendor.ledger) {
+        defaultLogger.account.wallet.addWalletStarted({
+          addMethod: 'ConnectHWWallet',
+          details: {
+            hardwareWalletType: 'Standard',
+            communication: getHardwareCommunicationTypeString(
+              hardwareTransportType,
+            ),
+            vendor: EHardwareVendor.ledger,
+          },
+          isSoftwareWalletOnlyUser,
+        });
         return verifyLedgerDevice(device);
       }
 
@@ -438,6 +457,7 @@ export function useDeviceConnect({
           communication: getHardwareCommunicationTypeString(
             hardwareTransportType,
           ),
+          vendor: EHardwareVendor.onekey,
         },
         isSoftwareWalletOnlyUser,
       });

--- a/packages/kit/src/views/Onboardingv2/pages/ConnectYourDevice.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ConnectYourDevice.tsx
@@ -1271,6 +1271,7 @@ function ConnectYourDevicePage({
               vendor: item.vendor,
             },
             isFirmwareVerified: true,
+            tabValue: innerTabValue,
           });
           return;
         }

--- a/packages/kit/src/views/Onboardingv2/pages/ConnectionFlowLedger.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ConnectionFlowLedger.tsx
@@ -214,9 +214,10 @@ export default function LedgerConnectionFlow() {
           vendor: EHardwareVendor.ledger,
         },
         isFirmwareVerified: true,
+        tabValue,
       });
     },
-    [ensureStopScan, navigation],
+    [ensureStopScan, navigation, tabValue],
   );
 
   // --- Listing mode ---

--- a/packages/kit/src/views/Onboardingv2/pages/FinalizeWalletSetup.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/FinalizeWalletSetup.tsx
@@ -50,6 +50,7 @@ import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { EMnemonicType } from '@onekeyhq/shared/src/utils/secret';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
+import type { EHardwareTransportType } from '@onekeyhq/shared/types';
 import type { IOneKeyDeviceFeatures } from '@onekeyhq/shared/types/device';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
@@ -359,9 +360,23 @@ function FinalizeWalletSetupPage({
           // (`forceTransportType || hardwareTransportType`) so the analytics
           // event reflects the channel actually used for this connection, not
           // the stale persisted setting.
-          const forceTransportType = ledgerTabValue
-            ? await getForceTransportType(ledgerTabValue)
-            : undefined;
+          //
+          // The resolver calls background services (devSetting / setting) over
+          // IPC and can fail. Per-session attribution is an analytics nice-to-
+          // have; it must not block Ledger wallet creation or suppress the
+          // walletAdded failure event. Fall back to the persisted setting on
+          // any error so the create + tracking pipeline runs unconditionally.
+          let forceTransportType: EHardwareTransportType | undefined;
+          if (ledgerTabValue) {
+            try {
+              forceTransportType = await getForceTransportType(ledgerTabValue);
+            } catch (transportResolveError) {
+              console.warn(
+                '[Ledger analytics] getForceTransportType failed; falling back to persisted hardwareTransportType',
+                transportResolveError,
+              );
+            }
+          }
           const resolvedTransportType =
             forceTransportType || hardwareTransportType;
           defaultLogger.account.wallet.addWalletStarted({

--- a/packages/kit/src/views/Onboardingv2/pages/FinalizeWalletSetup.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/FinalizeWalletSetup.tsx
@@ -71,7 +71,11 @@ import {
   useDeviceConnect,
 } from '../hooks/useDeviceConnect';
 import { OnboardingTestIDs } from '../testIDs';
-import { trackHardwareWalletConnection } from '../utils';
+import {
+  getForceTransportType,
+  getHardwareCommunicationTypeString,
+  trackHardwareWalletConnection,
+} from '../utils';
 
 import type { SearchDevice } from '@onekeyfe/hd-core';
 
@@ -151,6 +155,7 @@ function FinalizeWalletSetupPage({
   const mnemonicType = route?.params?.mnemonicType;
   const keylessPackSetId = route?.params?.keylessPackSetId;
   const deviceData = route?.params?.deviceData;
+  const ledgerTabValue = route?.params?.tabValue;
   const isFirmwareVerified = route?.params?.isFirmwareVerified;
   const isWalletBackedUp = route?.params?.isWalletBackedUp;
   const isKeylessWallet = route?.params?.isKeylessWallet;
@@ -349,10 +354,23 @@ function FinalizeWalletSetupPage({
           // verifyHardware/onSelectAddWalletType are bypassed. Mirror the
           // OneKey-side `addWalletStarted` + success/failure tracking here.
           const ledgerDevice = deviceData.device as SearchDevice;
+          // Resolve the per-session transport from the tabValue passed by the
+          // Ledger entry points. Mirrors the OneKey pattern in useDeviceConnect
+          // (`forceTransportType || hardwareTransportType`) so the analytics
+          // event reflects the channel actually used for this connection, not
+          // the stale persisted setting.
+          const forceTransportType = ledgerTabValue
+            ? await getForceTransportType(ledgerTabValue)
+            : undefined;
+          const resolvedTransportType =
+            forceTransportType || hardwareTransportType;
           defaultLogger.account.wallet.addWalletStarted({
             addMethod: 'ConnectHWWallet',
             details: {
               hardwareWalletType: 'Standard',
+              communication: getHardwareCommunicationTypeString(
+                resolvedTransportType,
+              ),
               vendor: deviceData.vendor,
             },
             isSoftwareWalletOnlyUser,
@@ -372,7 +390,7 @@ function FinalizeWalletSetupPage({
             await trackHardwareWalletConnection({
               status: 'success',
               deviceType: ledgerDevice.deviceType,
-              hardwareTransportType,
+              hardwareTransportType: resolvedTransportType,
               isSoftwareWalletOnlyUser,
               vendor: deviceData.vendor,
             });
@@ -380,7 +398,7 @@ function FinalizeWalletSetupPage({
             await trackHardwareWalletConnection({
               status: 'failure',
               deviceType: ledgerDevice.deviceType,
-              hardwareTransportType,
+              hardwareTransportType: resolvedTransportType,
               isSoftwareWalletOnlyUser,
               vendor: deviceData.vendor,
             });
@@ -447,6 +465,7 @@ function FinalizeWalletSetupPage({
     goNextStep,
     hardwareTransportType,
     isSoftwareWalletOnlyUser,
+    ledgerTabValue,
   ]);
 
   useEffect(() => {

--- a/packages/kit/src/views/Onboardingv2/pages/FinalizeWalletSetup.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/FinalizeWalletSetup.tsx
@@ -29,6 +29,7 @@ import type {
   IDBIndexedAccount,
   IDBWallet,
 } from '@onekeyhq/kit-bg/src/dbs/local/types';
+import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { EOAuthSocialLoginProvider } from '@onekeyhq/shared/src/consts/authConsts';
 import type { IAppEventBusPayload } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import {
@@ -55,6 +56,7 @@ import backgroundApiProxy from '../../../background/instance/backgroundApiProxy'
 import { AccountSelectorProviderMirror } from '../../../components/AccountSelector';
 import { getKeylessOnboardingPin } from '../../../components/KeylessWallet/useKeylessWallet';
 import useAppNavigation from '../../../hooks/useAppNavigation';
+import { useUserWalletProfile } from '../../../hooks/useUserWalletProfile';
 import { useKeylessWebFlowAutoConnectDapp } from '../../../hooks/useWebDapp/useKeylessWebFlow';
 import { useAccountSelectorActions } from '../../../states/jotai/contexts/accountSelector';
 import { withPromptPasswordVerify } from '../../../utils/passwordUtils';
@@ -69,6 +71,7 @@ import {
   useDeviceConnect,
 } from '../hooks/useDeviceConnect';
 import { OnboardingTestIDs } from '../testIDs';
+import { trackHardwareWalletConnection } from '../utils';
 
 import type { SearchDevice } from '@onekeyfe/hd-core';
 
@@ -226,6 +229,8 @@ function FinalizeWalletSetupPage({
   );
 
   const actions = useAccountSelectorActions();
+  const [{ hardwareTransportType }] = useSettingsPersistAtom();
+  const { isSoftwareWalletOnlyUser } = useUserWalletProfile();
 
   const { connectDevice, createHWWallet } = useDeviceConnect();
   const createWallet = useCallback(async () => {
@@ -338,17 +343,49 @@ function FinalizeWalletSetupPage({
           // createHWWalletWithoutHidden directly to avoid the
           // onSelectAddWalletType path which would push another
           // FinalizeWalletSetup page on top of this one.
-          await actions.current.createHWWalletWithoutHidden({
-            device: deviceData.device as SearchDevice,
-            hideCheckingDeviceLoading: true,
-            features: {
-              device_id: (deviceData.device as SearchDevice)?.deviceId || '',
+          //
+          // Analytics: this branch is the real Ledger creation site —
+          // the useDeviceConnect tracking calls never reach Ledger because
+          // verifyHardware/onSelectAddWalletType are bypassed. Mirror the
+          // OneKey-side `addWalletStarted` + success/failure tracking here.
+          const ledgerDevice = deviceData.device as SearchDevice;
+          defaultLogger.account.wallet.addWalletStarted({
+            addMethod: 'ConnectHWWallet',
+            details: {
+              hardwareWalletType: 'Standard',
               vendor: deviceData.vendor,
-            } as IOneKeyDeviceFeatures,
-            isFirmwareVerified: true,
-            defaultIsTemp: true,
-            vendor: deviceData.vendor,
+            },
+            isSoftwareWalletOnlyUser,
           });
+          try {
+            await actions.current.createHWWalletWithoutHidden({
+              device: ledgerDevice,
+              hideCheckingDeviceLoading: true,
+              features: {
+                device_id: ledgerDevice?.deviceId || '',
+                vendor: deviceData.vendor,
+              } as IOneKeyDeviceFeatures,
+              isFirmwareVerified: true,
+              defaultIsTemp: true,
+              vendor: deviceData.vendor,
+            });
+            await trackHardwareWalletConnection({
+              status: 'success',
+              deviceType: ledgerDevice.deviceType,
+              hardwareTransportType,
+              isSoftwareWalletOnlyUser,
+              vendor: deviceData.vendor,
+            });
+          } catch (createError) {
+            await trackHardwareWalletConnection({
+              status: 'failure',
+              deviceType: ledgerDevice.deviceType,
+              hardwareTransportType,
+              isSoftwareWalletOnlyUser,
+              vendor: deviceData.vendor,
+            });
+            throw createError;
+          }
         } else {
           goNextStep(EFinalizeWalletSetupSteps.ConnectingDevice);
           await connectDevice(deviceData.device as SearchDevice);
@@ -408,6 +445,8 @@ function FinalizeWalletSetupPage({
     createHWWallet,
     setPendingKeylessAutoConnectWalletId,
     goNextStep,
+    hardwareTransportType,
+    isSoftwareWalletOnlyUser,
   ]);
 
   useEffect(() => {

--- a/packages/kit/src/views/Onboardingv2/utils.tsx
+++ b/packages/kit/src/views/Onboardingv2/utils.tsx
@@ -6,6 +6,7 @@ import deviceUtils from '@onekeyhq/shared/src/utils/deviceUtils';
 import { EHardwareTransportType } from '@onekeyhq/shared/types';
 import { EConnectDeviceChannel } from '@onekeyhq/shared/types/connectDevice';
 import type { IConnectYourDeviceItem } from '@onekeyhq/shared/types/device';
+import { EHardwareVendor } from '@onekeyhq/shared/types/device';
 
 import backgroundApiProxy from '../../background/instance/backgroundApiProxy';
 
@@ -132,12 +133,14 @@ export const trackHardwareWalletConnection = async ({
   isSoftwareWalletOnlyUser,
   features,
   hardwareTransportType,
+  vendor = EHardwareVendor.onekey,
 }: {
   status: 'success' | 'failure';
   deviceType: IDeviceType;
   isSoftwareWalletOnlyUser: boolean;
   features?: Features;
   hardwareTransportType: EHardwareTransportType | undefined | 'QRCode';
+  vendor?: EHardwareVendor;
 }) => {
   const connectionType: IHardwareCommunicationType =
     getHardwareCommunicationTypeString(hardwareTransportType);
@@ -156,6 +159,7 @@ export const trackHardwareWalletConnection = async ({
       hardwareWalletType: 'Standard',
       communication: connectionType,
       deviceType,
+      vendor,
       ...(firmwareVersions && { firmwareVersions }),
     },
     isSoftwareWalletOnlyUser,

--- a/packages/shared/src/analytics/index.ts
+++ b/packages/shared/src/analytics/index.ts
@@ -180,6 +180,8 @@ export class Analytics {
     appWalletCount?: number;
     hwWalletCount?: number;
     keylessWalletCount?: number;
+    hwVendors?: string[];
+    primaryHwVendor?: string;
   }) {
     if (this.instanceId && this.baseURL) {
       void this.requestUserProfile(attributes);

--- a/packages/shared/src/logger/scopes/account/scenes/wallet.test.ts
+++ b/packages/shared/src/logger/scopes/account/scenes/wallet.test.ts
@@ -1,0 +1,151 @@
+import { EDeviceType } from '@onekeyfe/hd-shared';
+
+import { EHardwareVendor } from '@onekeyhq/shared/types/device';
+
+import { WalletScene } from './wallet';
+
+import type { IMethodDecoratorMetadata } from '../../../types';
+
+class TestWalletScene extends WalletScene {
+  emissions: Array<{
+    methodName: string;
+    args: unknown[];
+    metadataList: IMethodDecoratorMetadata[];
+  }> = [];
+
+  override _emitLog(
+    methodName: string,
+    args: unknown[],
+    metadataList: IMethodDecoratorMetadata[],
+  ) {
+    this.emissions.push({ methodName, args, metadataList });
+  }
+}
+
+describe('WalletScene vendor passthrough', () => {
+  // Vendor is an optional field on ConnectHWWallet details — when callers
+  // pass it (OneKey or Ledger paths after this change), it must reach the
+  // Mixpanel payload. When callers don't pass it (legacy hidden-wallet edge
+  // paths, or callers from yet-unaudited code), the field must be omitted so
+  // we don't pollute Mixpanel with `vendor: undefined` rows.
+
+  describe('addWalletStarted', () => {
+    it('includes vendor when ConnectHWWallet details carry it', () => {
+      const scene = new TestWalletScene();
+      scene.addWalletStarted({
+        addMethod: 'ConnectHWWallet',
+        details: {
+          communication: 'USB',
+          hardwareWalletType: 'Standard',
+          vendor: EHardwareVendor.ledger,
+        },
+        isSoftwareWalletOnlyUser: false,
+      });
+      expect(scene.emissions).toHaveLength(1);
+      const payload = scene.emissions[0].args[0] as {
+        details: { vendor?: string };
+      };
+      expect(payload.details.vendor).toBe('ledger');
+    });
+
+    it('omits vendor field when ConnectHWWallet details lack it', () => {
+      const scene = new TestWalletScene();
+      scene.addWalletStarted({
+        addMethod: 'ConnectHWWallet',
+        details: {
+          communication: 'USB',
+          hardwareWalletType: 'Standard',
+        },
+        isSoftwareWalletOnlyUser: false,
+      });
+      const payload = scene.emissions[0].args[0] as {
+        details: Record<string, unknown>;
+      };
+      expect(Object.keys(payload.details)).not.toContain('vendor');
+    });
+  });
+
+  describe('walletAdded', () => {
+    it('includes vendor on success path when ConnectHWWallet details carry it', () => {
+      const scene = new TestWalletScene();
+      scene.walletAdded({
+        status: 'success',
+        addMethod: 'ConnectHWWallet',
+        details: {
+          communication: 'USB',
+          deviceType: EDeviceType.Pro,
+          hardwareWalletType: 'Standard',
+          vendor: EHardwareVendor.onekey,
+        },
+        isSoftwareWalletOnlyUser: false,
+      });
+      const payload = scene.emissions[0].args[0] as {
+        details: { vendor?: string };
+      };
+      expect(payload.details.vendor).toBe('onekey');
+    });
+
+    it('includes vendor on failure path when ConnectHWWallet details carry it', () => {
+      // Critical for Ledger funnel: previously the Ledger path didn't emit
+      // failure events at all. Now it does, and the vendor field is what
+      // makes the funnel comparison "Ledger fails X% / OneKey fails Y%"
+      // possible in Mixpanel.
+      const scene = new TestWalletScene();
+      scene.walletAdded({
+        status: 'failure',
+        addMethod: 'ConnectHWWallet',
+        details: {
+          communication: 'Bluetooth',
+          deviceType: EDeviceType.Unknown,
+          hardwareWalletType: 'Standard',
+          vendor: EHardwareVendor.ledger,
+        },
+        isSoftwareWalletOnlyUser: false,
+      });
+      const payload = scene.emissions[0].args[0] as {
+        status: string;
+        details: { vendor?: string };
+      };
+      expect(payload.status).toBe('failure');
+      expect(payload.details.vendor).toBe('ledger');
+    });
+
+    it('omits vendor field when ConnectHWWallet details lack it', () => {
+      // Defensive coverage: a stale caller (e.g. a not-yet-audited hidden
+      // wallet variant) that doesn't pass vendor should produce events
+      // without the vendor key, not events with `vendor: undefined`.
+      const scene = new TestWalletScene();
+      scene.walletAdded({
+        status: 'success',
+        addMethod: 'ConnectHWWallet',
+        details: {
+          communication: 'QRCode',
+          deviceType: EDeviceType.Pro,
+          hardwareWalletType: 'Hidden',
+        },
+        isSoftwareWalletOnlyUser: false,
+      });
+      const payload = scene.emissions[0].args[0] as {
+        details: Record<string, unknown>;
+      };
+      expect(Object.keys(payload.details)).not.toContain('vendor');
+    });
+
+    it('does not add a vendor field for non-HW add methods', () => {
+      // Schema sanity: vendor lives on ConnectHWWallet only. CreateWallet
+      // / ImportWallet / Connect3rdPartyWallet branches must not gain a
+      // vendor field even by accident.
+      const scene = new TestWalletScene();
+      scene.walletAdded({
+        status: 'success',
+        addMethod: 'CreateWallet',
+        details: { isBiometricSet: true },
+        isSoftwareWalletOnlyUser: true,
+      });
+      const payload = scene.emissions[0].args[0] as {
+        details: Record<string, unknown>;
+      };
+      expect(payload.details).not.toHaveProperty('vendor');
+    });
+  });
+});

--- a/packages/shared/src/logger/scopes/account/scenes/wallet.ts
+++ b/packages/shared/src/logger/scopes/account/scenes/wallet.ts
@@ -44,6 +44,7 @@ export class WalletScene extends BaseScene {
           details: {
             communication: params.details.communication,
             hardwareWalletType: params.details.hardwareWalletType,
+            ...(params.details.vendor && { vendor: params.details.vendor }),
           },
         };
 
@@ -110,6 +111,7 @@ export class WalletScene extends BaseScene {
             communication: params.details.communication,
             deviceType: params.details.deviceType,
             hardwareWalletType: params.details.hardwareWalletType,
+            ...(params.details.vendor && { vendor: params.details.vendor }),
             ...(params.details.firmwareVersions && {
               firmwareVersions: params.details.firmwareVersions,
             }),

--- a/packages/shared/src/routes/onboardingv2.ts
+++ b/packages/shared/src/routes/onboardingv2.ts
@@ -88,6 +88,12 @@ export type IOnboardingParamListV2 = {
     shouldAutoResetKeylessPinAfterRestore?: boolean;
     isFirmwareVerified?: boolean;
     deviceData?: IConnectYourDeviceItem;
+    // User-selected connection channel for this session. Carried forward from
+    // the Ledger entry points (ConnectionFlowLedger / ConnectYourDevice Ledger
+    // branch) so the analytics `walletAdded` event can attribute the actual
+    // per-session transport (via getForceTransportType) rather than the stale
+    // persisted hardwareTransportType setting.
+    tabValue?: EConnectDeviceChannel;
     keylessPackSetId?: string;
     keylessOwnerId?: string;
     keylessDetailsInfo?: IKeylessWalletDetailsInfo;

--- a/packages/shared/types/analytics/onboarding.ts
+++ b/packages/shared/types/analytics/onboarding.ts
@@ -1,4 +1,5 @@
 import type { IBaseEventPayload } from './base';
+import type { EHardwareVendor } from '../device';
 import type { IDeviceType } from '@onekeyfe/hd-core';
 
 // Specific parameter details for each add method
@@ -29,6 +30,7 @@ interface IConnectHardwareWalletPayload {
     bootloaderVersion?: string;
   };
   hardwareWalletType: 'Hidden' | 'Standard';
+  vendor?: EHardwareVendor;
 }
 
 export interface IConnectExternalWalletPayload {
@@ -65,6 +67,7 @@ export type IWalletStartedParams =
       details: {
         communication?: IHardwareTransportType;
         hardwareWalletType: 'Hidden' | 'Standard';
+        vendor?: EHardwareVendor;
       };
       isSoftwareWalletOnlyUser: boolean;
     }


### PR DESCRIPTION
## JIRA

https://onekeyhq.atlassian.net/browse/OK-55031

## Summary

- Adds optional `vendor` field to `ConnectHWWallet` variants of `addWalletStarted` and `walletAdded` so OneKey vs Ledger (and future third-party hardware) can be sliced in Mixpanel.
- Adds `hwVendors[]` / `primaryHwVendor` analytics user-profile attributes computed from the wallet list, enabling cohort retention / usage analysis without touching every downstream send / swap / sign event.
- Backfills the Ledger onboarding funnel: the real Ledger flow goes through `FinalizeWalletSetup` (not `verifyHardware` / `onSelectAddWalletType`), so `addWalletStarted` + success / failure `trackHardwareWalletConnection` calls are placed in the `if (deviceData.vendor)` branch where Ledger wallet creation actually runs.
- Plumbs `tabValue` from both Ledger entry points (`ConnectionFlowLedger`, `ConnectYourDevice` Ledger branch) to `FinalizeWalletSetup` so per-session `communication` (USB / Bluetooth / WebUSB) is reported correctly via `forceTransportType || hardwareTransportType`, matching the OneKey pattern.
- Analytics resolution (`getForceTransportType`) is wrapped in try / catch so an IPC failure never blocks Ledger wallet creation and the `walletAdded` event still fires (falls back to persisted `hardwareTransportType`).
- QR hidden-wallet path now reads `vendor` from the parent wallet's device record rather than hardcoding `onekey`, so future third-party QR vendors (e.g. Keystone) flow through automatically.

OneKey path behavior is unchanged aside from gaining `vendor='onekey'` on its existing events. All schema additions are optional fields with conditional spread in the scene, so unaudited callers do not produce `vendor: undefined` rows in Mixpanel.

## What this enables in Mixpanel

- Ledger onboarding funnel: `addWalletStarted` -> `walletAdded(success | failure)`, sliceable by `vendor`, platform, channel, and app version.
- Add-wallet success / failure comparison across OneKey, Ledger, and future third-party hardware vendors.
- Cohort retention / behavior analysis for users whose `hwVendors` contains `ledger` across existing send / swap / sign events without modifying those events.
- OneKey vs Ledger vs multi-vendor user comparison via `primaryHwVendor` / `hwVendors.length`.

## Out of scope (intentional, may be follow-ups)

- Connect-time error taxonomy (HID / BLE permission denied, scan timeout, app-not-opened): OneKey doesn't have server-side equivalents today, so left for a future unified telemetry pass.
- Persisting `vendor` as a DB column (today still a runtime field on `IDBDevice`).
- Unifying OneKey + third-party onboarding events under a single builder.

## Test plan

- [ ] Add a Ledger wallet via USB on desktop, confirm `addWalletStarted` and `walletAdded(success)` fire with `vendor='ledger'` and `communication='USB'`.
- [ ] Add a Ledger wallet via BLE on iOS / Android, confirm `communication='Bluetooth'`.
- [ ] Add a Ledger wallet via WebHID on the extension, confirm `communication='WebUSB'`.
- [ ] Force Ledger wallet creation to fail in `FinalizeWalletSetup`, confirm `walletAdded(failure)` fires with `vendor='ledger'`.
- [ ] Add a OneKey hardware wallet, confirm existing events keep working and now carry `vendor='onekey'`.
- [ ] Add a QR hidden wallet on OneKey Pro, confirm events carry `vendor='onekey'`; old wallets without persisted vendor on the device record should also resolve to `onekey` via the sidebar user-profile fallback.
- [ ] In Mixpanel user profile, verify `hwVendors` / `primaryHwVendor` update after adding a Ledger wallet.
- [ ] Delete all hardware wallets while at least one software wallet remains, verify `hwVendors=[]` and `primaryHwVendor` is cleared.
- [ ] Cold start with mixed wallet types, verify `hwVendors` / `primaryHwVendor` repopulate correctly from the wallet list.
- [ ] Verify lint / tsc on staged files and the new unit tests:
  - `packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletList/walletListUtils.test.ts` (7 new cases for `computeHwVendorProfile`)
  - `packages/shared/src/logger/scopes/account/scenes/wallet.test.ts` (6 new cases for vendor field passthrough)
