### PR TITLE
chore: add 1k-pr-bundle-info skill and create-pr integration

### DIFF
--- a/.skillshare/skills/1k-create-pr/SKILL.md
+++ b/.skillshare/skills/1k-create-pr/SKILL.md
@@ -23,6 +23,7 @@ Automates the complete PR creation workflow for OneKey app-monorepo changes.
 | 9 | Update branch | `gh pr update-branch <number>` |
 | 10 | Enable auto-merge | `gh pr merge <number> --auto --squash` |
 | 11 | Update Jira issue | Update `1k-github-branch` and `1k-github-pr-url` fields |
+| 12 | Bundle Release Info (only when BASE is `release/v*`) | Trigger `release-app-bundles` + post Bundle Release Info comment |
 
 ## Workflow
 
@@ -220,7 +221,47 @@ fields: {
 }
 ```
 
-### 12. Return PR URL
+### 12. Bundle Release Info Comment (热更流程 only)
+
+**Trigger condition:** `BASE` from step 2 matches `release/v*` (i.e. this PR is part of the bundle hot-update flow). For PRs targeting `x`, **skip this entire step**.
+
+**Why:** Bundle hot-update PRs need a single canonical comment with PR / Bundle / BUILD_NUMBER / BUILD_BUNDLE_VERSION / BUILD_SOURCE / BRANCH / COMMIT / JIRA so QA can validate against the exact bundle artifact.
+
+**Ask the user first — this step is opt-in:**
+
+> "This PR targets `$BASE` (bundle hot-update). Run the Bundle Release Info step? It triggers the `release-app-bundles` workflow (if needed) and posts a comment on the PR.
+> Requires GitHub repo write access — skip if you don't have permission to trigger Actions or comment.
+> [Y] run / [n] skip"
+
+If the user says no, skip directly to step 13. Never auto-run this step without an explicit yes.
+
+**What to do (only after the user confirms):**
+
+1. Check whether a `release-app-bundles` run already exists for `$HEAD_BRANCH`:
+
+   ```bash
+   gh run list --repo OneKeyHQ/app-monorepo \
+     --branch "$HEAD_BRANCH" \
+     --workflow release-app-bundles \
+     --limit 1 \
+     --json databaseId,status,conclusion
+   ```
+
+2. If none exists → trigger one, **ref must match the PR head branch**:
+
+   ```bash
+   gh workflow run release-app-bundles.yml \
+     --repo OneKeyHQ/app-monorepo \
+     --ref "$HEAD_BRANCH"
+   ```
+
+   Ask the user before triggering — it's a shared-state action that costs ~25-30 min of CI time.
+
+3. Once a successful run exists, hand off to `/1k-pr-bundle-info <PR_NUMBER>` for the full flow (parse `prepare-params` logs → derive Jira key → format → post/update comment).
+
+See [/1k-pr-bundle-info](../1k-pr-bundle-info/SKILL.md) for the canonical comment format, parsing logic, and idempotent update behavior. Do not reimplement here.
+
+### 13. Return PR URL
 
 Display PR URL to user and open in browser:
 ```bash

--- a/.skillshare/skills/1k-pr-bundle-info/SKILL.md
+++ b/.skillshare/skills/1k-pr-bundle-info/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: 1k-pr-bundle-info
+description: Posts a formatted Bundle Release Info comment on a GitHub PR. Given a PR (URL or number), fetches the latest release-app-bundles workflow run, extracts BUILD_NUMBER / BUILD_BUNDLE_VERSION / BUILD_SOURCE / BRANCH / COMMIT from the prepare-params job logs, derives the Jira key (OK-XXXXX) from the PR title, and posts or updates a single comment with PR / Bundle / build params / JIRA links. Triggers on "bundle 信息留言", "PR 贴 bundle 信息", "post bundle info", "在 PR 上留言 bundle".
+allowed-tools: Bash, Read
+---
+
+# PR Bundle Info Comment
+
+Posts a formatted **Bundle Release Info** comment on a bundle-release PR. Reads from GitHub Actions, writes back to the PR. Idempotent — re-running on the same PR updates the existing comment instead of creating a duplicate.
+
+## When to use
+
+After a `release-app-bundles` workflow has finished for a PR, and you want QA / reviewers to see a single canonical block with:
+
+- PR link
+- Workflow run link
+- `BUILD_NUMBER`, `BUILD_BUNDLE_VERSION`, `BUILD_SOURCE`, `BRANCH`, `COMMIT`
+- Jira link (derived from PR title)
+
+Not a release flow step — a standalone utility. Works on any PR, on any base branch, as long as a `release-app-bundles` run exists for the PR's head branch.
+
+## Input
+
+Accept either form from the user:
+
+- A PR URL: `https://github.com/OneKeyHQ/app-monorepo/pull/11725`
+- A PR number alone: `11725`
+
+If nothing is supplied, ask the user.
+
+```bash
+REPO="OneKeyHQ/app-monorepo"
+PR_NUMBER="<parsed from input>"
+```
+
+## Step 1: Fetch PR metadata
+
+```bash
+gh pr view "$PR_NUMBER" --repo "$REPO" \
+  --json number,title,headRefName,headRefOid,url
+```
+
+Capture:
+
+- `title` → used to extract the Jira key
+- `headRefName` → used to find the workflow run (the branch name)
+- `headRefOid` → the current PR head commit. Save as `PR_HEAD_SHA`.
+- `url` → used in the comment
+
+If the PR cannot be fetched, stop with a clear message.
+
+## Step 2: Find the release-app-bundles workflow run
+
+List recent workflow runs for the PR branch and pick the latest successful `release-app-bundles` run:
+
+```bash
+gh run list --repo "$REPO" \
+  --branch "$HEAD_BRANCH" \
+  --workflow release-app-bundles \
+  --limit 10 \
+  --json databaseId,headSha,status,conclusion,url,createdAt
+```
+
+Selection rule:
+
+- Prefer the most recent run with `conclusion=success` **and** `headSha="$PR_HEAD_SHA"`.
+- If no successful run matches the current PR head, use the most recent run with `headSha="$PR_HEAD_SHA"` and wait for it to finish.
+- If no run matches the current PR head at all → trigger one (see Step 2a), then re-list after it completes.
+- Never post bundle info from a run whose `headSha` is different from the current `PR_HEAD_SHA`. A branch may have older successful runs after new commits are pushed.
+
+Save:
+
+- `RUN_ID` (the `databaseId`)
+- `RUN_URL` = `https://github.com/<repo>/actions/runs/<RUN_ID>`
+
+## Step 2a: Trigger a release-app-bundles run (when no current-head run exists)
+
+When Step 2 finds no run for `$HEAD_BRANCH` at `PR_HEAD_SHA`, present both options to the user — manual UI or CLI — and emphasize that **the workflow must be triggered against the PR's head branch**, not `x` or any release branch. A mismatch produces a bundle for the wrong code.
+
+**Manual UI**
+
+> No `release-app-bundles` run found for `$HEAD_BRANCH`. Trigger one here:
+> https://github.com/OneKeyHQ/app-monorepo/actions/workflows/release-app-bundles.yml
+> → click **Run workflow**, set **Use workflow from branch** = `$HEAD_BRANCH`, then run.
+
+**CLI (offer to run it for the user)**
+
+```bash
+gh workflow run release-app-bundles.yml \
+  --repo "$REPO" \
+  --ref "$HEAD_BRANCH"
+```
+
+Ask before executing — triggering a build is a shared-state action.
+
+After triggering, the full run takes ~25–30 minutes — **but we don't wait for the full run**. The `prepare-params` job emits all required build params and finishes in ~10-30 seconds. Wait only for that job, then proceed.
+
+```bash
+# Give GitHub a moment to register the run
+sleep 5
+NEW_RUN_ID=$(gh run list --repo "$REPO" --branch "$HEAD_BRANCH" \
+  --workflow release-app-bundles --limit 1 --json databaseId --jq '.[0].databaseId')
+
+# Poll until prepare-params completes (typically <30s)
+while :; do
+  STATE=$(gh run view "$NEW_RUN_ID" --repo "$REPO" --json jobs \
+    --jq '.jobs[] | select(.name=="prepare-params") | .status + ":" + (.conclusion // "")')
+  case "$STATE" in
+    completed:success) break ;;
+    completed:*) echo "prepare-params failed: $STATE"; exit 1 ;;
+    *) sleep 5 ;;
+  esac
+done
+
+RUN_ID="$NEW_RUN_ID"
+```
+
+Then continue to Step 3. The rest of the run (web/desktop/native bundles) keeps running in the background — Step 3's log fetch works on a single job even when the overall run is still `in_progress`.
+
+## Step 3: Extract build parameters from prepare-params logs
+
+Find the `prepare-params` job and read its logs **via the per-job API** (not `gh run view --log`, which refuses while the overall run is `in_progress`):
+
+```bash
+PREPARE_JOB_ID=$(gh run view "$RUN_ID" --repo "$REPO" --json jobs \
+  --jq '.jobs[] | select(.name=="prepare-params") | .databaseId')
+
+gh api "/repos/${REPO}/actions/jobs/${PREPARE_JOB_ID}/logs" 2>&1 \
+  | grep -E "  BUILD_NUMBER=|  BUILD_BUNDLE_VERSION=|  BUILD_SOURCE=|  BRANCH=|  COMMIT="
+```
+
+> Why per-job API: `gh run view --log` errors with `"run … is still in progress; logs will be available when it is complete"` until **every** job finishes. `gh api /repos/{repo}/actions/jobs/{id}/logs` returns a single job's logs as soon as that job completes, so we can post bundle info ~30 sec after triggering instead of waiting 25-30 min for native builds.
+
+The `Generate build parameters` step emits five summary lines (each indented by two spaces) at the end:
+
+```
+  BUILD_NUMBER=2026051841
+  BUILD_BUNDLE_VERSION=12018459
+  BUILD_SOURCE=bundle-release
+  BRANCH=fix/mobile-tab-list-restore-from-storage-v6.3.0
+  COMMIT=0dfc436d033204740456ffbcf46425cde491d256
+```
+
+Parse into shell variables: `BUILD_NUMBER`, `BUILD_BUNDLE_VERSION`, `BUILD_SOURCE`, `BRANCH`, `COMMIT`.
+
+If any are missing (logs trimmed, step renamed, etc.), stop and tell the user which one could not be parsed.
+
+Verify `COMMIT` matches the current PR head before posting:
+
+```bash
+if [ "$COMMIT" != "$PR_HEAD_SHA" ]; then
+  echo "Bundle run commit $COMMIT does not match current PR head $PR_HEAD_SHA. Trigger or wait for a fresh release-app-bundles run."
+  exit 1
+fi
+```
+
+## Step 4: Derive Jira key(s)
+
+Extract **all** `OK-<digits>` tokens from the PR title (a single PR often covers multiple issues):
+
+```bash
+JIRA_KEYS=$(printf '%s' "$PR_TITLE" | grep -oE 'OK-[0-9]+' | awk '!seen[$0]++')
+```
+
+- 0 keys → omit the `JIRA:` line entirely
+- 1 key → `JIRA: [OK-XXXXX](https://onekeyhq.atlassian.net/browse/OK-XXXXX)`
+- 2+ keys → comma-separate, each as its own link:
+  `JIRA: [OK-AAAAA](https://…/OK-AAAAA), [OK-BBBBB](https://…/OK-BBBBB)`
+
+Preserve title order; deduplicate.
+
+## Step 5: Build the comment body
+
+Use exactly this format. Short commit = first 7 chars of `COMMIT`.
+
+```
+PR: [#<PR_NUMBER>](<PR_URL>)
+Bundle: [actions/runs/<RUN_ID>](<RUN_URL>)
+Build Number: `<BUILD_NUMBER>`
+Build Bundle Version: `<BUILD_BUNDLE_VERSION>`
+Build Source: `<BUILD_SOURCE>`
+Branch: `<BRANCH>`
+Commit: [<COMMIT_SHORT>](https://github.com/<repo>/commit/<COMMIT>)
+JIRA: [<JIRA_KEY_1>](<JIRA_URL_1>), [<JIRA_KEY_2>](<JIRA_URL_2>)
+```
+
+Formatting rules:
+
+- Labels: Title Case with spaces (`Build Number`, not `BUILD_NUMBER`).
+- URL values → wrap as `[short display](url)`.
+- Non-URL values → wrap in backticks (`` `value` ``).
+- `Commit` links the full SHA but displays the 7-char short SHA.
+- `JIRA`: one line, comma-separated `[KEY](url)` per key. Omit the entire line if no key was found.
+
+## Step 6: Post or update the comment
+
+Look for an existing Bundle Release Info comment on the PR (heuristic: a comment whose body starts with `PR: [#<PR_NUMBER>](`):
+
+```bash
+EXISTING=$(gh api "/repos/${REPO}/issues/${PR_NUMBER}/comments" \
+  --jq ".[] | select(.body | startswith(\"PR: [#${PR_NUMBER}](\")) | .id" \
+  | head -1)
+```
+
+- If `EXISTING` is empty → create:
+
+  ```bash
+  gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BODY"
+  ```
+
+- If `EXISTING` is set → update in place:
+
+  ```bash
+  gh api -X PATCH "/repos/${REPO}/issues/comments/${EXISTING}" \
+    -f body="$BODY" --jq '.html_url'
+  ```
+
+Confirm with the user before overwriting if the existing content differs significantly.
+
+## Step 7: Output
+
+Print the comment URL returned by GitHub:
+
+```
+Posted: https://github.com/OneKeyHQ/app-monorepo/pull/11725#issuecomment-4494147672
+```
+
+## Worked example
+
+Input: `https://github.com/OneKeyHQ/app-monorepo/pull/11725`
+
+Output comment body:
+
+```
+PR: [#11725](https://github.com/OneKeyHQ/app-monorepo/pull/11725)
+Bundle: [actions/runs/26137511056](https://github.com/OneKeyHQ/app-monorepo/actions/runs/26137511056)
+Build Number: `2026051841`
+Build Bundle Version: `12018459`
+Build Source: `bundle-release`
+Branch: `fix/mobile-tab-list-restore-from-storage-v6.3.0`
+Commit: [0dfc436](https://github.com/OneKeyHQ/app-monorepo/commit/0dfc436d033204740456ffbcf46425cde491d256)
+JIRA: [OK-54651](https://onekeyhq.atlassian.net/browse/OK-54651)
+```
+
+## Related Skills
+
+- `/1k-bundle-release` — Multi-step bundle release flow (checkout, prepare, pr, diff-check, audit, publish, sync)


### PR DESCRIPTION
## Summary
- New skill `1k-pr-bundle-info`: posts a single canonical **Bundle Release Info** comment on a GitHub PR (PR / Bundle / build params / JIRA), reading from `release-app-bundles` workflow runs.
- New Step 12 in `1k-create-pr`: when the PR base is `release/v*`, opt-in offer to trigger `release-app-bundles` and post the bundle info comment (delegates to `1k-pr-bundle-info`).

## Intent & Context
While shipping bundle release PRs (e.g. #11725, #11729) we kept hand-writing a comment with `BUILD_NUMBER`, `BUILD_BUNDLE_VERSION`, `BUILD_SOURCE`, `BRANCH`, `COMMIT` and the Jira link so QA could validate the exact bundle artifact. The format drifted across PRs (table vs list, with/without emoji, etc.). This change codifies the format and the fetch-then-post flow so any contributor can produce the same comment with `/1k-pr-bundle-info <pr>`, and `/1k-create-pr` offers to run it automatically on bundle-release PRs.

## Design Decisions
- **Standalone skill, not nested in `1k-bundle-release`** — `1k-bundle-release` is a sequential release pipeline (checkout → prepare → pr → diff-check → audit → publish → sync). Posting the bundle info comment is a quick utility that can run on any PR at any time, independent of the pipeline. Keeping them separate avoids forcing the utility into the wrong mental model.
- **Per-job logs API, not `gh run view --log`** — `gh run view --log` refuses with `"run is still in progress; logs will be available when it is complete"` until **every** job finishes. The `prepare-params` job that emits the build params finishes in ~30 seconds; using `gh api /repos/{repo}/actions/jobs/{id}/logs` lets us post the comment immediately, instead of waiting 25-30 minutes for native bundle builds.
- **Idempotent update** — re-invoking on the same PR finds the existing comment (`PR: [#<num>](` prefix heuristic) and `PATCH`es it in place instead of creating duplicates.
- **Step 12 is opt-in (asks first)** — triggering `release-app-bundles` and commenting require repo write access; external contributors / users without write perms should be able to skip cleanly. Default is to ask the user before triggering.
- **Multi-Jira key support** — bundle release PR titles often combine multiple `OK-XXXXX` (e.g. `(OK-55017)(OK-55029)`). Step 4 extracts and renders all of them comma-separated.

## Changes Detail
- `.skillshare/skills/1k-pr-bundle-info/SKILL.md` *(new, 247 lines)* — full flow: fetch PR metadata → find/trigger `release-app-bundles` run → poll `prepare-params` job only → parse build params → derive Jira keys → format → post or update comment.
- `.skillshare/skills/1k-create-pr/SKILL.md` *(+43 / -1)* — adds Step 12 entry to Quick Reference, inserts new Step 12 section ("Bundle Release Info Comment (release branch only)"), renumbers original "Return PR URL" to Step 13.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: None (skill / docs only — no application or build code)
- **Risk Areas**: The Step 12 trigger calls `gh workflow run`, which is a shared-state action — guarded by an explicit confirmation prompt and a written reminder that repo write access is required.

## Test plan
- [ ] `/1k-pr-bundle-info 11725` reproduces the canonical comment on a closed-loop PR (#11725).
- [ ] `/1k-pr-bundle-info <new-pr>` on a PR with no existing `release-app-bundles` run prompts to trigger one, waits only for `prepare-params`, then posts the comment.
- [ ] Re-invoking `/1k-pr-bundle-info <same-pr>` updates the existing comment in place (no duplicate).
- [ ] `/1k-create-pr` on a release/* feature branch hits Step 12, asks before running, and routes to `1k-pr-bundle-info` on yes. Hitting `n` skips cleanly to Step 13.
- [ ] `/1k-create-pr` on an `x`-targeted feature branch skips Step 12 entirely.
- [ ] PR title with two `OK-XXXXX` keys produces a single `JIRA: [KEY1](...), [KEY2](...)` line.
