### PR TITLE
fix: refine bot wallet cloud sync

### DIFF
--- a/packages/kit-bg/src/dbs/local/LocalDbBase.test.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.test.ts
@@ -50,6 +50,8 @@ class TestLocalDb extends LocalDbBase {
 
   credentials: IDBCredentialBase[] = [];
 
+  addHDNextIndexedAccountCalls = 0;
+
   constructor() {
     super();
 
@@ -104,6 +106,7 @@ class TestLocalDb extends LocalDbBase {
     nextIndex: number;
     indexedAccountId: string;
   }> {
+    this.addHDNextIndexedAccountCalls += 1;
     return { nextIndex: 0, indexedAccountId: 'indexed-account-0' };
   }
 
@@ -184,6 +187,7 @@ describe('LocalDbBase.createHDWallet', () => {
     expect(regularWallet.wallet.walletNo).toBe(1);
     expect(db.context.nextHD).toBe(2);
     expect(db.context.nextWalletNo).toBe(2);
+    expect(db.addHDNextIndexedAccountCalls).toBe(1);
 
     const botWallet = await db.createHDWallet(
       buildParams({
@@ -194,12 +198,14 @@ describe('LocalDbBase.createHDWallet', () => {
     expect(botWallet.wallet.walletNo).toBe(2);
     expect(db.context.nextHD).toBe(2);
     expect(db.context.nextWalletNo).toBe(3);
+    expect(db.addHDNextIndexedAccountCalls).toBe(1);
 
     const nextRegularWallet = await db.createHDWallet(buildParams());
     expect(nextRegularWallet.wallet.id).toBe('hd-2');
     expect(nextRegularWallet.wallet.walletNo).toBe(3);
     expect(db.context.nextHD).toBe(3);
     expect(db.context.nextWalletNo).toBe(4);
+    expect(db.addHDNextIndexedAccountCalls).toBe(2);
   });
 });
 

--- a/packages/kit-bg/src/dbs/local/LocalDbBase.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.ts
@@ -2537,12 +2537,14 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
       applyRestoreSyncPolicy,
     } = params;
     const { overrideWalletId } = params;
+    const isBotWalletOverride = Boolean(
+      overrideWalletId &&
+      accountUtils.isBotWallet({ walletId: overrideWalletId }),
+    );
     const shouldConsumeNextHD = !overrideWalletId;
     // Bot wallets reuse the parent-derived wallet id, but still need a unique
     // walletNo for sorting and fallback ordering.
-    const shouldConsumeNextWalletNo =
-      !overrideWalletId ||
-      accountUtils.isBotWallet({ walletId: overrideWalletId });
+    const shouldConsumeNextWalletNo = !overrideWalletId || isBotWalletOverride;
     const context = await this.getContext({ verifyPassword: password });
     let walletId = accountUtils.buildHdWalletId({
       nextHD: context.nextHD,
@@ -2712,7 +2714,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
           });
 
           // add first indexed account
-          if (!skipAddHDNextIndexedAccount) {
+          if (!skipAddHDNextIndexedAccount && !isBotWalletOverride) {
             console.log('add first indexed account');
             const { nextIndex } = await this.txAddHDNextIndexedAccount({
               tx,

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -177,6 +177,12 @@ import keylessSyncCredentialStorage from '../ServiceKeylessWallet/utils/keylessS
 import { isBotWalletInCurrentKeylessSyncScope } from '../ServicePrimeCloudSync/botWalletCloudSyncUtils';
 import keylessCloudSyncUtils from '../ServicePrimeCloudSync/keylessCloudSyncUtils';
 
+import {
+  buildDefaultBotWalletName,
+  isDefaultBotWalletName,
+  resolveBotWalletSyncItemDataTime,
+} from './botWalletCreateUtils';
+
 import type { ISimpleDBAppStatus } from '../../dbs/simple/entity/SimpleDbEntityAppStatus';
 import type {
   IAccountDeriveInfo,
@@ -3564,7 +3570,11 @@ class ServiceAccount extends ServiceBase {
       const nextIndex = await simpleDb.botWallet.getNextIndex(
         parentKeylessWalletId,
       );
-      const botName = name || `Bot #${nextIndex + 1}`;
+      const botName = name || buildDefaultBotWalletName(nextIndex);
+      const shouldUseCreateGenesisTime = isDefaultBotWalletName({
+        index: nextIndex,
+        name: botName,
+      });
       const metadata: IBotWalletMetadata = {
         index: nextIndex,
         name: botName,
@@ -3582,6 +3592,7 @@ class ServiceAccount extends ServiceBase {
       });
       await this.syncBotWalletSyncItem({
         walletId: result.wallet.id,
+        shouldUseCreateGenesisTime,
       });
 
       await timerUtils.wait(100);
@@ -3710,10 +3721,12 @@ class ServiceAccount extends ServiceBase {
     walletId,
     metadataOverride,
     isDeleted = false,
+    shouldUseCreateGenesisTime,
   }: {
     walletId: string;
     metadataOverride?: IBotWalletMetadata;
     isDeleted?: boolean;
+    shouldUseCreateGenesisTime?: boolean;
   }): Promise<void> {
     if (
       (await this.backgroundApi.serviceKeylessCloudSync.getActiveSyncMode()) !==
@@ -3755,7 +3768,10 @@ class ServiceAccount extends ServiceBase {
             walletId,
             metadata,
           },
-          dataTime: await this.backgroundApi.servicePrimeCloudSync.timeNow(),
+          dataTime: await resolveBotWalletSyncItemDataTime({
+            shouldUseCreateGenesisTime,
+            timeNow: () => this.backgroundApi.servicePrimeCloudSync.timeNow(),
+          }),
           isDeleted,
         },
       );

--- a/packages/kit-bg/src/services/ServiceAccount/botWalletCreateUtils.test.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/botWalletCreateUtils.test.ts
@@ -1,0 +1,44 @@
+import { PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME } from '@onekeyhq/shared/src/consts/primeConsts';
+
+import {
+  buildDefaultBotWalletName,
+  isDefaultBotWalletName,
+  resolveBotWalletSyncItemDataTime,
+} from './botWalletCreateUtils';
+
+describe('botWalletCreateUtils', () => {
+  it('builds and detects the default bot wallet name for the target index', () => {
+    expect(buildDefaultBotWalletName(0)).toBe('Bot #1');
+    expect(buildDefaultBotWalletName(4)).toBe('Bot #5');
+
+    expect(isDefaultBotWalletName({ index: 0, name: 'Bot #1' })).toBe(true);
+    expect(isDefaultBotWalletName({ index: 0, name: 'Bot #2' })).toBe(false);
+    expect(isDefaultBotWalletName({ index: 0, name: 'Trading Bot' })).toBe(
+      false,
+    );
+  });
+
+  it('uses the cloud sync create genesis time for default-name bot wallet creation', async () => {
+    const timeNow = jest.fn(async () => 1_800_000_000_000);
+
+    await expect(
+      resolveBotWalletSyncItemDataTime({
+        shouldUseCreateGenesisTime: true,
+        timeNow,
+      }),
+    ).resolves.toBe(PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME);
+    expect(timeNow).not.toHaveBeenCalled();
+  });
+
+  it('uses current time for non-default bot wallet changes', async () => {
+    const timeNow = jest.fn(async () => 1_800_000_000_000);
+
+    await expect(
+      resolveBotWalletSyncItemDataTime({
+        shouldUseCreateGenesisTime: false,
+        timeNow,
+      }),
+    ).resolves.toBe(1_800_000_000_000);
+    expect(timeNow).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/kit-bg/src/services/ServiceAccount/botWalletCreateUtils.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/botWalletCreateUtils.ts
@@ -1,0 +1,28 @@
+import { PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME } from '@onekeyhq/shared/src/consts/primeConsts';
+
+export function buildDefaultBotWalletName(index: number): string {
+  return `Bot #${index + 1}`;
+}
+
+export function isDefaultBotWalletName({
+  index,
+  name,
+}: {
+  index: number;
+  name: string;
+}): boolean {
+  return name === buildDefaultBotWalletName(index);
+}
+
+export async function resolveBotWalletSyncItemDataTime({
+  shouldUseCreateGenesisTime,
+  timeNow,
+}: {
+  shouldUseCreateGenesisTime?: boolean;
+  timeNow: () => Promise<number>;
+}): Promise<number> {
+  if (shouldUseCreateGenesisTime) {
+    return PRIME_CLOUD_SYNC_CREATE_GENESIS_TIME;
+  }
+  return timeNow();
+}

--- a/packages/kit-bg/src/services/ServicePrimeCloudSync/ServicePrimeCloudSync.tsx
+++ b/packages/kit-bg/src/services/ServicePrimeCloudSync/ServicePrimeCloudSync.tsx
@@ -85,6 +85,7 @@ import {
 import ServiceBase from '../ServiceBase';
 
 import { filterBotWalletRecordsByCurrentKeylessSyncScope } from './botWalletCloudSyncUtils';
+import { buildOnlyCheckLocalDataTypes } from './cloudSyncCheckUtils';
 import { CloudSyncFlowManagerAccount } from './CloudSyncFlowManager/CloudSyncFlowManagerAccount';
 import { CloudSyncFlowManagerAddressBook } from './CloudSyncFlowManager/CloudSyncFlowManagerAddressBook';
 import { CloudSyncFlowManagerBotWallet } from './CloudSyncFlowManager/CloudSyncFlowManagerBotWallet';
@@ -412,15 +413,9 @@ class ServicePrimeCloudSync extends ServiceBase {
     isFullDBChecking?: boolean;
   } = {}): Promise<ICloudSyncCheckServerStatusResult> {
     const items = localItems || [];
-    const onlyCheckLocalDataType = isFullDBChecking
-      ? [
-          EPrimeCloudSyncDataType.Lock,
-          EPrimeCloudSyncDataType.Wallet,
-          EPrimeCloudSyncDataType.BotWallet,
-          EPrimeCloudSyncDataType.Account,
-          EPrimeCloudSyncDataType.IndexedAccount,
-        ]
-      : Object.values(EPrimeCloudSyncDataType);
+    const onlyCheckLocalDataType = buildOnlyCheckLocalDataTypes({
+      isFullDBChecking,
+    });
     const postData: ICloudSyncCheckServerStatusPostData = {
       localData: items.map((item) => ({
         key: item.id,

--- a/packages/kit-bg/src/services/ServicePrimeCloudSync/cloudSyncCheckUtils.test.ts
+++ b/packages/kit-bg/src/services/ServicePrimeCloudSync/cloudSyncCheckUtils.test.ts
@@ -1,0 +1,24 @@
+import { EPrimeCloudSyncDataType } from '@onekeyhq/shared/src/consts/primeConsts';
+
+import { buildOnlyCheckLocalDataTypes } from './cloudSyncCheckUtils';
+
+describe('cloudSyncCheckUtils', () => {
+  it('excludes BotWallet from full DB check local data types', () => {
+    expect(buildOnlyCheckLocalDataTypes({ isFullDBChecking: true })).toEqual([
+      EPrimeCloudSyncDataType.Lock,
+      EPrimeCloudSyncDataType.Wallet,
+      EPrimeCloudSyncDataType.Account,
+      EPrimeCloudSyncDataType.IndexedAccount,
+    ]);
+  });
+
+  it('includes BotWallet in regular check local data types', () => {
+    const dataTypes = buildOnlyCheckLocalDataTypes({
+      isFullDBChecking: false,
+    });
+
+    expect(dataTypes).toContain(EPrimeCloudSyncDataType.BotWallet);
+    expect(dataTypes).toContain(EPrimeCloudSyncDataType.Wallet);
+    expect(dataTypes).toContain(EPrimeCloudSyncDataType.Account);
+  });
+});

--- a/packages/kit-bg/src/services/ServicePrimeCloudSync/cloudSyncCheckUtils.ts
+++ b/packages/kit-bg/src/services/ServicePrimeCloudSync/cloudSyncCheckUtils.ts
@@ -1,0 +1,22 @@
+import { EPrimeCloudSyncDataType } from '@onekeyhq/shared/src/consts/primeConsts';
+
+const FULL_DB_CHECK_LOCAL_DATA_TYPES: EPrimeCloudSyncDataType[] = [
+  EPrimeCloudSyncDataType.Lock,
+  EPrimeCloudSyncDataType.Wallet,
+  EPrimeCloudSyncDataType.Account,
+  EPrimeCloudSyncDataType.IndexedAccount,
+];
+
+const ALL_CHECK_LOCAL_DATA_TYPES = Object.values(EPrimeCloudSyncDataType);
+
+export function buildOnlyCheckLocalDataTypes({
+  isFullDBChecking,
+}: {
+  isFullDBChecking?: boolean;
+}): EPrimeCloudSyncDataType[] {
+  return [
+    ...(isFullDBChecking
+      ? FULL_DB_CHECK_LOCAL_DATA_TYPES
+      : ALL_CHECK_LOCAL_DATA_TYPES),
+  ];
+}


### PR DESCRIPTION
## Summary
- Use the create-genesis timestamp for default-name BotWallet sync items.
- Keep BotWallet out of full DB check type lists while preserving it for regular checks.
- Skip automatic first IndexedAccount creation for BotWallet-derived HD wallets.

## Intent &amp; Context
Bot wallet creation was producing cloud sync payloads that differed from normal wallet behavior. Default BotWallet names such as Bot #1 should use the same create-genesis timestamp policy as other default wallet names. Also, full DB sync checks should not include BotWallet, while regular check requests should still include it. During investigation, BotWallet creation was also found to trigger an IndexedAccount check because createHDWallet automatically created a first IndexedAccount for override wallet IDs.

## Root Cause
BotWallet creation bypassed the normal wallet create flow for sync item timestamp selection and always used current server time. Separately, createHDWallet did not distinguish BotWallet override IDs when deciding whether to create the first IndexedAccount, so each BotWallet creation could create and sync an unnecessary IndexedAccount.

## Design Decisions
- Centralized BotWallet default-name and sync timestamp selection in a small ServiceAccount helper.
- Centralized check type-list generation so full DB and regular check behavior is explicit.
- Added BotWallet override detection in createHDWallet so callers do not need to remember a skip flag.

## Changes Detail
- ServiceAccount now marks default-name BotWallet create sync items with the create-genesis timestamp.
- Prime cloud sync check payload construction now uses explicit full DB and regular type lists.
- LocalDbBase.createHDWallet skips first IndexedAccount creation for BotWallet override IDs while preserving normal wallet behavior.
- Added focused unit coverage for BotWallet create utilities, cloud sync check list generation, and BotWallet IndexedAccount skip behavior.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: BotWallet creation, Keyless cloud sync check and upload flow, HD wallet creation with override IDs.

## Test plan
- [x] yarn jest packages/kit-bg/src/dbs/local/LocalDbBase.test.ts packages/kit-bg/src/services/ServiceAccount/botWalletCreateUtils.test.ts packages/kit-bg/src/services/ServicePrimeCloudSync/cloudSyncCheckUtils.test.ts --runInBand
- [x] yarn lint:staged
- [x] yarn tsc:staged
- [x] yarn tsc:only
- [x] target oxlint checks for touched files

[Claude session ↗](https://claude.ai/code/session_01LppwU3TFzPpRboUv9TTkU4)