### PR TITLE
fix: auto-create address for BTC/LTC in receive token selector(OK-54982)

### DIFF
--- a/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
+++ b/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
@@ -23,7 +23,10 @@ import {
 } from '@onekeyhq/kit/src/states/jotai/contexts/tokenList';
 import type { IAllNetworkAccountInfo } from '@onekeyhq/kit-bg/src/services/ServiceAllNetwork/ServiceAllNetwork';
 import { useTokenSelectorFilterPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import type { IVaultSettings } from '@onekeyhq/kit-bg/src/vaults/types';
+import type {
+  IAccountDeriveTypes,
+  IVaultSettings,
+} from '@onekeyhq/kit-bg/src/vaults/types';
 import { SEARCH_KEY_MIN_LENGTH } from '@onekeyhq/shared/src/consts/walletConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IAssetSelectorParamList } from '@onekeyhq/shared/src/routes';
@@ -392,18 +395,11 @@ function TokenSelector() {
             : true && item.networkId === token.networkId,
         );
 
-        if (
-          vaultSettings?.mergeDeriveAssetsEnabled ||
-          matchedAccount?.accountId
-        ) {
-          if (matchedAccount?.accountId) {
-            await executeOnSelect({
-              ...token,
-              accountId: matchedAccount.accountId,
-            });
-          } else {
-            await executeOnSelect(token);
-          }
+        if (matchedAccount?.accountId) {
+          await executeOnSelect({
+            ...token,
+            accountId: matchedAccount.accountId,
+          });
         } else if (account) {
           updateCreateAccountState({
             isCreating: true,
@@ -413,13 +409,24 @@ function TokenSelector() {
             accountId: account.id,
           });
           try {
+            // For multi-derive networks (e.g. BTC/LTC) align the new account's
+            // derive type with the network's global default so the downstream
+            // ReceiveToken lookup (getAccountsByIndexedAccounts) can find it.
+            const deriveType: IAccountDeriveTypes =
+              vaultSettings?.mergeDeriveAssetsEnabled && token.networkId
+                ? await backgroundApiProxy.serviceNetwork.getGlobalDeriveTypeOfNetwork(
+                    {
+                      networkId: token.networkId,
+                    },
+                  )
+                : 'default';
             const resp = await createAddress({
               num: 0,
               account: {
                 walletId,
                 networkId: token.networkId,
                 indexedAccountId: account.indexedAccountId,
-                deriveType: 'default',
+                deriveType,
               },
             });
 
@@ -440,6 +447,8 @@ function TokenSelector() {
               token: null,
             });
           }
+        } else if (vaultSettings?.mergeDeriveAssetsEnabled) {
+          await executeOnSelect(token);
         }
       } else {
         await executeOnSelect(token);


### PR DESCRIPTION
## Summary
- Restore the create-address flow in the Receive → Token Selector for multi-derive networks (BTC/LTC) when the indexedAccount has no matching account yet.
- Use the network's global default derive type when creating that address so the downstream `ReceiveToken` lookup can locate it.

## Intent & Context
Reported flow: Home → Receive → Receive Transfer → pick a token. When the active indexedAccount only had an EVM account and the user selected BTC or LTC, the receive page rendered blank.

## Root Cause
In `TokenSelector` the branch `if (vaultSettings?.mergeDeriveAssetsEnabled || matchedAccount?.accountId)` short-circuited the missing-account path: for multi-derive networks like BTC/LTC, `mergeDeriveAssetsEnabled` is true, so even when no matching account existed we fell through to `executeOnSelect(token)` without an `accountId`. The subsequent `ReceiveToken` screen calls `getAccountsByIndexedAccounts`, which can only resolve the address if a BTC/LTC account already exists for that indexedAccount and matches the network's global derive type — neither was true, so the page was blank.

Additionally, the previous `createAddress` call always passed `deriveType: 'default'`. For merge-derive networks, the global default may not be `'default'` (e.g. BTC's `BIP44` / Taproot variants), so even when the create path did run, the resulting account did not match what `ReceiveToken` later queries for.

## Design Decisions
- Split the gating condition so `mergeDeriveAssetsEnabled` no longer suppresses the create-address path when `matchedAccount?.accountId` is missing. The create flow now runs whenever there is an `account` context but no matched account.
- When creating the address on a merge-derive network, resolve the derive type via `serviceNetwork.getGlobalDeriveTypeOfNetwork({ networkId })` so the new account is the exact one `ReceiveToken` looks up next. For non-merge-derive networks, keep the existing `'default'` behavior.
- Preserve the original fallback `executeOnSelect(token)` for the merge-derive case where no `account` context exists at all, by moving it to a trailing `else if (vaultSettings?.mergeDeriveAssetsEnabled)` branch — keeps prior behavior intact for that edge case.

## Changes Detail
- `packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx`
  - Reworked the branching in the token-select handler so the create-address path is reachable for merge-derive networks lacking a matched account.
  - Pass `IAccountDeriveTypes` from `getGlobalDeriveTypeOfNetwork` when `mergeDeriveAssetsEnabled`, otherwise `'default'`.
  - Added a tail branch preserving the previous `executeOnSelect(token)` behavior for merge-derive networks without an `account` context.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Mobile / Web / Extension (shared `kit` view)
- **Risk Areas**:
  - Behavior change is scoped to the Receive token selector's selection handler.
  - The new branch only triggers `createAddress` when an `account` already exists for the indexedAccount (same precondition as before), so it cannot create accounts in unexpected contexts.
  - Verify non-merge-derive networks still use `'default'` derive type (unchanged path).

## Test plan
- [ ] Create a wallet, add only an EVM account to an indexedAccount, then Home → Receive → pick BTC: address is auto-created and the receive page shows the BTC address.
- [ ] Repeat with LTC: address is auto-created and the receive page renders correctly.
- [ ] On an indexedAccount that already has a BTC/LTC account, selecting BTC/LTC still uses the matched `accountId` (no duplicate creation).
- [ ] On a non-merge-derive network (e.g. ETH) without a matching account, the existing create flow still runs with `deriveType: 'default'`.
- [ ] No regression on the Receive Token Selector for EVM/Solana flows already covered before.